### PR TITLE
Finalize `init` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "clean": "rimraf dist && rimraf coverage",
     "lint": "eslint src",
     "lint:fix": "eslint --fix src",
-    "format": "prettier --write src",
     "test": "npm run test:jest && npm run test:publish",
     "test:publish": "npm run lint && npm publish --dry-run",
     "test:jest": "jest",

--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -1,11 +1,8 @@
-import { Argv } from 'yargs'
-
-import { Logger } from '../../lib/utils/logger'
 import { getApiKeyForModel, getLlm, getPrompt } from '../../lib/langchain/utils'
 
 import { loadConfig } from '../../lib/config/loadConfig'
-import { isInteractive } from '../../lib/ui/helpers'
-import { ChangelogOptions } from './options'
+import { LOGO, isInteractive } from '../../lib/ui/helpers'
+import { ChangelogArgv, ChangelogOptions } from './options'
 import { generateAndReviewLoop } from '../../lib/ui/generateAndReviewLoop'
 import { executeChain } from '../../lib/langchain/executeChain'
 import { handleResult } from '../../lib/ui/handleResult'
@@ -14,10 +11,10 @@ import { getCommitLogRange } from '../../lib/simple-git/getCommitLogRange'
 import { getCommitLogCurrentBranch } from '../../lib/simple-git/getCommitLogCurrentBranch'
 import { getRepo } from '../../lib/simple-git/getRepo'
 import { logSuccess } from '../../lib/ui/logSuccess'
+import { CommandHandler } from '../../lib/types'
 
-export async function handler(argv: Argv<ChangelogOptions>['argv']) {
+export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
   const options = loadConfig(argv) as ChangelogOptions
-  const logger = new Logger(options)
   const git = getRepo()
   const key = getApiKeyForModel(options.service, options)
 
@@ -32,6 +29,10 @@ export async function handler(argv: Argv<ChangelogOptions>['argv']) {
   })
 
   const INTERACTIVE = isInteractive(options)
+
+  if (INTERACTIVE) {
+    logger.log(LOGO)
+  }
 
   async function factory() {
     if (options.range) {
@@ -87,7 +88,7 @@ export async function handler(argv: Argv<ChangelogOptions>['argv']) {
       interactive: INTERACTIVE,
       review: {
         enableFullRetry: false,
-      }
+      },
     },
   })
 

--- a/src/commands/changelog/index.ts
+++ b/src/commands/changelog/index.ts
@@ -1,3 +1,4 @@
+import commandExecutor from '../../lib/utils/commandExecutor'
 import { handler } from './handler'
 import { builder, options } from './options'
 
@@ -5,6 +6,6 @@ export default {
   command: 'changelog',
   desc: 'Generate a changelog from a commit range',
   builder,
-  handler,
+  handler: commandExecutor(handler),
   options,
 }

--- a/src/commands/changelog/options.ts
+++ b/src/commands/changelog/options.ts
@@ -11,6 +11,8 @@ export interface ChangelogOptions extends BaseCommandOptions {
   ignoredExtensions: string[]
 }
 
+export type ChangelogArgv = Argv<ChangelogOptions>['argv']
+
 /**
  * Command line options via yargs
  */

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -1,5 +1,4 @@
 import { fileChangeParser } from '../../lib/parsers/default'
