### PR TITLE
Show branch overview in log TUI

### DIFF
--- a/src/commands/log/branchData.test.ts
+++ b/src/commands/log/branchData.test.ts
@@ -1,0 +1,58 @@
+import { FIELD_SEPARATOR } from './data'
+import { parseBranchRefs, parseDivergence } from './branchData'
+
+describe('log branch data', () => {
+  it('parses local and remote branch refs from stable git output', () => {
+    const refs = parseBranchRefs([
+      [
+        'refs/heads/main',
+        'main',
+        'abc1234',
+        'origin/main',
+        '*',
+        '2026-04-27',
+        'feat: current branch',
+      ].join(FIELD_SEPARATOR),
+      [
+        'refs/remotes/origin/main',
+        'origin/main',
+        'def5678',
+        '',
+        '',
+        '2026-04-26',
+        'feat: remote branch',
+      ].join(FIELD_SEPARATOR),
+      [
+        'refs/remotes/origin/HEAD',
+        'origin/HEAD',
+        'def5678',
+        '',
+        '',
+        '2026-04-26',
+        'origin/main',
+      ].join(FIELD_SEPARATOR),
+    ].join('\n'))
+
+    expect(refs).toEqual([
+      expect.objectContaining({
+        type: 'local',
+        shortName: 'main',
+        upstream: 'origin/main',
+        current: true,
+      }),
+      expect.objectContaining({
+        type: 'remote',
+        remote: 'origin',
+        shortName: 'origin/main',
+        current: false,
+      }),
+    ])
+  })
+
+  it('parses upstream divergence as behind and ahead counts', () => {
+    expect(parseDivergence('2\t5\n')).toEqual({
+      behind: 2,
+      ahead: 5,
+    })
+  })
+})

--- a/src/commands/log/branchData.ts
+++ b/src/commands/log/branchData.ts
@@ -1,0 +1,120 @@
+import { SimpleGit } from 'simple-git'
+
+const FIELD_SEPARATOR = '\x1f'
+
+export type BranchRefType = 'local' | 'remote'
+
+export type BranchRef = {
+  type: BranchRefType
+  name: string
+  shortName: string
+  hash: string
+  upstream?: string
+  current: boolean
+  remote?: string
+  date: string
+  subject: string
+  ahead: number
+  behind: number
+}
+
+export type BranchOverview = {
+  currentBranch?: string
+  dirty: boolean
+  localBranches: BranchRef[]
+  remoteBranches: BranchRef[]
+}
+
+export function parseBranchRefs(output: string): BranchRef[] {
+  return output
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line): BranchRef | undefined => {
+      const [refName, shortName, hash, upstream, head, date, subject] = line.split(FIELD_SEPARATOR)
+
+      if (!refName || !shortName) {
+        return undefined
+      }
+
+      if (
+        refName.startsWith('refs/remotes/') &&
+        (refName.endsWith('/HEAD') || shortName.endsWith('/HEAD'))
+      ) {
+        return undefined
+      }
+
+      const type: BranchRefType = refName.startsWith('refs/remotes/') ? 'remote' : 'local'
+      const remote = type === 'remote' ? shortName.split('/')[0] : undefined
+
+      return {
+        type,
+        name: refName,
+        shortName,
+        hash,
+        upstream: upstream || undefined,
+        current: head === '*',
+        remote,
+        date,
+        subject,
+        ahead: 0,
+        behind: 0,
+      }
+    })
+    .filter((ref): ref is BranchRef => Boolean(ref))
+}
+
+export function parseDivergence(output: string): Pick<BranchRef, 'ahead' | 'behind'> {
+  const [behind = '0', ahead = '0'] = output.trim().split(/\s+/)
+
+  return {
+    ahead: Number.parseInt(ahead, 10) || 0,
+    behind: Number.parseInt(behind, 10) || 0,
+  }
+}
+
+export async function getBranchDivergence(
+  git: SimpleGit,
+  branch: string,
+  upstream: string
+): Promise<Pick<BranchRef, 'ahead' | 'behind'>> {
+  return parseDivergence(await git.raw(['rev-list', '--left-right', '--count', `${upstream}...${branch}`]))
+}
+
+export async function getBranchOverview(git: SimpleGit): Promise<BranchOverview> {
+  const [branchOutput, statusOutput, currentBranchOutput] = await Promise.all([
+    git.raw([
+      'for-each-ref',
+      `--format=%(refname)${FIELD_SEPARATOR}%(refname:short)${FIELD_SEPARATOR}%(objectname:short)${FIELD_SEPARATOR}%(upstream:short)${FIELD_SEPARATOR}%(HEAD)${FIELD_SEPARATOR}%(committerdate:short)${FIELD_SEPARATOR}%(contents:subject)`,
+      'refs/heads',
+      'refs/remotes',
+    ]),
+    git.raw(['status', '--porcelain']),
+    git.raw(['branch', '--show-current']),
+  ])
+  const refs = parseBranchRefs(branchOutput)
+  const localBranches: BranchRef[] = []
+
+  for (const ref of refs.filter((entry) => entry.type === 'local')) {
+    if (!ref.upstream) {
+      localBranches.push(ref)
+      continue
+    }
+
+    try {
+      localBranches.push({
+        ...ref,
+        ...(await getBranchDivergence(git, ref.shortName, ref.upstream)),
+      })
+    } catch {
+      localBranches.push(ref)
+    }
+  }
+
+  return {
+    currentBranch: currentBranchOutput.trim() || undefined,
+    dirty: statusOutput.trim().length > 0,
+    localBranches,
+    remoteBranches: refs.filter((entry) => entry.type === 'remote'),
+  }
+}

