### PR TITLE
feat(log-tui): graph polish — colored row spans + Unicode topology chars

### DIFF
--- a/src/commands/log/inkGraphChars.test.ts
+++ b/src/commands/log/inkGraphChars.test.ts
@@ -1,0 +1,46 @@
+import { isPureGraphRow, substituteGraphChars } from './inkGraphChars'
+
+describe('substituteGraphChars', () => {
+  it('passes ASCII through unchanged when theme.ascii is true', () => {
+    const input = '* | | \\ /'
+    expect(substituteGraphChars(input, { ascii: true })).toBe(input)
+  })
+
+  it('replaces topology chars with Unicode equivalents when ascii is false', () => {
+    const input = '*'
+    expect(substituteGraphChars(input, { ascii: false })).toBe('●')
+    expect(substituteGraphChars('|', { ascii: false })).toBe('│')
+    expect(substituteGraphChars('/', { ascii: false })).toBe('╱')
+    expect(substituteGraphChars('\\', { ascii: false })).toBe('╲')
+    expect(substituteGraphChars('_', { ascii: false })).toBe('─')
+  })
+
+  it('preserves spaces and unmapped characters', () => {
+    const input = '*  | (HEAD)'
+    expect(substituteGraphChars(input, { ascii: false })).toBe('●  │ (HEAD)')
+  })
+
+  it('handles a multi-branch row from git log --graph output', () => {
+    const input = '* | |   '
+    expect(substituteGraphChars(input, { ascii: false })).toBe('● │ │   ')
+  })
+})
+
+describe('isPureGraphRow', () => {
+  it('returns true for rows with only topology characters', () => {
+    expect(isPureGraphRow('|')).toBe(true)
+    expect(isPureGraphRow('| | |')).toBe(true)
+    expect(isPureGraphRow('|/')).toBe(true)
+    expect(isPureGraphRow('| | \\ /')).toBe(true)
+  })
+
+  it('returns false for rows containing commit content', () => {
+    expect(isPureGraphRow('* abc1234 fix bug')).toBe(false)
+    expect(isPureGraphRow('| (HEAD) refs')).toBe(false)
+  })
+
+  it('returns false for empty / whitespace-only rows', () => {
+    expect(isPureGraphRow('')).toBe(false)
+    expect(isPureGraphRow('   ')).toBe(false)
+  })
+})

