### PR TITLE
Standard Command Usage Banners

### DIFF
--- a/src/commands/changelog/options.ts
+++ b/src/commands/changelog/options.ts
@@ -1,4 +1,6 @@
 import yargs, { Arguments, Options } from 'yargs'
+import changelog from '.'
+import { getCommandUsageHeader } from '../../lib/ui/helpers'
 import { BaseCommandOptions } from '../types'
 
 export interface ChangelogOptions extends BaseCommandOptions {
@@ -30,5 +32,5 @@ export const options = {
 } as Record<string, Options>
 
 export const builder = (yargsInstance: ReturnType<typeof yargs>) => {
-  return yargsInstance.options(options)
+  return yargsInstance.options(options).usage(getCommandUsageHeader(changelog.command))
 }

--- a/src/commands/commit/options.ts
+++ b/src/commands/commit/options.ts
@@ -1,4 +1,6 @@
 import yargs, { Arguments, Options } from 'yargs'
+import commit from '.'
+import { getCommandUsageHeader } from '../../lib/ui/helpers'
 import { BaseCommandOptions } from '../types'
 
 export interface CommitOptions extends BaseCommandOptions {
@@ -18,7 +20,7 @@ export const options = {
     alias: 'interactive',
     description: 'Toggle interactive mode',
     type: 'boolean',
-  }, 
+  },
   ignoredFiles: {
     description: 'Ignored files',
     type: 'array',
@@ -38,5 +40,5 @@ export const options = {
 } as Record<string, Options>
 
 export const builder = (yargsInstance: ReturnType<typeof yargs>) => {
-  return yargsInstance.options(options)
+  return yargsInstance.options(options).usage(getCommandUsageHeader(commit.command))
 }

--- a/src/commands/init/options.ts
+++ b/src/commands/init/options.ts
@@ -1,4 +1,6 @@
-import { Options, Argv } from 'yargs'
+import { Argv, Options } from 'yargs'
+import init from '.'
+import { getCommandUsageHeader } from '../../lib/ui/helpers'
 import { BaseArgvOptions } from '../types'
 
 export type InstallationScope = 'global' | 'project'
@@ -21,5 +23,5 @@ export const options = {
 } as Record<string, Options>
 
 export const builder = (yargs: Argv) => {
-  return yargs.options(options)
+  return yargs.options(options).usage(getCommandUsageHeader(init.command))
 }

--- a/src/commands/recap/options.ts
+++ b/src/commands/recap/options.ts
@@ -1,4 +1,6 @@
 import yargs, { Arguments, Options } from 'yargs'
+import recap from '.'
+import { getCommandUsageHeader } from '../../lib/ui/helpers'
 import { BaseCommandOptions } from '../types'
 
 export interface RecapOptions extends BaseCommandOptions {
@@ -41,5 +43,5 @@ export const options = {
 } as Record<string, Options>
 
 export const builder = (yargsInstance: ReturnType<typeof yargs>) => {
-  return yargsInstance.options(options).wrap(36)
+  return yargsInstance.options(options).usage(getCommandUsageHeader(recap.command))
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 import yargs from 'yargs'
 import changelog from './commands/changelog'
 import commit from './commands/commit'
@@ -11,11 +12,10 @@ import recap from './commands/recap'
 import { RecapOptions } from './commands/recap/options'
 import { Config } from './lib/config/types'
 import * as types from './lib/types'
-import { USAGE_BANNER } from './lib/ui/helpers'
 
 const y = yargs()
 
-y.scriptName('coco').usage(USAGE_BANNER)
+y.scriptName('coco')
 
 y.command<CommitOptions>(
   [commit.command, '$0'],

--- a/src/lib/ui/helpers.ts
+++ b/src/lib/ui/helpers.ts
@@ -2,24 +2,36 @@ import chalk from 'chalk'
 import { loadConfig } from '../config/utils/loadConfig'
 
 export const isInteractive = (config: ReturnType<typeof loadConfig>) => {
-  return config?.mode === 'interactive' || !!config?.interactive 
+  return config?.mode === 'interactive' || !!config?.interactive
 }
 
 export const SEPERATOR = chalk.blue('─────────────')
 
 export const LOGO = chalk.green(
-  `┌────────────┐
-│┌─┐┌─┐┌─┐┌─┐│
-││  │ ││  │ ││
-│└─┘└─┘└─┘└─┘│
-└────────────┘`
+  `┌──────┐
+│┏┏┓┏┏┓│
+│┗┗┛┗┗┛│
+└──────┘`
 )
+
+export const LOGO_SMALL = chalk.green(
+  `┌────┐
+│coco│
+└────┘`)
 
 export const USAGE_BANNER = chalk.green(
   `${LOGO}
-v: ${process.env.npm_package_version}
+${chalk.bgGreen(`\xa0v${process.env.npm_package_version}\xa0`)}
 `
 )
+
+export const getCommandUsageHeader = (command: string) => {
+  return chalk.green(
+    `${USAGE_BANNER}\n${chalk.white('Command:')}\n\xa0\xa0\xa0\xa0\xa0 $0 ${chalk.greenBright(
+      command
+    )} [options]`
+  )
+}
 
 export const CONFIG_ALREADY_EXISTS = (path: string) => {
   return `coco config found in '${path}', do you want to override it?`


### PR DESCRIPTION
- Remove global usage banner
  - Eliminate `USAGE_BANNER` from `yargs` setup to streamline command-line interface. Each command now has its own usage banner, enhancing clarity and modularity. This change simplifies the entry point by removing redundant global usage instructions, focusing on specific command guidance. (cfdb093)

- Add usage headers to command options
  - Enhance the command options builders by including usage headers using `getCommandUsageHeader` for better CLI guidance. Updated `builder` functions in `commit`, `recap`, `init`, and `changelog` to append usage details from their respective command definitions. This improves user experience by providing clear command usage information. (7afa1bd)

- Update UI helpers for improved display
  - Refactor `LOGO` for a cleaner look and add `LOGO_SMALL` for compact display options. Enhance `USAGE_BANNER` by embedding the version in a highlighted format. Introduce `getCommandUsageHeader` to streamline command usage messages. These changes improve the visual appeal and clarity of the UI components. (283bd82)
