### PR TITLE
feat(log-tui): P1 discoverability + reliability cluster

### DIFF
--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -2,6 +2,7 @@ import {
   LOG_INK_KEY_BINDINGS,
   filterLogInkPaletteCommands,
   formatLogInkBreadcrumb,
+  getLogInkChordContinuations,
   getLogInkCommandPaletteItems,
   getLogInkFooterHints,
   getLogInkHelpSections,
@@ -271,6 +272,45 @@ describe('log Ink keymap', () => {
     })
     expect(palette.find((item) => item.id === 'workflowActions')).toMatchObject({
       label: 'workflows',
+    })
+  })
+
+  describe('chord continuations', () => {
+    it('returns the registered second-key continuations for the g chord prefix', () => {
+      const continuations = getLogInkChordContinuations('g')
+      const keys = continuations.map((entry) => entry.key)
+      expect(keys).toEqual(expect.arrayContaining(['h', 's', 'd', 'c', 'b', 't', 'z', 'g']))
+      // Sorted alphabetically for stable rendering.
+      expect(keys).toEqual([...keys].sort((a, b) => a.localeCompare(b)))
+    })
+
+    it('returns an empty list for unknown prefixes', () => {
+      expect(getLogInkChordContinuations('z')).toEqual([])
+    })
+  })
+
+  describe('footer chord hints', () => {
+    it('replaces the contextual slot with chord continuations when pendingKey is set', () => {
+      const hints = getLogInkFooterHints({
+        activeView: 'history',
+        filterMode: false,
+        focus: 'commits',
+        showHelp: false,
+        pendingKey: 'g',
+      })
+      expect(hints.contextual[0]).toBe('g …')
+      expect(hints.contextual.some((entry) => entry.startsWith('h '))).toBe(true)
+      expect(hints.global).toContain('esc cancel')
+    })
+
+    it('falls through to normal hints when pendingKey is unset', () => {
+      const hints = getLogInkFooterHints({
+        activeView: 'history',
+        filterMode: false,
+        focus: 'commits',
+        showHelp: false,
+      })
+      expect(hints.contextual[0]).not.toBe('g …')
     })
   })
 })

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -308,6 +308,40 @@ export type GetLogInkFooterHintsOptions = {
   focus: LogInkFocus
   showHelp: boolean
   showCommandPalette?: boolean
+  /** Set when the user has pressed a chord prefix (e.g. `g`) and the
+   * dispatcher is waiting for the second key. The footer surfaces the
+   * available continuations inline as a fallback for the popup overlay. */
+  pendingKey?: string
+}
+
+export type LogInkChordContinuation = {
+  /** Single character — the second key in the chord (e.g. `h` for `gh`). */
+  key: string
+  label: string
+  description: string
+}
+
+/**
+ * Surface the second-key continuations for a chord prefix (e.g. `g`)
+ * as a flat list, sourced from the canonical keymap so the help, footer
+ * hint, and which-key overlay all stay in sync. Continuations are sorted
+ * by key for stable, scannable output.
+ */
+export function getLogInkChordContinuations(prefix: string): LogInkChordContinuation[] {
+  const continuations: LogInkChordContinuation[] = []
+  for (const binding of LOG_INK_KEY_BINDINGS) {
+    for (const keys of binding.keys) {
+      if (keys.length === 2 && keys.startsWith(prefix)) {
+        continuations.push({
+          key: keys.charAt(1),
+          label: binding.label,
+          description: binding.description,
+        })
+        break
+      }
+    }
+  }
+  return continuations.sort((a, b) => a.key.localeCompare(b.key))
 }
 
 /**
@@ -374,6 +408,19 @@ export function formatLogInkBreadcrumb(viewStack: LogInkView[]): string {
 }
 
 export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogInkFooterHints {
+  if (options.pendingKey) {
+    const continuations = getLogInkChordContinuations(options.pendingKey)
+    if (continuations.length > 0) {
+      return {
+        contextual: [
+          `${options.pendingKey} …`,
+          ...continuations.map((entry) => `${entry.key} ${entry.label}`),
+        ],
+        global: ['esc cancel'],
+      }
+    }
+  }
+
   if (options.filterMode) {
     return {
       contextual: ['enter apply', 'esc cancel', 'ctrl+u clear'],

--- a/src/commands/log/inkOnboarding.test.ts
+++ b/src/commands/log/inkOnboarding.test.ts
@@ -1,0 +1,50 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import {
+  getOnboardingMarkerPath,
+  hasSeenOnboarding,
+  markOnboardingSeen,
+} from './inkOnboarding'
+
+describe('onboarding marker', () => {
+  let tempCacheDir: string
+  let originalXdgCacheHome: string | undefined
+
+  beforeEach(() => {
+    tempCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-onboarding-'))
+    originalXdgCacheHome = process.env.XDG_CACHE_HOME
+    process.env.XDG_CACHE_HOME = tempCacheDir
+  })
+
+  afterEach(() => {
+    if (originalXdgCacheHome === undefined) {
+      delete process.env.XDG_CACHE_HOME
+    } else {
+      process.env.XDG_CACHE_HOME = originalXdgCacheHome
+    }
+    fs.rmSync(tempCacheDir, { recursive: true, force: true })
+  })
+
+  it('reports unseen on a fresh cache', () => {
+    expect(hasSeenOnboarding()).toBe(false)
+  })
+
+  it('persists the marker after markOnboardingSeen', () => {
+    markOnboardingSeen()
+    expect(hasSeenOnboarding()).toBe(true)
+    expect(fs.existsSync(getOnboardingMarkerPath())).toBe(true)
+  })
+
+  it('creates the cache directory if it does not exist', () => {
+    const markerPath = getOnboardingMarkerPath()
+    expect(fs.existsSync(path.dirname(markerPath))).toBe(false)
+    markOnboardingSeen()
+    expect(fs.existsSync(path.dirname(markerPath))).toBe(true)
+  })
+
+  it('routes through XDG_CACHE_HOME when set', () => {
+    expect(getOnboardingMarkerPath().startsWith(tempCacheDir)).toBe(true)
+  })
+})

--- a/src/commands/log/inkOnboarding.ts
+++ b/src/commands/log/inkOnboarding.ts
@@ -1,0 +1,49 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+/**
+ * Track whether the user has seen the first-launch onboarding overlay
+ * (P1.3 from #756) via an XDG-friendly marker file. We persist this
+ * outside of `.coco.config.json` so a fresh repo doesn't re-show the
+ * tip when the user already dismissed it elsewhere.
+ *
+ * The marker is touched empty — its existence is the signal. Writes
+ * are best-effort: filesystem failures (read-only $HOME, permissions)
+ * fall back to "already seen" so we never block startup.
+ */
+
+const MARKER_BASENAME = 'onboarding.seen'
+
+function resolveCacheDir(): string {
+  const xdg = process.env.XDG_CACHE_HOME
+  if (xdg && xdg.trim().length > 0) {
+    return path.join(xdg, 'coco')
+  }
+  return path.join(os.homedir(), '.cache', 'coco')
+}
+
+export function getOnboardingMarkerPath(): string {
+  return path.join(resolveCacheDir(), MARKER_BASENAME)
+}
+
+export function hasSeenOnboarding(): boolean {
+  try {
+    return fs.existsSync(getOnboardingMarkerPath())
+  } catch {
+    // If we can't even stat the path (sandboxed env, etc.), treat the
+    // user as "seen" so we don't keep showing a panel they can never
+    // dismiss persistently.
+    return true
+  }
+}
+
+export function markOnboardingSeen(): void {
+  const markerPath = getOnboardingMarkerPath()
+  try {
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true })
+    fs.writeFileSync(markerPath, '')
+  } catch {
+    // Best-effort persistence; swallow.
+  }
+}

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -74,6 +74,7 @@ import {
 } from './inkKeymap'
 import { substituteGraphChars } from './inkGraphChars'
 import { LogInkInputKey, getLogInkInputEvents } from './inkInput'
