### PR TITLE
feat(log-tui): P5.1 OSC 8 hyperlinks + P5.2 truecolor fallback

### DIFF
--- a/src/commands/log/inkColorSupport.test.ts
+++ b/src/commands/log/inkColorSupport.test.ts
@@ -1,0 +1,59 @@
+import { getColorLevel, presetUsesTrueColor } from './inkColorSupport'
+
+describe('log Ink color support (P5.2)', () => {
+  describe('getColorLevel', () => {
+    it('returns mono when NO_COLOR is set', () => {
+      expect(getColorLevel({ NO_COLOR: '1', COLORTERM: 'truecolor' })).toBe('mono')
+    })
+
+    it('returns mono for TERM=dumb', () => {
+      expect(getColorLevel({ TERM: 'dumb' })).toBe('mono')
+    })
+
+    it('honors FORCE_COLOR overrides for every level', () => {
+      expect(getColorLevel({ FORCE_COLOR: '0' })).toBe('mono')
+      expect(getColorLevel({ FORCE_COLOR: '1' })).toBe('16')
+      expect(getColorLevel({ FORCE_COLOR: '2' })).toBe('256')
+      expect(getColorLevel({ FORCE_COLOR: '3' })).toBe('truecolor')
+    })
+
+    it('returns truecolor when COLORTERM advertises it', () => {
+      expect(getColorLevel({ COLORTERM: 'truecolor' })).toBe('truecolor')
+      expect(getColorLevel({ COLORTERM: '24bit' })).toBe('truecolor')
+      expect(getColorLevel({ COLORTERM: 'TRUECOLOR' })).toBe('truecolor')
+    })
+
+    it('returns truecolor for known terminal emulators', () => {
+      expect(getColorLevel({ TERM_PROGRAM: 'iTerm.app' })).toBe('truecolor')
+      expect(getColorLevel({ TERM_PROGRAM: 'WezTerm' })).toBe('truecolor')
+      expect(getColorLevel({ TERM_PROGRAM: 'vscode' })).toBe('truecolor')
+      expect(getColorLevel({ TERM_PROGRAM: 'ghostty' })).toBe('truecolor')
+      expect(getColorLevel({ KITTY_WINDOW_ID: '1' })).toBe('truecolor')
+      expect(getColorLevel({ TERM: 'xterm-kitty' })).toBe('truecolor')
+      expect(getColorLevel({ WT_SESSION: 'abcd' })).toBe('truecolor')
+    })
+
+    it('returns 256 for xterm-256color and similar', () => {
+      expect(getColorLevel({ TERM: 'xterm-256color' })).toBe('256')
+      expect(getColorLevel({ TERM: 'screen-256color' })).toBe('256')
+    })
+
+    it('falls back to 16 for unknown terminals', () => {
+      expect(getColorLevel({ TERM: 'xterm' })).toBe('16')
+      expect(getColorLevel({})).toBe('16')
+    })
+  })
+
+  describe('presetUsesTrueColor', () => {
+    it('flags hex-color presets', () => {
+      expect(presetUsesTrueColor('catppuccin')).toBe(true)
+      expect(presetUsesTrueColor('gruvbox')).toBe(true)
+    })
+
+    it('returns false for ANSI-named or undefined presets', () => {
+      expect(presetUsesTrueColor('default')).toBe(false)
+      expect(presetUsesTrueColor('monochrome')).toBe(false)
+      expect(presetUsesTrueColor(undefined)).toBe(false)
+    })
+  })
+})

