### PR TITLE
fix(log-tui): arrow keys no longer pop the cherry-pick confirmation

### DIFF
--- a/src/commands/log/inkWorkflows.test.ts
+++ b/src/commands/log/inkWorkflows.test.ts
@@ -57,6 +57,22 @@ describe('log Ink workflows', () => {
     expect(getLogInkWorkflowActionById('ai-commit-summary')?.key).toBe('I')
   })
 
+  // Regression: arrow keys (left/right) and other unbound keystrokes
+  // arrive at the workflow lookup with `inputValue === ''`. Without
+  // the empty-string guard, `find()` would match the first action
+  // declared with `key: ''` (cherry-pick-commit) and pop a
+  // confirmation prompt on every arrow press. Palette-only entries
+  // (key: '') must stay reachable via the palette but ignore key
+  // dispatch entirely.
+  it('returns undefined for empty inputValue so palette-only actions never match a keystroke', () => {
+    expect(getLogInkWorkflowActionByKey('')).toBeUndefined()
+  })
+
+  it('still finds palette-only actions by id (cherry-pick-commit, etc.)', () => {
+    expect(getLogInkWorkflowActionById('cherry-pick-commit')?.key).toBe('')
+    expect(getLogInkWorkflowActionById('checkout-file-from-commit')?.key).toBe('')
+  })
+
   it('reports loading states while optional repository context hydrates', () => {
     const sections = getLogInkWorkflowSections({
       contextLoading: true,

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -288,6 +288,15 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
 export function getLogInkWorkflowActionByKey(
   inputValue: string
 ): LogInkWorkflowAction | undefined {
+  // Workflow actions with an empty `key` are palette-only — they
+  // exist so the command palette can surface them but should never
+  // match a raw keystroke. Without this guard, any unbound key
+  // (left/right arrow, function keys) that arrives with an empty
+  // inputValue would `find()` the first empty-key entry —
+  // `cherry-pick-commit` — and pop its confirmation dialog.
+  if (!inputValue) {
+    return undefined
+  }
   return getLogInkWorkflowActions().find((action) => action.key === inputValue)
 }
 


### PR DESCRIPTION
## Summary

`getLogInkWorkflowActionByKey('')` matched the first workflow action declared with `key: ''` (which happens to be `cherry-pick-commit`). So any unbound keystroke that arrived at the workflow lookup with `inputValue === ''` — left/right arrow, function keys, etc. — popped the cherry-pick confirmation prompt.

Workflow actions with an empty key are palette-only by design. The lookup should ignore empty input outright; the palette still finds them via id.

One-line guard: `if (!inputValue) return undefined` at the top of the function. Two regression tests added.

## Reported by

Visual smoke check after #792 merged — pressing left/right while browsing the commit history triggered cherry-pick confirmations.

## Test plan
- [x] Lint clean
- [x] 876 existing tests pass + 2 new regression tests
- [ ] Visual: open `coco ui`, press left/right arrows in the commits view — no cherry-pick prompt should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)