### PR TITLE
fix(log-tui): re-fetch rows on graph mode toggle

### DIFF
--- a/src/commands/log/data.test.ts
+++ b/src/commands/log/data.test.ts
@@ -4,6 +4,7 @@ import {
   LOG_DEFAULT_LIMIT,
   LOG_INTERACTIVE_DEFAULT_LIMIT,
   buildLogArgs,
+  buildToggleGraphArgs,
   getCommitFilePreview,
   getCommitRows,
   getLogView,
@@ -67,6 +68,54 @@ describe('log data layer', () => {
 
     expect(args).toContain('--first-parent')
     expect(args).not.toContain('--no-merges')
+  })
+
+  describe('buildToggleGraphArgs', () => {
+    it('switches to full topology when fullGraph is true', () => {
+      const merged = buildToggleGraphArgs(argv({ view: 'compact' }), true)
+
+      expect(merged.view).toBe('full')
+      // The merged args, fed through buildLogArgs, must produce --all and
+      // drop --first-parent so all branches' topology shows up.
+      const args = buildLogArgs(merged)
+      expect(args).toContain('--all')
+      expect(args).not.toContain('--first-parent')
+    })
+
+    it('restores the original view when fullGraph is false', () => {
+      const merged = buildToggleGraphArgs(argv({ view: 'compact' }), false)
+
+      expect(merged.view).toBe('compact')
+      const args = buildLogArgs(merged)
+      expect(args).toContain('--first-parent')
+      expect(args).not.toContain('--all')
+    })
+
+    it('defaults to compact when argv.view is undefined and fullGraph is false', () => {
+      const merged = buildToggleGraphArgs(argv(), false)
+
+      expect(merged.view).toBe('compact')
+    })
+
+    it('preserves unrelated argv fields (path, author, since, branch)', () => {
+      const merged = buildToggleGraphArgs(
+        argv({ view: 'compact', author: 'alice', path: 'src/', since: '2024-01-01', branch: 'main' }),
+        true
+      )
+
+      expect(merged.author).toBe('alice')
+      expect(merged.path).toBe('src/')
+      expect(merged.since).toBe('2024-01-01')
+      expect(merged.branch).toBe('main')
+      expect(merged.view).toBe('full')
+    })
+
+    it('does not mutate the input argv', () => {
+      const original = argv({ view: 'compact' })
+      buildToggleGraphArgs(original, true)
+
+      expect(original.view).toBe('compact')
+    })
   })
 
   it('preserves graph continuation rows while parsing commits', () => {

--- a/src/commands/log/data.ts
+++ b/src/commands/log/data.ts
@@ -298,6 +298,25 @@ export function buildLogArgs(argv: LogArgv, options: LogRowLoadOptions = {}): st
   return args
 }
 
+/**
+ * Build merged `LogArgv` for the interactive TUI's `g` graph toggle.
+ *
+ * The TUI tracks a transient `fullGraph` boolean; toggling it must produce
+ * a fresh fetch with the right `view` so the renderer actually has graph
+ * topology to draw. When switching to full mode we override `view` to
+ * `'full'` (which `buildLogArgs` already maps to `--all`, dropping
+ * `--first-parent`/`--no-merges`). When switching back we honor the user's
+ * original `view` from argv, defaulting to `'compact'`.
+ *
+ * Pure helper so the effect that calls it stays trivially testable.
+ */
+export function buildToggleGraphArgs(argv: LogArgv, fullGraph: boolean): LogArgv {
+  if (fullGraph) {
+    return { ...argv, view: 'full' }
+  }
+  return { ...argv, view: argv.view ?? 'compact' }
+}
+
 export async function getLogRows(
   git: SimpleGit,
   argv: LogArgv,

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -47,6 +47,7 @@ import {
   GitLogCommitRow,
   GitLogRow,
   LOG_INTERACTIVE_DEFAULT_LIMIT,
+  buildToggleGraphArgs,
   getCommitDetail,
   getCommitFilePreview,
   getCommitRows,
@@ -1791,6 +1792,54 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       })
     })()
   }, [dispatch, git, logArgv, state.historyFetchArgs])
