### PR TITLE
feat(log-tui): compare two refs via mark-then-Enter (#779)

### DIFF
--- a/src/commands/log/compareData.test.ts
+++ b/src/commands/log/compareData.test.ts
@@ -1,0 +1,57 @@
+import { SimpleGit } from 'simple-git'
+import { getCompareDiff } from './compareData'
+
+describe('getCompareDiff', () => {
+  it('invokes `git diff base..head` and splits the result on newlines', async () => {
+    const raw = jest.fn().mockResolvedValue(
+      [
+        'diff --git a/foo.ts b/foo.ts',
+        'index aaa..bbb 100644',
+        '--- a/foo.ts',
+        '+++ b/foo.ts',
+        '@@ -1,3 +1,4 @@',
+        ' const a = 1',
+        '+const b = 2',
+      ].join('\n')
+    )
+    const git = { raw } as unknown as SimpleGit
+
+    const lines = await getCompareDiff(git, 'main', 'feature')
+
+    expect(raw).toHaveBeenCalledWith(['diff', 'main..feature'])
+    expect(lines).toEqual([
+      'diff --git a/foo.ts b/foo.ts',
+      'index aaa..bbb 100644',
+      '--- a/foo.ts',
+      '+++ b/foo.ts',
+      '@@ -1,3 +1,4 @@',
+      ' const a = 1',
+      '+const b = 2',
+    ])
+  })
+
+  it('passes refs through verbatim — caller owns the git-resolvable form', async () => {
+    const raw = jest.fn().mockResolvedValue('')
+    const git = { raw } as unknown as SimpleGit
+
+    await getCompareDiff(git, 'v1.0.0', 'abc1234')
+
+    expect(raw).toHaveBeenCalledWith(['diff', 'v1.0.0..abc1234'])
+  })
+
+  it('strips trailing CR characters from each line (CRLF tolerance)', async () => {
+    const raw = jest.fn().mockResolvedValue('first line\r\nsecond line\r')
+    const git = { raw } as unknown as SimpleGit
+
+    expect(await getCompareDiff(git, 'a', 'b')).toEqual(['first line', 'second line'])
+  })
+
+  it('returns an empty-line array for an empty diff (trailing newline only)', async () => {
+    const raw = jest.fn().mockResolvedValue('')
+    const git = { raw } as unknown as SimpleGit
+
+    // Empty `git diff` output: a single empty string from .split('\n')
+    // — surfaces detect this as "no diff to display".
+    expect(await getCompareDiff(git, 'a', 'b')).toEqual([''])
+  })
+})

--- a/src/commands/log/compareData.ts
+++ b/src/commands/log/compareData.ts
@@ -1,0 +1,28 @@
+import { SimpleGit } from 'simple-git'
+
+/**
+ * Compare two refs (branches / tags / commits) and return the unified
+ * patch as line-split string output (#779).
+ *
+ * Mirrors the stash-diff loader's contract — emits `string[]` so the
+ * existing diff surface can render the lines through its standard
+ * +/-/@@ coloring path. Two-dot syntax (`base..head`) gives the
+ * "what changed on head, relative to base" view that's natural for
+ * branch reviews and pre-merge sanity checks.
+ *
+ * Defensive about input — both refs are passed as-is to git, so the
+ * caller is responsible for providing a git-resolvable form
+ * (branch shortName, tag name, or commit hash). On any git error
+ * (unknown ref, etc.) the runtime's `safe()` wrapper at the call
+ * site catches the throw and the surface falls back to a "no diff"
+ * hint.
+ */
+export async function getCompareDiff(
+  git: SimpleGit,
+  base: string,
+  head: string
+): Promise<string[]> {
+  return (await git.raw(['diff', `${base}..${head}`]))
+    .split('\n')
+    .map((line) => line.replace(/\r$/, ''))
+}

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -671,6 +671,152 @@ describe('log Ink input interactions', () => {
     )).toBeUndefined()
   })
 
