### PR TITLE
feat(log-tui): per-repo disk cache of the last commit-log fetch (#808)

### DIFF
--- a/src/commands/log/inkOverviewCache.test.ts
+++ b/src/commands/log/inkOverviewCache.test.ts
@@ -1,0 +1,150 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { GitLogRow } from './data'
+import {
+  getOverviewCachePath,
+  readCachedCommits,
+  writeCachedCommits,
+} from './inkOverviewCache'
+
+describe('inkOverviewCache (#808)', () => {
+  let tmpRoot: string
+  let originalXdgCacheHome: string | undefined
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-overview-cache-'))
+    originalXdgCacheHome = process.env.XDG_CACHE_HOME
+    process.env.XDG_CACHE_HOME = tmpRoot
+  })
+
+  afterEach(() => {
+    if (originalXdgCacheHome === undefined) {
+      delete process.env.XDG_CACHE_HOME
+    } else {
+      process.env.XDG_CACHE_HOME = originalXdgCacheHome
+    }
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  const sampleRows: GitLogRow[] = [
+    {
+      type: 'commit',
+      graph: '*',
+      shortHash: 'abc1234',
+      hash: 'abc123456789',
+      parents: ['def567890123'],
+      date: '2026-05-03',
+      author: 'Coco Test',
+      refs: ['HEAD -> main'],
+      message: 'feat: cache the commit log',
+    },
+    {
+      type: 'commit',
+      graph: '*',
+      shortHash: 'def5678',
+      hash: 'def567890123',
+      parents: [],
+      date: '2026-05-02',
+      author: 'Coco Test',
+      refs: [],
+      message: 'docs: warm the boot path',
+    },
+  ]
+
+  describe('getOverviewCachePath', () => {
+    it('returns a coco/overview/commits.<key>.json path under XDG_CACHE_HOME', () => {
+      const cachePath = getOverviewCachePath('/repo/path')
+      expect(cachePath.startsWith(path.join(tmpRoot, 'coco', 'overview'))).toBe(true)
+      expect(cachePath).toMatch(/commits\.[a-f0-9]{16}\.json$/)
+    })
+
+    it('two different repo paths produce two different cache files', () => {
+      const a = getOverviewCachePath('/repo/a')
+      const b = getOverviewCachePath('/repo/b')
+      expect(a).not.toBe(b)
+    })
+
+    it('the same repo path is stable across calls', () => {
+      expect(getOverviewCachePath('/repo/x')).toBe(getOverviewCachePath('/repo/x'))
+    })
+  })
+
+  describe('writeCachedCommits / readCachedCommits round-trip', () => {
+    it('returns undefined when nothing has been cached yet', () => {
+      expect(readCachedCommits('/never/cached')).toBeUndefined()
+    })
+
+    it('writes rows under the correct key and reads them back intact', () => {
+      writeCachedCommits('/repo/foo', sampleRows)
+      const read = readCachedCommits('/repo/foo')
+      expect(read).toEqual(sampleRows)
+    })
+
+    it('different repos do not pollute each other\'s cache', () => {
+      writeCachedCommits('/repo/foo', sampleRows)
+      writeCachedCommits('/repo/bar', sampleRows.slice(0, 1))
+      expect(readCachedCommits('/repo/foo')).toHaveLength(2)
+      expect(readCachedCommits('/repo/bar')).toHaveLength(1)
+    })
+
+    it('overwrites prior cached data on subsequent writes', () => {
+      writeCachedCommits('/repo/x', sampleRows)
+      const first = sampleRows[0]
+      if (first.type !== 'commit') throw new Error('test fixture invariant violated')
+      const newer: GitLogRow[] = [{ ...first, message: 'fix: overwrite' }]
+      writeCachedCommits('/repo/x', newer)
+      expect(readCachedCommits('/repo/x')).toEqual(newer)
+    })
+
+    it('caps the stored row count at 500 to bound disk size', () => {
+      const first = sampleRows[0]
+      if (first.type !== 'commit') throw new Error('test fixture invariant violated')
+      const huge: GitLogRow[] = Array.from({ length: 750 }, (_, index) => ({
+        ...first,
+        hash: `hash-${index}`,
+        message: `commit ${index}`,
+      }))
+      writeCachedCommits('/repo/big', huge)
+      expect(readCachedCommits('/repo/big')).toHaveLength(500)
+    })
+  })
+
+  describe('robustness', () => {
+    it('returns undefined on a corrupt cache file (best-effort, never throws)', () => {
+      const cachePath = getOverviewCachePath('/repo/corrupt')
+      fs.mkdirSync(path.dirname(cachePath), { recursive: true })
+      fs.writeFileSync(cachePath, 'not valid json {{{')
+      expect(readCachedCommits('/repo/corrupt')).toBeUndefined()
+    })
+
+    it('returns undefined on a schema-version mismatch', () => {
+      const cachePath = getOverviewCachePath('/repo/oldformat')
+      fs.mkdirSync(path.dirname(cachePath), { recursive: true })
+      fs.writeFileSync(cachePath, JSON.stringify({
+        version: 999,
+        savedAt: new Date().toISOString(),
+        rows: sampleRows,
+      }))
+      expect(readCachedCommits('/repo/oldformat')).toBeUndefined()
+    })
+
+    it('returns undefined when rows is not an array', () => {
+      const cachePath = getOverviewCachePath('/repo/badshape')
+      fs.mkdirSync(path.dirname(cachePath), { recursive: true })
+      fs.writeFileSync(cachePath, JSON.stringify({
+        version: 1,
+        savedAt: new Date().toISOString(),
+        rows: 'not an array',
+      }))
+      expect(readCachedCommits('/repo/badshape')).toBeUndefined()
+    })
+
+    it('falls back to ~/.cache/coco when XDG_CACHE_HOME is unset', () => {
+      delete process.env.XDG_CACHE_HOME
+      const cachePath = getOverviewCachePath('/repo/x')
+      expect(cachePath.startsWith(path.join(os.homedir(), '.cache', 'coco', 'overview'))).toBe(true)
+    })
+  })
+})

--- a/src/commands/log/inkOverviewCache.ts
+++ b/src/commands/log/inkOverviewCache.ts
@@ -1,0 +1,95 @@
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { GitLogRow } from './data'
+
+/**
+ * Per-repo disk cache of the last successful commit-log fetch (#808).
+ * Lets the TUI render an immediate stale-but-useful history view on
+ * subsequent boots while the fresh `git log` runs in the background;
+ * once the fresh data lands the runtime swaps it in transparently.
+ *
+ * Strict best-effort: read failures fall back to "no cache" (boot
+ * shows the loading placeholder), and write failures are swallowed
+ * silently (next boot just doesn't have the cache yet). The cache is
+ * never load-bearing.
+ *
+ * Repos are keyed by a short hash of their absolute path. No PII in
+ * the cache filename, and re-creating a repo at the same path keeps
+ * the same cache.
+ */
+
+const CACHE_SCHEMA_VERSION = 1
+const CACHE_DIR_NAME = 'overview'
+
+/**
+ * Hard cap on rows we'll write per cache entry. The interactive
+ * default limit is 300; this caps growth in case a user opts into a
+ * much larger window. Keeps the cache file under ~200kb on a typical
+ * repo.
+ */
+const CACHE_ROW_HARD_CAP = 500
+
+type CacheEnvelope = {
+  version: number
+  savedAt: string
+  rows: GitLogRow[]
+}
+
+function resolveCacheDir(): string {
+  const xdg = process.env.XDG_CACHE_HOME
+  if (xdg && xdg.trim().length > 0) {
+    return path.join(xdg, 'coco', CACHE_DIR_NAME)
+  }
+  return path.join(os.homedir(), '.cache', 'coco', CACHE_DIR_NAME)
+}
+
+function repoKey(repoPath: string): string {
+  // sha1 here is a non-security cache-key derivation — we just need a
+  // deterministic short identifier for the cache filename so two repos
+  // at different paths never collide. No PII or auth context is hashed
+  // and no collision-resistance against an adversary is required.
+  // DevSkim DS126858 doesn't apply.
+  // DevSkim: ignore DS126858
+  return crypto.createHash('sha1').update(repoPath).digest('hex').slice(0, 16)
+}
+
+export function getOverviewCachePath(repoPath: string): string {
+  return path.join(resolveCacheDir(), `commits.${repoKey(repoPath)}.json`)
+}
+
+export function readCachedCommits(repoPath: string): GitLogRow[] | undefined {
+  try {
+    const raw = fs.readFileSync(getOverviewCachePath(repoPath), 'utf8')
+    const parsed = JSON.parse(raw) as CacheEnvelope
+    if (parsed.version !== CACHE_SCHEMA_VERSION) {
+      // Schema mismatch — quietly drop the stale entry on next write.
+      // Treating it as "no cache" keeps boot behavior predictable
+      // across upgrades.
+      return undefined
+    }
+    if (!Array.isArray(parsed.rows)) {
+      return undefined
+    }
+    return parsed.rows
+  } catch {
+    return undefined
+  }
+}
+
+export function writeCachedCommits(repoPath: string, rows: GitLogRow[]): void {
+  const file = getOverviewCachePath(repoPath)
+  const envelope: CacheEnvelope = {
+    version: CACHE_SCHEMA_VERSION,
+    savedAt: new Date().toISOString(),
+    rows: rows.slice(0, CACHE_ROW_HARD_CAP),
+  }
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true })
+    fs.writeFileSync(file, JSON.stringify(envelope))
+  } catch {
+    // Best-effort persistence; swallow.
+  }
+}

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -847,11 +847,13 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   const [state, setState] = React.useState<LogInkState>(() =>
     createLogInkState(rows, {
       activeView: initialView,
-      // Boot loader is in flight when caller passed `loadRows` and the
-      // initial rows array is empty. The history surface keys off the
-      // flag to render a "Loading commits…" placeholder instead of an
-      // empty-state hint.
-      bootLoading: Boolean(loadRows && rows.length === 0),
+      // Boot loader is in flight whenever the caller passed
+      // `loadRows`, regardless of whether `rows` was empty or
+      // pre-populated from the disk cache (#808). The history
+      // surface only shows the "Loading commits…" placeholder when
+      // there are zero visible commits, so cached data renders
+      // immediately while the chrome still flags the refresh.
+      bootLoading: Boolean(loadRows),
     })
   )
   const [context, setContext] = React.useState<LogInkContext>({})

