### PR TITLE
feat(log-tui): aligned columns for branches / tags / worktrees views (#833)

### DIFF
--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -3521,6 +3521,15 @@ function renderBranchesSurface(
     : `${localBranches.length}/${sortedAll.length} local | current: ${branches?.currentBranch || '<detached>'}${filterLabel}${sortLabel}`
   const emptyLabel = formatLogInkBranchesEmpty({ filter: state.filter })
   const loadingLabel = formatLogInkLoading({ resource: 'branches' })
+  // Per-column width derived from the visible window (#833) so columns
+  // align across rows regardless of name length. Padded to the longest
+  // name in view so short rows fill out instead of leaving a gutter;
+  // capped at 40 cells so one runaway long branch name doesn't blow
+  // out the timestamp column entirely (longer names get truncated and
+  // the timestamp stays where the user expects it).
+  const nameColWidth = visible.length === 0
+    ? 28
+    : Math.min(40, Math.max(8, ...visible.map((branch) => branch.shortName.length)))
   const lines: ReactTypes.ReactNode[] = loading
     ? [h(Text, { key: 'branches-loading', dimColor: true }, loadingLabel)]
     : localBranches.length === 0
@@ -3534,18 +3543,18 @@ function renderBranchesSurface(
         const lastTouched = formatBranchLastTouched(branch.date, new Date())
         // Split the row into spans so the timestamp stays dim even on the
         // currently-selected (bold) row. The leading marker + name keep
-        // their original column widths; the timestamp is right-padded so
-        // the divergence column stays aligned across rows.
-        const namePadded = branch.shortName.padEnd(28)
+        // their per-window-derived column widths; the timestamp is
+        // right-padded so the divergence column stays aligned across rows.
+        const namePadded = truncate(branch.shortName, nameColWidth).padEnd(nameColWidth)
         const timestampPadded = lastTouched.padEnd(8)
         const lineDim = !isSelected && !branch.current
         const head = `${cursor} ${marker} ${namePadded} `
         const trailingDivergence = divergence ? ` ${divergence}` : ''
-        // Truncate the assembled line cooperatively so we never overflow
-        // the panel; the timestamp is short and the divergence is the
-        // most expendable, but the existing 140 cap is ample.
+        // Truncate the assembled line to the actual panel width so a
+        // narrow inspector / sidebar focus doesn't push branch rows
+        // onto a second visual line (#830).
         const fullText = `${head}${timestampPadded}${trailingDivergence}`
-        const truncated = truncate(fullText, 140)
+        const truncated = truncate(fullText, Math.max(20, width - 4))
         // If truncation chopped into the timestamp/divergence portion,
         // fall back to a single Text to keep the visible width honest.
         if (truncated !== fullText) {
@@ -3610,6 +3619,13 @@ function renderTagsSurface(
     : `${tags.length}/${sortedAll.length} tags${filterLabel}${sortLabel}`
   const emptyLabel = formatLogInkTagsEmpty({ filter: state.filter })
   const loadingLabel = formatLogInkLoading({ resource: 'tags' })
+  // Per-window name column width (#833) so short tags don't leave a
+  // wide gutter and long tags don't push the subject off-screen. Cap
+  // matches the branches surface for visual consistency across the
+  // promoted views.
+  const tagNameColWidth = visible.length === 0
+    ? 20
+    : Math.min(40, Math.max(8, ...visible.map((tag) => tag.name.length)))
   const lines: ReactTypes.ReactNode[] = loading
     ? [h(Text, { key: 'tags-loading', dimColor: true }, loadingLabel)]
     : tags.length === 0
@@ -3623,8 +3639,11 @@ function renderTagsSurface(
         // formatHyperlink wraps just the tag name, leaving width math
         // intact.
         const url = buildRefUrl(context.provider?.repository, tag.name)
-        const namePadded = tag.name.padEnd(20)
-        const lineText = truncate(`${cursor} ${namePadded} ${tag.subject}`, 140)
+        const namePadded = truncate(tag.name, tagNameColWidth).padEnd(tagNameColWidth)
+        const lineText = truncate(
+          `${cursor} ${namePadded} ${tag.subject}`,
+          Math.max(20, width - 4)
+        )
         if (!url || lineText.indexOf(namePadded) < 0) {
           return h(Text, {
             key: `tag-${index}`,
@@ -3745,6 +3764,17 @@ function renderWorktreesSurface(
   const headerRight = loading
     ? 'loading worktrees'
     : `${worktrees.length}/${allWorktrees.length} worktrees${filterLabel}`
+  // Per-window branch column width (#833). Worktrees often track
+  // branches with names varying widely in length (`main` vs.
+  // `feat/tui-something-long`); fixed-width padding either left a
+  // huge gutter on short rows or pushed the path column off-screen on
+  // long ones. Cap matches the other promoted surfaces.
+  const branchColWidth = visible.length === 0
+    ? 28
+    : Math.min(40, Math.max(8, ...visible.map((entry) => {
+      const label = entry.branch ? entry.branch : entry.head || '<detached>'
+      return label.length
+    })))
   const lines: ReactTypes.ReactNode[] = loading
     ? [h(Text, { key: 'worktrees-loading', dimColor: true }, formatLogInkLoading({ resource: 'worktrees' }))]
     : worktrees.length === 0
@@ -3756,12 +3786,13 @@ function renderWorktreesSurface(
         const marker = entry.current ? '*' : ' '
         const branchLabel = entry.branch ? entry.branch : entry.head || '<detached>'
         const stateLabel = entry.dirty ? 'dirty' : 'clean'
+        const branchPadded = truncate(branchLabel, branchColWidth).padEnd(branchColWidth)
         return h(Text, {
           key: `worktree-${index}`,
           bold: isSelected,
           dimColor: !isSelected && !entry.current,
         }, truncate(
-          `${cursor} ${marker} ${branchLabel.padEnd(28)} ${stateLabel.padEnd(6)} ${entry.path}`,
+          `${cursor} ${marker} ${branchPadded} ${stateLabel.padEnd(6)} ${entry.path}`,
           width - 4
         ))
       })


### PR DESCRIPTION
Closes #833.

## Summary

The promoted views (branches, tags, worktrees) previously padded their name / branch columns to a hardcoded width (28 cells for branches and worktrees, 20 for tags). That meant short rows left a wide gutter before the trailing columns, while long names overflowed and pushed everything rightward out of alignment.

## Fix

Compute the column width per render from the longest entry in the visible window, capped at 40 cells so one runaway long branch / tag / worktree label doesn't blow the trailing columns off-screen. Truncate long entries inside the column and pad short entries out to match — both sides converge so the timestamp / subject / state column lands in the same spot on every row.

Same change applied to all three promoted-view renderers:

- **Branches:** name column auto-fits the visible window, timestamp + divergence stay aligned across rows.
- **Tags:** name column auto-fits the visible window, subject takes the rest of the panel.
- **Worktrees:** branch column auto-fits the visible window, state + path stay aligned.

Also threaded the actual panel width into the per-row truncate budgets (was hardcoded to 140), matching the same fix from #830 on the history surface — narrow inspector / sidebar focus no longer causes promoted-view rows to wrap.

## Why this and not `ink-table`

`ink-table` would give us headers and borders for free but adds a runtime dependency and forces a more rigid table layout. The inline approach matches the rest of the TUI's render style (per-renderer inline `.map()` calls with tuned styling) and lets each surface keep its row-level coloring (current branch bold, dim non-current, etc.) without working around a generic component.

## Test plan

- [x] `npm run lint`
- [x] `npm run test:jest` (1145 tests pass)
- [x] `npm run build`
- [x] `npm run test:cli`
- [ ] Manual: `coco ui`, drill into branches (`g b`) / tags (`g t`) / worktrees (`g w`) on this repo and verify columns align across rows regardless of name length

🤖 Generated with [Claude Code](https://claude.com/claude-code)