### PR TITLE
Wire log TUI commit workflows

### DIFF
--- a/src/commands/log/commitWorkflowActions.test.ts
+++ b/src/commands/log/commitWorkflowActions.test.ts
@@ -1,0 +1,116 @@
+import { handler as commitHandler } from '../commit/handler'
+import { createCommit } from '../../lib/simple-git/createCommit'
+import { commitWorkflowTestInternals, runCommitWorkflow } from './commitWorkflowActions'
+
+jest.mock('../commit/handler', () => ({
+  handler: jest.fn(),
+}))
+
+jest.mock('../../lib/simple-git/createCommit', () => ({
+  createCommit: jest.fn(),
+  PreCommitHookError: class PreCommitHookError extends Error {
+    readonly hookOutput: string
+
+    constructor(hookOutput: string) {
+      super('Pre-commit hook failed')
+      this.name = 'PreCommitHookError'
+      this.hookOutput = hookOutput
+    }
+  },
+}))
+
+const mockedCommitHandler = commitHandler as jest.MockedFunction<typeof commitHandler>
+const mockedCreateCommit = createCommit as jest.MockedFunction<typeof createCommit>
+const git = {} as Parameters<typeof createCommit>[1]
+
+describe('log commit workflow actions', () => {
+  beforeEach(() => {
+    mockedCommitHandler.mockReset()
+    mockedCreateCommit.mockReset()
+  })
+
+  it('builds quiet stdout argv and commits generated messages', async () => {
+    mockedCommitHandler.mockImplementation(async () => {
+      process.stdout.write('feat: generated message\n\nGenerated body.\n')
+    })
+    mockedCreateCommit.mockResolvedValue({} as Awaited<ReturnType<typeof createCommit>>)
+
+    const result = await runCommitWorkflow({ action: 'commit', git })
+
+    expect(result).toEqual({
+      ok: true,
+      message: 'feat: generated message',
+    })
+    expect(mockedCreateCommit).toHaveBeenCalledWith(
+      'feat: generated message\n\nGenerated body.',
+      git,
+      undefined,
+      { noVerify: false }
+    )
+    expect(mockedCommitHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _: ['commit'],
+        interactive: false,
+        mode: 'stdout',
+        split: false,
+        plan: false,
+        apply: false,
+      }),
+      expect.objectContaining({
+        setConfig: expect.any(Function),
+      })
+    )
+  })
+
+  it('builds split plan argv for commit split planning', async () => {
+    mockedCommitHandler.mockImplementation(async () => {
+      process.stdout.write('## 1. feat: split plan\n')
+    })
+
+    const result = await runCommitWorkflow({ action: 'split-plan', git })
+
+    expect(result.message).toBe('## 1. feat: split plan')
+    expect(mockedCreateCommit).not.toHaveBeenCalled()
+    expect(mockedCommitHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _: ['commit', 'split'],
+        split: true,
+        plan: true,
+        apply: false,
+      }),
+      expect.anything()
+    )
+  })
+
+  it('builds split apply argv for commit split application', async () => {
+    mockedCommitHandler.mockImplementation(async () => {
+      process.stdout.write('Created 2 split commit(s).\n')
+    })
+
+    const result = await runCommitWorkflow({ action: 'split-apply', git })
+
+    expect(result.message).toBe('Created 2 split commit(s).')
+    expect(mockedCreateCommit).not.toHaveBeenCalled()
+    expect(mockedCommitHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _: ['commit', 'split'],
+        split: true,
+        plan: false,
+        apply: true,
+      }),
+      expect.anything()
+    )
+  })
+
+  it('uses a friendly fallback when command output is empty', () => {
+    expect(commitWorkflowTestInternals.formatCommitWorkflowMessage('commit', '')).toBe(
+      'Generated commit message.'
+    )
+    expect(commitWorkflowTestInternals.formatCommitWorkflowMessage('split-plan', '')).toBe(
+      'Generated commit split plan.'
+    )
+    expect(commitWorkflowTestInternals.formatCommitWorkflowMessage('split-apply', '')).toBe(
+      'Applied commit split plan.'
+    )
+  })
+})

