### PR TITLE
feat(error): enhance error handling in LangChain

### DIFF
--- a/src/lib/langchain/errorHandler.test.ts
+++ b/src/lib/langchain/errorHandler.test.ts
@@ -1,0 +1,122 @@
+import { isNetworkError, handleLangChainError } from './errorHandler'
+import { LangChainNetworkError, LangChainExecutionError } from './errors'
+
+describe('isNetworkError', () => {
+  it('should detect "fetch failed" errors', () => {
+    const error = new Error('fetch failed')
+    expect(isNetworkError(error)).toBe(true)
+  })
+
+  it('should detect ECONNREFUSED errors', () => {
+    const error = new Error('connect ECONNREFUSED 127.0.0.1:11434')
+    expect(isNetworkError(error)).toBe(true)
+  })
+
+  it('should detect ENOTFOUND errors', () => {
+    const error = new Error('getaddrinfo ENOTFOUND localhost')
+    expect(isNetworkError(error)).toBe(true)
+  })
+
+  it('should detect ETIMEDOUT errors', () => {
+    const error = new Error('ETIMEDOUT')
+    expect(isNetworkError(error)).toBe(true)
+  })
+
+  it('should detect socket hang up errors', () => {
+    const error = new Error('socket hang up')
+    expect(isNetworkError(error)).toBe(true)
+  })
+
+  it('should detect network request failed errors', () => {
+    const error = new Error('network request failed')
+    expect(isNetworkError(error)).toBe(true)
+  })
+
+  it('should not detect non-network errors', () => {
+    const error = new Error('Invalid JSON response')
+    expect(isNetworkError(error)).toBe(false)
+  })
+
+  it('should not detect validation errors', () => {
+    const error = new Error('Validation failed: missing required field')
+    expect(isNetworkError(error)).toBe(false)
+  })
+
+  it('should return false for non-Error objects', () => {
+    expect(isNetworkError('string error')).toBe(false)
+    expect(isNetworkError(null)).toBe(false)
+    expect(isNetworkError(undefined)).toBe(false)
+    expect(isNetworkError({ message: 'fetch failed' })).toBe(false)
+  })
+
+  it('should be case-insensitive', () => {
+    const error = new Error('FETCH FAILED')
+    expect(isNetworkError(error)).toBe(true)
+  })
+})
+
+describe('handleLangChainError', () => {
+  it('should throw LangChainNetworkError for network errors', () => {
+    const error = new Error('fetch failed')
+
+    expect(() => {
+      handleLangChainError(error, 'test context', {
+        endpoint: 'http://localhost:11434',
+        provider: 'ollama',
+      })
+    }).toThrow(LangChainNetworkError)
+  })
+
+  it('should include endpoint and provider in LangChainNetworkError', () => {
+    const error = new Error('connect ECONNREFUSED')
+
+    try {
+      handleLangChainError(error, 'test context', {
+        endpoint: 'http://localhost:11434',
+        provider: 'ollama',
+      })
+    } catch (e) {
+      expect(e).toBeInstanceOf(LangChainNetworkError)
+      const networkError = e as LangChainNetworkError
+      expect(networkError.endpoint).toBe('http://localhost:11434')
+      expect(networkError.provider).toBe('ollama')
+    }
+  })
+
+  it('should throw LangChainExecutionError for non-network errors', () => {
+    const error = new Error('Invalid response format')
+
+    expect(() => {
+      handleLangChainError(error, 'test context')
+    }).toThrow(LangChainExecutionError)
+  })
+
+  it('should include context in error message for non-network errors', () => {
+    const error = new Error('Parse error')
+
+    try {
+      handleLangChainError(error, 'executeChain: Chain failed')
+    } catch (e) {
+      expect(e).toBeInstanceOf(LangChainExecutionError)
+      expect((e as Error).message).toBe('executeChain: Chain failed: Parse error')
+    }
+  })
+})
+
+describe('LangChainNetworkError', () => {
+  it('should store endpoint and provider', () => {
+    const error = new LangChainNetworkError(
+      'Connection failed',
+      'http://localhost:11434',
+      'ollama',
+      { originalError: 'TypeError' }
+    )
+
+    expect(error.endpoint).toBe('http://localhost:11434')
+    expect(error.provider).toBe('ollama')
+    expect(error.message).toBe('Connection failed')
+    expect(error.context?.endpoint).toBe('http://localhost:11434')
+    expect(error.context?.provider).toBe('ollama')
+    expect(error.context?.originalError).toBe('TypeError')
+  })
+})

