### PR TITLE
Add log TUI polish QA coverage

### DIFF
--- a/bin/smokeCli.ts
+++ b/bin/smokeCli.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { spawnSync } from 'child_process'
@@ -7,12 +7,15 @@ type CommandCheck = {
   command: string
   args: string[]
   label: string
+  cwd?: string
+  env?: NodeJS.ProcessEnv
 }
 
-function runCheck({ command, args, label }: CommandCheck): string {
+function runCheck({ command, args, label, cwd = process.cwd(), env }: CommandCheck): string {
   const result = spawnSync(command, args, {
-    cwd: process.cwd(),
+    cwd,
     encoding: 'utf-8',
+    env: env ? { ...process.env, ...env } : process.env,
   })
 
   if (result.error) {
@@ -40,6 +43,12 @@ function assertHelpOutput(label: string, output: string): void {
   }
 }
 
+function assertOutputIncludes(label: string, output: string, expected: string): void {
+  if (!output.includes(expected)) {
+    throw new Error(`${label} did not include ${expected}:\n${output}`)
+  }
+}
+
 function runHelpCheck(check: CommandCheck): void {
   const output = runCheck(check)
   assertHelpOutput(check.label, output)
@@ -54,6 +63,45 @@ function packagedBinPath(prefix: string): string {
   return process.platform === 'win32'
     ? join(prefix, 'coco.cmd')
     : join(prefix, 'bin', 'coco')
+}
+
+function createSmokeRepo(root: string): string {
+  const repo = join(root, 'repo')
+
+  mkdirSync(repo)
+  runCheck({
+    command: 'git',
+    args: ['init', '--initial-branch=main'],
+    cwd: repo,
+    label: 'smoke repo init',
+  })
+  runCheck({
+    command: 'git',
+    args: ['config', 'user.name', 'Coco Smoke'],
+    cwd: repo,
+    label: 'smoke repo user name',
+  })
+  runCheck({
+    command: 'git',
+    args: ['config', 'user.email', 'smoke@example.com'],
+    cwd: repo,
+    label: 'smoke repo user email',
+  })
+  writeFileSync(join(repo, 'README.md'), '# Smoke repo\n', 'utf8')
+  runCheck({
+    command: 'git',
+    args: ['add', 'README.md'],
+    cwd: repo,
+    label: 'smoke repo add',
+  })
+  runCheck({
+    command: 'git',
+    args: ['commit', '-m', 'feat: smoke log command'],
+    cwd: repo,
+    label: 'smoke repo commit',
+  })
+
+  return repo
 }
 
 const tempRoot = mkdtempSync(join(tmpdir(), 'coco-cli-smoke-'))
@@ -117,6 +165,32 @@ try {
     label: 'packaged init dry run',
   })
   console.log('✓ packaged init dry run')
+
+  const smokeRepo = createSmokeRepo(tempRoot)
+  const logOutput = runCheck({
+    command: packagedBinPath(prefix),
+    args: ['log', '--limit', '1'],
+    cwd: smokeRepo,
+    label: 'packaged log command',
+    env: { NO_COLOR: '1' },
+  })
+  assertOutputIncludes('packaged log command', logOutput, 'feat: smoke log command')
+  console.log('✓ packaged log command')
+
+  const interactiveLogOutput = runCheck({
+    command: packagedBinPath(prefix),
+    args: ['log', '--interactive', '--limit', '1'],
+    cwd: smokeRepo,
+    label: 'packaged non-TTY interactive log command',
+    env: { NO_COLOR: '1' },
+  })
+  assertOutputIncludes('packaged non-TTY interactive log command', interactiveLogOutput, 'coco log')
+  assertOutputIncludes(
+    'packaged non-TTY interactive log command',
+    interactiveLogOutput,
+    'feat: smoke log command'
+  )
+  console.log('✓ packaged non-TTY interactive log command')
 } finally {
   rmSync(tempRoot, { recursive: true, force: true })
 }

--- a/src/commands/log/inkLayout.test.ts
+++ b/src/commands/log/inkLayout.test.ts
@@ -1,0 +1,42 @@
+import {
+  LOG_INK_MIN_COLUMNS,
+  LOG_INK_MIN_ROWS,
+  getLogInkLayout,
+} from './inkLayout'
+
+describe('log Ink layout', () => {
+  it('accepts the minimum supported terminal size', () => {
+    const layout = getLogInkLayout({
+      columns: LOG_INK_MIN_COLUMNS,
+      rows: LOG_INK_MIN_ROWS,
+    })
+
+    expect(layout.tooSmall).toBe(false)
+    expect(layout.bodyRows).toBe(19)
+    expect(layout.sidebarWidth).toBe(22)
+    expect(layout.detailWidth).toBe(30)
+  })
+
+  it('uses a balanced layout at the default terminal size', () => {
+    const layout = getLogInkLayout({ columns: 120, rows: 40 })
+
+    expect(layout.tooSmall).toBe(false)
+    expect(layout.bodyRows).toBe(35)
+    expect(layout.sidebarWidth).toBe(28)
+    expect(layout.detailWidth).toBe(40)
+  })
+
+  it('caps side panel widths on wide terminals', () => {
+    const layout = getLogInkLayout({ columns: 200, rows: 60 })
+
+    expect(layout.tooSmall).toBe(false)
+    expect(layout.bodyRows).toBe(55)
+    expect(layout.sidebarWidth).toBe(34)
+    expect(layout.detailWidth).toBe(56)
+  })
+
+  it('reports terminals below the minimum as too small', () => {
+    expect(getLogInkLayout({ columns: 79, rows: 24 }).tooSmall).toBe(true)
+    expect(getLogInkLayout({ columns: 80, rows: 23 }).tooSmall).toBe(true)
+  })
+})

--- a/src/commands/log/inkLayout.ts
+++ b/src/commands/log/inkLayout.ts
@@ -1,0 +1,32 @@
+export type LogInkLayoutInput = {
+  columns: number
+  rows: number
+}
+
+export type LogInkLayout = {
+  bodyRows: number
+  columns: number
+  detailWidth: number
+  rows: number
+  sidebarWidth: number
+  tooSmall: boolean
+}
+
+export const LOG_INK_MIN_COLUMNS = 80
+export const LOG_INK_MIN_ROWS = 24
+export const LOG_INK_DEFAULT_COLUMNS = 120
+export const LOG_INK_DEFAULT_ROWS = 40
+
+export function getLogInkLayout(input: LogInkLayoutInput): LogInkLayout {
+  const columns = input.columns || LOG_INK_DEFAULT_COLUMNS
+  const rows = input.rows || LOG_INK_DEFAULT_ROWS
+
+  return {
+    bodyRows: Math.max(8, rows - 5),
+    columns,
+    detailWidth: Math.max(30, Math.min(56, Math.floor(columns * 0.34))),
+    rows,
+    sidebarWidth: Math.max(22, Math.min(34, Math.floor(columns * 0.24))),
+    tooSmall: columns < LOG_INK_MIN_COLUMNS || rows < LOG_INK_MIN_ROWS,
+  }
+}

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -8,6 +8,13 @@ import {
   getLogInkFooterHints,
   getLogInkHelpSections,
 } from './inkKeymap'
+import {
+  LOG_INK_DEFAULT_COLUMNS,
+  LOG_INK_DEFAULT_ROWS,
+  LOG_INK_MIN_COLUMNS,
+  LOG_INK_MIN_ROWS,
+  getLogInkLayout,
+} from './inkLayout'
 import { createLogInkTheme, LogInkTheme } from './inkTheme'
 import {
   LogInkSidebarTab,
@@ -103,11 +110,6 @@ type LogInkComponentDeps = LogInkRuntime & {
   rows: GitLogRow[]
   theme: LogInkTheme
 }
-
-const MIN_COLUMNS = 80
-const MIN_ROWS = 24
-const DEFAULT_COLUMNS = 120
-const DEFAULT_ROWS = 40
 
 function truncate(value: string, width: number): string {
   if (width < 1) {
@@ -364,8 +366,10 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   const h = React.createElement
   const { exit } = useApp()
   const windowSize = useWindowSize()
-  const columns = windowSize.columns || process.stdout.columns || DEFAULT_COLUMNS
-  const terminalRows = windowSize.rows || process.stdout.rows || DEFAULT_ROWS
+  const layout = getLogInkLayout({
+    columns: windowSize.columns || process.stdout.columns || LOG_INK_DEFAULT_COLUMNS,
+    rows: windowSize.rows || process.stdout.rows || LOG_INK_DEFAULT_ROWS,
+  })
   const [state, setState] = React.useState<LogInkState>(() => createLogInkState(rows))
   const [context, setContext] = React.useState<LogInkContext>(initialContext)
   const [detail, setDetail] = React.useState<GitCommitDetail | undefined>(undefined)
@@ -490,29 +494,25 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
   })
 
-  if (columns < MIN_COLUMNS || terminalRows < MIN_ROWS) {
+  if (layout.tooSmall) {
     return h(Box, {
       flexDirection: 'column',
-      height: terminalRows,
+      height: layout.rows,
       paddingX: 1,
       paddingY: 1,
     },
     h(Text, { bold: true }, 'coco log -i'),
-    h(Text, undefined, `Terminal too small: ${columns}x${terminalRows}`),
-    h(Text, { dimColor: true }, `Minimum size is ${MIN_COLUMNS}x${MIN_ROWS}.`),
+    h(Text, undefined, `Terminal too small: ${layout.columns}x${layout.rows}`),
+    h(Text, { dimColor: true }, `Minimum size is ${LOG_INK_MIN_COLUMNS}x${LOG_INK_MIN_ROWS}.`),
     h(Text, { dimColor: true }, 'Resize the terminal or run plain coco log.'))
   }
 
-  const bodyRows = Math.max(8, terminalRows - 5)
-  const sidebarWidth = Math.max(22, Math.min(34, Math.floor(columns * 0.24)))
-  const detailWidth = Math.max(30, Math.min(56, Math.floor(columns * 0.34)))
-
-  return h(Box, { flexDirection: 'column', height: terminalRows },
-    renderHeader(h, { Box, Text }, state, context, columns, theme),
-    h(Box, { flexDirection: 'row', height: bodyRows },
-      renderSidebar(h, { Box, Text }, state, context, sidebarWidth, theme),
-      renderCommitPanel(h, { Box, Text }, state, bodyRows, theme),
-      renderDetailPanel(h, { Box, Text }, state, context, detail, detailLoading, detailWidth, theme)
+  return h(Box, { flexDirection: 'column', height: layout.rows },
+    renderHeader(h, { Box, Text }, state, context, layout.columns, theme),
+    h(Box, { flexDirection: 'row', height: layout.bodyRows },
+      renderSidebar(h, { Box, Text }, state, context, layout.sidebarWidth, theme),
+      renderCommitPanel(h, { Box, Text }, state, layout.bodyRows, theme),
+      renderDetailPanel(h, { Box, Text }, state, context, detail, detailLoading, layout.detailWidth, theme)
     ),
     renderFooter(h, { Box, Text }, state, theme)
   )


### PR DESCRIPTION
## Summary
- add a pure Ink layout calculator with 80x24, 120x40, wide, and too-small terminal coverage
- route the runtime through the shared layout constraints
- expand packaged CLI smoke tests to exercise `coco log` and non-TTY `coco log -i` in a real temp Git repo
- run the packaged smoke under `NO_COLOR=1` for the log path

## Validation
- `npm run test:jest -- src/commands/log/inkLayout.test.ts src/commands/log/inkTheme.test.ts src/commands/log/inkKeymap.test.ts src/commands/log/inkViewModel.test.ts src/commands/log/inkWorkflows.test.ts`
- `npm run lint`
- `npm run build`
- `npm run test:cli`
- `git diff --check`
- `npm test`

Closes #708
