### PR TITLE
Refine JSON format instructions

### DIFF
--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -138,7 +138,7 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
         ? ConventionalCommitMessageResponseSchema
         : CommitMessageResponseSchema
 
-      const formatInstructions = `You must always return valid JSON fenced by a markdown code block. Do not return any additional text. The JSON object you return should match the following schema:
+      const formatInstructions = `You must always return a valid JSON object. Do not return any additional text. The JSON object you return should match the following schema:
 ${schema.description}
 {
   "title": "The commit title",


### PR DESCRIPTION
Update `formatInstructions` to clarify that only a valid JSON object should be returned, removing the markdown code block requirement. This change ensures that the instructions are more straightforward and reduces potential confusion when generating commit messages. The schema description remains unchanged to maintain clarity on the expected JSON structure.