### PR TITLE
feat(workstation): polish split-plan overlay — main-panel render, spinner, error visibility

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -3132,6 +3132,35 @@ describe('log Ink input interactions', () => {
       ])
     })
 
+    it('r retries (re-runs the plan workflow) from the ready state', () => {
+      // After an error, the overlay surfaces "Press `r` to retry" —
+      // this keystroke should re-fire startCommitSplit. Also valid
+      // from a healthy 'ready' state (regenerate, like the changelog
+      // surface's `r`).
+      const state = applyLogInkAction(createLogInkState(rows), {
+        type: 'setSplitPlanReady',
+        plan: mockPlan,
+        planContext: mockPlanContext,
+      })
+
+      expect(getLogInkInputEvents(state, 'r', {}, { splitPlanLineCount: 10 })).toEqual([
+        { type: 'startCommitSplit' },
+      ])
+    })
+
+    it('r is a no-op during loading / applying (no workflow stacking)', () => {
+      const loadingState = applyLogInkAction(createLogInkState(rows), { type: 'startSplitPlanLoad' })
+      expect(getLogInkInputEvents(loadingState, 'r')).toEqual([])
+
+      let applyingState = applyLogInkAction(createLogInkState(rows), {
+        type: 'setSplitPlanReady',
+        plan: mockPlan,
+        planContext: mockPlanContext,
+      })
+      applyingState = applyLogInkAction(applyingState, { type: 'setSplitPlanApplying' })
+      expect(getLogInkInputEvents(applyingState, 'r', {}, { splitPlanLineCount: 10 })).toEqual([])
+    })
+
     it('y/Enter no-op while loading (no plan to apply)', () => {
       const state = applyLogInkAction(createLogInkState(rows), { type: 'startSplitPlanLoad' })
 

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -944,6 +944,14 @@ export function getLogInkInputEvents(
       return [{ type: 'applyCommitSplit' }]
     }
 
+    // `r` retries from the error state (or regenerates from ready,
+    // for parity with the changelog surface). Re-runs the LLM call.
+    // While loading or applying, retry is a no-op — we don't want to
+    // stack workflows.
+    if (inputValue === 'r' && state.splitPlan.status === 'ready') {
+      return [{ type: 'startCommitSplit' }]
+    }
+
     if (state.splitPlan.status === 'ready' && lineCount > 0) {
       if (inputValue === 'j') {
         return [action({ type: 'pageSplitPlan', delta: 1, lineCount })]

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -1189,6 +1189,37 @@ describe('log Ink view model', () => {
     })
   })
 
+  describe('status message kind (info / error / success)', () => {
+    it('defaults to no kind when setStatus is called without one', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setStatus', value: 'hello' })
+      expect(state.statusMessage).toBe('hello')
+      expect(state.statusKind).toBeUndefined()
+    })
+
+    it('preserves the kind across error / success / info transitions', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setStatus', value: 'oops', kind: 'error' })
+      expect(state.statusKind).toBe('error')
+
+      state = applyLogInkAction(state, { type: 'setStatus', value: 'yay', kind: 'success' })
+      expect(state.statusKind).toBe('success')
+
+      // Explicit 'info' clears the kind back to undefined so the error
+      // styling doesn't bleed through.
+      state = applyLogInkAction(state, { type: 'setStatus', value: 'fyi', kind: 'info' })
+      expect(state.statusKind).toBeUndefined()
+    })
+
+    it('clearing the message clears the kind', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setStatus', value: 'oops', kind: 'error' })
+      state = applyLogInkAction(state, { type: 'setStatus', value: undefined })
+      expect(state.statusMessage).toBeUndefined()
+      expect(state.statusKind).toBeUndefined()
+    })
+  })
+
   describe('split-plan overlay state (#907)', () => {
     const mockPlan = {
       groups: [

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -185,6 +185,22 @@ export type LogInkState = {
   statusGroupHeaderFocused: boolean
   statusMessage?: string
   /**
+   * Visual category for `statusMessage` — drives footer styling.
+   *   - 'info'    (default) : dim muted text, regular contextual hints
+   *   - 'error'              : red text + footer hides the global hints
+   *                            on the right so long error messages get
+   *                            the full width to render. Set explicitly
+   *                            by failure paths (LLM errors, validator
+   *                            issues, etc.) so users notice them.
+   *   - 'success'            : accent-colored text. Set by ops that
+   *                            mutate state successfully (commit
+   *                            created, split applied, PR opened, …)
+   *                            so the affirmative feedback stands out.
+   * Cleared alongside `statusMessage` when `setStatus` fires without
+   * a `kind` (or with `kind: 'info'`).
+   */
+  statusKind?: 'info' | 'error' | 'success'
+  /**
    * Set by `navigateOpenDiffForCommit` / `navigateOpenDiffForWorktreeFile`
    * to disambiguate the diff view when both a worktree file and a commit
    * are selectable. Cleared when the diff view is popped or replaced.
@@ -480,7 +496,7 @@ export type LogInkAction =
   | { type: 'setPendingKey'; value?: string }
   | { type: 'setSidebarTab'; value: LogInkSidebarTab }
   | { type: 'restoreSidebarTab'; value: LogInkSidebarTab }
-  | { type: 'setStatus'; value?: string }
+  | { type: 'setStatus'; value?: string; kind?: 'info' | 'error' | 'success' }
   | { type: 'setWorkflowAction'; value?: string }
   | { type: 'setPendingConfirmation'; value?: string; payload?: string }
   | { type: 'setPendingMutationConfirmation'; value?: LogInkMutationConfirmation }
@@ -1441,6 +1457,10 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         statusMessage: action.value,
+        // Clearing the message resets kind to undefined so a previous
+        // 'error' doesn't bleed into the next info update. Explicit
+        // 'info' also clears kind for the same reason.
+        statusKind: !action.value || action.kind === 'info' ? undefined : action.kind,
         pendingKey: undefined,
       }
     case 'setWorkflowAction':

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -509,6 +509,34 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   }, [idleTipsEnabled, state.statusMessage])
   const idleTip = idleTipsEnabled && !state.statusMessage ? pickIdleTip(idleTipIndex) : undefined
 
+  // Animation tick driver for loading states. Increments every 80ms
+  // while any overlay/surface is in a loading state — the renderer
+  // derives a spinner frame from `spinnerFrame % FRAMES.length` so
+  // the user sees motion instead of static "generating…" copy.
+  //
+  // Driven by a single shared tick rather than per-surface intervals
+  // because the cost of an Ink re-render is the whole app; one
+  // interval is the same cost as N. We pause the tick entirely when
+  // nothing is loading so an idle workstation doesn't waste cycles
+  // re-rendering the same frame.
+  const [spinnerFrame, setSpinnerFrame] = React.useState(0)
+  const anyLoading =
+    state.splitPlan?.status === 'loading' ||
+    state.splitPlan?.status === 'applying' ||
+    state.changelogView.status === 'loading'
+  React.useEffect(() => {
+    if (!anyLoading) {
+      // Reset to 0 so the next loading state starts from a known
+      // frame instead of wherever the last animation left off.
+      setSpinnerFrame(0)
+      return
+    }
+    // DevSkim: ignore DS172411 — callback is a function literal, delay
+    // is our own constant, no caller-supplied data flows through.
+    const id = setInterval(() => setSpinnerFrame((tick) => tick + 1), 80)
+    return () => clearInterval(id)
+  }, [anyLoading])
+
   const selected = getSelectedInkCommit(state)
   const selectedDetailFile = detail?.files[state.selectedFileIndex]
   // Status surface visibility mask (#776). `visibleWorktreeFiles` is the
@@ -1717,6 +1745,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       dispatch({
         type: 'setStatus',
         value: 'Nothing staged to split. Stage some files first (`g s` to pick).',
+        kind: 'error',
       })
       return
     }
@@ -1725,6 +1754,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       dispatch({
         type: 'setStatus',
         value: `A ${operation.operation} is in progress — finish or abort it before splitting.`,
+        kind: 'error',
       })
       return
     }
@@ -1736,7 +1766,11 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
 
     if (!result.ok) {
       dispatch({ type: 'setSplitPlanError', error: result.message })
-      dispatch({ type: 'setStatus', value: `Split plan failed: ${result.message}` })
+      dispatch({
+        type: 'setStatus',
+        value: `Split plan failed: ${result.message}`,
+        kind: 'error',
+      })
       return
     }
 
@@ -1748,6 +1782,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     dispatch({
       type: 'setStatus',
       value: `Split plan ready: ${result.plan.groups.length} commit(s). y/Enter to apply, Esc to cancel.`,
+      kind: 'success',
     })
   }, [context.operation, context.worktree?.stagedCount, dispatch, git])
 
@@ -1776,7 +1811,11 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       // try again. setSplitPlanError preserves the existing plan in
       // 'ready' state with the error annotation.
       dispatch({ type: 'setSplitPlanError', error: result.message })
-      dispatch({ type: 'setStatus', value: `Split apply failed: ${result.message}` })
+      dispatch({
+        type: 'setStatus',
+        value: `Split apply failed: ${result.message}`,
+        kind: 'error',
+      })
       return
     }
 
@@ -1785,7 +1824,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     // the new commits appear in history.
     dispatch({ type: 'clearSplitPlan' })
     dispatch({ type: 'commitCompose', action: { type: 'reset' } })
-    dispatch({ type: 'setStatus', value: result.message })
+    dispatch({ type: 'setStatus', value: result.message, kind: 'success' })
     await refreshWorktreeContext()
     // Re-fetch the commit log so the new commits show up in history.
     await refreshContext()
@@ -2870,7 +2909,8 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         layout.mainPanelWidth,
         theme,
         hasMoreCommits,
-        loadingMoreCommits
+        loadingMoreCommits,
+        spinnerFrame
       ),
       renderDetailPanel(
         h,

--- a/src/workstation/runtime/detailPanel.ts
+++ b/src/workstation/runtime/detailPanel.ts
@@ -36,7 +36,6 @@ import {
   renderConfirmationPanel,
   renderHelpPanel,
   renderInputPromptPanel,
-  renderSplitPlanOverlay,
 } from './overlays'
 import type { LogInkComponents, LogInkContext } from './types'
 
@@ -58,19 +57,6 @@ export function renderDetailPanel(
 
   if (state.showHelp) {
     return renderHelpPanel(h, components, state, width, theme, focused)
-  }
-
-  // Split-plan overlay (#907) sits above the regular palette/input/
-  // confirmation flow because the underlying input handler already
-  // intercepts all keystrokes while it's open — only the rendering
-  // needs to match. Bound by `bodyRows` so the scroll/clamp math has
-  // a real viewport; falls back to a sensible minimum elsewhere.
-  if (state.splitPlan) {
-    // Use the same height heuristic the diff/changelog surfaces use —
-    // detail panel body is roughly the panel width column count, but
-    // we don't have that here. Pass a permissive default; the overlay
-    // computes its own visible-line window from listRows.
-    return renderSplitPlanOverlay(h, components, state, width, 24, theme, focused)
   }
 
   if (state.showCommandPalette) {

--- a/src/workstation/runtime/footer.ts
+++ b/src/workstation/runtime/footer.ts
@@ -56,8 +56,27 @@ export function renderFooter(
   // would otherwise be empty.
   const trailing = state.statusMessage || idleTip || ''
   const status = trailing ? `  ${trailing}` : ''
-  const contextualText = `${hints.contextual.join('   ')}${status}`
+  const isError = state.statusKind === 'error'
+  const isSuccess = state.statusKind === 'success'
+  const contextualText = isError
+    // Errors get the full footer width and a `✗` prefix so they read
+    // as alarming. We drop the contextual hints when an error is
+    // active — they'd compete for attention with the message and
+    // long validator outputs (#907 polish: split-plan validator
+    // errors are often 100+ chars and got truncated against the hints).
+    ? `✗ ${state.statusMessage || ''}`
+    : `${hints.contextual.join('   ')}${status}`
   const globalText = hints.global.join(' · ')
+
+  // Error rendering: hide the global hints on the right so the
+  // message can wrap into that space. Success rendering: accent
+  // color on the message, hints stay visible. Default: existing
+  // muted styling.
+  const contextualColor = isError
+    ? 'red'
+    : isSuccess
+      ? theme.colors.accent
+      : theme.colors.muted
 
   return h(Box, {
     flexDirection: 'row',
@@ -65,6 +84,15 @@ export function renderFooter(
     justifyContent: 'space-between',
     paddingX: 1,
   },
-  h(Text, { color: theme.colors.muted, dimColor: true }, contextualText),
-  h(Text, { color: theme.colors.muted, dimColor: true }, globalText))
+  h(Text, {
+    color: contextualColor,
+    dimColor: !isError && !isSuccess,
+    bold: isError,
+  }, contextualText),
+  // Globals are dropped entirely when an error is on screen — that
+  // space is what the long message needs to render. They come back
+  // the moment the status flips to info / success / cleared.
+  isError
+    ? h(Text, undefined, '')
+    : h(Text, { color: theme.colors.muted, dimColor: true }, globalText))
 }

--- a/src/workstation/runtime/mainPanel.ts
+++ b/src/workstation/runtime/mainPanel.ts
@@ -25,6 +25,7 @@ import { renderComposeSurface } from '../surfaces/compose'
 import { renderConflictsSurface } from '../surfaces/conflicts'
 import { renderDiffSurface } from '../surfaces/diff'
 import { renderHistoryPanel } from '../surfaces/history'
+import { renderSplitPlanOverlay } from './overlays'
 import { renderPullRequestSurface } from '../surfaces/pullRequest'
 import { renderReflogSurface } from '../surfaces/reflog'
 import { renderStashSurface } from '../surfaces/stash'
@@ -57,8 +58,20 @@ export function renderMainPanel(
   width: number,
   theme: LogInkTheme,
   hasMoreCommits: boolean,
-  loadingMoreCommits: boolean
+  loadingMoreCommits: boolean,
+  spinnerFrame: number
 ): ReactTypes.ReactElement {
+  // Split-plan overlay (#907 polish): renders in the MAIN panel (not
+  // detail) when active, because the content — multiple commit groups
+  // with file lists, rationale, hunks — needs the full center width
+  // to be readable. The detail panel is too narrow for prose lists.
+  // Overlay sits at the top of dispatch so it pre-empts every regular
+  // view; the input handler already intercepts all keystrokes while
+  // `state.splitPlan` is set, so the underlying view is dormant.
+  if (state.splitPlan) {
+    return renderSplitPlanOverlay(h, components, state, width, bodyRows, theme, true, spinnerFrame)
+  }
+
   if (state.activeView === 'status') {
     return renderStatusSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
   }

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -353,6 +353,11 @@ export function renderCommandPalette(
  * Errors during apply keep the overlay open in 'ready' state with
  * an `error` annotation in the header — user can retry or back out.
  */
+// Braille-dot spinner frames — same set used by ora, ink-spinner, and
+// most other Node TUI tools. 10 frames at 80ms each gives a smooth
+// loop that reads as a true spinner rather than a flicker.
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+
 export function renderSplitPlanOverlay(
   h: typeof ReactTypes.createElement,
   components: LogInkComponents,
@@ -360,7 +365,8 @@ export function renderSplitPlanOverlay(
   width: number,
   bodyRows: number,
   theme: LogInkTheme,
-  focused: boolean
+  focused: boolean,
+  spinnerFrame: number = 0
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const overlay = state.splitPlan
@@ -370,9 +376,13 @@ export function renderSplitPlanOverlay(
 
   const maxLineWidth = Math.max(20, width - 4)
   const listRows = Math.max(4, bodyRows - 3)
+  const spinner = SPINNER_FRAMES[spinnerFrame % SPINNER_FRAMES.length]
 
   // Loading state — overlay opens immediately so the user sees the
   // "in flight" feedback without staring at a frozen compose view.
+  // The spinner gives motion so the user knows something's still
+  // happening even on slow LLM responses (which can take 30s+ on
+  // larger staged sets).
   if (overlay.status === 'loading') {
     return h(Box, {
       borderColor: focusBorderColor(theme, focused),
@@ -383,13 +393,13 @@ export function renderSplitPlanOverlay(
     },
     h(Box, { justifyContent: 'space-between' },
       h(Text, { bold: true }, panelTitle('Commit split', focused)),
-      h(Text, { dimColor: true }, 'generating plan…')
+      h(Text, { color: theme.colors.accent }, `${spinner} generating plan…`)
     ),
     h(Text, undefined, ''),
-    h(Text, { dimColor: true }, 'Asking the model to split the staged changes into coherent commits.'),
-    h(Text, { dimColor: true }, 'This can take a minute on larger sets.'),
+    h(Text, { color: theme.colors.accent }, `${spinner}  Asking the model to split the staged changes into coherent commits.`),
+    h(Text, { dimColor: true }, '   This can take 30 seconds to a minute on larger sets.'),
     h(Text, undefined, ''),
-    h(Text, { dimColor: true }, 'Esc cancels.'))
+    h(Text, { dimColor: true }, '   Esc cancels.'))
   }
 
   // Ready / applying — render the groups. We render to a virtual
@@ -434,8 +444,17 @@ export function renderSplitPlanOverlay(
   const visible = lines.slice(scrollOffset, scrollOffset + listRows)
 
   const headerRight = overlay.status === 'applying'
-    ? 'applying…'
+    ? `${spinner} applying…`
     : `${plan.groups.length} commit(s) · ${scrollOffset + 1}–${Math.min(totalLines, scrollOffset + listRows)} / ${totalLines}`
+
+  // Apply errors get the full available width — long validator
+  // messages (the failure path that surfaced in PR #916 testing was
+  // "unknown hunks: src/widgets/button.ts::hunk-1, ...") frequently
+  // exceed footer-status-line capacity. We wrap into multiple lines
+  // here, color them red + bold, and surface a retry hint underneath.
+  const errorBlock = overlay.error
+    ? wrapErrorMessage(overlay.error, maxLineWidth)
+    : []
 
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
@@ -446,12 +465,53 @@ export function renderSplitPlanOverlay(
   },
   h(Box, { justifyContent: 'space-between' },
     h(Text, { bold: true }, panelTitle('Commit split — review plan', focused)),
-    h(Text, { dimColor: true }, headerRight)
+    h(Text, {
+      bold: overlay.status === 'applying',
+      color: overlay.status === 'applying' ? theme.colors.accent : undefined,
+      dimColor: overlay.status !== 'applying',
+    }, headerRight)
   ),
+  ...errorBlock.map((line, offset) => h(Text, {
+    key: `split-plan-error-${offset}`,
+    color: 'red',
+    bold: offset === 0,
+  }, line)),
   ...(overlay.error
-    ? [h(Text, { key: 'split-plan-error', color: 'red' }, truncateCells(`error: ${overlay.error}`, maxLineWidth))]
+    ? [h(Text, { key: 'split-plan-error-hint', dimColor: true }, '   Press `r` to retry, `Esc` to cancel.')]
     : []),
   ...visible.map((line, offset) => h(Text, {
     key: `split-plan-${scrollOffset + offset}`,
   }, truncateCells(line || ' ', maxLineWidth))))
+}
+
+/**
+ * Wrap a long error message into multiple lines fit to the overlay
+ * width. Used for split-plan errors which can carry validator output
+ * listing offending hunks/files — frequently long enough to overflow
+ * a single line. Returns `[]` for empty input so callers can spread
+ * directly into a child list.
+ */
+function wrapErrorMessage(message: string, maxWidth: number): string[] {
+  if (!message) return []
+  const prefix = '✗ '
+  const continuation = '  '
+  // Naive wrapping by words. Good enough for validator-style
+  // messages which are space-delimited; longer words just get
+  // truncated by Ink's natural rendering, which is acceptable.
+  const words = message.split(/\s+/).filter(Boolean)
+  const lines: string[] = []
+  let current = prefix
+  for (const word of words) {
+    const candidate = current === prefix ? `${current}${word}` : `${current} ${word}`
+    if (candidate.length > maxWidth && current !== prefix) {
+      lines.push(current)
+      current = `${continuation}${word}`
+    } else {
+      current = candidate
+    }
+  }
+  if (current.trim()) {
+    lines.push(current)
+  }
+  return lines
 }


### PR DESCRIPTION
Follow-up to #916. Addresses three UX issues that surfaced during manual testing of the split flow.

## Issues from manual testing

1. **Overlay rendered in the detail panel** (right sidebar) → too narrow for prose lists of commit groups + file paths. Visible truncation on `feature-pr-ready`-style content.
2. **No visual feedback during the LLM call** — just static "generating plan…" copy. Slow runs felt frozen.
3. **Long validator errors got truncated in the footer** and were easy to miss (the screenshot in the issue shows `"Failed to produce a valid commit-split plan after 3 attempts. Final validator issues: unknown hunks: src/widgets/button.ts::hunk-1, ..."` getting clipped).

## What changed

### Main-panel render

Promoted `renderSplitPlanOverlay` from the detail-panel dispatcher to the **main-panel** dispatcher. The overlay now takes the full center column — the natural shape for prose-list content. Detail panel goes back to its normal inspector view in the background (no behavior change there).

### Animated spinner

Added a shared `spinnerFrame` tick at the app root, driven by `setInterval(80ms)` while any loading state is active (split-plan loading/applying OR changelog loading — extensible to future loading surfaces). Threaded through `renderMainPanel → renderSplitPlanOverlay`. Uses braille-dot frames (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) — same convention as ora / ink-spinner. The tick **pauses entirely** when nothing's loading so an idle workstation doesn't re-render every 80ms.

The spinner appears in two places during the LLM call:
- Header right (next to "generating plan…")
- Leading the body copy ("Asking the model to split the staged changes…")

### Status message kinds + error-aware footer

Added `statusKind?: 'info' | 'error' | 'success'` to state + the `setStatus` action. When kind is `'error'`:
- Message renders in red + bold with a `✗` prefix.
- **Footer drops the global key-hint chrome on the right** (`g jump · < back · …`) so the full footer width is available to the message. Long validator output gets room to breathe.

When kind is `'success'`, message renders in the accent color so affirmative feedback (e.g. "Applied 4 commits via split") reads as a win. Default `'info'` preserves the existing muted styling.

### Inline error rendering in the overlay

Failed apply attempts now surface the full error text **inside the overlay** (wrapped to overlay width via a word-wrap helper) with a "Press `r` to retry, Esc to cancel" hint underneath. Status line still surfaces the error briefly; the overlay copy is the durable record.

### `r` for retry from the overlay

Inside the overlay, `r` re-runs the plan workflow (parity with the changelog surface's `r`). Valid from `'ready'` state (regenerate); no-op while loading/applying so we don't stack workflows.

## Test plan

- [x] `npm run lint` clean
- [x] `tsc --noEmit` clean
- [x] `npm run test:jest` — **691 suites / 6669 tests pass** (+5 from this PR)
- [ ] Manual: `npm run scenario create dirty-many-files -- --run-ui` → press `S` from compose → overlay opens in the main panel with the spinner animating → plan renders with groups, can scroll with j/k, applies with y/Enter
- [ ] Manual: trigger an apply failure (or rely on the existing validator-issue path) → error renders inline in the overlay with `r` retry / Esc cancel hints, AND in the footer in red without the global chrome competing
- [ ] Manual: pre-flight failures (no staged, mid-op) render as red footer messages, no longer easy to miss

## Out of scope

- Modal escalation for pre-flight refuses (still ride the status line, just colored red now).
- Validator strictness questions (the original error in #916 testing was about hunk-id mismatch — separate concern).