### PR TITLE
Polish log TUI search and navigation

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -23,6 +23,16 @@ const rows: GitLogRow[] = [
     refs: [],
     message: 'fix: polish log TUI',
   },
+  {
+    type: 'commit',
+    graph: '*',
+    shortHash: 'fed9999',
+    hash: 'fed999900000',
+    date: '2026-05-01',
+    author: 'Coco Test',
+    refs: [],
+    message: 'docs: update log TUI help',
+  },
 ]
 
 function applyInput(
@@ -49,13 +59,14 @@ describe('log Ink input interactions', () => {
     state = applyInput(state, '/')
     expect(state.filterMode).toBe(true)
 
-    state = applyInput(state, 'p')
-    state = applyInput(state, 'o')
-    expect(state.filter).toBe('po')
+    state = applyInput(state, 'f')
+    state = applyInput(state, 'i')
+    state = applyInput(state, 'x')
+    expect(state.filter).toBe('fix')
     expect(state.filteredCommits).toHaveLength(1)
 
     state = applyInput(state, '', { backspace: true })
-    expect(state.filter).toBe('p')
+    expect(state.filter).toBe('fi')
 
     state = applyInput(state, 'u', { ctrl: true })
     expect(state.filter).toBe('')
@@ -85,9 +96,13 @@ describe('log Ink input interactions', () => {
 
     state = applyInput(state, 'g')
     expect(state.fullGraph).toBe(true)
+
+    state = applyInput(state, 'g')
+    expect(state.selectedIndex).toBe(0)
+    expect(state.statusMessage).toBe('jumped to first commit')
   })
 
-  it('moves commits and sidebar tabs with arrows and vim keys', () => {
+  it('moves commits and sidebar tabs with arrows, vim keys, and direct jumps', () => {
     let state = createLogInkState(rows)
 
     state = applyInput(state, 'j')
@@ -102,6 +117,45 @@ describe('log Ink input interactions', () => {
 
     state = applyInput(state, '', { upArrow: true })
     expect(state.sidebarTab).toBe('status')
+
+    state = applyInput(state, ']')
+    expect(state.sidebarTab).toBe('branches')
+
+    state = applyInput(state, '[')
+    expect(state.sidebarTab).toBe('status')
+
+    state = applyInput(state, '5')
+    expect(state.sidebarTab).toBe('worktrees')
+    expect(state.focus).toBe('sidebar')
+  })
+
+  it('supports next/previous match and top/bottom navigation conventions', () => {
+    let state = createLogInkState(rows)
+
+    state = applyInput(state, 'G')
+    expect(state.selectedIndex).toBe(2)
+    expect(state.statusMessage).toBe('jumped to last commit')
+
+    state = applyInput(state, 'N')
+    expect(state.selectedIndex).toBe(1)
+
+    state = applyInput(state, 'n')
+    expect(state.selectedIndex).toBe(2)
+
+    state = applyInput(state, 'g')
+    state = applyInput(state, 'g')
+    expect(state.selectedIndex).toBe(0)
+  })
+
+  it('clears pending key chords after unrelated actions', () => {
+    let state = createLogInkState(rows)
+
+    state = applyInput(state, 'g')
+    expect(state.pendingKey).toBe('g')
+
+    state = applyInput(state, '?')
+    expect(state.showHelp).toBe(true)
+    expect(state.pendingKey).toBeUndefined()
   })
 
   it('emits refresh event separately from state actions', () => {

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -1,4 +1,4 @@
-import { LogInkAction, LogInkState } from './inkViewModel'
+import { LogInkAction, LogInkSidebarTab, LogInkState } from './inkViewModel'
 import {
   getLogInkWorkflowActionById,
   getLogInkWorkflowActionByKey,
@@ -29,6 +29,14 @@ function action(actionValue: LogInkAction): LogInkInputEvent {
     type: 'action',
     action: actionValue,
   }
+}
+
+const SIDEBAR_TAB_BY_NUMBER: Record<string, LogInkSidebarTab> = {
+  '1': 'status',
+  '2': 'branches',
+  '3': 'tags',
+  '4': 'stashes',
+  '5': 'worktrees',
 }
 
 export function getLogInkInputEvents(
@@ -106,7 +114,32 @@ export function getLogInkInputEvents(
   }
 
   if (inputValue === 'g') {
-    return [action({ type: 'toggleGraph' })]
+    if (state.pendingKey === 'g') {
+      return [
+        action({ type: 'moveToTop' }),
+        action({ type: 'setStatus', value: 'jumped to first commit' }),
+      ]
+    }
+
+    return [
+      action({ type: 'toggleGraph' }),
+      action({ type: 'setPendingKey', value: 'g' }),
+    ]
+  }
+
+  if (inputValue === 'G') {
+    return [
+      action({ type: 'moveToBottom' }),
+      action({ type: 'setStatus', value: 'jumped to last commit' }),
+    ]
+  }
+
+  if (inputValue === 'n') {
+    return [action({ type: 'move', delta: 1 })]
+  }
+
+  if (inputValue === 'N') {
+    return [action({ type: 'move', delta: -1 })]
   }
 
   if (inputValue === 'r') {
@@ -115,6 +148,18 @@ export function getLogInkInputEvents(
 
   if (inputValue === ':') {
     return [action({ type: 'toggleCommandPalette' })]
+  }
+
+  if (inputValue === '[') {
+    return [action({ type: 'previousSidebarTab' })]
+  }
+
+  if (inputValue === ']') {
+    return [action({ type: 'nextSidebarTab' })]
+  }
+
+  if (SIDEBAR_TAB_BY_NUMBER[inputValue]) {
+    return [action({ type: 'setSidebarTab', value: SIDEBAR_TAB_BY_NUMBER[inputValue] })]
   }
 
   if (key.tab) {

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -11,7 +11,7 @@ describe('log Ink keymap', () => {
       filterMode: false,
       focus: 'commits',
       showHelp: false,
-    })).toEqual(['↑/↓ move', '/ search', 'tab focus', 'g graph', '? help'])
+    })).toEqual(['↑/↓ move', '/ search', 'gg/G top/bottom', 'n/N next', '? help'])
 
     expect(getLogInkFooterHints({
       filterMode: true,
@@ -35,6 +35,9 @@ describe('log Ink keymap', () => {
 
     expect(helpText).toContain('/ Filter commits')
     expect(helpText).toContain('g Toggle compact and full graph display.')
+    expect(helpText).toContain('gg Jump to the first visible commit.')
+    expect(helpText).toContain('G Jump to the last visible commit.')
+    expect(helpText).toContain('[ Move to the previous repository sidebar tab.')
     expect(helpText).toContain('q/ctrl+c Quit the interactive log.')
     expect(helpText).toContain('tab Move focus to the next panel.')
   })

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -7,9 +7,15 @@ export type LogInkCommandId =
   | 'focusPrevious'
   | 'help'
   | 'moveDown'
+  | 'moveToBottom'
+  | 'moveToTop'
+  | 'nextMatch'
+  | 'nextSidebarTab'
   | 'moveUp'
   | 'pageDown'
   | 'pageUp'
+  | 'previousMatch'
+  | 'previousSidebarTab'
   | 'quit'
   | 'refresh'
   | 'search'
@@ -64,6 +70,48 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     label: 'page down',
     description: 'Move a page down in the commit list.',
     contexts: ['commits'],
+  },
+  {
+    id: 'moveToTop',
+    keys: ['gg'],
+    label: 'top',
+    description: 'Jump to the first visible commit.',
+    contexts: ['commits'],
+  },
+  {
+    id: 'moveToBottom',
+    keys: ['G'],
+    label: 'bottom',
+    description: 'Jump to the last visible commit.',
+    contexts: ['commits'],
+  },
+  {
+    id: 'nextMatch',
+    keys: ['n'],
+    label: 'next match',
+    description: 'Move to the next visible search result.',
+    contexts: ['commits'],
+  },
+  {
+    id: 'previousMatch',
+    keys: ['N'],
+    label: 'previous match',
+    description: 'Move to the previous visible search result.',
+    contexts: ['commits'],
+  },
+  {
+    id: 'previousSidebarTab',
+    keys: ['['],
+    label: 'previous tab',
+    description: 'Move to the previous repository sidebar tab.',
+    contexts: ['sidebar'],
+  },
+  {
+    id: 'nextSidebarTab',
+    keys: [']'],
+    label: 'next tab',
+    description: 'Move to the next repository sidebar tab.',
+    contexts: ['sidebar'],
   },
   {
     id: 'focusNext',
@@ -162,14 +210,14 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): stri
   }
 
   if (options.focus === 'sidebar') {
-    return ['↑/↓ tab', 'tab focus', '/ search', '? help', 'q quit']
+    return ['[/] tab', '1-5 jump', 'tab focus', '/ search', '? help']
   }
 
   if (options.focus === 'detail') {
     return ['tab focus', 'g graph', 'r refresh', '? help', 'q quit']
   }
 
-  return ['↑/↓ move', '/ search', 'tab focus', 'g graph', '? help']
+  return ['↑/↓ move', '/ search', 'gg/G top/bottom', 'n/N next', '? help']
 }
 
 export function getLogInkHelpSections(): LogInkHelpSection[] {
@@ -177,7 +225,20 @@ export function getLogInkHelpSections(): LogInkHelpSection[] {
     {
       title: 'Navigation',
       bindings: LOG_INK_KEY_BINDINGS.filter((binding) =>
-        ['moveUp', 'moveDown', 'pageUp', 'pageDown', 'focusNext', 'focusPrevious'].includes(binding.id)
+        [
+          'moveUp',
+          'moveDown',
+          'pageUp',
+          'pageDown',
+          'moveToTop',
+          'moveToBottom',
+          'nextMatch',
+          'previousMatch',
+          'focusNext',
+          'focusPrevious',
+          'previousSidebarTab',
+          'nextSidebarTab',
+        ].includes(binding.id)
       ),
     },
     {

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -4,6 +4,7 @@ import {
   createLogInkState,
   getLogInkSidebarTabs,
   getSelectedInkCommit,
+  scoreLogInkCommitFilter,
 } from './inkViewModel'
 
 const rows: GitLogRow[] = [
@@ -27,14 +28,24 @@ const rows: GitLogRow[] = [
     refs: ['feature/ink'],
     message: 'fix: polish detail panel',
   },
+  {
+    type: 'commit',
+    graph: '*',
+    shortHash: 'fed9999',
+    hash: 'fed999900000',
+    date: '2026-04-29',
+    author: 'Feature Author',
+    refs: ['feature/polish'],
+    message: 'feat: polish commit browser',
+  },
 ]
 
 describe('log Ink view model', () => {
   it('creates a calm browsing state from parsed rows', () => {
     const state = createLogInkState(rows)
 
-    expect(state.commits).toHaveLength(2)
-    expect(state.filteredCommits).toHaveLength(2)
+    expect(state.commits).toHaveLength(3)
+    expect(state.filteredCommits).toHaveLength(3)
     expect(state.focus).toBe('commits')
     expect(state.sidebarTab).toBe('status')
     expect(state.showHelp).toBe(false)
@@ -48,7 +59,7 @@ describe('log Ink view model', () => {
     expect(getSelectedInkCommit(state)?.shortHash).toBe('def5678')
 
     state = applyLogInkAction(state, { type: 'move', delta: 10 })
-    expect(getSelectedInkCommit(state)?.shortHash).toBe('def5678')
+    expect(getSelectedInkCommit(state)?.shortHash).toBe('fed9999')
 
     state = applyLogInkAction(state, { type: 'move', delta: -10 })
     expect(getSelectedInkCommit(state)?.shortHash).toBe('abc1234')
@@ -58,7 +69,7 @@ describe('log Ink view model', () => {
     let state = createLogInkState(rows)
 
     state = applyLogInkAction(state, { type: 'setFilter', value: 'polish' })
-    expect(state.filteredCommits.map((commit) => commit.shortHash)).toEqual(['def5678'])
+    expect(state.filteredCommits.map((commit) => commit.shortHash)).toEqual(['def5678', 'fed9999'])
 
     state = applyLogInkAction(state, { type: 'setFilter', value: 'coco test' })
     expect(state.filteredCommits.map((commit) => commit.shortHash)).toEqual(['abc1234'])
@@ -68,6 +79,14 @@ describe('log Ink view model', () => {
 
     state = applyLogInkAction(state, { type: 'setFilter', value: 'def567890' })
     expect(state.filteredCommits.map((commit) => commit.shortHash)).toEqual(['def5678'])
+  })
+
+  it('uses fuzzy ranking when filtering commits', () => {
+    const state = applyLogInkAction(createLogInkState(rows), { type: 'setFilter', value: 'pcb' })
+
+    expect(state.filteredCommits.map((commit) => commit.shortHash)).toEqual(['fed9999'])
+    expect(scoreLogInkCommitFilter(rows[2] as typeof rows[number] & { type: 'commit' }, 'commit browser')).toBeDefined()
+    expect(scoreLogInkCommitFilter(rows[1] as typeof rows[number] & { type: 'commit' }, 'commit browser')).toBeUndefined()
   })
 
   it('edits search text through append, backspace, and clear actions', () => {
@@ -106,6 +125,20 @@ describe('log Ink view model', () => {
 
     state = applyLogInkAction(state, { type: 'previousSidebarTab' })
     expect(state.sidebarTab).toBe('status')
+
+    state = applyLogInkAction(state, { type: 'setSidebarTab', value: 'worktrees' })
+    expect(state.sidebarTab).toBe('worktrees')
+    expect(state.focus).toBe('sidebar')
+  })
+
+  it('jumps to list boundaries', () => {
+    let state = createLogInkState(rows)
+
+    state = applyLogInkAction(state, { type: 'moveToBottom' })
+    expect(getSelectedInkCommit(state)?.shortHash).toBe('fed9999')
+
+    state = applyLogInkAction(state, { type: 'moveToTop' })
+    expect(getSelectedInkCommit(state)?.shortHash).toBe('abc1234')
   })
 
   it('toggles graph, help, and command palette overlays', () => {

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -16,6 +16,7 @@ export type LogInkState = {
   showCommandPalette: boolean
   workflowActionId?: string
   pendingConfirmationId?: string
+  pendingKey?: string
   focus: LogInkFocus
   sidebarTab: LogInkSidebarTab
   statusMessage?: string
@@ -28,11 +29,14 @@ export type LogInkAction =
   | { type: 'focusNext' }
   | { type: 'focusPrevious' }
   | { type: 'move'; delta: number }
+  | { type: 'moveToBottom' }
+  | { type: 'moveToTop' }
   | { type: 'nextSidebarTab' }
   | { type: 'page'; delta: number }
   | { type: 'previousSidebarTab' }
   | { type: 'setFilter'; value: string }
   | { type: 'setFocus'; value: LogInkFocus }
+  | { type: 'setPendingKey'; value?: string }
   | { type: 'setSidebarTab'; value: LogInkSidebarTab }
   | { type: 'setStatus'; value?: string }
   | { type: 'setWorkflowAction'; value?: string }
@@ -45,13 +49,7 @@ export type LogInkAction =
 const FOCUS_ORDER: LogInkFocus[] = ['sidebar', 'commits', 'detail']
 const SIDEBAR_TABS: LogInkSidebarTab[] = ['status', 'branches', 'tags', 'stashes', 'worktrees']
 
-function matchesFilter(commit: GitLogCommitRow, filter: string): boolean {
-  const value = filter.trim().toLowerCase()
-
-  if (!value) {
-    return true
-  }
-
+function searchableFields(commit: GitLogCommitRow): string[] {
   return [
     commit.shortHash,
     commit.hash,
@@ -59,11 +57,91 @@ function matchesFilter(commit: GitLogCommitRow, filter: string): boolean {
     commit.author,
     commit.message,
     ...commit.refs,
-  ].some((field) => field.toLowerCase().includes(value))
+  ]
+}
+
+function scoreField(field: string, term: string): number | undefined {
+  const value = field.toLowerCase()
+  const normalized = term.toLowerCase()
+
+  if (!normalized) {
+    return 0
+  }
+
+  if (value === normalized) {
+    return 1000
+  }
+
+  if (value.startsWith(normalized)) {
+    return 800 - Math.min(value.length - normalized.length, 200)
+  }
+
+  const substringIndex = value.indexOf(normalized)
+
+  if (substringIndex >= 0) {
+    return 600 - Math.min(substringIndex, 200)
+  }
+
+  let searchIndex = 0
+  let distance = 0
+
+  for (const character of normalized) {
+    const nextIndex = value.indexOf(character, searchIndex)
+
+    if (nextIndex < 0) {
+      return undefined
+    }
+
+    distance += nextIndex - searchIndex
+    searchIndex = nextIndex + 1
+  }
+
+  return 300 - Math.min(distance, 200)
+}
+
+export function scoreLogInkCommitFilter(commit: GitLogCommitRow, filter: string): number | undefined {
+  const terms = filter.trim().split(/\s+/).filter(Boolean)
+
+  if (terms.length === 0) {
+    return 0
+  }
+
+  const fields = searchableFields(commit)
+  let score = 0
+
+  for (const term of terms) {
+    const bestFieldScore = fields.reduce<number | undefined>((best, field) => {
+      const fieldScore = scoreField(field, term)
+
+      if (fieldScore === undefined) {
+        return best
+      }
+
+      return best === undefined ? fieldScore : Math.max(best, fieldScore)
+    }, undefined)
+
+    if (bestFieldScore === undefined) {
+      return undefined
+    }
+
+    score += bestFieldScore
+  }
+
+  return score
 }
 
 function filterCommits(commits: GitLogCommitRow[], filter: string): GitLogCommitRow[] {
-  return commits.filter((commit) => matchesFilter(commit, filter))
+  return commits
+    .map((commit, index) => ({
+      commit,
+      index,
+      score: scoreLogInkCommitFilter(commit, filter),
+    }))
+    .filter((entry): entry is { commit: GitLogCommitRow; index: number; score: number } =>
+      entry.score !== undefined
+    )
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map((entry) => entry.commit)
 }
 
 function clampIndex(index: number, length: number): number {
@@ -89,6 +167,7 @@ function withFilter(state: LogInkState, filter: string): LogInkState {
     filter,
     filteredCommits,
     selectedIndex: clampIndex(state.selectedIndex, filteredCommits.length),
+    pendingKey: undefined,
   }
 }
 
@@ -111,6 +190,7 @@ export function createLogInkState(rows: GitLogRow[]): LogInkState {
     showCommandPalette: false,
     workflowActionId: undefined,
     pendingConfirmationId: undefined,
+    pendingKey: undefined,
     focus: 'commits',
     sidebarTab: 'status',
   }
@@ -135,31 +215,49 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         focus: cycleValue(FOCUS_ORDER, state.focus, 1),
+        pendingKey: undefined,
       }
     case 'focusPrevious':
       return {
         ...state,
         focus: cycleValue(FOCUS_ORDER, state.focus, -1),
+        pendingKey: undefined,
       }
     case 'move':
       return {
         ...state,
         selectedIndex: clampIndex(state.selectedIndex + action.delta, state.filteredCommits.length),
+        pendingKey: undefined,
+      }
+    case 'moveToBottom':
+      return {
+        ...state,
+        selectedIndex: clampIndex(state.filteredCommits.length - 1, state.filteredCommits.length),
+        pendingKey: undefined,
+      }
+    case 'moveToTop':
+      return {
+        ...state,
+        selectedIndex: 0,
+        pendingKey: undefined,
       }
     case 'nextSidebarTab':
       return {
         ...state,
         sidebarTab: cycleValue(SIDEBAR_TABS, state.sidebarTab, 1),
+        pendingKey: undefined,
       }
     case 'page':
       return {
         ...state,
         selectedIndex: clampIndex(state.selectedIndex + action.delta, state.filteredCommits.length),
+        pendingKey: undefined,
       }
     case 'previousSidebarTab':
       return {
         ...state,
         sidebarTab: cycleValue(SIDEBAR_TABS, state.sidebarTab, -1),
+        pendingKey: undefined,
       }
     case 'setFilter':
       return withFilter(state, action.value)
@@ -167,28 +265,39 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         focus: action.value,
+        pendingKey: undefined,
+      }
+    case 'setPendingKey':
+      return {
+        ...state,
+        pendingKey: action.value,
       }
     case 'setSidebarTab':
       return {
         ...state,
         sidebarTab: action.value,
+        focus: 'sidebar',
+        pendingKey: undefined,
       }
     case 'setStatus':
       return {
         ...state,
         statusMessage: action.value,
+        pendingKey: undefined,
       }
     case 'setWorkflowAction':
       return {
         ...state,
         workflowActionId: action.value,
         pendingConfirmationId: undefined,
+        pendingKey: undefined,
       }
     case 'setPendingConfirmation':
       return {
         ...state,
         pendingConfirmationId: action.value,
         workflowActionId: action.value ? undefined : state.workflowActionId,
+        pendingKey: undefined,
       }
     case 'toggleFilterMode':
       return {
@@ -196,23 +305,27 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         filterMode: !state.filterMode,
         showCommandPalette: false,
         showHelp: false,
+        pendingKey: undefined,
       }
     case 'toggleGraph':
       return {
         ...state,
         fullGraph: !state.fullGraph,
+        pendingKey: undefined,
       }
     case 'toggleHelp':
       return {
         ...state,
         showHelp: !state.showHelp,
         showCommandPalette: false,
+        pendingKey: undefined,
       }
     case 'toggleCommandPalette':
       return {
         ...state,
         showCommandPalette: !state.showCommandPalette,
         showHelp: false,
+        pendingKey: undefined,
       }
     default:
       return state


### PR DESCRIPTION
## Summary

- Add ranked fuzzy filtering for `coco log -i` commit search while preserving stable ordering for ties.
- Add common TUI navigation bindings: `gg`/`G`, `n`/`N`, `[`/`]`, and `1`-`5` sidebar tab jumps.
- Update contextual footer/help text and cover the new behavior with view-model, input, and keymap tests.

## Validation

- `npm run test:jest -- src/commands/log/inkViewModel.test.ts src/commands/log/inkInput.test.ts src/commands/log/inkKeymap.test.ts`
- `npm run lint`
- `npm run build`
- `git diff --check`
- `npm test`

Closes #715
