### PR TITLE
Resolve bug with file change parsing in `recap` cmd

### DIFF
--- a/src/commands/recap/handler.ts
+++ b/src/commands/recap/handler.ts
@@ -59,15 +59,30 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
             untracked?.length || 0
           }`
         )
-        const result = await fileChangeParser({
-          changes: [...staged, ...(unstaged ? unstaged : []), ...(untracked ? untracked : [])],
-          commit: 'HEAD',
+
+        const unstagedChanges = await fileChangeParser({
+          changes: unstaged || [],
+          commit: '--unstaged',
           options: { tokenizer, git, llm, logger },
         })
 
-        logger.log(`Parsed Result: ${result}`)
+        const unstagedResponse = `Unstaged changes:\n${unstagedChanges}`
 
-        return [result]
+        const untrackedChanges = await fileChangeParser({
+          changes: untracked || [],
+          commit: '--untracked',
+          options: { tokenizer, git, llm, logger },
+        })
+        const untrackedResponse = `Untracked changes:\n${untrackedChanges}`
+
+        const stagedChanges = await fileChangeParser({
+          changes: staged,
+          commit: '--staged',
+          options: { tokenizer, git, llm, logger },
+        })
+        const stagedResponse = `Staged changes:\n${stagedChanges}`
+
+        return [unstagedResponse, untrackedResponse, stagedResponse]
       case 'yesterday':
         const yesterday = new Date()
         yesterday.setDate(yesterday.getDate() - 1)
@@ -90,7 +105,7 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
   }
 
   async function parser(changes: string[]) {
-    console.log({ changes })
+    const [unstaged, untracked, staged] = changes
 
     return changes.join('\n')
   }

--- a/src/lib/parsers/default/index.ts
+++ b/src/lib/parsers/default/index.ts
@@ -1,10 +1,10 @@
 import { FileChangeParserInput } from '../../types'
 import { summarizeDiffs } from './utils/summarizeDiffs'
 
-import { createDiffTree } from './utils/createDiffTree'
-import { collectDiffs } from './utils/collectDiffs'
 import { getSummarizationChain } from '../../langchain/utils/getSummarizationChain'
 import { getTextSplitter } from '../../langchain/utils/getTextSplitter'
+import { collectDiffs } from './utils/collectDiffs'
+import { createDiffTree } from './utils/createDiffTree'
 // import { TokenTextSplitter } from "@langchain/textsplitters";
 
 import { SUMMARIZE_PROMPT } from '../../langchain/chains/summarize/prompt'
@@ -20,11 +20,6 @@ export async function fileChangeParser({
   options: { tokenizer, git, llm: model, logger },
 }: FileChangeParserInput): Promise<string> {
   const textSplitter = getTextSplitter({ chunkSize: 10000, chunkOverlap: 250 })
-
-  // const textSplitter = new TokenTextSplitter({
-  //   chunkSize: 10000,
-  //   chunkOverlap: 250,
-  // });
 
   const summarizationChain = getSummarizationChain(model, {
     type: 'map_reduce',

--- a/src/lib/simple-git/getDiff.ts
+++ b/src/lib/simple-git/getDiff.ts
@@ -1,7 +1,7 @@
-import { SimpleGit } from 'simple-git'
-import { createTwoFilesPatch } from 'diff'
-import { FileChange } from '../types'
-import { Logger } from '../utils/logger'
+import { createTwoFilesPatch } from 'diff';
+import { SimpleGit } from 'simple-git';
+import { FileChange } from '../types';
+import { Logger } from '../utils/logger';
 
 /**
  * Parses the default file diff for a given nodeFile.
@@ -16,8 +16,13 @@ async function parseDefaultFileDiff(
   commit = '--staged',
   git: SimpleGit
 ): Promise<string> {
-  if (commit !== '--staged') {
-    return await git.diff([`${commit}~1..${commit}`, '--', nodeFile.filePath])
+  if (commit === '--staged') {
+    return await git.diff(['--staged', nodeFile.filePath]);
+  } else if (commit === '--unstaged') {
+    return await git.diff([nodeFile.filePath]);
+  } else if (commit === '--untracked') {
+    // For untracked files, return the entire file content
+    return await git.show([`:${nodeFile.filePath}`]);
   }
 
   return await git.diff([commit, nodeFile.filePath])
@@ -99,7 +104,7 @@ async function parseRenamedFileDiff(
  */
 export async function getDiff(
   nodeFile: FileChange,
-  commit: string,
+  commit: '--staged' | '--unstaged' | '--untracked' | string,
   {
     git,
     logger,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,5 @@
-import { getLlm } from './langchain/utils/getLlm'
 import { SimpleGit } from 'simple-git'
+import { getLlm } from './langchain/utils/getLlm'
 import { Logger } from './utils/logger'
 import { TokenCounter } from './utils/tokenizer'
 
@@ -50,7 +50,7 @@ export interface BaseParserInput {
 
 export interface FileChangeParserInput extends BaseParserInput {
   changes: FileChange[]
-  commit: '--staged' | string
+  commit: '--staged' | '--unstaged' | '--untracked' | string
 }
 
 export interface CommitLogParserInput extends BaseParserInput {


### PR DESCRIPTION
- Improve file change parsing in `recap` command
  - Refactor `handler` to separately parse staged, unstaged, and untracked changes, enhancing clarity in command output.
  - Update `getDiff` to handle unstaged and untracked files, ensuring comprehensive diff retrieval.
  - Reorder imports and refine `fileChangeParser` for better code organization and functionality. (a93254e)