--- a/src/commands/log/inkColorSupport.ts
+++ b/src/commands/log/inkColorSupport.ts
@@ -1,0 +1,80 @@
+/**
+ * Explicit color-level detection for the Ink TUI (P5.2).
+ *
+ * Chalk already approximates hex colors when the terminal can't render
+ * truecolor — but we want an explicit signal so the catppuccin / gruvbox
+ * presets (which use hex) can fall back to the ANSI-named `default` preset
+ * cleanly on minimal SSH sessions, instead of relying on chalk's
+ * heuristics. Users who set `NO_COLOR` or pick the `monochrome` preset
+ * still get the manual override.
+ *
+ * Levels (matching the chalk taxonomy):
+ *   - 'mono'      → no ANSI escapes at all (NO_COLOR / TERM=dumb)
+ *   - '16'        → standard 16-color ANSI palette
+ *   - '256'       → xterm-256color
+ *   - 'truecolor' → 24-bit RGB (COLORTERM=truecolor or known terminals)
+ */
+
+export type ColorLevel = 'mono' | '16' | '256' | 'truecolor'
+
+export type ColorEnv = {
+  NO_COLOR?: string
+  FORCE_COLOR?: string
+  COLORTERM?: string
+  TERM?: string
+  TERM_PROGRAM?: string
+  KITTY_WINDOW_ID?: string
+  WT_SESSION?: string
+}
+
+export function getColorLevel(env: ColorEnv = process.env): ColorLevel {
+  if (env.NO_COLOR) return 'mono'
+
+  switch (env.FORCE_COLOR) {
+    case '0':
+      return 'mono'
+    case '1':
+      return '16'
+    case '2':
+      return '256'
+    case '3':
+      return 'truecolor'
+  }
+
+  const colorterm = env.COLORTERM?.toLowerCase()
+  if (colorterm === 'truecolor' || colorterm === '24bit') {
+    return 'truecolor'
+  }
+
+  // Modern terminal emulators that publicly advertise truecolor support.
+  if (env.KITTY_WINDOW_ID || env.TERM === 'xterm-kitty') {
+    return 'truecolor'
+  }
+  if (env.WT_SESSION) {
+    return 'truecolor'
+  }
+  switch (env.TERM_PROGRAM) {
+    case 'iTerm.app':
+    case 'WezTerm':
+    case 'vscode':
+    case 'ghostty':
+    case 'Hyper':
+      return 'truecolor'
+  }
+
+  if (env.TERM === 'dumb') return 'mono'
+  if (env.TERM?.includes('256color')) return '256'
+
+  return '16'
+}
+
+const TRUECOLOR_PRESETS = new Set<string>(['catppuccin', 'gruvbox'])
+
+/**
+ * `true` when the named preset relies on hex colors that look best under
+ * 24-bit RGB. Used by `createLogInkTheme` to decide whether to downgrade
+ * to the ANSI-named `default` palette on lower-capability terminals.
+ */
+export function presetUsesTrueColor(preset: string | undefined): boolean {
+  return preset !== undefined && TRUECOLOR_PRESETS.has(preset)
+}

