### PR TITLE
Add commit split planning and apply workflow

### DIFF
--- a/docs/COMMIT_SPLIT.md
+++ b/docs/COMMIT_SPLIT.md
@@ -1,0 +1,33 @@
+# Commit Split
+
+Commit split helps turn a broad staged change set into smaller, related commits.
+
+## Commands
+
+```bash
+coco commit split --plan
+coco commit split --apply
+```
+
+`--plan` is non-mutating. It reads staged changes, condenses the diffs using the existing
+diff parser, and asks the configured model to group files into proposed commits.
+
+`--apply` starts from a generated plan and creates one commit per group. The first
+implementation is file-level only. It intentionally aborts if a planned file also has
+unstaged or untracked changes, because staging the whole file would otherwise mix unrelated
+work into a generated commit.
+
+## Safety Rules
+
+- Every staged file must appear exactly once in the plan.
+- Plan files must match real staged files.
+- Apply mode unstages the current index, stages one group at a time, and uses the existing
+  `createCommit` utility.
+- Unstaged overlap blocks apply mode.
+
+## Hunk-Level Follow-Up
+
+Hunk-level grouping is intentionally not applied yet. It needs a structured patch parser and
+safe staging strategy because one file can contain unrelated staged and unstaged changes. The
+safe path is to prototype hunk staging in temp repositories before adding an apply mode that
+can split a single file across multiple commits.

--- a/src/commands/commands.integration.test.ts
+++ b/src/commands/commands.integration.test.ts
@@ -167,6 +167,117 @@ describe('command integration with temp git repos', () => {
     expect(variables.summary).toContain('# Temp repo')
   })
 
