### PR TITLE
fix(config): merge user ignoredFiles/Extensions with defaults (#851)

### DIFF
--- a/src/lib/config/utils/loadConfig.test.ts
+++ b/src/lib/config/utils/loadConfig.test.ts
@@ -1,5 +1,6 @@
 import { BaseArgvOptions, BaseCommandOptions } from '../../../commands/types'
 import { getDefaultServiceConfigFromAlias } from '../../langchain/utils'
+import { DEFAULT_IGNORED_EXTENSIONS, DEFAULT_IGNORED_FILES } from '../constants'
 import { loadConfig } from './loadConfig'
 import * as fs from 'fs'
 
@@ -63,5 +64,39 @@ describe('loadConfig', () => {
     // Cleanup
     delete process.env.OPENAI_API_KEY
     delete process.env.COCO_TOKEN_LIMIT
+  })
+
+  it('keeps default ignored files / extensions when project config provides only a subset (#851)', () => {
+    // Repro for #851: a user's `.coco.config.json` that includes
+    // ignoredExtensions but omits the lockfile entries used to wipe
+    // the canonical defaults. The merge step in loadConfig keeps the
+    // defaults regardless of what the user provides.
+    mockFs.existsSync.mockImplementation((filepath: fs.PathLike | undefined) => {
+      return filepath
+        ? ['.coco.config.json'].includes(filepath.toString())
+        : false
+    })
+    mockFs.readFileSync.mockImplementation((filepath) => {
+      if (filepath.toString() === '.coco.config.json') {
+        return JSON.stringify({
+          ignoredExtensions: ['.snap'],
+          ignoredFiles: ['mySecret.json'],
+        })
+      }
+      return ''
+    })
+
+    const config = loadConfig<BaseCommandOptions>({} as BaseArgvOptions)
+
+    // User additions are preserved.
+    expect(config.ignoredExtensions).toContain('.snap')
+    expect(config.ignoredFiles).toContain('mySecret.json')
+    // Defaults are still present — this is the bug fix.
+    for (const ext of DEFAULT_IGNORED_EXTENSIONS) {
+      expect(config.ignoredExtensions).toContain(ext)
+    }
+    for (const fileName of DEFAULT_IGNORED_FILES) {
+      expect(config.ignoredFiles).toContain(fileName)
+    }
   })
 })

--- a/src/lib/config/utils/loadConfig.ts
+++ b/src/lib/config/utils/loadConfig.ts
@@ -7,6 +7,7 @@ import { Config } from '../types'
 
 import { DEFAULT_CONFIG } from '../constants'
 import { BaseCommandOptions } from '../../../commands/types'
+import { mergeIgnoreLists } from './mergeIgnoreLists'
 
 export type ConfigSource =
   | 'default'
