### PR TITLE
Add support to review target branches with `coco review` command

### DIFF
--- a/src/commands/init/handler.ts
+++ b/src/commands/init/handler.ts
@@ -35,8 +35,7 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
       service: service,
     }
 
-    let apiKey = ''
-
+    let apiKey = '' as string
     if (llmProvider === 'openai') {
       apiKey = await questions.inputApiKey('OpenAI', 'OPENAI_API_KEY')
 
@@ -44,7 +43,7 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
         config.service.authentication.credentials.apiKey = '•••••••••••••••'
       }
     }
-
+    
     if (llmProvider === 'anthropic') {
       apiKey = await questions.inputApiKey('Anthropic', 'ANTHROPIC_API_KEY')
 

--- a/src/commands/review/options.ts
+++ b/src/commands/review/options.ts
@@ -3,7 +3,10 @@ import recap from '.'
 import { getCommandUsageHeader } from '../../lib/ui/helpers'
 import { BaseCommandOptions } from '../types'
 
-export interface ReviewOptions extends BaseCommandOptions {}
+export interface ReviewOptions extends BaseCommandOptions {
+  interactive: boolean
+  branch: string
+}
 
 export type ReviewArgv = Arguments<ReviewOptions>
 
@@ -23,7 +26,12 @@ export const options = {
     type: 'boolean',
     alias: 'interactive',
     description: 'Toggle interactive mode',
-  },  
+  },
+  'b': {
+    type: 'string',
+    alias: 'branch',
+    description: 'Branch to review',
+  },
 } as Record<string, Options>  
 
 export const builder = (yargs: Argv) => {

--- a/src/lib/config/constants.ts
+++ b/src/lib/config/constants.ts
@@ -2,7 +2,7 @@ import { SUMMARIZE_PROMPT } from '../langchain/chains/summarize/prompt'
 import { getDefaultServiceConfigFromAlias } from '../langchain/utils'
 import { Config } from './types'
 
-export const DEFAULT_IGNORED_FILES = ['package-lock.json']
+export const DEFAULT_IGNORED_FILES = ['package-lock.json', 'yarn.lock', 'node_modules']
 export const DEFAULT_IGNORED_EXTENSIONS = ['.map', '.lock']
 
 export const COCO_CONFIG_START_COMMENT = '# -- start coco config --'

--- a/src/lib/langchain/types.ts
+++ b/src/lib/langchain/types.ts
@@ -140,4 +140,4 @@ export type AnthropicLLMService = BaseLLMService & {
   fields?: AnthropicFields
 }
 
-export type LLMService = OpenAILLMService | OllamaLLMService
+export type LLMService = OpenAILLMService | OllamaLLMService | AnthropicLLMService

--- a/src/lib/simple-git/getDiffForBranch.ts
+++ b/src/lib/simple-git/getDiffForBranch.ts
@@ -1,0 +1,62 @@
+import { SimpleGit } from 'simple-git'
+import { Logger } from '../utils/logger'
+import { getCurrentBranchName } from './getCurrentBranchName'
+
+export type GetDiffForBranch = {
+  git: SimpleGit
+  logger?: Logger
+  targetBranch: string
+  ignoredFiles?: string[]
+  ignoredExtensions?: string[]
+  ignoredPaths?: string[]
+}
+
+/**
+ * Retrieves the diff between the current branch and a specified target branch.
+ *
+ * @param {Object} options - The options for retrieving the diff.
+ * @param {SimpleGit} options.git - The SimpleGit instance.
+ * @param {Logger} options.logger - The logger for logging messages.
+ * @param {string} options.targetBranch - The target branch to compare against.
+ * @param {string[]} options.ignoredFiles - Array of specific files to ignore.
+ * @param {string[]} options.ignoredExtensions - Array of file extensions to ignore.
+ * @returns {Promise<string>} The diff between the current branch and the target branch.
+ */
+export async function getDiffForBranch({
+  git,
+  logger,
+  targetBranch,
+  ignoredFiles = [],
+  ignoredExtensions = [],
+}: GetDiffForBranch): Promise<string> {
+  try {
+    // Get the current branch name
+    const currentBranch = await getCurrentBranchName({ git })
+
+    // Prepare ignore patterns
+    const ignorePatterns = [
+      ...ignoredFiles.map((file) => `:!${file}`),
+      ...ignoredExtensions.map((ext) => `:!*${ext}`),
+    ]
+
+    // Construct the diff command
+    const diffArgs = [`${targetBranch}..${currentBranch}`]
+    if (ignorePatterns.length > 0) {
+      diffArgs.push('--')
+      diffArgs.push(...ignorePatterns)
+    }
+
+    // Get the diff
+    const diff = await git.diff(diffArgs)
+
+    logger?.verbose(`Generated diff between "${currentBranch}" and "${targetBranch}"`, {
+      color: 'blue',
+    })
+
+    return diff
+  } catch (error) {
+    console.error('Error in getDiffForBranch:', error)
+    logger?.log('Encountered an error getting diff between branches', { color: 'red' })
+    return ''
+  }
+}


### PR DESCRIPTION
`coco review --branch target-branch-name`

---

- Add branch-diff functionality (3ab1275)
  - Introduce `getDiffForBranch` to generate diffs between branches.
  - Update `review` command `handler` to support branch diffing with `argv.branch`.
  - Extend `ReviewOptions` with `interactive` and `branch` options.

- Refactor `apiKey` type and update ignored files (ecd2629)
  - Explicitly type `apiKey` as `string` in `handler`.
  - Update `DEFAULT_IGNORED_FILES` to include `yarn.lock` and `node_modules`.

- Add `AnthropicLLMService` to `LLMService` type (6e1c1e1)
  - Expand `LLMService` type to include `AnthropicLLMService`.