### PR TITLE
Refactor `changelog` cmd response structure 

### DIFF
--- a/src/commands/changelog/config.ts
+++ b/src/commands/changelog/config.ts
@@ -9,7 +9,7 @@ export interface ChangelogOptions extends BaseCommandOptions {
 export type ChangelogArgv = Arguments<ChangelogOptions>
 
 export interface ChangelogResponse {
-  header: string
+  title: string
   content: string
 }
 

--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -109,7 +109,7 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
       })
 
       const formatInstructions =
-        "Respond with a valid JSON object, containing two fields: 'header' and 'content', both strings."
+        "Respond with a valid JSON object, containing two fields: 'title' a string, no more than 65 characters, and 'content' a string."
 
       const changelog = await executeChain<ChangelogResponse>({
         llm,
@@ -125,7 +125,7 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
       const ticketId = extractTicketIdFromBranchName(branchName)
       const footer = ticketId ? `\n\nPart of **${ticketId}**` : ''
 
-      return `${changelog.header}\n\n${changelog.content}${footer}`
+      return `${changelog.title}\n\n${changelog.content}${footer}`
     },
     noResult: async () => {
       if (config.range) {

--- a/src/commands/changelog/prompt.ts
+++ b/src/commands/changelog/prompt.ts
@@ -2,8 +2,11 @@ import { PromptTemplate } from '@langchain/core/prompts'
 
 const template = `Write informative git changelog, in the imperative, based on a series of individual messages.
 
-- Include the git commit hash as reference for each change, including just the first 7 characters
+- Annotate  each change with the git commit hash as reference, including just the first 7 characters
 - Logically group changes, and if necessary, summarize dependency updates
+- Include a descriptive title for the changelog, to give a high-level overview of the changes
+- Depending on the size of the changes, consider breaking the changelog into sections
+- Avoid generlizations like "various bug fixes" or "improvements" or "enhancements"
 
 {format_instructions}
 


### PR DESCRIPTION
### Changelog Structure Updates

- **Update changelog response structure**
  - Rename `header` to `title` in `ChangelogResponse` to better reflect its purpose and update related references in `handler.ts`. (4674737)

#### Prompt Enhancements

- **Enhance changelog format instructions**
  - Adjust format instructions to specify a `title` string with a max of 65 characters. (4674737)
  - Improve `prompt.ts` with guidelines for a more descriptive changelog, including titles and structured sections. (4674737)