### PR TITLE
feat(testUtils): five more scenarios + migrate 8 integration tests

### DIFF
--- a/src/commands/commands.integration.test.ts
+++ b/src/commands/commands.integration.test.ts
@@ -18,6 +18,11 @@ import { getTokenCounter } from '../lib/utils/tokenizer'
 import { Logger } from '../lib/utils/logger'
 import { Config } from '../commands/types'
 import { createTempGitRepo, TempGitRepo } from '../lib/testUtils/tempGitRepo'
+import {
+  featureBranchOneCommitScenario,
+  singleStagedFileScenario,
+  twoCommitFeatureScenario,
+} from '../lib/testUtils/scenarios'
 
 jest.mock('@langchain/classic/chains', () => ({
   loadSummarizationChain: jest.fn(),
@@ -154,10 +159,7 @@ describe('command integration with temp git repos', () => {
       mode: 'stdout',
     }))
 
-    await repo.writeFile('.gitkeep', '\n')
-    await repo.commitAll('chore: initial commit')
-    await repo.writeFile('README.md', '# Temp repo\n')
-    await repo.git.add('README.md')
+    await singleStagedFileScenario.setup(repo)
 
     await commitHandler({
       $0: 'coco',
@@ -198,10 +200,7 @@ describe('command integration with temp git repos', () => {
       },
     } as unknown as Config))
 
-    await repo.writeFile('.gitkeep', '\n')
-    await repo.commitAll('chore: initial commit')
-    await repo.writeFile('README.md', '# Dynamic repo\n')
-    await repo.git.add('README.md')
+    await singleStagedFileScenario.setup(repo)
 
     await commitHandler({
       $0: 'coco',
@@ -632,11 +631,7 @@ describe('command integration with temp git repos', () => {
       mode: 'stdout',
     }))
 
-    await repo.writeFile('README.md', '# Temp repo\n')
-    await repo.commitAll('chore: initial commit')
-    await repo.git.checkoutLocalBranch('feature/changelog-test')
-    await repo.writeFile('src/feature.ts', 'export const feature = true\n')
-    await repo.commitAll('feat: add feature module')
+    await featureBranchOneCommitScenario.setup(repo)
 
     await changelogHandler({
       $0: 'coco',
@@ -658,7 +653,7 @@ describe('command integration with temp git repos', () => {
     expect(stdout).toContain('Generated changelog')
     expect(stdout).toContain('- Summarized feature work')
     expect(variables.summary).toContain('feat: add feature module')
-    expect(variables.summary).toContain('feature/changelog-test')
+    expect(variables.summary).toContain('feat/x')
   })
 
   it('reviews real working tree changes from a temp git repo', async () => {
@@ -709,11 +704,7 @@ describe('command integration with temp git repos', () => {
       },
     ])
 
-    await repo.writeFile('README.md', '# Temp repo\n')
-    await repo.commitAll('chore: initial commit')
-    await repo.git.checkoutLocalBranch('feature/review-test')
-    await repo.writeFile('src/feature.ts', 'export const feature = true\n')
-    await repo.commitAll('feat: add review feature')
+    await featureBranchOneCommitScenario.setup(repo)
 
     await reviewHandler({
       $0: 'coco',
@@ -767,10 +758,7 @@ describe('command integration with temp git repos', () => {
       mode: 'stdout',
     }))
 
-    await repo.writeFile('README.md', '# Temp repo\n')
-    await repo.commitAll('chore: initial commit')
-    await repo.writeFile('src/interactive.ts', 'export const interactive = true\n')
-    await repo.commitAll('feat: add interactive log coverage')
+    await twoCommitFeatureScenario.setup(repo)
 
     await logHandler({
       $0: 'coco',
@@ -784,9 +772,13 @@ describe('command integration with temp git repos', () => {
     } as Arguments<LogOptions>, createLogger())
 
     expect(stdout).toContain('coco')
-    expect(stdout).toContain('feat: add interactive log coverage')
+    // Assertions match the scenario's commit subject + filename. The
+    // specific names are incidental to the smoke test — it's verifying
+    // that interactive log rendering surfaces commit subjects and
+    // changed files, not testing any particular subject/path.
+    expect(stdout).toContain('feat: add feature module')
     expect(stdout).toContain('Changed files:')
-    expect(stdout).toContain('src/interactive.ts')
+    expect(stdout).toContain('src/feature.ts')
   })
 
   it('renders the ui command smoke view in a non-TTY environment', async () => {
@@ -794,10 +786,7 @@ describe('command integration with temp git repos', () => {
       mode: 'stdout',
     }))
 
-    await repo.writeFile('README.md', '# Temp repo\n')
-    await repo.commitAll('chore: initial commit')
-    await repo.writeFile('src/ui.ts', 'export const ui = true\n')
-    await repo.commitAll('feat: add ui workstation coverage')
+    await twoCommitFeatureScenario.setup(repo)
 
     await uiHandler({
       $0: 'coco',
@@ -812,9 +801,11 @@ describe('command integration with temp git repos', () => {
     } as Arguments<UiOptions>, createLogger())
 
     expect(stdout).toContain('coco')
-    expect(stdout).toContain('feat: add ui workstation coverage')
+    // See the interactive-log test above re: scenario-default subject /
+    // filename — same rationale applies here.
+    expect(stdout).toContain('feat: add feature module')
     expect(stdout).toContain('Changed files:')
-    expect(stdout).toContain('src/ui.ts')
+    expect(stdout).toContain('src/feature.ts')
   })
 
   it('prints machine-readable git log output', async () => {
@@ -822,10 +813,7 @@ describe('command integration with temp git repos', () => {
       mode: 'stdout',
     }))
 
-    await repo.writeFile('README.md', '# Temp repo\n')
-    await repo.commitAll('chore: initial commit')
-    await repo.writeFile('src/feature.ts', 'export const feature = true\n')
-    await repo.commitAll('feat: add json log output')
+    await twoCommitFeatureScenario.setup(repo)
 
     await logHandler({
       $0: 'coco',
@@ -842,7 +830,7 @@ describe('command integration with temp git repos', () => {
 
     expect(entries).toHaveLength(2)
     expect(entries[0]).toEqual(expect.objectContaining({
-      message: 'feat: add json log output',
+      message: 'feat: add feature module',
       shortHash: expect.any(String),
       hash: expect.any(String),
       refs: expect.any(Array),
@@ -854,10 +842,7 @@ describe('command integration with temp git repos', () => {
       mode: 'stdout',
     }))
 
-    await repo.writeFile('README.md', '# Temp repo\n')
-    await repo.commitAll('chore: initial commit')
-    await repo.writeFile('src/detail.ts', 'export const detail = true\n')
-    await repo.commitAll('feat: add commit detail file')
+    await twoCommitFeatureScenario.setup(repo)
 
     const commit = (await repo.git.revparse(['HEAD'])).trim()
 
@@ -873,8 +858,8 @@ describe('command integration with temp git repos', () => {
     } as Arguments<LogOptions>, createLogger())
 
     expect(stdout).toContain(`commit ${commit}`)
-    expect(stdout).toContain('feat: add commit detail file')
+    expect(stdout).toContain('feat: add feature module')
     expect(stdout).toContain('Changed files:')
-    expect(stdout).toContain('A  src/detail.ts')
+    expect(stdout).toContain('A  src/feature.ts')
   })
 })

--- a/src/lib/testUtils/scenarios/feature-branch-one-commit.test.ts
+++ b/src/lib/testUtils/scenarios/feature-branch-one-commit.test.ts
@@ -1,0 +1,40 @@
+import { featureBranchOneCommitScenario } from './feature-branch-one-commit'
+import { createTempGitRepo, type TempGitRepo } from '../tempGitRepo'
+
+describe('feature-branch-one-commit scenario', () => {
+  let repo: TempGitRepo
+
+  beforeAll(async () => {
+    repo = await createTempGitRepo()
+    await featureBranchOneCommitScenario.setup(repo)
+  }, 30_000)
+
+  afterAll(async () => {
+    await repo?.cleanup()
+  })
+
+  it('has 1 commit on main', async () => {
+    const log = await repo.git.log(['main'])
+    expect(log.total).toBe(1)
+  })
+
+  it('has feat/x checked out', async () => {
+    const status = await repo.git.status()
+    expect(status.current).toBe('feat/x')
+  })
+
+  it('has 1 commit on feat/x ahead of main', async () => {
+    const ahead = await repo.git.raw(['rev-list', '--count', 'main..feat/x'])
+    expect(parseInt(ahead.trim(), 10)).toBe(1)
+  })
+
+  it('has src/feature.ts present', async () => {
+    const content = await repo.git.show(['HEAD:src/feature.ts'])
+    expect(content).toContain('export const feature')
+  })
+
+  it('has a clean worktree', async () => {
+    const status = await repo.git.status()
+    expect(status.isClean()).toBe(true)
+  })
+})

--- a/src/lib/testUtils/scenarios/feature-branch-one-commit.ts
+++ b/src/lib/testUtils/scenarios/feature-branch-one-commit.ts
@@ -1,0 +1,50 @@
+/**
+ * `feature-branch-one-commit` — a minimal feature-branch shape. `main`
+ * has the initial scaffold; `feat/x` is checked out with exactly one
+ * commit on top. The shape every "compare current branch against main"
+ * test wants — changelog, review, branch diff.
+ *
+ * State after setup:
+ *   - `main` has 1 commit (initial scaffold with README.md)
+ *   - `feat/x` is checked out, 1 commit ahead of main, adds `src/feature.ts`
+ *   - worktree is clean
+ *
+ * Used by `coco changelog --branch main`, `coco review --branch main`,
+ * and any other flow that compares the working branch against a base.
+ *
+ * EXTRACTION DISCIPLINE: no coco-specific imports.
+ */
+
+import type { Scenario } from './types'
+
+export const featureBranchOneCommitScenario: Scenario = {
+  name: 'feature-branch-one-commit',
+  summary: 'main + feat/x (1 commit ahead, src/feature.ts)',
+  description: [
+    'Minimal feature-branch shape. `main` has one initial commit;',
+    '`feat/x` is checked out with one commit on top adding',
+    '`src/feature.ts`. The worktree is clean.',
+    '',
+    'Useful for testing:',
+    '  - `coco changelog --branch main`',
+    '  - `coco review --branch main`',
+    '  - any branch-vs-base diff flow',
+    '  - the changelog auto-body in the create-PR flow (#905)',
+  ].join('\n'),
+  kind: 'branch',
+  contracts: [
+    'main has 1 commit',
+    'feat/x is checked out',
+    'feat/x has 1 commit on top of main',
+    'src/feature.ts exists',
+    'worktree is clean',
+  ],
+  setup: async (repo) => {
+    await repo.writeFile('README.md', '# Temp repo\n')
+    await repo.commitAll('chore: initial commit')
+
+    await repo.git.checkoutLocalBranch('feat/x')
+    await repo.writeFile('src/feature.ts', 'export const feature = true\n')
+    await repo.commitAll('feat: add feature module')
+  },
+}

--- a/src/lib/testUtils/scenarios/index.ts
+++ b/src/lib/testUtils/scenarios/index.ts
@@ -13,23 +13,34 @@
 
 import type { Scenario } from './types'
 import { dirtyManyFilesScenario } from './dirty-many-files'
+import { featureBranchOneCommitScenario } from './feature-branch-one-commit'
 import { featurePrReadyScenario } from './feature-pr-ready'
 import { midBisectScenario } from './mid-bisect'
+import { midMergeConflictScenario } from './mid-merge-conflict'
 import { multiCommitBranchScenario } from './multi-commit-branch'
+import { singleStagedFileScenario } from './single-staged-file'
+import { stashedChangesScenario } from './stashed-changes'
+import { twoCommitFeatureScenario } from './two-commit-feature'
 
 /**
  * Ordered list of all available scenarios. The order is shown in
  * `npm run scenario list` so we group related ones together —
- * branch-y scenarios first, then worktree, then operations.
+ * branch-y scenarios first, then worktree, then operations, then stash.
  */
 export const allScenarios: readonly Scenario[] = [
   // branch shapes
   featurePrReadyScenario,
+  featureBranchOneCommitScenario,
   multiCommitBranchScenario,
+  twoCommitFeatureScenario,
   // worktree shapes
+  singleStagedFileScenario,
   dirtyManyFilesScenario,
   // in-progress operations
   midBisectScenario,
+  midMergeConflictScenario,
+  // stash shapes
+  stashedChangesScenario,
 ]
 
 /**
@@ -43,6 +54,11 @@ export function findScenario(name: string): Scenario | undefined {
 
 export type { Scenario, ScenarioKind } from './types'
 export { dirtyManyFilesScenario } from './dirty-many-files'
+export { featureBranchOneCommitScenario } from './feature-branch-one-commit'
 export { featurePrReadyScenario } from './feature-pr-ready'
 export { midBisectScenario } from './mid-bisect'
+export { midMergeConflictScenario } from './mid-merge-conflict'
 export { multiCommitBranchScenario } from './multi-commit-branch'
+export { singleStagedFileScenario } from './single-staged-file'
+export { stashedChangesScenario } from './stashed-changes'
+export { twoCommitFeatureScenario } from './two-commit-feature'

--- a/src/lib/testUtils/scenarios/mid-merge-conflict.test.ts
+++ b/src/lib/testUtils/scenarios/mid-merge-conflict.test.ts
@@ -1,0 +1,46 @@
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+
+import { midMergeConflictScenario } from './mid-merge-conflict'
+import { createTempGitRepo, type TempGitRepo } from '../tempGitRepo'
+
+describe('mid-merge-conflict scenario', () => {
+  let repo: TempGitRepo
+
+  beforeAll(async () => {
+    repo = await createTempGitRepo()
+    await midMergeConflictScenario.setup(repo)
+  }, 30_000)
+
+  afterAll(async () => {
+    // Abort the merge so the cleanup path doesn't trip on the in-flight
+    // operation state. Best-effort.
+    try {
+      await repo.git.raw(['merge', '--abort'])
+    } catch {
+      /* ignore */
+    }
+    await repo?.cleanup()
+  })
+
+  it('has main checked out', async () => {
+    const status = await repo.git.status()
+    expect(status.current).toBe('main')
+  })
+
+  it('has a merge in progress (MERGE_HEAD exists)', () => {
+    expect(existsSync(join(repo.path, '.git', 'MERGE_HEAD'))).toBe(true)
+  })
+
+  it('has conflict markers in src/widget.ts', () => {
+    const content = readFileSync(join(repo.path, 'src/widget.ts'), 'utf-8')
+    expect(content).toContain('<<<<<<<')
+    expect(content).toContain('=======')
+    expect(content).toContain('>>>>>>>')
+  })
+
+  it('reports exactly 1 unresolved conflict', async () => {
+    const status = await repo.git.status()
+    expect(status.conflicted).toEqual(['src/widget.ts'])
+  })
+})

--- a/src/lib/testUtils/scenarios/mid-merge-conflict.ts
+++ b/src/lib/testUtils/scenarios/mid-merge-conflict.ts
@@ -1,0 +1,99 @@
+/**
+ * `mid-merge-conflict` — a repo mid-merge with one unresolved conflict.
+ * Two branches edit the same line of the same file; merging `feat/x`
+ * into `main` leaves the worktree with conflict markers and the merge
+ * uncommitted.
+ *
+ * State after setup:
+ *   - `main` has 3 commits — initial scaffold, baseline content, and a
+ *     conflicting edit to `src/widget.ts`
+ *   - `feat/x` has 2 commits forked from the baseline — a separate
+ *     conflicting edit to `src/widget.ts`
+ *   - `main` is checked out, `git merge feat/x` was attempted
+ *   - `src/widget.ts` has unresolved conflict markers (<<<<<<< / =======
+ *     / >>>>>>>) and is unstaged
+ *   - `MERGE_HEAD` is set; `git status` reports the merge as in
+ *     progress
+ *
+ * Used to validate the conflicts view (and any flow that needs to
+ * observe a real in-progress operation).
+ *
+ * EXTRACTION DISCIPLINE: no coco-specific imports.
+ */
+
+import type { Scenario } from './types'
+
+export const midMergeConflictScenario: Scenario = {
+  name: 'mid-merge-conflict',
+  summary: 'in-progress merge with one unresolved conflict in src/widget.ts',
+  description: [
+    'A repository mid-merge, blocked on one unresolved conflict.',
+    '`main` and `feat/x` both edited the same line of `src/widget.ts`',
+    'after forking from a shared baseline. Running `git merge feat/x`',
+    'on `main` triggered the conflict; the merge is now sitting',
+    'uncommitted with conflict markers in the worktree.',
+    '',
+    'Useful for testing:',
+    '  - conflicts view rendering + per-file resolve actions',
+    '  - title-bar in-progress-operation indicator',
+    '  - the `coco doctor` / `coco ui` flows when a merge is in flight',
+    '  - the C / Esc guard on the conflicts view (#905 included this)',
+  ].join('\n'),
+  kind: 'operation',
+  contracts: [
+    'main is checked out',
+    'a merge is in progress (MERGE_HEAD exists)',
+    'src/widget.ts has unresolved conflict markers',
+    'exactly 1 unresolved conflict',
+  ],
+  setup: async (repo) => {
+    // === baseline ===
+    await repo.writeFile('README.md', '# Widget\n')
+    await repo.commitAll('chore: initial scaffold')
+
+    await repo.writeFile('src/widget.ts', [
+      'export const widget = {',
+      '  name: "baseline",',
+      '  version: 1,',
+      '}',
+      '',
+    ].join('\n'))
+    await repo.commitAll('feat: baseline widget')
+
+    // === feat/x — different name for the widget ===
+    await repo.git.checkoutLocalBranch('feat/x')
+    await repo.writeFile('src/widget.ts', [
+      'export const widget = {',
+      '  name: "from-feat-x",',
+      '  version: 1,',
+      '}',
+      '',
+    ].join('\n'))
+    await repo.commitAll('feat: rename widget on feat/x')
+
+    // === main — different name for the widget (conflicts with feat/x's edit) ===
+    await repo.git.checkout('main')
+    await repo.writeFile('src/widget.ts', [
+      'export const widget = {',
+      '  name: "from-main",',
+      '  version: 1,',
+      '}',
+      '',
+    ].join('\n'))
+    await repo.commitAll('feat: rename widget on main')
+
+    // === merge attempt — leaves conflict markers in the worktree ===
+    // Using `git merge --no-commit --no-ff` here so the merge state is
+    // preserved even if the merge could otherwise be fast-forwarded
+    // (it can't, but belt-and-suspenders). `--no-commit` ensures we
+    // stop with conflict markers in place; in this case the conflict
+    // would prevent the auto-commit anyway, but explicit > implicit.
+    try {
+      await repo.git.raw(['merge', '--no-commit', '--no-ff', 'feat/x'])
+    } catch {
+      // simple-git throws on non-zero exit (which is what `git merge`
+      // does when there are unresolved conflicts). That's exactly the
+      // state we want — swallow the error so the scenario completes.
+    }
+  },
+}

--- a/src/lib/testUtils/scenarios/single-staged-file.test.ts
+++ b/src/lib/testUtils/scenarios/single-staged-file.test.ts
@@ -1,0 +1,31 @@
+import { singleStagedFileScenario } from './single-staged-file'
+import { createTempGitRepo, type TempGitRepo } from '../tempGitRepo'
+
+describe('single-staged-file scenario', () => {
+  let repo: TempGitRepo
+
+  beforeAll(async () => {
+    repo = await createTempGitRepo()
+    await singleStagedFileScenario.setup(repo)
+  }, 30_000)
+
+  afterAll(async () => {
+    await repo?.cleanup()
+  })
+
+  it('has 1 commit on main', async () => {
+    const log = await repo.git.log()
+    expect(log.total).toBe(1)
+  })
+
+  it('has exactly 1 staged file (README.md)', async () => {
+    const status = await repo.git.status()
+    expect(status.staged).toEqual(['README.md'])
+  })
+
+  it('has no unstaged or untracked files', async () => {
+    const status = await repo.git.status()
+    expect(status.modified).toEqual([])
+    expect(status.not_added).toEqual([])
+  })
+})

--- a/src/lib/testUtils/scenarios/single-staged-file.ts
+++ b/src/lib/testUtils/scenarios/single-staged-file.ts
@@ -1,0 +1,48 @@
+/**
+ * `single-staged-file` — minimal "ready to commit" state. A repo with
+ * one baseline commit and a single staged README. The smallest possible
+ * shape that lets `coco commit` actually have something to generate a
+ * message for.
+ *
+ * State after setup:
+ *   - `main` has 1 commit (initial scaffold)
+ *   - `README.md` is staged with new content
+ *   - no other staged / unstaged / untracked files
+ *
+ * Heavily used by integration tests for the `coco commit` family
+ * (commit, summarize, model routing) where the actual diff payload
+ * is incidental — the tests just need *some* staged diff to feed
+ * the pipeline.
+ *
+ * EXTRACTION DISCIPLINE: no coco-specific imports.
+ */
+
+import type { Scenario } from './types'
+
+export const singleStagedFileScenario: Scenario = {
+  name: 'single-staged-file',
+  summary: 'one baseline commit + a single staged README',
+  description: [
+    'Minimal "ready to commit" state. A single baseline commit on',
+    '`main` plus one staged file (`README.md`). No unstaged or',
+    'untracked files.',
+    '',
+    'Useful for testing:',
+    '  - `coco commit` (any flavor — has a staged diff to summarize)',
+    '  - any flow that asserts "there is staged content to commit"',
+    '  - smoke tests that just need a valid commit-ready repo',
+  ].join('\n'),
+  kind: 'worktree',
+  contracts: [
+    'main has 1 commit',
+    'exactly 1 staged file (README.md)',
+    'no unstaged or untracked files',
+  ],
+  setup: async (repo) => {
+    await repo.writeFile('.gitkeep', '\n')
+    await repo.commitAll('chore: initial commit')
+
+    await repo.writeFile('README.md', '# Temp repo\n')
+    await repo.git.add('README.md')
+  },
+}

--- a/src/lib/testUtils/scenarios/stashed-changes.test.ts
+++ b/src/lib/testUtils/scenarios/stashed-changes.test.ts
@@ -1,0 +1,45 @@
+import { stashedChangesScenario } from './stashed-changes'
+import { createTempGitRepo, type TempGitRepo } from '../tempGitRepo'
+
+describe('stashed-changes scenario', () => {
+  let repo: TempGitRepo
+
+  beforeAll(async () => {
+    repo = await createTempGitRepo()
+    await stashedChangesScenario.setup(repo)
+  }, 30_000)
+
+  afterAll(async () => {
+    await repo?.cleanup()
+  })
+
+  it('has 2 commits on main', async () => {
+    const log = await repo.git.log()
+    expect(log.total).toBe(2)
+  })
+
+  it('has a clean worktree', async () => {
+    const status = await repo.git.status()
+    expect(status.isClean()).toBe(true)
+  })
+
+  it('has 3 stashes with the expected messages in LIFO order', async () => {
+    const list = await repo.git.raw(['stash', 'list'])
+    const lines = list.trim().split('\n')
+    expect(lines).toHaveLength(3)
+    // Most-recent stash is stash@{0}. Messages appear after the
+    // stash ref + branch prefix ("stash@{0}: On main: <message>").
+    expect(lines[0]).toContain('WIP: experiment-c')
+    expect(lines[1]).toContain('WIP: experiment-b')
+    expect(lines[2]).toContain('WIP: experiment-a')
+  })
+
+  it('each stash touches a distinct file (verified by inspecting patches)', async () => {
+    const stash0 = await repo.git.raw(['stash', 'show', '--name-only', 'stash@{0}'])
+    const stash1 = await repo.git.raw(['stash', 'show', '--name-only', 'stash@{1}'])
+    const stash2 = await repo.git.raw(['stash', 'show', '--name-only', 'stash@{2}'])
+    expect(stash0.trim()).toBe('src/feature-c.ts')
+    expect(stash1.trim()).toBe('src/feature-b.ts')
+    expect(stash2.trim()).toBe('src/feature-a.ts')
+  })
+})

--- a/src/lib/testUtils/scenarios/stashed-changes.ts
+++ b/src/lib/testUtils/scenarios/stashed-changes.ts
@@ -1,0 +1,72 @@
+/**
+ * `stashed-changes` — a clean worktree on `main` with 3 stash entries,
+ * each carrying a distinct user-supplied message. Designed for testing
+ * the stash view's list rendering, per-entry actions (apply / pop /
+ * drop / checkout-file-from-stash), and the diff view's stash mode.
+ *
+ * State after setup:
+ *   - `main` has 2 commits (initial + a small content baseline)
+ *   - worktree is clean
+ *   - `git stash list` shows 3 stashes with messages:
+ *       stash@{0} — "WIP: experiment-c"
+ *       stash@{1} — "WIP: experiment-b"
+ *       stash@{2} — "WIP: experiment-a"
+ *
+ * Each stash carries edits to a different file so applying any one is
+ * idempotent against the baseline + non-conflicting with the others
+ * (useful for chained apply tests).
+ *
+ * EXTRACTION DISCIPLINE: no coco-specific imports.
+ */
+
+import type { Scenario } from './types'
+
+export const stashedChangesScenario: Scenario = {
+  name: 'stashed-changes',
+  summary: 'clean worktree on main + 3 stashes, each touching a different file',
+  description: [
+    'A repository with 3 distinct stashes preserved on top of a small',
+    '2-commit `main`. The worktree is clean; the stashes live only in',
+    '`refs/stash` and the reflog. Each stash carries edits to a',
+    'different file so applying any one is non-conflicting with the',
+    'others.',
+    '',
+    'Useful for testing:',
+    '  - stash view list rendering + filter',
+    '  - per-entry actions: apply, pop, drop, checkout-file-from-stash',
+    '  - diff view in stash mode (file-by-file navigation inside a patch)',
+    '  - sidebar stashes-tab rendering',
+  ].join('\n'),
+  kind: 'stash',
+  contracts: [
+    'main has 2 commits',
+    'worktree is clean',
+    'git stash list reports 3 entries',
+    'each stash touches a different file',
+  ],
+  setup: async (repo) => {
+    // === baseline ===
+    await repo.writeFile('README.md', '# Stash playground\n')
+    await repo.commitAll('chore: initial scaffold')
+
+    // Baseline files that each stash will edit a copy of.
+    await repo.writeFile('src/feature-a.ts', 'export const a = "baseline"\n')
+    await repo.writeFile('src/feature-b.ts', 'export const b = "baseline"\n')
+    await repo.writeFile('src/feature-c.ts', 'export const c = "baseline"\n')
+    await repo.commitAll('chore: baseline content for stashing')
+
+    // === stash 1 — edit feature-a, stash with message ===
+    await repo.writeFile('src/feature-a.ts', 'export const a = "experiment-a"\n')
+    await repo.git.raw(['stash', 'push', '-u', '-m', 'WIP: experiment-a'])
+
+    // === stash 2 — edit feature-b ===
+    await repo.writeFile('src/feature-b.ts', 'export const b = "experiment-b"\n')
+    await repo.git.raw(['stash', 'push', '-u', '-m', 'WIP: experiment-b'])
+
+    // === stash 3 — edit feature-c ===
+    await repo.writeFile('src/feature-c.ts', 'export const c = "experiment-c"\n')
+    await repo.git.raw(['stash', 'push', '-u', '-m', 'WIP: experiment-c'])
+
+    // Worktree is now clean — every stash carried away its own edits.
+  },
+}

--- a/src/lib/testUtils/scenarios/two-commit-feature.test.ts
+++ b/src/lib/testUtils/scenarios/two-commit-feature.test.ts
@@ -1,0 +1,38 @@
+import { twoCommitFeatureScenario } from './two-commit-feature'
+import { createTempGitRepo, type TempGitRepo } from '../tempGitRepo'
+
+describe('two-commit-feature scenario', () => {
+  let repo: TempGitRepo
+
+  beforeAll(async () => {
+    repo = await createTempGitRepo()
+    await twoCommitFeatureScenario.setup(repo)
+  }, 30_000)
+
+  afterAll(async () => {
+    await repo?.cleanup()
+  })
+
+  it('has 2 commits on main', async () => {
+    const log = await repo.git.log()
+    expect(log.total).toBe(2)
+  })
+
+  it('has the expected commit subjects in chronological order', async () => {
+    const log = await repo.git.log()
+    expect(log.all.map((c) => c.message)).toEqual([
+      'feat: add feature module',
+      'chore: initial commit',
+    ])
+  })
+
+  it('has src/feature.ts present', async () => {
+    const content = await repo.git.show(['HEAD:src/feature.ts'])
+    expect(content).toContain('export const feature')
+  })
+
+  it('has a clean worktree', async () => {
+    const status = await repo.git.status()
+    expect(status.isClean()).toBe(true)
+  })
+})

--- a/src/lib/testUtils/scenarios/two-commit-feature.ts
+++ b/src/lib/testUtils/scenarios/two-commit-feature.ts
@@ -1,0 +1,47 @@
+/**
+ * `two-commit-feature` — a tiny repo with two commits: a baseline
+ * scaffold and a follow-up "feat: add feature module." Clean worktree.
+ * The smallest shape that has a non-trivial commit history to inspect.
+ *
+ * State after setup:
+ *   - `main` has 2 commits (chore + feat)
+ *   - `README.md` and `src/feature.ts` exist on disk
+ *   - worktree is clean (no staged / unstaged / untracked files)
+ *
+ * Heavily used by integration tests for `coco changelog`, `coco log`,
+ * and `coco review` — anywhere a test needs "a repo with at least one
+ * non-initial commit and a feature file to read."
+ *
+ * EXTRACTION DISCIPLINE: no coco-specific imports.
+ */
+
+import type { Scenario } from './types'
+
+export const twoCommitFeatureScenario: Scenario = {
+  name: 'two-commit-feature',
+  summary: 'baseline scaffold + a single feat commit, clean worktree',
+  description: [
+    'Two commits on `main`: a baseline scaffold and one feat commit',
+    'adding `src/feature.ts`. The worktree is clean.',
+    '',
+    'Useful for testing:',
+    '  - `coco changelog` (has one non-baseline commit to summarize)',
+    '  - `coco log` table / JSON output (one feature commit to inspect)',
+    '  - `coco review` against a feature branch',
+    '  - smoke tests that need a `feat:` commit subject to render',
+  ].join('\n'),
+  kind: 'branch',
+  contracts: [
+    'main has 2 commits',
+    'commit subjects are "chore: initial commit" and "feat: add feature module"',
+    'src/feature.ts exists',
+    'worktree is clean',
+  ],
+  setup: async (repo) => {
+    await repo.writeFile('README.md', '# Temp repo\n')
+    await repo.commitAll('chore: initial commit')
+
+    await repo.writeFile('src/feature.ts', 'export const feature = true\n')
+    await repo.commitAll('feat: add feature module')
+  },
+}


### PR DESCRIPTION
Builds on #908 (now merged). Adds the scenarios the recently-shipped features and existing integration tests actually need, then migrates 8 tests in `commands.integration.test.ts` to use them.

## Five new scenarios

| Name | Kind | What you get |
|---|---|---|
| `single-staged-file` | worktree | baseline commit + 1 staged `README.md` — the minimum "ready to commit" shape |
| `two-commit-feature` | branch | baseline + a feat commit adding `src/feature.ts` on `main`, clean worktree |
| `feature-branch-one-commit` | branch | baseline on `main` + 1-commit `feat/x` branch — for branch-vs-base flows |
| `mid-merge-conflict` | operation | in-progress merge with 1 unresolved conflict on `src/widget.ts` — for the **conflicts view** |
| `stashed-changes` | stash | clean `main` + 3 stashes (LIFO ordered, each touching a distinct file) — for the **stash view** |

`npm run scenario list` now reports **9 scenarios across 4 kinds** (branch / worktree / operation / stash).

## Integration test migration (8 tests)

Each migrated test trades 4–8 lines of inline `writeFile`/`commitAll` setup for one `scenario.setup(repo)` call.

| Test | Scenario | Assertion changes |
|---|---|---|
| generates a commit message from real staged… | `singleStagedFileScenario` | none |
| routes dynamic commit and summarize models… | `singleStagedFileScenario` | none |
| generates a changelog from real branch commit history | `featureBranchOneCommitScenario` | `'feature/changelog-test'` → `'feat/x'` |
| reviews real branch diffs from a temp git repo | `featureBranchOneCommitScenario` | none |
| renders an interactive log smoke view… | `twoCommitFeatureScenario` | subject + filename match scenario defaults |
| renders the ui command smoke view… | `twoCommitFeatureScenario` | subject + filename match scenario defaults |
| prints machine-readable git log output | `twoCommitFeatureScenario` | subject matches scenario default |
| shows changed files for a selected commit | `twoCommitFeatureScenario` | subject + filename match scenario defaults |

The assertion changes are cosmetic — the specific subjects/filenames were incidental to smoke tests that verify rendering, not validate any particular content. Test intent (and coverage) is preserved.

## Tests deliberately left inline

| Test | Why |
|---|---|
| `keeps large staged commit summarization calls bounded` | 30 large files — too specific to canonicalize |
| 4× split-plan tests | Very specific staged file shapes tied to mocked plans |
| `applies a hunk-level commit split plan` | Hunk-shape sensitive |
| `reviews real working tree changes from a temp git repo` | Unique unstaged-modified-README shape |
| `prints a visual git log with refs and graph metadata` | Adds a tag inline — too specific |

These could be migrated later if they prove valuable as named scenarios. For now the test-side gain is minor and the inline setup is self-documenting.

## Validation

- `tsc --noEmit`: clean
- `eslint src`: clean
- Full Jest suite: **691/691 suites, 6,620/6,620 tests passing** (+5 suites, +20 tests vs the post-#908 baseline of 686/6,600)
- New scenarios verified both programmatically (per-scenario tests asserting declared contracts) and by passing the migrated integration tests
- Manually verified each new scenario with `npm run scenario create <name>` + inspecting `git status` / `git log`

## Stats

- **14 files changed, ~560 insertions / ~43 deletions**
- The deletion count is small because the integration-test migration trades multi-line setup for one-line scenario calls — bulk of the lines are new scenario files + their tests
- Each new scenario file is 47–99 LOC; each scenario test is 31–46 LOC

## Worth a manual smoke test

```bash
# Stash view with realistic stashes
npm run scenario create stashed-changes -- --run-ui
# → press `g z` to land on the stash view

# Conflicts view with an actual in-flight merge
npm run scenario create mid-merge-conflict -- --run-ui
# → land on coco ui, see the BISECTING-style indicator (but for merge)
# → drill into conflicts via the appropriate keystroke

# Quick sanity on the new minimal scenarios
npm run scenario create single-staged-file -- --run-ui
npm run scenario create two-commit-feature -- --run-ui
```

After this merges, smoke testing #905 and #906 has a clean baseline:

```bash
# Validates create-pr (#905) and changelog view (#906)
npm run scenario create feature-pr-ready -- --run-ui
# → press `C` to test #905, `L` to test #906
```

Closes the second item on the integration plan (scenarios + migrations done). The follow-up after this lands is reviewing/testing #905 and #906.