### PR TITLE
feat(log-tui): wire revert / reset / interactive-rebase to history view (#777)

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -1279,4 +1279,101 @@ describe('log Ink input interactions', () => {
       ])
     })
   })
+
+  // Issue #777 — wire revert / reset / interactive-rebase to history
+  // view keystrokes. R and `i` route through y-confirm via the existing
+  // pendingConfirmation flow; Z opens a mode prompt first because the
+  // soft / mixed / hard choice changes destructiveness.
+  describe('history-view mutation bindings (#777)', () => {
+    it('R on the history view sets pending confirmation for revert-commit', () => {
+      const events = getLogInkInputEvents(createLogInkState(rows), 'R')
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'setPendingConfirmation', value: 'revert-commit' } },
+      ])
+    })
+
+    it('Z on the history view opens the reset-mode prompt', () => {
+      const events = getLogInkInputEvents(createLogInkState(rows), 'Z')
+      expect(events).toEqual([
+        {
+          type: 'action',
+          action: {
+            type: 'openInputPrompt',
+            kind: 'reset-mode',
+            label: 'Reset mode (soft / mixed / hard)',
+          },
+        },
+      ])
+    })
+
+    it('i on the history view sets pending confirmation for interactive-rebase', () => {
+      // Lowercase `i` keeps the existing global `I` ai-commit-summary
+      // workflow reachable on the history view; matches `git rebase -i`.
+      const events = getLogInkInputEvents(createLogInkState(rows), 'i')
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'setPendingConfirmation', value: 'interactive-rebase' } },
+      ])
+    })
+
+    it('R / Z / i are scoped to the history view — branches view sees them differently', () => {
+      // Branches view has its own R (rename-branch). Z and i are unbound
+      // there — they fall through silently.
+      const branches = createLogInkState(rows, { activeView: 'branches' })
+      const r = getLogInkInputEvents(branches, 'R', {}, { branchCount: 3 })
+      expect(r[0]).toMatchObject({
+        type: 'action',
+        action: { type: 'openInputPrompt', kind: 'rename-branch' },
+      })
+    })
+
+    it('reset-mode prompt submission forwards the mode to reset-to-commit', () => {
+      let state = createLogInkState(rows)
+      state = applyInput(state, 'Z')
+      expect(state.inputPrompt?.kind).toBe('reset-mode')
+
+      // Simulate typing "soft" then Enter.
+      state = applyInput(state, 's')
+      state = applyInput(state, 'o')
+      state = applyInput(state, 'f')
+      state = applyInput(state, 't')
+      const events = getLogInkInputEvents(state, '', { return: true })
+      expect(events).toContainEqual({
+        type: 'runWorkflowAction',
+        id: 'reset-to-commit',
+        payload: 'soft',
+      })
+    })
+
+    it('reset-mode prompt rejects unknown modes with a status message', () => {
+      let state = createLogInkState(rows)
+      state = applyInput(state, 'Z')
+      'extreme'.split('').forEach((c) => { state = applyInput(state, c) })
+      const events = getLogInkInputEvents(state, '', { return: true })
+      // Status message + no workflow run.
+      expect(events.find((e) => e.type === 'runWorkflowAction')).toBeUndefined()
+      expect(events).toContainEqual({
+        type: 'action',
+        action: { type: 'setStatus', value: 'Unknown reset mode: extreme. Use soft, mixed, or hard.' },
+      })
+    })
+
+    it('reset-mode prompt accepts mixed and hard modes case-insensitively', () => {
+      let state = createLogInkState(rows)
+      state = applyInput(state, 'Z')
+      'HARD'.split('').forEach((c) => { state = applyInput(state, c) })
+      const events = getLogInkInputEvents(state, '', { return: true })
+      expect(events).toContainEqual({
+        type: 'runWorkflowAction',
+        id: 'reset-to-commit',
+        payload: 'hard',
+      })
+    })
+
+    it('R / Z / i no-op when the history list is empty', () => {
+      const empty = createLogInkState([])
+      expect(getLogInkInputEvents(empty, 'R')).toEqual([])
+      expect(getLogInkInputEvents(empty, 'Z')).toEqual([])
+      expect(getLogInkInputEvents(empty, 'i')).toEqual([])
+    })
+  })
 })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -369,12 +369,31 @@ export function getLogInkInputEvents(
         return [action({ type: 'setStatus', value: 'enter a value or press esc to cancel' })]
       }
       // Most prompt kinds dispatch a workflow whose id matches the
