### PR TITLE
Add log TUI history actions

### DIFF
--- a/src/commands/log/historyActions.test.ts
+++ b/src/commands/log/historyActions.test.ts
@@ -1,10 +1,30 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import {
   amendHeadCommit,
+  cherryPickCommit,
+  compareCommits,
+  copyCommitHash,
+  copyCommitMessage,
+  getReflogEntries,
+  getRemoteCommitUrl,
   historyActionTestInternals,
+  openCommitOnRemote,
+  parseReflog,
   rewordHeadCommit,
+  resetToCommit,
+  revertCommit,
+  startInteractiveRebase,
 } from './historyActions'
 
 describe('log history actions', () => {
+  const commit = {
+    hash: 'abcdef1234567890',
+    shortHash: 'abcdef1',
+    message: 'feat: add history actions',
+  }
+
   it('matches full and short selected hashes against HEAD', async () => {
     const git = {
       revparse: jest.fn().mockResolvedValue('abcdef1234567890\n'),
@@ -91,5 +111,177 @@ describe('log history actions', () => {
         'type must be one of feat, fix',
       ],
     })
+  })
+
+  it('copies selected commit hash and message through the clipboard runner', async () => {
+    const clipboard = jest.fn().mockResolvedValue(undefined)
+
+    await expect(copyCommitHash(commit, clipboard)).resolves.toEqual({
+      ok: true,
+      message: 'Copied commit hash abcdef1',
+    })
+    await expect(copyCommitMessage(commit, clipboard)).resolves.toEqual({
+      ok: true,
+      message: 'Copied commit message abcdef1',
+    })
+
+    expect(clipboard).toHaveBeenNthCalledWith(1, commit.hash)
+    expect(clipboard).toHaveBeenNthCalledWith(2, commit.message)
+  })
+
+  it('builds web commit URLs from common remote URL formats', async () => {
+    const git = {
+      raw: jest.fn().mockResolvedValue('git@github.com:gfargo/coco.git\n'),
+    }
+
+    await expect(getRemoteCommitUrl(git as never, commit.hash)).resolves.toBe(
+      'https://github.com/gfargo/coco/commit/abcdef1234567890'
+    )
+    expect(historyActionTestInternals.normalizeRemoteUrl('https://github.com/gfargo/coco.git')).toBe(
+      'https://github.com/gfargo/coco'
+    )
+  })
+
+  it('opens selected commits on the inferred remote URL', async () => {
+    const openUrl = jest.fn().mockResolvedValue(undefined)
+    const git = {
+      raw: jest.fn().mockResolvedValue('git@github.com:gfargo/coco.git\n'),
+    }
+
+    await expect(openCommitOnRemote(git as never, commit, openUrl)).resolves.toEqual({
+      ok: true,
+      message: 'Opened abcdef1',
+      details: ['https://github.com/gfargo/coco/commit/abcdef1234567890'],
+    })
+    expect(openUrl).toHaveBeenCalledWith('https://github.com/gfargo/coco/commit/abcdef1234567890')
+  })
+
+  it('compares two commits with a lazy diff stat', async () => {
+    const git = {
+      raw: jest.fn().mockResolvedValue(' src/a.ts | 2 ++\n 1 file changed, 2 insertions(+)\n'),
+    }
+    const target = {
+      hash: 'fedcba9876543210',
+      shortHash: 'fedcba9',
+      message: 'fix: target',
+    }
+
+    await expect(compareCommits(git as never, commit, target)).resolves.toEqual({
+      ok: true,
+      message: 'Compared abcdef1..fedcba9',
+      details: [
+        'src/a.ts | 2 ++',
+        '1 file changed, 2 insertions(+)',
+      ],
+    })
+    expect(git.raw).toHaveBeenCalledWith([
+      'diff',
+      '--stat',
+      '--color=never',
+      'abcdef1234567890..fedcba9876543210',
+    ])
+  })
+
+  it('constructs cherry-pick and revert commands', async () => {
+    const git = {
+      revparse: jest.fn().mockResolvedValue('/tmp/coco-missing-git-state'),
+      raw: jest.fn().mockResolvedValue(''),
+    }
+
+    await expect(cherryPickCommit(git as never, commit)).resolves.toEqual({
+      ok: true,
+      message: 'Cherry-picked abcdef1',
+    })
+    await expect(revertCommit(git as never, commit)).resolves.toEqual({
+      ok: true,
+      message: 'Reverted abcdef1',
+    })
+
+    expect(git.raw).toHaveBeenNthCalledWith(1, ['cherry-pick', commit.hash])
+    expect(git.raw).toHaveBeenNthCalledWith(2, ['revert', '--no-edit', commit.hash])
+  })
+
+  it('constructs reset and rebase commands with recovery guidance', async () => {
+    const git = {
+      revparse: jest.fn().mockResolvedValue('/tmp/coco-missing-git-state'),
+      raw: jest.fn().mockResolvedValue(''),
+    }
+
+    await expect(resetToCommit(git as never, commit, 'mixed')).resolves.toEqual({
+      ok: true,
+      message: 'Reset current branch to abcdef1 with --mixed',
+      details: [
+        'Recovery: use `git reflog` to find the previous HEAD.',
+        'Then run `git reset --hard HEAD@{n}` if you need to undo this reset.',
+      ],
+    })
+    await expect(startInteractiveRebase(git as never, commit)).resolves.toEqual({
+      ok: true,
+      message: 'Started interactive rebase from abcdef1',
+      details: [
+        'Recovery: use `git rebase --abort` while the rebase is in progress.',
+        'After completion, use `git reflog` to recover the previous HEAD if needed.',
+      ],
+    })
+
+    expect(git.raw).toHaveBeenNthCalledWith(1, ['reset', '--mixed', commit.hash])
+    expect(git.raw).toHaveBeenNthCalledWith(2, ['rebase', '-i', `${commit.hash}^`])
+  })
+
+  it('blocks destructive history edits while another git operation is in progress', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'coco-history-'))
+    const mergeHead = join(tempDir, 'MERGE_HEAD')
+
+    writeFileSync(mergeHead, commit.hash)
+
+    const git = {
+      revparse: jest.fn().mockResolvedValue(mergeHead),
+      raw: jest.fn(),
+    }
+
+    try {
+      await expect(cherryPickCommit(git as never, commit)).resolves.toEqual({
+        ok: false,
+        message: 'Finish or abort the in-progress merge before editing history.',
+      })
+      expect(git.raw).not.toHaveBeenCalled()
+    } finally {
+      rmSync(tempDir, {
+        force: true,
+        recursive: true,
+      })
+    }
+  })
+
+  it('parses and loads reflog entries', async () => {
+    const git = {
+      raw: jest.fn().mockResolvedValue('HEAD@{0}\x1fabc1234\x1fcommit: feat: one\nHEAD@{1}\x1fdef5678\x1freset: moving to HEAD~1\n'),
+    }
+
+    expect(parseReflog('HEAD@{0}\x1fabc1234\x1fcommit: feat: one\n')).toEqual([
+      {
+        selector: 'HEAD@{0}',
+        hash: 'abc1234',
+        subject: 'commit: feat: one',
+      },
+    ])
+    await expect(getReflogEntries(git as never, 2)).resolves.toEqual([
+      {
+        selector: 'HEAD@{0}',
+        hash: 'abc1234',
+        subject: 'commit: feat: one',
+      },
+      {
+        selector: 'HEAD@{1}',
+        hash: 'def5678',
+        subject: 'reset: moving to HEAD~1',
+      },
+    ])
+    expect(git.raw).toHaveBeenCalledWith([
+      'reflog',
+      '--date=short',
+      '--max-count=2',
+      '--pretty=format:%gd%x1f%h%x1f%gs',
+    ])
   })
 })

