### PR TITLE
Add branch actions to log TUI

### DIFF
--- a/src/commands/log/branchActions.test.ts
+++ b/src/commands/log/branchActions.test.ts
@@ -1,0 +1,123 @@
+import {
+  checkoutBranch,
+  createBranch,
+  deleteBranch,
+  fetchRemotes,
+  getBranchActionRefs,
+  pullCurrentBranch,
+  pushCurrentBranch,
+  renameBranch,
+  setUpstream,
+} from './branchActions'
+import { BranchRef } from './branchData'
+
+function localBranch(overrides: Partial<BranchRef> = {}): BranchRef {
+  return {
+    type: 'local',
+    name: 'refs/heads/feature/test',
+    shortName: 'feature/test',
+    hash: 'abc1234',
+    current: false,
+    date: '2026-04-27',
+    subject: 'feat: test',
+    ahead: 0,
+    behind: 0,
+    ...overrides,
+  }
+}
+
+function remoteBranch(overrides: Partial<BranchRef> = {}): BranchRef {
+  return {
+    type: 'remote',
+    name: 'refs/remotes/origin/feature/test',
+    shortName: 'origin/feature/test',
+    hash: 'abc1234',
+    current: false,
+    remote: 'origin',
+    date: '2026-04-27',
+    subject: 'feat: test',
+    ahead: 0,
+    behind: 0,
+    ...overrides,
+  }
+}
+
+describe('log branch actions', () => {
+  it('maps local and remote refs to actionable branch names', () => {
+    expect(getBranchActionRefs(localBranch({ upstream: 'origin/feature/test' }))).toEqual({
+      localBranch: 'feature/test',
+      remoteBranch: 'origin/feature/test',
+    })
+    expect(getBranchActionRefs(remoteBranch())).toEqual({
+      localBranch: 'feature/test',
+      remoteBranch: 'origin/feature/test',
+    })
+  })
+
+  it('checks out local branches and creates tracking branches from remotes', async () => {
+    const git = {
+      raw: jest.fn().mockResolvedValue(''),
+    }
+
+    await expect(checkoutBranch(git as never, localBranch())).resolves.toEqual({
+      ok: true,
+      message: 'Checked out feature/test',
+    })
+    await expect(checkoutBranch(git as never, remoteBranch())).resolves.toEqual({
+      ok: true,
+      message: 'Created tracking branch feature/test from origin/feature/test',
+    })
+
+    expect(git.raw).toHaveBeenNthCalledWith(1, ['switch', 'feature/test'])
+    expect(git.raw).toHaveBeenNthCalledWith(2, [
+      'switch',
+      '--track',
+      '-c',
+      'feature/test',
+      'origin/feature/test',
+    ])
+  })
+
+  it('rejects unsafe delete requests before invoking git', async () => {
+    const git = {
+      raw: jest.fn(),
+    }
+
+    await expect(deleteBranch(git as never, remoteBranch())).resolves.toEqual({
+      ok: false,
+      message: 'Only local branches can be deleted.',
+    })
+    await expect(deleteBranch(git as never, localBranch({ current: true }))).resolves.toEqual({
+      ok: false,
+      message: 'Cannot delete the current branch.',
+    })
+    expect(git.raw).not.toHaveBeenCalled()
+  })
+
+  it('uses safe git commands for branch management and remote sync', async () => {
+    const git = {
+      raw: jest.fn().mockResolvedValue(''),
+    }
+
+    await createBranch(git as never, 'feature/new', 'abc1234')
+    await renameBranch(git as never, 'feature/old', 'feature/new')
+    await deleteBranch(git as never, localBranch())
+    await fetchRemotes(git as never)
+    await pullCurrentBranch(git as never)
+    await pushCurrentBranch(git as never)
+    await setUpstream(git as never, 'feature/new', 'origin/feature/new')
+
+    expect(git.raw).toHaveBeenNthCalledWith(1, ['switch', '-c', 'feature/new', 'abc1234'])
+    expect(git.raw).toHaveBeenNthCalledWith(2, ['branch', '-m', 'feature/old', 'feature/new'])
+    expect(git.raw).toHaveBeenNthCalledWith(3, ['branch', '-d', 'feature/test'])
+    expect(git.raw).toHaveBeenNthCalledWith(4, ['fetch', '--all', '--prune'])
+    expect(git.raw).toHaveBeenNthCalledWith(5, ['pull', '--ff-only'])
+    expect(git.raw).toHaveBeenNthCalledWith(6, ['push'])
+    expect(git.raw).toHaveBeenNthCalledWith(7, [
+      'branch',
+      '--set-upstream-to',
+      'origin/feature/new',
+      'feature/new',
+    ])
+  })
+})

