### PR TITLE
Share diff parser option construction

### DIFF
--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -25,6 +25,7 @@ import { LOGO, isInteractive } from '../../lib/ui/helpers'
 import { logSuccess } from '../../lib/ui/logSuccess'
 import { getDiffForBranch } from '../../lib/simple-git/getDiffForBranch'
 import { fileChangeParser } from '../../lib/parsers/default'
+import { createFileChangeParserOptions } from '../../lib/parsers/default/utils/createFileChangeParserOptions'
 import { commandExit } from '../../lib/utils/commandExit'
 import { getTokenCounter } from '../../lib/utils/tokenizer'
 import {
@@ -166,21 +167,16 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
                 ? await fileChangeParser({
                     changes,
                     commit: `${commit.hash}^..${commit.hash}`,
-                    options: {
+                    options: createFileChangeParserOptions({
+                      command: 'changelog',
                       tokenizer,
                       git,
                       llm: summaryLlm,
                       logger,
-                      maxTokens: config.service.tokenLimit,
-                      minTokensForSummary: config.service.minTokensForSummary,
-                      maxFileTokens: config.service.maxFileTokens,
-                      maxConcurrent: config.service.maxConcurrent,
-                      metadata: {
-                        command: 'changelog',
-                        provider,
-                        model: String(summaryService.model),
-                      },
-                    },
+                      provider,
+                      model: String(summaryService.model),
+                      service: config.service,
+                    }),
                   })
                 : undefined,
           }
@@ -201,21 +197,16 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
       const diffSummary = await fileChangeParser({
         changes: data.diffChanges,
         commit: data.diffCommit,
-        options: {
+        options: createFileChangeParserOptions({
+          command: 'changelog',
           tokenizer,
           git,
           llm: summaryLlm,
           logger,
-          maxTokens: config.service.tokenLimit,
-          minTokensForSummary: config.service.minTokensForSummary,
-          maxFileTokens: config.service.maxFileTokens,
-          maxConcurrent: config.service.maxConcurrent,
-          metadata: {
-            command: 'changelog',
-            provider,
-            model: String(summaryService.model),
-          },
-        },
+          provider,
+          model: String(summaryService.model),
+          service: config.service,
+        }),
       })
 
       return `## Diff for ${data.branch}\n\n${diffSummary}`

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -10,6 +10,7 @@ import { resolveDynamicService } from '../../lib/langchain/utils/dynamicModels'
 import { logLlmTelemetrySummary } from '../../lib/langchain/utils/observability'
 import { getPrompt } from '../../lib/langchain/utils/getPrompt'
 import { fileChangeParser } from '../../lib/parsers/default'
+import { createFileChangeParserOptions } from '../../lib/parsers/default/utils/createFileChangeParserOptions'
 import { PreCommitHookError, createCommit } from '../../lib/simple-git/createCommit'
 import { extractTicketIdFromBranchName } from '../../lib/simple-git/extractTicketIdFromBranchName'
 import { getChanges } from '../../lib/simple-git/getChanges'
@@ -129,21 +130,16 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
     return await fileChangeParser({
       changes,
       commit: '--staged',
-      options: {
+      options: createFileChangeParserOptions({
+        command: 'commit',
         tokenizer,
         git,
         llm: summaryLlm,
         logger,
-        maxTokens: config.service.tokenLimit,
-        minTokensForSummary: config.service.minTokensForSummary,
-        maxFileTokens: config.service.maxFileTokens,
-        maxConcurrent: config.service.maxConcurrent,
-        metadata: {
-          command: 'commit',
-          provider,
-          model: String(summaryService.model),
-        },
-      },
+        provider,
+        model: String(summaryService.model),
+        service: config.service,
+      }),
     })
   }
 

--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -7,6 +7,7 @@ import { Config } from '../../lib/config/types'
 import { executeChainWithSchema } from '../../lib/langchain/utils/executeChainWithSchema'
 import { getLlm } from '../../lib/langchain/utils/getLlm'
 import { fileChangeParser } from '../../lib/parsers/default'
+import { createFileChangeParserOptions } from '../../lib/parsers/default/utils/createFileChangeParserOptions'
 import { createCommit } from '../../lib/simple-git/createCommit'
 import { getChanges } from '../../lib/simple-git/getChanges'
 import { FileChange } from '../../lib/types'
@@ -412,22 +413,17 @@ export async function handleCommitSplit({
   const summary = await fileChangeParser({
     changes: changes.staged,
     commit: '--staged',
-    options: {
+    options: createFileChangeParserOptions({
+      command: 'commit',
       tokenizer,
       git,
       llm,
       logger,
-      maxTokens: config.service.tokenLimit,
-        minTokensForSummary: config.service.minTokensForSummary,
-        maxFileTokens: config.service.maxFileTokens,
-        maxConcurrent: config.service.maxConcurrent,
-        metadata: {
-          command: 'commit',
-          provider: config.service.provider,
-          model: String(config.service.model),
-        },
-      },
-    })
+      provider: config.service.provider,
+      model: String(config.service.model),
+      service: config.service,
+    }),
+  })
 
   const fileInventory = changes.staged
     .map((change) => `- ${change.filePath}: ${change.status} - ${change.summary}`)