--- a/src/commands/log/inkGraphChars.ts
+++ b/src/commands/log/inkGraphChars.ts
@@ -1,0 +1,54 @@
+/**
+ * The chars `git log --graph` emits for branch topology — `*`, `|`, `\`,
+ * `/`, `_`, ` `. ASCII-only output is bulletproof for legacy terminals
+ * but the angles read poorly when many branches overlap.
+ *
+ * `substituteGraphChars` swaps them for box-drawing / geometric Unicode
+ * equivalents when the terminal can render them; falls back to ASCII
+ * under `theme.ascii` (TERM=dumb / vt100) and `theme.noColor` is
+ * orthogonal — the Unicode chars are still rendered, just without color.
+ *
+ * Kept ASCII-only intentionally:
+ *   - alphanumerics       (commit refs / annotations git sometimes injects)
+ *   - parens / brackets   (HEAD decoration markers, not part of the graph)
+ *   - hyphens / colons    (likewise)
+ */
+const ASCII_TO_UNICODE: Record<string, string> = {
+  '*': '●',
+  '|': '│',
+  '/': '╱',
+  '\\': '╲',
+  '_': '─',
+}
+
+export function substituteGraphChars(
+  graph: string,
+  options: { ascii: boolean }
+): string {
+  if (options.ascii) {
+    return graph
+  }
+  let output = ''
+  for (const character of graph) {
+    output += ASCII_TO_UNICODE[character] ?? character
+  }
+  return output
+}
+
+/**
+ * True when a graph string contains nothing but topology characters and
+ * whitespace — used to decide whether a row is decoration (a continuation
+ * of branch lines, no commit on this line) or actual commit content.
+ *
+ * Only the ASCII inputs need to match here; Unicode substitution happens
+ * at render time after this check.
+ */
+export function isPureGraphRow(graph: string): boolean {
+  for (const character of graph) {
+    if (character !== '*' && character !== '|' && character !== '\\' &&
+        character !== '/' && character !== '_' && character !== ' ') {
+      return false
+    }
+  }
+  return graph.trim().length > 0
+}

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -43,6 +43,7 @@ import { runCommitDraftWorkflow } from './commitWorkflowActions'
 import {
   GitCommitDetail,
   GitCommitFilePreview,
+  GitLogCommitRow,
   GitLogRow,
   LOG_INTERACTIVE_DEFAULT_LIMIT,
   getCommitDetail,
@@ -70,6 +71,7 @@ import {
   getLogInkFooterHints,
   getLogInkHelpSections,
 } from './inkKeymap'
+import { substituteGraphChars } from './inkGraphChars'
 import { LogInkInputKey, getLogInkInputEvents } from './inkInput'
 import {
   LogInkRefreshWatcher,
@@ -92,7 +94,7 @@ import {
   formatLogInkStatusEmpty,
   formatLogInkTagsEmpty,
 } from './inkSurfaceStates'
-import { truncateCells } from './inkText'
+import { cellWidth, truncateCells } from './inkText'
 import {
   LogInkSidebarTab,
   LogInkState,
@@ -1280,21 +1282,67 @@ function renderHistoryPanel(
       if (item.type === 'graph') {
         return h(Text, {
           key: `graph-${index}-${item.graph}`,
-          dimColor: true,
-        }, truncate(item.graph.padEnd(visible.graphWidth), 140))
+          color: theme.noColor ? undefined : theme.colors.muted,
+          dimColor: theme.noColor,
+        }, truncate(substituteGraphChars(
+          item.graph.padEnd(visible.graphWidth),
+          { ascii: theme.ascii }
+        ), 140))
       }
 
-      const { commit, selected } = item
-      const isVisuallySelected = selected && !realSelectionSuppressed
-      const graph = item.graph.padEnd(visible.graphWidth)
-      const row = `${graph} ${commit.shortHash} ${commit.date} ${commit.message}${formatInkRefLabels(commit.refs)}`
-
-      return h(Text, {
-        key: `${commit.hash}-${index}`,
-        backgroundColor: isVisuallySelected && !theme.noColor ? theme.colors.selection : undefined,
-        inverse: isVisuallySelected,
-      }, truncate(row, 140))
+      return renderCommitHistoryRow(
+        h, Text, item.commit, item.graph, visible.graphWidth,
+        Boolean(item.selected) && !realSelectionSuppressed, theme, index
+      )
     }))
