### PR TITLE
Improve coco ui history graph fidelity

### DIFF
--- a/src/commands/log/inkHistoryRows.test.ts
+++ b/src/commands/log/inkHistoryRows.test.ts
@@ -1,0 +1,82 @@
+import { GitLogRow } from './data'
+import {
+  formatInkHistoryGraphRow,
+  formatInkRefLabels,
+  getVisibleLogInkHistory,
+} from './inkHistoryRows'
+import { applyLogInkAction, createLogInkState } from './inkViewModel'
+
+const rows: GitLogRow[] = [
+  {
+    type: 'commit',
+    graph: '*   ',
+    shortHash: 'aaa1111',
+    hash: 'aaa111111111',
+    date: '2026-04-30',
+    author: 'Coco',
+    refs: ['HEAD -> main', 'tag: 0.34.0'],
+    message: 'Merge branch feature/history',
+  },
+  {
+    type: 'graph',
+    graph: '|\\  ',
+  },
+  {
+    type: 'commit',
+    graph: '| * ',
+    shortHash: 'bbb2222',
+    hash: 'bbb222222222',
+    date: '2026-04-29',
+    author: 'Coco',
+    refs: ['feature/history-with-a-long-name'],
+    message: 'feat: improve graph fidelity',
+  },
+  {
+    type: 'graph',
+    graph: '|/  ',
+  },
+  {
+    type: 'commit',
+    graph: '*   ',
+    shortHash: 'ccc3333',
+    hash: 'ccc333333333',
+    date: '2026-04-28',
+    author: 'Coco',
+    refs: [],
+    message: 'fix: status view',
+  },
+]
+
+describe('Ink history rows', () => {
+  it('keeps compact mode calm by rendering commits only', () => {
+    const state = createLogInkState(rows)
+    const visible = getVisibleLogInkHistory(state, 5)
+
+    expect(visible.items.map((item) => item.type)).toEqual(['commit', 'commit', 'commit'])
+    expect(visible.graphWidth).toBe(1)
+  })
+
+  it('preserves graph continuation rows in full graph mode', () => {
+    const state = applyLogInkAction(createLogInkState(rows), { type: 'toggleGraph' })
+    const visible = getVisibleLogInkHistory(state, 5)
+
+    expect(visible.items.map((item) => item.type)).toEqual([
+      'commit',
+      'graph',
+      'commit',
+      'graph',
+      'commit',
+    ])
+    expect(visible.graphWidth).toBe(4)
+  })
+
+  it('renders refs as distinct labels without dot truncation', () => {
+    expect(formatInkRefLabels(['HEAD -> main', 'tag: 0.34.0', 'origin/main'])).toBe(
+      ' [HEAD -> main] [tag: 0.34.0] [origin/main]'
+    )
+  })
+
+  it('pads graph rows using the computed graph lane width', () => {
+    expect(formatInkHistoryGraphRow({ type: 'graph', graph: '|/' }, 4)).toBe('|/  ')
+  })
+})

