### PR TITLE
Add branch name option to commit prompts

### DIFF
--- a/src/commands/commit/config.ts
+++ b/src/commands/commit/config.ts
@@ -10,6 +10,7 @@ export interface CommitOptions extends BaseCommandOptions {
   ignoredExtensions: string[]
   withPreviousCommits: number
   conventional: boolean
+  includeBranchName: boolean
 }
 
 export type CommitArgv = Arguments<CommitOptions>
@@ -80,6 +81,11 @@ export const options = {
     type: 'boolean',
     default: false,
     alias: 'c',
+  },
+  includeBranchName: {
+    description: 'Include the current branch name in the commit prompt for context',
+    type: 'boolean',
+    default: true,
   },
 } as Record<string, Options>
 

--- a/src/commands/commit/prompt.ts
+++ b/src/commands/commit/prompt.ts
@@ -8,6 +8,7 @@ import { PromptTemplate } from '@langchain/core/prompts'
  * - format_instructions: Instructions for the output format (JSON with title and body)
  * - additional_context: Optional user-provided context to guide the commit message generation
  * - commit_history: Optional history of previous commits for context
+ * - branch_name_context: String containing formatted branch name (or empty if disabled)
  */
 export const template = `Write informative git commit message, in the imperative, based on the diffs & file changes provided in the "Diff Summary" section.
 Commit Messages must have a short description that is less than 50 characters and a longer detailed summary around 300 characters, the shorter and more concise the better.
@@ -24,6 +25,8 @@ Please follow the guidelines below when writing your commit message:
 {{summary}}
 """"""
 
+{{branch_name_context}}
+
 {{format_instructions}}
 
 {{commit_history}}
@@ -32,7 +35,7 @@ Please follow the guidelines below when writing your commit message:
 `
 
 // Define the variables that will be passed to the prompt template
-const inputVariables = ['summary', 'format_instructions', 'additional_context', 'commit_history']
+const inputVariables = ['summary', 'format_instructions', 'additional_context', 'commit_history', 'branch_name_context']
 
 export const COMMIT_PROMPT = new PromptTemplate({
   template,
@@ -74,6 +77,8 @@ Based on the following diff summary, generate a conventional commit message that
 {{summary}}
 """"""
 
+{{branch_name_context}}
+
 {{format_instructions}}
 
 {{commit_history}}
@@ -91,6 +96,7 @@ const conventionalInputVariables = [
   'additional_context',
   'commit_history',
   'format_instructions',
+  'branch_name_context',
 ]
 
 export const CONVENTIONAL_COMMIT_PROMPT = new PromptTemplate({

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -14,7 +14,7 @@ type BaseConfig = {
   /**
    * Whether to generate commit messages in Conventional Commits format.
    * When enabled, commit messages will follow the Conventional Commits specification.
-   * 
+   *
    * @see https://www.conventionalcommits.org/
    * @default false
    */
@@ -68,6 +68,14 @@ type BaseConfig = {
    * @default 'main'
    */
   defaultBranch: string
+
+  /**
+   * Whether to include the current branch name in the commit prompt for context.
+   * When enabled, the current git branch name will be included in the prompt.
+   *
+   * @default true
+   */
+  includeBranchName?: boolean
 }
 
 export type ConfigWithServiceObject = BaseConfig &


### PR DESCRIPTION
Introduce `includeBranchName` option to include the current branch name in commit prompts for better context. Update `CommitOptions` and `BaseConfig` to support this feature, defaulting to true. Adjust prompt templates to handle the new `branch_name_context` variable, enhancing commit message generation.

Resolves #367 