### PR TITLE
feat(log-tui): synthetic '(+) new commit' row when worktree is dirty

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -140,6 +140,36 @@ describe('log Ink input interactions', () => {
     expect(state.focus).toBe('sidebar')
   })
 
+  it('focuses the synthetic pending-commit row on k from index 0 when worktree is dirty', () => {
+    let state = createLogInkState(rows)
+    expect(state.selectedIndex).toBe(0)
+    expect(state.pendingCommitFocused).toBeFalsy()
+
+    // Without worktreeDirty in context, k at index 0 must remain a no-op.
+    state = applyInput(state, 'k')
+    expect(state.pendingCommitFocused).toBeFalsy()
+    expect(state.selectedIndex).toBe(0)
+
+    state = applyInput(state, 'k', {}, { worktreeDirty: true })
+    expect(state.pendingCommitFocused).toBe(true)
+    expect(state.selectedIndex).toBe(0)
+
+    state = applyInput(state, 'j', {}, { worktreeDirty: true })
+    expect(state.pendingCommitFocused).toBeFalsy()
+    expect(state.selectedIndex).toBe(0)
+  })
+
+  it('Enter on the pending-commit row pushes the status view', () => {
+    let state = createLogInkState(rows)
+    state = applyInput(state, 'k', {}, { worktreeDirty: true })
+    expect(state.pendingCommitFocused).toBe(true)
+
+    state = applyInput(state, '', { return: true }, { worktreeDirty: true })
+    expect(state.activeView).toBe('status')
+    // Pending flag clears on view push so popping back lands on real commit 0.
+    expect(state.pendingCommitFocused).toBeFalsy()
+  })
+
   it('supports next/previous match and top/bottom navigation conventions', () => {
     let state = createLogInkState(rows)
 

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -50,6 +50,13 @@ export type LogInkInputContext = {
   branchCount?: number
   tagCount?: number
   stashCount?: number
+  /**
+   * True when the worktree has any staged, unstaged, or untracked changes.
+   * Drives the synthetic "(+) new commit" row at the top of the history
+   * list — pressing up at `selectedIndex === 0` transitions onto it; the
+   * row is hidden entirely when the worktree is clean.
+   */
+  worktreeDirty?: boolean
 }
 
 function action(actionValue: LogInkAction): LogInkInputEvent {
@@ -576,6 +583,16 @@ export function getLogInkInputEvents(
       return [action({ type: 'moveStash', delta: -1, count: context.stashCount })]
     }
 
+    if (
+      state.activeView === 'history' &&
+      state.focus === 'commits' &&
+      state.selectedIndex === 0 &&
+      !state.pendingCommitFocused &&
+      context.worktreeDirty
+    ) {
+      return [action({ type: 'focusPendingCommit' })]
+    }
+
     return [
       action(state.focus === 'sidebar'
         ? { type: 'previousSidebarTab' }
@@ -584,6 +601,10 @@ export function getLogInkInputEvents(
   }
 
   if (key.downArrow || inputValue === 'j') {
+    if (state.activeView === 'history' && state.pendingCommitFocused) {
+      return [action({ type: 'unfocusPendingCommit' })]
+    }
+
     if (state.focus === 'detail' && context.detailFileCount) {
       return [action({ type: 'moveDetailFile', delta: 1, fileCount: context.detailFileCount })]
     }
@@ -685,6 +706,20 @@ export function getLogInkInputEvents(
     }
 
     return [action({ type: 'page', delta: 10 })]
+  }
+
+  // Enter on the synthetic "(+) new commit" row pushes the status view so
+  // the user can stage/commit. The pending flag is cleared on view push so
+  // popping back lands on the real commit at index 0.
+  if (
+    key.return &&
+    state.activeView === 'history' &&
+    state.pendingCommitFocused
+  ) {
+    return [
+      action({ type: 'pushView', value: 'status' }),
+      action({ type: 'setStatus', value: 'staging worktree changes' }),
+    ]
   }
 
   if (

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -939,6 +939,11 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       .filter((index) => index >= 0)
   ), [filePreview])
 
+  const worktreeDirty = Boolean(
+    context.worktree &&
+    (context.worktree.stagedCount + context.worktree.unstagedCount + context.worktree.untrackedCount) > 0
+  )
+
   useInput((inputValue: string, key: LogInkInputKey) => {
     getLogInkInputEvents(state, inputValue, key, {
       detailFileCount: detail?.files.length,
@@ -950,6 +955,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       branchCount: context.branches?.localBranches.length,
       tagCount: context.tags?.tags.length,
       stashCount: context.stashes?.stashes.length,
+      worktreeDirty,
     }).forEach((event) => {
       if (event.type === 'exit') {
         exit()
@@ -1154,6 +1160,7 @@ function renderMainPanel(
     h,
     components,
     state,
+    context,
     bodyRows,
     theme,
     hasMoreCommits,
@@ -1165,6 +1172,7 @@ function renderHistoryPanel(
   h: typeof ReactTypes.createElement,
   components: LogInkComponents,
   state: LogInkState,
+  context: LogInkContext,
   bodyRows: number,
   theme: LogInkTheme,
   hasMoreCommits: boolean,
@@ -1172,7 +1180,18 @@ function renderHistoryPanel(
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const focused = state.focus === 'commits'
-  const listRows = Math.max(3, bodyRows - 4)
+  const worktree = context.worktree
+  const worktreeDirty = Boolean(
+    worktree && (worktree.stagedCount + worktree.unstagedCount + worktree.untrackedCount) > 0
+  )
+  // The synthetic "(+) new commit" row only appears when the worktree is
+  // dirty AND the visible window is anchored at the top of the list — i.e.
+  // the first real commit (selectedIndex 0) is in view. Scroll past that
+  // and the row slides off naturally; the user can `gg` to bring it back.
+  const showPendingRow = worktreeDirty &&
+    !state.filter &&
+    state.selectedIndex === 0
+  const listRows = Math.max(3, bodyRows - (showPendingRow ? 5 : 4))
   const visible = getVisibleLogInkHistory(state, listRows)
   const loadState = loadingMoreCommits
     ? 'loading older commits'
@@ -1181,6 +1200,15 @@ function renderHistoryPanel(
       : 'loaded'
   const title = `${state.filteredCommits.length}/${state.commits.length} commits`
   const graphMode = state.fullGraph ? 'full graph' : 'compact graph'
+
+  const pendingRowSelected = showPendingRow && Boolean(state.pendingCommitFocused) && focused
+  // Real-commit selection is suppressed while the cursor is on the pending
+  // row so the visible cursor only renders in one place at a time.
+  const realSelectionSuppressed = state.pendingCommitFocused
+
+  const pendingNode = showPendingRow
+    ? renderPendingCommitRow(h, Text, worktree!, pendingRowSelected, theme)
+    : null
 
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
@@ -1193,6 +1221,7 @@ function renderHistoryPanel(
     h(Text, { bold: true }, panelTitle('Commits', focused)),
     h(Text, { dimColor: true }, `${title} | ${graphMode} | ${loadState}`)
   ),
+  ...(pendingNode ? [pendingNode] : []),
   visible.items.length === 0
     ? h(Text, { dimColor: true }, formatLogInkHistoryEmpty({
       filter: state.filter,
@@ -1207,15 +1236,51 @@ function renderHistoryPanel(
       }
 
       const { commit, selected } = item
+      const isVisuallySelected = selected && !realSelectionSuppressed
       const graph = item.graph.padEnd(visible.graphWidth)
       const row = `${graph} ${commit.shortHash} ${commit.date} ${commit.message}${formatInkRefLabels(commit.refs)}`
 
       return h(Text, {
         key: `${commit.hash}-${index}`,
-        backgroundColor: selected && !theme.noColor ? theme.colors.selection : undefined,
-        inverse: selected,
+        backgroundColor: isVisuallySelected && !theme.noColor ? theme.colors.selection : undefined,
+        inverse: isVisuallySelected,
       }, truncate(row, 140))
     }))
+}
+
+/**
+ * Render the synthetic "(+) new commit" affordance shown above the real
+ * commit list when the worktree is dirty. Pressing up at `selectedIndex 0`
+ * focuses this row; pressing Enter pushes the status view so the user can
+ * stage / commit.
+ */
+function renderPendingCommitRow(
+  h: typeof ReactTypes.createElement,
+  Text: LogInkComponents['Text'],
+  worktree: NonNullable<LogInkContext['worktree']>,
+  selected: boolean,
+  theme: LogInkTheme
+): ReactTypes.ReactElement {
+  const parts: string[] = []
+  if (worktree.stagedCount) {
+    parts.push(`${worktree.stagedCount} staged`)
+  }
+  if (worktree.unstagedCount) {
+    parts.push(`${worktree.unstagedCount} unstaged`)
+  }
+  if (worktree.untrackedCount) {
+    parts.push(`${worktree.untrackedCount} untracked`)
+  }
+  const summary = parts.length ? parts.join(' · ') : 'pending changes'
+  const label = `${theme.ascii ? '[+]' : '(+)'} New commit · ${summary}`
+
+  return h(Text, {
+    key: 'pending-commit-row',
+    bold: true,
+    color: theme.noColor ? undefined : theme.colors.accent,
+    inverse: selected,
+    backgroundColor: selected && !theme.noColor ? theme.colors.selection : undefined,
+  }, truncate(label, 140))
 }
 
 function renderStatusSurface(
@@ -1693,6 +1758,13 @@ function renderDetailPanel(
 
   if (state.pendingConfirmationId || state.pendingMutationConfirmation) {
     return renderConfirmationPanel(h, components, state, width, theme, focused)
+  }
+
+  // The synthetic "(+) new commit" row routes the inspector through the
+  // worktree summary so the user sees what's staged / unstaged at a glance
+  // — same surface as the compose view's right panel.
+  if (state.activeView === 'history' && state.pendingCommitFocused) {
+    return renderComposeContextPanel(h, components, state, context, contextStatus, width, theme, focused)
   }
 
   // Status + worktree-sourced diff keep the staging compose panel — it's

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -162,6 +162,45 @@ describe('log Ink view model', () => {
     expect(getSelectedInkCommit(state)?.shortHash).toBe('abc1234')
   })
 
+  it('focusPendingCommit selects the synthetic row; getSelectedInkCommit returns undefined', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'focusPendingCommit' })
+
+    expect(state.pendingCommitFocused).toBe(true)
+    expect(state.selectedIndex).toBe(0)
+    expect(getSelectedInkCommit(state)).toBeUndefined()
+
+    state = applyLogInkAction(state, { type: 'unfocusPendingCommit' })
+    expect(state.pendingCommitFocused).toBe(false)
+    expect(getSelectedInkCommit(state)?.shortHash).toBe('abc1234')
+  })
+
+  it('clears the pending-commit focus when navigating away from history', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'focusPendingCommit' })
+    expect(state.pendingCommitFocused).toBe(true)
+
+    state = applyLogInkAction(state, { type: 'pushView', value: 'status' })
+    expect(state.activeView).toBe('status')
+    expect(state.pendingCommitFocused).toBe(false)
+  })
+
+  it('clears the pending-commit focus on moveToTop / moveToBottom / navigateHome', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'focusPendingCommit' })
+    state = applyLogInkAction(state, { type: 'moveToBottom' })
+    expect(state.pendingCommitFocused).toBe(false)
+
+    state = applyLogInkAction(state, { type: 'focusPendingCommit' })
+    state = applyLogInkAction(state, { type: 'moveToTop' })
+    expect(state.pendingCommitFocused).toBe(false)
+
+    state = applyLogInkAction(state, { type: 'focusPendingCommit' })
+    state = applyLogInkAction(state, { type: 'pushView', value: 'compose' })
+    state = applyLogInkAction(state, { type: 'navigateHome' })
+    expect(state.pendingCommitFocused).toBe(false)
+  })
+
   it('appends older rows while preserving the selected commit', () => {
     let state = createLogInkState(rows)
 

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -81,6 +81,19 @@ export type LogInkState = {
    * are selectable. Cleared when the diff view is popped or replaced.
    */
   diffSource?: LogInkDiffSource
+  /**
+   * When true, the cursor sits on the synthetic "(+) new commit" row
+   * that the history panel renders above the real commits whenever the
+   * worktree is dirty. `getSelectedInkCommit` returns undefined in this
+   * state, so the inspector and diff panels fall through to the worktree
+   * summary view.
+   *
+   * The reducer transitions in/out via the `move` action: pressing up
+   * (delta -1) at `selectedIndex === 0` flips the flag on; pressing
+   * down (delta +1) while focused unflips it. The history renderer is
+   * responsible for hiding the synthetic row when the worktree is clean.
+   */
+  pendingCommitFocused?: boolean
 }
 
 export type LogInkAction =
@@ -115,6 +128,8 @@ export type LogInkAction =
   | { type: 'navigateOpenComposeForFile'; fileIndex: number }
   | { type: 'jumpWorktreeHunk'; delta: number; hunkOffsets: number[] }
   | { type: 'jumpCommitDiffHunk'; delta: number; hunkOffsets: number[] }
+  | { type: 'focusPendingCommit' }
+  | { type: 'unfocusPendingCommit' }
   | { type: 'setFocus'; value: LogInkFocus }
   | { type: 'setPendingKey'; value?: string }
   | { type: 'setSidebarTab'; value: LogInkSidebarTab }
@@ -264,6 +279,7 @@ function withPushedView(state: LogInkState, value: LogInkView): LogInkState {
     worktreeDiffOffset: value === 'diff' ? state.worktreeDiffOffset : 0,
     selectedWorktreeHunkIndex: value === 'diff' ? state.selectedWorktreeHunkIndex : 0,
     diffSource: value === 'diff' ? state.diffSource : undefined,
+    pendingCommitFocused: value === 'history' ? state.pendingCommitFocused : false,
     pendingKey: undefined,
   }
 }
@@ -282,6 +298,7 @@ function withPoppedView(state: LogInkState): LogInkState {
     worktreeDiffOffset: next === 'diff' ? state.worktreeDiffOffset : 0,
     selectedWorktreeHunkIndex: next === 'diff' ? state.selectedWorktreeHunkIndex : 0,
     diffSource: next === 'diff' ? state.diffSource : undefined,
+    pendingCommitFocused: next === 'history' ? state.pendingCommitFocused : false,
     pendingKey: undefined,
   }
 }
@@ -299,6 +316,7 @@ function withReplacedView(state: LogInkState, value: LogInkView): LogInkState {
     worktreeDiffOffset: value === 'diff' ? state.worktreeDiffOffset : 0,
     selectedWorktreeHunkIndex: value === 'diff' ? state.selectedWorktreeHunkIndex : 0,
     diffSource: value === 'diff' ? state.diffSource : undefined,
+    pendingCommitFocused: value === 'history' ? state.pendingCommitFocused : false,
     pendingKey: undefined,
   }
 }
@@ -411,6 +429,12 @@ export function createLogInkState(
 }
 
 export function getSelectedInkCommit(state: LogInkState): GitLogCommitRow | undefined {
+  if (state.pendingCommitFocused) {
+    // The cursor is on the synthetic "(+) new commit" row, not a real
+    // commit; callers (detail loaders, diff intents) should treat this as
+    // "no commit selected" and route to the worktree summary instead.
+    return undefined
+  }
   return state.filteredCommits[state.selectedIndex]
 }
 
@@ -449,6 +473,24 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         selectedIndex: clampIndex(state.selectedIndex + action.delta, state.filteredCommits.length),
+        selectedFileIndex: 0,
+        diffPreviewOffset: 0,
+        pendingCommitFocused: false,
+        pendingKey: undefined,
+      }
+    case 'focusPendingCommit':
+      return {
+        ...state,
+        pendingCommitFocused: true,
+        selectedFileIndex: 0,
+        diffPreviewOffset: 0,
+        pendingKey: undefined,
+      }
+    case 'unfocusPendingCommit':
+      return {
+        ...state,
+        pendingCommitFocused: false,
+        selectedIndex: 0,
         selectedFileIndex: 0,
         diffPreviewOffset: 0,
         pendingKey: undefined,
@@ -496,6 +538,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         selectedIndex: clampIndex(state.filteredCommits.length - 1, state.filteredCommits.length),
         selectedFileIndex: 0,
         diffPreviewOffset: 0,
+        pendingCommitFocused: false,
         pendingKey: undefined,
       }
     case 'moveToTop':
@@ -504,6 +547,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         selectedIndex: 0,
         selectedFileIndex: 0,
         diffPreviewOffset: 0,
+        pendingCommitFocused: false,
         pendingKey: undefined,
       }
     case 'nextSidebarTab':
@@ -586,6 +630,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         viewStack: [HOME_VIEW],
         worktreeDiffOffset: 0,
         selectedWorktreeHunkIndex: 0,
+        pendingCommitFocused: false,
         pendingKey: undefined,
       }
     }


