### PR TITLE
fix(log-tui): P4.5 preserve cursor on filter when item is still visible

### DIFF
--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -76,6 +76,10 @@ import { substituteGraphChars } from './inkGraphChars'
 import { LogInkInputKey, getLogInkInputEvents } from './inkInput'
 import { hasSeenOnboarding, markOnboardingSeen } from './inkOnboarding'
 import {
+  PromotedSelectionsSnapshot,
+  rectifyPromotedSelectionIndex,
+} from './inkSelectionRectify'
+import {
   LogInkRefreshWatcher,
   createRefreshWatcher,
 } from './inkRefreshWatcher'
@@ -553,6 +557,110 @@ export async function startInkInteractiveLog(
     await instance.waitUntilExit()
   } finally {
     lifecycle.dispose()
+  }
+}
+
+/**
+ * Predict the filter value that a filter-mutating action would land on, so
+ * the runtime can compute the post-filter selection snapshot before the
+ * reducer ever runs (P4.5). Returns undefined when the action isn't a
+ * filter action.
+ */
+function predictNextFilter(
+  action: Parameters<typeof applyLogInkAction>[1],
+  currentFilter: string
+): string | undefined {
+  switch (action.type) {
+    case 'appendFilter':
+      return `${currentFilter}${action.value}`
+    case 'backspaceFilter':
+      return currentFilter.slice(0, -1)
+    case 'clearFilter':
+    case 'clearFilterText':
+      return ''
+    case 'setFilter':
+      return action.value
+    default:
+      return undefined
+  }
+}
+
+/**
+ * Build the post-filter selection snapshot for branches / tags / stash so
+ * the reducer can preserve the cursor when the previously-selected item is
+ * still in the filtered result. Identifies items by a single key per view
+ * (branch shortName, tag name, stash ref) — the same matchesPromotedFilter
+ * the surfaces use covers the multi-field haystacks.
+ */
+function computePromotedSelectionsSnapshot(
+  state: LogInkState,
+  context: LogInkContext,
+  nextFilter: string
+): PromotedSelectionsSnapshot {
+  const allBranches = context.branches?.localBranches || []
+  const filteredBranches = nextFilter
+    ? allBranches.filter((branch) =>
+      matchesPromotedFilter([branch.shortName, branch.upstream || ''], nextFilter))
+    : allBranches
+  const currentBranches = state.filter
+    ? allBranches.filter((branch) =>
+      matchesPromotedFilter([branch.shortName, branch.upstream || ''], state.filter))
+    : allBranches
+  const previousBranchKey = currentBranches[state.selectedBranchIndex]?.shortName
+  const branchIndex = rectifyPromotedSelectionIndex(
+    filteredBranches.map((branch) => branch.shortName),
+    previousBranchKey
+  )
+
+  const allTags = context.tags?.tags || []
+  const filteredTags = nextFilter
+    ? allTags.filter((tag) => matchesPromotedFilter([tag.name, tag.subject], nextFilter))
+    : allTags
+  const currentTags = state.filter
+    ? allTags.filter((tag) => matchesPromotedFilter([tag.name, tag.subject], state.filter))
+    : allTags
+  const previousTagKey = currentTags[state.selectedTagIndex]?.name
+  const tagIndex = rectifyPromotedSelectionIndex(
+    filteredTags.map((tag) => tag.name),
+    previousTagKey
+  )
+
+  const allStashes = context.stashes?.stashes || []
+  const filteredStashes = nextFilter
+    ? allStashes.filter((stash) => matchesPromotedFilter([stash.ref, stash.message], nextFilter))
+    : allStashes
+  const currentStashes = state.filter
+    ? allStashes.filter((stash) => matchesPromotedFilter([stash.ref, stash.message], state.filter))
+    : allStashes
+  const previousStashKey = currentStashes[state.selectedStashIndex]?.ref
+  const stashIndex = rectifyPromotedSelectionIndex(
+    filteredStashes.map((stash) => stash.ref),
+    previousStashKey
+  )
+
+  return { branchIndex, tagIndex, stashIndex }
+}
+
+function enrichFilterActionWithRectification(
+  action: Parameters<typeof applyLogInkAction>[1],
+  state: LogInkState,
+  context: LogInkContext
+): Parameters<typeof applyLogInkAction>[1] {
+  const nextFilter = predictNextFilter(action, state.filter)
+  if (nextFilter === undefined) {
+    return action
+  }
+  const promotedSelections = computePromotedSelectionsSnapshot(state, context, nextFilter)
+  switch (action.type) {
+    case 'appendFilter':
+    case 'setFilter':
+      return { ...action, promotedSelections }
+    case 'backspaceFilter':
+    case 'clearFilter':
+    case 'clearFilterText':
+      return { ...action, promotedSelections }
+    default:
+      return action
   }
 }
 
