### PR TITLE
Hide Coco Banner via Config

### DIFF
--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -40,7 +40,9 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
   const INTERACTIVE = isInteractive(config)
 
   if (INTERACTIVE) {
-    logger.log(LOGO)
+    if (!config.hideCocoBanner) {
+      logger.log(LOGO)
+    }
   }
 
   async function factory() {

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -45,7 +45,9 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
 
   const INTERACTIVE = argv.interactive || isInteractive(config)
   if (INTERACTIVE) {
-    logger.log(LOGO)
+    if (!config.hideCocoBanner) {
+      logger.log(LOGO)
+    }
   } else {
     logger.setConfig({ silent: true })
   }

--- a/src/commands/recap/handler.ts
+++ b/src/commands/recap/handler.ts
@@ -39,7 +39,9 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
 
   const INTERACTIVE = argv.interactive || isInteractive(config)
   if (INTERACTIVE) {
-    logger.log(LOGO)
+    if (!config.hideCocoBanner) {
+      logger.log(LOGO)
+    }
   } else {
     logger.setConfig({ silent: true })
   }

--- a/src/commands/review/handler.ts
+++ b/src/commands/review/handler.ts
@@ -38,7 +38,9 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
 
   const INTERACTIVE = isInteractive(config)
   if (INTERACTIVE) {
-    logger.log(LOGO)
+    if (!config.hideCocoBanner) {
+      logger.log(LOGO)
+    }
   }
 
   async function factory() {


### PR DESCRIPTION
  ### Behavior:
  - Default: Banner is shown (when hideCocoBanner is false or undefined)
  - Hidden: Banner is hidden when hideCocoBanner: true in config
  - Interactive Only: Banner only appears in interactive mode (unchanged)
  - Init Command: Still shows banner (setup command should always show branding)

#### Usage Example:
```
  {
    "hideCocoBanner": true,
    "mode": "interactive",
    "service": {
      "provider": "openai",
      "model": "gpt-4",
      "authentication": {
        "type": "APIKey",
        "credentials": { "apiKey": "your-key" }
      }
    }
  }
```

Resolves #398