### PR TITLE
feat(log-tui): bisect workflow view (gB) (#784)

### DIFF
--- a/src/commands/log/bisectActions.test.ts
+++ b/src/commands/log/bisectActions.test.ts
@@ -1,0 +1,89 @@
+import { SimpleGit } from 'simple-git'
+import {
+  bisectBad,
+  bisectGood,
+  bisectReset,
+  bisectSkip,
+  bisectStart,
+  extractBisectRemainingHint,
+} from './bisectActions'
+
+describe('bisect action wrappers', () => {
+  it('bisectStart invokes `git bisect start <bad> <good>`', async () => {
+    const raw = jest.fn().mockResolvedValue('')
+    const git = { raw } as unknown as SimpleGit
+    await bisectStart(git, 'main', 'v1.0')
+    expect(raw).toHaveBeenCalledWith(['bisect', 'start', 'main', 'v1.0'])
+  })
+
+  it('bisectGood / bisectBad / bisectSkip omit the ref when not provided', async () => {
+    const raw = jest.fn().mockResolvedValue('')
+    const git = { raw } as unknown as SimpleGit
+    await bisectGood(git)
+    await bisectBad(git)
+    await bisectSkip(git)
+    expect(raw.mock.calls).toEqual([
+      [['bisect', 'good']],
+      [['bisect', 'bad']],
+      [['bisect', 'skip']],
+    ])
+  })
+
+  it('bisectGood / bisectBad / bisectSkip pass the ref through when provided', async () => {
+    const raw = jest.fn().mockResolvedValue('')
+    const git = { raw } as unknown as SimpleGit
+    await bisectGood(git, 'abc1234')
+    await bisectBad(git, 'def5678')
+    await bisectSkip(git, '9012abcd')
+    expect(raw.mock.calls).toEqual([
+      [['bisect', 'good', 'abc1234']],
+      [['bisect', 'bad', 'def5678']],
+      [['bisect', 'skip', '9012abcd']],
+    ])
+  })
+
+  it('bisectReset invokes `git bisect reset`', async () => {
+    const raw = jest.fn().mockResolvedValue('')
+    const git = { raw } as unknown as SimpleGit
+    await bisectReset(git)
+    expect(raw).toHaveBeenCalledWith(['bisect', 'reset'])
+  })
+})
+
+describe('extractBisectRemainingHint', () => {
+  it('returns the canonical "Bisecting: N revisions left ..." line', () => {
+    const stdout = [
+      'Bisecting: 5 revisions left to test after this (roughly 2 steps)',
+      '[abc1234567890] some commit subject',
+    ].join('\n')
+    expect(extractBisectRemainingHint(stdout))
+      .toBe('Bisecting: 5 revisions left to test after this (roughly 2 steps)')
+  })
+
+  it('returns the "first bad commit" terminator when the run completed', () => {
+    const stdout = [
+      'abc1234567890 is the first bad commit',
+      'commit abc1234567890',
+      'Author: Coco Test',
+    ].join('\n')
+    expect(extractBisectRemainingHint(stdout))
+      .toBe('abc1234567890 is the first bad commit')
+  })
+
+  it('returns undefined when neither marker appears (e.g. on bisect skip with no progress)', () => {
+    expect(extractBisectRemainingHint('')).toBeUndefined()
+    expect(extractBisectRemainingHint('some unrelated stdout')).toBeUndefined()
+  })
+
+  it('prefers the most recent marker when multiple are present', () => {
+    // Defensive: a stale "Bisecting:" line earlier in the output
+    // shouldn't shadow a later "first bad commit" terminator. The
+    // function scans last-to-first so the latest hint wins.
+    const stdout = [
+      'Bisecting: 5 revisions left to test after this (roughly 2 steps)',
+      'abc1234567890 is the first bad commit',
+    ].join('\n')
+    expect(extractBisectRemainingHint(stdout))
+      .toBe('abc1234567890 is the first bad commit')
+  })
+})

--- a/src/commands/log/bisectActions.ts
+++ b/src/commands/log/bisectActions.ts
@@ -1,0 +1,64 @@
+import { SimpleGit } from 'simple-git'
+
+/**
+ * Thin wrappers around `git bisect <verb>` for the TUI's in-bisect
+ * action keys (#784). Each returns the raw stdout so the surface can
+ * surface git's own "Bisecting: N revisions left to test after this
+ * (roughly K steps)" hint as a status message — that wording is the
+ * single most useful piece of feedback git emits during bisect, and
+ * mirroring it keeps the TUI's status line authoritative.
+ *
+ * No try/catch here — git itself returns non-zero on user errors
+ * (already-bisecting, no good ref, etc.) and `simple-git` surfaces
+ * those as rejections. The runtime catches them and routes to the
+ * status line.
+ */
+
+export async function bisectStart(
+  git: SimpleGit,
+  badRef: string,
+  goodRef: string
+): Promise<string> {
+  return git.raw(['bisect', 'start', badRef, goodRef])
+}
+
+export async function bisectGood(git: SimpleGit, ref?: string): Promise<string> {
+  const args = ['bisect', 'good']
+  if (ref) args.push(ref)
+  return git.raw(args)
+}
+
+export async function bisectBad(git: SimpleGit, ref?: string): Promise<string> {
+  const args = ['bisect', 'bad']
+  if (ref) args.push(ref)
+  return git.raw(args)
+}
+
+export async function bisectSkip(git: SimpleGit, ref?: string): Promise<string> {
+  const args = ['bisect', 'skip']
+  if (ref) args.push(ref)
+  return git.raw(args)
+}
+
+export async function bisectReset(git: SimpleGit): Promise<string> {
+  return git.raw(['bisect', 'reset'])
+}
+
+/**
+ * Pull the user-facing remaining-revisions hint out of `git bisect`
+ * stdout. Looks for the canonical line:
+ *
+ *   `Bisecting: N revisions left to test after this (roughly K steps)`
+ *
+ * Returns undefined when the line isn't present (e.g. the run
+ * finished and git emitted a "<sha> is the first bad commit" line
+ * instead). Callers fall back to an empty status update in that case.
+ */
+export function extractBisectRemainingHint(stdout: string): string | undefined {
+  for (const line of stdout.split('\n').reverse()) {
+    const trimmed = line.trim()
+    if (trimmed.startsWith('Bisecting:')) return trimmed
+    if (trimmed.includes('is the first bad commit')) return trimmed
+  }
+  return undefined
+}

--- a/src/commands/log/bisectData.test.ts
+++ b/src/commands/log/bisectData.test.ts
@@ -1,0 +1,142 @@
+import { SimpleGit } from 'simple-git'
+import { getBisectStatus, parseBisectLog } from './bisectData'
+
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs')
+  return {
+    ...actual,
+    existsSync: jest.fn().mockReturnValue(false),
+  }
+})
+
+import { existsSync } from 'fs'
+const mockExistsSync = existsSync as jest.MockedFunction<typeof existsSync>
+
+describe('parseBisectLog', () => {
+  it('returns an empty list for empty input', () => {
+    expect(parseBisectLog('')).toEqual([])
+    expect(parseBisectLog('\n\n')).toEqual([])
+  })
+
+  it('parses command rows for start / good / bad / skip', () => {
+    const log = [
+      'git bisect start',
+      'git bisect bad abc1234',
+      'git bisect good def5678',
+      'git bisect skip 9012abcd',
+    ].join('\n')
+
+    expect(parseBisectLog(log)).toEqual([
+      { kind: 'start', sha: undefined, raw: 'git bisect start' },
+      { kind: 'bad', sha: 'abc1234', raw: 'git bisect bad abc1234' },
+      { kind: 'good', sha: 'def5678', raw: 'git bisect good def5678' },
+      { kind: 'skip', sha: '9012abcd', raw: 'git bisect skip 9012abcd' },
+    ])
+  })
+
+  it('parses comment rows with the [sha] subject form', () => {
+    const log = '# bad: [abc1234] feat: add the bug'
+
+    expect(parseBisectLog(log)).toEqual([
+      {
+        kind: 'bad',
+        sha: 'abc1234',
+        subject: 'feat: add the bug',
+        raw: '# bad: [abc1234] feat: add the bug',
+      },
+    ])
+  })
+
+  it('falls back to unknown kind for headers and free-form comments', () => {
+    const log = [
+      '# status: bisecting',
+      '# first bad commit: [abc1234] commit subject',
+      'random unparseable text',
+    ].join('\n')
+
+    expect(parseBisectLog(log)).toEqual([
+      { kind: 'unknown', raw: '# status: bisecting' },
+      { kind: 'unknown', raw: '# first bad commit: [abc1234] commit subject' },
+      { kind: 'unknown', raw: 'random unparseable text' },
+    ])
+  })
+
+  it('captures only the first ref token when a command lists multiple', () => {
+    // git bisect start records a `start` line followed by command
+    // rows; this guard means the parser doesn't accidentally swallow
+    // an entire trailing list as one ref.
+    const log = 'git bisect bad abc1234 def5678'
+    expect(parseBisectLog(log)).toEqual([
+      { kind: 'bad', sha: 'abc1234', raw: 'git bisect bad abc1234 def5678' },
+    ])
+  })
+})
+
+describe('getBisectStatus', () => {
+  beforeEach(() => {
+    mockExistsSync.mockReset()
+    mockExistsSync.mockReturnValue(false)
+  })
+
+  it('returns inactive status when BISECT_LOG does not exist', async () => {
+    const revparse = jest.fn().mockResolvedValue('/repo/.git/BISECT_LOG\n')
+    mockExistsSync.mockReturnValue(false)
+    const git = { revparse } as unknown as SimpleGit
+
+    const status = await getBisectStatus(git)
+
+    expect(status).toEqual({ active: false, currentSha: '', log: [] })
+  })
+
+  it('returns active status with parsed log when BISECT_LOG exists', async () => {
+    mockExistsSync.mockReturnValue(true)
+    const revparse = jest.fn()
+      .mockResolvedValueOnce('/repo/.git/BISECT_LOG\n')
+      .mockResolvedValueOnce('abc1234567890\n')
+    const raw = jest.fn().mockResolvedValue(
+      [
+        'git bisect start',
+        'git bisect bad abc1234',
+        'git bisect good def5678',
+      ].join('\n')
+    )
+    const git = { revparse, raw } as unknown as SimpleGit
+
+    const status = await getBisectStatus(git)
+
+    expect(status.active).toBe(true)
+    expect(status.currentSha).toBe('abc1234567890')
+    expect(status.log).toHaveLength(3)
+    expect(status.log[1]).toEqual({ kind: 'bad', sha: 'abc1234', raw: 'git bisect bad abc1234' })
+  })
+
+  it('treats a bisect log read failure as "active but empty" rather than inactive', async () => {
+    mockExistsSync.mockReturnValue(true)
+    const revparse = jest.fn()
+      .mockResolvedValueOnce('/repo/.git/BISECT_LOG\n')
+      .mockResolvedValueOnce('abc1234\n')
+    const raw = jest.fn().mockRejectedValue(new Error('not a bisect'))
+    const git = { revparse, raw } as unknown as SimpleGit
+
+    const status = await getBisectStatus(git)
+
+    expect(status.active).toBe(true)
+    expect(status.currentSha).toBe('abc1234')
+    expect(status.log).toEqual([])
+  })
+
+  it('tolerates HEAD lookup failure by returning an empty currentSha', async () => {
+    mockExistsSync.mockReturnValue(true)
+    const revparse = jest.fn()
+      .mockResolvedValueOnce('/repo/.git/BISECT_LOG\n')
+      .mockRejectedValueOnce(new Error('detached'))
+    const raw = jest.fn().mockResolvedValue('git bisect start\n')
+    const git = { revparse, raw } as unknown as SimpleGit
+
+    const status = await getBisectStatus(git)
+
+    expect(status.active).toBe(true)
+    expect(status.currentSha).toBe('')
+    expect(status.log).toHaveLength(1)
+  })
+})

