### PR TITLE
fix(handler): ensure result is string formatted

### DIFF
--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -133,6 +133,10 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
     },
     factory,
     parser,
+    reviewParser: (result) => {
+      // Ensure the result is properly formatted as a string for display
+      return typeof result === 'string' ? result : String(result)
+    },
     agent: async (context, options) => {
       // Select the appropriate schema based on whether conventional commits are enabled
       const schema = USE_CONVENTIONAL_COMMITS


### PR DESCRIPTION
Add `reviewParser` to convert results to strings for display. This ensures consistent formatting and prevents potential issues with non-string values. The change enhances the robustness of result handling and improves the user experience by maintaining uniform output.