### PR TITLE
feat(log-tui): promote branches, tags, and stash to top-level views

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -346,6 +346,99 @@ describe('log Ink input interactions', () => {
     expect(state.statusMessage).toBe('jumped to diff')
   })
 
+  it('pushes branches with the gb chord', () => {
+    let state = createLogInkState(rows)
+
+    state = applyInput(state, 'g')
+    state = applyInput(state, 'b')
+
+    expect(state.viewStack).toEqual(['history', 'branches'])
+    expect(state.activeView).toBe('branches')
+    expect(state.statusMessage).toBe('jumped to branches')
+  })
+
+  it('pushes tags with the gt chord', () => {
+    let state = createLogInkState(rows)
+
+    state = applyInput(state, 'g')
+    state = applyInput(state, 't')
+
+    expect(state.viewStack).toEqual(['history', 'tags'])
+    expect(state.activeView).toBe('tags')
+    expect(state.statusMessage).toBe('jumped to tags')
+  })
+
+  it('pushes stash with the gz chord (gs is reserved for status)', () => {
+    let state = createLogInkState(rows)
+
+    state = applyInput(state, 'g')
+    state = applyInput(state, 'z')
+
+    expect(state.viewStack).toEqual(['history', 'stash'])
+    expect(state.activeView).toBe('stash')
+    expect(state.statusMessage).toBe('jumped to stash')
+  })
+
+  it('moves the selected branch with arrow keys when in branches view', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'branches' })
+
+    state = applyInput(state, 'j', {}, { branchCount: 5 })
+    expect(state.selectedBranchIndex).toBe(1)
+
+    state = applyInput(state, '', { downArrow: true }, { branchCount: 5 })
+    expect(state.selectedBranchIndex).toBe(2)
+
+    state = applyInput(state, 'k', {}, { branchCount: 5 })
+    expect(state.selectedBranchIndex).toBe(1)
+  })
+
+  it('moves the selected tag with arrow keys when in tags view', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'tags' })
+
+    state = applyInput(state, 'j', {}, { tagCount: 4 })
+    state = applyInput(state, 'j', {}, { tagCount: 4 })
+    expect(state.selectedTagIndex).toBe(2)
+  })
+
+  it('moves the selected stash with arrow keys when in stash view', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'stash' })
+
+    state = applyInput(state, 'j', {}, { stashCount: 3 })
+    state = applyInput(state, 'j', {}, { stashCount: 3 })
+    expect(state.selectedStashIndex).toBe(2)
+
+    // Clamped at the count boundary.
+    state = applyInput(state, 'j', {}, { stashCount: 3 })
+    expect(state.selectedStashIndex).toBe(2)
+  })
+
+  it('preserves per-view selection across navigation', () => {
+    let state = createLogInkState(rows)
+
+    // Move within branches.
+    state = applyLogInkAction(state, { type: 'pushView', value: 'branches' })
+    state = applyInput(state, 'j', {}, { branchCount: 5 })
+    state = applyInput(state, 'j', {}, { branchCount: 5 })
+    expect(state.selectedBranchIndex).toBe(2)
+
+    // Pop to history, push tags, move there.
+    state = applyInput(state, '<')
+    state = applyLogInkAction(state, { type: 'pushView', value: 'tags' })
+    state = applyInput(state, 'j', {}, { tagCount: 4 })
+    expect(state.selectedTagIndex).toBe(1)
+
+    // Selection state for branches should be preserved.
+    expect(state.selectedBranchIndex).toBe(2)
+
+    // Round-trip back to branches and confirm.
+    state = applyInput(state, '<')
+    state = applyLogInkAction(state, { type: 'pushView', value: 'branches' })
+    expect(state.selectedBranchIndex).toBe(2)
+  })
+
   it('pops the navigation stack with < (back)', () => {
     let state = createLogInkState(rows)
     state = applyLogInkAction(state, { type: 'pushView', value: 'status' })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -36,6 +36,9 @@ export type LogInkInputContext = {
   previewLineCount?: number
   worktreeDiffLineCount?: number
   worktreeFileCount?: number
+  branchCount?: number
+  tagCount?: number
+  stashCount?: number
 }
 
 function action(actionValue: LogInkAction): LogInkInputEvent {
@@ -222,6 +225,27 @@ export function getLogInkInputEvents(
     ]
   }
 
+  if (state.pendingKey === 'g' && inputValue === 'b') {
+    return [
+      action({ type: 'pushView', value: 'branches' }),
+      action({ type: 'setStatus', value: 'jumped to branches' }),
+    ]
+  }
+
+  if (state.pendingKey === 'g' && inputValue === 't') {
+    return [
+      action({ type: 'pushView', value: 'tags' }),
+      action({ type: 'setStatus', value: 'jumped to tags' }),
+    ]
+  }
+
+  if (state.pendingKey === 'g' && inputValue === 'z') {
+    return [
+      action({ type: 'pushView', value: 'stash' }),
+      action({ type: 'setStatus', value: 'jumped to stash' }),
+    ]
+  }
+
   if (inputValue === 'g') {
     if (state.pendingKey === 'g') {
       return [
@@ -301,6 +325,18 @@ export function getLogInkInputEvents(
       })]
     }
 
+    if (state.activeView === 'branches' && context.branchCount) {
+      return [action({ type: 'moveBranch', delta: -1, count: context.branchCount })]
+    }
+
+    if (state.activeView === 'tags' && context.tagCount) {
+      return [action({ type: 'moveTag', delta: -1, count: context.tagCount })]
+    }
+
+    if (state.activeView === 'stash' && context.stashCount) {
+      return [action({ type: 'moveStash', delta: -1, count: context.stashCount })]
+    }
+
     return [
       action(state.focus === 'sidebar'
         ? { type: 'previousSidebarTab' }
@@ -327,6 +363,18 @@ export function getLogInkInputEvents(
         delta: 1,
         hunkOffsets: context.worktreeHunkOffsets || [],
       })]
+    }
+
+    if (state.activeView === 'branches' && context.branchCount) {
+      return [action({ type: 'moveBranch', delta: 1, count: context.branchCount })]
+    }
+
+    if (state.activeView === 'tags' && context.tagCount) {
+      return [action({ type: 'moveTag', delta: 1, count: context.tagCount })]
+    }
+
+    if (state.activeView === 'stash' && context.stashCount) {
+      return [action({ type: 'moveStash', delta: 1, count: context.stashCount })]
     }
 
     return [

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -49,6 +49,36 @@ describe('log Ink keymap', () => {
     })
 
     expect(getLogInkFooterHints({
+      activeView: 'branches',
+      filterMode: false,
+      focus: 'commits',
+      showHelp: false,
+    })).toEqual({
+      contextual: ['↑/↓ branches', 'D delete', 'X checkout', 'enter diff', 'esc back'],
+      global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
+    })
+
+    expect(getLogInkFooterHints({
+      activeView: 'tags',
+      filterMode: false,
+      focus: 'commits',
+      showHelp: false,
+    })).toEqual({
+      contextual: ['↑/↓ tags', 'T create', 'X push', 'esc back'],
+      global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
+    })
+
+    expect(getLogInkFooterHints({
+      activeView: 'stash',
+      filterMode: false,
+      focus: 'commits',
+      showHelp: false,
+    })).toEqual({
+      contextual: ['↑/↓ stashes', 'A apply', 'D drop', 'esc back'],
+      global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
+    })
+
+    expect(getLogInkFooterHints({
       filterMode: false,
       focus: 'sidebar',
       showHelp: false,
@@ -162,6 +192,19 @@ describe('log Ink keymap', () => {
 
     const composeBinding = sections[0].bindings.find((binding) => binding.id === 'navigateCompose')
     expect(composeBinding?.keys).toEqual(['gc'])
+  })
+
+  it('exposes the gb/gt/gz chords as global navigation bindings', () => {
+    const sections = getLogInkHelpSections({ activeView: 'history', focus: 'commits' })
+    const globals = sections[0].bindings
+
+    const branches = globals.find((binding) => binding.id === 'navigateBranches')
+    const tags = globals.find((binding) => binding.id === 'navigateTags')
+    const stash = globals.find((binding) => binding.id === 'navigateStash')
+
+    expect(branches?.keys).toEqual(['gb'])
+    expect(tags?.keys).toEqual(['gt'])
+    expect(stash?.keys).toEqual(['gz'])
   })
 
   it('derives command palette entries from the shared keymap', () => {

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -12,10 +12,13 @@ export type LogInkCommandId =
   | 'moveToBottom'
   | 'moveToTop'
   | 'navigateBack'
+  | 'navigateBranches'
   | 'navigateCompose'
   | 'navigateDiff'
   | 'navigateHome'
+  | 'navigateStash'
   | 'navigateStatus'
+  | 'navigateTags'
   | 'nextMatch'
   | 'nextSidebarTab'
   | 'moveUp'
@@ -186,6 +189,27 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     contexts: ['normal'],
   },
   {
+    id: 'navigateBranches',
+    keys: ['gb'],
+    label: 'branches',
+    description: 'Push the branches view (local branches with divergence info).',
+    contexts: ['normal'],
+  },
+  {
+    id: 'navigateTags',
+    keys: ['gt'],
+    label: 'tags',
+    description: 'Push the tags view.',
+    contexts: ['normal'],
+  },
+  {
+    id: 'navigateStash',
+    keys: ['gz'],
+    label: 'stash',
+    description: 'Push the stash view (gz; gs is reserved for status).',
+    contexts: ['normal'],
+  },
+  {
     id: 'navigateBack',
     keys: ['<', 'esc'],
     label: 'back',
@@ -293,6 +317,9 @@ const GLOBAL_BINDING_IDS: LogInkCommandId[] = [
   'navigateStatus',
   'navigateDiff',
   'navigateCompose',
+  'navigateBranches',
+  'navigateTags',
+  'navigateStash',
   'navigateBack',
 ]
 
@@ -378,6 +405,27 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
   if (options.activeView === 'compose') {
     return {
       contextual: ['e edit', 'tab field', 'c commit', 'I AI draft', 'esc back'],
+      global: NORMAL_GLOBAL_HINTS,
+    }
+  }
+
+  if (options.activeView === 'branches') {
+    return {
+      contextual: ['↑/↓ branches', 'D delete', 'X checkout', 'enter diff', 'esc back'],
+      global: NORMAL_GLOBAL_HINTS,
+    }
+  }
+
+  if (options.activeView === 'tags') {
+    return {
+      contextual: ['↑/↓ tags', 'T create', 'X push', 'esc back'],
+      global: NORMAL_GLOBAL_HINTS,
+    }
+  }
+
+  if (options.activeView === 'stash') {
+    return {
+      contextual: ['↑/↓ stashes', 'A apply', 'D drop', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -836,6 +836,9 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       worktreeDiffLineCount: worktreeDiff?.lines.length,
       worktreeFileCount: context.worktree?.files.length,
       worktreeHunkOffsets: worktreeDiff?.hunkOffsets,
+      branchCount: context.branches?.localBranches.length,
+      tagCount: context.tags?.tags.length,
+      stashCount: context.stashes?.stashes.length,
     }).forEach((event) => {
       if (event.type === 'exit') {
         exit()
@@ -1010,6 +1013,18 @@ function renderMainPanel(
 
   if (state.activeView === 'compose') {
     return renderComposeSurface(h, components, state, context, contextStatus, bodyRows, theme)
+  }
+
+  if (state.activeView === 'branches') {
+    return renderBranchesSurface(h, components, state, context, contextStatus, bodyRows, theme)
+  }
+
+  if (state.activeView === 'tags') {
+    return renderTagsSurface(h, components, state, context, contextStatus, bodyRows, theme)
+  }
+
+  if (state.activeView === 'stash') {
+    return renderStashSurface(h, components, state, context, contextStatus, bodyRows, theme)
   }
 
   return renderHistoryPanel(
@@ -1197,6 +1212,152 @@ function renderComposeSurface(
       }, truncate(line, 140))),
     ]
     : []))
+}
+
+function renderBranchesSurface(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  bodyRows: number,
+  theme: LogInkTheme
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const focused = state.focus === 'commits'
+  const branches = context.branches
+  const loading = isLogInkContextKeyLoading(contextStatus, 'branches')
+  const localBranches = branches?.localBranches || []
+  const selected = state.selectedBranchIndex
+  const listRows = Math.max(4, bodyRows - 4)
+  const startIndex = Math.max(0, selected - Math.floor(listRows / 2))
+  const visible = localBranches.slice(startIndex, startIndex + listRows)
+  const headerRight = loading
+    ? 'loading branches'
+    : `${localBranches.length} local | current: ${branches?.currentBranch || '<detached>'}`
+  const lines: ReactTypes.ReactNode[] = loading
+    ? [h(Text, { key: 'branches-loading', dimColor: true }, 'Loading branches...')]
+    : localBranches.length === 0
+      ? [h(Text, { key: 'branches-empty', dimColor: true }, 'No local branches')]
+      : visible.map((branch, offset) => {
+        const index = startIndex + offset
+        const isSelected = index === selected
+        const cursor = isSelected ? '>' : ' '
+        const marker = branch.current ? '*' : ' '
+        const divergence = formatDivergence(branch)
+        return h(Text, {
+          key: `branch-${index}`,
+          bold: isSelected,
+          dimColor: !isSelected && !branch.current,
+        }, truncate(`${cursor} ${marker} ${branch.shortName.padEnd(28)} ${divergence}`, 140))
+      })
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    flexGrow: 1,
+    paddingX: 1,
+  },
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle('Branches', focused)),
+    h(Text, { dimColor: true }, headerRight)
+  ),
+  ...lines)
+}
+
+function renderTagsSurface(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  bodyRows: number,
+  theme: LogInkTheme
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const focused = state.focus === 'commits'
+  const loading = isLogInkContextKeyLoading(contextStatus, 'tags')
+  const tags = context.tags?.tags || []
+  const selected = state.selectedTagIndex
+  const listRows = Math.max(4, bodyRows - 4)
+  const startIndex = Math.max(0, selected - Math.floor(listRows / 2))
+  const visible = tags.slice(startIndex, startIndex + listRows)
+  const headerRight = loading ? 'loading tags' : `${tags.length} tags`
+  const lines: ReactTypes.ReactNode[] = loading
+    ? [h(Text, { key: 'tags-loading', dimColor: true }, 'Loading tags...')]
+    : tags.length === 0
+      ? [h(Text, { key: 'tags-empty', dimColor: true }, 'No tags found')]
+      : visible.map((tag, offset) => {
+        const index = startIndex + offset
+        const isSelected = index === selected
+        const cursor = isSelected ? '>' : ' '
+        return h(Text, {
+          key: `tag-${index}`,
+          bold: isSelected,
+          dimColor: !isSelected,
+        }, truncate(`${cursor} ${tag.name.padEnd(20)} ${tag.subject}`, 140))
+      })
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    flexGrow: 1,
+    paddingX: 1,
+  },
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle('Tags', focused)),
+    h(Text, { dimColor: true }, headerRight)
+  ),
+  ...lines)
+}
+
+function renderStashSurface(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  bodyRows: number,
+  theme: LogInkTheme
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const focused = state.focus === 'commits'
+  const loading = isLogInkContextKeyLoading(contextStatus, 'stashes')
+  const stashes = context.stashes?.stashes || []
+  const selected = state.selectedStashIndex
+  const listRows = Math.max(4, bodyRows - 4)
+  const startIndex = Math.max(0, selected - Math.floor(listRows / 2))
+  const visible = stashes.slice(startIndex, startIndex + listRows)
+  const headerRight = loading ? 'loading stashes' : `${stashes.length} stashes`
+  const lines: ReactTypes.ReactNode[] = loading
+    ? [h(Text, { key: 'stash-loading', dimColor: true }, 'Loading stashes...')]
+    : stashes.length === 0
+      ? [h(Text, { key: 'stash-empty', dimColor: true }, 'No stashes')]
+      : visible.map((stash, offset) => {
+        const index = startIndex + offset
+        const isSelected = index === selected
+        const cursor = isSelected ? '>' : ' '
+        return h(Text, {
+          key: `stash-${index}`,
+          bold: isSelected,
+          dimColor: !isSelected,
+        }, truncate(`${cursor} ${stash.ref.padEnd(12)} ${stash.message}`, 140))
+      })
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    flexGrow: 1,
+    paddingX: 1,
+  },
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle('Stash', focused)),
+    h(Text, { dimColor: true }, headerRight)
+  ),
+  ...lines)
 }
 
 function renderDiffSurface(

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -9,7 +9,7 @@ import {
 export type LogInkFocus = 'sidebar' | 'commits' | 'detail'
 
 export type LogInkSidebarTab = 'status' | 'branches' | 'tags' | 'stashes' | 'worktrees'
-export type LogInkView = 'history' | 'status' | 'diff' | 'compose'
+export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash'
 export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk'
 
 export type CreateLogInkStateOptions = {
@@ -34,6 +34,14 @@ export type LogInkState = {
   selectedFileIndex: number
   selectedWorktreeFileIndex: number
   selectedWorktreeHunkIndex: number
+  /**
+   * Cursor positions for the promoted top-level views (branches/tags/stash).
+   * Persisted on the root state so navigating away and back keeps the user's
+   * place in each list.
+   */
+  selectedBranchIndex: number
+  selectedTagIndex: number
+  selectedStashIndex: number
   commitCompose: CommitComposeState
   diffPreviewOffset: number
   worktreeDiffOffset: number
@@ -62,6 +70,9 @@ export type LogInkAction =
   | { type: 'move'; delta: number }
   | { type: 'moveDetailFile'; delta: number; fileCount: number }
   | { type: 'moveWorktreeFile'; delta: number; fileCount: number }
+  | { type: 'moveBranch'; delta: number; count: number }
+  | { type: 'moveTag'; delta: number; count: number }
+  | { type: 'moveStash'; delta: number; count: number }
   | { type: 'moveToBottom' }
   | { type: 'moveToTop' }
   | { type: 'nextSidebarTab' }
@@ -343,6 +354,9 @@ export function createLogInkState(
     selectedFileIndex: 0,
     selectedWorktreeFileIndex: 0,
     selectedWorktreeHunkIndex: 0,
+    selectedBranchIndex: 0,
+    selectedTagIndex: 0,
+    selectedStashIndex: 0,
     commitCompose: createCommitComposeState(),
     diffPreviewOffset: 0,
     worktreeDiffOffset: 0,
@@ -422,6 +436,24 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         worktreeDiffOffset: 0,
       }
     }
+    case 'moveBranch':
+      return {
+        ...state,
+        selectedBranchIndex: clampIndex(state.selectedBranchIndex + action.delta, action.count),
+        pendingKey: undefined,
+      }
+    case 'moveTag':
+      return {
+        ...state,
+        selectedTagIndex: clampIndex(state.selectedTagIndex + action.delta, action.count),
+        pendingKey: undefined,
+      }
+    case 'moveStash':
+      return {
+        ...state,
+        selectedStashIndex: clampIndex(state.selectedStashIndex + action.delta, action.count),
+        pendingKey: undefined,
+      }
     case 'moveToBottom':
       return {
         ...state,


### PR DESCRIPTION
## Summary

Phase 5 of the TUI shell epic (#747). Branches, tags, and stash are now first-class destinations alongside history, status, diff, and compose — driveable without first navigating through a commit. Reuses the existing workflow data (\`context.branches\` / \`context.tags\` / \`context.stashes\`) as the issue specified — this is a navigation rewrite, not a re-implementation.

Closes #744.

## Navigation

| Chord | Pushes |
|---|---|
| \`g b\` | \`branches\` |
| \`g t\` | \`tags\` |
| \`g z\` | \`stash\` |

\`gs\` is already taken (status, from #750) so I went with \`gz\` for stash. Of the available letters, \`z\` is the least-bad — clearly distinct from \`s\` and surfaced explicitly in help and the binding description so users learn it. \`<\` / \`esc\` continue to pop back through the existing handler from #750.

## State

- \`LogInkView\` adds \`'branches'\`, \`'tags'\`, \`'stash'\`.
- \`LogInkState\` gains \`selectedBranchIndex\`, \`selectedTagIndex\`, \`selectedStashIndex\`, all persisted on the root state so **navigating away and back keeps the user's place in each list** (acceptance criterion).
- Three new reducer actions: \`moveBranch\`, \`moveTag\`, \`moveStash\`. The existing arrow / vim-key dispatch routes to the right slot when the matching view is active.

## Render

\`renderBranchesSurface\`, \`renderTagsSurface\`, \`renderStashSurface\`:

- Selection cursor (\`>\`) on the active row, bold styling, dimmed siblings.
- Viewport slides with the selection (window centered around the selected index).
- Header with totals + relevant context (\`current: <branch>\`, count, etc.).
- Loading and empty states handled per-view.

The existing workflow actions (\`D\` delete-branch, \`X\` checkout, \`T\` create-tag, \`A\` apply-stash, etc.) keep firing through the existing pipeline — no re-implementation.

## Chrome

- \`getLogInkFooterHints\` adds branches / tags / stash cases:
  - branches: \`↑/↓ branches · D delete · X checkout · enter diff · esc back\`
  - tags: \`↑/↓ tags · T create · X push · esc back\`
  - stash: \`↑/↓ stashes · A apply · D drop · esc back\`
- \`getLogInkHelpSections\` surfaces \`navigateBranches\` / \`navigateTags\` / \`navigateStash\` in the **Global** group.
- Breadcrumb (#749) shows \`history › branches\` etc. for free.

## Test plan

\`inkInput.test.ts\` (+7 cases):

- [x] \`gb\` chord pushes branches
- [x] \`gt\` chord pushes tags
- [x] \`gz\` chord pushes stash (and \`gs\` still goes to status)
- [x] \`j\`/\`k\`/\`↑\`/\`↓\` move \`selectedBranchIndex\` in branches view
- [x] Arrow keys move tag/stash selection in their views
- [x] Stash selection clamps at the boundary (count - 1)
- [x] **Round-trip:** move within branches → jump to tags → move there → branch index still preserved → round-trip back to branches confirms

\`inkKeymap.test.ts\` (+4 assertions):

- [x] Footer hints for branches/tags/stash views
- [x] \`gb\` / \`gt\` / \`gz\` appear in the Global help group

Local release-gate run:

- [x] \`npm run lint\`
- [x] \`npm run test:jest\` — 631/631 across 89 suites
- [x] \`npm run build\`
- [x] \`npm run test:cli\` — 10 packaged-CLI smoke checks
- [x] \`npm run release:dry-run\`

## Unblocks

After this lands, the chord set is complete: \`g h/s/d/c/b/t/z\` covers every top-level view. Phase 6 (#745, palette + global search) can enumerate \`getLogInkCommandPaletteItems()\` and the new bindings appear automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)