### PR TITLE
fix(log-tui): truncate history rows to actual panel width (#830)

### DIFF
--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -3034,13 +3034,13 @@ function renderHistoryPanel(
         }, truncate(substituteGraphChars(
           item.graph.padEnd(visible.graphWidth),
           { ascii: theme.ascii }
-        ), 140))
+        ), Math.max(8, width - 4)))
       }
 
       return renderCommitHistoryRow(
         h, Text, item.commit, item.graph, visible.graphWidth,
         Boolean(item.selected) && !realSelectionSuppressed, theme, index,
-        item.laneSegments
+        width, item.laneSegments
       )
     }))
 }
@@ -3105,12 +3105,24 @@ function renderCommitHistoryRow(
   selected: boolean,
   theme: LogInkTheme,
   index: number,
+  panelWidth: number,
   laneSegments?: LaneSegment[]
 ): ReactTypes.ReactElement {
   const refs = formatInkRefLabels(commit.refs)
-  const totalWidth = 140
+  // Total cells available to the row content. Earlier revisions used a
+  // hardcoded 140 here, which let row content overflow whenever the
+  // panel was narrower than that — Ink would wrap onto a second visual
+  // line and the next commit's graph indicator landed against the wrap
+  // continuation rather than its own commit (#830). Subtracting 4
+  // accounts for the panel's left + right border + 1-cell padding.
+  const totalWidth = Math.max(20, panelWidth - 4)
   const fixedWidth = graphWidth + 1 + commit.shortHash.length + 1 + commit.date.length + 1
-  const messageRoom = Math.max(8, totalWidth - fixedWidth - cellWidth(refs))
+  // Refs trail the message and shrink first when the row is narrow:
+  // the user can always see the full ref list in the inspector, so
+  // the headline subject keeps priority over decoration.
+  const refsRoom = Math.max(0, totalWidth - fixedWidth - 8)
+  const refsTrunc = refs ? truncate(refs, refsRoom) : ''
+  const messageRoom = Math.max(8, totalWidth - fixedWidth - cellWidth(refsTrunc))
   const message = truncate(commit.message, messageRoom)
 
   const selectedBg = selected && !theme.noColor ? theme.colors.selection : undefined
@@ -3137,7 +3149,7 @@ function renderCommitHistoryRow(
   h(Text, { dimColor: true }, commit.date),
   ' ',
   h(Text, undefined, message),
-  refs ? h(Text, { color: accent }, refs) : null)
+  refsTrunc ? h(Text, { color: accent }, refsTrunc) : null)
 }
 
 /**


### PR DESCRIPTION
Closes #830.

## Summary

`renderCommitHistoryRow` used a hardcoded `totalWidth = 140` for its truncation budget. When the actual main panel was narrower than 140 cells (any time the inspector or sidebar was focused, on the help overlay's wider right panel that just shipped, or on narrower terminals generally), row content overflowed and Ink wrapped the extra onto a second visual line. The next commit's graph indicator then landed against the wrap continuation rather than its own commit, breaking the perceived 1:1 between graph rows and commits.

## Fix

- Thread the actual panel width through `renderCommitHistoryRow` and the graph-only row branch.
- Derive `totalWidth` from `panelWidth - 4` (border + 1-cell padding each side).
- Refs trail the message and shrink first when the row is narrow — the user can always see the full ref list in the inspector under `Refs:`, so the headline subject keeps priority over decoration.

## Test plan

- [x] `npm run lint`
- [x] `npm run test:jest` (1145 tests pass)
- [x] `npm run build`
- [x] `npm run test:cli`
- [ ] Manual: `coco ui` on a moderately wide terminal, focus the inspector to narrow the history panel, verify long subjects + ref-heavy commits no longer wrap onto a second visual line

## Follow-up

Several other surfaces still hardcode `truncate(..., 140)` (compose panel, sidebar lists, status surface in places). They don't show the same severity since their content is shorter, but they're worth a sweep — tracking inside the existing visual-fidelity work or as a follow-up if any one of them surfaces visibly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)