+
+  // Graph mode toggle (`g` key, #791 follow-up). The header label flips
+  // between "compact graph" and "full graph", but unless we re-fetch with
+  // the right `view`, the underlying rows still come from the user's
+  // initial argv (default `--first-parent --no-merges`) and the renderer
+  // has no topology to draw — defeating the per-lane / junction work.
+  // Mirrors the historyFetchArgs effect: skip first run, request-id ref
+  // for stale-completion guard, swap rows in place via replaceRows.
+  const toggleGraphEffectInitialized = React.useRef(false)
+  const toggleGraphRequestRef = React.useRef(0)
+  React.useEffect(() => {
+    if (!logArgv) return
+    if (!toggleGraphEffectInitialized.current) {
+      toggleGraphEffectInitialized.current = true
+      return
+    }
+
+    const requestId = toggleGraphRequestRef.current + 1
+    toggleGraphRequestRef.current = requestId
+    const merged = buildToggleGraphArgs(logArgv, state.fullGraph)
+
+    dispatch({
+      type: 'setStatus',
+      value: state.fullGraph
+        ? 'Loading full topology…'
+        : 'Loading compact history…',
+    })
+
+    void (async () => {
+      const nextRows = await safe(getLogRows(git, merged, { limit: LOG_INTERACTIVE_DEFAULT_LIMIT }))
+      if (!mountedRef.current || toggleGraphRequestRef.current !== requestId) {
+        return
+      }
+      if (!nextRows) {
+        dispatch({ type: 'setStatus', value: 'Failed to refetch graph rows' })
+        return
+      }
+      dispatch({ type: 'replaceRows', rows: nextRows })
+      const matched = getCommitRows(nextRows).length
+      setHasMoreCommits(matched >= LOG_INTERACTIVE_DEFAULT_LIMIT)
+      dispatch({
+        type: 'setStatus',
+        value: state.fullGraph
+          ? `Showing ${matched} commits across all branches`
+          : `Showing ${matched} commits (compact)`,
+      })
+    })()
+  }, [dispatch, git, logArgv, state.fullGraph])
 
   const commitDiffHunkOffsets = React.useMemo(() => (
     filePreview?.hunks


### PR DESCRIPTION
## The bug

The `g` graph toggle (`toggleGraph` action) flipped `state.fullGraph` between `false`/`true` and updated only the header label ("compact graph" → "full graph"). It never re-fetched `git log`, so "full graph" mode kept showing the same `state.rows` fetched at startup with the user's argv (default: `--first-parent --no-merges`) — a plain commit list with no `|\` / `|/` graph rows. The pattern-aware junctions (`├╮` / `├╯`) and per-lane coloring shipped in #791 (PR #792) had nothing to render.

## The fix

Add a React effect in `inkRuntime.ts` that re-fetches log rows whenever `state.fullGraph` changes. Mirrors the existing `historyFetchArgs` effect:

- Skip first run (initial rows came in via deps; only react to *changes*).
- Request-id ref to ignore stale completions if the user mashes `g`.
- Build a merged `LogArgv` via a new pure helper `buildToggleGraphArgs(argv, fullGraph)` exported from `data.ts` — sets `view: 'full'` when toggled on (which `buildLogArgs` already maps to `--all`, dropping `--first-parent`/`--no-merges`), or restores `argv.view ?? 'compact'` when toggled off.
- Dispatch a status hint before the fetch ("Loading full topology…" / "Loading compact history…") and `replaceRows` on success.
- Update `setHasMoreCommits` based on the matched commit count, same as the existing effect.

The argv-merge logic is a pure helper so the pagination/dispatch in the effect stays trivially testable; covered with five unit cases in `data.test.ts`.

## Test plan

- [x] `npm run lint`
- [x] `npm run test:jest` (879/879 pass, including 5 new `buildToggleGraphArgs` cases)
- [x] `npm run build`
- [x] `npm run test` (release dry-run including packaged CLI smoke checks)
- [ ] Manual: open `coco log -i` in a repo with merge history, press `g` — the rendered output should now switch from a flat compact list to a graph with `|\`/`|/` rows and per-lane color, then back to compact on the next press.

Refs: #791, #792.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>