### PR TITLE
feat(log-tui): P3 iconography — divergence arrows, PR state glyph, stage dots, tab counts

### DIFF
--- a/src/commands/log/inkIconography.test.ts
+++ b/src/commands/log/inkIconography.test.ts
@@ -1,0 +1,162 @@
+import {
+  STAGE_STATUS_DOT,
+  branchRowMarker,
+  formatBranchDivergence,
+  getPullRequestStateGlyph,
+  getStageStatusDotColor,
+  sidebarTabCount,
+} from './inkIconography'
+import { createLogInkTheme } from './inkTheme'
+
+const colorTheme = createLogInkTheme({ preset: 'default', noColor: false })
+const monoTheme = createLogInkTheme({ preset: 'monochrome' })
+const asciiTheme = createLogInkTheme({ preset: 'default', ascii: true, noColor: false })
+
+describe('log Ink iconography', () => {
+  describe('formatBranchDivergence (P3.1)', () => {
+    it('reports no upstream for tracking-less branches', () => {
+      expect(formatBranchDivergence({ ahead: 0, behind: 0 })).toBe('no upstream')
+    })
+
+    it('reports parity when ahead and behind are zero', () => {
+      expect(formatBranchDivergence({ upstream: 'origin/main', ahead: 0, behind: 0 }))
+        .toBe('even with origin/main')
+    })
+
+    it('uses ↑↓ arrows for divergent branches', () => {
+      expect(formatBranchDivergence({ upstream: 'origin/main', ahead: 3, behind: 1 }))
+        .toBe('↑3 ↓1 origin/main')
+    })
+
+    it('omits the zero direction when divergence is one-sided', () => {
+      expect(formatBranchDivergence({ upstream: 'origin/main', ahead: 5, behind: 0 }))
+        .toBe('↑5 origin/main')
+      expect(formatBranchDivergence({ upstream: 'origin/main', ahead: 0, behind: 2 }))
+        .toBe('↓2 origin/main')
+    })
+
+    it('falls back to legacy +N/-N format under ASCII', () => {
+      expect(formatBranchDivergence(
+        { upstream: 'origin/main', ahead: 3, behind: 1 },
+        { ascii: true }
+      )).toBe('+3/-1 origin/main')
+    })
+  })
+
+  describe('branchRowMarker (P3.1)', () => {
+    it('marks the current branch with *', () => {
+      expect(branchRowMarker({ current: true, upstream: 'origin/main' })).toBe('*')
+      expect(branchRowMarker({ current: true })).toBe('*')
+    })
+
+    it('uses ◌ for non-current branches without upstream', () => {
+      expect(branchRowMarker({ current: false })).toBe('◌')
+    })
+
+    it('uses ? as ASCII fallback for non-current branches without upstream', () => {
+      expect(branchRowMarker({ current: false }, { ascii: true })).toBe('?')
+    })
+
+    it('renders a space for non-current branches with upstream', () => {
+      expect(branchRowMarker({ current: false, upstream: 'origin/feat' })).toBe(' ')
+    })
+  })
+
+  describe('getPullRequestStateGlyph (P3.2)', () => {
+    it('maps OPEN to a green ◉', () => {
+      const { glyph, color, dim } = getPullRequestStateGlyph(
+        { state: 'OPEN', isDraft: false },
+        colorTheme
+      )
+      expect(glyph).toBe('◉')
+      expect(color).toBe('green')
+      expect(dim).toBe(false)
+    })
+
+    it('maps MERGED to a magenta ●', () => {
+      const { glyph, color } = getPullRequestStateGlyph(
+        { state: 'MERGED', isDraft: false },
+        colorTheme
+      )
+      expect(glyph).toBe('●')
+      expect(color).toBe('magenta')
+    })
+
+    it('maps CLOSED to a red ×', () => {
+      const { glyph, color } = getPullRequestStateGlyph(
+        { state: 'CLOSED', isDraft: false },
+        colorTheme
+      )
+      expect(glyph).toBe('×')
+      expect(color).toBe('red')
+    })
+
+    it('uses dim ◇ for drafts regardless of state', () => {
+      const { glyph, color, dim } = getPullRequestStateGlyph(
+        { state: 'OPEN', isDraft: true },
+        colorTheme
+      )
+      expect(glyph).toBe('◇')
+      expect(color).toBeUndefined()
+      expect(dim).toBe(true)
+    })
+
+    it('drops color but keeps the glyph under monochrome', () => {
+      expect(getPullRequestStateGlyph({ state: 'OPEN', isDraft: false }, monoTheme).color).toBeUndefined()
+      expect(getPullRequestStateGlyph({ state: 'MERGED', isDraft: false }, monoTheme).color).toBeUndefined()
+    })
+
+    it('drops the glyph entirely under ASCII', () => {
+      expect(getPullRequestStateGlyph({ state: 'OPEN', isDraft: false }, asciiTheme).glyph).toBe('')
+      expect(getPullRequestStateGlyph({ state: 'MERGED', isDraft: false }, asciiTheme).glyph).toBe('')
+    })
+  })
+
+  describe('getStageStatusDotColor (P3.3)', () => {
+    it('maps unstaged → danger, staged → warning, untracked → muted', () => {
+      expect(getStageStatusDotColor('unstaged', colorTheme)).toBe('red')
+      expect(getStageStatusDotColor('staged', colorTheme)).toBe('yellow')
+      expect(getStageStatusDotColor('untracked', colorTheme)).toBe('gray')
+    })
+
+    it('returns undefined under monochrome (drop the dot — it would carry no info)', () => {
+      expect(getStageStatusDotColor('unstaged', monoTheme)).toBeUndefined()
+      expect(getStageStatusDotColor('staged', monoTheme)).toBeUndefined()
+      expect(getStageStatusDotColor('untracked', monoTheme)).toBeUndefined()
+    })
+
+    it('returns undefined under ASCII (raw codes carry meaning alone)', () => {
+      expect(getStageStatusDotColor('unstaged', asciiTheme)).toBeUndefined()
+    })
+
+    it('exposes ● as the canonical dot character', () => {
+      expect(STAGE_STATUS_DOT).toBe('●')
+    })
+  })
+
+  describe('sidebarTabCount (P3.4)', () => {
+    const ctx = {
+      worktree: { files: [{}, {}, {}] },
+      branches: { localBranches: [{}, {}] },
+      tags: { tags: [{}] },
+      stashes: { stashes: [{}, {}, {}, {}] },
+      worktreeList: { worktrees: [{}] },
+    }
+
+    it('reads counts from each overview slot', () => {
+      expect(sidebarTabCount('status', ctx)).toBe(3)
+      expect(sidebarTabCount('branches', ctx)).toBe(2)
+      expect(sidebarTabCount('tags', ctx)).toBe(1)
+      expect(sidebarTabCount('stashes', ctx)).toBe(4)
+      expect(sidebarTabCount('worktrees', ctx)).toBe(1)
+    })
+
+    it('returns undefined when the overview is missing (data still loading)', () => {
+      expect(sidebarTabCount('status', {})).toBeUndefined()
+      expect(sidebarTabCount('branches', {})).toBeUndefined()
+      expect(sidebarTabCount('tags', {})).toBeUndefined()
+      expect(sidebarTabCount('stashes', {})).toBeUndefined()
+      expect(sidebarTabCount('worktrees', {})).toBeUndefined()
+    })
+  })
+})