--- a/src/lib/langchain/errorHandler.ts
+++ b/src/lib/langchain/errorHandler.ts
@@ -1,12 +1,45 @@
-import { LangChainError, LangChainExecutionError } from './errors'
+import { LangChainError, LangChainExecutionError, LangChainNetworkError } from './errors'
 
 // Re-export retry utilities from general utils
-export { 
-  withRetry, 
-  withTimeout, 
+export {
+  withRetry,
+  withTimeout,
   withRetryAndTimeout,
-  type RetryOptions 
+  type RetryOptions
 } from '../utils/retry'
+
+/**
+ * Network error patterns to detect connection failures
+ */
+const NETWORK_ERROR_PATTERNS = [
+  'fetch failed',
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'ETIMEDOUT',
+  'ECONNRESET',
+  'ENETUNREACH',
+  'EHOSTUNREACH',
+  'socket hang up',
+  'network request failed',
+  'Failed to fetch',
+  'getaddrinfo',
+  'connect ECONNREFUSED',
+]
+
+/**
+ * Checks if an error message indicates a network/connection failure
+ */
+export function isNetworkError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+
+  const message = error.message.toLowerCase()
+  const errorCause = (error as Error & { cause?: Error })?.cause?.message?.toLowerCase() || ''
+
+  return NETWORK_ERROR_PATTERNS.some(pattern =>
+    message.includes(pattern.toLowerCase()) ||
+    errorCause.includes(pattern.toLowerCase())
+  )
+}
 
 /**
  * Wraps errors with additional context and converts them to LangChain errors
@@ -16,24 +49,16 @@ export function handleLangChainError(
   context: string,
   additionalContext?: Record<string, unknown>
 ): never {
-  // If it's already a LangChain error, re-throw with additional context
-  if (error instanceof LangChainError) {
-    throw new LangChainExecutionError(
-      `${context}: ${error.message}`,
-      { 
-        ...error.context,
-        ...additionalContext,
-        originalError: error.name,
-        context 
-      }
-    )
-  }
-  
-  // If it's a regular Error, wrap it
-  if (error instanceof Error) {
-    throw new LangChainExecutionError(
-      `${context}: ${error.message}`,
-      { 
+  // Check for network errors first
+  if (error instanceof Error && isNetworkError(error)) {
+    const endpoint = additionalContext?.endpoint as string | undefined
+    const provider = additionalContext?.provider as string | undefined
+
+    throw new LangChainNetworkError(
+      error.message,
+      endpoint,
+      provider,
+      {
         originalError: error.name,
         originalMessage: error.message,
         stack: error.stack,
@@ -42,11 +67,38 @@ export function handleLangChainError(
       }
     )
   }
-  
+
+  // If it's already a LangChain error, re-throw with additional context
+  if (error instanceof LangChainError) {
+    throw new LangChainExecutionError(
+      `${context}: ${error.message}`,
+      {
+        ...error.context,
+        ...additionalContext,
+        originalError: error.name,
+        context
+      }
+    )
+  }
+
+  // If it's a regular Error, wrap it
+  if (error instanceof Error) {
+    throw new LangChainExecutionError(
+      `${context}: ${error.message}`,
+      {
+        originalError: error.name,
+        originalMessage: error.message,
+        stack: error.stack,
+        context,
+        ...additionalContext
+      }
+    )
+  }
+
   // For unknown error types
   throw new LangChainExecutionError(
     `${context}: Unknown error occurred`,
-    { 
+    {
       originalError: typeof error,
       originalValue: String(error),
       context,

--- a/src/lib/langchain/errors.ts
+++ b/src/lib/langchain/errors.ts
@@ -55,3 +55,17 @@ export class LangChainTimeoutError extends LangChainError {
     super(message, context)
   }
 }
+
+/**
+ * Network/connection errors (service unreachable, DNS failures, etc.)
+ */
+export class LangChainNetworkError extends LangChainError {
+  constructor(
+    message: string,
+    public readonly endpoint?: string,
+    public readonly provider?: string,
+    context?: Record<string, unknown>
+  ) {
+    super(message, { ...context, endpoint, provider })
+  }
+}

--- a/src/lib/langchain/utils/executeChain.ts
+++ b/src/lib/langchain/utils/executeChain.ts
@@ -1,8 +1,8 @@
 import { BaseOutputParser } from '@langchain/core/output_parsers'
 import { PromptTemplate } from '@langchain/core/prompts'
 import { RunnableRetry } from '@langchain/core/runnables'
-import { handleLangChainError } from '../errorHandler'
-import { LangChainExecutionError } from '../errors'
+import { handleLangChainError, isNetworkError } from '../errorHandler'
+import { LangChainExecutionError, LangChainNetworkError } from '../errors'
 import { validateRequired } from '../validation'
 import { getLlm } from './getLlm'
 
