### PR TITLE
Add visual git log command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ coco -i
 - **`coco changelog`** - Create changelogs from commit history  
 - **`coco recap`** - Summarize recent changes and activity
 - **`coco review`** - AI-powered code review of your changes
+- **`coco log`** - Explore commit history with graph, filters, JSON output, and commit details
 - **`coco init`** - Interactive setup wizard
 
 ## Usage Examples
@@ -85,6 +86,12 @@ coco recap --yesterday
 
 # Code review before committing
 coco review
+
+# Explore commit history
+coco log --all --limit 20
+coco log --author "Grace Hopper" --path src
+coco log --commit HEAD
+coco log --format json
 ```
 
 ## Configuration

--- a/bin/smokeCli.ts
+++ b/bin/smokeCli.ts
@@ -106,6 +106,11 @@ try {
     args: ['commit', '--help'],
     label: 'packaged commit command help',
   })
+  runHelpCheck({
+    command: packagedBinPath(prefix),
+    args: ['log', '--help'],
+    label: 'packaged log command help',
+  })
 } finally {
   rmSync(tempRoot, { recursive: true, force: true })
 }

--- a/src/commands/commands.integration.test.ts
+++ b/src/commands/commands.integration.test.ts
@@ -4,6 +4,8 @@ import { handler as changelogHandler } from './changelog/handler'
 import { ChangelogOptions } from './changelog/config'
 import { handler as commitHandler } from './commit/handler'
 import { CommitOptions } from './commit/config'
+import { handler as logHandler } from './log/handler'
+import { LogOptions } from './log/config'
 import { loadConfig } from '../lib/config/utils/loadConfig'
 import { executeChain } from '../lib/langchain/utils/executeChain'
 import { executeChainWithSchema } from '../lib/langchain/utils/executeChainWithSchema'
@@ -529,5 +531,97 @@ describe('command integration with temp git repos', () => {
     expect(stdout).toContain('- Summarized feature work')
     expect(variables.summary).toContain('feat: add feature module')
     expect(variables.summary).toContain('feature/changelog-test')
+  })
+
+  it('prints a visual git log with refs and graph metadata', async () => {
+    mockLoadConfig.mockReturnValue(createConfig({
+      mode: 'stdout',
+    }))
+
+    await repo.writeFile('README.md', '# Temp repo\n')
+    await repo.commitAll('chore: initial commit')
+    await repo.git.addTag('v0.1.0')
+    await repo.git.checkoutLocalBranch('feature/log-test')
+    await repo.writeFile('src/feature.ts', 'export const feature = true\n')
+    await repo.commitAll('feat: add log feature')
+
+    await logHandler({
+      $0: 'coco',
+      _: ['log'],
+      all: true,
+      format: 'table',
+      limit: 10,
+      interactive: false,
+      verbose: false,
+      version: false,
+      help: false,
+    } as Arguments<LogOptions>, createLogger())
+
+    expect(stdout).toContain('Graph')
+    expect(stdout).toContain('Commit')
+    expect(stdout).toContain('feat: add log feature')
+    expect(stdout).toContain('v0.1.0')
+    expect(stdout).toContain('*')
+  })
+
+  it('prints machine-readable git log output', async () => {
+    mockLoadConfig.mockReturnValue(createConfig({
+      mode: 'stdout',
+    }))
+
+    await repo.writeFile('README.md', '# Temp repo\n')
+    await repo.commitAll('chore: initial commit')
+    await repo.writeFile('src/feature.ts', 'export const feature = true\n')
+    await repo.commitAll('feat: add json log output')
+
+    await logHandler({
+      $0: 'coco',
+      _: ['log'],
+      format: 'json',
+      limit: 2,
+      interactive: false,
+      verbose: false,
+      version: false,
+      help: false,
+    } as Arguments<LogOptions>, createLogger())
+
+    const entries = JSON.parse(stdout)
+
+    expect(entries).toHaveLength(2)
+    expect(entries[0]).toEqual(expect.objectContaining({
+      message: 'feat: add json log output',
+      shortHash: expect.any(String),
+      hash: expect.any(String),
+      refs: expect.any(Array),
+    }))
+  })
+
+  it('shows changed files for a selected commit', async () => {
+    mockLoadConfig.mockReturnValue(createConfig({
+      mode: 'stdout',
+    }))
+
+    await repo.writeFile('README.md', '# Temp repo\n')
+    await repo.commitAll('chore: initial commit')
+    await repo.writeFile('src/detail.ts', 'export const detail = true\n')
+    await repo.commitAll('feat: add commit detail file')
+
+    const commit = (await repo.git.revparse(['HEAD'])).trim()
+
+    await logHandler({
+      $0: 'coco',
+      _: ['log'],
+      commit,
+      format: 'table',
+      interactive: false,
+      verbose: false,
+      version: false,
+      help: false,
+    } as Arguments<LogOptions>, createLogger())
+
+    expect(stdout).toContain(`commit ${commit}`)
+    expect(stdout).toContain('feat: add commit detail file')
+    expect(stdout).toContain('Changed files:')
+    expect(stdout).toContain('A  src/detail.ts')
   })
 })

--- a/src/commands/log/config.ts
+++ b/src/commands/log/config.ts
@@ -1,0 +1,76 @@
+import { Arguments, Argv, Options } from 'yargs'
+import { getCommandUsageHeader } from '../../lib/ui/helpers'
+import { BaseCommandOptions } from '../types'
+
+export type LogFormat = 'table' | 'json'
+
+export interface LogOptions extends BaseCommandOptions {
+  all?: boolean
+  author?: string
+  branch?: string
+  commit?: string
+  format?: LogFormat
+  limit?: number
+  noMerges?: boolean
+  path?: string | string[]
+  since?: string
+  until?: string
+}
+
+export type LogArgv = Arguments<LogOptions>
+
+export const command = 'log'
+
+export const options = {
+  all: {
+    description: 'Show commits from all local and remote refs',
+    type: 'boolean',
+    default: false,
+  },
+  author: {
+    description: 'Filter commits by author',
+    type: 'string',
+  },
+  branch: {
+    description: 'Show commits reachable from a branch or ref',
+    type: 'string',
+    alias: 'b',
+  },
+  commit: {
+    description: 'Show details and changed files for a single commit',
+    type: 'string',
+    alias: 'c',
+  },
+  format: {
+    description: 'Output format',
+    choices: ['table', 'json'],
+    default: 'table',
+  },
+  limit: {
+    description: 'Maximum number of commits to show',
+    type: 'number',
+    default: 30,
+    alias: 'n',
+  },
+  noMerges: {
+    description: 'Exclude merge commits',
+    type: 'boolean',
+    default: false,
+  },
+  path: {
+    description: 'Filter commits by changed path',
+    type: 'array',
+  },
+  since: {
+    description: 'Show commits more recent than a date',
+    type: 'string',
+  },
+  until: {
+    description: 'Show commits older than a date',
+    type: 'string',
+  },
+} as Record<string, Options>
+
+export const builder = (yargs: Argv) => {
+  return yargs.options(options).usage(getCommandUsageHeader(command))
+}

--- a/src/commands/log/handler.ts
+++ b/src/commands/log/handler.ts
@@ -1,0 +1,279 @@
+import { SimpleGit } from 'simple-git'
+import { CommandHandler } from '../../lib/types'
+import { getRepo } from '../../lib/simple-git/getRepo'
+import { handleResult } from '../../lib/ui/handleResult'
+import { LogArgv, LogFormat } from './config'
+
+const FIELD_SEPARATOR = '\x1f'
+const LOG_FORMAT = `%x1f%h%x1f%H%x1f%ad%x1f%an%x1f%d%x1f%s`
+const DETAIL_FORMAT = `%H%x1f%h%x1f%ad%x1f%an%x1f%d%x1f%s%x1f%b`
+
+export type GitLogEntry = {
+  graph: string
+  shortHash: string
+  hash: string
+  date: string
+  author: string
+  refs: string[]
+  message: string
+}
+
+export type GitCommitDetail = Omit<GitLogEntry, 'graph'> & {
+  body: string
+  files: Array<{
+    status: string
+    path: string
+    oldPath?: string
+  }>
+}
+
+function toArray(value: string | string[] | undefined): string[] {
+  if (!value) {
+    return []
+  }
+
+  return Array.isArray(value) ? value : [value]
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  if (!limit || Number.isNaN(limit) || limit < 1) {
+    return 30
+  }
+
+  return Math.floor(limit)
+}
+
+function cleanRefs(refs: string): string[] {
+  const trimmed = refs.trim()
+
+  if (!trimmed) {
+    return []
+  }
+
+  return trimmed
+    .replace(/^\(/, '')
+    .replace(/\)$/, '')
+    .split(',')
+    .map((ref) => ref.trim())
+    .filter(Boolean)
+}
+
+export function parseLogOutput(output: string): GitLogEntry[] {
+  return output
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line) => line.includes(FIELD_SEPARATOR))
+    .map((line) => {
+      const [graph, shortHash, hash, date, author, refs, message] = line.split(FIELD_SEPARATOR)
+
+      return {
+        graph: graph.trimEnd(),
+        shortHash,
+        hash,
+        date,
+        author,
+        refs: cleanRefs(refs),
+        message,
+      }
+    })
+}
+
+function parseNameStatus(output: string): GitCommitDetail['files'] {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [status, firstPath, secondPath] = line.split('\t')
+
+      if (status.startsWith('R') || status.startsWith('C')) {
+        return {
+          status,
+          oldPath: firstPath,
+          path: secondPath,
+        }
+      }
+
+      return {
+        status,
+        path: firstPath,
+      }
+    })
+}
+
+export function parseCommitDetail(metadata: string, files: string): GitCommitDetail {
+  const [hash, shortHash, date, author, refs, message, body = ''] = metadata
+    .trimEnd()
+    .split(FIELD_SEPARATOR)
+
+  return {
+    shortHash,
+    hash,
+    date,
+    author,
+    refs: cleanRefs(refs),
+    message,
+    body: body.trim(),
+    files: parseNameStatus(files),
+  }
+}
+
+function truncate(value: string, width: number): string {
+  if (value.length <= width) {
+    return value
+  }
+
+  return `${value.slice(0, Math.max(0, width - 1))}.`
+}
+
+function pad(value: string, width: number): string {
+  return truncate(value, width).padEnd(width, ' ')
+}
+
+export function formatLogTable(entries: GitLogEntry[]): string {
+  if (entries.length === 0) {
+    return 'No commits found.'
+  }
+
+  const rows = entries.map((entry) => {
+    const refs = entry.refs.join(', ')
+
+    return [
+      pad(entry.graph || '*', 8),
+      pad(entry.shortHash, 9),
+      pad(entry.date, 10),
+      pad(entry.author, 18),
+      pad(refs, 26),
+      entry.message,
+    ].join('  ')
+  })
+
+  return [
+    [
+      pad('Graph', 8),
+      pad('Commit', 9),
+      pad('Date', 10),
+      pad('Author', 18),
+      pad('Refs', 26),
+      'Message',
+    ].join('  '),
+    ...rows,
+  ].join('\n')
+}
+
+export function formatCommitDetail(detail: GitCommitDetail, format: LogFormat): string {
+  if (format === 'json') {
+    return JSON.stringify(detail, null, 2)
+  }
+
+  const refs = detail.refs.length ? ` (${detail.refs.join(', ')})` : ''
+  const body = detail.body ? `\n\n${detail.body}` : ''
+  const files = detail.files.length
+    ? detail.files
+      .map((file) => {
+        if (file.oldPath) {
+          return `  ${file.status}  ${file.oldPath} -> ${file.path}`
+        }
+
+        return `  ${file.status}  ${file.path}`
+      })
+      .join('\n')
+    : '  No changed files found.'
+
+  return [
+    `commit ${detail.hash}${refs}`,
+    `Author: ${detail.author}`,
+    `Date:   ${detail.date}`,
+    '',
+    `    ${detail.message}${body}`,
+    '',
+    'Changed files:',
+    files,
+  ].join('\n')
+}
+
+function buildLogArgs(argv: LogArgv): string[] {
+  const args = [
+    'log',
+    '--graph',
+    '--decorate=short',
+    '--date=short',
+    '--color=never',
+    `--max-count=${normalizeLimit(argv.limit)}`,
+    `--pretty=format:${LOG_FORMAT}`,
+  ]
+
+  if (argv.noMerges) {
+    args.push('--no-merges')
+  }
+
+  if (argv.author) {
+    args.push(`--author=${argv.author}`)
+  }
+
+  if (argv.since) {
+    args.push(`--since=${argv.since}`)
+  }
+
+  if (argv.until) {
+    args.push(`--until=${argv.until}`)
+  }
+
+  if (argv.all) {
+    args.push('--all')
+  } else if (argv.branch) {
+    args.push(argv.branch)
+  }
+
+  const paths = toArray(argv.path)
+  if (paths.length > 0) {
+    args.push('--', ...paths)
+  }
+
+  return args
+}
+
+async function getCommitDetail(git: SimpleGit, commit: string): Promise<GitCommitDetail> {
+  const metadata = await git.raw([
+    'show',
+    '--no-patch',
+    '--date=short',
+    '--color=never',
+    `--pretty=format:${DETAIL_FORMAT}`,
+    commit,
+  ])
+  const files = await git.raw([
+    'show',
+    '--name-status',
+    '--format=',
+    '--find-renames',
+    '--color=never',
+    commit,
+  ])
+
+  return parseCommitDetail(metadata, files)
+}
+
+export const handler: CommandHandler<LogArgv> = async (argv) => {
+  const git = getRepo()
+  const mode = argv.interactive ? 'interactive' : 'stdout'
+  const format = argv.format === 'json' ? 'json' : 'table'
+
+  if (argv.commit) {
+    const detail = await getCommitDetail(git, argv.commit)
+    await handleResult({
+      result: formatCommitDetail(detail, format),
+      mode,
+    })
+    return
+  }
+
+  const output = await git.raw(buildLogArgs(argv))
+  const entries = parseLogOutput(output)
+  const result = format === 'json' ? JSON.stringify(entries, null, 2) : formatLogTable(entries)
+
+  await handleResult({
+    result,
+    mode,
+  })
+}

--- a/src/commands/log/index.ts
+++ b/src/commands/log/index.ts
@@ -1,0 +1,11 @@
+import commandExecutor from '../../lib/utils/commandExecutor'
+import { builder, command, options } from './config'
+import { handler } from './handler'
+
+export default {
+  command,
+  desc: 'Explore commit history with a branch graph, filters, and commit details.',
+  builder,
+  handler: commandExecutor(handler),
+  options,
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,14 @@ import yargs from 'yargs'
 import changelog from './commands/changelog'
 import commit from './commands/commit'
 import init from './commands/init'
+import log from './commands/log'
 import recap from './commands/recap'
 import review from './commands/review'
 
 import { ChangelogOptions } from './commands/changelog/config'
 import { CommitOptions } from './commands/commit/config'
 import { InitOptions } from './commands/init/config'
+import { LogOptions } from './commands/log/config'
 import { RecapOptions } from './commands/recap/config'
 import { ReviewOptions } from './commands/review/config'
 import { Config } from './lib/config/types'
@@ -53,7 +55,13 @@ y.command<InitOptions>(
   init.handler
 )
 
+y.command<LogOptions>(
+  log.command,
+  log.desc,
+  log.builder,
+  log.handler
+)
+
 y.help().parse(process.argv.slice(2))
 
-export { changelog, commit, Config, init, recap, types }
-
+export { changelog, commit, Config, init, log, recap, types }


### PR DESCRIPTION
## Summary
- Add `coco log` with graph/table output, JSON output, filters, and single-commit detail views
- Register the command in the CLI and document common usage
- Cover the command with temp-repo integration tests and packaged CLI smoke coverage

Closes #645

## Validation
- `npm test`