--- a/src/commands/log/inkHyperlinks.test.ts
+++ b/src/commands/log/inkHyperlinks.test.ts
@@ -1,0 +1,73 @@
+import { formatHyperlink, supportsHyperlinks } from './inkHyperlinks'
+
+const OSC_8_OPEN = ']8;;'
+const ST = '\\'
+
+describe('log Ink hyperlinks (P5.1)', () => {
+  describe('supportsHyperlinks', () => {
+    it('returns true for kitty (TERM=xterm-kitty or KITTY_WINDOW_ID set)', () => {
+      expect(supportsHyperlinks({ TERM: 'xterm-kitty' })).toBe(true)
+      expect(supportsHyperlinks({ KITTY_WINDOW_ID: '1' })).toBe(true)
+    })
+
+    it('returns true for Windows Terminal (WT_SESSION set)', () => {
+      expect(supportsHyperlinks({ WT_SESSION: 'abcd' })).toBe(true)
+    })
+
+    it('returns true for Ghostty (GHOSTTY_RESOURCES_DIR set or TERM_PROGRAM=ghostty)', () => {
+      expect(supportsHyperlinks({ GHOSTTY_RESOURCES_DIR: '/x' })).toBe(true)
+      expect(supportsHyperlinks({ TERM_PROGRAM: 'ghostty' })).toBe(true)
+    })
+
+    it('returns true for the curated TERM_PROGRAM list', () => {
+      expect(supportsHyperlinks({ TERM_PROGRAM: 'iTerm.app' })).toBe(true)
+      expect(supportsHyperlinks({ TERM_PROGRAM: 'WezTerm' })).toBe(true)
+      expect(supportsHyperlinks({ TERM_PROGRAM: 'vscode' })).toBe(true)
+      expect(supportsHyperlinks({ TERM_PROGRAM: 'mintty' })).toBe(true)
+      expect(supportsHyperlinks({ TERM_PROGRAM: 'Hyper' })).toBe(true)
+    })
+
+    it('returns false for Apple Terminal and unknown terminals', () => {
+      expect(supportsHyperlinks({ TERM_PROGRAM: 'Apple_Terminal' })).toBe(false)
+      expect(supportsHyperlinks({})).toBe(false)
+      expect(supportsHyperlinks({ TERM: 'screen' })).toBe(false)
+    })
+
+    it('honors NO_COLOR by suppressing hyperlinks', () => {
+      expect(supportsHyperlinks({ NO_COLOR: '1', TERM_PROGRAM: 'iTerm.app' })).toBe(false)
+    })
+
+    it('lets FORCE_HYPERLINK override detection', () => {
+      expect(supportsHyperlinks({ FORCE_HYPERLINK: '1' })).toBe(true)
+      expect(supportsHyperlinks({ FORCE_HYPERLINK: '1', TERM_PROGRAM: 'Apple_Terminal' })).toBe(true)
+      expect(supportsHyperlinks({ FORCE_HYPERLINK: '0', TERM_PROGRAM: 'iTerm.app' })).toBe(false)
+    })
+  })
+
+  describe('formatHyperlink', () => {
+    const supportingEnv = { TERM_PROGRAM: 'iTerm.app' }
+    const plainEnv = { TERM_PROGRAM: 'Apple_Terminal' }
+
+    it('wraps text in OSC 8 when the terminal supports hyperlinks', () => {
+      const out = formatHyperlink('PR #738', 'https://github.com/owner/repo/pull/738', supportingEnv)
+      expect(out).toBe(`${OSC_8_OPEN}https://github.com/owner/repo/pull/738${ST}PR #738${OSC_8_OPEN}${ST}`)
+    })
+
+    it('returns plain text when the terminal does not support hyperlinks', () => {
+      expect(formatHyperlink('PR #738', 'https://github.com/owner/repo/pull/738', plainEnv))
+        .toBe('PR #738')
+    })
+
+    it('returns plain text when the URL is missing or empty', () => {
+      expect(formatHyperlink('abc1234', undefined, supportingEnv)).toBe('abc1234')
+      expect(formatHyperlink('abc1234', '', supportingEnv)).toBe('abc1234')
+    })
+
+    it('preserves the original visible text content', () => {
+      const out = formatHyperlink('main', 'https://example.com/main', supportingEnv)
+      // The visible text (between the open OSC and the close OSC) must be
+      // verbatim — width math elsewhere relies on it.
+      expect(out).toContain(`${ST}main${OSC_8_OPEN}`)
+    })
+  })
+})

