### PR TITLE
Update README with new `coco` features and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,123 +6,80 @@
 [![NPM Version](https://img.shields.io/npm/v/git-coco.svg)](https://www.npmjs.com/package/git-coco)
 [![NPM Downloads](https://img.shields.io/npm/dt/git-coco.svg)](https://www.npmjs.com/package/git-coco)
 
-Commit Copilot, or `coco`, is your personal scribe for git commit messages. Leveraging the power of [LangChain🦜🔗](https://js.langchain.com/) and LLMs to encapsulate your staged changes into meaningful commit messages!
+`coco`, the Commit Copilot, is not just your scribe for git commit messages. With the power of [LangChain🦜🔗](https://js.langchain.com/) and LLMs, it now brings you a suite of tools to streamline your git workflow!
 
+## Commands
 
+- **`commit`**: generates commit messages based on staged changes.
 
-## Installation
+- **`changelog`**: create changelogs for the current branch or a range of commits.
 
-Get started by adding `coco` to your project's development dependencies:
+- **`init`**: step by step wizard to set up `coco` globally or for a project.
+
+## Getting Started
+
+**`coco init`** is the first step to getting started with `coco`. It will guide you through the installation process, including setting up your OpenAI API key and configuring `coco` to your preferences.
 
 ```bash
-npm i git-coco --save-dev
-```
+# For local project use
+npx git-coco@latest init -l project
 
-Or, for global access, you can install `coco` system-wide:
-
-```bash
-npm i -g git-coco
+# For global use
+npx git-coco@latest init -l global
 ```
 
 ## Usage
 
-There are two main ways to use `coco`: 
+### **`coco commit`**
 
-1. [Interactive Mode](#interactive)
-2. [Command Line Interface (CLI)](#cli)
-
-### **Interactive Mode**
-
-Just type `coco` and let the friendly prompts guide you through the commit process!
+Generates commit messages based on staged changes.
 
 ```bash
+coco commit
+```
+
+### **`coco changelog`**
+
+Creates changelogs.
+
+```bash
+# For the current branch
+coco changelog
+
+# For a specific range
+coco changelog -r HEAD~5:HEAD
+```
+
+
+### Stdout vs. Interactive Mode
+
+`coco` offers two modes of operation: **stdout** and **interactive**, defaulting to **stdout**. You can specify your preferred mode in your config file or via command line flags.
+
+```bash
+# Stdout mode
+git commit -m $(coco)
+
+# Interactive mode
 coco -i
 ```
 
-The interactive mode offers you several benefits:
+### Generate and commit all in one
 
-- Preview and approve or regenerate the commit message before it's committed
-- Customize your prompts for a personalized commit experience
-
-### **Command Line Interface (CLI)**
-
-If you're the type who likes to keep it simple, you can pass your commit message directly as a CLI argument:
-
-```bash
-coco --openAIApiKey="sk_your-openai-api-key"
-```
-
-Assuming you've stored your API key in the config file ([learn more](#the-cococonfig)), you can also commit with:
-
-```bash
-git commit -m $(coco)
-```
-
-Alternatively, take advantage of `coco`'s full potential by allowing it to make the commit for you!
+`coco` can generate and commit your changes in one command.
 
 ```bash
 coco -s
 ```
 
-## **The `coco.config`**
+### **Ignoring Files**
 
-`coco.config` houses the project-level settings and can be defined in multiple places, adhering to a hierarchical order of priority. If the same configuration is found in multiple places, the higher priority one will be considered.
+You can specify files to be ignored when generating commit messages by adding them to your config file or via command line flags.  Read more about ignoring files & extensions in the [wiki](https://github.com/gfargo/coco/wiki/Ignoring-Files-&-Extensions).
 
-From highest to lowest, the priority order is:
 
-1. **Command Line Flags**: Flags in the command line have the highest priority, and they override all other settings.
-2. **Environment Variables**: Next in line are environment variables. You can set any configuration option as an environment variable.
-3. **Project Config (`.coco.config.json`)**: Create a `.coco.config.json` file in your project root to set configurations. It's recommended to store your OpenAI API key here alongside any other project-specific configurations.
-4. **Git Profile (`.gitconfig`)**: You can define `coco` settings under a `[coco]` section in your git profile. These settings will be used unless overridden by higher-priority ones.
-5. **XDG Configuration Directory**: If `XDG_CONFIG_HOME` is set, `coco` will look for a `coco/config` file in this directory for configurations.
+## Configuration
 
-Here's an example `.coco.config.json` file:
-
-```json
-{
-    "openAIApiKey": "sk_your-openai-api-key",
-}
-```
-
-And the same settings in `.gitconfig`:
-
-```ini
-[coco]
-    openAIApiKey = sk_your-openai-api-key
-```
-
-Remember, command line flags and environment variables should be defined in `UPPER_SNAKE_CASE`. For instance, the `openAIApiKey` setting becomes `OPENAI_API_KEY`.
-
-### Options
-
-| Name                     | Type                            | Default Value                             | Description                                                                                                               |
-|--------------------------|---------------------------------|-------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| openAIApiKey             | string                          | None                                      | Your OpenAI API key                                                                                                       |
-| tokenLimit               | number                          | 500                                       | Maximum number of tokens for the commit message                                                                           |
-| prompt                   | string                          | `"What are the changes in this commit?"`  | Prompt for OpenAI GPT-3                                                                                                   |
-| temperature              | number                          | 0.4                                       | Controls randomness in GPT-3 output. Lower values yield focused output; higher values offer diversity                      |
-| mode                     | `stdout` \| `interactive`       | `stdout`                                  | Preferred output method for generated commit messages                                                                     |
-| summarizePrompt          | string                          | `"Summarize the changes in this large file:"` | GPT-3 prompt for summarizing large files                                                                                  |
-| ignoredFiles             | string[]                        | `["package-lock.json"]`                  | Paths of files to be excluded when generating commit messages                                                             |
-| ignoredExtensions        | string[]                        | `[".map", ".lock"]`                      | File extensions to be excluded when generating commit messages                                                            |
-
-## Roadmap
-
-- [x] Interactive mode 🤖
-- [x] Stdout 📤
-- [x] LangChain integration 🦜
-- [ ] Additional tests! 🧪
-- [ ] Conventional commits 🔜
-- [x] HuggingFace integration 🔜
-- [ ] Google Vertex AI integration (?)
-- [ ] Automatic changelog generation 🫣
-- [ ] Rebase support 🔀
-- [ ] `coco --amend b31dfc` 👩‍💻
-
-...and more! 🧑‍🔬 🚀
+The `.coco.config` documentation has moved to our [wiki](https://github.com/gfargo/coco/wiki/Config-Overview). Here, you'll find detailed information on setting up and customizing your experience.
 
 ## Contribution
 
-Have an idea for a feature or want to get involved, we welcome contributions!
-
-Please check out our [CONTRIBUTING.md](CONTRIBUTING.md) for more information.
+We welcome contributions! Check out our [CONTRIBUTING.md](CONTRIBUTING.md) for more information.


### PR DESCRIPTION
This update to the README includes a redefinition of `coco` as not just a scribe for git commit messages, but also as a suite of tools to streamline git workflow. The update introduces new commands such as `commit`, `changelog`, and `init`. It also provides detailed instructions on how to get started with `coco`, how to use the different commands, and how to configure `coco` according to user preferences. The section on ignoring files and the configuration documentation have been moved to the wiki for more detailed information.