### PR TITLE
Add `noDiff` option to commit

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -228,7 +228,7 @@
               "deprecated": "Use \"model\" instead."
             },
             "model": {
-              "type": "string",
+              "$ref": "#/definitions/OpenAIChatModelId",
               "description": "Model name to use"
             },
             "modelKwargs": {
@@ -705,6 +705,79 @@
       "type": "object",
       "additionalProperties": false,
       "description": "Base class for all caches. All caches should extend this class."
+    },
+    "OpenAIChatModelId": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/OpenAI.ChatModel"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "OpenAI.ChatModel": {
+      "$ref": "#/definitions/ChatModel"
+    },
+    "ChatModel": {
+      "type": "string",
+      "enum": [
+        "gpt-4.1",
+        "gpt-4.1-mini",
+        "gpt-4.1-nano",
+        "gpt-4.1-2025-04-14",
+        "gpt-4.1-mini-2025-04-14",
+        "gpt-4.1-nano-2025-04-14",
+        "o4-mini",
+        "o4-mini-2025-04-16",
+        "o3",
+        "o3-2025-04-16",
+        "o3-mini",
+        "o3-mini-2025-01-31",
+        "o1",
+        "o1-2024-12-17",
+        "o1-preview",
+        "o1-preview-2024-09-12",
+        "o1-mini",
+        "o1-mini-2024-09-12",
+        "gpt-4o",
+        "gpt-4o-2024-11-20",
+        "gpt-4o-2024-08-06",
+        "gpt-4o-2024-05-13",
+        "gpt-4o-audio-preview",
+        "gpt-4o-audio-preview-2024-10-01",
+        "gpt-4o-audio-preview-2024-12-17",
+        "gpt-4o-audio-preview-2025-06-03",
+        "gpt-4o-mini-audio-preview",
+        "gpt-4o-mini-audio-preview-2024-12-17",
+        "gpt-4o-search-preview",
+        "gpt-4o-mini-search-preview",
+        "gpt-4o-search-preview-2025-03-11",
+        "gpt-4o-mini-search-preview-2025-03-11",
+        "chatgpt-4o-latest",
+        "codex-mini-latest",
+        "gpt-4o-mini",
+        "gpt-4o-mini-2024-07-18",
+        "gpt-4-turbo",
+        "gpt-4-turbo-2024-04-09",
+        "gpt-4-0125-preview",
+        "gpt-4-turbo-preview",
+        "gpt-4-1106-preview",
+        "gpt-4-vision-preview",
+        "gpt-4",
+        "gpt-4-0314",
+        "gpt-4-0613",
+        "gpt-4-32k",
+        "gpt-4-32k-0314",
+        "gpt-4-32k-0613",
+        "gpt-3.5-turbo",
+        "gpt-3.5-turbo-16k",
+        "gpt-3.5-turbo-0301",
+        "gpt-3.5-turbo-0613",
+        "gpt-3.5-turbo-1106",
+        "gpt-3.5-turbo-0125",
+        "gpt-3.5-turbo-16k-0613"
+      ]
     },
     "OllamaLLMService": {
       "type": "object",

--- a/src/commands/commit/commit.test.ts
+++ b/src/commands/commit/commit.test.ts
@@ -1,0 +1,258 @@
+import { Arguments } from 'yargs'
+import { handler } from './handler'
+import { CommitOptions } from './config'
+import { getRepo } from '../../lib/simple-git/getRepo'
+import { getChanges } from '../../lib/simple-git/getChanges'
+import { logSuccess } from '../../lib/ui/logSuccess'
+import { fileChangeParser } from '../../lib/parsers/default'
+import { generateAndReviewLoop } from '../../lib/ui/generateAndReviewLoop'
+import { handleResult } from '../../lib/ui/handleResult'
+import { loadConfig } from '../../lib/config/utils/loadConfig'
+import { getApiKeyForModel, getModelAndProviderFromConfig } from '../../lib/langchain/utils'
+import { getLlm } from '../../lib/langchain/utils/getLlm'
+import { getTokenCounter } from '../../lib/utils/tokenizer'
+import { COMMIT_PROMPT, CONVENTIONAL_COMMIT_PROMPT } from './prompt'
+import { executeChainWithSchema } from '../../lib/langchain/utils/executeChainWithSchema'
+import { getPrompt } from '../../lib/langchain/utils/getPrompt'
+import { getCurrentBranchName } from '../../lib/simple-git/getCurrentBranchName'
+import { getPreviousCommits } from '../../lib/simple-git/getPreviousCommits'
+import { Logger } from '../../lib/utils/logger'
+import { SimpleGit } from 'simple-git'
+import { Config } from '../../commands/types'
+
+jest.mock('../../lib/simple-git/getRepo')
+jest.mock('../../lib/simple-git/getChanges')
+jest.mock('../../lib/ui/logSuccess')
+jest.mock('../../lib/parsers/default')
+jest.mock('../../lib/ui/generateAndReviewLoop')
+jest.mock('../../lib/ui/handleResult')
+jest.mock('../../lib/config/utils/loadConfig')
+jest.mock('../../lib/langchain/utils')
+jest.mock('../../lib/langchain/utils/getLlm')
+jest.mock('../../lib/utils/tokenizer')
+jest.mock('./prompt')
+jest.mock('../../lib/langchain/utils/executeChainWithSchema')
+jest.mock('../../lib/langchain/utils/getPrompt')
+jest.mock('../../lib/simple-git/getCurrentBranchName')
+jest.mock('../../lib/simple-git/getPreviousCommits')
+
+const mockGetRepo = getRepo as jest.MockedFunction<typeof getRepo>
+const mockGetChanges = getChanges as jest.MockedFunction<typeof getChanges>
+const mockLogSuccess = logSuccess as jest.MockedFunction<typeof logSuccess>
+const mockFileChangeParser = fileChangeParser as jest.MockedFunction<typeof fileChangeParser>
+const mockGenerateAndReviewLoop = generateAndReviewLoop as jest.MockedFunction<
+  typeof generateAndReviewLoop
+>
+const mockHandleResult = handleResult as jest.MockedFunction<typeof handleResult>
+const mockLoadConfig = loadConfig as jest.MockedFunction<typeof loadConfig>
+const mockGetApiKeyForModel = getApiKeyForModel as jest.MockedFunction<typeof getApiKeyForModel>
+const mockGetModelAndProviderFromConfig = getModelAndProviderFromConfig as jest.MockedFunction<
+  typeof getModelAndProviderFromConfig
+>
+const mockGetTokenCounter = getTokenCounter as jest.MockedFunction<typeof getTokenCounter>
+const mockGetLlm = getLlm as jest.MockedFunction<typeof getLlm>
+
+// Mock prompts
+const mockCommitPrompt = COMMIT_PROMPT as jest.Mocked<typeof COMMIT_PROMPT>
+const mockConventionalCommitPrompt = CONVENTIONAL_COMMIT_PROMPT as jest.Mocked<
+  typeof CONVENTIONAL_COMMIT_PROMPT
+>
+
+// Mock additional functions
+const mockExecuteChainWithSchema = executeChainWithSchema as jest.MockedFunction<
+  typeof executeChainWithSchema
+>
+const mockGetPrompt = getPrompt as jest.MockedFunction<typeof getPrompt>
+const mockGetCurrentBranchName = getCurrentBranchName as jest.MockedFunction<
+  typeof getCurrentBranchName
+>
+const mockGetPreviousCommits = getPreviousCommits as jest.MockedFunction<typeof getPreviousCommits>
+
+// Mock process.exit to prevent Jest worker crashes
+const mockProcessExit = jest.spyOn(process, 'exit').mockImplementation(() => {
+  return undefined as never
+})
+
+describe('commit command', () => {
+  let argv: Arguments<CommitOptions>
+  let logger: Logger
+
+  beforeEach(() => {
+    argv = {
+      $0: 'coco',
+      _: ['commit'],
+      interactive: false,
+      openInEditor: false,
+      ignoredFiles: [],
+      ignoredExtensions: [],
+      withPreviousCommits: 0,
+      conventional: false,
+      includeBranchName: true,
+      noDiff: false,
+      verbose: false,
+      version: false,
+      help: false,
+    }
+    logger = {
+      log: jest.fn(),
+      verbose: jest.fn(),
+      setConfig: jest.fn(),
+      startTimer: jest.fn().mockReturnThis(),
+      stopTimer: jest.fn(),
+      startSpinner: jest.fn().mockReturnThis(),
+      stopSpinner: jest.fn(),
+    } as unknown as Logger
+
+    mockGetRepo.mockReturnValue({
+      status: jest.fn().mockResolvedValue({
+        files: [
+          { path: 'file1.txt', index: 'A', working_dir: ' ' },
+          { path: 'file2.txt', index: 'M', working_dir: 'M' },
+          { path: 'file3.txt', index: '?', working_dir: '?' },
+        ],
+      }),
+      revparse: jest.fn().mockResolvedValue('mock-branch-name'),
+      commit: jest.fn().mockResolvedValue(undefined),
+    } as unknown as SimpleGit)
+
+    mockGetChanges.mockResolvedValue({
+      staged: [
+        { filePath: 'file1.txt', status: 'added', summary: 'file1.txt summary' },
+        { filePath: 'file2.txt', status: 'modified', summary: 'file2.txt summary' },
+      ],
+      unstaged: [],
+      untracked: [],
+    })
+
+    mockFileChangeParser.mockResolvedValue('mocked summary')
+    mockGenerateAndReviewLoop.mockImplementation(async ({ factory, parser, agent, options }) => {
+      // Call the factory function to simulate generateAndReviewLoop behavior
+      const changes = await factory()
+      // Call the parser function with proper parameters
+      const result = await agent('test context', options)
+      await parser(changes, result, options)
+      return 'mocked commit message'
+    })
+    mockLogSuccess.mockImplementation(() => {})
+    mockHandleResult.mockResolvedValue(undefined)
+
+    // Mock config and LLM dependencies
+    mockLoadConfig.mockReturnValue({
+      service: {
+        authentication: { type: 'apiKey' },
+        provider: 'openai',
+        model: 'gpt-4o',
+      },
+      hideCocoBanner: false,
+      noDiff: false,
+      ignoredFiles: [],
+      ignoredExtensions: [],
+      includeBranchName: true,
+      conventionalCommits: false,
+      openInEditor: false,
+      mode: 'stdout',
+    } as unknown as Config)
+
+    mockGetApiKeyForModel.mockReturnValue('mock-api-key')
+    mockGetModelAndProviderFromConfig.mockReturnValue({
+      provider: 'openai',
+      model: 'gpt-4o',
+    })
+    mockGetTokenCounter.mockResolvedValue(jest.fn())
+    mockGetLlm.mockReturnValue({} as unknown as ReturnType<typeof getLlm>)
+
+    // Mock prompts
+    mockCommitPrompt.template = 'Test commit prompt template'
+    mockCommitPrompt.inputVariables = [
+      'summary',
+      'format_instructions',
+      'additional_context',
+      'commit_history',
+      'branch_name_context',
+    ]
+    mockConventionalCommitPrompt.template = 'Test conventional commit prompt template'
+    mockConventionalCommitPrompt.inputVariables = [
+      'summary',
+      'format_instructions',
+      'additional_context',
+      'commit_history',
+      'branch_name_context',
+    ]
+
+    // Mock additional functions
+    mockExecuteChainWithSchema.mockResolvedValue({
+      title: 'Test commit title',
+      body: 'Test commit body',
+    })
+    mockGetPrompt.mockReturnValue({
+      template: 'Test prompt template',
+      inputVariables: ['summary'],
+    } as unknown as ReturnType<typeof getPrompt>)
+    mockGetCurrentBranchName.mockResolvedValue('main')
+    mockGetPreviousCommits.mockResolvedValue('Previous commits mock')
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+    mockProcessExit.mockRestore()
+  })
+
+  it('should call getChanges when noDiff is false', async () => {
+    await handler(argv, logger)
+    expect(mockGetChanges).toHaveBeenCalled()
+  })
+
+  it('should not call getChanges when noDiff is true', async () => {
+    argv.noDiff = true
+    // Update the config mock to have noDiff: true
+    mockLoadConfig.mockReturnValue({
+      service: {
+        authentication: { type: 'apiKey' },
+        provider: 'openai',
+        model: 'gpt-4o',
+      },
+      hideCocoBanner: false,
+      noDiff: true,
+      ignoredFiles: [],
+      ignoredExtensions: [],
+      includeBranchName: true,
+      conventionalCommits: false,
+      openInEditor: false,
+      mode: 'stdout',
+    } as unknown as Config)
+
+    await handler(argv, logger)
+    expect(mockGetChanges).not.toHaveBeenCalled()
+  })
+
+  it('should pass simplified file changes to parser when noDiff is true', async () => {
+    argv.noDiff = true
+    // Update the config mock to have noDiff: true
+    mockLoadConfig.mockReturnValue({
+      service: {
+        authentication: { type: 'apiKey' },
+        provider: 'openai',
+        model: 'gpt-4o',
+      },
+      hideCocoBanner: false,
+      noDiff: true,
+      ignoredFiles: [],
+      ignoredExtensions: [],
+      includeBranchName: true,
+      conventionalCommits: false,
+      openInEditor: false,
+      mode: 'stdout',
+    } as unknown as Config)
+
+    await handler(argv, logger)
+    expect(mockFileChangeParser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        changes: [
+          { filePath: 'file1.txt', status: 'added', summary: 'file1.txt' },
+          { filePath: 'file2.txt', status: 'modified', summary: 'file2.txt' },
+          { filePath: 'file3.txt', status: 'added', summary: 'file3.txt' },
+        ],
+      })
+    )
+  })
+})

