### PR TITLE
Add max token support for summarization

### DIFF
--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -101,7 +101,7 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
     return await fileChangeParser({
       changes,
       commit: '--staged',
-      options: { tokenizer, git, llm, logger },
+      options: { tokenizer, git, llm, logger, maxTokens: config.service.tokenLimit },
     })
   }
 

--- a/src/lib/parsers/default/index.ts
+++ b/src/lib/parsers/default/index.ts
@@ -7,14 +7,10 @@ import { getDiff } from '../../simple-git/getDiff'
 import { loadSummarizationChain } from 'langchain/chains'
 import { RecursiveCharacterTextSplitter } from '@langchain/textsplitters'
 
-// Max tokens for GPT-3 is 4096
-// const MAX_TOKENS_PER_SUMMARY = 4096
-const MAX_TOKENS_PER_SUMMARY = 12288
-
 export async function fileChangeParser({
   changes,
   commit,
-  options: { tokenizer, git, llm: model, logger },
+  options: { tokenizer, git, llm: model, logger, maxTokens },
 }: FileChangeParserInput): Promise<string> {
   const textSplitter = new RecursiveCharacterTextSplitter({ chunkSize: 10000, chunkOverlap: 250 })
 
@@ -42,7 +38,7 @@ export async function fileChangeParser({
   logger.startTimer()
   const summary = await summarizeDiffs(diffs, {
     tokenizer,
-    maxTokens: MAX_TOKENS_PER_SUMMARY,
+    maxTokens: maxTokens || 4096,
     textSplitter,
     chain: summarizationChain,
     logger,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -51,6 +51,7 @@ export interface BaseParserOptions {
   llm: ReturnType<typeof getLlm>
   git: SimpleGit
   logger: Logger
+  maxTokens?: number
 }
 
 export interface BaseParserInput {


### PR DESCRIPTION
Introduce optional `maxTokens` parameter to control token limits in `fileChangeParser`. Update `handler` to use `config.service.tokenLimit` for `maxTokens`. Adjust `BaseParserOptions` to include `maxTokens`. This enhances flexibility by allowing dynamic token limits, improving summarization efficiency.