### PR TITLE
Update terminology from 'system' to 'global'

### DIFF
--- a/src/commands/init/handler.ts
+++ b/src/commands/init/handler.ts
@@ -22,11 +22,11 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
   let level = options?.level
   if (!level) {
     level = await select({
-      message: 'configure coco at the system or project level:',
+      message: 'configure coco for the current user or project?',
       choices: [
         {
-          name: 'system',
-          value: 'system',
+          name: 'global',
+          value: 'global',
           description: 'add coco config to your global git config',
         },
         {
@@ -57,7 +57,7 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
       })
       configFilePath = await createProjectFileAndReturnPath(projectConfiguration)
       break
-    case 'system':
+    case 'global':
     default:
       configFilePath = getPathToUsersGitConfig()
       break
@@ -187,7 +187,7 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
     }
 
     // After config is written, check for package installation
-    await checkAndHandlePackageInstallation({ global: level === 'system', logger })
+    await checkAndHandlePackageInstallation({ global: level === 'global', logger })
 
     logger.log(`\ninit successful! 🦾🤖🎉`, { color: 'green' })
   } else {

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -4,7 +4,7 @@ import { builder, options } from './options'
 
 export default {
   command: 'init',
-  desc: 'Setup coco for a new project or system',
+  desc: 'install & configure coco globally or for the current project',
   builder,
   handler: commandExecutor(handler),
   options,

--- a/src/commands/init/options.ts
+++ b/src/commands/init/options.ts
@@ -2,7 +2,7 @@ import { Options, Argv } from 'yargs'
 import { BaseArgvOptions } from '../types'
 
 export interface InitOptions extends BaseArgvOptions {
-  level?: 'system' | 'project'
+  level?: 'global' | 'project'
 }
 
 export type InitArgv = Argv<InitOptions>['argv']
@@ -14,10 +14,9 @@ export const options = {
   level: {
     type: 'string',
     alias: 'l',
-    description: 'Configure coco at the system or project level',
-    choices: ['system', 'project'],
+    description: 'configure coco for the current user or project?',
+    choices: ['global', 'project'],
   },
-  
 } as Record<string, Options>
 
 export const builder = (yargs: Argv) => {


### PR DESCRIPTION
This commit updates the terminology used in the init command and its options. The term 'system' has been replaced with 'global' to better represent the scope of the configuration. This change affects the `handler.ts` and `options.ts` files in the `src/commands/init` directory. The choice options and related descriptions have been updated accordingly. The `checkAndHandlePackageInstallation` function call has also been updated to reflect this change.