### PR TITLE
Add log TUI provider integrations

### DIFF
--- a/src/commands/log/historyActions.ts
+++ b/src/commands/log/historyActions.ts
@@ -2,6 +2,7 @@ import { execFile, spawn } from 'child_process'
 import { SimpleGit } from 'simple-git'
 import { BranchActionResult } from './branchActions'
 import { getInProgressOperationType } from './operationData'
+import { buildProviderUrl, getProviderOverview } from './providerData'
 
 function compactOutputLines(output: string): string[] {
   return output
@@ -240,6 +241,19 @@ export async function getRemoteCommitUrl(
   commitHash: string,
   remote = 'origin'
 ): Promise<string | undefined> {
+  try {
+    const provider = await getProviderOverview(git)
+
+    if (provider.repository.remote === remote) {
+      return buildProviderUrl(provider.repository, {
+        type: 'commit',
+        commit: commitHash,
+      })
+    }
+  } catch {
+    // Fall back to direct remote URL parsing for older mocks and unsupported providers.
+  }
+
   const remoteUrl = await git.raw(['remote', 'get-url', remote])
   const webUrl = normalizeRemoteUrl(remoteUrl)
 

--- a/src/commands/log/interactive.test.ts
+++ b/src/commands/log/interactive.test.ts
@@ -9,6 +9,7 @@ import { WorktreeHunkOverview } from './statusHunks'
 import { StashOverview } from './stashData'
 import { WorktreeOverview as WorktreeListOverview } from './worktreeData'
 import { GitOperationOverview } from './operationData'
+import { ProviderOverview } from './providerData'
 
 const rows: GitLogRow[] = [
   {
@@ -219,6 +220,32 @@ const operationOverview: GitOperationOverview = {
   aiConflictHelpAvailable: true,
 }
 
+const providerOverview: ProviderOverview = {
+  authenticated: true,
+  currentBranch: 'feature/log-prs',
+  repository: {
+    provider: 'github',
+    remote: 'origin',
+    owner: 'gfargo',
+    name: 'coco',
+    webUrl: 'https://github.com/gfargo/coco',
+    defaultBranch: 'main',
+  },
+  currentPullRequest: {
+    number: 123,
+    title: 'Add PR workflow',
+    state: 'OPEN',
+    isDraft: false,
+    reviewDecision: 'APPROVED',
+    statusCheckRollup: [
+      {
+        name: 'test',
+        conclusion: 'SUCCESS',
+      },
+    ],
+  },
+}
+
 describe('log interactive renderer', () => {
   it('renders commit navigation, selected details, changed files, and help', () => {
     const output = renderInteractiveLog(createLogTuiState(rows), detail, branches, pullRequest, tags, undefined, worktree, {}, {
@@ -248,6 +275,38 @@ describe('log interactive renderer', () => {
     expect(output).toContain('Operation: unavailable')
     expect(output).toContain('Keys:')
     expect(output).toContain('Commit actions: e amend HEAD | w reword HEAD')
+  })
+
+  it('renders provider context, checks, and compare state', () => {
+    const output = renderInteractiveLog(
+      createLogTuiState(rows),
+      detail,
+      branches,
+      pullRequest,
+      tags,
+      undefined,
+      worktree,
+      {
+        focus: 'commits',
+      },
+      {
+        height: 90,
+        width: 140,
+      },
+      {},
+      {
+        providerCompareBase: 'main',
+      },
+      undefined,
+      providerOverview
+    )
+
+    expect(output).toContain('Provider: github gfargo/coco | default main | authenticated')
+    expect(output).toContain('Repository: https://github.com/gfargo/coco')
+    expect(output).toContain('Provider PR: #123 OPEN review APPROVED')
+    expect(output).toContain('Checks: test:SUCCESS')
+    expect(output).toContain('Provider compare base: main')
+    expect(output).toContain('Provider actions: R repo | L branch | O commit | U compare | o PR')
   })
 
   it('renders in-progress operation, conflicts, hooks, and no-verify state', () => {

--- a/src/commands/log/interactive.ts
+++ b/src/commands/log/interactive.ts
@@ -25,13 +25,12 @@ import {
   copyCommitMessage,
   getReflogEntries,
   isResetMode,
-  openCommitOnRemote,
   resetToCommit,
   revertCommit,
   rewordHeadCommit,
   startInteractiveRebase,
 } from './historyActions'
-import { createPullRequest, openPullRequest } from './pullRequestActions'
+import { createPullRequest } from './pullRequestActions'
 import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
 import { applyStash, createStash, dropStash, popStash } from './stashActions'
 import { StashEntry, StashOverview, getStashDiffSummary, getStashOverview } from './stashData'
@@ -65,6 +64,8 @@ import {
 } from './interactiveState'
 import { abortOperation, continueOperation, skipOperation } from './operationActions'
 import { GitOperationOverview, getGitOperationOverview } from './operationData'
+import { openProviderUrl } from './providerActions'
+import { ProviderOverview, getProviderOverview, providerBranchName } from './providerData'
 
 type LogTuiStreams = {
   input?: NodeJS.ReadStream
@@ -85,6 +86,7 @@ type RenderInteractiveLogWorkspace = {
 type RenderInteractiveLogHistory = {
   compareBase?: HistoryCommitRef
   reflog?: ReflogEntry[]
+  providerCompareBase?: string
 }
 
 type LogTuiFocus = 'commits' | 'branches' | 'tags' | 'status' | 'workspace'
@@ -302,6 +304,52 @@ function renderPullRequestOverview(
     `Title: ${pr.title}`,
     `URL: ${pr.url}`,
     action,
+  ].map((line) => truncate(line, width))
+}
+
+function renderProviderOverview(
+  overview: ProviderOverview | undefined,
+  history: RenderInteractiveLogHistory,
+  width: number
+): string[] {
+  if (!overview) {
+    return ['Provider: unavailable']
+  }
+
+  const repository = overview.repository
+  const repoName = repository.owner && repository.name
+    ? `${repository.owner}/${repository.name}`
+    : repository.message || 'unsupported remote'
+
+  if (repository.provider === 'unsupported' || !repository.webUrl) {
+    return [
+      `Provider: ${repoName} | ${overview.message || repository.message || 'unsupported remote'}`,
+    ].map((line) => truncate(line, width))
+  }
+
+  const defaultBranch = repository.defaultBranch || '<unknown>'
+  const auth = overview.authenticated ? 'authenticated' : 'offline'
+  const pr = overview.currentPullRequest
+  const checks = pr?.statusCheckRollup?.length
+    ? pr.statusCheckRollup
+      .slice(0, 3)
+      .map((check) => `${check.name}:${check.conclusion || check.status || 'pending'}`)
+      .join(', ')
+    : undefined
+  const prLine = pr
+    ? `Provider PR: #${pr.number} ${pr.state}${pr.isDraft ? ' draft' : ''} review ${pr.reviewDecision || '<unknown>'}`
+    : `Provider PR: ${overview.message || 'none for current branch'}`
+  const compareLine = history.providerCompareBase
+    ? `Provider compare base: ${history.providerCompareBase}`
+    : 'Provider compare: press U on a ref, then U on another ref'
+
+  return [
+    `Provider: ${repository.provider} ${repoName} | default ${defaultBranch} | ${auth}`,
+    repository.webUrl ? `Repository: ${repository.webUrl}` : `Provider fallback: ${overview.message || repository.message || 'unsupported'}`,
+    prLine,
+    checks ? `Checks: ${checks}` : 'Checks: unavailable',
+    compareLine,
+    'Provider actions: R repo | L branch | O commit | U compare | o PR',
   ].map((line) => truncate(line, width))
 }
 
@@ -542,7 +590,8 @@ export function renderInteractiveLog(
   options: RenderInteractiveLogOptions = {},
   workspace: RenderInteractiveLogWorkspace = {},
   history: RenderInteractiveLogHistory = {},
-  operation?: GitOperationOverview
+  operation?: GitOperationOverview,
+  provider?: ProviderOverview
 ): string {
   const height = options.height || process.stdout.rows || DEFAULT_HEIGHT
   const width = options.width || process.stdout.columns || DEFAULT_WIDTH
@@ -561,6 +610,7 @@ export function renderInteractiveLog(
     : 'Selected: none'
   const branchLines = renderBranchOverview(branches, ui, width).slice(0, 12)
   const pullRequestLines = renderPullRequestOverview(pullRequest, ui, width).slice(0, 4)
+  const providerLines = renderProviderOverview(provider, history, width).slice(0, 6)
   const tagLines = renderTagOverview(tags, tagRangeSummary, ui, width).slice(0, 10)
   const statusLines = renderStatusOverview(worktree, ui, width).slice(0, 10)
   const workspaceLines = workspace.stashes || workspace.worktreeList
@@ -581,6 +631,7 @@ export function renderInteractiveLog(
       listHeight -
       branchLines.length -
       pullRequestLines.length -
+      providerLines.length -
       tagLines.length -
       statusLines.length -
       workspaceLines.length -
@@ -602,6 +653,7 @@ export function renderInteractiveLog(
     '',
     ...branchLines,
     ...pullRequestLines,
+    ...providerLines,
     ...tagLines,
     ...statusLines,
     ...workspaceLines,
@@ -635,8 +687,10 @@ export async function startInteractiveLog(
   let worktreeList: WorktreeListOverview | undefined
   let stashDiffSummary: string[] | undefined
   let compareBase: HistoryCommitRef | undefined
+  let providerCompareBase: string | undefined
   let reflog: ReflogEntry[] | undefined
   let operationOverview: GitOperationOverview | undefined
+  let providerOverview: ProviderOverview | undefined
   let focus: LogTuiFocus = 'commits'
   let branchIndex = 0
   let tagIndex = 0
@@ -683,7 +737,7 @@ export async function startInteractiveLog(
 
   if (!input.isTTY || !output.isTTY) {
     try {
-      [branches, pullRequest, tags, worktree, stashes, worktreeList, operationOverview] = await Promise.all([
+      [branches, pullRequest, tags, worktree, stashes, worktreeList, operationOverview, providerOverview] = await Promise.all([
         getBranchOverview(git),
         getPullRequestOverview(git),
         getTagOverview(git),
@@ -691,6 +745,7 @@ export async function startInteractiveLog(
         getStashOverview(git),
         getWorktreeListOverview(git),
         getGitOperationOverview(git),
+        getProviderOverview(git),
       ])
     } catch {
       branches = undefined
@@ -709,7 +764,8 @@ export async function startInteractiveLog(
         {},
         { stashes, worktreeList },
         {},
-        operationOverview
+        operationOverview,
+        providerOverview
       )}\n`,
       'utf8'
     )
@@ -776,8 +832,9 @@ export async function startInteractiveLog(
           ui,
           {},
           { stashes, worktreeList, stashDiffSummary },
-          { compareBase, reflog },
-          operationOverview
+          { compareBase, reflog, providerCompareBase },
+          operationOverview,
+          providerOverview
         )}\n`,
         'utf8'
       )
@@ -798,8 +855,9 @@ export async function startInteractiveLog(
               ui,
               {},
               { stashes, worktreeList, stashDiffSummary },
-              { compareBase, reflog },
-              operationOverview
+              { compareBase, reflog, providerCompareBase },
+              operationOverview,
+              providerOverview
             )}\n`,
             'utf8'
           )
@@ -852,6 +910,10 @@ export async function startInteractiveLog(
       operationOverview = await getGitOperationOverview(git)
     }
 
+    const refreshProviderOverview = async () => {
+      providerOverview = await getProviderOverview(git)
+    }
+
     const setActionResult = async (result: BranchActionResult, refresh = true) => {
       statusMessage = result.message
       statusDetails = result.details
@@ -879,6 +941,7 @@ export async function startInteractiveLog(
           refreshStashes(),
           refreshWorktreeList(),
           refreshOperationOverview(),
+          refreshProviderOverview(),
         ])
         await refreshStatusHunks()
       }
@@ -907,6 +970,18 @@ export async function startInteractiveLog(
     const selectedRef = () => {
       if (focus === 'branches') {
         return selectedBranch()?.shortName
+      }
+
+      if (focus === 'tags') {
+        return selectedTag()?.name
+      }
+
+      return getSelectedCommit(state)?.hash
+    }
+
+    const selectedProviderRef = () => {
+      if (focus === 'branches') {
+        return providerBranchName(selectedBranch())
       }
 
       if (focus === 'tags') {
@@ -1366,6 +1441,53 @@ export async function startInteractiveLog(
           true,
           `Running git ${operation} --${action}...`
         )
+      } else if (sequence === 'R' && focus !== 'tags') {
+        void runBranchAction(
+          () => openProviderUrl(providerOverview?.repository, { type: 'repo' }),
+          false,
+          'Opening provider repository...'
+        )
+      } else if (sequence === 'L' && focus === 'branches') {
+        const branch = providerBranchName(selectedBranch())
+
+        if (branch) {
+          void runBranchAction(
+            () => openProviderUrl(providerOverview?.repository, { type: 'branch', branch }),
+            false,
+            'Opening provider branch...'
+          )
+        }
+      } else if (sequence === 'O' && focus === 'commits') {
+        const commit = selectedHistoryCommit()
+
+        if (commit) {
+          void runBranchAction(
+            () => openProviderUrl(providerOverview?.repository, { type: 'commit', commit: commit.hash }),
+            false,
+            'Opening selected commit...'
+          )
+        }
+      } else if (sequence === 'U') {
+        const ref = selectedProviderRef()
+
+        if (!providerCompareBase && ref) {
+          providerCompareBase = ref
+          statusMessage = `Provider compare base set to ${ref}`
+          statusDetails = ['Move to another ref and press U again to open a compare URL.']
+          void render()
+        } else if (ref) {
+          const base = providerCompareBase
+          providerCompareBase = undefined
+          void runBranchAction(
+            () => openProviderUrl(providerOverview?.repository, {
+              type: 'compare',
+              base: base as string,
+              head: ref,
+            }),
+            false,
+            'Opening provider compare URL...'
+          )
+        }
       } else if (key.name === 'h' && focus === 'commits') {
         void runBranchAction(() => copyCommitHash(selectedHistoryCommit()), false, 'Copying commit hash...')
       } else if (sequence === 'H' && focus === 'commits') {
@@ -1373,12 +1495,6 @@ export async function startInteractiveLog(
           () => copyCommitMessage(selectedHistoryCommit()),
           false,
           'Copying commit message...'
-        )
-      } else if (sequence === 'O' && focus === 'commits') {
-        void runBranchAction(
-          () => openCommitOnRemote(git, selectedHistoryCommit()),
-          false,
-          'Opening selected commit...'
         )
       } else if (sequence === '=' && focus === 'commits') {
         const commit = selectedHistoryCommit()
@@ -1747,10 +1863,14 @@ export async function startInteractiveLog(
         statusDetails = undefined
         void render()
       } else if (key.name === 'o') {
-        const url = pullRequest?.currentPullRequest?.url
+        const number = providerOverview?.currentPullRequest?.number || pullRequest?.currentPullRequest?.number
 
-        if (url) {
-          void runBranchAction(() => openPullRequest(url), false)
+        if (number) {
+          void runBranchAction(
+            () => openProviderUrl(providerOverview?.repository, { type: 'pull-request', number }),
+            false,
+            'Opening pull request...'
+          )
         } else {
           statusMessage = 'No current pull request to open.'
           statusDetails = undefined
@@ -1784,6 +1904,7 @@ export async function startInteractiveLog(
       refreshStashes(),
       refreshWorktreeList(),
       refreshOperationOverview(),
+      refreshProviderOverview(),
     ])
       .then(async () => {
         await refreshStatusHunks()
@@ -1798,6 +1919,7 @@ export async function startInteractiveLog(
         stashes = undefined
         worktreeList = undefined
         operationOverview = undefined
+        providerOverview = undefined
       })
     void render()
   })

--- a/src/commands/log/providerActions.test.ts
+++ b/src/commands/log/providerActions.test.ts
@@ -1,0 +1,36 @@
+import { openProviderUrl } from './providerActions'
+
+describe('log provider actions', () => {
+  const repository = {
+    provider: 'github' as const,
+    remote: 'origin',
+    owner: 'gfargo',
+    name: 'coco',
+    webUrl: 'https://github.com/gfargo/coco',
+  }
+
+  it('opens supported provider URLs', async () => {
+    const openUrl = jest.fn().mockResolvedValue(undefined)
+
+    await expect(openProviderUrl(repository, { type: 'commit', commit: 'abc123' }, openUrl)).resolves.toEqual({
+      ok: true,
+      message: 'Opened provider URL: https://github.com/gfargo/coco/commit/abc123',
+      details: ['https://github.com/gfargo/coco/commit/abc123'],
+    })
+    expect(openUrl).toHaveBeenCalledWith('https://github.com/gfargo/coco/commit/abc123')
+  })
+
+  it('reports unsupported provider URLs clearly', async () => {
+    const openUrl = jest.fn()
+
+    await expect(openProviderUrl({
+      provider: 'unsupported',
+      remote: 'origin',
+    }, { type: 'repo' }, openUrl)).resolves.toEqual({
+      ok: false,
+      message: 'No supported remote provider URL is available.',
+    })
+    expect(openUrl).not.toHaveBeenCalled()
+  })
+})
+

--- a/src/commands/log/providerActions.ts
+++ b/src/commands/log/providerActions.ts
@@ -1,0 +1,30 @@
+import { BranchActionResult } from './branchActions'
+import { defaultOpenUrlRunner, OpenUrlRunner } from './historyActions'
+import { ProviderRepository, ProviderUrlTarget, buildProviderUrl } from './providerData'
+
+export function openProviderUrl(
+  repository: ProviderRepository | undefined,
+  target: ProviderUrlTarget,
+  openUrl: OpenUrlRunner = defaultOpenUrlRunner
+): Promise<BranchActionResult> {
+  const url = repository ? buildProviderUrl(repository, target) : undefined
+
+  if (!url) {
+    return Promise.resolve({
+      ok: false,
+      message: 'No supported remote provider URL is available.',
+    })
+  }
+
+  return openUrl(url)
+    .then(() => ({
+      ok: true,
+      message: `Opened provider URL: ${url}`,
+      details: [url],
+    }))
+    .catch((error) => ({
+      ok: false,
+      message: (error as Error).message,
+    }))
+}
+

--- a/src/commands/log/providerData.test.ts
+++ b/src/commands/log/providerData.test.ts
@@ -1,0 +1,174 @@
+import {
+  buildProviderUrl,
+  getProviderOverview,
+  getProviderRepository,
+  parseGitHubRemoteUrl,
+  providerBranchName,
+} from './providerData'
+
+describe('log provider data', () => {
+  const repository = {
+    provider: 'github' as const,
+    remote: 'origin',
+    owner: 'gfargo',
+    name: 'coco',
+    webUrl: 'https://github.com/gfargo/coco',
+    defaultBranch: 'main',
+  }
+
+  it('parses GitHub HTTPS, SSH, and git remote URLs', () => {
+    expect(parseGitHubRemoteUrl('https://github.com/gfargo/coco.git')).toEqual({
+      owner: 'gfargo',
+      name: 'coco',
+      webUrl: 'https://github.com/gfargo/coco',
+    })
+    expect(parseGitHubRemoteUrl('git@github.com:gfargo/coco.git')).toEqual({
+      owner: 'gfargo',
+      name: 'coco',
+      webUrl: 'https://github.com/gfargo/coco',
+    })
+    expect(parseGitHubRemoteUrl('ssh://git@github.com/gfargo/coco.git')).toEqual({
+      owner: 'gfargo',
+      name: 'coco',
+      webUrl: 'https://github.com/gfargo/coco',
+    })
+    expect(parseGitHubRemoteUrl('git://github.com/gfargo/coco.git')).toEqual({
+      owner: 'gfargo',
+      name: 'coco',
+      webUrl: 'https://github.com/gfargo/coco',
+    })
+  })
+
+  it('falls back for unsupported providers', () => {
+    expect(getProviderRepository('origin', 'git@gitlab.com:gfargo/coco.git')).toEqual({
+      provider: 'unsupported',
+      remote: 'origin',
+      message: 'Unsupported remote provider for origin.',
+    })
+  })
+
+  it('builds GitHub provider URLs', () => {
+    expect(buildProviderUrl(repository, { type: 'repo' })).toBe('https://github.com/gfargo/coco')
+    expect(buildProviderUrl(repository, { type: 'branch', branch: 'feature/log ui' })).toBe(
+      'https://github.com/gfargo/coco/tree/feature%2Flog%20ui'
+    )
+    expect(buildProviderUrl(repository, { type: 'commit', commit: 'abc123' })).toBe(
+      'https://github.com/gfargo/coco/commit/abc123'
+    )
+    expect(buildProviderUrl(repository, { type: 'pull-request', number: 42 })).toBe(
+      'https://github.com/gfargo/coco/pull/42'
+    )
+    expect(buildProviderUrl(repository, { type: 'compare', base: 'main', head: 'feature/log ui' })).toBe(
+      'https://github.com/gfargo/coco/compare/main...feature%2Flog%20ui'
+    )
+  })
+
+  it('loads provider overview with default branch and PR status when authenticated', async () => {
+    const git = {
+      getRemotes: jest.fn().mockResolvedValue([
+        {
+          name: 'origin',
+          refs: {
+            fetch: 'git@github.com:gfargo/coco.git',
+            push: 'git@github.com:gfargo/coco.git',
+          },
+        },
+      ]),
+      raw: jest.fn().mockResolvedValue('feature/log\n'),
+    }
+    const runner = jest.fn().mockImplementation(async (args: string[]) => {
+      if (args[0] === 'auth') {
+        return ''
+      }
+
+      if (args[0] === 'repo') {
+        return JSON.stringify({
+          defaultBranchRef: {
+            name: 'main',
+          },
+        })
+      }
+
+      return JSON.stringify({
+        number: 12,
+        title: 'Add provider panel',
+        state: 'OPEN',
+        isDraft: false,
+        reviewDecision: 'APPROVED',
+        statusCheckRollup: [
+          {
+            name: 'test',
+            conclusion: 'SUCCESS',
+          },
+        ],
+      })
+    })
+
+    await expect(getProviderOverview(git as never, runner)).resolves.toMatchObject({
+      authenticated: true,
+      currentBranch: 'feature/log',
+      repository: {
+        provider: 'github',
+        owner: 'gfargo',
+        name: 'coco',
+        defaultBranch: 'main',
+      },
+      currentPullRequest: {
+        number: 12,
+        reviewDecision: 'APPROVED',
+      },
+    })
+  })
+
+  it('has a clear fallback when GitHub auth is unavailable', async () => {
+    const git = {
+      getRemotes: jest.fn().mockResolvedValue([
+        {
+          name: 'origin',
+          refs: {
+            fetch: 'https://github.com/gfargo/coco.git',
+          },
+        },
+      ]),
+      raw: jest.fn().mockResolvedValue('main\n'),
+    }
+    const runner = jest.fn().mockRejectedValue(new Error('not authenticated'))
+
+    await expect(getProviderOverview(git as never, runner)).resolves.toMatchObject({
+      authenticated: false,
+      message: 'GitHub CLI is missing or not authenticated.',
+      repository: {
+        provider: 'github',
+        owner: 'gfargo',
+        name: 'coco',
+      },
+    })
+  })
+
+  it('normalizes local and remote branch refs for provider URLs', () => {
+    expect(providerBranchName({
+      type: 'remote',
+      name: 'refs/remotes/origin/feature/log',
+      shortName: 'origin/feature/log',
+      hash: 'abc123',
+      current: false,
+      remote: 'origin',
+      date: '2026-04-28',
+      subject: 'feat',
+      ahead: 0,
+      behind: 0,
+    })).toBe('feature/log')
+    expect(providerBranchName({
+      type: 'local',
+      name: 'refs/heads/main',
+      shortName: 'main',
+      hash: 'abc123',
+      current: true,
+      date: '2026-04-28',
+      subject: 'feat',
+      ahead: 0,
+      behind: 0,
+    })).toBe('main')
+  })
+})
+

--- a/src/commands/log/providerData.ts
+++ b/src/commands/log/providerData.ts
@@ -1,0 +1,225 @@
+import { SimpleGit } from 'simple-git'
+import { BranchRef } from './branchData'
+import { GhRunner, defaultGhRunner } from './pullRequestData'
+
+export type GitProviderType = 'github' | 'unsupported'
+
+export type ProviderRepository = {
+  provider: GitProviderType
+  remote: string
+  owner?: string
+  name?: string
+  webUrl?: string
+  defaultBranch?: string
+  message?: string
+}
+
+export type ProviderPullRequestStatus = {
+  number: number
+  title: string
+  state: string
+  isDraft: boolean
+  reviewDecision?: string
+  statusCheckRollup?: Array<{
+    name: string
+    conclusion?: string
+    status?: string
+  }>
+}
+
+export type ProviderOverview = {
+  repository: ProviderRepository
+  currentBranch?: string
+  currentPullRequest?: ProviderPullRequestStatus
+  authenticated: boolean
+  message?: string
+}
+
+export type ProviderUrlTarget =
+  | { type: 'repo' }
+  | { type: 'branch'; branch: string }
+  | { type: 'commit'; commit: string }
+  | { type: 'pull-request'; number: number }
+  | { type: 'compare'; base: string; head: string }
+
+export function parseGitHubRemoteUrl(url: string): Pick<ProviderRepository, 'owner' | 'name' | 'webUrl'> | undefined {
+  const trimmed = url.trim().replace(/\.git$/, '')
+  const sshMatch = trimmed.match(/^git@github\.com:([^/]+)\/(.+)$/)
+  const sshProtocolMatch = trimmed.match(/^ssh:\/\/git@github\.com\/([^/]+)\/(.+)$/)
+  const httpsMatch = trimmed.match(/^https:\/\/github\.com\/([^/]+)\/(.+)$/)
+  const gitMatch = trimmed.match(/^git:\/\/github\.com\/([^/]+)\/(.+)$/)
+  const match = sshMatch || sshProtocolMatch || httpsMatch || gitMatch
+
+  if (!match) {
+    return undefined
+  }
+
+  return {
+    owner: match[1],
+    name: match[2],
+    webUrl: `https://github.com/${match[1]}/${match[2]}`,
+  }
+}
+
+export function getProviderRepository(remoteName: string, remoteUrl: string): ProviderRepository {
+  const github = parseGitHubRemoteUrl(remoteUrl)
+
+  if (github) {
+    return {
+      provider: 'github',
+      remote: remoteName,
+      ...github,
+    }
+  }
+
+  return {
+    provider: 'unsupported',
+    remote: remoteName,
+    message: `Unsupported remote provider for ${remoteName}.`,
+  }
+}
+
+export function buildProviderUrl(
+  repository: ProviderRepository,
+  target: ProviderUrlTarget
+): string | undefined {
+  if (repository.provider !== 'github' || !repository.webUrl) {
+    return undefined
+  }
+
+  if (target.type === 'repo') {
+    return repository.webUrl
+  }
+
+  if (target.type === 'branch') {
+    return `${repository.webUrl}/tree/${encodeURIComponent(target.branch)}`
+  }
+
+  if (target.type === 'commit') {
+    return `${repository.webUrl}/commit/${target.commit}`
+  }
+
+  if (target.type === 'pull-request') {
+    return `${repository.webUrl}/pull/${target.number}`
+  }
+
+  return `${repository.webUrl}/compare/${encodeURIComponent(target.base)}...${encodeURIComponent(target.head)}`
+}
+
+function parseRepositoryJson(output: string): { defaultBranchRef?: { name?: string } } | undefined {
+  const trimmed = output.trim()
+
+  return trimmed ? JSON.parse(trimmed) : undefined
+}
+
+function parsePullRequestJson(output: string): ProviderPullRequestStatus | undefined {
+  const trimmed = output.trim()
+
+  return trimmed ? JSON.parse(trimmed) as ProviderPullRequestStatus : undefined
+}
+
+async function getDefaultBranch(
+  repository: ProviderRepository,
+  runner: GhRunner
+): Promise<string | undefined> {
+  if (repository.provider !== 'github' || !repository.owner || !repository.name) {
+    return undefined
+  }
+
+  try {
+    const output = await runner([
+      'repo',
+      'view',
+      `${repository.owner}/${repository.name}`,
+      '--json',
+      'defaultBranchRef',
+    ])
+
+    return parseRepositoryJson(output)?.defaultBranchRef?.name
+  } catch {
+    return undefined
+  }
+}
+
+async function getCurrentPullRequest(
+  runner: GhRunner
+): Promise<ProviderPullRequestStatus | undefined> {
+  try {
+    return parsePullRequestJson(await runner([
+      'pr',
+      'view',
+      '--json',
+      'number,title,state,isDraft,reviewDecision,statusCheckRollup',
+    ]))
+  } catch {
+    return undefined
+  }
+}
+
+export async function getProviderOverview(
+  git: SimpleGit,
+  runner: GhRunner = defaultGhRunner
+): Promise<ProviderOverview> {
+  const [remotes, currentBranchOutput] = await Promise.all([
+    git.getRemotes(true),
+    git.raw(['branch', '--show-current']),
+  ])
+  const remote = remotes.find((entry) => entry.name === 'origin') || remotes[0]
+  const remoteUrl = remote?.refs.push || remote?.refs.fetch
+  const repository = remoteUrl
+    ? getProviderRepository(remote.name, remoteUrl)
+    : {
+      provider: 'unsupported' as const,
+      remote: 'origin',
+      message: 'No Git remote detected.',
+    }
+  const currentBranch = currentBranchOutput.trim() || undefined
+
+  if (repository.provider !== 'github') {
+    return {
+      repository,
+      currentBranch,
+      authenticated: false,
+      message: repository.message || 'Unsupported remote provider.',
+    }
+  }
+
+  try {
+    await runner(['auth', 'status', '--hostname', 'github.com'])
+  } catch {
+    return {
+      repository,
+      currentBranch,
+      authenticated: false,
+      message: 'GitHub CLI is missing or not authenticated.',
+    }
+  }
+
+  const [defaultBranch, currentPullRequest] = await Promise.all([
+    getDefaultBranch(repository, runner),
+    getCurrentPullRequest(runner),
+  ])
+
+  return {
+    repository: {
+      ...repository,
+      defaultBranch,
+    },
+    currentBranch,
+    currentPullRequest,
+    authenticated: true,
+  }
+}
+
+export function providerBranchName(branch: BranchRef | undefined): string | undefined {
+  if (!branch) {
+    return undefined
+  }
+
+  if (branch.type === 'remote') {
+    return branch.shortName.split('/').slice(1).join('/') || branch.shortName
+  }
+
+  return branch.shortName
+}
+


### PR DESCRIPTION
## Summary

- Add a narrow provider data layer for GitHub-first remote inference with unsupported-provider fallback.
- Support GitHub HTTPS, SSH, ssh://, and git:// remote URL parsing and URL generation for repo, branch, commit, PR, and compare targets.
- Add provider open actions used by the interactive log UI.
- Surface provider repository/default branch/auth state, current PR review/check status, and compare state in `coco log -i`.
- Wire provider browser-open actions for repository, selected branch, selected commit, current PR, and two-ref compare URLs.
- Keep existing local workflows usable when provider auth is missing or no supported remote exists.

## Validation

- `git diff --check`
- `npm run test:jest -- src/commands/log/providerData.test.ts src/commands/log/providerActions.test.ts src/commands/log/historyActions.test.ts src/commands/log/interactive.test.ts src/commands/commands.integration.test.ts`
- `npm run coco:ts -- log -i --limit 1 >/tmp/coco-log-provider.txt && rg "Provider:|Operation:|Changed files:" /tmp/coco-log-provider.txt`
- `npm test`

Closes #667
