### PR TITLE
fix(provider): detect default branch from local refs (offline + non-GitHub support)

### DIFF
--- a/src/git/providerData.test.ts
+++ b/src/git/providerData.test.ts
@@ -1,5 +1,6 @@
 import {
   buildProviderUrl,
+  detectLocalDefaultBranch,
   getProviderOverview,
   getProviderRepository,
   parseGitHubRemoteUrl,
@@ -63,6 +64,38 @@ describe('log provider data', () => {
     )
   })
 
+  // git.raw now answers three commands during a single getProviderOverview
+  // call: branch --show-current, symbolic-ref origin/HEAD (for local
+  // default-branch detection), and possibly rev-parse fallbacks. This
+  // helper builds a mock that dispatches on the command rather than
+  // returning one value for all of them.
+  function buildGitRawMock(answers: {
+    currentBranch?: string
+    originHead?: string | null
+    localBranches?: string[]
+  }): jest.Mock {
+    const localBranches = new Set(answers.localBranches || [])
+    return jest.fn().mockImplementation(async (args: string[]) => {
+      if (args[0] === 'branch' && args[1] === '--show-current') {
+        return `${answers.currentBranch || ''}\n`
+      }
+      if (args[0] === 'symbolic-ref' && args[1] === 'refs/remotes/origin/HEAD') {
+        if (answers.originHead === null || answers.originHead === undefined) {
+          throw new Error('fatal: ref refs/remotes/origin/HEAD is not a symbolic ref')
+        }
+        return `refs/remotes/origin/${answers.originHead}\n`
+      }
+      if (args[0] === 'rev-parse' && args[1] === '--verify') {
+        const ref = args[3]?.replace('refs/heads/', '')
+        if (ref && localBranches.has(ref)) {
+          return 'abc123\n'
+        }
+        throw new Error('fatal: Needed a single revision')
+      }
+      throw new Error(`unexpected git.raw call: ${args.join(' ')}`)
+    })
+  }
+
   it('loads provider overview with default branch and PR status when authenticated', async () => {
     const git = {
       getRemotes: jest.fn().mockResolvedValue([
@@ -74,7 +107,7 @@ describe('log provider data', () => {
           },
         },
       ]),
-      raw: jest.fn().mockResolvedValue('feature/log\n'),
+      raw: buildGitRawMock({ currentBranch: 'feature/log', originHead: 'main' }),
     }
     const runner = jest.fn().mockImplementation(async (args: string[]) => {
       if (args[0] === 'auth') {
@@ -130,7 +163,7 @@ describe('log provider data', () => {
           },
         },
       ]),
-      raw: jest.fn().mockResolvedValue('main\n'),
+      raw: buildGitRawMock({ currentBranch: 'main', originHead: 'main' }),
     }
     const runner = jest.fn().mockRejectedValue(new Error('not authenticated'))
 
@@ -141,7 +174,97 @@ describe('log provider data', () => {
         provider: 'github',
         owner: 'gfargo',
         name: 'coco',
+        // Local fallback still populates defaultBranch even though gh
+        // auth failed — this is the whole point of the offline path.
+        defaultBranch: 'main',
       },
+    })
+  })
+
+  describe('detectLocalDefaultBranch', () => {
+    it('returns the branch tracked by origin/HEAD when set', async () => {
+      const git = { raw: buildGitRawMock({ originHead: 'develop' }) }
+      await expect(detectLocalDefaultBranch(git as never)).resolves.toBe('develop')
+    })
+
+    it('falls back to "main" when origin/HEAD is missing and main exists locally', async () => {
+      const git = { raw: buildGitRawMock({ originHead: null, localBranches: ['main', 'feat/x'] }) }
+      await expect(detectLocalDefaultBranch(git as never)).resolves.toBe('main')
+    })
+
+    it('falls back to "master" when neither origin/HEAD nor main exists', async () => {
+      const git = { raw: buildGitRawMock({ originHead: null, localBranches: ['master'] }) }
+      await expect(detectLocalDefaultBranch(git as never)).resolves.toBe('master')
+    })
+
+    it('tries develop and trunk before giving up', async () => {
+      // Only develop is present — main and master miss, develop hits
+      // before trunk gets checked.
+      const developOnly = { raw: buildGitRawMock({ originHead: null, localBranches: ['develop'] }) }
+      await expect(detectLocalDefaultBranch(developOnly as never)).resolves.toBe('develop')
+
+      const trunkOnly = { raw: buildGitRawMock({ originHead: null, localBranches: ['trunk'] }) }
+      await expect(detectLocalDefaultBranch(trunkOnly as never)).resolves.toBe('trunk')
+    })
+
+    it('returns undefined when nothing matches', async () => {
+      const git = {
+        raw: buildGitRawMock({ originHead: null, localBranches: ['feat/x', 'feat/y'] }),
+      }
+      await expect(detectLocalDefaultBranch(git as never)).resolves.toBeUndefined()
+    })
+  })
+
+  it('populates defaultBranch from local refs when no remote is configured', async () => {
+    // Scenario-test shape: `git init` + a couple branches, no `origin`
+    // remote at all. Provider can't reach gh; local fallback should
+    // still surface a sensible defaultBranch so the workstation's PR /
+    // changelog flows can derive a base.
+    const git = {
+      getRemotes: jest.fn().mockResolvedValue([]),
+      raw: buildGitRawMock({
+        currentBranch: 'feat/widget-v2',
+        originHead: null,
+        localBranches: ['main'],
+      }),
+    }
+    const runner = jest.fn()
+
+    await expect(getProviderOverview(git as never, runner)).resolves.toMatchObject({
+      authenticated: false,
+      repository: {
+        provider: 'unsupported',
+        defaultBranch: 'main',
+      },
+      currentBranch: 'feat/widget-v2',
+    })
+    expect(runner).not.toHaveBeenCalled()
+  })
+
+  it('prefers the gh-reported default branch over local fallback when both are available', async () => {
+    // Edge case: a fork where the remote's default branch differs from
+    // what local refs would suggest. gh's answer wins because it
+    // reflects the actual remote-side configuration.
+    const git = {
+      getRemotes: jest.fn().mockResolvedValue([
+        {
+          name: 'origin',
+          refs: { fetch: 'git@github.com:fork/coco.git', push: 'git@github.com:fork/coco.git' },
+        },
+      ]),
+      raw: buildGitRawMock({ currentBranch: 'main', originHead: 'main', localBranches: ['main'] }),
+    }
+    const runner = jest.fn().mockImplementation(async (args: string[]) => {
+      if (args[0] === 'auth') return ''
+      if (args[0] === 'repo') {
+        return JSON.stringify({ defaultBranchRef: { name: 'develop' } })
+      }
+      return ''
+    })
+
+    await expect(getProviderOverview(git as never, runner)).resolves.toMatchObject({
+      authenticated: true,
+      repository: { defaultBranch: 'develop' },
     })
   })
 