-      // kind. PR-related prompts forward to a workflow id distinct
-      // from the prompt name so the panel can keep its keys
-      // mnemonic-friendly while the workflow ids stay descriptive.
-      // pr-merge-strategy validates the strategy at the input layer
-      // so a typo doesn't surface as a "workflow not yet wired"
-      // status downstream.
+      // kind (`create-branch`, `rename-branch`, etc.). A few are
+      // exceptions:
+      // - `reset-mode` collects soft/mixed/hard and forwards the mode
+      //   as the payload to `reset-to-commit` (#777).
+      // - `pr-merge-strategy` validates the strategy and routes to
+      //   `merge-pr` via the y-confirm path (#783).
+      // - `pr-comment` dispatches `comment-pr` directly — the body
+      //   itself is the affirmative action.
+      // - `pr-request-changes` routes to `request-changes-pr` via
+      //   y-confirm because the review is publicly visible.
+      // Each exception validates here so a typo doesn't surface as a
+      // "workflow not yet wired" status downstream.
+      if (state.inputPrompt.kind === 'reset-mode') {
+        const mode = value.toLowerCase()
+        if (mode !== 'soft' && mode !== 'mixed' && mode !== 'hard') {
+          return [action({
+            type: 'setStatus',
+            value: `Unknown reset mode: ${value}. Use soft, mixed, or hard.`,
+          })]
+        }
+        return [
+          { type: 'runWorkflowAction', id: 'reset-to-commit', payload: mode },
+          action({ type: 'closeInputPrompt' }),
+        ]
+      }
       if (state.inputPrompt.kind === 'pr-merge-strategy') {
         const strategy = value.toLowerCase()
         if (strategy !== 'merge' && strategy !== 'squash' && strategy !== 'rebase') {
@@ -1333,6 +1352,55 @@ export function getLogInkInputEvents(
     !state.pendingCommitFocused
   ) {
     return [action({ type: 'setPendingConfirmation', value: 'cherry-pick-commit' })]
+  }
+
+  // `R` reverts the cursored commit by adding an inverse commit on top
+  // of HEAD. Same y-confirm gate as cherry-pick — non-rewriting but
+  // still a real mutation.
+  if (
+    inputValue === 'R' &&
+    state.activeView === 'history' &&
+    state.focus === 'commits' &&
+    state.filteredCommits.length > 0 &&
+    !state.pendingCommitFocused
+  ) {
+    return [action({ type: 'setPendingConfirmation', value: 'revert-commit' })]
+  }
+
+  // `Z` resets the current branch tip to the cursored commit. Opens a
+  // mode prompt (soft / mixed / hard) instead of jumping straight to
+  // confirmation because the choice changes the destructiveness
+  // dramatically — `--hard` discards working-tree changes. The prompt
+  // submission special-cases `kind === 'reset-mode'` to forward the
+  // mode through `reset-to-commit` (see prompt-submit handler above).
+  // No `initial` value: existing prompts append to initial rather than
+  // replacing it, which would surprise the user typing the mode.
+  if (
+    inputValue === 'Z' &&
+    state.activeView === 'history' &&
+    state.focus === 'commits' &&
+    state.filteredCommits.length > 0 &&
+    !state.pendingCommitFocused
+  ) {
+    return [action({
+      type: 'openInputPrompt',
+      kind: 'reset-mode',
+      label: 'Reset mode (soft / mixed / hard)',
+    })]
+  }
+
+  // `i` (lowercase) starts an interactive rebase from the cursored
+  // commit's parent. Lowercase keeps the existing global `I`
+  // ai-commit-summary workflow reachable on the history view; `i`
+  // also matches the `git rebase -i` flag mnemonic.
+  if (
+    inputValue === 'i' &&
+    state.activeView === 'history' &&
+    state.focus === 'commits' &&
+    state.filteredCommits.length > 0 &&
+    !state.pendingCommitFocused
+  ) {
+    return [action({ type: 'setPendingConfirmation', value: 'interactive-rebase' })]
   }
 
   // `y` / `Y` yank the contextually relevant identifier from the active

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -17,7 +17,10 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ move', 'enter diff', 'c cherry-pick', 'y/Y yank', '/ search', 'gg/G top/bottom'],
+      // `c/R/Z/i mutate` is the compact chip for cherry-pick / revert /
+      // reset / interactive-rebase — full descriptions in ? help and
+      // the palette.
+      contextual: ['↑/↓ move', 'enter diff', 'c/R/Z/i mutate', 'y/Y yank', '/ search', 'gg/G top/bottom'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -606,7 +606,12 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
   }
 
   return {
-    contextual: ['↑/↓ move', 'enter diff', 'c cherry-pick', 'y/Y yank', '/ search', 'gg/G top/bottom'],
+    // History view default hints. Mutating ops (`c` cherry-pick, `R`
+    // revert, `Z` reset, `i` interactive-rebase) all route through a
+    // y-confirm or mode prompt — none fire silently from the keystroke.
+    // Grouped into a compact `c/R/Z/i mutate` chip so the footer stays
+    // scannable; full descriptions live in `?` help and the palette.
+    contextual: ['↑/↓ move', 'enter diff', 'c/R/Z/i mutate', 'y/Y yank', '/ search', 'gg/G top/bottom'],
     global: NORMAL_GLOBAL_HINTS,
   }
 }

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -157,9 +157,14 @@ import {
 import { createLightweightTag, deleteLocalTag, deleteRemoteTag, pushTag } from './tagActions'
 import {
   ClipboardRunner,
+  ResetMode,
   checkoutFileFromCommit,
   cherryPickCommit,
   defaultClipboardRunner,
+  isResetMode,
+  resetToCommit,
+  revertCommit,
+  startInteractiveRebase,
 } from './historyActions'
 import { applyStash, checkoutFileFromStash, createStash, dropStash, popStash } from './stashActions'
 import { removeWorktree } from './worktreeActions'
@@ -1312,6 +1317,41 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         const commit = getSelectedInkCommit(state)
         if (!commit) return { ok: false, message: 'No commit selected' }
         return cherryPickCommit(git, {
+          hash: commit.hash,
+          shortHash: commit.shortHash,
+          message: commit.message,
+        })
+      },
+      'revert-commit': async () => {
+        const commit = getSelectedInkCommit(state)
+        if (!commit) return { ok: false, message: 'No commit selected' }
+        return revertCommit(git, {
+          hash: commit.hash,
+          shortHash: commit.shortHash,
+          message: commit.message,
+        })
+      },
+      'reset-to-commit': async () => {
+        const commit = getSelectedInkCommit(state)
+        if (!commit) return { ok: false, message: 'No commit selected' }
+        // Mode arrives via the action's `payload` field — the input
+        // handler runs the reset-mode prompt (kind: 'reset-mode') and
+        // routes the typed value here. Default to `mixed` (git's own
+        // default) when the user submitted an empty value.
+        const raw = payload?.trim().toLowerCase() || 'mixed'
+        if (!isResetMode(raw)) {
+          return { ok: false, message: `Unknown reset mode: ${raw}. Use soft, mixed, or hard.` }
+        }
+        return resetToCommit(git, {
+          hash: commit.hash,
+          shortHash: commit.shortHash,
+          message: commit.message,
+        }, raw as ResetMode)
+      },
+      'interactive-rebase': async () => {
+        const commit = getSelectedInkCommit(state)
+        if (!commit) return { ok: false, message: 'No commit selected' }
+        return startInteractiveRebase(git, {
           hash: commit.hash,
           shortHash: commit.shortHash,
           message: commit.message,

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -206,6 +206,7 @@ export type LogInkInputPromptKind =
   | 'rename-branch'
   | 'set-upstream'
   | 'create-stash'
+  | 'reset-mode'
   | 'pr-merge-strategy'
   | 'pr-comment'
   | 'pr-request-changes'

--- a/src/commands/log/inkWorkflows.test.ts
+++ b/src/commands/log/inkWorkflows.test.ts
@@ -73,6 +73,33 @@ describe('log Ink workflows', () => {
     expect(getLogInkWorkflowActionById('checkout-file-from-commit')?.key).toBe('')
   })
 
+  // Issue #777 — revert / reset / interactive-rebase wired through the
+  // workflow registry as palette-only entries (key: ''). Real keystroke
+  // dispatch is per-view scoped in inkInput.ts so they only fire on
+  // history view.
+  it('registers history-mutation workflows as destructive + palette-only', () => {
+    const revert = getLogInkWorkflowActionById('revert-commit')
+    expect(revert).toMatchObject({
+      key: '',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    })
+
+    const reset = getLogInkWorkflowActionById('reset-to-commit')
+    expect(reset).toMatchObject({
+      key: '',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    })
+
+    const rebase = getLogInkWorkflowActionById('interactive-rebase')
+    expect(rebase).toMatchObject({
+      key: '',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    })
+  })
+
   it('reports loading states while optional repository context hydrates', () => {
     const sections = getLogInkWorkflowSections({
       contextLoading: true,

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -312,6 +312,41 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: false,
     },
     {
+      // Per-view-only: scoped to the history view in inkInput so `R`
+      // doesn't fire elsewhere (it's also `R` for rename in branches
+      // and delete-remote-tag in tags). Empty key keeps it
+      // palette-discoverable without registering a global hotkey.
+      id: 'revert-commit',
+      key: '',
+      label: 'Revert commit',
+      description: 'Revert the cursored commit by adding an inverse commit on top of HEAD.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
+      // Per-view-only: scoped to the history view in inkInput. Triggers
+      // a mode prompt (soft / mixed / hard) before the reset runs so
+      // `Z` alone never silently rewrites history.
+      id: 'reset-to-commit',
+      key: '',
+      label: 'Reset to commit',
+      description: 'Move the current branch tip to the cursored commit (prompts for soft / mixed / hard).',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
+      // Per-view-only: scoped to the history view in inkInput. `i`
+      // (lowercase) is used instead of `I` so the existing `I`
+      // ai-commit-summary workflow stays reachable on the history
+      // view — `i` matches the `git rebase -i` flag mnemonic anyway.
+      id: 'interactive-rebase',
+      key: '',
+      label: 'Interactive rebase',
+      description: 'Start an interactive rebase from the cursored commit (opens $GIT_EDITOR for the todo list).',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
       id: 'ai-commit-summary',
       key: 'I',
       label: 'AI commit summary',


### PR DESCRIPTION
Closes #777.

## Summary

The three history-action helpers (\`revertCommit\`, \`resetToCommit\`, \`startInteractiveRebase\`) already lived in \`historyActions.ts\` from earlier work but were palette-discoverable only — no keystrokes. Wire them as scoped bindings on the history view.

| Key | Action | Flow |
|---|---|---|
| **R** | revert the cursored commit | y-confirm → \`git revert --no-edit <sha>\` |
| **Z** | reset to the cursored commit | mode prompt (soft / mixed / hard) → \`git reset --<mode> <sha>\` |
| **i** | interactive rebase from the cursored commit's parent | y-confirm → \`git rebase -i <sha>^\` |

## Key choices

- **\`R\` for revert** — collides with \`R\` rename in the branches view, but the existing per-view scoping pattern handles it cleanly (R fires revert only on history view).
- **\`Z\` for reset** — free everywhere, mnemonic enough.
- **\`i\` (lowercase) for interactive-rebase** — the issue suggested \`I\`, but uppercase \`I\` is the global \`ai-commit-summary\` workflow key. Lowercase keeps both reachable on the history view and matches the \`git rebase -i\` flag mnemonic. Documented in the commit message.

## Reset mode prompt

\`Z\` opens an input prompt with kind \`reset-mode\` and label \`'Reset mode (soft / mixed / hard)'\`. The prompt-submit handler special-cases this kind: it validates the mode, then dispatches \`runWorkflowAction { id: 'reset-to-commit', payload: <mode> }\` so the runtime handler receives the mode as payload. Unknown modes surface a \`Use soft, mixed, or hard.\` status. Empty payload at the runtime level falls back to \`mixed\` (git's default).

No \`initial\` value on the prompt because the existing prompt model appends to it rather than replacing — would surprise the user typing the mode.

## Footer hint

Compressed the four mutation keys into a single \`c/R/Z/i mutate\` chip so the history footer stays scannable. Full per-key descriptions live in \`?\` help and the palette.

## Safety

All three workflows are \`kind: 'destructive'\` + \`requiresConfirmation: true\`. \`R\` and \`i\` route through the existing y-confirm pendingConfirmation flow. \`Z\` uses the mode prompt as the confirmation interaction. All three call \`guardNoInProgressOperation\` in the helpers so they refuse to fire mid-merge / mid-rebase.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run test:jest\` 927/927 passing (8 new dispatch cases for R/Z/i, mode validation, scoping, empty-history, plus 1 workflow-registration assertion)
- [x] \`npm run build\` clean
- [ ] Visual: cursor on a commit → R → y → revert lands on top. Z → soft → reset moves branch tip. i → y → opens \$GIT_EDITOR for the rebase todo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)