### PR TITLE
feat(log-tui): inspector actions list is executable (#791)

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -2095,4 +2095,169 @@ describe('log Ink input interactions', () => {
       )).toBeUndefined()
     })
   })
+
+  // Inspector Actions cursor (#791 follow-up). When focus=detail and
+  // inspectorTab=actions, ↑/↓ navigates the actions list; Enter on
+  // the cursored action fires its event. Cursor model only kicks in
+  // when actions exist for the current entity context.
+  describe('inspector actions cursor', () => {
+    function actionsFocusState(overrides: Partial<LogInkState> = {}) {
+      const base = createLogInkState(rows)
+      return {
+        ...base,
+        focus: 'detail' as const,
+        inspectorTab: 'actions' as const,
+        ...overrides,
+      }
+    }
+
+    it('↑ moves the cursor up through the actions list', () => {
+      const events = getLogInkInputEvents(
+        actionsFocusState({ inspectorActionIndex: 3 }),
+        '',
+        { upArrow: true },
+        { inspectorActionCount: 8 },
+      )
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'moveInspectorAction', delta: -1, actionCount: 8 } },
+      ])
+    })
+
+    it('↓ moves the cursor down through the actions list', () => {
+      const events = getLogInkInputEvents(
+        actionsFocusState({ inspectorActionIndex: 0 }),
+        '',
+        { downArrow: true },
+        { inspectorActionCount: 8 },
+      )
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'moveInspectorAction', delta: 1, actionCount: 8 } },
+      ])
+    })
+
+    it('↑/↓ falls through to moveDetailFile when inspectorTab=inspector', () => {
+      const events = getLogInkInputEvents(
+        actionsFocusState({ inspectorTab: 'inspector', inspectorActionIndex: 0 }),
+        '',
+        { upArrow: true },
+        { inspectorActionCount: 8, detailFileCount: 5 },
+      )
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'moveDetailFile', delta: -1, fileCount: 5 } },
+      ])
+    })
+
+    it('Enter on the first action (open diff) navigates to the diff', () => {
+      const events = getLogInkInputEvents(
+        actionsFocusState({ inspectorActionIndex: 0 }),
+        '',
+        { return: true },
+        { inspectorActionCount: 8 },
+      )
+      const firstCommit = rows.find((r) => r.type === 'commit')
+      const sha = firstCommit && firstCommit.type === 'commit' ? firstCommit.hash : ''
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'navigateOpenDiffForCommit', sha, commitIndex: 0 } },
+      ])
+    })
+
+    it('Enter on cherry-pick (index 1) opens the y-confirm', () => {
+      const events = getLogInkInputEvents(
+        actionsFocusState({ inspectorActionIndex: 1 }),
+        '',
+        { return: true },
+        { inspectorActionCount: 8 },
+      )
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'setPendingConfirmation', value: 'cherry-pick-commit' } },
+      ])
+    })
+
+    it('Enter on revert (index 2) opens the y-confirm for revert-commit', () => {
+      const events = getLogInkInputEvents(
+        actionsFocusState({ inspectorActionIndex: 2 }),
+        '',
+        { return: true },
+        { inspectorActionCount: 8 },
+      )
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'setPendingConfirmation', value: 'revert-commit' } },
+      ])
+    })
+
+    it('Enter on reset (index 3) opens the reset-mode prompt', () => {
+      const events = getLogInkInputEvents(
+        actionsFocusState({ inspectorActionIndex: 3 }),
+        '',
+        { return: true },
+        { inspectorActionCount: 8 },
+      )
+      expect(events).toEqual([
+        {
+          type: 'action',
+          action: {
+            type: 'openInputPrompt',
+            kind: 'reset-mode',
+            label: 'Reset mode (soft / mixed / hard)',
+          },
+        },
+      ])
+    })
+
+    it('Enter on yank (index 5) fires yankFromActiveView', () => {
+      const events = getLogInkInputEvents(
+        actionsFocusState({ inspectorActionIndex: 5 }),
+        '',
+        { return: true },
+        { inspectorActionCount: 8 },
+      )
+      expect(events).toEqual([{ type: 'yankFromActiveView' }])
+    })
+
+    it('Enter on yank short (index 6) fires yankFromActiveView with short=true', () => {
+      const events = getLogInkInputEvents(
+        actionsFocusState({ inspectorActionIndex: 6 }),
+        '',
+        { return: true },
+        { inspectorActionCount: 8 },
+      )
+      expect(events).toEqual([{ type: 'yankFromActiveView', short: true }])
+    })
+
+    it('Enter on open in browser (index 7) fires open-pr workflow', () => {
+      const events = getLogInkInputEvents(
+        actionsFocusState({ inspectorActionIndex: 7 }),
+        '',
+        { return: true },
+        { inspectorActionCount: 8 },
+      )
+      expect(events).toEqual([{ type: 'runWorkflowAction', id: 'open-pr' }])
+    })
+
+    it('Enter on inspector tab (not actions) falls through to existing diff handler', () => {
+      const events = getLogInkInputEvents(
+        actionsFocusState({ inspectorTab: 'inspector' }),
+        '',
+        { return: true },
+        { inspectorActionCount: 8, detailFileCount: 3 },
+      )
+      // Diff-for-file path, not an action invoke.
+      const types = events.map((e) =>
+        e.type === 'action' ? e.action.type : e.type
+      )
+      expect(types).toEqual(['navigateOpenDiffForCommit'])
+    })
+
+    it('Enter on actions tab when no commit selected emits a status hint', () => {
+      const events = getLogInkInputEvents(
+        actionsFocusState({ inspectorActionIndex: 1, selectedIndex: 99 }),
+        '',
+        { return: true },
+        { inspectorActionCount: 8 },
+      )
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'setStatus', value: 'No commit selected' } },
+      ])
+    })
+  })
 })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -1,5 +1,10 @@
 import { extractDiffHunk } from './inkHunkExtraction'
 import {
+  InspectorAction,
+  InspectorActionContext,
+  getInspectorActions,
+} from './inkInspectorActions'
+import {
   LogInkPaletteCommand,
   filterLogInkPaletteCommands,
   getLogInkPaletteCommands,
@@ -94,6 +99,13 @@ export type LogInkInputContext = {
     startIndex: number
   }>
   /**
+   * Number of actions in the active Inspector Actions list. Used to
+   * clamp the cursor in the actions tab. Undefined / 0 when no
+   * actions are available for the current state — the tab still
+   * renders but the cursor model is a no-op.
+   */
+  inspectorActionCount?: number
+  /**
    * Path of the cursored file in a commit-diff explore. Used by `c`
    * (cherry-pick file from commit).
    */
@@ -126,6 +138,93 @@ function action(actionValue: LogInkAction): LogInkInputEvent {
   return {
     type: 'action',
     action: actionValue,
+  }
+}
+
+/**
+ * Resolve which inspector action context applies for the current
+ * state. Today only history commits expose actions in the inspector
+ * (the renderer hard-coded `'history-commit'`); future PRs can fan
+ * this out to branch / tag / stash / worktree contexts as the
+ * inspector gains entity-aware sections. Returns `undefined` when no
+ * actions section should be shown (so the cursor model stays a
+ * no-op).
+ */
+export function resolveInspectorActionContext(
+  state: LogInkState
+): InspectorActionContext | undefined {
+  if (state.activeView === 'history' && !state.pendingCommitFocused) {
+    return 'history-commit'
+  }
+  return undefined
+}
+
+export function getInspectorActionsForState(state: LogInkState): InspectorAction[] {
+  const ctx = resolveInspectorActionContext(state)
+  return ctx ? getInspectorActions(ctx) : []
+}
+
+/**
+ * Synthesize the events that fire when the user presses Enter on a
+ * cursored inspector action (#791 follow-up). Mirrors
+ * `getLogInkPaletteExecuteEvents` — each action's `key` field
+ * routes to the same dispatch the corresponding keystroke would
+ * trigger from the history view's commit cursor. Per-key dispatch
+ * (rather than recursively re-running the keystroke through
+ * `getLogInkInputEvents`) avoids the gating problem: most history
+ * keystroke handlers require `state.focus === 'commits'`, but the
+ * inspector executor fires from `state.focus === 'detail'`.
+ */
+export function getInspectorActionExecuteEvents(
+  inspectorAction: InspectorAction,
+  state: LogInkState
+): LogInkInputEvent[] {
+  const commit = state.filteredCommits[state.selectedIndex]
+  const requireCommit = (
+    fn: (sha: string, commitIndex: number) => LogInkInputEvent[]
+  ): LogInkInputEvent[] => {
+    if (!commit) {
+      return [action({ type: 'setStatus', value: 'No commit selected' })]
+    }
+    return fn(commit.hash, state.selectedIndex)
+  }
+
+  switch (inspectorAction.key) {
+    case 'enter':
+      return requireCommit((sha, commitIndex) => [
+        action({ type: 'navigateOpenDiffForCommit', sha, commitIndex }),
+      ])
+    case 'c':
+      return requireCommit(() => [
+        action({ type: 'setPendingConfirmation', value: 'cherry-pick-commit' }),
+      ])
+    case 'R':
+      return requireCommit(() => [
+        action({ type: 'setPendingConfirmation', value: 'revert-commit' }),
+      ])
+    case 'Z':
+      return requireCommit(() => [
+        action({
+          type: 'openInputPrompt',
+          kind: 'reset-mode',
+          label: 'Reset mode (soft / mixed / hard)',
+        }),
+      ])
+    case 'i':
+      return requireCommit(() => [
+        action({ type: 'setPendingConfirmation', value: 'interactive-rebase' }),
+      ])
+    case 'y':
+      return requireCommit(() => [{ type: 'yankFromActiveView' }])
+    case 'Y':
+      return requireCommit(() => [{ type: 'yankFromActiveView', short: true }])
+    case 'O':
+      return [{ type: 'runWorkflowAction', id: 'open-pr' }]
+    default:
+      return [action({
+        type: 'setStatus',
+        value: `Action ${inspectorAction.key} not yet wired`,
+      })]
   }
 }
 
@@ -1062,6 +1161,19 @@ export function getLogInkInputEvents(
   }
 
   if (key.upArrow || inputValue === 'k') {
+    // Inspector Actions tab: ↑/↓ moves the cursor through the
+    // executable action list. Wins over moveDetailFile so a
+    // history-commit explore with both file list AND actions visible
+    // navigates the actions when the user has [/]-toggled to the
+    // actions tab. (#791 follow-up)
+    if (state.focus === 'detail' && state.inspectorTab === 'actions' && context.inspectorActionCount) {
+      return [action({
+        type: 'moveInspectorAction',
+        delta: -1,
+        actionCount: context.inspectorActionCount,
+      })]
+    }
+
     if (state.focus === 'detail' && context.detailFileCount) {
       return [action({ type: 'moveDetailFile', delta: -1, fileCount: context.detailFileCount })]
     }
@@ -1179,6 +1291,14 @@ export function getLogInkInputEvents(
   if (key.downArrow || inputValue === 'j') {
     if (state.activeView === 'history' && state.pendingCommitFocused) {
       return [action({ type: 'unfocusPendingCommit' })]
+    }
+
+    if (state.focus === 'detail' && state.inspectorTab === 'actions' && context.inspectorActionCount) {
+      return [action({
+        type: 'moveInspectorAction',
+        delta: 1,
+        actionCount: context.inspectorActionCount,
+      })]
     }
 
     if (state.focus === 'detail' && context.detailFileCount) {
@@ -1332,6 +1452,24 @@ export function getLogInkInputEvents(
         }),
         action({ type: 'setStatus', value: `viewing diff for ${selected.shortHash}` }),
       ]
+    }
+  }
+
+  // Inspector Actions tab: Enter on the cursored action fires its
+  // associated event (cherry-pick / revert / yank / etc.). Wins over
+  // the file-list Enter below when the user has [/]-toggled to the
+  // actions tab. Routes through `getInspectorActionExecuteEvents` so
+  // the per-action dispatch table stays the single source of truth
+  // for what each action does. (#791 follow-up)
+  if (
+    key.return &&
+    state.focus === 'detail' &&
+    state.inspectorTab === 'actions'
+  ) {
+    const actions = getInspectorActionsForState(state)
+    const cursored = actions[state.inspectorActionIndex]
+    if (cursored) {
+      return getInspectorActionExecuteEvents(cursored, state)
     }
   }
 

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -77,7 +77,11 @@ import {
 import { substituteGraphChars } from './inkGraphChars'
 import { LaneSegment, getLaneColor } from './inkGraphLanes'
 import { formatHyperlink } from './inkHyperlinks'
-import { LogInkInputKey, getLogInkInputEvents } from './inkInput'
+import {
+  LogInkInputKey,
+  getInspectorActionsForState,
+  getLogInkInputEvents,
+} from './inkInput'
 import { hasSeenOnboarding, markOnboardingSeen } from './inkOnboarding'
 import { getSavedDiffViewMode, saveDiffViewMode } from './inkDiffViewModePersistence'
 import { getSavedSidebarTab, saveSidebarTab } from './inkSidebarPersistence'
@@ -2263,6 +2267,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         count: group.files.length,
         startIndex: group.startIndex,
       })),
