### PR TITLE
Derive log TUI palette from keymap

### DIFF
--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -1,4 +1,9 @@
-import { getLogInkFooterHints, getLogInkHelpSections } from './inkKeymap'
+import {
+  LOG_INK_KEY_BINDINGS,
+  getLogInkCommandPaletteItems,
+  getLogInkFooterHints,
+  getLogInkHelpSections,
+} from './inkKeymap'
 
 describe('log Ink keymap', () => {
   it('keeps footer hints short and contextual', () => {
@@ -32,5 +37,15 @@ describe('log Ink keymap', () => {
     expect(helpText).toContain('g Toggle compact and full graph display.')
     expect(helpText).toContain('q/ctrl+c Quit the interactive log.')
     expect(helpText).toContain('tab Move focus to the next panel.')
+  })
+
+  it('derives command palette entries from the shared keymap', () => {
+    const palette = getLogInkCommandPaletteItems()
+
+    expect(palette.map((item) => item.id)).toEqual(LOG_INK_KEY_BINDINGS.map((binding) => binding.id))
+    expect(palette.find((item) => item.id === 'commandPalette')).toMatchObject({
+      keys: ':',
+      label: 'commands',
+    })
   })
 })

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -28,6 +28,13 @@ export type LogInkHelpSection = {
   bindings: LogInkKeyBinding[]
 }
 
+export type LogInkCommandPaletteItem = {
+  id: LogInkCommandId
+  keys: string
+  label: string
+  description: string
+}
+
 export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
   {
     id: 'moveUp',
@@ -178,4 +185,13 @@ export function getLogInkHelpSections(): LogInkHelpSection[] {
       ),
     },
   ]
+}
+
+export function getLogInkCommandPaletteItems(): LogInkCommandPaletteItem[] {
+  return LOG_INK_KEY_BINDINGS.map((binding) => ({
+    id: binding.id,
+    keys: formatBindingKeys(binding),
+    label: binding.label,
+    description: binding.description,
+  }))
 }

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -4,6 +4,7 @@ import { BranchOverview, getBranchOverview } from './branchData'
 import { GitCommitDetail, GitLogCommitRow, GitLogRow, getCommitDetail } from './data'
 import {
   formatBindingKeys,
+  getLogInkCommandPaletteItems,
   getLogInkFooterHints,
   getLogInkHelpSections,
 } from './inkKeymap'
@@ -409,7 +410,12 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       return
     }
 
-    if (state.showCommandPalette && key.escape) {
+    if (key.escape && state.showHelp) {
+      dispatch({ type: 'toggleHelp' })
+      return
+    }
+
+    if (key.escape && state.showCommandPalette) {
       dispatch({ type: 'toggleCommandPalette' })
       return
     }
@@ -660,14 +666,7 @@ function renderCommandPalette(
   focused: boolean
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
-  const commands = [
-    ['/', 'Search commits'],
-    ['g', 'Toggle graph density'],
-    ['r', 'Refresh repository context'],
-    ['tab', 'Move focus between panels'],
-    ['?', 'Open full help'],
-    ['q', 'Quit'],
-  ]
+  const commands = getLogInkCommandPaletteItems()
 
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
@@ -677,11 +676,11 @@ function renderCommandPalette(
     paddingX: 1,
   },
   h(Text, { bold: true }, panelTitle('Commands', focused)),
-  h(Text, { dimColor: true }, 'Less common actions will live here as workflows return.'),
+  h(Text, { dimColor: true }, 'Every command is sourced from the shared keymap.'),
   h(Text, undefined, ''),
-  ...commands.map(([key, label]) => h(Text, {
-    key,
-  }, truncate(`${key.padEnd(8)} ${label}`, width - 4))))
+  ...commands.map((command) => h(Text, {
+    key: command.id,
+  }, truncate(`${command.keys.padEnd(12)} ${command.label} - ${command.description}`, width - 4))))
 }
 
 function renderFooter(


### PR DESCRIPTION
## Summary
- derive command palette entries from the shared log TUI keymap
- let Escape dismiss help as well as the command palette
- cover the shared keymap-to-palette contract in tests

## Validation
- `npm run test:jest -- src/commands/log/inkKeymap.test.ts src/commands/log/inkViewModel.test.ts src/commands/log/inkTheme.test.ts`
- `npm run lint`
- `npm run build`
- `git diff --check`

Closes #706