--- a/src/commands/recap/handler.ts
+++ b/src/commands/recap/handler.ts
@@ -26,6 +26,7 @@ import { RecapArgv, RecapLlmResponseSchema, RecapOptions } from './config'
 import { noResult } from './noResult'
 import { RECAP_PROMPT } from './prompt'
 import { fileChangeParser } from '../../lib/parsers/default'
+import { createFileChangeParserOptions } from '../../lib/parsers/default/utils/createFileChangeParserOptions'
 
 export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
   const git = getRepo()
@@ -86,17 +87,16 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
         const unstagedChanges = await fileChangeParser({
           changes: unstaged || [],
           commit: '--unstaged',
-          options: {
+          options: createFileChangeParserOptions({
+            command: 'recap',
             tokenizer,
             git,
             llm: summaryLlm,
             logger,
-            metadata: {
-              command: 'recap',
-              provider,
-              model: String(summaryService.model),
-            },
-          },
+            provider,
+            model: String(summaryService.model),
+            service: config.service,
+          }),
         })
 
         const unstagedResponse = `Unstaged changes:\n${unstagedChanges}`
@@ -104,34 +104,32 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
         const untrackedChanges = await fileChangeParser({
           changes: untracked || [],
           commit: '--untracked',
-          options: {
+          options: createFileChangeParserOptions({
+            command: 'recap',
             tokenizer,
             git,
             llm: summaryLlm,
             logger,
-            metadata: {
-              command: 'recap',
-              provider,
-              model: String(summaryService.model),
-            },
-          },
+            provider,
+            model: String(summaryService.model),
+            service: config.service,
+          }),
         })
         const untrackedResponse = `Untracked changes:\n${untrackedChanges}`
 
         const stagedChanges = await fileChangeParser({
           changes: staged,
           commit: '--staged',
-          options: {
+          options: createFileChangeParserOptions({
+            command: 'recap',
             tokenizer,
             git,
             llm: summaryLlm,
             logger,
-            metadata: {
-              command: 'recap',
-              provider,
-              model: String(summaryService.model),
-            },
-          },
+            provider,
+            model: String(summaryService.model),
+            service: config.service,
+          }),
         })
         const stagedResponse = `Staged changes:\n${stagedChanges}`
 
@@ -167,17 +165,16 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
         const branchChanges = await fileChangeParser({
           changes: changes.staged,
           commit: baseBranch,
-          options: {
+          options: createFileChangeParserOptions({
+            command: 'recap',
             tokenizer,
             git,
             llm: summaryLlm,
             logger,
-            metadata: {
-              command: 'recap',
-              provider,
-              model: String(summaryService.model),
-            },
-          },
+            provider,
+            model: String(summaryService.model),
+            service: config.service,
+          }),
         })
 
         return [branchChanges]

--- a/src/commands/review/handler.ts
+++ b/src/commands/review/handler.ts
@@ -11,6 +11,7 @@ import { logLlmTelemetrySummary } from '../../lib/langchain/utils/observability'
 import { getLlm } from '../../lib/langchain/utils/getLlm'
 import { getPrompt } from '../../lib/langchain/utils/getPrompt'
 import { fileChangeParser } from '../../lib/parsers/default/index'
+import { createFileChangeParserOptions } from '../../lib/parsers/default/utils/createFileChangeParserOptions'
 import { getChanges } from '../../lib/simple-git/getChanges'
 import { getDiffForBranch } from '../../lib/simple-git/getDiffForBranch'
 import { getRepo } from '../../lib/simple-git/getRepo'
@@ -80,17 +81,16 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
       const branchChanges = await fileChangeParser({
         changes: diff.staged,
         commit: `${argv.branch}..${currentBranch}`,
-        options: {
+        options: createFileChangeParserOptions({
+          command: 'review',
           tokenizer,
           git,
           llm: summaryLlm,
           logger,
-          metadata: {
-            command: 'review',
-            provider,
-            model: String(summaryService.model),
-          },
-        },
+          provider,
+          model: String(summaryService.model),
+          service: config.service,
+        }),
       })
 
       return [branchChanges]
@@ -119,17 +119,16 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
       const unstagedChanges = await fileChangeParser({
         changes: unstaged || [],
         commit: '--unstaged',
-        options: {
+        options: createFileChangeParserOptions({
+          command: 'review',
           tokenizer,
           git,
           llm: summaryLlm,
           logger,
-          metadata: {
-            command: 'review',
-            provider,
-            model: String(summaryService.model),
-          },
-        },
+          provider,
+          model: String(summaryService.model),
+          service: config.service,
+        }),
       })
 
       const unstagedResponse = `Unstaged changes:\n${unstagedChanges}`
