### PR TITLE
feat(workstation): wire commit split into compose via `S` keystroke

### DIFF
--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -99,10 +99,22 @@ type StagedHunk = {
   preview: string
 }
 
-type HunkInventory = {
+export type HunkInventory = {
   hunks: StagedHunk[]
   byId: Map<string, StagedHunk>
   byFile: Map<string, StagedHunk[]>
+}
+
+/**
+ * Snapshot of the staged-state context needed to apply a previously-
+ * generated split plan without re-running the plan generator. The
+ * workstation flow holds onto this between the plan preview and the
+ * `y` to apply, so the executed split matches exactly what the user
+ * reviewed — no LLM re-roll between preview and execution.
+ */
+export type CommitSplitPlanContext = {
+  changes: Awaited<ReturnType<typeof getChanges>>
+  hunkInventory: HunkInventory
 }
 
 function getGroupFiles(group: CommitSplitGroup): string[] {
@@ -265,7 +277,7 @@ async function applyPatchToIndex(
   })
 }
 
-async function applyCommitSplitPlan({
+export async function applyCommitSplitPlan({
   plan,
   changes,
   hunkInventory,
@@ -305,7 +317,27 @@ async function applyCommitSplitPlan({
   return `Created ${plan.groups.length} split commit(s).`
 }
 
-export async function handleCommitSplit({
+/**
+ * Generate a validated commit split plan against the current staged
+ * state. Pure plan generation — no formatting, no apply, no side
+ * effects on the index. Returns the structured plan plus the context
+ * (`changes` + `hunkInventory`) needed to apply it later via
+ * `applyCommitSplitPlan`.
+ *
+ * Used by:
+ *   - `handleCommitSplit` (the CLI handler — formats the plan into
+ *     markdown for stdout or applies it directly when `argv.apply`).
+ *   - `runCommitSplitPlanWorkflow` (the workstation workflow — returns
+ *     the structured plan so the overlay can render it group-by-group
+ *     and pass the same plan to apply without re-rolling the LLM).
+ *
+ * The split between "generate the plan" and "apply the plan" is what
+ * lets the workstation guarantee the executed split matches the
+ * previewed plan exactly. Re-running the generator between preview
+ * and apply would risk drift (small LLM nondeterminism, staged-state
+ * changes the user didn't intend, etc.).
+ */
+export async function prepareCommitSplitPlan({
   argv,
   config,
   git,
@@ -319,7 +351,7 @@ export async function handleCommitSplit({
   logger: Logger
   tokenizer: TokenCounter
   llm: ReturnType<typeof getLlm>
-}): Promise<string> {
+}): Promise<{ plan: CommitSplitPlan; context: CommitSplitPlanContext } | { empty: true }> {
   const changes = await getChanges({
     git,
     options: {
@@ -329,7 +361,7 @@ export async function handleCommitSplit({
   })
 
   if (changes.staged.length === 0) {
-    return 'No staged changes found.'
+    return { empty: true }
   }
 
   const hunkInventory = await collectHunkInventory(changes.staged, git)
@@ -374,11 +406,37 @@ export async function handleCommitSplit({
     maxAttempts: DEFAULT_MAX_PLAN_ATTEMPTS,
   })
 
+  return { plan, context: { changes, hunkInventory } }
+}
+
+export async function handleCommitSplit({
+  argv,
+  config,
+  git,
+  logger,
+  tokenizer,
+  llm,
+}: {
+  argv: Arguments<CommitOptions>
+  config: Config & CommitOptions
+  git: ReturnType<typeof import('../../lib/simple-git/getRepo').getRepo>
+  logger: Logger
+  tokenizer: TokenCounter
+  llm: ReturnType<typeof getLlm>
+}): Promise<string> {
+  const result = await prepareCommitSplitPlan({ argv, config, git, logger, tokenizer, llm })
+
+  if ('empty' in result) {
+    return 'No staged changes found.'
+  }
+
+  const { plan, context } = result
+
   if (argv.apply) {
     return await applyCommitSplitPlan({
       plan,
-      changes,
-      hunkInventory,
+      changes: context.changes,
+      hunkInventory: context.hunkInventory,
       git,
       logger,
       noVerify: argv.noVerify || config.noVerify || false,

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -1069,6 +1069,41 @@ describe('log Ink input interactions', () => {
     expect(events.some((event) => event.type === 'openComposeInEditor')).toBe(false)
   })
 
+  it('S from compose starts the split flow', () => {
+    // Capital `S` — split staged changes into multiple commits. From
+    // compose, single dispatch (no view push needed since we're
+    // already in compose). Runtime callback handles pre-flight + plan
+    // generation; from the input handler's perspective it's one event.
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'compose' })
+
+    expect(getLogInkInputEvents(state, 'S')).toEqual([
+      { type: 'startCommitSplit' },
+    ])
+  })
+
+  it('S from status or diff pushes compose first, then starts the split flow', () => {
+    // Mirrors `E` and lowercase `c` — from worktree views, the
+    // keystroke auto-jumps into compose before invoking the split.
+    const statusState = createLogInkState(rows, { activeView: 'status' })
+    expect(getLogInkInputEvents(statusState, 'S', {}, { worktreeFileCount: 1 })).toEqual([
+      { type: 'action', action: { type: 'pushView', value: 'compose' } },
+      { type: 'startCommitSplit' },
+    ])
+
+    const diffState = createLogInkState(rows, { activeView: 'diff' })
+    expect(getLogInkInputEvents(diffState, 'S', {}, { worktreeFileCount: 1 })).toEqual([
+      { type: 'action', action: { type: 'pushView', value: 'compose' } },
+      { type: 'startCommitSplit' },
+    ])
+  })
+
+  it('S does not fire outside the status / diff / compose triad', () => {
+    const historyState = createLogInkState(rows, { activeView: 'history' })
+    const events = getLogInkInputEvents(historyState, 'S')
+    expect(events.some((event) => event.type === 'startCommitSplit')).toBe(false)
+  })
+
   it('preserves draft state across compose → history → compose round-trips', () => {
     let state = createLogInkState(rows)
 
@@ -3025,6 +3060,101 @@ describe('log Ink input interactions', () => {
         (e) => e.type === 'runWorkflowAction' && (e as { id: string }).id === 'resolve-conflict-stage'
       )
       expect(hasConflictStage).toBe(false)
+    })
+  })
+
+  describe('split-plan overlay intercept (#907)', () => {
+    // Mock plan + context for the 'ready' state tests. The shape is
+    // what runCommitSplitPlanWorkflow would return on success — the
+    // input handler doesn't validate it deeply, just checks presence.
+    const mockPlan = {
+      groups: [
+        { title: 'feat: foo', files: ['src/foo.ts'], hunks: [] },
+        { title: 'feat: bar', files: ['src/bar.ts'], hunks: [] },
+      ],
+    }
+    const mockPlanContext = {
+      changes: { staged: [], unstaged: [], untracked: [] },
+      hunkInventory: { hunks: [], byId: new Map(), byFile: new Map() },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+
+    it('intercepts y/Enter as apply when the plan is ready', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, {
+        type: 'setSplitPlanReady',
+        plan: mockPlan,
+        planContext: mockPlanContext,
+      })
+
+      expect(getLogInkInputEvents(state, 'y', {}, { splitPlanLineCount: 10 })).toEqual([
+        { type: 'applyCommitSplit' },
+      ])
+      expect(getLogInkInputEvents(state, '', { return: true }, { splitPlanLineCount: 10 })).toEqual([
+        { type: 'applyCommitSplit' },
+      ])
+    })
+
+    it('intercepts Esc as cancel from any phase', () => {
+      const loadingState = applyLogInkAction(createLogInkState(rows), { type: 'startSplitPlanLoad' })
+      expect(getLogInkInputEvents(loadingState, '', { escape: true })).toEqual([
+        { type: 'cancelCommitSplit' },
+      ])
+
+      const readyState = applyLogInkAction(createLogInkState(rows), {
+        type: 'setSplitPlanReady',
+        plan: mockPlan,
+        planContext: mockPlanContext,
+      })
+      expect(getLogInkInputEvents(readyState, '', { escape: true })).toEqual([
+        { type: 'cancelCommitSplit' },
+      ])
+    })
+
+    it('intercepts j/k as line scroll, PgUp/PgDn as 10-line scroll', () => {
+      const state = applyLogInkAction(createLogInkState(rows), {
+        type: 'setSplitPlanReady',
+        plan: mockPlan,
+        planContext: mockPlanContext,
+      })
+
+      expect(getLogInkInputEvents(state, 'j', {}, { splitPlanLineCount: 50 })).toEqual([
+        { type: 'action', action: { type: 'pageSplitPlan', delta: 1, lineCount: 50 } },
+      ])
+      expect(getLogInkInputEvents(state, 'k', {}, { splitPlanLineCount: 50 })).toEqual([
+        { type: 'action', action: { type: 'pageSplitPlan', delta: -1, lineCount: 50 } },
+      ])
+      expect(getLogInkInputEvents(state, '', { pageDown: true }, { splitPlanLineCount: 50 })).toEqual([
+        { type: 'action', action: { type: 'pageSplitPlan', delta: 10, lineCount: 50 } },
+      ])
+      expect(getLogInkInputEvents(state, '', { pageUp: true }, { splitPlanLineCount: 50 })).toEqual([
+        { type: 'action', action: { type: 'pageSplitPlan', delta: -10, lineCount: 50 } },
+      ])
+    })
+
+    it('y/Enter no-op while loading (no plan to apply)', () => {
+      const state = applyLogInkAction(createLogInkState(rows), { type: 'startSplitPlanLoad' })
+
+      // Returns empty array — keystroke consumed, no dispatch.
+      expect(getLogInkInputEvents(state, 'y')).toEqual([])
+      expect(getLogInkInputEvents(state, '', { return: true })).toEqual([])
+    })
+
+    it('consumes all other keystrokes without falling through to compose bindings', () => {
+      // While the overlay is open, none of the compose keystrokes
+      // (`c` commit, `e` inline-edit, `E` external editor) should
+      // reach the underlying view.
+      const state = applyLogInkAction(createLogInkState(rows), {
+        type: 'setSplitPlanReady',
+        plan: mockPlan,
+        planContext: mockPlanContext,
+      })
+
+      // `c` on compose normally fires createManualCommit. With the
+      // overlay open, it should be consumed (empty array, no event).
+      expect(getLogInkInputEvents(state, 'c', {}, { splitPlanLineCount: 10 })).toEqual([])
+      expect(getLogInkInputEvents(state, 'e', {}, { splitPlanLineCount: 10 })).toEqual([])
+      expect(getLogInkInputEvents(state, 'E', {}, { splitPlanLineCount: 10 })).toEqual([])
     })
   })
 })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -55,6 +55,9 @@ export type LogInkInputEvent =
   | { type: 'yankChangelog' }
   | { type: 'openChangelogInEditor' }
   | { type: 'openComposeInEditor' }
+  | { type: 'startCommitSplit' }
+  | { type: 'applyCommitSplit' }
+  | { type: 'cancelCommitSplit' }
   | { type: 'runWorkflowAction'; id: string; payload?: string }
   | { type: 'openFileInEditor'; path: string }
   | { type: 'yankFromActiveView'; short?: boolean }
@@ -171,6 +174,13 @@ export type LogInkInputContext = {
    * or generation failed — the scroll handlers no-op in that case.
    */
   changelogLineCount?: number
+  /**
+   * Total rendered line count of the split-plan overlay content.
+   * Used by the overlay's scroll bindings to clamp `pageSplitPlan`
+   * deltas. The runtime computes this from `state.splitPlan.plan`
+   * groups before dispatching to the input handler.
+   */
+  splitPlanLineCount?: number
 }
 
 function action(actionValue: LogInkAction): LogInkInputEvent {
@@ -903,6 +913,55 @@ export function getLogInkInputEvents(
       ]
     }
 
+    return []
+  }
+
+  // Split-plan overlay intercept (#907). When the overlay is open we
+  // claim every keystroke — no fall-through to the underlying compose
+  // surface, no accidental `c` commits, no chord prefixes. The overlay
+  // owns the screen until the user accepts (`y`/Enter), cancels (Esc),
+  // or scrolls (`j/k`/PgUp/PgDn). Status / loading / applying phases
+  // intercept keystrokes equally; the only state-dependent variation
+  // is that `y`/Enter is a no-op while loading or applying (nothing
+  // to accept yet, or accept already in flight).
+  if (state.splitPlan) {
+    const lineCount = context.splitPlanLineCount || 0
+
+    if (key.escape) {
+      // Esc during loading is a soft cancel — we can't actually abort
+      // the in-flight LLM call (runs in a sibling promise), but we
+      // close the overlay and the runtime ignores the resolved plan
+      // when it eventually lands (it checks `state.splitPlan?.status`
+      // before dispatching setSplitPlanReady).
+      return [{ type: 'cancelCommitSplit' }]
+    }
+
+    // Apply only fires from the 'ready' state. While loading we have
+    // no plan; while applying we'd race the in-flight apply call. The
+    // intercept consumes the keystroke either way so users don't
+    // fall back into the compose surface.
+    if ((inputValue === 'y' || key.return) && state.splitPlan.status === 'ready') {
+      return [{ type: 'applyCommitSplit' }]
+    }
+
+    if (state.splitPlan.status === 'ready' && lineCount > 0) {
+      if (inputValue === 'j') {
+        return [action({ type: 'pageSplitPlan', delta: 1, lineCount })]
+      }
+      if (inputValue === 'k') {
+        return [action({ type: 'pageSplitPlan', delta: -1, lineCount })]
+      }
+      if (key.pageDown) {
+        return [action({ type: 'pageSplitPlan', delta: 10, lineCount })]
+      }
+      if (key.pageUp) {
+        return [action({ type: 'pageSplitPlan', delta: -10, lineCount })]
+      }
+    }
+
+    // Catch-all: consume the keystroke so it doesn't reach the
+    // underlying compose surface. Returning an empty array keeps the
+    // overlay open without dispatching any state change.
     return []
   }
 
@@ -2030,7 +2089,18 @@ export function getLogInkInputEvents(
   // Global stash hotkey: `S` opens a stash-message prompt and
   // `createStash` runs once submitted. Available everywhere there's
   // not a more modal handler in front of it.
-  if (inputValue === 'S') {
+  //
+  // Scoped away from compose/status/diff (#907) since those views
+  // map `S` to the commit-split flow (handler is further down so
+  // those views fall through past this check). The triad is the
+  // natural commit-message work surface; create-stash is reachable
+  // from anywhere else (history, branches, tags, …).
+  if (
+    inputValue === 'S' &&
+    state.activeView !== 'compose' &&
+    state.activeView !== 'status' &&
+    state.activeView !== 'diff'
+  ) {
     return [action({
       type: 'openInputPrompt',
       kind: 'create-stash',
@@ -2345,6 +2415,26 @@ export function getLogInkInputEvents(
       events.push(action({ type: 'pushView', value: 'compose' }))
     }
     events.push({ type: 'openComposeInEditor' })
+    return events
+  }
+
+  // Capital `S` — start the `coco commit --split` flow as an in-TUI
+  // operation (#907). Generates a split plan against the current
+  // staged set and opens the plan-review overlay; from inside the
+  // overlay, `y`/Enter applies the previewed plan. Fires from the
+  // same triad as `E` (compose / status / diff) since those are the
+  // entry points to commit-message work; from status/diff we push
+  // into compose first so the flow ends with the user inside the
+  // compose surface (now with the split applied).
+  if (
+    inputValue === 'S' &&
+    (state.activeView === 'status' || state.activeView === 'diff' || state.activeView === 'compose')
+  ) {
+    const events: LogInkInputEvent[] = []
+    if (state.activeView !== 'compose') {
+      events.push(action({ type: 'pushView', value: 'compose' }))
+    }
+    events.push({ type: 'startCommitSplit' })
     return events
   }
 

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -67,7 +67,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['e edit', 'E $EDITOR', 'c commit', 'I AI draft', 'gs hunks', 'esc back'],
+      contextual: ['e edit', 'E $EDITOR', 'c commit', 'S split', 'I AI draft', 'gs hunks', 'esc back'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -12,6 +12,7 @@ export type LogInkCommandId =
   | 'cycleSort'
   | 'editCommit'
   | 'editCommitExternal'
+  | 'commitSplit'
   | 'focusNext'
   | 'focusPrevious'
   | 'help'
@@ -332,6 +333,13 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     contexts: ['commits'],
   },
   {
+    id: 'commitSplit',
+    keys: ['S'],
+    label: 'split commit',
+    description: 'Generate a plan to split staged changes into multiple coherent commits; review and apply from an overlay.',
+    contexts: ['commits'],
+  },
+  {
     id: 'commit',
     keys: ['c'],
     label: 'commit',
@@ -641,7 +649,7 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
 
   if (options.activeView === 'compose') {
     return {
-      contextual: ['e edit', 'E $EDITOR', 'c commit', 'I AI draft', 'gs hunks', 'esc back'],
+      contextual: ['e edit', 'E $EDITOR', 'c commit', 'S split', 'I AI draft', 'gs hunks', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -1188,4 +1188,121 @@ describe('log Ink view model', () => {
       expect(state.viewStack).toEqual(['history'])
     })
   })
+
+  describe('split-plan overlay state (#907)', () => {
+    const mockPlan = {
+      groups: [
+        { title: 'feat: foo', files: ['src/foo.ts'], hunks: [] },
+        { title: 'feat: bar', files: ['src/bar.ts'], hunks: [] },
+      ],
+    }
+    const mockPlanContext = {
+      changes: { staged: [], unstaged: [], untracked: [] },
+      hunkInventory: { hunks: [], byId: new Map(), byFile: new Map() },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+
+    it('startSplitPlanLoad opens the overlay in loading state', () => {
+      let state = createLogInkState(rows)
+      expect(state.splitPlan).toBeUndefined()
+
+      state = applyLogInkAction(state, { type: 'startSplitPlanLoad' })
+      expect(state.splitPlan).toEqual({ status: 'loading', scrollOffset: 0 })
+    })
+
+    it('setSplitPlanReady populates the plan and resets scroll', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'startSplitPlanLoad' })
+      state = applyLogInkAction(state, {
+        type: 'setSplitPlanReady',
+        plan: mockPlan,
+        planContext: mockPlanContext,
+      })
+
+      expect(state.splitPlan).toEqual({
+        status: 'ready',
+        plan: mockPlan,
+        planContext: mockPlanContext,
+        scrollOffset: 0,
+      })
+    })
+
+    it('setSplitPlanApplying preserves plan + context, transitions status', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, {
+        type: 'setSplitPlanReady',
+        plan: mockPlan,
+        planContext: mockPlanContext,
+      })
+      state = applyLogInkAction(state, { type: 'setSplitPlanApplying' })
+
+      expect(state.splitPlan?.status).toBe('applying')
+      // Plan + context preserved so the overlay can keep rendering
+      // the same content during the apply phase.
+      expect(state.splitPlan?.plan).toEqual(mockPlan)
+      expect(state.splitPlan?.planContext).toEqual(mockPlanContext)
+    })
+
+    it('setSplitPlanError keeps the overlay open when a plan exists', () => {
+      // Apply failed mid-flight — we keep the overlay open so the user
+      // can retry or back out. Status flips back to 'ready' (no longer
+      // applying), with the error annotated for the renderer.
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, {
+        type: 'setSplitPlanReady',
+        plan: mockPlan,
+        planContext: mockPlanContext,
+      })
+      state = applyLogInkAction(state, { type: 'setSplitPlanApplying' })
+      state = applyLogInkAction(state, { type: 'setSplitPlanError', error: 'patch conflict' })
+
+      expect(state.splitPlan?.status).toBe('ready')
+      expect(state.splitPlan?.error).toBe('patch conflict')
+      expect(state.splitPlan?.plan).toEqual(mockPlan)
+    })
+
+    it('setSplitPlanError closes the overlay when no plan exists', () => {
+      // Initial generation failed — nothing to retry from, close out.
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'startSplitPlanLoad' })
+      state = applyLogInkAction(state, { type: 'setSplitPlanError', error: 'LLM unreachable' })
+
+      expect(state.splitPlan).toBeUndefined()
+    })
+
+    it('pageSplitPlan scrolls within the line-count bounds', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, {
+        type: 'setSplitPlanReady',
+        plan: mockPlan,
+        planContext: mockPlanContext,
+      })
+
+      state = applyLogInkAction(state, { type: 'pageSplitPlan', delta: 5, lineCount: 20 })
+      expect(state.splitPlan?.scrollOffset).toBe(5)
+
+      // Clamps to 0 on overshoot the other way.
+      state = applyLogInkAction(state, { type: 'pageSplitPlan', delta: -100, lineCount: 20 })
+      expect(state.splitPlan?.scrollOffset).toBe(0)
+
+      // Clamps to lineCount-1 on overshoot upward.
+      state = applyLogInkAction(state, { type: 'pageSplitPlan', delta: 999, lineCount: 20 })
+      expect(state.splitPlan?.scrollOffset).toBe(19)
+    })
+
+    it('clearSplitPlan closes the overlay regardless of phase', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'startSplitPlanLoad' })
+      state = applyLogInkAction(state, { type: 'clearSplitPlan' })
+      expect(state.splitPlan).toBeUndefined()
+
+      state = applyLogInkAction(state, {
+        type: 'setSplitPlanReady',
+        plan: mockPlan,
+        planContext: mockPlanContext,
+      })
+      state = applyLogInkAction(state, { type: 'clearSplitPlan' })
+      expect(state.splitPlan).toBeUndefined()
+    })
+  })
 })

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -5,6 +5,7 @@ import {
     applyCommitComposeAction,
     createCommitComposeState,
 } from './commitCompose'
+import type { CommitSplitPlan, CommitSplitPlanContext } from '../commit/split'
 import { PromotedSelectionsSnapshot } from '../../workstation/chrome/selectionRectify'
 import {
     BranchSortMode,
@@ -274,6 +275,21 @@ export type LogInkState = {
    */
   bootLoading: boolean
   /**
+   * Split-plan overlay state (#907). When defined, the overlay is
+   * open. Three phases:
+   *   - 'loading'  : plan generation in flight, overlay shows a
+   *                  spinner. plan + planContext are undefined.
+   *   - 'ready'    : plan generated, overlay shows scrollable groups
+   *                  for review. `y`/Enter applies, Esc cancels.
+   *   - 'applying' : user accepted the plan, apply in flight. Overlay
+   *                  shows "applying…" until the workflow returns.
+   *
+   * Cleared (set to undefined) on cancel or successful apply. Apply
+   * failures keep the overlay open in 'ready' so the user can retry
+   * or back out — the status line carries the error message.
+   */
+  splitPlan?: SplitPlanState
+  /**
    * Changelog view (full-screen surface). `status` drives what the
    * panel renders:
    *   - 'idle'    : view pushed but no content yet (transient — flips
@@ -319,6 +335,22 @@ export type ChangelogCacheEntry = {
 export const DEFAULT_CHANGELOG_VIEW_STATE: ChangelogViewState = {
   status: 'idle',
   scrollOffset: 0,
+}
+
+/**
+ * Split-plan overlay state. Held on root state (not on a per-view
+ * surface) because the overlay can be triggered from compose and
+ * dismissed back to whatever view was active beneath. The plan +
+ * context come from `runCommitSplitPlanWorkflow`; the workstation
+ * holds them between preview and apply so the executed split matches
+ * exactly what was previewed.
+ */
+export type SplitPlanState = {
+  status: 'loading' | 'ready' | 'applying'
+  plan?: CommitSplitPlan
+  planContext?: CommitSplitPlanContext
+  scrollOffset: number
+  error?: string
 }
 
 export type LogInkStatusFilterMask = {
@@ -478,6 +510,12 @@ export type LogInkAction =
   | { type: 'setChangelogText'; text: string }
   | { type: 'pageChangelog'; delta: number; lineCount: number }
   | { type: 'clearChangelogCache'; branch?: string }
+  | { type: 'startSplitPlanLoad' }
+  | { type: 'setSplitPlanReady'; plan: CommitSplitPlan; planContext: CommitSplitPlanContext }
+  | { type: 'setSplitPlanApplying' }
+  | { type: 'setSplitPlanError'; error: string }
+  | { type: 'pageSplitPlan'; delta: number; lineCount: number }
+  | { type: 'clearSplitPlan' }
 
 const FOCUS_ORDER: LogInkFocus[] = ['sidebar', 'commits', 'detail']
 const SIDEBAR_TABS: LogInkSidebarTab[] = ['status', 'branches', 'tags', 'stashes', 'worktrees']
@@ -1606,6 +1644,76 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       delete next[action.branch]
       return { ...state, changelogCache: next, pendingKey: undefined }
     }
+    case 'startSplitPlanLoad':
+      // Overlay opens immediately so the user sees the loading state
+      // (rather than the compose view sitting frozen while the LLM
+      // call resolves). plan + planContext stay undefined until ready.
+      return {
+        ...state,
+        splitPlan: { status: 'loading', scrollOffset: 0 },
+        pendingKey: undefined,
+      }
+    case 'setSplitPlanReady':
+      return {
+        ...state,
+        splitPlan: {
+          status: 'ready',
+          plan: action.plan,
+          planContext: action.planContext,
+          scrollOffset: 0,
+        },
+        pendingKey: undefined,
+      }
+    case 'setSplitPlanApplying':
+      // Preserve plan + planContext so the overlay can keep rendering
+      // the same content during apply (just with a "applying…" hint
+      // overlaid). If somehow this fires without a plan loaded, fall
+      // back to the loading shape.
+      if (!state.splitPlan?.plan || !state.splitPlan.planContext) {
+        return { ...state, splitPlan: { status: 'loading', scrollOffset: 0 }, pendingKey: undefined }
+      }
+      return {
+        ...state,
+        splitPlan: {
+          ...state.splitPlan,
+          status: 'applying',
+        },
+        pendingKey: undefined,
+      }
+    case 'setSplitPlanError':
+      // Apply / plan failure path. We KEEP the overlay open in 'ready'
+      // shape with the previous plan if we have one, so the user can
+      // either retry or back out without losing context. If no plan
+      // yet (failure during initial load), close the overlay — there's
+      // nothing to retry from. The status line carries the message
+      // either way; the `error` field is for the overlay's own copy.
+      if (!state.splitPlan?.plan) {
+        return { ...state, splitPlan: undefined, pendingKey: undefined }
+      }
+      return {
+        ...state,
+        splitPlan: {
+          ...state.splitPlan,
+          status: 'ready',
+          error: action.error,
+        },
+        pendingKey: undefined,
+      }
+    case 'pageSplitPlan':
+      if (!state.splitPlan) return state
+      return {
+        ...state,
+        splitPlan: {
+          ...state.splitPlan,
+          scrollOffset: clampIndex(
+            state.splitPlan.scrollOffset + action.delta,
+            action.lineCount
+          ),
+        },
+        pendingKey: undefined,
+      }
+    case 'clearSplitPlan':
+      return { ...state, splitPlan: undefined, pendingKey: undefined }
     default:
       return state
   }

--- a/src/git/commitWorkflowActions.ts
+++ b/src/git/commitWorkflowActions.ts
@@ -1,13 +1,28 @@
 import { Arguments } from 'yargs'
+import { type TiktokenModel } from '@langchain/openai'
 import { SimpleGit } from 'simple-git'
 import { handler as commitHandler } from '../commands/commit/handler'
 import { CommitOptions } from '../commands/commit/config'
 import { generateCommitDraft } from '../commands/commit/generateCommitDraft'
+import {
+  CommitSplitPlan,
+  CommitSplitPlanContext,
+  applyCommitSplitPlan,
+  prepareCommitSplitPlan,
+} from '../commands/commit/split'
+import { LLMModel } from '../lib/langchain/types'
+import {
+  getApiKeyForModel,
+  getModelAndProviderFromConfig,
+} from '../lib/langchain/utils'
+import { resolveDynamicService } from '../lib/langchain/utils/dynamicModels'
+import { getLlm } from '../lib/langchain/utils/getLlm'
 import { loadConfig } from '../lib/config/utils/loadConfig'
 import { createCommit, PreCommitHookError } from '../lib/simple-git/createCommit'
 import { getRepo } from '../lib/simple-git/getRepo'
 import { isCommandExitError } from '../lib/utils/commandExit'
 import { Logger } from '../lib/utils/logger'
+import { getTokenCounter } from '../lib/utils/tokenizer'
 
 export type CommitWorkflowAction = 'commit' | 'split-plan' | 'split-apply'
 
@@ -198,6 +213,147 @@ export async function runCommitDraftWorkflow(
       }
     }
 
+    return formatCommitFailure(error)
+  }
+}
+
+/**
+ * Result shape for the workstation-side split-plan workflow. Distinct
+ * from `CommitWorkflowResult` because the workstation needs the
+ * structured plan + context (not just a string message) so the
+ * overlay can render groups one-by-one AND pass the same plan to
+ * apply without re-rolling the LLM.
+ *
+ * `planContext` carries the staged-state snapshot the apply phase
+ * needs (`changes` + `hunkInventory`). The workstation holds it in
+ * state between plan generation and apply.
+ */
+export type CommitSplitPlanResult =
+  | { ok: true; plan: CommitSplitPlan; planContext: CommitSplitPlanContext }
+  | { ok: false; message: string; details?: string[] }
+
+/**
+ * Run plan generation in isolation — no formatting, no apply, no
+ * stdout side effects. Returns the structured plan + the staged-state
+ * context the apply phase needs. The workstation's `S` keystroke
+ * calls this; the overlay renders the result; `y`/Enter passes the
+ * plan straight to `runCommitSplitApplyWorkflow` so the executed
+ * split matches what the user previewed.
+ */
+export async function runCommitSplitPlanWorkflow(
+  input: { git?: SimpleGit } = {}
+): Promise<CommitSplitPlanResult> {
+  const git = input.git || getRepo()
+  const argv = createCommitWorkflowArgv('split-plan')
+  const logger = new Logger({ silent: true })
+  const config = loadConfig<CommitOptions, CommitWorkflowArgv>(argv)
+
+  // Mirror the LLM / tokenizer setup from commit/handler.ts so plan
+  // generation runs against the same provider config as `coco commit
+  // --split --plan` would from the CLI. No fallback if the auth check
+  // fails — surface it as a workflow error instead.
+  const key = getApiKeyForModel(config)
+  const { provider } = getModelAndProviderFromConfig(config)
+  const commitService = resolveDynamicService(config, 'commit')
+  const model = commitService.model
+
+  if (config.service.authentication.type !== 'None' && !key) {
+    return {
+      ok: false,
+      message: 'No API key configured. Set one via env or .coco.config.json before running split.',
+    }
+  }
+
+  try {
+    const tokenizer = await getTokenCounter(
+      provider === 'openai' ? (model as TiktokenModel) : 'gpt-4o'
+    )
+    const llm = getLlm(provider, model as LLMModel, { ...config, service: commitService })
+
+    const result = await prepareCommitSplitPlan({
+      argv,
+      config,
+      git,
+      logger,
+      tokenizer,
+      llm,
+    })
+
+    if ('empty' in result) {
+      return {
+        ok: false,
+        message: 'No staged changes to split. Stage some files first.',
+      }
+    }
+
+    return {
+      ok: true,
+      plan: result.plan,
+      planContext: result.context,
+    }
+  } catch (error) {
+    if (isCommandExitError(error)) {
+      const lines = compactOutputLines(error.message)
+      return {
+        ok: false,
+        message: lines[0] || 'Split plan generation failed.',
+        details: lines.slice(1, 6),
+      }
+    }
+    // formatCommitFailure returns the broader CommitWorkflowResult shape
+    // (ok: boolean). Narrow it here — by construction the catch path only
+    // ever produces failures, so we know `ok` will be false.
+    const failure = formatCommitFailure(error)
+    return {
+      ok: false,
+      message: failure.message,
+      details: failure.details,
+    }
+  }
+}
+
+/**
+ * Apply a pre-generated split plan. Takes the plan + context that
+ * `runCommitSplitPlanWorkflow` produced (held in workstation state
+ * during the preview phase) and runs the underlying
+ * `applyCommitSplitPlan` — same code path as `coco commit --split
+ * --apply` would take through the CLI, just skipping the plan
+ * regeneration since the workstation already has the plan to apply.
+ *
+ * No LLM call here — pure git-index mutation. Each plan group becomes
+ * a single commit, in order.
+ */
+export async function runCommitSplitApplyWorkflow(input: {
+  plan: CommitSplitPlan
+  planContext: CommitSplitPlanContext
+  git?: SimpleGit
+  noVerify?: boolean
+}): Promise<CommitWorkflowResult> {
+  const git = input.git || getRepo()
+  const logger = new Logger({ silent: true })
+
+  try {
+    const message = await applyCommitSplitPlan({
+      plan: input.plan,
+      changes: input.planContext.changes,
+      hunkInventory: input.planContext.hunkInventory,
+      git,
+      logger,
+      noVerify: input.noVerify || false,
+    })
+    return {
+      ok: true,
+      message: message || 'Applied commit split plan.',
+    }
+  } catch (error) {
+    if (isCommandExitError(error)) {
+      const lines = compactOutputLines(error.message)
+      return {
+        ok: error.code === 0,
+        message: lines[0] || error.message,
+        details: lines.slice(1, 6),
+      }
+    }
     return formatCommitFailure(error)
   }
 }

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -59,7 +59,11 @@ import type * as ReactTypes from 'react'
 import { SimpleGit } from 'simple-git'
 import { getBranchOverview } from '../../git/branchData'
 import { createManualCommit, formatCommitComposeMessage } from '../../commands/log/commitCompose'
