### PR TITLE
feat(log-tui): hunk-level apply from commit-diff and stash-diff (#782)

### DIFF
--- a/src/commands/log/hunkActions.test.ts
+++ b/src/commands/log/hunkActions.test.ts
@@ -1,0 +1,149 @@
+import { promises as fsp } from 'fs'
+import { tmpdir } from 'os'
+import { applyHunkPatch } from './hunkActions'
+
+const SAMPLE_PATCH = [
+  'diff --git a/src/foo.ts b/src/foo.ts',
+  '--- a/src/foo.ts',
+  '+++ b/src/foo.ts',
+  '@@ -1,1 +1,2 @@',
+  ' const a = 1',
+  '+const b = 2',
+  '',
+].join('\n')
+
+describe('applyHunkPatch', () => {
+  let writtenPath: string | undefined
+  let writtenContent: string | undefined
+  let originalWriteFile: typeof fsp.writeFile
+  let originalUnlink: typeof fsp.unlink
+  let unlinkCalls: string[]
+
+  beforeEach(() => {
+    writtenPath = undefined
+    writtenContent = undefined
+    unlinkCalls = []
+
+    originalWriteFile = fsp.writeFile
+    originalUnlink = fsp.unlink
+
+    // Spy on writeFile so we can confirm the patch lands in $TMPDIR
+    // without actually creating files (and without making the test
+    // environment-dependent).
+    Object.defineProperty(fsp, 'writeFile', {
+      configurable: true,
+      writable: true,
+      value: async (path: string, content: string) => {
+        writtenPath = path
+        writtenContent = content
+      },
+    })
+    Object.defineProperty(fsp, 'unlink', {
+      configurable: true,
+      writable: true,
+      value: async (path: string) => {
+        unlinkCalls.push(path)
+      },
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(fsp, 'writeFile', {
+      configurable: true,
+      writable: true,
+      value: originalWriteFile,
+    })
+    Object.defineProperty(fsp, 'unlink', {
+      configurable: true,
+      writable: true,
+      value: originalUnlink,
+    })
+  })
+
+  it('writes the patch to a temp file and runs `git apply` for worktree target', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+
+    const result = await applyHunkPatch(git as never, SAMPLE_PATCH, { target: 'worktree' })
+
+    expect(result).toEqual({ ok: true, message: 'Applied hunk to worktree' })
+    expect(writtenPath).toBeDefined()
+    expect(writtenPath!.startsWith(tmpdir())).toBe(true)
+    expect(writtenPath!.endsWith('.patch')).toBe(true)
+    expect(writtenContent).toBe(SAMPLE_PATCH)
+    expect(git.raw).toHaveBeenCalledWith(['apply', '--whitespace=nowarn', writtenPath])
+    expect(unlinkCalls).toEqual([writtenPath])
+  })
+
+  it('passes --cached for index target', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+
+    const result = await applyHunkPatch(git as never, SAMPLE_PATCH, { target: 'index' })
+
+    expect(result).toEqual({ ok: true, message: 'Applied hunk to index' })
+    expect(git.raw).toHaveBeenCalledWith(['apply', '--cached', '--whitespace=nowarn', writtenPath])
+  })
+
+  it('surfaces the first line of git stderr on failure with details', async () => {
+    const git = {
+      raw: jest.fn().mockRejectedValue(new Error([
+        'error: patch failed: src/foo.ts:1',
+        'error: src/foo.ts: patch does not apply',
+      ].join('\n'))),
+    }
+
+    const result = await applyHunkPatch(git as never, SAMPLE_PATCH, { target: 'worktree' })
+
+    expect(result.ok).toBe(false)
+    expect(result.message).toBe('error: patch failed: src/foo.ts:1')
+    expect(result.details).toEqual(['error: src/foo.ts: patch does not apply'])
+    // Tempfile cleanup still runs after a failed apply.
+    expect(unlinkCalls).toEqual([writtenPath])
+  })
+
+  it('cleans up the temp file even when writeFile throws', async () => {
+    Object.defineProperty(fsp, 'writeFile', {
+      configurable: true,
+      writable: true,
+      value: async () => { throw new Error('disk full') },
+    })
+
+    const git = { raw: jest.fn() }
+
+    const result = await applyHunkPatch(git as never, SAMPLE_PATCH, { target: 'worktree' })
+
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('disk full')
+    expect(git.raw).not.toHaveBeenCalled()
+    // Even on writeFile failure we attempt the unlink (it will hit
+    // ENOENT internally, which the runner swallows).
+    expect(unlinkCalls.length).toBe(1)
+  })
+
+  it('rejects empty patch text without invoking git', async () => {
+    const git = { raw: jest.fn() }
+
+    const result = await applyHunkPatch(git as never, '   \n  ', { target: 'worktree' })
+
+    expect(result).toEqual({ ok: false, message: 'No hunk under cursor to apply.' })
+    expect(git.raw).not.toHaveBeenCalled()
+  })
+
+  it('swallows ENOENT during cleanup', async () => {
+    const enoentError = new Error('ENOENT') as NodeJS.ErrnoException
+    enoentError.code = 'ENOENT'
+
+    Object.defineProperty(fsp, 'unlink', {
+      configurable: true,
+      writable: true,
+      value: async () => { throw enoentError },
+    })
+
+    const git = { raw: jest.fn().mockResolvedValue('') }
+
+    // Should still report success even when the cleanup unlink hits
+    // ENOENT (e.g. because some other process or test cleanup beat us
+    // to it).
+    const result = await applyHunkPatch(git as never, SAMPLE_PATCH, { target: 'worktree' })
+    expect(result.ok).toBe(true)
+  })
+})

--- a/src/commands/log/hunkActions.ts
+++ b/src/commands/log/hunkActions.ts
@@ -1,0 +1,104 @@
+import { promises as fsp } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+import { SimpleGit } from 'simple-git'
+import { BranchActionResult } from './branchActions'
+
+export type ApplyHunkTarget = 'worktree' | 'index'
+
+export type ApplyHunkOptions = {
+  /** `worktree` runs `git apply`; `index` adds `--cached` so the patch
+   *  lands in the index without touching the working tree. */
+  target: ApplyHunkTarget
+}
+
+function compactOutputLines(output: string): string[] {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+async function safeUnlink(path: string): Promise<void> {
+  try {
+    await fsp.unlink(path)
+  } catch (error) {
+    // ENOENT is fine — the temp file was never created or already
+    // cleaned up. Anything else we silently swallow because the
+    // worst-case impact is a single ~1KB file in $TMPDIR.
+    const code = (error as NodeJS.ErrnoException).code
+    if (code !== 'ENOENT') {
+      // Intentional no-op: failing the action because we couldn't tidy
+      // up the tempfile would mask the actual git result.
+    }
+  }
+}
+
+/**
+ * Write a unified-diff patch to a temp file and feed it to
+ * `git apply` (or `git apply --cached` when target === 'index').
+ *
+ * This is the runner behind the `apply-hunk-worktree` /
+ * `apply-hunk-index` workflow actions — the input handler builds
+ * `patchText` from the cursored hunk via `extractDiffHunk` and the
+ * runtime hands it here.
+ *
+ * `--whitespace=nowarn` keeps `git apply` quiet about trailing
+ * whitespace differences (the most common false positive when the
+ * patch comes from a stash made on a different platform). Real
+ * conflicts still surface via the non-zero exit code.
+ *
+ * The patch is written to a temp file rather than piped on stdin
+ * because some `simple-git` adapters don't expose a clean stdin
+ * channel for `git.raw`; the tempfile path keeps the runner
+ * portable across environments.
+ */
+export async function applyHunkPatch(
+  git: SimpleGit,
+  patchText: string,
+  options: ApplyHunkOptions
+): Promise<BranchActionResult> {
+  if (!patchText.trim()) {
+    return {
+      ok: false,
+      message: 'No hunk under cursor to apply.',
+    }
+  }
+
+  const targetLabel = options.target === 'index' ? 'index' : 'worktree'
+  const tempPath = join(tmpdir(), `coco-hunk-${randomUUID()}.patch`)
+
+  try {
+    await fsp.writeFile(tempPath, patchText, 'utf8')
+
+    const args = ['apply']
+    if (options.target === 'index') {
+      args.push('--cached')
+    }
+    args.push('--whitespace=nowarn')
+    args.push(tempPath)
+
+    try {
+      await git.raw(args)
+      return {
+        ok: true,
+        message: `Applied hunk to ${targetLabel}`,
+      }
+    } catch (error) {
+      const lines = compactOutputLines((error as Error).message)
+      return {
+        ok: false,
+        message: lines[0] || `Failed to apply hunk to ${targetLabel}`,
+        details: lines.slice(1, 6),
+      }
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      message: `Could not stage hunk for apply: ${(error as Error).message}`,
+    }
+  } finally {
+    await safeUnlink(tempPath)
+  }
+}

--- a/src/commands/log/inkHunkExtraction.test.ts
+++ b/src/commands/log/inkHunkExtraction.test.ts
@@ -1,0 +1,185 @@
+import { extractDiffHunk, inkHunkExtractionTestInternals } from './inkHunkExtraction'
+
+describe('extractDiffHunk', () => {
+  const multiHunkPatch = [
+    'diff --git a/src/foo.ts b/src/foo.ts',
+    'index 1234567..89abcde 100644',
+    '--- a/src/foo.ts',
+    '+++ b/src/foo.ts',
+    '@@ -1,3 +1,4 @@',
+    ' const a = 1',
+    '+const b = 2',
+    ' const c = 3',
+    ' const d = 4',
+    '@@ -10,2 +11,3 @@',
+    ' const e = 5',
+    '+const f = 6',
+    ' const g = 7',
+  ]
+
+  it('extracts the first hunk when the cursor is inside it', () => {
+    const result = extractDiffHunk({
+      lines: multiHunkPatch,
+      cursorOffset: 6, // inside the first hunk body
+      path: 'src/foo.ts',
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.patchText).toBe([
+      'diff --git a/src/foo.ts b/src/foo.ts',
+      '--- a/src/foo.ts',
+      '+++ b/src/foo.ts',
+      '@@ -1,3 +1,4 @@',
+      ' const a = 1',
+      '+const b = 2',
+      ' const c = 3',
+      ' const d = 4',
+      '',
+    ].join('\n'))
+  })
+
+  it('extracts the second hunk when the cursor is on its @@ header', () => {
+    const result = extractDiffHunk({
+      lines: multiHunkPatch,
+      cursorOffset: 9, // the second `@@` line
+      path: 'src/foo.ts',
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.patchText).toContain('@@ -10,2 +11,3 @@')
+    expect(result!.patchText).toContain('+const f = 6')
+    expect(result!.patchText).not.toContain('+const b = 2')
+  })
+
+  it('extracts the last hunk when the cursor is on its final body line', () => {
+    const result = extractDiffHunk({
+      lines: multiHunkPatch,
+      cursorOffset: multiHunkPatch.length - 1,
+      path: 'src/foo.ts',
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.patchText).toContain('@@ -10,2 +11,3 @@')
+    expect(result!.patchText).not.toContain('+const b = 2')
+  })
+
+  it('returns null when the cursor is before the first @@', () => {
+    expect(
+      extractDiffHunk({
+        lines: multiHunkPatch,
+        cursorOffset: 2, // on the `--- a/src/foo.ts` line
+        path: 'src/foo.ts',
+      })
+    ).toBeNull()
+  })
+
+  it('returns null on an empty patch', () => {
+    expect(
+      extractDiffHunk({ lines: [], cursorOffset: 0, path: 'src/foo.ts' })
+    ).toBeNull()
+  })
+
+  it('returns null when the path is empty', () => {
+    expect(
+      extractDiffHunk({
+        lines: multiHunkPatch,
+        cursorOffset: 6,
+        path: '',
+      })
+    ).toBeNull()
+  })
+
+  it('uses the caller-provided path even on rename patches', () => {
+    // Renames have `diff --git a/old b/new` headers; the caller resolves
+    // the post-rename path and passes it in (parseStashDiffFiles already
+    // returns the b/ side). The synthesized patch should always reflect
+    // what the caller asked for.
+    const renamePatch = [
+      'diff --git a/old/path.ts b/new/path.ts',
+      'similarity index 95%',
+      'rename from old/path.ts',
+      'rename to new/path.ts',
+      '--- a/old/path.ts',
+      '+++ b/new/path.ts',
+      '@@ -1,2 +1,3 @@',
+      ' const a = 1',
+      '+const b = 2',
+      ' const c = 3',
+    ]
+
+    const result = extractDiffHunk({
+      lines: renamePatch,
+      cursorOffset: renamePatch.length - 1,
+      path: 'new/path.ts',
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.patchText).toContain('diff --git a/new/path.ts b/new/path.ts')
+    expect(result!.patchText).toContain('--- a/new/path.ts')
+    expect(result!.patchText).toContain('+++ b/new/path.ts')
+    expect(result!.patchText).not.toContain('a/old/path.ts')
+  })
+
+  it('returns null when the @@ header has no body before the next file', () => {
+    // Pathological case: a hunk header with no body lines before the
+    // next `diff --git`. extractDiffHunk should bail rather than
+    // produce a malformed patch.
+    const malformed = [
+      'diff --git a/a.ts b/a.ts',
+      '--- a/a.ts',
+      '+++ b/a.ts',
+      '@@ -1,1 +1,1 @@',
+      'diff --git a/b.ts b/b.ts',
+    ]
+    expect(
+      extractDiffHunk({ lines: malformed, cursorOffset: 3, path: 'a.ts' })
+    ).toBeNull()
+  })
+
+  it('handles a hunks-only commit-diff (no diff --git / --- / +++ headers)', () => {
+    // commit-diff hands `filePreview.hunks` directly — these are
+    // hunks-only with no file headers. extractDiffHunk has to
+    // synthesize the headers itself using the caller-provided path.
+    const hunksOnly = [
+      '@@ -1,3 +1,4 @@',
+      ' const a = 1',
+      '+const b = 2',
+      ' const c = 3',
+      ' const d = 4',
+    ]
+
+    const result = extractDiffHunk({
+      lines: hunksOnly,
+      cursorOffset: 1,
+      path: 'src/example.ts',
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.patchText).toBe([
+      'diff --git a/src/example.ts b/src/example.ts',
+      '--- a/src/example.ts',
+      '+++ b/src/example.ts',
+      '@@ -1,3 +1,4 @@',
+      ' const a = 1',
+      '+const b = 2',
+      ' const c = 3',
+      ' const d = 4',
+      '',
+    ].join('\n'))
+  })
+
+  describe('internals', () => {
+    it('findHunkHeaderAtOrBefore walks backwards', () => {
+      const lines = ['@@ a @@', 'x', 'y', '@@ b @@', 'z']
+      expect(inkHunkExtractionTestInternals.findHunkHeaderAtOrBefore(lines, 4)).toBe(3)
+      expect(inkHunkExtractionTestInternals.findHunkHeaderAtOrBefore(lines, 2)).toBe(0)
+      expect(inkHunkExtractionTestInternals.findHunkHeaderAtOrBefore(['no headers'], 0)).toBe(-1)
+    })
+
+    it('findHunkBodyEnd stops at the next @@ or diff --git', () => {
+      const lines = ['@@ a @@', 'x', 'y', '@@ b @@', 'z']
+      expect(inkHunkExtractionTestInternals.findHunkBodyEnd(lines, 0)).toBe(3)
+      expect(inkHunkExtractionTestInternals.findHunkBodyEnd(lines, 3)).toBe(5)
+    })
+  })
+})

--- a/src/commands/log/inkHunkExtraction.ts
+++ b/src/commands/log/inkHunkExtraction.ts
@@ -1,0 +1,113 @@
+/**
+ * Extract a single hunk from a unified-patch diff so it can be fed to
+ * `git apply` (or `git apply --cached`) for a hunk-level cherry-pick.
+ *
+ * The TUI's diff explore views render two flavors of patch text:
+ *
+ *   - stash-diff: full `git stash show -p` output, which includes
+ *     `diff --git`, `---`, `+++`, and one or more `@@ ... @@` hunks
+ *     per file.
+ *   - commit-diff: the per-file `filePreview.hunks` array, which is
+ *     hunks-only (no `diff --git` / `---` / `+++` headers).
+ *
+ * Either way, this helper walks `lines` from `cursorOffset` backwards
+ * to find the most recent `@@` header, walks forward to the end of
+ * that hunk's body, and synthesizes a fresh `diff --git` /
+ * `---` / `+++` set using the caller-provided path. The output is a
+ * complete, self-contained patch suitable for `git apply` without
+ * having to preserve original headers from `lines`.
+ */
+
+export type ExtractDiffHunkInput = {
+  /** Patch text split into lines. For stash-diff, the full
+   *  `git stash show -p` output. For commit-diff, the file's
+   *  `filePreview.hunks` (hunks-only). */
+  lines: string[]
+  /** Current cursor offset within `lines`. Determines which hunk
+   *  the user has selected. */
+  cursorOffset: number
+  /** Repo-relative path of the file the hunk belongs to. The caller
+   *  resolves this from `commitDiffSelectedPath` /
+   *  `stashDiffSelectedPath` (already post-rename for renamed files). */
+  path: string
+}
+
+export type ExtractDiffHunkResult = {
+  /** Complete patch text — `diff --git` header, file header, single
+   *  `@@` block, and that block's body. Trailing newline included
+   *  so the patch can be written straight to a tempfile and consumed
+   *  by `git apply` without any additional munging. */
+  patchText: string
+}
+
+const HUNK_HEADER_PREFIX = '@@'
+const DIFF_GIT_PREFIX = 'diff --git '
+
+/**
+ * Find the index of the `@@` hunk header at or before `cursorOffset`.
+ * Returns -1 when the cursor sits before the first hunk in the patch
+ * (i.e. on a `diff --git` / `---` / `+++` header line) — caller treats
+ * that as "no hunk at cursor" and surfaces a status message.
+ */
+function findHunkHeaderAtOrBefore(lines: string[], cursorOffset: number): number {
+  const start = Math.min(cursorOffset, lines.length - 1)
+  for (let i = start; i >= 0; i -= 1) {
+    if (lines[i]?.startsWith(HUNK_HEADER_PREFIX)) {
+      return i
+    }
+  }
+  return -1
+}
+
+/**
+ * Walk forward from a hunk header to either the next `@@` header or
+ * the next `diff --git` line — that's where this hunk's body ends.
+ * The end index is exclusive (the line at `endIndex` is NOT part of
+ * this hunk).
+ */
+function findHunkBodyEnd(lines: string[], headerIndex: number): number {
+  for (let i = headerIndex + 1; i < lines.length; i += 1) {
+    const line = lines[i]
+    if (line?.startsWith(HUNK_HEADER_PREFIX) || line?.startsWith(DIFF_GIT_PREFIX)) {
+      return i
+    }
+  }
+  return lines.length
+}
+
+export function extractDiffHunk(input: ExtractDiffHunkInput): ExtractDiffHunkResult | null {
+  const { lines, cursorOffset, path } = input
+
+  if (!lines.length || !path) {
+    return null
+  }
+
+  const headerIndex = findHunkHeaderAtOrBefore(lines, cursorOffset)
+  if (headerIndex < 0) {
+    return null
+  }
+
+  const bodyEnd = findHunkBodyEnd(lines, headerIndex)
+  // Header itself + at least one body line. An empty hunk body would
+  // mean the patch is malformed and `git apply` would reject it; bail
+  // out early so the caller can surface a clear status message.
+  if (bodyEnd <= headerIndex + 1) {
+    return null
+  }
+
+  const hunkLines = lines.slice(headerIndex, bodyEnd)
+  const patchText = [
+    `diff --git a/${path} b/${path}`,
+    `--- a/${path}`,
+    `+++ b/${path}`,
+    ...hunkLines,
+    '',
+  ].join('\n')
+
+  return { patchText }
+}
+
+export const inkHunkExtractionTestInternals = {
+  findHunkHeaderAtOrBefore,
+  findHunkBodyEnd,
+}

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -1447,4 +1447,120 @@ describe('log Ink input interactions', () => {
       })
     })
   })
+
+  describe('hunk-level apply (#782)', () => {
+    const COMMIT_DIFF_LINES = [
+      '@@ -1,3 +1,4 @@',
+      ' const a = 1',
+      '+const b = 2',
+      ' const c = 3',
+      ' const d = 4',
+    ]
+
+    const STASH_DIFF_LINES = [
+      'diff --git a/src/foo.ts b/src/foo.ts',
+      '--- a/src/foo.ts',
+      '+++ b/src/foo.ts',
+      '@@ -1,2 +1,3 @@',
+      ' const a = 1',
+      '+const b = 2',
+      ' const c = 3',
+    ]
+
+    function commitDiffState() {
+      const state = createLogInkState(rows, { activeView: 'diff' })
+      return {
+        ...state,
+        diffSource: 'commit' as const,
+        diffPreviewOffset: 1,
+      }
+    }
+
+    function stashDiffState() {
+      const state = createLogInkState(rows, { activeView: 'diff' })
+      return {
+        ...state,
+        diffSource: 'stash' as const,
+        stashDiffRef: 'stash@{0}',
+        diffPreviewOffset: 5,
+      }
+    }
+
+    it('H on commit-diff dispatches apply-hunk-worktree with the synthesized patch', () => {
+      const events = getLogInkInputEvents(commitDiffState(), 'H', {}, {
+        diffLinesForHunkApply: COMMIT_DIFF_LINES,
+        commitDiffSelectedPath: 'src/foo.ts',
+        commitDiffSelectedSha: 'abc1234',
+      })
+      expect(events).toHaveLength(1)
+      const event = events[0]
+      expect(event.type).toBe('runWorkflowAction')
+      if (event.type !== 'runWorkflowAction') throw new Error('expected workflow event')
+      expect(event.id).toBe('apply-hunk-worktree')
+      expect(event.payload?.startsWith('worktree\n')).toBe(true)
+      expect(event.payload).toContain('diff --git a/src/foo.ts b/src/foo.ts')
+      expect(event.payload).toContain('+const b = 2')
+    })
+
+    it('H on stash-diff dispatches apply-hunk-worktree with the synthesized patch', () => {
+      const events = getLogInkInputEvents(stashDiffState(), 'H', {}, {
+        diffLinesForHunkApply: STASH_DIFF_LINES,
+        stashDiffSelectedPath: 'src/foo.ts',
+      })
+      expect(events).toHaveLength(1)
+      const event = events[0]
+      expect(event.type).toBe('runWorkflowAction')
+      if (event.type !== 'runWorkflowAction') throw new Error('expected workflow event')
+      expect(event.id).toBe('apply-hunk-worktree')
+      expect(event.payload?.startsWith('worktree\n')).toBe(true)
+      expect(event.payload).toContain('diff --git a/src/foo.ts b/src/foo.ts')
+    })
+
+    it('gH chord dispatches apply-hunk-index instead of worktree', () => {
+      let state: ReturnType<typeof createLogInkState> = commitDiffState()
+      state = applyLogInkAction(state, { type: 'setPendingKey', value: 'g' })
+      const events = getLogInkInputEvents(state, 'H', {}, {
+        diffLinesForHunkApply: COMMIT_DIFF_LINES,
+        commitDiffSelectedPath: 'src/foo.ts',
+        commitDiffSelectedSha: 'abc1234',
+      })
+      // First event clears pendingKey, second event dispatches the workflow.
+      const workflowEvent = events.find((e) => e.type === 'runWorkflowAction')
+      expect(workflowEvent).toBeDefined()
+      if (!workflowEvent || workflowEvent.type !== 'runWorkflowAction') {
+        throw new Error('expected workflow event')
+      }
+      expect(workflowEvent.id).toBe('apply-hunk-index')
+      expect(workflowEvent.payload?.startsWith('index\n')).toBe(true)
+    })
+
+    it('H without a hunk-extractable cursor surfaces a status hint', () => {
+      const events = getLogInkInputEvents(stashDiffState(), 'H', {}, {
+        diffLinesForHunkApply: ['diff --git a/x b/x'], // no @@ header
+        stashDiffSelectedPath: 'x',
+      })
+      expect(events).toHaveLength(1)
+      expect(events[0]).toMatchObject({
+        type: 'action',
+        action: { type: 'setStatus', value: expect.stringContaining('no hunk under cursor') },
+      })
+    })
+
+    it('H outside of commit-diff / stash-diff is a no-op', () => {
+      // History view: H is unbound and should fall through to subsequent
+      // handlers. Empty events == nothing matched.
+      const events = getLogInkInputEvents(createLogInkState(rows), 'H')
+      expect(events).toEqual([])
+    })
+
+    it('gH chord without diff context shows a discoverability hint', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setPendingKey', value: 'g' })
+      const events = getLogInkInputEvents(state, 'H')
+      expect(events).toContainEqual({
+        type: 'action',
+        action: { type: 'setStatus', value: expect.stringContaining('gH applies a hunk') },
+      })
+    })
+  })
 })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -1,3 +1,4 @@
