### PR TITLE
fix: handle pre-commit hook file modifications gracefully

### DIFF
--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -464,7 +464,12 @@ IMPORTANT RULES:
   handleResult({
     result: commitMsg as string,
     interactiveModeCallback: async (result) => {
-      await createCommit(result, git)
+      await createCommit(result, git, () => {
+        logger.log(
+          '⚠️  Pre-commit hook modified files. Staging changes and retrying commit...',
+          { color: 'yellow' }
+        )
+      })
       logSuccess()
     },
     mode: MODE as 'interactive' | 'stdout',

--- a/src/lib/simple-git/createCommit.test.ts
+++ b/src/lib/simple-git/createCommit.test.ts
@@ -1,34 +1,127 @@
 import { SimpleGit, CommitResult } from 'simple-git'
-import { createCommit } from './createCommit'
+import { createCommit, isPreCommitHookModifiedFilesError } from './createCommit'
+
+const mockCommitResult: CommitResult = {
+  author: null,
+  branch: 'main',
+  commit: '123abc',
+  root: false,
+  summary: { changes: 1, deletions: 0, insertions: 1 },
+}
+
+function makeGit(commitImpl: jest.Mock, addImpl?: jest.Mock): SimpleGit {
+  return {
+    commit: commitImpl,
+    add: addImpl ?? jest.fn().mockResolvedValue(undefined),
+  } as unknown as SimpleGit
+}
+
+describe('isPreCommitHookModifiedFilesError', () => {
+  it('returns true for "files were modified by this hook"', () => {
+    const err = new Error('black...Failed\n- hook id: black\n- files were modified by this hook')
+    expect(isPreCommitHookModifiedFilesError(err)).toBe(true)
+  })
+
+  it('returns true for "modified by this hook"', () => {
+    const err = new Error('prettier modified by this hook')
+    expect(isPreCommitHookModifiedFilesError(err)).toBe(true)
+  })
+
+  it('returns true when message contains "hook id:"', () => {
+    const err = new Error('- hook id: trailing-whitespace\n- exit code: 1')
+    expect(isPreCommitHookModifiedFilesError(err)).toBe(true)
+  })
+
+  it('returns false for unrelated git errors', () => {
+    const err = new Error('nothing to commit, working tree clean')
+    expect(isPreCommitHookModifiedFilesError(err)).toBe(false)
+  })
+
+  it('returns false for non-Error values', () => {
+    expect(isPreCommitHookModifiedFilesError('string error')).toBe(false)
+    expect(isPreCommitHookModifiedFilesError(null)).toBe(false)
+  })
+})
 
 describe('createCommit', () => {
-  const git: SimpleGit = {
-    commit: jest.fn().mockResolvedValue({
-      author: null,
-      branch: 'main',
-      commit: '123abc',
-    } as CommitResult),
-  } as unknown as SimpleGit
+  afterEach(() => jest.clearAllMocks())
 
-  afterEach(() => {
-    jest.clearAllMocks()
+  it('calls git.commit with the provided message', async () => {
+    const commitMock = jest.fn().mockResolvedValue(mockCommitResult)
+    const git = makeGit(commitMock)
+    await createCommit('test commit', git)
+    expect(commitMock).toHaveBeenCalledWith('test commit')
   })
 
-  it('should call git commit with the provided message', async () => {
-    const commitMessage = 'test commit message'
-    await createCommit(commitMessage, git)
-
-    expect(git.commit).toHaveBeenCalledWith(commitMessage)
+  it('returns CommitResult on success', async () => {
+    const commitMock = jest.fn().mockResolvedValue(mockCommitResult)
+    const git = makeGit(commitMock)
+    const result = await createCommit('test commit', git)
+    expect(result).toEqual(mockCommitResult)
   })
 
-  it('should return CommitResult', async () => {
-    const commitMessage = 'another test commit message'
-    const result: CommitResult = await createCommit(commitMessage, git)
+  it('re-throws non-hook git errors', async () => {
+    const err = new Error('nothing to commit')
+    const commitMock = jest.fn().mockRejectedValue(err)
+    const git = makeGit(commitMock)
+    await expect(createCommit('test commit', git)).rejects.toThrow('nothing to commit')
+  })
 
-    expect(result).toEqual({
-      author: null,
-      branch: 'main',
-      commit: '123abc',
+  describe('pre-commit hook modifies files', () => {
+    const hookError = new Error(
+      'black...Failed\n- hook id: black\n- files were modified by this hook'
+    )
+
+    it('stages all files and retries the commit', async () => {
+      const addMock = jest.fn().mockResolvedValue(undefined)
+      const commitMock = jest
+        .fn()
+        .mockRejectedValueOnce(hookError)
+        .mockResolvedValueOnce(mockCommitResult)
+      const git = makeGit(commitMock, addMock)
+
+      const result = await createCommit('test commit', git)
+
+      expect(addMock).toHaveBeenCalledWith('.')
+      expect(commitMock).toHaveBeenCalledTimes(2)
+      expect(result).toEqual(mockCommitResult)
+    })
+
+    it('calls onHookModifiedFiles callback before retry', async () => {
+      const onHookModifiedFiles = jest.fn()
+      const addMock = jest.fn().mockResolvedValue(undefined)
+      const commitMock = jest
+        .fn()
+        .mockRejectedValueOnce(hookError)
+        .mockResolvedValueOnce(mockCommitResult)
+      const git = makeGit(commitMock, addMock)
+
+      await createCommit('test commit', git, onHookModifiedFiles)
+
+      expect(onHookModifiedFiles).toHaveBeenCalledTimes(1)
+    })
+
+    it('works without an onHookModifiedFiles callback', async () => {
+      const addMock = jest.fn().mockResolvedValue(undefined)
+      const commitMock = jest
+        .fn()
+        .mockRejectedValueOnce(hookError)
+        .mockResolvedValueOnce(mockCommitResult)
+      const git = makeGit(commitMock, addMock)
+
+      await expect(createCommit('test commit', git)).resolves.toEqual(mockCommitResult)
+    })
+
+    it('throws if the retry also fails', async () => {
+      const retryError = new Error('commit failed after hook fix')
+      const addMock = jest.fn().mockResolvedValue(undefined)
+      const commitMock = jest
+        .fn()
+        .mockRejectedValueOnce(hookError)
+        .mockRejectedValueOnce(retryError)
+      const git = makeGit(commitMock, addMock)
+
+      await expect(createCommit('test commit', git)).rejects.toThrow('commit failed after hook fix')
     })
   })
 })

--- a/src/lib/simple-git/createCommit.ts
+++ b/src/lib/simple-git/createCommit.ts
@@ -1,12 +1,51 @@
 import { CommitResult, SimpleGit } from 'simple-git'
 
 /**
+ * Detects whether a GitError was caused by a pre-commit hook that modified files.
+ * These hooks (e.g. black, prettier) reformat files and exit non-zero on the first run,
+ * but the commit can succeed once the modified files are re-staged.
+ */
+export function isPreCommitHookModifiedFilesError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  const msg = error.message
+  // pre-commit framework outputs "files were modified by this hook"
+  // git itself outputs "modified files exist in working tree" in some hook setups
+  return (
+    msg.includes('files were modified by this hook') ||
+    msg.includes('modified by this hook') ||
+    msg.includes('hook id:')
+  )
+}
+
+/**
  * Creates a commit with the specified commit message.
- * 
+ * Handles the case where pre-commit hooks modify files (e.g. black, prettier):
+ * when detected, stages the hook-modified files and retries the commit once.
+ *
  * @param message The commit message.
  * @param git The SimpleGit instance.
+ * @param onHookModifiedFiles Optional callback invoked before the auto-retry so callers can notify the user.
  * @returns A Promise that resolves to the CommitResult.
  */
-export async function createCommit(message: string, git: SimpleGit): Promise<CommitResult> {
-  return await git.commit(message)
+export async function createCommit(
+  message: string,
+  git: SimpleGit,
+  onHookModifiedFiles?: () => void | Promise<void>
+): Promise<CommitResult> {
+  try {
+    return await git.commit(message)
+  } catch (error) {
+    if (isPreCommitHookModifiedFilesError(error)) {
+      // Notify caller (e.g. to show a spinner message or log)
+      if (onHookModifiedFiles) {
+        await onHookModifiedFiles()
+      }
+
+      // Stage all hook-modified files and retry the commit once
+      await git.add('.')
+      return await git.commit(message)
+    }
+
+    throw error
+  }
 }


### PR DESCRIPTION
## Problem

Fixes #560

When a pre-commit hook (e.g. `black`, `prettier`, `trailing-whitespace`) reformats staged files, it exits with a non-zero code. `simple-git` surfaces this as an unhandled `GitError`, crashing `coco` with a raw stack trace instead of recovering gracefully.

The root cause: `createCommit` had no error handling at all — any `GitError` from `git.commit()` propagated straight to the top level.

## Solution

Updated `createCommit` to detect the pre-commit hook "files were modified" pattern and automatically recover:

1. Catch the `GitError` and check if it matches known pre-commit hook output patterns (`files were modified by this hook`, `modified by this hook`, `hook id:`)
2. If matched, stage all hook-modified files via `git add .`
3. Retry the commit once with the same message
4. If the retry also fails (for a different reason), re-throw normally

An optional `onHookModifiedFiles` callback lets the caller surface a user-facing message before the retry — the commit handler uses this to log a yellow warning.

## Changes

**Bug fix**
- `src/lib/simple-git/createCommit.ts` — added `isPreCommitHookModifiedFilesError` helper + retry logic
- `src/commands/commit/handler.ts` — passes the `onHookModifiedFiles` callback to surface a warning to the user

**Bug fix (found via tests)**
- `src/lib/simple-git/getStatus.ts` — `DiffResultBinaryFile` has `before`/`after` instead of `changes`, so the existing `'changes' in file` guard caused binary diffs to always throw `Invalid file type`. Added a dedicated binary branch that correctly maps `before`/`after` to `added`/`deleted`/`modified`/`untracked`/`renamed`.

**Tests**
- `src/lib/simple-git/createCommit.test.ts` — 12 tests covering success, non-hook errors, hook detection, retry, callback, and retry failure
- `src/lib/simple-git/getStatus.test.ts` — expanded to cover `DiffResultTextFile` branch fully and new `DiffResultBinaryFile` branch (added/deleted/modified/untracked/renamed)
- `src/lib/simple-git/formatSingleCommit.test.ts` — new file; hash truncation, body presence/absence, special characters, short hashes
- `src/lib/simple-git/parseFileString.test.ts` — new file; simple paths, rename paths with shared root prefix, whitespace trimming, `=>` without spaces edge case
- `src/lib/simple-git/formatCommitLog.test.ts` — expanded with empty log, empty body, multi-commit ordering, special characters

## Before / After

**Before:** crash with raw `GitError` stack trace
**After:** `⚠️  Pre-commit hook modified files. Staging changes and retrying commit...` → commit succeeds
