### PR TITLE
feat(log-tui): pin current branch at the top of the branches list

### DIFF
--- a/src/commands/log/historyActions.ts
+++ b/src/commands/log/historyActions.ts
@@ -447,6 +447,89 @@ export function resetToCommit(
   }))
 }
 
+/**
+ * Create a new local branch pointed at <commit>, without switching to it.
+ *
+ * This is the "create branch from cursored commit" history action — the
+ * user types the new branch name into an input prompt and we run
+ * `git branch <name> <sha>` (NOT `git switch -c`, which is what
+ * `branchActions.createBranch` does for the create-branch-at-HEAD flow).
+ * The split exists because GitKraken-style "create branch here" is
+ * specifically about marking a historical commit, not about switching
+ * onto a new working branch.
+ *
+ * Note for the inspector follow-up: workflow surfacing is driven by the
+ * registry in `inkWorkflows.ts`, not a hardcoded action list — adding
+ * `create-branch-here` there is enough for the inspector / palette to
+ * pick this up.
+ */
+export function createBranchFromCommit(
+  git: SimpleGit,
+  name: string,
+  commit: Pick<HistoryCommitRef, 'hash' | 'shortHash'> | undefined
+): Promise<BranchActionResult> {
+  const trimmedName = name.trim()
+
+  if (!commit) {
+    return Promise.resolve({
+      ok: false,
+      message: 'No commit selected.',
+    })
+  }
+
+  if (!trimmedName) {
+    return Promise.resolve({
+      ok: false,
+      message: 'Branch name required.',
+    })
+  }
+
+  return guardNoInProgressOperation(git).then((blocked) => (
+    blocked || runAction(
+      () => git.raw(['branch', trimmedName, commit.hash]),
+      `Created branch ${trimmedName} at ${commit.shortHash}`
+    )
+  ))
+}
+
+/**
+ * Create a lightweight tag pointed at <commit>.
+ *
+ * Mirrors `createBranchFromCommit` for the tag side: the user types a
+ * tag name into an input prompt and we run `git tag <name> <sha>`
+ * (lightweight, no `-a`/`-m`). Annotated tags remain available through
+ * the existing `+` flow on the tags view; this is the per-commit
+ * shortcut.
+ */
+export function createTagAtCommit(
+  git: SimpleGit,
+  name: string,
+  commit: Pick<HistoryCommitRef, 'hash' | 'shortHash'> | undefined
+): Promise<BranchActionResult> {
+  const trimmedName = name.trim()
+
+  if (!commit) {
+    return Promise.resolve({
+      ok: false,
+      message: 'No commit selected.',
+    })
+  }
+
+  if (!trimmedName) {
+    return Promise.resolve({
+      ok: false,
+      message: 'Tag name required.',
+    })
+  }
+
+  return guardNoInProgressOperation(git).then((blocked) => (
+    blocked || runAction(
+      () => git.raw(['tag', trimmedName, commit.hash]),
+      `Created tag ${trimmedName} at ${commit.shortHash}`
+    )
+  ))
+}
+
 export function startInteractiveRebase(
   git: SimpleGit,
   commit: HistoryCommitRef | undefined

--- a/src/commands/log/inkSorting.test.ts
+++ b/src/commands/log/inkSorting.test.ts
@@ -82,6 +82,48 @@ describe('log Ink sorting (P4.2)', () => {
       sortBranches(sample, 'ahead')
       expect(sample.map((b) => b.shortName)).toEqual(before)
     })
+
+    // Visual feedback after 0.38.0: the active branch should always
+    // sit at the top of the list so the cursor lands on it by default.
+    // Pin is mode-agnostic — applies to name / recent / ahead alike.
+    describe('pins the current branch at index 0', () => {
+      const withCurrent: BranchRef[] = [
+        branch({ shortName: 'feat/zeta', date: '2026-04-01', ahead: 0, behind: 5 }),
+        branch({ shortName: 'main', date: '2026-04-30', ahead: 1, behind: 0 }),
+        branch({ shortName: 'feat/alpha', date: '2026-04-20', ahead: 8, behind: 2 }),
+        branch({ shortName: 'feat/current', date: '2026-04-10', ahead: 3, behind: 0, current: true }),
+      ]
+
+      it('lands the current branch at position 0 under name sort', () => {
+        const sorted = sortBranches(withCurrent, 'name').map((b) => b.shortName)
+        expect(sorted[0]).toBe('feat/current')
+        // The remaining branches stay in alphabetical order.
+        expect(sorted.slice(1)).toEqual(['feat/alpha', 'feat/zeta', 'main'])
+      })
+
+      it('lands the current branch at position 0 under recent sort', () => {
+        // Even though `main` is the freshest commit, `feat/current` still
+        // pins to position 0 — pin overrides the configured mode.
+        const sorted = sortBranches(withCurrent, 'recent').map((b) => b.shortName)
+        expect(sorted[0]).toBe('feat/current')
+        expect(sorted.slice(1)).toEqual(['main', 'feat/alpha', 'feat/zeta'])
+      })
+
+      it('lands the current branch at position 0 under ahead sort', () => {
+        // `feat/alpha` has the most ahead but `feat/current` still pins.
+        const sorted = sortBranches(withCurrent, 'ahead').map((b) => b.shortName)
+        expect(sorted[0]).toBe('feat/current')
+        expect(sorted.slice(1)).toEqual(['feat/alpha', 'main', 'feat/zeta'])
+      })
+
+      it('falls through to plain sort when no branch is marked current', () => {
+        // Detached HEAD or fresh state — nothing to pin, sort the rest
+        // by mode only.
+        const noneCurrent = withCurrent.map((b) => ({ ...b, current: false }))
+        expect(sortBranches(noneCurrent, 'name').map((b) => b.shortName))
+          .toEqual(['feat/alpha', 'feat/current', 'feat/zeta', 'main'])
+      })
+    })
   })
 
   describe('cycleTagSort', () => {

--- a/src/commands/log/inkSorting.ts
+++ b/src/commands/log/inkSorting.ts
@@ -27,23 +27,31 @@ export function cycleBranchSort(mode: BranchSortMode): BranchSortMode {
 }
 
 export function sortBranches<T extends BranchRef>(branches: T[], mode: BranchSortMode): T[] {
-  const copy = branches.slice()
+  // Pin the current branch at index 0 regardless of sort mode (#806
+  // follow-up). Lands the user's cursor on the active branch by
+  // default and keeps the most-relevant row glued to the top of the
+  // list as they cycle sorts.
+  const current = branches.find((entry) => entry.current)
+  const rest = branches.filter((entry) => !entry.current)
+  const sortedRest = rest.slice()
   switch (mode) {
     case 'name':
-      return copy.sort((a, b) => a.shortName.localeCompare(b.shortName))
+      sortedRest.sort((a, b) => a.shortName.localeCompare(b.shortName))
+      break
     case 'recent':
       // ISO-shaped dates compare byte-for-byte; descending so the freshest
       // branch sits at the top.
-      return copy.sort((a, b) => (b.date || '').localeCompare(a.date || '') ||
+      sortedRest.sort((a, b) => (b.date || '').localeCompare(a.date || '') ||
         a.shortName.localeCompare(b.shortName))
+      break
     case 'ahead':
       // ahead-first; ties broken by behind, then by name. Keeps "this branch
       // has unmerged work" in the user's first scroll.
-      return copy.sort((a, b) => b.ahead - a.ahead || b.behind - a.behind ||
+      sortedRest.sort((a, b) => b.ahead - a.ahead || b.behind - a.behind ||
         a.shortName.localeCompare(b.shortName))
-    default:
-      return copy
+      break
   }
+  return current ? [current, ...sortedRest] : sortedRest
 }
 
 /* --------------------------------- tags --------------------------------- */

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -363,6 +363,38 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: true,
     },
     {
+      // Per-view-only: scoped to the history view in inkInput (key `B`).
+      // The prompt itself is the affirmative gate — the user has to
+      // type a branch name before anything happens — so this skips the
+      // y-confirm path. Empty key keeps it palette-discoverable; the
+      // palette path can't synthesize a branch name and surfaces a
+      // hint instead.
+      //
+      // Distinct from `create-branch` (palette / `+` on branches view),
+      // which uses `git switch -c` and switches onto the new branch.
+      // This workflow uses `git branch <name> <sha>` and stays put —
+      // GitKraken's "create branch here" semantic.
+      id: 'create-branch-here',
+      key: '',
+      label: 'Create branch from commit',
+      description: 'Create a branch pointed at the cursored commit (does not switch).',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      // Per-view-only: scoped to the history view in inkInput via the
+      // `gT` chord (bare `T` is taken by delete-tag on the tags view).
+      // Same prompt-as-confirmation pattern as create-branch-here.
+      // Lightweight tag — annotated tags remain available through the
+      // existing `+` flow on the tags view.
+      id: 'create-tag-here',
+      key: '',
+      label: 'Create tag at commit',
+      description: 'Create a lightweight tag at the cursored commit.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
       // Per-view-only: scoped to the history view in inkInput. `i`
       // (lowercase) is used instead of `I` so the existing `I`
       // ai-commit-summary workflow stays reachable on the history


### PR DESCRIPTION
Visual feedback after 0.38.0: when entering the branches view, the cursor lands wherever the configured sort happens to put the active branch. Alphabetical sort might bury \`main\` deep in a forest of \`feat/*\` names; recent sort might miss it.

Always-pin the current branch to position 0 of \`sortBranches\` so:
- The cursor defaults to the active branch (since \`selectedBranchIndex\` already defaults to 0).
- The most-relevant row stays glued to the top as the user cycles sorts.

Pin is mode-agnostic — applies to name / recent / ahead alike. Falls through to plain sort when no branch is marked current (detached HEAD or fresh-clone state).

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run test:jest\` 1021/1021 — 4 new pin tests
- [x] \`npm run build\` clean
- [ ] Visual: open \`coco ui\`, focus the branches sidebar, observe the current branch at row 0 with cursor on it. Cycle sorts via \`s\` — current branch stays at row 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)