### PR TITLE
feat(log-tui): tabbed inspector for short terminals

### DIFF
--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -954,6 +954,13 @@ export function getLogInkInputEvents(
         hunkOffsets: context.commitDiffHunkOffsets,
       })]
     }
+    // Inspector focused: cycle the inspector tab. The renderer only
+    // honors the tab field on short terminals (where the inspector
+    // collapses into a tabbed layout), but we let the user pre-set
+    // their preference on tall terminals too.
+    if (state.focus === 'detail') {
+      return [action({ type: 'cycleInspectorTab', delta: -1 })]
+    }
     return [action({ type: 'previousSidebarTab' })]
   }
 
@@ -978,6 +985,9 @@ export function getLogInkInputEvents(
         delta: 1,
         hunkOffsets: context.commitDiffHunkOffsets,
       })]
+    }
+    if (state.focus === 'detail') {
+      return [action({ type: 'cycleInspectorTab', delta: 1 })]
     }
     return [action({ type: 'nextSidebarTab' })]
   }

--- a/src/commands/log/inkLayout.test.ts
+++ b/src/commands/log/inkLayout.test.ts
@@ -71,6 +71,18 @@ describe('log Ink layout', () => {
     expect(getLogInkLayout({ columns: 80, rows: 23 }).tooSmall).toBe(true)
   })
 
+  // #806 follow-up — the inspector switches to a tabbed layout on
+  // short terminals so the commit-detail and actions sections each
+  // get their own view rather than clipping. Threshold lives in
+  // INSPECTOR_TABBED_BELOW_ROWS so the runtime + tests share one
+  // value.
+  it('flags inspectorTabbed when the terminal is shorter than the threshold', () => {
+    expect(getLogInkLayout({ columns: 120, rows: 24 }).inspectorTabbed).toBe(true)
+    expect(getLogInkLayout({ columns: 120, rows: 27 }).inspectorTabbed).toBe(true)
+    expect(getLogInkLayout({ columns: 120, rows: 28 }).inspectorTabbed).toBe(false)
+    expect(getLogInkLayout({ columns: 120, rows: 40 }).inspectorTabbed).toBe(false)
+  })
+
   it('grows the sidebar when sidebarFocused is set', () => {
     const collapsed = getLogInkLayout({ columns: 120, rows: 40 })
     const expanded = getLogInkLayout({ columns: 120, rows: 40, sidebarFocused: true })

--- a/src/commands/log/inkLayout.ts
+++ b/src/commands/log/inkLayout.ts
@@ -31,12 +31,30 @@ export type LogInkLayout = {
   rows: number
   sidebarWidth: number
   tooSmall: boolean
+  /**
+   * True when the terminal is short enough that the inspector should
+   * collapse its commit-detail and actions sections into a tabbed
+   * layout (only the active tab renders). Mirrors the sidebar
+   * accordion: same data, less scroll. The threshold lives below in
+   * `INSPECTOR_TABBED_BELOW_ROWS` so the runtime and tests share a
+   * single value.
+   */
+  inspectorTabbed: boolean
 }
 
 export const LOG_INK_MIN_COLUMNS = 80
 export const LOG_INK_MIN_ROWS = 24
 export const LOG_INK_DEFAULT_COLUMNS = 120
 export const LOG_INK_DEFAULT_ROWS = 40
+
+/**
+ * Terminal-row threshold below which the inspector switches to a
+ * tabbed layout (commit-detail vs actions). Picked empirically: at
+ * 28 rows the inspector's full stack (~30 rows when fully populated)
+ * starts clipping the actions section; below that, the tabbed mode
+ * gives both views their own air.
+ */
+export const INSPECTOR_TABBED_BELOW_ROWS = 28
 
 export function getLogInkLayout(input: LogInkLayoutInput): LogInkLayout {
   const columns = input.columns || LOG_INK_DEFAULT_COLUMNS
@@ -64,5 +82,6 @@ export function getLogInkLayout(input: LogInkLayoutInput): LogInkLayout {
     rows,
     sidebarWidth,
     tooSmall: columns < LOG_INK_MIN_COLUMNS || rows < LOG_INK_MIN_ROWS,
+    inspectorTabbed: rows < INSPECTOR_TABBED_BELOW_ROWS,
   }
 }

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -2319,6 +2319,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         filePreview,
         filePreviewLoading,
         layout.detailWidth,
+        layout.inspectorTabbed,
         theme
       )
     ),
