### PR TITLE
Cover log TUI interactions and terminal hygiene

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -1,0 +1,130 @@
+import { GitLogRow } from './data'
+import { getLogInkInputEvents } from './inkInput'
+import { applyLogInkAction, createLogInkState } from './inkViewModel'
+
+const rows: GitLogRow[] = [
+  {
+    type: 'commit',
+    graph: '*',
+    shortHash: 'abc1234',
+    hash: 'abc123456789',
+    date: '2026-04-29',
+    author: 'Coco Test',
+    refs: ['HEAD -> main'],
+    message: 'feat: add log TUI interactions',
+  },
+  {
+    type: 'commit',
+    graph: '*',
+    shortHash: 'def5678',
+    hash: 'def567890123',
+    date: '2026-04-30',
+    author: 'Coco Test',
+    refs: [],
+    message: 'fix: polish log TUI',
+  },
+]
+
+function applyInput(
+  state = createLogInkState(rows),
+  inputValue: string,
+  key: Parameters<typeof getLogInkInputEvents>[2] = {}
+) {
+  return getLogInkInputEvents(state, inputValue, key)
+    .filter((event): event is Extract<typeof event, { type: 'action' }> => event.type === 'action')
+    .reduce((current, event) => applyLogInkAction(current, event.action), state)
+}
+
+describe('log Ink input interactions', () => {
+  it('exits with q or Ctrl+C', () => {
+    expect(getLogInkInputEvents(createLogInkState(rows), 'q')).toEqual([{ type: 'exit' }])
+    expect(getLogInkInputEvents(createLogInkState(rows), 'c', { ctrl: true })).toEqual([
+      { type: 'exit' },
+    ])
+  })
+
+  it('opens and edits search mode without handling meta/control text input', () => {
+    let state = createLogInkState(rows)
+
+    state = applyInput(state, '/')
+    expect(state.filterMode).toBe(true)
+
+    state = applyInput(state, 'p')
+    state = applyInput(state, 'o')
+    expect(state.filter).toBe('po')
+    expect(state.filteredCommits).toHaveLength(1)
+
+    state = applyInput(state, '', { backspace: true })
+    expect(state.filter).toBe('p')
+
+    state = applyInput(state, 'u', { ctrl: true })
+    expect(state.filter).toBe('')
+    expect(state.filterMode).toBe(false)
+  })
+
+  it('toggles help, command palette, focus, and graph interactions', () => {
+    let state = createLogInkState(rows)
+
+    state = applyInput(state, '?')
+    expect(state.showHelp).toBe(true)
+
+    state = applyInput(state, '', { escape: true })
+    expect(state.showHelp).toBe(false)
+
+    state = applyInput(state, ':')
+    expect(state.showCommandPalette).toBe(true)
+
+    state = applyInput(state, '', { escape: true })
+    expect(state.showCommandPalette).toBe(false)
+
+    state = applyInput(state, '', { tab: true })
+    expect(state.focus).toBe('detail')
+
+    state = applyInput(state, '', { tab: true, shift: true })
+    expect(state.focus).toBe('commits')
+
+    state = applyInput(state, 'g')
+    expect(state.fullGraph).toBe(true)
+  })
+
+  it('moves commits and sidebar tabs with arrows and vim keys', () => {
+    let state = createLogInkState(rows)
+
+    state = applyInput(state, 'j')
+    expect(state.selectedIndex).toBe(1)
+
+    state = applyInput(state, 'k')
+    expect(state.selectedIndex).toBe(0)
+
+    state = applyLogInkAction(state, { type: 'setFocus', value: 'sidebar' })
+    state = applyInput(state, '', { downArrow: true })
+    expect(state.sidebarTab).toBe('branches')
+
+    state = applyInput(state, '', { upArrow: true })
+    expect(state.sidebarTab).toBe('status')
+  })
+
+  it('emits refresh event separately from state actions', () => {
+    expect(getLogInkInputEvents(createLogInkState(rows), 'r')).toEqual([
+      { type: 'refreshContext' },
+    ])
+  })
+
+  it('gates destructive and AI workflow actions behind confirmation', () => {
+    let state = createLogInkState(rows)
+
+    state = applyInput(state, 'D')
+    expect(state.pendingConfirmationId).toBe('delete-branch')
+
+    state = applyInput(state, 'n')
+    expect(state.pendingConfirmationId).toBeUndefined()
+    expect(state.statusMessage).toBe('workflow action cancelled')
+
+    state = applyInput(state, 'I')
+    expect(state.pendingConfirmationId).toBe('ai-commit-summary')
+
+    state = applyInput(state, 'y')
+    expect(state.pendingConfirmationId).toBeUndefined()
+    expect(state.statusMessage).toBe('AI commit summary queued for workflow execution')
+  })
+})

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -1,0 +1,162 @@
+import { LogInkAction, LogInkState } from './inkViewModel'
+import {
+  getLogInkWorkflowActionById,
+  getLogInkWorkflowActionByKey,
+} from './inkWorkflows'
+
+export type LogInkInputKey = {
+  backspace?: boolean
+  ctrl?: boolean
+  delete?: boolean
+  downArrow?: boolean
+  escape?: boolean
+  meta?: boolean
+  pageDown?: boolean
+  pageUp?: boolean
+  return?: boolean
+  shift?: boolean
+  tab?: boolean
+  upArrow?: boolean
+}
+
+export type LogInkInputEvent =
+  | { type: 'action'; action: LogInkAction }
+  | { type: 'exit' }
+  | { type: 'refreshContext' }
+
+function action(actionValue: LogInkAction): LogInkInputEvent {
+  return {
+    type: 'action',
+    action: actionValue,
+  }
+}
+
+export function getLogInkInputEvents(
+  state: LogInkState,
+  inputValue: string,
+  key: LogInkInputKey = {}
+): LogInkInputEvent[] {
+  if (key.ctrl && inputValue === 'c') {
+    return [{ type: 'exit' }]
+  }
+
+  if (state.filterMode) {
+    if (key.return || key.escape) {
+      return [action({ type: 'toggleFilterMode' })]
+    }
+
+    if (key.backspace || key.delete) {
+      return [action({ type: 'backspaceFilter' })]
+    }
+
+    if (key.ctrl && inputValue === 'u') {
+      return [action({ type: 'clearFilter' })]
+    }
+
+    if (inputValue && !key.ctrl && !key.meta) {
+      return [action({ type: 'appendFilter', value: inputValue })]
+    }
+
+    return []
+  }
+
+  if (state.pendingConfirmationId) {
+    if (inputValue === 'y') {
+      const workflowAction = getLogInkWorkflowActionById(state.pendingConfirmationId)
+
+      return [
+        action({ type: 'setPendingConfirmation', value: undefined }),
+        action({
+          type: 'setStatus',
+          value: workflowAction
+            ? `${workflowAction.label} queued for workflow execution`
+            : 'workflow action queued',
+        }),
+      ]
+    }
+
+    if (inputValue === 'n' || key.escape) {
+      return [
+        action({ type: 'setPendingConfirmation', value: undefined }),
+        action({ type: 'setStatus', value: 'workflow action cancelled' }),
+      ]
+    }
+
+    return []
+  }
+
+  if (key.escape && state.showHelp) {
+    return [action({ type: 'toggleHelp' })]
+  }
+
+  if (key.escape && state.showCommandPalette) {
+    return [action({ type: 'toggleCommandPalette' })]
+  }
+
+  if (inputValue === 'q') {
+    return [{ type: 'exit' }]
+  }
+
+  if (inputValue === '?') {
+    return [action({ type: 'toggleHelp' })]
+  }
+
+  if (inputValue === '/') {
+    return [action({ type: 'toggleFilterMode' })]
+  }
+
+  if (inputValue === 'g') {
+    return [action({ type: 'toggleGraph' })]
+  }
+
+  if (inputValue === 'r') {
+    return [{ type: 'refreshContext' }]
+  }
+
+  if (inputValue === ':') {
+    return [action({ type: 'toggleCommandPalette' })]
+  }
+
+  if (key.tab) {
+    return [action({ type: key.shift ? 'focusPrevious' : 'focusNext' })]
+  }
+
+  if (key.upArrow || inputValue === 'k') {
+    return [
+      action(state.focus === 'sidebar'
+        ? { type: 'previousSidebarTab' }
+        : { type: 'move', delta: -1 }),
+    ]
+  }
+
+  if (key.downArrow || inputValue === 'j') {
+    return [
+      action(state.focus === 'sidebar'
+        ? { type: 'nextSidebarTab' }
+        : { type: 'move', delta: 1 }),
+    ]
+  }
+
+  if (key.pageUp) {
+    return [action({ type: 'page', delta: -10 })]
+  }
+
+  if (key.pageDown) {
+    return [action({ type: 'page', delta: 10 })]
+  }
+
+  const workflowAction = getLogInkWorkflowActionByKey(inputValue)
+
+  if (workflowAction?.requiresConfirmation) {
+    return [action({ type: 'setPendingConfirmation', value: workflowAction.id })]
+  }
+
+  if (workflowAction) {
+    return [
+      action({ type: 'setWorkflowAction', value: workflowAction.id }),
+      action({ type: 'setStatus', value: `${workflowAction.label} selected` }),
+    ]
+  }
+
+  return []
+}

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -16,6 +16,7 @@ import {
   getLogInkFooterHints,
   getLogInkHelpSections,
 } from './inkKeymap'
