### PR TITLE
feat(log-tui): status mask 1/2/3 + history path:/author: re-fetch

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -1052,4 +1052,97 @@ describe('log Ink input interactions', () => {
       expect(events).toEqual([{ type: 'yankFromActiveView' }])
     })
   })
+
+  describe('status filter mask 1/2/3 (#776)', () => {
+    it('toggles the mask bits when the active view is status', () => {
+      let state = createLogInkState(rows, { activeView: 'status' })
+      expect(state.statusFilterMask).toEqual({ staged: true, unstaged: true, untracked: true })
+
+      state = applyInput(state, '1')
+      expect(state.statusFilterMask).toEqual({ staged: false, unstaged: true, untracked: true })
+
+      state = applyInput(state, '2')
+      expect(state.statusFilterMask).toEqual({ staged: false, unstaged: false, untracked: true })
+
+      state = applyInput(state, '3')
+      // Snap-back to all-on rather than a fully empty mask.
+      expect(state.statusFilterMask).toEqual({ staged: true, unstaged: true, untracked: true })
+    })
+
+    it('still drives sidebar tab numeric jumps from outside the status view', () => {
+      let state = createLogInkState(rows)
+      state = applyInput(state, '5')
+      expect(state.sidebarTab).toBe('worktrees')
+      expect(state.statusFilterMask).toEqual({ staged: true, unstaged: true, untracked: true })
+    })
+  })
+
+  describe('history server-side filter prefix (#776)', () => {
+    it('Enter on path:<value> dispatches setHistoryFetchArgs and clears the textual filter', () => {
+      let state = createLogInkState(rows)
+      state = applyInput(state, '/')
+      state = applyInput(state, 'p')
+      state = applyInput(state, 'a')
+      state = applyInput(state, 't')
+      state = applyInput(state, 'h')
+      state = applyInput(state, ':')
+      state = applyInput(state, 'f')
+      state = applyInput(state, 'o')
+      state = applyInput(state, 'o')
+      expect(state.filter).toBe('path:foo')
+      expect(state.filterMode).toBe(true)
+
+      state = applyInput(state, '', { return: true })
+      expect(state.historyFetchArgs).toEqual({ path: 'foo' })
+      expect(state.filter).toBe('')
+      expect(state.filterMode).toBe(false)
+    })
+
+    it('Enter on author:<value> sets the matching arg', () => {
+      let state = createLogInkState(rows, { activeView: 'history' })
+      state = applyInput(state, '/')
+      'author:alice'.split('').forEach((c) => {
+        state = applyInput(state, c)
+      })
+      state = applyInput(state, '', { return: true })
+      expect(state.historyFetchArgs).toEqual({ author: 'alice' })
+    })
+
+    it('Enter on a non-prefix filter still just exits filter mode (no fetch args)', () => {
+      let state = createLogInkState(rows)
+      state = applyInput(state, '/')
+      state = applyInput(state, 'f')
+      state = applyInput(state, 'i')
+      state = applyInput(state, 'x')
+
+      state = applyInput(state, '', { return: true })
+      expect(state.historyFetchArgs).toBeUndefined()
+      expect(state.filter).toBe('fix')
+      expect(state.filterMode).toBe(false)
+    })
+
+    it('Ctrl+U inside filter mode clears both the textual filter and active fetch args', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setHistoryFetchArgs', value: { author: 'alice' } })
+      state = applyInput(state, '/')
+      state = applyInput(state, 'a')
+      state = applyInput(state, 'b')
+      expect(state.filter).toBe('ab')
+
+      state = applyInput(state, 'u', { ctrl: true })
+      expect(state.filter).toBe('')
+      expect(state.filterMode).toBe(false)
+      expect(state.historyFetchArgs).toBeUndefined()
+    })
+
+    it('Enter on a path: prefix from a non-history view does not dispatch fetch args', () => {
+      let state = createLogInkState(rows, { activeView: 'branches' })
+      state = applyInput(state, '/')
+      'path:foo'.split('').forEach((c) => {
+        state = applyInput(state, c)
+      })
+      state = applyInput(state, '', { return: true })
+      expect(state.historyFetchArgs).toBeUndefined()
+    })
+  })
 })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -3,7 +3,12 @@ import {
   filterLogInkPaletteCommands,
   getLogInkPaletteCommands,
 } from './inkKeymap'
