### PR TITLE
feat(split): self-correcting retry on plan validation failure (#817)

### DIFF
--- a/src/commands/commands.integration.test.ts
+++ b/src/commands/commands.integration.test.ts
@@ -507,6 +507,125 @@ describe('command integration with temp git repos', () => {
     expect(variables.hunk_inventory).toContain('src/feature.ts::hunk-2')
   })
 
+  it('retries the split plan when the LLM produces an invalid grouping', async () => {
+    mockLoadConfig.mockReturnValue(createConfig({
+      mode: 'stdout',
+    }))
+
+    // First attempt drops src/feature.ts entirely; retry covers both files.
+    mockExecuteChainWithSchema
+      .mockResolvedValueOnce({
+        groups: [
+          {
+            title: 'docs: update readme',
+            body: 'Document the temp repo.',
+            files: ['README.md'],
+            hunks: [],
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        groups: [
+          {
+            title: 'docs: update readme',
+            body: 'Document the temp repo.',
+            files: ['README.md'],
+            hunks: [],
+          },
+          {
+            title: 'test: add feature fixture',
+            body: 'Add a feature fixture file.',
+            files: ['src/feature.ts'],
+            hunks: [],
+          },
+        ],
+      })
+
+    await repo.writeFile('.gitkeep', '\n')
+    await repo.commitAll('chore: initial commit')
+    await repo.writeFile('README.md', '# Temp repo\n')
+    await repo.writeFile('src/feature.ts', 'export const feature = true\n')
+    await repo.git.add(['README.md', 'src/feature.ts'])
+
+    await commitHandler({
+      $0: 'coco',
+      _: ['commit', 'split'],
+      interactive: false,
+      openInEditor: false,
+      ignoredFiles: [],
+      ignoredExtensions: [],
+      withPreviousCommits: 0,
+      conventional: false,
+      includeBranchName: false,
+      noDiff: false,
+      noVerify: true,
+      split: true,
+      plan: true,
+      apply: false,
+      verbose: false,
+      version: false,
+      help: false,
+    } as Arguments<CommitOptions>, createLogger())
+
+    expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(2)
+
+    const firstCallVars = mockExecuteChainWithSchema.mock.calls[0][3] as Record<string, string>
+    const secondCallVars = mockExecuteChainWithSchema.mock.calls[1][3] as Record<string, string>
+
+    expect(firstCallVars.previous_attempt_feedback).toContain('first attempt')
+    expect(secondCallVars.previous_attempt_feedback).toContain('Staged files missing')
+    expect(secondCallVars.previous_attempt_feedback).toContain('src/feature.ts')
+    expect(stdout).toContain('docs: update readme')
+    expect(stdout).toContain('test: add feature fixture')
+  })
+
+  it('surfaces a clear error after retries are exhausted', async () => {
+    mockLoadConfig.mockReturnValue(createConfig({
+      mode: 'stdout',
+    }))
+
+    mockExecuteChainWithSchema.mockResolvedValue({
+      groups: [
+        {
+          title: 'docs: update readme',
+          body: 'Document the temp repo.',
+          files: ['README.md'],
+          hunks: [],
+        },
+      ],
+    })
+
+    await repo.writeFile('.gitkeep', '\n')
+    await repo.commitAll('chore: initial commit')
+    await repo.writeFile('README.md', '# Temp repo\n')
+    await repo.writeFile('src/feature.ts', 'export const feature = true\n')
+    await repo.git.add(['README.md', 'src/feature.ts'])
+
+    await expect(
+      commitHandler({
+        $0: 'coco',
+        _: ['commit', 'split'],
+        interactive: false,
+        openInEditor: false,
+        ignoredFiles: [],
+        ignoredExtensions: [],
+        withPreviousCommits: 0,
+        conventional: false,
+        includeBranchName: false,
+        noDiff: false,
+        noVerify: true,
+        split: true,
+        plan: true,
+        apply: false,
+        verbose: false,
+        version: false,
+        help: false,
+      } as Arguments<CommitOptions>, createLogger())
+    ).rejects.toThrow(/after 3 attempts.*missing files: src\/feature\.ts/i)
+
+    expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(3)
+  })
+
   it('generates a changelog from real branch commit history', async () => {
     mockLoadConfig.mockImplementation((argv) => createConfig({
       ...(argv as Record<string, unknown>),

--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -1,10 +1,8 @@
 import { PromptTemplate } from '@langchain/core/prompts'
 import { spawn } from 'child_process'
 import { formatPatch, parsePatch, StructuredPatch, StructuredPatchHunk } from 'diff'
-import { z } from 'zod'
 import { Arguments } from 'yargs'
 import { Config } from '../../lib/config/types'
-import { executeChainWithSchema } from '../../lib/langchain/utils/executeChainWithSchema'
 import { getLlm } from '../../lib/langchain/utils/getLlm'
 import { fileChangeParser } from '../../lib/parsers/default'
 import { createFileChangeParserOptions } from '../../lib/parsers/default/utils/createFileChangeParserOptions'
@@ -14,26 +12,23 @@ import { FileChange } from '../../lib/types'
 import { Logger } from '../../lib/utils/logger'
 import { TokenCounter } from '../../lib/utils/tokenizer'
 import { CommitOptions } from './config'
+import {
+  DEFAULT_MAX_PLAN_ATTEMPTS,
+  generateValidatedCommitSplitPlan,
+} from './splitPlanGenerator'
+import {
+  CommitSplitGroup,
+  CommitSplitPlan,
+  CommitSplitPlanSchema,
+} from './splitPlanTypes'
+import {
+  formatPlanValidationIssuesError,
+  getPlanValidationIssues,
+  hasPlanValidationIssues,
+} from './splitPlanValidation'
 
-export const CommitSplitPlanSchema = z.object({
-  groups: z
-    .array(
-      z.object({
-        title: z.string().min(1),
-        body: z.string().optional(),
-        rationale: z.string().optional(),
-        files: z.array(z.string()),
-        hunks: z.array(z.string()),
-      })
-      .refine((group) => group.files.length > 0 || group.hunks.length > 0, {
-        message: 'Each group must include at least one file or hunk',
-      })
-    )
-    .min(1),
-})
-
-export type CommitSplitPlan = z.infer<typeof CommitSplitPlanSchema>
-export type CommitSplitGroup = CommitSplitPlan['groups'][number]
+export { CommitSplitPlanSchema }
+export type { CommitSplitPlan, CommitSplitGroup }
 
 const COMMIT_SPLIT_PROMPT = PromptTemplate.fromTemplate(`You are helping split staged git changes into a small sequence of coherent commits.
 
@@ -51,14 +46,13 @@ Return ONLY valid JSON matching this schema:
 }}
 
 Rules:
-- Use each staged file exactly once.
-- If a file has hunk IDs and contains unrelated changes, assign every hunk ID exactly once instead of assigning the whole file.
-- Do not list the same file in "files" when assigning that file through "hunks".
-- Only use file paths listed in the staged file inventory.
-- Only use hunk IDs listed in the staged hunk inventory.
+- Every staged file MUST be assigned exactly once across all groups, either via "files" OR via every one of its hunk IDs (never both).
+- If you assign any hunk for a file, you MUST assign EVERY hunk for that file across the groups — partial coverage is invalid.
+- Do not list the same file in "files" of more than one group, and do not assign the same hunk ID to more than one group.
+- Only use file paths listed in the staged file inventory. Do not invent files.
+- Only use hunk IDs listed in the staged hunk inventory. Do not invent hunk IDs.
 - Prefer 2-5 commits unless the changes are truly all one topic.
 - Keep commit titles concise and understandable.
-- Do not invent files.
 
 Staged file inventory:
 {file_inventory}
@@ -70,7 +64,10 @@ Condensed staged diff:
 {summary}
 
 Additional context:
-{additional_context}`)
+{additional_context}
+
+Feedback on previous attempt (fix every item before responding):
+{previous_attempt_feedback}`)
 
 export function isCommitSplitCommand(argv: Arguments<CommitOptions>): boolean {
   return Boolean(argv.split || argv.plan || argv.apply || argv._.includes('split'))
@@ -106,10 +103,6 @@ type HunkInventory = {
   hunks: StagedHunk[]
   byId: Map<string, StagedHunk>
   byFile: Map<string, StagedHunk[]>
-}
-
-function getStagedFileSet(changes: FileChange[]): Set<string> {
-  return new Set(changes.map((change) => change.filePath))
 }
 
 function getGroupFiles(group: CommitSplitGroup): string[] {
@@ -188,79 +181,9 @@ function validatePlanForStagedFiles(
   staged: FileChange[],
   hunkInventory?: HunkInventory
 ): void {
-  const stagedFiles = getStagedFileSet(staged)
-  const seen = new Set<string>()
-  const seenHunks = new Set<string>()
-  const unknown: string[] = []
-  const duplicate: string[] = []
-  const unknownHunks: string[] = []
-  const duplicateHunks: string[] = []
-
-  plan.groups.forEach((group) => {
-    getGroupFiles(group).forEach((file) => {
-      if (!stagedFiles.has(file)) {
-        unknown.push(file)
-        return
-      }
-
-      if (seen.has(file)) {
-        duplicate.push(file)
-        return
-      }
-
-      seen.add(file)
-    })
-
-    getGroupHunks(group).forEach((hunkId) => {
-      const hunk = hunkInventory?.byId.get(hunkId)
-      if (!hunk) {
-        unknownHunks.push(hunkId)
-        return
-      }
-
-      if (seenHunks.has(hunkId)) {
-        duplicateHunks.push(hunkId)
-        return
-      }
-
-      seenHunks.add(hunkId)
-    })
-  })
-
-  const hunkCoveredFiles = new Set([...seenHunks].map((hunkId) => hunkInventory?.byId.get(hunkId)?.filePath))
-  const mixedFiles = [...seen].filter((file) => hunkCoveredFiles.has(file))
-  const partiallyCoveredFiles = [...hunkCoveredFiles]
-    .filter((file): file is string => Boolean(file))
-    .filter((file) => {
-      const fileHunks = hunkInventory?.byFile.get(file) || []
-      return fileHunks.some((hunk) => !seenHunks.has(hunk.id))
-    })
-  const missing = [...stagedFiles].filter((file) => !seen.has(file) && !hunkCoveredFiles.has(file))
-
-  if (
-    unknown.length ||
-    duplicate.length ||
-    unknownHunks.length ||
-    duplicateHunks.length ||
-    mixedFiles.length ||
-    partiallyCoveredFiles.length ||
-    missing.length
-  ) {
-    throw new Error(
-      [
-        unknown.length ? `unknown files: ${unknown.join(', ')}` : undefined,
-        duplicate.length ? `duplicate files: ${duplicate.join(', ')}` : undefined,
-        unknownHunks.length ? `unknown hunks: ${unknownHunks.join(', ')}` : undefined,
-        duplicateHunks.length ? `duplicate hunks: ${duplicateHunks.join(', ')}` : undefined,
-        mixedFiles.length ? `files assigned both as whole files and hunks: ${mixedFiles.join(', ')}` : undefined,
-        partiallyCoveredFiles.length
-          ? `files with only some hunks assigned: ${partiallyCoveredFiles.join(', ')}`
-          : undefined,
-        missing.length ? `missing files: ${missing.join(', ')}` : undefined,
-      ]
-        .filter(Boolean)
-        .join('; ')
-    )
+  const issues = getPlanValidationIssues(plan, staged, hunkInventory)
+  if (hasPlanValidationIssues(issues)) {
+    throw new Error(formatPlanValidationIssuesError(issues))
   }
 }
 
@@ -430,29 +353,26 @@ export async function handleCommitSplit({
     .join('\n')
   const hunkInventoryText = formatHunkInventory(hunkInventory)
 
-  const plan = await executeChainWithSchema<CommitSplitPlan>(
-    CommitSplitPlanSchema,
+  const { plan } = await generateValidatedCommitSplitPlan({
     llm,
-    COMMIT_SPLIT_PROMPT,
-    {
+    prompt: COMMIT_SPLIT_PROMPT,
+    variables: {
       file_inventory: fileInventory,
       hunk_inventory: hunkInventoryText,
       summary,
       additional_context: argv.additional || '',
     },
-    {
-      logger,
-      tokenizer,
-      metadata: {
-        task: 'commit-split-plan',
-        command: 'commit',
-        provider: config.service.provider,
-        model: String(config.service.model),
-      },
-    }
-  )
-
-  validatePlanForStagedFiles(plan, changes.staged, hunkInventory)
+    staged: changes.staged,
+    hunkInventory,
+    logger,
+    tokenizer,
+    metadata: {
+      command: 'commit',
+      provider: config.service.provider,
+      model: String(config.service.model),
+    },
+    maxAttempts: DEFAULT_MAX_PLAN_ATTEMPTS,
+  })
 
   if (argv.apply) {
     return await applyCommitSplitPlan({

--- a/src/commands/commit/splitPlanGenerator.test.ts
+++ b/src/commands/commit/splitPlanGenerator.test.ts
@@ -1,0 +1,119 @@
+import { PromptTemplate } from '@langchain/core/prompts'
+import { executeChainWithSchema } from '../../lib/langchain/utils/executeChainWithSchema'
+import { FileChange } from '../../lib/types'
+import {
+  generateValidatedCommitSplitPlan,
+  NO_PREVIOUS_FEEDBACK_PLACEHOLDER,
+} from './splitPlanGenerator'
+import { CommitSplitPlan } from './splitPlanTypes'
+
+jest.mock('../../lib/langchain/utils/executeChainWithSchema')
+
+const mockExecuteChainWithSchema = executeChainWithSchema as jest.MockedFunction<
+  typeof executeChainWithSchema
+>
+
+const stagedFile = (filePath: string): FileChange => ({
+  filePath,
+  status: 'modified',
+  summary: '',
+})
+
+const noopPrompt = PromptTemplate.fromTemplate('noop')
+
+const baseArgs = () => ({
+  llm: {} as never,
+  prompt: noopPrompt,
+  variables: { file_inventory: '', hunk_inventory: '', summary: '', additional_context: '' },
+  staged: [stagedFile('a.ts'), stagedFile('b.ts')],
+})
+
+describe('generateValidatedCommitSplitPlan', () => {
+  beforeEach(() => {
+    mockExecuteChainWithSchema.mockReset()
+  })
+
+  it('returns immediately when the first plan is valid', async () => {
+    const validPlan: CommitSplitPlan = {
+      groups: [
+        { title: 'a', files: ['a.ts'], hunks: [] },
+        { title: 'b', files: ['b.ts'], hunks: [] },
+      ],
+    }
+    mockExecuteChainWithSchema.mockResolvedValueOnce(validPlan)
+
+    const result = await generateValidatedCommitSplitPlan(baseArgs())
+
+    expect(result.attempts).toBe(1)
+    expect(result.plan).toBe(validPlan)
+    expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(1)
+
+    const variables = mockExecuteChainWithSchema.mock.calls[0][3] as Record<string, unknown>
+    expect(variables.previous_attempt_feedback).toBe(NO_PREVIOUS_FEEDBACK_PLACEHOLDER)
+  })
+
+  it('feeds validator complaints back into a retry attempt and succeeds', async () => {
+    const invalidPlan: CommitSplitPlan = {
+      groups: [{ title: 'a', files: ['a.ts'], hunks: [] }],
+    }
+    const validPlan: CommitSplitPlan = {
+      groups: [
+        { title: 'a', files: ['a.ts'], hunks: [] },
+        { title: 'b', files: ['b.ts'], hunks: [] },
+      ],
+    }
+
+    mockExecuteChainWithSchema
+      .mockResolvedValueOnce(invalidPlan)
+      .mockResolvedValueOnce(validPlan)
+
+    const result = await generateValidatedCommitSplitPlan(baseArgs())
+
+    expect(result.attempts).toBe(2)
+    expect(result.plan).toBe(validPlan)
+    expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(2)
+
+    const firstCallVars = mockExecuteChainWithSchema.mock.calls[0][3] as Record<string, unknown>
+    const secondCallVars = mockExecuteChainWithSchema.mock.calls[1][3] as Record<string, unknown>
+
+    expect(firstCallVars.previous_attempt_feedback).toBe(NO_PREVIOUS_FEEDBACK_PLACEHOLDER)
+    expect(String(secondCallVars.previous_attempt_feedback)).toContain('Staged files missing')
+    expect(String(secondCallVars.previous_attempt_feedback)).toContain('b.ts')
+  })
+
+  it('throws after exhausting retries with the final validator complaints in the message', async () => {
+    const invalidPlan: CommitSplitPlan = {
+      groups: [{ title: 'a', files: ['a.ts'], hunks: [] }],
+    }
+    mockExecuteChainWithSchema.mockResolvedValue(invalidPlan)
+
+    await expect(
+      generateValidatedCommitSplitPlan({ ...baseArgs(), maxAttempts: 2 })
+    ).rejects.toThrow(/after 2 attempts.*missing files: b\.ts/i)
+
+    expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(2)
+  })
+
+  it('tags each LLM call with an incrementing planAttempt in metadata', async () => {
+    const invalidPlan: CommitSplitPlan = {
+      groups: [{ title: 'a', files: ['a.ts'], hunks: [] }],
+    }
+    const validPlan: CommitSplitPlan = {
+      groups: [
+        { title: 'a', files: ['a.ts'], hunks: [] },
+        { title: 'b', files: ['b.ts'], hunks: [] },
+      ],
+    }
+
+    mockExecuteChainWithSchema
+      .mockResolvedValueOnce(invalidPlan)
+      .mockResolvedValueOnce(validPlan)
+
+    await generateValidatedCommitSplitPlan(baseArgs())
+
+    const firstOptions = mockExecuteChainWithSchema.mock.calls[0][4] as { metadata?: Record<string, unknown> }
+    const secondOptions = mockExecuteChainWithSchema.mock.calls[1][4] as { metadata?: Record<string, unknown> }
+    expect(firstOptions.metadata?.planAttempt).toBe(1)
+    expect(secondOptions.metadata?.planAttempt).toBe(2)
+  })
+})

--- a/src/commands/commit/splitPlanGenerator.ts
+++ b/src/commands/commit/splitPlanGenerator.ts
@@ -1,0 +1,114 @@
+import { PromptTemplate } from '@langchain/core/prompts'
+import { executeChainWithSchema } from '../../lib/langchain/utils/executeChainWithSchema'
+import { getLlm } from '../../lib/langchain/utils/getLlm'
+import { Logger } from '../../lib/utils/logger'
+import { TokenCounter } from '../../lib/utils/tokenizer'
+import { FileChange } from '../../lib/types'
+import { CommitSplitPlan, CommitSplitPlanSchema } from './splitPlanTypes'
+import {
+  formatPlanValidationFeedback,
+  formatPlanValidationIssuesError,
+  getPlanValidationIssues,
+  hasPlanValidationIssues,
+  HunkInventoryLike,
+  PlanValidationIssues,
+} from './splitPlanValidation'
+
+export const NO_PREVIOUS_FEEDBACK_PLACEHOLDER = 'None — this is the first attempt.'
+
+export const DEFAULT_MAX_PLAN_ATTEMPTS = 3
+
+export interface GenerateSplitPlanArgs {
+  llm: ReturnType<typeof getLlm>
+  prompt: PromptTemplate
+  variables: Record<string, unknown>
+  staged: FileChange[]
+  hunkInventory?: HunkInventoryLike
+  logger?: Logger
+  tokenizer?: TokenCounter
+  metadata?: Record<string, unknown>
+  /** Total attempts including the initial call. Defaults to 3. */
+  maxAttempts?: number
+}
+
+export interface GenerateSplitPlanResult {
+  plan: CommitSplitPlan
+  attempts: number
+}
+
+/**
+ * Generate a commit-split plan with self-correcting retries on validator failures.
+ *
+ * The first attempt runs as normal. If `validatePlanForStagedFiles` rejects the result,
+ * the validator's complaints are formatted as natural-language feedback and fed back
+ * into the same prompt template (`previous_attempt_feedback` slot) so the model can
+ * fix its own mistakes without re-running pre-processing.
+ */
+export async function generateValidatedCommitSplitPlan({
+  llm,
+  prompt,
+  variables,
+  staged,
+  hunkInventory,
+  logger,
+  tokenizer,
+  metadata = {},
+  maxAttempts = DEFAULT_MAX_PLAN_ATTEMPTS,
+}: GenerateSplitPlanArgs): Promise<GenerateSplitPlanResult> {
+  let lastIssues: PlanValidationIssues | null = null
+  let attempt = 0
+
+  while (attempt < maxAttempts) {
+    attempt++
+
+    const previousFeedback = lastIssues
+      ? formatPlanValidationFeedback(lastIssues)
+      : NO_PREVIOUS_FEEDBACK_PLACEHOLDER
+
+    const plan = await executeChainWithSchema<CommitSplitPlan>(
+      CommitSplitPlanSchema,
+      llm,
+      prompt,
+      {
+        ...variables,
+        previous_attempt_feedback: previousFeedback,
+      },
+      {
+        logger,
+        tokenizer,
+        metadata: {
+          task: 'commit-split-plan',
+          ...metadata,
+          planAttempt: attempt,
+        },
+      }
+    )
+
+    const issues = getPlanValidationIssues(plan, staged, hunkInventory)
+    if (!hasPlanValidationIssues(issues)) {
+      if (attempt > 1 && logger) {
+        logger.verbose(`Plan validated after ${attempt} attempts.`, { color: 'green' })
+      }
+      return { plan, attempts: attempt }
+    }
+
+    lastIssues = issues
+
+    if (logger) {
+      logger.verbose(
+        `Plan attempt ${attempt}/${maxAttempts} failed validation: ${formatPlanValidationIssuesError(
+          issues
+        )}`,
+        { color: 'yellow' }
+      )
+    }
+  }
+
+  throw new Error(
+    lastIssues
+      ? `Failed to produce a valid commit-split plan after ${maxAttempts} attempts. Final validator issues: ${formatPlanValidationIssuesError(
+          lastIssues
+        )}`
+      : `Failed to produce a valid commit-split plan after ${maxAttempts} attempts.`
+  )
+}

--- a/src/commands/commit/splitPlanTypes.ts
+++ b/src/commands/commit/splitPlanTypes.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+export const CommitSplitPlanSchema = z.object({
+  groups: z
+    .array(
+      z
+        .object({
+          title: z.string().min(1),
+          body: z.string().optional(),
+          rationale: z.string().optional(),
+          files: z.array(z.string()),
+          hunks: z.array(z.string()),
+        })
+        .refine((group) => group.files.length > 0 || group.hunks.length > 0, {
+          message: 'Each group must include at least one file or hunk',
+        })
+    )
+    .min(1),
+})
+
+export type CommitSplitPlan = z.infer<typeof CommitSplitPlanSchema>
+export type CommitSplitGroup = CommitSplitPlan['groups'][number]

--- a/src/commands/commit/splitPlanValidation.test.ts
+++ b/src/commands/commit/splitPlanValidation.test.ts
@@ -1,0 +1,189 @@
+import { FileChange } from '../../lib/types'
+import {
+  formatPlanValidationFeedback,
+  formatPlanValidationIssuesError,
+  getPlanValidationIssues,
+  hasPlanValidationIssues,
+  HunkInventoryLike,
+} from './splitPlanValidation'
+import { CommitSplitPlan } from './splitPlanTypes'
+
+const stagedFile = (filePath: string): FileChange => ({
+  filePath,
+  status: 'modified',
+  summary: '',
+})
+
+const buildHunkInventory = (
+  byFile: Record<string, string[]>
+): HunkInventoryLike => {
+  const byIdMap = new Map<string, { id: string; filePath: string }>()
+  const byFileMap = new Map<string, { id: string; filePath: string }[]>()
+
+  for (const [filePath, hunkIds] of Object.entries(byFile)) {
+    const hunks = hunkIds.map((id) => ({ id, filePath }))
+    byFileMap.set(filePath, hunks)
+    for (const hunk of hunks) {
+      byIdMap.set(hunk.id, hunk)
+    }
+  }
+
+  return { byId: byIdMap, byFile: byFileMap }
+}
+
+describe('splitPlanValidation', () => {
+  describe('getPlanValidationIssues', () => {
+    it('returns no issues for a clean file-level plan', () => {
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'a', files: ['a.ts'], hunks: [] },
+          { title: 'b', files: ['b.ts'], hunks: [] },
+        ],
+      }
+
+      const issues = getPlanValidationIssues(plan, [stagedFile('a.ts'), stagedFile('b.ts')])
+
+      expect(hasPlanValidationIssues(issues)).toBe(false)
+    })
+
+    it('flags files not in the staged inventory as unknown', () => {
+      const plan: CommitSplitPlan = {
+        groups: [{ title: 'a', files: ['a.ts', 'ghost.ts'], hunks: [] }],
+      }
+
+      const issues = getPlanValidationIssues(plan, [stagedFile('a.ts')])
+
+      expect(issues.unknownFiles).toEqual(['ghost.ts'])
+    })
+
+    it('flags duplicate file assignments across groups', () => {
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'a', files: ['a.ts'], hunks: [] },
+          { title: 'a-again', files: ['a.ts'], hunks: [] },
+        ],
+      }
+
+      const issues = getPlanValidationIssues(plan, [stagedFile('a.ts')])
+
+      expect(issues.duplicateFiles).toEqual(['a.ts'])
+    })
+
+    it('flags missing staged files that never appear in any group', () => {
+      const plan: CommitSplitPlan = {
+        groups: [{ title: 'a', files: ['a.ts'], hunks: [] }],
+      }
+
+      const issues = getPlanValidationIssues(plan, [stagedFile('a.ts'), stagedFile('b.ts')])
+
+      expect(issues.missingFiles).toEqual(['b.ts'])
+    })
+
+    it('flags unknown hunk IDs', () => {
+      const plan: CommitSplitPlan = {
+        groups: [{ title: 'a', files: [], hunks: ['a.ts::hunk-99'] }],
+      }
+      const inventory = buildHunkInventory({ 'a.ts': ['a.ts::hunk-1', 'a.ts::hunk-2'] })
+
+      const issues = getPlanValidationIssues(plan, [stagedFile('a.ts')], inventory)
+
+      expect(issues.unknownHunks).toEqual(['a.ts::hunk-99'])
+    })
+
+    it('flags duplicate hunk IDs across groups', () => {
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'a', files: [], hunks: ['a.ts::hunk-1'] },
+          { title: 'a-again', files: [], hunks: ['a.ts::hunk-1'] },
+        ],
+      }
+      const inventory = buildHunkInventory({ 'a.ts': ['a.ts::hunk-1', 'a.ts::hunk-2'] })
+
+      const issues = getPlanValidationIssues(plan, [stagedFile('a.ts')], inventory)
+
+      expect(issues.duplicateHunks).toEqual(['a.ts::hunk-1'])
+    })
+
+    it('flags files assigned both as whole files and via hunks', () => {
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'whole', files: ['a.ts'], hunks: [] },
+          { title: 'hunked', files: [], hunks: ['a.ts::hunk-1'] },
+        ],
+      }
+      const inventory = buildHunkInventory({ 'a.ts': ['a.ts::hunk-1'] })
+
+      const issues = getPlanValidationIssues(plan, [stagedFile('a.ts')], inventory)
+
+      expect(issues.mixedFiles).toEqual(['a.ts'])
+    })
+
+    it('flags files with only some hunks assigned', () => {
+      const plan: CommitSplitPlan = {
+        groups: [{ title: 'a', files: [], hunks: ['a.ts::hunk-1'] }],
+      }
+      const inventory = buildHunkInventory({ 'a.ts': ['a.ts::hunk-1', 'a.ts::hunk-2'] })
+
+      const issues = getPlanValidationIssues(plan, [stagedFile('a.ts')], inventory)
+
+      expect(issues.partiallyCoveredFiles).toEqual(['a.ts'])
+    })
+  })
+
+  describe('formatPlanValidationFeedback', () => {
+    it('returns an empty string when there are no issues', () => {
+      const feedback = formatPlanValidationFeedback({
+        unknownFiles: [],
+        duplicateFiles: [],
+        unknownHunks: [],
+        duplicateHunks: [],
+        mixedFiles: [],
+        partiallyCoveredFiles: [],
+        missingFiles: [],
+      })
+
+      expect(feedback).toBe('')
+    })
+
+    it('formats each issue category as a bullet line with file lists', () => {
+      const feedback = formatPlanValidationFeedback({
+        unknownFiles: ['ghost.ts'],
+        duplicateFiles: ['a.ts'],
+        unknownHunks: ['x::hunk-9'],
+        duplicateHunks: ['a.ts::hunk-1'],
+        mixedFiles: ['b.ts'],
+        partiallyCoveredFiles: ['c.ts'],
+        missingFiles: ['d.ts'],
+      })
+
+      expect(feedback).toContain('- Files referenced that are NOT in the staged file inventory')
+      expect(feedback).toContain('ghost.ts')
+      expect(feedback).toContain('Files assigned to more than one group')
+      expect(feedback).toContain('a.ts')
+      expect(feedback).toContain('Hunk IDs referenced that are NOT in the staged hunk inventory')
+      expect(feedback).toContain('x::hunk-9')
+      expect(feedback).toContain('Files assigned BOTH as whole files and via hunks')
+      expect(feedback).toContain('b.ts')
+      expect(feedback).toContain('Files with only some hunks assigned')
+      expect(feedback).toContain('c.ts')
+      expect(feedback).toContain('Staged files missing from every group')
+      expect(feedback).toContain('d.ts')
+    })
+  })
+
+  describe('formatPlanValidationIssuesError', () => {
+    it('joins issue categories with semicolons', () => {
+      const message = formatPlanValidationIssuesError({
+        unknownFiles: ['ghost.ts'],
+        duplicateFiles: ['a.ts'],
+        unknownHunks: [],
+        duplicateHunks: [],
+        mixedFiles: [],
+        partiallyCoveredFiles: [],
+        missingFiles: [],
+      })
+
+      expect(message).toBe('unknown files: ghost.ts; duplicate files: a.ts')
+    })
+  })
+})

--- a/src/commands/commit/splitPlanValidation.ts
+++ b/src/commands/commit/splitPlanValidation.ts
@@ -1,0 +1,176 @@
+import { FileChange } from '../../lib/types'
+import type { CommitSplitGroup, CommitSplitPlan } from './splitPlanTypes'
+
+export type StagedHunkLike = {
+  id: string
+  filePath: string
+}
+
+export type HunkInventoryLike = {
+  byId: Map<string, StagedHunkLike>
+  byFile: Map<string, StagedHunkLike[]>
+}
+
+export interface PlanValidationIssues {
+  unknownFiles: string[]
+  duplicateFiles: string[]
+  unknownHunks: string[]
+  duplicateHunks: string[]
+  mixedFiles: string[]
+  partiallyCoveredFiles: string[]
+  missingFiles: string[]
+}
+
+const getGroupFiles = (group: CommitSplitGroup): string[] => group.files || []
+const getGroupHunks = (group: CommitSplitGroup): string[] => group.hunks || []
+
+export function getPlanValidationIssues(
+  plan: CommitSplitPlan,
+  staged: FileChange[],
+  hunkInventory?: HunkInventoryLike
+): PlanValidationIssues {
+  const stagedFiles = new Set(staged.map((change) => change.filePath))
+  const seen = new Set<string>()
+  const seenHunks = new Set<string>()
+  const unknownFiles: string[] = []
+  const duplicateFiles: string[] = []
+  const unknownHunks: string[] = []
+  const duplicateHunks: string[] = []
+
+  plan.groups.forEach((group) => {
+    getGroupFiles(group).forEach((file) => {
+      if (!stagedFiles.has(file)) {
+        unknownFiles.push(file)
+        return
+      }
+
+      if (seen.has(file)) {
+        duplicateFiles.push(file)
+        return
+      }
+
+      seen.add(file)
+    })
+
+    getGroupHunks(group).forEach((hunkId) => {
+      const hunk = hunkInventory?.byId.get(hunkId)
+      if (!hunk) {
+        unknownHunks.push(hunkId)
+        return
+      }
+
+      if (seenHunks.has(hunkId)) {
+        duplicateHunks.push(hunkId)
+        return
+      }
+
+      seenHunks.add(hunkId)
+    })
+  })
+
+  const hunkCoveredFiles = new Set(
+    [...seenHunks].map((hunkId) => hunkInventory?.byId.get(hunkId)?.filePath)
+  )
+  const mixedFiles = [...seen].filter((file) => hunkCoveredFiles.has(file))
+  const partiallyCoveredFiles = [...hunkCoveredFiles]
+    .filter((file): file is string => Boolean(file))
+    .filter((file) => {
+      const fileHunks = hunkInventory?.byFile.get(file) || []
+      return fileHunks.some((hunk) => !seenHunks.has(hunk.id))
+    })
+  const missingFiles = [...stagedFiles].filter(
+    (file) => !seen.has(file) && !hunkCoveredFiles.has(file)
+  )
+
+  return {
+    unknownFiles,
+    duplicateFiles,
+    unknownHunks,
+    duplicateHunks,
+    mixedFiles,
+    partiallyCoveredFiles,
+    missingFiles,
+  }
+}
+
+export function hasPlanValidationIssues(issues: PlanValidationIssues): boolean {
+  return (
+    issues.unknownFiles.length > 0 ||
+    issues.duplicateFiles.length > 0 ||
+    issues.unknownHunks.length > 0 ||
+    issues.duplicateHunks.length > 0 ||
+    issues.mixedFiles.length > 0 ||
+    issues.partiallyCoveredFiles.length > 0 ||
+    issues.missingFiles.length > 0
+  )
+}
+
+export function formatPlanValidationIssuesError(issues: PlanValidationIssues): string {
+  return [
+    issues.unknownFiles.length ? `unknown files: ${issues.unknownFiles.join(', ')}` : undefined,
+    issues.duplicateFiles.length
+      ? `duplicate files: ${issues.duplicateFiles.join(', ')}`
+      : undefined,
+    issues.unknownHunks.length ? `unknown hunks: ${issues.unknownHunks.join(', ')}` : undefined,
+    issues.duplicateHunks.length
+      ? `duplicate hunks: ${issues.duplicateHunks.join(', ')}`
+      : undefined,
+    issues.mixedFiles.length
+      ? `files assigned both as whole files and hunks: ${issues.mixedFiles.join(', ')}`
+      : undefined,
+    issues.partiallyCoveredFiles.length
+      ? `files with only some hunks assigned: ${issues.partiallyCoveredFiles.join(', ')}`
+      : undefined,
+    issues.missingFiles.length ? `missing files: ${issues.missingFiles.join(', ')}` : undefined,
+  ]
+    .filter(Boolean)
+    .join('; ')
+}
+
+export function formatPlanValidationFeedback(issues: PlanValidationIssues): string {
+  const sections: string[] = []
+
+  if (issues.unknownFiles.length) {
+    sections.push(
+      `Files referenced that are NOT in the staged file inventory (remove or replace): ${issues.unknownFiles.join(', ')}`
+    )
+  }
+
+  if (issues.duplicateFiles.length) {
+    sections.push(
+      `Files assigned to more than one group (each file may appear at most once): ${issues.duplicateFiles.join(', ')}`
+    )
+  }
+
+  if (issues.unknownHunks.length) {
+    sections.push(
+      `Hunk IDs referenced that are NOT in the staged hunk inventory: ${issues.unknownHunks.join(', ')}`
+    )
+  }
+
+  if (issues.duplicateHunks.length) {
+    sections.push(
+      `Hunk IDs assigned to more than one group (each hunk may appear at most once): ${issues.duplicateHunks.join(', ')}`
+    )
+  }
+
+  if (issues.mixedFiles.length) {
+    sections.push(
+      `Files assigned BOTH as whole files and via hunks (pick one mode per file): ${issues.mixedFiles.join(', ')}`
+    )
+  }
+
+  if (issues.partiallyCoveredFiles.length) {
+    sections.push(
+      `Files with only some hunks assigned (every hunk for these files must be covered): ${issues.partiallyCoveredFiles.join(', ')}`
+    )
+  }
+
+  if (issues.missingFiles.length) {
+    sections.push(
+      `Staged files missing from every group (must appear exactly once): ${issues.missingFiles.join(', ')}`
+    )
+  }
+
+  return sections.map((section) => `- ${section}`).join('\n')
+}

--- a/src/lib/langchain/utils/observability.ts
+++ b/src/lib/langchain/utils/observability.ts
@@ -10,6 +10,7 @@ export type LlmCallMetadata = {
   provider?: string
   model?: string
   retryAttempt?: number
+  planAttempt?: number
   parserType?: string
   variableKeys?: string[]
   promptTokens?: number


### PR DESCRIPTION
## Summary

Closes [#817](https://github.com/gfargo/coco/issues/817).

When `coco commit split --plan` produces a structurally invalid plan (duplicate files, unknown hunks, partial hunk coverage, missing files, etc.), the user used to lose all the pre-processing spend and get a wall of validator error text with no recovery.

This PR feeds the validator's complaints back into the model and retries up to 3 attempts total, so the LLM can fix its own mistakes on the cheap.

- New \`splitPlanValidation\` module exposes \`getPlanValidationIssues\` returning a structured shape (one array per category) plus a feedback formatter.
- New \`splitPlanGenerator\` wraps \`executeChainWithSchema\` in a loop: validate → if failed, format the issues into a \`previous_attempt_feedback\` prompt slot → retry. Default \`maxAttempts: 3\`.
- Prompt rules tightened to reduce first-try failures on partial hunk coverage and the whole-file-vs-hunks mode confusion.
- Original \`validatePlanForStagedFiles\` and apply-time validation behavior preserved (still throws with the same message format).

Per-attempt results are tagged with \`planAttempt\` in LLM observability metadata so retries are visible in benchmark runs.

## Out of scope (issue items 3-4)

The issue mentions a one-commit-per-directory safe fallback and a streaming preview UX. Those are separate, larger UX changes — leaving them for follow-up PRs to keep this one focused on the highest-leverage fix.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run build\` green
- [x] \`npx jest\` — 1280 passed
- [x] New unit tests cover every validator-issue category and the retry orchestration (success-after-retry, exhausted attempts, metadata tagging)
- [x] New integration tests through \`handleCommitSplit\` exercise both the success-after-retry and exhausted-attempts paths against a real temp git repo
- [ ] Manual smoke against a real ~30-file staged diff with a model known to produce bad plans