### PR TITLE
feat(log-tui): branch / tag selection auto-jumps the history view

### DIFF
--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -1122,6 +1122,75 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
   }, [git, selected?.hash])
 
+  // #806 follow-up — auto-jump the history view to whichever branch /
+  // tag the user is currently cursoring in the sidebar (or the
+  // dedicated branches / tags view). Debounced so cursor-scrolling
+  // through a long branch list doesn't dispatch on every keystroke.
+  // No-op when the cursored ref's tip isn't in the loaded commit
+  // window (under compact mode the cursored branch's tip may not be
+  // fetched yet); a status hint surfaces in that case so the user
+  // knows to toggle full graph or load older commits.
+  React.useEffect(() => {
+    const onBranchTab = state.activeView === 'branches' ||
+      (state.focus === 'sidebar' && state.sidebarTab === 'branches')
+    const onTagTab = state.activeView === 'tags' ||
+      (state.focus === 'sidebar' && state.sidebarTab === 'tags')
+    if (!onBranchTab && !onTagTab) return
+
+    let cancelled = false
+    const timer = setTimeout(() => {
+      if (cancelled) return
+      let targetHash: string | undefined
+      let targetLabel: string | undefined
+
+      if (onBranchTab) {
+        const all = sortBranches(context.branches?.localBranches || [], state.branchSort)
+        const visible = state.filter
+          ? all.filter((b) => matchesPromotedFilter([b.shortName, b.upstream || ''], state.filter))
+          : all
+        const branch = visible[Math.min(state.selectedBranchIndex, Math.max(0, visible.length - 1))]
+        if (branch) {
+          targetHash = branch.hash
+          targetLabel = `branch ${branch.shortName}`
+        }
+      } else if (onTagTab) {
+        const all = sortTags(context.tags?.tags || [], state.tagSort)
+        const visible = state.filter
+          ? all.filter((t) => matchesPromotedFilter([t.name, t.subject], state.filter))
+          : all
+        const tag = visible[Math.min(state.selectedTagIndex, Math.max(0, visible.length - 1))]
+        if (tag) {
+          targetHash = tag.hash
+          targetLabel = `tag ${tag.name}`
+        }
+      }
+
+      if (!targetHash) return
+      const loaded = state.filteredCommits.some((commit) =>
+        commit.hash === targetHash || commit.shortHash === targetHash
+      )
+      if (loaded) {
+        dispatch({ type: 'selectCommitByHash', hash: targetHash })
+      } else {
+        dispatch({
+          type: 'setStatus',
+          value: `${targetLabel} tip not in loaded window — press \\ for full graph or Ctrl+L to load more`,
+        })
+      }
+    }, 150)
+
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [
+    dispatch, context.branches, context.tags,
+    state.activeView, state.focus, state.sidebarTab,
+    state.selectedBranchIndex, state.selectedTagIndex,
+    state.branchSort, state.tagSort, state.filter,
+    state.filteredCommits,
+  ])
+
   React.useEffect(() => {
     let active = true
 

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -883,4 +883,41 @@ describe('log Ink view model', () => {
       expect(state.historyFetchArgs).toBeUndefined()
     })
   })
+
+  // #806 follow-up — branch / tag selection auto-jumps the history
+  // view to the cursored ref's tip commit. The reducer just locates
+  // the hash within the filtered list; the runtime React effect is
+  // what watches the cursor and dispatches.
+  describe('selectCommitByHash', () => {
+    it('snaps selectedIndex to the commit matching the full hash', () => {
+      let state = createLogInkState(rows)
+      // rows[2] has hash 'fed999900000'.
+      state = applyLogInkAction(state, { type: 'selectCommitByHash', hash: 'fed999900000' })
+      expect(state.selectedIndex).toBe(2)
+    })
+
+    it('also accepts the short hash', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'selectCommitByHash', hash: 'fed9999' })
+      expect(state.selectedIndex).toBe(2)
+    })
+
+    it('is a no-op when the hash is not in the loaded list', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'move', delta: 1 })
+      expect(state.selectedIndex).toBe(1)
+      // No matching commit → cursor stays put. The runtime effect
+      // surfaces a status hint; this reducer just declines to move.
+      state = applyLogInkAction(state, { type: 'selectCommitByHash', hash: 'nonexistent' })
+      expect(state.selectedIndex).toBe(1)
+    })
+
+    it('resets the file index and diff offset on jump', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'moveDetailFile', delta: 3, fileCount: 5 })
+      state = applyLogInkAction(state, { type: 'selectCommitByHash', hash: 'fed999900000' })
+      expect(state.selectedFileIndex).toBe(0)
+      expect(state.diffPreviewOffset).toBe(0)
+    })
+  })
 })

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -219,7 +219,9 @@ export function parseLogInkHistoryFetchPrefix(filter: string): LogInkHistoryFetc
 
 export type LogInkInputPromptKind =
   | 'create-branch'
