### PR TITLE
Add log TUI hunk staging

### DIFF
--- a/src/commands/log/interactive.test.ts
+++ b/src/commands/log/interactive.test.ts
@@ -5,6 +5,7 @@ import { BranchOverview } from './branchData'
 import { PullRequestOverview } from './pullRequestData'
 import { TagOverview, TagRangeSummary } from './tagData'
 import { WorktreeOverview } from './statusData'
+import { WorktreeHunkOverview } from './statusHunks'
 
 const rows: GitLogRow[] = [
   {
@@ -132,11 +133,26 @@ const worktree: WorktreeOverview = {
   ],
 }
 
+const statusHunks = {
+  filePath: 'unstaged.ts',
+  hunks: [
+    {
+      id: 'unstaged.ts::unstaged-hunk-1',
+      filePath: 'unstaged.ts',
+      state: 'unstaged',
+      header: '@@ -1,1 +1,1 @@',
+      preview: '-old +new',
+      patch: {},
+      hunk: {},
+    },
+  ],
+} as WorktreeHunkOverview
+
 describe('log interactive renderer', () => {
   it('renders commit navigation, selected details, changed files, and help', () => {
     const output = renderInteractiveLog(createLogTuiState(rows), detail, branches, pullRequest, tags, undefined, worktree, {}, {
       height: 70,
-      width: 100,
+      width: 140,
     })
 
     expect(output).toContain('coco log')
@@ -155,6 +171,34 @@ describe('log interactive renderer', () => {
     expect(output).toContain('S split plan')
     expect(output).toContain('A split apply')
     expect(output).toContain('Keys:')
+  })
+
+  it('renders selected file hunks and hunk staging controls', () => {
+    const output = renderInteractiveLog(
+      createLogTuiState(rows),
+      detail,
+      branches,
+      pullRequest,
+      tags,
+      undefined,
+      worktree,
+      {
+        focus: 'status',
+        statusIndex: 1,
+        statusHunks,
+        statusHunkIndex: 0,
+      },
+      {
+        height: 70,
+        width: 120,
+      }
+    )
+
+    expect(output).toContain('Focus: status')
+    expect(output).toContain('Hunks: unstaged.ts')
+    expect(output).toContain('> [U] @@ -1,1 +1,1 @@ -old +new')
+    expect(output).toContain('enter hunk')
+    expect(output).toContain('[/] hunk select')
   })
 
   it('renders branch focus, status, and pending delete prompts', () => {

--- a/src/commands/log/interactive.ts
+++ b/src/commands/log/interactive.ts
@@ -18,6 +18,7 @@ import { createPullRequest, openPullRequest } from './pullRequestActions'
 import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
 import { revertFile, stageFile, unstageFile } from './statusActions'
 import { WorktreeFile, WorktreeOverview, getWorktreeOverview } from './statusData'
+import { WorktreeHunkOverview, getWorktreeHunks, stageHunk, unstageHunk } from './statusHunks'
 import {
   createAnnotatedTag,
   createLightweightTag,
@@ -56,6 +57,8 @@ type LogTuiRenderUi = {
   pullRequestDraft?: boolean
   tagIndex?: number
   statusIndex?: number
+  statusHunks?: WorktreeHunkOverview
+  statusHunkIndex?: number
   pendingRevertFile?: string
 }
 
@@ -284,14 +287,28 @@ function renderStatusOverview(
   const hiddenFiles = overview.files.length > files.length
     ? [`  ... ${overview.files.length - files.length} more file(s)`]
     : []
+  const hunkOverview = ui.statusHunks
+  const hunkLines = hunkOverview?.hunks.length
+    ? hunkOverview.hunks.slice(0, 5).map((hunk, index) => {
+      const selected = ui.focus === 'status' && (ui.statusHunkIndex || 0) === index ? '>' : ' '
+      const state = hunk.state === 'staged' ? 'S' : 'U'
+      const preview = hunk.preview ? ` ${hunk.preview}` : ''
+
+      return `${selected} [${state}] ${hunk.header}${preview}`
+    })
+    : []
+  const hiddenHunks = hunkOverview && hunkOverview.hunks.length > hunkLines.length
+    ? [`  ... ${hunkOverview.hunks.length - hunkLines.length} more hunk(s)`]
+    : []
   const actionLine = ui.pendingRevertFile
     ? `Pending revert: press Z to revert ${ui.pendingRevertFile}`
-    : 'Status actions: space stage/unstage | c commit | S split plan | A split apply | z revert'
+    : 'Status actions: space file | enter hunk | [/] hunk select | c commit | S split plan | A split apply | z revert'
 
   return [
     `Status: ${overview.stagedCount} staged, ${overview.unstagedCount} unstaged, ${overview.untrackedCount} untracked`,
     ...(files.length ? files : ['  Worktree clean.']),
     ...hiddenFiles,
+    ...(hunkOverview ? [`Hunks: ${hunkOverview.filePath}`, ...hunkLines, ...hiddenHunks] : []),
     actionLine,
   ].map((line) => truncate(line, width))
 }
@@ -399,10 +416,12 @@ export async function startInteractiveLog(
   let tags: TagOverview | undefined
   let tagRangeSummary: TagRangeSummary | undefined
   let worktree: WorktreeOverview | undefined
+  let statusHunks: WorktreeHunkOverview | undefined
   let focus: LogTuiFocus = 'commits'
   let branchIndex = 0
   let tagIndex = 0
   let statusIndex = 0
+  let statusHunkIndex = 0
   let statusMessage: string | undefined
   let pendingDeleteBranch: string | undefined
   let pendingDeleteTag: string | undefined
@@ -485,6 +504,8 @@ export async function startInteractiveLog(
         pullRequestDraft,
         tagIndex,
         statusIndex,
+        statusHunks,
+        statusHunkIndex,
       }
 
       output.write(
@@ -548,6 +569,11 @@ export async function startInteractiveLog(
       statusIndex = Math.max(0, Math.min(statusIndex, (worktree?.files.length || 1) - 1))
     }
 
+    const refreshStatusHunks = async () => {
+      statusHunks = await getWorktreeHunks(git, worktree?.files[statusIndex])
+      statusHunkIndex = Math.max(0, Math.min(statusHunkIndex, (statusHunks?.hunks.length || 1) - 1))
+    }
+
     const setActionResult = async (result: BranchActionResult, refresh = true) => {
       statusMessage = result.message
       pendingDeleteBranch = undefined
@@ -563,6 +589,7 @@ export async function startInteractiveLog(
           refreshTags(),
           refreshWorktree(),
         ])
+        await refreshStatusHunks()
       }
 
       await render()
@@ -571,6 +598,7 @@ export async function startInteractiveLog(
     const selectedBranch = () => getBranchList(branches)[branchIndex]
     const selectedTag = () => tags?.tags[tagIndex]
     const selectedStatusFile = (): WorktreeFile | undefined => worktree?.files[statusIndex]
+    const selectedStatusHunk = () => statusHunks?.hunks[statusHunkIndex]
 
     const selectedRef = () => {
       if (focus === 'branches') {
@@ -632,7 +660,16 @@ export async function startInteractiveLog(
       const fileCount = worktree?.files.length || 0
 
       statusIndex = Math.max(0, Math.min(statusIndex + delta, fileCount - 1))
+      statusHunkIndex = 0
+      statusHunks = undefined
       pendingRevertFile = undefined
+      void refreshStatusHunks().then(render)
+    }
+
+    const moveStatusHunkSelection = (delta: number) => {
+      const hunkCount = statusHunks?.hunks.length || 0
+
+      statusHunkIndex = Math.max(0, Math.min(statusHunkIndex + delta, hunkCount - 1))
       void render()
     }
 
@@ -796,6 +833,35 @@ export async function startInteractiveLog(
         moveStatusSelection(-1)
       } else if ((key.name === 'down' || key.name === 'j') && focus === 'status') {
         moveStatusSelection(1)
+      } else if ((sequence === '[' || key.name === 'left') && focus === 'status') {
+        moveStatusHunkSelection(-1)
+      } else if ((sequence === ']' || key.name === 'right') && focus === 'status') {
+        moveStatusHunkSelection(1)
+      } else if (key.name === 'return' && focus === 'status') {
+        const hunk = selectedStatusHunk()
+
+        if (hunk) {
+          void runBranchAction(async () => {
+            if (hunk.state === 'staged') {
+              await unstageHunk(git, hunk)
+
+              return {
+                ok: true,
+                message: `Unstaged hunk in ${hunk.filePath}`,
+              }
+            }
+
+            await stageHunk(git, hunk)
+
+            return {
+              ok: true,
+              message: `Staged hunk in ${hunk.filePath}`,
+            }
+          })
+        } else {
+          statusMessage = 'No selectable hunk for the selected file.'
+          void render()
+        }
       } else if (key.name === 'space' && focus === 'status') {
         const file = selectedStatusFile()
 
@@ -868,6 +934,7 @@ export async function startInteractiveLog(
             refreshTags(),
             refreshWorktree(),
           ])
+          await refreshStatusHunks()
 
           return {
             ok: true,
@@ -1029,14 +1096,16 @@ export async function startInteractiveLog(
       refreshTags(),
       refreshWorktree(),
     ])
-      .then(() => {
-        void render()
+      .then(async () => {
+        await refreshStatusHunks()
+        await render()
       })
       .catch(() => {
         branches = undefined
         pullRequest = undefined
         tags = undefined
         worktree = undefined
+        statusHunks = undefined
       })
     void render()
   })

--- a/src/commands/log/statusHunks.test.ts
+++ b/src/commands/log/statusHunks.test.ts
@@ -1,0 +1,134 @@
+import { EventEmitter } from 'events'
+import { spawn } from 'child_process'
+import {
+  getWorktreeHunks,
+  stageHunk,
+  statusHunkTestInternals,
+  unstageHunk,
+} from './statusHunks'
+import { WorktreeFile } from './statusData'
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn(),
+}))
+
+const mockedSpawn = spawn as jest.MockedFunction<typeof spawn>
+
+const unstagedFile: WorktreeFile = {
+  path: 'src/file.ts',
+  indexStatus: ' ',
+  worktreeStatus: 'M',
+  state: 'unstaged',
+}
+
+const stagedFile: WorktreeFile = {
+  path: 'src/file.ts',
+  indexStatus: 'M',
+  worktreeStatus: ' ',
+  state: 'staged',
+}
+
+const diff = [
+  'diff --git a/src/file.ts b/src/file.ts',
+  'index 1111111..2222222 100644',
+  '--- a/src/file.ts',
+  '+++ b/src/file.ts',
+  '@@ -1,3 +1,3 @@',
+  ' const value = 1',
+  '-const oldName = true',
+  '+const newName = true',
+  ' export { value }',
+  '',
+].join('\n')
+
+function createGit(diffOutput = diff) {
+  return {
+    diff: jest.fn().mockResolvedValue(diffOutput),
+    revparse: jest.fn().mockResolvedValue('/repo'),
+  }
+}
+
+function mockSpawnSuccess() {
+  const child = new EventEmitter() as EventEmitter & {
+    stderr: EventEmitter
+    stdin: {
+      write: jest.Mock
+      end: jest.Mock
+    }
+  }
+  child.stderr = new EventEmitter()
+  child.stdin = {
+    write: jest.fn(),
+    end: jest.fn(),
+  }
+
+  mockedSpawn.mockReturnValue(child as never)
+
+  return child
+}
+
+describe('log status hunks', () => {
+  beforeEach(() => {
+    mockedSpawn.mockReset()
+  })
+
+  it('loads unstaged hunks for files with worktree changes', async () => {
+    const git = createGit()
+
+    const overview = await getWorktreeHunks(git as never, unstagedFile)
+
+    expect(git.diff).toHaveBeenCalledWith(['--', 'src/file.ts'])
+    expect(overview?.hunks).toHaveLength(1)
+    expect(overview?.hunks[0]).toMatchObject({
+      id: 'src/file.ts::unstaged-hunk-1',
+      filePath: 'src/file.ts',
+      state: 'unstaged',
+      header: '@@ -1,3 +1,3 @@',
+    })
+  })
+
+  it('loads staged hunks for files with index changes', async () => {
+    const git = createGit()
+
+    const overview = await getWorktreeHunks(git as never, stagedFile)
+
+    expect(git.diff).toHaveBeenCalledWith(['--staged', '--', 'src/file.ts'])
+    expect(overview?.hunks[0].state).toBe('staged')
+  })
+
+  it('does not load hunks for untracked files', async () => {
+    const git = createGit()
+
+    await expect(getWorktreeHunks(git as never, {
+      ...unstagedFile,
+      indexStatus: '?',
+      worktreeStatus: '?',
+      state: 'untracked',
+    })).resolves.toBeUndefined()
+    expect(git.diff).not.toHaveBeenCalled()
+  })
+
+  it('stages and unstages single hunks through git apply cached', async () => {
+    const git = createGit()
+    const child = mockSpawnSuccess()
+    const [unstagedHunk] = statusHunkTestInternals.parseHunks('src/file.ts', 'unstaged', diff)
+    const [stagedHunk] = statusHunkTestInternals.parseHunks('src/file.ts', 'staged', diff)
+
+    const stagePromise = stageHunk(git as never, unstagedHunk)
+    setImmediate(() => child.emit('close', 0))
+    await stagePromise
+
+    const unstagePromise = unstageHunk(git as never, stagedHunk)
+    setImmediate(() => child.emit('close', 0))
+    await unstagePromise
+
+    expect(mockedSpawn).toHaveBeenNthCalledWith(1, 'git', ['apply', '--cached', '-'], {
+      cwd: '/repo',
+      stdio: ['pipe', 'ignore', 'pipe'],
+    })
+    expect(mockedSpawn).toHaveBeenNthCalledWith(2, 'git', ['apply', '--cached', '--reverse', '-'], {
+      cwd: '/repo',
+      stdio: ['pipe', 'ignore', 'pipe'],
+    })
+  })
+})

--- a/src/commands/log/statusHunks.ts
+++ b/src/commands/log/statusHunks.ts
@@ -1,0 +1,145 @@
+import { spawn } from 'child_process'
+import { formatPatch, parsePatch, StructuredPatch, StructuredPatchHunk } from 'diff'
+import { SimpleGit } from 'simple-git'
+import { WorktreeFile } from './statusData'
+
+export type WorktreeHunkState = 'staged' | 'unstaged'
+
+export type WorktreeHunk = {
+  id: string
+  filePath: string
+  state: WorktreeHunkState
+  patch: StructuredPatch
+  hunk: StructuredPatchHunk
+  header: string
+  preview: string
+}
+
+export type WorktreeHunkOverview = {
+  filePath: string
+  hunks: WorktreeHunk[]
+}
+
+function hunkHeader(hunk: StructuredPatchHunk): string {
+  return `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`
+}
+
+function hunkPreview(hunk: StructuredPatchHunk): string {
+  return hunk.lines
+    .filter((line) => line.startsWith('+') || line.startsWith('-'))
+    .slice(0, 4)
+    .join(' ')
+}
+
+function hunkId(filePath: string, state: WorktreeHunkState, index: number): string {
+  return `${filePath}::${state}-hunk-${index + 1}`
+}
+
+function parseHunks(filePath: string, state: WorktreeHunkState, diff: string): WorktreeHunk[] {
+  const [patch] = parsePatch(diff)
+
+  if (!patch) {
+    return []
+  }
+
+  return patch.hunks.map((hunk, index) => ({
+    id: hunkId(filePath, state, index),
+    filePath,
+    state,
+    patch,
+    hunk,
+    header: hunkHeader(hunk),
+    preview: hunkPreview(hunk),
+  }))
+}
+
+function patchForHunk(hunk: WorktreeHunk): string {
+  return formatPatch({
+    ...hunk.patch,
+    hunks: [hunk.hunk],
+  })
+}
+
+async function applyPatchToIndex(
+  git: SimpleGit,
+  patch: string,
+  options: { reverse?: boolean } = {}
+): Promise<void> {
+  const cwd = await git.revparse(['--show-toplevel'])
+  const args = ['apply', '--cached', '-']
+
+  if (options.reverse) {
+    args.splice(2, 0, '--reverse')
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn('git', args, {
+      cwd,
+      stdio: ['pipe', 'ignore', 'pipe'],
+    })
+    let stderr = ''
+
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk)
+    })
+
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve()
+        return
+      }
+
+      reject(new Error(`Failed to apply hunk to index: ${stderr.trim()}`))
+    })
+
+    child.stdin.write(patch)
+    child.stdin.end()
+  })
+}
+
+export async function getWorktreeHunks(
+  git: SimpleGit,
+  file: WorktreeFile | undefined
+): Promise<WorktreeHunkOverview | undefined> {
+  if (!file || file.state === 'untracked') {
+    return undefined
+  }
+
+  const stagedDiff = file.indexStatus.trim()
+    ? await git.diff(['--staged', '--', file.path])
+    : ''
+  const unstagedDiff = file.worktreeStatus.trim()
+    ? await git.diff(['--', file.path])
+    : ''
+  const hunks = [
+    ...parseHunks(file.path, 'staged', stagedDiff),
+    ...parseHunks(file.path, 'unstaged', unstagedDiff),
+  ]
+
+  return {
+    filePath: file.path,
+    hunks,
+  }
+}
+
+export async function stageHunk(git: SimpleGit, hunk: WorktreeHunk): Promise<void> {
+  if (hunk.state !== 'unstaged') {
+    throw new Error('Only unstaged hunks can be staged.')
+  }
+
+  await applyPatchToIndex(git, patchForHunk(hunk))
+}
+
+export async function unstageHunk(git: SimpleGit, hunk: WorktreeHunk): Promise<void> {
+  if (hunk.state !== 'staged') {
+    throw new Error('Only staged hunks can be unstaged.')
+  }
+
+  await applyPatchToIndex(git, patchForHunk(hunk), { reverse: true })
+}
+
+export const statusHunkTestInternals = {
+  parseHunks,
+  patchForHunk,
+}


### PR DESCRIPTION
## Summary
- Add selected-file hunk parsing for staged and unstaged worktree changes
- Stage and unstage individual hunks through cached git apply operations
- Render hunk previews in the log TUI status panel with hunk navigation and enter-to-toggle behavior

## Validation
- npm run test:jest -- src/commands/log/statusHunks.test.ts src/commands/log/interactive.test.ts src/commands/log/statusActions.test.ts
- npm run lint -- --max-warnings=0
- npm test
- npm run coco:ts -- log -i --limit 1

Refs #663