--- a/src/commands/log/inkHyperlinks.ts
+++ b/src/commands/log/inkHyperlinks.ts
@@ -1,0 +1,92 @@
+/**
+ * OSC 8 hyperlink helpers for the Ink TUI (P5.1).
+ *
+ * Modern terminals (iTerm2, kitty, WezTerm, Ghostty, recent VS Code, Windows
+ * Terminal, Alacritty, foot) recognise the OSC 8 escape sequence and turn
+ * the wrapped text into a clickable / Cmd-clickable link. Older or
+ * minimal terminals ignore the sequence — but a few of them render the
+ * escape codes as raw garbage instead, so we feature-detect and fall back
+ * to plain text rather than always emitting.
+ *
+ * Sequence:  ESC ] 8 ; ; <url> ESC \  <text>  ESC ] 8 ; ;  ESC \
+ */
+
+const ESC = '\u001b'
+const OSC_PREFIX = `${ESC}]8;;`
+const ST = `${ESC}\\`
+
+export type HyperlinkEnv = {
+  NO_COLOR?: string
+  FORCE_HYPERLINK?: string
+  TERM?: string
+  TERM_PROGRAM?: string
+  KITTY_WINDOW_ID?: string
+  WT_SESSION?: string
+  GHOSTTY_RESOURCES_DIR?: string
+}
+
+/**
+ * Detect whether the host terminal will likely render OSC 8 hyperlinks.
+ *
+ * Conservative: only returns true for terminals that have publicly
+ * confirmed support. Unknown terminals fall back to plain text — making
+ * the wrap a no-op rather than risking garbage output. Set
+ * `FORCE_HYPERLINK=1` to override during testing.
+ */
+export function supportsHyperlinks(env: HyperlinkEnv = process.env): boolean {
+  if (env.FORCE_HYPERLINK) {
+    return env.FORCE_HYPERLINK !== '0'
+  }
+
+  // Honor NO_COLOR for parity with our color handling — users who opt out
+  // of color formatting generally want a clean plain-text output too.
+  if (env.NO_COLOR) {
+    return false
+  }
+
+  // kitty publishes either of these markers.
+  if (env.KITTY_WINDOW_ID || env.TERM === 'xterm-kitty') {
+    return true
+  }
+
+  // Windows Terminal sets WT_SESSION.
+  if (env.WT_SESSION) {
+    return true
+  }
+
+  // Ghostty exposes its resources dir.
+  if (env.GHOSTTY_RESOURCES_DIR) {
+    return true
+  }
+
+  switch (env.TERM_PROGRAM) {
+    case 'iTerm.app':
+    case 'WezTerm':
+    case 'vscode':
+    case 'ghostty':
+    case 'mintty':
+    case 'Hyper':
+      return true
+    default:
+      return false
+  }
+}
+
+/**
+ * Wrap `text` in an OSC 8 hyperlink when the host terminal supports it,
+ * otherwise return the plain text unchanged. Empty / missing url falls
+ * back to the plain text.
+ */
+export function formatHyperlink(
+  text: string,
+  url: string | undefined,
+  env: HyperlinkEnv = process.env
+): string {
+  if (!url) {
+    return text
+  }
+  if (!supportsHyperlinks(env)) {
+    return text
+  }
+  return `${OSC_PREFIX}${url}${ST}${text}${OSC_PREFIX}${ST}`
+}

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -73,6 +73,7 @@ import {
   getLogInkHelpSections,
 } from './inkKeymap'
 import { substituteGraphChars } from './inkGraphChars'
