### PR TITLE
Add coco ui commit compose

### DIFF
--- a/src/commands/log/commitCompose.test.ts
+++ b/src/commands/log/commitCompose.test.ts
@@ -1,0 +1,99 @@
+import { createCommit, PreCommitHookError } from '../../lib/simple-git/createCommit'
+import {
+  applyCommitComposeAction,
+  createCommitComposeState,
+  createManualCommit,
+  formatCommitComposeMessage,
+  splitCommitDraft,
+} from './commitCompose'
+
+jest.mock('../../lib/simple-git/createCommit', () => ({
+  createCommit: jest.fn(),
+  PreCommitHookError: class PreCommitHookError extends Error {
+    readonly hookOutput: string
+
+    constructor(hookOutput: string) {
+      super('Pre-commit hook failed')
+      this.name = 'PreCommitHookError'
+      this.hookOutput = hookOutput
+    }
+  },
+}))
+
+const mockedCreateCommit = createCommit as jest.MockedFunction<typeof createCommit>
+const git = {} as Parameters<typeof createCommit>[1]
+
+describe('log commit compose state', () => {
+  beforeEach(() => {
+    mockedCreateCommit.mockReset()
+  })
+
+  it('edits summary and body fields predictably', () => {
+    let state = createCommitComposeState({ editing: true })
+
+    state = applyCommitComposeAction(state, { type: 'append', value: 'feat' })
+    expect(state.summary).toBe('feat')
+
+    state = applyCommitComposeAction(state, { type: 'toggleField' })
+    state = applyCommitComposeAction(state, { type: 'append', value: 'Body' })
+    expect(state.body).toBe('Body')
+
+    state = applyCommitComposeAction(state, { type: 'backspace' })
+    expect(state.body).toBe('Bod')
+  })
+
+  it('splits AI drafts into editable summary and body fields', () => {
+    expect(splitCommitDraft('feat: add ui\n\nBody line one\nBody line two')).toEqual({
+      summary: 'feat: add ui',
+      body: 'Body line one\nBody line two',
+    })
+
+    const state = applyCommitComposeAction(createCommitComposeState(), {
+      type: 'setDraft',
+      value: 'fix: generated draft\n\nDetails.',
+    })
+
+    expect(state.summary).toBe('fix: generated draft')
+    expect(state.body).toBe('Details.')
+    expect(state.editing).toBe(true)
+  })
+
+  it('formats and creates manual commits from staged drafts', async () => {
+    mockedCreateCommit.mockResolvedValue({ commit: 'abc1234' } as Awaited<ReturnType<typeof createCommit>>)
+
+    await expect(createManualCommit({
+      git,
+      summary: 'feat: add commit box',
+      body: 'Adds manual compose support.',
+    })).resolves.toEqual({
+      ok: true,
+      message: 'Created commit abc1234',
+    })
+
+    expect(formatCommitComposeMessage('feat: add commit box', 'Adds manual compose support.')).toBe(
+      'feat: add commit box\n\nAdds manual compose support.'
+    )
+    expect(mockedCreateCommit).toHaveBeenCalledWith(
+      'feat: add commit box\n\nAdds manual compose support.',
+      git,
+      undefined,
+      { noVerify: false }
+    )
+  })
+
+  it('returns hook failures as commit box feedback', async () => {
+    mockedCreateCommit.mockRejectedValue(new PreCommitHookError([
+      'eslint failed',
+      'src/file.ts:1:1 error',
+    ].join('\n')))
+
+    await expect(createManualCommit({
+      git,
+      summary: 'fix: blocked',
+    })).resolves.toEqual({
+      ok: false,
+      message: 'Commit blocked by hook: eslint failed',
+      details: ['src/file.ts:1:1 error'],
+    })
+  })
+})

