### PR TITLE
feat(log-tui): side-by-side diff toggle (#785)

### DIFF
--- a/src/commands/log/inkDiffViewModePersistence.test.ts
+++ b/src/commands/log/inkDiffViewModePersistence.test.ts
@@ -1,0 +1,81 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import {
+  getDiffViewModeMarkerPath,
+  getSavedDiffViewMode,
+  saveDiffViewMode,
+} from './inkDiffViewModePersistence'
+
+describe('log Ink diff view mode persistence', () => {
+  let tmpRoot: string
+  let originalXdgCacheHome: string | undefined
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-diff-mode-'))
+    originalXdgCacheHome = process.env.XDG_CACHE_HOME
+    process.env.XDG_CACHE_HOME = tmpRoot
+  })
+
+  afterEach(() => {
+    if (originalXdgCacheHome === undefined) {
+      delete process.env.XDG_CACHE_HOME
+    } else {
+      process.env.XDG_CACHE_HOME = originalXdgCacheHome
+    }
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('returns undefined when no marker file has been written yet', () => {
+    expect(getSavedDiffViewMode('/some/repo')).toBeUndefined()
+  })
+
+  it('round-trips a saved mode through the marker file', () => {
+    saveDiffViewMode('/some/repo', 'split')
+    expect(getSavedDiffViewMode('/some/repo')).toBe('split')
+
+    saveDiffViewMode('/some/repo', 'unified')
+    expect(getSavedDiffViewMode('/some/repo')).toBe('unified')
+  })
+
+  it('keeps marker files distinct per repo path', () => {
+    saveDiffViewMode('/repo-a', 'split')
+    saveDiffViewMode('/repo-b', 'unified')
+
+    expect(getSavedDiffViewMode('/repo-a')).toBe('split')
+    expect(getSavedDiffViewMode('/repo-b')).toBe('unified')
+  })
+
+  it('uses XDG_CACHE_HOME when set', () => {
+    const expected = path.join(tmpRoot, 'coco')
+    expect(getDiffViewModeMarkerPath('/some/repo').startsWith(expected)).toBe(true)
+  })
+
+  it('falls back to ~/.cache/coco when XDG_CACHE_HOME is unset', () => {
+    delete process.env.XDG_CACHE_HOME
+    const expected = path.join(os.homedir(), '.cache', 'coco')
+    expect(getDiffViewModeMarkerPath('/some/repo').startsWith(expected)).toBe(true)
+  })
+
+  it('returns undefined for marker files containing an invalid mode', () => {
+    const markerPath = getDiffViewModeMarkerPath('/some/repo')
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true })
+    fs.writeFileSync(markerPath, 'not-a-mode')
+
+    expect(getSavedDiffViewMode('/some/repo')).toBeUndefined()
+  })
+
+  it('trims whitespace before validating saved markers', () => {
+    const markerPath = getDiffViewModeMarkerPath('/some/repo')
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true })
+    fs.writeFileSync(markerPath, '  split\n')
+
+    expect(getSavedDiffViewMode('/some/repo')).toBe('split')
+  })
+
+  it('does not throw when the marker directory cannot be created', () => {
+    process.env.XDG_CACHE_HOME = '/dev/null/forbidden'
+    expect(() => saveDiffViewMode('/some/repo', 'split')).not.toThrow()
+  })
+})

