### PR TITLE
Add log TUI amend and reword actions

### DIFF
--- a/src/commands/log/historyActions.test.ts
+++ b/src/commands/log/historyActions.test.ts
@@ -1,0 +1,75 @@
+import {
+  amendHeadCommit,
+  historyActionTestInternals,
+  rewordHeadCommit,
+} from './historyActions'
+
+describe('log history actions', () => {
+  it('matches full and short selected hashes against HEAD', async () => {
+    const git = {
+      revparse: jest.fn().mockResolvedValue('abcdef1234567890\n'),
+    }
+
+    await expect(historyActionTestInternals.isHeadCommit(git as never, 'abcdef1234567890')).resolves.toBe(true)
+    await expect(historyActionTestInternals.isHeadCommit(git as never, 'abcdef1')).resolves.toBe(true)
+    await expect(historyActionTestInternals.isHeadCommit(git as never, '1234567')).resolves.toBe(false)
+  })
+
+  it('amends HEAD with staged changes', async () => {
+    const git = {
+      revparse: jest.fn().mockResolvedValue('abcdef1234567890'),
+      raw: jest.fn().mockResolvedValue(''),
+    }
+
+    await expect(amendHeadCommit(git as never, 'abcdef1')).resolves.toEqual({
+      ok: true,
+      message: 'Amended HEAD with staged changes',
+    })
+
+    expect(git.raw).toHaveBeenCalledWith(['commit', '--amend', '--no-edit'])
+  })
+
+  it('rewords HEAD with a trimmed message', async () => {
+    const git = {
+      revparse: jest.fn().mockResolvedValue('abcdef1234567890'),
+      raw: jest.fn().mockResolvedValue(''),
+    }
+
+    await expect(rewordHeadCommit(git as never, 'abcdef1', '  feat: better title  ')).resolves.toEqual({
+      ok: true,
+      message: 'Reworded HEAD commit',
+    })
+
+    expect(git.raw).toHaveBeenCalledWith(['commit', '--amend', '-m', 'feat: better title'])
+  })
+
+  it('guards non-HEAD history edits', async () => {
+    const git = {
+      revparse: jest.fn().mockResolvedValue('abcdef1234567890'),
+      raw: jest.fn(),
+    }
+
+    await expect(amendHeadCommit(git as never, '1234567')).resolves.toEqual({
+      ok: false,
+      message: 'Amend is limited to HEAD. Select the latest commit first.',
+    })
+    await expect(rewordHeadCommit(git as never, '1234567', 'feat: title')).resolves.toEqual({
+      ok: false,
+      message: 'Reword is limited to HEAD. Select the latest commit first.',
+    })
+    expect(git.raw).not.toHaveBeenCalled()
+  })
+
+  it('rejects empty reword messages before invoking git', async () => {
+    const git = {
+      revparse: jest.fn().mockResolvedValue('abcdef1234567890'),
+      raw: jest.fn(),
+    }
+
+    await expect(rewordHeadCommit(git as never, 'abcdef1', '   ')).resolves.toEqual({
+      ok: false,
+      message: 'Reword cancelled: empty message.',
+    })
+    expect(git.raw).not.toHaveBeenCalled()
+  })
+})

