### PR TITLE
Enforce recap and review prompt budgets

### DIFF
--- a/src/commands/recap/handler.ts
+++ b/src/commands/recap/handler.ts
@@ -4,6 +4,7 @@ import { loadConfig } from '../../lib/config/utils/loadConfig'
 import { getApiKeyForModel, getModelAndProviderFromConfig } from '../../lib/langchain/utils'
 import { executeChain } from '../../lib/langchain/utils/executeChain'
 import { createSchemaParser } from '../../lib/langchain/utils/createSchemaParser'
+import { enforcePromptBudget } from '../../lib/langchain/utils/enforcePromptBudget'
 import { getLlm } from '../../lib/langchain/utils/getLlm'
 import { resolveDynamicService } from '../../lib/langchain/utils/dynamicModels'
 import { getPrompt } from '../../lib/langchain/utils/getPrompt'
@@ -186,14 +187,30 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const parser: any = createSchemaParser(RecapLlmResponseSchema, llm)
         
+        const variables = {
+          changes: context,
+          format_instructions: formatInstructions,
+          timeframe,
+        }
+        const budgetedPrompt = await enforcePromptBudget({
+          prompt,
+          variables,
+          tokenizer,
+          maxTokens: config.service.tokenLimit || 2048,
+          summaryKey: 'changes',
+        })
+
+        if (budgetedPrompt.truncated) {
+          logger.verbose(
+            `Rendered prompt exceeded token budget; trimmed changes to ${budgetedPrompt.promptTokenCount} tokens.`,
+            { color: 'yellow' }
+          )
+        }
+
         const response = await executeChain<{ title: string; summary: string }>({
           llm,
           prompt,
-          variables: {
-            changes: context,
-            format_instructions: formatInstructions,
-            timeframe,
-          },
+          variables: budgetedPrompt.variables,
           parser,
           logger,
           tokenizer,

--- a/src/commands/review/handler.ts
+++ b/src/commands/review/handler.ts
@@ -6,6 +6,7 @@ import { loadConfig } from '../../lib/config/utils/loadConfig'
 import { getApiKeyForModel, getModelAndProviderFromConfig } from '../../lib/langchain/utils'
 import { executeChain } from '../../lib/langchain/utils/executeChain'
 import { resolveDynamicService } from '../../lib/langchain/utils/dynamicModels'
+import { enforcePromptBudget } from '../../lib/langchain/utils/enforcePromptBudget'
 import { getLlm } from '../../lib/langchain/utils/getLlm'
 import { getPrompt } from '../../lib/langchain/utils/getPrompt'
 import { fileChangeParser } from '../../lib/parsers/default/index'
@@ -169,13 +170,29 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
         fallback: REVIEW_PROMPT,
       })
 