--- a/src/commands/commit/config.ts
+++ b/src/commands/commit/config.ts
@@ -87,6 +87,11 @@ export const options = {
     type: 'boolean',
     default: true,
   },
+  noDiff: {
+    description: 'Only pass basic "git status" result instead of providing entire diff',
+    type: 'boolean',
+    default: false,
+  },
 } as Record<string, Options>
 
 export const builder = (yargs: Argv) => {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -239,7 +239,7 @@ export const schema = {
               "deprecated": "Use \"model\" instead."
             },
             "model": {
-              "type": "string",
+              "$ref": "#/definitions/OpenAIChatModelId",
               "description": "Model name to use"
             },
             "modelKwargs": {
@@ -716,6 +716,79 @@ export const schema = {
       "type": "object",
       "additionalProperties": false,
       "description": "Base class for all caches. All caches should extend this class."
+    },
+    "OpenAIChatModelId": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/OpenAI.ChatModel"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "OpenAI.ChatModel": {
+      "$ref": "#/definitions/ChatModel"
+    },
+    "ChatModel": {
+      "type": "string",
+      "enum": [
+        "gpt-4.1",
+        "gpt-4.1-mini",
+        "gpt-4.1-nano",
+        "gpt-4.1-2025-04-14",
+        "gpt-4.1-mini-2025-04-14",
+        "gpt-4.1-nano-2025-04-14",
+        "o4-mini",
+        "o4-mini-2025-04-16",
+        "o3",
+        "o3-2025-04-16",
+        "o3-mini",
+        "o3-mini-2025-01-31",
+        "o1",
+        "o1-2024-12-17",
+        "o1-preview",
+        "o1-preview-2024-09-12",
+        "o1-mini",
+        "o1-mini-2024-09-12",
+        "gpt-4o",
+        "gpt-4o-2024-11-20",
+        "gpt-4o-2024-08-06",
+        "gpt-4o-2024-05-13",
+        "gpt-4o-audio-preview",
+        "gpt-4o-audio-preview-2024-10-01",
+        "gpt-4o-audio-preview-2024-12-17",
+        "gpt-4o-audio-preview-2025-06-03",
+        "gpt-4o-mini-audio-preview",
+        "gpt-4o-mini-audio-preview-2024-12-17",
+        "gpt-4o-search-preview",
+        "gpt-4o-mini-search-preview",
+        "gpt-4o-search-preview-2025-03-11",
+        "gpt-4o-mini-search-preview-2025-03-11",
+        "chatgpt-4o-latest",
+        "codex-mini-latest",
+        "gpt-4o-mini",
+        "gpt-4o-mini-2024-07-18",
+        "gpt-4-turbo",
+        "gpt-4-turbo-2024-04-09",
+        "gpt-4-0125-preview",
+        "gpt-4-turbo-preview",
+        "gpt-4-1106-preview",
+        "gpt-4-vision-preview",
+        "gpt-4",
+        "gpt-4-0314",
+        "gpt-4-0613",
+        "gpt-4-32k",
+        "gpt-4-32k-0314",
+        "gpt-4-32k-0613",
+        "gpt-3.5-turbo",
+        "gpt-3.5-turbo-16k",
+        "gpt-3.5-turbo-0301",
+        "gpt-3.5-turbo-0613",
+        "gpt-3.5-turbo-1106",
+        "gpt-3.5-turbo-0125",
+        "gpt-3.5-turbo-16k-0613"
+      ]
     },
     "OllamaLLMService": {
       "type": "object",


### PR DESCRIPTION
This pull request introduces enhancements to the schema definition for model identifiers and adds new functionality to the `commit` command, including support for a simplified "noDiff" mode. The most important changes involve updates to the schema for better extensibility and the implementation of the "noDiff" feature to streamline commit workflows.

### Schema Enhancements:
* Updated the `model` property in `schema.json` and `src/lib/schema.ts` to reference `OpenAIChatModelId`, enabling support for a comprehensive list of predefined model identifiers. [[1]](diffhunk://#diff-9fcde326d127f74194f70e563bdf2c118c51b719c308f015b8eb0204a9a552fbL231-R231) [[2]](diffhunk://#diff-9fcde326d127f74194f70e563bdf2c118c51b719c308f015b8eb0204a9a552fbR709-R781) [[3]](diffhunk://#diff-788cfa8897b3d37a0d726b64c66fa8700807c7439dd0be3f73198ef6e0cbb8a0L242-R242) [[4]](diffhunk://#diff-788cfa8897b3d37a0d726b64c66fa8700807c7439dd0be3f73198ef6e0cbb8a0R720-R792)

### Commit Command Improvements:
* Added a `noDiff` option to the `commit` command configuration, allowing users to pass simplified "git status" results instead of full diffs.
* Modified the `handler` in `src/commands/commit/handler.ts` to support the `noDiff` option, simplifying file change summaries when enabled. [[1]](diffhunk://#diff-090c67b823bdb36db61953a36e83f43eabc37161b4d123a2f17ce803600fc175R65-R72) [[2]](diffhunk://#diff-090c67b823bdb36db61953a36e83f43eabc37161b4d123a2f17ce803600fc175R82)
* Adjusted the `handleResult` call to ensure proper type handling for commit messages.

### Test Enhancements:
* Added comprehensive unit tests for the `commit` command, including scenarios for the `noDiff` mode, ensuring robust functionality.

Resolves #397