### PR TITLE
feat(log-tui): bisect completion panel (#879 item 3)

### DIFF
--- a/src/commands/log/bisectData.test.ts
+++ b/src/commands/log/bisectData.test.ts
@@ -1,5 +1,5 @@
 import { SimpleGit } from 'simple-git'
-import { getBisectStatus, parseBisectLog } from './bisectData'
+import { getBisectCompletion, getBisectStatus, parseBisectLog } from './bisectData'
 
 jest.mock('fs', () => {
   const actual = jest.requireActual('fs')
@@ -239,5 +239,55 @@ describe('getBisectStatus', () => {
     const status = await getBisectStatus(git)
 
     expect(status.active).toBe(false)
+  })
+})
+
+describe('getBisectCompletion', () => {
+  it('returns undefined for a log without the first-bad terminator', () => {
+    const log = parseBisectLog([
+      'git bisect start',
+      '# bad: [abc1234] feat: introduces the bug',
+      'git bisect bad abc1234',
+      '# good: [def5678] fix: previous state',
+      'git bisect good def5678',
+    ].join('\n'))
+    expect(getBisectCompletion(log)).toBeUndefined()
+  })
+
+  it('extracts the sha + subject from the first-bad terminator', () => {
+    const log = parseBisectLog([
+      'git bisect start',
+      'git bisect bad abc1234',
+      'git bisect good def5678',
+      '# first bad commit: [abc1234] feat: introduces the bug',
+    ].join('\n'))
+    expect(getBisectCompletion(log)).toEqual({
+      sha: 'abc1234',
+      subject: 'feat: introduces the bug',
+    })
+  })
+
+  it('returns the most recent terminator when multiple are present', () => {
+    // Defensive — a session that was completed, partially edited, and
+    // re-completed could in principle have two `# first bad commit`
+    // markers. Walk last-to-first so the latest one wins.
+    const log = parseBisectLog([
+      '# first bad commit: [abc1234] earlier conclusion',
+      'git bisect start',
+      '# first bad commit: [9999fff] later conclusion',
+    ].join('\n'))
+    expect(getBisectCompletion(log)?.sha).toBe('9999fff')
+  })
+
+  it('handles a terminator without subject text', () => {
+    const log = parseBisectLog('# first bad commit: [abc1234]')
+    expect(getBisectCompletion(log)).toEqual({
+      sha: 'abc1234',
+      subject: undefined,
+    })
+  })
+
+  it('returns undefined for an empty log', () => {
+    expect(getBisectCompletion([])).toBeUndefined()
   })
 })

--- a/src/commands/log/bisectData.ts
+++ b/src/commands/log/bisectData.ts
@@ -110,6 +110,45 @@ export function parseBisectLog(output: string): BisectLogEntry[] {
 }
 
 /**
+ * Detect bisect completion (#879, item 3). When git identifies the
+ * first bad commit it appends a comment row to BISECT_LOG of the
+ * form `# first bad commit: [<sha>] <subject>` and stops moving
+ * HEAD between candidates. The session technically remains "active"
+ * (BISECT_LOG and refs/bisect/* persist until `git bisect reset`),
+ * but from the user's perspective the answer is in — surfaces should
+ * render a completion panel rather than the same decision-log shape.
+ *
+ * Returns the first-bad sha + parsed subject when the terminator is
+ * present, or undefined when bisect is still in flight.
+ */
+export type BisectCompletion = {
+  /** Short or full hash of the first bad commit, as recorded by git. */
+  sha: string
+  /** Subject of the first bad commit, when git included one in the marker. */
+  subject?: string
+}
+
+export function getBisectCompletion(log: BisectLogEntry[]): BisectCompletion | undefined {
+  // Walk last-to-first so a completion-then-reset-then-restart
+  // sequence (rare but possible if a session is reused after a partial
+  // reset) reports the most recent terminator. The marker lives in
+  // an `unknown`-kind entry because the parser intentionally only
+  // classifies the four user-decision verbs.
+  for (let i = log.length - 1; i >= 0; i--) {
+    const entry = log[i]
+    if (entry.kind !== 'unknown') continue
+    const match = entry.raw.match(/^#\s+first\s+bad\s+commit:\s+\[([^\]]+)\]\s*(.*)$/)
+    if (match) {
+      return {
+        sha: match[1],
+        subject: match[2]?.trim() || undefined,
+      }
+    }
+  }
+  return undefined
+}
+
+/**
  * Load the live bisect status. Best-effort — when bisect isn't
  * active the empty-status sentinel returns immediately so callers
  * don't pay for a `git bisect log` round-trip on every refresh.

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -227,7 +227,7 @@ import {
     stageHunk,
     unstageHunk,
 } from './statusHunks'
-import { BisectStatus, getBisectStatus } from './bisectData'
+import { BisectStatus, getBisectCompletion, getBisectStatus } from './bisectData'
 import { bisectBad, bisectGood, bisectReset, bisectSkip, extractBisectRemainingHint } from './bisectActions'
 import { getCompareDiff } from './compareData'
 import { ReflogOverview, getReflogOverview, splitReflogSubject } from './reflogData'
@@ -2793,7 +2793,18 @@ function renderHeader(
   // #784 — surface bisect-in-progress in the title bar so users entering
   // the TUI mid-bisect see it immediately, before they navigate to gB.
   const dirtyBase = context.branches?.dirty ? 'dirty' : 'clean'
-  const dirty = context.bisect?.active ? `${dirtyBase} · BISECTING` : dirtyBase
+  // Three states the title bar surfaces (#779 / #879):
+  //   inactive    → just the worktree clean/dirty
+  //   in-flight   → '· BISECTING' (the original signal from #784)
+  //   completed   → '· BISECTED' so users entering the TUI see at a
+  //                 glance that bisect terminated and is waiting for
+  //                 reset, not that they need to make another decision.
+  const bisectBadge = !context.bisect?.active
+    ? ''
+    : getBisectCompletion(context.bisect.log)
+      ? ' · BISECTED'
+      : ' · BISECTING'
+  const dirty = `${dirtyBase}${bisectBadge}`
   const repo = context.provider?.repository.owner && context.provider.repository.name
     ? `${context.provider.repository.owner}/${context.provider.repository.name}`
     : 'local repository'
@@ -4214,6 +4225,58 @@ function renderBisectSurface(
     lines.push(h(Text, { key: 'bisect-empty-5' }, ''))
     lines.push(h(Text, { key: 'bisect-empty-6', dimColor: true },
       truncate('coco will pick up the active bisect on the next refresh — actions will become available here.', width - 4)))
+  } else if (getBisectCompletion(bisect.log)) {
+    // #879 (item 3) — completion panel. When git's "is the first bad
+    // commit" terminator appears in the log, the bisect session is
+    // technically still active (BISECT_LOG persists until reset) but
+    // from the user's perspective the answer is in. Swap the
+    // in-flight UI for a celebration / next-step panel so the moment
+    // doesn't disappear into the same shape as a regular decision.
+    const completion = getBisectCompletion(bisect.log)!
+    const sha8 = completion.sha.slice(0, 8)
+    lines.push(h(Text, { key: 'bisect-done-title', bold: true, color: accent },
+      truncate('Bisect complete — first bad commit identified.', width - 4)))
+    lines.push(h(Text, { key: 'bisect-done-spacer-1' }, ''))
+    lines.push(h(Text, { key: 'bisect-done-sha-label', dimColor: true },
+      truncate('First bad commit', width - 4)))
+    lines.push(h(Text, { key: 'bisect-done-sha', bold: true },
+      truncate(`  ${sha8}`, width - 4)))
+    if (completion.subject) {
+      lines.push(h(Text, { key: 'bisect-done-subject' },
+        truncate(`  ${completion.subject}`, width - 4)))
+    }
+
+    // Reuse the candidate detail loader's payload — when the bisect
+    // ends, HEAD is at the first-bad commit, so candidateDetail is
+    // already populated with author / date / files / stats.
+    if (candidateDetail) {
+      lines.push(h(Text, { key: 'bisect-done-author', dimColor: true },
+        truncate(`  ${candidateDetail.author} · ${candidateDetail.date}`, width - 4)))
+      const { stats, files } = candidateDetail
+      lines.push(h(Text, { key: 'bisect-done-stats' },
+        truncate(`  ${stats.filesChanged} file${stats.filesChanged === 1 ? '' : 's'} · +${stats.insertions} / -${stats.deletions}`, width - 4)))
+      const sampleFiles = files.slice(0, 3).map((file) => file.path)
+      if (sampleFiles.length > 0) {
+        const overflow = files.length > sampleFiles.length ? ` (+${files.length - sampleFiles.length} more)` : ''
+        lines.push(h(Text, { key: 'bisect-done-files', dimColor: true },
+          truncate(`    ${sampleFiles.join(', ')}${overflow}`, width - 4)))
+      }
+    }
+
+    lines.push(h(Text, { key: 'bisect-done-spacer-2' }, ''))
+    lines.push(h(Text, { key: 'bisect-done-actions-h', bold: true },
+      truncate('Next', width - 4)))
+    lines.push(h(Text, { key: 'bisect-done-action-y', color: accent },
+      truncate('  y  yank the hash to clipboard', width - 4)))
+    lines.push(h(Text, { key: 'bisect-done-action-x', color: accent },
+      truncate('  x  exit bisect (git bisect reset)', width - 4)))
+    lines.push(h(Text, { key: 'bisect-done-action-esc', dimColor: true },
+      truncate('  esc / <  back to history', width - 4)))
+    lines.push(h(Text, { key: 'bisect-done-spacer-3' }, ''))
+    lines.push(h(Text, { key: 'bisect-done-tip', dimColor: true },
+      truncate('Tip: `git bisect log > /tmp/replay` from the shell saves this', width - 4)))
+    lines.push(h(Text, { key: 'bisect-done-tip-2', dimColor: true },
+      truncate('session — replay it later with `git bisect replay /tmp/replay`.', width - 4)))
   } else {
     // Active bisect. Three-section body: current candidate (sha +
     // commit summary so the user can judge the diff at a glance),
@@ -4303,7 +4366,16 @@ function renderBisectSurface(
   },
   h(Box, { justifyContent: 'space-between' },
     h(Text, { bold: true }, panelTitle('Bisect', focused)),
-    h(Text, { dimColor: true }, bisect?.active ? 'BISECTING' : 'inactive')
+    h(Text, { dimColor: true },
+      // Three states: not running ('inactive'), running ('BISECTING'),
+      // ran-to-completion ('COMPLETE'). Same per-key color treatment;
+      // the surface body tells the rest.
+      !bisect?.active
+        ? 'inactive'
+        : getBisectCompletion(bisect.log)
+          ? 'COMPLETE'
+          : 'BISECTING'
+    )
   ),
   ...lines)
 }


### PR DESCRIPTION
Third child of [#879](https://github.com/gfargo/coco/issues/879). S effort. **Stacked on [#886](https://github.com/gfargo/coco/pull/886)** — base is \`feat/bisect-candidate-diff\`, not \`main\`. After #886 merges, this PR rebases cleanly onto main.

## Why

When git's \"is the first bad commit\" terminator appears in BISECT_LOG, the session is technically still active (BISECT_LOG persists until reset) but from the user's perspective the answer is in. Previously the surface stayed in the same shape as a regular decision step — confusing because nothing pointed at the result.

## What changed

The completion panel:

\`\`\`
Bisect                                         COMPLETE

Bisect complete — first bad commit identified.

First bad commit
  abc12345
  feat: introduces the bug
  Coco Test · 2026-04-29
  3 files · +42 / -8
    src/parsers/list.ts, src/parsers/index.ts, tests/list.test.ts

Next
  y  yank the hash to clipboard
  x  exit bisect (git bisect reset)
  esc / <  back to history

Tip: \`git bisect log > /tmp/replay\` from the shell saves this
session — replay it later with \`git bisect replay /tmp/replay\`.
\`\`\`

Title bar gains a third state — \`inactive\` / \`BISECTING\` / \`BISECTED\`.

## Implementation

- New \`getBisectCompletion(log)\` helper. Walks the parsed log last-to-first, matches \`# first bad commit: [<sha>] <subject>\` rows. Returns \`{ sha, subject }\` or undefined. Defensive against multiple terminators (latest wins), missing subject text, empty logs.
- \`renderBisectSurface\` gains a new branch BEFORE the in-flight rendering: when completion is detected, render the panel instead. Reuses \`candidateDetail\` loaded by item 2 (#886) — when bisect ends, HEAD is at the first-bad commit, so the detail is already populated.
- Title bar badge + surface subtitle add the \`COMPLETE\` / \`BISECTED\` state.

The yank + reset workflows are already wired from [#868](https://github.com/gfargo/coco/pull/868) — no input changes needed. The completion panel just gives users the right context to act in.

## Tests

5 new \`getBisectCompletion\` cases:
- No terminator → undefined
- Well-formed terminator → \`{ sha, subject }\`
- Multiple terminators → latest wins
- Terminator without subject → \`subject: undefined\`
- Empty log → undefined

## Validation

- [x] \`npx tsc --noEmit\` → 0 errors
- [x] \`npx jest src/commands/log/\` → 3828/3828 pass (5 new on top of #886's count)

## Children remaining in [#879](https://github.com/gfargo/coco/issues/879)

- In-TUI start (M)
- \`git bisect run <script>\` (L, deferrable)