### PR TITLE
feat(testUtils): scenario library + CLI for spinning up named git repo states

### DIFF
--- a/bin/scenario.ts
+++ b/bin/scenario.ts
@@ -1,0 +1,258 @@
+#!/usr/bin/env tsx
+/**
+ * CLI driver for the scenario library — spin up a fake repo in a
+ * named state for manual testing.
+ *
+ * Usage:
+ *   npm run scenario list                          # show all scenarios
+ *   npm run scenario describe <name>               # describe one
+ *   npm run scenario create <name>                 # create in /tmp
+ *   npm run scenario create <name> --path <dir>    # create at <dir>
+ *   npm run scenario create <name> --run-ui        # create AND launch `coco ui`
+ *
+ * By default, `create` PERSISTS the scenario (doesn't auto-clean) —
+ * that's what manual testing wants. Use `--ephemeral` to clean up on
+ * exit (handy for one-shot smoke tests). The cleanup hint is printed
+ * at the end either way.
+ *
+ * EXTRACTION NOTE: this CLI uses `coco` only for the optional `--run-ui`
+ * flag (it spawns `coco ui --path <dir>`). The core scenario logic is
+ * agnostic to which tool consumes it; only the convenience launcher
+ * knows about coco. When extracted to a standalone package, the
+ * `--run-ui` flag becomes `--run <command>` taking an arbitrary shell
+ * command — `lazygit`, `gitui`, etc. would all work.
+ */
+
+import { spawnSync } from 'node:child_process'
+import * as path from 'node:path'
+
+import { allScenarios, findScenario, type Scenario } from '../src/lib/testUtils/scenarios'
+import { createTempGitRepo } from '../src/lib/testUtils/tempGitRepo'
+
+type ParsedArgs = {
+  command?: 'list' | 'describe' | 'create' | 'help'
+  positional: string[]
+  flags: Record<string, string | boolean>
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const positional: string[] = []
+  const flags: Record<string, string | boolean> = {}
+  let command: ParsedArgs['command']
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg.startsWith('--')) {
+      const eqIdx = arg.indexOf('=')
+      if (eqIdx > 0) {
+        flags[arg.slice(2, eqIdx)] = arg.slice(eqIdx + 1)
+      } else if (i + 1 < argv.length && !argv[i + 1].startsWith('-')) {
+        flags[arg.slice(2)] = argv[i + 1]
+        i += 1
+      } else {
+        flags[arg.slice(2)] = true
+      }
+    } else if (!command) {
+      if (arg === 'list' || arg === 'describe' || arg === 'create' || arg === 'help') {
+        command = arg
+      } else {
+        positional.push(arg)
+      }
+    } else {
+      positional.push(arg)
+    }
+  }
+
+  return { command, positional, flags }
+}
+
+function printHelp(): void {
+  console.log([
+    '',
+    '  npm run scenario — manage testing scenarios for the workstation',
+    '',
+    '  Usage:',
+    '    npm run scenario list',
+    '    npm run scenario describe <name>',
+    '    npm run scenario create <name> [options]',
+    '',
+    '  Create options:',
+    '    --path <dir>     Materialize the scenario at <dir> instead of /tmp',
+    '    --run-ui         Launch `coco ui` against the scenario after creation',
+    '    --ephemeral      Remove the scenario directory when the CLI exits',
+    '                     (default: persist, print the cleanup hint)',
+    '',
+    `  Available scenarios (${allScenarios.length}):`,
+    ...allScenarios.map((s) => `    ${s.name.padEnd(28)} ${s.summary}`),
+    '',
+  ].join('\n'))
+}
+
+function commandList(): void {
+  console.log('')
+  console.log(`Available scenarios (${allScenarios.length}):`)
+  console.log('')
+  const byKind = new Map<string, Scenario[]>()
+  for (const scenario of allScenarios) {
+    const bucket = byKind.get(scenario.kind) || []
+    bucket.push(scenario)
+    byKind.set(scenario.kind, bucket)
+  }
+  for (const [kind, scenarios] of byKind) {
+    console.log(`  ${kind}:`)
+    for (const s of scenarios) {
+      console.log(`    ${s.name.padEnd(28)} ${s.summary}`)
+    }
+    console.log('')
+  }
+}
+
+function commandDescribe(name: string): number {
+  const scenario = findScenario(name)
+  if (!scenario) {
+    console.error(`Unknown scenario "${name}". Try \`npm run scenario list\`.`)
+    return 2
+  }
+  console.log('')
+  console.log(`  ${scenario.name}`)
+  console.log(`  ${'-'.repeat(scenario.name.length)}`)
+  console.log('')
+  console.log(`  Summary: ${scenario.summary}`)
+  console.log(`  Kind:    ${scenario.kind}`)
+  console.log('')
+  console.log(scenario.description.split('\n').map((l) => `  ${l}`).join('\n'))
+  if (scenario.contracts && scenario.contracts.length > 0) {
+    console.log('')
+    console.log('  Contracts:')
+    for (const c of scenario.contracts) {
+      console.log(`    - ${c}`)
+    }
+  }
+  console.log('')
+  return 0
+}
+
+async function commandCreate(
+  name: string,
+  options: { targetPath?: string; runUi?: boolean; ephemeral?: boolean }
+): Promise<number> {
+  const scenario = findScenario(name)
+  if (!scenario) {
+    console.error(`Unknown scenario "${name}". Try \`npm run scenario list\`.`)
+    return 2
+  }
+
+  console.log(`Building scenario "${scenario.name}"…`)
+  const repo = await createTempGitRepo()
+
+  // If the user passed --path, the scenario was built in a tmp dir and
+  // we move it. Doing the build-then-move dance means the scenarios
+  // don't need to know about the user's target path — they always run
+  // against the same standardized tempGitRepo shape.
+  try {
+    await scenario.setup(repo)
+  } catch (error) {
+    console.error(`Scenario setup failed: ${(error as Error).message}`)
+    return 1
+  }
+
+  let finalPath = repo.path
+  if (options.targetPath) {
+    const target = path.resolve(options.targetPath)
+    // Use git's own porcelain to clone the bare result somewhere else
+    // would preserve history but lose worktree state. Plain rename
+    // keeps everything intact and is what manual testers expect when
+    // they say "put this scenario at ~/sandbox".
+    const renameResult = spawnSync('mv', [repo.path, target])
+    if (renameResult.status !== 0) {
+      console.error(`Failed to move scenario to ${target}`)
+      return 1
+    }
+    finalPath = target
+  }
+
+  console.log('')
+  console.log(`✓ Scenario "${scenario.name}" ready at:`)
+  console.log(`    ${finalPath}`)
+  console.log('')
+  if (scenario.contracts && scenario.contracts.length > 0) {
+    console.log('  Contracts:')
+    for (const c of scenario.contracts) {
+      console.log(`    - ${c}`)
+    }
+    console.log('')
+  }
+
+  if (options.runUi) {
+    console.log(`Launching \`coco ui\` against the scenario…`)
+    console.log('')
+    const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+    const result = spawnSync(npmCmd, ['run', 'coco:ts', '--', 'ui', '--path', finalPath], {
+      stdio: 'inherit',
+      // coco:ts uses tsx on the workstation source, so the CLI cwd must
+      // be the coco repo, not the scenario dir.
+    })
+    if (result.status !== 0 && result.status !== null) {
+      // Non-zero exit on quit (q / Ctrl+C) is normal for Ink TUIs; only
+      // warn if it's a setup-level failure.
+      if (result.status > 1) {
+        console.warn(`coco ui exited with status ${result.status}`)
+      }
+    }
+  }
+
+  if (options.ephemeral) {
+    await repo.cleanup()
+    console.log('')
+    console.log('  (ephemeral — scenario directory has been removed)')
+  } else {
+    console.log('')
+    console.log('  When you\'re done, clean up with:')
+    console.log(`    rm -rf ${finalPath}`)
+    console.log('')
+  }
+
+  return 0
+}
+
+async function main(): Promise<void> {
+  const { command, positional, flags } = parseArgs(process.argv.slice(2))
+
+  if (!command || command === 'help' || flags.help) {
+    printHelp()
+    process.exit(0)
+  }
+
+  if (command === 'list') {
+    commandList()
+    process.exit(0)
+  }
+
+  if (command === 'describe') {
+    const name = positional[0]
+    if (!name) {
+      console.error('Missing scenario name. Try `npm run scenario list`.')
+      process.exit(2)
+    }
+    process.exit(commandDescribe(name))
+  }
+
+  if (command === 'create') {
+    const name = positional[0]
+    if (!name) {
+      console.error('Missing scenario name. Try `npm run scenario list`.')
+      process.exit(2)
+    }
+    const code = await commandCreate(name, {
+      targetPath: typeof flags.path === 'string' ? flags.path : undefined,
+      runUi: Boolean(flags['run-ui']),
+      ephemeral: Boolean(flags.ephemeral),
+    })
+    process.exit(code)
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:publish": "npm run lint && npm run build && npm run test:cli && npm pack --dry-run",
     "test:cli": "tsx bin/smokeCli.ts",
     "bench": "tsx bin/benchmark.ts",
+    "scenario": "tsx bin/scenario.ts",
     "pretest:jest": "npm run build:info",
     "test:jest": "jest",
     "test:jest:watch": "jest --watch",

--- a/src/lib/testUtils/README.md
+++ b/src/lib/testUtils/README.md
@@ -1,0 +1,165 @@
+# `testUtils/` — temp git repos + named scenarios
+
+This directory hosts the test-infrastructure layer for spinning up git
+repositories in known states. Two consumers:
+
+1. **Integration tests** — `spinUpScenario('feature-pr-ready')` returns
+   a `TempGitRepo` in a predictable state, so tests don't have to
+   reinvent the same `writeFile / commitAll` setup boilerplate every
+   time.
+2. **Manual testing & demos** — `npm run scenario create <name>`
+   materializes a scenario on disk for hand-testing the workstation
+   (or any other git-related tool).
+
+## Layout
+
+```
+testUtils/
+├── README.md             (this file)
+├── tempGitRepo.ts        (low-level: init + user config + main branch)
+├── spinUpScenario.ts     (programmatic API for tests)
+└── scenarios/
+    ├── types.ts          (Scenario type)
+    ├── index.ts          (registry + lookup)
+    ├── shared/
+    │   └── seededFiles.ts (wrapper around __fixtures__/generators)
+    ├── feature-pr-ready.ts
+    ├── dirty-many-files.ts
+    ├── mid-bisect.ts
+    └── multi-commit-branch.ts
+```
+
+The CLI driver lives in `bin/scenario.ts` and is exposed via
+`npm run scenario`.
+
+## Available scenarios
+
+Run `npm run scenario list` for the live list. Current set:
+
+| Name | Kind | What you get |
+|---|---|---|
+| `feature-pr-ready` | branch | `feat/widget-v2` 4 commits ahead of `main`, clean worktree — for create-pr and changelog flows |
+| `multi-commit-branch` | branch | `feat/dashboard` with 8 varied commits — baseline for navigation / filter / yank |
+| `dirty-many-files` | worktree | 12 staged + 6 unstaged + 3 untracked files across `src/`, `tests/`, `docs/` — for the future split flow |
+| `mid-bisect` | operation | 20 commits + active `git bisect`, HEAD at midpoint — for the bisect view |
+
+## Programmatic API
+
+```ts
+import { spinUpScenario } from 'src/lib/testUtils/spinUpScenario'
+
+describe('my integration test', () => {
+  let repo: TempGitRepo
+
+  beforeAll(async () => {
+    repo = await spinUpScenario('feature-pr-ready')
+  })
+
+  afterAll(async () => {
+    await repo.cleanup()
+  })
+
+  it('does the thing', async () => {
+    // repo.path     — absolute filesystem path
+    // repo.git      — simple-git instance bound to the path
+    // repo.writeFile, repo.commitAll, repo.cleanup
+    //
+    // The scenario set up the baseline; from here add whatever
+    // extra state the specific test needs.
+  })
+})
+```
+
+## CLI
+
+```bash
+# Show all scenarios grouped by kind
+npm run scenario list
+
+# Describe one (intent, contracts)
+npm run scenario describe feature-pr-ready
+
+# Materialize in /tmp (persisted — you clean up when done)
+npm run scenario create feature-pr-ready
+
+# Materialize at a specific path
+npm run scenario create feature-pr-ready -- --path ~/sandbox/widget
+
+# Materialize AND launch `coco ui` against it (manual testing)
+npm run scenario create feature-pr-ready -- --run-ui
+
+# Materialize + auto-clean on exit (one-shot smoke test)
+npm run scenario create feature-pr-ready -- --ephemeral
+```
+
+## Adding a new scenario
+
+1. Create `src/lib/testUtils/scenarios/<kebab-name>.ts` exporting a
+   `Scenario` (see `types.ts`).
+2. Add it to the registry in `src/lib/testUtils/scenarios/index.ts`.
+3. Add `<kebab-name>.test.ts` next to it — at minimum, assert each
+   `contract` line holds after setup. Use the existing scenario tests
+   as templates.
+4. The CLI picks it up automatically through the registry.
+
+The scenarios are deliberately small (30–80 LOC each) and focus on git
+state shape, not file content. File content comes from the deterministic
+generators in `src/lib/parsers/default/__fixtures__/generators.ts` —
+seeded so the same scenario name always produces identical content.
+
+## Extraction discipline
+
+This layer is intentionally **git-tool-agnostic** and a candidate for
+extraction to a standalone `git-scenarios` package on npm once the
+abstractions stabilize. The boundary rules below are what keeps that
+extraction path open.
+
+### Rules
+
+- **No coco-specific imports inside `scenarios/`.** Imports are
+  limited to:
+  - `simple-git`
+  - Node stdlib (`fs`, `path`, `os`)
+  - `../tempGitRepo` (the base helper — also extractable)
+  - `../../parsers/default/__fixtures__/generators` (git-agnostic
+    content generators — extractable as peer dependency or co-moved)
+- **Scenario signatures are pure git-state factories.**
+  `(repo: TempGitRepo) => Promise<void>`. No knowledge of which tool is
+  testing them. A scenario named `mid-bisect` produces a mid-bisect
+  repo — full stop.
+- **`spinUpScenario.ts` is the public programmatic surface.** Tests
+  import from it; nothing else in coco should reach into
+  `scenarios/*.ts` directly.
+- **The CLI (`bin/scenario.ts`) is the public command surface.** Its
+  `--run-ui` flag is the only piece that knows about coco; when
+  extracted, that becomes `--run <command>` for arbitrary downstream
+  tools.
+
+### When to extract
+
+Roughly: after 3–6 months of in-coco use, when at least one of these is
+true:
+- A second project we own wants to use it (e.g. `coco-vscode-extension`,
+  `create-coco`).
+- An external issue / discussion asks "is this published anywhere?"
+- Keeping it in coco actively complicates something (e.g. scenario
+  fixture data starts bloating the coco install).
+
+### How extraction looks
+
+Mechanical:
+
+```bash
+mkdir git-scenarios && cd git-scenarios
+cp -r ../coco/src/lib/testUtils/scenarios ./src
+cp ../coco/src/lib/testUtils/tempGitRepo.ts ./src/
+cp ../coco/src/lib/testUtils/spinUpScenario.ts ./src/
+cp ../coco/bin/scenario.ts ./bin/cli.ts
+# generators come with as a peer dep or co-moved
+# add package.json / README / LICENSE
+npm publish
+```
+
+The boundary rules above are what make that `cp` work. Until then, keep
+the discipline strict — every coco-specific import added to this
+directory tree is an extraction tax we'll pay later.

--- a/src/lib/testUtils/scenarios/dirty-many-files.test.ts
+++ b/src/lib/testUtils/scenarios/dirty-many-files.test.ts
@@ -1,0 +1,78 @@
+import { dirtyManyFilesScenario } from './dirty-many-files'
+import { createTempGitRepo, type TempGitRepo } from '../tempGitRepo'
+
+describe('dirty-many-files scenario', () => {
+  let repo: TempGitRepo
+
+  beforeAll(async () => {
+    repo = await createTempGitRepo()
+    await dirtyManyFilesScenario.setup(repo)
+  }, 30_000)
+
+  afterAll(async () => {
+    await repo?.cleanup()
+  })
+
+  it('has 2 commits on main', async () => {
+    const log = await repo.git.log(['main'])
+    expect(log.total).toBe(2)
+  })
+
+  // simple-git's StatusResult helpers double-count files modified in
+  // both index AND worktree (e.g. a file that was staged AND then
+  // edited again). Use the raw porcelain v2 output to get unambiguous
+  // counts per stage position.
+  async function porcelainCounts(): Promise<{
+    stagedOnly: number
+    unstagedOnly: number
+    untracked: number
+  }> {
+    const raw = await repo.git.raw(['status', '--porcelain'])
+    let stagedOnly = 0
+    let unstagedOnly = 0
+    let untracked = 0
+    for (const line of raw.split('\n')) {
+      if (!line) continue
+      const [x, y] = [line[0], line[1]]
+      if (x === '?' && y === '?') {
+        untracked += 1
+      } else {
+        if (x !== ' ' && x !== '?') stagedOnly += 1
+        if (y !== ' ' && y !== '?') unstagedOnly += 1
+      }
+    }
+    return { stagedOnly, unstagedOnly, untracked }
+  }
+
+  it('has 12 staged files', async () => {
+    const counts = await porcelainCounts()
+    expect(counts.stagedOnly).toBe(12)
+  })
+
+  it('has 6 unstaged (modified-but-not-staged) files', async () => {
+    const counts = await porcelainCounts()
+    expect(counts.unstagedOnly).toBe(6)
+  })
+
+  it('has 3 untracked files', async () => {
+    const counts = await porcelainCounts()
+    expect(counts.untracked).toBe(3)
+  })
+
+  it('dirty changes span src/, tests/, and docs/', async () => {
+    const status = await repo.git.status()
+    const allPaths = [
+      ...status.staged,
+      ...status.modified,
+      ...status.not_added,
+    ]
+    const topLevelDirs = new Set(
+      allPaths
+        .map((p) => p.split('/')[0])
+        .filter((d) => d.includes('/') === false && (d === 'src' || d === 'tests' || d === 'docs'))
+    )
+    expect(topLevelDirs).toContain('src')
+    expect(topLevelDirs).toContain('tests')
+    expect(topLevelDirs).toContain('docs')
+  })
+})

--- a/src/lib/testUtils/scenarios/dirty-many-files.ts
+++ b/src/lib/testUtils/scenarios/dirty-many-files.ts
@@ -1,0 +1,126 @@
+/**
+ * `dirty-many-files` — a worktree with a large dirty set spanning
+ * multiple top-level directories. Designed for testing commit-split
+ * flows, status-surface paging, and compose-view affordances that
+ * should surface when a user is about to commit a sprawling change.
+ *
+ * State after setup:
+ *   - `main` has 2 baseline commits
+ *   - worktree has 12 staged + 6 unstaged + 3 untracked files
+ *   - the dirty set spans 3 distinct top-level dirs (`src/`, `tests/`,
+ *     `docs/`) plus root-level config files
+ *
+ * Used to validate the split-in-compose flow (#907) and any future
+ * worktree-paging UI.
+ *
+ * EXTRACTION DISCIPLINE: no coco-specific imports.
+ */
+
+import type { Scenario } from './types'
+import { writeSeededFiles } from './shared/seededFiles'
+
+const SEED = 0xd1f71e5
+
+export const dirtyManyFilesScenario: Scenario = {
+  name: 'dirty-many-files',
+  summary: '12 staged + 6 unstaged + 3 untracked across 3 top-level dirs',
+  description: [
+    'A worktree mid-development with a large dirty set. `main` has 2',
+    'baseline commits; the working tree adds 12 staged files, modifies',
+    '6 unstaged files, and includes 3 untracked files. Changes span',
+    'three top-level directories (`src/`, `tests/`, `docs/`) plus',
+    'root-level config — exactly the shape that benefits from',
+    '`coco commit --split`.',
+    '',
+    'Useful for testing:',
+    '  - the split-in-compose flow (#907) once it ships',
+    '  - status-surface paging behavior with many files',
+    '  - the "large changeset" heuristic in compose',
+    '  - filter / mask narrowing on the status view',
+  ].join('\n'),
+  kind: 'worktree',
+  contracts: [
+    'main has 2 commits',
+    'worktree has 12 staged files',
+    'worktree has 6 unstaged files',
+    'worktree has 3 untracked files',
+    'changes span src/, tests/, and docs/',
+  ],
+  setup: async (repo) => {
+    // === baseline scaffold ===
+    await repo.writeFile('README.md', '# Sprawl\n\nA project mid-refactor.\n')
+    await repo.writeFile('package.json', JSON.stringify({
+      name: 'sprawl',
+      version: '0.2.0',
+      main: 'src/index.ts',
+    }, null, 2) + '\n')
+    await repo.commitAll('chore: initial commit')
+
+    // Baseline files that will be modified later.
+    await writeSeededFiles(repo, [
+      { path: 'src/index.ts', tokens: 80 },
+      { path: 'src/router.ts', tokens: 120 },
+      { path: 'src/store.ts', tokens: 140 },
+      { path: 'src/utils.ts', tokens: 70 },
+      { path: 'src/types.ts', tokens: 60 },
+      { path: 'src/api.ts', tokens: 100 },
+      { path: 'tests/router.test.ts', tokens: 90 },
+      { path: 'tests/store.test.ts', tokens: 110 },
+      { path: 'docs/architecture.md', tokens: 200 },
+      { path: 'docs/contributing.md', tokens: 80 },
+    ], SEED)
+    await repo.commitAll('chore: baseline app scaffold')
+
+    // === 12 staged: new feature module + tests + docs ===
+    await writeSeededFiles(repo, [
+      // Feature: new `widgets` module across 6 files
+      { path: 'src/widgets/index.ts', tokens: 50 },
+      { path: 'src/widgets/button.ts', tokens: 130 },
+      { path: 'src/widgets/input.ts', tokens: 140 },
+      { path: 'src/widgets/modal.ts', tokens: 180 },
+      { path: 'src/widgets/types.ts', tokens: 70 },
+      { path: 'src/widgets/styles.ts', tokens: 90 },
+      // Tests for the new module
+      { path: 'tests/widgets/button.test.ts', tokens: 100 },
+      { path: 'tests/widgets/input.test.ts', tokens: 110 },
+      { path: 'tests/widgets/modal.test.ts', tokens: 140 },
+      // Docs
+      { path: 'docs/widgets-guide.md', tokens: 250 },
+      // Top-level integration: re-export from index + a config file
+      { path: 'src/index.ts', tokens: 90 }, // re-touch baseline
+      { path: '.widgetsrc.json', tokens: 30 },
+    ], SEED + 1)
+    await repo.git.add([
+      'src/widgets/index.ts',
+      'src/widgets/button.ts',
+      'src/widgets/input.ts',
+      'src/widgets/modal.ts',
+      'src/widgets/types.ts',
+      'src/widgets/styles.ts',
+      'tests/widgets/button.test.ts',
+      'tests/widgets/input.test.ts',
+      'tests/widgets/modal.test.ts',
+      'docs/widgets-guide.md',
+      'src/index.ts',
+      '.widgetsrc.json',
+    ])
+
+    // === 6 unstaged: in-progress refactor touching baseline files ===
+    // These are MODIFICATIONS to existing files — re-seed so the
+    // content differs from the baseline content.
+    await writeSeededFiles(repo, [
+      { path: 'src/router.ts', tokens: 130 },
+      { path: 'src/store.ts', tokens: 150 },
+      { path: 'src/utils.ts', tokens: 80 },
+      { path: 'src/api.ts', tokens: 110 },
+      { path: 'tests/router.test.ts', tokens: 100 },
+      { path: 'docs/architecture.md', tokens: 220 },
+    ], SEED + 2)
+    // No `git add` — these stay unstaged.
+
+    // === 3 untracked: scratch / experimental files ===
+    await repo.writeFile('scratch.md', '# scratchpad\n\n- TODO: pick up where left off\n')
+    await repo.writeFile('src/_experimental.ts', '// experimental — do not ship\n')
+    await repo.writeFile('docs/_draft.md', '# Draft notes\n\nLorem ipsum.\n')
+  },
+}

--- a/src/lib/testUtils/scenarios/feature-pr-ready.test.ts
+++ b/src/lib/testUtils/scenarios/feature-pr-ready.test.ts
@@ -1,0 +1,49 @@
+import { featurePrReadyScenario } from './feature-pr-ready'
+import { createTempGitRepo, type TempGitRepo } from '../tempGitRepo'
+
+describe('feature-pr-ready scenario', () => {
+  let repo: TempGitRepo
+
+  beforeAll(async () => {
+    repo = await createTempGitRepo()
+    await featurePrReadyScenario.setup(repo)
+  }, 30_000)
+
+  afterAll(async () => {
+    await repo?.cleanup()
+  })
+
+  it('has 3 commits on main', async () => {
+    const log = await repo.git.log(['main'])
+    expect(log.total).toBe(3)
+  })
+
+  it('has feat/widget-v2 checked out', async () => {
+    const status = await repo.git.status()
+    expect(status.current).toBe('feat/widget-v2')
+  })
+
+  it('has feat/widget-v2 4 commits ahead of main', async () => {
+    const ahead = await repo.git.raw(['rev-list', '--count', 'main..feat/widget-v2'])
+    expect(parseInt(ahead.trim(), 10)).toBe(4)
+  })
+
+  it('has a clean worktree', async () => {
+    const status = await repo.git.status()
+    expect(status.isClean()).toBe(true)
+  })
+
+  it('preserves commit subjects in the expected order', async () => {
+    const log = await repo.git.log()
+    const subjects = log.all.map((entry) => entry.message.split('\n')[0])
+    expect(subjects).toEqual([
+      'docs: document widget-v2 API and migration path',
+      'test: cover widget-v2 happy path and edge cases',
+      'feat: expose widget-v2 from public index',
+      'feat: add widget-v2 entry point and types',
+      'test: add baseline widget tests',
+      'feat: scaffold widget module',
+      'chore: initial commit',
+    ])
+  })
+})

--- a/src/lib/testUtils/scenarios/feature-pr-ready.ts
+++ b/src/lib/testUtils/scenarios/feature-pr-ready.ts
@@ -1,0 +1,113 @@
+/**
+ * `feature-pr-ready` — a feature branch with 4 commits, clean worktree,
+ * ready to open a pull request against `main`.
+ *
+ * State after setup:
+ *   - `main`  has 3 commits (initial scaffold + 2 baseline)
+ *   - `feat/widget-v2` is checked out, 4 commits ahead of `main`
+ *   - worktree is clean
+ *   - no remote configured (the consumer can add a stub remote if it
+ *     needs to test gh-CLI integrations; the scenario keeps remote
+ *     setup out of scope so it works in fully-offline contexts)
+ *
+ * Used to validate the create-pr flow (#905) and changelog view (#906).
+ *
+ * EXTRACTION DISCIPLINE: no coco-specific imports.
+ */
+
+import type { Scenario } from './types'
+import { writeSeededFiles } from './shared/seededFiles'
+
+const SEED = 0xfeedc0de
+
+export const featurePrReadyScenario: Scenario = {
+  name: 'feature-pr-ready',
+  summary: 'feature branch with 4 commits, clean worktree, ready to open a PR',
+  description: [
+    'A feature branch ready to be PR\'d. `main` has 3 scaffold commits,',
+    '`feat/widget-v2` is checked out and 4 commits ahead. Worktree is',
+    'clean — no staged or unstaged changes.',
+    '',
+    'Useful for testing:',
+    '  - create-pr flow (`C` keystroke) — title + body seeded from changelog',
+    '  - changelog view (`L` keystroke) — exercises `--branch main` path',
+    '  - branches view — exercises the feat branch divergence display',
+    '  - history view — exercises commit list rendering on a non-main branch',
+  ].join('\n'),
+  kind: 'branch',
+  contracts: [
+    'main has 3 commits',
+    'feat/widget-v2 is checked out',
+    'feat/widget-v2 is 4 commits ahead of main',
+    'worktree is clean',
+  ],
+  setup: async (repo) => {
+    // === main: 3-commit scaffold ===
+    await repo.writeFile('README.md', '# Widget\n\nA hypothetical widget library.\n')
+    await repo.writeFile('package.json', JSON.stringify({
+      name: 'widget',
+      version: '0.1.0',
+      main: 'src/index.ts',
+    }, null, 2) + '\n')
+    await repo.commitAll('chore: initial commit')
+
+    await writeSeededFiles(repo, [
+      { path: 'src/index.ts', tokens: 60 },
+      { path: 'src/widget.ts', tokens: 120 },
+    ], SEED)
+    await repo.commitAll('feat: scaffold widget module')
+
+    await writeSeededFiles(repo, [
+      { path: 'src/utils.ts', tokens: 80 },
+      { path: 'tests/widget.test.ts', tokens: 100 },
+    ], SEED)
+    await repo.commitAll('test: add baseline widget tests')
+
+    // === feat/widget-v2: 4 commits ahead ===
+    await repo.git.checkoutLocalBranch('feat/widget-v2')
+
+    // Per-commit seed shifts so files re-touched across commits
+    // (e.g. src/index.ts) actually differ between commits — same path
+    // + same SEED would produce identical content and the commit would
+    // be a no-op.
+    // Commit 1 — feature: add v2 entry point + types
+    await writeSeededFiles(repo, [
+      { path: 'src/widget-v2.ts', tokens: 180 },
+      { path: 'src/types.ts', tokens: 70 },
+    ], SEED + 1)
+    await repo.commitAll('feat: add widget-v2 entry point and types')
+
+    // Commit 2 — feature: wire v2 into the index
+    await writeSeededFiles(repo, [
+      { path: 'src/index.ts', tokens: 90 },
+    ], SEED + 2)
+    await repo.commitAll('feat: expose widget-v2 from public index')
+
+    // Commit 3 — tests: cover v2
+    await writeSeededFiles(repo, [
+      { path: 'tests/widget-v2.test.ts', tokens: 140 },
+    ], SEED + 3)
+    await repo.commitAll('test: cover widget-v2 happy path and edge cases')
+
+    // Commit 4 — docs: update readme + add migration guide
+    await repo.writeFile('README.md', [
+      '# Widget',
+      '',
+      'A hypothetical widget library.',
+      '',
+      '## v2 (new!)',
+      '',
+      'The v2 API is a drop-in upgrade with structured option objects',
+      'and async lifecycle hooks. See `MIGRATING.md` for details.',
+      '',
+    ].join('\n'))
+    await repo.writeFile('MIGRATING.md', [
+      '# Migrating from v1 to v2',
+      '',
+      'The v1 positional-args API is replaced by an options object.',
+      'Lifecycle hooks are async-by-default — wrap calls in `await`.',
+      '',
+    ].join('\n'))
+    await repo.commitAll('docs: document widget-v2 API and migration path')
+  },
+}

--- a/src/lib/testUtils/scenarios/index.test.ts
+++ b/src/lib/testUtils/scenarios/index.test.ts
@@ -1,0 +1,45 @@
+import { allScenarios, findScenario } from './index'
+
+describe('scenarios registry', () => {
+  it('exposes a non-empty list of scenarios', () => {
+    expect(allScenarios.length).toBeGreaterThan(0)
+  })
+
+  it('has unique scenario names', () => {
+    const names = allScenarios.map((s) => s.name)
+    const unique = new Set(names)
+    expect(unique.size).toBe(names.length)
+  })
+
+  it('uses kebab-case names', () => {
+    for (const scenario of allScenarios) {
+      expect(scenario.name).toMatch(/^[a-z][a-z0-9-]*$/)
+    }
+  })
+
+  it('every scenario has a non-empty summary and description', () => {
+    for (const scenario of allScenarios) {
+      expect(scenario.summary.trim()).not.toBe('')
+      expect(scenario.description.trim()).not.toBe('')
+    }
+  })
+
+  it('every scenario declares a valid kind', () => {
+    const validKinds = new Set(['branch', 'worktree', 'operation', 'history', 'stash'])
+    for (const scenario of allScenarios) {
+      expect(validKinds.has(scenario.kind)).toBe(true)
+    }
+  })
+
+  describe('findScenario', () => {
+    it('returns the scenario for a known name', () => {
+      const result = findScenario('feature-pr-ready')
+      expect(result).toBeDefined()
+      expect(result?.name).toBe('feature-pr-ready')
+    })
+
+    it('returns undefined for an unknown name', () => {
+      expect(findScenario('does-not-exist')).toBeUndefined()
+    })
+  })
+})

--- a/src/lib/testUtils/scenarios/index.ts
+++ b/src/lib/testUtils/scenarios/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Scenario registry for `src/lib/testUtils/scenarios/`.
+ *
+ * Each named scenario produces a deterministic git-repo state useful
+ * for testing the workstation, integration tests, and manual demos.
+ * See `src/lib/testUtils/README.md` for the boundary rules and the
+ * extraction plan to a standalone `git-scenarios` package.
+ *
+ * EXTRACTION DISCIPLINE: this file is the public surface. The registry
+ * is the only thing consumers should depend on; individual scenario
+ * modules can be re-shaped without breaking the API.
+ */
+
+import type { Scenario } from './types'
+import { dirtyManyFilesScenario } from './dirty-many-files'
+import { featurePrReadyScenario } from './feature-pr-ready'
+import { midBisectScenario } from './mid-bisect'
+import { multiCommitBranchScenario } from './multi-commit-branch'
+
+/**
+ * Ordered list of all available scenarios. The order is shown in
+ * `npm run scenario list` so we group related ones together —
+ * branch-y scenarios first, then worktree, then operations.
+ */
+export const allScenarios: readonly Scenario[] = [
+  // branch shapes
+  featurePrReadyScenario,
+  multiCommitBranchScenario,
+  // worktree shapes
+  dirtyManyFilesScenario,
+  // in-progress operations
+  midBisectScenario,
+]
+
+/**
+ * Lookup helper. Returns undefined for an unknown name so callers can
+ * surface a helpful error (CLI prints the list; programmatic API
+ * throws with a suggestion).
+ */
+export function findScenario(name: string): Scenario | undefined {
+  return allScenarios.find((s) => s.name === name)
+}
+
+export type { Scenario, ScenarioKind } from './types'
+export { dirtyManyFilesScenario } from './dirty-many-files'
+export { featurePrReadyScenario } from './feature-pr-ready'
+export { midBisectScenario } from './mid-bisect'
+export { multiCommitBranchScenario } from './multi-commit-branch'

--- a/src/lib/testUtils/scenarios/mid-bisect.test.ts
+++ b/src/lib/testUtils/scenarios/mid-bisect.test.ts
@@ -1,0 +1,55 @@
+import { existsSync } from 'fs'
+import { join } from 'path'
+
+import { midBisectScenario } from './mid-bisect'
+import { createTempGitRepo, type TempGitRepo } from '../tempGitRepo'
+
+describe('mid-bisect scenario', () => {
+  let repo: TempGitRepo
+
+  beforeAll(async () => {
+    repo = await createTempGitRepo()
+    await midBisectScenario.setup(repo)
+  }, 60_000)
+
+  afterAll(async () => {
+    // `git bisect reset` first so the cleanup doesn't trip over the
+    // detached-HEAD state that some filesystem cleanup paths dislike.
+    // Best-effort — if it fails we still want the dir removed.
+    try {
+      await repo.git.raw(['bisect', 'reset'])
+    } catch {
+      /* ignore */
+    }
+    await repo?.cleanup()
+  })
+
+  it('has 20 commits total', async () => {
+    // Use `--all` so the count survives the detached-HEAD state. Any
+    // reachable commit through any ref counts; the bisect doesn't
+    // create new commits, so we get the 20 baseline commits.
+    const count = await repo.git.raw(['rev-list', '--all', '--count'])
+    expect(parseInt(count.trim(), 10)).toBe(20)
+  })
+
+  it('has a bisect in progress (BISECT_LOG exists)', () => {
+    expect(existsSync(join(repo.path, '.git', 'BISECT_LOG'))).toBe(true)
+  })
+
+  it('has HEAD detached at a non-tip commit', async () => {
+    // `git bisect start <bad> <good>` checks out the midpoint. HEAD
+    // is detached and not pointing at the `bad` tip.
+    const head = (await repo.git.revparse(['HEAD'])).trim()
+    const mainTip = (await repo.git.revparse(['main'])).trim()
+    expect(head).not.toBe(mainTip)
+  })
+
+  it('has no decision lines logged yet (start markers only)', async () => {
+    const bisectLog = await repo.git.raw(['bisect', 'log'])
+    // The bisect log emits `# bad: ...` / `# good: ...` for the start
+    // markers but should have NO `git bisect bad` / `git bisect good`
+    // command lines yet — those only appear once decisions are made.
+    expect(bisectLog).toMatch(/git bisect start/)
+    expect(bisectLog).not.toMatch(/git bisect (good|bad|skip) [a-f0-9]/)
+  })
+})

--- a/src/lib/testUtils/scenarios/mid-bisect.ts
+++ b/src/lib/testUtils/scenarios/mid-bisect.ts
@@ -1,0 +1,74 @@
+/**
+ * `mid-bisect` — a repo with 20 commits and an in-progress `git bisect`
+ * already running. The bisect has been started with `good=HEAD~19`
+ * and `bad=HEAD`, but no decisions have been logged yet — HEAD sits at
+ * git's chosen midpoint candidate, waiting for the user to mark it.
+ *
+ * State after setup:
+ *   - `main` has 20 commits (1 scaffold + 19 progressive)
+ *   - `git bisect start <bad> <good>` has been invoked
+ *   - HEAD is detached at the midpoint
+ *   - `.git/BISECT_LOG` exists with the start markers but no decisions
+ *
+ * Used to validate the bisect view (#784) — empty-state explainer
+ * doesn't apply (bisect IS active), but the active-bisect rendering
+ * with no decisions logged yet is a distinct state worth covering.
+ *
+ * EXTRACTION DISCIPLINE: no coco-specific imports.
+ */
+
+import type { Scenario } from './types'
+import { writeSeededFiles } from './shared/seededFiles'
+
+const SEED = 0xb15ec7
+
+export const midBisectScenario: Scenario = {
+  name: 'mid-bisect',
+  summary: '20-commit history with `git bisect` started, HEAD at midpoint',
+  description: [
+    'A repository with 20 commits on `main` and an active `git bisect`',
+    'run. HEAD is detached at the midpoint candidate; no `good` / `bad`',
+    'decisions have been recorded yet. The bisect log carries only the',
+    'start markers (`git bisect start <bad> <good>`).',
+    '',
+    'Useful for testing:',
+    '  - bisect view active-state rendering (#784)',
+    '  - decision keystrokes (`g`/`b`/`s`/`x`) and their immediate effect',
+    '  - completion-panel detection (apply `g` / `b` repeatedly until',
+    '    git emits "X is the first bad commit")',
+    '  - title-bar BISECTING badge',
+  ].join('\n'),
+  kind: 'operation',
+  contracts: [
+    'main has 20 commits',
+    'a bisect is in progress',
+    'HEAD is detached',
+    'no bisect decisions logged yet',
+  ],
+  setup: async (repo) => {
+    // 20 progressive commits. Each touches one file with seeded content
+    // so the bisect candidate diff at each commit is non-trivial but
+    // deterministic.
+    await repo.writeFile('README.md', '# Bisect target\n')
+    await repo.commitAll('chore: initial scaffold')
+
+    // 19 additional commits, each touching its own file. Total: 20.
+    for (let i = 1; i <= 19; i += 1) {
+      await writeSeededFiles(repo, [
+        { path: `src/step-${String(i).padStart(2, '0')}.ts`, tokens: 60 },
+      ], SEED + i)
+      await repo.commitAll(`feat: step ${i}`)
+    }
+
+    // Resolve refs: `bad` = current HEAD, `good` = HEAD~19 (the initial
+    // scaffold). Capture the sha of the good ref before running bisect
+    // because `HEAD~19` becomes unresolvable mid-bisect when HEAD is
+    // detached. Using shas keeps the scenario reproducible regardless
+    // of which midpoint git picks.
+    const badSha = (await repo.git.revparse(['HEAD'])).trim()
+    const goodSha = (await repo.git.revparse(['HEAD~19'])).trim()
+
+    // Start the bisect. Git checks out the midpoint commit automatically.
+    await repo.git.raw(['bisect', 'start', badSha, goodSha])
+  },
+}

--- a/src/lib/testUtils/scenarios/multi-commit-branch.test.ts
+++ b/src/lib/testUtils/scenarios/multi-commit-branch.test.ts
@@ -1,0 +1,50 @@
+import { multiCommitBranchScenario } from './multi-commit-branch'
+import { createTempGitRepo, type TempGitRepo } from '../tempGitRepo'
+
+describe('multi-commit-branch scenario', () => {
+  let repo: TempGitRepo
+
+  beforeAll(async () => {
+    repo = await createTempGitRepo()
+    await multiCommitBranchScenario.setup(repo)
+  }, 30_000)
+
+  afterAll(async () => {
+    await repo?.cleanup()
+  })
+
+  it('has 2 commits on main', async () => {
+    const log = await repo.git.log(['main'])
+    expect(log.total).toBe(2)
+  })
+
+  it('has feat/dashboard checked out', async () => {
+    const status = await repo.git.status()
+    expect(status.current).toBe('feat/dashboard')
+  })
+
+  it('has 8 commits on feat/dashboard ahead of main', async () => {
+    const ahead = await repo.git.raw(['rev-list', '--count', 'main..feat/dashboard'])
+    expect(parseInt(ahead.trim(), 10)).toBe(8)
+  })
+
+  it('has a clean worktree', async () => {
+    const status = await repo.git.status()
+    expect(status.isClean()).toBe(true)
+  })
+
+  it('has commits with varied conventional-commit types', async () => {
+    const log = await repo.git.log()
+    const subjects = log.all.map((entry) => entry.message.split('\n')[0])
+    // Sample 3 of the expected types — the full list is in the
+    // scenario file itself; the test just confirms variety, not
+    // exact ordering (the scenario could reorder commits later).
+    const types = new Set(subjects.map((s) => s.split(':')[0]))
+    expect(types.has('feat')).toBe(true)
+    expect(types.has('fix')).toBe(true)
+    expect(types.has('docs')).toBe(true)
+    expect(types.has('test')).toBe(true)
+    expect(types.has('refactor')).toBe(true)
+    expect(types.has('chore')).toBe(true)
+  })
+})

--- a/src/lib/testUtils/scenarios/multi-commit-branch.ts
+++ b/src/lib/testUtils/scenarios/multi-commit-branch.ts
@@ -1,0 +1,87 @@
+/**
+ * `multi-commit-branch` — a small repo with a feature branch carrying
+ * 8 commits of varied types (feat / fix / chore / docs / refactor /
+ * test). Clean worktree. No remote. Designed as a no-frills baseline
+ * for testing the workstation's general navigation, filter, palette,
+ * yank, and view-switching behaviors.
+ *
+ * State after setup:
+ *   - `main` has 2 commits
+ *   - `feat/dashboard` has 8 commits on top of `main`
+ *   - `feat/dashboard` is checked out
+ *   - worktree is clean
+ *
+ * Used to validate:
+ *   - history surface rendering (varied commit messages exercise the
+ *     subject column truncation, ref-label display, etc.)
+ *   - filter (`/`) with varied subjects
+ *   - palette + chord overlays (`:` / `g x`)
+ *   - yank (`y` / `Y`) from history
+ *   - view switches between history / status / branches / tags
+ *
+ * EXTRACTION DISCIPLINE: no coco-specific imports.
+ */
+
+import type { Scenario } from './types'
+import { writeSeededFiles } from './shared/seededFiles'
+
+const SEED = 0xdab0b00
+
+const COMMIT_MESSAGES = [
+  'feat: add dashboard layout',
+  'feat: wire dashboard to data source',
+  'test: cover dashboard reducer',
+  'fix: dashboard refresh interval respects user setting',
+  'refactor: extract dashboard data-fetch into hook',
+  'docs: document dashboard configuration',
+  'chore: bump dev dependencies',
+  'feat: add dashboard export-to-csv action',
+] as const
+
+export const multiCommitBranchScenario: Scenario = {
+  name: 'multi-commit-branch',
+  summary: 'feature branch with 8 varied commits (feat/fix/chore/docs/refactor/test)',
+  description: [
+    'A `feat/dashboard` branch with 8 commits of varied types on top of',
+    'a 2-commit `main`. Each commit touches a different file with',
+    'deterministic seeded content, so the history surface, filter,',
+    'and yank behaviors have realistic inputs to exercise.',
+    '',
+    'Useful for testing:',
+    '  - history surface column widths (varied subject lengths)',
+    '  - filter / search across commit subjects',
+    '  - palette and chord overlay interactions',
+    '  - view switches between history / status / branches',
+    '  - yank short-hash / full-hash from a selected commit',
+  ].join('\n'),
+  kind: 'branch',
+  contracts: [
+    'main has 2 commits',
+    'feat/dashboard is checked out',
+    'feat/dashboard has 8 commits on top of main',
+    'worktree is clean',
+  ],
+  setup: async (repo) => {
+    // main baseline
+    await repo.writeFile('README.md', '# Dashboard\n')
+    await repo.commitAll('chore: initial scaffold')
+
+    await writeSeededFiles(repo, [
+      { path: 'src/app.ts', tokens: 80 },
+      { path: 'src/index.ts', tokens: 50 },
+    ], SEED)
+    await repo.commitAll('chore: baseline app shell')
+
+    // feature branch — 8 commits, each on its own file with a
+    // distinct seed so the commit subjects actually correspond to
+    // distinct diffs.
+    await repo.git.checkoutLocalBranch('feat/dashboard')
+
+    for (let i = 0; i < COMMIT_MESSAGES.length; i += 1) {
+      await writeSeededFiles(repo, [
+        { path: `src/dashboard/feature-${String(i + 1).padStart(2, '0')}.ts`, tokens: 80 + i * 10 },
+      ], SEED + 100 + i)
+      await repo.commitAll(COMMIT_MESSAGES[i])
+    }
+  },
+}

--- a/src/lib/testUtils/scenarios/shared/seededFiles.ts
+++ b/src/lib/testUtils/scenarios/shared/seededFiles.ts
@@ -1,0 +1,74 @@
+/**
+ * Thin wrapper around the deterministic content generators in
+ * `src/lib/parsers/default/__fixtures__/generators.ts`. The generators
+ * themselves are git-agnostic (they produce file content from
+ * `(filename, approxTokens, seed)`); this wrapper adds the small
+ * conveniences scenarios actually need:
+ *
+ *   - `seededFile(seed)` — derive a per-file seed from a base + path so
+ *     every file in a scenario gets distinct content, but the scenario
+ *     as a whole stays deterministic.
+ *   - `writeSeededFiles(...)` — bulk-write a list of file specs to a
+ *     `TempGitRepo`.
+ *
+ * Both helpers reach into the parsers/__fixtures__/generators module by
+ * absolute path. That's the ONLY non-stdlib import in this directory
+ * tree — see the boundary rules in `src/lib/testUtils/README.md`.
+ * Extraction note: when this layer moves to a standalone package, the
+ * import becomes a peer dependency or the generators come along too.
+ */
+
+import { generateContentForFile } from '../../../parsers/default/__fixtures__/generators'
+import type { TempGitRepo } from '../../tempGitRepo'
+
+export type SeededFileSpec = {
+  path: string
+  /** Approximate token budget. ~chars/4. */
+  tokens: number
+  /**
+   * Optional per-file seed offset. Defaults to a stable hash of `path`
+   * so files in a scenario differ from each other without the scenario
+   * having to manage seeds.
+   */
+  seedOffset?: number
+}
+
+/**
+ * Deterministic per-file seed from a base seed + path. Same (baseSeed,
+ * path) pair always returns the same number — every file in a scenario
+ * gets distinct content while the whole scenario stays reproducible.
+ */
+export function seedForFile(baseSeed: number, path: string): number {
+  let hash = 0
+  for (let i = 0; i < path.length; i += 1) {
+    hash = ((hash << 5) - hash + path.charCodeAt(i)) | 0
+  }
+  // XOR with the base seed so passing different baseSeeds to the same
+  // (path, tokens) inputs produces different content. Without this, the
+  // base seed would be ignored.
+  return (baseSeed ^ hash) >>> 0
+}
+
+/**
+ * Generate file content using the seeded generators.
+ */
+export function seededContent(path: string, tokens: number, baseSeed: number, offset?: number): string {
+  const seed = seedForFile(baseSeed + (offset || 0), path)
+  return generateContentForFile(path, tokens, seed)
+}
+
+/**
+ * Write a batch of files to the repo with deterministic content. The
+ * order is preserved so the test layer can assert specific file paths
+ * exist in a specific shape.
+ */
+export async function writeSeededFiles(
+  repo: TempGitRepo,
+  files: SeededFileSpec[],
+  baseSeed: number,
+): Promise<void> {
+  for (const file of files) {
+    const content = seededContent(file.path, file.tokens, baseSeed, file.seedOffset)
+    await repo.writeFile(file.path, content)
+  }
+}

--- a/src/lib/testUtils/scenarios/types.ts
+++ b/src/lib/testUtils/scenarios/types.ts
@@ -1,0 +1,59 @@
+/**
+ * Scenario type definitions for `src/lib/testUtils/scenarios/`.
+ *
+ * EXTRACTION DISCIPLINE: this layer is intentionally git-tool-agnostic
+ * and a candidate for extraction to a standalone `git-scenarios` package
+ * once the abstractions stabilize. See `src/lib/testUtils/README.md`
+ * for the boundary rules and extraction criteria.
+ *
+ * In short: this file MUST NOT import anything from `src/commands/`,
+ * `src/git/`, or `src/workstation/`. The dependency graph stops at
+ * `simple-git` / Node stdlib / `__fixtures__/generators.ts` (itself
+ * git-agnostic).
+ */
+
+import type { TempGitRepo } from '../tempGitRepo'
+
+/**
+ * Categorization for filtering / listing. Used by the CLI's `list`
+ * subcommand to group scenarios when there are many of them.
+ *
+ *   - `branch`     — multi-commit branches, PR-ready states, etc.
+ *   - `worktree`   — dirty worktrees of various shapes
+ *   - `operation`  — in-progress git operations (bisect, merge, rebase)
+ *   - `history`    — history-shape scenarios (large logs, many tags)
+ *   - `stash`      — stashed changes
+ */
+export type ScenarioKind = 'branch' | 'worktree' | 'operation' | 'history' | 'stash'
+
+/**
+ * A named, deterministic git-state factory. Given a fresh `TempGitRepo`
+ * (already `git init`'d with a `main` branch and user config), `setup`
+ * brings the repo into the named state — commits, branches, staging,
+ * bisect, conflicts, etc.
+ *
+ * Setup is the ONLY side effect. The factory doesn't manage cleanup —
+ * that's the caller's job (test teardown, or the CLI's manual cleanup
+ * hint). The factory doesn't manage seeds either — scenarios that want
+ * deterministic file content pass an explicit `seed` into the content
+ * generators they use.
+ */
+export type Scenario = {
+  /** Stable identifier — kebab-case. Used as the CLI argument. */
+  name: string
+  /** One-line summary shown in `npm run scenario list`. */
+  summary: string
+  /** Multi-line description shown in `npm run scenario describe <name>`. */
+  description: string
+  /** Filtering category. */
+  kind: ScenarioKind
+  /** The actual state factory. Mutates the given repo. */
+  setup: (repo: TempGitRepo) => Promise<void>
+  /**
+   * Optional: a list of human-readable expectations the test layer
+   * verifies. Each line is something like "main has 5 commits" or
+   * "bisect is active." These also document the scenario's contract
+   * for the CLI's `describe` output.
+   */
+  contracts?: string[]
+}

--- a/src/lib/testUtils/spinUpScenario.test.ts
+++ b/src/lib/testUtils/spinUpScenario.test.ts
@@ -1,0 +1,35 @@
+import { spinUpScenario } from './spinUpScenario'
+import type { TempGitRepo } from './tempGitRepo'
+
+describe('spinUpScenario', () => {
+  const repos: TempGitRepo[] = []
+
+  afterAll(async () => {
+    await Promise.all(repos.map((r) => r.cleanup()))
+  })
+
+  it('returns a TempGitRepo with the named scenario applied', async () => {
+    const repo = await spinUpScenario('feature-pr-ready')
+    repos.push(repo)
+    const status = await repo.git.status()
+    expect(status.current).toBe('feat/widget-v2')
+    expect(status.isClean()).toBe(true)
+  }, 30_000)
+
+  it('throws a helpful error with the available names for an unknown scenario', async () => {
+    await expect(spinUpScenario('does-not-exist')).rejects.toThrow(
+      /Unknown scenario "does-not-exist"\. Available: .*feature-pr-ready/
+    )
+  })
+
+  it('produces independent repos when called multiple times', async () => {
+    const a = await spinUpScenario('multi-commit-branch')
+    const b = await spinUpScenario('multi-commit-branch')
+    repos.push(a, b)
+    expect(a.path).not.toBe(b.path)
+    // Same scenario name + deterministic seeds → identical commit graph.
+    const aLog = await a.git.log()
+    const bLog = await b.git.log()
+    expect(aLog.all.map((c) => c.message)).toEqual(bLog.all.map((c) => c.message))
+  }, 60_000)
+})

--- a/src/lib/testUtils/spinUpScenario.ts
+++ b/src/lib/testUtils/spinUpScenario.ts
@@ -1,0 +1,51 @@
+/**
+ * Programmatic API for the scenario library — the one-line replacement
+ * for hand-writing inline `tempGitRepo` setup in integration tests.
+ *
+ * Before:
+ *   const repo = await createTempGitRepo()
+ *   await repo.writeFile('.gitkeep', '\n')
+ *   await repo.commitAll('chore: initial commit')
+ *   await repo.writeFile('README.md', '# Temp repo\n')
+ *   // ... 12 more lines ...
+ *
+ * After:
+ *   const repo = await spinUpScenario('feature-pr-ready')
+ *
+ * The returned object is the same `TempGitRepo` shape (`path`, `git`,
+ * `writeFile`, `commitAll`, `cleanup`) so tests can still poke the
+ * worktree afterward for the specific edge they care about.
+ *
+ * EXTRACTION DISCIPLINE: this is the public programmatic API. When the
+ * scenario library extracts to a standalone package, this is the entry
+ * point consumers will import.
+ */
+
+import { createTempGitRepo, type TempGitRepo } from './tempGitRepo'
+import { findScenario } from './scenarios'
+
+/**
+ * Spin up a temp git repo and run the named scenario's setup against
+ * it. The repo is the standard `TempGitRepo` shape — caller is
+ * responsible for `cleanup()` in test teardown.
+ *
+ * @throws if the scenario name is unknown — error message lists the
+ *   available names so the typo is easy to spot.
+ */
+export async function spinUpScenario(name: string): Promise<TempGitRepo> {
+  const scenario = findScenario(name)
+  if (!scenario) {
+    // Surface available names so the consumer can see the typo at a
+    // glance. The list is small (currently 4 scenarios); we can prune
+    // to fuzzy-match suggestions if it grows past ~20.
+    const { allScenarios } = await import('./scenarios')
+    const available = allScenarios.map((s) => s.name).join(', ')
+    throw new Error(
+      `Unknown scenario "${name}". Available: ${available}`
+    )
+  }
+
+  const repo = await createTempGitRepo()
+  await scenario.setup(repo)
+  return repo
+}


### PR DESCRIPTION
Adds a layer between `tempGitRepo` (bare-bones init helper) and the things we want to test. **Named, deterministic git-state factories** serve two consumers:

1. **Integration tests** — `spinUpScenario('feature-pr-ready')` replaces inline `writeFile`/`commitAll` boilerplate with one call to a known baseline.
2. **Manual testing** — `npm run scenario create <name> [--path | --run-ui | --ephemeral]` materializes a scenario on disk for hand-testing the workstation. `--run-ui` spawns `coco ui` against it for the tightest demo loop.

## Why this exists

[Audit thread](/) on existing tooling: nothing on npm fits.

| Package | What it is | Why it doesn't fit |
|---|---|---|
| `@ianwalter/faygit` | One-shot CLI generating random HTML files + random commits | Random (unseeded). One scenario. 4 downloads. Demo-data generator, not a library. |
| `mock-git` | Stub the `git` binary | Different category — we want **real** git state. |
| `isomorphic-git` / `js-git` | Git implementations | Internal test fixtures, not exposed. |
| `testcontainers` + git | Docker-based | Way overkill. |

No "ChaosMonkey for git" exists either. The gap is real.

## What you get

### Initial scenarios

```
$ npm run scenario list

Available scenarios (4):

  branch:
    feature-pr-ready             feature branch with 4 commits, clean worktree, ready to open a PR
    multi-commit-branch          feature branch with 8 varied commits (feat/fix/chore/docs/refactor/test)

  worktree:
    dirty-many-files             12 staged + 6 unstaged + 3 untracked across 3 top-level dirs

  operation:
    mid-bisect                   20-commit history with `git bisect` started, HEAD at midpoint
```

Each scenario is **fully deterministic** — stable seeds, seeded content generators from `src/lib/parsers/default/__fixtures__/generators.ts` (which were already git-agnostic). Same scenario name → identical git state across runs.

### Programmatic API

```ts
import { spinUpScenario } from 'src/lib/testUtils/spinUpScenario'

beforeAll(async () => {
  repo = await spinUpScenario('feature-pr-ready')
})

afterAll(async () => {
  await repo.cleanup()
})
```

Returns the standard `TempGitRepo` shape — tests still poke the worktree afterward for the specific edge they care about.

### CLI

```bash
npm run scenario list                                    # show all
npm run scenario describe feature-pr-ready              # describe one
npm run scenario create feature-pr-ready                # materialize (persisted)
npm run scenario create feature-pr-ready -- --run-ui    # materialize + launch coco ui
npm run scenario create feature-pr-ready -- --ephemeral # auto-clean on exit
npm run scenario create feature-pr-ready -- --path ~/sandbox  # custom location
```

`--run-ui` is the killer feature for manual workflow validation: one command spins up a known state and drops you straight into the workstation against it. Tight loop for testing the recent feature work:

- **`feature-pr-ready` + `--run-ui`** → land on the workstation with a feature branch ready for `C` (create-pr from #905) and `L` (changelog view from #906).
- **`dirty-many-files` + `--run-ui`** → land on the workstation with a sprawling dirty worktree — perfect for validating the future split-in-compose work (#907).
- **`mid-bisect` + `--run-ui`** → land on the bisect view with an active bisect.

## Extraction discipline (the key design decision)

Per the audit discussion: this layer is **a candidate for extraction to a standalone `git-scenarios` package** once the abstractions stabilize. Building it in coco first to prove the API, but with strict boundary rules so extraction stays mechanical:

- **No coco-specific imports inside `scenarios/`.** Imports limited to: `simple-git`, Node stdlib, `tempGitRepo` (sibling), and the git-agnostic content generators.
- **Scenario signatures are pure git-state factories.** `(repo: TempGitRepo) => Promise<void>`. No knowledge of which tool tests them.
- **Public surface is `spinUpScenario.ts` + the CLI's `list`/`describe`/`create`.** Tests import only from `spinUpScenario`; nothing else reaches into `scenarios/*.ts` directly.
- **The CLI's `--run-ui` flag is the only coco-aware piece.** When extracted, it becomes `--run <command>` for arbitrary tools.

Full extraction plan + criteria documented in `src/lib/testUtils/README.md`. Rough trigger: after 3–6 months of use, when a second project wants it OR an external user asks for it.

## What's new in this PR

| File | LOC | Purpose |
|---|---|---|
| `bin/scenario.ts` | 200 | CLI driver: list / describe / create + flags |
| `src/lib/testUtils/README.md` | 142 | Usage docs + extraction discipline |
| `src/lib/testUtils/spinUpScenario.ts` | 51 | Programmatic API |
| `src/lib/testUtils/spinUpScenario.test.ts` | 35 | API tests (3 cases) |
| `src/lib/testUtils/scenarios/types.ts` | 59 | `Scenario` type |
| `src/lib/testUtils/scenarios/index.ts` | 48 | Registry + `findScenario` |
| `src/lib/testUtils/scenarios/index.test.ts` | 45 | Registry tests (5 cases) |
| `src/lib/testUtils/scenarios/shared/seededFiles.ts` | 74 | Content helper wrapping `__fixtures__/generators` |
| `src/lib/testUtils/scenarios/feature-pr-ready.ts` | 113 | + test (5 cases) |
| `src/lib/testUtils/scenarios/multi-commit-branch.ts` | 87 | + test (5 cases) |
| `src/lib/testUtils/scenarios/dirty-many-files.ts` | 126 | + test (4 cases) |
| `src/lib/testUtils/scenarios/mid-bisect.ts` | 74 | + test (4 cases) |
| `package.json` | +1 line | New `scenario` script |

**Net: +1,368 LOC across 17 files.** New jest scope: +6 suites, +21 tests.

## Validation

- `tsc --noEmit`: clean
- `eslint src`: clean
- Full Jest suite: **686/686 suites, 6,600/6,600 tests passing**
- All four scenarios verified end-to-end manually via `npm run scenario create` + inspecting `git status` / `git log` against the materialized state. Programmatic verification covered by the per-scenario `*.test.ts` files asserting the declared `contracts`.

## What's deliberately NOT in this PR

- **More scenarios**: `mid-merge-conflict`, `large-history`, `stashed-changes`, `dirty-mixed` (small variant). Cheap to add as needed — the pattern is now established.
- **Migrating `commands.integration.test.ts`** (880 LOC) to use scenarios. Mechanical follow-up; would shrink that file significantly.
- **Chaos layer**: random failure injection (corrupt objects, detached HEAD, dangling refs) wrapping a scenario. Composes orthogonally. v2.
- **Extraction**: see README for criteria. Roughly 3–6 months of usage horizon.

## Smoke test

After merging, try:

```bash
# Validate the workstation against the create-pr feature
npm run scenario create feature-pr-ready -- --run-ui
# → Press `C` to test #905's create-pr flow
# → Press `L` to test #906's changelog view

# Validate against the future split-in-compose work (#907)
npm run scenario create dirty-many-files -- --run-ui
# → Navigate to compose, see the staged + unstaged file counts

# Quick bisect-view check
npm run scenario create mid-bisect -- --run-ui
# → Press `g B` to land on the bisect view
```