-import { Logger } from '../../lib/utils/logger'
 import { COMMIT_PROMPT } from '../../lib/langchain/prompts/commitDefault'
 import {
   getApiKeyForModel,
@@ -9,11 +8,10 @@ import {
 } from '../../lib/langchain/utils'
 import { noResult } from '../../lib/parsers/noResult'
 import { getChanges } from '../../lib/simple-git/getChanges'
-import { CommitOptions } from './options'
-import { Argv } from 'yargs'
+import { CommitArgv, CommitOptions } from './options'
 import { loadConfig } from '../../lib/config/loadConfig'
-import { isInteractive } from '../../lib/ui/helpers'
-import { FileChange } from '../../lib/types'
+import { LOGO, isInteractive } from '../../lib/ui/helpers'
+import { CommandHandler, FileChange } from '../../lib/types'
 import { generateAndReviewLoop } from '../../lib/ui/generateAndReviewLoop'
 import { executeChain } from '../../lib/langchain/executeChain'
 import { handleResult } from '../../lib/ui/handleResult'
@@ -22,11 +20,10 @@ import { getTokenCounter } from '../../lib/utils/tokenizer'
 import { createCommit } from '../../lib/simple-git/createCommit'
 import { logSuccess } from '../../lib/ui/logSuccess'
 
-export async function handler(argv: Argv<CommitOptions>['argv']) {
+export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
   const git = getRepo()
   const options = loadConfig(argv) as CommitOptions
   const { service } = options
-  const logger = new Logger(options)
 
   const key = getApiKeyForModel(service, options)
   const tokenizer = await getTokenCounter(getModelFromService(service))
@@ -42,6 +39,9 @@ export async function handler(argv: Argv<CommitOptions>['argv']) {
   })
 
   const INTERACTIVE = isInteractive(options)
+  if (INTERACTIVE) {
+    logger.log(LOGO)
+  }
 
   async function factory() {
     const changes = await getChanges({ git })

--- a/src/commands/commit/index.ts
+++ b/src/commands/commit/index.ts
@@ -1,3 +1,4 @@
+import commandExecutor from '../../lib/utils/commandExecutor'
 import { handler } from './handler'
 import { builder, options } from './options'
 
@@ -5,6 +6,6 @@ export default {
   command: 'commit',
   desc: 'Generate commit message',
   builder,
-  handler,
+  handler: commandExecutor(handler),
   options,
 }

--- a/src/commands/commit/options.ts
+++ b/src/commands/commit/options.ts
@@ -10,6 +10,8 @@ export interface CommitOptions extends BaseCommandOptions {
   ignoredExtensions: string[]
 }
 
+export type CommitArgv = Argv<CommitOptions>['argv']
+
 /**
  * Command line options via yargs
  */

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -1,3 +1,4 @@
+import commandExecutor from '../../lib/utils/commandExecutor'
 import { handler } from './handler'
 import { builder, options } from './options'
 
@@ -5,6 +6,6 @@ export default {
   command: 'init',
   desc: 'Setup coco for a new project or system',
   builder,
-  handler,
+  handler: commandExecutor(handler),
   options,
 }

--- a/src/commands/init/options.ts
+++ b/src/commands/init/options.ts
@@ -1,64 +1,14 @@
 import { Options, Argv } from 'yargs'
-import { BaseCommandOptions } from '../types'
+import { BaseArgvOptions } from '../types'
 
-export interface CommitOptions extends BaseCommandOptions {
-  prompt: string
-  commit: boolean
-  summarizePrompt: string
-  openInEditor: boolean
-  ignoredFiles: string[]
-  ignoredExtensions: string[]
-}
+export type InitOptions = BaseArgvOptions
+
+export type InitArgv = Argv<InitOptions>['argv']
 
 /**
  * Command line options via yargs
  */
-export const options = {
-  model: { type: 'string', description: 'LLM/Model-Name' },
-  openAIApiKey: {
-    type: 'string',
-    description: 'OpenAI API Key',
-    conflicts: 'huggingFaceHubApiKey',
-  },
-  huggingFaceHubApiKey: {
-    type: 'string',
-    description: 'HuggingFace Hub API Key',
-    conflicts: 'openAIApiKey',
-  },
-  tokenLimit: { type: 'number', description: 'Token limit' },
-  prompt: {
-    type: 'string',
-    alias: 'p',
-    description: 'Commit message prompt',
-  },
-  i: {
-    type: 'boolean',
-    alias: 'interactive',
-    description: 'Toggle interactive mode',
-  },
-  s: {
-    type: 'boolean',
-    description: 'Automatically commit staged changes with generated commit message',
-    default: false,
-  },
-  e: {
-    type: 'boolean',
-    alias: 'edit',
-    description: 'Open commit message in editor before proceeding',
-  },
-  summarizePrompt: {
-    type: 'string',
-    description: 'Large file summary prompt',
-  },
-  ignoredFiles: {
-    type: 'array',
-    description: 'Ignored files',
-  },
-  ignoredExtensions: {
-    type: 'array',
-    description: 'Ignored extensions',
-  },
-} as Record<string, Options>
+export const options = {} as Record<string, Options>
 
 export const builder = (yargs: Argv) => {
   return yargs.options(options)

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -1,6 +1,6 @@
 import { Config } from '../lib/config/types'
 
-interface BaseArgvOptions {
+export interface BaseArgvOptions {
   interactive: boolean
   help: boolean
   verbose: boolean

--- a/src/lib/config/services/env.ts
+++ b/src/lib/config/services/env.ts
@@ -2,6 +2,7 @@ import { removeUndefined } from '../../utils/removeUndefined'
 import { Config } from '../types'
 import { CONFIG_KEYS } from '../constants'
 import { updateFileSection } from '../../utils/updateFileSection'
+import { CONFIG_ALREADY_EXISTS } from '../../ui/helpers'
 
 type Keys = keyof Config
 type ValuesTypes = Config[Keys]
@@ -77,5 +78,11 @@ export const appendToEnvFile = async (filePath: string, config: Partial<Config>)
       .join('\n')
   }
 
-  await updateFileSection(filePath, startComment, endComment, getNewContent)
+  await updateFileSection({
+    filePath,
+    startComment,
+    endComment,
+    getNewContent,
+    confirmMessage: CONFIG_ALREADY_EXISTS,
+  })
 }

--- a/src/lib/config/services/git.ts
+++ b/src/lib/config/services/git.ts
@@ -4,6 +4,7 @@ import * as path from 'path'
 import * as ini from 'ini'
 import { Config } from '../types'
 import { updateFileSection } from '../../utils/updateFileSection'
+import { CONFIG_ALREADY_EXISTS } from '../../ui/helpers'
 
 /**
  * Load git profile config (from ~/.gitconfig)
@@ -67,7 +68,13 @@ export const appendToGitConfig = async (filePath: string, config: Partial<Config
     }
     return contentLines.join('\n')
   }
-
-  // Use the updateFileSection utility
-  await updateFileSection(filePath, startComment, endComment, getNewContent)
+  
+  await updateFileSection({
+    filePath,
+    startComment,
+    endComment,
+    getNewContent,
+    confirmUpdate: true,
+    confirmMessage: CONFIG_ALREADY_EXISTS,
+  })
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -59,3 +59,8 @@ export interface CommitLogParserInput extends BaseParserInput {
     to: string
   }
 }
+
+export type CommandHandler<T> = (argv: T, logger: Logger) => Promise<void>;
+
+export type ConfirmMessageCallback = (path: string) => string
+export type ConfirmMessage = string | ConfirmMessageCallback

--- a/src/lib/ui/checkAndHandlePackageInstall.ts
+++ b/src/lib/ui/checkAndHandlePackageInstall.ts
@@ -1,0 +1,50 @@
+import { confirm } from '@inquirer/prompts'
+import { findProjectRoot } from '../utils/findProjectRoot'
+import { installNpmPackage } from '../utils/installPackage'
+import { isPackageInstalled } from '../utils/isPackageInstalled'
+import { Logger } from '../utils/logger'
+
+// TODO: QoL improvement to import this from `package.json`
+const packageName = 'git-coco'
+
+type CheckAndHandlePackageInstallationInput = {
+  global?: boolean
+  logger: Logger
+}
+
+export async function checkAndHandlePackageInstallation({
+  global = false,
+  logger,
+}: CheckAndHandlePackageInstallationInput) {
+  try {
+    // Global installation
+    if (global) {
+      logger.startSpinner(`Installing '${packageName}' globally...`, { color: 'blue' })
+      await installNpmPackage({ name: packageName, flags: ['-g'] })
+      logger.stopSpinner(`Installed '${packageName}' globally`)
+      return
+    }
+
+    // Project level installation
+    const projectRoot = findProjectRoot(process.cwd())
+    let shouldInstall = false
+    if (isPackageInstalled(packageName, projectRoot)) {
+      shouldInstall = await confirm({
+        message: `'${packageName}' is already installed in '${projectRoot}/package.json', would you like to update?`,
+        default: shouldInstall,
+      })
+    } else {
+      shouldInstall = true
+    }
+
+    if (!shouldInstall) {
+      return
+    }
+
+    logger.startSpinner(`Installing '${packageName}' in project...`, { color: 'blue' })
+    await installNpmPackage({ name: packageName, cwd: projectRoot })
+    logger.stopSpinner(`Installed '${packageName}' in project`)
+  } catch (error) {
+    console.error(`Error: ${(error as Error).message}`)
+  }
+}

--- a/src/lib/ui/handleResult.ts
+++ b/src/lib/ui/handleResult.ts
@@ -14,7 +14,7 @@ export async function handleResult({ result, mode, interactiveHandler }: HandleR
       if (interactiveHandler) {
         await interactiveHandler(result)
       } else {
-        console.error('No result handler provided for interactive mode')
+        console.warn('No result handler provided for interactive mode.')
         logSuccess()
       }
       break

--- a/src/lib/ui/helpers.ts
+++ b/src/lib/ui/helpers.ts
@@ -5,4 +5,17 @@ export const isInteractive = (argv: CommitOptions) => {
   return argv?.mode === 'interactive' || argv.interactive
 }
 
-export const SEPERATOR = chalk.blue('----------------')
+export const SEPERATOR = chalk.blue('─────────────')
+
+export const LOGO = chalk.green(
+  `┌────────────┐
+│┌─┐┌─┐┌─┐┌─┐│
+││  │ ││  │ ││
+│└─┘└─┘└─┘└─┘│
+└────────────┘ 
+`
+)
+
+export const CONFIG_ALREADY_EXISTS = (path: string) => {
+  return `coco config found in '${path}', do you want to override it?`
+}

--- a/src/lib/utils/commandExecutor.ts
+++ b/src/lib/utils/commandExecutor.ts
@@ -1,0 +1,23 @@
+import { Argv } from 'yargs'
+import { loadConfig } from '../config/loadConfig'
+import { Logger } from './logger'
+import { CommandHandler } from '../types'
+import { BaseArgvOptions } from '../../commands/types'
+
+function commandExecutor<T extends Argv<BaseArgvOptions>['argv']>(handler: CommandHandler<T>) {
+  return async (argv: T) => {
+    const options = loadConfig(argv)
+    const logger = new Logger(options)
+
+    try {
+      await handler(argv, logger)
+    } catch (error) {
+      logger.log('\nFailed to execute command', { color: 'yellow' })
+      logger.verbose(`\nError: "${(error as Error).message}"`, { color: 'red' })
+      logger.log('\nThanks for using coco, make it a great day! 👋🤖', { color: 'blue' })
+      process.exit(0)
+    }
+  }
+}
+
+export default commandExecutor

--- a/src/lib/utils/createProjectFileAndReturnPath.ts
+++ b/src/lib/utils/createProjectFileAndReturnPath.ts
@@ -1,0 +1,13 @@
+import fs from 'fs'
+import { findProjectRoot } from './findProjectRoot'
+
+export async function createProjectFileAndReturnPath(fileName: string, contents?: string) {
+  const projectRoot = findProjectRoot(process.cwd())
+  const configFile = `${projectRoot}/${fileName}`
+
+  if (!fs.existsSync(configFile)) {
+    fs.writeFileSync(configFile, contents || '')
+  }
+
+  return configFile
+}

--- a/src/lib/utils/execPromise.ts
+++ b/src/lib/utils/execPromise.ts
@@ -1,0 +1,19 @@
+import { exec } from 'child_process'
+
+type ExecPromiseResult = {
+  stdout: string
+  stderr: string
+}
+
+// Function to execute a command and return a promise
+export function execPromise(command: string, options = {}): Promise<ExecPromiseResult> {
+  return new Promise((resolve, reject) => {
+    exec(command, options, (error, stdout, stderr) => {
+      if (error) {
+        reject(`Execution error: ${error}`)
+      } else {
+        resolve({ stdout, stderr })
+      }
+    })
+  })
+}

--- a/src/lib/utils/findProjectRoot.ts
+++ b/src/lib/utils/findProjectRoot.ts
@@ -1,0 +1,29 @@
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * Finds the project root directory starting from the given current directory.
+ * It checks if the `.git` directory or `package.json` file exists in the current directory or any of its parent directories.
+ * If found, it returns the path to the project root directory.
+ * If not found, it throws an error.
+ *
+ * @param currentDir - The current directory to start searching from.
+ * @returns The path to the project root directory.
+ * @throws Error if the project root directory cannot be found.
+ */
+export function findProjectRoot(currentDir: string) {
+  const root = path.parse(currentDir).root
+
+  while (currentDir !== root) {
+    if (
+      fs.existsSync(path.join(currentDir, '.git')) ||
+      fs.existsSync(path.join(currentDir, 'package.json'))
+    ) {
+      return currentDir
+    }
+
+    currentDir = path.dirname(currentDir)
+  }
+
+  throw new Error('Unable to find project root. Are you in the right directory?')
+}

--- a/src/lib/utils/getPathToUsersGitConfig.ts
+++ b/src/lib/utils/getPathToUsersGitConfig.ts
@@ -1,0 +1,6 @@
+import os from 'os';
+import path from 'path';
+
+export function getPathToUsersGitConfig() {
+  return path.join(os.homedir(), '.gitconfig');
+}

--- a/src/lib/utils/installPackage.ts
+++ b/src/lib/utils/installPackage.ts
@@ -1,0 +1,31 @@
+import { execPromise } from './execPromise'
+
+type InstallPackageInput = {
+  name: string
+  flags?: string[]
+  cwd?: string
+}
+
+/**
+ * Installs a package using npm.
+ *
+ * @param {InstallPackageInput} options - The options for installing the package.
+ * @returns {Promise<boolean>} - A promise that resolves to true if the package is installed successfully, false otherwise.
+ */
+export async function installNpmPackage({
+  name,
+  flags = [],
+  cwd = process.cwd(),
+}: InstallPackageInput) {
+  const { stdout, stderr } = await execPromise(`npm i ${name} ${flags.join(' ')} --yes`, { cwd })
+
+  if (stderr) {
+    console.error(`Execution error: ${stderr}`)
+    return false
+  }
+
+  console.log(stdout)
+  console.error(stderr)
+
+  return true
+}

--- a/src/lib/utils/isPackageInstalled.ts
+++ b/src/lib/utils/isPackageInstalled.ts
@@ -1,0 +1,29 @@
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * Checks if a package is installed in a project.
+ * 
+ * @param packageName - The name of the package to check.
+ * @param projectPath - The path to the project.
+ * @returns True if the package is installed, false otherwise.
+ */
+export function isPackageInstalled(packageName: string, projectPath: string) {
+  try {
+    // Construct the path to the package.json file
+    const packageJsonPath = path.join(projectPath, 'package.json')
+
+    // Read the package.json file
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+
+    // Check both dependencies and devDependencies
+    const dependencies = packageJson.dependencies || {}
+    const devDependencies = packageJson.devDependencies || {}
+
+    // Return true if the package is found in either
+    return dependencies.hasOwnProperty(packageName) || devDependencies.hasOwnProperty(packageName)
+  } catch (error) {
+    console.error(`Error checking package installation: ${(error as Error).message}`)
+    return false
+  }
+}

--- a/src/lib/utils/updateFileSection.ts
+++ b/src/lib/utils/updateFileSection.ts
@@ -1,13 +1,25 @@
 import fs from 'fs'
-import { confirm }  from '@inquirer/prompts'
+import { confirm } from '@inquirer/prompts'
+import { ConfirmMessage } from '../types'
 
-export async function updateFileSection(
-  filePath: string,
-  startComment: string,
-  endComment: string,
-  getNewContent: () => Promise<string>,
-  confirmUpdate = true
-) {
+type UpdateFileSectionInput = {
+  filePath: string
+  startComment: string
+  endComment: string
+  getNewContent: () => Promise<string>
+  confirmUpdate?: boolean
+  confirmMessage?: ConfirmMessage
+}
+
+export async function updateFileSection({
+  filePath,
+  startComment,
+  endComment,
+  getNewContent,
+  confirmUpdate = true,
+  confirmMessage = (path: string) =>
+    `A section already exists in ${path}, do you want to override it?`,
+}: UpdateFileSectionInput) {
   const lines = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8').split(/\r?\n/) : []
   const newLines = []
   let foundSection = false
@@ -18,7 +30,7 @@ export async function updateFileSection(
 
       if (confirmUpdate) {
         const confirmOverwrite = await confirm({
-          message: `A section already exists in ${filePath}, do you want to override it?`,
+          message: typeof confirmMessage === 'function' ? confirmMessage(filePath) : confirmMessage,
           default: false,
         })
 


### PR DESCRIPTION
- Installs `git-coco` to specified location
- Improves logging
- Improve error handling and gracefully exiting
- Adds `coco` logo to top of commands when in interactive mode
- bunch of new utility methods for `init` command