### PR TITLE
fix(log-tui): commit-diff hunk nav + safe AI draft generation

### DIFF
--- a/src/commands/commit/generateCommitDraft.ts
+++ b/src/commands/commit/generateCommitDraft.ts
@@ -1,0 +1,319 @@
+import { Arguments } from 'yargs'
+import { type TiktokenModel } from '@langchain/openai'
+import { SimpleGit } from 'simple-git'
+
+import { loadConfig } from '../../lib/config/utils/loadConfig'
+import {
+  getApiKeyForModel,
+  getModelAndProviderFromConfig,
+} from '../../lib/langchain/utils'
+import { resolveDynamicService } from '../../lib/langchain/utils/dynamicModels'
+import { executeChainWithSchema } from '../../lib/langchain/utils/executeChainWithSchema'
+import { enforcePromptBudget } from '../../lib/langchain/utils/enforcePromptBudget'
+import { formatCommitMessage } from '../../lib/langchain/utils/formatCommitMessage'
+import { getLlm } from '../../lib/langchain/utils/getLlm'
+import { getPrompt } from '../../lib/langchain/utils/getPrompt'
+import { LLMModel } from '../../lib/langchain/types'
+import { fileChangeParser } from '../../lib/parsers/default'
+import { createFileChangeParserOptions } from '../../lib/parsers/default/utils/createFileChangeParserOptions'
+import { extractTicketIdFromBranchName } from '../../lib/simple-git/extractTicketIdFromBranchName'
+import { getChanges } from '../../lib/simple-git/getChanges'
+import { getCurrentBranchName } from '../../lib/simple-git/getCurrentBranchName'
+import { getPreviousCommits } from '../../lib/simple-git/getPreviousCommits'
+import { Logger } from '../../lib/utils/logger'
+import { getTokenCounter } from '../../lib/utils/tokenizer'
+import { hasCommitlintConfig } from '../../lib/utils/hasCommitlintConfig'
+import {
+  CommitArgv,
+  CommitMessageResponseSchema,
+  CommitOptions,
+  ConventionalCommitMessageResponseSchema,
+} from './config'
+import { COMMIT_PROMPT, CONVENTIONAL_COMMIT_PROMPT } from './prompt'
+
+export type CommitDraftInput = {
+  git: SimpleGit
+  argv: Arguments<CommitOptions>
+  logger?: Logger
+}
+
+export type CommitDraftResult = {
+  ok: boolean
+  draft: string
+  warnings: string[]
+  validationErrors: string[]
+}
+
+const FORMAT_INSTRUCTIONS_TEMPLATE = (schemaDescription: string): string => (
+  `CRITICAL: You must return ONLY a valid JSON object with no additional text, explanations, or markdown formatting.
+
+REQUIRED JSON FORMAT:
+${schemaDescription}
+
+EXAMPLE (follow this EXACT format - compact JSON on a single line or minimal whitespace):
+{"title": "feat(auth): add user authentication system", "body": "Implement JWT-based authentication with login and logout functionality. Includes password hashing and session management."}
+
+IMPORTANT RULES:
+- Return ONLY the JSON object - NO markdown code blocks, NO backticks, NO extra text
+- ALL string values MUST be enclosed in double quotes
+- Use compact JSON format (minimal whitespace) for best compatibility
+- NO trailing commas
+- NO comments or additional text outside the JSON
+- The "title" and "body" values must be properly quoted strings`
+)
+
+/**
+ * Generate a commit message draft with no UI side effects.
+ *
+ * Mirrors the LLM-chain logic from `commit/handler.ts`'s agent callback but
+ * skips the review loop, ora spinners, Inquirer prompts, and stdout writes
+ * that would corrupt the surrounding Ink TUI alt screen. Validation failures
+ * are surfaced as `validationErrors`/`warnings` rather than driving an
+ * interactive retry flow — the TUI can re-invoke or let the user edit.
+ */
+export async function generateCommitDraft({
+  git,
+  argv,
+  logger = new Logger({ silent: true }),
+}: CommitDraftInput): Promise<CommitDraftResult> {
+  const config = loadConfig<CommitOptions, CommitArgv>(argv as Arguments<CommitArgv>)
+  const key = getApiKeyForModel(config)
+  const { provider } = getModelAndProviderFromConfig(config)
+  const commitService = resolveDynamicService(config, 'commit')
+  const summaryService = resolveDynamicService(config, 'summarize')
+  const model = commitService.model
+
+  if (config.service.authentication.type !== 'None' && !key) {
+    return {
+      ok: false,
+      draft: '',
+      warnings: [],
+      validationErrors: ['No API key configured for the commit service.'],
+    }
+  }
+
+  const tokenizer = await getTokenCounter(
+    provider === 'openai' ? (model as TiktokenModel) : 'gpt-4o'
+  )
+  const llm = getLlm(provider, model as LLMModel, { ...config, service: commitService })
+  const summaryLlm = getLlm(provider, summaryService.model as LLMModel, {
+    ...config,
+    service: summaryService,
+  })
+
+  const useConventional = Boolean(config.conventionalCommits || argv.conventional)
+
+  const changes = await (async () => {
+    if (config.noDiff) {
+      const status = await git.status()
+      return status.files.map((file) => ({
+        filePath: file.path,
+        status: (file.index === 'A' || file.index === '?'
+          ? 'added'
+          : 'modified') as 'added' | 'modified',
+        summary: file.path,
+      }))
+    }
+    const result = await getChanges({
+      git,
+      options: {
+        ignoredFiles: config.ignoredFiles || undefined,
+        ignoredExtensions: config.ignoredExtensions || undefined,
+      },
+    })
+    return result.staged
+  })()
+
+  if (!changes || changes.length === 0) {
+    return {
+      ok: false,
+      draft: '',
+      warnings: ['No staged changes detected.'],
+      validationErrors: [],
+    }
+  }
+
+  const summary = config.noDiff
+    ? `Staged files:\n${changes.map((c) => `${c.status}: ${c.filePath}`).join('\n')}`
+    : await fileChangeParser({
+      changes,
+      commit: '--staged',
+      options: createFileChangeParserOptions({
+        command: 'commit',
+        tokenizer,
+        git,
+        llm: summaryLlm,
+        logger,
+        provider,
+        model: String(summaryService.model),
+        service: config.service,
+      }),
+    })
+
+  if (!summary || !summary.length) {
+    return {
+      ok: false,
+      draft: '',
+      warnings: ['Diff summary was empty after parsing staged changes.'],
+      validationErrors: [],
+    }
+  }
+
+  const schema = useConventional
+    ? ConventionalCommitMessageResponseSchema
+    : CommitMessageResponseSchema
+  const promptTemplate = useConventional ? CONVENTIONAL_COMMIT_PROMPT : COMMIT_PROMPT
+  const prompt = getPrompt({
+    template: config.prompt || (promptTemplate.template as string),
+    variables: promptTemplate.inputVariables,
+    fallback: promptTemplate,
+  })
+  const formatInstructions = FORMAT_INSTRUCTIONS_TEMPLATE(schema.description || '')
+
+  const additionalContext = argv.additional ? `## Additional Context\n${argv.additional}` : ''
+
+  let commitHistory = ''
+  const previousCommitsCount = Number(argv.withPreviousCommits || 0)
+  if (previousCommitsCount > 0) {
+    const commitHistoryData = await getPreviousCommits({ git, count: previousCommitsCount })
+    if (commitHistoryData) {
+      commitHistory = `## Commit History\n${commitHistoryData}`
+    }
+  }
+
+  const branchName = await getCurrentBranchName({ git })
+  const includeBranchName = argv.includeBranchName !== undefined
+    ? argv.includeBranchName
+    : config.includeBranchName !== false
+  const branchNameContext = includeBranchName ? `Current git branch name: ${branchName}` : ''
+
+  const warnings: string[] = []
+  const hasCommitLintConfig = await hasCommitlintConfig()
+  let commitlintRulesContext = ''
+  let validationEnabled = useConventional || hasCommitLintConfig
+
+  if (validationEnabled) {
+    const { getCommitlintRulesContext, checkCommitlintAvailability } = await import(
+      '../../lib/utils/commitlintValidator'
+    )
+    const availability = checkCommitlintAvailability()
+    if (!availability.available) {
+      warnings.push(
+        `Skipping commitlint validation: missing packages (${availability.missingPackages.join(', ')}).`
+      )
+      validationEnabled = false
+    } else {
+      commitlintRulesContext = await getCommitlintRulesContext()
+    }
+  }
+
+  const baseVariables: Record<string, string> = {
+    summary,
+    format_instructions: formatInstructions,
+    additional_context: additionalContext,
+    commit_history: commitHistory,
+    branch_name_context: branchNameContext,
+    commitlint_rules_context: commitlintRulesContext,
+  }
+
+  const maxParsingAttempts = config.service.provider === 'ollama' && 'maxParsingAttempts' in config.service
+    ? config.service.maxParsingAttempts || 3
+    : 3
+
+  let lastValidationErrors: string[] = []
+  let validationFeedback = ''
+  let lastDraft = ''
+
+  // Two attempts max — one initial generation plus one retry that incorporates
+  // commitlint feedback. Beyond that we surface warnings and let the TUI user
+  // edit the draft manually rather than driving an interactive prompt loop.
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    const variables = {
+      ...baseVariables,
+      additional_context: validationFeedback
+        ? `${baseVariables.additional_context}\n\n## Validation Errors from Previous Attempt\nPlease fix the following issues:\n${validationFeedback}`
+        : baseVariables.additional_context,
+    }
+
+    const budgetedPrompt = await enforcePromptBudget({
+      prompt,
+      variables,
+      tokenizer,
+      maxTokens: config.service.tokenLimit || 2048,
+    })
+
+    const commitMsg = await executeChainWithSchema(schema, llm, prompt, budgetedPrompt.variables, {
+      logger,
+      tokenizer,
+      metadata: {
+        task: useConventional ? 'commit-message-conventional' : 'commit-message',
+        command: 'commit-draft',
+        provider,
+        model: String(model),
+      },
+      retryOptions: {
+        maxAttempts: maxParsingAttempts,
+      },
+      fallbackParser: (text: string) => {
+        try {
+          let cleanText = text.trim()
+          const codeBlockMatch = cleanText.match(/```(?:json)?\s*(\{[\s\S]*?\})\s*```/)
+          if (codeBlockMatch && codeBlockMatch[1]) {
+            cleanText = codeBlockMatch[1].trim()
+          }
+          const parsed = JSON.parse(cleanText)
+          if (parsed && typeof parsed === 'object' &&
+              typeof parsed.title === 'string' &&
+              typeof parsed.body === 'string' &&
+              parsed.title.length > 0) {
+            return parsed
+          }
+        } catch {
+          // fall through
+        }
+        return {
+          title: text.split('\n')[0] || 'Auto-generated commit',
+          body: text.split('\n').slice(1).join('\n') || 'Generated commit message',
+        }
+      },
+    })
+
+    const ticketId = extractTicketIdFromBranchName(branchName)
+    const fullMessage = formatCommitMessage(commitMsg, {
+      append: argv.append as string | undefined,
+      ticketId: ticketId || undefined,
+      appendTicket: argv.appendTicket as boolean | undefined,
+    })
+    lastDraft = fullMessage
+
+    if (!validationEnabled) {
+      return { ok: true, draft: fullMessage, warnings, validationErrors: [] }
+    }
+
+    const { validateCommitMessage } = await import('../../lib/utils/commitlintValidator')
+    const validationResult = await validateCommitMessage(fullMessage)
+
+    if (validationResult.missingDependencies && validationResult.missingDependencies.length > 0) {
+      warnings.push(
+        `Skipping commitlint validation: missing packages (${validationResult.missingDependencies.join(', ')}).`
+      )
+      return { ok: true, draft: fullMessage, warnings, validationErrors: [] }
+    }
+
+    if (validationResult.valid) {
+      return { ok: true, draft: fullMessage, warnings, validationErrors: [] }
+    }
+
+    lastValidationErrors = validationResult.errors
+    validationFeedback = validationResult.errors.map((error) => `- ${error}`).join('\n')
+  }
+
+  // Both attempts failed validation — return the latest draft so the user can
+  // hand-edit in the compose surface, plus the validator output for context.
+  return {
+    ok: false,
+    draft: lastDraft,
+    warnings,
+    validationErrors: lastValidationErrors,
+  }
+}

