### PR TITLE
Enforce rendered prompt token budgets

### DIFF
--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -1,7 +1,9 @@
+import { type TiktokenModel } from '@langchain/openai'
 import { getApiKeyForModel, getModelAndProviderFromConfig } from '../../lib/langchain/utils'
 import { getLlm } from '../../lib/langchain/utils/getLlm'
 import { getPrompt } from '../../lib/langchain/utils/getPrompt'
 import { createSchemaParser } from '../../lib/langchain/utils/createSchemaParser'
+import { enforcePromptBudget } from '../../lib/langchain/utils/enforcePromptBudget'
 import { loadConfig } from '../../lib/config/utils/loadConfig'
 import { executeChain } from '../../lib/langchain/utils/executeChain'
 import { extractTicketIdFromBranchName } from '../../lib/simple-git/extractTicketIdFromBranchName'
@@ -19,6 +21,7 @@ import { LOGO, isInteractive } from '../../lib/ui/helpers'
 import { logSuccess } from '../../lib/ui/logSuccess'
 import { getDiffForCommit } from '../../lib/simple-git/getDiffForCommit'
 import { getDiffForBranch } from '../../lib/simple-git/getDiffForBranch'
+import { getTokenCounter } from '../../lib/utils/tokenizer'
 import {
     ChangelogArgv,
     ChangelogOptions,
@@ -59,6 +62,9 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
   }
 
   const llm = getLlm(provider, model, config)
+  const tokenizer = await getTokenCounter(
+    provider === 'openai' ? (model as TiktokenModel) : 'gpt-4o'
+  )
 
   const INTERACTIVE = isInteractive(config)
 
@@ -183,15 +189,31 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
         ? 'At the end of each item, attribute the author and include a reference to the commit hash, like this: `by @author_name (f6dbe61)`. Use the first 7 characters of the hash.'
         : 'At the end of each item, include a reference to the commit hash, like this: `(f6dbe61)`. Use the first 7 characters of the hash.'
 
+      const variables = {
+        summary: context,
+        format_instructions: formatInstructions,
+        additional_context: additional_context,
+        author_instructions: author_instructions,
+      }
+
+      const budgetedPrompt = await enforcePromptBudget({
+        prompt,
+        variables,
+        tokenizer,
+        maxTokens: config.service.tokenLimit || 2048,
+      })
+
+      if (budgetedPrompt.truncated) {
+        logger.verbose(
+          `Rendered prompt exceeded token budget; trimmed summary to ${budgetedPrompt.promptTokenCount} tokens.`,
+          { color: 'yellow' }
+        )
+      }
+
       const changelog = await executeChain<ChangelogResponse>({
         llm,
         prompt,
-        variables: {
-          summary: context,
-          format_instructions: formatInstructions,
-          additional_context: additional_context,
-          author_instructions: author_instructions,
-        },
+        variables: budgetedPrompt.variables,
         parser,
       })
 

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -2,6 +2,7 @@ import { type TiktokenModel } from '@langchain/openai'
 import { loadConfig } from '../../lib/config/utils/loadConfig'
 import { getApiKeyForModel, getModelAndProviderFromConfig } from '../../lib/langchain/utils'
 import { executeChainWithSchema } from '../../lib/langchain/utils/executeChainWithSchema'
+import { enforcePromptBudget } from '../../lib/langchain/utils/enforcePromptBudget'
 import { formatCommitMessage } from '../../lib/langchain/utils/formatCommitMessage'
 import { getLlm } from '../../lib/langchain/utils/getLlm'
 import { getPrompt } from '../../lib/langchain/utils/getPrompt'
@@ -272,7 +273,21 @@ IMPORTANT RULES:
             : variables.additional_context,
         }
 
