### PR TITLE
Update schema URLs to use HTTPS

### DIFF
--- a/bin/generateSchema.ts
+++ b/bin/generateSchema.ts
@@ -11,7 +11,7 @@ interface SchemaConfig extends TJS.Config {
 const CONFIG: SchemaConfig = {
   tsconfig: 'tsconfig.json',
   type: 'ConfigWithServiceObject',
-  schemaId: 'http://git-co.co/schema.json',
+  schemaId: 'https://git-co.co/schema.json',
   skipTypeCheck: false,
   outputDir: '.'
 }

--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "http://git-co.co/schema.json",
+  "$id": "https://git-co.co/schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$ref": "#/definitions/ConfigWithServiceObject",
   "definitions": {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -4,13 +4,13 @@
 /**
  * Schema ID for JSON validation
  */
-export const SCHEMA_PUBLIC_URL = "http://git-co.co/schema.json"
+export const SCHEMA_PUBLIC_URL = "https://git-co.co/schema.json"
 
 /**
  * Generated JSON schema
  */
 export const schema = {
-  "$id": "http://git-co.co/schema.json",
+  "$id": "https://git-co.co/schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$ref": "#/definitions/ConfigWithServiceObject",
   "definitions": {


### PR DESCRIPTION
Change schema URLs from HTTP to HTTPS for improved security. Update `SCHEMA_PUBLIC_URL` and `$id` in `schema.ts`, `schemaId` in `generateSchema.ts`, and `$id` in `schema.json`. This ensures consistent use of HTTPS across the project for schema-related URLs.