### PR TITLE
Add coco ui command foundation

### DIFF
--- a/bin/smokeCli.ts
+++ b/bin/smokeCli.ts
@@ -159,6 +159,11 @@ try {
     args: ['log', '--help'],
     label: 'packaged log command help',
   })
+  runHelpCheck({
+    command: packagedBinPath(prefix),
+    args: ['ui', '--help'],
+    label: 'packaged ui command help',
+  })
   runCheck({
     command: packagedBinPath(prefix),
     args: ['init', '--dry-run', '--scope', 'project'],
@@ -184,13 +189,24 @@ try {
     label: 'packaged non-TTY interactive log command',
     env: { NO_COLOR: '1' },
   })
-  assertOutputIncludes('packaged non-TTY interactive log command', interactiveLogOutput, 'coco log')
+  assertOutputIncludes('packaged non-TTY interactive log command', interactiveLogOutput, 'coco ui')
   assertOutputIncludes(
     'packaged non-TTY interactive log command',
     interactiveLogOutput,
     'feat: smoke log command'
   )
   console.log('✓ packaged non-TTY interactive log command')
+
+  const uiOutput = runCheck({
+    command: packagedBinPath(prefix),
+    args: ['ui', '--view', 'history', '--limit', '1'],
+    cwd: smokeRepo,
+    label: 'packaged non-TTY ui command',
+    env: { NO_COLOR: '1' },
+  })
+  assertOutputIncludes('packaged non-TTY ui command', uiOutput, 'coco ui')
+  assertOutputIncludes('packaged non-TTY ui command', uiOutput, 'feat: smoke log command')
+  console.log('✓ packaged non-TTY ui command')
 } finally {
   rmSync(tempRoot, { recursive: true, force: true })
 }

--- a/src/commands/commands.integration.test.ts
+++ b/src/commands/commands.integration.test.ts
@@ -8,6 +8,8 @@ import { handler as logHandler } from './log/handler'
 import { LogOptions } from './log/config'
 import { handler as reviewHandler } from './review/handler'
 import { ReviewOptions } from './review/config'
+import { handler as uiHandler } from './ui/handler'
+import { UiOptions } from './ui/config'
 import { loadConfig } from '../lib/config/utils/loadConfig'
 import { executeChain } from '../lib/langchain/utils/executeChain'
 import { executeChainWithSchema } from '../lib/langchain/utils/executeChainWithSchema'
@@ -662,10 +664,38 @@ describe('command integration with temp git repos', () => {
       help: false,
     } as Arguments<LogOptions>, createLogger())
 
-    expect(stdout).toContain('coco log')
+    expect(stdout).toContain('coco ui')
     expect(stdout).toContain('feat: add interactive log coverage')
     expect(stdout).toContain('Changed files:')
     expect(stdout).toContain('src/interactive.ts')
