### PR TITLE
Add log TUI workflow panels

### DIFF
--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -24,7 +24,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showCommandPalette: true,
       showHelp: false,
-    })).toEqual([': close', 'r refresh', 'g graph', '? help', 'q quit'])
+    })).toEqual([': close', 'D/T/X confirm', 'I/M AI', '? help', 'q quit'])
   })
 
   it('derives help from the same binding source', () => {
@@ -46,6 +46,9 @@ describe('log Ink keymap', () => {
     expect(palette.find((item) => item.id === 'commandPalette')).toMatchObject({
       keys: ':',
       label: 'commands',
+    })
+    expect(palette.find((item) => item.id === 'workflowActions')).toMatchObject({
+      label: 'workflows',
     })
   })
 })

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -14,6 +14,7 @@ export type LogInkCommandId =
   | 'refresh'
   | 'search'
   | 'toggleGraph'
+  | 'workflowActions'
 
 export type LogInkKeyBinding = {
   id: LogInkCommandId
@@ -121,6 +122,13 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     contexts: ['normal'],
   },
   {
+    id: 'workflowActions',
+    keys: ['D', 'T', 'X', 'W', 'A', 'I', 'M'],
+    label: 'workflows',
+    description: 'Open workflow actions with confirmation for destructive or AI operations.',
+    contexts: ['normal', 'sidebar', 'detail'],
+  },
+  {
     id: 'quit',
     keys: ['q', 'ctrl+c'],
     label: 'quit',
@@ -150,7 +158,7 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): stri
   }
 
   if (options.showCommandPalette) {
-    return [': close', 'r refresh', 'g graph', '? help', 'q quit']
+    return [': close', 'D/T/X confirm', 'I/M AI', '? help', 'q quit']
   }
 
   if (options.focus === 'sidebar') {
@@ -181,7 +189,7 @@ export function getLogInkHelpSections(): LogInkHelpSection[] {
     {
       title: 'Global',
       bindings: LOG_INK_KEY_BINDINGS.filter((binding) =>
-        ['help', 'commandPalette', 'quit'].includes(binding.id)
+        ['help', 'commandPalette', 'workflowActions', 'quit'].includes(binding.id)
       ),
     },
   ]

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -24,6 +24,11 @@ import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
 import { StashOverview, getStashOverview } from './stashData'
 import { WorktreeOverview, getWorktreeOverview } from './statusData'
 import { TagOverview, getTagOverview } from './tagData'
+import {
+  LogInkWorkflowAction,
+  getLogInkWorkflowActions,
+  getLogInkWorkflowSections,
+} from './inkWorkflows'
 import { WorktreeOverview as WorktreeListOverview, getWorktreeListOverview } from './worktreeData'
 
 type DynamicImport = <T>(specifier: string) => Promise<T>
@@ -302,6 +307,18 @@ function sidebarLines(context: LogInkContext, tab: LogInkSidebarTab, width: numb
     : ['No linked worktrees']
 }
 
+function getWorkflowActionByKey(inputValue: string): LogInkWorkflowAction | undefined {
+  return getLogInkWorkflowActions().find((action) => action.key === inputValue)
+}
+
+function getWorkflowActionById(id: string | undefined): LogInkWorkflowAction | undefined {
+  if (!id) {
+    return undefined
+  }
+
+  return getLogInkWorkflowActions().find((action) => action.id === id)
+}
+
 export async function startInkInteractiveLog(
   git: SimpleGit,
   rows: GitLogRow[],
@@ -410,6 +427,25 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       return
     }
 
+    if (state.pendingConfirmationId) {
+      if (inputValue === 'y') {
+        const action = getWorkflowActionById(state.pendingConfirmationId)
+
+        dispatch({ type: 'setPendingConfirmation', value: undefined })
+        dispatch({
+          type: 'setStatus',
+          value: action
+            ? `${action.label} queued for workflow execution`
+            : 'workflow action queued',
+        })
+      } else if (inputValue === 'n' || key.escape) {
+        dispatch({ type: 'setPendingConfirmation', value: undefined })
+        dispatch({ type: 'setStatus', value: 'workflow action cancelled' })
+      }
+
+      return
+    }
+
     if (key.escape && state.showHelp) {
       dispatch({ type: 'toggleHelp' })
       return
@@ -442,6 +478,15 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       dispatch({ type: 'page', delta: -10 })
     } else if (key.pageDown) {
       dispatch({ type: 'page', delta: 10 })
+    } else {
+      const workflowAction = getWorkflowActionByKey(inputValue)
+
+      if (workflowAction?.requiresConfirmation) {
+        dispatch({ type: 'setPendingConfirmation', value: workflowAction.id })
+      } else if (workflowAction) {
+        dispatch({ type: 'setWorkflowAction', value: workflowAction.id })
+        dispatch({ type: 'setStatus', value: `${workflowAction.label} selected` })
+      }
     }
   })
 
