### PR TITLE
feat(log-tui): P2 UX consistency — mode badge, filter UX, quit guard

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -74,6 +74,78 @@ describe('log Ink input interactions', () => {
     expect(state.filterMode).toBe(false)
   })
 
+  it('clears the filter on first Esc and exits filter mode on the second', () => {
+    let state = createLogInkState(rows)
+    state = applyInput(state, '/')
+    state = applyInput(state, 'f')
+    state = applyInput(state, 'i')
+    expect(state.filter).toBe('fi')
+    expect(state.filterMode).toBe(true)
+
+    state = applyInput(state, '', { escape: true })
+    expect(state.filter).toBe('')
+    expect(state.filterMode).toBe(true)
+
+    state = applyInput(state, '', { escape: true })
+    expect(state.filterMode).toBe(false)
+  })
+
+  it('q on an unsaved compose draft prompts a discard confirmation instead of exiting', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, {
+      type: 'commitCompose',
+      action: { type: 'append', value: 'feat: in-flight summary' },
+    })
+
+    const events = applyInput(state, 'q')
+    expect(events.pendingMutationConfirmation).toBe('discard-draft')
+
+    // n cancels and keeps the draft
+    state = applyInput(events, 'n')
+    expect(state.pendingMutationConfirmation).toBeUndefined()
+    expect(state.commitCompose.summary).toBe('feat: in-flight summary')
+  })
+
+  it('q with no compose draft exits immediately', () => {
+    const events = getLogInkInputEvents(createLogInkState(rows), 'q')
+    expect(events).toEqual([{ type: 'exit' }])
+  })
+
+  it('confirms discard-draft via y and emits exit', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, {
+      type: 'commitCompose',
+      action: { type: 'append', value: 'feat: ready to ship' },
+    })
+    state = applyInput(state, 'q')
+    expect(state.pendingMutationConfirmation).toBe('discard-draft')
+
+    const events = getLogInkInputEvents(state, 'y')
+    expect(events.find((event) => event.type === 'exit')).toBeDefined()
+  })
+
+  it('snaps promoted-view selection to 0 when the filter changes', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'moveBranch', delta: 5, count: 10 })
+    expect(state.selectedBranchIndex).toBe(5)
+
+    state = applyLogInkAction(state, { type: 'setFilter', value: 'feature' })
+    expect(state.selectedBranchIndex).toBe(0)
+  })
+
+  it('clearFilterText clears the filter input but keeps filterMode active', () => {
+    let state = createLogInkState(rows)
+    state = applyInput(state, '/')
+    state = applyInput(state, 'f')
+    state = applyInput(state, 'o')
+    expect(state.filter).toBe('fo')
+    expect(state.filterMode).toBe(true)
+
+    state = applyLogInkAction(state, { type: 'clearFilterText' })
+    expect(state.filter).toBe('')
+    expect(state.filterMode).toBe(true)
+  })
+
   it('toggles help, command palette, focus, and graph interactions', () => {
     let state = createLogInkState(rows)
 

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -195,6 +195,9 @@ export function getLogInkPaletteExecuteEvents(
       // Aggregate entry; individual workflows are surfaced separately.
       return []
     case 'quit':
+      if (hasUnsavedComposeDraft(state)) {
+        return [action({ type: 'setPendingMutationConfirmation', value: 'discard-draft' })]
+      }
       return [{ type: 'exit' }]
     case 'clearSearch':
       return [action({ type: 'clearFilter' })]
@@ -211,6 +214,20 @@ const SIDEBAR_TAB_BY_NUMBER: Record<string, LogInkSidebarTab> = {
   '5': 'worktrees',
 }
 
+/**
+ * Returns true when the compose surface holds an unsaved commit message
+ * (any text in summary or body and no in-flight AI draft). Used by the
+ * quit confirmation flow (P2.3) so users can't lose drafts via a stray
+ * `q` / Ctrl+C.
+ */
+function hasUnsavedComposeDraft(state: LogInkState): boolean {
+  const compose = state.commitCompose
+  if (compose.loading) {
+    return false
+  }
+  return Boolean(compose.summary.trim() || compose.body.trim())
+}
+
 export function getLogInkInputEvents(
   state: LogInkState,
   inputValue: string,
@@ -218,6 +235,9 @@ export function getLogInkInputEvents(
   context: LogInkInputContext = {}
 ): LogInkInputEvent[] {
   if (key.ctrl && inputValue === 'c') {
+    if (hasUnsavedComposeDraft(state) && !state.pendingMutationConfirmation) {
+      return [action({ type: 'setPendingMutationConfirmation', value: 'discard-draft' })]
+    }
     return [{ type: 'exit' }]
   }
 
@@ -257,7 +277,18 @@ export function getLogInkInputEvents(
   }
 
   if (state.filterMode) {
-    if (key.return || key.escape) {
+    if (key.return) {
+      return [action({ type: 'toggleFilterMode' })]
+    }
+
+    // Two-stage Esc (P2.4 / P4.4): first Esc with a non-empty filter
+    // clears the input but keeps filterMode active so the user can keep
+    // typing; second Esc exits filterMode entirely. Matches vim and
+    // most modal TUIs.
+    if (key.escape) {
+      if (state.filter.length > 0) {
+        return [action({ type: 'clearFilterText' })]
+      }
       return [action({ type: 'toggleFilterMode' })]
     }
 
@@ -310,6 +341,12 @@ export function getLogInkInputEvents(
 
   if (state.pendingMutationConfirmation) {
     if (inputValue === 'y') {
+      if (state.pendingMutationConfirmation === 'discard-draft') {
+        return [
+          action({ type: 'setPendingMutationConfirmation', value: undefined }),
+          { type: 'exit' },
+        ]
+      }
       return [
         state.pendingMutationConfirmation === 'revert-hunk'
           ? { type: 'revertSelectedHunk' }
@@ -319,9 +356,12 @@ export function getLogInkInputEvents(
     }
 
     if (inputValue === 'n' || key.escape) {
+      const cancelMessage = state.pendingMutationConfirmation === 'discard-draft'
+        ? 'kept draft — press q again to quit without saving'
+        : 'revert cancelled'
       return [
         action({ type: 'setPendingMutationConfirmation', value: undefined }),
-        action({ type: 'setStatus', value: 'revert cancelled' }),
+        action({ type: 'setStatus', value: cancelMessage }),
       ]
     }
 
@@ -336,6 +376,11 @@ export function getLogInkInputEvents(
     )
 
     if (key.escape) {
+      // Two-stage Esc inside the palette: first Esc with non-empty
+      // input clears the filter; second Esc closes the palette. P2.4.
+      if (state.paletteFilter.length > 0) {
+        return [action({ type: 'clearPaletteFilter' })]
+      }
       return [action({ type: 'toggleCommandPalette' })]
     }
 
@@ -392,6 +437,9 @@ export function getLogInkInputEvents(
   }
 
   if (inputValue === 'q') {
+    if (hasUnsavedComposeDraft(state)) {
+      return [action({ type: 'setPendingMutationConfirmation', value: 'discard-draft' })]
+    }
     return [{ type: 'exit' }]
   }
 

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -178,13 +178,14 @@ describe('log Ink keymap', () => {
     expect(helpText).toContain('tab Move focus to the next panel.')
   })
 
-  it('formats the navigation breadcrumb based on the view stack', () => {
+  it('formats the navigation breadcrumb with a back-hint cue when nested', () => {
     expect(formatLogInkBreadcrumb([])).toBe('')
     expect(formatLogInkBreadcrumb(['history'])).toBe('')
-    expect(formatLogInkBreadcrumb(['status'])).toBe('status')
-    expect(formatLogInkBreadcrumb(['history', 'diff'])).toBe('history › diff')
-    expect(formatLogInkBreadcrumb(['history', 'status', 'diff'])).toBe('history › status › diff')
-    expect(formatLogInkBreadcrumb(['history', 'compose'])).toBe('history › compose')
+    expect(formatLogInkBreadcrumb(['status'])).toBe('status   ← <')
+    expect(formatLogInkBreadcrumb(['history', 'diff'])).toBe('history › diff   ← <')
+    expect(formatLogInkBreadcrumb(['history', 'status', 'diff']))
+      .toBe('history › status › diff   ← <')
+    expect(formatLogInkBreadcrumb(['history', 'compose'])).toBe('history › compose   ← <')
   })
 
   it('exposes the gc compose chord as a global navigation binding', () => {

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -404,7 +404,9 @@ export function formatLogInkBreadcrumb(viewStack: LogInkView[]): string {
     return ''
   }
 
-  return viewStack.join(' › ')
+  // Trailing back-hint (P2.5) reminds the user how to walk back when
+  // they're nested deeper than the root view.
+  return `${viewStack.join(' › ')}   ← <`
 }
 
 export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogInkFooterHints {

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -1048,6 +1048,26 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       return
     }
 
+    // P4.5: navigation in branches/tags/stash uses the FILTERED list
+    // length when a filter is active so j/k stay live instead of getting
+    // stuck against a full-list count that no longer matches what's on
+    // screen.
+    const branchVisibleCount = state.filter
+      ? (context.branches?.localBranches || [])
+        .filter((branch) => matchesPromotedFilter([branch.shortName, branch.upstream || ''], state.filter))
+        .length
+      : context.branches?.localBranches.length
+    const tagVisibleCount = state.filter
+      ? (context.tags?.tags || [])
+        .filter((tag) => matchesPromotedFilter([tag.name, tag.subject], state.filter))
+        .length
+      : context.tags?.tags.length
+    const stashVisibleCount = state.filter
+      ? (context.stashes?.stashes || [])
+        .filter((stash) => matchesPromotedFilter([stash.ref, stash.message], state.filter))
+        .length
+      : context.stashes?.stashes.length
+
     getLogInkInputEvents(state, inputValue, key, {
       detailFileCount: detail?.files.length,
       previewLineCount: filePreview?.hunks.length,
@@ -1055,9 +1075,9 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       worktreeFileCount: context.worktree?.files.length,
       worktreeHunkOffsets: worktreeDiff?.hunkOffsets,
       commitDiffHunkOffsets,
-      branchCount: context.branches?.localBranches.length,
-      tagCount: context.tags?.tags.length,
-      stashCount: context.stashes?.stashes.length,
+      branchCount: branchVisibleCount,
+      tagCount: tagVisibleCount,
+      stashCount: stashVisibleCount,
       worktreeDirty,
     }).forEach((event) => {
       if (event.type === 'exit') {
@@ -1167,7 +1187,19 @@ function renderHeader(
   const loading = isLogInkContextLoading(contextStatus) ? '  loading context' : ''
   const breadcrumb = formatLogInkBreadcrumb(state.viewStack)
   const view = breadcrumb ? `  ${breadcrumb}` : ''
-  const title = truncate(`${appLabel}  ${repo}  ${branch}  ${dirty}  ${pr}${view}${loading}`, columns - 2)
+  // Mode indicator (P2.2) — surfaces the current input mode so users
+  // never wonder why `q` doesn't quit while they're editing or filtering.
+  const mode = state.commitCompose.editing
+    ? '[EDIT]'
+    : state.filterMode
+      ? '[FILTER]'
+      : '[NORMAL]'
+  const title = truncate(`${appLabel}  ${repo}  ${branch}  ${dirty}  ${pr}${view}${loading}`, columns - mode.length - 4)
+  const modeColor = theme.noColor
+    ? undefined
+    : state.filterMode || state.commitCompose.editing
+      ? theme.colors.warning
+      : theme.colors.accent
 
   return h(Box, {
     borderColor: theme.colors.border,
@@ -1176,6 +1208,7 @@ function renderHeader(
     paddingX: 1,
   },
   h(Text, { bold: true, color: theme.colors.accent }, title),
+  h(Text, { bold: true, color: modeColor }, `  ${mode}`),
   search ? h(Text, { dimColor: true }, `  ${truncate(search, 36)}`) : undefined)
 }
 
@@ -1642,6 +1675,7 @@ function renderBranchesSurface(
     h(Text, { bold: true }, panelTitle('Branches', focused)),
     h(Text, { dimColor: true }, headerRight)
   ),
+  ...renderPromotedFilterAffordance(h, Text, state, theme),
   ...lines)
 }
 
@@ -1697,6 +1731,7 @@ function renderTagsSurface(
     h(Text, { bold: true }, panelTitle('Tags', focused)),
     h(Text, { dimColor: true }, headerRight)
   ),
+  ...renderPromotedFilterAffordance(h, Text, state, theme),
   ...lines)
 }
 
@@ -1754,7 +1789,32 @@ function renderStashSurface(
     h(Text, { bold: true }, panelTitle('Stash', focused)),
     h(Text, { dimColor: true }, headerRight)
   ),
+  ...renderPromotedFilterAffordance(h, Text, state, theme),
   ...lines)
+}
+
+/**
+ * Filter input cursor for the promoted views (branches/tags/stash).
+ * History already shows the same `filter: foo_` affordance in its header
+ * — this mirrors that into the other surfaces so the user can see what
+ * they're typing instead of watching the list silently shrink (P2.1).
+ *
+ * Returns an empty array when the surface isn't in filter mode so call
+ * sites can spread it unconditionally.
+ */
+function renderPromotedFilterAffordance(
+  h: typeof ReactTypes.createElement,
+  Text: LogInkComponents['Text'],
+  state: LogInkState,
+  theme: LogInkTheme
+): ReactTypes.ReactElement[] {
+  if (!state.filterMode) {
+    return []
+  }
+  const accent = theme.noColor ? undefined : theme.colors.accent
+  return [
+    h(Text, { key: 'promoted-filter-input', color: accent }, `filter: ${state.filter}_`),
+  ]
 }
 
 function renderDiffSurface(
@@ -2312,9 +2372,13 @@ function renderConfirmationPanel(
     ? 'Revert selected hunk'
     : state.pendingMutationConfirmation === 'revert-file'
       ? 'Revert selected file'
-      : undefined
+      : state.pendingMutationConfirmation === 'discard-draft'
+        ? 'Quit and discard the in-progress commit draft'
+        : undefined
   const label = action?.label || mutationLabel || 'Workflow action'
-  const warning = state.pendingMutationConfirmation
+  const warning = state.pendingMutationConfirmation === 'discard-draft'
+    ? 'You have an unsaved commit draft. Press y to discard it and quit.'
+    : state.pendingMutationConfirmation
     ? 'This discards local changes and cannot be undone by Coco.'
     : action?.kind === 'ai'
     ? `AI action requires confirmation. Estimated ${action.estimatedTokens || '<unknown>'} tokens.`

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -10,7 +10,7 @@ export type LogInkFocus = 'sidebar' | 'commits' | 'detail'
 
 export type LogInkSidebarTab = 'status' | 'branches' | 'tags' | 'stashes' | 'worktrees'
 export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash'
-export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk'
+export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk' | 'discard-draft'
 /**
  * Tracks which kind of diff the user pushed into. `commit` means they
  * came from history → Enter on a commit (read-only commit-diff explore
@@ -101,6 +101,7 @@ export type LogInkAction =
   | { type: 'appendFilter'; value: string }
   | { type: 'backspaceFilter' }
   | { type: 'clearFilter' }
+  | { type: 'clearFilterText' }
   | { type: 'commitCompose'; action: CommitComposeAction }
   | { type: 'focusNext' }
   | { type: 'focusPrevious' }
@@ -323,6 +324,12 @@ function withReplacedView(state: LogInkState, value: LogInkView): LogInkState {
 
 function withFilter(state: LogInkState, filter: string): LogInkState {
   const filteredCommits = filterCommits(state.commits, filter)
+  // P4.5: snap promoted-view selections to the top of the filtered list
+  // when the filter changes. Pre-filter cursor positions reference indexes
+  // that may not exist in the filtered view, so resetting to 0 keeps
+  // navigation predictable. The runtime passes filtered counts into
+  // `moveBranch` / `moveTag` / `moveStash` so j/k stay live.
+  const filterChanged = state.filter !== filter
 
   return {
     ...state,
@@ -330,6 +337,9 @@ function withFilter(state: LogInkState, filter: string): LogInkState {
     filteredCommits,
     selectedIndex: clampIndex(state.selectedIndex, filteredCommits.length),
     selectedFileIndex: 0,
+    selectedBranchIndex: filterChanged ? 0 : state.selectedBranchIndex,
+    selectedTagIndex: filterChanged ? 0 : state.selectedTagIndex,
+    selectedStashIndex: filterChanged ? 0 : state.selectedStashIndex,
     diffPreviewOffset: 0,
     pendingKey: undefined,
   }
@@ -451,6 +461,10 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         ...state,
         filterMode: false,
       }, '')
+    case 'clearFilterText':
+      // Clears the filter input but stays in filterMode so the user can
+      // keep typing. P2.4 / P4.4: pairs with the two-stage Esc semantics.
+      return withFilter(state, '')
     case 'commitCompose':
       return {
         ...state,


### PR DESCRIPTION
P2 cluster from #756. Six items batched into one PR per your preference; tests + ship gates green.

## What's in here

| Step | What |
|---|---|
| **P2.5** | Back-hint cue \`← <\` trails the breadcrumb when the view stack is nested (no-op at the history root). |
| **P2.2** | \`[NORMAL]\` / \`[EDIT]\` / \`[FILTER]\` mode badge in the header, warning-color when not normal. Eliminates "why isn't q quitting?" surprises. |
| **P2.1** | Promoted views (branches / tags / stash) render the same \`filter: foo_\` input cursor that history has, so the user sees what they're typing. |
| **P2.4 / P4.4** | Two-stage \`Esc\` in filter + command palette: first clears the input, second exits the mode. New \`clearFilterText\` reducer keeps \`clearFilter\` (which exits) intact for \`Ctrl+U\` / palette clear. |
| **P4.5** | Selection snap-to-0 on filter change for branches / tags / stash; runtime feeds filtered counts into \`moveBranch\` / \`moveTag\` / \`moveStash\` so \`j\`/\`k\` stay live against the visible list. |
| **P2.3** | \`q\` / \`Ctrl+C\` / palette \`quit\` on a non-empty compose draft prompts \`Quit and discard the in-progress commit draft\` via the existing \`pendingMutationConfirmation\` flow with a new \`'discard-draft'\` kind. \`y\` exits, \`n\` / \`Esc\` keeps the draft. \`compose.loading\` suppresses the prompt so AI-in-flight quits don't show a spurious confirmation. |

## Tests

- Two-stage Esc clears then exits filter mode
- \`q\` on unsaved draft prompts confirmation; \`y\` exits, \`n\` cancels and preserves draft
- \`q\` on clean compose state exits immediately (regression check)
- Selection snaps to 0 when the filter changes
- \`clearFilterText\` clears input but keeps filterMode active
- Breadcrumb back-hint formatting

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 701/701 passing
- [x] \`npm run build\` clean
- [x] \`npm run test:cli\` — 10/10 packaged smoke checks
- [x] \`npm run release:dry-run\` clean
- [ ] Manual: any nested view → header shows \`history › status   ← <\`
- [ ] Manual: \`/\` filter → header shows \`[FILTER]\` in warning color
- [ ] Manual: edit compose body → header shows \`[EDIT]\`
- [ ] Manual: \`gb\` then \`/\` then type → \`filter: …_\` cursor visible at top of branches list
- [ ] Manual: \`/\`, type, Esc → input clears, still in filter mode; second Esc exits
- [ ] Manual: type into compose, press \`q\` → confirmation prompt; \`n\` keeps draft, \`y\` exits
- [ ] Manual: clean compose state, press \`q\` → exits without prompt
- [ ] Manual: \`gb\` with many branches, \`/\` filter narrows to 2, press \`j\` → cursor moves between filtered entries

## Status against #756

After this lands, ~16/~25 line items shipped. Remaining: P3 iconography cluster, P4 patterns (preview pane, sort toggles, idle tips), P5 (OSC 8, truecolor), and the perf/correctness audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)