+  })
+
+  it('renders the ui command smoke view in a non-TTY environment', async () => {
+    mockLoadConfig.mockReturnValue(createConfig({
+      mode: 'stdout',
+    }))
+
+    await repo.writeFile('README.md', '# Temp repo\n')
+    await repo.commitAll('chore: initial commit')
+    await repo.writeFile('src/ui.ts', 'export const ui = true\n')
+    await repo.commitAll('feat: add ui workstation coverage')
+
+    await uiHandler({
+      $0: 'coco',
+      _: ['ui'],
+      all: false,
+      limit: 2,
+      interactive: false,
+      verbose: false,
+      version: false,
+      help: false,
+      view: 'history',
+    } as Arguments<UiOptions>, createLogger())
+
+    expect(stdout).toContain('coco ui')
+    expect(stdout).toContain('feat: add ui workstation coverage')
+    expect(stdout).toContain('Changed files:')
+    expect(stdout).toContain('src/ui.ts')
   })
 
   it('prints machine-readable git log output', async () => {

--- a/src/commands/log/handler.ts
+++ b/src/commands/log/handler.ts
@@ -4,7 +4,7 @@ import { loadConfig } from '../../lib/config/utils/loadConfig'
 import { getRepo } from '../../lib/simple-git/getRepo'
 import { handleResult } from '../../lib/ui/handleResult'
 import { getCommitDetail, getLogRows } from './data'
-import { startInkInteractiveLog } from './inkRuntime'
+import { startCocoUiFromLogArgv } from '../ui/handler'
 import { formatCommitDetail, formatLogJson, formatLogTable } from './render'
 import { LogArgv } from './config'
 
@@ -25,9 +25,10 @@ export const handler: CommandHandler<LogArgv> = async (argv) => {
   const rows = await getLogRows(git, argv)
 
   if (argv.interactive && format === 'table') {
-    await startInkInteractiveLog(git, rows, {}, {
-      logArgv: argv,
-      theme: config.logTui?.theme,
+    await startCocoUiFromLogArgv(argv, {
+      config,
+      git,
+      rows,
     })
     return
   }

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -70,6 +70,8 @@ type LogInkStreams = {
 }
 
 type LogInkOptions = {
+  appLabel?: string
+  initialView?: 'history' | 'status' | 'diff'
   logArgv?: LogArgv
   theme?: LogInkThemeConfig
 }
@@ -117,7 +119,9 @@ type LogInkRuntime = {
 type LogInkComponents = Pick<LogInkRuntime['ink'], 'Box' | 'Text'>
 
 type LogInkComponentDeps = LogInkRuntime & {
+  appLabel: string
   git: SimpleGit
+  initialView: 'history' | 'status' | 'diff'
   logArgv?: LogArgv
   rows: GitLogRow[]
   theme: LogInkTheme
@@ -390,15 +394,21 @@ export async function startInkInteractiveLog(
   const error = streams.error || process.stderr
 
   if (!canStartLogInkTui(input, output)) {
-    await startInteractiveLog(git, rows, { input, output })
+    await startInteractiveLog(git, rows, {
+      appLabel: options.appLabel,
+      input,
+      output,
+    })
     return
   }
 
   const runtime = await loadInkRuntime()
   const { ink, React } = runtime
   const app = React.createElement(LogInkApp, {
+    appLabel: options.appLabel || 'coco log',
     git,
     ink,
+    initialView: options.initialView || 'history',
     logArgv: options.logArgv,
     React,
     rows,
@@ -410,7 +420,7 @@ export async function startInkInteractiveLog(
 }
 
 function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
-  const { git, ink, logArgv, React, rows, theme } = deps
+  const { appLabel, git, ink, initialView, logArgv, React, rows, theme } = deps
   const { Box, Text, useApp, useInput, useWindowSize } = ink
   const h = React.createElement
   const { exit } = useApp()
@@ -618,14 +628,14 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       paddingX: 1,
       paddingY: 1,
     },
-    h(Text, { bold: true }, 'coco log -i'),
+    h(Text, { bold: true }, appLabel),
     h(Text, undefined, `Terminal too small: ${layout.columns}x${layout.rows}`),
     h(Text, { dimColor: true }, `Minimum size is ${LOG_INK_MIN_COLUMNS}x${LOG_INK_MIN_ROWS}.`),
     h(Text, { dimColor: true }, 'Resize the terminal or run plain coco log.'))
   }
 
   return h(Box, { flexDirection: 'column', height: layout.rows },
-    renderHeader(h, { Box, Text }, state, context, contextStatus, layout.columns, theme),
+    renderHeader(h, { Box, Text }, state, context, contextStatus, layout.columns, theme, appLabel, initialView),
     h(Box, { flexDirection: 'row', height: layout.bodyRows },
       renderSidebar(h, { Box, Text }, state, context, contextStatus, layout.sidebarWidth, theme),
       renderCommitPanel(
@@ -662,7 +672,9 @@ function renderHeader(
   context: LogInkContext,
   contextStatus: LogInkContextStatus,
   columns: number,
-  theme: LogInkTheme
+  theme: LogInkTheme,
+  appLabel: string,
+  initialView: 'history' | 'status' | 'diff'
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const branch = context.branches?.currentBranch || context.provider?.currentBranch || '<detached>'
@@ -677,7 +689,8 @@ function renderHeader(
       : 'no PR'
   const search = state.filterMode ? `search: ${state.filter}_` : state.filter ? `filter: ${state.filter}` : ''
   const loading = isLogInkContextLoading(contextStatus) ? '  loading context' : ''
-  const title = truncate(`coco log  ${repo}  ${branch}  ${dirty}  ${pr}${loading}`, columns - 2)
+  const view = initialView === 'history' ? '' : `  ${initialView}`
+  const title = truncate(`${appLabel}  ${repo}  ${branch}  ${dirty}  ${pr}${view}${loading}`, columns - 2)
 
   return h(Box, {
     borderColor: theme.colors.border,

--- a/src/commands/log/interactive.ts
+++ b/src/commands/log/interactive.ts
@@ -74,11 +74,13 @@ import { openProviderUrl } from './providerActions'
 import { ProviderOverview, getProviderOverview, providerBranchName } from './providerData'
 
 type LogTuiStreams = {
+  appLabel?: string
   input?: NodeJS.ReadStream
   output?: NodeJS.WriteStream
 }
 
 type RenderInteractiveLogOptions = {
+  appLabel?: string
   height?: number
   width?: number
 }
@@ -683,7 +685,7 @@ export function renderInteractiveLog(
   const filterPrompt = state.filterMode ? `Search: ${state.filter}_` : `Filter: ${filter}`
 
   return [
-    'coco log',
+    options.appLabel || 'coco log',
     `${state.filteredCommits.length}/${state.commits.length} commits | Focus: ${focus} | ${filterPrompt} | ${graphMode}`,
     help,
     commitActions,
@@ -716,6 +718,7 @@ export async function startInteractiveLog(
 ): Promise<void> {
   const input = streams.input || process.stdin
   const output = streams.output || process.stdout
+  const appLabel = streams.appLabel
   let state = createLogTuiState(rows)
   const details = new Map<string, GitCommitDetail>()
   let branches: BranchOverview | undefined
@@ -805,7 +808,7 @@ export async function startInteractiveLog(
         tagRangeSummary,
         worktree,
         {},
-        {},
+        { appLabel },
         { stashes, worktreeList },
         {},
         operationOverview,
@@ -875,7 +878,7 @@ export async function startInteractiveLog(
           tagRangeSummary,
           worktree,
           ui,
-          {},
+          { appLabel },
           { stashes, worktreeList, stashDiffSummary },
           { compareBase, reflog, providerCompareBase },
           operationOverview,
@@ -903,7 +906,7 @@ export async function startInteractiveLog(
               tagRangeSummary,
               worktree,
               ui,
-              {},
+              { appLabel },
               { stashes, worktreeList, stashDiffSummary },
               { compareBase, reflog, providerCompareBase },
               operationOverview,

--- a/src/commands/ui/config.ts
+++ b/src/commands/ui/config.ts
@@ -1,0 +1,54 @@
+import { Arguments, Argv, Options } from 'yargs'
+import { getCommandUsageHeader } from '../../lib/ui/helpers'
+import { LogInkThemePreset } from '../log/inkTheme'
+import { BaseCommandOptions } from '../types'
+
+export type UiView = 'history' | 'status' | 'diff'
+
+export interface UiOptions extends BaseCommandOptions {
+  all?: boolean
+  branch?: string
+  limit?: number
+  path?: string | string[]
+  theme?: LogInkThemePreset
+  view?: UiView
+}
+
+export type UiArgv = Arguments<UiOptions>
+
+export const command = 'ui'
+
+export const options = {
+  view: {
+    description: 'Initial TUI surface',
+    choices: ['history', 'status', 'diff'],
+    default: 'history',
+  },
+  all: {
+    description: 'Load commits from all local and remote refs in history mode',
+    type: 'boolean',
+    default: false,
+  },
+  branch: {
+    description: 'Load history reachable from a branch or ref',
+    type: 'string',
+    alias: 'b',
+  },
+  limit: {
+    description: 'Maximum number of history commits to load initially',
+    type: 'number',
+    alias: 'n',
+  },
+  path: {
+    description: 'Filter history by changed path',
+    type: 'array',
+  },
+  theme: {
+    description: 'TUI theme preset',
+    choices: ['default', 'monochrome', 'catppuccin', 'gruvbox'],
+  },
+} as Record<string, Options>
+
+export const builder = (yargs: Argv) => {
+  return yargs.options(options).usage(getCommandUsageHeader(command))
+}

--- a/src/commands/ui/handler.test.ts
+++ b/src/commands/ui/handler.test.ts
@@ -1,0 +1,35 @@
+import { createLogArgvFromUiArgv } from './handler'
+import { UiArgv } from './config'
+
+function argv(overrides: Partial<UiArgv> = {}): UiArgv {
+  return {
+    $0: 'coco',
+    _: ['ui'],
+    all: false,
+    interactive: false,
+    verbose: false,
+    version: false,
+    help: false,
+    view: 'history',
+    ...overrides,
+  } as UiArgv
+}
+
+describe('ui command handler utilities', () => {
+  it('maps ui history options to interactive log args', () => {
+    const logArgv = createLogArgvFromUiArgv(argv({
+      all: true,
+      branch: 'feature/git-workstation',
+      limit: 500,
+      path: ['src', 'README.md'],
+    }))
+
+    expect(logArgv._).toEqual(['log'])
+    expect(logArgv.interactive).toBe(true)
+    expect(logArgv.format).toBe('table')
+    expect(logArgv.all).toBe(true)
+    expect(logArgv.branch).toBe('feature/git-workstation')
+    expect(logArgv.limit).toBe(500)
+    expect(logArgv.path).toEqual(['src', 'README.md'])
+  })
+})

--- a/src/commands/ui/handler.ts
+++ b/src/commands/ui/handler.ts
@@ -1,0 +1,78 @@
+import { Arguments } from 'yargs'
+import { SimpleGit } from 'simple-git'
+import { CommandHandler } from '../../lib/types'
+import { Config } from '../../lib/config/types'
+import { loadConfig } from '../../lib/config/utils/loadConfig'
+import { getRepo } from '../../lib/simple-git/getRepo'
+import { LogArgv, LogOptions } from '../log/config'
+import { GitLogRow, getLogRows } from '../log/data'
+import { startInkInteractiveLog } from '../log/inkRuntime'
+import { LogInkThemeConfig } from '../log/inkTheme'
+import { UiArgv } from './config'
+
+export function createLogArgvFromUiArgv(argv: UiArgv): LogArgv {
+  return {
+    $0: argv.$0,
+    _: ['log'],
+    all: argv.all,
+    branch: argv.branch,
+    format: 'table',
+    interactive: true,
+    limit: argv.limit,
+    path: argv.path,
+    verbose: argv.verbose,
+    version: argv.version,
+    help: argv.help,
+  } as Arguments<LogOptions>
+}
+
+function createUiTheme(config: Config, argv: UiArgv): LogInkThemeConfig | undefined {
+  if (!argv.theme) {
+    return config.logTui?.theme
+  }
+
+  return {
+    ...config.logTui?.theme,
+    preset: argv.theme,
+  }
+}
+
+type StartCocoUiFromLogArgvOptions = {
+  config?: Config
+  git?: SimpleGit
+  rows?: GitLogRow[]
+}
+
+export async function startCocoUiFromLogArgv(
+  logArgv: LogArgv,
+  options: StartCocoUiFromLogArgvOptions = {}
+): Promise<void> {
+  const config = options.config || loadConfig<Config, LogArgv>(logArgv)
+  const git = options.git || getRepo()
+  const rows = options.rows || (await getLogRows(git, logArgv))
+
+  await startInkInteractiveLog(git, rows, {}, {
+    appLabel: 'coco ui',
+    initialView: 'history',
+    logArgv,
+    theme: config.logTui?.theme,
+  })
+}
+
+export async function startCocoUi(argv: UiArgv): Promise<void> {
+  const config = loadConfig<Config, UiArgv>(argv)
+  const git = getRepo()
+  const logArgv = createLogArgvFromUiArgv(argv)
+  const rows = await getLogRows(git, logArgv)
+
+  await startInkInteractiveLog(git, rows, {}, {
+    appLabel: 'coco ui',
+    initialView: argv.view || 'history',
+    logArgv,
+    theme: createUiTheme(config, argv),
+  })
+}
+
+export const handler: CommandHandler<UiArgv> = async (argv) => {
+  await startCocoUi(argv)
+}

--- a/src/commands/ui/index.ts
+++ b/src/commands/ui/index.ts
@@ -1,0 +1,11 @@
+import commandExecutor from '../../lib/utils/commandExecutor'
+import { builder, command, options } from './config'
+import { handler } from './handler'
+
+export default {
+  command,
+  desc: 'Open the Coco Git workstation TUI.',
+  builder,
+  handler: commandExecutor(handler),
+  options,
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import init from './commands/init'
 import log from './commands/log'
 import recap from './commands/recap'
 import review from './commands/review'
+import ui from './commands/ui'
 
 import { ChangelogOptions } from './commands/changelog/config'
 import { CommitOptions } from './commands/commit/config'
@@ -13,6 +14,7 @@ import { InitOptions } from './commands/init/config'
 import { LogOptions } from './commands/log/config'
 import { RecapOptions } from './commands/recap/config'
 import { ReviewOptions } from './commands/review/config'
+import { UiOptions } from './commands/ui/config'
 import { Config } from './lib/config/types'
 import * as types from './lib/types'
 
@@ -62,6 +64,13 @@ y.command<LogOptions>(
   log.handler
 )
 
+y.command<UiOptions>(
+  ui.command,
+  ui.desc,
+  ui.builder,
+  ui.handler
+)
+
 y.help().parse(process.argv.slice(2))
 
-export { changelog, commit, Config, init, log, recap, types }
+export { changelog, commit, Config, init, log, recap, types, ui }


### PR DESCRIPTION
## Summary
- add the public `coco ui` command with `--view history|status|diff`, history filters, and theme preset option
- route `coco log -i` through the new UI startup path while keeping stdout/JSON `coco log` unchanged
- thread app labeling through the Ink and non-TTY fallback renderers so interactive log now presents as `coco ui`
- add unit, integration, and packaged CLI smoke coverage for the new command

Closes #725
Refs #724

## Validation
- `npm run lint`
- `npm run build`
- `npm run test:jest -- src/commands/ui/handler.test.ts src/commands/commands.integration.test.ts src/commands/log/interactive.test.ts`
- `npm test`
- `git diff --check`