### PR TITLE
chore(deps-dev): bump typescript from 5.4.5 to 6.0.3 (supersedes #700)

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "ts-json-schema-generator": "^2.9.0",
     "ts-node": "^10.9.1",
     "tsx": "^4.16.5",
-    "typescript": "^5.4.5"
+    "typescript": "^6.0.3"
   },
   "dependencies": {
     "@commitlint/core": "^20.5.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,16 +10,16 @@
     "declaration": true,
     "declarationDir": "dist/dts",
     "sourceMap": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,
     "skipLibCheck": true,
-    "downlevelIteration": true,
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "emitDecoratorMetadata": true,
+    "types": ["jest", "node"]
   },
   "include": ["src/**/*.ts", "bin/validateSchema.test.ts"],
   "exclude": ["node_modules", "**/*.spec.ts", "**/*.test.ts", "dist", "rollup.config.mjs"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5334,16 +5334,7 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5393,14 +5384,7 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5628,10 +5612,15 @@ type-fest@^5.5.0:
   dependencies:
     tagged-tag "^1.0.0"
 
-typescript@^5.4.5, typescript@^5.9.3:
+typescript@^5.9.3:
   version "5.9.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+typescript@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 uglify-js@^3.1.4:
   version "3.19.3"
@@ -5784,7 +5773,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -5801,24 +5790,6 @@ wrap-ansi@^10.0.0:
     ansi-styles "^6.2.3"
     string-width "^8.2.0"
     strip-ansi "^7.1.2"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
 
 wrap-ansi@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
Supersedes [#700](https://github.com/gfargo/coco/pull/700). The Dependabot branch went stale through months of code churn (#845, #861, #863, #817, splitPlanGenerator, doctor, dozens of ink/log modules) and a naive merge would have wiped that work out — rebased and rebuilt cleanly off current main.

## What changed

### Dependency
- \`typescript\` dev-dep: \`^5.4.5\` → \`^6.0.3\`
- ts-jest@29.4.9 already supports \`typescript: >=4.3 <7\` so no test-tooling bump needed

### tsconfig.json
TS 6 deprecates two options the project uses (both will stop functioning in TS 7):

- **\`downlevelIteration: true\`** removed — unnecessary at \`target: ES2020\` since ES2020 natively supports the iterator protocol.
- **\`moduleResolution: \"node\"\`** → **\`\"bundler\"\`** — the TS-recommended algorithm for projects compiled by a bundler (Rollup, in this case). Resolves imports the way the bundler does at build time and allows bare specifiers.
- **Added \`\"types\": [\"jest\", \"node\"]\`** — under \`moduleResolution: \"bundler\"\` the implicit auto-discovery of \`@types/*\` packages is narrower than under \`\"node\"\`. Without an explicit list, ts-jest's compile pass can't find Jest's ambient types (\`jest\`, \`expect\`, \`it\`, \`describe\`, etc.) and 1284 test files fail to compile. Listing the two needed packages fixes it.

## Validation

- [x] \`npx tsc --noEmit\` — 0 errors
- [x] \`npm run build\` (rollup + rpt2) — green
- [x] \`npm run lint\` — clean
- [x] \`npx jest\` — **1295/1295 pass**

## Why a fresh PR vs rebasing #700

#700 branched from a commit before #845 (the diff-condensing pipeline overhaul) and never updated. Its diff against current main showed ~24,000 lines of deletions across 149 files — a forced merge would have reverted the cache, trivial-shape skip, sort discipline, markdown fast path, splitPlanGenerator, doctor command, and most of the ink TUI modules.

Standard pattern when a Dependabot PR rots through major code churn: open a fresh branch off current main with the same upgrade + any code fixes needed, close the original PR as superseded.

## After this lands

- Close #700 with a comment pointing here