### PR TITLE
Update Command Options for `recap` and a little bit of tidying

### DIFF
--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -93,6 +93,15 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
     commits: string[]
   }, string>({
     label: 'changelog',
+    options: {
+      ...config,
+      prompt: config.prompt || (CHANGELOG_PROMPT.template as string),
+      logger,
+      interactive: INTERACTIVE,
+      review: {
+        enableFullRetry: false,
+      },
+    },
     factory,
     parser,
     agent: async (context, options) => {
@@ -132,15 +141,6 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
       logger.log(`No commits found in the current branch.`, { color: 'red' })
       process.exit(0)
     },
-    options: {
-      ...config,
-      prompt: config.prompt || (CHANGELOG_PROMPT.template as string),
-      logger,
-      interactive: INTERACTIVE,
-      review: {
-        enableFullRetry: false,
-      },
-    },
   })
 
   const MODE =
@@ -148,7 +148,7 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
 
   handleResult({
     result: changelogMsg,
-    interactiveHandler: async () => {
+    interactiveModeCallback: async () => {
       logSuccess()
     },
     mode: MODE as 'interactive' | 'stdout',

--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -16,13 +16,8 @@ import { generateAndReviewLoop } from '../../lib/ui/generateAndReviewLoop'
 import { handleResult } from '../../lib/ui/handleResult'
 import { LOGO, isInteractive } from '../../lib/ui/helpers'
 import { logSuccess } from '../../lib/ui/logSuccess'
-import { ChangelogArgv, ChangelogOptions } from './options'
+import { ChangelogArgv, ChangelogOptions, ChangelogResponse } from './options'
 import { CHANGELOG_PROMPT } from './prompt'
-
-interface ChangelogResponse {
-  header: string
-  content: string
-}
 
 export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
   const config = loadConfig<ChangelogOptions, ChangelogArgv>(argv)

--- a/src/commands/changelog/options.ts
+++ b/src/commands/changelog/options.ts
@@ -2,13 +2,17 @@ import { Arguments, Argv, Options } from 'yargs'
 import changelog from '.'
 import { getCommandUsageHeader } from '../../lib/ui/helpers'
 import { BaseCommandOptions } from '../types'
-
 export interface ChangelogOptions extends BaseCommandOptions {
   range: string
   branch: string
 }
 
 export type ChangelogArgv = Arguments<ChangelogOptions>
+
+export interface ChangelogResponse {
+  header: string
+  content: string
+}
 
 /**
  * Command line options via yargs
@@ -34,3 +38,4 @@ export const options = {
 export const builder = (yargs: Argv) => {
   return yargs.options(options).usage(getCommandUsageHeader(changelog.command))
 }
+

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -125,7 +125,7 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
 
   handleResult({
     result: commitMsg,
-    interactiveHandler: async (result) => {
+    interactiveModeCallback: async (result) => {
       await createCommit(result, git)
       logSuccess()
     },

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -18,13 +18,8 @@ import { LOGO, isInteractive } from '../../lib/ui/helpers'
 import { logSuccess } from '../../lib/ui/logSuccess'
 import { getTokenCounter } from '../../lib/utils/tokenizer'
 import { noResult } from './noResult'
-import { CommitArgv, CommitOptions } from './options'
+import { CommitArgv, CommitMessageResponse, CommitOptions } from './options'
 import { COMMIT_PROMPT } from './prompt'
-
-interface CommitMessageResponse {
-  title: string
-  body: string
-}
 
 export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
   const git = getRepo()

--- a/src/commands/commit/options.ts
+++ b/src/commands/commit/options.ts
@@ -12,6 +12,11 @@ export interface CommitOptions extends BaseCommandOptions {
 
 export type CommitArgv = Arguments<CommitOptions>
 
+export interface CommitMessageResponse {
+  title: string
+  body: string
+}
+
 /**
  * Command line options via yargs
  */

--- a/src/commands/recap/handler.ts
+++ b/src/commands/recap/handler.ts
@@ -46,7 +46,15 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
 
   const { 'last-month': lastMonth, 'last-tag': lastTag, yesterday, 'last-week': lastWeek } = argv
 
-  const timeframe = lastMonth ? 'last-month' : lastTag ? 'last-tag' : yesterday ? 'yesterday' : lastWeek ? 'last-week' : 'current'
+  const timeframe = lastMonth
+    ? 'last-month'
+    : lastTag
+    ? 'last-tag'
+    : yesterday
+    ? 'yesterday'
+    : lastWeek
+    ? 'last-week'
+    : 'current'
 
   logger.log(`Generating recap for timeframe: ${timeframe}`)
 
@@ -108,7 +116,7 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
     return changes.join('\n')
   }
 
-  const recap = await generateAndReviewLoop({
+  await generateAndReviewLoop({
     label: 'recap',
     options: {
       ...config,
@@ -116,13 +124,17 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
       logger,
       interactive: INTERACTIVE,
       review: {
+        enableModifyPrompt: false,
+        enableEdit: false,
+        enableFullRetry: false,
+        selectLabel: 'Any of this ringing a bell?',
+        labels: {
+          approve: '👍 Looks good',
+          retryMessageOnly: '🔄 Reword Recap',
+          cancel: '🚫 Exit',
+        },
         descriptions: {
-          approve: `Commit staged changes with generated commit message`,
-          edit: 'Edit the commit message before proceeding',
-          modifyPrompt: 'Modify the prompt template and regenerate the commit message',
-          retryMessageOnly: 'Restart the function execution from generating the commit message',
-          retryFull:
-            'Restart the function execution from the beginning, regenerating both the diff summary and commit message',
+          approve: `The generated recap for the timeframe: ${timeframe}`,
         },
       },
     },
@@ -150,15 +162,11 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
         },
         parser,
       })
-      logger.log(response.summary || 'no response')
-
-      return `${response.summary}`
+      return `${response.summary || 'no response'}`
     },
     noResult: async () => {
       await noResult({ git, logger })
       process.exit(0)
     },
   })
