### PR TITLE
feat: wiki refresh, coco doctor, and .coco.json config support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 dist/**/*
 
 # ignore commit-copilot project config
+.coco.json
 .coco.config.json
 
 # build reports
@@ -51,3 +52,6 @@ AGENTS.md
 
 package-lock.json
 commitlint.config.js
+
+# Internal specs, audits, and design docs
+specs/

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -86,9 +86,15 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
       llm,
     })
 
+    const splitMode = INTERACTIVE ? 'interactive' : (config.mode || 'stdout')
+
     await handleResult({
       result: splitResult,
-      mode: config.mode || 'stdout',
+      mode: splitMode as 'interactive' | 'stdout',
+      interactiveModeCallback: async (result) => {
+        logger.log(result)
+        logSuccess()
+      },
     })
     logLlmTelemetrySummary(logger, 'commit')
     return

--- a/src/commands/doctor/checks.ts
+++ b/src/commands/doctor/checks.ts
@@ -1,0 +1,282 @@
+import * as fs from 'fs'
+import { Config } from '../../lib/config/types'
+
+export type DiagnosticSeverity = 'error' | 'warn' | 'info'
+
+export interface Diagnostic {
+  severity: DiagnosticSeverity
+  message: string
+  fix?: string
+  autoFix?: (config: Record<string, unknown>) => void
+}
+
+/**
+ * Deprecated or renamed model identifiers that should be updated.
+ */
+const MODEL_UPGRADES: Record<string, string> = {
+  'gpt-4-turbo-preview': 'gpt-4o',
+  'gpt-4-0125-preview': 'gpt-4o',
+  'gpt-4-1106-preview': 'gpt-4o',
+  'gpt-3.5-turbo-0125': 'gpt-4o-mini',
+  'gpt-3.5-turbo-1106': 'gpt-4o-mini',
+  'gpt-3.5-turbo-16k': 'gpt-4o-mini',
+  'claude-3-opus-20240229': 'claude-sonnet-4-0',
+  'claude-3-sonnet-20240229': 'claude-3-5-sonnet-latest',
+  'claude-3-haiku-20240307': 'claude-3-5-haiku-latest',
+}
+
+export function runDiagnostics(config: Config): Diagnostic[] {
+  const diagnostics: Diagnostic[] = []
+
+  checkServiceBlock(config, diagnostics)
+  checkAuthentication(config, diagnostics)
+  checkModelCurrency(config, diagnostics)
+  checkModeConfig(config, diagnostics)
+  checkDynamicRouting(config, diagnostics)
+  checkTokenLimits(config, diagnostics)
+  checkIgnoredFiles(config, diagnostics)
+  checkProjectConfigFile(diagnostics)
+
+  return diagnostics
+}
+
+function checkServiceBlock(config: Config, diagnostics: Diagnostic[]) {
+  if (!config.service) {
+    diagnostics.push({
+      severity: 'error',
+      message: 'No service configuration found. Coco needs an AI provider to generate results.',
+      fix: 'Run `coco init` to set up a provider, or add a "service" block to .coco.config.json.',
+    })
+    return
+  }
+
+  if (!config.service.provider) {
+    diagnostics.push({
+      severity: 'error',
+      message: 'No provider set in service config.',
+      fix: 'Set service.provider to "openai", "anthropic", or "ollama".',
+    })
+  }
+
+  if (!config.service.model) {
+    diagnostics.push({
+      severity: 'error',
+      message: 'No model set in service config.',
+      fix: 'Set service.model to a valid model name (e.g. "gpt-4o") or "dynamic" for task-based routing.',
+    })
+  }
+}
+
+function checkAuthentication(config: Config, diagnostics: Diagnostic[]) {
+  if (!config.service) return
+
+  const { provider, authentication } = config.service
+
+  if (provider === 'ollama') {
+    if (authentication && authentication.type !== 'None') {
+      diagnostics.push({
+        severity: 'warn',
+        message: 'Ollama does not require authentication. Set authentication.type to "None".',
+        fix: 'Change service.authentication to { "type": "None" }.',
+        autoFix: (raw) => {
+          const svc = raw.service as Record<string, unknown>
+          if (svc) {
+            svc.authentication = { type: 'None' }
+          }
+        },
+      })
+    }
+
+    const ollamaService = config.service as { endpoint?: string }
+    if (!ollamaService.endpoint) {
+      diagnostics.push({
+        severity: 'warn',
+        message: 'No Ollama endpoint configured. Defaulting to http://localhost:11434.',
+        fix: 'Add service.endpoint: "http://localhost:11434" to your config.',
+        autoFix: (raw) => {
+          const svc = raw.service as Record<string, unknown>
+          if (svc) {
+            svc.endpoint = 'http://localhost:11434'
+          }
+        },
+      })
+    }
+    return
+  }
+
+  if (!authentication || authentication.type === 'None') {
+    diagnostics.push({
+      severity: 'error',
+      message: `Provider "${provider}" requires authentication but none is configured.`,
+      fix: `Set service.authentication to { "type": "APIKey", "credentials": { "apiKey": "..." } } or use the OPENAI_API_KEY / ANTHROPIC_API_KEY environment variable.`,
+    })
+    return
+  }
+
+  if (authentication.type === 'APIKey') {
+    const key = authentication.credentials?.apiKey
+    if (!key || key === '•••••••••••••••' || key.trim() === '') {
+      diagnostics.push({
+        severity: 'warn',
+        message: 'API key appears to be a placeholder or empty. Coco may fall back to environment variables.',
+        fix: `Set the API key in your config or via environment variable (OPENAI_API_KEY or ANTHROPIC_API_KEY).`,
+      })
+    }
+  }
+}
+
+function checkModelCurrency(config: Config, diagnostics: Diagnostic[]) {
+  if (!config.service?.model || config.service.model === 'dynamic') return
+
+  const model = String(config.service.model)
+  const upgrade = MODEL_UPGRADES[model]
+
+  if (upgrade) {
+    diagnostics.push({
+      severity: 'warn',
+      message: `Model "${model}" has a newer replacement available: "${upgrade}".`,
+      fix: `Update service.model to "${upgrade}" for better performance and pricing.`,
+      autoFix: (raw) => {
+        const svc = raw.service as Record<string, unknown>
+        if (svc) {
+          svc.model = upgrade
+        }
+      },
+    })
+  }
+}
+
+function checkModeConfig(config: Config, diagnostics: Diagnostic[]) {
+  if (!config.mode || config.mode === 'stdout') {
+    diagnostics.push({
+      severity: 'info',
+      message: 'Output mode is "stdout". Interactive features like commit split require -i or mode: "interactive".',
+      fix: 'Set "mode": "interactive" in your config, or pass -i when using interactive commands.',
+    })
+  }
+}
+
+function checkDynamicRouting(config: Config, diagnostics: Diagnostic[]) {
+  if (!config.service) return
+
+  if (config.service.model === 'dynamic') {
+    if (!config.service.dynamicModelPreference) {
+      diagnostics.push({
+        severity: 'info',
+        message: 'Dynamic model routing is enabled but no preference is set. Defaulting to "balanced".',
+        fix: 'Optionally set service.dynamicModelPreference to "cost", "balanced", or "quality".',
+      })
+    }
+
+    if (config.service.dynamicModels) {
+      const validTasks = ['summarize', 'commit', 'changelog', 'review', 'recap', 'repair', 'largeDiff']
+      for (const task of Object.keys(config.service.dynamicModels)) {
+        if (!validTasks.includes(task)) {
+          diagnostics.push({
+            severity: 'warn',
+            message: `Unknown dynamic model task "${task}". Valid tasks: ${validTasks.join(', ')}.`,
+            fix: `Remove or rename the "${task}" key in service.dynamicModels.`,
+          })
+        }
+      }
+    }
+
+    diagnostics.push({
+      severity: 'info',
+      message: 'Dynamic model routing is active. Coco will select models per task based on your preference.',
+    })
+  } else {
+    diagnostics.push({
+      severity: 'info',
+      message: `Using fixed model "${config.service.model}" for all tasks. Set service.model to "dynamic" to enable per-task model selection.`,
+    })
+  }
+}
+
+function checkTokenLimits(config: Config, diagnostics: Diagnostic[]) {
+  if (!config.service) return
+
+  const tokenLimit = config.service.tokenLimit || 2048
+
+  if (tokenLimit < 512) {
+    diagnostics.push({
+      severity: 'warn',
+      message: `Token limit (${tokenLimit}) is very low. This may cause truncated or poor-quality results.`,
+      fix: 'Increase service.tokenLimit to at least 1024, ideally 2048 or higher.',
+      autoFix: (raw) => {
+        const svc = raw.service as Record<string, unknown>
+        if (svc) {
+          svc.tokenLimit = 2048
+        }
+      },
+    })
+  }
+
+  if (config.service.maxConcurrent && config.service.provider === 'ollama' && config.service.maxConcurrent > 1) {
+    diagnostics.push({
+      severity: 'warn',
+      message: `maxConcurrent is ${config.service.maxConcurrent} but Ollama typically handles one request at a time.`,
+      fix: 'Set service.maxConcurrent to 1 for Ollama.',
+      autoFix: (raw) => {
+        const svc = raw.service as Record<string, unknown>
+        if (svc) {
+          svc.maxConcurrent = 1
+        }
+      },
+    })
+  }
+}
+
+function checkIgnoredFiles(config: Config, diagnostics: Diagnostic[]) {
+  if (!config.ignoredFiles || config.ignoredFiles.length === 0) {
+    diagnostics.push({
+      severity: 'info',
+      message: 'No custom ignored files configured. Coco uses defaults (package-lock.json, .gitignore contents, etc.).',
+    })
+  }
+}
+
+function checkProjectConfigFile(diagnostics: Diagnostic[]) {
+  const hasNewName = fs.existsSync('.coco.json')
+  const hasLegacyName = fs.existsSync('.coco.config.json')
+
+  if (!hasNewName && !hasLegacyName) {
+    diagnostics.push({
+      severity: 'info',
+      message: 'No project config file found in the current directory. Using git config, env vars, or defaults.',
+      fix: 'Run `coco init --scope project` to create a project config.',
+    })
+    return
+  }
+
+  if (hasLegacyName && !hasNewName) {
+    diagnostics.push({
+      severity: 'info',
+      message: 'Using legacy config filename .coco.config.json. Consider renaming to .coco.json.',
+      fix: 'Rename .coco.config.json to .coco.json. Both filenames are supported, but .coco.json is preferred.',
+    })
+  }
+
+  const configPath = hasNewName ? '.coco.json' : '.coco.config.json'
+
+  try {
+    const raw = JSON.parse(fs.readFileSync(configPath, 'utf-8'))
+
+    if (!raw.$schema) {
+      diagnostics.push({
+        severity: 'info',
+        message: `Project config (${configPath}) is missing the $schema field. Adding it enables editor autocompletion.`,
+        fix: `Add "$schema": "https://coco.griffen.codes/schema.json" to ${configPath}.`,
+        autoFix: (rawConfig) => {
+          rawConfig.$schema = 'https://coco.griffen.codes/schema.json'
+        },
+      })
+    }
+  } catch {
+    diagnostics.push({
+      severity: 'error',
+      message: `${configPath} contains invalid JSON.`,
+      fix: `Fix the JSON syntax in ${configPath} or regenerate it with \`coco init --scope project\`.`,
+    })
+  }
+}