--- a/src/commands/log/bisectData.ts
+++ b/src/commands/log/bisectData.ts
@@ -1,0 +1,142 @@
+import { existsSync } from 'fs'
+import { SimpleGit } from 'simple-git'
+
+/**
+ * Bisect state surfacing for the TUI (#784).
+ *
+ * Bisect is the one git workflow where a TUI can dramatically beat
+ * the CLI — every step needs a commit hash that the user has to copy
+ * out of `git log` today. To support that we need a small loader that
+ * (a) detects whether bisect is active, (b) parses the user-visible
+ * decision log, and (c) reports the current candidate commit so the
+ * surface can render it without an extra round-trip.
+ *
+ * Detection is via `.git/BISECT_LOG` (created by `git bisect start`,
+ * removed by `git bisect reset`). Parsing reads `git bisect log` so
+ * we get the same authoritative output git itself uses for resume.
+ */
+
+export type BisectLogEntryKind = 'start' | 'good' | 'bad' | 'skip' | 'unknown'
+
+export type BisectLogEntry = {
+  kind: BisectLogEntryKind
+  /** Short or full hash referenced by the entry, when present. */
+  sha?: string
+  /** Subject line (commit message) — only present for start/good/bad entries that include it. */
+  subject?: string
+  /** Original log line, preserved for verbose renderers and as a fallback display. */
+  raw: string
+}
+
+export type BisectStatus = {
+  /** True when `.git/BISECT_LOG` exists. */
+  active: boolean
+  /** HEAD sha at the moment the status was loaded. The bisect candidate
+   *  the user is being asked to test. Empty string when not active or
+   *  the read failed. */
+  currentSha: string
+  /** Parsed `git bisect log` entries, oldest-first. */
+  log: BisectLogEntry[]
+}
+
+const EMPTY_STATUS: BisectStatus = {
+  active: false,
+  currentSha: '',
+  log: [],
+}
+
+async function bisectIsActive(git: SimpleGit): Promise<boolean> {
+  try {
+    const path = (await git.revparse(['--git-path', 'BISECT_LOG'])).trim()
+    return path.length > 0 && existsSync(path)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Parse the output of `git bisect log` into structured entries. Each
+ * entry corresponds to one user decision (start / good / bad / skip)
+ * or the "# bad: [<sha>] <subject>" comment lines git emits for
+ * traceability. Comment lines without a recognized prefix are dropped
+ * — they're informational headers ("# status: ..."), not actions
+ * the user took.
+ */
+export function parseBisectLog(output: string): BisectLogEntry[] {
+  const entries: BisectLogEntry[] = []
+
+  for (const rawLine of output.split('\n')) {
+    const line = rawLine.trimEnd()
+    if (!line) continue
+
+    // Comment rows: "# good: [sha] subject" / "# bad: [sha] subject" /
+    // "# first bad commit: ..." / "# status: ...". The first two carry
+    // the most user-relevant info (which commits were marked) so we
+    // promote them to typed entries; the rest fall through as raw
+    // lines tagged 'unknown' so the renderer can dim them or hide
+    // entirely.
+    if (line.startsWith('#')) {
+      const commentMatch = line.match(/^#\s+(good|bad|skip):\s+\[([^\]]+)\]\s*(.*)$/)
+      if (commentMatch) {
+        entries.push({
+          kind: commentMatch[1] as BisectLogEntryKind,
+          sha: commentMatch[2],
+          subject: commentMatch[3] || undefined,
+          raw: line,
+        })
+        continue
+      }
+      entries.push({ kind: 'unknown', raw: line })
+      continue
+    }
+
+    // Command rows: "git bisect start", "git bisect good <sha>",
+    // "git bisect bad <sha>", "git bisect skip <sha>".
+    const commandMatch = line.match(/^git\s+bisect\s+(start|good|bad|skip)\s*(.*)$/)
+    if (commandMatch) {
+      const sha = commandMatch[2]?.trim().split(/\s+/)[0] || undefined
+      entries.push({
+        kind: commandMatch[1] as BisectLogEntryKind,
+        sha: sha || undefined,
+        raw: line,
+      })
+      continue
+    }
+
+    entries.push({ kind: 'unknown', raw: line })
+  }
+
+  return entries
+}
+
+/**
+ * Load the live bisect status. Best-effort — when bisect isn't
+ * active the empty-status sentinel returns immediately so callers
+ * don't pay for a `git bisect log` round-trip on every refresh.
+ */
+export async function getBisectStatus(git: SimpleGit): Promise<BisectStatus> {
+  if (!(await bisectIsActive(git))) {
+    return EMPTY_STATUS
+  }
+
+  let log: BisectLogEntry[] = []
+  try {
+    const output = await git.raw(['bisect', 'log'])
+    log = parseBisectLog(output)
+  } catch {
+    // bisect log can fail on a freshly-started bisect with no decisions.
+    // Treat the absence of a parseable log as "active but empty" rather
+    // than non-active, so the surface still routes to the bisect view
+    // and the user can see the badge.
+    log = []
+  }
+
+  let currentSha = ''
+  try {
+    currentSha = (await git.revparse(['HEAD'])).trim()
+  } catch {
+    currentSha = ''
+  }
+
+  return { active: true, currentSha, log }
+}

--- a/src/commands/log/inkContext.ts
+++ b/src/commands/log/inkContext.ts
@@ -1,4 +1,5 @@
 export const LOG_INK_CONTEXT_KEYS = [
+  'bisect',
   'branches',
   'operation',
   'provider',

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -817,6 +817,79 @@ describe('log Ink input interactions', () => {
     }
   })
 
+  it('pushes bisect with the gB chord (capital disambiguates from gb branches) (#784)', () => {
+    let state = createLogInkState(rows)
+
+    state = applyInput(state, 'g')
+    state = applyInput(state, 'B')
+
+    expect(state.viewStack).toEqual(['history', 'bisect'])
+    expect(state.activeView).toBe('bisect')
+    expect(state.statusMessage).toBe('jumped to bisect')
+  })
+
+  it('lower-case g on the bisect view marks good (no chord trigger) (#784)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'bisect' })
+
+    const events = getLogInkInputEvents(state, 'g', {}, {})
+
+    expect(events).toContainEqual({ type: 'runWorkflowAction', id: 'bisect-good' })
+    // pendingKey must NOT be set — bisect's g consumed the keystroke.
+    const pendingChange = events.find((event) =>
+      event.type === 'action' && event.action.type === 'setPendingKey'
+    )
+    expect(pendingChange).toBeUndefined()
+  })
+
+  it('b on the bisect view marks bad (does not require g chord) (#784)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'bisect' })
+
+    const events = getLogInkInputEvents(state, 'b', {}, {})
+
+    expect(events).toContainEqual({ type: 'runWorkflowAction', id: 'bisect-bad' })
+  })
+
+  it('s on the bisect view skips the candidate (#784)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'bisect' })
+
+    const events = getLogInkInputEvents(state, 's', {}, {})
+
+    expect(events).toContainEqual({ type: 'runWorkflowAction', id: 'bisect-skip' })
+  })
+
+  it('x on the bisect view opens the y-confirm for reset (#784)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'bisect' })
+
+    const events = getLogInkInputEvents(state, 'x', {}, {})
+
+    const confirm = events.find((event) =>
+      event.type === 'action' && event.action.type === 'setPendingConfirmation'
+    )
+    expect(confirm).toBeDefined()
+    if (confirm && confirm.type === 'action' && confirm.action.type === 'setPendingConfirmation') {
+      expect(confirm.action.value).toBe('bisect-reset')
+    }
+  })
+
+  it('does not hijack g/b/s/x outside the bisect view (#784)', () => {
+    // Defensive check: pressing `g` on the history view must still set
+    // pendingKey for the chord prefix, not fire bisect-good.
+    const state = createLogInkState(rows)
+    expect(state.activeView).toBe('history')
+
+    const events = getLogInkInputEvents(state, 'g', {}, {})
+
+    expect(events).not.toContainEqual({ type: 'runWorkflowAction', id: 'bisect-good' })
+    const pendingChange = events.find((event) =>
+      event.type === 'action' && event.action.type === 'setPendingKey'
+    )
+    expect(pendingChange).toBeDefined()
+  })
+
   it('preserves per-view selection across navigation', () => {
     let state = createLogInkState(rows)
 

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -489,6 +489,8 @@ export function getLogInkPaletteExecuteEvents(
       return [action({ type: 'pushView', value: 'conflicts' })]
     case 'navigateReflog':
       return [action({ type: 'pushView', value: 'reflog' })]
+    case 'navigateBisect':
+      return [action({ type: 'pushView', value: 'bisect' })]
     case 'markForCompare':
       // Palette context can't reach the cursored ref (filtered branch /
       // tag lists live in runtime state, not the reducer). Surface a
@@ -1047,6 +1049,17 @@ export function getLogInkInputEvents(
     ]
   }
 
+  // `gB` chord: jump to the bisect workflow view (#784). Capital B
+  // disambiguates from `gb` (branches). Always navigates — even when
+  // bisect is inactive — so the user can see the empty-state hint and
+  // know how to start one. The view's surface tells them the next step.
+  if (state.pendingKey === 'g' && inputValue === 'B') {
+    return [
+      action({ type: 'pushView', value: 'bisect' }),
+      action({ type: 'setStatus', value: 'jumped to bisect' }),
+    ]
+  }
+
   // `gH` chord: apply the cursored hunk to the index (`git apply
   // --cached`). Sibling of bare `H` which targets the worktree.
   // Discoverable via the footer hint on diff views and the help
@@ -1088,6 +1101,30 @@ export function getLogInkInputEvents(
       action({ type: 'setPendingKey', value: undefined }),
       action({ type: 'setStatus', value: 'gT creates a tag at the cursored commit on the history view' }),
     ]
+  }
+
+  // #784 — bisect view action keys. Scoped to `state.activeView ===
+  // 'bisect' && state.focus === 'commits'` so the single-letter keys
+  // stay free everywhere else. `g` and `b` collide with the global
+  // chord prefix and the `gb` continuation respectively — placed
+  // BEFORE the bare-`g` chord trigger below so a `g` keystroke on
+  // the bisect view marks good rather than entering chord mode. The
+  // user's path back out of bisect is `<` / `esc`, never a chord;
+  // the in-bisect view itself can't navigate elsewhere via `g`-prefix
+  // chords until the user exits with `esc` first.
+  if (state.activeView === 'bisect' && state.focus === 'commits') {
+    if (inputValue === 'g' && state.pendingKey !== 'g') {
+      return [{ type: 'runWorkflowAction', id: 'bisect-good' }]
+    }
+    if (inputValue === 'b' && state.pendingKey !== 'g') {
+      return [{ type: 'runWorkflowAction', id: 'bisect-bad' }]
+    }
+    if (inputValue === 's') {
+      return [{ type: 'runWorkflowAction', id: 'bisect-skip' }]
+    }
+    if (inputValue === 'x') {
+      return [action({ type: 'setPendingConfirmation', value: 'bisect-reset' })]
+    }
   }
 
   if (inputValue === 'g') {
@@ -1851,6 +1888,7 @@ export function getLogInkInputEvents(
   if (inputValue === 'R' && isTagActionTarget(state) && context.tagCount) {
     return [action({ type: 'setPendingConfirmation', value: 'delete-remote-tag' })]
   }
+
 
   // `m` marks (or un-marks) the cursored ref as the compare base
   // (#779). Scoped to compare-flow targets so it doesn't collide with

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -24,6 +24,7 @@ export type LogInkCommandId =
   | 'navigateConflicts'
   | 'navigateDiff'
   | 'navigateHome'
+  | 'navigateBisect'
   | 'navigatePullRequest'
   | 'navigateReflog'
   | 'navigateStash'
@@ -274,6 +275,13 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     contexts: ['normal'],
   },
   {
+    id: 'navigateBisect',
+    keys: ['gB'],
+    label: 'bisect',
+    description: 'Push the bisect workflow view (#784). Capital B disambiguates from gb (branches). Available whenever a bisect is in progress; surfaces the current candidate and the good / bad / skip / reset action keys.',
+    contexts: ['normal'],
+  },
+  {
     id: 'markForCompare',
     keys: ['m'],
     label: 'mark compare',
@@ -467,6 +475,7 @@ const GLOBAL_BINDING_IDS: LogInkCommandId[] = [
   'navigatePullRequest',
   'navigateConflicts',
   'navigateReflog',
+  'navigateBisect',
   'navigateBack',
 ]
 
@@ -690,6 +699,13 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
   if (options.activeView === 'reflog') {
     return {
       contextual: ['↑/↓ entries', 'enter inspect', 'esc back'],
+      global: NORMAL_GLOBAL_HINTS,
+    }
+  }
+
+  if (options.activeView === 'bisect') {
+    return {
+      contextual: ['g good', 'b bad', 's skip', 'x reset', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -227,6 +227,8 @@ import {
     stageHunk,
     unstageHunk,
 } from './statusHunks'
+import { BisectStatus, getBisectStatus } from './bisectData'
+import { bisectBad, bisectGood, bisectReset, bisectSkip, extractBisectRemainingHint } from './bisectActions'
 import { getCompareDiff } from './compareData'
 import { ReflogOverview, getReflogOverview, splitReflogSubject } from './reflogData'
 import { TagOverview, getTagOverview } from './tagData'
@@ -277,6 +279,7 @@ type LogInkOptions = {
 }
 
 type LogInkContext = {
+  bisect?: BisectStatus
   branches?: BranchOverview
   operation?: GitOperationOverview
   provider?: ProviderOverview
@@ -367,7 +370,7 @@ async function safe<T>(promise: Promise<T>): Promise<T | undefined> {
 }
 
 async function loadLogInkContext(git: SimpleGit): Promise<LogInkContext> {
-  const [branches, pullRequest, tags, worktree, stashes, worktreeList, operation, provider, reflog] =
+  const [branches, pullRequest, tags, worktree, stashes, worktreeList, operation, provider, reflog, bisect] =
     await Promise.all([
       safe(getBranchOverview(git)),
       safe(getPullRequestOverview(git)),
@@ -378,9 +381,11 @@ async function loadLogInkContext(git: SimpleGit): Promise<LogInkContext> {
       safe(getGitOperationOverview(git)),
       safe(getProviderOverview(git)),
       safe(getReflogOverview(git)),
+      safe(getBisectStatus(git)),
     ])
 
   return {
+    bisect,
     branches,
     operation,
     provider,
@@ -418,6 +423,10 @@ function loadLogInkContextEntries(git: SimpleGit): Array<{
     {
       key: 'reflog',
       load: () => safe(getReflogOverview(git)),
+    },
+    {
+      key: 'bisect',
+      load: () => safe(getBisectStatus(git)),
     },
     {
       key: 'worktree',
@@ -1819,6 +1828,42 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         if (!stash) return { ok: false, message: 'No stash selected' }
         return popStash(git, stash)
       },
+      'bisect-good': async () => {
+        if (!context.bisect?.active) return { ok: false, message: 'No bisect in progress' }
+        try {
+          const stdout = await bisectGood(git)
+          return { ok: true, message: extractBisectRemainingHint(stdout) || 'Marked good' }
+        } catch (error) {
+          return { ok: false, message: `Bisect good failed: ${(error as Error).message}` }
+        }
+      },
+      'bisect-bad': async () => {
+        if (!context.bisect?.active) return { ok: false, message: 'No bisect in progress' }
+        try {
+          const stdout = await bisectBad(git)
+          return { ok: true, message: extractBisectRemainingHint(stdout) || 'Marked bad' }
+        } catch (error) {
+          return { ok: false, message: `Bisect bad failed: ${(error as Error).message}` }
+        }
+      },
+      'bisect-skip': async () => {
+        if (!context.bisect?.active) return { ok: false, message: 'No bisect in progress' }
+        try {
+          const stdout = await bisectSkip(git)
+          return { ok: true, message: extractBisectRemainingHint(stdout) || 'Skipped' }
+        } catch (error) {
+          return { ok: false, message: `Bisect skip failed: ${(error as Error).message}` }
+        }
+      },
+      'bisect-reset': async () => {
+        if (!context.bisect?.active) return { ok: false, message: 'No bisect in progress' }
+        try {
+          await bisectReset(git)
+          return { ok: true, message: 'Bisect reset' }
+        } catch (error) {
+          return { ok: false, message: `Bisect reset failed: ${(error as Error).message}` }
+        }
+      },
       'checkout-file-from-stash': async () => {
         const path = payload?.trim()
         const ref = state.stashDiffRef
@@ -2713,7 +2758,10 @@ function renderHeader(
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const branch = context.branches?.currentBranch || context.provider?.currentBranch || '<detached>'
-  const dirty = context.branches?.dirty ? 'dirty' : 'clean'
+  // #784 — surface bisect-in-progress in the title bar so users entering
+  // the TUI mid-bisect see it immediately, before they navigate to gB.
+  const dirtyBase = context.branches?.dirty ? 'dirty' : 'clean'
+  const dirty = context.bisect?.active ? `${dirtyBase} · BISECTING` : dirtyBase
   const repo = context.provider?.repository.owner && context.provider.repository.name
     ? `${context.provider.repository.owner}/${context.provider.repository.name}`
     : 'local repository'
@@ -3112,6 +3160,10 @@ function renderMainPanel(
 
   if (state.activeView === 'reflog') {
     return renderReflogSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
+  }
+
+  if (state.activeView === 'bisect') {
+    return renderBisectSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
   }
 
   if (state.activeView === 'stash') {
@@ -4076,6 +4128,105 @@ function renderReflogSurface(
     h(Text, { dimColor: true }, headerRight)
   ),
   ...renderPromotedFilterAffordance(h, Text, state, theme),
+  ...lines)
+}
+
+/**
+ * Bisect workflow surface (#784). Shows the current candidate commit
+ * (HEAD), a parsed view of recent decisions from `git bisect log`, and
+ * the four action keys (g good, b bad, s skip, x reset).
+ *
+ * When bisect is inactive, the surface renders an empty-state hint
+ * pointing the user at the CLI to start one. The view stays
+ * navigable so the user can read the documentation before starting
+ * — they can't break anything from here.
+ */
+function renderBisectSurface(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  bodyRows: number,
+  width: number,
+  theme: LogInkTheme
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const focused = state.focus === 'commits'
+  const loading = isLogInkContextKeyLoading(contextStatus, 'bisect')
+  const bisect = context.bisect
+  const accent = theme.noColor ? undefined : theme.colors.accent
+
+  const lines: ReactTypes.ReactNode[] = []
+
+  if (loading) {
+    lines.push(h(Text, { key: 'bisect-loading', dimColor: true },
+      truncate('· Loading bisect status…', width - 4)))
+  } else if (!bisect?.active) {
+    // No bisect active. Surface the CLI on-ramp — starting from the
+    // TUI is intentionally out of scope for this PR (#784 follow-up).
+    // The user is expected to enter via `git bisect start <bad> <good>`
+    // and re-open `coco ui`; once bisect is active this view drives
+    // the rest.
+    lines.push(h(Text, { key: 'bisect-empty-1', bold: true },
+      truncate('No bisect in progress.', width - 4)))
+    lines.push(h(Text, { key: 'bisect-empty-2' }, ''))
+    lines.push(h(Text, { key: 'bisect-empty-3' },
+      truncate('Start one from the shell with:', width - 4)))
+    lines.push(h(Text, { key: 'bisect-empty-4', color: accent },
+      truncate('  git bisect start <bad-ref> <good-ref>', width - 4)))
+    lines.push(h(Text, { key: 'bisect-empty-5' }, ''))
+    lines.push(h(Text, { key: 'bisect-empty-6', dimColor: true },
+      truncate('coco will pick up the active bisect on the next refresh — actions will become available here.', width - 4)))
+  } else {
+    // Active bisect. Two-section body: current candidate, recent
+    // decisions. Action keys live in the footer.
+    const headerSha = bisect.currentSha ? bisect.currentSha.slice(0, 8) : '<unknown>'
+    lines.push(h(Text, { key: 'bisect-active-title', bold: true },
+      truncate(`Bisecting · current candidate ${headerSha}`, width - 4)))
+    lines.push(h(Text, { key: 'bisect-active-spacer' }, ''))
+
+    const decisions = bisect.log.filter((entry) =>
+      entry.kind === 'good' || entry.kind === 'bad' || entry.kind === 'skip'
+    )
+
+    if (decisions.length === 0) {
+      lines.push(h(Text, { key: 'bisect-no-decisions', dimColor: true },
+        truncate('No decisions logged yet — press g (good) or b (bad) to record one.', width - 4)))
+    } else {
+      lines.push(h(Text, { key: 'bisect-decisions-header', bold: true },
+        truncate(`Decisions (${decisions.length}):`, width - 4)))
+      const recent = decisions.slice(-Math.max(4, bodyRows - 8))
+      for (const entry of recent) {
+        const kindLabel = entry.kind.toUpperCase().padEnd(5)
+        const sha = (entry.sha || '<unknown>').padEnd(8)
+        const subject = entry.subject || ''
+        const text = `  ${kindLabel} ${sha} ${subject}`
+        lines.push(h(Text, {
+          key: `bisect-entry-${entry.raw}`,
+          dimColor: entry.kind === 'skip',
+          bold: entry.kind === 'bad',
+        }, truncate(text, width - 4)))
+      }
+    }
+
+    lines.push(h(Text, { key: 'bisect-action-spacer' }, ''))
+    lines.push(h(Text, { key: 'bisect-action-hint', dimColor: true },
+      truncate('Actions: g good · b bad · s skip · x reset', width - 4)))
+  }
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    flexShrink: 0,
+    paddingX: 1,
+    width,
+  },
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle('Bisect', focused)),
+    h(Text, { dimColor: true }, bisect?.active ? 'BISECTING' : 'inactive')
+  ),
   ...lines)
 }
 

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -18,7 +18,7 @@ import {
 export type LogInkFocus = 'sidebar' | 'commits' | 'detail'
 
 export type LogInkSidebarTab = 'status' | 'branches' | 'tags' | 'stashes' | 'worktrees'
-export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash' | 'worktrees' | 'pull-request' | 'conflicts' | 'reflog'
+export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash' | 'worktrees' | 'pull-request' | 'conflicts' | 'reflog' | 'bisect'
 export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk' | 'discard-draft'
 /**
  * Tracks which kind of diff the user pushed into. `commit` means they

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -481,6 +481,45 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: false,
     },
     {
+      // #784 — bisect workflow actions. All four are scoped per-view in
+      // inkInput (active only when activeView === 'bisect') so the
+      // single-letter keys stay free elsewhere. Empty `key` keeps them
+      // palette-discoverable. Reset is the only destructive one — it
+      // throws away the bisect state — so it routes through y-confirm;
+      // good / bad / skip are recoverable via `git bisect log` and run
+      // immediately.
+      id: 'bisect-good',
+      key: '',
+      label: 'Bisect: mark good',
+      description: 'Mark the current bisect candidate as good and advance to the next one.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      id: 'bisect-bad',
+      key: '',
+      label: 'Bisect: mark bad',
+      description: 'Mark the current bisect candidate as bad and advance to the next one.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      id: 'bisect-skip',
+      key: '',
+      label: 'Bisect: skip candidate',
+      description: 'Skip the current bisect candidate (e.g. it does not build) and advance.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      id: 'bisect-reset',
+      key: '',
+      label: 'Bisect: reset',
+      description: 'End the bisect session and restore HEAD. Discards in-progress bisect state.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
       id: 'ai-commit-summary',
       key: 'I',
       label: 'AI commit summary',


### PR DESCRIPTION
Closes [#784](https://github.com/gfargo/coco/issues/784).

## Summary

New promoted view at `gB` (capital B disambiguates from `gb` branches) that surfaces an active git bisect and exposes the four user decisions — **good / bad / skip / reset** — as single-keystroke actions on the candidate row.

```
Bisect                                      BISECTING

Bisecting · current candidate abc12345

Decisions (3):
  GOOD  def56789 fix: handle empty list edge case
  BAD   1234abcd feat: refactor list iteration
  SKIP  9876fedc chore: bump deps

Actions: g good · b bad · s skip · x reset
```

The title bar gains a `· BISECTING` badge so users entering the TUI mid-bisect see the state immediately, before navigating to `gB`.

## Scope

This PR supports an **externally-initiated bisect**. Users start from the shell (`git bisect start <bad> <good>`) — the canonical CLI entry point — and re-open `coco ui`; the TUI picks up the active bisect on its next context refresh and drives the rest of the workflow.

**In-TUI start** (B = bad / G = good capture flow on the history view) is deferred to a follow-up. Honest reasoning: the start UX needs design work (`G` already does \"jump to bottom\" in the history view's vim binding, so the conflict-resolution there is non-trivial), and the CLI entry covers the common workflow for v1.

## Implementation

| Module | Role |
|---|---|
| `bisectData.ts` (new) | `BisectStatus` + `getBisectStatus()` loader; parses `git bisect log` |
| `bisectActions.ts` (new) | Thin `git bisect <verb>` wrappers + `extractBisectRemainingHint` |
| `inkContext` | Registers `'bisect'` for the per-key loading machinery |
| `inkViewModel` | Adds `'bisect'` to `LogInkView` |
| `inkKeymap` | `navigateBisect` (gB) + footer hints |
| `inkInput` | gB chord; g/b/s/x scoped to the bisect view, placed BEFORE the bare-`g` chord trigger so `g` marks good rather than entering chord mode |
| `inkWorkflows` | Four palette-only workflow actions (good / bad / skip route normal, reset routes through y-confirm) |
| `inkRuntime` | Loader entry, four workflow handlers, title-bar BISECTING badge, `renderBisectSurface` |

Workflow handlers surface git's own \"Bisecting: N revisions left to test after this (roughly K steps)\" line as the status message — that wording is the single most useful piece of feedback git emits, and mirroring it keeps the TUI status line authoritative.

## Trade-offs

- **g and b on the bisect view bypass the chord prefix.** Inside the bisect view, the user's path back out is `<` / `esc` (never a chord). The scope guard is tight: only `activeView === 'bisect' && focus === 'commits'`. Outside the view, g/b/s/x keep their existing behavior.
- **Reset is the only y-confirm of the four.** It discards the bisect session — recoverable in principle (`git bisect log > /tmp/log; git bisect replay`) but not via Coco. Good / bad / skip are all recoverable via `git bisect log`, so they run immediately.

## Test plan

- [x] `bisectData.test.ts` — 9 tests (parser cases, loader active / inactive / failure paths)
- [x] `bisectActions.test.ts` — 8 tests (wrapper args, optional refs, remaining-hint extraction)
- [x] `inkInput.test.ts` — 6 new tests (gB chord push, g/b/s/x scoped behavior, no-hijack outside bisect)
- [x] `npx jest` — 1344/1344 pass (23 new)
- [x] `npm run lint` — clean
- [x] `npm run build` — green
- [x] `npx tsc --noEmit` — 0 errors