-import { runCommitDraftWorkflow } from '../../git/commitWorkflowActions'
+import {
+  runCommitDraftWorkflow,
+  runCommitSplitApplyWorkflow,
+  runCommitSplitPlanWorkflow,
+} from '../../git/commitWorkflowActions'
 import { runChangelogTextWorkflow } from '../../git/aiActions'
 import {
     GitCommitDetail,
@@ -1700,6 +1704,100 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     try { rmSync(dir, { recursive: true, force: true }) } catch { /* ignore */ }
   }, [dispatch, resumeRef, state.commitCompose])
 
+  // `S` keystroke — start the `coco commit --split` flow (#907).
+  // Pre-flight refuses cleanly when:
+  //   - Nothing is staged (suggests `g s` to pick files)
+  //   - A bisect / merge / rebase is in progress (split would be confusing)
+  // Then opens the overlay in 'loading' state, kicks off the plan
+  // workflow, and dispatches setSplitPlanReady (or setSplitPlanError)
+  // when it resolves. The overlay handles the rest from there.
+  const startCommitSplit = React.useCallback(async () => {
+    const stagedCount = context.worktree?.stagedCount || 0
+    if (stagedCount === 0) {
+      dispatch({
+        type: 'setStatus',
+        value: 'Nothing staged to split. Stage some files first (`g s` to pick).',
+      })
+      return
+    }
+    const operation = context.operation
+    if (operation?.operation && operation.operation !== 'none') {
+      dispatch({
+        type: 'setStatus',
+        value: `A ${operation.operation} is in progress — finish or abort it before splitting.`,
+      })
+      return
+    }
+
+    dispatch({ type: 'startSplitPlanLoad' })
+    dispatch({ type: 'setStatus', value: 'Generating split plan (this can take a minute)…' })
+
+    const result = await runCommitSplitPlanWorkflow({ git })
+
+    if (!result.ok) {
+      dispatch({ type: 'setSplitPlanError', error: result.message })
+      dispatch({ type: 'setStatus', value: `Split plan failed: ${result.message}` })
+      return
+    }
+
+    dispatch({
+      type: 'setSplitPlanReady',
+      plan: result.plan,
+      planContext: result.planContext,
+    })
+    dispatch({
+      type: 'setStatus',
+      value: `Split plan ready: ${result.plan.groups.length} commit(s). y/Enter to apply, Esc to cancel.`,
+    })
+  }, [context.operation, context.worktree?.stagedCount, dispatch, git])
+
+  // `y`/Enter inside the overlay — apply the previewed plan. Uses the
+  // plan + planContext from state (set by setSplitPlanReady) so the
+  // executed split matches what the user reviewed exactly. No LLM
+  // re-roll, no plan drift.
+  const applyCommitSplit = React.useCallback(async () => {
+    const splitPlan = state.splitPlan
+    if (!splitPlan?.plan || !splitPlan.planContext) {
+      dispatch({ type: 'setStatus', value: 'No split plan loaded yet — wait for generation.' })
+      return
+    }
+
+    dispatch({ type: 'setSplitPlanApplying' })
+    dispatch({ type: 'setStatus', value: 'Applying split plan…' })
+
+    const result = await runCommitSplitApplyWorkflow({
+      plan: splitPlan.plan,
+      planContext: splitPlan.planContext,
+      git,
+    })
+
+    if (!result.ok) {
+      // Keep the overlay open so the user can see what happened and
+      // try again. setSplitPlanError preserves the existing plan in
+      // 'ready' state with the error annotation.
+      dispatch({ type: 'setSplitPlanError', error: result.message })
+      dispatch({ type: 'setStatus', value: `Split apply failed: ${result.message}` })
+      return
+    }
+
+    // Success — close the overlay, reset compose (the staged set is
+    // now empty since the plan committed everything), and refresh so
+    // the new commits appear in history.
+    dispatch({ type: 'clearSplitPlan' })
+    dispatch({ type: 'commitCompose', action: { type: 'reset' } })
+    dispatch({ type: 'setStatus', value: result.message })
+    await refreshWorktreeContext()
+    // Re-fetch the commit log so the new commits show up in history.
+    await refreshContext()
+  }, [dispatch, git, refreshContext, refreshWorktreeContext, state.splitPlan])
+
+  // Esc inside the overlay — close without applying. Status line gets
+  // a confirmation so the user knows the operation was abandoned.
+  const cancelCommitSplit = React.useCallback(() => {
+    dispatch({ type: 'clearSplitPlan' })
+    dispatch({ type: 'setStatus', value: 'Split plan cancelled.' })
+  }, [dispatch])
+
   // Resolve the destructive-action target from the live filtered+sorted
   // list the user is looking at, run the action against it, surface the
   // result on the status line, and silently refresh so the deleted item
