### PR TITLE
Add log TUI theming and detail previews

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -102,6 +102,17 @@
               "approval-mode": "auto-edit"
             }
           ]
+        },
+        "logTui": {
+          "type": "object",
+          "properties": {
+            "theme": {
+              "$ref": "#/definitions/LogInkThemeConfig",
+              "description": "Theme settings for `coco log -i`."
+            }
+          },
+          "additionalProperties": false,
+          "description": "Interactive log TUI settings."
         }
       },
       "required": [
@@ -2095,6 +2106,83 @@
         "authentication",
         "model",
         "provider"
+      ]
+    },
+    "LogInkThemeConfig": {
+      "type": "object",
+      "properties": {
+        "ascii": {
+          "type": "boolean"
+        },
+        "borderStyle": {
+          "$ref": "#/definitions/LogInkBorderStyle"
+        },
+        "colors": {
+          "$ref": "#/definitions/LogInkThemeColors"
+        },
+        "preset": {
+          "$ref": "#/definitions/LogInkThemePreset"
+        }
+      },
+      "additionalProperties": false
+    },
+    "LogInkBorderStyle": {
+      "type": "string",
+      "enum": [
+        "round",
+        "single",
+        "classic"
+      ]
+    },
+    "LogInkThemeColors": {
+      "type": "object",
+      "properties": {
+        "accent": {
+          "type": "string"
+        },
+        "border": {
+          "type": "string"
+        },
+        "danger": {
+          "type": "string"
+        },
+        "focusBorder": {
+          "type": "string"
+        },
+        "gitAdded": {
+          "type": "string"
+        },
+        "gitDeleted": {
+          "type": "string"
+        },
+        "gitModified": {
+          "type": "string"
+        },
+        "info": {
+          "type": "string"
+        },
+        "muted": {
+          "type": "string"
+        },
+        "selection": {
+          "type": "string"
+        },
+        "success": {
+          "type": "string"
+        },
+        "warning": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "LogInkThemePreset": {
+      "type": "string",
+      "enum": [
+        "default",
+        "monochrome",
+        "catppuccin",
+        "gruvbox"
       ]
     }
   }

--- a/src/commands/log/data.test.ts
+++ b/src/commands/log/data.test.ts
@@ -2,6 +2,7 @@ import { Arguments } from 'yargs'
 import {
   FIELD_SEPARATOR,
   buildLogArgs,
+  getCommitFilePreview,
   getCommitRows,
   getLogView,
   parseCommitDetail,
@@ -91,7 +92,8 @@ describe('log data layer', () => {
         'feat: add details',
         'Detailed body',
       ].join(FIELD_SEPARATOR),
-      ['A\tREADME.md', 'R100\told.ts\tnew.ts'].join('\n')
+      ['A\tREADME.md', 'R100\told.ts\tnew.ts'].join('\n'),
+      ['10\t2\tREADME.md', '3\t1\tnew.ts'].join('\n')
     )
 
     expect(detail).toEqual(expect.objectContaining({
@@ -100,15 +102,67 @@ describe('log data layer', () => {
       body: 'Detailed body',
       files: [
         {
+          additions: 10,
+          binary: false,
+          deletions: 2,
           status: 'A',
           path: 'README.md',
         },
         {
+          additions: 3,
+          binary: false,
+          deletions: 1,
           status: 'R100',
           oldPath: 'old.ts',
           path: 'new.ts',
         },
       ],
+      stats: {
+        deletions: 3,
+        filesChanged: 2,
+        insertions: 13,
+      },
     }))
+  })
+
+  it('loads a bounded selected-file hunk preview', async () => {
+    const git = {
+      raw: jest.fn().mockResolvedValue([
+        'diff --git a/src/file.ts b/src/file.ts',
+        '@@ -1,2 +1,2 @@',
+        '-old line',
+        '+new line',
+        ' context',
+      ].join('\n')),
+    }
+
+    const preview = await getCommitFilePreview(git as never, 'abc1234', {
+      additions: 1,
+      binary: false,
+      deletions: 1,
+      path: 'src/file.ts',
+      status: 'M',
+    })
+
+    expect(git.raw).toHaveBeenCalledWith([
+      'show',
+      '--format=',
+      '--find-renames',
+      '--color=never',
+      '--unified=3',
+      'abc1234',
+      '--',
+      'src/file.ts',
+    ])
+    expect(preview).toEqual({
+      hunks: ['@@ -1,2 +1,2 @@', '-old line', '+new line', ' context'],
+      oldPath: undefined,
+      path: 'src/file.ts',
+      stats: {
+        additions: 1,
+        binary: false,
+        deletions: 1,
+      },
+    })
   })
 })

--- a/src/commands/log/data.ts
+++ b/src/commands/log/data.ts
@@ -26,10 +26,29 @@ export type GitLogRow = GitLogCommitRow | GitLogGraphRow
 export type GitCommitDetail = Omit<GitLogCommitRow, 'type' | 'graph'> & {
   body: string
   files: Array<{
+    additions?: number
+    binary?: boolean
+    deletions?: number
     status: string
     path: string
     oldPath?: string
   }>
+  stats: {
+    filesChanged: number
+    insertions: number
+    deletions: number
+  }
+}
+
+export type GitCommitFilePreview = {
+  path: string
+  oldPath?: string
+  stats: {
+    additions?: number
+    binary?: boolean
+    deletions?: number
+  }
+  hunks: string[]
 }
 
 export function toArray(value: string | string[] | undefined): string[] {
@@ -107,7 +126,49 @@ export function parseLogOutput(output: string): GitLogRow[] {
     })
 }
 