+import { formatHyperlink } from './inkHyperlinks'
 import { LogInkInputKey, getLogInkInputEvents } from './inkInput'
 import { hasSeenOnboarding, markOnboardingSeen } from './inkOnboarding'
 import {
@@ -109,7 +110,7 @@ import {
 } from './inkViewModel'
 import { startInteractiveLog } from './interactive'
 import { GitOperationOverview, getGitOperationOverview } from './operationData'
-import { ProviderOverview, getProviderOverview } from './providerData'
+import { ProviderOverview, ProviderRepository, buildProviderUrl, getProviderOverview } from './providerData'
 import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
 import { StashOverview, getStashOverview } from './stashData'
 import { revertFile, stageFile, unstageFile } from './statusActions'
@@ -1713,11 +1714,28 @@ function renderTagsSurface(
         const index = startIndex + offset
         const isSelected = index === selected
         const cursor = isSelected ? '>' : ' '
+        // P5.1 — link the tag name to its GitHub tree page when we know
+        // the remote. Truncation runs on the visible (pre-OSC) text;
+        // formatHyperlink wraps just the tag name, leaving width math
+        // intact.
+        const url = buildRefUrl(context.provider?.repository, tag.name)
+        const namePadded = tag.name.padEnd(20)
+        const lineText = truncate(`${cursor} ${namePadded} ${tag.subject}`, 140)
+        if (!url || lineText.indexOf(namePadded) < 0) {
+          return h(Text, {
+            key: `tag-${index}`,
+            bold: isSelected,
+            dimColor: !isSelected,
+          }, lineText)
+        }
+        const linkStart = lineText.indexOf(namePadded)
+        const before = lineText.slice(0, linkStart)
+        const after = lineText.slice(linkStart + namePadded.length)
         return h(Text, {
           key: `tag-${index}`,
           bold: isSelected,
           dimColor: !isSelected,
-        }, truncate(`${cursor} ${tag.name.padEnd(20)} ${tag.subject}`, 140))
+        }, before, formatHyperlink(namePadded, url), after)
       })
 
   return h(Box, {
@@ -2060,18 +2078,37 @@ function renderHistoryInspector(
   }
 
   const statLine = `${detail.stats.filesChanged} files  +${detail.stats.insertions}/-${detail.stats.deletions}`
-  const headerLines = [
-    detail.message,
-    '',
-    `Commit: ${compactHash(detail.hash)}`,
-    `Author: ${detail.author}`,
-    `Date: ${detail.date}`,
-    detail.refs.length ? `Refs: ${detail.refs.join(', ')}` : 'Refs: none',
-    statLine,
-    '',
-    ...(detail.body ? detail.body.split('\n').slice(0, 6) : ['No commit body.']),
-    '',
-    'Changed files:',
+  // P5.1 — link the commit hash and each ref out to GitHub when we know
+  // the remote. OSC 8 escapes embed inline; supportsHyperlinks() decides
+  // whether to wrap or fall through to plain text.
+  const repository = context.provider?.repository
+  const commitLink = formatHyperlink(
+    compactHash(detail.hash),
+    buildCommitUrl(repository, detail.hash)
+  )
+  const refNodes = detail.refs.length
+    ? renderInspectorRefs(h, Text, detail.refs, repository)
+    : null
+
+  const headerNodes: ReactTypes.ReactElement[] = [
+    h(Text, { key: 'detail-msg' }, truncate(detail.message, width - 4)),
+    h(Text, { key: 'detail-spacer-1' }, ''),
+    h(Text, { key: 'detail-commit', dimColor: true }, 'Commit: ', commitLink),
+    h(Text, { key: 'detail-author', dimColor: true }, truncate(`Author: ${detail.author}`, width - 4)),
+    h(Text, { key: 'detail-date', dimColor: true }, truncate(`Date: ${detail.date}`, width - 4)),
+    refNodes
+      ? h(Text, { key: 'detail-refs', dimColor: true }, 'Refs: ', ...refNodes)
+      : h(Text, { key: 'detail-refs', dimColor: true }, 'Refs: none'),
+    h(Text, { key: 'detail-stat', dimColor: true }, truncate(statLine, width - 4)),
+    h(Text, { key: 'detail-spacer-2' }, ''),
+    ...(detail.body ? detail.body.split('\n').slice(0, 6) : ['No commit body.']).map((line, index) =>
+      h(Text, {
+        key: `detail-body-${index}`,
+        dimColor: true,
+      }, truncate(line, width - 4))
+    ),
+    h(Text, { key: 'detail-spacer-3' }, ''),
+    h(Text, { key: 'detail-files-title' }, 'Changed files:'),
   ]
 
   const fileListMaxRows = Math.max(4, Math.min(detail.files.length, 10))
@@ -2096,15 +2133,60 @@ function renderHistoryInspector(
     paddingX: 1,
   },
   h(Text, { bold: true }, panelTitle('Inspector', focused)),
-  ...headerLines.map((line, index) => h(Text, {
-    key: `detail-header-${index}`,
-    dimColor: index > 1 && line !== 'Changed files:',
-  }, truncate(line, width - 4))),
+  ...headerNodes,
   ...fileListNodes,
   ...trailerLines.map((line, index) => h(Text, {
     key: `detail-trailer-${index}`,
     dimColor: index > 0,
   }, truncate(line, width - 4))))
+}
+
+/**
+ * Build a commit URL for the repo when GitHub provider info is available.
+ * Returns undefined for unsupported remotes — formatHyperlink falls through
+ * to plain text in that case.
+ */
+function buildCommitUrl(
+  repository: ProviderRepository | undefined,
+  hash: string
+): string | undefined {
+  if (!repository) return undefined
+  return buildProviderUrl(repository, { type: 'commit', commit: hash })
+}
+
+/**
+ * Build a branch URL for a ref name. Strips the `HEAD -> ` and `tag: `
+ * prefixes git decoration uses. For everything else we treat the ref as a
+ * branch — GitHub's `/tree/<ref>` resolves both branches and tags.
+ */
+function buildRefUrl(
+  repository: ProviderRepository | undefined,
+  ref: string
+): string | undefined {
+  if (!repository) return undefined
+  const stripped = ref.replace(/^HEAD -> /, '').replace(/^tag: /, '').trim()
+  if (!stripped) return undefined
+  return buildProviderUrl(repository, { type: 'branch', branch: stripped })
+}
+
+/**
+ * Render `refs` as a comma-separated sequence of <Text> fragments, each
+ * wrapped in OSC 8 (no-op when the terminal can't render hyperlinks).
+ */
+function renderInspectorRefs(
+  h: typeof ReactTypes.createElement,
+  Text: LogInkComponents['Text'],
+  refs: string[],
+  repository: ProviderRepository | undefined
+): ReactTypes.ReactElement[] {
+  const out: ReactTypes.ReactElement[] = []
+  refs.forEach((ref, index) => {
+    if (index > 0) {
+      out.push(h(Text, { key: `ref-sep-${index}` }, ', '))
+    }
+    out.push(h(Text, { key: `ref-${index}` }, formatHyperlink(ref, buildRefUrl(repository, ref))))
+  })
+  return out
 }
 
 function renderCommitDiffDetail(

--- a/src/commands/log/inkTheme.test.ts
+++ b/src/commands/log/inkTheme.test.ts
@@ -25,6 +25,7 @@ describe('log Ink theme', () => {
       colors: {
         accent: '#ffffff',
       },
+      env: { COLORTERM: 'truecolor' },
       noColor: false,
       preset: 'catppuccin',
       term: 'xterm-256color',
@@ -40,5 +41,40 @@ describe('log Ink theme', () => {
 
     expect(theme.noColor).toBe(true)
     expect(theme.colors).toEqual({})
+  })
+
+  describe('truecolor fallback (P5.2)', () => {
+    it('downgrades catppuccin to default ANSI colors on a 16-color terminal', () => {
+      const theme = createLogInkTheme({
+        env: { TERM: 'xterm' },
+        preset: 'catppuccin',
+      })
+      // Hex tokens (#89b4fa etc.) fall back to ANSI named colors.
+      expect(theme.colors.accent).toBe('cyan')
+      expect(theme.colors.danger).toBe('red')
+    })
+
+    it('downgrades gruvbox the same way', () => {
+      const theme = createLogInkTheme({
+        env: { TERM: 'xterm' },
+        preset: 'gruvbox',
+      })
+      expect(theme.colors.accent).toBe('cyan')
+    })
+
+    it('keeps the hex preset when the terminal advertises truecolor', () => {
+      const theme = createLogInkTheme({
+        env: { COLORTERM: 'truecolor' },
+        preset: 'catppuccin',
+      })
+      expect(theme.colors.accent).toBe('#89b4fa')
+    })
+
+    it('leaves the default preset alone regardless of color level', () => {
+      const lowColor = createLogInkTheme({ env: { TERM: 'xterm' }, preset: 'default' })
+      const highColor = createLogInkTheme({ env: { COLORTERM: 'truecolor' }, preset: 'default' })
+      expect(lowColor.colors.accent).toBe('cyan')
+      expect(highColor.colors.accent).toBe('cyan')
+    })
   })
 })

--- a/src/commands/log/inkTheme.ts
+++ b/src/commands/log/inkTheme.ts
@@ -1,3 +1,5 @@
+import { ColorEnv, getColorLevel, presetUsesTrueColor } from './inkColorSupport'
+
 export type LogInkBorderStyle = 'round' | 'single' | 'classic'
 export type LogInkThemePreset = 'default' | 'monochrome' | 'catppuccin' | 'gruvbox'
 
@@ -33,6 +35,12 @@ export type LogInkTheme = {
 export type CreateLogInkThemeOptions = LogInkThemeConfig & {
   noColor?: boolean
   term?: string
+  /**
+   * Snapshot of the env used for color-level detection (P5.2). Defaults to
+   * `process.env`. Tests pass a synthetic env to keep results deterministic
+   * across CI runners and developer machines.
+   */
+  env?: ColorEnv
 }
 
 const THEME_PRESET_COLORS: Record<Exclude<LogInkThemePreset, 'monochrome'>, LogInkThemeColors> = {
@@ -92,7 +100,15 @@ export function createLogInkTheme(options: CreateLogInkThemeOptions = {}): LogIn
   const noColor = (options.noColor ?? Boolean(process.env.NO_COLOR)) ||
     options.preset === 'monochrome'
   const ascii = options.ascii ?? shouldUseAscii(options.term ?? process.env.TERM)
-  const preset = options.preset && options.preset !== 'monochrome' ? options.preset : 'default'
+  const requestedPreset = options.preset && options.preset !== 'monochrome' ? options.preset : 'default'
+  // P5.2 — gracefully downgrade hex presets (catppuccin / gruvbox) when
+  // the host terminal can't render truecolor. Chalk approximates hex in
+  // those modes anyway, but the default preset's ANSI-named palette
+  // renders far more faithfully on 16-color terminals.
+  const colorLevel = getColorLevel(options.env ?? process.env)
+  const preset = !noColor && presetUsesTrueColor(requestedPreset) && colorLevel !== 'truecolor'
+    ? 'default'
+    : requestedPreset
   const colors = noColor
     ? {}
     : {


### PR DESCRIPTION
## Summary

Two additive polish items from #756 priority 5 — they're small individually and share no surfaces, so they ship together per the issue's PR plan.

### P5.1 — OSC 8 hyperlinks

Modern terminals (iTerm2, kitty, WezTerm, Ghostty, recent VS Code, Windows Terminal, Hyper, mintty) recognise the OSC 8 escape sequence and turn the wrapped text into Cmd-clickable links. We feature-detect via env vars and fall back to plain text on terminals that don't support it — no risk of garbage output on legacy hosts.

- New \`inkHyperlinks.ts\` with \`supportsHyperlinks(env)\` + \`formatHyperlink(text, url, env)\`. Conservative detection — unknown terminals get plain text. \`FORCE_HYPERLINK=1/0\` overrides.
- **History inspector**: commit hash links to the GitHub commit URL; each ref links to \`/tree/<ref>\` (works for branches and tags). The \`HEAD -> \` and \`tag: \` decorations are stripped before linking.
- **Tags surface**: tag name column wraps in an OSC 8 link to the tag's tree page. Truncation runs on the visible text first; only the name fragment gets wrapped, so width math stays intact.
- All targets reuse existing \`provider.repository\` + \`buildProviderUrl\` — nothing new in the data layer.

### P5.2 — truecolor / 256 / 16 / mono detection

The catppuccin and gruvbox presets use hex colors that look best at 24-bit RGB. Chalk approximates them on lower-capability terminals, but the result is fuzzy on 16-color SSH sessions. This adds an explicit color-level signal and silently downgrades hex presets to the ANSI-named \`default\` palette when the terminal can't render truecolor.

- New \`inkColorSupport.ts\` with \`getColorLevel(env)\` honouring \`NO_COLOR\`, \`FORCE_COLOR=0..3\`, \`COLORTERM=truecolor|24bit\`, and the same curated list of modern emulators.
- \`createLogInkTheme\` consults the level: hex preset on sub-truecolor terminal → fall back to \`default\` preset's named palette.
- \`createLogInkTheme\` gained an optional \`env\` option for testability — prevents the new behavior from depending on the test runner's host environment.

The user-controlled \`monochrome\` preset and \`NO_COLOR\` still take precedence as the manual escape hatches.

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run test:jest\` — 725/725 (23 new: 11 hyperlinks, 8 color support, 4 theme fallback)
- [x] \`npm run build\`
- [x] \`npm run test:cli\` — 10/10 packaged-CLI smoke checks
- [x] \`npm run release:dry-run\`
- [ ] Manual (iTerm2 / WezTerm / kitty): \`coco ui\` → arrow to a commit → confirm hash + refs in the inspector are Cmd-clickable
- [ ] Manual (Apple Terminal): same flow, confirm plain text renders cleanly with no escape garbage
- [ ] Manual (\`TERM=xterm coco ui --theme=catppuccin\`): confirm the palette falls back to ANSI cyan/red etc. instead of fuzzy hex approximation

Closes the rest of #756 P5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)