+import { hasSeenOnboarding, markOnboardingSeen } from './inkOnboarding'
 import {
   LogInkRefreshWatcher,
   createRefreshWatcher,
@@ -577,6 +578,10 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       resumeRef.current = null
     }
   }, [resumeRef])
+  // First-launch onboarding (P1.3). Persisted via a marker file in the
+  // user's cache dir so the tip never reappears once dismissed. Lazy
+  // initializer so the fs check only runs on mount, not every render.
+  const [showOnboarding, setShowOnboarding] = React.useState<boolean>(() => !hasSeenOnboarding())
   const [state, setState] = React.useState<LogInkState>(() =>
     createLogInkState(rows, { activeView: initialView })
   )
@@ -1034,6 +1039,15 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   )
 
   useInput((inputValue: string, key: LogInkInputKey) => {
+    // First-launch onboarding (P1.3): any keystroke dismisses the overlay
+    // and writes the seen-marker. Swallow the keystroke so the same key
+    // doesn't also trigger normal input dispatch.
+    if (showOnboarding) {
+      setShowOnboarding(false)
+      markOnboardingSeen()
+      return
+    }
+
     getLogInkInputEvents(state, inputValue, key, {
       detailFileCount: detail?.files.length,
       previewLineCount: filePreview?.hunks.length,
@@ -1079,6 +1093,12 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     h(Text, undefined, `Terminal too small: ${layout.columns}x${layout.rows}`),
     h(Text, { dimColor: true }, `Minimum size is ${LOG_INK_MIN_COLUMNS}x${LOG_INK_MIN_ROWS}.`),
     h(Text, { dimColor: true }, 'Resize the terminal or run plain coco log.'))
+  }
+
+  // First-launch onboarding overlay (P1.3) replaces the entire UI for
+  // one render — any keystroke dismisses it and persists the seen-marker.
+  if (showOnboarding) {
+    return renderOnboardingOverlay(h, { Box, Text }, layout.rows, layout.columns, theme, appLabel)
   }
 
   return h(Box, { flexDirection: 'column', height: layout.rows },
@@ -2312,6 +2332,53 @@ function renderConfirmationPanel(
   h(Text, { dimColor: true }, truncate(warning, width - 4)),
   h(Text, undefined, ''),
   h(Text, undefined, 'Press y to confirm or n/Esc to cancel.'))
+}
+
+/**
+ * First-launch onboarding overlay (P1.3). Shown once per machine, gated
+ * by an XDG-style cache marker so subsequent launches go straight to the
+ * normal UI. Auto-dismisses on the next keystroke.
+ *
+ * Replaces the whole layout for the first render rather than overlaying
+ * a transient banner — Ink doesn't support floating elements, and a full
+ * takeover keeps the message readable on small terminals while still
+ * being instantly dismissible.
+ */
+function renderOnboardingOverlay(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  rows: number,
+  columns: number,
+  theme: LogInkTheme,
+  appLabel: string
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const accent = theme.noColor ? undefined : theme.colors.accent
+  const tips = [
+    { keys: '?', text: 'open the help panel' },
+    { keys: ':', text: 'open the command palette' },
+    { keys: 'g h', text: 'jump to history (g s status, g d diff, g c compose, g b branches, g t tags, g z stash)' },
+    { keys: '<  esc', text: 'pop the navigation stack / go back' },
+    { keys: '/', text: 'filter the active list' },
+    { keys: 'q  ctrl+c', text: 'quit' },
+  ]
+  const maxKeys = tips.reduce((max, tip) => Math.max(max, tip.keys.length), 0)
+  const lineWidth = Math.max(40, columns - 4)
+
+  return h(Box, {
+    flexDirection: 'column',
+    height: rows,
+    paddingX: 2,
+    paddingY: 1,
+  },
+  h(Text, { bold: true, color: accent }, `Welcome to ${appLabel}`),
+  h(Text, { dimColor: true }, 'A quick keyboard tour — press any key to dismiss.'),
+  h(Text, undefined, ''),
+  ...tips.map((tip, index) => h(Text, { key: `onboarding-tip-${index}` },
+    h(Text, { color: accent, bold: true }, `  ${tip.keys.padEnd(maxKeys)}  `),
+    h(Text, undefined, truncate(tip.text, lineWidth - maxKeys - 4)))),
+  h(Text, undefined, ''),
+  h(Text, { dimColor: true }, 'This tip is shown once per machine. Press any key to continue.'))
 }
 
 /**

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -527,7 +527,7 @@ export async function startInkInteractiveLog(
 
   // Forward declared so the lifecycle handler can call back into the React
   // tree on SIGCONT to force a repaint after the user `fg`s.
-  let resumeRef: { current: (() => void) | null } = { current: null }
+  const resumeRef: { current: (() => void) | null } = { current: null }
 
   const app = React.createElement(LogInkApp, {
     appLabel: options.appLabel || 'coco log',

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -67,6 +67,7 @@ import {
   formatBindingKeys,
   formatLogInkBreadcrumb,
   filterLogInkPaletteCommands,
+  getLogInkChordContinuations,
   getLogInkPaletteCommands,
   getLogInkFooterHints,
   getLogInkHelpSections,
@@ -1894,6 +1895,13 @@ function renderDetailPanel(
     return renderConfirmationPanel(h, components, state, width, theme, focused)
   }
 
+  // which-key style overlay — shows the available chord continuations
+  // when the user has pressed the prefix and we're waiting for the
+  // second key. Mirrors helix / which-key.nvim / doom-emacs.
+  if (state.pendingKey) {
+    return renderChordOverlay(h, components, state, width, theme, focused)
+  }
+
   // The synthetic "(+) new commit" row routes the inspector through the
   // worktree summary so the user sees what's staged / unstaged at a glance
   // — same surface as the compose view's right panel.
@@ -2306,6 +2314,62 @@ function renderConfirmationPanel(
   h(Text, undefined, 'Press y to confirm or n/Esc to cancel.'))
 }
 
+/**
+ * Which-key style chord overlay (P1.1). When the user presses a chord
+ * prefix (currently just `g`), the dispatcher sets `state.pendingKey`
+ * and waits for the second key. This panel surfaces the available
+ * continuations so newcomers don't have to memorize the chord set.
+ *
+ * Renders in the detail panel slot; auto-dismisses when the chord
+ * completes or `pendingKey` is otherwise cleared.
+ */
+function renderChordOverlay(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  width: number,
+  theme: LogInkTheme,
+  focused: boolean
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const prefix = state.pendingKey || ''
+  const continuations = getLogInkChordContinuations(prefix)
+  const accent = theme.noColor ? undefined : theme.colors.accent
+
+  const lines: ReactTypes.ReactNode[] = [
+    h(Text, { key: 'chord-title', bold: true }, panelTitle(`${prefix} … jump`, focused)),
+    h(Text, { key: 'chord-spacer' }, ''),
+  ]
+
+  if (continuations.length === 0) {
+    lines.push(h(Text, {
+      key: 'chord-empty',
+      dimColor: true,
+    }, truncate(`No bindings registered for the ${prefix} prefix.`, width - 4)))
+  } else {
+    for (const entry of continuations) {
+      lines.push(h(Text, { key: `chord-${entry.key}` },
+        h(Text, { color: accent, bold: true }, `  ${entry.key}  `),
+        h(Text, undefined, truncate(`${entry.label.padEnd(10)} ${entry.description}`, width - 9))
+      ))
+    }
+  }
+
+  lines.push(h(Text, { key: 'chord-foot-spacer' }, ''))
+  lines.push(h(Text, {
+    key: 'chord-hint',
+    dimColor: true,
+  }, truncate('press the second key to jump · esc cancels', width - 4)))
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    width,
+    paddingX: 1,
+  }, ...lines)
+}
+
 function renderHelpPanel(
   h: typeof ReactTypes.createElement,
   components: LogInkComponents,
@@ -2426,6 +2490,7 @@ function renderFooter(
     activeView: state.activeView,
     filterMode: state.filterMode,
     focus: state.focus,
+    pendingKey: state.pendingKey,
     showCommandPalette: state.showCommandPalette,
     showHelp: state.showHelp,
   })

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -77,6 +77,7 @@ import {
   LogInkRefreshWatcher,
   createRefreshWatcher,
 } from './inkRefreshWatcher'
