### PR TITLE
Add coco ui layout surfaces

### DIFF
--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -8,6 +8,7 @@ import {
 describe('log Ink keymap', () => {
   it('keeps footer hints short and contextual', () => {
     expect(getLogInkFooterHints({
+      activeView: 'history',
       filterMode: false,
       focus: 'commits',
       showHelp: false,
@@ -24,6 +25,20 @@ describe('log Ink keymap', () => {
       focus: 'detail',
       showHelp: false,
     })).toEqual(['↑/↓ files', 'pgup/pgdn diff', 'tab focus', '? help', 'q quit'])
+
+    expect(getLogInkFooterHints({
+      activeView: 'status',
+      filterMode: false,
+      focus: 'commits',
+      showHelp: false,
+    })).toEqual(['↑/↓ files', 'enter diff', 'space stage', 'r refresh', '? help'])
+
+    expect(getLogInkFooterHints({
+      activeView: 'diff',
+      filterMode: false,
+      focus: 'commits',
+      showHelp: false,
+    })).toEqual(['pgup/pgdn diff', 'j/k hunks', 'space stage', 'esc files', '? help'])
 
     expect(getLogInkFooterHints({
       filterMode: false,

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -1,4 +1,4 @@
-import { LogInkFocus } from './inkViewModel'
+import { LogInkFocus, LogInkView } from './inkViewModel'
 
 export type LogInkCommandId =
   | 'clearSearch'
@@ -186,6 +186,7 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
 ]
 
 export type GetLogInkFooterHintsOptions = {
+  activeView?: LogInkView
   filterMode: boolean
   focus: LogInkFocus
   showHelp: boolean
@@ -215,6 +216,14 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): stri
 
   if (options.focus === 'detail') {
     return ['↑/↓ files', 'pgup/pgdn diff', 'tab focus', '? help', 'q quit']
+  }
+
+  if (options.activeView === 'status') {
+    return ['↑/↓ files', 'enter diff', 'space stage', 'r refresh', '? help']
+  }
+
+  if (options.activeView === 'diff') {
+    return ['pgup/pgdn diff', 'j/k hunks', 'space stage', 'esc files', '? help']
   }
 
   return ['↑/↓ move', '/ search', 'gg/G top/bottom', 'n/N next', '? help']

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -39,6 +39,7 @@ import { truncateCells } from './inkText'
 import {
   LogInkSidebarTab,
   LogInkState,
+  LogInkView,
   applyLogInkAction,
   createLogInkState,
   getLogInkSidebarTabs,
@@ -71,7 +72,7 @@ type LogInkStreams = {
 
 type LogInkOptions = {
   appLabel?: string
-  initialView?: 'history' | 'status' | 'diff'
+  initialView?: LogInkView
   logArgv?: LogArgv
   theme?: LogInkThemeConfig
 }
@@ -121,7 +122,7 @@ type LogInkComponents = Pick<LogInkRuntime['ink'], 'Box' | 'Text'>
 type LogInkComponentDeps = LogInkRuntime & {
   appLabel: string
   git: SimpleGit
-  initialView: 'history' | 'status' | 'diff'
+  initialView: LogInkView
   logArgv?: LogArgv
   rows: GitLogRow[]
   theme: LogInkTheme
@@ -429,7 +430,9 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     columns: windowSize.columns || process.stdout.columns || LOG_INK_DEFAULT_COLUMNS,
     rows: windowSize.rows || process.stdout.rows || LOG_INK_DEFAULT_ROWS,
   })
-  const [state, setState] = React.useState<LogInkState>(() => createLogInkState(rows))
+  const [state, setState] = React.useState<LogInkState>(() =>
+    createLogInkState(rows, { activeView: initialView })
+  )
   const [context, setContext] = React.useState<LogInkContext>({})
   const [contextStatus, setContextStatus] = React.useState<LogInkContextStatus>(() =>
     createLogInkContextStatus('loading')
@@ -635,13 +638,15 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   }
 
   return h(Box, { flexDirection: 'column', height: layout.rows },
-    renderHeader(h, { Box, Text }, state, context, contextStatus, layout.columns, theme, appLabel, initialView),
+    renderHeader(h, { Box, Text }, state, context, contextStatus, layout.columns, theme, appLabel),
     h(Box, { flexDirection: 'row', height: layout.bodyRows },
       renderSidebar(h, { Box, Text }, state, context, contextStatus, layout.sidebarWidth, theme),
-      renderCommitPanel(
+      renderMainPanel(
         h,
         { Box, Text },
         state,
+        context,
+        contextStatus,
         layout.bodyRows,
         theme,
         hasMoreCommits,
@@ -673,8 +678,7 @@ function renderHeader(
   contextStatus: LogInkContextStatus,
   columns: number,
   theme: LogInkTheme,
-  appLabel: string,
-  initialView: 'history' | 'status' | 'diff'
+  appLabel: string
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const branch = context.branches?.currentBranch || context.provider?.currentBranch || '<detached>'
@@ -689,7 +693,7 @@ function renderHeader(
       : 'no PR'
   const search = state.filterMode ? `search: ${state.filter}_` : state.filter ? `filter: ${state.filter}` : ''
   const loading = isLogInkContextLoading(contextStatus) ? '  loading context' : ''
-  const view = initialView === 'history' ? '' : `  ${initialView}`
+  const view = state.activeView === 'history' ? '' : `  ${state.activeView}`
   const title = truncate(`${appLabel}  ${repo}  ${branch}  ${dirty}  ${pr}${view}${loading}`, columns - 2)
 
   return h(Box, {
@@ -727,6 +731,36 @@ function renderSidebar(
   h(Text, { dimColor: true }, tabs.map((tab) => tab === state.sidebarTab ? `[${sidebarTabLabel(tab)}]` : sidebarTabLabel(tab)).join(' ')),
   h(Text, undefined, ''),
   ...lines.map((line, index) => h(Text, { key: `sidebar-${index}` }, truncate(line, width - 4))))
+}
+
+function renderMainPanel(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  bodyRows: number,
+  theme: LogInkTheme,
+  hasMoreCommits: boolean,
+  loadingMoreCommits: boolean
+): ReactTypes.ReactElement {
+  if (state.activeView === 'status') {
+    return renderStatusSurface(h, components, state, context, contextStatus, bodyRows, theme)
+  }
+
+  if (state.activeView === 'diff') {
+    return renderDiffSurface(h, components, state, context, contextStatus, bodyRows, theme)
+  }
+
+  return renderCommitPanel(
+    h,
+    components,
+    state,
+    bodyRows,
+    theme,
+    hasMoreCommits,
+    loadingMoreCommits
+  )
 }
 
 function renderCommitPanel(
@@ -775,6 +809,87 @@ function renderCommitPanel(
         inverse: selected,
       }, truncate(row, 140))
     }))
+}
+
+function renderStatusSurface(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  bodyRows: number,
+  theme: LogInkTheme
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const focused = state.focus === 'commits'
+  const worktree = context.worktree
+  const listRows = Math.max(4, bodyRows - 5)
+  const lines = isLogInkContextKeyLoading(contextStatus, 'worktree')
+    ? ['Loading worktree status...']
+    : worktree?.files.length
+      ? worktree.files.slice(0, listRows).map((file) =>
+        `${file.indexStatus}${file.worktreeStatus} ${file.state.padEnd(9)} ${file.path}`
+      )
+      : ['Worktree clean']
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    flexGrow: 1,
+    paddingX: 1,
+  },
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle('Worktree', focused)),
+    h(Text, { dimColor: true }, worktree
+      ? `${worktree.stagedCount} staged | ${worktree.unstagedCount} unstaged | ${worktree.untrackedCount} untracked`
+      : 'status loading')
+  ),
+  ...lines.map((line, index) => h(Text, {
+    key: `status-surface-${index}`,
+    dimColor: index > 0,
+  }, truncate(line, 140))))
+}
+
+function renderDiffSurface(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  bodyRows: number,
+  theme: LogInkTheme
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const focused = state.focus === 'commits'
+  const worktree = context.worktree
+  const firstFile = worktree?.files[0]
+  const lines = isLogInkContextKeyLoading(contextStatus, 'worktree')
+    ? ['Loading file context...']
+    : firstFile
+      ? [
+        `Selected file: ${firstFile.path}`,
+        '',
+        'Dedicated diff rendering lands in the next slice.',
+        'This surface keeps large patches out of the right inspector.',
+      ]
+      : ['No changed file selected.']
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    flexGrow: 1,
+    paddingX: 1,
+  },
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle('Diff', focused)),
+    h(Text, { dimColor: true }, `${Math.max(0, bodyRows - 4)} visible rows`)
+  ),
+  ...lines.map((line, index) => h(Text, {
+    key: `diff-surface-${index}`,
+    dimColor: index > 1,
+  }, truncate(line, 140))))
 }
 
 function renderDetailPanel(
@@ -864,7 +979,7 @@ function renderDetailPanel(
     width,
     paddingX: 1,
   },
-  h(Text, { bold: true }, panelTitle('Detail', focused)),
+  h(Text, { bold: true }, panelTitle('Inspector', focused)),
   ...lines.map((line, index) => h(Text, {
     key: `detail-${index}`,
     dimColor: index > 1 && line !== 'Changed files:',
@@ -978,6 +1093,7 @@ function renderFooter(
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const hints = getLogInkFooterHints({
+    activeView: state.activeView,
     filterMode: state.filterMode,
     focus: state.focus,
     showCommandPalette: state.showCommandPalette,

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -45,6 +45,7 @@ describe('log Ink view model', () => {
     const state = createLogInkState(rows)
 
     expect(state.commits).toHaveLength(3)
+    expect(state.activeView).toBe('history')
     expect(state.filteredCommits).toHaveLength(3)
     expect(state.selectedFileIndex).toBe(0)
     expect(state.diffPreviewOffset).toBe(0)
@@ -52,6 +53,16 @@ describe('log Ink view model', () => {
     expect(state.sidebarTab).toBe('status')
     expect(state.showHelp).toBe(false)
     expect(state.showCommandPalette).toBe(false)
+  })
+
+  it('supports workstation surface selection', () => {
+    let state = createLogInkState(rows, { activeView: 'status' })
+
+    expect(state.activeView).toBe('status')
+
+    state = applyLogInkAction(state, { type: 'setActiveView', value: 'diff' })
+
+    expect(state.activeView).toBe('diff')
   })
 
   it('moves selected commits and clamps at list bounds', () => {

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -3,8 +3,14 @@ import { GitLogCommitRow, GitLogRow, getCommitRows } from './data'
 export type LogInkFocus = 'sidebar' | 'commits' | 'detail'
 
 export type LogInkSidebarTab = 'status' | 'branches' | 'tags' | 'stashes' | 'worktrees'
+export type LogInkView = 'history' | 'status' | 'diff'
+
+export type CreateLogInkStateOptions = {
+  activeView?: LogInkView
+}
 
 export type LogInkState = {
+  activeView: LogInkView
   rows: GitLogRow[]
   commits: GitLogCommitRow[]
   filteredCommits: GitLogCommitRow[]
@@ -40,6 +46,7 @@ export type LogInkAction =
   | { type: 'pageDetailPreview'; delta: number; previewLineCount: number }
   | { type: 'previousSidebarTab' }
   | { type: 'setFilter'; value: string }
+  | { type: 'setActiveView'; value: LogInkView }
   | { type: 'setFocus'; value: LogInkFocus }
   | { type: 'setPendingKey'; value?: string }
   | { type: 'setSidebarTab'; value: LogInkSidebarTab }
@@ -211,10 +218,14 @@ export function getLogInkSidebarTabs(): LogInkSidebarTab[] {
   return [...SIDEBAR_TABS]
 }
 
-export function createLogInkState(rows: GitLogRow[]): LogInkState {
+export function createLogInkState(
+  rows: GitLogRow[],
+  options: CreateLogInkStateOptions = {}
+): LogInkState {
   const commits = getCommitRows(rows)
 
   return {
+    activeView: options.activeView || 'history',
     rows,
     commits,
     filteredCommits: commits,
@@ -325,6 +336,12 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       }
     case 'setFilter':
       return withFilter(state, action.value)
+    case 'setActiveView':
+      return {
+        ...state,
+        activeView: action.value,
+        pendingKey: undefined,
+      }
     case 'setFocus':
       return {
         ...state,


### PR DESCRIPTION
## Summary
- add explicit `history`, `status`, and `diff` surface state to the Ink view model
- initialize the TUI from `coco ui --view` so non-history surfaces have a stable shell
- split the central panel into history, worktree, and diff surfaces while keeping the right side as an inspector
- make footer hints aware of status and diff surfaces

Closes #726
Refs #724

## Validation
- `npm run test:jest -- src/commands/log/inkViewModel.test.ts src/commands/log/inkKeymap.test.ts src/commands/log/inkInput.test.ts src/commands/ui/handler.test.ts`
- `npm run lint`
- `npm run build`
- `npm test`
- `git diff --check`