### PR TITLE
feat(log-tui): inspector focus-expand + dynamic sidebar height + checkout polish

### DIFF
--- a/src/commands/log/inkLayout.test.ts
+++ b/src/commands/log/inkLayout.test.ts
@@ -14,8 +14,8 @@ describe('log Ink layout', () => {
     expect(layout.tooSmall).toBe(false)
     expect(layout.bodyRows).toBe(19)
     expect(layout.sidebarWidth).toBe(22)
-    // 80 * 0.28 = 22.4 → floor 22 → clamped up to the 26-cell minimum
-    expect(layout.detailWidth).toBe(26)
+    // 80 * 0.22 = 17.6 → floor 17 → clamped up to the 20-cell minimum
+    expect(layout.detailWidth).toBe(20)
   })
 
   it('uses a balanced layout at the default terminal size', () => {
@@ -24,8 +24,8 @@ describe('log Ink layout', () => {
     expect(layout.tooSmall).toBe(false)
     expect(layout.bodyRows).toBe(35)
     expect(layout.sidebarWidth).toBe(28)
-    // 120 * 0.28 = 33.6 → floor 33
-    expect(layout.detailWidth).toBe(33)
+    // 120 * 0.22 = 26.4 → floor 26
+    expect(layout.detailWidth).toBe(26)
   })
 
   it('caps side panel widths on wide terminals', () => {
@@ -34,16 +34,36 @@ describe('log Ink layout', () => {
     expect(layout.tooSmall).toBe(false)
     expect(layout.bodyRows).toBe(55)
     expect(layout.sidebarWidth).toBe(34)
-    // 200 * 0.28 = 56 → clamped down to the 44-cell maximum
-    expect(layout.detailWidth).toBe(44)
+    // 200 * 0.22 = 44 → clamped down to the 32-cell maximum
+    expect(layout.detailWidth).toBe(32)
   })
 
-  it('clamps the inspector to its 26-44 cell range', () => {
+  it('clamps the inspector at rest to its 20-32 cell range', () => {
     const tiny = getLogInkLayout({ columns: 80, rows: 24 })
     const huge = getLogInkLayout({ columns: 400, rows: 80 })
 
-    expect(tiny.detailWidth).toBe(26)
-    expect(huge.detailWidth).toBe(44)
+    expect(tiny.detailWidth).toBe(20)
+    expect(huge.detailWidth).toBe(32)
+  })
+
+  it('grows the inspector when inspectorFocused is set', () => {
+    const collapsed = getLogInkLayout({ columns: 120, rows: 40 })
+    const expanded = getLogInkLayout({ columns: 120, rows: 40, inspectorFocused: true })
+
+    expect(expanded.detailWidth).toBeGreaterThan(collapsed.detailWidth)
+    // 120 * 0.40 = 48 → clamped down to the 60-cell maximum (no clamp needed at 120)
+    expect(expanded.detailWidth).toBe(48)
+    expect(expanded.sidebarWidth).toBe(collapsed.sidebarWidth)
+    // Main panel shrinks to absorb the inspector growth.
+    expect(expanded.mainPanelWidth).toBe(120 - expanded.sidebarWidth - expanded.detailWidth)
+  })
+
+  it('clamps the focused inspector to its 36-60 cell range', () => {
+    const narrow = getLogInkLayout({ columns: 80, rows: 24, inspectorFocused: true })
+    const wide = getLogInkLayout({ columns: 200, rows: 60, inspectorFocused: true })
+
+    expect(narrow.detailWidth).toBe(36)
+    expect(wide.detailWidth).toBe(60)
   })
 
   it('reports terminals below the minimum as too small', () => {

--- a/src/commands/log/inkLayout.ts
+++ b/src/commands/log/inkLayout.ts
@@ -8,6 +8,13 @@ export type LogInkLayoutInput = {
    * width.
    */
   sidebarFocused?: boolean
+  /**
+   * When true the inspector grows so the user can read long commit
+   * bodies / file lists / action labels. Mirrors the sidebar pattern:
+   * compact at rest so the commit graph dominates, wide on focus so
+   * the inspection surface gets the room it needs.
+   */
+  inspectorFocused?: boolean
 }
 
 export type LogInkLayout = {
@@ -34,12 +41,14 @@ export const LOG_INK_DEFAULT_ROWS = 40
 export function getLogInkLayout(input: LogInkLayoutInput): LogInkLayout {
   const columns = input.columns || LOG_INK_DEFAULT_COLUMNS
   const rows = input.rows || LOG_INK_DEFAULT_ROWS
-  // Inspector width — 26-44 cells (~28% of width). Narrowed from the
-  // earlier 30-56 range when the inspector dropped its duplicative
-  // workflows trailer (repo / branch / status — all already visible in
-  // the top header and left sidebar). The reclaimed columns go to the
-  // commit graph in the main panel.
-  const detailWidth = Math.max(26, Math.min(44, Math.floor(columns * 0.28)))
+  // Inspector width — at rest 20-32 cells (~22% of width), focused
+  // 36-60 cells (~40% of width). Narrow rest state keeps the commit
+  // graph dominant; focus expansion gives the inspector room for long
+  // commit bodies / file lists / action labels. Mirrors the sidebar
+  // pattern (sidebarFocused above): instant transition per render.
+  const detailWidth = input.inspectorFocused
+    ? Math.max(36, Math.min(60, Math.floor(columns * 0.40)))
+    : Math.max(20, Math.min(32, Math.floor(columns * 0.22)))
   // Sidebar at rest: 22-34 cells (~24% of width). Focused: 32-50 cells
   // (~36% of width). The transition is instant per render — focus tab to
   // expand, focus away to collapse.

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -1727,9 +1727,20 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
     const result = await handler()
     dispatch({ type: 'setStatus', value: result?.message || 'Workflow action complete' })
-    // Silent refresh so the deleted item disappears from the list without
-    // flickering the surfaces through a 'loading' phase.
-    await refreshContext({ silent: true })
+    // Checkout-branch is the one workflow where we want a *visible*
+    // refresh so the user sees the branches sidebar repaint with the
+    // new current branch (per #806 follow-up). Snap the cursor to
+    // position 0 first so when the refresh completes and the new
+    // current branch lands at the top (per #809's pin-current rule),
+    // the cursor is already there waiting.
+    if (id === 'checkout-branch' && result?.ok) {
+      dispatch({ type: 'resetBranchSelection' })
+      await refreshContext()
+    } else {
+      // Silent refresh so the deleted item disappears from the list
+      // without flickering the surfaces through a 'loading' phase.
+      await refreshContext({ silent: true })
+    }
   }, [context, dispatch, git, refreshContext, state.branchSort, state.filter, state.selectedBranchIndex,
     state.selectedStashIndex, state.selectedTagIndex, state.selectedWorktreeListIndex, state.stashDiffRef,
     state.tagSort])
@@ -2231,6 +2242,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     columns: windowSize.columns || process.stdout.columns || LOG_INK_DEFAULT_COLUMNS,
     rows: windowSize.rows || process.stdout.rows || LOG_INK_DEFAULT_ROWS,
     sidebarFocused: state.focus === 'sidebar',
+    inspectorFocused: state.focus === 'detail',
   })
 
   if (layout.tooSmall) {
@@ -2255,7 +2267,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   return h(Box, { flexDirection: 'column', height: layout.rows },
     renderHeader(h, { Box, Text }, state, context, contextStatus, layout.columns, theme, appLabel),
     h(Box, { flexDirection: 'row', height: layout.bodyRows },
-      renderSidebar(h, { Box, Text }, state, context, contextStatus, layout.sidebarWidth, theme),
+      renderSidebar(h, { Box, Text }, state, context, contextStatus, layout.sidebarWidth, layout.bodyRows, theme),
       renderMainPanel(
         h,
         { Box, Text },
@@ -2370,6 +2382,7 @@ function renderSidebar(
   context: LogInkContext,
   contextStatus: LogInkContextStatus,
   width: number,
+  bodyRows: number,
   theme: LogInkTheme
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
@@ -2396,7 +2409,7 @@ function renderSidebar(
       dimColor: !isActive,
     }, headerText))
     if (isActive) {
-      blocks.push(...renderActiveSidebarContent(h, Text, tab, state, context, contextStatus, width, theme))
+      blocks.push(...renderActiveSidebarContent(h, Text, tab, state, context, contextStatus, width, bodyRows, theme))
     }
     return blocks
   })
@@ -2428,8 +2441,17 @@ function renderActiveSidebarContent(
   context: LogInkContext,
   contextStatus: LogInkContextStatus,
   width: number,
+  bodyRows: number,
   theme: LogInkTheme
 ): ReactTypes.ReactElement[] {
+  // Available rows for the active tab's list. The sidebar chrome
+  // takes ~10 rows (panel title + spacer + 5 tab headers + 4 inter-tab
+  // spacers); the branches tab eats 3 more for its summary header
+  // (Current / Worktree / spacer). Floor of 8 keeps short terminals
+  // usable; tall terminals (40+ rows) get noticeably more items.
+  const sidebarChrome = 10
+  const branchHeaderRows = tab === 'branches' ? 3 : 0
+  const visibleListCount = Math.max(8, bodyRows - sidebarChrome - branchHeaderRows)
   if (tab === 'status') {
     return renderActiveStatusTabContent(h, Text, context, contextStatus, width, theme)
   }
@@ -2461,7 +2483,7 @@ function renderActiveSidebarContent(
       ...renderSelectableSidebarRows(
         h, Text, sortedBranches, state.selectedBranchIndex, focused, width, theme,
         (branch) => `${branchRowMarker(branch, { ascii: theme.ascii })} ${branch.shortName}`,
-        'tab-branches'
+        'tab-branches', visibleListCount,
       ),
     ]
   }
@@ -2477,7 +2499,7 @@ function renderActiveSidebarContent(
     return renderSelectableSidebarRows(
       h, Text, tags, state.selectedTagIndex, focused, width, theme,
       (tag) => `${truncate(tag.name, 16)} ${tag.subject}`,
-      'tab-tags'
+      'tab-tags', visibleListCount,
     )
   }
 
@@ -2492,7 +2514,7 @@ function renderActiveSidebarContent(
     return renderSelectableSidebarRows(
       h, Text, stashes, state.selectedStashIndex, focused, width, theme,
       (stash, index) => `@{${index}} ${stash.message || '(no message)'}`,
-      'tab-stashes'
+      'tab-stashes', visibleListCount,
     )
   }
 
@@ -2511,7 +2533,7 @@ function renderActiveSidebarContent(
       const wstate = worktree.dirty ? 'dirty' : 'clean'
       return `${marker} ${worktree.branch || worktree.path} ${wstate}`
     },
-    'tab-worktrees'
+    'tab-worktrees', visibleListCount,
   )
 }
 
@@ -2531,11 +2553,12 @@ function renderSelectableSidebarRows<T>(
   width: number,
   theme: LogInkTheme,
   toRowText: (item: T, index: number) => string,
-  keyPrefix: string
+  keyPrefix: string,
+  visibleCount?: number,
 ): ReactTypes.ReactElement[] {
   if (items.length === 0) return []
 
-  const window = getSidebarVisibleWindow(items.length, selectedIndex)
+  const window = getSidebarVisibleWindow(items.length, selectedIndex, visibleCount)
   const elements: ReactTypes.ReactElement[] = []
 
   if (window.truncatedAbove > 0) {

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -920,4 +920,17 @@ describe('log Ink view model', () => {
       expect(state.diffPreviewOffset).toBe(0)
     })
   })
+
+  // #806 follow-up — after a successful checkout, the branches sidebar
+  // cursor snaps back to position 0 so it lands on the just-checked-out
+  // branch (which is now pinned at the top per the #809 sort rule).
+  describe('resetBranchSelection', () => {
+    it('snaps selectedBranchIndex to 0', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'moveBranch', delta: 5, count: 10 })
+      expect(state.selectedBranchIndex).toBe(5)
+      state = applyLogInkAction(state, { type: 'resetBranchSelection' })
+      expect(state.selectedBranchIndex).toBe(0)
+    })
+  })
 })

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -263,6 +263,7 @@ export type LogInkAction =
   | { type: 'moveDetailFile'; delta: number; fileCount: number }
   | { type: 'moveWorktreeFile'; delta: number; fileCount: number }
   | { type: 'moveBranch'; delta: number; count: number }