+import { installTerminalLifecycle } from './inkTerminalLifecycle'
 import {
   LOG_INK_DEFAULT_COLUMNS,
   LOG_INK_DEFAULT_ROWS,
@@ -171,6 +172,7 @@ type LogInkRuntime = {
       }
     ) => {
       waitUntilExit: () => Promise<void>
+      unmount: () => void
     }
     useApp: () => {
       exit: () => void
@@ -193,6 +195,12 @@ type LogInkComponentDeps = LogInkRuntime & {
   logArgv?: LogArgv
   rows: GitLogRow[]
   theme: LogInkTheme
+  /**
+   * Mutable ref the runtime fills with a force-render callback. The
+   * terminal-lifecycle module invokes it on `SIGCONT` so users land on a
+   * painted screen after `fg` instead of an empty alt buffer.
+   */
+  resumeRef?: { current: (() => void) | null }
 }
 
 const truncate = truncateCells
@@ -514,6 +522,11 @@ export async function startInkInteractiveLog(
 
   const runtime = await loadInkRuntime()
   const { ink, React } = runtime
+
+  // Forward declared so the lifecycle handler can call back into the React
+  // tree on SIGCONT to force a repaint after the user `fg`s.
+  let resumeRef: { current: (() => void) | null } = { current: null }
+
   const app = React.createElement(LogInkApp, {
     appLabel: options.appLabel || 'coco log',
     git,
@@ -523,14 +536,26 @@ export async function startInkInteractiveLog(
     React,
     rows,
     theme: createLogInkTheme(options.theme),
+    resumeRef,
   })
   const instance = ink.render(app, getLogInkRenderOptions({ input, output, error }))
 
-  await instance.waitUntilExit()
+  const lifecycle = installTerminalLifecycle({
+    input,
+    output,
+    instance,
+    onResume: () => resumeRef.current?.(),
+  })
+
+  try {
+    await instance.waitUntilExit()
+  } finally {
+    lifecycle.dispose()
+  }
 }
 
 function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
-  const { appLabel, git, ink, initialView, logArgv, React, rows, theme } = deps
+  const { appLabel, git, ink, initialView, logArgv, React, resumeRef, rows, theme } = deps
   const { Box, Text, useApp, useInput, useWindowSize } = ink
   const h = React.createElement
   const { exit } = useApp()
@@ -539,6 +564,18 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     columns: windowSize.columns || process.stdout.columns || LOG_INK_DEFAULT_COLUMNS,
     rows: windowSize.rows || process.stdout.rows || LOG_INK_DEFAULT_ROWS,
   })
