### PR TITLE
Add hunk-level commit split support

### DIFF
--- a/docs/COMMIT_SPLIT.md
+++ b/docs/COMMIT_SPLIT.md
@@ -10,24 +10,30 @@ coco commit split --apply
 ```
 
 `--plan` is non-mutating. It reads staged changes, condenses the diffs using the existing
-diff parser, and asks the configured model to group files into proposed commits.
+diff parser, builds a staged hunk inventory for modified files, and asks the configured
+model to group files or hunks into proposed commits.
 
-`--apply` starts from a generated plan and creates one commit per group. The first
-implementation is file-level only. It intentionally aborts if a planned file also has
-unstaged or untracked changes, because staging the whole file would otherwise mix unrelated
-work into a generated commit.
+`--apply` starts from a generated plan and creates one commit per group. Whole-file groups
+stage the listed files. Hunk groups apply selected staged hunks directly to the index with
+`git apply --cached`, which allows separate commits from different parts of the same file.
+
+Whole-file groups intentionally abort if a planned file also has unstaged or untracked
+changes, because staging the whole file would otherwise mix unrelated work into a generated
+commit. Hunk groups do not stage the whole file.
 
 ## Safety Rules
 
 - Every staged file must appear exactly once in the plan.
+- A file can be assigned either as a whole file or by all of its hunk IDs, but not both.
+- If a file is split by hunks, every generated hunk for that file must be assigned exactly once.
 - Plan files must match real staged files.
-- Apply mode unstages the current index, stages one group at a time, and uses the existing
-  `createCommit` utility.
-- Unstaged overlap blocks apply mode.
+- Plan hunks must match real staged hunk IDs.
+- Apply mode unstages the current index, stages one group at a time, applies selected hunks
+  with `git apply --cached`, and uses the existing `createCommit` utility.
+- Unstaged overlap blocks whole-file apply mode.
 
-## Hunk-Level Follow-Up
+## Hunk-Level Limits
 
-Hunk-level grouping is intentionally not applied yet. It needs a structured patch parser and
-safe staging strategy because one file can contain unrelated staged and unstaged changes. The
-safe path is to prototype hunk staging in temp repositories before adding an apply mode that
-can split a single file across multiple commits.
+Hunk-level apply is intentionally fail-closed. If a generated hunk patch cannot be applied
+cleanly after earlier split commits have changed the file, the command stops and leaves the
+remaining working tree changes available for manual review.

--- a/src/commands/commands.integration.test.ts
+++ b/src/commands/commands.integration.test.ts
@@ -278,6 +278,103 @@ describe('command integration with temp git repos', () => {
     expect(status.files).toHaveLength(0)
   })
 
+  it('applies a hunk-level commit split plan within a single file', async () => {
+    mockLoadConfig.mockReturnValue(createConfig({
+      mode: 'stdout',
+    }))
+    mockExecuteChainWithSchema.mockResolvedValueOnce({
+      groups: [
+        {
+          title: 'feat: update first behavior',
+          body: 'Update the first behavior in the shared module.',
+          rationale: 'The first hunk is an independent behavior change.',
+          files: [],
+          hunks: ['src/feature.ts::hunk-1'],
+        },
+        {
+          title: 'fix: update second behavior',
+          body: 'Update the second behavior in the shared module.',
+          rationale: 'The second hunk is an independent behavior change.',
+          files: [],
+          hunks: ['src/feature.ts::hunk-2'],
+        },
+      ],
+    })
+
+    await repo.writeFile(
+      'src/feature.ts',
+      [
+        'export const first = "old"',
+        'const spacer1 = 1',
+        'const spacer2 = 2',
+        'const spacer3 = 3',
+        'const spacer4 = 4',
+        'const spacer5 = 5',
+        'const spacer6 = 6',
+        'const spacer7 = 7',
+        'const spacer8 = 8',
+        'export const second = "old"',
+        '',
+      ].join('\n')
+    )
+    await repo.commitAll('chore: initial feature')
+    await repo.writeFile(
+      'src/feature.ts',
+      [
+        'export const first = "new"',
+        'const spacer1 = 1',
+        'const spacer2 = 2',
+        'const spacer3 = 3',
+        'const spacer4 = 4',
+        'const spacer5 = 5',
+        'const spacer6 = 6',
+        'const spacer7 = 7',
+        'const spacer8 = 8',
+        'export const second = "new"',
+        '',
+      ].join('\n')
+    )
+    await repo.git.add('src/feature.ts')
+
+    await commitHandler({
+      $0: 'coco',
+      _: ['commit', 'split'],
+      interactive: false,
+      openInEditor: false,
+      ignoredFiles: [],
+      ignoredExtensions: [],
+      withPreviousCommits: 0,
+      conventional: false,
+      includeBranchName: false,
+      noDiff: false,
+      noVerify: true,
+      split: true,
+      plan: false,
+      apply: true,
+      verbose: false,
+      version: false,
+      help: false,
+    } as Arguments<CommitOptions>, createLogger())
+
+    const log = await repo.git.log()
+    const firstCommit = await repo.git.show(['HEAD~1:src/feature.ts'])
+    const secondCommit = await repo.git.show(['HEAD:src/feature.ts'])
+    const status = await repo.git.status()
+    const variables = mockExecuteChainWithSchema.mock.calls[0][3] as Record<string, string>
+
+    expect(stdout).toContain('Created 2 split commit(s).')
+    expect(log.all.map((commit) => commit.message)).toEqual(
+      expect.arrayContaining(['feat: update first behavior', 'fix: update second behavior'])
+    )
+    expect(firstCommit).toContain('export const first = "new"')
+    expect(firstCommit).toContain('export const second = "old"')
+    expect(secondCommit).toContain('export const first = "new"')
+    expect(secondCommit).toContain('export const second = "new"')
+    expect(status.files).toHaveLength(0)
+    expect(variables.hunk_inventory).toContain('src/feature.ts::hunk-1')
+    expect(variables.hunk_inventory).toContain('src/feature.ts::hunk-2')
+  })
+
   it('generates a changelog from real branch commit history', async () => {
     mockLoadConfig.mockImplementation((argv) => createConfig({
       ...(argv as Record<string, unknown>),

--- a/src/commands/commit/config.ts
+++ b/src/commands/commit/config.ts
@@ -113,7 +113,7 @@ export const options = {
     default: false,
   },
   apply: {
-    description: 'Apply a generated file-level commit split plan and create commits',
+    description: 'Apply a generated file-level or hunk-level commit split plan and create commits',
     type: 'boolean',
     default: false,
   },

--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -1,4 +1,6 @@
 import { PromptTemplate } from '@langchain/core/prompts'
+import { spawn } from 'child_process'
+import { formatPatch, parsePatch, StructuredPatch, StructuredPatchHunk } from 'diff'
 import { z } from 'zod'
 import { Arguments } from 'yargs'
 import { Config } from '../../lib/config/types'
@@ -19,7 +21,11 @@ export const CommitSplitPlanSchema = z.object({
         title: z.string().min(1),
         body: z.string().optional(),
         rationale: z.string().optional(),
-        files: z.array(z.string()).min(1),
+        files: z.array(z.string()),
+        hunks: z.array(z.string()),
+      })
+      .refine((group) => group.files.length > 0 || group.hunks.length > 0, {
+        message: 'Each group must include at least one file or hunk',
       })
     )
     .min(1),
@@ -37,20 +43,27 @@ Return ONLY valid JSON matching this schema:
       "title": "conventional commit style title",
       "body": "commit body",
       "rationale": "why these files belong together",
-      "files": ["relative/path.ts"]
+      "files": ["relative/path.ts"],
+      "hunks": ["relative/path.ts::hunk-1"]
     }}
   ]
 }}
 
 Rules:
 - Use each staged file exactly once.
+- If a file has hunk IDs and contains unrelated changes, assign every hunk ID exactly once instead of assigning the whole file.
+- Do not list the same file in "files" when assigning that file through "hunks".
 - Only use file paths listed in the staged file inventory.
+- Only use hunk IDs listed in the staged hunk inventory.
 - Prefer 2-5 commits unless the changes are truly all one topic.
 - Keep commit titles concise and understandable.
 - Do not invent files.
 
 Staged file inventory:
 {file_inventory}
+
+Staged hunk inventory:
+{hunk_inventory}
 
 Condensed staged diff:
 {summary}
@@ -67,24 +80,123 @@ export function formatCommitSplitPlan(plan: CommitSplitPlan): string {
     .map((group, index) => {
       const body = group.body ? `\n\n${group.body}` : ''
       const rationale = group.rationale ? `\n\nRationale: ${group.rationale}` : ''
-      const files = group.files.map((file) => `- ${file}`).join('\n')
-      return `## ${index + 1}. ${group.title}${body}${rationale}\n\nFiles:\n${files}`
+      const files = (group.files || []).map((file) => `- ${file}`).join('\n')
+      const hunks = (group.hunks || []).map((hunk) => `- ${hunk}`).join('\n')
+      const sections = [
+        files ? `Files:\n${files}` : undefined,
+        hunks ? `Hunks:\n${hunks}` : undefined,
+      ].filter(Boolean)
+
+      return `## ${index + 1}. ${group.title}${body}${rationale}\n\n${sections.join('\n\n')}`
     })
     .join('\n\n---\n\n')
