### PR TITLE
fix: resolve TS2589 deep type instantiation errors from @langchain/core upgrade

### DIFF
--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -20,9 +20,10 @@ import { logSuccess } from '../../lib/ui/logSuccess'
 import { getDiffForCommit } from '../../lib/simple-git/getDiffForCommit'
 import { getDiffForBranch } from '../../lib/simple-git/getDiffForBranch'
 import {
-  ChangelogArgv,
-  ChangelogOptions,
-  ChangelogResponseSchema
+    ChangelogArgv,
+    ChangelogOptions,
+    ChangelogResponse,
+    ChangelogResponseSchema,
 } from './config'
 import { CHANGELOG_PROMPT } from './prompt'
 
@@ -161,7 +162,8 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
     factory,
     parser,
     agent: async (context, options) => {
-      const parser = createSchemaParser(ChangelogResponseSchema, llm)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const parser: any = createSchemaParser(ChangelogResponseSchema, llm)
 
       const prompt = getPrompt({
         template: options.prompt,
@@ -181,7 +183,7 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
         ? 'At the end of each item, attribute the author and include a reference to the commit hash, like this: `by @author_name (f6dbe61)`. Use the first 7 characters of the hash.'
         : 'At the end of each item, include a reference to the commit hash, like this: `(f6dbe61)`. Use the first 7 characters of the hash.'
 
-      const changelog = await executeChain({
+      const changelog = await executeChain<ChangelogResponse>({
         llm,
         prompt,
         variables: {

--- a/src/commands/recap/handler.ts
+++ b/src/commands/recap/handler.ts
@@ -177,9 +177,10 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
       })
 
       try {
-        const parser = createSchemaParser(RecapLlmResponseSchema, llm)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const parser: any = createSchemaParser(RecapLlmResponseSchema, llm)
         
-        const response = await executeChain({
+        const response = await executeChain<{ title: string; summary: string }>({
           llm,
           prompt,
           variables: {

--- a/src/commands/review/handler.ts
+++ b/src/commands/review/handler.ts
@@ -151,7 +151,8 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
     factory,
     parser,
     agent: async (context, options) => {
-      const parser = createSchemaParser(ReviewFeedbackResponseSchema, llm)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const parser: any = createSchemaParser(ReviewFeedbackResponseSchema, llm)
 
       const formatInstructions =
         "Respond with a valid JSON object, containing four fields:'title' a string, 'summary' a short summary of the problem (include line number if big file), 'severity' a numeric enum up to ten, 'category' an enum string, and 'filePath' a relative filepath to file as string."

--- a/src/lib/langchain/utils/createSchemaParser.ts
+++ b/src/lib/langchain/utils/createSchemaParser.ts
@@ -18,11 +18,13 @@ export interface SchemaParserOptions {
  * @returns StructuredOutputParser configured with the provided schema
  * @throws LangChainExecutionError if parser creation fails
  */
-export function createSchemaParser<S extends z.ZodType>(
-  schema: S,
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function createSchemaParser(
+  schema: z.ZodType,
   llm: ReturnType<typeof getLlm>,
   options: SchemaParserOptions = {}
-): StructuredOutputParser<S> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): any {
   validateRequired(schema, 'schema', 'createSchemaParser')
   validateRequired(llm, 'llm', 'createSchemaParser')
   validateRequired(options, 'options', 'createSchemaParser')
@@ -52,7 +54,8 @@ export function createSchemaParser<S extends z.ZodType>(
   }
 
   try {
-    return StructuredOutputParser.fromZodSchema(schema)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return StructuredOutputParser.fromZodSchema(schema as any)
   } catch (error) {
     handleLangChainError(error, 'createSchemaParser: Failed to create schema parser', {
       schemaName: schema.constructor.name,

--- a/src/lib/langchain/utils/executeChain.ts
+++ b/src/lib/langchain/utils/executeChain.ts
@@ -1,6 +1,5 @@
-import { BaseOutputParser } from '@langchain/core/output_parsers'
 import { PromptTemplate } from '@langchain/core/prompts'
-import { RunnableRetry } from '@langchain/core/runnables'
+import { Runnable } from '@langchain/core/runnables'
 import { handleLangChainError, isNetworkError } from '../errorHandler'
 import { LangChainExecutionError, LangChainNetworkError } from '../errors'
 import { validateRequired } from '../validation'
@@ -10,7 +9,8 @@ type ExecuteChainInput<T> = {
   variables: Record<string, unknown>
   prompt: PromptTemplate
   llm: ReturnType<typeof getLlm>
-  parser: BaseOutputParser<T> | RunnableRetry
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  parser: Runnable<any, T>
   /** Optional provider name for better error messages */
   provider?: string
   /** Optional endpoint URL for better error messages */
@@ -79,7 +79,7 @@ export const executeChain = async <T>({
 
   try {
     const chain = prompt.pipe(llm).pipe(parser)
-    const result = await chain.invoke(variables)
+    const result = (await chain.invoke(variables)) as T
 
     if (result === null || result === undefined) {
       throw new LangChainExecutionError(

--- a/src/lib/langchain/utils/executeChainWithSchema.ts
+++ b/src/lib/langchain/utils/executeChainWithSchema.ts
@@ -39,7 +39,8 @@ export async function executeChainWithSchema<T>(
     ...parserOptions
   } = options
   
-  const parser = createSchemaParser(schema, llm, parserOptions)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const parser: any = createSchemaParser(schema, llm, parserOptions)
 
   const operation = async (): Promise<T> => {
     const result = await executeChain({


### PR DESCRIPTION
The @langchain/core 1.1.32+ StructuredOutputParser types trigger infinite type recursion with Zod generics. Added targeted type casts in createSchemaParser, executeChain, executeChainWithSchema, and command handlers to break the recursive chain while preserving runtime behavior.