### PR TITLE
Add coco ui worktree diff view

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -163,6 +163,28 @@ describe('log Ink input interactions', () => {
     expect(state.diffPreviewOffset).toBe(0)
   })
 
+  it('opens and scrolls the worktree diff surface from status view', () => {
+    let state = createLogInkState(rows, { activeView: 'status' })
+
+    state = applyInput(state, 'j', {}, { worktreeFileCount: 3 })
+    expect(state.selectedWorktreeFileIndex).toBe(1)
+
+    state = applyInput(state, '', { return: true }, { worktreeFileCount: 3 })
+    expect(state.activeView).toBe('diff')
+
+    state = applyInput(state, '', { pageDown: true }, { worktreeDiffLineCount: 30 })
+    expect(state.worktreeDiffOffset).toBe(8)
+
+    state = applyInput(state, 'j', {}, {
+      worktreeDiffLineCount: 30,
+      worktreeHunkOffsets: [2, 12, 20],
+    })
+    expect(state.worktreeDiffOffset).toBe(12)
+
+    state = applyInput(state, '', { escape: true })
+    expect(state.activeView).toBe('status')
+  })
+
   it('clears pending key chords after unrelated actions', () => {
     let state = createLogInkState(rows)
 

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -26,7 +26,10 @@ export type LogInkInputEvent =
 
 export type LogInkInputContext = {
   detailFileCount?: number
+  worktreeHunkOffsets?: number[]
   previewLineCount?: number
+  worktreeDiffLineCount?: number
+  worktreeFileCount?: number
 }
 
 function action(actionValue: LogInkAction): LogInkInputEvent {
@@ -107,6 +110,10 @@ export function getLogInkInputEvents(
     return [action({ type: 'toggleCommandPalette' })]
   }
 
+  if (key.escape && state.activeView === 'diff') {
+    return [action({ type: 'setActiveView', value: 'status' })]
+  }
+
   if (inputValue === 'q') {
     return [{ type: 'exit' }]
   }
@@ -177,6 +184,22 @@ export function getLogInkInputEvents(
       return [action({ type: 'moveDetailFile', delta: -1, fileCount: context.detailFileCount })]
     }
 
+    if (state.activeView === 'status' && context.worktreeFileCount) {
+      return [action({
+        type: 'moveWorktreeFile',
+        delta: -1,
+        fileCount: context.worktreeFileCount,
+      })]
+    }
+
+    if (state.activeView === 'diff' && context.worktreeDiffLineCount) {
+      return [action({
+        type: 'jumpWorktreeHunk',
+        delta: -1,
+        hunkOffsets: context.worktreeHunkOffsets || [],
+      })]
+    }
+
     return [
       action(state.focus === 'sidebar'
         ? { type: 'previousSidebarTab' }
@@ -189,6 +212,22 @@ export function getLogInkInputEvents(
       return [action({ type: 'moveDetailFile', delta: 1, fileCount: context.detailFileCount })]
     }
 
+    if (state.activeView === 'status' && context.worktreeFileCount) {
+      return [action({
+        type: 'moveWorktreeFile',
+        delta: 1,
+        fileCount: context.worktreeFileCount,
+      })]
+    }
+
+    if (state.activeView === 'diff' && context.worktreeDiffLineCount) {
+      return [action({
+        type: 'jumpWorktreeHunk',
+        delta: 1,
+        hunkOffsets: context.worktreeHunkOffsets || [],
+      })]
+    }
+
     return [
       action(state.focus === 'sidebar'
         ? { type: 'nextSidebarTab' }
@@ -197,6 +236,14 @@ export function getLogInkInputEvents(
   }
 
   if (key.pageUp) {
+    if (state.activeView === 'diff' && context.worktreeDiffLineCount) {
+      return [action({
+        type: 'pageWorktreeDiff',
+        delta: -8,
+        lineCount: context.worktreeDiffLineCount,
+      })]
+    }
+
     if (state.focus === 'detail' && context.previewLineCount) {
       return [action({
         type: 'pageDetailPreview',
@@ -209,6 +256,14 @@ export function getLogInkInputEvents(
   }
 
   if (key.pageDown) {
+    if (state.activeView === 'diff' && context.worktreeDiffLineCount) {
+      return [action({
+        type: 'pageWorktreeDiff',
+        delta: 8,
+        lineCount: context.worktreeDiffLineCount,
+      })]
+    }
+
     if (state.focus === 'detail' && context.previewLineCount) {
       return [action({
         type: 'pageDetailPreview',
@@ -218,6 +273,10 @@ export function getLogInkInputEvents(
     }
 
     return [action({ type: 'page', delta: 10 })]
+  }
+
+  if (key.return && state.activeView === 'status' && context.worktreeFileCount) {
+    return [action({ type: 'setActiveView', value: 'diff' })]
   }
 
   const workflowAction = getLogInkWorkflowActionByKey(inputValue)

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -58,6 +58,7 @@ import {
   getLogInkWorkflowSections,
 } from './inkWorkflows'
 import { WorktreeOverview as WorktreeListOverview, getWorktreeListOverview } from './worktreeData'
+import { WorktreeFileDiff, getWorktreeFileDiff } from './worktreeDiffData'
 import { canStartLogInkTui, getLogInkRenderOptions } from './inkTerminal'
 import { LogArgv } from './config'
 
@@ -441,6 +442,8 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   const [detailLoading, setDetailLoading] = React.useState(false)
   const [filePreview, setFilePreview] = React.useState<GitCommitFilePreview | undefined>(undefined)
   const [filePreviewLoading, setFilePreviewLoading] = React.useState(false)
+  const [worktreeDiff, setWorktreeDiff] = React.useState<WorktreeFileDiff | undefined>(undefined)
+  const [worktreeDiffLoading, setWorktreeDiffLoading] = React.useState(false)
   const [hasMoreCommits, setHasMoreCommits] = React.useState(() => (
     Boolean(logArgv?.interactive && !logArgv.limit) &&
     getCommitRows(rows).length >= LOG_INTERACTIVE_DEFAULT_LIMIT
@@ -451,6 +454,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   const mountedRef = React.useRef(true)
   const selected = getSelectedInkCommit(state)
   const selectedDetailFile = detail?.files[state.selectedFileIndex]
+  const selectedWorktreeFile = context.worktree?.files[state.selectedWorktreeFileIndex]
 
   const dispatch = React.useCallback((action: Parameters<typeof applyLogInkAction>[1]) => {
     setState((current) => applyLogInkAction(current, action))
@@ -510,6 +514,38 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       active = false
     }
   }, [git, selected?.hash])
+
+  React.useEffect(() => {
+    let active = true
+
+    async function loadWorktreeDiff(): Promise<void> {
+      if (state.activeView !== 'diff' || !selectedWorktreeFile) {
+        setWorktreeDiff(undefined)
+        setWorktreeDiffLoading(false)
+        return
+      }
+
+      setWorktreeDiffLoading(true)
+      const nextDiff = await safe(getWorktreeFileDiff(git, selectedWorktreeFile))
+
+      if (active) {
+        setWorktreeDiff(nextDiff)
+        setWorktreeDiffLoading(false)
+      }
+    }
+
+    void loadWorktreeDiff()
+
+    return () => {
+      active = false
+    }
+  }, [
+    git,
+    selectedWorktreeFile?.indexStatus,
+    selectedWorktreeFile?.path,
+    selectedWorktreeFile?.worktreeStatus,
+    state.activeView,
+  ])
 
   React.useEffect(() => {
     let active = true
@@ -613,6 +649,9 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     getLogInkInputEvents(state, inputValue, key, {
       detailFileCount: detail?.files.length,
       previewLineCount: filePreview?.hunks.length,
+      worktreeDiffLineCount: worktreeDiff?.lines.length,
+      worktreeFileCount: context.worktree?.files.length,
+      worktreeHunkOffsets: worktreeDiff?.hunkOffsets,
     }).forEach((event) => {
       if (event.type === 'exit') {
         exit()
@@ -647,6 +686,8 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         state,
         context,
         contextStatus,
+        worktreeDiff,
+        worktreeDiffLoading,
         layout.bodyRows,
         theme,
         hasMoreCommits,
@@ -739,6 +780,8 @@ function renderMainPanel(
   state: LogInkState,
   context: LogInkContext,
   contextStatus: LogInkContextStatus,
+  worktreeDiff: WorktreeFileDiff | undefined,
+  worktreeDiffLoading: boolean,
   bodyRows: number,
   theme: LogInkTheme,
   hasMoreCommits: boolean,
@@ -749,7 +792,17 @@ function renderMainPanel(
   }
 
   if (state.activeView === 'diff') {
-    return renderDiffSurface(h, components, state, context, contextStatus, bodyRows, theme)
+    return renderDiffSurface(
+      h,
+      components,
+      state,
+      context,
+      contextStatus,
+      worktreeDiff,
+      worktreeDiffLoading,
+      bodyRows,
+      theme
+    )
   }
 
   return renderCommitPanel(
@@ -824,12 +877,18 @@ function renderStatusSurface(
   const focused = state.focus === 'commits'
   const worktree = context.worktree
   const listRows = Math.max(4, bodyRows - 5)
+  const selectedIndex = state.selectedWorktreeFileIndex
   const lines = isLogInkContextKeyLoading(contextStatus, 'worktree')
     ? ['Loading worktree status...']
     : worktree?.files.length
-      ? worktree.files.slice(0, listRows).map((file) =>
-        `${file.indexStatus}${file.worktreeStatus} ${file.state.padEnd(9)} ${file.path}`
-      )
+      ? worktree.files
+        .slice(Math.max(0, selectedIndex - Math.floor(listRows / 2)))
+        .slice(0, listRows)
+        .map((file, offset) => {
+          const index = Math.max(0, selectedIndex - Math.floor(listRows / 2)) + offset
+
+          return `${index === selectedIndex ? '>' : ' '} ${file.indexStatus}${file.worktreeStatus} ${file.state.padEnd(9)} ${file.path}`
+        })
       : ['Worktree clean']
 
   return h(Box, {
@@ -857,21 +916,31 @@ function renderDiffSurface(
   state: LogInkState,
   context: LogInkContext,
   contextStatus: LogInkContextStatus,
+  worktreeDiff: WorktreeFileDiff | undefined,
+  worktreeDiffLoading: boolean,
   bodyRows: number,
   theme: LogInkTheme
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const focused = state.focus === 'commits'
   const worktree = context.worktree
-  const firstFile = worktree?.files[0]
+  const selectedFile = worktree?.files[state.selectedWorktreeFileIndex]
+  const visibleRows = Math.max(4, bodyRows - 4)
+  const diffLines = worktreeDiff?.lines || []
+  const visibleDiffLines = diffLines.slice(
+    state.worktreeDiffOffset,
+    state.worktreeDiffOffset + visibleRows
+  )
   const lines = isLogInkContextKeyLoading(contextStatus, 'worktree')
     ? ['Loading file context...']
-    : firstFile
+    : worktreeDiffLoading
+      ? [`Loading diff for ${selectedFile?.path || 'selected file'}...`]
+      : selectedFile
       ? [
-        `Selected file: ${firstFile.path}`,
+        `Selected file: ${selectedFile.path}`,
+        `Lines ${Math.min(state.worktreeDiffOffset + 1, diffLines.length || 1)}-${Math.min(state.worktreeDiffOffset + visibleDiffLines.length, diffLines.length)}/${diffLines.length}`,
         '',
-        'Dedicated diff rendering lands in the next slice.',
-        'This surface keeps large patches out of the right inspector.',
+        ...visibleDiffLines,
       ]
       : ['No changed file selected.']
 
@@ -884,7 +953,7 @@ function renderDiffSurface(
   },
   h(Box, { justifyContent: 'space-between' },
     h(Text, { bold: true }, panelTitle('Diff', focused)),
-    h(Text, { dimColor: true }, `${Math.max(0, bodyRows - 4)} visible rows`)
+    h(Text, { dimColor: true }, selectedFile ? selectedFile.path : 'no file')
   ),
   ...lines.map((line, index) => h(Text, {
     key: `diff-surface-${index}`,

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -48,7 +48,9 @@ describe('log Ink view model', () => {
     expect(state.activeView).toBe('history')
     expect(state.filteredCommits).toHaveLength(3)
     expect(state.selectedFileIndex).toBe(0)
+    expect(state.selectedWorktreeFileIndex).toBe(0)
     expect(state.diffPreviewOffset).toBe(0)
+    expect(state.worktreeDiffOffset).toBe(0)
     expect(state.focus).toBe('commits')
     expect(state.sidebarTab).toBe('status')
     expect(state.showHelp).toBe(false)
@@ -193,6 +195,28 @@ describe('log Ink view model', () => {
     state = applyLogInkAction(state, { type: 'move', delta: 1 })
     expect(state.selectedFileIndex).toBe(0)
     expect(state.diffPreviewOffset).toBe(0)
+  })
+
+  it('tracks worktree file selection and diff paging', () => {
+    let state = createLogInkState(rows, { activeView: 'status' })
+
+    state = applyLogInkAction(state, { type: 'moveWorktreeFile', delta: 2, fileCount: 4 })
+    expect(state.selectedWorktreeFileIndex).toBe(2)
+    expect(state.activeView).toBe('status')
+
+    state = applyLogInkAction(state, { type: 'setActiveView', value: 'diff' })
+    state = applyLogInkAction(state, { type: 'pageWorktreeDiff', delta: 8, lineCount: 20 })
+    expect(state.worktreeDiffOffset).toBe(8)
+
+    state = applyLogInkAction(state, {
+      type: 'jumpWorktreeHunk',
+      delta: 1,
+      hunkOffsets: [3, 12],
+    })
+    expect(state.worktreeDiffOffset).toBe(12)
+
+    state = applyLogInkAction(state, { type: 'setActiveView', value: 'status' })
+    expect(state.worktreeDiffOffset).toBe(0)
   })
 
   it('toggles graph, help, and command palette overlays', () => {

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -16,7 +16,9 @@ export type LogInkState = {
   filteredCommits: GitLogCommitRow[]
   selectedIndex: number
   selectedFileIndex: number
+  selectedWorktreeFileIndex: number
   diffPreviewOffset: number
+  worktreeDiffOffset: number
   filter: string
   filterMode: boolean
   fullGraph: boolean
@@ -39,14 +41,17 @@ export type LogInkAction =
   | { type: 'focusPrevious' }
   | { type: 'move'; delta: number }
   | { type: 'moveDetailFile'; delta: number; fileCount: number }
+  | { type: 'moveWorktreeFile'; delta: number; fileCount: number }
   | { type: 'moveToBottom' }
   | { type: 'moveToTop' }
   | { type: 'nextSidebarTab' }
   | { type: 'page'; delta: number }
   | { type: 'pageDetailPreview'; delta: number; previewLineCount: number }
+  | { type: 'pageWorktreeDiff'; delta: number; lineCount: number }
   | { type: 'previousSidebarTab' }
   | { type: 'setFilter'; value: string }
   | { type: 'setActiveView'; value: LogInkView }
+  | { type: 'jumpWorktreeHunk'; delta: number; hunkOffsets: number[] }
   | { type: 'setFocus'; value: LogInkFocus }
   | { type: 'setPendingKey'; value?: string }
   | { type: 'setSidebarTab'; value: LogInkSidebarTab }
@@ -214,6 +219,20 @@ function appendRows(state: LogInkState, rows: GitLogRow[]): LogInkState {
   }
 }
 
+function nextHunkOffset(currentOffset: number, hunkOffsets: number[], delta: number): number {
+  if (hunkOffsets.length === 0) {
+    return currentOffset
+  }
+
+  if (delta > 0) {
+    return hunkOffsets.find((offset) => offset > currentOffset) ||
+      hunkOffsets[hunkOffsets.length - 1]
+  }
+
+  return [...hunkOffsets].reverse().find((offset) => offset < currentOffset) ||
+    hunkOffsets[0]
+}
+
 export function getLogInkSidebarTabs(): LogInkSidebarTab[] {
   return [...SIDEBAR_TABS]
 }
@@ -231,7 +250,9 @@ export function createLogInkState(
     filteredCommits: commits,
     selectedIndex: 0,
     selectedFileIndex: 0,
+    selectedWorktreeFileIndex: 0,
     diffPreviewOffset: 0,
+    worktreeDiffOffset: 0,
     filter: '',
     filterMode: false,
     fullGraph: false,
@@ -289,6 +310,17 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         diffPreviewOffset: 0,
         pendingKey: undefined,
       }
+    case 'moveWorktreeFile':
+      return {
+        ...state,
+        activeView: 'status',
+        selectedWorktreeFileIndex: clampIndex(
+          state.selectedWorktreeFileIndex + action.delta,
+          action.fileCount
+        ),
+        worktreeDiffOffset: 0,
+        pendingKey: undefined,
+      }
     case 'moveToBottom':
       return {
         ...state,
@@ -328,6 +360,22 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         ),
         pendingKey: undefined,
       }
+    case 'pageWorktreeDiff':
+      return {
+        ...state,
+        worktreeDiffOffset: clampIndex(state.worktreeDiffOffset + action.delta, action.lineCount),
+        pendingKey: undefined,
+      }
+    case 'jumpWorktreeHunk':
+      return {
+        ...state,
+        worktreeDiffOffset: nextHunkOffset(
+          state.worktreeDiffOffset,
+          action.hunkOffsets,
+          action.delta
+        ),
+        pendingKey: undefined,
+      }
     case 'previousSidebarTab':
       return {
         ...state,
@@ -340,6 +388,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         activeView: action.value,
+        worktreeDiffOffset: action.value === 'diff' ? state.worktreeDiffOffset : 0,
         pendingKey: undefined,
       }
     case 'setFocus':

--- a/src/commands/log/worktreeDiffData.test.ts
+++ b/src/commands/log/worktreeDiffData.test.ts
@@ -1,0 +1,47 @@
+import { SimpleGit } from 'simple-git'
+import { getWorktreeFileDiff } from './worktreeDiffData'
+import { WorktreeFile } from './statusData'
+
+function gitWithDiffs(outputs: string[]): SimpleGit {
+  return {
+    diff: jest.fn()
+      .mockImplementation(() => Promise.resolve(outputs.shift() || '')),
+  } as unknown as SimpleGit
+}
+
+describe('worktree diff data', () => {
+  it('loads staged and unstaged diffs for a modified file', async () => {
+    const file: WorktreeFile = {
+      path: 'src/app.ts',
+      indexStatus: 'M',
+      worktreeStatus: 'M',
+      state: 'staged',
+    }
+    const diff = await getWorktreeFileDiff(gitWithDiffs([
+      'diff --git a/src/app.ts b/src/app.ts\n@@ -1 +1 @@\n+staged\n',
+      'diff --git a/src/app.ts b/src/app.ts\n@@ -2 +2 @@\n+unstaged\n',
+    ]), file)
+
+    expect(diff?.filePath).toBe('src/app.ts')
+    expect(diff?.staged).toBe(true)
+    expect(diff?.unstaged).toBe(true)
+    expect(diff?.lines).toContain('Staged changes')
+    expect(diff?.lines).toContain('Unstaged changes')
+    expect(diff?.lines).toContain('+staged')
+    expect(diff?.lines).toContain('+unstaged')
+    expect(diff?.hunkOffsets).toHaveLength(2)
+  })
+
+  it('returns a useful placeholder for untracked files', async () => {
+    const file: WorktreeFile = {
+      path: 'src/new.ts',
+      indexStatus: '?',
+      worktreeStatus: '?',
+      state: 'untracked',
+    }
+    const diff = await getWorktreeFileDiff(gitWithDiffs([]), file)
+
+    expect(diff?.untracked).toBe(true)
+    expect(diff?.lines.join('\n')).toContain('Untracked file: src/new.ts')
+  })
+})

--- a/src/commands/log/worktreeDiffData.ts
+++ b/src/commands/log/worktreeDiffData.ts
@@ -1,0 +1,67 @@
+import { SimpleGit } from 'simple-git'
+import { WorktreeFile } from './statusData'
+
+export type WorktreeFileDiff = {
+  filePath: string
+  hunkOffsets: number[]
+  lines: string[]
+  staged: boolean
+  unstaged: boolean
+  untracked: boolean
+}
+
+function sectionLines(title: string, diff: string): string[] {
+  const lines = diff.split('\n').map((line) => line.trimEnd())
+
+  return [
+    title,
+    ...lines.filter(Boolean),
+  ]
+}
+
+export async function getWorktreeFileDiff(
+  git: SimpleGit,
+  file: WorktreeFile | undefined
+): Promise<WorktreeFileDiff | undefined> {
+  if (!file) {
+    return undefined
+  }
+
+  if (file.state === 'untracked') {
+    return {
+      filePath: file.path,
+      lines: [
+        `Untracked file: ${file.path}`,
+        '',
+        'Git does not expose a line diff until the file is staged.',
+      ],
+      hunkOffsets: [],
+      staged: false,
+      unstaged: false,
+      untracked: true,
+    }
+  }
+
+  const stagedDiff = file.indexStatus.trim()
+    ? await git.diff(['--staged', '--', file.path])
+    : ''
+  const unstagedDiff = file.worktreeStatus.trim()
+    ? await git.diff(['--', file.path])
+    : ''
+  const lines = [
+    ...(stagedDiff ? sectionLines('Staged changes', stagedDiff) : []),
+    ...(stagedDiff && unstagedDiff ? [''] : []),
+    ...(unstagedDiff ? sectionLines('Unstaged changes', unstagedDiff) : []),
+  ]
+
+  return {
+    filePath: file.path,
+    hunkOffsets: lines
+      .map((line, index) => line.startsWith('@@') ? index : undefined)
+      .filter((index): index is number => index !== undefined),
+    lines: lines.length ? lines : ['No diff available for selected file.'],
+    staged: Boolean(stagedDiff),
+    unstaged: Boolean(unstagedDiff),
+    untracked: false,
+  }
+}


### PR DESCRIPTION
## Summary
- add worktree diff data loading for staged, unstaged, and untracked files
- track selected worktree file and dedicated diff scroll state in the Ink view model
- let status view move through changed files and open diff view with Enter
- let diff view jump hunks with j/k, scroll with PgUp/PgDn, and return to status with Esc
- render selected file diffs in the main diff surface instead of the right inspector

Closes #727
Refs #724

## Validation
- `npm run test:jest -- src/commands/log/worktreeDiffData.test.ts src/commands/log/inkViewModel.test.ts src/commands/log/inkInput.test.ts src/commands/log/inkKeymap.test.ts`
- `npm run lint`
- `npm run build`
- `npm test`
- `git diff --check`