### PR TITLE
feat(log-tui): show counts on compose Staged / Unstaged section headers (#840)

### DIFF
--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -4735,7 +4735,13 @@ function renderComposeContextPanel(
     : []),
   ...(stagedFiles.length
     ? [
-      h(Text, { key: 'compose-context-staged-title', bold: true }, 'Staged'),
+      // Section header carries the total count to match the status
+      // surface's "▾ Staged (n)" treatment (#840). The visible
+      // file list is sliced at 12 rows; using `worktree.stagedCount`
+      // (the total) avoids a misleading "Staged (12)" label when
+      // there are actually more staged files below the slice.
+      h(Text, { key: 'compose-context-staged-title', bold: true },
+        `Staged (${worktree?.stagedCount ?? stagedFiles.length})`),
       ...stagedFiles.map((file, index) => h(Text, {
         key: `compose-context-staged-${index}`,
         color: theme.noColor ? undefined : theme.colors.gitAdded,
@@ -4745,7 +4751,8 @@ function renderComposeContextPanel(
     : []),
   ...(unstagedFiles.length
     ? [
-      h(Text, { key: 'compose-context-unstaged-title', bold: true }, 'Unstaged'),
+      h(Text, { key: 'compose-context-unstaged-title', bold: true },
+        `Unstaged (${worktree?.unstagedCount ?? unstagedFiles.length})`),
       ...unstagedFiles.map((file, index) => h(Text, {
         key: `compose-context-unstaged-${index}`,
         color: theme.noColor ? undefined : theme.colors.gitModified,


### PR DESCRIPTION
Closes #840.

## Summary

Compose view's right-hand Worktree panel rendered `Staged` / `Unstaged` as bare section labels while the status surface (post-#791) shows `▾ Staged (n)` / `▾ Unstaged (n)`. Visual language now matches across surfaces.

## Behavior

| Before | After |
|--------|-------|
| `Staged` | `Staged (9)` |
| `Unstaged` | `Unstaged (1)` |

Counts come from the worktree overview totals (`stagedCount` / `unstagedCount`) rather than the visible-after-slice file list, so "Staged (12)" never lies when there are actually more staged files hiding below the 12-row slice. Falls back to the visible count when the overview hasn't loaded yet.

## Test plan

- [x] `npm run lint`
- [x] `npm run test:jest` (1145 tests pass)
- [x] `npm run build`
- [x] `npm run test:cli`
- [ ] Manual: `coco ui` on a repo with staged + unstaged changes, `gc` to compose view, verify the right-hand Worktree panel shows `Staged (n)` / `Unstaged (n)` matching the status surface

## Follow-up

The "remove the duplicate count from the compose pane header" piece from #840 is left as a separate UX call. The header line `9 staged | 1 unstaged` is now redundant with the section header counts on the right, but removing it changes a visible affordance and is worth its own discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)