### PR TITLE
Remove outdated TypeScript error comment

### DIFF
--- a/src/lib/simple-git/getDiff.test.ts
+++ b/src/lib/simple-git/getDiff.test.ts
@@ -32,7 +32,6 @@ describe('getDiff', () => {
   it('should return diff for renamed files when contents are different', async () => {
     ;(git.show as jest.MockedFunction<typeof git.show>).mockResolvedValueOnce('old content')
     ;(git.show as jest.MockedFunction<typeof git.show>).mockResolvedValueOnce('new content')
-    // @ts-expect-error - jest types are not up to date
     ;(createTwoFilesPatch as jest.MockedFunction<typeof createTwoFilesPatch>).mockReturnValue(`
 --- old.txt
 +++ new.txt


### PR DESCRIPTION
Eliminate the `@ts-expect-error` comment in `getDiff` test for renamed files. The jest types are now up to date, so the comment is no longer necessary. This simplifies the test code and ensures that it remains clean and readable without unnecessary annotations.