### PR TITLE
Add per-command LLM telemetry summaries

### DIFF
--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -3,6 +3,7 @@ import { LLMModel } from '../../lib/langchain/types'
 import { getApiKeyForModel, getModelAndProviderFromConfig } from '../../lib/langchain/utils'
 import { getLlm } from '../../lib/langchain/utils/getLlm'
 import { resolveDynamicService } from '../../lib/langchain/utils/dynamicModels'
+import { logLlmTelemetrySummary } from '../../lib/langchain/utils/observability'
 import { getPrompt } from '../../lib/langchain/utils/getPrompt'
 import { createSchemaParser } from '../../lib/langchain/utils/createSchemaParser'
 import { enforcePromptBudget } from '../../lib/langchain/utils/enforcePromptBudget'
@@ -173,6 +174,11 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
                       minTokensForSummary: config.service.minTokensForSummary,
                       maxFileTokens: config.service.maxFileTokens,
                       maxConcurrent: config.service.maxConcurrent,
+                      metadata: {
+                        command: 'changelog',
+                        provider,
+                        model: String(summaryService.model),
+                      },
                     },
                   })
                 : undefined,
@@ -203,6 +209,11 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
           minTokensForSummary: config.service.minTokensForSummary,
           maxFileTokens: config.service.maxFileTokens,
           maxConcurrent: config.service.maxConcurrent,
+          metadata: {
+            command: 'changelog',
+            provider,
+            model: String(summaryService.model),
+          },
         },
       })
 
@@ -323,4 +334,5 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
     },
     mode: MODE as 'interactive' | 'stdout',
   })
+  logLlmTelemetrySummary(logger, 'changelog')
 }

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -7,6 +7,7 @@ import { enforcePromptBudget } from '../../lib/langchain/utils/enforcePromptBudg
 import { formatCommitMessage } from '../../lib/langchain/utils/formatCommitMessage'
 import { getLlm } from '../../lib/langchain/utils/getLlm'
 import { resolveDynamicService } from '../../lib/langchain/utils/dynamicModels'
+import { logLlmTelemetrySummary } from '../../lib/langchain/utils/observability'
 import { getPrompt } from '../../lib/langchain/utils/getPrompt'
 import { fileChangeParser } from '../../lib/parsers/default'
 import { PreCommitHookError, createCommit } from '../../lib/simple-git/createCommit'
@@ -87,6 +88,7 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
       result: splitResult,
       mode: config.mode || 'stdout',
     })
+    logLlmTelemetrySummary(logger, 'commit')
     return
   }
 
@@ -135,6 +137,11 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
         minTokensForSummary: config.service.minTokensForSummary,
         maxFileTokens: config.service.maxFileTokens,
         maxConcurrent: config.service.maxConcurrent,
+        metadata: {
+          command: 'commit',
+          provider,
+          model: String(summaryService.model),
+        },
       },
     })
   }
@@ -585,4 +592,5 @@ IMPORTANT RULES:
     },
     mode: MODE as 'interactive' | 'stdout',
   })
+  logLlmTelemetrySummary(logger, 'commit')
 }

--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -418,11 +418,16 @@ export async function handleCommitSplit({
       llm,
       logger,
       maxTokens: config.service.tokenLimit,
-      minTokensForSummary: config.service.minTokensForSummary,
-      maxFileTokens: config.service.maxFileTokens,
-      maxConcurrent: config.service.maxConcurrent,
-    },
-  })
+        minTokensForSummary: config.service.minTokensForSummary,
+        maxFileTokens: config.service.maxFileTokens,
+        maxConcurrent: config.service.maxConcurrent,
+        metadata: {
+          command: 'commit',
+          provider: config.service.provider,
+          model: String(config.service.model),
+        },
+      },
+    })
 
   const fileInventory = changes.staged
     .map((change) => `- ${change.filePath}: ${change.status} - ${change.summary}`)

