### PR TITLE
feat(log-tui): create branch / tag from cursored commit on history view

### DIFF
--- a/src/commands/log/historyActions.test.ts
+++ b/src/commands/log/historyActions.test.ts
@@ -7,6 +7,8 @@ import {
   compareCommits,
   copyCommitHash,
   copyCommitMessage,
+  createBranchFromCommit,
+  createTagAtCommit,
   getReflogEntries,
   getRemoteCommitUrl,
   historyActionTestInternals,
@@ -283,5 +285,120 @@ describe('log history actions', () => {
       '--max-count=2',
       '--pretty=format:%gd%x1f%h%x1f%gs',
     ])
+  })
+
+  // GitKraken-style "create branch here" / "create tag here" — the
+  // user picks a historical commit, names the ref, and we mark the
+  // commit without touching HEAD.
+  describe('createBranchFromCommit / createTagAtCommit', () => {
+    it('runs git branch <name> <sha> for a selected commit (does not switch)', async () => {
+      const git = {
+        revparse: jest.fn().mockResolvedValue('/tmp/coco-missing-git-state'),
+        raw: jest.fn().mockResolvedValue(''),
+      }
+
+      await expect(createBranchFromCommit(git as never, 'feature/x', commit)).resolves.toEqual({
+        ok: true,
+        message: 'Created branch feature/x at abcdef1',
+      })
+
+      expect(git.raw).toHaveBeenCalledWith(['branch', 'feature/x', commit.hash])
+    })
+
+    it('runs git tag <name> <sha> for a selected commit (lightweight)', async () => {
+      const git = {
+        revparse: jest.fn().mockResolvedValue('/tmp/coco-missing-git-state'),
+        raw: jest.fn().mockResolvedValue(''),
+      }
+
+      await expect(createTagAtCommit(git as never, 'v1.0.0', commit)).resolves.toEqual({
+        ok: true,
+        message: 'Created tag v1.0.0 at abcdef1',
+      })
+
+      expect(git.raw).toHaveBeenCalledWith(['tag', 'v1.0.0', commit.hash])
+    })
+
+    it('trims whitespace from the supplied name before invoking git', async () => {
+      const git = {
+        revparse: jest.fn().mockResolvedValue('/tmp/coco-missing-git-state'),
+        raw: jest.fn().mockResolvedValue(''),
+      }
+
+      await expect(createBranchFromCommit(git as never, '  feature/x  ', commit)).resolves.toEqual({
+        ok: true,
+        message: 'Created branch feature/x at abcdef1',
+      })
+
+      expect(git.raw).toHaveBeenCalledWith(['branch', 'feature/x', commit.hash])
+    })
+
+    it('rejects missing commits and empty names without invoking git', async () => {
+      const git = {
+        revparse: jest.fn(),
+        raw: jest.fn(),
+      }
+
+      await expect(createBranchFromCommit(git as never, 'feature/x', undefined)).resolves.toEqual({
+        ok: false,
+        message: 'No commit selected.',
+      })
+      await expect(createTagAtCommit(git as never, 'v1.0.0', undefined)).resolves.toEqual({
+        ok: false,
+        message: 'No commit selected.',
+      })
+      await expect(createBranchFromCommit(git as never, '   ', commit)).resolves.toEqual({
+        ok: false,
+        message: 'Branch name required.',
+      })
+      await expect(createTagAtCommit(git as never, '   ', commit)).resolves.toEqual({
+        ok: false,
+        message: 'Tag name required.',
+      })
+      expect(git.raw).not.toHaveBeenCalled()
+    })
+
+    it('blocks while another git operation is in progress', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'coco-history-here-'))
+      const mergeHead = join(tempDir, 'MERGE_HEAD')
+
+      writeFileSync(mergeHead, commit.hash)
+
+      const git = {
+        revparse: jest.fn().mockResolvedValue(mergeHead),
+        raw: jest.fn(),
+      }
+
+      try {
+        await expect(createBranchFromCommit(git as never, 'feature/x', commit)).resolves.toEqual({
+          ok: false,
+          message: 'Finish or abort the in-progress merge before editing history.',
+        })
+        await expect(createTagAtCommit(git as never, 'v1.0.0', commit)).resolves.toEqual({
+          ok: false,
+          message: 'Finish or abort the in-progress merge before editing history.',
+        })
+        expect(git.raw).not.toHaveBeenCalled()
+      } finally {
+        rmSync(tempDir, {
+          force: true,
+          recursive: true,
+        })
+      }
+    })
+
+    it('surfaces git failures (e.g. ref already exists) as structured details', async () => {
+      const git = {
+        revparse: jest.fn().mockResolvedValue('/tmp/coco-missing-git-state'),
+        raw: jest.fn().mockRejectedValue(new Error([
+          "fatal: a branch named 'feature/x' already exists",
+        ].join('\n'))),
+      }
+
+      await expect(createBranchFromCommit(git as never, 'feature/x', commit)).resolves.toMatchObject({
+        ok: false,
+        message: "fatal: a branch named 'feature/x' already exists",
+      })
+    })
   })
 })

