### PR TITLE
feat(log-tui): P4.1 preview pane for branches / tags / stash

### DIFF
--- a/src/commands/log/inkPreviewPane.test.ts
+++ b/src/commands/log/inkPreviewPane.test.ts
@@ -1,0 +1,164 @@
+import { BranchRef } from './branchData'
+import { StashEntry } from './stashData'
+import { GitTagRef } from './tagData'
+import {
+  PreviewLine,
+  formatBranchPreview,
+  formatStashPreview,
+  formatTagPreview,
+} from './inkPreviewPane'
+
+const text = (lines: PreviewLine[]): string[] => lines.map((line) => line.text)
+
+const baseBranch = (overrides: Partial<BranchRef> = {}): BranchRef => ({
+  type: 'local',
+  name: 'refs/heads/feat/foo',
+  shortName: 'feat/foo',
+  hash: '1234567890abcdef',
+  upstream: undefined,
+  current: false,
+  remote: undefined,
+  date: '2026-04-30',
+  subject: 'add the foo widget',
+  ahead: 0,
+  behind: 0,
+  ...overrides,
+})
+
+const baseTag = (overrides: Partial<GitTagRef> = {}): GitTagRef => ({
+  name: 'v1.2.3',
+  hash: 'deadbeefcafebabe',
+  date: '2026-04-15',
+  subject: 'release v1.2.3',
+  ...overrides,
+})
+
+const baseStash = (overrides: Partial<StashEntry> = {}): StashEntry => ({
+  ref: 'stash@{0}',
+  hash: 'cafef00dba5eba11',
+  date: '2026-04-29',
+  branch: 'feat/foo',
+  message: 'WIP debugging',
+  files: ['src/lib/foo.ts', 'src/lib/foo.test.ts'],
+  ...overrides,
+})
+
+describe('log Ink preview pane (P4.1)', () => {
+  describe('formatBranchPreview', () => {
+    it('returns a hint when nothing is selected', () => {
+      const lines = formatBranchPreview(undefined)
+      expect(lines).toHaveLength(1)
+      expect(lines[0].text).toMatch(/Select a branch/i)
+      expect(lines[0].emphasis).toBe('dim')
+    })
+
+    it('shows tip metadata + an in-sync line for an even branch', () => {
+      const lines = formatBranchPreview(baseBranch({ upstream: 'origin/feat/foo' }))
+      const out = text(lines)
+      expect(out[0]).toBe('feat/foo')
+      expect(lines[0].emphasis).toBe('heading')
+      expect(out).toEqual(expect.arrayContaining([
+        expect.stringMatching(/Tip:.*1234567/),
+        'Date:   2026-04-30',
+        'Subject: add the foo widget',
+        'Upstream: origin/feat/foo',
+        'Status:   in sync',
+      ]))
+    })
+
+    it('describes ahead/behind divergence in plain prose', () => {
+      const lines = formatBranchPreview(baseBranch({ upstream: 'origin/main', ahead: 3, behind: 1 }))
+      expect(text(lines)).toEqual(expect.arrayContaining([
+        'Status:   3 ahead, 1 behind',
+      ]))
+    })
+
+    it('flags a missing upstream', () => {
+      const lines = formatBranchPreview(baseBranch())
+      expect(lines.some((line) => line.text === 'No upstream tracking.' && line.emphasis === 'dim')).toBe(true)
+    })
+
+    it('marks the current branch with a footer note', () => {
+      const lines = formatBranchPreview(baseBranch({ current: true, upstream: 'origin/main' }))
+      const lastLines = lines.slice(-2)
+      expect(lastLines[1].text).toMatch(/current branch/)
+      expect(lastLines[1].emphasis).toBe('dim')
+    })
+
+    it('falls back to placeholders for missing date/subject', () => {
+      const lines = formatBranchPreview(baseBranch({ date: '', subject: '' }))
+      const out = text(lines)
+      expect(out).toEqual(expect.arrayContaining([
+        'Date:   <unknown>',
+        'Subject: <no subject>',
+      ]))
+    })
+  })
+
+  describe('formatTagPreview', () => {
+    it('returns a hint when nothing is selected', () => {
+      const lines = formatTagPreview(undefined)
+      expect(lines[0].text).toMatch(/Select a tag/i)
+      expect(lines[0].emphasis).toBe('dim')
+    })
+
+    it('returns name as heading and the commit metadata + subject body', () => {
+      const lines = formatTagPreview(baseTag())
+      expect(lines[0].text).toBe('v1.2.3')
+      expect(lines[0].emphasis).toBe('heading')
+      const out = text(lines)
+      expect(out).toEqual(expect.arrayContaining([
+        expect.stringMatching(/Commit:.*deadbee/),
+        'Date:    2026-04-15',
+        'Subject:',
+        '  release v1.2.3',
+      ]))
+    })
+
+    it('handles tags with missing date/subject', () => {
+      const lines = formatTagPreview(baseTag({ date: '', subject: '' }))
+      const out = text(lines)
+      expect(out).toEqual(expect.arrayContaining(['Date:    <unknown>', '  <no subject>']))
+    })
+  })
+
+  describe('formatStashPreview', () => {
+    it('returns a hint when nothing is selected', () => {
+      const lines = formatStashPreview(undefined)
+      expect(lines[0].text).toMatch(/Select a stash/i)
+      expect(lines[0].emphasis).toBe('dim')
+    })
+
+    it('returns ref + branch + message + file list', () => {
+      const lines = formatStashPreview(baseStash())
+      expect(lines[0].text).toBe('stash@{0}')
+      expect(lines[0].emphasis).toBe('heading')
+      const out = text(lines)
+      expect(out).toEqual(expect.arrayContaining([
+        'On:      feat/foo',
+        expect.stringMatching(/Commit:.*cafef00/),
+        'Date:    2026-04-29',
+        'Message:',
+        '  WIP debugging',
+        'Files (2):',
+        '  src/lib/foo.ts',
+        '  src/lib/foo.test.ts',
+      ]))
+    })
+
+    it('caps long file lists and reports the overflow', () => {
+      const files = Array.from({ length: 15 }, (_, i) => `src/file${i}.ts`)
+      const lines = formatStashPreview(baseStash({ files }), { fileCap: 10 })
+      const out = text(lines)
+      expect(out).toContain('Files (15):')
+      expect(out).toContain('  src/file9.ts')
+      expect(out).not.toContain('  src/file10.ts')
+      expect(out.some((line) => /…\s5 more/.test(line))).toBe(true)
+    })
+
+    it('flags an empty file list as dim', () => {
+      const lines = formatStashPreview(baseStash({ files: [] }))
+      expect(lines.some((line) => line.text === 'No files in stash.' && line.emphasis === 'dim')).toBe(true)
+    })
+  })
+})

