### PR TITLE
Enhance pnpm conventional commit handling and validation

### DIFF
--- a/src/commands/commit/config.ts
+++ b/src/commands/commit/config.ts
@@ -15,7 +15,7 @@ export interface CommitOptions extends BaseCommandOptions {
 
 export type CommitArgv = Arguments<CommitOptions>
 
-const conventionalTypeRegex = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?:/;
+const conventionalTypeRegex = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?:/;
 
 // Regular commit message schema with basic validation
 export const CommitMessageResponseSchema = z.object({

--- a/src/commands/commit/conventionalCommits.test.ts
+++ b/src/commands/commit/conventionalCommits.test.ts
@@ -1,0 +1,208 @@
+import { ConventionalCommitMessageResponseSchema, CommitMessageResponseSchema } from './config'
+import { CONVENTIONAL_COMMIT_PROMPT, COMMIT_PROMPT } from './prompt'
+
+describe('Conventional Commits Configuration', () => {
+  describe('ConventionalCommitMessageResponseSchema', () => {
+    it('should validate valid conventional commit format', () => {
+      const validCommit = {
+        title: 'feat: add new authentication system',
+        body: 'Implement JWT-based authentication with login and logout functionality.'
+      }
+      
+      const result = ConventionalCommitMessageResponseSchema.safeParse(validCommit)
+      expect(result.success).toBe(true)
+    })
+
+    it('should validate conventional commit with scope', () => {
+      const validCommit = {
+        title: 'fix(auth): resolve login timeout issue',
+        body: 'Increase timeout duration and add retry logic for better reliability.'
+      }
+      
+      const result = ConventionalCommitMessageResponseSchema.safeParse(validCommit)
+      expect(result.success).toBe(true)
+    })
+
+    it('should reject title longer than 50 characters', () => {
+      const invalidCommit = {
+        title: 'feat: add a very long feature description that exceeds the fifty character limit',
+        body: 'This should fail validation.'
+      }
+      
+      const result = ConventionalCommitMessageResponseSchema.safeParse(invalidCommit)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toContain('50 characters or less')
+      }
+    })
+
+    it('should reject non-conventional commit format', () => {
+      const invalidCommit = {
+        title: 'Add new feature without proper format',
+        body: 'This does not follow conventional commits format.'
+      }
+      
+      const result = ConventionalCommitMessageResponseSchema.safeParse(invalidCommit)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toContain('Conventional Commits format')
+      }
+    })
+
+    it('should accept all valid conventional commit types', () => {
+      const validTypes = [
+        'feat', 'fix', 'docs', 'style', 'refactor', 
+        'perf', 'test', 'build', 'ci', 'chore', 'revert'
+      ]
+      
+      validTypes.forEach(type => {
+        const commit = {
+          title: `${type}: test commit`,
+          body: 'Test body content.'
+        }
+        
+        const result = ConventionalCommitMessageResponseSchema.safeParse(commit)
+        expect(result.success).toBe(true)
+      })
+    })
+
+    it('should accept breaking change format', () => {
+      const breakingChange = {
+        title: 'feat!: add breaking API changes',
+        body: 'BREAKING CHANGE: API endpoints have been restructured.'
+      }
+      
+      const result = ConventionalCommitMessageResponseSchema.safeParse(breakingChange)
+      expect(result.success).toBe(true)
+    })
+
+    it('should accept scope with breaking change', () => {
+      const breakingChange = {
+        title: 'feat(api)!: restructure authentication endpoints',
+        body: 'BREAKING CHANGE: All auth endpoints now require v2 prefix.'
+      }
+      
+      const result = ConventionalCommitMessageResponseSchema.safeParse(breakingChange)
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('Regular CommitMessageResponseSchema', () => {
+    it('should accept any title format', () => {
+      const commit = {
+        title: 'Add new feature without conventional format',
+        body: 'This should be accepted by the regular schema.'
+      }
+      
+      const result = CommitMessageResponseSchema.safeParse(commit)
+      expect(result.success).toBe(true)
+    })
+
+    it('should accept empty body', () => {
+      const commit = {
+        title: 'Simple commit',
+        body: ''
+      }
+      
+      const result = CommitMessageResponseSchema.safeParse(commit)
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('Prompt Templates', () => {
+    it('should have all required input variables for conventional prompt', () => {
+      const expectedVariables = [
+        'summary',
+        'additional_context',
+        'commit_history',
+        'format_instructions',
+        'branch_name_context',
+        'commitlint_rules_context'
+      ]
+      
+      expectedVariables.forEach(variable => {
+        expect(CONVENTIONAL_COMMIT_PROMPT.inputVariables).toContain(variable)
+      })
+    })
+
+    it('should have all required input variables for regular prompt', () => {
+      const expectedVariables = [
+        'summary',
+        'format_instructions',
+        'additional_context',
+        'commit_history',
+        'branch_name_context',
+        'commitlint_rules_context'
+      ]
+      
+      expectedVariables.forEach(variable => {
+        expect(COMMIT_PROMPT.inputVariables).toContain(variable)
+      })
+    })
+
+    it('should contain conventional commits guidance in template', () => {
+      expect(CONVENTIONAL_COMMIT_PROMPT.template).toContain('Conventional Commits')
+      expect(CONVENTIONAL_COMMIT_PROMPT.template).toContain('feat:')
+      expect(CONVENTIONAL_COMMIT_PROMPT.template).toContain('fix:')
+      expect(CONVENTIONAL_COMMIT_PROMPT.template).toContain('type')
+      expect(CONVENTIONAL_COMMIT_PROMPT.template).toContain('scope')
+    })
+
+    it('should contain JSON formatting instructions', () => {
+      expect(CONVENTIONAL_COMMIT_PROMPT.template).toContain('JSON')
+      expect(COMMIT_PROMPT.template).toContain('format_instructions')
+    })
+  })
+
+  describe('Schema Validation Edge Cases', () => {
+    it('should handle minimal valid conventional commit', () => {
+      const minimalCommit = {
+        title: 'fix: bug',
+        body: 'Fixed.'
+      }
+      
+      const result = ConventionalCommitMessageResponseSchema.safeParse(minimalCommit)
+      expect(result.success).toBe(true)
+    })
+
+    it('should handle maximum length conventional commit', () => {
+      const maxLengthCommit = {
+        title: 'feat(scope): add feature that is exactly fifty', // Exactly 50 chars
+        body: 'This is a detailed explanation of the changes made.'
+      }
+      
+      const result = ConventionalCommitMessageResponseSchema.safeParse(maxLengthCommit)
+      expect(result.success).toBe(true)
+    })
+
+    it('should reject invalid type', () => {
+      const invalidType = {
+        title: 'invalid: not a valid conventional commit type',
+        body: 'This should fail.'
+      }
+      
+      const result = ConventionalCommitMessageResponseSchema.safeParse(invalidType)
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject missing colon', () => {
+      const missingColon = {
+        title: 'feat add feature without colon',
+        body: 'This should fail.'
+      }
+      
+      const result = ConventionalCommitMessageResponseSchema.safeParse(missingColon)
+      expect(result.success).toBe(false)
+    })
+
+    it('should handle complex scopes', () => {
+      const complexScope = {
+        title: 'feat(api-auth-v2): add new authentication',
+        body: 'Added comprehensive authentication system.'
+      }
+      
+      const result = ConventionalCommitMessageResponseSchema.safeParse(complexScope)
+      expect(result.success).toBe(true)
+    })
+  })
+})

--- a/src/commands/commit/conventionalCommitsHandler.test.ts
+++ b/src/commands/commit/conventionalCommitsHandler.test.ts
@@ -1,0 +1,201 @@
+import { handler } from './handler'
+import { Arguments } from 'yargs'
+import { CommitOptions } from './config'
+import { Logger } from '../../lib/utils/logger'
+
+// Mock all dependencies
+jest.mock('../../lib/simple-git/getRepo')
+jest.mock('../../lib/simple-git/getChanges')
+jest.mock('../../lib/config/utils/loadConfig')
+jest.mock('../../lib/langchain/utils')
+jest.mock('../../lib/ui/generateAndReviewLoop')
+jest.mock('../../lib/ui/handleResult')
+jest.mock('../../lib/utils/hasCommitlintConfig')
+jest.mock('../../lib/utils/commitlintValidator')
+
+import { loadConfig } from '../../lib/config/utils/loadConfig'
+import { getApiKeyForModel, getModelAndProviderFromConfig } from '../../lib/langchain/utils'
+import { generateAndReviewLoop } from '../../lib/ui/generateAndReviewLoop'
+import { hasCommitlintConfig } from '../../lib/utils/hasCommitlintConfig'
+import { getCommitlintRulesContext, checkCommitlintAvailability } from '../../lib/utils/commitlintValidator'
+
+const mockLoadConfig = loadConfig as jest.MockedFunction<typeof loadConfig>
+const mockGetApiKeyForModel = getApiKeyForModel as jest.MockedFunction<typeof getApiKeyForModel>
+const mockGetModelAndProviderFromConfig = getModelAndProviderFromConfig as jest.MockedFunction<typeof getModelAndProviderFromConfig>
+const mockGenerateAndReviewLoop = generateAndReviewLoop as jest.MockedFunction<typeof generateAndReviewLoop>
+const mockHasCommitlintConfig = hasCommitlintConfig as jest.MockedFunction<typeof hasCommitlintConfig>
+const mockGetCommitlintRulesContext = getCommitlintRulesContext as jest.MockedFunction<typeof getCommitlintRulesContext>
+const mockCheckCommitlintAvailability = checkCommitlintAvailability as jest.MockedFunction<typeof checkCommitlintAvailability>
+
+describe('Conventional Commits Handler', () => {
+  let argv: Arguments<CommitOptions>
+  let logger: Logger
+
+  beforeEach(() => {
+    argv = {
+      $0: 'coco',
+      _: ['commit'],
+      interactive: false,
+      openInEditor: false,
+      ignoredFiles: [],
+      ignoredExtensions: [],
+      withPreviousCommits: 0,
+      conventional: false,
+      includeBranchName: true,
+      noDiff: false,
+      verbose: false,
+      version: false,
+      help: false,
+    }
+
+    logger = {
+      log: jest.fn(),
+      verbose: jest.fn(),
+      setConfig: jest.fn(),
+    } as unknown as Logger
+
+    // Default mocks
+    mockLoadConfig.mockReturnValue({
+      service: {
+        authentication: { type: 'apiKey' },
+        provider: 'openai',
+        model: 'gpt-4o',
+      },
+      conventionalCommits: false,
+    } as any)
+
+    mockGetApiKeyForModel.mockReturnValue('mock-api-key')
+    mockGetModelAndProviderFromConfig.mockReturnValue({
+      provider: 'openai',
+      model: 'gpt-4o',
+    })
+
+    mockGenerateAndReviewLoop.mockResolvedValue('mock commit message')
+    mockHasCommitlintConfig.mockResolvedValue(false)
+    mockGetCommitlintRulesContext.mockResolvedValue('')
+    mockCheckCommitlintAvailability.mockReturnValue({
+      available: true,
+      missingPackages: [],
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('Conventional Commits Mode Detection', () => {
+    it('should call generateAndReviewLoop when conventional flag is set', async () => {
+      argv.conventional = true
+
+      await handler(argv, logger)
+
+      expect(mockGenerateAndReviewLoop).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent: expect.any(Function),
+        })
+      )
+    })
+
+    it('should call generateAndReviewLoop when conventional commits enabled in config', async () => {
+      mockLoadConfig.mockReturnValue({
+        service: {
+          authentication: { type: 'apiKey' },
+          provider: 'openai',
+          model: 'gpt-4o',
+        },
+        conventionalCommits: true,
+      } as any)
+
+      await handler(argv, logger)
+
+      expect(mockGenerateAndReviewLoop).toHaveBeenCalled()
+    })
+
+    it('should call generateAndReviewLoop in regular mode', async () => {
+      await handler(argv, logger)
+
+      expect(mockGenerateAndReviewLoop).toHaveBeenCalled()
+    })
+  })
+
+  describe('Basic Handler Functionality', () => {
+    it('should handle conventional commits flag', async () => {
+      argv.conventional = true
+
+      await handler(argv, logger)
+
+      expect(mockGenerateAndReviewLoop).toHaveBeenCalled()
+    })
+
+    it('should handle additional context', async () => {
+      argv.additional = 'This resolves issue #123'
+
+      await handler(argv, logger)
+
+      expect(mockGenerateAndReviewLoop).toHaveBeenCalled()
+    })
+
+    it('should handle commit history requests', async () => {
+      argv.withPreviousCommits = 3
+
+      await handler(argv, logger)
+
+      expect(mockGenerateAndReviewLoop).toHaveBeenCalled()
+    })
+  })
+
+  describe('Configuration Options', () => {
+    it('should handle branch name inclusion', async () => {
+      argv.includeBranchName = true
+
+      await handler(argv, logger)
+
+      expect(mockGenerateAndReviewLoop).toHaveBeenCalled()
+    })
+
+    it('should handle branch name exclusion', async () => {
+      argv.includeBranchName = false
+
+      await handler(argv, logger)
+
+      expect(mockGenerateAndReviewLoop).toHaveBeenCalled()
+    })
+  })
+
+  describe('Error Handling', () => {
+    it('should exit when API key is missing', async () => {
+      mockGetApiKeyForModel.mockReturnValue('')
+      const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit called')
+      })
+
+      await expect(handler(argv, logger)).rejects.toThrow('process.exit called')
+      expect(logger.log).toHaveBeenCalledWith('No API Key found. 🗝️🚪', { color: 'red' })
+      
+      mockExit.mockRestore()
+    })
+
+    it('should warn about Ollama model limitations', async () => {
+      mockLoadConfig.mockReturnValue({
+        service: {
+          authentication: { type: 'apiKey' },
+          provider: 'ollama',
+          model: 'llama2',
+        },
+        conventionalCommits: true,
+      } as unknown)
+
+      mockGetModelAndProviderFromConfig.mockReturnValue({
+        provider: 'ollama',
+        model: 'llama2',
+      })
+
+      await handler(argv, logger)
+
+      expect(logger.verbose).toHaveBeenCalledWith(
+        '⚠️  Ollama models may not strictly adhere to the output format instructions.',
+        { color: 'yellow' }
+      )
+    })
+  })
+})

--- a/src/commands/commit/conventionalCommitsIntegration.test.ts
+++ b/src/commands/commit/conventionalCommitsIntegration.test.ts
@@ -1,0 +1,181 @@
+import { formatCommitMessage } from '../../lib/langchain/utils/formatCommitMessage'
+import { repairJson } from '../../lib/utils/repairJson'
+
+describe('Conventional Commits Integration', () => {
+  describe('End-to-End JSON Processing', () => {
+    it('should handle complete conventional commit flow with valid JSON', () => {
+      const aiResponse = '{"title": "feat(auth): add OAuth2 integration", "body": "Implement OAuth2 authentication flow with Google and GitHub providers. Includes token refresh and user profile management."}'
+      
+      const result = formatCommitMessage(aiResponse, {
+        append: 'Closes #123',
+        ticketId: 'PROJ-456',
+        appendTicket: true
+      })
+      
+      const expected = 'feat(auth): add OAuth2 integration\n\nImplement OAuth2 authentication flow with Google and GitHub providers. Includes token refresh and user profile management.\n\nCloses #123\n\nPart of **PROJ-456**'
+      expect(result).toBe(expected)
+    })
+
+    it('should handle malformed JSON from AI and repair it', () => {
+      const malformedResponse = '{"title": feat(ui): improve responsive design, "body": "Update CSS grid layouts and media queries for better mobile experience. Includes touch-friendly button sizes and improved navigation."}'
+      
+      const result = formatCommitMessage(malformedResponse)
+      
+      const expected = 'feat(ui): improve responsive design\n\nUpdate CSS grid layouts and media queries for better mobile experience. Includes touch-friendly button sizes and improved navigation.'
+      expect(result).toBe(expected)
+    })
+
+    it('should handle conventional commits in markdown code blocks', () => {
+      const markdownResponse = '```json\n{"title": "fix(api): resolve rate limiting issues", "body": "Implement exponential backoff and retry logic for API calls. Improves reliability under high load conditions."}\n```'
+      
+      const result = formatCommitMessage(markdownResponse)
+      
+      const expected = 'fix(api): resolve rate limiting issues\n\nImplement exponential backoff and retry logic for API calls. Improves reliability under high load conditions.'
+      expect(result).toBe(expected)
+    })
+
+    it('should handle breaking changes format', () => {
+      const breakingChangeResponse = '{"title": "feat!: restructure API endpoints", "body": "BREAKING CHANGE: All API endpoints now use v2 prefix. Update client applications to use /api/v2/ instead of /api/."}'
+      
+      const result = formatCommitMessage(breakingChangeResponse)
+      
+      const expected = 'feat!: restructure API endpoints\n\nBREAKING CHANGE: All API endpoints now use v2 prefix. Update client applications to use /api/v2/ instead of /api/.'
+      expect(result).toBe(expected)
+    })
+
+    it('should handle scoped breaking changes', () => {
+      const scopedBreakingChange = '{"title": "refactor(database)!: change user schema", "body": "BREAKING CHANGE: User table schema updated. Migration required for existing databases."}'
+      
+      const result = formatCommitMessage(scopedBreakingChange)
+      
+      const expected = 'refactor(database)!: change user schema\n\nBREAKING CHANGE: User table schema updated. Migration required for existing databases.'
+      expect(result).toBe(expected)
+    })
+  })
+
+  describe('Real-world Scenarios', () => {
+    it('should handle complex conventional commit with all features', () => {
+      const complexResponse = '{"title": "feat(auth): add multi-factor authentication", "body": "Implement TOTP-based 2FA with backup codes. Includes user enrollment flow, recovery options, and admin management interface. Supports Google Authenticator and Authy."}'
+      
+      const result = formatCommitMessage(complexResponse, {
+        append: 'Co-authored-by: Jane Doe <jane@example.com>',
+        ticketId: 'SEC-789',
+        appendTicket: true
+      })
+      
+      const expected = 'feat(auth): add multi-factor authentication\n\nImplement TOTP-based 2FA with backup codes. Includes user enrollment flow, recovery options, and admin management interface. Supports Google Authenticator and Authy.\n\nCo-authored-by: Jane Doe <jane@example.com>\n\nPart of **SEC-789**'
+      expect(result).toBe(expected)
+    })
+
+    it('should handle malformed JSON with special characters', () => {
+      const specialCharsResponse = '{"title": chore(deps): update @types/node to v18.15.0, "body": "Update TypeScript definitions for Node.js. Includes new APIs and improved type safety."}'
+      
+      const result = formatCommitMessage(specialCharsResponse)
+      
+      const expected = 'chore(deps): update @types/node to v18.15.0\n\nUpdate TypeScript definitions for Node.js. Includes new APIs and improved type safety.'
+      expect(result).toBe(expected)
+    })
+
+    it('should handle revert commits', () => {
+      const revertResponse = '{"title": "revert: remove experimental feature", "body": "This reverts commit abc123def456. The feature caused performance issues in production."}'
+      
+      const result = formatCommitMessage(revertResponse)
+      
+      const expected = 'revert: remove experimental feature\n\nThis reverts commit abc123def456. The feature caused performance issues in production.'
+      expect(result).toBe(expected)
+    })
+
+    it('should handle docs commits', () => {
+      const docsResponse = '{"title": "docs(api): update authentication examples", "body": "Add comprehensive examples for OAuth2 flow. Includes code samples in JavaScript, Python, and cURL."}'
+      
+      const result = formatCommitMessage(docsResponse)
+      
+      const expected = 'docs(api): update authentication examples\n\nAdd comprehensive examples for OAuth2 flow. Includes code samples in JavaScript, Python, and cURL.'
+      expect(result).toBe(expected)
+    })
+
+    it('should handle test commits', () => {
+      const testResponse = '{"title": "test(auth): add integration tests for OAuth flow", "body": "Add comprehensive test coverage for OAuth2 authentication. Includes happy path, error cases, and edge conditions."}'
+      
+      const result = formatCommitMessage(testResponse)
+      
+      const expected = 'test(auth): add integration tests for OAuth flow\n\nAdd comprehensive test coverage for OAuth2 authentication. Includes happy path, error cases, and edge conditions.'
+      expect(result).toBe(expected)
+    })
+
+    it('should handle build/ci commits', () => {
+      const buildResponse = '{"title": "ci: add automated security scanning", "body": "Integrate SAST and dependency scanning into CI pipeline. Includes vulnerability reporting and PR blocking for high-severity issues."}'
+      
+      const result = formatCommitMessage(buildResponse)
+      
+      const expected = 'ci: add automated security scanning\n\nIntegrate SAST and dependency scanning into CI pipeline. Includes vulnerability reporting and PR blocking for high-severity issues.'
+      expect(result).toBe(expected)
+    })
+  })
+
+  describe('Error Recovery', () => {
+    it('should gracefully handle completely invalid JSON', () => {
+      const invalidJson = 'This is not JSON at all, just plain text'
+      
+      const result = formatCommitMessage(invalidJson)
+      
+      expect(result).toBe(invalidJson)
+    })
+
+    it('should handle JSON with missing required fields', () => {
+      const incompleteJson = '{"title": "feat: add feature"}'
+      
+      const result = formatCommitMessage(incompleteJson)
+      
+      expect(result).toBe(incompleteJson)
+    })
+
+    it('should handle empty JSON object', () => {
+      const emptyJson = '{}'
+      
+      const result = formatCommitMessage(emptyJson)
+      
+      expect(result).toBe(emptyJson)
+    })
+
+    it('should handle JSON with null values', () => {
+      const nullJson = '{"title": null, "body": null}'
+      
+      const result = formatCommitMessage(nullJson)
+      
+      expect(result).toBe(nullJson)
+    })
+  })
+
+  describe('JSON Repair Specific Cases', () => {
+    it('should repair multiple unquoted values', () => {
+      const multipleUnquoted = '{"title": feat(api): add rate limiting, "body": Implement token bucket algorithm for API rate limiting}'
+      
+      const repaired = repairJson(multipleUnquoted)
+      const result = formatCommitMessage(repaired)
+      
+      const expected = 'feat(api): add rate limiting\n\nImplement token bucket algorithm for API rate limiting'
+      expect(result).toBe(expected)
+    })
+
+    it('should handle trailing commas in JSON', () => {
+      const trailingComma = '{"title": "perf: optimize database queries", "body": "Add indexes and query optimization for better performance.",}'
+      
+      const repaired = repairJson(trailingComma)
+      const result = formatCommitMessage(repaired)
+      
+      const expected = 'perf: optimize database queries\n\nAdd indexes and query optimization for better performance.'
+      expect(result).toBe(expected)
+    })
+
+    it('should handle mixed quoted and unquoted values', () => {
+      const mixedQuoting = '{"title": "style: format code with prettier", "body": Update code formatting across all TypeScript files}'
+      
+      const repaired = repairJson(mixedQuoting)
+      const result = formatCommitMessage(repaired)
+      
+      const expected = 'style: format code with prettier\n\nUpdate code formatting across all TypeScript files'
+      expect(result).toBe(expected)
+    })
+  })
+})

--- a/src/lib/utils/pnpmCommitlint.test.ts
+++ b/src/lib/utils/pnpmCommitlint.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Simple test to verify pnpm ES module error detection
+ */
+
+// Mock the isPnpmEsModuleIssue function logic
+function isPnpmEsModuleIssue(error: Error): boolean {
+  const message = error.message
+  return (
+    message.includes('Directory import') &&
+    message.includes('is not supported resolving ES modules') &&
+    message.includes('@commitlint/config-conventional')
+  )
+}
+
+describe('pnpm ES module error detection', () => {
+  it('should detect pnpm ES module errors', () => {
+    const pnpmError = new Error(
+      "Directory import '/Users/gfargo/dev/gfargo/vercel-doorman/node_modules/.pnpm/@commitlint+config-conventional@18.6.3/node_modules/@commitlint/config-conventional/lib' is not supported resolving ES modules imported from /Users/gfargo/dev/gfargo/vercel-doorman/node_modules/.pnpm/@commitlint+config-conventional@18.6.3/node_modules/@commitlint/config-conventional/wrapper.mjs"
+    )
+    
+    expect(isPnpmEsModuleIssue(pnpmError)).toBe(true)
+  })
+
+  it('should not detect regular module not found errors', () => {
+    const regularError = new Error('Cannot find module "@commitlint/config-conventional"')
+    expect(isPnpmEsModuleIssue(regularError)).toBe(false)
+  })
+
+  it('should not detect unrelated errors', () => {
+    const unrelatedError = new Error('Some other error')
+    expect(isPnpmEsModuleIssue(unrelatedError)).toBe(false)
+  })
+})


### PR DESCRIPTION
### Features
- Enhance commit handling for pnpm and conventional commits by updating `conventionalTypeRegex` to detect breaking changes with `!`. Add tests for `conventionalCommits`, `handler`, and `formatCommitMessage` to validate conventional commit formats and error handling. Improve `commitlintValidator` to manage pnpm ES module issues, providing fallbacks and guidance. Add tests for pnpm error detection. (030d888)