--- a/src/commands/log/branchActions.ts
+++ b/src/commands/log/branchActions.ts
@@ -1,0 +1,136 @@
+import { SimpleGit } from 'simple-git'
+import { BranchRef } from './branchData'
+
+export type BranchActionResult = {
+  ok: boolean
+  message: string
+}
+
+function localNameFromRemote(remoteBranch: string): string {
+  const [, ...parts] = remoteBranch.split('/')
+  return parts.join('/') || remoteBranch
+}
+
+export function getBranchActionRefs(branch: BranchRef): {
+  localBranch: string
+  remoteBranch?: string
+} {
+  if (branch.type === 'remote') {
+    return {
+      localBranch: localNameFromRemote(branch.shortName),
+      remoteBranch: branch.shortName,
+    }
+  }
+
+  return {
+    localBranch: branch.shortName,
+    remoteBranch: branch.upstream,
+  }
+}
+
+async function runAction(action: () => Promise<unknown>, successMessage: string): Promise<BranchActionResult> {
+  try {
+    await action()
+
+    return {
+      ok: true,
+      message: successMessage,
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      message: (error as Error).message,
+    }
+  }
+}
+
+export function checkoutBranch(git: SimpleGit, branch: BranchRef): Promise<BranchActionResult> {
+  const refs = getBranchActionRefs(branch)
+
+  if (branch.type === 'remote') {
+    return runAction(
+      () => git.raw(['switch', '--track', '-c', refs.localBranch, refs.remoteBranch as string]),
+      `Created tracking branch ${refs.localBranch} from ${refs.remoteBranch}`
+    )
+  }
+
+  return runAction(
+    () => git.raw(['switch', refs.localBranch]),
+    `Checked out ${refs.localBranch}`
+  )
+}
+
+export function createBranch(
+  git: SimpleGit,
+  branchName: string,
+  startPoint: string
+): Promise<BranchActionResult> {
+  return runAction(
+    () => git.raw(['switch', '-c', branchName, startPoint]),
+    `Created branch ${branchName} from ${startPoint}`
+  )
+}
+
+export function renameBranch(
+  git: SimpleGit,
+  oldName: string,
+  newName: string
+): Promise<BranchActionResult> {
+  return runAction(
+    () => git.raw(['branch', '-m', oldName, newName]),
+    `Renamed ${oldName} to ${newName}`
+  )
+}
+
+export function deleteBranch(git: SimpleGit, branch: BranchRef): Promise<BranchActionResult> {
+  if (branch.type !== 'local') {
+    return Promise.resolve({
+      ok: false,
+      message: 'Only local branches can be deleted.',
+    })
+  }
+
+  if (branch.current) {
+    return Promise.resolve({
+      ok: false,
+      message: 'Cannot delete the current branch.',
+    })
+  }
+
+  return runAction(
+    () => git.raw(['branch', '-d', branch.shortName]),
+    `Deleted branch ${branch.shortName}`
+  )
+}
+
+export function fetchRemotes(git: SimpleGit): Promise<BranchActionResult> {
+  return runAction(
+    () => git.raw(['fetch', '--all', '--prune']),
+    'Fetched all remotes'
+  )
+}
+
+export function pullCurrentBranch(git: SimpleGit): Promise<BranchActionResult> {
+  return runAction(
+    () => git.raw(['pull', '--ff-only']),
+    'Pulled current branch'
+  )
+}
+
+export function pushCurrentBranch(git: SimpleGit): Promise<BranchActionResult> {
+  return runAction(
+    () => git.raw(['push']),
+    'Pushed current branch'
+  )
+}
+
+export function setUpstream(
+  git: SimpleGit,
+  localBranch: string,
+  upstreamBranch: string
+): Promise<BranchActionResult> {
+  return runAction(
+    () => git.raw(['branch', '--set-upstream-to', upstreamBranch, localBranch]),
+    `Set ${localBranch} upstream to ${upstreamBranch}`
+  )
+}

