### PR TITLE
Update `review` cmd description and adjust version logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ npm-debug.log*
 .DS_Store
 
 coverage/
+
+/src/lib/buildInfo.ts

--- a/bin/generateBuildInfo.ts
+++ b/bin/generateBuildInfo.ts
@@ -1,0 +1,51 @@
+import chalk from 'chalk';
+import * as fs from 'fs';
+import * as path from 'path';
+
+function ensureDirectoryExists(filePath: string): void {
+  const dir = path.dirname(filePath)
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true })
+    console.log(chalk.gray(`Created directory: ${dir}`))
+  }
+}
+
+async function generateBuildInfo(): Promise<void> {
+  console.log(chalk.blue.bold('⚡ Generating build info...'))
+  
+  try {
+    const tsPath = path.join('src/lib/buildInfo.ts')
+    ensureDirectoryExists(tsPath)
+    
+    const tsContent = `// This file is auto-generated - DO NOT EDIT
+/* eslint-disable */
+
+/**
+ * Current build version from package.json
+ */
+export const BUILD_VERSION = ${JSON.stringify(process.env.npm_package_version)}
+`
+
+    fs.writeFileSync(tsPath, tsContent)
+    console.log(chalk.green('✓'), `Generated ${chalk.cyan('buildInfo.ts')}`)
+
+    console.log(chalk.green.bold('\n✨ Build info generation completed successfully!'))
+  } catch (error) {
+    console.error(chalk.red.bold('\n❌ Build info generation failed:'))
+    if (error instanceof Error) {
+      console.error(chalk.red(`  ${error.message}`))
+      if (error.stack) {
+        console.error(chalk.gray(error.stack.split('\n').slice(1).join('\n')))
+      }
+    } else {
+      console.error(chalk.red(String(error)))
+    }
+    process.exit(1)
+  }
+}
+
+// Execute the generator
+generateBuildInfo().catch((error) => {
+  console.error(chalk.red.bold('Unexpected error:'), error)
+  process.exit(1)
+})

--- a/bin/generateSchema.ts
+++ b/bin/generateSchema.ts
@@ -64,11 +64,6 @@ async function generateSchema(config: SchemaConfig): Promise<void> {
 export const SCHEMA_PUBLIC_URL = ${JSON.stringify(schema.$id)}
 
 /**
- * Current build version from package.json
- */
-export const BUILD_VERSION = ${JSON.stringify(process.env.npm_package_version)}
-
-/**
  * Generated JSON schema
  */
 export const schema = ${schemaString} as const`

--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
   "scripts": {
     "start": "npm run dev",
     "dev": "tsx watch src/index.ts",
-    "prebuild": "npm run build:schema",
+    "prebuild": "npm run build:schema && npm run build:info",
     "build": "rollup -c",
     "build:schema": "tsx bin/generateSchema.ts",
+    "build:info": "tsx bin/generateBuildInfo.ts",
     "build:watch": "rollup -c -w",
     "clean": "rimraf dist && rimraf coverage",
     "lint": "eslint src",

--- a/src/commands/review/config.ts
+++ b/src/commands/review/config.ts
@@ -20,22 +20,21 @@ export type ReviewFeedbackItem = {
 export const command = 'review'
 
 /**
- * Command line options via yargs 
+ * Command line options via yargs
  */
-export const options = { 
+export const options = {
   i: {
     type: 'boolean',
     alias: 'interactive',
     description: 'Toggle interactive mode',
   },
-  'b': {
+  b: {
     type: 'string',
     alias: 'branch',
     description: 'Branch to review',
   },
-} as Record<string, Options>  
+} as Record<string, Options>
 
-export const builder = (yargs: Argv) => {
+export const builder = (yargs: Argv) => { 
   return yargs.options(options).usage(getCommandUsageHeader(command))
-}  
-
+}

--- a/src/commands/review/index.ts
+++ b/src/commands/review/index.ts
@@ -4,7 +4,7 @@ import { handler } from './handler'
 
 export default {
   command,
-  desc: 'Review the staged changes',
+  desc: 'Perform a code review on your changes',
   builder,
   handler: commandExecutor(handler),
   options,

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -7,11 +7,6 @@
 export const SCHEMA_PUBLIC_URL = "http://git-co.co/schema.json"
 
 /**
- * Current build version from package.json
- */
-export const BUILD_VERSION = "0.14.2"
-
-/**
  * Generated JSON schema
  */
 export const schema = {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -9,7 +9,7 @@ export const SCHEMA_PUBLIC_URL = "http://git-co.co/schema.json"
 /**
  * Current build version from package.json
  */
-export const BUILD_VERSION = "0.14.1"
+export const BUILD_VERSION = "0.14.2"
 
 /**
  * Generated JSON schema

--- a/src/lib/ui/helpers.ts
+++ b/src/lib/ui/helpers.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
+import { BUILD_VERSION } from '../buildInfo'
 import { loadConfig } from '../config/utils/loadConfig'
-import { BUILD_VERSION } from '../schema'
 
 export const isInteractive = (config: ReturnType<typeof loadConfig>) => {
   return config?.mode === 'interactive' || !!config?.interactive
@@ -30,7 +30,7 @@ export const bannerWithHeader = (banner: string) => {
 
 export const USAGE_BANNER = chalk.green(
   `${LOGO}
-${chalk.bgGreen(`\xa0v${BUILD_VERSION}\xa0`)}
+${BUILD_VERSION ? chalk.bgGreen(`\xa0v${BUILD_VERSION}\xa0`) : ''}
 `
 )
 


### PR DESCRIPTION
### Features

- Add build info generation script (`28e8be1`)
  - Introduce `generateBuildInfo.ts` to automate build info creation.
  - Update `package.json` scripts to include `build:info` for generating build info before building.
  - Remove `BUILD_VERSION` from `generateSchema.ts` and `schema.ts`.
  - Adjust `.gitignore` to exclude generated `buildInfo.ts`.
  - Refactor imports in `helpers.ts`.

### Improvements
- Update descriptions and version (`76b4eeb`)
  - Revise `desc` in `review` command to clarify its purpose as performing a code review.
  - Increment `BUILD_VERSION` to `0.14.2` to reflect the latest changes.