--- a/src/commands/log/historyActions.ts
+++ b/src/commands/log/historyActions.ts
@@ -1,0 +1,74 @@
+import { SimpleGit } from 'simple-git'
+import { BranchActionResult } from './branchActions'
+
+async function runAction(action: () => Promise<unknown>, successMessage: string): Promise<BranchActionResult> {
+  try {
+    await action()
+
+    return {
+      ok: true,
+      message: successMessage,
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      message: (error as Error).message,
+    }
+  }
+}
+
+async function isHeadCommit(git: SimpleGit, commitHash: string): Promise<boolean> {
+  const head = await git.revparse(['HEAD'])
+  const normalizedHead = head.trim()
+  const normalizedCommit = commitHash.trim()
+
+  return normalizedHead === normalizedCommit || normalizedHead.startsWith(normalizedCommit)
+}
+
+export async function amendHeadCommit(
+  git: SimpleGit,
+  selectedCommitHash: string | undefined
+): Promise<BranchActionResult> {
+  if (!selectedCommitHash || !(await isHeadCommit(git, selectedCommitHash))) {
+    return {
+      ok: false,
+      message: 'Amend is limited to HEAD. Select the latest commit first.',
+    }
+  }
+
+  return runAction(
+    () => git.raw(['commit', '--amend', '--no-edit']),
+    'Amended HEAD with staged changes'
+  )
+}
+
+export async function rewordHeadCommit(
+  git: SimpleGit,
+  selectedCommitHash: string | undefined,
+  message: string
+): Promise<BranchActionResult> {
+  const trimmedMessage = message.trim()
+
+  if (!selectedCommitHash || !(await isHeadCommit(git, selectedCommitHash))) {
+    return {
+      ok: false,
+      message: 'Reword is limited to HEAD. Select the latest commit first.',
+    }
+  }
+
+  if (!trimmedMessage) {
+    return {
+      ok: false,
+      message: 'Reword cancelled: empty message.',
+    }
+  }
+
+  return runAction(
+    () => git.raw(['commit', '--amend', '-m', trimmedMessage]),
+    'Reworded HEAD commit'
+  )
+}
+
+export const historyActionTestInternals = {
+  isHeadCommit,
+}