--- a/src/commands/recap/handler.ts
+++ b/src/commands/recap/handler.ts
@@ -7,6 +7,7 @@ import { createSchemaParser } from '../../lib/langchain/utils/createSchemaParser
 import { enforcePromptBudget } from '../../lib/langchain/utils/enforcePromptBudget'
 import { getLlm } from '../../lib/langchain/utils/getLlm'
 import { resolveDynamicService } from '../../lib/langchain/utils/dynamicModels'
+import { logLlmTelemetrySummary } from '../../lib/langchain/utils/observability'
 import { getPrompt } from '../../lib/langchain/utils/getPrompt'
 import { getChanges } from '../../lib/simple-git/getChanges'
 import { getChangesByTimestamp } from '../../lib/simple-git/getChangesByTimestamp'
@@ -84,7 +85,17 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
         const unstagedChanges = await fileChangeParser({
           changes: unstaged || [],
           commit: '--unstaged',
-          options: { tokenizer, git, llm: summaryLlm, logger },
+          options: {
+            tokenizer,
+            git,
+            llm: summaryLlm,
+            logger,
+            metadata: {
+              command: 'recap',
+              provider,
+              model: String(summaryService.model),
+            },
+          },
         })
 
         const unstagedResponse = `Unstaged changes:\n${unstagedChanges}`
@@ -92,14 +103,34 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
         const untrackedChanges = await fileChangeParser({
           changes: untracked || [],
           commit: '--untracked',
-          options: { tokenizer, git, llm: summaryLlm, logger },
+          options: {
+            tokenizer,
+            git,
+            llm: summaryLlm,
+            logger,
+            metadata: {
+              command: 'recap',
+              provider,
+              model: String(summaryService.model),
+            },
+          },
         })
         const untrackedResponse = `Untracked changes:\n${untrackedChanges}`
 
         const stagedChanges = await fileChangeParser({
           changes: staged,
           commit: '--staged',
-          options: { tokenizer, git, llm: summaryLlm, logger },
+          options: {
+            tokenizer,
+            git,
+            llm: summaryLlm,
+            logger,
+            metadata: {
+              command: 'recap',
+              provider,
+              model: String(summaryService.model),
+            },
+          },
         })
         const stagedResponse = `Staged changes:\n${stagedChanges}`
 
@@ -135,7 +166,17 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
         const branchChanges = await fileChangeParser({
           changes: changes.staged,
           commit: baseBranch,
-          options: { tokenizer, git, llm: summaryLlm, logger },
+          options: {
+            tokenizer,
+            git,
+            llm: summaryLlm,
+            logger,
+            metadata: {
+              command: 'recap',
+              provider,
+              model: String(summaryService.model),
+            },
+          },
         })
 
         return [branchChanges]
@@ -260,4 +301,5 @@ ${errorMessage}
     },
     mode: MODE as 'interactive' | 'stdout',
   })
+  logLlmTelemetrySummary(logger, 'recap')
 }

--- a/src/commands/review/handler.ts
+++ b/src/commands/review/handler.ts
@@ -7,6 +7,7 @@ import { getApiKeyForModel, getModelAndProviderFromConfig } from '../../lib/lang
 import { executeChain } from '../../lib/langchain/utils/executeChain'
 import { resolveDynamicService } from '../../lib/langchain/utils/dynamicModels'
 import { enforcePromptBudget } from '../../lib/langchain/utils/enforcePromptBudget'
+import { logLlmTelemetrySummary } from '../../lib/langchain/utils/observability'
 import { getLlm } from '../../lib/langchain/utils/getLlm'
 import { getPrompt } from '../../lib/langchain/utils/getPrompt'
 import { fileChangeParser } from '../../lib/parsers/default/index'
@@ -78,7 +79,17 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
       const branchChanges = await fileChangeParser({
         changes: diff.staged,
         commit: `--branch-diff-${argv.branch}`,
-        options: { tokenizer, git, llm: summaryLlm, logger },
+        options: {
+          tokenizer,
+          git,
+          llm: summaryLlm,
+          logger,
+          metadata: {
+            command: 'review',
+            provider,
+            model: String(summaryService.model),
+          },
+        },
       })
 
       return [branchChanges]
