### PR TITLE
Surface log TUI validation and hook feedback

### DIFF
--- a/src/commands/log/branchActions.ts
+++ b/src/commands/log/branchActions.ts
@@ -4,6 +4,7 @@ import { BranchRef } from './branchData'
 export type BranchActionResult = {
   ok: boolean
   message: string
+  details?: string[]
 }
 
 function localNameFromRemote(remoteBranch: string): string {

--- a/src/commands/log/commitWorkflowActions.test.ts
+++ b/src/commands/log/commitWorkflowActions.test.ts
@@ -113,4 +113,42 @@ describe('log commit workflow actions', () => {
       'Applied commit split plan.'
     )
   })
+
+  it('returns hook output as structured feedback details', async () => {
+    mockedCommitHandler.mockImplementation(async () => {
+      process.stdout.write('feat: generated message\n')
+    })
+    mockedCreateCommit.mockRejectedValue(new Error([
+      'Pre-commit hook failed',
+      'eslint failed',
+      'src/file.ts:1:1 error',
+    ].join('\n')))
+
+    await expect(runCommitWorkflow({ action: 'commit', git })).resolves.toEqual({
+      ok: false,
+      message: 'Pre-commit hook failed',
+      details: [
+        'eslint failed',
+        'src/file.ts:1:1 error',
+      ],
+    })
+  })
+
+  it('splits command-exit output into a status message and details', async () => {
+    mockedCommitHandler.mockImplementation(async () => {
+      process.stdout.write('Commitlint failed\nsubject may not be empty\nbody may not be empty\n')
+
+      const { CommandExitError } = await import('../../lib/utils/commandExit')
+      throw new CommandExitError(1)
+    })
+
+    await expect(runCommitWorkflow({ action: 'commit', git })).resolves.toEqual({
+      ok: false,
+      message: 'Commitlint failed',
+      details: [
+        'subject may not be empty',
+        'body may not be empty',
+      ],
+    })
+  })
 })

--- a/src/commands/log/commitWorkflowActions.ts
+++ b/src/commands/log/commitWorkflowActions.ts
@@ -13,6 +13,7 @@ export type CommitWorkflowAction = 'commit' | 'split-plan' | 'split-apply'
 export type CommitWorkflowResult = {
   ok: boolean
   message: string
+  details?: string[]
 }
 
 type CommitWorkflowInput = {
@@ -73,12 +74,31 @@ function formatCommitWorkflowMessage(action: CommitWorkflowAction, output: strin
   return 'Generated commit message.'
 }
 
-function formatCommitFailure(error: unknown): string {
+function compactOutputLines(output: string): string[] {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+function formatCommitFailure(error: unknown): CommitWorkflowResult {
   if (error instanceof PreCommitHookError) {
-    return `Commit blocked by hook: ${error.hookOutput.split('\n')[0]}`
+    const details = compactOutputLines(error.hookOutput)
+
+    return {
+      ok: false,
+      message: `Commit blocked by hook: ${details[0] || 'hook failed'}`,
+      details: details.slice(1, 6),
+    }
   }
 
-  return (error as Error).message
+  const details = compactOutputLines((error as Error).message)
+
+  return {
+    ok: false,
+    message: details[0] || 'Commit action failed.',
+    details: details.slice(1, 6),
+  }
 }
 
 export async function runCommitWorkflow({
@@ -114,22 +134,24 @@ export async function runCommitWorkflow({
     }
   } catch (error) {
     if (isCommandExitError(error)) {
+      const lines = compactOutputLines(output || error.message)
+
       return {
         ok: error.code === 0,
-        message: output.trim() || error.message,
+        message: lines[0] || error.message,
+        details: lines.slice(1, 6),
       }
     }
 
-    return {
-      ok: false,
-      message: formatCommitFailure(error),
-    }
+    return formatCommitFailure(error)
   } finally {
     process.stdout.write = originalWrite
   }
 }
 
 export const commitWorkflowTestInternals = {
+  compactOutputLines,
   createCommitWorkflowArgv,
+  formatCommitFailure,
   formatCommitWorkflowMessage,
 }

--- a/src/commands/log/historyActions.test.ts
+++ b/src/commands/log/historyActions.test.ts
@@ -72,4 +72,24 @@ describe('log history actions', () => {
     })
     expect(git.raw).not.toHaveBeenCalled()
   })
+
+  it('returns hook and validation failures as structured details', async () => {
+    const git = {
+      revparse: jest.fn().mockResolvedValue('abcdef1234567890'),
+      raw: jest.fn().mockRejectedValue(new Error([
+        'commit-msg hook failed',
+        'subject must be lower-case',
+        'type must be one of feat, fix',
+      ].join('\n'))),
+    }
+
+    await expect(amendHeadCommit(git as never, 'abcdef1')).resolves.toEqual({
+      ok: false,
+      message: 'commit-msg hook failed',
+      details: [
+        'subject must be lower-case',
+        'type must be one of feat, fix',
+      ],
+    })
+  })
 })