+  | 'create-branch-here'
   | 'create-tag'
+  | 'create-tag-here'
   | 'rename-branch'
   | 'set-upstream'
   | 'create-stash'
@@ -257,6 +259,7 @@ export type LogInkAction =
   | { type: 'focusNext' }
   | { type: 'focusPrevious' }
   | { type: 'move'; delta: number }
+  | { type: 'selectCommitByHash'; hash: string }
   | { type: 'moveDetailFile'; delta: number; fileCount: number }
   | { type: 'moveWorktreeFile'; delta: number; fileCount: number }
   | { type: 'moveBranch'; delta: number; count: number }
@@ -712,6 +715,30 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         pendingCommitFocused: false,
         pendingKey: undefined,
       }
+    case 'selectCommitByHash': {
+      // Locates a commit by its full or short hash within the active
+      // filtered list and snaps the cursor to it. Used by the
+      // branch/tag auto-jump effect (#806 follow-up): cursoring a
+      // branch in the sidebar tracks the history view to that
+      // branch's tip without the user manually scrolling. No-op when
+      // the hash isn't in the loaded list (the runtime surfaces a
+      // status hint in that case).
+      const target = action.hash
+      const index = state.filteredCommits.findIndex((commit) =>
+        commit.hash === target || commit.shortHash === target
+      )
+      if (index < 0) {
+        return state
+      }
+      return {
+        ...state,
+        selectedIndex: index,
+        selectedFileIndex: 0,
+        diffPreviewOffset: 0,
+        pendingCommitFocused: false,
+        pendingKey: undefined,
+      }
+    }
     case 'focusPendingCommit':
       return {
         ...state,


### PR DESCRIPTION
Visual feedback after 0.38.0: cursoring a branch in the sidebar (or the dedicated branches view) leaves the history panel parked on whatever was selected before. The cursors in the two lists were independent, so users had to manually scroll the history to see what was on the branch they just landed on.

Now they sync. Cursoring a branch (or tag) snaps the history view's cursor to that ref's tip commit, debounced so cursor-scrolling through a long branch list doesn't dispatch on every keystroke.

## What changed

| Piece | Detail |
|---|---|
| **Reducer action** | New \`selectCommitByHash { hash }\`. Locates the commit by full or short hash within \`state.filteredCommits\` and updates \`selectedIndex\`. No-op when the hash isn't loaded. Resets file index + diff offset on jump (mirrors \`move\`). |
| **Auto-jump effect** | New React effect in \`inkRuntime.ts\` watches \`selectedBranchIndex\` and \`selectedTagIndex\`. On change, with a 150ms debounce, dispatches \`selectCommitByHash\` for the cursored ref's tip. Active when on the dedicated branches/tags view OR the sidebar with that tab focused. |
| **Hash-not-loaded fallback** | When the cursored ref's tip isn't in \`state.filteredCommits\` (common under compact \`--first-parent\` mode), the effect surfaces a status hint: \`branch feat/foo tip not in loaded window — press \\ for full graph or Ctrl+L to load more\`. |

## Why debounced

Cursor-scrolling through 50 branches with \`j/k\` would dispatch 50 selectCommitByHash actions in 200ms without a debounce — wasted re-renders and a flickering cursor in the history panel. 150ms feels snappy on a single keypress and absorbs rapid scrolling.

## Out of scope (deferred follow-up)

- **Re-fetch the commit graph** with the cursored branch as a ref filter when the tip isn't loaded, with a loading state in the history panel during the fetch. The status hint is the v1 placeholder. Filing a follow-up issue if you want the auto-fetch behavior.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run test:jest\` 1021/1021 passing — 4 new \`selectCommitByHash\` reducer cases
- [x] \`npm run build\` clean
- [ ] Visual: \`gb\` to branches view → cursor a non-current branch with \`j/k\` → history view cursor jumps to that branch's tip after ~150ms
- [ ] Visual: same flow on the sidebar Branches tab
- [ ] Visual: same flow on the Tags view / Tags tab
- [ ] Visual: cursor a feature branch whose tip isn't in compact mode → status hint surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)