### PR TITLE
fix(test): smoke CLI assertions match the new `coco` header label

### DIFF
--- a/bin/smokeCli.ts
+++ b/bin/smokeCli.ts
@@ -189,7 +189,7 @@ try {
     label: 'packaged non-TTY interactive log command',
     env: { NO_COLOR: '1' },
   })
-  assertOutputIncludes('packaged non-TTY interactive log command', interactiveLogOutput, 'coco ui')
+  assertOutputIncludes('packaged non-TTY interactive log command', interactiveLogOutput, 'coco')
   assertOutputIncludes(
     'packaged non-TTY interactive log command',
     interactiveLogOutput,
@@ -204,7 +204,7 @@ try {
     label: 'packaged non-TTY ui command',
     env: { NO_COLOR: '1' },
   })
-  assertOutputIncludes('packaged non-TTY ui command', uiOutput, 'coco ui')
+  assertOutputIncludes('packaged non-TTY ui command', uiOutput, 'coco')
   assertOutputIncludes('packaged non-TTY ui command', uiOutput, 'feat: smoke log command')
   console.log('✓ packaged non-TTY ui command')
 } finally {


### PR DESCRIPTION
Two packaged-CLI smoke assertions in \`bin/smokeCli.ts\` still expected \`coco ui\` in the TUI's stdout output, but #813 dropped the \`ui\` suffix from the header label (\`coco ui\` → \`coco\`). \`npm run test\` (the full release validation chain — lint + jest + packaged smoke checks + publish dry-run) failed at the smoke step because of this stale assertion. The unit-test assertions in \`commands.integration.test.ts\` were updated in #813; the bin-level smoke assertions were missed.

Updates both assertions to expect \`coco\`. Verified \`npm run test\` passes end-to-end after the change (4897 tests + all 8 smoke checks + publish dry-run).

This blocks the 0.39.0 release tag — without this fix, \`release-it\` would fail at the test step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)