### PR TITLE
Hydrate log TUI context asynchronously

### DIFF
--- a/src/commands/log/inkContext.test.ts
+++ b/src/commands/log/inkContext.test.ts
@@ -1,0 +1,26 @@
+import {
+  LOG_INK_CONTEXT_KEYS,
+  createLogInkContextStatus,
+  isLogInkContextKeyLoading,
+  isLogInkContextLoading,
+  updateLogInkContextStatus,
+} from './inkContext'
+
+describe('log Ink context loading state', () => {
+  it('creates consistent context status for every repository context source', () => {
+    const status = createLogInkContextStatus('loading')
+
+    expect(Object.keys(status)).toEqual([...LOG_INK_CONTEXT_KEYS])
+    expect(isLogInkContextLoading(status)).toBe(true)
+    expect(isLogInkContextKeyLoading(status, 'provider')).toBe(true)
+  })
+
+  it('updates one context source without mutating the rest', () => {
+    const loading = createLogInkContextStatus('loading')
+    const next = updateLogInkContextStatus(loading, 'branches', 'ready')
+
+    expect(next.branches).toBe('ready')
+    expect(next.provider).toBe('loading')
+    expect(loading.branches).toBe('loading')
+  })
+})

--- a/src/commands/log/inkContext.ts
+++ b/src/commands/log/inkContext.ts
@@ -1,0 +1,46 @@
+export const LOG_INK_CONTEXT_KEYS = [
+  'branches',
+  'operation',
+  'provider',
+  'pullRequest',
+  'stashes',
+  'tags',
+  'worktree',
+  'worktreeList',
+] as const
+
+export type LogInkContextKey = typeof LOG_INK_CONTEXT_KEYS[number]
+
+export type LogInkContextLoadState = 'idle' | 'loading' | 'ready'
+
+export type LogInkContextStatus = Record<LogInkContextKey, LogInkContextLoadState>
+
+export function createLogInkContextStatus(
+  state: LogInkContextLoadState = 'idle'
+): LogInkContextStatus {
+  return Object.fromEntries(
+    LOG_INK_CONTEXT_KEYS.map((key) => [key, state])
+  ) as LogInkContextStatus
+}
+
+export function updateLogInkContextStatus(
+  status: LogInkContextStatus,
+  key: LogInkContextKey,
+  state: LogInkContextLoadState
+): LogInkContextStatus {
+  return {
+    ...status,
+    [key]: state,
+  }
+}
+
+export function isLogInkContextLoading(status: LogInkContextStatus): boolean {
+  return Object.values(status).some((state) => state === 'loading')
+}
+
+export function isLogInkContextKeyLoading(
+  status: LogInkContextStatus,
+  key: LogInkContextKey
+): boolean {
+  return status[key] === 'loading'
+}

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -3,6 +3,14 @@ import { SimpleGit } from 'simple-git'
 import { BranchOverview, getBranchOverview } from './branchData'
 import { GitCommitDetail, GitLogCommitRow, GitLogRow, getCommitDetail } from './data'
 import {
+  LogInkContextKey,
+  LogInkContextStatus,
+  createLogInkContextStatus,
+  isLogInkContextKeyLoading,
+  isLogInkContextLoading,
+  updateLogInkContextStatus,
+} from './inkContext'
+import {
   formatBindingKeys,
   getLogInkCommandPaletteItems,
   getLogInkFooterHints,
@@ -106,7 +114,6 @@ type LogInkKey = {
 
 type LogInkComponentDeps = LogInkRuntime & {
   git: SimpleGit
-  initialContext: LogInkContext
   rows: GitLogRow[]
   theme: LogInkTheme
 }
@@ -174,6 +181,46 @@ async function loadLogInkContext(git: SimpleGit): Promise<LogInkContext> {
     worktree,
     worktreeList,
   }
+}
+
+function loadLogInkContextEntries(git: SimpleGit): Array<{
+  key: LogInkContextKey
+  load: () => Promise<LogInkContext[LogInkContextKey] | undefined>
+}> {
+  return [
+    {
+      key: 'branches',
+      load: () => safe(getBranchOverview(git)),
+    },
+    {
+      key: 'pullRequest',
+      load: () => safe(getPullRequestOverview(git)),
+    },
+    {
+      key: 'tags',
+      load: () => safe(getTagOverview(git)),
+    },
+    {
+      key: 'worktree',
+      load: () => safe(getWorktreeOverview(git)),
+    },
+    {
+      key: 'stashes',
+      load: () => safe(getStashOverview(git)),
+    },
+    {
+      key: 'worktreeList',
+      load: () => safe(getWorktreeListOverview(git)),
+    },
+    {
+      key: 'operation',
+      load: () => safe(getGitOperationOverview(git)),
+    },
+    {
+      key: 'provider',
+      load: () => safe(getProviderOverview(git)),
+    },
+  ]
 }
 
 async function loadInkRuntime(): Promise<LogInkRuntime> {
@@ -244,9 +291,18 @@ function formatDivergence(branch: BranchOverview['localBranches'][number]): stri
   return `+${branch.ahead}/-${branch.behind} ${branch.upstream}`
 }
 
-function sidebarLines(context: LogInkContext, tab: LogInkSidebarTab, width: number): string[] {
+function sidebarLines(
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  tab: LogInkSidebarTab,
+  width: number
+): string[] {
   if (tab === 'status') {
     const worktree = context.worktree
+
+    if (isLogInkContextKeyLoading(contextStatus, 'worktree')) {
+      return ['Loading status...']
+    }
 
     if (!worktree) {
       return ['Status unavailable']
@@ -266,6 +322,10 @@ function sidebarLines(context: LogInkContext, tab: LogInkSidebarTab, width: numb
   if (tab === 'branches') {
     const branches = context.branches
 
+    if (isLogInkContextKeyLoading(contextStatus, 'branches')) {
+      return ['Loading branches...']
+    }
+
     if (!branches) {
       return ['Branches unavailable']
     }
@@ -284,6 +344,10 @@ function sidebarLines(context: LogInkContext, tab: LogInkSidebarTab, width: numb
   }
 
   if (tab === 'tags') {
+    if (isLogInkContextKeyLoading(contextStatus, 'tags')) {
+      return ['Loading tags...']
+    }
+
     return context.tags?.tags.length
       ? context.tags.tags.slice(0, 12).map((tag) =>
         `${truncate(tag.name, 16)} ${truncate(tag.subject, Math.max(8, width - 18))}`
@@ -292,11 +356,19 @@ function sidebarLines(context: LogInkContext, tab: LogInkSidebarTab, width: numb
   }
 
   if (tab === 'stashes') {
+    if (isLogInkContextKeyLoading(contextStatus, 'stashes')) {
+      return ['Loading stashes...']
+    }
+
     return context.stashes?.stashes.length
       ? context.stashes.stashes.slice(0, 12).map((stash) =>
         `${stash.ref} ${truncate(stash.message, Math.max(8, width - stash.ref.length - 1))}`
       )
       : ['No stashes found']
+  }
+
+  if (isLogInkContextKeyLoading(contextStatus, 'worktreeList')) {
+    return ['Loading worktrees...']
   }
 
   return context.worktreeList?.worktrees.length
@@ -335,14 +407,10 @@ export async function startInkInteractiveLog(
     return
   }
 
-  const [runtime, initialContext] = await Promise.all([
-    loadInkRuntime(),
-    loadLogInkContext(git),
-  ])
+  const runtime = await loadInkRuntime()
   const { ink, React } = runtime
   const app = React.createElement(LogInkApp, {
     git,
-    initialContext,
     ink,
     React,
     rows,
@@ -361,7 +429,7 @@ export async function startInkInteractiveLog(
 }
 
 function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
-  const { git, initialContext, ink, React, rows, theme } = deps
+  const { git, ink, React, rows, theme } = deps
   const { Box, Text, useApp, useInput, useWindowSize } = ink
   const h = React.createElement
   const { exit } = useApp()
@@ -371,7 +439,10 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     rows: windowSize.rows || process.stdout.rows || LOG_INK_DEFAULT_ROWS,
   })
   const [state, setState] = React.useState<LogInkState>(() => createLogInkState(rows))
-  const [context, setContext] = React.useState<LogInkContext>(initialContext)
+  const [context, setContext] = React.useState<LogInkContext>({})
+  const [contextStatus, setContextStatus] = React.useState<LogInkContextStatus>(() =>
+    createLogInkContextStatus('loading')
+  )
   const [detail, setDetail] = React.useState<GitCommitDetail | undefined>(undefined)
   const [detailLoading, setDetailLoading] = React.useState(false)
   const selected = getSelectedInkCommit(state)
@@ -382,9 +453,33 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
 
   const refreshContext = React.useCallback(async () => {
     dispatch({ type: 'setStatus', value: 'refreshing repository context' })
+    setContextStatus(createLogInkContextStatus('loading'))
     setContext(await loadLogInkContext(git))
+    setContextStatus(createLogInkContextStatus('ready'))
     dispatch({ type: 'setStatus', value: 'repository context refreshed' })
   }, [dispatch, git])
+
+  React.useEffect(() => {
+    let active = true
+
+    loadLogInkContextEntries(git).forEach(({ key, load }) => {
+      void load().then((value) => {
+        if (!active) {
+          return
+        }
+
+        setContext((current) => ({
+          ...current,
+          [key]: value,
+        }))
+        setContextStatus((current) => updateLogInkContextStatus(current, key, 'ready'))
+      })
+    })
+
+    return () => {
+      active = false
+    }
+  }, [git])
 
   React.useEffect(() => {
     let active = true
@@ -508,11 +603,21 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   }
 
   return h(Box, { flexDirection: 'column', height: layout.rows },
-    renderHeader(h, { Box, Text }, state, context, layout.columns, theme),
+    renderHeader(h, { Box, Text }, state, context, contextStatus, layout.columns, theme),
     h(Box, { flexDirection: 'row', height: layout.bodyRows },
-      renderSidebar(h, { Box, Text }, state, context, layout.sidebarWidth, theme),
+      renderSidebar(h, { Box, Text }, state, context, contextStatus, layout.sidebarWidth, theme),
       renderCommitPanel(h, { Box, Text }, state, layout.bodyRows, theme),
-      renderDetailPanel(h, { Box, Text }, state, context, detail, detailLoading, layout.detailWidth, theme)
+      renderDetailPanel(
+        h,
+        { Box, Text },
+        state,
+        context,
+        contextStatus,
+        detail,
+        detailLoading,
+        layout.detailWidth,
+        theme
+      )
     ),
     renderFooter(h, { Box, Text }, state, theme)
   )
@@ -523,6 +628,7 @@ function renderHeader(
   components: LogInkComponents,
   state: LogInkState,
   context: LogInkContext,
+  contextStatus: LogInkContextStatus,
   columns: number,
   theme: LogInkTheme
 ): ReactTypes.ReactElement {
@@ -538,7 +644,8 @@ function renderHeader(
       ? `PR #${context.pullRequest.currentPullRequest.number} ${context.pullRequest.currentPullRequest.state}`
       : 'no PR'
   const search = state.filterMode ? `search: ${state.filter}_` : state.filter ? `filter: ${state.filter}` : ''
-  const title = truncate(`coco log  ${repo}  ${branch}  ${dirty}  ${pr}`, columns - 2)
+  const loading = isLogInkContextLoading(contextStatus) ? '  loading context' : ''
+  const title = truncate(`coco log  ${repo}  ${branch}  ${dirty}  ${pr}${loading}`, columns - 2)
 
   return h(Box, {
     borderColor: theme.colors.border,
@@ -555,12 +662,13 @@ function renderSidebar(
   components: LogInkComponents,
   state: LogInkState,
   context: LogInkContext,
+  contextStatus: LogInkContextStatus,
   width: number,
   theme: LogInkTheme
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const focused = state.focus === 'sidebar'
-  const lines = sidebarLines(context, state.sidebarTab, width - 4)
+  const lines = sidebarLines(context, contextStatus, state.sidebarTab, width - 4)
   const tabs = getLogInkSidebarTabs()
 
   return h(Box, {
@@ -622,6 +730,7 @@ function renderDetailPanel(
   components: LogInkComponents,
   state: LogInkState,
   context: LogInkContext,
+  contextStatus: LogInkContextStatus,
   detail: GitCommitDetail | undefined,
   loading: boolean,
   width: number,
@@ -645,6 +754,7 @@ function renderDetailPanel(
   const selected = getSelectedInkCommit(state)
   const workflowSections = getLogInkWorkflowSections({
     ...context,
+    contextLoading: isLogInkContextLoading(contextStatus),
     selectedCommit: selected,
   })
   const lines = detail

--- a/src/commands/log/inkWorkflows.test.ts
+++ b/src/commands/log/inkWorkflows.test.ts
@@ -48,4 +48,17 @@ describe('log Ink workflows', () => {
     expect(destructive.every((action) => action.requiresConfirmation)).toBe(true)
     expect(ai.every((action) => action.requiresConfirmation && action.estimatedTokens)).toBe(true)
   })
+
+  it('reports loading states while optional repository context hydrates', () => {
+    const sections = getLogInkWorkflowSections({
+      contextLoading: true,
+    })
+    const text = sections.flatMap((section) => section.lines).join('\n')
+
+    expect(text).toContain('Branch data loading')
+    expect(text).toContain('Provider and pull request data loading')
+    expect(text).toContain('Status data loading')
+    expect(text).toContain('Tags loading')
+    expect(text).toContain('Operation data loading')
+  })
 })

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -10,6 +10,7 @@ import { WorktreeOverview as WorktreeListOverview } from './worktreeData'
 
 export type LogInkWorkflowContext = {
   branches?: BranchOverview
+  contextLoading?: boolean
   operation?: GitOperationOverview
   provider?: ProviderOverview
   pullRequest?: PullRequestOverview
@@ -44,6 +45,7 @@ function countLabel(count: number, singular: string, plural = `${singular}s`): s
 export function getLogInkWorkflowSections(context: LogInkWorkflowContext): LogInkWorkflowSection[] {
   const currentBranch = context.branches?.currentBranch || context.provider?.currentBranch || '<detached>'
   const dirty = context.branches?.dirty ? 'dirty worktree' : 'clean worktree'
+  const loading = context.contextLoading
   const currentPullRequest = context.provider?.currentPullRequest || context.pullRequest?.currentPullRequest
   const repository = context.provider?.repository
   const repoName = repository?.owner && repository.name
@@ -58,7 +60,9 @@ export function getLogInkWorkflowSections(context: LogInkWorkflowContext): LogIn
       lines: [
         `Current: ${currentBranch}`,
         `State: ${dirty}`,
-        context.branches
+        loading && !context.branches
+          ? 'Branch data loading'
+          : context.branches
           ? `${countLabel(context.branches.localBranches.length, 'local branch', 'local branches')} | ${countLabel(context.branches.remoteBranches.length, 'remote branch', 'remote branches')}`
           : 'Branch data unavailable',
       ],
@@ -67,7 +71,9 @@ export function getLogInkWorkflowSections(context: LogInkWorkflowContext): LogIn
       title: 'Provider / PR',
       lines: [
         `Repository: ${repoName}`,
-        currentPullRequest
+        loading && !context.provider && !context.pullRequest
+          ? 'Provider and pull request data loading'
+          : currentPullRequest
           ? `PR #${currentPullRequest.number} ${currentPullRequest.state}${currentPullRequest.isDraft ? ' draft' : ''}`
           : 'No pull request detected for current branch',
         context.provider?.authenticated === false ? 'Provider auth: offline' : 'Provider auth: available',
@@ -75,7 +81,9 @@ export function getLogInkWorkflowSections(context: LogInkWorkflowContext): LogIn
     },
     {
       title: 'Status',
-      lines: worktree
+      lines: loading && !worktree
+        ? ['Status data loading']
+        : worktree
         ? [
           `${countLabel(worktree.stagedCount, 'staged file')}`,
           `${countLabel(worktree.unstagedCount, 'unstaged file')}`,
@@ -86,17 +94,21 @@ export function getLogInkWorkflowSections(context: LogInkWorkflowContext): LogIn
     {
       title: 'Tags / Stashes / Worktrees',
       lines: [
-        context.tags ? countLabel(context.tags.tags.length, 'tag') : 'Tags unavailable',
-        context.stashes ? countLabel(context.stashes.stashes.length, 'stash', 'stashes') : 'Stashes unavailable',
+        loading && !context.tags ? 'Tags loading' : context.tags ? countLabel(context.tags.tags.length, 'tag') : 'Tags unavailable',
+        loading && !context.stashes ? 'Stashes loading' : context.stashes ? countLabel(context.stashes.stashes.length, 'stash', 'stashes') : 'Stashes unavailable',
         context.worktreeList
           ? countLabel(context.worktreeList.worktrees.length, 'worktree')
-          : 'Worktrees unavailable',
+          : loading
+            ? 'Worktrees loading'
+            : 'Worktrees unavailable',
       ],
     },
     {
       title: 'Operation / AI',
       lines: [
-        operation?.operation
+        loading && !operation
+          ? 'Operation data loading'
+          : operation?.operation
           ? `${operation.operation} in progress with ${countLabel(operation.conflictedFiles.length, 'conflict')}`
           : 'No merge, rebase, cherry-pick, or revert in progress',
         context.selectedCommit


### PR DESCRIPTION
## Summary
- render `coco log -i` after the Ink runtime loads instead of waiting for all optional repo context
- hydrate branch, provider/PR, status, tags, stashes, worktrees, and operation context independently
- add loading states for sidebar/workflow surfaces while optional context is still resolving
- add pure tests for context loading state and workflow loading copy

## Validation
- `npm run test:jest -- src/commands/log/inkContext.test.ts src/commands/log/inkWorkflows.test.ts src/commands/log/inkLayout.test.ts src/commands/log/inkViewModel.test.ts src/commands/log/inkKeymap.test.ts`
- `npm run lint`
- `npm run build`
- `git diff --check`
- `npm test`

Closes #713
