### PR TITLE
feat(log-tui): interactive command palette and global search

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -602,6 +602,113 @@ describe('log Ink input interactions', () => {
     expect(state.fullGraph).toBe(true)
   })
 
+  describe('command palette', () => {
+    function openPalette() {
+      return applyLogInkAction(createLogInkState(rows), { type: 'toggleCommandPalette' })
+    }
+
+    it('intercepts every key while open — no leaks to normal handlers', () => {
+      let state = openPalette()
+      expect(state.showCommandPalette).toBe(true)
+
+      // Pressing 'j' would normally move the commit cursor; while the palette
+      // is open it must append to the filter instead.
+      state = applyInput(state, 'j')
+      expect(state.paletteFilter).toBe('j')
+      expect(state.selectedIndex).toBe(0) // commit cursor untouched
+    })
+
+    it('appends, backspaces, and clears the palette filter', () => {
+      let state = openPalette()
+
+      state = applyInput(state, 'b')
+      state = applyInput(state, 'r')
+      state = applyInput(state, 'a')
+      state = applyInput(state, 'n')
+      state = applyInput(state, 'c')
+      state = applyInput(state, 'h')
+      expect(state.paletteFilter).toBe('branch')
+
+      state = applyInput(state, '', { backspace: true })
+      expect(state.paletteFilter).toBe('branc')
+
+      state = applyInput(state, 'u', { ctrl: true })
+      expect(state.paletteFilter).toBe('')
+    })
+
+    it('moves the palette selection with arrow keys and ctrl+n/ctrl+p', () => {
+      let state = openPalette()
+
+      state = applyInput(state, '', { downArrow: true })
+      expect(state.paletteSelectedIndex).toBe(1)
+
+      state = applyInput(state, 'n', { ctrl: true })
+      expect(state.paletteSelectedIndex).toBe(2)
+
+      state = applyInput(state, '', { upArrow: true })
+      expect(state.paletteSelectedIndex).toBe(1)
+
+      state = applyInput(state, 'p', { ctrl: true })
+      expect(state.paletteSelectedIndex).toBe(0)
+    })
+
+    it('closes on escape without executing anything', () => {
+      let state = openPalette()
+      expect(state.showCommandPalette).toBe(true)
+
+      state = applyInput(state, '', { escape: true })
+      expect(state.showCommandPalette).toBe(false)
+      expect(state.paletteFilter).toBe('')
+      expect(state.paletteSelectedIndex).toBe(0)
+    })
+
+    it('executes the selected command on enter and closes', () => {
+      let state = openPalette()
+
+      // Filter to the home navigation, then run.
+      state = applyInput(state, 'h')
+      state = applyInput(state, 'o')
+      state = applyInput(state, 'm')
+      state = applyInput(state, 'e')
+
+      const events = getLogInkInputEvents(state, '', { return: true })
+      // First the palette records the recent command, then closes, then
+      // dispatches the command's events.
+      expect(events.length).toBeGreaterThan(0)
+      const types = events
+        .filter((event): event is Extract<typeof event, { type: 'action' }> => event.type === 'action')
+        .map((event) => event.action.type)
+      expect(types).toContain('recordPaletteRecent')
+      expect(types).toContain('toggleCommandPalette')
+      expect(types).toContain('navigateHome')
+    })
+
+    it('records executed commands in paletteRecent (most recent first, dedup)', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'recordPaletteRecent', value: 'navigateStatus' })
+      state = applyLogInkAction(state, { type: 'recordPaletteRecent', value: 'navigateDiff' })
+      state = applyLogInkAction(state, { type: 'recordPaletteRecent', value: 'navigateStatus' })
+
+      // navigateStatus moves to the front; no duplicate.
+      expect(state.paletteRecent).toEqual(['navigateStatus', 'navigateDiff'])
+    })
+
+    it('does not move the palette selection past the filtered command count', () => {
+      let state = openPalette()
+
+      // Filter to a unique label to get exactly one match.
+      state = applyInput(state, 'g')
+      state = applyInput(state, 'r')
+      state = applyInput(state, 'a')
+      state = applyInput(state, 'p')
+      state = applyInput(state, 'h')
+
+      // Only one match (toggleGraph). Down-arrow should clamp at index 0.
+      state = applyInput(state, '', { downArrow: true })
+      expect(state.paletteSelectedIndex).toBe(0)
+    })
+  })
+
   it('gates destructive and AI workflow actions behind confirmation', () => {
     let state = createLogInkState(rows)
 

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -1,3 +1,8 @@
+import {
+  LogInkPaletteCommand,
+  filterLogInkPaletteCommands,
+  getLogInkPaletteCommands,
+} from './inkKeymap'
 import { LogInkAction, LogInkSidebarTab, LogInkState } from './inkViewModel'
 import {
   getLogInkWorkflowActionById,
@@ -45,6 +50,134 @@ function action(actionValue: LogInkAction): LogInkInputEvent {
   return {
     type: 'action',
     action: actionValue,
+  }
+}
+
+/**
+ * Translate a palette command into the same events its keystroke would have
+ * produced. Phase 6 makes `:` a real launcher: this is the single mapping
+ * from palette IDs to dispatchable behavior.
+ */
+export function getLogInkPaletteExecuteEvents(
+  command: LogInkPaletteCommand,
+  state: LogInkState
+): LogInkInputEvent[] {
+  if (command.kind === 'workflow') {
+    if (command.requiresConfirmation) {
+      return [action({ type: 'setPendingConfirmation', value: command.id })]
+    }
+    return [
+      action({ type: 'setWorkflowAction', value: command.id }),
+      action({ type: 'setStatus', value: `${command.label} selected` }),
+    ]
+  }
+
+  // Binding-derived commands. Map each LogInkCommandId to the same events
+  // the keystroke would emit. Order matches the keymap registry.
+  switch (command.id) {
+    case 'moveUp':
+      return [action({ type: 'move', delta: -1 })]
+    case 'moveDown':
+      return [action({ type: 'move', delta: 1 })]
+    case 'pageUp':
+      return [action({ type: 'page', delta: -10 })]
+    case 'pageDown':
+      return [action({ type: 'page', delta: 10 })]
+    case 'moveToTop':
+      return [
+        action({ type: 'moveToTop' }),
+        action({ type: 'setStatus', value: 'jumped to first commit' }),
+      ]
+    case 'moveToBottom':
+      return [
+        action({ type: 'moveToBottom' }),
+        action({ type: 'setStatus', value: 'jumped to last commit' }),
+      ]
+    case 'nextMatch':
+      return [action({ type: 'move', delta: 1 })]
+    case 'previousMatch':
+      return [action({ type: 'move', delta: -1 })]
+    case 'previousSidebarTab':
+      return [action({ type: 'previousSidebarTab' })]
+    case 'nextSidebarTab':
+      return [action({ type: 'nextSidebarTab' })]
+    case 'focusNext':
+      return [action({ type: 'focusNext' })]
+    case 'focusPrevious':
+      return [action({ type: 'focusPrevious' })]
+    case 'search':
+      return [action({ type: 'toggleFilterMode' })]
+    case 'toggleGraph':
+      return [action({ type: 'toggleGraph' })]
+    case 'navigateHome':
+      return [action({ type: 'navigateHome' })]
+    case 'navigateStatus':
+      return [action({ type: 'pushView', value: 'status' })]
+    case 'navigateDiff':
+      return [action({ type: 'pushView', value: 'diff' })]
+    case 'navigateCompose':
+      return [action({ type: 'pushView', value: 'compose' })]
+    case 'navigateBranches':
+      return [action({ type: 'pushView', value: 'branches' })]
+    case 'navigateTags':
+      return [action({ type: 'pushView', value: 'tags' })]
+    case 'navigateStash':
+      return [action({ type: 'pushView', value: 'stash' })]
+    case 'navigateBack':
+      return [action({ type: 'popView' })]
+    case 'openSelected': {
+      // From history → diff for selected commit; from status → diff for
+      // selected file. Mirrors the enter-key behavior.
+      if (state.activeView === 'history' && state.filteredCommits.length > 0) {
+        const selected = state.filteredCommits[state.selectedIndex]
+        if (selected) {
+          return [action({
+            type: 'navigateOpenDiffForCommit',
+            sha: selected.hash,
+            commitIndex: state.selectedIndex,
+          })]
+        }
+      }
+      if (state.activeView === 'status') {
+        return [action({
+          type: 'navigateOpenDiffForWorktreeFile',
+          fileIndex: state.selectedWorktreeFileIndex,
+        })]
+      }
+      return []
+    }
+    case 'refresh':
+      return [{ type: 'refreshContext' }]
+    case 'revertSelection':
+      return [action({ type: 'setPendingMutationConfirmation', value: 'revert-file' })]
+    case 'editCommit':
+      return [
+        ...(state.activeView !== 'compose'
+          ? [action({ type: 'pushView', value: 'compose' })]
+          : []),
+        action({ type: 'commitCompose', action: { type: 'setEditing', value: true } }),
+      ]
+    case 'commit':
+      return [
+        ...(state.activeView !== 'compose'
+          ? [action({ type: 'pushView', value: 'compose' })]
+          : []),
+        { type: 'createManualCommit' },
+      ]
+    case 'help':
+      return [action({ type: 'toggleHelp' })]
+    case 'commandPalette':
+      // Re-toggling closes; the dispatcher will close after execute anyway.
+      return []
+    case 'workflowActions':
+      // Aggregate entry; individual workflows are surfaced separately.
+      return []
+    case 'quit':
+      return [{ type: 'exit' }]
+    case 'clearSearch':
+      return [action({ type: 'clearFilter' })]
+    default:
+      return []
   }
 }
 
@@ -173,12 +306,63 @@ export function getLogInkInputEvents(
     return []
   }
 
-  if (key.escape && state.showHelp) {
-    return [action({ type: 'toggleHelp' })]
+  if (state.showCommandPalette) {
+    const filtered = filterLogInkPaletteCommands(
+      getLogInkPaletteCommands(),
+      state.paletteFilter,
+      state.paletteRecent
+    )
+
+    if (key.escape) {
+      return [action({ type: 'toggleCommandPalette' })]
+    }
+
+    if (key.return) {
+      const index = Math.max(0, Math.min(state.paletteSelectedIndex, filtered.length - 1))
+      const selected = filtered[index]
+      if (!selected) {
+        return [action({ type: 'toggleCommandPalette' })]
+      }
+      return [
+        action({ type: 'recordPaletteRecent', value: selected.id }),
+        action({ type: 'toggleCommandPalette' }),
+        ...getLogInkPaletteExecuteEvents(selected, state),
+      ]
+    }
+
+    if (key.upArrow || (key.ctrl && inputValue === 'p')) {
+      return [action({
+        type: 'movePaletteSelection',
+        delta: -1,
+        commandCount: filtered.length,
+      })]
+    }
+
+    if (key.downArrow || (key.ctrl && inputValue === 'n')) {
+      return [action({
+        type: 'movePaletteSelection',
+        delta: 1,
+        commandCount: filtered.length,
+      })]
+    }
+
+    if (key.backspace || key.delete) {
+      return [action({ type: 'backspacePaletteFilter' })]
+    }
+
+    if (key.ctrl && inputValue === 'u') {
+      return [action({ type: 'clearPaletteFilter' })]
+    }
+
+    if (inputValue && !key.ctrl && !key.meta) {
+      return [action({ type: 'appendPaletteFilter', value: inputValue })]
+    }
+
+    return []
   }
 
-  if (key.escape && state.showCommandPalette) {
-    return [action({ type: 'toggleCommandPalette' })]
+  if (key.escape && state.showHelp) {
+    return [action({ type: 'toggleHelp' })]
   }
 
   if (key.escape && state.viewStack.length > 1) {

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -1,9 +1,11 @@
 import {
   LOG_INK_KEY_BINDINGS,
+  filterLogInkPaletteCommands,
   formatLogInkBreadcrumb,
   getLogInkCommandPaletteItems,
   getLogInkFooterHints,
   getLogInkHelpSections,
+  getLogInkPaletteCommands,
 } from './inkKeymap'
 
 describe('log Ink keymap', () => {
@@ -205,6 +207,58 @@ describe('log Ink keymap', () => {
     expect(branches?.keys).toEqual(['gb'])
     expect(tags?.keys).toEqual(['gt'])
     expect(stash?.keys).toEqual(['gz'])
+  })
+
+  describe('palette commands', () => {
+    it('returns both keybinding-derived and workflow commands', () => {
+      const commands = getLogInkPaletteCommands()
+      const ids = commands.map((command) => command.id)
+      const kinds = new Set(commands.map((command) => command.kind))
+
+      expect(ids).toContain('navigateHome')
+      expect(ids).toContain('toggleGraph')
+      expect(ids).toContain('delete-branch')
+      expect(ids).toContain('ai-commit-summary')
+      expect(kinds).toEqual(new Set(['binding', 'workflow']))
+    })
+
+    it('passes through every command when filter is empty and no recent', () => {
+      const commands = getLogInkPaletteCommands()
+      const result = filterLogInkPaletteCommands(commands, '', [])
+      expect(result.length).toBe(commands.length)
+    })
+
+    it('floats recent commands to the top when the filter is empty', () => {
+      const commands = getLogInkPaletteCommands()
+      const result = filterLogInkPaletteCommands(commands, '', ['toggleGraph', 'navigateStash'])
+
+      expect(result[0].id).toBe('toggleGraph')
+      expect(result[1].id).toBe('navigateStash')
+      expect(result.length).toBe(commands.length)
+    })
+
+    it('fuzzy-matches the filter against label, description, keys, and id', () => {
+      const commands = getLogInkPaletteCommands()
+
+      expect(filterLogInkPaletteCommands(commands, 'home', [])[0].id).toBe('navigateHome')
+
+      const diffResults = filterLogInkPaletteCommands(commands, 'gd', [])
+      expect(diffResults.map((command) => command.id)).toContain('navigateDiff')
+
+      expect(filterLogInkPaletteCommands(commands, 'compose', [])[0].id).toBe('navigateCompose')
+    })
+
+    it('drops commands that do not match the filter at all', () => {
+      const commands = getLogInkPaletteCommands()
+      const result = filterLogInkPaletteCommands(commands, 'zzzzznosuchcommand', [])
+      expect(result).toHaveLength(0)
+    })
+
+    it('ignores recent ordering when a filter is set (relevance wins)', () => {
+      const commands = getLogInkPaletteCommands()
+      const result = filterLogInkPaletteCommands(commands, 'compose', ['navigateStash'])
+      expect(result[0].id).toBe('navigateCompose')
+    })
   })
 
   it('derives command palette entries from the shared keymap', () => {

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -1,4 +1,9 @@
 import { LogInkFocus, LogInkView } from './inkViewModel'
+import {
+  LogInkWorkflowAction,
+  LogInkWorkflowActionKind,
+  getLogInkWorkflowActions,
+} from './inkWorkflows'
 
 export type LogInkCommandId =
   | 'clearSearch'
@@ -490,4 +495,152 @@ export function getLogInkCommandPaletteItems(): LogInkCommandPaletteItem[] {
     label: binding.label,
     description: binding.description,
   }))
+}
+
+/**
+ * Unified palette command type — covers both keybinding-derived commands
+ * (`'binding'`) and workflow actions (`'workflow'`). The palette renderer
+ * iterates these and the executor dispatches the right events for each.
+ */
+export type LogInkPaletteCommandKind = 'binding' | 'workflow'
+
+export type LogInkPaletteCommand = {
+  id: string
+  kind: LogInkPaletteCommandKind
+  keys: string
+  label: string
+  description: string
+  workflowKind?: LogInkWorkflowActionKind
+  requiresConfirmation?: boolean
+}
+
+function bindingToPaletteCommand(binding: LogInkKeyBinding): LogInkPaletteCommand {
+  return {
+    id: binding.id,
+    kind: 'binding',
+    keys: formatBindingKeys(binding),
+    label: binding.label,
+    description: binding.description,
+  }
+}
+
+function workflowToPaletteCommand(action: LogInkWorkflowAction): LogInkPaletteCommand {
+  return {
+    id: action.id,
+    kind: 'workflow',
+    keys: action.key,
+    label: action.label,
+    description: action.description,
+    workflowKind: action.kind,
+    requiresConfirmation: action.requiresConfirmation,
+  }
+}
+
+/**
+ * The full palette command set: every keybinding plus every workflow
+ * action. Phase 6 onwards, both surfaces are filterable and executable
+ * from `:`.
+ */
+export function getLogInkPaletteCommands(): LogInkPaletteCommand[] {
+  return [
+    ...LOG_INK_KEY_BINDINGS.map(bindingToPaletteCommand),
+    ...getLogInkWorkflowActions().map(workflowToPaletteCommand),
+  ]
+}
+
+function paletteSearchableFields(command: LogInkPaletteCommand): string[] {
+  return [command.label, command.description, command.keys, command.id]
+}
+
+function scorePaletteCommand(command: LogInkPaletteCommand, term: string): number | undefined {
+  const normalized = term.trim().toLowerCase()
+  if (!normalized) {
+    return 0
+  }
+
+  let best: number | undefined
+  for (const raw of paletteSearchableFields(command)) {
+    const value = raw.toLowerCase()
+
+    if (value === normalized) {
+      return 1000
+    }
+
+    if (value.startsWith(normalized)) {
+      const fieldScore = 800 - Math.min(value.length - normalized.length, 200)
+      best = best === undefined ? fieldScore : Math.max(best, fieldScore)
+      continue
+    }
+
+    const substringIndex = value.indexOf(normalized)
+    if (substringIndex >= 0) {
+      const fieldScore = 600 - Math.min(substringIndex, 200)
+      best = best === undefined ? fieldScore : Math.max(best, fieldScore)
+      continue
+    }
+
+    let searchIndex = 0
+    let distance = 0
+    let matched = true
+
+    for (const character of normalized) {
+      const nextIndex = value.indexOf(character, searchIndex)
+      if (nextIndex < 0) {
+        matched = false
+        break
+      }
+      distance += nextIndex - searchIndex
+      searchIndex = nextIndex + 1
+    }
+
+    if (matched) {
+      const fieldScore = 300 - Math.min(distance, 200)
+      best = best === undefined ? fieldScore : Math.max(best, fieldScore)
+    }
+  }
+
+  return best
+}
+
+/**
+ * Filter and sort the palette command list by user query.
+ *   - Empty filter: float `recent` IDs to the top, preserve registry order
+ *     for everything else.
+ *   - Non-empty filter: fuzzy score, descending; ties broken by registry
+ *     order. Commands that don't match are dropped.
+ */
+export function filterLogInkPaletteCommands(
+  commands: LogInkPaletteCommand[],
+  filter: string,
+  recent: string[]
+): LogInkPaletteCommand[] {
+  if (!filter.trim()) {
+    if (recent.length === 0) {
+      return [...commands]
+    }
+    const recentIndex = new Map(recent.map((id, index) => [id, index]))
+    const recentCommands: LogInkPaletteCommand[] = []
+    const others: LogInkPaletteCommand[] = []
+    for (const command of commands) {
+      if (recentIndex.has(command.id)) {
+        recentCommands.push(command)
+      } else {
+        others.push(command)
+      }
+    }
+    recentCommands.sort((a, b) => (recentIndex.get(a.id) || 0) - (recentIndex.get(b.id) || 0))
+    return [...recentCommands, ...others]
+  }
+
+  return commands
+    .map((command, index) => ({
+      command,
+      index,
+      score: scorePaletteCommand(command, filter),
+    }))
+    .filter((entry): entry is { command: LogInkPaletteCommand; index: number; score: number } =>
+      entry.score !== undefined
+    )
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map((entry) => entry.command)
 }

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -28,7 +28,8 @@ import {
 import {
   formatBindingKeys,
   formatLogInkBreadcrumb,
-  getLogInkCommandPaletteItems,
+  filterLogInkPaletteCommands,
+  getLogInkPaletteCommands,
   getLogInkFooterHints,
   getLogInkHelpSections,
 } from './inkKeymap'
@@ -68,7 +69,6 @@ import {
 import { TagOverview, getTagOverview } from './tagData'
 import {
   getLogInkWorkflowActionById,
-  getLogInkWorkflowActions,
   getLogInkWorkflowSections,
 } from './inkWorkflows'
 import { WorktreeOverview as WorktreeListOverview, getWorktreeListOverview } from './worktreeData'
@@ -1214,6 +1214,14 @@ function renderComposeSurface(
     : []))
 }
 
+function matchesPromotedFilter(haystacks: string[], filter: string): boolean {
+  if (!filter.trim()) {
+    return true
+  }
+  const needle = filter.toLowerCase()
+  return haystacks.some((value) => value.toLowerCase().includes(needle))
+}
+
 function renderBranchesSurface(
   h: typeof ReactTypes.createElement,
   components: LogInkComponents,
@@ -1227,18 +1235,27 @@ function renderBranchesSurface(
   const focused = state.focus === 'commits'
   const branches = context.branches
   const loading = isLogInkContextKeyLoading(contextStatus, 'branches')
-  const localBranches = branches?.localBranches || []
-  const selected = state.selectedBranchIndex
+  const allLocalBranches = branches?.localBranches || []
+  const localBranches = state.filter
+    ? allLocalBranches.filter((branch) =>
+      matchesPromotedFilter([branch.shortName, branch.upstream || ''], state.filter)
+    )
+    : allLocalBranches
+  const selected = Math.max(0, Math.min(state.selectedBranchIndex, Math.max(0, localBranches.length - 1)))
   const listRows = Math.max(4, bodyRows - 4)
   const startIndex = Math.max(0, selected - Math.floor(listRows / 2))
   const visible = localBranches.slice(startIndex, startIndex + listRows)
+  const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
   const headerRight = loading
     ? 'loading branches'
-    : `${localBranches.length} local | current: ${branches?.currentBranch || '<detached>'}`
+    : `${localBranches.length}/${allLocalBranches.length} local | current: ${branches?.currentBranch || '<detached>'}${filterLabel}`
+  const emptyLabel = state.filter
+    ? `No branches match filter '${state.filter}'`
+    : 'No local branches'
   const lines: ReactTypes.ReactNode[] = loading
     ? [h(Text, { key: 'branches-loading', dimColor: true }, 'Loading branches...')]
     : localBranches.length === 0
-      ? [h(Text, { key: 'branches-empty', dimColor: true }, 'No local branches')]
+      ? [h(Text, { key: 'branches-empty', dimColor: true }, emptyLabel)]
       : visible.map((branch, offset) => {
         const index = startIndex + offset
         const isSelected = index === selected
@@ -1278,16 +1295,23 @@ function renderTagsSurface(
   const { Box, Text } = components
   const focused = state.focus === 'commits'
   const loading = isLogInkContextKeyLoading(contextStatus, 'tags')
-  const tags = context.tags?.tags || []
-  const selected = state.selectedTagIndex
+  const allTags = context.tags?.tags || []
+  const tags = state.filter
+    ? allTags.filter((tag) => matchesPromotedFilter([tag.name, tag.subject], state.filter))
+    : allTags
+  const selected = Math.max(0, Math.min(state.selectedTagIndex, Math.max(0, tags.length - 1)))
   const listRows = Math.max(4, bodyRows - 4)
   const startIndex = Math.max(0, selected - Math.floor(listRows / 2))
   const visible = tags.slice(startIndex, startIndex + listRows)
-  const headerRight = loading ? 'loading tags' : `${tags.length} tags`
+  const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
+  const headerRight = loading
+    ? 'loading tags'
+    : `${tags.length}/${allTags.length} tags${filterLabel}`
+  const emptyLabel = state.filter ? `No tags match filter '${state.filter}'` : 'No tags found'
   const lines: ReactTypes.ReactNode[] = loading
     ? [h(Text, { key: 'tags-loading', dimColor: true }, 'Loading tags...')]
     : tags.length === 0
-      ? [h(Text, { key: 'tags-empty', dimColor: true }, 'No tags found')]
+      ? [h(Text, { key: 'tags-empty', dimColor: true }, emptyLabel)]
       : visible.map((tag, offset) => {
         const index = startIndex + offset
         const isSelected = index === selected
@@ -1325,16 +1349,27 @@ function renderStashSurface(
   const { Box, Text } = components
   const focused = state.focus === 'commits'
   const loading = isLogInkContextKeyLoading(contextStatus, 'stashes')
-  const stashes = context.stashes?.stashes || []
-  const selected = state.selectedStashIndex
+  const allStashes = context.stashes?.stashes || []
+  const stashes = state.filter
+    ? allStashes.filter((stash) =>
+      matchesPromotedFilter([stash.ref, stash.message], state.filter)
+    )
+    : allStashes
+  const selected = Math.max(0, Math.min(state.selectedStashIndex, Math.max(0, stashes.length - 1)))
   const listRows = Math.max(4, bodyRows - 4)
   const startIndex = Math.max(0, selected - Math.floor(listRows / 2))
   const visible = stashes.slice(startIndex, startIndex + listRows)
-  const headerRight = loading ? 'loading stashes' : `${stashes.length} stashes`
+  const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
+  const headerRight = loading
+    ? 'loading stashes'
+    : `${stashes.length}/${allStashes.length} stashes${filterLabel}`
+  const emptyLabel = state.filter
+    ? `No stashes match filter '${state.filter}'`
+    : 'No stashes'
   const lines: ReactTypes.ReactNode[] = loading
     ? [h(Text, { key: 'stash-loading', dimColor: true }, 'Loading stashes...')]
     : stashes.length === 0
-      ? [h(Text, { key: 'stash-empty', dimColor: true }, 'No stashes')]
+      ? [h(Text, { key: 'stash-empty', dimColor: true }, emptyLabel)]
       : visible.map((stash, offset) => {
         const index = startIndex + offset
         const isSelected = index === selected
@@ -1440,7 +1475,7 @@ function renderDetailPanel(
   }
 
   if (state.showCommandPalette) {
-    return renderCommandPalette(h, components, width, theme, focused)
+    return renderCommandPalette(h, components, state, width, theme, focused)
   }
 
   if (state.pendingConfirmationId || state.pendingMutationConfirmation) {
@@ -1644,13 +1679,54 @@ function renderHelpPanel(
 function renderCommandPalette(
   h: typeof ReactTypes.createElement,
   components: LogInkComponents,
+  state: LogInkState,
   width: number,
   theme: LogInkTheme,
   focused: boolean
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
-  const commands = getLogInkCommandPaletteItems()
-  const workflowActions = getLogInkWorkflowActions()
+  const all = getLogInkPaletteCommands()
+  const filtered = filterLogInkPaletteCommands(all, state.paletteFilter, state.paletteRecent)
+  const recentSet = new Set(state.paletteRecent)
+  const showingRecent = !state.paletteFilter.trim() && state.paletteRecent.length > 0
+
+  const selectedIndex = filtered.length === 0
+    ? 0
+    : Math.max(0, Math.min(state.paletteSelectedIndex, filtered.length - 1))
+
+  // Slide a window of rows around the selection so the cursor stays visible
+  // even with hundreds of bindings.
+  const listRows = 14
+  const startIndex = Math.max(0, selectedIndex - Math.floor(listRows / 2))
+  const visible = filtered.slice(startIndex, startIndex + listRows)
+
+  const inputLine = `> ${state.paletteFilter}_`
+  const matchSummary = filtered.length === 0
+    ? 'no matches'
+    : `${filtered.length} ${filtered.length === 1 ? 'match' : 'matches'}`
+  const hint = '↑/↓ select · enter run · esc close'
+
+  const itemLines = filtered.length === 0
+    ? [h(Text, { key: 'palette-empty', dimColor: true }, 'No commands match the current filter.')]
+    : visible.map((command, offset) => {
+      const index = startIndex + offset
+      const isSelected = index === selectedIndex
+      const cursor = isSelected ? '>' : ' '
+      const recentMarker = showingRecent && recentSet.has(command.id) ? '·' : ' '
+      const kindMarker = command.kind === 'workflow'
+        ? command.workflowKind === 'ai'
+          ? '[AI]'
+          : command.requiresConfirmation
+            ? '[confirm]'
+            : '[action]'
+        : ''
+      const line = `${cursor} ${recentMarker} ${command.keys.padEnd(8)} ${command.label.padEnd(20)} ${kindMarker ? `${kindMarker} ` : ''}${command.description}`
+      return h(Text, {
+        key: `palette-${command.kind}-${command.id}`,
+        bold: isSelected,
+        dimColor: !isSelected,
+      }, truncate(line, width - 4))
+    })
 
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
@@ -1659,25 +1735,17 @@ function renderCommandPalette(
     width,
     paddingX: 1,
   },
-  h(Text, { bold: true }, panelTitle('Commands', focused)),
-  h(Text, { dimColor: true }, 'Every command is sourced from the shared keymap.'),
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle('Command palette', focused)),
+    h(Text, { dimColor: true }, matchSummary)
+  ),
+  h(Text, { color: theme.colors.accent }, truncate(inputLine, width - 4)),
+  h(Text, { dimColor: true }, truncate(hint, width - 4)),
   h(Text, undefined, ''),
-  ...commands.map((command) => h(Text, {
-    key: command.id,
-  }, truncate(`${command.keys.padEnd(12)} ${command.label} - ${command.description}`, width - 4))),
-  h(Text, undefined, ''),
-  h(Text, { bold: true }, 'Workflow actions'),
-  ...workflowActions.map((action) => {
-    const marker = action.kind === 'ai'
-      ? `[AI ~${action.estimatedTokens || '?'} tokens]`
-      : action.requiresConfirmation
-        ? '[confirm]'
-        : '[action]'
-
-    return h(Text, {
-      key: action.id,
-    }, truncate(`${action.key.padEnd(4)} ${marker} ${action.label}`, width - 4))
-  }))
+  ...(showingRecent
+    ? [h(Text, { key: 'palette-recent-hint', dimColor: true }, '· marks recently-used')]
+    : []),
+  ...itemLines)
 }
 
 function renderFooter(

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -50,6 +50,15 @@ export type LogInkState = {
   fullGraph: boolean
   showHelp: boolean
   showCommandPalette: boolean
+  /**
+   * Command-palette interaction state. `paletteFilter` is the user-typed
+   * fuzzy query. `paletteSelectedIndex` is a cursor into the filtered list.
+   * `paletteRecent` keeps recently-executed command IDs so the palette can
+   * float them to the top when the filter is empty.
+   */
+  paletteFilter: string
+  paletteSelectedIndex: number
+  paletteRecent: string[]
   workflowActionId?: string
   pendingConfirmationId?: string
   pendingMutationConfirmation?: LogInkMutationConfirmation
@@ -97,6 +106,11 @@ export type LogInkAction =
   | { type: 'setWorkflowAction'; value?: string }
   | { type: 'setPendingConfirmation'; value?: string }
   | { type: 'setPendingMutationConfirmation'; value?: LogInkMutationConfirmation }
+  | { type: 'appendPaletteFilter'; value: string }
+  | { type: 'backspacePaletteFilter' }
+  | { type: 'clearPaletteFilter' }
+  | { type: 'movePaletteSelection'; delta: number; commandCount: number }
+  | { type: 'recordPaletteRecent'; value: string }
   | { type: 'toggleFilterMode' }
   | { type: 'toggleGraph' }
   | { type: 'toggleHelp' }
@@ -357,6 +371,9 @@ export function createLogInkState(
     selectedBranchIndex: 0,
     selectedTagIndex: 0,
     selectedStashIndex: 0,
+    paletteFilter: '',
+    paletteSelectedIndex: 0,
+    paletteRecent: [],
     commitCompose: createCommitComposeState(),
     diffPreviewOffset: 0,
     worktreeDiffOffset: 0,
@@ -642,13 +659,57 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         showCommandPalette: false,
         pendingKey: undefined,
       }
-    case 'toggleCommandPalette':
+    case 'toggleCommandPalette': {
+      const opening = !state.showCommandPalette
       return {
         ...state,
-        showCommandPalette: !state.showCommandPalette,
+        showCommandPalette: opening,
         showHelp: false,
+        // Reset palette interaction state on every open/close so the next
+        // session starts from a clean slate.
+        paletteFilter: '',
+        paletteSelectedIndex: 0,
         pendingKey: undefined,
       }
+    }
+    case 'appendPaletteFilter':
+      return {
+        ...state,
+        paletteFilter: `${state.paletteFilter}${action.value}`,
+        paletteSelectedIndex: 0,
+        pendingKey: undefined,
+      }
+    case 'backspacePaletteFilter':
+      return {
+        ...state,
+        paletteFilter: state.paletteFilter.slice(0, -1),
+        paletteSelectedIndex: 0,
+        pendingKey: undefined,
+      }
+    case 'clearPaletteFilter':
+      return {
+        ...state,
+        paletteFilter: '',
+        paletteSelectedIndex: 0,
+        pendingKey: undefined,
+      }
+    case 'movePaletteSelection':
+      return {
+        ...state,
+        paletteSelectedIndex: clampIndex(
+          state.paletteSelectedIndex + action.delta,
+          action.commandCount
+        ),
+        pendingKey: undefined,
+      }
+    case 'recordPaletteRecent': {
+      const next = [action.value, ...state.paletteRecent.filter((id) => id !== action.value)]
+      return {
+        ...state,
+        paletteRecent: next.slice(0, 8),
+        pendingKey: undefined,
+      }
+    }
     default:
       return state
   }


### PR DESCRIPTION
## Summary

Phase 6 of the TUI shell epic (#747). The \`:\` palette becomes a real launcher — fuzzy filter, recently-used at the top, direct execution of every keybinding **and** every workflow action. The \`/\` search filter, previously commits-only, now applies to branches, tags, and stash views as well.

Closes #745.

## Palette

- **Unified command list.** New \`LogInkPaletteCommand\` covers both keybinding-derived commands and workflow actions (\`commit\`, \`delete-branch\`, \`ai-commit-summary\`, etc.) under one type. \`getLogInkPaletteCommands()\` returns the full set.
- **Fuzzy filter + recent-first ranking.** \`filterLogInkPaletteCommands(commands, filter, recent)\` ranks by score against label, description, keys, and id. Empty filter floats recent IDs to the top, preserves registry order for everything else. Recent ordering is **ignored when a filter is set** — relevance wins.
- **State slice.** \`paletteFilter\` / \`paletteSelectedIndex\` / \`paletteRecent\` (capped at 8, deduped, MRU). \`toggleCommandPalette\` resets filter + selection on every open/close so the next session starts fresh.
- **Executor.** \`getLogInkPaletteExecuteEvents(command, state)\` maps every command id to the same \`LogInkInputEvent[]\` its keystroke would dispatch — palette and key path stay in sync.

## Input dispatch

The palette is now a real modal mode in \`getLogInkInputEvents\`. Previously, keys like \`j\` could leak through to the normal handlers and move the commit cursor while the palette was \"open\". Now:

| Key | Behavior |
|---|---|
| printable | append to filter |
| \`backspace\` / \`del\` | remove last filter char |
| \`ctrl+u\` | clear filter |
| \`↑\` / \`↓\` / \`ctrl+p\` / \`ctrl+n\` | move selection (clamped to filtered count) |
| \`enter\` | record recent → close → dispatch executor events |
| \`esc\` | close |

## Render

\`renderCommandPalette\` is now an interactive overlay:

- Title with match count summary (\`N matches\` / \`no matches\`)
- Input line with cursor (\`> filter_\`)
- Hint row (\`↑/↓ select · enter run · esc close\`)
- Sliding viewport of filtered/recent-sorted commands, with the active row marked by \`>\` cursor + bold styling. Recent items show a \`·\` marker when filter is empty. Workflow badges (\`[AI]\` / \`[confirm]\` / \`[action]\`) render inline so users see what they're about to trigger.

## Global search

\`renderBranchesSurface\` / \`renderTagsSurface\` / \`renderStashSurface\` now honor \`state.filter\`:

- Header shows \`N/M\` totals plus the active filter (\`5/12 local | filter: feat\`).
- Empty-state message reflects whether the filter excluded everything (\`No branches match filter 'foo'\`) vs. genuinely empty data (\`No local branches\`).
- Selection clamps to the filtered count so the cursor never lands beyond the visible list.

The existing \`/\` filter mode opens search in any of these views — no extra keybindings needed.

## Test plan

\`inkInput.test.ts\` (+7 cases):

- [x] Palette intercepts every key while open — no leaks (\`j\` doesn't move the commit cursor)
- [x] Append, backspace, ctrl+u clear the filter
- [x] \`↑\` / \`↓\` / \`ctrl+p\` / \`ctrl+n\` all move palette selection
- [x] \`esc\` closes and resets filter + selection
- [x] \`enter\` records recent → closes → dispatches executor events for the matched command
- [x] \`paletteRecent\` dedupes and reorders to MRU
- [x] Selection clamps at filtered count - 1 (no overflow)

\`inkKeymap.test.ts\` (+6 cases):

- [x] Palette command set contains both binding-derived and workflow commands
- [x] Empty filter + no recent passes through full list
- [x] Empty filter + recent floats those IDs to the top
- [x] Fuzzy match scores label / description / keys / id
- [x] Non-matching filter returns empty list
- [x] Filter set → recent ordering ignored, relevance wins

Local release-gate run:

- [x] \`npm run lint\`
- [x] \`npm run test:jest\` — 644/644 across 89 suites
- [x] \`npm run build\`
- [x] \`npm run test:cli\` — 10 packaged-CLI smoke checks
- [x] \`npm run release:dry-run\`

## Notes

The optional configurable-keymap-overrides scope from #745 is **not** in this PR. With the executor (\`getLogInkPaletteExecuteEvents\`) and the unified command list now in place, that's a natural follow-up — config can rebind any \`LogInkCommandId\` to a different key without touching dispatch. Open to a small follow-up issue if you'd like.

## Unblocks

After this lands, only phase 7 (#746, polish pass) remains in the TUI shell epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)