### PR TITLE
docs: refresh contributor + workstation + testUtils docs post-0.48.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,41 @@ To set up a development environment for Commit Copilot, follow these steps:
 4. Build the project locally with `npm run build` and ensure that tests pass with `npm test`.
 5. You are now ready to start making changes!
 
+### Where things live
+
+The codebase is split into four top-level concerns under `src/`:
+
+- `commands/` — CLI subcommands (`commit`, `changelog`, `log`, `ui`, `review`, `recap`, etc.)
+- `git/` — Shared git data layer (overview loaders + workstation-shaped action wrappers)
+- `workstation/` — The full Ink-based TUI. **Has its own `README.md`** documenting the layout, the input → state → render flow, and how to add a new view.
+- `lib/` — Core libraries (config, langchain, simple-git, parsers, ui, utils, testUtils)
+
+If you're contributing TUI changes, read `src/workstation/README.md` first.
+
+### Testing the workstation (`coco ui`)
+
+Coco ships with a scenario library that spins up deterministic temp git repos for manual + automated testing. List the available scenarios, then create one and run `coco ui` against it:
+
+```bash
+npm run scenario list                                              # show all scenarios
+npm run scenario describe feature-pr-ready                         # describe one
+npm run scenario create feature-pr-ready -- --run-ui               # create + launch coco ui
+npm run scenario create dirty-many-files -- --run-ui               # different scenario
+```
+
+`--run-ui` spawns `coco ui` against the materialized repo — the tightest dev loop for trying workstation changes against a known state. The scenarios cover the common shapes (feature branch ready to PR, dirty worktree with many files, in-progress bisect, merge conflict, stashed changes, etc.) so you can validate keystroke behaviors and rendering without hand-building repo state every time.
+
+For automated tests, use `spinUpScenario` from `src/lib/testUtils/spinUpScenario` instead of inline `writeFile` / `commitAll` setup:
+
+```ts
+import { spinUpScenario } from 'src/lib/testUtils/spinUpScenario'
+
+const repo = await spinUpScenario('two-commit-feature')
+// repo.path / repo.git / repo.writeFile / repo.commitAll / repo.cleanup
+```
+
+See `src/lib/testUtils/README.md` for the full list of scenarios, the programmatic API, and the discipline for adding new scenarios.
+
 ## Documentation
 
 The GitHub wiki is the canonical source for user-facing documentation. The local wiki checkout lives at `.wiki/` and can be managed with:

--- a/src/lib/testUtils/README.md
+++ b/src/lib/testUtils/README.md
@@ -24,9 +24,14 @@ testUtils/
     ├── shared/
     │   └── seededFiles.ts (wrapper around __fixtures__/generators)
     ├── feature-pr-ready.ts
+    ├── feature-branch-one-commit.ts
+    ├── multi-commit-branch.ts
+    ├── two-commit-feature.ts
+    ├── single-staged-file.ts
     ├── dirty-many-files.ts
     ├── mid-bisect.ts
