### PR TITLE
Enhance TUI with Cherry-Pick, Sidebar Persistence, and Quick Actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ npm-debug.log*
 # Output of 'npm pack'
 *.tgz
 
+
 # dotenv environment variable files
 .env
 .env.development.local

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ npm-debug.log*
 # Output of 'npm pack'
 *.tgz
 
-
 # dotenv environment variable files
 .env
 .env.development.local

--- a/src/commands/log/commitCompose.ts
+++ b/src/commands/log/commitCompose.ts
@@ -95,13 +95,18 @@ export function applyCommitComposeAction(
         loading: action.value,
       }
     case 'setDraft':
+      // No `message` here — the loader → filled fields are the confirmation
+      // that the AI generated something. A lingering "AI draft ready for
+      // editing" line in the panel reads as stale state. The runtime still
+      // posts the same string to the footer status line for transient
+      // feedback.
       return {
         ...state,
         ...splitCommitDraft(action.value),
         field: 'summary',
         editing: true,
         loading: false,
-        message: 'AI draft ready for editing',
+        message: undefined,
         details: undefined,
       }
     case 'setResult':

--- a/src/commands/log/historyActions.ts
+++ b/src/commands/log/historyActions.ts
@@ -345,6 +345,27 @@ export function cherryPickCommit(
   ))
 }
 
