### PR TITLE
fix(log-tui): wrap inspector tab spacer in Text to stop Ink crash

### DIFF
--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -4202,19 +4202,26 @@ function renderHistoryInspector(
   // owns and learn the `[/]` toggle. Without this on tall terminals,
   // the actions list looked like a static cheat-sheet — there was no
   // visible signal that the cursor could move into it.
+  //
+  // Spacing between tab labels comes from the labels' own padding
+  // (the active label is bracketed `[Inspector]` while the inactive
+  // one is space-padded ` Inspector `, so adjacency reads cleanly).
+  // Earlier revisions stuck a raw `' '` between the Text children to
+  // pad them visually — that crashes Ink at first paint with
+  // "Text string ' ' must be rendered inside <Text> component"
+  // because Box only accepts component children, never bare strings.
   const activeTab = state.inspectorTab
   const tabHeader = h(Box, { key: 'inspector-tabs', flexDirection: 'row' },
     h(Text, {
       bold: activeTab === 'inspector',
       dimColor: activeTab !== 'inspector',
     }, activeTab === 'inspector' ? '[Inspector]' : ' Inspector '),
-    ' ',
     h(Text, {
       bold: activeTab === 'actions',
       dimColor: activeTab !== 'actions',
     }, activeTab === 'actions' ? '[Actions]' : ' Actions '),
     ...(focused
-      ? [' ', h(Text, { dimColor: true }, '· [/] switch')]
+      ? [h(Text, { key: 'inspector-tabs-hint', dimColor: true }, '  · [/] switch')]
       : []))
 
   // Tabbed mode (short terminals): render only the active tab's


### PR DESCRIPTION
## Summary

`coco ui` crashed on boot with:

\`\`\`
Error: Text string " " must be rendered inside <Text> component
\`\`\`

The inspector tab header was building a \`Box\` with raw \`' '\` strings as direct children between the \`[Inspector]\` / \`[Actions]\` \`Text\` labels (and another for the focused \`· [/] switch\` hint). Ink rejects bare strings as direct \`Box\` children — only component children are allowed.

The original 0.40.0 code (#820) had the same bug but only fired when the inspector collapsed into tabbed mode (short terminals only). The tab-discoverability follow-up (#822) made the \`tabHeader\` render unconditionally, which moved the crash to every \`coco ui\` boot because the inspector renders on first paint of the history view.

Surfaced thanks to the error-visibility fix in #823 — without it the user only saw a hidden "Failed to execute command" line.

## Fix

- Drop the raw \`' '\` spacer strings between the tab labels. The active label is bracketed (\`[Inspector]\`) while the inactive one is space-padded (\` Inspector \`), so adjacency reads cleanly without an explicit gap.
- Move the focused hint's leading whitespace inside its \`Text\` content (\`'  · [/] switch'\`).
- Add a load-bearing comment on the tabHeader so the next contributor who reaches for \`' '\` as a quick spacer hits the explanation before Ink does.

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run test:jest\` (1122 tests pass)
- [x] \`npm run build\`
- [ ] Manual: \`yarn coco ui\` mounts and renders the inspector tab header on history view without crashing

## Follow-up

Worth adding an \`ink-testing-library\` smoke test that mounts \`renderHistoryInspector\` so this class of bug (raw string in Box) gets caught in CI rather than at runtime. Tracked as part of the #808 sprint's reliability pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)