### PR TITLE
Feat/add-level-arg-to-init-wizard

### DIFF
--- a/src/commands/init/handler.ts
+++ b/src/commands/init/handler.ts
@@ -8,29 +8,35 @@ import { appendToProjectConfig } from '../../lib/config/services/project'
 import { LOGO } from '../../lib/ui/helpers'
 import { checkAndHandlePackageInstallation } from '../../lib/ui/checkAndHandlePackageInstall'
 
-import { InitArgv } from './options'
+import { InitArgv, InitOptions } from './options'
 import { getPathToUsersGitConfig } from '../../lib/utils/getPathToUsersGitConfig'
 import { createProjectFileAndReturnPath } from '../../lib/utils/createProjectFileAndReturnPath'
 import { CommandHandler } from '../../lib/types'
+import { loadConfig } from '../../lib/config/loadConfig'
 
 export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
+  const options = loadConfig(argv) as InitOptions
+  
   logger.log(LOGO)
-
-  const level = await select({
-    message: 'configure coco at the system or project level:',
-    choices: [
-      {
-        name: 'system',
-        value: 'system',
-        description: 'add coco config to your global git config',
-      },
-      {
-        name: 'project',
-        value: 'project',
-        description: 'add coco config to existing git project',
-      },
-    ],
-  })
+  
+  let level = options?.level
+  if (!level) {
+    level = await select({
+      message: 'configure coco at the system or project level:',
+      choices: [
+        {
+          name: 'system',
+          value: 'system',
+          description: 'add coco config to your global git config',
+        },
+        {
+          name: 'project',
+          value: 'project',
+          description: 'add coco config to existing git project',
+        },
+      ],
+    })
+  }
 
   let configFilePath = ''
 

--- a/src/commands/init/options.ts
+++ b/src/commands/init/options.ts
@@ -1,14 +1,24 @@
 import { Options, Argv } from 'yargs'
 import { BaseArgvOptions } from '../types'
 
-export type InitOptions = BaseArgvOptions
+export interface InitOptions extends BaseArgvOptions {
+  level?: 'system' | 'project'
+}
 
 export type InitArgv = Argv<InitOptions>['argv']
 
 /**
  * Command line options via yargs
  */
-export const options = {} as Record<string, Options>
+export const options = {
+  level: {
+    type: 'string',
+    alias: 'l',
+    description: 'Configure coco at the system or project level',
+    choices: ['system', 'project'],
+  },
+  
+} as Record<string, Options>
 
 export const builder = (yargs: Argv) => {
   return yargs.options(options)

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -1,12 +1,12 @@
 import { Config } from '../lib/config/types'
 
 export interface BaseArgvOptions {
+  [x: string]: unknown
   interactive: boolean
   help: boolean
   verbose: boolean
 }
 export interface BaseCommandOptions extends BaseArgvOptions {
-  [x: string]: unknown
   service: Config['service']
   openAIApiKey: Config['openAIApiKey']
   huggingFaceHubApiKey: Config['huggingFaceHubApiKey']

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -15,7 +15,7 @@ export interface Config {
    * @example 'huggingface/bigscience/bloom'
    **/
 
-  service: Service
+  service?: Service
   
   /**
    * The OpenAI API key.


### PR DESCRIPTION
This update adds a new `level` option to the `init` command. This option allows the user to configure coco at either the system or project level directly from the command line, without having to go through the selection prompt. The `level` option is optional and if not provided, the selection prompt will be displayed as before.

Changes were made to both `handler.ts` and `options.ts` within the `init` command directory. In `handler.ts`, the `loadConfig` function is now used to load the command options and if the `level` option is not provided, the selection prompt is displayed. In `options.ts`, the `InitOptions` interface was extended to include the `level` option and the `options` object was updated to include the new `level` option.