### PR TITLE
docs: README sync for views shipped since v0.43.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ An AI-powered git assistant that generates meaningful commit messages, creates c
 - 📋 **Conventional Commits** - Full support with automatic validation and formatting  
 - 🔧 **Commitlint Integration** - Seamless integration with your existing commitlint configuration
 - 🏠 **Local AI Support** - Run completely offline with Ollama (no API costs, full privacy)
-- 🖥️ **Coco UI Git Workstation** - Seven top-level views (history, status, diff, compose, branches, tags, stash) reachable via `g`-prefixed chords, with an interactive command palette (`:`) and global search (`/`)
+- 🖥️ **Coco UI Git Workstation** - Eleven top-level views (history, status, diff, compose, branches, tags, stash, worktrees, pull-request, conflicts, reflog) reachable via `g`-prefixed chords, with an interactive command palette (`:`), global search (`/`), and cross-view flows like compare-two-refs
 - 📦 **Package Manager Friendly** - Works with npm, yarn, and pnpm
 - 👥 **Team Ready** - Shared configurations and enterprise deployment
 
@@ -106,13 +106,15 @@ coco log --format json
 `coco ui` and `coco log -i` share a chord-driven navigation model. Press `g` and then a second key to jump anywhere; `<` (or `Esc`) pops the navigation stack back.
 
 ```text
-g h   history          g c   compose         <    back
-g s   status           g b   branches        Esc  back / close modal
-g d   diff             g t   tags            ?    help overlay
-                       g z   stash           :    command palette
+g h   history          g c   compose         g x   conflicts
+g s   status           g b   branches        g r   reflog
+g d   diff             g t   tags            <     back
+                       g z   stash           Esc   back / close modal
+                       g w   worktrees       ?     help overlay
+                       g p   pull request    :     command palette
 ```
 
-The command palette (`:`) is an interactive launcher with fuzzy filter and recently-used at the top — every keybinding and workflow action is reachable from there. `/` searches the active view (history, branches, tags, or stash). See the [Coco UI](https://github.com/gfargo/coco/wiki/Coco-UI) wiki page for the full keymap.
+The command palette (`:`) is an interactive launcher with fuzzy filter and recently-used at the top — every keybinding and workflow action is reachable from there. `/` searches the active view (history, branches, tags, stash, or reflog). On branches, tags, and history, press `m` to mark a ref as the compare base — then `Enter` on a second ref opens a `git diff <base>..<head>` view. See the [Coco UI](https://github.com/gfargo/coco/wiki/Coco-UI) and [TUI Navigation](https://github.com/gfargo/coco/wiki/TUI-Navigation) wiki pages for the full keymap.
 
 ## Configuration
 


### PR DESCRIPTION
README's TUI section was lagging the actual surface. Two updates:

1. The headline bullet listed **seven** views (\`history, status, diff, compose, branches, tags, stash\`); the actual surface is **eleven** (adds \`worktrees\`, \`pull-request\`, \`conflicts\`, \`reflog\` shipped over v0.34→v0.45).

2. The chord-box only showed seven chords; updated to include \`gw worktrees\`, \`gp pull request\`, \`gx conflicts\`, \`gr reflog\`.

3. Added a one-line mention of the **compare-two-refs flow** (\`m\` to mark a base on branches/tags/history, then \`Enter\` on a second ref) since the README is most users' first stop.

No code changes. Wiki updates (\`Coco-UI.md\`, \`TUI-Navigation.md\`, \`Interactive-Log-TUI.md\`) are staged on a local clone of the wiki repo and will be pushed separately — wiki edits are public immediately so they shouldn't precede a merge.

## Test plan

- [x] Markdown renders in GitHub preview
- [x] All chord references match the current keymap (\`src/commands/log/inkKeymap.ts\`)
- [x] Compare-flow description matches the implementation in \`inkInput.ts\` (\`m\` mark, Enter override on branches/tags/history)