### PR TITLE
feat(log-tui): P4.2 sort toggles + P4.3 idle status-line tips

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -109,6 +109,10 @@
             "theme": {
               "$ref": "#/definitions/LogInkThemeConfig",
               "description": "Theme settings for `coco log -i`."
+            },
+            "idleTips": {
+              "type": "boolean",
+              "description": "Rotate short usage tips through the status line when the TUI has been idle for >10s. Off by default so power users aren't distracted."
             }
           },
           "additionalProperties": false,

--- a/src/commands/log/inkIdleTips.test.ts
+++ b/src/commands/log/inkIdleTips.test.ts
@@ -1,0 +1,40 @@
+import {
+  IDLE_TIPS,
+  IDLE_TIPS_GRACE_MS,
+  IDLE_TIPS_INTERVAL_MS,
+  pickIdleTip,
+} from './inkIdleTips'
+
+describe('log Ink idle tips (P4.3)', () => {
+  it('exposes the canonical 6+ tip rotation called out in the spec', () => {
+    expect(IDLE_TIPS.length).toBeGreaterThanOrEqual(6)
+    expect(IDLE_TIPS.length).toBeLessThanOrEqual(8)
+    // Each tip is a short scannable hint.
+    IDLE_TIPS.forEach((tip) => {
+      expect(tip.length).toBeGreaterThan(8)
+      expect(tip.length).toBeLessThan(80)
+    })
+  })
+
+  it('returns undefined for the initial grace tick (0)', () => {
+    expect(pickIdleTip(0)).toBeUndefined()
+    expect(pickIdleTip(-3)).toBeUndefined()
+  })
+
+  it('rotates through the tip list in order starting at tick 1', () => {
+    expect(pickIdleTip(1)).toBe(IDLE_TIPS[0])
+    expect(pickIdleTip(2)).toBe(IDLE_TIPS[1])
+    expect(pickIdleTip(IDLE_TIPS.length)).toBe(IDLE_TIPS[IDLE_TIPS.length - 1])
+  })
+
+  it('wraps around the rotation modulo the tip count', () => {
+    expect(pickIdleTip(IDLE_TIPS.length + 1)).toBe(IDLE_TIPS[0])
+    expect(pickIdleTip(IDLE_TIPS.length * 3 + 2)).toBe(IDLE_TIPS[1])
+  })
+
+  it('matches the spec timing constants (>10s grace, ~8s rotation)', () => {
+    expect(IDLE_TIPS_GRACE_MS).toBeGreaterThanOrEqual(10_000)
+    expect(IDLE_TIPS_INTERVAL_MS).toBeGreaterThanOrEqual(5_000)
+    expect(IDLE_TIPS_INTERVAL_MS).toBeLessThanOrEqual(15_000)
+  })
+})

--- a/src/commands/log/inkIdleTips.ts
+++ b/src/commands/log/inkIdleTips.ts
@@ -1,0 +1,41 @@
+/**
+ * Idle status-line tip rotation (P4.3).
+ *
+ * Off by default; opt-in via `logTui.idleTips: true`. The runtime drives a
+ * tick counter that this module turns into a tip — pure mapping so the
+ * cadence + content can be tested without spinning React or timers.
+ *
+ * Convention:
+ *   - tickIndex 0   → no tip (initial grace, before the first idle window).
+ *   - tickIndex N>0 → IDLE_TIPS[(N - 1) % IDLE_TIPS.length].
+ *
+ * The runtime keeps tickIndex at 0 whenever the user is active or
+ * `state.statusMessage` is non-empty, so the tip only appears during true
+ * idle stretches.
+ */
+
+export const IDLE_TIPS: string[] = [
+  'press : to search every command',
+  'g h returns home from anywhere',
+  '/ filters the active view',
+  'press ? to see the full keymap',
+  's cycles sort modes in branches and tags',
+  'gz opens the stash view',
+  '< or esc walks the navigation stack back',
+]
+
+/**
+ * Threshold (in ms) of idle time before the first tip appears. Picked at 10s
+ * to match the spec in #756 — long enough that an active user never sees
+ * one, short enough to be useful when the user genuinely paused.
+ */
+export const IDLE_TIPS_GRACE_MS = 10_000
+
+/** Cadence between subsequent tips in ms. */
+export const IDLE_TIPS_INTERVAL_MS = 8_000
+
+export function pickIdleTip(tickIndex: number): string | undefined {
+  if (tickIndex <= 0) return undefined
+  if (IDLE_TIPS.length === 0) return undefined
+  return IDLE_TIPS[(tickIndex - 1) % IDLE_TIPS.length]
+}

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -923,4 +923,35 @@ describe('log Ink input interactions', () => {
       },
     ])
   })
