### PR TITLE
Load older commits in log TUI

### DIFF
--- a/src/commands/log/data.test.ts
+++ b/src/commands/log/data.test.ts
@@ -46,6 +46,13 @@ describe('log data layer', () => {
     expect(args).toContain('--max-count=42')
   })
 
+  it('supports incremental interactive history loading with skip and batch limit', () => {
+    const args = buildLogArgs(argv({ interactive: true }), { limit: 50, skip: 300 })
+
+    expect(args).toContain('--max-count=50')
+    expect(args).toContain('--skip=300')
+  })
+
   it('uses full topology when all refs are requested', () => {
     const args = buildLogArgs(argv({ all: true, view: 'compact' }))
 

--- a/src/commands/log/data.ts
+++ b/src/commands/log/data.ts
@@ -7,6 +7,11 @@ const DETAIL_FORMAT = `%H%x1f%h%x1f%ad%x1f%an%x1f%d%x1f%s%x1f%b`
 export const LOG_DEFAULT_LIMIT = 30
 export const LOG_INTERACTIVE_DEFAULT_LIMIT = 300
 
+export type LogRowLoadOptions = {
+  limit?: number
+  skip?: number
+}
+
 export type GitLogCommitRow = {
   type: 'commit'
   graph: string
@@ -61,7 +66,15 @@ export function toArray(value: string | string[] | undefined): string[] {
   return Array.isArray(value) ? value : [value]
 }
 
-function normalizeLimit(limit: number | undefined, interactive: boolean | undefined): number {
+function normalizeLimit(
+  limit: number | undefined,
+  interactive: boolean | undefined,
+  options: LogRowLoadOptions = {}
+): number {
+  if (options.limit !== undefined) {
+    return Math.max(1, Math.floor(options.limit))
+  }
+
   if (!limit || Number.isNaN(limit) || limit < 1) {
     return interactive ? LOG_INTERACTIVE_DEFAULT_LIMIT : LOG_DEFAULT_LIMIT
   }
@@ -221,7 +234,7 @@ export function parseCommitDetail(metadata: string, files: string, numstatOutput
   }
 }
 
-export function buildLogArgs(argv: LogArgv): string[] {
+export function buildLogArgs(argv: LogArgv, options: LogRowLoadOptions = {}): string[] {
   const view = getLogView(argv)
   const args = [
     'log',
@@ -229,9 +242,13 @@ export function buildLogArgs(argv: LogArgv): string[] {
     '--decorate=short',
     '--date=short',
     '--color=never',
-    `--max-count=${normalizeLimit(argv.limit, argv.interactive)}`,
+    `--max-count=${normalizeLimit(argv.limit, argv.interactive, options)}`,
     `--pretty=format:${LOG_FORMAT}`,
   ]
+
+  if (options.skip && options.skip > 0) {
+    args.push(`--skip=${Math.floor(options.skip)}`)
+  }
 
   if (view === 'compact') {
     args.push('--first-parent')
@@ -269,8 +286,12 @@ export function buildLogArgs(argv: LogArgv): string[] {
   return args
 }
 
-export async function getLogRows(git: SimpleGit, argv: LogArgv): Promise<GitLogRow[]> {
-  return parseLogOutput(await git.raw(buildLogArgs(argv)))
+export async function getLogRows(
+  git: SimpleGit,
+  argv: LogArgv,
+  options: LogRowLoadOptions = {}
+): Promise<GitLogRow[]> {
+  return parseLogOutput(await git.raw(buildLogArgs(argv, options)))
 }
 
 export async function getCommitDetail(git: SimpleGit, commit: string): Promise<GitCommitDetail> {

--- a/src/commands/log/handler.ts
+++ b/src/commands/log/handler.ts
@@ -26,6 +26,7 @@ export const handler: CommandHandler<LogArgv> = async (argv) => {
 
   if (argv.interactive && format === 'table') {
     await startInkInteractiveLog(git, rows, {}, {
+      logArgv: argv,
       theme: config.logTui?.theme,
     })
     return

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -6,8 +6,11 @@ import {
   GitCommitFilePreview,
   GitLogCommitRow,
   GitLogRow,
+  LOG_INTERACTIVE_DEFAULT_LIMIT,
   getCommitDetail,
   getCommitFilePreview,
+  getCommitRows,
+  getLogRows,
 } from './data'
 import {
   LogInkContextKey,
@@ -55,6 +58,7 @@ import {
 } from './inkWorkflows'
 import { WorktreeOverview as WorktreeListOverview, getWorktreeListOverview } from './worktreeData'
 import { canStartLogInkTui, getLogInkRenderOptions } from './inkTerminal'
+import { LogArgv } from './config'
 
 type DynamicImport = <T>(specifier: string) => Promise<T>
 const dynamicImport = new Function('specifier', 'return import(specifier)') as DynamicImport
@@ -66,6 +70,7 @@ type LogInkStreams = {
 }
 
 type LogInkOptions = {
+  logArgv?: LogArgv
   theme?: LogInkThemeConfig
 }
 
@@ -113,6 +118,7 @@ type LogInkComponents = Pick<LogInkRuntime['ink'], 'Box' | 'Text'>
 
 type LogInkComponentDeps = LogInkRuntime & {
   git: SimpleGit
+  logArgv?: LogArgv
   rows: GitLogRow[]
   theme: LogInkTheme
 }
@@ -393,6 +399,7 @@ export async function startInkInteractiveLog(
   const app = React.createElement(LogInkApp, {
     git,
     ink,
+    logArgv: options.logArgv,
     React,
     rows,
     theme: createLogInkTheme(options.theme),
@@ -403,7 +410,7 @@ export async function startInkInteractiveLog(
 }
 
 function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
-  const { git, ink, React, rows, theme } = deps
+  const { git, ink, logArgv, React, rows, theme } = deps
   const { Box, Text, useApp, useInput, useWindowSize } = ink
   const h = React.createElement
   const { exit } = useApp()
@@ -421,6 +428,14 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   const [detailLoading, setDetailLoading] = React.useState(false)
   const [filePreview, setFilePreview] = React.useState<GitCommitFilePreview | undefined>(undefined)
   const [filePreviewLoading, setFilePreviewLoading] = React.useState(false)
+  const [hasMoreCommits, setHasMoreCommits] = React.useState(() => (
+    Boolean(logArgv?.interactive && !logArgv.limit) &&
+    getCommitRows(rows).length >= LOG_INTERACTIVE_DEFAULT_LIMIT
+  ))
+  const [loadingMoreCommits, setLoadingMoreCommits] = React.useState(false)
+  const loadingMoreCommitsRef = React.useRef(false)
+  const loadMoreRequestRef = React.useRef(0)
+  const mountedRef = React.useRef(true)
   const selected = getSelectedInkCommit(state)
   const selectedDetailFile = detail?.files[state.selectedFileIndex]
 
@@ -508,6 +523,79 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
   }, [git, selected?.hash, selectedDetailFile?.path, selectedDetailFile?.oldPath])
 
+  React.useEffect(() => {
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  React.useEffect(() => {
+    loadingMoreCommitsRef.current = loadingMoreCommits
+  }, [loadingMoreCommits])
+
+  React.useEffect(() => {
+    const remaining = state.filteredCommits.length - state.selectedIndex - 1
+
+    async function loadMoreCommits(): Promise<void> {
+      if (!logArgv || logArgv.limit || loadingMoreCommitsRef.current || !hasMoreCommits) {
+        return
+      }
+
+      if (state.filteredCommits.length === 0 || remaining > 20) {
+        return
+      }
+
+      loadingMoreCommitsRef.current = true
+      const requestId = loadMoreRequestRef.current + 1
+      loadMoreRequestRef.current = requestId
+      setLoadingMoreCommits(true)
+      dispatch({ type: 'setStatus', value: 'loading older commits' })
+      const nextRows = await safe(
+        getLogRows(git, logArgv, {
+          limit: LOG_INTERACTIVE_DEFAULT_LIMIT,
+          skip: state.commits.length,
+        })
+      )
+
+      if (!mountedRef.current || loadMoreRequestRef.current !== requestId) {
+        return
+      }
+
+      loadingMoreCommitsRef.current = false
+      setLoadingMoreCommits(false)
+
+      const nextCommitCount = nextRows ? getCommitRows(nextRows).length : 0
+
+      if (!nextRows) {
+        dispatch({ type: 'setStatus', value: 'failed to load older commits' })
+        return
+      }
+
+      if (nextRows?.length) {
+        dispatch({ type: 'appendRows', rows: nextRows })
+      }
+
+      setHasMoreCommits(nextCommitCount >= LOG_INTERACTIVE_DEFAULT_LIMIT)
+      dispatch({
+        type: 'setStatus',
+        value: nextCommitCount
+          ? `loaded ${nextCommitCount} older commits`
+          : 'end of history',
+      })
+    }
+
+    void loadMoreCommits()
+  }, [
+    dispatch,
+    git,
+    hasMoreCommits,
+    loadingMoreCommits,
+    logArgv,
+    state.commits.length,
+    state.filteredCommits.length,
+    state.selectedIndex,
+  ])
+
   useInput((inputValue: string, key: LogInkInputKey) => {
     getLogInkInputEvents(state, inputValue, key, {
       detailFileCount: detail?.files.length,
@@ -540,7 +628,15 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     renderHeader(h, { Box, Text }, state, context, contextStatus, layout.columns, theme),
     h(Box, { flexDirection: 'row', height: layout.bodyRows },
       renderSidebar(h, { Box, Text }, state, context, contextStatus, layout.sidebarWidth, theme),
-      renderCommitPanel(h, { Box, Text }, state, layout.bodyRows, theme),
+      renderCommitPanel(
+        h,
+        { Box, Text },
+        state,
+        layout.bodyRows,
+        theme,
+        hasMoreCommits,
+        loadingMoreCommits
+      ),
       renderDetailPanel(
         h,
         { Box, Text },
@@ -625,12 +721,19 @@ function renderCommitPanel(
   components: LogInkComponents,
   state: LogInkState,
   bodyRows: number,
-  theme: LogInkTheme
+  theme: LogInkTheme,
+  hasMoreCommits: boolean,
+  loadingMoreCommits: boolean
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const focused = state.focus === 'commits'
   const listRows = Math.max(3, bodyRows - 4)
   const visible = getVisibleCommits(state, listRows)
+  const loadState = loadingMoreCommits
+    ? 'loading older commits'
+    : hasMoreCommits
+      ? 'more below'
+      : 'loaded'
   const title = `${state.filteredCommits.length}/${state.commits.length} commits`
   const graphMode = state.fullGraph ? 'full graph' : 'compact graph'
 
@@ -643,7 +746,7 @@ function renderCommitPanel(
   },
   h(Box, { justifyContent: 'space-between' },
     h(Text, { bold: true }, panelTitle('Commits', focused)),
-    h(Text, { dimColor: true }, `${title} | ${graphMode}`)
+    h(Text, { dimColor: true }, `${title} | ${graphMode} | ${loadState}`)
   ),
   visible.commits.length === 0
     ? h(Text, { dimColor: true }, 'No commits match the current filter.')

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -143,6 +143,30 @@ describe('log Ink view model', () => {
     expect(getSelectedInkCommit(state)?.shortHash).toBe('abc1234')
   })
 
+  it('appends older rows while preserving the selected commit', () => {
+    let state = createLogInkState(rows)
+
+    state = applyLogInkAction(state, { type: 'move', delta: 1 })
+    state = applyLogInkAction(state, {
+      type: 'appendRows',
+      rows: [
+        {
+          type: 'commit',
+          graph: '*',
+          shortHash: '9999999',
+          hash: '999999900000',
+          date: '2026-04-25',
+          author: 'Coco Test',
+          refs: [],
+          message: 'chore: older commit',
+        },
+      ],
+    })
+
+    expect(state.commits).toHaveLength(4)
+    expect(getSelectedInkCommit(state)?.shortHash).toBe('def5678')
+  })
+
   it('tracks selected changed files and diff preview paging', () => {
     let state = createLogInkState(rows)
 

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -25,6 +25,7 @@ export type LogInkState = {
 }
 
 export type LogInkAction =
+  | { type: 'appendRows'; rows: GitLogRow[] }
   | { type: 'appendFilter'; value: string }
   | { type: 'backspaceFilter' }
   | { type: 'clearFilter' }
@@ -177,6 +178,35 @@ function withFilter(state: LogInkState, filter: string): LogInkState {
   }
 }
 
+function appendRows(state: LogInkState, rows: GitLogRow[]): LogInkState {
+  const selected = getSelectedInkCommit(state)
+  const nextRows = [...state.rows, ...rows]
+  const seen = new Set<string>()
+  const commits = getCommitRows(nextRows).filter((commit) => {
+    if (seen.has(commit.hash)) {
+      return false
+    }
+
+    seen.add(commit.hash)
+    return true
+  })
+  const filteredCommits = filterCommits(commits, state.filter)
+  const selectedIndex = selected
+    ? filteredCommits.findIndex((commit) => commit.hash === selected.hash)
+    : state.selectedIndex
+
+  return {
+    ...state,
+    rows: nextRows,
+    commits,
+    filteredCommits,
+    selectedIndex: selectedIndex >= 0
+      ? selectedIndex
+      : clampIndex(state.selectedIndex, filteredCommits.length),
+    pendingKey: undefined,
+  }
+}
+
 export function getLogInkSidebarTabs(): LogInkSidebarTab[] {
   return [...SIDEBAR_TABS]
 }
@@ -210,6 +240,8 @@ export function getSelectedInkCommit(state: LogInkState): GitLogCommitRow | unde
 
 export function applyLogInkAction(state: LogInkState, action: LogInkAction): LogInkState {
   switch (action.type) {
+    case 'appendRows':
+      return appendRows(state, action.rows)
     case 'appendFilter':
       return withFilter(state, `${state.filter}${action.value}`)
     case 'backspaceFilter':


### PR DESCRIPTION
## Summary
- add skip/limit load options for log rows
- append older commit rows while preserving the selected commit and active filter
- trigger incremental loading when interactive log navigation nears the end of the loaded buffer
- show commit-panel load state with `more below`, `loading older commits`, and `loaded`
- keep explicit `--limit` as a hard cap for interactive history
- update the wiki with incremental loading behavior in commit `0354859`

## Validation
- `npm run test:jest -- src/commands/log/data.test.ts src/commands/log/inkViewModel.test.ts src/commands/log/inkInput.test.ts src/commands/log/inkKeymap.test.ts`
- `npm run lint`
- `npm run build`
- `npm test`
- `git diff --check`