--- a/src/commands/log/commitWorkflowActions.test.ts
+++ b/src/commands/log/commitWorkflowActions.test.ts
@@ -1,4 +1,5 @@
 import { handler as commitHandler } from '../commit/handler'
+import { generateCommitDraft } from '../commit/generateCommitDraft'
 import { createCommit } from '../../lib/simple-git/createCommit'
 import {
   commitWorkflowTestInternals,
@@ -8,6 +9,10 @@ import {
 
 jest.mock('../commit/handler', () => ({
   handler: jest.fn(),
+}))
+
+jest.mock('../commit/generateCommitDraft', () => ({
+  generateCommitDraft: jest.fn(),
 }))
 
 jest.mock('../../lib/simple-git/createCommit', () => ({
@@ -24,12 +29,15 @@ jest.mock('../../lib/simple-git/createCommit', () => ({
 }))
 
 const mockedCommitHandler = commitHandler as jest.MockedFunction<typeof commitHandler>
+const mockedGenerateCommitDraft =
+  generateCommitDraft as jest.MockedFunction<typeof generateCommitDraft>
 const mockedCreateCommit = createCommit as jest.MockedFunction<typeof createCommit>
 const git = {} as Parameters<typeof createCommit>[1]
 
 describe('log commit workflow actions', () => {
   beforeEach(() => {
     mockedCommitHandler.mockReset()
+    mockedGenerateCommitDraft.mockReset()
     mockedCreateCommit.mockReset()
   })
 
@@ -86,17 +94,49 @@ describe('log commit workflow actions', () => {
     )
   })
 
-  it('generates commit drafts without creating commits', async () => {
-    mockedCommitHandler.mockImplementation(async () => {
-      process.stdout.write('feat: draft message\n\nDraft body.\n')
+  it('generates commit drafts without creating commits or invoking the legacy handler', async () => {
+    mockedGenerateCommitDraft.mockResolvedValue({
+      ok: true,
+      draft: 'feat: draft message\n\nDraft body.',
+      warnings: [],
+      validationErrors: [],
     })
 
-    await expect(runCommitDraftWorkflow()).resolves.toEqual({
+    await expect(runCommitDraftWorkflow({ git })).resolves.toEqual({
       ok: true,
       message: 'feat: draft message',
+      details: [],
       draft: 'feat: draft message\n\nDraft body.',
     })
+
+    // Bug 2 (issue #757): the legacy commitHandler must not run inside the
+    // TUI — it leaks ora spinners and Inquirer prompts onto the alt screen.
+    expect(mockedCommitHandler).not.toHaveBeenCalled()
     expect(mockedCreateCommit).not.toHaveBeenCalled()
+    expect(mockedGenerateCommitDraft).toHaveBeenCalledWith(expect.objectContaining({
+      git,
+      argv: expect.objectContaining({
+        _: ['commit'],
+        interactive: false,
+        mode: 'stdout',
+      }),
+    }))
+  })
+
+  it('surfaces validation failures as structured workflow feedback', async () => {
+    mockedGenerateCommitDraft.mockResolvedValue({
+      ok: false,
+      draft: 'foo: bad type',
+      warnings: [],
+      validationErrors: ['type must be one of [feat, fix, ...]', 'subject too long'],
+    })
+
+    await expect(runCommitDraftWorkflow({ git })).resolves.toEqual({
+      ok: false,
+      message: 'type must be one of [feat, fix, ...]',
+      details: ['subject too long'],
+      draft: 'foo: bad type',
+    })
   })
 
   it('passes no-verify into TUI commit workflows', async () => {

--- a/src/commands/log/commitWorkflowActions.ts
+++ b/src/commands/log/commitWorkflowActions.ts
@@ -2,6 +2,7 @@ import { Arguments } from 'yargs'
 import { SimpleGit } from 'simple-git'
 import { handler as commitHandler } from '../commit/handler'
 import { CommitOptions } from '../commit/config'
+import { generateCommitDraft } from '../commit/generateCommitDraft'
 import { loadConfig } from '../../lib/config/utils/loadConfig'
 import { createCommit, PreCommitHookError } from '../../lib/simple-git/createCommit'
 import { getRepo } from '../../lib/simple-git/getRepo'
@@ -153,45 +154,51 @@ export async function runCommitWorkflow({
   }
 }
 
-export async function runCommitDraftWorkflow(): Promise<CommitWorkflowResult> {
+export async function runCommitDraftWorkflow(
+  input: { git?: SimpleGit } = {}
+): Promise<CommitWorkflowResult> {
+  const git = input.git || getRepo()
   const argv = createCommitWorkflowArgv('commit')
   const logger = new Logger({ silent: true })
-  const originalWrite = process.stdout.write.bind(process.stdout)
-  let output = ''
-
-  process.stdout.write = ((chunk: string | Uint8Array, ...args: unknown[]) => {
-    output += typeof chunk === 'string' ? chunk : chunk.toString()
-
-    const callback = args.find((arg): arg is (error?: Error | null) => void => typeof arg === 'function')
-    callback?.()
-
-    return true
-  }) as typeof process.stdout.write
 
   try {
-    await commitHandler(argv, logger)
-    const draft = output.trim()
+    const result = await generateCommitDraft({ git, argv, logger })
+    const draft = result.draft.trim()
+
+    if (result.ok && draft) {
+      return {
+        ok: true,
+        message: formatCommitWorkflowMessage('commit', draft),
+        details: result.warnings,
+        draft,
+      }
+    }
+
+    const failureLines = [
+      ...(result.validationErrors || []),
+      ...(result.warnings || []),
+    ]
 
     return {
-      ok: Boolean(draft),
-      message: draft ? formatCommitWorkflowMessage('commit', draft) : 'AI draft was empty.',
+      ok: false,
+      message: failureLines[0] ||
+        (draft ? 'AI draft did not pass commitlint.' : 'AI draft was empty.'),
+      details: failureLines.slice(1, 6),
       draft,
     }
   } catch (error) {
     if (isCommandExitError(error)) {
-      const lines = compactOutputLines(output || error.message)
+      const lines = compactOutputLines(error.message)
 
       return {
         ok: error.code === 0,
         message: lines[0] || error.message,
         details: lines.slice(1, 6),
-        draft: output.trim(),
+        draft: '',
       }
     }
 
     return formatCommitFailure(error)
-  } finally {
-    process.stdout.write = originalWrite
   }
 }
 

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -196,6 +196,45 @@ describe('log Ink input interactions', () => {
     expect(state.activeView).toBe('status')
   })
 
+  it('routes j/k in diff view to commit-diff hunks when no worktree file is in scope', () => {
+    let state = createLogInkState(rows, { activeView: 'diff' })
+
+    // Worktree context is empty; commit-diff hunk offsets are present.
+    const context = { commitDiffHunkOffsets: [2, 8, 14], previewLineCount: 30 }
+
+    // Pressing k from offset 0 (before the first hunk) must be a no-op,
+    // not a forward jump. This is the regression from inkViewModel:330.
+    state = applyInput(state, 'k', {}, context)
+    expect(state.diffPreviewOffset).toBe(0)
+
+    state = applyInput(state, 'j', {}, context)
+    expect(state.diffPreviewOffset).toBe(2)
+
+    state = applyInput(state, 'j', {}, context)
+    expect(state.diffPreviewOffset).toBe(8)
+
+    state = applyInput(state, 'k', {}, context)
+    expect(state.diffPreviewOffset).toBe(2)
+
+    // Pressing j from the last hunk must stay put, never wrap backward.
+    state = applyInput(state, 'j', {}, context)
+    state = applyInput(state, 'j', {}, context)
+    expect(state.diffPreviewOffset).toBe(14)
+    state = applyInput(state, 'j', {}, context)
+    expect(state.diffPreviewOffset).toBe(14)
+  })
+
+  it('routes PageUp/PageDown in diff view to detail-preview paging when no worktree file is in scope', () => {
+    let state = createLogInkState(rows, { activeView: 'diff' })
+    const context = { previewLineCount: 30 }
+
+    state = applyInput(state, '', { pageDown: true }, context)
+    expect(state.diffPreviewOffset).toBe(8)
+
+    state = applyInput(state, '', { pageUp: true }, context)
+    expect(state.diffPreviewOffset).toBe(0)
+  })
+
   it('emits worktree file and hunk mutation events from status and diff views', () => {
     expect(getLogInkInputEvents(
       createLogInkState(rows, { activeView: 'status' }),

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -41,6 +41,12 @@ export type LogInkInputContext = {
   previewLineCount?: number
   worktreeDiffLineCount?: number
   worktreeFileCount?: number
+  /**
+   * `@@` line offsets within `filePreview.hunks` for the selected commit's
+   * file. Lets diff-view j/k/PageUp/PageDown navigate the commit's hunks when
+   * no worktree file is in scope.
+   */
+  commitDiffHunkOffsets?: number[]
   branchCount?: number
   tagCount?: number
   stashCount?: number
@@ -509,6 +515,14 @@ export function getLogInkInputEvents(
       })]
     }
 
+    if (state.activeView === 'diff' && context.commitDiffHunkOffsets?.length) {
+      return [action({
+        type: 'jumpCommitDiffHunk',
+        delta: -1,
+        hunkOffsets: context.commitDiffHunkOffsets,
+      })]
+    }
+
     if (state.activeView === 'branches' && context.branchCount) {
       return [action({ type: 'moveBranch', delta: -1, count: context.branchCount })]
     }
@@ -549,6 +563,14 @@ export function getLogInkInputEvents(
       })]
     }
 
+    if (state.activeView === 'diff' && context.commitDiffHunkOffsets?.length) {
+      return [action({
+        type: 'jumpCommitDiffHunk',
+        delta: 1,
+        hunkOffsets: context.commitDiffHunkOffsets,
+      })]
+    }
+
     if (state.activeView === 'branches' && context.branchCount) {
       return [action({ type: 'moveBranch', delta: 1, count: context.branchCount })]
     }
@@ -577,6 +599,14 @@ export function getLogInkInputEvents(
       })]
     }
 
+    if (state.activeView === 'diff' && context.previewLineCount) {
+      return [action({
+        type: 'pageDetailPreview',
+        delta: -8,
+        previewLineCount: context.previewLineCount,
+      })]
+    }
+
     if (state.focus === 'detail' && context.previewLineCount) {
       return [action({
         type: 'pageDetailPreview',
@@ -594,6 +624,14 @@ export function getLogInkInputEvents(
         type: 'pageWorktreeDiff',
         delta: 8,
         lineCount: context.worktreeDiffLineCount,
+      })]
+    }
+
+    if (state.activeView === 'diff' && context.previewLineCount) {
+      return [action({
+        type: 'pageDetailPreview',
+        delta: 8,
+        previewLineCount: context.previewLineCount,
       })]
     }
 

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -875,6 +875,12 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     state.selectedIndex,
   ])
 
+  const commitDiffHunkOffsets = React.useMemo(() => (
+    filePreview?.hunks
+      .map((line, index) => (line.startsWith('@@') ? index : -1))
+      .filter((index) => index >= 0)
+  ), [filePreview])
+
   useInput((inputValue: string, key: LogInkInputKey) => {
     getLogInkInputEvents(state, inputValue, key, {
       detailFileCount: detail?.files.length,
@@ -882,6 +888,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       worktreeDiffLineCount: worktreeDiff?.lines.length,
       worktreeFileCount: context.worktree?.files.length,
       worktreeHunkOffsets: worktreeDiff?.hunkOffsets,
+      commitDiffHunkOffsets,
       branchCount: context.branches?.localBranches.length,
       tagCount: context.tags?.tags.length,
       stashCount: context.stashes?.stashes.length,
@@ -935,6 +942,10 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         worktreeDiffLoading,
         worktreeHunks,
         worktreeHunksLoading,
+        filePreview,
+        filePreviewLoading,
+        commitDiffHunkOffsets,
+        selectedDetailFile,
         layout.bodyRows,
         theme,
         hasMoreCommits,
@@ -1032,6 +1043,10 @@ function renderMainPanel(
   worktreeDiffLoading: boolean,
   worktreeHunks: WorktreeHunkOverview | undefined,
   worktreeHunksLoading: boolean,
+  filePreview: GitCommitFilePreview | undefined,
+  filePreviewLoading: boolean,
+  commitDiffHunkOffsets: number[] | undefined,
+  selectedDetailFile: GitCommitDetail['files'][number] | undefined,
   bodyRows: number,
   theme: LogInkTheme,
   hasMoreCommits: boolean,
@@ -1052,6 +1067,10 @@ function renderMainPanel(
       worktreeDiffLoading,
       worktreeHunks,
       worktreeHunksLoading,
+      filePreview,
+      filePreviewLoading,
+      commitDiffHunkOffsets,
+      selectedDetailFile,
       bodyRows,
       theme
     )
@@ -1464,14 +1483,70 @@ function renderDiffSurface(
   worktreeDiffLoading: boolean,
   worktreeHunks: WorktreeHunkOverview | undefined,
   worktreeHunksLoading: boolean,
+  filePreview: GitCommitFilePreview | undefined,
+  filePreviewLoading: boolean,
+  commitDiffHunkOffsets: number[] | undefined,
+  selectedDetailFile: GitCommitDetail['files'][number] | undefined,
   bodyRows: number,
   theme: LogInkTheme
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const focused = state.focus === 'commits'
   const worktree = context.worktree
-  const selectedFile = worktree?.files[state.selectedWorktreeFileIndex]
+  const worktreeFile = worktree?.files[state.selectedWorktreeFileIndex]
   const visibleRows = Math.max(4, bodyRows - 4)
+
+  // When the user opens diff via history → Enter (no worktree file in scope),
+  // render the selected commit's file preview hunks instead of the worktree
+  // surface. j/k/PageUp/PageDown are wired through commitDiffHunkOffsets and
+  // the existing pageDetailPreview action so navigation stays symmetric.
+  const useCommitDiff = !worktreeFile && Boolean(selectedDetailFile)
+
+  if (useCommitDiff) {
+    const previewHunks = filePreview?.hunks || []
+    const visiblePreviewHunks = previewHunks.slice(
+      state.diffPreviewOffset,
+      state.diffPreviewOffset + visibleRows
+    )
+    const hunkCount = commitDiffHunkOffsets?.length || 0
+    const currentHunkIndex = hunkCount > 0
+      ? Math.max(0, [...(commitDiffHunkOffsets || [])]
+          .reverse()
+          .findIndex((offset) => offset <= state.diffPreviewOffset))
+      : 0
+    const currentHunkLabel = hunkCount > 0
+      ? `Hunk ${Math.min(hunkCount - currentHunkIndex, hunkCount)}/${hunkCount}`
+      : 'No hunks for this file.'
+
+    const lines = filePreviewLoading
+      ? [`Loading diff for ${selectedDetailFile?.path || 'selected file'}...`]
+      : previewHunks.length
+        ? [
+          `Selected file: ${selectedDetailFile?.path || ''}`,
+          currentHunkLabel,
+          `Lines ${Math.min(state.diffPreviewOffset + 1, previewHunks.length || 1)}-${Math.min(state.diffPreviewOffset + visiblePreviewHunks.length, previewHunks.length)}/${previewHunks.length}`,
+          '',
+          ...visiblePreviewHunks,
+        ]
+        : ['No diff preview available for this file.']
+
+    return h(Box, {
+      borderColor: focusBorderColor(theme, focused),
+      borderStyle: theme.borderStyle,
+      flexDirection: 'column',
+      flexGrow: 1,
+      paddingX: 1,
+    },
+    h(Box, { justifyContent: 'space-between' },
+      h(Text, { bold: true }, panelTitle('Diff', focused)),
+      h(Text, { dimColor: true }, selectedDetailFile?.path || 'no file')
+    ),
+    ...lines.map((line, index) => h(Text, {
+      key: `diff-surface-${index}`,
+      dimColor: index > 1,
+    }, truncate(line, 140))))
+  }
+
   const diffLines = worktreeDiff?.lines || []
   const selectedHunk = worktreeHunks?.hunks[state.selectedWorktreeHunkIndex]
   const visibleDiffLines = diffLines.slice(
@@ -1481,10 +1556,10 @@ function renderDiffSurface(
   const lines = isLogInkContextKeyLoading(contextStatus, 'worktree')
     ? ['Loading file context...']
     : worktreeDiffLoading
-      ? [`Loading diff for ${selectedFile?.path || 'selected file'}...`]
-      : selectedFile
+      ? [`Loading diff for ${worktreeFile?.path || 'selected file'}...`]
+      : worktreeFile
       ? [
-        `Selected file: ${selectedFile.path}`,
+        `Selected file: ${worktreeFile.path}`,
         worktreeHunksLoading
           ? 'Hunks loading...'
           : worktreeHunks?.hunks.length
@@ -1505,7 +1580,7 @@ function renderDiffSurface(
   },
   h(Box, { justifyContent: 'space-between' },
     h(Text, { bold: true }, panelTitle('Diff', focused)),
-    h(Text, { dimColor: true }, selectedFile ? selectedFile.path : 'no file')
+    h(Text, { dimColor: true }, worktreeFile ? worktreeFile.path : 'no file')
   ),
   ...lines.map((line, index) => h(Text, {
     key: `diff-surface-${index}`,

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -227,6 +227,74 @@ describe('log Ink view model', () => {
     expect(state.selectedWorktreeHunkIndex).toBe(0)
   })
 
+  it('jumps commit-diff hunks symmetrically and stays put past the last hunk', () => {
+    let state = createLogInkState(rows, { activeView: 'diff' })
+
+    state = applyLogInkAction(state, {
+      type: 'jumpCommitDiffHunk',
+      delta: 1,
+      hunkOffsets: [3, 12, 25],
+    })
+    expect(state.diffPreviewOffset).toBe(3)
+
+    state = applyLogInkAction(state, {
+      type: 'jumpCommitDiffHunk',
+      delta: 1,
+      hunkOffsets: [3, 12, 25],
+    })
+    expect(state.diffPreviewOffset).toBe(12)
+
+    state = applyLogInkAction(state, {
+      type: 'jumpCommitDiffHunk',
+      delta: -1,
+      hunkOffsets: [3, 12, 25],
+    })
+    expect(state.diffPreviewOffset).toBe(3)
+  })
+
+  it('keeps diffPreviewOffset put when jumping past either edge', () => {
+    let state = createLogInkState(rows, { activeView: 'diff' })
+
+    // From offset 0 (before first hunk), pressing k must not jump forward
+    state = applyLogInkAction(state, {
+      type: 'jumpCommitDiffHunk',
+      delta: -1,
+      hunkOffsets: [5, 10],
+    })
+    expect(state.diffPreviewOffset).toBe(0)
+
+    // After advancing to the last hunk, pressing j again must stay put
+    state = applyLogInkAction(state, {
+      type: 'jumpCommitDiffHunk',
+      delta: 1,
+      hunkOffsets: [5, 10],
+    })
+    state = applyLogInkAction(state, {
+      type: 'jumpCommitDiffHunk',
+      delta: 1,
+      hunkOffsets: [5, 10],
+    })
+    expect(state.diffPreviewOffset).toBe(10)
+
+    state = applyLogInkAction(state, {
+      type: 'jumpCommitDiffHunk',
+      delta: 1,
+      hunkOffsets: [5, 10],
+    })
+    expect(state.diffPreviewOffset).toBe(10)
+  })
+
+  it('keeps worktreeDiffOffset put when jumping before the first hunk', () => {
+    let state = createLogInkState(rows, { activeView: 'diff' })
+
+    state = applyLogInkAction(state, {
+      type: 'jumpWorktreeHunk',
+      delta: -1,
+      hunkOffsets: [5, 10],
+    })
+    expect(state.worktreeDiffOffset).toBe(0)
+  })
+
   it('stores commit compose state in the shared view model', () => {
     let state = createLogInkState(rows, { activeView: 'status' })
 

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -99,6 +99,7 @@ export type LogInkAction =
   | { type: 'navigateOpenDiffForWorktreeFile'; fileIndex: number }
   | { type: 'navigateOpenComposeForFile'; fileIndex: number }
   | { type: 'jumpWorktreeHunk'; delta: number; hunkOffsets: number[] }
+  | { type: 'jumpCommitDiffHunk'; delta: number; hunkOffsets: number[] }
   | { type: 'setFocus'; value: LogInkFocus }
   | { type: 'setPendingKey'; value?: string }
   | { type: 'setSidebarTab'; value: LogInkSidebarTab }
@@ -333,12 +334,12 @@ function nextHunkOffset(currentOffset: number, hunkOffsets: number[], delta: num
   }
 
   if (delta > 0) {
-    return hunkOffsets.find((offset) => offset > currentOffset) ||
-      hunkOffsets[hunkOffsets.length - 1]
+    const nextOffset = hunkOffsets.find((offset) => offset > currentOffset)
+    return nextOffset === undefined ? currentOffset : nextOffset
   }
 
-  return [...hunkOffsets].reverse().find((offset) => offset < currentOffset) ||
-    hunkOffsets[0]
+  const previousOffset = [...hunkOffsets].reverse().find((offset) => offset < currentOffset)
+  return previousOffset === undefined ? currentOffset : previousOffset
 }
 
 function nextHunkIndex(currentOffset: number, hunkOffsets: number[], delta: number): number {
@@ -526,6 +527,16 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         ),
         selectedWorktreeHunkIndex: nextHunkIndex(
           state.worktreeDiffOffset,
+          action.hunkOffsets,
+          action.delta
+        ),
+        pendingKey: undefined,
+      }
+    case 'jumpCommitDiffHunk':
+      return {
+        ...state,
+        diffPreviewOffset: nextHunkOffset(
+          state.diffPreviewOffset,
           action.hunkOffsets,
           action.delta
         ),


### PR DESCRIPTION
Closes #757.

## Summary

- **Bug 1 — diff chunk navigation only works in one direction.** `j`/`k`/`PageUp`/`PageDown` in the diff view now navigate the selected commit's \`filePreview\` hunks when no worktree file is in scope. Adds a parallel \`jumpCommitDiffHunk\` action that operates on \`diffPreviewOffset\` and exposes \`commitDiffHunkOffsets\` (computed from \`@@\` line indices) through the input context. \`renderDiffSurface\` now renders the commit's hunks when entered via history → Enter so the navigation has something to scroll. \`nextHunkOffset\` stays put at either edge instead of wrapping to the first hunk on \`k\` from offset 0.
- **Bug 2 — AI commit corrupts the alt screen.** Extracted \`generateCommitDraft\` (\`src/commands/commit/generateCommitDraft.ts\`) — a UI-side-effect-free function that runs the LLM chain, formats with ticket extraction, and validates against commitlint with one auto-retry. \`runCommitDraftWorkflow\` no longer hijacks \`process.stdout\` to capture \`commitHandler\` output, so ora spinners and Inquirer prompts can no longer paint over the Ink alt screen. Validation failures surface as structured feedback through the existing compose pipeline. Legacy \`coco commit -i\` is unchanged.

## Tests added

- \`inkViewModel\`: symmetric \`jumpCommitDiffHunk\` traversal; no-op past either edge for both commit-diff and worktree variants.
- \`inkInput\`: \`j\`/\`k\` route to commit-diff in diff view when no worktree file is in scope; \`PageUp\`/\`PageDown\` route to detail-preview paging.
- \`commitWorkflowActions\`: \`runCommitDraftWorkflow\` no longer invokes \`commitHandler\`; validation failures surface as structured \`{ ok: false, message, details, draft }\`.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 665/665 passing (jest + lint + release dry-run)
- [x] \`npm run build\` — dual CJS/ESM output
- [x] \`npm run test:cli\` — 10/10 packaged smoke checks
- [x] \`npm run release:dry-run\` — clean
- [ ] Manual: history → Enter on a commit → \`j\`/\`k\` walk hunks symmetrically; \`k\` from offset 0 stays put
- [ ] Manual: status → diff → \`j\`/\`k\` continue to navigate worktree hunks (regression check)
- [ ] Manual: compose view → \`I\` requests AI draft → no terminal output leaks into the Ink frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)