### PR TITLE
feat(log-tui): live refresh on .git + working-tree changes

### DIFF
--- a/src/commands/log/inkRefreshWatcher.test.ts
+++ b/src/commands/log/inkRefreshWatcher.test.ts
@@ -1,0 +1,133 @@
+import { LogInkRefreshKind, createRefreshDebouncer } from './inkRefreshWatcher'
+
+/**
+ * Synchronous fake scheduler so we can run debounce timing without
+ * involving real timers. Tests step the clock by calling `flush(ms)`.
+ */
+function createFakeScheduler() {
+  type Pending = { id: number; due: number; callback: () => void }
+  const pending: Pending[] = []
+  let nextId = 1
+  let now = 0
+
+  return {
+    scheduler: {
+      setTimeout: (callback: () => void, ms: number): number => {
+        const id = nextId++
+        pending.push({ id, due: now + ms, callback })
+        return id
+      },
+      clearTimeout: (handle: unknown): void => {
+        const id = handle as number
+        const index = pending.findIndex((entry) => entry.id === id)
+        if (index >= 0) {
+          pending.splice(index, 1)
+        }
+      },
+    },
+    flush: (ms: number): void => {
+      now += ms
+      while (pending.length > 0 && pending[0].due <= now) {
+        const next = pending.shift()!
+        next.callback()
+      }
+    },
+    pendingCount: () => pending.length,
+  }
+}
+
+describe('createRefreshDebouncer', () => {
+  it('emits exactly one onSettle per debounce window', () => {
+    const fake = createFakeScheduler()
+    const settles: LogInkRefreshKind[] = []
+
+    const debouncer = createRefreshDebouncer({
+      debounceMs: 100,
+      scheduler: fake.scheduler,
+      onSettle: (kind) => settles.push(kind),
+    })
+
+    debouncer.trigger('worktree')
+    debouncer.trigger('worktree')
+    debouncer.trigger('worktree')
+
+    expect(settles).toEqual([])
+    fake.flush(100)
+    expect(settles).toEqual(['worktree'])
+  })
+
+  it('escalates to "full" when any trigger in the window is full', () => {
+    const fake = createFakeScheduler()
+    const settles: LogInkRefreshKind[] = []
+
+    const debouncer = createRefreshDebouncer({
+      debounceMs: 100,
+      scheduler: fake.scheduler,
+      onSettle: (kind) => settles.push(kind),
+    })
+
+    debouncer.trigger('worktree')
+    debouncer.trigger('full')
+    debouncer.trigger('worktree')
+
+    fake.flush(100)
+    expect(settles).toEqual(['full'])
+  })
+
+  it('does NOT downgrade once a "full" is queued in the window', () => {
+    const fake = createFakeScheduler()
+    const settles: LogInkRefreshKind[] = []
+
+    const debouncer = createRefreshDebouncer({
+      debounceMs: 100,
+      scheduler: fake.scheduler,
+      onSettle: (kind) => settles.push(kind),
+    })
+
+    debouncer.trigger('full')
+    debouncer.trigger('worktree')
+    debouncer.trigger('worktree')
+
+    fake.flush(100)
+    expect(settles).toEqual(['full'])
+  })
+
+  it('starts a fresh window after the previous one settles', () => {
+    const fake = createFakeScheduler()
+    const settles: LogInkRefreshKind[] = []
+
+    const debouncer = createRefreshDebouncer({
+      debounceMs: 100,
+      scheduler: fake.scheduler,
+      onSettle: (kind) => settles.push(kind),
+    })
+
+    debouncer.trigger('full')
+    fake.flush(100)
+    expect(settles).toEqual(['full'])
+
+    debouncer.trigger('worktree')
+    fake.flush(100)
+    expect(settles).toEqual(['full', 'worktree'])
+  })
+
+  it('close() cancels any pending settle without firing it', () => {
+    const fake = createFakeScheduler()
+    const settles: LogInkRefreshKind[] = []
+
+    const debouncer = createRefreshDebouncer({
+      debounceMs: 100,
+      scheduler: fake.scheduler,
+      onSettle: (kind) => settles.push(kind),
+    })
+
+    debouncer.trigger('full')
+    expect(fake.pendingCount()).toBe(1)
+
+    debouncer.close()
+    expect(fake.pendingCount()).toBe(0)
+
+    fake.flush(500)
+    expect(settles).toEqual([])
+  })
+})

