### PR TITLE
feat(log-tui): in-TUI bisect start wizard (#879 item 4)

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -851,13 +851,81 @@ describe('log Ink input interactions', () => {
     expect(events).toContainEqual({ type: 'runWorkflowAction', id: 'bisect-bad' })
   })
 
-  it('s on the bisect view skips the candidate (#784)', () => {
+  it('s on the bisect view skips the candidate when a bisect is active (#784)', () => {
     let state = createLogInkState(rows)
     state = applyLogInkAction(state, { type: 'pushView', value: 'bisect' })
 
-    const events = getLogInkInputEvents(state, 's', {}, {})
+    // bisectActive=true is the discriminator (#879 item 4) — without
+    // it, `s` is interpreted as "start the wizard" instead of "skip."
+    const events = getLogInkInputEvents(state, 's', {}, { bisectActive: true })
 
     expect(events).toContainEqual({ type: 'runWorkflowAction', id: 'bisect-skip' })
+  })
+
+  it('s on the empty bisect view enters the in-TUI start wizard (#879 item 4)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'bisect' })
+
+    // bisectActive omitted (or false) → s means "start the wizard."
+    // Expect: setBisectPickMode 'bad', push history, sticky status.
+    const events = getLogInkInputEvents(state, 's', {}, {})
+
+    const types = events
+      .filter((e) => e.type === 'action')
+      .map((e) => (e as Extract<typeof e, { type: 'action' }>).action.type)
+    expect(types).toContain('setBisectPickMode')
+    expect(types).toContain('pushView')
+    expect(types).toContain('setStatus')
+  })
+
+  it('Enter on a history commit while in bisect-pick=bad mode advances to good (#879 item 4)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'setBisectPickMode', value: 'bad' })
+
+    const events = getLogInkInputEvents(state, '', { return: true }, {})
+
+    const setMode = events.find((e) =>
+      e.type === 'action' && e.action.type === 'setBisectPickMode'
+    )
+    expect(setMode).toBeDefined()
+    if (setMode && setMode.type === 'action' && setMode.action.type === 'setBisectPickMode') {
+      expect(setMode.action.value).toBe('good')
+      expect(setMode.action.pendingBad).toBeTruthy()
+    }
+  })
+
+  it('Enter on a history commit while in bisect-pick=good mode runs the start workflow (#879 item 4)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, {
+      type: 'setBisectPickMode',
+      value: 'good',
+      pendingBad: 'abc1234',
+    })
+
+    const events = getLogInkInputEvents(state, '', { return: true }, {})
+
+    const workflow = events.find((e) =>
+      e.type === 'runWorkflowAction' && e.id === 'bisect-start-from-history'
+    )
+    expect(workflow).toBeDefined()
+    if (workflow && workflow.type === 'runWorkflowAction') {
+      expect(workflow.payload?.startsWith('abc1234\n')).toBe(true)
+    }
+  })
+
+  it('Esc clears the bisect-pick wizard mode without firing the workflow (#879 item 4)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'setBisectPickMode', value: 'bad' })
+
+    const events = getLogInkInputEvents(state, '', { escape: true }, {})
+
+    const clear = events.find((e) =>
+      e.type === 'action' && e.action.type === 'clearBisectPickMode'
+    )
+    expect(clear).toBeDefined()
+    expect(events.find((e) =>
+      e.type === 'runWorkflowAction' && e.id === 'bisect-start-from-history'
+    )).toBeUndefined()
   })
 
   it('x on the bisect view opens the y-confirm for reset (#784)', () => {

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -82,6 +82,14 @@ export type LogInkInputContext = {
   reflogCount?: number
   /** Hash of the cursored reflog entry (#781). Used by Enter to drill into the diff. */
   reflogSelectedHash?: string
+  /**
+   * True when `context.bisect.active` is set on the runtime side
+   * (#879 item 4). Lets the input handler differentiate `s` on the
+   * bisect view between "skip the candidate" (active) vs "enter the
+   * in-TUI start wizard" (inactive) without dragging the full
+   * BisectStatus into this scope.
+   */
+  bisectActive?: boolean
   worktreeListCount?: number
   /** Ref of the stash currently under the cursor (e.g. `stash@{0}`). */
   stashSelectedRef?: string
@@ -1120,10 +1128,68 @@ export function getLogInkInputEvents(
       return [{ type: 'runWorkflowAction', id: 'bisect-bad' }]
     }
     if (inputValue === 's') {
-      return [{ type: 'runWorkflowAction', id: 'bisect-skip' }]
+      // #879 item 4 — `s` is overloaded by context. When bisect is
+      // active, it skips the candidate (the original behavior from
+      // #868). When bisect is INACTIVE (empty state), it enters the
+      // in-TUI start wizard: pushes to history with mode='bad' so
+      // the user can pick the bad commit visually.
+      if (context.bisectActive) {
+        return [{ type: 'runWorkflowAction', id: 'bisect-skip' }]
+      }
+      return [
+        action({ type: 'setBisectPickMode', value: 'bad' }),
+        action({ type: 'pushView', value: 'history' }),
+        action({ type: 'setStatus', value: 'Bisect: pick the bad commit (where the bug is present). Press Enter, or Esc to cancel.' }),
+      ]
     }
     if (inputValue === 'x') {
       return [action({ type: 'setPendingConfirmation', value: 'bisect-reset' })]
+    }
+  }
+
+  // #879 item 4 — Esc clears the bisect-start wizard mode whenever
+  // it's set, regardless of which view the user is on. Runs BEFORE
+  // the generic Esc handler so the cancel path always works.
+  if (key.escape && state.bisectPickMode) {
+    return [
+      action({ type: 'clearBisectPickMode' }),
+      action({ type: 'setStatus', value: 'Bisect start cancelled.' }),
+    ]
+  }
+
+  // #879 item 4 — Enter on a history commit row while in the
+  // bisect-start wizard captures that commit's hash. The first Enter
+  // captures bad and advances to step 2 ("pick good"); the second
+  // Enter runs `git bisect start <bad> <good>` via the workflow
+  // runner. Both override the normal history-Enter (which would open
+  // the diff view) — placed BEFORE the existing history-Enter handler
+  // below so the wizard wins.
+  if (
+    key.return &&
+    state.bisectPickMode &&
+    state.activeView === 'history' &&
+    state.focus === 'commits' &&
+    state.filteredCommits.length > 0 &&
+    !state.pendingCommitFocused
+  ) {
+    const selected = state.filteredCommits[state.selectedIndex]
+    if (selected) {
+      if (state.bisectPickMode === 'bad') {
+        return [
+          action({ type: 'setBisectPickMode', value: 'good', pendingBad: selected.hash }),
+          action({
+            type: 'setStatus',
+            value: `Bisect: bad = ${selected.shortHash}. Pick a known-good commit (older). Press Enter, or Esc to cancel.`,
+          }),
+        ]
+      }
+      // 'good' step — fire the workflow with both refs in the payload.
+      // Payload format: `<bad-sha>\n<good-sha>` — the runtime parses
+      // it, validates the worktree, and runs git bisect start.
+      const payload = `${state.bisectPickPendingBad ?? ''}\n${selected.hash}`
+      return [
+        { type: 'runWorkflowAction', id: 'bisect-start-from-history', payload },
+      ]
     }
   }
 

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -228,7 +228,7 @@ import {
     unstageHunk,
 } from './statusHunks'
 import { BisectStatus, getBisectCompletion, getBisectStatus } from './bisectData'
-import { bisectBad, bisectGood, bisectReset, bisectSkip, extractBisectRemainingHint } from './bisectActions'
+import { bisectBad, bisectGood, bisectReset, bisectSkip, bisectStart, extractBisectRemainingHint } from './bisectActions'
 import { getCompareDiff } from './compareData'
 import { ReflogOverview, getReflogOverview, splitReflogSubject } from './reflogData'
 import { TagOverview, getTagOverview } from './tagData'
@@ -1894,6 +1894,52 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
           return { ok: false, message: `Bisect reset failed: ${(error as Error).message}` }
         }
       },
