### PR TITLE
Adds `init` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ npm-debug.log*
 .env.local
 
 .DS_Store
+
+coverage/

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@types/diff": "^5.0.3",
         "@types/ini": "^1.3.31",
         "@types/inquirer": "^9.0.3",
-        "@types/jest": "^29.5.2",
+        "@types/jest": "^29.5.10",
         "@types/yargs": "^17.0.24",
         "@typescript-eslint/eslint-plugin": "^5.61.0",
         "@typescript-eslint/parser": "^5.61.0",
@@ -2664,9 +2664,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.3.tgz",
-      "integrity": "sha512-1Nq7YrO/vJE/FYnqYyw0FS8LdrjExSgIiHyKg7xPpn+yi8Q4huZryKnkJatN1ZRH89Kw2v33/8ZMB7DuZeSLlA==",
+      "version": "29.5.10",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.10.tgz",
+      "integrity": "sha512-tE4yxKEphEyxj9s4inideLHktW/x6DwesIwWZ9NN1FKf9zbJYsnhBoA9vrHA/IuIOKwPa5PcFBNV4lpMIOEzyQ==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/diff": "^5.0.3",
     "@types/ini": "^1.3.31",
     "@types/inquirer": "^9.0.3",
-    "@types/jest": "^29.5.2",
+    "@types/jest": "^29.5.10",
     "@types/yargs": "^17.0.24",
     "@typescript-eslint/eslint-plugin": "^5.61.0",
     "@typescript-eslint/parser": "^5.61.0",