--- a/src/commands/log/inkRefreshWatcher.ts
+++ b/src/commands/log/inkRefreshWatcher.ts
@@ -1,0 +1,158 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+/**
+ * Severity of refresh required by an observed change.
+ *
+ * - `worktree` — only the working tree / index changed. Cheap to refresh
+ *   (single `getWorktreeOverview` call); the rest of the context (branches,
+ *   tags, stashes, PR metadata) stays valid.
+ * - `full` — branch tip moved, HEAD switched, or refs were created /
+ *   deleted. Requires `loadLogInkContext` to reload everything.
+ *
+ * The debouncer escalates monotonically: once a `full` is requested in a
+ * window, subsequent `worktree` triggers don't downgrade it.
+ */
+export type LogInkRefreshKind = 'worktree' | 'full'
+
+export type LogInkRefreshDebouncerOptions = {
+  /** ms to wait after the last trigger before emitting `onSettle`. */
+  debounceMs?: number
+  /** Called once per debounce window with the highest kind seen. */
+  onSettle: (kind: LogInkRefreshKind) => void
+  /** Override `setTimeout`/`clearTimeout` for tests. */
+  scheduler?: {
+    setTimeout: (callback: () => void, ms: number) => unknown
+    clearTimeout: (handle: unknown) => void
+  }
+}
+
+export type LogInkRefreshDebouncer = {
+  trigger: (kind: LogInkRefreshKind) => void
+  /** Drops any pending settle without firing it. */
+  close: () => void
+}
+
+const DEFAULT_DEBOUNCE_MS = 250
+
+const DEFAULT_SCHEDULER = {
+  setTimeout: (callback: () => void, ms: number) => setTimeout(callback, ms),
+  clearTimeout: (handle: unknown) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+}
+
+/**
+ * Pure debouncer that coalesces a burst of `trigger` calls into one
+ * `onSettle` invocation. Tracks the highest-severity kind across the
+ * window so a fast sequence of worktree-then-HEAD changes still produces
+ * a single `full` refresh.
+ *
+ * Extracted from the watcher so it's testable without touching `fs.watch`.
+ */
+export function createRefreshDebouncer(
+  options: LogInkRefreshDebouncerOptions
+): LogInkRefreshDebouncer {
+  const debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS
+  const scheduler = options.scheduler ?? DEFAULT_SCHEDULER
+  let timer: unknown = null
+  let pendingKind: LogInkRefreshKind | null = null
+
+  const trigger = (kind: LogInkRefreshKind) => {
+    pendingKind = pendingKind === 'full' ? 'full' : kind
+    if (timer !== null) {
+      scheduler.clearTimeout(timer)
+    }
+    timer = scheduler.setTimeout(() => {
+      timer = null
+      const kindToEmit = pendingKind || 'worktree'
+      pendingKind = null
+      options.onSettle(kindToEmit)
+    }, debounceMs)
+  }
+
+  const close = () => {
+    if (timer !== null) {
+      scheduler.clearTimeout(timer)
+      timer = null
+    }
+    pendingKind = null
+  }
+
+  return { trigger, close }
+}
+
+export type LogInkRefreshWatcherOptions = {
+  /** Working tree root (output of `git rev-parse --show-toplevel`). */
+  repoRoot: string
+  /** Resolved git directory (output of `git rev-parse --absolute-git-dir`). */
+  gitDir: string
+  /** Called once per debounce window. */
+  onChange: (kind: LogInkRefreshKind) => void
+  debounceMs?: number
+}
+
+export type LogInkRefreshWatcher = {
+  close: () => void
+}
+
+/**
+ * Watch the repo's `.git` metadata + the working tree root for changes
+ * that should refresh the TUI's repository context. Best-effort: missing
+ * paths or platforms without `fs.watch` support degrade gracefully — the
+ * user can still manually refresh with `r`.
+ *
+ * The watch surface is deliberately narrow:
+ *
+ * - `.git/index` (worktree refresh) — fires on `git add` / `rm` / `commit`
+ * - `.git/HEAD` (full refresh)      — fires on branch switches
+ * - `.git/refs/heads` recursively (full refresh) — fires on commits to a
+ *   branch tip, branch creation/deletion
+ * - repo root non-recursively (worktree refresh) — picks up top-level
+ *   create/delete/rename. Subdirectory unstaged edits do NOT trigger an
+ *   auto-refresh; the user can press `r` for those, which keeps watch
+ *   overhead negligible on large repos.
+ */
+export function createRefreshWatcher(
+  options: LogInkRefreshWatcherOptions
+): LogInkRefreshWatcher {
+  const debouncer = createRefreshDebouncer({
+    debounceMs: options.debounceMs,
+    onSettle: options.onChange,
+  })
+  const watchers: fs.FSWatcher[] = []
+
+  const safeWatch = (
+    pathname: string,
+    kind: LogInkRefreshKind,
+    watchOptions: fs.WatchOptions = {}
+  ): void => {
+    try {
+      const watcher = fs.watch(pathname, watchOptions, () => debouncer.trigger(kind))
+      // fs.watch errors at runtime (e.g. file removed) shouldn't crash the
+      // TUI — the watcher is best-effort.
+      watcher.on('error', () => {})
+      watchers.push(watcher)
+    } catch {
+      // Path may not exist (fresh repo with no commits yet) or the platform
+      // may not support fs.watch on this entry. Skip silently.
+    }
+  }
+
+  safeWatch(path.join(options.gitDir, 'index'), 'worktree')
+  safeWatch(path.join(options.gitDir, 'HEAD'), 'full')
+  safeWatch(path.join(options.gitDir, 'refs', 'heads'), 'full', { recursive: true })
+  safeWatch(options.repoRoot, 'worktree')
+
+  return {
+    close: () => {
+      debouncer.close()
+      for (const watcher of watchers) {
+        try {
+          watcher.close()
+        } catch {
+          // already closed; ignore
+        }
+      }
+      watchers.length = 0
+    },
+  }
+}

