### PR TITLE
fix(log-tui): 0.39.0 polish — open-in-browser commit URL, header label, cursor sync confirmation

### DIFF
--- a/src/commands/commands.integration.test.ts
+++ b/src/commands/commands.integration.test.ts
@@ -664,7 +664,7 @@ describe('command integration with temp git repos', () => {
       help: false,
     } as Arguments<LogOptions>, createLogger())
 
-    expect(stdout).toContain('coco ui')
+    expect(stdout).toContain('coco')
     expect(stdout).toContain('feat: add interactive log coverage')
     expect(stdout).toContain('Changed files:')
     expect(stdout).toContain('src/interactive.ts')
@@ -692,7 +692,7 @@ describe('command integration with temp git repos', () => {
       view: 'history',
     } as Arguments<UiOptions>, createLogger())
 
-    expect(stdout).toContain('coco ui')
+    expect(stdout).toContain('coco')
     expect(stdout).toContain('feat: add ui workstation coverage')
     expect(stdout).toContain('Changed files:')
     expect(stdout).toContain('src/ui.ts')

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -1177,6 +1177,13 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       )
       if (loaded) {
         dispatch({ type: 'selectCommitByHash', hash: targetHash })
+        // Confirmation status message so the user gets feedback even
+        // when the dedicated branches / tags view is occupying the
+        // main panel and the history cursor moves invisibly behind it.
+        dispatch({
+          type: 'setStatus',
+          value: `Synced history to ${targetLabel} tip`,
+        })
       } else {
         dispatch({
           type: 'setStatus',
@@ -1647,6 +1654,17 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         const repo = context.provider?.repository
         if (!repo || repo.provider !== 'github' || !repo.owner || !repo.name) {
           return { ok: false, message: 'No GitHub remote detected for this repo' }
+        }
+        // History view: prefer the cursored commit's URL so `O` from
+        // a commit context lands the user on the commit page rather
+        // than the repo root or the current PR. The user-visible
+        // intent of `O` is "open whatever I'm cursoring on the web";
+        // a commit is what the cursor is on in the history view.
+        if (state.activeView === 'history') {
+          const commit = getSelectedInkCommit(state)
+          if (commit) {
+            return openProviderUrl(repo, { type: 'commit', commit: commit.hash })
+          }
         }
         const pr = context.provider?.currentPullRequest || context.pullRequest?.currentPullRequest
         if (pr) {

--- a/src/commands/ui/handler.ts
+++ b/src/commands/ui/handler.ts
@@ -52,7 +52,7 @@ export async function startCocoUiFromLogArgv(
   const rows = options.rows || (await getLogRows(git, logArgv))
 
   await startInkInteractiveLog(git, rows, {}, {
-    appLabel: 'coco ui',
+    appLabel: 'coco',
     idleTips: config.logTui?.idleTips,
     initialView: 'history',
     logArgv,
@@ -67,7 +67,7 @@ export async function startCocoUi(argv: UiArgv): Promise<void> {
   const rows = await getLogRows(git, logArgv)
 
   await startInkInteractiveLog(git, rows, {}, {
-    appLabel: 'coco ui',
+    appLabel: 'coco',
     idleTips: config.logTui?.idleTips,
     initialView: argv.view || 'history',
     logArgv,


### PR DESCRIPTION
Three small post-0.39.0-cut fixes spotted in visual review.

## Open in Browser opens the cursored commit, not the repo root

\`O\` on the history view used to fall through to the \`open-pr\` workflow's "no PR? open the repo" fallback when no PR was on the current branch — sending the user to \`https://github.com/owner/repo\` instead of the commit they were cursoring on.

The handler is now context-aware: on the history view it prefers the cursored commit's URL (\`openProviderUrl(repo, { type: 'commit', commit: hash })\`). The PR/repo fallback chain still applies on every other view.

## Header label drops "ui"

\`coco ui\` → \`coco\` in the chrome header. Shorter and less redundant. \`appLabel\` flows through both entry points (\`startCocoUi\` and \`startCocoUiFromLogArgv\`).

## Cursor sync surfaces confirmation status

The branch / tag → history cursor sync from #811 was firing as designed, but on the dedicated branches view (\`gb\` chord) the main panel renders the branches list — so the history cursor moved invisibly behind it. Adds a \`Synced history to <ref> tip\` status message on successful jump so the user gets feedback regardless of which view occupies the main panel. The "tip not in loaded window" hint stays put for the unloaded case.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run test:jest\` 1055/1055 (integration assertion updated to expect \`coco\` not \`coco ui\` in stdout)
- [x] \`npm run build\` clean
- [ ] Visual: \`O\` on a history commit → opens \`https://github.com/owner/repo/commit/<sha>\`
- [ ] Visual: header reads \`coco\` not \`coco ui\`
- [ ] Visual: cursor branches via \`j/k\` on the branches view → status line confirms \`Synced history to branch <name> tip\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)