@@ -11,6 +11,36 @@ type ExecuteChainInput<T> = {
   prompt: PromptTemplate
   llm: ReturnType<typeof getLlm>
   parser: BaseOutputParser<T> | RunnableRetry
+  /** Optional provider name for better error messages */
+  provider?: string
+  /** Optional endpoint URL for better error messages */
+  endpoint?: string
+}
+
+/**
+ * Extracts provider and endpoint info from LLM instance if available
+ */
+function extractLlmInfo(llm: ReturnType<typeof getLlm>): { provider?: string; endpoint?: string } {
+  const info: { provider?: string; endpoint?: string } = {}
+
+  // Try to extract provider from class name
+  const className = llm?.constructor?.name || ''
+  if (className.includes('Ollama')) {
+    info.provider = 'ollama'
+    // Try to get baseUrl from ollama instance
+    if ('lc_kwargs' in llm && typeof llm.lc_kwargs === 'object' && llm.lc_kwargs !== null) {
+      const kwargs = llm.lc_kwargs as Record<string, unknown>
+      if (typeof kwargs.baseUrl === 'string') {
+        info.endpoint = kwargs.baseUrl
+      }
+    }
+  } else if (className.includes('OpenAI')) {
+    info.provider = 'openai'
+  } else if (className.includes('Anthropic')) {
+    info.provider = 'anthropic'
+  }
+
+  return info
 }
 
 /**
@@ -18,8 +48,16 @@ type ExecuteChainInput<T> = {
  * @param params - The execution parameters
  * @returns The parsed result from the LLM chain
  * @throws LangChainExecutionError if the chain execution fails or returns empty results
+ * @throws LangChainNetworkError if a network/connection error occurs
  */
