### PR TITLE
feat(log-tui): multi-line input prompt for free-form text (#806)

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -1563,4 +1563,148 @@ describe('log Ink input interactions', () => {
       })
     })
   })
+
+  // Issue #806 — multi-line input prompt for free-form text. Enter
+  // inserts a newline; Ctrl+D submits (Unix EOF convention, more
+  // reliable than Ctrl+Enter across terminals/Ink). Esc and the
+  // existing backspace / Ctrl+U keys still work the same way.
+  describe('multi-line input prompt (#806)', () => {
+    function openMultilinePrompt(state = createLogInkState(rows)) {
+      return applyLogInkAction(state, {
+        type: 'openInputPrompt',
+        kind: 'pr-comment',
+        label: 'Comment body',
+        multiline: true,
+      })
+    }
+
+    it('Enter on a multi-line prompt inserts a newline instead of submitting', () => {
+      let state = openMultilinePrompt()
+      'lgtm'.split('').forEach((c) => { state = applyInput(state, c) })
+      const events = getLogInkInputEvents(state, '', { return: true })
+
+      // Enter dispatches an append-newline, not a submit. The prompt
+      // stays open so the user can keep typing.
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'appendInputPrompt', value: '\n' } },
+      ])
+      const next = applyInput(state, '', { return: true })
+      expect(next.inputPrompt).toBeDefined()
+      expect(next.inputPrompt?.value).toBe('lgtm\n')
+    })
+
+    it('Ctrl+D on a multi-line prompt submits the buffered text including newlines', () => {
+      let state = openMultilinePrompt()
+      'first line'.split('').forEach((c) => { state = applyInput(state, c) })
+      state = applyInput(state, '', { return: true })
+      'second line'.split('').forEach((c) => { state = applyInput(state, c) })
+
+      const events = getLogInkInputEvents(state, 'd', { ctrl: true })
+      expect(events).toEqual([
+        {
+          type: 'runWorkflowAction',
+          id: 'comment-pr',
+          payload: 'first line\nsecond line',
+        },
+        { type: 'action', action: { type: 'closeInputPrompt' } },
+      ])
+    })
+
+    it('Esc on a multi-line prompt cancels the same way as single-line', () => {
+      let state = openMultilinePrompt()
+      'wip'.split('').forEach((c) => { state = applyInput(state, c) })
+      const events = getLogInkInputEvents(state, '', { escape: true })
+      expect(events).toContainEqual({ type: 'action', action: { type: 'closeInputPrompt' } })
+      expect(events).toContainEqual({
+        type: 'action',
+        action: { type: 'setStatus', value: 'cancelled' },
+      })
+    })
+
+    it('Backspace on a multi-line prompt deletes a newline cleanly', () => {
+      let state = openMultilinePrompt()
+      'line1'.split('').forEach((c) => { state = applyInput(state, c) })
+      state = applyInput(state, '', { return: true })
+      expect(state.inputPrompt?.value).toBe('line1\n')
+      state = applyInput(state, '', { backspace: true })
+      // Backspace removes the trailing `\n`; the user is back to
+      // editing line 1.
+      expect(state.inputPrompt?.value).toBe('line1')
+    })
+
+    it('Ctrl+U on a multi-line prompt clears the entire buffer', () => {
+      let state = openMultilinePrompt()
+      'first\nsecond\nthird'.split('').forEach((c) => {
+        state = c === '\n'
+          ? applyInput(state, '', { return: true })
+          : applyInput(state, c)
+      })
+      expect(state.inputPrompt?.value).toBe('first\nsecond\nthird')
+      state = applyInput(state, 'u', { ctrl: true })
+      expect(state.inputPrompt?.value).toBe('')
+    })
+
+    it('Ctrl+D on an empty multi-line prompt surfaces the same hint as Enter on a single-line prompt', () => {
+      const state = openMultilinePrompt()
+      const events = getLogInkInputEvents(state, 'd', { ctrl: true })
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'setStatus', value: 'enter a value or press esc to cancel' } },
+      ])
+    })
+
+    it('PR comment + PR request-changes open the prompt in multi-line mode', () => {
+      // Comment body — c on the pull-request view.
+      const prState = createLogInkState(rows, { activeView: 'pull-request' })
+      const commentEvents = getLogInkInputEvents(prState, 'c')
+      expect(commentEvents[0]).toMatchObject({
+        type: 'action',
+        action: {
+          type: 'openInputPrompt',
+          kind: 'pr-comment',
+          multiline: true,
+        },
+      })
+
+      // Request-changes review — R on the pull-request view.
+      const requestEvents = getLogInkInputEvents(prState, 'R')
+      expect(requestEvents[0]).toMatchObject({
+        type: 'action',
+        action: {
+          type: 'openInputPrompt',
+          kind: 'pr-request-changes',
+          multiline: true,
+        },
+      })
+    })
+
+    it('keeps single-line prompts (create-branch, reset-mode, etc.) untouched', () => {
+      // Sanity check: opening a non-multiline prompt and pressing
+      // Enter still submits as before — the new dispatch path is
+      // strictly opt-in.
+      let state = applyLogInkAction(createLogInkState(rows), {
+        type: 'openInputPrompt',
+        kind: 'create-branch',
+        label: 'New branch name',
+      })
+      'feature/x'.split('').forEach((c) => { state = applyInput(state, c) })
+      const events = getLogInkInputEvents(state, '', { return: true })
+      expect(events).toEqual([
+        { type: 'runWorkflowAction', id: 'create-branch', payload: 'feature/x' },
+        { type: 'action', action: { type: 'closeInputPrompt' } },
+      ])
+    })
+
+    it('Ctrl+D on a single-line prompt does NOT submit (only multi-line uses it)', () => {
+      let state = applyLogInkAction(createLogInkState(rows), {
+        type: 'openInputPrompt',
+        kind: 'create-branch',
+        label: 'New branch name',
+      })
+      'feature/x'.split('').forEach((c) => { state = applyInput(state, c) })
+      const events = getLogInkInputEvents(state, 'd', { ctrl: true })
+      // Falls through to the `inputValue && !key.ctrl` guard which
+      // rejects ctrl-modified chars — empty events == nothing claimed.
+      expect(events).toEqual([])
+    })
+  })
 })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -388,6 +388,77 @@ function hasUnsavedComposeDraft(state: LogInkState): boolean {
   return Boolean(compose.summary.trim() || compose.body.trim())
 }
 
