### PR TITLE
Improve log output fidelity

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ coco recap --yesterday
 coco review
 
 # Explore commit history
+coco log --limit 20
+coco log --view full --limit 20
 coco log --all --limit 20
 coco log --author "Grace Hopper" --path src
 coco log --commit HEAD

--- a/src/commands/commands.integration.test.ts
+++ b/src/commands/commands.integration.test.ts
@@ -564,6 +564,31 @@ describe('command integration with temp git repos', () => {
     expect(stdout).toContain('*')
   })
 
+  it('prints log output when interactive mode is requested', async () => {
+    mockLoadConfig.mockReturnValue(createConfig({
+      mode: 'stdout',
+    }))
+
+    await repo.writeFile('README.md', '# Temp repo\n')
+    await repo.commitAll('chore: initial commit')
+    await repo.writeFile('src/interactive.ts', 'export const interactive = true\n')
+    await repo.commitAll('feat: add interactive log coverage')
+
+    await logHandler({
+      $0: 'coco',
+      _: ['log'],
+      format: 'table',
+      limit: 2,
+      interactive: true,
+      verbose: false,
+      version: false,
+      help: false,
+    } as Arguments<LogOptions>, createLogger())
+
+    expect(stdout).toContain('feat: add interactive log coverage')
+    expect(stdout).toContain('Graph')
+  })
+
   it('prints machine-readable git log output', async () => {
     mockLoadConfig.mockReturnValue(createConfig({
       mode: 'stdout',

--- a/src/commands/log/config.ts
+++ b/src/commands/log/config.ts
@@ -3,6 +3,7 @@ import { getCommandUsageHeader } from '../../lib/ui/helpers'
 import { BaseCommandOptions } from '../types'
 
 export type LogFormat = 'table' | 'json'
+export type LogView = 'compact' | 'graph' | 'full'
 
 export interface LogOptions extends BaseCommandOptions {
   all?: boolean
@@ -11,10 +12,12 @@ export interface LogOptions extends BaseCommandOptions {
   commit?: string
   format?: LogFormat
   limit?: number
+  merges?: boolean
   noMerges?: boolean
   path?: string | string[]
   since?: string
   until?: string
+  view?: LogView
 }
 
 export type LogArgv = Arguments<LogOptions>
@@ -52,6 +55,11 @@ export const options = {
     default: 30,
     alias: 'n',
   },
+  merges: {
+    description: 'Include merge commits in compact view',
+    type: 'boolean',
+    default: false,
+  },
   noMerges: {
     description: 'Exclude merge commits',
     type: 'boolean',
@@ -68,6 +76,11 @@ export const options = {
   until: {
     description: 'Show commits older than a date',
     type: 'string',
+  },
+  view: {
+    description: 'History view preset',
+    choices: ['compact', 'graph', 'full'],
+    default: 'compact',
   },
 } as Record<string, Options>
 

--- a/src/commands/log/data.test.ts
+++ b/src/commands/log/data.test.ts
@@ -1,0 +1,114 @@
+import { Arguments } from 'yargs'
+import {
+  FIELD_SEPARATOR,
+  buildLogArgs,
+  getCommitRows,
+  getLogView,
+  parseCommitDetail,
+  parseLogOutput,
+} from './data'
+import { LogOptions } from './config'
+
+function argv(overrides: Partial<LogOptions> = {}): Arguments<LogOptions> {
+  return {
+    $0: 'coco',
+    _: ['log'],
+    interactive: false,
+    verbose: false,
+    version: false,
+    help: false,
+    ...overrides,
+  } as Arguments<LogOptions>
+}
+
+describe('log data layer', () => {
+  it('defaults to a compact first-parent history view', () => {
+    const args = buildLogArgs(argv())
+
+    expect(getLogView(argv())).toBe('compact')
+    expect(args).toEqual(expect.arrayContaining(['--first-parent', '--no-merges']))
+    expect(args).not.toContain('--all')
+  })
+
+  it('uses full topology when all refs are requested', () => {
+    const args = buildLogArgs(argv({ all: true, view: 'compact' }))
+
+    expect(getLogView(argv({ all: true, view: 'compact' }))).toBe('full')
+    expect(args).toContain('--all')
+    expect(args).not.toContain('--first-parent')
+    expect(args).not.toContain('--no-merges')
+  })
+
+  it('allows merge commits in compact view when requested', () => {
+    const args = buildLogArgs(argv({ merges: true }))
+
+    expect(args).toContain('--first-parent')
+    expect(args).not.toContain('--no-merges')
+  })
+
+  it('preserves graph continuation rows while parsing commits', () => {
+    const output = [
+      `*${FIELD_SEPARATOR}abc1234${FIELD_SEPARATOR}abc1234${FIELD_SEPARATOR}2026-04-27${FIELD_SEPARATOR}Coco Test${FIELD_SEPARATOR}(HEAD -> main, tag: 1.0.0)${FIELD_SEPARATOR}feat: first`,
+      '|\\',
+      `| *${FIELD_SEPARATOR}def5678${FIELD_SEPARATOR}def5678${FIELD_SEPARATOR}2026-04-26${FIELD_SEPARATOR}Coco Test${FIELD_SEPARATOR}${FIELD_SEPARATOR}fix: second`,
+      '|/',
+    ].join('\n')
+
+    const rows = parseLogOutput(output)
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        type: 'commit',
+        graph: '*',
+        shortHash: 'abc1234',
+        refs: ['HEAD -> main', 'tag: 1.0.0'],
+      }),
+      {
+        type: 'graph',
+        graph: '|\\',
+      },
+      expect.objectContaining({
+        type: 'commit',
+        graph: '| *',
+        shortHash: 'def5678',
+      }),
+      {
+        type: 'graph',
+        graph: '|/',
+      },
+    ])
+    expect(getCommitRows(rows)).toHaveLength(2)
+  })
+
+  it('parses commit detail metadata and changed files', () => {
+    const detail = parseCommitDetail(
+      [
+        'abc1234',
+        'abc1234',
+        '2026-04-27',
+        'Coco Test',
+        '(tag: 1.0.0)',
+        'feat: add details',
+        'Detailed body',
+      ].join(FIELD_SEPARATOR),
+      ['A\tREADME.md', 'R100\told.ts\tnew.ts'].join('\n')
+    )
+
+    expect(detail).toEqual(expect.objectContaining({
+      refs: ['tag: 1.0.0'],
+      message: 'feat: add details',
+      body: 'Detailed body',
+      files: [
+        {
+          status: 'A',
+          path: 'README.md',
+        },
+        {
+          status: 'R100',
+          oldPath: 'old.ts',
+          path: 'new.ts',
+        },
+      ],
+    }))
+  })
+})

--- a/src/commands/log/data.ts
+++ b/src/commands/log/data.ts
@@ -1,0 +1,221 @@
+import { SimpleGit } from 'simple-git'
+import { LogArgv, LogView } from './config'
+
+export const FIELD_SEPARATOR = '\x1f'
+const LOG_FORMAT = `%x1f%h%x1f%H%x1f%ad%x1f%an%x1f%d%x1f%s`
+const DETAIL_FORMAT = `%H%x1f%h%x1f%ad%x1f%an%x1f%d%x1f%s%x1f%b`
+
+export type GitLogCommitRow = {
+  type: 'commit'
+  graph: string
+  shortHash: string
+  hash: string
+  date: string
+  author: string
+  refs: string[]
+  message: string
+}
+
+export type GitLogGraphRow = {
+  type: 'graph'
+  graph: string
+}
+
+export type GitLogRow = GitLogCommitRow | GitLogGraphRow
+
+export type GitCommitDetail = Omit<GitLogCommitRow, 'type' | 'graph'> & {
+  body: string
+  files: Array<{
+    status: string
+    path: string
+    oldPath?: string
+  }>
+}
+
+export function toArray(value: string | string[] | undefined): string[] {
+  if (!value) {
+    return []
+  }
+
+  return Array.isArray(value) ? value : [value]
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  if (!limit || Number.isNaN(limit) || limit < 1) {
+    return 30
+  }
+
+  return Math.floor(limit)
+}
+
+function cleanRefs(refs: string): string[] {
+  const trimmed = refs.trim()
+
+  if (!trimmed) {
+    return []
+  }
+
+  return trimmed
+    .replace(/^\(/, '')
+    .replace(/\)$/, '')
+    .split(',')
+    .map((ref) => ref.trim())
+    .filter(Boolean)
+}
+
+export function getLogView(argv: LogArgv): LogView {
+  if (argv.all) {
+    return 'full'
+  }
+
+  if (argv.view) {
+    return argv.view
+  }
+
+  return 'compact'
+}
+
+export function getCommitRows(rows: GitLogRow[]): GitLogCommitRow[] {
+  return rows.filter((row): row is GitLogCommitRow => row.type === 'commit')
+}
+
+export function parseLogOutput(output: string): GitLogRow[] {
+  return output
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line): GitLogRow => {
+      if (!line.includes(FIELD_SEPARATOR)) {
+        return {
+          type: 'graph',
+          graph: line,
+        }
+      }
+
+      const [graph, shortHash, hash, date, author, refs, message] = line.split(FIELD_SEPARATOR)
+
+      return {
+        type: 'commit',
+        graph: graph.trimEnd(),
+        shortHash,
+        hash,
+        date,
+        author,
+        refs: cleanRefs(refs),
+        message,
+      }
+    })
+}
+
+function parseNameStatus(output: string): GitCommitDetail['files'] {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [status, firstPath, secondPath] = line.split('\t')
+
+      if (status.startsWith('R') || status.startsWith('C')) {
+        return {
+          status,
+          oldPath: firstPath,
+          path: secondPath,
+        }
+      }
+
+      return {
+        status,
+        path: firstPath,
+      }
+    })
+}
+
+export function parseCommitDetail(metadata: string, files: string): GitCommitDetail {
+  const [hash, shortHash, date, author, refs, message, body = ''] = metadata
+    .trimEnd()
+    .split(FIELD_SEPARATOR)
+
+  return {
+    shortHash,
+    hash,
+    date,
+    author,
+    refs: cleanRefs(refs),
+    message,
+    body: body.trim(),
+    files: parseNameStatus(files),
+  }
+}
+
+export function buildLogArgs(argv: LogArgv): string[] {
+  const view = getLogView(argv)
+  const args = [
+    'log',
+    '--graph',
+    '--decorate=short',
+    '--date=short',
+    '--color=never',
+    `--max-count=${normalizeLimit(argv.limit)}`,
+    `--pretty=format:${LOG_FORMAT}`,
+  ]
+
+  if (view === 'compact') {
+    args.push('--first-parent')
+  }
+
+  if (view === 'compact' && !argv.merges) {
+    args.push('--no-merges')
+  } else if (argv.noMerges) {
+    args.push('--no-merges')
+  }
+
+  if (argv.author) {
+    args.push(`--author=${argv.author}`)
+  }
+
+  if (argv.since) {
+    args.push(`--since=${argv.since}`)
+  }
+
+  if (argv.until) {
+    args.push(`--until=${argv.until}`)
+  }
+
+  if (view === 'full' || argv.all) {
+    args.push('--all')
+  } else if (argv.branch) {
+    args.push(argv.branch)
+  }
+
+  const paths = toArray(argv.path)
+  if (paths.length > 0) {
+    args.push('--', ...paths)
+  }
+
+  return args
+}
+
+export async function getLogRows(git: SimpleGit, argv: LogArgv): Promise<GitLogRow[]> {
+  return parseLogOutput(await git.raw(buildLogArgs(argv)))
+}
+
+export async function getCommitDetail(git: SimpleGit, commit: string): Promise<GitCommitDetail> {
+  const metadata = await git.raw([
+    'show',
+    '--no-patch',
+    '--date=short',
+    '--color=never',
+    `--pretty=format:${DETAIL_FORMAT}`,
+    commit,
+  ])
+  const files = await git.raw([
+    'show',
+    '--name-status',
+    '--format=',
+    '--find-renames',
+    '--color=never',
+    commit,
+  ])
+
+  return parseCommitDetail(metadata, files)
+}

