### PR TITLE
fix(log-tui): stable center panel width + silent watcher refresh (+ doctor build fix)

### DIFF
--- a/src/commands/doctor/index.ts
+++ b/src/commands/doctor/index.ts
@@ -1,3 +1,4 @@
+import commandExecutor from '../../lib/utils/commandExecutor'
 import { builder, command } from './config'
 import { handler } from './handler'
 
@@ -5,5 +6,5 @@ export default {
   command,
   desc: 'Check your coco configuration for common issues and suggest fixes',
   builder,
-  handler,
+  handler: commandExecutor(handler),
 }

--- a/src/commands/log/inkLayout.ts
+++ b/src/commands/log/inkLayout.ts
@@ -7,6 +7,13 @@ export type LogInkLayout = {
   bodyRows: number
   columns: number
   detailWidth: number
+  /**
+   * Width allocated to the main panel (history / status / diff / compose /
+   * branches / tags / stash). Computed as `columns - sidebarWidth -
+   * detailWidth` so the three panels always tile flush. Surfaces lock to
+   * this width to prevent the box from resizing per file in diff view.
+   */
+  mainPanelWidth: number
   rows: number
   sidebarWidth: number
   tooSmall: boolean
@@ -20,13 +27,16 @@ export const LOG_INK_DEFAULT_ROWS = 40
 export function getLogInkLayout(input: LogInkLayoutInput): LogInkLayout {
   const columns = input.columns || LOG_INK_DEFAULT_COLUMNS
   const rows = input.rows || LOG_INK_DEFAULT_ROWS
+  const detailWidth = Math.max(30, Math.min(56, Math.floor(columns * 0.34)))
+  const sidebarWidth = Math.max(22, Math.min(34, Math.floor(columns * 0.24)))
 
   return {
     bodyRows: Math.max(8, rows - 5),
     columns,
-    detailWidth: Math.max(30, Math.min(56, Math.floor(columns * 0.34))),
+    detailWidth,
+    mainPanelWidth: Math.max(20, columns - sidebarWidth - detailWidth),
     rows,
-    sidebarWidth: Math.max(22, Math.min(34, Math.floor(columns * 0.24))),
+    sidebarWidth,
     tooSmall: columns < LOG_INK_MIN_COLUMNS || rows < LOG_INK_MIN_ROWS,
   }
 }

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -778,16 +778,29 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     setState((current) => applyLogInkAction(current, action))
   }, [])
 
