### PR TITLE
Update model types and schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -454,6 +454,9 @@
     "OllamaModel": {
       "type": "string",
       "enum": [
+        "deepseek-r1:1.5b",
+        "deepseek-r1:8b",
+        "deepseek-r1:32b",
         "codegemma:2b",
         "codegemma:7b-code",
         "codegemma",
@@ -488,6 +491,7 @@
         "llama3.2:1b-instruct-fp16",
         "llama3.2:1b-instruct-q3_K_M",
         "llama3",
+        "llava-llama3:latest",
         "mistral:7b",
         "mistral:latest",
         "mistral:text",
@@ -503,12 +507,18 @@
         "qwen2:1.5b",
         "qwen2:72b-text",
         "qwen2:72b",
-        "qwen2"
+        "qwen2",
+        "qwen2.5-coder:32b"
       ]
     },
     "AnthropicModel": {
       "type": "string",
       "enum": [
+        "claude-sonnet-4-0",
+        "claude-3-7-sonnet-latest",
+        "claude-3-5-haiku-latest",
+        "claude-3-5-sonnet-latest",
+        "claude-3-5-sonnet-20241022",
         "claude-3-5-sonnet-20240620",
         "claude-3-opus-20240229",
         "claude-3-sonnet-20240229",

--- a/src/lib/langchain/types.ts
+++ b/src/lib/langchain/types.ts
@@ -5,6 +5,11 @@ import { type OpenAIInput, type TiktokenModel } from '@langchain/openai'
 export type LLMProvider = 'openai' | 'ollama' | 'anthropic'
 
 export type AnthropicModel =
+  | 'claude-sonnet-4-0'
+  | 'claude-3-7-sonnet-latest'
+  | 'claude-3-5-haiku-latest'
+  | 'claude-3-5-sonnet-latest'
+  | 'claude-3-5-sonnet-20241022'
   | 'claude-3-5-sonnet-20240620'
   | 'claude-3-opus-20240229'
   | 'claude-3-sonnet-20240229'
@@ -13,6 +18,9 @@ export type AnthropicModel =
   | 'claude-2.0'
 
 export type OllamaModel =
+  | 'deepseek-r1:1.5b'
+  | 'deepseek-r1:8b'
+  | 'deepseek-r1:32b'
   | 'codegemma:2b'
   | 'codegemma:7b-code'
   | 'codegemma'
@@ -47,6 +55,7 @@ export type OllamaModel =
   | 'llama3.2:1b-instruct-fp16'
   | 'llama3.2:1b-instruct-q3_K_M'
   | 'llama3'
+  | 'llava-llama3:latest'
   | 'mistral:7b'
   | 'mistral:latest'
   | 'mistral:text'
@@ -63,6 +72,7 @@ export type OllamaModel =
   | 'qwen2:72b-text'
   | 'qwen2:72b'
   | 'qwen2'
+  | 'qwen2.5-coder:32b'
 
 export type LLMModel = TiktokenModel | OllamaModel | AnthropicModel
 

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -465,6 +465,9 @@ export const schema = {
     "OllamaModel": {
       "type": "string",
       "enum": [
+        "deepseek-r1:1.5b",
+        "deepseek-r1:8b",
+        "deepseek-r1:32b",
         "codegemma:2b",
         "codegemma:7b-code",
         "codegemma",
@@ -499,6 +502,7 @@ export const schema = {
         "llama3.2:1b-instruct-fp16",
         "llama3.2:1b-instruct-q3_K_M",
         "llama3",
+        "llava-llama3:latest",
         "mistral:7b",
         "mistral:latest",
         "mistral:text",
@@ -514,12 +518,18 @@ export const schema = {
         "qwen2:1.5b",
         "qwen2:72b-text",
         "qwen2:72b",
-        "qwen2"
+        "qwen2",
+        "qwen2.5-coder:32b"
       ]
     },
     "AnthropicModel": {
       "type": "string",
       "enum": [
+        "claude-sonnet-4-0",
+        "claude-3-7-sonnet-latest",
+        "claude-3-5-haiku-latest",
+        "claude-3-5-sonnet-latest",
+        "claude-3-5-sonnet-20241022",
         "claude-3-5-sonnet-20240620",
         "claude-3-opus-20240229",
         "claude-3-sonnet-20240229",


### PR DESCRIPTION
Expand `AnthropicModel` and `OllamaModel` enums with new entries like `claude-sonnet-4-0` and `deepseek-r1:32b`. These additions enhance model selection flexibility by incorporating the latest versions and variants. Ensure the `schema` and `schema.json` reflect these updates to maintain consistency across the codebase.