### PR TITLE
Add `--append-ticket` flag to `commit` command

### DIFF
--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -7,7 +7,9 @@ import { getLlm } from '../../lib/langchain/utils/getLlm'
 import { getPrompt } from '../../lib/langchain/utils/getPrompt'
 import { fileChangeParser } from '../../lib/parsers/default'
 import { createCommit } from '../../lib/simple-git/createCommit'
+import { extractTicketIdFromBranchName } from '../../lib/simple-git/extractTicketIdFromBranchName'
 import { getChanges } from '../../lib/simple-git/getChanges'
+import { getCurrentBranchName } from '../../lib/simple-git/getCurrentBranchName'
 import { getRepo } from '../../lib/simple-git/getRepo'
 import { CommandHandler, FileChange } from '../../lib/types'
 import { generateAndReviewLoop } from '../../lib/ui/generateAndReviewLoop'
@@ -105,7 +107,12 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
       })
 
       const appendedText = argv.append ? `\n\n${argv.append}` : ''
-      return `${commitMsg.title}\n\n${commitMsg.body}${appendedText}`
+      
+      const branchName = await getCurrentBranchName({ git })
+      const ticketId = extractTicketIdFromBranchName(branchName)
+      const ticketFooter = argv.appendTicket && ticketId ? `\n\nPart of **${ticketId}**` : ''
+      
+      return `${commitMsg.title}\n\n${commitMsg.body}${appendedText}${ticketFooter}`
     },
     noResult: async () => {
       await noResult({ git, logger })

--- a/src/commands/commit/options.ts
+++ b/src/commands/commit/options.ts
@@ -33,6 +33,10 @@ export const options = {
     description: 'Add content to the end of the generated commit message',
     type: 'string',
   },
+  appendTicket: {
+    description: 'Append ticket ID from branch name to the commit message',
+    type: 'boolean',
+  },
   additional: {
     description: 'Add extra contextual information to the prompt',
     type: 'string',


### PR DESCRIPTION
Automatically add a note to the footer of the commit message with the Ticket ID referenced inside of the git branch.

**e.g.** 

with a branch name of `PROJ-421-fixes-that-bug` the commit message would include the following footer text

```bash
$ coco --append-ticket
```
...
```
<generated commit>

Part of PROJ-421
```

### Changelog

- Update `handler` to include ticket ID in commit messages if `appendTicket` is true. 
- Use `getCurrentBranchName` and `extractTicketIdFromBranchName` to fetch and append the ticket ID from the branch name. 
- Add `appendTicket` option to control this behavior, providing more context in commit messages.