--- a/src/commands/log/handler.ts
+++ b/src/commands/log/handler.ts
@@ -1,279 +1,28 @@
-import { SimpleGit } from 'simple-git'
 import { CommandHandler } from '../../lib/types'
 import { getRepo } from '../../lib/simple-git/getRepo'
 import { handleResult } from '../../lib/ui/handleResult'
-import { LogArgv, LogFormat } from './config'
-
-const FIELD_SEPARATOR = '\x1f'
-const LOG_FORMAT = `%x1f%h%x1f%H%x1f%ad%x1f%an%x1f%d%x1f%s`
-const DETAIL_FORMAT = `%H%x1f%h%x1f%ad%x1f%an%x1f%d%x1f%s%x1f%b`
-
-export type GitLogEntry = {
-  graph: string
-  shortHash: string
-  hash: string
-  date: string
-  author: string
-  refs: string[]
-  message: string
-}
-
-export type GitCommitDetail = Omit<GitLogEntry, 'graph'> & {
-  body: string
-  files: Array<{
-    status: string
-    path: string
-    oldPath?: string
-  }>
-}
-
-function toArray(value: string | string[] | undefined): string[] {
-  if (!value) {
-    return []
-  }
-
-  return Array.isArray(value) ? value : [value]
-}
-
-function normalizeLimit(limit: number | undefined): number {
-  if (!limit || Number.isNaN(limit) || limit < 1) {
-    return 30
-  }
-
-  return Math.floor(limit)
-}
-
-function cleanRefs(refs: string): string[] {
-  const trimmed = refs.trim()
-
-  if (!trimmed) {
-    return []
-  }
-
-  return trimmed
-    .replace(/^\(/, '')
-    .replace(/\)$/, '')
-    .split(',')
-    .map((ref) => ref.trim())
-    .filter(Boolean)
-}
-
-export function parseLogOutput(output: string): GitLogEntry[] {
-  return output
-    .split('\n')
-    .map((line) => line.trimEnd())
-    .filter((line) => line.includes(FIELD_SEPARATOR))
-    .map((line) => {
-      const [graph, shortHash, hash, date, author, refs, message] = line.split(FIELD_SEPARATOR)
-
-      return {
-        graph: graph.trimEnd(),
-        shortHash,
-        hash,
-        date,
-        author,
-        refs: cleanRefs(refs),
-        message,
-      }
-    })
-}
-
-function parseNameStatus(output: string): GitCommitDetail['files'] {
-  return output
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      const [status, firstPath, secondPath] = line.split('\t')
-
-      if (status.startsWith('R') || status.startsWith('C')) {
-        return {
-          status,
-          oldPath: firstPath,
-          path: secondPath,
-        }
-      }
-
-      return {
-        status,
-        path: firstPath,
-      }
-    })
-}
-
-export function parseCommitDetail(metadata: string, files: string): GitCommitDetail {
-  const [hash, shortHash, date, author, refs, message, body = ''] = metadata
-    .trimEnd()
-    .split(FIELD_SEPARATOR)
-
-  return {
-    shortHash,
-    hash,
-    date,
-    author,
-    refs: cleanRefs(refs),
-    message,
-    body: body.trim(),
-    files: parseNameStatus(files),
-  }
-}
-
-function truncate(value: string, width: number): string {
-  if (value.length <= width) {
-    return value
-  }
-
-  return `${value.slice(0, Math.max(0, width - 1))}.`
-}
-
-function pad(value: string, width: number): string {
-  return truncate(value, width).padEnd(width, ' ')
-}
-
-export function formatLogTable(entries: GitLogEntry[]): string {
-  if (entries.length === 0) {
-    return 'No commits found.'
-  }
-
-  const rows = entries.map((entry) => {
-    const refs = entry.refs.join(', ')
-
-    return [
-      pad(entry.graph || '*', 8),
-      pad(entry.shortHash, 9),
-      pad(entry.date, 10),
-      pad(entry.author, 18),
-      pad(refs, 26),
-      entry.message,
-    ].join('  ')
-  })
-
-  return [
-    [
-      pad('Graph', 8),
-      pad('Commit', 9),
-      pad('Date', 10),
-      pad('Author', 18),
-      pad('Refs', 26),
-      'Message',
-    ].join('  '),
-    ...rows,
-  ].join('\n')
-}
-
-export function formatCommitDetail(detail: GitCommitDetail, format: LogFormat): string {
-  if (format === 'json') {
-    return JSON.stringify(detail, null, 2)
-  }
-
-  const refs = detail.refs.length ? ` (${detail.refs.join(', ')})` : ''
-  const body = detail.body ? `\n\n${detail.body}` : ''
-  const files = detail.files.length
-    ? detail.files
-      .map((file) => {
-        if (file.oldPath) {
-          return `  ${file.status}  ${file.oldPath} -> ${file.path}`
-        }
-
-        return `  ${file.status}  ${file.path}`
-      })
-      .join('\n')
-    : '  No changed files found.'
-
-  return [
-    `commit ${detail.hash}${refs}`,
-    `Author: ${detail.author}`,
-    `Date:   ${detail.date}`,
-    '',
-    `    ${detail.message}${body}`,
-    '',
-    'Changed files:',
-    files,
-  ].join('\n')
-}
-
-function buildLogArgs(argv: LogArgv): string[] {
-  const args = [
-    'log',
-    '--graph',
-    '--decorate=short',
-    '--date=short',
-    '--color=never',
-    `--max-count=${normalizeLimit(argv.limit)}`,
-    `--pretty=format:${LOG_FORMAT}`,
-  ]
-
-  if (argv.noMerges) {
-    args.push('--no-merges')
-  }
-
-  if (argv.author) {
-    args.push(`--author=${argv.author}`)
-  }
-
-  if (argv.since) {
-    args.push(`--since=${argv.since}`)
-  }
-
-  if (argv.until) {
-    args.push(`--until=${argv.until}`)
-  }
-
-  if (argv.all) {
-    args.push('--all')
-  } else if (argv.branch) {
-    args.push(argv.branch)
-  }
-
-  const paths = toArray(argv.path)
-  if (paths.length > 0) {
-    args.push('--', ...paths)
-  }
-
-  return args
-}
-
-async function getCommitDetail(git: SimpleGit, commit: string): Promise<GitCommitDetail> {
-  const metadata = await git.raw([
-    'show',
-    '--no-patch',
-    '--date=short',
-    '--color=never',
-    `--pretty=format:${DETAIL_FORMAT}`,
-    commit,
-  ])
-  const files = await git.raw([
-    'show',
-    '--name-status',
-    '--format=',
-    '--find-renames',
-    '--color=never',
-    commit,
-  ])
-
-  return parseCommitDetail(metadata, files)
-}
+import { getCommitDetail, getLogRows } from './data'
+import { formatCommitDetail, formatLogJson, formatLogTable } from './render'
+import { LogArgv } from './config'
 
 export const handler: CommandHandler<LogArgv> = async (argv) => {
   const git = getRepo()
-  const mode = argv.interactive ? 'interactive' : 'stdout'
   const format = argv.format === 'json' ? 'json' : 'table'
 
   if (argv.commit) {
     const detail = await getCommitDetail(git, argv.commit)
     await handleResult({
       result: formatCommitDetail(detail, format),
-      mode,
+      mode: 'stdout',
     })
     return
   }
 
-  const output = await git.raw(buildLogArgs(argv))
-  const entries = parseLogOutput(output)
-  const result = format === 'json' ? JSON.stringify(entries, null, 2) : formatLogTable(entries)
+  const rows = await getLogRows(git, argv)
+  const result = format === 'json' ? formatLogJson(rows) : formatLogTable(rows)
 
   await handleResult({
     result,
-    mode,
+    mode: 'stdout',
   })
 }

