### PR TITLE
fix(cli): always show error message on command failure

### DIFF
--- a/src/lib/utils/commandExecutor.ts
+++ b/src/lib/utils/commandExecutor.ts
@@ -59,11 +59,21 @@ function formatAuthenticationError(error: LangChainAuthenticationError, logger: 
 }
 
 /**
- * Formats a generic error
+ * Formats a generic error.
+ *
+ * The error message prints unconditionally (was previously gated behind
+ * `--verbose`, which left users staring at a "Failed to execute command"
+ * line with no actionable detail when something crashed). The full stack
+ * trace stays under `logger.verbose` so plain output stays focused on the
+ * one-line cause; users running into something they can't diagnose can opt
+ * in with `--verbose` for the trace.
  */
 function formatGenericError(error: Error, logger: Logger): void {
   logger.log('\nFailed to execute command', { color: 'yellow' })
-  logger.verbose(`\nError: "${error.message}"`, { color: 'red' })
+  logger.log(`\nError: ${error.message}`, { color: 'red' })
+  if (error.stack) {
+    logger.verbose(`\n${error.stack}`, { color: 'gray' })
+  }
 }
 
 function commandExecutor<T extends Argv<BaseArgvOptions>['argv']>(handler: CommandHandler<T>) {


### PR DESCRIPTION
## Summary

The generic error path printed `Failed to execute command` and then hid the actual error message behind `--verbose`. Two problems with that:

1. Users hitting an unexpected crash had no actionable signal and no obvious way to learn that `--verbose` would surface the cause.
2. When invoked through wrappers (`yarn coco ui`, `npm run`), the `--verbose` flag is consumed by the wrapper itself and never reaches the script. So even a user who knows to retry with `--verbose` lands on the same blank failure (npm prints its own verbose chatter, but the script never sees the flag).

## Fix

Print `Error: <message>` unconditionally after the `Failed to execute command` banner. Keep the full stack trace under `--verbose` so plain output stays one line focused on the cause; users diagnosing something deeper can still opt in for the trace.

Network and auth error paths already printed their own targeted context lines (endpoint hints, troubleshooting steps) and stay unchanged.

## Test plan

- [x] `npm run lint`
- [x] Typecheck clean
- [ ] Manual: trigger any error and confirm the message line shows without `--verbose`

🤖 Generated with [Claude Code](https://claude.com/claude-code)