--- a/src/commands/log/historyActions.ts
+++ b/src/commands/log/historyActions.ts
@@ -447,6 +447,89 @@ export function resetToCommit(
   }))
 }
 
+/**
+ * Create a new local branch pointed at <commit>, without switching to it.
+ *
+ * This is the "create branch from cursored commit" history action — the
+ * user types the new branch name into an input prompt and we run
+ * `git branch <name> <sha>` (NOT `git switch -c`, which is what
+ * `branchActions.createBranch` does for the create-branch-at-HEAD flow).
+ * The split exists because GitKraken-style "create branch here" is
+ * specifically about marking a historical commit, not about switching
+ * onto a new working branch.
+ *
+ * Note for the inspector follow-up: workflow surfacing is driven by the
+ * registry in `inkWorkflows.ts`, not a hardcoded action list — adding
+ * `create-branch-here` there is enough for the inspector / palette to
+ * pick this up.
+ */
+export function createBranchFromCommit(
+  git: SimpleGit,
+  name: string,
+  commit: Pick<HistoryCommitRef, 'hash' | 'shortHash'> | undefined
+): Promise<BranchActionResult> {
+  const trimmedName = name.trim()
+
+  if (!commit) {
+    return Promise.resolve({
+      ok: false,
+      message: 'No commit selected.',
+    })
+  }
+
+  if (!trimmedName) {
+    return Promise.resolve({
+      ok: false,
+      message: 'Branch name required.',
+    })
+  }
+
+  return guardNoInProgressOperation(git).then((blocked) => (
+    blocked || runAction(
+      () => git.raw(['branch', trimmedName, commit.hash]),
+      `Created branch ${trimmedName} at ${commit.shortHash}`
+    )
+  ))
+}
+
+/**
+ * Create a lightweight tag pointed at <commit>.
+ *
+ * Mirrors `createBranchFromCommit` for the tag side: the user types a
+ * tag name into an input prompt and we run `git tag <name> <sha>`
+ * (lightweight, no `-a`/`-m`). Annotated tags remain available through
+ * the existing `+` flow on the tags view; this is the per-commit
+ * shortcut.
+ */
+export function createTagAtCommit(
+  git: SimpleGit,
+  name: string,
+  commit: Pick<HistoryCommitRef, 'hash' | 'shortHash'> | undefined
+): Promise<BranchActionResult> {
+  const trimmedName = name.trim()
+
+  if (!commit) {
+    return Promise.resolve({
+      ok: false,
+      message: 'No commit selected.',
+    })
+  }
+
+  if (!trimmedName) {
+    return Promise.resolve({
+      ok: false,
+      message: 'Tag name required.',
+    })
+  }
+
+  return guardNoInProgressOperation(git).then((blocked) => (
+    blocked || runAction(
+      () => git.raw(['tag', trimmedName, commit.hash]),
+      `Created tag ${trimmedName} at ${commit.shortHash}`
+    )
+  ))
+}
+
 export function startInteractiveRebase(
   git: SimpleGit,
   commit: HistoryCommitRef | undefined

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -1378,6 +1378,124 @@ describe('log Ink input interactions', () => {
     })
   })
 
