### PR TITLE
feat(log-tui): sidebar tab header is a first-class cursor target

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -1825,4 +1825,108 @@ describe('log Ink input interactions', () => {
       expect(events).toEqual([])
     })
   })
+
+  // Sidebar header focus (#806 follow-up) — the cursor escapes the
+  // top of the items list onto the active tab's header. Enter on the
+  // header drills into the dedicated view; ↓ re-enters the list at
+  // index 0. ←/→ tab switching preserves the header focus so the
+  // user can scan tab → tab → drill.
+  describe('sidebar header focus', () => {
+    function sidebarBranchesState() {
+      const state = createLogInkState(rows)
+      return { ...state, focus: 'sidebar' as const, sidebarTab: 'branches' as const }
+    }
+
+    it('↑ at branches index 0 promotes cursor onto the tab header', () => {
+      const events = getLogInkInputEvents(
+        sidebarBranchesState(),
+        '',
+        { upArrow: true },
+        { branchCount: 5 },
+      )
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'setSidebarHeaderFocused', value: true } },
+      ])
+    })
+
+    it('↑ when already on the header is a no-op', () => {
+      const state = { ...sidebarBranchesState(), sidebarHeaderFocused: true }
+      const events = getLogInkInputEvents(state, '', { upArrow: true }, { branchCount: 5 })
+      expect(events).toEqual([])
+    })
+
+    it('↓ from the header re-enters the items list at index 0', () => {
+      const state = { ...sidebarBranchesState(), sidebarHeaderFocused: true }
+      const events = getLogInkInputEvents(state, '', { downArrow: true }, { branchCount: 5 })
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'setSidebarHeaderFocused', value: false } },
+      ])
+    })
+
+    it('↑ at items index 0 promotes onto the header for tags / stashes / worktrees too', () => {
+      const tags = { ...createLogInkState(rows), focus: 'sidebar' as const, sidebarTab: 'tags' as const }
+      expect(getLogInkInputEvents(tags, '', { upArrow: true }, { tagCount: 3 })).toEqual([
+        { type: 'action', action: { type: 'setSidebarHeaderFocused', value: true } },
+      ])
+
+      const stashes = { ...createLogInkState(rows), focus: 'sidebar' as const, sidebarTab: 'stashes' as const }
+      expect(getLogInkInputEvents(stashes, '', { upArrow: true }, { stashCount: 2 })).toEqual([
+        { type: 'action', action: { type: 'setSidebarHeaderFocused', value: true } },
+      ])
+
+      const worktrees = { ...createLogInkState(rows), focus: 'sidebar' as const, sidebarTab: 'worktrees' as const }
+      expect(getLogInkInputEvents(worktrees, '', { upArrow: true }, { worktreeListCount: 1 })).toEqual([
+        { type: 'action', action: { type: 'setSidebarHeaderFocused', value: true } },
+      ])
+    })
+
+    it('does not promote onto the header when the cursor is past index 0', () => {
+      // selectedBranchIndex = 2 — ↑ should still dispatch moveBranch
+      // toward index 1, not jump to the header.
+      const state = { ...sidebarBranchesState(), selectedBranchIndex: 2 }
+      const events = getLogInkInputEvents(state, '', { upArrow: true }, { branchCount: 5 })
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'moveBranch', delta: -1, count: 5 } },
+      ])
+    })
+
+    it('Enter on a header-focused sidebar drills into the dedicated view', () => {
+      // Even when the tab has items + a primary action, header focus
+      // overrides — Enter explicitly opens the dedicated view.
+      const state = { ...sidebarBranchesState(), sidebarHeaderFocused: true }
+      const events = getLogInkInputEvents(
+        state,
+        '',
+        { return: true },
+        { branchCount: 5 },
+      )
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'pushView', value: 'branches' } },
+        { type: 'action', action: { type: 'setFocus', value: 'commits' } },
+      ])
+    })
+
+    it('Enter on items (not header-focused) still fires the per-entity action', () => {
+      // Sanity check: the existing per-entity Enter path still wins
+      // when the cursor is on items.
+      const events = getLogInkInputEvents(
+        sidebarBranchesState(),
+        '',
+        { return: true },
+        { branchCount: 5 },
+      )
+      expect(events).toContainEqual({ type: 'runWorkflowAction', id: 'checkout-branch' })
+    })
+
+    it('does not promote onto the header on empty content tabs', () => {
+      // No items → ↑ falls through to the existing tab-cycle fallback
+      // (no header to escape to in the items-less case; user can use
+      // ←/→ for tab switching anyway).
+      const empty = { ...sidebarBranchesState(), selectedBranchIndex: 0 }
+      const events = getLogInkInputEvents(empty, '', { upArrow: true }, { branchCount: 0 })
+      expect(events.find((e) =>
+        e.type === 'action' && e.action.type === 'setSidebarHeaderFocused'
+      )).toBeUndefined()
+    })
+  })
 })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -1055,6 +1055,31 @@ export function getLogInkInputEvents(
       })]
     }
 
