### PR TITLE
feat(log-tui): bisect run integration — automate decisions via a script (#879 item 5)

### DIFF
--- a/src/commands/log/bisectActions.test.ts
+++ b/src/commands/log/bisectActions.test.ts
@@ -3,6 +3,7 @@ import {
   bisectBad,
   bisectGood,
   bisectReset,
+  bisectRun,
   bisectSkip,
   bisectStart,
   extractBisectRemainingHint,
@@ -47,6 +48,13 @@ describe('bisect action wrappers', () => {
     const git = { raw } as unknown as SimpleGit
     await bisectReset(git)
     expect(raw).toHaveBeenCalledWith(['bisect', 'reset'])
+  })
+
+  it('bisectRun invokes `git bisect run sh -c <command>` so shell snippets work without escaping', async () => {
+    const raw = jest.fn().mockResolvedValue('')
+    const git = { raw } as unknown as SimpleGit
+    await bisectRun(git, 'npm test -- --filter=regression')
+    expect(raw).toHaveBeenCalledWith(['bisect', 'run', 'sh', '-c', 'npm test -- --filter=regression'])
   })
 })
 

--- a/src/commands/log/bisectActions.ts
+++ b/src/commands/log/bisectActions.ts
@@ -45,6 +45,28 @@ export async function bisectReset(git: SimpleGit): Promise<string> {
 }
 
 /**
+ * Drive a bisect by automating `git bisect run <command>` (#879 item
+ * 5). The user's command runs once per candidate; git interprets
+ * the exit code:
+ *
+ *   0       → mark good
+ *   125     → skip (the "untestable" code reserved by git)
+ *   1..127  → mark bad (anything non-zero except 125)
+ *   128+    → abort (e.g. SIGSEGV, killed)
+ *
+ * The CLI form is `git bisect run sh -c '<cmd>'` so users can pass
+ * any shell snippet without escaping flags into git's argv.
+ *
+ * Returns full stdout. Caller surfaces git's `Bisecting: ...` /
+ * `<sha> is the first bad commit` lines via
+ * `extractBisectRemainingHint`. Errors propagate — git non-zero
+ * exits become rejections, the same as the other action wrappers.
+ */
+export async function bisectRun(git: SimpleGit, command: string): Promise<string> {
+  return git.raw(['bisect', 'run', 'sh', '-c', command])
+}
+
+/**
  * Pull the user-facing remaining-revisions hint out of `git bisect`
  * stdout. Looks for the canonical line:
  *

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -673,6 +673,18 @@ function submitInputPrompt(state: LogInkState): LogInkInputEvent[] {
       action({ type: 'closeInputPrompt' }),
     ]
   }
+  if (state.inputPrompt.kind === 'bisect-run-command') {
+    // #879 item 5 — submit-from-prompt fires the bisect-run workflow
+    // with the raw shell command as payload. The workflow handler in
+    // the runtime spawns `git bisect run <cmd>` and surfaces the
+    // result via the status line. Mapped explicitly here because the
+    // prompt-kind name differs from the workflow id (workflow is
+    // 'bisect-run', not 'bisect-run-command').
+    return [
+      { type: 'runWorkflowAction', id: 'bisect-run', payload: value },
+      action({ type: 'closeInputPrompt' }),
+    ]
+  }
   const id = state.inputPrompt.kind
   return [
     { type: 'runWorkflowAction', id, payload: value },
@@ -1144,6 +1156,17 @@ export function getLogInkInputEvents(
     }
     if (inputValue === 'x') {
       return [action({ type: 'setPendingConfirmation', value: 'bisect-reset' })]
+    }
+    // #879 item 5 — `R` opens the bisect-run command prompt. Capital
+    // disambiguates from the global `r` (refresh) which still works
+    // outside the bisect view. Only fires when bisect is active —
+    // otherwise the prompt would have nothing to drive.
+    if (inputValue === 'R' && context.bisectActive) {
+      return [action({
+        type: 'openInputPrompt',
+        kind: 'bisect-run-command',
+        label: 'Bisect run command (e.g. npm test, pytest -k regression)',
+      })]
     }
   }
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -705,7 +705,7 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
 
   if (options.activeView === 'bisect') {
     return {
-      contextual: ['g good', 'b bad', 's skip', 'x reset', 'esc back'],
+      contextual: ['g good', 'b bad', 's skip', 'R run', 'x reset', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -228,7 +228,7 @@ import {
     unstageHunk,
 } from './statusHunks'
 import { BisectStatus, getBisectCompletion, getBisectStatus } from './bisectData'
-import { bisectBad, bisectGood, bisectReset, bisectSkip, bisectStart, extractBisectRemainingHint } from './bisectActions'
+import { bisectBad, bisectGood, bisectReset, bisectRun, bisectSkip, bisectStart, extractBisectRemainingHint } from './bisectActions'
 import { getCompareDiff } from './compareData'
 import { ReflogOverview, getReflogOverview, splitReflogSubject } from './reflogData'
 import { TagOverview, getTagOverview } from './tagData'
@@ -1892,6 +1892,34 @@ function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
           return { ok: true, message: 'Bisect reset' }
         } catch (error) {
           return { ok: false, message: `Bisect reset failed: ${(error as Error).message}` }
+        }
+      },
+      'bisect-run': async () => {
+        // #879 item 5 — `git bisect run <cmd>` automation. The user
+        // typed a shell command in the prompt; bisectRun shells it
+        // through `sh -c` per candidate and lets git's exit-code
+        // contract drive good/bad/skip. Returns the final stdout
+        // which includes git's "is the first bad commit" terminator
+        // if the run succeeded — surface that as the status message.
+        if (!context.bisect?.active) {
+          return { ok: false, message: 'No bisect in progress — start one first (s on the bisect view)' }
+        }
+        const command = payload?.trim()
+        if (!command) {
+          return { ok: false, message: 'Bisect run needs a command — try again with `R`' }
+        }
+        try {
+          const stdout = await bisectRun(git, command)
+          const hint = extractBisectRemainingHint(stdout)
+          return {
+            ok: true,
+            message: hint || 'Bisect run completed — see git output for results',
+          }
+        } catch (error) {
+          // Common failure modes: command exits 128 (abort), or 125
+          // every time (untestable everywhere → bisect aborts).
+          // Either way surface the underlying git message.
+          return { ok: false, message: `Bisect run failed: ${(error as Error).message}` }
         }
       },
       'bisect-start-from-history': async () => {
@@ -4405,7 +4433,7 @@ function renderBisectSurface(
 
     lines.push(h(Text, { key: 'bisect-action-spacer' }, ''))
     lines.push(h(Text, { key: 'bisect-action-hint', dimColor: true },
-      truncate('Actions: g good · b bad · s skip · x reset', width - 4)))
+      truncate('Actions: g good · b bad · s skip · R run · x reset', width - 4)))
   }
 
   return h(Box, {

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -345,6 +345,7 @@ export type LogInkInputPromptKind =
   | 'pr-merge-strategy'
   | 'pr-comment'
   | 'pr-request-changes'
+  | 'bisect-run-command'
 
 export type LogInkInputPromptState = {
   kind: LogInkInputPromptKind

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -535,6 +535,21 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: false,
     },
     {
+      // #879 item 5 — `git bisect run <script>` automation. Per-view
+      // only (R on the active bisect view). Triggers an input prompt
+      // for the user's command; on submit, runs git bisect run. The
+      // typed command itself is the affirmative gate (mirrors
+      // create-branch-here's prompt-as-confirmation pattern), so no
+      // additional y-confirm. Exit code drives the decision: 0 →
+      // good, 125 → skip, else → bad.
+      id: 'bisect-run',
+      key: '',
+      label: 'Bisect: run automated command',
+      description: 'Automate the bisect by running a command for each candidate. Exit 0 = good, 125 = skip, else = bad.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
       id: 'ai-commit-summary',
       key: 'I',
       label: 'AI commit summary',


### PR DESCRIPTION
Fifth and final child of [#879](https://github.com/gfargo/coco/issues/879). Closes the tracker. **Stacked on [#888](https://github.com/gfargo/coco/pull/888)** — base is \`feat/bisect-in-tui-start\`. After the chain merges, this rebases onto main.

## Why

The killer power-user feature for bisect. Press \`R\` on the active bisect view, type a command (\`npm test\`, \`pytest -k regression\`, etc.), git runs it for each candidate and the exit code drives good/bad/skip automatically. Turns *\"I'll bisect this once a year\"* into *\"I'll bisect this every Friday because it's faster than reading commit logs.\"*

## Flow

1. From the active bisect view, press \`R\` → input prompt: *\"Bisect run command (e.g. \`npm test\`, \`pytest -k regression\`)\"*
2. User types the command and submits
3. Runtime spawns \`git bisect run sh -c '<command>'\` — git handles the loop itself, running the command for each candidate
4. Exit-code contract:
   - \`0\` → mark good
   - \`125\` → skip (untestable, e.g. doesn't build)
   - \`1..127\` → mark bad
   - \`128+\` → abort (SIGSEGV, killed)
5. When git terminates, the runtime surfaces the result via the status line — typically \`<sha> is the first bad commit\` on success

## MVP scope

The loop runs synchronously — no live streaming of per-candidate output. Users see a \"running…\" while git churns, then the final status. Live streaming + cancel mid-run can come in a follow-up; the API surface is in place.

## Implementation

| File | Change |
|---|---|
| \`bisectActions.ts\` | New \`bisectRun(git, command)\` wrapping \`git bisect run sh -c '<command>'\`. The \`sh -c\` form lets users pass shell snippets (pipes, env vars, arg flags) without escaping into git's argv |
| \`inkViewModel.ts\` | \`'bisect-run-command'\` added to \`LogInkInputPromptKind\` |
| \`inkInput.ts\` | \`R\` on bisect view (active only) opens the input prompt; submit fires \`bisect-run\` workflow with typed command as payload |
| \`inkWorkflows.ts\` | New \`bisect-run\` workflow (palette-only key, prompt-as-confirmation pattern) |
| \`inkRuntime.ts\` | Workflow handler validates payload, runs the command, surfaces \`extractBisectRemainingHint\` |
| \`inkKeymap.ts\` + \`inkRuntime.ts\` | Footer hint + surface action line both gain \`R run\` |

## Tests

- \`bisectRun\` argv contract: \`git bisect run sh -c <cmd>\` — ensures shell snippets pass through verbatim

## Validation

- [x] \`npx tsc --noEmit\` → 0 errors
- [x] \`npx jest src/commands/log/\` → 3833/3833 pass (1 new)

## Tracker close-out

This is the last child in [#879](https://github.com/gfargo/coco/issues/879). After this and PRs [#885](https://github.com/gfargo/coco/pull/885) / [#886](https://github.com/gfargo/coco/pull/886) / [#887](https://github.com/gfargo/coco/pull/887) / [#888](https://github.com/gfargo/coco/pull/888) merge, the tracker can close.