### PR TITLE
refactor(workstation): extract history surface from inkRuntime (#890 phase 5a.5)

### DIFF
--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -44,7 +44,6 @@ import { runCommitDraftWorkflow } from '../../git/commitWorkflowActions'
 import {
     GitCommitDetail,
     GitCommitFilePreview,
-    GitLogCommitRow,
     GitLogRow,
     LOG_INTERACTIVE_DEFAULT_LIMIT,
     buildToggleGraphArgs,
@@ -62,10 +61,6 @@ import {
     updateLogInkContextStatus,
 } from '../../workstation/chrome/context'
 import {
-    formatInkRefLabels,
-    getVisibleLogInkHistory,
-} from '../../workstation/chrome/historyRows'
-import {
     formatBindingKeys,
     formatLogInkBreadcrumb,
     filterLogInkPaletteCommands,
@@ -74,8 +69,6 @@ import {
     getLogInkFooterHints,
     getLogInkHelpSections,
 } from './inkKeymap'
-import { substituteGraphChars } from '../../workstation/chrome/graphChars'
-import { LaneSegment, getLaneColor } from '../../workstation/chrome/graphLanes'
 import { formatHyperlink } from '../../workstation/chrome/hyperlinks'
 import {
     LogInkInputKey,
@@ -120,12 +113,10 @@ import {
     sortTags,
 } from '../../workstation/chrome/sorting'
 import {
-    formatLogInkHistoryEmpty,
     formatLogInkLoading,
 } from '../../workstation/chrome/surfaceStates'
-import { cellWidth, truncateCells, wrapCells } from '../../workstation/chrome/text'
+import { truncateCells, wrapCells } from '../../workstation/chrome/text'
 import {
-    LogInkHistoryFetchArgs,
     LogInkSidebarTab,
     LogInkState,
     LogInkView,
@@ -288,6 +279,7 @@ import { renderBranchesSurface } from '../../workstation/surfaces/branches'
 import { renderComposeSurface } from '../../workstation/surfaces/compose'
 import { renderConflictsSurface } from '../../workstation/surfaces/conflicts'
 import { renderDiffSurface } from '../../workstation/surfaces/diff'
+import { renderHistoryPanel } from '../../workstation/surfaces/history'
 import { renderPullRequestSurface } from '../../workstation/surfaces/pullRequest'
 import { renderReflogSurface } from '../../workstation/surfaces/reflog'
 import { renderStashSurface } from '../../workstation/surfaces/stash'
@@ -2959,263 +2951,6 @@ function renderMainPanel(
   )
 }
 
-function renderHistoryPanel(
-  h: typeof ReactTypes.createElement,
-  components: LogInkComponents,
-  state: LogInkState,
-  context: LogInkContext,
-  bodyRows: number,
-  width: number,
-  theme: LogInkTheme,
-  hasMoreCommits: boolean,
-  loadingMoreCommits: boolean
-): ReactTypes.ReactElement {
-  const { Box, Text } = components
-  const focused = state.focus === 'commits'
-  const worktree = context.worktree
-  const worktreeDirty = Boolean(
-    worktree && (worktree.stagedCount + worktree.unstagedCount + worktree.untrackedCount) > 0
-  )
-  // The synthetic "(+) new commit" row only appears when the worktree is
-  // dirty AND the visible window is anchored at the top of the list — i.e.
-  // the first real commit (selectedIndex 0) is in view. Scroll past that
-  // and the row slides off naturally; the user can `gg` to bring it back.
-  const showPendingRow = worktreeDirty &&
-    !state.filter &&
-    state.selectedIndex === 0
-  const listRows = Math.max(3, bodyRows - (showPendingRow ? 5 : 4))
-  const visible = getVisibleLogInkHistory(state, listRows)
-  const loadState = loadingMoreCommits
-    ? 'loading older commits'
-    : hasMoreCommits
-      ? 'more below'
-      : 'loaded'
-  const title = `${state.filteredCommits.length}/${state.commits.length} commits`
-  const graphMode = state.fullGraph ? 'full graph' : 'compact graph'
-
-  const pendingRowSelected = showPendingRow && Boolean(state.pendingCommitFocused) && focused
-  // Real-commit selection is suppressed while the cursor is on the pending
-  // row so the visible cursor only renders in one place at a time.
-  const realSelectionSuppressed = state.pendingCommitFocused
-
-  const pendingNode = showPendingRow
-    ? renderPendingCommitRow(h, Text, worktree!, pendingRowSelected, theme)
-    : null
-
-  return h(Box, {
-    borderColor: focusBorderColor(theme, focused),
-    borderStyle: theme.borderStyle,
-    flexDirection: 'column',
-    flexShrink: 0,
-    paddingX: 1,
-    width,
-  },
-  h(Box, { justifyContent: 'space-between' },
-    h(Text, { bold: true }, panelTitle('Commits', focused)),
-    h(Text, { dimColor: true }, `${title} | ${graphMode} | ${loadState}`)
-  ),
-  // Server-side filter indicator (#776). Only rendered when the user
-  // has an active path:/author: prefix; clears when they Ctrl+U.
-  ...(state.historyFetchArgs
-    ? [h(Text, { key: 'history-fetch-indicator', dimColor: true },
-        `filter: ${formatHistoryFetchArgs(state.historyFetchArgs)}  (ctrl+u in / to clear)`)]
-    : []),
-  ...(pendingNode ? [pendingNode] : []),
-  visible.items.length === 0
-    ? h(Text, { dimColor: true }, state.bootLoading
-        ? formatLogInkLoading({ resource: 'commits' })
-        : formatLogInkHistoryEmpty({
-          filter: state.filter,
-          totalCommits: state.commits.length,
-        }))
-    : visible.items.map((item, index) => {
-      if (item.type === 'graph') {
-        // Graph-only rows are git's lane-closure scaffolding (`|/`,
-        // `|\`, etc.) — they're real topology but visually they look
-        // like blank rows that the user might wonder if they
-        // accidentally skipped a commit on (#831). Render dim-on-dim
-        // so they retreat as connectors rather than competing with
-        // commit rows for the eye's attention.
-        if (item.laneSegments && !theme.ascii) {
-          return h(Text, { key: `graph-${index}-${item.graph}`, dimColor: true },
-            ...renderLaneSegmentSpans(
-              h, Text, item.laneSegments, theme, visible.graphWidth, `g${index}`,
-              { forceDim: true }
-            ))
-        }
-        return h(Text, {
-          key: `graph-${index}-${item.graph}`,
-          color: theme.noColor ? undefined : theme.colors.muted,
-          dimColor: true,
-        }, truncate(substituteGraphChars(
-          item.graph.padEnd(visible.graphWidth),
-          { ascii: theme.ascii }
-        ), Math.max(8, width - 4)))
-      }
-
-      return renderCommitHistoryRow(
-        h, Text, item.commit, item.graph, visible.graphWidth,
-        Boolean(item.selected) && !realSelectionSuppressed, theme, index,
-        width, item.laneSegments
-      )
-    }))
-}
-
-/**
- * Render `LaneSegment[]` as a flat list of Text spans, one per lane
- * (#791 stage 2). Each segment paints in its lane's palette color so
- * the eye can follow a branch column-by-column; segments without a
- * lane id (spaces, padding, decorations) fall back to the muted graph
- * color so they visually recede.
- *
- * Final padding is appended as its own span so callers do not need to
- * pre-pad the graph string before computing lane segments.
- */
-function renderLaneSegmentSpans(
-  h: typeof ReactTypes.createElement,
-  Text: LogInkComponents['Text'],
-  segments: LaneSegment[],
-  theme: LogInkTheme,
-  padTo: number,
-  keyPrefix: string,
-  options: { forceDim?: boolean } = {}
-): ReactTypes.ReactElement[] {
-  const muted = theme.noColor ? undefined : theme.colors.muted
-  const elements: ReactTypes.ReactElement[] = []
-  let totalLen = 0
-
-  segments.forEach((seg, idx) => {
-    const laneColor = getLaneColor(seg.laneId, theme)
-    elements.push(h(Text, {
-      key: `${keyPrefix}-${idx}`,
-      color: laneColor ?? muted,
-      // Ink does not cascade dimColor from a parent Text to children,
-      // so the caller's "this whole row should fade" intent has to
-      // travel here as an explicit flag (#831). Used for graph-only
-      // lane-closure rows, where the lane colors otherwise compete
-      // for attention with the commits they connect.
-      dimColor: options.forceDim || (theme.noColor && seg.laneId === undefined),
-    }, seg.text))
-    totalLen += seg.text.length
-  })
-
-  if (padTo > totalLen) {
-    elements.push(h(Text, { key: `${keyPrefix}-pad` }, ' '.repeat(padTo - totalLen)))
-  }
-
-  return elements
-}
-
-/**
- * Render a single commit row with each segment in its own colored span.
- * Graph chars render in `theme.colors.muted` so the topology visually
- * recedes; shortHash takes the accent so the eye lands on the commit
- * identifier first; date is dimmed; message is normal; ref labels
- * (`[HEAD -> main]`) trail in accent. Selection styling is applied at
- * the outer span via `backgroundColor` / `inverse` so the highlight
- * fills the whole row regardless of inner-span coloring.
- *
- * Truncation is per-segment so the variable-length message field gets
- * the leftover budget after fixed segments are accounted for.
- */
-function renderCommitHistoryRow(
-  h: typeof ReactTypes.createElement,
-  Text: LogInkComponents['Text'],
-  commit: GitLogCommitRow,
-  graph: string,
-  graphWidth: number,
-  selected: boolean,
-  theme: LogInkTheme,
-  index: number,
-  panelWidth: number,
-  laneSegments?: LaneSegment[]
-): ReactTypes.ReactElement {
-  const refs = formatInkRefLabels(commit.refs)
-  // Total cells available to the row content. Earlier revisions used a
-  // hardcoded 140 here, which let row content overflow whenever the
-  // panel was narrower than that — Ink would wrap onto a second visual
-  // line and the next commit's graph indicator landed against the wrap
-  // continuation rather than its own commit (#830). Subtracting 4
-  // accounts for the panel's left + right border + 1-cell padding.
-  const totalWidth = Math.max(20, panelWidth - 4)
-  const fixedWidth = graphWidth + 1 + commit.shortHash.length + 1 + commit.date.length + 1
-  // Refs trail the message and shrink first when the row is narrow:
-  // the user can always see the full ref list in the inspector, so
-  // the headline subject keeps priority over decoration.
-  const refsRoom = Math.max(0, totalWidth - fixedWidth - 8)
-  const refsTrunc = refs ? truncate(refs, refsRoom) : ''
-  const messageRoom = Math.max(8, totalWidth - fixedWidth - cellWidth(refsTrunc))
-  const message = truncate(commit.message, messageRoom)
-
-  const selectedBg = selected && !theme.noColor ? theme.colors.selection : undefined
-  const accent = theme.noColor ? undefined : theme.colors.accent
-  const muted = theme.noColor ? undefined : theme.colors.muted
-
-  // Lane-colored graph spans when full graph mode + non-ASCII rendering
-  // is in play; otherwise fall back to the legacy single-muted span so
-  // compact mode and legacy terminals stay visually unchanged.
-  const graphChildren = laneSegments && !theme.ascii
-    ? renderLaneSegmentSpans(h, Text, laneSegments, theme, graphWidth, `c${index}`)
-    : [h(Text, { color: muted, dimColor: theme.noColor },
-        substituteGraphChars(graph.padEnd(graphWidth), { ascii: theme.ascii }))]
-
-  return h(Text, {
-    key: `${commit.hash}-${index}`,
-    backgroundColor: selectedBg,
-    inverse: selected,
-  },
-  ...graphChildren,
-  ' ',
-  h(Text, { color: accent, bold: selected }, commit.shortHash),
-  ' ',
-  h(Text, { dimColor: true }, commit.date),
-  ' ',
-  h(Text, undefined, message),
-  refsTrunc ? h(Text, { color: accent }, refsTrunc) : null)
-}
-
-/**
- * Render the synthetic "(+) new commit" affordance shown above the real
- * commit list when the worktree is dirty. Pressing up at `selectedIndex 0`
- * focuses this row; pressing Enter pushes the status view so the user can
- * stage / commit.
- */
-function renderPendingCommitRow(
-  h: typeof ReactTypes.createElement,
-  Text: LogInkComponents['Text'],
-  worktree: NonNullable<LogInkContext['worktree']>,
-  selected: boolean,
-  theme: LogInkTheme
-): ReactTypes.ReactElement {
-  const parts: string[] = []
-  if (worktree.stagedCount) {
-    parts.push(`${worktree.stagedCount} staged`)
-  }
-  if (worktree.unstagedCount) {
-    parts.push(`${worktree.unstagedCount} unstaged`)
-  }
-  if (worktree.untrackedCount) {
-    parts.push(`${worktree.untrackedCount} untracked`)
-  }
-  const summary = parts.length ? parts.join(' · ') : 'pending changes'
-  const label = `${theme.ascii ? '[+]' : '(+)'} New commit · ${summary}`
-
-  return h(Text, {
-    key: 'pending-commit-row',
-    bold: true,
-    color: theme.noColor ? undefined : theme.colors.accent,
-    inverse: selected,
-    backgroundColor: selected && !theme.noColor ? theme.colors.selection : undefined,
-  }, truncate(label, 140))
-}
-
-
-function formatHistoryFetchArgs(args: LogInkHistoryFetchArgs): string {
-  const parts: string[] = []
-  if (args.author) parts.push(`--author=${args.author}`)
-  if (args.path) parts.push(`-- ${args.path}`)
-  return parts.join(' ') || 'none'
-}
 
 
 

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -1,0 +1,295 @@
+/**
+ * History surface — the commit log view (the workstation's home
+ * screen). Renders the commit list with optional graph lanes, a
+ * synthetic "(+) new commit" row when the worktree is dirty, and a
+ * server-side filter indicator when `path:` / `author:` prefixes are
+ * active.
+ *
+ * Per-row actions (open diff, copy hash, cherry-pick, revert, reset,
+ * rebase, etc.) are wired in inkInput.ts; this renderer is read-only.
+ *
+ * Extracted from `src/commands/log/inkRuntime.ts` as part of phase 5a.5
+ * of #890. The supporting helpers (`renderLaneSegmentSpans`,
+ * `renderCommitHistoryRow`, `renderPendingCommitRow`,
+ * `formatHistoryFetchArgs`) lived in inkRuntime.ts only to support
+ * this surface; they migrate together.
+ */
+
+import type * as ReactTypes from 'react'
+import { substituteGraphChars } from '../../chrome/graphChars'
+import type { LaneSegment } from '../../chrome/graphLanes'
+import { getLaneColor } from '../../chrome/graphLanes'
+import {
+  formatInkRefLabels,
+  getVisibleLogInkHistory,
+} from '../../chrome/historyRows'
+import {
+  formatLogInkHistoryEmpty,
+  formatLogInkLoading,
+} from '../../chrome/surfaceStates'
+import { cellWidth, truncateCells } from '../../chrome/text'
+import type { LogInkTheme } from '../../chrome/theme'
+import type { GitLogCommitRow } from '../../../commands/log/data'
+import type {
+  LogInkHistoryFetchArgs,
+  LogInkState,
+} from '../../../commands/log/inkViewModel'
+import type { LogInkComponents, LogInkContext } from '../../runtime/types'
+import { focusBorderColor, panelTitle } from '../../runtime/utils'
+
+function formatHistoryFetchArgs(args: LogInkHistoryFetchArgs): string {
+  const parts: string[] = []
+  if (args.author) parts.push(`--author=${args.author}`)
+  if (args.path) parts.push(`-- ${args.path}`)
+  return parts.join(' ') || 'none'
+}
+
+/**
+ * Render `LaneSegment[]` as a flat list of Text spans, one per lane
+ * (#791 stage 2). Each segment paints in its lane's palette color so
+ * the eye can follow a branch column-by-column; segments without a
+ * lane id (spaces, padding, decorations) fall back to the muted graph
+ * color so they visually recede.
+ *
+ * Final padding is appended as its own span so callers do not need to
+ * pre-pad the graph string before computing lane segments.
+ */
+function renderLaneSegmentSpans(
+  h: typeof ReactTypes.createElement,
+  Text: LogInkComponents['Text'],
+  segments: LaneSegment[],
+  theme: LogInkTheme,
+  padTo: number,
+  keyPrefix: string,
+  options: { forceDim?: boolean } = {}
+): ReactTypes.ReactElement[] {
+  const muted = theme.noColor ? undefined : theme.colors.muted
+  const elements: ReactTypes.ReactElement[] = []
+  let totalLen = 0
+
+  segments.forEach((seg, idx) => {
+    const laneColor = getLaneColor(seg.laneId, theme)
+    elements.push(h(Text, {
+      key: `${keyPrefix}-${idx}`,
+      color: laneColor ?? muted,
+      // Ink does not cascade dimColor from a parent Text to children,
+      // so the caller's "this whole row should fade" intent has to
+      // travel here as an explicit flag (#831). Used for graph-only
+      // lane-closure rows, where the lane colors otherwise compete
+      // for attention with the commits they connect.
+      dimColor: options.forceDim || (theme.noColor && seg.laneId === undefined),
+    }, seg.text))
+    totalLen += seg.text.length
+  })
+
+  if (padTo > totalLen) {
+    elements.push(h(Text, { key: `${keyPrefix}-pad` }, ' '.repeat(padTo - totalLen)))
+  }
+
+  return elements
+}
+
+/**
+ * Render a single commit row with each segment in its own colored span.
+ * Graph chars render in `theme.colors.muted` so the topology visually
+ * recedes; shortHash takes the accent so the eye lands on the commit
+ * identifier first; date is dimmed; message is normal; ref labels
+ * (`[HEAD -> main]`) trail in accent. Selection styling is applied at
+ * the outer span via `backgroundColor` / `inverse` so the highlight
+ * fills the whole row regardless of inner-span coloring.
+ *
+ * Truncation is per-segment so the variable-length message field gets
+ * the leftover budget after fixed segments are accounted for.
+ */
+function renderCommitHistoryRow(
+  h: typeof ReactTypes.createElement,
+  Text: LogInkComponents['Text'],
+  commit: GitLogCommitRow,
+  graph: string,
+  graphWidth: number,
+  selected: boolean,
+  theme: LogInkTheme,
+  index: number,
+  panelWidth: number,
+  laneSegments?: LaneSegment[]
+): ReactTypes.ReactElement {
+  const refs = formatInkRefLabels(commit.refs)
+  // Total cells available to the row content. Earlier revisions used a
+  // hardcoded 140 here, which let row content overflow whenever the
+  // panel was narrower than that — Ink would wrap onto a second visual
+  // line and the next commit's graph indicator landed against the wrap
+  // continuation rather than its own commit (#830). Subtracting 4
+  // accounts for the panel's left + right border + 1-cell padding.
+  const totalWidth = Math.max(20, panelWidth - 4)
+  const fixedWidth = graphWidth + 1 + commit.shortHash.length + 1 + commit.date.length + 1
+  // Refs trail the message and shrink first when the row is narrow:
+  // the user can always see the full ref list in the inspector, so
+  // the headline subject keeps priority over decoration.
+  const refsRoom = Math.max(0, totalWidth - fixedWidth - 8)
+  const refsTrunc = refs ? truncateCells(refs, refsRoom) : ''
+  const messageRoom = Math.max(8, totalWidth - fixedWidth - cellWidth(refsTrunc))
+  const message = truncateCells(commit.message, messageRoom)
+
+  const selectedBg = selected && !theme.noColor ? theme.colors.selection : undefined
+  const accent = theme.noColor ? undefined : theme.colors.accent
+  const muted = theme.noColor ? undefined : theme.colors.muted
+
+  // Lane-colored graph spans when full graph mode + non-ASCII rendering
+  // is in play; otherwise fall back to the legacy single-muted span so
+  // compact mode and legacy terminals stay visually unchanged.
+  const graphChildren = laneSegments && !theme.ascii
+    ? renderLaneSegmentSpans(h, Text, laneSegments, theme, graphWidth, `c${index}`)
+    : [h(Text, { color: muted, dimColor: theme.noColor },
+        substituteGraphChars(graph.padEnd(graphWidth), { ascii: theme.ascii }))]
+
+  return h(Text, {
+    key: `${commit.hash}-${index}`,
+    backgroundColor: selectedBg,
+    inverse: selected,
+  },
+  ...graphChildren,
+  ' ',
+  h(Text, { color: accent, bold: selected }, commit.shortHash),
+  ' ',
+  h(Text, { dimColor: true }, commit.date),
+  ' ',
+  h(Text, undefined, message),
+  refsTrunc ? h(Text, { color: accent }, refsTrunc) : null)
+}
+
+/**
+ * Render the synthetic "(+) new commit" affordance shown above the real
+ * commit list when the worktree is dirty. Pressing up at `selectedIndex 0`
+ * focuses this row; pressing Enter pushes the status view so the user can
+ * stage / commit.
+ */
+function renderPendingCommitRow(
+  h: typeof ReactTypes.createElement,
+  Text: LogInkComponents['Text'],
+  worktree: NonNullable<LogInkContext['worktree']>,
+  selected: boolean,
+  theme: LogInkTheme
+): ReactTypes.ReactElement {
+  const parts: string[] = []
+  if (worktree.stagedCount) {
+    parts.push(`${worktree.stagedCount} staged`)
+  }
+  if (worktree.unstagedCount) {
+    parts.push(`${worktree.unstagedCount} unstaged`)
+  }
+  if (worktree.untrackedCount) {
+    parts.push(`${worktree.untrackedCount} untracked`)
+  }
+  const summary = parts.length ? parts.join(' · ') : 'pending changes'
+  const label = `${theme.ascii ? '[+]' : '(+)'} New commit · ${summary}`
+
+  return h(Text, {
+    key: 'pending-commit-row',
+    bold: true,
+    color: theme.noColor ? undefined : theme.colors.accent,
+    inverse: selected,
+    backgroundColor: selected && !theme.noColor ? theme.colors.selection : undefined,
+  }, truncateCells(label, 140))
+}
+
+export function renderHistoryPanel(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  bodyRows: number,
+  width: number,
+  theme: LogInkTheme,
+  hasMoreCommits: boolean,
+  loadingMoreCommits: boolean
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const focused = state.focus === 'commits'
+  const worktree = context.worktree
+  const worktreeDirty = Boolean(
+    worktree && (worktree.stagedCount + worktree.unstagedCount + worktree.untrackedCount) > 0
+  )
+  // The synthetic "(+) new commit" row only appears when the worktree is
+  // dirty AND the visible window is anchored at the top of the list — i.e.
+  // the first real commit (selectedIndex 0) is in view. Scroll past that
+  // and the row slides off naturally; the user can `gg` to bring it back.
+  const showPendingRow = worktreeDirty &&
+    !state.filter &&
+    state.selectedIndex === 0
+  const listRows = Math.max(3, bodyRows - (showPendingRow ? 5 : 4))
+  const visible = getVisibleLogInkHistory(state, listRows)
+  const loadState = loadingMoreCommits
+    ? 'loading older commits'
+    : hasMoreCommits
+      ? 'more below'
+      : 'loaded'
+  const title = `${state.filteredCommits.length}/${state.commits.length} commits`
+  const graphMode = state.fullGraph ? 'full graph' : 'compact graph'
+
+  const pendingRowSelected = showPendingRow && Boolean(state.pendingCommitFocused) && focused
+  // Real-commit selection is suppressed while the cursor is on the pending
+  // row so the visible cursor only renders in one place at a time.
+  const realSelectionSuppressed = state.pendingCommitFocused
+
+  const pendingNode = showPendingRow
+    ? renderPendingCommitRow(h, Text, worktree!, pendingRowSelected, theme)
+    : null
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    flexShrink: 0,
+    paddingX: 1,
+    width,
+  },
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle('Commits', focused)),
+    h(Text, { dimColor: true }, `${title} | ${graphMode} | ${loadState}`)
+  ),
+  // Server-side filter indicator (#776). Only rendered when the user
+  // has an active path:/author: prefix; clears when they Ctrl+U.
+  ...(state.historyFetchArgs
+    ? [h(Text, { key: 'history-fetch-indicator', dimColor: true },
+        `filter: ${formatHistoryFetchArgs(state.historyFetchArgs)}  (ctrl+u in / to clear)`)]
+    : []),
+  ...(pendingNode ? [pendingNode] : []),
+  visible.items.length === 0
+    ? h(Text, { dimColor: true }, state.bootLoading
+        ? formatLogInkLoading({ resource: 'commits' })
+        : formatLogInkHistoryEmpty({
+          filter: state.filter,
+          totalCommits: state.commits.length,
+        }))
+    : visible.items.map((item, index) => {
+      if (item.type === 'graph') {
+        // Graph-only rows are git's lane-closure scaffolding (`|/`,
+        // `|\`, etc.) — they're real topology but visually they look
+        // like blank rows that the user might wonder if they
+        // accidentally skipped a commit on (#831). Render dim-on-dim
+        // so they retreat as connectors rather than competing with
+        // commit rows for the eye's attention.
+        if (item.laneSegments && !theme.ascii) {
+          return h(Text, { key: `graph-${index}-${item.graph}`, dimColor: true },
+            ...renderLaneSegmentSpans(
+              h, Text, item.laneSegments, theme, visible.graphWidth, `g${index}`,
+              { forceDim: true }
+            ))
+        }
+        return h(Text, {
+          key: `graph-${index}-${item.graph}`,
+          color: theme.noColor ? undefined : theme.colors.muted,
+          dimColor: true,
+        }, truncateCells(substituteGraphChars(
+          item.graph.padEnd(visible.graphWidth),
+          { ascii: theme.ascii }
+        ), Math.max(8, width - 4)))
+      }
+
+      return renderCommitHistoryRow(
+        h, Text, item.commit, item.graph, visible.graphWidth,
+        Boolean(item.selected) && !realSelectionSuppressed, theme, index,
+        width, item.laneSegments
+      )
+    }))
+}