+  // GitKraken-style "create branch / tag from cursored commit" — the
+  // user types the name into an input prompt; submitting forwards the
+  // typed name as the workflow payload. The prompt itself is the
+  // affirmative gate (no extra y-confirm).
+  describe('create-branch-here (B) / create-tag-here (gT) bindings', () => {
+    it('B on the history view opens the create-branch-here prompt', () => {
+      const events = getLogInkInputEvents(createLogInkState(rows), 'B')
+      expect(events).toEqual([
+        {
+          type: 'action',
+          action: {
+            type: 'openInputPrompt',
+            kind: 'create-branch-here',
+            label: 'New branch name (at cursored commit)',
+          },
+        },
+      ])
+    })
+
+    it('B is scoped to the history view — does not fire elsewhere', () => {
+      const branches = createLogInkState(rows, { activeView: 'branches' })
+      // Branches view doesn't bind `B`; it falls through to the default
+      // workflow lookup which has no entry for `B`.
+      expect(getLogInkInputEvents(branches, 'B', {}, { branchCount: 3 })).toEqual([])
+    })
+
+    it('B no-ops when the history list is empty', () => {
+      const empty = createLogInkState([])
+      expect(getLogInkInputEvents(empty, 'B')).toEqual([])
+    })
+
+    it('gT chord on the history view opens the create-tag-here prompt', () => {
+      let state = createLogInkState(rows)
+      // First press `g` to set the chord prefix.
+      state = applyInput(state, 'g')
+      expect(state.pendingKey).toBe('g')
+
+      const events = getLogInkInputEvents(state, 'T')
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'setPendingKey', value: undefined } },
+        {
+          type: 'action',
+          action: {
+            type: 'openInputPrompt',
+            kind: 'create-tag-here',
+            label: 'New tag name (at cursored commit)',
+          },
+        },
+      ])
+    })
+
+    it('gT outside the history view surfaces a hint instead of opening the prompt', () => {
+      let state = createLogInkState(rows, { activeView: 'branches' })
+      state = applyInput(state, 'g', {}, { branchCount: 3 })
+      expect(state.pendingKey).toBe('g')
+
+      const events = getLogInkInputEvents(state, 'T', {}, { branchCount: 3 })
+      expect(events).toContainEqual({
+        type: 'action',
+        action: { type: 'setPendingKey', value: undefined },
+      })
+      expect(events.find((e) => e.type === 'action' && (e.action as { type: string }).type === 'openInputPrompt')).toBeUndefined()
+    })
+
+    it('gT does not collide with gt (lowercase jumps to tags view)', () => {
+      let state = createLogInkState(rows)
+      state = applyInput(state, 'g')
+      // Lowercase t still routes to the tags view.
+      const events = getLogInkInputEvents(state, 't')
+      expect(events).toContainEqual({
+        type: 'action',
+        action: { type: 'pushView', value: 'tags' },
+      })
+    })
+
+    it('submitting create-branch-here forwards the typed name as the workflow payload', () => {
+      let state = applyLogInkAction(createLogInkState(rows), {
+        type: 'openInputPrompt',
+        kind: 'create-branch-here',
+        label: 'New branch name (at cursored commit)',
+      })
+      'feature/release'.split('').forEach((c) => { state = applyInput(state, c) })
+      const events = getLogInkInputEvents(state, '', { return: true })
+      expect(events).toEqual([
+        { type: 'runWorkflowAction', id: 'create-branch-here', payload: 'feature/release' },
+        { type: 'action', action: { type: 'closeInputPrompt' } },
+      ])
+    })
+
+    it('submitting create-tag-here forwards the typed name as the workflow payload', () => {
+      let state = applyLogInkAction(createLogInkState(rows), {
+        type: 'openInputPrompt',
+        kind: 'create-tag-here',
+        label: 'New tag name (at cursored commit)',
+      })
+      'v1.2.3'.split('').forEach((c) => { state = applyInput(state, c) })
+      const events = getLogInkInputEvents(state, '', { return: true })
+      expect(events).toEqual([
+        { type: 'runWorkflowAction', id: 'create-tag-here', payload: 'v1.2.3' },
+        { type: 'action', action: { type: 'closeInputPrompt' } },
+      ])
+    })
+
+    it('submitting an empty name surfaces a hint instead of running the workflow', () => {
+      const state = applyLogInkAction(createLogInkState(rows), {
+        type: 'openInputPrompt',
+        kind: 'create-branch-here',
+        label: 'New branch name (at cursored commit)',
+      })
+      const events = getLogInkInputEvents(state, '', { return: true })
+      expect(events.find((e) => e.type === 'runWorkflowAction')).toBeUndefined()
+      expect(events).toContainEqual({
+        type: 'action',
+        action: { type: 'setStatus', value: 'enter a value or press esc to cancel' },
+      })
+    })
+  })
+
   describe('d toggles diff view mode (#785)', () => {
     it('emits toggleDiffViewMode + a status hint when pressed in the diff view', () => {
       const state = { ...createLogInkState(rows), activeView: 'diff' as const }

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -835,6 +835,33 @@ export function getLogInkInputEvents(
     ]
   }
 
+  // `gT` chord: create a lightweight tag at the cursored commit on the
+  // history view. Bare `T` is taken (delete-tag on the tags view) so we
+  // use the chord. Mirrors `gH` exactly — uppercase letter after the
+  // `g` chord prefix, distinct from the lowercase `gt` chord which
+  // jumps to the tags view. The prompt is the affirmative gate.
+  if (state.pendingKey === 'g' && inputValue === 'T') {
+    if (
+      state.activeView === 'history' &&
+      state.focus === 'commits' &&
+      state.filteredCommits.length > 0 &&
+      !state.pendingCommitFocused
+    ) {
+      return [
+        action({ type: 'setPendingKey', value: undefined }),
+        action({
+          type: 'openInputPrompt',
+          kind: 'create-tag-here',
+          label: 'New tag name (at cursored commit)',
+        }),
+      ]
+    }
+    return [
+      action({ type: 'setPendingKey', value: undefined }),
+      action({ type: 'setStatus', value: 'gT creates a tag at the cursored commit on the history view' }),
+    ]
+  }
+
   if (inputValue === 'g') {
     if (state.pendingKey === 'g') {
       return [
@@ -1529,6 +1556,25 @@ export function getLogInkInputEvents(
     !state.pendingCommitFocused
   ) {
     return [action({ type: 'setPendingConfirmation', value: 'interactive-rebase' })]
+  }
+
+  // `B` opens a create-branch prompt rooted at the cursored commit
+  // (`git branch <name> <sha>` — does NOT switch to the new branch).
+  // The prompt itself is the affirmative gate, so no separate y-confirm.
+  // Bare uppercase `B` since the lowercase `b` is used by the `gb`
+  // chord prefix and we want a single keystroke for this common op.
+  if (
+    inputValue === 'B' &&
+    state.activeView === 'history' &&
+    state.focus === 'commits' &&
+    state.filteredCommits.length > 0 &&
+    !state.pendingCommitFocused
+  ) {
+    return [action({
+      type: 'openInputPrompt',
+      kind: 'create-branch-here',
+      label: 'New branch name (at cursored commit)',
+    })]
   }
 
   // `y` / `Y` yank the contextually relevant identifier from the active

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -19,8 +19,8 @@ describe('log Ink keymap', () => {
     })).toEqual({
       // `c/R/Z/i mutate` is the compact chip for cherry-pick / revert /
       // reset / interactive-rebase — full descriptions in ? help and
-      // the palette.
-      contextual: ['↑/↓ move', 'enter diff', 'c/R/Z/i mutate', 'y/Y yank', '/ search', 'gg/G top/bottom'],
+      // the palette. `B/gT new` covers create-branch-here / create-tag-here.
+      contextual: ['↑/↓ move', 'enter diff', 'c/R/Z/i mutate', 'B/gT new', 'y/Y yank', '/ search', 'gg/G top/bottom'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -629,9 +629,12 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
     // History view default hints. Mutating ops (`c` cherry-pick, `R`
     // revert, `Z` reset, `i` interactive-rebase) all route through a
     // y-confirm or mode prompt — none fire silently from the keystroke.
-    // Grouped into a compact `c/R/Z/i mutate` chip so the footer stays
-    // scannable; full descriptions live in `?` help and the palette.
-    contextual: ['↑/↓ move', 'enter diff', 'c/R/Z/i mutate', 'y/Y yank', '/ search', 'gg/G top/bottom'],
+    // `B` create-branch-here and `gT` create-tag-here use a prompt as
+    // the affirmative gate (typing the name is the confirmation).
+    // Grouped into compact `c/R/Z/i mutate` and `B/gT new` chips so
+    // the footer stays scannable; full descriptions live in `?` help
+    // and the palette.
+    contextual: ['↑/↓ move', 'enter diff', 'c/R/Z/i mutate', 'B/gT new', 'y/Y yank', '/ search', 'gg/G top/bottom'],
     global: NORMAL_GLOBAL_HINTS,
   }
 }

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -162,6 +162,8 @@ import {
   ResetMode,
   checkoutFileFromCommit,
   cherryPickCommit,
+  createBranchFromCommit,
+  createTagAtCommit,
   defaultClipboardRunner,
   isResetMode,
   resetToCommit,
@@ -1503,6 +1505,26 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
           hash: commit.hash,
           shortHash: commit.shortHash,
           message: commit.message,
+        })
+      },
+      'create-branch-here': async () => {
+        const commit = getSelectedInkCommit(state)
+        const name = payload?.trim()
+        if (!commit) return { ok: false, message: 'No commit selected' }
+        if (!name) return { ok: false, message: 'Branch name required' }
+        return createBranchFromCommit(git, name, {
+          hash: commit.hash,
+          shortHash: commit.shortHash,
+        })
+      },
+      'create-tag-here': async () => {
+        const commit = getSelectedInkCommit(state)
+        const name = payload?.trim()
+        if (!commit) return { ok: false, message: 'No commit selected' }
+        if (!name) return { ok: false, message: 'Tag name required' }
+        return createTagAtCommit(git, name, {
+          hash: commit.hash,
+          shortHash: commit.shortHash,
         })
       },
       'checkout-file-from-commit': async () => {

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -219,7 +219,9 @@ export function parseLogInkHistoryFetchPrefix(filter: string): LogInkHistoryFetc
 
 export type LogInkInputPromptKind =
   | 'create-branch'
+  | 'create-branch-here'
   | 'create-tag'
+  | 'create-tag-here'
   | 'rename-branch'
   | 'set-upstream'
   | 'create-stash'

--- a/src/commands/log/inkWorkflows.test.ts
+++ b/src/commands/log/inkWorkflows.test.ts
@@ -100,6 +100,27 @@ describe('log Ink workflows', () => {
     })
   })
 
+  it('registers create-branch-here / create-tag-here as palette-only normal actions', () => {
+    // GitKraken-style "create branch / tag from commit" — bound to `B`
+    // and `gT` on the history view in inkInput. Palette-only `key: ''`
+    // here keeps them discoverable without registering global hotkeys;
+    // the prompt itself is the affirmative gate so requiresConfirmation
+    // stays false (no extra y-confirm).
+    const branchHere = getLogInkWorkflowActionById('create-branch-here')
+    expect(branchHere).toMatchObject({
+      key: '',
+      kind: 'normal',
+      requiresConfirmation: false,
+    })
+
+    const tagHere = getLogInkWorkflowActionById('create-tag-here')
+    expect(tagHere).toMatchObject({
+      key: '',
+      kind: 'normal',
+      requiresConfirmation: false,
+    })
+  })
+
   it('registers hunk-apply workflows as palette-only and non-destructive (#782)', () => {
     const worktree = getLogInkWorkflowActionById('apply-hunk-worktree')
     const index = getLogInkWorkflowActionById('apply-hunk-index')

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -375,6 +375,38 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: true,
     },
     {
+      // Per-view-only: scoped to the history view in inkInput (key `B`).
+      // The prompt itself is the affirmative gate — the user has to
+      // type a branch name before anything happens — so this skips the
+      // y-confirm path. Empty key keeps it palette-discoverable; the
+      // palette path can't synthesize a branch name and surfaces a
+      // hint instead.
+      //
+      // Distinct from `create-branch` (palette / `+` on branches view),
+      // which uses `git switch -c` and switches onto the new branch.
+      // This workflow uses `git branch <name> <sha>` and stays put —
+      // GitKraken's "create branch here" semantic.
+      id: 'create-branch-here',
+      key: '',
+      label: 'Create branch from commit',
+      description: 'Create a branch pointed at the cursored commit (does not switch).',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      // Per-view-only: scoped to the history view in inkInput via the
+      // `gT` chord (bare `T` is taken by delete-tag on the tags view).
+      // Same prompt-as-confirmation pattern as create-branch-here.
+      // Lightweight tag — annotated tags remain available through the
+      // existing `+` flow on the tags view.
+      id: 'create-tag-here',
+      key: '',
+      label: 'Create tag at commit',
+      description: 'Create a lightweight tag at the cursored commit.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
       id: 'ai-commit-summary',
       key: 'I',
       label: 'AI commit summary',


### PR DESCRIPTION
## Summary

GitKraken-style "create branch / tag from cursored commit" — two new shortcuts on the history view that mark the commit under the cursor without touching HEAD.

- **`B`** opens a create-branch prompt rooted at the cursored commit (`git branch <name> <sha>`). Does NOT switch to the new branch — distinct from the existing `+` create-branch flow on the branches view, which uses `git switch -c` and switches.
- **`gT`** chord opens a lightweight create-tag prompt at the cursored commit (`git tag <name> <sha>`). Annotated tags remain available through the existing `+` flow on the tags view; this is the per-commit shortcut.
- The input prompt itself is the affirmative gate — typing the name is the confirmation. No extra y-confirm.

### Tag-key choice (`gT`)

The bare uppercase `T` is already taken (delete-tag on the tags view), and bare `N` collides with the global "previous match" navigation key. So the tag shortcut uses the `gT` chord — mirrors `gH` exactly (uppercase letter after the `g` chord prefix). It's distinct from the lowercase `gt` chord which jumps to the tags view (pendingKey lookup is case-sensitive). This keeps the chord pattern consistent with the rest of the registry (`gh / gs / gd / gc / gb / gt / gz / gw / gp / gH`).

### Footer hints

History view contextual chip extended from `c/R/Z/i mutate` to `c/R/Z/i mutate, B/gT new`. Full descriptions live in `?` help and the palette.

### Workflow registry

Both register as palette-only `kind: 'normal'` entries (`create-branch-here`, `create-tag-here`). The inspector and command palette surface them automatically through `getLogInkWorkflowSections` / `getLogInkWorkflowActions` — no inspector-specific wiring needed.

## Out of scope (follow-ups)

The original feedback also called out two more GitKraken actions worth wiring, but they're complex enough to warrant their own PRs:

- **Drop commit** — needs `git rebase --onto <sha>^ <sha> HEAD` with careful conflict handling.
- **Move commit up / down** — requires writing an interactive-rebase todo file via `GIT_SEQUENCE_EDITOR`.

Happy to file follow-up issues for either / both if you'd like.

## Test plan

- [x] `npm run lint`
- [x] `npm run test:jest` (1033 passed, +16 new)
- [x] `npm run build`
- [ ] Manual smoke in `coco ui`: cursor on a commit, press `B`, type a branch name, Enter — verify `git branch <name>` lands and HEAD is unchanged.
- [ ] Manual smoke in `coco ui`: cursor on a commit, press `gT`, type a tag name, Enter — verify `git tag <name>` lands.
- [ ] Verify both surface in the `:` palette as "Create branch from commit" / "Create tag at commit".

🤖 Generated with [Claude Code](https://claude.com/claude-code)