### PR TITLE
Update log TUI docs and guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,21 @@ To set up a development environment for Commit Copilot, follow these steps:
 
 1. Fork the Commit Copilot repository on GitHub.
 2. Clone your forked repository to your local machine.
-3. Install the required dependencies using [dependency manager/tool].
-4. Build the project locally and ensure that all tests pass successfully.
+3. Install the required dependencies with `npm install`.
+4. Build the project locally with `npm run build` and ensure that tests pass with `npm test`.
 5. You are now ready to start making changes!
+
+## Documentation
+
+The GitHub wiki is the canonical source for user-facing documentation. The local wiki checkout lives at `.wiki/` and can be managed with:
+
+```bash
+npm run wiki:pull
+npm run wiki:status
+npm run wiki:push
+```
+
+Keep repository docs concise and link to the wiki for detailed guides. Update `README.md` for high-level feature visibility, update the wiki for full user documentation, and regenerate `schema.json` with `npm run build:schema` when configuration types change.
 
 ## Submitting Pull Requests
 
@@ -59,18 +71,6 @@ We welcome and encourage pull requests from the community. To submit a pull requ
 7. Submit a pull request to the `main` branch of the Commit Copilot repository.
 
 Please provide a clear and detailed description of the changes you have made in your pull request. We will review your contribution as soon as possible.
-
-<!-- ## Coding Guidelines
-
-To maintain a consistent codebase, we follow a set of coding guidelines. Please ensure that your code adheres to these guidelines before submitting a pull request. These guidelines include:
-
-- [Style guidelines]
-- [Naming conventions]
-- [Best practices] -->
-
-<!-- ## Documentation
-
-Clear and comprehensive documentation is crucial for any successful project. We appreciate contributions that improve the existing documentation or add new examples, tutorials, or explanations. You can find the project documentation in the [docs](docs/) directory. Please ensure that any changes or additions are well-documented and follow the existing style. -->
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Last Commit](https://img.shields.io/github/last-commit/gfargo/coco)](https://github.com/gfargo/coco/tree/main)
 [![Discord](https://img.shields.io/discord/1176716060825767948)](https://discord.gg/KGu9nE9Ejx)
 
-An AI-powered git assistant that generates meaningful commit messages, creates changelogs, and streamlines your development workflow.
+An AI-powered git assistant that generates meaningful commit messages, creates changelogs, explores repository history, and streamlines your development workflow.
 
 **✨ Key Features:**
 
@@ -18,6 +18,7 @@ An AI-powered git assistant that generates meaningful commit messages, creates c
 - 📋 **Conventional Commits** - Full support with automatic validation and formatting  
 - 🔧 **Commitlint Integration** - Seamless integration with your existing commitlint configuration
 - 🏠 **Local AI Support** - Run completely offline with Ollama (no API costs, full privacy)
+- 🖥️ **Interactive Git Log TUI** - Browse commits, refs, changed files, and hunk previews from `coco log -i`
 - 📦 **Package Manager Friendly** - Works with npm, yarn, and pnpm
 - 👥 **Team Ready** - Shared configurations and enterprise deployment
 
@@ -89,6 +90,7 @@ coco review
 
 # Explore commit history
 coco log --limit 20
+coco log -i
 coco log --view full --limit 20
 coco log --all --limit 20
 coco log --author "Grace Hopper" --path src
@@ -118,6 +120,11 @@ coco init --scope project
 {
   "mode": "interactive",
   "conventionalCommits": true,
+  "logTui": {
+    "theme": {
+      "preset": "catppuccin"
+    }
+  },
   "service": {
     "provider": "openai",
     "model": "gpt-4o"
@@ -135,6 +142,7 @@ For comprehensive guides, advanced usage, and detailed configuration options, vi
 - **[Getting Started](https://github.com/gfargo/coco/wiki/Getting-Started)** - Complete beginner's guide from installation to first commit
 - **[Command Reference](https://github.com/gfargo/coco/wiki/Command-Reference)** - Detailed command options and examples
 - **[Configuration Overview](https://github.com/gfargo/coco/wiki/Config-Overview)** - All configuration options and setup methods
+- **[Interactive Log TUI](https://github.com/gfargo/coco/wiki/Interactive-Log-TUI)** - Full-screen `coco log -i` guide, keybindings, themes, and detail previews
 - **[Team Collaboration](https://github.com/gfargo/coco/wiki/Team-Collaboration)** - Enterprise deployment and team adoption strategies
 
 **Advanced Resources:**

--- a/src/lib/config/README.md
+++ b/src/lib/config/README.md
@@ -3,6 +3,11 @@
 
 This directory contains configuration files and services for the application. The configurations are used to manage various settings and behaviors of the application.
 
+For user-facing configuration documentation, use the GitHub wiki as the source of truth:
+
+- [Configuration Overview](https://github.com/gfargo/coco/wiki/Config-Overview)
+- [Interactive Log TUI](https://github.com/gfargo/coco/wiki/Interactive-Log-TUI)
+
 ## Files and Directories
 
 - `constants.ts`: Defines constants and default configuration settings.


### PR DESCRIPTION
## Summary

- Surface `coco log -i` in the README feature list, examples, and wiki links.
- Document the wiki as the canonical user-facing docs source in `CONTRIBUTING.md`.
- Point config maintainers from `src/lib/config/README.md` to the wiki configuration and interactive log TUI docs.

## Wiki

Pushed the GitHub wiki updates directly to the wiki repository default branch:

- Added `Interactive-Log-TUI.md`.
- Updated Home, Command Reference, Config Overview, and Getting Started.
- Commit: `b055c4b docs: document interactive log TUI`.

## Validation

- `git diff --check`
- `npm run lint`