+      inspectorActionCount: getInspectorActionsForState(state).length,
       commitDiffSelectedPath: state.diffSource === 'commit'
         ? selectedDetailFile?.path
         : undefined,
@@ -4129,7 +4134,10 @@ function renderHistoryInspector(
       key: `detail-${index}`,
       dimColor: index > 1,
     }, truncate(line, width - 4))),
-    ...renderInspectorActionsSection(h, Text, 'history-commit', width, theme))
+    ...renderInspectorActionsSection(h, Text, 'history-commit', width, theme, {
+      cursorIndex: state.inspectorActionIndex,
+      cursorActive: focused && state.inspectorTab === 'actions',
+    }))
   }
 
   const statLine = `${detail.stats.filesChanged} files  +${detail.stats.insertions}/-${detail.stats.deletions}`
@@ -4208,7 +4216,10 @@ function renderHistoryInspector(
     h(Text, { key: 'inspector-tabs-spacer' }, ''),
     ...(activeTab === 'inspector'
       ? [...headerNodes, ...fileListNodes]
-      : renderInspectorActionsSection(h, Text, 'history-commit', width, theme)))
+      : renderInspectorActionsSection(h, Text, 'history-commit', width, theme, {
+          cursorIndex: state.inspectorActionIndex,
+          cursorActive: focused,
+        })))
   }
 
   return h(Box, {
@@ -4221,7 +4232,10 @@ function renderHistoryInspector(
   h(Text, { bold: true }, panelTitle('Inspector', focused)),
   ...headerNodes,
   ...fileListNodes,
-  ...renderInspectorActionsSection(h, Text, 'history-commit', width, theme))
+  ...renderInspectorActionsSection(h, Text, 'history-commit', width, theme, {
+    cursorIndex: state.inspectorActionIndex,
+    cursorActive: focused && state.inspectorTab === 'actions',
+  }))
 }
 
 /**
@@ -4240,7 +4254,8 @@ function renderInspectorActionsSection(
   Text: LogInkComponents['Text'],
   context: InspectorActionContext,
   width: number,
-  theme: LogInkTheme
+  theme: LogInkTheme,
+  options: { cursorIndex?: number; cursorActive?: boolean } = {}
 ): ReactTypes.ReactElement[] {
   const actions = getInspectorActions(context)
   if (!actions.length) return []
@@ -4256,10 +4271,14 @@ function renderInspectorActionsSection(
     width - 4 /* border + padX */ - KEY_COLUMN - GAP.length - DESTRUCTIVE_SUFFIX.length
   )
 