+      'bisect-start-from-history': async () => {
+        // #879 item 4. Payload format: `<bad-sha>\n<good-sha>`.
+        // Refuses if a bisect is already active (would conflict with
+        // the existing session) or if the worktree is dirty (git
+        // refuses bisect on a dirty tree anyway, but we surface a
+        // friendlier message). Both refs are validated before the
+        // git invocation. On success, clears the wizard mode and
+        // pushes the bisect view so the user lands on the new
+        // candidate's diff (which the candidate-detail loader from
+        // #886 picks up automatically).
+        if (context.bisect?.active) {
+          return { ok: false, message: 'A bisect is already in progress — reset it first (x on the bisect view)' }
+        }
+        if (!payload) {
+          return { ok: false, message: 'Bisect start needs both refs — try the wizard again from the bisect view (s)' }
+        }
+        const newlineIndex = payload.indexOf('\n')
+        if (newlineIndex < 0) {
+          return { ok: false, message: 'Malformed bisect-start payload' }
+        }
+        const badRef = payload.slice(0, newlineIndex).trim()
+        const goodRef = payload.slice(newlineIndex + 1).trim()
+        if (!badRef || !goodRef) {
+          return { ok: false, message: 'Bisect start needs both a bad ref and a good ref' }
+        }
+        if (badRef === goodRef) {
+          return { ok: false, message: 'Bisect: bad and good cannot be the same commit' }
+        }
+        if (context.branches?.dirty) {
+          return { ok: false, message: 'Bisect requires a clean worktree — stash your changes first' }
+        }
+        try {
+          await bisectStart(git, badRef, goodRef)
+          // Clear the wizard mode synchronously so the next render
+          // doesn't keep the sticky banner. Push the bisect view in
+          // the same dispatch so the user lands on the new candidate.
+          dispatch({ type: 'setBisectPickMode', value: undefined })
+          dispatch({ type: 'pushView', value: 'bisect' })
+          return {
+            ok: true,
+            message: `Bisecting between ${badRef.slice(0, 8)} (bad) and ${goodRef.slice(0, 8)} (good)`,
+          }
+        } catch (error) {
+          return { ok: false, message: `Bisect start failed: ${(error as Error).message}` }
+        }
+      },
       'checkout-file-from-stash': async () => {
         const path = payload?.trim()
         const ref = state.stashDiffRef
@@ -2628,6 +2674,7 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       stashCount: stashVisibleCount,
       reflogCount: reflogVisibleCount,
       reflogSelectedHash,
+      bisectActive: Boolean(context.bisect?.active),
       stashSelectedRef,
       stashDiffFileOffsets: stashDiffFileOffsets.length ? stashDiffFileOffsets : undefined,
       stashDiffSelectedPath,
@@ -4210,21 +4257,26 @@ function renderBisectSurface(
     lines.push(h(Text, { key: 'bisect-loading', dimColor: true },
       truncate('· Loading bisect status…', width - 4)))
   } else if (!bisect?.active) {
-    // No bisect active. Surface the CLI on-ramp — starting from the
-    // TUI is intentionally out of scope for this PR (#784 follow-up).
-    // The user is expected to enter via `git bisect start <bad> <good>`
-    // and re-open `coco ui`; once bisect is active this view drives
-    // the rest.
+    // No bisect active. Two on-ramps: the in-TUI wizard (#879 item 4,
+    // press s to pick bad + good visually) and the CLI start. The
+    // wizard is faster because the user can see commit history while
+    // picking. Either path lands the user back on this view with the
+    // active bisect's controls.
     lines.push(h(Text, { key: 'bisect-empty-1', bold: true },
       truncate('No bisect in progress.', width - 4)))
     lines.push(h(Text, { key: 'bisect-empty-2' }, ''))
     lines.push(h(Text, { key: 'bisect-empty-3' },
-      truncate('Start one from the shell with:', width - 4)))
+      truncate('Start one — pick visually from history:', width - 4)))
     lines.push(h(Text, { key: 'bisect-empty-4', color: accent },
-      truncate('  git bisect start <bad-ref> <good-ref>', width - 4)))
+      truncate('  s   pick the bad commit, then a known-good commit', width - 4)))
     lines.push(h(Text, { key: 'bisect-empty-5' }, ''))