@@ -107,7 +118,17 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
       const unstagedChanges = await fileChangeParser({
         changes: unstaged || [],
         commit: '--unstaged',
-        options: { tokenizer, git, llm: summaryLlm, logger },
+        options: {
+          tokenizer,
+          git,
+          llm: summaryLlm,
+          logger,
+          metadata: {
+            command: 'review',
+            provider,
+            model: String(summaryService.model),
+          },
+        },
       })
 
       const unstagedResponse = `Unstaged changes:\n${unstagedChanges}`
@@ -115,14 +136,34 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
       const untrackedChanges = await fileChangeParser({
         changes: untracked || [],
         commit: '--untracked',
-        options: { tokenizer, git, llm: summaryLlm, logger },
+        options: {
+          tokenizer,
+          git,
+          llm: summaryLlm,
+          logger,
+          metadata: {
+            command: 'review',
+            provider,
+            model: String(summaryService.model),
+          },
+        },
       })
       const untrackedResponse = `Untracked changes:\n${untrackedChanges}`
 
       const stagedChanges = await fileChangeParser({
         changes: staged,
         commit: '--staged',
-        options: { tokenizer, git, llm: summaryLlm, logger },
+        options: {
+          tokenizer,
+          git,
+          llm: summaryLlm,
+          logger,
+          metadata: {
+            command: 'review',
+            provider,
+            model: String(summaryService.model),
+          },
+        },
       })
       const stagedResponse = `Staged changes:\n${stagedChanges}`
 
@@ -226,5 +267,6 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
   })
 
   const reviewer = new TaskList(recap as ReviewFeedbackItem[], { ...config, apiKey: key ?? undefined })
+  logLlmTelemetrySummary(logger, 'review')
   await reviewer.start()
 }