+}
+
+type StagedHunk = {
+  id: string
+  filePath: string
+  patch: StructuredPatch
+  hunk: StructuredPatchHunk
+  header: string
+  preview: string
+}
+
+type HunkInventory = {
+  hunks: StagedHunk[]
+  byId: Map<string, StagedHunk>
+  byFile: Map<string, StagedHunk[]>
 }
 
 function getStagedFileSet(changes: FileChange[]): Set<string> {
   return new Set(changes.map((change) => change.filePath))
 }
 
-function validatePlanForStagedFiles(plan: CommitSplitPlan, staged: FileChange[]): void {
+function getGroupFiles(group: CommitSplitGroup): string[] {
+  return group.files || []
+}
+
+function getGroupHunks(group: CommitSplitGroup): string[] {
+  return group.hunks || []
+}
+
+function hunkHeader(hunk: StructuredPatchHunk): string {
+  return `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`
+}
+
+function hunkPreview(hunk: StructuredPatchHunk): string {
+  return hunk.lines
+    .filter((line) => line.startsWith('+') || line.startsWith('-'))
+    .slice(0, 6)
+    .join('\n')
+}
+
+async function collectHunkInventory(
+  staged: FileChange[],
+  git: ReturnType<typeof import('../../lib/simple-git/getRepo').getRepo>
+): Promise<HunkInventory> {
+  const hunks: StagedHunk[] = []
+  const byId = new Map<string, StagedHunk>()
+  const byFile = new Map<string, StagedHunk[]>()
+
+  for (const change of staged) {
+    if (change.status !== 'modified') {
+      continue
+    }
+
+    const diff = await git.diff(['--staged', '--', change.filePath])
+    const [patch] = parsePatch(diff)
+
+    if (!patch || patch.hunks.length === 0) {
+      continue
+    }
+
+    patch.hunks.forEach((hunk, index) => {
+      const stagedHunk = {
+        id: `${change.filePath}::hunk-${index + 1}`,
+        filePath: change.filePath,
+        patch,
+        hunk,
+        header: hunkHeader(hunk),
+        preview: hunkPreview(hunk),
+      }
+
+      hunks.push(stagedHunk)
+      byId.set(stagedHunk.id, stagedHunk)
+      byFile.set(change.filePath, [...(byFile.get(change.filePath) || []), stagedHunk])
+    })
+  }
+
+  return { hunks, byId, byFile }
+}
+
+function formatHunkInventory(inventory: HunkInventory): string {
+  if (inventory.hunks.length === 0) {
+    return 'No hunk-level inventory available. Use file-level groups.'
+  }
+
+  return inventory.hunks
+    .map((hunk) => {
+      const preview = hunk.preview ? `\n${hunk.preview}` : ''
+      return `- ${hunk.id}: ${hunk.header}${preview}`
+    })
+    .join('\n')
+}
+
+function validatePlanForStagedFiles(
+  plan: CommitSplitPlan,
+  staged: FileChange[],
+  hunkInventory?: HunkInventory
+): void {
   const stagedFiles = getStagedFileSet(staged)
   const seen = new Set<string>()
+  const seenHunks = new Set<string>()
   const unknown: string[] = []
   const duplicate: string[] = []
+  const unknownHunks: string[] = []
+  const duplicateHunks: string[] = []
 
   plan.groups.forEach((group) => {
-    group.files.forEach((file) => {
+    getGroupFiles(group).forEach((file) => {
       if (!stagedFiles.has(file)) {
         unknown.push(file)
         return
@@ -97,15 +209,52 @@ function validatePlanForStagedFiles(plan: CommitSplitPlan, staged: FileChange[])
 
       seen.add(file)
     })
+
+    getGroupHunks(group).forEach((hunkId) => {
+      const hunk = hunkInventory?.byId.get(hunkId)
+      if (!hunk) {
+        unknownHunks.push(hunkId)
+        return
+      }
+
+      if (seenHunks.has(hunkId)) {
+        duplicateHunks.push(hunkId)
+        return
+      }
+
+      seenHunks.add(hunkId)
+    })
   })
 
-  const missing = [...stagedFiles].filter((file) => !seen.has(file))
+  const hunkCoveredFiles = new Set([...seenHunks].map((hunkId) => hunkInventory?.byId.get(hunkId)?.filePath))
+  const mixedFiles = [...seen].filter((file) => hunkCoveredFiles.has(file))
+  const partiallyCoveredFiles = [...hunkCoveredFiles]
+    .filter((file): file is string => Boolean(file))
+    .filter((file) => {
+      const fileHunks = hunkInventory?.byFile.get(file) || []
+      return fileHunks.some((hunk) => !seenHunks.has(hunk.id))
+    })
+  const missing = [...stagedFiles].filter((file) => !seen.has(file) && !hunkCoveredFiles.has(file))
 
-  if (unknown.length || duplicate.length || missing.length) {
+  if (
+    unknown.length ||
+    duplicate.length ||
+    unknownHunks.length ||
+    duplicateHunks.length ||
+    mixedFiles.length ||
+    partiallyCoveredFiles.length ||
+    missing.length
+  ) {
     throw new Error(
       [
         unknown.length ? `unknown files: ${unknown.join(', ')}` : undefined,
         duplicate.length ? `duplicate files: ${duplicate.join(', ')}` : undefined,
+        unknownHunks.length ? `unknown hunks: ${unknownHunks.join(', ')}` : undefined,
+        duplicateHunks.length ? `duplicate hunks: ${duplicateHunks.join(', ')}` : undefined,
+        mixedFiles.length ? `files assigned both as whole files and hunks: ${mixedFiles.join(', ')}` : undefined,
+        partiallyCoveredFiles.length
+          ? `files with only some hunks assigned: ${partiallyCoveredFiles.join(', ')}`
+          : undefined,
         missing.length ? `missing files: ${missing.join(', ')}` : undefined,
       ]
         .filter(Boolean)
@@ -114,8 +263,23 @@ function validatePlanForStagedFiles(plan: CommitSplitPlan, staged: FileChange[])
   }
 }
 
-function assertNoUnstagedOverlap(plan: CommitSplitPlan, changes: Awaited<ReturnType<typeof getChanges>>): void {
-  const plannedFiles = new Set(plan.groups.flatMap((group) => group.files))
+function assertNoUnstagedOverlap(
+  plan: CommitSplitPlan,
+  changes: Awaited<ReturnType<typeof getChanges>>,
+  hunkInventory?: HunkInventory
+): void {
+  const hunkFiles = new Set(
+    plan.groups.flatMap((group) =>
+      getGroupHunks(group)
+        .map((hunkId) => hunkInventory?.byId.get(hunkId)?.filePath)
+        .filter((file): file is string => Boolean(file))
+    )
+  )
+  const plannedFiles = new Set(
+    plan.groups
+      .flatMap((group) => getGroupFiles(group))
+      .filter((file) => !hunkFiles.has(file))
+  )
   const overlapping = [...(changes.unstaged || []), ...(changes.untracked || [])]
     .map((change) => change.filePath)
     .filter((file) => plannedFiles.has(file))
@@ -127,26 +291,89 @@ function assertNoUnstagedOverlap(plan: CommitSplitPlan, changes: Awaited<ReturnT
   }
 }
 
+function buildPatchForHunks(hunks: StagedHunk[]): string {
+  const byFile = new Map<string, StagedHunk[]>()
+
+  hunks.forEach((hunk) => {
+    byFile.set(hunk.filePath, [...(byFile.get(hunk.filePath) || []), hunk])
+  })
+
+  return [...byFile.values()]
+    .map((fileHunks) => {
+      const [firstHunk] = fileHunks
+      return formatPatch({
+        ...firstHunk.patch,
+        hunks: fileHunks.map((hunk) => hunk.hunk),
+      })
+    })
+    .join('\n')
+}
+
+async function applyPatchToIndex(
+  patch: string,
+  git: ReturnType<typeof import('../../lib/simple-git/getRepo').getRepo>
+): Promise<void> {
+  const cwd = await git.revparse(['--show-toplevel'])
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn('git', ['apply', '--cached', '-'], {
+      cwd,
+      stdio: ['pipe', 'ignore', 'pipe'],
+    })
+    let stderr = ''
+
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk)
+    })
+
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve()
+        return
+      }
+
+      reject(new Error(`Failed to apply hunk patch to index: ${stderr.trim()}`))
+    })
+
+    child.stdin.write(patch)
+    child.stdin.end()
+  })
+}
+
 async function applyCommitSplitPlan({
   plan,
   changes,
+  hunkInventory,
   git,
   logger,
   noVerify,
 }: {
   plan: CommitSplitPlan
   changes: Awaited<ReturnType<typeof getChanges>>
+  hunkInventory: HunkInventory
   git: ReturnType<typeof import('../../lib/simple-git/getRepo').getRepo>
   logger: Logger
   noVerify: boolean
 }): Promise<string> {
-  validatePlanForStagedFiles(plan, changes.staged)
-  assertNoUnstagedOverlap(plan, changes)
+  validatePlanForStagedFiles(plan, changes.staged, hunkInventory)
+  assertNoUnstagedOverlap(plan, changes, hunkInventory)
 
   await git.raw(['reset'])
 
   for (const group of plan.groups) {
-    await git.add(group.files)
+    const groupFiles = getGroupFiles(group)
+    const groupHunks = getGroupHunks(group).map((hunkId) => hunkInventory.byId.get(hunkId))
+
+    if (groupFiles.length > 0) {
+      await git.add(groupFiles)
+    }
+
+    if (groupHunks.length > 0) {
+      const patch = buildPatchForHunks(groupHunks.filter((hunk): hunk is StagedHunk => Boolean(hunk)))
+      await applyPatchToIndex(patch, git)
+    }
+
     await createCommit(`${group.title}\n\n${group.body}`.trim(), git, undefined, { noVerify })
     logger.verbose(`Created split commit: ${group.title}`, { color: 'green' })
   }
@@ -181,6 +408,7 @@ export async function handleCommitSplit({
     return 'No staged changes found.'
   }
 
+  const hunkInventory = await collectHunkInventory(changes.staged, git)
   const summary = await fileChangeParser({
     changes: changes.staged,
     commit: '--staged',
@@ -199,6 +427,7 @@ export async function handleCommitSplit({
   const fileInventory = changes.staged
     .map((change) => `- ${change.filePath}: ${change.status} - ${change.summary}`)
     .join('\n')
+  const hunkInventoryText = formatHunkInventory(hunkInventory)
 
   const plan = await executeChainWithSchema<CommitSplitPlan>(
     CommitSplitPlanSchema,
@@ -206,6 +435,7 @@ export async function handleCommitSplit({
     COMMIT_SPLIT_PROMPT,
     {
       file_inventory: fileInventory,
+      hunk_inventory: hunkInventoryText,
       summary,
       additional_context: argv.additional || '',
     },
@@ -221,12 +451,13 @@ export async function handleCommitSplit({
     }
   )
 
-  validatePlanForStagedFiles(plan, changes.staged)
+  validatePlanForStagedFiles(plan, changes.staged, hunkInventory)
 
   if (argv.apply) {
     return await applyCommitSplitPlan({
       plan,
       changes,
+      hunkInventory,
       git,
       logger,
       noVerify: argv.noVerify || config.noVerify || false,


### PR DESCRIPTION
## Summary

- extend commit split plans with optional hunk groups for modified files
- validate whole-file and hunk-level coverage before apply mode mutates the index
- apply selected hunks with git apply --cached so one file can be split across commits
- document the safety model and add real-git integration coverage

## Validation

- npm run test:jest -- src/commands/commands.integration.test.ts --runInBand
- npm test

Closes #631