### PR TITLE
Add pull request workflows to log TUI

### DIFF
--- a/src/commands/log/interactive.test.ts
+++ b/src/commands/log/interactive.test.ts
@@ -2,6 +2,7 @@ import { GitCommitDetail, GitLogRow } from './data'
 import { createLogTuiState } from './interactiveState'
 import { renderInteractiveLog } from './interactive'
 import { BranchOverview } from './branchData'
+import { PullRequestOverview } from './pullRequestData'
 
 const rows: GitLogRow[] = [
   {
@@ -65,9 +66,28 @@ const branches: BranchOverview = {
   ],
 }
 
+const pullRequest: PullRequestOverview = {
+  available: true,
+  authenticated: true,
+  repository: {
+    owner: 'gfargo',
+    name: 'coco',
+  },
+  currentBranch: 'feature/log-prs',
+  currentPullRequest: {
+    number: 123,
+    title: 'Add PR workflow',
+    url: 'https://github.com/gfargo/coco/pull/123',
+    state: 'OPEN',
+    isDraft: false,
+    headRefName: 'feature/log-prs',
+    baseRefName: 'main',
+  },
+}
+
 describe('log interactive renderer', () => {
   it('renders commit navigation, selected details, changed files, and help', () => {
-    const output = renderInteractiveLog(createLogTuiState(rows), detail, branches, {}, {
+    const output = renderInteractiveLog(createLogTuiState(rows), detail, branches, pullRequest, {}, {
       height: 52,
       width: 100,
     })
@@ -80,6 +100,8 @@ describe('log interactive renderer', () => {
     expect(output).toContain('Branches: main | dirty worktree')
     expect(output).toContain('* main +1/-2 vs origin/main')
     expect(output).toContain('origin/main')
+    expect(output).toContain('Pull request: #123 OPEN feature/log-prs -> main')
+    expect(output).toContain('Add PR workflow')
     expect(output).toContain('Keys:')
   })
 
@@ -88,6 +110,7 @@ describe('log interactive renderer', () => {
       createLogTuiState(rows),
       detail,
       branches,
+      pullRequest,
       {
         focus: 'branches',
         branchIndex: 0,
@@ -112,6 +135,12 @@ describe('log interactive renderer', () => {
       detail,
       branches,
       {
+        available: true,
+        authenticated: true,
+        currentBranch: 'feature/log-prs',
+        message: 'No pull request found for feature/log-prs.',
+      },
+      {
         focus: 'branches',
         branchIndex: 0,
         inputPrompt: {
@@ -129,7 +158,35 @@ describe('log interactive renderer', () => {
     )
 
     expect(output).toContain('Rename main to: feature/main_')
-    expect(output).toContain('n new')
-    expect(output).toContain('u upstream')
+    expect(output).toContain('n branch')
+    expect(output).toContain('enter checkout')
+    expect(output).toContain('Pull request: no PR for feature/log-prs')
+  })
+
+  it('renders PR create prompts and draft mode', () => {
+    const output = renderInteractiveLog(
+      createLogTuiState(rows),
+      detail,
+      branches,
+      pullRequest,
+      {
+        inputPrompt: {
+          kind: 'create-pr-title',
+          label: 'Create draft PR into main',
+          value: 'Add PR workflow',
+          sourceRef: 'feature/log-prs',
+          baseRef: 'main',
+        },
+        pullRequestDraft: true,
+      },
+      {
+        height: 52,
+        width: 100,
+      }
+    )
+
+    expect(output).toContain('Create draft PR into main: Add PR workflow_')
+    expect(output).toContain('C PR')
+    expect(output).toContain('v draft')
   })
 })

--- a/src/commands/log/interactive.ts
+++ b/src/commands/log/interactive.ts
@@ -13,6 +13,8 @@ import {
 } from './branchActions'
 import { BranchOverview, BranchRef, getBranchOverview } from './branchData'
 import { GitCommitDetail, GitLogRow, getCommitDetail } from './data'
+import { createPullRequest, openPullRequest } from './pullRequestActions'
+import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
 import {
   LogTuiState,
   applyLogTuiAction,
@@ -38,9 +40,10 @@ type LogTuiRenderUi = {
   statusMessage?: string
   pendingDeleteBranch?: string
   inputPrompt?: LogTuiInputPrompt
+  pullRequestDraft?: boolean
 }
 
-type LogTuiInputKind = 'create-branch' | 'rename-branch'
+type LogTuiInputKind = 'create-branch' | 'rename-branch' | 'create-pr-title'
 
 type LogTuiInputPrompt = {
   kind: LogTuiInputKind
@@ -48,6 +51,7 @@ type LogTuiInputPrompt = {
   value: string
   sourceRef: string
   branchName?: string
+  baseRef?: string
 }
 
 const DEFAULT_HEIGHT = 52
@@ -170,6 +174,46 @@ function renderBranchOverview(
   ].map((line) => truncate(line, width))
 }
 
+function renderPullRequestOverview(
+  overview: PullRequestOverview | undefined,
+  ui: LogTuiRenderUi,
+  width: number
+): string[] {
+  if (!overview) {
+    return ['Pull request: unavailable']
+  }
+
+  if (!overview.available || !overview.authenticated) {
+    return [
+      `Pull request: ${overview.message || 'GitHub PR workflow unavailable.'}`,
+    ].map((line) => truncate(line, width))
+  }
+
+  const repo = overview.repository
+    ? `${overview.repository.owner}/${overview.repository.name}`
+    : 'GitHub repository'
+  const draft = ui.pullRequestDraft ? 'draft' : 'ready'
+  const action = 'PR actions: C create | v draft toggle | o open current PR'
+
+  if (!overview.currentPullRequest) {
+    return [
+      `Pull request: no PR for ${overview.currentBranch || '<detached>'} on ${repo}`,
+      `Create mode: ${draft}`,
+      action,
+    ].map((line) => truncate(line, width))
+  }
+
+  const pr = overview.currentPullRequest
+  const prState = `${pr.state}${pr.isDraft ? ' draft' : ''}`
+
+  return [
+    `Pull request: #${pr.number} ${prState} ${pr.headRefName} -> ${pr.baseRefName}`,
+    `Title: ${pr.title}`,
+    `URL: ${pr.url}`,
+    action,
+  ].map((line) => truncate(line, width))
+}
+
 function renderDetail(detail: GitCommitDetail | undefined, width: number): string[] {
   if (!detail) {
     return ['Loading selected commit details...']
@@ -202,6 +246,7 @@ export function renderInteractiveLog(
   state: LogTuiState,
   detail?: GitCommitDetail,
   branches?: BranchOverview,
+  pullRequest?: PullRequestOverview,
   ui: LogTuiRenderUi = {},
   options: RenderInteractiveLogOptions = {}
 ): string {
@@ -212,14 +257,15 @@ export function renderInteractiveLog(
   const graphMode = state.fullGraph ? 'full graph' : 'compact graph'
   const focus = ui.focus || 'commits'
   const help = state.showHelp
-    ? 'Keys: tab focus | up/down move | enter checkout | n new | m rename | u upstream | f fetch | q quit'
+    ? 'Keys: tab focus | up/down move | enter checkout | n branch | C PR | v draft | f fetch | q quit'
     : 'Press ? for help'
   const detailHeader = selected
     ? `Selected: ${selected.shortHash} ${selected.message}`
     : 'Selected: none'
   const branchLines = renderBranchOverview(branches, ui, width).slice(0, 12)
+  const pullRequestLines = renderPullRequestOverview(pullRequest, ui, width).slice(0, 4)
   const listHeight = Math.max(4, Math.floor(height * 0.35))
-  const detailHeight = Math.max(6, height - listHeight - branchLines.length - 10)
+  const detailHeight = Math.max(6, height - listHeight - branchLines.length - pullRequestLines.length - 11)
   const detailLines = renderDetail(detail, width).slice(0, detailHeight)
   const filterPrompt = state.filterMode ? `Search: ${state.filter}_` : `Filter: ${filter}`
 
@@ -231,6 +277,7 @@ export function renderInteractiveLog(
     ui.inputPrompt ? truncate(`${ui.inputPrompt.label}: ${ui.inputPrompt.value}_`, width) : '',
     '',
     ...branchLines,
+    ...pullRequestLines,
     '',
     ...renderCommitList(state, listHeight, width),
     '',
@@ -250,11 +297,13 @@ export async function startInteractiveLog(
   let state = createLogTuiState(rows)
   const details = new Map<string, GitCommitDetail>()
   let branches: BranchOverview | undefined
+  let pullRequest: PullRequestOverview | undefined
   let focus: LogTuiFocus = 'commits'
   let branchIndex = 0
   let statusMessage: string | undefined
   let pendingDeleteBranch: string | undefined
   let inputPrompt: LogTuiInputPrompt | undefined
+  let pullRequestDraft = false
 
   async function loadSelectedDetail(): Promise<GitCommitDetail | undefined> {
     const selected = getSelectedCommit(state)
@@ -275,12 +324,18 @@ export async function startInteractiveLog(
 
   if (!input.isTTY || !output.isTTY) {
     try {
-      branches = await getBranchOverview(git)
+      [branches, pullRequest] = await Promise.all([
+        getBranchOverview(git),
+        getPullRequestOverview(git),
+      ])
     } catch {
       branches = undefined
     }
 
-    output.write(`${renderInteractiveLog(state, await loadSelectedDetail(), branches)}\n`, 'utf8')
+    output.write(
+      `${renderInteractiveLog(state, await loadSelectedDetail(), branches, pullRequest)}\n`,
+      'utf8'
+    )
     return
   }
 
@@ -308,15 +363,22 @@ export async function startInteractiveLog(
         statusMessage,
         pendingDeleteBranch,
         inputPrompt,
+        pullRequestDraft,
       }
 
-      output.write(`\x1b[2J\x1b[H${renderInteractiveLog(state, undefined, branches, ui)}\n`, 'utf8')
+      output.write(
+        `\x1b[2J\x1b[H${renderInteractiveLog(state, undefined, branches, pullRequest, ui)}\n`,
+        'utf8'
+      )
 
       try {
         const detail = await loadSelectedDetail()
 
         if (!closed && version === renderVersion) {
-          output.write(`\x1b[2J\x1b[H${renderInteractiveLog(state, detail, branches, ui)}\n`, 'utf8')
+          output.write(
+            `\x1b[2J\x1b[H${renderInteractiveLog(state, detail, branches, pullRequest, ui)}\n`,
+            'utf8'
+          )
         }
       } catch (error) {
         reject(error)
@@ -333,13 +395,20 @@ export async function startInteractiveLog(
       branchIndex = Math.max(0, Math.min(branchIndex, getBranchList(branches).length - 1))
     }
 
+    const refreshPullRequest = async () => {
+      pullRequest = await getPullRequestOverview(git)
+    }
+
     const setActionResult = async (result: BranchActionResult, refresh = true) => {
       statusMessage = result.message
       pendingDeleteBranch = undefined
       inputPrompt = undefined
 
       if (refresh) {
-        await refreshBranches()
+        await Promise.all([
+          refreshBranches(),
+          refreshPullRequest(),
+        ])
       }
 
       await render()
@@ -354,6 +423,33 @@ export async function startInteractiveLog(
 
       return getSelectedCommit(state)?.hash
     }
+
+    const selectedBaseRef = () => {
+      const branch = focus === 'branches' ? selectedBranch() : undefined
+
+      if (branch?.type === 'remote') {
+        return branch.shortName.split('/').slice(1).join('/') || branch.shortName
+      }
+
+      if (branch?.type === 'local' && !branch.current) {
+        return branch.shortName
+      }
+
+      const upstreamDefault = branches?.localBranches
+        .find((entry) => entry.upstream)
+        ?.upstream
+        ?.split('/')
+        .slice(1)
+        .join('/')
+
+      return upstreamDefault || 'main'
+    }
+
+    const generatedPullRequestBody = () => [
+      '## Summary',
+      '',
+      ...state.commits.slice(0, 8).map((commit) => `- ${commit.message}`),
+    ].join('\n')
 
     const moveBranchSelection = (delta: number) => {
       const branchesList = getBranchList(branches)
@@ -396,6 +492,22 @@ export async function startInteractiveLog(
         await runBranchAction(() => createBranch(git, value, prompt.sourceRef))
       } else if (prompt.kind === 'rename-branch' && prompt.branchName) {
         await runBranchAction(() => renameBranch(git, prompt.branchName as string, value))
+      } else if (prompt.kind === 'create-pr-title' && prompt.baseRef) {
+        const head = pullRequest?.currentBranch || branches?.currentBranch
+
+        if (!head) {
+          statusMessage = 'Cannot create pull request without a current branch.'
+          await render()
+          return
+        }
+
+        await runBranchAction(() => createPullRequest({
+          base: prompt.baseRef as string,
+          head,
+          title: value,
+          body: generatedPullRequestBody(),
+          draft: pullRequestDraft,
+        }))
       }
     }
 
@@ -507,11 +619,14 @@ export async function startInteractiveLog(
         }
       } else if (key.name === 'r') {
         void runBranchAction(async () => {
-          await refreshBranches()
+          await Promise.all([
+            refreshBranches(),
+            refreshPullRequest(),
+          ])
 
           return {
             ok: true,
-            message: 'Refreshed branch overview',
+            message: 'Refreshed Git overview',
           }
         }, false)
       } else if (key.name === 'n') {
@@ -550,6 +665,30 @@ export async function startInteractiveLog(
           statusMessage = 'Select a remote branch to set as the current branch upstream.'
           void render()
         }
+      } else if (sequence === 'C') {
+        const baseRef = selectedBaseRef()
+        const title = getSelectedCommit(state)?.message || `Open ${pullRequest?.currentBranch || 'branch'}`
+
+        startInputPrompt({
+          kind: 'create-pr-title',
+          label: `Create ${pullRequestDraft ? 'draft ' : ''}PR into ${baseRef}`,
+          value: title,
+          sourceRef: pullRequest?.currentBranch || branches?.currentBranch || '',
+          baseRef,
+        })
+      } else if (key.name === 'v') {
+        pullRequestDraft = !pullRequestDraft
+        statusMessage = `Pull request create mode: ${pullRequestDraft ? 'draft' : 'ready'}`
+        void render()
+      } else if (key.name === 'o') {
+        const url = pullRequest?.currentPullRequest?.url
+
+        if (url) {
+          void runBranchAction(() => openPullRequest(url), false)
+        } else {
+          statusMessage = 'No current pull request to open.'
+          void render()
+        }
       } else if (key.name === 'up' || key.name === 'k') {
         applyAndRender(applyLogTuiAction(state, { type: 'move', delta: -1 }))
       } else if (key.name === 'down' || key.name === 'j') {
@@ -570,12 +709,16 @@ export async function startInteractiveLog(
     }
 
     input.on('keypress', onKeypress)
-    void refreshBranches()
+    void Promise.all([
+      refreshBranches(),
+      refreshPullRequest(),
+    ])
       .then(() => {
         void render()
       })
       .catch(() => {
         branches = undefined
+        pullRequest = undefined
       })
     void render()
   })

--- a/src/commands/log/pullRequestActions.test.ts
+++ b/src/commands/log/pullRequestActions.test.ts
@@ -1,0 +1,55 @@
+import { buildCreatePullRequestArgs, createPullRequest, openPullRequest } from './pullRequestActions'
+
+describe('log pull request actions', () => {
+  it('builds ready and draft PR create commands', () => {
+    expect(buildCreatePullRequestArgs({
+      base: 'main',
+      head: 'feature/pr',
+      title: 'Add PR workflow',
+      body: 'Generated body',
+    })).toEqual([
+      'pr',
+      'create',
+      '--base',
+      'main',
+      '--head',
+      'feature/pr',
+      '--title',
+      'Add PR workflow',
+      '--body',
+      'Generated body',
+    ])
+
+    expect(buildCreatePullRequestArgs({
+      base: 'main',
+      head: 'feature/pr',
+      title: 'Add PR workflow',
+      body: 'Generated body',
+      draft: true,
+    })).toContain('--draft')
+  })
+
+  it('creates and opens pull requests through gh', async () => {
+    const runner = jest
+      .fn()
+      .mockResolvedValueOnce('https://github.com/gfargo/coco/pull/123\n')
+      .mockResolvedValueOnce('')
+
+    await expect(createPullRequest({
+      base: 'main',
+      head: 'feature/pr',
+      title: 'Add PR workflow',
+      body: 'Generated body',
+    }, runner)).resolves.toEqual({
+      ok: true,
+      message: 'Created pull request: https://github.com/gfargo/coco/pull/123',
+      url: 'https://github.com/gfargo/coco/pull/123',
+    })
+    await expect(openPullRequest('https://github.com/gfargo/coco/pull/123', runner)).resolves.toEqual({
+      ok: true,
+      message: 'Opened pull request: https://github.com/gfargo/coco/pull/123',
+      url: 'https://github.com/gfargo/coco/pull/123',
+    })
+    expect(runner).toHaveBeenLastCalledWith(['pr', 'view', '--web'])
+  })
+})

--- a/src/commands/log/pullRequestActions.ts
+++ b/src/commands/log/pullRequestActions.ts
@@ -1,0 +1,81 @@
+import { GhRunner, defaultGhRunner } from './pullRequestData'
+
+export type PullRequestActionResult = {
+  ok: boolean
+  message: string
+  url?: string
+}
+
+export type CreatePullRequestInput = {
+  base: string
+  head: string
+  title: string
+  body: string
+  draft?: boolean
+}
+
+function parseCreatedPullRequestUrl(output: string): string | undefined {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.startsWith('https://'))
+}
+
+async function runGhAction(
+  runner: GhRunner,
+  args: string[],
+  successMessage: (output: string) => PullRequestActionResult
+): Promise<PullRequestActionResult> {
+  try {
+    return successMessage(await runner(args))
+  } catch (error) {
+    return {
+      ok: false,
+      message: (error as Error).message,
+    }
+  }
+}
+
+export function buildCreatePullRequestArgs(input: CreatePullRequestInput): string[] {
+  const args = [
+    'pr',
+    'create',
+    '--base',
+    input.base,
+    '--head',
+    input.head,
+    '--title',
+    input.title,
+    '--body',
+    input.body,
+  ]
+
+  if (input.draft) {
+    args.push('--draft')
+  }
+
+  return args
+}
+
+export function createPullRequest(
+  input: CreatePullRequestInput,
+  runner: GhRunner = defaultGhRunner
+): Promise<PullRequestActionResult> {
+  return runGhAction(runner, buildCreatePullRequestArgs(input), (output) => {
+    const url = parseCreatedPullRequestUrl(output)
+
+    return {
+      ok: true,
+      message: url ? `Created pull request: ${url}` : 'Created pull request',
+      url,
+    }
+  })
+}
+
+export function openPullRequest(url: string, runner: GhRunner = defaultGhRunner): Promise<PullRequestActionResult> {
+  return runGhAction(runner, ['pr', 'view', '--web'], () => ({
+    ok: true,
+    message: `Opened pull request: ${url}`,
+    url,
+  }))
+}

--- a/src/commands/log/pullRequestData.test.ts
+++ b/src/commands/log/pullRequestData.test.ts
@@ -1,0 +1,84 @@
+import { getPullRequestOverview, parseGitHubRemoteUrl } from './pullRequestData'
+
+describe('log pull request data', () => {
+  it('parses GitHub SSH and HTTPS remotes', () => {
+    expect(parseGitHubRemoteUrl('git@github.com:gfargo/coco.git')).toEqual({
+      owner: 'gfargo',
+      name: 'coco',
+    })
+    expect(parseGitHubRemoteUrl('https://github.com/gfargo/coco.git')).toEqual({
+      owner: 'gfargo',
+      name: 'coco',
+    })
+    expect(parseGitHubRemoteUrl('git@gitlab.com:gfargo/coco.git')).toBeUndefined()
+  })
+
+  it('reports missing GitHub remotes without invoking gh', async () => {
+    const runner = jest.fn()
+    const git = {
+      getRemotes: jest.fn().mockResolvedValue([]),
+      raw: jest.fn().mockResolvedValue('feature/test\n'),
+    }
+
+    await expect(getPullRequestOverview(git as never, runner)).resolves.toEqual({
+      available: false,
+      authenticated: false,
+      currentBranch: 'feature/test',
+      message: 'No GitHub remote detected.',
+    })
+    expect(runner).not.toHaveBeenCalled()
+  })
+
+  it('loads the current branch pull request when gh is authenticated', async () => {
+    const runner = jest
+      .fn()
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce(JSON.stringify({
+        number: 123,
+        title: 'Add PR workflow',
+        url: 'https://github.com/gfargo/coco/pull/123',
+        state: 'OPEN',
+        isDraft: false,
+        headRefName: 'feature/pr',
+        baseRefName: 'main',
+      }))
+    const git = {
+      getRemotes: jest.fn().mockResolvedValue([
+        {
+          name: 'origin',
+          refs: {
+            fetch: 'git@github.com:gfargo/coco.git',
+            push: 'git@github.com:gfargo/coco.git',
+          },
+        },
+      ]),
+      raw: jest.fn().mockResolvedValue('feature/pr\n'),
+    }
+
+    await expect(getPullRequestOverview(git as never, runner)).resolves.toEqual({
+      available: true,
+      authenticated: true,
+      repository: {
+        owner: 'gfargo',
+        name: 'coco',
+      },
+      currentBranch: 'feature/pr',
+      currentPullRequest: {
+        number: 123,
+        title: 'Add PR workflow',
+        url: 'https://github.com/gfargo/coco/pull/123',
+        state: 'OPEN',
+        isDraft: false,
+        headRefName: 'feature/pr',
+        baseRefName: 'main',
+      },
+    })
+    expect(runner).toHaveBeenNthCalledWith(1, ['auth', 'status', '--hostname', 'github.com'])
+    expect(runner).toHaveBeenNthCalledWith(2, [
+      'pr',
+      'view',
+      '--json',
+      'number,title,url,state,isDraft,headRefName,baseRefName',
+    ])
+  })
+})

--- a/src/commands/log/pullRequestData.ts
+++ b/src/commands/log/pullRequestData.ts
@@ -1,0 +1,128 @@
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { SimpleGit } from 'simple-git'
+
+const execFileAsync = promisify(execFile)
+
+export type GhRunner = (args: string[]) => Promise<string>
+
+export type GitHubRepository = {
+  owner: string
+  name: string
+}
+
+export type PullRequestInfo = {
+  number: number
+  title: string
+  url: string
+  state: string
+  isDraft: boolean
+  headRefName: string
+  baseRefName: string
+}
+
+export type PullRequestOverview = {
+  available: boolean
+  authenticated: boolean
+  repository?: GitHubRepository
+  currentBranch?: string
+  currentPullRequest?: PullRequestInfo
+  message?: string
+}
+
+export function parseGitHubRemoteUrl(url: string): GitHubRepository | undefined {
+  const trimmed = url.trim().replace(/\.git$/, '')
+  const sshMatch = trimmed.match(/^git@github\.com:([^/]+)\/(.+)$/)
+  const httpsMatch = trimmed.match(/^https:\/\/github\.com\/([^/]+)\/(.+)$/)
+  const match = sshMatch || httpsMatch
+
+  if (!match) {
+    return undefined
+  }
+
+  return {
+    owner: match[1],
+    name: match[2],
+  }
+}
+
+export async function defaultGhRunner(args: string[]): Promise<string> {
+  const result = await execFileAsync('gh', args)
+
+  return result.stdout
+}
+
+async function getGitHubRepository(git: SimpleGit): Promise<GitHubRepository | undefined> {
+  const remotes = await git.getRemotes(true)
+  const remote = remotes.find((entry) => entry.name === 'origin') || remotes[0]
+  const url = remote?.refs.push || remote?.refs.fetch
+
+  return url ? parseGitHubRemoteUrl(url) : undefined
+}
+
+function parsePullRequestInfo(output: string): PullRequestInfo | undefined {
+  const trimmed = output.trim()
+
+  if (!trimmed) {
+    return undefined
+  }
+
+  return JSON.parse(trimmed) as PullRequestInfo
+}
+
+export async function getPullRequestOverview(
+  git: SimpleGit,
+  runner: GhRunner = defaultGhRunner
+): Promise<PullRequestOverview> {
+  const [repository, currentBranchOutput] = await Promise.all([
+    getGitHubRepository(git),
+    git.raw(['branch', '--show-current']),
+  ])
+  const currentBranch = currentBranchOutput.trim() || undefined
+
+  if (!repository) {
+    return {
+      available: false,
+      authenticated: false,
+      currentBranch,
+      message: 'No GitHub remote detected.',
+    }
+  }
+
+  try {
+    await runner(['auth', 'status', '--hostname', 'github.com'])
+  } catch {
+    return {
+      available: true,
+      authenticated: false,
+      repository,
+      currentBranch,
+      message: 'GitHub CLI is missing or not authenticated.',
+    }
+  }
+
+  try {
+    const output = await runner([
+      'pr',
+      'view',
+      '--json',
+      'number,title,url,state,isDraft,headRefName,baseRefName',
+    ])
+
+    return {
+      available: true,
+      authenticated: true,
+      repository,
+      currentBranch,
+      currentPullRequest: parsePullRequestInfo(output),
+    }
+  } catch {
+    return {
+      available: true,
+      authenticated: true,
+      repository,
+      currentBranch,
+      message: currentBranch ? `No pull request found for ${currentBranch}.` : 'No current branch.',
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add a GitHub PR provider boundary around `gh` for remote/auth detection and current-branch PR lookup
- add tested PR action helpers for `gh pr create` command construction and opening existing PRs
- render PR state in `coco log -i`, including missing GitHub/gh auth paths
- add TUI flow for draft/ready PR creation from the current branch into the selected target branch/default base
- generate a non-AI PR body from loaded commit messages so PR creation does not require provider credentials

## Validation

- `npm run test:jest -- src/commands/log/pullRequestData.test.ts src/commands/log/pullRequestActions.test.ts src/commands/log/interactive.test.ts src/commands/commands.integration.test.ts`
- `npm run lint && npm run build`
- `npm run coco:ts -- log -i --limit 2`
- `npm test`

Closes #661.
