### PR TITLE
Add dynamic model routing profiles

### DIFF
--- a/docs/DYNAMIC_MODEL_ROUTING.md
+++ b/docs/DYNAMIC_MODEL_ROUTING.md
@@ -1,0 +1,60 @@
+# Dynamic Model Routing
+
+Dynamic routing lets users keep a provider fixed while allowing Coco to choose a task-appropriate model.
+It is enabled by setting `service.model` to `dynamic`.
+
+```json
+{
+  "service": {
+    "provider": "openai",
+    "model": "dynamic",
+    "dynamicModelPreference": "balanced",
+    "dynamicModels": {
+      "summarize": "gpt-4.1-nano",
+      "commit": "gpt-4.1-mini",
+      "changelog": "gpt-4.1",
+      "review": "gpt-4.1",
+      "largeDiff": "gpt-4.1"
+    }
+  }
+}
+```
+
+## Tasks
+
+Supported task keys are:
+
+- `summarize`: routine diff compression.
+- `commit`: final commit message generation.
+- `changelog`: final changelog copy generation.
+- `review`: code review analysis.
+- `recap`: recap generation.
+- `repair`: parsing repair and retry work.
+- `largeDiff`: large branch or changelog diff condensation.
+
+## Routing Inputs
+
+The current resolver uses:
+
+- Provider: `openai`, `anthropic`, or `ollama`.
+- Task: one of the task keys above.
+- Preference: `cost`, `balanced`, or `quality`.
+- User overrides: `service.dynamicModels`.
+
+Explicit models are preserved. If `service.model` is not `dynamic`, Coco uses that model for every task.
+
+## Defaults
+
+Defaults are provider-specific and intentionally conservative:
+
+- Summarization uses smaller/faster models where available.
+- Commit/changelog generation uses balanced models.
+- Review, repair, and large-diff tasks use stronger or larger-context models.
+
+User overrides replace individual tasks without requiring a full profile.
+
+## Backward Compatibility
+
+Existing configs continue to work unchanged. The new fields are optional. `dynamicModels`
+is ignored unless `service.model` is `dynamic`, but it is still validated when dynamic
+routing is resolved so invalid task names fail clearly.

--- a/schema.json
+++ b/schema.json
@@ -131,7 +131,7 @@
           "$ref": "#/definitions/LLMProvider"
         },
         "model": {
-          "$ref": "#/definitions/LLMModel"
+          "$ref": "#/definitions/ConfiguredLLMModel"
         },
         "baseURL": {
           "type": "string",
@@ -823,6 +823,15 @@
           "type": "number",
           "description": "The maximum number of attempts for schema parsing with retry logic.",
           "default": 3
+        },
+        "dynamicModels": {
+          "$ref": "#/definitions/DynamicModelProfile",
+          "description": "Optional task-to-model overrides used when model is set to \"dynamic\"."
+        },
+        "dynamicModelPreference": {
+          "$ref": "#/definitions/DynamicModelPreference",
+          "description": "Default dynamic routing preference when model is set to \"dynamic\".",
+          "default": "balanced"
         }
       },
       "required": [
@@ -837,6 +846,17 @@
         "openai",
         "ollama",
         "anthropic"
+      ]
+    },
+    "ConfiguredLLMModel": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/LLMModel"
+        },
+        {
+          "type": "string",
+          "const": "dynamic"
+        }
       ]
     },
     "LLMModel": {
@@ -1136,6 +1156,41 @@
         null
       ]
     },
