### PR TITLE
Refactor `yargs` imports and builder functions

### DIFF
--- a/src/commands/changelog/options.ts
+++ b/src/commands/changelog/options.ts
@@ -1,4 +1,4 @@
-import yargs, { Arguments, Options } from 'yargs'
+import { Arguments, Argv, Options } from 'yargs'
 import changelog from '.'
 import { getCommandUsageHeader } from '../../lib/ui/helpers'
 import { BaseCommandOptions } from '../types'
@@ -31,6 +31,6 @@ export const options = {
   },
 } as Record<string, Options>
 
-export const builder = (yargsInstance: ReturnType<typeof yargs>) => {
-  return yargsInstance.options(options).usage(getCommandUsageHeader(changelog.command))
+export const builder = (yargs: Argv) => {
+  return yargs.options(options).usage(getCommandUsageHeader(changelog.command))
 }

--- a/src/commands/commit/options.ts
+++ b/src/commands/commit/options.ts
@@ -1,4 +1,4 @@
-import yargs, { Arguments, Options } from 'yargs'
+import { Arguments, Argv, Options } from 'yargs'
 import commit from '.'
 import { getCommandUsageHeader } from '../../lib/ui/helpers'
 import { BaseCommandOptions } from '../types'
@@ -43,6 +43,6 @@ export const options = {
   },
 } as Record<string, Options>
 
-export const builder = (yargsInstance: ReturnType<typeof yargs>) => {
-  return yargsInstance.options(options).usage(getCommandUsageHeader(commit.command))
+export const builder = (yargs: Argv) => {
+  return yargs.options(options).usage(getCommandUsageHeader(commit.command))
 }

--- a/src/commands/recap/options.ts
+++ b/src/commands/recap/options.ts
@@ -1,13 +1,13 @@
-import yargs, { Arguments, Options } from 'yargs'
+import { Arguments, Argv, Options } from 'yargs'
 import recap from '.'
 import { getCommandUsageHeader } from '../../lib/ui/helpers'
 import { BaseCommandOptions } from '../types'
 
 export interface RecapOptions extends BaseCommandOptions {
   yesterday?: boolean
-  "last-week"?: boolean
-  "last-month"?: boolean
-  "last-tag"?: boolean
+  'last-week'?: boolean
+  'last-month'?: boolean
+  'last-tag'?: boolean
 }
 
 export type RecapArgv = Arguments<RecapOptions>
@@ -20,17 +20,17 @@ export const options = {
     type: 'boolean',
     description: 'Recap for yesterday',
   },
-  "last-week": {
+  'last-week': {
     alias: 'week',
     type: 'boolean',
     description: 'Recap for last week',
   },
-  "last-month": {
+  'last-month': {
     alias: 'month',
     type: 'boolean',
     description: 'Recap for last month',
   },
-  "last-tag": {
+  'last-tag': {
     alias: 'tag',
     type: 'boolean',
     description: 'Recap for last tag',
@@ -42,6 +42,6 @@ export const options = {
   },
 } as Record<string, Options>
 
-export const builder = (yargsInstance: ReturnType<typeof yargs>) => {
-  return yargsInstance.options(options).usage(getCommandUsageHeader(recap.command))
+export const builder = (yargs: Argv) => {
+  return yargs.options(options).usage(getCommandUsageHeader(recap.command))
 }


### PR DESCRIPTION
Update `yargs` imports to use named imports for `Arguments`, `Argv`, and `Options` in `recap`, `changelog`, and `commit` commands. Simplify `builder` functions by using `Argv` type directly, improving readability and consistency across command modules. Adjust quotes for option keys to single quotes for uniformity.