--- a/src/commands/log/interactive.test.ts
+++ b/src/commands/log/interactive.test.ts
@@ -168,9 +168,12 @@ describe('log interactive renderer', () => {
     expect(output).toContain('0.33.0')
     expect(output).toContain('Status: 1 staged, 1 unstaged, 1 untracked')
     expect(output).toContain('c commit')
+    expect(output).toContain('e amend')
+    expect(output).toContain('w reword')
     expect(output).toContain('S split plan')
     expect(output).toContain('A split apply')
     expect(output).toContain('Keys:')
+    expect(output).toContain('Commit actions: e amend HEAD | w reword HEAD')
   })
 
   it('renders selected file hunks and hunk staging controls', () => {
@@ -265,6 +268,35 @@ describe('log interactive renderer', () => {
     expect(output).toContain('Pull request: no PR for feature/log-prs')
   })
 
+  it('renders reword prompts as a focused commit action', () => {
+    const output = renderInteractiveLog(
+      createLogTuiState(rows),
+      detail,
+      branches,
+      pullRequest,
+      tags,
+      undefined,
+      worktree,
+      {
+        focus: 'commits',
+        inputPrompt: {
+          kind: 'reword-commit',
+          label: 'Reword HEAD',
+          value: 'feat: updated title',
+          sourceRef: 'abc1234',
+          commitHash: 'abc1234',
+        },
+      },
+      {
+        height: 70,
+        width: 120,
+      }
+    )
+
+    expect(output).toContain('Reword HEAD: feat: updated title_')
+    expect(output).toContain('Commit actions: e amend HEAD | w reword HEAD')
+  })
+
   it('renders PR create prompts and draft mode', () => {
     const output = renderInteractiveLog(
       createLogTuiState(rows),
@@ -344,6 +376,5 @@ describe('log interactive renderer', () => {
     expect(output).toContain('Focus: status')
     expect(output).toContain('>  M unstaged.ts')
     expect(output).toContain('Pending revert: press Z to revert unstaged.ts')
-    expect(output).toContain('space stage')
   })
 })

--- a/src/commands/log/interactive.ts
+++ b/src/commands/log/interactive.ts
@@ -14,6 +14,7 @@ import {
 import { BranchOverview, BranchRef, getBranchOverview } from './branchData'
 import { runCommitWorkflow } from './commitWorkflowActions'
 import { GitCommitDetail, GitLogRow, getCommitDetail } from './data'
+import { amendHeadCommit, rewordHeadCommit } from './historyActions'
 import { createPullRequest, openPullRequest } from './pullRequestActions'
 import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
 import { revertFile, stageFile, unstageFile } from './statusActions'
@@ -62,7 +63,13 @@ type LogTuiRenderUi = {
   pendingRevertFile?: string
 }
 
-type LogTuiInputKind = 'create-branch' | 'rename-branch' | 'create-pr-title' | 'create-tag' | 'create-annotated-tag'
+type LogTuiInputKind =
+  | 'create-branch'
+  | 'rename-branch'
+  | 'create-pr-title'
+  | 'create-tag'
+  | 'create-annotated-tag'
+  | 'reword-commit'
 
 type LogTuiInputPrompt = {
   kind: LogTuiInputKind
@@ -72,6 +79,7 @@ type LogTuiInputPrompt = {
   branchName?: string
   baseRef?: string
   tagName?: string
+  commitHash?: string
 }
 
 const DEFAULT_HEIGHT = 70
@@ -359,8 +367,11 @@ export function renderInteractiveLog(
   const graphMode = state.fullGraph ? 'full graph' : 'compact graph'
   const focus = ui.focus || 'commits'
   const help = state.showHelp
-    ? 'Keys: tab focus | up/down move | space stage | n branch | t tag | C PR | f fetch | q quit'
+    ? 'Keys: tab focus | up/down move | n branch | t tag | C PR | c commit | e amend | w reword | q quit'
     : 'Press ? for help'
+  const commitActions = focus === 'commits'
+    ? 'Commit actions: e amend HEAD | w reword HEAD'
+    : ''
   const detailHeader = selected
     ? `Selected: ${selected.shortHash} ${selected.message}`
     : 'Selected: none'
@@ -386,6 +397,7 @@ export function renderInteractiveLog(
     'coco log',
     `${state.filteredCommits.length}/${state.commits.length} commits | Focus: ${focus} | ${filterPrompt} | ${graphMode}`,
     help,
+    commitActions,
     ui.statusMessage ? truncate(`Status: ${ui.statusMessage}`, width) : '',
     ui.inputPrompt ? truncate(`${ui.inputPrompt.label}: ${ui.inputPrompt.value}_`, width) : '',
     '',
@@ -733,6 +745,12 @@ export async function startInteractiveLog(
         await runBranchAction(() => createLightweightTag(git, value, prompt.sourceRef))
       } else if (prompt.kind === 'create-annotated-tag') {
         await runBranchAction(() => createAnnotatedTag(git, value, prompt.sourceRef, `release ${value}`))
+      } else if (prompt.kind === 'reword-commit' && prompt.commitHash) {
+        await runBranchAction(
+          () => rewordHeadCommit(git, prompt.commitHash as string, value),
+          true,
+          'Rewording HEAD commit...'
+        )
       }
     }
 
@@ -900,6 +918,26 @@ export async function startInteractiveLog(
           true,
           'Applying commit split plan...'
         )
+      } else if (key.name === 'e') {
+        const selected = getSelectedCommit(state)
+
+        void runBranchAction(
+          () => amendHeadCommit(git, selected?.hash),
+          true,
+          'Amending HEAD commit...'
+        )
+      } else if (key.name === 'w') {
+        const selected = getSelectedCommit(state)
+
+        if (selected) {
+          startInputPrompt({
+            kind: 'reword-commit',
+            label: 'Reword HEAD',
+            value: selected.message,
+            sourceRef: selected.hash,
+            commitHash: selected.hash,
+          })
+        }
       } else if (key.name === 'return' && focus === 'branches') {
         const branch = selectedBranch()
 


### PR DESCRIPTION
## Summary
- Add HEAD-only amend and reword helpers for the log TUI
- Surface concise commit-focused controls without expanding the status pane
- Guard non-HEAD history edits with clear status messages instead of starting risky history rewrites

## UX notes
- Kept the history-edit controls contextual to commit focus so the working-tree panel stays low-noise
- Used a prompt for rewording and a direct action for amend-with-staged-changes

## Validation
- npm run test:jest -- src/commands/log/historyActions.test.ts src/commands/log/interactive.test.ts
- npm run lint -- --max-warnings=0
- npm test
- npm run coco:ts -- log -i --limit 1

Refs #663