### PR TITLE
Remove unused variables in `parser`

### DIFF
--- a/src/commands/recap/handler.ts
+++ b/src/commands/recap/handler.ts
@@ -105,8 +105,6 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
   }
 
   async function parser(changes: string[]) {
-    const [unstaged, untracked, staged] = changes
-
     return changes.join('\n')
   }
 


### PR DESCRIPTION
Simplify the `parser` function by removing unused variables `unstaged`, `untracked`, and `staged`. These variables were defined but not utilized, so getting rid of them streamlines the code and avoids potential confusion. The function now directly returns the joined `changes` array as a string.