--- a/src/commands/log/historyActions.ts
+++ b/src/commands/log/historyActions.ts
@@ -1,3 +1,5 @@
+import { execFile, spawn } from 'child_process'
+import { existsSync } from 'fs'
 import { SimpleGit } from 'simple-git'
 import { BranchActionResult } from './branchActions'
 
@@ -27,12 +29,131 @@ async function runAction(action: () => Promise<unknown>, successMessage: string)
   }
 }
 
+export type ResetMode = 'soft' | 'mixed' | 'hard'
+
+export type HistoryCommitRef = {
+  hash: string
+  shortHash: string
+  message: string
+}
+
+export type ReflogEntry = {
+  selector: string
+  hash: string
+  subject: string
+}
+
+export type ClipboardRunner = (value: string) => Promise<void>
+export type OpenUrlRunner = (url: string) => Promise<void>
+
+const IN_PROGRESS_GIT_PATHS = [
+  { name: 'merge', path: 'MERGE_HEAD' },
+  { name: 'cherry-pick', path: 'CHERRY_PICK_HEAD' },
+  { name: 'revert', path: 'REVERT_HEAD' },
+  { name: 'rebase', path: 'rebase-merge' },
+  { name: 'rebase', path: 'rebase-apply' },
+]
+
+function runCommandWithInput(command: string, args: string[], input: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: ['pipe', 'ignore', 'ignore'],
+    })
+
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve()
+      } else {
+        reject(new Error(`${command} exited with code ${code}`))
+      }
+    })
+    child.stdin.end(input)
+  })
+}
+
+function runCommand(command: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, (error) => {
+      if (error) {
+        reject(error)
+      } else {
+        resolve()
+      }
+    })
+  })
+}
+
+export async function defaultClipboardRunner(value: string): Promise<void> {
+  const commands = process.platform === 'darwin'
+    ? [{ command: 'pbcopy', args: [] }]
+    : process.platform === 'win32'
+      ? [{ command: 'clip', args: [] }]
+      : [
+        { command: 'wl-copy', args: [] },
+        { command: 'xclip', args: ['-selection', 'clipboard'] },
+        { command: 'xsel', args: ['--clipboard', '--input'] },
+      ]
+
+  const errors: string[] = []
+
+  for (const command of commands) {
+    try {
+      await runCommandWithInput(command.command, command.args, value)
+      return
+    } catch (error) {
+      errors.push((error as Error).message)
+    }
+  }
+
+  throw new Error(errors[0] || 'No clipboard command is available.')
+}
+
+export async function defaultOpenUrlRunner(url: string): Promise<void> {
+  if (process.platform === 'darwin') {
+    await runCommand('open', [url])
+    return
+  }
+
+  if (process.platform === 'win32') {
+    await runCommand('cmd', ['/c', 'start', '', url])
+    return
+  }
+
+  await runCommand('xdg-open', [url])
+}
+
 async function isHeadCommit(git: SimpleGit, commitHash: string): Promise<boolean> {
   const head = await git.revparse(['HEAD'])
   const normalizedHead = head.trim()
   const normalizedCommit = commitHash.trim()
 
   return normalizedHead === normalizedCommit || normalizedHead.startsWith(normalizedCommit)
+}
+
+export async function getInProgressOperation(git: SimpleGit): Promise<string | undefined> {
+  for (const entry of IN_PROGRESS_GIT_PATHS) {
+    const gitPath = (await git.revparse(['--git-path', entry.path])).trim()
+
+    if (existsSync(gitPath)) {
+      return entry.name
+    }
+  }
+
+  return undefined
+}
+
+async function guardNoInProgressOperation(git: SimpleGit): Promise<BranchActionResult | undefined> {
+  const operation = await getInProgressOperation(git)
+
+  if (!operation) {
+    return undefined
+  }
+
+  return {
+    ok: false,
+    message: `Finish or abort the in-progress ${operation} before editing history.`,
+  }
 }
 
 export async function amendHeadCommit(
@@ -79,7 +200,257 @@ export async function rewordHeadCommit(
   )
 }
 
