### PR TITLE
Add log TUI stash and worktree workflows

### DIFF
--- a/src/commands/log/interactive.test.ts
+++ b/src/commands/log/interactive.test.ts
@@ -6,6 +6,8 @@ import { PullRequestOverview } from './pullRequestData'
 import { TagOverview, TagRangeSummary } from './tagData'
 import { WorktreeOverview } from './statusData'
 import { WorktreeHunkOverview } from './statusHunks'
+import { StashOverview } from './stashData'
+import { WorktreeOverview as WorktreeListOverview } from './worktreeData'
 
 const rows: GitLogRow[] = [
   {
@@ -148,6 +150,43 @@ const statusHunks = {
   ],
 } as WorktreeHunkOverview
 
+const stashOverview: StashOverview = {
+  stashes: [
+    {
+      ref: 'stash@{0}',
+      hash: 'abc123',
+      date: '2026-04-28 09:00:00 -0400',
+      branch: 'main',
+      message: 'save local edits',
+      files: ['src/a.ts', 'src/b.ts'],
+    },
+  ],
+}
+
+const worktreeList: WorktreeListOverview = {
+  currentPath: '/repo',
+  worktrees: [
+    {
+      path: '/repo',
+      head: 'abc123',
+      branch: 'main',
+      detached: false,
+      bare: false,
+      current: true,
+      dirty: false,
+    },
+    {
+      path: '/repo-feature',
+      head: 'def456',
+      branch: 'feature/log',
+      detached: false,
+      bare: false,
+      current: false,
+      dirty: true,
+    },
+  ],
+}
+
 describe('log interactive renderer', () => {
   it('renders commit navigation, selected details, changed files, and help', () => {
     const output = renderInteractiveLog(createLogTuiState(rows), detail, branches, pullRequest, tags, undefined, worktree, {}, {
@@ -228,6 +267,70 @@ describe('log interactive renderer', () => {
 
     expect(output).toContain('Pending hunk revert: press Z to revert selected hunk')
     expect(output).toContain('> [U] @@ -1,1 +1,1 @@ -old +new')
+  })
+
+  it('renders stash and worktree workspace controls', () => {
+    const output = renderInteractiveLog(
+      createLogTuiState(rows),
+      detail,
+      branches,
+      pullRequest,
+      tags,
+      undefined,
+      worktree,
+      {
+        focus: 'workspace',
+        workspaceSection: 'stashes',
+        stashIndex: 0,
+      },
+      {
+        height: 80,
+        width: 140,
+      },
+      {
+        stashes: stashOverview,
+        worktreeList,
+        stashDiffSummary: [' src/a.ts | 2 +-', ' 1 file changed'],
+      }
+    )
+
+    expect(output).toContain('Focus: workspace')
+    expect(output).toContain('Workspace: stashes')
+    expect(output).toContain('> stash@{0} main: save local edits 2 file(s)')
+    expect(output).toContain('  feature/log dirty /repo-feature')
+    expect(output).toContain('src/a.ts | 2 +-')
+    expect(output).toContain('s stash')
+    expect(output).toContain('B branch+worktree')
+  })
+
+  it('renders workspace destructive confirmations', () => {
+    const output = renderInteractiveLog(
+      createLogTuiState(rows),
+      detail,
+      branches,
+      pullRequest,
+      tags,
+      undefined,
+      worktree,
+      {
+        focus: 'workspace',
+        workspaceSection: 'worktrees',
+        worktreeIndex: 1,
+        pendingRemoveWorktree: '/repo-feature',
+      },
+      {
+        height: 80,
+        width: 140,
+      },
+      {
+        stashes: stashOverview,
+        worktreeList,
+      }
+    )
+
+    expect(output).toContain('Workspace: worktrees')
+    expect(output).toContain('>  feature/log dirty /repo-feature')
+    expect(output).toContain('Pending worktree remove: press X to remove /repo-feature')
   })
 
   it('renders branch focus, status, and pending delete prompts', () => {

--- a/src/commands/log/interactive.ts
+++ b/src/commands/log/interactive.ts
@@ -17,6 +17,8 @@ import { GitCommitDetail, GitLogRow, getCommitDetail } from './data'
 import { amendHeadCommit, rewordHeadCommit } from './historyActions'
 import { createPullRequest, openPullRequest } from './pullRequestActions'
 import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
+import { applyStash, createStash, dropStash, popStash } from './stashActions'
+import { StashEntry, StashOverview, getStashDiffSummary, getStashOverview } from './stashData'
 import { revertFile, stageFile, unstageFile } from './statusActions'
 import { WorktreeFile, WorktreeOverview, getWorktreeOverview } from './statusData'
 import { WorktreeHunkOverview, getWorktreeHunks, revertHunk, stageHunk, unstageHunk } from './statusHunks'
@@ -28,6 +30,17 @@ import {
   pushTag,
 } from './tagActions'
 import { TagOverview, TagRangeSummary, getTagOverview, getTagRangeSummary } from './tagData'
+import {
+  createBranchWorktree,
+  createWorktree,
+  removeWorktree,
+  worktreePathAction,
+} from './worktreeActions'
+import {
+  WorktreeEntry,
+  WorktreeOverview as WorktreeListOverview,
+  getWorktreeListOverview,
+} from './worktreeData'
 import {
   LogTuiState,
   applyLogTuiAction,
@@ -45,7 +58,14 @@ type RenderInteractiveLogOptions = {
   width?: number
 }
 
-type LogTuiFocus = 'commits' | 'branches' | 'tags' | 'status'
+type RenderInteractiveLogWorkspace = {
+  stashes?: StashOverview
+  worktreeList?: WorktreeListOverview
+  stashDiffSummary?: string[]
+}
+
+type LogTuiFocus = 'commits' | 'branches' | 'tags' | 'status' | 'workspace'
+type WorkspaceSection = 'stashes' | 'worktrees'
 
 type LogTuiRenderUi = {
   focus?: LogTuiFocus
@@ -63,6 +83,11 @@ type LogTuiRenderUi = {
   statusHunkIndex?: number
   pendingRevertFile?: string
   pendingRevertHunk?: string
+  stashIndex?: number
+  worktreeIndex?: number
+  workspaceSection?: WorkspaceSection
+  pendingDropStash?: string
+  pendingRemoveWorktree?: string
 }
 
 type LogTuiInputKind =
@@ -72,6 +97,10 @@ type LogTuiInputKind =
   | 'create-tag'
   | 'create-annotated-tag'
   | 'reword-commit'
+  | 'create-stash'
+  | 'create-worktree'
+  | 'create-branch-worktree-path'
+  | 'create-branch-worktree-branch'
 
 type LogTuiInputPrompt = {
   kind: LogTuiInputKind
@@ -82,6 +111,7 @@ type LogTuiInputPrompt = {
   baseRef?: string
   tagName?: string
   commitHash?: string
+  worktreePath?: string
 }
 
 const DEFAULT_HEIGHT = 70
@@ -325,6 +355,46 @@ function renderStatusOverview(
   ].map((line) => truncate(line, width))
 }
 
+function renderWorkspaceOverview(
+  stashes: StashOverview | undefined,
+  worktrees: WorktreeListOverview | undefined,
+  stashDiffSummary: string[] | undefined,
+  ui: LogTuiRenderUi,
+  width: number
+): string[] {
+  const section = ui.workspaceSection || 'stashes'
+  const stashLines = stashes?.stashes.slice(0, 4).map((stash, index) => {
+    const selected = ui.focus === 'workspace' && section === 'stashes' && (ui.stashIndex || 0) === index ? '>' : ' '
+    const files = stash.files.length ? ` ${stash.files.length} file(s)` : ''
+
+    return `${selected} ${stash.ref} ${stash.branch}: ${stash.message}${files}`
+  }) || []
+  const worktreeLines = worktrees?.worktrees.slice(0, 4).map((worktree, index) => {
+    const selected = ui.focus === 'workspace' && section === 'worktrees' && (ui.worktreeIndex || 0) === index ? '>' : ' '
+    const marker = worktree.current ? '*' : ' '
+    const branch = worktree.branch || (worktree.detached ? '<detached>' : '<unknown>')
+    const dirty = worktree.dirty ? 'dirty' : 'clean'
+
+    return `${selected}${marker} ${branch} ${dirty} ${worktree.path}`
+  }) || []
+  const actionLine = ui.pendingDropStash
+    ? `Pending stash drop: press D to drop ${ui.pendingDropStash}`
+    : ui.pendingRemoveWorktree
+      ? `Pending worktree remove: press X to remove ${ui.pendingRemoveWorktree}`
+      : 'Workspace actions: [/] section | s stash | a apply | P pop | d drop | i inspect | w worktree | B branch+worktree | x remove | o path'
+  const diffLines = stashDiffSummary?.slice(0, 3).map((line) => `  ${line}`) || []
+
+  return [
+    `Workspace: ${section}`,
+    'Stashes:',
+    ...(stashLines.length ? stashLines : ['  No stashes found.']),
+    'Worktrees:',
+    ...(worktreeLines.length ? worktreeLines : ['  No linked worktrees found.']),
+    ...diffLines,
+    actionLine,
+  ].map((line) => truncate(line, width))
+}
+
 function renderDetail(detail: GitCommitDetail | undefined, width: number): string[] {
   if (!detail) {
     return ['Loading selected commit details...']
@@ -362,7 +432,8 @@ export function renderInteractiveLog(
   tagRangeSummary?: TagRangeSummary,
   worktree?: WorktreeOverview,
   ui: LogTuiRenderUi = {},
-  options: RenderInteractiveLogOptions = {}
+  options: RenderInteractiveLogOptions = {},
+  workspace: RenderInteractiveLogWorkspace = {}
 ): string {
   const height = options.height || process.stdout.rows || DEFAULT_HEIGHT
   const width = options.width || process.stdout.columns || DEFAULT_WIDTH
@@ -383,6 +454,15 @@ export function renderInteractiveLog(
   const pullRequestLines = renderPullRequestOverview(pullRequest, ui, width).slice(0, 4)
   const tagLines = renderTagOverview(tags, tagRangeSummary, ui, width).slice(0, 10)
   const statusLines = renderStatusOverview(worktree, ui, width).slice(0, 10)
+  const workspaceLines = workspace.stashes || workspace.worktreeList
+    ? renderWorkspaceOverview(
+      workspace.stashes,
+      workspace.worktreeList,
+      workspace.stashDiffSummary,
+      ui,
+      width
+    ).slice(0, 12)
+    : []
   const listHeight = Math.max(4, Math.floor(height * 0.35))
   const detailHeight = Math.max(
     6,
@@ -392,6 +472,7 @@ export function renderInteractiveLog(
       pullRequestLines.length -
       tagLines.length -
       statusLines.length -
+      workspaceLines.length -
       11
   )
   const detailLines = renderDetail(detail, width).slice(0, detailHeight)
@@ -410,6 +491,7 @@ export function renderInteractiveLog(
     ...pullRequestLines,
     ...tagLines,
     ...statusLines,
+    ...workspaceLines,
     '',
     ...renderCommitList(state, listHeight, width),
     '',
@@ -434,11 +516,17 @@ export async function startInteractiveLog(
   let tagRangeSummary: TagRangeSummary | undefined
   let worktree: WorktreeOverview | undefined
   let statusHunks: WorktreeHunkOverview | undefined
+  let stashes: StashOverview | undefined
+  let worktreeList: WorktreeListOverview | undefined
+  let stashDiffSummary: string[] | undefined
   let focus: LogTuiFocus = 'commits'
   let branchIndex = 0
   let tagIndex = 0
   let statusIndex = 0
   let statusHunkIndex = 0
+  let stashIndex = 0
+  let worktreeIndex = 0
+  let workspaceSection: WorkspaceSection = 'stashes'
   let statusMessage: string | undefined
   let statusDetails: string[] | undefined
   let pendingDeleteBranch: string | undefined
@@ -446,6 +534,8 @@ export async function startInteractiveLog(
   let pendingDeleteRemoteTag: string | undefined
   let pendingRevertFile: string | undefined
   let pendingRevertHunk: string | undefined
+  let pendingDropStash: string | undefined
+  let pendingRemoveWorktree: string | undefined
   let inputPrompt: LogTuiInputPrompt | undefined
   let pullRequestDraft = false
 
@@ -468,11 +558,13 @@ export async function startInteractiveLog(
 
   if (!input.isTTY || !output.isTTY) {
     try {
-      [branches, pullRequest, tags, worktree] = await Promise.all([
+      [branches, pullRequest, tags, worktree, stashes, worktreeList] = await Promise.all([
         getBranchOverview(git),
         getPullRequestOverview(git),
         getTagOverview(git),
         getWorktreeOverview(git),
+        getStashOverview(git),
+        getWorktreeListOverview(git),
       ])
     } catch {
       branches = undefined
@@ -486,7 +578,10 @@ export async function startInteractiveLog(
         pullRequest,
         tags,
         tagRangeSummary,
-        worktree
+        worktree,
+        {},
+        {},
+        { stashes, worktreeList }
       )}\n`,
       'utf8'
     )
@@ -527,6 +622,11 @@ export async function startInteractiveLog(
         statusIndex,
         statusHunks,
         statusHunkIndex,
+        stashIndex,
+        worktreeIndex,
+        workspaceSection,
+        pendingDropStash,
+        pendingRemoveWorktree,
       }
 
       output.write(
@@ -538,7 +638,9 @@ export async function startInteractiveLog(
           tags,
           tagRangeSummary,
           worktree,
-          ui
+          ui,
+          {},
+          { stashes, worktreeList, stashDiffSummary }
         )}\n`,
         'utf8'
       )
@@ -556,7 +658,9 @@ export async function startInteractiveLog(
               tags,
               tagRangeSummary,
               worktree,
-              ui
+              ui,
+              {},
+              { stashes, worktreeList, stashDiffSummary }
             )}\n`,
             'utf8'
           )
@@ -595,6 +699,16 @@ export async function startInteractiveLog(
       statusHunkIndex = Math.max(0, Math.min(statusHunkIndex, (statusHunks?.hunks.length || 1) - 1))
     }
 
+    const refreshStashes = async () => {
+      stashes = await getStashOverview(git)
+      stashIndex = Math.max(0, Math.min(stashIndex, (stashes?.stashes.length || 1) - 1))
+    }
+
+    const refreshWorktreeList = async () => {
+      worktreeList = await getWorktreeListOverview(git)
+      worktreeIndex = Math.max(0, Math.min(worktreeIndex, (worktreeList?.worktrees.length || 1) - 1))
+    }
+
     const setActionResult = async (result: BranchActionResult, refresh = true) => {
       statusMessage = result.message
       statusDetails = result.details
@@ -603,6 +717,8 @@ export async function startInteractiveLog(
       pendingDeleteRemoteTag = undefined
       pendingRevertFile = undefined
       pendingRevertHunk = undefined
+      pendingDropStash = undefined
+      pendingRemoveWorktree = undefined
       inputPrompt = undefined
 
       if (refresh) {
@@ -611,6 +727,8 @@ export async function startInteractiveLog(
           refreshPullRequest(),
           refreshTags(),
           refreshWorktree(),
+          refreshStashes(),
+          refreshWorktreeList(),
         ])
         await refreshStatusHunks()
       }
@@ -622,6 +740,8 @@ export async function startInteractiveLog(
     const selectedTag = () => tags?.tags[tagIndex]
     const selectedStatusFile = (): WorktreeFile | undefined => worktree?.files[statusIndex]
     const selectedStatusHunk = () => statusHunks?.hunks[statusHunkIndex]
+    const selectedStash = (): StashEntry | undefined => stashes?.stashes[stashIndex]
+    const selectedWorkspaceWorktree = (): WorktreeEntry | undefined => worktreeList?.worktrees[worktreeIndex]
 
     const selectedRef = () => {
       if (focus === 'branches') {
@@ -697,6 +817,30 @@ export async function startInteractiveLog(
       void render()
     }
 
+    const moveWorkspaceSelection = (delta: number) => {
+      if (workspaceSection === 'stashes') {
+        const stashCount = stashes?.stashes.length || 0
+
+        stashIndex = Math.max(0, Math.min(stashIndex + delta, stashCount - 1))
+        pendingDropStash = undefined
+        stashDiffSummary = undefined
+      } else {
+        const worktreeCount = worktreeList?.worktrees.length || 0
+
+        worktreeIndex = Math.max(0, Math.min(worktreeIndex + delta, worktreeCount - 1))
+        pendingRemoveWorktree = undefined
+      }
+
+      void render()
+    }
+
+    const toggleWorkspaceSection = () => {
+      workspaceSection = workspaceSection === 'stashes' ? 'worktrees' : 'stashes'
+      pendingDropStash = undefined
+      pendingRemoveWorktree = undefined
+      void render()
+    }
+
     const runBranchAction = async (
       action: () => Promise<BranchActionResult>,
       refresh = true,
@@ -716,6 +860,8 @@ export async function startInteractiveLog(
       pendingDeleteRemoteTag = undefined
       pendingRevertFile = undefined
       pendingRevertHunk = undefined
+      pendingDropStash = undefined
+      pendingRemoveWorktree = undefined
       void render()
     }
 
@@ -766,6 +912,28 @@ export async function startInteractiveLog(
           () => rewordHeadCommit(git, prompt.commitHash as string, value),
           true,
           'Rewording HEAD commit...'
+        )
+      } else if (prompt.kind === 'create-stash') {
+        await runBranchAction(() => createStash(git, value), true, 'Creating stash...')
+      } else if (prompt.kind === 'create-worktree') {
+        await runBranchAction(
+          () => createWorktree(git, value, prompt.sourceRef),
+          true,
+          'Creating worktree...'
+        )
+      } else if (prompt.kind === 'create-branch-worktree-path') {
+        startInputPrompt({
+          kind: 'create-branch-worktree-branch',
+          label: `New branch for ${value}`,
+          value: '',
+          sourceRef: prompt.sourceRef,
+          worktreePath: value,
+        })
+      } else if (prompt.kind === 'create-branch-worktree-branch' && prompt.worktreePath) {
+        await runBranchAction(
+          () => createBranchWorktree(git, prompt.worktreePath as string, value, prompt.sourceRef),
+          true,
+          'Creating branch worktree...'
         )
       }
     }
@@ -850,12 +1018,16 @@ export async function startInteractiveLog(
             ? 'tags'
             : focus === 'tags'
               ? 'status'
-              : 'commits'
+              : focus === 'status'
+                ? 'workspace'
+                : 'commits'
         pendingDeleteBranch = undefined
         pendingDeleteTag = undefined
         pendingDeleteRemoteTag = undefined
         pendingRevertFile = undefined
         pendingRevertHunk = undefined
+        pendingDropStash = undefined
+        pendingRemoveWorktree = undefined
         void render()
       } else if ((key.name === 'up' || key.name === 'k') && focus === 'branches') {
         moveBranchSelection(-1)
@@ -869,10 +1041,108 @@ export async function startInteractiveLog(
         moveStatusSelection(-1)
       } else if ((key.name === 'down' || key.name === 'j') && focus === 'status') {
         moveStatusSelection(1)
+      } else if ((key.name === 'up' || key.name === 'k') && focus === 'workspace') {
+        moveWorkspaceSelection(-1)
+      } else if ((key.name === 'down' || key.name === 'j') && focus === 'workspace') {
+        moveWorkspaceSelection(1)
+      } else if ((sequence === '[' || key.name === 'left') && focus === 'workspace') {
+        toggleWorkspaceSection()
+      } else if ((sequence === ']' || key.name === 'right') && focus === 'workspace') {
+        toggleWorkspaceSection()
       } else if ((sequence === '[' || key.name === 'left') && focus === 'status') {
         moveStatusHunkSelection(-1)
       } else if ((sequence === ']' || key.name === 'right') && focus === 'status') {
         moveStatusHunkSelection(1)
+      } else if (key.name === 's' && focus === 'workspace') {
+        startInputPrompt({
+          kind: 'create-stash',
+          label: 'Create stash message',
+          value: '',
+          sourceRef: 'HEAD',
+        })
+      } else if (key.name === 'a' && focus === 'workspace' && workspaceSection === 'stashes') {
+        const stash = selectedStash()
+
+        if (stash) {
+          void runBranchAction(() => applyStash(git, stash), true, 'Applying stash...')
+        }
+      } else if (sequence === 'P' && focus === 'workspace' && workspaceSection === 'stashes') {
+        const stash = selectedStash()
+
+        if (stash) {
+          void runBranchAction(() => popStash(git, stash), true, 'Popping stash...')
+        }
+      } else if (key.name === 'd' && focus === 'workspace' && workspaceSection === 'stashes') {
+        const stash = selectedStash()
+
+        if (stash) {
+          pendingDropStash = stash.ref
+          statusMessage = `Press D to confirm dropping ${stash.ref}`
+          statusDetails = undefined
+          void render()
+        }
+      } else if (sequence === 'D' && focus === 'workspace' && workspaceSection === 'stashes') {
+        const stash = selectedStash()
+
+        if (stash && pendingDropStash === stash.ref) {
+          void runBranchAction(() => dropStash(git, stash), true, 'Dropping stash...')
+        }
+      } else if (key.name === 'i' && focus === 'workspace' && workspaceSection === 'stashes') {
+        const stash = selectedStash()
+
+        if (stash) {
+          void runBranchAction(async () => {
+            stashDiffSummary = await getStashDiffSummary(git, stash.ref)
+
+            return {
+              ok: true,
+              message: `Inspecting ${stash.ref}`,
+            }
+          }, false, 'Loading stash diff...')
+        }
+      } else if (key.name === 'w' && focus === 'workspace') {
+        const ref = selectedRef()
+
+        if (ref) {
+          startInputPrompt({
+            kind: 'create-worktree',
+            label: `New worktree path from ${ref}`,
+            value: '',
+            sourceRef: ref,
+          })
+        }
+      } else if (sequence === 'B' && focus === 'workspace') {
+        const ref = selectedRef()
+
+        if (ref) {
+          startInputPrompt({
+            kind: 'create-branch-worktree-path',
+            label: `New branch worktree path from ${ref}`,
+            value: '',
+            sourceRef: ref,
+          })
+        }
+      } else if (key.name === 'x' && focus === 'workspace' && workspaceSection === 'worktrees') {
+        const selectedWorktree = selectedWorkspaceWorktree()
+
+        if (selectedWorktree) {
+          pendingRemoveWorktree = selectedWorktree.path
+          statusMessage = `Press X to confirm removing ${selectedWorktree.path}`
+          statusDetails = undefined
+          void render()
+        }
+      } else if (sequence === 'X' && focus === 'workspace' && workspaceSection === 'worktrees') {
+        const selectedWorktree = selectedWorkspaceWorktree()
+
+        if (selectedWorktree && pendingRemoveWorktree === selectedWorktree.path) {
+          void runBranchAction(() => removeWorktree(git, selectedWorktree), true, 'Removing worktree...')
+        }
+      } else if (key.name === 'o' && focus === 'workspace' && workspaceSection === 'worktrees') {
+        const selectedWorktree = selectedWorkspaceWorktree()
+
+        if (selectedWorktree) {
+          void runBranchAction(() => Promise.resolve(worktreePathAction(selectedWorktree)), false)
+        }
       } else if (key.name === 'return' && focus === 'status') {
         const hunk = selectedStatusHunk()
 
@@ -1175,6 +1445,8 @@ export async function startInteractiveLog(
       refreshPullRequest(),
       refreshTags(),
       refreshWorktree(),
+      refreshStashes(),
+      refreshWorktreeList(),
     ])
       .then(async () => {
         await refreshStatusHunks()
@@ -1186,6 +1458,8 @@ export async function startInteractiveLog(
         tags = undefined
         worktree = undefined
         statusHunks = undefined
+        stashes = undefined
+        worktreeList = undefined
       })
     void render()
   })

--- a/src/commands/log/stashActions.test.ts
+++ b/src/commands/log/stashActions.test.ts
@@ -1,0 +1,41 @@
+import { applyStash, createStash, dropStash, popStash } from './stashActions'
+import { StashEntry } from './stashData'
+
+const stash: StashEntry = {
+  ref: 'stash@{0}',
+  hash: 'abc123',
+  date: '2026-04-28',
+  branch: 'main',
+  message: 'save docs',
+  files: ['src/a.ts'],
+}
+
+describe('log stash actions', () => {
+  it('creates, applies, pops, and drops stashes with explicit refs', async () => {
+    const git = {
+      raw: jest.fn().mockResolvedValue(''),
+    }
+
+    await createStash(git as never, ' save docs ')
+    await applyStash(git as never, stash)
+    await popStash(git as never, stash)
+    await dropStash(git as never, stash)
+
+    expect(git.raw).toHaveBeenNthCalledWith(1, ['stash', 'push', '-u', '-m', 'save docs'])
+    expect(git.raw).toHaveBeenNthCalledWith(2, ['stash', 'apply', 'stash@{0}'])
+    expect(git.raw).toHaveBeenNthCalledWith(3, ['stash', 'pop', 'stash@{0}'])
+    expect(git.raw).toHaveBeenNthCalledWith(4, ['stash', 'drop', 'stash@{0}'])
+  })
+
+  it('rejects empty stash messages before invoking git', async () => {
+    const git = {
+      raw: jest.fn(),
+    }
+
+    await expect(createStash(git as never, '   ')).resolves.toEqual({
+      ok: false,
+      message: 'Stash cancelled: empty message.',
+    })
+    expect(git.raw).not.toHaveBeenCalled()
+  })
+})

--- a/src/commands/log/stashActions.ts
+++ b/src/commands/log/stashActions.ts
@@ -1,0 +1,56 @@
+import { SimpleGit } from 'simple-git'
+import { BranchActionResult } from './branchActions'
+import { StashEntry } from './stashData'
+
+async function runAction(action: () => Promise<unknown>, successMessage: string): Promise<BranchActionResult> {
+  try {
+    await action()
+
+    return {
+      ok: true,
+      message: successMessage,
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      message: (error as Error).message,
+    }
+  }
+}
+
+export function createStash(git: SimpleGit, message: string): Promise<BranchActionResult> {
+  const trimmedMessage = message.trim()
+
+  if (!trimmedMessage) {
+    return Promise.resolve({
+      ok: false,
+      message: 'Stash cancelled: empty message.',
+    })
+  }
+
+  return runAction(
+    () => git.raw(['stash', 'push', '-u', '-m', trimmedMessage]),
+    `Created stash: ${trimmedMessage}`
+  )
+}
+
+export function applyStash(git: SimpleGit, stash: StashEntry): Promise<BranchActionResult> {
+  return runAction(
+    () => git.raw(['stash', 'apply', stash.ref]),
+    `Applied ${stash.ref}`
+  )
+}
+
+export function popStash(git: SimpleGit, stash: StashEntry): Promise<BranchActionResult> {
+  return runAction(
+    () => git.raw(['stash', 'pop', stash.ref]),
+    `Popped ${stash.ref}`
+  )
+}
+
+export function dropStash(git: SimpleGit, stash: StashEntry): Promise<BranchActionResult> {
+  return runAction(
+    () => git.raw(['stash', 'drop', stash.ref]),
+    `Dropped ${stash.ref}`
+  )
+}

--- a/src/commands/log/stashData.test.ts
+++ b/src/commands/log/stashData.test.ts
@@ -1,0 +1,68 @@
+import { getStashDiffSummary, getStashOverview, parseStashFiles, parseStashList, stashDataTestInternals } from './stashData'
+
+describe('log stash data', () => {
+  it('parses stash list lines with branch context and messages', () => {
+    const output = [
+      'stash@{0}\x1fabc123\x1f2026-04-28 09:00:00 -0400\x1fOn main: save docs',
+      'stash@{1}\x1fdef456\x1f2026-04-27 18:00:00 -0400\x1fWIP on feature/log: 1234567 add tui',
+    ].join('\n')
+
+    expect(parseStashList(output)).toEqual([
+      {
+        ref: 'stash@{0}',
+        hash: 'abc123',
+        date: '2026-04-28 09:00:00 -0400',
+        branch: 'main',
+        message: 'save docs',
+      },
+      {
+        ref: 'stash@{1}',
+        hash: 'def456',
+        date: '2026-04-27 18:00:00 -0400',
+        branch: 'feature/log',
+        message: '1234567 add tui',
+      },
+    ])
+  })
+
+  it('keeps unknown stash subjects readable', () => {
+    expect(stashDataTestInternals.parseStashSubject('custom stash subject')).toEqual({
+      branch: '<unknown>',
+      message: 'custom stash subject',
+    })
+  })
+
+  it('parses stash files and loads overview details', async () => {
+    const git = {
+      raw: jest.fn()
+        .mockResolvedValueOnce('stash@{0}\x1fabc123\x1f2026-04-28 09:00:00 -0400\x1fOn main: save docs')
+        .mockResolvedValueOnce('src/a.ts\nsrc/b.ts\n'),
+    }
+
+    await expect(getStashOverview(git as never)).resolves.toEqual({
+      stashes: [
+        {
+          ref: 'stash@{0}',
+          hash: 'abc123',
+          date: '2026-04-28 09:00:00 -0400',
+          branch: 'main',
+          message: 'save docs',
+          files: ['src/a.ts', 'src/b.ts'],
+        },
+      ],
+    })
+    expect(parseStashFiles('\n src/a.ts \n\n')).toEqual(['src/a.ts'])
+  })
+
+  it('loads stash diff summary lines', async () => {
+    const git = {
+      raw: jest.fn().mockResolvedValue(' src/a.ts | 2 +-\n 1 file changed\n'),
+    }
+
+    await expect(getStashDiffSummary(git as never, 'stash@{0}')).resolves.toEqual([
+      ' src/a.ts | 2 +-',
+      ' 1 file changed',
+    ])
+    expect(git.raw).toHaveBeenCalledWith(['stash', 'show', '--stat', 'stash@{0}'])
+  })
+})

--- a/src/commands/log/stashData.ts
+++ b/src/commands/log/stashData.ts
@@ -1,0 +1,80 @@
+import { SimpleGit } from 'simple-git'
+
+export type StashEntry = {
+  ref: string
+  hash: string
+  date: string
+  branch: string
+  message: string
+  files: string[]
+}
+
+export type StashOverview = {
+  stashes: StashEntry[]
+}
+
+function parseStashSubject(subject: string): { branch: string; message: string } {
+  const match = subject.match(/^(?:WIP on|On) ([^:]+):\s*(.*)$/)
+
+  if (!match) {
+    return {
+      branch: '<unknown>',
+      message: subject,
+    }
+  }
+
+  return {
+    branch: match[1],
+    message: match[2] || subject,
+  }
+}
+
+export function parseStashList(output: string): Omit<StashEntry, 'files'>[] {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [ref, hash, date, subject] = line.split('\x1f')
+      const parsedSubject = parseStashSubject(subject || '')
+
+      return {
+        ref,
+        hash,
+        date,
+        branch: parsedSubject.branch,
+        message: parsedSubject.message,
+      }
+    })
+}
+
+export function parseStashFiles(output: string): string[] {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+export async function getStashOverview(git: SimpleGit): Promise<StashOverview> {
+  const stashes = parseStashList(
+    await git.raw(['stash', 'list', '--date=iso', '--format=%gd%x1f%H%x1f%ci%x1f%gs'])
+  )
+
+  return {
+    stashes: await Promise.all(stashes.map(async (stash) => ({
+      ...stash,
+      files: parseStashFiles(await git.raw(['stash', 'show', '--name-only', stash.ref])),
+    }))),
+  }
+}
+
+export async function getStashDiffSummary(git: SimpleGit, stashRef: string): Promise<string[]> {
+  return (await git.raw(['stash', 'show', '--stat', stashRef]))
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+}
+
+export const stashDataTestInternals = {
+  parseStashSubject,
+}

--- a/src/commands/log/worktreeActions.test.ts
+++ b/src/commands/log/worktreeActions.test.ts
@@ -1,0 +1,70 @@
+import {
+  createBranchWorktree,
+  createWorktree,
+  removeWorktree,
+  worktreePathAction,
+} from './worktreeActions'
+import { WorktreeEntry } from './worktreeData'
+
+const worktree: WorktreeEntry = {
+  path: '/repo-feature',
+  head: 'abc123',
+  branch: 'feature/log',
+  detached: false,
+  bare: false,
+  current: false,
+  dirty: false,
+}
+
+describe('log worktree actions', () => {
+  it('creates worktrees and branch worktrees with explicit paths', async () => {
+    const git = {
+      raw: jest.fn().mockResolvedValue(''),
+    }
+
+    await createWorktree(git as never, ' ../repo-feature ', 'main')
+    await createBranchWorktree(git as never, '../repo-new', 'feature/new', 'main')
+
+    expect(git.raw).toHaveBeenNthCalledWith(1, ['worktree', 'add', '../repo-feature', 'main'])
+    expect(git.raw).toHaveBeenNthCalledWith(2, [
+      'worktree',
+      'add',
+      '-b',
+      'feature/new',
+      '../repo-new',
+      'main',
+    ])
+  })
+
+  it('removes clean non-current worktrees and reports paths', async () => {
+    const git = {
+      raw: jest.fn().mockResolvedValue(''),
+    }
+
+    await expect(removeWorktree(git as never, worktree)).resolves.toEqual({
+      ok: true,
+      message: 'Removed worktree /repo-feature',
+    })
+    expect(worktreePathAction(worktree)).toEqual({
+      ok: true,
+      message: 'Worktree path: /repo-feature',
+    })
+    expect(git.raw).toHaveBeenCalledWith(['worktree', 'remove', '/repo-feature'])
+  })
+
+  it('blocks current or dirty worktree removal before invoking git', async () => {
+    const git = {
+      raw: jest.fn(),
+    }
+
+    await expect(removeWorktree(git as never, { ...worktree, current: true })).resolves.toEqual({
+      ok: false,
+      message: 'Cannot remove the current worktree.',
+    })
+    await expect(removeWorktree(git as never, { ...worktree, dirty: true })).resolves.toEqual({
+      ok: false,
+      message: 'Cannot remove dirty worktree /repo-feature. Clean or stash it first.',
+    })
+    expect(git.raw).not.toHaveBeenCalled()
+  })
+})

--- a/src/commands/log/worktreeActions.ts
+++ b/src/commands/log/worktreeActions.ts
@@ -1,0 +1,89 @@
+import { SimpleGit } from 'simple-git'
+import { BranchActionResult } from './branchActions'
+import { WorktreeEntry } from './worktreeData'
+
+async function runAction(action: () => Promise<unknown>, successMessage: string): Promise<BranchActionResult> {
+  try {
+    await action()
+
+    return {
+      ok: true,
+      message: successMessage,
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      message: (error as Error).message,
+    }
+  }
+}
+
+export function createWorktree(
+  git: SimpleGit,
+  path: string,
+  ref: string
+): Promise<BranchActionResult> {
+  const trimmedPath = path.trim()
+
+  if (!trimmedPath) {
+    return Promise.resolve({
+      ok: false,
+      message: 'Worktree cancelled: empty path.',
+    })
+  }
+
+  return runAction(
+    () => git.raw(['worktree', 'add', trimmedPath, ref]),
+    `Created worktree ${trimmedPath} from ${ref}`
+  )
+}
+
+export function createBranchWorktree(
+  git: SimpleGit,
+  path: string,
+  branchName: string,
+  startPoint: string
+): Promise<BranchActionResult> {
+  const trimmedPath = path.trim()
+  const trimmedBranch = branchName.trim()
+
+  if (!trimmedPath || !trimmedBranch) {
+    return Promise.resolve({
+      ok: false,
+      message: 'Worktree cancelled: empty path or branch name.',
+    })
+  }
+
+  return runAction(
+    () => git.raw(['worktree', 'add', '-b', trimmedBranch, trimmedPath, startPoint]),
+    `Created worktree ${trimmedPath} on ${trimmedBranch}`
+  )
+}
+
+export function removeWorktree(git: SimpleGit, worktree: WorktreeEntry): Promise<BranchActionResult> {
+  if (worktree.current) {
+    return Promise.resolve({
+      ok: false,
+      message: 'Cannot remove the current worktree.',
+    })
+  }
+
+  if (worktree.dirty) {
+    return Promise.resolve({
+      ok: false,
+      message: `Cannot remove dirty worktree ${worktree.path}. Clean or stash it first.`,
+    })
+  }
+
+  return runAction(
+    () => git.raw(['worktree', 'remove', worktree.path]),
+    `Removed worktree ${worktree.path}`
+  )
+}
+
+export function worktreePathAction(worktree: WorktreeEntry): BranchActionResult {
+  return {
+    ok: true,
+    message: `Worktree path: ${worktree.path}`,
+  }
+}

--- a/src/commands/log/worktreeData.test.ts
+++ b/src/commands/log/worktreeData.test.ts
@@ -1,0 +1,85 @@
+import { getWorktreeListOverview, parseWorktreeList } from './worktreeData'
+
+const porcelain = [
+  'worktree /repo',
+  'HEAD abc123',
+  'branch refs/heads/main',
+  '',
+  'worktree /repo-feature',
+  'HEAD def456',
+  'branch refs/heads/feature/log',
+  '',
+  'worktree /repo-detached',
+  'HEAD fedcba',
+  'detached',
+].join('\n')
+
+describe('log worktree data', () => {
+  it('parses porcelain worktree list output', () => {
+    expect(parseWorktreeList(porcelain)).toEqual([
+      {
+        path: '/repo',
+        head: 'abc123',
+        branch: 'main',
+        detached: false,
+        bare: false,
+      },
+      {
+        path: '/repo-feature',
+        head: 'def456',
+        branch: 'feature/log',
+        detached: false,
+        bare: false,
+      },
+      {
+        path: '/repo-detached',
+        head: 'fedcba',
+        detached: true,
+        bare: false,
+      },
+    ])
+  })
+
+  it('loads current and dirty status for worktrees', async () => {
+    const git = {
+      revparse: jest.fn().mockResolvedValue('/repo\n'),
+      raw: jest.fn()
+        .mockResolvedValueOnce(porcelain)
+        .mockResolvedValueOnce('')
+        .mockResolvedValueOnce(' M src/file.ts\n')
+        .mockResolvedValueOnce(''),
+    }
+
+    await expect(getWorktreeListOverview(git as never)).resolves.toEqual({
+      currentPath: '/repo',
+      worktrees: [
+        {
+          path: '/repo',
+          head: 'abc123',
+          branch: 'main',
+          detached: false,
+          bare: false,
+          current: true,
+          dirty: false,
+        },
+        {
+          path: '/repo-feature',
+          head: 'def456',
+          branch: 'feature/log',
+          detached: false,
+          bare: false,
+          current: false,
+          dirty: true,
+        },
+        {
+          path: '/repo-detached',
+          head: 'fedcba',
+          detached: true,
+          bare: false,
+          current: false,
+          dirty: false,
+        },
+      ],
+    })
+  })
+})

--- a/src/commands/log/worktreeData.ts
+++ b/src/commands/log/worktreeData.ts
@@ -1,0 +1,78 @@
+import { SimpleGit } from 'simple-git'
+
+export type WorktreeEntry = {
+  path: string
+  head?: string
+  branch?: string
+  detached: boolean
+  bare: boolean
+  prunable?: string
+  current: boolean
+  dirty: boolean
+}
+
+export type WorktreeOverview = {
+  currentPath: string
+  worktrees: WorktreeEntry[]
+}
+
+function shortBranch(branch: string | undefined): string | undefined {
+  return branch?.replace(/^refs\/heads\//, '')
+}
+
+export function parseWorktreeList(output: string): Omit<WorktreeEntry, 'current' | 'dirty'>[] {
+  return output
+    .split('\n\n')
+    .map((block) => block.trim())
+    .filter(Boolean)
+    .map((block) => {
+      const entry: Omit<WorktreeEntry, 'current' | 'dirty'> = {
+        path: '',
+        detached: false,
+        bare: false,
+      }
+
+      block.split('\n').forEach((line) => {
+        const [key, ...valueParts] = line.split(' ')
+        const value = valueParts.join(' ')
+
+        if (key === 'worktree') {
+          entry.path = value
+        } else if (key === 'HEAD') {
+          entry.head = value
+        } else if (key === 'branch') {
+          entry.branch = shortBranch(value)
+        } else if (key === 'detached') {
+          entry.detached = true
+        } else if (key === 'bare') {
+          entry.bare = true
+        } else if (key === 'prunable') {
+          entry.prunable = value || 'prunable'
+        }
+      })
+
+      return entry
+    })
+}
+
+async function isWorktreeDirty(git: SimpleGit, path: string): Promise<boolean> {
+  try {
+    return Boolean((await git.raw(['-C', path, 'status', '--porcelain'])).trim())
+  } catch {
+    return false
+  }
+}
+
+export async function getWorktreeListOverview(git: SimpleGit): Promise<WorktreeOverview> {
+  const currentPath = (await git.revparse(['--show-toplevel'])).trim()
+  const worktrees = parseWorktreeList(await git.raw(['worktree', 'list', '--porcelain']))
+
+  return {
+    currentPath,
+    worktrees: await Promise.all(worktrees.map(async (worktree) => ({
+      ...worktree,
+      current: worktree.path === currentPath,
+      dirty: await isWorktreeDirty(git, worktree.path),
+    }))),
+  }
+}


### PR DESCRIPTION
## Summary

- Add stash parsing and actions for create, apply, pop, drop, and diff inspection.
- Add worktree parsing and actions for create, create branch plus worktree, path display, and safe removal.
- Wire a new `workspace` focus panel into `coco log -i` for stashes and linked worktrees with destructive confirmations.
- Cover stash/worktree parsing, command construction, and renderer states with focused tests.

## Notes

This covers the acceptance criteria for #664. The broader AI-assisted worktree explanation idea should stay as a follow-up so it can share the upcoming model/telemetry strategy work instead of adding another remote call path here.

## Validation

- `npm test`
- `git diff --check`

Closes #664
