### PR TITLE
Replace direct command exits

### DIFF
--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -25,6 +25,7 @@ import { LOGO, isInteractive } from '../../lib/ui/helpers'
 import { logSuccess } from '../../lib/ui/logSuccess'
 import { getDiffForBranch } from '../../lib/simple-git/getDiffForBranch'
 import { fileChangeParser } from '../../lib/parsers/default'
+import { commandExit } from '../../lib/utils/commandExit'
 import { getTokenCounter } from '../../lib/utils/tokenizer'
 import {
     ChangelogArgv,
@@ -77,12 +78,12 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
 
   if (exclusiveOptions.length > 1) {
     logger.log(`Options ${exclusiveOptions.join(', ')} cannot be used together.`, { color: 'red' })
-    process.exit(1)
+    commandExit(1)
   }
 
   if (config.service.authentication.type !== 'None' && !key) {
     logger.log(`No API Key found. 🗝️🚪`, { color: 'red' })
-    process.exit(1)
+    commandExit(1)
   }
 
   const llm = getLlm(provider, model as LLMModel, { ...config, service: changelogService })
@@ -125,7 +126,7 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
       const [from, to] = config.range.split(':')
       if (!from || !to) {
         logger.log(`Invalid range provided. Expected format is <from>:<to>`, { color: 'red' })
-        process.exit(1)
+        commandExit(1)
       }
       commits = await getCommitLogRangeDetails(from, to, { git, noMerges: true })
     } else if (argv.branch) {
@@ -316,11 +317,11 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
     noResult: async () => {
       if (config.range) {
         logger.log(`No commits found in the provided range.`, { color: 'red' })
-        process.exit(0)
+        commandExit(0)
       }
 
       logger.log(`No commits found in the current branch.`, { color: 'red' })
-      process.exit(0)
+      commandExit(0)
     },
   })
 

--- a/src/commands/commit/commit.test.ts
+++ b/src/commands/commit/commit.test.ts
@@ -78,11 +78,6 @@ const mockGetCurrentBranchName = getCurrentBranchName as jest.MockedFunction<
 >
 const mockGetPreviousCommits = getPreviousCommits as jest.MockedFunction<typeof getPreviousCommits>
 
