### PR TITLE
Add status staging to log TUI

### DIFF
--- a/src/commands/log/interactive.test.ts
+++ b/src/commands/log/interactive.test.ts
@@ -4,6 +4,7 @@ import { renderInteractiveLog } from './interactive'
 import { BranchOverview } from './branchData'
 import { PullRequestOverview } from './pullRequestData'
 import { TagOverview, TagRangeSummary } from './tagData'
+import { WorktreeOverview } from './statusData'
 
 const rows: GitLogRow[] = [
   {
@@ -105,9 +106,35 @@ const tagRangeSummary: TagRangeSummary = {
   changedFiles: ['src/commands/log/interactive.ts'],
 }
 
+const worktree: WorktreeOverview = {
+  stagedCount: 1,
+  unstagedCount: 1,
+  untrackedCount: 1,
+  files: [
+    {
+      path: 'staged.ts',
+      indexStatus: 'M',
+      worktreeStatus: ' ',
+      state: 'staged',
+    },
+    {
+      path: 'unstaged.ts',
+      indexStatus: ' ',
+      worktreeStatus: 'M',
+      state: 'unstaged',
+    },
+    {
+      path: 'new.ts',
+      indexStatus: '?',
+      worktreeStatus: '?',
+      state: 'untracked',
+    },
+  ],
+}
+
 describe('log interactive renderer', () => {
   it('renders commit navigation, selected details, changed files, and help', () => {
-    const output = renderInteractiveLog(createLogTuiState(rows), detail, branches, pullRequest, tags, undefined, {}, {
+    const output = renderInteractiveLog(createLogTuiState(rows), detail, branches, pullRequest, tags, undefined, worktree, {}, {
       height: 70,
       width: 100,
     })
@@ -123,6 +150,7 @@ describe('log interactive renderer', () => {
     expect(output).toContain('Pull request: #123 OPEN feature/log-prs -> main')
     expect(output).toContain('Add PR workflow')
     expect(output).toContain('0.33.0')
+    expect(output).toContain('Status: 1 staged, 1 unstaged, 1 untracked')
     expect(output).toContain('Keys:')
   })
 
@@ -134,6 +162,7 @@ describe('log interactive renderer', () => {
       pullRequest,
       tags,
       undefined,
+      worktree,
       {
         focus: 'branches',
         branchIndex: 0,
@@ -165,6 +194,7 @@ describe('log interactive renderer', () => {
       },
       tags,
       undefined,
+      worktree,
       {
         focus: 'branches',
         branchIndex: 0,
@@ -196,6 +226,7 @@ describe('log interactive renderer', () => {
       pullRequest,
       tags,
       undefined,
+      worktree,
       {
         inputPrompt: {
           kind: 'create-pr-title',
@@ -225,6 +256,7 @@ describe('log interactive renderer', () => {
       pullRequest,
       tags,
       tagRangeSummary,
+      worktree,
       {
         focus: 'tags',
         tagIndex: 0,
@@ -240,5 +272,31 @@ describe('log interactive renderer', () => {
     expect(output).toContain('> 0.33.0 2026-04-27 abc1234 release v0.33.0')
     expect(output).toContain('Pending tag delete: press X to delete 0.33.0')
     expect(output).toContain('Range 0.33.0..HEAD: 4 commits, 1 authors, 1 files')
+  })
+
+  it('renders status focus and revert confirmation', () => {
+    const output = renderInteractiveLog(
+      createLogTuiState(rows),
+      detail,
+      branches,
+      pullRequest,
+      tags,
+      undefined,
+      worktree,
+      {
+        focus: 'status',
+        statusIndex: 1,
+        pendingRevertFile: 'unstaged.ts',
+      },
+      {
+        height: 70,
+        width: 100,
+      }
+    )
+
+    expect(output).toContain('Focus: status')
+    expect(output).toContain('>  M unstaged.ts')
+    expect(output).toContain('Pending revert: press Z to revert unstaged.ts')
+    expect(output).toContain('space stage')
   })
 })

--- a/src/commands/log/interactive.ts
+++ b/src/commands/log/interactive.ts
@@ -15,6 +15,8 @@ import { BranchOverview, BranchRef, getBranchOverview } from './branchData'
 import { GitCommitDetail, GitLogRow, getCommitDetail } from './data'
 import { createPullRequest, openPullRequest } from './pullRequestActions'
 import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
+import { revertFile, stageFile, unstageFile } from './statusActions'
+import { WorktreeFile, WorktreeOverview, getWorktreeOverview } from './statusData'
 import {
   createAnnotatedTag,
   createLightweightTag,
@@ -40,7 +42,7 @@ type RenderInteractiveLogOptions = {
   width?: number
 }
 
-type LogTuiFocus = 'commits' | 'branches' | 'tags'
+type LogTuiFocus = 'commits' | 'branches' | 'tags' | 'status'
 
 type LogTuiRenderUi = {
   focus?: LogTuiFocus
@@ -52,6 +54,8 @@ type LogTuiRenderUi = {
   inputPrompt?: LogTuiInputPrompt
   pullRequestDraft?: boolean
   tagIndex?: number
+  statusIndex?: number
+  pendingRevertFile?: string
 }
 
 type LogTuiInputKind = 'create-branch' | 'rename-branch' | 'create-pr-title' | 'create-tag' | 'create-annotated-tag'
@@ -262,6 +266,35 @@ function renderTagOverview(
   ].map((line) => truncate(line, width))
 }
 
+function renderStatusOverview(
+  overview: WorktreeOverview | undefined,
+  ui: LogTuiRenderUi,
+  width: number
+): string[] {
+  if (!overview) {
+    return ['Status: unavailable']
+  }
+
+  const files = overview.files.slice(0, 8).map((file, index) => {
+    const selected = ui.focus === 'status' && (ui.statusIndex || 0) === index ? '>' : ' '
+
+    return `${selected} ${file.indexStatus}${file.worktreeStatus} ${file.path}`
+  })
+  const hiddenFiles = overview.files.length > files.length
+    ? [`  ... ${overview.files.length - files.length} more file(s)`]
+    : []
+  const actionLine = ui.pendingRevertFile
+    ? `Pending revert: press Z to revert ${ui.pendingRevertFile}`
+    : 'Status actions: space stage/unstage | z revert selected file'
+
+  return [
+    `Status: ${overview.stagedCount} staged, ${overview.unstagedCount} unstaged, ${overview.untrackedCount} untracked`,
+    ...(files.length ? files : ['  Worktree clean.']),
+    ...hiddenFiles,
+    actionLine,
+  ].map((line) => truncate(line, width))
+}
+
 function renderDetail(detail: GitCommitDetail | undefined, width: number): string[] {
   if (!detail) {
     return ['Loading selected commit details...']
@@ -297,6 +330,7 @@ export function renderInteractiveLog(
   pullRequest?: PullRequestOverview,
   tags?: TagOverview,
   tagRangeSummary?: TagRangeSummary,
+  worktree?: WorktreeOverview,
   ui: LogTuiRenderUi = {},
   options: RenderInteractiveLogOptions = {}
 ): string {
@@ -307,7 +341,7 @@ export function renderInteractiveLog(
   const graphMode = state.fullGraph ? 'full graph' : 'compact graph'
   const focus = ui.focus || 'commits'
   const help = state.showHelp
-    ? 'Keys: tab focus | up/down move | enter checkout | n branch | t tag | C PR | f fetch | q quit'
+    ? 'Keys: tab focus | up/down move | space stage | n branch | t tag | C PR | f fetch | q quit'
     : 'Press ? for help'
   const detailHeader = selected
     ? `Selected: ${selected.shortHash} ${selected.message}`
@@ -315,10 +349,17 @@ export function renderInteractiveLog(
   const branchLines = renderBranchOverview(branches, ui, width).slice(0, 12)
   const pullRequestLines = renderPullRequestOverview(pullRequest, ui, width).slice(0, 4)
   const tagLines = renderTagOverview(tags, tagRangeSummary, ui, width).slice(0, 10)
+  const statusLines = renderStatusOverview(worktree, ui, width).slice(0, 10)
   const listHeight = Math.max(4, Math.floor(height * 0.35))
   const detailHeight = Math.max(
     6,
-    height - listHeight - branchLines.length - pullRequestLines.length - tagLines.length - 11
+    height -
+      listHeight -
+      branchLines.length -
+      pullRequestLines.length -
+      tagLines.length -
+      statusLines.length -
+      11
   )
   const detailLines = renderDetail(detail, width).slice(0, detailHeight)
   const filterPrompt = state.filterMode ? `Search: ${state.filter}_` : `Filter: ${filter}`
@@ -333,6 +374,7 @@ export function renderInteractiveLog(
     ...branchLines,
     ...pullRequestLines,
     ...tagLines,
+    ...statusLines,
     '',
     ...renderCommitList(state, listHeight, width),
     '',
@@ -355,13 +397,16 @@ export async function startInteractiveLog(
   let pullRequest: PullRequestOverview | undefined
   let tags: TagOverview | undefined
   let tagRangeSummary: TagRangeSummary | undefined
+  let worktree: WorktreeOverview | undefined
   let focus: LogTuiFocus = 'commits'
   let branchIndex = 0
   let tagIndex = 0
+  let statusIndex = 0
   let statusMessage: string | undefined
   let pendingDeleteBranch: string | undefined
   let pendingDeleteTag: string | undefined
   let pendingDeleteRemoteTag: string | undefined
+  let pendingRevertFile: string | undefined
   let inputPrompt: LogTuiInputPrompt | undefined
   let pullRequestDraft = false
 
@@ -384,17 +429,26 @@ export async function startInteractiveLog(
 
   if (!input.isTTY || !output.isTTY) {
     try {
-      [branches, pullRequest, tags] = await Promise.all([
+      [branches, pullRequest, tags, worktree] = await Promise.all([
         getBranchOverview(git),
         getPullRequestOverview(git),
         getTagOverview(git),
+        getWorktreeOverview(git),
       ])
     } catch {
       branches = undefined
     }
 
     output.write(
-      `${renderInteractiveLog(state, await loadSelectedDetail(), branches, pullRequest, tags, tagRangeSummary)}\n`,
+      `${renderInteractiveLog(
+        state,
+        await loadSelectedDetail(),
+        branches,
+        pullRequest,
+        tags,
+        tagRangeSummary,
+        worktree
+      )}\n`,
       'utf8'
     )
     return
@@ -425,13 +479,24 @@ export async function startInteractiveLog(
         pendingDeleteBranch,
         pendingDeleteTag,
         pendingDeleteRemoteTag,
+        pendingRevertFile,
         inputPrompt,
         pullRequestDraft,
         tagIndex,
+        statusIndex,
       }
 
       output.write(
-        `\x1b[2J\x1b[H${renderInteractiveLog(state, undefined, branches, pullRequest, tags, tagRangeSummary, ui)}\n`,
+        `\x1b[2J\x1b[H${renderInteractiveLog(
+          state,
+          undefined,
+          branches,
+          pullRequest,
+          tags,
+          tagRangeSummary,
+          worktree,
+          ui
+        )}\n`,
         'utf8'
       )
 
@@ -440,7 +505,16 @@ export async function startInteractiveLog(
 
         if (!closed && version === renderVersion) {
           output.write(
-            `\x1b[2J\x1b[H${renderInteractiveLog(state, detail, branches, pullRequest, tags, tagRangeSummary, ui)}\n`,
+            `\x1b[2J\x1b[H${renderInteractiveLog(
+              state,
+              detail,
+              branches,
+              pullRequest,
+              tags,
+              tagRangeSummary,
+              worktree,
+              ui
+            )}\n`,
             'utf8'
           )
         }
@@ -468,11 +542,17 @@ export async function startInteractiveLog(
       tagIndex = Math.max(0, Math.min(tagIndex, (tags?.tags.length || 1) - 1))
     }
 
+    const refreshWorktree = async () => {
+      worktree = await getWorktreeOverview(git)
+      statusIndex = Math.max(0, Math.min(statusIndex, (worktree?.files.length || 1) - 1))
+    }
+
     const setActionResult = async (result: BranchActionResult, refresh = true) => {
       statusMessage = result.message
       pendingDeleteBranch = undefined
       pendingDeleteTag = undefined
       pendingDeleteRemoteTag = undefined
+      pendingRevertFile = undefined
       inputPrompt = undefined
 
       if (refresh) {
@@ -480,6 +560,7 @@ export async function startInteractiveLog(
           refreshBranches(),
           refreshPullRequest(),
           refreshTags(),
+          refreshWorktree(),
         ])
       }
 
@@ -488,6 +569,7 @@ export async function startInteractiveLog(
 
     const selectedBranch = () => getBranchList(branches)[branchIndex]
     const selectedTag = () => tags?.tags[tagIndex]
+    const selectedStatusFile = (): WorktreeFile | undefined => worktree?.files[statusIndex]
 
     const selectedRef = () => {
       if (focus === 'branches') {
@@ -545,6 +627,14 @@ export async function startInteractiveLog(
       void render()
     }
 
+    const moveStatusSelection = (delta: number) => {
+      const fileCount = worktree?.files.length || 0
+
+      statusIndex = Math.max(0, Math.min(statusIndex + delta, fileCount - 1))
+      pendingRevertFile = undefined
+      void render()
+    }
+
     const runBranchAction = async (action: () => Promise<BranchActionResult>, refresh = true) => {
       statusMessage = 'Running branch action...'
       await render()
@@ -557,6 +647,7 @@ export async function startInteractiveLog(
       pendingDeleteBranch = undefined
       pendingDeleteTag = undefined
       pendingDeleteRemoteTag = undefined
+      pendingRevertFile = undefined
       void render()
     }
 
@@ -676,10 +767,17 @@ export async function startInteractiveLog(
       }
 
       if (key.name === 'tab') {
-        focus = focus === 'commits' ? 'branches' : focus === 'branches' ? 'tags' : 'commits'
+        focus = focus === 'commits'
+          ? 'branches'
+          : focus === 'branches'
+            ? 'tags'
+            : focus === 'tags'
+              ? 'status'
+              : 'commits'
         pendingDeleteBranch = undefined
         pendingDeleteTag = undefined
         pendingDeleteRemoteTag = undefined
+        pendingRevertFile = undefined
         void render()
       } else if ((key.name === 'up' || key.name === 'k') && focus === 'branches') {
         moveBranchSelection(-1)
@@ -689,6 +787,30 @@ export async function startInteractiveLog(
         moveTagSelection(-1)
       } else if ((key.name === 'down' || key.name === 'j') && focus === 'tags') {
         moveTagSelection(1)
+      } else if ((key.name === 'up' || key.name === 'k') && focus === 'status') {
+        moveStatusSelection(-1)
+      } else if ((key.name === 'down' || key.name === 'j') && focus === 'status') {
+        moveStatusSelection(1)
+      } else if (key.name === 'space' && focus === 'status') {
+        const file = selectedStatusFile()
+
+        if (file) {
+          void runBranchAction(() => file.state === 'staged' ? unstageFile(git, file) : stageFile(git, file))
+        }
+      } else if (key.name === 'z' && focus === 'status') {
+        const file = selectedStatusFile()
+
+        if (file) {
+          pendingRevertFile = file.path
+          statusMessage = `Press Z to confirm reverting ${file.path}`
+          void render()
+        }
+      } else if (sequence === 'Z' && focus === 'status') {
+        const file = selectedStatusFile()
+
+        if (file && pendingRevertFile === file.path) {
+          void runBranchAction(() => revertFile(git, file))
+        }
       } else if (key.name === 'return' && focus === 'branches') {
         const branch = selectedBranch()
 
@@ -721,6 +843,7 @@ export async function startInteractiveLog(
             refreshBranches(),
             refreshPullRequest(),
             refreshTags(),
+            refreshWorktree(),
           ])
 
           return {
@@ -881,6 +1004,7 @@ export async function startInteractiveLog(
       refreshBranches(),
       refreshPullRequest(),
       refreshTags(),
+      refreshWorktree(),
     ])
       .then(() => {
         void render()
@@ -889,6 +1013,7 @@ export async function startInteractiveLog(
         branches = undefined
         pullRequest = undefined
         tags = undefined
+        worktree = undefined
       })
     void render()
   })

--- a/src/commands/log/statusActions.test.ts
+++ b/src/commands/log/statusActions.test.ts
@@ -1,0 +1,42 @@
+import { revertFile, stageFile, unstageFile } from './statusActions'
+import { WorktreeFile } from './statusData'
+
+const file: WorktreeFile = {
+  path: 'src/file.ts',
+  indexStatus: ' ',
+  worktreeStatus: 'M',
+  state: 'unstaged',
+}
+
+describe('log status actions', () => {
+  it('stages, unstages, and reverts files with explicit path separators', async () => {
+    const git = {
+      raw: jest.fn().mockResolvedValue(''),
+    }
+
+    await stageFile(git as never, file)
+    await unstageFile(git as never, file)
+    await revertFile(git as never, file)
+
+    expect(git.raw).toHaveBeenNthCalledWith(1, ['add', '--', 'src/file.ts'])
+    expect(git.raw).toHaveBeenNthCalledWith(2, ['restore', '--staged', '--', 'src/file.ts'])
+    expect(git.raw).toHaveBeenNthCalledWith(3, ['restore', '--', 'src/file.ts'])
+  })
+
+  it('does not revert untracked files automatically', async () => {
+    const git = {
+      raw: jest.fn(),
+    }
+
+    await expect(revertFile(git as never, {
+      ...file,
+      indexStatus: '?',
+      worktreeStatus: '?',
+      state: 'untracked',
+    })).resolves.toEqual({
+      ok: false,
+      message: 'Untracked files are not reverted automatically.',
+    })
+    expect(git.raw).not.toHaveBeenCalled()
+  })
+})

--- a/src/commands/log/statusActions.ts
+++ b/src/commands/log/statusActions.ts
@@ -1,0 +1,51 @@
+import { SimpleGit } from 'simple-git'
+import { WorktreeFile } from './statusData'
+
+export type StatusActionResult = {
+  ok: boolean
+  message: string
+}
+
+async function runAction(action: () => Promise<unknown>, successMessage: string): Promise<StatusActionResult> {
+  try {
+    await action()
+
+    return {
+      ok: true,
+      message: successMessage,
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      message: (error as Error).message,
+    }
+  }
+}
+
+export function stageFile(git: SimpleGit, file: WorktreeFile): Promise<StatusActionResult> {
+  return runAction(
+    () => git.raw(['add', '--', file.path]),
+    `Staged ${file.path}`
+  )
+}
+
+export function unstageFile(git: SimpleGit, file: WorktreeFile): Promise<StatusActionResult> {
+  return runAction(
+    () => git.raw(['restore', '--staged', '--', file.path]),
+    `Unstaged ${file.path}`
+  )
+}
+
+export function revertFile(git: SimpleGit, file: WorktreeFile): Promise<StatusActionResult> {
+  if (file.state === 'untracked') {
+    return Promise.resolve({
+      ok: false,
+      message: 'Untracked files are not reverted automatically.',
+    })
+  }
+
+  return runAction(
+    () => git.raw(['restore', '--', file.path]),
+    `Reverted ${file.path}`
+  )
+}

--- a/src/commands/log/statusData.test.ts
+++ b/src/commands/log/statusData.test.ts
@@ -1,0 +1,37 @@
+import { parsePorcelainStatus } from './statusData'
+
+describe('log status data', () => {
+  it('parses staged, unstaged, untracked, and rename status rows', () => {
+    expect(parsePorcelainStatus([
+      'M  staged.ts',
+      ' M unstaged.ts',
+      '?? new.ts',
+      'R  old.ts -> renamed.ts',
+    ].join('\n'))).toEqual([
+      {
+        path: 'staged.ts',
+        indexStatus: 'M',
+        worktreeStatus: ' ',
+        state: 'staged',
+      },
+      {
+        path: 'unstaged.ts',
+        indexStatus: ' ',
+        worktreeStatus: 'M',
+        state: 'unstaged',
+      },
+      {
+        path: 'new.ts',
+        indexStatus: '?',
+        worktreeStatus: '?',
+        state: 'untracked',
+      },
+      {
+        path: 'renamed.ts',
+        indexStatus: 'R',
+        worktreeStatus: ' ',
+        state: 'staged',
+      },
+    ])
+  })
+})

--- a/src/commands/log/statusData.ts
+++ b/src/commands/log/statusData.ts
@@ -1,0 +1,60 @@
+import { SimpleGit } from 'simple-git'
+
+export type WorktreeFileState = 'staged' | 'unstaged' | 'untracked'
+
+export type WorktreeFile = {
+  path: string
+  indexStatus: string
+  worktreeStatus: string
+  state: WorktreeFileState
+}
+
+export type WorktreeOverview = {
+  files: WorktreeFile[]
+  stagedCount: number
+  unstagedCount: number
+  untrackedCount: number
+}
+
+function fileState(indexStatus: string, worktreeStatus: string): WorktreeFileState {
+  if (indexStatus === '?' && worktreeStatus === '?') {
+    return 'untracked'
+  }
+
+  if (indexStatus.trim()) {
+    return 'staged'
+  }
+
+  return 'unstaged'
+}
+
+export function parsePorcelainStatus(output: string): WorktreeFile[] {
+  return output
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => {
+      const indexStatus = line[0] || ' '
+      const worktreeStatus = line[1] || ' '
+      const rawPath = line.slice(3)
+      const renamePath = rawPath.includes(' -> ') ? rawPath.split(' -> ').at(-1) as string : rawPath
+
+      return {
+        path: renamePath,
+        indexStatus,
+        worktreeStatus,
+        state: fileState(indexStatus, worktreeStatus),
+      }
+    })
+}
+
+export async function getWorktreeOverview(git: SimpleGit): Promise<WorktreeOverview> {
+  const files = parsePorcelainStatus(await git.raw(['status', '--porcelain']))
+
+  return {
+    files,
+    stagedCount: files.filter((file) => file.state === 'staged').length,
+    unstagedCount: files.filter((file) => file.state === 'unstaged').length,
+    untrackedCount: files.filter((file) => file.state === 'untracked').length,
+  }
+}


### PR DESCRIPTION
## Summary

- add working-tree status parsing for staged, unstaged, untracked, and renamed files
- add tested status actions for file-level stage, unstage, and guarded revert
- render a status focus panel in `coco log -i`
- allow `tab` focus cycling into status, up/down status file selection, `space` stage/unstage, and confirmed `z`/`Z` revert

## Validation

- `npm run test:jest -- src/commands/log/statusData.test.ts src/commands/log/statusActions.test.ts src/commands/log/interactive.test.ts src/commands/commands.integration.test.ts`
- `npm run lint && npm run build`
- `npm test`

Refs #663.
