### PR TITLE
Enhance `commit` command with `--append` and `--additional` options

### DIFF
--- a/src/commands/commit/options.ts
+++ b/src/commands/commit/options.ts
@@ -27,6 +27,14 @@ export const options = {
     description: 'Ignored extensions',
     type: 'array',
   },
+  append: {
+    description: 'Add content to the end of the generated commit message',
+    type: 'string',
+  },
+  additional: {
+    description: 'Add extra contextual information to the prompt',
+    type: 'string',
+  },
 } as Record<string, Options>
 
 export const builder = (yargsInstance: ReturnType<typeof yargs>) => {

--- a/src/commands/commit/prompt.ts
+++ b/src/commands/commit/prompt.ts
@@ -13,9 +13,14 @@ Please follow the guidelines below when writing your commit message:
 
 {format_instructions}
 
-"""{summary}"""`
+""""""
+{summary}
+""""""
 
-export const inputVariables = ['summary', 'format_instructions']
+{additional}
+`
+
+const inputVariables = ['summary', 'format_instructions', 'additional']
 
 export const COMMIT_PROMPT = new PromptTemplate({
   template,


### PR DESCRIPTION
### Features

Enhance the `coco commit` command with new options: Add `--additional` and `--append` options to the commit command, allowing users to include extra context and append custom text to generated commit messages. 

These additions aim to improve the flexibility and accuracy of commit message generation by integrating user-provided information directly into the process. (4ef4245)

Additional details in #19

Resolves #19 