### PR TITLE
feat(log-tui): persistent shell chrome (breadcrumb, footer slots, help groups)

### DIFF
--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -1,55 +1,125 @@
 import {
   LOG_INK_KEY_BINDINGS,
+  formatLogInkBreadcrumb,
   getLogInkCommandPaletteItems,
   getLogInkFooterHints,
   getLogInkHelpSections,
 } from './inkKeymap'
 
 describe('log Ink keymap', () => {
-  it('keeps footer hints short and contextual', () => {
+  it('returns view-aware contextual hints alongside persistent globals', () => {
     expect(getLogInkFooterHints({
       activeView: 'history',
       filterMode: false,
       focus: 'commits',
       showHelp: false,
-    })).toEqual(['↑/↓ move', '/ search', 'gg/G top/bottom', 'n/N next', '? help'])
-
-    expect(getLogInkFooterHints({
-      filterMode: true,
-      focus: 'commits',
-      showHelp: false,
-    })).toEqual(['enter apply', 'esc cancel', 'ctrl+u clear', 'q quit'])
-
-    expect(getLogInkFooterHints({
-      filterMode: false,
-      focus: 'detail',
-      showHelp: false,
-    })).toEqual(['↑/↓ files', 'pgup/pgdn diff', 'tab focus', '? help', 'q quit'])
+    })).toEqual({
+      contextual: ['↑/↓ move', '/ search', 'gg/G top/bottom', 'n/N next'],
+      global: ['? help', ': cmds', 'q quit'],
+    })
 
     expect(getLogInkFooterHints({
       activeView: 'status',
       filterMode: false,
       focus: 'commits',
       showHelp: false,
-    })).toEqual(['↑/↓ files', 'enter diff', 'space stage', 'z revert', 'e/c compose'])
+    })).toEqual({
+      contextual: ['↑/↓ files', 'enter diff', 'space stage', 'z revert', 'e/c compose'],
+      global: ['? help', ': cmds', 'q quit'],
+    })
 
     expect(getLogInkFooterHints({
       activeView: 'diff',
       filterMode: false,
       focus: 'commits',
       showHelp: false,
-    })).toEqual(['j/k hunks', 'space stage', 'z revert', 'e/c compose', 'esc files'])
+    })).toEqual({
+      contextual: ['j/k hunks', 'space stage', 'z revert', 'e/c compose', 'esc files'],
+      global: ['? help', ': cmds', 'q quit'],
+    })
+
+    expect(getLogInkFooterHints({
+      filterMode: false,
+      focus: 'sidebar',
+      showHelp: false,
+    })).toEqual({
+      contextual: ['[/] tab', '1-5 jump', 'tab focus'],
+      global: ['? help', ': cmds', 'q quit'],
+    })
+
+    expect(getLogInkFooterHints({
+      filterMode: false,
+      focus: 'detail',
+      showHelp: false,
+    })).toEqual({
+      contextual: ['↑/↓ files', 'pgup/pgdn diff', 'tab focus'],
+      global: ['? help', ': cmds', 'q quit'],
+    })
+  })
+
+  it('reduces global hints in special modes (filter, help, palette)', () => {
+    expect(getLogInkFooterHints({
+      filterMode: true,
+      focus: 'commits',
+      showHelp: false,
+    })).toEqual({
+      contextual: ['enter apply', 'esc cancel', 'ctrl+u clear'],
+      global: ['q quit'],
+    })
+
+    expect(getLogInkFooterHints({
+      filterMode: false,
+      focus: 'commits',
+      showHelp: true,
+    })).toEqual({
+      contextual: ['? close', 'tab focus', '/ search'],
+      global: ['q quit'],
+    })
 
     expect(getLogInkFooterHints({
       filterMode: false,
       focus: 'commits',
       showCommandPalette: true,
       showHelp: false,
-    })).toEqual([': close', 'D/T/X confirm', 'I/M AI', '? help', 'q quit'])
+    })).toEqual({
+      contextual: [': close', 'D/T/X confirm', 'I/M AI'],
+      global: ['? help', 'q quit'],
+    })
   })
 