+  const cursorIndex = options.cursorIndex ?? 0
+  const cursorActive = options.cursorActive ?? false
+
   const nodes: ReactTypes.ReactElement[] = [
     h(Text, { key: 'actions-spacer' }, ''),
-    h(Text, { key: 'actions-title' }, 'Actions:'),
+    h(Text, { key: 'actions-title' }, cursorActive ? '[Actions]' : 'Actions:'),
     ...actions.map((action: InspectorAction, index) => {
+      const isSelected = cursorActive && index === cursorIndex
       const keyCell = action.key.padEnd(KEY_COLUMN)
       const label = truncate(action.label, labelBudget)
       const children: Array<string | ReactTypes.ReactElement> = [
@@ -4277,7 +4296,11 @@ function renderInspectorActionsSection(
           dimColor: false,
         }, DESTRUCTIVE_SUFFIX))
       }
-      return h(Text, { key: `actions-${index}` }, ...children)
+      return h(Text, {
+        key: `actions-${index}`,
+        backgroundColor: isSelected && !theme.noColor ? theme.colors.selection : undefined,
+        inverse: isSelected,
+      }, ...children)
     }),
   ]
 

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -1081,5 +1081,44 @@ describe('log Ink view model', () => {
       state = applyLogInkAction(state, { type: 'cycleInspectorTab', delta: -1 })
       expect(state.inspectorTab).toBe('actions')
     })