-    lines.push(h(Text, { key: 'bisect-empty-6', dimColor: true },
-      truncate('coco will pick up the active bisect on the next refresh — actions will become available here.', width - 4)))
+    lines.push(h(Text, { key: 'bisect-empty-6' },
+      truncate('Or from your shell:', width - 4)))
+    lines.push(h(Text, { key: 'bisect-empty-7', color: accent },
+      truncate('  git bisect start <bad-ref> <good-ref>', width - 4)))
+    lines.push(h(Text, { key: 'bisect-empty-8' }, ''))
+    lines.push(h(Text, { key: 'bisect-empty-9', dimColor: true },
+      truncate('Once active you get single-keystroke controls — g good · b bad · s skip · x reset.', width - 4)))
   } else if (getBisectCompletion(bisect.log)) {
     // #879 (item 3) — completion panel. When git's "is the first bad
     // commit" terminator appears in the log, the bisect session is

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -140,6 +140,26 @@ export type LogInkState = {
    */
   pendingConfirmationPayload?: string
   pendingMutationConfirmation?: LogInkMutationConfirmation
+  /**
+   * In-TUI bisect-start flow (#879 item 4). When the user opts in
+   * (`s` from the bisect view's empty state), this captures which
+   * step of the two-pick wizard the user is on:
+   *
+   *   - `'bad'`: pick the commit where the bug is present (Enter on
+   *     a history row → captures hash, transitions to `'good'`).
+   *   - `'good'`: pick a known-good commit older than the bad one
+   *     (Enter on a history row → runs `git bisect start <bad>
+   *     <good>` and clears the mode).
+   *
+   * `Esc` clears the mode at any point.
+   */
+  bisectPickMode?: 'bad' | 'good'
+  /**
+   * Hash captured during the `'bad'` step of the bisect-start
+   * wizard. Carried through to the `'good'` step so the workflow
+   * runner can pass both refs to `git bisect start`.
+   */
+  bisectPickPendingBad?: string
   pendingKey?: string
   focus: LogInkFocus
   sidebarTab: LogInkSidebarTab
@@ -392,6 +412,8 @@ export type LogInkAction =
   | { type: 'navigateOpenDiffForCompare'; base: LogInkCompareRef; head: LogInkCompareRef }
   | { type: 'setCompareBase'; value: LogInkCompareRef }
   | { type: 'clearCompareBase' }
+  | { type: 'setBisectPickMode'; value?: 'bad' | 'good'; pendingBad?: string }
+  | { type: 'clearBisectPickMode' }
   | { type: 'navigateOpenComposeForFile'; fileIndex: number }
   | { type: 'jumpWorktreeHunk'; delta: number; hunkOffsets: number[] }
   | { type: 'jumpCommitDiffHunk'; delta: number; hunkOffsets: number[] }
@@ -1295,6 +1317,26 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         compareBase: undefined,
+        pendingKey: undefined,
+      }
+    case 'setBisectPickMode':
+      // Used by both "enter the wizard" (mode='bad', pendingBad omitted)
+      // and "advance to step 2" (mode='good', pendingBad=captured-bad).
+      // The runner treats `value: undefined` as "exit wizard cleanly"
+      // — used after the start-bisect git command runs successfully.
+      return {
+        ...state,
+        bisectPickMode: action.value,
+        bisectPickPendingBad: action.pendingBad,
+        pendingKey: undefined,
+      }
+    case 'clearBisectPickMode':
+      // Esc key path. Drops both fields together so a partially-
+      // captured "bad" pick doesn't strand the second step.
+      return {
+        ...state,
+        bisectPickMode: undefined,
+        bisectPickPendingBad: undefined,
         pendingKey: undefined,
       }
     case 'navigateOpenComposeForFile': {

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -520,6 +520,21 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: true,
     },
     {
+      // #879 item 4 — in-TUI start. Per-view-only: scoped to the
+      // bisect-start wizard's second-step Enter. Empty key keeps it
+      // palette-discoverable but the palette path emits a hint
+      // instead (it can't synthesize the bad/good shas without the
+      // wizard state). Worktree-dirty pre-flight check lives in the
+      // runtime handler — kind='normal' because the operation itself
+      // is recoverable via `git bisect reset`.
+      id: 'bisect-start-from-history',
+      key: '',
+      label: 'Bisect: start from history (pick bad + good)',
+      description: 'Start a bisect session by picking the bad commit and a known-good commit from the history view.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
       id: 'ai-commit-summary',
       key: 'I',
       label: 'AI commit summary',


### PR DESCRIPTION
Fourth child of [#879](https://github.com/gfargo/coco/issues/879). M effort. **Stacked on [#887](https://github.com/gfargo/coco/pull/887)** — base is \`feat/bisect-completion-panel\`. After the prior PRs land, this one rebases onto main.

## Why

Removes the CLI cliff for starting a bisect. The pitch for the in-TUI flow over CLI is exactly that the user can *see* the commits while picking — an input-prompt version would barely beat the shell.

## Wizard flow

1. From the bisect view's empty state, press \`s\` → enters pick-bad mode, pushes to history, sticky banner: *"Pick the bad commit (where the bug is present)."*
2. Navigate history with \`j/k\`, press \`Enter\` on the bad commit → captures the hash, transitions to pick-good mode, banner updates: *"bad = <sha>. Pick a known-good commit (older)."*
3. Press \`Enter\` on the good commit → fires the \`bisect-start-from-history\` workflow with both shas in the payload. The runtime validates (no existing bisect, both refs distinct, worktree clean), runs \`git bisect start\`, clears the wizard mode, and pushes the bisect view.
4. \`Esc\` at any point cancels and clears the mode.

## Implementation

| File | Change |
|---|---|
| \`inkViewModel.ts\` | New state \`bisectPickMode\` / \`bisectPickPendingBad\`; two new actions (\`setBisectPickMode\`, \`clearBisectPickMode\`) |
| \`inkInput.ts\` | \`s\` on bisect is now **context-overloaded**: \`bisectActive=true\` → skip (original #784); else → enter wizard. \`Esc\` clears the mode globally. \`Enter\` on history with mode set is intercepted BEFORE the regular history-Enter |
| \`inkWorkflows.ts\` | New \`bisect-start-from-history\` workflow (palette-only key) |
| \`inkRuntime.ts\` | Workflow handler validates payload (no existing bisect, distinct refs, clean worktree) and dispatches mode-clear + view-push synchronously. Empty-state copy advertises \`s\` as the recommended on-ramp |

## Pre-flight checks

The workflow refuses with a clear status message when:
- A bisect is already in progress (\"reset it first (x on the bisect view)\")
- Refs are missing or identical (\"bad and good cannot be the same commit\")
- The worktree is dirty (\"stash your changes first\")

## Tests

- Existing #784 \`s → bisect-skip\` test updated to pass \`bisectActive: true\` (the new context flag)
- 4 new tests for the wizard flow:
  - \`s\` with \`bisectActive=false\` → enters wizard (mode=bad, push history, status)
  - Enter on history with mode='bad' → advances to mode='good' with pendingBad captured
  - Enter on history with mode='good' → runs bisect-start-from-history with payload \`<bad>\\n<good>\`
  - Esc with mode set → clearBisectPickMode, no workflow fires

## Validation

- [x] \`npx tsc --noEmit\` → 0 errors
- [x] \`npx jest src/commands/log/\` → 3832/3832 (4 new)

## Children remaining in [#879](https://github.com/gfargo/coco/issues/879)

- \`git bisect run <script>\` (L, deferrable) — the last item, power-user automation