+
+  describe('s cycles sort modes (P4.2)', () => {
+    it('cycles branch sort when active view is branches', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'branches' })
+      expect(state.branchSort).toBe('name')
+
+      state = applyInput(state, 's')
+      expect(state.branchSort).toBe('recent')
+
+      state = applyInput(state, 's')
+      expect(state.branchSort).toBe('ahead')
+    })
+
+    it('cycles tag sort when active view is tags', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'tags' })
+      expect(state.tagSort).toBe('recent')
+
+      state = applyInput(state, 's')
+      expect(state.tagSort).toBe('name')
+    })
+
+    it('does not cycle sort outside branches/tags views', () => {
+      let state = createLogInkState(rows)
+      // history view: `s` is unbound; reducer should not touch sort modes.
+      state = applyInput(state, 's')
+      expect(state.branchSort).toBe('name')
+      expect(state.tagSort).toBe('recent')
+    })
+  })
 })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -201,6 +201,17 @@ export function getLogInkPaletteExecuteEvents(
       return [{ type: 'exit' }]
     case 'clearSearch':
       return [action({ type: 'clearFilter' })]
+    case 'cycleSort':
+      if (state.activeView === 'branches') {
+        return [action({ type: 'cycleBranchSort' })]
+      }
+      if (state.activeView === 'tags') {
+        return [action({ type: 'cycleTagSort' })]
+      }
+      return [action({
+        type: 'setStatus',
+        value: 'Sort cycle is available in the branches and tags views',
+      })]
     default:
       return []
   }