--- a/src/commands/log/inkDiffViewModePersistence.ts
+++ b/src/commands/log/inkDiffViewModePersistence.ts
@@ -1,0 +1,56 @@
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { LogInkDiffViewMode } from './inkViewModel'
+
+/**
+ * Persist the user's preferred diff view mode (unified vs side-by-side
+ * split — #785) per repo. Mirrors `inkSidebarPersistence.ts` so the
+ * cache layout, error model, and key derivation stay consistent across
+ * settings: best-effort, XDG-friendly, no PII in the cache filename.
+ */
+
+const VALID_MODES: ReadonlyArray<LogInkDiffViewMode> = ['unified', 'split']
+
+function resolveCacheDir(): string {
+  const xdg = process.env.XDG_CACHE_HOME
+  if (xdg && xdg.trim().length > 0) {
+    return path.join(xdg, 'coco')
+  }
+  return path.join(os.homedir(), '.cache', 'coco')
+}
+
+function repoKey(repoPath: string): string {
+  // sha1 is used here as a non-security cache-key derivation — we just
+  // need a deterministic short identifier for the marker filename. No
+  // PII or auth context is hashed.
+  // DevSkim: ignore DS126858
+  return crypto.createHash('sha1').update(repoPath).digest('hex').slice(0, 16)
+}
+
+export function getDiffViewModeMarkerPath(repoPath: string): string {
+  return path.join(resolveCacheDir(), `diff-view-mode.${repoKey(repoPath)}`)
+}
+
+export function getSavedDiffViewMode(repoPath: string): LogInkDiffViewMode | undefined {
+  try {
+    const raw = fs.readFileSync(getDiffViewModeMarkerPath(repoPath), 'utf8').trim()
+    return VALID_MODES.includes(raw as LogInkDiffViewMode)
+      ? (raw as LogInkDiffViewMode)
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function saveDiffViewMode(repoPath: string, mode: LogInkDiffViewMode): void {
+  const marker = getDiffViewModeMarkerPath(repoPath)
+  try {
+    fs.mkdirSync(path.dirname(marker), { recursive: true })
+    fs.writeFileSync(marker, mode)
+  } catch {
+    // Best-effort persistence; swallow.
+  }
+}

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -893,13 +893,14 @@ describe('log Ink input interactions', () => {
       let state = openPalette()
 
       // Filter to a unique substring that ONLY matches toggleGraph.
-      // Earlier the test typed `graph` letter-by-letter, but the
-      // fuzzy-match scorer also accepts long-distance matches like
-      // `Merge ... current ... branch's ... pull ... squash` which
-      // collide with the new PR-panel workflows added in #783.
-      // `togglegr` is a substring of the toggleGraph id and lives
-      // nowhere else in the command set.
-      'togglegr'.split('').forEach((c) => { state = applyInput(state, c) })
+      // The fuzzy-match scorer accepts long-distance character chains,
+      // so the original `graph` filter started colliding with new
+      // commands as the registry grew (e.g., #783's PR-panel
+      // workflows, #785's toggleDiffViewMode description). The full
+      // id substring `togglegraph` is unique to toggleGraph because
+      // toggleDiffViewMode lacks the `p` after `togglegra` in any of
+      // its searchable fields.
+      'togglegraph'.split('').forEach((c) => { state = applyInput(state, c) })
 
       // Only one match (toggleGraph). Down-arrow should clamp at index 0.
       state = applyInput(state, '', { downArrow: true })
@@ -1374,6 +1375,76 @@ describe('log Ink input interactions', () => {
       expect(getLogInkInputEvents(empty, 'R')).toEqual([])
       expect(getLogInkInputEvents(empty, 'Z')).toEqual([])
       expect(getLogInkInputEvents(empty, 'i')).toEqual([])
+    })
+  })
+
+  describe('d toggles diff view mode (#785)', () => {
+    it('emits toggleDiffViewMode + a status hint when pressed in the diff view', () => {
+      const state = { ...createLogInkState(rows), activeView: 'diff' as const }
+      const events = getLogInkInputEvents(state, 'd')
+
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'toggleDiffViewMode' } },
+        {
+          type: 'action',
+          action: { type: 'setStatus', value: 'Switched to side-by-side diff' },
+        },
+      ])
+    })
+
+    it('labels the status hint with the next mode (split → unified)', () => {
+      const state = {
+        ...createLogInkState(rows),
+        activeView: 'diff' as const,
+        diffViewMode: 'split' as const,
+      }
+      const events = getLogInkInputEvents(state, 'd')
+
+      expect(events).toContainEqual({
+        type: 'action',
+        action: { type: 'setStatus', value: 'Switched to unified diff' },
+      })
+    })
+
+    it('does not toggle the mode when pressed outside the diff view', () => {
+      const state = createLogInkState(rows)
+      // history view (default)
+      const historyEvents = getLogInkInputEvents(state, 'd')
+      expect(historyEvents).not.toContainEqual({
+        type: 'action',
+        action: { type: 'toggleDiffViewMode' },
+      })
+
+      const statusEvents = getLogInkInputEvents(
+        { ...state, activeView: 'status' as const },
+        'd'
+      )
+      expect(statusEvents).not.toContainEqual({
+        type: 'action',
+        action: { type: 'toggleDiffViewMode' },
+      })
+    })
+
+    it('does not collide with the gd chord — gd still pushes the diff view', () => {
+      const state = createLogInkState(rows)
+      // First press starts the chord
+      const startChord = getLogInkInputEvents(state, 'g')
+      expect(startChord).toContainEqual({
+        type: 'action',
+        action: { type: 'setPendingKey', value: 'g' },
+      })
+
+      // Second press completes gd → pushView 'diff', not toggleDiffViewMode
+      const chordState = applyLogInkAction(state, { type: 'setPendingKey', value: 'g' })
+      const completeChord = getLogInkInputEvents(chordState, 'd')
+      expect(completeChord).toContainEqual({
+        type: 'action',
+        action: { type: 'pushView', value: 'diff' },
+      })
+      expect(completeChord).not.toContainEqual({
+        type: 'action',
+        action: { type: 'toggleDiffViewMode' },
+      })
     })
   })
 })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -757,6 +757,23 @@ export function getLogInkInputEvents(
     return [action({ type: 'setPendingKey', value: 'g' })]
   }
 
+  // `d` on the diff view toggles between unified and side-by-side split
+  // rendering (#785). Scoped to the diff view so the letter stays free
+  // for other surfaces. The chord branch above already claimed `gd`,
+  // so by the time we get here `pendingKey` is not `g`.
+  if (inputValue === 'd' && state.activeView === 'diff') {
+    const next = state.diffViewMode === 'unified' ? 'split' : 'unified'
+    return [
+      action({ type: 'toggleDiffViewMode' }),
+      action({
+        type: 'setStatus',
+        value: next === 'split'
+          ? 'Switched to side-by-side diff'
+          : 'Switched to unified diff',
+      }),
+    ]
+  }
+
   if (inputValue === '\\') {
     return [action({ type: 'toggleGraph' })]
   }

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -106,6 +106,56 @@ describe('log Ink keymap', () => {
     })
   })
 
+  describe('diff view split/unified hint (#785)', () => {
+    it('surfaces "d split" on a unified commit diff', () => {
+      const hints = getLogInkFooterHints({
+        activeView: 'diff',
+        diffSource: 'commit',
+        diffViewMode: 'unified',
+        filterMode: false,
+        focus: 'commits',
+        showHelp: false,
+      })
+      expect(hints.contextual).toContain('d split')
+    })
+
+    it('surfaces "d unified" once split is active on a commit diff', () => {
+      const hints = getLogInkFooterHints({
+        activeView: 'diff',
+        diffSource: 'commit',
+        diffViewMode: 'split',
+        filterMode: false,
+        focus: 'commits',
+        showHelp: false,
+      })
+      expect(hints.contextual).toContain('d unified')
+    })
+
+    it('surfaces the toggle on the stash diff source as well', () => {
+      const hints = getLogInkFooterHints({
+        activeView: 'diff',
+        diffSource: 'stash',
+        diffViewMode: 'unified',
+        filterMode: false,
+        focus: 'commits',
+        showHelp: false,
+      })
+      expect(hints.contextual).toContain('d split')
+    })
+
+    it('does not surface the toggle on the worktree diff source', () => {
+      // Worktree diff stays unified-only for now — staging is the
+      // primary action there and split mode complicates the hunk picker.
+      const hints = getLogInkFooterHints({
+        activeView: 'diff',
+        filterMode: false,
+        focus: 'commits',
+        showHelp: false,
+      })
+      expect(hints.contextual.some((h) => h.startsWith('d '))).toBe(false)
+    })
+  })
+
   // #791 follow-up — in-sidebar selection. When sidebar is focused on a
   // content tab WITH items, the footer surfaces the per-entity ops
   // (checkout / apply / pop / drop / etc.) so the user discovers that

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -41,6 +41,7 @@ export type LogInkCommandId =
   | 'refresh'
   | 'revertSelection'
   | 'search'
+  | 'toggleDiffViewMode'
   | 'toggleGraph'
   | 'workflowActions'
   | 'yankClipboard'
@@ -184,6 +185,13 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     label: 'graph',
     description: 'Toggle compact and full graph display.',
     contexts: ['normal', 'commits'],