@@ -137,34 +136,32 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
       const untrackedChanges = await fileChangeParser({
         changes: untracked || [],
         commit: '--untracked',
-        options: {
+        options: createFileChangeParserOptions({
+          command: 'review',
           tokenizer,
           git,
           llm: summaryLlm,
           logger,
-          metadata: {
-            command: 'review',
-            provider,
-            model: String(summaryService.model),
-          },
-        },
+          provider,
+          model: String(summaryService.model),
+          service: config.service,
+        }),
       })
       const untrackedResponse = `Untracked changes:\n${untrackedChanges}`
 
       const stagedChanges = await fileChangeParser({
         changes: staged,
         commit: '--staged',
-        options: {
+        options: createFileChangeParserOptions({
+          command: 'review',
           tokenizer,
           git,
           llm: summaryLlm,
           logger,
-          metadata: {
-            command: 'review',
-            provider,
-            model: String(summaryService.model),
-          },
-        },
+          provider,
+          model: String(summaryService.model),
+          service: config.service,
+        }),
       })
       const stagedResponse = `Staged changes:\n${stagedChanges}`
 

--- a/src/lib/parsers/default/utils/createFileChangeParserOptions.test.ts
+++ b/src/lib/parsers/default/utils/createFileChangeParserOptions.test.ts
@@ -1,0 +1,67 @@
+import { createFileChangeParserOptions } from './createFileChangeParserOptions'
+import { Logger } from '../../../utils/logger'
+
+describe('createFileChangeParserOptions', () => {
+  it('builds parser options with budget fields and telemetry metadata', () => {
+    const tokenizer = jest.fn()
+    const git = {} as never
+    const llm = {} as never
+    const logger = {} as Logger
+
+    const result = createFileChangeParserOptions({
+      command: 'review',
+      git,
+      llm,
+      logger,
+      model: 'gpt-4o-mini',
+      provider: 'openai',
+      service: {
+        tokenLimit: 4096,
+        minTokensForSummary: 400,
+        maxFileTokens: 1200,
+        maxConcurrent: 2,
+      },
+      tokenizer,
+    })
+
+    expect(result).toEqual({
+      tokenizer,
+      git,
+      llm,
+      logger,
+      maxTokens: 4096,
+      minTokensForSummary: 400,
+      maxFileTokens: 1200,
+      maxConcurrent: 2,
+      metadata: {
+        command: 'review',
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+      },
+    })
+  })
+
+  it('allows commands without explicit budget overrides', () => {
+    const result = createFileChangeParserOptions({
+      command: 'recap',
+      git: {} as never,
+      llm: {} as never,
+      logger: {} as Logger,
+      model: 'gpt-4o',
+      provider: 'openai',
+      tokenizer: jest.fn(),
+    })
+
+    expect(result).toEqual(expect.objectContaining({
+      maxTokens: undefined,
+      minTokensForSummary: undefined,
+      maxFileTokens: undefined,
+      maxConcurrent: undefined,
+      metadata: {
+        command: 'recap',
+        provider: 'openai',
+        model: 'gpt-4o',
+      },
+    }))
+  })
+})

--- a/src/lib/parsers/default/utils/createFileChangeParserOptions.ts
+++ b/src/lib/parsers/default/utils/createFileChangeParserOptions.ts
@@ -1,0 +1,51 @@
+import { SimpleGit } from 'simple-git'
+import { BaseParserOptions } from '../../../types'
+import { LLMProvider } from '../../../langchain/types'
+import { Logger } from '../../../utils/logger'
+import { TokenCounter } from '../../../utils/tokenizer'
+import { getLlm } from '../../../langchain/utils/getLlm'
+
+export type FileChangeParserServiceBudget = {
+  tokenLimit?: number
+  minTokensForSummary?: number
+  maxFileTokens?: number
+  maxConcurrent?: number
+}
+
+export type CreateFileChangeParserOptionsInput = {
+  command: string
+  git: SimpleGit
+  llm: ReturnType<typeof getLlm>
+  logger: Logger
+  model: string
+  provider: LLMProvider | string
+  service?: FileChangeParserServiceBudget
+  tokenizer: TokenCounter
+}
+
+export function createFileChangeParserOptions({
+  command,
+  git,
+  llm,
+  logger,
+  model,
+  provider,
+  service,
+  tokenizer,
+}: CreateFileChangeParserOptionsInput): BaseParserOptions {
+  return {
+    tokenizer,
+    git,
+    llm,
+    logger,
+    maxTokens: service?.tokenLimit,
+    minTokensForSummary: service?.minTokensForSummary,
+    maxFileTokens: service?.maxFileTokens,
+    maxConcurrent: service?.maxConcurrent,
+    metadata: {
+      command,
+      provider,
+      model,
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Add `createFileChangeParserOptions` for shared diff condensation budget and telemetry metadata wiring
- Use the helper from commit, commit split, review, recap, and changelog
- Add focused tests for budget and telemetry option construction

Closes #653

## Validation
- `npm test`