### PR TITLE
Expand init and review command coverage

### DIFF
--- a/bin/smokeCli.ts
+++ b/bin/smokeCli.ts
@@ -111,6 +111,12 @@ try {
     args: ['log', '--help'],
     label: 'packaged log command help',
   })
+  runCheck({
+    command: packagedBinPath(prefix),
+    args: ['init', '--dry-run', '--scope', 'project'],
+    label: 'packaged init dry run',
+  })
+  console.log('✓ packaged init dry run')
 } finally {
   rmSync(tempRoot, { recursive: true, force: true })
 }

--- a/src/commands/commands.integration.test.ts
+++ b/src/commands/commands.integration.test.ts
@@ -6,6 +6,8 @@ import { handler as commitHandler } from './commit/handler'
 import { CommitOptions } from './commit/config'
 import { handler as logHandler } from './log/handler'
 import { LogOptions } from './log/config'
+import { handler as reviewHandler } from './review/handler'
+import { ReviewOptions } from './review/config'
 import { loadConfig } from '../lib/config/utils/loadConfig'
 import { executeChain } from '../lib/langchain/utils/executeChain'
 import { executeChainWithSchema } from '../lib/langchain/utils/executeChainWithSchema'
@@ -41,6 +43,11 @@ jest.mock('../lib/langchain/utils/getLlm')
 jest.mock('../lib/utils/tokenizer')
 jest.mock('../lib/ui/logSuccess', () => ({
   logSuccess: jest.fn(),
+}))
+jest.mock('../lib/ui/TaskList', () => ({
+  TaskList: jest.fn().mockImplementation(() => ({
+    start: jest.fn(),
+  })),
 }))
 jest.mock('../lib/utils/hasCommitlintConfig', () => ({
   hasCommitlintConfig: jest.fn().mockResolvedValue(false),
@@ -531,6 +538,76 @@ describe('command integration with temp git repos', () => {
     expect(stdout).toContain('- Summarized feature work')
     expect(variables.summary).toContain('feat: add feature module')
     expect(variables.summary).toContain('feature/changelog-test')
+  })
+
+  it('reviews real working tree changes from a temp git repo', async () => {
+    mockLoadConfig.mockReturnValue(createConfig({
+      mode: 'stdout',
+    }))
+    mockExecuteChain.mockResolvedValueOnce([
+      {
+        title: 'Review finding',
+        summary: 'Check README wording.',
+        severity: 4,
+        category: 'maintainability',
+        filePath: 'README.md',
+      },
+    ])
+
+    await repo.writeFile('README.md', '# Temp repo\n')
+    await repo.commitAll('chore: initial commit')
+    await repo.writeFile('README.md', '# Temp repo\n\nUpdated documentation.\n')
+
+    await reviewHandler({
+      $0: 'coco',
+      _: ['review'],
+      branch: '',
+      interactive: false,
+      verbose: false,
+      version: false,
+      help: false,
+    } as Arguments<ReviewOptions>, createLogger())
+
+    const variables = mockExecuteChain.mock.calls[0][0].variables as Record<string, string>
+
+    expect(variables.changes).toContain('README.md')
+    expect(variables.changes).toContain('Updated documentation')
+  })
+
+  it('reviews real branch diffs from a temp git repo', async () => {
+    mockLoadConfig.mockReturnValue(createConfig({
+      mode: 'stdout',
+    }))
+    mockExecuteChain.mockResolvedValueOnce([
+      {
+        title: 'Review finding',
+        summary: 'Check feature module.',
+        severity: 5,
+        category: 'maintainability',
+        filePath: 'src/feature.ts',
+      },
+    ])
+
+    await repo.writeFile('README.md', '# Temp repo\n')
+    await repo.commitAll('chore: initial commit')
+    await repo.git.checkoutLocalBranch('feature/review-test')
+    await repo.writeFile('src/feature.ts', 'export const feature = true\n')
+    await repo.commitAll('feat: add review feature')
+
+    await reviewHandler({
+      $0: 'coco',
+      _: ['review'],
+      branch: 'main',
+      interactive: false,
+      verbose: false,
+      version: false,
+      help: false,
+    } as Arguments<ReviewOptions>, createLogger())
+
+    const variables = mockExecuteChain.mock.calls[0][0].variables as Record<string, string>
+
+    expect(variables.changes).toContain('src/feature.ts')
+    expect(variables.changes).toContain('export const feature = true')
   })
 
   it('prints a visual git log with refs and graph metadata', async () => {

--- a/src/commands/init/config.ts
+++ b/src/commands/init/config.ts
@@ -6,6 +6,7 @@ export type InstallationScope = 'global' | 'project'
 
 export interface InitOptions extends BaseArgvOptions {
   scope?: InstallationScope
+  dryRun?: boolean
 }
 
 export type InitArgv = Argv<InitOptions>['argv']
@@ -20,6 +21,11 @@ export const options = {
     type: 'string',
     description: 'configure coco for the current user or project?',
     choices: ['global', 'project'],
+  },
+  dryRun: {
+    type: 'boolean',
+    description: 'validate init can run without prompts or filesystem writes',
+    default: false,
   },
 } as Record<string, Options>
 

--- a/src/commands/init/handler.ts
+++ b/src/commands/init/handler.ts
@@ -25,42 +25,48 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
 
   let scope = options?.scope
   let shouldSetupCommitlint = false
+
+  if (options.dryRun) {
+    logger.log(`\ninit dry run successful for ${scope || 'project'} scope`, { color: 'green' })
+    return
+  }
   
   if (!scope) {
     scope = await questions.whatScope()
+  }
 
-    // Ask about commitlint setup after scope selection
-    shouldSetupCommitlint = await questions.setupCommitlint()
+  // Ask about commitlint setup after scope selection
+  shouldSetupCommitlint = await questions.setupCommitlint()
 
-    const llmProvider = await questions.selectLLMProvider()
-    const llmModel = await questions.selectLLMModel(llmProvider)
+  const llmProvider = await questions.selectLLMProvider()
+  const llmModel = await questions.selectLLMModel(llmProvider)
 
-    const service = getDefaultServiceConfigFromAlias(llmProvider, llmModel)
+  const service = getDefaultServiceConfigFromAlias(llmProvider, llmModel)
 
-    const config: ConfigWithServiceObject = {
-      defaultBranch: 'main',
-      mode: 'interactive',
-      service: service,
+  const config: ConfigWithServiceObject = {
+    defaultBranch: 'main',
+    mode: 'interactive',
+    service: service,
+  }
+
+  let apiKey = '' as string
+  if (llmProvider === 'openai') {
+    apiKey = await questions.inputApiKey('OpenAI', 'OPENAI_API_KEY')
+
+    if (config.service.authentication.type === 'APIKey') {
+      config.service.authentication.credentials.apiKey = '•••••••••••••••'
     }
+  }
 
-    let apiKey = '' as string
-    if (llmProvider === 'openai') {
-      apiKey = await questions.inputApiKey('OpenAI', 'OPENAI_API_KEY')
+  if (llmProvider === 'anthropic') {
+    apiKey = await questions.inputApiKey('Anthropic', 'ANTHROPIC_API_KEY')
 
-      if (config.service.authentication.type === 'APIKey') {
-        config.service.authentication.credentials.apiKey = '•••••••••••••••'
-      }
+    if (config.service.authentication.type === 'APIKey') {
+      config.service.authentication.credentials.apiKey = '•••••••••••••••'
     }
+  }
 
-    if (llmProvider === 'anthropic') {
-      apiKey = await questions.inputApiKey('Anthropic', 'ANTHROPIC_API_KEY')
-
-      if (config.service.authentication.type === 'APIKey') {
-        config.service.authentication.credentials.apiKey = '•••••••••••••••'
-      }
-    }
-
-    const advOptions = await questions.configureAdvancedOptions()
+  const advOptions = await questions.configureAdvancedOptions()
 
     /**
      * Prompt for advanced options
@@ -75,8 +81,8 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
      * - ignored extensions
      * - commit message prompt
      */
-    if (advOptions) {
-      config.mode = await questions.selectMode()
+  if (advOptions) {
+    config.mode = await questions.selectMode()
 
       config.defaultBranch = await questions.selectDefaultGitBranch()
 
@@ -135,53 +141,52 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
       }
     }
 
-    logResult('Config', JSON.stringify(config, null, 2))
-    let approvalMessage = 'does this look good?'
+  logResult('Config', JSON.stringify(config, null, 2))
+  let approvalMessage = 'does this look good?'
 
-    if (config.service.authentication.type === 'APIKey') {
-      // add to config after logging, so that the API key is not logged
-      config.service.authentication.credentials.apiKey = apiKey
-      approvalMessage = 'looking good? (API key hidden for security)'
+  if (config.service.authentication.type === 'APIKey') {
+    // add to config after logging, so that the API key is not logged
+    config.service.authentication.credentials.apiKey = apiKey
+    approvalMessage = 'looking good? (API key hidden for security)'
+  }
+
+  const isApproved = await confirm({
+    message: approvalMessage,
+  })
+
+  let configFilePath = ''
+
+  switch (scope) {
+    case 'project':
+      const fileTypeSelection = await questions.selectProjectConfigFileType()
+      configFilePath = await getProjectConfigFilePath(fileTypeSelection)
+      break
+    case 'global':
+    default:
+      configFilePath = getPathToUsersGitConfig()
+      break
+  }
+
+  if (isApproved) {
+    if (configFilePath.endsWith('.gitconfig')) {
+      await appendToGitConfig(configFilePath, config)
+    } else if (configFilePath.endsWith('.env')) {
+      await appendToEnvFile(configFilePath, config)
+    } else if (configFilePath.endsWith('.coco.config.json')) {
+      appendToProjectJsonConfig(configFilePath, config)
     }
 
-    const isApproved = await confirm({
-      message: approvalMessage,
-    })
+    // After config is written, check for package installation
+    await checkAndHandlePackageInstallation({ global: scope === 'global', logger })
 
-    let configFilePath = ''
-
-    switch (scope) {
-      case 'project':
-        const fileTypeSelection = await questions.selectProjectConfigFileType()
-        configFilePath = await getProjectConfigFilePath(fileTypeSelection)
-        break
-      case 'global':
-      default:
-        configFilePath = getPathToUsersGitConfig()
-        break
+    // Install commitlint packages if user requested
+    if (shouldSetupCommitlint) {
+      await installCommitlintPackages(scope, logger)
     }
 
-    if (isApproved) {
-      if (configFilePath.endsWith('.gitconfig')) {
-        await appendToGitConfig(configFilePath, config)
-      } else if (configFilePath.endsWith('.env')) {
-        await appendToEnvFile(configFilePath, config)
-      } else if (configFilePath.endsWith('.coco.config.json')) {
-        appendToProjectJsonConfig(configFilePath, config)
-      }
-
-      // After config is written, check for package installation
-      await checkAndHandlePackageInstallation({ global: scope === 'global', logger })
-
-      // Install commitlint packages if user requested
-      if (shouldSetupCommitlint) {
-        await installCommitlintPackages(scope, logger)
-      }
-
-      logger.log(`\ninit successful! 🦾🤖🎉`, { color: 'green' })
-    } else {
-      logger.log('\ninit cancelled.', { color: 'yellow' })
-    }
+    logger.log(`\ninit successful! 🦾🤖🎉`, { color: 'green' })
+  } else {
+    logger.log('\ninit cancelled.', { color: 'yellow' })
   }
 }
 

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -1,0 +1,243 @@
+import { confirm } from '@inquirer/prompts'
+import { handler } from './handler'
+import { questions } from './questions'
+import { InitOptions } from './config'
+import { Config } from '../types'
+import { appendToEnvFile } from '../../lib/config/services/env'
+import { appendToGitConfig } from '../../lib/config/services/git'
+import { appendToProjectJsonConfig } from '../../lib/config/services/project'
+import { loadConfig } from '../../lib/config/utils/loadConfig'
+import { checkAndHandlePackageInstallation } from '../../lib/ui/checkAndHandlePackageInstall'
+import { logResult } from '../../lib/ui/logResult'
+import { getDefaultServiceConfigFromAlias } from '../../lib/langchain/utils'
+import { getPathToUsersGitConfig } from '../../lib/utils/getPathToUsersGitConfig'
+import { getProjectConfigFilePath } from '../../lib/utils/getProjectConfigFilePath'
+import { installNpmPackage } from '../../lib/utils/installPackage'
+import { Logger } from '../../lib/utils/logger'
+
+jest.mock('@inquirer/prompts', () => ({
+  confirm: jest.fn(),
+}))
+jest.mock('../../lib/config/services/env')
+jest.mock('../../lib/config/services/git')
+jest.mock('../../lib/config/services/project')
+jest.mock('../../lib/config/utils/loadConfig')
+jest.mock('../../lib/ui/checkAndHandlePackageInstall')
+jest.mock('../../lib/ui/logResult')
+jest.mock('../../lib/langchain/utils')
+jest.mock('../../lib/utils/getPathToUsersGitConfig')
+jest.mock('../../lib/utils/getProjectConfigFilePath')
+jest.mock('../../lib/utils/installPackage')
+
+const mockConfirm = confirm as jest.MockedFunction<typeof confirm>
+const mockAppendToEnvFile = appendToEnvFile as jest.MockedFunction<typeof appendToEnvFile>
+const mockAppendToGitConfig = appendToGitConfig as jest.MockedFunction<typeof appendToGitConfig>
+const mockAppendToProjectJsonConfig = appendToProjectJsonConfig as jest.MockedFunction<
+  typeof appendToProjectJsonConfig
+>
+const mockLoadConfig = loadConfig as jest.MockedFunction<typeof loadConfig>
+const mockCheckAndHandlePackageInstallation = checkAndHandlePackageInstallation as jest.MockedFunction<
+  typeof checkAndHandlePackageInstallation
+>
+const mockLogResult = logResult as jest.MockedFunction<typeof logResult>
+const mockGetDefaultServiceConfigFromAlias = getDefaultServiceConfigFromAlias as jest.MockedFunction<
+  typeof getDefaultServiceConfigFromAlias
+>
+const mockGetPathToUsersGitConfig = getPathToUsersGitConfig as jest.MockedFunction<
+  typeof getPathToUsersGitConfig
+>
+const mockGetProjectConfigFilePath = getProjectConfigFilePath as jest.MockedFunction<
+  typeof getProjectConfigFilePath
+>
+const mockInstallNpmPackage = installNpmPackage as jest.MockedFunction<typeof installNpmPackage>
+
+function createLogger(): Logger {
+  return {
+    log: jest.fn(),
+    verbose: jest.fn(),
+    setConfig: jest.fn(),
+    startTimer: jest.fn().mockReturnThis(),
+    stopTimer: jest.fn().mockReturnThis(),
+    startSpinner: jest.fn().mockReturnThis(),
+    stopSpinner: jest.fn().mockReturnThis(),
+  } as unknown as Logger
+}
+
+function createArgv(overrides: Partial<InitOptions> = {}) {
+  return {
+    $0: 'coco',
+    _: ['init'],
+    interactive: false,
+    verbose: false,
+    version: false,
+    help: false,
+    ...overrides,
+  }
+}
+
+function mockApiKeyService(provider: 'openai' | 'anthropic' = 'openai') {
+  mockGetDefaultServiceConfigFromAlias.mockReturnValue({
+    provider,
+    model: provider === 'openai' ? 'gpt-4o' : 'claude-3-5-sonnet-latest',
+    authentication: {
+      type: 'APIKey',
+      credentials: {
+        apiKey: '',
+      },
+    },
+  } as never)
+}
+
+function mockOllamaService() {
+  mockGetDefaultServiceConfigFromAlias.mockReturnValue({
+    provider: 'ollama',
+    model: 'llama3',
+    endpoint: 'http://localhost:11434',
+    authentication: {
+      type: 'None',
+    },
+  } as never)
+}
+
+describe('init command', () => {
+  let logger: Logger
+
+  beforeEach(() => {
+    logger = createLogger()
+    mockLoadConfig.mockReturnValue({
+      scope: 'project',
+      dryRun: false,
+    } as unknown as Config)
+    mockConfirm.mockResolvedValue(true)
+    mockCheckAndHandlePackageInstallation.mockResolvedValue(undefined)
+    mockAppendToGitConfig.mockResolvedValue(undefined)
+    mockAppendToEnvFile.mockResolvedValue(undefined)
+    mockInstallNpmPackage.mockResolvedValue(true)
+    mockGetPathToUsersGitConfig.mockReturnValue('/home/coco/.gitconfig')
+    mockGetProjectConfigFilePath.mockResolvedValue('/repo/.coco.config.json')
+    mockApiKeyService('openai')
+
+    jest.spyOn(questions, 'whatScope').mockResolvedValue('project')
+    jest.spyOn(questions, 'setupCommitlint').mockResolvedValue(false)
+    jest.spyOn(questions, 'selectLLMProvider').mockResolvedValue('openai')
+    jest.spyOn(questions, 'selectLLMModel').mockResolvedValue('gpt-4o')
+    jest.spyOn(questions, 'inputApiKey').mockResolvedValue('secret-api-key')
+    jest.spyOn(questions, 'configureAdvancedOptions').mockResolvedValue(false)
+    jest.spyOn(questions, 'selectProjectConfigFileType').mockResolvedValue('.coco.config.json')
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
+  })
+
+  it('supports a non-interactive dry run without prompts or writes', async () => {
+    mockLoadConfig.mockReturnValue({
+      scope: 'project',
+      dryRun: true,
+    } as unknown as Config)
+
+    await handler(createArgv({ dryRun: true }), logger)
+
+    expect(questions.selectLLMProvider).not.toHaveBeenCalled()
+    expect(mockAppendToProjectJsonConfig).not.toHaveBeenCalled()
+    expect(mockCheckAndHandlePackageInstallation).not.toHaveBeenCalled()
+    expect(logger.log).toHaveBeenCalledWith('\ninit dry run successful for project scope', {
+      color: 'green',
+    })
+  })
+
+  it('writes project json config when scope is provided', async () => {
+    await handler(createArgv({ scope: 'project' }), logger)
+
+    expect(questions.whatScope).not.toHaveBeenCalled()
+    expect(mockAppendToProjectJsonConfig).toHaveBeenCalledWith(
+      '/repo/.coco.config.json',
+      expect.objectContaining({
+        service: expect.objectContaining({
+          provider: 'openai',
+          authentication: expect.objectContaining({
+            credentials: expect.objectContaining({
+              apiKey: 'secret-api-key',
+            }),
+          }),
+        }),
+      })
+    )
+    expect(mockCheckAndHandlePackageInstallation).toHaveBeenCalledWith({
+      global: false,
+      logger,
+    })
+  })
+
+  it('writes env config when selected for a project config', async () => {
+    jest.spyOn(questions, 'selectProjectConfigFileType').mockResolvedValue('.env')
+    mockGetProjectConfigFilePath.mockResolvedValue('/repo/.env')
+
+    await handler(createArgv({ scope: 'project' }), logger)
+
+    expect(mockAppendToEnvFile).toHaveBeenCalledWith('/repo/.env', expect.any(Object))
+  })
+
+  it('writes global git config and installs commitlint packages when requested', async () => {
+    mockLoadConfig.mockReturnValue({
+      scope: 'global',
+      dryRun: false,
+    } as unknown as Config)
+    jest.spyOn(questions, 'setupCommitlint').mockResolvedValue(true)
+    jest.spyOn(questions, 'selectLLMProvider').mockResolvedValue('ollama')
+    jest.spyOn(questions, 'selectLLMModel').mockResolvedValue('llama3')
+    mockOllamaService()
+
+    await handler(createArgv({ scope: 'global' }), logger)
+
+    expect(mockAppendToGitConfig).toHaveBeenCalledWith('/home/coco/.gitconfig', expect.any(Object))
+    expect(mockCheckAndHandlePackageInstallation).toHaveBeenCalledWith({
+      global: true,
+      logger,
+    })
+    expect(mockInstallNpmPackage).toHaveBeenCalledWith({
+      name: '@commitlint/config-conventional',
+      flags: ['-g'],
+    })
+    expect(mockInstallNpmPackage).toHaveBeenCalledWith({
+      name: '@commitlint/cli',
+      flags: ['-g'],
+    })
+  })
+
+  it('does not write config when approval is declined', async () => {
+    mockConfirm.mockResolvedValue(false)
+
+    await handler(createArgv({ scope: 'project' }), logger)
+
+    expect(mockAppendToProjectJsonConfig).not.toHaveBeenCalled()
+    expect(mockCheckAndHandlePackageInstallation).not.toHaveBeenCalled()
+    expect(logger.log).toHaveBeenCalledWith('\ninit cancelled.', { color: 'yellow' })
+  })
+
+  it('logs invalid advanced service fields and continues', async () => {
+    jest.spyOn(questions, 'configureAdvancedOptions').mockResolvedValue(true)
+    jest.spyOn(questions, 'selectMode').mockResolvedValue('stdout')
+    jest.spyOn(questions, 'selectDefaultGitBranch').mockResolvedValue('main')
+    jest.spyOn(questions, 'inputModelTemperature').mockResolvedValue(0.2)
+    jest.spyOn(questions, 'inputTokenLimit').mockResolvedValue(4096)
+    jest.spyOn(questions, 'enableVerboseMode').mockResolvedValue(false)
+    jest.spyOn(questions, 'inputRequestTimeout').mockResolvedValue(30000)
+    jest.spyOn(questions, 'inputRequestMaxRetries').mockResolvedValue(2)
+    jest.spyOn(questions, 'inputServiceFields').mockResolvedValue('{bad json')
+    mockConfirm
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true)
+
+    await handler(createArgv({ scope: 'project' }), logger)
+
+    expect(logger.log).toHaveBeenCalledWith('Invalid JSON for service fields. Skipping.', {
+      color: 'red',
+    })
+    expect(mockLogResult).toHaveBeenCalled()
+    expect(mockAppendToProjectJsonConfig).toHaveBeenCalled()
+  })
+})

--- a/src/commands/review/handler.ts
+++ b/src/commands/review/handler.ts
@@ -79,7 +79,7 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
 
       const branchChanges = await fileChangeParser({
         changes: diff.staged,
-        commit: `--branch-diff-${argv.branch}`,
+        commit: `${argv.branch}..${currentBranch}`,
         options: {
           tokenizer,
           git,


### PR DESCRIPTION
## Summary
- Add `coco init --dry-run` as a non-interactive smoke path
- Fix `coco init --scope ...` so scoped init still runs setup instead of returning early
- Add init unit coverage for project/global/env/cancel/advanced-field/commitlint paths
- Add packaged CLI smoke coverage for init dry-run
- Add temp-git integration coverage for `coco review` working tree and branch diff flows
- Fix branch review diff parsing to use a real `<base>..<head>` git range

Closes #654
Closes #651

## Validation
- `npm test`