### PR TITLE
feat(workstation): in-TUI changelog view (`L` keystroke)

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -2129,6 +2129,38 @@ describe('log Ink input interactions', () => {
       ])
     })
 
+    it('L globally starts the changelog-view flow', () => {
+      // From the history view — `L` should start the changelog flow.
+      // Runtime callback handles the changelog fetch + prompt-open
+      // side effects; from the input handler's perspective it's a
+      // single event the dispatcher routes to startChangelogView.
+      const historyState = createLogInkState(rows, { activeView: 'history' })
+      expect(getLogInkInputEvents(historyState, 'L')).toEqual([
+        { type: 'startChangelogView' },
+      ])
+
+      // From the branches view — same dispatch.
+      const branchesState = createLogInkState(rows, { activeView: 'branches' })
+      expect(getLogInkInputEvents(branchesState, 'L')).toEqual([
+        { type: 'startChangelogView' },
+      ])
+    })
+
+    it('L is scoped away from the compose view', () => {
+      // Compose: explicit guard so users mid-draft can't fat-finger
+      // out of their commit into the changelog flow.
+      const composeState = createLogInkState(rows, { activeView: 'compose' })
+      expect(getLogInkInputEvents(composeState, 'L')).toEqual([
+        {
+          type: 'action',
+          action: {
+            type: 'setStatus',
+            value: 'Finish or cancel the commit draft before generating a changelog.',
+          },
+        },
+      ])
+    })
+
     it('submitting a create-pr prompt dispatches runWorkflowAction with the raw multi-line value', () => {
       const state = applyLogInkAction(createLogInkState(rows), {
         type: 'openInputPrompt',
@@ -2172,6 +2204,31 @@ describe('log Ink input interactions', () => {
         },
       ])
     })
+
+    it('submitting a changelog-view prompt dispatches yankText with the prompt value', () => {
+      const state = applyLogInkAction(createLogInkState(rows), {
+        type: 'openInputPrompt',
+        kind: 'changelog-view',
+        label: 'Changelog: feat/x (vs main)',
+        initial: 'feat: workstation\n\n- thing one\n- thing two',
+        multiline: true,
+      })
+
+      // Ctrl+D submits the multi-line prompt. For the changelog-view
+      // kind specifically, "submit" means copy-to-clipboard — the
+      // value travels with the event so the clipboard handler can
+      // read it before the close-prompt dispatch wipes the prompt.
+      const events = getLogInkInputEvents(state, 'd', { ctrl: true })
+      expect(events).toEqual([
+        {
+          type: 'yankText',
+          value: 'feat: workstation\n\n- thing one\n- thing two',
+          label: 'changelog',
+        },
+        { type: 'action', action: { type: 'closeInputPrompt' } },
+      ])
+    })
+
 
     it('keeps single-line prompts (create-branch, reset-mode, etc.) untouched', () => {
       // Sanity check: opening a non-multiline prompt and pressing

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -50,9 +50,11 @@ export type LogInkInputEvent =
   | { type: 'createManualCommit' }
   | { type: 'runAiCommitDraft' }
   | { type: 'startCreatePullRequest' }
+  | { type: 'startChangelogView' }
   | { type: 'runWorkflowAction'; id: string; payload?: string }
   | { type: 'openFileInEditor'; path: string }
   | { type: 'yankFromActiveView'; short?: boolean }
+  | { type: 'yankText'; value: string; label: string }
 
 export type LogInkInputContext = {
   detailFileCount?: number
@@ -674,6 +676,17 @@ function submitInputPrompt(state: LogInkState): LogInkInputEvent[] {
     // the "newline-then-body" edge.
     return [
       { type: 'runWorkflowAction', id: 'create-pr', payload: value },
+      action({ type: 'closeInputPrompt' }),
+    ]
+  }
+  if (state.inputPrompt.kind === 'changelog-view') {
+    // The changelog view uses the multi-line prompt as a scrollable +
+    // editable display surface. "Submit" here means copy-to-clipboard,
+    // not run-a-workflow — the user reviewed the text and wants it.
+    // The value travels with the event so the clipboard handler reads
+    // it before the close-prompt dispatch wipes the prompt state.
+    return [
+      { type: 'yankText', value, label: 'changelog' },
       action({ type: 'closeInputPrompt' }),
     ]
   }
@@ -2043,6 +2056,23 @@ export function getLogInkInputEvents(
   }
   if (inputValue === 'C' && state.activeView !== 'conflicts') {
     return [{ type: 'startCreatePullRequest' }]
+  }
+
+  // Global `L` — generate the changelog for the current branch and
+  // open it in a multi-line review prompt. The runtime callback does
+  // the pre-flight (default-branch resolution, current-branch
+  // detection) + the changelog fetch, then opens the prompt for the
+  // user to read / edit / copy. Same scope-guard pattern as `C`:
+  // compose is explicitly intercepted with a helpful status so users
+  // mid-draft don't fat-finger out of their commit.
+  if (inputValue === 'L' && state.activeView === 'compose') {
+    return [action({
+      type: 'setStatus',
+      value: 'Finish or cancel the commit draft before generating a changelog.',
+    })]
+  }
+  if (inputValue === 'L') {
+    return [{ type: 'startChangelogView' }]
   }
 
   // `c` on a stash diff cherry-picks the file under the cursor —

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -326,6 +326,7 @@ export type LogInkInputPromptKind =
   | 'pr-comment'
   | 'pr-request-changes'
   | 'create-pr'
+  | 'changelog-view'
 
 export type LogInkInputPromptState = {
   kind: LogInkInputPromptKind

--- a/src/git/aiActions.test.ts
+++ b/src/git/aiActions.test.ts
@@ -3,6 +3,7 @@ import { runCommitWorkflow } from './commitWorkflowActions'
 import {
   aiActionTestInternals,
   estimateLogAiActionImpact,
+  runChangelogTextWorkflow,
   runLogAiAction,
   runPullRequestBodyWorkflow,
 } from './aiActions'
@@ -230,6 +231,94 @@ describe('log AI actions', () => {
       // hand.
       expect(result.title).toBeUndefined()
       expect(result.body).toBeUndefined()
+    })
+  })
+
+  describe('runChangelogTextWorkflow', () => {
+    it('returns the raw changelog output with blank lines + section structure intact', async () => {
+      mockedChangelogHandler.mockImplementation(async () => {
+        process.stdout.write([
+          'feat: workstation v0.49.0',
+          '',
+          '## Highlights',
+          '',
+          '- create-pr now seeds the body from coco changelog',
+          '- new `L` keystroke generates a changelog for the current branch',
+        ].join('\n'))
+      })
+
+      const result = await runChangelogTextWorkflow({ branch: 'main' })
+
+      expect(result.ok).toBe(true)
+      // The text field preserves blank lines unlike runChangelogAction
+      // (which strips them via compactOutputLines). That's the whole
+      // point of this helper — UI surfaces want the full prose.
+      expect(result.text).toBe([
+        'feat: workstation v0.49.0',
+        '',
+        '## Highlights',
+        '',
+        '- create-pr now seeds the body from coco changelog',
+        '- new `L` keystroke generates a changelog for the current branch',
+      ].join('\n'))
+      expect(result.message).toBe('feat: workstation v0.49.0')
+
+      const argv = mockedChangelogHandler.mock.calls[0][0]
+      expect(argv).toMatchObject({ branch: 'main', mode: 'stdout' })
+    })
+
+    it('skips leading blank lines when computing the first-line message', async () => {
+      mockedChangelogHandler.mockImplementation(async () => {
+        process.stdout.write('\n\nfeat: x\n')
+      })
+
+      const result = await runChangelogTextWorkflow({ sinceLastTag: true })
+
+      expect(result.ok).toBe(true)
+      expect(result.message).toBe('feat: x')
+    })
+
+    it('surfaces an empty-output result when the changelog produces nothing', async () => {
+      mockedChangelogHandler.mockImplementation(async () => {
+        // Common case: branch has no commits ahead of base.
+        process.stdout.write('   \n\n  ')
+      })
+
+      const result = await runChangelogTextWorkflow({ branch: 'main' })
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toContain('No changelog output')
+      expect(result.text).toBeUndefined()
+    })
+
+    it('propagates changelog handler errors', async () => {
+      mockedChangelogHandler.mockImplementation(async () => {
+        throw new Error('LLM provider not configured')
+      })
+
+      const result = await runChangelogTextWorkflow({ branch: 'main' })
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toContain('LLM provider not configured')
+      expect(result.text).toBeUndefined()
+    })
+
+    it('accepts the full set of changelog argv shapes (sinceLastTag, tag, range)', async () => {
+      mockedChangelogHandler.mockImplementation(async () => {
+        process.stdout.write('feat: changelog')
+      })
+
+      await runChangelogTextWorkflow({ sinceLastTag: true })
+      await runChangelogTextWorkflow({ tag: 'v1.0.0' })
+      await runChangelogTextWorkflow({ range: 'abc..def' })
+
+      // Each invocation forwards the input through createChangelogArgv,
+      // leaving the rest of the argv at its defaults (mode: 'stdout',
+      // interactive: false, etc.).
+      const calls = mockedChangelogHandler.mock.calls
+      expect(calls[0][0]).toMatchObject({ sinceLastTag: true, mode: 'stdout' })
+      expect(calls[1][0]).toMatchObject({ tag: 'v1.0.0', mode: 'stdout' })
+      expect(calls[2][0]).toMatchObject({ range: 'abc..def', mode: 'stdout' })
     })
   })
 })

--- a/src/git/aiActions.ts
+++ b/src/git/aiActions.ts
@@ -284,6 +284,54 @@ export async function runPullRequestBodyWorkflow(
   }
 }
 
