### PR TITLE
Add `includeBranchName` option in schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -80,6 +80,11 @@
           "type": "string",
           "description": "Default git branch for the repository.",
           "default": "main"
+        },
+        "includeBranchName": {
+          "type": "boolean",
+          "description": "Whether to include the current branch name in the commit prompt for context. When enabled, the current git branch name will be included in the prompt.",
+          "default": true
         }
       },
       "required": [

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -91,6 +91,11 @@ export const schema = {
           "type": "string",
           "description": "Default git branch for the repository.",
           "default": "main"
+        },
+        "includeBranchName": {
+          "type": "boolean",
+          "description": "Whether to include the current branch name in the commit prompt for context. When enabled, the current git branch name will be included in the prompt.",
+          "default": true
         }
       },
       "required": [


### PR DESCRIPTION
Introduce `includeBranchName` as a new boolean option in the schema to control whether the current branch name is included in the commit prompt. This provides additional context during commit creation, enhancing the user experience by allowing branch-specific information to be part of the commit message.