+}
+
+/**
+ * Render a single commit row with each segment in its own colored span.
+ * Graph chars render in `theme.colors.muted` so the topology visually
+ * recedes; shortHash takes the accent so the eye lands on the commit
+ * identifier first; date is dimmed; message is normal; ref labels
+ * (`[HEAD -> main]`) trail in accent. Selection styling is applied at
+ * the outer span via `backgroundColor` / `inverse` so the highlight
+ * fills the whole row regardless of inner-span coloring.
+ *
+ * Truncation is per-segment so the variable-length message field gets
+ * the leftover budget after fixed segments are accounted for.
+ */
+function renderCommitHistoryRow(
+  h: typeof ReactTypes.createElement,
+  Text: LogInkComponents['Text'],
+  commit: GitLogCommitRow,
+  graph: string,
+  graphWidth: number,
+  selected: boolean,
+  theme: LogInkTheme,
+  index: number
+): ReactTypes.ReactElement {
+  const renderedGraph = substituteGraphChars(graph.padEnd(graphWidth), { ascii: theme.ascii })
+  const refs = formatInkRefLabels(commit.refs)
+  const totalWidth = 140
+  const fixedWidth = graphWidth + 1 + commit.shortHash.length + 1 + commit.date.length + 1
+  const messageRoom = Math.max(8, totalWidth - fixedWidth - cellWidth(refs))
+  const message = truncate(commit.message, messageRoom)
+
+  const selectedBg = selected && !theme.noColor ? theme.colors.selection : undefined
+  const accent = theme.noColor ? undefined : theme.colors.accent
+  const muted = theme.noColor ? undefined : theme.colors.muted
+
+  return h(Text, {
+    key: `${commit.hash}-${index}`,
+    backgroundColor: selectedBg,
+    inverse: selected,
+  },
+  h(Text, { color: muted, dimColor: theme.noColor }, renderedGraph),
+  ' ',
+  h(Text, { color: accent, bold: selected }, commit.shortHash),
+  ' ',
+  h(Text, { dimColor: true }, commit.date),
+  ' ',
+  h(Text, undefined, message),
+  refs ? h(Text, { color: accent }, refs) : null)
 }
 
 /**


### PR DESCRIPTION
PR E from the v2 polish plan in #756. Scoped pass on the history list rendering — stops short of full topology parsing (that's a much larger lift) but addresses the "wall of slashes" readability complaint and gives the eye obvious anchor points.

## Summary

- **\`substituteGraphChars\`** — maps the ASCII graph chars from \`git log --graph\` to box-drawing / geometric Unicode equivalents (\`*\` → \`●\`, \`|\` → \`│\`, \`/\` → \`╱\`, \`\\\` → \`╲\`, \`_\` → \`─\`). Gated on \`theme.ascii\` so \`TERM=dumb\` / \`vt100\` stay on the safe ASCII output.
- **Each commit row renders as nested Text spans** inside the row container so each segment can be styled independently:
  - graph chars → \`theme.colors.muted\` (visually recede behind commit data)
  - shortHash → \`theme.colors.accent\` + bold when selected (eye lands on the identifier first)
  - date → dimmed
  - message → normal
  - ref labels → \`theme.colors.accent\`
- **Per-segment truncation** — the variable-length message field gets whatever budget remains after the fixed-width segments. Stops the message from blowing past the row width when refs are long.
- **Pure full-graph rows** (no commit on this line, just continuation \`| | |\` topology) now render entirely in \`theme.colors.muted\` so they read as connectors, not as fresh rows competing for attention.
- **\`NO_COLOR\` / monochrome theme** paths still work end-to-end — colors collapse to dim/normal and Unicode substitution stays on (it's orthogonal to color).

## What's NOT in this PR

Full GitKraken-style topology rendering — branch lineage coloring, custom box-drawing layouts, parent/merge tracking — needs a real parser for git's commit graph and is multiple PRs of work on its own. This PR keeps the existing topology output (\`git log --graph\`) and just paints it more legibly. Worth revisiting if the colorized version still feels insufficient after using it for a while.

## Tests

- \`inkGraphChars.test.ts\` — 7 tests covering ASCII passthrough, single-char substitution per topology glyph, multi-branch row rendering, mixed graph + text, and the \`isPureGraphRow\` heuristic.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 687/687 passing
- [x] \`npm run build\` clean
- [x] \`npm run test:cli\` — 10/10 packaged smoke checks
- [x] \`npm run release:dry-run\` clean
- [ ] Manual: \`coco ui\` on a multi-branch repo → graph chars dim, sha + refs colored, more readable than the flat ASCII version
- [ ] Manual: \`\\\` toggle full graph → continuation rows render in muted color
- [ ] Manual: \`NO_COLOR=1 coco ui\` → no theme colors, Unicode chars still render
- [ ] Manual: \`TERM=dumb coco ui\` → ASCII fallback active (no Unicode), no colors
- [ ] Manual: long commit messages → truncated cleanly with ellipsis, refs still visible

## Reference

- Tracks against polish issue [#756](https://github.com/gfargo/coco/issues/756) — addresses idea #4 from the original brainstorm
- Builds on PRs #758, #759, #760, #761, #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)