### PR TITLE
Add aliases for commit command options

### DIFF
--- a/src/commands/commit/config.ts
+++ b/src/commands/commit/config.ts
@@ -42,10 +42,12 @@ export const options = {
   appendTicket: {
     description: 'Append ticket ID from branch name to the commit message',
     type: 'boolean',
+    alias: 't',
   },
   additional: {
     description: 'Add extra contextual information to the prompt',
     type: 'string',
+    alias: 'a',
   },
 } as Record<string, Options>
 


### PR DESCRIPTION
Add short aliases for `appendTicket` and `additional` options in the commit command configuration. Use `-t` for `appendTicket` and `-a` for `additional`. This improves usability by providing quick shortcuts for these commonly used options.