### PR TITLE
Enhance commit context and refactor git utilities

### DIFF
--- a/src/commands/commit/config.ts
+++ b/src/commands/commit/config.ts
@@ -7,6 +7,7 @@ export interface CommitOptions extends BaseCommandOptions {
   openInEditor: boolean
   ignoredFiles: string[]
   ignoredExtensions: string[]
+  withPreviousCommits: number
 }
 
 export type CommitArgv = Arguments<CommitOptions>
@@ -48,6 +49,12 @@ export const options = {
     description: 'Add extra contextual information to the prompt',
     type: 'string',
     alias: 'a',
+  },
+  withPreviousCommits: {
+    description: 'Include previous commits as context (specify number of commits, 0 for none)',
+    type: 'number',
+    default: 0,
+    alias: 'p',
   },
 } as Record<string, Options>
 

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -98,21 +98,21 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
         "Respond with a valid JSON object, containing two fields: 'title' and 'body', both strings."
 
       // Get additional context if provided
-      let additional_context = argv.additional || ''
-      if (additional_context) {
-        additional_context = `## Additional Context\n${additional_context}`
+      let additional_context = ''
+      if (argv.additional) {
+        additional_context = `## Additional Context\n${argv.additional}`
       }
       
-      // Get previous commits if requested
-      let previous_commits = ''
+      // Get commit history if requested
+      let commit_history = ''
       if (argv.withPreviousCommits > 0) {
-        const previousCommitsData = await getPreviousCommits({
+        const commitHistoryData = await getPreviousCommits({
           git,
           count: argv.withPreviousCommits
         })
         
-        if (previousCommitsData) {
-          previous_commits = `## Previous Commits\n${previousCommitsData}`
+        if (commitHistoryData) {
+          commit_history = `## Commit History\n${commitHistoryData}`
         }
       }
 
@@ -123,7 +123,7 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
           summary: context,
           format_instructions: formatInstructions,
           additional_context: additional_context,
-          previous_commits: previous_commits,
+          commit_history: commit_history,
         },
         parser,
       })

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -97,18 +97,22 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
       const formatInstructions =
         "Respond with a valid JSON object, containing two fields: 'title' and 'body', both strings."
 
-      const additionalContext = argv.additional ? `${argv.additional}` : ''
+      // Get additional context if provided
+      let additional_context = argv.additional || ''
+      if (additional_context) {
+        additional_context = `## Additional Context\n${additional_context}`
+      }
       
       // Get previous commits if requested
-      let previousCommitsContext = ''
+      let previous_commits = ''
       if (argv.withPreviousCommits > 0) {
-        previousCommitsContext = await getPreviousCommits({
+        const previousCommitsData = await getPreviousCommits({
           git,
           count: argv.withPreviousCommits
         })
         
-        if (previousCommitsContext) {
-          previousCommitsContext = `\n\nPrevious commits:\n${previousCommitsContext}`
+        if (previousCommitsData) {
+          previous_commits = `## Previous Commits\n${previousCommitsData}`
         }
       }
 
@@ -118,7 +122,8 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
         variables: {
           summary: context,
           format_instructions: formatInstructions,
-          additional: `${additionalContext}${previousCommitsContext}`,
+          additional_context: additional_context,
+          previous_commits: previous_commits,
         },
         parser,
       })

--- a/src/commands/commit/prompt.ts
+++ b/src/commands/commit/prompt.ts
@@ -17,10 +17,12 @@ Please follow the guidelines below when writing your commit message:
 {summary}
 """"""
 
-{additional}
+{additional_context}
+
+{previous_commits}
 `
 
-const inputVariables = ['summary', 'format_instructions', 'additional']
+const inputVariables = ['summary', 'format_instructions', 'additional_context', 'previous_commits']
 
 export const COMMIT_PROMPT = new PromptTemplate({
   template,

--- a/src/commands/commit/prompt.ts
+++ b/src/commands/commit/prompt.ts
@@ -1,7 +1,16 @@
 import { PromptTemplate } from '@langchain/core/prompts'
 
-export const template = `Write informative git commit message, in the imperative, based on the diffs & file changes provided in the "Diff Summary" section.  
-Commit Messages must have a short description that is less than 50 characters and a longer detailed summary around 300 characters, the shorter and more concise the better. 
+/**
+ * Template for generating git commit messages based on code changes
+ * 
+ * Variables:
+ * - summary: Contains the diff summary of staged changes
+ * - format_instructions: Instructions for the output format (JSON with title and body)
+ * - additional_context: Optional user-provided context to guide the commit message generation
+ * - commit_history: Optional history of previous commits for context
+ */
+export const template = `Write informative git commit message, in the imperative, based on the diffs & file changes provided in the "Diff Summary" section.
+Commit Messages must have a short description that is less than 50 characters and a longer detailed summary around 300 characters, the shorter and more concise the better.
 
 Please follow the guidelines below when writing your commit message:
 
@@ -13,7 +22,7 @@ Please follow the guidelines below when writing your commit message:
 
 {format_instructions}
 
-{previous_commits}
+{commit_history}
 
 """"""
 {summary}
@@ -22,7 +31,8 @@ Please follow the guidelines below when writing your commit message:
 {additional_context}
 `
 
-const inputVariables = ['summary', 'format_instructions', 'additional_context', 'previous_commits']
+// Define the variables that will be passed to the prompt template
+const inputVariables = ['summary', 'format_instructions', 'additional_context', 'commit_history']
 
 export const COMMIT_PROMPT = new PromptTemplate({
   template,

--- a/src/commands/commit/prompt.ts
+++ b/src/commands/commit/prompt.ts
@@ -13,13 +13,13 @@ Please follow the guidelines below when writing your commit message:
 
 {format_instructions}
 
+{previous_commits}
+
 """"""
 {summary}
 """"""
 
 {additional_context}
-
-{previous_commits}
 `
 
 const inputVariables = ['summary', 'format_instructions', 'additional_context', 'previous_commits']

--- a/src/lib/simple-git/formatSingleCommit.ts
+++ b/src/lib/simple-git/formatSingleCommit.ts
@@ -1,0 +1,17 @@
+import { DefaultLogFields, ListLogLine } from 'simple-git'
+
+/**
+ * Format a single commit log entry into a readable string
+ * @param commit - The commit log entry
+ * @returns Formatted commit log string
+ */
+export function formatSingleCommit(commit: DefaultLogFields & ListLogLine): string {
+  const { hash, date, message, body, author_name } = commit
+  const shortHash = hash.substring(0, 7)
+  
+  return `Commit: ${shortHash}
+Author: ${author_name}
+Date: ${date}
+Message: ${message}
+${body ? `\nDetails: ${body}` : ''}`;
+}

--- a/src/lib/simple-git/getPreviousCommits.test.ts
+++ b/src/lib/simple-git/getPreviousCommits.test.ts
@@ -1,0 +1,76 @@
+import { SimpleGit } from 'simple-git'
+import { getPreviousCommits } from './getPreviousCommits'
+import { formatSingleCommit } from './formatSingleCommit'
+
+// Mock the formatSingleCommit function
+jest.mock('./formatSingleCommit', () => ({
+  formatSingleCommit: jest.fn((commit) => `Formatted: ${commit.hash} - ${commit.message}`),
+}))
+
+describe('getPreviousCommits', () => {
+  // Create a mock for SimpleGit with the log method
+  const mockLog = jest.fn();
+  const mockGit = { log: mockLog } as unknown as SimpleGit;
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return empty string when count is 0', async () => {
+    const result = await getPreviousCommits({ git: mockGit, count: 0 })
+    expect(result).toBe('')
+    expect(mockLog).not.toHaveBeenCalled()
+  })
+
+  it('should return empty string when count is negative', async () => {
+    const result = await getPreviousCommits({ git: mockGit, count: -1 })
+    expect(result).toBe('')
+    expect(mockLog).not.toHaveBeenCalled()
+  })
+
+  it('should return empty string when no commits are found', async () => {
+    mockLog.mockResolvedValue({ total: 0, all: [] })
+    const result = await getPreviousCommits({ git: mockGit, count: 1 })
+    expect(result).toBe('')
+    expect(mockLog).toHaveBeenCalledWith({ maxCount: 1 })
+  })
+
+  it('should return formatted commits when commits are found', async () => {
+    const mockCommits = {
+      total: 2,
+      all: [
+        { hash: 'abc123', message: 'First commit' },
+        { hash: 'def456', message: 'Second commit' },
+      ],
+    }
+    mockLog.mockResolvedValue(mockCommits)
+    
+    const result = await getPreviousCommits({ git: mockGit, count: 2 })
+    
+    expect(mockLog).toHaveBeenCalledWith({ maxCount: 2 })
+    expect(formatSingleCommit).toHaveBeenCalledTimes(2)
+    expect(result).toBe('Formatted: abc123 - First commit\n\nFormatted: def456 - Second commit')
+  })
+
+  it('should handle errors gracefully', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+    mockLog.mockRejectedValue(new Error('Git error'))
+    
+    const result = await getPreviousCommits({ git: mockGit, count: 1 })
+    
+    expect(result).toBe('')
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error getting previous commits: Git error')
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('should use default count of 1 when not specified', async () => {
+    mockLog.mockResolvedValue({
+      total: 1,
+      all: [{ hash: 'abc123', message: 'First commit' }],
+    })
+    
+    await getPreviousCommits({ git: mockGit })
+    
+    expect(mockLog).toHaveBeenCalledWith({ maxCount: 1 })
+  })
+})

--- a/src/lib/simple-git/getPreviousCommits.ts
+++ b/src/lib/simple-git/getPreviousCommits.ts
@@ -1,0 +1,38 @@
+import { SimpleGit } from 'simple-git'
+import { formatSingleCommit } from './formatSingleCommit'
+
+export interface GetPreviousCommitsOptions {
+  git: SimpleGit
+  count?: number
+}
+
+/**
+ * Get the specified number of previous commits
+ * @param options - Options for getting previous commits
+ * @returns Formatted commit logs
+ */
+export async function getPreviousCommits(options: GetPreviousCommitsOptions): Promise<string> {
+  const { git, count = 1 } = options
+
+  if (count <= 0) {
+    return ''
+  }
+
+  try {
+    const logs = await git.log({ maxCount: count })
+    
+    if (!logs || logs.total === 0) {
+      return ''
+    }
+
+    // Format the commit logs
+    const formattedLogs = logs.all.map((commit) => {
+      return formatSingleCommit(commit)
+    }).join('\n\n')
+
+    return formattedLogs
+  } catch (error) {
+    console.error(`Error getting previous commits: ${(error as Error).message}`)
+    return ''
+  }
+}


### PR DESCRIPTION
## Git Utilities

- Add `getPreviousCommits` function to fetch and format commit history (2421b07)
- Create `formatSingleCommit` utility to standardize commit formatting (2421b07)
- Update `commit` command handler to use new functionality (2421b07)

## Commit Context

- Implement `withPreviousCommits` option to include previous commits as context in commit messages (2421b07)

## Testing

- Add tests for `getPreviousCommits` function (2421b07)

Resolves #284.