### PR TITLE
fix(log-tui): dim graph-only lane-closure rows so they recede (#831)

### DIFF
--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -3021,16 +3021,23 @@ function renderHistoryPanel(
         }))
     : visible.items.map((item, index) => {
       if (item.type === 'graph') {
+        // Graph-only rows are git's lane-closure scaffolding (`|/`,
+        // `|\`, etc.) — they're real topology but visually they look
+        // like blank rows that the user might wonder if they
+        // accidentally skipped a commit on (#831). Render dim-on-dim
+        // so they retreat as connectors rather than competing with
+        // commit rows for the eye's attention.
         if (item.laneSegments && !theme.ascii) {
-          return h(Text, { key: `graph-${index}-${item.graph}` },
+          return h(Text, { key: `graph-${index}-${item.graph}`, dimColor: true },
             ...renderLaneSegmentSpans(
-              h, Text, item.laneSegments, theme, visible.graphWidth, `g${index}`
+              h, Text, item.laneSegments, theme, visible.graphWidth, `g${index}`,
+              { forceDim: true }
             ))
         }
         return h(Text, {
           key: `graph-${index}-${item.graph}`,
           color: theme.noColor ? undefined : theme.colors.muted,
-          dimColor: theme.noColor,
+          dimColor: true,
         }, truncate(substituteGraphChars(
           item.graph.padEnd(visible.graphWidth),
           { ascii: theme.ascii }
@@ -3061,7 +3068,8 @@ function renderLaneSegmentSpans(
   segments: LaneSegment[],
   theme: LogInkTheme,
   padTo: number,
-  keyPrefix: string
+  keyPrefix: string,
+  options: { forceDim?: boolean } = {}
 ): ReactTypes.ReactElement[] {
   const muted = theme.noColor ? undefined : theme.colors.muted
   const elements: ReactTypes.ReactElement[] = []
@@ -3072,7 +3080,12 @@ function renderLaneSegmentSpans(
     elements.push(h(Text, {
       key: `${keyPrefix}-${idx}`,
       color: laneColor ?? muted,
-      dimColor: theme.noColor && seg.laneId === undefined,
+      // Ink does not cascade dimColor from a parent Text to children,
+      // so the caller's "this whole row should fade" intent has to
+      // travel here as an explicit flag (#831). Used for graph-only
+      // lane-closure rows, where the lane colors otherwise compete
+      // for attention with the commits they connect.
+      dimColor: options.forceDim || (theme.noColor && seg.laneId === undefined),
     }, seg.text))
     totalLen += seg.text.length
   })


### PR DESCRIPTION
Closes #831.

## Summary

In full graph mode, `git --graph` emits lane-closure rows (`|/`, `|\`, etc.) between commits to indicate where branches converge. Visually those rows were rendering at the same color weight as commit rows, so the eye read them as blank rows where a commit was skipped — the user reported this as "breaks in the commit graph".

## Fix

Force-dim graph-only rows so they retreat as topology connectors rather than competing with commit content for attention. Two pieces:

- The outer `Text` for the graph-only row gets `dimColor: true`.
- `renderLaneSegmentSpans` gains a `forceDim` option that dims every inner segment regardless of its lane id. Without this, the per-lane colored segments (each branch's column gets a distinct color) overrode the outer dim and the row stayed visually prominent. Ink does not cascade `dimColor` from a parent `Text` down to children, so the caller's "the whole row should fade" intent has to travel through as an explicit flag.

The lane topology stays intact — the user can still see how branches converge — but the closure rows visually settle into the background as scaffolding instead of reading as missing data.

## Test plan

- [x] `npm run lint`
- [x] `npm run test:jest` (1145 tests pass)
- [x] `npm run build`
- [x] `npm run test:cli`
- [ ] Manual: `coco ui` on `main`, press `\` to enter full graph mode, scroll through merge-heavy regions and verify lane-closure rows fade visually while commit rows stay sharp

## Follow-up

- A more aggressive option would be to suppress trivial closure rows entirely, but that loses the topology fidelity full graph mode is for. The dim treatment keeps the data and just rebalances the visual hierarchy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)