+  },
+  {
+    id: 'toggleDiffViewMode',
+    keys: ['d'],
+    label: 'split/unified',
+    description: 'Toggle the diff view between unified and side-by-side split rendering. Falls back to unified on narrow terminals.',
+    contexts: ['commits'],
   },
   {
     id: 'navigateHome',
@@ -354,6 +362,12 @@ export type GetLogInkFooterHintsOptions = {
    *  back to the generic "enter open" hint instead of showing per-item
    *  ops the user cannot reach. */
   sidebarItemCount?: number
+  /**
+   * Current diff view rendering mode (#785). When set on the diff view
+   * the footer surfaces `d split` / `d unified` so users see what `d`
+   * will switch to.
+   */
+  diffViewMode?: 'unified' | 'split'
 }
 
 export type LogInkChordContinuation = {
@@ -539,9 +553,14 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
   }
 
   if (options.activeView === 'diff') {
+    // Surface what `d` will switch *to* — labels the next mode rather
+    // than the current one so the hint reads as a verb. The split-mode
+    // hint is only shown for the read-only diff sources (commit/stash);
+    // the worktree diff stays unified-only for now.
+    const splitToggleHint = options.diffViewMode === 'split' ? 'd unified' : 'd split'
     if (options.diffSource === 'stash') {
       return {
-        contextual: ['j/k lines', '[/] file', 'c cherry-pick', 'o edit', 'y yank', 'esc back'],
+        contextual: ['j/k lines', '[/] file', 'c cherry-pick', 'o edit', splitToggleHint, 'y yank', 'esc back'],
         global: NORMAL_GLOBAL_HINTS,
       }
     }
@@ -549,7 +568,7 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
       // Commit-diff explore: read-only diff, but `c` cherry-picks the
       // cursored file from the commit into the worktree.
       return {
-        contextual: ['j/k hunks', '[/] file', 'c cherry-pick', 'y/Y yank', 'esc back'],
+        contextual: ['j/k hunks', '[/] file', 'c cherry-pick', splitToggleHint, 'y/Y yank', 'esc back'],
         global: NORMAL_GLOBAL_HINTS,
       }
     }

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -79,7 +79,9 @@ import { LaneSegment, getLaneColor } from './inkGraphLanes'
 import { formatHyperlink } from './inkHyperlinks'
 import { LogInkInputKey, getLogInkInputEvents } from './inkInput'
 import { hasSeenOnboarding, markOnboardingSeen } from './inkOnboarding'
+import { getSavedDiffViewMode, saveDiffViewMode } from './inkDiffViewModePersistence'
 import { getSavedSidebarTab, saveSidebarTab } from './inkSidebarPersistence'
+import { SplitDiffRow, buildSplitDiffRows } from './inkSplitDiff'
 import { getSidebarVisibleWindow } from './inkSidebarSelection'
 import {
   PromotedSelectionsSnapshot,
@@ -433,6 +435,113 @@ function diffLineProps(
   }
 
   return {}
+}
+
+/**
+ * Minimum terminal width below which the split diff falls back to
+ * unified rendering (#785). Each column needs ~50 columns for code to
+ * read comfortably plus border + padding overhead, so anything narrower
+ * than ~120 columns gets the unified view regardless of the user's
+ * preference. The preference is preserved — switching back to a wide
+ * terminal restores split mode automatically.
+ */
+const MIN_SPLIT_DIFF_WIDTH = 120
+
+function isSplitDiffViable(state: LogInkState, width: number): boolean {
+  return state.diffViewMode === 'split' && width >= MIN_SPLIT_DIFF_WIDTH
+}
+
+/**
+ * Style props for one side of a split-diff row, derived from the row's
+ * `kind` rather than the leading character (because the helper has
+ * already stripped the leading +/-/space). Keeps the colors aligned with
+ * `diffLineProps`.
+ */
+function splitDiffSideProps(
+  kind: SplitDiffRow['left']['kind'] | SplitDiffRow['right']['kind'],
+  theme: LogInkTheme
+): { color?: string; dimColor?: boolean } {
+  if (kind === 'header') {
+    if (theme.noColor) return { dimColor: true }
+    return { color: theme.colors.accent }
+  }
+  if (kind === 'empty') {
+    return { dimColor: true }
+  }
+  if (theme.noColor) {
+    return { dimColor: kind === 'context' }
+  }
+  if (kind === 'add') return { color: theme.colors.gitAdded }
+  if (kind === 'remove') return { color: theme.colors.gitDeleted }
+  return {}
+}
+
+/**
+ * Format one column of a split-diff row: an optional 4-digit line
+ * number prefix + the line text, padded/truncated to the column width.
+ * Empty rows render a faint `·` placeholder so the alignment gap is
+ * visible at a glance.
+ */
+function formatSplitDiffCell(
+  side: SplitDiffRow['left'] | SplitDiffRow['right'],
+  columnWidth: number
+): string {
+  if (side.kind === 'empty') {
+    const placeholder = ' · '
+    return placeholder.padEnd(columnWidth)
+  }
+  if (side.kind === 'header') {
+    return truncate(side.text, columnWidth).padEnd(columnWidth)
+  }
+  const lineNo = side.lineNumber !== undefined ? String(side.lineNumber).padStart(4) : '    '
+  // Strip the trailing newline that some diffs include. Keeps column
+  // widths predictable.
+  const text = side.text.replace(/\n$/, '')
+  // 4 digits + 1 space gutter = 5 chars; reserve that off the column
+  // before truncating the text.
+  const textRoom = Math.max(1, columnWidth - 5)
+  return `${lineNo} ${truncate(text, textRoom)}`.padEnd(columnWidth)
+}
+
+/**
+ * Render the split-diff body as a list of two-column rows. The caller
+ * is responsible for slicing the unified-line array to the visible
+ * window — the helper just transforms that slice into Ink nodes.
+ */
+function renderSplitDiffBody(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  unifiedSlice: string[],
+  startOffset: number,
+  width: number,
+  theme: LogInkTheme,
+  keyPrefix: string
+): ReactTypes.ReactElement[] {
+  const { Box, Text } = components
+  const rows = buildSplitDiffRows(unifiedSlice)
+  // Reserve 3 columns of gutter (1 left padding from the Box + 1 column
+  // separator + 1 right padding) so neither side touches the border.
+  const usable = Math.max(20, width - 4)
+  const gutter = 1
+  const half = Math.max(10, Math.floor((usable - gutter) / 2))
+  return rows.map((row, index) => {
+    const leftProps = splitDiffSideProps(row.left.kind, theme)
+    const rightProps = splitDiffSideProps(row.right.kind, theme)
+    const leftText = formatSplitDiffCell(row.left, half)
+    const rightText = formatSplitDiffCell(row.right, half)
+    return h(Box, {
+      key: `${keyPrefix}-${startOffset + index}`,
+      flexDirection: 'row',
+    },
+    h(Box, { width: half, flexShrink: 0 },
+      h(Text, leftProps, leftText)
+    ),
+    h(Box, { width: gutter, flexShrink: 0 }, h(Text, { dimColor: true }, ' ')),
+    h(Box, { width: half, flexShrink: 0 },
+      h(Text, rightProps, rightText)
+    )
+    )
+  })
 }
 
 /**
@@ -888,6 +997,13 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         if (saved && saved !== state.userSidebarTab) {
           dispatch({ type: 'restoreSidebarTab', value: saved })
         }
+        // Diff view mode persistence (#785). Same per-repo cache pattern
+        // as the sidebar tab — restore the user's last preference if
+        // they had one. New repos / fresh installs default to unified.
+        const savedDiffMode = getSavedDiffViewMode(repoRoot)
+        if (savedDiffMode && savedDiffMode !== state.diffViewMode) {
+          dispatch({ type: 'setDiffViewMode', value: savedDiffMode })
+        }
       } catch {
         // Not in a worktree, or revparse failed; nothing to restore.
       }
@@ -900,6 +1016,12 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     if (!repoRoot) return
     saveSidebarTab(repoRoot, state.userSidebarTab)
   }, [state.userSidebarTab])
+
+  React.useEffect(() => {
+    const repoRoot = repoRootRef.current
+    if (!repoRoot) return
+    saveDiffViewMode(repoRoot, state.diffViewMode)
+  }, [state.diffViewMode])
 
   // P-stash-explorer: load `git stash show -p <ref>` once the diff view
   // becomes active with diffSource='stash'. Best-effort — empty stashes
@@ -3363,6 +3485,8 @@ function renderDiffSurface(
   // cherry-picks the file at the cursor.
   if (state.diffSource === 'stash') {
     const lines = stashDiffLines || []
+    const splitActive = isSplitDiffViable(state, width)
+    const splitRequestedButTooNarrow = state.diffViewMode === 'split' && !splitActive
     const visibleLines = lines.slice(
       state.diffPreviewOffset,
       state.diffPreviewOffset + visibleRows
@@ -3392,7 +3516,7 @@ function renderDiffSurface(
     // when they ran `git stash`. Body still shows the full ref so it
     // stays unambiguous.
     const stashIdentity = formatStashHeaderIdentity(state.stashDiffRef, context.stashes?.stashes)
-    const headerLines: string[] = stashDiffLoading
+    const baseHeaderLines: string[] = stashDiffLoading
       ? [`Loading diff for ${stashIdentity.subtitle}...`]
       : lines.length
         ? [
@@ -3404,6 +3528,21 @@ function renderDiffSurface(
           '',
         ]
         : ['No diff to display for this stash.']
+    const headerLines = splitRequestedButTooNarrow
+      ? [...baseHeaderLines.slice(0, -1), 'Terminal too narrow for side-by-side; showing unified.', '']
+      : baseHeaderLines
+
+    const stashBodyNodes: ReactTypes.ReactNode[] = stashDiffLoading || !lines.length
+      ? []
+      : splitActive
+        ? renderSplitDiffBody(
+          h, components, visibleLines, state.diffPreviewOffset, width, theme,
+          'stash-diff-split'
+        )
+        : visibleLines.map((line, index) => h(Text, {
+          key: `stash-diff-line-${state.diffPreviewOffset + index}`,
+          ...diffLineProps(line, theme),
+        }, truncate(line, width - 4)))
 
     return h(Box, {
       borderColor: focusBorderColor(theme, focused),
@@ -3414,19 +3553,14 @@ function renderDiffSurface(
       width,
     },
     h(Box, { justifyContent: 'space-between' },
-      h(Text, { bold: true }, panelTitle('Stash diff', focused)),
+      h(Text, { bold: true }, panelTitle(splitActive ? 'Stash diff (split)' : 'Stash diff', focused)),
       h(Text, { dimColor: true }, stashIdentity.subtitle)
     ),
     ...headerLines.map((line, index) => h(Text, {
       key: `stash-diff-header-${index}`,
       dimColor: index > 0,
     }, truncate(line, width - 4))),
-    ...(stashDiffLoading || !lines.length
-      ? []
-      : visibleLines.map((line, index) => h(Text, {
-        key: `stash-diff-line-${state.diffPreviewOffset + index}`,
-        ...diffLineProps(line, theme),
-      }, truncate(line, width - 4)))))
+    ...stashBodyNodes)
   }
 
   // diffSource disambiguates: 'commit' was set when the user opened the
@@ -3439,6 +3573,8 @@ function renderDiffSurface(
 
   if (useCommitDiff) {
     const previewHunks = filePreview?.hunks || []
+    const splitActive = isSplitDiffViable(state, width)
+    const splitRequestedButTooNarrow = state.diffViewMode === 'split' && !splitActive
     const visiblePreviewHunks = previewHunks.slice(
       state.diffPreviewOffset,
       state.diffPreviewOffset + visibleRows
@@ -3453,7 +3589,7 @@ function renderDiffSurface(
       ? `Hunk ${Math.min(hunkCount - currentHunkIndex, hunkCount)}/${hunkCount}`
       : 'No hunks for this file.'
 
-    const headerLines: string[] = filePreviewLoading
+    const baseHeaderLines: string[] = filePreviewLoading
       ? [`Loading diff for ${selectedDetailFile?.path || 'selected file'}...`]
       : previewHunks.length
         ? [
@@ -3463,6 +3599,21 @@ function renderDiffSurface(
           '',
         ]
         : ['No diff preview available for this file.']
+    const headerLines = splitRequestedButTooNarrow
+      ? [...baseHeaderLines.slice(0, -1), 'Terminal too narrow for side-by-side; showing unified.', '']
+      : baseHeaderLines
+
+    const commitBodyNodes: ReactTypes.ReactNode[] = filePreviewLoading || !previewHunks.length
+      ? []
+      : splitActive
+        ? renderSplitDiffBody(
+          h, components, visiblePreviewHunks, state.diffPreviewOffset, width, theme,
+          'commit-diff-split'
+        )
+        : visiblePreviewHunks.map((line, index) => h(Text, {
+          key: `diff-surface-line-${state.diffPreviewOffset + index}`,
+          ...diffLineProps(line, theme),
+        }, truncate(line, 140)))
 
     return h(Box, {
       borderColor: focusBorderColor(theme, focused),
@@ -3473,19 +3624,14 @@ function renderDiffSurface(
       width,
     },
     h(Box, { justifyContent: 'space-between' },
-      h(Text, { bold: true }, panelTitle('Diff', focused)),
+      h(Text, { bold: true }, panelTitle(splitActive ? 'Diff (split)' : 'Diff', focused)),
       h(Text, { dimColor: true }, selectedDetailFile?.path || 'no file')
     ),
     ...headerLines.map((line, index) => h(Text, {
       key: `diff-surface-header-${index}`,
       dimColor: index > 0,
     }, truncate(line, 140))),
-    ...(filePreviewLoading || !previewHunks.length
-      ? []
-      : visiblePreviewHunks.map((line, index) => h(Text, {
-        key: `diff-surface-line-${state.diffPreviewOffset + index}`,
-        ...diffLineProps(line, theme),
-      }, truncate(line, 140)))))
+    ...commitBodyNodes)
   }
 
   const diffLines = worktreeDiff?.lines || []
@@ -4467,6 +4613,7 @@ function renderFooter(
   const hints = getLogInkFooterHints({
     activeView: state.activeView,
     diffSource: state.diffSource,
+    diffViewMode: state.diffViewMode,
     filterMode: state.filterMode,
     focus: state.focus,
     pendingKey: state.pendingKey,

--- a/src/commands/log/inkSplitDiff.test.ts
+++ b/src/commands/log/inkSplitDiff.test.ts
@@ -1,0 +1,222 @@
+import { buildSplitDiffRows } from './inkSplitDiff'
+
+describe('buildSplitDiffRows', () => {
+  it('returns an empty array for empty input', () => {
+    expect(buildSplitDiffRows([])).toEqual([])
+  })
+
+  it('emits a header row for a single hunk header', () => {
+    const rows = buildSplitDiffRows(['@@ -1,1 +1,1 @@'])
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].left.kind).toBe('header')
+    expect(rows[0].right.kind).toBe('header')
+    expect(rows[0].left.text).toBe('@@ -1,1 +1,1 @@')
+  })
+
+  it('pairs a 1-1 change block element-wise', () => {
+    const rows = buildSplitDiffRows([
+      '@@ -1,1 +1,1 @@',
+      '-old line',
+      '+new line',
+    ])
+
+    // header + 1 paired row
+    expect(rows).toHaveLength(2)
+    const change = rows[1]
+    expect(change.left.kind).toBe('remove')
+    expect(change.left.text).toBe('old line')
+    expect(change.left.lineNumber).toBe(1)
+    expect(change.right.kind).toBe('add')
+    expect(change.right.text).toBe('new line')
+    expect(change.right.lineNumber).toBe(1)
+  })
+
+  it('pads the shorter side with empty rows when removals outnumber additions', () => {
+    const rows = buildSplitDiffRows([
+      '@@ -1,3 +1,1 @@',
+      '-a',
+      '-b',
+      '-c',
+      '+x',
+    ])
+
+    // header + 3 rows (longest side)
+    expect(rows).toHaveLength(4)
+    expect(rows[1]).toMatchObject({
+      left: { text: 'a', kind: 'remove', lineNumber: 1 },
+      right: { text: 'x', kind: 'add', lineNumber: 1 },
+    })
+    expect(rows[2]).toMatchObject({
+      left: { text: 'b', kind: 'remove', lineNumber: 2 },
+      right: { text: '', kind: 'empty' },
+    })
+    expect(rows[3]).toMatchObject({
+      left: { text: 'c', kind: 'remove', lineNumber: 3 },
+      right: { text: '', kind: 'empty' },
+    })
+  })
+
+  it('pads the shorter side with empty rows when additions outnumber removals', () => {
+    const rows = buildSplitDiffRows([
+      '@@ -1,1 +1,3 @@',
+      '-only',
+      '+x',
+      '+y',
+      '+z',
+    ])
+
+    expect(rows).toHaveLength(4)
+    expect(rows[1]).toMatchObject({
+      left: { text: 'only', kind: 'remove', lineNumber: 1 },
+      right: { text: 'x', kind: 'add', lineNumber: 1 },
+    })
+    expect(rows[2]).toMatchObject({
+      left: { text: '', kind: 'empty' },
+      right: { text: 'y', kind: 'add', lineNumber: 2 },
+    })
+    expect(rows[3]).toMatchObject({
+      left: { text: '', kind: 'empty' },
+      right: { text: 'z', kind: 'add', lineNumber: 3 },
+    })
+  })
+
+  it('does not pair across a context line that interrupts a change block', () => {
+    const rows = buildSplitDiffRows([
+      '@@ -1,3 +1,3 @@',
+      '-a',
+      '+b',
+      ' ctx',
+      '-c',
+      '+d',
+    ])
+
+    // header + change + context + change
+    expect(rows).toHaveLength(4)
+    expect(rows[1]).toMatchObject({
+      left: { text: 'a', kind: 'remove', lineNumber: 1 },
+      right: { text: 'b', kind: 'add', lineNumber: 1 },
+    })
+    expect(rows[2]).toMatchObject({
+      left: { text: 'ctx', kind: 'context', lineNumber: 2 },
+      right: { text: 'ctx', kind: 'context', lineNumber: 2 },
+    })
+    expect(rows[3]).toMatchObject({
+      left: { text: 'c', kind: 'remove', lineNumber: 3 },
+      right: { text: 'd', kind: 'add', lineNumber: 3 },
+    })
+  })
+
+  it('handles an all-additions hunk (file added) with empty left column', () => {
+    const rows = buildSplitDiffRows([
+      '@@ -0,0 +1,2 @@',
+      '+first',
+      '+second',
+    ])
+
+    expect(rows).toHaveLength(3)
+    expect(rows[1]).toMatchObject({
+      left: { text: '', kind: 'empty' },
+      right: { text: 'first', kind: 'add', lineNumber: 1 },
+    })
+    expect(rows[2]).toMatchObject({
+      left: { text: '', kind: 'empty' },
+      right: { text: 'second', kind: 'add', lineNumber: 2 },
+    })
+  })
+
+  it('handles an all-removals hunk (file deleted) with empty right column', () => {
+    const rows = buildSplitDiffRows([
+      '@@ -1,2 +0,0 @@',
+      '-first',
+      '-second',
+    ])
+
+    expect(rows).toHaveLength(3)
+    expect(rows[1]).toMatchObject({
+      left: { text: 'first', kind: 'remove', lineNumber: 1 },
+      right: { text: '', kind: 'empty' },
+    })
+    expect(rows[2]).toMatchObject({
+      left: { text: 'second', kind: 'remove', lineNumber: 2 },
+      right: { text: '', kind: 'empty' },
+    })
+  })
+
+  it('emits diff metadata lines (diff/index/+++/---) as header rows', () => {
+    const rows = buildSplitDiffRows([
+      'diff --git a/foo.ts b/foo.ts',
+      'index abc..def 100644',
+      '--- a/foo.ts',
+      '+++ b/foo.ts',
+      '@@ -1,1 +1,1 @@',
+      '-x',
+      '+y',
+    ])
+
+    expect(rows.slice(0, 4)).toEqual([
+      { left: { text: 'diff --git a/foo.ts b/foo.ts', kind: 'header' }, right: { text: 'diff --git a/foo.ts b/foo.ts', kind: 'header' } },
+      { left: { text: 'index abc..def 100644', kind: 'header' }, right: { text: 'index abc..def 100644', kind: 'header' } },
+      { left: { text: '--- a/foo.ts', kind: 'header' }, right: { text: '--- a/foo.ts', kind: 'header' } },
+      { left: { text: '+++ b/foo.ts', kind: 'header' }, right: { text: '+++ b/foo.ts', kind: 'header' } },
+    ])
+    expect(rows[4].left.kind).toBe('header')
+    expect(rows[5].left.kind).toBe('remove')
+    expect(rows[5].right.kind).toBe('add')
+  })
+
+  it('handles multiple hunks with independent line-number cursors', () => {
+    const rows = buildSplitDiffRows([
+      '@@ -1,1 +1,1 @@',
+      '-a',
+      '+b',
+      '@@ -10,1 +10,1 @@',
+      '-c',
+      '+d',
+    ])
+
+    expect(rows).toHaveLength(4)
+    expect(rows[1]).toMatchObject({
+      left: { lineNumber: 1, text: 'a' },
+      right: { lineNumber: 1, text: 'b' },
+    })
+    expect(rows[3]).toMatchObject({
+      left: { lineNumber: 10, text: 'c' },
+      right: { lineNumber: 10, text: 'd' },
+    })
+  })
+
+  it('keeps removals and additions paired even when grouped across the block', () => {
+    const rows = buildSplitDiffRows([
+      '@@ -1,2 +1,2 @@',
+      '-a',
+      '-b',
+      '+x',
+      '+y',
+    ])
+
+    expect(rows).toHaveLength(3)
+    expect(rows[1]).toMatchObject({
+      left: { text: 'a', kind: 'remove' },
+      right: { text: 'x', kind: 'add' },
+    })
+    expect(rows[2]).toMatchObject({
+      left: { text: 'b', kind: 'remove' },
+      right: { text: 'y', kind: 'add' },
+    })
+  })
+
+  it('treats a "\\ No newline at end of file" marker as a context-aligned row', () => {
+    const rows = buildSplitDiffRows([
+      '@@ -1,1 +1,1 @@',
+      '-x',
+      '+y',
+      '\\ No newline at end of file',
+    ])
+
+    expect(rows).toHaveLength(3)
+    expect(rows[2].left.kind).toBe('context')
+    expect(rows[2].right.kind).toBe('context')
+    expect(rows[2].left.text).toBe('\\ No newline at end of file')
+  })
+})

--- a/src/commands/log/inkSplitDiff.ts
+++ b/src/commands/log/inkSplitDiff.ts
@@ -1,0 +1,168 @@
+/**
+ * Pair-alignment helper for the side-by-side diff view (#785).
+ *
+ * Takes the unified-diff line array that the renderer already paints (one
+ * line per element, the leading character drives `+`/`-`/context coloring)
+ * and re-shapes it into two-column rows the split renderer can lay out
+ * without further parsing. Pure / synchronous so it can be exercised from
+ * tests without spinning up Ink.
+ *
+ * Algorithm:
+ *  1. Walk lines in order. `@@` headers seed a new hunk and reset the
+ *     `oldLineNo` / `newLineNo` cursors from the header range.
+ *  2. Inside a hunk, group the consecutive runs of `-` and `+` lines that
+ *     follow each other. Each run of removals + the immediately-following
+ *     run of additions forms a "change block" that pairs up element-wise:
+ *     row[i] = { left: removals[i], right: additions[i] }. When one side
+ *     is shorter, pad with `kind: 'empty'` rows so the columns stay
+ *     aligned.
+ *  3. Context lines emit as a paired row with the same text on both
+ *     sides and the synthesized line numbers from each cursor.
+ *  4. Diff metadata (`diff `, `index `, `--- `, `+++ `, etc.) emit as
+ *     `kind: 'header'` rows so the split view still has a section break.
+ *  5. A context line that interrupts a change block forces the in-flight
+ *     block to flush before the context row is emitted — pairs are never
+ *     drawn across context boundaries (matches lazygit / fugitive
+ *     behavior, and is what the issue specifies).
+ *
+ * Long lines are not wrapped here — the renderer truncates per column at
+ * paint time so this helper stays pure and trivially testable.
+ */
+
+export type SplitDiffSideKind = 'context' | 'add' | 'remove' | 'header' | 'empty'
+
+export type SplitDiffSide = {
+  text: string
+  lineNumber?: number
+  kind: SplitDiffSideKind
+}
+
+export type SplitDiffRow = {
+  left: SplitDiffSide
+  right: SplitDiffSide
+}
+
+const EMPTY_LEFT: SplitDiffSide = { text: '', kind: 'empty' }
+const EMPTY_RIGHT: SplitDiffSide = { text: '', kind: 'empty' }
+
+/**
+ * Parse the start line numbers out of an `@@ -A,B +C,D @@` header. Returns
+ * `[oldStart, newStart]`; either falls back to 1 when the header is
+ * malformed (which only happens with synthetic / hand-crafted patches).
+ */
+function parseHunkHeader(line: string): [number, number] {
+  const match = /@@\s+-(\d+)(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/.exec(line)
+  if (!match) {
+    return [1, 1]
+  }
+  return [Number(match[1]) || 1, Number(match[2]) || 1]
+}
+
+function isDiffHeader(line: string): boolean {
+  return (
+    line.startsWith('diff ') ||
+    line.startsWith('index ') ||
+    line.startsWith('--- ') ||
+    line.startsWith('+++ ') ||
+    line.startsWith('similarity ') ||
+    line.startsWith('rename ') ||
+    line.startsWith('copy ') ||
+    line.startsWith('new file ') ||
+    line.startsWith('deleted file ') ||
+    line.startsWith('old mode ') ||
+    line.startsWith('new mode ') ||
+    line.startsWith('Binary files ')
+  )
+}
+
+/**
+ * Flush a pending change block (removals + additions accumulated from a
+ * contiguous `-`/`+` run) into paired rows. Pads the shorter side with
+ * empty placeholders so columns stay aligned.
+ */
+function flushChangeBlock(
+  removals: SplitDiffSide[],
+  additions: SplitDiffSide[],
+  rows: SplitDiffRow[]
+): void {
+  const max = Math.max(removals.length, additions.length)
+  for (let i = 0; i < max; i++) {
+    const left = removals[i] || EMPTY_LEFT
+    const right = additions[i] || EMPTY_RIGHT
+    rows.push({ left, right })
+  }
+  removals.length = 0
+  additions.length = 0
+}
+
+export function buildSplitDiffRows(unifiedLines: string[]): SplitDiffRow[] {
+  const rows: SplitDiffRow[] = []
+  let oldLineNo = 0
+  let newLineNo = 0
+  let inHunk = false
+  const removals: SplitDiffSide[] = []
+  const additions: SplitDiffSide[] = []
+
+  const flushHeader = (text: string) => {
+    flushChangeBlock(removals, additions, rows)
+    rows.push({
+      left: { text, kind: 'header' },
+      right: { text, kind: 'header' },
+    })
+  }
+
+  for (const raw of unifiedLines) {
+    if (raw.startsWith('@@')) {
+      flushChangeBlock(removals, additions, rows)
+      const [oldStart, newStart] = parseHunkHeader(raw)
+      oldLineNo = oldStart
+      newLineNo = newStart
+      inHunk = true
+      rows.push({
+        left: { text: raw, kind: 'header' },
+        right: { text: raw, kind: 'header' },
+      })
+      continue
+    }
+
+    if (!inHunk || isDiffHeader(raw)) {
+      flushHeader(raw)
+      continue
+    }
+
+    if (raw.startsWith('-')) {
+      removals.push({
+        text: raw.slice(1),
+        lineNumber: oldLineNo,
+        kind: 'remove',
+      })
+      oldLineNo += 1
+      continue
+    }
+
+    if (raw.startsWith('+')) {
+      additions.push({
+        text: raw.slice(1),
+        lineNumber: newLineNo,
+        kind: 'add',
+      })
+      newLineNo += 1
+      continue
+    }
+
+    // Context line (or `\ No newline at end of file` marker, which we
+    // treat like a context row so it lands on both sides — readers
+    // expect to see it in either column).
+    flushChangeBlock(removals, additions, rows)
+    const text = raw.startsWith(' ') ? raw.slice(1) : raw
+    rows.push({
+      left: { text, lineNumber: oldLineNo, kind: 'context' },
+      right: { text, lineNumber: newLineNo, kind: 'context' },
+    })
+    oldLineNo += 1
+    newLineNo += 1
+  }
+
+  flushChangeBlock(removals, additions, rows)
+  return rows
+}

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -368,6 +368,40 @@ describe('log Ink view model', () => {
     expect(state.showCommandPalette).toBe(true)
   })
 
+  it('defaults the diff view mode to unified', () => {
+    const state = createLogInkState(rows)
+    expect(state.diffViewMode).toBe('unified')
+  })
+
+  it('toggles diffViewMode between unified and split, resetting scroll offsets', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pageDetailPreview', delta: 5, previewLineCount: 100 })
+    state = applyLogInkAction(state, { type: 'pageWorktreeDiff', delta: 5, lineCount: 100 })
+    expect(state.diffPreviewOffset).toBe(5)
+    expect(state.worktreeDiffOffset).toBe(5)
+
+    state = applyLogInkAction(state, { type: 'toggleDiffViewMode' })
+    expect(state.diffViewMode).toBe('split')
+    expect(state.diffPreviewOffset).toBe(0)
+    expect(state.worktreeDiffOffset).toBe(0)
+
+    state = applyLogInkAction(state, { type: 'toggleDiffViewMode' })
+    expect(state.diffViewMode).toBe('unified')
+  })
+
+  it('honors setDiffViewMode for explicit (e.g. persistence-restored) values', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'setDiffViewMode', value: 'split' })
+    expect(state.diffViewMode).toBe('split')
+
+    // Re-applying the same value is a no-op for diffViewMode but still
+    // resets scroll — consistent with toggle semantics.
+    state = applyLogInkAction(state, { type: 'pageDetailPreview', delta: 3, previewLineCount: 50 })
+    state = applyLogInkAction(state, { type: 'setDiffViewMode', value: 'unified' })
+    expect(state.diffViewMode).toBe('unified')
+    expect(state.diffPreviewOffset).toBe(0)
+  })
+
   it('tracks workflow action and confirmation state', () => {
     let state = createLogInkState(rows)
 

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -29,6 +29,15 @@ export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk' | 'discar
  * UI into a commit-diff view.
  */
 export type LogInkDiffSource = 'commit' | 'worktree' | 'stash'
+/**
+ * Diff rendering mode (#785). `unified` is the historical single-column
+ * patch view; `split` lays the same lines out side-by-side (removals on
+ * the left, additions on the right) for wide terminals. The toggle is
+ * scoped to the diff view (`d` key) and falls back to unified at render
+ * time when the terminal is too narrow — the user's preference is
+ * preserved either way.
+ */
+export type LogInkDiffViewMode = 'unified' | 'split'
 
 export type CreateLogInkStateOptions = {
   activeView?: LogInkView
@@ -160,6 +169,14 @@ export type LogInkState = {
    * cleared.
    */
   historyFetchArgs?: LogInkHistoryFetchArgs
+  /**
+   * Diff view rendering mode (#785). `unified` (default) keeps the
+   * historical single-column patch view; `split` lays removals on the
+   * left and additions on the right. The renderer falls back to
+   * unified at paint time when the terminal is too narrow — this field
+   * stores the user's preference, not the effective render mode.
+   */
+  diffViewMode: LogInkDiffViewMode
 }
 
 export type LogInkStatusFilterMask = {
@@ -281,6 +298,8 @@ export type LogInkAction =
   | { type: 'closeInputPrompt' }
   | { type: 'toggleStatusFilterMask'; kind: keyof LogInkStatusFilterMask }
   | { type: 'setHistoryFetchArgs'; value?: LogInkHistoryFetchArgs }
+  | { type: 'toggleDiffViewMode' }
+  | { type: 'setDiffViewMode'; value: LogInkDiffViewMode }
 
 const FOCUS_ORDER: LogInkFocus[] = ['sidebar', 'commits', 'detail']
 const SIDEBAR_TABS: LogInkSidebarTab[] = ['status', 'branches', 'tags', 'stashes', 'worktrees']
@@ -621,6 +640,7 @@ export function createLogInkState(
     sidebarTab: 'status',
     userSidebarTab: 'status',
     statusFilterMask: { ...DEFAULT_LOG_INK_STATUS_FILTER_MASK },
+    diffViewMode: 'unified',
   }
 }
 
@@ -795,6 +815,27 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
     }
     case 'setHistoryFetchArgs':
       return { ...state, historyFetchArgs: action.value, pendingKey: undefined }
+    case 'toggleDiffViewMode':
+      // Reset the scroll offsets so the new mode opens at the top — long
+      // lines wrap differently in split mode (the renderer truncates per
+      // column instead of per row), so the saved offset can land on a
+      // different visual line. Snap to the top is simpler than mapping
+      // unified offsets to split offsets.
+      return {
+        ...state,
+        diffViewMode: state.diffViewMode === 'unified' ? 'split' : 'unified',
+        diffPreviewOffset: 0,
+        worktreeDiffOffset: 0,
+        pendingKey: undefined,
+      }
+    case 'setDiffViewMode':
+      return {
+        ...state,
+        diffViewMode: action.value,
+        diffPreviewOffset: 0,
+        worktreeDiffOffset: 0,
+        pendingKey: undefined,
+      }
     case 'moveToBottom':
       return {
         ...state,


### PR DESCRIPTION
## Summary

Closes #785. Adds `d` on the diff view to toggle between unified and side-by-side split rendering, with automatic fallback to unified on narrow terminals and per-repo persistence of the preference.

- New `LogInkDiffViewMode` field on `LogInkState` (default `unified`) plus `toggleDiffViewMode` / `setDiffViewMode` reducer cases that reset `diffPreviewOffset` and `worktreeDiffOffset` to 0 so the new mode opens at the top.
- Pair-alignment helper in `inkSplitDiff.ts` (pure / unit-tested) groups consecutive `-`/`+` runs into change blocks and pads the shorter side with empty placeholder rows so columns stay aligned. Context lines flush the in-flight block so pairs never draw across context boundaries — matches lazygit/fugitive.
- Per-repo persistence module `inkDiffViewModePersistence.ts` mirrors the sidebar-tab cache (XDG-friendly, sha1 cache key, best-effort I/O). Hydrates on mount, saves whenever the toggle fires.
- `d` keybinding scoped to `state.activeView === 'diff'` in `inkInput.ts` — emits the toggle action plus a status hint (`Switched to side-by-side diff` / `Switched to unified diff`). The chord branch (`gd` → push diff view) still claims first so there's no collision.
- Footer hint surfaces the toggle on commit + stash diff sources only (worktree diff stays unified-only — staging is the primary action there). Hint labels the *next* mode (`d split` when unified is active, `d unified` when split is active).
- Title bar shows `Diff (split)` / `Stash diff (split)` when split is rendering. When the user has split selected but the terminal is too narrow, the header surfaces `Terminal too narrow for side-by-side; showing unified.` once — the preference is preserved either way.

## Algorithm + threshold decisions

- **Pair-alignment** walks the unified line array, accumulating contiguous removal and addition runs. At a flush boundary (context line, hunk header, or end of input) the runs zip element-wise: `row[i] = { left: removals[i], right: additions[i] }`. Uneven runs pad the shorter side with `kind: 'empty'`. This matches what users expect from lazygit and is what the issue spec prescribed.
- **Line numbers** use independent `oldLineNo` / `newLineNo` cursors seeded from each `@@` header range. Context rows advance both, removals advance only old, additions advance only new.
- **Width threshold** is 120 columns. Below that, split mode falls back to unified at paint time without mutating the user's preference. Empirically the columns get unreadably narrow under ~50 each plus border + padding overhead.
- **Rendering** uses Ink `Box` flex rows with explicit `width` per column — half of `(usable - gutter)` where `usable = width - 4` (border + padding) and `gutter = 1`. Each cell is pre-formatted via `formatSplitDiffCell` (line-number prefix + truncated text) so the `Box` widths are deterministic and Ink's flex layout doesn't shrink either side. Empty rows render a faint `· ` placeholder so the alignment gap is visible.

## Persistence decision

Implemented per-repo persistence (the issue called it optional). Same pattern as `inkSidebarPersistence` so the cost was low. Falls back to `unified` when the marker is missing or invalid; load/save are best-effort and swallow filesystem errors.

## Test plan

- [x] `npm run lint`
- [x] `npx jest` — 949/949 pass (12 new in `inkSplitDiff.test.ts`, 8 in `inkDiffViewModePersistence.test.ts`, plus reducer + input + keymap coverage in the existing test files)
- [x] `npm run build`
- [ ] Manual smoke: `coco log -i`, navigate to a commit with multi-line edits, press Enter to open the diff, press `d` to toggle. Verify split layout, narrow-terminal fallback, persistence across sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)