--- a/src/commands/init/handler.ts
+++ b/src/commands/init/handler.ts
@@ -108,18 +108,38 @@ export async function handler(argv: Argv<CommitOptions>['argv']) {
    * Prompt for advanced options
    *
    * e.g.
+   * - temperature
+   * - verbose logging
    * - ignored files
    * - ignored extensions
    * - commit message prompt
    */
   if (advOptions) {
+    const { temperature, verbose } = await inquirer.prompt([
+      {
+        type: 'number',
+        name: 'temperature',
+        message: 'temperature for the model:',
+        default: 0.4,
+      },
+      {
+        type: 'confirm',
+        name: 'verbose',
+        message: 'enable verbose logging:',
+        default: false,
+      },
+    ])
+
+    config.temperature = temperature
+    config.verbose = verbose
+
     const { promptForIgnores } = await inquirer.prompt({
       type: 'confirm',
       name: 'promptForIgnores',
       message: 'would you like to configure ignored files and extensions?',
       default: false,
     })
-
+    
     if (promptForIgnores) {
       const { ignoredFiles, ignoredExtensions } = await inquirer.prompt([
         {

--- a/src/commands/init/handler.ts
+++ b/src/commands/init/handler.ts
@@ -12,6 +12,7 @@ import { loadConfig } from '../../lib/config/loadConfig'
 import { Logger } from '../../lib/utils/logger'
 import { logResult } from '../../lib/ui/logResult'
 import { COMMIT_PROMPT } from '../../lib/langchain/prompts/commitDefault'
+import { appendToProjectConfig } from '../../lib/config/services/project'
 
 const handleProjectLevelConfig = async () => {
   const { projectConfiguration } = await inquirer.prompt({
@@ -45,16 +46,16 @@ export async function handler(argv: Argv<CommitOptions>['argv']) {
     type: 'list',
     name: 'level',
     message: 'configure coco at the system or project level:',
-    choices: ['System', 'Project'],
+    choices: ['system', 'project'],
   })
 
   let configFilePath = ''
 
   switch (level) {
-    case 'System':
+    case 'system':
       configFilePath = await handleSystemLevelConfig()
       break
-    case 'Project':
+    case 'project':
       configFilePath = await handleProjectLevelConfig()
       break
     default:
@@ -71,7 +72,6 @@ export async function handler(argv: Argv<CommitOptions>['argv']) {
     {
       type: 'password',
       name: 'apiKey',
-      // message: `Enter your ${llm} API key:`,
       message: `enter your OpenAI API key:`,
       validate(input) {
         return input.length > 0 ? true : 'API key cannot be empty'
@@ -167,7 +167,6 @@ export async function handler(argv: Argv<CommitOptions>['argv']) {
   // add to config after logging, so that the API key is not logged
   config.openAIApiKey = apiKey
 
-  // Verify answers before proceeding
   const { confirm } = await inquirer.prompt({
     type: 'confirm',
     name: 'confirm',
@@ -178,9 +177,9 @@ export async function handler(argv: Argv<CommitOptions>['argv']) {
     if (configFilePath.endsWith('.gitconfig')) {
       await appendToGitConfig(configFilePath, config)
     } else if (configFilePath === '.env') {
-      appendToEnvFile(configFilePath, config)
-    } else {
-      fs.appendFileSync(configFilePath, JSON.stringify(config, null, 2))
+      await appendToEnvFile(configFilePath, config)
+    } else if (configFilePath === '.coco.config.json'){
+      await appendToProjectConfig(configFilePath, config)
     }
 
     logger.log(`init successful! 🦾🤖🎉`, { color: 'green' })

--- a/src/commands/init/handler.ts
+++ b/src/commands/init/handler.ts
@@ -1,7 +1,7 @@
 import { CommitOptions } from './options'
 import { Argv } from 'yargs'
 
-import inquirer from 'inquirer'
+import { input, password, select, confirm, editor } from '@inquirer/prompts'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
@@ -15,11 +15,18 @@ import { COMMIT_PROMPT } from '../../lib/langchain/prompts/commitDefault'
 import { appendToProjectConfig } from '../../lib/config/services/project'
 
 const handleProjectLevelConfig = async () => {
-  const { projectConfiguration } = await inquirer.prompt({
-    type: 'list',
-    name: 'projectConfiguration',
+  const projectConfiguration = await select({
     message: 'select type project level configuration:',
-    choices: ['.coco.config.json', '.env'],
+    choices: [
+      {
+        name: '.coco.config.json',
+        value: '.coco.config.json',
+      },
+      {
+        name: '.env',
+        value: '.env',
+      },
+    ],
   })
 
   let configFile = '.coco.config.json'
@@ -42,11 +49,20 @@ export async function handler(argv: Argv<CommitOptions>['argv']) {
   const options = loadConfig(argv) as CommitOptions
   const logger = new Logger(options)
 
-  const { level } = await inquirer.prompt({
-    type: 'list',
-    name: 'level',
+  const level = await select({
     message: 'configure coco at the system or project level:',
-    choices: ['system', 'project'],
+    choices: [
+      {
+        name: 'system',
+        value: 'system',
+        description: 'add coco config to your global git config',
+      },
+      {
+        name: 'project',
+        value: 'project',
+        description: 'add coco config to existing git project',
+      },
+    ],
   })
 
   let configFilePath = ''
@@ -62,44 +78,48 @@ export async function handler(argv: Argv<CommitOptions>['argv']) {
       break
   }
 
-  const { apiKey, tokenLimit, defaultBranch, advOptions, mode } = await inquirer.prompt([
-    {
-      type: 'list',
-      name: 'mode',
-      message: 'what mode would you like to use?',
-      choices: ['interactive', 'stdout'],
-    },
-    {
-      type: 'password',
-      name: 'apiKey',
-      message: `enter your OpenAI API key:`,
-      validate(input) {
-        return input.length > 0 ? true : 'API key cannot be empty'
+  // interactive v.s stdout mode
+  const mode = (await select({
+    message: 'select mode:',
+    choices: [
+      {
+        name: 'interactive',
+        value: 'interactive',
+        description: 'interactive prompt for creating, reviewing, and committing',
       },
+      {
+        name: 'stdout',
+        value: 'stdout',
+        description: 'print results to stdout',
+      },
+    ],
+  })) as 'interactive' | 'stdout'
+
+  const apiKey = await password({
+    message: `enter your OpenAI API key:`,
+    validate(input) {
+      return input.length > 0 ? true : 'API key cannot be empty'
     },
-    {
-      type: 'number',
-      name: 'tokenLimit',
-      message: 'maximum number of tokens for the commit message:',
-      default: 500,
-    },
-    {
-      type: 'input',
-      name: 'defaultBranch',
-      message: 'default branch for the repository:',
-      default: 'main',
-    },
-    {
-      type: 'confirm',
-      name: 'advOptions',
-      message: 'would you like to configure advanced options?',
-      default: false,
-    },
-  ])
+  })
+
+  const tokenLimit = await input({
+    message: 'maximum number of tokens for the commit message:',
+    default: '500',
+  })
+
+  const defaultBranch = await input({
+    message: 'default branch for the repository:',
+    default: 'main',
+  })
+
+  const advOptions = await confirm({
+    message: 'would you like to configure advanced options?',
+    default: false,
+  })
 
   const config: Partial<Config> = {
     openAIApiKey: '•••••••••••••••',
-    tokenLimit,
+    tokenLimit: parseInt(tokenLimit),
     defaultBranch,
     mode,
   }
@@ -115,66 +135,47 @@ export async function handler(argv: Argv<CommitOptions>['argv']) {
    * - commit message prompt
    */
   if (advOptions) {
-    const { temperature, verbose } = await inquirer.prompt([
-      {
-        type: 'number',
-        name: 'temperature',
-        message: 'temperature for the model:',
-        default: 0.4,
-      },
-      {
-        type: 'confirm',
-        name: 'verbose',
-        message: 'enable verbose logging:',
-        default: false,
-      },
-    ])
+    const temperature = await input({
+      message: 'temperature for the model:',
+      default: '0.4',
+    })
+    config.temperature = parseFloat(temperature)
 
-    config.temperature = temperature
-    config.verbose = verbose
+    config.verbose = await confirm({
+      message: 'enable verbose logging:',
+      default: false,
+    })
 
-    const { promptForIgnores } = await inquirer.prompt({
-      type: 'confirm',
-      name: 'promptForIgnores',
+    const promptForIgnores = await confirm({
       message: 'would you like to configure ignored files and extensions?',
       default: false,
     })
-    
+
     if (promptForIgnores) {
-      const { ignoredFiles, ignoredExtensions } = await inquirer.prompt([
-        {
-          type: 'input',
-          name: 'ignoredFiles',
-          message:
-            'paths of files to be excluded when generating commit messages (comma-separated):',
-          default: 'package-lock.json',
-        },
-        {
-          type: 'input',
-          name: 'ignoredExtensions',
-          message:
-            'file extensions to be excluded when generating commit messages (comma-separated):',
-          default: '.map, .lock',
-        },
-      ])
+      const ignoredFiles = await input({
+        message: 'paths of files to be excluded when generating commit messages (comma-separated):',
+        default: 'package-lock.json',
+      })
+
+      const ignoredExtensions = await input({
+        message:
+          'file extensions to be excluded when generating commit messages (comma-separated):',
+        default: '.map, .lock',
+      })
 
       config.ignoredFiles =
-        ignoredFiles && ignoredFiles.split(',').map((file: string) => file.trim())
+        (ignoredFiles && ignoredFiles.split(',').map((file: string) => file.trim())) || []
       config.ignoredExtensions =
-        ignoredExtensions && ignoredExtensions.split(',').map((ext: string) => ext.trim())
+        (ignoredExtensions && ignoredExtensions.split(',').map((ext: string) => ext.trim())) || []
     }
 
-    const { promptForCommitPrompt } = await inquirer.prompt({
-      type: 'confirm',
-      name: 'promptForCommitPrompt',
+    const promptForCommitPrompt = await confirm({
       message: 'would you like to configure the commit message prompt?',
       default: false,
     })
 
     if (promptForCommitPrompt) {
-      const { commitPrompt } = await inquirer.prompt({
-        type: 'editor',
-        name: 'commitPrompt',
+      const commitPrompt = await editor({
         message: 'modify default commit message prompt:',
         default: COMMIT_PROMPT.template,
       })
@@ -187,18 +188,16 @@ export async function handler(argv: Argv<CommitOptions>['argv']) {
   // add to config after logging, so that the API key is not logged
   config.openAIApiKey = apiKey
 
-  const { confirm } = await inquirer.prompt({
-    type: 'confirm',
-    name: 'confirm',
+  const isApproved = await confirm({
     message: 'look good? (hiding API key for security)',
   })
 
-  if (confirm) {
+  if (isApproved) {
     if (configFilePath.endsWith('.gitconfig')) {
       await appendToGitConfig(configFilePath, config)
     } else if (configFilePath === '.env') {
       await appendToEnvFile(configFilePath, config)
-    } else if (configFilePath === '.coco.config.json'){
+    } else if (configFilePath === '.coco.config.json') {
       await appendToProjectConfig(configFilePath, config)
     }
 

--- a/src/commands/init/handler.ts
+++ b/src/commands/init/handler.ts
@@ -1,0 +1,130 @@
+import { CommitOptions } from './options'
+import { Argv } from 'yargs'
+
+import inquirer from 'inquirer'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { Config } from '../types'
+import { appendToIniFile } from '../../lib/config/services/git'
+import { appendToEnvFile } from '../../lib/config/services/env'
+import { loadConfig } from '../../lib/config/loadConfig'
+import { Logger } from '../../lib/utils/logger'
+import { logResult } from '../../lib/ui/logResult'
+
+const handleProjectLevelConfig = async () => {
+  const { projectConfiguration } = await inquirer.prompt({
+    type: 'list',
+    name: 'projectConfiguration',
+    message: 'select type project level configuration:',
+    choices: ['.coco.config.json', '.env'],
+  })
+
+  let configFile = '.coco.config.json'
+
+  if (projectConfiguration === '.env') {
+    configFile = '.env'
+    if (!fs.existsSync('.env')) {
+      fs.writeFileSync('.env', '')
+    }
+  }
+
+  return configFile
+}
+
+const handleSystemLevelConfig = () => {
+  return path.join(os.homedir(), '.gitconfig')
+}
+
+export async function handler(argv: Argv<CommitOptions>['argv']) {
+  const options = loadConfig(argv) as CommitOptions
+  const logger = new Logger(options)
+
+  const { level } = await inquirer.prompt({
+    type: 'list',
+    name: 'level',
+    message: 'configure coco at the system or project level:',
+    choices: ['System', 'Project'],
+  })
+
+  let configFilePath = ''
+
+  switch (level) {
+    case 'System':
+      configFilePath = handleSystemLevelConfig()
+      break
+    case 'Project':
+      configFilePath = await handleProjectLevelConfig()
+      break
+    default:
+      break
+  }
+
+  const { apiKey, tokenLimit, ignoredFiles, ignoredExtensions, defaultBranch } =
+    await inquirer.prompt([
+      {
+        type: 'password',
+        name: 'apiKey',
+        // message: `Enter your ${llm} API key:`,
+        message: `enter your OpenAI API key:`,
+        validate(input) {
+          return input.length > 0 ? true : 'API key cannot be empty'
+        },
+      },
+      {
+        type: 'number',
+        name: 'tokenLimit',
+        message: 'maximum number of tokens for the commit message:',
+        default: 500,
+      },
+      {
+        type: 'input',
+        name: 'ignoredFiles',
+        message: 'paths of files to be excluded when generating commit messages (comma-separated):',
+        default: 'package-lock.json',
+      },
+      {
+        type: 'input',
+        name: 'ignoredExtensions',
+        message:
+          'File extensions to be excluded when generating commit messages (comma-separated):',
+        default: '.map, .lock',
+      },
+      {
+        type: 'input',
+        name: 'defaultBranch',
+        message: 'Default branch for the repository:',
+        default: 'main',
+      },
+    ])
+
+  const config: Partial<Config> = {
+    openAIApiKey: apiKey,
+    tokenLimit,
+    ignoredFiles: ignoredFiles.split(',').map((file: string) => file.trim()),
+    ignoredExtensions: ignoredExtensions.split(',').map((ext: string) => ext.trim()),
+    defaultBranch,
+  }
+
+  logResult('Config', JSON.stringify(config, null, 2))
+
+  // Verify answers before proceeding
+  const { confirm } = await inquirer.prompt({
+    type: 'confirm',
+    name: 'confirm',
+    message: 'Are these settings correct?',
+  })
+
+  if (confirm) {
+    if (configFilePath.endsWith('.gitconfig')) {
+      appendToIniFile(configFilePath, config)
+    } else if (configFilePath === '.env') {
+      appendToEnvFile(configFilePath, config)
+    } else {
+      fs.appendFileSync(configFilePath, JSON.stringify(config, null, 2))
+    }
+    logger.log(`configuration appended to ${configFilePath}`, { color: 'green' })
+  } else {
+    logger.log('init cancelled.', { color: 'yellow' })
+  }
+}

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -1,0 +1,10 @@
+import { handler } from './handler'
+import { builder, options } from './options'
+
+export default {
+  command: 'init',
+  desc: 'Setup coco for a new project or system',
+  builder,
+  handler,
+  options,
+}

--- a/src/commands/init/options.ts
+++ b/src/commands/init/options.ts
@@ -1,0 +1,65 @@
+import { Options, Argv } from 'yargs'
+import { BaseCommandOptions } from '../types'
+
+export interface CommitOptions extends BaseCommandOptions {
+  prompt: string
+  commit: boolean
+  summarizePrompt: string
+  openInEditor: boolean
+  ignoredFiles: string[]
+  ignoredExtensions: string[]
+}
+
+/**
+ * Command line options via yargs
+ */
+export const options = {
+  model: { type: 'string', description: 'LLM/Model-Name' },
+  openAIApiKey: {
+    type: 'string',
+    description: 'OpenAI API Key',
+    conflicts: 'huggingFaceHubApiKey',
+  },
+  huggingFaceHubApiKey: {
+    type: 'string',
+    description: 'HuggingFace Hub API Key',
+    conflicts: 'openAIApiKey',
+  },
+  tokenLimit: { type: 'number', description: 'Token limit' },
+  prompt: {
+    type: 'string',
+    alias: 'p',
+    description: 'Commit message prompt',
+  },
+  i: {
+    type: 'boolean',
+    alias: 'interactive',
+    description: 'Toggle interactive mode',
+  },
+  s: {
+    type: 'boolean',
+    description: 'Automatically commit staged changes with generated commit message',
+    default: false,
+  },
+  e: {
+    type: 'boolean',
+    alias: 'edit',
+    description: 'Open commit message in editor before proceeding',
+  },
+  summarizePrompt: {
+    type: 'string',
+    description: 'Large file summary prompt',
+  },
+  ignoredFiles: {
+    type: 'array',
+    description: 'Ignored files',
+  },
+  ignoredExtensions: {
+    type: 'array',
+    description: 'Ignored extensions',
+  },
+} as Record<string, Options>
+
+export const builder = (yargs: Argv) => {
+  return yargs.options(options)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 import yargs from 'yargs'
 import commit from './commands/commit'
 import changelog from './commands/changelog'
+import init from './commands/init'
 
 yargs
   .scriptName('coco')
@@ -23,6 +24,15 @@ yargs
     // @ts-ignore
     changelog.builder,
     changelog.handler
+  )
+  .command(
+    init.command,
+    init.desc,
+    // TODO: fix type on builder
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    init.builder,
+    init.handler
   )
   .demandCommand()
   .help().argv

--- a/src/lib/config/constants.ts
+++ b/src/lib/config/constants.ts
@@ -1,0 +1,32 @@
+import { SUMMARIZE_PROMPT } from '../langchain/prompts/summarize';
+import { Config } from './types';
+
+/**
+ * Default Config
+ *
+ * @type {Config}
+ */
+
+export const DEFAULT_CONFIG = {
+  model: 'openai/gpt-4',
+  verbose: false,
+  tokenLimit: 1024,
+  summarizePrompt: SUMMARIZE_PROMPT.template,
+  temperature: 0.4,
+  mode: 'stdout',
+  ignoredFiles: ['package-lock.json'],
+  ignoredExtensions: ['.map', '.lock'],
+  defaultBranch: 'main',
+} as Config
+
+/**
+ * Config keys
+ *
+ * @type {string[]}
+ */
+export const CONFIG_KEYS = Object.keys({
+  ...DEFAULT_CONFIG,
+  huggingFaceHubApiKey: '',
+  openAIApiKey: '',
+  prompt: '',
+} as Config) as (keyof Config)[]

--- a/src/lib/config/loadConfig.ts
+++ b/src/lib/config/loadConfig.ts
@@ -5,24 +5,7 @@ import { loadProjectConfig } from './services/project'
 import { loadXDGConfig } from './services/xdg'
 import { Config } from './types'
 
-import { SUMMARIZE_PROMPT } from '../langchain/prompts/summarize'
-
-/**
- * Default Config
- *
- * @type {Config}
- */
-export const DEFAULT_CONFIG = {
-  model: 'openai/gpt-4',
-  verbose: false,
-  tokenLimit: 1024,
-  summarizePrompt: SUMMARIZE_PROMPT.template,
-  temperature: 0.4,
-  mode: 'stdout',
-  ignoredFiles: ['package-lock.json'],
-  ignoredExtensions: ['.map', '.lock'],
-  defaultBranch: 'main',
-} as Config
+import { DEFAULT_CONFIG } from './constants'
 
 /**
  * Load application config

--- a/src/lib/config/services/env.ts
+++ b/src/lib/config/services/env.ts
@@ -1,3 +1,5 @@
+import fs from 'fs'
+
 import { removeUndefined } from '../../utils/removeUndefined'
 import { Config } from '../types'
 
@@ -24,9 +26,23 @@ export function loadEnvConfig(config: Config): Config {
     ignoredExtensions: process.env.COCO_IGNORED_EXTENSIONS
       ? process.env.COCO_IGNORED_EXTENSIONS.split(',')
       : undefined,
-    defaultBranch: process.env.COCO_DEFAULT_BRANCH || undefined,
+    defaultBranch: process.env.COCO_DEFAULT_BRANCH 
   }
 
   config = { ...config, ...removeUndefined(envConfig) }
   return config
+}
+
+export const appendToEnvFile = (filePath: string, config: Partial<Config>) => {
+  const formattedConfig = Object.entries(config)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n')
+  fs.appendFileSync(filePath, `\n${formattedConfig}`)
+}
+
+export const convertToEnvFormat = (config: Partial<Config>): string => {
+  // Convert the JSON object to .env format (KEY=VALUE)
+  return Object.entries(config)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n')
 }

--- a/src/lib/config/services/env.ts
+++ b/src/lib/config/services/env.ts
@@ -1,5 +1,6 @@
 import { removeUndefined } from '../../utils/removeUndefined'
 import { Config } from '../types'
+import { CONFIG_KEYS } from '../constants'
 import { updateFileSection } from '../../utils/updateFileSection'
 
 type Keys = keyof Config
@@ -14,20 +15,13 @@ type ValuesTypes = Config[Keys]
 export function loadEnvConfig(config: Config): Config {
   const envConfig: Partial<Config> = {}
 
-  Object.keys(config).forEach((key) => {
+  CONFIG_KEYS.forEach((key) => {
     const envVarName = toEnvVarName(key as keyof Config)
     const envValue = parseEnvValue(key, process.env[envVarName])
-    
+
     if (envValue === undefined) return
-    if (!envConfig || !envConfig[key as Keys] || typeof envValue !== typeof config[key as Keys]) {
-      throw new Error(
-        `Invalid type for environment variable ${envVarName}. Expected ${typeof config[
-          key as Keys
-        ]} but got ${typeof envValue}`
-      )
-    }
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore  
+    // @ts-ignore
     envConfig[key as Keys] = envValue
   })
 

--- a/src/lib/config/services/env.ts
+++ b/src/lib/config/services/env.ts
@@ -1,7 +1,9 @@
-import fs from 'fs'
-
 import { removeUndefined } from '../../utils/removeUndefined'
 import { Config } from '../types'
+import { updateFileSection } from '../../utils/updateFileSection'
+
+type Keys = keyof Config
+type ValuesTypes = Config[Keys]
 
 /**
  * Load environment variables
@@ -10,39 +12,76 @@ import { Config } from '../types'
  * @returns {Config} Updated config
  **/
 export function loadEnvConfig(config: Config): Config {
-  const envConfig: Partial<Config> = {
-    model: process.env.COCO_MODEL || undefined,
-    openAIApiKey: process.env.OPENAI_API_KEY || undefined,
-    huggingFaceHubApiKey: process.env.HUGGINGFACE_HUB_API_KEY || undefined,
-    tokenLimit: process.env.COCO_TOKEN_LIMIT
-      ? parseInt(process.env.COCO_TOKEN_LIMIT)
-      : undefined,
-    prompt: process.env.COCO_PROMPT,
-    mode: process.env.COCO_MODE as Config['mode'],
-    summarizePrompt: process.env.COCO_SUMMARIZE_PROMPT,
-    ignoredFiles: process.env.COCO_IGNORED_FILES
-      ? process.env.COCO_IGNORED_FILES.split(',')
-      : undefined,
-    ignoredExtensions: process.env.COCO_IGNORED_EXTENSIONS
-      ? process.env.COCO_IGNORED_EXTENSIONS.split(',')
-      : undefined,
-    defaultBranch: process.env.COCO_DEFAULT_BRANCH 
+  const envConfig: Partial<Config> = {}
+
+  Object.keys(config).forEach((key) => {
+    const envVarName = toEnvVarName(key as keyof Config)
+    const envValue = parseEnvValue(key, process.env[envVarName])
+    
+    if (envValue === undefined) return
+    if (!envConfig || !envConfig[key as Keys] || typeof envValue !== typeof config[key as Keys]) {
+      throw new Error(
+        `Invalid type for environment variable ${envVarName}. Expected ${typeof config[
+          key as Keys
+        ]} but got ${typeof envValue}`
+      )
+    }
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore  
+    envConfig[key as Keys] = envValue
+  })
+
+  return { ...config, ...removeUndefined(envConfig) }
+}
+
+function parseEnvValue(key: string, value: ValuesTypes) {
+  if (value === undefined) {
+    return undefined
+  } else if (key === 'tokenLimit' && typeof value === 'string') {
+    return parseInt(value)
+  } else if (
+    (key === 'ignoredFiles' || key === 'ignoredExtensions') &&
+    typeof value === 'string' &&
+    value.includes(',')
+  ) {
+    return value.split(',')
+  }
+  return value
+}
+
+function toEnvVarName(key: Keys): string {
+  switch (key) {
+    case 'openAIApiKey':
+      return 'OPENAI_API_KEY'
+    case 'huggingFaceHubApiKey':
+      return 'HUGGINGFACE_HUB_API_KEY'
+    default:
+      return 'COCO_' + key.replace(/([A-Z])/g, '_$1').toUpperCase()
+  }
+}
+
+function formatEnvValue(value: ValuesTypes): string {
+  if (typeof value === 'number') {
+    return `${value}`
+  } else if (Array.isArray(value)) {
+    return `${value.join(',')}`
+  } else if (typeof value === 'string') {
+    // Escape newlines and tabs in strings
+    return `${value.replace(/\n/g, '\\n').replace(/\t/g, '\\t')}`
   }
 
-  config = { ...config, ...removeUndefined(envConfig) }
-  return config
+  return `${value}`
 }
 
-export const appendToEnvFile = (filePath: string, config: Partial<Config>) => {
-  const formattedConfig = Object.entries(config)
-    .map(([key, value]) => `${key}=${value}`)
-    .join('\n')
-  fs.appendFileSync(filePath, `\n${formattedConfig}`)
-}
+export const appendToEnvFile = async (filePath: string, config: Partial<Config>) => {
+  const startComment = '# -- Start coco config --'
+  const endComment = '# -- End coco config --'
 
-export const convertToEnvFormat = (config: Partial<Config>): string => {
-  // Convert the JSON object to .env format (KEY=VALUE)
-  return Object.entries(config)
-    .map(([key, value]) => `${key}=${value}`)
-    .join('\n')
+  const getNewContent = async () => {
+    return Object.entries(config)
+      .map(([key, value]) => `${toEnvVarName(key as keyof Config)}=${formatEnvValue(value)}`)
+      .join('\n')
+  }
+
+  await updateFileSection(filePath, startComment, endComment, getNewContent)
 }

--- a/src/lib/config/services/git.ts
+++ b/src/lib/config/services/git.ts
@@ -37,10 +37,9 @@ export function loadGitConfig(config: Config): Config {
 }
 
 /**
- * Appends the provided configuration to an INI file.
- * If the file does not exist, it creates a new one.
+ * Appends the provided configuration to a git config file.
  *
- * @param filePath - The path to the INI file.
+ * @param filePath - The path to the .gitconfig
  * @param config - The configuration object to append.
  */
 export const appendToGitConfig = async (filePath: string, config: Partial<Config>) => {
@@ -81,6 +80,14 @@ export const appendToGitConfig = async (filePath: string, config: Partial<Config
       newLines.push(startComment)
       newLines.push(header)
       for (const key in config) {
+        // check if string has new lines, if so, wrap in quotes
+        if (typeof config[key as keyof Config] === 'string') {
+          const value = config[key as keyof Config] as string
+          if (value.includes('\n')) {
+            newLines.push(`\t${key} = ${JSON.stringify(value)}`)
+            continue
+          }
+        }
         newLines.push(`\t${key} = ${config[key as keyof Config]}`)
       }
 
@@ -102,6 +109,14 @@ export const appendToGitConfig = async (filePath: string, config: Partial<Config
     newLines.push('\n' + startComment)
     newLines.push(header)
     for (const key in config) {
+      // check if string has new lines, if so, wrap in quotes
+      if (typeof config[key as keyof Config] === 'string') {
+        const value = config[key as keyof Config] as string
+        if (value.includes('\n')) {
+          newLines.push(`\t${key} = ${JSON.stringify(value)}`)
+          continue
+        }
+      }
       newLines.push(`\t${key} = ${config[key as keyof Config]}`)
     }
     newLines.push(endComment)

--- a/src/lib/config/services/git.ts
+++ b/src/lib/config/services/git.ts
@@ -20,17 +20,43 @@ export function loadGitConfig(config: Config): Config {
       ...config,
       model: gitConfigParsed.coco?.model || config.model,
       openAIApiKey: gitConfigParsed.coco?.openAIApiKey || config.openAIApiKey,
-      huggingFaceHubApiKey: gitConfigParsed.coco?.huggingFaceHubApiKey || config.huggingFaceHubApiKey,
+      huggingFaceHubApiKey:
+        gitConfigParsed.coco?.huggingFaceHubApiKey || config.huggingFaceHubApiKey,
       tokenLimit: parseInt(gitConfigParsed.coco?.tokenLimit) || config.tokenLimit,
       prompt: gitConfigParsed.coco?.prompt || config.prompt,
       mode: gitConfigParsed.coco?.mode || config.mode,
       temperature: gitConfigParsed.coco?.temperature || config.temperature,
-      summarizePrompt:
-        gitConfigParsed.coco?.summarizePrompt || config.summarizePrompt,
+      summarizePrompt: gitConfigParsed.coco?.summarizePrompt || config.summarizePrompt,
       ignoredFiles: gitConfigParsed.coco?.ignoredFiles || config.ignoredFiles,
       ignoredExtensions: gitConfigParsed.coco?.ignoredExtensions || config.ignoredExtensions,
       defaultBranch: gitConfigParsed.coco?.defaultBranch || config.defaultBranch,
     }
   }
   return config
+}
+
+/**
+ * Appends the provided configuration to an INI file.
+ * If the file does not exist, it creates a new one.
+ *
+ * @param filePath - The path to the INI file.
+ * @param config - The configuration object to append.
+ */
+export const appendToIniFile = (filePath: string, config: Partial<Config>) => {
+  const existingConfig = fs.existsSync(filePath)
+    ? ini.parse(fs.readFileSync(filePath, 'utf-8'))
+    : {}
+  const combinedConfig = { ...existingConfig, ...config }
+  const formattedConfig = ini.stringify(combinedConfig)
+  fs.appendFileSync(filePath, `\n${formattedConfig}`)
+}
+
+/**
+ * Converts the provided configuration to INI format.
+ *
+ * @param config - The configuration object to convert.
+ * @returns The configuration in INI format.
+ */
+export const convertToIniFormat = (config: Partial<Config>): string => {
+  return ini.stringify(config)
 }

--- a/src/lib/config/services/project.ts
+++ b/src/lib/config/services/project.ts
@@ -16,3 +16,17 @@ export function loadProjectConfig(config: Config): Config {
   }
   return config
 }
+
+export const appendToProjectConfig = (filePath: string, config: Partial<Config>) => {
+  fs.writeFileSync(
+    filePath,
+    JSON.stringify(
+      {
+        $schema: 'https://git-co.co/schema.json',
+        ...config,
+      },
+      null,
+      2
+    )
+  )
+}

--- a/src/lib/ui/generateAndReviewLoop.ts
+++ b/src/lib/ui/generateAndReviewLoop.ts
@@ -77,7 +77,7 @@ export async function generateAndReviewLoop<T>({
       .stopTimer()
 
     if (options?.interactive) {
-      logResult(result)
+      logResult(label, result)
       const reviewAnswer = await getUserReviewDecision()
 
       if (reviewAnswer === 'cancel') {

--- a/src/lib/ui/logResult.ts
+++ b/src/lib/ui/logResult.ts
@@ -1,8 +1,8 @@
 import chalk from 'chalk';
 import { SEPERATOR } from "./helpers";
 
-export function logResult(result: string) {
+export function logResult(label: string, result: string) {
   console.log(
-    `\n${chalk.bgBlue(chalk.bold('Proposed Commit:'))}\n${SEPERATOR}\n${result}\n${SEPERATOR}\n`
+    `\n${chalk.bgBlue(chalk.bold(`Proposed ${label}:`))}\n${SEPERATOR}\n${result}\n${SEPERATOR}\n`
   );
 }

--- a/src/lib/utils/updateFileSection.ts
+++ b/src/lib/utils/updateFileSection.ts
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import inquirer from 'inquirer'
+import { confirm }  from '@inquirer/prompts'
 
 export async function updateFileSection(
   filePath: string,
@@ -17,13 +17,12 @@ export async function updateFileSection(
       foundSection = true
 
       if (confirmUpdate) {
-        const { confirm } = await inquirer.prompt({
-          type: 'confirm',
-          name: 'confirm',
+        const confirmOverwrite = await confirm({
           message: `A section already exists in ${filePath}, do you want to override it?`,
+          default: false,
         })
 
-        if (!confirm) {
+        if (!confirmOverwrite) {
           // keep all lines until the end comment
           while (i < lines.length && lines[i].trim() !== endComment) {
             newLines.push(lines[i])

--- a/src/lib/utils/updateFileSection.ts
+++ b/src/lib/utils/updateFileSection.ts
@@ -1,0 +1,65 @@
+import fs from 'fs'
+import inquirer from 'inquirer'
+
+export async function updateFileSection(
+  filePath: string,
+  startComment: string,
+  endComment: string,
+  getNewContent: () => Promise<string>,
+  confirmUpdate = true
+) {
+  const lines = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8').split(/\r?\n/) : []
+  const newLines = []
+  let foundSection = false
+
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() === startComment) {
+      foundSection = true
+
+      if (confirmUpdate) {
+        const { confirm } = await inquirer.prompt({
+          type: 'confirm',
+          name: 'confirm',
+          message: `A section already exists in ${filePath}, do you want to override it?`,
+        })
+
+        if (!confirm) {
+          // keep all lines until the end comment
+          while (i < lines.length && lines[i].trim() !== endComment) {
+            newLines.push(lines[i])
+            i++
+          }
+          newLines.push(endComment)
+          continue
+        }
+      }
+
+      newLines.push(startComment)
+      // Insert the new content
+      const newContent = await getNewContent()
+      newLines.push(newContent)
+
+      // Skip the existing content of the section
+      while (i < lines.length && lines[i].trim() !== endComment) {
+        i++
+      }
+      newLines.push(endComment)
+      continue
+    }
+
+    if (!foundSection || lines[i].trim() !== endComment) {
+      newLines.push(lines[i])
+    }
+  }
+
+  // If section wasn't found, append it at the end
+  if (!foundSection) {
+    newLines.push('\n' + startComment)
+    const newContent = await getNewContent()
+    newLines.push(newContent)
+    newLines.push(endComment)
+  }
+
+  // Write the updated contents back to the file
+  fs.writeFileSync(filePath, newLines.join('\n'))
+}


### PR DESCRIPTION
Create new `init` command responsible for setting up the required config for `coco`.  It can be setup on a global system level with the `.gitconfig` file, or on a project level with an `.env` or `.coco.config.json` file.

