### PR TITLE
feat(log-tui): stash diff header shows stash identity (#791 follow-up)

### DIFF
--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -164,6 +164,7 @@ import { removeWorktree } from './worktreeActions'
 import { abortOperation } from './operationActions'
 import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
 import { StashOverview, getStashDiff, getStashOverview, parseStashDiffFiles } from './stashData'
+import { formatStashHeaderIdentity } from './inkStashHeader'
 import { revertFile, stageFile, unstageFile } from './statusActions'
 import { WorktreeOverview, applyStatusFilterMask, getWorktreeOverview } from './statusData'
 import {
@@ -3105,11 +3106,19 @@ function renderDiffSurface(
     const currentFileIndex = currentFile
       ? Math.max(0, stashFiles.findIndex((file) => file.startLine === currentFile.startLine))
       : -1
+    // Look up the active stash entry so the panel header can show a
+    // human-identifier instead of the raw `stash@{<iso-date>}` ref.
+    // The git ref is the timestamp form (we fetch with --date=iso for
+    // stable parsing) which reads as noise in the title bar; the
+    // message + branch + index combination is what the user wrote down
+    // when they ran `git stash`. Body still shows the full ref so it
+    // stays unambiguous.
+    const stashIdentity = formatStashHeaderIdentity(state.stashDiffRef, context.stashes?.stashes)
     const headerLines: string[] = stashDiffLoading
-      ? [`Loading diff for ${state.stashDiffRef || 'stash'}...`]
+      ? [`Loading diff for ${stashIdentity.subtitle}...`]
       : lines.length
         ? [
-          `Stash: ${state.stashDiffRef || ''}`,
+          stashIdentity.bodyLine,
           fileCount > 0 && currentFile
             ? `File ${currentFileIndex + 1}/${fileCount}: ${currentFile.path}`
             : 'No files in this stash.',
@@ -3128,7 +3137,7 @@ function renderDiffSurface(
     },
     h(Box, { justifyContent: 'space-between' },
       h(Text, { bold: true }, panelTitle('Stash diff', focused)),
-      h(Text, { dimColor: true }, state.stashDiffRef || 'no stash')
+      h(Text, { dimColor: true }, stashIdentity.subtitle)
     ),
     ...headerLines.map((line, index) => h(Text, {
       key: `stash-diff-header-${index}`,

--- a/src/commands/log/inkStashHeader.test.ts
+++ b/src/commands/log/inkStashHeader.test.ts
@@ -1,0 +1,80 @@
+import { formatStashHeaderIdentity } from './inkStashHeader'
+import { StashEntry } from './stashData'
+
+const stashes: StashEntry[] = [
+  {
+    ref: 'stash@{2026-05-01 23:01:18 -0400}',
+    hash: 'aaa1111',
+    date: '2026-05-01',
+    branch: 'main',
+    message: 'WIP polish stash header',
+    files: ['.gitignore'],
+  },
+  {
+    ref: 'stash@{2026-05-01 23:00:01 -0400}',
+    hash: 'bbb2222',
+    date: '2026-05-01',
+    branch: 'feat/x',
+    message: 'experiment with carousel',
+    files: ['src/carousel.tsx'],
+  },
+  {
+    ref: 'stash@{2026-04-22 11:00:00 -0400}',
+    hash: 'ccc3333',
+    date: '2026-04-22',
+    branch: '<unknown>',
+    message: '',
+    files: [],
+  },
+]
+
+describe('formatStashHeaderIdentity', () => {
+  it('returns a placeholder when no ref is active', () => {
+    expect(formatStashHeaderIdentity(undefined, stashes)).toEqual({
+      subtitle: 'no stash',
+      bodyLine: 'Stash:',
+    })
+  })
+
+  it('builds a human-readable subtitle from the matched stash entry', () => {
+    // The user pen-arrowed at the panel title in #791 follow-up review
+    // saying "Display stash ID that we're inspecting in header" — this
+    // is what the right slot now shows: `@{N} <message> on <branch>`
+    // instead of the timestamp ref noise.
+    const identity = formatStashHeaderIdentity(stashes[0].ref, stashes)
+    expect(identity.subtitle).toBe('@{0} WIP polish stash header on main')
+    // Body line keeps the full ref so the user can still copy it for
+    // `git stash apply <ref>` / inspection.
+    expect(identity.bodyLine).toBe(
+      'Stash: stash@{2026-05-01 23:01:18 -0400} on main — WIP polish stash header'
+    )
+  })
+
+  it('uses the position in the stash list as the @{N} index', () => {
+    expect(formatStashHeaderIdentity(stashes[1].ref, stashes).subtitle)
+      .toBe('@{1} experiment with carousel on feat/x')
+  })
+
+  it('omits the "on <branch>" suffix when the branch is unknown', () => {
+    // `parseStashSubject` returns `<unknown>` when the stash subject
+    // does not match the WIP/On pattern. Skip the `on <unknown>` noise.
+    const identity = formatStashHeaderIdentity(stashes[2].ref, stashes)
+    expect(identity.subtitle).toBe('@{2} (no message)')
+    expect(identity.bodyLine).toBe('Stash: stash@{2026-04-22 11:00:00 -0400} — (no message)')
+  })
+
+  it('falls back to the bare ref when the stash list is missing or stale', () => {
+    // Race window: user opens diff, another process drops the stash
+    // before our context refresh — render the ref so the surface stays
+    // navigable instead of throwing.
+    const ref = 'stash@{0}'
+    expect(formatStashHeaderIdentity(ref, undefined)).toEqual({
+      subtitle: ref,
+      bodyLine: `Stash: ${ref}`,
+    })
+    expect(formatStashHeaderIdentity(ref, [])).toEqual({
+      subtitle: ref,
+      bodyLine: `Stash: ${ref}`,
+    })
+  })
+})

--- a/src/commands/log/inkStashHeader.ts
+++ b/src/commands/log/inkStashHeader.ts
@@ -1,0 +1,52 @@
+import { StashEntry } from './stashData'
+
+/**
+ * Header identity strings for the stash diff surface.
+ *
+ * `git stash list --date=iso` returns refs like `stash@{2026-05-01
+ * 23:01:18 -0400}` because of the date-style flag we use for stable
+ * parsing. That timestamp ref reads as noise in the diff panel title
+ * bar — the human-meaningful identifier is the message + branch + the
+ * sequential stash index (`@{0}`, `@{1}`, …).
+ *
+ * `subtitle` is what shows in the panel header's right slot — the
+ * one-line "what am I looking at" answer. `bodyLine` is the first
+ * header line inside the panel body — it preserves the full ref so the
+ * user can still copy it for `git stash apply <ref>` etc.
+ *
+ * When the entry can't be found in the active stash list (race with a
+ * `git stash drop` between Enter and the diff fetch, or empty
+ * context.stashes), we degrade gracefully to the bare ref so the
+ * surface stays usable.
+ */
+export type StashHeaderIdentity = {
+  subtitle: string
+  bodyLine: string
+}
+
+export function formatStashHeaderIdentity(
+  ref: string | undefined,
+  stashes: StashEntry[] | undefined
+): StashHeaderIdentity {
+  if (!ref) {
+    return { subtitle: 'no stash', bodyLine: 'Stash:' }
+  }
+
+  const index = stashes?.findIndex((entry) => entry.ref === ref) ?? -1
+  const entry = index >= 0 ? stashes![index] : undefined
+
+  if (!entry) {
+    return {
+      subtitle: ref,
+      bodyLine: `Stash: ${ref}`,
+    }
+  }
+
+  const onBranch = entry.branch && entry.branch !== '<unknown>' ? ` on ${entry.branch}` : ''
+  const message = entry.message?.trim() || '(no message)'
+
+  return {
+    subtitle: `@{${index}} ${message}${onBranch}`,
+    bodyLine: `Stash: ${ref}${onBranch} — ${message}`,
+  }
+}


### PR DESCRIPTION
## Summary

The stash diff panel header showed the raw ref (`stash@{2026-05-01 23:01:18 -0400}` form because we fetch with `--date=iso` for parser stability), which reads as noise in the title bar — the user wanted to know *which* stash they're looking at. Pen-arrow feedback after the #791 follow-up visual review.

Look up the active stash entry by ref in `context.stashes` and surface `@{N} <message> on <branch>` as the panel subtitle. Body header keeps the full ref so it stays unambiguous and copy-pasteable for `git stash apply <ref>`.

## Before / after

```
# before
Stash diff *                  stash@{2026-05-01 23:01:18 -0400}
Stash: stash@{2026-05-01 23:01:18 -0400}

# after
Stash diff *                  @{0} WIP polish stash header on main
Stash: stash@{2026-05-01 23:01:18 -0400} on main — WIP polish stash header
```

## Race-safe degradation

When the stash entry can't be found (e.g., dropped between Enter and the diff fetch, or `context.stashes` not yet hydrated), the surface degrades to the bare ref so the panel stays usable.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run test:jest` 886/886 (5 new for `formatStashHeaderIdentity`)
- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)