@@ -2644,6 +2742,21 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       // Computed from view state rather than threaded through context
       // because the surface owns its own content — no external loader.
       changelogLineCount: state.changelogView.text?.split('\n').length,
+      // Approximate line count for the split-plan overlay. Each group
+      // renders as a header + (body if any) + files block + (rationale
+      // if any) + blank separator. Used by j/k/PgUp/PgDn to clamp the
+      // scroll offset. The exact render math lives in the overlay
+      // module — this is a close-enough heuristic for clamping.
+      splitPlanLineCount: state.splitPlan?.plan
+        ? state.splitPlan.plan.groups.reduce((sum, group) => {
+          let lines = 2 // title + separator
+          if (group.body) lines += group.body.split('\n').length + 1
+          if (group.rationale) lines += 2
+          lines += (group.files?.length || 0) + 1
+          if ((group.hunks?.length || 0) > 0) lines += group.hunks.length + 1
+          return sum + lines
+        }, 0)
+        : undefined,
     }).forEach((event) => {
       if (event.type === 'exit') {
         exit()
@@ -2673,6 +2786,12 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         openChangelogInEditor()
       } else if (event.type === 'openComposeInEditor') {
         openComposeInEditor()
+      } else if (event.type === 'startCommitSplit') {
+        void startCommitSplit()
+      } else if (event.type === 'applyCommitSplit') {
+        void applyCommitSplit()
+      } else if (event.type === 'cancelCommitSplit') {
+        cancelCommitSplit()
       } else if (event.type === 'yankText') {
         void yankText(event.value, event.label)
       } else if (event.type === 'runWorkflowAction') {

--- a/src/workstation/runtime/detailPanel.ts
+++ b/src/workstation/runtime/detailPanel.ts
@@ -36,6 +36,7 @@ import {
   renderConfirmationPanel,
   renderHelpPanel,
   renderInputPromptPanel,
+  renderSplitPlanOverlay,
 } from './overlays'
 import type { LogInkComponents, LogInkContext } from './types'
 
@@ -57,6 +58,19 @@ export function renderDetailPanel(
 
   if (state.showHelp) {
     return renderHelpPanel(h, components, state, width, theme, focused)
+  }
+
+  // Split-plan overlay (#907) sits above the regular palette/input/
+  // confirmation flow because the underlying input handler already
+  // intercepts all keystrokes while it's open — only the rendering
+  // needs to match. Bound by `bodyRows` so the scroll/clamp math has
+  // a real viewport; falls back to a sensible minimum elsewhere.
+  if (state.splitPlan) {
+    // Use the same height heuristic the diff/changelog surfaces use —
+    // detail panel body is roughly the panel width column count, but
+    // we don't have that here. Pass a permissive default; the overlay
+    // computes its own visible-line window from listRows.
+    return renderSplitPlanOverlay(h, components, state, width, 24, theme, focused)
   }
 
   if (state.showCommandPalette) {

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -333,3 +333,125 @@ export function renderCommandPalette(
     : []),
   ...itemLines)
 }
+
+/**
+ * Split-plan overlay (#907) — renders the proposed commit groups for
+ * the user to review before applying. Three phases driven by
+ * `state.splitPlan.status`:
+ *
+ *   - 'loading'  : spinner-ish copy while plan generation is in flight.
+ *                  Esc cancels (soft — the in-flight LLM resolves
+ *                  silently after; runtime ignores the result).
+ *   - 'ready'    : scrollable list of groups. Each group shows the
+ *                  proposed title, optional body, files, and (when
+ *                  available) rationale. Footer hints: j/k scroll,
+ *                  y/Enter apply, Esc cancel.
+ *   - 'applying' : same content as 'ready' but a status banner
+ *                  surfaces "Applying…" so the user knows the apply
+ *                  is in flight. Keystrokes are consumed but no-op.
+ *
+ * Errors during apply keep the overlay open in 'ready' state with
+ * an `error` annotation in the header — user can retry or back out.
+ */
+export function renderSplitPlanOverlay(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  width: number,
+  bodyRows: number,
+  theme: LogInkTheme,
+  focused: boolean
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const overlay = state.splitPlan
+  if (!overlay) {
+    return h(Box, { width })
+  }
+
+  const maxLineWidth = Math.max(20, width - 4)
+  const listRows = Math.max(4, bodyRows - 3)
+
+  // Loading state — overlay opens immediately so the user sees the
+  // "in flight" feedback without staring at a frozen compose view.
+  if (overlay.status === 'loading') {
+    return h(Box, {
+      borderColor: focusBorderColor(theme, focused),
+      borderStyle: theme.borderStyle,
+      flexDirection: 'column',
+      width,
+      paddingX: 1,
+    },
+    h(Box, { justifyContent: 'space-between' },
+      h(Text, { bold: true }, panelTitle('Commit split', focused)),
+      h(Text, { dimColor: true }, 'generating plan…')
+    ),
+    h(Text, undefined, ''),
+    h(Text, { dimColor: true }, 'Asking the model to split the staged changes into coherent commits.'),
+    h(Text, { dimColor: true }, 'This can take a minute on larger sets.'),
+    h(Text, undefined, ''),
+    h(Text, { dimColor: true }, 'Esc cancels.'))
+  }
+
+  // Ready / applying — render the groups. We render to a virtual
+  // line list first, then slice by scrollOffset so j/k/PgUp/PgDn
+  // behave like every other scrollable surface in the workstation.
+  const plan = overlay.plan
+  if (!plan) {
+    // Safety: shouldn't hit this since the reducer guarantees plan
+    // is set when status is 'ready' or 'applying'. Render an empty
+    // overlay rather than crashing.
+    return h(Box, { width },
+      h(Text, { dimColor: true }, 'No plan data available.'))
+  }
+
+  const lines: string[] = []
+  plan.groups.forEach((group, index) => {
+    lines.push(`▎ ${index + 1}. ${group.title}`)
+    if (group.body) {
+      group.body.split('\n').forEach((bodyLine) => lines.push(`  ${bodyLine}`))
+    }
+    if (group.rationale) {
+      lines.push('')
+      lines.push(`  why: ${group.rationale}`)
+    }
+    const files = group.files || []
+    if (files.length > 0) {
+      lines.push('')
+      lines.push(`  files (${files.length}):`)
+      files.forEach((file) => lines.push(`    · ${file}`))
+    }
+    const hunks = group.hunks || []
+    if (hunks.length > 0) {
+      lines.push('')
+      lines.push(`  hunks (${hunks.length}):`)
+      hunks.forEach((hunkId) => lines.push(`    · ${hunkId}`))
+    }
+    lines.push('')
+  })
+
+  const totalLines = lines.length
+  const scrollOffset = Math.min(overlay.scrollOffset, Math.max(0, totalLines - 1))
+  const visible = lines.slice(scrollOffset, scrollOffset + listRows)
+
+  const headerRight = overlay.status === 'applying'
+    ? 'applying…'
+    : `${plan.groups.length} commit(s) · ${scrollOffset + 1}–${Math.min(totalLines, scrollOffset + listRows)} / ${totalLines}`
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    width,
+    paddingX: 1,
+  },
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle('Commit split — review plan', focused)),
+    h(Text, { dimColor: true }, headerRight)
+  ),
+  ...(overlay.error
+    ? [h(Text, { key: 'split-plan-error', color: 'red' }, truncateCells(`error: ${overlay.error}`, maxLineWidth))]
+    : []),
+  ...visible.map((line, offset) => h(Text, {
+    key: `split-plan-${scrollOffset + offset}`,
+  }, truncateCells(line || ' ', maxLineWidth))))
+}


