### PR TITLE
Wire coco ui staging actions

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -180,9 +180,83 @@ describe('log Ink input interactions', () => {
       worktreeHunkOffsets: [2, 12, 20],
     })
     expect(state.worktreeDiffOffset).toBe(12)
+    expect(state.selectedWorktreeHunkIndex).toBe(1)
 
     state = applyInput(state, '', { escape: true })
     expect(state.activeView).toBe('status')
+  })
+
+  it('emits worktree file and hunk mutation events from status and diff views', () => {
+    expect(getLogInkInputEvents(
+      createLogInkState(rows, { activeView: 'status' }),
+      ' ',
+      {},
+      { worktreeFileCount: 1 }
+    )).toEqual([{ type: 'toggleSelectedFileStage' }])
+
+    expect(getLogInkInputEvents(
+      createLogInkState(rows, { activeView: 'diff' }),
+      ' ',
+      {},
+      { worktreeHunkOffsets: [2] }
+    )).toEqual([{ type: 'toggleSelectedHunkStage' }])
+
+    expect(getLogInkInputEvents(
+      createLogInkState(rows, { activeView: 'status' }),
+      'z',
+      {},
+      { worktreeFileCount: 1 }
+    )).toEqual([
+      {
+        type: 'action',
+        action: { type: 'setPendingMutationConfirmation', value: 'revert-file' },
+      },
+    ])
+
+    expect(getLogInkInputEvents(
+      createLogInkState(rows, { activeView: 'diff' }),
+      'z',
+      {},
+      { worktreeHunkOffsets: [2] }
+    )).toEqual([
+      {
+        type: 'action',
+        action: { type: 'setPendingMutationConfirmation', value: 'revert-hunk' },
+      },
+    ])
+  })
+
+  it('confirms or cancels worktree revert actions explicitly', () => {
+    const filePending = applyLogInkAction(createLogInkState(rows), {
+      type: 'setPendingMutationConfirmation',
+      value: 'revert-file',
+    })
+    const hunkPending = applyLogInkAction(createLogInkState(rows), {
+      type: 'setPendingMutationConfirmation',
+      value: 'revert-hunk',
+    })
+
+    expect(getLogInkInputEvents(filePending, 'y')).toEqual([
+      { type: 'revertSelectedFile' },
+      {
+        type: 'action',
+        action: { type: 'setPendingMutationConfirmation', value: undefined },
+      },
+    ])
+    expect(getLogInkInputEvents(hunkPending, 'y')).toEqual([
+      { type: 'revertSelectedHunk' },
+      {
+        type: 'action',
+        action: { type: 'setPendingMutationConfirmation', value: undefined },
+      },
+    ])
+    expect(getLogInkInputEvents(filePending, 'n')).toEqual([
+      {
+        type: 'action',
+        action: { type: 'setPendingMutationConfirmation', value: undefined },
+      },
+      { type: 'action', action: { type: 'setStatus', value: 'revert cancelled' } },
+    ])
   })
 
   it('clears pending key chords after unrelated actions', () => {

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -23,6 +23,10 @@ export type LogInkInputEvent =
   | { type: 'action'; action: LogInkAction }
   | { type: 'exit' }
   | { type: 'refreshContext' }
+  | { type: 'toggleSelectedFileStage' }
+  | { type: 'toggleSelectedHunkStage' }
+  | { type: 'revertSelectedFile' }
+  | { type: 'revertSelectedHunk' }
 
 export type LogInkInputContext = {
   detailFileCount?: number
@@ -96,6 +100,26 @@ export function getLogInkInputEvents(
       return [
         action({ type: 'setPendingConfirmation', value: undefined }),
         action({ type: 'setStatus', value: 'workflow action cancelled' }),
+      ]
+    }
+
+    return []
+  }
+
+  if (state.pendingMutationConfirmation) {
+    if (inputValue === 'y') {
+      return [
+        state.pendingMutationConfirmation === 'revert-hunk'
+          ? { type: 'revertSelectedHunk' }
+          : { type: 'revertSelectedFile' },
+        action({ type: 'setPendingMutationConfirmation', value: undefined }),
+      ]
+    }
+
+    if (inputValue === 'n' || key.escape) {
+      return [
+        action({ type: 'setPendingMutationConfirmation', value: undefined }),
+        action({ type: 'setStatus', value: 'revert cancelled' }),
       ]
     }
 
@@ -277,6 +301,22 @@ export function getLogInkInputEvents(
 
   if (key.return && state.activeView === 'status' && context.worktreeFileCount) {
     return [action({ type: 'setActiveView', value: 'diff' })]
+  }
+
+  if (inputValue === ' ' && state.activeView === 'status' && context.worktreeFileCount) {
+    return [{ type: 'toggleSelectedFileStage' }]
+  }
+
+  if (inputValue === ' ' && state.activeView === 'diff' && context.worktreeHunkOffsets?.length) {
+    return [{ type: 'toggleSelectedHunkStage' }]
+  }
+
+  if (inputValue === 'z' && state.activeView === 'status' && context.worktreeFileCount) {
+    return [action({ type: 'setPendingMutationConfirmation', value: 'revert-file' })]
+  }
+
+  if (inputValue === 'z' && state.activeView === 'diff' && context.worktreeHunkOffsets?.length) {
+    return [action({ type: 'setPendingMutationConfirmation', value: 'revert-hunk' })]
   }
 
   const workflowAction = getLogInkWorkflowActionByKey(inputValue)

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -31,14 +31,14 @@ describe('log Ink keymap', () => {
       filterMode: false,
       focus: 'commits',
       showHelp: false,
-    })).toEqual(['↑/↓ files', 'enter diff', 'space stage', 'r refresh', '? help'])
+    })).toEqual(['↑/↓ files', 'enter diff', 'space stage', 'z revert', '? help'])
 
     expect(getLogInkFooterHints({
       activeView: 'diff',
       filterMode: false,
       focus: 'commits',
       showHelp: false,
-    })).toEqual(['pgup/pgdn diff', 'j/k hunks', 'space stage', 'esc files', '? help'])
+    })).toEqual(['j/k hunks', 'space stage', 'z revert', 'esc files', '? help'])
 
     expect(getLogInkFooterHints({
       filterMode: false,
@@ -59,6 +59,7 @@ describe('log Ink keymap', () => {
     expect(helpText).toContain('gg Jump to the first visible commit.')
     expect(helpText).toContain('G Jump to the last visible commit.')
     expect(helpText).toContain('[ Move to the previous repository sidebar tab.')
+    expect(helpText).toContain('z Ask to revert the selected file or hunk.')
     expect(helpText).toContain('q/ctrl+c Quit the interactive log.')
     expect(helpText).toContain('tab Move focus to the next panel.')
   })

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -18,6 +18,7 @@ export type LogInkCommandId =
   | 'previousSidebarTab'
   | 'quit'
   | 'refresh'
+  | 'revertSelection'
   | 'search'
   | 'toggleGraph'
   | 'workflowActions'
@@ -156,6 +157,13 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     contexts: ['normal'],
   },
   {
+    id: 'revertSelection',
+    keys: ['z'],
+    label: 'revert',
+    description: 'Ask to revert the selected file or hunk.',
+    contexts: ['commits'],
+  },
+  {
     id: 'help',
     keys: ['?'],
     label: 'help',
@@ -219,11 +227,11 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): stri
   }
 
   if (options.activeView === 'status') {
-    return ['↑/↓ files', 'enter diff', 'space stage', 'r refresh', '? help']
+    return ['↑/↓ files', 'enter diff', 'space stage', 'z revert', '? help']
   }
 
   if (options.activeView === 'diff') {
-    return ['pgup/pgdn diff', 'j/k hunks', 'space stage', 'esc files', '? help']
+    return ['j/k hunks', 'space stage', 'z revert', 'esc files', '? help']
   }
 
   return ['↑/↓ move', '/ search', 'gg/G top/bottom', 'n/N next', '? help']
@@ -253,7 +261,7 @@ export function getLogInkHelpSections(): LogInkHelpSection[] {
     {
       title: 'Browsing',
       bindings: LOG_INK_KEY_BINDINGS.filter((binding) =>
-        ['search', 'clearSearch', 'toggleGraph', 'refresh'].includes(binding.id)
+        ['search', 'clearSearch', 'toggleGraph', 'refresh', 'revertSelection'].includes(binding.id)
       ),
     },
     {

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -50,7 +50,15 @@ import { GitOperationOverview, getGitOperationOverview } from './operationData'
 import { ProviderOverview, getProviderOverview } from './providerData'
 import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
 import { StashOverview, getStashOverview } from './stashData'
+import { revertFile, stageFile, unstageFile } from './statusActions'
 import { WorktreeOverview, getWorktreeOverview } from './statusData'
+import {
+  WorktreeHunkOverview,
+  getWorktreeHunks,
+  revertHunk,
+  stageHunk,
+  unstageHunk,
+} from './statusHunks'
 import { TagOverview, getTagOverview } from './tagData'
 import {
   getLogInkWorkflowActionById,
@@ -444,6 +452,10 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   const [filePreviewLoading, setFilePreviewLoading] = React.useState(false)
   const [worktreeDiff, setWorktreeDiff] = React.useState<WorktreeFileDiff | undefined>(undefined)
   const [worktreeDiffLoading, setWorktreeDiffLoading] = React.useState(false)
+  const [worktreeHunks, setWorktreeHunks] = React.useState<WorktreeHunkOverview | undefined>(
+    undefined
+  )
+  const [worktreeHunksLoading, setWorktreeHunksLoading] = React.useState(false)
   const [hasMoreCommits, setHasMoreCommits] = React.useState(() => (
     Boolean(logArgv?.interactive && !logArgv.limit) &&
     getCommitRows(rows).length >= LOG_INTERACTIVE_DEFAULT_LIMIT
@@ -467,6 +479,49 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     setContextStatus(createLogInkContextStatus('ready'))
     dispatch({ type: 'setStatus', value: 'repository context refreshed' })
   }, [dispatch, git])
+
+  const refreshWorktreeContext = React.useCallback(async () => {
+    setContextStatus((current) => updateLogInkContextStatus(current, 'worktree', 'loading'))
+    const worktree = await safe(getWorktreeOverview(git))
+
+    setContext((current) => ({
+      ...current,
+      worktree,
+    }))
+    setContextStatus((current) => updateLogInkContextStatus(current, 'worktree', 'ready'))
+  }, [git])
+
+  React.useEffect(() => {
+    let active = true
+
+    async function loadWorktreeHunks(): Promise<void> {
+      if (state.activeView !== 'diff' || !selectedWorktreeFile) {
+        setWorktreeHunks(undefined)
+        setWorktreeHunksLoading(false)
+        return
+      }
+
+      setWorktreeHunksLoading(true)
+      const nextHunks = await safe(getWorktreeHunks(git, selectedWorktreeFile))
+
+      if (active) {
+        setWorktreeHunks(nextHunks)
+        setWorktreeHunksLoading(false)
+      }
+    }
+
+    void loadWorktreeHunks()
+
+    return () => {
+      active = false
+    }
+  }, [
+    git,
+    selectedWorktreeFile?.indexStatus,
+    selectedWorktreeFile?.path,
+    selectedWorktreeFile?.worktreeStatus,
+    state.activeView,
+  ])
 
   React.useEffect(() => {
     let active = true
@@ -546,6 +601,92 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     selectedWorktreeFile?.worktreeStatus,
     state.activeView,
   ])
+
+  const toggleSelectedFileStage = React.useCallback(async () => {
+    if (!selectedWorktreeFile) {
+      dispatch({ type: 'setStatus', value: 'no worktree file selected' })
+      return
+    }
+
+    dispatch({ type: 'setStatus', value: 'updating file stage state' })
+    const result = selectedWorktreeFile.state === 'staged'
+      ? await unstageFile(git, selectedWorktreeFile)
+      : await stageFile(git, selectedWorktreeFile)
+
+    dispatch({ type: 'setStatus', value: result.message })
+    await refreshWorktreeContext()
+    setWorktreeDiff(undefined)
+    setWorktreeHunks(undefined)
+  }, [dispatch, git, refreshWorktreeContext, selectedWorktreeFile])
+
+  const toggleSelectedHunkStage = React.useCallback(async () => {
+    const selectedHunk = worktreeHunks?.hunks[state.selectedWorktreeHunkIndex]
+
+    if (!selectedHunk) {
+      dispatch({ type: 'setStatus', value: 'no hunk selected' })
+      return
+    }
+
+    dispatch({ type: 'setStatus', value: 'updating hunk stage state' })
+    try {
+      if (selectedHunk.state === 'staged') {
+        await unstageHunk(git, selectedHunk)
+      } else {
+        await stageHunk(git, selectedHunk)
+      }
+
+      dispatch({
+        type: 'setStatus',
+        value: `${selectedHunk.state === 'staged' ? 'Unstaged' : 'Staged'} hunk`,
+      })
+      await refreshWorktreeContext()
+      setWorktreeDiff(undefined)
+      setWorktreeHunks(undefined)
+    } catch (error) {
+      dispatch({
+        type: 'setStatus',
+        value: (error as Error).message || 'failed to update hunk stage state',
+      })
+    }
+  }, [dispatch, git, refreshWorktreeContext, state.selectedWorktreeHunkIndex, worktreeHunks])
+
+  const revertSelectedFile = React.useCallback(async () => {
+    if (!selectedWorktreeFile) {
+      dispatch({ type: 'setStatus', value: 'no worktree file selected' })
+      return
+    }
+
+    dispatch({ type: 'setStatus', value: 'reverting selected file' })
+    const result = await revertFile(git, selectedWorktreeFile)
+
+    dispatch({ type: 'setStatus', value: result.message })
+    await refreshWorktreeContext()
+    setWorktreeDiff(undefined)
+    setWorktreeHunks(undefined)
+  }, [dispatch, git, refreshWorktreeContext, selectedWorktreeFile])
+
+  const revertSelectedHunk = React.useCallback(async () => {
+    const selectedHunk = worktreeHunks?.hunks[state.selectedWorktreeHunkIndex]
+
+    if (!selectedHunk) {
+      dispatch({ type: 'setStatus', value: 'no hunk selected' })
+      return
+    }
+
+    dispatch({ type: 'setStatus', value: 'reverting selected hunk' })
+    try {
+      await revertHunk(git, selectedHunk)
+      dispatch({ type: 'setStatus', value: `Reverted hunk in ${selectedHunk.filePath}` })
+      await refreshWorktreeContext()
+      setWorktreeDiff(undefined)
+      setWorktreeHunks(undefined)
+    } catch (error) {
+      dispatch({
+        type: 'setStatus',
+        value: (error as Error).message || 'failed to revert hunk',
+      })
+    }
+  }, [dispatch, git, refreshWorktreeContext, state.selectedWorktreeHunkIndex, worktreeHunks])
 
   React.useEffect(() => {
     let active = true
@@ -657,6 +798,14 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         exit()
       } else if (event.type === 'refreshContext') {
         void refreshContext()
+      } else if (event.type === 'toggleSelectedFileStage') {
+        void toggleSelectedFileStage()
+      } else if (event.type === 'toggleSelectedHunkStage') {
+        void toggleSelectedHunkStage()
+      } else if (event.type === 'revertSelectedFile') {
+        void revertSelectedFile()
+      } else if (event.type === 'revertSelectedHunk') {
+        void revertSelectedHunk()
       } else {
         dispatch(event.action)
       }
@@ -688,6 +837,8 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         contextStatus,
         worktreeDiff,
         worktreeDiffLoading,
+        worktreeHunks,
+        worktreeHunksLoading,
         layout.bodyRows,
         theme,
         hasMoreCommits,
@@ -782,6 +933,8 @@ function renderMainPanel(
   contextStatus: LogInkContextStatus,
   worktreeDiff: WorktreeFileDiff | undefined,
   worktreeDiffLoading: boolean,
+  worktreeHunks: WorktreeHunkOverview | undefined,
+  worktreeHunksLoading: boolean,
   bodyRows: number,
   theme: LogInkTheme,
   hasMoreCommits: boolean,
@@ -800,6 +953,8 @@ function renderMainPanel(
       contextStatus,
       worktreeDiff,
       worktreeDiffLoading,
+      worktreeHunks,
+      worktreeHunksLoading,
       bodyRows,
       theme
     )
@@ -918,6 +1073,8 @@ function renderDiffSurface(
   contextStatus: LogInkContextStatus,
   worktreeDiff: WorktreeFileDiff | undefined,
   worktreeDiffLoading: boolean,
+  worktreeHunks: WorktreeHunkOverview | undefined,
+  worktreeHunksLoading: boolean,
   bodyRows: number,
   theme: LogInkTheme
 ): ReactTypes.ReactElement {
@@ -927,6 +1084,7 @@ function renderDiffSurface(
   const selectedFile = worktree?.files[state.selectedWorktreeFileIndex]
   const visibleRows = Math.max(4, bodyRows - 4)
   const diffLines = worktreeDiff?.lines || []
+  const selectedHunk = worktreeHunks?.hunks[state.selectedWorktreeHunkIndex]
   const visibleDiffLines = diffLines.slice(
     state.worktreeDiffOffset,
     state.worktreeDiffOffset + visibleRows
@@ -938,6 +1096,11 @@ function renderDiffSurface(
       : selectedFile
       ? [
         `Selected file: ${selectedFile.path}`,
+        worktreeHunksLoading
+          ? 'Hunks loading...'
+          : worktreeHunks?.hunks.length
+            ? `Hunk ${state.selectedWorktreeHunkIndex + 1}/${worktreeHunks.hunks.length} ${selectedHunk?.state || ''}`
+            : 'No stageable hunks for this file.',
         `Lines ${Math.min(state.worktreeDiffOffset + 1, diffLines.length || 1)}-${Math.min(state.worktreeDiffOffset + visibleDiffLines.length, diffLines.length)}/${diffLines.length}`,
         '',
         ...visibleDiffLines,
@@ -985,7 +1148,7 @@ function renderDetailPanel(
     return renderCommandPalette(h, components, width, theme, focused)
   }
 
-  if (state.pendingConfirmationId) {
+  if (state.pendingConfirmationId || state.pendingMutationConfirmation) {
     return renderConfirmationPanel(h, components, state, width, theme, focused)
   }
 
@@ -1065,8 +1228,15 @@ function renderConfirmationPanel(
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const action = getLogInkWorkflowActionById(state.pendingConfirmationId)
-  const label = action?.label || 'Workflow action'
-  const warning = action?.kind === 'ai'
+  const mutationLabel = state.pendingMutationConfirmation === 'revert-hunk'
+    ? 'Revert selected hunk'
+    : state.pendingMutationConfirmation === 'revert-file'
+      ? 'Revert selected file'
+      : undefined
+  const label = action?.label || mutationLabel || 'Workflow action'
+  const warning = state.pendingMutationConfirmation
+    ? 'This discards local changes and cannot be undone by Coco.'
+    : action?.kind === 'ai'
     ? `AI action requires confirmation. Estimated ${action.estimatedTokens || '<unknown>'} tokens.`
     : 'Destructive Git action requires confirmation.'
 

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -55,6 +55,7 @@ describe('log Ink view model', () => {
     expect(state.sidebarTab).toBe('status')
     expect(state.showHelp).toBe(false)
     expect(state.showCommandPalette).toBe(false)
+    expect(state.pendingMutationConfirmation).toBeUndefined()
   })
 
   it('supports workstation surface selection', () => {
@@ -214,9 +215,11 @@ describe('log Ink view model', () => {
       hunkOffsets: [3, 12],
     })
     expect(state.worktreeDiffOffset).toBe(12)
+    expect(state.selectedWorktreeHunkIndex).toBe(1)
 
     state = applyLogInkAction(state, { type: 'setActiveView', value: 'status' })
     expect(state.worktreeDiffOffset).toBe(0)
+    expect(state.selectedWorktreeHunkIndex).toBe(0)
   })
 
   it('toggles graph, help, and command palette overlays', () => {
@@ -244,5 +247,15 @@ describe('log Ink view model', () => {
 
     state = applyLogInkAction(state, { type: 'setPendingConfirmation', value: undefined })
     expect(state.pendingConfirmationId).toBeUndefined()
+
+    state = applyLogInkAction(state, {
+      type: 'setPendingMutationConfirmation',
+      value: 'revert-file',
+    })
+    expect(state.pendingMutationConfirmation).toBe('revert-file')
+    expect(state.pendingConfirmationId).toBeUndefined()
+
+    state = applyLogInkAction(state, { type: 'setPendingMutationConfirmation', value: undefined })
+    expect(state.pendingMutationConfirmation).toBeUndefined()
   })
 })

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -4,6 +4,7 @@ export type LogInkFocus = 'sidebar' | 'commits' | 'detail'
 
 export type LogInkSidebarTab = 'status' | 'branches' | 'tags' | 'stashes' | 'worktrees'
 export type LogInkView = 'history' | 'status' | 'diff'
+export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk'
 
 export type CreateLogInkStateOptions = {
   activeView?: LogInkView
@@ -17,6 +18,7 @@ export type LogInkState = {
   selectedIndex: number
   selectedFileIndex: number
   selectedWorktreeFileIndex: number
+  selectedWorktreeHunkIndex: number
   diffPreviewOffset: number
   worktreeDiffOffset: number
   filter: string
@@ -26,6 +28,7 @@ export type LogInkState = {
   showCommandPalette: boolean
   workflowActionId?: string
   pendingConfirmationId?: string
+  pendingMutationConfirmation?: LogInkMutationConfirmation
   pendingKey?: string
   focus: LogInkFocus
   sidebarTab: LogInkSidebarTab
@@ -58,6 +61,7 @@ export type LogInkAction =
   | { type: 'setStatus'; value?: string }
   | { type: 'setWorkflowAction'; value?: string }
   | { type: 'setPendingConfirmation'; value?: string }
+  | { type: 'setPendingMutationConfirmation'; value?: LogInkMutationConfirmation }
   | { type: 'toggleFilterMode' }
   | { type: 'toggleGraph' }
   | { type: 'toggleHelp' }
@@ -233,6 +237,12 @@ function nextHunkOffset(currentOffset: number, hunkOffsets: number[], delta: num
     hunkOffsets[0]
 }
 
+function nextHunkIndex(currentOffset: number, hunkOffsets: number[], delta: number): number {
+  const offset = nextHunkOffset(currentOffset, hunkOffsets, delta)
+
+  return Math.max(0, hunkOffsets.indexOf(offset))
+}
+
 export function getLogInkSidebarTabs(): LogInkSidebarTab[] {
   return [...SIDEBAR_TABS]
 }
@@ -251,6 +261,7 @@ export function createLogInkState(
     selectedIndex: 0,
     selectedFileIndex: 0,
     selectedWorktreeFileIndex: 0,
+    selectedWorktreeHunkIndex: 0,
     diffPreviewOffset: 0,
     worktreeDiffOffset: 0,
     filter: '',
@@ -260,6 +271,7 @@ export function createLogInkState(
     showCommandPalette: false,
     workflowActionId: undefined,
     pendingConfirmationId: undefined,
+    pendingMutationConfirmation: undefined,
     pendingKey: undefined,
     focus: 'commits',
     sidebarTab: 'status',
@@ -318,6 +330,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
           state.selectedWorktreeFileIndex + action.delta,
           action.fileCount
         ),
+        selectedWorktreeHunkIndex: 0,
         worktreeDiffOffset: 0,
         pendingKey: undefined,
       }
@@ -374,6 +387,11 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
           action.hunkOffsets,
           action.delta
         ),
+        selectedWorktreeHunkIndex: nextHunkIndex(
+          state.worktreeDiffOffset,
+          action.hunkOffsets,
+          action.delta
+        ),
         pendingKey: undefined,
       }
     case 'previousSidebarTab':
@@ -389,6 +407,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         ...state,
         activeView: action.value,
         worktreeDiffOffset: action.value === 'diff' ? state.worktreeDiffOffset : 0,
+        selectedWorktreeHunkIndex: action.value === 'diff' ? state.selectedWorktreeHunkIndex : 0,
         pendingKey: undefined,
       }
     case 'setFocus':
@@ -420,12 +439,22 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         ...state,
         workflowActionId: action.value,
         pendingConfirmationId: undefined,
+        pendingMutationConfirmation: undefined,
         pendingKey: undefined,
       }
     case 'setPendingConfirmation':
       return {
         ...state,
         pendingConfirmationId: action.value,
+        workflowActionId: action.value ? undefined : state.workflowActionId,
+        pendingMutationConfirmation: action.value ? undefined : state.pendingMutationConfirmation,
+        pendingKey: undefined,
+      }
+    case 'setPendingMutationConfirmation':
+      return {
+        ...state,
+        pendingMutationConfirmation: action.value,
+        pendingConfirmationId: action.value ? undefined : state.pendingConfirmationId,
         workflowActionId: action.value ? undefined : state.workflowActionId,
         pendingKey: undefined,
       }


### PR DESCRIPTION
## Summary
- wire Space in status and diff views to stage or unstage the selected file/hunk
- add confirmation-gated z/y/n revert flows for selected files and hunks
- refresh worktree context and clear stale diff/hunk state after mutations
- surface file/hunk mutation controls through the shared Ink keymap and footer hints

Closes #728
Refs #724

## Validation
- npm run test:jest -- src/commands/log/inkInput.test.ts src/commands/log/inkViewModel.test.ts src/commands/log/inkKeymap.test.ts src/commands/log/worktreeDiffData.test.ts src/commands/log/statusActions.test.ts src/commands/log/statusHunks.test.ts
- npm run lint
- npm run build
- npm test