### PR TITLE
Limit concurrent git diff collection

### DIFF
--- a/src/lib/parsers/default/index.ts
+++ b/src/lib/parsers/default/index.ts
@@ -39,7 +39,8 @@ export async function fileChangeParser({
     rootTreeNode,
     (path) => getDiff(path, commit, { git, logger }),
     tokenizer,
-    logger
+    logger,
+    maxConcurrent
   )
   logger.stopSpinner('Diffs Collected').stopTimer()
 

--- a/src/lib/parsers/default/utils/collectDiffs.test.ts
+++ b/src/lib/parsers/default/utils/collectDiffs.test.ts
@@ -1,0 +1,40 @@
+import { collectDiffs } from './collectDiffs'
+import { createDiffTree } from './createDiffTree'
+import { FileChange } from '../../../types'
+
+describe('collectDiffs', () => {
+  const logger = {
+    verbose: jest.fn().mockReturnThis(),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('limits concurrent file diff collection', async () => {
+    const changes: FileChange[] = Array.from({ length: 5 }, (_, index) => ({
+      filePath: `src/file${index}.ts`,
+      status: 'modified',
+      summary: `modified src/file${index}.ts`,
+    }))
+
+    const tree = createDiffTree(changes)
+    let active = 0
+    let maxActive = 0
+
+    const getFileDiff = jest.fn(async (change: FileChange) => {
+      active++
+      maxActive = Math.max(maxActive, active)
+
+      await new Promise((resolve) => setTimeout(resolve, 5))
+
+      active--
+      return `diff for ${change.filePath}`
+    })
+
+    await collectDiffs(tree, getFileDiff, (text) => text.length, logger as never, 2)
+
+    expect(getFileDiff).toHaveBeenCalledTimes(5)
+    expect(maxActive).toBeLessThanOrEqual(2)
+  })
+})

--- a/src/lib/parsers/default/utils/collectDiffs.ts
+++ b/src/lib/parsers/default/utils/collectDiffs.ts
@@ -3,6 +3,34 @@ import { Logger } from '../../../utils/logger'
 import { DiffTreeNode } from './createDiffTree'
 import { TokenCounter } from '../../../utils/tokenizer'
 
+type Limit = <T>(operation: () => Promise<T>) => Promise<T>
+
+function createLimit(maxConcurrent: number): Limit {
+  const limit = Math.max(1, maxConcurrent)
+  let active = 0
+  const queue: (() => void)[] = []
+
+  const runNext = () => {
+    active--
+    const next = queue.shift()
+    if (next) next()
+  }
+
+  return async <T>(operation: () => Promise<T>): Promise<T> => {
+    if (active >= limit) {
+      await new Promise<void>((resolve) => queue.push(resolve))
+    }
+
+    active++
+
+    try {
+      return await operation()
+    } finally {
+      runNext()
+    }
+  }
+}
+
 /**
  * Asynchronously collect diffs for a given node and its children.
  */
@@ -10,10 +38,12 @@ export async function collectDiffs(
   node: DiffTreeNode,
   getFileDiff: (change: FileChange) => Promise<string>,
   tokenizer: TokenCounter,
-  logger: Logger
+  logger: Logger,
+  maxConcurrent = 6,
+  limit: Limit = createLimit(maxConcurrent)
 ): Promise<DiffNode> {
   // Collect diffs for the files of the current node
-  const diffPromises = node.files.map(async (nodeFile) => {
+  const diffPromises = node.files.map((nodeFile) => limit(async () => {
     const diff = await getFileDiff(nodeFile)
     const tokenCount = tokenizer(diff)
 
@@ -27,11 +57,11 @@ export async function collectDiffs(
       diff,
       tokenCount,
     }
-  })
+  }))
 
   // Collect diffs for the children of the current node
   const childrenPromises = Array.from(node.children.values()).map(async (child) =>
-    collectDiffs(child, getFileDiff, tokenizer, logger)
+    collectDiffs(child, getFileDiff, tokenizer, logger, maxConcurrent, limit)
   )
 
   const [diffs, children] = await Promise.all([


### PR DESCRIPTION
## Summary
- fixes #602
- adds a bounded concurrency limiter around per-file diff collection
- passes parser `maxConcurrent` through to `collectDiffs`
- adds coverage for the concurrency cap

## Validation
- `git diff --check`
- `./node_modules/.bin/jest src/lib/parsers/default/utils/collectDiffs.test.ts` fails before running tests because Jest cannot resolve the configured `ts-jest` preset in this sandbox.