-
-  logger.log(`Recap generated: ${recap}`, { color: 'green' })
 }

--- a/src/commands/recap/handler.ts
+++ b/src/commands/recap/handler.ts
@@ -15,12 +15,8 @@ import { generateAndReviewLoop } from '../../lib/ui/generateAndReviewLoop'
 import { isInteractive, LOGO } from '../../lib/ui/helpers'
 import { getTokenCounter } from '../../lib/utils/tokenizer'
 import { noResult } from './noResult'
-import { RecapArgv, RecapOptions } from './options'
+import { RecapArgv, RecapLlmResponse, RecapOptions } from './options'
 import { RECAP_PROMPT } from './prompt'
-
-interface RecapLlmResponse {
-  summary: string
-}
 
 export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
   const git = getRepo()

--- a/src/commands/recap/options.ts
+++ b/src/commands/recap/options.ts
@@ -12,6 +12,10 @@ export interface RecapOptions extends BaseCommandOptions {
 
 export type RecapArgv = Arguments<RecapOptions>
 
+export interface RecapLlmResponse {
+  summary: string
+}
+
 /**
  * Command line options via yargs
  */

--- a/src/lib/ui/getUserReviewDecision.ts
+++ b/src/lib/ui/getUserReviewDecision.ts
@@ -56,7 +56,7 @@ export async function getUserReviewDecision({
 
   if (enableRetry) {
     choices.push({
-      name: '🔄 Retry',
+      name: labels?.retryMessageOnly || '🔄 Retry',
       value: 'retryMessageOnly',
       description:
         descriptions?.retryMessageOnly ||
@@ -66,7 +66,7 @@ export async function getUserReviewDecision({
 
   if (enableFullRetry) {
     choices.push({
-      name: '🔄 Retry Full',
+      name: labels?.retryFull || '🔄 Retry Full',
       value: 'retryFull',
       description:
         descriptions?.retryFull ||
@@ -75,7 +75,7 @@ export async function getUserReviewDecision({
   }
 
   choices.push({
-    name: '💣 Cancel',
+    name: labels?.cancel || '💣 Cancel',
     value: 'cancel',
     description: descriptions?.cancel || `Cancel the ${label}`,
   })

--- a/src/lib/ui/handleResult.ts
+++ b/src/lib/ui/handleResult.ts
@@ -4,15 +4,15 @@ type ResultHandler = (result: string) => Promise<void>
 
 type HandleResultInput = {
   result: string
-  interactiveHandler?: ResultHandler
+  interactiveModeCallback?: ResultHandler
   mode: 'interactive' | 'stdout'
 }
 
-export async function handleResult({ result, mode, interactiveHandler }: HandleResultInput) {
+export async function handleResult({ result, mode, interactiveModeCallback }: HandleResultInput) {
   switch (mode) {
     case 'interactive':
-      if (interactiveHandler) {
-        await interactiveHandler(result)
+      if (interactiveModeCallback) {
+        await interactiveModeCallback(result)
       } else {
         console.warn('No result handler provided for interactive mode.')
         logSuccess()


### PR DESCRIPTION
### Refactor Response Interfaces
- Move response interfaces `ChangelogResponse`, `RecapLlmResponse`, and `CommitMessageResponse` from handlers to options for better organization and reusability. This change simplifies the handler files and ensures that response structures are defined alongside their related options, improving code maintainability. (ab6c742)

### Refactor Interactive Handler Callbacks
- Rename `interactiveHandler` to `interactiveModeCallback` across relevant functions to improve clarity and consistency. This change affects the `handleResult` function and its usage in various handlers. The update enhances readability and aligns with naming conventions, ensuring better understanding of callback purposes. (7ddf669)

### Refine Recap Command and UI Labels
- Improve readability in `handler` by formatting `timeframe` assignment. Update `generateAndReviewLoop` to remove unnecessary `recap` variable. Enhance user decision prompts in `getUserReviewDecision` by utilizing customizable `labels`. (e4d6440)