### PR TITLE
Add LLM call observability and AI call audit

### DIFF
--- a/docs/AI_CALL_AUDIT.md
+++ b/docs/AI_CALL_AUDIT.md
@@ -1,0 +1,57 @@
+# AI Call Audit
+
+This audit inventories the remote AI call paths in Coco as of `0.32.0` and defines the
+observability fields needed before dynamic model routing.
+
+## Call Sites
+
+| Subsystem | Entry point | Task metadata | Current input source | Budget behavior | Retry behavior |
+| --- | --- | --- | --- | --- | --- |
+| Commit | `src/commands/commit/handler.ts` | `commit-message`, `commit-message-conventional` | Staged file summaries from `fileChangeParser` | `enforcePromptBudget` trims `summary` before the final LLM call | Schema parsing retries up to provider/config limits; commitlint can trigger regeneration |
+| Changelog | `src/commands/changelog/handler.ts` | `changelog`, `changelog-with-diff`, `changelog-only-diff` | Commit log details, optional condensed commit diffs, or branch diff summary | `enforcePromptBudget` trims `summary` before the final LLM call | Single chain call today |
+| Recap | `src/commands/recap/handler.ts` | `recap` | Current changes or commit history for a timeframe | No explicit final prompt budget enforcement yet | Single chain call with fallback text on parsing errors |
+| Review | `src/commands/review/handler.ts` | `review`, `review-branch` | Staged, unstaged, untracked, or branch diff summaries | No explicit final prompt budget enforcement yet | Single chain call today |
+| Diff summarization | `src/lib/parsers/default/utils/summarizeDiffs.ts` | `summarize-directory-diff` | Directory-grouped file diffs | Stops once condensed diff groups are below `maxTokens`; processes in bounded waves | No retry beyond chain internals |
+| Large-file summarization | `src/lib/parsers/default/utils/summarizeLargeFiles.ts` | `summarize-large-file` | Individual file diffs over `maxFileTokens` | Runs only when the whole diff is already over budget | Returns original diff on summary failure |
+| Autofix | `src/lib/autofix` | External CLI, not LangChain | Review findings and user-selected fixes | No LLM provider call inside Coco; delegates to configured CLI | Adapter-specific process behavior |
+
+## Runtime Observability
+
+Verbose logging now emits structured, prompt-safe metadata from the shared LangChain paths:
+
+```text
+[llm] task=commit-message command=commit provider=openai model=gpt-4o retryAttempt=1 promptTokens=1180 variableKeys=summary,format_instructions,additional_context
+```
+
+Logged fields intentionally exclude API keys, raw prompt content, diff content, and model output. The current fields are:
+
+- `task`: the workflow-specific operation.
+- `command`: CLI command when applicable.
+- `provider` and `model`: selected service identity when known.
+- `retryAttempt`: schema-chain attempt count when available.
+- `promptTokens`: tokenizer-based estimate of rendered prompt or summarization input.
+- `inputDocuments` and `inputChunks`: summarization input shape.
+- `parser`: parser class name when known.
+- `variableKeys`: prompt variable names only, not values.
+
+## Model Strategy Notes
+
+Lower-risk cheaper/faster candidates:
+
+- `summarize-large-file` and `summarize-directory-diff`: usually extractive compression; good candidates for smaller or faster models.
+- `recap`: often lower-risk prose when not used for commit history decisions.
+- Changelog without diffs: structured commit metadata tends to need less context than raw diff analysis.
+
+Higher-context or higher-quality candidates:
+
+- `commit-message` when summaries include many unrelated changes or commitlint retries occur.
+- `changelog-with-diff` and `changelog-only-diff` for large branch diffs.
+- `review` and `review-branch`, where missing an issue is more costly than prose quality variation.
+
+## Follow-Ups
+
+- Add persisted aggregate counters for total LLM operations per command run.
+- Add optional estimated cost calculation once provider model pricing is configurable.
+- Route summarization tasks to cheaper dynamic-model profile entries.
+- Route large branch diff and review tasks to larger-context profile entries.
+- Add final prompt-budget enforcement to recap and review, matching commit/changelog behavior.

--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -280,6 +280,14 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
         prompt,
         variables: budgetedPrompt.variables,
         parser,
