### PR TITLE
feat(compose): `E` keystroke — edit commit draft in $EDITOR

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -1031,6 +1031,44 @@ describe('log Ink input interactions', () => {
     expect(getLogInkInputEvents(state, 'c')).toEqual([{ type: 'createManualCommit' }])
   })
 
+  it('E from compose opens the draft in the external editor', () => {
+    // Capital `E` (companion to lowercase `e` which activates inline
+    // editing). The runtime callback handles the temp-file write + spawn
+    // + read-back; the input handler emits a single openComposeInEditor
+    // event the dispatcher routes there.
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'compose' })
+
+    expect(getLogInkInputEvents(state, 'E')).toEqual([
+      { type: 'openComposeInEditor' },
+    ])
+  })
+
+  it('E from status or diff pushes compose first, then opens the external editor', () => {
+    // Mirrors the lowercase `e` flow — from worktree views, the
+    // keystroke auto-jumps into compose before invoking the editor.
+    const statusState = createLogInkState(rows, { activeView: 'status' })
+    expect(getLogInkInputEvents(statusState, 'E', {}, { worktreeFileCount: 1 })).toEqual([
+      { type: 'action', action: { type: 'pushView', value: 'compose' } },
+      { type: 'openComposeInEditor' },
+    ])
+
+    const diffState = createLogInkState(rows, { activeView: 'diff' })
+    expect(getLogInkInputEvents(diffState, 'E', {}, { worktreeFileCount: 1 })).toEqual([
+      { type: 'action', action: { type: 'pushView', value: 'compose' } },
+      { type: 'openComposeInEditor' },
+    ])
+  })
+
+  it('E does not fire outside the status / diff / compose triad', () => {
+    // History, branches, tags, etc. should fall through to whatever
+    // other E-binding exists for that view (or no-op) — the editor
+    // keystroke is scoped to commit-message work.
+    const historyState = createLogInkState(rows, { activeView: 'history' })
+    const events = getLogInkInputEvents(historyState, 'E')
+    expect(events.some((event) => event.type === 'openComposeInEditor')).toBe(false)
+  })
+
   it('preserves draft state across compose → history → compose round-trips', () => {
     let state = createLogInkState(rows)
 

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -51,6 +51,7 @@ export type LogInkInputEvent =
   | { type: 'runAiCommitDraft' }
   | { type: 'startCreatePullRequest' }
   | { type: 'startChangelogView' }
+  | { type: 'openComposeInEditor' }
   | { type: 'runWorkflowAction'; id: string; payload?: string }
   | { type: 'openFileInEditor'; path: string }
   | { type: 'yankFromActiveView'; short?: boolean }
@@ -2288,6 +2289,27 @@ export function getLogInkInputEvents(
       events.push(action({ type: 'pushView', value: 'compose' }))
     }
     events.push(action({ type: 'commitCompose', action: { type: 'setEditing', value: true } }))
+    return events
+  }
+
+  // Capital `E` — open the commit draft in $EDITOR (or $VISUAL). Companion
+  // to lowercase `e` which activates inline editing inside the panel:
+  // `e` for quick tweaks in-place, `E` for "I want the full power of my
+  // editor — syntax highlighting, multi-line nav, paste buffers, etc."
+  // The runtime callback handles the temp-file write, editor session,
+  // and read-back; the input handler emits a single event the
+  // dispatcher routes there. As with lowercase `e`, fires from status
+  // and diff views too (auto-pushes into compose first), since those
+  // are the natural entry points to commit-message work.
+  if (
+    inputValue === 'E' &&
+    (state.activeView === 'status' || state.activeView === 'diff' || state.activeView === 'compose')
+  ) {
+    const events: LogInkInputEvent[] = []
+    if (state.activeView !== 'compose') {
+      events.push(action({ type: 'pushView', value: 'compose' }))
+    }
+    events.push({ type: 'openComposeInEditor' })
     return events
   }
 

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -67,7 +67,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['e edit', 'c commit', 'I AI draft', 'gs hunks', 'esc back'],
+      contextual: ['e edit', 'E $EDITOR', 'c commit', 'I AI draft', 'gs hunks', 'esc back'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 
@@ -315,7 +315,8 @@ describe('log Ink keymap', () => {
     expect(helpText).toContain('gg Jump to the first visible commit.')
     expect(helpText).toContain('G Jump to the last visible commit.')
     expect(helpText).toContain('z Ask to revert the selected file or hunk.')
-    expect(helpText).toContain('e Edit the manual commit summary or body.')
+    expect(helpText).toContain('e Edit the manual commit summary or body inline.')
+    expect(helpText).toContain('E Open the current commit draft in $EDITOR (or $VISUAL) for full editing, write-back on save.')
     expect(helpText).toContain('c Create a commit from staged changes with the current draft.')
     expect(helpText).toContain('q/ctrl+c Quit the interactive log.')
     expect(helpText).toContain('tab Move focus to the next panel.')

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -11,6 +11,7 @@ export type LogInkCommandId =
   | 'commit'
   | 'cycleSort'
   | 'editCommit'
+  | 'editCommitExternal'
   | 'focusNext'
   | 'focusPrevious'
   | 'help'
@@ -320,7 +321,14 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     id: 'editCommit',
     keys: ['e'],
     label: 'edit commit',
-    description: 'Edit the manual commit summary or body.',
+    description: 'Edit the manual commit summary or body inline.',
+    contexts: ['commits'],
+  },
+  {
+    id: 'editCommitExternal',
+    keys: ['E'],
+    label: 'edit in $EDITOR',
+    description: 'Open the current commit draft in $EDITOR (or $VISUAL) for full editing, write-back on save.',
     contexts: ['commits'],
   },
   {
@@ -633,7 +641,7 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
 
   if (options.activeView === 'compose') {
     return {
-      contextual: ['e edit', 'c commit', 'I AI draft', 'gs hunks', 'esc back'],
+      contextual: ['e edit', 'E $EDITOR', 'c commit', 'I AI draft', 'gs hunks', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -52,10 +52,13 @@
  */
 
 import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import * as nodePath from 'node:path'
 import type * as ReactTypes from 'react'
 import { SimpleGit } from 'simple-git'
 import { getBranchOverview } from '../../git/branchData'
-import { createManualCommit } from '../../commands/log/commitCompose'
+import { createManualCommit, formatCommitComposeMessage } from '../../commands/log/commitCompose'
 import { runCommitDraftWorkflow } from '../../git/commitWorkflowActions'
 import { runChangelogTextWorkflow } from '../../git/aiActions'
 import {
@@ -1449,6 +1452,109 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     void refreshWorktreeContext({ silent: true })
   }, [dispatch, refreshWorktreeContext, resumeRef])
 
+  // `E` keystroke handler — open the current commit draft in $EDITOR
+  // (or $VISUAL), then read the file back and update the compose state
+  // with the saved content. Mirrors the suspend → spawn → resume
+  // terminal dance of `openInEditor` but operates on an in-memory
+  // draft (round-tripped through a temp file) rather than a worktree
+  // file. Useful when the inline compose editor isn't enough — long
+  // bodies, markdown highlighting, paste from elsewhere, etc.
+  //
+  // Empty drafts are still written to the temp file so the user gets
+  // a blank canvas; the read-back uses `setDraft` which splits content
+  // into summary + body via `splitCommitDraft`, so the new content
+  // re-populates both fields correctly regardless of which one was
+  // active before.
+  const openComposeInEditor = React.useCallback(() => {
+    // Build the current draft text the same way `createManualCommit`
+    // would — single string, blank line between summary and body.
+    // Round-tripping through this format keeps the parse symmetric:
+    // the editor sees what a real commit message would look like, and
+    // `splitCommitDraft` on the way back reverses it cleanly.
+    const composeState = state.commitCompose
+    const draft = formatCommitComposeMessage(composeState.summary, composeState.body)
+
+    // Temp dir + file. mkdtemp is cleaned up at the end regardless of
+    // editor success/failure (`finally` block below). `.md` extension
+    // helps editors pick up markdown highlighting — most commit-
+    // message workflows treat the body as markdown-ish.
+    let dir: string | undefined
+    try {
+      dir = mkdtempSync(nodePath.join(tmpdir(), 'coco-compose-'))
+    } catch (error) {
+      dispatch({
+        type: 'setStatus',
+        value: `Failed to create temp file for editor: ${(error as Error).message}`,
+      })
+      return
+    }
+    const file = nodePath.join(dir, 'COMMIT_EDITMSG.md')
+    try {
+      writeFileSync(file, draft, 'utf8')
+    } catch (error) {
+      dispatch({
+        type: 'setStatus',
+        value: `Failed to seed temp file: ${(error as Error).message}`,
+      })
+      try { rmSync(dir, { recursive: true, force: true }) } catch { /* ignore */ }
+      return
+    }
+
+    const editorEnv = process.env.VISUAL || process.env.EDITOR || 'vi'
+    const editorArgs = editorEnv.trim().split(/\s+/).filter(Boolean)
+    const editor = editorArgs[0] || 'vi'
+    const editorPrefixArgs = editorArgs.slice(1)
+    const out = process.stdout
+    const stdin = process.stdin
+    const ENTER_ALT = '\x1b[?1049h'
+    const EXIT_ALT = '\x1b[?1049l'
+    const SHOW_CURSOR = '\x1b[?25h'
+    const HIDE_CURSOR = '\x1b[?25l'
+
+    let editorOk = false
+    try {
+      stdin.setRawMode?.(false)
+      out.write(`${SHOW_CURSOR}${EXIT_ALT}`)
+      const result = spawnSync(editor, [...editorPrefixArgs, file], { stdio: 'inherit' })
+      if (result.error) {
+        dispatch({ type: 'setStatus', value: `Failed to launch ${editor}: ${result.error.message}` })
+      } else if (result.signal) {
+        dispatch({ type: 'setStatus', value: `${editor} interrupted by ${result.signal}` })
+      } else if (typeof result.status === 'number' && result.status !== 0) {
+        dispatch({ type: 'setStatus', value: `${editor} exited with status ${result.status}` })
+      } else {
+        editorOk = true
+      }
+    } finally {
+      out.write(`${ENTER_ALT}${HIDE_CURSOR}`)
+      stdin.setRawMode?.(true)
+      resumeRef?.current?.()
+    }
+
+    // Read the (possibly edited) file back and update compose state.
+    // We only do this when the editor exited cleanly — a crash / kill
+    // shouldn't blow away the user's draft. The setDraft action
+    // re-splits into summary + body via splitCommitDraft.
+    if (editorOk) {
+      try {
+        const content = readFileSync(file, 'utf8')
+        dispatch({ type: 'commitCompose', action: { type: 'setDraft', value: content } })
+        dispatch({ type: 'setStatus', value: 'Commit draft updated from editor.' })
+      } catch (error) {
+        dispatch({
+          type: 'setStatus',
+          value: `Failed to read back edited draft: ${(error as Error).message}`,
+        })
+      }
+    }
+
+    // Always clean up the temp dir — even on failure paths above. We
+    // don't want abandoned coco-compose-* directories accumulating in
+    // /tmp across sessions. Best-effort; ignore errors (e.g. file
+    // already removed by the user from inside their editor).
+    try { rmSync(dir, { recursive: true, force: true }) } catch { /* ignore */ }
+  }, [dispatch, resumeRef, state.commitCompose])
+
   // Resolve the destructive-action target from the live filtered+sorted
   // list the user is looking at, run the action against it, surface the
   // result on the status line, and silently refresh so the deleted item
@@ -2409,6 +2515,8 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         void startCreatePullRequest()
       } else if (event.type === 'startChangelogView') {
         void startChangelogView()
+      } else if (event.type === 'openComposeInEditor') {
+        openComposeInEditor()
       } else if (event.type === 'yankText') {
         void yankText(event.value, event.label)
       } else if (event.type === 'runWorkflowAction') {


### PR DESCRIPTION
## Summary

New `E` (capital) keystroke in compose / status / diff: opens the current commit draft in `$EDITOR` (or `$VISUAL`), reads the file back on save, splits the content into summary + body. Companion to lowercase `e` which still activates **inline** editing in the panel.

- `e` — quick tweaks in the compose panel (unchanged)
- `E` — full editor: long bodies, markdown highlighting, paste, multi-line nav

## Why

Inline editing in the compose panel is fine for small edits but cramped for anything beyond a couple lines. The existing `openInEditor` callback already handles the suspend → spawn → resume terminal dance for worktree files (in status / diff views); this PR adapts that pattern for an in-memory draft round-tripped through a temp file.

## Design notes

**Why `E` and not `e`?** `e` already activates inline editing in compose. Reassigning it to "external editor" would break muscle memory; capital `E` follows the vim convention (`E` = open in external editor) without colliding. Both modes coexist.

**Temp-file shape.** `mkdtempSync` → `coco-compose-XXXXXX/COMMIT_EDITMSG.md`. `.md` extension for markdown highlighting. Always cleaned up in `finally`, regardless of editor success/failure.

**Failed-editor handling.** Non-zero exit / signal / ENOENT preserves the existing draft — a vim crash shouldn't blow away in-progress work. Status line surfaces what went wrong.

**Round-trip symmetry.** Writes `formatCommitComposeMessage(summary, body)` (summary + blank line + body). Reads back via `setDraft` which uses `splitCommitDraft` — exact inverse, so editing either field externally is clean.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test:jest` — 691 suites / 6646 tests (+3 from this PR)
- [x] `tsc --noEmit` clean
- [ ] Manual: `coco ui` → `gc` to compose → `E` → vim opens with current draft → edit → `:wq` → compose shows updated content
- [ ] Manual: from status view → `E` → pushes into compose AND opens editor in one motion
- [ ] Manual: `:q!` in vim (non-zero exit) → status shows error, original draft preserved
- [ ] Manual: with `EDITOR="code -w"` set → VS Code opens, save+close → draft updates
- [ ] Help text (`?`): `E` listed under "edit in $EDITOR"
- [ ] Footer hints in compose view show `E $EDITOR`

## Follow-up

Same pattern will be reused in the changelog-view surface (PR coming next) — `e` from inside that view opens the generated changelog in `$EDITOR` for tweaks before yanking / creating a PR.