+    "DynamicModelProfile": {
+      "type": "object",
+      "properties": {
+        "summarize": {
+          "$ref": "#/definitions/LLMModel"
+        },
+        "commit": {
+          "$ref": "#/definitions/LLMModel"
+        },
+        "changelog": {
+          "$ref": "#/definitions/LLMModel"
+        },
+        "review": {
+          "$ref": "#/definitions/LLMModel"
+        },
+        "recap": {
+          "$ref": "#/definitions/LLMModel"
+        },
+        "repair": {
+          "$ref": "#/definitions/LLMModel"
+        },
+        "largeDiff": {
+          "$ref": "#/definitions/LLMModel"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DynamicModelPreference": {
+      "type": "string",
+      "enum": [
+        "cost",
+        "balanced",
+        "quality"
+      ]
+    },
     "OllamaLLMService": {
       "type": "object",
       "additionalProperties": false,
@@ -1144,7 +1199,7 @@
           "$ref": "#/definitions/LLMProvider"
         },
         "model": {
-          "$ref": "#/definitions/LLMModel"
+          "$ref": "#/definitions/ConfiguredLLMModel"
         },
         "endpoint": {
           "type": "string"
@@ -1864,6 +1919,15 @@
           "type": "number",
           "description": "The maximum number of attempts for schema parsing with retry logic.",
           "default": 3
+        },
+        "dynamicModels": {
+          "$ref": "#/definitions/DynamicModelProfile",
+          "description": "Optional task-to-model overrides used when model is set to \"dynamic\"."
+        },
+        "dynamicModelPreference": {
+          "$ref": "#/definitions/DynamicModelPreference",
+          "description": "Default dynamic routing preference when model is set to \"dynamic\".",
+          "default": "balanced"
         }
       },
       "required": [
@@ -1886,7 +1950,7 @@
           "$ref": "#/definitions/LLMProvider"
         },
         "model": {
-          "$ref": "#/definitions/LLMModel"
+          "$ref": "#/definitions/ConfiguredLLMModel"
         },
         "fields": {
           "type": "object",
@@ -2016,6 +2080,15 @@
           "type": "number",
           "description": "The maximum number of attempts for schema parsing with retry logic.",
           "default": 3
+        },
+        "dynamicModels": {
+          "$ref": "#/definitions/DynamicModelProfile",
+          "description": "Optional task-to-model overrides used when model is set to \"dynamic\"."
+        },
+        "dynamicModelPreference": {
+          "$ref": "#/definitions/DynamicModelPreference",
+          "description": "Default dynamic routing preference when model is set to \"dynamic\".",
+          "default": "balanced"
         }
       },
       "required": [

--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -1,6 +1,8 @@
 import { type TiktokenModel } from '@langchain/openai'
+import { LLMModel } from '../../lib/langchain/types'
 import { getApiKeyForModel, getModelAndProviderFromConfig } from '../../lib/langchain/utils'
 import { getLlm } from '../../lib/langchain/utils/getLlm'
+import { resolveDynamicService } from '../../lib/langchain/utils/dynamicModels'
 import { getPrompt } from '../../lib/langchain/utils/getPrompt'
 import { createSchemaParser } from '../../lib/langchain/utils/createSchemaParser'
 import { enforcePromptBudget } from '../../lib/langchain/utils/enforcePromptBudget'
@@ -61,7 +63,10 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
   const config = loadConfig<ChangelogOptions, ChangelogArgv>(argv)
   const git = getRepo()
   const key = getApiKeyForModel(config)
-  const { provider, model } = getModelAndProviderFromConfig(config)
+  const { provider } = getModelAndProviderFromConfig(config)
+  const changelogService = resolveDynamicService(config, 'changelog')
+  const summaryService = resolveDynamicService(config, argv.withDiff || argv.onlyDiff ? 'largeDiff' : 'summarize')
+  const model = changelogService.model
 
   const exclusiveOptions = [
     argv.branch ? '--branch' : null,
@@ -79,7 +84,8 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
     process.exit(1)
   }
 
-  const llm = getLlm(provider, model, config)
+  const llm = getLlm(provider, model as LLMModel, { ...config, service: changelogService })
+  const summaryLlm = getLlm(provider, summaryService.model as LLMModel, { ...config, service: summaryService })
   const tokenizer = await getTokenCounter(
     provider === 'openai' ? (model as TiktokenModel) : 'gpt-4o'
   )
@@ -161,7 +167,7 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
                     options: {
                       tokenizer,
                       git,
-                      llm,
+                      llm: summaryLlm,
                       logger,
                       maxTokens: config.service.tokenLimit,
                       minTokensForSummary: config.service.minTokensForSummary,
@@ -191,7 +197,7 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
         options: {
           tokenizer,
           git,
-          llm,
+          llm: summaryLlm,
           logger,
           maxTokens: config.service.tokenLimit,
           minTokensForSummary: config.service.minTokensForSummary,
@@ -286,7 +292,7 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
           task: argv.withDiff ? 'changelog-with-diff' : argv.onlyDiff ? 'changelog-only-diff' : 'changelog',
           command: 'changelog',
           provider,
-          model,
+          model: String(model),
         },
       })
 

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -1,10 +1,12 @@
 import { type TiktokenModel } from '@langchain/openai'
+import { LLMModel } from '../../lib/langchain/types'
 import { loadConfig } from '../../lib/config/utils/loadConfig'
 import { getApiKeyForModel, getModelAndProviderFromConfig } from '../../lib/langchain/utils'
 import { executeChainWithSchema } from '../../lib/langchain/utils/executeChainWithSchema'
 import { enforcePromptBudget } from '../../lib/langchain/utils/enforcePromptBudget'
 import { formatCommitMessage } from '../../lib/langchain/utils/formatCommitMessage'
 import { getLlm } from '../../lib/langchain/utils/getLlm'
+import { resolveDynamicService } from '../../lib/langchain/utils/dynamicModels'
 import { getPrompt } from '../../lib/langchain/utils/getPrompt'
 import { fileChangeParser } from '../../lib/parsers/default'
 import { PreCommitHookError, createCommit } from '../../lib/simple-git/createCommit'