+  | { type: 'resetBranchSelection' }
   | { type: 'moveTag'; delta: number; count: number }
   | { type: 'moveStash'; delta: number; count: number }
   | { type: 'moveWorktreeListEntry'; delta: number; count: number }
@@ -779,6 +780,16 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         selectedBranchIndex: clampIndex(state.selectedBranchIndex + action.delta, action.count),
+        pendingKey: undefined,
+      }
+    case 'resetBranchSelection':
+      // Snap the branches sidebar / view cursor back to position 0.
+      // Used after a successful checkout (#806 follow-up): combined
+      // with the "current branch pinned at top" rule from #809, this
+      // lands the user's cursor on the just-checked-out branch.
+      return {
+        ...state,
+        selectedBranchIndex: 0,
         pendingKey: undefined,
       }
     case 'moveTag':


### PR DESCRIPTION
Three companion 0.39.0 polish items.

## Inspector focus-expand

The inspector now mirrors the existing sidebar focus pattern.

| State | Width range | % of cols |
|---|---|---|
| Rest | 20-32 cells | ~22% |
| Focused | 36-60 cells | ~40% |

When \`tab\` cycles focus to \`detail\`, the inspector grows so the metadata, body preview, file list, and action panel get the room they need. At rest it stays compact so the commit graph dominates. Same instant-per-render transition as \`sidebarFocused\`.

## Dynamic sidebar list height

The sidebar list used to cap at 8 visible items regardless of terminal size. Now grows to fill available rows: \`max(8, bodyRows - sidebarChrome - branchHeaderRows)\`. On a 40-row terminal that's ~26 visible branches under the active tab; on the 24-row minimum it stays at 8.

\`bodyRows\` threads through \`renderSidebar\` → \`renderActiveSidebarContent\` → \`renderSelectableSidebarRows\`. The \`getSidebarVisibleWindow\` helper already accepted a custom \`visible\` count; this PR just starts passing it.

## Checkout polish

Two small fixes for the \`enter checkout\` flow on the branches sidebar / view:

- The post-action context refresh runs **visibly** (not silent) so the branches list flashes its loading state while git updates HEAD. Previously the refresh was silent and the user had no signal that the checkout was in progress.
- New \`resetBranchSelection\` action snaps \`selectedBranchIndex\` back to 0. Combined with the #809 "current branch pinned at top" sort rule, this lands the cursor on the just-checked-out branch when the refresh completes — no manual scrolling needed.

Both changes are scoped to \`id === 'checkout-branch'\` in the workflow runner. Every other workflow keeps the silent refresh and its existing cursor behavior.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run test:jest\` 1058/1058 — 2 new layout tests for inspector focus-expand, 1 new for resetBranchSelection
- [x] \`npm run build\` clean
- [ ] Visual: focus the inspector via \`tab\` cycle → it expands; focus away → it collapses
- [ ] Visual: 40+ row terminal shows more than 8 branches under the active tab
- [ ] Visual: \`enter checkout\` on a non-current branch → branches list shows "Loading branches…" briefly → refresh completes with cursor on the new current branch (now at row 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)