@@ -1097,7 +1205,14 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       } else if (event.type === 'runAiCommitDraft') {
         void runAiCommitDraft()
       } else {
-        dispatch(event.action)
+        // P4.5: enrich filter-mutating actions with a precomputed
+        // selection snapshot so the reducer can preserve the cursor on
+        // the same item when it's still in the filtered result, only
+        // snapping to result[0] when the previously selected item drops
+        // out. The snapshot lives in the action so the reducer never
+        // needs context items.
+        const enriched = enrichFilterActionWithRectification(event.action, state, context)
+        dispatch(enriched)
       }
     })
   })

--- a/src/commands/log/inkSelectionRectify.test.ts
+++ b/src/commands/log/inkSelectionRectify.test.ts
@@ -1,0 +1,29 @@
+import { rectifyPromotedSelectionIndex } from './inkSelectionRectify'
+
+describe('log Ink selection rectification (P4.5)', () => {
+  describe('rectifyPromotedSelectionIndex', () => {
+    it('preserves the cursor when the selected key is still in the filtered list', () => {
+      const filtered = ['feat/alpha', 'feat/widget', 'main']
+      expect(rectifyPromotedSelectionIndex(filtered, 'feat/widget')).toBe(1)
+    })
+
+    it('snaps to result[0] when the selected key dropped out', () => {
+      const filtered = ['feat/alpha', 'main']
+      expect(rectifyPromotedSelectionIndex(filtered, 'feat/widget')).toBe(0)
+    })
+
+    it('returns 0 when the filtered list is empty', () => {
+      expect(rectifyPromotedSelectionIndex([], 'anything')).toBe(0)
+      expect(rectifyPromotedSelectionIndex([], undefined)).toBe(0)
+    })
+
+    it('returns 0 when no previous selection key was provided', () => {
+      expect(rectifyPromotedSelectionIndex(['a', 'b'], undefined)).toBe(0)
+    })
+
+    it('handles a single-item result set', () => {
+      expect(rectifyPromotedSelectionIndex(['feat/widget'], 'feat/widget')).toBe(0)
+      expect(rectifyPromotedSelectionIndex(['feat/widget'], 'main')).toBe(0)
+    })
+  })
+})