--- a/src/commands/log/interactive.test.ts
+++ b/src/commands/log/interactive.test.ts
@@ -67,8 +67,8 @@ const branches: BranchOverview = {
 
 describe('log interactive renderer', () => {
   it('renders commit navigation, selected details, changed files, and help', () => {
-    const output = renderInteractiveLog(createLogTuiState(rows), detail, branches, {
-      height: 40,
+    const output = renderInteractiveLog(createLogTuiState(rows), detail, branches, {}, {
+      height: 52,
       width: 100,
     })
 
@@ -81,5 +81,28 @@ describe('log interactive renderer', () => {
     expect(output).toContain('* main +1/-2 vs origin/main')
     expect(output).toContain('origin/main')
     expect(output).toContain('Keys:')
+  })
+
+  it('renders branch focus, status, and pending delete prompts', () => {
+    const output = renderInteractiveLog(
+      createLogTuiState(rows),
+      detail,
+      branches,
+      {
+        focus: 'branches',
+        branchIndex: 0,
+        statusMessage: 'Press D to confirm deleting main',
+        pendingDeleteBranch: 'main',
+      },
+      {
+        height: 52,
+        width: 100,
+      }
+    )
+
+    expect(output).toContain('Focus: branches')
+    expect(output).toContain('Status: Press D to confirm deleting main')
+    expect(output).toContain('Pending delete: press D to delete main')
+    expect(output).toContain('>* main +1/-2 vs origin/main')
   })
 })

--- a/src/commands/log/interactive.ts
+++ b/src/commands/log/interactive.ts
@@ -1,5 +1,13 @@
 import readline from 'readline'
 import { SimpleGit } from 'simple-git'
+import {
+  BranchActionResult,
+  checkoutBranch,
+  deleteBranch,
+  fetchRemotes,
+  pullCurrentBranch,
+  pushCurrentBranch,
+} from './branchActions'
 import { BranchOverview, BranchRef, getBranchOverview } from './branchData'
 import { GitCommitDetail, GitLogRow, getCommitDetail } from './data'
 import {
@@ -19,7 +27,16 @@ type RenderInteractiveLogOptions = {
   width?: number
 }
 
-const DEFAULT_HEIGHT = 40
+type LogTuiFocus = 'commits' | 'branches'
+
+type LogTuiRenderUi = {
+  focus?: LogTuiFocus
+  branchIndex?: number
+  statusMessage?: string
+  pendingDeleteBranch?: string
+}
+
+const DEFAULT_HEIGHT = 52
 const DEFAULT_WIDTH = 120
 
 function truncate(value: string, width: number): string {
@@ -84,20 +101,39 @@ function formatDivergence(branch: BranchRef): string {
   return `+${branch.ahead}/-${branch.behind} vs ${branch.upstream}`
 }
 
-function renderBranchOverview(overview: BranchOverview | undefined, width: number): string[] {
+function getBranchList(overview: BranchOverview | undefined): BranchRef[] {
+  if (!overview) {
+    return []
+  }
+
+  return [...overview.localBranches, ...overview.remoteBranches]
+}
+
+function renderBranchOverview(
+  overview: BranchOverview | undefined,
+  ui: LogTuiRenderUi,
+  width: number
+): string[] {
   if (!overview) {
     return ['Branches: unavailable']
   }
 
   const dirty = overview.dirty ? 'dirty worktree' : 'clean worktree'
   const current = overview.localBranches.find((branch) => branch.current)
+  const selectedBranches = getBranchList(overview)
+  const isBranchFocused = ui.focus === 'branches'
   const localBranches = overview.localBranches
     .slice(0, 6)
     .map((branch) => {
       const marker = branch.current ? '*' : ' '
-      return `${marker} ${branch.shortName} ${formatDivergence(branch)}`
+      const selected = isBranchFocused && selectedBranches[ui.branchIndex || 0] === branch ? '>' : ' '
+      return `${selected}${marker} ${branch.shortName} ${formatDivergence(branch)}`
     })
-  const remoteBranches = overview.remoteBranches.slice(0, 6).map((branch) => `  ${branch.shortName}`)
+  const remoteBranches = overview.remoteBranches.slice(0, 6).map((branch) => {
+    const selected = isBranchFocused && selectedBranches[ui.branchIndex || 0] === branch ? '>' : ' '
+
+    return `${selected}  ${branch.shortName}`
+  })
   const hiddenLocal = overview.localBranches.length > localBranches.length
     ? [`  ... ${overview.localBranches.length - localBranches.length} more local branch(es)`]
     : []
@@ -108,6 +144,9 @@ function renderBranchOverview(overview: BranchOverview | undefined, width: numbe
   return [
     `Branches: ${overview.currentBranch || '<detached>'} | ${dirty}`,
     current ? `Upstream: ${formatDivergence(current)}` : 'Upstream: none',
+    ui.pendingDeleteBranch
+      ? `Pending delete: press D to delete ${ui.pendingDeleteBranch}`
+      : 'Branch actions: tab focus | enter checkout/track | f fetch | p push | P pull | d delete',
     'Local:',
     ...(localBranches.length ? localBranches : ['  No local branches found.']),
     'Remote:',
@@ -149,6 +188,7 @@ export function renderInteractiveLog(
   state: LogTuiState,
   detail?: GitCommitDetail,
   branches?: BranchOverview,
+  ui: LogTuiRenderUi = {},
   options: RenderInteractiveLogOptions = {}
 ): string {
   const height = options.height || process.stdout.rows || DEFAULT_HEIGHT
@@ -156,13 +196,14 @@ export function renderInteractiveLog(
   const selected = getSelectedCommit(state)
   const filter = state.filter ? state.filter : '<none>'
   const graphMode = state.fullGraph ? 'full graph' : 'compact graph'
+  const focus = ui.focus || 'commits'
   const help = state.showHelp
-    ? 'Keys: up/down or j/k move | / search | g graph | ? help | q quit'
+    ? 'Keys: tab focus | up/down or j/k move | / search | enter checkout | g graph | f fetch | q quit'
     : 'Press ? for help'
   const detailHeader = selected
     ? `Selected: ${selected.shortHash} ${selected.message}`
     : 'Selected: none'
-  const branchLines = renderBranchOverview(branches, width).slice(0, 12)
+  const branchLines = renderBranchOverview(branches, ui, width).slice(0, 12)
   const listHeight = Math.max(4, Math.floor(height * 0.35))
   const detailHeight = Math.max(6, height - listHeight - branchLines.length - 10)
   const detailLines = renderDetail(detail, width).slice(0, detailHeight)
@@ -170,8 +211,9 @@ export function renderInteractiveLog(
 
   return [
     'coco log',
-    `${state.filteredCommits.length}/${state.commits.length} commits | ${filterPrompt} | ${graphMode}`,
+    `${state.filteredCommits.length}/${state.commits.length} commits | Focus: ${focus} | ${filterPrompt} | ${graphMode}`,
     help,
+    ui.statusMessage ? truncate(`Status: ${ui.statusMessage}`, width) : '',
     '',
     ...branchLines,
     '',
@@ -193,6 +235,10 @@ export async function startInteractiveLog(
   let state = createLogTuiState(rows)
   const details = new Map<string, GitCommitDetail>()
   let branches: BranchOverview | undefined
+  let focus: LogTuiFocus = 'commits'
+  let branchIndex = 0
+  let statusMessage: string | undefined
+  let pendingDeleteBranch: string | undefined
 
   async function loadSelectedDetail(): Promise<GitCommitDetail | undefined> {
     const selected = getSelectedCommit(state)
@@ -240,13 +286,20 @@ export async function startInteractiveLog(
 
     const render = async () => {
       const version = ++renderVersion
-      output.write(`\x1b[2J\x1b[H${renderInteractiveLog(state, undefined, branches)}\n`, 'utf8')
+      const ui = {
+        focus,
+        branchIndex,
+        statusMessage,
+        pendingDeleteBranch,
+      }
+
+      output.write(`\x1b[2J\x1b[H${renderInteractiveLog(state, undefined, branches, ui)}\n`, 'utf8')
 
       try {
         const detail = await loadSelectedDetail()
 
         if (!closed && version === renderVersion) {
-          output.write(`\x1b[2J\x1b[H${renderInteractiveLog(state, detail, branches)}\n`, 'utf8')
+          output.write(`\x1b[2J\x1b[H${renderInteractiveLog(state, detail, branches, ui)}\n`, 'utf8')
         }
       } catch (error) {
         reject(error)
@@ -256,6 +309,38 @@ export async function startInteractiveLog(
     const applyAndRender = (nextState: LogTuiState) => {
       state = nextState
       void render()
+    }
+
+    const refreshBranches = async () => {
+      branches = await getBranchOverview(git)
+      branchIndex = Math.max(0, Math.min(branchIndex, getBranchList(branches).length - 1))
+    }
+
+    const setActionResult = async (result: BranchActionResult, refresh = true) => {
+      statusMessage = result.message
+      pendingDeleteBranch = undefined
+
+      if (refresh) {
+        await refreshBranches()
+      }
+
+      await render()
+    }
+
+    const selectedBranch = () => getBranchList(branches)[branchIndex]
+
+    const moveBranchSelection = (delta: number) => {
+      const branchesList = getBranchList(branches)
+
+      branchIndex = Math.max(0, Math.min(branchIndex + delta, branchesList.length - 1))
+      pendingDeleteBranch = undefined
+      void render()
+    }
+
+    const runBranchAction = async (action: () => Promise<BranchActionResult>, refresh = true) => {
+      statusMessage = 'Running branch action...'
+      await render()
+      await setActionResult(await action(), refresh)
     }
 
     const onFilterKeypress = (sequence: string | undefined, key: readline.Key) => {
@@ -290,7 +375,50 @@ export async function startInteractiveLog(
         return
       }
 
-      if (key.name === 'up' || key.name === 'k') {
+      if (key.name === 'tab') {
+        focus = focus === 'commits' ? 'branches' : 'commits'
+        pendingDeleteBranch = undefined
+        void render()
+      } else if ((key.name === 'up' || key.name === 'k') && focus === 'branches') {
+        moveBranchSelection(-1)
+      } else if ((key.name === 'down' || key.name === 'j') && focus === 'branches') {
+        moveBranchSelection(1)
+      } else if (key.name === 'return' && focus === 'branches') {
+        const branch = selectedBranch()
+
+        if (branch) {
+          void runBranchAction(() => checkoutBranch(git, branch))
+        }
+      } else if (key.name === 'f') {
+        void runBranchAction(() => fetchRemotes(git))
+      } else if (key.name === 'p' && sequence !== 'P') {
+        void runBranchAction(() => pushCurrentBranch(git))
+      } else if (sequence === 'P') {
+        void runBranchAction(() => pullCurrentBranch(git))
+      } else if (key.name === 'd' && focus === 'branches') {
+        const branch = selectedBranch()
+
+        if (branch) {
+          pendingDeleteBranch = branch.shortName
+          statusMessage = `Press D to confirm deleting ${branch.shortName}`
+          void render()
+        }
+      } else if (sequence === 'D' && focus === 'branches') {
+        const branch = selectedBranch()
+
+        if (branch && pendingDeleteBranch === branch.shortName) {
+          void runBranchAction(() => deleteBranch(git, branch))
+        }
+      } else if (key.name === 'r') {
+        void runBranchAction(async () => {
+          await refreshBranches()
+
+          return {
+            ok: true,
+            message: 'Refreshed branch overview',
+          }
+        }, false)
+      } else if (key.name === 'up' || key.name === 'k') {
         applyAndRender(applyLogTuiAction(state, { type: 'move', delta: -1 }))
       } else if (key.name === 'down' || key.name === 'j') {
         applyAndRender(applyLogTuiAction(state, { type: 'move', delta: 1 }))
@@ -310,9 +438,8 @@ export async function startInteractiveLog(
     }
 
     input.on('keypress', onKeypress)
-    void getBranchOverview(git)
-      .then((overview) => {
-        branches = overview
+    void refreshBranches()
+      .then(() => {
         void render()
       })
       .catch(() => {


### PR DESCRIPTION
## Summary

- add tested branch action helpers for checkout, tracking branch creation, branch create/rename/delete, fetch, pull, push, and upstream assignment
- add branch focus navigation in `coco log -i` with `tab` and branch selection via up/down
- wire `enter` to checkout local branches or create local tracking branches from remote refs
- wire `f`, `p`, `P`, and `d`/`D` to fetch, push, pull, and confirmed safe branch delete flows with status messages
- keep destructive delete guarded by local-only/current-branch checks and Git's safe `branch -d` behavior

## Validation

- `npm run test:jest -- src/commands/log/branchActions.test.ts src/commands/log/branchData.test.ts src/commands/log/interactive.test.ts src/commands/log/interactiveState.test.ts src/commands/commands.integration.test.ts`
- `npm run coco:ts -- log -i --limit 2`
- `npm test`

Refs #660.