-  it('derives help from the same binding source', () => {
-    const helpText = getLogInkHelpSections()
+  it('groups help into Global and the active view', () => {
+    const sections = getLogInkHelpSections({ activeView: 'history', focus: 'commits' })
+
+    expect(sections.map((section) => section.title)).toEqual([
+      'Global',
+      'This view (history)',
+    ])
+
+    const globals = sections[0].bindings.map((binding) => binding.id)
+    expect(globals).toContain('help')
+    expect(globals).toContain('commandPalette')
+    expect(globals).toContain('quit')
+    expect(globals).toContain('focusNext')
+    expect(globals).not.toContain('moveUp')
+
+    const viewBindings = sections[1].bindings.map((binding) => binding.id)
+    expect(viewBindings).toContain('moveUp')
+    expect(viewBindings).toContain('search')
+    expect(viewBindings).toContain('toggleGraph')
+    expect(viewBindings).not.toContain('quit')
+    expect(viewBindings).not.toContain('help')
+  })
+
+  it('renders the help label with the active view', () => {
+    const status = getLogInkHelpSections({ activeView: 'status', focus: 'commits' })
+    expect(status[1].title).toBe('This view (status)')
+
+    const diff = getLogInkHelpSections({ activeView: 'diff', focus: 'detail' })
+    expect(diff[1].title).toBe('This view (diff)')
+  })
+
+  it('still derives bindings from the shared keymap', () => {
+    const helpText = getLogInkHelpSections({ activeView: 'history', focus: 'commits' })
       .flatMap((section) => section.bindings)
       .map((binding) => `${binding.keys.join('/')} ${binding.description}`)
       .join('\n')
@@ -58,12 +128,19 @@ describe('log Ink keymap', () => {
     expect(helpText).toContain('g Toggle compact and full graph display.')
     expect(helpText).toContain('gg Jump to the first visible commit.')
     expect(helpText).toContain('G Jump to the last visible commit.')
-    expect(helpText).toContain('[ Move to the previous repository sidebar tab.')
     expect(helpText).toContain('z Ask to revert the selected file or hunk.')
     expect(helpText).toContain('e Edit the manual commit summary or body.')
     expect(helpText).toContain('c Create a commit from staged changes with the current draft.')
     expect(helpText).toContain('q/ctrl+c Quit the interactive log.')
     expect(helpText).toContain('tab Move focus to the next panel.')
+  })
+
+  it('formats the navigation breadcrumb based on the view stack', () => {
+    expect(formatLogInkBreadcrumb([])).toBe('')
+    expect(formatLogInkBreadcrumb(['history'])).toBe('')
+    expect(formatLogInkBreadcrumb(['status'])).toBe('status')
+    expect(formatLogInkBreadcrumb(['history', 'diff'])).toBe('history › diff')
+    expect(formatLogInkBreadcrumb(['history', 'status', 'diff'])).toBe('history › status › diff')
   })
 
   it('derives command palette entries from the shared keymap', () => {

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -217,81 +217,161 @@ export type GetLogInkFooterHintsOptions = {
   showCommandPalette?: boolean
 }
 
+/**
+ * Footer hints split into two slots so the chrome can render them in
+ * separate spans:
+ *   `contextual` — what changes with mode, view, or focus.
+ *   `global`     — persistent affordances (help · commands · quit).
+ */
+export type LogInkFooterHints = {
+  contextual: string[]
+  global: string[]
+}
+
+/**
+ * Bindings considered "global" — always available regardless of which view
+ * or pane has focus. Surfaced as a separate group in the help overlay and
+ * always rendered in the footer's global slot.
+ */
+const GLOBAL_BINDING_IDS: LogInkCommandId[] = [
+  'help',
+  'commandPalette',
+  'workflowActions',
+  'focusNext',
+  'focusPrevious',
+  'refresh',
+  'quit',
+]
+
+const NORMAL_GLOBAL_HINTS = ['? help', ': cmds', 'q quit']
+
 export function formatBindingKeys(binding: LogInkKeyBinding): string {
   return binding.keys.join('/')
 }
 
-export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): string[] {
+/**
+ * Render the navigation `viewStack` as a breadcrumb suitable for the
+ * chrome header. A single-frame stack at the root view returns an empty
+ * string so the header stays compact when nothing has been pushed.
+ *
+ * Examples:
+ *   `[history]`             → ''
+ *   `[history, diff]`       → 'history › diff'
+ *   `[status, diff]`        → 'status › diff'
+ *   `[history, diff, status]` → 'history › diff › status'
+ */
+export function formatLogInkBreadcrumb(viewStack: LogInkView[]): string {
+  if (viewStack.length === 0) {
+    return ''
+  }
+
+  if (viewStack.length === 1 && viewStack[0] === 'history') {
+    return ''
+  }
+
+  return viewStack.join(' › ')
+}
+
+export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogInkFooterHints {
   if (options.filterMode) {
-    return ['enter apply', 'esc cancel', 'ctrl+u clear', 'q quit']
+    return {
+      contextual: ['enter apply', 'esc cancel', 'ctrl+u clear'],
+      global: ['q quit'],
+    }
   }
 
   if (options.showHelp) {
-    return ['? close', 'tab focus', '/ search', 'q quit']
+    return {
+      contextual: ['? close', 'tab focus', '/ search'],
+      global: ['q quit'],
+    }
   }
 
   if (options.showCommandPalette) {
-    return [': close', 'D/T/X confirm', 'I/M AI', '? help', 'q quit']
+    return {
+      contextual: [': close', 'D/T/X confirm', 'I/M AI'],
+      global: ['? help', 'q quit'],
+    }
   }
 
   if (options.focus === 'sidebar') {
-    return ['[/] tab', '1-5 jump', 'tab focus', '/ search', '? help']
+    return {
+      contextual: ['[/] tab', '1-5 jump', 'tab focus'],
+      global: NORMAL_GLOBAL_HINTS,
+    }
   }
 
   if (options.focus === 'detail') {
-    return ['↑/↓ files', 'pgup/pgdn diff', 'tab focus', '? help', 'q quit']
+    return {
+      contextual: ['↑/↓ files', 'pgup/pgdn diff', 'tab focus'],
+      global: NORMAL_GLOBAL_HINTS,
+    }
   }
 
   if (options.activeView === 'status') {
-    return ['↑/↓ files', 'enter diff', 'space stage', 'z revert', 'e/c compose']
+    return {
+      contextual: ['↑/↓ files', 'enter diff', 'space stage', 'z revert', 'e/c compose'],
+      global: NORMAL_GLOBAL_HINTS,
+    }
   }
 
   if (options.activeView === 'diff') {
-    return ['j/k hunks', 'space stage', 'z revert', 'e/c compose', 'esc files']
+    return {
+      contextual: ['j/k hunks', 'space stage', 'z revert', 'e/c compose', 'esc files'],
+      global: NORMAL_GLOBAL_HINTS,
+    }
   }
 
-  return ['↑/↓ move', '/ search', 'gg/G top/bottom', 'n/N next', '? help']
+  return {
+    contextual: ['↑/↓ move', '/ search', 'gg/G top/bottom', 'n/N next'],
+    global: NORMAL_GLOBAL_HINTS,
+  }
 }
 
-export function getLogInkHelpSections(): LogInkHelpSection[] {
+export type GetLogInkHelpSectionsOptions = {
+  activeView: LogInkView
+  focus: LogInkFocus
+}
+
+function bindingMatchesViewContext(
+  binding: LogInkKeyBinding,
+  options: GetLogInkHelpSectionsOptions
+): boolean {
+  if (binding.contexts.includes(options.focus)) {
+    return true
+  }
+
+  if (binding.contexts.includes('normal')) {
+    return true
+  }
+
+  return false
+}
+
+/**
+ * Help bindings grouped for the persistent help overlay.
+ *
+ * Returns two top-level groups:
+ *   - `Global` — bindings that work from any view or focus.
+ *   - `This view (...)` — bindings relevant to the current view + focus.
+ *
+ * The active-view label is appended so users always know which section
+ * applies to where they currently are.
+ */
+export function getLogInkHelpSections(
+  options: GetLogInkHelpSectionsOptions
+): LogInkHelpSection[] {
+  const globals = LOG_INK_KEY_BINDINGS.filter((binding) =>
+    GLOBAL_BINDING_IDS.includes(binding.id)
+  )
+
+  const viewBindings = LOG_INK_KEY_BINDINGS.filter((binding) =>
+    !GLOBAL_BINDING_IDS.includes(binding.id) && bindingMatchesViewContext(binding, options)
+  )
+
   return [
-    {
-      title: 'Navigation',
-      bindings: LOG_INK_KEY_BINDINGS.filter((binding) =>
-        [
-          'moveUp',
-          'moveDown',
-          'pageUp',
-          'pageDown',
-          'moveToTop',
-          'moveToBottom',
-          'nextMatch',
-          'previousMatch',
-          'focusNext',
-          'focusPrevious',
-          'previousSidebarTab',
-          'nextSidebarTab',
-        ].includes(binding.id)
-      ),
-    },
-    {
-      title: 'Browsing',
-      bindings: LOG_INK_KEY_BINDINGS.filter((binding) =>
-        ['search', 'clearSearch', 'toggleGraph', 'refresh', 'revertSelection'].includes(binding.id)
-      ),
-    },
-    {
-      title: 'Commit',
-      bindings: LOG_INK_KEY_BINDINGS.filter((binding) =>
-        ['editCommit', 'commit'].includes(binding.id)
-      ),
-    },
-    {
-      title: 'Global',
-      bindings: LOG_INK_KEY_BINDINGS.filter((binding) =>
-        ['help', 'commandPalette', 'workflowActions', 'quit'].includes(binding.id)
-      ),
-    },
+    { title: 'Global', bindings: globals },
+    { title: `This view (${options.activeView})`, bindings: viewBindings },
   ]
 }
 

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -27,6 +27,7 @@ import {
 } from './inkHistoryRows'
 import {
   formatBindingKeys,
+  formatLogInkBreadcrumb,
   getLogInkCommandPaletteItems,
   getLogInkFooterHints,
   getLogInkHelpSections,
@@ -931,7 +932,8 @@ function renderHeader(
       : 'no PR'
   const search = state.filterMode ? `search: ${state.filter}_` : state.filter ? `filter: ${state.filter}` : ''
   const loading = isLogInkContextLoading(contextStatus) ? '  loading context' : ''
-  const view = state.activeView === 'history' ? '' : `  ${state.activeView}`
+  const breadcrumb = formatLogInkBreadcrumb(state.viewStack)
+  const view = breadcrumb ? `  ${breadcrumb}` : ''
   const title = truncate(`${appLabel}  ${repo}  ${branch}  ${dirty}  ${pr}${view}${loading}`, columns - 2)
 
   return h(Box, {
@@ -1193,7 +1195,7 @@ function renderDetailPanel(
   const focused = state.focus === 'detail'
 
   if (state.showHelp) {
-    return renderHelpPanel(h, components, width, theme, focused)
+    return renderHelpPanel(h, components, state, width, theme, focused)
   }
 
   if (state.showCommandPalette) {
@@ -1364,6 +1366,7 @@ function renderConfirmationPanel(
 function renderHelpPanel(
   h: typeof ReactTypes.createElement,
   components: LogInkComponents,
+  state: LogInkState,
   width: number,
   theme: LogInkTheme,
   focused: boolean
@@ -1373,11 +1376,16 @@ function renderHelpPanel(
     h(Text, { bold: true, key: 'title' }, panelTitle('Help', focused)),
   ]
 
-  for (const section of getLogInkHelpSections()) {
+  const sections = getLogInkHelpSections({
+    activeView: state.activeView,
+    focus: state.focus,
+  })
+
+  for (const section of sections) {
     children.push(h(Text, { key: `${section.title}-spacer` }, ''))
     children.push(h(Text, { bold: true, key: section.title }, section.title))
     section.bindings.forEach((binding) => {
-      children.push(h(Text, { key: binding.id },
+      children.push(h(Text, { key: `${section.title}:${binding.id}` },
         truncate(`${formatBindingKeys(binding).padEnd(14)} ${binding.description}`, width - 4)
       ))
     })
@@ -1446,10 +1454,15 @@ function renderFooter(
     showHelp: state.showHelp,
   })
   const status = state.statusMessage ? `  ${state.statusMessage}` : ''
+  const contextualText = `${hints.contextual.join('   ')}${status}`
+  const globalText = hints.global.join(' · ')
 
   return h(Box, {
+    flexDirection: 'row',
     height: 2,
+    justifyContent: 'space-between',
     paddingX: 1,
   },
-  h(Text, { color: theme.colors.muted, dimColor: true }, `${hints.join('   ')}${status}`))
+  h(Text, { color: theme.colors.muted, dimColor: true }, contextualText),
+  h(Text, { color: theme.colors.muted, dimColor: true }, globalText))
 }


### PR DESCRIPTION
## Summary

Phase 2 of the TUI shell epic (#747). A consistent visual frame around every view so users always know **where they are**, **what they can press**, and **how to get help** — without each view inventing its own chrome. Visual diff is intentionally contained to the header, footer, and help overlay; main-area rendering of every existing view is unchanged.

Closes #741. Builds on #748.

## What changed

### Header

- Title bar now renders a \`›\`-separated **breadcrumb** derived from \`state.viewStack\` (added in #748). Single-frame stacks at the history root render compactly with no breadcrumb (no behavioral change for default open).
- New \`formatLogInkBreadcrumb(viewStack)\` helper, exported and tested.

| stack | breadcrumb |
|---|---|
| \`['history']\` | (empty) |
| \`['status']\` | \`status\` |
| \`['history', 'diff']\` | \`history › diff\` |
| \`['history', 'status', 'diff']\` | \`history › status › diff\` |

### Footer

- \`getLogInkFooterHints\` return type changed from \`string[]\` to \`{ contextual: string[]; global: string[] }\`.
  - **\`contextual\`** = what changes by mode/view/focus.
  - **\`global\`** = persistent affordances (\`? help · : cmds · q quit\`), trimmed in special modes where those keys mean close.
- \`renderFooter\` lays the two slots out as \`space-between\`, so the contextual hints sit on the left and the global affordances always sit on the right edge.
- All hints continue to flow from the keymap — no hardcoded duplication.

### Help overlay

- \`getLogInkHelpSections\` now takes \`{ activeView, focus }\` and returns two top-level groups:
  - **\`Global\`** — bindings that work from any view or focus (\`?\`, \`:\`, \`q\`, focus nav, refresh, workflow actions).
  - **\`This view (...)\`** — bindings filtered to the current view + focus, with the active view appended to the section title so users always see which scope applies.
- \`renderHelpPanel\` threads view + focus through from state.

## Test plan

\`inkKeymap.test.ts\` updated for the new return shapes; coverage added for:

- [x] Breadcrumb formatting — empty stack, single-frame root, single-frame non-root, multi-frame
- [x] Contextual / global split in every existing mode (history, status, diff, sidebar focus, detail focus)
- [x] Global hints reduced in special modes (filter, help open, palette open) — and \`q quit\` always present somewhere
- [x] Help groups labelled \`Global\` and \`This view (<active>)\`
- [x] Group membership: globals exclude view bindings and vice versa
- [x] Active-view label changes when the active view does

Local release-gate run:

- [x] \`npm run lint\`
- [x] \`npm run test:jest\` — 608/608 across 89 suites
- [x] \`npm run build\`
- [x] \`npm run test:cli\` — 10 packaged-CLI smoke checks
- [x] \`npm run release:dry-run\`

## Unblocks

- Phase 3 (#742): cross-view keybindings can plug into the existing keymap and have the new chrome reflect them automatically — footer/help update with no extra render code.
- Phase 4 (#743): compose-as-view will appear in breadcrumbs the moment its \`LogInkView\` lands.
- Phase 6 (#745): the palette's command-list rendering can reuse the help-section grouping pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)