--- a/src/commands/log/inkSelectionRectify.ts
+++ b/src/commands/log/inkSelectionRectify.ts
@@ -1,0 +1,49 @@
+/**
+ * Promoted-view selection rectification on filter changes (P4.5).
+ *
+ * Without this, the reducer used to snap selectedBranchIndex/Tag/Stash to 0
+ * on every filter keystroke — which kept the cursor in range but lost the
+ * user's place even when the previously-selected item was still in the
+ * filtered result.
+ *
+ * The proper behavior (called out in #756 P4.5):
+ *   - If the previously-selected item is still in the filtered list, the
+ *     cursor follows it (its new index in the filtered list).
+ *   - If it dropped out of the filtered list, snap to result[0].
+ *   - If no filter change happened, leave the cursor alone.
+ *
+ * Implementation: the runtime computes a `PromotedSelectionsSnapshot` from
+ * existing context items + the predicted next filter, attaches it to the
+ * filter-mutating action, and the reducer applies the precomputed indexes.
+ *
+ * The rectification is a pure function over (lookup, filteredKeys); see
+ * inkSelectionRectify.test.ts for the cases it covers.
+ */
+
+export type PromotedSelectionsSnapshot = {
+  branchIndex?: number
+  tagIndex?: number
+  stashIndex?: number
+}
+
+/**
+ * Map (filtered keys, previously-selected key) → new selected index.
+ * Falls back to 0 when the key dropped out or no key was provided —
+ * matching the spec's "snap to result[0]" requirement.
+ *
+ * The runtime is responsible for producing `filteredKeys` using the same
+ * match function the renderer uses (multi-field haystacks per item).
+ */
+export function rectifyPromotedSelectionIndex(
+  filteredKeys: string[],
+  selectedKey: string | undefined
+): number {
+  if (filteredKeys.length === 0) {
+    return 0
+  }
+  if (!selectedKey) {
+    return 0
+  }
+  const next = filteredKeys.indexOf(selectedKey)
+  return next < 0 ? 0 : next
+}

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -629,4 +629,72 @@ describe('log Ink view model', () => {
       expect(state.selectedWorktreeFileIndex).toBe(0)
     })
   })
+
+  describe('promoted-view selection rectification on filter (P4.5)', () => {
+    it('uses the supplied snapshot to preserve the cursor on the same item', () => {
+      let state = createLogInkState(rows)
+      state = { ...state, selectedBranchIndex: 1 }
+
+      state = applyLogInkAction(state, {
+        type: 'appendFilter',
+        value: 'feat',
+        promotedSelections: { branchIndex: 0, tagIndex: 0, stashIndex: 0 },
+      })
+
+      expect(state.filter).toBe('feat')
+      expect(state.selectedBranchIndex).toBe(0)
+    })
+
+    it('snaps each promoted selection to result[0] when the snapshot says so', () => {
+      let state = createLogInkState(rows)
+      state = {
+        ...state,
+        selectedBranchIndex: 5,
+        selectedTagIndex: 3,
+        selectedStashIndex: 2,
+      }
+
+      state = applyLogInkAction(state, {
+        type: 'appendFilter',
+        value: 'q',
+        promotedSelections: { branchIndex: 0, tagIndex: 0, stashIndex: 0 },
+      })
+
+      expect(state.selectedBranchIndex).toBe(0)
+      expect(state.selectedTagIndex).toBe(0)
+      expect(state.selectedStashIndex).toBe(0)
+    })
+
+    it('falls back to "always snap to 0" when no snapshot is supplied', () => {
+      let state = createLogInkState(rows)
+      state = { ...state, selectedBranchIndex: 4, selectedTagIndex: 7 }
+
+      state = applyLogInkAction(state, { type: 'appendFilter', value: 'x' })
+
+      expect(state.selectedBranchIndex).toBe(0)
+      expect(state.selectedTagIndex).toBe(0)
+    })
+
+    it('lets the snapshot move the cursor to a non-zero index in the filtered list', () => {
+      let state = createLogInkState(rows)
+      state = { ...state, filter: 'alpha', selectedBranchIndex: 0 }
+
+      state = applyLogInkAction(state, {
+        type: 'backspaceFilter',
+        promotedSelections: { branchIndex: 2 },
+      })
+
+      expect(state.filter).toBe('alph')
+      expect(state.selectedBranchIndex).toBe(2)
+    })
+
+    it('keeps the cursor put when the filter string did not actually change', () => {
+      let state = createLogInkState(rows)
+      state = { ...state, filter: 'foo', selectedBranchIndex: 3 }
+
+      state = applyLogInkAction(state, { type: 'setFilter', value: 'foo' })
+
+      expect(state.selectedBranchIndex).toBe(3)
+    })
+  })
 })

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -5,6 +5,7 @@ import {
   applyCommitComposeAction,
   createCommitComposeState,
 } from './commitCompose'
