### PR TITLE
Add minimal interactive log TUI

### DIFF
--- a/src/commands/commands.integration.test.ts
+++ b/src/commands/commands.integration.test.ts
@@ -641,7 +641,7 @@ describe('command integration with temp git repos', () => {
     expect(stdout).toContain('*')
   })
 
-  it('prints log output when interactive mode is requested', async () => {
+  it('renders an interactive log smoke view when interactive mode is requested', async () => {
     mockLoadConfig.mockReturnValue(createConfig({
       mode: 'stdout',
     }))
@@ -662,8 +662,10 @@ describe('command integration with temp git repos', () => {
       help: false,
     } as Arguments<LogOptions>, createLogger())
 
+    expect(stdout).toContain('coco log')
     expect(stdout).toContain('feat: add interactive log coverage')
-    expect(stdout).toContain('Graph')
+    expect(stdout).toContain('Changed files:')
+    expect(stdout).toContain('src/interactive.ts')
   })
 
   it('prints machine-readable git log output', async () => {

--- a/src/commands/log/config.ts
+++ b/src/commands/log/config.ts
@@ -25,6 +25,11 @@ export type LogArgv = Arguments<LogOptions>
 export const command = 'log'
 
 export const options = {
+  i: {
+    description: 'Open the interactive terminal log UI',
+    type: 'boolean',
+    alias: 'interactive',
+  },
   all: {
     description: 'Show commits from all local and remote refs',
     type: 'boolean',

--- a/src/commands/log/handler.ts
+++ b/src/commands/log/handler.ts
@@ -2,6 +2,7 @@ import { CommandHandler } from '../../lib/types'
 import { getRepo } from '../../lib/simple-git/getRepo'
 import { handleResult } from '../../lib/ui/handleResult'
 import { getCommitDetail, getLogRows } from './data'
+import { startInteractiveLog } from './interactive'
 import { formatCommitDetail, formatLogJson, formatLogTable } from './render'
 import { LogArgv } from './config'
 
@@ -19,6 +20,12 @@ export const handler: CommandHandler<LogArgv> = async (argv) => {
   }
 
   const rows = await getLogRows(git, argv)
+
+  if (argv.interactive && format === 'table') {
+    await startInteractiveLog(git, rows)
+    return
+  }
+
   const result = format === 'json' ? formatLogJson(rows) : formatLogTable(rows)
 
   await handleResult({

--- a/src/commands/log/interactive.test.ts
+++ b/src/commands/log/interactive.test.ts
@@ -1,0 +1,48 @@
+import { GitCommitDetail, GitLogRow } from './data'
+import { createLogTuiState } from './interactiveState'
+import { renderInteractiveLog } from './interactive'
+
+const rows: GitLogRow[] = [
+  {
+    type: 'commit',
+    graph: '*',
+    shortHash: 'abc1234',
+    hash: 'abc1234',
+    date: '2026-04-27',
+    author: 'Coco Test',
+    refs: ['HEAD -> main'],
+    message: 'feat: add interactive log',
+  },
+]
+
+const detail: GitCommitDetail = {
+  shortHash: 'abc1234',
+  hash: 'abc1234',
+  date: '2026-04-27',
+  author: 'Coco Test',
+  refs: ['HEAD -> main'],
+  message: 'feat: add interactive log',
+  body: 'Adds the first terminal UI.',
+  files: [
+    {
+      status: 'A',
+      path: 'src/commands/log/interactive.ts',
+    },
+  ],
+}
+
+describe('log interactive renderer', () => {
+  it('renders commit navigation, selected details, changed files, and help', () => {
+    const output = renderInteractiveLog(createLogTuiState(rows), detail, {
+      height: 40,
+      width: 100,
+    })
+
+    expect(output).toContain('coco log')
+    expect(output).toContain('1/1 commits')
+    expect(output).toContain('feat: add interactive log')
+    expect(output).toContain('Changed files:')
+    expect(output).toContain('A  src/commands/log/interactive.ts')
+    expect(output).toContain('Keys:')
+  })
+})

--- a/src/commands/log/interactive.ts
+++ b/src/commands/log/interactive.ts
@@ -1,0 +1,258 @@
+import readline from 'readline'
+import { SimpleGit } from 'simple-git'
+import { GitCommitDetail, GitLogRow, getCommitDetail } from './data'
+import {
+  LogTuiState,
+  applyLogTuiAction,
+  createLogTuiState,
+  getSelectedCommit,
+} from './interactiveState'
+
+type LogTuiStreams = {
+  input?: NodeJS.ReadStream
+  output?: NodeJS.WriteStream
+}
+
+type RenderInteractiveLogOptions = {
+  height?: number
+  width?: number
+}
+
+const DEFAULT_HEIGHT = 40
+const DEFAULT_WIDTH = 120
+
+function truncate(value: string, width: number): string {
+  if (width < 1) {
+    return ''
+  }
+
+  if (value.length <= width) {
+    return value
+  }
+
+  if (width <= 3) {
+    return value.slice(0, width)
+  }
+
+  return `${value.slice(0, width - 3)}...`
+}
+
+function formatChangedFile(file: GitCommitDetail['files'][number]): string {
+  if (file.oldPath) {
+    return `${file.status}  ${file.oldPath} -> ${file.path}`
+  }
+
+  return `${file.status}  ${file.path}`
+}
+
+function renderCommitList(state: LogTuiState, maxRows: number, width: number): string[] {
+  const start = Math.max(0, state.selectedIndex - Math.floor(maxRows / 2))
+  const visible = state.filteredCommits.slice(start, start + maxRows)
+
+  if (visible.length === 0) {
+    return ['  No commits match the current filter.']
+  }
+
+  return visible.map((commit, offset) => {
+    const index = start + offset
+    const selected = index === state.selectedIndex ? '>' : ' '
+    const graph = state.fullGraph ? commit.graph || '*' : '*'
+    const refs = commit.refs.length ? ` [${commit.refs.join(', ')}]` : ''
+    const row = [
+      selected,
+      graph.padEnd(state.fullGraph ? 8 : 2),
+      commit.shortHash.padEnd(9),
+      commit.date.padEnd(10),
+      truncate(commit.author, 18).padEnd(18),
+      `${commit.message}${refs}`,
+    ].join(' ')
+
+    return truncate(row, width)
+  })
+}
+
+function renderDetail(detail: GitCommitDetail | undefined, width: number): string[] {
+  if (!detail) {
+    return ['Loading selected commit details...']
+  }
+
+  const refs = detail.refs.length ? ` (${detail.refs.join(', ')})` : ''
+  const body = detail.body ? ['', ...detail.body.split('\n').map((line) => `  ${line}`)] : []
+  const files = detail.files.length
+    ? detail.files.slice(0, 12).map((file) => `  ${formatChangedFile(file)}`)
+    : ['  No changed files found.']
+  const hiddenFiles = detail.files.length > 12
+    ? [`  ... ${detail.files.length - 12} more file(s)`]
+    : []
+
+  return [
+    truncate(`commit ${detail.hash}${refs}`, width),
+    truncate(`Author: ${detail.author}`, width),
+    truncate(`Date:   ${detail.date}`, width),
+    '',
+    truncate(`  ${detail.message}`, width),
+    ...body.map((line) => truncate(line, width)),
+    '',
+    'Changed files:',
+    ...files.map((line) => truncate(line, width)),
+    ...hiddenFiles,
+  ]
+}
+
+export function renderInteractiveLog(
+  state: LogTuiState,
+  detail?: GitCommitDetail,
+  options: RenderInteractiveLogOptions = {}
+): string {
+  const height = options.height || process.stdout.rows || DEFAULT_HEIGHT
+  const width = options.width || process.stdout.columns || DEFAULT_WIDTH
+  const selected = getSelectedCommit(state)
+  const filter = state.filter ? state.filter : '<none>'
+  const graphMode = state.fullGraph ? 'full graph' : 'compact graph'
+  const help = state.showHelp
+    ? 'Keys: up/down or j/k move | / search | g graph | ? help | q quit'
+    : 'Press ? for help'
+  const detailHeader = selected
+    ? `Selected: ${selected.shortHash} ${selected.message}`
+    : 'Selected: none'
+  const listHeight = Math.max(4, Math.floor(height * 0.45))
+  const detailHeight = Math.max(6, height - listHeight - 8)
+  const detailLines = renderDetail(detail, width).slice(0, detailHeight)
+  const filterPrompt = state.filterMode ? `Search: ${state.filter}_` : `Filter: ${filter}`
+
+  return [
+    'coco log',
+    `${state.filteredCommits.length}/${state.commits.length} commits | ${filterPrompt} | ${graphMode}`,
+    help,
+    '',
+    ...renderCommitList(state, listHeight, width),
+    '',
+    truncate(detailHeader, width),
+    '-'.repeat(Math.min(width, 80)),
+    ...detailLines,
+  ].join('\n')
+}
+
+export async function startInteractiveLog(
+  git: SimpleGit,
+  rows: GitLogRow[],
+  streams: LogTuiStreams = {}
+): Promise<void> {
+  const input = streams.input || process.stdin
+  const output = streams.output || process.stdout
+  let state = createLogTuiState(rows)
+  const details = new Map<string, GitCommitDetail>()
+
+  async function loadSelectedDetail(): Promise<GitCommitDetail | undefined> {
+    const selected = getSelectedCommit(state)
+
+    if (!selected) {
+      return undefined
+    }
+
+    const cached = details.get(selected.hash)
+    if (cached) {
+      return cached
+    }
+
+    const detail = await getCommitDetail(git, selected.hash)
+    details.set(selected.hash, detail)
+    return detail
+  }
+
+  if (!input.isTTY || !output.isTTY) {
+    output.write(`${renderInteractiveLog(state, await loadSelectedDetail())}\n`, 'utf8')
+    return
+  }
+
+  readline.emitKeypressEvents(input)
+  input.setRawMode(true)
+  output.write('\x1b[?25l', 'utf8')
+
+  let closed = false
+  let renderVersion = 0
+
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      closed = true
+      input.off('keypress', onKeypress)
+      input.setRawMode(false)
+      output.write('\x1b[?25h\n', 'utf8')
+      resolve()
+    }
+
+    const render = async () => {
+      const version = ++renderVersion
+      output.write(`\x1b[2J\x1b[H${renderInteractiveLog(state)}\n`, 'utf8')
+
+      try {
+        const detail = await loadSelectedDetail()
+
+        if (!closed && version === renderVersion) {
+          output.write(`\x1b[2J\x1b[H${renderInteractiveLog(state, detail)}\n`, 'utf8')
+        }
+      } catch (error) {
+        reject(error)
+      }
+    }
+
+    const applyAndRender = (nextState: LogTuiState) => {
+      state = nextState
+      void render()
+    }
+
+    const onFilterKeypress = (sequence: string | undefined, key: readline.Key) => {
+      if (key.name === 'return' || key.name === 'escape') {
+        applyAndRender(applyLogTuiAction(state, { type: 'toggleFilterMode' }))
+        return
+      }
+
+      if (key.name === 'backspace') {
+        applyAndRender(applyLogTuiAction(state, { type: 'backspaceFilter' }))
+        return
+      }
+
+      if (key.ctrl && key.name === 'u') {
+        applyAndRender(applyLogTuiAction(state, { type: 'clearFilter' }))
+        return
+      }
+
+      if (sequence && sequence.length === 1 && !key.ctrl && !key.meta) {
+        applyAndRender(applyLogTuiAction(state, { type: 'appendFilter', value: sequence }))
+      }
+    }
+
+    const onKeypress = (sequence: string | undefined, key: readline.Key) => {
+      if ((key.ctrl && key.name === 'c') || key.name === 'q') {
+        cleanup()
+        return
+      }
+
+      if (state.filterMode) {
+        onFilterKeypress(sequence, key)
+        return
+      }
+
+      if (key.name === 'up' || key.name === 'k') {
+        applyAndRender(applyLogTuiAction(state, { type: 'move', delta: -1 }))
+      } else if (key.name === 'down' || key.name === 'j') {
+        applyAndRender(applyLogTuiAction(state, { type: 'move', delta: 1 }))
+      } else if (key.name === 'pageup') {
+        applyAndRender(applyLogTuiAction(state, { type: 'page', delta: -10 }))
+      } else if (key.name === 'pagedown') {
+        applyAndRender(applyLogTuiAction(state, { type: 'page', delta: 10 }))
+      } else if (key.name === 'g') {
+        applyAndRender(applyLogTuiAction(state, { type: 'toggleGraph' }))
+      } else if (key.name === '/') {
+        applyAndRender(applyLogTuiAction(state, { type: 'toggleFilterMode' }))
+      } else if (key.name === '?') {
+        applyAndRender(applyLogTuiAction(state, { type: 'toggleHelp' }))
+      } else if (key.name === 'escape') {
+        applyAndRender(applyLogTuiAction(state, { type: 'clearFilter' }))
+      }
+    }
+
+    input.on('keypress', onKeypress)
+    void render()
+  })
+}

--- a/src/commands/log/interactiveState.test.ts
+++ b/src/commands/log/interactiveState.test.ts
@@ -1,0 +1,80 @@
+import { GitLogRow } from './data'
+import { applyLogTuiAction, createLogTuiState, getSelectedCommit } from './interactiveState'
+
+const rows: GitLogRow[] = [
+  {
+    type: 'commit',
+    graph: '*',
+    shortHash: 'aaa1111',
+    hash: 'aaa1111',
+    date: '2026-04-27',
+    author: 'Coco Test',
+    refs: ['HEAD -> main'],
+    message: 'feat: add graph ui',
+  },
+  {
+    type: 'graph',
+    graph: '|\\',
+  },
+  {
+    type: 'commit',
+    graph: '| *',
+    shortHash: 'bbb2222',
+    hash: 'bbb2222',
+    date: '2026-04-26',
+    author: 'Dependabot',
+    refs: [],
+    message: 'chore: update dependency',
+  },
+]
+
+describe('log interactive state', () => {
+  it('moves through commit rows without selecting graph-only rows', () => {
+    let state = createLogTuiState(rows)
+
+    state = applyLogTuiAction(state, { type: 'move', delta: 1 })
+
+    expect(getSelectedCommit(state)).toEqual(expect.objectContaining({
+      shortHash: 'bbb2222',
+    }))
+
+    state = applyLogTuiAction(state, { type: 'move', delta: 1 })
+
+    expect(getSelectedCommit(state)).toEqual(expect.objectContaining({
+      shortHash: 'bbb2222',
+    }))
+  })
+
+  it('filters commits by message, author, hash, and refs', () => {
+    let state = createLogTuiState(rows)
+
+    state = applyLogTuiAction(state, { type: 'setFilter', value: 'dependency' })
+
+    expect(state.filteredCommits).toHaveLength(1)
+    expect(getSelectedCommit(state)).toEqual(expect.objectContaining({
+      shortHash: 'bbb2222',
+    }))
+
+    state = applyLogTuiAction(state, { type: 'setFilter', value: 'HEAD' })
+
+    expect(state.filteredCommits).toHaveLength(1)
+    expect(getSelectedCommit(state)).toEqual(expect.objectContaining({
+      shortHash: 'aaa1111',
+    }))
+  })
+
+  it('updates filter text incrementally and supports graph/help toggles', () => {
+    let state = createLogTuiState(rows)
+
+    state = applyLogTuiAction(state, { type: 'toggleFilterMode' })
+    state = applyLogTuiAction(state, { type: 'appendFilter', value: 'feat' })
+    state = applyLogTuiAction(state, { type: 'backspaceFilter' })
+    state = applyLogTuiAction(state, { type: 'toggleGraph' })
+    state = applyLogTuiAction(state, { type: 'toggleHelp' })
+
+    expect(state.filterMode).toBe(true)
+    expect(state.filter).toBe('fea')
+    expect(state.fullGraph).toBe(true)
+    expect(state.showHelp).toBe(false)
+  })
+})

--- a/src/commands/log/interactiveState.ts
+++ b/src/commands/log/interactiveState.ts
@@ -1,0 +1,125 @@
+import { GitLogCommitRow, GitLogRow, getCommitRows } from './data'
+
+export type LogTuiState = {
+  rows: GitLogRow[]
+  commits: GitLogCommitRow[]
+  filteredCommits: GitLogCommitRow[]
+  selectedIndex: number
+  filter: string
+  filterMode: boolean
+  fullGraph: boolean
+  showHelp: boolean
+}
+
+export type LogTuiAction =
+  | { type: 'move'; delta: number }
+  | { type: 'page'; delta: number }
+  | { type: 'setFilter'; value: string }
+  | { type: 'appendFilter'; value: string }
+  | { type: 'backspaceFilter' }
+  | { type: 'clearFilter' }
+  | { type: 'toggleFilterMode' }
+  | { type: 'toggleGraph' }
+  | { type: 'toggleHelp' }
+
+function matchesFilter(commit: GitLogCommitRow, filter: string): boolean {
+  const value = filter.trim().toLowerCase()
+
+  if (!value) {
+    return true
+  }
+
+  return [
+    commit.shortHash,
+    commit.hash,
+    commit.date,
+    commit.author,
+    commit.message,
+    ...commit.refs,
+  ].some((field) => field.toLowerCase().includes(value))
+}
+
+function filterCommits(commits: GitLogCommitRow[], filter: string): GitLogCommitRow[] {
+  return commits.filter((commit) => matchesFilter(commit, filter))
+}
+
+function clampIndex(index: number, length: number): number {
+  if (length === 0) {
+    return 0
+  }
+
+  return Math.max(0, Math.min(index, length - 1))
+}
+
+function withFilter(state: LogTuiState, filter: string): LogTuiState {
+  const filteredCommits = filterCommits(state.commits, filter)
+
+  return {
+    ...state,
+    filter,
+    filteredCommits,
+    selectedIndex: clampIndex(state.selectedIndex, filteredCommits.length),
+  }
+}
+
+export function createLogTuiState(rows: GitLogRow[]): LogTuiState {
+  const commits = getCommitRows(rows)
+
+  return {
+    rows,
+    commits,
+    filteredCommits: commits,
+    selectedIndex: 0,
+    filter: '',
+    filterMode: false,
+    fullGraph: false,
+    showHelp: true,
+  }
+}
+
+export function getSelectedCommit(state: LogTuiState): GitLogCommitRow | undefined {
+  return state.filteredCommits[state.selectedIndex]
+}
+
+export function applyLogTuiAction(state: LogTuiState, action: LogTuiAction): LogTuiState {
+  switch (action.type) {
+    case 'move':
+      return {
+        ...state,
+        selectedIndex: clampIndex(state.selectedIndex + action.delta, state.filteredCommits.length),
+      }
+    case 'page':
+      return {
+        ...state,
+        selectedIndex: clampIndex(state.selectedIndex + action.delta, state.filteredCommits.length),
+      }
+    case 'setFilter':
+      return withFilter(state, action.value)
+    case 'appendFilter':
+      return withFilter(state, `${state.filter}${action.value}`)
+    case 'backspaceFilter':
+      return withFilter(state, state.filter.slice(0, -1))
+    case 'clearFilter':
+      return withFilter({
+        ...state,
+        filterMode: false,
+      }, '')
+    case 'toggleFilterMode':
+      return {
+        ...state,
+        filterMode: !state.filterMode,
+      }
+    case 'toggleGraph':
+      return {
+        ...state,
+        fullGraph: !state.fullGraph,
+      }
+    case 'toggleHelp':
+      return {
+        ...state,
+        showHelp: !state.showHelp,
+      }
+    default:
+      return state
+  }
+}


### PR DESCRIPTION
## Summary

- add a real `coco log -i` terminal UI entrypoint backed by the existing log data layer
- add pure TUI state transitions for navigation, filtering, graph toggling, and help toggling
- lazy-load selected commit details and changed files, with a deterministic non-TTY smoke render for tests/CI
- keep `coco log`, `coco log --format json`, and `coco log --commit <ref>` on their existing stdout paths

## Validation

- `npm run test:jest -- src/commands/log/interactiveState.test.ts src/commands/log/interactive.test.ts src/commands/log/data.test.ts src/commands/commands.integration.test.ts`
- `npm run coco:ts -- log -i --limit 3`
- `npm test`

Closes #659.