--- a/src/commands/ui/handler.ts
+++ b/src/commands/ui/handler.ts
@@ -7,6 +7,7 @@ import { getRepo } from '../../lib/simple-git/getRepo'
 import { LogArgv, LogOptions } from '../log/config'
 import { GitLogRow, getLogRows } from '../log/data'
 import { startInkInteractiveLog } from '../log/inkRuntime'
+import { readCachedCommits, writeCachedCommits } from '../log/inkOverviewCache'
 import { LogInkThemeConfig } from '../log/inkTheme'
 import { UiArgv } from './config'
 
@@ -43,20 +44,48 @@ type StartCocoUiFromLogArgvOptions = {
   rows?: GitLogRow[]
 }
 
+/**
+ * Wrap a fresh-rows loader with the disk-cache write step. Lets the
+ * runtime stay caching-agnostic — it just receives the rows and
+ * doesn't know whether they came from cache or git, while the caller
+ * (which knows the repo path) handles persistence.
+ */
+function withCacheWrite(
+  repoPath: string,
+  loader: () => Promise<GitLogRow[]>
+): () => Promise<GitLogRow[]> {
+  return async () => {
+    const rows = await loader()
+    writeCachedCommits(repoPath, rows)
+    return rows
+  }
+}
+
 export async function startCocoUiFromLogArgv(
   logArgv: LogArgv,
   options: StartCocoUiFromLogArgvOptions = {}
 ): Promise<void> {
   const config = options.config || loadConfig<Config, LogArgv>(logArgv)
   const git = options.git || getRepo()
-  // Defer the commit log fetch into the runtime when the caller
-  // didn't already have rows (#808). Mounts Ink immediately with a
-  // "Loading commits…" placeholder so the user never stares at a
-  // black terminal during the synchronous git log phase.
-  const rows = options.rows || []
-  const loadRows = options.rows ? undefined : () => getLogRows(git, logArgv)
+  const repoPath = process.cwd()
 
-  await startInkInteractiveLog(git, rows, {}, {
+  // Three-stage boot (#808):
+  //   1. Read the disk cache and pass cached rows as the initial set
+  //      so the user sees the workstation chrome populated with
+  //      commits in the first frame.
+  //   2. Mount Ink immediately with those rows (or [] if no cache).
+  //   3. Run loadRows in the background to refresh — when fresh data
+  //      lands the runtime swaps it in transparently and we persist
+  //      the new rows back to the cache for next boot.
+  // Caller-provided rows skip the lazy path entirely (caller already
+  // has up-to-date data — no point redoing the fetch).
+  const cachedRows = options.rows ? undefined : readCachedCommits(repoPath)
+  const initialRows = options.rows || cachedRows || []
+  const loadRows = options.rows
+    ? undefined
+    : withCacheWrite(repoPath, () => getLogRows(git, logArgv))
+
+  await startInkInteractiveLog(git, initialRows, {}, {
     appLabel: 'coco',
     idleTips: config.logTui?.idleTips,
     initialView: 'history',
@@ -70,12 +99,17 @@ export async function startCocoUi(argv: UiArgv): Promise<void> {
   const config = loadConfig<Config, UiArgv>(argv)
   const git = getRepo()
   const logArgv = createLogArgvFromUiArgv(argv)
+  const repoPath = process.cwd()
 
-  await startInkInteractiveLog(git, [], {}, {
+  // Same three-stage boot as startCocoUiFromLogArgv — mount with
+  // cached rows for an instant-paint shell, refresh in background.
+  const cachedRows = readCachedCommits(repoPath)
+
+  await startInkInteractiveLog(git, cachedRows || [], {}, {
     appLabel: 'coco',
     idleTips: config.logTui?.idleTips,
     initialView: argv.view || 'history',
-    loadRows: () => getLogRows(git, logArgv),
+    loadRows: withCacheWrite(repoPath, () => getLogRows(git, logArgv)),
     logArgv,
     theme: createUiTheme(config, argv),
   })


### PR DESCRIPTION
## Summary

Third chunk of the #808 boot-perf umbrella. PR G removed the synchronous `git log` from the pre-mount path; PR H removed the duplicate `gh pr view` from the post-mount path. This PR adds the stale-while-revalidate piece — a per-repo disk cache of the most recent successful `git log` result, so subsequent boots paint the workstation chrome with a populated history view in the first frame.

## Behavior

| Boot | Before PR I | After PR I |
|------|-------------|------------|
| First boot in a repo | Empty history + "Loading commits…" placeholder, ~1-3s wait | Same — no cache yet |
| Second + boots | Same as first boot | History view populated immediately with cached rows; `loading commits` header indicator until fresh data lands |
| Workflow refresh | Re-fetches, surface re-renders | Re-fetches, persists fresh rows to cache for next boot |

## Architecture

- **New module** `src/commands/log/inkOverviewCache.ts`. Best-effort read/write helpers, versioned JSON envelope. Cache lives at `$XDG_CACHE_HOME/coco/overview/` (falls back to `~/.cache/coco/overview/`), keyed by `sha1(repoPath)` so two repos at different paths never collide. Hard cap at 500 rows per entry to bound disk size on repos where the user opts into a much larger interactive window than the default 300.
- **Failure modes**: read failures, schema mismatches, and bad JSON all return `undefined`; boot falls through to the existing loading placeholder. Write failures are swallowed silently. The cache is never load-bearing.
- **Wire-up**: `startCocoUi` + `startCocoUiFromLogArgv` read the cache on entry and pass cached rows as the initial set. Their `loadRows` callback wraps `getLogRows` with a `writeCachedCommits` step so every successful refresh persists the new rows back to disk for next boot.
- **`bootLoading` semantics**: now true whenever `loadRows` is in flight (was previously gated on `rows.length === 0`). The history surface still only paints the `Loading commits…` placeholder when there are zero visible commits, so cached data renders immediately; the chrome's `loading commits` header indicator continues to flag the in-flight refresh.

## Test plan

- [x] `npm run lint`
- [x] `npm run test:jest` (1142 tests pass — added 12 new tests covering cache path resolution, round-trip, repo isolation, the row cap, and graceful handling of corrupt / mis-versioned / wrong-shape cache files)
- [x] `npm run build`
- [x] `npm run test:cli`
- [ ] Manual: `coco ui` once on a fresh repo (boot shows `Loading commits…`); quit, run again — second boot should paint the history view immediately with cached commits while the header shows `loading commits` for the duration of the refresh

## Follow-up

- Cache also covers branches / tags / stashes / PR data — could extend the cache to hold those too. Deferred to a follow-up since commits are the highest-leverage cached resource and the surface most likely to read empty.
- PR J (render cost profile + memo audit) is the last chunk of the #808 umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)