--- a/src/commands/log/inkRefreshWatcher.ts
+++ b/src/commands/log/inkRefreshWatcher.ts
@@ -36,6 +36,10 @@ export type LogInkRefreshDebouncer = {
 const DEFAULT_DEBOUNCE_MS = 250
 
 const DEFAULT_SCHEDULER = {
+  // `callback` is typed `() => void` (a function reference, never a string),
+  // and `ms` is a number, so the eval-injection vector behind DevSkim
+  // DS172411 doesn't apply here.
+  // DevSkim: ignore DS172411
   setTimeout: (callback: () => void, ms: number) => setTimeout(callback, ms),
   clearTimeout: (handle: unknown) => clearTimeout(handle as ReturnType<typeof setTimeout>),
 }
@@ -56,17 +60,24 @@ export function createRefreshDebouncer(
   let timer: unknown = null
   let pendingKind: LogInkRefreshKind | null = null
 
+  const onTimerFire = (): void => {
+    timer = null
+    const kindToEmit = pendingKind || 'worktree'
+    pendingKind = null
+    options.onSettle(kindToEmit)
+  }
+
   const trigger = (kind: LogInkRefreshKind) => {
     pendingKind = pendingKind === 'full' ? 'full' : kind
     if (timer !== null) {
       scheduler.clearTimeout(timer)
     }
-    timer = scheduler.setTimeout(() => {
-      timer = null
-      const kindToEmit = pendingKind || 'worktree'
-      pendingKind = null
-      options.onSettle(kindToEmit)
-    }, debounceMs)
+    // The first arg is a function value defined above (`onTimerFire`),
+    // never a string, so the eval-injection vector that drives
+    // DevSkim DS172411 doesn't apply here. The second arg is also our
+    // own `debounceMs` constant — no caller-supplied data flows in.
+    // DevSkim: ignore DS172411
+    timer = scheduler.setTimeout(onTimerFire, debounceMs)
   }
 
   const close = () => {

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -72,6 +72,10 @@ import {
 } from './inkKeymap'
 import { LogInkInputKey, getLogInkInputEvents } from './inkInput'
 import {
+  LogInkRefreshWatcher,
+  createRefreshWatcher,
+} from './inkRefreshWatcher'
+import {
   LOG_INK_DEFAULT_COLUMNS,
   LOG_INK_DEFAULT_ROWS,
   LOG_INK_MIN_COLUMNS,
@@ -584,6 +588,51 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }))
     setContextStatus((current) => updateLogInkContextStatus(current, 'worktree', 'ready'))
   }, [git])
