### PR TITLE
Upgrade Inquirer prompts

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -2,7 +2,7 @@
 
 Recommended required checks for `main`:
 
-- `Release gate (Node 22.12.0)`
+- `Release gate (Node 22.13.0)`
 - `Release gate (Node 24.x)`
 - `DevSkim`
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,3 @@ updates:
       - dependency-name: "p-queue"
       - dependency-name: "ora"
       - dependency-name: "chalk"
-      - dependency-name: " @inquirer/prompts"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 22.12.0
+          - 22.13.0
           - 24.x
 
     steps:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.12.0
+          node-version: 22.13.0
           cache: yarn
           cache-dependency-path: yarn.lock
 
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.12.0
+          node-version: 22.13.0
           registry-url: https://registry.npmjs.org
           cache: yarn
           cache-dependency-path: yarn.lock

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "git+https://github.com/gfargo/coco.git"
   },
   "engines": {
-    "node": "^22.12.0 || >=24"
+    "node": "^22.13.0 || >=24"
   },
   "scripts": {
     "start": "npm run dev",
@@ -86,7 +86,7 @@
   },
   "dependencies": {
     "@commitlint/core": "^20.5.0",
-    "@inquirer/prompts": "3.3.0",
+    "@inquirer/prompts": "8.4.2",
     "@langchain/anthropic": "^1.0.0",
     "@langchain/community": "^1.0.0",
     "@langchain/core": "^1.1.34",

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -541,8 +541,8 @@ IMPORTANT RULES:
             logger.log(SEPERATOR)
 
             if (INTERACTIVE) {
-              const { select } = await import('@inquirer/prompts')
-              const choice = await select({
+              const { selectPrompt } = await import('../../lib/ui/inquirerPrompts')
+              const choice = await selectPrompt<'retry' | 'skip' | 'abort'>({
                 message: 'How would you like to proceed?',
                 choices: [
                   {

--- a/src/commands/init/handler.ts
+++ b/src/commands/init/handler.ts
@@ -1,9 +1,9 @@
-import { confirm } from '@inquirer/prompts'
 import { appendToEnvFile } from '../../lib/config/services/env'
 import { appendToGitConfig } from '../../lib/config/services/git'
 import { appendToProjectJsonConfig } from '../../lib/config/services/project'
 import { checkAndHandlePackageInstallation } from '../../lib/ui/checkAndHandlePackageInstall'
 import { LOGO } from '../../lib/ui/helpers'
+import { confirmPrompt } from '../../lib/ui/inquirerPrompts'
 import { logResult } from '../../lib/ui/logResult'
 import { installNpmPackage } from '../../lib/utils/installPackage'
 
@@ -103,7 +103,7 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
         maxRetries: await questions.inputRequestMaxRetries(),
       }
 
-      const promptForServiceFields = await confirm({
+      const promptForServiceFields = await confirmPrompt({
         message: 'would you like to configure additional service fields (advanced)?',
         default: false,
       })
@@ -121,7 +121,7 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
         }
       }
 
-      const promptForIgnores = await confirm({
+      const promptForIgnores = await confirmPrompt({
         message: 'would you like to configure ignored files and extensions?',
         default: false,
       })
@@ -131,7 +131,7 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
         config.ignoredExtensions = await questions.whatExtensionsToIgnore()
       }
 
-      const promptForCommitPrompt = await confirm({
+      const promptForCommitPrompt = await confirmPrompt({
         message: 'would you like to configure the commit message prompt?',
         default: false,
       })
@@ -150,7 +150,7 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
     approvalMessage = 'looking good? (API key hidden for security)'
   }
 
-  const isApproved = await confirm({
+  const isApproved = await confirmPrompt({
     message: approvalMessage,
   })
 

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -1,4 +1,3 @@
-import { confirm } from '@inquirer/prompts'
 import { handler } from './handler'
 import { questions } from './questions'
 import { InitOptions } from './config'
@@ -14,9 +13,10 @@ import { getPathToUsersGitConfig } from '../../lib/utils/getPathToUsersGitConfig
 import { getProjectConfigFilePath } from '../../lib/utils/getProjectConfigFilePath'
 import { installNpmPackage } from '../../lib/utils/installPackage'
 import { Logger } from '../../lib/utils/logger'
+import { confirmPrompt } from '../../lib/ui/inquirerPrompts'
 
-jest.mock('@inquirer/prompts', () => ({
-  confirm: jest.fn(),
+jest.mock('../../lib/ui/inquirerPrompts', () => ({
+  confirmPrompt: jest.fn(),
 }))
 jest.mock('../../lib/config/services/env')
 jest.mock('../../lib/config/services/git')
@@ -29,7 +29,7 @@ jest.mock('../../lib/utils/getPathToUsersGitConfig')
 jest.mock('../../lib/utils/getProjectConfigFilePath')
 jest.mock('../../lib/utils/installPackage')
 
-const mockConfirm = confirm as jest.MockedFunction<typeof confirm>
+const mockConfirm = confirmPrompt as jest.MockedFunction<typeof confirmPrompt>
 const mockAppendToEnvFile = appendToEnvFile as jest.MockedFunction<typeof appendToEnvFile>
 const mockAppendToGitConfig = appendToGitConfig as jest.MockedFunction<typeof appendToGitConfig>
 const mockAppendToProjectJsonConfig = appendToProjectJsonConfig as jest.MockedFunction<

--- a/src/commands/init/questions.ts
+++ b/src/commands/init/questions.ts
@@ -1,6 +1,12 @@
-import { confirm, editor, input, password, select } from '@inquirer/prompts'
 import { ANTHROPIC_MODELS, OPEN_AI_MODELS } from '../../lib/langchain/constants'
 import { LLMModel, LLMProvider } from '../../lib/langchain/types'
+import {
+  confirmPrompt,
+  editorPrompt,
+  inputPrompt,
+  passwordPrompt,
+  selectPrompt,
+} from '../../lib/ui/inquirerPrompts'
 import { commandExit } from '../../lib/utils/commandExit'
 import { execPromise } from '../../lib/utils/execPromise'
 import { ProjectConfigFileName } from '../../lib/utils/getProjectConfigFilePath'
@@ -12,7 +18,7 @@ export const questions = {
    * @description configure coco globally for the current user or project?
    */
   whatScope: async (): Promise<InstallationScope> =>
-    await select({
+    await selectPrompt<InstallationScope>({
       message: 'configure coco globally for the current user or for the current directory?',
       choices: [
         {
@@ -28,7 +34,7 @@ export const questions = {
       ],
     }),
   selectLLMProvider: async (): Promise<LLMProvider> =>
-    await select({
+    await selectPrompt<LLMProvider>({
       message: 'select language model provider:',
       choices: [
         {
@@ -92,7 +98,7 @@ export const questions = {
       ]
     }
 
-    return await select({
+    return await selectPrompt<LLMModel>({
       message: 'select language model:',
       choices: availableModels,
     })
@@ -104,7 +110,7 @@ export const questions = {
    * @returns 'interactive' | 'stdout'
    */
   selectMode: async (): Promise<'interactive' | 'stdout'> =>
-    await select({
+    await selectPrompt<'interactive' | 'stdout'>({
       message: 'select mode:',
       choices: [
         {
@@ -127,7 +133,7 @@ export const questions = {
     const envVarValue = process.env[envVarName];
   
     if (envVarValue) {
-      const useExisting = await confirm({
+      const useExisting = await confirmPrompt({
         message: `Use existing ${envVarName} env var?`,
         default: true,
       });
@@ -137,7 +143,7 @@ export const questions = {
       }
     }
   
-    return await password({
+    return await passwordPrompt({
       message: `Enter your ${keyName} API key:`,
       validate(input) {
         return input.length > 0 ? true : 'API key cannot be empty';
@@ -146,7 +152,7 @@ export const questions = {
   },
 
   inputTokenLimit: async (): Promise<number> => {
-    const tokenLimit = await input({
+    const tokenLimit = await inputPrompt({
       message: 'maximum number of tokens for generating commit messages:',
       default: '300',
     })
@@ -155,7 +161,7 @@ export const questions = {
   },
 
   inputModelTemperature: async (): Promise<number> => {
-    const temperature = await input({
+    const temperature = await inputPrompt({
       message: 'model temperature for generating commit messages:',
       default: '0.36',
     })
@@ -163,14 +169,14 @@ export const questions = {
   },
 
   inputOllamaEndpoint: async (): Promise<string> => {
-    return await input({
+    return await inputPrompt({
       message: 'Ollama endpoint (e.g., http://localhost:11434):',
       default: 'http://localhost:11434',
     })
   },
 
   inputRequestTimeout: async (): Promise<number> => {
-    const timeout = await input({
+    const timeout = await inputPrompt({
       message: 'Request timeout in milliseconds:',
       default: '30000',
     })
@@ -178,7 +184,7 @@ export const questions = {
   },
 
   inputRequestMaxRetries: async (): Promise<number> => {
-    const maxRetries = await input({
+    const maxRetries = await inputPrompt({
       message: 'Maximum number of request retries:',
       default: '3',
     })
@@ -186,33 +192,33 @@ export const questions = {
   },
 
   inputServiceFields: async (): Promise<string> => {
-    return await editor({
+    return await editorPrompt({
       message: 'Enter additional service fields as a JSON string (optional):',
       default: '{}',
     })
   },
 
   selectDefaultGitBranch: async (): Promise<string> =>
-    (await input({
+    (await inputPrompt({
       message: 'default branch for the repository:',
       default: 'main',
     })) || 'main',
 
   configureAdvancedOptions: async (): Promise<boolean> =>
-    await confirm({
+    await confirmPrompt({
       message: 'would you like to configure advanced options?',
       default: false,
     }),
 
   enableVerboseMode: async (): Promise<boolean> =>
-    await confirm({
+    await confirmPrompt({
       message: 'enable verbose logging:',
       default: false,
     }),
 
   whatFilesToIgnore: async (): Promise<string[]> =>
     (
-      await input({
+      await inputPrompt({
         message: 'paths of files to be excluded when generating commit messages (comma-separated):',
         default: 'package-lock.json,yarn.lock,pnpm-lock.yaml,bun.lockb',
       })
@@ -222,7 +228,7 @@ export const questions = {
 
   whatExtensionsToIgnore: async (): Promise<string[]> =>
     (
-      await input({
+      await inputPrompt({
         message:
           'file extensions to be excluded when generating commit messages (comma-separated):',
         default: '.map, .lock',
@@ -232,13 +238,13 @@ export const questions = {
       ?.map((ext: string) => ext.trim()) || [],
 
   modifyCommitPrompt: async (): Promise<string> =>
-    await editor({
+    await editorPrompt({
       message: 'modify default commit message prompt:',
       default: COMMIT_PROMPT.template as string,
     }),
 
   selectProjectConfigFileType: async (): Promise<ProjectConfigFileName> =>
-    await select({
+    await selectPrompt<ProjectConfigFileName>({
       message: 'where would you like to store the project config?',
       choices: [
         {
@@ -253,7 +259,7 @@ export const questions = {
     }),
 
   setupCommitlint: async (): Promise<boolean> =>
-    await confirm({
+    await confirmPrompt({
       message: 'set up commitlint for conventional commits support?',
       default: true,
     }),

--- a/src/lib/ui/checkAndHandlePackageInstall.ts
+++ b/src/lib/ui/checkAndHandlePackageInstall.ts
@@ -1,8 +1,8 @@
-import { confirm } from '@inquirer/prompts'
 import { findProjectRoot } from '../utils/findProjectRoot'
 import { installNpmPackage } from '../utils/installPackage'
 import { isPackageInstalled } from '../utils/isPackageInstalled'
 import { Logger } from '../utils/logger'
+import { confirmPrompt } from './inquirerPrompts'
 
 // TODO: QoL improvement to import this from `package.json`
 const packageName = 'git-coco'
@@ -19,7 +19,7 @@ export async function checkAndHandlePackageInstallation({
   try {
     // Global installation
     if (global) {
-      const shouldInstall = await confirm({
+      const shouldInstall = await confirmPrompt({
         message: `Would you like to install/update '${packageName}' globally at this time?`,
         default: true,
       })
@@ -39,12 +39,12 @@ export async function checkAndHandlePackageInstallation({
     let shouldInstall = false
 
     if (isPackageInstalled(packageName, projectRoot)) {
-      shouldInstall = await confirm({
+      shouldInstall = await confirmPrompt({
         message: `'${packageName}' is already installed in '${projectRoot}/package.json', would you like to update?`,
         default: shouldInstall,
       })
     } else {
-      shouldInstall = await confirm({
+      shouldInstall = await confirmPrompt({
         message: `'${packageName}' is not installed in '${projectRoot}/package.json', would you like to install?`,
         default: shouldInstall,
       })

--- a/src/lib/ui/commitValidationHandler.ts
+++ b/src/lib/ui/commitValidationHandler.ts
@@ -1,7 +1,7 @@
-import { select } from '@inquirer/prompts'
 import { ValidationResult } from '../utils/commitlintValidator'
 import { Logger } from '../utils/logger'
 import { editResult } from './editResult'
+import { selectPrompt } from './inquirerPrompts'
 
 export interface ValidationHandlerOptions {
   logger: Logger
@@ -52,7 +52,7 @@ export async function handleValidationErrors(
   }
 
   // In interactive mode, offer options to the user
-  const choice = await select({
+  const choice = await selectPrompt<'retry' | 'edit' | 'abort'>({
     message: 'How would you like to proceed?:',
     choices: [
       {

--- a/src/lib/ui/editPrompt.ts
+++ b/src/lib/ui/editPrompt.ts
@@ -1,13 +1,13 @@
-import { editor } from '@inquirer/prompts'
 import { COMMIT_PROMPT } from '../../commands/commit/prompt'
 import { validatePromptTemplate } from '../langchain/utils/validatePromptTemplate'
 import { GenerateReviewLoopOptions } from './generateAndReviewLoop'
+import { editorPrompt } from './inquirerPrompts'
 
 export async function editPrompt(options: GenerateReviewLoopOptions): Promise<string> {
-  return await editor({
+  return await editorPrompt({
     message: 'Edit the prompt',
     default: options.prompt?.length ? options.prompt : COMMIT_PROMPT.template as string,
-    waitForUseInput: false,
+    waitForUserInput: false,
     postfix: 'Press ENTER to continue',
     validate: (text) => {
       try {

--- a/src/lib/ui/editResult.ts
+++ b/src/lib/ui/editResult.ts
@@ -1,15 +1,15 @@
-import { editor } from '@inquirer/prompts'
 import { GenerateReviewLoopOptions } from './generateAndReviewLoop'
+import { editorPrompt } from './inquirerPrompts'
 
 export async function editResult(
   result: string,
   options: GenerateReviewLoopOptions
 ): Promise<string> {
   if (options.openInEditor) {
-    return await editor({
+    return await editorPrompt({
       message: 'Edit the commit message',
       default: result,
-      waitForUseInput: false,
+      waitForUserInput: false,
       validate: (text) => (text ? true : 'Commit message cannot be empty'),
     })
   }

--- a/src/lib/ui/getUserReviewDecision.ts
+++ b/src/lib/ui/getUserReviewDecision.ts
@@ -1,4 +1,4 @@
-import { select } from '@inquirer/prompts'
+import { selectPrompt } from './inquirerPrompts'
 
 export type ReviewDecision =
   | 'approve'
@@ -29,7 +29,11 @@ export async function getUserReviewDecision({
   enableModifyPrompt = true,
   selectLabel,
 }: GetUserReviewDecisionInput): Promise<ReviewDecision> {
-  const choices = [
+  const choices: Array<{
+    name: string
+    value: ReviewDecision
+    description: string
+  }> = [
     {
       name: labels?.approve || '✨ Looks good!',
       value: 'approve',
@@ -80,8 +84,8 @@ export async function getUserReviewDecision({
     description: descriptions?.cancel || `Cancel the ${label}`,
   })
 
-  return (await select({
+  return await selectPrompt<ReviewDecision>({
     message: selectLabel || `Would you like to make any changes to the ${label}?`,
     choices,
-  })) as ReviewDecision
+  })
 }

--- a/src/lib/ui/handleMissingCommitlintDeps.ts
+++ b/src/lib/ui/handleMissingCommitlintDeps.ts
@@ -1,5 +1,5 @@
-import { select } from '@inquirer/prompts'
 import { Logger } from '../utils/logger'
+import { selectPrompt } from './inquirerPrompts'
 
 export interface MissingDependencyOptions {
   logger: Logger
@@ -37,7 +37,7 @@ export async function handleMissingCommitlintDeps(
   })
   logger.log('')
 
-  const choice = await select({
+  const choice = await selectPrompt<MissingDependencyAction>({
     message: 'How would you like to proceed?',
     choices: [
       {

--- a/src/lib/ui/inquirerPrompts.ts
+++ b/src/lib/ui/inquirerPrompts.ts
@@ -1,0 +1,69 @@
+import type {
+  confirm as inquirerConfirm,
+  editor as inquirerEditor,
+  input as inquirerInput,
+  password as inquirerPassword,
+  select as inquirerSelect,
+} from '@inquirer/prompts'
+
+type InquirerPromptsModule = {
+  confirm: typeof inquirerConfirm
+  editor: typeof inquirerEditor
+  input: typeof inquirerInput
+  password: typeof inquirerPassword
+  select: typeof inquirerSelect
+}
+
+const dynamicImport = new Function('specifier', 'return import(specifier)') as <
+  T
+>(specifier: string) => Promise<T>
+
+let promptsPromise: Promise<InquirerPromptsModule> | undefined
+
+export function loadInquirerPrompts(): Promise<InquirerPromptsModule> {
+  if (!promptsPromise) {
+    promptsPromise = dynamicImport<InquirerPromptsModule>('@inquirer/prompts')
+  }
+
+  return promptsPromise
+}
+
+export async function confirmPrompt(
+  ...args: Parameters<typeof inquirerConfirm>
+): ReturnType<typeof inquirerConfirm> {
+  const { confirm } = await loadInquirerPrompts()
+
+  return confirm(...args)
+}
+
+export async function editorPrompt(
+  ...args: Parameters<typeof inquirerEditor>
+): ReturnType<typeof inquirerEditor> {
+  const { editor } = await loadInquirerPrompts()
+
+  return editor(...args)
+}
+
+export async function inputPrompt(
+  ...args: Parameters<typeof inquirerInput>
+): ReturnType<typeof inquirerInput> {
+  const { input } = await loadInquirerPrompts()
+
+  return input(...args)
+}
+
+export async function passwordPrompt(
+  ...args: Parameters<typeof inquirerPassword>
+): ReturnType<typeof inquirerPassword> {
+  const { password } = await loadInquirerPrompts()
+
+  return password(...args)
+}
+
+export async function selectPrompt<Value>(
+  ...args: [config: unknown, context?: unknown]
+): Promise<Value> {
+  const { select } = await loadInquirerPrompts()
+
+  return (select as (config: unknown, context?: unknown) => Promise<Value>)(...args)
+}

--- a/src/lib/utils/updateFileSection.ts
+++ b/src/lib/utils/updateFileSection.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
-import { confirm } from '@inquirer/prompts'
 import { ConfirmMessage } from '../types'
+import { confirmPrompt } from '../ui/inquirerPrompts'
 
 type UpdateFileSectionInput = {
   filePath: string
@@ -29,7 +29,7 @@ export async function updateFileSection({
       foundSection = true
 
       if (confirmUpdate) {
-        const confirmOverwrite = await confirm({
+        const confirmOverwrite = await confirmPrompt({
           message: typeof confirmMessage === 'function' ? confirmMessage(filePath) : confirmMessage,
           default: false,
         })

--- a/yarn.lock
+++ b/yarn.lock
@@ -686,16 +686,10 @@
   resolved "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.0.tgz"
   integrity sha512-JWaTfCxI1eTmJ1BIv86vUfjVatOdxwD0DAVKYevY8SazeUUZtW+tNbsdejVO1GYE0GXJW1N1ahmiC3TFd+7wZA==
 
-"@inquirer/checkbox@^1.5.0":
-  version "1.5.2"
-  resolved "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-1.5.2.tgz"
-  integrity sha512-CifrkgQjDkUkWexmgYYNyB5603HhTHI91vLFeQXh6qrTKiCMVASol01Rs1cv6LP/A2WccZSRlJKZhbaBIs/9ZA==
-  dependencies:
-    "@inquirer/core" "^6.0.0"
-    "@inquirer/type" "^1.1.6"
-    ansi-escapes "^4.3.2"
-    chalk "^4.1.2"
-    figures "^3.2.0"
+"@inquirer/ansi@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@inquirer/ansi/-/ansi-2.0.5.tgz#7b7e121f6a0c40128711daf20325e6ff2cdff8b7"
+  integrity sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==
 
 "@inquirer/checkbox@^4.2.4":
   version "4.2.4"
@@ -708,14 +702,15 @@
     "@inquirer/type" "^3.0.8"
     yoctocolors-cjs "^2.1.2"
 
-"@inquirer/confirm@^2.0.15":
-  version "2.0.17"
-  resolved "https://registry.npmjs.org/@inquirer/confirm/-/confirm-2.0.17.tgz"
-  integrity sha512-EqzhGryzmGpy2aJf6LxJVhndxYmFs+m8cxXzf8nejb1DE3sabf6mUgBcp4J0jAUEiAcYzqmkqRr7LPFh/WdnXA==
+"@inquirer/checkbox@^5.1.4":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/checkbox/-/checkbox-5.1.4.tgz#dd209aec1a37cb2e0bfa1ee216b310176d3c6dbf"
+  integrity sha512-w6KF8ZYRvqHhROkOTHXYC3qIV/KYEu5o12oLqQySvch61vrYtRxNSHTONSdJqWiFJPlCUQAHT5OgOIyuTr+MHQ==
   dependencies:
-    "@inquirer/core" "^6.0.0"
-    "@inquirer/type" "^1.1.6"
-    chalk "^4.1.2"
+    "@inquirer/ansi" "^2.0.5"
+    "@inquirer/core" "^11.1.9"
+    "@inquirer/figures" "^2.0.5"
+    "@inquirer/type" "^4.0.5"
 
 "@inquirer/confirm@^5.1.18":
   version "5.1.18"
@@ -724,6 +719,14 @@
   dependencies:
     "@inquirer/core" "^10.2.2"
     "@inquirer/type" "^3.0.8"
+
+"@inquirer/confirm@^6.0.12":
+  version "6.0.12"
+  resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-6.0.12.tgz#7a317aec813214cec2f5339b9fa0926c20bf0dbe"
+  integrity sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==
+  dependencies:
+    "@inquirer/core" "^11.1.9"
+    "@inquirer/type" "^4.0.5"
 
 "@inquirer/core@^10.2.2":
   version "10.2.2"
@@ -739,55 +742,18 @@
     wrap-ansi "^6.2.0"
     yoctocolors-cjs "^2.1.2"
 
-"@inquirer/core@^5.1.1":
-  version "5.1.2"
-  resolved "https://registry.npmjs.org/@inquirer/core/-/core-5.1.2.tgz"
-  integrity sha512-w3PMZH5rahrukn8/I7P9Ihil+twgLTUHDZtJlJyBbUKyPaOSSQjLZkb0PpncVhin1gCaMgOFXy6iNPgcZUoo2w==
+"@inquirer/core@^11.1.9":
+  version "11.1.9"
+  resolved "https://registry.yarnpkg.com/@inquirer/core/-/core-11.1.9.tgz#97f099f5217f50f168c12db00ac07f51ab550fbb"
+  integrity sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==
   dependencies:
-    "@inquirer/type" "^1.1.6"
-    "@types/mute-stream" "^0.0.4"
-    "@types/node" "^20.10.7"
-    "@types/wrap-ansi" "^3.0.0"
-    ansi-escapes "^4.3.2"
-    chalk "^4.1.2"
-    cli-spinners "^2.9.2"
+    "@inquirer/ansi" "^2.0.5"
+    "@inquirer/figures" "^2.0.5"
+    "@inquirer/type" "^4.0.5"
     cli-width "^4.1.0"
-    figures "^3.2.0"
-    mute-stream "^1.0.0"
-    run-async "^3.0.0"
+    fast-wrap-ansi "^0.2.0"
+    mute-stream "^3.0.0"
     signal-exit "^4.1.0"
-    strip-ansi "^6.0.1"
-    wrap-ansi "^6.2.0"
-
-"@inquirer/core@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/@inquirer/core/-/core-6.0.0.tgz"
-  integrity sha512-fKi63Khkisgda3ohnskNf5uZJj+zXOaBvOllHsOkdsXRA/ubQLJQrZchFFi57NKbZzkTunXiBMdvWOv71alonw==
-  dependencies:
-    "@inquirer/type" "^1.1.6"
-    "@types/mute-stream" "^0.0.4"
-    "@types/node" "^20.10.7"
-    "@types/wrap-ansi" "^3.0.0"
-    ansi-escapes "^4.3.2"
-    chalk "^4.1.2"
-    cli-spinners "^2.9.2"
-    cli-width "^4.1.0"
-    figures "^3.2.0"
-    mute-stream "^1.0.0"
-    run-async "^3.0.0"
-    signal-exit "^4.1.0"
-    strip-ansi "^6.0.1"
-    wrap-ansi "^6.2.0"
-
-"@inquirer/editor@^1.2.13":
-  version "1.2.15"
-  resolved "https://registry.npmjs.org/@inquirer/editor/-/editor-1.2.15.tgz"
-  integrity sha512-gQ77Ls09x5vKLVNMH9q/7xvYPT6sIs5f7URksw+a2iJZ0j48tVS6crLqm2ugG33tgXHIwiEqkytY60Zyh5GkJQ==
-  dependencies:
-    "@inquirer/core" "^6.0.0"
-    "@inquirer/type" "^1.1.6"
-    chalk "^4.1.2"
-    external-editor "^3.1.0"
 
 "@inquirer/editor@^4.2.20":
   version "4.2.20"
@@ -798,15 +764,14 @@
     "@inquirer/external-editor" "^1.0.2"
     "@inquirer/type" "^3.0.8"
 
-"@inquirer/expand@^1.1.14":
-  version "1.1.16"
-  resolved "https://registry.npmjs.org/@inquirer/expand/-/expand-1.1.16.tgz"
-  integrity sha512-TGLU9egcuo+s7PxphKUCnJnpCIVY32/EwPCLLuu+gTvYiD8hZgx8Z2niNQD36sa6xcfpdLY6xXDBiL/+g1r2XQ==
+"@inquirer/editor@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/editor/-/editor-5.1.1.tgz#dd36105ee655c1951f3300f84a2ed0bb188e3b1b"
+  integrity sha512-6y11LgmNpmn5D2aB5FgnCfBUBK8ZstwLCalyJmORcJZ/WrhOjm16mu6eSqIx8DnErxDqSLr+Jkp+GP8/Nwd5tA==
   dependencies:
-    "@inquirer/core" "^6.0.0"
-    "@inquirer/type" "^1.1.6"
-    chalk "^4.1.2"
-    figures "^3.2.0"
+    "@inquirer/core" "^11.1.9"
+    "@inquirer/external-editor" "^3.0.0"
+    "@inquirer/type" "^4.0.5"
 
 "@inquirer/expand@^4.0.20":
   version "4.0.20"
@@ -817,6 +782,14 @@
     "@inquirer/type" "^3.0.8"
     yoctocolors-cjs "^2.1.2"
 
+"@inquirer/expand@^5.0.13":
+  version "5.0.13"
+  resolved "https://registry.yarnpkg.com/@inquirer/expand/-/expand-5.0.13.tgz#86f1310d6dd389e8f94af8781b8ca62ed8e53f0d"
+  integrity sha512-dF2zvrFo9LshkcB23/O1il13kBkBltWIXzut1evfbuBLXMiGIuC45c+ZQ0uukjCDsvI8OWqun4FRYMnzFCQa3g==
+  dependencies:
+    "@inquirer/core" "^11.1.9"
+    "@inquirer/type" "^4.0.5"
+
 "@inquirer/external-editor@^1.0.2":
   version "1.0.2"
   resolved "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.2.tgz"
@@ -825,19 +798,23 @@
     chardet "^2.1.0"
     iconv-lite "^0.7.0"
 
+"@inquirer/external-editor@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/external-editor/-/external-editor-3.0.0.tgz#915e7d3f808e3d2213c4fe0f525dcd7ea890e78a"
+  integrity sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg==
+  dependencies:
+    chardet "^2.1.1"
+    iconv-lite "^0.7.2"
+
 "@inquirer/figures@^1.0.13":
   version "1.0.13"
   resolved "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz"
   integrity sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==
 
-"@inquirer/input@^1.2.14":
-  version "1.2.16"
-  resolved "https://registry.npmjs.org/@inquirer/input/-/input-1.2.16.tgz"
-  integrity sha512-Ou0LaSWvj1ni+egnyQ+NBtfM1885UwhRCMtsRt2bBO47DoC1dwtCa+ZUNgrxlnCHHF0IXsbQHYtIIjFGAavI4g==
-  dependencies:
-    "@inquirer/core" "^6.0.0"
-    "@inquirer/type" "^1.1.6"
-    chalk "^4.1.2"
+"@inquirer/figures@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@inquirer/figures/-/figures-2.0.5.tgz#d12f4889ac6ea7731ebc52bd9c066ca51d8fdee7"
+  integrity sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==
 
 "@inquirer/input@^4.2.4":
   version "4.2.4"
@@ -847,6 +824,14 @@
     "@inquirer/core" "^10.2.2"
     "@inquirer/type" "^3.0.8"
 
+"@inquirer/input@^5.0.12":
+  version "5.0.12"
+  resolved "https://registry.yarnpkg.com/@inquirer/input/-/input-5.0.12.tgz#3da22915b88867b0474d2ca6306616e38ba3942d"
+  integrity sha512-uiMFBl4LqFzJClh80Q3f9hbOFJ6kgkDWI4LjAeBuyO6EanVVMF69AgOvpi1qdqjDSjDN6578B6nky9ceEpI+1Q==
+  dependencies:
+    "@inquirer/core" "^11.1.9"
+    "@inquirer/type" "^4.0.5"
+
 "@inquirer/number@^3.0.20":
   version "3.0.20"
   resolved "https://registry.npmjs.org/@inquirer/number/-/number-3.0.20.tgz"
@@ -855,15 +840,13 @@
     "@inquirer/core" "^10.2.2"
     "@inquirer/type" "^3.0.8"
 
-"@inquirer/password@^1.1.14":
-  version "1.1.16"
-  resolved "https://registry.npmjs.org/@inquirer/password/-/password-1.1.16.tgz"
-  integrity sha512-aZYZVHLUXZ2gbBot+i+zOJrks1WaiI95lvZCn1sKfcw6MtSSlYC8uDX8sTzQvAsQ8epHoP84UNvAIT0KVGOGqw==
+"@inquirer/number@^4.0.12":
+  version "4.0.12"
+  resolved "https://registry.yarnpkg.com/@inquirer/number/-/number-4.0.12.tgz#964a68783c55fc2a9a0bce5a0ebd6f17818a79a6"
+  integrity sha512-/vrwhEf7Xsuh+YlHF4IjSy3g1cyrQuPaSiHIxCEbLu8qnfvrcvJyCkoktOOF+xV9gSb77/G0n3h04RbMDW2sIg==
   dependencies:
-    "@inquirer/core" "^6.0.0"
-    "@inquirer/type" "^1.1.6"
-    ansi-escapes "^4.3.2"
-    chalk "^4.1.2"
+    "@inquirer/core" "^11.1.9"
+    "@inquirer/type" "^4.0.5"
 
 "@inquirer/password@^4.0.20":
   version "4.0.20"
@@ -874,20 +857,30 @@
     "@inquirer/core" "^10.2.2"
     "@inquirer/type" "^3.0.8"
 
-"@inquirer/prompts@3.3.0":
-  version "3.3.0"
-  resolved "https://registry.npmjs.org/@inquirer/prompts/-/prompts-3.3.0.tgz"
-  integrity sha512-BBCqdSnhNs+WziSIo4f/RNDu6HAj4R/Q5nMgJb5MNPFX8sJGCvj9BoALdmR0HTWXyDS7TO8euKj6W6vtqCQG7A==
+"@inquirer/password@^5.0.12":
+  version "5.0.12"
+  resolved "https://registry.yarnpkg.com/@inquirer/password/-/password-5.0.12.tgz#c1dcf197258a8cfba800325b78287fa55a5a3ef8"
+  integrity sha512-CBh7YHju623lxJRcAOo498ZUwIuMy63bqW/vVq0tQAZVv+lkWlHkP9ealYE1utWSisEShY5VMdzIXRmyEODzcQ==
   dependencies:
-    "@inquirer/checkbox" "^1.5.0"
-    "@inquirer/confirm" "^2.0.15"
-    "@inquirer/core" "^5.1.1"
-    "@inquirer/editor" "^1.2.13"
-    "@inquirer/expand" "^1.1.14"
-    "@inquirer/input" "^1.2.14"
-    "@inquirer/password" "^1.1.14"
-    "@inquirer/rawlist" "^1.2.14"
-    "@inquirer/select" "^1.3.1"
+    "@inquirer/ansi" "^2.0.5"
+    "@inquirer/core" "^11.1.9"
+    "@inquirer/type" "^4.0.5"
+
+"@inquirer/prompts@8.4.2":
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/@inquirer/prompts/-/prompts-8.4.2.tgz#725131d95853b2afe610bdbd945ca10f093a1de8"
+  integrity sha512-XJmn/wY4AX56l1BRU+ZjDrFtg9+2uBEi4JvJQj82kwJDQKiPgSn4CEsbfGGygS4Gw6rkL4W18oATjfVfaqub2Q==
+  dependencies:
+    "@inquirer/checkbox" "^5.1.4"
+    "@inquirer/confirm" "^6.0.12"
+    "@inquirer/editor" "^5.1.1"
+    "@inquirer/expand" "^5.0.13"
+    "@inquirer/input" "^5.0.12"
+    "@inquirer/number" "^4.0.12"
+    "@inquirer/password" "^5.0.12"
+    "@inquirer/rawlist" "^5.2.8"
+    "@inquirer/search" "^4.1.8"
+    "@inquirer/select" "^5.1.4"
 
 "@inquirer/prompts@^7.8.6":
   version "7.8.6"
@@ -905,15 +898,6 @@
     "@inquirer/search" "^3.1.3"
     "@inquirer/select" "^4.3.4"
 
-"@inquirer/rawlist@^1.2.14":
-  version "1.2.16"
-  resolved "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-1.2.16.tgz"
-  integrity sha512-pZ6TRg2qMwZAOZAV6TvghCtkr53dGnK29GMNQ3vMZXSNguvGqtOVc4j/h1T8kqGJFagjyfBZhUPGwNS55O5qPQ==
-  dependencies:
-    "@inquirer/core" "^6.0.0"
-    "@inquirer/type" "^1.1.6"
-    chalk "^4.1.2"
-
 "@inquirer/rawlist@^4.1.8":
   version "4.1.8"
   resolved "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.8.tgz"
@@ -922,6 +906,14 @@
     "@inquirer/core" "^10.2.2"
     "@inquirer/type" "^3.0.8"
     yoctocolors-cjs "^2.1.2"
+
+"@inquirer/rawlist@^5.2.8":
+  version "5.2.8"
+  resolved "https://registry.yarnpkg.com/@inquirer/rawlist/-/rawlist-5.2.8.tgz#38e17d3967cbe03555a8bfff405d01fe6bfee6da"
+  integrity sha512-Su7FQvp5buZmCymN3PPoYv31ZQQX4ve2j02k7piGgKAWgE+AQRB5YoYVveGXcl3TZ9ldgRMSxj56YfDFmmaqLg==
+  dependencies:
+    "@inquirer/core" "^11.1.9"
+    "@inquirer/type" "^4.0.5"
 
 "@inquirer/search@^3.1.3":
   version "3.1.3"
@@ -933,16 +925,14 @@
     "@inquirer/type" "^3.0.8"
     yoctocolors-cjs "^2.1.2"
 
-"@inquirer/select@^1.3.1":
-  version "1.3.3"
-  resolved "https://registry.npmjs.org/@inquirer/select/-/select-1.3.3.tgz"
-  integrity sha512-RzlRISXWqIKEf83FDC9ZtJ3JvuK1l7aGpretf41BCWYrvla2wU8W8MTRNMiPrPJ+1SIqrRC1nZdZ60hD9hRXLg==
+"@inquirer/search@^4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@inquirer/search/-/search-4.1.8.tgz#1ff32d80ac0859772bd9c38fbccc82818862ee85"
+  integrity sha512-fGiHKGD6DyPIYUWxoXnQTeXeyYqSOUrasDMABBmMHUalH/LxkuzY0xVRtimXAt1sUeeyYkVuKQx1bebMuN11Kw==
   dependencies:
-    "@inquirer/core" "^6.0.0"
-    "@inquirer/type" "^1.1.6"
-    ansi-escapes "^4.3.2"
-    chalk "^4.1.2"
-    figures "^3.2.0"
+    "@inquirer/core" "^11.1.9"
+    "@inquirer/figures" "^2.0.5"
+    "@inquirer/type" "^4.0.5"
 
 "@inquirer/select@^4.3.4":
   version "4.3.4"
@@ -955,17 +945,25 @@
     "@inquirer/type" "^3.0.8"
     yoctocolors-cjs "^2.1.2"
 
-"@inquirer/type@^1.1.6":
-  version "1.5.5"
-  resolved "https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz"
-  integrity sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==
+"@inquirer/select@^5.1.4":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/select/-/select-5.1.4.tgz#651374b766a8c38157975257f23732e8bc689452"
+  integrity sha512-2kWcGKPMLAXAWRp1AH1SLsQmX+j0QjeljyXMUji9WMZC8nRDO0b7qquIGr6143E7KMLt3VAIGNXzwa/6PXQs4Q==
   dependencies:
-    mute-stream "^1.0.0"
+    "@inquirer/ansi" "^2.0.5"
+    "@inquirer/core" "^11.1.9"
+    "@inquirer/figures" "^2.0.5"
+    "@inquirer/type" "^4.0.5"
 
 "@inquirer/type@^3.0.8":
   version "3.0.8"
   resolved "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz"
   integrity sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==
+
+"@inquirer/type@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-4.0.5.tgz#a02d90e5da8a36dce27ac8e7237a50c99a9003a3"
+  integrity sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
@@ -1891,26 +1889,12 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/mute-stream@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz"
-  integrity sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==
-  dependencies:
-    "@types/node" "*"
-
 "@types/node@*", "@types/node@^25.0.10":
   version "25.0.10"
   resolved "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz"
   integrity sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==
   dependencies:
     undici-types "~7.16.0"
-
-"@types/node@^20.10.7":
-  version "20.19.10"
-  resolved "https://registry.npmjs.org/@types/node/-/node-20.19.10.tgz"
-  integrity sha512-iAFpG6DokED3roLSP0K+ybeDdIX6Bc0Vd3mLW5uDqThPWtNos3E+EqOM11mPQHKzfWHqEBuLjIlsBQQ8CsISmQ==
-  dependencies:
-    undici-types "~6.21.0"
 
 "@types/parse-path@^7.0.0":
   version "7.1.0"
@@ -1928,11 +1912,6 @@
   version "2.0.3"
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
-
-"@types/wrap-ansi@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz"
-  integrity sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==
 
 "@types/yargs-parser@*":
   version "21.0.3"
@@ -2475,15 +2454,15 @@ char-regex@^1.0.2:
   resolved "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
-chardet@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz"
-  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
-
 chardet@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz"
   integrity sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==
+
+chardet@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-2.1.1.tgz#5c75593704a642f71ee53717df234031e65373c8"
+  integrity sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==
 
 chokidar@^4.0.3:
   version "4.0.3"
@@ -2523,7 +2502,7 @@ cli-cursor@^5.0.0:
   dependencies:
     restore-cursor "^5.0.0"
 
-cli-spinners@^2.5.0, cli-spinners@^2.9.2:
+cli-spinners@^2.5.0:
   version "2.9.2"
   resolved "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz"
   integrity sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==
@@ -2871,11 +2850,6 @@ escalade@^3.1.1, escalade@^3.2.0:
   resolved "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
 
-escape-string-regexp@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-  integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
-
 escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz"
@@ -3076,15 +3050,6 @@ exsolve@^1.0.7:
   resolved "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz"
   integrity sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==
 
-external-editor@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz"
-  integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
-  dependencies:
-    chardet "^0.7.0"
-    iconv-lite "^0.4.24"
-    tmp "^0.0.33"
-
 fast-content-type-parse@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz"
@@ -3116,10 +3081,29 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-string-truncated-width@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz#23afe0da67d752ca0727538f1e6967759728ce49"
+  integrity sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==
+
+fast-string-width@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/fast-string-width/-/fast-string-width-3.0.2.tgz#16dbabb491ce5585b5ecb675b65c165d71688eeb"
+  integrity sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==
+  dependencies:
+    fast-string-truncated-width "^3.0.2"
+
 fast-uri@^3.0.1:
   version "3.0.6"
   resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz"
   integrity sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==
+
+fast-wrap-ansi@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz#c0ae3f3982d061c3d657ec927196fbb47e22fe64"
+  integrity sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==
+  dependencies:
+    fast-string-width "^3.0.2"
 
 fastq@^1.6.0:
   version "1.19.1"
@@ -3139,13 +3123,6 @@ fdir@^6.2.0, fdir@^6.5.0:
   version "6.5.0"
   resolved "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
-
-figures@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz"
-  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
-  dependencies:
-    escape-string-regexp "^1.0.5"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -3447,17 +3424,17 @@ human-signals@^5.0.0:
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz"
   integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
 
-iconv-lite@^0.4.24:
-  version "0.4.24"
-  resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz"
-  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
-
 iconv-lite@^0.7.0:
   version "0.7.0"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz"
   integrity sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
+iconv-lite@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.2.tgz#d0bdeac3f12b4835b7359c2ad89c422a4d1cc72e"
+  integrity sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
@@ -4526,15 +4503,15 @@ mustache@^4.2.0:
   resolved "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz"
   integrity sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==
 
-mute-stream@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz"
-  integrity sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==
-
 mute-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz"
   integrity sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==
+
+mute-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-3.0.0.tgz#cd8014dd2acb72e1e91bb67c74f0019e620ba2d1"
+  integrity sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==
 
 napi-postinstall@^0.3.0:
   version "0.3.3"
@@ -4734,11 +4711,6 @@ os-name@6.1.0:
   dependencies:
     macos-release "^3.3.0"
     windows-release "^6.1.0"
-
-os-tmpdir@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
-  integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
 
 p-finally@^1.0.0:
   version "1.0.0"
@@ -5248,11 +5220,6 @@ run-applescript@^7.0.0:
   resolved "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz"
   integrity sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==
 
-run-async@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz"
-  integrity sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==
-
 run-async@^4.0.5:
   version "4.0.6"
   resolved "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz"
@@ -5282,7 +5249,7 @@ safe-stable-stringify@^2.5.0:
   resolved "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz"
   integrity sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==
 
-"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
+"safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -5577,13 +5544,6 @@ tinyglobby@0.2.15:
     fdir "^6.5.0"
     picomatch "^4.0.3"
 
-tmp@^0.0.33:
-  version "0.0.33"
-  resolved "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz"
-  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
-  dependencies:
-    os-tmpdir "~1.0.2"
-
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz"
@@ -5709,11 +5669,6 @@ uglify-js@^3.1.4:
   version "3.19.3"
   resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz"
   integrity sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==
-
-undici-types@~6.21.0:
-  version "6.21.0"
-  resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz"
-  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 undici-types@~7.16.0:
   version "7.16.0"


### PR DESCRIPTION
## Summary

- upgrades `@inquirer/prompts` from 3.3.0 to 8.4.2
- raises Coco's Node 22 floor from 22.12.0 to 22.13.0 to satisfy the new package engine range
- adds a lazy prompt loader so the ESM-only Inquirer package is not statically parsed by Jest or required by the CJS bundle
- updates prompt call sites to use the loader and fixes the renamed editor option `waitForUserInput`
- updates CI/release Node floor docs and removes a stale malformed Dependabot ignore entry

## Context

This supersedes Dependabot PR #679, which failed because `@inquirer/prompts@8.4.2` requires Node `^22.13.0` or newer and is ESM-only.

## Validation

- `source /Users/gfargo/.nvm/nvm.sh && nvm use 22.13.0 && npx yarn install --frozen-lockfile`
- `git diff --check && npm test`
- `npm run lint -- --max-warnings=0`

Supersedes #679