### PR TITLE
fix(log-tui): inspector tab swap on ←/→ instead of /-shaped hint

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -2259,5 +2259,59 @@ describe('log Ink input interactions', () => {
         { type: 'action', action: { type: 'setStatus', value: 'No commit selected' } },
       ])
     })
+
+    // ←/→ for inspector tab switching mirrors the sidebar pattern. The
+    // bracketed `[/]` notation that previously appeared in the chrome
+    // hint read as "press the / key" — which collides with the global
+    // filter trigger and was confusing users. Arrow keys are
+    // unambiguous + match the sidebar's existing left/right tab axis.
+    it('← on detail focus switches to the Inspector tab', () => {
+      const events = getLogInkInputEvents(
+        actionsFocusState(),
+        '',
+        { leftArrow: true },
+      )
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'setInspectorTab', value: 'inspector' } },
+      ])
+    })
+
+    it('→ on detail focus switches to the Actions tab', () => {
+      const events = getLogInkInputEvents(
+        actionsFocusState({ inspectorTab: 'inspector' }),
+        '',
+        { rightArrow: true },
+      )
+      expect(events).toEqual([
+        { type: 'action', action: { type: 'setInspectorTab', value: 'actions' } },
+      ])
+    })
+
+    it('←/→ on detail focus does not affect the global filter trigger', () => {
+      // The original `[/] switch` chrome hint suggested pressing `/` —
+      // which fires the global filter, not the inspector tab swap.
+      // ←/→ should fire setInspectorTab and nothing else; the global
+      // filter event (`toggleFilterMode`) must not appear in the
+      // dispatch list.
+      const left = getLogInkInputEvents(actionsFocusState(), '', { leftArrow: true })
+      const right = getLogInkInputEvents(actionsFocusState({ inspectorTab: 'inspector' }), '', { rightArrow: true })
+      for (const events of [left, right]) {
+        expect(events.find((e) =>
+          e.type === 'action' && e.action.type === 'toggleFilterMode'
+        )).toBeUndefined()
+      }
+    })
+
+    it('[/] keep working as alternates', () => {
+      // Existing keyboard alternates stay so muscle memory carries.
+      const lbracket = getLogInkInputEvents(actionsFocusState(), '[', {})
+      const rbracket = getLogInkInputEvents(actionsFocusState({ inspectorTab: 'inspector' }), ']', {})
+      expect(lbracket).toEqual([
+        { type: 'action', action: { type: 'cycleInspectorTab', delta: -1 } },
+      ])
+      expect(rbracket).toEqual([
+        { type: 'action', action: { type: 'cycleInspectorTab', delta: 1 } },
+      ])
+    })
   })
 })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -1133,6 +1133,19 @@ export function getLogInkInputEvents(
     return [action({ type: 'nextSidebarTab' })]
   }
 
+  // ←/→ on the inspector switch between the [Inspector] / [Actions]
+  // tabs, mirroring the sidebar's left/right tab semantics. `[` and
+  // `]` still work as keyboard alternatives, but the visible hint in
+  // the inspector chrome shows ←/→ because the bracketed `[/]`
+  // notation reads as "press the / key" — which is the global filter
+  // trigger and was making users think the binding was busted.
+  if (key.leftArrow && state.focus === 'detail') {
+    return [action({ type: 'setInspectorTab', value: 'inspector' })]
+  }
+  if (key.rightArrow && state.focus === 'detail') {
+    return [action({ type: 'setInspectorTab', value: 'actions' })]
+  }
+
   // ←/→ on the status surface jump between the staged / unstaged /
   // untracked groups — the horizontal axis is "between groups", the
   // vertical axis (↑/↓ below) is "within the active group's files".

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -4221,7 +4221,7 @@ function renderHistoryInspector(
       dimColor: activeTab !== 'actions',
     }, activeTab === 'actions' ? '[Actions]' : ' Actions '),
     ...(focused
-      ? [h(Text, { key: 'inspector-tabs-hint', dimColor: true }, '  · [/] switch')]
+      ? [h(Text, { key: 'inspector-tabs-hint', dimColor: true }, '  · ←/→ switch')]
       : []))
 
   // Tabbed mode (short terminals): render only the active tab's


### PR DESCRIPTION
## Summary

Two related inspector papercuts users hit on `0.40.0`:

1. The chrome hint read `· [/] switch`, which looks like "press the `/` key" — but `/` is the global filter trigger. Pressing `/` while the inspector was focused opened the filter input instead of swapping tabs, and the actual `[` / `]` bindings were undiscoverable behind the misleading notation.
2. `←` / `→` were unused on detail focus while the sidebar was already using them as its primary tab axis. Inconsistent navigation for no reason.

## Fix

- Wire `←` / `→` on detail focus to switch between the `[Inspector]` and `[Actions]` tabs, mirroring the sidebar's left/right tab semantics.
- Update the chrome hint to read `· ←/→ switch` — unambiguous, matches the sidebar's visual language, and stops colliding with the `/` filter trigger.
- `[` and `]` keep working as keyboard alternates so existing muscle memory carries.

## Test plan

- [x] `npm run lint`
- [x] `npm run test:jest` (1126 tests pass — added 4 new tests covering the ←/→ dispatch, the no-collision guarantee with `toggleFilterMode`, and the `[`/`]` alternates)
- [x] `npm run build`
- [x] `npm run test:cli`
- [ ] Manual: `coco ui`, `Tab` to inspector, `←` / `→` switches between `[Inspector]` and `[Actions]`; chrome shows `· ←/→ switch` hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)