--- a/src/commands/log/commitWorkflowActions.ts
+++ b/src/commands/log/commitWorkflowActions.ts
@@ -1,0 +1,135 @@
+import { Arguments } from 'yargs'
+import { SimpleGit } from 'simple-git'
+import { handler as commitHandler } from '../commit/handler'
+import { CommitOptions } from '../commit/config'
+import { loadConfig } from '../../lib/config/utils/loadConfig'
+import { createCommit, PreCommitHookError } from '../../lib/simple-git/createCommit'
+import { getRepo } from '../../lib/simple-git/getRepo'
+import { isCommandExitError } from '../../lib/utils/commandExit'
+import { Logger } from '../../lib/utils/logger'
+
+export type CommitWorkflowAction = 'commit' | 'split-plan' | 'split-apply'
+
+export type CommitWorkflowResult = {
+  ok: boolean
+  message: string
+}
+
+type CommitWorkflowInput = {
+  action: CommitWorkflowAction
+  git?: SimpleGit
+}
+
+type CommitWorkflowArgv = Arguments<CommitOptions> & {
+  mode: 'stdout'
+  noDiff: boolean
+  additional?: string
+  append?: string
+  appendTicket?: boolean
+}
+
+function createCommitWorkflowArgv(action: CommitWorkflowAction): CommitWorkflowArgv {
+  const split = action === 'split-plan' || action === 'split-apply'
+  const apply = action === 'split-apply'
+  const plan = action === 'split-plan'
+
+  return {
+    $0: 'coco',
+    _: split ? ['commit', 'split'] : ['commit'],
+    interactive: false,
+    verbose: false,
+    version: false,
+    help: false,
+    mode: 'stdout',
+    openInEditor: false,
+    ignoredFiles: [],
+    ignoredExtensions: [],
+    withPreviousCommits: 0,
+    conventional: false,
+    includeBranchName: true,
+    noVerify: false,
+    noDiff: false,
+    split,
+    plan,
+    apply,
+  } as CommitWorkflowArgv
+}
+
+function formatCommitWorkflowMessage(action: CommitWorkflowAction, output: string): string {
+  const normalized = output.trim()
+
+  if (normalized) {
+    return normalized.split('\n')[0]
+  }
+
+  if (action === 'split-plan') {
+    return 'Generated commit split plan.'
+  }
+
+  if (action === 'split-apply') {
+    return 'Applied commit split plan.'
+  }
+
+  return 'Generated commit message.'
+}
+
+function formatCommitFailure(error: unknown): string {
+  if (error instanceof PreCommitHookError) {
+    return `Commit blocked by hook: ${error.hookOutput.split('\n')[0]}`
+  }
+
+  return (error as Error).message
+}
+
+export async function runCommitWorkflow({
+  action,
+  git = getRepo(),
+}: CommitWorkflowInput): Promise<CommitWorkflowResult> {
+  const argv = createCommitWorkflowArgv(action)
+  const logger = new Logger({ silent: true })
+  const config = loadConfig<CommitOptions, CommitWorkflowArgv>(argv)
+  const originalWrite = process.stdout.write.bind(process.stdout)
+  let output = ''
+
+  process.stdout.write = ((chunk: string | Uint8Array, ...args: unknown[]) => {
+    output += typeof chunk === 'string' ? chunk : chunk.toString()
+
+    const callback = args.find((arg): arg is (error?: Error | null) => void => typeof arg === 'function')
+    callback?.()
+
+    return true
+  }) as typeof process.stdout.write
+
+  try {
+    await commitHandler(argv, logger)
+    const message = output.trim()
+
+    if (action === 'commit' && message) {
+      await createCommit(message, git, undefined, { noVerify: config.noVerify || false })
+    }
+
+    return {
+      ok: true,
+      message: formatCommitWorkflowMessage(action, output),
+    }
+  } catch (error) {
+    if (isCommandExitError(error)) {
+      return {
+        ok: error.code === 0,
+        message: output.trim() || error.message,
+      }
+    }
+
+    return {
+      ok: false,
+      message: formatCommitFailure(error),
+    }
+  } finally {
+    process.stdout.write = originalWrite
+  }
+}
+
+export const commitWorkflowTestInternals = {
+  createCommitWorkflowArgv,
+  formatCommitWorkflowMessage,
+}

