### PR TITLE
feat(log-tui): add view stack and navigation intents

### DIFF
--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -4,6 +4,10 @@ import {
   createLogInkState,
   getLogInkSidebarTabs,
   getSelectedInkCommit,
+  intentGoHome,
+  intentOpenComposeForFile,
+  intentOpenDiffForCommit,
+  intentOpenDiffForWorktreeFile,
   scoreLogInkCommitFilter,
 } from './inkViewModel'
 
@@ -274,5 +278,218 @@ describe('log Ink view model', () => {
 
     state = applyLogInkAction(state, { type: 'setPendingMutationConfirmation', value: undefined })
     expect(state.pendingMutationConfirmation).toBeUndefined()
+  })
+
+  describe('navigation primitives', () => {
+    it('initializes the view stack with the root view', () => {
+      const state = createLogInkState(rows)
+      expect(state.viewStack).toEqual(['history'])
+      expect(state.activeView).toBe('history')
+    })
+
+    it('honors a custom initial view in the stack', () => {
+      const state = createLogInkState(rows, { activeView: 'status' })
+      expect(state.viewStack).toEqual(['status'])
+      expect(state.activeView).toBe('status')
+    })
+
+    it('pushes a new view onto the stack', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'diff' })
+
+      expect(state.viewStack).toEqual(['history', 'diff'])
+      expect(state.activeView).toBe('diff')
+    })
+
+    it('does not duplicate the top of the stack on push', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'history' })
+      state = applyLogInkAction(state, { type: 'pushView', value: 'diff' })
+      state = applyLogInkAction(state, { type: 'pushView', value: 'diff' })
+
+      expect(state.viewStack).toEqual(['history', 'diff'])
+    })
+
+    it('pops the top of the stack', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'status' })
+      state = applyLogInkAction(state, { type: 'pushView', value: 'diff' })
+
+      state = applyLogInkAction(state, { type: 'popView' })
+      expect(state.viewStack).toEqual(['history', 'status'])
+      expect(state.activeView).toBe('status')
+
+      state = applyLogInkAction(state, { type: 'popView' })
+      expect(state.viewStack).toEqual(['history'])
+      expect(state.activeView).toBe('history')
+    })
+
+    it('refuses to pop past the root view', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'popView' })
+      state = applyLogInkAction(state, { type: 'popView' })
+
+      expect(state.viewStack).toEqual(['history'])
+      expect(state.activeView).toBe('history')
+    })
+
+    it('preserves stack depth when replacing the top', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'status' })
+      state = applyLogInkAction(state, { type: 'replaceView', value: 'diff' })
+
+      expect(state.viewStack).toEqual(['history', 'diff'])
+      expect(state.activeView).toBe('diff')
+    })
+
+    it('keeps the stack consistent when setActiveView is dispatched', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'status' })
+      state = applyLogInkAction(state, { type: 'setActiveView', value: 'diff' })
+
+      // setActiveView replaces the top of the stack — same depth, new top
+      expect(state.viewStack).toEqual(['history', 'diff'])
+      expect(state.activeView).toBe('diff')
+    })
+
+    it('keeps the stack consistent when moveWorktreeFile flips into status view', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'diff' })
+      state = applyLogInkAction(state, { type: 'moveWorktreeFile', delta: 1, fileCount: 3 })
+
+      // moveWorktreeFile uses replace semantics, so depth is preserved
+      expect(state.viewStack).toEqual(['history', 'status'])
+      expect(state.activeView).toBe('status')
+      expect(state.selectedWorktreeFileIndex).toBe(1)
+    })
+
+    it('clears worktree state when navigating away from diff', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'diff' })
+      state = applyLogInkAction(state, { type: 'pageWorktreeDiff', delta: 15, lineCount: 100 })
+      state = applyLogInkAction(state, {
+        type: 'jumpWorktreeHunk',
+        delta: 1,
+        hunkOffsets: [10, 20, 30],
+      })
+
+      expect(state.worktreeDiffOffset).toBeGreaterThan(0)
+      expect(state.selectedWorktreeHunkIndex).toBeGreaterThan(0)
+
+      state = applyLogInkAction(state, { type: 'popView' })
+      expect(state.activeView).toBe('history')
+      expect(state.worktreeDiffOffset).toBe(0)
+      expect(state.selectedWorktreeHunkIndex).toBe(0)
+    })
+
+    it('navigates home, resetting the stack to the history root', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'status' })
+      state = applyLogInkAction(state, { type: 'pushView', value: 'diff' })
+      state = applyLogInkAction(state, { type: 'navigateHome' })
+
+      expect(state.viewStack).toEqual(['history'])
+      expect(state.activeView).toBe('history')
+    })
+  })
+
+  describe('navigation intents', () => {
+    it('intentGoHome returns null when already at the root history view', () => {
+      const state = createLogInkState(rows)
+      expect(intentGoHome(state)).toBeNull()
+    })
+
+    it('intentGoHome returns navigateHome when not at root', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'diff' })
+
+      expect(intentGoHome(state)).toEqual({ type: 'navigateHome' })
+    })
+
+    it('intentGoHome returns navigateHome when initial view is non-history', () => {
+      const state = createLogInkState(rows, { activeView: 'status' })
+      expect(intentGoHome(state)).toEqual({ type: 'navigateHome' })
+    })
+
+    it('intentOpenDiffForCommit resolves to a navigate action when the sha is known', () => {
+      const state = createLogInkState(rows)
+      const intent = intentOpenDiffForCommit(state, 'def567890123')
+
+      expect(intent).toEqual({
+        type: 'navigateOpenDiffForCommit',
+        sha: 'def567890123',
+        commitIndex: 1,
+      })
+    })
+
+    it('intentOpenDiffForCommit returns null for an unknown sha', () => {
+      const state = createLogInkState(rows)
+      expect(intentOpenDiffForCommit(state, 'deadbeef')).toBeNull()
+    })
+
+    it('navigateOpenDiffForCommit pushes diff and selects the commit', () => {
+      let state = createLogInkState(rows)
+      const intent = intentOpenDiffForCommit(state, 'fed999900000')!
+
+      state = applyLogInkAction(state, intent)
+
+      expect(state.viewStack).toEqual(['history', 'diff'])
+      expect(state.activeView).toBe('diff')
+      expect(getSelectedInkCommit(state)?.hash).toBe('fed999900000')
+    })
+
+    it('intentOpenDiffForWorktreeFile resolves a known path to a fileIndex', () => {
+      const intent = intentOpenDiffForWorktreeFile('src/foo.ts', [
+        'src/bar.ts',
+        'src/foo.ts',
+        'src/baz.ts',
+      ])
+
+      expect(intent).toEqual({ type: 'navigateOpenDiffForWorktreeFile', fileIndex: 1 })
+    })
+
+    it('intentOpenDiffForWorktreeFile returns null when the path is not in the worktree list', () => {
+      expect(intentOpenDiffForWorktreeFile('src/foo.ts', ['src/bar.ts'])).toBeNull()
+    })
+
+    it('navigateOpenDiffForWorktreeFile pushes diff and selects the file', () => {
+      let state = createLogInkState(rows)
+      const intent = intentOpenDiffForWorktreeFile('src/foo.ts', [
+        'src/bar.ts',
+        'src/foo.ts',
+        'src/baz.ts',
+      ])!
+
+      state = applyLogInkAction(state, intent)
+
+      expect(state.viewStack).toEqual(['history', 'diff'])
+      expect(state.activeView).toBe('diff')
+      expect(state.selectedWorktreeFileIndex).toBe(1)
+    })
+
+    it('intentOpenComposeForFile is a no-op when the working tree is clean', () => {
+      expect(intentOpenComposeForFile('src/foo.ts', [])).toBeNull()
+    })
+
+    it('intentOpenComposeForFile returns null when the path is not in the worktree list', () => {
+      expect(intentOpenComposeForFile('src/foo.ts', ['src/bar.ts'])).toBeNull()
+    })
+
+    it('intentOpenComposeForFile resolves a dirty worktree path', () => {
+      expect(
+        intentOpenComposeForFile('src/foo.ts', ['src/bar.ts', 'src/foo.ts'])
+      ).toEqual({ type: 'navigateOpenComposeForFile', fileIndex: 1 })
+    })
+
+    it('navigateOpenComposeForFile pushes status view and selects the file', () => {
+      let state = createLogInkState(rows)
+      const intent = intentOpenComposeForFile('src/foo.ts', ['src/foo.ts'])!
+
+      state = applyLogInkAction(state, intent)
+
+      expect(state.viewStack).toEqual(['history', 'status'])
+      expect(state.activeView).toBe('status')
+      expect(state.selectedWorktreeFileIndex).toBe(0)
+    })
   })
 })

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -17,7 +17,16 @@ export type CreateLogInkStateOptions = {
 }
 
 export type LogInkState = {
+  /**
+   * Top of `viewStack`. Maintained as a denormalized field so existing call
+   * sites can read the active view without dereferencing the stack.
+   */
   activeView: LogInkView
+  /**
+   * Navigation stack. Always non-empty; bottom is the root view, top is
+   * `activeView`. Push/pop/replace actions keep both fields in sync.
+   */
+  viewStack: LogInkView[]
   rows: GitLogRow[]
   commits: GitLogCommitRow[]
   filteredCommits: GitLogCommitRow[]
@@ -62,6 +71,13 @@ export type LogInkAction =
   | { type: 'previousSidebarTab' }
   | { type: 'setFilter'; value: string }
   | { type: 'setActiveView'; value: LogInkView }
+  | { type: 'pushView'; value: LogInkView }
+  | { type: 'popView' }
+  | { type: 'replaceView'; value: LogInkView }
+  | { type: 'navigateHome' }
+  | { type: 'navigateOpenDiffForCommit'; sha: string; commitIndex: number }
+  | { type: 'navigateOpenDiffForWorktreeFile'; fileIndex: number }
+  | { type: 'navigateOpenComposeForFile'; fileIndex: number }
   | { type: 'jumpWorktreeHunk'; delta: number; hunkOffsets: number[] }
   | { type: 'setFocus'; value: LogInkFocus }
   | { type: 'setPendingKey'; value?: string }
@@ -188,6 +204,61 @@ function cycleValue<T>(values: T[], current: T, delta: number): T {
   return values[nextIndex]
 }
 
+const HOME_VIEW: LogInkView = 'history'
+
+function topOfStack(stack: LogInkView[]): LogInkView {
+  return stack[stack.length - 1]
+}
+
+function withPushedView(state: LogInkState, value: LogInkView): LogInkState {
+  if (topOfStack(state.viewStack) === value) {
+    return { ...state, pendingKey: undefined }
+  }
+
+  const viewStack = [...state.viewStack, value]
+  return {
+    ...state,
+    activeView: value,
+    viewStack,
+    worktreeDiffOffset: value === 'diff' ? state.worktreeDiffOffset : 0,
+    selectedWorktreeHunkIndex: value === 'diff' ? state.selectedWorktreeHunkIndex : 0,
+    pendingKey: undefined,
+  }
+}
+
+function withPoppedView(state: LogInkState): LogInkState {
+  if (state.viewStack.length <= 1) {
+    return { ...state, pendingKey: undefined }
+  }
+
+  const viewStack = state.viewStack.slice(0, -1)
+  const next = topOfStack(viewStack)
+  return {
+    ...state,
+    activeView: next,
+    viewStack,
+    worktreeDiffOffset: next === 'diff' ? state.worktreeDiffOffset : 0,
+    selectedWorktreeHunkIndex: next === 'diff' ? state.selectedWorktreeHunkIndex : 0,
+    pendingKey: undefined,
+  }
+}
+
+function withReplacedView(state: LogInkState, value: LogInkView): LogInkState {
+  if (topOfStack(state.viewStack) === value) {
+    return { ...state, pendingKey: undefined }
+  }
+
+  const viewStack = [...state.viewStack.slice(0, -1), value]
+  return {
+    ...state,
+    activeView: value,
+    viewStack,
+    worktreeDiffOffset: value === 'diff' ? state.worktreeDiffOffset : 0,
+    selectedWorktreeHunkIndex: value === 'diff' ? state.selectedWorktreeHunkIndex : 0,
+    pendingKey: undefined,
+  }
+}
+
 function withFilter(state: LogInkState, filter: string): LogInkState {
   const filteredCommits = filterCommits(state.commits, filter)
 
@@ -260,9 +331,11 @@ export function createLogInkState(
   options: CreateLogInkStateOptions = {}
 ): LogInkState {
   const commits = getCommitRows(rows)
+  const initialView: LogInkView = options.activeView || 'history'
 
   return {
-    activeView: options.activeView || 'history',
+    activeView: initialView,
+    viewStack: [initialView],
     rows,
     commits,
     filteredCommits: commits,
@@ -337,18 +410,18 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         diffPreviewOffset: 0,
         pendingKey: undefined,
       }
-    case 'moveWorktreeFile':
+    case 'moveWorktreeFile': {
+      const next = withReplacedView(state, 'status')
       return {
-        ...state,
-        activeView: 'status',
+        ...next,
         selectedWorktreeFileIndex: clampIndex(
           state.selectedWorktreeFileIndex + action.delta,
           action.fileCount
         ),
         selectedWorktreeHunkIndex: 0,
         worktreeDiffOffset: 0,
-        pendingKey: undefined,
       }
+    }
     case 'moveToBottom':
       return {
         ...state,
@@ -418,13 +491,56 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
     case 'setFilter':
       return withFilter(state, action.value)
     case 'setActiveView':
+      return withReplacedView(state, action.value)
+    case 'pushView':
+      return withPushedView(state, action.value)
+    case 'popView':
+      return withPoppedView(state)
+    case 'replaceView':
+      return withReplacedView(state, action.value)
+    case 'navigateHome': {
+      if (state.viewStack.length === 1 && topOfStack(state.viewStack) === HOME_VIEW) {
+        return { ...state, pendingKey: undefined }
+      }
       return {
         ...state,
-        activeView: action.value,
-        worktreeDiffOffset: action.value === 'diff' ? state.worktreeDiffOffset : 0,
-        selectedWorktreeHunkIndex: action.value === 'diff' ? state.selectedWorktreeHunkIndex : 0,
+        activeView: HOME_VIEW,
+        viewStack: [HOME_VIEW],
+        worktreeDiffOffset: 0,
+        selectedWorktreeHunkIndex: 0,
         pendingKey: undefined,
       }
+    }
+    case 'navigateOpenDiffForCommit': {
+      const next = withPushedView(state, 'diff')
+      const filteredCommits = state.filteredCommits
+      const idx = filteredCommits.findIndex((commit) => commit.hash === action.sha)
+      const selectedIndex = idx >= 0 ? idx : action.commitIndex
+      return {
+        ...next,
+        selectedIndex: clampIndex(selectedIndex, filteredCommits.length),
+        selectedFileIndex: 0,
+        diffPreviewOffset: 0,
+      }
+    }
+    case 'navigateOpenDiffForWorktreeFile': {
+      const next = withPushedView(state, 'diff')
+      return {
+        ...next,
+        selectedWorktreeFileIndex: Math.max(0, action.fileIndex),
+        selectedWorktreeHunkIndex: 0,
+        worktreeDiffOffset: 0,
+      }
+    }
+    case 'navigateOpenComposeForFile': {
+      const next = withPushedView(state, 'status')
+      return {
+        ...next,
+        selectedWorktreeFileIndex: Math.max(0, action.fileIndex),
+        selectedWorktreeHunkIndex: 0,
+        worktreeDiffOffset: 0,
+      }
+    }
     case 'setFocus':
       return {
         ...state,
@@ -504,4 +620,65 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
     default:
       return state
   }
+}
+
+/**
+ * Navigation intents — high-level transitions the rest of the app calls
+ * instead of pushing/popping the view stack directly. Each intent returns
+ * either a `LogInkAction` to dispatch, or `null` if the intent is not
+ * applicable (e.g. compose with a clean working tree, or a commit sha that
+ * is not in the current view).
+ *
+ * Future phases of the TUI shell (palette, cross-view keymaps) enumerate
+ * these intents to drive the UI.
+ */
+
+export function intentGoHome(state: LogInkState): LogInkAction | null {
+  if (state.viewStack.length === 1 && state.activeView === HOME_VIEW) {
+    return null
+  }
+  return { type: 'navigateHome' }
+}
+
+export function intentOpenDiffForCommit(
+  state: LogInkState,
+  sha: string
+): LogInkAction | null {
+  const filteredIndex = state.filteredCommits.findIndex((commit) => commit.hash === sha)
+
+  if (filteredIndex < 0) {
+    return null
+  }
+
+  return { type: 'navigateOpenDiffForCommit', sha, commitIndex: filteredIndex }
+}
+
+export function intentOpenDiffForWorktreeFile(
+  path: string,
+  worktreeFiles: string[]
+): LogInkAction | null {
+  const idx = worktreeFiles.indexOf(path)
+
+  if (idx < 0) {
+    return null
+  }
+
+  return { type: 'navigateOpenDiffForWorktreeFile', fileIndex: idx }
+}
+
+export function intentOpenComposeForFile(
+  path: string,
+  worktreeFiles: string[]
+): LogInkAction | null {
+  if (worktreeFiles.length === 0) {
+    return null
+  }
+
+  const idx = worktreeFiles.indexOf(path)
+
+  if (idx < 0) {
+    return null
+  }
+
+  return { type: 'navigateOpenComposeForFile', fileIndex: idx }
 }


### PR DESCRIPTION
## Summary

First PR of the TUI shell epic (#747). Adds the navigation plumbing that the rest of the phases will build on. **No visual change in this PR** — `coco ui` and `coco log -i` look and behave identically to today.

Closes #740.

## What changed

**State**
- `LogInkState` gains a `viewStack: LogInkView[]` (always non-empty, root at index 0, top is the active view).
- `activeView` is kept as a denormalized mirror of `viewStack[top]` so the dozens of existing call sites that read `state.activeView` need no changes.

**Reducer actions (additive)**
- `pushView` / `popView` / `replaceView` — primitive stack ops with invariants (no duplicate-top push, popping root no-ops, replace preserves depth).
- `navigateHome` — resets the stack to the history root.
- `navigateOpenDiffForCommit` / `navigateOpenDiffForWorktreeFile` / `navigateOpenComposeForFile` — atomic transitions that combine a view push with the appropriate selection update.

**Existing actions adapted**
- `setActiveView` now routes through `withReplacedView`, so the stack always stays consistent with `activeView`.
- The `moveWorktreeFile` auto-switch into status uses the same helper (replace semantics, depth preserved).

**Intent helpers (pure)**
- `intentGoHome`, `intentOpenDiffForCommit`, `intentOpenDiffForWorktreeFile`, `intentOpenComposeForFile`.
- Each returns `LogInkAction | null` — the *"no-op when the working tree is clean"* semantics from #740 live in `intentOpenComposeForFile` so callers can simply dispatch when non-null.
- These are what the palette in phase 6 will enumerate.

**Worktree-state cleanup**
- The existing behavior of clearing `worktreeDiffOffset` / `selectedWorktreeHunkIndex` when leaving the diff view is preserved across all stack transitions (push, pop, replace, navigateHome).

## Test plan

22 new cases in `inkViewModel.test.ts`, alongside the existing 16. Coverage includes:

- [x] Stack initialization (default and `--view status` path)
- [x] `pushView` appends and de-dupes the top
- [x] `popView` pops and refuses to drop below root
- [x] `replaceView` preserves stack depth
- [x] `setActiveView` keeps the stack in sync (replace semantics)
- [x] `moveWorktreeFile` keeps the stack in sync
- [x] `worktreeDiffOffset` / `selectedWorktreeHunkIndex` reset on nav away from diff
- [x] `navigateHome` resets the stack
- [x] `intentGoHome` returns null at the root, action otherwise
- [x] `intentOpenDiffForCommit` resolves a known sha, returns null for an unknown one
- [x] `intentOpenDiffForWorktreeFile` resolves a known path
- [x] `intentOpenComposeForFile` returns null for clean tree and for unknown path
- [x] Each `navigate*` reducer leaves the stack and selection in the expected state

Local release-gate run:
- [x] `npm run lint`
- [x] `npm run test:jest` — 604/604 across 89 suites
- [x] `npm run build`
- [x] `npm run test:cli` — 10 packaged-CLI smoke checks
- [x] `npm run release:dry-run`

## Unblocks

- Phase 2 (#741): chrome can read the view stack to render breadcrumbs.
- Phase 3 (#742): cross-view keybindings dispatch the new navigate actions; back/forward map to popView/pushView.
- Phase 4 (#743): compose-as-view rebuilds on `pushView('compose')`.
- Phase 6 (#745): palette enumerates the intent helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)