### PR TITLE
feat(log-tui): defer commit-log fetch into runtime for instant boot (#808)

### DIFF
--- a/src/commands/log/handler.ts
+++ b/src/commands/log/handler.ts
@@ -22,17 +22,19 @@ export const handler: CommandHandler<LogArgv> = async (argv) => {
     return
   }
 
-  const rows = await getLogRows(git, argv)
-
+  // Interactive path defers the commit log fetch into the runtime
+  // (#808) so the TUI mounts immediately with a "Loading commits…"
+  // placeholder. The non-interactive (stdout) path still needs rows
+  // up-front because the formatter just dumps a static snapshot.
   if (argv.interactive && format === 'table') {
     await startCocoUiFromLogArgv(argv, {
       config,
       git,
-      rows,
     })
     return
   }
 
+  const rows = await getLogRows(git, argv)
   const result = format === 'json' ? formatLogJson(rows) : formatLogTable(rows)
 
   await handleResult({

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -260,6 +260,16 @@ type LogInkOptions = {
   idleTips?: boolean
   initialView?: LogInkView
   logArgv?: LogArgv
+  /**
+   * Deferred commit-log loader (#808). When set, the runtime mounts
+   * Ink immediately with whatever `rows` was passed (typically `[]`)
+   * and runs `loadRows` in a useEffect. The history surface shows a
+   * "Loading commits…" placeholder while the load is in flight; the
+   * loader's result is dispatched via `replaceRows` which clears the
+   * boot flag. Without this option the runtime keeps the previous
+   * eager behavior (caller awaits the rows before mount).
+   */
+  loadRows?: () => Promise<GitLogRow[]>
   theme?: LogInkThemeConfig
 }
 
@@ -314,6 +324,15 @@ type LogInkComponentDeps = LogInkRuntime & {
   initialView: LogInkView
   logArgv?: LogArgv
   rows: GitLogRow[]
+  /**
+   * Optional deferred commit-log loader (#808). When set, the React
+   * tree mounts with `rows` (typically `[]`) and runs the loader on
+   * mount, dispatching `replaceRows` on completion. Boot UX is the
+   * sole motivator — for a moderately large repo, awaiting `git log`
+   * before mount produces 1-3 seconds of black terminal that reads as
+   * "is this hanging?".
+   */
+  loadRows?: () => Promise<GitLogRow[]>
   theme: LogInkTheme
   /**
    * Mutable ref the runtime fills with a force-render callback. The
@@ -642,8 +661,15 @@ export async function startInkInteractiveLog(
   const output = streams.output || process.stdout
   const error = streams.error || process.stderr
 
+  // Non-TTY fallback (CI logs, piped output) needs the rows up-front
+  // because the renderer just dumps a static snapshot. Run the
+  // deferred loader synchronously here when present so callers get
+  // the same shape regardless of the entry path.
   if (!canStartLogInkTui(input, output)) {
-    await startInteractiveLog(git, rows, {
+    const fallbackRows = options.loadRows && rows.length === 0
+      ? await options.loadRows()
+      : rows
+    await startInteractiveLog(git, fallbackRows, {
       appLabel: options.appLabel,
       input,
       output,
@@ -665,6 +691,7 @@ export async function startInkInteractiveLog(
     ink,
     initialView: options.initialView || 'history',
     logArgv: options.logArgv,
+    loadRows: options.loadRows,
     React,
     rows,
     theme: createLogInkTheme(options.theme),
@@ -791,7 +818,7 @@ function enrichFilterActionWithRectification(
 }
 
 function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
-  const { appLabel, clipboardRunner, git, idleTipsEnabled, ink, initialView, logArgv, React, resumeRef, rows, theme } = deps
+  const { appLabel, clipboardRunner, git, idleTipsEnabled, ink, initialView, loadRows, logArgv, React, resumeRef, rows, theme } = deps
   const { Box, Text, useApp, useInput, useWindowSize } = ink
   const h = React.createElement
   const { exit } = useApp()
@@ -813,7 +840,14 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // initializer so the fs check only runs on mount, not every render.
   const [showOnboarding, setShowOnboarding] = React.useState<boolean>(() => !hasSeenOnboarding())
   const [state, setState] = React.useState<LogInkState>(() =>
-    createLogInkState(rows, { activeView: initialView })
+    createLogInkState(rows, {
+      activeView: initialView,
+      // Boot loader is in flight when caller passed `loadRows` and the
+      // initial rows array is empty. The history surface keys off the
+      // flag to render a "Loading commits…" placeholder instead of an
+      // empty-state hint.
+      bootLoading: Boolean(loadRows && rows.length === 0),
+    })
   )
   const [context, setContext] = React.useState<LogInkContext>({})
   const [contextStatus, setContextStatus] = React.useState<LogInkContextStatus>(() =>
@@ -905,6 +939,34 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
 
   const dispatch = React.useCallback((action: Parameters<typeof applyLogInkAction>[1]) => {
     setState((current) => applyLogInkAction(current, action))
+  }, [])
+
+  // Deferred commit-log loader (#808). Runs once on mount when the
+  // caller opted into the lazy boot path. The Ink tree is already on
+  // screen at this point — without this the user stares at a black
+  // terminal during the synchronous git log pre-mount fetch. The
+  // mounted-ref guard prevents a late-resolving promise from
+  // dispatching after the user `q` quits before rows arrive.
+  React.useEffect(() => {
+    if (!loadRows) return
+    let cancelled = false
+    void loadRows()
+      .then((nextRows) => {
+        if (cancelled || !mountedRef.current) return
+        dispatch({ type: 'replaceRows', rows: nextRows })
+      })
+      .catch((error: unknown) => {
+        if (cancelled || !mountedRef.current) return
+        const message = error instanceof Error ? error.message : String(error)
+        dispatch({ type: 'setStatus', value: `Failed to load commits: ${message}` })
+        dispatch({ type: 'setBootLoading', value: false })
+      })
+    return () => {
+      cancelled = true
+    }
+    // Intentionally one-shot — re-running the boot load on hot
+    // dispatch / loader changes would refetch the entire log on every
+    // re-render. The loader fires once per app mount and that's it.
   }, [])
 
   // Auto-dismiss status messages after a short window so transient
@@ -2406,7 +2468,13 @@ function renderHeader(
     ? `PR #${prInfo.number} ${prInfo.isDraft ? 'DRAFT' : prInfo.state}`
     : 'no PR'
   const search = state.filterMode ? `search: ${state.filter}_` : state.filter ? `filter: ${state.filter}` : ''
-  const loading = isLogInkContextLoading(contextStatus) ? '  loading context' : ''
+  // Boot loading wins over the per-context loading hint because it
+  // tells the user the headline thing they care about (commits aren't
+  // ready yet) — the context fetches finish independently and surface
+  // their own per-section loading copy in the sidebars.
+  const loading = state.bootLoading
+    ? '  loading commits'
+    : isLogInkContextLoading(contextStatus) ? '  loading context' : ''
   const breadcrumb = formatLogInkBreadcrumb(state.viewStack)
   const view = breadcrumb ? `  ${breadcrumb}` : ''
   // Mode indicator (P2.2) — surfaces the current input mode so users
@@ -2871,10 +2939,12 @@ function renderHistoryPanel(
     : []),
   ...(pendingNode ? [pendingNode] : []),
   visible.items.length === 0
-    ? h(Text, { dimColor: true }, formatLogInkHistoryEmpty({
-      filter: state.filter,
-      totalCommits: state.commits.length,
-    }))
+    ? h(Text, { dimColor: true }, state.bootLoading
+        ? formatLogInkLoading({ resource: 'commits' })
+        : formatLogInkHistoryEmpty({
+          filter: state.filter,
+          totalCommits: state.commits.length,
+        }))
     : visible.items.map((item, index) => {
       if (item.type === 'graph') {
         if (item.laneSegments && !theme.ascii) {

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -1121,4 +1121,33 @@ describe('log Ink view model', () => {
       expect(state.inspectorActionIndex).toBe(0)
     })
   })
+
+  // Boot loading flag (#808). Drives the "Loading commits…"
+  // placeholder + the "loading commits" header indicator while the
+  // deferred commit-log fetch is in flight on TUI mount.
+  describe('bootLoading', () => {
+    it('defaults to false', () => {
+      expect(createLogInkState(rows).bootLoading).toBe(false)
+    })
+
+    it('createLogInkState honors the bootLoading option', () => {
+      expect(createLogInkState([], { bootLoading: true }).bootLoading).toBe(true)
+    })
+
+    it('setBootLoading toggles the flag', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setBootLoading', value: true })
+      expect(state.bootLoading).toBe(true)
+      state = applyLogInkAction(state, { type: 'setBootLoading', value: false })
+      expect(state.bootLoading).toBe(false)
+    })
+
+    it('replaceRows clears bootLoading once rows arrive', () => {
+      let state = createLogInkState([], { bootLoading: true })
+      expect(state.bootLoading).toBe(true)
+      state = applyLogInkAction(state, { type: 'replaceRows', rows })
+      expect(state.bootLoading).toBe(false)
+      expect(state.commits.length).toBeGreaterThan(0)
+    })
+  })
 })

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -53,6 +53,7 @@ export type LogInkInspectorTab = 'inspector' | 'actions'
 
 export type CreateLogInkStateOptions = {
   activeView?: LogInkView
+  bootLoading?: boolean
 }
 
 export type LogInkState = {
@@ -230,6 +231,15 @@ export type LogInkState = {
    * entity context never sits highlighted.
    */
   inspectorActionIndex: number
+  /**
+   * True while the runtime is fetching the initial commit log (#808).
+   * Set when the TUI mounts with a `loadRows` deferred loader and
+   * cleared once the loader returns. Drives the "Loading commits…"
+   * placeholder in the history surface and the loading hint in the
+   * top header chrome — without this flag, an empty `filteredCommits`
+   * looks like "no commits found" rather than "still loading".
+   */
+  bootLoading: boolean
 }
 
 export type LogInkStatusFilterMask = {
@@ -324,6 +334,7 @@ export type LogInkAction =
   | { type: 'cycleInspectorTab'; delta: -1 | 1 }
   | { type: 'moveInspectorAction'; delta: number; actionCount: number }
   | { type: 'resetInspectorActionIndex' }
+  | { type: 'setBootLoading'; value: boolean }
   | { type: 'moveTag'; delta: number; count: number }
   | { type: 'moveStash'; delta: number; count: number }
   | { type: 'moveWorktreeListEntry'; delta: number; count: number }
@@ -620,6 +631,11 @@ function replaceRows(state: LogInkState, rows: GitLogRow[]): LogInkState {
     selectedFileIndex: 0,
     pendingCommitFocused: false,
     pendingKey: undefined,
+    // Rows just landed — clear the boot-loading flag so the history
+    // surface drops the "Loading commits…" placeholder. Safe to clear
+    // unconditionally because `replaceRows` only fires after a real
+    // git log returns.
+    bootLoading: false,
   }
 }
 
@@ -724,6 +740,7 @@ export function createLogInkState(
     diffViewMode: 'unified',
     inspectorTab: 'inspector',
     inspectorActionIndex: 0,
+    bootLoading: options.bootLoading ?? false,
   }
 }
 
@@ -933,6 +950,12 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         inspectorActionIndex: 0,
+        pendingKey: undefined,
+      }
+    case 'setBootLoading':
+      return {
+        ...state,
+        bootLoading: action.value,
         pendingKey: undefined,
       }
     case 'moveTag':

--- a/src/commands/ui/handler.ts
+++ b/src/commands/ui/handler.ts
@@ -49,12 +49,18 @@ export async function startCocoUiFromLogArgv(
 ): Promise<void> {
   const config = options.config || loadConfig<Config, LogArgv>(logArgv)
   const git = options.git || getRepo()
-  const rows = options.rows || (await getLogRows(git, logArgv))
+  // Defer the commit log fetch into the runtime when the caller
+  // didn't already have rows (#808). Mounts Ink immediately with a
+  // "Loading commits…" placeholder so the user never stares at a
+  // black terminal during the synchronous git log phase.
+  const rows = options.rows || []
+  const loadRows = options.rows ? undefined : () => getLogRows(git, logArgv)
 
   await startInkInteractiveLog(git, rows, {}, {
     appLabel: 'coco',
     idleTips: config.logTui?.idleTips,
     initialView: 'history',
+    loadRows,
     logArgv,
     theme: config.logTui?.theme,
   })
@@ -64,12 +70,12 @@ export async function startCocoUi(argv: UiArgv): Promise<void> {
   const config = loadConfig<Config, UiArgv>(argv)
   const git = getRepo()
   const logArgv = createLogArgvFromUiArgv(argv)
-  const rows = await getLogRows(git, logArgv)
 
-  await startInkInteractiveLog(git, rows, {}, {
+  await startInkInteractiveLog(git, [], {}, {
     appLabel: 'coco',
     idleTips: config.logTui?.idleTips,
     initialView: argv.view || 'history',
+    loadRows: () => getLogRows(git, logArgv),
     logArgv,
     theme: createUiTheme(config, argv),
   })


### PR DESCRIPTION
## Summary

First chunk of the #808 boot-perf umbrella. `coco ui` and `coco log -i` previously awaited `git log` synchronously before mounting Ink. On a moderately large repo that's a 1-3 second black-terminal stretch that reads as "is this hanging?" — by the time the first paint lands the user has already wondered whether they typed the wrong command.

Mount Ink immediately, dispatch the commit-log fetch from a mount-time useEffect, and surface the in-flight state with a "Loading commits…" placeholder.

## Behavior

| Before | After |
|--------|-------|
| Black terminal during `git log` (1-3s on large repos) | Ink mounts in <100ms with workstation chrome visible |
| Empty history view post-mount with no signal as to why | History surface shows `· Loading commits…` |
| Header reads `coco …` while context fetches happen | Header shows `… loading commits` until rows arrive |
| Empty history → "No commits in view." (looks like an empty repo) | Empty history during boot → "Loading commits…" placeholder |

Per-section "loading" hints inside the sidebar chrome were already present via `isLogInkContextLoading` + `formatLogInkLoading`. This PR addresses the gap *before* those start firing.

## Architecture

- New `loadRows: () => Promise<GitLogRow[]>` option on `startInkInteractiveLog`. When set, the runtime mounts with whatever `rows` was passed (typically `[]`) and runs the loader after first paint. The mounted-ref guard prevents a late-resolving promise from dispatching after the user `q` quits before rows arrive.
- New `bootLoading: boolean` state field with `setBootLoading` reducer action. `replaceRows` clears it implicitly; the loader's catch path also clears it (with a status hint) so a failed boot fetch doesn't leave the placeholder stuck on screen.
- Non-TTY fallback (CI logs, piped output) still resolves the loader synchronously before handing rows to the static formatter, so the stdout / JSON output path is unchanged.
- `coco ui`, `coco log -i`, and the `startCocoUiFromLogArgv` helper all opt in by default. The helper keeps its eager `rows` option so callers that already have rows skip the loader entirely (no double-fetch).

## Test plan

- [x] `npm run lint`
- [x] `npm run test:jest` (1130 tests pass — added 4 reducer tests covering `bootLoading` defaults, `setBootLoading` toggling, and the implicit clear on `replaceRows`)
- [x] `npm run build`
- [x] `npm run test:cli` (CLI smoke tests including non-TTY UI fallback)
- [ ] Manual: `coco ui` paints the workstation chrome immediately, history surface shows `· Loading commits…` for the duration of the `git log` fetch, then populates

## Follow-up

Tracked in #808's umbrella for later PRs in this sprint:
- Audit and parallelize independent context fetches (branches / tags / PR / etc.) — currently sequential in places (PR H)
- Disk cache for last-known overview so subsequent boots render an immediate stale-but-useful shell (PR I)
- Render cost profile + targeted memo audit on large repos (PR J)

🤖 Generated with [Claude Code](https://claude.com/claude-code)