-export const executeChain = async <T>({ llm, prompt, variables, parser }: ExecuteChainInput<T>): Promise<T> => {
+export const executeChain = async <T>({
+  llm,
+  prompt,
+  variables,
+  parser,
+  provider,
+  endpoint,
+}: ExecuteChainInput<T>): Promise<T> => {
   validateRequired(llm, 'llm', 'executeChain')
   validateRequired(prompt, 'prompt', 'executeChain')
   validateRequired(variables, 'variables', 'executeChain')
@@ -27,16 +65,22 @@ export const executeChain = async <T>({ llm, prompt, variables, parser }: Execut
 
   // Validate that variables is an object
   if (typeof variables !== 'object' || Array.isArray(variables)) {
-    throw new LangChainExecutionError(
-      'executeChain: Variables must be a non-array object',
-      { variables, type: typeof variables, isArray: Array.isArray(variables) }
-    )
+    throw new LangChainExecutionError('executeChain: Variables must be a non-array object', {
+      variables,
+      type: typeof variables,
+      isArray: Array.isArray(variables),
+    })
   }
+
+  // Extract LLM info for error reporting if not provided
+  const llmInfo = extractLlmInfo(llm)
+  const effectiveProvider = provider || llmInfo.provider
+  const effectiveEndpoint = endpoint || llmInfo.endpoint
 
   try {
     const chain = prompt.pipe(llm).pipe(parser)
     const result = await chain.invoke(variables)
-    
+
     if (result === null || result === undefined) {
       throw new LangChainExecutionError(
         'executeChain: Chain execution returned null or undefined result',
@@ -47,15 +91,29 @@ export const executeChain = async <T>({ llm, prompt, variables, parser }: Execut
     return result
   } catch (error) {
     // Re-throw LangChain errors as-is
-    if (error instanceof LangChainExecutionError) {
+    if (error instanceof LangChainExecutionError || error instanceof LangChainNetworkError) {
       throw error
     }
-    
+
+    // Check for network errors and throw specific error type
+    if (error instanceof Error && isNetworkError(error)) {
+      throw new LangChainNetworkError(error.message, effectiveEndpoint, effectiveProvider, {
+        originalError: error.name,
+        originalMessage: error.message,
+        stack: error.stack,
+        promptInputVariables: prompt.inputVariables,
+        variableKeys: Object.keys(variables),
+        parserType: parser.constructor.name,
+      })
+    }
+
     // Wrap other errors with context
     handleLangChainError(error, 'executeChain: Chain execution failed', {
       promptInputVariables: prompt.inputVariables,
       variableKeys: Object.keys(variables),
-      parserType: parser.constructor.name
+      parserType: parser.constructor.name,
+      provider: effectiveProvider,
+      endpoint: effectiveEndpoint,
     })
   }
 }

--- a/src/lib/utils/commandExecutor.ts
+++ b/src/lib/utils/commandExecutor.ts
@@ -3,6 +3,67 @@ import { loadConfig } from '../config/utils/loadConfig'
 import { Logger } from './logger'
 import { CommandHandler } from '../types'
 import { BaseArgvOptions } from '../../commands/types'
+import { LangChainNetworkError, LangChainAuthenticationError } from '../langchain/errors'
+
+/**
+ * Formats a network error with helpful troubleshooting information
+ */
+function formatNetworkError(error: LangChainNetworkError, logger: Logger): void {
+  const endpoint = error.endpoint || 'unknown endpoint'
+  const provider = error.provider || 'LLM service'
+
+  logger.log('\nFailed to execute command', { color: 'yellow' })
+  logger.log(`\nError: Unable to connect to ${provider}`, { color: 'red' })
+
+  if (error.endpoint) {
+    logger.log(`       Endpoint: ${endpoint}`, { color: 'red' })
+  }
+
+  logger.log('\nTroubleshooting:', { color: 'cyan' })
+
+  // Provider-specific troubleshooting
+  if (provider === 'ollama' || endpoint.includes('11434')) {
+    logger.log('  • Is Ollama running? Try: ollama serve', { color: 'white' })
+    logger.log('  • Check if the endpoint is correct in your config', { color: 'white' })
+    logger.log(`  • Verify Ollama is accessible: curl ${endpoint}/api/version`, { color: 'white' })
+  } else if (provider === 'openai' || endpoint.includes('openai')) {
+    logger.log('  • Check your internet connection', { color: 'white' })
+    logger.log('  • Verify the API endpoint is accessible', { color: 'white' })
+    logger.log('  • If using a custom baseURL, verify it is correct', { color: 'white' })
+  } else if (provider === 'anthropic') {
+    logger.log('  • Check your internet connection', { color: 'white' })
+    logger.log('  • Verify the Anthropic API is accessible', { color: 'white' })
+  } else {
+    logger.log('  • Check your internet connection', { color: 'white' })
+    logger.log('  • Verify the service endpoint is correct', { color: 'white' })
+    logger.log('  • Ensure the LLM service is running and accessible', { color: 'white' })
+  }
+
+  logger.verbose(`\nOriginal error: ${error.message}`, { color: 'gray' })
+}
+
+/**
+ * Formats an authentication error with helpful information
+ */
+function formatAuthenticationError(error: LangChainAuthenticationError, logger: Logger): void {
+  logger.log('\nFailed to execute command', { color: 'yellow' })
+  logger.log('\nError: Authentication failed', { color: 'red' })
+
+  logger.log('\nTroubleshooting:', { color: 'cyan' })
+  logger.log('  • Verify your API key is correct', { color: 'white' })
+  logger.log('  • Check that your API key has not expired', { color: 'white' })
+  logger.log('  • Ensure the API key is set in your environment or config', { color: 'white' })
+
+  logger.verbose(`\nOriginal error: ${error.message}`, { color: 'gray' })
+}
+
+/**
+ * Formats a generic error
+ */
+function formatGenericError(error: Error, logger: Logger): void {
+  logger.log('\nFailed to execute command', { color: 'yellow' })
+  logger.verbose(`\nError: "${error.message}"`, { color: 'red' })
+}
 
 function commandExecutor<T extends Argv<BaseArgvOptions>['argv']>(handler: CommandHandler<T>) {
   return async (argv: T) => {
@@ -12,8 +73,15 @@ function commandExecutor<T extends Argv<BaseArgvOptions>['argv']>(handler: Comma
     try {
       await handler(argv, logger)
     } catch (error) {
-      logger.log('\nFailed to execute command', { color: 'yellow' })
-      logger.verbose(`\nError: "${(error as Error).message}"`, { color: 'red' })
+      // Handle specific error types with helpful messages
+      if (error instanceof LangChainNetworkError) {
+        formatNetworkError(error, logger)
+      } else if (error instanceof LangChainAuthenticationError) {
+        formatAuthenticationError(error, logger)
+      } else {
+        formatGenericError(error as Error, logger)
+      }
+
       logger.log('\nThanks for using coco, make it a great day! 👋🤖', { color: 'blue' })
       process.exit(0)
     }


### PR DESCRIPTION
Add unit tests for `isNetworkError`, `handleLangChainError`, and `LangChainNetworkError`. Introduce `NETWORK_ERROR_PATTERNS` to identify network issues. Update `executeChain` to include `provider` and `endpoint` for better error messages. Enhance `commandExecutor` with specific error formatting functions for network and authentication errors.