+  // Bumping this on SIGCONT forces the existing tree to repaint so users
+  // land on a drawn screen after `fg` instead of an empty alt buffer.
+  const [, setResumeTick] = React.useState(0)
+  React.useEffect(() => {
+    if (!resumeRef) {
+      return
+    }
+    resumeRef.current = () => setResumeTick((tick) => tick + 1)
+    return () => {
+      resumeRef.current = null
+    }
+  }, [resumeRef])
   const [state, setState] = React.useState<LogInkState>(() =>
     createLogInkState(rows, { activeView: initialView })
   )

--- a/src/commands/log/inkTerminalLifecycle.ts
+++ b/src/commands/log/inkTerminalLifecycle.ts
@@ -1,0 +1,130 @@
+/**
+ * Install panic + suspend handlers around an Ink instance so the terminal
+ * never gets left in alt-screen / raw-mode / hidden-cursor state when:
+ *
+ *   - an uncaught exception throws past Ink's render loop (P1.4)
+ *   - the user hits Ctrl+Z and the kernel raises SIGTSTP (P1.5)
+ *
+ * `dispose()` removes every registered listener so a clean exit doesn't
+ * leak global handlers on subsequent runs.
+ *
+ * The escape sequences here are the standard ANSI/xterm trio:
+ *   - `\x1b[?25h`  — show the cursor
+ *   - `\x1b[?25l`  — hide the cursor
+ *   - `\x1b[?1049l` — exit alt screen
+ *   - `\x1b[?1049h` — enter alt screen
+ */
+
+const SHOW_CURSOR = '\x1b[?25h'
+const HIDE_CURSOR = '\x1b[?25l'
+const ENTER_ALT_SCREEN = '\x1b[?1049h'
+const EXIT_ALT_SCREEN = '\x1b[?1049l'
+
+export type TerminalLifecycleOptions = {
+  output: NodeJS.WriteStream
+  input: NodeJS.ReadStream
+  instance: { unmount: () => void }
+  /**
+   * Called after the terminal is restored on `SIGCONT`. The runtime
+   * uses this to nudge React into re-rendering so the user comes back
+   * from `fg` to a painted screen instead of an empty alt buffer.
+   */
+  onResume?: () => void
+  /**
+   * Called when a panic is observed and the terminal has been restored,
+   * just before `process.exit(1)`. Lets the caller log the error
+   * however it sees fit (defaults to printing the stack to stderr).
+   */
+  onPanic?: (error: unknown) => void
+}
+
+export type TerminalLifecycle = {
+  dispose: () => void
+}
+
+const tryWrite = (output: NodeJS.WriteStream, sequence: string): void => {
+  try {
+    output.write(sequence)
+  } catch {
+    // stream may already be closed during shutdown; ignore
+  }
+}
+
+const trySetRawMode = (input: NodeJS.ReadStream, value: boolean): void => {
+  try {
+    input.setRawMode?.(value)
+  } catch {
+    // stdin may not be a TTY; ignore
+  }
+}
+
+const tryUnmount = (instance: { unmount: () => void }): void => {
+  try {
+    instance.unmount()
+  } catch {
+    // Ink may have already cleaned up; ignore
+  }
+}
+
+export function installTerminalLifecycle(
+  options: TerminalLifecycleOptions
+): TerminalLifecycle {
+  const { input, instance, output } = options
+
+  const restoreTerminal = (): void => {
+    // Belt-and-suspenders: tell Ink to unmount AND write the escape
+    // sequences directly. Ink's unmount handles most cases but we've
+    // seen it leave artifacts when a render is in flight at panic time.
+    tryUnmount(instance)
+    trySetRawMode(input, false)
+    tryWrite(output, `${SHOW_CURSOR}${EXIT_ALT_SCREEN}`)
+  }
+
+  const handlePanic = (error: unknown): void => {
+    restoreTerminal()
+    if (options.onPanic) {
+      options.onPanic(error)
+    } else if (error instanceof Error) {
+      process.stderr.write(`\n${error.stack || error.message}\n`)
+    } else {
+      process.stderr.write(`\n${String(error)}\n`)
+    }
+    // Exit with non-zero so callers (CI, scripts) see the failure.
+    process.exit(1)
+  }
+
+  const onUncaughtException = (error: Error): void => handlePanic(error)
+  const onUnhandledRejection = (reason: unknown): void => handlePanic(reason)
+
+  // Ctrl+Z: leave the alt screen + restore the cursor + drop raw mode
+  // BEFORE the kernel actually suspends us. We don't unmount Ink — the
+  // tree stays alive so SIGCONT can repaint without re-mounting.
+  const onSigtstp = (): void => {
+    trySetRawMode(input, false)
+    tryWrite(output, `${SHOW_CURSOR}${EXIT_ALT_SCREEN}`)
+    process.kill(process.pid, 'SIGSTOP')
+  }
+
+  // Resume: re-enter alt screen + hide cursor + raw mode back on, then
+  // ask the runtime to nudge React so the user lands on a painted screen
+  // instead of an empty alt buffer.
+  const onSigcont = (): void => {
+    tryWrite(output, `${ENTER_ALT_SCREEN}${HIDE_CURSOR}`)
+    trySetRawMode(input, true)
+    options.onResume?.()
+  }
+
+  process.on('uncaughtException', onUncaughtException)
+  process.on('unhandledRejection', onUnhandledRejection)
+  process.on('SIGTSTP', onSigtstp)
+  process.on('SIGCONT', onSigcont)
+
+  return {
+    dispose: (): void => {
+      process.off('uncaughtException', onUncaughtException)
+      process.off('unhandledRejection', onUnhandledRejection)
+      process.off('SIGTSTP', onSigtstp)
+      process.off('SIGCONT', onSigcont)
+    },
+  }
+}