-  const refreshContext = React.useCallback(async () => {
-    dispatch({ type: 'setStatus', value: 'refreshing repository context' })
-    setContextStatus(createLogInkContextStatus('loading'))
-    setContext(await loadLogInkContext(git))
+  const refreshContext = React.useCallback(async (options: { silent?: boolean } = {}) => {
+    // Loud refresh (manual `r`): flip everything to 'loading' so the user
+    // sees the surfaces clear, then settle to 'ready' on completion.
+    // Silent refresh (fs.watch trigger): keep the existing data on screen
+    // (stale-while-revalidate) and quietly swap it in once the new fetch
+    // resolves — avoids the every-second flicker the watcher would
+    // otherwise produce on busy repos.
+    if (!options.silent) {
+      dispatch({ type: 'setStatus', value: 'refreshing repository context' })
+      setContextStatus(createLogInkContextStatus('loading'))
+    }
+    const next = await loadLogInkContext(git)
+    setContext(next)
     setContextStatus(createLogInkContextStatus('ready'))
-    dispatch({ type: 'setStatus', value: 'repository context refreshed' })
+    if (!options.silent) {
+      dispatch({ type: 'setStatus', value: 'repository context refreshed' })
+    }
   }, [dispatch, git])
 
-  const refreshWorktreeContext = React.useCallback(async () => {
-    setContextStatus((current) => updateLogInkContextStatus(current, 'worktree', 'loading'))
+  const refreshWorktreeContext = React.useCallback(async (options: { silent?: boolean } = {}) => {
+    if (!options.silent) {
+      setContextStatus((current) => updateLogInkContextStatus(current, 'worktree', 'loading'))
+    }
     const worktree = await safe(getWorktreeOverview(git))
 
     setContext((current) => ({
@@ -819,14 +832,20 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         watcher = createRefreshWatcher({
           repoRoot: repoRoot.trim(),
           gitDir: gitDir.trim(),
+          // Editor saves and git background processes can produce a steady
+          // drip of fs events on busy repos. The default 250ms debounce
+          // was tight enough that the watcher fired ~once per second; 750
+          // batches the steady-state better without delaying the user's
+          // perception of an actual change.
+          debounceMs: 750,
           onChange: (kind) => {
             if (!mountedRef.current) {
               return
             }
             if (kind === 'full') {
-              void refreshContext()
+              void refreshContext({ silent: true })
             } else {
-              void refreshWorktreeContext()
+              void refreshWorktreeContext({ silent: true })
             }
           },
         })
@@ -1310,6 +1329,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         commitDiffHunkOffsets,
         selectedDetailFile,
         layout.bodyRows,
+        layout.mainPanelWidth,
         theme,
         hasMoreCommits,
         loadingMoreCommits
@@ -1447,12 +1467,13 @@ function renderMainPanel(
   commitDiffHunkOffsets: number[] | undefined,
   selectedDetailFile: GitCommitDetail['files'][number] | undefined,
   bodyRows: number,
+  width: number,
   theme: LogInkTheme,
   hasMoreCommits: boolean,
   loadingMoreCommits: boolean
 ): ReactTypes.ReactElement {
   if (state.activeView === 'status') {
-    return renderStatusSurface(h, components, state, context, contextStatus, bodyRows, theme)
+    return renderStatusSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
   }
 
   if (state.activeView === 'diff') {
@@ -1471,24 +1492,25 @@ function renderMainPanel(
       commitDiffHunkOffsets,
       selectedDetailFile,
       bodyRows,
+      width,
       theme
     )
   }
 
   if (state.activeView === 'compose') {
-    return renderComposeSurface(h, components, state, context, contextStatus, bodyRows, theme)
+    return renderComposeSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
   }
 
   if (state.activeView === 'branches') {
-    return renderBranchesSurface(h, components, state, context, contextStatus, bodyRows, theme)
+    return renderBranchesSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
   }
 
   if (state.activeView === 'tags') {
-    return renderTagsSurface(h, components, state, context, contextStatus, bodyRows, theme)
+    return renderTagsSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
   }
 
   if (state.activeView === 'stash') {
-    return renderStashSurface(h, components, state, context, contextStatus, bodyRows, theme)
+    return renderStashSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
   }
 
   return renderHistoryPanel(
@@ -1497,6 +1519,7 @@ function renderMainPanel(
     state,
     context,
     bodyRows,
+    width,
     theme,
     hasMoreCommits,
     loadingMoreCommits
@@ -1509,6 +1532,7 @@ function renderHistoryPanel(
   state: LogInkState,
   context: LogInkContext,
   bodyRows: number,
+  width: number,
   theme: LogInkTheme,
   hasMoreCommits: boolean,
   loadingMoreCommits: boolean
@@ -1549,8 +1573,9 @@ function renderHistoryPanel(
     borderColor: focusBorderColor(theme, focused),
     borderStyle: theme.borderStyle,
     flexDirection: 'column',
-    flexGrow: 1,
+    flexShrink: 0,
     paddingX: 1,
+    width,
   },
   h(Box, { justifyContent: 'space-between' },
     h(Text, { bold: true }, panelTitle('Commits', focused)),
@@ -1671,6 +1696,7 @@ function renderStatusSurface(
   context: LogInkContext,
   contextStatus: LogInkContextStatus,
   bodyRows: number,
+  width: number,
   theme: LogInkTheme
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
@@ -1713,8 +1739,9 @@ function renderStatusSurface(
     borderColor: focusBorderColor(theme, focused),
     borderStyle: theme.borderStyle,
     flexDirection: 'column',
-    flexGrow: 1,
+    flexShrink: 0,
     paddingX: 1,
+    width,
   },
   h(Box, { justifyContent: 'space-between' },
     h(Text, { bold: true }, panelTitle('Worktree', focused)),
@@ -1736,6 +1763,7 @@ function renderComposeSurface(
   context: LogInkContext,
   contextStatus: LogInkContextStatus,
   bodyRows: number,
+  width: number,
   theme: LogInkTheme
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
@@ -1768,8 +1796,9 @@ function renderComposeSurface(
     borderColor: focusBorderColor(theme, focused),
     borderStyle: theme.borderStyle,
     flexDirection: 'column',
-    flexGrow: 1,
+    flexShrink: 0,
     paddingX: 1,
+    width,
   },
   h(Box, { justifyContent: 'space-between' },
     h(Text, { bold: true }, panelTitle('Compose commit', focused)),
@@ -1834,6 +1863,7 @@ function renderBranchesSurface(
   context: LogInkContext,
   contextStatus: LogInkContextStatus,
   bodyRows: number,
+  width: number,
   theme: LogInkTheme
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
@@ -1878,8 +1908,9 @@ function renderBranchesSurface(
     borderColor: focusBorderColor(theme, focused),
     borderStyle: theme.borderStyle,
     flexDirection: 'column',
-    flexGrow: 1,
+    flexShrink: 0,
     paddingX: 1,
+    width,
   },
   h(Box, { justifyContent: 'space-between' },
     h(Text, { bold: true }, panelTitle('Branches', focused)),
@@ -1896,6 +1927,7 @@ function renderTagsSurface(
   context: LogInkContext,
   contextStatus: LogInkContextStatus,
   bodyRows: number,
+  width: number,
   theme: LogInkTheme
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
@@ -1952,8 +1984,9 @@ function renderTagsSurface(
     borderColor: focusBorderColor(theme, focused),
     borderStyle: theme.borderStyle,
     flexDirection: 'column',
-    flexGrow: 1,
+    flexShrink: 0,
     paddingX: 1,
+    width,
   },
   h(Box, { justifyContent: 'space-between' },
     h(Text, { bold: true }, panelTitle('Tags', focused)),
@@ -1970,6 +2003,7 @@ function renderStashSurface(
   context: LogInkContext,
   contextStatus: LogInkContextStatus,
   bodyRows: number,
+  width: number,
   theme: LogInkTheme
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
@@ -2010,8 +2044,9 @@ function renderStashSurface(
     borderColor: focusBorderColor(theme, focused),
     borderStyle: theme.borderStyle,
     flexDirection: 'column',
-    flexGrow: 1,
+    flexShrink: 0,
     paddingX: 1,
+    width,
   },
   h(Box, { justifyContent: 'space-between' },
     h(Text, { bold: true }, panelTitle('Stash', focused)),
@@ -2060,6 +2095,7 @@ function renderDiffSurface(
   commitDiffHunkOffsets: number[] | undefined,
   selectedDetailFile: GitCommitDetail['files'][number] | undefined,
   bodyRows: number,
+  width: number,
   theme: LogInkTheme
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
@@ -2107,8 +2143,9 @@ function renderDiffSurface(
       borderColor: focusBorderColor(theme, focused),
       borderStyle: theme.borderStyle,
       flexDirection: 'column',
-      flexGrow: 1,
+      flexShrink: 0,
       paddingX: 1,
+      width,
     },
     h(Box, { justifyContent: 'space-between' },
       h(Text, { bold: true }, panelTitle('Diff', focused)),
@@ -2157,8 +2194,9 @@ function renderDiffSurface(
     borderColor: focusBorderColor(theme, focused),
     borderStyle: theme.borderStyle,
     flexDirection: 'column',
-    flexGrow: 1,
+    flexShrink: 0,
     paddingX: 1,
+    width,
   },
   h(Box, { justifyContent: 'space-between' },
     h(Text, { bold: true }, panelTitle('Diff', focused)),


### PR DESCRIPTION
## Summary

Two TUI bugs surfaced during initial 0.35.0 testing, plus a tag-along build fix for the merged \`coco doctor\` command.

### Bug 1 — Center panel width changed per file in diff view

The seven main-panel surfaces (history / status / diff / compose / branches / tags / stash) used \`flexGrow: 1\` with no explicit width. Long diff lines pushed the box wider than its flex allocation, so the center panel visibly grew and shrank as the user navigated files in the right-hand sidebar.

**Fix**: compute \`mainPanelWidth = columns - sidebarWidth - detailWidth\` in \`getLogInkLayout\`, thread it through \`renderMainPanel\`, and lock each surface's outer Box to \`width: mainPanelWidth\` with \`flexShrink: 0\`. Sidebar and detail panels were already width-locked; the center panel now matches.

### Bug 2 — Live refresh flickered the entire UI ~once per second

The \`fs.watch\`-driven refresh watcher (added in #762) flipped \`contextStatus\` to \`'loading'\` before each fetch and back to \`'ready'\` on completion. Surfaces showed their loading copy mid-fetch — every editor save or git background process produced a visible flicker on busy repos.

**Fix**:
- \`refreshContext\` / \`refreshWorktreeContext\` now accept an \`options.silent\` flag. The watcher path passes \`silent: true\` so the existing data stays on screen (stale-while-revalidate) and surfaces only re-render once the new data arrives.
- Manual \`r\` refreshes keep the loud \"refreshing repository context\" status message — user-initiated action wants the visible feedback.
- Watcher debounce bumped from 250ms → 750ms so a steady drip of editor save events doesn't keep firing background fetches.

### Build fix — \`coco doctor\` was breaking the build

The merged \`coco doctor\` command (commit \`9b0e11ab\`) exported its raw 2-arg \`(argv, logger)\` handler directly, but yargs' \`.command()\` expects a 1-arg handler. Every other command wraps its handler via \`commandExecutor\` (which adapts the signature and adds the shared error-formatting layer). Doing the same for doctor unblocks \`tsc --noEmit\` / rollup. Runtime behavior of \`coco doctor\` is unchanged.

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run test:jest\` — 791/791
- [x] \`npm run build\` — dual CJS/ESM emitted (was previously failing on main due to doctor)
- [x] \`npm run test:cli\` — 10/10 smoke checks
- [x] \`npm run release:dry-run\`
- [ ] Manual: \`coco ui\` → \`g d\` and arrow through files in the right sidebar; verify the center panel width is stable across selections
- [ ] Manual: \`coco ui\` then save files in your editor for ~30s; verify the surfaces don't flicker
- [ ] Manual: press \`r\` in \`coco ui\`; confirm the loud \"refreshing repository context\" status message still shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)