### PR TITLE
`changelog` v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ coverage/
 .claude
 CLAUDE.md
 GEMINI.md
+
+commitlint.config.js

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,0 @@
-export default {
-  rules: {
-    'header-max-length': [2, 'always', 100], // => 100
-    'body-max-line-length': [2, 'always', 300], // => 300
-  },
-}

--- a/src/commands/changelog/config.ts
+++ b/src/commands/changelog/config.ts
@@ -6,6 +6,9 @@ export interface ChangelogOptions extends BaseCommandOptions {
   range: string
   branch: string
   sinceLastTag: boolean
+  withDiff?: boolean
+  onlyDiff?: boolean
+  additional?: string
 }
 
 export type ChangelogArgv = Arguments<ChangelogOptions>
@@ -38,6 +41,21 @@ export const options = {
     alias: 't',
     description: 'Generate changelog for all commits since the last tag',
     default: false,
+  },
+  withDiff: {
+    type: 'boolean',
+    description: 'Include the diff for each commit in the prompt',
+    default: false,
+  },
+  onlyDiff: {
+    type: 'boolean',
+    description: 'Generate a changelog based only on the diff of the entire branch',
+    default: false,
+  },
+  additional: {
+    type: 'string',
+    alias: 'a',
+    description: 'Add extra contextual information to the prompt',
   },
   i: {
     type: 'boolean',

--- a/src/commands/changelog/config.ts
+++ b/src/commands/changelog/config.ts
@@ -9,6 +9,7 @@ export interface ChangelogOptions extends BaseCommandOptions {
   withDiff?: boolean
   onlyDiff?: boolean
   additional?: string
+  noAuthor?: boolean
 }
 
 export type ChangelogArgv = Arguments<ChangelogOptions>
@@ -56,6 +57,11 @@ export const options = {
     type: 'string',
     alias: 'a',
     description: 'Add extra contextual information to the prompt',
+  },
+  noAuthor: {
+    type: 'boolean',
+    description: 'Omit author attribution from the changelog',
+    default: false,
   },
   i: {
     type: 'boolean',

--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -162,6 +162,10 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
         additional_context = `## Additional Context\n${argv.additional}`
       }
 
+      const author_instructions = argv.noAuthor
+        ? 'At the end of each item, include a reference to the commit hash, like this: `(f6dbe61)`. Use the first 7 characters of the hash.'
+        : 'At the end of each item, attribute the author and include a reference to the commit hash, like this: `by @author_name (f6dbe61)`. Use the first 7 characters of the hash.'
+
       const changelog = await executeChain({
         llm,
         prompt,
@@ -169,6 +173,7 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
           summary: context,
           format_instructions: formatInstructions,
           additional_context: additional_context,
+          author_instructions: author_instructions,
         },
         parser,
       })

--- a/src/commands/changelog/prompt.ts
+++ b/src/commands/changelog/prompt.ts
@@ -10,15 +10,14 @@ You will be provided with a summary of changes. This summary can be one of the f
 
 ## Rules
 - Create a descriptive title for the changelog that gives a high-level overview of the changes.
