### PR TITLE
Add log TUI AI workflows

### DIFF
--- a/src/commands/log/aiActions.test.ts
+++ b/src/commands/log/aiActions.test.ts
@@ -1,0 +1,157 @@
+import { handler as changelogHandler } from '../changelog/handler'
+import { runCommitWorkflow } from './commitWorkflowActions'
+import {
+  aiActionTestInternals,
+  estimateLogAiActionImpact,
+  runLogAiAction,
+} from './aiActions'
+
+jest.mock('../changelog/handler', () => ({
+  handler: jest.fn(),
+}))
+
+jest.mock('./commitWorkflowActions', () => ({
+  runCommitWorkflow: jest.fn(),
+}))
+
+const mockedChangelogHandler = changelogHandler as jest.MockedFunction<typeof changelogHandler>
+const mockedRunCommitWorkflow = runCommitWorkflow as jest.MockedFunction<typeof runCommitWorkflow>
+
+describe('log AI actions', () => {
+  const selectedCommit = {
+    hash: 'abcdef1234567890',
+    shortHash: 'abcdef1',
+    message: 'feat: add ai actions',
+  }
+
+  beforeEach(() => {
+    mockedChangelogHandler.mockReset()
+    mockedRunCommitWorkflow.mockReset()
+  })
+
+  it('estimates token impact before running AI actions', () => {
+    expect(estimateLogAiActionImpact('summarize-commit', {
+      selectedCommit,
+    })).toEqual({
+      action: 'summarize-commit',
+      label: 'summarize commit',
+      estimatedTokens: expect.any(Number),
+      large: false,
+      requiresConfirmation: true,
+    })
+  })
+
+  it('routes selected commit summaries through bounded changelog ranges', async () => {
+    mockedChangelogHandler.mockImplementation(async () => {
+      process.stdout.write('AI commit summary\n\n- Changed the log UI.\n')
+    })
+
+    await expect(runLogAiAction('summarize-commit', {
+      selectedCommit,
+    })).resolves.toEqual({
+      ok: true,
+      message: 'AI commit summary',
+      details: [],
+      editable: 'AI commit summary\n- Changed the log UI.',
+    })
+    expect(mockedChangelogHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _: ['changelog'],
+        interactive: false,
+        mode: 'stdout',
+        range: 'abcdef1234567890^:abcdef1234567890',
+      }),
+      expect.anything()
+    )
+  })
+
+  it('routes selected range summaries through changelog ranges', async () => {
+    mockedChangelogHandler.mockImplementation(async () => {
+      process.stdout.write('Range summary\n')
+    })
+
+    await expect(runLogAiAction('summarize-range', {
+      selectedCommit,
+      compareBase: {
+        hash: '1111111',
+        shortHash: '1111111',
+        message: 'base',
+      },
+    })).resolves.toMatchObject({
+      ok: true,
+      message: 'Range summary',
+    })
+    expect(mockedChangelogHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        range: '1111111:abcdef1234567890',
+      }),
+      expect.anything()
+    )
+  })
+
+  it('requires a compare base before range summaries', async () => {
+    await expect(runLogAiAction('summarize-range', {
+      selectedCommit,
+    })).resolves.toEqual({
+      ok: false,
+      message: 'Select a compare base before summarizing a range.',
+    })
+    expect(mockedChangelogHandler).not.toHaveBeenCalled()
+  })
+
+  it('routes release notes through changelog tag summaries', async () => {
+    mockedChangelogHandler.mockImplementation(async () => {
+      process.stdout.write('Release notes\n')
+    })
+
+    await expect(runLogAiAction('release-notes', {
+      selectedTag: '0.33.0',
+    })).resolves.toMatchObject({
+      ok: true,
+      message: 'Release notes',
+    })
+    expect(mockedChangelogHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tag: '0.33.0',
+        author: true,
+      }),
+      expect.anything()
+    )
+  })
+
+  it('requires a selected tag before generating release notes', async () => {
+    await expect(runLogAiAction('release-notes', {})).resolves.toEqual({
+      ok: false,
+      message: 'Select a tag before generating release notes.',
+    })
+    expect(mockedChangelogHandler).not.toHaveBeenCalled()
+  })
+
+  it('routes risk review through existing commit split analysis', async () => {
+    mockedRunCommitWorkflow.mockResolvedValue({
+      ok: true,
+      message: 'Generated commit split plan.',
+    })
+
+    await expect(runLogAiAction('risk-review', {})).resolves.toEqual({
+      ok: true,
+      message: 'Risk review prepared from commit split analysis.',
+    })
+    expect(mockedRunCommitWorkflow).toHaveBeenCalledWith({
+      action: 'split-plan',
+    })
+  })
+
+  it('extracts telemetry while keeping generated text editable', () => {
+    expect(aiActionTestInternals.formatCapturedAiOutput([
+      '[llm] task=changelog command=changelog',
+      'Generated title',
+      'Generated body',
+      '[llm:summary] command=changelog calls=1 promptTokens=123',
+    ].join('\n'))).toEqual({
+      message: 'Generated title',
+      details: ['[llm:summary] command=changelog calls=1 promptTokens=123'],
+      editable: 'Generated title\nGenerated body',
+    })
+  })
+})