@@ -34,7 +36,10 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
   const git = getRepo()
   const config = loadConfig<CommitOptions, CommitArgv>(argv)
   const key = getApiKeyForModel(config)
-  const { provider, model } = getModelAndProviderFromConfig(config)
+  const { provider } = getModelAndProviderFromConfig(config)
+  const commitService = resolveDynamicService(config, 'commit')
+  const summaryService = resolveDynamicService(config, 'summarize')
+  const model = commitService.model
 
   if (config.service.authentication.type !== 'None' && !key) {
     logger.log(`No API Key found. 🗝️🚪`, { color: 'red' })
@@ -45,7 +50,8 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
     provider === 'openai' ? (model as TiktokenModel) : 'gpt-4o'
   )
 
-  const llm = getLlm(provider, model, config)
+  const llm = getLlm(provider, model as LLMModel, { ...config, service: commitService })
+  const summaryLlm = getLlm(provider, summaryService.model as LLMModel, { ...config, service: summaryService })
 
   const INTERACTIVE = argv.interactive || isInteractive(config)
   if (INTERACTIVE) {
@@ -105,7 +111,7 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
       options: {
         tokenizer,
         git,
-        llm,
+        llm: summaryLlm,
         logger,
         maxTokens: config.service.tokenLimit,
         minTokensForSummary: config.service.minTokensForSummary,
@@ -294,7 +300,7 @@ IMPORTANT RULES:
             task: USE_CONVENTIONAL_COMMITS ? 'commit-message-conventional' : 'commit-message',
             command: 'commit',
             provider,
-            model,
+            model: String(model),
           },
           retryOptions: {
             maxAttempts,

--- a/src/commands/recap/handler.ts
+++ b/src/commands/recap/handler.ts
@@ -1,9 +1,11 @@
 import { TiktokenModel } from '@langchain/openai'
+import { LLMModel } from '../../lib/langchain/types'
 import { loadConfig } from '../../lib/config/utils/loadConfig'
 import { getApiKeyForModel, getModelAndProviderFromConfig } from '../../lib/langchain/utils'
 import { executeChain } from '../../lib/langchain/utils/executeChain'
 import { createSchemaParser } from '../../lib/langchain/utils/createSchemaParser'
 import { getLlm } from '../../lib/langchain/utils/getLlm'
+import { resolveDynamicService } from '../../lib/langchain/utils/dynamicModels'
 import { getPrompt } from '../../lib/langchain/utils/getPrompt'
 import { getChanges } from '../../lib/simple-git/getChanges'
 import { getChangesByTimestamp } from '../../lib/simple-git/getChangesByTimestamp'
@@ -26,7 +28,10 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
   const git = getRepo()
   const config = loadConfig<RecapOptions, RecapArgv>(argv)
   const key = getApiKeyForModel(config)
-  const { provider, model } = getModelAndProviderFromConfig(config)
+  const { provider } = getModelAndProviderFromConfig(config)
+  const recapService = resolveDynamicService(config, 'recap')
+  const summaryService = resolveDynamicService(config, 'summarize')
+  const model = recapService.model
 
   if (config.service.authentication.type !== 'None' && !key) {
     logger.log(`No API Key found. 🗝️🚪`, { color: 'red' })
@@ -37,7 +42,8 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
     provider === 'openai' ? (model as TiktokenModel) : 'gpt-4o'
   )
 
-  const llm = getLlm(provider, model, config)
+  const llm = getLlm(provider, model as LLMModel, { ...config, service: recapService })
+  const summaryLlm = getLlm(provider, summaryService.model as LLMModel, { ...config, service: summaryService })
 
   const INTERACTIVE = argv.interactive || isInteractive(config)
   if (INTERACTIVE) {
@@ -77,7 +83,7 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
         const unstagedChanges = await fileChangeParser({
           changes: unstaged || [],
           commit: '--unstaged',
-          options: { tokenizer, git, llm, logger },
+          options: { tokenizer, git, llm: summaryLlm, logger },
         })
 
         const unstagedResponse = `Unstaged changes:\n${unstagedChanges}`
@@ -85,14 +91,14 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
         const untrackedChanges = await fileChangeParser({
           changes: untracked || [],
           commit: '--untracked',
-          options: { tokenizer, git, llm, logger },
+          options: { tokenizer, git, llm: summaryLlm, logger },
         })
         const untrackedResponse = `Untracked changes:\n${untrackedChanges}`
 
         const stagedChanges = await fileChangeParser({
           changes: staged,
           commit: '--staged',
-          options: { tokenizer, git, llm, logger },
+          options: { tokenizer, git, llm: summaryLlm, logger },
         })
         const stagedResponse = `Staged changes:\n${stagedChanges}`
 
@@ -128,7 +134,7 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
         const branchChanges = await fileChangeParser({
           changes: changes.staged,
           commit: baseBranch,
-          options: { tokenizer, git, llm, logger },
+          options: { tokenizer, git, llm: summaryLlm, logger },
         })
 
         return [branchChanges]
@@ -195,7 +201,7 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
             task: 'recap',
             command: 'recap',
             provider,
-            model,
+            model: String(model),
           },
         })
 

