### PR TITLE
Add temp git repo command integration coverage

### DIFF
--- a/src/commands/commands.integration.test.ts
+++ b/src/commands/commands.integration.test.ts
@@ -1,0 +1,204 @@
+import { Arguments } from 'yargs'
+import { handler as changelogHandler } from './changelog/handler'
+import { ChangelogOptions } from './changelog/config'
+import { handler as commitHandler } from './commit/handler'
+import { CommitOptions } from './commit/config'
+import { loadConfig } from '../lib/config/utils/loadConfig'
+import { executeChain } from '../lib/langchain/utils/executeChain'
+import { executeChainWithSchema } from '../lib/langchain/utils/executeChainWithSchema'
+import { getLlm } from '../lib/langchain/utils/getLlm'
+import { getTokenCounter } from '../lib/utils/tokenizer'
+import { Logger } from '../lib/utils/logger'
+import { Config } from '../commands/types'
+import { createTempGitRepo, TempGitRepo } from '../lib/testUtils/tempGitRepo'
+
+jest.mock('@langchain/classic/chains', () => ({
+  loadSummarizationChain: jest.fn().mockReturnValue({}),
+}))
+
+jest.mock('../lib/config/utils/loadConfig')
+jest.mock('../lib/langchain/utils', () => {
+  const actual = jest.requireActual('../lib/langchain/utils')
+
+  return {
+    ...actual,
+    getApiKeyForModel: jest.fn().mockReturnValue('mock-api-key'),
+    getModelAndProviderFromConfig: jest.fn().mockReturnValue({
+      provider: 'openai',
+      model: 'gpt-4o',
+    }),
+  }
+})
+jest.mock('../lib/langchain/utils/createSchemaParser', () => ({
+  createSchemaParser: jest.fn().mockReturnValue({}),
+}))
+jest.mock('../lib/langchain/utils/executeChain')
+jest.mock('../lib/langchain/utils/executeChainWithSchema')
+jest.mock('../lib/langchain/utils/getLlm')
+jest.mock('../lib/utils/tokenizer')
+jest.mock('../lib/ui/logSuccess', () => ({
+  logSuccess: jest.fn(),
+}))
+jest.mock('../lib/utils/hasCommitlintConfig', () => ({
+  hasCommitlintConfig: jest.fn().mockResolvedValue(false),
+}))
+
+const mockLoadConfig = loadConfig as jest.MockedFunction<typeof loadConfig>
+const mockExecuteChain = executeChain as jest.MockedFunction<typeof executeChain>
+const mockExecuteChainWithSchema = executeChainWithSchema as jest.MockedFunction<
+  typeof executeChainWithSchema
+>
+const mockGetLlm = getLlm as jest.MockedFunction<typeof getLlm>
+const mockGetTokenCounter = getTokenCounter as jest.MockedFunction<typeof getTokenCounter>
+
+jest.setTimeout(15000)
+
+const serviceConfig = {
+  authentication: {
+    type: 'APIKey',
+    credentials: {
+      apiKey: 'mock-api-key',
+    },
+  },
+  provider: 'openai',
+  model: 'gpt-4o',
+  tokenLimit: 4096,
+  temperature: 0.2,
+  maxConcurrent: 2,
+  minTokensForSummary: 400,
+  maxFileTokens: 2000,
+}
+
+function createConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    service: serviceConfig,
+    defaultBranch: 'main',
+    mode: 'stdout',
+    interactive: false,
+    ignoredFiles: [],
+    ignoredExtensions: [],
+    includeBranchName: false,
+    conventionalCommits: false,
+    openInEditor: false,
+    noVerify: true,
+    ...overrides,
+  } as unknown as Config
+}
+
+function createLogger(): Logger {
+  return {
+    log: jest.fn(),
+    verbose: jest.fn(),
+    setConfig: jest.fn(),
+    startTimer: jest.fn().mockReturnThis(),
+    stopTimer: jest.fn().mockReturnThis(),
+    startSpinner: jest.fn().mockReturnThis(),
+    stopSpinner: jest.fn().mockReturnThis(),
+  } as unknown as Logger
+}
+
+describe('command integration with temp git repos', () => {
+  const originalCwd = process.cwd()
+  let repo: TempGitRepo
+  let stdout = ''
+  let stdoutSpy: jest.SpyInstance
+
+  beforeEach(async () => {
+    repo = await createTempGitRepo()
+    process.chdir(repo.path)
+    stdout = ''
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdout += String(chunk)
+      return true
+    })
+
+    mockGetLlm.mockReturnValue({} as unknown as ReturnType<typeof getLlm>)
+    mockGetTokenCounter.mockResolvedValue((text: string) => Math.ceil(text.length / 4))
+    mockExecuteChain.mockResolvedValue({
+      title: 'Generated changelog',
+      content: '- Summarized feature work',
+    })
+    mockExecuteChainWithSchema.mockResolvedValue({
+      title: 'test: commit staged readme',
+      body: 'Commit the staged README file.',
+    })
+  })
+
+  afterEach(async () => {
+    stdoutSpy.mockRestore()
+    jest.clearAllMocks()
+    process.chdir(originalCwd)
+    await repo.cleanup()
+  })
+
+  it('generates a commit message from real staged git status and diff collection', async () => {
+    mockLoadConfig.mockReturnValue(createConfig({
+      mode: 'stdout',
+    }))
+
+    await repo.writeFile('.gitkeep', '\n')
+    await repo.commitAll('chore: initial commit')
+    await repo.writeFile('README.md', '# Temp repo\n')
+    await repo.git.add('README.md')
+
+    await commitHandler({
+      $0: 'coco',
+      _: ['commit'],
+      interactive: false,
+      openInEditor: false,
+      ignoredFiles: [],
+      ignoredExtensions: [],
+      withPreviousCommits: 0,
+      conventional: false,
+      includeBranchName: false,
+      noDiff: false,
+      noVerify: true,
+      verbose: false,
+      version: false,
+      help: false,
+    } as Arguments<CommitOptions>, createLogger())
+
+    const status = await repo.git.status()
+    const variables = mockExecuteChainWithSchema.mock.calls[0][3] as Record<string, string>
+
+    expect(stdout).toContain('test: commit staged readme')
+    expect(status.staged).toContain('README.md')
+    expect(variables.summary).toContain('README.md')
+    expect(variables.summary).toContain('# Temp repo')
+  })
+
+  it('generates a changelog from real branch commit history', async () => {
+    mockLoadConfig.mockImplementation((argv) => createConfig({
+      ...(argv as Record<string, unknown>),
+      mode: 'stdout',
+    }))
+
+    await repo.writeFile('README.md', '# Temp repo\n')
+    await repo.commitAll('chore: initial commit')
+    await repo.git.checkoutLocalBranch('feature/changelog-test')
+    await repo.writeFile('src/feature.ts', 'export const feature = true\n')
+    await repo.commitAll('feat: add feature module')
+
+    await changelogHandler({
+      $0: 'coco',
+      _: ['changelog'],
+      branch: 'main',
+      range: '',
+      tag: '',
+      sinceLastTag: false,
+      withDiff: false,
+      onlyDiff: false,
+      interactive: false,
+      verbose: false,
+      version: false,
+      help: false,
+    } as Arguments<ChangelogOptions>, createLogger())
+
+    const variables = mockExecuteChain.mock.calls[0][0].variables as Record<string, string>
+
+    expect(stdout).toContain('Generated changelog')
+    expect(stdout).toContain('- Summarized feature work')
+    expect(variables.summary).toContain('feat: add feature module')
+    expect(variables.summary).toContain('feature/changelog-test')
+  })
+})