+/**
+ * Materialize a single file's contents from a historical commit into the
+ * working tree, leaving every other path untouched. Equivalent to
+ * `git checkout <sha> -- <path>`. Used by the commit-diff explore surface
+ * for file-level cherry-pick.
+ *
+ * Important: this overwrites the file in the working tree. The caller
+ * is responsible for confirming with the user when the working tree
+ * already has uncommitted changes to that path.
+ */
+export function checkoutFileFromCommit(
+  git: SimpleGit,
+  sha: string,
+  path: string
+): Promise<BranchActionResult> {
+  return runAction(
+    () => git.raw(['checkout', sha, '--', path]),
+    `Checked out ${path} from ${sha.slice(0, 7)}`
+  )
+}
+
 export function revertCommit(
   git: SimpleGit,
   commit: HistoryCommitRef | undefined

--- a/src/commands/log/historyActions.ts
+++ b/src/commands/log/historyActions.ts
@@ -348,22 +348,52 @@ export function cherryPickCommit(
 /**
  * Materialize a single file's contents from a historical commit into the
  * working tree, leaving every other path untouched. Equivalent to
- * `git checkout <sha> -- <path>`. Used by the commit-diff explore surface
- * for file-level cherry-pick.
+ * `git checkout <sha> -- <path>` for additions/modifications. When the
+ * path no longer exists at <sha> (i.e. the commit deleted that file),
+ * mirror the deletion in the worktree via `git rm --force`.
  *
  * Important: this overwrites the file in the working tree. The caller
  * is responsible for confirming with the user when the working tree
  * already has uncommitted changes to that path.
  */
-export function checkoutFileFromCommit(
+export async function checkoutFileFromCommit(
   git: SimpleGit,
   sha: string,
   path: string
 ): Promise<BranchActionResult> {
+  return checkoutOrDeleteFromRef(git, sha, path, sha.slice(0, 7))
+}
+
+export async function checkoutOrDeleteFromRef(
+  git: SimpleGit,
+  ref: string,
+  path: string,
+  label: string
+): Promise<BranchActionResult> {
+  const exists = await pathExistsAtRef(git, ref, path)
+  if (exists) {
+    return runAction(
+      () => git.raw(['checkout', ref, '--', path]),
+      `Checked out ${path} from ${label}`
+    )
+  }
   return runAction(
-    () => git.raw(['checkout', sha, '--', path]),
-    `Checked out ${path} from ${sha.slice(0, 7)}`
+    () => git.raw(['rm', '--force', '--quiet', '--', path]),
+    `Removed ${path} (mirrors deletion from ${label})`
   )
+}
+
+async function pathExistsAtRef(
+  git: SimpleGit,
+  ref: string,
+  path: string
+): Promise<boolean> {
+  try {
+    await git.raw(['cat-file', '-e', `${ref}:${path}`])
+    return true
+  } catch {
+    return false
+  }
 }
 
 export function revertCommit(

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -1096,9 +1096,23 @@ export function getLogInkInputEvents(
     return [{
       type: 'runWorkflowAction',
       id: 'checkout-file-from-commit',
-      payload: `${context.commitDiffSelectedSha} ${context.commitDiffSelectedPath}`,
+      payload: `${context.commitDiffSelectedSha} ${context.commitDiffSelectedPath}`,
     }]
   }
+
+  // `c` on the history view cherry-picks the full selected commit on
+  // top of the current branch. Routed through the y-confirm flow since
+  // it can produce conflicts and is a real working-tree mutation.
+  if (
+    inputValue === 'c' &&
+    state.activeView === 'history' &&
+    state.focus === 'commits' &&
+    state.filteredCommits.length > 0 &&
+    !state.pendingCommitFocused
+  ) {
+    return [action({ type: 'setPendingConfirmation', value: 'cherry-pick-commit' })]
+  }
+
   // Enter on a stash row pushes the diff view scoped to that stash.
   // The runtime loads `git stash show -p <ref>` once the view is
   // active. The stash ref is passed via the action so we don't need a

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -110,10 +110,12 @@ export function getLogInkPaletteExecuteEvents(
     if (command.requiresConfirmation) {
       return [action({ type: 'setPendingConfirmation', value: command.id })]
     }
-    return [
-      action({ type: 'setWorkflowAction', value: command.id }),
-      action({ type: 'setStatus', value: `${command.label} selected` }),
-    ]
+    // Non-confirm workflows are dispatched directly through the runtime
+    // workflow runner — same path the keyboard takes. Previously this
+    // emitted `setWorkflowAction` only, which set state but never fired
+    // the action because nothing in the runtime consumes
+    // `workflowActionId`.
+    return [{ type: 'runWorkflowAction', id: command.id }]
   }
 
   // Binding-derived commands. Map each LogInkCommandId to the same events
@@ -402,7 +404,7 @@ export function getLogInkInputEvents(
       // selected item and run the right action function.
       if (workflowAction) {
         return [
-          { type: 'runWorkflowAction', id: workflowAction.id },
+          { type: 'runWorkflowAction', id: workflowAction.id, payload: state.pendingConfirmationPayload },
           action({ type: 'setPendingConfirmation', value: undefined }),
         ]
       }
@@ -940,6 +942,10 @@ export function getLogInkInputEvents(
   // handlers so a sidebar-focused Enter never fires checkout-branch /
   // navigateOpenDiffForCommit / etc. against the (hidden) selection in
   // the active tab.
+  //
+  // The Enter also moves focus out of the sidebar into the newly opened
+  // list — otherwise ↑/↓ keep cycling sidebar tabs instead of navigating
+  // inside the just-opened view, which made the drill-in feel half-done.
   if (key.return && state.focus === 'sidebar') {
     const tabToView: Partial<Record<LogInkSidebarTab, 'status' | 'branches' | 'tags' | 'stash' | 'worktrees'>> = {
       status: 'status',
@@ -950,7 +956,10 @@ export function getLogInkInputEvents(
     }
     const target = tabToView[state.sidebarTab]
     if (target) {
-      return [action({ type: 'pushView', value: target })]
+      return [
+        action({ type: 'pushView', value: target }),
+        action({ type: 'setFocus', value: 'commits' }),
+      ]
     }
     return [action({ type: 'setStatus', value: 'no detail view for this tab' })]
   }
@@ -1066,8 +1075,10 @@ export function getLogInkInputEvents(
 
   // `c` on a stash diff cherry-picks the file under the cursor —
   // materializes that single path from the stash into the working tree
-  // (`git checkout <stashRef> -- <path>`). Scoped to the stash diff
-  // surface so the letter is free elsewhere.
+  // (`git checkout <stashRef> -- <path>`). Routed through the y-confirm
+  // path because the checkout overwrites the worktree file
+  // unconditionally; the prompt is the user's chance to abort if they
+  // have unsaved edits at that path.
   if (
     inputValue === 'c' &&
     state.activeView === 'diff' &&
@@ -1075,17 +1086,18 @@ export function getLogInkInputEvents(
     context.stashDiffSelectedPath &&
     state.stashDiffRef
   ) {
-    return [{
-      type: 'runWorkflowAction',
-      id: 'checkout-file-from-stash',
+    return [action({
+      type: 'setPendingConfirmation',
+      value: 'checkout-file-from-stash',
       payload: context.stashDiffSelectedPath,
-    }]
+    })]
   }
 
   // `c` on a commit-diff explore cherry-picks the cursored file from
-  // that historical commit — `git checkout <sha> -- <path>`. The
-  // commit's hash + the selected file's path are captured at dispatch
-  // time so the runtime handler doesn't have to re-resolve them.
+  // that historical commit — `git checkout <sha> -- <path>`. Same
+  // confirmation rationale as the stash variant. The payload encodes
+  // both the sha and the path so the runtime handler doesn't have to
+  // re-resolve either.
   if (
     inputValue === 'c' &&
     state.activeView === 'diff' &&
@@ -1093,11 +1105,11 @@ export function getLogInkInputEvents(
     context.commitDiffSelectedPath &&
     context.commitDiffSelectedSha
   ) {
-    return [{
-      type: 'runWorkflowAction',
-      id: 'checkout-file-from-commit',
+    return [action({
+      type: 'setPendingConfirmation',
+      value: 'checkout-file-from-commit',
       payload: `${context.commitDiffSelectedSha} ${context.commitDiffSelectedPath}`,
-    }]
+    })]
   }
 
   // `c` on the history view cherry-picks the full selected commit on

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -847,6 +847,12 @@ export function getLogInkInputEvents(
     })]
   }
 
+  // Enter on a branch row checks the branch out. Non-destructive workflow
+  // action — no confirmation prompt.
+  if (key.return && state.activeView === 'branches' && context.branchCount) {
+    return [{ type: 'runWorkflowAction', id: 'checkout-branch' }]
+  }
+
   if (inputValue === ' ' && state.activeView === 'status' && context.worktreeFileCount) {
     return [{ type: 'toggleSelectedFileStage' }]
   }

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -72,6 +72,16 @@ export type LogInkInputContext = {
    */
   worktreeSelectedPath?: string
   /**
+   * Path of the cursored file in a commit-diff explore. Used by `c`
+   * (cherry-pick file from commit).
+   */
+  commitDiffSelectedPath?: string
+  /**
+   * Hash of the commit being explored — pairs with commitDiffSelectedPath
+   * so the cherry-pick handler knows which sha to checkout from.
+   */
+  commitDiffSelectedSha?: string
+  /**
    * True when the worktree has any staged, unstaged, or untracked changes.
    * Drives the synthetic "(+) new commit" row at the top of the history
    * list — pressing up at `selectedIndex === 0` transitions onto it; the
@@ -1069,6 +1079,24 @@ export function getLogInkInputEvents(
       type: 'runWorkflowAction',
       id: 'checkout-file-from-stash',
       payload: context.stashDiffSelectedPath,
+    }]
+  }
+
+  // `c` on a commit-diff explore cherry-picks the cursored file from
+  // that historical commit — `git checkout <sha> -- <path>`. The
+  // commit's hash + the selected file's path are captured at dispatch
+  // time so the runtime handler doesn't have to re-resolve them.
+  if (
+    inputValue === 'c' &&
+    state.activeView === 'diff' &&
+    state.diffSource === 'commit' &&
+    context.commitDiffSelectedPath &&
+    context.commitDiffSelectedSha
+  ) {
+    return [{
+      type: 'runWorkflowAction',
+      id: 'checkout-file-from-commit',
+      payload: `${context.commitDiffSelectedSha} ${context.commitDiffSelectedPath}`,
     }]
   }
   // Enter on a stash row pushes the diff view scoped to that stash.

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -876,7 +876,26 @@ export function getLogInkInputEvents(
     }
   }
 
-  if (key.return && state.activeView === 'status' && context.worktreeFileCount) {
+  // Enter on a sidebar tab drills into the corresponding promoted view
+  // (status / branches / tags / stash). Sits above the per-view Enter
+  // handlers so a sidebar-focused Enter never fires checkout-branch /
+  // navigateOpenDiffForCommit / etc. against the (hidden) selection in
+  // the active tab.
+  if (key.return && state.focus === 'sidebar') {
+    const tabToView: Partial<Record<LogInkSidebarTab, 'status' | 'branches' | 'tags' | 'stash'>> = {
+      status: 'status',
+      branches: 'branches',
+      tags: 'tags',
+      stashes: 'stash',
+    }
+    const target = tabToView[state.sidebarTab]
+    if (target) {
+      return [action({ type: 'pushView', value: target })]
+    }
+    return [action({ type: 'setStatus', value: 'no detail view for this tab' })]
+  }
+
+  if (key.return && state.activeView === 'status' && state.focus === 'commits' && context.worktreeFileCount) {
     return [action({
       type: 'navigateOpenDiffForWorktreeFile',
       fileIndex: state.selectedWorktreeFileIndex,
@@ -885,7 +904,7 @@ export function getLogInkInputEvents(
 
   // Enter on a branch row checks the branch out. Non-destructive workflow
   // action — no confirmation prompt.
-  if (key.return && state.activeView === 'branches' && context.branchCount) {
+  if (key.return && state.activeView === 'branches' && state.focus === 'commits' && context.branchCount) {
     return [{ type: 'runWorkflowAction', id: 'checkout-branch' }]
   }
 
@@ -927,7 +946,7 @@ export function getLogInkInputEvents(
   // The runtime loads `git stash show -p <ref>` once the view is
   // active. The stash ref is passed via the action so we don't need a
   // context lookup here.
-  if (key.return && state.activeView === 'stash' && context.stashCount && context.stashSelectedRef) {
+  if (key.return && state.activeView === 'stash' && state.focus === 'commits' && context.stashCount && context.stashSelectedRef) {
     return [action({
       type: 'navigateOpenDiffForStash',
       ref: context.stashSelectedRef,

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -35,6 +35,7 @@ export type LogInkInputEvent =
   | { type: 'createManualCommit' }
   | { type: 'runAiCommitDraft' }
   | { type: 'runWorkflowAction'; id: string; payload?: string }
+  | { type: 'openFileInEditor'; path: string }
 
 export type LogInkInputContext = {
   detailFileCount?: number
@@ -65,6 +66,11 @@ export type LogInkInputContext = {
    * patch. Used by `c` (cherry-pick) to know which path to materialize.
    */
   stashDiffSelectedPath?: string
+  /**
+   * Path of the cursored file in the worktree (status / worktree diff
+   * views). Used by `o` (open in $EDITOR).
+   */
+  worktreeSelectedPath?: string
   /**
    * True when the worktree has any staged, unstaged, or untracked changes.
    * Drives the synthetic "(+) new commit" row at the top of the history
@@ -1031,6 +1037,21 @@ export function getLogInkInputEvents(
       kind: 'create-stash',
       label: 'Stash message',
     })]
+  }
+
+  // `o` opens the file under the cursor in $EDITOR. Available on the
+  // status surface (worktree files), the worktree diff (the file being
+  // diffed), and the stash diff (the file the cursor sits in inside
+  // the patch). The runtime suspends Ink, spawns the editor sync, then
+  // re-renders.
+  if (inputValue === 'o' && state.activeView === 'status' && context.worktreeFileCount && context.worktreeSelectedPath) {
+    return [{ type: 'openFileInEditor', path: context.worktreeSelectedPath }]
+  }
+  if (inputValue === 'o' && state.activeView === 'diff' && state.diffSource === 'worktree' && context.worktreeSelectedPath) {
+    return [{ type: 'openFileInEditor', path: context.worktreeSelectedPath }]
+  }
+  if (inputValue === 'o' && state.activeView === 'diff' && state.diffSource === 'stash' && context.stashDiffSelectedPath) {
+    return [{ type: 'openFileInEditor', path: context.stashDiffSelectedPath }]
   }
 
   // `c` on a stash diff cherry-picks the file under the cursor —

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -991,9 +991,46 @@ export function getLogInkInputEvents(
   }
   // Per-view tag action: `P` pushes the selected tag to origin. Letter
   // is scoped to the tags surface so it doesn't collide with `p` for
-  // pop-stash.
+  // pop-stash. Note: this also takes precedence over the global
+  // push-current-branch workflow's `P` key.
   if (inputValue === 'P' && state.activeView === 'tags' && context.tagCount) {
     return [{ type: 'runWorkflowAction', id: 'push-tag' }]
+  }
+
+  // Per-view branches actions: `R` renames the selected branch, `u`
+  // sets its upstream. Both open the input prompt so the user can type
+  // the new value. Pre-fills are handled by the prompt's `initial`.
+  if (inputValue === 'R' && state.activeView === 'branches' && context.branchCount) {
+    return [action({
+      type: 'openInputPrompt',
+      kind: 'rename-branch',
+      label: 'Rename branch to',
+    })]
+  }
+  if (inputValue === 'u' && state.activeView === 'branches' && context.branchCount) {
+    return [action({
+      type: 'openInputPrompt',
+      kind: 'set-upstream',
+      label: 'Upstream ref (e.g. origin/main)',
+    })]
+  }
+
+  // Per-view tag action: `R` deletes the tag from the remote (after
+  // confirmation). Scoped per-view so this letter is free elsewhere
+  // (especially the `R` rename binding on the branches view).
+  if (inputValue === 'R' && state.activeView === 'tags' && context.tagCount) {
+    return [action({ type: 'setPendingConfirmation', value: 'delete-remote-tag' })]
+  }
+
+  // Global stash hotkey: `S` opens a stash-message prompt and
+  // `createStash` runs once submitted. Available everywhere there's
+  // not a more modal handler in front of it.
+  if (inputValue === 'S') {
+    return [action({
+      type: 'openInputPrompt',
+      kind: 'create-stash',
+      label: 'Stash message',
+    })]
   }
 
   // `c` on a stash diff cherry-picks the file under the cursor —

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -51,6 +51,8 @@ export type LogInkInputContext = {
   branchCount?: number
   tagCount?: number
   stashCount?: number
+  /** Ref of the stash currently under the cursor (e.g. `stash@{0}`). */
+  stashSelectedRef?: string
   /**
    * True when the worktree has any staged, unstaged, or untracked changes.
    * Drives the synthetic "(+) new commit" row at the top of the history
@@ -914,6 +916,17 @@ export function getLogInkInputEvents(
   }
   if (inputValue === 'p' && state.activeView === 'stash' && context.stashCount) {
     return [{ type: 'runWorkflowAction', id: 'pop-stash' }]
+  }
+  // Enter on a stash row pushes the diff view scoped to that stash.
+  // The runtime loads `git stash show -p <ref>` once the view is
+  // active. The stash ref is passed via the action so we don't need a
+  // context lookup here.
+  if (key.return && state.activeView === 'stash' && context.stashCount && context.stashSelectedRef) {
+    return [action({
+      type: 'navigateOpenDiffForStash',
+      ref: context.stashSelectedRef,
+      stashIndex: state.selectedStashIndex,
+    })]
   }
 
   if (inputValue === ' ' && state.activeView === 'status' && context.worktreeFileCount) {

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -905,6 +905,17 @@ export function getLogInkInputEvents(
     })]
   }
 
+  // Per-view stash actions: `a` apply (keep the stash), `p` pop (apply
+  // then drop). Drop is the existing destructive `X` workflow which
+  // routes through the y-confirm path. Scoped to the stash view so the
+  // letters stay free elsewhere.
+  if (inputValue === 'a' && state.activeView === 'stash' && context.stashCount) {
+    return [{ type: 'runWorkflowAction', id: 'apply-stash' }]
+  }
+  if (inputValue === 'p' && state.activeView === 'stash' && context.stashCount) {
+    return [{ type: 'runWorkflowAction', id: 'pop-stash' }]
+  }
+
   if (inputValue === ' ' && state.activeView === 'status' && context.worktreeFileCount) {
     return [{ type: 'toggleSelectedFileStage' }]
   }
@@ -952,10 +963,10 @@ export function getLogInkInputEvents(
   }
 
   if (workflowAction) {
-    return [
-      action({ type: 'setWorkflowAction', value: workflowAction.id }),
-      action({ type: 'setStatus', value: `${workflowAction.label} selected` }),
-    ]
+    // Non-destructive workflow — fire it directly via the runtime
+    // handler. The handler surfaces success/failure on the status line
+    // and silently refreshes context so the list updates.
+    return [{ type: 'runWorkflowAction', id: workflowAction.id }]
   }
 
   return []

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -51,6 +51,7 @@ export type LogInkInputContext = {
   branchCount?: number
   tagCount?: number
   stashCount?: number
+  worktreeListCount?: number
   /** Ref of the stash currently under the cursor (e.g. `stash@{0}`). */
   stashSelectedRef?: string
   /**
@@ -159,6 +160,8 @@ export function getLogInkPaletteExecuteEvents(
       return [action({ type: 'pushView', value: 'tags' })]
     case 'navigateStash':
       return [action({ type: 'pushView', value: 'stash' })]
+    case 'navigateWorktrees':
+      return [action({ type: 'pushView', value: 'worktrees' })]
     case 'navigateBack':
       return [action({ type: 'popView' })]
     case 'openSelected': {
@@ -565,6 +568,13 @@ export function getLogInkInputEvents(
     ]
   }
 
+  if (state.pendingKey === 'g' && inputValue === 'w') {
+    return [
+      action({ type: 'pushView', value: 'worktrees' }),
+      action({ type: 'setStatus', value: 'jumped to worktrees' }),
+    ]
+  }
+
   if (inputValue === 'g') {
     if (state.pendingKey === 'g') {
       return [
@@ -721,6 +731,10 @@ export function getLogInkInputEvents(
       return [action({ type: 'moveStash', delta: -1, count: context.stashCount })]
     }
 
+    if (state.activeView === 'worktrees' && context.worktreeListCount) {
+      return [action({ type: 'moveWorktreeListEntry', delta: -1, count: context.worktreeListCount })]
+    }
+
     if (
       state.activeView === 'history' &&
       state.focus === 'commits' &&
@@ -781,6 +795,10 @@ export function getLogInkInputEvents(
 
     if (state.activeView === 'stash' && context.stashCount) {
       return [action({ type: 'moveStash', delta: 1, count: context.stashCount })]
+    }
+
+    if (state.activeView === 'worktrees' && context.worktreeListCount) {
+      return [action({ type: 'moveWorktreeListEntry', delta: 1, count: context.worktreeListCount })]
     }
 
     return [
@@ -907,11 +925,12 @@ export function getLogInkInputEvents(
   // navigateOpenDiffForCommit / etc. against the (hidden) selection in
   // the active tab.
   if (key.return && state.focus === 'sidebar') {
-    const tabToView: Partial<Record<LogInkSidebarTab, 'status' | 'branches' | 'tags' | 'stash'>> = {
+    const tabToView: Partial<Record<LogInkSidebarTab, 'status' | 'branches' | 'tags' | 'stash' | 'worktrees'>> = {
       status: 'status',
       branches: 'branches',
       tags: 'tags',
       stashes: 'stash',
+      worktrees: 'worktrees',
     }
     const target = tabToView[state.sidebarTab]
     if (target) {
@@ -933,17 +952,26 @@ export function getLogInkInputEvents(
     return [{ type: 'runWorkflowAction', id: 'checkout-branch' }]
   }
 
-  // `+` on the branches / tags views opens a text-input prompt for the
-  // new branch / tag name. Empty submit is rejected by the prompt
-  // handler so the user has to either type a name or press Esc.
-  if (inputValue === '+' && state.activeView === 'branches') {
+  // `+` opens a create-branch / create-tag prompt depending on context.
+  // Works from either the matching promoted view (active branches /
+  // tags surface) or from the sidebar when the corresponding tab is
+  // active — saves a drill-in for "I just want to make a new branch".
+  const wantsCreateBranch = inputValue === '+' && (
+    state.activeView === 'branches' ||
+    (state.focus === 'sidebar' && state.sidebarTab === 'branches')
+  )
+  const wantsCreateTag = inputValue === '+' && (
+    state.activeView === 'tags' ||
+    (state.focus === 'sidebar' && state.sidebarTab === 'tags')
+  )
+  if (wantsCreateBranch) {
     return [action({
       type: 'openInputPrompt',
       kind: 'create-branch',
       label: 'New branch name',
     })]
   }
-  if (inputValue === '+' && state.activeView === 'tags') {
+  if (wantsCreateTag) {
     return [action({
       type: 'openInputPrompt',
       kind: 'create-tag',

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -917,6 +917,12 @@ export function getLogInkInputEvents(
   if (inputValue === 'p' && state.activeView === 'stash' && context.stashCount) {
     return [{ type: 'runWorkflowAction', id: 'pop-stash' }]
   }
+  // Per-view tag action: `P` pushes the selected tag to origin. Letter
+  // is scoped to the tags surface so it doesn't collide with `p` for
+  // pop-stash.
+  if (inputValue === 'P' && state.activeView === 'tags' && context.tagCount) {
+    return [{ type: 'runWorkflowAction', id: 'push-tag' }]
+  }
   // Enter on a stash row pushes the diff view scoped to that stash.
   // The runtime loads `git stash show -p <ref>` once the view is
   // active. The stash ref is passed via the action so we don't need a

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -34,7 +34,7 @@ export type LogInkInputEvent =
   | { type: 'revertSelectedHunk' }
   | { type: 'createManualCommit' }
   | { type: 'runAiCommitDraft' }
-  | { type: 'runWorkflowAction'; id: string }
+  | { type: 'runWorkflowAction'; id: string; payload?: string }
 
 export type LogInkInputContext = {
   detailFileCount?: number
@@ -251,6 +251,40 @@ export function getLogInkInputEvents(
       return [action({ type: 'setPendingMutationConfirmation', value: 'discard-draft' })]
     }
     return [{ type: 'exit' }]
+  }
+
+  // Input prompt is the most modal — when active, every keystroke routes
+  // into the prompt until Enter (submit) or Esc (cancel). Sits above the
+  // filter/confirmation/compose handlers so a prompt opened from inside
+  // any of those still captures focus cleanly.
+  if (state.inputPrompt) {
+    if (key.escape) {
+      return [
+        action({ type: 'closeInputPrompt' }),
+        action({ type: 'setStatus', value: 'cancelled' }),
+      ]
+    }
+    if (key.return) {
+      const value = state.inputPrompt.value.trim()
+      if (!value) {
+        return [action({ type: 'setStatus', value: 'enter a value or press esc to cancel' })]
+      }
+      const id = state.inputPrompt.kind
+      return [
+        { type: 'runWorkflowAction', id, payload: value },
+        action({ type: 'closeInputPrompt' }),
+      ]
+    }
+    if (key.backspace || key.delete) {
+      return [action({ type: 'backspaceInputPrompt' })]
+    }
+    if (key.ctrl && inputValue === 'u') {
+      return [action({ type: 'clearInputPromptText' })]
+    }
+    if (inputValue && !key.ctrl && !key.meta) {
+      return [action({ type: 'appendInputPrompt', value: inputValue })]
+    }
+    return []
   }
 
   if (state.commitCompose.editing) {
@@ -851,6 +885,24 @@ export function getLogInkInputEvents(
   // action — no confirmation prompt.
   if (key.return && state.activeView === 'branches' && context.branchCount) {
     return [{ type: 'runWorkflowAction', id: 'checkout-branch' }]
+  }
+
+  // `+` on the branches / tags views opens a text-input prompt for the
+  // new branch / tag name. Empty submit is rejected by the prompt
+  // handler so the user has to either type a name or press Esc.
+  if (inputValue === '+' && state.activeView === 'branches') {
+    return [action({
+      type: 'openInputPrompt',
+      kind: 'create-branch',
+      label: 'New branch name',
+    })]
+  }
+  if (inputValue === '+' && state.activeView === 'tags') {
+    return [action({
+      type: 'openInputPrompt',
+      kind: 'create-tag',
+      label: 'New tag name',
+    })]
   }
 
   if (inputValue === ' ' && state.activeView === 'status' && context.worktreeFileCount) {

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -54,6 +54,17 @@ export type LogInkInputContext = {
   /** Ref of the stash currently under the cursor (e.g. `stash@{0}`). */
   stashSelectedRef?: string
   /**
+   * Per-file `diff --git` line offsets inside the active stash diff.
+   * Used by `]` / `[` to jump to next / previous file within a stash
+   * patch.
+   */
+  stashDiffFileOffsets?: number[]
+  /**
+   * Path of the file currently under the diff-view cursor in a stash
+   * patch. Used by `c` (cherry-pick) to know which path to materialize.
+   */
+  stashDiffSelectedPath?: string
+  /**
    * True when the worktree has any staged, unstaged, or untracked changes.
    * Drives the synthetic "(+) new commit" row at the top of the history
    * list — pressing up at `selectedIndex === 0` transitions onto it; the
@@ -615,6 +626,13 @@ export function getLogInkInputEvents(
         hunkOffsets: context.worktreeHunkOffsets,
       })]
     }
+    if (state.activeView === 'diff' && state.diffSource === 'stash' && context.stashDiffFileOffsets?.length) {
+      return [action({
+        type: 'jumpCommitDiffHunk',
+        delta: -1,
+        hunkOffsets: context.stashDiffFileOffsets,
+      })]
+    }
     if (state.activeView === 'diff' && context.commitDiffHunkOffsets?.length) {
       return [action({
         type: 'jumpCommitDiffHunk',
@@ -631,6 +649,13 @@ export function getLogInkInputEvents(
         type: 'jumpWorktreeHunk',
         delta: 1,
         hunkOffsets: context.worktreeHunkOffsets,
+      })]
+    }
+    if (state.activeView === 'diff' && state.diffSource === 'stash' && context.stashDiffFileOffsets?.length) {
+      return [action({
+        type: 'jumpCommitDiffHunk',
+        delta: 1,
+        hunkOffsets: context.stashDiffFileOffsets,
       })]
     }
     if (state.activeView === 'diff' && context.commitDiffHunkOffsets?.length) {
@@ -941,6 +966,24 @@ export function getLogInkInputEvents(
   // pop-stash.
   if (inputValue === 'P' && state.activeView === 'tags' && context.tagCount) {
     return [{ type: 'runWorkflowAction', id: 'push-tag' }]
+  }
+
+  // `c` on a stash diff cherry-picks the file under the cursor —
+  // materializes that single path from the stash into the working tree
+  // (`git checkout <stashRef> -- <path>`). Scoped to the stash diff
+  // surface so the letter is free elsewhere.
+  if (
+    inputValue === 'c' &&
+    state.activeView === 'diff' &&
+    state.diffSource === 'stash' &&
+    context.stashDiffSelectedPath &&
+    state.stashDiffRef
+  ) {
+    return [{
+      type: 'runWorkflowAction',
+      id: 'checkout-file-from-stash',
+      payload: context.stashDiffSelectedPath,
+    }]
   }
   // Enter on a stash row pushes the diff view scoped to that stash.
   // The runtime loads `git stash show -p <ref>` once the view is

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -57,7 +57,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ branches', 's sort', 'D delete', 'X checkout', 'enter diff'],
+      contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'D delete', 's sort'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 
@@ -67,7 +67,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ tags', 's sort', 'T create', 'X push', 'esc back'],
+      contextual: ['↑/↓ tags', '+ new', 'T delete', 's sort'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -17,7 +17,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ move', '/ search', 'gg/G top/bottom', 'n/N next'],
+      contextual: ['↑/↓ move', 'enter diff', 'c cherry-pick', '/ search', 'gg/G top/bottom'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -77,7 +77,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ stashes', 'A apply', 'D drop', 'esc back'],
+      contextual: ['↑/↓ stashes', 'a apply', 'p pop', 'X drop', 'esc back'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -67,7 +67,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ tags', '+ new', 'T delete', 's sort'],
+      contextual: ['↑/↓ tags', '+ new', 'P push', 'T delete', 's sort'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -37,7 +37,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['j/k hunks', 'space stage', 'z revert', 'e/c compose', 'esc files'],
+      contextual: ['j/k hunks', 'space stage', 'z revert', 'o edit', 'e/c compose', 'esc files'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 
@@ -47,7 +47,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['e edit', 'tab field', 'c commit', 'I AI draft', 'esc back'],
+      contextual: ['e edit', 'c commit', 'I AI draft', 'gs hunks', 'esc back'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -77,7 +77,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ stashes', 'a apply', 'p pop', 'X drop', 'esc back'],
+      contextual: ['↑/↓ stashes', 'enter diff', 'a apply', 'p pop', 'X drop'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -488,19 +488,27 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
   if (options.activeView === 'diff') {
     if (options.diffSource === 'stash') {
       return {
-        contextual: ['j/k lines', '[/] file', 'c cherry-pick', 'esc back'],
+        contextual: ['j/k lines', '[/] file', 'c cherry-pick', 'o edit', 'esc back'],
+        global: NORMAL_GLOBAL_HINTS,
+      }
+    }
+    if (options.diffSource === 'commit') {
+      // Read-only commit-diff explore: no staging applies. Surface only
+      // the keys that actually do something.
+      return {
+        contextual: ['j/k hunks', '[/] file', 'esc back'],
         global: NORMAL_GLOBAL_HINTS,
       }
     }
     return {
-      contextual: ['j/k hunks', 'space stage', 'z revert', 'e/c compose', 'esc files'],
+      contextual: ['j/k hunks', 'space stage', 'z revert', 'o edit', 'e/c compose', 'esc files'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }
 
   if (options.activeView === 'compose') {
     return {
-      contextual: ['e edit', 'tab field', 'c commit', 'I AI draft', 'esc back'],
+      contextual: ['e edit', 'c commit', 'I AI draft', 'gs hunks', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -496,7 +496,7 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
 
   if (options.activeView === 'tags') {
     return {
-      contextual: ['↑/↓ tags', '+ new', 'T delete', 's sort'],
+      contextual: ['↑/↓ tags', '+ new', 'P push', 'T delete', 's sort'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -503,7 +503,7 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
 
   if (options.activeView === 'stash') {
     return {
-      contextual: ['↑/↓ stashes', 'A apply', 'D drop', 'esc back'],
+      contextual: ['↑/↓ stashes', 'a apply', 'p pop', 'X drop', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -493,10 +493,10 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
       }
     }
     if (options.diffSource === 'commit') {
-      // Read-only commit-diff explore: no staging applies. Surface only
-      // the keys that actually do something.
+      // Commit-diff explore: read-only diff, but `c` cherry-picks the
+      // cursored file from the commit into the worktree.
       return {
-        contextual: ['j/k hunks', '[/] file', 'esc back'],
+        contextual: ['j/k hunks', '[/] file', 'c cherry-pick', 'esc back'],
         global: NORMAL_GLOBAL_HINTS,
       }
     }

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -489,14 +489,14 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
 
   if (options.activeView === 'branches') {
     return {
-      contextual: ['↑/↓ branches', 's sort', 'D delete', 'X checkout', 'enter diff'],
+      contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'D delete', 's sort'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }
 
   if (options.activeView === 'tags') {
     return {
-      contextual: ['↑/↓ tags', 's sort', 'T create', 'X push', 'esc back'],
+      contextual: ['↑/↓ tags', '+ new', 'T delete', 's sort'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -542,7 +542,7 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
   }
 
   return {
-    contextual: ['↑/↓ move', '/ search', 'gg/G top/bottom', 'n/N next'],
+    contextual: ['↑/↓ move', 'enter diff', 'c cherry-pick', '/ search', 'gg/G top/bottom'],
     global: NORMAL_GLOBAL_HINTS,
   }
 }

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -23,6 +23,7 @@ export type LogInkCommandId =
   | 'navigateDiff'
   | 'navigateHome'
   | 'navigateStash'
+  | 'navigateWorktrees'
   | 'navigateStatus'
   | 'navigateTags'
   | 'nextHunk'
@@ -232,6 +233,13 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     contexts: ['normal'],
   },
   {
+    id: 'navigateWorktrees',
+    keys: ['gw'],
+    label: 'worktrees',
+    description: 'Push the linked worktrees view.',
+    contexts: ['normal'],
+  },
+  {
     id: 'navigateBack',
     keys: ['<', 'esc'],
     label: 'back',
@@ -386,6 +394,7 @@ const GLOBAL_BINDING_IDS: LogInkCommandId[] = [
   'navigateBranches',
   'navigateTags',
   'navigateStash',
+  'navigateWorktrees',
   'navigateBack',
 ]
 
@@ -513,6 +522,13 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
   if (options.activeView === 'stash') {
     return {
       contextual: ['↑/↓ stashes', 'enter diff', 'a apply', 'p pop', 'X drop'],
+      global: NORMAL_GLOBAL_HINTS,
+    }
+  }
+
+  if (options.activeView === 'worktrees') {
+    return {
+      contextual: ['↑/↓ worktrees', 'W remove', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -503,7 +503,7 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
 
   if (options.activeView === 'stash') {
     return {
-      contextual: ['↑/↓ stashes', 'a apply', 'p pop', 'X drop', 'esc back'],
+      contextual: ['↑/↓ stashes', 'enter diff', 'a apply', 'p pop', 'X drop'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -312,6 +312,9 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
 
 export type GetLogInkFooterHintsOptions = {
   activeView?: LogInkView
+  /** Used to differentiate the diff-view hints between commit / worktree
+   *  / stash sources without reaching into runtime state. */
+  diffSource?: 'commit' | 'worktree' | 'stash'
   filterMode: boolean
   focus: LogInkFocus
   showHelp: boolean
@@ -474,6 +477,12 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
   }
 
   if (options.activeView === 'diff') {
+    if (options.diffSource === 'stash') {
+      return {
+        contextual: ['j/k lines', '[/] file', 'c cherry-pick', 'esc back'],
+        global: NORMAL_GLOBAL_HINTS,
+      }
+    }
     return {
       contextual: ['j/k hunks', 'space stage', 'z revert', 'e/c compose', 'esc files'],
       global: NORMAL_GLOBAL_HINTS,

--- a/src/commands/log/inkLayout.test.ts
+++ b/src/commands/log/inkLayout.test.ts
@@ -39,4 +39,24 @@ describe('log Ink layout', () => {
     expect(getLogInkLayout({ columns: 79, rows: 24 }).tooSmall).toBe(true)
     expect(getLogInkLayout({ columns: 80, rows: 23 }).tooSmall).toBe(true)
   })
+
+  it('grows the sidebar when sidebarFocused is set', () => {
+    const collapsed = getLogInkLayout({ columns: 120, rows: 40 })
+    const expanded = getLogInkLayout({ columns: 120, rows: 40, sidebarFocused: true })
+
+    expect(expanded.sidebarWidth).toBeGreaterThan(collapsed.sidebarWidth)
+    expect(expanded.sidebarWidth).toBe(43)
+    expect(expanded.detailWidth).toBe(collapsed.detailWidth)
+    // Main panel shrinks to absorb the sidebar growth so the three
+    // panels still tile flush across the terminal.
+    expect(expanded.mainPanelWidth).toBe(120 - expanded.sidebarWidth - expanded.detailWidth)
+  })
+
+  it('clamps the focused sidebar to its 32–50 cell range', () => {
+    const narrow = getLogInkLayout({ columns: 80, rows: 24, sidebarFocused: true })
+    const wide = getLogInkLayout({ columns: 200, rows: 60, sidebarFocused: true })
+
+    expect(narrow.sidebarWidth).toBe(32)
+    expect(wide.sidebarWidth).toBe(50)
+  })
 })

--- a/src/commands/log/inkLayout.ts
+++ b/src/commands/log/inkLayout.ts
@@ -1,6 +1,13 @@
 export type LogInkLayoutInput = {
   columns: number
   rows: number
+  /**
+   * When true the sidebar grows so long branch / file names stop
+   * truncating. Set this when the sidebar pane has focus — at rest the
+   * sidebar stays compact so the diff / history panels get most of the
+   * width.
+   */
+  sidebarFocused?: boolean
 }
 
 export type LogInkLayout = {
@@ -28,7 +35,12 @@ export function getLogInkLayout(input: LogInkLayoutInput): LogInkLayout {
   const columns = input.columns || LOG_INK_DEFAULT_COLUMNS
   const rows = input.rows || LOG_INK_DEFAULT_ROWS
   const detailWidth = Math.max(30, Math.min(56, Math.floor(columns * 0.34)))
-  const sidebarWidth = Math.max(22, Math.min(34, Math.floor(columns * 0.24)))
+  // Sidebar at rest: 22-34 cells (~24% of width). Focused: 32-50 cells
+  // (~36% of width). The transition is instant per render — focus tab to
+  // expand, focus away to collapse.
+  const sidebarWidth = input.sidebarFocused
+    ? Math.max(32, Math.min(50, Math.floor(columns * 0.36)))
+    : Math.max(22, Math.min(34, Math.floor(columns * 0.24)))
 
   return {
     bodyRows: Math.max(8, rows - 5),

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -136,8 +136,7 @@ import { startInteractiveLog } from './interactive'
 import { GitOperationOverview, getGitOperationOverview } from './operationData'
 import { ProviderOverview, ProviderRepository, buildProviderUrl, getProviderOverview } from './providerData'
 import { checkoutBranch, createBranch, deleteBranch } from './branchActions'
-import { createLightweightTag } from './tagActions'
-import { deleteLocalTag } from './tagActions'
+import { createLightweightTag, deleteLocalTag, pushTag } from './tagActions'
 import { applyStash, dropStash, popStash } from './stashActions'
 import { removeWorktree } from './worktreeActions'
 import { abortOperation } from './operationActions'
@@ -1184,6 +1183,15 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         const tag = visible[Math.min(state.selectedTagIndex, visible.length - 1)]
         if (!tag) return { ok: false, message: 'No tag selected' }
         return deleteLocalTag(git, tag.name)
+      },
+      'push-tag': async () => {
+        const all = sortTags(context.tags?.tags || [], state.tagSort)
+        const visible = state.filter
+          ? all.filter((t) => matchesPromotedFilter([t.name, t.subject], state.filter))
+          : all
+        const tag = visible[Math.min(state.selectedTagIndex, visible.length - 1)]
+        if (!tag) return { ok: false, message: 'No tag selected' }
+        return pushTag(git, tag.name)
       },
       'drop-stash': async () => {
         const all = context.stashes?.stashes || []

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -1500,8 +1500,32 @@ function renderSidebar(
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const focused = state.focus === 'sidebar'
-  const lines = sidebarLines(context, contextStatus, state.sidebarTab, width - 4, state, theme)
   const tabs = getLogInkSidebarTabs()
+
+  // Accordion layout — every tab's title is visible on its own line, but
+  // only the active tab expands its content underneath. Switching tabs
+  // (1-5 / [/]) collapses the previous and expands the next.
+  const tabBlocks = tabs.flatMap((tab, tabIndex) => {
+    const isActive = tab === state.sidebarTab
+    const count = sidebarTabCount(tab, context)
+    const labelWithCount = count !== undefined
+      ? `${sidebarTabLabel(tab)} (${count})`
+      : sidebarTabLabel(tab)
+    const headerText = isActive ? `[${labelWithCount}]` : labelWithCount
+    const blocks: ReactTypes.ReactElement[] = []
+    if (tabIndex > 0) {
+      blocks.push(h(Text, { key: `tab-spacer-${tab}` }, ''))
+    }
+    blocks.push(h(Text, {
+      key: `tab-header-${tab}`,
+      bold: isActive,
+      dimColor: !isActive,
+    }, headerText))
+    if (isActive) {
+      blocks.push(...renderActiveSidebarContent(h, Text, tab, state, context, contextStatus, width, theme))
+    }
+    return blocks
+  })
 
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
@@ -1511,15 +1535,75 @@ function renderSidebar(
     paddingX: 1,
   },
   h(Text, { bold: true }, panelTitle('Repository', focused)),
-  h(Text, { dimColor: true }, tabs.map((tab) => {
-    const count = sidebarTabCount(tab, context)
-    const labelWithCount = count !== undefined
-      ? `${sidebarTabLabel(tab)} (${count})`
-      : sidebarTabLabel(tab)
-    return tab === state.sidebarTab ? `[${labelWithCount}]` : labelWithCount
-  }).join(' ')),
   h(Text, undefined, ''),
-  ...lines.map((line, index) => h(Text, { key: `sidebar-${index}` }, truncate(line, width - 4))))
+  ...tabBlocks)
+}
+
+/**
+ * Render the indented body of the active sidebar tab. The status tab
+ * colours its summary counts (warning / danger / muted) and per-file
+ * rows so they read as the same severity scale used in the main status
+ * surface; every other tab falls through to `sidebarLines` for its
+ * string-based summary.
+ */
+function renderActiveSidebarContent(
+  h: typeof ReactTypes.createElement,
+  Text: LogInkComponents['Text'],
+  tab: LogInkSidebarTab,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  width: number,
+  theme: LogInkTheme
+): ReactTypes.ReactElement[] {
+  if (tab === 'status') {
+    return renderActiveStatusTabContent(h, Text, context, contextStatus, width, theme)
+  }
+  const lines = sidebarLines(context, contextStatus, tab, width - 6, state, theme)
+  return lines.map((line, index) => h(Text, {
+    key: `tab-content-${tab}-${index}`,
+    dimColor: !line.trim(),
+  }, truncate(`  ${line}`, width - 4)))
+}
+
+function renderActiveStatusTabContent(
+  h: typeof ReactTypes.createElement,
+  Text: LogInkComponents['Text'],
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  width: number,
+  theme: LogInkTheme
+): ReactTypes.ReactElement[] {
+  if (isLogInkContextKeyLoading(contextStatus, 'worktree')) {
+    return [h(Text, { key: 'tab-status-loading', dimColor: true }, '  Loading status…')]
+  }
+  const worktree = context.worktree
+  if (!worktree) {
+    return [h(Text, { key: 'tab-status-empty', dimColor: true }, '  Status unavailable')]
+  }
+  const colorOf = (state: 'staged' | 'unstaged' | 'untracked'): string | undefined => {
+    if (theme.noColor) return undefined
+    if (state === 'staged') return theme.colors.warning
+    if (state === 'unstaged') return theme.colors.danger
+    return theme.colors.muted
+  }
+  const summaryRow = (count: number, label: string, key: string, kind: 'staged' | 'unstaged' | 'untracked') =>
+    h(Text, { key }, '  ', h(Text, { color: colorOf(kind), bold: count > 0 }, `${count} ${label}`))
+  const fileRows = worktree.files.slice(0, 12).map((file, index) => {
+    const codes = `${file.indexStatus}${file.worktreeStatus}`
+    return h(Text, {
+      key: `tab-status-file-${index}`,
+      color: colorOf(file.state),
+    }, truncate(`  ${codes} ${file.path}`, width - 4))
+  })
+  return [
+    summaryRow(worktree.stagedCount, 'staged', 'tab-status-staged', 'staged'),
+    summaryRow(worktree.unstagedCount, 'unstaged', 'tab-status-unstaged', 'unstaged'),
+    summaryRow(worktree.untrackedCount, 'untracked', 'tab-status-untracked', 'untracked'),
+    ...(fileRows.length
+      ? [h(Text, { key: 'tab-status-spacer' }, ''), ...fileRows]
+      : []),
+  ]
 }
 
 function renderMainPanel(

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -1904,17 +1904,25 @@ function renderComposeSurface(
       dimColor: line === '<empty>',
     }, `  ${line}${bodyCursor && isLast ? bodyCursor : ''}`)
   }),
-  h(Text, undefined, ''),
+  // Loading indicator + post-action message belong inline with the draft
+  // (they describe what just happened to the fields above). The state-
+  // line ("Editing — Enter switches summary↔body…" / "Press e to edit
+  // …") is footer-style guidance and now sits at the very bottom of the
+  // pane so it doesn't visually separate the body from any
+  // result/details.
   ...(compose.loading
-    ? [h(Text, {
-      key: 'compose-loading',
-      bold: true,
-      color: theme.noColor ? undefined : theme.colors.accent,
-    }, theme.ascii
-      ? '[...] Generating AI commit draft (this can take a moment)'
-      : '⏳ Generating AI commit draft… (this can take a moment)')]
-    : [h(Text, { dimColor: true }, stateLine)]),
-  ...(compose.message ? [h(Text, { key: 'compose-msg' }, truncate(compose.message, 140))] : []),
+    ? [
+      h(Text, undefined, ''),
+      h(Text, {
+        key: 'compose-loading',
+        bold: true,
+        color: theme.noColor ? undefined : theme.colors.accent,
+      }, theme.ascii
+        ? '[...] Generating AI commit draft (this can take a moment)'
+        : '⏳ Generating AI commit draft… (this can take a moment)'),
+    ]
+    : []),
+  ...(compose.message ? [h(Text, undefined, ''), h(Text, { key: 'compose-msg' }, truncate(compose.message, 140))] : []),
   ...(compose.details || []).map((line, index) => h(Text, {
     key: `compose-detail-${index}`,
     dimColor: true,
@@ -1924,7 +1932,9 @@ function renderComposeSurface(
       h(Text, { key: 'compose-no-staged-spacer' }, ''),
       h(Text, { key: 'compose-no-staged', dimColor: true }, truncate(noStagedHint, 140)),
     ]
-    : []))
+    : []),
+  h(Box, { flexGrow: 1 }),
+  h(Text, { key: 'compose-stateline', dimColor: true }, truncate(stateLine, width - 4)))
 }
 
 function matchesPromotedFilter(haystacks: string[], filter: string): boolean {

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -35,6 +35,7 @@
  *     every text decoration is dropped.
  */
 
+import { spawnSync } from 'node:child_process'
 import type * as ReactTypes from 'react'
 import { SimpleGit } from 'simple-git'
 import { BranchOverview, getBranchOverview } from './branchData'
@@ -1147,6 +1148,47 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     dispatch({ type: 'setStatus', value: result.message })
   }, [dispatch])
 
+  // Open a file in $EDITOR (or $VISUAL) by suspending Ink's hold on the
+  // terminal, spawning the editor synchronously inheriting stdio, then
+  // restoring the alt screen + raw mode and forcing a re-render. The
+  // dance mirrors the SIGTSTP / SIGCONT path in inkTerminalLifecycle.
+  // Falls back to vi when neither env var is set; surfaces a status
+  // message on missing-binary / non-zero exit so the user isn't left
+  // wondering.
+  const openInEditor = React.useCallback((path: string) => {
+    if (!path) return
+    const editor = process.env.VISUAL || process.env.EDITOR || 'vi'
+    const out = process.stdout
+    const stdin = process.stdin
+    const ENTER_ALT = '\x1b[?1049h'
+    const EXIT_ALT = '\x1b[?1049l'
+    const SHOW_CURSOR = '\x1b[?25h'
+    const HIDE_CURSOR = '\x1b[?25l'
+    try {
+      // Drop into the primary buffer + cooked mode so the editor
+      // doesn't inherit our raw-mode keystrokes.
+      stdin.setRawMode?.(false)
+      out.write(`${SHOW_CURSOR}${EXIT_ALT}`)
+      const result = spawnSync(editor, [path], { stdio: 'inherit' })
+      if (result.error) {
+        dispatch({ type: 'setStatus', value: `Failed to launch ${editor}: ${result.error.message}` })
+      } else if (typeof result.status === 'number' && result.status !== 0) {
+        dispatch({ type: 'setStatus', value: `${editor} exited with status ${result.status}` })
+      } else {
+        dispatch({ type: 'setStatus', value: `Edited ${path}` })
+      }
+    } finally {
+      // Re-enter the alt screen + raw mode + hidden cursor; nudge React
+      // so the freshly-restored screen actually paints.
+      out.write(`${ENTER_ALT}${HIDE_CURSOR}`)
+      stdin.setRawMode?.(true)
+      resumeRef?.current?.()
+    }
+    // Worktree status may have changed (e.g. user saved an edit) — silent
+    // refresh so the file row reflects the new staged/unstaged state.
+    void refreshWorktreeContext({ silent: true })
+  }, [dispatch, refreshWorktreeContext, resumeRef])
+
   // Resolve the destructive-action target from the live filtered+sorted
   // list the user is looking at, run the action against it, surface the
   // result on the status line, and silently refresh so the deleted item
@@ -1493,6 +1535,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       stashDiffFileOffsets: stashDiffFileOffsets.length ? stashDiffFileOffsets : undefined,
       stashDiffSelectedPath,
       worktreeListCount: context.worktreeList?.worktrees.length,
+      worktreeSelectedPath: context.worktree?.files[state.selectedWorktreeFileIndex]?.path,
       worktreeDirty,
     }).forEach((event) => {
       if (event.type === 'exit') {
@@ -1513,6 +1556,8 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         void runAiCommitDraft()
       } else if (event.type === 'runWorkflowAction') {
         void runWorkflowAction(event.id, event.payload)
+      } else if (event.type === 'openFileInEditor') {
+        openInEditor(event.path)
       } else {
         // P4.5: enrich filter-mutating actions with a precomputed
         // selection snapshot so the reducer can preserve the cursor on

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -135,6 +135,7 @@ import {
 } from './inkViewModel'
 import { startInteractiveLog } from './interactive'
 import { GitOperationOverview, getGitOperationOverview } from './operationData'
+import { openProviderUrl } from './providerActions'
 import { ProviderOverview, ProviderRepository, buildProviderUrl, getProviderOverview } from './providerData'
 import {
   checkoutBranch,
@@ -1296,6 +1297,19 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
           return { ok: false, message: 'No git operation in progress' }
         }
         return abortOperation(git, operation)
+      },
+      'open-pr': async () => {
+        const repo = context.provider?.repository
+        if (!repo || repo.provider !== 'github' || !repo.owner || !repo.name) {
+          return { ok: false, message: 'No GitHub remote detected for this repo' }
+        }
+        const pr = context.provider?.currentPullRequest || context.pullRequest?.currentPullRequest
+        if (pr) {
+          return openProviderUrl(repo, { type: 'pull-request', number: pr.number })
+        }
+        // No PR — fall back to opening the repo page so the user can
+        // create one or browse from there.
+        return openProviderUrl(repo, { type: 'repo' })
       },
       'fetch-remotes': async () => fetchRemotes(git),
       'pull-current-branch': async () => pullCurrentBranch(git),

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -810,8 +810,10 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     if (state.inputPrompt || state.pendingConfirmationId || state.pendingMutationConfirmation || state.showCommandPalette) {
       return
     }
-    // DevSkim: ignore DS172411 — callback is a function literal, delay
-    // is a hard-coded constant.
+    // The `setTimeout` callback is a literal arrow function (not a
+    // string), and the delay is a hard-coded constant, so the
+    // eval-injection vector behind DevSkim DS172411 doesn't apply here.
+    // DevSkim: ignore DS172411
     const handle = setTimeout(() => {
       if (mountedRef.current) {
         dispatch({ type: 'setStatus', value: undefined })
@@ -911,10 +913,16 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   }, [git, refreshContext, refreshWorktreeContext])
 
   // Per-repo sidebar tab persistence (#21). Resolve the repo root, look
-  // up the cached tab, and dispatch `setSidebarTab` once on mount so the
-  // user lands on whichever tab they were last on for this project.
-  // Subsequent setSidebarTab actions (1-5 / [/]) write back to the cache.
-  // Best-effort — read/write failures fall through to the default tab.
+  // up the cached tab, and dispatch `restoreSidebarTab` once on mount so
+  // the user lands on whichever tab they were last on for this project.
+  // `restoreSidebarTab` (vs `setSidebarTab`) intentionally does not pull
+  // focus into the sidebar — the user lands on commits, the saved tab
+  // is just visible in the gutter.
+  //
+  // The save effect listens to `userSidebarTab` (the user's explicit
+  // choice mirror), not `sidebarTab`. That way the auto-switch to
+  // Branches when entering compose / status doesn't overwrite the saved
+  // preference.
   const repoRootRef = React.useRef<string | undefined>(undefined)
   React.useEffect(() => {
     let cancelled = false
@@ -924,8 +932,8 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         if (cancelled || !repoRoot) return
         repoRootRef.current = repoRoot
         const saved = getSavedSidebarTab(repoRoot)
-        if (saved && saved !== state.sidebarTab) {
-          dispatch({ type: 'setSidebarTab', value: saved })
+        if (saved && saved !== state.userSidebarTab) {
+          dispatch({ type: 'restoreSidebarTab', value: saved })
         }
       } catch {
         // Not in a worktree, or revparse failed; nothing to restore.
@@ -937,8 +945,8 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   React.useEffect(() => {
     const repoRoot = repoRootRef.current
     if (!repoRoot) return
-    saveSidebarTab(repoRoot, state.sidebarTab)
-  }, [state.sidebarTab])
+    saveSidebarTab(repoRoot, state.userSidebarTab)
+  }, [state.userSidebarTab])
 
   // P-stash-explorer: load `git stash show -p <ref>` once the diff view
   // becomes active with diffSource='stash'. Best-effort — empty stashes
@@ -1218,7 +1226,15 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // wondering.
   const openInEditor = React.useCallback((path: string) => {
     if (!path) return
-    const editor = process.env.VISUAL || process.env.EDITOR || 'vi'
+    const editorEnv = process.env.VISUAL || process.env.EDITOR || 'vi'
+    // $VISUAL / $EDITOR commonly include flags (`code -w`, `vim -f`,
+    // `emacs -nw`). Tokenize on whitespace so the leading word is the
+    // executable and the rest are passed as arguments — passing the
+    // full string to spawnSync as the executable would fail with
+    // ENOENT for any of those configurations.
+    const editorArgs = editorEnv.trim().split(/\s+/).filter(Boolean)
+    const editor = editorArgs[0] || 'vi'
+    const editorPrefixArgs = editorArgs.slice(1)
     const out = process.stdout
     const stdin = process.stdin
     const ENTER_ALT = '\x1b[?1049h'
@@ -1230,9 +1246,14 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       // doesn't inherit our raw-mode keystrokes.
       stdin.setRawMode?.(false)
       out.write(`${SHOW_CURSOR}${EXIT_ALT}`)
-      const result = spawnSync(editor, [path], { stdio: 'inherit' })
+      const result = spawnSync(editor, [...editorPrefixArgs, path], { stdio: 'inherit' })
       if (result.error) {
         dispatch({ type: 'setStatus', value: `Failed to launch ${editor}: ${result.error.message}` })
+      } else if (result.signal) {
+        // Editor was killed by a signal (e.g. ^C, SIGTERM). status is
+        // null in this case, so the old `status !== 0` check would
+        // mistakenly fall through to the success branch.
+        dispatch({ type: 'setStatus', value: `${editor} interrupted by ${result.signal}` })
       } else if (typeof result.status === 'number' && result.status !== 0) {
         dispatch({ type: 'setStatus', value: `${editor} exited with status ${result.status}` })
       } else {
@@ -1362,15 +1383,25 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       },
       'remove-worktree': async () => {
         const all = context.worktreeList?.worktrees || []
-        // Prefer the cursor on the worktrees promoted view; fall back to
-        // the first non-current worktree (e.g. when the action is fired
-        // from the command palette without ever visiting `g w`).
-        const cursorTarget = all[Math.min(state.selectedWorktreeListIndex, Math.max(0, all.length - 1))]
-        const target = cursorTarget && !cursorTarget.current
-          ? cursorTarget
-          : all.find((w) => !w.current)
-        if (!target) return { ok: false, message: 'No removable worktree' }
-        return removeWorktree(git, target)
+        // Resolve the target from the visible (filtered) list so a
+        // hidden filtered-out worktree can never be the action target.
+        // Falls back to the cursor against the unfiltered list when the
+        // action is invoked from the palette without ever visiting the
+        // worktrees view.
+        const visible = state.filter
+          ? all.filter((w) => matchesPromotedFilter([w.path, w.branch || ''], state.filter))
+          : all
+        const cursorTarget = visible.length
+          ? visible[Math.min(state.selectedWorktreeListIndex, visible.length - 1)]
+          : all[Math.min(state.selectedWorktreeListIndex, Math.max(0, all.length - 1))]
+        if (!cursorTarget) return { ok: false, message: 'No worktree selected' }
+        if (cursorTarget.current) {
+          return {
+            ok: false,
+            message: 'Cannot remove the current worktree — switch to another worktree first.',
+          }
+        }
+        return removeWorktree(git, cursorTarget)
       },
       'abort-operation': async () => {
         const operation = context.operation?.operation
@@ -1586,6 +1617,15 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     const stashVisibleCount = visibleStashes.length
     const stashSelectedRef = visibleStashes[Math.min(state.selectedStashIndex, Math.max(0, visibleStashes.length - 1))]?.ref
 
+    // The worktrees promoted view is filterable; mirror the branches /
+    // tags / stash pattern and feed the filtered count into the input
+    // dispatcher so ↑/↓ stay synchronized with the visible rows.
+    const worktreeVisibleCount = state.filter
+      ? (context.worktreeList?.worktrees || [])
+        .filter((w) => matchesPromotedFilter([w.path, w.branch || ''], state.filter))
+        .length
+      : context.worktreeList?.worktrees.length
+
     // When the diff view is showing a stash patch, swap the previewLineCount
     // to the stash diff length so the existing pageDetailPreview path
     // (j/k, PgUp/PgDn) scrolls through it without a parallel pipeline.
@@ -1629,7 +1669,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       stashSelectedRef,
       stashDiffFileOffsets: stashDiffFileOffsets.length ? stashDiffFileOffsets : undefined,
       stashDiffSelectedPath,
-      worktreeListCount: context.worktreeList?.worktrees.length,
+      worktreeListCount: worktreeVisibleCount,
       worktreeSelectedPath: context.worktree?.files[state.selectedWorktreeFileIndex]?.path,
       commitDiffSelectedPath: state.diffSource === 'commit'
         ? selectedDetailFile?.path

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -148,6 +148,7 @@ import {
   setUpstream,
 } from './branchActions'
 import { createLightweightTag, deleteLocalTag, deleteRemoteTag, pushTag } from './tagActions'
+import { checkoutFileFromCommit } from './historyActions'
 import { applyStash, checkoutFileFromStash, createStash, dropStash, popStash } from './stashActions'
 import { removeWorktree } from './worktreeActions'
 import { abortOperation } from './operationActions'
@@ -1279,6 +1280,18 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         if (!ref) return { ok: false, message: 'No stash ref active' }
         return checkoutFileFromStash(git, ref, path)
       },
+      'checkout-file-from-commit': async () => {
+        // payload is "<sha> <path>" so we pass both through a single
+        // string field on the action.
+        const trimmed = payload?.trim()
+        if (!trimmed) return { ok: false, message: 'No commit file under cursor' }
+        const spaceIndex = trimmed.indexOf(' ')
+        if (spaceIndex < 0) return { ok: false, message: 'Malformed commit file payload' }
+        const sha = trimmed.slice(0, spaceIndex)
+        const path = trimmed.slice(spaceIndex + 1)
+        if (!sha || !path) return { ok: false, message: 'No commit file under cursor' }
+        return checkoutFileFromCommit(git, sha, path)
+      },
       'remove-worktree': async () => {
         const all = context.worktreeList?.worktrees || []
         // Prefer the cursor on the worktrees promoted view; fall back to
@@ -1550,6 +1563,12 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       stashDiffSelectedPath,
       worktreeListCount: context.worktreeList?.worktrees.length,
       worktreeSelectedPath: context.worktree?.files[state.selectedWorktreeFileIndex]?.path,
+      commitDiffSelectedPath: state.diffSource === 'commit'
+        ? selectedDetailFile?.path
+        : undefined,
+      commitDiffSelectedSha: state.diffSource === 'commit'
+        ? selected?.hash
+        : undefined,
       worktreeDirty,
     }).forEach((event) => {
       if (event.type === 'exit') {

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -135,7 +135,7 @@ import {
 import { startInteractiveLog } from './interactive'
 import { GitOperationOverview, getGitOperationOverview } from './operationData'
 import { ProviderOverview, ProviderRepository, buildProviderUrl, getProviderOverview } from './providerData'
-import { deleteBranch } from './branchActions'
+import { checkoutBranch, deleteBranch } from './branchActions'
 import { deleteLocalTag } from './tagActions'
 import { dropStash } from './stashActions'
 import { removeWorktree } from './worktreeActions'
@@ -1119,6 +1119,16 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // tag / drop-stash / remove-worktree / abort-operation.
   const runWorkflowAction = React.useCallback(async (id: string) => {
     const handlers: Record<string, () => Promise<{ ok: boolean; message: string } | undefined>> = {
+      'checkout-branch': async () => {
+        const all = sortBranches(context.branches?.localBranches || [], state.branchSort)
+        const visible = state.filter
+          ? all.filter((b) => matchesPromotedFilter([b.shortName, b.upstream || ''], state.filter))
+          : all
+        const branch = visible[Math.min(state.selectedBranchIndex, visible.length - 1)]
+        if (!branch) return { ok: false, message: 'No branch selected' }
+        if (branch.current) return { ok: true, message: `Already on ${branch.shortName}` }
+        return checkoutBranch(git, branch)
+      },
       'delete-branch': async () => {
         const all = sortBranches(context.branches?.localBranches || [], state.branchSort)
         const visible = state.filter

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -142,7 +142,7 @@ import { applyStash, dropStash, popStash } from './stashActions'
 import { removeWorktree } from './worktreeActions'
 import { abortOperation } from './operationActions'
 import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
-import { StashOverview, getStashOverview } from './stashData'
+import { StashOverview, getStashDiff, getStashOverview } from './stashData'
 import { revertFile, stageFile, unstageFile } from './statusActions'
 import { WorktreeOverview, getWorktreeOverview } from './statusData'
 import {
@@ -732,6 +732,13 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     undefined
   )
   const [worktreeHunksLoading, setWorktreeHunksLoading] = React.useState(false)
+  // Stash diff explorer (Enter on a stash row): the runtime fetches
+  // `git stash show -p <ref>` lazily once the diff view becomes active
+  // with diffSource='stash'. Lines are stored as a flat string[] —
+  // renderDiffSurface paints each line through diffLineProps so +/-
+  // colors match the commit-diff path.
+  const [stashDiffLines, setStashDiffLines] = React.useState<string[] | undefined>(undefined)
+  const [stashDiffLoading, setStashDiffLoading] = React.useState(false)
   const [hasMoreCommits, setHasMoreCommits] = React.useState(() => (
     Boolean(logArgv?.interactive && !logArgv.limit) &&
     getCommitRows(rows).length >= LOG_INTERACTIVE_DEFAULT_LIMIT
@@ -862,6 +869,25 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       watcher?.close()
     }
   }, [git, refreshContext, refreshWorktreeContext])
+
+  // P-stash-explorer: load `git stash show -p <ref>` once the diff view
+  // becomes active with diffSource='stash'. Best-effort — empty stashes
+  // or read errors fall through to a "no diff" hint at the render site.
+  React.useEffect(() => {
+    if (state.activeView !== 'diff' || state.diffSource !== 'stash' || !state.stashDiffRef) {
+      return
+    }
+    let active = true
+    setStashDiffLoading(true)
+    void (async () => {
+      const lines = await safe(getStashDiff(git, state.stashDiffRef!))
+      if (active) {
+        setStashDiffLines(lines || [])
+        setStashDiffLoading(false)
+      }
+    })()
+    return () => { active = false }
+  }, [git, state.activeView, state.diffSource, state.stashDiffRef])
 
   React.useEffect(() => {
     let active = true
@@ -1348,15 +1374,23 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         .filter((tag) => matchesPromotedFilter([tag.name, tag.subject], state.filter))
         .length
       : context.tags?.tags.length
-    const stashVisibleCount = state.filter
+    const visibleStashes = state.filter
       ? (context.stashes?.stashes || [])
         .filter((stash) => matchesPromotedFilter([stash.ref, stash.message], state.filter))
-        .length
-      : context.stashes?.stashes.length
+      : (context.stashes?.stashes || [])
+    const stashVisibleCount = visibleStashes.length
+    const stashSelectedRef = visibleStashes[Math.min(state.selectedStashIndex, Math.max(0, visibleStashes.length - 1))]?.ref
+
+    // When the diff view is showing a stash patch, swap the previewLineCount
+    // to the stash diff length so the existing pageDetailPreview path
+    // (j/k, PgUp/PgDn) scrolls through it without a parallel pipeline.
+    const diffPreviewLineCount = state.diffSource === 'stash'
+      ? stashDiffLines?.length
+      : filePreview?.hunks.length
 
     getLogInkInputEvents(state, inputValue, key, {
       detailFileCount: detail?.files.length,
-      previewLineCount: filePreview?.hunks.length,
+      previewLineCount: diffPreviewLineCount,
       worktreeDiffLineCount: worktreeDiff?.lines.length,
       worktreeFileCount: context.worktree?.files.length,
       worktreeHunkOffsets: worktreeDiff?.hunkOffsets,
@@ -1364,6 +1398,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       branchCount: branchVisibleCount,
       tagCount: tagVisibleCount,
       stashCount: stashVisibleCount,
+      stashSelectedRef,
       worktreeDirty,
     }).forEach((event) => {
       if (event.type === 'exit') {
@@ -1442,6 +1477,8 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         filePreviewLoading,
         commitDiffHunkOffsets,
         selectedDetailFile,
+        stashDiffLines,
+        stashDiffLoading,
         layout.bodyRows,
         layout.mainPanelWidth,
         theme,
@@ -1664,6 +1701,8 @@ function renderMainPanel(
   filePreviewLoading: boolean,
   commitDiffHunkOffsets: number[] | undefined,
   selectedDetailFile: GitCommitDetail['files'][number] | undefined,
+  stashDiffLines: string[] | undefined,
+  stashDiffLoading: boolean,
   bodyRows: number,
   width: number,
   theme: LogInkTheme,
@@ -1689,6 +1728,8 @@ function renderMainPanel(
       filePreviewLoading,
       commitDiffHunkOffsets,
       selectedDetailFile,
+      stashDiffLines,
+      stashDiffLoading,
       bodyRows,
       width,
       theme
@@ -2311,6 +2352,8 @@ function renderDiffSurface(
   filePreviewLoading: boolean,
   commitDiffHunkOffsets: number[] | undefined,
   selectedDetailFile: GitCommitDetail['files'][number] | undefined,
+  stashDiffLines: string[] | undefined,
+  stashDiffLoading: boolean,
   bodyRows: number,
   width: number,
   theme: LogInkTheme
@@ -2320,6 +2363,49 @@ function renderDiffSurface(
   const worktree = context.worktree
   const worktreeFile = worktree?.files[state.selectedWorktreeFileIndex]
   const visibleRows = Math.max(4, bodyRows - 4)
+
+  // Stash diff branch: when the user opened the diff via Enter on a stash
+  // row, render the stash patch text directly (no per-file selection yet —
+  // the lines arrive as one flat patch).
+  if (state.diffSource === 'stash') {
+    const lines = stashDiffLines || []
+    const visibleLines = lines.slice(
+      state.diffPreviewOffset,
+      state.diffPreviewOffset + visibleRows
+    )
+    const headerLines: string[] = stashDiffLoading
+      ? [`Loading diff for ${state.stashDiffRef || 'stash'}...`]
+      : lines.length
+        ? [
+          `Stash: ${state.stashDiffRef || ''}`,
+          `Lines ${Math.min(state.diffPreviewOffset + 1, lines.length)}-${Math.min(state.diffPreviewOffset + visibleLines.length, lines.length)}/${lines.length}`,
+          '',
+        ]
+        : ['No diff to display for this stash.']
+
+    return h(Box, {
+      borderColor: focusBorderColor(theme, focused),
+      borderStyle: theme.borderStyle,
+      flexDirection: 'column',
+      flexShrink: 0,
+      paddingX: 1,
+      width,
+    },
+    h(Box, { justifyContent: 'space-between' },
+      h(Text, { bold: true }, panelTitle('Stash diff', focused)),
+      h(Text, { dimColor: true }, state.stashDiffRef || 'no stash')
+    ),
+    ...headerLines.map((line, index) => h(Text, {
+      key: `stash-diff-header-${index}`,
+      dimColor: index > 0,
+    }, truncate(line, width - 4))),
+    ...(stashDiffLoading || !lines.length
+      ? []
+      : visibleLines.map((line, index) => h(Text, {
+        key: `stash-diff-line-${state.diffPreviewOffset + index}`,
+        ...diffLineProps(line, theme),
+      }, truncate(line, width - 4)))))
+  }
 
   // diffSource disambiguates: 'commit' was set when the user opened the
   // diff via history → Enter (read-only commit-diff explore), 'worktree'

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -698,10 +698,6 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   const h = React.createElement
   const { exit } = useApp()
   const windowSize = useWindowSize()
-  const layout = getLogInkLayout({
-    columns: windowSize.columns || process.stdout.columns || LOG_INK_DEFAULT_COLUMNS,
-    rows: windowSize.rows || process.stdout.rows || LOG_INK_DEFAULT_ROWS,
-  })
   // Bumping this on SIGCONT forces the existing tree to repaint so users
   // land on a drawn screen after `fg` instead of an empty alt buffer.
   const [, setResumeTick] = React.useState(0)
@@ -1359,6 +1355,14 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         dispatch(enriched)
       }
     })
+  })
+
+  // Layout depends on focus (sidebar grows when focused), so it's
+  // computed here — after state is in scope but before the render path.
+  const layout = getLogInkLayout({
+    columns: windowSize.columns || process.stdout.columns || LOG_INK_DEFAULT_COLUMNS,
+    rows: windowSize.rows || process.stdout.rows || LOG_INK_DEFAULT_ROWS,
+    sidebarFocused: state.focus === 'sidebar',
   })
 
   if (layout.tooSmall) {

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -135,7 +135,8 @@ import {
 import { startInteractiveLog } from './interactive'
 import { GitOperationOverview, getGitOperationOverview } from './operationData'
 import { ProviderOverview, ProviderRepository, buildProviderUrl, getProviderOverview } from './providerData'
-import { checkoutBranch, deleteBranch } from './branchActions'
+import { checkoutBranch, createBranch, deleteBranch } from './branchActions'
+import { createLightweightTag } from './tagActions'
 import { deleteLocalTag } from './tagActions'
 import { dropStash } from './stashActions'
 import { removeWorktree } from './worktreeActions'
@@ -1117,8 +1118,19 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // result on the status line, and silently refresh so the deleted item
   // disappears. Called from the y-confirm path for delete-branch / delete-
   // tag / drop-stash / remove-worktree / abort-operation.
-  const runWorkflowAction = React.useCallback(async (id: string) => {
+  const runWorkflowAction = React.useCallback(async (id: string, payload?: string) => {
     const handlers: Record<string, () => Promise<{ ok: boolean; message: string } | undefined>> = {
+      'create-branch': async () => {
+        const name = payload?.trim()
+        if (!name) return { ok: false, message: 'Branch name required' }
+        const startPoint = context.branches?.currentBranch || 'HEAD'
+        return createBranch(git, name, startPoint)
+      },
+      'create-tag': async () => {
+        const name = payload?.trim()
+        if (!name) return { ok: false, message: 'Tag name required' }
+        return createLightweightTag(git, name, 'HEAD')
+      },
       'checkout-branch': async () => {
         const all = sortBranches(context.branches?.localBranches || [], state.branchSort)
         const visible = state.filter
@@ -1353,7 +1365,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       } else if (event.type === 'runAiCommitDraft') {
         void runAiCommitDraft()
       } else if (event.type === 'runWorkflowAction') {
-        void runWorkflowAction(event.id)
+        void runWorkflowAction(event.id, event.payload)
       } else {
         // P4.5: enrich filter-mutating actions with a precomputed
         // selection snapshot so the reducer can preserve the cursor on
@@ -2424,6 +2436,10 @@ function renderDetailPanel(
     return renderCommandPalette(h, components, state, width, theme, focused)
   }
 
+  if (state.inputPrompt) {
+    return renderInputPromptPanel(h, components, state, width, theme, focused)
+  }
+
   if (state.pendingConfirmationId || state.pendingMutationConfirmation) {
     return renderConfirmationPanel(h, components, state, width, theme, focused)
   }
@@ -3016,6 +3032,37 @@ function renderCommitPanel(
   loading
     ? null
     : h(Text, { key: 'commit-state', dimColor: true }, truncate(stateLine, width - 4)))
+}
+
+function renderInputPromptPanel(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  width: number,
+  theme: LogInkTheme,
+  focused: boolean
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const prompt = state.inputPrompt
+  if (!prompt) {
+    return h(Box, { width })
+  }
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    width,
+    paddingX: 1,
+  },
+  h(Text, { bold: true }, panelTitle('Prompt', focused)),
+  h(Text, { dimColor: true }, truncate(prompt.label, width - 4)),
+  h(Text, undefined, ''),
+  h(Text, {
+    bold: true,
+    color: theme.noColor ? undefined : theme.colors.accent,
+  }, truncate(`${prompt.value}_`, width - 4)),
+  h(Text, undefined, ''),
+  h(Text, { dimColor: true }, 'Enter to submit · Esc to cancel · Ctrl+u to clear'))
 }
 
 function renderConfirmationPanel(

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -138,7 +138,7 @@ import { ProviderOverview, ProviderRepository, buildProviderUrl, getProviderOver
 import { checkoutBranch, createBranch, deleteBranch } from './branchActions'
 import { createLightweightTag } from './tagActions'
 import { deleteLocalTag } from './tagActions'
-import { dropStash } from './stashActions'
+import { applyStash, dropStash, popStash } from './stashActions'
 import { removeWorktree } from './worktreeActions'
 import { abortOperation } from './operationActions'
 import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
@@ -1167,6 +1167,24 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         const stash = visible[Math.min(state.selectedStashIndex, visible.length - 1)]
         if (!stash) return { ok: false, message: 'No stash selected' }
         return dropStash(git, stash)
+      },
+      'apply-stash': async () => {
+        const all = context.stashes?.stashes || []
+        const visible = state.filter
+          ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], state.filter))
+          : all
+        const stash = visible[Math.min(state.selectedStashIndex, visible.length - 1)]
+        if (!stash) return { ok: false, message: 'No stash selected' }
+        return applyStash(git, stash)
+      },
+      'pop-stash': async () => {
+        const all = context.stashes?.stashes || []
+        const visible = state.filter
+          ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], state.filter))
+          : all
+        const stash = visible[Math.min(state.selectedStashIndex, visible.length - 1)]
+        if (!stash) return { ok: false, message: 'No stash selected' }
+        return popStash(git, stash)
       },
       'remove-worktree': async () => {
         const all = context.worktreeList?.worktrees || []

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -1229,9 +1229,13 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       },
       'remove-worktree': async () => {
         const all = context.worktreeList?.worktrees || []
-        // No dedicated cursor for the worktrees tab yet — operate on the
-        // first non-current worktree as a safe default.
-        const target = all.find((w) => !w.current)
+        // Prefer the cursor on the worktrees promoted view; fall back to
+        // the first non-current worktree (e.g. when the action is fired
+        // from the command palette without ever visiting `g w`).
+        const cursorTarget = all[Math.min(state.selectedWorktreeListIndex, Math.max(0, all.length - 1))]
+        const target = cursorTarget && !cursorTarget.current
+          ? cursorTarget
+          : all.find((w) => !w.current)
         if (!target) return { ok: false, message: 'No removable worktree' }
         return removeWorktree(git, target)
       },
@@ -1254,7 +1258,8 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     // flickering the surfaces through a 'loading' phase.
     await refreshContext({ silent: true })
   }, [context, dispatch, git, refreshContext, state.branchSort, state.filter, state.selectedBranchIndex,
-    state.selectedStashIndex, state.selectedTagIndex, state.stashDiffRef, state.tagSort])
+    state.selectedStashIndex, state.selectedTagIndex, state.selectedWorktreeListIndex, state.stashDiffRef,
+    state.tagSort])
 
   React.useEffect(() => {
     let active = true
@@ -1439,6 +1444,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       stashSelectedRef,
       stashDiffFileOffsets: stashDiffFileOffsets.length ? stashDiffFileOffsets : undefined,
       stashDiffSelectedPath,
+      worktreeListCount: context.worktreeList?.worktrees.length,
       worktreeDirty,
     }).forEach((event) => {
       if (event.type === 'exit') {
@@ -1790,6 +1796,10 @@ function renderMainPanel(
 
   if (state.activeView === 'stash') {
     return renderStashSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
+  }
+
+  if (state.activeView === 'worktrees') {
+    return renderWorktreesSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
   }
 
   return renderHistoryPanel(
@@ -2348,6 +2358,70 @@ function renderStashSurface(
   },
   h(Box, { justifyContent: 'space-between' },
     h(Text, { bold: true }, panelTitle('Stash', focused)),
+    h(Text, { dimColor: true }, headerRight)
+  ),
+  ...renderPromotedFilterAffordance(h, Text, state, theme),
+  ...lines)
+}
+
+function renderWorktreesSurface(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  bodyRows: number,
+  width: number,
+  theme: LogInkTheme
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const focused = state.focus === 'commits'
+  const loading = isLogInkContextKeyLoading(contextStatus, 'worktreeList')
+  const allWorktrees = context.worktreeList?.worktrees || []
+  const worktrees = state.filter
+    ? allWorktrees.filter((entry) =>
+      matchesPromotedFilter([entry.path, entry.branch || '', entry.head || ''], state.filter)
+    )
+    : allWorktrees
+  const selected = Math.max(0, Math.min(state.selectedWorktreeListIndex, Math.max(0, worktrees.length - 1)))
+  const listRows = Math.max(4, bodyRows - 4)
+  const startIndex = Math.max(0, selected - Math.floor(listRows / 2))
+  const visible = worktrees.slice(startIndex, startIndex + listRows)
+  const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
+  const headerRight = loading
+    ? 'loading worktrees'
+    : `${worktrees.length}/${allWorktrees.length} worktrees${filterLabel}`
+  const lines: ReactTypes.ReactNode[] = loading
+    ? [h(Text, { key: 'worktrees-loading', dimColor: true }, formatLogInkLoading({ resource: 'worktrees' }))]
+    : worktrees.length === 0
+      ? [h(Text, { key: 'worktrees-empty', dimColor: true }, 'No linked worktrees.')]
+      : visible.map((entry, offset) => {
+        const index = startIndex + offset
+        const isSelected = index === selected
+        const cursor = isSelected ? '>' : ' '
+        const marker = entry.current ? '*' : ' '
+        const branchLabel = entry.branch ? entry.branch : entry.head || '<detached>'
+        const stateLabel = entry.dirty ? 'dirty' : 'clean'
+        return h(Text, {
+          key: `worktree-${index}`,
+          bold: isSelected,
+          dimColor: !isSelected && !entry.current,
+        }, truncate(
+          `${cursor} ${marker} ${branchLabel.padEnd(28)} ${stateLabel.padEnd(6)} ${entry.path}`,
+          width - 4
+        ))
+      })
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    flexShrink: 0,
+    paddingX: 1,
+    width,
+  },
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle('Worktrees', focused)),
     h(Text, { dimColor: true }, headerRight)
   ),
   ...renderPromotedFilterAffordance(h, Text, state, theme),

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -135,9 +135,18 @@ import {
 import { startInteractiveLog } from './interactive'
 import { GitOperationOverview, getGitOperationOverview } from './operationData'
 import { ProviderOverview, ProviderRepository, buildProviderUrl, getProviderOverview } from './providerData'
-import { checkoutBranch, createBranch, deleteBranch } from './branchActions'
-import { createLightweightTag, deleteLocalTag, pushTag } from './tagActions'
-import { applyStash, checkoutFileFromStash, dropStash, popStash } from './stashActions'
+import {
+  checkoutBranch,
+  createBranch,
+  deleteBranch,
+  fetchRemotes,
+  pullCurrentBranch,
+  pushCurrentBranch,
+  renameBranch,
+  setUpstream,
+} from './branchActions'
+import { createLightweightTag, deleteLocalTag, deleteRemoteTag, pushTag } from './tagActions'
+import { applyStash, checkoutFileFromStash, createStash, dropStash, popStash } from './stashActions'
 import { removeWorktree } from './worktreeActions'
 import { abortOperation } from './operationActions'
 import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
@@ -1245,6 +1254,45 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
           return { ok: false, message: 'No git operation in progress' }
         }
         return abortOperation(git, operation)
+      },
+      'fetch-remotes': async () => fetchRemotes(git),
+      'pull-current-branch': async () => pullCurrentBranch(git),
+      'push-current-branch': async () => pushCurrentBranch(git),
+      'rename-branch': async () => {
+        const newName = payload?.trim()
+        if (!newName) return { ok: false, message: 'New branch name required' }
+        const all = sortBranches(context.branches?.localBranches || [], state.branchSort)
+        const visible = state.filter
+          ? all.filter((b) => matchesPromotedFilter([b.shortName, b.upstream || ''], state.filter))
+          : all
+        const branch = visible[Math.min(state.selectedBranchIndex, visible.length - 1)]
+        if (!branch) return { ok: false, message: 'No branch selected' }
+        return renameBranch(git, branch.shortName, newName)
+      },
+      'set-upstream': async () => {
+        const upstream = payload?.trim()
+        if (!upstream) return { ok: false, message: 'Upstream ref required' }
+        const all = sortBranches(context.branches?.localBranches || [], state.branchSort)
+        const visible = state.filter
+          ? all.filter((b) => matchesPromotedFilter([b.shortName, b.upstream || ''], state.filter))
+          : all
+        const branch = visible[Math.min(state.selectedBranchIndex, visible.length - 1)]
+        if (!branch) return { ok: false, message: 'No branch selected' }
+        return setUpstream(git, branch.shortName, upstream)
+      },
+      'delete-remote-tag': async () => {
+        const all = sortTags(context.tags?.tags || [], state.tagSort)
+        const visible = state.filter
+          ? all.filter((t) => matchesPromotedFilter([t.name, t.subject], state.filter))
+          : all
+        const tag = visible[Math.min(state.selectedTagIndex, visible.length - 1)]
+        if (!tag) return { ok: false, message: 'No tag selected' }
+        return deleteRemoteTag(git, tag.name)
+      },
+      'create-stash': async () => {
+        const message = payload?.trim()
+        if (!message) return { ok: false, message: 'Stash message required' }
+        return createStash(git, message)
       },
     }
     const handler = handlers[id]

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -77,6 +77,7 @@ import { substituteGraphChars } from './inkGraphChars'
 import { formatHyperlink } from './inkHyperlinks'
 import { LogInkInputKey, getLogInkInputEvents } from './inkInput'
 import { hasSeenOnboarding, markOnboardingSeen } from './inkOnboarding'
+import { getSavedSidebarTab, saveSidebarTab } from './inkSidebarPersistence'
 import {
   PromotedSelectionsSnapshot,
   rectifyPromotedSelectionIndex,
@@ -148,7 +149,7 @@ import {
   setUpstream,
 } from './branchActions'
 import { createLightweightTag, deleteLocalTag, deleteRemoteTag, pushTag } from './tagActions'
-import { checkoutFileFromCommit } from './historyActions'
+import { checkoutFileFromCommit, cherryPickCommit } from './historyActions'
 import { applyStash, checkoutFileFromStash, createStash, dropStash, popStash } from './stashActions'
 import { removeWorktree } from './worktreeActions'
 import { abortOperation } from './operationActions'
@@ -798,6 +799,34 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     setState((current) => applyLogInkAction(current, action))
   }, [])
 
+  // Auto-dismiss status messages after a short window so transient
+  // confirmations ("Pulled current branch", "Edited foo.ts") don't
+  // linger forever. Each new message resets the timer; clearing the
+  // message via setStatus(undefined) cancels it. Doesn't fire while a
+  // modal (input prompt, confirmation, palette) is open — those flows
+  // use the status line as live feedback for the open task.
+  React.useEffect(() => {
+    if (!state.statusMessage) return
+    if (state.inputPrompt || state.pendingConfirmationId || state.pendingMutationConfirmation || state.showCommandPalette) {
+      return
+    }
+    // DevSkim: ignore DS172411 — callback is a function literal, delay
+    // is a hard-coded constant.
+    const handle = setTimeout(() => {
+      if (mountedRef.current) {
+        dispatch({ type: 'setStatus', value: undefined })
+      }
+    }, 4000)
+    return () => clearTimeout(handle)
+  }, [
+    dispatch,
+    state.inputPrompt,
+    state.pendingConfirmationId,
+    state.pendingMutationConfirmation,
+    state.showCommandPalette,
+    state.statusMessage,
+  ])
+
   const refreshContext = React.useCallback(async (options: { silent?: boolean } = {}) => {
     // Loud refresh (manual `r`): flip everything to 'loading' so the user
     // sees the surfaces clear, then settle to 'ready' on completion.
@@ -880,6 +909,36 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       watcher?.close()
     }
   }, [git, refreshContext, refreshWorktreeContext])
+
+  // Per-repo sidebar tab persistence (#21). Resolve the repo root, look
+  // up the cached tab, and dispatch `setSidebarTab` once on mount so the
+  // user lands on whichever tab they were last on for this project.
+  // Subsequent setSidebarTab actions (1-5 / [/]) write back to the cache.
+  // Best-effort — read/write failures fall through to the default tab.
+  const repoRootRef = React.useRef<string | undefined>(undefined)
+  React.useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const repoRoot = (await git.revparse(['--show-toplevel'])).trim()
+        if (cancelled || !repoRoot) return
+        repoRootRef.current = repoRoot
+        const saved = getSavedSidebarTab(repoRoot)
+        if (saved && saved !== state.sidebarTab) {
+          dispatch({ type: 'setSidebarTab', value: saved })
+        }
+      } catch {
+        // Not in a worktree, or revparse failed; nothing to restore.
+      }
+    })()
+    return () => { cancelled = true }
+  }, [git, dispatch])
+
+  React.useEffect(() => {
+    const repoRoot = repoRootRef.current
+    if (!repoRoot) return
+    saveSidebarTab(repoRoot, state.sidebarTab)
+  }, [state.sidebarTab])
 
   // P-stash-explorer: load `git stash show -p <ref>` once the diff view
   // becomes active with diffSource='stash'. Best-effort — empty stashes
@@ -1279,6 +1338,15 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         if (!path) return { ok: false, message: 'No stash file under cursor' }
         if (!ref) return { ok: false, message: 'No stash ref active' }
         return checkoutFileFromStash(git, ref, path)
+      },
+      'cherry-pick-commit': async () => {
+        const commit = getSelectedInkCommit(state)
+        if (!commit) return { ok: false, message: 'No commit selected' }
+        return cherryPickCommit(git, {
+          hash: commit.hash,
+          shortHash: commit.shortHash,
+          message: commit.message,
+        })
       },
       'checkout-file-from-commit': async () => {
         // payload is "<sha> <path>" so we pass both through a single

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -137,11 +137,11 @@ import { GitOperationOverview, getGitOperationOverview } from './operationData'
 import { ProviderOverview, ProviderRepository, buildProviderUrl, getProviderOverview } from './providerData'
 import { checkoutBranch, createBranch, deleteBranch } from './branchActions'
 import { createLightweightTag, deleteLocalTag, pushTag } from './tagActions'
-import { applyStash, dropStash, popStash } from './stashActions'
+import { applyStash, checkoutFileFromStash, dropStash, popStash } from './stashActions'
 import { removeWorktree } from './worktreeActions'
 import { abortOperation } from './operationActions'
 import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
-import { StashOverview, getStashDiff, getStashOverview } from './stashData'
+import { StashOverview, getStashDiff, getStashOverview, parseStashDiffFiles } from './stashData'
 import { revertFile, stageFile, unstageFile } from './statusActions'
 import { WorktreeOverview, getWorktreeOverview } from './statusData'
 import {
@@ -1220,6 +1220,13 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         if (!stash) return { ok: false, message: 'No stash selected' }
         return popStash(git, stash)
       },
+      'checkout-file-from-stash': async () => {
+        const path = payload?.trim()
+        const ref = state.stashDiffRef
+        if (!path) return { ok: false, message: 'No stash file under cursor' }
+        if (!ref) return { ok: false, message: 'No stash ref active' }
+        return checkoutFileFromStash(git, ref, path)
+      },
       'remove-worktree': async () => {
         const all = context.worktreeList?.worktrees || []
         // No dedicated cursor for the worktrees tab yet — operate on the
@@ -1247,7 +1254,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     // flickering the surfaces through a 'loading' phase.
     await refreshContext({ silent: true })
   }, [context, dispatch, git, refreshContext, state.branchSort, state.filter, state.selectedBranchIndex,
-    state.selectedStashIndex, state.selectedTagIndex, state.tagSort])
+    state.selectedStashIndex, state.selectedTagIndex, state.stashDiffRef, state.tagSort])
 
   React.useEffect(() => {
     let active = true
@@ -1396,6 +1403,29 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       ? stashDiffLines?.length
       : filePreview?.hunks.length
 
+    // Parse the active stash diff into per-file sections so `]`/`[` can
+    // jump between files and `c` knows which path the cursor is on for
+    // a file-level cherry-pick.
+    const stashDiffFiles = state.diffSource === 'stash' && stashDiffLines
+      ? parseStashDiffFiles(stashDiffLines)
+      : []
+    const stashDiffFileOffsets = stashDiffFiles.map((file) => file.startLine)
+    const stashDiffSelectedPath = (() => {
+      if (state.diffSource !== 'stash' || stashDiffFiles.length === 0) return undefined
+      const offset = state.diffPreviewOffset
+      // Walk backwards to the most recent file header at or before the
+      // current cursor offset.
+      let current = stashDiffFiles[0]
+      for (const file of stashDiffFiles) {
+        if (file.startLine <= offset) {
+          current = file
+        } else {
+          break
+        }
+      }
+      return current.path
+    })()
+
     getLogInkInputEvents(state, inputValue, key, {
       detailFileCount: detail?.files.length,
       previewLineCount: diffPreviewLineCount,
@@ -1407,6 +1437,8 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       tagCount: tagVisibleCount,
       stashCount: stashVisibleCount,
       stashSelectedRef,
+      stashDiffFileOffsets: stashDiffFileOffsets.length ? stashDiffFileOffsets : undefined,
+      stashDiffSelectedPath,
       worktreeDirty,
     }).forEach((event) => {
       if (event.type === 'exit') {
@@ -2373,19 +2405,40 @@ function renderDiffSurface(
   const visibleRows = Math.max(4, bodyRows - 4)
 
   // Stash diff branch: when the user opened the diff via Enter on a stash
-  // row, render the stash patch text directly (no per-file selection yet —
-  // the lines arrive as one flat patch).
+  // row, render the stash patch text directly. The patch is parsed into
+  // per-file sections so `]` / `[` jumps between files and `c`
+  // cherry-picks the file at the cursor.
   if (state.diffSource === 'stash') {
     const lines = stashDiffLines || []
     const visibleLines = lines.slice(
       state.diffPreviewOffset,
       state.diffPreviewOffset + visibleRows
     )
+    const stashFiles = parseStashDiffFiles(lines)
+    const fileCount = stashFiles.length
+    const currentFile = (() => {
+      if (fileCount === 0) return undefined
+      let current = stashFiles[0]
+      for (const file of stashFiles) {
+        if (file.startLine <= state.diffPreviewOffset) {
+          current = file
+        } else {
+          break
+        }
+      }
+      return current
+    })()
+    const currentFileIndex = currentFile
+      ? Math.max(0, stashFiles.findIndex((file) => file.startLine === currentFile.startLine))
+      : -1
     const headerLines: string[] = stashDiffLoading
       ? [`Loading diff for ${state.stashDiffRef || 'stash'}...`]
       : lines.length
         ? [
           `Stash: ${state.stashDiffRef || ''}`,
+          fileCount > 0 && currentFile
+            ? `File ${currentFileIndex + 1}/${fileCount}: ${currentFile.path}`
+            : 'No files in this stash.',
           `Lines ${Math.min(state.diffPreviewOffset + 1, lines.length)}-${Math.min(state.diffPreviewOffset + visibleLines.length, lines.length)}/${lines.length}`,
           '',
         ]
@@ -3439,6 +3492,7 @@ function renderFooter(
   const { Box, Text } = components
   const hints = getLogInkFooterHints({
     activeView: state.activeView,
+    diffSource: state.diffSource,
     filterMode: state.filterMode,
     focus: state.focus,
     pendingKey: state.pendingKey,

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -2899,17 +2899,25 @@ function renderCommitPanel(
     key: `commit-header-${index}`,
     dimColor: index < 2 || line.startsWith('  ') || line === '<empty>',
   }, truncate(line, width - 4))),
-  loading
-    ? h(Text, {
+  // Loading indicator + commit result/details stay inline with the body
+  // (they describe what just happened to the fields above). The action
+  // hint ("e edit | c commit | I AI draft") moves to the bottom of the
+  // pane to read as footer guidance, matching the compose surface.
+  ...(loading
+    ? [h(Text, {
       key: 'commit-loading',
       bold: true,
       color: theme.noColor ? undefined : theme.colors.accent,
-    }, truncate(theme.ascii ? '[...] Generating AI draft' : '⏳ Generating AI draft…', width - 4))
-    : h(Text, { key: 'commit-state', dimColor: true }, truncate(stateLine, width - 4)),
+    }, truncate(theme.ascii ? '[...] Generating AI draft' : '⏳ Generating AI draft…', width - 4))]
+    : []),
   ...trailerLines.map((line, index) => h(Text, {
     key: `commit-trailer-${index}`,
     dimColor: line.startsWith('  '),
-  }, truncate(line, width - 4))))
+  }, truncate(line, width - 4))),
+  h(Box, { flexGrow: 1 }),
+  loading
+    ? null
+    : h(Text, { key: 'commit-state', dimColor: true }, truncate(stateLine, width - 4)))
 }
 
 function renderConfirmationPanel(

--- a/src/commands/log/inkSidebarPersistence.test.ts
+++ b/src/commands/log/inkSidebarPersistence.test.ts
@@ -1,0 +1,79 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import {
+  getSavedSidebarTab,
+  getSidebarTabMarkerPath,
+  saveSidebarTab,
+} from './inkSidebarPersistence'
+
+describe('log Ink sidebar persistence', () => {
+  let tmpRoot: string
+  let originalXdgCacheHome: string | undefined
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-sidebar-'))
+    originalXdgCacheHome = process.env.XDG_CACHE_HOME
+    process.env.XDG_CACHE_HOME = tmpRoot
+  })
+
+  afterEach(() => {
+    if (originalXdgCacheHome === undefined) {
+      delete process.env.XDG_CACHE_HOME
+    } else {
+      process.env.XDG_CACHE_HOME = originalXdgCacheHome
+    }
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('returns undefined when no marker file has been written yet', () => {
+    expect(getSavedSidebarTab('/some/repo')).toBeUndefined()
+  })
+
+  it('round-trips a saved tab through the marker file', () => {
+    saveSidebarTab('/some/repo', 'stashes')
+    expect(getSavedSidebarTab('/some/repo')).toBe('stashes')
+  })
+
+  it('keeps marker files distinct per repo path', () => {
+    saveSidebarTab('/repo-a', 'branches')
+    saveSidebarTab('/repo-b', 'tags')
+
+    expect(getSavedSidebarTab('/repo-a')).toBe('branches')
+    expect(getSavedSidebarTab('/repo-b')).toBe('tags')
+  })
+
+  it('uses XDG_CACHE_HOME when set', () => {
+    const expected = path.join(tmpRoot, 'coco')
+    expect(getSidebarTabMarkerPath('/some/repo').startsWith(expected)).toBe(true)
+  })
+
+  it('falls back to ~/.cache/coco when XDG_CACHE_HOME is unset', () => {
+    delete process.env.XDG_CACHE_HOME
+    const expected = path.join(os.homedir(), '.cache', 'coco')
+    expect(getSidebarTabMarkerPath('/some/repo').startsWith(expected)).toBe(true)
+  })
+
+  it('returns undefined for marker files containing an invalid tab', () => {
+    const markerPath = getSidebarTabMarkerPath('/some/repo')
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true })
+    fs.writeFileSync(markerPath, 'definitely-not-a-tab')
+
+    expect(getSavedSidebarTab('/some/repo')).toBeUndefined()
+  })
+
+  it('trims whitespace before validating saved markers', () => {
+    const markerPath = getSidebarTabMarkerPath('/some/repo')
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true })
+    fs.writeFileSync(markerPath, '  worktrees\n')
+
+    expect(getSavedSidebarTab('/some/repo')).toBe('worktrees')
+  })
+
+  it('does not throw when the marker directory cannot be created', () => {
+    // Point XDG at an unwritable path so the save fails silently.
+    process.env.XDG_CACHE_HOME = '/dev/null/forbidden'
+    expect(() => saveSidebarTab('/some/repo', 'branches')).not.toThrow()
+  })
+})

