### PR TITLE
Update default LLM model to gpt-4o

### DIFF
--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -33,7 +33,7 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
   }
 
   const tokenizer = await getTokenCounter(
-    provider === 'openai' ? (model as TiktokenModel) : 'gpt-4'
+    provider === 'openai' ? (model as TiktokenModel) : 'gpt-4o'
   )
 
   const llm = getLlm(provider, model, config)

--- a/src/commands/recap/handler.ts
+++ b/src/commands/recap/handler.ts
@@ -30,7 +30,7 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
   }
 
   const tokenizer = await getTokenCounter(
-    provider === 'openai' ? (model as TiktokenModel) : 'gpt-4'
+    provider === 'openai' ? (model as TiktokenModel) : 'gpt-4o'
   )
 
   const llm = getLlm(provider, model, config)

--- a/src/commands/review/handler.ts
+++ b/src/commands/review/handler.ts
@@ -31,7 +31,7 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
   }
 
   const tokenizer = await getTokenCounter(
-    provider === 'openai' ? (model as TiktokenModel) : 'gpt-4'
+    provider === 'openai' ? (model as TiktokenModel) : 'gpt-4o'
   )
 
   const llm = getLlm(provider, model, config)

--- a/src/lib/langchain/utils.ts
+++ b/src/lib/langchain/utils.ts
@@ -58,7 +58,7 @@ export function getDefaultServiceApiKey(config: Config) {
 
 export const DEFAULT_OPENAI_LLM_SERVICE: OpenAILLMService = {
   provider: 'openai',
-  model: 'gpt-4',
+  model: 'gpt-4o',
   tokenLimit: 2024,
   temperature: 0.32,
   authentication: {


### PR DESCRIPTION
Change default OpenAI model from `gpt-4` to `gpt-4o` across multiple command handlers and in the `DEFAULT_OPENAI_LLM_SERVICE` configuration. This update affects the `commit`, `review`, and `recap` commands, as well as the default language model settings in the langchain utils.