### PR DESCRIPTION
Closes #907.

## Summary

Brings `coco commit --split` into the workstation. Press `S` from compose / status / diff, review the LLM-generated split plan in a dedicated overlay, accept with `y` / Enter, apply with no LLM re-roll between preview and execution. Pre-flight refuses cleanly when nothing is staged or a bisect/merge/rebase is in progress.

## Architecture decision

The existing `runCommitWorkflow({ action: 'split-plan' })` captured only the formatted markdown — it discarded the structured plan. If the workstation just regenerated on apply, the plan could drift between preview and execution (LLM nondeterminism, staged-state changes the user didn't intend). The fix: refactor `handleCommitSplit` to expose `prepareCommitSplitPlan` so the workstation can hold the structured plan and pass the same plan back to apply. **The executed split matches what the user previewed exactly.**

## Six layers

1. **`commands/commit/split.ts` refactor** — `prepareCommitSplitPlan` extracted; `applyCommitSplitPlan`, `HunkInventory`, `CommitSplitPlanContext` exported. Existing CLI behavior preserved (`handleCommitSplit` is a thin wrapper now).
2. **`git/commitWorkflowActions.ts`** — `runCommitSplitPlanWorkflow()` returns structured plan + context; `runCommitSplitApplyWorkflow({ plan, planContext })` applies pre-generated.
3. **`inkViewModel.ts` state** — `state.splitPlan` with 3-phase status (loading/ready/applying); 6 reducer actions; error-preserves-plan semantics (so user can retry).
4. **`inkInput.ts` keymap** — `S` in compose/status/diff fires the flow; global `S` (create-stash) scoped away from the triad; overlay intercepts ALL keystrokes while open.
5. **`app.ts` runtime** — `startCommitSplit` / `applyCommitSplit` / `cancelCommitSplit` callbacks with pre-flight + refresh.
6. **`overlays.ts` + `detailPanel.ts` rendering** — `renderSplitPlanOverlay` with virtualized line list, header showing group count + scroll position, error annotation on failed apply. Footer hint `S split` added.

## Test plan

- [x] `npm run lint` clean
- [x] `tsc --noEmit` clean
- [x] `npm run test:jest` — **691 suites / 6664 tests pass** (+15 from this PR)
- [ ] Manual: `npm run scenario create dirty-many-files -- --run-ui` → press `S` from compose → overlay opens in loading state → plan renders → review with `j/k` → press `y` → apply succeeds, compose resets, history shows the new commits
- [ ] Manual: scenario with no staged files → `S` → status line says "Nothing staged to split"
- [ ] Manual: `mid-merge-conflict` scenario → `S` → status line refuses with "A merge is in progress"
- [ ] Manual: `S` then Esc during loading → overlay closes cleanly
- [ ] Manual: simulated apply failure (e.g. patch conflict) → overlay stays open with error annotation, can retry

## Out of scope (per issue's "v2 / follow-ups")

- Heuristic hint on compose ("these changes look big — press S to split")
- Palette command `:split`
- Editable proposed subjects in the overlay
- Rejecting individual groups before apply
- Reordering proposed commits
- Status view group-header "split this group" affordance