-function parseNameStatus(output: string): GitCommitDetail['files'] {
+type ParsedNumstat = {
+  additions?: number
+  binary?: boolean
+  deletions?: number
+  path: string
+}
+
+function parseNumericStat(value: string): number | undefined {
+  return value === '-' ? undefined : Number(value)
+}
+
+function parseNumstat(output: string): ParsedNumstat[] {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [additions, deletions, path] = line.split('\t')
+
+      return {
+        additions: parseNumericStat(additions),
+        binary: additions === '-' || deletions === '-',
+        deletions: parseNumericStat(deletions),
+        path,
+      }
+    })
+}
+
+function summarizeNumstat(entries: ParsedNumstat[]): GitCommitDetail['stats'] {
+  return entries.reduce<GitCommitDetail['stats']>((summary, entry) => ({
+    filesChanged: summary.filesChanged + 1,
+    insertions: summary.insertions + (entry.additions || 0),
+    deletions: summary.deletions + (entry.deletions || 0),
+  }), {
+    filesChanged: 0,
+    insertions: 0,
+    deletions: 0,
+  })
+}
+
+function parseNameStatus(output: string, numstat: ParsedNumstat[] = []): GitCommitDetail['files'] {
+  const statsByPath = new Map(numstat.map((entry) => [entry.path, entry]))
+
   return output
     .split('\n')
     .map((line) => line.trim())
@@ -116,24 +177,34 @@ function parseNameStatus(output: string): GitCommitDetail['files'] {
       const [status, firstPath, secondPath] = line.split('\t')
 
       if (status.startsWith('R') || status.startsWith('C')) {
+        const stats = statsByPath.get(secondPath) || statsByPath.get(`${firstPath} => ${secondPath}`)
+
         return {
+          additions: stats?.additions,
+          binary: stats?.binary,
+          deletions: stats?.deletions,
           status,
           oldPath: firstPath,
           path: secondPath,
         }
       }
+      const stats = statsByPath.get(firstPath)
 
       return {
+        additions: stats?.additions,
+        binary: stats?.binary,
+        deletions: stats?.deletions,
         status,
         path: firstPath,
       }
     })
 }
 