+      const variables = {
+        changes: context,
+        format_instructions: formatInstructions,
+      }
+      const budgetedPrompt = await enforcePromptBudget({
+        prompt,
+        variables,
+        tokenizer,
+        maxTokens: config.service.tokenLimit || 2048,
+        summaryKey: 'changes',
+      })
+
+      if (budgetedPrompt.truncated) {
+        logger.verbose(
+          `Rendered prompt exceeded token budget; trimmed changes to ${budgetedPrompt.promptTokenCount} tokens.`,
+          { color: 'yellow' }
+        )
+      }
+
       const response = await executeChain({
         llm,
         prompt,
-        variables: {
-          changes: context,
-          format_instructions: formatInstructions,
-        },
+        variables: budgetedPrompt.variables,
         parser,
         logger,
         tokenizer,

--- a/src/commands/review/review.test.ts
+++ b/src/commands/review/review.test.ts
@@ -1,12 +1,12 @@
 import { Arguments } from 'yargs'
+import { SimpleGit } from 'simple-git'
 import { handler } from './handler'
-import { RecapOptions } from './config'
+import { ReviewOptions } from './config'
+import { Config } from '../../commands/types'
 import { getRepo } from '../../lib/simple-git/getRepo'
 import { getChanges } from '../../lib/simple-git/getChanges'
-import { getChangesByTimestamp } from '../../lib/simple-git/getChangesByTimestamp'
-import { getChangesSinceLastTag } from '../../lib/simple-git/getChangesSinceLastTag'
-import { getCurrentBranchName } from '../../lib/simple-git/getCurrentBranchName'
 import { getDiffForBranch } from '../../lib/simple-git/getDiffForBranch'
+import { getCurrentBranchName } from '../../lib/simple-git/getCurrentBranchName'
 import { fileChangeParser } from '../../lib/parsers/default'
 import { executeChain } from '../../lib/langchain/utils/executeChain'
 import { loadConfig } from '../../lib/config/utils/loadConfig'
@@ -14,39 +14,41 @@ import { getApiKeyForModel, getModelAndProviderFromConfig } from '../../lib/lang
 import { getLlm } from '../../lib/langchain/utils/getLlm'
 import { getTokenCounter } from '../../lib/utils/tokenizer'
 import { Logger } from '../../lib/utils/logger'
-import { SimpleGit } from 'simple-git'
-import { Config } from '../../commands/types'
 
 jest.mock('../../lib/simple-git/getRepo')
 jest.mock('../../lib/simple-git/getChanges')
-jest.mock('../../lib/simple-git/getChangesByTimestamp')
-jest.mock('../../lib/simple-git/getChangesSinceLastTag')
-jest.mock('../../lib/simple-git/getCurrentBranchName')
 jest.mock('../../lib/simple-git/getDiffForBranch')
+jest.mock('../../lib/simple-git/getCurrentBranchName')
 jest.mock('../../lib/parsers/default')
 jest.mock('../../lib/langchain/utils/executeChain')
+jest.mock('../../lib/langchain/utils/createSchemaParser', () => ({
+  createSchemaParser: jest.fn().mockReturnValue({}),
+}))
 jest.mock('../../lib/config/utils/loadConfig')
 jest.mock('../../lib/langchain/utils')
 jest.mock('../../lib/langchain/utils/getLlm')
 jest.mock('../../lib/utils/tokenizer')
 jest.mock('../../lib/ui/generateAndReviewLoop', () => ({
   generateAndReviewLoop: jest.fn().mockImplementation(async ({ factory, parser, agent, noResult, options }) => {
-    const changes = await factory();
+    const changes = await factory()
     if (!changes || (Array.isArray(changes) && changes.length === 0)) {
-      await noResult(options);
-      return '';
+      await noResult(options)
+      return []
     }
-    const context = await parser(changes, '', options);
-    return await agent(context, options);
+    const context = await parser(changes, '', options)
+    return await agent(context, options)
   }),
-}));
+}))
+jest.mock('../../lib/ui/TaskList', () => ({
+  TaskList: jest.fn().mockImplementation(() => ({
+    start: jest.fn(),
+  })),
+}))
 
 const mockGetRepo = getRepo as jest.MockedFunction<typeof getRepo>
 const mockGetChanges = getChanges as jest.MockedFunction<typeof getChanges>
-const mockGetChangesByTimestamp = getChangesByTimestamp as jest.MockedFunction<typeof getChangesByTimestamp>
-const mockGetChangesSinceLastTag = getChangesSinceLastTag as jest.MockedFunction<typeof getChangesSinceLastTag>
-const mockGetCurrentBranchName = getCurrentBranchName as jest.MockedFunction<typeof getCurrentBranchName>
 const mockGetDiffForBranch = getDiffForBranch as jest.MockedFunction<typeof getDiffForBranch>
+const mockGetCurrentBranchName = getCurrentBranchName as jest.MockedFunction<typeof getCurrentBranchName>
 const mockFileChangeParser = fileChangeParser as jest.MockedFunction<typeof fileChangeParser>
 const mockExecuteChain = executeChain as jest.MockedFunction<typeof executeChain>
 const mockLoadConfig = loadConfig as jest.MockedFunction<typeof loadConfig>
@@ -57,17 +59,16 @@ const mockGetModelAndProviderFromConfig = getModelAndProviderFromConfig as jest.
 const mockGetLlm = getLlm as jest.MockedFunction<typeof getLlm>
 const mockGetTokenCounter = getTokenCounter as jest.MockedFunction<typeof getTokenCounter>
 
