### PR TITLE
Refactor recap command and improve output handling

### DIFF
--- a/src/commands/recap/handler.ts
+++ b/src/commands/recap/handler.ts
@@ -165,8 +165,6 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
         })) as string
 
         return `${response || 'no response'}`
-
-        // return `${response.summary || 'no response'}`
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error)
         // Log the error but don't exit
@@ -174,19 +172,13 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
 
         // Always return a fallback message instead of exiting
         const fallbackMessage = `
-## Recap of Changes (Timeframe: ${timeframe})
-
-### Changes Overview
+## Failed to parse the response [timeframe: ${timeframe}]
 - There are changes in the codebase that couldn't be properly summarized due to a technical issue.
-- The changes include modifications to files related to the coco project.
+- LLM encountered issues when parsing the changes.
 
-### Technical Details
-- Error encountered: ${errorMessage}
-- Try running in interactive mode for more details.
+### Error encountered
 
-### Next Steps
-- You can run the command again or try in interactive mode.
-- Check the logs for more information about the error.
+${errorMessage}
 `
         return fallbackMessage
       }
@@ -201,13 +193,10 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
   const MODE =
     (INTERACTIVE && 'interactive') || (config.recap && 'interactive') || config?.mode || 'stdout' // Default to stdout
 
-  // In non-interactive mode, we need to ensure the result is properly output to stdout
   handleResult({
     result: recapResult,
     interactiveModeCallback: async () => {
-      // In interactive mode, we've already displayed the result
       logSuccess()
-      // process.exit(0)
     },
     mode: MODE as 'interactive' | 'stdout',
   })

--- a/src/commands/recap/prompt.ts
+++ b/src/commands/recap/prompt.ts
@@ -5,13 +5,13 @@ The summarization should descibe in a general sense what has changed in the repo
 
 Breaking down the changes into categories (e.g. bug fixes, new features, etc.) with markdown headings is encouraged.
 
-{timeframe}
+{{timeframe}}
 
-{format_instructions}
+{{format_instructions}}
 
-"""{changes}"""`
+"""{{changes}}"""`
 
-export const inputVariables = ['format_instructions', 'changes', 'timeframe']
+export const inputVariables = ['timeframe', 'format_instructions', 'changes']
 
 export const RECAP_PROMPT = new PromptTemplate({
   template,

--- a/src/lib/langchain/utils/executeChain.ts
+++ b/src/lib/langchain/utils/executeChain.ts
@@ -9,7 +9,7 @@ type ExecuteChainInput<T> = {
   llm: ReturnType<typeof getLlm>
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-expect-error
-  parser: JsonOutputParser<T>
+  parser: JsonOutputParser<T> | StringOutputParser<T>
 }
 
 export const executeChain = async <T>({ llm, prompt, variables, parser }: ExecuteChainInput<T>) => {

--- a/src/lib/langchain/utils/getPrompt.ts
+++ b/src/lib/langchain/utils/getPrompt.ts
@@ -14,6 +14,7 @@ export function getPrompt({ template, variables, fallback }: CreatePromptInput) 
       ? new PromptTemplate({
           template,
           inputVariables: variables,
+          templateFormat: 'mustache',
         })
       : fallback
   ) as PromptTemplate

--- a/src/lib/ui/generateAndReviewLoop.ts
+++ b/src/lib/ui/generateAndReviewLoop.ts
@@ -88,7 +88,6 @@ export async function generateAndReviewLoop<T, R>({
       .stopTimer()
 
     if (options?.interactive) {
-
       logResult(label, reviewParser ? reviewParser(result, options) : result as string)
 
       const reviewAnswer = await getUserReviewDecision({
@@ -122,10 +121,18 @@ export async function generateAndReviewLoop<T, R>({
         result = '' as string as R
         continue
       }
+      
+      // Only edit the result in interactive mode if approved
+      result = await editResult(result as string, options) as R
+    } else {
+      // In non-interactive mode, we return the result as is to be output to stdout by the caller.
+      const displayResult = reviewParser ? reviewParser(result, options) : result as string
+    
+      // In non-interactive mode, ensure we return the properly formatted result
+      result = displayResult as unknown as R
     }
 
     // if we're here, we're done.
-    result = await editResult(result as string, options) as R
     continueLoop = false
   }
 

--- a/src/lib/ui/handleResult.ts
+++ b/src/lib/ui/handleResult.ts
@@ -20,7 +20,8 @@ export async function handleResult({ result, mode, interactiveModeCallback }: Ha
       break
     case 'stdout':
     default:
-      process.stdout.write(result, 'utf8')
+      // Ensure we write the result to stdout in non-interactive mode
+      process.stdout.write(result + '\n', 'utf8')
       break
   }
 


### PR DESCRIPTION
Update `recap` command to use `StringOutputParser` instead of `JsonOutputParser`. Enhance error handling with fallback message. Improve output handling in non-interactive mode.

Modify `generateAndReviewLoop` to return properly formatted result in non-interactive mode. Update `handleResult` to ensure correct stdout output. Adjust `RECAP_PROMPT` template variables for consistency.

Resolves #309 