+/**
+ * Run `coco changelog` and return the raw captured stdout, intact —
+ * blank lines preserved, no telemetry stripping. Use this when you
+ * want to show or copy the changelog as the user would see it from
+ * the CLI (the chromed-up `runChangelogAction` collapses blank lines
+ * via `compactOutputLines` which is wrong for any UI that wants the
+ * full prose output).
+ *
+ * The argv defaults match `createChangelogArgv` — pass overrides via
+ * `input`. Common shapes:
+ *
+ *   - { branch: 'main' }           — commits on current branch vs main
+ *   - { sinceLastTag: true }       — since last tag
+ *   - { tag: 'v1.0.0' }            — since a specific tag
+ *   - { range: 'abc..def' }        — between two refs
+ *
+ * Returns:
+ *   - { ok: true, message, text } on success (message = first non-blank
+ *     line, useful for status surface; text = full raw output)
+ *   - { ok: false, message } on changelog handler error or empty output
+ */
+export async function runChangelogTextWorkflow(
+  input: Partial<ChangelogOptions> = {}
+): Promise<{ ok: boolean; message: string; text?: string }> {
+  const argv = createChangelogArgv(input)
+
+  let raw = ''
+  try {
+    raw = await captureStdout(() => changelogHandler(argv, new Logger({
+      verbose: true,
+      silent: false,
+    })))
+  } catch (error) {
+    return { ok: false, message: (error as Error).message }
+  }
+
+  const text = raw.trim()
+  if (!text) {
+    return {
+      ok: false,
+      message: 'No changelog output produced — branch may have no commits ahead of base.',
+    }
+  }
+
+  const firstLine = text.split('\n').find((line) => line.trim()) || 'Changelog generated.'
+  return { ok: true, message: firstLine, text }
+}
+
 export const aiActionTestInternals = {
   compactOutputLines,
   createChangelogArgv,

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -57,6 +57,7 @@ import { SimpleGit } from 'simple-git'
 import { getBranchOverview } from '../../git/branchData'
 import { createManualCommit } from '../../commands/log/commitCompose'
 import { runCommitDraftWorkflow } from '../../git/commitWorkflowActions'
+import { runChangelogTextWorkflow } from '../../git/aiActions'
 import {
     GitCommitDetail,
     GitCommitFilePreview,
@@ -1320,6 +1321,77 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     dispatch,
   ])
 