--- a/src/commands/log/render.test.ts
+++ b/src/commands/log/render.test.ts
@@ -1,0 +1,51 @@
+import { GitLogRow } from './data'
+import { formatLogJson, formatLogTable } from './render'
+
+const rows: GitLogRow[] = [
+  {
+    type: 'commit',
+    graph: '* | | | | *',
+    shortHash: 'abc1234',
+    hash: 'abc1234',
+    date: '2026-04-27',
+    author: 'Coco Test',
+    refs: ['HEAD -> main', 'tag: 0.33.0', 'origin/main'],
+    message: 'feat: preserve graph fidelity',
+  },
+  {
+    type: 'graph',
+    graph: '| |/ / /',
+  },
+  {
+    type: 'commit',
+    graph: '| *',
+    shortHash: 'def5678',
+    hash: 'def5678',
+    date: '2026-04-26',
+    author: 'dependabot[bot]',
+    refs: [],
+    message: 'chore(deps): bump dependency',
+  },
+]
+
+describe('log render layer', () => {
+  it('preserves long graph topology and renders refs without dot truncation', () => {
+    const output = formatLogTable(rows, { terminalWidth: 160 })
+
+    expect(output).toContain('* | | | | *')
+    expect(output).toContain('| |/ / /')
+    expect(output).toContain('[HEAD -> main, tag: 0.33.0, origin/main]')
+    expect(output).not.toContain('tag: 0.33.0.')
+  })
+
+  it('keeps json output focused on commit rows', () => {
+    const entries = JSON.parse(formatLogJson(rows))
+
+    expect(entries).toHaveLength(2)
+    expect(entries[0]).toEqual(expect.objectContaining({
+      type: 'commit',
+      graph: '* | | | | *',
+      refs: ['HEAD -> main', 'tag: 0.33.0', 'origin/main'],
+    }))
+  })
+})