+import { LogInkInputKey, getLogInkInputEvents } from './inkInput'
 import {
   LOG_INK_DEFAULT_COLUMNS,
   LOG_INK_DEFAULT_ROWS,
@@ -40,11 +41,12 @@ import { StashOverview, getStashOverview } from './stashData'
 import { WorktreeOverview, getWorktreeOverview } from './statusData'
 import { TagOverview, getTagOverview } from './tagData'
 import {
-  LogInkWorkflowAction,
+  getLogInkWorkflowActionById,
   getLogInkWorkflowActions,
   getLogInkWorkflowSections,
 } from './inkWorkflows'
 import { WorktreeOverview as WorktreeListOverview, getWorktreeListOverview } from './worktreeData'
+import { canStartLogInkTui, getLogInkRenderOptions } from './inkTerminal'
 
 type DynamicImport = <T>(specifier: string) => Promise<T>
 const dynamicImport = new Function('specifier', 'return import(specifier)') as DynamicImport
@@ -86,7 +88,7 @@ type LogInkRuntime = {
     useApp: () => {
       exit: () => void
     }
-    useInput: (handler: (input: string, key: LogInkKey) => void) => void
+    useInput: (handler: (input: string, key: LogInkInputKey) => void) => void
     useWindowSize: () => {
       columns: number
       rows: number
@@ -96,21 +98,6 @@ type LogInkRuntime = {
 }
 
 type LogInkComponents = Pick<LogInkRuntime['ink'], 'Box' | 'Text'>
-
-type LogInkKey = {
-  backspace?: boolean
-  ctrl?: boolean
-  delete?: boolean
-  downArrow?: boolean
-  escape?: boolean
-  meta?: boolean
-  pageDown?: boolean
-  pageUp?: boolean
-  return?: boolean
-  shift?: boolean
-  tab?: boolean
-  upArrow?: boolean
-}
 
 type LogInkComponentDeps = LogInkRuntime & {
   git: SimpleGit
@@ -381,18 +368,6 @@ function sidebarLines(
     : ['No linked worktrees']
 }
 
-function getWorkflowActionByKey(inputValue: string): LogInkWorkflowAction | undefined {
-  return getLogInkWorkflowActions().find((action) => action.key === inputValue)
-}
-
-function getWorkflowActionById(id: string | undefined): LogInkWorkflowAction | undefined {
-  if (!id) {
-    return undefined
-  }
-
-  return getLogInkWorkflowActions().find((action) => action.id === id)
-}
-
 export async function startInkInteractiveLog(
   git: SimpleGit,
   rows: GitLogRow[],
@@ -402,7 +377,7 @@ export async function startInkInteractiveLog(
   const output = streams.output || process.stdout
   const error = streams.error || process.stderr
 
-  if (!input.isTTY || !output.isTTY) {
+  if (!canStartLogInkTui(input, output)) {
     await startInteractiveLog(git, rows, { input, output })
     return
   }
@@ -416,14 +391,7 @@ export async function startInkInteractiveLog(
     rows,
     theme: createLogInkTheme(),
   })
-  const instance = ink.render(app, {
-    exitOnCtrlC: true,
-    patchConsole: false,
-    stdin: input,
-    stdout: output,
-    stderr: error,
-    alternateScreen: true,
-  })
+  const instance = ink.render(app, getLogInkRenderOptions({ input, output, error }))
 
   await instance.waitUntilExit()
 }
@@ -506,87 +474,16 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
   }, [git, selected?.hash])
 
-  useInput((inputValue: string, key: LogInkKey) => {
-    if (key.ctrl && inputValue === 'c') {
-      exit()
-      return
-    }
-
-    if (state.filterMode) {
-      if (key.return || key.escape) {
-        dispatch({ type: 'toggleFilterMode' })
-      } else if (key.backspace || key.delete) {
-        dispatch({ type: 'backspaceFilter' })
-      } else if (key.ctrl && inputValue === 'u') {
-        dispatch({ type: 'clearFilter' })
-      } else if (inputValue && !key.ctrl && !key.meta) {
-        dispatch({ type: 'appendFilter', value: inputValue })
+  useInput((inputValue: string, key: LogInkInputKey) => {
+    getLogInkInputEvents(state, inputValue, key).forEach((event) => {
+      if (event.type === 'exit') {
+        exit()
+      } else if (event.type === 'refreshContext') {
+        void refreshContext()
+      } else {
+        dispatch(event.action)
       }
-
-      return
-    }
-
-    if (state.pendingConfirmationId) {
-      if (inputValue === 'y') {
-        const action = getWorkflowActionById(state.pendingConfirmationId)
-
-        dispatch({ type: 'setPendingConfirmation', value: undefined })
-        dispatch({
-          type: 'setStatus',
-          value: action
-            ? `${action.label} queued for workflow execution`
-            : 'workflow action queued',
-        })
-      } else if (inputValue === 'n' || key.escape) {
-        dispatch({ type: 'setPendingConfirmation', value: undefined })
-        dispatch({ type: 'setStatus', value: 'workflow action cancelled' })
-      }
-
-      return
-    }
-
-    if (key.escape && state.showHelp) {
-      dispatch({ type: 'toggleHelp' })
-      return
-    }
-
-    if (key.escape && state.showCommandPalette) {
-      dispatch({ type: 'toggleCommandPalette' })
-      return
-    }
-
-    if (inputValue === 'q') {
-      exit()
-    } else if (inputValue === '?') {
-      dispatch({ type: 'toggleHelp' })
-    } else if (inputValue === '/') {
-      dispatch({ type: 'toggleFilterMode' })
-    } else if (inputValue === 'g') {
-      dispatch({ type: 'toggleGraph' })
-    } else if (inputValue === 'r') {
-      void refreshContext()
-    } else if (inputValue === ':') {
-      dispatch({ type: 'toggleCommandPalette' })
-    } else if (key.tab) {
-      dispatch({ type: key.shift ? 'focusPrevious' : 'focusNext' })
-    } else if (key.upArrow || inputValue === 'k') {
-      dispatch(state.focus === 'sidebar' ? { type: 'previousSidebarTab' } : { type: 'move', delta: -1 })
-    } else if (key.downArrow || inputValue === 'j') {
-      dispatch(state.focus === 'sidebar' ? { type: 'nextSidebarTab' } : { type: 'move', delta: 1 })
-    } else if (key.pageUp) {
-      dispatch({ type: 'page', delta: -10 })
-    } else if (key.pageDown) {
-      dispatch({ type: 'page', delta: 10 })
-    } else {
-      const workflowAction = getWorkflowActionByKey(inputValue)
-
-      if (workflowAction?.requiresConfirmation) {
-        dispatch({ type: 'setPendingConfirmation', value: workflowAction.id })
-      } else if (workflowAction) {
-        dispatch({ type: 'setWorkflowAction', value: workflowAction.id })
-        dispatch({ type: 'setStatus', value: `${workflowAction.label} selected` })
-      }
-    }
+    })
   })
 
   if (layout.tooSmall) {
@@ -806,7 +703,7 @@ function renderConfirmationPanel(
   focused: boolean
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
-  const action = getWorkflowActionById(state.pendingConfirmationId)
+  const action = getLogInkWorkflowActionById(state.pendingConfirmationId)
   const label = action?.label || 'Workflow action'
   const warning = action?.kind === 'ai'
     ? `AI action requires confirmation. Estimated ${action.estimatedTokens || '<unknown>'} tokens.`

--- a/src/commands/log/inkTerminal.test.ts
+++ b/src/commands/log/inkTerminal.test.ts
@@ -1,0 +1,33 @@
+import { PassThrough } from 'stream'
+import { canStartLogInkTui, getLogInkRenderOptions } from './inkTerminal'
+
+function readStream(isTTY: boolean): NodeJS.ReadStream {
+  return Object.assign(new PassThrough(), { isTTY }) as unknown as NodeJS.ReadStream
+}
+
+function writeStream(isTTY: boolean): NodeJS.WriteStream {
+  return Object.assign(new PassThrough(), { isTTY }) as unknown as NodeJS.WriteStream
+}
+
+describe('log Ink terminal hygiene', () => {
+  it('only starts the full-screen TUI when input and output are TTYs', () => {
+    expect(canStartLogInkTui(readStream(true), writeStream(true))).toBe(true)
+    expect(canStartLogInkTui(readStream(false), writeStream(true))).toBe(false)
+    expect(canStartLogInkTui(readStream(true), writeStream(false))).toBe(false)
+  })
+
+  it('uses alternate screen and avoids stdout console patching', () => {
+    const input = readStream(true)
+    const output = writeStream(true)
+    const error = writeStream(true)
+
+    expect(getLogInkRenderOptions({ input, output, error })).toEqual({
+      alternateScreen: true,
+      exitOnCtrlC: true,
+      patchConsole: false,
+      stdin: input,
+      stdout: output,
+      stderr: error,
+    })
+  })
+})

--- a/src/commands/log/inkTerminal.ts
+++ b/src/commands/log/inkTerminal.ts
@@ -1,0 +1,34 @@
+export type LogInkTerminalStreams = {
+  input: NodeJS.ReadStream
+  output: NodeJS.WriteStream
+  error: NodeJS.WriteStream
+}
+
+export type LogInkRenderOptions = {
+  alternateScreen: true
+  exitOnCtrlC: true
+  patchConsole: false
+  stdin: NodeJS.ReadStream
+  stdout: NodeJS.WriteStream
+  stderr: NodeJS.WriteStream
+}
+
+export function canStartLogInkTui(
+  input: NodeJS.ReadStream,
+  output: NodeJS.WriteStream
+): boolean {
+  return Boolean(input.isTTY && output.isTTY)
+}
+
+export function getLogInkRenderOptions(
+  streams: LogInkTerminalStreams
+): LogInkRenderOptions {
+  return {
+    alternateScreen: true,
+    exitOnCtrlC: true,
+    patchConsole: false,
+    stdin: streams.input,
+    stdout: streams.output,
+    stderr: streams.error,
+  }
+}

--- a/src/commands/log/inkWorkflows.test.ts
+++ b/src/commands/log/inkWorkflows.test.ts
@@ -1,4 +1,9 @@
-import { getLogInkWorkflowActions, getLogInkWorkflowSections } from './inkWorkflows'
+import {
+  getLogInkWorkflowActionById,
+  getLogInkWorkflowActionByKey,
+  getLogInkWorkflowActions,
+  getLogInkWorkflowSections,
+} from './inkWorkflows'
 
 describe('log Ink workflows', () => {
   it('builds workflow sections from available repository context', () => {
@@ -47,6 +52,8 @@ describe('log Ink workflows', () => {
     expect(destructive.length).toBeGreaterThan(0)
     expect(destructive.every((action) => action.requiresConfirmation)).toBe(true)
     expect(ai.every((action) => action.requiresConfirmation && action.estimatedTokens)).toBe(true)
+    expect(getLogInkWorkflowActionByKey('D')?.id).toBe('delete-branch')
+    expect(getLogInkWorkflowActionById('ai-commit-summary')?.key).toBe('I')
   })
 
   it('reports loading states while optional repository context hydrates', () => {

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -205,3 +205,19 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
     },
   ]
 }
+
+export function getLogInkWorkflowActionByKey(
+  inputValue: string
+): LogInkWorkflowAction | undefined {
+  return getLogInkWorkflowActions().find((action) => action.key === inputValue)
+}
+
+export function getLogInkWorkflowActionById(
+  id: string | undefined
+): LogInkWorkflowAction | undefined {
+  if (!id) {
+    return undefined
+  }
+
+  return getLogInkWorkflowActions().find((action) => action.id === id)
+}


### PR DESCRIPTION
## Summary
- extract log TUI key handling into a pure interaction harness used by the Ink runtime
- cover `/`, `?`, `:`, `Tab`, vim/arrows, refresh, quit, and destructive/AI confirmation flows
- extract terminal hygiene helpers for TTY gating and Ink render options
- assert alternate screen, Ctrl+C exit handling, console patch behavior, and non-TTY fallback gating

## Validation
- `npm run test:jest -- src/commands/log/inkInput.test.ts src/commands/log/inkTerminal.test.ts src/commands/log/inkWorkflows.test.ts src/commands/log/inkLayout.test.ts src/commands/log/inkKeymap.test.ts src/commands/log/inkViewModel.test.ts`
- `npm run lint`
- `npm run build`
- `git diff --check`
- `npm test`

Closes #714