+import { PromotedSelectionsSnapshot } from './inkSelectionRectify'
 
 export type LogInkFocus = 'sidebar' | 'commits' | 'detail'
 
@@ -98,10 +99,10 @@ export type LogInkState = {
 
 export type LogInkAction =
   | { type: 'appendRows'; rows: GitLogRow[] }
-  | { type: 'appendFilter'; value: string }
-  | { type: 'backspaceFilter' }
-  | { type: 'clearFilter' }
-  | { type: 'clearFilterText' }
+  | { type: 'appendFilter'; value: string; promotedSelections?: PromotedSelectionsSnapshot }
+  | { type: 'backspaceFilter'; promotedSelections?: PromotedSelectionsSnapshot }
+  | { type: 'clearFilter'; promotedSelections?: PromotedSelectionsSnapshot }
+  | { type: 'clearFilterText'; promotedSelections?: PromotedSelectionsSnapshot }
   | { type: 'commitCompose'; action: CommitComposeAction }
   | { type: 'focusNext' }
   | { type: 'focusPrevious' }
@@ -118,7 +119,7 @@ export type LogInkAction =
   | { type: 'pageDetailPreview'; delta: number; previewLineCount: number }
   | { type: 'pageWorktreeDiff'; delta: number; lineCount: number }
   | { type: 'previousSidebarTab' }
-  | { type: 'setFilter'; value: string }
+  | { type: 'setFilter'; value: string; promotedSelections?: PromotedSelectionsSnapshot }
   | { type: 'setActiveView'; value: LogInkView }
   | { type: 'pushView'; value: LogInkView }
   | { type: 'popView' }
@@ -322,14 +323,25 @@ function withReplacedView(state: LogInkState, value: LogInkView): LogInkState {
   }
 }
 
