### PR TITLE
feat(log-tui): three-tier nav for status surface (#791)

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -1,6 +1,6 @@
 import { GitLogRow } from './data'
 import { getLogInkInputEvents, getLogInkPaletteExecuteEvents } from './inkInput'
-import { applyLogInkAction, createLogInkState } from './inkViewModel'
+import { LogInkState, applyLogInkAction, createLogInkState } from './inkViewModel'
 
 const rows: GitLogRow[] = [
   {
@@ -1926,6 +1926,172 @@ describe('log Ink input interactions', () => {
       const events = getLogInkInputEvents(empty, '', { upArrow: true }, { branchCount: 0 })
       expect(events.find((e) =>
         e.type === 'action' && e.action.type === 'setSidebarHeaderFocused'
+      )).toBeUndefined()
+    })
+  })
+
+  // Status surface three-tier nav (#791 follow-up). ←/→ jumps between
+  // staged / unstaged / untracked groups; ↑ at the top of a group
+  // promotes onto the header; Enter on the header fires the group's
+  // batch workflow.
+  describe('status group three-tier navigation', () => {
+    function statusState(overrides: Partial<LogInkState> = {}) {
+      const base = createLogInkState(rows)
+      return {
+        ...base,
+        focus: 'commits' as const,
+        activeView: 'status' as const,
+        viewStack: ['status'] as LogInkState['viewStack'],
+        ...overrides,
+      }
+    }
+
+    const groups = [
+      { state: 'staged' as const, count: 2, startIndex: 0 },
+      { state: 'unstaged' as const, count: 3, startIndex: 2 },
+      { state: 'untracked' as const, count: 1, startIndex: 5 },
+    ]
+
+    it('→ jumps to the next group\'s first file', () => {
+      const events = getLogInkInputEvents(
+        statusState({ selectedWorktreeFileIndex: 0 }),
+        '',
+        { rightArrow: true },
+        { worktreeFileCount: 6, statusGroups: groups },
+      )
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'jumpToStatusGroup', targetIndex: 2 } },
+      ])
+    })
+
+    it('← from the unstaged group jumps back to staged', () => {
+      const events = getLogInkInputEvents(
+        statusState({ selectedWorktreeFileIndex: 3 }),
+        '',
+        { leftArrow: true },
+        { worktreeFileCount: 6, statusGroups: groups },
+      )
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'jumpToStatusGroup', targetIndex: 0 } },
+      ])
+    })
+
+    it('→ at the last group is a no-op', () => {
+      const events = getLogInkInputEvents(
+        statusState({ selectedWorktreeFileIndex: 5 }),
+        '',
+        { rightArrow: true },
+        { worktreeFileCount: 6, statusGroups: groups },
+      )
+      expect(events).toEqual([])
+    })
+
+    it('↑ at the first file of the unstaged group promotes onto the header', () => {
+      const events = getLogInkInputEvents(
+        statusState({ selectedWorktreeFileIndex: 2 }),
+        '',
+        { upArrow: true },
+        { worktreeFileCount: 6, statusGroups: groups },
+      )
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'setStatusGroupHeaderFocused', value: true } },
+      ])
+    })
+
+    it('↑ in the middle of a group falls through to moveWorktreeFile', () => {
+      const events = getLogInkInputEvents(
+        statusState({ selectedWorktreeFileIndex: 3 }),
+        '',
+        { upArrow: true },
+        { worktreeFileCount: 6, statusGroups: groups },
+      )
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'moveWorktreeFile', delta: -1, fileCount: 6 } },
+      ])
+    })
+
+    it('↑ when header focused is a no-op', () => {
+      const events = getLogInkInputEvents(
+        statusState({ selectedWorktreeFileIndex: 2, statusGroupHeaderFocused: true }),
+        '',
+        { upArrow: true },
+        { worktreeFileCount: 6, statusGroups: groups },
+      )
+      expect(events).toEqual([])
+    })
+
+    it('↓ when header focused clears the flag (cursor stays on first file)', () => {
+      const events = getLogInkInputEvents(
+        statusState({ selectedWorktreeFileIndex: 2, statusGroupHeaderFocused: true }),
+        '',
+        { downArrow: true },
+        { worktreeFileCount: 6, statusGroups: groups },
+      )
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'setStatusGroupHeaderFocused', value: false } },
+      ])
+    })
+
+    it('Enter on staged-group header fires unstage-all-staged', () => {
+      const events = getLogInkInputEvents(
+        statusState({ selectedWorktreeFileIndex: 0, statusGroupHeaderFocused: true }),
+        '',
+        { return: true },
+        { worktreeFileCount: 6, statusGroups: groups },
+      )
+      expect(events).toEqual([
+        { type: 'runWorkflowAction', id: 'unstage-all-staged', payload: 'staged' },
+      ])
+    })
+
+    it('Enter on unstaged-group header fires stage-all-unstaged', () => {
+      const events = getLogInkInputEvents(
+        statusState({ selectedWorktreeFileIndex: 3, statusGroupHeaderFocused: true }),
+        '',
+        { return: true },
+        { worktreeFileCount: 6, statusGroups: groups },
+      )
+      expect(events).toEqual([
+        { type: 'runWorkflowAction', id: 'stage-all-unstaged', payload: 'unstaged' },
+      ])
+    })
+
+    it('Enter on untracked-group header fires stage-all-untracked', () => {
+      const events = getLogInkInputEvents(
+        statusState({ selectedWorktreeFileIndex: 5, statusGroupHeaderFocused: true }),
+        '',
+        { return: true },
+        { worktreeFileCount: 6, statusGroups: groups },
+      )
+      expect(events).toEqual([
+        { type: 'runWorkflowAction', id: 'stage-all-untracked', payload: 'untracked' },
+      ])
+    })
+
+    it('Enter on a file (not header focused) still opens the diff', () => {
+      const events = getLogInkInputEvents(
+        statusState({ selectedWorktreeFileIndex: 1 }),
+        '',
+        { return: true },
+        { worktreeFileCount: 6, statusGroups: groups },
+      )
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'navigateOpenDiffForWorktreeFile', fileIndex: 1 } },
+      ])
+    })
+
+    it('←/→ does nothing when only one group is visible (mask narrowed)', () => {
+      const onlyStaged = [{ state: 'staged' as const, count: 2, startIndex: 0 }]
+      const events = getLogInkInputEvents(
+        statusState({ selectedWorktreeFileIndex: 0 }),
+        '',
+        { rightArrow: true },
+        { worktreeFileCount: 2, statusGroups: onlyStaged },
+      )
+      // Falls through to the next handler — no jumpToStatusGroup
+      // event in the dispatch list.
+      expect(events.find((e) =>
+        e.type === 'action' && e.action.type === 'jumpToStatusGroup'
       )).toBeUndefined()
     })
   })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -82,6 +82,18 @@ export type LogInkInputContext = {
    */
   worktreeSelectedPath?: string
   /**
+   * Sectioned view of the visible (mask-filtered) worktree files for
+   * the status surface, in canonical order (staged → unstaged →
+   * untracked). Drives ←/→ group jumps and the ↑-at-top-of-group →
+   * header-focus transition. Empty / undefined when status isn't the
+   * active view.
+   */
+  statusGroups?: Array<{
+    state: 'staged' | 'unstaged' | 'untracked'
+    count: number
+    startIndex: number
+  }>
+  /**
    * Path of the cursored file in a commit-diff explore. Used by `c`
    * (cherry-pick file from commit).
    */
@@ -1022,12 +1034,58 @@ export function getLogInkInputEvents(
     return [action({ type: 'nextSidebarTab' })]
   }
 
+  // ←/→ on the status surface jump between the staged / unstaged /
+  // untracked groups — the horizontal axis is "between groups", the
+  // vertical axis (↑/↓ below) is "within the active group's files".
+  // Lands on the first file of the target group (clears header
+  // focus) so the user is always on a real file after a jump,
+  // mirroring the sidebar's tab-switch landing behavior.
+  if (
+    (key.leftArrow || key.rightArrow) &&
+    state.activeView === 'status' &&
+    state.focus === 'commits' &&
+    context.statusGroups &&
+    context.statusGroups.length > 1
+  ) {
+    const groups = context.statusGroups
+    const currentIndex = groups.findIndex((group) =>
+      state.selectedWorktreeFileIndex >= group.startIndex &&
+      state.selectedWorktreeFileIndex < group.startIndex + group.count
+    )
+    const fallback = currentIndex >= 0 ? currentIndex : 0
+    const delta = key.leftArrow ? -1 : 1
+    const nextIndex = Math.max(0, Math.min(groups.length - 1, fallback + delta))
+    if (nextIndex !== fallback) {
+      return [action({ type: 'jumpToStatusGroup', targetIndex: groups[nextIndex].startIndex })]
+    }
+    return []
+  }
+
   if (key.upArrow || inputValue === 'k') {
     if (state.focus === 'detail' && context.detailFileCount) {
       return [action({ type: 'moveDetailFile', delta: -1, fileCount: context.detailFileCount })]
     }
 
     if (state.activeView === 'status' && context.worktreeFileCount) {
+      // Already on the group header — ↑ is a no-op (use ←/→ to switch
+      // groups). Mirrors the sidebar's "header is the top of the
+      // hierarchy" behavior.
+      if (state.statusGroupHeaderFocused) {
+        return []
+      }
+      // Cursor at the first file of its group → promote to the group
+      // header rather than crossing the boundary into the previous
+      // group's last file. Keeps the cursor inside its current
+      // container; ←/→ is the explicit way to move between groups.
+      if (context.statusGroups && context.statusGroups.length > 0) {
+        const currentGroup = context.statusGroups.find((group) =>
+          state.selectedWorktreeFileIndex >= group.startIndex &&
+          state.selectedWorktreeFileIndex < group.startIndex + group.count
+        )
+        if (currentGroup && state.selectedWorktreeFileIndex === currentGroup.startIndex) {
+          return [action({ type: 'setStatusGroupHeaderFocused', value: true })]
+        }
+      }
       return [action({
         type: 'moveWorktreeFile',
         delta: -1,
@@ -1128,6 +1186,12 @@ export function getLogInkInputEvents(
     }
 
     if (state.activeView === 'status' && context.worktreeFileCount) {
+      // Header focused → ↓ re-enters the group at the cursored file
+      // (which is already the group's first file by construction).
+      // Just clear the flag.
+      if (state.statusGroupHeaderFocused) {
+        return [action({ type: 'setStatusGroupHeaderFocused', value: false })]
+      }
       return [action({
         type: 'moveWorktreeFile',
         delta: 1,
@@ -1343,6 +1407,26 @@ export function getLogInkInputEvents(
   }
 
   if (key.return && state.activeView === 'status' && state.focus === 'commits' && context.worktreeFileCount) {
+    // Group header focused → fire the group's batch workflow action.
+    // Routed through the workflow runner so the runtime owns the
+    // git invocation + status messaging consistently with the
+    // single-file `space` toggle. The `payload` carries the group's
+    // state ('staged' / 'unstaged' / 'untracked') so the runtime can
+    // resolve which files to act on without re-deriving group state.
+    if (state.statusGroupHeaderFocused && context.statusGroups) {
+      const currentGroup = context.statusGroups.find((group) =>
+        state.selectedWorktreeFileIndex >= group.startIndex &&
+        state.selectedWorktreeFileIndex < group.startIndex + group.count
+      )
+      if (currentGroup) {
+        const workflowId = currentGroup.state === 'staged'
+          ? 'unstage-all-staged'
+          : currentGroup.state === 'unstaged'
+          ? 'stage-all-unstaged'
+          : 'stage-all-untracked'
+        return [{ type: 'runWorkflowAction', id: workflowId, payload: currentGroup.state }]
+      }
+    }
     return [action({
       type: 'navigateOpenDiffForWorktreeFile',
       fileIndex: state.selectedWorktreeFileIndex,

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -193,8 +193,22 @@ import {
   summarizePullRequestChecks,
   summarizePullRequestReviews,
 } from './inkPullRequestPanel'
-import { revertFile, stageFile, unstageFile } from './statusActions'
-import { WorktreeOverview, applyStatusFilterMask, getWorktreeOverview } from './statusData'
+import {
+  revertFile,
+  stageAllFiles,
+  stageFile,
+  unstageAllFiles,
+  unstageFile,
+} from './statusActions'
+import {
+  WorktreeFile,
+  WorktreeFileGroup,
+  WorktreeOverview,
+  applyStatusFilterMask,
+  flattenWorktreeGroups,
+  getWorktreeOverview,
+  groupWorktreeFiles,
+} from './statusData'
 import {
   WorktreeHunkOverview,
   getWorktreeHunks,
@@ -862,7 +876,22 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     () => applyStatusFilterMask(context.worktree?.files || [], state.statusFilterMask),
     [context.worktree?.files, state.statusFilterMask]
   )
-  const selectedWorktreeFile = visibleWorktreeFiles[state.selectedWorktreeFileIndex]
+  // Sectioned view of the visible files (#791 follow-up). Drives the
+  // status surface's three-tier cursor model: ←/→ jumps between
+  // groups, ↑ at index 0 promotes to the group header, Enter on the
+  // header fires the group's batch action. The renderer also consumes
+  // this so the visible file list stays in canonical group order
+  // regardless of whatever order `git status --porcelain` happens to
+  // emit.
+  const visibleWorktreeGroups = React.useMemo(
+    () => groupWorktreeFiles(visibleWorktreeFiles),
+    [visibleWorktreeFiles]
+  )
+  const visibleWorktreeFilesGrouped = React.useMemo(
+    () => flattenWorktreeGroups(visibleWorktreeGroups),
+    [visibleWorktreeGroups]
+  )
+  const selectedWorktreeFile = visibleWorktreeFilesGrouped[state.selectedWorktreeFileIndex]
 
   const dispatch = React.useCallback((action: Parameters<typeof applyLogInkAction>[1]) => {
     setState((current) => applyLogInkAction(current, action))
@@ -1737,6 +1766,35 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         if (!body) return { ok: false, message: 'Comment body required' }
         return commentPullRequest(body)
       },
+      // Status surface group-level batch ops (#791 follow-up). The
+      // input handler dispatches these when the user presses Enter on a
+      // group header. We re-derive the file list from the live
+      // `context.worktree?.files` rather than trusting a snapshot —
+      // the worktree may have changed since the keystroke fired (rare,
+      // but the cost of re-filtering is negligible compared to the cost
+      // of a stale add). The mask is honored too so a user who's
+      // hidden a category never has it touched by accident.
+      'stage-all-unstaged': async () => {
+        const files = applyStatusFilterMask(
+          context.worktree?.files || [],
+          state.statusFilterMask
+        ).filter((file) => file.state === 'unstaged')
+        return stageAllFiles(git, files)
+      },
+      'unstage-all-staged': async () => {
+        const files = applyStatusFilterMask(
+          context.worktree?.files || [],
+          state.statusFilterMask
+        ).filter((file) => file.state === 'staged')
+        return unstageAllFiles(git, files)
+      },
+      'stage-all-untracked': async () => {
+        const files = applyStatusFilterMask(
+          context.worktree?.files || [],
+          state.statusFilterMask
+        ).filter((file) => file.state === 'untracked')
+        return stageAllFiles(git, files)
+      },
     }
     const handler = handlers[id]
     if (!handler) {
@@ -1761,7 +1819,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
   }, [context, dispatch, git, refreshContext, state.branchSort, state.filter, state.selectedBranchIndex,
     state.selectedStashIndex, state.selectedTagIndex, state.selectedWorktreeListIndex, state.stashDiffRef,
-    state.tagSort])
+    state.statusFilterMask, state.tagSort])
 
   // Resolve the active view's "yank target" (commit hash / branch /
   // tag / stash ref / file path) against the live filtered+sorted list,
@@ -1814,14 +1872,14 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       // Read from the mask-filtered list (#776) so the cursor and the
       // yanked path always match what's on screen — yanking a hidden
       // row is always a desync bug.
-      const path = visibleWorktreeFiles[state.selectedWorktreeFileIndex]?.path
+      const path = visibleWorktreeFilesGrouped[state.selectedWorktreeFileIndex]?.path
       if (path) {
         value = path
         label = `path ${path}`
       }
     } else if (view === 'diff') {
       if (state.diffSource === 'worktree') {
-        const path = visibleWorktreeFiles[state.selectedWorktreeFileIndex]?.path
+        const path = visibleWorktreeFilesGrouped[state.selectedWorktreeFileIndex]?.path
         if (path) {
           value = path
           label = `path ${path}`
@@ -1891,7 +1949,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     state.selectedTagIndex,
     state.selectedWorktreeFileIndex,
     state.tagSort,
-    visibleWorktreeFiles,
+    visibleWorktreeFilesGrouped,
   ])
 
   React.useEffect(() => {
@@ -2189,7 +2247,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       detailFileCount: detail?.files.length,
       previewLineCount: diffPreviewLineCount,
       worktreeDiffLineCount: worktreeDiff?.lines.length,
-      worktreeFileCount: visibleWorktreeFiles.length,
+      worktreeFileCount: visibleWorktreeFilesGrouped.length,
       worktreeHunkOffsets: worktreeDiff?.hunkOffsets,
       commitDiffHunkOffsets,
       branchCount: branchVisibleCount,
@@ -2199,7 +2257,12 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       stashDiffFileOffsets: stashDiffFileOffsets.length ? stashDiffFileOffsets : undefined,
       stashDiffSelectedPath,
       worktreeListCount: worktreeVisibleCount,
-      worktreeSelectedPath: visibleWorktreeFiles[state.selectedWorktreeFileIndex]?.path,
+      worktreeSelectedPath: visibleWorktreeFilesGrouped[state.selectedWorktreeFileIndex]?.path,
+      statusGroups: visibleWorktreeGroups.map((group) => ({
+        state: group.state as 'staged' | 'unstaged' | 'untracked',
+        count: group.files.length,
+        startIndex: group.startIndex,
+      })),
       commitDiffSelectedPath: state.diffSource === 'commit'
         ? selectedDetailFile?.path
         : undefined,
@@ -2974,6 +3037,24 @@ function renderPendingCommitRow(
   }, truncate(label, 140))
 }
 
+// Row descriptor for the status surface's grouped layout. Each
+// rendered row is either a group header (e.g. "▾ Unstaged (3)") or a
+// file under that group; both are first-class cursor targets.
+type StatusSurfaceRow =
+  | { kind: 'header'; group: WorktreeFileGroup }
+  | { kind: 'file'; group: WorktreeFileGroup; file: WorktreeFile; flatIndex: number }
+
+function buildStatusSurfaceRows(groups: WorktreeFileGroup[]): StatusSurfaceRow[] {
+  const rows: StatusSurfaceRow[] = []
+  for (const group of groups) {
+    rows.push({ kind: 'header', group })
+    group.files.forEach((file, offset) => {
+      rows.push({ kind: 'file', group, file, flatIndex: group.startIndex + offset })
+    })
+  }
+  return rows
+}
+
 function renderStatusSurface(
   h: typeof ReactTypes.createElement,
   components: LogInkComponents,
@@ -2992,28 +3073,72 @@ function renderStatusSurface(
   // uses for j/k navigation. `visibleFiles` may be a strict subset of
   // worktree.files when the user has narrowed via 1/2/3.
   const visibleFiles = applyStatusFilterMask(worktree?.files || [], state.statusFilterMask)
+  // Group + canonical-sort. The runtime + input handler agree on this
+  // order so a `selectedWorktreeFileIndex` of N always points to the
+  // same file across all three (renderer / input / workflow handlers).
+  const visibleGroups = groupWorktreeFiles(visibleFiles)
+  const surfaceRows = buildStatusSurfaceRows(visibleGroups)
   const listRows = Math.max(4, bodyRows - 5)
   const selectedIndex = state.selectedWorktreeFileIndex
+  const headerFocused = state.statusGroupHeaderFocused
+  // Resolve the cursor's row index in the flat (header-and-file) row
+  // list. Used to window the visible slice around the cursor.
+  const cursorRowIndex = (() => {
+    if (!surfaceRows.length) return 0
+    const currentGroup = visibleGroups.find((group) =>
+      selectedIndex >= group.startIndex && selectedIndex < group.startIndex + group.files.length
+    )
+    if (!currentGroup) return 0
+    if (headerFocused) {
+      const idx = surfaceRows.findIndex((row) => row.kind === 'header' && row.group === currentGroup)
+      return idx >= 0 ? idx : 0
+    }
+    const idx = surfaceRows.findIndex((row) => row.kind === 'file' && row.flatIndex === selectedIndex)
+    return idx >= 0 ? idx : 0
+  })()
   const cleanHint = formatLogInkStatusEmpty({ hasChanges: Boolean(worktree?.files.length) })
-  const startIndex = Math.max(0, selectedIndex - Math.floor(listRows / 2))
+  const windowStart = Math.max(
+    0,
+    Math.min(
+      Math.max(0, surfaceRows.length - listRows),
+      cursorRowIndex - Math.floor(listRows / 2)
+    )
+  )
   const isLoading = isLogInkContextKeyLoading(contextStatus, 'worktree')
-  const fileRows: ReactTypes.ReactNode[] = isLoading || !visibleFiles.length
+  const renderedRows: ReactTypes.ReactNode[] = isLoading || !surfaceRows.length
     ? []
-    : visibleFiles.slice(startIndex).slice(0, listRows).map((file, offset) => {
-      const index = startIndex + offset
-      const isSelected = index === selectedIndex
+    : surfaceRows.slice(windowStart, windowStart + listRows).map((row, offset) => {
+      const rowIndex = windowStart + offset
+      if (row.kind === 'header') {
+        const groupContainsCursor =
+          selectedIndex >= row.group.startIndex &&
+          selectedIndex < row.group.startIndex + row.group.files.length
+        const headerSelected = focused && headerFocused && groupContainsCursor
+        const arrow = theme.ascii ? '>' : '▾'
+        const groupLabel = capitalizeGroupName(row.group.state)
+        const text = `  ${arrow} ${groupLabel} (${row.group.files.length})`
+        return h(Text, {
+          key: `status-group-${row.group.state}-${rowIndex}`,
+          bold: true,
+          dimColor: !headerSelected && rowIndex > cursorRowIndex,
+          backgroundColor: headerSelected && !theme.noColor ? theme.colors.selection : undefined,
+          inverse: headerSelected,
+        }, truncate(text, 140))
+      }
+      const isSelected = !headerFocused && row.flatIndex === selectedIndex
       const cursorPart = `${isSelected ? '>' : ' '} `
-      const dotColor = getStageStatusDotColor(file.state, theme)
+      const dotColor = getStageStatusDotColor(row.file.state, theme)
       const useDot = dotColor !== undefined
       const dotCells = useDot ? cellWidth(STAGE_STATUS_DOT) + 1 : 0
-      const tail = `${file.indexStatus}${file.worktreeStatus} ${file.state.padEnd(9)} ${file.path}`
-      const tailTrunc = truncate(tail, Math.max(0, 140 - cellWidth(cursorPart) - dotCells))
-
+      const tail = `${row.file.indexStatus}${row.file.worktreeStatus} ${row.file.path}`
+      const tailTrunc = truncate(tail, Math.max(0, 140 - cellWidth(cursorPart) - dotCells - 2))
       return h(Text, {
-        key: `status-row-${index}`,
-        dimColor: offset > 0,
+        key: `status-file-${row.flatIndex}-${rowIndex}`,
+        dimColor: !isSelected && rowIndex > cursorRowIndex,
+        backgroundColor: isSelected && focused && !theme.noColor ? theme.colors.selection : undefined,
+        inverse: isSelected && focused,
       },
-      cursorPart,
+      `  ${cursorPart}`,
       ...(useDot ? [h(Text, { color: dotColor }, STAGE_STATUS_DOT), ' '] : []),
       tailTrunc)
     })
@@ -3053,11 +3178,15 @@ function renderStatusSurface(
     ? [h(Text, { key: 'status-mask-indicator', dimColor: true },
         `filter: ${formatStatusFilterMask(state.statusFilterMask)}  (1/2/3 to toggle)`)]
     : []),
-  ...fileRows,
+  ...renderedRows,
   ...fallbackLines.map((line, index) => h(Text, {
     key: `status-surface-fallback-${index}`,
     dimColor: index > 0,
   }, truncate(line, 140))))
+}
+
+function capitalizeGroupName(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1)
 }
 
 function isStatusFilterMaskActive(mask: LogInkStatusFilterMask): boolean {

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -980,6 +980,83 @@ describe('log Ink view model', () => {
     })
   })
 
+  // Status surface group header focus (#791 follow-up) — same shape
+  // as `sidebarHeaderFocused` but scoped to the worktree status
+  // surface, where the cursor escapes upward onto the active group's
+  // header (Staged / Unstaged / Untracked) instead of the sidebar's
+  // tab header.
+  describe('statusGroupHeaderFocused', () => {
+    it('defaults to false', () => {
+      expect(createLogInkState(rows).statusGroupHeaderFocused).toBe(false)
+    })
+
+    it('setStatusGroupHeaderFocused toggles the flag', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setStatusGroupHeaderFocused', value: true })
+      expect(state.statusGroupHeaderFocused).toBe(true)
+      state = applyLogInkAction(state, { type: 'setStatusGroupHeaderFocused', value: false })
+      expect(state.statusGroupHeaderFocused).toBe(false)
+    })
+
+    it('clears when focus moves away from commits', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setStatusGroupHeaderFocused', value: true })
+      expect(state.statusGroupHeaderFocused).toBe(true)
+      state = applyLogInkAction(state, { type: 'setFocus', value: 'sidebar' })
+      expect(state.statusGroupHeaderFocused).toBe(false)
+    })
+
+    it('clears on Tab / Shift+Tab cycling', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setStatusGroupHeaderFocused', value: true })
+      state = applyLogInkAction(state, { type: 'focusNext' })
+      expect(state.statusGroupHeaderFocused).toBe(false)
+    })
+
+    it('clears when the cursor moves to a real file (moveWorktreeFile)', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setStatusGroupHeaderFocused', value: true })
+      state = applyLogInkAction(state, { type: 'moveWorktreeFile', delta: 1, fileCount: 4 })
+      expect(state.statusGroupHeaderFocused).toBe(false)
+    })
+
+    it('clears when the filter mask changes (groups recompose)', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setStatusGroupHeaderFocused', value: true })
+      state = applyLogInkAction(state, { type: 'toggleStatusFilterMask', kind: 'staged' })
+      expect(state.statusGroupHeaderFocused).toBe(false)
+    })
+
+    it('clears when leaving the status view (popView away from status)', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'status' })
+      state = applyLogInkAction(state, { type: 'setStatusGroupHeaderFocused', value: true })
+      expect(state.statusGroupHeaderFocused).toBe(true)
+      state = applyLogInkAction(state, { type: 'popView' })
+      expect(state.statusGroupHeaderFocused).toBe(false)
+    })
+  })
+
+  describe('jumpToStatusGroup', () => {
+    it('snaps the worktree file index to the target and clears header focus', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setStatusGroupHeaderFocused', value: true })
+      state = applyLogInkAction(state, { type: 'jumpToStatusGroup', targetIndex: 3 })
+      expect(state.selectedWorktreeFileIndex).toBe(3)
+      expect(state.statusGroupHeaderFocused).toBe(false)
+      expect(state.selectedWorktreeHunkIndex).toBe(0)
+      expect(state.worktreeDiffOffset).toBe(0)
+    })
+
+    it('clamps a negative target to 0', () => {
+      const state = applyLogInkAction(createLogInkState(rows), {
+        type: 'jumpToStatusGroup',
+        targetIndex: -5,
+      })
+      expect(state.selectedWorktreeFileIndex).toBe(0)
+    })
+  })
+
   // #806 follow-up — tabbed inspector for short terminals.
   describe('inspectorTab', () => {
     it('defaults to inspector', () => {

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -145,6 +145,20 @@ export type LogInkState = {
    * focus starts on items.
    */
   sidebarHeaderFocused: boolean
+  /**
+   * Status surface counterpart of `sidebarHeaderFocused`: when true,
+   * the cursor sits on the active group's *header row* (e.g.
+   * "Unstaged (3)") rather than on a file inside the group. Pressing
+   * Enter fires the group-level batch action (stage-all / unstage-all)
+   * instead of opening a per-file diff.
+   *
+   * Triggered by ↑ at the first file of the active group; cleared by
+   * ↓ (cursor re-enters the group's first file) or by ←/→ jumping to
+   * a different group's first file. Resets whenever the status view
+   * loses focus or its file selection moves so we never get stuck
+   * "between" cursor states.
+   */
+  statusGroupHeaderFocused: boolean
   statusMessage?: string
   /**
    * Set by `navigateOpenDiffForCommit` / `navigateOpenDiffForWorktreeFile`
@@ -296,6 +310,8 @@ export type LogInkAction =
   | { type: 'moveBranch'; delta: number; count: number }
   | { type: 'resetBranchSelection' }
   | { type: 'setSidebarHeaderFocused'; value: boolean }
+  | { type: 'setStatusGroupHeaderFocused'; value: boolean }
+  | { type: 'jumpToStatusGroup'; targetIndex: number }
   | { type: 'setInspectorTab'; value: LogInkInspectorTab }
   | { type: 'cycleInspectorTab'; delta: -1 | 1 }
   | { type: 'moveTag'; delta: number; count: number }
@@ -494,6 +510,7 @@ function withPushedView(state: LogInkState, value: LogInkView): LogInkState {
     diffSource: value === 'diff' ? state.diffSource : undefined,
     stashDiffRef: value === 'diff' ? state.stashDiffRef : undefined,
     pendingCommitFocused: value === 'history' ? state.pendingCommitFocused : false,
+    statusGroupHeaderFocused: value === 'status' ? state.statusGroupHeaderFocused : false,
     pendingKey: undefined,
   }
 }
@@ -518,6 +535,7 @@ function withPoppedView(state: LogInkState): LogInkState {
     diffSource: next === 'diff' ? state.diffSource : undefined,
     stashDiffRef: next === 'diff' ? state.stashDiffRef : undefined,
     pendingCommitFocused: next === 'history' ? state.pendingCommitFocused : false,
+    statusGroupHeaderFocused: next === 'status' ? state.statusGroupHeaderFocused : false,
     pendingKey: undefined,
   }
 }
@@ -537,6 +555,7 @@ function withReplacedView(state: LogInkState, value: LogInkView): LogInkState {
     diffSource: value === 'diff' ? state.diffSource : undefined,
     stashDiffRef: value === 'diff' ? state.stashDiffRef : undefined,
     pendingCommitFocused: value === 'history' ? state.pendingCommitFocused : false,
+    statusGroupHeaderFocused: value === 'status' ? state.statusGroupHeaderFocused : false,
     pendingKey: undefined,
   }
 }
@@ -690,6 +709,7 @@ export function createLogInkState(
     sidebarTab: 'status',
     userSidebarTab: 'status',
     sidebarHeaderFocused: false,
+    statusGroupHeaderFocused: false,
     statusFilterMask: { ...DEFAULT_LOG_INK_STATUS_FILTER_MASK },
     diffViewMode: 'unified',
     inspectorTab: 'inspector',
@@ -738,6 +758,10 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         // Reset header focus when leaving the sidebar so the next
         // re-entry starts on items rather than mid-flag.
         sidebarHeaderFocused: false,
+        // Same idea for the status group header — Tab cycling away
+        // from 'commits' should always land back on a real file when
+        // the user returns.
+        statusGroupHeaderFocused: false,
         pendingKey: undefined,
       }
     case 'focusPrevious':
@@ -745,6 +769,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         ...state,
         focus: cycleValue(FOCUS_ORDER, state.focus, -1),
         sidebarHeaderFocused: false,
+        statusGroupHeaderFocused: false,
         pendingKey: undefined,
       }
     case 'move':
@@ -814,6 +839,9 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         ),
         selectedWorktreeHunkIndex: 0,
         worktreeDiffOffset: 0,
+        // Cursor moved to a real file row — drop header focus so the
+        // file Enter handler (open diff) is what fires next.
+        statusGroupHeaderFocused: false,
       }
     }
     case 'moveBranch':
@@ -836,6 +864,26 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         sidebarHeaderFocused: action.value,
+        pendingKey: undefined,
+      }
+    case 'setStatusGroupHeaderFocused':
+      return {
+        ...state,
+        statusGroupHeaderFocused: action.value,
+        pendingKey: undefined,
+      }
+    case 'jumpToStatusGroup':
+      // Used by ←/→ on the status surface to land on the first file of
+      // the previous / next non-empty group. Clears header focus so the
+      // user is on a real file after the jump (matches the
+      // sidebar pattern where ←/→ between tabs lands on items, not on
+      // the next tab's header).
+      return {
+        ...state,
+        selectedWorktreeFileIndex: Math.max(0, action.targetIndex),
+        selectedWorktreeHunkIndex: 0,
+        worktreeDiffOffset: 0,
+        statusGroupHeaderFocused: false,
         pendingKey: undefined,
       }
     case 'setInspectorTab':
@@ -925,6 +973,10 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         ...state,
         statusFilterMask: allOff ? { ...DEFAULT_LOG_INK_STATUS_FILTER_MASK } : next,
         selectedWorktreeFileIndex: 0,
+        // Group composition changed — header focus would be ambiguous
+        // (cursor lands on file 0 which may belong to a different
+        // group now). Reset to clear the indicator.
+        statusGroupHeaderFocused: false,
         pendingKey: undefined,
       }
     }
@@ -1113,6 +1165,10 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         // Reset sidebar header focus when leaving the sidebar so a
         // re-entry starts on items rather than mid-flag.
         sidebarHeaderFocused: action.value === 'sidebar' ? state.sidebarHeaderFocused : false,
+        // The status group header lives in the 'commits' focus on
+        // the status view — clear when focus moves away so a
+        // re-entry starts on a real file.
+        statusGroupHeaderFocused: action.value === 'commits' ? state.statusGroupHeaderFocused : false,
         pendingKey: undefined,
       }
     case 'setPendingKey':

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -252,6 +252,35 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       kind: 'normal',
       requiresConfirmation: false,
     },
+    // Status surface group-level batch ops (#791 follow-up). Triggered
+    // by Enter when the cursor is on a status group header
+    // (Staged / Unstaged / Untracked). Empty `key` keeps them
+    // palette-discoverable without registering a global hotkey — the
+    // Enter-on-header path in inkInput is the canonical trigger.
+    {
+      id: 'unstage-all-staged',
+      key: '',
+      label: 'Unstage all staged files',
+      description: 'Unstage every file currently in the staged group.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      id: 'stage-all-unstaged',
+      key: '',
+      label: 'Stage all unstaged files',
+      description: 'Stage every modified-but-not-staged file.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      id: 'stage-all-untracked',
+      key: '',
+      label: 'Stage all untracked files',
+      description: 'Add every untracked file to the index after confirmation.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
     {
       id: 'delete-branch',
       key: 'D',

--- a/src/commands/log/statusActions.ts
+++ b/src/commands/log/statusActions.ts
@@ -49,3 +49,36 @@ export function revertFile(git: SimpleGit, file: WorktreeFile): Promise<StatusAc
     `Reverted ${file.path}`
   )
 }
+
+/**
+ * Group-level batch ops triggered by Enter on a status group header
+ * (staged / unstaged / untracked). Pass the files belonging to that
+ * group; the helpers run a single `git add` / `git restore --staged`
+ * with all paths in one invocation rather than looping per-file —
+ * faster + atomic from the user's point of view.
+ */
+export function stageAllFiles(
+  git: SimpleGit,
+  files: WorktreeFile[]
+): Promise<StatusActionResult> {
+  if (files.length === 0) {
+    return Promise.resolve({ ok: false, message: 'No files to stage' })
+  }
+  return runAction(
+    () => git.raw(['add', '--', ...files.map((file) => file.path)]),
+    `Staged ${files.length} ${files.length === 1 ? 'file' : 'files'}`
+  )
+}
+
+export function unstageAllFiles(
+  git: SimpleGit,
+  files: WorktreeFile[]
+): Promise<StatusActionResult> {
+  if (files.length === 0) {
+    return Promise.resolve({ ok: false, message: 'No files to unstage' })
+  }
+  return runAction(
+    () => git.raw(['restore', '--staged', '--', ...files.map((file) => file.path)]),
+    `Unstaged ${files.length} ${files.length === 1 ? 'file' : 'files'}`
+  )
+}

--- a/src/commands/log/statusData.test.ts
+++ b/src/commands/log/statusData.test.ts
@@ -1,4 +1,11 @@
-import { applyStatusFilterMask, parsePorcelainStatus, WorktreeFile } from './statusData'
+import {
+  WorktreeFile,
+  applyStatusFilterMask,
+  findGroupForIndex,
+  flattenWorktreeGroups,
+  groupWorktreeFiles,
+  parsePorcelainStatus,
+} from './statusData'
 
 describe('log status data', () => {
   it('parses staged, unstaged, untracked, and rename status rows', () => {
@@ -63,6 +70,84 @@ describe('log status data', () => {
     it('returns an empty array when every bit is off (caller decides snap-back behavior)', () => {
       expect(applyStatusFilterMask(files, { staged: false, unstaged: false, untracked: false }))
         .toEqual([])
+    })
+  })
+
+  // #791 follow-up — sectioned view of the file list. Drives the
+  // status surface's three-tier cursor model: groups have their own
+  // header rows that the cursor can land on.
+  describe('groupWorktreeFiles', () => {
+    const files: WorktreeFile[] = [
+      { path: 'a.ts', indexStatus: 'M', worktreeStatus: ' ', state: 'staged' },
+      { path: 'b.ts', indexStatus: ' ', worktreeStatus: 'M', state: 'unstaged' },
+      { path: 'c.ts', indexStatus: '?', worktreeStatus: '?', state: 'untracked' },
+      { path: 'd.ts', indexStatus: 'A', worktreeStatus: ' ', state: 'staged' },
+    ]
+
+    it('emits groups in canonical order regardless of input ordering', () => {
+      const groups = groupWorktreeFiles(files)
+      expect(groups.map((g) => g.state)).toEqual(['staged', 'unstaged', 'untracked'])
+      expect(groups[0].files.map((f) => f.path)).toEqual(['a.ts', 'd.ts'])
+      expect(groups[1].files.map((f) => f.path)).toEqual(['b.ts'])
+      expect(groups[2].files.map((f) => f.path)).toEqual(['c.ts'])
+    })
+
+    it('omits empty categories', () => {
+      const onlyUnstaged: WorktreeFile[] = [files[1]]
+      expect(groupWorktreeFiles(onlyUnstaged).map((g) => g.state)).toEqual(['unstaged'])
+    })
+
+    it('returns an empty array for an empty file list', () => {
+      expect(groupWorktreeFiles([])).toEqual([])
+    })
+
+    it('startIndex tracks the flat position of each group\'s first file', () => {
+      const groups = groupWorktreeFiles(files)
+      expect(groups[0].startIndex).toBe(0)
+      expect(groups[1].startIndex).toBe(2)
+      expect(groups[2].startIndex).toBe(3)
+    })
+  })
+
+  describe('flattenWorktreeGroups', () => {
+    it('round-trips through groupWorktreeFiles in canonical order', () => {
+      const files: WorktreeFile[] = [
+        { path: 'a.ts', indexStatus: 'M', worktreeStatus: ' ', state: 'staged' },
+        { path: 'b.ts', indexStatus: ' ', worktreeStatus: 'M', state: 'unstaged' },
+        { path: 'c.ts', indexStatus: '?', worktreeStatus: '?', state: 'untracked' },
+        { path: 'd.ts', indexStatus: 'A', worktreeStatus: ' ', state: 'staged' },
+      ]
+      // Note: round-trip preserves group ordering but reorders within
+      // categories (a, d, b, c) — the canonical order is what the
+      // renderer + cursor model agree on.
+      expect(flattenWorktreeGroups(groupWorktreeFiles(files)).map((f) => f.path)).toEqual([
+        'a.ts',
+        'd.ts',
+        'b.ts',
+        'c.ts',
+      ])
+    })
+  })
+
+  describe('findGroupForIndex', () => {
+    const files: WorktreeFile[] = [
+      { path: 'a.ts', indexStatus: 'M', worktreeStatus: ' ', state: 'staged' },
+      { path: 'd.ts', indexStatus: 'A', worktreeStatus: ' ', state: 'staged' },
+      { path: 'b.ts', indexStatus: ' ', worktreeStatus: 'M', state: 'unstaged' },
+      { path: 'c.ts', indexStatus: '?', worktreeStatus: '?', state: 'untracked' },
+    ]
+    const groups = groupWorktreeFiles(files)
+
+    it('resolves a flat index to the owning group', () => {
+      expect(findGroupForIndex(groups, 0)?.state).toBe('staged')
+      expect(findGroupForIndex(groups, 1)?.state).toBe('staged')
+      expect(findGroupForIndex(groups, 2)?.state).toBe('unstaged')
+      expect(findGroupForIndex(groups, 3)?.state).toBe('untracked')
+    })
+
+    it('returns undefined for an out-of-range index', () => {
+      expect(findGroupForIndex(groups, 99)).toBeUndefined()
+      expect(findGroupForIndex(groups, -1)).toBeUndefined()
     })
   })
 })

--- a/src/commands/log/statusData.ts
+++ b/src/commands/log/statusData.ts
@@ -80,3 +80,50 @@ export function applyStatusFilterMask(
   }
   return files.filter((file) => mask[file.state])
 }
+
+/**
+ * Sectioned view of a (filtered) worktree file list. Groups are emitted
+ * in canonical order (staged → unstaged → untracked) so the renderer
+ * and the cursor model agree on layout regardless of the order
+ * `git status --porcelain` happens to spit them out in. Empty
+ * categories are omitted; `startIndex` is the offset of the group's
+ * first file in the *flattened* sorted list — pair with
+ * `flattenWorktreeGroups` so the canonical `selectedWorktreeFileIndex`
+ * always points to the right file.
+ */
+export type WorktreeFileGroup = {
+  state: WorktreeFileState
+  files: WorktreeFile[]
+  startIndex: number
+}
+
+const WORKTREE_GROUP_ORDER: WorktreeFileState[] = ['staged', 'unstaged', 'untracked']
+
+export function groupWorktreeFiles(files: WorktreeFile[]): WorktreeFileGroup[] {
+  const groups: WorktreeFileGroup[] = []
+  let cursor = 0
+  for (const groupState of WORKTREE_GROUP_ORDER) {
+    const groupFiles = files.filter((file) => file.state === groupState)
+    if (groupFiles.length > 0) {
+      groups.push({ state: groupState, files: groupFiles, startIndex: cursor })
+      cursor += groupFiles.length
+    }
+  }
+  return groups
+}
+
+export function flattenWorktreeGroups(groups: WorktreeFileGroup[]): WorktreeFile[] {
+  return groups.flatMap((group) => group.files)
+}
+
+export function findGroupForIndex(
+  groups: WorktreeFileGroup[],
+  index: number
+): WorktreeFileGroup | undefined {
+  for (const group of groups) {
+    if (index >= group.startIndex && index < group.startIndex + group.files.length) {
+      return group
+    }
+  }
+  return undefined
+}


### PR DESCRIPTION
## Summary

Promote staged / unstaged / untracked categories from incidental visual groupings to first-class cursor targets in the worktree status view. Mirrors the sidebar header focus pattern from #818 so the same mental model carries across surfaces — wherever items live inside named groups, the group's title is also a cursor target with its own canonical action.

## Behavior

| Key | When cursor is on... | Behavior |
|-----|----------------------|----------|
| `←` / `→` | A file | Jump to the prev / next group's first file |
| `↑` | First file of a group | Promote cursor onto the group header |
| `↑` | Group header | No-op (use ←/→ to switch groups) |
| `↓` | Group header | Re-enter the group at its first file |
| `Enter` | A file | Open diff (existing) |
| `Enter` | Staged header | Unstage all staged files |
| `Enter` | Unstaged header | Stage all unstaged files |
| `Enter` | Untracked header | Stage all untracked files (y-confirm) |

`1` / `2` / `3` mask toggles still work; the cursor model adapts to whichever groups are visible. ↑/↓ within a group falls through to the existing `moveWorktreeFile` path, so per-file Enter (open diff), `space` (toggle stage), and the rest of the file-row behavior are unchanged.

## Renderer

Files now render under `▾ Staged (n)` / `▾ Unstaged (n)` / `▾ Untracked (n)` headers. Group rows get the same bold + reverse highlight styling the sidebar uses for its own header focus, so the visual language stays consistent. Layout windowing tracks the cursor across the combined header-and-file row list, so a tall list still keeps the cursor centered in view.

## Architecture

- **State**: new `statusGroupHeaderFocused: boolean` flag, mirroring `sidebarHeaderFocused`. Auto-resets when focus leaves `commits`, when the cursor moves to a real file, when the filter mask changes (groups recompose), or when the status view is popped.
- **Data**: new `groupWorktreeFiles` / `flattenWorktreeGroups` / `findGroupForIndex` helpers in `statusData.ts` keep the renderer + input handler + workflow handlers all reading the same canonical group order regardless of how `git status --porcelain` happens to emit lines.
- **Workflows**: three new palette-discoverable actions (`unstage-all-staged`, `stage-all-unstaged`, `stage-all-untracked`) wrap one-shot `git add` / `git restore --staged` calls. Untracked is `requiresConfirmation: true` since `git add .` of untracked files is the most accident-prone of the three.

## Test plan

- [x] `npm run lint`
- [x] `npm run test:jest` (1103 tests pass — added 28 new tests across `inkInput.test.ts`, `inkViewModel.test.ts`, `statusData.test.ts`)
- [x] `npm run build`
- [x] `npm run test:cli` (CLI smoke tests)
- [ ] Manual: `coco log -i`, focus status view, verify ←/→ jumps groups, ↑ at top promotes to header, Enter on each group header fires the right batch action

🤖 Generated with [Claude Code](https://claude.com/claude-code)