--- a/src/lib/testUtils/tempGitRepo.ts
+++ b/src/lib/testUtils/tempGitRepo.ts
@@ -1,0 +1,42 @@
+import { mkdir, mkdtemp, rm, writeFile as writeFileContent } from 'fs/promises'
+import { tmpdir } from 'os'
+import { dirname, join } from 'path'
+import { simpleGit, SimpleGit } from 'simple-git'
+
+export type TempGitRepo = {
+  path: string
+  git: SimpleGit
+  writeFile: (filePath: string, content: string) => Promise<void>
+  commitAll: (message: string) => Promise<void>
+  cleanup: () => Promise<void>
+}
+
+export async function createTempGitRepo(): Promise<TempGitRepo> {
+  const path = await mkdtemp(join(tmpdir(), 'coco-git-test-'))
+  const git = simpleGit(path)
+
+  await git.init()
+  await git.addConfig('user.name', 'Coco Test')
+  await git.addConfig('user.email', 'coco@example.com')
+  await git.addConfig('commit.gpgsign', 'false')
+  await git.raw(['checkout', '-b', 'main'])
+
+  const writeFile = async (filePath: string, content: string) => {
+    const absolutePath = join(path, filePath)
+    await mkdir(dirname(absolutePath), { recursive: true })
+    await writeFileContent(absolutePath, content)
+  }
+
+  return {
+    path,
+    git,
+    writeFile,
+    commitAll: async (message: string) => {
+      await git.add('.')
+      await git.commit(message)
+    },
+    cleanup: async () => {
+      await rm(path, { recursive: true, force: true })
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a reusable temp git repo test helper with local git identity and cleanup
- Adds command integration coverage for commit using real staged status and diff collection
- Adds changelog integration coverage using real branch commit history
- Keeps remote LLM calls mocked for deterministic tests

Fixes #613

## Validation
- npm run test:jest -- --runTestsByPath src/commands/commands.integration.test.ts
- npm test