--- a/src/commands/log/inkHistoryRows.ts
+++ b/src/commands/log/inkHistoryRows.ts
@@ -1,0 +1,96 @@
+import { GitLogCommitRow, GitLogGraphRow, GitLogRow } from './data'
+import { LogInkState } from './inkViewModel'
+
+export type LogInkHistoryCommitItem = {
+  type: 'commit'
+  commit: GitLogCommitRow
+  graph: string
+  selected: boolean
+}
+
+export type LogInkHistoryGraphItem = {
+  type: 'graph'
+  graph: string
+}
+
+export type LogInkHistoryItem = LogInkHistoryCommitItem | LogInkHistoryGraphItem
+
+export type VisibleLogInkHistory = {
+  graphWidth: number
+  items: LogInkHistoryItem[]
+}
+
+function clampWindowStart(index: number, count: number, visibleCount: number): number {
+  return Math.max(0, Math.min(index - Math.floor(visibleCount / 2), Math.max(0, count - visibleCount)))
+}
+
+function commitKey(commit: GitLogCommitRow): string {
+  return commit.hash || commit.shortHash
+}
+
+function graphWidth(items: LogInkHistoryItem[]): number {
+  return Math.max(1, ...items.map((item) => item.graph.length))
+}
+
+function toCompactItems(state: LogInkState, visibleCount: number): LogInkHistoryItem[] {
+  const start = clampWindowStart(state.selectedIndex, state.filteredCommits.length, visibleCount)
+
+  return state.filteredCommits.slice(start, start + visibleCount).map((commit, offset) => ({
+    type: 'commit',
+    commit,
+    graph: '*',
+    selected: start + offset === state.selectedIndex,
+  }))
+}
+
+function isSelectedCommit(row: GitLogRow, selected: GitLogCommitRow | undefined): boolean {
+  return row.type === 'commit' && selected ? commitKey(row) === commitKey(selected) : false
+}
+
+function toFullGraphItems(state: LogInkState, visibleCount: number): LogInkHistoryItem[] {
+  const selected = state.filteredCommits[state.selectedIndex]
+  const selectedRowIndex = state.rows.findIndex((row) => isSelectedCommit(row, selected))
+  const start = clampWindowStart(
+    selectedRowIndex >= 0 ? selectedRowIndex : 0,
+    state.rows.length,
+    visibleCount
+  )
+
+  return state.rows.slice(start, start + visibleCount).map((row) => {
+    if (row.type === 'graph') {
+      return {
+        type: 'graph',
+        graph: row.graph,
+      }
+    }
+
+    return {
+      type: 'commit',
+      commit: row,
+      graph: row.graph || '*',
+      selected: isSelectedCommit(row, selected),
+    }
+  })
+}
+
+export function getVisibleLogInkHistory(
+  state: LogInkState,
+  visibleCount: number
+): VisibleLogInkHistory {
+  const items = state.fullGraph && !state.filter
+    ? toFullGraphItems(state, visibleCount)
+    : toCompactItems(state, visibleCount)
+
+  return {
+    graphWidth: graphWidth(items),
+    items,
+  }
+}
+
+export function formatInkRefLabels(refs: string[]): string {
+  return refs.length ? ` ${refs.map((ref) => `[${ref}]`).join(' ')}` : ''
+}
+
+export function formatInkHistoryGraphRow(row: GitLogGraphRow, width: number): string {
+  return row.graph.padEnd(width)
+}

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -6,7 +6,6 @@ import { runCommitDraftWorkflow } from './commitWorkflowActions'
 import {
   GitCommitDetail,
   GitCommitFilePreview,
-  GitLogCommitRow,
   GitLogRow,
   LOG_INTERACTIVE_DEFAULT_LIMIT,
   getCommitDetail,
@@ -22,6 +21,10 @@ import {
   isLogInkContextLoading,
   updateLogInkContextStatus,
 } from './inkContext'
+import {
+  formatInkRefLabels,
+  getVisibleLogInkHistory,
+} from './inkHistoryRows'
 import {
   formatBindingKeys,
   getLogInkCommandPaletteItems,
@@ -143,10 +146,6 @@ const truncate = truncateCells
 
 function compactHash(hash: string | undefined): string {
   return hash ? hash.slice(0, 7) : '<none>'
-}
-
-function formatRefs(commit: GitLogCommitRow): string {
-  return commit.refs.length ? ` [${commit.refs.join(', ')}]` : ''
 }
 
 function formatChangedFile(file: GitCommitDetail['files'][number]): string {
@@ -278,18 +277,6 @@ function sidebarTabLabel(tab: LogInkSidebarTab): string {
       return 'Worktrees'
     default:
       return tab
-  }
-}
-
-function getVisibleCommits(state: LogInkState, visibleRows: number): {
-  commits: GitLogCommitRow[]
-  offset: number
-} {
-  const offset = Math.max(0, state.selectedIndex - Math.floor(visibleRows / 2))
-
-  return {
-    commits: state.filteredCommits.slice(offset, offset + visibleRows),
-    offset,
   }
 }
 
@@ -1042,7 +1029,7 @@ function renderHistoryPanel(
   const { Box, Text } = components
   const focused = state.focus === 'commits'
   const listRows = Math.max(3, bodyRows - 4)
-  const visible = getVisibleCommits(state, listRows)
+  const visible = getVisibleLogInkHistory(state, listRows)
   const loadState = loadingMoreCommits
     ? 'loading older commits'
     : hasMoreCommits
@@ -1062,16 +1049,22 @@ function renderHistoryPanel(
     h(Text, { bold: true }, panelTitle('Commits', focused)),
     h(Text, { dimColor: true }, `${title} | ${graphMode} | ${loadState}`)
   ),
-  visible.commits.length === 0
+  visible.items.length === 0
     ? h(Text, { dimColor: true }, 'No commits match the current filter.')
-    : visible.commits.map((commit, offset) => {
-      const index = visible.offset + offset
-      const selected = index === state.selectedIndex
-      const graph = state.fullGraph ? commit.graph || '*' : '*'
-      const row = `${graph.padEnd(state.fullGraph ? 8 : 2)} ${commit.shortHash} ${commit.date} ${commit.message}${formatRefs(commit)}`
+    : visible.items.map((item, index) => {
+      if (item.type === 'graph') {
+        return h(Text, {
+          key: `graph-${index}-${item.graph}`,
+          dimColor: true,
+        }, truncate(item.graph.padEnd(visible.graphWidth), 140))
+      }
+
+      const { commit, selected } = item
+      const graph = item.graph.padEnd(visible.graphWidth)
+      const row = `${graph} ${commit.shortHash} ${commit.date} ${commit.message}${formatInkRefLabels(commit.refs)}`
 
       return h(Text, {
-        key: commit.hash,
+        key: `${commit.hash}-${index}`,
         backgroundColor: selected && !theme.noColor ? theme.colors.selection : undefined,
         inverse: selected,
       }, truncate(row, 140))


### PR DESCRIPTION
## Summary
- add a dedicated Ink history row adapter for compact versus full graph rendering
- preserve graph continuation rows in full graph mode
- compute graph lane width from visible topology instead of a fixed width
- render refs as distinct labels instead of comma-packed text
- add coverage for branch crossings, continuation lines, long refs, and graph padding

Closes #730
Refs #724

## Validation
- npm run test:jest -- src/commands/log/inkHistoryRows.test.ts src/commands/log/inkViewModel.test.ts src/commands/log/inkInput.test.ts
- npm test