### PR TITLE
feat(log-tui): full pull-request action panel (#783)

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -892,12 +892,14 @@ describe('log Ink input interactions', () => {
     it('does not move the palette selection past the filtered command count', () => {
       let state = openPalette()
 
-      // Filter to a unique label to get exactly one match.
-      state = applyInput(state, 'g')
-      state = applyInput(state, 'r')
-      state = applyInput(state, 'a')
-      state = applyInput(state, 'p')
-      state = applyInput(state, 'h')
+      // Filter to a unique substring that ONLY matches toggleGraph.
+      // Earlier the test typed `graph` letter-by-letter, but the
+      // fuzzy-match scorer also accepts long-distance matches like
+      // `Merge ... current ... branch's ... pull ... squash` which
+      // collide with the new PR-panel workflows added in #783.
+      // `togglegr` is a substring of the toggleGraph id and lives
+      // nowhere else in the command set.
+      'togglegr'.split('').forEach((c) => { state = applyInput(state, c) })
 
       // Only one match (toggleGraph). Down-arrow should clamp at index 0.
       state = applyInput(state, '', { downArrow: true })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -237,6 +237,8 @@ export function getLogInkPaletteExecuteEvents(
       return [action({ type: 'pushView', value: 'stash' })]
     case 'navigateWorktrees':
       return [action({ type: 'pushView', value: 'worktrees' })]
+    case 'navigatePullRequest':
+      return [action({ type: 'pushView', value: 'pull-request' })]
     case 'navigateBack':
       return [action({ type: 'popView' })]
     case 'openSelected': {
@@ -365,6 +367,38 @@ export function getLogInkInputEvents(
       const value = state.inputPrompt.value.trim()
       if (!value) {
         return [action({ type: 'setStatus', value: 'enter a value or press esc to cancel' })]
+      }
+      // Most prompt kinds dispatch a workflow whose id matches the
+      // kind. PR-related prompts forward to a workflow id distinct
+      // from the prompt name so the panel can keep its keys
+      // mnemonic-friendly while the workflow ids stay descriptive.
+      // pr-merge-strategy validates the strategy at the input layer
+      // so a typo doesn't surface as a "workflow not yet wired"
+      // status downstream.
+      if (state.inputPrompt.kind === 'pr-merge-strategy') {
+        const strategy = value.toLowerCase()
+        if (strategy !== 'merge' && strategy !== 'squash' && strategy !== 'rebase') {
+          return [action({
+            type: 'setStatus',
+            value: `Unknown merge strategy: ${value}. Use merge, squash, or rebase.`,
+          })]
+        }
+        return [
+          action({ type: 'setPendingConfirmation', value: 'merge-pr', payload: strategy }),
+          action({ type: 'closeInputPrompt' }),
+        ]
+      }
+      if (state.inputPrompt.kind === 'pr-comment') {
+        return [
+          { type: 'runWorkflowAction', id: 'comment-pr', payload: value },
+          action({ type: 'closeInputPrompt' }),
+        ]
+      }
+      if (state.inputPrompt.kind === 'pr-request-changes') {
+        return [
+          action({ type: 'setPendingConfirmation', value: 'request-changes-pr', payload: value }),
+          action({ type: 'closeInputPrompt' }),
+        ]
       }
       const id = state.inputPrompt.kind
       return [
@@ -678,6 +712,18 @@ export function getLogInkInputEvents(
     return [
       action({ type: 'pushView', value: 'worktrees' }),
       action({ type: 'setStatus', value: 'jumped to worktrees' }),
+    ]
+  }
+
+  // `gp` jumps to the dedicated pull-request action panel (#783).
+  // Lowercase `p` matches the pattern of other navigation chords
+  // (gh / gs / gd / gc / gb / gt / gz / gw). The panel renders the
+  // current branch's PR via `gh pr view --json` enriched fields and
+  // exposes m / x / a / R / c action keys scoped to the view.
+  if (state.pendingKey === 'g' && inputValue === 'p') {
+    return [
+      action({ type: 'pushView', value: 'pull-request' }),
+      action({ type: 'setStatus', value: 'jumped to pull request' }),
     ]
   }
 
@@ -1177,6 +1223,38 @@ export function getLogInkInputEvents(
   // (especially the `R` rename binding on the branches target).
   if (inputValue === 'R' && isTagActionTarget(state) && context.tagCount) {
     return [action({ type: 'setPendingConfirmation', value: 'delete-remote-tag' })]
+  }
+
+  // #783 — full PR action panel keys, scoped to the pull-request view.
+  // All five wrap a `gh pr <verb>` invocation; merge / request-changes /
+  // comment open prompts first, the rest route through the y-confirm
+  // path because they're irreversible (or near-irreversible).
+  if (inputValue === 'm' && state.activeView === 'pull-request') {
+    return [action({
+      type: 'openInputPrompt',
+      kind: 'pr-merge-strategy',
+      label: 'Merge strategy (merge / squash / rebase)',
+    })]
+  }
+  if (inputValue === 'x' && state.activeView === 'pull-request') {
+    return [action({ type: 'setPendingConfirmation', value: 'close-pr' })]
+  }
+  if (inputValue === 'a' && state.activeView === 'pull-request') {
+    return [action({ type: 'setPendingConfirmation', value: 'approve-pr' })]
+  }
+  if (inputValue === 'R' && state.activeView === 'pull-request') {
+    return [action({
+      type: 'openInputPrompt',
+      kind: 'pr-request-changes',
+      label: 'Request changes — review body',
+    })]
+  }
+  if (inputValue === 'c' && state.activeView === 'pull-request') {
+    return [action({
+      type: 'openInputPrompt',
+      kind: 'pr-comment',
+      label: 'Comment body',
+    })]
   }
 
   // Global stash hotkey: `S` opens a stash-message prompt and

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -22,6 +22,7 @@ export type LogInkCommandId =
   | 'navigateCompose'
   | 'navigateDiff'
   | 'navigateHome'
+  | 'navigatePullRequest'
   | 'navigateStash'
   | 'navigateWorktrees'
   | 'navigateStatus'
@@ -241,6 +242,13 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     contexts: ['normal'],
   },
   {
+    id: 'navigatePullRequest',
+    keys: ['gp'],
+    label: 'pull request',
+    description: 'Push the dedicated pull-request action panel for the current branch.',
+    contexts: ['normal'],
+  },
+  {
     id: 'navigateBack',
     keys: ['<', 'esc'],
     label: 'back',
@@ -410,6 +418,7 @@ const GLOBAL_BINDING_IDS: LogInkCommandId[] = [
   'navigateTags',
   'navigateStash',
   'navigateWorktrees',
+  'navigatePullRequest',
   'navigateBack',
 ]
 
@@ -581,6 +590,17 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
   if (options.activeView === 'worktrees') {
     return {
       contextual: ['↑/↓ worktrees', 'W remove', 'esc back'],
+      global: NORMAL_GLOBAL_HINTS,
+    }
+  }
+
+  if (options.activeView === 'pull-request') {
+    return {
+      // #783 — full PR action panel. Five mutating ops scoped to this
+      // view: m / x / a / R / c, plus O for open-in-browser (already
+      // a global). Each routes through y-confirm or an input prompt;
+      // none fire silently.
+      contextual: ['m merge', 'x close', 'a approve', 'R changes', 'c comment', 'O open', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkPullRequestPanel.test.ts
+++ b/src/commands/log/inkPullRequestPanel.test.ts
@@ -1,0 +1,167 @@
+import {
+  buildPullRequestCheckRows,
+  formatPullRequestChecksSummary,
+  formatPullRequestReviewsSummary,
+  formatPullRequestStateLine,
+  normalizePullRequestCheckStatus,
+  pullRequestCheckGlyph,
+  summarizePullRequestChecks,
+  summarizePullRequestReviews,
+} from './inkPullRequestPanel'
+
+describe('normalizePullRequestCheckStatus', () => {
+  it('treats IN_PROGRESS / QUEUED / PENDING (no conclusion) as pending', () => {
+    expect(normalizePullRequestCheckStatus({ name: 'a', status: 'IN_PROGRESS' })).toBe('pending')
+    expect(normalizePullRequestCheckStatus({ name: 'a', status: 'QUEUED' })).toBe('pending')
+    expect(normalizePullRequestCheckStatus({ name: 'a', status: 'PENDING' })).toBe('pending')
+  })
+
+  it('promotes failure conclusions even when status is COMPLETED', () => {
+    expect(normalizePullRequestCheckStatus({ name: 'a', status: 'COMPLETED', conclusion: 'FAILURE' })).toBe('failure')
+    expect(normalizePullRequestCheckStatus({ name: 'a', status: 'COMPLETED', conclusion: 'ERROR' })).toBe('failure')
+    expect(normalizePullRequestCheckStatus({ name: 'a', status: 'COMPLETED', conclusion: 'TIMED_OUT' })).toBe('failure')
+    expect(normalizePullRequestCheckStatus({ name: 'a', status: 'COMPLETED', conclusion: 'ACTION_REQUIRED' })).toBe('failure')
+  })
+
+  it('maps SUCCESS / NEUTRAL / SKIPPED / CANCELLED conclusions', () => {
+    expect(normalizePullRequestCheckStatus({ name: 'a', conclusion: 'SUCCESS' })).toBe('success')
+    expect(normalizePullRequestCheckStatus({ name: 'a', conclusion: 'NEUTRAL' })).toBe('neutral')
+    expect(normalizePullRequestCheckStatus({ name: 'a', conclusion: 'SKIPPED' })).toBe('skipped')
+    expect(normalizePullRequestCheckStatus({ name: 'a', conclusion: 'CANCELLED' })).toBe('skipped')
+  })
+
+  it('falls back to pending for unknown signals', () => {
+    expect(normalizePullRequestCheckStatus({ name: 'a' })).toBe('pending')
+    expect(normalizePullRequestCheckStatus({ name: 'a', conclusion: 'MYSTERY' })).toBe('pending')
+  })
+})
+
+describe('pullRequestCheckGlyph', () => {
+  it('uses Unicode glyphs by default and ASCII fallbacks under ascii mode', () => {
+    expect(pullRequestCheckGlyph('success')).toBe('✓')
+    expect(pullRequestCheckGlyph('failure')).toBe('✗')
+    expect(pullRequestCheckGlyph('pending')).toBe('◌')
+
+    expect(pullRequestCheckGlyph('success', { ascii: true })).toBe('+')
+    expect(pullRequestCheckGlyph('failure', { ascii: true })).toBe('x')
+    expect(pullRequestCheckGlyph('pending', { ascii: true })).toBe('.')
+  })
+})
+
+describe('summarizePullRequestChecks', () => {
+  it('counts each normalized status across the rollup', () => {
+    const summary = summarizePullRequestChecks([
+      { name: 'lint', conclusion: 'SUCCESS' },
+      { name: 'test', conclusion: 'SUCCESS' },
+      { name: 'build', status: 'IN_PROGRESS' },
+      { name: 'flaky', status: 'COMPLETED', conclusion: 'FAILURE' },
+      { name: 'optional', conclusion: 'SKIPPED' },
+    ])
+    expect(summary).toEqual({
+      total: 5, success: 2, failure: 1, pending: 1, neutral: 0, skipped: 1,
+    })
+  })
+
+  it('returns a zeroed summary for missing rollup', () => {
+    expect(summarizePullRequestChecks(undefined).total).toBe(0)
+  })
+})
+
+describe('formatPullRequestChecksSummary', () => {
+  it('hides zero-count categories so the line stays scannable', () => {
+    const summary = summarizePullRequestChecks([
+      { name: 'lint', conclusion: 'SUCCESS' },
+      { name: 'test', conclusion: 'SUCCESS' },
+      { name: 'build', status: 'IN_PROGRESS' },
+    ])
+    expect(formatPullRequestChecksSummary(summary)).toBe('3 checks · 2 ✓ · 1 ◌')
+  })
+
+  it('falls back to "No status checks" when total is zero', () => {
+    expect(formatPullRequestChecksSummary(summarizePullRequestChecks([]))).toBe('No status checks reported')
+  })
+})
+
+describe('buildPullRequestCheckRows', () => {
+  it('produces one row per check with glyph + normalized status + detail', () => {
+    const rows = buildPullRequestCheckRows([
+      { name: 'lint', conclusion: 'SUCCESS' },
+      { name: 'build', status: 'IN_PROGRESS' },
+    ])
+    expect(rows).toEqual([
+      { glyph: '✓', name: 'lint', status: 'success', detail: 'success' },
+      { glyph: '◌', name: 'build', status: 'pending', detail: 'in_progress' },
+    ])
+  })
+})
+
+describe('summarizePullRequestReviews', () => {
+  it('counts per-state reviews and exposes the GraphQL decision label', () => {
+    const summary = summarizePullRequestReviews(
+      [
+        { state: 'APPROVED' },
+        { state: 'APPROVED' },
+        { state: 'COMMENTED' },
+        { state: 'CHANGES_REQUESTED' },
+        { state: 'DISMISSED' },
+      ],
+      'APPROVED'
+    )
+    expect(summary).toEqual({
+      total: 5,
+      approved: 2,
+      changesRequested: 1,
+      commented: 1,
+      dismissed: 1,
+      pending: 0,
+      decisionLabel: 'APPROVED',
+    })
+  })
+})
+
+describe('formatPullRequestReviewsSummary', () => {
+  it('renders per-state counts plus the decision label', () => {
+    const summary = summarizePullRequestReviews(
+      [{ state: 'APPROVED' }, { state: 'COMMENTED' }],
+      'APPROVED'
+    )
+    expect(formatPullRequestReviewsSummary(summary))
+      .toBe('2 reviews · 1 approved · 1 commented · decision: approved')
+  })
+
+  it('uses the decision label even when no reviews exist', () => {
+    const summary = summarizePullRequestReviews([], 'REVIEW_REQUIRED')
+    expect(formatPullRequestReviewsSummary(summary)).toBe('No reviews · review required')
+  })
+
+  it('omits the decision suffix when no reviews and no decision', () => {
+    expect(formatPullRequestReviewsSummary(summarizePullRequestReviews([])))
+      .toBe('No reviews submitted')
+  })
+})
+
+describe('formatPullRequestStateLine', () => {
+  it('appends draft + mergeable for open PRs', () => {
+    expect(formatPullRequestStateLine({
+      number: 1, title: 't', url: 'u',
+      state: 'OPEN', isDraft: true, headRefName: 'h', baseRefName: 'b',
+      mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN',
+    })).toBe('OPEN · draft · mergeable')
+  })
+
+  it('surfaces merge-state warnings when the PR is dirty / blocked / behind', () => {
+    expect(formatPullRequestStateLine({
+      number: 1, title: 't', url: 'u',
+      state: 'OPEN', isDraft: false, headRefName: 'h', baseRefName: 'b',
+      mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY',
+    })).toBe('OPEN · conflicting · dirty')
+  })
+
+  it('returns just the state for merged / closed PRs', () => {
+    expect(formatPullRequestStateLine({
+      number: 1, title: 't', url: 'u',
+      state: 'MERGED', isDraft: false, headRefName: 'h', baseRefName: 'b',
+      mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN',
+    })).toBe('MERGED')
+  })
+})

--- a/src/commands/log/inkPullRequestPanel.ts
+++ b/src/commands/log/inkPullRequestPanel.ts
@@ -1,0 +1,235 @@
+import { PullRequestInfo, PullRequestStatusCheck } from './pullRequestData'
+
+/**
+ * Pull request panel formatting helpers (#783).
+ *
+ * The runtime owns the Ink layout — these helpers produce the strings
+ * and glyph metadata so the renderer just maps over them. Keeping the
+ * formatting logic here makes it easy to unit-test (no Ink dependency)
+ * and matches the TUI cadence preference of separating helpers from
+ * runtime.
+ */
+
+export type PullRequestCheckStatus = 'success' | 'failure' | 'pending' | 'neutral' | 'skipped'
+
+/**
+ * Normalize gh's two parallel signals (`status` for in-flight check
+ * runs, `conclusion` for completed runs and status contexts) into a
+ * single status enum the renderer can map to a glyph + color.
+ */
+export function normalizePullRequestCheckStatus(
+  check: PullRequestStatusCheck
+): PullRequestCheckStatus {
+  const status = (check.status || '').toUpperCase()
+  const conclusion = (check.conclusion || '').toUpperCase()
+
+  // In-flight check runs: gh emits `status: IN_PROGRESS|QUEUED` with
+  // no conclusion yet. `PENDING` covers status-context runs that are
+  // still waiting on a reporter.
+  if (!conclusion && (status === 'IN_PROGRESS' || status === 'QUEUED' || status === 'PENDING')) {
+    return 'pending'
+  }
+
+  switch (conclusion || status) {
+    case 'SUCCESS':
+      return 'success'
+    case 'FAILURE':
+    case 'ERROR':
+    case 'TIMED_OUT':
+    case 'ACTION_REQUIRED':
+      return 'failure'
+    case 'NEUTRAL':
+      return 'neutral'
+    case 'SKIPPED':
+    case 'CANCELLED':
+      return 'skipped'
+    default:
+      return 'pending'
+  }
+}
+
+/**
+ * Glyph for a normalized check status. ASCII fallbacks keep the panel
+ * usable on legacy terminals where the geometric shapes block isn't
+ * rendered.
+ */
+export function pullRequestCheckGlyph(
+  status: PullRequestCheckStatus,
+  options: { ascii?: boolean } = {}
+): string {
+  if (options.ascii) {
+    switch (status) {
+      case 'success': return '+'
+      case 'failure': return 'x'
+      case 'pending': return '.'
+      case 'neutral': return '-'
+      case 'skipped': return '/'
+    }
+  }
+
+  switch (status) {
+    case 'success': return '✓'
+    case 'failure': return '✗'
+    case 'pending': return '◌'
+    case 'neutral': return '○'
+    case 'skipped': return '∼'
+  }
+}
+
+export type PullRequestChecksSummary = {
+  total: number
+  success: number
+  failure: number
+  pending: number
+  neutral: number
+  skipped: number
+}
+
+export function summarizePullRequestChecks(
+  checks: PullRequestStatusCheck[] | undefined
+): PullRequestChecksSummary {
+  const summary: PullRequestChecksSummary = {
+    total: 0, success: 0, failure: 0, pending: 0, neutral: 0, skipped: 0,
+  }
+  if (!checks) return summary
+  for (const check of checks) {
+    summary.total += 1
+    summary[normalizePullRequestCheckStatus(check)] += 1
+  }
+  return summary
+}
+
+/**
+ * One-line summary like `5 checks · 4 ✓ · 1 ◌` for the panel header.
+ * Hides zero-count categories so the line stays scannable.
+ */
+export function formatPullRequestChecksSummary(
+  summary: PullRequestChecksSummary,
+  options: { ascii?: boolean } = {}
+): string {
+  if (summary.total === 0) {
+    return 'No status checks reported'
+  }
+  const parts: string[] = [`${summary.total} ${summary.total === 1 ? 'check' : 'checks'}`]
+  const push = (count: number, status: PullRequestCheckStatus) => {
+    if (count > 0) parts.push(`${count} ${pullRequestCheckGlyph(status, options)}`)
+  }
+  push(summary.success, 'success')
+  push(summary.failure, 'failure')
+  push(summary.pending, 'pending')
+  push(summary.neutral, 'neutral')
+  push(summary.skipped, 'skipped')
+  return parts.join(' · ')
+}
+
+/**
+ * Per-check rows for the table body. Each entry includes the
+ * normalized status so the renderer can pick a color without
+ * re-running the normalizer.
+ */
+export type PullRequestCheckRow = {
+  glyph: string
+  name: string
+  status: PullRequestCheckStatus
+  /** Raw context — `IN_PROGRESS`, `SUCCESS`, etc. — for the dim trailer. */
+  detail: string
+}
+
+export function buildPullRequestCheckRows(
+  checks: PullRequestStatusCheck[] | undefined,
+  options: { ascii?: boolean } = {}
+): PullRequestCheckRow[] {
+  if (!checks) return []
+  return checks.map((check) => {
+    const status = normalizePullRequestCheckStatus(check)
+    return {
+      glyph: pullRequestCheckGlyph(status, options),
+      name: check.name,
+      status,
+      detail: (check.conclusion || check.status || '').toLowerCase(),
+    }
+  })
+}
+
+/**
+ * Counts of the per-state reviews. `decisionLabel` is the
+ * GraphQL-aggregated review decision (APPROVED / CHANGES_REQUESTED /
+ * REVIEW_REQUIRED / etc.) when available — that's the canonical
+ * "what's the verdict" answer; the per-state counts surface as the
+ * supporting detail.
+ */
+export type PullRequestReviewsSummary = {
+  total: number
+  approved: number
+  changesRequested: number
+  commented: number
+  dismissed: number
+  pending: number
+  decisionLabel?: string
+}
+
+export function summarizePullRequestReviews(
+  reviews: { state: string }[] | undefined,
+  reviewDecision?: string
+): PullRequestReviewsSummary {
+  const summary: PullRequestReviewsSummary = {
+    total: 0, approved: 0, changesRequested: 0, commented: 0, dismissed: 0, pending: 0,
+    decisionLabel: reviewDecision || undefined,
+  }
+  if (!reviews) return summary
+  for (const review of reviews) {
+    summary.total += 1
+    switch (review.state.toUpperCase()) {
+      case 'APPROVED':
+        summary.approved += 1
+        break
+      case 'CHANGES_REQUESTED':
+        summary.changesRequested += 1
+        break
+      case 'COMMENTED':
+        summary.commented += 1
+        break
+      case 'DISMISSED':
+        summary.dismissed += 1
+        break
+      case 'PENDING':
+        summary.pending += 1
+        break
+    }
+  }
+  return summary
+}
+
+export function formatPullRequestReviewsSummary(summary: PullRequestReviewsSummary): string {
+  const decision = summary.decisionLabel
+    ? summary.decisionLabel.replace(/_/g, ' ').toLowerCase()
+    : undefined
+  if (summary.total === 0) {
+    return decision ? `No reviews · ${decision}` : 'No reviews submitted'
+  }
+  const parts: string[] = [`${summary.total} ${summary.total === 1 ? 'review' : 'reviews'}`]
+  if (summary.approved > 0) parts.push(`${summary.approved} approved`)
+  if (summary.changesRequested > 0) parts.push(`${summary.changesRequested} changes requested`)
+  if (summary.commented > 0) parts.push(`${summary.commented} commented`)
+  if (summary.pending > 0) parts.push(`${summary.pending} pending`)
+  if (summary.dismissed > 0) parts.push(`${summary.dismissed} dismissed`)
+  if (decision) parts.push(`decision: ${decision}`)
+  return parts.join(' · ')
+}
+
+/**
+ * One-line state badge for the header, e.g. `OPEN · draft` or `MERGED`.
+ * Mergeable / merge-state is appended as a secondary chip when the PR
+ * is open so the user sees `MERGEABLE` / `CONFLICTING` at a glance.
+ */
+export function formatPullRequestStateLine(pr: PullRequestInfo): string {
+  const parts: string[] = [pr.state]
+  if (pr.isDraft) parts.push('draft')
+  if (pr.state === 'OPEN' && pr.mergeable) {
+    parts.push(pr.mergeable.toLowerCase())
+  }
+  if (pr.state === 'OPEN' && pr.mergeStateStatus && pr.mergeStateStatus !== 'CLEAN') {
+    parts.push(pr.mergeStateStatus.toLowerCase())
+  }
+  return parts.join(' · ')
+}

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -165,8 +165,24 @@ import { applyStash, checkoutFileFromStash, createStash, dropStash, popStash } f
 import { removeWorktree } from './worktreeActions'
 import { abortOperation } from './operationActions'
 import { PullRequestOverview, getPullRequestOverview } from './pullRequestData'
+import {
+  approvePullRequest,
+  closePullRequest,
+  commentPullRequest,
+  isPullRequestMergeStrategy,
+  mergePullRequest,
+  requestChangesPullRequest,
+} from './pullRequestActions'
 import { StashOverview, getStashDiff, getStashOverview, parseStashDiffFiles } from './stashData'
 import { formatStashHeaderIdentity } from './inkStashHeader'
+import {
+  buildPullRequestCheckRows,
+  formatPullRequestChecksSummary,
+  formatPullRequestReviewsSummary,
+  formatPullRequestStateLine,
+  summarizePullRequestChecks,
+  summarizePullRequestReviews,
+} from './inkPullRequestPanel'
 import { revertFile, stageFile, unstageFile } from './statusActions'
 import { WorktreeOverview, applyStatusFilterMask, getWorktreeOverview } from './statusData'
 import {
@@ -1394,6 +1410,30 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         if (!message) return { ok: false, message: 'Stash message required' }
         return createStash(git, message)
       },
+      // #783 — full PR action panel handlers. Each wraps the matching
+      // pullRequestActions verb. Strategy / body arrives via `payload`
+      // — input prompts validate before they reach here, but the
+      // strategy guard stays as a defensive belt-and-suspenders since
+      // a future palette path could call us with a raw value.
+      'merge-pr': async () => {
+        const strategy = (payload || 'merge').toLowerCase()
+        if (!isPullRequestMergeStrategy(strategy)) {
+          return { ok: false, message: `Unknown merge strategy: ${strategy}. Use merge, squash, or rebase.` }
+        }
+        return mergePullRequest(strategy)
+      },
+      'close-pr': async () => closePullRequest(),
+      'approve-pr': async () => approvePullRequest(),
+      'request-changes-pr': async () => {
+        const body = payload?.trim()
+        if (!body) return { ok: false, message: 'Review body required for change-request' }
+        return requestChangesPullRequest(body)
+      },
+      'comment-pr': async () => {
+        const body = payload?.trim()
+        if (!body) return { ok: false, message: 'Comment body required' }
+        return commentPullRequest(body)
+      },
     }
     const handler = handlers[id]
     if (!handler) {
@@ -2340,6 +2380,10 @@ function renderMainPanel(
     return renderWorktreesSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
   }
 
+  if (state.activeView === 'pull-request') {
+    return renderPullRequestSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
+  }
+
   return renderHistoryPanel(
     h,
     components,
@@ -3090,6 +3134,137 @@ function renderWorktreesSurface(
   ),
   ...renderPromotedFilterAffordance(h, Text, state, theme),
   ...lines)
+}
+
+/**
+ * Pull-request action panel (#783) — renders the current branch's PR
+ * with header, checks table, reviews summary, and a body preview.
+ * Action keys (m / x / a / R / c / O) are wired in inkInput.ts and
+ * surfaced via the footer; this renderer is read-only.
+ *
+ * Three loading / fallback states matter:
+ * - Provider data still loading → "Loading pull request..."
+ * - GitHub remote present but no PR for the current branch → empty
+ *   state hint pointing the user at `C` to create one.
+ * - GitHub CLI missing / unauthenticated → unavailable hint.
+ */
+function renderPullRequestSurface(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  bodyRows: number,
+  width: number,
+  theme: LogInkTheme
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const focused = state.focus === 'commits'
+  const loading = isLogInkContextKeyLoading(contextStatus, 'pullRequest')
+  const pullRequestOverview = context.pullRequest
+  // Use the dedicated `pullRequest` overview only — the `provider`
+  // shape carries a slimmer ProviderPullRequestStatus that lacks
+  // url / headRefName / body / mergeable / reviews. The dedicated
+  // overview hits `gh pr view --json` with the full enriched field
+  // list (PULL_REQUEST_VIEW_JSON_FIELDS) so the panel has everything.
+  const pr = pullRequestOverview?.currentPullRequest
+  const muted = theme.noColor ? undefined : theme.colors.muted
+  const accent = theme.noColor ? undefined : theme.colors.accent
+
+  const containerProps = {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column' as const,
+    flexShrink: 0,
+    paddingX: 1,
+    width,
+  }
+
+  if (loading && !pr) {
+    return h(Box, containerProps,
+      h(Box, { justifyContent: 'space-between' },
+        h(Text, { bold: true }, panelTitle('Pull request', focused)),
+        h(Text, { dimColor: true }, 'loading')
+      ),
+      h(Text, { dimColor: true }, formatLogInkLoading({ resource: 'pull request' })))
+  }
+
+  if (!pr) {
+    const hint = pullRequestOverview?.message
+      || 'No pull request detected for this branch. Press `C` (or `:create-pr`) to create one.'
+    return h(Box, containerProps,
+      h(Box, { justifyContent: 'space-between' },
+        h(Text, { bold: true }, panelTitle('Pull request', focused)),
+        h(Text, { dimColor: true }, 'no PR')
+      ),
+      h(Text, { dimColor: true }, truncate(hint, width - 4)))
+  }
+
+  const checks = summarizePullRequestChecks(pr.statusCheckRollup)
+  const reviews = summarizePullRequestReviews(pr.reviews, pr.reviewDecision)
+  const checkRows = buildPullRequestCheckRows(pr.statusCheckRollup, { ascii: theme.ascii })
+  const checkColor = (s: 'success' | 'failure' | 'pending' | 'neutral' | 'skipped'): string | undefined => {
+    if (theme.noColor) return undefined
+    if (s === 'success') return theme.colors.success
+    if (s === 'failure') return theme.colors.danger
+    if (s === 'pending') return theme.colors.warning
+    return theme.colors.muted
+  }
+
+  // Reserve a few rows for the header/section labels; the rest go to
+  // the checks table. Body preview gets the leftover rows so the
+  // surface stays vertically balanced even on tall terminals.
+  const checkBudget = Math.max(3, Math.min(checkRows.length, Math.floor(bodyRows / 2)))
+  const visibleChecks = checkRows.slice(0, checkBudget)
+  const truncatedChecks = checkRows.length - visibleChecks.length
+  const bodyPreviewBudget = Math.max(2, bodyRows - 8 - visibleChecks.length)
+  const bodyLines = (pr.body || '').split(/\r?\n/).filter((line) => line.trim().length > 0)
+  const visibleBodyLines = bodyLines.slice(0, bodyPreviewBudget)
+  const truncatedBodyLines = bodyLines.length - visibleBodyLines.length
+
+  const headerRight = `#${pr.number} · ${pr.headRefName} → ${pr.baseRefName}`
+  const stateLine = formatPullRequestStateLine(pr)
+  const author = pr.author ? `by @${pr.author}` : ''
+
+  return h(Box, containerProps,
+    h(Box, { justifyContent: 'space-between' },
+      h(Text, { bold: true }, panelTitle('Pull request', focused)),
+      h(Text, { dimColor: true }, headerRight)
+    ),
+    h(Text, undefined, truncate(pr.title, width - 4)),
+    h(Text, { dimColor: true }, truncate(`${stateLine}${author ? ` · ${author}` : ''}`, width - 4)),
+    h(Text, undefined, ''),
+
+    // Checks section
+    h(Text, { bold: true, color: accent }, 'Checks'),
+    h(Text, { dimColor: true }, truncate(`  ${formatPullRequestChecksSummary(checks, { ascii: theme.ascii })}`, width - 4)),
+    ...visibleChecks.map((row, index) => h(Text, {
+      key: `pr-check-${index}`,
+      color: checkColor(row.status),
+    }, truncate(`  ${row.glyph} ${row.name.padEnd(28)} ${row.detail}`, width - 4))),
+    ...(truncatedChecks > 0
+      ? [h(Text, { key: 'pr-checks-trunc', dimColor: true }, truncate(`  … ${truncatedChecks} more`, width - 4))]
+      : []),
+    h(Text, undefined, ''),
+
+    // Reviews section
+    h(Text, { bold: true, color: accent }, 'Reviews'),
+    h(Text, { dimColor: true }, truncate(`  ${formatPullRequestReviewsSummary(reviews)}`, width - 4)),
+    h(Text, undefined, ''),
+
+    // Body preview
+    ...(visibleBodyLines.length > 0
+      ? [
+        h(Text, { key: 'pr-body-label', bold: true, color: accent }, 'Description'),
+        ...visibleBodyLines.map((line, index) => h(Text, {
+          key: `pr-body-${index}`,
+          color: muted,
+        }, truncate(`  ${line}`, width - 4))),
+        ...(truncatedBodyLines > 0
+          ? [h(Text, { key: 'pr-body-trunc', dimColor: true }, truncate(`  … ${truncatedBodyLines} more lines`, width - 4))]
+          : []),
+      ]
+      : []))
 }
 
 /**

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -18,7 +18,7 @@ import {
 export type LogInkFocus = 'sidebar' | 'commits' | 'detail'
 
 export type LogInkSidebarTab = 'status' | 'branches' | 'tags' | 'stashes' | 'worktrees'
-export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash' | 'worktrees'
+export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash' | 'worktrees' | 'pull-request'
 export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk' | 'discard-draft'
 /**
  * Tracks which kind of diff the user pushed into. `commit` means they
@@ -206,6 +206,9 @@ export type LogInkInputPromptKind =
   | 'rename-branch'
   | 'set-upstream'
   | 'create-stash'
+  | 'pr-merge-strategy'
+  | 'pr-comment'
+  | 'pr-request-changes'
 
 export type LogInkInputPromptState = {
   kind: LogInkInputPromptKind

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -264,6 +264,53 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       kind: 'destructive',
       requiresConfirmation: true,
     },
+    // #783 — full PR action panel. All five entries are palette-only
+    // (`key: ''`) — actual dispatch is per-view scoped in inkInput so
+    // the keys stay free outside the pull-request view. Merge / close /
+    // approve / request-changes route through the y-confirm path
+    // because each is irreversible (or near-irreversible) once gh
+    // publishes it; comment is a free-form prompt with no extra
+    // confirmation since the body itself is the affirmative action.
+    {
+      id: 'merge-pr',
+      key: '',
+      label: 'Merge pull request',
+      description: 'Merge the current branch\'s pull request (prompts for merge / squash / rebase, then confirms).',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
+      id: 'close-pr',
+      key: '',
+      label: 'Close pull request',
+      description: 'Close the current pull request without merging.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
+      id: 'approve-pr',
+      key: '',
+      label: 'Approve pull request',
+      description: 'Submit an approving review on the current pull request.',
+      kind: 'normal',
+      requiresConfirmation: true,
+    },
+    {
+      id: 'request-changes-pr',
+      key: '',
+      label: 'Request changes on pull request',
+      description: 'Submit a change-request review (prompts for the review body, then confirms).',
+      kind: 'normal',
+      requiresConfirmation: true,
+    },
+    {
+      id: 'comment-pr',
+      key: '',
+      label: 'Comment on pull request',
+      description: 'Add a comment to the current pull request (prompts for body).',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
     {
       id: 'ai-commit-summary',
       key: 'I',

--- a/src/commands/log/pullRequestActions.test.ts
+++ b/src/commands/log/pullRequestActions.test.ts
@@ -1,4 +1,15 @@
-import { buildCreatePullRequestArgs, createPullRequest, openPullRequest } from './pullRequestActions'
+import {
+  approvePullRequest,
+  buildCreatePullRequestArgs,
+  buildMergePullRequestArgs,
+  closePullRequest,
+  commentPullRequest,
+  createPullRequest,
+  isPullRequestMergeStrategy,
+  mergePullRequest,
+  openPullRequest,
+  requestChangesPullRequest,
+} from './pullRequestActions'
 
 describe('log pull request actions', () => {
   it('builds ready and draft PR create commands', () => {
@@ -51,5 +62,96 @@ describe('log pull request actions', () => {
       url: 'https://github.com/gfargo/coco/pull/123',
     })
     expect(runner).toHaveBeenLastCalledWith(['pr', 'view', '--web'])
+  })
+
+  // #783 — full PR action panel. Each action wraps a single
+  // `gh pr <verb>` invocation; failure surfaces via the standard
+  // runner error path which `runGhAction` already covers.
+  describe('PR action panel verbs (#783)', () => {
+    it('builds merge args for each strategy', () => {
+      expect(buildMergePullRequestArgs('merge')).toEqual(['pr', 'merge', '--merge'])
+      expect(buildMergePullRequestArgs('squash')).toEqual(['pr', 'merge', '--squash'])
+      expect(buildMergePullRequestArgs('rebase')).toEqual(['pr', 'merge', '--rebase'])
+    })
+
+    it('validates the merge strategy union', () => {
+      expect(isPullRequestMergeStrategy('merge')).toBe(true)
+      expect(isPullRequestMergeStrategy('squash')).toBe(true)
+      expect(isPullRequestMergeStrategy('rebase')).toBe(true)
+      expect(isPullRequestMergeStrategy('fastforward')).toBe(false)
+      expect(isPullRequestMergeStrategy('')).toBe(false)
+    })
+
+    it('runs merge / close / approve through gh', async () => {
+      const runner = jest.fn().mockResolvedValue('')
+
+      await expect(mergePullRequest('squash', runner)).resolves.toEqual({
+        ok: true,
+        message: 'Merged pull request with squash',
+      })
+      expect(runner).toHaveBeenLastCalledWith(['pr', 'merge', '--squash'])
+
+      await expect(closePullRequest(runner)).resolves.toEqual({
+        ok: true,
+        message: 'Closed pull request',
+      })
+      expect(runner).toHaveBeenLastCalledWith(['pr', 'close'])
+
+      await expect(approvePullRequest(runner)).resolves.toEqual({
+        ok: true,
+        message: 'Approved pull request',
+      })
+      expect(runner).toHaveBeenLastCalledWith(['pr', 'review', '--approve'])
+    })
+
+    it('passes the body through for request-changes and comment', async () => {
+      const runner = jest.fn().mockResolvedValue('')
+
+      await expect(requestChangesPullRequest('please address X', runner)).resolves.toEqual({
+        ok: true,
+        message: 'Requested changes',
+      })
+      expect(runner).toHaveBeenLastCalledWith([
+        'pr', 'review', '--request-changes', '--body', 'please address X',
+      ])
+
+      await expect(commentPullRequest('lgtm', runner)).resolves.toEqual({
+        ok: true,
+        message: 'Comment added',
+      })
+      expect(runner).toHaveBeenLastCalledWith(['pr', 'comment', '--body', 'lgtm'])
+    })
+
+    it('rejects empty bodies for request-changes and comment without invoking gh', async () => {
+      const runner = jest.fn()
+
+      await expect(requestChangesPullRequest('   ', runner)).resolves.toEqual({
+        ok: false,
+        message: 'Review body required for change-request',
+      })
+      await expect(commentPullRequest('', runner)).resolves.toEqual({
+        ok: false,
+        message: 'Comment body required',
+      })
+      expect(runner).not.toHaveBeenCalled()
+    })
+
+    it('surfaces gh runner errors as failed action results', async () => {
+      const runner = jest.fn().mockRejectedValue(new Error('gh: not authenticated'))
+
+      await expect(mergePullRequest('merge', runner)).resolves.toEqual({
+        ok: false,
+        message: 'gh: not authenticated',
+      })
+    })
+
+    it('preserves trimmed gh stdout as the success message when present', async () => {
+      const runner = jest.fn().mockResolvedValue('Merged pull request #42 (squash)\n')
+
+      await expect(mergePullRequest('squash', runner)).resolves.toEqual({
+        ok: true,
+        message: 'Merged pull request #42 (squash)',
+      })
+    })
   })
 })

--- a/src/commands/log/pullRequestActions.ts
+++ b/src/commands/log/pullRequestActions.ts
@@ -79,3 +79,88 @@ export function openPullRequest(url: string, runner: GhRunner = defaultGhRunner)
     url,
   }))
 }
+
+/**
+ * #783 — full PR action panel. The actions below all wrap a single
+ * `gh pr <verb>` invocation. Strategy / body / option text travels in
+ * via the action input; the runner-error / status surfacing is handled
+ * by the shared `runGhAction` wrapper so callers always get a uniform
+ * `PullRequestActionResult`.
+ */
+
+export type PullRequestMergeStrategy = 'merge' | 'squash' | 'rebase'
+
+export function isPullRequestMergeStrategy(value: string): value is PullRequestMergeStrategy {
+  return value === 'merge' || value === 'squash' || value === 'rebase'
+}
+
+export function buildMergePullRequestArgs(strategy: PullRequestMergeStrategy): string[] {
+  // `--auto` and `--admin` are intentionally omitted — they're rarely
+  // what a user wants from a TUI and require explicit gh auth scopes.
+  // `--delete-branch` is opt-in via a future flag; default leaves the
+  // branch in place so the user can verify before cleanup.
+  return ['pr', 'merge', `--${strategy}`]
+}
+
+export function mergePullRequest(
+  strategy: PullRequestMergeStrategy,
+  runner: GhRunner = defaultGhRunner
+): Promise<PullRequestActionResult> {
+  return runGhAction(runner, buildMergePullRequestArgs(strategy), (output) => ({
+    ok: true,
+    message: output.trim() || `Merged pull request with ${strategy}`,
+  }))
+}
+
+export function closePullRequest(
+  runner: GhRunner = defaultGhRunner
+): Promise<PullRequestActionResult> {
+  return runGhAction(runner, ['pr', 'close'], (output) => ({
+    ok: true,
+    message: output.trim() || 'Closed pull request',
+  }))
+}
+
+/**
+ * `gh pr review --approve` requires the user's gh auth to have scope
+ * to write reviews — same scope that the in-browser approve button
+ * uses. The runner surfaces auth failures via the standard error path.
+ */
+export function approvePullRequest(
+  runner: GhRunner = defaultGhRunner
+): Promise<PullRequestActionResult> {
+  return runGhAction(runner, ['pr', 'review', '--approve'], (output) => ({
+    ok: true,
+    message: output.trim() || 'Approved pull request',
+  }))
+}
+
+/**
+ * Request changes — `gh pr review` requires a body with this verb so
+ * the empty-body case is rejected upstream by the input prompt.
+ */
+export function requestChangesPullRequest(
+  body: string,
+  runner: GhRunner = defaultGhRunner
+): Promise<PullRequestActionResult> {
+  if (!body.trim()) {
+    return Promise.resolve({ ok: false, message: 'Review body required for change-request' })
+  }
+  return runGhAction(runner, ['pr', 'review', '--request-changes', '--body', body], (output) => ({
+    ok: true,
+    message: output.trim() || 'Requested changes',
+  }))
+}
+
+export function commentPullRequest(
+  body: string,
+  runner: GhRunner = defaultGhRunner
+): Promise<PullRequestActionResult> {
+  if (!body.trim()) {
+    return Promise.resolve({ ok: false, message: 'Comment body required' })
+  }
+  return runGhAction(runner, ['pr', 'comment', '--body', body], (output) => ({
+    ok: true,
+    message: output.trim() || 'Comment added',
+  }))
+}

--- a/src/commands/log/pullRequestData.test.ts
+++ b/src/commands/log/pullRequestData.test.ts
@@ -1,4 +1,8 @@
-import { getPullRequestOverview, parseGitHubRemoteUrl } from './pullRequestData'
+import {
+  PULL_REQUEST_VIEW_JSON_FIELDS,
+  getPullRequestOverview,
+  parseGitHubRemoteUrl,
+} from './pullRequestData'
 
 describe('log pull request data', () => {
   it('parses GitHub SSH and HTTPS remotes', () => {
@@ -41,6 +45,24 @@ describe('log pull request data', () => {
         isDraft: false,
         headRefName: 'feature/pr',
         baseRefName: 'main',
+        // Enriched fields for the dedicated PR action panel (#783) —
+        // body / author / mergeable / reviews / statusCheckRollup all
+        // come back from the same `gh pr view --json` call so the
+        // panel renders without a second round-trip.
+        body: 'Adds the PR action panel.',
+        author: { login: 'gfargo' },
+        reviewDecision: 'APPROVED',
+        mergeable: 'MERGEABLE',
+        mergeStateStatus: 'CLEAN',
+        statusCheckRollup: [
+          { name: 'lint', status: 'COMPLETED', conclusion: 'SUCCESS' },
+          { name: 'test', status: 'COMPLETED', conclusion: 'SUCCESS' },
+          { name: 'build', status: 'IN_PROGRESS' },
+        ],
+        reviews: [
+          { author: { login: 'reviewer-a' }, state: 'APPROVED' },
+          { author: { login: 'reviewer-b' }, state: 'COMMENTED' },
+        ],
       }))
     const git = {
       getRemotes: jest.fn().mockResolvedValue([
@@ -55,7 +77,8 @@ describe('log pull request data', () => {
       raw: jest.fn().mockResolvedValue('feature/pr\n'),
     }
 
-    await expect(getPullRequestOverview(git as never, runner)).resolves.toEqual({
+    const overview = await getPullRequestOverview(git as never, runner)
+    expect(overview).toEqual({
       available: true,
       authenticated: true,
       repository: {
@@ -71,14 +94,68 @@ describe('log pull request data', () => {
         isDraft: false,
         headRefName: 'feature/pr',
         baseRefName: 'main',
+        body: 'Adds the PR action panel.',
+        author: 'gfargo',
+        reviewDecision: 'APPROVED',
+        mergeable: 'MERGEABLE',
+        mergeStateStatus: 'CLEAN',
+        statusCheckRollup: [
+          { name: 'lint', status: 'COMPLETED', conclusion: 'SUCCESS' },
+          { name: 'test', status: 'COMPLETED', conclusion: 'SUCCESS' },
+          { name: 'build', status: 'IN_PROGRESS', conclusion: undefined },
+        ],
+        reviews: [
+          { author: 'reviewer-a', state: 'APPROVED' },
+          { author: 'reviewer-b', state: 'COMMENTED' },
+        ],
       },
     })
     expect(runner).toHaveBeenNthCalledWith(1, ['auth', 'status', '--hostname', 'github.com'])
-    expect(runner).toHaveBeenNthCalledWith(2, [
-      'pr',
-      'view',
-      '--json',
-      'number,title,url,state,isDraft,headRefName,baseRefName',
-    ])
+    expect(runner).toHaveBeenNthCalledWith(2, ['pr', 'view', '--json', PULL_REQUEST_VIEW_JSON_FIELDS])
+  })
+
+  it('parses a minimal pull request payload without the enriched fields', () => {
+    // Falls back gracefully when gh returns the legacy minimum shape —
+    // older gh versions, restricted-token environments, or partial
+    // JSON. The panel renders the basics without crashing on missing
+    // statusCheckRollup / reviews.
+    const runner = jest
+      .fn()
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce(JSON.stringify({
+        number: 7,
+        title: 'minimal',
+        url: 'https://github.com/gfargo/coco/pull/7',
+        state: 'OPEN',
+        isDraft: true,
+        headRefName: 'wip',
+        baseRefName: 'main',
+      }))
+    const git = {
+      getRemotes: jest.fn().mockResolvedValue([
+        { name: 'origin', refs: { fetch: 'git@github.com:gfargo/coco.git', push: '' } },
+      ]),
+      raw: jest.fn().mockResolvedValue('wip\n'),
+    }
+
+    return expect(getPullRequestOverview(git as never, runner)).resolves.toMatchObject({
+      currentPullRequest: {
+        number: 7,
+        title: 'minimal',
+        isDraft: true,
+        body: undefined,
+        author: undefined,
+        statusCheckRollup: undefined,
+        reviews: undefined,
+      },
+    })
+  })
+
+  it('exports the centralized JSON field list', () => {
+    expect(PULL_REQUEST_VIEW_JSON_FIELDS).toContain('statusCheckRollup')
+    expect(PULL_REQUEST_VIEW_JSON_FIELDS).toContain('reviews')
+    expect(PULL_REQUEST_VIEW_JSON_FIELDS).toContain('mergeable')
+    expect(PULL_REQUEST_VIEW_JSON_FIELDS).toContain('mergeStateStatus')
+    expect(PULL_REQUEST_VIEW_JSON_FIELDS).toContain('author')
   })
 })

--- a/src/commands/log/pullRequestData.ts
+++ b/src/commands/log/pullRequestData.ts
@@ -11,6 +11,30 @@ export type GitHubRepository = {
   name: string
 }
 
+export type PullRequestStatusCheck = {
+  /** Display name from `gh pr view --json statusCheckRollup`. */
+  name: string
+  /**
+   * `IN_PROGRESS` / `COMPLETED` / `QUEUED` / etc. for check runs;
+   * `PENDING` / `SUCCESS` / `FAILURE` / `ERROR` for status contexts.
+   * The renderer normalizes both into a single status glyph.
+   */
+  status?: string
+  /**
+   * `SUCCESS` / `FAILURE` / `NEUTRAL` / `CANCELLED` / `SKIPPED` /
+   * `TIMED_OUT` / `ACTION_REQUIRED` for completed check runs;
+   * `undefined` while still in progress.
+   */
+  conclusion?: string
+}
+
+export type PullRequestReviewInfo = {
+  /** GitHub login of the reviewer. */
+  author: string
+  /** `APPROVED` / `CHANGES_REQUESTED` / `COMMENTED` / `DISMISSED` / `PENDING`. */
+  state: string
+}
+
 export type PullRequestInfo = {
   number: number
   title: string
@@ -19,6 +43,22 @@ export type PullRequestInfo = {
   isDraft: boolean
   headRefName: string
   baseRefName: string
+  /** PR body — rendered as a collapsed preview in the panel header. */
+  body?: string
+  /** GitHub login of the PR author. */
+  author?: string
+  /** Aggregated GraphQL review decision (cheaper than computing it
+   *  from the per-review array). */
+  reviewDecision?: string
+  /** `MERGEABLE` / `CONFLICTING` / `UNKNOWN` from gh. */
+  mergeable?: string
+  /** `CLEAN` / `DIRTY` / `BLOCKED` / `BEHIND` / `UNSTABLE` / etc. —
+   *  drives the merge action's affordance and any pre-merge warnings. */
+  mergeStateStatus?: string
+  /** Flat per-check status; rendered as a small table in the panel. */
+  statusCheckRollup?: PullRequestStatusCheck[]
+  /** Per-reviewer entries; rendered as a summary line. */
+  reviews?: PullRequestReviewInfo[]
 }
 
 export type PullRequestOverview = {
@@ -67,8 +107,67 @@ function parsePullRequestInfo(output: string): PullRequestInfo | undefined {
     return undefined
   }
 
-  return JSON.parse(trimmed) as PullRequestInfo
+  const raw = JSON.parse(trimmed) as Record<string, unknown>
+  const author = raw.author && typeof raw.author === 'object' && 'login' in raw.author
+    ? String((raw.author as { login: unknown }).login)
+    : undefined
+
+  return {
+    number: raw.number as number,
+    title: raw.title as string,
+    url: raw.url as string,
+    state: raw.state as string,
+    isDraft: raw.isDraft as boolean,
+    headRefName: raw.headRefName as string,
+    baseRefName: raw.baseRefName as string,
+    body: typeof raw.body === 'string' ? raw.body : undefined,
+    author,
+    reviewDecision: typeof raw.reviewDecision === 'string' ? raw.reviewDecision : undefined,
+    mergeable: typeof raw.mergeable === 'string' ? raw.mergeable : undefined,
+    mergeStateStatus: typeof raw.mergeStateStatus === 'string' ? raw.mergeStateStatus : undefined,
+    statusCheckRollup: Array.isArray(raw.statusCheckRollup)
+      ? (raw.statusCheckRollup as Array<Record<string, unknown>>).map((entry) => ({
+        name: String(entry.name || entry.context || 'check'),
+        status: typeof entry.status === 'string' ? entry.status : undefined,
+        conclusion: typeof entry.conclusion === 'string' ? entry.conclusion : undefined,
+      }))
+      : undefined,
+    reviews: Array.isArray(raw.reviews)
+      ? (raw.reviews as Array<Record<string, unknown>>).map((entry) => {
+        const author = entry.author && typeof entry.author === 'object' && 'login' in entry.author
+          ? String((entry.author as { login: unknown }).login)
+          : ''
+        return {
+          author,
+          state: typeof entry.state === 'string' ? entry.state : '',
+        }
+      }).filter((review) => review.author)
+      : undefined,
+  }
 }
+
+/**
+ * `gh pr view --json` field list. Centralized so the data fetcher and
+ * any future re-fetch (e.g., refresh after a merge action) request the
+ * same shape — the parser depends on every field being present, even
+ * if optional, so they're safe to deserialize.
+ */
+export const PULL_REQUEST_VIEW_JSON_FIELDS = [
+  'number',
+  'title',
+  'url',
+  'state',
+  'isDraft',
+  'headRefName',
+  'baseRefName',
+  'body',
+  'author',
+  'reviewDecision',
+  'mergeable',
+  'mergeStateStatus',
+  'statusCheckRollup',
+  'reviews',
+].join(',')
 
 export async function getPullRequestOverview(
   git: SimpleGit,
@@ -106,7 +205,7 @@ export async function getPullRequestOverview(
       'pr',
       'view',
       '--json',
-      'number,title,url,state,isDraft,headRefName,baseRefName',
+      PULL_REQUEST_VIEW_JSON_FIELDS,
     ])
 
     return {


### PR DESCRIPTION
Closes #783.

## Summary

New \`gp\` chord opens a dedicated pull-request action panel for the current branch's PR. Builds on the \`O\` open-in-browser hotkey from 0.35.0 — every action that previously required drilling into the GitHub web UI is now a keystroke away.

## Surface

- **Header**: PR number, title, state glyph (\`OPEN · draft · mergeable\` / \`OPEN · conflicting · dirty\` / \`MERGED\`), branch arrow (\`feature/x → main\`), author
- **Checks**: one-line summary (\`5 checks · 4 ✓ · 1 ◌\`) plus a per-check table colored by normalized status (success / failure / pending / neutral / skipped), with ASCII glyph fallbacks under \`theme.ascii\`
- **Reviews**: per-state counts plus the GraphQL \`reviewDecision\` (\`approved\` / \`changes requested\` / \`review required\`)
- **Description**: PR body preview, collapsed with truncation hint

## Action keys (scoped to the PR view)

| Key | Action | Flow |
|---|---|---|
| **m** | merge | strategy prompt (merge / squash / rebase) → y-confirm → \`gh pr merge --<strategy>\` |
| **x** | close | y-confirm → \`gh pr close\` |
| **a** | approve | y-confirm → \`gh pr review --approve\` |
| **R** | request changes | body prompt → y-confirm → \`gh pr review --request-changes --body <body>\` |
| **c** | comment | body prompt → \`gh pr comment --body <body>\` |
| **O** | open in browser | already a global workflow |

## Data layer

- \`PULL_REQUEST_VIEW_JSON_FIELDS\` centralizes the \`gh pr view --json\` field list so the existing fetcher and any future re-fetch (post-action refresh, for example) use the same shape
- Enriched with \`body\` / \`author\` / \`mergeable\` / \`mergeStateStatus\` / \`reviewDecision\` / \`reviews\` / \`statusCheckRollup\` so the panel renders without a second round-trip
- Parser handles missing fields gracefully (older gh versions, restricted-token environments)

## Action helpers

New verbs in \`pullRequestActions.ts\`: \`mergePullRequest(strategy)\`, \`closePullRequest\`, \`approvePullRequest\`, \`requestChangesPullRequest(body)\`, \`commentPullRequest(body)\`. Each wraps a single \`gh pr <verb>\` invocation; the existing \`runGhAction\` wrapper surfaces failures uniformly. Empty-body guards on request-changes / comment short-circuit before invoking gh so the user gets a clear error rather than a gh complaint.

## Helper module

\`inkPullRequestPanel.ts\` (new) holds the formatting helpers — check-status normalization, summary builders, glyph picker, state line — so the runtime renderer just maps over them. Matches the TUI cadence preference of separating helpers from runtime.

## Out of scope (follow-ups)

- **Multi-line input prompt** for review / comment bodies — currently single-line only. Acceptable for short reviews; long comments still open in the editor via the existing \`o\` flow.
- The slimmer \`provider.currentPullRequest\` shape (used by the global header glyph) stays untouched. The panel uses the dedicated \`pullRequest\` overview which fetches the full \`PullRequestInfo\`.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run test:jest\` 944/944 passing — 17 new for the panel helpers + 7 new for the action verbs + 2 new for the enriched data parser
- [x] \`npm run build\` clean
- [ ] Visual: from any view, press \`gp\` → PR panel renders with checks + reviews + body preview
- [ ] Visual: press \`m\` → strategy prompt → \`squash\` → y → \`Merged pull request\` status
- [ ] Visual: press \`c\` → comment body prompt → submit → comment posted
- [ ] Visual: PR panel under \`NO_COLOR=1\` and \`TERM=dumb\` (ASCII glyph fallbacks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)