+export async function copyCommitHash(
+  commit: HistoryCommitRef | undefined,
+  clipboard: ClipboardRunner = defaultClipboardRunner
+): Promise<BranchActionResult> {
+  if (!commit) {
+    return {
+      ok: false,
+      message: 'No commit selected.',
+    }
+  }
+
+  return runAction(
+    () => clipboard(commit.hash),
+    `Copied commit hash ${commit.shortHash}`
+  )
+}
+
+export async function copyCommitMessage(
+  commit: HistoryCommitRef | undefined,
+  clipboard: ClipboardRunner = defaultClipboardRunner
+): Promise<BranchActionResult> {
+  if (!commit) {
+    return {
+      ok: false,
+      message: 'No commit selected.',
+    }
+  }
+
+  return runAction(
+    () => clipboard(commit.message),
+    `Copied commit message ${commit.shortHash}`
+  )
+}
+
+function normalizeRemoteUrl(remoteUrl: string): string | undefined {
+  const trimmed = remoteUrl.trim().replace(/\.git$/, '')
+  const sshMatch = trimmed.match(/^git@([^:]+):(.+)$/)
+
+  if (sshMatch) {
+    return `https://${sshMatch[1]}/${sshMatch[2]}`
+  }
+
+  if (trimmed.startsWith('https://') || trimmed.startsWith('http://')) {
+    return trimmed
+  }
+
+  return undefined
+}
+
+export async function getRemoteCommitUrl(
+  git: SimpleGit,
+  commitHash: string,
+  remote = 'origin'
+): Promise<string | undefined> {
+  const remoteUrl = await git.raw(['remote', 'get-url', remote])
+  const webUrl = normalizeRemoteUrl(remoteUrl)
+
+  return webUrl ? `${webUrl}/commit/${commitHash}` : undefined
+}
+
+export async function openCommitOnRemote(
+  git: SimpleGit,
+  commit: HistoryCommitRef | undefined,
+  openUrl: OpenUrlRunner = defaultOpenUrlRunner
+): Promise<BranchActionResult> {
+  if (!commit) {
+    return {
+      ok: false,
+      message: 'No commit selected.',
+    }
+  }
+
+  try {
+    const url = await getRemoteCommitUrl(git, commit.hash)
+
+    if (!url) {
+      return {
+        ok: false,
+        message: 'Could not infer a web URL for origin.',
+      }
+    }
+
+    await openUrl(url)
+
+    return {
+      ok: true,
+      message: `Opened ${commit.shortHash}`,
+      details: [url],
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      message: (error as Error).message,
+    }
+  }
+}
+
+export async function compareCommits(
+  git: SimpleGit,
+  from: HistoryCommitRef | undefined,
+  to: HistoryCommitRef | undefined
+): Promise<BranchActionResult> {
+  if (!from || !to) {
+    return {
+      ok: false,
+      message: 'Select two commits to compare.',
+    }
+  }
+
+  try {
+    const output = await git.raw(['diff', '--stat', '--color=never', `${from.hash}..${to.hash}`])
+    const lines = compactOutputLines(output)
+
+    return {
+      ok: true,
+      message: `Compared ${from.shortHash}..${to.shortHash}`,
+      details: lines.length ? lines.slice(0, 8) : ['No file changes in range.'],
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      message: (error as Error).message,
+    }
+  }
+}
+
+export function cherryPickCommit(
+  git: SimpleGit,
+  commit: HistoryCommitRef | undefined
+): Promise<BranchActionResult> {
+  if (!commit) {
+    return Promise.resolve({
+      ok: false,
+      message: 'No commit selected.',
+    })
+  }
+
+  return guardNoInProgressOperation(git).then((blocked) => (
+    blocked || runAction(
+      () => git.raw(['cherry-pick', commit.hash]),
+      `Cherry-picked ${commit.shortHash}`
+    )
+  ))
+}
+
+export function revertCommit(
+  git: SimpleGit,
+  commit: HistoryCommitRef | undefined
+): Promise<BranchActionResult> {
+  if (!commit) {
+    return Promise.resolve({
+      ok: false,
+      message: 'No commit selected.',
+    })
+  }
+
+  return guardNoInProgressOperation(git).then((blocked) => (
+    blocked || runAction(
+      () => git.raw(['revert', '--no-edit', commit.hash]),
+      `Reverted ${commit.shortHash}`
+    )
+  ))
+}
+
+export function isResetMode(value: string): value is ResetMode {
+  return ['soft', 'mixed', 'hard'].includes(value)
+}
+
+export function resetToCommit(
+  git: SimpleGit,
+  commit: HistoryCommitRef | undefined,
+  mode: ResetMode
+): Promise<BranchActionResult> {
+  if (!commit) {
+    return Promise.resolve({
+      ok: false,
+      message: 'No commit selected.',
+    })
+  }
+
+  return guardNoInProgressOperation(git).then((blocked) => (
+    blocked || runAction(
+      () => git.raw(['reset', `--${mode}`, commit.hash]),
+      `Reset current branch to ${commit.shortHash} with --${mode}`
+    )
+  )).then((result) => ({
+    ...result,
+    details: result.ok
+      ? [
+        'Recovery: use `git reflog` to find the previous HEAD.',
+        'Then run `git reset --hard HEAD@{n}` if you need to undo this reset.',
+      ]
+      : result.details,
+  }))
+}
+
+export function startInteractiveRebase(
+  git: SimpleGit,
+  commit: HistoryCommitRef | undefined
+): Promise<BranchActionResult> {
+  if (!commit) {
+    return Promise.resolve({
+      ok: false,
+      message: 'No commit selected.',
+    })
+  }
+
+  return guardNoInProgressOperation(git).then((blocked) => (
+    blocked || runAction(
+      () => git.raw(['rebase', '-i', `${commit.hash}^`]),
+      `Started interactive rebase from ${commit.shortHash}`
+    )
+  )).then((result) => ({
+    ...result,
+    details: result.ok
+      ? [
+        'Recovery: use `git rebase --abort` while the rebase is in progress.',
+        'After completion, use `git reflog` to recover the previous HEAD if needed.',
+      ]
+      : result.details,
+  }))
+}
+
+export function parseReflog(output: string): ReflogEntry[] {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [selector, hash, subject] = line.split('\x1f')
+
+      return {
+        selector,
+        hash,
+        subject,
+      }
+    })
+}
+
+export async function getReflogEntries(git: SimpleGit, limit = 8): Promise<ReflogEntry[]> {
+  return parseReflog(await git.raw([
+    'reflog',
+    '--date=short',
+    `--max-count=${limit}`,
+    '--pretty=format:%gd%x1f%h%x1f%gs',
+  ]))
+}
+
 export const historyActionTestInternals = {
   compactOutputLines,
+  getInProgressOperation,
   isHeadCommit,
+  normalizeRemoteUrl,
 }