+
+    it('switching tabs resets inspectorActionIndex to 0', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'moveInspectorAction', delta: 3, actionCount: 8 })
+      expect(state.inspectorActionIndex).toBe(3)
+      state = applyLogInkAction(state, { type: 'cycleInspectorTab', delta: 1 })
+      expect(state.inspectorActionIndex).toBe(0)
+      state = applyLogInkAction(state, { type: 'moveInspectorAction', delta: 4, actionCount: 8 })
+      state = applyLogInkAction(state, { type: 'setInspectorTab', value: 'inspector' })
+      expect(state.inspectorActionIndex).toBe(0)
+    })
+  })
+
+  // Inspector Actions cursor (#791 follow-up). Mirrors the
+  // moveDetailFile / moveBranch shape — clamp on count, reset on tab
+  // switch.
+  describe('inspectorActionIndex', () => {
+    it('defaults to 0', () => {
+      expect(createLogInkState(rows).inspectorActionIndex).toBe(0)
+    })
+
+    it('moveInspectorAction clamps to [0, count - 1]', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'moveInspectorAction', delta: 5, actionCount: 3 })
+      expect(state.inspectorActionIndex).toBe(2)
+      state = applyLogInkAction(state, { type: 'moveInspectorAction', delta: -10, actionCount: 3 })
+      expect(state.inspectorActionIndex).toBe(0)
+    })
+
+    it('resetInspectorActionIndex snaps back to 0', () => {
+      let state = applyLogInkAction(createLogInkState(rows), {
+        type: 'moveInspectorAction',
+        delta: 4,
+        actionCount: 8,
+      })
+      expect(state.inspectorActionIndex).toBe(4)
+      state = applyLogInkAction(state, { type: 'resetInspectorActionIndex' })
+      expect(state.inspectorActionIndex).toBe(0)
+    })
   })
 })

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -222,6 +222,14 @@ export type LogInkState = {
    * `[/]` when the inspector is focused on a short terminal.
    */
   inspectorTab: LogInkInspectorTab
+  /**
+   * Cursor index into the inspector's Actions list when the user has
+   * the actions tab focused (#791 follow-up). Auto-clamped against
+   * the current entity's action count by the reducer; reset to 0 on
+   * tab switch / focus change so an action stale from a different
+   * entity context never sits highlighted.
+   */
+  inspectorActionIndex: number
 }
 
 export type LogInkStatusFilterMask = {
@@ -314,6 +322,8 @@ export type LogInkAction =
   | { type: 'jumpToStatusGroup'; targetIndex: number }
   | { type: 'setInspectorTab'; value: LogInkInspectorTab }
   | { type: 'cycleInspectorTab'; delta: -1 | 1 }
+  | { type: 'moveInspectorAction'; delta: number; actionCount: number }
+  | { type: 'resetInspectorActionIndex' }
   | { type: 'moveTag'; delta: number; count: number }
   | { type: 'moveStash'; delta: number; count: number }
   | { type: 'moveWorktreeListEntry'; delta: number; count: number }
@@ -713,6 +723,7 @@ export function createLogInkState(
     statusFilterMask: { ...DEFAULT_LOG_INK_STATUS_FILTER_MASK },
     diffViewMode: 'unified',
     inspectorTab: 'inspector',
+    inspectorActionIndex: 0,
   }
 }
 