@@ -536,6 +547,17 @@ export function getLogInkInputEvents(
 
   if (inputValue === 'r') {
     return [{ type: 'refreshContext' }]
+  }
+
+  if (inputValue === 's') {
+    if (state.activeView === 'branches') {
+      return [action({ type: 'cycleBranchSort' })]
+    }
+    if (state.activeView === 'tags') {
+      return [action({ type: 'cycleTagSort' })]
+    }
+    // Falls through so other views (history/status/diff/compose/stash) still
+    // see the literal `s` for whatever per-view bindings they may grow.
   }
 
   if (inputValue === ':') {

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -57,7 +57,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ branches', 'D delete', 'X checkout', 'enter diff', 'esc back'],
+      contextual: ['↑/↓ branches', 's sort', 'D delete', 'X checkout', 'enter diff'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 
@@ -67,7 +67,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ tags', 'T create', 'X push', 'esc back'],
+      contextual: ['↑/↓ tags', 's sort', 'T create', 'X push', 'esc back'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -9,6 +9,7 @@ export type LogInkCommandId =
   | 'clearSearch'
   | 'commandPalette'
   | 'commit'
+  | 'cycleSort'
   | 'editCommit'
   | 'focusNext'
   | 'focusPrevious'
@@ -273,6 +274,13 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     contexts: ['commits'],
   },
   {
+    id: 'cycleSort',
+    keys: ['s'],
+    label: 'sort',
+    description: 'Cycle the sort mode in branches (name/recent/ahead) or tags (recent/name).',
+    contexts: ['commits'],
+  },
+  {
     id: 'help',
     keys: ['?'],
     label: 'help',
@@ -481,14 +489,14 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
 
   if (options.activeView === 'branches') {
     return {
-      contextual: ['↑/↓ branches', 'D delete', 'X checkout', 'enter diff', 'esc back'],
+      contextual: ['↑/↓ branches', 's sort', 'D delete', 'X checkout', 'enter diff'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }
 
   if (options.activeView === 'tags') {
     return {
-      contextual: ['↑/↓ tags', 'T create', 'X push', 'esc back'],
+      contextual: ['↑/↓ tags', 's sort', 'T create', 'X push', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -89,6 +89,12 @@ import {
 } from './inkLayout'
 import { createLogInkTheme, LogInkTheme, LogInkThemeConfig } from './inkTheme'
 import {
+  formatSortIndicator,
+  sortBranches,
+  sortTags,
+} from './inkSorting'
+import { IDLE_TIPS_GRACE_MS, IDLE_TIPS_INTERVAL_MS, pickIdleTip } from './inkIdleTips'
+import {
   formatLogInkBranchesEmpty,
   formatLogInkComposeEmpty,
   formatLogInkHistoryEmpty,
@@ -142,6 +148,13 @@ type LogInkStreams = {
 
 type LogInkOptions = {
   appLabel?: string
+  /**
+   * P4.3 — opt-in idle tip rotation. Forwarded from `logTui.idleTips` in the
+   * user's config. The runtime starts a tip cycle when `state.statusMessage`
+   * is empty for >10s; the tip lives in the footer's status slot until the
+   * next user action sets a real message.
+   */
+  idleTips?: boolean
   initialView?: LogInkView
   logArgv?: LogArgv
   theme?: LogInkThemeConfig
@@ -193,6 +206,8 @@ type LogInkComponents = Pick<LogInkRuntime['ink'], 'Box' | 'Text'>
 type LogInkComponentDeps = LogInkRuntime & {
   appLabel: string
   git: SimpleGit
+  /** Drives P4.3 idle status-line tip rotation when truthy. */
+  idleTipsEnabled?: boolean
   initialView: LogInkView
   logArgv?: LogArgv
   rows: GitLogRow[]
@@ -417,7 +432,8 @@ function sidebarLines(
   context: LogInkContext,
   contextStatus: LogInkContextStatus,
   tab: LogInkSidebarTab,
-  width: number
+  width: number,
+  state: LogInkState
 ): string[] {
   if (tab === 'status') {
     const worktree = context.worktree
@@ -452,14 +468,15 @@ function sidebarLines(
       return ['Branches unavailable']
     }
 
+    const sortedBranches = sortBranches(branches.localBranches, state.branchSort)
     return [
       `Current: ${branches.currentBranch || '<detached>'}`,
       branches.dirty ? 'Worktree: dirty' : 'Worktree: clean',
       '',
-      ...branches.localBranches.slice(0, 8).map((branch) =>
+      ...sortedBranches.slice(0, 8).map((branch) =>
         `${branch.current ? '*' : ' '} ${truncate(branch.shortName, width - 4)}`
       ),
-      ...branches.localBranches.slice(0, 4).map((branch) =>
+      ...sortedBranches.slice(0, 4).map((branch) =>
         `  ${truncate(formatDivergence(branch), width - 2)}`
       ),
     ]
@@ -470,8 +487,9 @@ function sidebarLines(
       return ['Loading tags...']
     }
 
-    return context.tags?.tags.length
-      ? context.tags.tags.slice(0, 12).map((tag) =>
+    const sortedTags = sortTags(context.tags?.tags || [], state.tagSort)
+    return sortedTags.length
+      ? sortedTags.slice(0, 12).map((tag) =>
         `${truncate(tag.name, 16)} ${truncate(tag.subject, Math.max(8, width - 18))}`
       )
       : ['No tags found']
@@ -532,6 +550,7 @@ export async function startInkInteractiveLog(
   const app = React.createElement(LogInkApp, {
     appLabel: options.appLabel || 'coco log',
     git,
+    idleTipsEnabled: Boolean(options.idleTips),
     ink,
     initialView: options.initialView || 'history',
     logArgv: options.logArgv,
@@ -557,7 +576,7 @@ export async function startInkInteractiveLog(
 }
 
 function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
-  const { appLabel, git, ink, initialView, logArgv, React, resumeRef, rows, theme } = deps
+  const { appLabel, git, idleTipsEnabled, ink, initialView, logArgv, React, resumeRef, rows, theme } = deps
   const { Box, Text, useApp, useInput, useWindowSize } = ink
   const h = React.createElement
   const { exit } = useApp()
@@ -607,6 +626,32 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   const loadingMoreCommitsRef = React.useRef(false)
   const loadMoreRequestRef = React.useRef(0)
   const mountedRef = React.useRef(true)
+
+  // P4.3 — idle tip rotation. tickIndex 0 ⇒ no tip; the hook bumps it after
+  // a grace window of empty statusMessage and then on a steady cadence, so
+  // the footer surfaces a different hint every interval until the user does
+  // anything that sets statusMessage.
+  const [idleTipIndex, setIdleTipIndex] = React.useState(0)
+  React.useEffect(() => {
+    if (!idleTipsEnabled) return
+    if (state.statusMessage) {
+      // Any explicit message resets the cycle; next idle stretch starts
+      // from the grace window again.
+      setIdleTipIndex(0)
+      return
+    }
+    let interval: NodeJS.Timeout | undefined
+    const grace = setTimeout(() => {
+      setIdleTipIndex(1)
+      interval = setInterval(() => setIdleTipIndex((tick) => tick + 1), IDLE_TIPS_INTERVAL_MS)
+    }, IDLE_TIPS_GRACE_MS)
+    return () => {
+      clearTimeout(grace)
+      if (interval) clearInterval(interval)
+    }
+  }, [idleTipsEnabled, state.statusMessage])
+  const idleTip = idleTipsEnabled && !state.statusMessage ? pickIdleTip(idleTipIndex) : undefined
+
   const selected = getSelectedInkCommit(state)
   const selectedDetailFile = detail?.files[state.selectedFileIndex]
   const selectedWorktreeFile = context.worktree?.files[state.selectedWorktreeFileIndex]
@@ -1158,7 +1203,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         theme
       )
     ),
-    renderFooter(h, { Box, Text }, state, theme)
+    renderFooter(h, { Box, Text }, state, theme, idleTip)
   )
 }
 
@@ -1223,7 +1268,7 @@ function renderSidebar(
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const focused = state.focus === 'sidebar'
-  const lines = sidebarLines(context, contextStatus, state.sidebarTab, width - 4)
+  const lines = sidebarLines(context, contextStatus, state.sidebarTab, width - 4, state)
   const tabs = getLogInkSidebarTabs()
 
   return h(Box, {
@@ -1631,20 +1676,21 @@ function renderBranchesSurface(
   const focused = state.focus === 'commits'
   const branches = context.branches
   const loading = isLogInkContextKeyLoading(contextStatus, 'branches')
-  const allLocalBranches = branches?.localBranches || []
+  const sortedAll = sortBranches(branches?.localBranches || [], state.branchSort)
   const localBranches = state.filter
-    ? allLocalBranches.filter((branch) =>
+    ? sortedAll.filter((branch) =>
       matchesPromotedFilter([branch.shortName, branch.upstream || ''], state.filter)
     )
-    : allLocalBranches
+    : sortedAll
   const selected = Math.max(0, Math.min(state.selectedBranchIndex, Math.max(0, localBranches.length - 1)))
   const listRows = Math.max(4, bodyRows - 4)
   const startIndex = Math.max(0, selected - Math.floor(listRows / 2))
   const visible = localBranches.slice(startIndex, startIndex + listRows)
   const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
+  const sortLabel = ` | ${formatSortIndicator(state.branchSort, { ascii: theme.ascii })}`
   const headerRight = loading
     ? 'loading branches'
-    : `${localBranches.length}/${allLocalBranches.length} local | current: ${branches?.currentBranch || '<detached>'}${filterLabel}`
+    : `${localBranches.length}/${sortedAll.length} local | current: ${branches?.currentBranch || '<detached>'}${filterLabel}${sortLabel}`
   const emptyLabel = formatLogInkBranchesEmpty({ filter: state.filter })
   const loadingLabel = formatLogInkLoading({ resource: 'branches' })
   const lines: ReactTypes.ReactNode[] = loading
@@ -1691,18 +1737,19 @@ function renderTagsSurface(
   const { Box, Text } = components
   const focused = state.focus === 'commits'
   const loading = isLogInkContextKeyLoading(contextStatus, 'tags')
-  const allTags = context.tags?.tags || []
+  const sortedAll = sortTags(context.tags?.tags || [], state.tagSort)
   const tags = state.filter
-    ? allTags.filter((tag) => matchesPromotedFilter([tag.name, tag.subject], state.filter))
-    : allTags
+    ? sortedAll.filter((tag) => matchesPromotedFilter([tag.name, tag.subject], state.filter))
+    : sortedAll
   const selected = Math.max(0, Math.min(state.selectedTagIndex, Math.max(0, tags.length - 1)))
   const listRows = Math.max(4, bodyRows - 4)
   const startIndex = Math.max(0, selected - Math.floor(listRows / 2))
   const visible = tags.slice(startIndex, startIndex + listRows)
   const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
+  const sortLabel = ` | ${formatSortIndicator(state.tagSort, { ascii: theme.ascii })}`
   const headerRight = loading
     ? 'loading tags'
-    : `${tags.length}/${allTags.length} tags${filterLabel}`
+    : `${tags.length}/${sortedAll.length} tags${filterLabel}${sortLabel}`
   const emptyLabel = formatLogInkTagsEmpty({ filter: state.filter })
   const loadingLabel = formatLogInkLoading({ resource: 'tags' })
   const lines: ReactTypes.ReactNode[] = loading
@@ -2614,7 +2661,8 @@ function renderFooter(
   h: typeof ReactTypes.createElement,
   components: LogInkComponents,
   state: LogInkState,
-  theme: LogInkTheme
+  theme: LogInkTheme,
+  idleTip?: string
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const hints = getLogInkFooterHints({
@@ -2625,7 +2673,10 @@ function renderFooter(
     showCommandPalette: state.showCommandPalette,
     showHelp: state.showHelp,
   })
-  const status = state.statusMessage ? `  ${state.statusMessage}` : ''
+  // Real status messages always win; idle tips only fill the slot when it
+  // would otherwise be empty.
+  const trailing = state.statusMessage || idleTip || ''
+  const status = trailing ? `  ${trailing}` : ''
   const contextualText = `${hints.contextual.join('   ')}${status}`
   const globalText = hints.global.join(' · ')
 

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -753,8 +753,14 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       return
     }
     let interval: NodeJS.Timeout | undefined
+    // Both timer callbacks are function literals (never strings) and the
+    // delays are our own `IDLE_TIPS_*_MS` constants — no caller-supplied
+    // data flows in, so the eval-injection vector that drives
+    // DevSkim DS172411 doesn't apply here.
+    // DevSkim: ignore DS172411
     const grace = setTimeout(() => {
       setIdleTipIndex(1)
+      // DevSkim: ignore DS172411
       interval = setInterval(() => setIdleTipIndex((tick) => tick + 1), IDLE_TIPS_INTERVAL_MS)
     }, IDLE_TIPS_GRACE_MS)
     return () => {

--- a/src/commands/log/inkSorting.test.ts
+++ b/src/commands/log/inkSorting.test.ts
@@ -1,0 +1,128 @@
+import { BranchRef } from './branchData'
+import { GitTagRef } from './tagData'
+import {
+  BRANCH_SORT_MODES,
+  TAG_SORT_MODES,
+  cycleBranchSort,
+  cycleTagSort,
+  formatSortIndicator,
+  sortBranches,
+  sortTags,
+} from './inkSorting'
+
+const branch = (overrides: Partial<BranchRef>): BranchRef => ({
+  type: 'local',
+  name: `refs/heads/${overrides.shortName || 'x'}`,
+  shortName: 'x',
+  hash: '0000000',
+  upstream: undefined,
+  current: false,
+  remote: undefined,
+  date: '',
+  subject: '',
+  ahead: 0,
+  behind: 0,
+  ...overrides,
+})
+
+const tag = (overrides: Partial<GitTagRef>): GitTagRef => ({
+  name: 'x',
+  hash: '0000000',
+  date: '',
+  subject: '',
+  ...overrides,
+})
+
+describe('log Ink sorting (P4.2)', () => {
+  describe('cycleBranchSort', () => {
+    it('cycles through every mode in order', () => {
+      let mode = BRANCH_SORT_MODES[0]
+      const seen: string[] = []
+      for (let i = 0; i < BRANCH_SORT_MODES.length + 1; i += 1) {
+        seen.push(mode)
+        mode = cycleBranchSort(mode)
+      }
+      expect(seen.slice(0, BRANCH_SORT_MODES.length)).toEqual(BRANCH_SORT_MODES)
+      // After one full revolution we land back on the first mode.
+      expect(seen[BRANCH_SORT_MODES.length]).toBe(BRANCH_SORT_MODES[0])
+    })
+
+    it('falls back to the first mode for an unknown current value', () => {
+      // @ts-expect-error -- exercising the recovery path
+      expect(cycleBranchSort('not-a-mode')).toBe(BRANCH_SORT_MODES[0])
+    })
+  })
+
+  describe('sortBranches', () => {
+    const sample: BranchRef[] = [
+      branch({ shortName: 'feat/zeta', date: '2026-04-01', ahead: 0, behind: 5 }),
+      branch({ shortName: 'main', date: '2026-04-30', ahead: 1, behind: 0 }),
+      branch({ shortName: 'feat/alpha', date: '2026-04-20', ahead: 8, behind: 2 }),
+    ]
+
+    it('sorts by name (alphabetical, stable)', () => {
+      expect(sortBranches(sample, 'name').map((b) => b.shortName))
+        .toEqual(['feat/alpha', 'feat/zeta', 'main'])
+    })
+
+    it('sorts by recent (newest date first)', () => {
+      expect(sortBranches(sample, 'recent').map((b) => b.shortName))
+        .toEqual(['main', 'feat/alpha', 'feat/zeta'])
+    })
+
+    it('sorts by ahead (most unmerged work first)', () => {
+      expect(sortBranches(sample, 'ahead').map((b) => b.shortName))
+        .toEqual(['feat/alpha', 'main', 'feat/zeta'])
+    })
+
+    it('returns a copy — never mutates the input', () => {
+      const before = sample.map((b) => b.shortName)
+      sortBranches(sample, 'name')
+      sortBranches(sample, 'recent')
+      sortBranches(sample, 'ahead')
+      expect(sample.map((b) => b.shortName)).toEqual(before)
+    })
+  })
+
+  describe('cycleTagSort', () => {
+    it('cycles through every mode in order', () => {
+      const seen: string[] = []
+      let mode = TAG_SORT_MODES[0]
+      for (let i = 0; i < TAG_SORT_MODES.length + 1; i += 1) {
+        seen.push(mode)
+        mode = cycleTagSort(mode)
+      }
+      expect(seen.slice(0, TAG_SORT_MODES.length)).toEqual(TAG_SORT_MODES)
+      expect(seen[TAG_SORT_MODES.length]).toBe(TAG_SORT_MODES[0])
+    })
+  })
+
+  describe('sortTags', () => {
+    const sample: GitTagRef[] = [
+      tag({ name: 'v0.9.0', date: '2026-01-01' }),
+      tag({ name: 'v1.0.0', date: '2026-04-01' }),
+      tag({ name: 'v0.10.0', date: '2026-03-01' }),
+    ]
+
+    it('sorts by name (alphabetical)', () => {
+      expect(sortTags(sample, 'name').map((t) => t.name))
+        .toEqual(['v0.10.0', 'v0.9.0', 'v1.0.0'])
+    })
+
+    it('sorts by recent (newest date first)', () => {
+      expect(sortTags(sample, 'recent').map((t) => t.name))
+        .toEqual(['v1.0.0', 'v0.10.0', 'v0.9.0'])
+    })
+  })
+
+  describe('formatSortIndicator', () => {
+    it('uses ▼ glyph by default', () => {
+      expect(formatSortIndicator('recent')).toBe('▼ recent')
+      expect(formatSortIndicator('name')).toBe('▼ name')
+    })
+
+    it('falls back to v under ASCII', () => {
+      expect(formatSortIndicator('recent', { ascii: true })).toBe('v recent')
+    })
+  })
+})

--- a/src/commands/log/inkSorting.ts
+++ b/src/commands/log/inkSorting.ts
@@ -1,0 +1,80 @@
+/**
+ * Sort modes for the promoted views (P4.2).
+ *
+ * Pure: takes existing context entries + the active mode, returns a sorted
+ * copy. Tested in isolation; the runtime just calls these helpers.
+ *
+ * Display label uses `▼` (U+25BC) under truecolor / UTF-8 and falls back to
+ * `v` under ASCII. Letters (`recent` / `name` / `ahead`) carry meaning;
+ * shape enhances.
+ */
+
+import { BranchRef } from './branchData'
+import { GitTagRef } from './tagData'
+
+/* ------------------------------- branches ------------------------------- */
+
+export type BranchSortMode = 'name' | 'recent' | 'ahead'
+
+export const BRANCH_SORT_MODES: BranchSortMode[] = ['name', 'recent', 'ahead']
+
+export const DEFAULT_BRANCH_SORT_MODE: BranchSortMode = 'name'
+
+export function cycleBranchSort(mode: BranchSortMode): BranchSortMode {
+  const index = BRANCH_SORT_MODES.indexOf(mode)
+  if (index < 0) return BRANCH_SORT_MODES[0]
+  return BRANCH_SORT_MODES[(index + 1) % BRANCH_SORT_MODES.length]
+}
+
+export function sortBranches<T extends BranchRef>(branches: T[], mode: BranchSortMode): T[] {
+  const copy = branches.slice()
+  switch (mode) {
+    case 'name':
+      return copy.sort((a, b) => a.shortName.localeCompare(b.shortName))
+    case 'recent':
+      // ISO-shaped dates compare byte-for-byte; descending so the freshest
+      // branch sits at the top.
+      return copy.sort((a, b) => (b.date || '').localeCompare(a.date || '') ||
+        a.shortName.localeCompare(b.shortName))
+    case 'ahead':
+      // ahead-first; ties broken by behind, then by name. Keeps "this branch
+      // has unmerged work" in the user's first scroll.
+      return copy.sort((a, b) => b.ahead - a.ahead || b.behind - a.behind ||
+        a.shortName.localeCompare(b.shortName))
+    default:
+      return copy
+  }
+}
+
+/* --------------------------------- tags --------------------------------- */
+
+export type TagSortMode = 'name' | 'recent'
+
+export const TAG_SORT_MODES: TagSortMode[] = ['recent', 'name']
+
+export const DEFAULT_TAG_SORT_MODE: TagSortMode = 'recent'
+
+export function cycleTagSort(mode: TagSortMode): TagSortMode {
+  const index = TAG_SORT_MODES.indexOf(mode)
+  if (index < 0) return TAG_SORT_MODES[0]
+  return TAG_SORT_MODES[(index + 1) % TAG_SORT_MODES.length]
+}
+
+export function sortTags<T extends GitTagRef>(tags: T[], mode: TagSortMode): T[] {
+  const copy = tags.slice()
+  switch (mode) {
+    case 'name':
+      return copy.sort((a, b) => a.name.localeCompare(b.name))
+    case 'recent':
+      return copy.sort((a, b) => (b.date || '').localeCompare(a.date || '') ||
+        a.name.localeCompare(b.name))
+    default:
+      return copy
+  }
+}
+
+/* ---------------------------- header indicator -------------------------- */
+
+export function formatSortIndicator(mode: string, options: { ascii?: boolean } = {}): string {
+  return `${options.ascii ? 'v' : '▼'} ${mode}`
+}

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -629,4 +629,43 @@ describe('log Ink view model', () => {
       expect(state.selectedWorktreeFileIndex).toBe(0)
     })
   })
+
+  describe('sort cycling (P4.2)', () => {
+    it('cycleBranchSort advances the mode and resets the cursor to the top', () => {
+      let state = createLogInkState(rows)
+      state = { ...state, selectedBranchIndex: 5 }
+      expect(state.branchSort).toBe('name')
+
+      state = applyLogInkAction(state, { type: 'cycleBranchSort' })
+      expect(state.branchSort).toBe('recent')
+      expect(state.selectedBranchIndex).toBe(0)
+
+      state = applyLogInkAction(state, { type: 'cycleBranchSort' })
+      expect(state.branchSort).toBe('ahead')
+
+      state = applyLogInkAction(state, { type: 'cycleBranchSort' })
+      expect(state.branchSort).toBe('name')
+    })
+
+    it('cycleTagSort advances the mode and resets the cursor', () => {
+      let state = createLogInkState(rows)
+      state = { ...state, selectedTagIndex: 7 }
+      expect(state.tagSort).toBe('recent')
+
+      state = applyLogInkAction(state, { type: 'cycleTagSort' })
+      expect(state.tagSort).toBe('name')
+      expect(state.selectedTagIndex).toBe(0)
+
+      state = applyLogInkAction(state, { type: 'cycleTagSort' })
+      expect(state.tagSort).toBe('recent')
+    })
+
+    it('cycle actions clear any pending chord prefix', () => {
+      let state = createLogInkState(rows)
+      state = { ...state, pendingKey: 'g' }
+
+      state = applyLogInkAction(state, { type: 'cycleBranchSort' })
+      expect(state.pendingKey).toBeUndefined()
+    })
+  })
 })

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -5,6 +5,14 @@ import {
   applyCommitComposeAction,
   createCommitComposeState,
 } from './commitCompose'
+import {
+  BranchSortMode,
+  DEFAULT_BRANCH_SORT_MODE,
+  DEFAULT_TAG_SORT_MODE,
+  TagSortMode,
+  cycleBranchSort,
+  cycleTagSort,
+} from './inkSorting'
 
 export type LogInkFocus = 'sidebar' | 'commits' | 'detail'
 
@@ -51,6 +59,13 @@ export type LogInkState = {
   selectedBranchIndex: number
   selectedTagIndex: number
   selectedStashIndex: number
+  /**
+   * Sort modes for the promoted views (P4.2). `s` cycles through the
+   * available modes; the surface header shows a `▼ <mode>` indicator.
+   * Defaults match the existing display order so opting out is a no-op.
+   */
+  branchSort: BranchSortMode
+  tagSort: TagSortMode
   commitCompose: CommitComposeState
   diffPreviewOffset: number
   worktreeDiffOffset: number
@@ -147,6 +162,8 @@ export type LogInkAction =
   | { type: 'toggleGraph' }
   | { type: 'toggleHelp' }
   | { type: 'toggleCommandPalette' }
+  | { type: 'cycleBranchSort' }
+  | { type: 'cycleTagSort' }
 
 const FOCUS_ORDER: LogInkFocus[] = ['sidebar', 'commits', 'detail']
 const SIDEBAR_TABS: LogInkSidebarTab[] = ['status', 'branches', 'tags', 'stashes', 'worktrees']
@@ -418,6 +435,8 @@ export function createLogInkState(
     selectedBranchIndex: 0,
     selectedTagIndex: 0,
     selectedStashIndex: 0,
+    branchSort: DEFAULT_BRANCH_SORT_MODE,
+    tagSort: DEFAULT_TAG_SORT_MODE,
     paletteFilter: '',
     paletteSelectedIndex: 0,
     paletteRecent: [],
@@ -544,6 +563,22 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         selectedStashIndex: clampIndex(state.selectedStashIndex + action.delta, action.count),
+        pendingKey: undefined,
+      }
+    case 'cycleBranchSort':
+      return {
+        ...state,
+        branchSort: cycleBranchSort(state.branchSort),
+        // Snap to the top of the (newly ordered) list so the user always
+        // sees what's now most relevant under the new mode.
+        selectedBranchIndex: 0,
+        pendingKey: undefined,
+      }
+    case 'cycleTagSort':
+      return {
+        ...state,
+        tagSort: cycleTagSort(state.tagSort),
+        selectedTagIndex: 0,
         pendingKey: undefined,
       }
     case 'moveToBottom':

--- a/src/commands/ui/handler.ts
+++ b/src/commands/ui/handler.ts
@@ -53,6 +53,7 @@ export async function startCocoUiFromLogArgv(
 
   await startInkInteractiveLog(git, rows, {}, {
     appLabel: 'coco ui',
+    idleTips: config.logTui?.idleTips,
     initialView: 'history',
     logArgv,
     theme: config.logTui?.theme,
@@ -67,6 +68,7 @@ export async function startCocoUi(argv: UiArgv): Promise<void> {
 
   await startInkInteractiveLog(git, rows, {}, {
     appLabel: 'coco ui',
+    idleTips: config.logTui?.idleTips,
     initialView: argv.view || 'history',
     logArgv,
     theme: createUiTheme(config, argv),

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -100,6 +100,12 @@ type BaseConfig = {
      * Theme settings for `coco log -i`.
      */
     theme?: LogInkThemeConfig
+
+    /**
+     * Rotate short usage tips through the status line when the TUI has been
+     * idle for >10s. Off by default so power users aren't distracted.
+     */
+    idleTips?: boolean
   }
 }
 


### PR DESCRIPTION
## Summary

Two opt-in power-user touches from #756 priority 4. Shipped together because they're small individually and the only shared surface is the footer.

### P4.2 — sort indicator + `s` toggle (branches / tags)

- **Branches**: cycle `name` (default) → `recent` → `ahead` via \`s\`. Header surfaces \`▼ <mode>\` (\`v <mode>\` under ASCII).
- **Tags**: cycle \`recent\` (default) → \`name\` via \`s\`. Same header indicator.
- Sort is applied *before* filter so the cursor snaps to the top of the newly-ordered list — users always see what's most relevant under the new mode.
- Sidebar tab summaries pick up the same sort, keeping the side glance and full-screen view consistent.
- Pure comparators live in \`inkSorting.ts\` and are tested in isolation against fixed inputs.

### P4.3 — idle tip rotation

- **Off by default**. Opt in via \`logTui.idleTips: true\` in \`.coco.config.json\`.
- After 10s of empty \`state.statusMessage\`, a soft hint rotates through the footer's status slot every ~8s — \`:\` palette, \`g h\` home, \`/\` filter, \`?\` help, \`s\` cycles sort, \`gz\` stash, \`<\`/\`esc\` walks back.
- Real status messages always win — any user action that sets a message resets the cycle.
- \`inkIdleTips.ts\` is a pure tip-picker (\`tickIndex → tip|undefined\`); the React hook is a thin wrapper around it.
- Config field flows through the ui handler into \`LogInkOptions\` and on into the runtime as \`idleTipsEnabled\`. Schema regenerated.

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run test:jest\` — 723/723 (16 new in inkSorting/inkIdleTips, plus reducer + input dispatch coverage)
- [x] \`npm run build\` — dual CJS/ESM emitted; \`schema.json\` regenerated for the new \`idleTips\` field
- [x] \`npm run test:cli\` — 10/10 packaged-CLI smoke checks
- [x] \`npm run release:dry-run\`
- [ ] Manual: \`coco ui\` → \`g b\` and press \`s\` repeatedly; verify list reorders + indicator cycles
- [ ] Manual: \`g t\` and press \`s\`; verify tags reorder + indicator cycles
- [ ] Manual: set \`logTui.idleTips: true\`, leave the TUI alone for ~12s, watch the footer pick up rotating tips; press any key and confirm the tip clears

Closes part of #756 (P4.2 + P4.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)