+  // `L` keystroke handler — generate a changelog for the current branch
+  // and open it in a multi-line review prompt. The prompt acts as a
+  // scrollable + editable display: Ctrl+D copies the (possibly edited)
+  // content to clipboard, Esc closes. Runs `coco changelog --branch
+  // <default>` via runChangelogTextWorkflow, which captures the raw
+  // stdout so blank lines / section structure survive intact.
+  const startChangelogView = React.useCallback(async () => {
+    const head = context.branches?.currentBranch || context.provider?.currentBranch
+    if (!head) {
+      dispatch({ type: 'setStatus', value: 'No current branch — check out a branch first.' })
+      return
+    }
+    const defaultBranch = context.provider?.repository.defaultBranch
+    // The changelog command will fall back to its own defaults when no
+    // branch arg is passed, but being explicit about the base is more
+    // honest about what the user is seeing. Skip the default-branch
+    // requirement only when there's no provider detected — in that
+    // case the command's --since-last-tag heuristic kicks in.
+    const argv = defaultBranch && head !== defaultBranch
+      ? { branch: defaultBranch }
+      : { sinceLastTag: true }
+    const baseLabel = defaultBranch && head !== defaultBranch
+      ? `vs ${defaultBranch}`
+      : 'since last tag'
+
+    dispatch({ type: 'setStatus', value: `generating changelog (${baseLabel})…` })
+    const result = await runChangelogTextWorkflow(argv)
+
+    if (!result.ok || !result.text) {
+      dispatch({ type: 'setStatus', value: `Changelog failed: ${result.message}` })
+      return
+    }
+
+    dispatch({ type: 'setStatus', value: 'Changelog ready — Ctrl+D copies, Esc closes.' })
+    dispatch({
+      type: 'openInputPrompt',
+      kind: 'changelog-view',
+      label: `Changelog: ${head} (${baseLabel})  ·  Ctrl+D copy · Esc close`,
+      initial: result.text,
+      multiline: true,
+    })
+  }, [
+    context.branches?.currentBranch,
+    context.provider?.currentBranch,
+    context.provider?.repository.defaultBranch,
+    dispatch,
+  ])
+
+  // Copy an arbitrary string to the system clipboard. Distinct from
+  // `yankFromActiveView` which derives the value from the current view
+  // — this one takes the value as an explicit event payload, used by
+  // the changelog-view prompt (and a candidate for future "copy this"
+  // surfaces). Surfaces a status confirming what landed in clipboard.
+  const yankText = React.useCallback(async (value: string, label: string) => {
+    const clipboard: ClipboardRunner = clipboardRunner || defaultClipboardRunner
+    if (!value) {
+      dispatch({ type: 'setStatus', value: `Nothing to copy — ${label} is empty.` })
+      return
+    }
+    try {
+      await clipboard(value)
+      dispatch({ type: 'setStatus', value: `Copied ${label} to clipboard.` })
+    } catch (error) {
+      dispatch({
+        type: 'setStatus',
+        value: `Copy failed (${label}): ${(error as Error).message}`,
+      })
+    }
+  }, [clipboardRunner, dispatch])
+
+
   // Open a file in $EDITOR (or $VISUAL) by suspending Ink's hold on the
   // terminal, spawning the editor synchronously inheriting stdio, then
   // restoring the alt screen + raw mode and forcing a re-render. The
