### PR TITLE
Add release dry-run validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,6 @@ jobs:
 
       - name: Verify package dry run
         run: npm pack --dry-run
+
+      - name: Validate release dry run
+        run: npm run release:dry-run

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Run release gate
         run: npm test
 
+      - name: Validate release dry run
+        run: npm run release:dry-run
+
   publish:
     name: Publish package to npm
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test:jest": "jest",
     "test:jest:watch": "jest --watch",
     "release": "release-it",
+    "release:dry-run": "release-it --ci --dry-run --no-git --no-github.release --no-github.publish --no-npm.publish",
     "prepublishOnly": "npm run clean && npm run build",
     "coco": "npm run coco:ts",
     "coco:ts": "tsx src/index.ts",


### PR DESCRIPTION
## Summary

- add a release:dry-run script that validates release-it configuration without publishing
- run release dry-run validation in PR CI after package verification
- run the same dry-run in the release verification workflow before npm publish is allowed

## Validation

- npm run release:dry-run
- npm run lint

Closes #637