### PR TITLE
feat(log-tui): redesign inspector with per-entity action list

### DIFF
--- a/src/commands/log/inkInspectorActions.test.ts
+++ b/src/commands/log/inkInspectorActions.test.ts
@@ -1,0 +1,119 @@
+import {
+  InspectorActionContext,
+  getInspectorActions,
+} from './inkInspectorActions'
+
+describe('inspector actions', () => {
+  describe('history-commit', () => {
+    const actions = getInspectorActions('history-commit')
+
+    it('exposes the per-commit action set', () => {
+      const keys = actions.map((action) => action.key)
+      expect(keys).toEqual(
+        expect.arrayContaining(['enter', 'c', 'R', 'Z', 'i', 'y', 'Y', 'O'])
+      )
+    })
+
+    it('marks revert / reset / interactive-rebase as destructive', () => {
+      const destructive = actions
+        .filter((action) => action.destructive)
+        .map((action) => action.key)
+      expect(destructive).toEqual(expect.arrayContaining(['R', 'Z', 'i']))
+    })
+
+    it('does not mark cherry-pick or yank as destructive', () => {
+      const cherryPick = actions.find((action) => action.key === 'c')
+      const yank = actions.find((action) => action.key === 'y')
+      expect(cherryPick?.destructive).toBeFalsy()
+      expect(yank?.destructive).toBeFalsy()
+    })
+
+    it('places open-diff first so the primary action is at the top', () => {
+      expect(actions[0]).toMatchObject({ key: 'enter', label: expect.stringMatching(/diff/i) })
+    })
+  })
+
+  describe('branch', () => {
+    const actions = getInspectorActions('branch')
+
+    it('exposes the per-branch action set', () => {
+      const keys = actions.map((action) => action.key)
+      expect(keys).toEqual(
+        expect.arrayContaining(['enter', '+', 'R', 'u', 'D', 'P', 'F', 'y'])
+      )
+    })
+
+    it('marks delete as destructive', () => {
+      const destructive = actions
+        .filter((action) => action.destructive)
+        .map((action) => action.key)
+      expect(destructive).toEqual(['D'])
+    })
+  })
+
+  describe('tag', () => {
+    const actions = getInspectorActions('tag')
+
+    it('exposes the per-tag action set', () => {
+      const keys = actions.map((action) => action.key)
+      expect(keys).toEqual(expect.arrayContaining(['+', 'P', 'T', 'R', 'y']))
+    })
+
+    it('marks delete (T) and delete-remote (R) as destructive', () => {
+      const destructive = actions
+        .filter((action) => action.destructive)
+        .map((action) => action.key)
+      expect(destructive).toEqual(expect.arrayContaining(['T', 'R']))
+      expect(destructive).not.toContain('+')
+      expect(destructive).not.toContain('P')
+    })
+  })
+
+  describe('stash', () => {
+    const actions = getInspectorActions('stash')
+
+    it('exposes the per-stash action set', () => {
+      const keys = actions.map((action) => action.key)
+      expect(keys).toEqual(expect.arrayContaining(['enter', 'a', 'p', 'X', 'y']))
+    })
+
+    it('marks drop (X) as destructive but apply / pop as non-destructive', () => {
+      const destructive = actions
+        .filter((action) => action.destructive)
+        .map((action) => action.key)
+      expect(destructive).toEqual(['X'])
+    })
+  })
+
+  describe('worktree', () => {
+    const actions = getInspectorActions('worktree')
+
+    it('exposes the per-worktree action set', () => {
+      const keys = actions.map((action) => action.key)
+      expect(keys).toEqual(expect.arrayContaining(['W', 'y']))
+    })
+
+    it('marks remove (W) as destructive', () => {
+      const destructive = actions
+        .filter((action) => action.destructive)
+        .map((action) => action.key)
+      expect(destructive).toEqual(['W'])
+    })
+  })
+
+  it('every action has a non-empty key and label', () => {
+    const contexts: InspectorActionContext[] = [
+      'history-commit',
+      'branch',
+      'tag',
+      'stash',
+      'worktree',
+    ]
+    for (const context of contexts) {
+      for (const action of getInspectorActions(context)) {
+        expect(action.key.length).toBeGreaterThan(0)
+        expect(action.label.length).toBeGreaterThan(0)
+      }
+    }
+  })
+})