+    // Sidebar header focus: ↑ at item index 0 promotes the cursor
+    // onto the active tab's header. Pressing ↑ again is a no-op
+    // (use ←/→ to switch between tab headers, Enter to drill in).
+    // Only triggers when the sidebar is focused on a content tab —
+    // dedicated promoted views (`g b` etc.) keep the legacy clamp
+    // behavior because they have no header to escape to.
+    if (state.focus === 'sidebar' && !state.sidebarHeaderFocused) {
+      if (state.sidebarTab === 'branches' && state.selectedBranchIndex === 0 && (context.branchCount ?? 0) > 0) {
+        return [action({ type: 'setSidebarHeaderFocused', value: true })]
+      }
+      if (state.sidebarTab === 'tags' && state.selectedTagIndex === 0 && (context.tagCount ?? 0) > 0) {
+        return [action({ type: 'setSidebarHeaderFocused', value: true })]
+      }
+      if (state.sidebarTab === 'stashes' && state.selectedStashIndex === 0 && (context.stashCount ?? 0) > 0) {
+        return [action({ type: 'setSidebarHeaderFocused', value: true })]
+      }
+      if (state.sidebarTab === 'worktrees' && state.selectedWorktreeListIndex === 0 && (context.worktreeListCount ?? 0) > 0) {
+        return [action({ type: 'setSidebarHeaderFocused', value: true })]
+      }
+    }
+    // Already on the header — ↑ is a no-op (←/→ switches tabs).
+    if (state.focus === 'sidebar' && state.sidebarHeaderFocused) {
+      return []
+    }
+
     if (isBranchActionTarget(state) && context.branchCount) {
       return [action({ type: 'moveBranch', delta: -1, count: context.branchCount })]
     }
@@ -1124,6 +1149,14 @@ export function getLogInkInputEvents(
         delta: 1,
         previewLineCount: context.previewLineCount,
       })]
