### PR TITLE
Add log TUI operation state support

### DIFF
--- a/src/commands/log/commitWorkflowActions.test.ts
+++ b/src/commands/log/commitWorkflowActions.test.ts
@@ -82,6 +82,30 @@ describe('log commit workflow actions', () => {
     )
   })
 
+  it('passes no-verify into TUI commit workflows', async () => {
+    mockedCommitHandler.mockImplementation(async () => {
+      process.stdout.write('fix: skip hooks\n')
+    })
+    mockedCreateCommit.mockResolvedValue({} as Awaited<ReturnType<typeof createCommit>>)
+
+    await expect(runCommitWorkflow({ action: 'commit', git, noVerify: true })).resolves.toEqual({
+      ok: true,
+      message: 'fix: skip hooks',
+    })
+    expect(mockedCommitHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        noVerify: true,
+      }),
+      expect.anything()
+    )
+    expect(mockedCreateCommit).toHaveBeenCalledWith(
+      'fix: skip hooks',
+      git,
+      undefined,
+      { noVerify: true }
+    )
+  })
+
   it('builds split apply argv for commit split application', async () => {
     mockedCommitHandler.mockImplementation(async () => {
       process.stdout.write('Created 2 split commit(s).\n')

--- a/src/commands/log/commitWorkflowActions.ts
+++ b/src/commands/log/commitWorkflowActions.ts
@@ -19,6 +19,7 @@ export type CommitWorkflowResult = {
 type CommitWorkflowInput = {
   action: CommitWorkflowAction
   git?: SimpleGit
+  noVerify?: boolean
 }
 
 type CommitWorkflowArgv = Arguments<CommitOptions> & {
@@ -104,8 +105,10 @@ function formatCommitFailure(error: unknown): CommitWorkflowResult {
 export async function runCommitWorkflow({
   action,
   git = getRepo(),
+  noVerify = false,
 }: CommitWorkflowInput): Promise<CommitWorkflowResult> {
   const argv = createCommitWorkflowArgv(action)
+  argv.noVerify = noVerify
   const logger = new Logger({ silent: true })
   const config = loadConfig<CommitOptions, CommitWorkflowArgv>(argv)
   const originalWrite = process.stdout.write.bind(process.stdout)

--- a/src/commands/log/historyActions.ts
+++ b/src/commands/log/historyActions.ts
@@ -1,7 +1,7 @@
 import { execFile, spawn } from 'child_process'
-import { existsSync } from 'fs'
 import { SimpleGit } from 'simple-git'
 import { BranchActionResult } from './branchActions'
+import { getInProgressOperationType } from './operationData'
 
 function compactOutputLines(output: string): string[] {
   return output
@@ -45,14 +45,6 @@ export type ReflogEntry = {
 
 export type ClipboardRunner = (value: string) => Promise<void>
 export type OpenUrlRunner = (url: string) => Promise<void>
-
-const IN_PROGRESS_GIT_PATHS = [
-  { name: 'merge', path: 'MERGE_HEAD' },
-  { name: 'cherry-pick', path: 'CHERRY_PICK_HEAD' },
-  { name: 'revert', path: 'REVERT_HEAD' },
-  { name: 'rebase', path: 'rebase-merge' },
-  { name: 'rebase', path: 'rebase-apply' },
-]
 
 function runCommandWithInput(command: string, args: string[], input: string): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -132,15 +124,9 @@ async function isHeadCommit(git: SimpleGit, commitHash: string): Promise<boolean
 }
 
 export async function getInProgressOperation(git: SimpleGit): Promise<string | undefined> {
-  for (const entry of IN_PROGRESS_GIT_PATHS) {
-    const gitPath = (await git.revparse(['--git-path', entry.path])).trim()
+  const operation = await getInProgressOperationType(git)
 
-    if (existsSync(gitPath)) {
-      return entry.name
-    }
-  }
-
-  return undefined
+  return operation === 'none' ? undefined : operation
 }
 
 async function guardNoInProgressOperation(git: SimpleGit): Promise<BranchActionResult | undefined> {

--- a/src/commands/log/interactive.test.ts
+++ b/src/commands/log/interactive.test.ts
@@ -8,6 +8,7 @@ import { WorktreeOverview } from './statusData'
 import { WorktreeHunkOverview } from './statusHunks'
 import { StashOverview } from './stashData'
 import { WorktreeOverview as WorktreeListOverview } from './worktreeData'
+import { GitOperationOverview } from './operationData'
 
 const rows: GitLogRow[] = [
   {
@@ -195,6 +196,29 @@ const reflog = [
   },
 ]
 
+const operationOverview: GitOperationOverview = {
+  operation: 'merge',
+  conflictedFiles: [
+    {
+      path: 'src/conflict.ts',
+      indexStatus: 'U',
+      worktreeStatus: 'U',
+    },
+  ],
+  conflictMarkers: [
+    {
+      path: 'src/conflict.ts',
+      line: 12,
+      marker: '<<<<<<< HEAD',
+    },
+  ],
+  hooks: {
+    hooksPath: '/repo/.git/hooks',
+    configuredHooks: ['pre-commit', 'commit-msg'],
+  },
+  aiConflictHelpAvailable: true,
+}
+
 describe('log interactive renderer', () => {
   it('renders commit navigation, selected details, changed files, and help', () => {
     const output = renderInteractiveLog(createLogTuiState(rows), detail, branches, pullRequest, tags, undefined, worktree, {}, {
@@ -221,8 +245,41 @@ describe('log interactive renderer', () => {
     expect(output).toContain('= compare')
     expect(output).toContain('S split plan')
     expect(output).toContain('A split apply')
+    expect(output).toContain('Operation: unavailable')
     expect(output).toContain('Keys:')
     expect(output).toContain('Commit actions: e amend HEAD | w reword HEAD')
+  })
+
+  it('renders in-progress operation, conflicts, hooks, and no-verify state', () => {
+    const output = renderInteractiveLog(
+      createLogTuiState(rows),
+      detail,
+      branches,
+      pullRequest,
+      tags,
+      undefined,
+      worktree,
+      {
+        focus: 'commits',
+        pendingOperationAction: 'abort',
+        noVerify: true,
+      },
+      {
+        height: 90,
+        width: 140,
+      },
+      {},
+      {},
+      operationOverview
+    )
+
+    expect(output).toContain('Operation: merge in progress | no-verify on')
+    expect(output).toContain('Pending abort: press G to confirm abort merge')
+    expect(output).toContain('Conflicts: 1')
+    expect(output).toContain('UU src/conflict.ts')
+    expect(output).toContain('src/conflict.ts:12 <<<<<<< HEAD')
+    expect(output).toContain('Hooks: pre-commit, commit-msg')
+    expect(output).toContain('AI conflict help: opt-in action planned')
   })
 
   it('renders commit history actions and recovery state', () => {

--- a/src/commands/log/interactive.ts
+++ b/src/commands/log/interactive.ts
@@ -63,6 +63,8 @@ import {
   createLogTuiState,
   getSelectedCommit,
 } from './interactiveState'
+import { abortOperation, continueOperation, skipOperation } from './operationActions'
+import { GitOperationOverview, getGitOperationOverview } from './operationData'
 
 type LogTuiStreams = {
   input?: NodeJS.ReadStream
@@ -114,6 +116,8 @@ type LogTuiRenderUi = {
   pendingResetCommit?: string
   pendingResetMode?: ResetMode
   pendingRebaseCommit?: string
+  pendingOperationAction?: 'continue' | 'abort' | 'skip'
+  noVerify?: boolean
 }
 
 type LogTuiInputKind =
@@ -451,6 +455,53 @@ function renderHistoryOverview(
   ].map((line) => truncate(line, width))
 }
 
+function renderOperationOverview(
+  overview: GitOperationOverview | undefined,
+  ui: LogTuiRenderUi,
+  width: number
+): string[] {
+  if (!overview) {
+    return ['Operation: unavailable']
+  }
+
+  if (overview.operation === 'none' && overview.conflictedFiles.length === 0 && !ui.pendingOperationAction) {
+    return [
+      `Operation: none | no-verify ${ui.noVerify ? 'on' : 'off'}`,
+      'Operation actions: none active | N no-verify',
+    ].map((line) => truncate(line, width))
+  }
+
+  const operation = overview.operation === 'none' ? 'none' : `${overview.operation} in progress`
+  const pendingLine = ui.pendingOperationAction
+    ? `Pending ${ui.pendingOperationAction}: press G to confirm ${ui.pendingOperationAction} ${overview.operation}`
+    : overview.operation === 'none'
+      ? 'Operation actions: none active | N no-verify'
+      : 'Operation actions: g continue | A abort | K skip | N no-verify'
+  const conflictLines = overview.conflictedFiles.slice(0, 5).map((file) => (
+    `  ${file.indexStatus}${file.worktreeStatus} ${file.path}`
+  ))
+  const markerLines = overview.conflictMarkers.slice(0, 5).map((marker) => (
+    `  ${marker.path}:${marker.line} ${marker.marker}`
+  ))
+  const hookLine = overview.hooks.configuredHooks.length
+    ? `Hooks: ${overview.hooks.configuredHooks.slice(0, 5).join(', ')}`
+    : 'Hooks: none configured'
+  const aiLine = overview.aiConflictHelpAvailable
+    ? 'AI conflict help: opt-in action planned; no remote call made automatically'
+    : 'AI conflict help: available when conflicts exist'
+
+  return [
+    `Operation: ${operation} | no-verify ${ui.noVerify ? 'on' : 'off'}`,
+    pendingLine,
+    `Conflicts: ${overview.conflictedFiles.length}`,
+    ...(conflictLines.length ? conflictLines : ['  No conflicted files.']),
+    ...(markerLines.length ? ['Conflict markers:', ...markerLines] : []),
+    hookLine,
+    `Hooks path: ${overview.hooks.hooksPath}`,
+    aiLine,
+  ].map((line) => truncate(line, width))
+}
+
 function renderDetail(detail: GitCommitDetail | undefined, width: number): string[] {
   if (!detail) {
     return ['Loading selected commit details...']
@@ -490,7 +541,8 @@ export function renderInteractiveLog(
   ui: LogTuiRenderUi = {},
   options: RenderInteractiveLogOptions = {},
   workspace: RenderInteractiveLogWorkspace = {},
-  history: RenderInteractiveLogHistory = {}
+  history: RenderInteractiveLogHistory = {},
+  operation?: GitOperationOverview
 ): string {
   const height = options.height || process.stdout.rows || DEFAULT_HEIGHT
   const width = options.width || process.stdout.columns || DEFAULT_WIDTH
@@ -521,6 +573,7 @@ export function renderInteractiveLog(
     ).slice(0, 12)
     : []
   const historyLines = renderHistoryOverview(history, ui, width).slice(0, 8)
+  const operationLines = renderOperationOverview(operation, ui, width).slice(0, 12)
   const listHeight = Math.max(4, Math.floor(height * 0.35))
   const detailHeight = Math.max(
     6,
@@ -532,6 +585,7 @@ export function renderInteractiveLog(
       statusLines.length -
       workspaceLines.length -
       historyLines.length -
+      operationLines.length -
       11
   )
   const detailLines = renderDetail(detail, width).slice(0, detailHeight)
@@ -552,6 +606,7 @@ export function renderInteractiveLog(
     ...statusLines,
     ...workspaceLines,
     ...historyLines,
+    ...operationLines,
     '',
     ...renderCommitList(state, listHeight, width),
     '',
@@ -581,6 +636,7 @@ export async function startInteractiveLog(
   let stashDiffSummary: string[] | undefined
   let compareBase: HistoryCommitRef | undefined
   let reflog: ReflogEntry[] | undefined
+  let operationOverview: GitOperationOverview | undefined
   let focus: LogTuiFocus = 'commits'
   let branchIndex = 0
   let tagIndex = 0
@@ -603,8 +659,10 @@ export async function startInteractiveLog(
   let pendingResetCommit: string | undefined
   let pendingResetMode: ResetMode | undefined
   let pendingRebaseCommit: string | undefined
+  let pendingOperationAction: 'continue' | 'abort' | 'skip' | undefined
   let inputPrompt: LogTuiInputPrompt | undefined
   let pullRequestDraft = false
+  let noVerify = false
 
   async function loadSelectedDetail(): Promise<GitCommitDetail | undefined> {
     const selected = getSelectedCommit(state)
@@ -625,13 +683,14 @@ export async function startInteractiveLog(
 
   if (!input.isTTY || !output.isTTY) {
     try {
-      [branches, pullRequest, tags, worktree, stashes, worktreeList] = await Promise.all([
+      [branches, pullRequest, tags, worktree, stashes, worktreeList, operationOverview] = await Promise.all([
         getBranchOverview(git),
         getPullRequestOverview(git),
         getTagOverview(git),
         getWorktreeOverview(git),
         getStashOverview(git),
         getWorktreeListOverview(git),
+        getGitOperationOverview(git),
       ])
     } catch {
       branches = undefined
@@ -648,7 +707,9 @@ export async function startInteractiveLog(
         worktree,
         {},
         {},
-        { stashes, worktreeList }
+        { stashes, worktreeList },
+        {},
+        operationOverview
       )}\n`,
       'utf8'
     )
@@ -699,6 +760,8 @@ export async function startInteractiveLog(
         pendingResetCommit,
         pendingResetMode,
         pendingRebaseCommit,
+        pendingOperationAction,
+        noVerify,
       }
 
       output.write(
@@ -713,7 +776,8 @@ export async function startInteractiveLog(
           ui,
           {},
           { stashes, worktreeList, stashDiffSummary },
-          { compareBase, reflog }
+          { compareBase, reflog },
+          operationOverview
         )}\n`,
         'utf8'
       )
@@ -734,7 +798,8 @@ export async function startInteractiveLog(
               ui,
               {},
               { stashes, worktreeList, stashDiffSummary },
-              { compareBase, reflog }
+              { compareBase, reflog },
+              operationOverview
             )}\n`,
             'utf8'
           )
@@ -783,6 +848,10 @@ export async function startInteractiveLog(
       worktreeIndex = Math.max(0, Math.min(worktreeIndex, (worktreeList?.worktrees.length || 1) - 1))
     }
 
+    const refreshOperationOverview = async () => {
+      operationOverview = await getGitOperationOverview(git)
+    }
+
     const setActionResult = async (result: BranchActionResult, refresh = true) => {
       statusMessage = result.message
       statusDetails = result.details
@@ -798,6 +867,7 @@ export async function startInteractiveLog(
       pendingResetCommit = undefined
       pendingResetMode = undefined
       pendingRebaseCommit = undefined
+      pendingOperationAction = undefined
       inputPrompt = undefined
 
       if (refresh) {
@@ -808,6 +878,7 @@ export async function startInteractiveLog(
           refreshWorktree(),
           refreshStashes(),
           refreshWorktreeList(),
+          refreshOperationOverview(),
         ])
         await refreshStatusHunks()
       }
@@ -957,6 +1028,7 @@ export async function startInteractiveLog(
       pendingResetCommit = undefined
       pendingResetMode = undefined
       pendingRebaseCommit = undefined
+      pendingOperationAction = undefined
       void render()
     }
 
@@ -1143,6 +1215,7 @@ export async function startInteractiveLog(
         pendingResetCommit = undefined
         pendingResetMode = undefined
         pendingRebaseCommit = undefined
+        pendingOperationAction = undefined
         void render()
       } else if ((key.name === 'up' || key.name === 'k') && focus === 'branches') {
         moveBranchSelection(-1)
@@ -1258,6 +1331,41 @@ export async function startInteractiveLog(
         if (selectedWorktree) {
           void runBranchAction(() => Promise.resolve(worktreePathAction(selectedWorktree)), false)
         }
+      } else if (sequence === 'N') {
+        noVerify = !noVerify
+        statusMessage = `Commit no-verify mode: ${noVerify ? 'on' : 'off'}`
+        statusDetails = noVerify
+          ? ['TUI commit actions will pass --no-verify and skip Git hooks.']
+          : ['TUI commit actions will run Git hooks.']
+        void render()
+      } else if (key.name === 'g' && focus === 'commits' && operationOverview && operationOverview.operation !== 'none') {
+        pendingOperationAction = 'continue'
+        statusMessage = `Press G to continue ${operationOverview?.operation}`
+        statusDetails = ['Coco will not continue until you confirm.']
+        void render()
+      } else if (sequence === 'A' && focus === 'commits' && operationOverview && operationOverview.operation !== 'none') {
+        pendingOperationAction = 'abort'
+        statusMessage = `Press G to abort ${operationOverview?.operation}`
+        statusDetails = ['This asks Git to abort the in-progress operation.']
+        void render()
+      } else if (sequence === 'K' && focus === 'commits' && operationOverview && operationOverview.operation !== 'none') {
+        pendingOperationAction = 'skip'
+        statusMessage = `Press G to skip ${operationOverview?.operation}`
+        statusDetails = ['Skip is supported by rebase, cherry-pick, and revert operations.']
+        void render()
+      } else if (sequence === 'G' && focus === 'commits' && pendingOperationAction && operationOverview) {
+        const action = pendingOperationAction
+        const operation = operationOverview.operation
+
+        void runBranchAction(
+          () => action === 'continue'
+            ? continueOperation(git, operation)
+            : action === 'abort'
+              ? abortOperation(git, operation)
+              : skipOperation(git, operation),
+          true,
+          `Running git ${operation} --${action}...`
+        )
       } else if (key.name === 'h' && focus === 'commits') {
         void runBranchAction(() => copyCommitHash(selectedHistoryCommit()), false, 'Copying commit hash...')
       } else if (sequence === 'H' && focus === 'commits') {
@@ -1436,19 +1544,19 @@ export async function startInteractiveLog(
         }
       } else if (key.name === 'c' && focus === 'status') {
         void runBranchAction(
-          () => runCommitWorkflow({ action: 'commit', git }),
+          () => runCommitWorkflow({ action: 'commit', git, noVerify }),
           true,
           'Generating commit message...'
         )
       } else if (sequence === 'S' && focus === 'status') {
         void runBranchAction(
-          () => runCommitWorkflow({ action: 'split-plan', git }),
+          () => runCommitWorkflow({ action: 'split-plan', git, noVerify }),
           true,
           'Generating commit split plan...'
         )
       } else if (sequence === 'A' && focus === 'status') {
         void runBranchAction(
-          () => runCommitWorkflow({ action: 'split-apply', git }),
+          () => runCommitWorkflow({ action: 'split-apply', git, noVerify }),
           true,
           'Applying commit split plan...'
         )
@@ -1675,6 +1783,7 @@ export async function startInteractiveLog(
       refreshWorktree(),
       refreshStashes(),
       refreshWorktreeList(),
+      refreshOperationOverview(),
     ])
       .then(async () => {
         await refreshStatusHunks()
@@ -1688,6 +1797,7 @@ export async function startInteractiveLog(
         statusHunks = undefined
         stashes = undefined
         worktreeList = undefined
+        operationOverview = undefined
       })
     void render()
   })

--- a/src/commands/log/operationActions.test.ts
+++ b/src/commands/log/operationActions.test.ts
@@ -1,0 +1,71 @@
+import {
+  abortOperation,
+  continueOperation,
+  operationActionTestInternals,
+  skipOperation,
+} from './operationActions'
+
+describe('log operation actions', () => {
+  it('constructs continue, abort, and skip commands for rebase operations', async () => {
+    const git = {
+      raw: jest.fn().mockResolvedValue(''),
+    }
+
+    await expect(continueOperation(git as never, 'rebase')).resolves.toEqual({
+      ok: true,
+      message: 'Continued rebase',
+    })
+    await expect(abortOperation(git as never, 'rebase')).resolves.toEqual({
+      ok: true,
+      message: 'Aborted rebase',
+    })
+    await expect(skipOperation(git as never, 'rebase')).resolves.toEqual({
+      ok: true,
+      message: 'Skipped rebase',
+    })
+
+    expect(git.raw).toHaveBeenNthCalledWith(1, ['rebase', '--continue'])
+    expect(git.raw).toHaveBeenNthCalledWith(2, ['rebase', '--abort'])
+    expect(git.raw).toHaveBeenNthCalledWith(3, ['rebase', '--skip'])
+  })
+
+  it('uses merge-specific continue and abort commands', async () => {
+    expect(operationActionTestInternals.getOperationCommand('merge', 'continue')).toEqual({
+      args: ['merge', '--continue'],
+      successMessage: 'Continued merge',
+    })
+    expect(operationActionTestInternals.getOperationCommand('merge', 'abort')).toEqual({
+      args: ['merge', '--abort'],
+      successMessage: 'Aborted merge',
+    })
+    expect(operationActionTestInternals.getOperationCommand('merge', 'skip')).toBeUndefined()
+  })
+
+  it('blocks actions when no operation is active', async () => {
+    const git = {
+      raw: jest.fn(),
+    }
+
+    await expect(continueOperation(git as never, 'none')).resolves.toEqual({
+      ok: false,
+      message: 'No in-progress Git operation to continue.',
+    })
+    await expect(abortOperation(git as never, 'none')).resolves.toEqual({
+      ok: false,
+      message: 'No in-progress Git operation to abort.',
+    })
+    expect(git.raw).not.toHaveBeenCalled()
+  })
+
+  it('returns readable command failures', async () => {
+    const git = {
+      raw: jest.fn().mockRejectedValue(new Error('conflicts remain\nfix conflict.ts first')),
+    }
+
+    await expect(continueOperation(git as never, 'merge')).resolves.toEqual({
+      ok: false,
+      message: 'conflicts remain',
+      details: ['fix conflict.ts first'],
+    })
+  })
+})

--- a/src/commands/log/operationActions.ts
+++ b/src/commands/log/operationActions.ts
@@ -1,0 +1,135 @@
+import { SimpleGit } from 'simple-git'
+import { BranchActionResult } from './branchActions'
+import { GitOperationType } from './operationData'
+
+type OperationCommand = {
+  args: string[]
+  successMessage: string
+}
+
+function compactOutputLines(output: string): string[] {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+async function runAction(action: () => Promise<unknown>, successMessage: string): Promise<BranchActionResult> {
+  try {
+    await action()
+
+    return {
+      ok: true,
+      message: successMessage,
+    }
+  } catch (error) {
+    const details = compactOutputLines((error as Error).message)
+
+    return {
+      ok: false,
+      message: details[0] || 'Git operation action failed.',
+      details: details.slice(1, 8),
+    }
+  }
+}
+
+function getOperationCommand(
+  operation: GitOperationType,
+  action: 'continue' | 'abort' | 'skip'
+): OperationCommand | undefined {
+  if (operation === 'none') {
+    return undefined
+  }
+
+  if (operation === 'merge') {
+    if (action === 'continue') {
+      return {
+        args: ['merge', '--continue'],
+        successMessage: 'Continued merge',
+      }
+    }
+
+    if (action === 'abort') {
+      return {
+        args: ['merge', '--abort'],
+        successMessage: 'Aborted merge',
+      }
+    }
+
+    return undefined
+  }
+
+  return {
+    args: [operation, `--${action}`],
+    successMessage: action === 'skip'
+      ? `Skipped ${operation}`
+      : action === 'continue'
+        ? `Continued ${operation}`
+        : `Aborted ${operation}`,
+  }
+}
+
+export function continueOperation(
+  git: SimpleGit,
+  operation: GitOperationType
+): Promise<BranchActionResult> {
+  const command = getOperationCommand(operation, 'continue')
+
+  if (!command) {
+    return Promise.resolve({
+      ok: false,
+      message: operation === 'none'
+        ? 'No in-progress Git operation to continue.'
+        : `Continue is not supported for ${operation}.`,
+    })
+  }
+
+  return runAction(
+    () => git.raw(command.args),
+    command.successMessage
+  )
+}
+
+export function abortOperation(
+  git: SimpleGit,
+  operation: GitOperationType
+): Promise<BranchActionResult> {
+  const command = getOperationCommand(operation, 'abort')
+
+  if (!command) {
+    return Promise.resolve({
+      ok: false,
+      message: 'No in-progress Git operation to abort.',
+    })
+  }
+
+  return runAction(
+    () => git.raw(command.args),
+    command.successMessage
+  )
+}
+
+export function skipOperation(
+  git: SimpleGit,
+  operation: GitOperationType
+): Promise<BranchActionResult> {
+  const command = getOperationCommand(operation, 'skip')
+
+  if (!command) {
+    return Promise.resolve({
+      ok: false,
+      message: operation === 'merge'
+        ? 'Skip is not supported for merge operations.'
+        : 'No in-progress Git operation to skip.',
+    })
+  }
+
+  return runAction(
+    () => git.raw(command.args),
+    command.successMessage
+  )
+}
+
+export const operationActionTestInternals = {
+  getOperationCommand,
+}

--- a/src/commands/log/operationData.test.ts
+++ b/src/commands/log/operationData.test.ts
@@ -1,0 +1,197 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  getConflictMarkers,
+  getGitOperationOverview,
+  getHookOverview,
+  getInProgressOperationType,
+  parseConflictMarkers,
+  parseConflictedFiles,
+} from './operationData'
+
+describe('log operation data', () => {
+  it('detects conflicted files from porcelain status', () => {
+    expect(parseConflictedFiles([
+      'UU src/conflict.ts',
+      'AA src/add-both.ts',
+      ' M src/normal.ts',
+      '?? src/new.ts',
+    ].join('\n'))).toEqual([
+      {
+        path: 'src/conflict.ts',
+        indexStatus: 'U',
+        worktreeStatus: 'U',
+      },
+      {
+        path: 'src/add-both.ts',
+        indexStatus: 'A',
+        worktreeStatus: 'A',
+      },
+    ])
+  })
+
+  it('parses conflict markers with line numbers', () => {
+    expect(parseConflictMarkers('src/conflict.ts', [
+      'const value = 1',
+      '<<<<<<< HEAD',
+      'current',
+      '=======',
+      'incoming',
+      '>>>>>>> branch',
+    ].join('\n'))).toEqual([
+      {
+        path: 'src/conflict.ts',
+        line: 2,
+        marker: '<<<<<<< HEAD',
+      },
+      {
+        path: 'src/conflict.ts',
+        line: 4,
+        marker: '=======',
+      },
+      {
+        path: 'src/conflict.ts',
+        line: 6,
+        marker: '>>>>>>> branch',
+      },
+    ])
+  })
+
+  it('loads conflict markers from conflicted files', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'coco-conflicts-'))
+    const filePath = join(root, 'src/conflict.ts')
+
+    mkdirSync(join(root, 'src'))
+    writeFileSync(filePath, [
+      '<<<<<<< HEAD',
+      'current',
+      '=======',
+      'incoming',
+      '>>>>>>> branch',
+    ].join('\n'))
+
+    const git = {
+      revparse: jest.fn().mockResolvedValue(root),
+    }
+
+    try {
+      await expect(getConflictMarkers(git as never, [{
+        path: 'src/conflict.ts',
+        indexStatus: 'U',
+        worktreeStatus: 'U',
+      }])).resolves.toHaveLength(3)
+    } finally {
+      rmSync(root, {
+        force: true,
+        recursive: true,
+      })
+    }
+  })
+
+  it('detects in-progress operations from git paths', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'coco-operation-'))
+    const mergeHead = join(tempDir, 'MERGE_HEAD')
+
+    writeFileSync(mergeHead, 'abc123')
+
+    const git = {
+      revparse: jest.fn().mockImplementation(async (args: string[]) => join(tempDir, args.at(-1) as string)),
+    }
+
+    try {
+      await expect(getInProgressOperationType(git as never)).resolves.toBe('merge')
+    } finally {
+      rmSync(tempDir, {
+        force: true,
+        recursive: true,
+      })
+    }
+  })
+
+  it('loads hook overview from default hooks path', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'coco-hooks-'))
+    const hooksPath = join(root, '.git/hooks')
+
+    mkdirSync(hooksPath, {
+      recursive: true,
+    })
+    writeFileSync(join(hooksPath, 'pre-commit'), '#!/bin/sh\n')
+    writeFileSync(join(hooksPath, 'pre-push.sample'), '#!/bin/sh\n')
+
+    const git = {
+      raw: jest.fn().mockRejectedValue(new Error('missing config')),
+      revparse: jest.fn().mockImplementation(async (args: string[]) => {
+        if (args.includes('--show-toplevel')) {
+          return root
+        }
+
+        return hooksPath
+      }),
+    }
+
+    try {
+      await expect(getHookOverview(git as never)).resolves.toEqual({
+        hooksPath,
+        configuredHooks: ['pre-commit'],
+      })
+    } finally {
+      rmSync(root, {
+        force: true,
+        recursive: true,
+      })
+    }
+  })
+
+  it('loads the combined operation overview', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'coco-operation-overview-'))
+    const gitDir = join(root, '.git')
+    const mergeHead = join(gitDir, 'MERGE_HEAD')
+    const hooksPath = join(gitDir, 'hooks')
+    const conflictPath = join(root, 'conflict.ts')
+
+    mkdirSync(hooksPath, {
+      recursive: true,
+    })
+    writeFileSync(mergeHead, 'abc123')
+    writeFileSync(join(hooksPath, 'commit-msg'), '#!/bin/sh\n')
+    writeFileSync(conflictPath, '<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n')
+
+    const git = {
+      raw: jest.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'status') {
+          return 'UU conflict.ts\n'
+        }
+
+        throw new Error('missing config')
+      }),
+      revparse: jest.fn().mockImplementation(async (args: string[]) => {
+        if (args.includes('--show-toplevel')) {
+          return root
+        }
+
+        return join(gitDir, args.at(-1) as string)
+      }),
+    }
+
+    try {
+      await expect(getGitOperationOverview(git as never)).resolves.toMatchObject({
+        operation: 'merge',
+        conflictedFiles: [
+          {
+            path: 'conflict.ts',
+            indexStatus: 'U',
+            worktreeStatus: 'U',
+          },
+        ],
+        aiConflictHelpAvailable: true,
+      })
+    } finally {
+      rmSync(root, {
+        force: true,
+        recursive: true,
+      })
+    }
+  })
+})
+

--- a/src/commands/log/operationData.ts
+++ b/src/commands/log/operationData.ts
@@ -1,0 +1,174 @@
+import { existsSync, readdirSync, readFileSync } from 'fs'
+import { isAbsolute, join } from 'path'
+import { SimpleGit } from 'simple-git'
+
+export type GitOperationType = 'none' | 'merge' | 'rebase' | 'cherry-pick' | 'revert'
+
+export type ConflictFile = {
+  path: string
+  indexStatus: string
+  worktreeStatus: string
+}
+
+export type ConflictMarker = {
+  path: string
+  line: number
+  marker: string
+}
+
+export type GitHookOverview = {
+  hooksPath: string
+  configuredHooks: string[]
+}
+
+export type GitOperationOverview = {
+  operation: GitOperationType
+  conflictedFiles: ConflictFile[]
+  conflictMarkers: ConflictMarker[]
+  hooks: GitHookOverview
+  aiConflictHelpAvailable: boolean
+}
+
+const OPERATION_PATHS: Array<{ operation: Exclude<GitOperationType, 'none'>; path: string }> = [
+  { operation: 'merge', path: 'MERGE_HEAD' },
+  { operation: 'rebase', path: 'rebase-merge' },
+  { operation: 'rebase', path: 'rebase-apply' },
+  { operation: 'cherry-pick', path: 'CHERRY_PICK_HEAD' },
+  { operation: 'revert', path: 'REVERT_HEAD' },
+]
+
+const UNMERGED_STATUSES = new Set([
+  'DD',
+  'AU',
+  'UD',
+  'UA',
+  'DU',
+  'AA',
+  'UU',
+])
+
+async function pathExists(git: SimpleGit, path: string): Promise<boolean> {
+  return existsSync((await git.revparse(['--git-path', path])).trim())
+}
+
+export async function getInProgressOperationType(git: SimpleGit): Promise<GitOperationType> {
+  for (const entry of OPERATION_PATHS) {
+    if (await pathExists(git, entry.path)) {
+      return entry.operation
+    }
+  }
+
+  return 'none'
+}
+
+export function parseConflictedFiles(statusOutput: string): ConflictFile[] {
+  return statusOutput
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => {
+      const indexStatus = line[0] || ' '
+      const worktreeStatus = line[1] || ' '
+      const rawPath = line.slice(3)
+      const path = rawPath.includes(' -> ') ? rawPath.split(' -> ').at(-1) as string : rawPath
+
+      return {
+        path,
+        indexStatus,
+        worktreeStatus,
+      }
+    })
+    .filter((file) => (
+      UNMERGED_STATUSES.has(`${file.indexStatus}${file.worktreeStatus}`) ||
+      file.indexStatus === 'U' ||
+      file.worktreeStatus === 'U'
+    ))
+}
+
+export async function getConflictedFiles(git: SimpleGit): Promise<ConflictFile[]> {
+  return parseConflictedFiles(await git.raw(['status', '--porcelain']))
+}
+
+export function parseConflictMarkers(path: string, content: string): ConflictMarker[] {
+  return content
+    .split('\n')
+    .map((line, index) => ({
+      path,
+      line: index + 1,
+      marker: line.trim(),
+    }))
+    .filter((entry) => (
+      entry.marker.startsWith('<<<<<<<') ||
+      entry.marker.startsWith('=======') ||
+      entry.marker.startsWith('>>>>>>>')
+    ))
+}
+
+export async function getConflictMarkers(
+  git: SimpleGit,
+  files: ConflictFile[],
+  limit = 12
+): Promise<ConflictMarker[]> {
+  const root = (await git.revparse(['--show-toplevel'])).trim()
+  const markers: ConflictMarker[] = []
+
+  for (const file of files) {
+    if (markers.length >= limit) {
+      break
+    }
+
+    const filePath = join(root, file.path)
+
+    if (!existsSync(filePath)) {
+      continue
+    }
+
+    markers.push(...parseConflictMarkers(file.path, readFileSync(filePath, 'utf8')))
+  }
+
+  return markers.slice(0, limit)
+}
+
+async function getConfiguredHooksPath(git: SimpleGit): Promise<string | undefined> {
+  try {
+    const output = (await git.raw(['config', '--get', 'core.hooksPath'])).trim()
+
+    return output || undefined
+  } catch {
+    return undefined
+  }
+}
+
+export async function getHookOverview(git: SimpleGit): Promise<GitHookOverview> {
+  const configuredHooksPath = await getConfiguredHooksPath(git)
+  const gitHooksPath = (await git.revparse(['--git-path', 'hooks'])).trim()
+  const root = (await git.revparse(['--show-toplevel'])).trim()
+  const hooksPath = configuredHooksPath
+    ? isAbsolute(configuredHooksPath)
+      ? configuredHooksPath
+      : join(root, configuredHooksPath)
+    : gitHooksPath
+  const configuredHooks = existsSync(hooksPath)
+    ? readdirSync(hooksPath)
+      .filter((entry) => !entry.endsWith('.sample'))
+      .sort()
+    : []
+
+  return {
+    hooksPath,
+    configuredHooks,
+  }
+}
+
+export async function getGitOperationOverview(git: SimpleGit): Promise<GitOperationOverview> {
+  const conflictedFiles = await getConflictedFiles(git)
+
+  return {
+    operation: await getInProgressOperationType(git),
+    conflictedFiles,
+    conflictMarkers: await getConflictMarkers(git, conflictedFiles),
+    hooks: await getHookOverview(git),
+    aiConflictHelpAvailable: conflictedFiles.length > 0,
+  }
+}
+


### PR DESCRIPTION
## Summary

- Add a reusable operation data layer for merge/rebase/cherry-pick/revert detection, conflicted file parsing, conflict marker snippets, and Git hook path discovery.
- Add operation actions for continue, abort, and skip with readable failure details.
- Surface operation state in `coco log -i`, including conflicts, hook paths, configured hooks, and explicit confirmation before continue/abort/skip.
- Add a visible `N` no-verify toggle for TUI commit workflows and pass it through to commit generation/application.
- Reuse the new operation data layer from history edit safety guards so in-progress operation detection is centralized.

## Validation

- `git diff --check`
- `npm run test:jest -- src/commands/log/historyActions.test.ts src/commands/log/operationData.test.ts src/commands/log/operationActions.test.ts src/commands/log/interactive.test.ts src/commands/log/commitWorkflowActions.test.ts`
- `npm run coco:ts -- log -i --limit 1 >/tmp/coco-log-operation.txt && rg "Operation:|Hooks path|no-verify" /tmp/coco-log-operation.txt`
- `npm test`

Closes #666
