### PR TITLE
feat(log-tui): polish branches list (drop noise, add timestamp + remote glyph)

### DIFF
--- a/src/commands/log/inkIconography.test.ts
+++ b/src/commands/log/inkIconography.test.ts
@@ -2,6 +2,7 @@ import {
   STAGE_STATUS_DOT,
   branchRowMarker,
   formatBranchDivergence,
+  formatBranchLastTouched,
   getPullRequestStateGlyph,
   getStageStatusDotColor,
   sidebarTabCount,
@@ -18,9 +19,11 @@ describe('log Ink iconography', () => {
       expect(formatBranchDivergence({ ahead: 0, behind: 0 })).toBe('no upstream')
     })
 
-    it('reports parity when ahead and behind are zero', () => {
+    it('returns an empty string when even with upstream (the boring default)', () => {
+      // The row marker conveys "synced" — repeating "even with X" on every
+      // row is noise that dominates the line.
       expect(formatBranchDivergence({ upstream: 'origin/main', ahead: 0, behind: 0 }))
-        .toBe('even with origin/main')
+        .toBe('')
     })
 
     it('uses ↑↓ arrows for divergent branches', () => {
@@ -44,9 +47,10 @@ describe('log Ink iconography', () => {
   })
 
   describe('branchRowMarker (P3.1)', () => {
-    it('marks the current branch with *', () => {
+    it('marks the current branch with * regardless of upstream state', () => {
       expect(branchRowMarker({ current: true, upstream: 'origin/main' })).toBe('*')
       expect(branchRowMarker({ current: true })).toBe('*')
+      expect(branchRowMarker({ current: true, upstream: 'origin/main', ahead: 3 })).toBe('*')
     })
 
     it('uses ◌ for non-current branches without upstream', () => {
@@ -57,8 +61,73 @@ describe('log Ink iconography', () => {
       expect(branchRowMarker({ current: false }, { ascii: true })).toBe('?')
     })
 
-    it('renders a space for non-current branches with upstream', () => {
-      expect(branchRowMarker({ current: false, upstream: 'origin/feat' })).toBe(' ')
+    it('uses ≡ for non-current branches synced with their upstream', () => {
+      expect(branchRowMarker({ current: false, upstream: 'origin/feat', ahead: 0, behind: 0 })).toBe('≡')
+      // Default ahead/behind to 0 when not provided.
+      expect(branchRowMarker({ current: false, upstream: 'origin/feat' })).toBe('≡')
+    })
+
+    it('uses = as ASCII fallback for synced branches', () => {
+      expect(branchRowMarker(
+        { current: false, upstream: 'origin/feat', ahead: 0, behind: 0 },
+        { ascii: true }
+      )).toBe('=')
+    })
+
+    it('uses ↕ for non-current branches that have diverged from their upstream', () => {
+      expect(branchRowMarker({ current: false, upstream: 'origin/feat', ahead: 2, behind: 0 })).toBe('↕')
+      expect(branchRowMarker({ current: false, upstream: 'origin/feat', ahead: 0, behind: 1 })).toBe('↕')
+      expect(branchRowMarker({ current: false, upstream: 'origin/feat', ahead: 3, behind: 4 })).toBe('↕')
+    })
+
+    it('uses ~ as ASCII fallback for diverged branches', () => {
+      expect(branchRowMarker(
+        { current: false, upstream: 'origin/feat', ahead: 1, behind: 1 },
+        { ascii: true }
+      )).toBe('~')
+    })
+  })
+
+  describe('formatBranchLastTouched', () => {
+    const now = new Date(Date.UTC(2026, 4, 2)) // 2026-05-02
+
+    it('returns "today" for same-day commits', () => {
+      expect(formatBranchLastTouched('2026-05-02', now)).toBe('today')
+    })
+
+    it('returns "Nd ago" for the past two weeks', () => {
+      expect(formatBranchLastTouched('2026-05-01', now)).toBe('1d ago')
+      expect(formatBranchLastTouched('2026-04-30', now)).toBe('2d ago')
+      expect(formatBranchLastTouched('2026-04-19', now)).toBe('13d ago')
+    })
+
+    it('switches to weeks once we cross 14 days', () => {
+      expect(formatBranchLastTouched('2026-04-18', now)).toBe('2w ago')
+      expect(formatBranchLastTouched('2026-03-15', now)).toBe('6w ago')
+    })
+
+    it('switches to months once we cross ~9 weeks', () => {
+      expect(formatBranchLastTouched('2026-02-15', now)).toBe('2mo ago')
+      expect(formatBranchLastTouched('2025-08-15', now)).toBe('8mo ago')
+    })
+
+    it('switches to years for >= 12 months old', () => {
+      expect(formatBranchLastTouched('2024-05-02', now)).toBe('2y ago')
+      expect(formatBranchLastTouched('2023-01-01', now)).toBe('3y ago')
+    })
+
+    it('collapses future-dated inputs (clock skew) to "today"', () => {
+      expect(formatBranchLastTouched('2026-05-10', now)).toBe('today')
+    })
+
+    it('returns "" for missing or malformed input', () => {
+      expect(formatBranchLastTouched(undefined, now)).toBe('')
+      expect(formatBranchLastTouched('', now)).toBe('')
+      expect(formatBranchLastTouched('not-a-date', now)).toBe('')
+    })
+
+    it('tolerates full ISO timestamps (uses the date prefix only)', () => {
+      expect(formatBranchLastTouched('2026-04-30T18:33:42Z', now)).toBe('2d ago')
     })
   })
 

--- a/src/commands/log/inkIconography.ts
+++ b/src/commands/log/inkIconography.ts
@@ -20,7 +20,8 @@ export type BranchDivergenceInput = {
 /**
  * Format a branch's relationship to its upstream.
  * - no upstream  → "no upstream"
- * - even         → "even with <upstream>"
+ * - even         → "" (the boring default — keep the row tight; the row
+ *   marker already encodes "synced")
  * - divergent    → "↑<ahead> ↓<behind> <upstream>" (only the non-zero side
  *   is rendered so the line stays tight). ASCII mode falls back to the
  *   legacy `+N/-N` form.
@@ -34,7 +35,7 @@ export function formatBranchDivergence(
   }
 
   if (branch.ahead === 0 && branch.behind === 0) {
-    return `even with ${branch.upstream}`
+    return ''
   }
 
   if (options.ascii) {
@@ -51,11 +52,21 @@ export function formatBranchDivergence(
 export type BranchRowMarkerInput = {
   current: boolean
   upstream?: string
+  ahead?: number
+  behind?: number
 }
 
 /**
  * Single-cell marker shown to the left of a branch name in lists.
- * `*` = current, `◌` = no upstream (detached from a remote), space otherwise.
+ *
+ * - `*` — current branch (regardless of remote state)
+ * - `◌` — no upstream
+ * - `≡` — has upstream + synced (ahead === 0 && behind === 0)
+ * - `↕` — has upstream + diverged (any non-zero ahead/behind)
+ * - ` ` — fallback / no info
+ *
+ * ASCII fallbacks (legible without box-drawing/arrow glyphs):
+ * - `?` for "no upstream", `=` for synced, `~` for diverged.
  */
 export function branchRowMarker(
   branch: BranchRowMarkerInput,
@@ -63,7 +74,62 @@ export function branchRowMarker(
 ): string {
   if (branch.current) return '*'
   if (!branch.upstream) return options.ascii ? '?' : '◌'
-  return ' '
+
+  const ahead = branch.ahead ?? 0
+  const behind = branch.behind ?? 0
+  if (ahead === 0 && behind === 0) {
+    return options.ascii ? '=' : '≡'
+  }
+  return options.ascii ? '~' : '↕'
+}
+
+/**
+ * Compact, human-friendly relative timestamp for the branch row.
+ * Inputs:
+ * - `iso` — committer-date in `YYYY-MM-DD` form (as produced by
+ *   `for-each-ref` with `committerdate:short`).
+ * - `now` — reference instant; pass it explicitly so callers can pin it
+ *   for deterministic tests.
+ *
+ * Outputs (rounded toward the nearest unit):
+ * - `today`, `1d ago`, `2d ago` … up to 13d
+ * - `2w ago` … up to 8w
+ * - `2mo ago` … up to 12mo
+ * - `2y ago` for older
+ * - `''` for malformed inputs (caller renders nothing).
+ *
+ * "in the future" inputs (clock skew, bad data) collapse to `today`.
+ */
+export function formatBranchLastTouched(iso: string | undefined, now: Date): string {
+  if (!iso) return ''
+  // Tolerate either `YYYY-MM-DD` or `YYYY-MM-DDTHH:MM:SS…` ISO strings.
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso)
+  if (!match) return ''
+
+  const year = Number.parseInt(match[1], 10)
+  const month = Number.parseInt(match[2], 10)
+  const day = Number.parseInt(match[3], 10)
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return ''
+
+  // Compare at day granularity in UTC so a branch touched "yesterday"
+  // never reads "today" depending on the operator's timezone.
+  const branchUtc = Date.UTC(year, month - 1, day)
+  const nowUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  const diffMs = nowUtc - branchUtc
+  const oneDay = 24 * 60 * 60 * 1000
+  const days = Math.floor(diffMs / oneDay)
+
+  if (days <= 0) return 'today'
+  if (days < 14) return `${days}d ago`
+
+  const weeks = Math.floor(days / 7)
+  if (weeks < 9) return `${weeks}w ago`
+
+  const months = Math.floor(days / 30)
+  if (months < 12) return `${months}mo ago`
+
+  const years = Math.floor(days / 365)
+  return `${years}y ago`
 }
 
 /* ------------------------------ P3.2 — PR ------------------------------- */

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -101,6 +101,7 @@ import {
   STAGE_STATUS_DOT,
   branchRowMarker,
   formatBranchDivergence,
+  formatBranchLastTouched,
   getPullRequestStateGlyph,
   getStageStatusDotColor,
   sidebarTabCount,
@@ -517,9 +518,11 @@ function sidebarLines(
       ...sortedBranches.slice(0, 8).map((branch) =>
         `${branchRowMarker(branch, { ascii: theme.ascii })} ${truncate(branch.shortName, width - 4)}`
       ),
-      ...sortedBranches.slice(0, 4).map((branch) =>
-        `  ${truncate(formatBranchDivergence(branch, { ascii: theme.ascii }), width - 2)}`
-      ),
+      ...sortedBranches
+        .slice(0, 4)
+        .map((branch) => formatBranchDivergence(branch, { ascii: theme.ascii }))
+        .filter((line) => line.length > 0)
+        .map((line) => `  ${truncate(line, width - 2)}`),
     ]
   }
 
@@ -2805,11 +2808,39 @@ function renderBranchesSurface(
         const cursor = isSelected ? '>' : ' '
         const marker = branchRowMarker(branch, { ascii: theme.ascii })
         const divergence = formatBranchDivergence(branch, { ascii: theme.ascii })
+        const lastTouched = formatBranchLastTouched(branch.date, new Date())
+        // Split the row into spans so the timestamp stays dim even on the
+        // currently-selected (bold) row. The leading marker + name keep
+        // their original column widths; the timestamp is right-padded so
+        // the divergence column stays aligned across rows.
+        const namePadded = branch.shortName.padEnd(28)
+        const timestampPadded = lastTouched.padEnd(8)
+        const lineDim = !isSelected && !branch.current
+        const head = `${cursor} ${marker} ${namePadded} `
+        const trailingDivergence = divergence ? ` ${divergence}` : ''
+        // Truncate the assembled line cooperatively so we never overflow
+        // the panel; the timestamp is short and the divergence is the
+        // most expendable, but the existing 140 cap is ample.
+        const fullText = `${head}${timestampPadded}${trailingDivergence}`
+        const truncated = truncate(fullText, 140)
+        // If truncation chopped into the timestamp/divergence portion,
+        // fall back to a single Text to keep the visible width honest.
+        if (truncated !== fullText) {
+          return h(Text, {
+            key: `branch-${index}`,
+            bold: isSelected,
+            dimColor: lineDim,
+          }, truncated)
+        }
         return h(Text, {
           key: `branch-${index}`,
           bold: isSelected,
-          dimColor: !isSelected && !branch.current,
-        }, truncate(`${cursor} ${marker} ${branch.shortName.padEnd(28)} ${divergence}`, 140))
+          dimColor: lineDim,
+        },
+        head,
+        h(Text, { dimColor: true }, timestampPadded),
+        trailingDivergence
+        )
       })
 
   return h(Box, {


### PR DESCRIPTION
## Summary

Three small UX improvements to the Ink TUI Branches view (`coco ui` → Branches), based on a fresh visual review.

### 1. Drop the "even with origin/X" noise

Being up-to-date is the boring default — the literal text dominated every line and conveyed near-zero information. The row marker now carries the synced signal (see #3).

**Before**
```
  ≡  feat/auth                   even with origin/feat/auth
  ≡  feat/billing                even with origin/feat/billing
  *  main                        even with origin/main
```

**After**
```
  ≡  feat/auth
  ≡  feat/billing
  *  main
```

The non-zero case (`↑3 ↓1 origin/main`) is informative and stays as-is.

### 2. Add a "last touched" relative timestamp

Branches lists are scanned to find "the recently active stuff" — relative timing answers that directly. Uses `branch.date` (already collected via `for-each-ref committerdate:short`, no new git calls). Rendered dim so it subordinates to the branch name; split into Text spans so it stays dim even on the bold/selected row. Pinned to a `now` parameter for deterministic tests.

Buckets: `today` / `1d ago` … `13d ago` / `2w ago` … `8w ago` / `2mo ago` … `11mo ago` / `2y ago`.

**Before**
```
  *  main                       
     feat/auth                  
```

**After**
```
  *  main                        today
  ≡  feat/auth                   2d ago
  ↕  feat/billing                3w ago    ↑5 ↓1 origin/feat/billing
  ◌  experiment/old              5mo ago   no upstream
```

### 3. New "remote status" glyph in the row marker

`branchRowMarker` now distinguishes four remote states with a single glyph:

| Marker | Meaning                  | ASCII |
|--------|--------------------------|-------|
| `*`    | current branch           | `*`   |
| `◌`    | no upstream              | `?`   |
| `≡`    | upstream + synced        | `=`   |
| `↕`    | upstream + diverged      | `~`   |

ASCII fallbacks honor `theme.ascii` for `NO_COLOR`/legacy terminals.

## Out of scope (noted for follow-up)

- The legacy non-Ink TUI in `src/commands/log/interactive.ts:224` still has its own local `formatDivergence` (not the shared helper) that emits "even with X". That path is not reached by `coco ui`, predates the iconography helpers, and was left untouched here to keep the PR focused.
- Could add a header sort indicator showing the `last-touched` axis when sorted by date — left for a follow-up.

## Test plan

- [x] `npm run lint`
- [x] `npm run test:jest` (892/892 passing) — added unit coverage for every new and changed helper in `inkIconography.test.ts` (32 cases in that file alone)
- [x] `npm run build`
- [x] `npm run test` (full validation suite incl. CLI smoke + release dry-run)
- [ ] Manual visual check: open `coco ui`, navigate to Branches, confirm rows look as in the "After" snippets above (synced, diverged, no-upstream, current)
- [ ] Manual visual check under `NO_COLOR=1` and `--ascii` to confirm the ASCII fallbacks read cleanly