### PR TITLE
Update `simple-git` library documentation

### DIFF
--- a/src/lib/simple-git/createCommit.ts
+++ b/src/lib/simple-git/createCommit.ts
@@ -1,8 +1,12 @@
-import { CommitResult, SimpleGit } from 'simple-git';
+import { CommitResult, SimpleGit } from 'simple-git'
 
-export async function createCommit(
-  commitMsg: string,
-  git: SimpleGit
-): Promise<CommitResult> {
-  return await git.commit(commitMsg);
+/**
+ * Creates a commit with the specified commit message.
+ * 
+ * @param message The commit message.
+ * @param git The SimpleGit instance.
+ * @returns A Promise that resolves to the CommitResult.
+ */
+export async function createCommit(message: string, git: SimpleGit): Promise<CommitResult> {
+  return await git.commit(message)
 }

--- a/src/lib/simple-git/getChanges.ts
+++ b/src/lib/simple-git/getChanges.ts
@@ -20,6 +20,12 @@ export type GetChangesResult = {
   untracked?: FileChange[]
 }
 
+/**
+ * Retrieves the changes in the Git repository.
+ * 
+ * @param {GetChangesInput} options - The options for retrieving the changes.
+ * @returns {Promise<GetChangesResult>} A promise that resolves to the changes in the Git repository.
+ */
 export async function getChanges({ git, options }: GetChangesInput): Promise<GetChangesResult> {
   const { ignoredFiles = DEFAULT_IGNORED_FILES, ignoredExtensions = DEFAULT_IGNORED_EXTENSIONS } =
     options || {}

--- a/src/lib/simple-git/getChangesByCommit.ts
+++ b/src/lib/simple-git/getChangesByCommit.ts
@@ -23,6 +23,13 @@ export type GetChangeByCommitInput = {
   }
 }
 
+/**
+ * Retrieves the changes made in a commit.
+ * 
+ * @param commit - The commit hash.
+ * @param options - Optional parameters for customization.
+ * @returns A promise that resolves to an array of FileChange objects representing the changes made in the commit.
+ */
 export async function getChangesByCommit({
   commit,
   options: {

--- a/src/lib/simple-git/getCommitLogCurrentBranch.ts
+++ b/src/lib/simple-git/getCommitLogCurrentBranch.ts
@@ -10,6 +10,16 @@ export type GetCommitLogCurrentBranch = {
   comparisonRemote?: string
 }
 
+/**
+ * Retrieves the commit log for the current branch.
+ * 
+ * @param {Object} options - The options for retrieving the commit log.
+ * @param {SimpleGit} options.git - The SimpleGit instance.
+ * @param {Logger} options.logger - The logger for logging messages.
+ * @param {string} [options.comparisonBranch='main'] - The branch to compare against.
+ * @param {string} [options.comparisonRemote='origin'] - The remote to compare against.
+ * @returns {Promise<string[]>} The array of commit messages in the commit log.
+ */
 export async function getCommitLogCurrentBranch({
   git,
   logger,

--- a/src/lib/simple-git/getCommitLogRange.ts
+++ b/src/lib/simple-git/getCommitLogRange.ts
@@ -2,6 +2,15 @@ import { DefaultLogFields, LogOptions, SimpleGit, TaskOptions } from 'simple-git
 
 type GetCommitLogRangeOptions = { git: SimpleGit; noMerges?: boolean }
 
+/**
+ * Retrieves the commit log range between two specified commits.
+ *
+ * @param from - The starting commit.
+ * @param to - The ending commit.
+ * @param options - Additional options for retrieving the commit log range.
+ * @returns A promise that resolves to an array of commit log messages.
+ * @throws If there is an error retrieving the commit log range.
+ */
 export async function getCommitLogRange(
   from: string,
   to: string,

--- a/src/lib/simple-git/getCurrentBranchName.ts
+++ b/src/lib/simple-git/getCurrentBranchName.ts
@@ -4,6 +4,11 @@ export type GetCurrentBranchName = {
   git: SimpleGit
 }
 
+/**
+ * Retrieves the name of the current branch.
+ * @param {GetCurrentBranchName} options - The options for retrieving the branch name.
+ * @returns {Promise<string>} - A promise that resolves to the name of the current branch.
+ */
 export async function getCurrentBranchName({ git }: GetCurrentBranchName): Promise<string> {
   return await git.revparse(['--abbrev-ref', 'HEAD'])
 }

--- a/src/lib/simple-git/getDiff.ts
+++ b/src/lib/simple-git/getDiff.ts
@@ -3,6 +3,14 @@ import { createTwoFilesPatch } from 'diff'
 import { FileChange } from '../types'
 import { Logger } from '../utils/logger'
 
+/**
+ * Parses the default file diff for a given nodeFile.
+ *
+ * @param nodeFile - The file change object.
+ * @param commit - The commit to diff against. Defaults to '--staged'.
+ * @param git - The SimpleGit instance.
+ * @returns A Promise that resolves to the file diff as a string.
+ */
 async function parseDefaultFileDiff(
   nodeFile: FileChange,
   commit = '--staged',
@@ -15,6 +23,15 @@ async function parseDefaultFileDiff(
   return await git.diff([commit, nodeFile.filePath])
 }
 
+/**
+ * Parses the diff for a renamed file.
+ *
+ * @param nodeFile - The file change object.
+ * @param commit - The commit hash or '--staged'.
+ * @param git - The SimpleGit instance.
+ * @param logger - The logger instance.
+ * @returns A Promise that resolves to the diff string.
+ */
 async function parseRenamedFileDiff(
   nodeFile: FileChange,
   commit: string,
@@ -68,6 +85,18 @@ async function parseRenamedFileDiff(
   return result
 }
 
+/**
+ * Retrieves the diff for a given file change in a specific commit.
+ * If the file is deleted, it returns a message indicating that the file has been deleted.
+ * If the file is renamed, it parses the renamed file diff and returns it.
+ * Otherwise, it retrieves the default diff from the index and returns it.
+ *
+ * @param nodeFile - The file change object.
+ * @param commit - The commit hash.
+ * @param git - The SimpleGit instance.
+ * @param logger - The logger instance.
+ * @returns A promise that resolves to the diff as a string.
+ */
 export async function getDiff(
   nodeFile: FileChange,
   commit: string,

--- a/src/lib/simple-git/getRepo.ts
+++ b/src/lib/simple-git/getRepo.ts
@@ -1,5 +1,9 @@
 import { simpleGit, SimpleGit } from 'simple-git'
 
+/**
+ * Retrieves the SimpleGit instance for the repository.
+ * @returns {SimpleGit} The SimpleGit instance.
+ */
 export const getRepo = () => {
   let git: SimpleGit
   

--- a/src/lib/simple-git/getStatus.ts
+++ b/src/lib/simple-git/getStatus.ts
@@ -1,6 +1,14 @@
 import { FileChangeStatus } from '../types'
 import { DiffResultBinaryFile, DiffResultTextFile, FileStatusResult } from 'simple-git'
 
+/**
+ * Determines the status of a file based on its changes in the Git repository.
+ *
+ * @param file - The file to check the status of.
+ * @param location - The location to check the status in ('index' or 'working_dir'). Defaults to 'index'.
+ * @returns The status of the file ('added', 'deleted', 'modified', 'renamed', 'untracked', or 'unknown').
+ * @throws Error if the file type is invalid.
+ */
 export function getStatus(
   file: FileStatusResult | DiffResultTextFile | DiffResultBinaryFile,
   location: 'index' | 'working_dir' = 'index'

--- a/src/lib/simple-git/getSummaryText.ts
+++ b/src/lib/simple-git/getSummaryText.ts
@@ -2,6 +2,14 @@ import { DiffResultBinaryFile, DiffResultTextFile, FileStatusResult } from 'simp
 import { getStatus } from './getStatus'
 import { FileChange } from '../types'
 
+/**
+ * Returns the summary text for a file change.
+ * 
+ * @param file - The file status or diff result.
+ * @param change - The partial file change object.
+ * @returns The summary text for the file change.
+ * @throws Error if the file type is invalid.
+ */
 export function getSummaryText(
   file: FileStatusResult | DiffResultTextFile | DiffResultBinaryFile,
   change: Partial<FileChange>

--- a/src/lib/simple-git/helpers.ts
+++ b/src/lib/simple-git/helpers.ts
@@ -3,14 +3,21 @@ interface ParsedFilePaths {
   oldFilePath?: string;
 }
 
-export const parseFileString = (file: string): ParsedFilePaths => {
+/**
+ * Parses a file string and returns the parsed file paths.
+ * If the file string contains a separator, it splits the string into root path, file path, and old file path.
+ * If the file string doesn't contain the separator, it assumes the file string itself is the file path and old file path is undefined.
+ * @param file The file string to parse.
+ * @returns The parsed file paths.
+ */
+export function parseFileString(file: string): ParsedFilePaths {
   const separator = ' => ';
-  
+
   if (file.includes(separator)) {
     const [oldFilePathWithRoot, filePath] = file.split(separator);
 
-    const [rootPath, oldFilePath] = oldFilePathWithRoot.split("{")
-    
+    const [rootPath, oldFilePath] = oldFilePathWithRoot.split("{");
+
     return {
       filePath: rootPath + filePath.trim().replace("{", "").replace("}", ""),
       oldFilePath: rootPath + oldFilePath.trim().replace("{", "").replace("}", "")


### PR DESCRIPTION
Added comprehensive comments to functions in the `simple-git` library. The functions now have detailed explanations regarding their functionality, input parameters, return values, and exceptions. This documentation update also includes a minor code modification in the `createCommit` function, where the variable name 'commitMsg' has been updated to 'message'.