### PR TITLE
Add support for generating changelog since latest tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ coco changelog -r HEAD~5:HEAD
 
 # For a target branch
 coco changelog -b other-branch
+
+# For all commits since the last tag
+coco changelog -t
 ```
 
 ### **`coco recap`**

--- a/src/commands/changelog/config.ts
+++ b/src/commands/changelog/config.ts
@@ -4,6 +4,7 @@ import { BaseCommandOptions } from '../types'
 export interface ChangelogOptions extends BaseCommandOptions {
   range: string
   branch: string
+  sinceLastTag: boolean
 }
 
 export type ChangelogArgv = Arguments<ChangelogOptions>
@@ -28,6 +29,12 @@ export const options = {
     type: 'string',
     alias: 'b',
     description: 'Target branch to compare against',
+  },
+  sinceLastTag: {
+    type: 'boolean',
+    alias: 't',
+    description: 'Generate changelog for all commits since the last tag',
+    default: false,
   },
   i: {
     type: 'boolean',

--- a/src/commands/changelog/index.ts
+++ b/src/commands/changelog/index.ts
@@ -4,7 +4,7 @@ import { handler } from './handler'
 
 export default {
   command,
-  desc: 'Generate a changelog from current or target branch or provided commit range.',
+  desc: 'Generate a changelog from current or target branch, provided commit range, or since the last tag.',
   builder,
   handler: commandExecutor(handler),
   options,

--- a/src/lib/simple-git/getChangesSinceLastTag.test.ts
+++ b/src/lib/simple-git/getChangesSinceLastTag.test.ts
@@ -1,0 +1,56 @@
+import { getChangesSinceLastTag } from './getChangesSinceLastTag'
+import { SimpleGit } from 'simple-git'
+
+describe('getChangesSinceLastTag', () => {
+  it('should return formatted commit logs since the last tag', async () => {
+    // Mock data
+    const mockCommitLog = {
+      all: [
+        {
+          hash: 'abc123',
+          date: '2023-01-01',
+          message: 'feat: add new feature',
+          body: 'This is a detailed description',
+          author_name: 'Test User',
+          author_email: 'test@example.com'
+        }
+      ]
+    }
+
+    // Mock git instance
+    const mockGit = {
+      tags: jest.fn().mockResolvedValue({
+        all: ['v1.0.0', 'v1.1.0'],
+        latest: 'v1.1.0'
+      }),
+      log: jest.fn().mockResolvedValue(mockCommitLog)
+    } as unknown as SimpleGit
+
+    // Call the function
+    const result = await getChangesSinceLastTag({ git: mockGit })
+
+    // Assertions
+    expect(mockGit.tags).toHaveBeenCalled()
+    expect(mockGit.log).toHaveBeenCalledWith({ from: 'v1.1.0' })
+    expect(result).toEqual([
+      '[2023-01-01] feat: add new feature\nThis is a detailed description\n(abc123) - Test User<test@example.com>'
+    ])
+  })
+
+  it('should return a message when no tags are found', async () => {
+    // Mock git instance with no tags
+    const mockGit = {
+      tags: jest.fn().mockResolvedValue({
+        all: [],
+        latest: undefined
+      })
+    } as unknown as SimpleGit
+
+    // Call the function
+    const result = await getChangesSinceLastTag({ git: mockGit })
+
+    // Assertions
+    expect(mockGit.tags).toHaveBeenCalled()
+    expect(result).toEqual(['No tags found in the repository.'])
+  })
+})

--- a/src/lib/simple-git/getDiff.test.ts
+++ b/src/lib/simple-git/getDiff.test.ts
@@ -1,8 +1,8 @@
-import { SimpleGit } from 'simple-git'
-import { FileChange, FileChangeStatus } from '../types' // update this according to your directory structure
-import { createTwoFilesPatch } from 'diff'
-import { Logger } from '../utils/logger'
-import { getDiff } from './getDiff' // update this according to your directory structure
+import { createTwoFilesPatch } from 'diff';
+import { SimpleGit } from 'simple-git';
+import { FileChange, FileChangeStatus } from '../types'; // update this according to your directory structure
+import { Logger } from '../utils/logger';
+import { getDiff } from './getDiff'; // update this according to your directory structure
 
 jest.mock('simple-git')
 jest.mock('diff')
@@ -30,41 +30,42 @@ describe('getDiff', () => {
   })
 
   it('should return diff for renamed files when contents are different', async () => {
-    (git.show as jest.MockedFunction<typeof git.show>).mockResolvedValueOnce('old content');
-    (git.show as jest.MockedFunction<typeof git.show>).mockResolvedValueOnce('new content');
-    (createTwoFilesPatch as jest.MockedFunction<typeof createTwoFilesPatch>).mockReturnValue(`
+    ;(git.show as jest.MockedFunction<typeof git.show>).mockResolvedValueOnce('old content')
+    ;(git.show as jest.MockedFunction<typeof git.show>).mockResolvedValueOnce('new content')
+    // @ts-expect-error - jest types are not up to date
+    ;(createTwoFilesPatch as jest.MockedFunction<typeof createTwoFilesPatch>).mockReturnValue(`
 --- old.txt
 +++ new.txt
 @@ -1,3 +1,3 @@
 -old content
 +new content
-`);
-    nodeFile.status = 'renamed';
-    nodeFile.oldFilePath = 'old.txt';
-    const result = await getDiff(nodeFile, '--staged', { git, logger });
-    expect(result).toBe('-old content\n+new content\n'); // Expecting the '\n' character as createTwoFilesPatch returns with a '\n' in the end
-});
+`)
+    nodeFile.status = 'renamed'
+    nodeFile.oldFilePath = 'old.txt'
+    const result = await getDiff(nodeFile, '--staged', { git, logger })
+    expect(result).toBe('-old content\n+new content\n') // Expecting the '\n' character as createTwoFilesPatch returns with a '\n' in the end
+  })
 
-it('should return message for renamed files when contents are same', async () => {
-    (git.show as jest.MockedFunction<typeof git.show>).mockResolvedValueOnce('same content');
-    (git.show as jest.MockedFunction<typeof git.show>).mockResolvedValueOnce('same content');
-    nodeFile.status = 'renamed';
-    nodeFile.oldFilePath = 'old.txt';
-    const result = await getDiff(nodeFile, '--staged', { git, logger });
-    expect(result).toBe('File contents are unchanged.');
-});
+  it('should return message for renamed files when contents are same', async () => {
+    ;(git.show as jest.MockedFunction<typeof git.show>).mockResolvedValueOnce('same content')
+    ;(git.show as jest.MockedFunction<typeof git.show>).mockResolvedValueOnce('same content')
+    nodeFile.status = 'renamed'
+    nodeFile.oldFilePath = 'old.txt'
+    const result = await getDiff(nodeFile, '--staged', { git, logger })
+    expect(result).toBe('File contents are unchanged.')
+  })
 
   it('should return diff for other files', async () => {
-    (git.diff as jest.MockedFunction<typeof git.diff>).mockResolvedValueOnce('diff')
+    ;(git.diff as jest.MockedFunction<typeof git.diff>).mockResolvedValueOnce('diff')
     nodeFile.status = 'modified'
     const result = await getDiff(nodeFile, '--staged', { git, logger })
     expect(result).toBe('diff')
   })
 
   it('should handle errors while comparing file contents for renamed files', async () => {
-    nodeFile.status = 'renamed';
-    nodeFile.oldFilePath = 'old.txt';
-    (git.show as jest.MockedFunction<typeof git.show>).mockRejectedValueOnce(new Error('error'))
+    nodeFile.status = 'renamed'
+    nodeFile.oldFilePath = 'old.txt'
+    ;(git.show as jest.MockedFunction<typeof git.show>).mockRejectedValueOnce(new Error('error'))
     const result = await getDiff(nodeFile, '--staged', { git, logger })
     expect(result).toBe('Error comparing file contents.')
     expect(logger.verbose).toHaveBeenCalled()


### PR DESCRIPTION
# Add support for generating changelog since latest tag

## Features

- Add option to generate changelog since last tag (30d40b1)
  - Introduce `sinceLastTag` option in `ChangelogOptions` interface and CLI options
  - Update handler to support this new option
  - Modify README and command description
  - Enhance logging for clearer feedback on default behavior

## Testing

- Add tests for getChangesSinceLastTag function (9b739dc)
  - Implement unit tests for `getChangesSinceLastTag` function
  - Add tests for scenarios with existing tags and no tags
  - Update `getDiff.test.ts` for improved type safety and formatting
  - Enhance error handling in renamed file comparisons
  
Resolves #275 