+/**
+ * Submit the active input prompt — used by Enter on single-line
+ * prompts and by Ctrl+D on multi-line prompts (#806). Most prompt
+ * kinds dispatch a workflow whose id matches the kind
+ * (`create-branch`, `rename-branch`, etc.). A few are exceptions:
+ *   - `reset-mode` (#777) collects soft/mixed/hard and forwards the
+ *     mode as the payload to `reset-to-commit`.
+ *   - `pr-merge-strategy` (#783) validates the strategy and routes to
+ *     `merge-pr` via the y-confirm path.
+ *   - `pr-comment` dispatches `comment-pr` directly — the body itself
+ *     is the affirmative action.
+ *   - `pr-request-changes` routes to `request-changes-pr` via
+ *     y-confirm because the review is publicly visible.
+ * Each exception validates here so a typo doesn't surface as a
+ * "workflow not yet wired" status downstream.
+ *
+ * Empty values yield a hint instead of a no-op so the user knows what
+ * to do — the same UX whether they pressed Enter (single-line) or
+ * Ctrl+D (multi-line).
+ */
+function submitInputPrompt(state: LogInkState): LogInkInputEvent[] {
+  if (!state.inputPrompt) return []
+  const value = state.inputPrompt.value.trim()
+  if (!value) {
+    return [action({ type: 'setStatus', value: 'enter a value or press esc to cancel' })]
+  }
+  if (state.inputPrompt.kind === 'reset-mode') {
+    const mode = value.toLowerCase()
+    if (mode !== 'soft' && mode !== 'mixed' && mode !== 'hard') {
+      return [action({
+        type: 'setStatus',
+        value: `Unknown reset mode: ${value}. Use soft, mixed, or hard.`,
+      })]
+    }
+    return [
+      { type: 'runWorkflowAction', id: 'reset-to-commit', payload: mode },
+      action({ type: 'closeInputPrompt' }),
+    ]
+  }
+  if (state.inputPrompt.kind === 'pr-merge-strategy') {
+    const strategy = value.toLowerCase()
+    if (strategy !== 'merge' && strategy !== 'squash' && strategy !== 'rebase') {
+      return [action({
+        type: 'setStatus',
+        value: `Unknown merge strategy: ${value}. Use merge, squash, or rebase.`,
+      })]
+    }
+    return [
+      action({ type: 'setPendingConfirmation', value: 'merge-pr', payload: strategy }),
+      action({ type: 'closeInputPrompt' }),
+    ]
+  }
+  if (state.inputPrompt.kind === 'pr-comment') {
+    return [
+      { type: 'runWorkflowAction', id: 'comment-pr', payload: value },
+      action({ type: 'closeInputPrompt' }),
+    ]
+  }
+  if (state.inputPrompt.kind === 'pr-request-changes') {
+    return [
+      action({ type: 'setPendingConfirmation', value: 'request-changes-pr', payload: value }),
+      action({ type: 'closeInputPrompt' }),
+    ]
+  }
+  const id = state.inputPrompt.kind
+  return [
+    { type: 'runWorkflowAction', id, payload: value },
+    action({ type: 'closeInputPrompt' }),
+  ]
+}
+
 export function getLogInkInputEvents(
   state: LogInkState,
   inputValue: string,
@@ -406,73 +477,26 @@ export function getLogInkInputEvents(
   // filter/confirmation/compose handlers so a prompt opened from inside
   // any of those still captures focus cleanly.
   if (state.inputPrompt) {
+    const isMultiline = Boolean(state.inputPrompt.multiline)
+
     if (key.escape) {
       return [
         action({ type: 'closeInputPrompt' }),
         action({ type: 'setStatus', value: 'cancelled' }),
       ]
     }
+    // Multi-line prompts (#806): Ctrl+D submits (Unix EOF convention,
+    // mirrors `git commit -m -` and HEREDOC patterns). Plain Enter
+    // inserts a newline so the user can compose review bodies / PR
+    // comments naturally without opening $EDITOR.
+    if (isMultiline && key.ctrl && inputValue === 'd') {
+      return submitInputPrompt(state)
+    }
+    if (isMultiline && key.return) {
+      return [action({ type: 'appendInputPrompt', value: '\n' })]
+    }
     if (key.return) {
-      const value = state.inputPrompt.value.trim()
-      if (!value) {
-        return [action({ type: 'setStatus', value: 'enter a value or press esc to cancel' })]
-      }
-      // Most prompt kinds dispatch a workflow whose id matches the
-      // kind (`create-branch`, `rename-branch`, etc.). A few are
-      // exceptions:
-      // - `reset-mode` collects soft/mixed/hard and forwards the mode
-      //   as the payload to `reset-to-commit` (#777).
-      // - `pr-merge-strategy` validates the strategy and routes to
-      //   `merge-pr` via the y-confirm path (#783).
-      // - `pr-comment` dispatches `comment-pr` directly — the body
-      //   itself is the affirmative action.
-      // - `pr-request-changes` routes to `request-changes-pr` via
-      //   y-confirm because the review is publicly visible.
-      // Each exception validates here so a typo doesn't surface as a
-      // "workflow not yet wired" status downstream.
-      if (state.inputPrompt.kind === 'reset-mode') {
-        const mode = value.toLowerCase()
-        if (mode !== 'soft' && mode !== 'mixed' && mode !== 'hard') {
-          return [action({
-            type: 'setStatus',
-            value: `Unknown reset mode: ${value}. Use soft, mixed, or hard.`,
-          })]
-        }
-        return [
-          { type: 'runWorkflowAction', id: 'reset-to-commit', payload: mode },
-          action({ type: 'closeInputPrompt' }),
-        ]
-      }
-      if (state.inputPrompt.kind === 'pr-merge-strategy') {
-        const strategy = value.toLowerCase()
-        if (strategy !== 'merge' && strategy !== 'squash' && strategy !== 'rebase') {
-          return [action({
-            type: 'setStatus',
-            value: `Unknown merge strategy: ${value}. Use merge, squash, or rebase.`,
-          })]
-        }
-        return [
-          action({ type: 'setPendingConfirmation', value: 'merge-pr', payload: strategy }),
-          action({ type: 'closeInputPrompt' }),
-        ]
-      }
-      if (state.inputPrompt.kind === 'pr-comment') {
-        return [
-          { type: 'runWorkflowAction', id: 'comment-pr', payload: value },
-          action({ type: 'closeInputPrompt' }),
-        ]
-      }
-      if (state.inputPrompt.kind === 'pr-request-changes') {
-        return [
-          action({ type: 'setPendingConfirmation', value: 'request-changes-pr', payload: value }),
-          action({ type: 'closeInputPrompt' }),
-        ]
-      }
-      const id = state.inputPrompt.kind
-      return [
-        { type: 'runWorkflowAction', id, payload: value },
-        action({ type: 'closeInputPrompt' }),
-      ]
+      return submitInputPrompt(state)
     }
     if (key.backspace || key.delete) {
       return [action({ type: 'backspaceInputPrompt' })]
@@ -1344,17 +1368,23 @@ export function getLogInkInputEvents(
     return [action({ type: 'setPendingConfirmation', value: 'approve-pr' })]
   }
   if (inputValue === 'R' && state.activeView === 'pull-request') {
+    // Free-form review body — multi-line so the reviewer can structure
+    // their feedback naturally without opening $EDITOR (#806).
     return [action({
       type: 'openInputPrompt',
       kind: 'pr-request-changes',
-      label: 'Request changes — review body',
+      label: 'Request changes — review body (Enter newline · Ctrl+D submit)',
+      multiline: true,
     })]
   }
   if (inputValue === 'c' && state.activeView === 'pull-request') {
+    // Free-form comment body — multi-line for the same reason as
+    // pr-request-changes.
     return [action({
       type: 'openInputPrompt',
       kind: 'pr-comment',
-      label: 'Comment body',
+      label: 'Comment body (Enter newline · Ctrl+D submit)',
+      multiline: true,
     })]
   }
 

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -4358,6 +4358,29 @@ function renderInputPromptPanel(
   if (!prompt) {
     return h(Box, { width })
   }
+
+  const accent = theme.noColor ? undefined : theme.colors.accent
+  // Multi-line prompts (#806) split on newline and render one Text
+  // row per buffer line — the cursor sits at the end of the last
+  // line via the trailing `_`. Single-line prompts collapse to the
+  // original one-row layout for muscle-memory continuity.
+  const promptLines = prompt.multiline ? prompt.value.split('\n') : [prompt.value]
+  if (promptLines.length === 0) {
+    promptLines.push('')
+  }
+  const valueRows = promptLines.map((line, index) => {
+    const isLast = index === promptLines.length - 1
+    const display = isLast ? `${line}_` : line
+    return h(Text, {
+      key: `prompt-line-${index}`,
+      bold: true,
+      color: accent,
+    }, truncate(display, width - 4))
+  })
+  const hint = prompt.multiline
+    ? 'Enter newline · Ctrl+d submit · Esc cancel · Ctrl+u clear'
+    : 'Enter submit · Esc cancel · Ctrl+u clear'
+
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
     borderStyle: theme.borderStyle,
@@ -4368,12 +4391,9 @@ function renderInputPromptPanel(
   h(Text, { bold: true }, panelTitle('Prompt', focused)),
   h(Text, { dimColor: true }, truncate(prompt.label, width - 4)),
   h(Text, undefined, ''),
-  h(Text, {
-    bold: true,
-    color: theme.noColor ? undefined : theme.colors.accent,
-  }, truncate(`${prompt.value}_`, width - 4)),
+  ...valueRows,
   h(Text, undefined, ''),
-  h(Text, { dimColor: true }, 'Enter to submit · Esc to cancel · Ctrl+u to clear'))
+  h(Text, { dimColor: true }, hint))
 }
 
 function renderConfirmationPanel(

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -232,6 +232,18 @@ export type LogInkInputPromptState = {
   kind: LogInkInputPromptKind
   label: string
   value: string
+  /**
+   * Free-form text mode (#806). When true:
+   *   - Enter inserts a literal newline into `value`
+   *   - Ctrl+D submits (Unix EOF convention — more reliable across
+   *     terminals + Ink than Ctrl+Enter, which most terminals
+   *     deliver as plain Enter)
+   *   - Backspace, Ctrl+U, Esc behave the same as single-line mode
+   * Opt-in per prompt — structured prompts (branch / tag / stash
+   * names, merge strategies, reset modes) stay single-line so muscle
+   * memory survives.
+   */
+  multiline?: boolean
 }
 
 export type LogInkAction =
@@ -291,7 +303,7 @@ export type LogInkAction =
   | { type: 'toggleCommandPalette' }
   | { type: 'cycleBranchSort' }
   | { type: 'cycleTagSort' }
-  | { type: 'openInputPrompt'; kind: LogInkInputPromptKind; label: string; initial?: string }
+  | { type: 'openInputPrompt'; kind: LogInkInputPromptKind; label: string; initial?: string; multiline?: boolean }
   | { type: 'appendInputPrompt'; value: string }
   | { type: 'backspaceInputPrompt' }
   | { type: 'clearInputPromptText' }
@@ -783,6 +795,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
           kind: action.kind,
           label: action.label,
           value: action.initial || '',
+          multiline: action.multiline,
         },
         pendingKey: undefined,
       }


### PR DESCRIPTION
Closes #806.

The PR action panel that landed in #805 left \`pr-comment\` and \`pr-request-changes\` reading from a single-line prompt — fine for branch names and merge strategies, painful for review bodies that legitimately span multiple lines.

## What changed

Add an opt-in \`multiline?: boolean\` flag to \`LogInkInputPromptState\` and the matching \`openInputPrompt\` action. When set:

| Key | Behavior |
|---|---|
| **Enter** | Inserts a literal \`\\n\` into \`value\` instead of submitting |
| **Ctrl+D** | Submits — Unix EOF convention, mirrors \`git commit -m -\` and HEREDOC patterns |
| **Esc** | Cancels (same as single-line) |
| **Backspace** | Deletes the last char including newlines (same as single-line) |
| **Ctrl+U** | Clears the entire buffer (same as single-line) |

Why **Ctrl+D** for submit instead of the issue's Ctrl+Enter / Esc Esc / Tab Enter ideas? Ctrl+Enter is unreliable across terminals — most terminals on Mac (and many Linux configurations) deliver Ctrl+Enter as plain Enter. Ctrl+D is the Unix-shell convention for \"end of input\" (HEREDOCs, \`git commit -m -\`, REPL exits) so it carries muscle memory for the user demographic this targets, and Ink delivers it reliably as \`key.ctrl + inputValue === 'd'\`.

## Opt-in only

The two PR action panel prompts that need long-form text get the flag:

- \`pr-comment\` → \`multiline: true\`
- \`pr-request-changes\` → \`multiline: true\`

Everything else stays single-line so muscle memory survives:

- \`create-branch\`, \`create-tag\`, \`create-stash\`, \`rename-branch\`, \`set-upstream\` — short structured names
- \`reset-mode\` — soft / mixed / hard
- \`pr-merge-strategy\` — merge / squash / rebase

## Refactor

Extracted submit logic into a module-level \`submitInputPrompt(state)\` helper so the single-line Enter path and the multi-line Ctrl+D path share the same dispatch flow — including the existing kind-specific routing (reset-mode → reset-to-commit, pr-merge-strategy → merge-pr, etc.). Cleaner than duplicating the switch.

## Renderer

\`renderInputPromptOverlay\` splits \`value\` on \`\\n\` and paints one Text row per line. Cursor glyph (\`_\`) sits at the end of the last row. Single-line prompts collapse to the original one-row layout — no visual change for them. Footer hint switches per mode so the discoverable submit shortcut is always visible.

## Out of scope (deferred follow-ups)

The issue mentioned a richer cursor-navigation surface; those land in a follow-up:

- Arrow-key cursor navigation within the buffer (Home / End / ← / →)
- Cancel-with-confirmation when text has been entered
- Scroll if the buffer overruns the available prompt overlay height

The minimum viable v1 here addresses the acute pain (typing review bodies) — append-only multi-line editing with a clean submit shortcut.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run test:jest\` 1017/1017 — 9 new tests for multi-line dispatch
- [x] \`npm run build\` clean
- [ ] Visual: \`gp\` → PR panel → \`c\` → comment prompt opens with the new label hint → type two lines separated by Enter → Ctrl+D submits
- [ ] Visual: same flow on \`R\` (request changes)
- [ ] Visual: \`+\` on the branches view → create-branch prompt still single-line, Enter still submits

🤖 Generated with [Claude Code](https://claude.com/claude-code)