--- a/src/lib/langchain/chains/summarize/index.ts
+++ b/src/lib/langchain/chains/summarize/index.ts
@@ -31,17 +31,20 @@ export async function summarize(
     ? docs.reduce((sum, doc) => sum + tokenizer(doc.pageContent), 0)
     : undefined
 
-  logLlmCall(logger, {
-    task: 'summarize',
-    promptTokens,
-    inputDocuments: documents.length,
-    inputChunks: docs.length,
-    ...metadata,
-  })
-
+  const startedAt = Date.now()
   const res = await chain.invoke({
     input_documents: docs,
     returnIntermediateSteps,
+  })
+  const elapsedMs = Date.now() - startedAt
+
+  logLlmCall(logger, {
+    task: 'summarize',
+    promptTokens,
+    elapsedMs,
+    inputDocuments: documents.length,
+    inputChunks: docs.length,
+    ...metadata,
   })
 
   if (res.error) throw new Error(res.error)

--- a/src/lib/langchain/utils/executeChain.ts
+++ b/src/lib/langchain/utils/executeChain.ts
@@ -90,17 +90,20 @@ export const executeChain = async <T>({
     const renderedPrompt = await prompt.format(variables)
     const promptTokens = estimatePromptTokens(tokenizer, renderedPrompt)
 
+    const chain = prompt.pipe(llm).pipe(parser)
+    const startedAt = Date.now()
+    const result = (await chain.invoke(variables)) as T
+    const elapsedMs = Date.now() - startedAt
+
     logLlmCall(logger, {
       task: metadata?.task || 'chain',
       provider: effectiveProvider,
       parserType: parser.constructor.name,
       variableKeys: Object.keys(variables),
       promptTokens,
+      elapsedMs,
       ...metadata,
     })
-
-    const chain = prompt.pipe(llm).pipe(parser)
-    const result = (await chain.invoke(variables)) as T
 
     if (result === null || result === undefined) {
       throw new LangChainExecutionError(

--- a/src/lib/langchain/utils/observability.test.ts
+++ b/src/lib/langchain/utils/observability.test.ts
@@ -1,7 +1,16 @@
 import { Logger } from '../../utils/logger'
-import { estimatePromptTokens, logLlmCall } from './observability'
+import {
+  estimatePromptTokens,
+  logLlmCall,
+  logLlmTelemetrySummary,
+  resetLlmTelemetry,
+} from './observability'
 
 describe('LLM observability utilities', () => {
+  afterEach(() => {
+    resetLlmTelemetry()
+  })
+
   it('estimates prompt tokens with the configured tokenizer', () => {
     expect(estimatePromptTokens((text) => text.split(/\s+/).length, 'one two three')).toBe(3)
   })
@@ -29,5 +38,37 @@ describe('LLM observability utilities', () => {
 
   it('does not log when a logger is not provided', () => {
     expect(() => logLlmCall(undefined, { task: 'summarize' })).not.toThrow()
+  })
+
+  it('logs and resets per-command telemetry summaries', () => {
+    const logger = {
+      verbose: jest.fn(),
+    } as unknown as Logger
+
+    logLlmCall(logger, {
+      task: 'summarize-large-file',
+      command: 'commit',
+      model: 'gpt-4.1-nano',
+      promptTokens: 100,
+      elapsedMs: 25,
+      inputDocuments: 1,
+      inputChunks: 3,
+    })
+    logLlmCall(logger, {
+      task: 'commit-message',
+      command: 'commit',
+      model: 'gpt-4.1-mini',
+      promptTokens: 50,
+      elapsedMs: 10,
+    })
+
+    logLlmTelemetrySummary(logger, 'commit')
+    logLlmTelemetrySummary(logger, 'commit')
+
+    expect(logger.verbose).toHaveBeenCalledWith(
+      '[llm:summary] command=commit calls=2 promptTokens=150 elapsedMs=35 inputDocuments=1 inputChunks=3 tasks=summarize-large-file,commit-message models=gpt-4.1-nano,gpt-4.1-mini',
+      { color: 'cyan' }
+    )
+    expect(logger.verbose).toHaveBeenCalledTimes(3)
   })
 })

--- a/src/lib/langchain/utils/observability.ts
+++ b/src/lib/langchain/utils/observability.ts
@@ -10,9 +10,22 @@ export type LlmCallMetadata = {
   parserType?: string
   variableKeys?: string[]
   promptTokens?: number
+  elapsedMs?: number
   inputDocuments?: number
   inputChunks?: number
 }
+
+type LlmTelemetrySummary = {
+  calls: number
+  promptTokens: number
+  elapsedMs: number
+  inputDocuments: number
+  inputChunks: number
+  tasks: Set<string>
+  models: Set<string>
+}
+
+const telemetryByCommand = new Map<string, LlmTelemetrySummary>()
 
 export function estimatePromptTokens(
   tokenizer: TokenCounter | undefined,
@@ -30,6 +43,8 @@ export function estimatePromptTokens(
 export function logLlmCall(logger: Logger | undefined, metadata: LlmCallMetadata): void {
   if (!logger) return
 
+  recordLlmTelemetry(metadata)
+
   const fields = [
     `task=${metadata.task}`,
     metadata.command ? `command=${metadata.command}` : undefined,
@@ -37,6 +52,7 @@ export function logLlmCall(logger: Logger | undefined, metadata: LlmCallMetadata
     metadata.model ? `model=${metadata.model}` : undefined,
     metadata.retryAttempt ? `retryAttempt=${metadata.retryAttempt}` : undefined,
     metadata.promptTokens !== undefined ? `promptTokens=${metadata.promptTokens}` : undefined,
+    metadata.elapsedMs !== undefined ? `elapsedMs=${metadata.elapsedMs}` : undefined,
     metadata.inputDocuments !== undefined ? `inputDocuments=${metadata.inputDocuments}` : undefined,
     metadata.inputChunks !== undefined ? `inputChunks=${metadata.inputChunks}` : undefined,
     metadata.parserType ? `parser=${metadata.parserType}` : undefined,
@@ -44,4 +60,55 @@ export function logLlmCall(logger: Logger | undefined, metadata: LlmCallMetadata
   ].filter(Boolean)
 
   logger.verbose(`[llm] ${fields.join(' ')}`, { color: 'cyan' })
+}
+
+function recordLlmTelemetry(metadata: LlmCallMetadata): void {
+  const command = metadata.command || 'unknown'
+  const current = telemetryByCommand.get(command) || {
+    calls: 0,
+    promptTokens: 0,
+    elapsedMs: 0,
+    inputDocuments: 0,
+    inputChunks: 0,
+    tasks: new Set<string>(),
+    models: new Set<string>(),
+  }
+
+  current.calls += 1
+  current.promptTokens += metadata.promptTokens || 0
+  current.elapsedMs += metadata.elapsedMs || 0
+  current.inputDocuments += metadata.inputDocuments || 0
+  current.inputChunks += metadata.inputChunks || 0
+  current.tasks.add(metadata.task)
+
+  if (metadata.model) {
+    current.models.add(metadata.model)
+  }
+
+  telemetryByCommand.set(command, current)
+}
+
+export function logLlmTelemetrySummary(logger: Logger | undefined, command: string): void {
+  if (!logger) return
+
+  const summary = telemetryByCommand.get(command)
+  if (!summary || summary.calls === 0) return
+
+  const fields = [
+    `command=${command}`,
+    `calls=${summary.calls}`,
+    summary.promptTokens > 0 ? `promptTokens=${summary.promptTokens}` : undefined,
+    summary.elapsedMs > 0 ? `elapsedMs=${summary.elapsedMs}` : undefined,
+    summary.inputDocuments > 0 ? `inputDocuments=${summary.inputDocuments}` : undefined,
+    summary.inputChunks > 0 ? `inputChunks=${summary.inputChunks}` : undefined,
+    summary.tasks.size > 0 ? `tasks=${[...summary.tasks].join(',')}` : undefined,
+    summary.models.size > 0 ? `models=${[...summary.models].join(',')}` : undefined,
+  ].filter(Boolean)
+
+  logger.verbose(`[llm:summary] ${fields.join(' ')}`, { color: 'cyan' })
+  telemetryByCommand.delete(command)
+}
+
+export function resetLlmTelemetry(): void {
+  telemetryByCommand.clear()
 }

--- a/src/lib/parsers/default/index.ts
+++ b/src/lib/parsers/default/index.ts
@@ -19,6 +19,7 @@ export async function fileChangeParser({
     minTokensForSummary,
     maxFileTokens,
     maxConcurrent,
+    metadata,
   },
 }: FileChangeParserInput): Promise<string> {
   const textSplitter = new RecursiveCharacterTextSplitter({ chunkSize: 10000, chunkOverlap: 250 })
@@ -58,6 +59,7 @@ export async function fileChangeParser({
     textSplitter,
     chain: summarizationChain,
     logger,
+    metadata,
   })
   logger.stopTimer(`\nSummary generated for ${changes.length} staged files`, { color: 'green' })
 

--- a/src/lib/parsers/default/utils/summarizeDiffs.ts
+++ b/src/lib/parsers/default/utils/summarizeDiffs.ts
@@ -40,7 +40,7 @@ type SummarizeDirectoryDiffOptions = {
  */
 export async function summarizeDirectoryDiff(
   directory: DirectoryDiff,
-  { chain, textSplitter, tokenizer, logger }: SummarizeDirectoryDiffOptions
+  { chain, textSplitter, tokenizer, logger, metadata }: SummarizeDirectoryDiffOptions
 ): Promise<DirectoryDiff> {
   try {
     const directorySummary = await summarize(
@@ -57,6 +57,7 @@ export async function summarizeDirectoryDiff(
         tokenizer,
         logger,
         metadata: {
+          ...metadata,
           task: 'summarize-directory-diff',
         },
         options: {
@@ -149,6 +150,7 @@ async function summarizeInWaves(
     chain,
     textSplitter,
     tokenizer,
+    metadata,
   } = options
 
   let totalTokenCount = initialTotal
@@ -194,7 +196,7 @@ async function summarizeInWaves(
     // Process wave in parallel
     const waveResults = await Promise.all(
       wave.map((idx) =>
-        summarizeDirectoryDiff(results[idx], { chain, textSplitter, tokenizer, logger })
+        summarizeDirectoryDiff(results[idx], { chain, textSplitter, tokenizer, logger, metadata })
       )
     )
 
@@ -251,6 +253,7 @@ export async function summarizeDiffs(
     maxConcurrent = 6,
     textSplitter,
     chain,
+    metadata,
     handleOutput = defaultOutputCallback,
   }: SummarizeDiffsOptions
 ): Promise<string> {
@@ -289,6 +292,7 @@ export async function summarizeDiffs(
     logger,
     chain,
     textSplitter,
+    metadata,
   })
 
   logger.stopSpinner('Files pre-processed').stopTimer()
@@ -318,6 +322,7 @@ export async function summarizeDiffs(
     chain,
     textSplitter,
     tokenizer,
+    metadata,
   })
 
   logger.stopSpinner(`Diffs Consolidated`).stopTimer()

--- a/src/lib/parsers/default/utils/summarizeLargeFiles.ts
+++ b/src/lib/parsers/default/utils/summarizeLargeFiles.ts
@@ -25,7 +25,13 @@ export type SummarizeLargeFilesOptions = {
  */
 async function summarizeFileDiff(
   fileDiff: FileDiff,
-  { chain, textSplitter, tokenizer, logger }: Pick<SummarizeLargeFilesOptions, 'chain' | 'textSplitter' | 'tokenizer' | 'logger'>
+  {
+    chain,
+    textSplitter,
+    tokenizer,
+    logger,
+    metadata,
+  }: Pick<SummarizeLargeFilesOptions, 'chain' | 'textSplitter' | 'tokenizer' | 'logger' | 'metadata'>
 ): Promise<FileDiff> {
   try {
     const fileSummary = await summarize(
@@ -44,6 +50,7 @@ async function summarizeFileDiff(
         tokenizer,
         logger,
         metadata: {
+          ...metadata,
           task: 'summarize-large-file',
         },
         options: {
@@ -98,7 +105,7 @@ export async function summarizeLargeFiles(
   diffs: FileDiff[],
   options: SummarizeLargeFilesOptions
 ): Promise<FileDiff[]> {
-  const { maxFileTokens, minTokensForSummary, maxConcurrent, tokenizer, logger, chain, textSplitter } =
+  const { maxFileTokens, minTokensForSummary, maxConcurrent, tokenizer, logger, chain, textSplitter, metadata } =
     options
 
   // Identify files that need summarization
@@ -120,7 +127,7 @@ export async function summarizeLargeFiles(
   // Process large files in waves
   const summarizedFiles = await processInWaves(
     filesToSummarize,
-    async ({ diff }) => summarizeFileDiff(diff, { chain, textSplitter, tokenizer, logger }),
+    async ({ diff }) => summarizeFileDiff(diff, { chain, textSplitter, tokenizer, logger, metadata }),
     maxConcurrent
   )
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,6 @@
 import { SimpleGit } from 'simple-git'
 import { getLlm } from './langchain/utils/getLlm'
+import { LlmCallMetadata } from './langchain/utils/observability'
 import { Logger } from './utils/logger'
 import { TokenCounter } from './utils/tokenizer'
 
@@ -67,6 +68,7 @@ export interface BaseParserOptions {
    * @default 6
    */
   maxConcurrent?: number
+  metadata?: Partial<LlmCallMetadata>
 }
 
 export interface BaseParserInput {


### PR DESCRIPTION
## Summary

- aggregate LLM call telemetry by command while preserving existing per-call verbose logs
- include call count, prompt token estimates, elapsed time, input document/chunk counts, tasks, and models
- propagate command/provider/model metadata through diff summarization calls
- flush command summaries from commit, changelog, recap, and review flows

## Validation

- npm run test:jest -- src/lib/langchain/utils/observability.test.ts src/commands/commit/commit.test.ts src/commands/recap/recap.test.ts src/commands/review/review.test.ts --runInBand
- npm run lint
- npm test

Closes #632