### PR TITLE
Raise interactive log default limit

### DIFF
--- a/src/commands/log/config.ts
+++ b/src/commands/log/config.ts
@@ -55,9 +55,8 @@ export const options = {
     default: 'table',
   },
   limit: {
-    description: 'Maximum number of commits to show',
+    description: 'Maximum number of commits to show (defaults to 30, or 300 in interactive mode)',
     type: 'number',
-    default: 30,
     alias: 'n',
   },
   merges: {

--- a/src/commands/log/data.test.ts
+++ b/src/commands/log/data.test.ts
@@ -1,6 +1,8 @@
 import { Arguments } from 'yargs'
 import {
   FIELD_SEPARATOR,
+  LOG_DEFAULT_LIMIT,
+  LOG_INTERACTIVE_DEFAULT_LIMIT,
   buildLogArgs,
   getCommitFilePreview,
   getCommitRows,
@@ -29,6 +31,19 @@ describe('log data layer', () => {
     expect(getLogView(argv())).toBe('compact')
     expect(args).toEqual(expect.arrayContaining(['--first-parent', '--no-merges']))
     expect(args).not.toContain('--all')
+    expect(args).toContain(`--max-count=${LOG_DEFAULT_LIMIT}`)
+  })
+
+  it('uses a larger default history window for interactive mode', () => {
+    const args = buildLogArgs(argv({ interactive: true }))
+
+    expect(args).toContain(`--max-count=${LOG_INTERACTIVE_DEFAULT_LIMIT}`)
+  })
+
+  it('preserves an explicit limit in interactive mode', () => {
+    const args = buildLogArgs(argv({ interactive: true, limit: 42 }))
+
+    expect(args).toContain('--max-count=42')
   })
 
   it('uses full topology when all refs are requested', () => {

--- a/src/commands/log/data.ts
+++ b/src/commands/log/data.ts
@@ -4,6 +4,8 @@ import { LogArgv, LogView } from './config'
 export const FIELD_SEPARATOR = '\x1f'
 const LOG_FORMAT = `%x1f%h%x1f%H%x1f%ad%x1f%an%x1f%d%x1f%s`
 const DETAIL_FORMAT = `%H%x1f%h%x1f%ad%x1f%an%x1f%d%x1f%s%x1f%b`
+export const LOG_DEFAULT_LIMIT = 30
+export const LOG_INTERACTIVE_DEFAULT_LIMIT = 300
 
 export type GitLogCommitRow = {
   type: 'commit'
@@ -59,9 +61,9 @@ export function toArray(value: string | string[] | undefined): string[] {
   return Array.isArray(value) ? value : [value]
 }
 
-function normalizeLimit(limit: number | undefined): number {
+function normalizeLimit(limit: number | undefined, interactive: boolean | undefined): number {
   if (!limit || Number.isNaN(limit) || limit < 1) {
-    return 30
+    return interactive ? LOG_INTERACTIVE_DEFAULT_LIMIT : LOG_DEFAULT_LIMIT
   }
 
   return Math.floor(limit)
@@ -227,7 +229,7 @@ export function buildLogArgs(argv: LogArgv): string[] {
     '--decorate=short',
     '--date=short',
     '--color=never',
-    `--max-count=${normalizeLimit(argv.limit)}`,
+    `--max-count=${normalizeLimit(argv.limit, argv.interactive)}`,
     `--pretty=format:${LOG_FORMAT}`,
   ]
 


### PR DESCRIPTION
## Summary

- Keep non-interactive `coco log` default history at 30 commits.
- Raise the implicit `coco log -i` history window to 300 commits.
- Preserve explicit `--limit` values in interactive mode.
- Update the `--limit` help text and cover mode-specific defaults with tests.

## Why

The TUI was only loading 30 commits because yargs applied the same `limit` default before the handler called the shared log data layer. Removing the yargs default lets `buildLogArgs` pick a context-aware default based on `argv.interactive`.

## Wiki

Updated the wiki directly with the new behavior:

- Commit: `7043ea9 docs: clarify log TUI history limit`

## Validation

- `npm run test:jest -- src/commands/log/data.test.ts`
- `git diff --check`
- `npm run lint`
- `npm test`