--- a/src/commands/log/interactive.test.ts
+++ b/src/commands/log/interactive.test.ts
@@ -187,6 +187,14 @@ const worktreeList: WorktreeListOverview = {
   ],
 }
 
+const reflog = [
+  {
+    selector: 'HEAD@{0}',
+    hash: 'abc1234',
+    subject: 'commit: feat: add interactive log',
+  },
+]
+
 describe('log interactive renderer', () => {
   it('renders commit navigation, selected details, changed files, and help', () => {
     const output = renderInteractiveLog(createLogTuiState(rows), detail, branches, pullRequest, tags, undefined, worktree, {}, {
@@ -209,10 +217,48 @@ describe('log interactive renderer', () => {
     expect(output).toContain('c commit')
     expect(output).toContain('e amend')
     expect(output).toContain('w reword')
+    expect(output).toContain('h hash')
+    expect(output).toContain('= compare')
     expect(output).toContain('S split plan')
     expect(output).toContain('A split apply')
     expect(output).toContain('Keys:')
     expect(output).toContain('Commit actions: e amend HEAD | w reword HEAD')
+  })
+
+  it('renders commit history actions and recovery state', () => {
+    const output = renderInteractiveLog(
+      createLogTuiState(rows),
+      detail,
+      branches,
+      pullRequest,
+      tags,
+      undefined,
+      worktree,
+      {
+        focus: 'commits',
+        pendingResetCommit: 'abc1234',
+        pendingResetMode: 'mixed',
+      },
+      {
+        height: 80,
+        width: 140,
+      },
+      {},
+      {
+        compareBase: {
+          hash: 'abc1234',
+          shortHash: 'abc1234',
+          message: 'feat: add interactive log',
+        },
+        reflog,
+      }
+    )
+
+    expect(output).toContain('History:')
+    expect(output).toContain('Pending reset: press X to reset --mixed to abc1234')
+    expect(output).toContain('Compare base: abc1234 feat: add interactive log')
+    expect(output).toContain('Reflog:')
+    expect(output).toContain('HEAD@{0} abc1234 commit: feat: add interactive log')
   })
 
   it('renders selected file hunks and hunk staging controls', () => {

--- a/src/commands/log/interactive.ts
+++ b/src/commands/log/interactive.ts
@@ -14,7 +14,23 @@ import {
 import { BranchOverview, BranchRef, getBranchOverview } from './branchData'
 import { runCommitWorkflow } from './commitWorkflowActions'
 import { GitCommitDetail, GitLogRow, getCommitDetail } from './data'
-import { amendHeadCommit, rewordHeadCommit } from './historyActions'
+import {
+  HistoryCommitRef,
+  ReflogEntry,
+  ResetMode,
+  amendHeadCommit,
+  cherryPickCommit,
+  compareCommits,
+  copyCommitHash,
+  copyCommitMessage,
+  getReflogEntries,
+  isResetMode,
+  openCommitOnRemote,
+  resetToCommit,
+  revertCommit,
+  rewordHeadCommit,
+  startInteractiveRebase,
+} from './historyActions'
 import { createPullRequest, openPullRequest } from './pullRequestActions'
 import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
 import { applyStash, createStash, dropStash, popStash } from './stashActions'
@@ -64,6 +80,11 @@ type RenderInteractiveLogWorkspace = {
   stashDiffSummary?: string[]
 }
 
+type RenderInteractiveLogHistory = {
+  compareBase?: HistoryCommitRef
+  reflog?: ReflogEntry[]
+}
+
 type LogTuiFocus = 'commits' | 'branches' | 'tags' | 'status' | 'workspace'
 type WorkspaceSection = 'stashes' | 'worktrees'
 
@@ -88,6 +109,11 @@ type LogTuiRenderUi = {
   workspaceSection?: WorkspaceSection
   pendingDropStash?: string
   pendingRemoveWorktree?: string
+  pendingCherryPick?: string
+  pendingRevertCommit?: string
+  pendingResetCommit?: string
+  pendingResetMode?: ResetMode
+  pendingRebaseCommit?: string
 }
 
 type LogTuiInputKind =
@@ -101,6 +127,7 @@ type LogTuiInputKind =
   | 'create-worktree'
   | 'create-branch-worktree-path'
   | 'create-branch-worktree-branch'
+  | 'reset-mode'
 
 type LogTuiInputPrompt = {
   kind: LogTuiInputKind
@@ -395,6 +422,35 @@ function renderWorkspaceOverview(
   ].map((line) => truncate(line, width))
 }
 
+function renderHistoryOverview(
+  history: RenderInteractiveLogHistory,
+  ui: LogTuiRenderUi,
+  width: number
+): string[] {
+  const pendingLine = ui.pendingCherryPick
+    ? `Pending cherry-pick: press Y to cherry-pick ${ui.pendingCherryPick}`
+    : ui.pendingRevertCommit
+      ? `Pending revert: press V to revert ${ui.pendingRevertCommit}`
+      : ui.pendingResetCommit && ui.pendingResetMode
+        ? `Pending reset: press X to reset --${ui.pendingResetMode} to ${ui.pendingResetCommit}`
+        : ui.pendingRebaseCommit
+          ? `Pending rebase: press B to start rebase from ${ui.pendingRebaseCommit}`
+          : undefined
+  const compareLine = history.compareBase
+    ? `Compare base: ${history.compareBase.shortHash} ${history.compareBase.message}`
+    : 'Compare: press = on a commit, then = on another commit'
+  const reflogLines = history.reflog?.slice(0, 5).map((entry) => (
+    `  ${entry.selector} ${entry.hash} ${entry.subject}`
+  )) || []
+
+  return [
+    'History:',
+    pendingLine || 'History actions: h hash | H message | O open | = compare | y cherry-pick | V revert | ! reset | B rebase | F reflog',
+    compareLine,
+    ...(reflogLines.length ? ['Reflog:', ...reflogLines] : []),
+  ].map((line) => truncate(line, width))
+}
+
 function renderDetail(detail: GitCommitDetail | undefined, width: number): string[] {
   if (!detail) {
     return ['Loading selected commit details...']
@@ -433,7 +489,8 @@ export function renderInteractiveLog(
   worktree?: WorktreeOverview,
   ui: LogTuiRenderUi = {},
   options: RenderInteractiveLogOptions = {},
-  workspace: RenderInteractiveLogWorkspace = {}
+  workspace: RenderInteractiveLogWorkspace = {},
+  history: RenderInteractiveLogHistory = {}
 ): string {
   const height = options.height || process.stdout.rows || DEFAULT_HEIGHT
   const width = options.width || process.stdout.columns || DEFAULT_WIDTH
@@ -442,10 +499,10 @@ export function renderInteractiveLog(
   const graphMode = state.fullGraph ? 'full graph' : 'compact graph'
   const focus = ui.focus || 'commits'
   const help = state.showHelp
-    ? 'Keys: tab focus | up/down move | n branch | t tag | C PR | c commit | e amend | w reword | q quit'
+    ? 'Keys: tab focus | up/down move | n branch | t tag | C PR | c commit | history h/H/O/= | q quit'
     : 'Press ? for help'
   const commitActions = focus === 'commits'
-    ? 'Commit actions: e amend HEAD | w reword HEAD'
+    ? 'Commit actions: e amend HEAD | w reword HEAD | h hash | H message | O open | = compare'
     : ''
   const detailHeader = selected
     ? `Selected: ${selected.shortHash} ${selected.message}`
@@ -463,6 +520,7 @@ export function renderInteractiveLog(
       width
     ).slice(0, 12)
     : []
+  const historyLines = renderHistoryOverview(history, ui, width).slice(0, 8)
   const listHeight = Math.max(4, Math.floor(height * 0.35))
   const detailHeight = Math.max(
     6,
@@ -473,6 +531,7 @@ export function renderInteractiveLog(
       tagLines.length -
       statusLines.length -
       workspaceLines.length -
+      historyLines.length -
       11
   )
   const detailLines = renderDetail(detail, width).slice(0, detailHeight)
@@ -492,6 +551,7 @@ export function renderInteractiveLog(
     ...tagLines,
     ...statusLines,
     ...workspaceLines,
+    ...historyLines,
     '',
     ...renderCommitList(state, listHeight, width),
     '',
@@ -519,6 +579,8 @@ export async function startInteractiveLog(
   let stashes: StashOverview | undefined
   let worktreeList: WorktreeListOverview | undefined
   let stashDiffSummary: string[] | undefined
+  let compareBase: HistoryCommitRef | undefined
+  let reflog: ReflogEntry[] | undefined
   let focus: LogTuiFocus = 'commits'
   let branchIndex = 0
   let tagIndex = 0
@@ -536,6 +598,11 @@ export async function startInteractiveLog(
   let pendingRevertHunk: string | undefined
   let pendingDropStash: string | undefined
   let pendingRemoveWorktree: string | undefined
+  let pendingCherryPick: string | undefined
+  let pendingRevertCommit: string | undefined
+  let pendingResetCommit: string | undefined
+  let pendingResetMode: ResetMode | undefined
+  let pendingRebaseCommit: string | undefined
   let inputPrompt: LogTuiInputPrompt | undefined
   let pullRequestDraft = false
 
@@ -627,6 +694,11 @@ export async function startInteractiveLog(
         workspaceSection,
         pendingDropStash,
         pendingRemoveWorktree,
+        pendingCherryPick,
+        pendingRevertCommit,
+        pendingResetCommit,
+        pendingResetMode,
+        pendingRebaseCommit,
       }
 
       output.write(
@@ -640,7 +712,8 @@ export async function startInteractiveLog(
           worktree,
           ui,
           {},
-          { stashes, worktreeList, stashDiffSummary }
+          { stashes, worktreeList, stashDiffSummary },
+          { compareBase, reflog }
         )}\n`,
         'utf8'
       )
@@ -660,7 +733,8 @@ export async function startInteractiveLog(
               worktree,
               ui,
               {},
-              { stashes, worktreeList, stashDiffSummary }
+              { stashes, worktreeList, stashDiffSummary },
+              { compareBase, reflog }
             )}\n`,
             'utf8'
           )
@@ -719,6 +793,11 @@ export async function startInteractiveLog(
       pendingRevertHunk = undefined
       pendingDropStash = undefined
       pendingRemoveWorktree = undefined
+      pendingCherryPick = undefined
+      pendingRevertCommit = undefined
+      pendingResetCommit = undefined
+      pendingResetMode = undefined
+      pendingRebaseCommit = undefined
       inputPrompt = undefined
 
       if (refresh) {
@@ -742,6 +821,17 @@ export async function startInteractiveLog(
     const selectedStatusHunk = () => statusHunks?.hunks[statusHunkIndex]
     const selectedStash = (): StashEntry | undefined => stashes?.stashes[stashIndex]
     const selectedWorkspaceWorktree = (): WorktreeEntry | undefined => worktreeList?.worktrees[worktreeIndex]
+    const selectedHistoryCommit = (): HistoryCommitRef | undefined => {
+      const selected = getSelectedCommit(state)
+
+      return selected
+        ? {
+          hash: selected.hash,
+          shortHash: selected.shortHash,
+          message: selected.message,
+        }
+        : undefined
+    }
 
     const selectedRef = () => {
       if (focus === 'branches') {
@@ -862,6 +952,11 @@ export async function startInteractiveLog(
       pendingRevertHunk = undefined
       pendingDropStash = undefined
       pendingRemoveWorktree = undefined
+      pendingCherryPick = undefined
+      pendingRevertCommit = undefined
+      pendingResetCommit = undefined
+      pendingResetMode = undefined
+      pendingRebaseCommit = undefined
       void render()
     }
 
@@ -882,7 +977,22 @@ export async function startInteractiveLog(
         return
       }
 
-      if (prompt.kind === 'create-branch') {
+      if (prompt.kind === 'reset-mode' && prompt.commitHash) {
+        if (!isResetMode(value)) {
+          statusMessage = 'Reset cancelled: mode must be soft, mixed, or hard.'
+          statusDetails = undefined
+          await render()
+          return
+        }
+
+        pendingResetCommit = prompt.commitHash
+        pendingResetMode = value
+        statusMessage = `Press X to confirm reset --${value} to ${prompt.commitHash}`
+        statusDetails = [
+          'This moves the current branch. Use reflog to recover the previous HEAD.',
+        ]
+        await render()
+      } else if (prompt.kind === 'create-branch') {
         await runBranchAction(() => createBranch(git, value, prompt.sourceRef))
       } else if (prompt.kind === 'rename-branch' && prompt.branchName) {
         await runBranchAction(() => renameBranch(git, prompt.branchName as string, value))
@@ -1028,6 +1138,11 @@ export async function startInteractiveLog(
         pendingRevertHunk = undefined
         pendingDropStash = undefined
         pendingRemoveWorktree = undefined
+        pendingCherryPick = undefined
+        pendingRevertCommit = undefined
+        pendingResetCommit = undefined
+        pendingResetMode = undefined
+        pendingRebaseCommit = undefined
         void render()
       } else if ((key.name === 'up' || key.name === 'k') && focus === 'branches') {
         moveBranchSelection(-1)
@@ -1143,6 +1258,117 @@ export async function startInteractiveLog(
         if (selectedWorktree) {
           void runBranchAction(() => Promise.resolve(worktreePathAction(selectedWorktree)), false)
         }
+      } else if (key.name === 'h' && focus === 'commits') {
+        void runBranchAction(() => copyCommitHash(selectedHistoryCommit()), false, 'Copying commit hash...')
+      } else if (sequence === 'H' && focus === 'commits') {
+        void runBranchAction(
+          () => copyCommitMessage(selectedHistoryCommit()),
+          false,
+          'Copying commit message...'
+        )
+      } else if (sequence === 'O' && focus === 'commits') {
+        void runBranchAction(
+          () => openCommitOnRemote(git, selectedHistoryCommit()),
+          false,
+          'Opening selected commit...'
+        )
+      } else if (sequence === '=' && focus === 'commits') {
+        const commit = selectedHistoryCommit()
+
+        if (!compareBase && commit) {
+          compareBase = commit
+          statusMessage = `Compare base set to ${commit.shortHash}`
+          statusDetails = ['Move to another commit and press = again to compare.']
+          void render()
+        } else if (commit) {
+          const base = compareBase
+          compareBase = undefined
+          void runBranchAction(
+            () => compareCommits(git, base, commit),
+            false,
+            'Comparing selected commits...'
+          )
+        }
+      } else if (key.name === 'y' && focus === 'commits') {
+        const commit = selectedHistoryCommit()
+
+        if (commit) {
+          pendingCherryPick = commit.hash
+          statusMessage = `Press Y to confirm cherry-picking ${commit.shortHash}`
+          statusDetails = ['This applies the selected commit onto the current branch.']
+          void render()
+        }
+      } else if (sequence === 'Y' && focus === 'commits') {
+        const commit = selectedHistoryCommit()
+
+        if (commit && pendingCherryPick === commit.hash) {
+          void runBranchAction(
+            () => cherryPickCommit(git, commit),
+            true,
+            'Cherry-picking selected commit...'
+          )
+        }
+      } else if (sequence === 'V' && focus === 'commits') {
+        const commit = selectedHistoryCommit()
+
+        if (commit && pendingRevertCommit === commit.hash) {
+          void runBranchAction(
+            () => revertCommit(git, commit),
+            true,
+            'Reverting selected commit...'
+          )
+        } else if (commit) {
+          pendingRevertCommit = commit.hash
+          statusMessage = `Press V again to confirm reverting ${commit.shortHash}`
+          statusDetails = ['This creates a new commit that reverses the selected commit.']
+          void render()
+        }
+      } else if (sequence === '!' && focus === 'commits') {
+        const commit = selectedHistoryCommit()
+
+        if (commit) {
+          startInputPrompt({
+            kind: 'reset-mode',
+            label: `Reset ${commit.shortHash} mode (soft|mixed|hard)`,
+            value: 'mixed',
+            sourceRef: commit.hash,
+            commitHash: commit.hash,
+          })
+        }
+      } else if (sequence === 'X' && focus === 'commits') {
+        const commit = selectedHistoryCommit()
+
+        if (commit && pendingResetCommit === commit.hash && pendingResetMode) {
+          void runBranchAction(
+            () => resetToCommit(git, commit, pendingResetMode as ResetMode),
+            true,
+            `Resetting current branch --${pendingResetMode}...`
+          )
+        }
+      } else if (sequence === 'B' && focus === 'commits') {
+        const commit = selectedHistoryCommit()
+
+        if (commit && pendingRebaseCommit === commit.hash) {
+          void runBranchAction(
+            () => startInteractiveRebase(git, commit),
+            true,
+            'Starting interactive rebase...'
+          )
+        } else if (commit) {
+          pendingRebaseCommit = commit.hash
+          statusMessage = `Press B again to start interactive rebase from ${commit.shortHash}`
+          statusDetails = ['Use `git rebase --abort` if the rebase needs to be cancelled.']
+          void render()
+        }
+      } else if (sequence === 'F' && focus === 'commits') {
+        void runBranchAction(async () => {
+          reflog = await getReflogEntries(git)
+
+          return {
+            ok: true,
+            message: 'Loaded reflog recovery view',
+          }
+        }, false, 'Loading reflog...')
       } else if (key.name === 'return' && focus === 'status') {
         const hunk = selectedStatusHunk()
 
@@ -1279,6 +1505,8 @@ export async function startInteractiveLog(
             refreshPullRequest(),
             refreshTags(),
             refreshWorktree(),
+            refreshStashes(),
+            refreshWorktreeList(),
           ])
           await refreshStatusHunks()
 


### PR DESCRIPTION
## Summary

- Add selected-commit history actions for copying hash/message, opening inferred remote commit URLs, comparing two commits with lazy diff stats, cherry-picking, and reverting.
- Add protected reset and interactive rebase flows with explicit confirmations and reflog recovery guidance.
- Add reflog loading for recovery context in the interactive history panel.
- Block destructive history edits while merge, rebase, cherry-pick, or revert state is already in progress.
- Cover command construction, safety gates, URL inference, reflog parsing, and renderer states with tests.

## Validation

- `git diff --check`
- `npm test`
- `npm run coco:ts -- log -i --limit 1 >/tmp/coco-log-history.txt && rg "History:|History actions|Compare:" /tmp/coco-log-history.txt`

Closes #665
