### PR TITLE
fix(split): rescue phantom hunks the LLM invents for all-new-files staged sets

### DIFF
--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -50,7 +50,8 @@ Rules:
 - If you assign any hunk for a file, you MUST assign EVERY hunk for that file across the groups — partial coverage is invalid.
 - Do not list the same file in "files" of more than one group, and do not assign the same hunk ID to more than one group.
 - Only use file paths listed in the staged file inventory. Do not invent files.
-- Only use hunk IDs listed in the staged hunk inventory. Do not invent hunk IDs.
+- Only use hunk IDs LITERALLY copied from the "Staged hunk inventory" section below. Do not invent or guess hunk IDs.
+- If the hunk inventory says "No hunk-level inventory available" then EVERY group's "hunks" array MUST be empty (use only "files"). Do not write hunk IDs like "path::hunk-1" when no hunk inventory exists — those are not valid.
 - Prefer 2-5 commits unless the changes are truly all one topic.
 - Keep commit titles concise and understandable.
 

--- a/src/commands/commit/splitPlanGenerator.test.ts
+++ b/src/commands/commit/splitPlanGenerator.test.ts
@@ -45,7 +45,11 @@ describe('generateValidatedCommitSplitPlan', () => {
     const result = await generateValidatedCommitSplitPlan(baseArgs())
 
     expect(result.attempts).toBe(1)
-    expect(result.plan).toBe(validPlan)
+    // toStrictEqual rather than toBe — the generator now passes the
+    // raw plan through rescuePhantomHunks which returns a new object,
+    // so reference equality no longer holds. The semantic content is
+    // identical when the plan has no phantom hunks to rescue.
+    expect(result.plan).toStrictEqual(validPlan)
     expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(1)
 
     const variables = mockExecuteChainWithSchema.mock.calls[0][3] as Record<string, unknown>
@@ -70,7 +74,11 @@ describe('generateValidatedCommitSplitPlan', () => {
     const result = await generateValidatedCommitSplitPlan(baseArgs())
 
     expect(result.attempts).toBe(2)
-    expect(result.plan).toBe(validPlan)
+    // toStrictEqual rather than toBe — the generator now passes the
+    // raw plan through rescuePhantomHunks which returns a new object,
+    // so reference equality no longer holds. The semantic content is
+    // identical when the plan has no phantom hunks to rescue.
+    expect(result.plan).toStrictEqual(validPlan)
     expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(2)
 
     const firstCallVars = mockExecuteChainWithSchema.mock.calls[0][3] as Record<string, unknown>
@@ -79,6 +87,33 @@ describe('generateValidatedCommitSplitPlan', () => {
     expect(firstCallVars.previous_attempt_feedback).toBe(NO_PREVIOUS_FEEDBACK_PLACEHOLDER)
     expect(String(secondCallVars.previous_attempt_feedback)).toContain('Staged files missing')
     expect(String(secondCallVars.previous_attempt_feedback)).toContain('b.ts')
+  })
+
+  it('rescues phantom hunks before validation when the inventory is empty', async () => {
+    // Regression for the #916 failure pattern: LLM emits hunk IDs
+    // against an empty inventory (all staged files are new/added),
+    // validator rejects, retry loop never recovers. With the rescue
+    // pass, the same LLM output validates on the first attempt.
+    const phantomHunkPlan: CommitSplitPlan = {
+      groups: [
+        {
+          title: 'feat: a/b',
+          files: [],
+          hunks: ['a.ts::hunk-1', 'b.ts::hunk-1'],
+        },
+      ],
+    }
+    mockExecuteChainWithSchema.mockResolvedValueOnce(phantomHunkPlan)
+
+    // baseArgs() has 2 staged files (a.ts, b.ts) and no hunk inventory.
+    const result = await generateValidatedCommitSplitPlan(baseArgs())
+
+    expect(result.attempts).toBe(1)
+    // Phantom hunks promoted to files; the rescued plan validates
+    // because the staged files are now claimed via files[].
+    expect(result.plan.groups[0].files).toEqual(['a.ts', 'b.ts'])
+    expect(result.plan.groups[0].hunks).toEqual([])
+    expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(1)
   })
 
   it('throws after exhausting retries with the final validator complaints in the message', async () => {

--- a/src/commands/commit/splitPlanGenerator.ts
+++ b/src/commands/commit/splitPlanGenerator.ts
@@ -12,6 +12,7 @@ import {
   hasPlanValidationIssues,
   HunkInventoryLike,
   PlanValidationIssues,
+  rescuePhantomHunks,
 } from './splitPlanValidation'
 
 export const NO_PREVIOUS_FEEDBACK_PLACEHOLDER = 'None — this is the first attempt.'
@@ -65,7 +66,7 @@ export async function generateValidatedCommitSplitPlan({
       ? formatPlanValidationFeedback(lastIssues)
       : NO_PREVIOUS_FEEDBACK_PLACEHOLDER
 
-    const plan = await executeChainWithSchema<CommitSplitPlan>(
+    const rawPlan = await executeChainWithSchema<CommitSplitPlan>(
       CommitSplitPlanSchema,
       llm,
       prompt,
@@ -83,6 +84,16 @@ export async function generateValidatedCommitSplitPlan({
         },
       }
     )
+
+    // Rescue pass: when the staged set is all new/added files (no
+    // hunk inventory), the LLM commonly emits "file::hunk-1" entries
+    // anyway because the prompt's hunk-aware language convinces it
+    // that's the right format. The validator then rejects them as
+    // unknown hunks and the retry loop just regenerates the same
+    // mistake. Pre-validation, promote phantom hunks back to
+    // file-level assignments — same semantic, accepted by the
+    // validator, no LLM re-roll needed.
+    const plan = rescuePhantomHunks(rawPlan, staged, hunkInventory)
 
     const issues = getPlanValidationIssues(plan, staged, hunkInventory)
     if (!hasPlanValidationIssues(issues)) {

--- a/src/commands/commit/splitPlanValidation.test.ts
+++ b/src/commands/commit/splitPlanValidation.test.ts
@@ -5,6 +5,7 @@ import {
   getPlanValidationIssues,
   hasPlanValidationIssues,
   HunkInventoryLike,
+  rescuePhantomHunks,
 } from './splitPlanValidation'
 import { CommitSplitPlan } from './splitPlanTypes'
 
@@ -184,6 +185,160 @@ describe('splitPlanValidation', () => {
       })
 
       expect(message).toBe('unknown files: ghost.ts; duplicate files: a.ts')
+    })
+  })
+
+  describe('rescuePhantomHunks', () => {
+    // The dominant failure pattern from #916 testing: all staged files
+    // are new/added (so collectHunkInventory skips them, leaving an
+    // empty inventory), but the LLM still emits hunk IDs in the
+    // canonical `<filepath>::hunk-N` shape. Validator rejects them as
+    // unknown; retry loop just regenerates the same mistake. Rescue
+    // promotes those phantom hunks to file-level assignments so the
+    // semantically-equivalent plan survives validation.
+
+    it('rescues phantom hunks to file-level assignments when inventory is empty', () => {
+      const staged = ['src/widgets/button.ts', 'src/widgets/input.ts'].map(stagedFile)
+      const plan: CommitSplitPlan = {
+        groups: [
+          {
+            title: 'feat: widgets',
+            files: [],
+            hunks: ['src/widgets/button.ts::hunk-1', 'src/widgets/input.ts::hunk-1'],
+          },
+        ],
+      }
+
+      const rescued = rescuePhantomHunks(plan, staged, buildHunkInventory({}))
+
+      expect(rescued.groups[0].files).toEqual([
+        'src/widgets/button.ts',
+        'src/widgets/input.ts',
+      ])
+      expect(rescued.groups[0].hunks).toEqual([])
+    })
+
+    it('preserves real hunk IDs that are in the inventory', () => {
+      const staged = ['src/router.ts'].map(stagedFile)
+      const inventory = buildHunkInventory({
+        'src/router.ts': ['src/router.ts::hunk-1', 'src/router.ts::hunk-2'],
+      })
+      const plan: CommitSplitPlan = {
+        groups: [
+          {
+            title: 'feat: router',
+            files: [],
+            hunks: ['src/router.ts::hunk-1', 'src/router.ts::hunk-2'],
+          },
+        ],
+      }
+
+      const rescued = rescuePhantomHunks(plan, staged, inventory)
+
+      // Real hunks pass through, no file-level promotion.
+      expect(rescued.groups[0].hunks).toEqual([
+        'src/router.ts::hunk-1',
+        'src/router.ts::hunk-2',
+      ])
+      expect(rescued.groups[0].files).toEqual([])
+    })
+
+    it('first group wins when multiple groups reference the same phantom hunk', () => {
+      // LLM mistake: split a "single file's hunks" across groups when
+      // the file actually has zero hunks. Rescue assigns the file to
+      // the first group only; subsequent groups silently drop the
+      // phantom hunk.
+      const staged = ['src/widget.ts'].map(stagedFile)
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'feat: a', files: [], hunks: ['src/widget.ts::hunk-1'] },
+          { title: 'feat: b', files: [], hunks: ['src/widget.ts::hunk-1'] },
+        ],
+      }
+
+      const rescued = rescuePhantomHunks(plan, staged, buildHunkInventory({}))
+
+      expect(rescued.groups[0].files).toEqual(['src/widget.ts'])
+      expect(rescued.groups[1].files).toEqual([])
+      expect(rescued.groups[0].hunks).toEqual([])
+      expect(rescued.groups[1].hunks).toEqual([])
+    })
+
+    it('does not duplicate-claim a file already in another group\'s files[]', () => {
+      // If group A already legitimately claims the file via files[],
+      // group B's phantom hunk for that file just drops — no
+      // duplicateFiles validator error.
+      const staged = ['src/widget.ts'].map(stagedFile)
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'feat: a', files: ['src/widget.ts'], hunks: [] },
+          { title: 'feat: b', files: [], hunks: ['src/widget.ts::hunk-1'] },
+        ],
+      }
+
+      const rescued = rescuePhantomHunks(plan, staged, buildHunkInventory({}))
+
+      expect(rescued.groups[0].files).toEqual(['src/widget.ts'])
+      expect(rescued.groups[1].files).toEqual([])
+    })
+
+    it('drops phantom hunks whose file path is not in the staged set', () => {
+      // LLM hallucinated both the hunk AND a file that doesn't exist.
+      // Drop the hunk; the validator's missingFiles check will catch
+      // any actually-missing staged files separately.
+      const staged = ['src/real.ts'].map(stagedFile)
+      const plan: CommitSplitPlan = {
+        groups: [
+          {
+            title: 'feat: x',
+            files: ['src/real.ts'],
+            hunks: ['src/hallucinated.ts::hunk-1'],
+          },
+        ],
+      }
+
+      const rescued = rescuePhantomHunks(plan, staged, buildHunkInventory({}))
+
+      expect(rescued.groups[0].files).toEqual(['src/real.ts'])
+      expect(rescued.groups[0].hunks).toEqual([])
+    })
+
+    it('handles a mix of real hunks (kept) and phantom hunks (rescued)', () => {
+      // Edge case: inventory has hunks for one file (modified) but
+      // the LLM also emits a phantom hunk for a different staged
+      // file that has no inventory (added). Both should be handled
+      // correctly — real preserved, phantom rescued.
+      const staged = ['src/router.ts', 'src/widget.ts'].map(stagedFile)
+      const inventory = buildHunkInventory({
+        'src/router.ts': ['src/router.ts::hunk-1'],
+      })
+      const plan: CommitSplitPlan = {
+        groups: [
+          {
+            title: 'feat: combined',
+            files: [],
+            hunks: ['src/router.ts::hunk-1', 'src/widget.ts::hunk-1'],
+          },
+        ],
+      }
+
+      const rescued = rescuePhantomHunks(plan, staged, inventory)
+
+      expect(rescued.groups[0].hunks).toEqual(['src/router.ts::hunk-1'])
+      expect(rescued.groups[0].files).toEqual(['src/widget.ts'])
+    })
+
+    it('is a no-op when there are no hunks anywhere', () => {
+      const staged = ['src/a.ts', 'src/b.ts'].map(stagedFile)
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'feat: ab', files: ['src/a.ts', 'src/b.ts'], hunks: [] },
+        ],
+      }
+
+      const rescued = rescuePhantomHunks(plan, staged, buildHunkInventory({}))
+
+      expect(rescued).toEqual(plan)
     })
   })
 })