@@ -890,6 +901,10 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         inspectorTab: action.value,
+        // Reset the action cursor so a fresh tab visit always starts
+        // on the first action, regardless of where the user left off
+        // in a previous entity context.
+        inspectorActionIndex: 0,
         pendingKey: undefined,
       }
     case 'cycleInspectorTab': {
@@ -901,9 +916,25 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         inspectorTab: next,
+        inspectorActionIndex: 0,
         pendingKey: undefined,
       }
     }
+    case 'moveInspectorAction':
+      return {
+        ...state,
+        inspectorActionIndex: clampIndex(
+          state.inspectorActionIndex + action.delta,
+          action.actionCount
+        ),
+        pendingKey: undefined,
+      }
+    case 'resetInspectorActionIndex':
+      return {
+        ...state,
+        inspectorActionIndex: 0,
+        pendingKey: undefined,
+      }
     case 'moveTag':
       return {
         ...state,


### PR DESCRIPTION
## Summary

Promote the inspector's per-entity **Actions** cheat-sheet from a static key reference to a cursor-navigable, Enter-executable list — the third application of the three-tier nav pattern (after the sidebar redesign in #818 and the status surface groups in #819).

## Behavior

When the inspector has focus (Tab cycles to it) and the **Actions** tab is active (`[/]` toggles between Inspector / Actions):

| Key | Behavior |
|-----|----------|
| `↑` / `↓` | Move cursor through the actions list |
| `Enter` | Fire the cursored action's event |
| `[` / `]` | Toggle back to the Inspector tab |

The active row gets the same selection styling the sidebar header and status group header use, so the visual cue stays consistent across all three surfaces.

## Action dispatch

Each `InspectorAction.key` routes through `getInspectorActionExecuteEvents` and emits the same events the keystroke would dispatch from the history view's commit cursor:

| Action | Event |
|--------|-------|
| `enter` | `navigateOpenDiffForCommit` |
| `c` | `setPendingConfirmation: cherry-pick-commit` |
| `R` | `setPendingConfirmation: revert-commit` |
| `Z` | `openInputPrompt: reset-mode` |
| `i` | `setPendingConfirmation: interactive-rebase` |
| `y` / `Y` | `yankFromActiveView` (short for `Y`) |
| `O` | `runWorkflowAction: open-pr` |

If no commit is selected, the dispatcher emits a `setStatus` hint instead of firing the action — protects against orphaned cursors after filtering.

## Architecture

- **State**: new `inspectorActionIndex: number`, auto-resets to 0 on `setInspectorTab` / `cycleInspectorTab` so a fresh tab visit always starts from the top.
- **Resolver**: `resolveInspectorActionContext(state)` returns `'history-commit'` today (matches the renderer's existing scope). Future PRs that fan the inspector out to branch / tag / stash / worktree contexts add new return values here without touching the dispatcher.
- **Renderer**: `renderInspectorActionsSection` accepts `cursorIndex` + `cursorActive` options and paints the active row with the selection background. Passed from all three call sites (no-detail fallback, tabbed mode, stacked mode).

## Test plan

- [x] `npm run lint`
- [x] `npm run test:jest` (1119 tests pass — added 16 new tests across `inkInput.test.ts` + `inkViewModel.test.ts`)
- [x] `npm run build`
- [x] `npm run test:cli` (CLI smoke tests)
- [ ] Manual: `coco log -i`, Tab to inspector, `[` to switch to Actions tab, ↑/↓ moves cursor, Enter on each action fires the right event

🤖 Generated with [Claude Code](https://claude.com/claude-code)