### PR TITLE
feat(workstation): wire create-pr keystroke + seed body from coco changelog

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -2074,6 +2074,105 @@ describe('log Ink input interactions', () => {
       })
     })
 
+    it('C globally starts the create-pull-request flow (changelog seed + prompt)', () => {
+      // From the history view — `C` should start the PR creation
+      // workflow. The runtime callback (in app.ts) handles the
+      // changelog-fetch + prompt-open side effects; from the input
+      // handler's perspective it's a single event the dispatcher
+      // routes to `startCreatePullRequest`.
+      const historyState = createLogInkState(rows, { activeView: 'history' })
+      expect(getLogInkInputEvents(historyState, 'C')).toEqual([
+        { type: 'startCreatePullRequest' },
+      ])
+
+      // From the branches view too — the natural starting point when
+      // looking at the current branch.
+      const branchesState = createLogInkState(rows, { activeView: 'branches' })
+      expect(getLogInkInputEvents(branchesState, 'C')).toEqual([
+        { type: 'startCreatePullRequest' },
+      ])
+
+      // From the PR view (when no PR exists yet). The runtime callback
+      // takes care of the "already has an open PR" guard; the input
+      // handler unconditionally fires.
+      const prState = createLogInkState(rows, { activeView: 'pull-request' })
+      expect(getLogInkInputEvents(prState, 'C')).toEqual([
+        { type: 'startCreatePullRequest' },
+      ])
+    })
+
+    it('C is scoped away from the conflicts and compose views', () => {
+      // Conflicts: `C` means "continue the in-progress operation" when
+      // no conflicts remain, otherwise it surfaces a "resolve first"
+      // status. Either way it MUST NOT fall through to startCreate.
+      const conflictsClear = createLogInkState(rows, { activeView: 'conflicts' })
+      const conflictsBlocked = createLogInkState(rows, { activeView: 'conflicts' })
+      expect(getLogInkInputEvents(conflictsClear, 'C', {}, { conflictFileCount: 0 }))
+        .toEqual([{ type: 'runWorkflowAction', id: 'continue-operation' }])
+      expect(getLogInkInputEvents(conflictsBlocked, 'C', {}, { conflictFileCount: 2 })[0])
+        .toMatchObject({
+          type: 'action',
+          action: { type: 'setStatus', value: 'Resolve all conflicts before continuing' },
+        })
+
+      // Compose: claims the keystroke with an explicit "finish draft
+      // first" status so the user mid-draft doesn't fat-finger their
+      // way out. Without this guard the keystroke would fall through
+      // to the generic workflow-by-key dispatch at the bottom of
+      // getLogInkInputEvents.
+      const composeState = createLogInkState(rows, { activeView: 'compose' })
+      expect(getLogInkInputEvents(composeState, 'C')).toEqual([
+        {
+          type: 'action',
+          action: { type: 'setStatus', value: 'Finish or cancel the commit draft before creating a PR.' },
+        },
+      ])
+    })
+
+    it('submitting a create-pr prompt dispatches runWorkflowAction with the raw multi-line value', () => {
+      const state = applyLogInkAction(createLogInkState(rows), {
+        type: 'openInputPrompt',
+        kind: 'create-pr',
+        label: 'Create PR',
+        initial: 'feat: workstation refactor\n\nLine 1 of body.\nLine 2 of body.',
+        multiline: true,
+      })
+
+      // Ctrl+D submits multi-line prompts. The payload arrives as the
+      // raw value — the workflow handler in app.ts splits title (line 1)
+      // from body (lines 2+).
+      const events = getLogInkInputEvents(state, 'd', { ctrl: true })
+      expect(events).toEqual([
+        {
+          type: 'runWorkflowAction',
+          id: 'create-pr',
+          payload: 'feat: workstation refactor\n\nLine 1 of body.\nLine 2 of body.',
+        },
+        { type: 'action', action: { type: 'closeInputPrompt' } },
+      ])
+    })
+
+    it('submitting an empty create-pr prompt falls back to the generic empty-value guard', () => {
+      const state = applyLogInkAction(createLogInkState(rows), {
+        type: 'openInputPrompt',
+        kind: 'create-pr',
+        label: 'Create PR',
+        multiline: true,
+      })
+
+      // Ctrl+D on an empty multi-line prompt is rejected by the generic
+      // empty-value check that runs before the per-kind dispatch. The
+      // prompt stays open and the user sees the same "enter a value or
+      // press esc to cancel" status as every other empty submission.
+      const events = getLogInkInputEvents(state, 'd', { ctrl: true })
+      expect(events).toEqual([
+        {
+          type: 'action',
+          action: { type: 'setStatus', value: 'enter a value or press esc to cancel' },
+        },
+      ])
+    })
+
     it('keeps single-line prompts (create-branch, reset-mode, etc.) untouched', () => {
       // Sanity check: opening a non-multiline prompt and pressing
       // Enter still submits as before — the new dispatch path is

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -49,6 +49,7 @@ export type LogInkInputEvent =
   | { type: 'revertSelectedHunk' }
   | { type: 'createManualCommit' }
   | { type: 'runAiCommitDraft' }
+  | { type: 'startCreatePullRequest' }
   | { type: 'runWorkflowAction'; id: string; payload?: string }
   | { type: 'openFileInEditor'; path: string }
   | { type: 'yankFromActiveView'; short?: boolean }
@@ -662,6 +663,17 @@ function submitInputPrompt(state: LogInkState): LogInkInputEvent[] {
   if (state.inputPrompt.kind === 'pr-request-changes') {
     return [
       action({ type: 'setPendingConfirmation', value: 'request-changes-pr', payload: value }),
+      action({ type: 'closeInputPrompt' }),
+    ]
+  }
+  if (state.inputPrompt.kind === 'create-pr') {
+    // Multi-line content: line 1 is the PR title, lines 2+ are the body
+    // (leading blank line tolerated). The generic empty-value guard
+    // above (line ~627) covers truly-empty submissions; the workflow
+    // handler in app.ts has the belt-and-suspenders title check for
+    // the "newline-then-body" edge.
+    return [
+      { type: 'runWorkflowAction', id: 'create-pr', payload: value },
       action({ type: 'closeInputPrompt' }),
     ]
   }
@@ -2012,6 +2024,25 @@ export function getLogInkInputEvents(
   // the global `C` (Create PR) binding when conflicts remain.
   if (inputValue === 'C' && state.activeView === 'conflicts') {
     return [action({ type: 'setStatus', value: 'Resolve all conflicts before continuing' })]
+  }
+  // Global `C` — create a pull request from the current branch. The
+  // runtime callback handles pre-flight (current branch resolution,
+  // provider check) and seeds the input prompt with a changelog-derived
+  // title + body before handing control back to the user for editing.
+  // Conflicts view handles `C` above (continue-operation). Compose view
+  // gets an explicit guard — claiming the keystroke with a status
+  // message — so users mid-draft don't fat-finger out of their commit
+  // into a PR-creation flow. Without this guard the keystroke would
+  // fall through to the generic workflow-by-key dispatch at the end of
+  // this function, which would fire `create-pr` to its handler.
+  if (inputValue === 'C' && state.activeView === 'compose') {
+    return [action({
+      type: 'setStatus',
+      value: 'Finish or cancel the commit draft before creating a PR.',
+    })]
+  }
+  if (inputValue === 'C' && state.activeView !== 'conflicts') {
+    return [{ type: 'startCreatePullRequest' }]
   }
 
   // `c` on a stash diff cherry-picks the file under the cursor —

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -325,6 +325,7 @@ export type LogInkInputPromptKind =
   | 'pr-merge-strategy'
   | 'pr-comment'
   | 'pr-request-changes'
+  | 'create-pr'
 
 export type LogInkInputPromptState = {
   kind: LogInkInputPromptKind

--- a/src/git/aiActions.test.ts
+++ b/src/git/aiActions.test.ts
@@ -4,6 +4,7 @@ import {
   aiActionTestInternals,
   estimateLogAiActionImpact,
   runLogAiAction,
+  runPullRequestBodyWorkflow,
 } from './aiActions'
 
 jest.mock('../commands/changelog/handler', () => ({
@@ -152,6 +153,83 @@ describe('log AI actions', () => {
       message: 'Generated title',
       details: ['[llm:summary] command=changelog calls=1 promptTokens=123'],
       editable: 'Generated title\nGenerated body',
+    })
+  })
+
+  describe('runPullRequestBodyWorkflow', () => {
+    it('runs the changelog against the base branch and splits title from body', async () => {
+      mockedChangelogHandler.mockImplementation(async () => {
+        process.stdout.write([
+          'feat: workstation refactor',
+          '',
+          '- promote git data layer to src/git/',
+          '- promote workstation chrome to src/workstation/',
+          '- split inkRuntime into per-surface modules',
+        ].join('\n'))
+      })
+
+      await expect(runPullRequestBodyWorkflow({ baseBranch: 'main' })).resolves.toEqual({
+        ok: true,
+        message: 'feat: workstation refactor',
+        details: [],
+        editable: [
+          'feat: workstation refactor',
+          '',
+          '- promote git data layer to src/git/',
+          '- promote workstation chrome to src/workstation/',
+          '- split inkRuntime into per-surface modules',
+        ].join('\n'),
+        title: 'feat: workstation refactor',
+        body: [
+          '- promote git data layer to src/git/',
+          '- promote workstation chrome to src/workstation/',
+          '- split inkRuntime into per-surface modules',
+        ].join('\n'),
+      })
+
+      // The handler was called with the base branch on the argv. Other
+      // changelog options stay at their defaults from createChangelogArgv.
+      const argv = mockedChangelogHandler.mock.calls[0][0]
+      expect(argv).toMatchObject({ branch: 'main', mode: 'stdout' })
+    })
+
+    it('defaults the base branch to "main" when none is supplied', async () => {
+      mockedChangelogHandler.mockImplementation(async () => {
+        process.stdout.write('feat: x\n\nBody.')
+      })
+
+      await runPullRequestBodyWorkflow()
+
+      const argv = mockedChangelogHandler.mock.calls[0][0]
+      expect(argv.branch).toBe('main')
+    })
+
+    it('falls back to a single-line title when the changelog has no body', async () => {
+      mockedChangelogHandler.mockImplementation(async () => {
+        process.stdout.write('feat: tiny one-liner')
+      })
+
+      const result = await runPullRequestBodyWorkflow({ baseBranch: 'develop' })
+
+      expect(result.ok).toBe(true)
+      expect(result.title).toBe('feat: tiny one-liner')
+      expect(result.body).toBe('')
+    })
+
+    it('propagates changelog failures without producing a title/body pair', async () => {
+      mockedChangelogHandler.mockImplementation(async () => {
+        throw new Error('no commits in range')
+      })
+
+      const result = await runPullRequestBodyWorkflow({ baseBranch: 'main' })
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toContain('no commits in range')
+      // Title / body fields are absent on failure — the caller is expected
+      // to open the prompt with empty fields and let the user author by
+      // hand.
+      expect(result.title).toBeUndefined()
+      expect(result.body).toBeUndefined()
     })
   })
 })

--- a/src/git/aiActions.ts
+++ b/src/git/aiActions.ts
@@ -215,6 +215,75 @@ export async function runLogAiAction(
   }))
 }
 
+/**
+ * Generate a pull-request body for the current branch by running
+ * `coco changelog --branch <base>` and parsing the title / content
+ * out of the captured stdout.
+ *
+ * The changelog handler emits `${title}\n\n${content}[\n\nPart of <ticket>]`
+ * (see `commands/changelog/handler.ts` line 306). We split on the first
+ * blank-line boundary so the caller gets a clean title + body pair to
+ * pre-fill the PR creation prompt with. Ticket footer (when present)
+ * stays in the body so the resulting PR keeps the reference.
+ *
+ * Captures the raw stdout (rather than going through `runChangelogAction`,
+ * which strips blank lines via its `compactOutputLines` filter) so the
+ * title-vs-body separator survives intact.
+ *
+ * Returns the standard LogAiActionResult plus extracted `title` / `body`
+ * fields. Falls back to undefined `title` / `body` when the changelog
+ * fails or produces no parseable output; the caller is expected to
+ * surface that as a prompt with empty fields rather than aborting.
+ */
+export async function runPullRequestBodyWorkflow(
+  input: { baseBranch?: string } = {}
+): Promise<LogAiActionResult & { title?: string; body?: string }> {
+  const baseBranch = input.baseBranch || 'main'
+  const argv = createChangelogArgv({ branch: baseBranch })
+
+  let raw = ''
+  try {
+    raw = await captureStdout(() => changelogHandler(argv, new Logger({
+      verbose: true,
+      silent: false,
+    })))
+  } catch (error) {
+    return {
+      ok: false,
+      message: (error as Error).message,
+    }
+  }
+
+  const text = raw.trim()
+  if (!text) {
+    return {
+      ok: false,
+      message: 'No changelog output produced — branch may have no commits ahead of base.',
+    }
+  }
+
+  // First blank-line boundary separates title from body. Falls back to
+  // "everything is the title" when no blank line is found — typical of
+  // very small changesets where the changelog content collapsed to one
+  // line.
+  const blankIdx = text.indexOf('\n\n')
+  const title = blankIdx > 0 ? text.slice(0, blankIdx).trim() : text.split('\n')[0].trim()
+  const body = blankIdx > 0 ? text.slice(blankIdx + 2).trim() : ''
+
+  // Keep the standard LogAiActionResult shape (message + telemetry
+  // details + editable text) so palette callers get a consistent
+  // surface. The captured telemetry lines are dropped here — the PR
+  // body should be the actionable content, not the LLM trace.
+  return {
+    ok: true,
+    message: title || 'Pull request body drafted.',
+    details: [],
+    editable: text,
+    title,
+    body,
+  }
+}
+
 export const aiActionTestInternals = {
   compactOutputLines,
   createChangelogArgv,

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -231,10 +231,12 @@ import {
     approvePullRequest,
     closePullRequest,
     commentPullRequest,
+    createPullRequest,
     isPullRequestMergeStrategy,
     mergePullRequest,
     requestChangesPullRequest,
 } from '../../git/pullRequestActions'
+import { runPullRequestBodyWorkflow } from '../../git/aiActions'
 import {
     findStashFileForOffset,
     getStashDiff,
@@ -1246,6 +1248,78 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     dispatch({ type: 'setStatus', value: result.message })
   }, [dispatch])
 
+  // `C` keystroke handler — start the create-pull-request flow. Resolves
+  // the head + base branches from the live context, runs
+  // `coco changelog --branch <base>` (via `runPullRequestBodyWorkflow`)
+  // to seed a title + body, then opens a multi-line input prompt
+  // pre-filled with that content for the user to edit before submission.
+  //
+  // On submit, the workflow handler `'create-pr'` parses the prompt
+  // value (line 1 = title, lines 2+ = body) and runs
+  // `createPullRequest({ base, head, title, body })`. If anything in the
+  // pre-flight goes sideways (no current branch, no provider, gh CLI
+  // missing) we surface the failure on the status line and skip the
+  // prompt entirely — better than opening a prompt the user can't
+  // actually submit successfully.
+  const startCreatePullRequest = React.useCallback(async () => {
+    const head = context.branches?.currentBranch || context.provider?.currentBranch
+    if (!head) {
+      dispatch({ type: 'setStatus', value: 'No current branch to create a PR from.' })
+      return
+    }
+    const defaultBranch = context.provider?.repository.defaultBranch
+    if (!defaultBranch) {
+      dispatch({ type: 'setStatus', value: 'No default branch detected — is the GitHub remote configured?' })
+      return
+    }
+    if (head === defaultBranch) {
+      dispatch({ type: 'setStatus', value: `Current branch is ${defaultBranch}; check out a feature branch first.` })
+      return
+    }
+    if (context.pullRequest?.currentPullRequest || context.provider?.currentPullRequest) {
+      const existing = context.pullRequest?.currentPullRequest || context.provider?.currentPullRequest
+      dispatch({
+        type: 'setStatus',
+        value: existing
+          ? `PR #${existing.number} already open for ${head}. Use the PR view to manage it.`
+          : `A pull request is already open for ${head}.`,
+      })
+      return
+    }
+
+    dispatch({ type: 'setStatus', value: `generating PR body from changelog (vs ${defaultBranch})…` })
+    const body = await runPullRequestBodyWorkflow({ baseBranch: defaultBranch })
+
+    // Fallback shape when the changelog generation fails — open the
+    // prompt with empty title + body rather than aborting, so the user
+    // can still author the PR manually. The status line surfaces why
+    // we couldn't pre-fill.
+    const initialTitle = body.title || head.replace(/^(feat|fix|chore|docs|refactor|test)\//, '').replace(/[-_]/g, ' ')
+    const initialBody = body.body || ''
+    const initial = initialBody ? `${initialTitle}\n\n${initialBody}` : initialTitle
+
+    if (!body.ok) {
+      dispatch({ type: 'setStatus', value: `PR body generation failed: ${body.message}. Edit manually.` })
+    } else {
+      dispatch({ type: 'setStatus', value: 'PR body drafted — review and Ctrl+D to submit.' })
+    }
+
+    dispatch({
+      type: 'openInputPrompt',
+      kind: 'create-pr',
+      label: `Create PR: ${head} → ${defaultBranch}  (line 1 title · rest body · Enter newline · Ctrl+D submit)`,
+      initial,
+      multiline: true,
+    })
+  }, [
+    context.branches?.currentBranch,
+    context.provider?.currentBranch,
+    context.provider?.currentPullRequest,
+    context.provider?.repository.defaultBranch,
+    context.pullRequest?.currentPullRequest,
+    dispatch,
+  ])
+
   // Open a file in $EDITOR (or $VISUAL) by suspending Ink's hold on the
   // terminal, spawning the editor synchronously inheriting stdio, then
   // restoring the alt screen + raw mode and forcing a re-render. The
@@ -1692,6 +1766,32 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       // — input prompts validate before they reach here, but the
       // strategy guard stays as a defensive belt-and-suspenders since
       // a future palette path could call us with a raw value.
+      'create-pr': async () => {
+        // The input-prompt submit handler validates non-empty title
+        // already; this is the defensive belt-and-suspenders for
+        // future palette callers passing in a raw payload.
+        const text = (payload || '').trim()
+        if (!text) {
+          return { ok: false, message: 'Pull request title is required (first line of the prompt).' }
+        }
+        const lines = text.split('\n')
+        const title = lines[0].trim()
+        if (!title) {
+          return { ok: false, message: 'Pull request title cannot be blank.' }
+        }
+        // Body: lines 2+, with the leading blank line tolerated. Empty
+        // body is allowed — GitHub renders an empty PR body fine.
+        const body = lines.slice(1).join('\n').replace(/^\n+/, '').trimEnd()
+        const head = context.branches?.currentBranch || context.provider?.currentBranch
+        const base = context.provider?.repository.defaultBranch
+        if (!head) {
+          return { ok: false, message: 'No current branch detected.' }
+        }
+        if (!base) {
+          return { ok: false, message: 'No default branch detected. Configure the GitHub remote.' }
+        }
+        return createPullRequest({ base, head, title, body })
+      },
       'merge-pr': async () => {
         const strategy = (payload || 'merge').toLowerCase()
         if (!isPullRequestMergeStrategy(strategy)) {
@@ -2230,6 +2330,8 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         void createCommitFromCompose()
       } else if (event.type === 'runAiCommitDraft') {
         void runAiCommitDraft()
+      } else if (event.type === 'startCreatePullRequest') {
+        void startCreatePullRequest()
       } else if (event.type === 'runWorkflowAction') {
         void runWorkflowAction(event.id, event.payload)
       } else if (event.type === 'openFileInEditor') {


### PR DESCRIPTION
The first of two cross-feature integrations identified in the audit. The `create-pr` workflow has been registered in `inkWorkflows.ts` since the v0.43.0 Ink rewrite, but **no actual keystroke handler or workflow dispatcher was ever wired.** Pressing `C` on the PR view silently fell through to a generic dispatcher with no handler.

This PR finishes the integration and **adds AI-driven body pre-fill** on top, demonstrating how the workstation can leverage existing CLI commands (`coco changelog`) for in-TUI operations.

## What you get

Press `C` on any view (except `conflicts` and `compose` — both have explicit guards) to start the create-pull-request flow:

1. **Pre-flight**: resolves the current branch and the GitHub default branch; refuses if on the default branch or a PR is already open.
2. **Seed body**: runs `coco changelog --branch <default-branch>` under the hood (`runPullRequestBodyWorkflow`) to derive a structured title + body for the new PR.
3. **Edit**: a multi-line input prompt opens, pre-filled with the changelog output. Line 1 = title; lines 2+ = body. Enter inserts newlines, Ctrl+D submits, Esc cancels.
4. **Submit**: parses the prompt value and calls `createPullRequest({ base, head, title, body })`. Status line shows the URL on success.

## How it leverages existing commands

The big finding from the audit was that `runCommitDraftWorkflow` already proves the pattern for calling a CLI command from inside the TUI without spawning a subprocess. This PR applies the same recipe to `coco changelog`:

```ts
// src/git/aiActions.ts — new export
export async function runPullRequestBodyWorkflow(
  input: { baseBranch?: string } = {}
): Promise<LogAiActionResult & { title?: string; body?: string }> {
  // 1. Build synthetic argv { branch: <base>, mode: 'stdout', interactive: false }
  // 2. Capture raw stdout while invoking changelogHandler directly
  // 3. Parse on first blank-line boundary — title vs body
  // 4. Return both as separate fields on the LogAiActionResult
}
```

The changelog handler at `commands/changelog/handler.ts:306` emits exactly `${title}\n\n${content}[\n\nPart of <ticket>]`. By capturing raw stdout (rather than going through `runChangelogAction`'s `compactOutputLines` filter, which strips blank lines), the title-vs-body separator survives intact.

The ticket-id footer (extracted from the branch name by the changelog handler) lands inside the body, so the resulting PR keeps the reference automatically.

## The bug being fixed

Search the codebase for `'create-pr'`:

| Location | What it does |
|---|---|
| `inkWorkflows.ts:133` | Registers `create-pr` with key `C`, label "Create pull request" |
| `inkInput.ts:847` | **Old comment** referencing `create-pr` (no handler) |
| `app.ts` workflow handlers map | **Missing.** Falls through to "Workflow action not yet wired" status |
| `interactive.ts` | Dead non-TTY fallback's `'create-pr-title'` prompt kind |

After this PR:

| Location | What it does |
|---|---|
| `inkWorkflows.ts:133` | (unchanged — still the source of truth for the binding) |
| `inkInput.ts` | `C` → `{ type: 'startCreatePullRequest' }`; `create-pr` submit handler dispatches `runWorkflowAction` |
| `app.ts` | `startCreatePullRequest` callback + workflow handler that creates the PR |

## Files touched

| File | Δ | Why |
|---|---|---|
| `src/git/aiActions.ts` | +69 | New `runPullRequestBodyWorkflow` helper |
| `src/git/aiActions.test.ts` | +78 (4 new cases) | Coverage for the helper: success, default-base, body-less, error |
| `src/commands/log/inkViewModel.ts` | +1 | Add `'create-pr'` to `LogInkInputPromptKind` |
| `src/commands/log/inkInput.ts` | +31 | `C` keystroke handler (with conflicts + compose guards), submit-prompt branch, new event type `'startCreatePullRequest'` |
| `src/commands/log/inkInput.test.ts` | +99 (4 new cases) | Coverage: global `C`, conflicts + compose scoping, multi-line submit, empty submit fallback |
| `src/workstation/runtime/app.ts` | +102 | `startCreatePullRequest` callback (pre-flight + body fetch + prompt open), event-switch branch, `'create-pr'` workflow handler |

**Net: +380 LOC across 6 files. No deletions — pure addition.**

## Validation

- `tsc --noEmit`: clean
- `eslint src`: clean
- Full Jest suite: **680/680 suites, 6,579/6,579 tests passing** (+8 net new vs the post-0.48.0 baseline of 6,571)
- No behavior change for any other keystroke / view / workflow

## Worth a manual smoke test

When you check this out, try:

1. **Happy path**: Check out a feature branch with a few commits, run `coco ui`, press `C` on the history view. You should see the status line cycle "generating PR body…" → "PR body drafted — review and Ctrl+D to submit." then a multi-line prompt appears with the changelog content. Edit, Ctrl+D, watch it run.
2. **Already-open PR**: With an open PR for the current branch, press `C`. Status line should say "PR #N already open for X. Use the PR view to manage it."
3. **Default branch**: Check out main, press `C`. "Current branch is main; check out a feature branch first."
4. **Compose guard**: Open the compose surface (`g c`), press `C`. "Finish or cancel the commit draft before creating a PR."
5. **Conflicts guard**: With an in-progress merge with conflicts, press `C` on the conflicts view. "Resolve all conflicts before continuing."

## What's NOT in scope (deliberately)

- **Draft PR toggle.** First cut keeps the input surface minimal. The user can flip with `gh pr ready --undo` after creation. Follow-up: a `D` keybinding inside the prompt to toggle draft mode, surfaced in the prompt label.
- **PR template detection.** GitHub repos may ship `.github/PULL_REQUEST_TEMPLATE.md`. We currently ignore it. Follow-up: load template, append changelog summary, let user edit.
- **Push-before-create.** If the local branch isn't pushed, `gh pr create` fails with a clear error and the status line surfaces it. A nicer flow would detect this and offer to push first. Follow-up.

Closes the first integration item from the cross-feature audit (1 of 3).