@@ -77,6 +78,14 @@ export function loadConfig<ConfigType, ArgvType = BaseCommandOptions>(argv = {} 
   const { config: envConfig, active: envActive } = loadEnvConfig(config, { returnSource: true })
   config = envConfig
   if (envActive) sources.push({ source: 'env' })
+
+  // Re-apply the canonical default ignore lists after every loader has
+  // had a chance to override (#851). Each loader replaces ignoredFiles
+  // / ignoredExtensions wholesale via shallow spread, which used to
+  // silently drop the lockfile + node_modules defaults the moment a
+  // user provided their own list. The merge is a union — defaults first,
+  // user-only entries appended.
+  config = mergeIgnoreLists(config)
 
   _lastConfigSources = sources
 

--- a/src/lib/config/utils/mergeIgnoreLists.test.ts
+++ b/src/lib/config/utils/mergeIgnoreLists.test.ts
@@ -1,0 +1,75 @@
+import { DEFAULT_IGNORED_EXTENSIONS, DEFAULT_IGNORED_FILES } from '../constants'
+import { Config } from '../types'
+import { mergeIgnoreLists } from './mergeIgnoreLists'
+
+const baseConfig = (overrides: Partial<Config>) =>
+  ({ ...overrides } as unknown as Config)
+
+describe('mergeIgnoreLists (#851)', () => {
+  it('returns the defaults when user has provided no custom lists', () => {
+    const merged = mergeIgnoreLists(baseConfig({}))
+    expect(merged.ignoredFiles).toEqual(DEFAULT_IGNORED_FILES)
+    expect(merged.ignoredExtensions).toEqual(DEFAULT_IGNORED_EXTENSIONS)
+  })
+
+  it('appends user ignoredFiles after the defaults without duplicates', () => {
+    const merged = mergeIgnoreLists(
+      baseConfig({ ignoredFiles: ['mySecret.json', 'package-lock.json'] })
+    )
+    // Defaults first (full set, in original order)
+    expect(merged.ignoredFiles?.slice(0, DEFAULT_IGNORED_FILES.length)).toEqual(
+      DEFAULT_IGNORED_FILES
+    )
+    // Then user-only additions
+    expect(merged.ignoredFiles).toContain('mySecret.json')
+    // No duplicate of the existing default
+    const counts = (merged.ignoredFiles as string[]).reduce<Record<string, number>>(
+      (acc, key) => ({ ...acc, [key]: (acc[key] ?? 0) + 1 }),
+      {}
+    )
+    expect(counts['package-lock.json']).toBe(1)
+  })
+
+  it('appends user ignoredExtensions after the defaults without duplicates', () => {
+    const merged = mergeIgnoreLists(
+      baseConfig({ ignoredExtensions: ['.snap', '.lock'] })
+    )
+    expect(merged.ignoredExtensions?.slice(0, DEFAULT_IGNORED_EXTENSIONS.length)).toEqual(
+      DEFAULT_IGNORED_EXTENSIONS
+    )
+    expect(merged.ignoredExtensions).toContain('.snap')
+    const counts = (merged.ignoredExtensions as string[]).reduce<Record<string, number>>(
+      (acc, key) => ({ ...acc, [key]: (acc[key] ?? 0) + 1 }),
+      {}
+    )
+    expect(counts['.lock']).toBe(1)
+  })
+
+  it('cannot drop a default — replacement attempts still keep all defaults', () => {
+    // Repro of #851: a user that drops the lockfile entries from their
+    // config used to wipe them; now the defaults are always present.
+    const merged = mergeIgnoreLists(
+      baseConfig({
+        ignoredFiles: ['mySecret.json'],
+        ignoredExtensions: ['.snap'],
+      })
+    )
+    for (const fileName of DEFAULT_IGNORED_FILES) {
+      expect(merged.ignoredFiles).toContain(fileName)
+    }
+    for (const ext of DEFAULT_IGNORED_EXTENSIONS) {
+      expect(merged.ignoredExtensions).toContain(ext)
+    }
+  })
+
+  it('preserves other config fields untouched', () => {
+    const config = baseConfig({
+      ignoredFiles: ['extra.json'],
+      defaultBranch: 'main',
+      verbose: true,
+    } as Partial<Config>)
+    const merged = mergeIgnoreLists(config)
+    expect((merged as Config).defaultBranch).toBe('main')
+    expect((merged as Config).verbose).toBe(true)
+  })
+})

--- a/src/lib/config/utils/mergeIgnoreLists.ts
+++ b/src/lib/config/utils/mergeIgnoreLists.ts
@@ -1,0 +1,42 @@
+import { DEFAULT_IGNORED_EXTENSIONS, DEFAULT_IGNORED_FILES } from '../constants'
+import { Config } from '../types'
+
+/**
+ * Ensure the canonical default ignore lists are always present in
+ * the resolved config (#851). User-provided `ignoredFiles` /
+ * `ignoredExtensions` arrays from XDG / git / project / env config
+ * sources used to *replace* the defaults wholesale via the shallow
+ * spread in each loader, which silently dropped lockfile + node_modules
+ * entries the moment a user provided their own list. The reported
+ * symptom: `pnpm-lock.yaml` reaching the diff-condensing pipeline
+ * after a user added `.coco.config.json` for unrelated overrides.
+ *
+ * Now: user values are *unioned* with the defaults. Order is preserved
+ * (defaults first, then user-only additions in their original order).
+ * Duplicates are de-duped. The defaults can no longer be opted out of —
+ * the cost of accidentally summarizing a lockfile (minutes of LLM time
+ * per commit) outweighs the niche case of intentionally excluding a
+ * default lockfile pattern.
+ */
+function unionPreservingOrder(base: string[], extras: string[] | undefined): string[] {
+  if (!extras || extras.length === 0) return [...base]
+  const seen = new Set(base)
+  const merged = [...base]
+  for (const value of extras) {
+    if (!seen.has(value)) {
+      seen.add(value)
+      merged.push(value)
+    }
+  }
+  return merged
+}
+
+export function mergeIgnoreLists<T extends Pick<Config, 'ignoredFiles' | 'ignoredExtensions'>>(
+  config: T
+): T {
+  return {
+    ...config,
+    ignoredFiles: unionPreservingOrder(DEFAULT_IGNORED_FILES, config.ignoredFiles),
+    ignoredExtensions: unionPreservingOrder(DEFAULT_IGNORED_EXTENSIONS, config.ignoredExtensions),
+  }
+}


### PR DESCRIPTION
Closes #851.

## Summary

User-provided \`ignoredFiles\` / \`ignoredExtensions\` arrays from XDG, git, project, or env config used to **replace** \`DEFAULT_IGNORED_FILES\` / \`DEFAULT_IGNORED_EXTENSIONS\` wholesale via the shallow spread in each loader. Reported symptom: lockfiles like \`pnpm-lock.yaml\` reaching the diff-condensing pipeline after the user added a \`.coco.config.json\` for unrelated overrides — burning LLM time on noise.

Now: \`loadConfig\` applies a final \`mergeIgnoreLists\` pass that **unions** user values with the defaults. Defaults always present, user additions appended in their original order, no duplicates.

## Why a post-process step in loadConfig

Three loaders (\`project.ts\`, \`xdg.ts\`, \`git.ts\`) each spread user config and overwrite arrays; \`env.ts\` builds the values up incrementally. Patching each loader is four edits with subtly different shapes. Patching at the resolved-config level is one well-tested helper applied in the single place every source feeds into.

## Trade-off

Users can no longer opt *out* of an individual default. The issue calls this "essentially never relevant" — the cost of accidentally summarizing a lockfile (minutes of LLM time per commit) outweighs the niche case of intentionally including one in the diff feed. If someone hits a real need for opt-out later, we can add a sentinel like \`!package-lock.json\` to skip; for now, the simple merge is the right default.

## Files

- \`src/lib/config/utils/mergeIgnoreLists.ts\` — new helper. Order-preserving union with de-dupe.
- \`src/lib/config/utils/mergeIgnoreLists.test.ts\` — 5 unit tests covering empty, append, dedupe, preservation of other fields, and the issue repro shape.
- \`src/lib/config/utils/loadConfig.ts\` — calls \`mergeIgnoreLists\` after all sources have been combined.
- \`src/lib/config/utils/loadConfig.test.ts\` — new integration test that mocks a project config providing only a subset and asserts the canonical defaults survive.

## Test plan

- [x] \`npm run test\` (5140 passing, 0 regressions; +6 new)
- [x] \`npm run lint\`