--- a/src/commands/log/commitCompose.ts
+++ b/src/commands/log/commitCompose.ts
@@ -1,0 +1,200 @@
+import { SimpleGit } from 'simple-git'
+import { createCommit, PreCommitHookError } from '../../lib/simple-git/createCommit'
+
+export type CommitComposeField = 'summary' | 'body'
+
+export type CommitComposeState = {
+  summary: string
+  body: string
+  field: CommitComposeField
+  editing: boolean
+  loading: boolean
+  message?: string
+  details?: string[]
+}
+
+export type CommitComposeAction =
+  | { type: 'append'; value: string }
+  | { type: 'backspace' }
+  | { type: 'clearField' }
+  | { type: 'setField'; value: CommitComposeField }
+  | { type: 'toggleField' }
+  | { type: 'setEditing'; value: boolean }
+  | { type: 'setLoading'; value: boolean }
+  | { type: 'setDraft'; value: string }
+  | { type: 'setResult'; message?: string; details?: string[] }
+  | { type: 'reset' }
+
+export type ManualCommitResult = {
+  ok: boolean
+  message: string
+  details?: string[]
+}
+
+export type CreateManualCommitInput = {
+  git: SimpleGit
+  summary: string
+  body?: string
+  noVerify?: boolean
+}
+
+export function createCommitComposeState(
+  input: Partial<CommitComposeState> = {}
+): CommitComposeState {
+  return {
+    summary: '',
+    body: '',
+    field: 'summary',
+    editing: false,
+    loading: false,
+    message: undefined,
+    details: undefined,
+    ...input,
+  }
+}
+
+function activeFieldValue(state: CommitComposeState): string {
+  return state.field === 'summary' ? state.summary : state.body
+}
+
+function withActiveField(state: CommitComposeState, value: string): CommitComposeState {
+  return state.field === 'summary'
+    ? { ...state, summary: value }
+    : { ...state, body: value }
+}
+
+export function applyCommitComposeAction(
+  state: CommitComposeState,
+  action: CommitComposeAction
+): CommitComposeState {
+  switch (action.type) {
+    case 'append':
+      return withActiveField(state, `${activeFieldValue(state)}${action.value}`)
+    case 'backspace':
+      return withActiveField(state, activeFieldValue(state).slice(0, -1))
+    case 'clearField':
+      return withActiveField(state, '')
+    case 'setField':
+      return {
+        ...state,
+        field: action.value,
+      }
+    case 'toggleField':
+      return {
+        ...state,
+        field: state.field === 'summary' ? 'body' : 'summary',
+      }
+    case 'setEditing':
+      return {
+        ...state,
+        editing: action.value,
+      }
+    case 'setLoading':
+      return {
+        ...state,
+        loading: action.value,
+      }
+    case 'setDraft':
+      return {
+        ...state,
+        ...splitCommitDraft(action.value),
+        field: 'summary',
+        editing: true,
+        loading: false,
+        message: 'AI draft ready for editing',
+        details: undefined,
+      }
+    case 'setResult':
+      return {
+        ...state,
+        loading: false,
+        message: action.message,
+        details: action.details,
+      }
+    case 'reset':
+      return createCommitComposeState({
+        message: state.message,
+        details: state.details,
+      })
+    default:
+      return state
+  }
+}
+
+export function formatCommitComposeMessage(summary: string, body?: string): string {
+  const trimmedSummary = summary.trim()
+  const trimmedBody = body?.trim()
+
+  return trimmedBody ? `${trimmedSummary}\n\n${trimmedBody}` : trimmedSummary
+}
+
+export function splitCommitDraft(draft: string): Pick<CommitComposeState, 'summary' | 'body'> {
+  const lines = draft
+    .split('\n')
+    .map((line) => line.trimEnd())
+  const summary = lines.find((line) => line.trim())?.trim() || ''
+  const summaryIndex = lines.findIndex((line) => line.trim())
+  const body = summaryIndex >= 0
+    ? lines.slice(summaryIndex + 1).join('\n').trim()
+    : ''
+
+  return {
+    summary,
+    body,
+  }
+}
+
+function compactOutputLines(output: string): string[] {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+function formatManualCommitFailure(error: unknown): ManualCommitResult {
+  if (error instanceof PreCommitHookError) {
+    const details = compactOutputLines(error.hookOutput)
+
+    return {
+      ok: false,
+      message: `Commit blocked by hook: ${details[0] || 'hook failed'}`,
+      details: details.slice(1, 6),
+    }
+  }
+
+  const details = compactOutputLines((error as Error).message)
+
+  return {
+    ok: false,
+    message: details[0] || 'Commit failed.',
+    details: details.slice(1, 6),
+  }
+}
+
+export async function createManualCommit({
+  git,
+  summary,
+  body,
+  noVerify = false,
+}: CreateManualCommitInput): Promise<ManualCommitResult> {
+  const message = formatCommitComposeMessage(summary, body)
+
+  if (!message) {
+    return {
+      ok: false,
+      message: 'Commit summary is required.',
+    }
+  }
+
+  try {
+    const result = await createCommit(message, git, undefined, { noVerify })
+    const hash = result.commit
+
+    return {
+      ok: true,
+      message: hash ? `Created commit ${hash}` : 'Created commit.',
+    }
+  } catch (error) {
+    return formatManualCommitFailure(error)
+  }
+}

--- a/src/commands/log/commitWorkflowActions.test.ts
+++ b/src/commands/log/commitWorkflowActions.test.ts
@@ -1,6 +1,10 @@
 import { handler as commitHandler } from '../commit/handler'
 import { createCommit } from '../../lib/simple-git/createCommit'
-import { commitWorkflowTestInternals, runCommitWorkflow } from './commitWorkflowActions'
+import {
+  commitWorkflowTestInternals,
+  runCommitDraftWorkflow,
+  runCommitWorkflow,
+} from './commitWorkflowActions'
 
 jest.mock('../commit/handler', () => ({
   handler: jest.fn(),
@@ -80,6 +84,19 @@ describe('log commit workflow actions', () => {
       }),
       expect.anything()
     )
+  })
+
+  it('generates commit drafts without creating commits', async () => {
+    mockedCommitHandler.mockImplementation(async () => {
+      process.stdout.write('feat: draft message\n\nDraft body.\n')
+    })
+
+    await expect(runCommitDraftWorkflow()).resolves.toEqual({
+      ok: true,
+      message: 'feat: draft message',
+      draft: 'feat: draft message\n\nDraft body.',
+    })
+    expect(mockedCreateCommit).not.toHaveBeenCalled()
   })
 
   it('passes no-verify into TUI commit workflows', async () => {

--- a/src/commands/log/commitWorkflowActions.ts
+++ b/src/commands/log/commitWorkflowActions.ts
@@ -14,6 +14,7 @@ export type CommitWorkflowResult = {
   ok: boolean
   message: string
   details?: string[]
+  draft?: string
 }
 
 type CommitWorkflowInput = {
@@ -143,6 +144,48 @@ export async function runCommitWorkflow({
         ok: error.code === 0,
         message: lines[0] || error.message,
         details: lines.slice(1, 6),
+      }
+    }
+
+    return formatCommitFailure(error)
+  } finally {
+    process.stdout.write = originalWrite
+  }
+}
+
+export async function runCommitDraftWorkflow(): Promise<CommitWorkflowResult> {
+  const argv = createCommitWorkflowArgv('commit')
+  const logger = new Logger({ silent: true })
+  const originalWrite = process.stdout.write.bind(process.stdout)
+  let output = ''
+
+  process.stdout.write = ((chunk: string | Uint8Array, ...args: unknown[]) => {
+    output += typeof chunk === 'string' ? chunk : chunk.toString()
+
+    const callback = args.find((arg): arg is (error?: Error | null) => void => typeof arg === 'function')
+    callback?.()
+
+    return true
+  }) as typeof process.stdout.write
+
+  try {
+    await commitHandler(argv, logger)
+    const draft = output.trim()
+
+    return {
+      ok: Boolean(draft),
+      message: draft ? formatCommitWorkflowMessage('commit', draft) : 'AI draft was empty.',
+      draft,
+    }
+  } catch (error) {
+    if (isCommandExitError(error)) {
+      const lines = compactOutputLines(output || error.message)
+
+      return {
+        ok: error.code === 0,
+        message: lines[0] || error.message,
+        details: lines.slice(1, 6),
+        draft: output.trim(),
       }
     }
 

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -259,6 +259,30 @@ describe('log Ink input interactions', () => {
     ])
   })
 
+  it('edits commit compose fields and emits commit events', () => {
+    let state = createLogInkState(rows, { activeView: 'status' })
+
+    state = applyInput(state, 'e')
+    expect(state.commitCompose.editing).toBe(true)
+
+    state = applyInput(state, 'f')
+    state = applyInput(state, 'e')
+    state = applyInput(state, 'a')
+    state = applyInput(state, 't')
+    expect(state.commitCompose.summary).toBe('feat')
+
+    state = applyInput(state, '', { return: true })
+    expect(state.commitCompose.field).toBe('body')
+
+    state = applyInput(state, 'body')
+    expect(state.commitCompose.body).toBe('body')
+
+    state = applyInput(state, '', { escape: true })
+    expect(state.commitCompose.editing).toBe(false)
+
+    expect(getLogInkInputEvents(state, 'c')).toEqual([{ type: 'createManualCommit' }])
+  })
+
   it('clears pending key chords after unrelated actions', () => {
     let state = createLogInkState(rows)
 
@@ -289,8 +313,12 @@ describe('log Ink input interactions', () => {
     state = applyInput(state, 'I')
     expect(state.pendingConfirmationId).toBe('ai-commit-summary')
 
-    state = applyInput(state, 'y')
-    expect(state.pendingConfirmationId).toBeUndefined()
-    expect(state.statusMessage).toBe('AI commit summary queued for workflow execution')
+    expect(getLogInkInputEvents(state, 'y')).toEqual([
+      { type: 'runAiCommitDraft' },
+      {
+        type: 'action',
+        action: { type: 'setPendingConfirmation', value: undefined },
+      },
+    ])
   })
 })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -27,6 +27,8 @@ export type LogInkInputEvent =
   | { type: 'toggleSelectedHunkStage' }
   | { type: 'revertSelectedFile' }
   | { type: 'revertSelectedHunk' }
+  | { type: 'createManualCommit' }
+  | { type: 'runAiCommitDraft' }
 
 export type LogInkInputContext = {
   detailFileCount?: number
@@ -61,6 +63,41 @@ export function getLogInkInputEvents(
     return [{ type: 'exit' }]
   }
 
+  if (state.commitCompose.editing) {
+    if (key.escape) {
+      return [action({ type: 'commitCompose', action: { type: 'setEditing', value: false } })]
+    }
+
+    if (key.tab) {
+      return [action({ type: 'commitCompose', action: { type: 'toggleField' } })]
+    }
+
+    if (key.return) {
+      return [
+        action({
+          type: 'commitCompose',
+          action: state.commitCompose.field === 'summary'
+            ? { type: 'setField', value: 'body' }
+            : { type: 'setEditing', value: false },
+        }),
+      ]
+    }
+
+    if (key.backspace || key.delete) {
+      return [action({ type: 'commitCompose', action: { type: 'backspace' } })]
+    }
+
+    if (key.ctrl && inputValue === 'u') {
+      return [action({ type: 'commitCompose', action: { type: 'clearField' } })]
+    }
+
+    if (inputValue && !key.ctrl && !key.meta) {
+      return [action({ type: 'commitCompose', action: { type: 'append', value: inputValue } })]
+    }
+
+    return []
+  }
+
   if (state.filterMode) {
     if (key.return || key.escape) {
       return [action({ type: 'toggleFilterMode' })]
@@ -84,6 +121,13 @@ export function getLogInkInputEvents(
   if (state.pendingConfirmationId) {
     if (inputValue === 'y') {
       const workflowAction = getLogInkWorkflowActionById(state.pendingConfirmationId)
+
+      if (workflowAction?.id === 'ai-commit-summary') {
+        return [
+          { type: 'runAiCommitDraft' },
+          action({ type: 'setPendingConfirmation', value: undefined }),
+        ]
+      }
 
       return [
         action({ type: 'setPendingConfirmation', value: undefined }),
@@ -317,6 +361,14 @@ export function getLogInkInputEvents(
 
   if (inputValue === 'z' && state.activeView === 'diff' && context.worktreeHunkOffsets?.length) {
     return [action({ type: 'setPendingMutationConfirmation', value: 'revert-hunk' })]
+  }
+
+  if (inputValue === 'e' && (state.activeView === 'status' || state.activeView === 'diff')) {
+    return [action({ type: 'commitCompose', action: { type: 'setEditing', value: true } })]
+  }
+
+  if (inputValue === 'c' && (state.activeView === 'status' || state.activeView === 'diff')) {
+    return [{ type: 'createManualCommit' }]
   }
 
   const workflowAction = getLogInkWorkflowActionByKey(inputValue)

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -31,14 +31,14 @@ describe('log Ink keymap', () => {
       filterMode: false,
       focus: 'commits',
       showHelp: false,
-    })).toEqual(['↑/↓ files', 'enter diff', 'space stage', 'z revert', '? help'])
+    })).toEqual(['↑/↓ files', 'enter diff', 'space stage', 'z revert', 'e/c compose'])
 
     expect(getLogInkFooterHints({
       activeView: 'diff',
       filterMode: false,
       focus: 'commits',
       showHelp: false,
-    })).toEqual(['j/k hunks', 'space stage', 'z revert', 'esc files', '? help'])
+    })).toEqual(['j/k hunks', 'space stage', 'z revert', 'e/c compose', 'esc files'])
 
     expect(getLogInkFooterHints({
       filterMode: false,
@@ -60,6 +60,8 @@ describe('log Ink keymap', () => {
     expect(helpText).toContain('G Jump to the last visible commit.')
     expect(helpText).toContain('[ Move to the previous repository sidebar tab.')
     expect(helpText).toContain('z Ask to revert the selected file or hunk.')
+    expect(helpText).toContain('e Edit the manual commit summary or body.')
+    expect(helpText).toContain('c Create a commit from staged changes with the current draft.')
     expect(helpText).toContain('q/ctrl+c Quit the interactive log.')
     expect(helpText).toContain('tab Move focus to the next panel.')
   })

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -3,6 +3,8 @@ import { LogInkFocus, LogInkView } from './inkViewModel'
 export type LogInkCommandId =
   | 'clearSearch'
   | 'commandPalette'
+  | 'commit'
+  | 'editCommit'
   | 'focusNext'
   | 'focusPrevious'
   | 'help'
@@ -164,6 +166,20 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     contexts: ['commits'],
   },
   {
+    id: 'editCommit',
+    keys: ['e'],
+    label: 'edit commit',
+    description: 'Edit the manual commit summary or body.',
+    contexts: ['commits'],
+  },
+  {
+    id: 'commit',
+    keys: ['c'],
+    label: 'commit',
+    description: 'Create a commit from staged changes with the current draft.',
+    contexts: ['commits'],
+  },
+  {
     id: 'help',
     keys: ['?'],
     label: 'help',
@@ -227,11 +243,11 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): stri
   }
 
   if (options.activeView === 'status') {
-    return ['↑/↓ files', 'enter diff', 'space stage', 'z revert', '? help']
+    return ['↑/↓ files', 'enter diff', 'space stage', 'z revert', 'e/c compose']
   }
 
   if (options.activeView === 'diff') {
-    return ['j/k hunks', 'space stage', 'z revert', 'esc files', '? help']
+    return ['j/k hunks', 'space stage', 'z revert', 'e/c compose', 'esc files']
   }
 
   return ['↑/↓ move', '/ search', 'gg/G top/bottom', 'n/N next', '? help']
@@ -262,6 +278,12 @@ export function getLogInkHelpSections(): LogInkHelpSection[] {
       title: 'Browsing',
       bindings: LOG_INK_KEY_BINDINGS.filter((binding) =>
         ['search', 'clearSearch', 'toggleGraph', 'refresh', 'revertSelection'].includes(binding.id)
+      ),
+    },
+    {
+      title: 'Commit',
+      bindings: LOG_INK_KEY_BINDINGS.filter((binding) =>
+        ['editCommit', 'commit'].includes(binding.id)
       ),
     },
     {

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -1,6 +1,8 @@
 import type * as ReactTypes from 'react'
 import { SimpleGit } from 'simple-git'
 import { BranchOverview, getBranchOverview } from './branchData'
+import { createManualCommit } from './commitCompose'
+import { runCommitDraftWorkflow } from './commitWorkflowActions'
 import {
   GitCommitDetail,
   GitCommitFilePreview,
@@ -688,6 +690,59 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
   }, [dispatch, git, refreshWorktreeContext, state.selectedWorktreeHunkIndex, worktreeHunks])
 
+  const createCommitFromCompose = React.useCallback(async () => {
+    const stagedCount = context.worktree?.stagedCount || 0
+
+    if (!stagedCount) {
+      dispatch({ type: 'setStatus', value: 'stage changes before committing' })
+      return
+    }
+
+    dispatch({ type: 'commitCompose', action: { type: 'setLoading', value: true } })
+    dispatch({ type: 'setStatus', value: 'creating commit' })
+    const result = await createManualCommit({
+      git,
+      summary: state.commitCompose.summary,
+      body: state.commitCompose.body,
+    })
+
+    dispatch({
+      type: 'commitCompose',
+      action: { type: 'setResult', message: result.message, details: result.details },
+    })
+    dispatch({ type: 'setStatus', value: result.message })
+
+    if (result.ok) {
+      dispatch({ type: 'commitCompose', action: { type: 'reset' } })
+      await refreshWorktreeContext()
+    }
+  }, [
+    context.worktree?.stagedCount,
+    dispatch,
+    git,
+    refreshWorktreeContext,
+    state.commitCompose.body,
+    state.commitCompose.summary,
+  ])
+
+  const runAiCommitDraft = React.useCallback(async () => {
+    dispatch({ type: 'commitCompose', action: { type: 'setLoading', value: true } })
+    dispatch({ type: 'setStatus', value: 'generating AI commit draft' })
+    const result = await runCommitDraftWorkflow()
+
+    if (result.ok && result.draft) {
+      dispatch({ type: 'commitCompose', action: { type: 'setDraft', value: result.draft } })
+      dispatch({ type: 'setStatus', value: 'AI draft ready for editing' })
+      return
+    }
+
+    dispatch({
+      type: 'commitCompose',
+      action: { type: 'setResult', message: result.message, details: result.details },
+    })
+    dispatch({ type: 'setStatus', value: result.message })
+  }, [dispatch])
+
   React.useEffect(() => {
     let active = true
 
@@ -806,6 +861,10 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         void revertSelectedFile()
       } else if (event.type === 'revertSelectedHunk') {
         void revertSelectedHunk()
+      } else if (event.type === 'createManualCommit') {
+        void createCommitFromCompose()
+      } else if (event.type === 'runAiCommitDraft') {
+        void runAiCommitDraft()
       } else {
         dispatch(event.action)
       }
@@ -960,7 +1019,7 @@ function renderMainPanel(
     )
   }
 
-  return renderCommitPanel(
+  return renderHistoryPanel(
     h,
     components,
     state,
@@ -971,7 +1030,7 @@ function renderMainPanel(
   )
 }
 
-function renderCommitPanel(
+function renderHistoryPanel(
   h: typeof ReactTypes.createElement,
   components: LogInkComponents,
   state: LogInkState,
@@ -1152,6 +1211,10 @@ function renderDetailPanel(
     return renderConfirmationPanel(h, components, state, width, theme, focused)
   }
 
+  if (state.activeView === 'status' || state.activeView === 'diff') {
+    return renderCommitPanel(h, components, state, context, contextStatus, width, theme, focused)
+  }
+
   const selected = getSelectedInkCommit(state)
   const selectedFile = detail?.files[state.selectedFileIndex]
   const previewWindow = filePreview?.hunks.slice(state.diffPreviewOffset, state.diffPreviewOffset + 8)
@@ -1215,6 +1278,57 @@ function renderDetailPanel(
   ...lines.map((line, index) => h(Text, {
     key: `detail-${index}`,
     dimColor: index > 1 && line !== 'Changed files:',
+  }, truncate(line, width - 4))))
+}
+
+function renderCommitPanel(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  width: number,
+  theme: LogInkTheme,
+  focused: boolean
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const compose = state.commitCompose
+  const loading = compose.loading
+  const stagedCount = context.worktree?.stagedCount || 0
+  const unstagedCount = context.worktree?.unstagedCount || 0
+  const statusLine = isLogInkContextKeyLoading(contextStatus, 'worktree')
+    ? 'Status loading'
+    : `${stagedCount} staged | ${unstagedCount} unstaged`
+  const summaryCursor = compose.editing && compose.field === 'summary' ? '_' : ''
+  const bodyCursor = compose.editing && compose.field === 'body' ? '_' : ''
+  const bodyLines = compose.body ? compose.body.split('\n').slice(0, 4) : ['<empty>']
+  const lines = [
+    statusLine,
+    '',
+    `${compose.field === 'summary' && compose.editing ? '>' : ' '} Summary: ${compose.summary || '<empty>'}${summaryCursor}`,
+    `${compose.field === 'body' && compose.editing ? '>' : ' '} Body:`,
+    ...bodyLines.map((line) => `  ${line}${bodyCursor && line === bodyLines[bodyLines.length - 1] ? bodyCursor : ''}`),
+    '',
+    loading
+      ? 'Working...'
+      : compose.editing
+        ? 'Enter/tab edits fields, Esc exits edit mode.'
+        : 'e edit | c commit | I AI draft',
+    ...(compose.message ? ['', compose.message] : []),
+    ...(compose.details || []).map((line) => `  ${line}`),
+  ]
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    width,
+    paddingX: 1,
+  },
+  h(Text, { bold: true }, panelTitle('Commit', focused)),
+  ...lines.map((line, index) => h(Text, {
+    key: `commit-${index}`,
+    dimColor: index < 2 || line.startsWith('  ') || line === '<empty>',
   }, truncate(line, width - 4))))
 }
 

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -51,6 +51,7 @@ describe('log Ink view model', () => {
     expect(state.selectedWorktreeFileIndex).toBe(0)
     expect(state.diffPreviewOffset).toBe(0)
     expect(state.worktreeDiffOffset).toBe(0)
+    expect(state.commitCompose.summary).toBe('')
     expect(state.focus).toBe('commits')
     expect(state.sidebarTab).toBe('status')
     expect(state.showHelp).toBe(false)
@@ -220,6 +221,22 @@ describe('log Ink view model', () => {
     state = applyLogInkAction(state, { type: 'setActiveView', value: 'status' })
     expect(state.worktreeDiffOffset).toBe(0)
     expect(state.selectedWorktreeHunkIndex).toBe(0)
+  })
+
+  it('stores commit compose state in the shared view model', () => {
+    let state = createLogInkState(rows, { activeView: 'status' })
+
+    state = applyLogInkAction(state, {
+      type: 'commitCompose',
+      action: { type: 'setEditing', value: true },
+    })
+    state = applyLogInkAction(state, {
+      type: 'commitCompose',
+      action: { type: 'append', value: 'feat: compose commit' },
+    })
+
+    expect(state.commitCompose.editing).toBe(true)
+    expect(state.commitCompose.summary).toBe('feat: compose commit')
   })
 
   it('toggles graph, help, and command palette overlays', () => {

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -1,4 +1,10 @@
 import { GitLogCommitRow, GitLogRow, getCommitRows } from './data'
+import {
+  CommitComposeAction,
+  CommitComposeState,
+  applyCommitComposeAction,
+  createCommitComposeState,
+} from './commitCompose'
 
 export type LogInkFocus = 'sidebar' | 'commits' | 'detail'
 
@@ -19,6 +25,7 @@ export type LogInkState = {
   selectedFileIndex: number
   selectedWorktreeFileIndex: number
   selectedWorktreeHunkIndex: number
+  commitCompose: CommitComposeState
   diffPreviewOffset: number
   worktreeDiffOffset: number
   filter: string
@@ -40,6 +47,7 @@ export type LogInkAction =
   | { type: 'appendFilter'; value: string }
   | { type: 'backspaceFilter' }
   | { type: 'clearFilter' }
+  | { type: 'commitCompose'; action: CommitComposeAction }
   | { type: 'focusNext' }
   | { type: 'focusPrevious' }
   | { type: 'move'; delta: number }
@@ -262,6 +270,7 @@ export function createLogInkState(
     selectedFileIndex: 0,
     selectedWorktreeFileIndex: 0,
     selectedWorktreeHunkIndex: 0,
+    commitCompose: createCommitComposeState(),
     diffPreviewOffset: 0,
     worktreeDiffOffset: 0,
     filter: '',
@@ -295,6 +304,12 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         ...state,
         filterMode: false,
       }, '')
+    case 'commitCompose':
+      return {
+        ...state,
+        commitCompose: applyCommitComposeAction(state.commitCompose, action.action),
+        pendingKey: undefined,
+      }
     case 'focusNext':
       return {
         ...state,


### PR DESCRIPTION
## Summary
- add a commit compose model for editable summary/body state and manual commit execution
- render a right-dock Commit panel for status and diff views
- wire e/c keyboard flows for editing and committing staged changes
- make AI commit drafts require the existing explicit confirmation before generating editable text
- add focused coverage for compose state, AI draft transitions, and commit workflow behavior

Closes #729
Refs #724

## Validation
- npm run test:jest -- src/commands/log/commitCompose.test.ts src/commands/log/commitWorkflowActions.test.ts src/commands/log/inkInput.test.ts src/commands/log/inkViewModel.test.ts src/commands/log/inkKeymap.test.ts
- npm run lint
- npm run build
- npm test