+import { extractDiffHunk } from './inkHunkExtraction'
 import {
   LogInkPaletteCommand,
   filterLogInkPaletteCommands,
@@ -97,6 +98,16 @@ export type LogInkInputContext = {
    * row is hidden entirely when the worktree is clean.
    */
   worktreeDirty?: boolean
+  /**
+   * Lines of the active diff (stash or commit) when the user is on a
+   * diff explore. Used by the H / gH hunk-apply handler to slice the
+   * cursored hunk out of the patch text and ship it to `git apply`.
+   * Stash uses the full `git stash show -p` output; commit-diff uses
+   * the per-file `filePreview.hunks` array (hunks-only). The handler
+   * doesn't care which — `extractDiffHunk` walks `@@` headers either
+   * way.
+   */
+  diffLinesForHunkApply?: string[]
 }
 
 function action(actionValue: LogInkAction): LogInkInputEvent {
@@ -104,6 +115,44 @@ function action(actionValue: LogInkAction): LogInkInputEvent {
     type: 'action',
     action: actionValue,
   }
+}
+
+/**
+ * Build the events needed to apply the hunk under the diff cursor. The
+ * runtime workflow handler expects payload format `<target>\n<patch>`
+ * — splitting on the first newline keeps the patch body intact for
+ * targets like `worktree` and `index` (no newlines in the prefix).
+ *
+ * Returns [] when the user isn't on a commit-diff / stash-diff explore,
+ * or when no hunk can be extracted at the current cursor offset
+ * (e.g. cursor sits on a `diff --git` header before the first `@@`).
+ * Callers fall back to a contextual status message when this returns [].
+ */
+function buildApplyHunkEvents(
+  state: LogInkState,
+  context: LogInkInputContext,
+  target: 'worktree' | 'index'
+): LogInkInputEvent[] {
+  if (state.activeView !== 'diff') return []
+  if (state.diffSource !== 'commit' && state.diffSource !== 'stash') return []
+  const lines = context.diffLinesForHunkApply
+  if (!lines || lines.length === 0) return []
+  const path = state.diffSource === 'stash'
+    ? context.stashDiffSelectedPath
+    : context.commitDiffSelectedPath
+  if (!path) return []
+  const extracted = extractDiffHunk({
+    lines,
+    cursorOffset: state.diffPreviewOffset,
+    path,
+  })
+  if (!extracted) return []
+  const id = target === 'index' ? 'apply-hunk-index' : 'apply-hunk-worktree'
+  return [{
+    type: 'runWorkflowAction',
+    id,
+    payload: `${target}\n${extracted.patchText}`,
+  }]
 }
 
 /**
@@ -746,6 +795,22 @@ export function getLogInkInputEvents(
     ]
   }
 
+  // `gH` chord: apply the cursored hunk to the index (`git apply
+  // --cached`). Sibling of bare `H` which targets the worktree.
+  // Discoverable via the footer hint on diff views and the help
+  // overlay; the explicit chord keeps `H` (single keystroke) for
+  // the more common worktree case.
+  if (state.pendingKey === 'g' && inputValue === 'H') {
+    const events = buildApplyHunkEvents(state, context, 'index')
+    if (events.length) {
+      return [action({ type: 'setPendingKey', value: undefined }), ...events]
+    }
+    return [
+      action({ type: 'setPendingKey', value: undefined }),
+      action({ type: 'setStatus', value: 'gH applies a hunk in commit-diff or stash-diff view' }),
+    ]
+  }
+
   if (inputValue === 'g') {
     if (state.pendingKey === 'g') {
       return [
@@ -1356,6 +1421,22 @@ export function getLogInkInputEvents(
       value: 'checkout-file-from-commit',
       payload: `${context.commitDiffSelectedSha} ${context.commitDiffSelectedPath}`,
     })]
+  }
+
+  // `H` on a commit-diff or stash-diff explore extracts the hunk under
+  // the cursor and applies it to the working tree (`git apply`). The
+  // sibling `gH` chord targets the index (`git apply --cached`). Both
+  // bypass the y-confirm path because `git apply` is non-destructive
+  // (it'll fail loudly on conflict and `git apply -R` undoes a clean
+  // apply).
+  if (inputValue === 'H') {
+    const events = buildApplyHunkEvents(state, context, 'worktree')
+    if (events.length) {
+      return events
+    }
+    if (state.activeView === 'diff' && (state.diffSource === 'commit' || state.diffSource === 'stash')) {
+      return [action({ type: 'setStatus', value: 'no hunk under cursor — j/k to a + or - line first' })]
+    }
   }
 
   // `c` on the history view cherry-picks the full selected commit on

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -44,6 +44,23 @@ describe('log Ink keymap', () => {
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 
+    // Hunk-apply (#782): commit-diff and stash-diff hints surface `H`.
+    expect(getLogInkFooterHints({
+      activeView: 'diff',
+      diffSource: 'commit',
+      filterMode: false,
+      focus: 'commits',
+      showHelp: false,
+    }).contextual).toContain('H apply hunk')
+
+    expect(getLogInkFooterHints({
+      activeView: 'diff',
+      diffSource: 'stash',
+      filterMode: false,
+      focus: 'commits',
+      showHelp: false,
+    }).contextual).toContain('H apply hunk')
+
     expect(getLogInkFooterHints({
       activeView: 'compose',
       filterMode: false,

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -560,15 +560,16 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
     const splitToggleHint = options.diffViewMode === 'split' ? 'd unified' : 'd split'
     if (options.diffSource === 'stash') {
       return {
-        contextual: ['j/k lines', '[/] file', 'c cherry-pick', 'o edit', splitToggleHint, 'y yank', 'esc back'],
+        contextual: ['j/k lines', '[/] file', 'c cherry-pick', 'H apply hunk', 'o edit', splitToggleHint, 'y yank', 'esc back'],
         global: NORMAL_GLOBAL_HINTS,
       }
     }
     if (options.diffSource === 'commit') {
       // Commit-diff explore: read-only diff, but `c` cherry-picks the
-      // cursored file from the commit into the worktree.
+      // cursored file from the commit into the worktree, and `H`
+      // (or `gH` for index) applies just the cursored hunk.
       return {
-        contextual: ['j/k hunks', '[/] file', 'c cherry-pick', splitToggleHint, 'y/Y yank', 'esc back'],
+        contextual: ['j/k hunks', '[/] file', 'c cherry-pick', 'H apply hunk', splitToggleHint, 'y/Y yank', 'esc back'],
         global: NORMAL_GLOBAL_HINTS,
       }
     }

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -169,6 +169,7 @@ import {
   startInteractiveRebase,
 } from './historyActions'
 import { applyStash, checkoutFileFromStash, createStash, dropStash, popStash } from './stashActions'
+import { ApplyHunkTarget, applyHunkPatch } from './hunkActions'
 import { removeWorktree } from './worktreeActions'
 import { abortOperation } from './operationActions'
 import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
@@ -1352,6 +1353,31 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // disappears. Called from the y-confirm path for delete-branch / delete-
   // tag / drop-stash / remove-worktree / abort-operation.
   const runWorkflowAction = React.useCallback(async (id: string, payload?: string) => {
+    // Hunk-apply payload format: `<target>\n<patchText>` — the input
+    // handler synthesizes both pieces (target from the keystroke,
+    // patch text from extractDiffHunk against the live diff lines)
+    // and packs them into the single `payload` field. Splitting on
+    // the first newline keeps the patch body intact.
+    const runApplyHunk = (
+      expectedTarget: ApplyHunkTarget,
+      raw: string | undefined
+    ): Promise<{ ok: boolean; message: string; details?: string[] }> => {
+      if (!raw) {
+        return Promise.resolve({ ok: false, message: 'No hunk under cursor to apply.' })
+      }
+      const newlineIndex = raw.indexOf('\n')
+      if (newlineIndex < 0) {
+        return Promise.resolve({ ok: false, message: 'Malformed hunk-apply payload.' })
+      }
+      const target = raw.slice(0, newlineIndex) === 'index' ? 'index' : 'worktree'
+      const patchText = raw.slice(newlineIndex + 1)
+      // The input handler is the source of truth for target — but if a
+      // palette-injected payload mismatches the workflow id, prefer
+      // the workflow id so the user sees the action they asked for.
+      const effectiveTarget = expectedTarget || target
+      return applyHunkPatch(git, patchText, { target: effectiveTarget })
+    }
+
     const handlers: Record<string, () => Promise<{ ok: boolean; message: string } | undefined>> = {
       'create-branch': async () => {
         const name = payload?.trim()
@@ -1491,6 +1517,8 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         if (!sha || !path) return { ok: false, message: 'No commit file under cursor' }
         return checkoutFileFromCommit(git, sha, path)
       },
+      'apply-hunk-worktree': async () => runApplyHunk('worktree', payload),
+      'apply-hunk-index': async () => runApplyHunk('index', payload),
       'remove-worktree': async () => {
         const all = context.worktreeList?.worktrees || []
         // Resolve the target from the visible (filtered) list so a
@@ -2055,6 +2083,17 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         ? selected?.hash
         : undefined,
       worktreeDirty,
+      // H / gH need the actual diff text (not just hunk offsets) to
+      // slice the cursored hunk into a `git apply` patch. Stash uses
+      // the full `git stash show -p` output; commit-diff uses the
+      // per-file `filePreview.hunks` array. Either way, extractDiffHunk
+      // walks `@@` headers and synthesizes a fresh diff --git / --- /
+      // +++ header set using the path the caller already resolved.
+      diffLinesForHunkApply: state.diffSource === 'stash'
+        ? stashDiffLines
+        : state.diffSource === 'commit'
+          ? filePreview?.hunks
+          : undefined,
     }).forEach((event) => {
       if (event.type === 'exit') {
         exit()

--- a/src/commands/log/inkWorkflows.test.ts
+++ b/src/commands/log/inkWorkflows.test.ts
@@ -100,6 +100,17 @@ describe('log Ink workflows', () => {
     })
   })
 
+  it('registers hunk-apply workflows as palette-only and non-destructive (#782)', () => {
+    const worktree = getLogInkWorkflowActionById('apply-hunk-worktree')
+    const index = getLogInkWorkflowActionById('apply-hunk-index')
+    expect(worktree?.key).toBe('')
+    expect(worktree?.kind).toBe('normal')
+    expect(worktree?.requiresConfirmation).toBe(false)
+    expect(index?.key).toBe('')
+    expect(index?.kind).toBe('normal')
+    expect(index?.requiresConfirmation).toBe(false)
+  })
+
   it('reports loading states while optional repository context hydrates', () => {
     const sections = getLogInkWorkflowSections({
       contextLoading: true,

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -173,6 +173,34 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: true,
     },
     {
+      // Per-view-only: scoped to commit-diff and stash-diff explores in
+      // inkInput (key: H). The action is non-destructive in the sense
+      // that `git apply` won't lose any data — `git apply -R` undoes
+      // it cleanly — so it bypasses the y-confirm path. The patch text
+      // travels via the action's `payload` field. Empty key keeps the
+      // workflow palette-discoverable without registering a global
+      // hotkey (the palette path can't synthesize the patch text and
+      // surfaces a hint instead — actual dispatch is from H in diff
+      // view).
+      id: 'apply-hunk-worktree',
+      key: '',
+      label: 'Apply hunk to worktree',
+      description: 'Extract the hunk under the cursor and apply it to the working tree via `git apply`.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      // Sibling of `apply-hunk-worktree` — same extraction path, but
+      // `git apply --cached` so the patch lands in the index without
+      // touching the worktree. Bound to the `gH` chord in inkInput.
+      id: 'apply-hunk-index',
+      key: '',
+      label: 'Apply hunk to index',
+      description: 'Extract the hunk under the cursor and apply it to the index via `git apply --cached`.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
       id: 'open-pr',
       key: 'O',
       label: 'Open PR / repo',


### PR DESCRIPTION
## Summary

Adds hunk-level extraction inside commit-diff and stash-diff explores. Pressing `H` slices the cursored hunk out of the patch and applies it to the working tree (`git apply`); `gH` does the same against the index (`git apply --cached`).

Continuation of the file-level cherry-pick that already exists — file-level often overshoots; hunk-level lets users pull just the relevant change.

Closes #782.

## User-visible workflow

1. Drill into a commit-diff or stash-diff explore (Enter on a commit / stash row).
2. Move the cursor (`j`/`k`, `[`/`]`) to a `+` / `-` line inside the hunk you want to grab.
3. Press `H` to apply the hunk to the worktree, or `gH` to stage it directly into the index.
4. Status line reports `Applied hunk to worktree` / `Applied hunk to index`. On conflict, the first line of `git apply` stderr surfaces (e.g. `error: patch failed: src/foo.ts:42`).
5. Undo a clean apply with `git apply -R` from the shell — the action is non-destructive.

Footer hints on commit-diff and stash-diff advertise `H apply hunk`. The `gH` chord shows a discoverability hint when pressed without diff context.

## Key choice + rationale

- **`H`** = apply to worktree (most common case)
- **`gH`** chord = apply to index

Why not `Y`? `y`/`Y` are already taken by the clipboard yank action in diff view.

Why not a multi-choice confirmation overlay? The existing confirmation infra is binary (y/n). Adding a third option pattern would touch state shape, the input dispatcher, and the overlay renderer for one workflow — disproportionate. The `g`-chord pattern is already established (`gh`/`gs`/`gd`/`gc`/`gb`/`gt`/`gz`/`gw`); `gH` slots in cleanly without new modal scaffolding.

`H` was unbound in diff view and the `g`-chord namespace had `H` available — no collisions.

## Worktree vs index decision

`H` (bare) → worktree, because:
- Most "I want this hunk locally" workflows want the file modified for review/testing first
- Worktree apply is reversible via `git apply -R` (or just discard the unstaged change)
- Index apply is the staged-only workflow — opt-in via the chord makes the intent explicit

## Architecture

- `inkHunkExtraction.ts` — pure helper. Walks `@@` headers around `cursorOffset`, synthesizes a fresh `diff --git` / `---` / `+++` header set using the caller-provided path. Handles both stash-diff (full patch) and commit-diff (`filePreview.hunks`, headers stripped) the same way.
- `hunkActions.ts` — `applyHunkPatch(git, patchText, { target })` writes to `\$TMPDIR + randomUUID + .patch`, runs `git apply [--cached] --whitespace=nowarn`, cleans up in `finally` (swallows ENOENT).
- Two palette-only workflows (`apply-hunk-worktree`, `apply-hunk-index`) registered in `inkWorkflows.ts`. Empty `key` keeps them palette-discoverable; actual dispatch is direct from `inkInput.ts` since palette execution can't synthesize a patch payload.
- The patch text + target travel through the existing `payload` field as `<target>\\n<patch>`. Splitting on the first newline keeps the patch body intact.
- `inkRuntime.ts` plumbs `diffLinesForHunkApply` (stashDiffLines or filePreview.hunks) through `LogInkInputContext` so the input handler can synthesize the patch without re-architecting around runtime state.

## Test plan

- [x] `npm run lint`
- [x] `npm run test` (full validation: 942 tests pass + lint + publish dry-run)
- [x] `npm run build`
- [ ] Manual: `coco ui` → drill into a commit-diff, cursor on a hunk, press `H` — verify status line says `Applied hunk to worktree` and `git status` shows the change
- [ ] Manual: same but `gH` — verify the change lands in the index
- [ ] Manual: `H` on a stash-diff — verify the cursored hunk lands in the worktree without applying the rest of the stash
- [ ] Manual: trigger an apply conflict (modify the worktree first, then try `H`) — verify error surfaces on the status line
- [ ] Manual: `H` with cursor on a `diff --git` line (before any `@@`) — verify status hint says "no hunk under cursor"

🤖 Generated with [Claude Code](https://claude.com/claude-code)