### PR TITLE
fix: filter out `.gitignore` negation patterns (`!`) from ignoredFiles

### DIFF
--- a/src/lib/config/services/ignore.test.ts
+++ b/src/lib/config/services/ignore.test.ts
@@ -20,12 +20,27 @@ const defaultConfig: Config = {
 }
 
 describe('loadGitignore', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
   it('should load .gitignore', () => {
     mockFs.existsSync.mockReturnValue(true)
     mockFs.readFileSync.mockReturnValue('file.txt\n#comment\n')
     const config = loadGitignore(defaultConfig)
     expect(config.ignoredFiles).toContain('file.txt')
     expect(config.ignoredFiles).not.toContain('#comment')
+  })
+
+  it('should exclude negation patterns starting with !', () => {
+    mockFs.existsSync.mockReturnValue(true)
+    mockFs.readFileSync.mockReturnValue(
+      'node_modules\n!stacks/*/logs/\n!stacks/*/logs/**/.gitkeep\n#comment\n'
+    )
+    const config = loadGitignore(defaultConfig)
+    expect(config.ignoredFiles).toContain('node_modules')
+    expect(config.ignoredFiles).not.toContain('!stacks/*/logs/')
+    expect(config.ignoredFiles).not.toContain('!stacks/*/logs/**/.gitkeep')
   })
 })
 
@@ -40,5 +55,13 @@ describe('loadIgnore', () => {
     const config = loadIgnore(defaultConfig)
     expect(config.ignoredFiles).toContain('ignore.txt')
     expect(config.ignoredFiles).not.toContain('#comment')
+  })
+
+  it('should exclude negation patterns starting with !', () => {
+    mockFs.existsSync.mockReturnValue(true)
+    mockFs.readFileSync.mockReturnValue('dist\n!dist/keep.js\n#comment\n')
+    const config = loadIgnore(defaultConfig)
+    expect(config.ignoredFiles).toContain('dist')
+    expect(config.ignoredFiles).not.toContain('!dist/keep.js')
   })
 })

--- a/src/lib/config/services/ignore.ts
+++ b/src/lib/config/services/ignore.ts
@@ -13,7 +13,9 @@ export function loadGitignore<ConfigType = Config>(config: Partial<Config>) {
     
     config.ignoredFiles = [
       ...(config?.ignoredFiles || []),
-      ...gitignoreContent.split('\n').filter((line) => line.trim() !== '' && !line.startsWith('#')),
+      ...gitignoreContent
+        .split('\n')
+        .filter((line) => line.trim() !== '' && !line.startsWith('#') && !line.startsWith('!')),
     ]
   }
   return config as ConfigType
@@ -30,7 +32,9 @@ export function loadIgnore<ConfigType = Config>(config: Partial<Config>) {
     const ignoreContent = fs.readFileSync('.ignore', 'utf-8')
     config.ignoredFiles = [
       ...(config?.ignoredFiles || []),
-      ...ignoreContent.split('\n').filter((line) => line.trim() !== '' && !line.startsWith('#')),
+      ...ignoreContent
+        .split('\n')
+        .filter((line) => line.trim() !== '' && !line.startsWith('#') && !line.startsWith('!')),
     ]
   }
   return config as ConfigType


### PR DESCRIPTION
## Summary

Fixes #573

When a project's `.gitignore` contains negation patterns (lines starting with `!`), coco's `loadGitignore()` and `loadIgnore()` functions were adding them directly to the `ignoredFiles` array. Since `minimatch` interprets `!` as a negation operator, patterns like `!stacks/*/logs/**` match **everything except** that path — effectively filtering out all staged files and producing the "no summary generated" error.

## Changes

- `src/lib/config/services/ignore.ts` — Added `!line.startsWith('!')` filter to both `loadGitignore()` and `loadIgnore()` so negation patterns are skipped
- `src/lib/config/services/ignore.test.ts` — Added test cases for both functions verifying negation patterns are excluded

## Testing

```
 PASS  src/lib/config/services/ignore.test.ts
  loadGitignore
    ✓ should load .gitignore
    ✓ should exclude negation patterns starting with !
  loadIgnore
    ✓ should load .ignore
    ✓ should exclude negation patterns starting with !
```