### PR TITLE
fix(log-tui): expand right panel when help overlay is active (#832)

### DIFF
--- a/src/commands/log/inkLayout.test.ts
+++ b/src/commands/log/inkLayout.test.ts
@@ -102,4 +102,39 @@ describe('log Ink layout', () => {
     expect(narrow.sidebarWidth).toBe(32)
     expect(wide.sidebarWidth).toBe(50)
   })
+
+  // Help overlay (#832) — wrests width from the history panel so the
+  // hotkey descriptions stop truncating. Wins over both the at-rest
+  // and the inspector-focused states.
+  describe('helpOverlayActive', () => {
+    it('expands the detail panel beyond both at-rest and inspector-focused widths', () => {
+      const collapsed = getLogInkLayout({ columns: 160, rows: 40 })
+      const focused = getLogInkLayout({ columns: 160, rows: 40, inspectorFocused: true })
+      const help = getLogInkLayout({ columns: 160, rows: 40, helpOverlayActive: true })
+
+      expect(help.detailWidth).toBeGreaterThan(focused.detailWidth)
+      expect(help.detailWidth).toBeGreaterThan(collapsed.detailWidth)
+      // Main panel absorbs the loss so the three columns still tile
+      // across the terminal width.
+      expect(help.mainPanelWidth).toBe(160 - help.sidebarWidth - help.detailWidth)
+    })
+
+    it('clamps the help-overlay detail width to its 60-100 cell range', () => {
+      const narrow = getLogInkLayout({ columns: 80, rows: 24, helpOverlayActive: true })
+      const wide = getLogInkLayout({ columns: 240, rows: 60, helpOverlayActive: true })
+      expect(narrow.detailWidth).toBe(60)
+      expect(wide.detailWidth).toBe(100)
+    })
+
+    it('overrides inspectorFocused when both are set (help wins)', () => {
+      const both = getLogInkLayout({
+        columns: 160,
+        rows: 40,
+        inspectorFocused: true,
+        helpOverlayActive: true,
+      })
+      const helpOnly = getLogInkLayout({ columns: 160, rows: 40, helpOverlayActive: true })
+      expect(both.detailWidth).toBe(helpOnly.detailWidth)
+    })
+  })
 })

--- a/src/commands/log/inkLayout.ts
+++ b/src/commands/log/inkLayout.ts
@@ -15,6 +15,14 @@ export type LogInkLayoutInput = {
    * the inspection surface gets the room it needs.
    */
   inspectorFocused?: boolean
+  /**
+   * When true the right-hand panel takes a much larger share of the
+   * width so the help / hotkey overlay can render its descriptions
+   * without truncating to "Move focus...". The overlay is read-mostly
+   * so taking visual real estate from the history panel while it's
+   * open is fine — the user is paused on the help, not navigating.
+   */
+  helpOverlayActive?: boolean
 }
 
 export type LogInkLayout = {
@@ -64,9 +72,16 @@ export function getLogInkLayout(input: LogInkLayoutInput): LogInkLayout {
   // graph dominant; focus expansion gives the inspector room for long
   // commit bodies / file lists / action labels. Mirrors the sidebar
   // pattern (sidebarFocused above): instant transition per render.
-  const detailWidth = input.inspectorFocused
-    ? Math.max(36, Math.min(60, Math.floor(columns * 0.40)))
-    : Math.max(20, Math.min(32, Math.floor(columns * 0.22)))
+  //
+  // Help overlay overrides both — it borrows ~50% of the terminal so
+  // hotkey descriptions render in full instead of truncating to
+  // "Move focus...". Capped at 100 cells so a wide terminal doesn't
+  // waste an absurd amount of horizontal space on the cheat sheet.
+  const detailWidth = input.helpOverlayActive
+    ? Math.max(60, Math.min(100, Math.floor(columns * 0.50)))
+    : input.inspectorFocused
+      ? Math.max(36, Math.min(60, Math.floor(columns * 0.40)))
+      : Math.max(20, Math.min(32, Math.floor(columns * 0.22)))
   // Sidebar at rest: 22-34 cells (~24% of width). Focused: 32-50 cells
   // (~36% of width). The transition is instant per render — focus tab to
   // expand, focus away to collapse.

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -2453,6 +2453,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     rows: windowSize.rows || process.stdout.rows || LOG_INK_DEFAULT_ROWS,
     sidebarFocused: state.focus === 'sidebar',
     inspectorFocused: state.focus === 'detail',
+    helpOverlayActive: state.showHelp,
   })
 
   if (layout.tooSmall) {


### PR DESCRIPTION
Closes #832.

## Summary

The `?` help / hotkey overlay rendered into the inspector's at-rest narrow width (~22% of terminal), which truncated every action description to `Move focus...`, `Push the d...`, and so on. Users could see the keys but not what they did, defeating the purpose of an in-app help overlay.

## Fix

Borrow ~50% of the terminal width for the help panel while it's open (clamped to 60-100 cells). The overlay is read-mostly so taking visual real estate from the history panel while it's up is fine — the user is paused on the help, not navigating.

- New `helpOverlayActive` layout input flag. The runtime passes `state.showHelp` into `getLogInkLayout`; when true, `detailWidth` becomes `max(60, min(100, columns × 0.50))` regardless of inspector focus.
- The flag wins over both the at-rest and the inspector-focused widths so the override behaves the same regardless of which focus the user came from.
- Help-panel render path is unchanged; it just receives a wider `width` and the `truncate(line, width - 4)` call now has enough room to render full descriptions.

## Test plan

- [x] `npm run lint`
- [x] `npm run test:jest` (1145 tests pass — added 3 new layout tests covering the expansion, the 60-100 clamp, and the help-wins-over-inspectorFocused precedence)
- [x] `npm run build`
- [x] `npm run test:cli`
- [ ] Manual: `coco ui` on a typical terminal width, press `?`, verify hotkey descriptions render in full instead of truncating to "..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)