### PR DESCRIPTION
P1 cluster from #756 — the highest-leverage UX + reliability items in one PR. Each step is its own commit so the diff stays auditable.

## Commits

1. **\`30a202b\` panic + suspend handlers** (P1.4 + P1.5)
2. **\`7b5cf06\` which-key chord overlay + footer fallback** (P1.1 + P1.2)
3. **\`8444867\` first-launch onboarding overlay** (P1.3) + chord/onboarding tests
4. **\`352ac1f\` lint nit** (prefer-const on \`resumeRef\`)

## Summary

### P1.4 + P1.5 — terminal lifecycle
\`installTerminalLifecycle\` registers \`uncaughtException\` + \`unhandledRejection\` handlers that unmount Ink, restore the cursor, exit alt screen, drop raw mode, then \`exit(1)\`. Belt-and-suspenders so partial cleanup still leaves a usable shell. \`SIGTSTP\` exits the alt screen + restores cursor BEFORE re-raising \`SIGSTOP\` so the kernel suspends with a clean terminal; \`SIGCONT\` re-enters alt screen + raw mode and bumps a React resume tick so users return from \`fg\` to a painted screen instead of an empty alt buffer. \`dispose()\` removes every listener on clean exit.

### P1.1 + P1.2 — which-key
- \`getLogInkChordContinuations(prefix)\` — keymap-derived list of valid second keys for a chord. One source of truth so help, footer hint, and overlay all stay in sync.
- \`renderChordOverlay\` routes through the detail panel slot when \`state.pendingKey\` is set. Shows \`<prefix> … jump\` header and a list of \`(key, label, description)\` rows with the continuation key in theme accent. Mirrors helix / which-key.nvim / doom-emacs.
- \`getLogInkFooterHints\` surfaces the same continuations inline when \`pendingKey\` is set, as a fallback that's visible regardless of which surface owns the right panel.

### P1.3 — first-launch onboarding
- \`inkOnboarding.ts\` persists the seen-marker as an XDG-friendly file (\`~/.cache/coco/onboarding.seen\`, honoring \`XDG_CACHE_HOME\`). Best-effort: filesystem failures fall through to "already seen" so we never block startup.
- \`LogInkApp\` tracks \`showOnboarding\` via a lazy initializer that runs the fs check exactly once on mount. Any keystroke flips the flag and writes the marker, then short-circuits the input dispatcher so the same key doesn't also trigger normal navigation.
- \`renderOnboardingOverlay\` takes over the whole layout for one render — Ink doesn't support floating elements, and a takeover keeps the tip legible on small terminals.

## Tests

- \`inkKeymap.test.ts\` — chord continuations sorted + complete (g h/s/d/c/b/t/z/g); \`getLogInkFooterHints\` swaps to chord menu when \`pendingKey\` is set, falls through otherwise.
- \`inkOnboarding.test.ts\` — marker round-trips through \`XDG_CACHE_HOME\`, creates the cache dir, fresh cache reports unseen.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 695/695 passing
- [x] \`npm run build\` clean
- [x] \`npm run test:cli\` — 10/10 packaged smoke checks
- [x] \`npm run release:dry-run\` clean
- [ ] Manual: throw mid-render → terminal restored, stack printed, exit 1
- [ ] Manual: \`Ctrl+Z\` → terminal restored, shell prompt usable. \`fg\` → TUI repaints
- [ ] Manual: press \`g\` → which-key overlay lists 8 continuations + footer shows them inline
- [ ] Manual: press \`g\` then \`h\` → overlay dismisses, navigates home
- [ ] Manual: \`Esc\` from a pending chord → overlay dismisses without navigating
- [ ] Manual: \`rm ~/.cache/coco/onboarding.seen && coco ui\` → onboarding overlay shows; any keystroke dismisses; relaunch goes straight to normal UI
- [ ] Manual: \`XDG_CACHE_HOME=/tmp/foo coco ui\` → marker persists at \`/tmp/foo/coco/onboarding.seen\`

## Reference

- Tracks polish issue [#756](https://github.com/gfargo/coco/issues/756) — P1 cluster
- Builds on PRs #758–#763

🤖 Generated with [Claude Code](https://claude.com/claude-code)