@@ -3871,6 +3872,7 @@ function renderDetailPanel(
   filePreview: GitCommitFilePreview | undefined,
   filePreviewLoading: boolean,
   width: number,
+  tabbed: boolean,
   theme: LogInkTheme
 ): ReactTypes.ReactElement {
   const focused = state.focus === 'detail'
@@ -3942,7 +3944,7 @@ function renderDetailPanel(
 
   return renderHistoryInspector(
     h, components, state, context, contextStatus, detail, loading,
-    filePreview, filePreviewLoading, width, theme, focused
+    filePreview, filePreviewLoading, width, tabbed, theme, focused
   )
 }
 
@@ -3957,6 +3959,7 @@ function renderHistoryInspector(
   _filePreview: GitCommitFilePreview | undefined,
   _filePreviewLoading: boolean,
   width: number,
+  tabbed: boolean,
   theme: LogInkTheme,
   focused: boolean
 ): ReactTypes.ReactElement {
@@ -4030,6 +4033,38 @@ function renderHistoryInspector(
   const fileListNodes = renderCommitFileList(
     h, Text, detail.files, state.selectedFileIndex, focused, fileListMaxRows, width, theme
   )
+
+  // Tabbed mode (#806 follow-up — short terminals): render only the
+  // active inspector tab with a `[Inspector] Actions` header so the
+  // user knows what they're seeing and how to switch (`[/]` while
+  // focus is on the inspector). Tall terminals stack both sections
+  // as before.
+  if (tabbed) {
+    const activeTab = state.inspectorTab
+    const tabHeader = h(Box, { key: 'inspector-tabs', flexDirection: 'row' },
+      h(Text, {
+        bold: activeTab === 'inspector',
+        dimColor: activeTab !== 'inspector',
+      }, activeTab === 'inspector' ? '[Inspector]' : ' Inspector '),
+      ' ',
+      h(Text, {
+        bold: activeTab === 'actions',
+        dimColor: activeTab !== 'actions',
+      }, activeTab === 'actions' ? '[Actions]' : ' Actions '))
+    return h(Box, {
+      borderColor: focusBorderColor(theme, focused),
+      borderStyle: theme.borderStyle,
+      flexDirection: 'column',
+      width,
+      paddingX: 1,
+    },
+    h(Text, { bold: true }, panelTitle('Inspector', focused)),
+    tabHeader,
+    h(Text, { key: 'inspector-tabs-spacer' }, ''),
+    ...(activeTab === 'inspector'
+      ? [...headerNodes, ...fileListNodes]
+      : renderInspectorActionsSection(h, Text, 'history-commit', width, theme)))
+  }
 
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -933,4 +933,30 @@ describe('log Ink view model', () => {
       expect(state.selectedBranchIndex).toBe(0)
     })
   })
+
+  // #806 follow-up — tabbed inspector for short terminals.
+  describe('inspectorTab', () => {
+    it('defaults to inspector', () => {
+      const state = createLogInkState(rows)
+      expect(state.inspectorTab).toBe('inspector')
+    })
+
+    it('setInspectorTab snaps to the requested tab', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setInspectorTab', value: 'actions' })
+      expect(state.inspectorTab).toBe('actions')
+      state = applyLogInkAction(state, { type: 'setInspectorTab', value: 'inspector' })
+      expect(state.inspectorTab).toBe('inspector')
+    })
+
+    it('cycleInspectorTab toggles between inspector and actions', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'cycleInspectorTab', delta: 1 })
+      expect(state.inspectorTab).toBe('actions')
+      state = applyLogInkAction(state, { type: 'cycleInspectorTab', delta: 1 })
+      expect(state.inspectorTab).toBe('inspector')
+      state = applyLogInkAction(state, { type: 'cycleInspectorTab', delta: -1 })
+      expect(state.inspectorTab).toBe('actions')
+    })
+  })
 })

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -39,6 +39,18 @@ export type LogInkDiffSource = 'commit' | 'worktree' | 'stash'
  */
 export type LogInkDiffViewMode = 'unified' | 'split'
 
+/**
+ * Inspector tab (#806 follow-up). On tall terminals the inspector
+ * stacks the commit-detail block and the actions block together. On
+ * short terminals (rows below the layout's tabbed threshold) only one
+ * tab renders at a time and the user toggles between them with `[/]`
+ * while the inspector is focused. The field is always present in
+ * state so the user can pre-set their preference; the renderer
+ * decides whether to honor it (short terminal) or stack both
+ * (tall terminal).
+ */
+export type LogInkInspectorTab = 'inspector' | 'actions'
+
 export type CreateLogInkStateOptions = {
   activeView?: LogInkView
 }