-    └── multi-commit-branch.ts
+    ├── mid-merge-conflict.ts
+    └── stashed-changes.ts
 ```
 
 The CLI driver lives in `bin/scenario.ts` and is exposed via
@@ -34,14 +39,19 @@ The CLI driver lives in `bin/scenario.ts` and is exposed via
 
 ## Available scenarios
 
-Run `npm run scenario list` for the live list. Current set:
+Run `npm run scenario list` for the live list. Current set (9 scenarios across 4 kinds):
 
 | Name | Kind | What you get |
 |---|---|---|
-| `feature-pr-ready` | branch | `feat/widget-v2` 4 commits ahead of `main`, clean worktree — for create-pr and changelog flows |
+| `feature-pr-ready` | branch | `feat/widget-v2` 4 commits ahead of `main`, clean worktree — for create-pr (`C`) and changelog (`L`) flows |
+| `feature-branch-one-commit` | branch | `main` + `feat/x` (1 commit ahead, `src/feature.ts`) — minimal branch-vs-base shape |
 | `multi-commit-branch` | branch | `feat/dashboard` with 8 varied commits — baseline for navigation / filter / yank |
+| `two-commit-feature` | branch | baseline + a feat commit on `main`, clean worktree — for changelog / log / review smoke tests |
+| `single-staged-file` | worktree | baseline + 1 staged README — minimum "ready to commit" shape |
 | `dirty-many-files` | worktree | 12 staged + 6 unstaged + 3 untracked files across `src/`, `tests/`, `docs/` — for the future split flow |
 | `mid-bisect` | operation | 20 commits + active `git bisect`, HEAD at midpoint — for the bisect view |
+| `mid-merge-conflict` | operation | in-progress merge with 1 unresolved conflict on `src/widget.ts` — for the conflicts view |
+| `stashed-changes` | stash | clean `main` + 3 stashes (LIFO ordered, each touching a distinct file) — for the stash view |
 
 ## Programmatic API
 

--- a/src/workstation/README.md
+++ b/src/workstation/README.md
@@ -141,6 +141,49 @@ For an inline keypress on an existing view, you only need:
 
 For a global chord (e.g. a new `g <letter>` view selector), the chord goes in `inkKeymap.ts` plus the route into the action / view-switch in the reducer.
 
+## Calling existing CLI commands from a workstation flow
+
+When a workstation flow needs the full behavior of a `coco <command>` (commit message generation, changelog body for PR creation, etc.), invoke the command's `handler` directly with a synthetic `argv` rather than spawning a subprocess. The pattern lives in `src/git/commitWorkflowActions.ts` and `src/git/aiActions.ts`:
+
+```ts
+// Synthetic argv shape: mode 'stdout', interactive false, silent logger
+const argv = createChangelogArgv({ branch: 'main' })
+
+// Capture stdout via process.stdout.write override
+const captured = await captureStdout(() => changelogHandler(argv, new Logger({ silent: true })))
+
+// Parse / return a typed *WorkflowResult shape
+return { ok: true, message: firstLine(captured), text: captured }
+```
+
+Worked examples:
+
+- `runCommitDraftWorkflow` → drives `coco commit` AI-draft generation from the compose surface's `I` keystroke (`src/git/commitWorkflowActions.ts`)
+- `runCommitWorkflow({ action: 'commit' | 'split-plan' | 'split-apply' })` → drives `coco commit` and its `--split` modes (`src/git/commitWorkflowActions.ts`)
+- `runChangelogTextWorkflow({ branch | sinceLastTag | tag | range })` → drives `coco changelog` and returns raw stdout (`src/git/aiActions.ts`)
+- `runPullRequestBodyWorkflow({ baseBranch })` → uses `coco changelog --branch <base>` to seed a PR title + body (`src/git/aiActions.ts`)
+
+The recipe scales — any CLI command with a `handler(argv, logger)` signature can be wrapped this way. Two rules:
+
+1. **Pass `mode: 'stdout'` and `interactive: false` in the synthetic argv** so the handler emits structured output instead of opening an Inquirer prompt.
+2. **Use the raw-capture variant** (not the chrome-stripping one) if your UI surface wants blank lines / section structure preserved. `runChangelogAction` strips blank lines via `compactOutputLines`; `runChangelogTextWorkflow` keeps them.
+
+## Testing changes
+
+The scenario library in `src/lib/testUtils/scenarios/` is the recommended way to validate workstation changes — both manually and in automated tests.
+
+```bash
+# Manual testing — spin up a known state and launch the workstation
+npm run scenario list
+npm run scenario create feature-pr-ready -- --run-ui
+
+# Automated testing — replace inline writeFile / commitAll setup
+import { spinUpScenario } from 'src/lib/testUtils/spinUpScenario'
+const repo = await spinUpScenario('feature-pr-ready')
+```
+
+Scenarios match common workstation states: feature branch ready to PR, dirty worktree with many files, in-progress bisect, in-progress merge conflict, stashed changes, etc. Adding a new view? Add a scenario alongside it that reproduces the state the view renders against. See `src/lib/testUtils/README.md` for the full list + the contract for adding new scenarios.
+
 ## Conventions
 
 - **Chord prefix.** `g` is the global view-selector prefix. Inside a view, the prefix is bypassed for view-local single-key bindings (`g`, `b`, `s`, `x` on the bisect view fire bisect actions, not chord entry). Path back out is always `<` or `Esc`, never a chord.


### PR DESCRIPTION
## Summary

Audit + refresh of in-repo documentation after the 0.48.0 release and the #908 / #909 scenarios library work. No behavior changes — docs only.

- **`CONTRIBUTING.md`** — adds a "Where things live" tour of the post-0.48.0 `src/` layout (`commands/`, `git/`, `workstation/`, `lib/`) and a new "Testing the workstation (`coco ui`)" section walking contributors through `npm run scenario list / describe / create -- --run-ui` plus the `spinUpScenario` programmatic API.
- **`src/workstation/README.md`** — documents the "calling existing CLI commands from a workstation flow" pattern (synthetic argv + `captureStdout`) with worked examples (`runCommitDraftWorkflow`, `runCommitWorkflow`, `runChangelogTextWorkflow`, `runPullRequestBodyWorkflow`) and adds a "Testing changes" section pointing at the scenario library.
- **`src/lib/testUtils/README.md`** — updates the directory tree and the scenarios table to reflect the full 9-scenario set across 4 kinds (branch / worktree / operation / stash) that landed in #909.

## Why

After 0.48.0 the layout shifted (`src/git/` promoted out of `commands/log/`, `src/workstation/` houses the TUI) and the scenarios library is now the recommended way to test workstation changes — but neither was documented for new contributors. The "calling CLI commands from a workstation flow" recipe was also undocumented despite being the pattern behind the `I` keystroke, the upcoming `C` create-pr keystroke (#905), and the upcoming `L` changelog view (#906).

## Test plan

- [x] `npm run lint` clean
- [ ] Render-check the new README sections on GitHub after push
- [ ] Confirm scenario names in the table still match `npm run scenario list`