-export function parseCommitDetail(metadata: string, files: string): GitCommitDetail {
+export function parseCommitDetail(metadata: string, files: string, numstatOutput = ''): GitCommitDetail {
   const [hash, shortHash, date, author, refs, message, body = ''] = metadata
     .trimEnd()
     .split(FIELD_SEPARATOR)
+  const numstat = parseNumstat(numstatOutput)
 
   return {
     shortHash,
@@ -143,7 +214,8 @@ export function parseCommitDetail(metadata: string, files: string): GitCommitDet
     refs: cleanRefs(refs),
     message,
     body: body.trim(),
-    files: parseNameStatus(files),
+    files: parseNameStatus(files, numstat),
+    stats: summarizeNumstat(numstat),
   }
 }
 
@@ -200,22 +272,71 @@ export async function getLogRows(git: SimpleGit, argv: LogArgv): Promise<GitLogR
 }
 
 export async function getCommitDetail(git: SimpleGit, commit: string): Promise<GitCommitDetail> {
-  const metadata = await git.raw([
-    'show',
-    '--no-patch',
-    '--date=short',
-    '--color=never',
-    `--pretty=format:${DETAIL_FORMAT}`,
-    commit,
+  const [metadata, files, numstat] = await Promise.all([
+    git.raw([
+      'show',
+      '--no-patch',
+      '--date=short',
+      '--color=never',
+      `--pretty=format:${DETAIL_FORMAT}`,
+      commit,
+    ]),
+    git.raw([
+      'show',
+      '--name-status',
+      '--format=',
+      '--find-renames',
+      '--color=never',
+      commit,
+    ]),
+    git.raw([
+      'show',
+      '--numstat',
+      '--format=',
+      '--find-renames',
+      '--color=never',
+      commit,
+    ]),
   ])
-  const files = await git.raw([
+
+  return parseCommitDetail(metadata, files, numstat)
+}
+
+export async function getCommitFilePreview(
+  git: SimpleGit,
+  commit: string,
+  file: GitCommitDetail['files'][number],
+  limit = 40
+): Promise<GitCommitFilePreview> {
+  const paths = file.oldPath ? [file.oldPath, file.path] : [file.path]
+  const patch = await git.raw([
     'show',
-    '--name-status',
     '--format=',
     '--find-renames',
     '--color=never',
+    '--unified=3',
     commit,
+    '--',
+    ...paths,
   ])
+  const hunks = patch
+    .split('\n')
+    .filter((line) => (
+      line.startsWith('@@') ||
+      line.startsWith('+') ||
+      line.startsWith('-') ||
+      line.startsWith(' ')
+    ))
+    .slice(0, limit)
 
-  return parseCommitDetail(metadata, files)
+  return {
+    path: file.path,
+    oldPath: file.oldPath,
+    stats: {
+      additions: file.additions,
+      binary: file.binary,
+      deletions: file.deletions,
+    },
+    hunks,
+  }
 }

--- a/src/commands/log/handler.ts
+++ b/src/commands/log/handler.ts
@@ -1,4 +1,6 @@
 import { CommandHandler } from '../../lib/types'
+import { Config } from '../../lib/config/types'
+import { loadConfig } from '../../lib/config/utils/loadConfig'
 import { getRepo } from '../../lib/simple-git/getRepo'
 import { handleResult } from '../../lib/ui/handleResult'
 import { getCommitDetail, getLogRows } from './data'
@@ -7,6 +9,7 @@ import { formatCommitDetail, formatLogJson, formatLogTable } from './render'
 import { LogArgv } from './config'
 
 export const handler: CommandHandler<LogArgv> = async (argv) => {
+  const config = loadConfig<Config, LogArgv>(argv)
   const git = getRepo()
   const format = argv.format === 'json' ? 'json' : 'table'
 
@@ -22,7 +25,9 @@ export const handler: CommandHandler<LogArgv> = async (argv) => {
   const rows = await getLogRows(git, argv)
 
   if (argv.interactive && format === 'table') {
-    await startInkInteractiveLog(git, rows)
+    await startInkInteractiveLog(git, rows, {}, {
+      theme: config.logTui?.theme,
+    })
     return
   }
 

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -38,9 +38,10 @@ const rows: GitLogRow[] = [
 function applyInput(
   state = createLogInkState(rows),
   inputValue: string,
-  key: Parameters<typeof getLogInkInputEvents>[2] = {}
+  key: Parameters<typeof getLogInkInputEvents>[2] = {},
+  context: Parameters<typeof getLogInkInputEvents>[3] = {}
 ) {
-  return getLogInkInputEvents(state, inputValue, key)
+  return getLogInkInputEvents(state, inputValue, key, context)
     .filter((event): event is Extract<typeof event, { type: 'action' }> => event.type === 'action')
     .reduce((current, event) => applyLogInkAction(current, event.action), state)
 }
@@ -145,6 +146,21 @@ describe('log Ink input interactions', () => {
     state = applyInput(state, 'g')
     state = applyInput(state, 'g')
     expect(state.selectedIndex).toBe(0)
+  })
+
+  it('moves detail file selection and diff preview pages when detail is focused', () => {
+    let state = createLogInkState(rows)
+
+    state = applyLogInkAction(state, { type: 'setFocus', value: 'detail' })
+    state = applyInput(state, 'j', {}, { detailFileCount: 3, previewLineCount: 30 })
+    expect(state.selectedFileIndex).toBe(1)
+
+    state = applyInput(state, '', { pageDown: true }, { detailFileCount: 3, previewLineCount: 30 })
+    expect(state.diffPreviewOffset).toBe(8)
+
+    state = applyInput(state, 'k', {}, { detailFileCount: 3, previewLineCount: 30 })
+    expect(state.selectedFileIndex).toBe(0)
+    expect(state.diffPreviewOffset).toBe(0)
   })
 
   it('clears pending key chords after unrelated actions', () => {

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -24,6 +24,11 @@ export type LogInkInputEvent =
   | { type: 'exit' }
   | { type: 'refreshContext' }
 
+export type LogInkInputContext = {
+  detailFileCount?: number
+  previewLineCount?: number
+}
+
 function action(actionValue: LogInkAction): LogInkInputEvent {
   return {
     type: 'action',
@@ -42,7 +47,8 @@ const SIDEBAR_TAB_BY_NUMBER: Record<string, LogInkSidebarTab> = {
 export function getLogInkInputEvents(
   state: LogInkState,
   inputValue: string,
-  key: LogInkInputKey = {}
+  key: LogInkInputKey = {},
+  context: LogInkInputContext = {}
 ): LogInkInputEvent[] {
   if (key.ctrl && inputValue === 'c') {
     return [{ type: 'exit' }]
@@ -167,6 +173,10 @@ export function getLogInkInputEvents(
   }
 
   if (key.upArrow || inputValue === 'k') {
+    if (state.focus === 'detail' && context.detailFileCount) {
+      return [action({ type: 'moveDetailFile', delta: -1, fileCount: context.detailFileCount })]
+    }
+
     return [
       action(state.focus === 'sidebar'
         ? { type: 'previousSidebarTab' }
@@ -175,6 +185,10 @@ export function getLogInkInputEvents(
   }
 
   if (key.downArrow || inputValue === 'j') {
+    if (state.focus === 'detail' && context.detailFileCount) {
+      return [action({ type: 'moveDetailFile', delta: 1, fileCount: context.detailFileCount })]
+    }
+
     return [
       action(state.focus === 'sidebar'
         ? { type: 'nextSidebarTab' }
@@ -183,10 +197,26 @@ export function getLogInkInputEvents(
   }
 
   if (key.pageUp) {
+    if (state.focus === 'detail' && context.previewLineCount) {
+      return [action({
+        type: 'pageDetailPreview',
+        delta: -8,
+        previewLineCount: context.previewLineCount,
+      })]
+    }
+
     return [action({ type: 'page', delta: -10 })]
   }
 
   if (key.pageDown) {
+    if (state.focus === 'detail' && context.previewLineCount) {
+      return [action({
+        type: 'pageDetailPreview',
+        delta: 8,
+        previewLineCount: context.previewLineCount,
+      })]
+    }
+
     return [action({ type: 'page', delta: 10 })]
   }
 

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -21,6 +21,12 @@ describe('log Ink keymap', () => {
 
     expect(getLogInkFooterHints({
       filterMode: false,
+      focus: 'detail',
+      showHelp: false,
+    })).toEqual(['↑/↓ files', 'pgup/pgdn diff', 'tab focus', '? help', 'q quit'])
+
+    expect(getLogInkFooterHints({
+      filterMode: false,
       focus: 'commits',
       showCommandPalette: true,
       showHelp: false,

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -214,7 +214,7 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): stri
   }
 
   if (options.focus === 'detail') {
-    return ['tab focus', 'g graph', 'r refresh', '? help', 'q quit']
+    return ['↑/↓ files', 'pgup/pgdn diff', 'tab focus', '? help', 'q quit']
   }
 
   return ['↑/↓ move', '/ search', 'gg/G top/bottom', 'n/N next', '? help']

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -1,7 +1,14 @@
 import type * as ReactTypes from 'react'
 import { SimpleGit } from 'simple-git'
 import { BranchOverview, getBranchOverview } from './branchData'
-import { GitCommitDetail, GitLogCommitRow, GitLogRow, getCommitDetail } from './data'
+import {
+  GitCommitDetail,
+  GitCommitFilePreview,
+  GitLogCommitRow,
+  GitLogRow,
+  getCommitDetail,
+  getCommitFilePreview,
+} from './data'
 import {
   LogInkContextKey,
   LogInkContextStatus,
@@ -24,7 +31,8 @@ import {
   LOG_INK_MIN_ROWS,
   getLogInkLayout,
 } from './inkLayout'
-import { createLogInkTheme, LogInkTheme } from './inkTheme'
+import { createLogInkTheme, LogInkTheme, LogInkThemeConfig } from './inkTheme'
+import { truncateCells } from './inkText'
 import {
   LogInkSidebarTab,
   LogInkState,
@@ -55,6 +63,10 @@ type LogInkStreams = {
   input?: NodeJS.ReadStream
   output?: NodeJS.WriteStream
   error?: NodeJS.WriteStream
+}
+
+type LogInkOptions = {
+  theme?: LogInkThemeConfig
 }
 
 type LogInkContext = {
@@ -105,21 +117,7 @@ type LogInkComponentDeps = LogInkRuntime & {
   theme: LogInkTheme
 }
 
-function truncate(value: string, width: number): string {
-  if (width < 1) {
-    return ''
-  }
-
-  if (value.length <= width) {
-    return value
-  }
-
-  if (width <= 3) {
-    return value.slice(0, width)
-  }
-
-  return `${value.slice(0, width - 3)}...`
-}
+const truncate = truncateCells
 
 function compactHash(hash: string | undefined): string {
   return hash ? hash.slice(0, 7) : '<none>'
@@ -130,11 +128,18 @@ function formatRefs(commit: GitLogCommitRow): string {
 }
 
 function formatChangedFile(file: GitCommitDetail['files'][number]): string {
+  const stats = file.binary
+    ? 'bin'
+    : file.additions !== undefined || file.deletions !== undefined
+      ? `+${file.additions || 0}/-${file.deletions || 0}`
+      : ''
+  const suffix = stats ? ` ${stats}` : ''
+
   if (file.oldPath) {
-    return `${file.status} ${file.oldPath} -> ${file.path}`
+    return `${file.status} ${file.oldPath} -> ${file.path}${suffix}`
   }
 
-  return `${file.status} ${file.path}`
+  return `${file.status} ${file.path}${suffix}`
 }
 
 async function safe<T>(promise: Promise<T>): Promise<T | undefined> {
@@ -371,7 +376,8 @@ function sidebarLines(
 export async function startInkInteractiveLog(
   git: SimpleGit,
   rows: GitLogRow[],
-  streams: LogInkStreams = {}
+  streams: LogInkStreams = {},
+  options: LogInkOptions = {}
 ): Promise<void> {
   const input = streams.input || process.stdin
   const output = streams.output || process.stdout
@@ -389,7 +395,7 @@ export async function startInkInteractiveLog(
     ink,
     React,
     rows,
-    theme: createLogInkTheme(),
+    theme: createLogInkTheme(options.theme),
   })
   const instance = ink.render(app, getLogInkRenderOptions({ input, output, error }))
 
@@ -413,7 +419,10 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   )
   const [detail, setDetail] = React.useState<GitCommitDetail | undefined>(undefined)
   const [detailLoading, setDetailLoading] = React.useState(false)
+  const [filePreview, setFilePreview] = React.useState<GitCommitFilePreview | undefined>(undefined)
+  const [filePreviewLoading, setFilePreviewLoading] = React.useState(false)
   const selected = getSelectedInkCommit(state)
+  const selectedDetailFile = detail?.files[state.selectedFileIndex]
 
   const dispatch = React.useCallback((action: Parameters<typeof applyLogInkAction>[1]) => {
     setState((current) => applyLogInkAction(current, action))
@@ -474,8 +483,36 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
   }, [git, selected?.hash])
 
+  React.useEffect(() => {
+    let active = true
+
+    async function loadPreview(): Promise<void> {
+      if (!selected || !selectedDetailFile) {
+        setFilePreview(undefined)
+        return
+      }
+
+      setFilePreviewLoading(true)
+      const nextPreview = await safe(getCommitFilePreview(git, selected.hash, selectedDetailFile))
+
+      if (active) {
+        setFilePreview(nextPreview)
+        setFilePreviewLoading(false)
+      }
+    }
+
+    void loadPreview()
+
+    return () => {
+      active = false
+    }
+  }, [git, selected?.hash, selectedDetailFile?.path, selectedDetailFile?.oldPath])
+
   useInput((inputValue: string, key: LogInkInputKey) => {
-    getLogInkInputEvents(state, inputValue, key).forEach((event) => {
+    getLogInkInputEvents(state, inputValue, key, {
+      detailFileCount: detail?.files.length,
+      previewLineCount: filePreview?.hunks.length,
+    }).forEach((event) => {
       if (event.type === 'exit') {
         exit()
       } else if (event.type === 'refreshContext') {
@@ -512,6 +549,8 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         contextStatus,
         detail,
         detailLoading,
+        filePreview,
+        filePreviewLoading,
         layout.detailWidth,
         theme
       )
@@ -630,6 +669,8 @@ function renderDetailPanel(
   contextStatus: LogInkContextStatus,
   detail: GitCommitDetail | undefined,
   loading: boolean,
+  filePreview: GitCommitFilePreview | undefined,
+  filePreviewLoading: boolean,
   width: number,
   theme: LogInkTheme
 ): ReactTypes.ReactElement {
@@ -649,6 +690,11 @@ function renderDetailPanel(
   }
 
   const selected = getSelectedInkCommit(state)
+  const selectedFile = detail?.files[state.selectedFileIndex]
+  const previewWindow = filePreview?.hunks.slice(state.diffPreviewOffset, state.diffPreviewOffset + 8)
+  const statLine = detail
+    ? `${detail.stats.filesChanged} files  +${detail.stats.insertions}/-${detail.stats.deletions}`
+    : ''
   const workflowSections = getLogInkWorkflowSections({
     ...context,
     contextLoading: isLogInkContextLoading(contextStatus),
@@ -662,11 +708,26 @@ function renderDetailPanel(
       `Author: ${detail.author}`,
       `Date: ${detail.date}`,
       detail.refs.length ? `Refs: ${detail.refs.join(', ')}` : 'Refs: none',
+      statLine,
       '',
       ...(detail.body ? detail.body.split('\n').slice(0, 6) : ['No commit body.']),
       '',
       'Changed files:',
-      ...(detail.files.length ? detail.files.slice(0, 12).map(formatChangedFile) : ['No changed files found.']),
+      ...(detail.files.length
+        ? detail.files.slice(0, 8).map((file, index) =>
+          `${index === state.selectedFileIndex ? '>' : ' '} ${formatChangedFile(file)}`
+        )
+        : ['No changed files found.']),
+      '',
+      selectedFile
+        ? `Preview: ${formatChangedFile(selectedFile)}`
+        : 'Preview: no file selected',
+      filePreviewLoading
+        ? 'Loading diff preview...'
+        : previewWindow?.length
+          ? `Lines ${state.diffPreviewOffset + 1}-${state.diffPreviewOffset + previewWindow.length}/${filePreview?.hunks.length || 0}`
+          : 'No hunk preview available.',
+      ...(previewWindow || []).map((line) => `  ${line}`),
       '',
       'Workflows:',
       ...workflowSections.flatMap((section) => [

--- a/src/commands/log/inkText.test.ts
+++ b/src/commands/log/inkText.test.ts
@@ -1,0 +1,14 @@
+import { cellWidth, truncateCells } from './inkText'
+
+describe('log Ink text helpers', () => {
+  it('measures wide and emoji characters by terminal cell width', () => {
+    expect(cellWidth('abc')).toBe(3)
+    expect(cellWidth('変更')).toBe(4)
+    expect(cellWidth('fix ✨')).toBe(6)
+  })
+
+  it('truncates without splitting wide characters past the target width', () => {
+    expect(truncateCells('src/変更-summary.ts', 10)).toBe('src/変...')
+    expect(cellWidth(truncateCells('emoji ✨ commit message', 12))).toBeLessThanOrEqual(12)
+  })
+})

--- a/src/commands/log/inkText.ts
+++ b/src/commands/log/inkText.ts
@@ -1,0 +1,76 @@
+const COMBINING_MARK_RANGES: Array<[number, number]> = [
+  [0x0300, 0x036f],
+  [0x1ab0, 0x1aff],
+  [0x1dc0, 0x1dff],
+  [0x20d0, 0x20ff],
+  [0xfe20, 0xfe2f],
+]
+
+const WIDE_CHARACTER_RANGES: Array<[number, number]> = [
+  [0x1100, 0x115f],
+  [0x2329, 0x232a],
+  [0x2e80, 0xa4cf],
+  [0xac00, 0xd7a3],
+  [0xf900, 0xfaff],
+  [0xfe10, 0xfe19],
+  [0xfe30, 0xfe6f],
+  [0xff00, 0xff60],
+  [0xffe0, 0xffe6],
+  [0x2600, 0x27bf],
+  [0x1f000, 0x1f9ff],
+  [0x20000, 0x3fffd],
+]
+
+function isInRange(codePoint: number, ranges: Array<[number, number]>): boolean {
+  return ranges.some(([start, end]) => codePoint >= start && codePoint <= end)
+}
+
+function characterWidth(character: string): number {
+  const codePoint = character.codePointAt(0) || 0
+
+  if (codePoint === 0 || codePoint < 32 || (codePoint >= 0x7f && codePoint < 0xa0)) {
+    return 0
+  }
+
+  if (
+    codePoint === 0x200d ||
+    (codePoint >= 0xfe00 && codePoint <= 0xfe0f) ||
+    isInRange(codePoint, COMBINING_MARK_RANGES)
+  ) {
+    return 0
+  }
+
+  return isInRange(codePoint, WIDE_CHARACTER_RANGES) ? 2 : 1
+}
+
+export function cellWidth(value: string): number {
+  return Array.from(value).reduce((width, character) => width + characterWidth(character), 0)
+}
+
+export function truncateCells(value: string, width: number): string {
+  if (width < 1) {
+    return ''
+  }
+
+  if (cellWidth(value) <= width) {
+    return value
+  }
+
+  const suffix = width > 3 ? '...' : ''
+  const available = width - cellWidth(suffix)
+  let used = 0
+  let output = ''
+
+  for (const character of Array.from(value)) {
+    const nextWidth = characterWidth(character)
+
+    if (used + nextWidth > available) {
+      break
+    }
+
+    output += character
+    used += nextWidth
+  }
+
+  return `${output}${suffix}`
+}

--- a/src/commands/log/inkTheme.test.ts
+++ b/src/commands/log/inkTheme.test.ts
@@ -18,4 +18,27 @@ describe('log Ink theme', () => {
     expect(theme.borderStyle).toBe('classic')
     expect(theme.colors).toEqual({})
   })
+
+  it('supports configurable presets and token overrides', () => {
+    const theme = createLogInkTheme({
+      borderStyle: 'single',
+      colors: {
+        accent: '#ffffff',
+      },
+      noColor: false,
+      preset: 'catppuccin',
+      term: 'xterm-256color',
+    })
+
+    expect(theme.borderStyle).toBe('single')
+    expect(theme.colors.focusBorder).toBe('#89dceb')
+    expect(theme.colors.accent).toBe('#ffffff')
+  })
+
+  it('treats the monochrome preset as a no-color theme', () => {
+    const theme = createLogInkTheme({ noColor: false, preset: 'monochrome' })
+
+    expect(theme.noColor).toBe(true)
+    expect(theme.colors).toEqual({})
+  })
 })

--- a/src/commands/log/inkTheme.ts
+++ b/src/commands/log/inkTheme.ts
@@ -1,29 +1,83 @@
 export type LogInkBorderStyle = 'round' | 'single' | 'classic'
+export type LogInkThemePreset = 'default' | 'monochrome' | 'catppuccin' | 'gruvbox'
+
+export type LogInkThemeColors = {
+  accent?: string
+  border?: string
+  danger?: string
+  focusBorder?: string
+  gitAdded?: string
+  gitDeleted?: string
+  gitModified?: string
+  info?: string
+  muted?: string
+  selection?: string
+  success?: string
+  warning?: string
+}
+
+export type LogInkThemeConfig = {
+  ascii?: boolean
+  borderStyle?: LogInkBorderStyle
+  colors?: LogInkThemeColors
+  preset?: LogInkThemePreset
+}
 
 export type LogInkTheme = {
   noColor: boolean
   ascii: boolean
   borderStyle: LogInkBorderStyle
-  colors: {
-    accent?: string
-    border?: string
-    danger?: string
-    focusBorder?: string
-    gitAdded?: string
-    gitDeleted?: string
-    gitModified?: string
-    info?: string
-    muted?: string
-    selection?: string
-    success?: string
-    warning?: string
-  }
+  colors: LogInkThemeColors
 }
 
-export type CreateLogInkThemeOptions = {
+export type CreateLogInkThemeOptions = LogInkThemeConfig & {
   noColor?: boolean
-  ascii?: boolean
   term?: string
+}
+
+const THEME_PRESET_COLORS: Record<Exclude<LogInkThemePreset, 'monochrome'>, LogInkThemeColors> = {
+  default: {
+    accent: 'cyan',
+    border: 'gray',
+    danger: 'red',
+    focusBorder: 'cyan',
+    gitAdded: 'green',
+    gitDeleted: 'red',
+    gitModified: 'yellow',
+    info: 'blue',
+    muted: 'gray',
+    selection: 'cyan',
+    success: 'green',
+    warning: 'yellow',
+  },
+  catppuccin: {
+    accent: '#89b4fa',
+    border: '#585b70',
+    danger: '#f38ba8',
+    focusBorder: '#89dceb',
+    gitAdded: '#a6e3a1',
+    gitDeleted: '#f38ba8',
+    gitModified: '#f9e2af',
+    info: '#89b4fa',
+    muted: '#6c7086',
+    selection: '#45475a',
+    success: '#a6e3a1',
+    warning: '#f9e2af',
+  },
+  gruvbox: {
+    accent: '#83a598',
+    border: '#665c54',
+    danger: '#fb4934',
+    focusBorder: '#8ec07c',
+    gitAdded: '#b8bb26',
+    gitDeleted: '#fb4934',
+    gitModified: '#fabd2f',
+    info: '#83a598',
+    muted: '#928374',
+    selection: '#504945',
+    success: '#b8bb26',
+    warning: '#fabd2f',
+  },
 }
 
 function shouldUseAscii(term: string | undefined): boolean {
@@ -35,28 +89,21 @@ function shouldUseAscii(term: string | undefined): boolean {
 }
 
 export function createLogInkTheme(options: CreateLogInkThemeOptions = {}): LogInkTheme {
-  const noColor = options.noColor ?? Boolean(process.env.NO_COLOR)
+  const noColor = (options.noColor ?? Boolean(process.env.NO_COLOR)) ||
+    options.preset === 'monochrome'
   const ascii = options.ascii ?? shouldUseAscii(options.term ?? process.env.TERM)
+  const preset = options.preset && options.preset !== 'monochrome' ? options.preset : 'default'
+  const colors = noColor
+    ? {}
+    : {
+      ...THEME_PRESET_COLORS[preset],
+      ...options.colors,
+    }
 
   return {
     noColor,
     ascii,
-    borderStyle: ascii ? 'classic' : 'round',
-    colors: noColor
-      ? {}
-      : {
-        accent: 'cyan',
-        border: 'gray',
-        danger: 'red',
-        focusBorder: 'cyan',
-        gitAdded: 'green',
-        gitDeleted: 'red',
-        gitModified: 'yellow',
-        info: 'blue',
-        muted: 'gray',
-        selection: 'cyan',
-        success: 'green',
-        warning: 'yellow',
-      },
+    borderStyle: options.borderStyle || (ascii ? 'classic' : 'round'),
+    colors,
   }
 }

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -46,6 +46,8 @@ describe('log Ink view model', () => {
 
     expect(state.commits).toHaveLength(3)
     expect(state.filteredCommits).toHaveLength(3)
+    expect(state.selectedFileIndex).toBe(0)
+    expect(state.diffPreviewOffset).toBe(0)
     expect(state.focus).toBe('commits')
     expect(state.sidebarTab).toBe('status')
     expect(state.showHelp).toBe(false)
@@ -139,6 +141,23 @@ describe('log Ink view model', () => {
 
     state = applyLogInkAction(state, { type: 'moveToTop' })
     expect(getSelectedInkCommit(state)?.shortHash).toBe('abc1234')
+  })
+
+  it('tracks selected changed files and diff preview paging', () => {
+    let state = createLogInkState(rows)
+
+    state = applyLogInkAction(state, { type: 'moveDetailFile', delta: 2, fileCount: 3 })
+    expect(state.selectedFileIndex).toBe(2)
+
+    state = applyLogInkAction(state, { type: 'moveDetailFile', delta: 1, fileCount: 3 })
+    expect(state.selectedFileIndex).toBe(2)
+
+    state = applyLogInkAction(state, { type: 'pageDetailPreview', delta: 10, previewLineCount: 20 })
+    expect(state.diffPreviewOffset).toBe(10)
+
+    state = applyLogInkAction(state, { type: 'move', delta: 1 })
+    expect(state.selectedFileIndex).toBe(0)
+    expect(state.diffPreviewOffset).toBe(0)
   })
 
   it('toggles graph, help, and command palette overlays', () => {

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -9,6 +9,8 @@ export type LogInkState = {
   commits: GitLogCommitRow[]
   filteredCommits: GitLogCommitRow[]
   selectedIndex: number
+  selectedFileIndex: number
+  diffPreviewOffset: number
   filter: string
   filterMode: boolean
   fullGraph: boolean
@@ -29,10 +31,12 @@ export type LogInkAction =
   | { type: 'focusNext' }
   | { type: 'focusPrevious' }
   | { type: 'move'; delta: number }
+  | { type: 'moveDetailFile'; delta: number; fileCount: number }
   | { type: 'moveToBottom' }
   | { type: 'moveToTop' }
   | { type: 'nextSidebarTab' }
   | { type: 'page'; delta: number }
+  | { type: 'pageDetailPreview'; delta: number; previewLineCount: number }
   | { type: 'previousSidebarTab' }
   | { type: 'setFilter'; value: string }
   | { type: 'setFocus'; value: LogInkFocus }
@@ -167,6 +171,8 @@ function withFilter(state: LogInkState, filter: string): LogInkState {
     filter,
     filteredCommits,
     selectedIndex: clampIndex(state.selectedIndex, filteredCommits.length),
+    selectedFileIndex: 0,
+    diffPreviewOffset: 0,
     pendingKey: undefined,
   }
 }
@@ -183,6 +189,8 @@ export function createLogInkState(rows: GitLogRow[]): LogInkState {
     commits,
     filteredCommits: commits,
     selectedIndex: 0,
+    selectedFileIndex: 0,
+    diffPreviewOffset: 0,
     filter: '',
     filterMode: false,
     fullGraph: false,
@@ -227,18 +235,31 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         selectedIndex: clampIndex(state.selectedIndex + action.delta, state.filteredCommits.length),
+        selectedFileIndex: 0,
+        diffPreviewOffset: 0,
+        pendingKey: undefined,
+      }
+    case 'moveDetailFile':
+      return {
+        ...state,
+        selectedFileIndex: clampIndex(state.selectedFileIndex + action.delta, action.fileCount),
+        diffPreviewOffset: 0,
         pendingKey: undefined,
       }
     case 'moveToBottom':
       return {
         ...state,
         selectedIndex: clampIndex(state.filteredCommits.length - 1, state.filteredCommits.length),
+        selectedFileIndex: 0,
+        diffPreviewOffset: 0,
         pendingKey: undefined,
       }
     case 'moveToTop':
       return {
         ...state,
         selectedIndex: 0,
+        selectedFileIndex: 0,
+        diffPreviewOffset: 0,
         pendingKey: undefined,
       }
     case 'nextSidebarTab':
@@ -251,6 +272,17 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         selectedIndex: clampIndex(state.selectedIndex + action.delta, state.filteredCommits.length),
+        selectedFileIndex: 0,
+        diffPreviewOffset: 0,
+        pendingKey: undefined,
+      }
+    case 'pageDetailPreview':
+      return {
+        ...state,
+        diffPreviewOffset: clampIndex(
+          state.diffPreviewOffset + action.delta,
+          action.previewLineCount
+        ),
         pendingKey: undefined,
       }
     case 'previousSidebarTab':

--- a/src/commands/log/interactive.test.ts
+++ b/src/commands/log/interactive.test.ts
@@ -34,10 +34,18 @@ const detail: GitCommitDetail = {
   body: 'Adds the first terminal UI.',
   files: [
     {
+      additions: 12,
+      binary: false,
+      deletions: 1,
       status: 'A',
       path: 'src/commands/log/interactive.ts',
     },
   ],
+  stats: {
+    deletions: 1,
+    filesChanged: 1,
+    insertions: 12,
+  },
 }
 
 const branches: BranchOverview = {

--- a/src/lib/config/README.md
+++ b/src/lib/config/README.md
@@ -83,6 +83,12 @@ This directory contains configuration files and services for the application. Th
   "ignoredFiles": ["node_modules", ".git"],
   "ignoredExtensions": [".log", ".tmp"],
   "defaultBranch": "main",
+  "logTui": {
+    "theme": {
+      "preset": "catppuccin",
+      "borderStyle": "round"
+    }
+  },
   "service": {
     "provider": "openai",
     "model": "gpt-3.5-turbo",

--- a/src/lib/config/constants.ts
+++ b/src/lib/config/constants.ts
@@ -24,6 +24,11 @@ export const DEFAULT_CONFIG: Config = {
   mode: 'stdout',
   verbose: false,
   defaultBranch: 'main',
+  logTui: {
+    theme: {
+      preset: 'default',
+    },
+  },
   service: getDefaultServiceConfigFromAlias('openai'),
   summarizePrompt: SUMMARIZE_PROMPT.template as string,
   ignoredFiles: DEFAULT_IGNORED_FILES,

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -1,4 +1,5 @@
 import { BaseCommandOptions } from '../../commands/types'
+import { LogInkThemeConfig } from '../../commands/log/inkTheme'
 import { LLMService } from '../langchain/types'
 
 type BaseConfig = {
@@ -90,6 +91,16 @@ type BaseConfig = {
    * @example { "model": "o4-mini", "approval-mode": "auto-edit" }
    */
   autoFixToolOptions?: Record<string, string>
+
+  /**
+   * Interactive log TUI settings.
+   */
+  logTui?: {
+    /**
+     * Theme settings for `coco log -i`.
+     */
+    theme?: LogInkThemeConfig
+  }
 }
 
 export type ConfigWithServiceObject = BaseConfig &

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -113,6 +113,17 @@ export const schema = {
               "approval-mode": "auto-edit"
             }
           ]
+        },
+        "logTui": {
+          "type": "object",
+          "properties": {
+            "theme": {
+              "$ref": "#/definitions/LogInkThemeConfig",
+              "description": "Theme settings for `coco log -i`."
+            }
+          },
+          "additionalProperties": false,
+          "description": "Interactive log TUI settings."
         }
       },
       "required": [
@@ -2106,6 +2117,83 @@ export const schema = {
         "authentication",
         "model",
         "provider"
+      ]
+    },
+    "LogInkThemeConfig": {
+      "type": "object",
+      "properties": {
+        "ascii": {
+          "type": "boolean"
+        },
+        "borderStyle": {
+          "$ref": "#/definitions/LogInkBorderStyle"
+        },
+        "colors": {
+          "$ref": "#/definitions/LogInkThemeColors"
+        },
+        "preset": {
+          "$ref": "#/definitions/LogInkThemePreset"
+        }
+      },
+      "additionalProperties": false
+    },
+    "LogInkBorderStyle": {
+      "type": "string",
+      "enum": [
+        "round",
+        "single",
+        "classic"
+      ]
+    },
+    "LogInkThemeColors": {
+      "type": "object",
+      "properties": {
+        "accent": {
+          "type": "string"
+        },
+        "border": {
+          "type": "string"
+        },
+        "danger": {
+          "type": "string"
+        },
+        "focusBorder": {
+          "type": "string"
+        },
+        "gitAdded": {
+          "type": "string"
+        },
+        "gitDeleted": {
+          "type": "string"
+        },
+        "gitModified": {
+          "type": "string"
+        },
+        "info": {
+          "type": "string"
+        },
+        "muted": {
+          "type": "string"
+        },
+        "selection": {
+          "type": "string"
+        },
+        "success": {
+          "type": "string"
+        },
+        "warning": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "LogInkThemePreset": {
+      "type": "string",
+      "enum": [
+        "default",
+        "monochrome",
+        "catppuccin",
+        "gruvbox"
       ]
     }
   }


### PR DESCRIPTION
## Summary

- Add configurable `logTui.theme` settings with default, monochrome, Catppuccin, and Gruvbox presets plus token overrides.
- Add terminal cell-width-aware truncation for CJK/emoji-safe TUI alignment.
- Enrich selected commit detail data with numstat totals, changed-file stats, selected-file navigation, and lazy hunk previews.
- Update contextual detail footer hints and config schema/docs.

## Validation

- `npm run test:jest -- src/commands/log/data.test.ts src/commands/log/inkTheme.test.ts src/commands/log/inkText.test.ts src/commands/log/inkViewModel.test.ts src/commands/log/inkInput.test.ts src/commands/log/inkKeymap.test.ts src/commands/log/interactive.test.ts src/commands/log/render.test.ts`
- `npm run lint`
- `npm run build`
- `git diff --check`
- `npm test`

Closes #716
