### PR TITLE
feat(log-tui): y/Y yank cursored identifier to clipboard

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -1,5 +1,5 @@
 import { GitLogRow } from './data'
-import { getLogInkInputEvents } from './inkInput'
+import { getLogInkInputEvents, getLogInkPaletteExecuteEvents } from './inkInput'
 import { applyLogInkAction, createLogInkState } from './inkViewModel'
 
 const rows: GitLogRow[] = [
@@ -952,6 +952,104 @@ describe('log Ink input interactions', () => {
       state = applyInput(state, 's')
       expect(state.branchSort).toBe('name')
       expect(state.tagSort).toBe('recent')
+    })
+  })
+
+  describe('y / Y yank to clipboard (#778)', () => {
+    it('emits yankFromActiveView from history view (y full hash, Y short hash)', () => {
+      const state = createLogInkState(rows)
+
+      expect(getLogInkInputEvents(state, 'y')).toEqual([
+        { type: 'yankFromActiveView', short: false },
+      ])
+      expect(getLogInkInputEvents(state, 'Y')).toEqual([
+        { type: 'yankFromActiveView', short: true },
+      ])
+    })
+
+    it('does not emit a short flag for views where it is meaningless', () => {
+      // Branches/tags/stash/status only have one identifier per row — short
+      // is reserved for hash-bearing views (history + commit-diff).
+      let state = createLogInkState(rows)
+
+      state = applyLogInkAction(state, { type: 'pushView', value: 'branches' })
+      expect(getLogInkInputEvents(state, 'y', {}, { branchCount: 1 })).toEqual([
+        { type: 'yankFromActiveView' },
+      ])
+
+      state = applyLogInkAction(state, { type: 'popView' })
+      state = applyLogInkAction(state, { type: 'pushView', value: 'status' })
+      expect(
+        getLogInkInputEvents(state, 'y', {}, { worktreeFileCount: 1, worktreeSelectedPath: 'a.ts' })
+      ).toEqual([{ type: 'yankFromActiveView' }])
+    })
+
+    it('emits yankFromActiveView from branches when there is a selectable branch', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'branches' })
+
+      expect(getLogInkInputEvents(state, 'y', {}, { branchCount: 3 })).toEqual([
+        { type: 'yankFromActiveView' },
+      ])
+      // Empty branches list — no event, falls through to existing handlers.
+      expect(getLogInkInputEvents(state, 'y', {}, { branchCount: 0 })).toEqual([])
+    })
+
+    it('emits yankFromActiveView from tags and stash when those views have a selection', () => {
+      let state = createLogInkState(rows)
+
+      state = applyLogInkAction(state, { type: 'pushView', value: 'tags' })
+      expect(getLogInkInputEvents(state, 'y', {}, { tagCount: 2 })).toEqual([
+        { type: 'yankFromActiveView' },
+      ])
+
+      state = applyLogInkAction(state, { type: 'popView' })
+      state = applyLogInkAction(state, { type: 'pushView', value: 'stash' })
+      expect(
+        getLogInkInputEvents(state, 'y', {}, { stashCount: 1, stashSelectedRef: 'stash@{0}' })
+      ).toEqual([{ type: 'yankFromActiveView' }])
+      // No stashSelectedRef → can't yank.
+      expect(getLogInkInputEvents(state, 'y', {}, { stashCount: 1 })).toEqual([])
+    })
+
+    it('emits yankFromActiveView from status only when a worktree path is selected', () => {
+      const state = createLogInkState(rows, { activeView: 'status' })
+
+      expect(getLogInkInputEvents(state, 'y', {}, { worktreeFileCount: 1, worktreeSelectedPath: 'src/foo.ts' })).toEqual([
+        { type: 'yankFromActiveView' },
+      ])
+      // Empty worktree → fall through.
+      expect(getLogInkInputEvents(state, 'y', {}, { worktreeFileCount: 0 })).toEqual([])
+    })
+
+    it('emits yankFromActiveView from diff view across worktree/stash/commit sources', () => {
+      const state = createLogInkState(rows, { activeView: 'diff' })
+
+      expect(getLogInkInputEvents(state, 'y', {}, { worktreeSelectedPath: 'src/foo.ts' })).toEqual([
+        { type: 'yankFromActiveView', short: false },
+      ])
+      expect(getLogInkInputEvents(state, 'y', {}, { stashDiffSelectedPath: 'src/bar.ts' })).toEqual([
+        { type: 'yankFromActiveView', short: false },
+      ])
+      expect(
+        getLogInkInputEvents(state, 'Y', {}, { commitDiffSelectedSha: 'abc123', commitDiffSelectedPath: 'src/baz.ts' })
+      ).toEqual([{ type: 'yankFromActiveView', short: true }])
+      // No diff context → fall through.
+      expect(getLogInkInputEvents(state, 'y', {}, {})).toEqual([])
+    })
+
+    it('palette execute for yankClipboard fires yankFromActiveView', () => {
+      const events = getLogInkPaletteExecuteEvents(
+        {
+          id: 'yankClipboard',
+          kind: 'binding',
+          keys: 'y/Y',
+          label: 'yank',
+          description: 'Copy the cursored identifier to the clipboard.',
+        },
+        createLogInkState(rows)
+      )
+      expect(events).toEqual([{ type: 'yankFromActiveView' }])
     })
   })
 })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -36,6 +36,7 @@ export type LogInkInputEvent =
   | { type: 'runAiCommitDraft' }
   | { type: 'runWorkflowAction'; id: string; payload?: string }
   | { type: 'openFileInEditor'; path: string }
