### PR TITLE
fix(tests): update imports for type safety

### DIFF
--- a/src/lib/autofix/index.test.ts
+++ b/src/lib/autofix/index.test.ts
@@ -32,10 +32,10 @@ describe('runAutoFix', () => {
   beforeEach(async () => {
     jest.clearAllMocks()
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const codexModule = await import('./adapters/codex') as any
+    const codexModule = await import('./adapters/codex') as { __mockRun: jest.Mock }
     mockRun = codexModule.__mockRun
     mockRun.mockResolvedValue(undefined)
-    const promptModule = await import('./buildPrompt') as any
+    const promptModule = await import('./buildPrompt') as { buildPrompt: typeof import('./buildPrompt').buildPrompt }
     buildPrompt = promptModule.buildPrompt
   })
 

--- a/src/lib/simple-git/getStatus.test.ts
+++ b/src/lib/simple-git/getStatus.test.ts
@@ -37,7 +37,6 @@ describe('getStatus', () => {
 
   describe('DiffResultTextFile / DiffResultBinaryFile (changes / binary)', () => {
     const textFile = { file: 'file.ts', binary: false as const, changes: 5, insertions: 3, deletions: 2 }
-    const binaryFile = { file: 'image.png', binary: true as const, changes: 1, insertions: 0, deletions: 0 }
 
     it('returns added when only insertions', () => {
       expect(getStatus({ ...textFile, insertions: 5, deletions: 0 })).toBe('added')


### PR DESCRIPTION
Refactor imports in `runAutoFix` and `getStatus` tests to improve type safety. Use specific type imports for `codexModule` and `promptModule` in `runAutoFix`. Remove unused `binaryFile` variable in `getStatus` test to clean up code and enhance readability.