--- a/src/commands/log/inkPreviewPane.ts
+++ b/src/commands/log/inkPreviewPane.ts
@@ -1,0 +1,130 @@
+/**
+ * Preview-pane content formatters for the promoted views (P4.1).
+ *
+ * Each formatter turns an existing context entry into a list of lines the
+ * detail panel renders on the right. Pure — no git calls, no React — so the
+ * shape is easy to assert in unit tests and the renderer stays a simple map
+ * over the result.
+ *
+ * Designed to mirror what `lazygit` / `yazi` show in their preview pane:
+ * the answer to "what am I about to act on" without forcing a checkout / show.
+ */
+
+import { BranchRef } from './branchData'
+import { StashEntry } from './stashData'
+import { GitTagRef } from './tagData'
+
+export type PreviewLineEmphasis = 'heading' | 'dim'
+
+export type PreviewLine = {
+  text: string
+  emphasis?: PreviewLineEmphasis
+}
+
+const heading = (text: string): PreviewLine => ({ text, emphasis: 'heading' })
+const dim = (text: string): PreviewLine => ({ text, emphasis: 'dim' })
+const line = (text: string): PreviewLine => ({ text })
+const blank = (): PreviewLine => ({ text: '' })
+
+function shortHash(hash: string | undefined): string {
+  return hash ? hash.slice(0, 7) : '<none>'
+}
+
+/* ------------------------------- branch -------------------------------- */
+
+function describeBranchDivergence(branch: Pick<BranchRef, 'ahead' | 'behind'>): string {
+  if (branch.ahead === 0 && branch.behind === 0) {
+    return 'in sync'
+  }
+  return `${branch.ahead} ahead, ${branch.behind} behind`
+}
+
+export function formatBranchPreview(branch: BranchRef | undefined): PreviewLine[] {
+  if (!branch) {
+    return [dim('Select a branch to preview.')]
+  }
+
+  const out: PreviewLine[] = [
+    heading(branch.shortName),
+    blank(),
+    line(`Tip:    ${shortHash(branch.hash)}`),
+    line(`Date:   ${branch.date || '<unknown>'}`),
+    line(`Subject: ${branch.subject || '<no subject>'}`),
+    blank(),
+  ]
+
+  if (branch.upstream) {
+    out.push(line(`Upstream: ${branch.upstream}`))
+    out.push(line(`Status:   ${describeBranchDivergence(branch)}`))
+  } else {
+    out.push(dim('No upstream tracking.'))
+  }
+
+  if (branch.current) {
+    out.push(blank())
+    out.push(dim('* current branch'))
+  }
+
+  return out
+}
+
+/* --------------------------------- tag --------------------------------- */
+
+export function formatTagPreview(tag: GitTagRef | undefined): PreviewLine[] {
+  if (!tag) {
+    return [dim('Select a tag to preview.')]
+  }
+
+  return [
+    heading(tag.name),
+    blank(),
+    line(`Commit:  ${shortHash(tag.hash)}`),
+    line(`Date:    ${tag.date || '<unknown>'}`),
+    blank(),
+    line('Subject:'),
+    line(`  ${tag.subject || '<no subject>'}`),
+  ]
+}
+
+/* -------------------------------- stash -------------------------------- */
+
+export type StashPreviewOptions = {
+  /** Cap on listed file paths in the preview. */
+  fileCap?: number
+}
+
+export function formatStashPreview(
+  stash: StashEntry | undefined,
+  options: StashPreviewOptions = {}
+): PreviewLine[] {
+  if (!stash) {
+    return [dim('Select a stash to preview.')]
+  }
+
+  const cap = options.fileCap ?? 10
+  const out: PreviewLine[] = [
+    heading(stash.ref),
+    blank(),
+    line(`On:      ${stash.branch || '<unknown>'}`),
+    line(`Commit:  ${shortHash(stash.hash)}`),
+    line(`Date:    ${stash.date || '<unknown>'}`),
+    blank(),
+    line('Message:'),
+    line(`  ${stash.message || '<no message>'}`),
+  ]
+
+  const files = stash.files || []
+  if (files.length > 0) {
+    out.push(blank())
+    out.push(line(`Files (${files.length}):`))
+    files.slice(0, cap).forEach((path) => out.push(line(`  ${path}`)))
+    if (files.length > cap) {
+      out.push(dim(`  … ${files.length - cap} more`))
+    }
+  } else {
+    out.push(blank())
+    out.push(dim('No files in stash.'))
+  }
+
+  return out
+}

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -89,6 +89,12 @@ import {
 } from './inkLayout'
 import { createLogInkTheme, LogInkTheme, LogInkThemeConfig } from './inkTheme'
 import {
+  PreviewLine,
+  formatBranchPreview,
+  formatStashPreview,
+  formatTagPreview,
+} from './inkPreviewPane'
+import {
   formatLogInkBranchesEmpty,
   formatLogInkComposeEmpty,
   formatLogInkHistoryEmpty,
@@ -2011,6 +2017,19 @@ function renderDetailPanel(
     return renderComposeContextPanel(h, components, state, context, contextStatus, width, theme, focused)
   }
 
+  // Preview pane (P4.1) — fzf / yazi / lazygit style: branches, tags, and
+  // stash views each get a tailored summary of the selected entry instead
+  // of falling through to the (stale) history inspector.
+  if (state.activeView === 'branches') {
+    return renderBranchPreviewPanel(h, components, state, context, contextStatus, width, theme, focused)
+  }
+  if (state.activeView === 'tags') {
+    return renderTagPreviewPanel(h, components, state, context, contextStatus, width, theme, focused)
+  }
+  if (state.activeView === 'stash') {
+    return renderStashPreviewPanel(h, components, state, context, contextStatus, width, theme, focused)
+  }
+
   return renderHistoryInspector(
     h, components, state, context, contextStatus, detail, loading,
     filePreview, filePreviewLoading, width, theme, focused
@@ -2294,6 +2313,113 @@ function renderCommitFileList(
       bold: isSelected,
     }, truncate(label, width - 4))
   })