--- a/src/commands/log/inkInspectorActions.ts
+++ b/src/commands/log/inkInspectorActions.ts
@@ -1,0 +1,107 @@
+/**
+ * Hardcoded per-entity action lists surfaced inside the right-hand
+ * inspector panel. The inspector used to repeat the repo / branch /
+ * status content the top header and left sidebar already show; we drop
+ * that trailer in favor of an actionable cheat-sheet so the user knows
+ * exactly which keystrokes apply to whatever they have under the cursor.
+ *
+ * Why hardcoded instead of introspecting `LOG_INK_KEY_BINDINGS`:
+ *   - Most per-entity actions live in `inkInput.ts` as direct keystroke
+ *     handlers (e.g. `c` cherry-pick, `R` revert) rather than as
+ *     globally-registered bindings, so the registry would be a partial
+ *     view at best.
+ *   - The bindings registry's `contexts` model (normal / search / focus
+ *     name) does not cleanly map to inspector entity types like "branch"
+ *     or "tag". Filtering it would mean replicating the same per-view
+ *     scoping logic the input dispatcher already encodes.
+ *   - New per-entity actions are added infrequently — the maintenance
+ *     cost of mirroring them here is low and keeps this file the single
+ *     source of truth for "what shows in the inspector".
+ *
+ * If you wire up a new per-entity keystroke in `inkInput.ts` — for
+ * example a "create branch from this commit" or "create tag from this
+ * commit" action — add the matching row to the relevant array below so
+ * it shows up in the inspector automatically.
+ */
+
+export type InspectorAction = {
+  /** Key label shown in the inspector. Use the literal keystroke
+   *  (`c`, `R`, `gp`, `enter`). */
+  key: string
+  /** Human-readable description of what the keystroke does. */
+  label: string
+  /** Marks irreversible / destructive ops so the inspector can paint
+   *  them with `theme.colors.danger` and a `[!]` marker. */
+  destructive?: boolean
+}
+
+export type InspectorActionContext =
+  | 'history-commit'
+  | 'branch'
+  | 'tag'
+  | 'stash'
+  | 'worktree'
+
+const HISTORY_COMMIT_ACTIONS: InspectorAction[] = [
+  { key: 'enter', label: 'Open diff' },
+  { key: 'c', label: 'Cherry-pick' },
+  { key: 'R', label: 'Revert', destructive: true },
+  { key: 'Z', label: 'Reset to commit', destructive: true },
+  { key: 'i', label: 'Interactive rebase', destructive: true },
+  { key: 'y', label: 'Yank hash' },
+  { key: 'Y', label: 'Yank short hash' },
+  { key: 'O', label: 'Open in browser' },
+]
+
+const BRANCH_ACTIONS: InspectorAction[] = [
+  { key: 'enter', label: 'Checkout' },
+  { key: '+', label: 'New branch' },
+  { key: 'R', label: 'Rename' },
+  { key: 'u', label: 'Set upstream' },
+  { key: 'D', label: 'Delete', destructive: true },
+  { key: 'P', label: 'Push current' },
+  { key: 'F', label: 'Fetch all' },
+  { key: 'y', label: 'Yank name' },
+]
+
+const TAG_ACTIONS: InspectorAction[] = [
+  { key: '+', label: 'New tag' },
+  { key: 'P', label: 'Push tag' },
+  { key: 'T', label: 'Delete', destructive: true },
+  { key: 'R', label: 'Delete remote', destructive: true },
+  { key: 'y', label: 'Yank name' },
+]
+
+const STASH_ACTIONS: InspectorAction[] = [
+  { key: 'enter', label: 'Open diff' },
+  { key: 'a', label: 'Apply' },
+  { key: 'p', label: 'Pop' },
+  { key: 'X', label: 'Drop', destructive: true },
+  { key: 'y', label: 'Yank ref' },
+]
+
+const WORKTREE_ACTIONS: InspectorAction[] = [
+  { key: 'W', label: 'Remove', destructive: true },
+  { key: 'y', label: 'Yank path' },
+]
+
+export function getInspectorActions(
+  context: InspectorActionContext
+): InspectorAction[] {
+  switch (context) {
+    case 'history-commit':
+      return HISTORY_COMMIT_ACTIONS
+    case 'branch':
+      return BRANCH_ACTIONS
+    case 'tag':
+      return TAG_ACTIONS
+    case 'stash':
+      return STASH_ACTIONS
+    case 'worktree':
+      return WORKTREE_ACTIONS
+    default: {
+      const exhaustive: never = context
+      throw new Error(`Unhandled inspector action context: ${String(exhaustive)}`)
+    }
+  }
+}