--- a/src/commands/doctor/config.ts
+++ b/src/commands/doctor/config.ts
@@ -1,0 +1,23 @@
+import { Arguments, Argv, Options } from 'yargs'
+import { getCommandUsageHeader } from '../../lib/ui/helpers'
+import { BaseCommandOptions } from '../types'
+
+export interface DoctorOptions extends BaseCommandOptions {
+  fix?: boolean
+}
+
+export type DoctorArgv = Arguments<DoctorOptions>
+
+export const command = 'doctor'
+
+export const options = {
+  fix: {
+    description: 'Attempt to auto-fix detected issues and write the updated config',
+    type: 'boolean',
+    default: false,
+  },
+} as Record<string, Options>
+
+export const builder = (yargs: Argv) => {
+  return yargs.options(options).usage(getCommandUsageHeader(command))
+}

--- a/src/commands/doctor/handler.ts
+++ b/src/commands/doctor/handler.ts
@@ -1,0 +1,168 @@
+import * as fs from 'fs'
+import chalk from 'chalk'
+import { loadConfig } from '../../lib/config/utils/loadConfig'
+import { getConfigSources, ConfigSourceInfo } from '../../lib/config/utils/loadConfig'
+import { SCHEMA_PUBLIC_URL } from '../../lib/schema'
+import { CommandHandler } from '../../lib/types'
+import { LOGO } from '../../lib/ui/helpers'
+import { DoctorArgv, DoctorOptions } from './config'
+import { DiagnosticSeverity, runDiagnostics } from './checks'
+
+const SEVERITY_ICON: Record<DiagnosticSeverity, string> = {
+  error: chalk.red('✖'),
+  warn: chalk.yellow('⚠'),
+  info: chalk.blue('ℹ'),
+}
+
+const SEVERITY_LABEL: Record<DiagnosticSeverity, string> = {
+  error: chalk.red('error'),
+  warn: chalk.yellow('warn'),
+  info: chalk.blue('info'),
+}
+
+const SOURCE_LABELS: Record<string, string> = {
+  default: 'Built-in defaults',
+  xdg: 'XDG config',
+  git: 'Git config (~/.gitconfig)',
+  project: 'Project config',
+  env: 'Environment variables',
+}
+
+function formatSourceInfo(sources: ConfigSourceInfo[]): string[] {
+  const lines: string[] = []
+  for (const source of sources) {
+    const label = SOURCE_LABELS[source.source] || source.source
+    if (source.path) {
+      lines.push(`  ${chalk.green('✓')} ${label} ${chalk.dim(`(${source.path})`)}`)
+    } else {
+      lines.push(`  ${chalk.green('✓')} ${label}`)
+    }
+  }
+  return lines
+}
+
+export const handler: CommandHandler<DoctorArgv> = async (argv, logger) => {
+  const config = loadConfig<DoctorOptions, DoctorArgv>(argv)
+  const sources = getConfigSources()
+
+  logger.log(LOGO)
+  logger.log('')
+  logger.log(chalk.bold('coco doctor') + ' — checking your configuration\n')
+
+  // Show active config sources
+  logger.log(chalk.bold('Config sources') + chalk.dim(' (lowest → highest precedence):\n'))
+  const sourceLines = formatSourceInfo(sources)
+  for (const line of sourceLines) {
+    logger.log(line)
+  }
+
+  // Show inactive sources
+  const activeSources = new Set(sources.map((s) => s.source))
+  const allSources = ['xdg', 'git', 'project', 'env'] as const
+  const inactive = allSources.filter((s) => !activeSources.has(s))
+  if (inactive.length > 0) {
+    logger.log('')
+    for (const source of inactive) {
+      const label = SOURCE_LABELS[source] || source
+      logger.log(`  ${chalk.dim('–')} ${chalk.dim(label)} ${chalk.dim('(not found)')}`)
+    }
+  }
+
+  logger.log('')
+
+  // Run diagnostics
+  const diagnostics = runDiagnostics(config)
+
+  if (diagnostics.length === 0) {
+    logger.log(chalk.green('✓ No issues found. Your configuration looks good!'))
+    return
+  }
+
+  const errors = diagnostics.filter((d) => d.severity === 'error')
+  const warnings = diagnostics.filter((d) => d.severity === 'warn')
+  const infos = diagnostics.filter((d) => d.severity === 'info')
+
+  logger.log(chalk.bold('Diagnostics:\n'))
+
+  for (const diagnostic of diagnostics) {
+    const icon = SEVERITY_ICON[diagnostic.severity]
+    const label = SEVERITY_LABEL[diagnostic.severity]
+    logger.log(`${icon} ${label}: ${diagnostic.message}`)
+    if (diagnostic.fix) {
+      logger.log(chalk.dim(`  → ${diagnostic.fix}`))
+    }
+    logger.log('')
+  }
+
+  // Summary
+  const parts: string[] = []
+  if (errors.length > 0) parts.push(chalk.red(`${errors.length} error(s)`))
+  if (warnings.length > 0) parts.push(chalk.yellow(`${warnings.length} warning(s)`))
+  if (infos.length > 0) parts.push(chalk.blue(`${infos.length} info(s)`))
+  logger.log(`Found ${parts.join(', ')}.\n`)
+
+  // Auto-fix
+  if (argv.fix) {
+    const fixable = diagnostics.filter((d) => d.autoFix)
+    if (fixable.length === 0) {
+      logger.log(chalk.dim('No auto-fixable issues found.'))
+      return
+    }
+
+    // Find the project config file to write to
+    const projectSource = sources.find((s) => s.source === 'project')
+    const configPath = projectSource?.path
+
+    if (!configPath) {
+      logger.log(
+        chalk.yellow(
+          'No project config file found. Run `coco init --scope project` first, then re-run `coco doctor --fix`.'
+        )
+      )
+      logger.log(
+        chalk.dim(
+          '  Auto-fix writes to the project config file (.coco.json or .coco.config.json).'
+        )
+      )
+
+      // If config is coming from git or env, explain
+      const gitSource = sources.find((s) => s.source === 'git')
+      const envSource = sources.find((s) => s.source === 'env')
+      if (gitSource) {
+        logger.log(
+          chalk.dim(`  Your config is loaded from ${gitSource.path} — edit that file manually, or create a project config.`)
+        )
+      }
+      if (envSource) {
+        logger.log(
+          chalk.dim('  Some config comes from environment variables — update those in your shell profile.')
+        )
+      }
+      return
+    }
+
+    try {
+      const raw = JSON.parse(fs.readFileSync(configPath, 'utf-8'))
+
+      for (const diagnostic of fixable) {
+        diagnostic.autoFix!(raw)
+        logger.log(chalk.green(`  ✓ Fixed: ${diagnostic.message}`))
+      }
+
+      // Ensure $schema is present
+      if (!raw.$schema) {
+        raw.$schema = SCHEMA_PUBLIC_URL
+      }
+
+      fs.writeFileSync(configPath, JSON.stringify(raw, null, 2) + '\n')
+      logger.log(chalk.green(`\nWrote ${fixable.length} fix(es) to ${configPath}`))
+    } catch (e) {
+      logger.log(chalk.red(`Failed to apply fixes: ${(e as Error).message}`))
+    }
+  } else {
+    const fixable = diagnostics.filter((d) => d.autoFix)
+    if (fixable.length > 0) {
+      logger.log(chalk.dim(`${fixable.length} issue(s) can be auto-fixed. Run \`coco doctor --fix\` to apply.`))
+    }
+  }
+}