+
+  // Live refresh: watch .git metadata + the working tree root and reload
+  // context when something changes outside the TUI (editor save, external
+  // git commands, branch switch in another terminal). Best-effort — the
+  // watcher quietly skips paths that don't exist or platforms where
+  // fs.watch fails. Subdirectory unstaged edits don't fire; users can
+  // press `r` for those.
+  React.useEffect(() => {
+    let cancelled = false
+    let watcher: LogInkRefreshWatcher | null = null
+
+    void (async () => {
+      try {
+        const [repoRoot, gitDir] = await Promise.all([
+          git.revparse(['--show-toplevel']),
+          git.revparse(['--absolute-git-dir']),
+        ])
+        if (cancelled) {
+          return
+        }
+        watcher = createRefreshWatcher({
+          repoRoot: repoRoot.trim(),
+          gitDir: gitDir.trim(),
+          onChange: (kind) => {
+            if (!mountedRef.current) {
+              return
+            }
+            if (kind === 'full') {
+              void refreshContext()
+            } else {
+              void refreshWorktreeContext()
+            }
+          },
+        })
+      } catch {
+        // Not in a git worktree, or revparse failed. Skip — manual `r`
+        // refresh still works.
+      }
+    })()
+
+    return () => {
+      cancelled = true
+      watcher?.close()
+    }
+  }, [git, refreshContext, refreshWorktreeContext])
 
   React.useEffect(() => {
     let active = true


### PR DESCRIPTION
PR D from the v2 polish plan in #756. Cuts out the "press r to see what I just staged" friction by watching a narrow set of .git metadata + the repo root with \`fs.watch\` and debouncing 250ms before refreshing context. No new deps, no recursive working-tree watcher.

## Summary

- **\`createRefreshDebouncer\`** — pure helper that coalesces a burst of triggers into one \`onSettle\` call per debounce window, escalating monotonically (\`full\` > \`worktree\`). A fast worktree-then-HEAD sequence still produces a single \`full\` refresh, never a downgraded \`worktree\` one. Extracted from the watcher so the kind-escalation logic is unit-testable without \`fs.watch\`.
- **\`createRefreshWatcher\`** — watches a deliberately narrow surface:
  - \`.git/index\` (worktree refresh) — fires on \`git add\` / \`rm\` / \`commit\`
  - \`.git/HEAD\` (full refresh) — fires on branch switches
  - \`.git/refs/heads\` recursively (full refresh) — fires on branch tip updates, create/delete
  - repo root non-recursively (worktree refresh) — picks up top-level create/delete/rename
- **Subdirectory unstaged edits do NOT auto-refresh.** Manual \`r\` covers them and keeps watch overhead negligible on monorepos. This was the explicit tradeoff to avoid pulling in chokidar / a recursive watcher.
- **Best-effort.** Missing paths, fresh repos without commits, or platforms where \`fs.watch\` fails all degrade gracefully — the watcher quietly no-ops and manual \`r\` still works.
- **Hooked into \`inkRuntime\`** via a React effect that resolves \`repoRoot\` + \`gitDir\` via \`git rev-parse\`, dispatches \`refreshContext\` (full) or \`refreshWorktreeContext\` (worktree) on settle, and cleans up on unmount.

## Tests

- \`createRefreshDebouncer\` — 5 tests covering single-emission per window, kind escalation in both orderings, fresh window after settle, \`close()\` cancels pending.
- The fs-bound \`createRefreshWatcher\` is exercised end-to-end via the existing TUI integration; watching real fs in unit tests is flaky, so the testable surface stays in the pure debouncer.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 680/680 passing (5 new debouncer tests)
- [x] \`npm run build\` clean
- [x] \`npm run test:cli\` — 10/10 packaged smoke checks
- [x] \`npm run release:dry-run\` clean
- [ ] Manual: \`coco ui\` running → \`git add file.ts\` in another terminal → status sidebar updates within ~250ms without pressing \`r\`
- [ ] Manual: \`coco ui\` running → \`git commit\` in another terminal → history repaints with the new commit
- [ ] Manual: \`coco ui\` running → \`git switch branch\` in another terminal → header / branch summary updates
- [ ] Manual: edit a file in a subdirectory → no auto-refresh (expected — manual \`r\` works)
- [ ] Manual: rapid \`git add\` / \`git reset\` in a loop → single batched refresh, not a flood

## Reference

- Tracks against polish issue [#756](https://github.com/gfargo/coco/issues/756)
- Builds on PRs #758, #759, #760, #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)