### PR TITLE
feat(log-tui): reflog browser view (gr) (#781)

### DIFF
--- a/src/commands/log/inkContext.ts
+++ b/src/commands/log/inkContext.ts
@@ -3,6 +3,7 @@ export const LOG_INK_CONTEXT_KEYS = [
   'operation',
   'provider',
   'pullRequest',
+  'reflog',
   'stashes',
   'tags',
   'worktree',

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -611,6 +611,66 @@ describe('log Ink input interactions', () => {
     expect(state.selectedStashIndex).toBe(2)
   })
 
+  it('pushes reflog with the gr chord (#781)', () => {
+    let state = createLogInkState(rows)
+
+    state = applyInput(state, 'g')
+    state = applyInput(state, 'r')
+
+    expect(state.viewStack).toEqual(['history', 'reflog'])
+    expect(state.activeView).toBe('reflog')
+    expect(state.statusMessage).toBe('jumped to reflog')
+  })
+
+  it('moves the selected reflog entry with arrow keys when in reflog view (#781)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'reflog' })
+
+    state = applyInput(state, 'j', {}, { reflogCount: 4 })
+    state = applyInput(state, 'j', {}, { reflogCount: 4 })
+    expect(state.selectedReflogIndex).toBe(2)
+
+    state = applyInput(state, 'k', {}, { reflogCount: 4 })
+    expect(state.selectedReflogIndex).toBe(1)
+
+    // Clamped at the count boundary going up.
+    state = applyInput(state, 'k', {}, { reflogCount: 4 })
+    state = applyInput(state, 'k', {}, { reflogCount: 4 })
+    expect(state.selectedReflogIndex).toBe(0)
+  })
+
+  it('Enter on a reflog row drills into the diff for that hash (#781)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'reflog' })
+
+    const events = getLogInkInputEvents(state, '', { return: true }, {
+      reflogCount: 5,
+      reflogSelectedHash: 'abc1234',
+    })
+
+    const navigate = events.find((event) =>
+      event.type === 'action' && event.action.type === 'navigateOpenDiffForCommit'
+    )
+    expect(navigate).toBeDefined()
+    if (navigate && navigate.type === 'action' && navigate.action.type === 'navigateOpenDiffForCommit') {
+      expect(navigate.action.sha).toBe('abc1234')
+    }
+  })
+
+  it('Enter on a reflog row is a no-op when no entry is cursored (#781)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'reflog' })
+
+    const events = getLogInkInputEvents(state, '', { return: true }, {
+      reflogCount: 0,
+      reflogSelectedHash: undefined,
+    })
+
+    expect(events.find((event) =>
+      event.type === 'action' && event.action.type === 'navigateOpenDiffForCommit'
+    )).toBeUndefined()
+  })
+
   it('preserves per-view selection across navigation', () => {
     let state = createLogInkState(rows)
 

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -67,6 +67,9 @@ export type LogInkInputContext = {
   branchCount?: number
   tagCount?: number
   stashCount?: number
+  reflogCount?: number
+  /** Hash of the cursored reflog entry (#781). Used by Enter to drill into the diff. */
+  reflogSelectedHash?: string
   worktreeListCount?: number
   /** Ref of the stash currently under the cursor (e.g. `stash@{0}`). */
   stashSelectedRef?: string
@@ -299,6 +302,15 @@ function isStashActionTarget(state: LogInkState): boolean {
     (state.focus === 'sidebar' && state.sidebarTab === 'stashes')
 }
 
+/**
+ * Reflog has no sidebar tab — only the dedicated promoted view (#781).
+ * The condition stays as a single helper anyway so navigation handlers
+ * can read it the same way they do for the other promoted views.
+ */
+function isReflogActionTarget(state: LogInkState): boolean {
+  return state.activeView === 'reflog' && state.focus === 'commits'
+}
+
 function isWorktreeActionTarget(state: LogInkState): boolean {
   return (state.activeView === 'worktrees' && state.focus === 'commits') ||
     (state.focus === 'sidebar' && state.sidebarTab === 'worktrees')
@@ -411,6 +423,8 @@ export function getLogInkPaletteExecuteEvents(
       return [action({ type: 'pushView', value: 'pull-request' })]
     case 'navigateConflicts':
       return [action({ type: 'pushView', value: 'conflicts' })]
+    case 'navigateReflog':
+      return [action({ type: 'pushView', value: 'reflog' })]
     case 'navigateBack':
       return [action({ type: 'popView' })]
     case 'openSelected': {
@@ -949,6 +963,16 @@ export function getLogInkInputEvents(
     ]
   }
 
+  // `gr` chord: jump to the reflog browser (#781). Recovery view —
+  // chronological list of reflog entries with Enter to drill into the
+  // commit-diff for the entry's hash. Loaded lazily by the runtime.
+  if (state.pendingKey === 'g' && inputValue === 'r') {
+    return [
+      action({ type: 'pushView', value: 'reflog' }),
+      action({ type: 'setStatus', value: 'jumped to reflog' }),
+    ]
+  }
+
   // `gH` chord: apply the cursored hunk to the index (`git apply
   // --cached`). Sibling of bare `H` which targets the worktree.
   // Discoverable via the footer hint on diff views and the help
@@ -1294,6 +1318,10 @@ export function getLogInkInputEvents(
       return [action({ type: 'moveStash', delta: -1, count: context.stashCount })]
     }
 
+    if (isReflogActionTarget(state) && context.reflogCount) {
+      return [action({ type: 'moveReflog', delta: -1, count: context.reflogCount })]
+    }
+
     if (isWorktreeActionTarget(state) && context.worktreeListCount) {
       return [action({ type: 'moveWorktreeListEntry', delta: -1, count: context.worktreeListCount })]
     }
@@ -1389,6 +1417,10 @@ export function getLogInkInputEvents(
 
     if (isStashActionTarget(state) && context.stashCount) {
       return [action({ type: 'moveStash', delta: 1, count: context.stashCount })]
+    }
+
+    if (isReflogActionTarget(state) && context.reflogCount) {
+      return [action({ type: 'moveReflog', delta: 1, count: context.reflogCount })]
     }
 
     if (isWorktreeActionTarget(state) && context.worktreeListCount) {
@@ -1493,6 +1525,31 @@ export function getLogInkInputEvents(
         action({ type: 'setStatus', value: `viewing diff for ${selected.shortHash}` }),
       ]
     }
+  }
+
+  // Enter on a reflog row drills into the diff for that entry's hash
+  // (#781). Reuses `navigateOpenDiffForCommit`, which finds the commit
+  // by hash in `state.filteredCommits` first and falls back to
+  // `commitIndex` only when the hash isn't present. Reflog hashes that
+  // exist in the loaded history (the common case) drill in cleanly;
+  // dangling-commit hashes fall back to the index. The `commitIndex`
+  // we pass is best-effort — index in `state.commits` if found, else
+  // `state.selectedIndex` so the cursor stays sane on the diff view.
+  if (
+    key.return &&
+    isReflogActionTarget(state) &&
+    context.reflogSelectedHash
+  ) {
+    const sha = context.reflogSelectedHash
+    const fallbackIndex = state.commits.findIndex((commit) => commit.hash === sha)
+    return [
+      action({
+        type: 'navigateOpenDiffForCommit',
+        sha,
+        commitIndex: fallbackIndex >= 0 ? fallbackIndex : state.selectedIndex,
+      }),
+      action({ type: 'setStatus', value: `viewing diff for ${sha.slice(0, 7)}` }),
+    ]
   }
 
   // Inspector Actions tab: Enter on the cursored action fires its

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -24,6 +24,7 @@ export type LogInkCommandId =
   | 'navigateDiff'
   | 'navigateHome'
   | 'navigatePullRequest'
+  | 'navigateReflog'
   | 'navigateStash'
   | 'navigateWorktrees'
   | 'navigateStatus'
@@ -265,6 +266,13 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     contexts: ['normal'],
   },
   {
+    id: 'navigateReflog',
+    keys: ['gr'],
+    label: 'reflog',
+    description: 'Push the reflog browser view — chronological recovery log.',
+    contexts: ['normal'],
+  },
+  {
     id: 'navigateBack',
     keys: ['<', 'esc'],
     label: 'back',
@@ -442,6 +450,7 @@ const GLOBAL_BINDING_IDS: LogInkCommandId[] = [
   'navigateWorktrees',
   'navigatePullRequest',
   'navigateConflicts',
+  'navigateReflog',
   'navigateBack',
 ]
 
@@ -637,6 +646,13 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
   if (options.activeView === 'conflicts') {
     return {
       contextual: ['↑/↓ files', 'enter diff', 's stage', 'u theirs', 'U ours', 'o edit', 'C continue*', 'esc back'],
+      global: NORMAL_GLOBAL_HINTS,
+    }
+  }
+
+  if (options.activeView === 'reflog') {
+    return {
+      contextual: ['↑/↓ entries', 'enter inspect', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -130,6 +130,7 @@ import {
     formatLogInkComposeEmpty,
     formatLogInkHistoryEmpty,
     formatLogInkLoading,
+    formatLogInkReflogEmpty,
     formatLogInkStashEmpty,
     formatLogInkStatusEmpty,
     formatLogInkTagsEmpty,
@@ -226,6 +227,7 @@ import {
     stageHunk,
     unstageHunk,
 } from './statusHunks'
+import { ReflogOverview, getReflogOverview, splitReflogSubject } from './reflogData'
 import { TagOverview, getTagOverview } from './tagData'
 import {
     getLogInkWorkflowActionById,
@@ -278,6 +280,7 @@ type LogInkContext = {
   operation?: GitOperationOverview
   provider?: ProviderOverview
   pullRequest?: PullRequestOverview
+  reflog?: ReflogOverview
   stashes?: StashOverview
   tags?: TagOverview
   worktree?: WorktreeOverview
@@ -363,7 +366,7 @@ async function safe<T>(promise: Promise<T>): Promise<T | undefined> {
 }
 
 async function loadLogInkContext(git: SimpleGit): Promise<LogInkContext> {
-  const [branches, pullRequest, tags, worktree, stashes, worktreeList, operation, provider] =
+  const [branches, pullRequest, tags, worktree, stashes, worktreeList, operation, provider, reflog] =
     await Promise.all([
       safe(getBranchOverview(git)),
       safe(getPullRequestOverview(git)),
@@ -373,6 +376,7 @@ async function loadLogInkContext(git: SimpleGit): Promise<LogInkContext> {
       safe(getWorktreeListOverview(git)),
       safe(getGitOperationOverview(git)),
       safe(getProviderOverview(git)),
+      safe(getReflogOverview(git)),
     ])
 
   return {
@@ -380,6 +384,7 @@ async function loadLogInkContext(git: SimpleGit): Promise<LogInkContext> {
     operation,
     provider,
     pullRequest,
+    reflog,
     stashes,
     tags,
     worktree,
@@ -408,6 +413,10 @@ function loadLogInkContextEntries(git: SimpleGit): Array<{
     {
       key: 'tags',
       load: () => safe(getTagOverview(git)),
+    },
+    {
+      key: 'reflog',
+      load: () => safe(getReflogOverview(git)),
     },
     {
       key: 'worktree',
@@ -1001,6 +1010,16 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       matchesPromotedFilter([entry.path, entry.branch || ''], state.filter)
     )
   }, [context.worktreeList?.worktrees, state.filter])
+  const filteredReflogList = React.useMemo(() => {
+    const all = context.reflog?.entries || []
+    if (!state.filter) return all
+    return all.filter((entry) =>
+      matchesPromotedFilter(
+        [entry.selector, entry.hash, entry.relativeDate, entry.subject],
+        state.filter
+      )
+    )
+  }, [context.reflog?.entries, state.filter])
 
   const dispatch = React.useCallback((action: Parameters<typeof applyLogInkAction>[1]) => {
     setState((current) => applyLogInkAction(current, action))
@@ -2447,6 +2466,10 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     const stashSelectedRef = filteredStashList[
       Math.min(state.selectedStashIndex, Math.max(0, filteredStashList.length - 1))
     ]?.ref
+    const reflogVisibleCount = filteredReflogList.length
+    const reflogSelectedHash = filteredReflogList[
+      Math.min(state.selectedReflogIndex, Math.max(0, filteredReflogList.length - 1))
+    ]?.hash
     const worktreeVisibleCount = filteredWorktreeList.length
 
     // When the diff view is showing a stash patch, swap the previewLineCount
@@ -2476,6 +2499,8 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       branchCount: branchVisibleCount,
       tagCount: tagVisibleCount,
       stashCount: stashVisibleCount,
+      reflogCount: reflogVisibleCount,
+      reflogSelectedHash,
       stashSelectedRef,
       stashDiffFileOffsets: stashDiffFileOffsets.length ? stashDiffFileOffsets : undefined,
       stashDiffSelectedPath,
@@ -3025,6 +3050,10 @@ function renderMainPanel(
 
   if (state.activeView === 'tags') {
     return renderTagsSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
+  }
+
+  if (state.activeView === 'reflog') {
+    return renderReflogSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
   }
 
   if (state.activeView === 'stash') {
@@ -3887,6 +3916,105 @@ function renderTagsSurface(
   },
   h(Box, { justifyContent: 'space-between' },
     h(Text, { bold: true }, panelTitle('Tags', focused)),
+    h(Text, { dimColor: true }, headerRight)
+  ),
+  ...renderPromotedFilterAffordance(h, Text, state, theme),
+  ...lines)
+}
+
+/**
+ * Promoted reflog browser (#781). Mirrors `renderTagsSurface` visually
+ * — same header / filter affordance / footer hint conventions — but
+ * lays out four columns per row: relative date, action prefix, short
+ * hash, and message. Filtering matches against all four (so typing
+ * "checkout" narrows to checkout entries, "abc" narrows to a hash).
+ *
+ * Per-row layout uses fixed column widths derived from the visible
+ * window so short-action rows don't leave a wide gutter and long
+ * actions don't push the message off-screen. The cap mirrors the
+ * tags surface's name-column treatment.
+ */
+function renderReflogSurface(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  bodyRows: number,
+  width: number,
+  theme: LogInkTheme
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const focused = state.focus === 'commits'
+  const loading = isLogInkContextKeyLoading(contextStatus, 'reflog')
+  const allEntries = context.reflog?.entries || []
+  const entries = state.filter
+    ? allEntries.filter((entry) => matchesPromotedFilter(
+      [entry.selector, entry.hash, entry.relativeDate, entry.subject],
+      state.filter
+    ))
+    : allEntries
+  const selected = Math.max(0, Math.min(state.selectedReflogIndex, Math.max(0, entries.length - 1)))
+  const listRows = Math.max(4, bodyRows - 4)
+  const startIndex = Math.max(0, selected - Math.floor(listRows / 2))
+  const visible = entries.slice(startIndex, startIndex + listRows)
+  const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
+  const headerRight = loading
+    ? 'loading reflog'
+    : `${entries.length}/${allEntries.length} entries${filterLabel}`
+  const emptyLabel = formatLogInkReflogEmpty({ filter: state.filter })
+  const loadingLabel = formatLogInkLoading({ resource: 'reflog' })
+
+  // Column widths derived from the visible window. The hash column is
+  // fixed (short SHA is always 7 chars) and the date column caps so
+  // "X minutes ago" / "Y hours ago" stays readable without dominating
+  // the row. Action column scales to the longest visible action so
+  // commit / checkout / merge align cleanly.
+  const splitVisible = visible.map((entry) => ({
+    entry,
+    parts: splitReflogSubject(entry.subject),
+  }))
+  const dateColWidth = splitVisible.length === 0
+    ? 16
+    : Math.min(20, Math.max(6, ...splitVisible.map(({ entry }) => entry.relativeDate.length)))
+  const actionColWidth = splitVisible.length === 0
+    ? 12
+    : Math.min(24, Math.max(6, ...splitVisible.map(({ parts }) => parts.action.length)))
+  const hashColWidth = 8
+
+  const lines: ReactTypes.ReactNode[] = loading
+    ? [h(Text, { key: 'reflog-loading', dimColor: true }, loadingLabel)]
+    : entries.length === 0
+      ? [h(Text, { key: 'reflog-empty', dimColor: true }, emptyLabel)]
+      : splitVisible.map(({ entry, parts }, offset) => {
+        const index = startIndex + offset
+        const isSelected = index === selected
+        const cursor = isSelected ? '>' : ' '
+        const datePadded = truncate(entry.relativeDate, dateColWidth).padEnd(dateColWidth)
+        const actionPadded = truncate(parts.action, actionColWidth).padEnd(actionColWidth)
+        const hashPadded = truncate(entry.hash, hashColWidth).padEnd(hashColWidth)
+        const message = parts.message || entry.subject
+        const lineText = truncate(
+          `${cursor} ${datePadded} ${actionPadded} ${hashPadded} ${message}`,
+          Math.max(20, width - 4)
+        )
+        return h(Text, {
+          key: `reflog-${index}`,
+          bold: isSelected,
+          dimColor: !isSelected,
+        }, lineText)
+      })
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    flexShrink: 0,
+    paddingX: 1,
+    width,
+  },
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle('Reflog', focused)),
     h(Text, { dimColor: true }, headerRight)
   ),
   ...renderPromotedFilterAffordance(h, Text, state, theme),

--- a/src/commands/log/inkSurfaceStates.ts
+++ b/src/commands/log/inkSurfaceStates.ts
@@ -80,6 +80,17 @@ export function formatLogInkStatusEmpty({ hasChanges }: LogInkStatusEmptyArgs): 
   return 'Worktree clean. Press gh for history, gb for branches, gz for stash.'
 }
 
+export type LogInkReflogEmptyArgs = {
+  filter: string
+}
+
+export function formatLogInkReflogEmpty({ filter }: LogInkReflogEmptyArgs): string {
+  if (filter.trim()) {
+    return `No reflog entries match filter '${filter}'. Press ctrl+u to clear.`
+  }
+  return 'No reflog entries. Activity in this repo will appear here over time.'
+}
+
 export type LogInkComposeEmptyArgs = {
   /** Whether the worktree has any staged changes ready to commit. */
   hasStaged: boolean

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -18,7 +18,7 @@ import {
 export type LogInkFocus = 'sidebar' | 'commits' | 'detail'
 
 export type LogInkSidebarTab = 'status' | 'branches' | 'tags' | 'stashes' | 'worktrees'
-export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash' | 'worktrees' | 'pull-request' | 'conflicts'
+export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash' | 'worktrees' | 'pull-request' | 'conflicts' | 'reflog'
 export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk' | 'discard-draft'
 /**
  * Tracks which kind of diff the user pushed into. `commit` means they
@@ -84,6 +84,12 @@ export type LogInkState = {
   selectedStashIndex: number
   selectedWorktreeListIndex: number
   selectedConflictFileIndex: number
+  /**
+   * Cursor for the promoted reflog view (#781). Lives on the root state
+   * for the same reason as the other selected* indices: navigating away
+   * and back should keep the user's place in the list.
+   */
+  selectedReflogIndex: number
   /**
    * Sort modes for the promoted views (P4.2). `s` cycles through the
    * available modes; the surface header shows a `▼ <mode>` indicator.
@@ -338,6 +344,7 @@ export type LogInkAction =
   | { type: 'setBootLoading'; value: boolean }
   | { type: 'moveTag'; delta: number; count: number }
   | { type: 'moveStash'; delta: number; count: number }
+  | { type: 'moveReflog'; delta: number; count: number }
   | { type: 'moveWorktreeListEntry'; delta: number; count: number }
   | { type: 'moveConflictFile'; delta: number; count: number }
   | { type: 'moveToBottom' }
@@ -602,6 +609,11 @@ function withFilter(
     (filterChanged ? 0 : state.selectedTagIndex)
   const stashIndex = promotedSelections?.stashIndex ??
     (filterChanged ? 0 : state.selectedStashIndex)
+  // Reflog (#781) snaps to 0 on filter change rather than rectifying.
+  // The list is chronological and the user is unlikely to be tracking
+  // a specific entry through filter changes — the simpler reset
+  // matches the "find recovery target by typing" interaction.
+  const reflogIndex = filterChanged ? 0 : state.selectedReflogIndex
 
   return {
     ...state,
@@ -612,6 +624,7 @@ function withFilter(
     selectedBranchIndex: branchIndex,
     selectedTagIndex: tagIndex,
     selectedStashIndex: stashIndex,
+    selectedReflogIndex: reflogIndex,
     diffPreviewOffset: 0,
     pendingKey: undefined,
   }
@@ -716,6 +729,7 @@ export function createLogInkState(
     selectedStashIndex: 0,
     selectedWorktreeListIndex: 0,
     selectedConflictFileIndex: 0,
+    selectedReflogIndex: 0,
     branchSort: DEFAULT_BRANCH_SORT_MODE,
     tagSort: DEFAULT_TAG_SORT_MODE,
     paletteFilter: '',
@@ -971,6 +985,12 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         selectedStashIndex: clampIndex(state.selectedStashIndex + action.delta, action.count),
+        pendingKey: undefined,
+      }
+    case 'moveReflog':
+      return {
+        ...state,
+        selectedReflogIndex: clampIndex(state.selectedReflogIndex + action.delta, action.count),
         pendingKey: undefined,
       }
     case 'moveWorktreeListEntry':

--- a/src/commands/log/reflogData.test.ts
+++ b/src/commands/log/reflogData.test.ts
@@ -1,0 +1,134 @@
+import { SimpleGit } from 'simple-git'
+import { getReflogOverview, parseReflogOverview, splitReflogSubject } from './reflogData'
+
+const SEP = '\x1f'
+
+describe('parseReflogOverview', () => {
+  it('returns an empty list for empty output', () => {
+    expect(parseReflogOverview('')).toEqual([])
+    expect(parseReflogOverview('\n\n')).toEqual([])
+  })
+
+  it('parses well-formed entries with selector, hash, relative date, and subject', () => {
+    const output = [
+      `HEAD@{0}${SEP}abc1234${SEP}2 hours ago${SEP}commit: add reflog view`,
+      `HEAD@{1}${SEP}def5678${SEP}3 hours ago${SEP}checkout: moving from main to feat/reflog`,
+      `HEAD@{2}${SEP}ghi9012${SEP}1 day ago${SEP}merge feature: Merge branch 'feature' into main`,
+    ].join('\n')
+
+    expect(parseReflogOverview(output)).toEqual([
+      {
+        selector: 'HEAD@{0}',
+        hash: 'abc1234',
+        relativeDate: '2 hours ago',
+        subject: 'commit: add reflog view',
+      },
+      {
+        selector: 'HEAD@{1}',
+        hash: 'def5678',
+        relativeDate: '3 hours ago',
+        subject: 'checkout: moving from main to feat/reflog',
+      },
+      {
+        selector: 'HEAD@{2}',
+        hash: 'ghi9012',
+        relativeDate: '1 day ago',
+        subject: "merge feature: Merge branch 'feature' into main",
+      },
+    ])
+  })
+
+  it('tolerates trailing whitespace and blank lines between entries', () => {
+    const output = [
+      `HEAD@{0}${SEP}abc${SEP}now${SEP}commit: a   `,
+      '',
+      `HEAD@{1}${SEP}def${SEP}now${SEP}commit: b`,
+      '',
+    ].join('\n')
+
+    const entries = parseReflogOverview(output)
+    expect(entries).toHaveLength(2)
+    expect(entries[0].selector).toBe('HEAD@{0}')
+    expect(entries[1].selector).toBe('HEAD@{1}')
+  })
+
+  it('fills missing fields with empty strings rather than undefined', () => {
+    // Defensive — a malformed line missing the subject shouldn't crash
+    // the renderer. Selector + hash come through; the rest is empty.
+    const output = `HEAD@{0}${SEP}abc${SEP}now`
+    expect(parseReflogOverview(output)).toEqual([
+      {
+        selector: 'HEAD@{0}',
+        hash: 'abc',
+        relativeDate: 'now',
+        subject: '',
+      },
+    ])
+  })
+})
+
+describe('getReflogOverview', () => {
+  it('invokes git reflog with the expected format and parses the result', async () => {
+    const raw = jest.fn().mockResolvedValue(
+      `HEAD@{0}${SEP}abc${SEP}now${SEP}commit: x\nHEAD@{1}${SEP}def${SEP}5 minutes ago${SEP}checkout: moving from main to dev`
+    )
+    const git = { raw } as unknown as SimpleGit
+
+    const result = await getReflogOverview(git, 50)
+
+    expect(raw).toHaveBeenCalledWith([
+      'reflog',
+      '--max-count=50',
+      `--pretty=format:%gd${SEP}%h${SEP}%cr${SEP}%gs`,
+    ])
+    expect(result.entries).toHaveLength(2)
+    expect(result.entries[0].selector).toBe('HEAD@{0}')
+  })
+
+  it('uses a sensible default limit when none is provided', async () => {
+    const raw = jest.fn().mockResolvedValue('')
+    const git = { raw } as unknown as SimpleGit
+
+    await getReflogOverview(git)
+
+    const args = raw.mock.calls[0][0] as string[]
+    expect(args).toContain('--max-count=200')
+  })
+})
+
+describe('splitReflogSubject', () => {
+  it('separates the action prefix from the message at the first colon', () => {
+    expect(splitReflogSubject('commit: my message')).toEqual({
+      action: 'commit',
+      message: 'my message',
+    })
+  })
+
+  it('preserves parenthetical qualifiers in the action prefix', () => {
+    expect(splitReflogSubject('commit (amend): updated message')).toEqual({
+      action: 'commit (amend)',
+      message: 'updated message',
+    })
+  })
+
+  it('handles checkout subjects with no leading verb-only convention', () => {
+    expect(splitReflogSubject('checkout: moving from main to feature')).toEqual({
+      action: 'checkout',
+      message: 'moving from main to feature',
+    })
+  })
+
+  it('treats subjects without a colon as action-only with empty message', () => {
+    expect(splitReflogSubject('reset')).toEqual({
+      action: 'reset',
+      message: '',
+    })
+  })
+
+  it('trims whitespace around both action and message', () => {
+    expect(splitReflogSubject('  commit  :  my message  ')).toEqual({
+      action: 'commit',
+      message: 'my message',
+    })
+  })
+})

--- a/src/commands/log/reflogData.ts
+++ b/src/commands/log/reflogData.ts
@@ -1,0 +1,91 @@
+import { SimpleGit } from 'simple-git'
+
+const FIELD_SEPARATOR = '\x1f'
+
+/**
+ * Per-row data for the promoted reflog view (#781). Mirrors the
+ * `historyActions.ReflogEntry` shape used by the recovery banner but
+ * adds the relative date so the view can render "2 hours ago" without
+ * a second git call. Kept here (not in `historyActions.ts`) because
+ * the reflog browser is the only consumer of the relative date and
+ * the recovery banner reads only selector/hash/subject.
+ */
+export type ReflogViewEntry = {
+  /** `HEAD@{N}` — the index selector. */
+  selector: string
+  /** Short hash (`%h`). */
+  hash: string
+  /** Committer-date relative (`%cr`), e.g. "2 hours ago". */
+  relativeDate: string
+  /** Reflog subject (`%gs`), e.g. "commit: my message" or "checkout: ...". */
+  subject: string
+}
+
+export type ReflogOverview = {
+  entries: ReflogViewEntry[]
+}
+
+/**
+ * Default fetch limit. 200 entries is enough to span weeks of normal
+ * activity for an active repo while keeping the load fast — `git reflog`
+ * is local-only so even 1000+ entries is sub-second, but 200 keeps the
+ * rendered list bounded for terminals.
+ */
+const DEFAULT_REFLOG_LIMIT = 200
+
+export function parseReflogOverview(output: string): ReflogViewEntry[] {
+  return output
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => {
+      const [selector, hash, relativeDate, subject] = line.split(FIELD_SEPARATOR)
+
+      return {
+        selector: selector || '',
+        hash: hash || '',
+        relativeDate: relativeDate || '',
+        subject: subject || '',
+      }
+    })
+}
+
+export async function getReflogOverview(
+  git: SimpleGit,
+  limit = DEFAULT_REFLOG_LIMIT
+): Promise<ReflogOverview> {
+  const output = await git.raw([
+    'reflog',
+    `--max-count=${limit}`,
+    `--pretty=format:%gd${FIELD_SEPARATOR}%h${FIELD_SEPARATOR}%cr${FIELD_SEPARATOR}%gs`,
+  ])
+
+  return {
+    entries: parseReflogOverview(output),
+  }
+}
+
+/**
+ * Pull the action prefix off a reflog subject. Reflog subjects follow
+ * a `<verb>[ qualifier]: <message>` pattern emitted by git itself —
+ * "commit: ...", "commit (amend): ...", "checkout: moving from main
+ * to feature", "merge feature: ...", "reset: moving to HEAD~1", etc.
+ *
+ * For display we want the verb (and any parenthetical qualifier) on
+ * its own so the view can render a fixed-width `action` column and
+ * keep the rest of the message left-aligned.
+ *
+ * Defensive: if the subject has no colon, the whole string is treated
+ * as the action and the message is empty. This keeps the renderer
+ * from crashing on a malformed entry.
+ */
+export function splitReflogSubject(subject: string): { action: string; message: string } {
+  const colonIndex = subject.indexOf(':')
+  if (colonIndex === -1) {
+    return { action: subject.trim(), message: '' }
+  }
+  return {
+    action: subject.slice(0, colonIndex).trim(),
+    message: subject.slice(colonIndex + 1).trim(),
+  }
+}


### PR DESCRIPTION
Closes [#781](https://github.com/gfargo/coco/issues/781).

## Summary

New promoted TUI view at \`gr\` that lists the repo's reflog chronologically. Each row shows relative date, action prefix (commit / checkout / merge / etc.), short hash, and message. **Enter** on a row drills into the commit-diff explore for that entry's hash, turning reflog into a discoverable recovery surface.

\`\`\`
> 2 hours ago   commit       abc1234  add reflog view
  3 hours ago   checkout     def5678  moving from main to feat/tui-reflog-view
  1 day ago     merge        ghi9012  Merge branch 'feature' into main
  2 days ago    reset        jkl3456  moving to HEAD~1
\`\`\`

Footer: \`↑/↓ entries · enter inspect · esc back\`

## Implementation

Mirrors the existing **tags** view as the template:

- **\`reflogData.ts\`** — new helper module (per the TUI cadence preference for separating helpers from runtime). Exports \`ReflogOverview\`, \`getReflogOverview\`, and \`splitReflogSubject\`. Loader caps at 200 entries — git reflog is local-only so even thousands is sub-second, but 200 keeps the rendered list bounded and the filter responsive.
- **\`inkContext\`** registers \`'reflog'\` for the per-key loading state machinery.
- **\`inkViewModel\`** adds \`'reflog'\` to \`LogInkView\`, a \`selectedReflogIndex\` cursor on root state, and a \`moveReflog\` action mirroring \`moveTag\` / \`moveStash\`. Filter changes snap to 0 (chronological lists don't benefit from the rectify path used by branches/tags).
- **\`inkKeymap\`** registers \`navigateReflog\` with the \`gr\` chord, adds it to \`GLOBAL_BINDING_IDS\`, and gives the view its own footer hint set.
- **\`inkInput\`** wires the chord, up/down navigation, and Enter → \`navigateOpenDiffForCommit\` with the cursored hash. \`commitIndex\` is best-effort — index in \`state.commits\` if the hash is loaded, else fallback to selectedIndex. Reflog hashes that exist in the loaded history (the common case) drill in cleanly; dangling-commit hashes fall back gracefully.
- **\`inkRuntime\`** adds the data loader, the render dispatch, the \`renderReflogSurface\` itself, and threads \`reflogVisibleCount\` / \`reflogSelectedHash\` into the input context. Surface lays out four columns per row (date / action / hash / message) with widths derived from the visible window so short rows don't leave a gutter and long actions don't push the message off-screen.

## Out of scope

- **\`y\` yank hash** — deferred per the issue's note that it depends on [#778](https://github.com/gfargo/coco/issues/778)'s clipboard hash-yank infrastructure. The view will pick this up automatically when that lands.

## Test plan

- [x] \`reflogData.test.ts\` — 11 tests: parser, git invocation contract, subject splitter
- [x] \`inkInput.test.ts\` — 4 new tests: \`gr\` chord, j/k navigation, Enter dispatches \`navigateOpenDiffForCommit\`, Enter is a no-op when no entry is cursored
- [x] \`npx jest\` — 1310/1310 (15 new)
- [x] \`npm run lint\` — clean
- [x] \`npm run build\` — green
- [x] \`npx tsc --noEmit\` — 0 errors