--- a/src/commands/log/historyActions.ts
+++ b/src/commands/log/historyActions.ts
@@ -1,6 +1,13 @@
 import { SimpleGit } from 'simple-git'
 import { BranchActionResult } from './branchActions'
 
+function compactOutputLines(output: string): string[] {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
 async function runAction(action: () => Promise<unknown>, successMessage: string): Promise<BranchActionResult> {
   try {
     await action()
@@ -10,9 +17,12 @@ async function runAction(action: () => Promise<unknown>, successMessage: string)
       message: successMessage,
     }
   } catch (error) {
+    const lines = compactOutputLines((error as Error).message)
+
     return {
       ok: false,
-      message: (error as Error).message,
+      message: lines[0] || 'History action failed.',
+      details: lines.slice(1, 6),
     }
   }
 }
@@ -70,5 +80,6 @@ export async function rewordHeadCommit(
 }
 
 export const historyActionTestInternals = {
+  compactOutputLines,
   isHeadCommit,
 }

--- a/src/commands/log/interactive.test.ts
+++ b/src/commands/log/interactive.test.ts
@@ -204,6 +204,32 @@ describe('log interactive renderer', () => {
     expect(output).toContain('[/] hunk select')
   })
 
+  it('renders selected hunk revert confirmation without extra chrome', () => {
+    const output = renderInteractiveLog(
+      createLogTuiState(rows),
+      detail,
+      branches,
+      pullRequest,
+      tags,
+      undefined,
+      worktree,
+      {
+        focus: 'status',
+        statusIndex: 1,
+        statusHunks,
+        statusHunkIndex: 0,
+        pendingRevertHunk: 'unstaged.ts::unstaged-hunk-1',
+      },
+      {
+        height: 70,
+        width: 120,
+      }
+    )
+
+    expect(output).toContain('Pending hunk revert: press Z to revert selected hunk')
+    expect(output).toContain('> [U] @@ -1,1 +1,1 @@ -old +new')
+  })
+
   it('renders branch focus, status, and pending delete prompts', () => {
     const output = renderInteractiveLog(
       createLogTuiState(rows),
@@ -229,6 +255,34 @@ describe('log interactive renderer', () => {
     expect(output).toContain('Status: Press D to confirm deleting main')
     expect(output).toContain('Pending delete: press D to delete main')
     expect(output).toContain('>* main +1/-2 vs origin/main')
+  })
+
+  it('renders concise action feedback details below the status line', () => {
+    const output = renderInteractiveLog(
+      createLogTuiState(rows),
+      detail,
+      branches,
+      pullRequest,
+      tags,
+      undefined,
+      worktree,
+      {
+        focus: 'status',
+        statusMessage: 'Commit blocked by hook: eslint failed',
+        statusDetails: [
+          'src/file.ts:1:1 error no-unused-vars',
+          'Run npm run lint before committing',
+        ],
+      },
+      {
+        height: 70,
+        width: 120,
+      }
+    )
+
+    expect(output).toContain('Status: Commit blocked by hook: eslint failed')
+    expect(output).toContain('  src/file.ts:1:1 error no-unused-vars')
+    expect(output).toContain('  Run npm run lint before committing')
   })
 
   it('renders branch input prompts for create and rename actions', () => {

--- a/src/commands/log/interactive.ts
+++ b/src/commands/log/interactive.ts
@@ -19,7 +19,7 @@ import { createPullRequest, openPullRequest } from './pullRequestActions'
 import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
 import { revertFile, stageFile, unstageFile } from './statusActions'
 import { WorktreeFile, WorktreeOverview, getWorktreeOverview } from './statusData'
-import { WorktreeHunkOverview, getWorktreeHunks, stageHunk, unstageHunk } from './statusHunks'
+import { WorktreeHunkOverview, getWorktreeHunks, revertHunk, stageHunk, unstageHunk } from './statusHunks'
 import {
   createAnnotatedTag,
   createLightweightTag,
@@ -51,6 +51,7 @@ type LogTuiRenderUi = {
   focus?: LogTuiFocus
   branchIndex?: number
   statusMessage?: string
+  statusDetails?: string[]
   pendingDeleteBranch?: string
   pendingDeleteTag?: string
   pendingDeleteRemoteTag?: string
@@ -61,6 +62,7 @@ type LogTuiRenderUi = {
   statusHunks?: WorktreeHunkOverview
   statusHunkIndex?: number
   pendingRevertFile?: string
+  pendingRevertHunk?: string
 }
 
 type LogTuiInputKind =
@@ -310,6 +312,8 @@ function renderStatusOverview(
     : []
   const actionLine = ui.pendingRevertFile
     ? `Pending revert: press Z to revert ${ui.pendingRevertFile}`
+    : ui.pendingRevertHunk
+      ? 'Pending hunk revert: press Z to revert selected hunk'
     : 'Status actions: space file | enter hunk | [/] hunk select | c commit | S split plan | A split apply | z revert'
 
   return [
@@ -399,6 +403,7 @@ export function renderInteractiveLog(
     help,
     commitActions,
     ui.statusMessage ? truncate(`Status: ${ui.statusMessage}`, width) : '',
+    ...(ui.statusDetails || []).slice(0, 4).map((line) => truncate(`  ${line}`, width)),
     ui.inputPrompt ? truncate(`${ui.inputPrompt.label}: ${ui.inputPrompt.value}_`, width) : '',
     '',
     ...branchLines,
@@ -435,10 +440,12 @@ export async function startInteractiveLog(
   let statusIndex = 0
   let statusHunkIndex = 0
   let statusMessage: string | undefined
+  let statusDetails: string[] | undefined
   let pendingDeleteBranch: string | undefined
   let pendingDeleteTag: string | undefined
   let pendingDeleteRemoteTag: string | undefined
   let pendingRevertFile: string | undefined
+  let pendingRevertHunk: string | undefined
   let inputPrompt: LogTuiInputPrompt | undefined
   let pullRequestDraft = false
 
@@ -508,10 +515,12 @@ export async function startInteractiveLog(
         focus,
         branchIndex,
         statusMessage,
+        statusDetails,
         pendingDeleteBranch,
         pendingDeleteTag,
         pendingDeleteRemoteTag,
         pendingRevertFile,
+        pendingRevertHunk,
         inputPrompt,
         pullRequestDraft,
         tagIndex,
@@ -588,10 +597,12 @@ export async function startInteractiveLog(
 
     const setActionResult = async (result: BranchActionResult, refresh = true) => {
       statusMessage = result.message
+      statusDetails = result.details
       pendingDeleteBranch = undefined
       pendingDeleteTag = undefined
       pendingDeleteRemoteTag = undefined
       pendingRevertFile = undefined
+      pendingRevertHunk = undefined
       inputPrompt = undefined
 
       if (refresh) {
@@ -675,6 +686,7 @@ export async function startInteractiveLog(
       statusHunkIndex = 0
       statusHunks = undefined
       pendingRevertFile = undefined
+      pendingRevertHunk = undefined
       void refreshStatusHunks().then(render)
     }
 
@@ -698,10 +710,12 @@ export async function startInteractiveLog(
     const startInputPrompt = (prompt: LogTuiInputPrompt) => {
       inputPrompt = prompt
       statusMessage = undefined
+      statusDetails = undefined
       pendingDeleteBranch = undefined
       pendingDeleteTag = undefined
       pendingDeleteRemoteTag = undefined
       pendingRevertFile = undefined
+      pendingRevertHunk = undefined
       void render()
     }
 
@@ -717,6 +731,7 @@ export async function startInteractiveLog(
 
       if (!value) {
         statusMessage = 'Branch action cancelled: empty value'
+        statusDetails = undefined
         await render()
         return
       }
@@ -730,6 +745,7 @@ export async function startInteractiveLog(
 
         if (!head) {
           statusMessage = 'Cannot create pull request without a current branch.'
+          statusDetails = undefined
           await render()
           return
         }
@@ -767,6 +783,7 @@ export async function startInteractiveLog(
       if (key.name === 'escape') {
         inputPrompt = undefined
         statusMessage = 'Branch action cancelled'
+        statusDetails = undefined
         void render()
         return
       }
@@ -838,6 +855,7 @@ export async function startInteractiveLog(
         pendingDeleteTag = undefined
         pendingDeleteRemoteTag = undefined
         pendingRevertFile = undefined
+        pendingRevertHunk = undefined
         void render()
       } else if ((key.name === 'up' || key.name === 'k') && focus === 'branches') {
         moveBranchSelection(-1)
@@ -878,6 +896,7 @@ export async function startInteractiveLog(
           })
         } else {
           statusMessage = 'No selectable hunk for the selected file.'
+          statusDetails = undefined
           void render()
         }
       } else if (key.name === 'space' && focus === 'status') {
@@ -888,16 +907,35 @@ export async function startInteractiveLog(
         }
       } else if (key.name === 'z' && focus === 'status') {
         const file = selectedStatusFile()
+        const hunk = selectedStatusHunk()
 
-        if (file) {
+        if (hunk) {
+          pendingRevertHunk = hunk.id
+          pendingRevertFile = undefined
+          statusMessage = `Press Z to confirm reverting hunk in ${hunk.filePath}`
+          statusDetails = undefined
+          void render()
+        } else if (file) {
           pendingRevertFile = file.path
+          pendingRevertHunk = undefined
           statusMessage = `Press Z to confirm reverting ${file.path}`
+          statusDetails = undefined
           void render()
         }
       } else if (sequence === 'Z' && focus === 'status') {
         const file = selectedStatusFile()
+        const hunk = selectedStatusHunk()
 
-        if (file && pendingRevertFile === file.path) {
+        if (hunk && pendingRevertHunk === hunk.id) {
+          void runBranchAction(async () => {
+            await revertHunk(git, hunk)
+
+            return {
+              ok: true,
+              message: `Reverted hunk in ${hunk.filePath}`,
+            }
+          })
+        } else if (file && pendingRevertFile === file.path) {
           void runBranchAction(() => revertFile(git, file))
         }
       } else if (key.name === 'c' && focus === 'status') {
@@ -1003,6 +1041,7 @@ export async function startInteractiveLog(
           })
         } else {
           statusMessage = 'Only local branches can be renamed.'
+          statusDetails = undefined
           void render()
         }
       } else if (key.name === 'u' && focus === 'branches') {
@@ -1013,6 +1052,7 @@ export async function startInteractiveLog(
           void runBranchAction(() => setUpstream(git, current.shortName, branch.shortName))
         } else {
           statusMessage = 'Select a remote branch to set as the current branch upstream.'
+          statusDetails = undefined
           void render()
         }
       } else if (key.name === 't') {
@@ -1098,6 +1138,7 @@ export async function startInteractiveLog(
       } else if (key.name === 'v') {
         pullRequestDraft = !pullRequestDraft
         statusMessage = `Pull request create mode: ${pullRequestDraft ? 'draft' : 'ready'}`
+        statusDetails = undefined
         void render()
       } else if (key.name === 'o') {
         const url = pullRequest?.currentPullRequest?.url
@@ -1106,6 +1147,7 @@ export async function startInteractiveLog(
           void runBranchAction(() => openPullRequest(url), false)
         } else {
           statusMessage = 'No current pull request to open.'
+          statusDetails = undefined
           void render()
         }
       } else if (key.name === 'up' || key.name === 'k') {

--- a/src/commands/log/statusHunks.test.ts
+++ b/src/commands/log/statusHunks.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events'
 import { spawn } from 'child_process'
 import {
   getWorktreeHunks,
+  revertHunk,
   stageHunk,
   statusHunkTestInternals,
   unstageHunk,
@@ -123,6 +124,43 @@ describe('log status hunks', () => {
     await unstagePromise
 
     expect(mockedSpawn).toHaveBeenNthCalledWith(1, 'git', ['apply', '--cached', '-'], {
+      cwd: '/repo',
+      stdio: ['pipe', 'ignore', 'pipe'],
+    })
+    expect(mockedSpawn).toHaveBeenNthCalledWith(2, 'git', ['apply', '--cached', '--reverse', '-'], {
+      cwd: '/repo',
+      stdio: ['pipe', 'ignore', 'pipe'],
+    })
+  })
+
+  it('reverts unstaged hunks from the worktree', async () => {
+    const git = createGit()
+    const child = mockSpawnSuccess()
+    const [unstagedHunk] = statusHunkTestInternals.parseHunks('src/file.ts', 'unstaged', diff)
+
+    const revertPromise = revertHunk(git as never, unstagedHunk)
+    setImmediate(() => child.emit('close', 0))
+    await revertPromise
+
+    expect(mockedSpawn).toHaveBeenCalledWith('git', ['apply', '--reverse', '-'], {
+      cwd: '/repo',
+      stdio: ['pipe', 'ignore', 'pipe'],
+    })
+  })
+
+  it('reverts staged hunks from the worktree and index', async () => {
+    const git = createGit()
+    const child = mockSpawnSuccess()
+    const [stagedHunk] = statusHunkTestInternals.parseHunks('src/file.ts', 'staged', diff)
+
+    const revertPromise = revertHunk(git as never, stagedHunk)
+    setImmediate(() => {
+      child.emit('close', 0)
+      setImmediate(() => child.emit('close', 0))
+    })
+    await revertPromise
+
+    expect(mockedSpawn).toHaveBeenNthCalledWith(1, 'git', ['apply', '--reverse', '-'], {
       cwd: '/repo',
       stdio: ['pipe', 'ignore', 'pipe'],
     })

--- a/src/commands/log/statusHunks.ts
+++ b/src/commands/log/statusHunks.ts
@@ -60,17 +60,12 @@ function patchForHunk(hunk: WorktreeHunk): string {
   })
 }
 
-async function applyPatchToIndex(
+async function applyPatch(
   git: SimpleGit,
   patch: string,
-  options: { reverse?: boolean } = {}
+  args: string[],
 ): Promise<void> {
   const cwd = await git.revparse(['--show-toplevel'])
-  const args = ['apply', '--cached', '-']
-
-  if (options.reverse) {
-    args.splice(2, 0, '--reverse')
-  }
 
   await new Promise<void>((resolve, reject) => {
     const child = spawn('git', args, {
@@ -90,12 +85,26 @@ async function applyPatchToIndex(
         return
       }
 
-      reject(new Error(`Failed to apply hunk to index: ${stderr.trim()}`))
+      reject(new Error(`Failed to apply hunk patch: ${stderr.trim()}`))
     })
 
     child.stdin.write(patch)
     child.stdin.end()
   })
+}
+
+async function applyPatchToIndex(
+  git: SimpleGit,
+  patch: string,
+  options: { reverse?: boolean } = {}
+): Promise<void> {
+  const args = ['apply', '--cached', '-']
+
+  if (options.reverse) {
+    args.splice(2, 0, '--reverse')
+  }
+
+  await applyPatch(git, patch, args)
 }
 
 export async function getWorktreeHunks(
@@ -139,7 +148,20 @@ export async function unstageHunk(git: SimpleGit, hunk: WorktreeHunk): Promise<v
   await applyPatchToIndex(git, patchForHunk(hunk), { reverse: true })
 }
 
+export async function revertHunk(git: SimpleGit, hunk: WorktreeHunk): Promise<void> {
+  const patch = patchForHunk(hunk)
+
+  if (hunk.state === 'staged') {
+    await applyPatch(git, patch, ['apply', '--reverse', '-'])
+    await applyPatchToIndex(git, patch, { reverse: true })
+    return
+  }
+
+  await applyPatch(git, patch, ['apply', '--reverse', '-'])
+}
+
 export const statusHunkTestInternals = {
+  applyPatch,
   parseHunks,
   patchForHunk,
 }


### PR DESCRIPTION
## Summary
- Add structured feedback details for commit, amend, and reword failures
- Render concise hook/commitlint detail lines below the TUI status message only when present
- Add selected-hunk revert with confirmation so status workflows can stage, unstage, and discard hunks

## UX notes
- Keeps the default TUI low-noise while making failed actions actionable
- Uses contextual detail lines instead of opening a large permanent error panel
- Keeps destructive hunk revert confirmation-based

## Validation
- npm run test:jest -- src/commands/log/statusHunks.test.ts src/commands/log/commitWorkflowActions.test.ts src/commands/log/historyActions.test.ts src/commands/log/interactive.test.ts
- npm run lint -- --max-warnings=0
- npm test
- npm run coco:ts -- log -i --limit 1

Closes #663