--- a/src/commands/log/interactive.test.ts
+++ b/src/commands/log/interactive.test.ts
@@ -151,6 +151,9 @@ describe('log interactive renderer', () => {
     expect(output).toContain('Add PR workflow')
     expect(output).toContain('0.33.0')
     expect(output).toContain('Status: 1 staged, 1 unstaged, 1 untracked')
+    expect(output).toContain('c commit')
+    expect(output).toContain('S split plan')
+    expect(output).toContain('A split apply')
     expect(output).toContain('Keys:')
   })
 

--- a/src/commands/log/interactive.ts
+++ b/src/commands/log/interactive.ts
@@ -12,6 +12,7 @@ import {
   setUpstream,
 } from './branchActions'
 import { BranchOverview, BranchRef, getBranchOverview } from './branchData'
+import { runCommitWorkflow } from './commitWorkflowActions'
 import { GitCommitDetail, GitLogRow, getCommitDetail } from './data'
 import { createPullRequest, openPullRequest } from './pullRequestActions'
 import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
@@ -285,7 +286,7 @@ function renderStatusOverview(
     : []
   const actionLine = ui.pendingRevertFile
     ? `Pending revert: press Z to revert ${ui.pendingRevertFile}`
-    : 'Status actions: space stage/unstage | z revert selected file'
+    : 'Status actions: space stage/unstage | c commit | S split plan | A split apply | z revert'
 
   return [
     `Status: ${overview.stagedCount} staged, ${overview.unstagedCount} unstaged, ${overview.untrackedCount} untracked`,
@@ -635,8 +636,12 @@ export async function startInteractiveLog(
       void render()
     }
 
-    const runBranchAction = async (action: () => Promise<BranchActionResult>, refresh = true) => {
-      statusMessage = 'Running branch action...'
+    const runBranchAction = async (
+      action: () => Promise<BranchActionResult>,
+      refresh = true,
+      runningMessage = 'Running branch action...'
+    ) => {
+      statusMessage = runningMessage
       await render()
       await setActionResult(await action(), refresh)
     }
@@ -811,6 +816,24 @@ export async function startInteractiveLog(
         if (file && pendingRevertFile === file.path) {
           void runBranchAction(() => revertFile(git, file))
         }
+      } else if (key.name === 'c' && focus === 'status') {
+        void runBranchAction(
+          () => runCommitWorkflow({ action: 'commit', git }),
+          true,
+          'Generating commit message...'
+        )
+      } else if (sequence === 'S' && focus === 'status') {
+        void runBranchAction(
+          () => runCommitWorkflow({ action: 'split-plan', git }),
+          true,
+          'Generating commit split plan...'
+        )
+      } else if (sequence === 'A' && focus === 'status') {
+        void runBranchAction(
+          () => runCommitWorkflow({ action: 'split-apply', git }),
+          true,
+          'Applying commit split plan...'
+        )
       } else if (key.name === 'return' && focus === 'branches') {
         const branch = selectedBranch()
 


### PR DESCRIPTION
## Summary
- Add a log TUI adapter that runs the existing Coco commit handler in quiet stdout mode
- Create commits from TUI-generated commit messages through the existing createCommit helper
- Expose status-pane shortcuts for commit creation, split planning, and split apply

## Validation
- npm run test:jest -- src/commands/log/commitWorkflowActions.test.ts src/commands/log/interactive.test.ts
- npm run lint -- --max-warnings=0
- npm test
- npm run coco:ts -- log -i --limit 1

Refs #663