+        logger,
+        tokenizer,
+        metadata: {
+          task: argv.withDiff ? 'changelog-with-diff' : argv.onlyDiff ? 'changelog-only-diff' : 'changelog',
+          command: 'changelog',
+          provider,
+          model,
+        },
       })
 
       const branchName = await getCurrentBranchName({ git })

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -288,6 +288,14 @@ IMPORTANT RULES:
         }
 
         const commitMsg = await executeChainWithSchema(schema, llm, prompt, budgetedPrompt.variables, {
+          logger,
+          tokenizer,
+          metadata: {
+            task: USE_CONVENTIONAL_COMMITS ? 'commit-message-conventional' : 'commit-message',
+            command: 'commit',
+            provider,
+            model,
+          },
           retryOptions: {
             maxAttempts,
             onRetry: (attempt: number, error: Error) => {

--- a/src/commands/recap/handler.ts
+++ b/src/commands/recap/handler.ts
@@ -189,6 +189,14 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
             timeframe,
           },
           parser,
+          logger,
+          tokenizer,
+          metadata: {
+            task: 'recap',
+            command: 'recap',
+            provider,
+            model,
+          },
         })
 
         return response ? `${response.title}\n\n${response.summary}` : 'no response'

--- a/src/commands/review/handler.ts
+++ b/src/commands/review/handler.ts
@@ -171,6 +171,14 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
           format_instructions: formatInstructions,
         },
         parser,
+        logger,
+        tokenizer,
+        metadata: {
+          task: argv.branch ? 'review-branch' : 'review',
+          command: 'review',
+          provider,
+          model,
+        },
       }) as ReviewFeedbackItem[]
 
       // sort by severity

--- a/src/lib/langchain/chains/summarize/index.ts
+++ b/src/lib/langchain/chains/summarize/index.ts
@@ -5,6 +5,9 @@ import {
 } from '@langchain/classic/chains'
 import { Document, DocumentInput } from '@langchain/classic/document'
 import { RecursiveCharacterTextSplitter } from '@langchain/textsplitters'
