### PR TITLE
feat(log-tui): line-scroll diff nav + diff colors + AI loading indicator

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -185,7 +185,16 @@ describe('log Ink input interactions', () => {
     state = applyInput(state, '', { pageDown: true }, { worktreeDiffLineCount: 30 })
     expect(state.worktreeDiffOffset).toBe(8)
 
+    // j now scrolls the diff one line at a time (line-level scroll), so
+    // after pageDown(+8) a single j advances to offset 9. Hunk navigation
+    // moved to ]/[.
     state = applyInput(state, 'j', {}, {
+      worktreeDiffLineCount: 30,
+      worktreeHunkOffsets: [2, 12, 20],
+    })
+    expect(state.worktreeDiffOffset).toBe(9)
+
+    state = applyInput(state, ']', {}, {
       worktreeDiffLineCount: 30,
       worktreeHunkOffsets: [2, 12, 20],
     })
@@ -196,31 +205,42 @@ describe('log Ink input interactions', () => {
     expect(state.activeView).toBe('status')
   })
 
-  it('routes j/k in diff view to commit-diff hunks when no worktree file is in scope', () => {
+  it('scrolls the commit-diff preview line-by-line on j/k in diff view', () => {
     let state = createLogInkState(rows, { activeView: 'diff' })
-
-    // Worktree context is empty; commit-diff hunk offsets are present.
     const context = { commitDiffHunkOffsets: [2, 8, 14], previewLineCount: 30 }
 
-    // Pressing k from offset 0 (before the first hunk) must be a no-op,
-    // not a forward jump. This is the regression from inkViewModel:330.
+    // k from offset 0 is a no-op (not a forward jump).
     state = applyInput(state, 'k', {}, context)
     expect(state.diffPreviewOffset).toBe(0)
 
     state = applyInput(state, 'j', {}, context)
-    expect(state.diffPreviewOffset).toBe(2)
+    expect(state.diffPreviewOffset).toBe(1)
 
     state = applyInput(state, 'j', {}, context)
-    expect(state.diffPreviewOffset).toBe(8)
+    expect(state.diffPreviewOffset).toBe(2)
 
     state = applyInput(state, 'k', {}, context)
+    expect(state.diffPreviewOffset).toBe(1)
+  })
+
+  it('jumps commit-diff hunks bidirectionally on ]/[ in diff view', () => {
+    let state = createLogInkState(rows, { activeView: 'diff' })
+    const context = { commitDiffHunkOffsets: [2, 8, 14], previewLineCount: 30 }
+
+    state = applyInput(state, ']', {}, context)
     expect(state.diffPreviewOffset).toBe(2)
 
-    // Pressing j from the last hunk must stay put, never wrap backward.
-    state = applyInput(state, 'j', {}, context)
-    state = applyInput(state, 'j', {}, context)
+    state = applyInput(state, ']', {}, context)
+    expect(state.diffPreviewOffset).toBe(8)
+
+    state = applyInput(state, '[', {}, context)
+    expect(state.diffPreviewOffset).toBe(2)
+
+    // Past the last hunk, ] stays put; before the first hunk, [ stays put.
+    state = applyInput(state, ']', {}, context)
+    state = applyInput(state, ']', {}, context)
     expect(state.diffPreviewOffset).toBe(14)
-    state = applyInput(state, 'j', {}, context)
+    state = applyInput(state, ']', {}, context)
     expect(state.diffPreviewOffset).toBe(14)
   })
 
@@ -233,6 +253,17 @@ describe('log Ink input interactions', () => {
 
     state = applyInput(state, '', { pageUp: true }, context)
     expect(state.diffPreviewOffset).toBe(0)
+  })
+
+  it('falls back to sidebar tab navigation when ]/[ is pressed outside diff view', () => {
+    const stateHistory = createLogInkState(rows)
+
+    expect(getLogInkInputEvents(stateHistory, ']', {})).toEqual([
+      { type: 'action', action: { type: 'nextSidebarTab' } },
+    ])
+    expect(getLogInkInputEvents(stateHistory, '[', {})).toEqual([
+      { type: 'action', action: { type: 'previousSidebarTab' } },
+    ])
   })
 
   it('emits worktree file and hunk mutation events from status and diff views', () => {

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -107,6 +107,15 @@ export function getLogInkPaletteExecuteEvents(
       return [action({ type: 'previousSidebarTab' })]
     case 'nextSidebarTab':
       return [action({ type: 'nextSidebarTab' })]
+    case 'previousHunk':
+    case 'nextHunk':
+      // Palette execution can't reach the live worktree/commit hunk offsets
+      // (those live in runtime state, not the reducer). Surface a hint and
+      // let the user press the keystroke directly in diff view.
+      return [action({
+        type: 'setStatus',
+        value: 'open the diff view and press [ or ] to jump hunks',
+      })]
     case 'focusNext':
       return [action({ type: 'focusNext' })]
     case 'focusPrevious':
@@ -479,10 +488,38 @@ export function getLogInkInputEvents(
   }
 
   if (inputValue === '[') {
+    if (state.activeView === 'diff' && context.worktreeHunkOffsets?.length) {
+      return [action({
+        type: 'jumpWorktreeHunk',
+        delta: -1,
+        hunkOffsets: context.worktreeHunkOffsets,
+      })]
+    }
+    if (state.activeView === 'diff' && context.commitDiffHunkOffsets?.length) {
+      return [action({
+        type: 'jumpCommitDiffHunk',
+        delta: -1,
+        hunkOffsets: context.commitDiffHunkOffsets,
+      })]
+    }
     return [action({ type: 'previousSidebarTab' })]
   }
 
   if (inputValue === ']') {
+    if (state.activeView === 'diff' && context.worktreeHunkOffsets?.length) {
+      return [action({
+        type: 'jumpWorktreeHunk',
+        delta: 1,
+        hunkOffsets: context.worktreeHunkOffsets,
+      })]
+    }
+    if (state.activeView === 'diff' && context.commitDiffHunkOffsets?.length) {
+      return [action({
+        type: 'jumpCommitDiffHunk',
+        delta: 1,
+        hunkOffsets: context.commitDiffHunkOffsets,
+      })]
+    }
     return [action({ type: 'nextSidebarTab' })]
   }
 
@@ -507,19 +544,23 @@ export function getLogInkInputEvents(
       })]
     }
 
+    // Diff view: j/k scrolls the visible diff one line. Hunk navigation
+    // moved to ]/[ so single-hunk files (longer than the preview pane)
+    // can scroll bidirectionally instead of getting pinned to a hunk
+    // anchor.
     if (state.activeView === 'diff' && context.worktreeDiffLineCount) {
       return [action({
-        type: 'jumpWorktreeHunk',
+        type: 'pageWorktreeDiff',
         delta: -1,
-        hunkOffsets: context.worktreeHunkOffsets || [],
+        lineCount: context.worktreeDiffLineCount,
       })]
     }
 
-    if (state.activeView === 'diff' && context.commitDiffHunkOffsets?.length) {
+    if (state.activeView === 'diff' && context.previewLineCount) {
       return [action({
-        type: 'jumpCommitDiffHunk',
+        type: 'pageDetailPreview',
         delta: -1,
-        hunkOffsets: context.commitDiffHunkOffsets,
+        previewLineCount: context.previewLineCount,
       })]
     }
 
@@ -557,17 +598,17 @@ export function getLogInkInputEvents(
 
     if (state.activeView === 'diff' && context.worktreeDiffLineCount) {
       return [action({
-        type: 'jumpWorktreeHunk',
+        type: 'pageWorktreeDiff',
         delta: 1,
-        hunkOffsets: context.worktreeHunkOffsets || [],
+        lineCount: context.worktreeDiffLineCount,
       })]
     }
 
-    if (state.activeView === 'diff' && context.commitDiffHunkOffsets?.length) {
+    if (state.activeView === 'diff' && context.previewLineCount) {
       return [action({
-        type: 'jumpCommitDiffHunk',
+        type: 'pageDetailPreview',
         delta: 1,
-        hunkOffsets: context.commitDiffHunkOffsets,
+        previewLineCount: context.previewLineCount,
       })]
     }
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -24,12 +24,14 @@ export type LogInkCommandId =
   | 'navigateStash'
   | 'navigateStatus'
   | 'navigateTags'
+  | 'nextHunk'
   | 'nextMatch'
   | 'nextSidebarTab'
   | 'moveUp'
   | 'openSelected'
   | 'pageDown'
   | 'pageUp'
+  | 'previousHunk'
   | 'previousMatch'
   | 'previousSidebarTab'
   | 'quit'
@@ -120,15 +122,29 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     id: 'previousSidebarTab',
     keys: ['['],
     label: 'previous tab',
-    description: 'Move to the previous repository sidebar tab.',
+    description: 'Move to the previous repository sidebar tab (outside diff view).',
     contexts: ['sidebar'],
   },
   {
     id: 'nextSidebarTab',
     keys: [']'],
     label: 'next tab',
-    description: 'Move to the next repository sidebar tab.',
+    description: 'Move to the next repository sidebar tab (outside diff view).',
     contexts: ['sidebar'],
+  },
+  {
+    id: 'previousHunk',
+    keys: ['['],
+    label: 'previous hunk',
+    description: 'Jump to the previous diff hunk in the current diff view.',
+    contexts: ['commits'],
+  },
+  {
+    id: 'nextHunk',
+    keys: [']'],
+    label: 'next hunk',
+    description: 'Jump to the next diff hunk in the current diff view.',
+    contexts: ['commits'],
   },
   {
     id: 'focusNext',

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -310,6 +310,39 @@ function panelTitle(title: string, focused: boolean): string {
   return focused ? `${title} *` : title
 }
 
+/**
+ * Map a unified-diff line to the props passed to an Ink `<Text>` so the
+ * standard +/-/@@ prefixes render in their conventional colors. File
+ * headers (`+++`, `---`, `diff --git`, `index`) get a softer treatment so
+ * they don't compete with the actual hunk content.
+ *
+ * `theme.noColor` collapses everything to dim/normal so we stay readable
+ * under `NO_COLOR` and the `monochrome` preset.
+ */
+function diffLineProps(
+  line: string,
+  theme: LogInkTheme
+): { color?: string; dimColor?: boolean } {
+  if (theme.noColor) {
+    return { dimColor: line.startsWith(' ') || line.startsWith('diff ') || line.startsWith('index ') }
+  }
+
+  if (line.startsWith('diff ') || line.startsWith('index ') || line.startsWith('+++') || line.startsWith('---')) {
+    return { dimColor: true }
+  }
+  if (line.startsWith('@@')) {
+    return { color: theme.colors.accent }
+  }
+  if (line.startsWith('+')) {
+    return { color: theme.colors.gitAdded }
+  }
+  if (line.startsWith('-')) {
+    return { color: theme.colors.gitDeleted }
+  }
+
+  return {}
+}
+
 function sidebarTabLabel(tab: LogInkSidebarTab): string {
   switch (tab) {
     case 'status':
@@ -1233,11 +1266,9 @@ function renderComposeSurface(
   const bodyLines = compose.body
     ? compose.body.split('\n').slice(0, bodyRowsAvailable)
     : ['<empty>']
-  const stateLine = compose.loading
-    ? 'Working...'
-    : compose.editing
-      ? 'Editing — Enter switches summary↔body, Esc exits edit mode.'
-      : 'Press e to edit, c to commit, I for AI draft, esc to leave.'
+  const stateLine = compose.editing
+    ? 'Editing — Enter switches summary↔body, Esc exits edit mode.'
+    : 'Press e to edit, c to commit, I for AI draft, esc to leave.'
   const stagedFileLines = (worktree?.files || [])
     .filter((file) => file.indexStatus !== ' ' && file.indexStatus !== '?')
     .slice(0, 5)
@@ -1270,7 +1301,15 @@ function renderComposeSurface(
     dimColor: line === '<empty>',
   }, truncate(`  ${line}${bodyCursor && index === bodyLines.length - 1 ? bodyCursor : ''}`, 140))),
   h(Text, undefined, ''),
-  h(Text, { dimColor: true }, stateLine),
+  ...(compose.loading
+    ? [h(Text, {
+      key: 'compose-loading',
+      bold: true,
+      color: theme.noColor ? undefined : theme.colors.accent,
+    }, theme.ascii
+      ? '[...] Generating AI commit draft (this can take a moment)'
+      : '⏳ Generating AI commit draft… (this can take a moment)')]
+    : [h(Text, { dimColor: true }, stateLine)]),
   ...(compose.message ? [h(Text, { key: 'compose-msg' }, truncate(compose.message, 140))] : []),
   ...(compose.details || []).map((line, index) => h(Text, {
     key: `compose-detail-${index}`,
@@ -1518,7 +1557,7 @@ function renderDiffSurface(
       ? `Hunk ${Math.min(hunkCount - currentHunkIndex, hunkCount)}/${hunkCount}`
       : 'No hunks for this file.'
 
-    const lines = filePreviewLoading
+    const headerLines: string[] = filePreviewLoading
       ? [`Loading diff for ${selectedDetailFile?.path || 'selected file'}...`]
       : previewHunks.length
         ? [
@@ -1526,7 +1565,6 @@ function renderDiffSurface(
           currentHunkLabel,
           `Lines ${Math.min(state.diffPreviewOffset + 1, previewHunks.length || 1)}-${Math.min(state.diffPreviewOffset + visiblePreviewHunks.length, previewHunks.length)}/${previewHunks.length}`,
           '',
-          ...visiblePreviewHunks,
         ]
         : ['No diff preview available for this file.']
 
@@ -1541,10 +1579,16 @@ function renderDiffSurface(
       h(Text, { bold: true }, panelTitle('Diff', focused)),
       h(Text, { dimColor: true }, selectedDetailFile?.path || 'no file')
     ),
-    ...lines.map((line, index) => h(Text, {
-      key: `diff-surface-${index}`,
-      dimColor: index > 1,
-    }, truncate(line, 140))))
+    ...headerLines.map((line, index) => h(Text, {
+      key: `diff-surface-header-${index}`,
+      dimColor: index > 0,
+    }, truncate(line, 140))),
+    ...(filePreviewLoading || !previewHunks.length
+      ? []
+      : visiblePreviewHunks.map((line, index) => h(Text, {
+        key: `diff-surface-line-${state.diffPreviewOffset + index}`,
+        ...diffLineProps(line, theme),
+      }, truncate(line, 140)))))
   }
 
   const diffLines = worktreeDiff?.lines || []
@@ -1553,7 +1597,7 @@ function renderDiffSurface(
     state.worktreeDiffOffset,
     state.worktreeDiffOffset + visibleRows
   )
-  const lines = isLogInkContextKeyLoading(contextStatus, 'worktree')
+  const headerLines: string[] = isLogInkContextKeyLoading(contextStatus, 'worktree')
     ? ['Loading file context...']
     : worktreeDiffLoading
       ? [`Loading diff for ${worktreeFile?.path || 'selected file'}...`]
@@ -1567,9 +1611,12 @@ function renderDiffSurface(
             : 'No stageable hunks for this file.',
         `Lines ${Math.min(state.worktreeDiffOffset + 1, diffLines.length || 1)}-${Math.min(state.worktreeDiffOffset + visibleDiffLines.length, diffLines.length)}/${diffLines.length}`,
         '',
-        ...visibleDiffLines,
       ]
       : ['No changed file selected.']
+
+  const showDiffLines = Boolean(worktreeFile) &&
+    !worktreeDiffLoading &&
+    !isLogInkContextKeyLoading(contextStatus, 'worktree')
 
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
@@ -1582,10 +1629,16 @@ function renderDiffSurface(
     h(Text, { bold: true }, panelTitle('Diff', focused)),
     h(Text, { dimColor: true }, worktreeFile ? worktreeFile.path : 'no file')
   ),
-  ...lines.map((line, index) => h(Text, {
-    key: `diff-surface-${index}`,
-    dimColor: index > 1,
-  }, truncate(line, 140))))
+  ...headerLines.map((line, index) => h(Text, {
+    key: `diff-surface-header-${index}`,
+    dimColor: index > 0,
+  }, truncate(line, 140))),
+  ...(showDiffLines
+    ? visibleDiffLines.map((line, index) => h(Text, {
+      key: `diff-surface-line-${state.worktreeDiffOffset + index}`,
+      ...diffLineProps(line, theme),
+    }, truncate(line, 140)))
+    : []))
 }
 
 function renderDetailPanel(
@@ -1631,46 +1684,63 @@ function renderDetailPanel(
     contextLoading: isLogInkContextLoading(contextStatus),
     selectedCommit: selected,
   })
-  const lines = detail
-    ? [
-      detail.message,
-      '',
-      `Commit: ${compactHash(detail.hash)}`,
-      `Author: ${detail.author}`,
-      `Date: ${detail.date}`,
-      detail.refs.length ? `Refs: ${detail.refs.join(', ')}` : 'Refs: none',
-      statLine,
-      '',
-      ...(detail.body ? detail.body.split('\n').slice(0, 6) : ['No commit body.']),
-      '',
-      'Changed files:',
-      ...(detail.files.length
-        ? detail.files.slice(0, 8).map((file, index) =>
-          `${index === state.selectedFileIndex ? '>' : ' '} ${formatChangedFile(file)}`
-        )
-        : ['No changed files found.']),
-      '',
-      selectedFile
-        ? `Preview: ${formatChangedFile(selectedFile)}`
-        : 'Preview: no file selected',
-      filePreviewLoading
-        ? 'Loading diff preview...'
-        : previewWindow?.length
-          ? `Lines ${state.diffPreviewOffset + 1}-${state.diffPreviewOffset + previewWindow.length}/${filePreview?.hunks.length || 0}`
-          : 'No hunk preview available.',
-      ...(previewWindow || []).map((line) => `  ${line}`),
-      '',
-      'Workflows:',
-      ...workflowSections.flatMap((section) => [
-        section.title,
-        ...section.lines.slice(0, 3).map((line) => `  ${line}`),
-      ]).slice(0, 14),
-    ]
-    : [
+
+  if (!detail) {
+    const fallbackLines = [
       selected?.message || 'No commit selected.',
       '',
       loading ? 'Loading commit details...' : 'Commit details unavailable.',
     ]
+    return h(Box, {
+      borderColor: focusBorderColor(theme, focused),
+      borderStyle: theme.borderStyle,
+      flexDirection: 'column',
+      width,
+      paddingX: 1,
+    },
+    h(Text, { bold: true }, panelTitle('Inspector', focused)),
+    ...fallbackLines.map((line, index) => h(Text, {
+      key: `detail-${index}`,
+      dimColor: index > 1,
+    }, truncate(line, width - 4))))
+  }
+
+  const headerLines = [
+    detail.message,
+    '',
+    `Commit: ${compactHash(detail.hash)}`,
+    `Author: ${detail.author}`,
+    `Date: ${detail.date}`,
+    detail.refs.length ? `Refs: ${detail.refs.join(', ')}` : 'Refs: none',
+    statLine,
+    '',
+    ...(detail.body ? detail.body.split('\n').slice(0, 6) : ['No commit body.']),
+    '',
+    'Changed files:',
+    ...(detail.files.length
+      ? detail.files.slice(0, 8).map((file, index) =>
+        `${index === state.selectedFileIndex ? '>' : ' '} ${formatChangedFile(file)}`
+      )
+      : ['No changed files found.']),
+    '',
+    selectedFile
+      ? `Preview: ${formatChangedFile(selectedFile)}`
+      : 'Preview: no file selected',
+    filePreviewLoading
+      ? 'Loading diff preview...'
+      : previewWindow?.length
+        ? `Lines ${state.diffPreviewOffset + 1}-${state.diffPreviewOffset + previewWindow.length}/${filePreview?.hunks.length || 0}`
+        : 'No hunk preview available.',
+  ]
+  const previewLines = previewWindow || []
+  const trailerLines = [
+    '',
+    'Workflows:',
+    ...workflowSections.flatMap((section) => [
+      section.title,
+      ...section.lines.slice(0, 3).map((line) => `  ${line}`),
+    ]).slice(0, 14),
+  ]
 
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
@@ -1680,9 +1750,17 @@ function renderDetailPanel(
     paddingX: 1,
   },
   h(Text, { bold: true }, panelTitle('Inspector', focused)),
-  ...lines.map((line, index) => h(Text, {
-    key: `detail-${index}`,
+  ...headerLines.map((line, index) => h(Text, {
+    key: `detail-header-${index}`,
     dimColor: index > 1 && line !== 'Changed files:',
+  }, truncate(line, width - 4))),
+  ...previewLines.map((line, index) => h(Text, {
+    key: `detail-preview-${state.diffPreviewOffset + index}`,
+    ...diffLineProps(line, theme),
+  }, truncate(`  ${line}`, width - 4))),
+  ...trailerLines.map((line, index) => h(Text, {
+    key: `detail-trailer-${index}`,
+    dimColor: index > 0,
   }, truncate(line, width - 4))))
 }
 
@@ -1707,21 +1785,21 @@ function renderCommitPanel(
   const summaryCursor = compose.editing && compose.field === 'summary' ? '_' : ''
   const bodyCursor = compose.editing && compose.field === 'body' ? '_' : ''
   const bodyLines = compose.body ? compose.body.split('\n').slice(0, 4) : ['<empty>']
-  const lines = [
+  const headerLines = [
     statusLine,
     '',
     `${compose.field === 'summary' && compose.editing ? '>' : ' '} Summary: ${compose.summary || '<empty>'}${summaryCursor}`,
     `${compose.field === 'body' && compose.editing ? '>' : ' '} Body:`,
     ...bodyLines.map((line) => `  ${line}${bodyCursor && line === bodyLines[bodyLines.length - 1] ? bodyCursor : ''}`),
     '',
-    loading
-      ? 'Working...'
-      : compose.editing
-        ? 'Enter/tab edits fields, Esc exits edit mode.'
-        : 'e edit | c commit | I AI draft',
+  ]
+  const trailerLines = [
     ...(compose.message ? ['', compose.message] : []),
     ...(compose.details || []).map((line) => `  ${line}`),
   ]
+  const stateLine = compose.editing
+    ? 'Enter/tab edits fields, Esc exits edit mode.'
+    : 'e edit | c commit | I AI draft'
 
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
@@ -1731,9 +1809,20 @@ function renderCommitPanel(
     paddingX: 1,
   },
   h(Text, { bold: true }, panelTitle('Commit', focused)),
-  ...lines.map((line, index) => h(Text, {
-    key: `commit-${index}`,
+  ...headerLines.map((line, index) => h(Text, {
+    key: `commit-header-${index}`,
     dimColor: index < 2 || line.startsWith('  ') || line === '<empty>',
+  }, truncate(line, width - 4))),
+  loading
+    ? h(Text, {
+      key: 'commit-loading',
+      bold: true,
+      color: theme.noColor ? undefined : theme.colors.accent,
+    }, truncate(theme.ascii ? '[...] Generating AI draft' : '⏳ Generating AI draft…', width - 4))
+    : h(Text, { key: 'commit-state', dimColor: true }, truncate(stateLine, width - 4)),
+  ...trailerLines.map((line, index) => h(Text, {
+    key: `commit-trailer-${index}`,
+    dimColor: line.startsWith('  '),
   }, truncate(line, width - 4))))
 }
 


### PR DESCRIPTION
First slice of the v2 polish work catalogued in #756. Targets the issues that surfaced after #758 shipped — single-hunk diffs that wouldn't scroll back up, no visual feedback during AI draft generation, and a flat monochrome diff that's hard to scan.

## Summary

- **j/k → single-line scroll** in both worktree and commit-diff modes. Replaces the hunk-anchor jump from #758 so single-hunk diffs longer than the preview pane scroll bidirectionally instead of getting pinned to the `@@` anchor.
- **`]` / `[` → next/prev hunk**, context-aware. In diff view they advance through hunks (worktree or commit-diff, whichever is in scope); outside diff view they fall through to the existing sidebar-tab navigation. Adds `nextHunk` / `previousHunk` command IDs to the keymap so `?` and `:` surface them properly.
- **Diff colors.** `+` lines render in `theme.colors.gitAdded`, `-` lines in `gitDeleted`, `@@` hunk headers in the theme `accent`, and file headers (`diff --git`, `index`, `+++`, `---`) dim. Applied in both `renderDiffSurface` and the inspector preview. Honors `NO_COLOR` and the `monochrome` preset.
- **AI draft loading indicator.** Replaces the subtle `Working...` text with a bold accent-color banner (`⏳ Generating AI commit draft…`, with `[...]` ASCII fallback when `theme.ascii` is true) so the user gets clear feedback that the request is in flight. Surfaced in both `renderComposeSurface` and the smaller `renderCommitPanel` detail.

## Tests added

- `inkInput`: j/k now scroll line-by-line in diff view (`worktreeDiff` and commit-diff branches), `]`/`[` jump hunks bidirectionally with the same edge-case semantics from #758, `]`/`[` fall back to sidebar-tab nav when outside diff view.
- Existing test that exercised \`j\` as hunk-jump updated to use \`]\` for the same assertion.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 665/665 passing
- [x] \`npm run build\` clean
- [x] \`npm run test:cli\` — 10/10 packaged smoke checks
- [x] \`npm run release:dry-run\` clean
- [ ] Manual: history → Enter on a single-hunk commit longer than the pane → \`j\`/\`k\` scroll line-by-line, both directions
- [ ] Manual: history → Enter on a multi-hunk commit → \`]\` and \`[\` walk hunks
- [ ] Manual: status → Enter on a worktree file → \`j\`/\`k\` scroll, \`]\`/\`[\` jump hunks, \`space\` still toggles hunk stage
- [ ] Manual: anywhere outside diff view → \`]\`/\`[\` cycle sidebar tabs (regression)
- [ ] Manual: compose view → \`I\` shows the bold loading banner until the draft arrives
- [ ] Manual: \`NO_COLOR=1 coco ui\` → diff lines render dim, no green/red

## Reference

- Builds on #758 (commit-diff hunk wiring landed there)
- Tracks against polish issue [#756](https://github.com/gfargo/coco/issues/756)

🤖 Generated with [Claude Code](https://claude.com/claude-code)