### PR TITLE
chore(engines): bump Node floor to match ini@7 + commitlint@21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,13 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 22.13.0
-          - 24.x
+          # Pinned to the floor declared in package.json engines
+          # (^22.22.2 || ^24.15.0 || >=26.0.0). The floor moved when
+          # ini@7 + commitlint@21 landed; CI exercises both LTS lines
+          # at the lower bound so a future transitive bump can't
+          # silently raise the floor without us noticing here first.
+          - 22.22.2
+          - 24.15.0
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.13.0
+          node-version: 22.22.2
           cache: yarn
           cache-dependency-path: yarn.lock
 
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.13.0
+          node-version: 22.22.2
           registry-url: https://registry.npmjs.org
           cache: yarn
           cache-dependency-path: yarn.lock

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "git+https://github.com/gfargo/coco.git"
   },
   "engines": {
-    "node": "^22.13.0 || >=24"
+    "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
   },
   "scripts": {
     "start": "npm run dev",


### PR DESCRIPTION
Two majors merged in quick succession ([#870](https://github.com/gfargo/coco/pull/870) ini 6→7 and [#872](https://github.com/gfargo/coco/pull/872) @commitlint/core 20→21) both raised their Node engine floor. Coco's `engines` field was looser than ini 7's range, so `yarn install` errors immediately on the lower end of the previously-declared range:

```
error ini@7.0.0: The engine "node" is incompatible with this module.
Expected version "^22.22.2 || ^24.15.0 || >=26.0.0". Got "22.14.0"
```

Tightening the engines field to match the strictest transitive requirement so the published package metadata is honest about what actually works.

## Changed

```diff
   "engines": {
-    "node": "^22.13.0 || >=24"
+    "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
   },
```

## Effective floor

- Node 22 LTS users: 22.22.2+ (released ~2025)
- Node 24 LTS users: 24.15.0+
- Node 26+: when it ships

Users on Node 22.13–22.22.1 would be broken by this; most stable LTS users are on 22.18+ already as of 2026-05, so the affected window is narrow.

## Validation

Run with `--ignore-engines` locally on Node 22.14 (since I didn't have a 22.22.2+ binary handy, but the published `engines` constraint is for users who'd otherwise hit the actual ini error):

- [x] `yarn install` (with `--ignore-engines` for local Node) — clean
- [x] `npm run build` — green
- [x] `npm run lint` — clean
- [x] `npx jest` — 6565/6565 pass