### PR TITLE
feat(log-tui): cross-view keybindings and contextual transitions

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -95,8 +95,18 @@ describe('log Ink input interactions', () => {
     state = applyInput(state, '', { tab: true, shift: true })
     expect(state.focus).toBe('commits')
 
-    state = applyInput(state, 'g')
+    state = applyInput(state, '\\')
     expect(state.fullGraph).toBe(true)
+
+    state = applyInput(state, '\\')
+    expect(state.fullGraph).toBe(false)
+
+    // gg jump to top: first 'g' is a pure prefix, second 'g' fires moveToTop.
+    state = applyLogInkAction(state, { type: 'move', delta: 2 })
+    expect(state.selectedIndex).toBeGreaterThan(0)
+
+    state = applyInput(state, 'g')
+    expect(state.pendingKey).toBe('g')
 
     state = applyInput(state, 'g')
     expect(state.selectedIndex).toBe(0)
@@ -298,6 +308,112 @@ describe('log Ink input interactions', () => {
     expect(getLogInkInputEvents(createLogInkState(rows), 'r')).toEqual([
       { type: 'refreshContext' },
     ])
+  })
+
+  it('jumps to history with the gh chord and clears the navigation stack', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'status' })
+    state = applyLogInkAction(state, { type: 'pushView', value: 'diff' })
+
+    state = applyInput(state, 'g')
+    expect(state.pendingKey).toBe('g')
+
+    state = applyInput(state, 'h')
+    expect(state.viewStack).toEqual(['history'])
+    expect(state.activeView).toBe('history')
+    expect(state.statusMessage).toBe('jumped to history')
+  })
+
+  it('pushes the status view with the gs chord', () => {
+    let state = createLogInkState(rows)
+
+    state = applyInput(state, 'g')
+    state = applyInput(state, 's')
+
+    expect(state.viewStack).toEqual(['history', 'status'])
+    expect(state.activeView).toBe('status')
+    expect(state.statusMessage).toBe('jumped to status')
+  })
+
+  it('pushes the diff view with the gd chord', () => {
+    let state = createLogInkState(rows)
+
+    state = applyInput(state, 'g')
+    state = applyInput(state, 'd')
+
+    expect(state.viewStack).toEqual(['history', 'diff'])
+    expect(state.activeView).toBe('diff')
+    expect(state.statusMessage).toBe('jumped to diff')
+  })
+
+  it('pops the navigation stack with < (back)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'status' })
+    state = applyLogInkAction(state, { type: 'pushView', value: 'diff' })
+
+    state = applyInput(state, '<')
+    expect(state.viewStack).toEqual(['history', 'status'])
+    expect(state.activeView).toBe('status')
+
+    state = applyInput(state, '<')
+    expect(state.viewStack).toEqual(['history'])
+    expect(state.activeView).toBe('history')
+
+    // No-op when the stack is at the root.
+    state = applyInput(state, '<')
+    expect(state.viewStack).toEqual(['history'])
+  })
+
+  it('uses escape as back when the navigation stack has been pushed onto', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'diff' })
+
+    state = applyInput(state, '', { escape: true })
+    expect(state.viewStack).toEqual(['history'])
+    expect(state.activeView).toBe('history')
+  })
+
+  it('opens diff for the selected commit with enter from history view', () => {
+    let state = createLogInkState(rows)
+    state = applyInput(state, 'j') // move to def5678
+    expect(state.selectedIndex).toBe(1)
+
+    state = applyInput(state, '', { return: true })
+
+    expect(state.viewStack).toEqual(['history', 'diff'])
+    expect(state.activeView).toBe('diff')
+    expect(state.statusMessage).toBe('viewing diff for def5678')
+  })
+
+  it('opens diff for the selected file with enter from status view, preserving stack depth', () => {
+    let state = createLogInkState(rows, { activeView: 'status' })
+
+    state = applyInput(state, 'j', {}, { worktreeFileCount: 3 })
+    expect(state.selectedWorktreeFileIndex).toBe(1)
+
+    state = applyInput(state, '', { return: true }, { worktreeFileCount: 3 })
+
+    expect(state.viewStack).toEqual(['status', 'diff'])
+    expect(state.activeView).toBe('diff')
+    expect(state.selectedWorktreeFileIndex).toBe(1)
+
+    // Escape pops back to status (where we came from).
+    state = applyInput(state, '', { escape: true })
+    expect(state.activeView).toBe('status')
+  })
+
+  it('toggles graph with the relocated \\\\ key (g is now a pure prefix)', () => {
+    let state = createLogInkState(rows)
+    expect(state.fullGraph).toBe(false)
+
+    // Single g press only sets a pending chord — no graph flicker.
+    state = applyInput(state, 'g')
+    expect(state.fullGraph).toBe(false)
+    expect(state.pendingKey).toBe('g')
+
+    // \\ is the new toggle.
+    state = applyInput(state, '\\')
+    expect(state.fullGraph).toBe(true)
   })
 
   it('gates destructive and AI workflow actions behind confirmation', () => {

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -178,8 +178,8 @@ export function getLogInkInputEvents(
     return [action({ type: 'toggleCommandPalette' })]
   }
 
-  if (key.escape && state.activeView === 'diff') {
-    return [action({ type: 'setActiveView', value: 'status' })]
+  if (key.escape && state.viewStack.length > 1) {
+    return [action({ type: 'popView' })]
   }
 
   if (inputValue === 'q') {
@@ -194,6 +194,27 @@ export function getLogInkInputEvents(
     return [action({ type: 'toggleFilterMode' })]
   }
 
+  if (state.pendingKey === 'g' && inputValue === 'h') {
+    return [
+      action({ type: 'navigateHome' }),
+      action({ type: 'setStatus', value: 'jumped to history' }),
+    ]
+  }
+
+  if (state.pendingKey === 'g' && inputValue === 's') {
+    return [
+      action({ type: 'pushView', value: 'status' }),
+      action({ type: 'setStatus', value: 'jumped to status' }),
+    ]
+  }
+
+  if (state.pendingKey === 'g' && inputValue === 'd') {
+    return [
+      action({ type: 'pushView', value: 'diff' }),
+      action({ type: 'setStatus', value: 'jumped to diff' }),
+    ]
+  }
+
   if (inputValue === 'g') {
     if (state.pendingKey === 'g') {
       return [
@@ -202,10 +223,15 @@ export function getLogInkInputEvents(
       ]
     }
 
-    return [
-      action({ type: 'toggleGraph' }),
-      action({ type: 'setPendingKey', value: 'g' }),
-    ]
+    return [action({ type: 'setPendingKey', value: 'g' })]
+  }
+
+  if (inputValue === '\\') {
+    return [action({ type: 'toggleGraph' })]
+  }
+
+  if (inputValue === '<') {
+    return [action({ type: 'popView' })]
   }
 
   if (inputValue === 'G') {
@@ -343,8 +369,30 @@ export function getLogInkInputEvents(
     return [action({ type: 'page', delta: 10 })]
   }
 
+  if (
+    key.return &&
+    state.activeView === 'history' &&
+    state.focus === 'commits' &&
+    state.filteredCommits.length > 0
+  ) {
+    const selected = state.filteredCommits[state.selectedIndex]
+    if (selected) {
+      return [
+        action({
+          type: 'navigateOpenDiffForCommit',
+          sha: selected.hash,
+          commitIndex: state.selectedIndex,
+        }),
+        action({ type: 'setStatus', value: `viewing diff for ${selected.shortHash}` }),
+      ]
+    }
+  }
+
   if (key.return && state.activeView === 'status' && context.worktreeFileCount) {
-    return [action({ type: 'setActiveView', value: 'diff' })]
+    return [action({
+      type: 'navigateOpenDiffForWorktreeFile',
+      fileIndex: state.selectedWorktreeFileIndex,
+    })]
   }
 
   if (inputValue === ' ' && state.activeView === 'status' && context.worktreeFileCount) {

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -15,7 +15,7 @@ describe('log Ink keymap', () => {
       showHelp: false,
     })).toEqual({
       contextual: ['↑/↓ move', '/ search', 'gg/G top/bottom', 'n/N next'],
-      global: ['? help', ': cmds', 'q quit'],
+      global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 
     expect(getLogInkFooterHints({
@@ -25,7 +25,7 @@ describe('log Ink keymap', () => {
       showHelp: false,
     })).toEqual({
       contextual: ['↑/↓ files', 'enter diff', 'space stage', 'z revert', 'e/c compose'],
-      global: ['? help', ': cmds', 'q quit'],
+      global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 
     expect(getLogInkFooterHints({
@@ -35,7 +35,7 @@ describe('log Ink keymap', () => {
       showHelp: false,
     })).toEqual({
       contextual: ['j/k hunks', 'space stage', 'z revert', 'e/c compose', 'esc files'],
-      global: ['? help', ': cmds', 'q quit'],
+      global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 
     expect(getLogInkFooterHints({
@@ -44,7 +44,7 @@ describe('log Ink keymap', () => {
       showHelp: false,
     })).toEqual({
       contextual: ['[/] tab', '1-5 jump', 'tab focus'],
-      global: ['? help', ': cmds', 'q quit'],
+      global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 
     expect(getLogInkFooterHints({
@@ -53,7 +53,7 @@ describe('log Ink keymap', () => {
       showHelp: false,
     })).toEqual({
       contextual: ['↑/↓ files', 'pgup/pgdn diff', 'tab focus'],
-      global: ['? help', ': cmds', 'q quit'],
+      global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
   })
 
@@ -125,7 +125,7 @@ describe('log Ink keymap', () => {
       .join('\n')
 
     expect(helpText).toContain('/ Filter commits')
-    expect(helpText).toContain('g Toggle compact and full graph display.')
+    expect(helpText).toContain('\\ Toggle compact and full graph display.')
     expect(helpText).toContain('gg Jump to the first visible commit.')
     expect(helpText).toContain('G Jump to the last visible commit.')
     expect(helpText).toContain('z Ask to revert the selected file or hunk.')

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -11,9 +11,14 @@ export type LogInkCommandId =
   | 'moveDown'
   | 'moveToBottom'
   | 'moveToTop'
+  | 'navigateBack'
+  | 'navigateDiff'
+  | 'navigateHome'
+  | 'navigateStatus'
   | 'nextMatch'
   | 'nextSidebarTab'
   | 'moveUp'
+  | 'openSelected'
   | 'pageDown'
   | 'pageUp'
   | 'previousMatch'
@@ -146,10 +151,45 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
   },
   {
     id: 'toggleGraph',
-    keys: ['g'],
+    keys: ['\\'],
     label: 'graph',
     description: 'Toggle compact and full graph display.',
     contexts: ['normal', 'commits'],
+  },
+  {
+    id: 'navigateHome',
+    keys: ['gh'],
+    label: 'home',
+    description: 'Jump to the history root view (clears the navigation stack).',
+    contexts: ['normal'],
+  },
+  {
+    id: 'navigateStatus',
+    keys: ['gs'],
+    label: 'status',
+    description: 'Push the working-tree status view onto the navigation stack.',
+    contexts: ['normal'],
+  },
+  {
+    id: 'navigateDiff',
+    keys: ['gd'],
+    label: 'diff',
+    description: 'Push the diff view for the selected commit or file.',
+    contexts: ['normal'],
+  },
+  {
+    id: 'navigateBack',
+    keys: ['<', 'esc'],
+    label: 'back',
+    description: 'Pop the navigation stack and return to the previous view.',
+    contexts: ['normal'],
+  },
+  {
+    id: 'openSelected',
+    keys: ['enter'],
+    label: 'open',
+    description: 'Open the diff for the selected commit (history) or file (status).',
+    contexts: ['commits'],
   },
   {
     id: 'refresh',
@@ -241,9 +281,13 @@ const GLOBAL_BINDING_IDS: LogInkCommandId[] = [
   'focusPrevious',
   'refresh',
   'quit',
+  'navigateHome',
+  'navigateStatus',
+  'navigateDiff',
+  'navigateBack',
 ]
 
-const NORMAL_GLOBAL_HINTS = ['? help', ': cmds', 'q quit']
+const NORMAL_GLOBAL_HINTS = ['g jump', '< back', '? help', ': cmds', 'q quit']
 
 export function formatBindingKeys(binding: LogInkKeyBinding): string {
   return binding.keys.join('/')


### PR DESCRIPTION
## Summary

Phase 3 of the TUI shell epic (#747) and the **user-visible unlock**. Every view is now reachable from every other view, and the obvious transitions are wired up. Footer and help update automatically through the keymap-derived hint system from #748/#749 — no hardcoded strings.

Closes #742.

## Global jumps

\`g\` is now a **pure chord prefix**. Single \`g\` no longer does anything visible — it just sets the pending chord.

| Chord | Action |
|---|---|
| \`g h\` | navigateHome (clears the stack to history root) |
| \`g s\` | pushView \`'status'\` |
| \`g d\` | pushView \`'diff'\` |
| \`g g\` | jump to first commit (existing) |
| \`<\` | popView (back) |
| \`esc\` | popView when the stack has been pushed onto |

## Contextual transitions

| Trigger | Behavior |
|---|---|
| \`enter\` on a commit (history view) | push diff scoped to that commit via \`navigateOpenDiffForCommit\` (selectedIndex follows the user) |
| \`enter\` on a file row (status view) | push diff scoped to that file via \`navigateOpenDiffForWorktreeFile\` |

The status-file enter path previously used \`setActiveView\` (replace) — users couldn't pop back. It now pushes, so \`<\` / \`esc\` returns to status as expected.

## Keymap migration

- \`g\` no longer toggles graph as a side effect of starting a \`gg\` chord (the old behavior caused a brief graph flicker on every \`g\`-prefixed chord).
- \`\\\\\` is the new \`toggleGraph\` binding. Surfaced in the help overlay and command palette so users can discover it.

## Footer + help

Both update through the existing keymap-derived helpers — no hardcoded strings:

- **Footer global slot** now reads \`g jump · < back · ? help · : cmds · q quit\`.
- **Help overlay's \`Global\` group** lists \`navigateHome\` / \`navigateStatus\` / \`navigateDiff\` / \`navigateBack\` alongside the existing global affordances.
- The \`This view (...)\` group still filters by \`activeView\` + \`focus\` from #749.

## Test plan

8 new cases in \`inkInput.test.ts\`:

- [x] \`g h\` chord → navigateHome, viewStack reset to root
- [x] \`g s\` chord → push status, viewStack \`['history', 'status']\`
- [x] \`g d\` chord → push diff, viewStack \`['history', 'diff']\`
- [x] \`<\` pops the stack and refuses to drop below root
- [x] \`esc\` pops when the stack has been pushed onto
- [x] \`enter\` on a commit in history pushes diff scoped to that commit (status message confirms which sha)
- [x] \`enter\` on a file in status pushes diff and preserves stack depth (escape returns to status)
- [x] \`g\` is a pure prefix (no graph flicker), \`\\\\\` is the new toggle

Local release-gate run:

- [x] \`npm run lint\`
- [x] \`npm run test:jest\` — 616/616 across 89 suites
- [x] \`npm run build\`
- [x] \`npm run test:cli\` — 10 packaged-CLI smoke checks
- [x] \`npm run release:dry-run\`

## Notes for review

- \`gc\` (compose jump) is intentionally **not** included — compose isn't a top-level \`LogInkView\` yet. That binding lands with phase 4 (#743) when compose becomes its own view.
- The \`\\\\\` migration for graph toggle is the only existing-key change. Worth calling out in 0.34.0 release notes.

## Unblocks

- Phase 4 (#743): \`gc\` chord can plug in once \`'compose'\` joins \`LogInkView\`.
- Phase 5 (#744): \`gb\` / \`gt\` / \`gss\` (or similar) chords can be added the same way.
- Phase 6 (#745): the palette already enumerates all bindings — the new ones show up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)