@@ -177,6 +189,12 @@ export type LogInkState = {
    * stores the user's preference, not the effective render mode.
    */
   diffViewMode: LogInkDiffViewMode
+  /**
+   * Inspector tab — see `LogInkInspectorTab`. Defaults to 'inspector'
+   * so first paint shows the commit metadata; the user toggles via
+   * `[/]` when the inspector is focused on a short terminal.
+   */
+  inspectorTab: LogInkInspectorTab
 }
 
 export type LogInkStatusFilterMask = {
@@ -264,6 +282,8 @@ export type LogInkAction =
   | { type: 'moveWorktreeFile'; delta: number; fileCount: number }
   | { type: 'moveBranch'; delta: number; count: number }
   | { type: 'resetBranchSelection' }
+  | { type: 'setInspectorTab'; value: LogInkInspectorTab }
+  | { type: 'cycleInspectorTab'; delta: -1 | 1 }
   | { type: 'moveTag'; delta: number; count: number }
   | { type: 'moveStash'; delta: number; count: number }
   | { type: 'moveWorktreeListEntry'; delta: number; count: number }
@@ -657,6 +677,7 @@ export function createLogInkState(
     userSidebarTab: 'status',
     statusFilterMask: { ...DEFAULT_LOG_INK_STATUS_FILTER_MASK },
     diffViewMode: 'unified',
+    inspectorTab: 'inspector',
   }
 }
 
@@ -792,6 +813,24 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         selectedBranchIndex: 0,
         pendingKey: undefined,
       }
+    case 'setInspectorTab':
+      return {
+        ...state,
+        inspectorTab: action.value,
+        pendingKey: undefined,
+      }
+    case 'cycleInspectorTab': {
+      // Two-tab toggle — `delta` is symmetrical so direction does not
+      // matter, but we keep the action shape consistent with the
+      // sidebar's `nextSidebarTab` / `previousSidebarTab` so callers
+      // can mirror the sidebar pattern verbatim.
+      const next: LogInkInspectorTab = state.inspectorTab === 'inspector' ? 'actions' : 'inspector'
+      return {
+        ...state,
+        inspectorTab: next,
+        pendingKey: undefined,
+      }
+    }
     case 'moveTag':
       return {
         ...state,


### PR DESCRIPTION
Visual feedback after 0.39.0: on short terminals (~24-row SSH sessions, split-tmux panes) the inspector's metadata + body + file list + actions stack overruns the available height and the actions section clips below the fold. This PR adds a tabbed inspector layout that activates automatically on short terminals.

## What changed

| Piece | Detail |
|---|---|
| **Layout flag** | \`inspectorTabbed\` set when \`rows < 28\`. Threshold exposed as \`INSPECTOR_TABBED_BELOW_ROWS\` so the runtime + tests share one value. |
| **View-model field** | \`inspectorTab: 'inspector' \| 'actions'\`, default \`inspector\`. Always present in state so the user can pre-set their preference; the renderer only honors it on short terminals. |
| **Reducer actions** | \`setInspectorTab(value)\` and \`cycleInspectorTab(delta)\`. |
| **Renderer** | When tabbed, paints a \`[Inspector] Actions\` tab header at the top and only the active tab's content below. When not tabbed (tall terminal), stacks both sections as before. No visual change for the tall case. |
| **Keystroke** | \`[/]\` while \`focus === 'detail'\` cycles inspector tabs. Same keys still cycle sidebar tabs when \`focus === 'sidebar'\` and jump diff hunks when \`activeView === 'diff'\`. Each context owns its meaning of \`[/]\`. |

## Why \`[/]\` instead of a new key

Mirrors the sidebar pattern (\`[/]\` cycles sidebar tabs when sidebar focused). Same key, focus-routed meaning. Discoverable via the existing footer-hint convention.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run test:jest\` 1059/1059 — 1 new layout test for the threshold flag, 3 new view-model tests for the tab actions
- [x] \`npm run build\` clean
- [ ] Visual: 24-row terminal → inspector shows tabs, only one section at a time
- [ ] Visual: focus inspector via tab cycle → press \`]\` → switches to Actions tab
- [ ] Visual: 40-row terminal → inspector stacks both sections (no tabs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)