-- Logically group related changes under descriptive headings (e.g., ### Features, ### Fixes, ### Refactors).
-- For each change, provide a concise summary.
-- Annotate each change with the git commit hash (first 7 characters) as a reference.
-- Mention the author of the commit where appropriate, perhaps at the end of the line 
-(Thanks @author_name!)
-.
-- If provided with diffs, use them to understand the technical details and provide a more accurate and detailed description of the changes.
-- Avoid generalizations like "various bug fixes," "improvements," or "enhancements." Be specific.
-- Your entire response must be valid Markdown.
+- **BREAKING CHANGES**: Identify any commits that introduce breaking changes. These must be listed first under a "### 💥 BREAKING CHANGES" heading.
+- **Grouping**: Logically group related changes under descriptive headings (e.g., ### Features, ### Fixes, ### Refactors).
+- **Dependencies**: Group all dependency updates (e.g., changes to package.json, go.mod) under a "### Dependencies" section.
+- **Summaries**: For each change, provide a concise summary.
+- **Attribution**: {{author_instructions}}
+- **Technical Details**: If provided with diffs, use them to understand the technical details and provide a more accurate and detailed description of the changes.
+- **Clarity**: Avoid generalizations like "various bug fixes," "improvements," or "enhancements." Be specific.
+- **Formatting**: Your entire response must be valid Markdown.
 
 ## Formatting Instructions
 {{format_instructions}}
@@ -27,7 +26,12 @@ You will be provided with a summary of changes. This summary can be one of the f
 
 """{{summary}}"""`
 
-export const inputVariables = ['format_instructions', 'summary', 'additional_context']
+export const inputVariables = [
+  'format_instructions',
+  'summary',
+  'additional_context',
+  'author_instructions',
+]
 
 export const CHANGELOG_PROMPT = new PromptTemplate({
   template,

--- a/src/commands/changelog/prompt.ts
+++ b/src/commands/changelog/prompt.ts
@@ -1,13 +1,15 @@
 import { PromptTemplate } from '@langchain/core/prompts'
 
-const template = `Write informative git changelog, in the imperative, based on a series of individual messages.
+const template = `You are a highly skilled software engineer. Write informative git changelog, in the imperative, based on a series of individual messages.
 
-- Annotate  each change with the git commit hash as reference, including just the first 7 characters
+## Rules
+- Annotate each change with the git commit hash as reference, including just the first 7 characters
 - Logically group changes, and if necessary, summarize dependency updates
 - Include a descriptive title for the changelog, to give a high-level overview of the changes
 - Depending on the size of the changes, consider breaking the changelog into sections
 - Avoid generlizations like "various bug fixes" or "improvements" or "enhancements"
 
+## Formatting Instructions
 {{format_instructions}}
 
 """{{summary}}"""`

--- a/src/commands/changelog/prompt.ts
+++ b/src/commands/changelog/prompt.ts
@@ -1,20 +1,33 @@
 import { PromptTemplate } from '@langchain/core/prompts'
 
-const template = `You are a highly skilled software engineer. Write informative git changelog, in the imperative, based on a series of individual messages.
+const template = `You are a highly skilled software engineer tasked with writing a git changelog. Your response should be informative, well-structured, and in the imperative.
+
+## Input
+You will be provided with a summary of changes. This summary can be one of the following:
+1. A list of commits, each with its author, hash, message, and body.
+2. A list of commits, each with its details AND the full diff of the changes.
+3. A single, comprehensive diff for an entire branch.
 
 ## Rules
-- Annotate each change with the git commit hash as reference, including just the first 7 characters
-- Logically group changes, and if necessary, summarize dependency updates
-- Include a descriptive title for the changelog, to give a high-level overview of the changes
-- Depending on the size of the changes, consider breaking the changelog into sections
-- Avoid generlizations like "various bug fixes" or "improvements" or "enhancements"
+- Create a descriptive title for the changelog that gives a high-level overview of the changes.
+- Logically group related changes under descriptive headings (e.g., ### Features, ### Fixes, ### Refactors).
+- For each change, provide a concise summary.
+- Annotate each change with the git commit hash (first 7 characters) as a reference.
+- Mention the author of the commit where appropriate, perhaps at the end of the line 
+(Thanks @author_name!)
+.
+- If provided with diffs, use them to understand the technical details and provide a more accurate and detailed description of the changes.
+- Avoid generalizations like "various bug fixes," "improvements," or "enhancements." Be specific.
+- Your entire response must be valid Markdown.
 
 ## Formatting Instructions
 {{format_instructions}}
 
+{{additional_context}}
+
 """{{summary}}"""`
 
-export const inputVariables = ['format_instructions', 'summary']
+export const inputVariables = ['format_instructions', 'summary', 'additional_context']
 
 export const CHANGELOG_PROMPT = new PromptTemplate({
   template,

--- a/src/lib/simple-git/getCommitLogAgainstBranch.ts
+++ b/src/lib/simple-git/getCommitLogAgainstBranch.ts
@@ -1,6 +1,6 @@
 import { SimpleGit } from 'simple-git'
 import { Logger } from '../utils/logger'
-import { getCommitLogRange } from './getCommitLogRange'
+import { getCommitLogRangeDetails, CommitDetails } from './getCommitLogRangeDetails'
 import { getCurrentBranchName } from './getCurrentBranchName'
 
 export type GetCommitLogAgainstBranch = {
@@ -16,13 +16,13 @@ export type GetCommitLogAgainstBranch = {
  * @param {SimpleGit} options.git - The SimpleGit instance.
  * @param {Logger} options.logger - The logger for logging messages.
  * @param {string} options.targetBranch - The target branch to compare against.
- * @returns {Promise<string[]>} The array of commit messages in the commit log.
+ * @returns {Promise<CommitDetails[]>} The array of commit messages in the commit log.
  */
 export async function getCommitLogAgainstBranch({
   git,
   logger,
   targetBranch,
-}: GetCommitLogAgainstBranch): Promise<string[]> {
+}: GetCommitLogAgainstBranch): Promise<CommitDetails[]> {
   try {
     // Get the current branch name
     const currentBranch = await getCurrentBranchName({ git })
@@ -47,7 +47,7 @@ export async function getCommitLogAgainstBranch({
     }
 
     // Retrieve commit log with messages
-    return await getCommitLogRange(firstCommit, lastCommit, { git, noMerges: true })
+    return await getCommitLogRangeDetails(firstCommit, lastCommit, { git, noMerges: true })
   } catch (error) {
     logger?.log('Encountered an error getting commit log between branches', { color: 'red' })
   }

--- a/src/lib/simple-git/getCommitLogCurrentBranch.ts
+++ b/src/lib/simple-git/getCommitLogCurrentBranch.ts
@@ -1,6 +1,6 @@
 import { SimpleGit } from 'simple-git'
 import { Logger } from '../utils/logger'
-import { getCommitLogRange } from './getCommitLogRange'
+import { getCommitLogRangeDetails, CommitDetails } from './getCommitLogRangeDetails'
 import { getCurrentBranchName } from './getCurrentBranchName'
 
 export type GetCommitLogCurrentBranch = {
@@ -18,14 +18,14 @@ export type GetCommitLogCurrentBranch = {
  * @param {Logger} options.logger - The logger for logging messages.
  * @param {string} [options.comparisonBranch='main'] - The branch to compare against.
  * @param {string} [options.comparisonRemote='origin'] - The remote to compare against.
- * @returns {Promise<string[]>} The array of commit messages in the commit log.
+ * @returns {Promise<CommitDetails[]>} The array of commit messages in the commit log.
  */
 export async function getCommitLogCurrentBranch({
   git,
   logger,
   comparisonBranch = 'main',
   comparisonRemote = 'origin',
-}: GetCommitLogCurrentBranch): Promise<string[]> {
+}: GetCommitLogCurrentBranch): Promise<CommitDetails[]> {
   try {
     const branchName = await getCurrentBranchName({ git })
 
@@ -66,7 +66,7 @@ export async function getCommitLogCurrentBranch({
       return []
     }
 
-    return await getCommitLogRange(firstCommit, lastCommit, { git, noMerges: true })
+    return await getCommitLogRangeDetails(firstCommit, lastCommit, { git, noMerges: true })
   } catch (error) {
     logger?.log('Encountered an error getting commit log from current branch', { color: 'red' })
   }

--- a/src/lib/simple-git/getCommitLogRangeDetails.test.ts
+++ b/src/lib/simple-git/getCommitLogRangeDetails.test.ts
@@ -1,0 +1,65 @@
+import { simpleGit, SimpleGit } from 'simple-git'
+import { getCommitLogRangeDetails } from './getCommitLogRangeDetails'
+
+jest.mock('simple-git', () => ({
+  simpleGit: jest.fn().mockImplementation(() => ({
+    log: jest.fn().mockResolvedValue({
+      all: [
+        {
+          message: 'Initial commit',
+          date: '2023-10-01',
+          body: '',
+          author_name: 'John Doe',
+          hash: 'abc123',
+          author_email: 'john.doe@example.com',
+        },
+        {
+          message: 'Add new feature',
+          date: '2023-10-02',
+          body: 'Implemented new feature',
+          author_name: 'Jane Smith',
+          hash: 'def456',
+          author_email: 'jane.smith@example.com',
+        },
+      ],
+    }),
+  })),
+}))
+
+describe('getCommitLogRangeDetails', () => {
+  let git: SimpleGit
+
+  beforeEach(() => {
+    git = simpleGit()
+    jest.clearAllMocks()
+  })
+
+  it('should return detailed commit log objects with inclusive range', async () => {
+    const commits = await getCommitLogRangeDetails('abc123', 'def456', { git, noMerges: true })
+    
+    expect(git.log).toHaveBeenCalledWith({
+      from: 'abc123^',
+      to: 'def456',
+      '--no-merges': true
+    })
+    
+    expect(commits).toEqual([
+        {
+          message: 'Initial commit',
+          date: '2023-10-01',
+          body: '',
+          author_name: 'John Doe',
+          hash: 'abc123',
+          author_email: 'john.doe@example.com',
+        },
+        {
+          message: 'Add new feature',
+          date: '2023-10-02',
+          body: 'Implemented new feature',
+          author_name: 'Jane Smith',
+          hash: 'def456',
+          author_email: 'jane.smith@example.com',
+        },
+    ])
+  })
+})

--- a/src/lib/simple-git/getCommitLogRangeDetails.ts
+++ b/src/lib/simple-git/getCommitLogRangeDetails.ts
@@ -1,0 +1,57 @@
+import { DefaultLogFields, LogOptions, SimpleGit, TaskOptions, ListLogLine } from 'simple-git';
+
+type GetCommitLogRangeDetailsOptions = { git: SimpleGit; noMerges?: boolean }
+
+export type CommitDetails = DefaultLogFields & ListLogLine;
+
+/**
+ * Retrieves the detailed commit log range between two specified commits (inclusive of both commits).
+ *
+ * @param from - The starting commit (can be a commit hash, HEAD reference, or branch name). This commit will be included in the results.
+ * @param to - The ending commit (can be a commit hash, HEAD reference, or branch name). This commit will be included in the results.
+ * @param options - Additional options for retrieving the commit log range.
+ * @returns A promise that resolves to an array of commit details objects.
+ * @throws If there is an error retrieving the commit log range.
+ */
+export async function getCommitLogRangeDetails(
+  from: string,
+  to: string,
+  { noMerges, git }: GetCommitLogRangeDetailsOptions
+): Promise<CommitDetails[]> {
+  try {
+    const logOptions = { 
+      from: `${from}^`, 
+      to, 
+      '--no-merges': noMerges 
+    } as TaskOptions | LogOptions<DefaultLogFields> | undefined
+
+    const commitLog = await git.log(logOptions)
+
+    return [...commitLog.all]
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('unknown revision')) {
+      try {
+        const fromCommitLog = await git.log({ from: from, maxCount: 1 })
+        const fromCommit = fromCommitLog.latest
+        
+        const rangeLogOptions = { 
+          from, 
+          to, 
+          '--no-merges': noMerges 
+        } as TaskOptions | LogOptions<DefaultLogFields> | undefined
+        
+        const rangeCommitLog = await git.log(rangeLogOptions)
+        
+        const allCommits = fromCommit 
+          ? [fromCommit, ...rangeCommitLog.all]
+          : [...rangeCommitLog.all]
+        
+        return allCommits
+      } catch (fallbackError) {
+        throw fallbackError
+      }
+    }
+    
+    throw error
+  }
+}


### PR DESCRIPTION
> Enhancements to Changelog Command and Prompt

### Features

- Add `noAuthor` option to changelog command, allowing users to omit author attribution from the changelog. Update the handler to adjust author instructions based on this option. Modify the prompt to include `author_instructions` for more flexible changelog formatting. by @Griffen Fargo (ee2211d)

- Enhance changelog command with `withDiff`, `onlyDiff`, and `additional` options for more detailed changelogs. Update handler to support generating changelogs with diffs and additional context. Refactor commit log retrieval to use `getCommitLogRangeDetails` for detailed commit information. Add tests for `getCommitLogRangeDetails`. by @Griffen Fargo (8a1c885)

- Enhance changelog prompt with engineer context by updating the `template` in `prompt.ts` to include context about being a skilled software engineer. Add sections for rules and formatting instructions to improve clarity and structure of the changelog creation process. by @Griffen Fargo (193384f)

### Fixes

- Update `.gitignore` to add `commitlint.config.js` to prevent configuration files from being tracked in the repository. This helps maintain a clean working directory by excluding files that are not necessary for version control, ensuring that only relevant files are committed. by @Griffen Fargo (f6dbe61)