+import { Logger } from '../../../utils/logger'
+import { TokenCounter } from '../../../utils/tokenizer'
+import { LlmCallMetadata, logLlmCall } from '../../utils/observability'
 
 export type SummarizeContext = {
   textSplitter: RecursiveCharacterTextSplitter
@@ -12,15 +15,29 @@ export type SummarizeContext = {
   options?: {
     returnIntermediateSteps?: boolean
   }
+  logger?: Logger
+  tokenizer?: TokenCounter
+  metadata?: Partial<LlmCallMetadata>
 }
 
 export async function summarize(
   documents: DocumentInput[],
-  { chain, textSplitter, options }: SummarizeContext
+  { chain, textSplitter, options, logger, tokenizer, metadata }: SummarizeContext
 ): Promise<string> {
   const { returnIntermediateSteps = false } = options || {}
 
   const docs = await textSplitter.splitDocuments(documents.map((doc) => new Document(doc)))
+  const promptTokens = tokenizer
+    ? docs.reduce((sum, doc) => sum + tokenizer(doc.pageContent), 0)
+    : undefined
+
+  logLlmCall(logger, {
+    task: 'summarize',
+    promptTokens,
+    inputDocuments: documents.length,
+    inputChunks: docs.length,
+    ...metadata,
+  })
 
   const res = await chain.invoke({
     input_documents: docs,

--- a/src/lib/langchain/utils/executeChain.ts
+++ b/src/lib/langchain/utils/executeChain.ts
@@ -4,6 +4,9 @@ import { handleLangChainError, isNetworkError } from '../errorHandler'
 import { LangChainExecutionError, LangChainNetworkError } from '../errors'
 import { validateRequired } from '../validation'
 import { getLlm } from './getLlm'
+import { Logger } from '../../utils/logger'
+import { TokenCounter } from '../../utils/tokenizer'
+import { estimatePromptTokens, LlmCallMetadata, logLlmCall } from './observability'
 
 type ExecuteChainInput<T> = {
   variables: Record<string, unknown>
@@ -15,6 +18,9 @@ type ExecuteChainInput<T> = {
   provider?: string
   /** Optional endpoint URL for better error messages */
   endpoint?: string
+  logger?: Logger
+  tokenizer?: TokenCounter
+  metadata?: Partial<LlmCallMetadata>
 }
 
 /**
@@ -57,6 +63,9 @@ export const executeChain = async <T>({
   parser,
   provider,
   endpoint,
+  logger,
+  tokenizer,
+  metadata,
 }: ExecuteChainInput<T>): Promise<T> => {
   validateRequired(llm, 'llm', 'executeChain')
   validateRequired(prompt, 'prompt', 'executeChain')
@@ -78,6 +87,18 @@ export const executeChain = async <T>({
   const effectiveEndpoint = endpoint || llmInfo.endpoint
 
   try {
+    const renderedPrompt = await prompt.format(variables)
+    const promptTokens = estimatePromptTokens(tokenizer, renderedPrompt)
+
+    logLlmCall(logger, {
+      task: metadata?.task || 'chain',
+      provider: effectiveProvider,
+      parserType: parser.constructor.name,
+      variableKeys: Object.keys(variables),
+      promptTokens,
+      ...metadata,
+    })
+
     const chain = prompt.pipe(llm).pipe(parser)
     const result = (await chain.invoke(variables)) as T
 

--- a/src/lib/langchain/utils/executeChainWithSchema.ts
+++ b/src/lib/langchain/utils/executeChainWithSchema.ts
@@ -2,9 +2,12 @@ import { StringOutputParser } from '@langchain/core/output_parsers'
 import { PromptTemplate } from '@langchain/core/prompts'
 import { z } from 'zod'
 import { withRetry, type RetryOptions } from '../../utils/retry'
+import { Logger } from '../../utils/logger'
+import { TokenCounter } from '../../utils/tokenizer'
 import { createSchemaParser, SchemaParserOptions } from './createSchemaParser'
 import { executeChain } from './executeChain'
 import { getLlm } from './getLlm'
+import { LlmCallMetadata } from './observability'
 
 export interface ExecuteChainWithSchemaOptions<T> extends SchemaParserOptions {
   /** Options for retry behavior - uses general retry utility */
@@ -13,6 +16,9 @@ export interface ExecuteChainWithSchemaOptions<T> extends SchemaParserOptions {
   fallbackParser?: (text: string) => T
   /** Called when fallback parser is used */
   onFallback?: () => void
+  logger?: Logger
+  tokenizer?: TokenCounter
+  metadata?: Partial<LlmCallMetadata>
 }
 
 /**
@@ -36,18 +42,30 @@ export async function executeChainWithSchema<T>(
     retryOptions = { maxAttempts: 3 },
     fallbackParser,
     onFallback,
+    logger,
+    tokenizer,
+    metadata,
     ...parserOptions
   } = options
   
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const parser: any = createSchemaParser(schema, llm, parserOptions)
+  let attempt = 0
 
   const operation = async (): Promise<T> => {
+    attempt++
     const result = await executeChain({
       llm,
       prompt,
       variables,
       parser,
+      logger,
+      tokenizer,
+      metadata: {
+        task: 'schema-chain',
+        ...metadata,
+        retryAttempt: attempt,
+      },
     })
     
     return result as T
@@ -66,6 +84,12 @@ export async function executeChainWithSchema<T>(
         prompt,
         variables,
         parser: new StringOutputParser(),
+        logger,
+        tokenizer,
+        metadata: {
+          task: 'schema-chain-fallback',
+          ...metadata,
+        },
       })
       
       const fallbackText = typeof fallbackResult === 'string' ? fallbackResult : String(fallbackResult)

--- a/src/lib/langchain/utils/observability.test.ts
+++ b/src/lib/langchain/utils/observability.test.ts
@@ -1,0 +1,33 @@
+import { Logger } from '../../utils/logger'
+import { estimatePromptTokens, logLlmCall } from './observability'
+
+describe('LLM observability utilities', () => {
+  it('estimates prompt tokens with the configured tokenizer', () => {
+    expect(estimatePromptTokens((text) => text.split(/\s+/).length, 'one two three')).toBe(3)
+  })
+
+  it('logs structured metadata without prompt content', () => {
+    const logger = {
+      verbose: jest.fn(),
+    } as unknown as Logger
+
+    logLlmCall(logger, {
+      task: 'commit-message',
+      command: 'commit',
+      provider: 'openai',
+      model: 'gpt-4o',
+      retryAttempt: 2,
+      promptTokens: 123,
+      variableKeys: ['summary', 'format_instructions'],
+    })
+
+    expect(logger.verbose).toHaveBeenCalledWith(
+      '[llm] task=commit-message command=commit provider=openai model=gpt-4o retryAttempt=2 promptTokens=123 variableKeys=summary,format_instructions',
+      { color: 'cyan' }
+    )
+  })
+
+  it('does not log when a logger is not provided', () => {
+    expect(() => logLlmCall(undefined, { task: 'summarize' })).not.toThrow()
+  })
+})

--- a/src/lib/langchain/utils/observability.ts
+++ b/src/lib/langchain/utils/observability.ts
@@ -1,0 +1,47 @@
+import { Logger } from '../../utils/logger'
+import { TokenCounter } from '../../utils/tokenizer'
+
+export type LlmCallMetadata = {
+  task: string
+  command?: string
+  provider?: string
+  model?: string
+  retryAttempt?: number
+  parserType?: string
+  variableKeys?: string[]
+  promptTokens?: number
+  inputDocuments?: number
+  inputChunks?: number
+}
+
+export function estimatePromptTokens(
+  tokenizer: TokenCounter | undefined,
+  renderedPrompt: string
+): number | undefined {
+  if (!tokenizer) return undefined
+
+  try {
+    return tokenizer(renderedPrompt)
+  } catch {
+    return undefined
+  }
+}
+
+export function logLlmCall(logger: Logger | undefined, metadata: LlmCallMetadata): void {
+  if (!logger) return
+
+  const fields = [
+    `task=${metadata.task}`,
+    metadata.command ? `command=${metadata.command}` : undefined,
+    metadata.provider ? `provider=${metadata.provider}` : undefined,
+    metadata.model ? `model=${metadata.model}` : undefined,
+    metadata.retryAttempt ? `retryAttempt=${metadata.retryAttempt}` : undefined,
+    metadata.promptTokens !== undefined ? `promptTokens=${metadata.promptTokens}` : undefined,
+    metadata.inputDocuments !== undefined ? `inputDocuments=${metadata.inputDocuments}` : undefined,
+    metadata.inputChunks !== undefined ? `inputChunks=${metadata.inputChunks}` : undefined,
+    metadata.parserType ? `parser=${metadata.parserType}` : undefined,
+    metadata.variableKeys?.length ? `variableKeys=${metadata.variableKeys.join(',')}` : undefined,
+  ].filter(Boolean)
+
+  logger.verbose(`[llm] ${fields.join(' ')}`, { color: 'cyan' })
+}

--- a/src/lib/parsers/default/utils/summarizeDiffs.ts
+++ b/src/lib/parsers/default/utils/summarizeDiffs.ts
@@ -32,6 +32,7 @@ export function createDirectoryDiffs(node: DiffNode): DirectoryDiff[] {
 
 type SummarizeDirectoryDiffOptions = {
   tokenizer: TokenCounter
+  logger?: Logger
 } & SummarizeContext
 
 /**
@@ -39,7 +40,7 @@ type SummarizeDirectoryDiffOptions = {
  */
 export async function summarizeDirectoryDiff(
   directory: DirectoryDiff,
-  { chain, textSplitter, tokenizer }: SummarizeDirectoryDiffOptions
+  { chain, textSplitter, tokenizer, logger }: SummarizeDirectoryDiffOptions
 ): Promise<DirectoryDiff> {
   try {
     const directorySummary = await summarize(
@@ -53,6 +54,11 @@ export async function summarizeDirectoryDiff(
       {
         chain,
         textSplitter,
+        tokenizer,
+        logger,
+        metadata: {
+          task: 'summarize-directory-diff',
+        },
         options: {
           returnIntermediateSteps: true,
         },
@@ -188,7 +194,7 @@ async function summarizeInWaves(
     // Process wave in parallel
     const waveResults = await Promise.all(
       wave.map((idx) =>
-        summarizeDirectoryDiff(results[idx], { chain, textSplitter, tokenizer })
+        summarizeDirectoryDiff(results[idx], { chain, textSplitter, tokenizer, logger })
       )
     )
 

--- a/src/lib/parsers/default/utils/summarizeLargeFiles.ts
+++ b/src/lib/parsers/default/utils/summarizeLargeFiles.ts
@@ -25,7 +25,7 @@ export type SummarizeLargeFilesOptions = {
  */
 async function summarizeFileDiff(
   fileDiff: FileDiff,
-  { chain, textSplitter, tokenizer }: Pick<SummarizeLargeFilesOptions, 'chain' | 'textSplitter' | 'tokenizer'>
+  { chain, textSplitter, tokenizer, logger }: Pick<SummarizeLargeFilesOptions, 'chain' | 'textSplitter' | 'tokenizer' | 'logger'>
 ): Promise<FileDiff> {
   try {
     const fileSummary = await summarize(
@@ -41,6 +41,11 @@ async function summarizeFileDiff(
       {
         chain,
         textSplitter,
+        tokenizer,
+        logger,
+        metadata: {
+          task: 'summarize-large-file',
+        },
         options: {
           returnIntermediateSteps: false,
         },
@@ -115,7 +120,7 @@ export async function summarizeLargeFiles(
   // Process large files in waves
   const summarizedFiles = await processInWaves(
     filesToSummarize,
-    async ({ diff }) => summarizeFileDiff(diff, { chain, textSplitter, tokenizer }),
+    async ({ diff }) => summarizeFileDiff(diff, { chain, textSplitter, tokenizer, logger }),
     maxConcurrent
   )
 


### PR DESCRIPTION
## Summary
- Adds prompt-safe verbose LLM call metadata for shared chain execution and summarization paths
- Tags commit, changelog, recap, review, large-file summary, and directory summary calls with task metadata
- Adds unit coverage for observability formatting and token estimation
- Documents the current AI call inventory, budget/retry behavior, model strategy notes, and follow-up work

Fixes #621
Fixes #624

## Validation
- npm run test:jest -- --runTestsByPath src/lib/langchain/utils/observability.test.ts src/lib/parsers/default/utils/summarizeDiffs.test.ts src/lib/parsers/default/utils/summarizeLargeFiles.test.ts src/commands/commit/commit.test.ts src/commands/recap/recap.test.ts
- npm test