-// Mock process.exit to prevent Jest worker crashes
-const mockProcessExit = jest.spyOn(process, 'exit').mockImplementation(() => {
-  return undefined as never
-})
-
 describe('commit command', () => {
   let argv: Arguments<CommitOptions>
   let logger: Logger
@@ -205,7 +200,6 @@ describe('commit command', () => {
 
   afterEach(() => {
     jest.clearAllMocks()
-    mockProcessExit.mockRestore()
   })
 
   it('should call getChanges when noDiff is false', async () => {

--- a/src/commands/commit/conventionalCommitsHandler.test.ts
+++ b/src/commands/commit/conventionalCommitsHandler.test.ts
@@ -2,6 +2,7 @@ import { handler } from './handler'
 import { Arguments } from 'yargs'
 import { CommitOptions } from './config'
 import { Logger } from '../../lib/utils/logger'
+import { CommandExitError } from '../../lib/utils/commandExit'
 
 // Mock all dependencies
 jest.mock('../../lib/simple-git/getRepo')
@@ -176,14 +177,11 @@ describe('Conventional Commits Handler', () => {
   describe('Error Handling', () => {
     it('should exit when API key is missing', async () => {
       mockGetApiKeyForModel.mockReturnValue('')
-      const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {
-        throw new Error('process.exit called')
-      })
 
-      await expect(handler(argv, logger)).rejects.toThrow('process.exit called')
+      await expect(handler(argv, logger)).rejects.toMatchObject({
+        code: 1,
+      } satisfies Partial<CommandExitError>)
       expect(logger.log).toHaveBeenCalledWith('No API Key found. 🗝️🚪', { color: 'red' })
-      
-      mockExit.mockRestore()
     })
 
     it('should warn about Ollama model limitations', async () => {

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -21,6 +21,7 @@ import { generateAndReviewLoop } from '../../lib/ui/generateAndReviewLoop'
 import { handleResult } from '../../lib/ui/handleResult'
 import { LOGO, SEPERATOR, isInteractive } from '../../lib/ui/helpers'
 import { logSuccess } from '../../lib/ui/logSuccess'
+import { commandExit } from '../../lib/utils/commandExit'
 import { getTokenCounter } from '../../lib/utils/tokenizer'
 import { hasCommitlintConfig } from '../../lib/utils/hasCommitlintConfig'
 import { withRetry } from '../../lib/utils/retry'
@@ -45,7 +46,7 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
 
   if (config.service.authentication.type !== 'None' && !key) {
     logger.log(`No API Key found. 🗝️🚪`, { color: 'red' })
-    process.exit(1)
+    commandExit(1)
   }
 
   const tokenizer = await getTokenCounter(
@@ -266,10 +267,10 @@ IMPORTANT RULES:
               break
             case 'setup':
               logger.log('\nPlease run `coco init` to set up commitlint, then try again.', { color: 'blue' })
-              process.exit(0)
+              commandExit(0)
             case 'abort':
               logger.log('\nAborting commit operation.', { color: 'red' })
-              process.exit(1)
+              commandExit(1)
           }
         } else {
           commitlint_rules_context = await getCommitlintRulesContext()
@@ -412,10 +413,10 @@ IMPORTANT RULES:
                 return fullMessage
               case 'setup':
                 logger.log('\nPlease run `coco init` to set up commitlint, then try again.', { color: 'blue' })
-                process.exit(0)
+                commandExit(0)
               case 'abort':
                 logger.log('\nAborting commit due to missing dependencies.', { color: 'red' })
-                process.exit(1)
+                commandExit(1)
             }
           }
 
@@ -472,7 +473,7 @@ IMPORTANT RULES:
                 )
               case 'abort':
                 logger.log('\nAborting commit due to validation errors.', { color: 'red' })
-                process.exit(1)
+                commandExit(1)
             }
           }
         }
@@ -508,7 +509,7 @@ IMPORTANT RULES:
     },
     noResult: async () => {
       await noResult({ git, logger })
-      process.exit(0)
+      commandExit(0)
     },
   })
 
@@ -573,14 +574,14 @@ IMPORTANT RULES:
                 await attemptCommit(true)
               } else {
                 logger.log('\nCommit aborted.', { color: 'red' })
-                process.exit(1)
+                commandExit(1)
               }
             } else {
               logger.log(
                 '\nFix the issues above and try again, or use --no-verify to skip hooks.',
                 { color: 'yellow' }
               )
-              process.exit(1)
+              commandExit(1)
             }
           } else {
             throw error

--- a/src/commands/init/questions.ts
+++ b/src/commands/init/questions.ts
@@ -1,6 +1,7 @@
 import { confirm, editor, input, password, select } from '@inquirer/prompts'
 import { ANTHROPIC_MODELS, OPEN_AI_MODELS } from '../../lib/langchain/constants'
 import { LLMModel, LLMProvider } from '../../lib/langchain/types'
+import { commandExit } from '../../lib/utils/commandExit'
 import { execPromise } from '../../lib/utils/execPromise'
 import { ProjectConfigFileName } from '../../lib/utils/getProjectConfigFilePath'
 import { COMMIT_PROMPT } from '../commit/prompt'
@@ -80,7 +81,7 @@ export const questions = {
 
       if (availableOllamaModels.length === 0) {
         console.log('No Ollama models found. Please install one via Ollama CLI.')
-        process.exit(1)
+        commandExit(1)
       }
 
       availableModels = [

--- a/src/commands/recap/handler.ts
+++ b/src/commands/recap/handler.ts
@@ -20,6 +20,7 @@ import { generateAndReviewLoop } from '../../lib/ui/generateAndReviewLoop'
 import { handleResult } from '../../lib/ui/handleResult'
 import { isInteractive, LOGO } from '../../lib/ui/helpers'
 import { logSuccess } from '../../lib/ui/logSuccess'
+import { commandExit } from '../../lib/utils/commandExit'
 import { getTokenCounter } from '../../lib/utils/tokenizer'
 import { RecapArgv, RecapLlmResponseSchema, RecapOptions } from './config'
 import { noResult } from './noResult'
@@ -37,7 +38,7 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
 
   if (config.service.authentication.type !== 'None' && !key) {
     logger.log(`No API Key found. 🗝️🚪`, { color: 'red' })
-    process.exit(1)
+    commandExit(1)
   }
 
   const tokenizer = await getTokenCounter(
@@ -285,7 +286,7 @@ ${errorMessage}
     noResult: async () => {
       await noResult({ git, logger })
       if (process.env.NODE_ENV !== 'test') {
-        process.exit(0)
+        commandExit(0)
       }
     },
   })

--- a/src/commands/review/handler.ts
+++ b/src/commands/review/handler.ts
@@ -19,6 +19,7 @@ import { CommandHandler } from '../../lib/types'
 import { generateAndReviewLoop } from '../../lib/ui/generateAndReviewLoop'
 import { isInteractive, LOGO, severityColor } from '../../lib/ui/helpers'
 import { TaskList } from '../../lib/ui/TaskList'
+import { commandExit } from '../../lib/utils/commandExit'
 import { getTokenCounter } from '../../lib/utils/tokenizer'
 import { ReviewArgv, ReviewFeedbackItemArraySchema, ReviewOptions, ReviewFeedbackItem } from './config'
 import { noResult } from './noResult'
@@ -43,7 +44,7 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
 
   if (config.service.authentication.type !== 'None' && !key) {
     logger.log(`No API Key found. 🗝️🚪`, { color: 'red' })
-    process.exit(1)
+    commandExit(1)
   }
 
   const tokenizer = await getTokenCounter(
@@ -104,7 +105,7 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
 
       if (staged.length === 0 && unstaged?.length === 0 && untracked?.length === 0) {
         logger.log('No changes detected. Exiting...')
-        process.exit(0)
+        commandExit(0)
       }
 
       if (INTERACTIVE) {
@@ -262,7 +263,7 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
     },
     noResult: async () => {
       await noResult({ git, logger })
-      process.exit(0)
+      commandExit(0)
     },
   })
 

--- a/src/lib/simple-git/getRepo.ts
+++ b/src/lib/simple-git/getRepo.ts
@@ -1,4 +1,5 @@
 import { simpleGit, SimpleGit } from 'simple-git'
+import { commandExit } from '../utils/commandExit'
 
 /**
  * Retrieves the SimpleGit instance for the repository.
@@ -11,7 +12,7 @@ export const getRepo = () => {
     git = simpleGit()
   } catch (e) {
     console.log('Error initializing git repo', e)
-    process.exit(1)
+    commandExit(1)
   }
 
   return git

--- a/src/lib/ui/generateAndReviewLoop.ts
+++ b/src/lib/ui/generateAndReviewLoop.ts
@@ -3,6 +3,7 @@ import { editPrompt } from './editPrompt'
 import { editResult } from './editResult'
 import { ReviewDecision, getUserReviewDecision } from './getUserReviewDecision'
 import { logResult } from './logResult'
+import { commandExit } from '../utils/commandExit'
 
 export type GenerateReviewLoopOptions = {
   interactive: boolean
@@ -79,7 +80,7 @@ export async function generateAndReviewLoop<T, R>({
           mode: 'fail',
           color: 'red',
         })
-        process.exit(0)
+        commandExit(0)
       }
     } catch (error) {
       // Handle special regeneration request from validation
@@ -111,7 +112,7 @@ export async function generateAndReviewLoop<T, R>({
       })
 
       if (reviewAnswer === 'cancel') {
-        process.exit(0)
+        commandExit(0)
       }
 
       if (reviewAnswer === 'edit') {

--- a/src/lib/ui/handleResult.ts
+++ b/src/lib/ui/handleResult.ts
@@ -24,8 +24,4 @@ export async function handleResult({ result, mode, interactiveModeCallback }: Ha
       process.stdout.write(result + '\n', 'utf8')
       break
   }
-
-  if (process.env.NODE_ENV !== 'test') {
-    process.exit(0)
-  }
 }

--- a/src/lib/utils/commandExecutor.ts
+++ b/src/lib/utils/commandExecutor.ts
@@ -4,6 +4,7 @@ import { Logger } from './logger'
 import { CommandHandler } from '../types'
 import { BaseArgvOptions } from '../../commands/types'
 import { LangChainNetworkError, LangChainAuthenticationError } from '../langchain/errors'
+import { isCommandExitError } from './commandExit'
 
 /**
  * Formats a network error with helpful troubleshooting information
@@ -73,6 +74,11 @@ function commandExecutor<T extends Argv<BaseArgvOptions>['argv']>(handler: Comma
     try {
       await handler(argv, logger)
     } catch (error) {
+      if (isCommandExitError(error)) {
+        process.exitCode = error.code
+        return
+      }
+
       // Handle specific error types with helpful messages
       if (error instanceof LangChainNetworkError) {
         formatNetworkError(error, logger)
@@ -83,7 +89,7 @@ function commandExecutor<T extends Argv<BaseArgvOptions>['argv']>(handler: Comma
       }
 
       logger.log('\nThanks for using coco, make it a great day! 👋🤖', { color: 'blue' })
-      process.exit(0)
+      process.exitCode = 1
     }
   }
 }

--- a/src/lib/utils/commandExit.test.ts
+++ b/src/lib/utils/commandExit.test.ts
@@ -1,0 +1,70 @@
+import commandExecutor from './commandExecutor'
+import { CommandExitError, commandExit, isCommandExitError } from './commandExit'
+import { loadConfig } from '../config/utils/loadConfig'
+
+jest.mock('../config/utils/loadConfig')
+
+const mockLoadConfig = loadConfig as jest.MockedFunction<typeof loadConfig>
+
+describe('commandExit', () => {
+  const originalExitCode = process.exitCode
+
+  beforeEach(() => {
+    process.exitCode = undefined
+    mockLoadConfig.mockReturnValue({ silent: true } as never)
+  })
+
+  afterEach(() => {
+    process.exitCode = originalExitCode
+    jest.clearAllMocks()
+  })
+
+  it('throws a typed command exit error', () => {
+    expect(() => commandExit(7)).toThrow(CommandExitError)
+
+    try {
+      commandExit(7)
+    } catch (error) {
+      expect(isCommandExitError(error)).toBe(true)
+      expect(error).toMatchObject({
+        code: 7,
+      })
+    }
+  })
+
+  it('lets commandExecutor handle expected command exits without generic failure logging', async () => {
+    const handler = jest.fn(async () => {
+      commandExit(1)
+    })
+    const wrapped = commandExecutor(handler)
+
+    await wrapped({
+      $0: 'coco',
+      _: [],
+      interactive: false,
+      verbose: false,
+      version: false,
+      help: false,
+    })
+
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('maps unexpected errors to a failing exit code', async () => {
+    const handler = jest.fn(async () => {
+      throw new Error('Unexpected failure')
+    })
+    const wrapped = commandExecutor(handler)
+
+    await wrapped({
+      $0: 'coco',
+      _: [],
+      interactive: false,
+      verbose: false,
+      version: false,
+      help: false,
+    })
+
+    expect(process.exitCode).toBe(1)
+  })
+})

--- a/src/lib/utils/commandExit.ts
+++ b/src/lib/utils/commandExit.ts
@@ -1,0 +1,17 @@
+export class CommandExitError extends Error {
+  readonly code: number
+
+  constructor(code = 0, message = `Command exited with code ${code}`) {
+    super(message)
+    this.name = 'CommandExitError'
+    this.code = code
+  }
+}
+
+export function commandExit(code = 0, message?: string): never {
+  throw new CommandExitError(code, message)
+}
+
+export function isCommandExitError(error: unknown): error is CommandExitError {
+  return error instanceof CommandExitError
+}


### PR DESCRIPTION
## Summary
- Add a typed `CommandExitError` and `commandExit` helper for expected command termination
- Teach `commandExecutor` to map expected command exits to process exit codes without generic error handling
- Remove direct runtime `process.exit` calls from command handlers and shared UI helpers
- Keep standalone build scripts unchanged
- Update tests that previously mocked `process.exit`

Closes #652

## Validation
- `npm test`