-        const commitMsg = await executeChainWithSchema(schema, llm, prompt, currentVariables, {
+        const budgetedPrompt = await enforcePromptBudget({
+          prompt,
+          variables: currentVariables,
+          tokenizer,
+          maxTokens: config.service.tokenLimit || 2048,
+        })
+
+        if (budgetedPrompt.truncated) {
+          logger.verbose(
+            `Rendered prompt exceeded token budget; trimmed summary to ${budgetedPrompt.promptTokenCount} tokens.`,
+            { color: 'yellow' }
+          )
+        }
+
+        const commitMsg = await executeChainWithSchema(schema, llm, prompt, budgetedPrompt.variables, {
           retryOptions: {
             maxAttempts,
             onRetry: (attempt: number, error: Error) => {

--- a/src/lib/langchain/utils/enforcePromptBudget.test.ts
+++ b/src/lib/langchain/utils/enforcePromptBudget.test.ts
@@ -1,0 +1,60 @@
+import { PromptTemplate } from '@langchain/core/prompts'
+import { enforcePromptBudget } from './enforcePromptBudget'
+
+describe('enforcePromptBudget', () => {
+  const tokenizer = (text: string) => text.length
+  const prompt = new PromptTemplate({
+    template: 'Instructions\n{summary}\nContext: {additional_context}',
+    inputVariables: ['summary', 'additional_context'],
+  })
+
+  it('keeps variables unchanged when the rendered prompt fits', async () => {
+    const variables = {
+      summary: 'small diff',
+      additional_context: 'ticket context',
+    }
+
+    const result = await enforcePromptBudget({
+      prompt,
+      variables,
+      tokenizer,
+      maxTokens: 100,
+      responseTokenReserve: 10,
+    })
+
+    expect(result.truncated).toBe(false)
+    expect(result.variables).toEqual(variables)
+  })
+
+  it('trims summary when prompt overhead pushes the rendered prompt over budget', async () => {
+    const result = await enforcePromptBudget({
+      prompt,
+      variables: {
+        summary: 'x'.repeat(200),
+        additional_context: 'context',
+      },
+      tokenizer,
+      maxTokens: 80,
+      responseTokenReserve: 10,
+    })
+
+    expect(result.truncated).toBe(true)
+    expect(result.variables.summary.length).toBeLessThan(200)
+    expect(tokenizer(await prompt.format(result.variables))).toBeLessThanOrEqual(70)
+  })
+
+  it('throws when prompt overhead alone exceeds the budget', async () => {
+    await expect(
+      enforcePromptBudget({
+        prompt,
+        variables: {
+          summary: 'diff',
+          additional_context: 'context'.repeat(20),
+        },
+        tokenizer,
+        maxTokens: 20,
+        responseTokenReserve: 10,
+      })
+    ).rejects.toThrow('Rendered prompt exceeds token budget')
+  })
+})

--- a/src/lib/langchain/utils/enforcePromptBudget.ts
+++ b/src/lib/langchain/utils/enforcePromptBudget.ts
@@ -1,0 +1,90 @@
+import { PromptTemplate } from '@langchain/core/prompts'
+import { TokenCounter } from '../../utils/tokenizer'
+
+export type EnforcePromptBudgetInput = {
+  prompt: PromptTemplate
+  variables: Record<string, string>
+  tokenizer: TokenCounter
+  maxTokens: number
+  summaryKey?: string
+  responseTokenReserve?: number
+}
+
+export type EnforcePromptBudgetResult = {
+  variables: Record<string, string>
+  promptTokenCount: number
+  truncated: boolean
+}
+
+/**
+ * Ensure the fully rendered LLM prompt fits the configured request budget.
+ *
+ * Diff condensation budgets only cover the diff summary itself. This guard accounts
+ * for the rest of the rendered prompt, then trims the summary as a deterministic
+ * fallback when additional context pushes the request over budget.
+ */
+export async function enforcePromptBudget({
+  prompt,
+  variables,
+  tokenizer,
+  maxTokens,
+  summaryKey = 'summary',
+  responseTokenReserve = 512,
+}: EnforcePromptBudgetInput): Promise<EnforcePromptBudgetResult> {
+  const renderedPrompt = await prompt.format(variables)
+  const promptTokenCount = tokenizer(renderedPrompt)
+
+  if (promptTokenCount <= maxTokens) {
+    return { variables, promptTokenCount, truncated: false }
+  }
+
+  const summary = variables[summaryKey] || ''
+  const variablesWithoutSummary = { ...variables, [summaryKey]: '' }
+  const overheadTokenCount = tokenizer(await prompt.format(variablesWithoutSummary))
+  const summaryBudget = Math.max(0, maxTokens - overheadTokenCount - responseTokenReserve)
+
+  if (summaryBudget === 0) {
+    const emptySummaryVariables = { ...variables, [summaryKey]: '' }
+    const emptySummaryTokenCount = tokenizer(await prompt.format(emptySummaryVariables))
+
+    if (emptySummaryTokenCount > maxTokens) {
+      throw new Error(
+        `Rendered prompt exceeds token budget before adding ${summaryKey}: ` +
+        `${emptySummaryTokenCount} > ${maxTokens}`
+      )
+    }
+
+    return {
+      variables: emptySummaryVariables,
+      promptTokenCount: emptySummaryTokenCount,
+      truncated: true,
+    }
+  }
+
+  let low = 0
+  let high = summary.length
+  let bestSummary = ''
+  let bestTokenCount = overheadTokenCount
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2)
+    const candidateSummary = summary.slice(0, mid)
+    const candidateVariables = { ...variables, [summaryKey]: candidateSummary }
+    const candidateTokenCount = tokenizer(await prompt.format(candidateVariables))
+
+    if (candidateTokenCount <= maxTokens - responseTokenReserve) {
+      bestSummary = candidateSummary
+      bestTokenCount = candidateTokenCount
+      low = mid + 1
+    } else {
+      high = mid - 1
+    }
+  }
+
+  const trimmedVariables = { ...variables, [summaryKey]: bestSummary.trimEnd() }
+  return {
+    variables: trimmedVariables,
+    promptTokenCount: bestTokenCount,
+    truncated: true,
+  }
+}


### PR DESCRIPTION
## Summary
- fixes #601
- adds a reusable rendered prompt budget guard
- trims `summary` deterministically when prompt/context overhead would exceed the configured service token limit
- applies the guard to commit and changelog generation before invoking the LLM

## Validation
- `git diff --check`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint src/lib/langchain/utils/enforcePromptBudget.ts src/lib/langchain/utils/enforcePromptBudget.test.ts src/commands/commit/handler.ts src/commands/changelog/handler.ts`
- `./node_modules/.bin/jest src/lib/langchain/utils/enforcePromptBudget.test.ts` fails before running tests because Jest cannot resolve the configured `ts-jest` preset in this sandbox.