--- a/src/commands/log/render.ts
+++ b/src/commands/log/render.ts
@@ -1,0 +1,117 @@
+import { GitCommitDetail, GitLogRow, getCommitRows } from './data'
+import { LogFormat } from './config'
+
+const DEFAULT_TERMINAL_WIDTH = 120
+
+type RenderOptions = {
+  terminalWidth?: number
+}
+
+function truncate(value: string, width: number): string {
+  if (width < 1) {
+    return ''
+  }
+
+  if (value.length <= width) {
+    return value
+  }
+
+  if (width <= 3) {
+    return value.slice(0, width)
+  }
+
+  return `${value.slice(0, width - 3)}...`
+}
+
+function pad(value: string, width: number): string {
+  return value.padEnd(width, ' ')
+}
+
+function maxLength(values: string[], minimum: number): number {
+  return values.reduce((max, value) => Math.max(max, value.length), minimum)
+}
+
+function getTerminalWidth(options?: RenderOptions): number {
+  return options?.terminalWidth || process.stdout.columns || DEFAULT_TERMINAL_WIDTH
+}
+
+export function formatLogJson(rows: GitLogRow[]): string {
+  return JSON.stringify(getCommitRows(rows), null, 2)
+}
+
+export function formatLogTable(rows: GitLogRow[], options?: RenderOptions): string {
+  const commits = getCommitRows(rows)
+
+  if (commits.length === 0) {
+    return 'No commits found.'
+  }
+
+  const graphWidth = maxLength(rows.map((row) => row.graph), 'Graph'.length)
+  const authorWidth = Math.min(
+    24,
+    maxLength(commits.map((entry) => entry.author), 'Author'.length)
+  )
+  const refsByHash = new Map(commits.map((entry) => [entry.hash, entry.refs.join(', ')]))
+  const terminalWidth = getTerminalWidth(options)
+  const baseWidth = graphWidth + 2 + 9 + 2 + 10 + 2 + authorWidth + 2
+
+  const renderedRows = rows.map((row) => {
+    if (row.type === 'graph') {
+      return row.graph
+    }
+
+    const refs = refsByHash.get(row.hash)
+    const refText = refs ? `  [${refs}]` : ''
+    const messageWidth = Math.max(24, terminalWidth - baseWidth - refText.length)
+
+    return [
+      pad(row.graph || '*', graphWidth),
+      pad(row.shortHash, 9),
+      pad(row.date, 10),
+      pad(truncate(row.author, authorWidth), authorWidth),
+      `${truncate(row.message, messageWidth)}${refText}`,
+    ].join('  ')
+  })
+
+  return [
+    [
+      pad('Graph', graphWidth),
+      pad('Commit', 9),
+      pad('Date', 10),
+      pad('Author', authorWidth),
+      'Message',
+    ].join('  '),
+    ...renderedRows,
+  ].join('\n')
+}
+
+export function formatCommitDetail(detail: GitCommitDetail, format: LogFormat): string {
+  if (format === 'json') {
+    return JSON.stringify(detail, null, 2)
+  }
+
+  const refs = detail.refs.length ? ` (${detail.refs.join(', ')})` : ''
+  const body = detail.body ? `\n\n${detail.body}` : ''
+  const files = detail.files.length
+    ? detail.files
+      .map((file) => {
+        if (file.oldPath) {
+          return `  ${file.status}  ${file.oldPath} -> ${file.path}`
+        }
+
+        return `  ${file.status}  ${file.path}`
+      })
+      .join('\n')
+    : '  No changed files found.'
+
+  return [
+    `commit ${detail.hash}${refs}`,
+    `Author: ${detail.author}`,
+    `Date:   ${detail.date}`,
+    '',
+    `    ${detail.message}${body}`,
+    '',
+    'Changed files:',
+    files,
+  ].join('\n')
+}


### PR DESCRIPTION
## Summary
- Split `coco log` into data and render layers for stdout now and future TUI work
- Make interactive mode fall back to stdout until a dedicated TUI exists
- Preserve graph continuation rows and avoid fixed-width graph/ref truncation
- Add compact default history view with opt-in full topology via `--view full` or `--all`
- Add focused data/render tests plus temp-repo coverage for interactive fallback

## Validation
- `npm test`