### PR TITLE
Refine changelog formatting instructions

### DIFF
--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -109,7 +109,7 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
       })
 
       const formatInstructions =
-        "Respond with a valid JSON object, containing two fields: 'title' a string, no more than 65 characters, and 'content' a string."
+        "Only respond with a valid JSON object, containing two fields: 'title' an escaped string, no more than 65 characters, and 'content' also an escaped string."
 
       const changelog = await executeChain<ChangelogResponse>({
         llm,


### PR DESCRIPTION
Update `formatInstructions` in `handler.ts` to specify escaped strings for 'title' and 'content' fields in the JSON response. Clarify that the response should only contain the JSON object. This change ensures proper parsing of the LLM-generated changelog entries.

Relates to #291