+}
+
+function renderPreviewPanel(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  title: string,
+  lines: PreviewLine[],
+  width: number,
+  theme: LogInkTheme,
+  focused: boolean
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    width,
+    paddingX: 1,
+  },
+  h(Text, { bold: true }, panelTitle(title, focused)),
+  ...lines.map((line, index) => {
+    const isHeading = line.emphasis === 'heading' && index > 0
+    return h(Text, {
+      key: `preview-${index}`,
+      bold: isHeading,
+      dimColor: line.emphasis === 'dim',
+    }, truncate(line.text, width - 4))
+  }))
+}
+
+function renderBranchPreviewPanel(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  width: number,
+  theme: LogInkTheme,
+  focused: boolean
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  if (isLogInkContextKeyLoading(contextStatus, 'branches')) {
+    return renderPreviewPanel(h, { Box, Text }, 'Branch preview',
+      [{ text: formatLogInkLoading({ resource: 'branches' }), emphasis: 'dim' }],
+      width, theme, focused)
+  }
+  const all = context.branches?.localBranches || []
+  const visible = state.filter
+    ? all.filter((branch) =>
+      matchesPromotedFilter([branch.shortName, branch.upstream || ''], state.filter))
+    : all
+  const index = Math.max(0, Math.min(state.selectedBranchIndex, Math.max(0, visible.length - 1)))
+  const branch = visible[index]
+  return renderPreviewPanel(h, { Box, Text }, 'Branch preview',
+    formatBranchPreview(branch), width, theme, focused)
+}
+
+function renderTagPreviewPanel(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  width: number,
+  theme: LogInkTheme,
+  focused: boolean
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  if (isLogInkContextKeyLoading(contextStatus, 'tags')) {
+    return renderPreviewPanel(h, { Box, Text }, 'Tag preview',
+      [{ text: formatLogInkLoading({ resource: 'tags' }), emphasis: 'dim' }],
+      width, theme, focused)
+  }
+  const all = context.tags?.tags || []
+  const visible = state.filter
+    ? all.filter((tag) => matchesPromotedFilter([tag.name, tag.subject], state.filter))
+    : all
+  const index = Math.max(0, Math.min(state.selectedTagIndex, Math.max(0, visible.length - 1)))
+  const tag = visible[index]
+  return renderPreviewPanel(h, { Box, Text }, 'Tag preview',
+    formatTagPreview(tag), width, theme, focused)
+}
+
+function renderStashPreviewPanel(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  width: number,
+  theme: LogInkTheme,
+  focused: boolean
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  if (isLogInkContextKeyLoading(contextStatus, 'stashes')) {
+    return renderPreviewPanel(h, { Box, Text }, 'Stash preview',
+      [{ text: formatLogInkLoading({ resource: 'stashes' }), emphasis: 'dim' }],
+      width, theme, focused)
+  }
+  const all = context.stashes?.stashes || []
+  const visible = state.filter
+    ? all.filter((stash) => matchesPromotedFilter([stash.ref, stash.message], state.filter))
+    : all
+  const index = Math.max(0, Math.min(state.selectedStashIndex, Math.max(0, visible.length - 1)))
+  const stash = visible[index]
+  return renderPreviewPanel(h, { Box, Text }, 'Stash preview',
+    formatStashPreview(stash), width, theme, focused)
 }
 
 function renderCommitPanel(


### PR DESCRIPTION
## Summary

Branches, tags, and stash views were falling through to the history inspector on the right — showing the last-selected commit's data, which is the wrong context. lazygit / yazi / fzf all answer *"what am I about to act on"* with a tailored preview pane. This wires that into the existing detail-panel slot for the three promoted views.

- **Branch**: short name (heading) → tip sha + date + subject → upstream + ahead/behind summary (`3 ahead, 1 behind`) or a "No upstream tracking." hint, plus a `* current branch` footer.
- **Tag**: tag name (heading) → commit sha + date → subject body.
- **Stash**: ref (heading) → parent branch → sha + date → message body → file list with a soft cap that flags the overflow (`… 5 more`).

All formatters live in `inkPreviewPane.ts`, are pure, and read from already-fetched context — no new git calls and no new async flow. Loading and empty-selection cases fall back to dim hints. The dispatch sits inside `renderDetailPanel` so the modal overlays (help, palette, confirmation, chord) already short-circuit before it.

This is the first slice of #756 priority 4 — the next PR will combine P4.2 (sort toggles) + P4.3 (idle status-line tip rotation).

## Test plan

- [x] `npm run lint`
- [x] `npm run test:jest` — 714/714 passing (13 new in `inkPreviewPane.test.ts`)
- [x] `npm run build` — dual CJS/ESM emitted
- [x] `npm run test:cli` — 10/10 packaged-CLI smoke checks
- [x] `npm run release:dry-run`
- [ ] Manual: \`coco ui\` → \`g b\` and arrow-key through branches; verify the right pane updates per row, including a branch with no upstream and the current branch footer
- [ ] Manual: \`g t\` and \`g z\` to confirm tag + stash preview content matches the underlying entry

Closes part of #756 (P4.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)