@@ -467,7 +512,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     h(Box, { flexDirection: 'row', height: bodyRows },
       renderSidebar(h, { Box, Text }, state, context, sidebarWidth, theme),
       renderCommitPanel(h, { Box, Text }, state, bodyRows, theme),
-      renderDetailPanel(h, { Box, Text }, state, detail, detailLoading, detailWidth, theme)
+      renderDetailPanel(h, { Box, Text }, state, context, detail, detailLoading, detailWidth, theme)
     ),
     renderFooter(h, { Box, Text }, state, theme)
   )
@@ -576,6 +621,7 @@ function renderDetailPanel(
   h: typeof ReactTypes.createElement,
   components: LogInkComponents,
   state: LogInkState,
+  context: LogInkContext,
   detail: GitCommitDetail | undefined,
   loading: boolean,
   width: number,
@@ -592,7 +638,15 @@ function renderDetailPanel(
     return renderCommandPalette(h, components, width, theme, focused)
   }
 
+  if (state.pendingConfirmationId) {
+    return renderConfirmationPanel(h, components, state, width, theme, focused)
+  }
+
   const selected = getSelectedInkCommit(state)
+  const workflowSections = getLogInkWorkflowSections({
+    ...context,
+    selectedCommit: selected,
+  })
   const lines = detail
     ? [
       detail.message,
@@ -606,6 +660,12 @@ function renderDetailPanel(
       '',
       'Changed files:',
       ...(detail.files.length ? detail.files.slice(0, 12).map(formatChangedFile) : ['No changed files found.']),
+      '',
+      'Workflows:',
+      ...workflowSections.flatMap((section) => [
+        section.title,
+        ...section.lines.slice(0, 3).map((line) => `  ${line}`),
+      ]).slice(0, 14),
     ]
     : [
       selected?.message || 'No commit selected.',
@@ -625,6 +685,35 @@ function renderDetailPanel(
     key: `detail-${index}`,
     dimColor: index > 1 && line !== 'Changed files:',
   }, truncate(line, width - 4))))