+  | { type: 'yankFromActiveView'; short?: boolean }
 
 export type LogInkInputContext = {
   detailFileCount?: number
@@ -247,6 +248,12 @@ export function getLogInkPaletteExecuteEvents(
         type: 'setStatus',
         value: 'Sort cycle is available in the branches and tags views',
       })]
+    case 'yankClipboard':
+      // The runtime resolves the value/label against the live filtered
+      // list — palette execute simply fires the same event the keystroke
+      // would. Empty active views (no commits / no branches / etc.) are
+      // surfaced by the runtime as a "Nothing to yank" status.
+      return [{ type: 'yankFromActiveView' }]
     default:
       return []
   }
@@ -1123,6 +1130,45 @@ export function getLogInkInputEvents(
     !state.pendingCommitFocused
   ) {
     return [action({ type: 'setPendingConfirmation', value: 'cherry-pick-commit' })]
+  }
+
+  // `y` / `Y` yank the contextually relevant identifier from the active
+  // view to the system clipboard:
+  //   history    → cursored commit hash (Y for short hash)
+  //   branches   → cursored branch shortName
+  //   tags       → cursored tag name
+  //   stash      → cursored stash ref
+  //   status     → cursored worktree file path
+  //   diff       → cursored file path (Y on a commit-diff yanks the sha instead)
+  // The runtime resolves the actual value/label against live filtered
+  // lists; the dispatcher only decides whether the keystroke applies.
+  if (inputValue === 'y' || inputValue === 'Y') {
+    const short = inputValue === 'Y'
+    if (state.activeView === 'history' && state.filteredCommits.length > 0) {
+      return [{ type: 'yankFromActiveView', short }]
+    }
+    if (state.activeView === 'branches' && context.branchCount) {
+      return [{ type: 'yankFromActiveView' }]
+    }
+    if (state.activeView === 'tags' && context.tagCount) {
+      return [{ type: 'yankFromActiveView' }]
+    }
+    if (state.activeView === 'stash' && context.stashCount && context.stashSelectedRef) {
+      return [{ type: 'yankFromActiveView' }]
+    }
+    if (state.activeView === 'status' && context.worktreeSelectedPath) {
+      return [{ type: 'yankFromActiveView' }]
+    }
+    if (state.activeView === 'diff') {
+      if (
+        context.worktreeSelectedPath ||
+        context.stashDiffSelectedPath ||
+        context.commitDiffSelectedPath ||
+        context.commitDiffSelectedSha
+      ) {
+        return [{ type: 'yankFromActiveView', short }]
+      }
+    }
   }
 
   // Enter on a stash row pushes the diff view scoped to that stash.

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -17,7 +17,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ move', 'enter diff', 'c cherry-pick', '/ search', 'gg/G top/bottom'],
+      contextual: ['↑/↓ move', 'enter diff', 'c cherry-pick', 'y/Y yank', '/ search', 'gg/G top/bottom'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 
@@ -27,7 +27,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ files', 'enter diff', 'space stage', 'z revert', 'e/c compose'],
+      contextual: ['↑/↓ files', 'enter diff', 'space stage', 'z revert', 'e/c compose', 'y yank'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 
@@ -37,7 +37,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['j/k hunks', 'space stage', 'z revert', 'o edit', 'e/c compose', 'esc files'],
+      contextual: ['j/k hunks', 'space stage', 'z revert', 'o edit', 'e/c compose', 'y yank'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 
@@ -57,7 +57,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'D delete', 's sort'],
+      contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'D delete', 's sort', 'y yank'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 
@@ -67,7 +67,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ tags', '+ new', 'P push', 'T delete', 's sort'],
+      contextual: ['↑/↓ tags', '+ new', 'P push', 'T delete', 's sort', 'y yank'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 
@@ -77,7 +77,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ stashes', 'enter diff', 'a apply', 'p pop', 'X drop'],
+      contextual: ['↑/↓ stashes', 'enter diff', 'a apply', 'p pop', 'X drop', 'y yank'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -42,6 +42,7 @@ export type LogInkCommandId =
   | 'search'
   | 'toggleGraph'
   | 'workflowActions'
+  | 'yankClipboard'
 
 export type LogInkKeyBinding = {
   id: LogInkCommandId
@@ -289,6 +290,13 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     contexts: ['commits'],
   },
   {
+    id: 'yankClipboard',
+    keys: ['y', 'Y'],
+    label: 'yank',
+    description: 'Copy the cursored identifier (commit hash, branch shortName, stash ref, file path, or tag name) to the clipboard. Y yanks the short hash on history and commit-diff views.',
+    contexts: ['commits'],
+  },
+  {
     id: 'help',
     keys: ['?'],
     label: 'help',
@@ -480,7 +488,7 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
 
   if (options.activeView === 'status') {
     return {
-      contextual: ['↑/↓ files', 'enter diff', 'space stage', 'z revert', 'e/c compose'],
+      contextual: ['↑/↓ files', 'enter diff', 'space stage', 'z revert', 'e/c compose', 'y yank'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }
@@ -488,7 +496,7 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
   if (options.activeView === 'diff') {
     if (options.diffSource === 'stash') {
       return {
-        contextual: ['j/k lines', '[/] file', 'c cherry-pick', 'o edit', 'esc back'],
+        contextual: ['j/k lines', '[/] file', 'c cherry-pick', 'o edit', 'y yank', 'esc back'],
         global: NORMAL_GLOBAL_HINTS,
       }
     }
@@ -496,12 +504,12 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
       // Commit-diff explore: read-only diff, but `c` cherry-picks the
       // cursored file from the commit into the worktree.
       return {
-        contextual: ['j/k hunks', '[/] file', 'c cherry-pick', 'esc back'],
+        contextual: ['j/k hunks', '[/] file', 'c cherry-pick', 'y/Y yank', 'esc back'],
         global: NORMAL_GLOBAL_HINTS,
       }
     }
     return {
-      contextual: ['j/k hunks', 'space stage', 'z revert', 'o edit', 'e/c compose', 'esc files'],
+      contextual: ['j/k hunks', 'space stage', 'z revert', 'o edit', 'e/c compose', 'y yank'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }
@@ -515,21 +523,21 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
 
   if (options.activeView === 'branches') {
     return {
-      contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'D delete', 's sort'],
+      contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'D delete', 's sort', 'y yank'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }
 
   if (options.activeView === 'tags') {
     return {
-      contextual: ['↑/↓ tags', '+ new', 'P push', 'T delete', 's sort'],
+      contextual: ['↑/↓ tags', '+ new', 'P push', 'T delete', 's sort', 'y yank'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }
 
   if (options.activeView === 'stash') {
     return {
-      contextual: ['↑/↓ stashes', 'enter diff', 'a apply', 'p pop', 'X drop'],
+      contextual: ['↑/↓ stashes', 'enter diff', 'a apply', 'p pop', 'X drop', 'y yank'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }
@@ -542,7 +550,7 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
   }
 
   return {
-    contextual: ['↑/↓ move', 'enter diff', 'c cherry-pick', '/ search', 'gg/G top/bottom'],
+    contextual: ['↑/↓ move', 'enter diff', 'c cherry-pick', 'y/Y yank', '/ search', 'gg/G top/bottom'],
     global: NORMAL_GLOBAL_HINTS,
   }
 }

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -149,7 +149,12 @@ import {
   setUpstream,
 } from './branchActions'
 import { createLightweightTag, deleteLocalTag, deleteRemoteTag, pushTag } from './tagActions'
-import { checkoutFileFromCommit, cherryPickCommit } from './historyActions'
+import {
+  ClipboardRunner,
+  checkoutFileFromCommit,
+  cherryPickCommit,
+  defaultClipboardRunner,
+} from './historyActions'
 import { applyStash, checkoutFileFromStash, createStash, dropStash, popStash } from './stashActions'
 import { removeWorktree } from './worktreeActions'
 import { abortOperation } from './operationActions'
@@ -255,6 +260,12 @@ type LogInkComponentDeps = LogInkRuntime & {
    * painted screen after `fg` instead of an empty alt buffer.
    */
   resumeRef?: { current: (() => void) | null }
+  /**
+   * Test seam — when set, the yank-to-clipboard handler uses this runner
+   * instead of `defaultClipboardRunner`. Lets unit tests assert that the
+   * right value reached the clipboard without spawning pbcopy/wl-copy.
+   */
+  clipboardRunner?: ClipboardRunner
 }
 
 const truncate = truncateCells
@@ -706,7 +717,7 @@ function enrichFilterActionWithRectification(
 }
 
 function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
-  const { appLabel, git, idleTipsEnabled, ink, initialView, logArgv, React, resumeRef, rows, theme } = deps
+  const { appLabel, clipboardRunner, git, idleTipsEnabled, ink, initialView, logArgv, React, resumeRef, rows, theme } = deps
   const { Box, Text, useApp, useInput, useWindowSize } = ink
   const h = React.createElement
   const { exit } = useApp()
@@ -1477,6 +1488,134 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     state.selectedStashIndex, state.selectedTagIndex, state.selectedWorktreeListIndex, state.stashDiffRef,
     state.tagSort])
 
+  // Resolve the active view's "yank target" (commit hash / branch /
+  // tag / stash ref / file path) against the live filtered+sorted list,
+  // copy it to the system clipboard, and surface the result on the
+  // status line. `short=true` opts into the short hash on history /
+  // commit-diff views (Y vs y); ignored for ref-only views.
+  const yankFromActiveView = React.useCallback(async (short?: boolean) => {
+    const clipboard: ClipboardRunner = clipboardRunner || defaultClipboardRunner
+    let value: string | undefined
+    let label: string | undefined
+
+    const view = state.activeView
+    if (view === 'history') {
+      const commit = state.filteredCommits[state.selectedIndex]
+      if (commit) {
+        value = short ? commit.shortHash : commit.hash
+        label = short ? `short hash ${commit.shortHash}` : `commit ${commit.shortHash}`
+      }
+    } else if (view === 'branches') {
+      const all = sortBranches(context.branches?.localBranches || [], state.branchSort)
+      const visible = state.filter
+        ? all.filter((b) => matchesPromotedFilter([b.shortName, b.upstream || ''], state.filter))
+        : all
+      const branch = visible[Math.min(state.selectedBranchIndex, Math.max(0, visible.length - 1))]
+      if (branch) {
+        value = branch.shortName
+        label = `branch ${branch.shortName}`
+      }
+    } else if (view === 'tags') {
+      const all = sortTags(context.tags?.tags || [], state.tagSort)
+      const visible = state.filter
+        ? all.filter((t) => matchesPromotedFilter([t.name, t.subject], state.filter))
+        : all
+      const tag = visible[Math.min(state.selectedTagIndex, Math.max(0, visible.length - 1))]
+      if (tag) {
+        value = tag.name
+        label = `tag ${tag.name}`
+      }
+    } else if (view === 'stash') {
+      const all = context.stashes?.stashes || []
+      const visible = state.filter
+        ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], state.filter))
+        : all
+      const stash = visible[Math.min(state.selectedStashIndex, Math.max(0, visible.length - 1))]
+      if (stash) {
+        value = stash.ref
+        label = `stash ${stash.ref}`
+      }
+    } else if (view === 'status') {
+      const path = context.worktree?.files[state.selectedWorktreeFileIndex]?.path
+      if (path) {
+        value = path
+        label = `path ${path}`
+      }
+    } else if (view === 'diff') {
+      if (state.diffSource === 'worktree') {
+        const path = context.worktree?.files[state.selectedWorktreeFileIndex]?.path
+        if (path) {
+          value = path
+          label = `path ${path}`
+        }
+      } else if (state.diffSource === 'stash' && stashDiffLines) {
+        // Walk back to the most recent file header at or before the
+        // current preview offset — same logic the input-context block
+        // uses to expose stashDiffSelectedPath.
+        const files = parseStashDiffFiles(stashDiffLines)
+        if (files.length > 0) {
+          let current = files[0]
+          for (const file of files) {
+            if (file.startLine <= state.diffPreviewOffset) {
+              current = file
+            } else {
+              break
+            }
+          }
+          value = current.path
+          label = `path ${current.path}`
+        }
+      } else if (state.diffSource === 'commit') {
+        // Y on a commit-diff yanks the sha (handy when the user has
+        // drilled into the file list); y yanks the cursored file path.
+        if (short && selected) {
+          value = selected.hash
+          label = `commit ${selected.shortHash}`
+        } else if (selectedDetailFile?.path) {
+          value = selectedDetailFile.path
+          label = `path ${selectedDetailFile.path}`
+        } else if (selected) {
+          value = selected.hash
+          label = `commit ${selected.shortHash}`
+        }
+      }
+    }
+
+    if (!value || !label) {
+      dispatch({ type: 'setStatus', value: 'Nothing to yank in this view' })
+      return
+    }
+
+    try {
+      await clipboard(value)
+      dispatch({ type: 'setStatus', value: `Copied ${label}` })
+    } catch (error) {
+      dispatch({ type: 'setStatus', value: `Copy failed: ${(error as Error).message}` })
+    }
+  }, [
+    clipboardRunner,
+    context.branches,
+    context.stashes,
+    context.tags,
+    context.worktree,
+    dispatch,
+    selected,
+    selectedDetailFile,
+    stashDiffLines,
+    state.activeView,
+    state.branchSort,
+    state.diffPreviewOffset,
+    state.diffSource,
+    state.filter,
+    state.filteredCommits,
+    state.selectedBranchIndex,
+    state.selectedIndex,
+    state.selectedStashIndex,
+    state.selectedTagIndex,
+    state.selectedWorktreeFileIndex,
+    state.tagSort,
+  ])
+
   React.useEffect(() => {
     let active = true
 
@@ -1699,6 +1838,8 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         void runWorkflowAction(event.id, event.payload)
       } else if (event.type === 'openFileInEditor') {
         openInEditor(event.path)
+      } else if (event.type === 'yankFromActiveView') {
+        void yankFromActiveView(event.short)
       } else {
         // P4.5: enrich filter-mutating actions with a precomputed
         // selection snapshot so the reducer can preserve the cursor on


### PR DESCRIPTION
Closes #778.

## Summary

Wires a universal `y` / `Y` keybinding across the shell's promoted views:

| View | `y` yanks | `Y` yanks |
|---|---|---|
| history | full commit hash | short hash |
| branches | branch shortName | (same) |
| tags | tag name | (same) |
| stash | stash ref | (same) |
| status | worktree file path | (same) |
| diff (worktree) | cursored file path | (same) |
| diff (stash) | cursored file path inside the patch | (same) |
| diff (commit) | cursored file path | commit sha |

A status message confirms what was copied (`Copied commit abc1234`, `Copied branch feat/foo`, `Copy failed: <error>`), and the binding is reachable from the command palette as `:yank`.

## Implementation

- `historyActions.ts` already exposed `defaultClipboardRunner` (pbcopy / clip / wl-copy / xclip / xsel chain) and `copyCommitHash` / `copyCommitMessage`, but no key was wired. The PR adds the missing input → runtime path without touching the existing helpers.
- New `yankFromActiveView` input event. Dispatcher decides *whether* the keystroke applies (which view, has-selection guards); runtime resolves the *value/label* against the live filtered+sorted list — same resolution logic the workflow handlers use, kept in one place.
- `clipboardRunner` test seam in deps so unit tests can inject a fake without spawning a clipboard subprocess.
- Footer hint added to every relevant view; `yankClipboard` joins the keymap registry so help / footer / palette stay in sync.

## Test plan

- [x] `npm run test` (full suite + lint + publish dry-run): 817 tests / 101 suites, CLI smoke checks all green
- [ ] Manual: `coco log -i`, press `y` on history → commit hash on clipboard, status message confirms
- [ ] Manual: drill into branches/tags/stash, `y` yanks the cursored ref
- [ ] Manual: `y` from status view yanks the file path
- [ ] Manual: `:` palette → `yank` executes the same path
- [ ] Manual: with `coco log -i` on a system without pbcopy/clip/wl-copy/xclip → status line surfaces a "Copy failed" message instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)