+  it('prints a non-mutating commit split plan for staged files', async () => {
+    mockLoadConfig.mockReturnValue(createConfig({
+      mode: 'stdout',
+    }))
+    mockExecuteChainWithSchema.mockResolvedValueOnce({
+      groups: [
+        {
+          title: 'docs: update readme',
+          body: 'Document the temp repo.',
+          rationale: 'README-only documentation change.',
+          files: ['README.md'],
+        },
+        {
+          title: 'test: add feature fixture',
+          body: 'Add a feature fixture file.',
+          rationale: 'Fixture code belongs in its own commit.',
+          files: ['src/feature.ts'],
+        },
+      ],
+    })
+
+    await repo.writeFile('.gitkeep', '\n')
+    await repo.commitAll('chore: initial commit')
+    await repo.writeFile('README.md', '# Temp repo\n')
+    await repo.writeFile('src/feature.ts', 'export const feature = true\n')
+    await repo.git.add(['README.md', 'src/feature.ts'])
+
+    await commitHandler({
+      $0: 'coco',
+      _: ['commit', 'split'],
+      interactive: false,
+      openInEditor: false,
+      ignoredFiles: [],
+      ignoredExtensions: [],
+      withPreviousCommits: 0,
+      conventional: false,
+      includeBranchName: false,
+      noDiff: false,
+      noVerify: true,
+      split: true,
+      plan: true,
+      apply: false,
+      verbose: false,
+      version: false,
+      help: false,
+    } as Arguments<CommitOptions>, createLogger())
+
+    const status = await repo.git.status()
+
+    expect(stdout).toContain('docs: update readme')
+    expect(stdout).toContain('test: add feature fixture')
+    expect(status.staged).toEqual(expect.arrayContaining(['README.md', 'src/feature.ts']))
+  })
+
+  it('applies a file-level commit split plan using real git commits', async () => {
+    mockLoadConfig.mockReturnValue(createConfig({
+      mode: 'stdout',
+    }))
+    mockExecuteChainWithSchema.mockResolvedValueOnce({
+      groups: [
+        {
+          title: 'docs: update readme',
+          body: 'Document the temp repo.',
+          rationale: 'README-only documentation change.',
+          files: ['README.md'],
+        },
+        {
+          title: 'test: add feature fixture',
+          body: 'Add a feature fixture file.',
+          rationale: 'Fixture code belongs in its own commit.',
+          files: ['src/feature.ts'],
+        },
+      ],
+    })
+
+    await repo.writeFile('.gitkeep', '\n')
+    await repo.commitAll('chore: initial commit')
+    await repo.writeFile('README.md', '# Temp repo\n')
+    await repo.writeFile('src/feature.ts', 'export const feature = true\n')
+    await repo.git.add(['README.md', 'src/feature.ts'])
+
+    await commitHandler({
+      $0: 'coco',
+      _: ['commit', 'split'],
+      interactive: false,
+      openInEditor: false,
+      ignoredFiles: [],
+      ignoredExtensions: [],
+      withPreviousCommits: 0,
+      conventional: false,
+      includeBranchName: false,
+      noDiff: false,
+      noVerify: true,
+      split: true,
+      plan: false,
+      apply: true,
+      verbose: false,
+      version: false,
+      help: false,
+    } as Arguments<CommitOptions>, createLogger())
+
+    const log = await repo.git.log()
+    const status = await repo.git.status()
+
+    expect(stdout).toContain('Created 2 split commit(s).')
+    expect(log.all.map((commit) => commit.message)).toEqual(
+      expect.arrayContaining(['docs: update readme', 'test: add feature fixture'])
+    )
+    expect(status.files).toHaveLength(0)
+  })
+
   it('generates a changelog from real branch commit history', async () => {
     mockLoadConfig.mockImplementation((argv) => createConfig({
       ...(argv as Record<string, unknown>),

--- a/src/commands/commit/config.ts
+++ b/src/commands/commit/config.ts
@@ -12,6 +12,9 @@ export interface CommitOptions extends BaseCommandOptions {
   conventional: boolean
   includeBranchName: boolean
   noVerify: boolean
+  split?: boolean
+  plan?: boolean
+  apply?: boolean
 }
 
 export type CommitArgv = Arguments<CommitOptions>
@@ -98,6 +101,21 @@ export const options = {
     type: 'boolean',
     default: false,
     alias: 'n',
+  },
+  split: {
+    description: 'Group staged changes into multiple related commit proposals',
+    type: 'boolean',
+    default: false,
+  },
+  plan: {
+    description: 'Only print a commit split plan without changing git state',
+    type: 'boolean',
+    default: false,
+  },
+  apply: {
+    description: 'Apply a generated file-level commit split plan and create commits',
+    type: 'boolean',
+    default: false,
   },
 } as Record<string, Options>
 

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -29,6 +29,7 @@ import {
 } from './config'
 import { noResult } from './noResult'
 import { COMMIT_PROMPT, CONVENTIONAL_COMMIT_PROMPT } from './prompt'
+import { handleCommitSplit, isCommitSplitCommand } from './split'
 
 export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
   const git = getRepo()
@@ -65,6 +66,23 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
   logger.verbose(`→ ${provider} (${model})`, {
     color: 'green',
   })
+
+  if (isCommitSplitCommand(argv)) {
+    const splitResult = await handleCommitSplit({
+      argv,
+      config,
+      git,
+      logger,
+      tokenizer,
+      llm,
+    })
+
+    await handleResult({
+      result: splitResult,
+      mode: config.mode || 'stdout',
+    })
+    return
+  }
 
   const USE_CONVENTIONAL_COMMITS = config.conventionalCommits || argv.conventional
 

--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -1,0 +1,237 @@
+import { PromptTemplate } from '@langchain/core/prompts'
+import { z } from 'zod'
+import { Arguments } from 'yargs'
+import { Config } from '../../lib/config/types'
+import { executeChainWithSchema } from '../../lib/langchain/utils/executeChainWithSchema'
+import { getLlm } from '../../lib/langchain/utils/getLlm'
+import { fileChangeParser } from '../../lib/parsers/default'
+import { createCommit } from '../../lib/simple-git/createCommit'
+import { getChanges } from '../../lib/simple-git/getChanges'
+import { FileChange } from '../../lib/types'
+import { Logger } from '../../lib/utils/logger'
+import { TokenCounter } from '../../lib/utils/tokenizer'
+import { CommitOptions } from './config'
+
+export const CommitSplitPlanSchema = z.object({
+  groups: z
+    .array(
+      z.object({
+        title: z.string().min(1),
+        body: z.string().optional(),
+        rationale: z.string().optional(),
+        files: z.array(z.string()).min(1),
+      })
+    )
+    .min(1),
+})
+
+export type CommitSplitPlan = z.infer<typeof CommitSplitPlanSchema>
+export type CommitSplitGroup = CommitSplitPlan['groups'][number]
+
+const COMMIT_SPLIT_PROMPT = PromptTemplate.fromTemplate(`You are helping split staged git changes into a small sequence of coherent commits.
+
+Return ONLY valid JSON matching this schema:
+{{
+  "groups": [
+    {{
+      "title": "conventional commit style title",
+      "body": "commit body",
+      "rationale": "why these files belong together",
+      "files": ["relative/path.ts"]
+    }}
+  ]
+}}
+
+Rules:
+- Use each staged file exactly once.
+- Only use file paths listed in the staged file inventory.
+- Prefer 2-5 commits unless the changes are truly all one topic.
+- Keep commit titles concise and understandable.
+- Do not invent files.
+
+Staged file inventory:
+{file_inventory}
+
+Condensed staged diff:
+{summary}
+
+Additional context:
+{additional_context}`)
+
+export function isCommitSplitCommand(argv: Arguments<CommitOptions>): boolean {
+  return Boolean(argv.split || argv.plan || argv.apply || argv._.includes('split'))
+}
+
+export function formatCommitSplitPlan(plan: CommitSplitPlan): string {
+  return plan.groups
+    .map((group, index) => {
+      const body = group.body ? `\n\n${group.body}` : ''
+      const rationale = group.rationale ? `\n\nRationale: ${group.rationale}` : ''
+      const files = group.files.map((file) => `- ${file}`).join('\n')
+      return `## ${index + 1}. ${group.title}${body}${rationale}\n\nFiles:\n${files}`
+    })
+    .join('\n\n---\n\n')
+}
+
+function getStagedFileSet(changes: FileChange[]): Set<string> {
+  return new Set(changes.map((change) => change.filePath))
+}
+
+function validatePlanForStagedFiles(plan: CommitSplitPlan, staged: FileChange[]): void {
+  const stagedFiles = getStagedFileSet(staged)
+  const seen = new Set<string>()
+  const unknown: string[] = []
+  const duplicate: string[] = []
+
+  plan.groups.forEach((group) => {
+    group.files.forEach((file) => {
+      if (!stagedFiles.has(file)) {
+        unknown.push(file)
+        return
+      }
+
+      if (seen.has(file)) {
+        duplicate.push(file)
+        return
+      }
+
+      seen.add(file)
+    })
+  })
+
+  const missing = [...stagedFiles].filter((file) => !seen.has(file))
+
+  if (unknown.length || duplicate.length || missing.length) {
+    throw new Error(
+      [
+        unknown.length ? `unknown files: ${unknown.join(', ')}` : undefined,
+        duplicate.length ? `duplicate files: ${duplicate.join(', ')}` : undefined,
+        missing.length ? `missing files: ${missing.join(', ')}` : undefined,
+      ]
+        .filter(Boolean)
+        .join('; ')
+    )
+  }
+}
+
+function assertNoUnstagedOverlap(plan: CommitSplitPlan, changes: Awaited<ReturnType<typeof getChanges>>): void {
+  const plannedFiles = new Set(plan.groups.flatMap((group) => group.files))
+  const overlapping = [...(changes.unstaged || []), ...(changes.untracked || [])]
+    .map((change) => change.filePath)
+    .filter((file) => plannedFiles.has(file))
+
+  if (overlapping.length > 0) {
+    throw new Error(
+      `Cannot apply split plan because these files also have unstaged or untracked changes: ${overlapping.join(', ')}`
+    )
+  }
+}
+
+async function applyCommitSplitPlan({
+  plan,
+  changes,
+  git,
+  logger,
+  noVerify,
+}: {
+  plan: CommitSplitPlan
+  changes: Awaited<ReturnType<typeof getChanges>>
+  git: ReturnType<typeof import('../../lib/simple-git/getRepo').getRepo>
+  logger: Logger
+  noVerify: boolean
+}): Promise<string> {
+  validatePlanForStagedFiles(plan, changes.staged)
+  assertNoUnstagedOverlap(plan, changes)
+
+  await git.raw(['reset'])
+
+  for (const group of plan.groups) {
+    await git.add(group.files)
+    await createCommit(`${group.title}\n\n${group.body}`.trim(), git, undefined, { noVerify })
+    logger.verbose(`Created split commit: ${group.title}`, { color: 'green' })
+  }
+
+  return `Created ${plan.groups.length} split commit(s).`
+}
+
+export async function handleCommitSplit({
+  argv,
+  config,
+  git,
+  logger,
+  tokenizer,
+  llm,
+}: {
+  argv: Arguments<CommitOptions>
+  config: Config & CommitOptions
+  git: ReturnType<typeof import('../../lib/simple-git/getRepo').getRepo>
+  logger: Logger
+  tokenizer: TokenCounter
+  llm: ReturnType<typeof getLlm>
+}): Promise<string> {
+  const changes = await getChanges({
+    git,
+    options: {
+      ignoredFiles: config.ignoredFiles || undefined,
+      ignoredExtensions: config.ignoredExtensions || undefined,
+    },
+  })
+
+  if (changes.staged.length === 0) {
+    return 'No staged changes found.'
+  }
+
+  const summary = await fileChangeParser({
+    changes: changes.staged,
+    commit: '--staged',
+    options: {
+      tokenizer,
+      git,
+      llm,
+      logger,
+      maxTokens: config.service.tokenLimit,
+      minTokensForSummary: config.service.minTokensForSummary,
+      maxFileTokens: config.service.maxFileTokens,
+      maxConcurrent: config.service.maxConcurrent,
+    },
+  })
+
+  const fileInventory = changes.staged
+    .map((change) => `- ${change.filePath}: ${change.status} - ${change.summary}`)
+    .join('\n')
+
+  const plan = await executeChainWithSchema<CommitSplitPlan>(
+    CommitSplitPlanSchema,
+    llm,
+    COMMIT_SPLIT_PROMPT,
+    {
+      file_inventory: fileInventory,
+      summary,
+      additional_context: argv.additional || '',
+    },
+    {
+      logger,
+      tokenizer,
+      metadata: {
+        task: 'commit-split-plan',
+        command: 'commit',
+        provider: config.service.provider,
+        model: String(config.service.model),
+      },
+    }
+  )
+
+  validatePlanForStagedFiles(plan, changes.staged)
+
+  if (argv.apply) {
+    return await applyCommitSplitPlan({
+      plan,
+      changes,
+      git,
+      logger,
+      noVerify: argv.noVerify || config.noVerify || false,
+    })
+  }
+
+  return formatCommitSplitPlan(plan)
+}


### PR DESCRIPTION
## Summary
- Adds coco commit split --plan for non-mutating file-level split plans
- Adds coco commit split --apply to safely create one commit per generated file group
- Reuses existing staged change collection, diff condensation, schema-chain execution, and createCommit utilities
- Adds temp git repo integration coverage for split plan and apply flows
- Documents the file-level safety model and hunk-level follow-up risks

Fixes #617
Fixes #618
Fixes #619
Fixes #620

## Validation
- npm run test:jest -- --runTestsByPath src/commands/commands.integration.test.ts src/commands/commit/commit.test.ts
- npm test