--- a/src/commands/log/inkIconography.ts
+++ b/src/commands/log/inkIconography.ts
@@ -1,0 +1,174 @@
+/**
+ * Iconography helpers for the Ink TUI surfaces.
+ *
+ * Letters always carry the meaning; symbols enhance. Glyphs come from the
+ * Geometric Shapes / Arrows blocks (high-compat Unicode, no emoji), and all
+ * helpers degrade cleanly under `theme.ascii` and `theme.noColor`.
+ */
+
+import { LogInkTheme } from './inkTheme'
+import { LogInkSidebarTab } from './inkViewModel'
+
+/* ----------------------------- P3.1 — branch ----------------------------- */
+
+export type BranchDivergenceInput = {
+  upstream?: string
+  ahead: number
+  behind: number
+}
+
+/**
+ * Format a branch's relationship to its upstream.
+ * - no upstream  → "no upstream"
+ * - even         → "even with <upstream>"
+ * - divergent    → "↑<ahead> ↓<behind> <upstream>" (only the non-zero side
+ *   is rendered so the line stays tight). ASCII mode falls back to the
+ *   legacy `+N/-N` form.
+ */
+export function formatBranchDivergence(
+  branch: BranchDivergenceInput,
+  options: { ascii?: boolean } = {}
+): string {
+  if (!branch.upstream) {
+    return 'no upstream'
+  }
+
+  if (branch.ahead === 0 && branch.behind === 0) {
+    return `even with ${branch.upstream}`
+  }
+
+  if (options.ascii) {
+    return `+${branch.ahead}/-${branch.behind} ${branch.upstream}`
+  }
+
+  const parts: string[] = []
+  if (branch.ahead > 0) parts.push(`↑${branch.ahead}`)
+  if (branch.behind > 0) parts.push(`↓${branch.behind}`)
+
+  return `${parts.join(' ')} ${branch.upstream}`
+}
+
+export type BranchRowMarkerInput = {
+  current: boolean
+  upstream?: string
+}
+
+/**
+ * Single-cell marker shown to the left of a branch name in lists.
+ * `*` = current, `◌` = no upstream (detached from a remote), space otherwise.
+ */
+export function branchRowMarker(
+  branch: BranchRowMarkerInput,
+  options: { ascii?: boolean } = {}
+): string {
+  if (branch.current) return '*'
+  if (!branch.upstream) return options.ascii ? '?' : '◌'
+  return ' '
+}
+
+/* ------------------------------ P3.2 — PR ------------------------------- */
+
+export type PullRequestStateInput = {
+  state: string
+  isDraft: boolean
+}
+
+export type PullRequestStateGlyph = {
+  glyph: string
+  color: string | undefined
+  dim: boolean
+}
+
+/**
+ * Pick the glyph + color for a PR state badge.
+ * Returns an empty glyph under ASCII mode so the textual state (OPEN /
+ * MERGED / DRAFT / CLOSED) carries the meaning alone.
+ */
+export function getPullRequestStateGlyph(
+  pr: PullRequestStateInput,
+  theme: LogInkTheme
+): PullRequestStateGlyph {
+  if (theme.ascii) {
+    return { glyph: '', color: undefined, dim: false }
+  }
+
+  if (pr.isDraft) {
+    return { glyph: '◇', color: undefined, dim: true }
+  }
+
+  switch (pr.state.toUpperCase()) {
+    case 'OPEN':
+      return { glyph: '◉', color: theme.colors.success, dim: false }
+    case 'MERGED':
+      return { glyph: '●', color: theme.noColor ? undefined : 'magenta', dim: false }
+    case 'CLOSED':
+      return { glyph: '×', color: theme.colors.danger, dim: false }
+    default:
+      return { glyph: '·', color: undefined, dim: true }
+  }
+}
+
+/* --------------------------- P3.3 — stage dot --------------------------- */
+
+export type StageStatusState = 'staged' | 'unstaged' | 'untracked'
+
+/**
+ * Color for the leading dot in a status row. `undefined` means "skip the
+ * dot" — under noColor or ascii mode the dot carries no information so the
+ * raw porcelain codes (M / ?? / etc.) and the textual state carry meaning
+ * alone.
+ */
+export function getStageStatusDotColor(
+  state: StageStatusState,
+  theme: LogInkTheme
+): string | undefined {
+  if (theme.noColor || theme.ascii) return undefined
+
+  switch (state) {
+    case 'unstaged':
+      return theme.colors.danger
+    case 'staged':
+      return theme.colors.warning
+    case 'untracked':
+      return theme.colors.muted
+    default:
+      return undefined
+  }
+}
+
+export const STAGE_STATUS_DOT = '●'
+
+/* ------------------------- P3.4 — sidebar counts ------------------------ */
+
+export type SidebarTabCountContext = {
+  worktree?: { files: unknown[] }
+  branches?: { localBranches: unknown[] }
+  tags?: { tags: unknown[] }
+  stashes?: { stashes: unknown[] }
+  worktreeList?: { worktrees: unknown[] }
+}
+
+/**
+ * Count to show next to a sidebar tab name, or `undefined` when the
+ * underlying data has not loaded yet (so the label renders without a `(N)`
+ * rather than a misleading `(0)`).
+ */
+export function sidebarTabCount(
+  tab: LogInkSidebarTab,
+  context: SidebarTabCountContext
+): number | undefined {
+  switch (tab) {
+    case 'status':
+      return context.worktree?.files.length
+    case 'branches':
+      return context.branches?.localBranches.length
+    case 'tags':
+      return context.tags?.tags.length
+    case 'stashes':
+      return context.stashes?.stashes.length
+    case 'worktrees':
+      return context.worktreeList?.worktrees.length
+    default:
+      return undefined
+  }
+}

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -89,6 +89,14 @@ import {
 } from './inkLayout'
 import { createLogInkTheme, LogInkTheme, LogInkThemeConfig } from './inkTheme'
 import {
+  STAGE_STATUS_DOT,
+  branchRowMarker,
+  formatBranchDivergence,
+  getPullRequestStateGlyph,
+  getStageStatusDotColor,
+  sidebarTabCount,
+} from './inkIconography'
+import {
   formatLogInkBranchesEmpty,
   formatLogInkComposeEmpty,
   formatLogInkHistoryEmpty,
@@ -401,23 +409,12 @@ function sidebarTabLabel(tab: LogInkSidebarTab): string {
   }
 }
 