--- a/src/git/providerData.ts
+++ b/src/git/providerData.ts
@@ -141,6 +141,55 @@ async function getDefaultBranch(
   }
 }
 
+/**
+ * Local-only fallback for the default branch — used when no GitHub
+ * remote is configured, when `gh` isn't authenticated, or when
+ * `gh repo view` fails (e.g. private repo we can't access, offline).
+ *
+ * Detection order, picking the first that resolves:
+ *   1. `origin/HEAD` — the symbolic ref set by `git clone` pointing at
+ *      whatever the remote's default branch was at clone time. This is
+ *      the most authoritative local signal.
+ *   2. Conventional branch names checked against local refs in order:
+ *      `main`, `master`, `develop`, `trunk`.
+ *
+ * Returns `undefined` when nothing matches — caller surfaces that as
+ * "no default branch detected" without claiming any particular cause.
+ *
+ * Pure local-ref reads (no network) — safe to call on every overview
+ * load regardless of provider state.
+ */
+export async function detectLocalDefaultBranch(git: SimpleGit): Promise<string | undefined> {
+  // origin/HEAD — set by `git clone` to track the remote's HEAD. The
+  // symbolic-ref output is the full ref (refs/remotes/origin/main); we
+  // strip the prefix to get just the branch name. `--short` would do it
+  // too but isn't supported on older git, and the prefix is fixed-length.
+  try {
+    const ref = (await git.raw(['symbolic-ref', 'refs/remotes/origin/HEAD'])).trim()
+    const match = ref.match(/^refs\/remotes\/origin\/(.+)$/)
+    if (match) {
+      return match[1]
+    }
+  } catch {
+    // symbolic-ref returns non-zero when origin/HEAD doesn't exist —
+    // expected on fresh repos and `git init`-only working trees. Fall
+    // through to the conventional-name check.
+  }
+
+  // Conventional names — most repos follow one of these. `rev-parse
+  // --verify --quiet <ref>` returns 0 + hash on hit, non-zero on miss.
+  for (const candidate of ['main', 'master', 'develop', 'trunk']) {
+    try {
+      await git.raw(['rev-parse', '--verify', '--quiet', `refs/heads/${candidate}`])
+      return candidate
+    } catch {
+      // Not present — try the next one.
+    }
+  }
+
+  return undefined
+}
+
 async function getCurrentPullRequest(
   runner: GhRunner
 ): Promise<ProviderPullRequestStatus | undefined> {
@@ -160,9 +209,14 @@ export async function getProviderOverview(
   git: SimpleGit,
   runner: GhRunner = defaultGhRunner
 ): Promise<ProviderOverview> {
-  const [remotes, currentBranchOutput] = await Promise.all([
+  const [remotes, currentBranchOutput, localDefaultBranch] = await Promise.all([
     git.getRemotes(true),
     git.raw(['branch', '--show-current']),
+    // Read local default-branch signal up-front in parallel — used as
+    // the fallback when gh is unavailable / unauthenticated / can't see
+    // the repo. Coco aims to be platform-agnostic + work offline; the
+    // GH-specific paths layer on top of this, they don't replace it.
+    detectLocalDefaultBranch(git),
   ])
   const remote = remotes.find((entry) => entry.name === 'origin') || remotes[0]
   const remoteUrl = remote?.refs.push || remote?.refs.fetch
@@ -177,7 +231,10 @@ export async function getProviderOverview(
 
   if (repository.provider !== 'github') {
     return {
-      repository,
+      repository: {
+        ...repository,
+        defaultBranch: localDefaultBranch,
+      },
       currentBranch,
       authenticated: false,
       message: repository.message || 'Unsupported remote provider.',
@@ -188,14 +245,17 @@ export async function getProviderOverview(
     await runner(['auth', 'status', '--hostname', 'github.com'])
   } catch {
     return {
-      repository,
+      repository: {
+        ...repository,
+        defaultBranch: localDefaultBranch,
+      },
       currentBranch,
       authenticated: false,
       message: 'GitHub CLI is missing or not authenticated.',
     }
   }
 
-  const [defaultBranch, currentPullRequest] = await Promise.all([
+  const [providerDefaultBranch, currentPullRequest] = await Promise.all([
     getDefaultBranch(repository, runner),
     getCurrentPullRequest(runner),
   ])
@@ -203,7 +263,11 @@ export async function getProviderOverview(
   return {
     repository: {
       ...repository,
-      defaultBranch,
+      // gh's answer wins when it has one — it knows the remote's
+      // current state, including custom default-branch settings the
+      // local refs can't reflect. Fall back to local detection when gh
+      // returns undefined (offline, private repo, transient failure).
+      defaultBranch: providerDefaultBranch || localDefaultBranch,
     },
     currentBranch,
     currentPullRequest,

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -1270,7 +1270,10 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
     const defaultBranch = context.provider?.repository.defaultBranch
     if (!defaultBranch) {
-      dispatch({ type: 'setStatus', value: 'No default branch detected — is the GitHub remote configured?' })
+      dispatch({
+        type: 'setStatus',
+        value: 'No default branch detected. Set origin/HEAD or ensure main/master exists locally.',
+      })
       return
     }
     if (head === defaultBranch) {


### PR DESCRIPTION
## Why

Workstation flows that key off `context.provider.repository.defaultBranch` (notably `C` create-pr and `L` changelog) were silently bailing for users without an authenticated GitHub setup:

- **Local-only / scenario repos**: no `origin` remote → no provider → no defaultBranch → bail
- **Non-GitHub remotes** (GitLab, Bitbucket, self-hosted): same path
- **Offline / behind proxy**: `gh repo view` fails → no defaultBranch → bail
- **Private fork or repo the gh account can't see**: same

That's the opposite of the platform-agnostic + offline-friendly posture we want. GitHub-specific tooling should layer on top of local-first detection, not gate it.

## What

Adds `detectLocalDefaultBranch(git)` — pure local-ref reads, no network:

1. `git symbolic-ref refs/remotes/origin/HEAD` (set by `git clone`)
2. If missing, check local refs for `main` / `master` / `develop` / `trunk` in order
3. Otherwise `undefined`

`getProviderOverview` runs it in parallel with the existing reads and falls back to its result in three paths:
- Non-GitHub remote (or no remote)
- `gh auth status` failure
- `gh repo view` returns no defaultBranch (offline / private / transient)

gh's answer still wins when it has one (it reflects remote-side config that local refs can't see — e.g. fork-specific defaults).

Also: updates the C-keystroke status message from GitHub-centric to platform-neutral.

## Impact

- The `C` and `L` keystrokes now work against scenario repos and other local-only / non-GitHub setups (the user's exact pain point with `feature-pr-ready`)
- The `gh pr create` call inside `C` will still fail with no GitHub remote — but the prompt opens, the user can edit, and they get a real error message instead of silent bail
- Real GitHub repos: zero behavior change. gh-reported default still wins.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test:jest` — 691 suites / 6643 tests pass (+7 from this PR)
- [x] `tsc --noEmit` clean
- [ ] Manual: `npm run scenario create feature-pr-ready -- --run-ui` → press `L` → changelog generates against detected `main`
- [ ] Manual: same scenario → press `C` → PR prompt opens (will fail at `gh pr create` since no remote, but the UX path runs end-to-end)
- [ ] Manual: real coco repo → `C` still seeds from gh-reported default branch (unchanged behavior)

## Follow-up

Separate PR for the changelog-view-as-surface redesign — current cramped-sidebar UX is wrong for prose output (user feedback from PR #906 testing).