### PR TITLE
Skip large-file summaries when diffs fit

### DIFF
--- a/src/lib/parsers/default/utils/summarizeDiffs.test.ts
+++ b/src/lib/parsers/default/utils/summarizeDiffs.test.ts
@@ -125,6 +125,7 @@ describe('summarizeDiffs', () => {
   })
 
   it('should skip summarization when total tokens under maxTokens', async () => {
+    const preprocessLargeFilesMock = jest.requireMock('./summarizeLargeFiles').preprocessLargeFiles
     const rootNode: DiffNode = {
       path: '',
       diffs: [
@@ -145,6 +146,7 @@ describe('summarizeDiffs', () => {
 
     // Should contain raw diff, not summary
     expect(result).toContain('small change')
+    expect(preprocessLargeFilesMock).not.toHaveBeenCalled()
     expect(mockLogger.verbose).toHaveBeenCalledWith(
       expect.stringContaining('Already under token budget'),
       expect.any(Object)
@@ -214,16 +216,16 @@ describe('summarizeDiffs', () => {
     await summarizeDiffs(rootNode, {
       tokenizer: mockTokenizer,
       logger: mockLogger as never,
-      maxTokens: 2000,
+      maxTokens: 50,
       chain: mockChain,
       textSplitter: mockTextSplitter,
     })
 
-    // preprocessLargeFiles should be called with maxFileTokens = 500 (25% of 2000)
+    // preprocessLargeFiles should be called with maxFileTokens = 12 (25% of 50)
     expect(preprocessLargeFilesMock).toHaveBeenCalledWith(
       rootNode,
       expect.objectContaining({
-        maxFileTokens: 500,
+        maxFileTokens: 12,
       })
     )
   })
@@ -240,7 +242,7 @@ describe('summarizeDiffs', () => {
     await summarizeDiffs(rootNode, {
       tokenizer: mockTokenizer,
       logger: mockLogger as never,
-      maxTokens: 2000,
+      maxTokens: 50,
       maxFileTokens: 300, // Custom value
       chain: mockChain,
       textSplitter: mockTextSplitter,

--- a/src/lib/parsers/default/utils/summarizeDiffs.ts
+++ b/src/lib/parsers/default/utils/summarizeDiffs.ts
@@ -251,7 +251,28 @@ export async function summarizeDiffs(
   // Calculate maxFileTokens as 25% of maxTokens if not specified
   const effectiveMaxFileTokens = maxFileTokens ?? Math.floor(maxTokens * 0.25)
 
-  // PHASE 1: Pre-process large files
+  // PHASE 1: Directory grouping & assessment
+  logger.startTimer().startSpinner(`Organizing Diffs...`, { color: 'blue' })
+  let directoryDiffs = createDirectoryDiffs(rootDiffNode)
+
+  // Sort by token count descending for consistent output ordering
+  directoryDiffs.sort((a, b) => b.tokenCount - a.tokenCount)
+
+  let totalTokenCount = directoryDiffs.reduce((sum, group) => sum + group.tokenCount, 0)
+
+  logger.stopSpinner('Diffs Organized').stopTimer()
+
+  logger.verbose(`Total token count: ${totalTokenCount}, max allowed: ${maxTokens}`, {
+    color: totalTokenCount > maxTokens ? 'yellow' : 'green',
+  })
+
+  // Early exit if already under budget
+  if (totalTokenCount <= maxTokens) {
+    logger.verbose(`Already under token budget, skipping summarization.`, { color: 'green' })
+    return directoryDiffs.map(handleOutput).join('')
+  }
+
+  // PHASE 2: Pre-process large files only when the raw diff is over budget
   logger.startTimer().startSpinner(`Pre-processing large files...`, { color: 'blue' })
 
   const preprocessedNode = await preprocessLargeFiles(rootDiffNode, {
@@ -266,24 +287,16 @@ export async function summarizeDiffs(
 
   logger.stopSpinner('Files pre-processed').stopTimer()
 
-  // PHASE 2: Directory grouping & assessment
-  logger.startTimer().startSpinner(`Organizing Diffs...`, { color: 'blue' })
-  const directoryDiffs = createDirectoryDiffs(preprocessedNode)
-
-  // Sort by token count descending for consistent output ordering
+  directoryDiffs = createDirectoryDiffs(preprocessedNode)
   directoryDiffs.sort((a, b) => b.tokenCount - a.tokenCount)
+  totalTokenCount = directoryDiffs.reduce((sum, group) => sum + group.tokenCount, 0)
 
-  const totalTokenCount = directoryDiffs.reduce((sum, group) => sum + group.tokenCount, 0)
-
-  logger.stopSpinner('Diffs Organized').stopTimer()
-
-  logger.verbose(`Total token count: ${totalTokenCount}, max allowed: ${maxTokens}`, {
+  logger.verbose(`Total token count after file pre-processing: ${totalTokenCount}`, {
     color: totalTokenCount > maxTokens ? 'yellow' : 'green',
   })
 
-  // Early exit if already under budget
   if (totalTokenCount <= maxTokens) {
-    logger.verbose(`Already under token budget, skipping summarization.`, { color: 'green' })
+    logger.verbose(`Under token budget after file pre-processing.`, { color: 'green' })
     return directoryDiffs.map(handleOutput).join('')
   }
 


### PR DESCRIPTION
## Summary
- fixes #603
- checks the raw grouped diff token total before pre-summarizing large files
- returns raw diffs when they already fit within the configured budget
- updates condenser tests for the new early-exit behavior

## Validation
- `git diff --check`
- `./node_modules/.bin/jest src/lib/parsers/default/utils/summarizeDiffs.test.ts` fails before running tests because Jest cannot resolve the configured `ts-jest` preset in this sandbox.