### PR TITLE
Add Anthropic API key to ChatAnthropic config

### DIFF
--- a/src/lib/langchain/utils/getLlm.ts
+++ b/src/lib/langchain/utils/getLlm.ts
@@ -20,6 +20,7 @@ export function getLlm(provider: LLMProvider, model: LLMModel, config: Config) {
   switch (provider) {
     case 'anthropic':
       return new ChatAnthropic({
+        anthropicApiKey:  getApiKeyForModel(config),
         maxConcurrency: config.service.maxConcurrent,
         model,
       })


### PR DESCRIPTION
Include `anthropicApiKey` in the `ChatAnthropic` configuration object. This ensures proper authentication when initializing the Anthropic LLM provider. The API key is retrieved using the `getApiKeyForModel` function with the current config.