+}
+
+function renderConfirmationPanel(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  width: number,
+  theme: LogInkTheme,
+  focused: boolean
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const action = getWorkflowActionById(state.pendingConfirmationId)
+  const label = action?.label || 'Workflow action'
+  const warning = action?.kind === 'ai'
+    ? `AI action requires confirmation. Estimated ${action.estimatedTokens || '<unknown>'} tokens.`
+    : 'Destructive Git action requires confirmation.'
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    width,
+    paddingX: 1,
+  },
+  h(Text, { bold: true }, panelTitle('Confirm', focused)),
+  h(Text, undefined, truncate(label, width - 4)),
+  h(Text, { dimColor: true }, truncate(warning, width - 4)),
+  h(Text, undefined, ''),
+  h(Text, undefined, 'Press y to confirm or n/Esc to cancel.'))
 }
 
 function renderHelpPanel(
@@ -667,6 +756,7 @@ function renderCommandPalette(
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const commands = getLogInkCommandPaletteItems()
+  const workflowActions = getLogInkWorkflowActions()
 
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
@@ -680,7 +770,20 @@ function renderCommandPalette(
   h(Text, undefined, ''),
   ...commands.map((command) => h(Text, {
     key: command.id,
-  }, truncate(`${command.keys.padEnd(12)} ${command.label} - ${command.description}`, width - 4))))
+  }, truncate(`${command.keys.padEnd(12)} ${command.label} - ${command.description}`, width - 4))),
+  h(Text, undefined, ''),
+  h(Text, { bold: true }, 'Workflow actions'),
+  ...workflowActions.map((action) => {
+    const marker = action.kind === 'ai'
+      ? `[AI ~${action.estimatedTokens || '?'} tokens]`
+      : action.requiresConfirmation
+        ? '[confirm]'
+        : '[action]'
+
+    return h(Text, {
+      key: action.id,
+    }, truncate(`${action.key.padEnd(4)} ${marker} ${action.label}`, width - 4))
+  }))
 }
 
 function renderFooter(

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -119,4 +119,19 @@ describe('log Ink view model', () => {
     expect(state.showHelp).toBe(false)
     expect(state.showCommandPalette).toBe(true)
   })
+
+  it('tracks workflow action and confirmation state', () => {
+    let state = createLogInkState(rows)
+
+    state = applyLogInkAction(state, { type: 'setWorkflowAction', value: 'checkout-branch' })
+    expect(state.workflowActionId).toBe('checkout-branch')
+    expect(state.pendingConfirmationId).toBeUndefined()
+
+    state = applyLogInkAction(state, { type: 'setPendingConfirmation', value: 'delete-branch' })
+    expect(state.pendingConfirmationId).toBe('delete-branch')
+    expect(state.workflowActionId).toBeUndefined()
+
+    state = applyLogInkAction(state, { type: 'setPendingConfirmation', value: undefined })
+    expect(state.pendingConfirmationId).toBeUndefined()
+  })
 })

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -14,6 +14,8 @@ export type LogInkState = {
   fullGraph: boolean
   showHelp: boolean
   showCommandPalette: boolean
+  workflowActionId?: string
+  pendingConfirmationId?: string
   focus: LogInkFocus
   sidebarTab: LogInkSidebarTab
   statusMessage?: string
@@ -33,6 +35,8 @@ export type LogInkAction =
   | { type: 'setFocus'; value: LogInkFocus }
   | { type: 'setSidebarTab'; value: LogInkSidebarTab }
   | { type: 'setStatus'; value?: string }
+  | { type: 'setWorkflowAction'; value?: string }
+  | { type: 'setPendingConfirmation'; value?: string }
   | { type: 'toggleFilterMode' }
   | { type: 'toggleGraph' }
   | { type: 'toggleHelp' }
@@ -105,6 +109,8 @@ export function createLogInkState(rows: GitLogRow[]): LogInkState {
     fullGraph: false,
     showHelp: false,
     showCommandPalette: false,
+    workflowActionId: undefined,
+    pendingConfirmationId: undefined,
     focus: 'commits',
     sidebarTab: 'status',
   }
@@ -171,6 +177,18 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         statusMessage: action.value,
+      }
+    case 'setWorkflowAction':
+      return {
+        ...state,
+        workflowActionId: action.value,
+        pendingConfirmationId: undefined,
+      }
+    case 'setPendingConfirmation':
+      return {
+        ...state,
+        pendingConfirmationId: action.value,
+        workflowActionId: action.value ? undefined : state.workflowActionId,
       }
     case 'toggleFilterMode':
       return {

--- a/src/commands/log/inkWorkflows.test.ts
+++ b/src/commands/log/inkWorkflows.test.ts
@@ -1,0 +1,51 @@
+import { getLogInkWorkflowActions, getLogInkWorkflowSections } from './inkWorkflows'
+
+describe('log Ink workflows', () => {
+  it('builds workflow sections from available repository context', () => {
+    const sections = getLogInkWorkflowSections({
+      branches: {
+        currentBranch: 'main',
+        dirty: true,
+        localBranches: [],
+        remoteBranches: [],
+      },
+      worktree: {
+        stagedCount: 1,
+        unstagedCount: 2,
+        untrackedCount: 3,
+        files: [],
+      },
+      selectedCommit: {
+        type: 'commit',
+        graph: '*',
+        shortHash: 'abc1234',
+        hash: 'abc123456789',
+        date: '2026-04-29',
+        author: 'Coco Test',
+        refs: [],
+        message: 'feat: add workflows',
+      },
+    })
+
+    expect(sections.map((section) => section.title)).toEqual([
+      'Branch',
+      'Provider / PR',
+      'Status',
+      'Tags / Stashes / Worktrees',
+      'Operation / AI',
+    ])
+    expect(sections[0].lines).toContain('Current: main')
+    expect(sections[2].lines).toContain('1 staged file')
+    expect(sections[4].lines.join('\n')).toContain('abc1234')
+  })
+
+  it('marks destructive and AI actions as confirmation-gated', () => {
+    const actions = getLogInkWorkflowActions()
+    const destructive = actions.filter((action) => action.kind === 'destructive')
+    const ai = actions.filter((action) => action.kind === 'ai')
+
+    expect(destructive.length).toBeGreaterThan(0)
+    expect(destructive.every((action) => action.requiresConfirmation)).toBe(true)
+    expect(ai.every((action) => action.requiresConfirmation && action.estimatedTokens)).toBe(true)
+  })
+})

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -1,0 +1,195 @@
+import { BranchOverview } from './branchData'
+import { GitLogCommitRow } from './data'
+import { GitOperationOverview } from './operationData'
+import { ProviderOverview } from './providerData'
+import { PullRequestOverview } from './pullRequestData'
+import { StashOverview } from './stashData'
+import { WorktreeOverview } from './statusData'
+import { TagOverview } from './tagData'
+import { WorktreeOverview as WorktreeListOverview } from './worktreeData'
+
+export type LogInkWorkflowContext = {
+  branches?: BranchOverview
+  operation?: GitOperationOverview
+  provider?: ProviderOverview
+  pullRequest?: PullRequestOverview
+  selectedCommit?: GitLogCommitRow
+  stashes?: StashOverview
+  tags?: TagOverview
+  worktree?: WorktreeOverview
+  worktreeList?: WorktreeListOverview
+}
+
+export type LogInkWorkflowSection = {
+  title: string
+  lines: string[]
+}
+
+export type LogInkWorkflowActionKind = 'normal' | 'destructive' | 'ai'
+
+export type LogInkWorkflowAction = {
+  id: string
+  key: string
+  label: string
+  description: string
+  kind: LogInkWorkflowActionKind
+  requiresConfirmation: boolean
+  estimatedTokens?: number
+}
+
+function countLabel(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`
+}
+
+export function getLogInkWorkflowSections(context: LogInkWorkflowContext): LogInkWorkflowSection[] {
+  const currentBranch = context.branches?.currentBranch || context.provider?.currentBranch || '<detached>'
+  const dirty = context.branches?.dirty ? 'dirty worktree' : 'clean worktree'
+  const currentPullRequest = context.provider?.currentPullRequest || context.pullRequest?.currentPullRequest
+  const repository = context.provider?.repository
+  const repoName = repository?.owner && repository.name
+    ? `${repository.owner}/${repository.name}`
+    : repository?.message || 'local repository'
+  const operation = context.operation
+  const worktree = context.worktree
+
+  return [
+    {
+      title: 'Branch',
+      lines: [
+        `Current: ${currentBranch}`,
+        `State: ${dirty}`,
+        context.branches
+          ? `${countLabel(context.branches.localBranches.length, 'local branch', 'local branches')} | ${countLabel(context.branches.remoteBranches.length, 'remote branch', 'remote branches')}`
+          : 'Branch data unavailable',
+      ],
+    },
+    {
+      title: 'Provider / PR',
+      lines: [
+        `Repository: ${repoName}`,
+        currentPullRequest
+          ? `PR #${currentPullRequest.number} ${currentPullRequest.state}${currentPullRequest.isDraft ? ' draft' : ''}`
+          : 'No pull request detected for current branch',
+        context.provider?.authenticated === false ? 'Provider auth: offline' : 'Provider auth: available',
+      ],
+    },
+    {
+      title: 'Status',
+      lines: worktree
+        ? [
+          `${countLabel(worktree.stagedCount, 'staged file')}`,
+          `${countLabel(worktree.unstagedCount, 'unstaged file')}`,
+          `${countLabel(worktree.untrackedCount, 'untracked file')}`,
+        ]
+        : ['Status data unavailable'],
+    },
+    {
+      title: 'Tags / Stashes / Worktrees',
+      lines: [
+        context.tags ? countLabel(context.tags.tags.length, 'tag') : 'Tags unavailable',
+        context.stashes ? countLabel(context.stashes.stashes.length, 'stash', 'stashes') : 'Stashes unavailable',
+        context.worktreeList
+          ? countLabel(context.worktreeList.worktrees.length, 'worktree')
+          : 'Worktrees unavailable',
+      ],
+    },
+    {
+      title: 'Operation / AI',
+      lines: [
+        operation?.operation
+          ? `${operation.operation} in progress with ${countLabel(operation.conflictedFiles.length, 'conflict')}`
+          : 'No merge, rebase, cherry-pick, or revert in progress',
+        context.selectedCommit
+          ? `AI actions target ${context.selectedCommit.shortHash}; estimates shown before execution`
+          : 'AI actions require a selected commit',
+      ],
+    },
+  ]
+}
+
+export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
+  return [
+    {
+      id: 'checkout-branch',
+      key: 'enter',
+      label: 'Checkout selected branch',
+      description: 'Switch to the selected local or remote branch.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      id: 'create-pr',
+      key: 'C',
+      label: 'Create pull request',
+      description: 'Create a pull request from the current branch.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      id: 'stage-file',
+      key: 'space',
+      label: 'Stage or unstage file',
+      description: 'Toggle the selected status file between staged and unstaged.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      id: 'delete-branch',
+      key: 'D',
+      label: 'Delete branch',
+      description: 'Delete the selected branch after confirmation.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
+      id: 'delete-tag',
+      key: 'T',
+      label: 'Delete tag',
+      description: 'Delete the selected tag after confirmation.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
+      id: 'drop-stash',
+      key: 'X',
+      label: 'Drop stash',
+      description: 'Drop the selected stash after confirmation.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
+      id: 'remove-worktree',
+      key: 'W',
+      label: 'Remove worktree',
+      description: 'Remove the selected linked worktree after confirmation.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
+      id: 'abort-operation',
+      key: 'A',
+      label: 'Abort operation',
+      description: 'Abort the in-progress Git operation after confirmation.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
+      id: 'ai-commit-summary',
+      key: 'I',
+      label: 'AI commit summary',
+      description: 'Summarize the selected commit with token/cost awareness.',
+      kind: 'ai',
+      requiresConfirmation: true,
+      estimatedTokens: 800,
+    },
+    {
+      id: 'ai-conflict-help',
+      key: 'M',
+      label: 'AI conflict help',
+      description: 'Explain conflicted files and suggest resolution steps.',
+      kind: 'ai',
+      requiresConfirmation: true,
+      estimatedTokens: 1200,
+    },
+  ]
+}


### PR DESCRIPTION
## Summary
- add workflow summaries for branch, provider/PR, status, tags, stashes, worktrees, operations, and AI
- surface workflow actions in the command palette with destructive and AI confirmation markers
- add confirmation state/rendering before destructive or AI workflow operations proceed
- cover workflow sections, action gating, and view-model confirmation state in tests

## Validation
- `npm run test:jest -- src/commands/log/inkKeymap.test.ts src/commands/log/inkViewModel.test.ts src/commands/log/inkTheme.test.ts src/commands/log/inkWorkflows.test.ts`
- `npm run lint`
- `npm run build`
- `git diff --check`
- `npm test`

Closes #707