-function withFilter(state: LogInkState, filter: string): LogInkState {
+function withFilter(
+  state: LogInkState,
+  filter: string,
+  promotedSelections?: PromotedSelectionsSnapshot
+): LogInkState {
   const filteredCommits = filterCommits(state.commits, filter)
-  // P4.5: snap promoted-view selections to the top of the filtered list
-  // when the filter changes. Pre-filter cursor positions reference indexes
-  // that may not exist in the filtered view, so resetting to 0 keeps
-  // navigation predictable. The runtime passes filtered counts into
-  // `moveBranch` / `moveTag` / `moveStash` so j/k stay live.
+  // P4.5: rectify promoted-view selections when the filter changes. Prefer
+  // the runtime-supplied snapshot — which preserves the cursor on the same
+  // item when it's still in the filtered list and only snaps to result[0]
+  // when the previously-selected item dropped out. Falls back to the older
+  // "snap to 0" behavior when no snapshot was provided (test paths,
+  // dispatchers without context).
   const filterChanged = state.filter !== filter
+  const branchIndex = promotedSelections?.branchIndex ??
+    (filterChanged ? 0 : state.selectedBranchIndex)
+  const tagIndex = promotedSelections?.tagIndex ??
+    (filterChanged ? 0 : state.selectedTagIndex)
+  const stashIndex = promotedSelections?.stashIndex ??
+    (filterChanged ? 0 : state.selectedStashIndex)
 
   return {
     ...state,
@@ -337,9 +349,9 @@ function withFilter(state: LogInkState, filter: string): LogInkState {
     filteredCommits,
     selectedIndex: clampIndex(state.selectedIndex, filteredCommits.length),
     selectedFileIndex: 0,
-    selectedBranchIndex: filterChanged ? 0 : state.selectedBranchIndex,
-    selectedTagIndex: filterChanged ? 0 : state.selectedTagIndex,
-    selectedStashIndex: filterChanged ? 0 : state.selectedStashIndex,
+    selectedBranchIndex: branchIndex,
+    selectedTagIndex: tagIndex,
+    selectedStashIndex: stashIndex,
     diffPreviewOffset: 0,
     pendingKey: undefined,
   }
@@ -453,18 +465,18 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
     case 'appendRows':
       return appendRows(state, action.rows)
     case 'appendFilter':
-      return withFilter(state, `${state.filter}${action.value}`)
+      return withFilter(state, `${state.filter}${action.value}`, action.promotedSelections)
     case 'backspaceFilter':
-      return withFilter(state, state.filter.slice(0, -1))
+      return withFilter(state, state.filter.slice(0, -1), action.promotedSelections)
     case 'clearFilter':
       return withFilter({
         ...state,
         filterMode: false,
-      }, '')
+      }, '', action.promotedSelections)
     case 'clearFilterText':
       // Clears the filter input but stays in filterMode so the user can
       // keep typing. P2.4 / P4.4: pairs with the two-stage Esc semantics.
-      return withFilter(state, '')
+      return withFilter(state, '', action.promotedSelections)
     case 'commitCompose':
       return {
         ...state,
@@ -625,7 +637,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         pendingKey: undefined,
       }
     case 'setFilter':
-      return withFilter(state, action.value)
+      return withFilter(state, action.value, action.promotedSelections)
     case 'setActiveView':
       return withReplacedView(state, action.value)
     case 'pushView':


### PR DESCRIPTION
## Summary

Closes part of #756 (P4.5). The branches / tags / stash views were snapping the cursor to result[0] on **every** filter keystroke — keeping the index in range but losing the user's place even when the previously-selected item was still in the filtered result. The spec asks for the smarter behavior: preserve cursor when the item is still visible, snap to result[0] only when it dropped out.

## What changed

- **New pure helper** \`rectifyPromotedSelectionIndex(filteredKeys, selectedKey)\` in \`inkSelectionRectify.ts\` — maps a previously-selected key into its new index in the filtered list, falling back to 0 when the key is missing.
- **Action shapes**: \`appendFilter\` / \`backspaceFilter\` / \`clearFilter\` / \`clearFilterText\` / \`setFilter\` gained an optional \`promotedSelections\` field carrying precomputed branch / tag / stash indexes.
- **Reducer**: \`withFilter\` applies the snapshot when present and falls back to the legacy "snap to 0 on filter change" when not — keeping unit-test paths that dispatch the reducer directly safe.
- **Runtime**: intercepts filter actions before dispatch, predicts the next filter via \`predictNextFilter\`, runs the same \`matchesPromotedFilter\` the surfaces use against context items, identifies the previously-selected key from the current filtered list + \`selectedBranchIndex\` / etc., and attaches the snapshot. Reducer never needs context items.

## Result

Typing into the filter no longer rips the cursor away from a still-visible branch/tag/stash. Backspacing the filter restores the cursor to the same item if it's part of the broader filtered list. When the item genuinely drops out, the cursor still snaps to result[0] as before.

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run test:jest\` — 711/711 (5 new in \`inkSelectionRectify.test.ts\`, 5 reducer cases covering snapshot vs fallback)
- [x] \`npm run build\`
- [x] \`npm run test:cli\` — 10/10 packaged-CLI smoke checks
- [x] \`npm run release:dry-run\`
- [ ] Manual: \`coco ui\` → \`g b\`, arrow to a non-first branch, type \`/feat\` and watch the cursor stay on the same branch (or follow it as the filtered list shrinks)
- [ ] Manual: type until the selected branch falls out of the result; verify cursor jumps to result[0]
- [ ] Manual: backspace the filter and confirm the cursor lands back on the same branch in the broader list

🤖 Generated with [Claude Code](https://claude.com/claude-code)