+    }
+
+    // Sidebar header focused: ↓ re-enters the list at index 0.
+    // Clears the header flag and snaps the per-entity selection to 0
+    // (mirrors the existing default selection behavior on first
+    // sidebar focus).
+    if (state.focus === 'sidebar' && state.sidebarHeaderFocused) {
+      return [action({ type: 'setSidebarHeaderFocused', value: false })]
     }
 
     if (isBranchActionTarget(state) && context.branchCount) {
@@ -1281,7 +1314,15 @@ export function getLogInkInputEvents(
       (state.sidebarTab === 'branches' || state.sidebarTab === 'stashes') &&
       sidebarTabHasSelectableItems(state.sidebarTab, sidebarItemCount)
 
-    if (!hasInSidebarPrimaryAction) {
+    // Three cases drill into the dedicated view:
+    //   1. The cursor is on the tab header (user pressed ↑ at the
+    //      top of the list to escape the items — Enter explicitly
+    //      jumps to the dedicated view).
+    //   2. The tab has no in-sidebar primary action defined (status,
+    //      tags, worktrees — drilling in is the canonical path).
+    //   3. The tab has zero items (the dedicated view's empty state
+    //      tells the user what to do next).
+    if (state.sidebarHeaderFocused || !hasInSidebarPrimaryAction) {
       const tabToView: Partial<Record<LogInkSidebarTab, 'status' | 'branches' | 'tags' | 'stash' | 'worktrees'>> = {
         status: 'status',
         branches: 'branches',

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -2411,6 +2411,11 @@ function renderSidebar(
   // Accordion layout — every tab's title is visible on its own line, but
   // only the active tab expands its content underneath. Switching tabs
   // (1-5 / [/]) collapses the previous and expands the next.
+  // When sidebar focus has been promoted to the tab header (#806
+  // follow-up), the active tab's title row gets selection styling
+  // and the items below it render without their cursor highlight
+  // (which now lives on the header).
+  const headerFocused = focused && state.sidebarHeaderFocused
   const tabBlocks = tabs.flatMap((tab, tabIndex) => {
     const isActive = tab === state.sidebarTab
     const count = sidebarTabCount(tab, context)
@@ -2418,6 +2423,7 @@ function renderSidebar(
       ? `${sidebarTabLabel(tab)} (${count})`
       : sidebarTabLabel(tab)
     const headerText = isActive ? `[${labelWithCount}]` : labelWithCount
+    const headerSelected = isActive && headerFocused
     const blocks: ReactTypes.ReactElement[] = []
     if (tabIndex > 0) {
       blocks.push(h(Text, { key: `tab-spacer-${tab}` }, ''))
@@ -2426,6 +2432,12 @@ function renderSidebar(
       key: `tab-header-${tab}`,
       bold: isActive,
       dimColor: !isActive,
+      // Selection styling on the header itself when the cursor has
+      // been promoted off the items list. inverse swaps fg/bg so the
+      // highlight reads as "this is the cursor target" identically
+      // to how items render when focused.
+      backgroundColor: headerSelected && !theme.noColor ? theme.colors.selection : undefined,
+      inverse: headerSelected,
     }, headerText))
     if (isActive) {
       blocks.push(...renderActiveSidebarContent(h, Text, tab, state, context, contextStatus, width, bodyRows, theme))
@@ -2479,7 +2491,11 @@ function renderActiveSidebarContent(
   // ↑/↓ navigates within the sidebar list and Enter / per-entity keys
   // act on the cursored item without needing to drill into the
   // dedicated view (#791 follow-up — in-sidebar selection).
-  const focused = state.focus === 'sidebar' && state.sidebarTab === tab
+  // Items render with the cursor highlight only when the sidebar is
+  // focused on this tab AND the cursor is on items (not promoted to
+  // the tab header). The header-focused branch up in `renderSidebar`
+  // owns the highlight in that case.
+  const focused = state.focus === 'sidebar' && state.sidebarTab === tab && !state.sidebarHeaderFocused
 
   if (tab === 'branches') {
     if (isLogInkContextKeyLoading(contextStatus, 'branches')) {

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -934,6 +934,52 @@ describe('log Ink view model', () => {
     })
   })
 
+  // Sidebar header focus (#806 follow-up) — escapes the items list
+  // upward onto the active tab's header. Reducer-level coverage
+  // here; input dispatch coverage lives in inkInput.test.ts.
+  describe('sidebarHeaderFocused', () => {
+    it('defaults to false', () => {
+      expect(createLogInkState(rows).sidebarHeaderFocused).toBe(false)
+    })
+
+    it('setSidebarHeaderFocused toggles the flag', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setSidebarHeaderFocused', value: true })
+      expect(state.sidebarHeaderFocused).toBe(true)
+      state = applyLogInkAction(state, { type: 'setSidebarHeaderFocused', value: false })
+      expect(state.sidebarHeaderFocused).toBe(false)
+    })
+
+    it('clears when focus moves away from the sidebar', () => {
+      let state = applyLogInkAction(createLogInkState(rows), { type: 'setFocus', value: 'sidebar' })
+      state = applyLogInkAction(state, { type: 'setSidebarHeaderFocused', value: true })
+      expect(state.sidebarHeaderFocused).toBe(true)
+      state = applyLogInkAction(state, { type: 'setFocus', value: 'commits' })
+      expect(state.sidebarHeaderFocused).toBe(false)
+    })
+
+    it('clears on focusNext / focusPrevious', () => {
+      let state = applyLogInkAction(createLogInkState(rows), { type: 'setFocus', value: 'sidebar' })
+      state = applyLogInkAction(state, { type: 'setSidebarHeaderFocused', value: true })
+      state = applyLogInkAction(state, { type: 'focusNext' })
+      expect(state.sidebarHeaderFocused).toBe(false)
+
+      state = applyLogInkAction(state, { type: 'setFocus', value: 'sidebar' })
+      state = applyLogInkAction(state, { type: 'setSidebarHeaderFocused', value: true })
+      state = applyLogInkAction(state, { type: 'focusPrevious' })
+      expect(state.sidebarHeaderFocused).toBe(false)
+    })
+
+    it('preserves the flag when setFocus targets sidebar (no-op self-assignment)', () => {
+      let state = applyLogInkAction(createLogInkState(rows), { type: 'setFocus', value: 'sidebar' })
+      state = applyLogInkAction(state, { type: 'setSidebarHeaderFocused', value: true })
+      // Re-setting focus to sidebar (e.g. via setSidebarTab which
+      // also normalizes focus) should not reset header focus.
+      state = applyLogInkAction(state, { type: 'setFocus', value: 'sidebar' })
+      expect(state.sidebarHeaderFocused).toBe(true)
+    })
+  })
+
   // #806 follow-up — tabbed inspector for short terminals.
   describe('inspectorTab', () => {
     it('defaults to inspector', () => {

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -132,6 +132,19 @@ export type LogInkState = {
    *    had open before they opened those surfaces.
    */
   userSidebarTab: LogInkSidebarTab
+  /**
+   * When true, the cursor sits on the active sidebar tab's *header*
+   * rather than on an item inside the list. Pressing Enter drills
+   * into the dedicated view (`g b`/`g t`/`g z`/`g w`/`g s`) instead
+   * of firing a per-entity action.
+   *
+   * Triggered by pressing ↑ at item index 0; cleared by pressing ↓
+   * (cursor re-enters the list at index 0). Persists across ←/→ tab
+   * switches so the user can scan headers tab-to-tab and drill in.
+   * Resets whenever focus leaves the sidebar so the next sidebar
+   * focus starts on items.
+   */
+  sidebarHeaderFocused: boolean
   statusMessage?: string
   /**
    * Set by `navigateOpenDiffForCommit` / `navigateOpenDiffForWorktreeFile`
@@ -282,6 +295,7 @@ export type LogInkAction =
   | { type: 'moveWorktreeFile'; delta: number; fileCount: number }
   | { type: 'moveBranch'; delta: number; count: number }
   | { type: 'resetBranchSelection' }
+  | { type: 'setSidebarHeaderFocused'; value: boolean }
   | { type: 'setInspectorTab'; value: LogInkInspectorTab }
   | { type: 'cycleInspectorTab'; delta: -1 | 1 }
   | { type: 'moveTag'; delta: number; count: number }
@@ -675,6 +689,7 @@ export function createLogInkState(
     focus: 'commits',
     sidebarTab: 'status',
     userSidebarTab: 'status',
+    sidebarHeaderFocused: false,
     statusFilterMask: { ...DEFAULT_LOG_INK_STATUS_FILTER_MASK },
     diffViewMode: 'unified',
     inspectorTab: 'inspector',
@@ -720,12 +735,16 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         focus: cycleValue(FOCUS_ORDER, state.focus, 1),
+        // Reset header focus when leaving the sidebar so the next
+        // re-entry starts on items rather than mid-flag.
+        sidebarHeaderFocused: false,
         pendingKey: undefined,
       }
     case 'focusPrevious':
       return {
         ...state,
         focus: cycleValue(FOCUS_ORDER, state.focus, -1),
+        sidebarHeaderFocused: false,
         pendingKey: undefined,
       }
     case 'move':
@@ -811,6 +830,12 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         selectedBranchIndex: 0,
+        pendingKey: undefined,
+      }
+    case 'setSidebarHeaderFocused':
+      return {
+        ...state,
+        sidebarHeaderFocused: action.value,
         pendingKey: undefined,
       }
     case 'setInspectorTab':
@@ -1085,6 +1110,9 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         focus: action.value,
+        // Reset sidebar header focus when leaving the sidebar so a
+        // re-entry starts on items rather than mid-flag.
+        sidebarHeaderFocused: action.value === 'sidebar' ? state.sidebarHeaderFocused : false,
         pendingKey: undefined,
       }
     case 'setPendingKey':


### PR DESCRIPTION
Pressing ↑ at item index 0 in a sidebar content tab (branches / tags / stashes / worktrees) now promotes the cursor onto the active tab's header instead of clamping. The header gets selection styling; pressing Enter drills into the dedicated view (\`g b\` / \`g t\` / \`g z\` / \`g w\`) — the same dedicated-view path that empty tabs already used. Pressing ↓ re-enters the items list at index 0.

Lets the user fluidly scan tab → tab via ←/→ (header focus preserved across tab switches) and drill in with Enter, without ever accidentally firing a per-entity action like checkout-branch.

## What changed

| Piece | Detail |
|---|---|
| **State** | New \`sidebarHeaderFocused: boolean\` on \`LogInkState\`, default false. |
| **Reducer** | \`setSidebarHeaderFocused(value)\` toggles. Auto-cleared on \`focusNext\` / \`focusPrevious\` / \`setFocus\` (when leaving sidebar) so re-entries start fresh on items. |
| **Up dispatch** | At item index 0 on a content tab with items: dispatches \`setSidebarHeaderFocused(true)\`. When already header-focused: no-op. |
| **Down dispatch** | When header-focused: dispatches \`setSidebarHeaderFocused(false)\` to re-enter the list at index 0. |
| **Enter dispatch** | When header-focused: drills into the dedicated view unconditionally (overrides the per-entity primary action gate). |
| **Render** | Active tab header gets the same \`backgroundColor: theme.colors.selection\` + \`inverse\` styling that items use when focused. Items lose their cursor highlight when header-focused so the cursor never appears in two places. |

Empty content tabs unchanged — ↑/↓ still falls through to tab cycling since there's no list to escape from.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run test:jest\` 1075/1075 (8 new dispatch cases + 5 new reducer cases)
- [x] \`npm run build\` clean
- [ ] Visual: focus sidebar → ↑ until at top of branches list → press ↑ once more → \`[Branches (N)]\` row gains selection highlight. Enter opens the dedicated branches view (\`g b\`).
- [ ] Visual: with header focused, → switches to Tags tab; the header focus stays on the new tab's title.
- [ ] Visual: ↓ from header re-enters the list at row 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)