--- a/src/commands/doctor/index.ts
+++ b/src/commands/doctor/index.ts
@@ -1,0 +1,9 @@
+import { builder, command } from './config'
+import { handler } from './handler'
+
+export default {
+  command,
+  desc: 'Check your coco configuration for common issues and suggest fixes',
+  builder,
+  handler,
+}

--- a/src/commands/init/questions.ts
+++ b/src/commands/init/questions.ts
@@ -1,11 +1,11 @@
 import { ANTHROPIC_MODELS, OPEN_AI_MODELS } from '../../lib/langchain/constants'
 import { LLMModel, LLMProvider } from '../../lib/langchain/types'
 import {
-  confirmPrompt,
-  editorPrompt,
-  inputPrompt,
-  passwordPrompt,
-  selectPrompt,
+    confirmPrompt,
+    editorPrompt,
+    inputPrompt,
+    passwordPrompt,
+    selectPrompt,
 } from '../../lib/ui/inquirerPrompts'
 import { commandExit } from '../../lib/utils/commandExit'
 import { execPromise } from '../../lib/utils/execPromise'
@@ -248,7 +248,11 @@ export const questions = {
       message: 'where would you like to store the project config?',
       choices: [
         {
-          name: '.coco.config.json',
+          name: '.coco.json (recommended)',
+          value: '.coco.json',
+        },
+        {
+          name: '.coco.config.json (legacy)',
           value: '.coco.config.json',
         },
         {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,13 @@ y.command<InitOptions>(
   init.handler
 )
 
+y.command<DoctorOptions>(
+  doctor.command,
+  doctor.desc,
+  doctor.builder,
+  doctor.handler
+)
+
 y.command<LogOptions>(
   log.command,
   log.desc,
@@ -73,4 +80,4 @@ y.command<UiOptions>(
 
 y.help().parse(process.argv.slice(2))
 
-export { changelog, commit, Config, init, log, recap, types, ui }
+export { changelog, commit, Config, doctor, init, log, recap, types, ui }

--- a/src/lib/config/services/env.ts
+++ b/src/lib/config/services/env.ts
@@ -11,10 +11,23 @@ type ValuesTypes = Config[keyof Config]
  * Load environment variables
  *
  * @param {Config} config
+ * @param {object} opts
  * @returns {Config} Updated config
  **/
-export function loadEnvConfig<ConfigType = Config>(config: Partial<Config>) {
+export function loadEnvConfig<ConfigType = Config>(
+  config: Partial<Config>,
+  opts: { returnSource: true }
+): { config: ConfigType; active: boolean }
+export function loadEnvConfig<ConfigType = Config>(
+  config: Partial<Config>,
+  opts?: { returnSource?: false }
+): ConfigType
+export function loadEnvConfig<ConfigType = Config>(
+  config: Partial<Config>,
+  opts?: { returnSource?: boolean }
+): ConfigType | { config: ConfigType; active: boolean } {
   const envConfig: Partial<Record<keyof Config, ValuesTypes>> = {}
+  let foundAny = false
 
   const envKeys = [
     ...CONFIG_KEYS,
@@ -55,16 +68,22 @@ export function loadEnvConfig<ConfigType = Config>(config: Partial<Config>) {
       // @ts-ignore
       envConfig.service = envConfig.service || {}
       handleServiceEnvVar(envConfig.service as LLMService, key, envValue)
+      foundAny = true
     } else {
       if (key === 'service' || !envValue) {
         return
       }
 
       envConfig[key as keyof typeof envConfig] = envValue as ValuesTypes
+      foundAny = true
     }
   })
 
-  return { ...config, ...removeUndefined(envConfig) } as ConfigType
+  const merged = { ...config, ...removeUndefined(envConfig) } as ConfigType
+  if (opts?.returnSource) {
+    return { config: merged, active: foundAny }
+  }
+  return merged
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/lib/config/services/git.ts
+++ b/src/lib/config/services/git.ts
@@ -14,16 +14,32 @@ import { Config } from '../types'
  * Load git profile config (from ~/.gitconfig)
  *
  * @param {Config} config
+ * @param {object} opts
  * @returns {Config} Updated config
  **/
-export function loadGitConfig<ConfigType = Config>(config: Partial<Config>) {
+export function loadGitConfig<ConfigType = Config>(
+  config: Partial<Config>,
+  opts: { returnSource: true }
+): { config: ConfigType; path?: string }
+export function loadGitConfig<ConfigType = Config>(
+  config: Partial<Config>,
+  opts?: { returnSource?: false }
+): ConfigType
+export function loadGitConfig<ConfigType = Config>(
+  config: Partial<Config>,
+  opts?: { returnSource?: boolean }
+): ConfigType | { config: ConfigType; path?: string } {
   const gitConfigPath = path.join(os.homedir(), '.gitconfig')
+  let foundPath: string | undefined
+
   if (fs.existsSync(gitConfigPath)) {
     const gitConfigRaw = fs.readFileSync(gitConfigPath, 'utf-8')
     const gitConfigParsed = ini.parse(gitConfigRaw)
 
     let service: LLMService | undefined = config.service
     if (gitConfigParsed.coco) {
+      foundPath = gitConfigPath
+
       service = {
         provider: gitConfigParsed.coco?.serviceProvider,
         model: gitConfigParsed.coco?.serviceModel,
@@ -78,7 +94,12 @@ export function loadGitConfig<ConfigType = Config>(config: Partial<Config>) {
       includeBranchName: gitConfigParsed.coco?.includeBranchName || config.includeBranchName,
     }
   }
-  return removeUndefined(config) as ConfigType
+
+  const cleaned = removeUndefined(config) as ConfigType
+  if (opts?.returnSource) {
+    return { config: cleaned, path: foundPath }
+  }
+  return cleaned
 }
 
 /**

--- a/src/lib/config/services/project.ts
+++ b/src/lib/config/services/project.ts
@@ -8,15 +8,41 @@ const validate = ajv.compile(schema)
 /**
  * Load project config
  *
+ * Looks for `.coco.json` first (preferred), then falls back to `.coco.config.json`
+ * for backward compatibility.
+ *
  * @param {Config} config
+ * @param {object} opts
  * @returns {Config} Updated config
  **/
-export function loadProjectJsonConfig<ConfigType = Config>(config: Partial<Config>) {
-  if (fs.existsSync('.coco.config.json')) {
+export function loadProjectJsonConfig<ConfigType = Config>(
+  config: Partial<Config>,
+  opts: { returnSource: true }
+): { config: ConfigType; path?: string }
+export function loadProjectJsonConfig<ConfigType = Config>(
+  config: Partial<Config>,
+  opts?: { returnSource?: false }
+): ConfigType
+export function loadProjectJsonConfig<ConfigType = Config>(
+  config: Partial<Config>,
+  opts?: { returnSource?: boolean }
+): ConfigType | { config: ConfigType; path?: string } {
+  // Prefer .coco.json, fall back to .coco.config.json
+  const candidates = ['.coco.json', '.coco.config.json']
+  let resolvedPath: string | undefined
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      resolvedPath = candidate
+      break
+    }
+  }
+
+  if (resolvedPath) {
     // Removing $schema from the project config to avoid validation errors.
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { $schema, ...projectConfig } = JSON.parse(
-      fs.readFileSync('.coco.config.json', 'utf-8')
+      fs.readFileSync(resolvedPath, 'utf-8')
     ) as Partial<Config> & { $schema: string }
 
     config = { ...config, ...projectConfig } as Config
@@ -25,6 +51,10 @@ export function loadProjectJsonConfig<ConfigType = Config>(config: Partial<Confi
     if (!isProjectConfigValid) {
       throw new Error('Invalid project config', { cause: ajv.errorsText(validate.errors) })
     }
+  }
+
+  if (opts?.returnSource) {
+    return { config: config as ConfigType, path: resolvedPath }
   }
   return config as ConfigType
 }

--- a/src/lib/config/services/xdg.ts
+++ b/src/lib/config/services/xdg.ts
@@ -8,12 +8,27 @@ import { Config } from '../types'
  * Load XDG config
  *
  * @param {Config} config
+ * @param {object} opts
  * @returns {Config} Updated config
  */
-export function loadXDGConfig<ConfigType = Config>(config: Partial<Config>) {
+export function loadXDGConfig<ConfigType = Config>(
+  config: Partial<Config>,
+  opts: { returnSource: true }
+): { config: ConfigType; path?: string }
+export function loadXDGConfig<ConfigType = Config>(
+  config: Partial<Config>,
+  opts?: { returnSource?: false }
+): ConfigType
+export function loadXDGConfig<ConfigType = Config>(
+  config: Partial<Config>,
+  opts?: { returnSource?: boolean }
+): ConfigType | { config: ConfigType; path?: string } {
   const xdgConfigHome = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config')
   const xdgConfigPath = path.join(xdgConfigHome, 'coco', 'config.json')
+  let foundPath: string | undefined
+
   if (fs.existsSync(xdgConfigPath)) {
+    foundPath = xdgConfigPath
     const xdgConfig = JSON.parse(fs.readFileSync(xdgConfigPath, 'utf-8'))
 
     const service = parseServiceConfig(xdgConfig.service || config.service)
@@ -23,6 +38,10 @@ export function loadXDGConfig<ConfigType = Config>(config: Partial<Config>) {
       ...xdgConfig, 
       service: service 
     }
+  }
+
+  if (opts?.returnSource) {
+    return { config: config as ConfigType, path: foundPath }
   }
   return config as ConfigType
 }

--- a/src/lib/config/utils/loadConfig.ts
+++ b/src/lib/config/utils/loadConfig.ts
@@ -8,6 +8,34 @@ import { Config } from '../types'
 import { DEFAULT_CONFIG } from '../constants'
 import { BaseCommandOptions } from '../../../commands/types'
 
+export type ConfigSource =
+  | 'default'
+  | 'gitignore'
+  | 'ignore'
+  | 'xdg'
+  | 'git'
+  | 'project'
+  | 'env'
+  | 'argv'
+
+export interface ConfigSourceInfo {
+  source: ConfigSource
+  path?: string
+}
+
+/**
+ * Tracked config sources populated during the last loadConfig call.
+ * Useful for diagnostics (e.g. `coco doctor`).
+ */
+let _lastConfigSources: ConfigSourceInfo[] = []
+
+/**
+ * Returns the config sources detected during the most recent loadConfig call.
+ */
+export function getConfigSources(): ConfigSourceInfo[] {
+  return _lastConfigSources
+}
+
 /**
  * Load application config
  *
@@ -26,15 +54,31 @@ import { BaseCommandOptions } from '../../../commands/types'
  * @returns {Config} application config
  **/
 export function loadConfig<ConfigType, ArgvType = BaseCommandOptions>(argv = {} as ArgvType) {
+  const sources: ConfigSourceInfo[] = [{ source: 'default' }]
+
   // Default config
   let config = DEFAULT_CONFIG
 
   config = loadGitignore(config)
   config = loadIgnore(config)
-  config = loadXDGConfig(config)
-  config = loadGitConfig(config)
-  config = loadProjectJsonConfig(config)
-  config = loadEnvConfig(config)
+
+  const { config: xdgConfig, path: xdgPath } = loadXDGConfig(config, { returnSource: true })
+  config = xdgConfig
+  if (xdgPath) sources.push({ source: 'xdg', path: xdgPath })
+
+  const { config: gitConfig, path: gitPath } = loadGitConfig(config, { returnSource: true })
+  config = gitConfig
+  if (gitPath) sources.push({ source: 'git', path: gitPath })
+
+  const { config: projectConfig, path: projectPath } = loadProjectJsonConfig(config, { returnSource: true })
+  config = projectConfig
+  if (projectPath) sources.push({ source: 'project', path: projectPath })
+
+  const { config: envConfig, active: envActive } = loadEnvConfig(config, { returnSource: true })
+  config = envConfig
+  if (envActive) sources.push({ source: 'env' })
+
+  _lastConfigSources = sources
 
   return { ...config, ...argv } as Config & ConfigType & ArgvType
 }

--- a/src/lib/utils/getProjectConfigFilePath.ts
+++ b/src/lib/utils/getProjectConfigFilePath.ts
@@ -1,6 +1,6 @@
 import { findProjectRoot } from './findProjectRoot'
 
-export type ProjectConfigFileName = '.coco.config.json' | '.env'
+export type ProjectConfigFileName = '.coco.json' | '.coco.config.json' | '.env'
 
 export async function getProjectConfigFilePath(configFileName: ProjectConfigFileName) {
   const projectRoot = findProjectRoot(process.cwd())


### PR DESCRIPTION
## Summary

Wiki refresh, config diagnostics, and quality-of-life improvements for config management.

Companion wiki changes are already live: [gfargo/coco.wiki@ef12f0e](https://github.com/gfargo/coco/wiki)

## Changes

### fix(commit): wire interactive mode for commit split handler
The split code path ignored the `-i` flag and never provided an `interactiveModeCallback`, causing `No result handler provided for interactive mode` even with `-i`. Now respects `argv.interactive` and displays the plan properly.

### feat: add `coco doctor` command
New command that inspects merged config and reports issues:
- **Config source detection** — shows which sources are active (project file, git config, XDG, env vars) with file paths
- **Diagnostics** — missing provider/auth (error), outdated models with upgrade suggestions (warn), Ollama misconfig, low token limits, stdout mode hint, dynamic routing status, missing `$schema` (info)
- **`--fix`** — auto-applies fixable issues to the project config file; explains where to edit when config comes from git or env vars instead

Config service loaders (`project`, `git`, `xdg`, `env`) now support a `returnSource` overload for source tracking without breaking existing callers.

### feat(config): support `.coco.json` as preferred project config filename
- Loader checks `.coco.json` first, falls back to `.coco.config.json`
- `coco init` offers `.coco.json (recommended)` as the primary choice
- `coco doctor` flags the legacy filename with an info suggestion
- Full backward compatibility — existing `.coco.config.json` files keep working

### chore: `.gitignore` updates
- Added `.coco.json` alongside existing `.coco.config.json` ignore
- Added `specs/` for internal design docs moved out of the wiki

### Wiki (already pushed)
- Removed 5 internal spec/audit/roadmap pages (moved to gitignored `specs/`)
- Updated Config Overview: `.coco.json` as preferred name, full service options table, `autoFixTool` section, dynamic model routing, expanded env var docs, `coco doctor` in troubleshooting
- Updated Command Reference: `coco commit split`, `--no-verify`, `coco doctor`
- Rewrote Commit Split page with quick start, requirements, troubleshooting
- Updated Home sidebar: removed roadmap section, added Reference section

## Testing

All 701 tests pass across 93 suites. No new test dependencies.