@@ -2332,6 +2404,10 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         void runAiCommitDraft()
       } else if (event.type === 'startCreatePullRequest') {
         void startCreatePullRequest()
+      } else if (event.type === 'startChangelogView') {
+        void startChangelogView()
+      } else if (event.type === 'yankText') {
+        void yankText(event.value, event.label)
       } else if (event.type === 'runWorkflowAction') {
         void runWorkflowAction(event.id, event.payload)
       } else if (event.type === 'openFileInEditor') {


### PR DESCRIPTION
The second of two cross-feature integrations identified in the audit. Lets users **generate a changelog for the current branch without leaving the workstation**, review/edit the output in a multi-line prompt, and yank it to clipboard.

Independent of #905 (create-pr wiring) — both can land in any order. Once both land, the `runChangelogTextWorkflow` helper added here and the `runPullRequestBodyWorkflow` helper added in #905 can be reconciled into a single base helper in a small cleanup PR.

## What you get

Press `L` globally (except on `compose`, which has an explicit guard) to start the changelog-view flow:

1. Runtime callback `startChangelogView` resolves the current branch + default branch.
2. Picks the right argv:
   - **On a feature branch**: `coco changelog --branch <default>` — produces "what's on this branch but not on base"
   - **On the default branch**: `coco changelog --since-last-tag` — branch-vs-base would be empty
3. Opens a multi-line prompt prefilled with the captured output. Label says "Changelog: \<branch\> (vs main · Ctrl+D copy · Esc close)".
4. In the prompt: standard multi-line prompt behaviors. **Ctrl+D copies the (possibly edited) text to clipboard.** Esc closes.

## How it leverages existing commands

The same recipe as #905 (PR creation), refined into a more general helper.

```ts
// src/git/aiActions.ts — new export
export async function runChangelogTextWorkflow(
  input: Partial<ChangelogOptions> = {}
): Promise<{ ok: boolean; message: string; text?: string }> {
  // 1. createChangelogArgv → synthetic argv with mode:'stdout', verbose:true
  // 2. captureStdout while invoking changelogHandler directly
  // 3. Return raw output preserved as-is (blank lines + section structure
  //    survive intact, unlike runChangelogAction which strips them via
  //    compactOutputLines)
}
```

The existing `runChangelogAction` was wrong for any UI surface that wants the full prose output — its `compactOutputLines` filter strips blank lines, collapsing the title-vs-body separator and the section spacing in long changelogs. `runChangelogTextWorkflow` returns the raw stdout, intact.

## Files touched

| File | Δ | Why |
|---|---|---|
| `src/git/aiActions.ts` | +48 | New `runChangelogTextWorkflow` helper |
| `src/git/aiActions.test.ts` | +89 (5 cases) | Raw output preservation, leading-blank handling, empty output, error propagation, argv shape coverage |
| `src/commands/log/inkViewModel.ts` | +1 | Add `'changelog-view'` to `LogInkInputPromptKind` |
| `src/commands/log/inkInput.ts` | +30 | `L` keystroke handler (with compose guard), submit-prompt branch for `changelog-view`, new event types `startChangelogView` + `yankText` |
| `src/commands/log/inkInput.test.ts` | +56 (3 cases) | Global `L`, compose guard, multi-line submit |
| `src/workstation/runtime/app.ts` | +75 | `startChangelogView` callback (with argv selection: branch vs since-last-tag), `yankText` callback (generic payload-driven clipboard copy), two event-switch branches |

**Net: +299 LOC across 6 files. Pure addition — no deletions.**

## Reusing the multi-line prompt as a display surface

The `changelog-view` kind reuses the entire multi-line input-prompt machinery — Ink rendering, scrolling, editing, Ctrl+D / Esc handling — **without any new chrome**. The semantic shift is small: instead of "type a value, submit dispatches a workflow," it's "review pre-filled content, submit copies to clipboard." Same UI, different submit semantics, plumbed through a per-kind branch in `submitInputPrompt`.

This sidesteps the need for a new "result panel" overlay surface, which would have meant new render code, new keystroke handlers for the new modality, etc. The cost is that the user can edit the text before copying — but that's actually a feature, not a bug.

## The new `yankText` generic

`yankFromActiveView` (existing) takes the current view + state and derives a value to copy. `yankText` (new) takes the value as an explicit event payload. Plugs into the same `defaultClipboardRunner` chain (pbcopy on macOS, wl-copy on Wayland, xclip on X11). Useful for the changelog-view submit and any future "copy this string" surfaces.

## Validation

- `tsc --noEmit`: clean
- `eslint src`: clean
- Full Jest suite: **680/680 suites, 6,579/6,579 tests passing**
- No behavior change for any other keystroke / view / workflow

## Worth a manual smoke test

1. **Happy path (feature branch with commits)**: `coco ui`, press `L`. Status cycles "generating changelog (vs main)…" → "Changelog ready — Ctrl+D copies, Esc closes." Prompt opens prefilled. Edit if desired. Ctrl+D. Status: "Copied changelog to clipboard."
2. **On main / default branch**: press `L`. Status: "generating changelog (since last tag)…" — flips to since-last-tag mode since branch-vs-base would be empty.
3. **Branch with no commits ahead of base**: press `L`. Status: "Changelog failed: No changelog output produced — branch may have no commits ahead of base." No prompt opens.
4. **Compose guard**: open compose (`g c`), press `L`. Status: "Finish or cancel the commit draft before generating a changelog."

## What's NOT in scope (deliberately)

- **Palette command** (`:changelog`, `:changelog since-last-tag`, `:changelog tag X`). The keystroke is enough for v1; palette discoverability is a follow-up that needs a small extension to the palette mechanism to allow event-dispatching commands (not just workflow-action commands).
- **In-context bindings**: `L` on tags view runs since-last-tag against the cursored tag, `L` on branches view runs vs the cursored branch. The current global `L` always uses the current-branch head, which is the most-common case. Follow-up: per-view variants.
- **"Send to PR body"** — when an open PR exists for the branch, a key inside the changelog prompt could push the text to the PR body via `gh pr edit --body`. Follow-up.

Closes the second integration item from the cross-feature audit (2 of 3). The split-in-compose work (item 3) is being filed as a separate issue for review/refinement.