--- a/src/commands/review/handler.ts
+++ b/src/commands/review/handler.ts
@@ -1,9 +1,11 @@
 import { TiktokenModel } from '@langchain/openai'
+import { LLMModel } from '../../lib/langchain/types'
 import chalk from 'chalk'
 import { z } from 'zod'
 import { loadConfig } from '../../lib/config/utils/loadConfig'
 import { getApiKeyForModel, getModelAndProviderFromConfig } from '../../lib/langchain/utils'
 import { executeChain } from '../../lib/langchain/utils/executeChain'
+import { resolveDynamicService } from '../../lib/langchain/utils/dynamicModels'
 import { getLlm } from '../../lib/langchain/utils/getLlm'
 import { getPrompt } from '../../lib/langchain/utils/getPrompt'
 import { fileChangeParser } from '../../lib/parsers/default/index'
@@ -32,7 +34,10 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
   const git = getRepo()
   const config = loadConfig<ReviewOptions, ReviewArgv>(argv)
   const key = getApiKeyForModel(config)
-  const { provider, model } = getModelAndProviderFromConfig(config)
+  const { provider } = getModelAndProviderFromConfig(config)
+  const reviewService = resolveDynamicService(config, 'review')
+  const summaryService = resolveDynamicService(config, argv.branch ? 'largeDiff' : 'summarize')
+  const model = reviewService.model
 
   if (config.service.authentication.type !== 'None' && !key) {
     logger.log(`No API Key found. 🗝️🚪`, { color: 'red' })
@@ -43,7 +48,8 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
     provider === 'openai' ? (model as TiktokenModel) : 'gpt-4o'
   )
 
-  const llm = getLlm(provider, model, config)
+  const llm = getLlm(provider, model as LLMModel, { ...config, service: reviewService })
+  const summaryLlm = getLlm(provider, summaryService.model as LLMModel, { ...config, service: summaryService })
 
   const INTERACTIVE = isInteractive(config)
   if (INTERACTIVE) {
@@ -71,7 +77,7 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
       const branchChanges = await fileChangeParser({
         changes: diff.staged,
         commit: `--branch-diff-${argv.branch}`,
-        options: { tokenizer, git, llm, logger },
+        options: { tokenizer, git, llm: summaryLlm, logger },
       })
 
       return [branchChanges]
@@ -100,7 +106,7 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
       const unstagedChanges = await fileChangeParser({
         changes: unstaged || [],
         commit: '--unstaged',
-        options: { tokenizer, git, llm, logger },
+        options: { tokenizer, git, llm: summaryLlm, logger },
       })
 
       const unstagedResponse = `Unstaged changes:\n${unstagedChanges}`
@@ -108,14 +114,14 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
       const untrackedChanges = await fileChangeParser({
         changes: untracked || [],
         commit: '--untracked',
-        options: { tokenizer, git, llm, logger },
+        options: { tokenizer, git, llm: summaryLlm, logger },
       })
       const untrackedResponse = `Untracked changes:\n${untrackedChanges}`
 
       const stagedChanges = await fileChangeParser({
         changes: staged,
         commit: '--staged',
-        options: { tokenizer, git, llm, logger },
+        options: { tokenizer, git, llm: summaryLlm, logger },
       })
       const stagedResponse = `Staged changes:\n${stagedChanges}`
 
@@ -177,7 +183,7 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
           task: argv.branch ? 'review-branch' : 'review',
           command: 'review',
           provider,
-          model,
+          model: String(model),
         },
       }) as ReviewFeedbackItem[]
 

