### PR TITLE
refactor(workstation): extract shared types + visual helpers from inkRuntime (#890 phase 5a.0)

### DIFF
--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -38,7 +38,7 @@
 import { spawnSync } from 'node:child_process'
 import type * as ReactTypes from 'react'
 import { SimpleGit } from 'simple-git'
-import { BranchOverview, getBranchOverview } from '../../git/branchData'
+import { getBranchOverview } from '../../git/branchData'
 import { createManualCommit } from './commitCompose'
 import { runCommitDraftWorkflow } from '../../git/commitWorkflowActions'
 import {
@@ -148,9 +148,9 @@ import {
     getSelectedInkCommit,
 } from './inkViewModel'
 import { startInteractiveLog } from './interactive'
-import { GitOperationOverview, getGitOperationOverview } from '../../git/operationData'
+import { getGitOperationOverview } from '../../git/operationData'
 import { openProviderUrl } from '../../git/providerActions'
-import { ProviderOverview, ProviderRepository, buildProviderUrl, getProviderOverview } from '../../git/providerData'
+import { ProviderRepository, buildProviderUrl, getProviderOverview } from '../../git/providerData'
 import {
     checkoutBranch,
     createBranch,
@@ -179,7 +179,7 @@ import { applyStash, checkoutFileFromStash, createStash, dropStash, popStash } f
 import { ApplyHunkTarget, applyHunkPatch } from '../../git/hunkActions'
 import { removeWorktree, removeWorktreeAndBranch } from '../../git/worktreeActions'
 import { abortOperation, continueOperation, resolveConflictOurs, resolveConflictTheirs, stageConflictResolved } from '../../git/operationActions'
-import { PullRequestOverview, getPullRequestOverview } from '../../git/pullRequestData'
+import { getPullRequestOverview } from '../../git/pullRequestData'
 import {
     approvePullRequest,
     closePullRequest,
@@ -189,7 +189,6 @@ import {
     requestChangesPullRequest,
 } from '../../git/pullRequestActions'
 import {
-    StashOverview,
     findStashFileForOffset,
     getStashDiff,
     getStashOverview,
@@ -214,7 +213,6 @@ import {
 import {
     WorktreeFile,
     WorktreeFileGroup,
-    WorktreeOverview,
     applyStatusFilterMask,
     flattenWorktreeGroups,
     getWorktreeOverview,
@@ -227,11 +225,11 @@ import {
     stageHunk,
     unstageHunk,
 } from '../../git/statusHunks'
-import { BisectStatus, getBisectStatus } from '../../git/bisectData'
+import { getBisectStatus } from '../../git/bisectData'
 import { bisectBad, bisectGood, bisectReset, bisectSkip, extractBisectRemainingHint } from '../../git/bisectActions'
 import { getCompareDiff } from '../../git/compareData'
-import { ReflogOverview, getReflogOverview, splitReflogSubject } from '../../git/reflogData'
-import { TagOverview, getTagOverview } from '../../git/tagData'
+import { getReflogOverview, splitReflogSubject } from '../../git/reflogData'
+import { getTagOverview } from '../../git/tagData'
 import {
     getLogInkWorkflowActionById,
 } from './inkWorkflows'
@@ -240,7 +238,7 @@ import {
     InspectorActionContext,
     getInspectorActions,
 } from '../../workstation/chrome/inspectorActions'
-import { WorktreeOverview as WorktreeListOverview, getWorktreeListOverview } from '../../git/worktreeData'
+import { getWorktreeListOverview } from '../../git/worktreeData'
 import { WorktreeFileDiff, getWorktreeFileDiff } from '../../git/worktreeDiffData'
 import { canStartLogInkTui, getLogInkRenderOptions } from '../../workstation/chrome/terminal'
 import { LogArgv } from './config'
@@ -278,88 +276,30 @@ type LogInkOptions = {
   theme?: LogInkThemeConfig
 }
 
-type LogInkContext = {
-  bisect?: BisectStatus
-  branches?: BranchOverview
-  operation?: GitOperationOverview
-  provider?: ProviderOverview
-  pullRequest?: PullRequestOverview
-  reflog?: ReflogOverview
-  stashes?: StashOverview
-  tags?: TagOverview
-  worktree?: WorktreeOverview
-  worktreeList?: WorktreeListOverview
-}
+// Shared workstation runtime types live in src/workstation/runtime/types.ts.
+// They're imported here under their original names so existing intra-file
+// references continue to work without rewriting every render helper.
+import type {
+  LogInkComponentDeps,
+  LogInkComponents,
+  LogInkContext,
+  LogInkRuntime,
+} from '../../workstation/runtime/types'
 
-type LogInkRuntime = {
-  ink: {
-    Box: ReactTypes.ComponentType<Record<string, unknown>>
-    Text: ReactTypes.ComponentType<Record<string, unknown>>
-    render: (
-      app: ReactTypes.ReactElement,
-      options: {
-        alternateScreen?: boolean
-        exitOnCtrlC?: boolean
-        patchConsole?: boolean
-        stderr?: NodeJS.WriteStream
-        stdin?: NodeJS.ReadStream
-        stdout?: NodeJS.WriteStream
-      }
-    ) => {
-      waitUntilExit: () => Promise<void>
-      unmount: () => void
-    }
-    useApp: () => {
-      exit: () => void
-    }
-    useInput: (handler: (input: string, key: LogInkInputKey) => void) => void
-    useWindowSize: () => {
-      columns: number
-      rows: number
-    }
-  }
-  React: typeof ReactTypes
-}
-
-type LogInkComponents = Pick<LogInkRuntime['ink'], 'Box' | 'Text'>
-
-type LogInkComponentDeps = LogInkRuntime & {
-  appLabel: string
-  git: SimpleGit
-  /** Drives P4.3 idle status-line tip rotation when truthy. */
-  idleTipsEnabled?: boolean
-  initialView: LogInkView
-  logArgv?: LogArgv
-  rows: GitLogRow[]
-  /**
-   * Optional deferred commit-log loader (#808). When set, the React
-   * tree mounts with `rows` (typically `[]`) and runs the loader on
-   * mount, dispatching `replaceRows` on completion. Boot UX is the
-   * sole motivator — for a moderately large repo, awaiting `git log`
-   * before mount produces 1-3 seconds of black terminal that reads as
-   * "is this hanging?".
-   */
-  loadRows?: () => Promise<GitLogRow[]>
-  theme: LogInkTheme
-  /**
-   * Mutable ref the runtime fills with a force-render callback. The
-   * terminal-lifecycle module invokes it on `SIGCONT` so users land on a
-   * painted screen after `fg` instead of an empty alt buffer.
-   */
-  resumeRef?: { current: (() => void) | null }
-  /**
-   * Test seam — when set, the yank-to-clipboard handler uses this runner
-   * instead of `defaultClipboardRunner`. Lets unit tests assert that the
-   * right value reached the clipboard without spawning pbcopy/wl-copy.
-   */
-  clipboardRunner?: ClipboardRunner
-}
+// Pure visual helpers shared with future per-surface modules. Moved out of
+// this file so a surface module can render with the same color / glyph rules
+// without pulling in the orchestration code.
+import {
+  compactHash,
+  diffLineProps,
+  focusBorderColor,
+  formatChangedFileStats,
+  panelTitle,
+  sidebarTabLabel,
+  statusCodeColor,
+} from '../../workstation/runtime/utils'
 
 const truncate = truncateCells
-
-function compactHash(hash: string | undefined): string {
-  return hash ? hash.slice(0, 7) : '<none>'
-}
 
 async function safe<T>(promise: Promise<T>): Promise<T | undefined> {
   try {
@@ -461,54 +401,6 @@ async function loadInkRuntime(): Promise<LogInkRuntime> {
     ink,
     React,
   }
-}
-
-function focusBorderColor(
-  theme: LogInkTheme,
-  focused: boolean
-): string | undefined {
-  if (theme.noColor) {
-    return undefined
-  }
-
-  return focused ? theme.colors.focusBorder : theme.colors.border
-}
-
-function panelTitle(title: string, focused: boolean): string {
-  return focused ? `${title} *` : title
-}
-
-/**
- * Map a unified-diff line to the props passed to an Ink `<Text>` so the
- * standard +/-/@@ prefixes render in their conventional colors. File
- * headers (`+++`, `---`, `diff --git`, `index`) get a softer treatment so
- * they don't compete with the actual hunk content.
- *
- * `theme.noColor` collapses everything to dim/normal so we stay readable
- * under `NO_COLOR` and the `monochrome` preset.
- */
-function diffLineProps(
-  line: string,
-  theme: LogInkTheme
-): { color?: string; dimColor?: boolean } {
-  if (theme.noColor) {
-    return { dimColor: line.startsWith(' ') || line.startsWith('diff ') || line.startsWith('index ') }
-  }
-
-  if (line.startsWith('diff ') || line.startsWith('index ') || line.startsWith('+++') || line.startsWith('---')) {
-    return { dimColor: true }
-  }
-  if (line.startsWith('@@')) {
-    return { color: theme.colors.accent }
-  }
-  if (line.startsWith('+')) {
-    return { color: theme.colors.gitAdded }
-  }
-  if (line.startsWith('-')) {
-    return { color: theme.colors.gitDeleted }
-  }
-
-  return {}
 }
 
 /**
@@ -618,62 +510,10 @@ function renderSplitDiffBody(
   })
 }
 
-/**
- * Pick a theme color for a single name-status code (`A`, `M`, `D`,
- * `R100`, etc.) so the inspector and commit-diff file list render with
- * familiar git colors at a glance. Letters stay in the line so the
- * meaning survives `NO_COLOR`.
- */
-function statusCodeColor(status: string, theme: LogInkTheme): string | undefined {
-  if (theme.noColor) {
-    return undefined
-  }
-
-  const head = status.charAt(0)
-  switch (head) {
-    case 'A':
-      return theme.colors.gitAdded
-    case 'D':
-      return theme.colors.gitDeleted
-    case 'U':
-      return theme.colors.danger
-    case 'M':
-    case 'T':
-      return theme.colors.gitModified
-    case 'R':
-    case 'C':
-      return theme.colors.accent
-    default:
-      return undefined
-  }
-}
-
-function formatChangedFileStats(file: GitCommitDetail['files'][number]): string {
-  if (file.binary) {
-    return 'bin'
-  }
-  if (file.additions === undefined && file.deletions === undefined) {
-    return ''
-  }
-  return `+${file.additions || 0}/-${file.deletions || 0}`
-}
-
-function sidebarTabLabel(tab: LogInkSidebarTab): string {
-  switch (tab) {
-    case 'status':
-      return 'Status'
-    case 'branches':
-      return 'Branches'
-    case 'tags':
-      return 'Tags'
-    case 'stashes':
-      return 'Stashes'
-    case 'worktrees':
-      return 'Worktrees'
-    default:
-      return tab
-  }
-}
+// compactHash, focusBorderColor, panelTitle, diffLineProps, statusCodeColor,
+// formatChangedFileStats, and sidebarTabLabel moved to
+// src/workstation/runtime/utils.ts so per-surface modules can import them
+// without pulling in this entire orchestration file.
 
 export async function startInkInteractiveLog(
   git: SimpleGit,

--- a/src/workstation/runtime/types.ts
+++ b/src/workstation/runtime/types.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared types for the Ink workstation runtime.
+ *
+ * Extracted from `src/commands/log/inkRuntime.ts` so per-surface modules
+ * (planned under `src/workstation/surfaces/<view>/`) and chrome render
+ * helpers (planned under `src/workstation/runtime/`) can speak the same
+ * type vocabulary without re-importing the giant inkRuntime module.
+ *
+ * `LogInkRuntime['ink']` carries Ink's ESM-only surface; we type it
+ * structurally (rather than importing from 'ink') so the rest of the
+ * codebase compiles without bundling Ink. The actual module is loaded
+ * via dynamicImport at runtime.
+ */
+
+import type * as ReactTypes from 'react'
+import type { SimpleGit } from 'simple-git'
+import type { BisectStatus } from '../../git/bisectData'
+import type { BranchOverview } from '../../git/branchData'
+import type { GitOperationOverview } from '../../git/operationData'
+import type { ProviderOverview } from '../../git/providerData'
+import type { PullRequestOverview } from '../../git/pullRequestData'
+import type { ReflogOverview } from '../../git/reflogData'
+import type { StashOverview } from '../../git/stashData'
+import type { TagOverview } from '../../git/tagData'
+import type { WorktreeOverview } from '../../git/statusData'
+import type { WorktreeOverview as WorktreeListOverview } from '../../git/worktreeData'
+import type { ClipboardRunner } from '../../git/historyActions'
+import type { LogArgv } from '../../commands/log/config'
+import type { GitLogRow } from '../../commands/log/data'
+import type { LogInkView } from '../../commands/log/inkViewModel'
+import type { LogInkInputKey } from '../../commands/log/inkInput'
+import type { LogInkTheme } from '../chrome/theme'
+
+export type LogInkContext = {
+  bisect?: BisectStatus
+  branches?: BranchOverview
+  operation?: GitOperationOverview
+  provider?: ProviderOverview
+  pullRequest?: PullRequestOverview
+  reflog?: ReflogOverview
+  stashes?: StashOverview
+  tags?: TagOverview
+  worktree?: WorktreeOverview
+  worktreeList?: WorktreeListOverview
+}
+
+export type LogInkRuntime = {
+  ink: {
+    Box: ReactTypes.ComponentType<Record<string, unknown>>
+    Text: ReactTypes.ComponentType<Record<string, unknown>>
+    render: (
+      app: ReactTypes.ReactElement,
+      options: {
+        alternateScreen?: boolean
+        exitOnCtrlC?: boolean
+        patchConsole?: boolean
+        stderr?: NodeJS.WriteStream
+        stdin?: NodeJS.ReadStream
+        stdout?: NodeJS.WriteStream
+      }
+    ) => {
+      waitUntilExit: () => Promise<void>
+      unmount: () => void
+    }
+    useApp: () => {
+      exit: () => void
+    }
+    useInput: (handler: (input: string, key: LogInkInputKey) => void) => void
+    useWindowSize: () => {
+      columns: number
+      rows: number
+    }
+  }
+  React: typeof ReactTypes
+}
+
+export type LogInkComponents = Pick<LogInkRuntime['ink'], 'Box' | 'Text'>
+
+export type LogInkComponentDeps = LogInkRuntime & {
+  appLabel: string
+  git: SimpleGit
+  /** Drives P4.3 idle status-line tip rotation when truthy. */
+  idleTipsEnabled?: boolean
+  initialView: LogInkView
+  logArgv?: LogArgv
+  rows: GitLogRow[]
+  /**
+   * Optional deferred commit-log loader (#808). When set, the React
+   * tree mounts with `rows` (typically `[]`) and runs the loader on
+   * mount, dispatching `replaceRows` on completion. Boot UX is the
+   * sole motivator — for a moderately large repo, awaiting `git log`
+   * before mount produces 1-3 seconds of black terminal that reads as
+   * "is this hanging?".
+   */
+  loadRows?: () => Promise<GitLogRow[]>
+  theme: LogInkTheme
+  /**
+   * Mutable ref the runtime fills with a force-render callback. The
+   * terminal-lifecycle module invokes it on `SIGCONT` so users land on a
+   * painted screen after `fg` instead of an empty alt buffer.
+   */
+  resumeRef?: { current: (() => void) | null }
+  /**
+   * Test seam — when set, the yank-to-clipboard handler uses this runner
+   * instead of `defaultClipboardRunner`. Lets unit tests assert that the
+   * right value reached the clipboard without spawning pbcopy/wl-copy.
+   */
+  clipboardRunner?: ClipboardRunner
+}

--- a/src/workstation/runtime/utils.ts
+++ b/src/workstation/runtime/utils.ts
@@ -1,0 +1,144 @@
+/**
+ * Pure visual helpers shared across workstation render code.
+ *
+ * Extracted from `src/commands/log/inkRuntime.ts` so per-surface modules
+ * can render with the same color / glyph rules without re-importing the
+ * orchestration file. None of these helpers touch React, Ink, or git —
+ * they take state/theme inputs and return strings or style props.
+ */
+
+import type { GitCommitDetail } from '../../commands/log/data'
+import type { LogInkSidebarTab } from '../../commands/log/inkViewModel'
+import type { LogInkTheme } from '../chrome/theme'
+
+/**
+ * Short-form commit hash for one-line displays. Returns `<none>` when
+ * the hash is missing so the column never collapses to whitespace.
+ */
+export function compactHash(hash: string | undefined): string {
+  return hash ? hash.slice(0, 7) : '<none>'
+}
+
+/**
+ * Pick the border color for a focusable panel. Honors `NO_COLOR` /
+ * monochrome by returning undefined so the terminal default takes
+ * over without shifting layout.
+ */
+export function focusBorderColor(
+  theme: LogInkTheme,
+  focused: boolean
+): string | undefined {
+  if (theme.noColor) {
+    return undefined
+  }
+
+  return focused ? theme.colors.focusBorder : theme.colors.border
+}
+
+/**
+ * Append a focus indicator (` *`) to a panel's title when it owns the
+ * focus. Used in panel headers so keyboard focus is visible without
+ * relying on color alone.
+ */
+export function panelTitle(title: string, focused: boolean): string {
+  return focused ? `${title} *` : title
+}
+
+/**
+ * Map a unified-diff line to the props passed to an Ink `<Text>` so the
+ * standard +/-/@@ prefixes render in their conventional colors. File
+ * headers (`+++`, `---`, `diff --git`, `index`) get a softer treatment so
+ * they don't compete with the actual hunk content.
+ *
+ * `theme.noColor` collapses everything to dim/normal so we stay readable
+ * under `NO_COLOR` and the `monochrome` preset.
+ */
+export function diffLineProps(
+  line: string,
+  theme: LogInkTheme
+): { color?: string; dimColor?: boolean } {
+  if (theme.noColor) {
+    return { dimColor: line.startsWith(' ') || line.startsWith('diff ') || line.startsWith('index ') }
+  }
+
+  if (line.startsWith('diff ') || line.startsWith('index ') || line.startsWith('+++') || line.startsWith('---')) {
+    return { dimColor: true }
+  }
+  if (line.startsWith('@@')) {
+    return { color: theme.colors.accent }
+  }
+  if (line.startsWith('+')) {
+    return { color: theme.colors.gitAdded }
+  }
+  if (line.startsWith('-')) {
+    return { color: theme.colors.gitDeleted }
+  }
+
+  return {}
+}
+
+/**
+ * Pick a theme color for a single name-status code (`A`, `M`, `D`,
+ * `R100`, etc.) so the inspector and commit-diff file list render with
+ * familiar git colors at a glance. Letters stay in the line so the
+ * meaning survives `NO_COLOR`.
+ */
+export function statusCodeColor(status: string, theme: LogInkTheme): string | undefined {
+  if (theme.noColor) {
+    return undefined
+  }
+
+  const head = status.charAt(0)
+  switch (head) {
+    case 'A':
+      return theme.colors.gitAdded
+    case 'D':
+      return theme.colors.gitDeleted
+    case 'U':
+      return theme.colors.danger
+    case 'M':
+    case 'T':
+      return theme.colors.gitModified
+    case 'R':
+    case 'C':
+      return theme.colors.accent
+    default:
+      return undefined
+  }
+}
+
+/**
+ * Format the additions/deletions stats column for a commit's changed
+ * file list. Binary files render as `bin`; missing stats collapse to
+ * empty so the column doesn't show meaningless `+0/-0`.
+ */
+export function formatChangedFileStats(file: GitCommitDetail['files'][number]): string {
+  if (file.binary) {
+    return 'bin'
+  }
+  if (file.additions === undefined && file.deletions === undefined) {
+    return ''
+  }
+  return `+${file.additions || 0}/-${file.deletions || 0}`
+}
+
+/**
+ * User-facing label for a sidebar tab. Drives both the sidebar header
+ * and breadcrumb / palette descriptions so the wording stays consistent.
+ */
+export function sidebarTabLabel(tab: LogInkSidebarTab): string {
+  switch (tab) {
+    case 'status':
+      return 'Status'
+    case 'branches':
+      return 'Branches'
+    case 'tags':
+      return 'Tags'
+    case 'stashes':
+      return 'Stashes'
+    case 'worktrees':
+      return 'Worktrees'
+    default:
+      return tab
+  }
+}


### PR DESCRIPTION
> Foundation PR for phase 5a of [#890](https://github.com/gfargo/coco/issues/890). Stand-alone — no stacking. Small, focused, easy to review.

## Why this PR exists

Phase 5a as originally pitched (\"split inkRuntime.ts by surface\") would touch ~30 files in one PR. Reading the actual code revealed the layered structure:

1. **Lines 1–843** — imports, small helpers, `startInkInteractiveLog`, `loadInkRuntime` — orchestration, stays.
2. **Lines 844–2780** — `LogInkApp` React component (~1,940 LOC) — phase 5b target.
3. **Lines 2781+** — ~50 `render*Surface` and chrome render helpers (~3,250 LOC) — phase 5a target.

Every surface extraction in phase 5a.1+ will need the same shared vocabulary: a few core types (`LogInkContext`, `LogInkComponents`, `LogInkRuntime`, `LogInkComponentDeps`) and a few pure visual helpers (`compactHash`, `focusBorderColor`, `panelTitle`, `diffLineProps`, `statusCodeColor`, `formatChangedFileStats`, `sidebarTabLabel`).

This PR sets that foundation. After it lands, **each subsequent surface extraction is a near-pure cut** — function moves to its own file, imports thread through. No more \"first I have to figure out where this type lives.\"

## What changes

**New: `src/workstation/runtime/types.ts`** (109 LOC)
- `LogInkContext` — the bag of overview data each surface reads from.
- `LogInkRuntime` — structural type for Ink's surface (`Box`, `Text`, `render`, `useApp`, `useInput`, `useWindowSize`). Lets the rest of the codebase compile without bundling the ESM-only \`ink\` module.
- `LogInkComponents` — `Pick<LogInkRuntime['ink'], 'Box' | 'Text'>`.
- `LogInkComponentDeps` — props for the eventual `LogInkApp` surface module.

**New: `src/workstation/runtime/utils.ts`** (144 LOC)
- `compactHash(hash)` — short-form commit hash, `<none>` fallback.
- `focusBorderColor(theme, focused)` — `NO_COLOR`-aware border color.
- `panelTitle(title, focused)` — appends ` *` for focus.
- `diffLineProps(line, theme)` — Ink `<Text>` props for unified-diff lines (+/-/@@/headers).
- `statusCodeColor(status, theme)` — color for `A`/`M`/`D`/`R`/`U` codes.
- `formatChangedFileStats(file)` — `+12/-3` / `bin` / empty.
- `sidebarTabLabel(tab)` — \"Status\" / \"Branches\" / etc.

All pure: string-in / string-or-props-out. No React, no Ink, no git.

**`src/commands/log/inkRuntime.ts`**: 6,039 → **5,879 LOC** (-160).
- Drops 4 type definitions (now imported from `runtime/types`).
- Drops 7 helper definitions (now imported from `runtime/utils`).
- Drops 8 unused-after-extraction type imports flagged by ESLint.
- Adds 2 import blocks pointing at the new files.

## Validation

- `tsc --noEmit`: clean.
- `eslint src`: clean.
- Full Jest suite: **680/680 suites, 6571/6571 tests passing** — same numbers as the post-#893 baseline.
- No file in the moved set is imported externally (yet) — `runtime/types.ts` and `runtime/utils.ts` are first imported by `inkRuntime.ts` and will be imported by every surface module in phase 5a.1+.

## What's next

Phase 5a.1 (next PR): extract the simplest surfaces — likely `renderReflogSurface`, `renderStashSurface`, `renderWorktreesSurface`, `renderBisectSurface` — each into `src/workstation/surfaces/<view>/index.tsx`. Each surface is ~80–200 LOC, a near-pure cut now that types and visual helpers are in place.

Closes phase 5a.0 of #890.