### PR TITLE
feat(workstation): changelog as a full-screen surface

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -2167,11 +2167,11 @@ describe('log Ink input interactions', () => {
       ])
     })
 
-    it('L globally starts the changelog-view flow', () => {
+    it('L from history or branches starts the changelog flow', () => {
       // From the history view — `L` should start the changelog flow.
-      // Runtime callback handles the changelog fetch + prompt-open
-      // side effects; from the input handler's perspective it's a
-      // single event the dispatcher routes to startChangelogView.
+      // Runtime callback handles the fetch + view-push side effects;
+      // from the input handler's perspective it's a single event the
+      // dispatcher routes to startChangelogView.
       const historyState = createLogInkState(rows, { activeView: 'history' })
       expect(getLogInkInputEvents(historyState, 'L')).toEqual([
         { type: 'startChangelogView' },
@@ -2184,19 +2184,67 @@ describe('log Ink input interactions', () => {
       ])
     })
 
-    it('L is scoped away from the compose view', () => {
-      // Compose: explicit guard so users mid-draft can't fat-finger
-      // out of their commit into the changelog flow.
-      const composeState = createLogInkState(rows, { activeView: 'compose' })
-      expect(getLogInkInputEvents(composeState, 'L')).toEqual([
-        {
-          type: 'action',
-          action: {
-            type: 'setStatus',
-            value: 'Finish or cancel the commit draft before generating a changelog.',
-          },
-        },
+    it('L does not fire outside history / branches', () => {
+      // Scoped tight on purpose — the changelog is a "where am I, what
+      // landed here" question that fits history/branches semantics.
+      // Other views keep their own L-bindings (or none) without
+      // colliding with the changelog flow.
+      const compose = createLogInkState(rows, { activeView: 'compose' })
+      const status = createLogInkState(rows, { activeView: 'status' })
+      const diff = createLogInkState(rows, { activeView: 'diff' })
+      const stash = createLogInkState(rows, { activeView: 'stash' })
+
+      for (const state of [compose, status, diff, stash]) {
+        const events = getLogInkInputEvents(state, 'L')
+        expect(events.some((event) => event.type === 'startChangelogView')).toBe(false)
+      }
+    })
+
+    it('inside the changelog view, j/k scrolls one line at a time', () => {
+      const state = createLogInkState(rows, { activeView: 'changelog' })
+      expect(getLogInkInputEvents(state, 'j', {}, { changelogLineCount: 50 })).toEqual([
+        { type: 'action', action: { type: 'pageChangelog', delta: 1, lineCount: 50 } },
       ])
+      expect(getLogInkInputEvents(state, 'k', {}, { changelogLineCount: 50 })).toEqual([
+        { type: 'action', action: { type: 'pageChangelog', delta: -1, lineCount: 50 } },
+      ])
+    })
+
+    it('inside the changelog view, pgup/pgdn scrolls by 10 lines', () => {
+      const state = createLogInkState(rows, { activeView: 'changelog' })
+      expect(getLogInkInputEvents(state, '', { pageDown: true }, { changelogLineCount: 50 })).toEqual([
+        { type: 'action', action: { type: 'pageChangelog', delta: 10, lineCount: 50 } },
+      ])
+      expect(getLogInkInputEvents(state, '', { pageUp: true }, { changelogLineCount: 50 })).toEqual([
+        { type: 'action', action: { type: 'pageChangelog', delta: -10, lineCount: 50 } },
+      ])
+    })
+
+    it('inside the changelog view, scroll keystrokes no-op when no content is loaded', () => {
+      // changelogLineCount is undefined during loading / error states —
+      // pressing j/k/pgup/pgdn should fall through cleanly rather than
+      // dispatch a pageChangelog with an undefined line count.
+      const state = createLogInkState(rows, { activeView: 'changelog' })
+      const events = getLogInkInputEvents(state, 'j')
+      expect(events.some((event) =>
+        event.type === 'action' && event.action.type === 'pageChangelog'
+      )).toBe(false)
+    })
+
+    it('inside the changelog view, y/E/c/r dispatch their workflow events', () => {
+      const state = createLogInkState(rows, { activeView: 'changelog' })
+
+      // y → yank text (handler reads view state, not context)
+      expect(getLogInkInputEvents(state, 'y')).toEqual([{ type: 'yankChangelog' }])
+
+      // E → open in $EDITOR (mirrors compose's `E` from #913)
+      expect(getLogInkInputEvents(state, 'E')).toEqual([{ type: 'openChangelogInEditor' }])
+
+      // c → kick off create-PR (handler can reuse the cached changelog)
+      expect(getLogInkInputEvents(state, 'c')).toEqual([{ type: 'startCreatePullRequest' }])
+
+      // r → regenerate (skip cache, re-run LLM)
+      expect(getLogInkInputEvents(state, 'r')).toEqual([{ type: 'regenerateChangelog' }])
     })
 
     it('submitting a create-pr prompt dispatches runWorkflowAction with the raw multi-line value', () => {
@@ -2243,29 +2291,6 @@ describe('log Ink input interactions', () => {
       ])
     })
 
-    it('submitting a changelog-view prompt dispatches yankText with the prompt value', () => {
-      const state = applyLogInkAction(createLogInkState(rows), {
-        type: 'openInputPrompt',
-        kind: 'changelog-view',
-        label: 'Changelog: feat/x (vs main)',
-        initial: 'feat: workstation\n\n- thing one\n- thing two',
-        multiline: true,
-      })
-
-      // Ctrl+D submits the multi-line prompt. For the changelog-view
-      // kind specifically, "submit" means copy-to-clipboard — the
-      // value travels with the event so the clipboard handler can
-      // read it before the close-prompt dispatch wipes the prompt.
-      const events = getLogInkInputEvents(state, 'd', { ctrl: true })
-      expect(events).toEqual([
-        {
-          type: 'yankText',
-          value: 'feat: workstation\n\n- thing one\n- thing two',
-          label: 'changelog',
-        },
-        { type: 'action', action: { type: 'closeInputPrompt' } },
-      ])
-    })
 
 
     it('keeps single-line prompts (create-branch, reset-mode, etc.) untouched', () => {

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -51,6 +51,9 @@ export type LogInkInputEvent =
   | { type: 'runAiCommitDraft' }
   | { type: 'startCreatePullRequest' }
   | { type: 'startChangelogView' }
+  | { type: 'regenerateChangelog' }
+  | { type: 'yankChangelog' }
+  | { type: 'openChangelogInEditor' }
   | { type: 'openComposeInEditor' }
   | { type: 'runWorkflowAction'; id: string; payload?: string }
   | { type: 'openFileInEditor'; path: string }
@@ -161,6 +164,13 @@ export type LogInkInputContext = {
    * Used by `o` (open in $EDITOR) and `s` (stage/resolve).
    */
   conflictSelectedPath?: string
+  /**
+   * Number of lines in `state.changelogView.text`. Used by the
+   * changelog view's scroll bindings (`j/k`, `pgup/pgdn`) to clamp
+   * `pageChangelog` deltas. Undefined when the view hasn't been loaded
+   * or generation failed — the scroll handlers no-op in that case.
+   */
+  changelogLineCount?: number
 }
 
 function action(actionValue: LogInkAction): LogInkInputEvent {
@@ -680,17 +690,6 @@ function submitInputPrompt(state: LogInkState): LogInkInputEvent[] {
       action({ type: 'closeInputPrompt' }),
     ]
   }
-  if (state.inputPrompt.kind === 'changelog-view') {
-    // The changelog view uses the multi-line prompt as a scrollable +
-    // editable display surface. "Submit" here means copy-to-clipboard,
-    // not run-a-workflow — the user reviewed the text and wants it.
-    // The value travels with the event so the clipboard handler reads
-    // it before the close-prompt dispatch wipes the prompt state.
-    return [
-      { type: 'yankText', value, label: 'changelog' },
-      action({ type: 'closeInputPrompt' }),
-    ]
-  }
   const id = state.inputPrompt.kind
   return [
     { type: 'runWorkflowAction', id, payload: value },
@@ -1150,6 +1149,47 @@ export function getLogInkInputEvents(
     }
     if (inputValue === 'x') {
       return [action({ type: 'setPendingConfirmation', value: 'bisect-reset' })]
+    }
+  }
+
+  // Changelog view local keymap. Scoped to `activeView === 'changelog'`
+  // so the letters stay free everywhere else. Bindings:
+  //
+  //   j / k          → scroll line down / up (1 line)
+  //   pgdn / pgup    → scroll page down / up (10 lines)
+  //   y              → yank text to clipboard
+  //   E              → open in $EDITOR (companion to compose's `E` from #913)
+  //   c              → create-PR seeded with this changelog
+  //   r              → regenerate (skip cache, re-run LLM)
+  //
+  // Back-out is `<` / Esc handled by the global pop-view path lower
+  // down. The view only renders when `state.changelogView.status`
+  // is 'ready' — scroll keystrokes early-return when changelogLineCount
+  // is missing so they no-op gracefully during loading / error states.
+  if (state.activeView === 'changelog') {
+    if (inputValue === 'j' && context.changelogLineCount) {
+      return [action({ type: 'pageChangelog', delta: 1, lineCount: context.changelogLineCount })]
+    }
+    if (inputValue === 'k' && context.changelogLineCount) {
+      return [action({ type: 'pageChangelog', delta: -1, lineCount: context.changelogLineCount })]
+    }
+    if (key.pageDown && context.changelogLineCount) {
+      return [action({ type: 'pageChangelog', delta: 10, lineCount: context.changelogLineCount })]
+    }
+    if (key.pageUp && context.changelogLineCount) {
+      return [action({ type: 'pageChangelog', delta: -10, lineCount: context.changelogLineCount })]
+    }
+    if (inputValue === 'y') {
+      return [{ type: 'yankChangelog' }]
+    }
+    if (inputValue === 'E') {
+      return [{ type: 'openChangelogInEditor' }]
+    }
+    if (inputValue === 'c') {
+      return [{ type: 'startCreatePullRequest' }]
+    }
+    if (inputValue === 'r') {
+      return [{ type: 'regenerateChangelog' }]
     }
   }
 
@@ -2060,19 +2100,14 @@ export function getLogInkInputEvents(
   }
 
   // Global `L` — generate the changelog for the current branch and
-  // open it in a multi-line review prompt. The runtime callback does
-  // the pre-flight (default-branch resolution, current-branch
-  // detection) + the changelog fetch, then opens the prompt for the
-  // user to read / edit / copy. Same scope-guard pattern as `C`:
-  // compose is explicitly intercepted with a helpful status so users
-  // mid-draft don't fat-finger out of their commit.
-  if (inputValue === 'L' && state.activeView === 'compose') {
-    return [action({
-      type: 'setStatus',
-      value: 'Finish or cancel the commit draft before generating a changelog.',
-    })]
-  }
-  if (inputValue === 'L') {
+  // push the dedicated `changelog` view. Scoped to history and branches
+  // — those are the natural "where am I, what landed here recently"
+  // entry points. Avoids polluting every view's global namespace; the
+  // changelog is reachable from anywhere via `g L` (added in keymap).
+  if (
+    inputValue === 'L' &&
+    (state.activeView === 'history' || state.activeView === 'branches')
+  ) {
     return [{ type: 'startChangelogView' }]
   }
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -718,6 +718,13 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
     }
   }
 
+  if (options.activeView === 'changelog') {
+    return {
+      contextual: ['j/k scroll', 'pg up/dn', 'y yank', 'E $EDITOR', 'c PR', 'r regen', '< back'],
+      global: NORMAL_GLOBAL_HINTS,
+    }
+  }
+
   if (options.compareBaseSet) {
     // History view with a compare base set — Enter is overridden to
     // open the compare diff; show the override + the bail-out key.

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -18,7 +18,7 @@ import {
 export type LogInkFocus = 'sidebar' | 'commits' | 'detail'
 
 export type LogInkSidebarTab = 'status' | 'branches' | 'tags' | 'stashes' | 'worktrees'
-export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash' | 'worktrees' | 'pull-request' | 'conflicts' | 'reflog' | 'bisect'
+export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash' | 'worktrees' | 'pull-request' | 'conflicts' | 'reflog' | 'bisect' | 'changelog'
 export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk' | 'discard-draft'
 /**
  * Tracks which kind of diff the user pushed into. `commit` means they
@@ -273,6 +273,52 @@ export type LogInkState = {
    * looks like "no commits found" rather than "still loading".
    */
   bootLoading: boolean
+  /**
+   * Changelog view (full-screen surface). `status` drives what the
+   * panel renders:
+   *   - 'idle'    : view pushed but no content yet (transient — flips
+   *                 immediately to 'loading' or 'ready'-from-cache)
+   *   - 'loading' : LLM generation in flight
+   *   - 'ready'   : `text` is populated and renderable
+   *   - 'error'   : generation failed; `error` carries the message
+   *
+   * `branch` and `baseLabel` are the metadata that drove generation —
+   * surfaced in the panel header so the user knows what they're looking
+   * at. `scrollOffset` is view-local UI state (line offset into `text`)
+   * the same way `diffPreviewOffset` works for the diff view.
+   */
+  changelogView: ChangelogViewState
+  /**
+   * Per-branch cache of generated changelogs. Keyed by branch name so
+   * switching branches naturally produces a fresh generation; pressing
+   * `r` inside the view forces a regenerate even on the same branch.
+   * Each entry is small (a few KB of text) and there's at most one per
+   * branch, so memory pressure is negligible — the cache lives in
+   * state, not on disk, and clears with the workstation session.
+   */
+  changelogCache: { [branch: string]: ChangelogCacheEntry }
+}
+
+export type ChangelogViewStatus = 'idle' | 'loading' | 'ready' | 'error'
+
+export type ChangelogViewState = {
+  status: ChangelogViewStatus
+  text?: string
+  error?: string
+  branch?: string
+  baseLabel?: string
+  scrollOffset: number
+}
+
+export type ChangelogCacheEntry = {
+  text: string
+  baseLabel: string
+  generatedAt: number
+}
+
+export const DEFAULT_CHANGELOG_VIEW_STATE: ChangelogViewState = {
+  status: 'idle',
+  scrollOffset: 0,
 }
 
 export type LogInkStatusFilterMask = {
@@ -326,7 +372,6 @@ export type LogInkInputPromptKind =
   | 'pr-comment'
   | 'pr-request-changes'
   | 'create-pr'
-  | 'changelog-view'
 
 export type LogInkInputPromptState = {
   kind: LogInkInputPromptKind
@@ -427,6 +472,12 @@ export type LogInkAction =
   | { type: 'setHistoryFetchArgs'; value?: LogInkHistoryFetchArgs }
   | { type: 'toggleDiffViewMode' }
   | { type: 'setDiffViewMode'; value: LogInkDiffViewMode }
+  | { type: 'setChangelogLoading'; branch: string; baseLabel: string }
+  | { type: 'setChangelogReady'; branch: string; baseLabel: string; text: string }
+  | { type: 'setChangelogError'; branch: string; baseLabel: string; error: string }
+  | { type: 'setChangelogText'; text: string }
+  | { type: 'pageChangelog'; delta: number; lineCount: number }
+  | { type: 'clearChangelogCache'; branch?: string }
 
 const FOCUS_ORDER: LogInkFocus[] = ['sidebar', 'commits', 'detail']
 const SIDEBAR_TABS: LogInkSidebarTab[] = ['status', 'branches', 'tags', 'stashes', 'worktrees']
@@ -800,6 +851,8 @@ export function createLogInkState(
     inspectorTab: 'inspector',
     inspectorActionIndex: 0,
     bootLoading: options.bootLoading ?? false,
+    changelogView: { ...DEFAULT_CHANGELOG_VIEW_STATE },
+    changelogCache: {},
   }
 }
 
@@ -1450,6 +1503,108 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         paletteRecent: next.slice(0, 8),
         pendingKey: undefined,
       }
+    }
+    case 'setChangelogLoading':
+      return {
+        ...state,
+        changelogView: {
+          status: 'loading',
+          branch: action.branch,
+          baseLabel: action.baseLabel,
+          scrollOffset: 0,
+        },
+        pendingKey: undefined,
+      }
+    case 'setChangelogReady': {
+      // Cache the result so re-entry (or `c` to PR) reuses it instead of
+      // re-running the LLM. Keyed by branch so a checkout naturally
+      // produces a fresh generation.
+      const cached: ChangelogCacheEntry = {
+        text: action.text,
+        baseLabel: action.baseLabel,
+        generatedAt: Date.now(),
+      }
+      return {
+        ...state,
+        changelogView: {
+          status: 'ready',
+          text: action.text,
+          branch: action.branch,
+          baseLabel: action.baseLabel,
+          scrollOffset: 0,
+        },
+        changelogCache: {
+          ...state.changelogCache,
+          [action.branch]: cached,
+        },
+        pendingKey: undefined,
+      }
+    }
+    case 'setChangelogError':
+      return {
+        ...state,
+        changelogView: {
+          status: 'error',
+          branch: action.branch,
+          baseLabel: action.baseLabel,
+          error: action.error,
+          scrollOffset: 0,
+        },
+        pendingKey: undefined,
+      }
+    case 'setChangelogText': {
+      // Used by the $EDITOR round-trip: user edits the cached text, we
+      // update the view AND the cache entry so subsequent re-entry
+      // reflects the edits. Branch key is taken from the current view
+      // (which is what the user just edited against).
+      if (state.changelogView.status !== 'ready' || !state.changelogView.branch) {
+        return state
+      }
+      const branch = state.changelogView.branch
+      const existing = state.changelogCache[branch]
+      return {
+        ...state,
+        changelogView: {
+          ...state.changelogView,
+          text: action.text,
+        },
+        changelogCache: {
+          ...state.changelogCache,
+          [branch]: {
+            text: action.text,
+            baseLabel: existing?.baseLabel || state.changelogView.baseLabel || '',
+            // Updated-at timestamp reflects the edit. Not the original
+            // generation time — `r` (regenerate) is the explicit knob
+            // for "I want fresh LLM output, not my edits".
+            generatedAt: Date.now(),
+          },
+        },
+        pendingKey: undefined,
+      }
+    }
+    case 'pageChangelog':
+      return {
+        ...state,
+        changelogView: {
+          ...state.changelogView,
+          scrollOffset: clampIndex(
+            state.changelogView.scrollOffset + action.delta,
+            action.lineCount
+          ),
+        },
+        pendingKey: undefined,
+      }
+    case 'clearChangelogCache': {
+      // Targeted clear for a single branch, or wholesale wipe when
+      // `branch` is omitted. Wholesale used on session reset / config
+      // change; targeted reserved for future "this generation looks
+      // wrong, drop it" UX.
+      if (!action.branch) {
+        return { ...state, changelogCache: {}, pendingKey: undefined }
+      }
+      const next = { ...state.changelogCache }
+      delete next[action.branch]
+      return { ...state, changelogCache: next, pendingKey: undefined }
     }
     default:
       return state

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -1327,59 +1327,12 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     dispatch,
   ])
 
-  // `L` keystroke handler — generate a changelog for the current branch
-  // and open it in a multi-line review prompt. The prompt acts as a
-  // scrollable + editable display: Ctrl+D copies the (possibly edited)
-  // content to clipboard, Esc closes. Runs `coco changelog --branch
-  // <default>` via runChangelogTextWorkflow, which captures the raw
-  // stdout so blank lines / section structure survive intact.
-  const startChangelogView = React.useCallback(async () => {
-    const head = context.branches?.currentBranch || context.provider?.currentBranch
-    if (!head) {
-      dispatch({ type: 'setStatus', value: 'No current branch — check out a branch first.' })
-      return
-    }
-    const defaultBranch = context.provider?.repository.defaultBranch
-    // The changelog command will fall back to its own defaults when no
-    // branch arg is passed, but being explicit about the base is more
-    // honest about what the user is seeing. Skip the default-branch
-    // requirement only when there's no provider detected — in that
-    // case the command's --since-last-tag heuristic kicks in.
-    const argv = defaultBranch && head !== defaultBranch
-      ? { branch: defaultBranch }
-      : { sinceLastTag: true }
-    const baseLabel = defaultBranch && head !== defaultBranch
-      ? `vs ${defaultBranch}`
-      : 'since last tag'
-
-    dispatch({ type: 'setStatus', value: `generating changelog (${baseLabel})…` })
-    const result = await runChangelogTextWorkflow(argv)
-
-    if (!result.ok || !result.text) {
-      dispatch({ type: 'setStatus', value: `Changelog failed: ${result.message}` })
-      return
-    }
-
-    dispatch({ type: 'setStatus', value: 'Changelog ready — Ctrl+D copies, Esc closes.' })
-    dispatch({
-      type: 'openInputPrompt',
-      kind: 'changelog-view',
-      label: `Changelog: ${head} (${baseLabel})  ·  Ctrl+D copy · Esc close`,
-      initial: result.text,
-      multiline: true,
-    })
-  }, [
-    context.branches?.currentBranch,
-    context.provider?.currentBranch,
-    context.provider?.repository.defaultBranch,
-    dispatch,
-  ])
-
   // Copy an arbitrary string to the system clipboard. Distinct from
   // `yankFromActiveView` which derives the value from the current view
   // — this one takes the value as an explicit event payload, used by
-  // the changelog-view prompt (and a candidate for future "copy this"
-  // surfaces). Surfaces a status confirming what landed in clipboard.
+  // the changelog view's `y` keystroke (and a candidate for future
+  // "copy this" surfaces). Surfaces a status confirming what landed
+  // in clipboard.
   const yankText = React.useCallback(async (value: string, label: string) => {
     const clipboard: ClipboardRunner = clipboardRunner || defaultClipboardRunner
     if (!value) {
@@ -1397,6 +1350,198 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
   }, [clipboardRunner, dispatch])
 
+  // `L` keystroke handler — generate (or recall from cache) a changelog
+  // for the current branch and push the dedicated `changelog` surface
+  // to display it. The view renders the full text in the main panel
+  // (not cramped into an input prompt), with its own keymap for scroll,
+  // yank, $EDITOR, create-PR, and regenerate.
+  //
+  // Caching: `state.changelogCache` is keyed by branch name. On `L`,
+  // we check the cache first and reuse if hit (no LLM call); the user
+  // presses `r` from inside the view to force a regenerate. Switching
+  // branches naturally produces a fresh generation since the cache key
+  // changes.
+  //
+  // Surface lifecycle: we push the `changelog` view BEFORE awaiting the
+  // workflow, so the user sees a loading state instead of a blank
+  // history view while the LLM runs. On error, we keep the view pushed
+  // and render the error there (with `r` to retry) instead of bailing
+  // back to history with a status-line message that may scroll past.
+  const startChangelogView = React.useCallback(async (options: { force?: boolean } = {}) => {
+    const head = context.branches?.currentBranch || context.provider?.currentBranch
+    if (!head) {
+      dispatch({ type: 'setStatus', value: 'No current branch — check out a branch first.' })
+      return
+    }
+    const defaultBranch = context.provider?.repository.defaultBranch
+    // The changelog command will fall back to its own defaults when no
+    // branch arg is passed, but being explicit about the base is more
+    // honest about what the user is seeing. With the local default-
+    // branch fallback in providerData (#912), `defaultBranch` is
+    // populated even for non-GitHub / offline scenarios — we only fall
+    // through to `--since-last-tag` when truly nothing resolves.
+    const argv = defaultBranch && head !== defaultBranch
+      ? { branch: defaultBranch }
+      : { sinceLastTag: true }
+    const baseLabel = defaultBranch && head !== defaultBranch
+      ? `vs ${defaultBranch}`
+      : 'since last tag'
+
+    // Cache hit — skip the LLM, push view with ready content. The
+    // generated-at timestamp on the cache entry drives the "(cached, N
+    // ago)" hint in the header, so the user knows whether to press `r`.
+    const cached = !options.force ? state.changelogCache[head] : undefined
+    if (cached) {
+      dispatch({ type: 'pushView', value: 'changelog' })
+      dispatch({
+        type: 'setChangelogReady',
+        branch: head,
+        baseLabel: cached.baseLabel,
+        text: cached.text,
+      })
+      dispatch({
+        type: 'setStatus',
+        value: `Changelog loaded from cache (${cached.baseLabel}). r to regenerate.`,
+      })
+      return
+    }
+
+    // No cache (or force=true via `r`) — push view with loading state,
+    // then run the workflow.
+    dispatch({ type: 'pushView', value: 'changelog' })
+    dispatch({ type: 'setChangelogLoading', branch: head, baseLabel })
+    dispatch({ type: 'setStatus', value: `generating changelog (${baseLabel})…` })
+
+    const result = await runChangelogTextWorkflow(argv)
+
+    if (!result.ok || !result.text) {
+      dispatch({
+        type: 'setChangelogError',
+        branch: head,
+        baseLabel,
+        error: result.message,
+      })
+      dispatch({ type: 'setStatus', value: `Changelog failed: ${result.message}` })
+      return
+    }
+
+    dispatch({
+      type: 'setChangelogReady',
+      branch: head,
+      baseLabel,
+      text: result.text,
+    })
+    dispatch({
+      type: 'setStatus',
+      value: 'Changelog ready — y yank · E $EDITOR · c PR · r regen · < back.',
+    })
+  }, [
+    context.branches?.currentBranch,
+    context.provider?.currentBranch,
+    context.provider?.repository.defaultBranch,
+    dispatch,
+    state.changelogCache,
+  ])
+
+  // `r` keystroke inside the changelog view — re-run generation
+  // ignoring any cached result. Thin wrapper since the underlying
+  // logic in `startChangelogView` already supports the force path.
+  const regenerateChangelog = React.useCallback(() => {
+    void startChangelogView({ force: true })
+  }, [startChangelogView])
+
+  // `y` keystroke inside the changelog view — yank the current text
+  // to the system clipboard. Pulled from view state rather than from
+  // wherever the cursor is (no per-row selection on this surface).
+  const yankChangelog = React.useCallback(() => {
+    const text = state.changelogView.text
+    if (!text) {
+      dispatch({ type: 'setStatus', value: 'No changelog text to copy.' })
+      return
+    }
+    void yankText(text, 'changelog')
+  }, [dispatch, state.changelogView.text, yankText])
+
+  // `E` keystroke inside the changelog view — open the current text in
+  // $EDITOR / $VISUAL, read it back, update view + cache. Mirrors the
+  // compose `E` flow (#913) but on the changelog-view state slice.
+  // After save, `setChangelogText` updates both view and cache so the
+  // edits persist across view re-entry.
+  const openChangelogInEditor = React.useCallback(() => {
+    const current = state.changelogView.text
+    if (current === undefined) {
+      dispatch({ type: 'setStatus', value: 'Changelog not loaded yet — wait for generation.' })
+      return
+    }
+
+    let dir: string | undefined
+    try {
+      dir = mkdtempSync(nodePath.join(tmpdir(), 'coco-changelog-'))
+    } catch (error) {
+      dispatch({
+        type: 'setStatus',
+        value: `Failed to create temp file for editor: ${(error as Error).message}`,
+      })
+      return
+    }
+    const file = nodePath.join(dir, 'CHANGELOG.md')
+    try {
+      writeFileSync(file, current, 'utf8')
+    } catch (error) {
+      dispatch({
+        type: 'setStatus',
+        value: `Failed to seed temp file: ${(error as Error).message}`,
+      })
+      try { rmSync(dir, { recursive: true, force: true }) } catch { /* ignore */ }
+      return
+    }
+
+    const editorEnv = process.env.VISUAL || process.env.EDITOR || 'vi'
+    const editorArgs = editorEnv.trim().split(/\s+/).filter(Boolean)
+    const editor = editorArgs[0] || 'vi'
+    const editorPrefixArgs = editorArgs.slice(1)
+    const out = process.stdout
+    const stdin = process.stdin
+    const ENTER_ALT = '\x1b[?1049h'
+    const EXIT_ALT = '\x1b[?1049l'
+    const SHOW_CURSOR = '\x1b[?25h'
+    const HIDE_CURSOR = '\x1b[?25l'
+
+    let editorOk = false
+    try {
+      stdin.setRawMode?.(false)
+      out.write(`${SHOW_CURSOR}${EXIT_ALT}`)
+      const result = spawnSync(editor, [...editorPrefixArgs, file], { stdio: 'inherit' })
+      if (result.error) {
+        dispatch({ type: 'setStatus', value: `Failed to launch ${editor}: ${result.error.message}` })
+      } else if (result.signal) {
+        dispatch({ type: 'setStatus', value: `${editor} interrupted by ${result.signal}` })
+      } else if (typeof result.status === 'number' && result.status !== 0) {
+        dispatch({ type: 'setStatus', value: `${editor} exited with status ${result.status}` })
+      } else {
+        editorOk = true
+      }
+    } finally {
+      out.write(`${ENTER_ALT}${HIDE_CURSOR}`)
+      stdin.setRawMode?.(true)
+      resumeRef?.current?.()
+    }
+
+    if (editorOk) {
+      try {
+        const content = readFileSync(file, 'utf8')
+        dispatch({ type: 'setChangelogText', text: content })
+        dispatch({ type: 'setStatus', value: 'Changelog updated from editor.' })
+      } catch (error) {
+        dispatch({
+          type: 'setStatus',
+          value: `Failed to read back edited changelog: ${(error as Error).message}`,
+        })
+      }
+    }
+
+    try { rmSync(dir, { recursive: true, force: true }) } catch { /* ignore */ }
+  }, [dispatch, resumeRef, state.changelogView.text])
 
   // Open a file in $EDITOR (or $VISUAL) by suspending Ink's hold on the
   // terminal, spawning the editor synchronously inheriting stdio, then
@@ -2494,6 +2639,11 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         : state.diffSource === 'commit'
           ? filePreview?.hunks
           : undefined,
+      // Line count of the changelog text, used by the changelog view's
+      // j/k/PgUp/PgDn scroll bindings to clamp `pageChangelog` deltas.
+      // Computed from view state rather than threaded through context
+      // because the surface owns its own content — no external loader.
+      changelogLineCount: state.changelogView.text?.split('\n').length,
     }).forEach((event) => {
       if (event.type === 'exit') {
         exit()
@@ -2515,6 +2665,12 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         void startCreatePullRequest()
       } else if (event.type === 'startChangelogView') {
         void startChangelogView()
+      } else if (event.type === 'regenerateChangelog') {
+        regenerateChangelog()
+      } else if (event.type === 'yankChangelog') {
+        yankChangelog()
+      } else if (event.type === 'openChangelogInEditor') {
+        openChangelogInEditor()
       } else if (event.type === 'openComposeInEditor') {
         openComposeInEditor()
       } else if (event.type === 'yankText') {

--- a/src/workstation/runtime/mainPanel.ts
+++ b/src/workstation/runtime/mainPanel.ts
@@ -20,6 +20,7 @@ import type { WorktreeHunkOverview } from '../../git/statusHunks'
 import type { WorktreeFileDiff } from '../../git/worktreeDiffData'
 import { renderBisectSurface } from '../surfaces/bisect'
 import { renderBranchesSurface } from '../surfaces/branches'
+import { renderChangelogSurface } from '../surfaces/changelog'
 import { renderComposeSurface } from '../surfaces/compose'
 import { renderConflictsSurface } from '../surfaces/conflicts'
 import { renderDiffSurface } from '../surfaces/diff'
@@ -121,6 +122,10 @@ export function renderMainPanel(
 
   if (state.activeView === 'conflicts') {
     return renderConflictsSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
+  }
+
+  if (state.activeView === 'changelog') {
+    return renderChangelogSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
   }
 
   return renderHistoryPanel(

--- a/src/workstation/surfaces/changelog/index.ts
+++ b/src/workstation/surfaces/changelog/index.ts
@@ -1,0 +1,143 @@
+/**
+ * Changelog surface — full-screen view that renders LLM-generated
+ * release notes for the current branch. Reached via `L` from history
+ * or branches; rendered as a real surface (not an input prompt) so the
+ * content gets proper scroll, editing, yank, and create-PR follow-ups.
+ *
+ * Replaces the input-prompt-in-sidebar implementation from #906 (PR
+ * feedback: cramped, no useful navigation, hotkeys invisible).
+ *
+ * Display states:
+ *   - loading : spinner + "generating changelog vs main…"
+ *   - ready   : full text with scroll, header showing branch + base +
+ *               cache age, footer hints driven by the keymap
+ *   - error   : error message + "press r to retry"
+ *
+ * View-local bindings (also reflected in footer hints + help):
+ *   - j/k          scroll line
+ *   - pgup/pgdn    scroll page
+ *   - y            yank to clipboard
+ *   - E            open in $EDITOR (write-back updates view + cache)
+ *   - c            create-PR seeded with this content
+ *   - r            regenerate (force-refresh, skip cache)
+ *   - </Esc        pop back to prior view
+ *
+ * Caching: state.changelogCache is keyed by branch name. Re-entering
+ * the view for the same branch hits the cache (no LLM call); switching
+ * branches naturally produces a fresh generation. `r` is the explicit
+ * "I want fresh output right now" knob.
+ */
+
+import type * as ReactTypes from 'react'
+import type { LogInkContextStatus } from '../../chrome/context'
+import { truncateCells } from '../../chrome/text'
+import type { LogInkTheme } from '../../chrome/theme'
+import type { LogInkState } from '../../../commands/log/inkViewModel'
+import type { LogInkComponents, LogInkContext } from '../../runtime/types'
+import { focusBorderColor, panelTitle } from '../../runtime/utils'
+
+/**
+ * Pluralization-free relative-time string for cache age. Coarse on
+ * purpose — exact seconds don't help, but "5 minutes ago" vs "2 hours
+ * ago" tells the user whether the cached content might be stale.
+ */
+function formatCacheAge(generatedAt: number, now: number): string {
+  const diffMs = Math.max(0, now - generatedAt)
+  const sec = Math.floor(diffMs / 1000)
+  if (sec < 5) return 'just now'
+  if (sec < 60) return `${sec}s ago`
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min}m ago`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr}h ago`
+  const day = Math.floor(hr / 24)
+  return `${day}d ago`
+}
+
+export function renderChangelogSurface(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  _context: LogInkContext,
+  _contextStatus: LogInkContextStatus,
+  bodyRows: number,
+  width: number,
+  theme: LogInkTheme
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const focused = state.focus === 'commits'
+  const view = state.changelogView
+
+  // Reserve rows for the header (1) + cache hint line (1) + 1 for
+  // borders. Body fills the rest. Min of 4 so even ultra-short terminals
+  // don't collapse to negative space.
+  const listRows = Math.max(4, bodyRows - 3)
+  const maxLineWidth = Math.max(20, width - 4)
+
+  const headerLeft = view.branch
+    ? `Changelog: ${view.branch}${view.baseLabel ? ` (${view.baseLabel})` : ''}`
+    : 'Changelog'
+
+  let headerRight = ''
+  let lines: ReactTypes.ReactNode[]
+
+  if (view.status === 'loading') {
+    headerRight = 'generating…'
+    lines = [
+      h(Text, { key: 'changelog-loading', dimColor: true },
+        `Generating changelog ${view.baseLabel ? `(${view.baseLabel})` : ''}…`),
+      h(Text, { key: 'changelog-loading-hint', dimColor: true }, ''),
+      h(Text, { key: 'changelog-loading-hint-2', dimColor: true },
+        'Esc cancels and returns to the previous view.'),
+    ]
+  } else if (view.status === 'error') {
+    headerRight = 'error'
+    lines = [
+      h(Text, { key: 'changelog-error', color: 'red' },
+        `Changelog generation failed.`),
+      h(Text, { key: 'changelog-error-msg', dimColor: true },
+        view.error || 'No additional detail.'),
+      h(Text, { key: 'changelog-error-hint', dimColor: true }, ''),
+      h(Text, { key: 'changelog-error-retry', dimColor: true },
+        'Press `r` to retry, `<` / Esc to go back.'),
+    ]
+  } else if (view.status === 'ready' && view.text) {
+    const allLines = view.text.split('\n')
+    const totalLines = allLines.length
+    const scrollOffset = Math.min(view.scrollOffset, Math.max(0, totalLines - 1))
+    const visible = allLines.slice(scrollOffset, scrollOffset + listRows)
+    const cached = view.branch ? state.changelogCache[view.branch] : undefined
+    const ageHint = cached ? formatCacheAge(cached.generatedAt, Date.now()) : 'just now'
+
+    headerRight = `${scrollOffset + 1}–${Math.min(totalLines, scrollOffset + listRows)} / ${totalLines} · ${ageHint}`
+
+    lines = visible.length === 0
+      ? [h(Text, { key: 'changelog-empty', dimColor: true }, '(empty changelog)')]
+      : visible.map((line, offset) => h(Text, {
+        key: `changelog-line-${scrollOffset + offset}`,
+        dimColor: false,
+      }, truncateCells(line || ' ', maxLineWidth)))
+  } else {
+    // 'idle' — view was pushed but loading hasn't started yet. Should
+    // be a single-frame transient; we render the same loading copy so
+    // there's no jarring "empty" frame.
+    headerRight = ''
+    lines = [
+      h(Text, { key: 'changelog-idle', dimColor: true }, 'Preparing changelog…'),
+    ]
+  }
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    flexShrink: 0,
+    paddingX: 1,
+    width,
+  },
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle(headerLeft, focused)),
+    h(Text, { dimColor: true }, headerRight)
+  ),
+  ...lines)
+}


### PR DESCRIPTION
## Summary

Replaces #906's input-prompt-in-sidebar implementation with a proper full-screen view surface. Direct response to PR-feedback that the original was cramped, lacked useful navigation, and the hotkeys appeared not to work (they did, but inside a panel too small to surface their effect).

New surface module at `src/workstation/surfaces/changelog/` with its own keymap, scroll, and follow-up actions.

## Design choices (from earlier convo)

- **Scope (Q1: B)** — `L` only fires from `history` and `branches` views. Keeps the global namespace clean; the changelog is a "where am I, what landed here recently" question, fits those view semantics.
- **Edit model (Q2: A)** — Read-only view + `y` to yank + `E` to open in `$EDITOR`. Mirrors the compose `E` pattern from #913. Round-trip writes back to both view state and cache.
- **`c` from changelog (Q3: A)** — Dispatches `startCreatePullRequest`. Will refine PR-cache integration in a follow-up.
- **Caching (Q4: A)** — Per-branch, in-memory. Re-entry hits cache (no LLM call); branch switch produces fresh generation; `r` is the explicit "regenerate now" knob. Header surfaces "(cached, N ago)" so user knows whether to refresh.

## What landed

**State + reducer** (`inkViewModel.ts`):
- `state.changelogView`: status (`idle | loading | ready | error`), text, branch, baseLabel, scrollOffset
- `state.changelogCache`: keyed by branch, stores text + baseLabel + generatedAt
- Actions: `setChangelogLoading`, `setChangelogReady`, `setChangelogError`, `setChangelogText`, `pageChangelog`, `clearChangelogCache`

**Surface** (`workstation/surfaces/changelog/index.ts`, ~140 LOC):
- Three render modes (loading / ready / error)
- Header: `Changelog: <branch> (<baseLabel>)` + right-side scroll counter + cache age (`5m ago`)
- `truncateCells` for terminal-cell-width-aware line truncation
- Empty changelog → `(empty changelog)` placeholder

**Runtime callbacks** (`app.ts`):
- `startChangelogView({ force? })` — cache-aware; pushes view + dispatches loading; on success caches result and surfaces success status with the keymap reminder
- `regenerateChangelog` — thin wrapper, `force: true`
- `yankChangelog` — reads view text, delegates to `yankText`
- `openChangelogInEditor` — temp-file + suspend/spawn/resume dance (mirrors #913 compose `E`), writes back via `setChangelogText`

**Keymap** (`inkInput.ts`):
- `L` scoped to history + branches (removed global)
- View-local: `j/k`, `pgup/pgdn`, `y`, `E`, `c`, `r`
- `<` / Esc handled by global pop-view path

**Wiring**: `mainPanel.ts` adds the changelog dispatch case; footer hints in `inkKeymap.ts` surface the new bindings.

**Cleanup**: removed the dead `'changelog-view'` input-prompt kind from #906 (along with its submit handler).

## Test plan

- [x] `npm run lint` clean
- [x] `tsc --noEmit` clean
- [x] `npm run test:jest` — 691 suites / 6649 tests pass (+8 from this PR)
- [ ] Manual: `npm run scenario create feature-pr-ready -- --run-ui` (post-#912 default-branch fallback) → `L` from history → changelog surface renders with content, scroll works, `y` copies, `E` opens vim, `r` regenerates
- [ ] Manual: switch branches with `gb` → reopen `L` → fresh generation
- [ ] Manual: `c` from changelog view → kicks off create-PR flow (which currently regenerates body; cache-sharing is a follow-up)

## Follow-ups

- Share the changelog cache with `startCreatePullRequest` so `L → c` doesn't re-run the LLM
- Optional: persist changelog cache across sessions in `.coco/cache/`
- Wiki documentation update for `L` and `C` keystrokes (deferred until both have stabilized)