### PR TITLE
feat(log-tui): promote commit compose to a top-level view

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -402,6 +402,99 @@ describe('log Ink input interactions', () => {
     expect(state.activeView).toBe('status')
   })
 
+  it('jumps to compose with the gc chord', () => {
+    let state = createLogInkState(rows)
+
+    state = applyInput(state, 'g')
+    expect(state.pendingKey).toBe('g')
+
+    state = applyInput(state, 'c')
+    expect(state.viewStack).toEqual(['history', 'compose'])
+    expect(state.activeView).toBe('compose')
+    expect(state.statusMessage).toBe('jumped to compose')
+  })
+
+  it('routes e from status to compose with editing started', () => {
+    let state = createLogInkState(rows, { activeView: 'status' })
+
+    const events = getLogInkInputEvents(state, 'e', {}, { worktreeFileCount: 1 })
+    expect(events).toEqual([
+      { type: 'action', action: { type: 'pushView', value: 'compose' } },
+      {
+        type: 'action',
+        action: { type: 'commitCompose', action: { type: 'setEditing', value: true } },
+      },
+    ])
+
+    state = events
+      .filter((event): event is Extract<typeof event, { type: 'action' }> => event.type === 'action')
+      .reduce((current, event) => applyLogInkAction(current, event.action), state)
+
+    expect(state.viewStack).toEqual(['status', 'compose'])
+    expect(state.activeView).toBe('compose')
+    expect(state.commitCompose.editing).toBe(true)
+  })
+
+  it('routes c from diff to compose then commits', () => {
+    const state = createLogInkState(rows, { activeView: 'diff' })
+
+    expect(getLogInkInputEvents(state, 'c', {}, { worktreeFileCount: 1 })).toEqual([
+      { type: 'action', action: { type: 'pushView', value: 'compose' } },
+      { type: 'createManualCommit' },
+    ])
+  })
+
+  it('e from compose toggles editing without re-pushing the view', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'compose' })
+
+    expect(getLogInkInputEvents(state, 'e')).toEqual([
+      {
+        type: 'action',
+        action: { type: 'commitCompose', action: { type: 'setEditing', value: true } },
+      },
+    ])
+  })
+
+  it('c from compose commits without re-pushing the view', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'compose' })
+
+    expect(getLogInkInputEvents(state, 'c')).toEqual([{ type: 'createManualCommit' }])
+  })
+
+  it('preserves draft state across compose → history → compose round-trips', () => {
+    let state = createLogInkState(rows)
+
+    // gc → push compose
+    state = applyInput(state, 'g')
+    state = applyInput(state, 'c')
+    expect(state.activeView).toBe('compose')
+
+    // e → start editing, then type "hello" into the summary.
+    state = applyInput(state, 'e')
+    expect(state.commitCompose.editing).toBe(true)
+    state = applyInput(state, 'h')
+    state = applyInput(state, 'e')
+    state = applyInput(state, 'l')
+    state = applyInput(state, 'l')
+    state = applyInput(state, 'o')
+    expect(state.commitCompose.summary).toBe('hello')
+
+    // Leave editing, then jump home.
+    state = applyInput(state, '', { escape: true })
+    expect(state.commitCompose.editing).toBe(false)
+    state = applyInput(state, 'g')
+    state = applyInput(state, 'h')
+    expect(state.activeView).toBe('history')
+
+    // Round-trip back to compose. Draft must still be there.
+    state = applyInput(state, 'g')
+    state = applyInput(state, 'c')
+    expect(state.activeView).toBe('compose')
+    expect(state.commitCompose.summary).toBe('hello')
+  })
+
   it('toggles graph with the relocated \\\\ key (g is now a pure prefix)', () => {
     let state = createLogInkState(rows)
     expect(state.fullGraph).toBe(false)

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -215,6 +215,13 @@ export function getLogInkInputEvents(
     ]
   }
 
+  if (state.pendingKey === 'g' && inputValue === 'c') {
+    return [
+      action({ type: 'pushView', value: 'compose' }),
+      action({ type: 'setStatus', value: 'jumped to compose' }),
+    ]
+  }
+
   if (inputValue === 'g') {
     if (state.pendingKey === 'g') {
       return [
@@ -411,12 +418,28 @@ export function getLogInkInputEvents(
     return [action({ type: 'setPendingMutationConfirmation', value: 'revert-hunk' })]
   }
 
-  if (inputValue === 'e' && (state.activeView === 'status' || state.activeView === 'diff')) {
-    return [action({ type: 'commitCompose', action: { type: 'setEditing', value: true } })]
+  if (
+    inputValue === 'e' &&
+    (state.activeView === 'status' || state.activeView === 'diff' || state.activeView === 'compose')
+  ) {
+    const events: LogInkInputEvent[] = []
+    if (state.activeView !== 'compose') {
+      events.push(action({ type: 'pushView', value: 'compose' }))
+    }
+    events.push(action({ type: 'commitCompose', action: { type: 'setEditing', value: true } }))
+    return events
   }
 
-  if (inputValue === 'c' && (state.activeView === 'status' || state.activeView === 'diff')) {
-    return [{ type: 'createManualCommit' }]
+  if (
+    inputValue === 'c' &&
+    (state.activeView === 'status' || state.activeView === 'diff' || state.activeView === 'compose')
+  ) {
+    const events: LogInkInputEvent[] = []
+    if (state.activeView !== 'compose') {
+      events.push(action({ type: 'pushView', value: 'compose' }))
+    }
+    events.push({ type: 'createManualCommit' })
+    return events
   }
 
   const workflowAction = getLogInkWorkflowActionByKey(inputValue)

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -39,6 +39,16 @@ describe('log Ink keymap', () => {
     })
 
     expect(getLogInkFooterHints({
+      activeView: 'compose',
+      filterMode: false,
+      focus: 'commits',
+      showHelp: false,
+    })).toEqual({
+      contextual: ['e edit', 'tab field', 'c commit', 'I AI draft', 'esc back'],
+      global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
+    })
+
+    expect(getLogInkFooterHints({
       filterMode: false,
       focus: 'sidebar',
       showHelp: false,
@@ -141,6 +151,17 @@ describe('log Ink keymap', () => {
     expect(formatLogInkBreadcrumb(['status'])).toBe('status')
     expect(formatLogInkBreadcrumb(['history', 'diff'])).toBe('history › diff')
     expect(formatLogInkBreadcrumb(['history', 'status', 'diff'])).toBe('history › status › diff')
+    expect(formatLogInkBreadcrumb(['history', 'compose'])).toBe('history › compose')
+  })
+
+  it('exposes the gc compose chord as a global navigation binding', () => {
+    const sections = getLogInkHelpSections({ activeView: 'history', focus: 'commits' })
+    const globalIds = sections[0].bindings.map((binding) => binding.id)
+
+    expect(globalIds).toContain('navigateCompose')
+
+    const composeBinding = sections[0].bindings.find((binding) => binding.id === 'navigateCompose')
+    expect(composeBinding?.keys).toEqual(['gc'])
   })
 
   it('derives command palette entries from the shared keymap', () => {

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -12,6 +12,7 @@ export type LogInkCommandId =
   | 'moveToBottom'
   | 'moveToTop'
   | 'navigateBack'
+  | 'navigateCompose'
   | 'navigateDiff'
   | 'navigateHome'
   | 'navigateStatus'
@@ -178,6 +179,13 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     contexts: ['normal'],
   },
   {
+    id: 'navigateCompose',
+    keys: ['gc'],
+    label: 'compose',
+    description: 'Push the commit-compose view (draft + staged-files summary).',
+    contexts: ['normal'],
+  },
+  {
     id: 'navigateBack',
     keys: ['<', 'esc'],
     label: 'back',
@@ -284,6 +292,7 @@ const GLOBAL_BINDING_IDS: LogInkCommandId[] = [
   'navigateHome',
   'navigateStatus',
   'navigateDiff',
+  'navigateCompose',
   'navigateBack',
 ]
 
@@ -362,6 +371,13 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
   if (options.activeView === 'diff') {
     return {
       contextual: ['j/k hunks', 'space stage', 'z revert', 'e/c compose', 'esc files'],
+      global: NORMAL_GLOBAL_HINTS,
+    }
+  }
+
+  if (options.activeView === 'compose') {
+    return {
+      contextual: ['e edit', 'tab field', 'c commit', 'I AI draft', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -1008,6 +1008,10 @@ function renderMainPanel(
     )
   }
 
+  if (state.activeView === 'compose') {
+    return renderComposeSurface(h, components, state, context, contextStatus, bodyRows, theme)
+  }
+
   return renderHistoryPanel(
     h,
     components,
@@ -1117,6 +1121,82 @@ function renderStatusSurface(
     key: `status-surface-${index}`,
     dimColor: index > 0,
   }, truncate(line, 140))))
+}
+
+function renderComposeSurface(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  bodyRows: number,
+  theme: LogInkTheme
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const compose = state.commitCompose
+  const focused = state.focus === 'commits'
+  const worktree = context.worktree
+  const statusLine = isLogInkContextKeyLoading(contextStatus, 'worktree')
+    ? 'Status loading'
+    : worktree
+      ? `${worktree.stagedCount} staged | ${worktree.unstagedCount} unstaged | ${worktree.untrackedCount} untracked`
+      : 'No worktree info yet'
+  const summaryCursor = compose.editing && compose.field === 'summary' ? '_' : ''
+  const bodyCursor = compose.editing && compose.field === 'body' ? '_' : ''
+  const bodyRowsAvailable = Math.max(4, bodyRows - 10)
+  const bodyLines = compose.body
+    ? compose.body.split('\n').slice(0, bodyRowsAvailable)
+    : ['<empty>']
+  const stateLine = compose.loading
+    ? 'Working...'
+    : compose.editing
+      ? 'Editing — Enter switches summary↔body, Esc exits edit mode.'
+      : 'Press e to edit, c to commit, I for AI draft, esc to leave.'
+  const stagedFileLines = (worktree?.files || [])
+    .filter((file) => file.indexStatus !== ' ' && file.indexStatus !== '?')
+    .slice(0, 5)
+    .map((file) => `  ${file.indexStatus} ${file.path}`)
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    flexGrow: 1,
+    paddingX: 1,
+  },
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle('Compose commit', focused)),
+    h(Text, { dimColor: true }, statusLine)
+  ),
+  h(Text, undefined, ''),
+  h(Text, {
+    bold: compose.field === 'summary' && compose.editing,
+  }, truncate(`Summary  ${compose.summary || '<empty>'}${summaryCursor}`, 140)),
+  h(Text, undefined, ''),
+  h(Text, {
+    bold: compose.field === 'body' && compose.editing,
+  }, 'Body'),
+  ...bodyLines.map((line, index) => h(Text, {
+    key: `compose-body-${index}`,
+    dimColor: line === '<empty>',
+  }, truncate(`  ${line}${bodyCursor && index === bodyLines.length - 1 ? bodyCursor : ''}`, 140))),
+  h(Text, undefined, ''),
+  h(Text, { dimColor: true }, stateLine),
+  ...(compose.message ? [h(Text, { key: 'compose-msg' }, truncate(compose.message, 140))] : []),
+  ...(compose.details || []).map((line, index) => h(Text, {
+    key: `compose-detail-${index}`,
+    dimColor: true,
+  }, truncate(`  ${line}`, 140))),
+  ...(stagedFileLines.length > 0
+    ? [
+      h(Text, { key: 'compose-staged-spacer' }, ''),
+      h(Text, { key: 'compose-staged-title', bold: true }, 'Staged'),
+      ...stagedFileLines.map((line, index) => h(Text, {
+        key: `compose-staged-${index}`,
+        dimColor: true,
+      }, truncate(line, 140))),
+    ]
+    : []))
 }
 
 function renderDiffSurface(

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -9,7 +9,7 @@ import {
 export type LogInkFocus = 'sidebar' | 'commits' | 'detail'
 
 export type LogInkSidebarTab = 'status' | 'branches' | 'tags' | 'stashes' | 'worktrees'
-export type LogInkView = 'history' | 'status' | 'diff'
+export type LogInkView = 'history' | 'status' | 'diff' | 'compose'
 export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk'
 
 export type CreateLogInkStateOptions = {


### PR DESCRIPTION
## Summary

Phase 4 of the TUI shell epic (#747). Compose is now a first-class destination instead of a hidden modal in the status/diff views — reachable, persistent, and consistent with the navigation model from #748–#750.

Closes #743.

## State

- \`LogInkView\` gains \`'compose'\`. The existing \`commitCompose\` state already lives on \`LogInkState\`, so draft contents persist across navigation **for free** — round-tripping through history and back never drops the user's in-progress message. The acceptance criterion ("Round-trip nav (compose → history → compose) preserves draft") falls out of the existing data model with no extra plumbing.

## Navigation

| Trigger | Behavior |
|---|---|
| \`g c\` | Push compose (matches the rest of the global jumps) |
| \`e\` from status/diff | Push compose **then** start editing |
| \`c\` from status/diff | Push compose **then** fire \`createManualCommit\` (compose surface shows the result) |
| \`e\` / \`c\` from compose | Behave the same without re-pushing |
| \`esc\` from compose | Pops back via the existing back handler from #750 |

## Render

\`renderComposeSurface\` renders the compose editor at main-panel size:

- Header with stage / unstage / untrack counts.
- Summary editor (single line, cursor when \`field === 'summary'\` and editing).
- Body editor (multi-line, cursor when \`field === 'body'\` and editing).
- Contextual state line (\`Editing — Enter switches…\` / \`Press e to edit, c to commit, I for AI draft, esc to leave.\`).
- AI / result feedback from \`compose.message\` + \`compose.details\` (existing pipeline).
- Compact staged-files summary (top 5 staged paths).

The detail panel intentionally falls through to the default selected-commit detail view — gives users a useful "what was already committed" companion while drafting the next commit.

## Chrome

- \`getLogInkFooterHints\` adds a compose case: \`e edit · tab field · c commit · I AI draft · esc back\`, alongside the persistent global slot from #749.
- \`getLogInkHelpSections\` surfaces \`navigateCompose\` (\`gc\`) in the **Global** group and the editor bindings in **This view (compose)**.
- Breadcrumb (#749) shows \`history › compose\` automatically.

## Test plan

\`inkInput.test.ts\` (+6 cases):

- [x] \`gc\` chord pushes compose
- [x] \`e\` from status pushes compose + sets editing
- [x] \`c\` from diff pushes compose + emits \`createManualCommit\`
- [x] \`e\` from compose toggles editing **without** re-pushing
- [x] \`c\` from compose commits **without** re-pushing
- [x] **Round-trip preservation:** \`gc\` → \`e\` → type \`hello\` → \`esc\` → \`gh\` → \`gc\` → summary still reads \`hello\`

\`inkKeymap.test.ts\` (+3 assertions):

- [x] Compose footer slot returns the editor hints
- [x] Breadcrumb formatter handles \`['history', 'compose']\`
- [x] \`navigateCompose\` appears in the Global help group with keys \`['gc']\`

Local release-gate run:

- [x] \`npm run lint\`
- [x] \`npm run test:jest\` — 623/623 across 89 suites
- [x] \`npm run build\`
- [x] \`npm run test:cli\` — 10 packaged-CLI smoke checks
- [x] \`npm run release:dry-run\`

## Unblocks

- Phase 5 (#744): branches/tags/stash views can ship with the same pattern (push view + chord + footer hints).
- Phase 6 (#745): the palette already enumerates all bindings — \`gc\` and the compose-editor bindings appear automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)