### PR TITLE
Improve error handling in `parseDefaultFileDiff`

### DIFF
--- a/src/lib/simple-git/getDiff.ts
+++ b/src/lib/simple-git/getDiff.ts
@@ -27,7 +27,7 @@ async function parseDefaultFileDiff(
       const fileContent = await fs.readFile(nodeFile.filePath, 'utf-8')
       return fileContent
     } catch (error) {
-      throw new Error(`Error reading untracked file: ${error?.message || 'Unknown error'}`)
+      throw new Error(`Error reading untracked file: ${(error as Error)?.message || 'Unknown error'}`)
     }
   }
 


### PR DESCRIPTION
Refactor error handling in `parseDefaultFileDiff` to use TypeScript type assertion for `error` object. This ensures more precise error message extraction by casting `error` as `Error`, enhancing code robustness and readability. This change addresses potential type issues when accessing `error.message`.