-import { LogInkAction, LogInkSidebarTab, LogInkState } from './inkViewModel'
+import {
+  LogInkAction,
+  LogInkSidebarTab,
+  LogInkState,
+  parseLogInkHistoryFetchPrefix,
+} from './inkViewModel'
 import {
   getLogInkWorkflowActionById,
   getLogInkWorkflowActionByKey,
@@ -365,6 +370,21 @@ export function getLogInkInputEvents(
 
   if (state.filterMode) {
     if (key.return) {
+      // History server-side filter prefixes (#776): on Enter, if the
+      // active view is history and the filter matches `path:<value>`
+      // or `author:<value>`, hand the parsed args to the runtime
+      // (which re-runs `getLogRows`) and clear the textual filter.
+      // For any other view or any non-prefix filter, Enter just exits
+      // filter mode like before.
+      if (state.activeView === 'history') {
+        const fetchArgs = parseLogInkHistoryFetchPrefix(state.filter)
+        if (fetchArgs) {
+          return [
+            action({ type: 'setHistoryFetchArgs', value: fetchArgs }),
+            action({ type: 'clearFilter' }),
+          ]
+        }
+      }
       return [action({ type: 'toggleFilterMode' })]
     }
 
@@ -384,7 +404,17 @@ export function getLogInkInputEvents(
     }
 
     if (key.ctrl && inputValue === 'u') {
-      return [action({ type: 'clearFilter' })]
+      // Ctrl+U is the canonical "blow away the filter" key. When the
+      // history view also has server-side fetch args active (#776),
+      // drop those too — otherwise the user has no obvious way to
+      // unwind a `path:` / `author:` fetch and the visible filter
+      // appears stuck.
+      return state.historyFetchArgs
+        ? [
+          action({ type: 'clearFilter' }),
+          action({ type: 'setHistoryFetchArgs', value: undefined }),
+        ]
+        : [action({ type: 'clearFilter' })]
     }
 
     if (inputValue && !key.ctrl && !key.meta) {
@@ -701,6 +731,16 @@ export function getLogInkInputEvents(
       })]
     }
     return [action({ type: 'nextSidebarTab' })]
+  }
+
+  // Status surface intercepts 1/2/3 before the sidebar-tab numeric
+  // jump (#776): each key toggles a staging-category bit on the
+  // visibility mask. The reducer snaps back to all-on if all three
+  // bits go off so the user always has rendered files.
+  if (state.activeView === 'status' && (inputValue === '1' || inputValue === '2' || inputValue === '3')) {
+    const kind: 'staged' | 'unstaged' | 'untracked' =
+      inputValue === '1' ? 'staged' : inputValue === '2' ? 'unstaged' : 'untracked'
+    return [action({ type: 'toggleStatusFilterMask', kind })]
   }
 
   if (SIDEBAR_TAB_BY_NUMBER[inputValue]) {

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -126,8 +126,10 @@ import {
 } from './inkSurfaceStates'
 import { cellWidth, truncateCells, wrapCells } from './inkText'
 import {
+  LogInkHistoryFetchArgs,
   LogInkSidebarTab,
   LogInkState,
+  LogInkStatusFilterMask,
   LogInkView,
   applyLogInkAction,
   createLogInkState,
@@ -161,7 +163,7 @@ import { abortOperation } from './operationActions'
 import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
 import { StashOverview, getStashDiff, getStashOverview, parseStashDiffFiles } from './stashData'
 import { revertFile, stageFile, unstageFile } from './statusActions'
-import { WorktreeOverview, getWorktreeOverview } from './statusData'
+import { WorktreeOverview, applyStatusFilterMask, getWorktreeOverview } from './statusData'
 import {
   WorktreeHunkOverview,
   getWorktreeHunks,
@@ -804,7 +806,15 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
 
   const selected = getSelectedInkCommit(state)
   const selectedDetailFile = detail?.files[state.selectedFileIndex]
-  const selectedWorktreeFile = context.worktree?.files[state.selectedWorktreeFileIndex]
+  // Status surface visibility mask (#776). `visibleWorktreeFiles` is the
+  // single source of truth for staged/unstaged/untracked filtering: file
+  // count, selected-file resolution, and the rendered list all key off
+  // it so toggles never desync the cursor from the rendered rows.
+  const visibleWorktreeFiles = React.useMemo(
+    () => applyStatusFilterMask(context.worktree?.files || [], state.statusFilterMask),
+    [context.worktree?.files, state.statusFilterMask]
+  )
+  const selectedWorktreeFile = visibleWorktreeFiles[state.selectedWorktreeFileIndex]
 
   const dispatch = React.useCallback((action: Parameters<typeof applyLogInkAction>[1]) => {
     setState((current) => applyLogInkAction(current, action))
@@ -1536,14 +1546,17 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         label = `stash ${stash.ref}`
       }
     } else if (view === 'status') {
-      const path = context.worktree?.files[state.selectedWorktreeFileIndex]?.path
+      // Read from the mask-filtered list (#776) so the cursor and the
+      // yanked path always match what's on screen — yanking a hidden
+      // row is always a desync bug.
+      const path = visibleWorktreeFiles[state.selectedWorktreeFileIndex]?.path
       if (path) {
         value = path
         label = `path ${path}`
       }
     } else if (view === 'diff') {
       if (state.diffSource === 'worktree') {
-        const path = context.worktree?.files[state.selectedWorktreeFileIndex]?.path
+        const path = visibleWorktreeFiles[state.selectedWorktreeFileIndex]?.path
         if (path) {
           value = path
           label = `path ${path}`
@@ -1597,7 +1610,6 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     context.branches,
     context.stashes,
     context.tags,
-    context.worktree,
     dispatch,
     selected,
     selectedDetailFile,
@@ -1614,6 +1626,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     state.selectedTagIndex,
     state.selectedWorktreeFileIndex,
     state.tagSort,
+    visibleWorktreeFiles,
   ])
 
   React.useEffect(() => {
@@ -1668,8 +1681,14 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       loadMoreRequestRef.current = requestId
       setLoadingMoreCommits(true)
       dispatch({ type: 'setStatus', value: 'loading older commits' })
+      const fetchArgs = state.historyFetchArgs
+      const mergedArgv: LogArgv = {
+        ...logArgv,
+        ...(fetchArgs?.author ? { author: fetchArgs.author } : {}),
+        ...(fetchArgs?.path ? { path: fetchArgs.path } : {}),
+      }
       const nextRows = await safe(
-        getLogRows(git, logArgv, {
+        getLogRows(git, mergedArgv, {
           limit: LOG_INTERACTIVE_DEFAULT_LIMIT,
           skip: state.commits.length,
         })
@@ -1711,8 +1730,66 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     logArgv,
     state.commits.length,
     state.filteredCommits.length,
+    state.historyFetchArgs,
     state.selectedIndex,
   ])
+
+  // Server-side history filter (#776). When the user submits `path:foo`
+  // or `author:foo`, the filter parser dispatches setHistoryFetchArgs;
+  // this effect picks up the change, re-runs `getLogRows` with merged
+  // args, and replaces the rows. Clearing the fetch args (Ctrl+U inside
+  // filter mode) re-fetches with the original logArgv so the user gets
+  // the live full log back, not a stale snapshot of the initial rows.
+  const historyFetchEffectInitialized = React.useRef(false)
+  const historyFetchRequestRef = React.useRef(0)
+  React.useEffect(() => {
+    if (!logArgv) return
+    // Skip the first run — initial rows came in via deps.rows; we only
+    // want to fetch in response to *changes* to historyFetchArgs.
+    if (!historyFetchEffectInitialized.current) {
+      historyFetchEffectInitialized.current = true
+      return
+    }
+
+    const requestId = historyFetchRequestRef.current + 1
+    historyFetchRequestRef.current = requestId
+    const fetchArgs = state.historyFetchArgs
+    const merged: LogArgv = {
+      ...logArgv,
+      ...(fetchArgs?.author ? { author: fetchArgs.author } : {}),
+      ...(fetchArgs?.path ? { path: fetchArgs.path } : {}),
+    }
+    const description = fetchArgs?.author
+      ? `author:${fetchArgs.author}`
+      : fetchArgs?.path
+        ? `path:${fetchArgs.path}`
+        : undefined
+
+    dispatch({
+      type: 'setStatus',
+      value: description ? `Refetching with ${description}` : 'Restoring full log',
+    })
+
+    void (async () => {
+      const nextRows = await safe(getLogRows(git, merged, { limit: LOG_INTERACTIVE_DEFAULT_LIMIT }))
+      if (!mountedRef.current || historyFetchRequestRef.current !== requestId) {
+        return
+      }
+      if (!nextRows) {
+        dispatch({ type: 'setStatus', value: 'Failed to refetch with active filter' })
+        return
+      }
+      dispatch({ type: 'replaceRows', rows: nextRows })
+      const matched = getCommitRows(nextRows).length
+      setHasMoreCommits(matched >= LOG_INTERACTIVE_DEFAULT_LIMIT)
+      dispatch({
+        type: 'setStatus',
+        value: description
+          ? `Showing ${matched} commits matching ${description}`
+          : 'Showing full log',
+      })
+    })()
+  }, [dispatch, git, logArgv, state.historyFetchArgs])
 
   const commitDiffHunkOffsets = React.useMemo(() => (
     filePreview?.hunks
@@ -1799,7 +1876,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       detailFileCount: detail?.files.length,
       previewLineCount: diffPreviewLineCount,
       worktreeDiffLineCount: worktreeDiff?.lines.length,
-      worktreeFileCount: context.worktree?.files.length,
+      worktreeFileCount: visibleWorktreeFiles.length,
       worktreeHunkOffsets: worktreeDiff?.hunkOffsets,
       commitDiffHunkOffsets,
       branchCount: branchVisibleCount,
@@ -1809,7 +1886,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       stashDiffFileOffsets: stashDiffFileOffsets.length ? stashDiffFileOffsets : undefined,
       stashDiffSelectedPath,
       worktreeListCount: worktreeVisibleCount,
-      worktreeSelectedPath: context.worktree?.files[state.selectedWorktreeFileIndex]?.path,
+      worktreeSelectedPath: visibleWorktreeFiles[state.selectedWorktreeFileIndex]?.path,
       commitDiffSelectedPath: state.diffSource === 'commit'
         ? selectedDetailFile?.path
         : undefined,
@@ -2245,6 +2322,12 @@ function renderHistoryPanel(
     h(Text, { bold: true }, panelTitle('Commits', focused)),
     h(Text, { dimColor: true }, `${title} | ${graphMode} | ${loadState}`)
   ),
+  // Server-side filter indicator (#776). Only rendered when the user
+  // has an active path:/author: prefix; clears when they Ctrl+U.
+  ...(state.historyFetchArgs
+    ? [h(Text, { key: 'history-fetch-indicator', dimColor: true },
+        `filter: ${formatHistoryFetchArgs(state.historyFetchArgs)}  (ctrl+u in / to clear)`)]
+    : []),
   ...(pendingNode ? [pendingNode] : []),
   visible.items.length === 0
     ? h(Text, { dimColor: true }, formatLogInkHistoryEmpty({
@@ -2366,14 +2449,19 @@ function renderStatusSurface(
   const { Box, Text } = components
   const focused = state.focus === 'commits'
   const worktree = context.worktree
+  // Apply the status visibility mask (#776) at render time so the
+  // rendered rows match the filtered count the input context already
+  // uses for j/k navigation. `visibleFiles` may be a strict subset of
+  // worktree.files when the user has narrowed via 1/2/3.
+  const visibleFiles = applyStatusFilterMask(worktree?.files || [], state.statusFilterMask)
   const listRows = Math.max(4, bodyRows - 5)
   const selectedIndex = state.selectedWorktreeFileIndex
   const cleanHint = formatLogInkStatusEmpty({ hasChanges: Boolean(worktree?.files.length) })
   const startIndex = Math.max(0, selectedIndex - Math.floor(listRows / 2))
   const isLoading = isLogInkContextKeyLoading(contextStatus, 'worktree')
-  const fileRows: ReactTypes.ReactNode[] = isLoading || !worktree?.files.length
+  const fileRows: ReactTypes.ReactNode[] = isLoading || !visibleFiles.length
     ? []
-    : worktree.files.slice(startIndex).slice(0, listRows).map((file, offset) => {
+    : visibleFiles.slice(startIndex).slice(0, listRows).map((file, offset) => {
       const index = startIndex + offset
       const isSelected = index === selectedIndex
       const cursorPart = `${isSelected ? '>' : ' '} `
@@ -2391,13 +2479,20 @@ function renderStatusSurface(
       ...(useDot ? [h(Text, { color: dotColor }, STAGE_STATUS_DOT), ' '] : []),
       tailTrunc)
     })
+  // When the mask narrows the list to nothing but the underlying repo
+  // is non-clean, surface why the panel looks empty so the user can
+  // un-narrow rather than wonder if the repo is actually clean.
+  const maskHidesAll =
+    Boolean(worktree?.files.length) && visibleFiles.length === 0
   const fallbackLines = isLoading
     ? [formatLogInkLoading({ resource: 'worktree status' })]
-    : worktree?.files.length
+    : visibleFiles.length
       ? []
-      : cleanHint
-        ? [cleanHint]
-        : ['Worktree clean']
+      : maskHidesAll
+        ? [`No files match the active filter (${formatStatusFilterMask(state.statusFilterMask)}). Press 1/2/3 to widen.`]
+        : cleanHint
+          ? [cleanHint]
+          : ['Worktree clean']
 
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
@@ -2413,11 +2508,37 @@ function renderStatusSurface(
       ? `${worktree.stagedCount} staged | ${worktree.unstagedCount} unstaged | ${worktree.untrackedCount} untracked`
       : 'status loading')
   ),
+  // Mask indicator (#776). Only rendered when the mask is narrower
+  // than the all-on default — keeps the chrome clean for users who
+  // never touch the filter.
+  ...(isStatusFilterMaskActive(state.statusFilterMask)
+    ? [h(Text, { key: 'status-mask-indicator', dimColor: true },
+        `filter: ${formatStatusFilterMask(state.statusFilterMask)}  (1/2/3 to toggle)`)]
+    : []),
   ...fileRows,
   ...fallbackLines.map((line, index) => h(Text, {
     key: `status-surface-fallback-${index}`,
     dimColor: index > 0,
   }, truncate(line, 140))))
+}
+
+function isStatusFilterMaskActive(mask: LogInkStatusFilterMask): boolean {
+  return !mask.staged || !mask.unstaged || !mask.untracked
+}
+
+function formatStatusFilterMask(mask: LogInkStatusFilterMask): string {
+  const active: string[] = []
+  if (mask.staged) active.push('staged')
+  if (mask.unstaged) active.push('unstaged')
+  if (mask.untracked) active.push('untracked')
+  return active.join(' + ') || 'none'
+}
+
+function formatHistoryFetchArgs(args: LogInkHistoryFetchArgs): string {
+  const parts: string[] = []
+  if (args.author) parts.push(`--author=${args.author}`)
+  if (args.path) parts.push(`-- ${args.path}`)
+  return parts.join(' ') || 'none'
 }
 
 function renderComposeSurface(

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -1,5 +1,6 @@
 import { GitLogRow } from './data'
 import {
+  DEFAULT_LOG_INK_STATUS_FILTER_MASK,
   applyLogInkAction,
   createLogInkState,
   getLogInkSidebarTabs,
@@ -8,6 +9,7 @@ import {
   intentOpenComposeForFile,
   intentOpenDiffForCommit,
   intentOpenDiffForWorktreeFile,
+  parseLogInkHistoryFetchPrefix,
   scoreLogInkCommitFilter,
 } from './inkViewModel'
 
@@ -734,6 +736,112 @@ describe('log Ink view model', () => {
       state = applyLogInkAction(state, { type: 'setFilter', value: 'foo' })
 
       expect(state.selectedBranchIndex).toBe(3)
+    })
+  })
+
+  describe('status filter mask (#776)', () => {
+    it('initializes the mask to all-on so existing flows are unaffected', () => {
+      const state = createLogInkState(rows)
+      expect(state.statusFilterMask).toEqual(DEFAULT_LOG_INK_STATUS_FILTER_MASK)
+    })
+
+    it('toggles a single bit on each press', () => {
+      let state = createLogInkState(rows)
+
+      state = applyLogInkAction(state, { type: 'toggleStatusFilterMask', kind: 'staged' })
+      expect(state.statusFilterMask).toEqual({ staged: false, unstaged: true, untracked: true })
+
+      state = applyLogInkAction(state, { type: 'toggleStatusFilterMask', kind: 'staged' })
+      expect(state.statusFilterMask).toEqual({ staged: true, unstaged: true, untracked: true })
+
+      state = applyLogInkAction(state, { type: 'toggleStatusFilterMask', kind: 'untracked' })
+      state = applyLogInkAction(state, { type: 'toggleStatusFilterMask', kind: 'unstaged' })
+      expect(state.statusFilterMask).toEqual({ staged: true, unstaged: false, untracked: false })
+    })
+
+    it('snaps back to all-on when the user would have zeroed the mask', () => {
+      let state = createLogInkState(rows)
+      // Zero each bit one at a time. The third toggle is the one that
+      // would land on all-off; the reducer must restore the default.
+      state = applyLogInkAction(state, { type: 'toggleStatusFilterMask', kind: 'staged' })
+      state = applyLogInkAction(state, { type: 'toggleStatusFilterMask', kind: 'unstaged' })
+      state = applyLogInkAction(state, { type: 'toggleStatusFilterMask', kind: 'untracked' })
+
+      expect(state.statusFilterMask).toEqual(DEFAULT_LOG_INK_STATUS_FILTER_MASK)
+    })
+
+    it('resets selectedWorktreeFileIndex on toggle so the cursor lands on a visible row', () => {
+      let state = createLogInkState(rows)
+      state = { ...state, selectedWorktreeFileIndex: 5 }
+
+      state = applyLogInkAction(state, { type: 'toggleStatusFilterMask', kind: 'staged' })
+      expect(state.selectedWorktreeFileIndex).toBe(0)
+    })
+  })
+
+  describe('history server-side filter (#776)', () => {
+    describe('parseLogInkHistoryFetchPrefix', () => {
+      it('parses path:<value> into a path fetch arg', () => {
+        expect(parseLogInkHistoryFetchPrefix('path:src/commands/log')).toEqual({
+          path: 'src/commands/log',
+        })
+      })
+
+      it('parses author:<value> into an author fetch arg', () => {
+        expect(parseLogInkHistoryFetchPrefix('author:alice')).toEqual({ author: 'alice' })
+      })
+
+      it('keeps the rest of the string verbatim — paths and author names can contain spaces', () => {
+        expect(parseLogInkHistoryFetchPrefix('path:src/with spaces/foo.ts')).toEqual({
+          path: 'src/with spaces/foo.ts',
+        })
+        expect(parseLogInkHistoryFetchPrefix('author:Griffen Fargo')).toEqual({
+          author: 'Griffen Fargo',
+        })
+      })
+
+      it('returns undefined when the prefix has no value', () => {
+        expect(parseLogInkHistoryFetchPrefix('path:')).toBeUndefined()
+        expect(parseLogInkHistoryFetchPrefix('author:   ')).toBeUndefined()
+      })
+
+      it('returns undefined for plain (client-side) filter strings', () => {
+        expect(parseLogInkHistoryFetchPrefix('feat')).toBeUndefined()
+        expect(parseLogInkHistoryFetchPrefix('fixpathfoo')).toBeUndefined()
+      })
+    })
+
+    it('setHistoryFetchArgs / replaceRows / clear flow keeps state internally consistent', () => {
+      let state = createLogInkState(rows)
+
+      state = applyLogInkAction(state, {
+        type: 'setHistoryFetchArgs',
+        value: { author: 'alice' },
+      })
+      expect(state.historyFetchArgs).toEqual({ author: 'alice' })
+
+      // Server replaces rows with a smaller matched set.
+      const matched: GitLogRow[] = [
+        {
+          type: 'commit',
+          graph: '*',
+          shortHash: 'fff0001',
+          hash: 'fff000111111',
+          date: '2026-05-01',
+          author: 'alice',
+          refs: [],
+          message: 'matched commit',
+        },
+      ]
+      state = applyLogInkAction(state, { type: 'replaceRows', rows: matched })
+      expect(state.commits).toHaveLength(1)
+      expect(state.selectedIndex).toBe(0)
+      expect(state.historyFetchArgs).toEqual({ author: 'alice' })
+
+      // Clearing the fetch args is a separate action — replaceRows did
+      // not touch them, so the runtime can decide when to drop them.
+      state = applyLogInkAction(state, { type: 'setHistoryFetchArgs', value: undefined })
+      expect(state.historyFetchArgs).toBeUndefined()
     })
   })
 })

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -144,6 +144,60 @@ export type LogInkState = {
    * or Esc (cancel) is pressed.
    */
   inputPrompt?: LogInkInputPromptState
+  /**
+   * Visibility mask for the status surface (#776). Each flag controls
+   * whether files of that staging category are rendered. Default: all
+   * three on. Pressing `1`/`2`/`3` while the status view is active
+   * toggles the matching bit; if a toggle would zero the mask, it snaps
+   * back to all-on so the user always has something to look at.
+   */
+  statusFilterMask: LogInkStatusFilterMask
+  /**
+   * Server-side history filter, set when the user submits a filter that
+   * begins with `path:` or `author:` (#776). The runtime re-runs
+   * `getLogRows` with the matching `--author=` / `-- <path>` args; the
+   * panel header surfaces what's active. Cleared when the filter is
+   * cleared.
+   */
+  historyFetchArgs?: LogInkHistoryFetchArgs
+}
+
+export type LogInkStatusFilterMask = {
+  staged: boolean
+  unstaged: boolean
+  untracked: boolean
+}
+
+export type LogInkHistoryFetchArgs = {
+  author?: string
+  path?: string
+}
+
+export const DEFAULT_LOG_INK_STATUS_FILTER_MASK: LogInkStatusFilterMask = {
+  staged: true,
+  unstaged: true,
+  untracked: true,
+}
+
+/**
+ * Detect a history server-side filter prefix (#776). Returns the parsed
+ * `LogInkHistoryFetchArgs` for `path:<value>` and `author:<value>`
+ * prefixes, or `undefined` for a plain (client-side) filter. The whole
+ * remainder of the string (post-prefix) becomes the value — paths and
+ * author names commonly contain spaces, and we don't try to parse
+ * shell-like syntax.
+ */
+export function parseLogInkHistoryFetchPrefix(filter: string): LogInkHistoryFetchArgs | undefined {
+  const trimmed = filter.trim()
+  if (trimmed.startsWith('path:')) {
+    const value = trimmed.slice('path:'.length).trim()
+    return value ? { path: value } : undefined
+  }
+  if (trimmed.startsWith('author:')) {
+    const value = trimmed.slice('author:'.length).trim()
+    return value ? { author: value } : undefined
+  }
+  return undefined
 }
 
 export type LogInkInputPromptKind =
@@ -161,6 +215,7 @@ export type LogInkInputPromptState = {
 
 export type LogInkAction =
   | { type: 'appendRows'; rows: GitLogRow[] }
+  | { type: 'replaceRows'; rows: GitLogRow[] }
   | { type: 'appendFilter'; value: string; promotedSelections?: PromotedSelectionsSnapshot }
   | { type: 'backspaceFilter'; promotedSelections?: PromotedSelectionsSnapshot }
   | { type: 'clearFilter'; promotedSelections?: PromotedSelectionsSnapshot }
@@ -220,6 +275,8 @@ export type LogInkAction =
   | { type: 'backspaceInputPrompt' }
   | { type: 'clearInputPromptText' }
   | { type: 'closeInputPrompt' }
+  | { type: 'toggleStatusFilterMask'; kind: keyof LogInkStatusFilterMask }
+  | { type: 'setHistoryFetchArgs'; value?: LogInkHistoryFetchArgs }
 
 const FOCUS_ORDER: LogInkFocus[] = ['sidebar', 'commits', 'detail']
 const SIDEBAR_TABS: LogInkSidebarTab[] = ['status', 'branches', 'tags', 'stashes', 'worktrees']
@@ -445,6 +502,25 @@ function withFilter(
   }
 }
 
+function replaceRows(state: LogInkState, rows: GitLogRow[]): LogInkState {
+  // Wholesale row replacement after a server-side re-fetch (#776).
+  // Resets the cursor to the top because the new commit set may not
+  // share any hashes with the old one (e.g. switching from `--all` to
+  // `-- some/path` typically dumps the previous selection).
+  const commits = getCommitRows(rows)
+  const filteredCommits = filterCommits(commits, state.filter)
+  return {
+    ...state,
+    rows,
+    commits,
+    filteredCommits,
+    selectedIndex: 0,
+    selectedFileIndex: 0,
+    pendingCommitFocused: false,
+    pendingKey: undefined,
+  }
+}
+
 function appendRows(state: LogInkState, rows: GitLogRow[]): LogInkState {
   const selected = getSelectedInkCommit(state)
   const nextRows = [...state.rows, ...rows]
@@ -540,6 +616,7 @@ export function createLogInkState(
     focus: 'commits',
     sidebarTab: 'status',
     userSidebarTab: 'status',
+    statusFilterMask: { ...DEFAULT_LOG_INK_STATUS_FILTER_MASK },
   }
 }
 
@@ -557,6 +634,8 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
   switch (action.type) {
     case 'appendRows':
       return appendRows(state, action.rows)
+    case 'replaceRows':
+      return replaceRows(state, action.rows)
     case 'appendFilter':
       return withFilter(state, `${state.filter}${action.value}`, action.promotedSelections)
     case 'backspaceFilter':
@@ -697,6 +776,21 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         : state
     case 'closeInputPrompt':
       return { ...state, inputPrompt: undefined, pendingKey: undefined }
+    case 'toggleStatusFilterMask': {
+      const next = { ...state.statusFilterMask, [action.kind]: !state.statusFilterMask[action.kind] }
+      // If the user just zeroed the mask, snap back to all-on rather
+      // than rendering an empty pane. Keeps the affordance reversible
+      // without requiring a "reset" key.
+      const allOff = !next.staged && !next.unstaged && !next.untracked
+      return {
+        ...state,
+        statusFilterMask: allOff ? { ...DEFAULT_LOG_INK_STATUS_FILTER_MASK } : next,
+        selectedWorktreeFileIndex: 0,
+        pendingKey: undefined,
+      }
+    }
+    case 'setHistoryFetchArgs':
+      return { ...state, historyFetchArgs: action.value, pendingKey: undefined }
     case 'moveToBottom':
       return {
         ...state,

--- a/src/commands/log/statusData.test.ts
+++ b/src/commands/log/statusData.test.ts
@@ -1,4 +1,4 @@
-import { parsePorcelainStatus } from './statusData'
+import { applyStatusFilterMask, parsePorcelainStatus, WorktreeFile } from './statusData'
 
 describe('log status data', () => {
   it('parses staged, unstaged, untracked, and rename status rows', () => {
@@ -33,5 +33,36 @@ describe('log status data', () => {
         state: 'staged',
       },
     ])
+  })
+
+  describe('applyStatusFilterMask (#776)', () => {
+    const files: WorktreeFile[] = [
+      { path: 'a.ts', indexStatus: 'M', worktreeStatus: ' ', state: 'staged' },
+      { path: 'b.ts', indexStatus: ' ', worktreeStatus: 'M', state: 'unstaged' },
+      { path: 'c.ts', indexStatus: '?', worktreeStatus: '?', state: 'untracked' },
+      { path: 'd.ts', indexStatus: 'A', worktreeStatus: ' ', state: 'staged' },
+    ]
+
+    it('returns the input array unchanged when the mask is all-on (identity)', () => {
+      expect(applyStatusFilterMask(files, { staged: true, unstaged: true, untracked: true }))
+        .toBe(files)
+    })
+
+    it('keeps only files whose state has a matching bit set', () => {
+      expect(
+        applyStatusFilterMask(files, { staged: true, unstaged: false, untracked: false })
+          .map((f) => f.path)
+      ).toEqual(['a.ts', 'd.ts'])
+
+      expect(
+        applyStatusFilterMask(files, { staged: false, unstaged: true, untracked: true })
+          .map((f) => f.path)
+      ).toEqual(['b.ts', 'c.ts'])
+    })
+
+    it('returns an empty array when every bit is off (caller decides snap-back behavior)', () => {
+      expect(applyStatusFilterMask(files, { staged: false, unstaged: false, untracked: false }))
+        .toEqual([])
+    })
   })
 })

--- a/src/commands/log/statusData.ts
+++ b/src/commands/log/statusData.ts
@@ -58,3 +58,25 @@ export async function getWorktreeOverview(git: SimpleGit): Promise<WorktreeOverv
     untrackedCount: files.filter((file) => file.state === 'untracked').length,
   }
 }
+
+/**
+ * Visibility mask for the status surface (#776). Each flag controls
+ * whether files of that staging category are rendered. The all-on
+ * default is the no-op identity — `applyStatusFilterMask` returns the
+ * input array unchanged.
+ */
+export type WorktreeFileVisibilityMask = {
+  staged: boolean
+  unstaged: boolean
+  untracked: boolean
+}
+
+export function applyStatusFilterMask(
+  files: WorktreeFile[],
+  mask: WorktreeFileVisibilityMask
+): WorktreeFile[] {
+  if (mask.staged && mask.unstaged && mask.untracked) {
+    return files
+  }
+  return files.filter((file) => mask[file.state])
+}


### PR DESCRIPTION
Closes #776.

## Summary

Two parallel filter affordances on the shell's busiest list views.

### Status surface — `1`/`2`/`3` mask

- `1` toggles **staged**, `2` toggles **unstaged**, `3` toggles **untracked** visibility.
- Intercepted before the global sidebar-tab numeric jump, so `1-5` still drives the sidebar from any other view.
- If a toggle would zero the mask, the reducer snaps back to all-on so the pane never renders blank.
- The header shows the active mask: `filter: staged + unstaged  (1/2/3 to toggle)`.

### History — `path:` / `author:` prefix re-fetch

- When the active view is history and the filter input matches `path:<value>` or `author:<value>`, **Enter** parses it into a new `historyFetchArgs` field, clears the textual filter, and exits filter mode.
- A runtime effect re-runs `getLogRows` with the merged `LogArgv`, dispatches the new `replaceRows` action, and surfaces the matched count on the status line.
- Load-more pagination merges the same args so subsequent pages still respect the filter.
- **Ctrl+U** inside filter mode clears both the textual filter and any active fetch args — without it the user has no obvious way to unwind a re-fetch. The history panel header shows the active filter so state is never invisible.
- Plain (non-prefix) filters still behave exactly as before.

## Implementation

- New state fields: `statusFilterMask` (all-on default) and `historyFetchArgs?`. New actions: `toggleStatusFilterMask`, `setHistoryFetchArgs`, `replaceRows`. Pure reducer logic with full test coverage in `inkViewModel.test.ts`.
- New helper `applyStatusFilterMask(files, mask)` in `statusData.ts` — single source of truth for the visible worktree file list, threaded through the runtime so input-context counts, the rendered list, and `selectedWorktreeFile` resolution all stay in lock-step.
- New runtime effect for history re-fetch, with a request-id guard against out-of-order responses and a one-shot bypass on the very first run so the initial `deps.rows` aren't immediately overwritten.
- New shared parser `parseLogInkHistoryFetchPrefix(filter)` in `inkViewModel.ts` so the input dispatcher and the prefix tests use exactly the same recognition logic.

## Test plan

- [x] `npm run test` (full suite + lint + publish dry-run): 830 tests / 101 suites, CLI smoke checks all green
- [ ] Manual: drill into status, press `1` — only staged files render; press again — back to all
- [ ] Manual: in status, hide every category one by one — pane snaps back to all-on rather than going blank
- [ ] Manual: on history, `/path:src/commands/log` then Enter — only commits touching that path; header shows the filter
- [ ] Manual: same flow with `author:` prefix
- [ ] Manual: with a fetch filter active, press `/` then Ctrl+U — fetch + textual filter both clear, full log returns
- [ ] Manual: scroll past the initial limit while filter is active — load-more keeps respecting the filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)