### PR TITLE
Update package installation to devDependencies

### DIFF
--- a/src/lib/ui/checkAndHandlePackageInstall.ts
+++ b/src/lib/ui/checkAndHandlePackageInstall.ts
@@ -42,7 +42,7 @@ export async function checkAndHandlePackageInstallation({
     }
 
     logger.startSpinner(`Installing '${packageName}' in project...`, { color: 'blue' })
-    await installNpmPackage({ name: packageName, cwd: projectRoot })
+    await installNpmPackage({ name: packageName, cwd: projectRoot, flags: ['--save-dev'] })
     logger.stopSpinner(`Installed '${packageName}' in project`)
   } catch (error) {
     console.error(`Error: ${(error as Error).message}`)


### PR DESCRIPTION
Modified the `installNpmPackage` function in the `checkAndHandlePackageInstall.ts` file to install packages as devDependencies. Previously, the function was installing packages without any specific flag. 

Now, it installs the packages with the '--save-dev' flag, ensuring the packages are added to the `devDependencies` section in the `package.json` file.