-
-describe('recap command', () => {
-  let argv: Arguments<RecapOptions>
+describe('review command', () => {
+  let argv: Arguments<ReviewOptions>
   let logger: Logger
 
   beforeEach(() => {
     argv = {
       $0: 'coco',
-      _: ['recap'],
+      _: ['review'],
       interactive: false,
-      mode: 'stdout',
+      branch: '',
       verbose: false,
       version: false,
       help: false,
@@ -99,7 +100,7 @@ describe('recap command', () => {
       },
       defaultBranch: 'main',
       mode: 'stdout',
-      currentBranch: false,
+      interactive: false,
     } as unknown as Config)
     mockGetApiKeyForModel.mockReturnValue('mock-api-key')
     mockGetModelAndProviderFromConfig.mockReturnValue({
@@ -109,75 +110,33 @@ describe('recap command', () => {
     mockGetLlm.mockReturnValue({} as unknown as ReturnType<typeof getLlm>)
     mockGetTokenCounter.mockResolvedValue((text: string) => text.length)
     mockGetChanges.mockResolvedValue({
-      staged: [],
+      staged: [{ filePath: 'src/file.ts', status: 'modified', summary: 'changed file' }],
       unstaged: [],
       untracked: [],
     })
-    mockGetChangesByTimestamp.mockResolvedValue(['mocked timestamp changes'])
-    mockGetChangesSinceLastTag.mockResolvedValue(['mocked tag changes'])
     mockGetCurrentBranchName.mockResolvedValue('feature/test-branch')
     mockGetDiffForBranch.mockResolvedValue({
-      staged: [{ filePath: 'branch-file.txt', status: 'added', summary: 'branch file summary' }],
+      staged: [{ filePath: 'src/file.ts', status: 'modified', summary: 'changed file' }],
       unstaged: [],
       untracked: [],
     })
     mockFileChangeParser.mockResolvedValue('mocked file change summary')
-    mockExecuteChain.mockResolvedValue({ title: 'mocked git commit title', summary: 'mocked summary message from git commit message' })
+    mockExecuteChain.mockResolvedValue([
+      {
+        title: 'Review finding',
+        summary: 'A review finding.',
+        severity: 5,
+        category: 'maintainability',
+        filePath: 'src/file.ts',
+      },
+    ])
   })
 
   afterEach(() => {
     jest.clearAllMocks()
   })
 
-  it('should call getChanges for current timeframe', async () => {
-    await handler(argv, logger)
-    expect(mockGetChanges).toHaveBeenCalled()
-  })
-
-  it('should call getChangesByTimestamp for yesterday', async () => {
-    argv.yesterday = true
-    await handler(argv, logger)
-    expect(mockGetChangesByTimestamp).toHaveBeenCalled()
-  })
-
-  it('should call getChangesByTimestamp for last-week', async () => {
-    argv['last-week'] = true
-    await handler(argv, logger)
-    expect(mockGetChangesByTimestamp).toHaveBeenCalled()
-  })
-
-  it('should call getChangesByTimestamp for last-month', async () => {
-    argv['last-month'] = true
-    await handler(argv, logger)
-    expect(mockGetChangesByTimestamp).toHaveBeenCalled()
-  })
-
-  it('should call getChangesSinceLastTag for last-tag', async () => {
-    argv['last-tag'] = true
-    await handler(argv, logger)
-    expect(mockGetChangesSinceLastTag).toHaveBeenCalled()
-  })
-
-  it('should call getDiffForBranch for currentBranch', async () => {
-    argv.currentBranch = true
-    await handler(argv, logger)
-    expect(mockGetDiffForBranch).toHaveBeenCalledWith(expect.objectContaining({
-      baseBranch: 'main',
-      headBranch: 'feature/test-branch',
-    }))
-  })
-
-  it('should pass correct changes to parser for currentBranch', async () => {
-    argv.currentBranch = true
-    await handler(argv, logger)
-    expect(mockFileChangeParser).toHaveBeenCalledWith(expect.objectContaining({
-      changes: [
-        { filePath: 'branch-file.txt', status: 'added', summary: 'branch file summary' },
-      ],
-    }))
-  })
-
-  it('trims oversized rendered recap prompts before execution', async () => {
+  it('trims oversized rendered review prompts before execution', async () => {
     mockLoadConfig.mockReturnValue({
       service: {
         authentication: {
@@ -188,21 +147,21 @@ describe('recap command', () => {
         },
         provider: 'openai',
         model: 'gpt-4o',
-        tokenLimit: 700,
+        tokenLimit: 2000,
         temperature: 0.2,
         maxConcurrent: 1,
       },
       defaultBranch: 'main',
       mode: 'stdout',
-      currentBranch: false,
+      interactive: false,
     } as unknown as Config)
-    mockFileChangeParser.mockResolvedValue('x'.repeat(2000))
+    mockFileChangeParser.mockResolvedValue('x'.repeat(2500))
 
     await handler(argv, logger)
 
     const variables = mockExecuteChain.mock.calls[0][0].variables as Record<string, string>
 
-    expect(variables.changes.length).toBeLessThan(2000)
+    expect(variables.changes.length).toBeLessThan(2500)
     expect(logger.verbose).toHaveBeenCalledWith(
       expect.stringContaining('Rendered prompt exceeded token budget'),
       { color: 'yellow' }


### PR DESCRIPTION
## Summary

- apply rendered prompt budget enforcement before recap model calls
- apply the same guard before review model calls
- add recap and review tests for oversized change text trimming

## Validation

- npm run test:jest -- src/commands/recap/recap.test.ts src/commands/review/review.test.ts --runInBand
- npm run lint
- npm test

Closes #634