### PR TITLE
Add tag management to log TUI

### DIFF
--- a/src/commands/log/interactive.test.ts
+++ b/src/commands/log/interactive.test.ts
@@ -3,6 +3,7 @@ import { createLogTuiState } from './interactiveState'
 import { renderInteractiveLog } from './interactive'
 import { BranchOverview } from './branchData'
 import { PullRequestOverview } from './pullRequestData'
+import { TagOverview, TagRangeSummary } from './tagData'
 
 const rows: GitLogRow[] = [
   {
@@ -85,10 +86,29 @@ const pullRequest: PullRequestOverview = {
   },
 }
 
+const tags: TagOverview = {
+  tags: [
+    {
+      name: '0.33.0',
+      hash: 'abc1234',
+      date: '2026-04-27',
+      subject: 'release v0.33.0',
+    },
+  ],
+}
+
+const tagRangeSummary: TagRangeSummary = {
+  from: '0.33.0',
+  to: 'HEAD',
+  commitCount: 4,
+  authors: ['Coco Test'],
+  changedFiles: ['src/commands/log/interactive.ts'],
+}
+
 describe('log interactive renderer', () => {
   it('renders commit navigation, selected details, changed files, and help', () => {
-    const output = renderInteractiveLog(createLogTuiState(rows), detail, branches, pullRequest, {}, {
-      height: 52,
+    const output = renderInteractiveLog(createLogTuiState(rows), detail, branches, pullRequest, tags, undefined, {}, {
+      height: 70,
       width: 100,
     })
 
@@ -102,6 +122,7 @@ describe('log interactive renderer', () => {
     expect(output).toContain('origin/main')
     expect(output).toContain('Pull request: #123 OPEN feature/log-prs -> main')
     expect(output).toContain('Add PR workflow')
+    expect(output).toContain('0.33.0')
     expect(output).toContain('Keys:')
   })
 
@@ -111,6 +132,8 @@ describe('log interactive renderer', () => {
       detail,
       branches,
       pullRequest,
+      tags,
+      undefined,
       {
         focus: 'branches',
         branchIndex: 0,
@@ -118,7 +141,7 @@ describe('log interactive renderer', () => {
         pendingDeleteBranch: 'main',
       },
       {
-        height: 52,
+        height: 70,
         width: 100,
       }
     )
@@ -140,6 +163,8 @@ describe('log interactive renderer', () => {
         currentBranch: 'feature/log-prs',
         message: 'No pull request found for feature/log-prs.',
       },
+      tags,
+      undefined,
       {
         focus: 'branches',
         branchIndex: 0,
@@ -152,7 +177,7 @@ describe('log interactive renderer', () => {
         },
       },
       {
-        height: 52,
+        height: 70,
         width: 100,
       }
     )
@@ -169,6 +194,8 @@ describe('log interactive renderer', () => {
       detail,
       branches,
       pullRequest,
+      tags,
+      undefined,
       {
         inputPrompt: {
           kind: 'create-pr-title',
@@ -180,7 +207,7 @@ describe('log interactive renderer', () => {
         pullRequestDraft: true,
       },
       {
-        height: 52,
+        height: 70,
         width: 100,
       }
     )
@@ -188,5 +215,30 @@ describe('log interactive renderer', () => {
     expect(output).toContain('Create draft PR into main: Add PR workflow_')
     expect(output).toContain('C PR')
     expect(output).toContain('v draft')
+  })
+
+  it('renders tag focus, delete prompts, and release range summaries', () => {
+    const output = renderInteractiveLog(
+      createLogTuiState(rows),
+      detail,
+      branches,
+      pullRequest,
+      tags,
+      tagRangeSummary,
+      {
+        focus: 'tags',
+        tagIndex: 0,
+        pendingDeleteTag: '0.33.0',
+      },
+      {
+        height: 60,
+        width: 100,
+      }
+    )
+
+    expect(output).toContain('Focus: tags')
+    expect(output).toContain('> 0.33.0 2026-04-27 abc1234 release v0.33.0')
+    expect(output).toContain('Pending tag delete: press X to delete 0.33.0')
+    expect(output).toContain('Range 0.33.0..HEAD: 4 commits, 1 authors, 1 files')
   })
 })

--- a/src/commands/log/interactive.ts
+++ b/src/commands/log/interactive.ts
@@ -16,6 +16,14 @@ import { GitCommitDetail, GitLogRow, getCommitDetail } from './data'
 import { createPullRequest, openPullRequest } from './pullRequestActions'
 import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
 import {
+  createAnnotatedTag,
+  createLightweightTag,
+  deleteLocalTag,
+  deleteRemoteTag,
+  pushTag,
+} from './tagActions'
+import { TagOverview, TagRangeSummary, getTagOverview, getTagRangeSummary } from './tagData'
+import {
   LogTuiState,
   applyLogTuiAction,
   createLogTuiState,
@@ -32,18 +40,21 @@ type RenderInteractiveLogOptions = {
   width?: number
 }
 
-type LogTuiFocus = 'commits' | 'branches'
+type LogTuiFocus = 'commits' | 'branches' | 'tags'
 
 type LogTuiRenderUi = {
   focus?: LogTuiFocus
   branchIndex?: number
   statusMessage?: string
   pendingDeleteBranch?: string
+  pendingDeleteTag?: string
+  pendingDeleteRemoteTag?: string
   inputPrompt?: LogTuiInputPrompt
   pullRequestDraft?: boolean
+  tagIndex?: number
 }
 
-type LogTuiInputKind = 'create-branch' | 'rename-branch' | 'create-pr-title'
+type LogTuiInputKind = 'create-branch' | 'rename-branch' | 'create-pr-title' | 'create-tag' | 'create-annotated-tag'
 
 type LogTuiInputPrompt = {
   kind: LogTuiInputKind
@@ -52,9 +63,10 @@ type LogTuiInputPrompt = {
   sourceRef: string
   branchName?: string
   baseRef?: string
+  tagName?: string
 }
 
-const DEFAULT_HEIGHT = 52
+const DEFAULT_HEIGHT = 70
 const DEFAULT_WIDTH = 120
 
 function truncate(value: string, width: number): string {
@@ -214,6 +226,42 @@ function renderPullRequestOverview(
   ].map((line) => truncate(line, width))
 }
 
+function renderTagOverview(
+  overview: TagOverview | undefined,
+  summary: TagRangeSummary | undefined,
+  ui: LogTuiRenderUi,
+  width: number
+): string[] {
+  if (!overview) {
+    return ['Tags: unavailable']
+  }
+
+  const tags = overview.tags.slice(0, 6).map((tag, index) => {
+    const selected = ui.focus === 'tags' && (ui.tagIndex || 0) === index ? '>' : ' '
+
+    return `${selected} ${tag.name} ${tag.date} ${tag.hash} ${tag.subject}`
+  })
+  const hiddenTags = overview.tags.length > tags.length
+    ? [`  ... ${overview.tags.length - tags.length} more tag(s)`]
+    : []
+  const deletePrompt = ui.pendingDeleteTag
+    ? `Pending tag delete: press X to delete ${ui.pendingDeleteTag}`
+    : ui.pendingDeleteRemoteTag
+      ? `Pending remote tag delete: press Y to delete origin/${ui.pendingDeleteRemoteTag}`
+      : 'Tag actions: t tag | a annotated | s push | x delete local | y delete remote | R range'
+  const summaryLine = summary
+    ? `Range ${summary.from}..${summary.to}: ${summary.commitCount} commits, ${summary.authors.length} authors, ${summary.changedFiles.length} files`
+    : 'Range: select a tag and press R to compare with HEAD'
+
+  return [
+    'Tags:',
+    ...(tags.length ? tags : ['  No tags found.']),
+    ...hiddenTags,
+    deletePrompt,
+    summaryLine,
+  ].map((line) => truncate(line, width))
+}
+
 function renderDetail(detail: GitCommitDetail | undefined, width: number): string[] {
   if (!detail) {
     return ['Loading selected commit details...']
@@ -247,6 +295,8 @@ export function renderInteractiveLog(
   detail?: GitCommitDetail,
   branches?: BranchOverview,
   pullRequest?: PullRequestOverview,
+  tags?: TagOverview,
+  tagRangeSummary?: TagRangeSummary,
   ui: LogTuiRenderUi = {},
   options: RenderInteractiveLogOptions = {}
 ): string {
@@ -257,15 +307,19 @@ export function renderInteractiveLog(
   const graphMode = state.fullGraph ? 'full graph' : 'compact graph'
   const focus = ui.focus || 'commits'
   const help = state.showHelp
-    ? 'Keys: tab focus | up/down move | enter checkout | n branch | C PR | v draft | f fetch | q quit'
+    ? 'Keys: tab focus | up/down move | enter checkout | n branch | t tag | C PR | f fetch | q quit'
     : 'Press ? for help'
   const detailHeader = selected
     ? `Selected: ${selected.shortHash} ${selected.message}`
     : 'Selected: none'
   const branchLines = renderBranchOverview(branches, ui, width).slice(0, 12)
   const pullRequestLines = renderPullRequestOverview(pullRequest, ui, width).slice(0, 4)
+  const tagLines = renderTagOverview(tags, tagRangeSummary, ui, width).slice(0, 10)
   const listHeight = Math.max(4, Math.floor(height * 0.35))
-  const detailHeight = Math.max(6, height - listHeight - branchLines.length - pullRequestLines.length - 11)
+  const detailHeight = Math.max(
+    6,
+    height - listHeight - branchLines.length - pullRequestLines.length - tagLines.length - 11
+  )
   const detailLines = renderDetail(detail, width).slice(0, detailHeight)
   const filterPrompt = state.filterMode ? `Search: ${state.filter}_` : `Filter: ${filter}`
 
@@ -278,6 +332,7 @@ export function renderInteractiveLog(
     '',
     ...branchLines,
     ...pullRequestLines,
+    ...tagLines,
     '',
     ...renderCommitList(state, listHeight, width),
     '',
@@ -298,10 +353,15 @@ export async function startInteractiveLog(
   const details = new Map<string, GitCommitDetail>()
   let branches: BranchOverview | undefined
   let pullRequest: PullRequestOverview | undefined
+  let tags: TagOverview | undefined
+  let tagRangeSummary: TagRangeSummary | undefined
   let focus: LogTuiFocus = 'commits'
   let branchIndex = 0
+  let tagIndex = 0
   let statusMessage: string | undefined
   let pendingDeleteBranch: string | undefined
+  let pendingDeleteTag: string | undefined
+  let pendingDeleteRemoteTag: string | undefined
   let inputPrompt: LogTuiInputPrompt | undefined
   let pullRequestDraft = false
 
@@ -324,16 +384,17 @@ export async function startInteractiveLog(
 
   if (!input.isTTY || !output.isTTY) {
     try {
-      [branches, pullRequest] = await Promise.all([
+      [branches, pullRequest, tags] = await Promise.all([
         getBranchOverview(git),
         getPullRequestOverview(git),
+        getTagOverview(git),
       ])
     } catch {
       branches = undefined
     }
 
     output.write(
-      `${renderInteractiveLog(state, await loadSelectedDetail(), branches, pullRequest)}\n`,
+      `${renderInteractiveLog(state, await loadSelectedDetail(), branches, pullRequest, tags, tagRangeSummary)}\n`,
       'utf8'
     )
     return
@@ -362,12 +423,15 @@ export async function startInteractiveLog(
         branchIndex,
         statusMessage,
         pendingDeleteBranch,
+        pendingDeleteTag,
+        pendingDeleteRemoteTag,
         inputPrompt,
         pullRequestDraft,
+        tagIndex,
       }
 
       output.write(
-        `\x1b[2J\x1b[H${renderInteractiveLog(state, undefined, branches, pullRequest, ui)}\n`,
+        `\x1b[2J\x1b[H${renderInteractiveLog(state, undefined, branches, pullRequest, tags, tagRangeSummary, ui)}\n`,
         'utf8'
       )
 
@@ -376,7 +440,7 @@ export async function startInteractiveLog(
 
         if (!closed && version === renderVersion) {
           output.write(
-            `\x1b[2J\x1b[H${renderInteractiveLog(state, detail, branches, pullRequest, ui)}\n`,
+            `\x1b[2J\x1b[H${renderInteractiveLog(state, detail, branches, pullRequest, tags, tagRangeSummary, ui)}\n`,
             'utf8'
           )
         }
@@ -399,15 +463,23 @@ export async function startInteractiveLog(
       pullRequest = await getPullRequestOverview(git)
     }
 
+    const refreshTags = async () => {
+      tags = await getTagOverview(git)
+      tagIndex = Math.max(0, Math.min(tagIndex, (tags?.tags.length || 1) - 1))
+    }
+
     const setActionResult = async (result: BranchActionResult, refresh = true) => {
       statusMessage = result.message
       pendingDeleteBranch = undefined
+      pendingDeleteTag = undefined
+      pendingDeleteRemoteTag = undefined
       inputPrompt = undefined
 
       if (refresh) {
         await Promise.all([
           refreshBranches(),
           refreshPullRequest(),
+          refreshTags(),
         ])
       }
 
@@ -415,10 +487,15 @@ export async function startInteractiveLog(
     }
 
     const selectedBranch = () => getBranchList(branches)[branchIndex]
+    const selectedTag = () => tags?.tags[tagIndex]
 
     const selectedRef = () => {
       if (focus === 'branches') {
         return selectedBranch()?.shortName
+      }
+
+      if (focus === 'tags') {
+        return selectedTag()?.name
       }
 
       return getSelectedCommit(state)?.hash
@@ -459,6 +536,15 @@ export async function startInteractiveLog(
       void render()
     }
 
+    const moveTagSelection = (delta: number) => {
+      const tagCount = tags?.tags.length || 0
+
+      tagIndex = Math.max(0, Math.min(tagIndex + delta, tagCount - 1))
+      pendingDeleteTag = undefined
+      pendingDeleteRemoteTag = undefined
+      void render()
+    }
+
     const runBranchAction = async (action: () => Promise<BranchActionResult>, refresh = true) => {
       statusMessage = 'Running branch action...'
       await render()
@@ -469,6 +555,8 @@ export async function startInteractiveLog(
       inputPrompt = prompt
       statusMessage = undefined
       pendingDeleteBranch = undefined
+      pendingDeleteTag = undefined
+      pendingDeleteRemoteTag = undefined
       void render()
     }
 
@@ -508,6 +596,10 @@ export async function startInteractiveLog(
           body: generatedPullRequestBody(),
           draft: pullRequestDraft,
         }))
+      } else if (prompt.kind === 'create-tag') {
+        await runBranchAction(() => createLightweightTag(git, value, prompt.sourceRef))
+      } else if (prompt.kind === 'create-annotated-tag') {
+        await runBranchAction(() => createAnnotatedTag(git, value, prompt.sourceRef, `release ${value}`))
       }
     }
 
@@ -584,13 +676,19 @@ export async function startInteractiveLog(
       }
 
       if (key.name === 'tab') {
-        focus = focus === 'commits' ? 'branches' : 'commits'
+        focus = focus === 'commits' ? 'branches' : focus === 'branches' ? 'tags' : 'commits'
         pendingDeleteBranch = undefined
+        pendingDeleteTag = undefined
+        pendingDeleteRemoteTag = undefined
         void render()
       } else if ((key.name === 'up' || key.name === 'k') && focus === 'branches') {
         moveBranchSelection(-1)
       } else if ((key.name === 'down' || key.name === 'j') && focus === 'branches') {
         moveBranchSelection(1)
+      } else if ((key.name === 'up' || key.name === 'k') && focus === 'tags') {
+        moveTagSelection(-1)
+      } else if ((key.name === 'down' || key.name === 'j') && focus === 'tags') {
+        moveTagSelection(1)
       } else if (key.name === 'return' && focus === 'branches') {
         const branch = selectedBranch()
 
@@ -622,11 +720,12 @@ export async function startInteractiveLog(
           await Promise.all([
             refreshBranches(),
             refreshPullRequest(),
+            refreshTags(),
           ])
 
           return {
             ok: true,
-            message: 'Refreshed Git overview',
+          message: 'Refreshed Git overview',
           }
         }, false)
       } else if (key.name === 'n') {
@@ -664,6 +763,75 @@ export async function startInteractiveLog(
         } else {
           statusMessage = 'Select a remote branch to set as the current branch upstream.'
           void render()
+        }
+      } else if (key.name === 't') {
+        const target = selectedRef()
+
+        if (target) {
+          startInputPrompt({
+            kind: 'create-tag',
+            label: `Create tag at ${target}`,
+            value: '',
+            sourceRef: target,
+          })
+        }
+      } else if (key.name === 'a') {
+        const target = selectedRef()
+
+        if (target) {
+          startInputPrompt({
+            kind: 'create-annotated-tag',
+            label: `Create annotated tag at ${target}`,
+            value: '',
+            sourceRef: target,
+          })
+        }
+      } else if (key.name === 's' && focus === 'tags') {
+        const tag = selectedTag()
+
+        if (tag) {
+          void runBranchAction(() => pushTag(git, tag.name))
+        }
+      } else if (key.name === 'x' && focus === 'tags') {
+        const tag = selectedTag()
+
+        if (tag) {
+          pendingDeleteTag = tag.name
+          statusMessage = `Press X to confirm deleting local tag ${tag.name}`
+          void render()
+        }
+      } else if (sequence === 'X' && focus === 'tags') {
+        const tag = selectedTag()
+
+        if (tag && pendingDeleteTag === tag.name) {
+          void runBranchAction(() => deleteLocalTag(git, tag.name))
+        }
+      } else if (key.name === 'y' && focus === 'tags') {
+        const tag = selectedTag()
+
+        if (tag) {
+          pendingDeleteRemoteTag = tag.name
+          statusMessage = `Press Y to confirm deleting remote tag ${tag.name}`
+          void render()
+        }
+      } else if (sequence === 'Y' && focus === 'tags') {
+        const tag = selectedTag()
+
+        if (tag && pendingDeleteRemoteTag === tag.name) {
+          void runBranchAction(() => deleteRemoteTag(git, tag.name))
+        }
+      } else if (sequence === 'R' && focus === 'tags') {
+        const tag = selectedTag()
+
+        if (tag) {
+          void runBranchAction(async () => {
+            tagRangeSummary = await getTagRangeSummary(git, tag.name)
+
+            return {
+              ok: true,
+              message: `Compared ${tag.name}..HEAD`,
+            }
+          }, false)
         }
       } else if (sequence === 'C') {
         const baseRef = selectedBaseRef()
@@ -712,6 +880,7 @@ export async function startInteractiveLog(
     void Promise.all([
       refreshBranches(),
       refreshPullRequest(),
+      refreshTags(),
     ])
       .then(() => {
         void render()
@@ -719,6 +888,7 @@ export async function startInteractiveLog(
       .catch(() => {
         branches = undefined
         pullRequest = undefined
+        tags = undefined
       })
     void render()
   })

--- a/src/commands/log/tagActions.test.ts
+++ b/src/commands/log/tagActions.test.ts
@@ -1,0 +1,34 @@
+import {
+  createAnnotatedTag,
+  createLightweightTag,
+  deleteLocalTag,
+  deleteRemoteTag,
+  pushTag,
+} from './tagActions'
+
+describe('log tag actions', () => {
+  it('uses explicit git commands for tag creation and deletion', async () => {
+    const git = {
+      raw: jest.fn().mockResolvedValue(''),
+    }
+
+    await createLightweightTag(git as never, '0.34.0', 'abc1234')
+    await createAnnotatedTag(git as never, '0.34.0', 'abc1234', 'release v0.34.0')
+    await deleteLocalTag(git as never, '0.34.0')
+    await pushTag(git as never, '0.34.0')
+    await deleteRemoteTag(git as never, '0.34.0')
+
+    expect(git.raw).toHaveBeenNthCalledWith(1, ['tag', '0.34.0', 'abc1234'])
+    expect(git.raw).toHaveBeenNthCalledWith(2, [
+      'tag',
+      '-a',
+      '0.34.0',
+      'abc1234',
+      '-m',
+      'release v0.34.0',
+    ])
+    expect(git.raw).toHaveBeenNthCalledWith(3, ['tag', '-d', '0.34.0'])
+    expect(git.raw).toHaveBeenNthCalledWith(4, ['push', 'origin', '0.34.0'])
+    expect(git.raw).toHaveBeenNthCalledWith(5, ['push', 'origin', ':0.34.0'])
+  })
+})

--- a/src/commands/log/tagActions.ts
+++ b/src/commands/log/tagActions.ts
@@ -1,0 +1,66 @@
+import { SimpleGit } from 'simple-git'
+
+export type TagActionResult = {
+  ok: boolean
+  message: string
+}
+
+async function runAction(action: () => Promise<unknown>, successMessage: string): Promise<TagActionResult> {
+  try {
+    await action()
+
+    return {
+      ok: true,
+      message: successMessage,
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      message: (error as Error).message,
+    }
+  }
+}
+
+export function createLightweightTag(
+  git: SimpleGit,
+  tagName: string,
+  target: string
+): Promise<TagActionResult> {
+  return runAction(
+    () => git.raw(['tag', tagName, target]),
+    `Created tag ${tagName}`
+  )
+}
+
+export function createAnnotatedTag(
+  git: SimpleGit,
+  tagName: string,
+  target: string,
+  message: string
+): Promise<TagActionResult> {
+  return runAction(
+    () => git.raw(['tag', '-a', tagName, target, '-m', message]),
+    `Created annotated tag ${tagName}`
+  )
+}
+
+export function deleteLocalTag(git: SimpleGit, tagName: string): Promise<TagActionResult> {
+  return runAction(
+    () => git.raw(['tag', '-d', tagName]),
+    `Deleted local tag ${tagName}`
+  )
+}
+
+export function pushTag(git: SimpleGit, tagName: string): Promise<TagActionResult> {
+  return runAction(
+    () => git.raw(['push', 'origin', tagName]),
+    `Pushed tag ${tagName}`
+  )
+}
+
+export function deleteRemoteTag(git: SimpleGit, tagName: string): Promise<TagActionResult> {
+  return runAction(
+    () => git.raw(['push', 'origin', `:${tagName}`]),
+    `Deleted remote tag ${tagName}`
+  )
+}

--- a/src/commands/log/tagData.test.ts
+++ b/src/commands/log/tagData.test.ts
@@ -1,0 +1,25 @@
+import { parseTagRefs } from './tagData'
+
+describe('log tag data', () => {
+  it('parses tag refs from git for-each-ref output', () => {
+    const refs = parseTagRefs([
+      ['0.33.0', 'abc1234', '2026-04-27', 'release v0.33.0'].join('\x1f'),
+      ['0.32.0', 'def5678', '2026-04-26', 'release v0.32.0'].join('\x1f'),
+    ].join('\n'))
+
+    expect(refs).toEqual([
+      {
+        name: '0.33.0',
+        hash: 'abc1234',
+        date: '2026-04-27',
+        subject: 'release v0.33.0',
+      },
+      {
+        name: '0.32.0',
+        hash: 'def5678',
+        date: '2026-04-26',
+        subject: 'release v0.32.0',
+      },
+    ])
+  })
+})

--- a/src/commands/log/tagData.ts
+++ b/src/commands/log/tagData.ts
@@ -1,0 +1,72 @@
+import { SimpleGit } from 'simple-git'
+
+const FIELD_SEPARATOR = '\x1f'
+
+export type GitTagRef = {
+  name: string
+  hash: string
+  date: string
+  subject: string
+}
+
+export type TagOverview = {
+  tags: GitTagRef[]
+}
+
+export type TagRangeSummary = {
+  from: string
+  to: string
+  commitCount: number
+  authors: string[]
+  changedFiles: string[]
+}
+
+export function parseTagRefs(output: string): GitTagRef[] {
+  return output
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => {
+      const [name, hash, date, subject] = line.split(FIELD_SEPARATOR)
+
+      return {
+        name,
+        hash,
+        date,
+        subject,
+      }
+    })
+}
+
+export async function getTagOverview(git: SimpleGit): Promise<TagOverview> {
+  const output = await git.raw([
+    'for-each-ref',
+    `--format=%(refname:short)${FIELD_SEPARATOR}%(objectname:short)${FIELD_SEPARATOR}%(creatordate:short)${FIELD_SEPARATOR}%(subject)`,
+    '--sort=-creatordate',
+    'refs/tags',
+  ])
+
+  return {
+    tags: parseTagRefs(output),
+  }
+}
+
+export async function getTagRangeSummary(
+  git: SimpleGit,
+  from: string,
+  to = 'HEAD'
+): Promise<TagRangeSummary> {
+  const [commits, authors, files] = await Promise.all([
+    git.raw(['rev-list', '--count', `${from}..${to}`]),
+    git.raw(['log', '--format=%an', `${from}..${to}`]),
+    git.raw(['diff', '--name-only', `${from}..${to}`]),
+  ])
+
+  return {
+    from,
+    to,
+    commitCount: Number.parseInt(commits.trim(), 10) || 0,
+    authors: Array.from(new Set(authors.split('\n').map((author) => author.trim()).filter(Boolean))),
+    changedFiles: Array.from(new Set(files.split('\n').map((file) => file.trim()).filter(Boolean))),
+  }
+}


### PR DESCRIPTION
## Summary

- add tag data loading for local tags with target hash, date, and subject
- add tested tag actions for lightweight tags, annotated tags, local delete, remote delete, and push
- render tags as a third `coco log -i` focus area alongside commits and branches
- add TUI flows for tag creation, annotated tag creation, push selected tag, confirmed local/remote delete, and tag-to-HEAD range summaries
- keep tag management independent from npm/package release automation

## Validation

- `npm run test:jest -- src/commands/log/tagData.test.ts src/commands/log/tagActions.test.ts src/commands/log/interactive.test.ts src/commands/commands.integration.test.ts`
- `npm run coco:ts -- log -i --limit 2`
- `npm test`

Closes #662.