--- a/src/commands/log/inkSidebarPersistence.ts
+++ b/src/commands/log/inkSidebarPersistence.ts
@@ -34,6 +34,12 @@ function resolveCacheDir(): string {
 }
 
 function repoKey(repoPath: string): string {
+  // sha1 is used here as a non-security cache-key derivation — we just
+  // need a deterministic short identifier for the marker filename so
+  // re-creating a repo at the same path keeps the same preference.
+  // No PII or auth context is hashed; no collision-resistance against
+  // an adversary is required. DevSkim DS126858 doesn't apply.
+  // DevSkim: ignore DS126858
   return crypto.createHash('sha1').update(repoPath).digest('hex').slice(0, 16)
 }
 

--- a/src/commands/log/inkSidebarPersistence.ts
+++ b/src/commands/log/inkSidebarPersistence.ts
@@ -1,0 +1,63 @@
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { LogInkSidebarTab } from './inkViewModel'
+
+/**
+ * Persist which sidebar tab the user last had active, keyed per repo so
+ * switching projects doesn't reset every other repo's preference. The
+ * cache lives next to the onboarding marker (XDG-friendly) and is
+ * best-effort: read/write failures fall back to the default sidebar
+ * tab on next start.
+ *
+ * Repos are keyed by a short hash of their absolute path — no PII in
+ * the cache filename, and re-creating a repo at the same path keeps
+ * the same preference.
+ */
+
+const VALID_TABS: ReadonlyArray<LogInkSidebarTab> = [
+  'status',
+  'branches',
+  'tags',
+  'stashes',
+  'worktrees',
+]
+
+function resolveCacheDir(): string {
+  const xdg = process.env.XDG_CACHE_HOME
+  if (xdg && xdg.trim().length > 0) {
+    return path.join(xdg, 'coco')
+  }
+  return path.join(os.homedir(), '.cache', 'coco')
+}
+
+function repoKey(repoPath: string): string {
+  return crypto.createHash('sha1').update(repoPath).digest('hex').slice(0, 16)
+}
+
+export function getSidebarTabMarkerPath(repoPath: string): string {
+  return path.join(resolveCacheDir(), `sidebar-tab.${repoKey(repoPath)}`)
+}
+
+export function getSavedSidebarTab(repoPath: string): LogInkSidebarTab | undefined {
+  try {
+    const raw = fs.readFileSync(getSidebarTabMarkerPath(repoPath), 'utf8').trim()
+    return VALID_TABS.includes(raw as LogInkSidebarTab)
+      ? (raw as LogInkSidebarTab)
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function saveSidebarTab(repoPath: string, tab: LogInkSidebarTab): void {
+  const marker = getSidebarTabMarkerPath(repoPath)
+  try {
+    fs.mkdirSync(path.dirname(marker), { recursive: true })
+    fs.writeFileSync(marker, tab)
+  } catch {
+    // Best-effort persistence; swallow.
+  }
+}

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -110,6 +110,23 @@ export type LogInkState = {
    * responsible for hiding the synthetic row when the worktree is clean.
    */
   pendingCommitFocused?: boolean
+  /**
+   * Active text-input prompt overlay. Drives create-branch / create-tag /
+   * etc. flows where we need a free-text value before running an action.
+   * When set, all keystrokes route into the prompt until Enter (submit)
+   * or Esc (cancel) is pressed.
+   */
+  inputPrompt?: LogInkInputPromptState
+}
+
+export type LogInkInputPromptKind =
+  | 'create-branch'
+  | 'create-tag'
+
+export type LogInkInputPromptState = {
+  kind: LogInkInputPromptKind
+  label: string
+  value: string
 }
 
 export type LogInkAction =
@@ -165,6 +182,11 @@ export type LogInkAction =
   | { type: 'toggleCommandPalette' }
   | { type: 'cycleBranchSort' }
   | { type: 'cycleTagSort' }
+  | { type: 'openInputPrompt'; kind: LogInkInputPromptKind; label: string; initial?: string }
+  | { type: 'appendInputPrompt'; value: string }
+  | { type: 'backspaceInputPrompt' }
+  | { type: 'clearInputPromptText' }
+  | { type: 'closeInputPrompt' }
 
 const FOCUS_ORDER: LogInkFocus[] = ['sidebar', 'commits', 'detail']
 const SIDEBAR_TABS: LogInkSidebarTab[] = ['status', 'branches', 'tags', 'stashes', 'worktrees']
@@ -598,6 +620,30 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         selectedTagIndex: 0,
         pendingKey: undefined,
       }
+    case 'openInputPrompt':
+      return {
+        ...state,
+        inputPrompt: {
+          kind: action.kind,
+          label: action.label,
+          value: action.initial || '',
+        },
+        pendingKey: undefined,
+      }
+    case 'appendInputPrompt':
+      return state.inputPrompt
+        ? { ...state, inputPrompt: { ...state.inputPrompt, value: `${state.inputPrompt.value}${action.value}` } }
+        : state
+    case 'backspaceInputPrompt':
+      return state.inputPrompt
+        ? { ...state, inputPrompt: { ...state.inputPrompt, value: state.inputPrompt.value.slice(0, -1) } }
+        : state
+    case 'clearInputPromptText':
+      return state.inputPrompt
+        ? { ...state, inputPrompt: { ...state.inputPrompt, value: '' } }
+        : state
+    case 'closeInputPrompt':
+      return { ...state, inputPrompt: undefined, pendingKey: undefined }
     case 'moveToBottom':
       return {
         ...state,

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -28,7 +28,7 @@ export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk' | 'discar
  * input handlers off this field so a dirty worktree can't bleed staging
  * UI into a commit-diff view.
  */
-export type LogInkDiffSource = 'commit' | 'worktree'
+export type LogInkDiffSource = 'commit' | 'worktree' | 'stash'
 
 export type CreateLogInkStateOptions = {
   activeView?: LogInkView
@@ -98,6 +98,12 @@ export type LogInkState = {
    */
   diffSource?: LogInkDiffSource
   /**
+   * Stash ref (e.g. `stash@{0}`) currently being inspected in the diff
+   * view. Set by `navigateOpenDiffForStash`; cleared when the diff view
+   * is popped or replaced.
+   */
+  stashDiffRef?: string
+  /**
    * When true, the cursor sits on the synthetic "(+) new commit" row
    * that the history panel renders above the real commits whenever the
    * worktree is dirty. `getSelectedInkCommit` returns undefined in this
@@ -159,6 +165,7 @@ export type LogInkAction =
   | { type: 'navigateHome' }
   | { type: 'navigateOpenDiffForCommit'; sha: string; commitIndex: number; fileIndex?: number }
   | { type: 'navigateOpenDiffForWorktreeFile'; fileIndex: number }
+  | { type: 'navigateOpenDiffForStash'; ref: string; stashIndex?: number }
   | { type: 'navigateOpenComposeForFile'; fileIndex: number }
   | { type: 'jumpWorktreeHunk'; delta: number; hunkOffsets: number[] }
   | { type: 'jumpCommitDiffHunk'; delta: number; hunkOffsets: number[] }
@@ -325,6 +332,7 @@ function withPushedView(state: LogInkState, value: LogInkView): LogInkState {
     worktreeDiffOffset: value === 'diff' ? state.worktreeDiffOffset : 0,
     selectedWorktreeHunkIndex: value === 'diff' ? state.selectedWorktreeHunkIndex : 0,
     diffSource: value === 'diff' ? state.diffSource : undefined,
+    stashDiffRef: value === 'diff' ? state.stashDiffRef : undefined,
     pendingCommitFocused: value === 'history' ? state.pendingCommitFocused : false,
     pendingKey: undefined,
   }
@@ -344,6 +352,7 @@ function withPoppedView(state: LogInkState): LogInkState {
     worktreeDiffOffset: next === 'diff' ? state.worktreeDiffOffset : 0,
     selectedWorktreeHunkIndex: next === 'diff' ? state.selectedWorktreeHunkIndex : 0,
     diffSource: next === 'diff' ? state.diffSource : undefined,
+    stashDiffRef: next === 'diff' ? state.stashDiffRef : undefined,
     pendingCommitFocused: next === 'history' ? state.pendingCommitFocused : false,
     pendingKey: undefined,
   }
@@ -362,6 +371,7 @@ function withReplacedView(state: LogInkState, value: LogInkView): LogInkState {
     worktreeDiffOffset: value === 'diff' ? state.worktreeDiffOffset : 0,
     selectedWorktreeHunkIndex: value === 'diff' ? state.selectedWorktreeHunkIndex : 0,
     diffSource: value === 'diff' ? state.diffSource : undefined,
+    stashDiffRef: value === 'diff' ? state.stashDiffRef : undefined,
     pendingCommitFocused: value === 'history' ? state.pendingCommitFocused : false,
     pendingKey: undefined,
   }
@@ -769,6 +779,16 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         diffSource: 'worktree',
       }
     }
+    case 'navigateOpenDiffForStash': {
+      const next = withPushedView(state, 'diff')
+      return {
+        ...next,
+        diffSource: 'stash',
+        stashDiffRef: action.ref,
+        selectedStashIndex: Math.max(0, action.stashIndex ?? state.selectedStashIndex),
+        worktreeDiffOffset: 0,
+      }
+    }
     case 'navigateOpenComposeForFile': {
       const next = withPushedView(state, 'status')
       return {
@@ -945,6 +965,16 @@ export function intentOpenDiffForWorktreeFile(
   }
 
   return { type: 'navigateOpenDiffForWorktreeFile', fileIndex: idx }
+}
+
+export function intentOpenDiffForStash(
+  ref: string,
+  stashIndex?: number
+): LogInkAction | null {
+  if (!ref) {
+    return null
+  }
+  return { type: 'navigateOpenDiffForStash', ref, stashIndex }
 }
 
 export function intentOpenComposeForFile(

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -295,6 +295,11 @@ function withPushedView(state: LogInkState, value: LogInkView): LogInkState {
     ...state,
     activeView: value,
     viewStack,
+    // The compose view's right detail panel already shows worktree
+    // status, so keeping the left sidebar on the Status tab duplicates
+    // that information. Auto-switch to Branches when entering compose;
+    // the user can swap back with [/] if they want.
+    sidebarTab: value === 'compose' ? 'branches' : state.sidebarTab,
     worktreeDiffOffset: value === 'diff' ? state.worktreeDiffOffset : 0,
     selectedWorktreeHunkIndex: value === 'diff' ? state.selectedWorktreeHunkIndex : 0,
     diffSource: value === 'diff' ? state.diffSource : undefined,

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -87,10 +87,30 @@ export type LogInkState = {
   paletteRecent: string[]
   workflowActionId?: string
   pendingConfirmationId?: string
+  /**
+   * Optional payload carried into the y-confirm path. When the user
+   * answers `y`, the confirmation handler forwards this value to the
+   * runtime workflow runner so workflows that need a captured target
+   * (selected file path, sha+path, etc.) can resolve it without re-
+   * walking state.
+   */
+  pendingConfirmationPayload?: string
   pendingMutationConfirmation?: LogInkMutationConfirmation
   pendingKey?: string
   focus: LogInkFocus
   sidebarTab: LogInkSidebarTab
+  /**
+   * The user's last *explicit* sidebar tab choice. Only changes when
+   * the user picks a tab themselves (number-key, [/], or palette). The
+   * auto-switch in `withPushedView` (compose / status views) updates
+   * `sidebarTab` for display only — `userSidebarTab` stays put so:
+   *
+   *  - Per-repo persistence (#21) only writes when the user actually
+   *    changes the tab, never on incidental view pushes.
+   *  - Popping back from compose / status restores the tab the user
+   *    had open before they opened those surfaces.
+   */
+  userSidebarTab: LogInkSidebarTab
   statusMessage?: string
   /**
    * Set by `navigateOpenDiffForCommit` / `navigateOpenDiffForWorktreeFile`
@@ -179,9 +199,10 @@ export type LogInkAction =
   | { type: 'setFocus'; value: LogInkFocus }
   | { type: 'setPendingKey'; value?: string }
   | { type: 'setSidebarTab'; value: LogInkSidebarTab }
+  | { type: 'restoreSidebarTab'; value: LogInkSidebarTab }
   | { type: 'setStatus'; value?: string }
   | { type: 'setWorkflowAction'; value?: string }
-  | { type: 'setPendingConfirmation'; value?: string }
+  | { type: 'setPendingConfirmation'; value?: string; payload?: string }
   | { type: 'setPendingMutationConfirmation'; value?: LogInkMutationConfirmation }
   | { type: 'appendPaletteFilter'; value: string }
   | { type: 'backspacePaletteFilter' }
@@ -333,6 +354,10 @@ function withPushedView(state: LogInkState, value: LogInkView): LogInkState {
     // worktree info, so keeping the left sidebar on the Status tab
     // duplicates that information. Auto-switch to Branches when entering
     // either view; the user can swap back with [/] if they want.
+    //
+    // We update only the rendered `sidebarTab` here, never
+    // `userSidebarTab`, so this auto-switch is invisible to per-repo
+    // persistence and pop-view restores the previous tab.
     sidebarTab: value === 'compose' || value === 'status' ? 'branches' : state.sidebarTab,
     worktreeDiffOffset: value === 'diff' ? state.worktreeDiffOffset : 0,
     selectedWorktreeHunkIndex: value === 'diff' ? state.selectedWorktreeHunkIndex : 0,
@@ -354,6 +379,10 @@ function withPoppedView(state: LogInkState): LogInkState {
     ...state,
     activeView: next,
     viewStack,
+    // Restore the user's last explicit tab choice so popping out of
+    // compose / status (which auto-switch the sidebar to Branches)
+    // returns the user to whatever they actually had open before.
+    sidebarTab: state.userSidebarTab,
     worktreeDiffOffset: next === 'diff' ? state.worktreeDiffOffset : 0,
     selectedWorktreeHunkIndex: next === 'diff' ? state.selectedWorktreeHunkIndex : 0,
     diffSource: next === 'diff' ? state.diffSource : undefined,
@@ -505,10 +534,12 @@ export function createLogInkState(
     showCommandPalette: false,
     workflowActionId: undefined,
     pendingConfirmationId: undefined,
+    pendingConfirmationPayload: undefined,
     pendingMutationConfirmation: undefined,
     pendingKey: undefined,
     focus: 'commits',
     sidebarTab: 'status',
+    userSidebarTab: 'status',
   }
 }
 
@@ -684,12 +715,15 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         pendingCommitFocused: false,
         pendingKey: undefined,
       }
-    case 'nextSidebarTab':
+    case 'nextSidebarTab': {
+      const next = cycleValue(SIDEBAR_TABS, state.sidebarTab, 1)
       return {
         ...state,
-        sidebarTab: cycleValue(SIDEBAR_TABS, state.sidebarTab, 1),
+        sidebarTab: next,
+        userSidebarTab: next,
         pendingKey: undefined,
       }
+    }
     case 'page':
       return {
         ...state,
@@ -738,12 +772,15 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         ),
         pendingKey: undefined,
       }
-    case 'previousSidebarTab':
+    case 'previousSidebarTab': {
+      const previous = cycleValue(SIDEBAR_TABS, state.sidebarTab, -1)
       return {
         ...state,
-        sidebarTab: cycleValue(SIDEBAR_TABS, state.sidebarTab, -1),
+        sidebarTab: previous,
+        userSidebarTab: previous,
         pendingKey: undefined,
       }
+    }
     case 'setFilter':
       return withFilter(state, action.value, action.promotedSelections)
     case 'setActiveView':
@@ -798,6 +835,11 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         diffSource: 'stash',
         stashDiffRef: action.ref,
         selectedStashIndex: Math.max(0, action.stashIndex ?? state.selectedStashIndex),
+        // Reset the diff scroll offset so the stash patch always opens
+        // at the top, mirroring `navigateOpenDiffForCommit`. Without
+        // this, opening a stash inherits whatever offset the previous
+        // diff had, landing the user mid-patch.
+        diffPreviewOffset: 0,
         worktreeDiffOffset: 0,
       }
     }
@@ -825,7 +867,20 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         sidebarTab: action.value,
+        userSidebarTab: action.value,
         focus: 'sidebar',
+        pendingKey: undefined,
+      }
+    case 'restoreSidebarTab':
+      // Mount-time restore from per-repo persistence (#21). Updates the
+      // tab + the user-choice mirror without forcing focus into the
+      // sidebar — that's the focus-steal regression flagged in the PR
+      // review. Users land on commits as usual; their saved tab is
+      // visible in the sidebar but doesn't grab the cursor.
+      return {
+        ...state,
+        sidebarTab: action.value,
+        userSidebarTab: action.value,
         pendingKey: undefined,
       }
     case 'setStatus':
@@ -839,6 +894,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         ...state,
         workflowActionId: action.value,
         pendingConfirmationId: undefined,
+        pendingConfirmationPayload: undefined,
         pendingMutationConfirmation: undefined,
         pendingKey: undefined,
       }
@@ -846,6 +902,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         pendingConfirmationId: action.value,
+        pendingConfirmationPayload: action.value ? action.payload : undefined,
         workflowActionId: action.value ? undefined : state.workflowActionId,
         pendingMutationConfirmation: action.value ? undefined : state.pendingMutationConfirmation,
         pendingKey: undefined,
@@ -855,6 +912,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         ...state,
         pendingMutationConfirmation: action.value,
         pendingConfirmationId: action.value ? undefined : state.pendingConfirmationId,
+        pendingConfirmationPayload: action.value ? undefined : state.pendingConfirmationPayload,
         workflowActionId: action.value ? undefined : state.workflowActionId,
         pendingKey: undefined,
       }

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -295,11 +295,11 @@ function withPushedView(state: LogInkState, value: LogInkView): LogInkState {
     ...state,
     activeView: value,
     viewStack,
-    // The compose view's right detail panel already shows worktree
-    // status, so keeping the left sidebar on the Status tab duplicates
-    // that information. Auto-switch to Branches when entering compose;
-    // the user can swap back with [/] if they want.
-    sidebarTab: value === 'compose' ? 'branches' : state.sidebarTab,
+    // The compose + status views' right detail panels already show
+    // worktree info, so keeping the left sidebar on the Status tab
+    // duplicates that information. Auto-switch to Branches when entering
+    // either view; the user can swap back with [/] if they want.
+    sidebarTab: value === 'compose' || value === 'status' ? 'branches' : state.sidebarTab,
     worktreeDiffOffset: value === 'diff' ? state.worktreeDiffOffset : 0,
     selectedWorktreeHunkIndex: value === 'diff' ? state.selectedWorktreeHunkIndex : 0,
     diffSource: value === 'diff' ? state.diffSource : undefined,

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -18,7 +18,7 @@ import {
 export type LogInkFocus = 'sidebar' | 'commits' | 'detail'
 
 export type LogInkSidebarTab = 'status' | 'branches' | 'tags' | 'stashes' | 'worktrees'
-export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash'
+export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash' | 'worktrees'
 export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk' | 'discard-draft'
 /**
  * Tracks which kind of diff the user pushed into. `commit` means they
@@ -60,6 +60,7 @@ export type LogInkState = {
   selectedBranchIndex: number
   selectedTagIndex: number
   selectedStashIndex: number
+  selectedWorktreeListIndex: number
   /**
    * Sort modes for the promoted views (P4.2). `s` cycles through the
    * available modes; the surface header shows a `▼ <mode>` indicator.
@@ -150,6 +151,7 @@ export type LogInkAction =
   | { type: 'moveBranch'; delta: number; count: number }
   | { type: 'moveTag'; delta: number; count: number }
   | { type: 'moveStash'; delta: number; count: number }
+  | { type: 'moveWorktreeListEntry'; delta: number; count: number }
   | { type: 'moveToBottom' }
   | { type: 'moveToTop' }
   | { type: 'nextSidebarTab' }
@@ -484,6 +486,7 @@ export function createLogInkState(
     selectedBranchIndex: 0,
     selectedTagIndex: 0,
     selectedStashIndex: 0,
+    selectedWorktreeListIndex: 0,
     branchSort: DEFAULT_BRANCH_SORT_MODE,
     tagSort: DEFAULT_TAG_SORT_MODE,
     paletteFilter: '',
@@ -612,6 +615,12 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         selectedStashIndex: clampIndex(state.selectedStashIndex + action.delta, action.count),
+        pendingKey: undefined,
+      }
+    case 'moveWorktreeListEntry':
+      return {
+        ...state,
+        selectedWorktreeListIndex: clampIndex(state.selectedWorktreeListIndex + action.delta, action.count),
         pendingKey: undefined,
       }
     case 'cycleBranchSort':

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -129,6 +129,9 @@ export type LogInkState = {
 export type LogInkInputPromptKind =
   | 'create-branch'
   | 'create-tag'
+  | 'rename-branch'
+  | 'set-upstream'
+  | 'create-stash'
 
 export type LogInkInputPromptState = {
   kind: LogInkInputPromptKind

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -149,6 +149,30 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: true,
     },
     {
+      // Per-view-only: scoped to the commit-diff explore in inkInput.
+      // Routed through the y-confirm path because `git checkout <sha> --
+      // <path>` overwrites the worktree file unconditionally and we
+      // want the user to acknowledge that before discarding any local
+      // edits to the path.
+      id: 'checkout-file-from-commit',
+      key: '',
+      label: 'Cherry-pick file from commit',
+      description: 'Materialize the selected file from this commit into the working tree (after confirmation).',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
+      // Per-view-only: scoped to the stash-diff explorer in inkInput.
+      // Same overwrite rationale as `checkout-file-from-commit` — the
+      // y-confirm path is the dirty-tree warning.
+      id: 'checkout-file-from-stash',
+      key: '',
+      label: 'Cherry-pick file from stash',
+      description: 'Materialize the selected file from this stash into the working tree (after confirmation).',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
       id: 'open-pr',
       key: 'O',
       label: 'Open PR / repo',

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -138,6 +138,17 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: false,
     },
     {
+      // Per-view-only: scoped to the history view in inkInput so `c`
+      // doesn't fire elsewhere. Empty key keeps it palette-discoverable
+      // without registering a global hotkey.
+      id: 'cherry-pick-commit',
+      key: '',
+      label: 'Cherry-pick commit',
+      description: 'Apply the selected commit on top of the current branch (after confirmation).',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
       id: 'open-pr',
       key: 'O',
       label: 'Open PR / repo',

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -138,6 +138,42 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: false,
     },
     {
+      id: 'fetch-remotes',
+      key: 'F',
+      label: 'Fetch all remotes',
+      description: 'Run `git fetch --all --prune` and silently refresh context.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      id: 'pull-current-branch',
+      key: 'U',
+      label: 'Pull current branch',
+      description: 'Run `git pull --ff-only` against the current branch.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      id: 'push-current-branch',
+      key: 'P',
+      label: 'Push current branch',
+      description: 'Run `git push` for the current branch.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      // Per-view-only — the inkInput handler scopes this to the tags
+      // surface so we don't expose `R` as a remote-delete from elsewhere.
+      // The empty `key` keeps the workflow palette-discoverable but does
+      // not register a global hotkey.
+      id: 'delete-remote-tag',
+      key: '',
+      label: 'Delete remote tag',
+      description: 'Push :tag to origin to delete the selected tag remotely after confirmation.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
       id: 'stage-file',
       key: 'space',
       label: 'Stage or unstage file',

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -138,6 +138,14 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: false,
     },
     {
+      id: 'open-pr',
+      key: 'O',
+      label: 'Open PR / repo',
+      description: 'Open the current branch\'s pull request in the browser, or the repo page if there\'s no PR.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
       id: 'fetch-remotes',
       key: 'F',
       label: 'Fetch all remotes',

--- a/src/commands/log/stashActions.ts
+++ b/src/commands/log/stashActions.ts
@@ -54,3 +54,24 @@ export function dropStash(git: SimpleGit, stash: StashEntry): Promise<BranchActi
     `Dropped ${stash.ref}`
   )
 }
+
+/**
+ * Materialize a single file's contents from a stash into the working
+ * tree, leaving the rest of the stash untouched. Equivalent to
+ * `git checkout <stashRef> -- <path>`. Used by the stash diff explorer
+ * for file-level cherry-pick.
+ *
+ * Important: this overwrites the file in the working tree. The caller
+ * is responsible for confirming with the user when the working tree
+ * already has uncommitted changes to that path.
+ */
+export function checkoutFileFromStash(
+  git: SimpleGit,
+  stashRef: string,
+  path: string
+): Promise<BranchActionResult> {
+  return runAction(
+    () => git.raw(['checkout', stashRef, '--', path]),
+    `Checked out ${path} from ${stashRef}`
+  )
+}

--- a/src/commands/log/stashActions.ts
+++ b/src/commands/log/stashActions.ts
@@ -1,5 +1,6 @@
 import { SimpleGit } from 'simple-git'
 import { BranchActionResult } from './branchActions'
+import { checkoutOrDeleteFromRef } from './historyActions'
 import { StashEntry } from './stashData'
 
 async function runAction(action: () => Promise<unknown>, successMessage: string): Promise<BranchActionResult> {
@@ -58,8 +59,9 @@ export function dropStash(git: SimpleGit, stash: StashEntry): Promise<BranchActi
 /**
  * Materialize a single file's contents from a stash into the working
  * tree, leaving the rest of the stash untouched. Equivalent to
- * `git checkout <stashRef> -- <path>`. Used by the stash diff explorer
- * for file-level cherry-pick.
+ * `git checkout <stashRef> -- <path>` for additions/modifications. When
+ * the path doesn't exist at <stashRef> — i.e. the stash recorded a
+ * deletion — mirror that deletion in the worktree.
  *
  * Important: this overwrites the file in the working tree. The caller
  * is responsible for confirming with the user when the working tree
@@ -70,8 +72,5 @@ export function checkoutFileFromStash(
   stashRef: string,
   path: string
 ): Promise<BranchActionResult> {
-  return runAction(
-    () => git.raw(['checkout', stashRef, '--', path]),
-    `Checked out ${path} from ${stashRef}`
-  )
+  return checkoutOrDeleteFromRef(git, stashRef, path, stashRef)
 }

--- a/src/commands/log/stashData.test.ts
+++ b/src/commands/log/stashData.test.ts
@@ -1,4 +1,4 @@
-import { getStashDiffSummary, getStashOverview, parseStashFiles, parseStashList, stashDataTestInternals } from './stashData'
+import { getStashDiffSummary, getStashOverview, parseStashDiffFiles, parseStashFiles, parseStashList, stashDataTestInternals } from './stashData'
 
 describe('log stash data', () => {
   it('parses stash list lines with branch context and messages', () => {
@@ -64,5 +64,46 @@ describe('log stash data', () => {
       ' 1 file changed',
     ])
     expect(git.raw).toHaveBeenCalledWith(['stash', 'show', '--stat', 'stash@{0}'])
+  })
+
+  describe('parseStashDiffFiles', () => {
+    it('extracts each file path + diff-header line offset', () => {
+      const lines = [
+        'diff --git a/src/a.ts b/src/a.ts',
+        'index aaa..bbb 100644',
+        '--- a/src/a.ts',
+        '+++ b/src/a.ts',
+        '@@ -1 +1 @@',
+        '-old',
+        '+new',
+        'diff --git a/src/b.ts b/src/b.ts',
+        'index ccc..ddd 100644',
+        '--- a/src/b.ts',
+        '+++ b/src/b.ts',
+        '@@ -1 +1 @@',
+        '-x',
+        '+y',
+      ]
+      expect(parseStashDiffFiles(lines)).toEqual([
+        { path: 'src/a.ts', startLine: 0 },
+        { path: 'src/b.ts', startLine: 7 },
+      ])
+    })
+
+    it('returns the destination path when a file was renamed', () => {
+      const lines = [
+        'diff --git a/old/path.ts b/new/path.ts',
+        'similarity index 95%',
+        'rename from old/path.ts',
+        'rename to new/path.ts',
+      ]
+      expect(parseStashDiffFiles(lines)).toEqual([
+        { path: 'new/path.ts', startLine: 0 },
+      ])
+    })
+
+    it('returns an empty array for an empty patch', () => {
+      expect(parseStashDiffFiles([])).toEqual([])
+    })
   })
 })

--- a/src/commands/log/stashData.test.ts
+++ b/src/commands/log/stashData.test.ts
@@ -105,5 +105,30 @@ describe('log stash data', () => {
     it('returns an empty array for an empty patch', () => {
       expect(parseStashDiffFiles([])).toEqual([])
     })
+
+    it('handles git\'s quoted-path form for filenames with spaces', () => {
+      const lines = [
+        'diff --git "a/src/file with spaces.ts" "b/src/file with spaces.ts"',
+        'index aaa..bbb 100644',
+        '--- "a/src/file with spaces.ts"',
+        '+++ "b/src/file with spaces.ts"',
+        '@@ -1 +1 @@',
+        '-old',
+        '+new',
+      ]
+      expect(parseStashDiffFiles(lines)).toEqual([
+        { path: 'src/file with spaces.ts', startLine: 0 },
+      ])
+    })
+
+    it('decodes git\'s C-style escapes inside quoted paths', () => {
+      const lines = [
+        'diff --git "a/src/quote\\".ts" "b/src/quote\\".ts"',
+        'index aaa..bbb 100644',
+      ]
+      expect(parseStashDiffFiles(lines)).toEqual([
+        { path: 'src/quote".ts', startLine: 0 },
+      ])
+    })
   })
 })

--- a/src/commands/log/stashData.ts
+++ b/src/commands/log/stashData.ts
@@ -75,6 +75,20 @@ export async function getStashDiffSummary(git: SimpleGit, stashRef: string): Pro
     .filter(Boolean)
 }
 
+/**
+ * Full unified-patch diff for a stash. Used by the diff surface when
+ * `state.diffSource === 'stash'` to render the stash's changes inline.
+ *
+ * Empty stashes (e.g. created by `git stash --keep-index` against an
+ * already-clean tree) return [] rather than throwing — surfaces fall
+ * back to a "no diff to display" message.
+ */
+export async function getStashDiff(git: SimpleGit, stashRef: string): Promise<string[]> {
+  return (await git.raw(['stash', 'show', '-p', stashRef]))
+    .split('\n')
+    .map((line) => line.replace(/\r$/, ''))
+}
+
 export const stashDataTestInternals = {
   parseStashSubject,
 }

--- a/src/commands/log/stashData.ts
+++ b/src/commands/log/stashData.ts
@@ -107,17 +107,46 @@ export type StashDiffFile = {
  *
  * Renames / moves return the destination path (the `b/` side); the
  * action surface treats that as the path to materialize from the stash.
+ *
+ * Path quoting: git wraps paths containing spaces or special characters
+ * in double-quotes (`diff --git "a/path with spaces" "b/path with spaces"`).
+ * The parser handles both the unquoted and quoted forms; without that,
+ * stash-file navigation and cherry-pick silently broke for any file
+ * whose path contained a space.
  */
 export function parseStashDiffFiles(lines: string[]): StashDiffFile[] {
   const files: StashDiffFile[] = []
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i]
-    const match = line.match(/^diff --git a\/(.+) b\/(.+)$/)
-    if (match) {
-      files.push({ path: match[2] || match[1], startLine: i })
+    const parsed = parseDiffGitHeader(line)
+    if (parsed) {
+      files.push({ path: parsed.bPath || parsed.aPath, startLine: i })
     }
   }
   return files
+}
+
+const DIFF_GIT_HEADER = /^diff --git (?:"a\/((?:\\.|[^"\\])+)"|a\/(\S+)) (?:"b\/((?:\\.|[^"\\])+)"|b\/(\S+))$/
+
+function parseDiffGitHeader(line: string): { aPath: string; bPath: string } | undefined {
+  const match = line.match(DIFF_GIT_HEADER)
+  if (!match) return undefined
+  const aPath = unescapeGitQuoted(match[1]) || match[2]
+  const bPath = unescapeGitQuoted(match[3]) || match[4]
+  if (!aPath || !bPath) return undefined
+  return { aPath, bPath }
+}
+
+function unescapeGitQuoted(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined
+  // Git's diff header quoting escapes `"`, `\`, and the usual
+  // C-style sequences. Reverse the most common ones so callers get the
+  // raw on-disk path.
+  return value
+    .replace(/\\\\/g, '\\')
+    .replace(/\\"/g, '"')
+    .replace(/\\t/g, '\t')
+    .replace(/\\n/g, '\n')
 }
 
 export const stashDataTestInternals = {

--- a/src/commands/log/stashData.ts
+++ b/src/commands/log/stashData.ts
@@ -89,6 +89,37 @@ export async function getStashDiff(git: SimpleGit, stashRef: string): Promise<st
     .map((line) => line.replace(/\r$/, ''))
 }
 
+export type StashDiffFile = {
+  /** Repo-relative path of the file as parsed from the `b/` side of the
+   *  diff header. Used for the cherry-pick action's `--` argument. */
+  path: string
+  /** Line offset of the `diff --git` header inside the patch text. The
+   *  diff surface jumps to this offset when the user navigates to the
+   *  next/previous file. */
+  startLine: number
+}
+
+/**
+ * Slice a unified-patch into per-file sections. Each entry records the
+ * file path and the offset of its `diff --git` header within `lines`.
+ * Used by the stash explorer to build a per-file cursor + cherry-pick
+ * the file at the cursor.
+ *
+ * Renames / moves return the destination path (the `b/` side); the
+ * action surface treats that as the path to materialize from the stash.
+ */
+export function parseStashDiffFiles(lines: string[]): StashDiffFile[] {
+  const files: StashDiffFile[] = []
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]
+    const match = line.match(/^diff --git a\/(.+) b\/(.+)$/)
+    if (match) {
+      files.push({ path: match[2] || match[1], startLine: i })
+    }
+  }
+  return files
+}
+
 export const stashDataTestInternals = {
   parseStashSubject,
 }


### PR DESCRIPTION
### Features
- **Auto-Dismiss Status Messages**: Implement a 4-second timeout to auto-dismiss transient status messages unless a modal is open, ensuring a cleaner user interface. (515ff9a)
- **Cherry-Pick from History**: Enable 'c' key to cherry-pick commits directly from the history view, enhancing workflow efficiency. (515ff9a)
- **Persistent Sidebar Tabs**: Store the active sidebar tab per repository, maintaining user context across sessions. (515ff9a)
- **Cherry-Pick File from Commit-Diff**: Allow cherry-picking of individual files from commit diffs, improving selective file management. (bd9d248)
- **Open PR or Repo in Browser**: Introduce 'O' key to open the current PR or repository in the browser, streamlining navigation. (f2ef987)
- **File-Level Cherry-Pick from Stash Diff**: Enable file-level cherry-picking within stash diffs, enhancing granularity in file management. (e6e4ec4)
- **Sidebar Enter Key Functionality**: Use Enter to drill into corresponding promoted views from the sidebar, improving navigation. (fc881eb)
- **Tags View Push Action**: Add 'P' key to push selected tags to origin from the tags view, facilitating tag management. (4de0dc8)
- **Stash Diff Explorer**: Enable Enter on a stash row to open its patch, providing a complete stash diff exploration experience. (f47df9f)

### Fixes
- **Differentiate Diff-View Footer Hints**: Adjust footer hints based on the diff source to prevent misleading actions. (2761f9f)

### Dependencies
- **Batch of Quick-Win Actions**: Implement various quick-win actions for branches, tags, stashes, and repositories, enhancing overall usability. (868ca7f)

### Refactors
- **Open File in Editor**: Use 'o' key to open files in the user's editor, improving file editing workflow. (674979b)

### Technical Details
- Various linting and testing improvements ensuring code quality and stability. All changes are lint clean with 798/798 jest tests passing.