### PR TITLE
Update TypeScript and dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
       - dependency-name: "p-queue"
       - dependency-name: "ora"
       - dependency-name: "chalk"
+      - dependency-name: " @inquirer/prompts"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/inquirer": "^9.0.3",
     "@types/jest": "^29.5.10",
     "@types/node": "^20.14.4",
-    "@types/yargs": "^17.0.24",
+    "@types/yargs": "^17.0.32",
     "@typescript-eslint/eslint-plugin": "^7.13.1",
     "@typescript-eslint/parser": "^7.13.1",
     "eslint": "^8.54.0",
@@ -77,7 +77,7 @@
     "ts-node": "^10.9.1",
     "tslib": "^2.5.3",
     "tsx": "^3.12.7",
-    "typescript": "^5.1.6"
+    "typescript": "^5.4.5"
   },
   "dependencies": {
     "@inquirer/prompts": "3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1367,7 +1367,7 @@
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
   integrity sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==
 
-"@types/yargs@^17.0.24", "@types/yargs@^17.0.8":
+"@types/yargs@^17.0.32", "@types/yargs@^17.0.8":
   version "17.0.32"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.32.tgz#030774723a2f7faafebf645f4e5a48371dca6229"
   integrity sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==
@@ -5947,7 +5947,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^5.1.6:
+typescript@^5.4.5:
   version "5.4.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
   integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==


### PR DESCRIPTION
- Bump `@types/yargs` to `^17.0.32` and `typescript` to `^5.4.5`. 
- Add `@inquirer/prompts` to the list of dependencies for automated updates in `dependabot.yml`.