--- a/src/commands/log/inkLayout.test.ts
+++ b/src/commands/log/inkLayout.test.ts
@@ -14,7 +14,8 @@ describe('log Ink layout', () => {
     expect(layout.tooSmall).toBe(false)
     expect(layout.bodyRows).toBe(19)
     expect(layout.sidebarWidth).toBe(22)
-    expect(layout.detailWidth).toBe(30)
+    // 80 * 0.28 = 22.4 → floor 22 → clamped up to the 26-cell minimum
+    expect(layout.detailWidth).toBe(26)
   })
 
   it('uses a balanced layout at the default terminal size', () => {
@@ -23,7 +24,8 @@ describe('log Ink layout', () => {
     expect(layout.tooSmall).toBe(false)
     expect(layout.bodyRows).toBe(35)
     expect(layout.sidebarWidth).toBe(28)
-    expect(layout.detailWidth).toBe(40)
+    // 120 * 0.28 = 33.6 → floor 33
+    expect(layout.detailWidth).toBe(33)
   })
 
   it('caps side panel widths on wide terminals', () => {
@@ -32,7 +34,16 @@ describe('log Ink layout', () => {
     expect(layout.tooSmall).toBe(false)
     expect(layout.bodyRows).toBe(55)
     expect(layout.sidebarWidth).toBe(34)
-    expect(layout.detailWidth).toBe(56)
+    // 200 * 0.28 = 56 → clamped down to the 44-cell maximum
+    expect(layout.detailWidth).toBe(44)
+  })
+
+  it('clamps the inspector to its 26-44 cell range', () => {
+    const tiny = getLogInkLayout({ columns: 80, rows: 24 })
+    const huge = getLogInkLayout({ columns: 400, rows: 80 })
+
+    expect(tiny.detailWidth).toBe(26)
+    expect(huge.detailWidth).toBe(44)
   })
 
   it('reports terminals below the minimum as too small', () => {

--- a/src/commands/log/inkLayout.ts
+++ b/src/commands/log/inkLayout.ts
@@ -34,7 +34,12 @@ export const LOG_INK_DEFAULT_ROWS = 40
 export function getLogInkLayout(input: LogInkLayoutInput): LogInkLayout {
   const columns = input.columns || LOG_INK_DEFAULT_COLUMNS
   const rows = input.rows || LOG_INK_DEFAULT_ROWS
-  const detailWidth = Math.max(30, Math.min(56, Math.floor(columns * 0.34)))
+  // Inspector width — 26-44 cells (~28% of width). Narrowed from the
+  // earlier 30-56 range when the inspector dropped its duplicative
+  // workflows trailer (repo / branch / status — all already visible in
+  // the top header and left sidebar). The reclaimed columns go to the
+  // commit graph in the main panel.
+  const detailWidth = Math.max(26, Math.min(44, Math.floor(columns * 0.28)))
   // Sidebar at rest: 22-34 cells (~24% of width). Focused: 32-50 cells
   // (~36% of width). The transition is instant per render — focus tab to
   // expand, focus away to collapse.

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -203,8 +203,12 @@ import {
 import { TagOverview, getTagOverview } from './tagData'
 import {
   getLogInkWorkflowActionById,
-  getLogInkWorkflowSections,
 } from './inkWorkflows'
+import {
+  InspectorAction,
+  InspectorActionContext,
+  getInspectorActions,
+} from './inkInspectorActions'
 import { WorktreeOverview as WorktreeListOverview, getWorktreeListOverview } from './worktreeData'
 import { WorktreeFileDiff, getWorktreeFileDiff } from './worktreeDiffData'
 import { canStartLogInkTui, getLogInkRenderOptions } from './inkTerminal'
@@ -3815,7 +3819,7 @@ function renderHistoryInspector(
   components: LogInkComponents,
   state: LogInkState,
   context: LogInkContext,
-  contextStatus: LogInkContextStatus,
+  _contextStatus: LogInkContextStatus,
   detail: GitCommitDetail | undefined,
   loading: boolean,
   _filePreview: GitCommitFilePreview | undefined,
@@ -3826,11 +3830,6 @@ function renderHistoryInspector(
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const selected = getSelectedInkCommit(state)
-  const workflowSections = getLogInkWorkflowSections({
-    ...context,
-    contextLoading: isLogInkContextLoading(contextStatus),
-    selectedCommit: selected,
-  })
 
   if (!detail) {
     const fallbackLines = [
@@ -3849,7 +3848,8 @@ function renderHistoryInspector(
     ...fallbackLines.map((line, index) => h(Text, {
       key: `detail-${index}`,
       dimColor: index > 1,
-    }, truncate(line, width - 4))))
+    }, truncate(line, width - 4))),
+    ...renderInspectorActionsSection(h, Text, 'history-commit', width, theme))
   }
 
   const statLine = `${detail.stats.filesChanged} files  +${detail.stats.insertions}/-${detail.stats.deletions}`
@@ -3865,18 +3865,26 @@ function renderHistoryInspector(
     ? renderInspectorRefs(h, Text, detail.refs, repository)
     : null
 
+  // Inspector reorder (PR — drop duplicative Workflows trailer):
+  //  1. Commit message (the headline of what you're looking at)
+  //  2. Metadata (hash / author / date / refs / stats)
+  //  3. Body preview (up to 8 lines now that the trailer is gone)
+  //  4. Changed files list (cursored entry highlights)
+  //  5. Actions cheat-sheet (per-entity keystrokes; destructive marked)
+  // The Workflows: trailer that used to repeat the repo / branch /
+  // status from the top header and left sidebar is intentionally gone.
   const headerNodes: ReactTypes.ReactElement[] = [
     h(Text, { key: 'detail-msg' }, truncate(detail.message, width - 4)),
     h(Text, { key: 'detail-spacer-1' }, ''),
     h(Text, { key: 'detail-commit', dimColor: true }, 'Commit: ', commitLink),
     h(Text, { key: 'detail-author', dimColor: true }, truncate(`Author: ${detail.author}`, width - 4)),
-    h(Text, { key: 'detail-date', dimColor: true }, truncate(`Date: ${detail.date}`, width - 4)),
+    h(Text, { key: 'detail-date', dimColor: true }, truncate(`Date:   ${detail.date}`, width - 4)),
     refNodes
-      ? h(Text, { key: 'detail-refs', dimColor: true }, 'Refs: ', ...refNodes)
-      : h(Text, { key: 'detail-refs', dimColor: true }, 'Refs: none'),
-    h(Text, { key: 'detail-stat', dimColor: true }, truncate(statLine, width - 4)),
+      ? h(Text, { key: 'detail-refs', dimColor: true }, 'Refs:   ', ...refNodes)
+      : h(Text, { key: 'detail-refs', dimColor: true }, 'Refs:   none'),
+    h(Text, { key: 'detail-stat', dimColor: true }, truncate(`Stats:  ${statLine}`, width - 4)),
     h(Text, { key: 'detail-spacer-2' }, ''),
-    ...(detail.body ? detail.body.split('\n').slice(0, 6) : ['No commit body.']).map((line, index) =>
+    ...(detail.body ? detail.body.split('\n').slice(0, 8) : ['No commit body.']).map((line, index) =>
       h(Text, {
         key: `detail-body-${index}`,
         dimColor: true,
@@ -3891,15 +3899,6 @@ function renderHistoryInspector(
     h, Text, detail.files, state.selectedFileIndex, focused, fileListMaxRows, width, theme
   )
 
-  const trailerLines = [
-    '',
-    'Workflows:',
-    ...workflowSections.flatMap((section) => [
-      section.title,
-      ...section.lines.slice(0, 3).map((line) => `  ${line}`),
-    ]).slice(0, 12),
-  ]
-
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
     borderStyle: theme.borderStyle,
@@ -3910,10 +3909,67 @@ function renderHistoryInspector(
   h(Text, { bold: true }, panelTitle('Inspector', focused)),
   ...headerNodes,
   ...fileListNodes,
-  ...trailerLines.map((line, index) => h(Text, {
-    key: `detail-trailer-${index}`,
-    dimColor: index > 0,
-  }, truncate(line, width - 4))))
+  ...renderInspectorActionsSection(h, Text, 'history-commit', width, theme))
+}
+
+/**
+ * Render the trailing "Actions:" section that surfaces which keystrokes
+ * apply to whatever the inspector is focused on. Keys are colored with
+ * `theme.colors.accent` so they pop as the actionable element. Destructive
+ * actions get the danger color plus a `[!]` marker so they don't blend
+ * into the cherry-pick / yank rows.
+ *
+ * Truncates labels when the inspector is narrow (down to the 26-cell
+ * minimum from `getLogInkLayout`) so an overflowing label never wraps and
+ * collides with the next row.
+ */
+function renderInspectorActionsSection(
+  h: typeof ReactTypes.createElement,
+  Text: LogInkComponents['Text'],
+  context: InspectorActionContext,
+  width: number,
+  theme: LogInkTheme
+): ReactTypes.ReactElement[] {
+  const actions = getInspectorActions(context)
+  if (!actions.length) return []
+
+  // Width budget for each row: subtract padding + " " gutter, the key
+  // column (left-padded to 5 cells so labels align), the "  " gap
+  // between key and label, and the optional "  [!]" suffix (5 cells).
+  const KEY_COLUMN = 5
+  const GAP = '  '
+  const DESTRUCTIVE_SUFFIX = '  [!]'
+  const labelBudget = Math.max(
+    4,
+    width - 4 /* border + padX */ - KEY_COLUMN - GAP.length - DESTRUCTIVE_SUFFIX.length
+  )
+
+  const nodes: ReactTypes.ReactElement[] = [
+    h(Text, { key: 'actions-spacer' }, ''),
+    h(Text, { key: 'actions-title' }, 'Actions:'),
+    ...actions.map((action: InspectorAction, index) => {
+      const keyCell = action.key.padEnd(KEY_COLUMN)
+      const label = truncate(action.label, labelBudget)
+      const children: Array<string | ReactTypes.ReactElement> = [
+        h(Text, {
+          key: `actions-${index}-key`,
+          color: action.destructive ? theme.colors.danger : theme.colors.accent,
+        }, keyCell),
+        GAP,
+        label,
+      ]
+      if (action.destructive) {
+        children.push(h(Text, {
+          key: `actions-${index}-mark`,
+          color: theme.colors.danger,
+          dimColor: false,
+        }, DESTRUCTIVE_SUFFIX))
+      }
+      return h(Text, { key: `actions-${index}` }, ...children)
+    }),
+  ]
+
+  return nodes
 }
 
 /**


### PR DESCRIPTION
## Summary

Visual feedback after 0.38.0 shipped: the right-hand inspector duplicated content already shown in the top header (repo + branch) and left sidebar (status), eating width that should belong to the commit graph. This PR reclaims the inspector for commit-context info plus an action cheat-sheet, and narrows it so the graph gets more room.

- **Drop the `Workflows:` trailer entirely.** The repo / branch / status / tags / stashes / worktrees / operation / AI section data it was repeating already lives in the header and sidebar.
- **Add an `Actions:` section.** Hardcoded per-entity action list lives in the new `inkInspectorActions.ts` module. Destructive ops (`R` revert, `Z` reset, `i` interactive-rebase on history-commit; `D` delete, `T` delete-tag, `R` delete-remote-tag, `X` drop-stash, `W` remove-worktree elsewhere) are painted with `theme.colors.danger` and a `[!]` suffix; non-destructive ops use `theme.colors.accent` for the key letter.
- **Narrow the inspector** from `max(30, min(56, cols * 0.34))` → `max(26, min(44, cols * 0.28))`. The reclaimed cells flow into `mainPanelWidth` automatically. Labels in the action list truncate at the narrowest case (26 cells) so a long entry never wraps.
- **Reorder the inspector body** to message → metadata → body (bumped 6→8 lines now that the trailer is gone) → changed files → actions, with the metadata column-aligned (`Commit:` / `Author:` / `Date:   ` / `Refs:   ` / `Stats:  `).

The action helper covers history-commit / branch / tag / stash / worktree contexts so a follow-up PR can wire the same surface into the dedicated branches / tags / stash / worktree views (out of scope here — the history view is the only one with the inspector today). A comment at the top of `inkInspectorActions.ts` flags that any new per-entity keystroke added in `inkInput.ts` should also be added to the matching array so the inspector picks it up.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run test:jest` — 110 suites / 1031 tests pass (run with explicit `--rootDir` since this PR is built from a worktree under `.claude/worktrees/`)
- [x] `npm run build` produces clean dual CJS/ESM output
- [ ] Manual TUI smoke: open `coco log -i` on a real repo, confirm the action list renders for the cursored commit, destructive marker shows, narrowing leaves the graph more room

🤖 Generated with [Claude Code](https://claude.com/claude-code)