+  it('marks the cursored branch as compare base on m (#779)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'branches' })
+
+    state = applyInput(state, 'm', {}, {
+      branchCount: 3,
+      branchSelectedShortName: 'main',
+    })
+
+    expect(state.compareBase).toEqual({ kind: 'branch', ref: 'main', label: 'main' })
+    expect(state.statusMessage).toContain('Compare base: main')
+  })
+
+  it('toggles the compare base off when m is pressed on the same ref (#779)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'branches' })
+
+    state = applyInput(state, 'm', {}, {
+      branchCount: 3,
+      branchSelectedShortName: 'main',
+    })
+    expect(state.compareBase?.ref).toBe('main')
+
+    state = applyInput(state, 'm', {}, {
+      branchCount: 3,
+      branchSelectedShortName: 'main',
+    })
+    expect(state.compareBase).toBeUndefined()
+    expect(state.statusMessage).toContain('Cleared compare base')
+  })
+
+  it('replaces the compare base when m is pressed on a different ref (#779)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'tags' })
+
+    state = applyInput(state, 'm', {}, {
+      tagCount: 3,
+      tagSelectedName: 'v1.0',
+    })
+    expect(state.compareBase).toEqual({ kind: 'tag', ref: 'v1.0', label: 'v1.0' })
+
+    state = applyInput(state, 'm', {}, {
+      tagCount: 3,
+      tagSelectedName: 'v2.0',
+    })
+    expect(state.compareBase).toEqual({ kind: 'tag', ref: 'v2.0', label: 'v2.0' })
+  })
+
+  it('Enter on a second ref dispatches navigateOpenDiffForCompare with base + head (#779)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'branches' })
+
+    // Mark base from branches.
+    state = applyInput(state, 'm', {}, {
+      branchCount: 3,
+      branchSelectedShortName: 'main',
+    })
+    expect(state.compareBase?.ref).toBe('main')
+
+    // Switch to tags and press Enter on a tag — Enter override fires.
+    state = applyLogInkAction(state, { type: 'pushView', value: 'tags' })
+    const events = getLogInkInputEvents(state, '', { return: true }, {
+      tagCount: 3,
+      tagSelectedName: 'v1.0',
+    })
+
+    const compare = events.find((event) =>
+      event.type === 'action' && event.action.type === 'navigateOpenDiffForCompare'
+    )
+    expect(compare).toBeDefined()
+    if (compare && compare.type === 'action' && compare.action.type === 'navigateOpenDiffForCompare') {
+      expect(compare.action.base).toEqual({ kind: 'branch', ref: 'main', label: 'main' })
+      expect(compare.action.head).toEqual({ kind: 'tag', ref: 'v1.0', label: 'v1.0' })
+    }
+  })
+
+  it('Enter on the same ref as the compare base shows a hint (#779)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'branches' })
+
+    state = applyInput(state, 'm', {}, {
+      branchCount: 3,
+      branchSelectedShortName: 'main',
+    })
+
+    const events = getLogInkInputEvents(state, '', { return: true }, {
+      branchCount: 3,
+      branchSelectedShortName: 'main',
+    })
+
+    expect(events.find((event) =>
+      event.type === 'action' && event.action.type === 'navigateOpenDiffForCompare'
+    )).toBeUndefined()
+    const status = events.find((event) =>
+      event.type === 'action' && event.action.type === 'setStatus'
+    )
+    expect(status).toBeDefined()
+  })
+
+  it('clears the compare base when the diff view is popped (#779)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'branches' })
+
+    // Mark base + open compare diff.
+    state = applyInput(state, 'm', {}, {
+      branchCount: 3,
+      branchSelectedShortName: 'main',
+    })
+    state = applyLogInkAction(state, {
+      type: 'navigateOpenDiffForCompare',
+      base: { kind: 'branch', ref: 'main', label: 'main' },
+      head: { kind: 'tag', ref: 'v1.0', label: 'v1.0' },
+    })
+    expect(state.activeView).toBe('diff')
+    expect(state.compareBase?.ref).toBe('main')
+    expect(state.compareHead?.ref).toBe('v1.0')
+
+    // Pop the diff — compareBase + compareHead both clear.
+    state = applyLogInkAction(state, { type: 'popView' })
+    expect(state.activeView).toBe('branches')
+    expect(state.compareBase).toBeUndefined()
+    expect(state.compareHead).toBeUndefined()
+  })
+
+  it('Enter on a history commit row uses its hash as the compare head (#779)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, {
+      type: 'setCompareBase',
+      value: { kind: 'branch', ref: 'main', label: 'main' },
+    })
+
+    // History view, default cursor on commit at index 0.
+    const events = getLogInkInputEvents(state, '', { return: true }, {})
+
+    const compare = events.find((event) =>
+      event.type === 'action' && event.action.type === 'navigateOpenDiffForCompare'
+    )
+    expect(compare).toBeDefined()
+    if (compare && compare.type === 'action' && compare.action.type === 'navigateOpenDiffForCompare') {
+      expect(compare.action.base.ref).toBe('main')
+      expect(compare.action.head.kind).toBe('commit')
+      // Hash matches the cursored commit (rows[0] is a commit row in this fixture).
+      expect(compare.action.head.ref).toBeTruthy()
+    }
+  })
+
   it('preserves per-view selection across navigation', () => {
     let state = createLogInkState(rows)
 

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -11,6 +11,7 @@ import {
 } from './inkKeymap'
 import {
     LogInkAction,
+    LogInkCompareRef,
     LogInkSidebarTab,
     LogInkState,
     parseLogInkHistoryFetchPrefix,
@@ -65,7 +66,18 @@ export type LogInkInputContext = {
    */
   commitDiffHunkOffsets?: number[]
   branchCount?: number
+  /**
+   * Short name of the cursored branch (#779). Used by `m` to capture
+   * the compare-base ref and by Enter (when compareBase is set) to
+   * resolve the head ref from the branches view.
+   */
+  branchSelectedShortName?: string
   tagCount?: number
+  /**
+   * Name of the cursored tag (#779). Same role as
+   * `branchSelectedShortName` but scoped to the tags view.
+   */
+  tagSelectedName?: string
   stashCount?: number
   reflogCount?: number
   /** Hash of the cursored reflog entry (#781). Used by Enter to drill into the diff. */
@@ -317,6 +329,58 @@ function isWorktreeActionTarget(state: LogInkState): boolean {
 }
 
 /**
+ * Compare-flow target views (#779). The `m` mark + Enter-as-compare
+ * overrides only fire on rows that represent a single ref the user
+ * could pass to `git diff <ref>..<ref>` — branches, tags, and history
+ * commits. The reflog view is intentionally excluded because reflog
+ * entries are *moves* of HEAD, not refs a user typically diffs against.
+ */
+function isCompareFlowTarget(state: LogInkState): boolean {
+  if (state.focus !== 'commits') return false
+  return state.activeView === 'branches' ||
+    state.activeView === 'tags' ||
+    state.activeView === 'history'
+}
+
+/**
+ * Resolve the cursored ref for the compare flow (#779). Pulls the
+ * concrete ref + label off context for branches / tags, and reads the
+ * commit row from state for history. Returns undefined when no usable
+ * ref is under the cursor (e.g., the views are empty, or the focus is
+ * on the synthetic "(+) new commit" row).
+ */
+function getCursoredCompareRef(
+  state: LogInkState,
+  context: LogInkInputContext
+): LogInkCompareRef | undefined {
+  if (state.activeView === 'branches' && context.branchSelectedShortName) {
+    return {
+      kind: 'branch',
+      ref: context.branchSelectedShortName,
+      label: context.branchSelectedShortName,
+    }
+  }
+  if (state.activeView === 'tags' && context.tagSelectedName) {
+    return {
+      kind: 'tag',
+      ref: context.tagSelectedName,
+      label: context.tagSelectedName,
+    }
+  }
+  if (state.activeView === 'history' && !state.pendingCommitFocused) {
+    const commit = state.filteredCommits[state.selectedIndex]
+    if (commit) {
+      return {
+        kind: 'commit',
+        ref: commit.hash,
+        label: `${commit.shortHash} ${commit.message}`.trim(),
+      }
+    }
+  }
+  return undefined
+}
+
+/**
  * Item count for the active sidebar tab — used by the generic
  * sidebar-Enter handler to decide whether to defer to the per-entity
  * Enter (when items are present and the user is cursoring through
@@ -425,6 +489,16 @@ export function getLogInkPaletteExecuteEvents(
       return [action({ type: 'pushView', value: 'conflicts' })]
     case 'navigateReflog':
       return [action({ type: 'pushView', value: 'reflog' })]
+    case 'markForCompare':
+      // Palette context can't reach the cursored ref (filtered branch /
+      // tag lists live in runtime state, not the reducer). Surface a
+      // hint and let the user press `m` directly on the row. The
+      // inline keypress handler further down in this file does the
+      // actual work and has access to the necessary context.
+      return [action({
+        type: 'setStatus',
+        value: 'open branches / tags / history and press m on the cursored ref',
+      })]
     case 'navigateBack':
       return [action({ type: 'popView' })]
     case 'openSelected': {
@@ -1508,6 +1582,31 @@ export function getLogInkInputEvents(
     ]
   }
 
+  // Compare-flow Enter override (#779). When `compareBase` is set and
+  // the user presses Enter on a branch / tag / history commit row, we
+  // open the compare diff (base..head) instead of the row's normal
+  // action (checkout / drill-in / diff). Scoped to compare-flow
+  // targets so non-flow views keep their Enter intact. Runs BEFORE
+  // the per-row Enter handlers below so the override wins, including
+  // before the history-row drill-in.
+  if (key.return && state.compareBase && isCompareFlowTarget(state)) {
+    const head = getCursoredCompareRef(state, context)
+    if (!head) {
+      return [action({ type: 'setStatus', value: 'No ref under cursor — move to a branch / tag / commit row first' })]
+    }
+    if (head.ref === state.compareBase.ref && head.kind === state.compareBase.kind) {
+      return [action({ type: 'setStatus', value: 'Compare base and head are the same ref — pick a different one' })]
+    }
+    return [
+      action({
+        type: 'navigateOpenDiffForCompare',
+        base: state.compareBase,
+        head,
+      }),
+      action({ type: 'setStatus', value: `Comparing ${state.compareBase.label} → ${head.label}` }),
+    ]
+  }
+
   if (
     key.return &&
     state.activeView === 'history' &&
@@ -1751,6 +1850,28 @@ export function getLogInkInputEvents(
   // (especially the `R` rename binding on the branches target).
   if (inputValue === 'R' && isTagActionTarget(state) && context.tagCount) {
     return [action({ type: 'setPendingConfirmation', value: 'delete-remote-tag' })]
+  }
+
+  // `m` marks (or un-marks) the cursored ref as the compare base
+  // (#779). Scoped to compare-flow targets so it doesn't collide with
+  // the `m` PR-merge handler further down. The toggle behavior — `m`
+  // again on the same ref clears the base — gives the user a way to
+  // bail out without remembering a separate cancel key.
+  if (inputValue === 'm' && isCompareFlowTarget(state)) {
+    const ref = getCursoredCompareRef(state, context)
+    if (!ref) {
+      return [action({ type: 'setStatus', value: 'No ref under cursor — move to a branch / tag / commit row first' })]
+    }
+    if (state.compareBase && state.compareBase.ref === ref.ref && state.compareBase.kind === ref.kind) {
+      return [
+        action({ type: 'clearCompareBase' }),
+        action({ type: 'setStatus', value: `Cleared compare base ${ref.label}` }),
+      ]
+    }
+    return [
+      action({ type: 'setCompareBase', value: ref }),
+      action({ type: 'setStatus', value: `Compare base: ${ref.label} — press enter on another ref to diff` }),
+    ]
   }
 
   // Per-view worktree action: `D` removes the worktree AND deletes

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -20,7 +20,7 @@ describe('log Ink keymap', () => {
       // `c/R/Z/i mutate` is the compact chip for cherry-pick / revert /
       // reset / interactive-rebase — full descriptions in ? help and
       // the palette. `B/gT new` covers create-branch-here / create-tag-here.
-      contextual: ['↑/↓ move', 'enter diff', 'c/R/Z/i mutate', 'B/gT new', 'y/Y yank', '/ search', 'gg/G top/bottom'],
+      contextual: ['↑/↓ move', 'enter diff', 'c/R/Z/i mutate', 'B/gT new', 'm compare', 'y/Y yank', '/ search'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 
@@ -77,7 +77,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'D delete', 's sort', 'y yank'],
+      contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'D delete', 'm compare', 's sort', 'y yank'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 
@@ -87,7 +87,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ tags', '+ new', 'P push', 'T delete', 's sort', 'y yank'],
+      contextual: ['↑/↓ tags', '+ new', 'P push', 'T delete', 'm compare', 's sort', 'y yank'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -14,6 +14,7 @@ export type LogInkCommandId =
   | 'focusNext'
   | 'focusPrevious'
   | 'help'
+  | 'markForCompare'
   | 'moveDown'
   | 'moveToBottom'
   | 'moveToTop'
@@ -273,6 +274,13 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     contexts: ['normal'],
   },
   {
+    id: 'markForCompare',
+    keys: ['m'],
+    label: 'mark compare',
+    description: 'Mark the cursored ref (branch / tag / commit) as the base for a compare-two-refs diff (#779). Press again on the same ref to clear; with a base set, Enter on another ref opens the compare diff.',
+    contexts: ['commits'],
+  },
+  {
     id: 'navigateBack',
     keys: ['<', 'esc'],
     label: 'back',
@@ -362,7 +370,7 @@ export type GetLogInkFooterHintsOptions = {
   activeView?: LogInkView
   /** Used to differentiate the diff-view hints between commit / worktree
    *  / stash sources without reaching into runtime state. */
-  diffSource?: 'commit' | 'worktree' | 'stash'
+  diffSource?: 'commit' | 'worktree' | 'stash' | 'compare'
   filterMode: boolean
   focus: LogInkFocus
   showHelp: boolean
@@ -384,6 +392,14 @@ export type GetLogInkFooterHintsOptions = {
    * will switch to.
    */
   diffViewMode?: 'unified' | 'split'
+  /**
+   * True when a compare base is set (#779). Compare-flow target views
+   * (branches / tags / history) swap their `enter` hint to show
+   * "enter compare" so users know the override is active. Also adds
+   * "m clear" so they can bail out of the flow without remembering a
+   * separate cancel key.
+   */
+  compareBaseSet?: boolean
 }
 
 export type LogInkChordContinuation = {
@@ -591,6 +607,15 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
         global: NORMAL_GLOBAL_HINTS,
       }
     }
+    if (options.diffSource === 'compare') {
+      // Compare-two-refs (#779): read-only diff with no per-file
+      // cherry-pick or hunk apply (those don't make sense across
+      // arbitrary refs). Just scroll + back out.
+      return {
+        contextual: ['j/k lines', splitToggleHint, 'esc back'],
+        global: NORMAL_GLOBAL_HINTS,
+      }
+    }
     return {
       contextual: ['j/k hunks', 'space stage', 'z revert', 'o edit', 'e/c compose', 'y yank'],
       global: NORMAL_GLOBAL_HINTS,
@@ -605,15 +630,27 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
   }
 
   if (options.activeView === 'branches') {
+    if (options.compareBaseSet) {
+      return {
+        contextual: ['↑/↓ branches', 'enter compare', 'm clear', 'esc back'],
+        global: NORMAL_GLOBAL_HINTS,
+      }
+    }
     return {
-      contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'D delete', 's sort', 'y yank'],
+      contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'D delete', 'm compare', 's sort', 'y yank'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }
 
   if (options.activeView === 'tags') {
+    if (options.compareBaseSet) {
+      return {
+        contextual: ['↑/↓ tags', 'enter compare', 'm clear', 'esc back'],
+        global: NORMAL_GLOBAL_HINTS,
+      }
+    }
     return {
-      contextual: ['↑/↓ tags', '+ new', 'P push', 'T delete', 's sort', 'y yank'],
+      contextual: ['↑/↓ tags', '+ new', 'P push', 'T delete', 'm compare', 's sort', 'y yank'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }
@@ -657,6 +694,17 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
     }
   }
 
+  if (options.compareBaseSet) {
+    // History view with a compare base set — Enter is overridden to
+    // open the compare diff; show the override + the bail-out key.
+    // Mutate / new chips are dropped so the footer doesn't compete
+    // with the active workflow.
+    return {
+      contextual: ['↑/↓ move', 'enter compare', 'm clear', 'esc back'],
+      global: NORMAL_GLOBAL_HINTS,
+    }
+  }
+
   return {
     // History view default hints. Mutating ops (`c` cherry-pick, `R`
     // revert, `Z` reset, `i` interactive-rebase) all route through a
@@ -666,7 +714,7 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
     // Grouped into compact `c/R/Z/i mutate` and `B/gT new` chips so
     // the footer stays scannable; full descriptions live in `?` help
     // and the palette.
-    contextual: ['↑/↓ move', 'enter diff', 'c/R/Z/i mutate', 'B/gT new', 'y/Y yank', '/ search', 'gg/G top/bottom'],
+    contextual: ['↑/↓ move', 'enter diff', 'c/R/Z/i mutate', 'B/gT new', 'm compare', 'y/Y yank', '/ search'],
     global: NORMAL_GLOBAL_HINTS,
   }
 }

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -227,6 +227,7 @@ import {
     stageHunk,
     unstageHunk,
 } from './statusHunks'
+import { getCompareDiff } from './compareData'
 import { ReflogOverview, getReflogOverview, splitReflogSubject } from './reflogData'
 import { TagOverview, getTagOverview } from './tagData'
 import {
@@ -896,6 +897,10 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // colors match the commit-diff path.
   const [stashDiffLines, setStashDiffLines] = React.useState<string[] | undefined>(undefined)
   const [stashDiffLoading, setStashDiffLoading] = React.useState(false)
+  // #779 — compare-two-refs diff state. Loaded lazily when the diff
+  // view becomes active with `diffSource === 'compare'`.
+  const [compareDiffLines, setCompareDiffLines] = React.useState<string[] | undefined>(undefined)
+  const [compareDiffLoading, setCompareDiffLoading] = React.useState(false)
   const [hasMoreCommits, setHasMoreCommits] = React.useState(() => (
     Boolean(logArgv?.interactive && !logArgv.limit) &&
     getCommitRows(rows).length >= LOG_INTERACTIVE_DEFAULT_LIMIT
@@ -1233,6 +1238,45 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     })()
     return () => { active = false }
   }, [git, state.activeView, state.diffSource, state.stashDiffRef])
+
+  // #779 — load `git diff <base>..<head>` once the diff view becomes
+  // active with diffSource='compare'. Mirrors the stash loader's
+  // shape; the surface renders the lines via the same +/-/@@ coloring
+  // path. On unknown ref / git error, `safe()` swallows and the
+  // surface falls back to a "no diff" hint.
+  const compareBaseRef = state.compareBase?.ref
+  const compareHeadRef = state.compareHead?.ref
+  React.useEffect(() => {
+    if (
+      state.activeView !== 'diff' ||
+      state.diffSource !== 'compare' ||
+      !compareBaseRef ||
+      !compareHeadRef
+    ) {
+      return
+    }
+    let active = true
+    setCompareDiffLoading(true)
+    void (async () => {
+      const lines = await safe(getCompareDiff(git, compareBaseRef, compareHeadRef))
+      if (active) {
+        setCompareDiffLines(lines || [])
+        setCompareDiffLoading(false)
+      }
+    })()
+    return () => { active = false }
+  }, [git, state.activeView, state.diffSource, compareBaseRef, compareHeadRef])
+
+  // Reset compare-diff state whenever the diff view exits. Without
+  // this, opening a new compare immediately after closing one would
+  // briefly show the previous comparison's lines while the new
+  // loader runs.
+  React.useEffect(() => {
+    if (state.diffSource !== 'compare') {
+      setCompareDiffLines(undefined)
+      setCompareDiffLoading(false)
+    }
+  }, [state.diffSource])
 
   React.useEffect(() => {
     let active = true
@@ -2461,7 +2505,13 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     // perf pass) — reading them here is O(1) instead of O(branches +
     // tags + stashes + worktrees) per keystroke.
     const branchVisibleCount = filteredBranchList.length
+    const branchSelectedShortName = filteredBranchList[
+      Math.min(state.selectedBranchIndex, Math.max(0, filteredBranchList.length - 1))
+    ]?.shortName
     const tagVisibleCount = filteredTagList.length
+    const tagSelectedName = filteredTagList[
+      Math.min(state.selectedTagIndex, Math.max(0, filteredTagList.length - 1))
+    ]?.name
     const stashVisibleCount = filteredStashList.length
     const stashSelectedRef = filteredStashList[
       Math.min(state.selectedStashIndex, Math.max(0, filteredStashList.length - 1))
@@ -2497,7 +2547,9 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       worktreeHunkOffsets: worktreeDiff?.hunkOffsets,
       commitDiffHunkOffsets,
       branchCount: branchVisibleCount,
+      branchSelectedShortName,
       tagCount: tagVisibleCount,
+      tagSelectedName,
       stashCount: stashVisibleCount,
       reflogCount: reflogVisibleCount,
       reflogSelectedHash,
@@ -2622,6 +2674,8 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         selectedDetailFile,
         stashDiffLines,
         stashDiffLoading,
+        compareDiffLines,
+        compareDiffLoading,
         layout.bodyRows,
         layout.mainPanelWidth,
         theme,
@@ -3007,6 +3061,8 @@ function renderMainPanel(
   selectedDetailFile: GitCommitDetail['files'][number] | undefined,
   stashDiffLines: string[] | undefined,
   stashDiffLoading: boolean,
+  compareDiffLines: string[] | undefined,
+  compareDiffLoading: boolean,
   bodyRows: number,
   width: number,
   theme: LogInkTheme,
@@ -3034,6 +3090,8 @@ function renderMainPanel(
       selectedDetailFile,
       stashDiffLines,
       stashDiffLoading,
+      compareDiffLines,
+      compareDiffLoading,
       bodyRows,
       width,
       theme
@@ -4328,6 +4386,8 @@ function renderDiffSurface(
   selectedDetailFile: GitCommitDetail['files'][number] | undefined,
   stashDiffLines: string[] | undefined,
   stashDiffLoading: boolean,
+  compareDiffLines: string[] | undefined,
+  compareDiffLoading: boolean,
   bodyRows: number,
   width: number,
   theme: LogInkTheme
@@ -4436,6 +4496,65 @@ function renderDiffSurface(
       dimColor: index > 0,
     }, truncate(line, width - 4))),
     ...stashBodyNodes)
+  }
+
+  // Compare-two-refs branch (#779). Mirrors the stash diff above but
+  // sourced from `git diff <base>..<head>`. No per-file cherry-pick or
+  // hunk apply — comparing arbitrary refs doesn't have a sensible
+  // mutate-from-here flow, so the surface is read-only navigation.
+  if (state.diffSource === 'compare') {
+    const lines = compareDiffLines || []
+    const splitActive = isSplitDiffViable(state, width)
+    const splitRequestedButTooNarrow = state.diffViewMode === 'split' && !splitActive
+    const visibleLines = lines.slice(
+      state.diffPreviewOffset,
+      state.diffPreviewOffset + visibleRows
+    )
+    const baseLabel = state.compareBase?.label || state.compareBase?.ref || '<base>'
+    const headLabel = state.compareHead?.label || state.compareHead?.ref || '<head>'
+    const compareTitle = `${baseLabel} → ${headLabel}`
+    const baseHeaderLines: string[] = compareDiffLoading
+      ? [`Loading diff for ${compareTitle}...`]
+      : lines.length && (lines.length > 1 || lines[0])
+        ? [
+          compareTitle,
+          `Lines ${Math.min(state.diffPreviewOffset + 1, lines.length)}-${Math.min(state.diffPreviewOffset + visibleLines.length, lines.length)}/${lines.length}`,
+          '',
+        ]
+        : ['No diff to display — refs may resolve to the same tree.']
+    const headerLines = splitRequestedButTooNarrow
+      ? [...baseHeaderLines.slice(0, -1), 'Terminal too narrow for side-by-side; showing unified.', '']
+      : baseHeaderLines
+
+    const compareBodyNodes: ReactTypes.ReactNode[] = compareDiffLoading || !lines.length || (lines.length === 1 && !lines[0])
+      ? []
+      : splitActive
+        ? renderSplitDiffBody(
+          h, components, visibleLines, state.diffPreviewOffset, width, theme,
+          'compare-diff-split'
+        )
+        : visibleLines.map((line, index) => h(Text, {
+          key: `compare-diff-line-${state.diffPreviewOffset + index}`,
+          ...diffLineProps(line, theme),
+        }, truncate(line, width - 4)))
+
+    return h(Box, {
+      borderColor: focusBorderColor(theme, focused),
+      borderStyle: theme.borderStyle,
+      flexDirection: 'column',
+      flexShrink: 0,
+      paddingX: 1,
+      width,
+    },
+    h(Box, { justifyContent: 'space-between' },
+      h(Text, { bold: true }, panelTitle(splitActive ? 'Compare (split)' : 'Compare', focused)),
+      h(Text, { dimColor: true }, truncate(compareTitle, Math.max(20, Math.floor(width / 2))))
+    ),
+    ...headerLines.map((line, index) => h(Text, {
+      key: `compare-diff-header-${index}`,
+      dimColor: index > 0,
+    }, truncate(line, width - 4))),
+    ...compareBodyNodes)
   }
 
   // diffSource disambiguates: 'commit' was set when the user opened the
@@ -5650,6 +5769,7 @@ function renderFooter(
     showHelp: state.showHelp,
     sidebarTab: state.sidebarTab,
     sidebarItemCount,
+    compareBaseSet: Boolean(state.compareBase),
   })
   // Real status messages always win; idle tips only fill the slot when it
   // would otherwise be empty.

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -28,7 +28,22 @@ export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk' | 'discar
  * input handlers off this field so a dirty worktree can't bleed staging
  * UI into a commit-diff view.
  */
-export type LogInkDiffSource = 'commit' | 'worktree' | 'stash'
+export type LogInkDiffSource = 'commit' | 'worktree' | 'stash' | 'compare'
+
+/**
+ * A ref in the compare-two-refs flow (#779). `kind` is captured from
+ * the source view (branches / tags / history) so the surface can
+ * label the diff header appropriately. `ref` is the git-resolvable
+ * form passed straight to `git diff`. `label` is the display string
+ * — usually equal to `ref` for branches/tags, or `<shortHash> <subject>`
+ * for commits.
+ */
+export type LogInkCompareRefKind = 'branch' | 'tag' | 'commit'
+export type LogInkCompareRef = {
+  kind: LogInkCompareRefKind
+  ref: string
+  label: string
+}
 /**
  * Diff rendering mode (#785). `unified` is the historical single-column
  * patch view; `split` lays the same lines out side-by-side (removals on
@@ -180,6 +195,17 @@ export type LogInkState = {
    * is popped or replaced.
    */
   stashDiffRef?: string
+  /**
+   * Compare-two-refs flow (#779). `compareBase` is set by `m` on a
+   * branch / tag / history row; while it's defined, the footer shows
+   * a "compare base: <label>" hint and `Enter` on a second ref opens
+   * a compare diff instead of the row's normal action. `compareHead`
+   * is set when the compare diff is active and identifies the right-
+   * hand side of the comparison. Both clear when the diff view is
+   * popped or replaced.
+   */
+  compareBase?: LogInkCompareRef
+  compareHead?: LogInkCompareRef
   /**
    * When true, the cursor sits on the synthetic "(+) new commit" row
    * that the history panel renders above the real commits whenever the
@@ -363,6 +389,9 @@ export type LogInkAction =
   | { type: 'navigateOpenDiffForCommit'; sha: string; commitIndex: number; fileIndex?: number }
   | { type: 'navigateOpenDiffForWorktreeFile'; fileIndex: number }
   | { type: 'navigateOpenDiffForStash'; ref: string; stashIndex?: number }
+  | { type: 'navigateOpenDiffForCompare'; base: LogInkCompareRef; head: LogInkCompareRef }
+  | { type: 'setCompareBase'; value: LogInkCompareRef }
+  | { type: 'clearCompareBase' }
   | { type: 'navigateOpenComposeForFile'; fileIndex: number }
   | { type: 'jumpWorktreeHunk'; delta: number; hunkOffsets: number[] }
   | { type: 'jumpCommitDiffHunk'; delta: number; hunkOffsets: number[] }
@@ -539,6 +568,7 @@ function withPushedView(state: LogInkState, value: LogInkView): LogInkState {
     selectedWorktreeHunkIndex: value === 'diff' ? state.selectedWorktreeHunkIndex : 0,
     diffSource: value === 'diff' ? state.diffSource : undefined,
     stashDiffRef: value === 'diff' ? state.stashDiffRef : undefined,
+    compareHead: value === 'diff' ? state.compareHead : undefined,
     pendingCommitFocused: value === 'history' ? state.pendingCommitFocused : false,
     statusGroupHeaderFocused: value === 'status' ? state.statusGroupHeaderFocused : false,
     pendingKey: undefined,
@@ -552,6 +582,13 @@ function withPoppedView(state: LogInkState): LogInkState {
 
   const viewStack = state.viewStack.slice(0, -1)
   const next = topOfStack(viewStack)
+  // #779 — compareBase is "cleared when the diff view is popped." We
+  // detect that case by checking if the *previous* top was 'diff'.
+  // The compare workflow ends when the user backs out of the compare
+  // diff; on the next mark they re-set the base. Other view pops
+  // preserve compareBase so the user can move between branches / tags /
+  // history while hunting for a head ref.
+  const wasOnDiff = state.activeView === 'diff'
   return {
     ...state,
     activeView: next,
@@ -564,6 +601,8 @@ function withPoppedView(state: LogInkState): LogInkState {
     selectedWorktreeHunkIndex: next === 'diff' ? state.selectedWorktreeHunkIndex : 0,
     diffSource: next === 'diff' ? state.diffSource : undefined,
     stashDiffRef: next === 'diff' ? state.stashDiffRef : undefined,
+    compareBase: wasOnDiff ? undefined : state.compareBase,
+    compareHead: next === 'diff' ? state.compareHead : undefined,
     pendingCommitFocused: next === 'history' ? state.pendingCommitFocused : false,
     statusGroupHeaderFocused: next === 'status' ? state.statusGroupHeaderFocused : false,
     pendingKey: undefined,
@@ -584,6 +623,7 @@ function withReplacedView(state: LogInkState, value: LogInkView): LogInkState {
     selectedWorktreeHunkIndex: value === 'diff' ? state.selectedWorktreeHunkIndex : 0,
     diffSource: value === 'diff' ? state.diffSource : undefined,
     stashDiffRef: value === 'diff' ? state.stashDiffRef : undefined,
+    compareHead: value === 'diff' ? state.compareHead : undefined,
     pendingCommitFocused: value === 'history' ? state.pendingCommitFocused : false,
     statusGroupHeaderFocused: value === 'status' ? state.statusGroupHeaderFocused : false,
     pendingKey: undefined,
@@ -1232,6 +1272,31 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         worktreeDiffOffset: 0,
       }
     }
+    case 'navigateOpenDiffForCompare': {
+      const next = withPushedView(state, 'diff')
+      return {
+        ...next,
+        diffSource: 'compare',
+        compareBase: action.base,
+        compareHead: action.head,
+        // Reset scroll offset so the compare patch always opens at
+        // the top — same reasoning as the stash branch above.
+        diffPreviewOffset: 0,
+        worktreeDiffOffset: 0,
+      }
+    }
+    case 'setCompareBase':
+      return {
+        ...state,
+        compareBase: action.value,
+        pendingKey: undefined,
+      }
+    case 'clearCompareBase':
+      return {
+        ...state,
+        compareBase: undefined,
+        pendingKey: undefined,
+      }
     case 'navigateOpenComposeForFile': {
       const next = withPushedView(state, 'status')
       return {


### PR DESCRIPTION
Closes [#779](https://github.com/gfargo/coco/issues/779).

## Summary

New mark-then-Enter flow for diffing any two refs in the TUI. Mark a base on branches / tags / history with `m`, navigate to a second ref on any of those views, press `Enter` to open a compare diff. Cleared when the diff is popped.

```
1. on branches view → cursor on \"main\" → m
   status: \"Compare base: main — press enter on another ref to diff\"
   footer: ↑/↓ branches · enter compare · m clear · esc back

2. gt → cursor on \"v1.0.0\" → enter
   pushes diff view with diffSource='compare'

3. diff renders `main → v1.0.0` with the unified patch
   footer: j/k lines · d split · esc back

4. esc → pops diff, clears compareBase
```

Works across any combination of branches, tags, and history commits — the cursored ref's `kind` is captured at mark time and used for display labels in the diff header.

## Discoverability

Footer hints adapt to the flow state:

| State | Branches | Tags | History |
|---|---|---|---|
| **No base set** | `enter checkout · m compare` | `+ new · m compare` | `enter diff · m compare` |
| **Base set** | `enter compare · m clear` | `enter compare · m clear` | `enter compare · m clear` |

When the base is set, the override status message stays sticky (\"Compare base: main — press enter on another ref to diff\") so the user remembers what `Enter` is going to do before they press it.

## Plumbing

- `compareData.ts` — focused loader for `git diff <base>..<head>`, emits `string[]` so the existing diff surface renders via its standard +/-/@@ path.
- `inkViewModel` — new `LogInkCompareRef` type, `compare` added to `LogInkDiffSource`, `compareBase` / `compareHead` on root state, three new actions (`setCompareBase`, `clearCompareBase`, `navigateOpenDiffForCompare`). Pop from the diff view clears `compareBase` per the issue's spec.
- `inkKeymap` — `markForCompare` command (`m` key, `commits` focus); footer hints conditional on `compareBaseSet`.
- `inkInput` — `isCompareFlowTarget` predicate, `getCursoredCompareRef` resolver (reads branch / tag from context, commit from state), inline `m` toggle handler, Enter override placed BEFORE the history-row drill-in so it wins.
- `inkRuntime` — threads `branchSelectedShortName` / `tagSelectedName` into the input context; loads compare diff lazily on `diffSource === 'compare'`; `renderDiffSurface` gains a `compare` branch that mirrors the stash diff shape with a `<base> → <head>` header.

## Trade-offs

- **Compare diff is read-only.** No per-file cherry-pick or hunk-apply — those don't have a sensible mutate-from-here flow across arbitrary refs (you'd merge or cherry-pick the actual commits, not arbitrary file changes).
- **`m` from the command palette emits a hint** to press the keystroke directly. Palette execution can't reach the cursored ref (filtered branch / tag lists live in runtime state, not the reducer). Inline keypress is the canonical path.
- **Same-ref guard** — pressing Enter on a row that matches the current base shows a status hint instead of opening an empty diff.

## Test plan

- [x] `compareData.test.ts` — 4 tests: git invocation contract, ref pass-through, CRLF tolerance, empty-diff edge case
- [x] `inkInput.test.ts` — 7 new tests: mark branch / tag, toggle off, replace, Enter dispatches with base + head, same-ref hint, pop clears compareBase, history rows resolve to commit refs
- [x] `inkKeymap.test.ts` — updated existing assertions to reflect the new `m compare` hints
- [x] `npx jest` — 1321/1321 pass (11 new)
- [x] `npm run lint` — clean
- [x] `npm run build` — green
- [x] `npx tsc --noEmit` — 0 errors