--- a/src/commands/log/interactive.test.ts
+++ b/src/commands/log/interactive.test.ts
@@ -1,6 +1,7 @@
 import { GitCommitDetail, GitLogRow } from './data'
 import { createLogTuiState } from './interactiveState'
 import { renderInteractiveLog } from './interactive'
+import { BranchOverview } from './branchData'
 
 const rows: GitLogRow[] = [
   {
@@ -31,9 +32,42 @@ const detail: GitCommitDetail = {
   ],
 }
 
+const branches: BranchOverview = {
+  currentBranch: 'main',
+  dirty: true,
+  localBranches: [
+    {
+      type: 'local',
+      name: 'refs/heads/main',
+      shortName: 'main',
+      hash: 'abc1234',
+      upstream: 'origin/main',
+      current: true,
+      date: '2026-04-27',
+      subject: 'feat: add interactive log',
+      ahead: 1,
+      behind: 2,
+    },
+  ],
+  remoteBranches: [
+    {
+      type: 'remote',
+      name: 'refs/remotes/origin/main',
+      shortName: 'origin/main',
+      hash: 'abc1234',
+      current: false,
+      remote: 'origin',
+      date: '2026-04-27',
+      subject: 'feat: add interactive log',
+      ahead: 0,
+      behind: 0,
+    },
+  ],
+}
+
 describe('log interactive renderer', () => {
   it('renders commit navigation, selected details, changed files, and help', () => {
-    const output = renderInteractiveLog(createLogTuiState(rows), detail, {
+    const output = renderInteractiveLog(createLogTuiState(rows), detail, branches, {
       height: 40,
       width: 100,
     })
@@ -43,6 +77,9 @@ describe('log interactive renderer', () => {
     expect(output).toContain('feat: add interactive log')
     expect(output).toContain('Changed files:')
     expect(output).toContain('A  src/commands/log/interactive.ts')
+    expect(output).toContain('Branches: main | dirty worktree')
+    expect(output).toContain('* main +1/-2 vs origin/main')
+    expect(output).toContain('origin/main')
     expect(output).toContain('Keys:')
   })
 })

--- a/src/commands/log/interactive.ts
+++ b/src/commands/log/interactive.ts
@@ -1,5 +1,6 @@
 import readline from 'readline'
 import { SimpleGit } from 'simple-git'
+import { BranchOverview, BranchRef, getBranchOverview } from './branchData'
 import { GitCommitDetail, GitLogRow, getCommitDetail } from './data'
 import {
   LogTuiState,
@@ -71,6 +72,51 @@ function renderCommitList(state: LogTuiState, maxRows: number, width: number): s
   })
 }
 
+function formatDivergence(branch: BranchRef): string {
+  if (!branch.upstream) {
+    return 'no upstream'
+  }
+
+  if (branch.ahead === 0 && branch.behind === 0) {
+    return `even with ${branch.upstream}`
+  }
+
+  return `+${branch.ahead}/-${branch.behind} vs ${branch.upstream}`
+}
+
+function renderBranchOverview(overview: BranchOverview | undefined, width: number): string[] {
+  if (!overview) {
+    return ['Branches: unavailable']
+  }
+
+  const dirty = overview.dirty ? 'dirty worktree' : 'clean worktree'
+  const current = overview.localBranches.find((branch) => branch.current)
+  const localBranches = overview.localBranches
+    .slice(0, 6)
+    .map((branch) => {
+      const marker = branch.current ? '*' : ' '
+      return `${marker} ${branch.shortName} ${formatDivergence(branch)}`
+    })
+  const remoteBranches = overview.remoteBranches.slice(0, 6).map((branch) => `  ${branch.shortName}`)
+  const hiddenLocal = overview.localBranches.length > localBranches.length
+    ? [`  ... ${overview.localBranches.length - localBranches.length} more local branch(es)`]
+    : []
+  const hiddenRemote = overview.remoteBranches.length > remoteBranches.length
+    ? [`  ... ${overview.remoteBranches.length - remoteBranches.length} more remote branch(es)`]
+    : []
+
+  return [
+    `Branches: ${overview.currentBranch || '<detached>'} | ${dirty}`,
+    current ? `Upstream: ${formatDivergence(current)}` : 'Upstream: none',
+    'Local:',
+    ...(localBranches.length ? localBranches : ['  No local branches found.']),
+    'Remote:',
+    ...(remoteBranches.length ? remoteBranches : ['  No remote branches found.']),
+    ...hiddenLocal,
+    ...hiddenRemote,
+  ].map((line) => truncate(line, width))
+}
+
 function renderDetail(detail: GitCommitDetail | undefined, width: number): string[] {
   if (!detail) {
     return ['Loading selected commit details...']
@@ -102,6 +148,7 @@ function renderDetail(detail: GitCommitDetail | undefined, width: number): strin
 export function renderInteractiveLog(
   state: LogTuiState,
   detail?: GitCommitDetail,
+  branches?: BranchOverview,
   options: RenderInteractiveLogOptions = {}
 ): string {
   const height = options.height || process.stdout.rows || DEFAULT_HEIGHT
@@ -115,8 +162,9 @@ export function renderInteractiveLog(
   const detailHeader = selected
     ? `Selected: ${selected.shortHash} ${selected.message}`
     : 'Selected: none'
-  const listHeight = Math.max(4, Math.floor(height * 0.45))
-  const detailHeight = Math.max(6, height - listHeight - 8)
+  const branchLines = renderBranchOverview(branches, width).slice(0, 12)
+  const listHeight = Math.max(4, Math.floor(height * 0.35))
+  const detailHeight = Math.max(6, height - listHeight - branchLines.length - 10)
   const detailLines = renderDetail(detail, width).slice(0, detailHeight)
   const filterPrompt = state.filterMode ? `Search: ${state.filter}_` : `Filter: ${filter}`
 
@@ -124,6 +172,8 @@ export function renderInteractiveLog(
     'coco log',
     `${state.filteredCommits.length}/${state.commits.length} commits | ${filterPrompt} | ${graphMode}`,
     help,
+    '',
+    ...branchLines,
     '',
     ...renderCommitList(state, listHeight, width),
     '',
@@ -142,6 +192,7 @@ export async function startInteractiveLog(
   const output = streams.output || process.stdout
   let state = createLogTuiState(rows)
   const details = new Map<string, GitCommitDetail>()
+  let branches: BranchOverview | undefined
 
   async function loadSelectedDetail(): Promise<GitCommitDetail | undefined> {
     const selected = getSelectedCommit(state)
@@ -161,7 +212,13 @@ export async function startInteractiveLog(
   }
 
   if (!input.isTTY || !output.isTTY) {
-    output.write(`${renderInteractiveLog(state, await loadSelectedDetail())}\n`, 'utf8')
+    try {
+      branches = await getBranchOverview(git)
+    } catch {
+      branches = undefined
+    }
+
+    output.write(`${renderInteractiveLog(state, await loadSelectedDetail(), branches)}\n`, 'utf8')
     return
   }
 
@@ -183,13 +240,13 @@ export async function startInteractiveLog(
 
     const render = async () => {
       const version = ++renderVersion
-      output.write(`\x1b[2J\x1b[H${renderInteractiveLog(state)}\n`, 'utf8')
+      output.write(`\x1b[2J\x1b[H${renderInteractiveLog(state, undefined, branches)}\n`, 'utf8')
 
       try {
         const detail = await loadSelectedDetail()
 
         if (!closed && version === renderVersion) {
-          output.write(`\x1b[2J\x1b[H${renderInteractiveLog(state, detail)}\n`, 'utf8')
+          output.write(`\x1b[2J\x1b[H${renderInteractiveLog(state, detail, branches)}\n`, 'utf8')
         }
       } catch (error) {
         reject(error)
@@ -253,6 +310,14 @@ export async function startInteractiveLog(
     }
 
     input.on('keypress', onKeypress)
+    void getBranchOverview(git)
+      .then((overview) => {
+        branches = overview
+        void render()
+      })
+      .catch(() => {
+        branches = undefined
+      })
     void render()
   })
 }


### PR DESCRIPTION
## Summary

- add a reusable branch/ref data service for local and remote refs
- parse upstream divergence from stable `git rev-list --left-right --count` output
- render current branch, dirty worktree state, local branches, remote branches, and upstream ahead/behind in `coco log -i`
- keep this as the first branch-management slice for #660; follow-up work can add checkout/create/delete/fetch/pull/push actions on top of the new data layer

## Validation

- `npm run test:jest -- src/commands/log/branchData.test.ts src/commands/log/interactive.test.ts src/commands/log/interactiveState.test.ts src/commands/commands.integration.test.ts`
- `npm run coco:ts -- log -i --limit 2`
- `npm test`

Refs #660.