--- a/src/commands/commit/splitPlanValidation.ts
+++ b/src/commands/commit/splitPlanValidation.ts
@@ -127,6 +127,78 @@ export function formatPlanValidationIssuesError(issues: PlanValidationIssues): s
     .join('; ')
 }
 
+/**
+ * Salvage a plan that references hunk IDs not in the inventory by
+ * promoting those hunks to file-level assignments. The LLM commonly
+ * does this when the staged set is all new/added files (no
+ * inventory) but the prompt's hunk-aware language convinces it to
+ * emit "file::hunk-1" anyway.
+ *
+ * Recovery rules:
+ *   1. For each group, walk `hunks[]`. Any entry whose ID isn't in
+ *      `inventory.byId` is a phantom — extract the file path from
+ *      the `<filepath>::hunk-N` format and drop the hunk.
+ *   2. If the recovered file path is in the staged set AND no other
+ *      group already claims it via `files[]`, append it to THIS
+ *      group's `files[]`. (Across multiple groups referencing the
+ *      same phantom hunk, the first group wins — subsequent groups
+ *      just drop the hunk without duplicating the file claim.)
+ *   3. Real hunk IDs (those in `inventory.byId`) pass through
+ *      untouched. Files already in `files[]` pass through untouched.
+ *
+ * If the inventory has real hunks AND the LLM produces an invalid
+ * one (typo, made-up name), the validator still rejects it. This
+ * function only rescues the "phantom hunks against an empty
+ * inventory" failure mode, which is the dominant failure for
+ * scenarios like `dirty-many-files` where every staged file is new.
+ *
+ * Returns a NEW plan object — original is not mutated.
+ */
+export function rescuePhantomHunks(
+  plan: CommitSplitPlan,
+  staged: FileChange[],
+  hunkInventory?: HunkInventoryLike
+): CommitSplitPlan {
+  const stagedFiles = new Set(staged.map((change) => change.filePath))
+  const claimedFiles = new Set<string>()
+  // First pass: harvest files already claimed via `files[]` so the
+  // recovery pass below doesn't double-claim them.
+  plan.groups.forEach((group) => {
+    (group.files || []).forEach((file) => claimedFiles.add(file))
+  })
+
+  const rescuedGroups = plan.groups.map((group) => {
+    const rescuedFiles = [...(group.files || [])]
+    const keptHunks: string[] = []
+
+    for (const hunkId of group.hunks || []) {
+      if (hunkInventory?.byId.has(hunkId)) {
+        // Real hunk — pass through.
+        keptHunks.push(hunkId)
+        continue
+      }
+      // Phantom hunk. Try to recover the file path.
+      const filePath = hunkId.split('::')[0]
+      if (filePath && stagedFiles.has(filePath) && !claimedFiles.has(filePath)) {
+        rescuedFiles.push(filePath)
+        claimedFiles.add(filePath)
+      }
+      // Either way the phantom hunk gets dropped — if we can't
+      // recover the file, the missingFiles validator will catch it
+      // and surface a real error. We just don't want "unknown hunks"
+      // to be that error when "file-level recovery would have worked".
+    }
+
+    return {
+      ...group,
+      files: rescuedFiles,
+      hunks: keptHunks,
+    }
+  })
+
+  return { ...plan, groups: rescuedGroups }
+}
+
 export function formatPlanValidationFeedback(issues: PlanValidationIssues): string {
   const sections: string[] = []
 


### PR DESCRIPTION
Direct fix for the underlying split-plan validator failure surfaced in #917 manual testing. Closes the loop on issue #907.

## What was broken

When the staged set is all NEW files (status `added`, not `modified`), `collectHunkInventory` skips them entirely — only `modified` files get hunks. So `hunkInventory` is empty and `formatHunkInventory` returns "No hunk-level inventory available. Use file-level groups."

The LLM ignores that guidance roughly 100% of the time. It still emits hunk IDs in the canonical `<filepath>::hunk-N` shape because the format LOOKS right and the model is being "helpful." The validator catches them as unknown hunks. The retry loop regenerates the same mistake 3 times. The user sees:

> Split plan failed: Failed to produce a valid commit-split plan after 3 attempts. Final validator issues: unknown hunks: src/widgets/button.ts::hunk-1, src/widgets/index.ts::hunk-1, ...

**Reproducible against `dirty-many-files` scenario** where all 12 staged files are new (the whole new `src/widgets/` module). Exact failure shown in #917's screenshot.

## Two-pronged fix

### 1. Sanitization pass (the bullet-proof part)

New `rescuePhantomHunks(plan, staged, inventory)` in `splitPlanValidation.ts`. Runs between the LLM call and the validator. For each group, walks `hunks[]`; any entry whose ID isn't in `inventory.byId` gets:
- File path extracted from the `<filepath>::hunk-N` format
- File added to that group's `files[]` (if it's in the staged set and not already claimed by another group)
- Hunk dropped from `hunks[]`