-function formatDivergence(branch: BranchOverview['localBranches'][number]): string {
-  if (!branch.upstream) {
-    return 'no upstream'
-  }
-
-  if (branch.ahead === 0 && branch.behind === 0) {
-    return `even with ${branch.upstream}`
-  }
-
-  return `+${branch.ahead}/-${branch.behind} ${branch.upstream}`
-}
-
 function sidebarLines(
   context: LogInkContext,
   contextStatus: LogInkContextStatus,
   tab: LogInkSidebarTab,
-  width: number
+  width: number,
+  theme: LogInkTheme
 ): string[] {
   if (tab === 'status') {
     const worktree = context.worktree
@@ -457,10 +454,10 @@ function sidebarLines(
       branches.dirty ? 'Worktree: dirty' : 'Worktree: clean',
       '',
       ...branches.localBranches.slice(0, 8).map((branch) =>
-        `${branch.current ? '*' : ' '} ${truncate(branch.shortName, width - 4)}`
+        `${branchRowMarker(branch, { ascii: theme.ascii })} ${truncate(branch.shortName, width - 4)}`
       ),
       ...branches.localBranches.slice(0, 4).map((branch) =>
-        `  ${truncate(formatDivergence(branch), width - 2)}`
+        `  ${truncate(formatBranchDivergence(branch, { ascii: theme.ascii }), width - 2)}`
       ),
     ]
   }
@@ -1178,11 +1175,11 @@ function renderHeader(
   const repo = context.provider?.repository.owner && context.provider.repository.name
     ? `${context.provider.repository.owner}/${context.provider.repository.name}`
     : 'local repository'
-  const pr = context.provider?.currentPullRequest
-    ? `PR #${context.provider.currentPullRequest.number} ${context.provider.currentPullRequest.state}`
-    : context.pullRequest?.currentPullRequest
-      ? `PR #${context.pullRequest.currentPullRequest.number} ${context.pullRequest.currentPullRequest.state}`
-      : 'no PR'
+  const prInfo = context.provider?.currentPullRequest || context.pullRequest?.currentPullRequest
+  const prGlyph = prInfo ? getPullRequestStateGlyph(prInfo, theme) : null
+  const prLabel = prInfo
+    ? `PR #${prInfo.number} ${prInfo.isDraft ? 'DRAFT' : prInfo.state}`
+    : 'no PR'
   const search = state.filterMode ? `search: ${state.filter}_` : state.filter ? `filter: ${state.filter}` : ''
   const loading = isLogInkContextLoading(contextStatus) ? '  loading context' : ''
   const breadcrumb = formatLogInkBreadcrumb(state.viewStack)
@@ -1194,7 +1191,16 @@ function renderHeader(
     : state.filterMode
       ? '[FILTER]'
       : '[NORMAL]'
-  const title = truncate(`${appLabel}  ${repo}  ${branch}  ${dirty}  ${pr}${view}${loading}`, columns - mode.length - 4)
+  const titlePrefix = `${appLabel}  ${repo}  ${branch}  ${dirty}  `
+  const glyphPart = prGlyph?.glyph ? `${prGlyph.glyph} ` : ''
+  const titleSuffix = `${view}${loading}`
+  const fullTitle = `${titlePrefix}${glyphPart}${prLabel}${titleSuffix}`
+  const titleBudget = columns - mode.length - 4
+  const truncatedTitle = truncate(fullTitle, titleBudget)
+  // Only split into colored fragments when the prefix + glyph + label all
+  // fit unmodified — otherwise the truncate ellipsis can land mid-fragment
+  // and we'd render half a glyph in the wrong color.
+  const splitFragments = truncatedTitle === fullTitle && glyphPart.length > 0
   const modeColor = theme.noColor
     ? undefined
     : state.filterMode || state.commitCompose.editing
@@ -1207,7 +1213,15 @@ function renderHeader(
     height: 3,
     paddingX: 1,
   },
-  h(Text, { bold: true, color: theme.colors.accent }, title),
+  splitFragments
+    ? h(Text, { bold: true, color: theme.colors.accent }, titlePrefix)
+    : h(Text, { bold: true, color: theme.colors.accent }, truncatedTitle),
+  splitFragments
+    ? h(Text, { bold: true, color: prGlyph?.color, dimColor: prGlyph?.dim }, glyphPart)
+    : undefined,
+  splitFragments
+    ? h(Text, { bold: true, color: theme.colors.accent }, `${prLabel}${titleSuffix}`)
+    : undefined,
   h(Text, { bold: true, color: modeColor }, `  ${mode}`),
   search ? h(Text, { dimColor: true }, `  ${truncate(search, 36)}`) : undefined)
 }
@@ -1223,7 +1237,7 @@ function renderSidebar(
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const focused = state.focus === 'sidebar'
-  const lines = sidebarLines(context, contextStatus, state.sidebarTab, width - 4)
+  const lines = sidebarLines(context, contextStatus, state.sidebarTab, width - 4, theme)
   const tabs = getLogInkSidebarTabs()
 
   return h(Box, {
@@ -1234,7 +1248,13 @@ function renderSidebar(
     paddingX: 1,
   },
   h(Text, { bold: true }, panelTitle('Repository', focused)),
-  h(Text, { dimColor: true }, tabs.map((tab) => tab === state.sidebarTab ? `[${sidebarTabLabel(tab)}]` : sidebarTabLabel(tab)).join(' ')),
+  h(Text, { dimColor: true }, tabs.map((tab) => {
+    const count = sidebarTabCount(tab, context)
+    const labelWithCount = count !== undefined
+      ? `${sidebarTabLabel(tab)} (${count})`
+      : sidebarTabLabel(tab)
+    return tab === state.sidebarTab ? `[${labelWithCount}]` : labelWithCount
+  }).join(' ')),
   h(Text, undefined, ''),
   ...lines.map((line, index) => h(Text, { key: `sidebar-${index}` }, truncate(line, width - 4))))
 }
@@ -1486,17 +1506,32 @@ function renderStatusSurface(
   const listRows = Math.max(4, bodyRows - 5)
   const selectedIndex = state.selectedWorktreeFileIndex
   const cleanHint = formatLogInkStatusEmpty({ hasChanges: Boolean(worktree?.files.length) })
-  const lines = isLogInkContextKeyLoading(contextStatus, 'worktree')
+  const startIndex = Math.max(0, selectedIndex - Math.floor(listRows / 2))
+  const isLoading = isLogInkContextKeyLoading(contextStatus, 'worktree')
+  const fileRows: ReactTypes.ReactNode[] = isLoading || !worktree?.files.length
+    ? []
+    : worktree.files.slice(startIndex).slice(0, listRows).map((file, offset) => {
+      const index = startIndex + offset
+      const isSelected = index === selectedIndex
+      const cursorPart = `${isSelected ? '>' : ' '} `
+      const dotColor = getStageStatusDotColor(file.state, theme)
+      const useDot = dotColor !== undefined
+      const dotCells = useDot ? cellWidth(STAGE_STATUS_DOT) + 1 : 0
+      const tail = `${file.indexStatus}${file.worktreeStatus} ${file.state.padEnd(9)} ${file.path}`
+      const tailTrunc = truncate(tail, Math.max(0, 140 - cellWidth(cursorPart) - dotCells))
+
+      return h(Text, {
+        key: `status-row-${index}`,
+        dimColor: offset > 0,
+      },
+      cursorPart,
+      ...(useDot ? [h(Text, { color: dotColor }, STAGE_STATUS_DOT), ' '] : []),
+      tailTrunc)
+    })
+  const fallbackLines = isLoading
     ? [formatLogInkLoading({ resource: 'worktree status' })]
     : worktree?.files.length
-      ? worktree.files
-        .slice(Math.max(0, selectedIndex - Math.floor(listRows / 2)))
-        .slice(0, listRows)
-        .map((file, offset) => {
-          const index = Math.max(0, selectedIndex - Math.floor(listRows / 2)) + offset
-
-          return `${index === selectedIndex ? '>' : ' '} ${file.indexStatus}${file.worktreeStatus} ${file.state.padEnd(9)} ${file.path}`
-        })
+      ? []
       : cleanHint
         ? [cleanHint]
         : ['Worktree clean']
@@ -1514,8 +1549,9 @@ function renderStatusSurface(
       ? `${worktree.stagedCount} staged | ${worktree.unstagedCount} unstaged | ${worktree.untrackedCount} untracked`
       : 'status loading')
   ),
-  ...lines.map((line, index) => h(Text, {
-    key: `status-surface-${index}`,
+  ...fileRows,
+  ...fallbackLines.map((line, index) => h(Text, {
+    key: `status-surface-fallback-${index}`,
     dimColor: index > 0,
   }, truncate(line, 140))))
 }
@@ -1655,8 +1691,8 @@ function renderBranchesSurface(
         const index = startIndex + offset
         const isSelected = index === selected
         const cursor = isSelected ? '>' : ' '
-        const marker = branch.current ? '*' : ' '
-        const divergence = formatDivergence(branch)
+        const marker = branchRowMarker(branch, { ascii: theme.ascii })
+        const divergence = formatBranchDivergence(branch, { ascii: theme.ascii })
         return h(Text, {
           key: `branch-${index}`,
           bold: isSelected,


### PR DESCRIPTION
## Summary

Cluster polish from #756 priority 3. Visual hierarchy via high-compat Unicode (Geometric Shapes + Arrows blocks — no emoji). Letters always carry meaning; symbols enhance and degrade cleanly under `theme.ascii` and `theme.noColor`.

- **P3.1** branch divergence: `+3/-1 origin/main` → `↑3 ↓1 origin/main` (only non-zero directions render). Non-current branches without an upstream get a leading `◌`; current keeps `*`. ASCII mode falls back to the legacy `+N/-N` form.
- **P3.2** PR header: shape prefix on `PR #N STATE` — `◉` green (open), `●` magenta (merged), `◇` dim (draft), `×` red (closed). Draft PRs now read `DRAFT` instead of `OPEN`. Glyph is dropped under ASCII so the text label carries the meaning alone.
- **P3.3** status rows: leading colored `●` encodes severity — red unstaged, yellow staged, gray untracked. Raw porcelain codes (`M `, ` M`, `??`) and the textual state are preserved for screen readers; the dot drops to nothing under `noColor`/ASCII (would carry no info).
- **P3.4** sidebar tabs: `Status (N)`, `Branches (N)`, `Tags (N)`, `Stashes (N)`, `Worktrees (N)` so users see which tabs have content before pressing the digit. Counts are sourced from already-fetched context overviews.

All helpers live in a new `src/commands/log/inkIconography.ts` so they're easy to test and reuse. Covered by 21 new unit tests.

Mirrors the v1 epic's small-PR cadence; next up from #756 is P4 (preview pane, sort toggles, idle tips).

## Test plan

- [x] `npm run lint`
- [x] `npm run test:jest` — 722/722 passing (21 new in `inkIconography.test.ts`)
- [x] `npm run build` — dual CJS/ESM emitted
- [x] `npm run test:cli` — all 10 packaged-CLI smoke checks
- [x] `npm run release:dry-run`
- [ ] Manual run: `coco ui` against a repo with mixed branch divergence states + an open/draft/merged PR; verify `monochrome` and `TERM=dumb` fallbacks

Closes part of #756.

🤖 Generated with [Claude Code](https://claude.com/claude-code)