### PR TITLE
docs: TUI chord navigation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ An AI-powered git assistant that generates meaningful commit messages, creates c
 - 📋 **Conventional Commits** - Full support with automatic validation and formatting  
 - 🔧 **Commitlint Integration** - Seamless integration with your existing commitlint configuration
 - 🏠 **Local AI Support** - Run completely offline with Ollama (no API costs, full privacy)
-- 🖥️ **Coco UI Git Workstation** - Browse history, inspect status/diffs, stage hunks, and compose commits from `coco ui`
+- 🖥️ **Coco UI Git Workstation** - Seven top-level views (history, status, diff, compose, branches, tags, stash) reachable via `g`-prefixed chords, with an interactive command palette (`:`) and global search (`/`)
 - 📦 **Package Manager Friendly** - Works with npm, yarn, and pnpm
 - 👥 **Team Ready** - Shared configurations and enterprise deployment
 
@@ -100,6 +100,19 @@ coco log --author "Grace Hopper" --path src
 coco log --commit HEAD
 coco log --format json
 ```
+
+### Navigating the TUI
+
+`coco ui` and `coco log -i` share a chord-driven navigation model. Press `g` and then a second key to jump anywhere; `<` (or `Esc`) pops the navigation stack back.
+
+```text
+g h   history          g c   compose         <    back
+g s   status           g b   branches        Esc  back / close modal
+g d   diff             g t   tags            ?    help overlay
+                       g z   stash           :    command palette
+```
+
+The command palette (`:`) is an interactive launcher with fuzzy filter and recently-used at the top — every keybinding and workflow action is reachable from there. `/` searches the active view (history, branches, tags, or stash). See the [Coco UI](https://github.com/gfargo/coco/wiki/Coco-UI) wiki page for the full keymap.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

The TUI shell epic (#747) shipped chord-driven navigation, an interactive command palette, and global search across promoted views — but the README had no quick reference for any of it.

This PR adds a compact navigation cheat-sheet to the Usage Examples section and refreshes the headline feature bullet so the README reflects what \`coco ui\` actually does as of v0.34.0.

## Wiki updates (already pushed)

The user-facing keymap pages were also out of date. They've been refreshed and pushed directly to the wiki repo (\`gfargo/coco.wiki\`) — that's a separate repo so the changes aren't part of this PR:

- **\`Coco-UI.md\`** — views table now lists all seven views (history, status, diff, compose, branches, tags, stash), keybindings split into Global / Navigation chords / Within a view / Compose / Workflow actions, header/footer descriptions reflect the breadcrumb + global slot.
- **\`Interactive-Log-TUI.md\`** — added a Navigation section pointing at the chord set; keybindings table fixed (\`g\` is a chord prefix, \`\\\` toggles graph, \`:\` is the interactive palette).
- **\`Command-Reference.md\`** — \`coco ui\` feature list rewritten; \`coco log -i\` common-keys table updated with chord row and the \`\\\` migration note.

The notable v0.34.0 migration call-out is consistent across all three wiki pages: **\`g\` alone is now a chord prefix and no longer toggles the graph; the graph toggle moved to \`\\\`**.

## Local CLAUDE.md

CLAUDE.md is gitignored, so it's not part of this PR. It was updated locally to reflect the shell architecture (viewStack + intents + palette executor + surface-state helpers) so future AI-assisted work has accurate context.

## Test plan

- [x] README renders correctly on GitHub (visual check)
- [x] Chord table aligns in monospace and reads cleanly
- [x] Pre-existing markdownlint warnings unchanged (this PR doesn't introduce new ones)

## Tier 3 follow-up

A consolidated \`TUI-Navigation.md\` wiki page is queued as a separate, additive PR after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)