**Rules:**
- First group wins when multiple groups reference the same phantom hunk.
- Already-claimed files (via `files[]` somewhere else) aren't double-claimed — phantom hunks for them just drop.
- Real hunk IDs pass through untouched.
- Hallucinated files (LLM invented both the hunk AND a non-existent file path) just drop — the validator's existing `missingFiles` check catches any actually-missing staged files separately.

### 2. Prompt strengthening (reduce the failure rate at the source)

Added two explicit rules to `COMMIT_SPLIT_PROMPT`:
- "Only use hunk IDs **LITERALLY copied from** the 'Staged hunk inventory' section below. Do not invent or guess hunk IDs."
- "If the hunk inventory says 'No hunk-level inventory available' then **EVERY group's `hunks` array MUST be empty** (use only `files`). Do not write hunk IDs like `path::hunk-1` when no hunk inventory exists — those are not valid."

## Test plan

- [x] `npm run lint` clean
- [x] `tsc --noEmit` clean
- [x] `npm run test:jest` — **691 suites / 6677 tests pass** (+8 from this PR)
- [ ] Manual: `npm run scenario create dirty-many-files -- --run-ui` → press `S` from compose → plan generates on first attempt (no more "unknown hunks" failure)
- [ ] Manual: review the rendered plan — should show file-level groups since no hunks are valid against an empty inventory
- [ ] Manual: press `y` → split applies cleanly, 4-5 new commits land

## What's NOT changed

- The underlying behavior of `collectHunkInventory` (only modified files get hunks) — that's correct for the apply phase, which uses `git apply --cached` patches. New files don't need hunks; `git add <file>` is enough.
- The retry semantics — still 3 attempts, still fed back validator feedback. Just no longer wasted on phantom-hunk failures the sanitization can fix in-process.