### PR DESCRIPTION
PR C from the v2 polish plan in #756. **Stacked on top of #760** — review and merge that one first; this PR's diff will collapse to its own commits once #760 lands.

Adds a discovery affordance at the top of the history list so dirty worktrees are visible from the home view without needing to know the \`g s\` chord. Press \`k\` from \`selectedIndex 0\` and the cursor moves onto a synthetic '(+) new commit' row; the right panel shows the worktree summary; \`Enter\` pushes the status view in one keystroke.

## Summary

- **\`pendingCommitFocused\` state flag** with \`focusPendingCommit\` / \`unfocusPendingCommit\` reducers. Up at \`selectedIndex 0\` in history view transitions onto the synthetic row when \`worktreeDirty\` is true; down unflips to \`selectedIndex 0\`. Navigating away from history, jumping to top/bottom, or going home all clear the flag so popped views never return to a stale pending state.
- **\`getSelectedInkCommit\`** returns \`undefined\` while \`pendingCommitFocused\` so the inspector / diff loaders short-circuit cleanly.
- **History panel** renders the synthetic row above the commits when the worktree has any staged / unstaged / untracked files AND the visible window is anchored at index 0. Label reads \`(+) New commit · N staged · M unstaged · K untracked\` with theme accent color and ASCII fallback (\`[+]\`).
- **Detail panel** routes through the worktree summary (the same \`renderComposeContextPanel\` introduced in PR B) when \`pendingCommitFocused\` so the user sees staged + unstaged file lists at a glance.
- **Enter on the pending row** pushes the status view so the staging flow is reachable in one keystroke.

## Tests

- \`inkViewModel\`: \`focusPendingCommit\` / \`unfocusPendingCommit\` transitions, \`getSelectedInkCommit\` returning undefined while pending, flag clearing on \`pushView\` / \`moveToTop\` / \`moveToBottom\` / \`navigateHome\`.
- \`inkInput\`: \`k\` from index 0 with \`worktreeDirty: false\` is a no-op; with \`worktreeDirty: true\` transitions to pending. \`j\` from pending unfocuses. \`Enter\` on pending pushes status.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 675/675 passing
- [x] \`npm run build\` clean
- [x] \`npm run test:cli\` — 10/10 packaged smoke checks
- [x] \`npm run release:dry-run\` clean
- [ ] Manual: clean worktree → no synthetic row visible (regression)
- [ ] Manual: dirty worktree (stage / modify / untrack) → synthetic row appears at top of history with summary counts
- [ ] Manual: \`k\` from top commit → cursor moves onto synthetic row, right panel switches to worktree summary
- [ ] Manual: \`Enter\` on synthetic row → pushes status view; \`<\` returns to history with cursor on real commit 0
- [ ] Manual: \`gg\` from anywhere returns to real commit 0 (not the synthetic row)
- [ ] Manual: \`NO_COLOR=1 coco ui\` → synthetic row still visible, no theme accent

## Reference

- Stacked on #760 (commit-diff explore + colored file list)
- Tracks against polish issue [#756](https://github.com/gfargo/coco/issues/756)

🤖 Generated with [Claude Code](https://claude.com/claude-code)