### PR DESCRIPTION
Fifth and final surface-family extraction. The history surface is the workstation's **home screen** — commit list with optional graph lanes, synthetic pending-commit row, and server-side filter indicator. Pulls the family of five paired functions out of inkRuntime in one cut, since they only call each other.

## What moves

All five into `src/workstation/surfaces/history/index.ts` (295 LOC):

| Function | Role |
|---|---|
| `renderHistoryPanel` | The surface itself (exported) |
| `renderLaneSegmentSpans` | [#791](https://github.com/gfargo/coco/issues/791) stage 2 lane-color rendering |
| `renderCommitHistoryRow` | Per-commit row with theme-aware spans |
| `renderPendingCommitRow` | The `(+) new commit` affordance when worktree is dirty |
| `formatHistoryFetchArgs` | `path: ` / `author: ` filter indicator |

Only `renderHistoryPanel` is exported — the rest are private to the module, mirroring how they lived as inkRuntime locals.

## 🎉 All 12 main surfaces are now extracted

| Phase | Surfaces |
|---|---|
| **5a.1** | reflog, bisect, stash, worktrees |
| **5a.2** | compose, branches, tags, pullRequest |
| **5a.3** | status + conflicts |
| **5a.4** | diff (+ split-diff helpers in `runtime/splitDiff.ts`) |
| **5a.5** | **history** (this PR) |

`src/workstation/surfaces/` now has **13 directories** (12 main surfaces + conflicts).

## Stats

| Metric | Pre-#890 | Post-5a.4 | **Post-5a.5 (this)** |
|---|---|---|---|
| `inkRuntime.ts` LOC | 6,039 | 4,305 | **4,040 (-265 this PR, -1,999 / -33% cumulative)** |
| Surfaces extracted | 0 | 11 | **12 of 12 main + 1 conflicts** |
| Diff (this PR) | — | — | 2 files, 297 ins / 267 del |

## What's left in `inkRuntime.ts` at 4,040 LOC

| Area | Approx LOC | Future phase |
|---|---|---|
| `LogInkApp` React component | ~1,940 | **5b** |
| Chrome render helpers (header, sidebar, footer, overlays, command palette) | ~1,200 | **5a.6** |
| Detail panel + inspector family | ~600 | **5a.6** |
| Preview panels (branch, tag, stash) | ~150 | **5a.6** |
| Imports + small orchestration + `startInkInteractiveLog` + `loadInkRuntime` | ~150 | stays |

Phase 5a.6 = chrome + detail + preview promotion. Phase 5b = `LogInkApp` itself. After both, `inkRuntime.ts` should land in the **150–300 LOC** range — pure runtime entry point.

## Imports pruned post-extraction

ESLint flagged 9 imports that became unused after history's deletion; all pruned:
- `GitLogCommitRow` (commands/log/data)
- `formatInkRefLabels`, `getVisibleLogInkHistory` (whole `chrome/historyRows` import)
- `substituteGraphChars` (whole `chrome/graphChars` import)
- `LaneSegment`, `getLaneColor` (whole `chrome/graphLanes` import)
- `formatLogInkHistoryEmpty` (chrome/surfaceStates)
- `cellWidth` (chrome/text)
- `LogInkHistoryFetchArgs` (commands/log/inkViewModel)

That `chrome/historyRows` / `chrome/graphChars` / `chrome/graphLanes` imports went away entirely is a clean signal: those modules are now consumed exclusively by per-surface code, not by the orchestration layer. Exactly the dependency direction the workstation architecture is supposed to enforce.

## Validation

- `tsc --noEmit`: clean
- `eslint src`: clean
- Full Jest suite: **680/680 suites, 6571/6571 tests passing** — same baseline as post-5a.4
- No behavior change — history renders byte-identically before/after across all branches (empty, loading, with/without graph mode, with/without pending row, with/without filter)

Closes phase 5a.5 of [#890](https://github.com/gfargo/coco/issues/890).