--- a/src/lib/config/services/env.ts
+++ b/src/lib/config/services/env.ts
@@ -26,6 +26,8 @@ export function loadEnvConfig<ConfigType = Config>(config: Partial<Config>) {
     'COCO_SERVICE_REQUEST_OPTIONS_TIMEOUT',
     'COCO_SERVICE_REQUEST_OPTIONS_MAX_RETRIES',
     'COCO_SERVICE_FIELDS',
+    'COCO_SERVICE_DYNAMIC_MODELS',
+    'COCO_SERVICE_DYNAMIC_MODEL_PREFERENCE',
   ]
 
   envKeys.forEach((key) => {
@@ -44,7 +46,9 @@ export function loadEnvConfig<ConfigType = Config>(config: Partial<Config>) {
       key === 'COCO_SERVICE_ENDPOINT' ||
       key === 'COCO_SERVICE_REQUEST_OPTIONS_TIMEOUT' ||
       key === 'COCO_SERVICE_REQUEST_OPTIONS_MAX_RETRIES' ||
-      key === 'COCO_SERVICE_FIELDS'
+      key === 'COCO_SERVICE_FIELDS' ||
+      key === 'COCO_SERVICE_DYNAMIC_MODELS' ||
+      key === 'COCO_SERVICE_DYNAMIC_MODEL_PREFERENCE'
     ) {
       // NOTE: We want to ensure that the service object is always defined
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -101,6 +105,12 @@ function handleServiceEnvVar(service: LLMService, key: string, value: any) {
       break
     case 'COCO_SERVICE_FIELDS':
       service.fields = value
+      break
+    case 'COCO_SERVICE_DYNAMIC_MODELS':
+      service.dynamicModels = value
+      break
+    case 'COCO_SERVICE_DYNAMIC_MODEL_PREFERENCE':
+      service.dynamicModelPreference = value
       break
   }
 }

--- a/src/lib/langchain/types.ts
+++ b/src/lib/langchain/types.ts
@@ -3,6 +3,15 @@ import { type BaseLLMParams } from '@langchain/core/language_models/llms'
 import { type OpenAIInput, type TiktokenModel } from '@langchain/openai'
 
 export type LLMProvider = 'openai' | 'ollama' | 'anthropic'
+export type DynamicModelTask =
+  | 'summarize'
+  | 'commit'
+  | 'changelog'
+  | 'review'
+  | 'recap'
+  | 'repair'
+  | 'largeDiff'
+export type DynamicModelPreference = 'cost' | 'balanced' | 'quality'
 
 export type OpenAIModel =
   | TiktokenModel
@@ -89,10 +98,12 @@ export type OllamaModel =
   | 'qwen2.5-coder:32b'
 
 export type LLMModel = OpenAIModel | OllamaModel | AnthropicModel
+export type ConfiguredLLMModel = LLMModel | 'dynamic'
+export type DynamicModelProfile = Partial<Record<DynamicModelTask, LLMModel>>
 
 export type BaseLLMService = {
   provider: LLMProvider
-  model: LLMModel
+  model: ConfiguredLLMModel
   /**
    * The maximum number of tokens per request.
    *
@@ -138,6 +149,16 @@ export type BaseLLMService = {
    * @default 3
    */
   maxParsingAttempts?: number
+  /**
+   * Optional task-to-model overrides used when model is set to "dynamic".
+   */
+  dynamicModels?: DynamicModelProfile
+  /**
+   * Default dynamic routing preference when model is set to "dynamic".
+   *
+   * @default 'balanced'
+   */
+  dynamicModelPreference?: DynamicModelPreference
 }
 
 type Authentication =
@@ -165,7 +186,7 @@ type OllamaFields = Partial<OllamaInput> & BaseLLMParams
 
 export type OpenAILLMService = BaseLLMService & {
   provider: 'openai'
-  model: OpenAIModel
+  model: OpenAIModel | 'dynamic'
   /**
    * Custom base URL for OpenAI-compatible APIs (e.g., OpenRouter, Azure OpenAI).
    * If not specified, uses the default OpenAI API endpoint.
@@ -179,14 +200,14 @@ export type OpenAILLMService = BaseLLMService & {
 
 export type OllamaLLMService = BaseLLMService & {
   provider: 'ollama'
-  model: OllamaModel
+  model: OllamaModel | 'dynamic'
   endpoint: string
   fields?: OllamaFields
 }
 
 export type AnthropicLLMService = BaseLLMService & {
   provider: 'anthropic'
-  model: AnthropicModel
+  model: AnthropicModel | 'dynamic'
   fields?: {
     temperature?: number
     maxTokens?: number

--- a/src/lib/langchain/utils/dynamicModels.test.ts
+++ b/src/lib/langchain/utils/dynamicModels.test.ts
@@ -1,0 +1,118 @@
+import { Config } from '../../../commands/types'
+import { DEFAULT_OPENAI_LLM_SERVICE } from '../utils'
+import {
+  getDynamicModelDefaults,
+  resolveDynamicModel,
+  resolveDynamicService,
+  validateDynamicModelProfile,
+} from './dynamicModels'
+
+const baseConfig = {
+  mode: 'stdout',
+  defaultBranch: 'main',
+  service: {
+    ...DEFAULT_OPENAI_LLM_SERVICE,
+    model: 'dynamic',
+    authentication: {
+      type: 'APIKey',
+      credentials: {
+        apiKey: 'test',
+      },
+    },
+  },
+} as Config
+
+describe('dynamic model routing', () => {
+  it('preserves explicit model behavior', () => {
+    const config = {
+      ...baseConfig,
+      service: {
+        ...baseConfig.service,
+        model: 'gpt-4o-mini',
+      },
+    } as Config
+
+    expect(resolveDynamicModel(config, 'commit')).toBe('gpt-4o-mini')
+  })
+
+  it('uses provider defaults when model is dynamic', () => {
+    expect(resolveDynamicModel(baseConfig, 'summarize')).toBe('gpt-4.1-mini')
+    expect(resolveDynamicModel(baseConfig, 'review')).toBe('gpt-4.1')
+  })
+
+  it('supports user task overrides', () => {
+    const config = {
+      ...baseConfig,
+      service: {
+        ...baseConfig.service,
+        dynamicModels: {
+          summarize: 'gpt-4.1-nano',
+          commit: 'gpt-4o',
+        },
+      },
+    } as Config
+
+    expect(resolveDynamicModel(config, 'summarize')).toBe('gpt-4.1-nano')
+    expect(resolveDynamicModel(config, 'commit')).toBe('gpt-4o')
+    expect(resolveDynamicModel(config, 'review')).toBe('gpt-4.1')
+  })
+
+  it('supports preference-specific defaults', () => {
+    const config = {
+      ...baseConfig,
+      service: {
+        ...baseConfig.service,
+        dynamicModelPreference: 'cost',
+      },
+    } as Config
+
+    expect(resolveDynamicModel(config, 'summarize')).toBe('gpt-4.1-nano')
+  })
+
+  it('returns a concrete service config for a task', () => {
+    const service = resolveDynamicService(baseConfig, 'commit')
+
+    expect(service.provider).toBe('openai')
+    expect(service.model).toBe('gpt-4.1-mini')
+  })
+
+  it('rejects unknown dynamic task keys', () => {
+    const config = {
+      ...baseConfig,
+      service: {
+        ...baseConfig.service,
+        dynamicModels: {
+          unknownTask: 'gpt-4o',
+        },
+      },
+    } as unknown as Config
+
+    expect(() => validateDynamicModelProfile(config.service)).toThrow(
+      'Unknown dynamic model task'
+    )
+  })
+
+  it('rejects dynamic model overrides that are not concrete models', () => {
+    const config = {
+      ...baseConfig,
+      service: {
+        ...baseConfig.service,
+        dynamicModels: {
+          summarize: 'dynamic',
+        },
+      },
+    } as unknown as Config
+
+    expect(() => validateDynamicModelProfile(config.service)).toThrow(
+      'must be a concrete model name'
+    )
+  })
+
+  it('exposes provider defaults for documentation and UI use', () => {
+    expect(getDynamicModelDefaults('openai')).toMatchObject({
+      summarize: expect.any(String),
+      commit: expect.any(String),
+      review: expect.any(String),
+    })
+  })
+})

--- a/src/lib/langchain/utils/dynamicModels.ts
+++ b/src/lib/langchain/utils/dynamicModels.ts
@@ -1,0 +1,169 @@
+import { Config } from '../../../commands/types'
+import {
+  DynamicModelPreference,
+  DynamicModelTask,
+  LLMModel,
+  LLMProvider,
+  LLMService,
+} from '../types'
+import { LangChainConfigurationError } from '../errors'
+
+type ProviderDynamicDefaults = Record<DynamicModelPreference, Record<DynamicModelTask, LLMModel>>
+
+const OPENAI_DYNAMIC_DEFAULTS: ProviderDynamicDefaults = {
+  cost: {
+    summarize: 'gpt-4.1-nano',
+    commit: 'gpt-4.1-mini',
+    changelog: 'gpt-4.1-mini',
+    review: 'gpt-4.1-mini',
+    recap: 'gpt-4.1-nano',
+    repair: 'gpt-4.1-mini',
+    largeDiff: 'gpt-4.1',
+  },
+  balanced: {
+    summarize: 'gpt-4.1-mini',
+    commit: 'gpt-4.1-mini',
+    changelog: 'gpt-4.1',
+    review: 'gpt-4.1',
+    recap: 'gpt-4.1-mini',
+    repair: 'gpt-4.1',
+    largeDiff: 'gpt-4.1',
+  },
+  quality: {
+    summarize: 'gpt-4.1-mini',
+    commit: 'gpt-4.1',
+    changelog: 'gpt-4.1',
+    review: 'gpt-4.1',
+    recap: 'gpt-4.1',
+    repair: 'gpt-4.1',
+    largeDiff: 'gpt-4.1',
+  },
+}
+
+const ANTHROPIC_DYNAMIC_DEFAULTS: ProviderDynamicDefaults = {
+  cost: {
+    summarize: 'claude-3-5-haiku-latest',
+    commit: 'claude-3-5-haiku-latest',
+    changelog: 'claude-3-5-sonnet-latest',
+    review: 'claude-3-5-sonnet-latest',
+    recap: 'claude-3-5-haiku-latest',
+    repair: 'claude-3-5-sonnet-latest',
+    largeDiff: 'claude-3-5-sonnet-latest',
+  },
+  balanced: {
+    summarize: 'claude-3-5-haiku-latest',
+    commit: 'claude-3-5-sonnet-latest',
+    changelog: 'claude-3-5-sonnet-latest',
+    review: 'claude-3-7-sonnet-latest',
+    recap: 'claude-3-5-sonnet-latest',
+    repair: 'claude-3-7-sonnet-latest',
+    largeDiff: 'claude-3-7-sonnet-latest',
+  },
+  quality: {
+    summarize: 'claude-3-5-sonnet-latest',
+    commit: 'claude-3-7-sonnet-latest',
+    changelog: 'claude-3-7-sonnet-latest',
+    review: 'claude-sonnet-4-0',
+    recap: 'claude-3-7-sonnet-latest',
+    repair: 'claude-sonnet-4-0',
+    largeDiff: 'claude-sonnet-4-0',
+  },
+}
+
+const OLLAMA_DYNAMIC_DEFAULTS: ProviderDynamicDefaults = {
+  cost: {
+    summarize: 'llama3.2:3b',
+    commit: 'llama3.1:8b',
+    changelog: 'llama3.1:8b',
+    review: 'qwen2.5-coder:7b',
+    recap: 'llama3.2:3b',
+    repair: 'qwen2.5-coder:7b',
+    largeDiff: 'qwen2.5-coder:14b',
+  },
+  balanced: {
+    summarize: 'llama3.1:8b',
+    commit: 'qwen2.5-coder:14b',
+    changelog: 'qwen2.5-coder:14b',
+    review: 'qwen2.5-coder:32b',
+    recap: 'llama3.1:8b',
+    repair: 'qwen2.5-coder:32b',
+    largeDiff: 'qwen2.5-coder:32b',
+  },
+  quality: {
+    summarize: 'qwen2.5-coder:14b',
+    commit: 'qwen2.5-coder:32b',
+    changelog: 'qwen2.5-coder:32b',
+    review: 'qwen2.5-coder:32b',
+    recap: 'qwen2.5-coder:14b',
+    repair: 'qwen2.5-coder:32b',
+    largeDiff: 'qwen2.5-coder:32b',
+  },
+}
+
+const DYNAMIC_DEFAULTS: Record<LLMProvider, ProviderDynamicDefaults> = {
+  openai: OPENAI_DYNAMIC_DEFAULTS,
+  anthropic: ANTHROPIC_DYNAMIC_DEFAULTS,
+  ollama: OLLAMA_DYNAMIC_DEFAULTS,
+}
+
+export const DYNAMIC_MODEL_TASKS: DynamicModelTask[] = [
+  'summarize',
+  'commit',
+  'changelog',
+  'review',
+  'recap',
+  'repair',
+  'largeDiff',
+]
+
+export function validateDynamicModelProfile(service: LLMService): void {
+  const dynamicModels = service.dynamicModels
+  if (!dynamicModels) return
+
+  const unknownTasks = Object.keys(dynamicModels).filter(
+    (task) => !DYNAMIC_MODEL_TASKS.includes(task as DynamicModelTask)
+  )
+
+  if (unknownTasks.length > 0) {
+    throw new LangChainConfigurationError(
+      `Unknown dynamic model task(s): ${unknownTasks.join(', ')}. Supported tasks: ${DYNAMIC_MODEL_TASKS.join(', ')}`,
+      { unknownTasks, supportedTasks: DYNAMIC_MODEL_TASKS }
+    )
+  }
+
+  Object.entries(dynamicModels as Record<string, string>).forEach(([task, model]) => {
+    if (typeof model !== 'string' || model.trim() === '' || model === 'dynamic') {
+      throw new LangChainConfigurationError(
+        `Dynamic model override for '${task}' must be a concrete model name`,
+        { task, model }
+      )
+    }
+  })
+}
+
+export function resolveDynamicModel(config: Config, task: DynamicModelTask): LLMModel {
+  const service = config.service
+  validateDynamicModelProfile(service)
+
+  if (service.model !== 'dynamic') {
+    return service.model as LLMModel
+  }
+
+  const preference = service.dynamicModelPreference || 'balanced'
+  const providerDefaults = DYNAMIC_DEFAULTS[service.provider]
+  const defaultModel = providerDefaults[preference]?.[task]
+
+  return service.dynamicModels?.[task] || defaultModel
+}
+
+export function resolveDynamicService(config: Config, task: DynamicModelTask): LLMService {
+  const model = resolveDynamicModel(config, task)
+  return {
+    ...config.service,
+    model,
+  } as LLMService
+}
+
+export function getDynamicModelDefaults(provider: LLMProvider, preference: DynamicModelPreference = 'balanced') {
+  return DYNAMIC_DEFAULTS[provider][preference]
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -142,7 +142,7 @@ export const schema = {
           "$ref": "#/definitions/LLMProvider"
         },
         "model": {
-          "$ref": "#/definitions/LLMModel"
+          "$ref": "#/definitions/ConfiguredLLMModel"
         },
         "baseURL": {
           "type": "string",
@@ -834,6 +834,15 @@ export const schema = {
           "type": "number",
           "description": "The maximum number of attempts for schema parsing with retry logic.",
           "default": 3
+        },
+        "dynamicModels": {
+          "$ref": "#/definitions/DynamicModelProfile",
+          "description": "Optional task-to-model overrides used when model is set to \"dynamic\"."
+        },
+        "dynamicModelPreference": {
+          "$ref": "#/definitions/DynamicModelPreference",
+          "description": "Default dynamic routing preference when model is set to \"dynamic\".",
+          "default": "balanced"
         }
       },
       "required": [
@@ -848,6 +857,17 @@ export const schema = {
         "openai",
         "ollama",
         "anthropic"
+      ]
+    },
+    "ConfiguredLLMModel": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/LLMModel"
+        },
+        {
+          "type": "string",
+          "const": "dynamic"
+        }
       ]
     },
     "LLMModel": {
@@ -1147,6 +1167,41 @@ export const schema = {
         null
       ]
     },
+    "DynamicModelProfile": {
+      "type": "object",
+      "properties": {
+        "summarize": {
+          "$ref": "#/definitions/LLMModel"
+        },
+        "commit": {
+          "$ref": "#/definitions/LLMModel"
+        },
+        "changelog": {
+          "$ref": "#/definitions/LLMModel"
+        },
+        "review": {
+          "$ref": "#/definitions/LLMModel"
+        },
+        "recap": {
+          "$ref": "#/definitions/LLMModel"
+        },
+        "repair": {
+          "$ref": "#/definitions/LLMModel"
+        },
+        "largeDiff": {
+          "$ref": "#/definitions/LLMModel"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DynamicModelPreference": {
+      "type": "string",
+      "enum": [
+        "cost",
+        "balanced",
+        "quality"
+      ]
+    },
     "OllamaLLMService": {
       "type": "object",
       "additionalProperties": false,
@@ -1155,7 +1210,7 @@ export const schema = {
           "$ref": "#/definitions/LLMProvider"
         },
         "model": {
-          "$ref": "#/definitions/LLMModel"
+          "$ref": "#/definitions/ConfiguredLLMModel"
         },
         "endpoint": {
           "type": "string"
@@ -1875,6 +1930,15 @@ export const schema = {
           "type": "number",
           "description": "The maximum number of attempts for schema parsing with retry logic.",
           "default": 3
+        },
+        "dynamicModels": {
+          "$ref": "#/definitions/DynamicModelProfile",
+          "description": "Optional task-to-model overrides used when model is set to \"dynamic\"."
+        },
+        "dynamicModelPreference": {
+          "$ref": "#/definitions/DynamicModelPreference",
+          "description": "Default dynamic routing preference when model is set to \"dynamic\".",
+          "default": "balanced"
         }
       },
       "required": [
@@ -1897,7 +1961,7 @@ export const schema = {
           "$ref": "#/definitions/LLMProvider"
         },
         "model": {
-          "$ref": "#/definitions/LLMModel"
+          "$ref": "#/definitions/ConfiguredLLMModel"
         },
         "fields": {
           "type": "object",
@@ -2027,6 +2091,15 @@ export const schema = {
           "type": "number",
           "description": "The maximum number of attempts for schema parsing with retry logic.",
           "default": 3
+        },
+        "dynamicModels": {
+          "$ref": "#/definitions/DynamicModelProfile",
+          "description": "Optional task-to-model overrides used when model is set to \"dynamic\"."
+        },
+        "dynamicModelPreference": {
+          "$ref": "#/definitions/DynamicModelPreference",
+          "description": "Default dynamic routing preference when model is set to \"dynamic\".",
+          "default": "balanced"
         }
       },
       "required": [


### PR DESCRIPTION
## Summary
- Adds typed dynamic model config with provider defaults, preferences, and user task overrides
- Resolves dynamic models per task for commit, changelog, recap, review, and diff summarization paths
- Supports env overrides for dynamic model profiles and preference
- Regenerates config schema and documents the routing model

Fixes #622
Fixes #623

## Validation
- npm run test:jest -- --runTestsByPath src/lib/langchain/utils/dynamicModels.test.ts src/lib/config/services/env.test.ts src/commands/commit/commit.test.ts src/commands/recap/recap.test.ts src/commands/commands.integration.test.ts
- npm test