--- a/src/commands/log/aiActions.ts
+++ b/src/commands/log/aiActions.ts
@@ -1,0 +1,223 @@
+import { Arguments } from 'yargs'
+import { handler as changelogHandler } from '../changelog/handler'
+import { ChangelogOptions } from '../changelog/config'
+import { runCommitWorkflow } from './commitWorkflowActions'
+import { HistoryCommitRef } from './historyActions'
+import { TagRangeSummary } from './tagData'
+import { Logger } from '../../lib/utils/logger'
+
+export type LogAiAction =
+  | 'summarize-commit'
+  | 'summarize-range'
+  | 'release-notes'
+  | 'split-plan'
+  | 'risk-review'
+
+export type LogAiActionContext = {
+  selectedCommit?: HistoryCommitRef
+  compareBase?: HistoryCommitRef
+  selectedTag?: string
+  tagRangeSummary?: TagRangeSummary
+  defaultBranch?: string
+}
+
+export type LogAiActionImpact = {
+  action: LogAiAction
+  label: string
+  estimatedTokens: number
+  large: boolean
+  requiresConfirmation: boolean
+}
+
+export type LogAiActionResult = {
+  ok: boolean
+  message: string
+  details?: string[]
+  editable?: string
+}
+
+type ChangelogWorkflowArgv = Arguments<ChangelogOptions> & {
+  mode: 'stdout'
+}
+
+const LARGE_AI_ACTION_TOKEN_THRESHOLD = 4000
+
+function estimateTextTokens(value: string): number {
+  return Math.ceil(value.length / 4)
+}
+
+export function estimateLogAiActionImpact(
+  action: LogAiAction,
+  context: LogAiActionContext
+): LogAiActionImpact {
+  const contextText = [
+    context.selectedCommit?.hash,
+    context.selectedCommit?.message,
+    context.compareBase?.hash,
+    context.compareBase?.message,
+    context.selectedTag,
+    context.tagRangeSummary
+      ? `${context.tagRangeSummary.commitCount} commits ${context.tagRangeSummary.changedFiles.length} files`
+      : undefined,
+  ].filter(Boolean).join('\n')
+  const estimatedTokens = Math.max(64, estimateTextTokens(contextText) + 256)
+
+  return {
+    action,
+    label: action.replace(/-/g, ' '),
+    estimatedTokens,
+    large: estimatedTokens >= LARGE_AI_ACTION_TOKEN_THRESHOLD,
+    requiresConfirmation: true,
+  }
+}
+
+function createChangelogArgv(input: Partial<ChangelogOptions>): ChangelogWorkflowArgv {
+  return {
+    $0: 'coco',
+    _: ['changelog'],
+    interactive: false,
+    verbose: true,
+    version: false,
+    help: false,
+    mode: 'stdout',
+    range: '',
+    branch: '',
+    tag: '',
+    sinceLastTag: false,
+    withDiff: false,
+    onlyDiff: false,
+    author: false,
+    ...input,
+  } as ChangelogWorkflowArgv
+}
+
+function compactOutputLines(output: string): string[] {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+async function captureStdout(action: () => Promise<void>): Promise<string> {
+  const originalWrite = process.stdout.write.bind(process.stdout)
+  let output = ''
+
+  process.stdout.write = ((chunk: string | Uint8Array, ...args: unknown[]) => {
+    output += typeof chunk === 'string' ? chunk : chunk.toString()
+
+    const callback = args.find((arg): arg is (error?: Error | null) => void => typeof arg === 'function')
+    callback?.()
+
+    return true
+  }) as typeof process.stdout.write
+
+  try {
+    await action()
+    return output
+  } finally {
+    process.stdout.write = originalWrite
+  }
+}
+
+function formatCapturedAiOutput(output: string): Pick<LogAiActionResult, 'message' | 'details' | 'editable'> {
+  const lines = compactOutputLines(output)
+  const telemetry = lines.filter((line) => line.includes('[llm:summary]'))
+  const content = lines.filter((line) => !line.includes('[llm]') && !line.includes('[llm:summary]'))
+  const editable = content.join('\n')
+
+  return {
+    message: content[0] || telemetry[0] || 'AI action completed.',
+    details: telemetry.slice(0, 3),
+    editable,
+  }
+}
+
+async function runChangelogAction(argv: ChangelogWorkflowArgv): Promise<LogAiActionResult> {
+  try {
+    const output = await captureStdout(() => changelogHandler(argv, new Logger({
+      verbose: true,
+      silent: false,
+    })))
+    const formatted = formatCapturedAiOutput(output)
+
+    return {
+      ok: true,
+      ...formatted,
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      message: (error as Error).message,
+    }
+  }
+}
+
+export async function runLogAiAction(
+  action: LogAiAction,
+  context: LogAiActionContext
+): Promise<LogAiActionResult> {
+  if (action === 'split-plan') {
+    return runCommitWorkflow({
+      action: 'split-plan',
+    })
+  }
+
+  if (action === 'risk-review') {
+    return runCommitWorkflow({
+      action: 'split-plan',
+    }).then((result) => ({
+      ...result,
+      message: result.ok ? 'Risk review prepared from commit split analysis.' : result.message,
+    }))
+  }
+
+  if (action === 'release-notes') {
+    const tag = context.selectedTag || context.tagRangeSummary?.from
+
+    if (!tag) {
+      return {
+        ok: false,
+        message: 'Select a tag before generating release notes.',
+      }
+    }
+
+    return runChangelogAction(createChangelogArgv({
+      tag,
+      author: true,
+    }))
+  }
+
+  if (action === 'summarize-range') {
+    const from = context.compareBase?.hash
+    const to = context.selectedCommit?.hash
+
+    if (!from || !to) {
+      return {
+        ok: false,
+        message: 'Select a compare base before summarizing a range.',
+      }
+    }
+
+    return runChangelogAction(createChangelogArgv({
+      range: `${from}:${to}`,
+    }))
+  }
+
+  if (!context.selectedCommit) {
+    return {
+      ok: false,
+      message: 'No commit selected for AI summary.',
+    }
+  }
+
+  return runChangelogAction(createChangelogArgv({
+    range: `${context.selectedCommit.hash}^:${context.selectedCommit.hash}`,
+  }))
+}
+
+export const aiActionTestInternals = {
+  compactOutputLines,
+  createChangelogArgv,
+  estimateTextTokens,
+  formatCapturedAiOutput,
+}

--- a/src/commands/log/interactive.test.ts
+++ b/src/commands/log/interactive.test.ts
@@ -309,6 +309,47 @@ describe('log interactive renderer', () => {
     expect(output).toContain('Provider actions: R repo | L branch | O commit | U compare | o PR')
   })
 
+  it('renders opt-in AI impact and editable drafts', () => {
+    const output = renderInteractiveLog(
+      createLogTuiState(rows),
+      detail,
+      branches,
+      pullRequest,
+      tags,
+      undefined,
+      worktree,
+      {
+        focus: 'commits',
+        pendingAiAction: 'summarize-commit',
+      },
+      {
+        height: 90,
+        width: 140,
+      },
+      {},
+      {},
+      undefined,
+      undefined,
+      {
+        pendingAction: 'summarize-commit',
+        impact: {
+          action: 'summarize-commit',
+          label: 'summarize commit',
+          estimatedTokens: 512,
+          large: false,
+          requiresConfirmation: true,
+        },
+        draft: 'Generated summary\n- Important change',
+      }
+    )
+
+    expect(output).toContain('Coco AI:')
+    expect(output).toContain('Pending AI summarize commit: press I to run | ~512 tokens')
+    expect(output).toContain('AI calls are opt-in')
+    expect(output).toContain('AI draft:')
+    expect(output).toContain('Generated summary')
+  })
+
   it('renders in-progress operation, conflicts, hooks, and no-verify state', () => {
     const output = renderInteractiveLog(
       createLogTuiState(rows),

--- a/src/commands/log/interactive.ts
+++ b/src/commands/log/interactive.ts
@@ -1,6 +1,12 @@
 import readline from 'readline'
 import { SimpleGit } from 'simple-git'
 import {
+  LogAiAction,
+  LogAiActionImpact,
+  estimateLogAiActionImpact,
+  runLogAiAction,
+} from './aiActions'
+import {
   BranchActionResult,
   checkoutBranch,
   createBranch,
@@ -89,6 +95,12 @@ type RenderInteractiveLogHistory = {
   providerCompareBase?: string
 }
 
+type RenderInteractiveLogAi = {
+  pendingAction?: LogAiAction
+  impact?: LogAiActionImpact
+  draft?: string
+}
+
 type LogTuiFocus = 'commits' | 'branches' | 'tags' | 'status' | 'workspace'
 type WorkspaceSection = 'stashes' | 'worktrees'
 
@@ -120,6 +132,7 @@ type LogTuiRenderUi = {
   pendingRebaseCommit?: string
   pendingOperationAction?: 'continue' | 'abort' | 'skip'
   noVerify?: boolean
+  pendingAiAction?: LogAiAction
 }
 
 type LogTuiInputKind =
@@ -550,6 +563,30 @@ function renderOperationOverview(
   ].map((line) => truncate(line, width))
 }
 
+function renderAiOverview(
+  ai: RenderInteractiveLogAi,
+  width: number
+): string[] {
+  if (!ai.pendingAction && !ai.draft) {
+    return []
+  }
+
+  const impact = ai.impact
+  const pendingLine = ai.pendingAction && impact
+    ? `Pending AI ${impact.label}: press ${ai.pendingAction === 'summarize-range' ? 'M' : ai.pendingAction === 'release-notes' ? 'J' : ai.pendingAction === 'risk-review' ? 'W' : 'I'} to run | ~${impact.estimatedTokens} tokens${impact.large ? ' large' : ''}`
+    : 'AI actions: I commit summary | M range summary | J release notes | W risk review'
+  const draftLines = ai.draft
+    ? ai.draft.split('\n').slice(0, 4).map((line) => `  ${line}`)
+    : []
+
+  return [
+    'Coco AI:',
+    pendingLine,
+    'AI calls are opt-in; large actions show token awareness before running.',
+    ...(draftLines.length ? ['AI draft:', ...draftLines] : []),
+  ].map((line) => truncate(line, width))
+}
+
 function renderDetail(detail: GitCommitDetail | undefined, width: number): string[] {
   if (!detail) {
     return ['Loading selected commit details...']
@@ -591,7 +628,8 @@ export function renderInteractiveLog(
   workspace: RenderInteractiveLogWorkspace = {},
   history: RenderInteractiveLogHistory = {},
   operation?: GitOperationOverview,
-  provider?: ProviderOverview
+  provider?: ProviderOverview,
+  ai: RenderInteractiveLogAi = {}
 ): string {
   const height = options.height || process.stdout.rows || DEFAULT_HEIGHT
   const width = options.width || process.stdout.columns || DEFAULT_WIDTH
@@ -600,7 +638,7 @@ export function renderInteractiveLog(
   const graphMode = state.fullGraph ? 'full graph' : 'compact graph'
   const focus = ui.focus || 'commits'
   const help = state.showHelp
-    ? 'Keys: tab focus | up/down move | n branch | t tag | C PR | c commit | history h/H/O/= | q quit'
+    ? 'Keys: tab focus | up/down move | n branch | t tag | C PR | c commit | AI I/M/J/W | q quit'
     : 'Press ? for help'
   const commitActions = focus === 'commits'
     ? 'Commit actions: e amend HEAD | w reword HEAD | h hash | H message | O open | = compare'
@@ -624,6 +662,7 @@ export function renderInteractiveLog(
     : []
   const historyLines = renderHistoryOverview(history, ui, width).slice(0, 8)
   const operationLines = renderOperationOverview(operation, ui, width).slice(0, 12)
+  const aiLines = renderAiOverview(ai, width).slice(0, 8)
   const listHeight = Math.max(4, Math.floor(height * 0.35))
   const detailHeight = Math.max(
     6,
@@ -637,6 +676,7 @@ export function renderInteractiveLog(
       workspaceLines.length -
       historyLines.length -
       operationLines.length -
+      aiLines.length -
       11
   )
   const detailLines = renderDetail(detail, width).slice(0, detailHeight)
@@ -659,6 +699,7 @@ export function renderInteractiveLog(
     ...workspaceLines,
     ...historyLines,
     ...operationLines,
+    ...aiLines,
     '',
     ...renderCommitList(state, listHeight, width),
     '',
@@ -691,6 +732,9 @@ export async function startInteractiveLog(
   let reflog: ReflogEntry[] | undefined
   let operationOverview: GitOperationOverview | undefined
   let providerOverview: ProviderOverview | undefined
+  let pendingAiAction: LogAiAction | undefined
+  let aiImpact: LogAiActionImpact | undefined
+  let aiDraft: string | undefined
   let focus: LogTuiFocus = 'commits'
   let branchIndex = 0
   let tagIndex = 0
@@ -818,6 +862,7 @@ export async function startInteractiveLog(
         pendingRebaseCommit,
         pendingOperationAction,
         noVerify,
+        pendingAiAction,
       }
 
       output.write(
@@ -834,7 +879,12 @@ export async function startInteractiveLog(
           { stashes, worktreeList, stashDiffSummary },
           { compareBase, reflog, providerCompareBase },
           operationOverview,
-          providerOverview
+          providerOverview,
+          {
+            pendingAction: pendingAiAction,
+            impact: aiImpact,
+            draft: aiDraft,
+          }
         )}\n`,
         'utf8'
       )
@@ -857,7 +907,12 @@ export async function startInteractiveLog(
               { stashes, worktreeList, stashDiffSummary },
               { compareBase, reflog, providerCompareBase },
               operationOverview,
-              providerOverview
+              providerOverview,
+              {
+                pendingAction: pendingAiAction,
+                impact: aiImpact,
+                draft: aiDraft,
+              }
             )}\n`,
             'utf8'
           )
@@ -930,6 +985,8 @@ export async function startInteractiveLog(
       pendingResetMode = undefined
       pendingRebaseCommit = undefined
       pendingOperationAction = undefined
+      pendingAiAction = undefined
+      aiImpact = undefined
       inputPrompt = undefined
 
       if (refresh) {
@@ -965,6 +1022,47 @@ export async function startInteractiveLog(
           message: selected.message,
         }
         : undefined
+    }
+
+    const aiActionContext = () => ({
+      selectedCommit: selectedHistoryCommit(),
+      compareBase,
+      selectedTag: selectedTag()?.name,
+      tagRangeSummary,
+      defaultBranch: providerOverview?.repository.defaultBranch || selectedBaseRef(),
+    })
+
+    const prepareOrRunAiAction = (action: LogAiAction, confirmKey: string) => {
+      const context = aiActionContext()
+
+      if (pendingAiAction !== action) {
+        pendingAiAction = action
+        aiImpact = estimateLogAiActionImpact(action, context)
+        statusMessage = `Press ${confirmKey} to run AI ${aiImpact.label}`
+        statusDetails = [
+          `Estimated prompt impact: ~${aiImpact.estimatedTokens} tokens${aiImpact.large ? ' (large)' : ''}.`,
+          'Generated text will be shown as an editable draft before you use it.',
+        ]
+        void render()
+        return
+      }
+
+      statusMessage = `Running AI ${aiImpact?.label || action}...`
+      void render()
+      void runLogAiAction(action, context).then(async (result) => {
+        statusMessage = result.message
+        statusDetails = result.details
+        aiDraft = result.editable
+        pendingAiAction = undefined
+        aiImpact = undefined
+        await render()
+      }).catch(async (error) => {
+        statusMessage = (error as Error).message
+        statusDetails = undefined
+        pendingAiAction = undefined
+        aiImpact = undefined
+        await render()
+      })
     }
 
     const selectedRef = () => {
@@ -1104,6 +1202,8 @@ export async function startInteractiveLog(
       pendingResetMode = undefined
       pendingRebaseCommit = undefined
       pendingOperationAction = undefined
+      pendingAiAction = undefined
+      aiImpact = undefined
       void render()
     }
 
@@ -1291,6 +1391,8 @@ export async function startInteractiveLog(
         pendingResetMode = undefined
         pendingRebaseCommit = undefined
         pendingOperationAction = undefined
+        pendingAiAction = undefined
+        aiImpact = undefined
         void render()
       } else if ((key.name === 'up' || key.name === 'k') && focus === 'branches') {
         moveBranchSelection(-1)
@@ -1488,6 +1590,14 @@ export async function startInteractiveLog(
             'Opening provider compare URL...'
           )
         }
+      } else if (sequence === 'I') {
+        prepareOrRunAiAction('summarize-commit', 'I')
+      } else if (sequence === 'M') {
+        prepareOrRunAiAction('summarize-range', 'M')
+      } else if (sequence === 'J') {
+        prepareOrRunAiAction('release-notes', 'J')
+      } else if (sequence === 'W') {
+        prepareOrRunAiAction('risk-review', 'W')
       } else if (key.name === 'h' && focus === 'commits') {
         void runBranchAction(() => copyCommitHash(selectedHistoryCommit()), false, 'Copying commit hash...')
       } else if (sequence === 'H' && focus === 'commits') {

--- a/src/lib/langchain/utils/observability.test.ts
+++ b/src/lib/langchain/utils/observability.test.ts
@@ -62,9 +62,9 @@ describe('LLM observability utilities', () => {
       elapsedMs: 10,
     })
 
-    logLlmTelemetrySummary(logger, 'commit')
-    logLlmTelemetrySummary(logger, 'commit')
+    const summary = logLlmTelemetrySummary(logger, 'commit')
 
+    expect(summary).toBe('[llm:summary] command=commit calls=2 promptTokens=150 elapsedMs=35 inputDocuments=1 inputChunks=3 tasks=summarize-large-file,commit-message models=gpt-4.1-nano,gpt-4.1-mini')
     expect(logger.verbose).toHaveBeenCalledWith(
       '[llm:summary] command=commit calls=2 promptTokens=150 elapsedMs=35 inputDocuments=1 inputChunks=3 tasks=summarize-large-file,commit-message models=gpt-4.1-nano,gpt-4.1-mini',
       { color: 'cyan' }

--- a/src/lib/langchain/utils/observability.ts
+++ b/src/lib/langchain/utils/observability.ts
@@ -88,11 +88,11 @@ function recordLlmTelemetry(metadata: LlmCallMetadata): void {
   telemetryByCommand.set(command, current)
 }
 
-export function logLlmTelemetrySummary(logger: Logger | undefined, command: string): void {
-  if (!logger) return
+export function logLlmTelemetrySummary(logger: Logger | undefined, command: string): string | undefined {
+  if (!logger) return undefined
 
   const summary = telemetryByCommand.get(command)
-  if (!summary || summary.calls === 0) return
+  if (!summary || summary.calls === 0) return undefined
 
   const fields = [
     `command=${command}`,
@@ -104,9 +104,11 @@ export function logLlmTelemetrySummary(logger: Logger | undefined, command: stri
     summary.tasks.size > 0 ? `tasks=${[...summary.tasks].join(',')}` : undefined,
     summary.models.size > 0 ? `models=${[...summary.models].join(',')}` : undefined,
   ].filter(Boolean)
+  const message = `[llm:summary] ${fields.join(' ')}`
 
-  logger.verbose(`[llm:summary] ${fields.join(' ')}`, { color: 'cyan' })
+  logger.verbose(message, { color: 'cyan' })
   telemetryByCommand.delete(command)
+  return message
 }
 
 export function resetLlmTelemetry(): void {


### PR DESCRIPTION
## Summary

- adds explicit opt-in AI actions to `coco log -i` for selected commit summaries, selected range summaries, release-note drafts, and risk review prep
- routes AI work through existing changelog and commit split workflows so prompt budgets, diff condensation, dynamic model routing, and telemetry stay centralized
- shows token impact before running an AI action and renders generated text as an editable draft preview in the TUI
- returns telemetry summary text from the observability helper so interactive flows can surface it cleanly

## Validation

- `npm run test:jest -- src/commands/log/aiActions.test.ts src/commands/log/interactive.test.ts src/lib/langchain/utils/observability.test.ts src/commands/commands.integration.test.ts`
- `npm run lint -- --max-warnings=0`
- `git diff --check && npm test`

Closes #668