### PR TITLE
test: expand simple-git utility test coverage

### DIFF
--- a/src/lib/simple-git/formatCommitLog.test.ts
+++ b/src/lib/simple-git/formatCommitLog.test.ts
@@ -1,7 +1,58 @@
 import { DefaultLogFields, LogResult } from 'simple-git'
 import { formatCommitLog } from './formatCommitLog'
 
+const makeLog = (overrides: Partial<DefaultLogFields> = {}): LogResult<DefaultLogFields> => {
+  const entry: DefaultLogFields = {
+    message: 'chore: update deps',
+    date: '2024-06-01',
+    body: '',
+    author_name: 'Dev',
+    hash: 'deadbeef',
+    refs: '',
+    author_email: 'dev@example.com',
+    ...overrides,
+  }
+  return { all: [entry], latest: entry, total: 1 }
+}
+
 describe('formatCommitLog', () => {
+  it('returns an empty array for an empty commit log', () => {
+    const log: LogResult<DefaultLogFields> = { all: [], latest: null, total: 0 }
+    expect(formatCommitLog(log)).toEqual([])
+  })
+
+  it('includes date, message, body, hash, author name and email', () => {
+    const [result] = formatCommitLog(makeLog({ body: 'Some body text.' }))
+    expect(result).toContain('[2024-06-01]')
+    expect(result).toContain('chore: update deps')
+    expect(result).toContain('Some body text.')
+    expect(result).toContain('(deadbeef)')
+    expect(result).toContain('Dev<dev@example.com>')
+  })
+
+  it('handles an empty body without breaking format', () => {
+    const [result] = formatCommitLog(makeLog({ body: '' }))
+    // body line should be present but empty
+    expect(result).toMatch(/\n\n/)
+  })
+
+  it('preserves order of multiple commits', () => {
+    const first: DefaultLogFields = { ...makeLog().all[0], message: 'first', date: '2024-01-01', hash: 'aaa' }
+    const second: DefaultLogFields = { ...makeLog().all[0], message: 'second', date: '2024-01-02', hash: 'bbb' }
+    const log: LogResult<DefaultLogFields> = { all: [first, second], latest: second, total: 2 }
+    const results = formatCommitLog(log)
+    expect(results[0]).toContain('first')
+    expect(results[1]).toContain('second')
+  })
+
+  it('handles special characters in message and author fields', () => {
+    const [result] = formatCommitLog(
+      makeLog({ message: 'fix: handle <null> & "quotes"', author_name: "O'Brien" })
+    )
+    expect(result).toContain('fix: handle <null> & "quotes"')
+    expect(result).toContain("O'Brien")
+  })
+
   it('should format a single commit log correctly', () => {
     const commitLog: LogResult<DefaultLogFields> = {
       all: [

--- a/src/lib/simple-git/formatSingleCommit.test.ts
+++ b/src/lib/simple-git/formatSingleCommit.test.ts
@@ -1,0 +1,60 @@
+import { DefaultLogFields, ListLogLine } from 'simple-git'
+import { formatSingleCommit } from './formatSingleCommit'
+
+type CommitEntry = DefaultLogFields & ListLogLine
+
+const base: CommitEntry = {
+  hash: 'a1b2c3d4e5f6789',
+  date: '2024-01-15',
+  message: 'feat: add login page',
+  body: '',
+  author_name: 'Jane Dev',
+  author_email: 'jane@example.com',
+  refs: '',
+}
+
+describe('formatSingleCommit', () => {
+  it('truncates hash to 7 characters', () => {
+    const result = formatSingleCommit(base)
+    expect(result).toContain('Commit: a1b2c3d')
+    expect(result).not.toContain('a1b2c3d4e5f6789')
+  })
+
+  it('includes author name', () => {
+    expect(formatSingleCommit(base)).toContain('Author: Jane Dev')
+  })
+
+  it('includes date', () => {
+    expect(formatSingleCommit(base)).toContain('Date: 2024-01-15')
+  })
+
+  it('includes message', () => {
+    expect(formatSingleCommit(base)).toContain('Message: feat: add login page')
+  })
+
+  it('omits Details section when body is empty', () => {
+    const result = formatSingleCommit({ ...base, body: '' })
+    expect(result).not.toContain('Details:')
+  })
+
+  it('includes Details section when body is present', () => {
+    const result = formatSingleCommit({ ...base, body: 'Some extra context here.' })
+    expect(result).toContain('Details: Some extra context here.')
+  })
+
+  it('handles a hash shorter than 7 characters without throwing', () => {
+    // substring(0, 7) on a short string just returns the whole string
+    const result = formatSingleCommit({ ...base, hash: 'abc' })
+    expect(result).toContain('Commit: abc')
+  })
+
+  it('handles special characters in message and body', () => {
+    const result = formatSingleCommit({
+      ...base,
+      message: 'fix: handle `null` & <undefined>',
+      body: 'Fixes issue #42 — see PR "foo/bar"',
+    })
+    expect(result).toContain('fix: handle `null` & <undefined>')
+    expect(result).toContain('Fixes issue #42')
+  })
+})

--- a/src/lib/simple-git/getStatus.test.ts
+++ b/src/lib/simple-git/getStatus.test.ts
@@ -1,18 +1,97 @@
-import { getStatus } from './getStatus';
-import { FileStatusResult } from 'simple-git';
+import { getStatus } from './getStatus'
+import { FileStatusResult } from 'simple-git'
 
 describe('getStatus', () => {
-  it('should return correct status based on statusCode', () => {
-    const file: FileStatusResult = { path: 'file.txt', index: 'A', working_dir: 'M' };
+  describe('FileStatusResult (index / working_dir)', () => {
+    const file: FileStatusResult = { path: 'file.txt', index: 'A', working_dir: 'M' }
 
-    expect(getStatus(file)).toBe('added');
-    expect(getStatus(file, 'working_dir')).toBe('modified');
-  });
+    it('returns added for index "A"', () => {
+      expect(getStatus({ ...file, index: 'A' })).toBe('added')
+    })
 
-  it('should return unknown when the status is not recognized', () => {
-    const file: FileStatusResult = { path: 'file.txt', index: 'Z', working_dir: 'Z' };
+    it('returns deleted for index "D"', () => {
+      expect(getStatus({ ...file, index: 'D' })).toBe('deleted')
+    })
 
-    expect(getStatus(file)).toBe('unknown');
-    expect(getStatus(file, 'working_dir')).toBe('unknown');
-  });
-});
+    it('returns modified for index "M"', () => {
+      expect(getStatus({ ...file, index: 'M' })).toBe('modified')
+    })
+
+    it('returns renamed for index "R"', () => {
+      expect(getStatus({ ...file, index: 'R' })).toBe('renamed')
+    })
+
+    it('returns untracked for index "?"', () => {
+      expect(getStatus({ ...file, index: '?' })).toBe('untracked')
+    })
+
+    it('returns unknown for unrecognised index code', () => {
+      expect(getStatus({ ...file, index: 'Z' })).toBe('unknown')
+    })
+
+    it('reads from working_dir when location is specified', () => {
+      expect(getStatus({ ...file, working_dir: 'M' }, 'working_dir')).toBe('modified')
+      expect(getStatus({ ...file, working_dir: 'D' }, 'working_dir')).toBe('deleted')
+    })
+  })
+
+  describe('DiffResultTextFile / DiffResultBinaryFile (changes / binary)', () => {
+    const textFile = { file: 'file.ts', binary: false as const, changes: 5, insertions: 3, deletions: 2 }
+    const binaryFile = { file: 'image.png', binary: true as const, changes: 1, insertions: 0, deletions: 0 }
+
+    it('returns added when only insertions', () => {
+      expect(getStatus({ ...textFile, insertions: 5, deletions: 0 })).toBe('added')
+    })
+
+    it('returns deleted when only deletions', () => {
+      expect(getStatus({ ...textFile, insertions: 0, deletions: 5 })).toBe('deleted')
+    })
+
+    it('returns modified when both insertions and deletions', () => {
+      expect(getStatus({ ...textFile, insertions: 3, deletions: 2 })).toBe('modified')
+    })
+
+    it('returns modified when changes > 0 with zero insertions and deletions', () => {
+      expect(getStatus({ ...textFile, insertions: 0, deletions: 0, changes: 1 })).toBe('modified')
+    })
+
+    it('returns untracked when changes === 0', () => {
+      expect(getStatus({ ...textFile, changes: 0, insertions: 0, deletions: 0 })).toBe('untracked')
+    })
+
+    it('returns renamed when file path contains "=>"', () => {
+      expect(getStatus({ ...textFile, file: 'src/{old.ts => new.ts}', changes: 3 })).toBe('renamed')
+    })
+
+    it('returns untracked for a binary file with no changes', () => {
+      const binaryNoChange = { file: 'image.png', binary: true as const, before: 0, after: 0 }
+      expect(getStatus(binaryNoChange)).toBe('untracked')
+    })
+
+    it('returns added for a new binary file', () => {
+      const binaryAdded = { file: 'image.png', binary: true as const, before: 0, after: 1024 }
+      expect(getStatus(binaryAdded)).toBe('added')
+    })
+
+    it('returns deleted for a removed binary file', () => {
+      const binaryDeleted = { file: 'image.png', binary: true as const, before: 1024, after: 0 }
+      expect(getStatus(binaryDeleted)).toBe('deleted')
+    })
+
+    it('returns modified for a changed binary file', () => {
+      const binaryModified = { file: 'image.png', binary: true as const, before: 512, after: 1024 }
+      expect(getStatus(binaryModified)).toBe('modified')
+    })
+
+    it('returns renamed for a binary file with "=>" in path', () => {
+      const binaryRenamed = { file: 'assets/{old.png => new.png}', binary: true as const, before: 512, after: 512 }
+      expect(getStatus(binaryRenamed)).toBe('renamed')
+    })
+  })
+
+  describe('invalid file type', () => {
+    it('throws for an object that matches neither shape', () => {
+      expect(() => getStatus({} as never)).toThrow('Invalid file type')
+    })
+  })
+})

--- a/src/lib/simple-git/getStatus.ts
+++ b/src/lib/simple-git/getStatus.ts
@@ -30,7 +30,15 @@ export function getStatus(
       default:
         return 'unknown'
     }
+  } else if ('binary' in file && file.binary === true) {
+    // DiffResultBinaryFile: has before/after, no changes/insertions/deletions
+    if (file.file.includes('=>')) return 'renamed'
+    if (file.before === 0 && file.after > 0) return 'added'
+    if (file.after === 0 && file.before > 0) return 'deleted'
+    if (file.before > 0 && file.after > 0) return 'modified'
+    return 'untracked'
   } else if ('changes' in file && 'binary' in file) {
+    // DiffResultTextFile: has changes/insertions/deletions
     if (file.changes === 0) return 'untracked'
     if (file.file.includes('=>')) return 'renamed'
     if (file.deletions === 0 && file.insertions > 0) return 'added'

--- a/src/lib/simple-git/parseFileString.test.ts
+++ b/src/lib/simple-git/parseFileString.test.ts
@@ -1,0 +1,70 @@
+import { parseFileString } from './parseFileString'
+
+describe('parseFileString', () => {
+  describe('simple paths (no rename)', () => {
+    it('returns the trimmed path as filePath', () => {
+      expect(parseFileString('src/index.ts')).toEqual({
+        filePath: 'src/index.ts',
+        oldFilePath: undefined,
+      })
+    })
+
+    it('trims leading/trailing whitespace', () => {
+      expect(parseFileString('  src/index.ts  ')).toEqual({
+        filePath: 'src/index.ts',
+        oldFilePath: undefined,
+      })
+    })
+
+    it('handles a file at the root level', () => {
+      expect(parseFileString('README.md')).toEqual({
+        filePath: 'README.md',
+        oldFilePath: undefined,
+      })
+    })
+
+    it('handles deeply nested paths', () => {
+      expect(parseFileString('a/b/c/d/file.ts')).toEqual({
+        filePath: 'a/b/c/d/file.ts',
+        oldFilePath: undefined,
+      })
+    })
+  })
+
+  describe('rename paths (contains " => ")', () => {
+    it('parses a simple rename at root level', () => {
+      // git diff --stat format: "src/{old.ts => new.ts}"
+      const result = parseFileString('src/{old.ts => new.ts}')
+      expect(result.filePath).toBe('src/new.ts')
+      expect(result.oldFilePath).toBe('src/old.ts')
+    })
+
+    it('parses a rename with a shared root prefix', () => {
+      const result = parseFileString('src/lib/{utils.ts => helpers.ts}')
+      expect(result.filePath).toBe('src/lib/helpers.ts')
+      expect(result.oldFilePath).toBe('src/lib/utils.ts')
+    })
+
+    it('parses a rename where the directory changes', () => {
+      const result = parseFileString('src/{old/file.ts => new/file.ts}')
+      expect(result.filePath).toBe('src/new/file.ts')
+      expect(result.oldFilePath).toBe('src/old/file.ts')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles a path that is just whitespace after trim', () => {
+      expect(parseFileString('   ')).toEqual({
+        filePath: '',
+        oldFilePath: undefined,
+      })
+    })
+
+    it('does not treat a path containing "=>" (no spaces) as a rename', () => {
+      // Only " => " (with spaces) is the separator
+      const result = parseFileString('src/a=>b.ts')
+      expect(result.filePath).toBe('src/a=>b.ts')
+      expect(result.oldFilePath).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
- formatSingleCommit: new test file covering hash truncation, body presence/absence, special characters, and short hashes
- parseFileString: new test file covering simple paths, rename paths with shared root prefix, whitespace trimming, and edge cases
- getStatus: expand to cover DiffResultTextFile branch (added/deleted/ modified/untracked/renamed) and fix DiffResultBinaryFile handling
- formatCommitLog: add edge cases for empty log, empty body, multiple commits ordering, and special characters

fix: getStatus now correctly handles DiffResultBinaryFile (before/after) instead of throwing 'Invalid file type' for binary diffs