### PR TITLE
fix(split): rescue mixed-mode file claims

### DIFF
--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -47,6 +47,7 @@ Return ONLY valid JSON matching this schema:
 
 Rules:
 - Every staged file MUST be assigned exactly once across all groups, either via "files" OR via every one of its hunk IDs (never both).
+- A SINGLE file is EITHER fully claimed via "files" (its name appears in one group's "files" array) OR fully claimed via "hunks" (every one of its hunk IDs is split across one or more groups). NEVER mix the two modes for the same file. If a file appears in any group's "files" array, that file's hunk IDs MUST NOT appear in any group's "hunks" array.
 - If you assign any hunk for a file, you MUST assign EVERY hunk for that file across the groups — partial coverage is invalid.
 - Do not list the same file in "files" of more than one group, and do not assign the same hunk ID to more than one group.
 - Only use file paths listed in the staged file inventory. Do not invent files.

--- a/src/commands/commit/splitPlanGenerator.test.ts
+++ b/src/commands/commit/splitPlanGenerator.test.ts
@@ -116,6 +116,41 @@ describe('generateValidatedCommitSplitPlan', () => {
     expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(1)
   })
 
+  it('rescues mixed-mode file claims before validation (#919 regression)', async () => {
+    // Exact pattern from #919 manual testing on dirty-many-files:
+    // src/index.ts is the only modified file (has real hunks), but
+    // the LLM put it BOTH in group A's files[] AND used its hunks in
+    // group B's hunks[]. Validator's mixedFiles check rejected it
+    // for 3 attempts running. With rescueMixedFiles, the same output
+    // validates on the first attempt.
+    // baseArgs() has 2 staged files (a.ts, b.ts); include b.ts in
+    // group 2 so the plan satisfies file-coverage post-rescue.
+    const mixedPlan: CommitSplitPlan = {
+      groups: [
+        { title: 'feat: integration', files: ['a.ts'], hunks: [] },
+        { title: 'feat: misc', files: ['b.ts'], hunks: ['a.ts::hunk-1'] },
+      ],
+    }
+    mockExecuteChainWithSchema.mockResolvedValueOnce(mixedPlan)
+
+    // Override baseArgs to provide an inventory with real hunks for a.ts
+    // — this is what makes the mixedFiles validation kick in (without
+    // inventory, the hunks would just get phantom-rescued).
+    const inventoryWithRealHunks = {
+      byId: new Map([['a.ts::hunk-1', { id: 'a.ts::hunk-1', filePath: 'a.ts' }]]),
+      byFile: new Map([['a.ts', [{ id: 'a.ts::hunk-1', filePath: 'a.ts' }]]]),
+    }
+    const result = await generateValidatedCommitSplitPlan({
+      ...baseArgs(),
+      hunkInventory: inventoryWithRealHunks,
+    })
+
+    expect(result.attempts).toBe(1)
+    expect(result.plan.groups[0].files).toEqual(['a.ts'])
+    expect(result.plan.groups[1].hunks).toEqual([])
+    expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(1)
+  })
+
   it('throws after exhausting retries with the final validator complaints in the message', async () => {
     const invalidPlan: CommitSplitPlan = {
       groups: [{ title: 'a', files: ['a.ts'], hunks: [] }],

--- a/src/commands/commit/splitPlanGenerator.ts
+++ b/src/commands/commit/splitPlanGenerator.ts
@@ -12,6 +12,7 @@ import {
   hasPlanValidationIssues,
   HunkInventoryLike,
   PlanValidationIssues,
+  rescueMixedFiles,
   rescuePhantomHunks,
 } from './splitPlanValidation'
 
@@ -85,15 +86,24 @@ export async function generateValidatedCommitSplitPlan({
       }
     )
 
-    // Rescue pass: when the staged set is all new/added files (no
-    // hunk inventory), the LLM commonly emits "file::hunk-1" entries
-    // anyway because the prompt's hunk-aware language convinces it
-    // that's the right format. The validator then rejects them as
-    // unknown hunks and the retry loop just regenerates the same
-    // mistake. Pre-validation, promote phantom hunks back to
-    // file-level assignments — same semantic, accepted by the
-    // validator, no LLM re-roll needed.
-    const plan = rescuePhantomHunks(rawPlan, staged, hunkInventory)
+    // Rescue passes (#918, #919). Run in order — order matters:
+    //
+    //   1. rescuePhantomHunks: LLM commonly emits "file::hunk-1"
+    //      against an empty inventory (all staged files are new).
+    //      Promote those to file-level assignments.
+    //
+    //   2. rescueMixedFiles: LLM commonly puts a file in `files[]`
+    //      of group A AND uses its hunks in `hunks[]` of group B.
+    //      Drop the hunks (the file-level claim is more specific).
+    //      Must run AFTER phantom-hunk rescue because the rescue
+    //      itself can create mixed-files situations (phantom hunks
+    //      get promoted to files; pre-existing real hunks for the
+    //      same file remain elsewhere and now overlap).
+    //
+    // Both rescues are no-ops when there's nothing to rescue, so
+    // running them unconditionally costs nothing on healthy plans.
+    const phantomRescued = rescuePhantomHunks(rawPlan, staged, hunkInventory)
+    const plan = rescueMixedFiles(phantomRescued, hunkInventory)
 
     const issues = getPlanValidationIssues(plan, staged, hunkInventory)
     if (!hasPlanValidationIssues(issues)) {

--- a/src/commands/commit/splitPlanValidation.test.ts
+++ b/src/commands/commit/splitPlanValidation.test.ts
@@ -5,6 +5,7 @@ import {
   getPlanValidationIssues,
   hasPlanValidationIssues,
   HunkInventoryLike,
+  rescueMixedFiles,
   rescuePhantomHunks,
 } from './splitPlanValidation'
 import { CommitSplitPlan } from './splitPlanTypes'
@@ -339,6 +340,104 @@ describe('splitPlanValidation', () => {
       const rescued = rescuePhantomHunks(plan, staged, buildHunkInventory({}))
 
       expect(rescued).toEqual(plan)
+    })
+  })
+
+  describe('rescueMixedFiles', () => {
+    // The dominant failure pattern from #918 testing: src/index.ts is
+    // the only modified file in dirty-many-files (so it has real hunks
+    // in the inventory). The LLM puts it in `files[]` of one group AND
+    // uses its real hunks in `hunks[]` of another group. Validator's
+    // mixedFiles check rejects. Rescue drops the redundant hunks since
+    // the file is already claimed via files[].
+
+    it('drops hunks for a file already claimed via files[]', () => {
+      const inventory = buildHunkInventory({
+        'src/index.ts': ['src/index.ts::hunk-1', 'src/index.ts::hunk-2'],
+      })
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'feat: integration', files: ['src/index.ts'], hunks: [] },
+          { title: 'feat: misc', files: [], hunks: ['src/index.ts::hunk-1', 'src/index.ts::hunk-2'] },
+        ],
+      }
+
+      const rescued = rescueMixedFiles(plan, inventory)
+
+      expect(rescued.groups[0].files).toEqual(['src/index.ts'])
+      expect(rescued.groups[1].hunks).toEqual([])
+    })
+
+    it('drops only the conflicting hunks, leaves others alone', () => {
+      // Mixed group: some hunks are for a files[]-claimed file (drop),
+      // others are for an unclaimed file (keep). Real-world the LLM
+      // often groups several files' hunks together.
+      const inventory = buildHunkInventory({
+        'src/index.ts': ['src/index.ts::hunk-1'],
+        'src/router.ts': ['src/router.ts::hunk-1'],
+      })
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'feat: a', files: ['src/index.ts'], hunks: [] },
+          { title: 'feat: b', files: [], hunks: ['src/index.ts::hunk-1', 'src/router.ts::hunk-1'] },
+        ],
+      }
+
+      const rescued = rescueMixedFiles(plan, inventory)
+
+      expect(rescued.groups[1].hunks).toEqual(['src/router.ts::hunk-1'])
+    })
+
+    it('passes through unknown hunks (phantom-hunk rescue handles them)', () => {
+      // If a hunk ID isn't in the inventory, mixedFiles rescue can't
+      // know which file it belongs to without parsing — leave it for
+      // the phantom-hunk rescue to handle (which runs earlier in the
+      // generator).
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'feat: a', files: ['src/index.ts'], hunks: [] },
+          { title: 'feat: b', files: [], hunks: ['phantom.ts::hunk-1'] },
+        ],
+      }
+
+      const rescued = rescueMixedFiles(plan, buildHunkInventory({}))
+
+      // Unknown hunk left alone — phantom rescue handles it upstream.
+      expect(rescued.groups[1].hunks).toEqual(['phantom.ts::hunk-1'])
+    })
+
+    it('is a no-op when no file is claimed via both modes', () => {
+      const inventory = buildHunkInventory({
+        'src/router.ts': ['src/router.ts::hunk-1'],
+      })
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'feat: a', files: ['src/index.ts'], hunks: [] },
+          { title: 'feat: b', files: [], hunks: ['src/router.ts::hunk-1'] },
+        ],
+      }
+
+      const rescued = rescueMixedFiles(plan, inventory)
+
+      expect(rescued).toEqual(plan)
+    })
+
+    it('handles the same file claimed via files[] AND hunks[] in the SAME group', () => {
+      // Less common LLM mistake but still possible — file appears in
+      // both arrays of the same group. Drop the hunks; files[] wins.
+      const inventory = buildHunkInventory({
+        'src/index.ts': ['src/index.ts::hunk-1'],
+      })
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'feat: combined', files: ['src/index.ts'], hunks: ['src/index.ts::hunk-1'] },
+        ],
+      }
+
+      const rescued = rescueMixedFiles(plan, inventory)
+
+      expect(rescued.groups[0].files).toEqual(['src/index.ts'])
+      expect(rescued.groups[0].hunks).toEqual([])
     })
   })
 })

--- a/src/commands/commit/splitPlanValidation.ts
+++ b/src/commands/commit/splitPlanValidation.ts
@@ -199,6 +199,58 @@ export function rescuePhantomHunks(
   return { ...plan, groups: rescuedGroups }
 }
 
+/**
+ * Salvage a plan where a file appears BOTH in some group's `files[]`
+ * AND as covered by hunks in some (possibly different) group's
+ * `hunks[]`. The validator calls this `mixedFiles` and rejects it.
+ *
+ * Common cause after `rescuePhantomHunks` runs: the LLM put one of
+ * the (legitimately modifiable) files in `files[]` of group A, and
+ * put its real hunks in `hunks[]` of group B. The phantom-hunk
+ * rescue doesn't touch this — real hunks pass through — so the
+ * mixed-files combination survives into validation.
+ *
+ * Recovery: drop the hunks. The `files[]` claim is more specific
+ * about user intent ("this whole file goes in commit A"); the hunks
+ * become redundant once the whole file is already committed
+ * somewhere. The validator's coverage check is satisfied because the
+ * file is now claimed exactly once (via `files[]`).
+ *
+ * If a file's hunks are dropped AND the file isn't in any group's
+ * `files[]`, it'll fall through to the `missingFiles` check — but
+ * that's caught upstream by the file-coverage requirement.
+ *
+ * Returns a NEW plan object — original is not mutated.
+ */
+export function rescueMixedFiles(
+  plan: CommitSplitPlan,
+  hunkInventory?: HunkInventoryLike
+): CommitSplitPlan {
+  // First pass: collect every file claimed via files[] across all
+  // groups. These are the files whose `hunks[]` entries become
+  // redundant.
+  const fileClaims = new Set<string>()
+  plan.groups.forEach((group) => {
+    (group.files || []).forEach((file) => fileClaims.add(file))
+  })
+
+  // Second pass: drop hunks whose file path is in fileClaims.
+  const rescuedGroups = plan.groups.map((group) => {
+    const keptHunks = (group.hunks || []).filter((hunkId) => {
+      const hunk = hunkInventory?.byId.get(hunkId)
+      // Hunk isn't in inventory → not our problem here (the phantom-
+      // hunk rescue handles unknown hunks). Pass through.
+      if (!hunk) return true
+      // Hunk's file is claimed via files[] somewhere → redundant.
+      return !fileClaims.has(hunk.filePath)
+    })
+
+    return { ...group, hunks: keptHunks }
+  })
+
+  return { ...plan, groups: rescuedGroups }
+}
+
 export function formatPlanValidationFeedback(issues: PlanValidationIssues): string {
   const sections: string[] = []
 


### PR DESCRIPTION
Direct follow-up to #918. Same failure shape (LLM produces an invalid plan, retry loop just regenerates the same mistake), different validator complaint:

> Split plan failed: files assigned both as whole files and hunks: src/index.ts

## What was broken

In `dirty-many-files`, `src/index.ts` is the only **modified** file in the staged set — it's the only file `collectHunkInventory` produces real hunks for. The LLM commonly puts it in `files[]` of one group AND uses its real hunks in `hunks[]` of another. Validator's `mixedFiles` check rejects.

The #918 phantom-hunk rescue doesn't cover this — real hunks pass through unchanged, so the mixed-mode claim survives into validation. **Worse**, in some plans the phantom-hunk rescue *creates* mixed-files situations: phantom hunks for new files get promoted to file claims, and pre-existing real hunks for the same file remain elsewhere and now overlap.

## Fix

New `rescueMixedFiles(plan, hunkInventory)` in `splitPlanValidation.ts`. Runs **after** `rescuePhantomHunks` in the generator. For any file claimed via `files[]` somewhere across groups, drops every real hunk for that file from any group's `hunks[]`. The `files[]` claim is more specific about user intent ("this whole file goes in commit A"); the hunks become redundant once the whole file is already going somewhere.

Order in the generator now:
1. `rescuePhantomHunks` — phantom hunks → file claims
2. `rescueMixedFiles` — drop hunks where the file is already file-claimed (catches the natural mixed-mode case AND the cases created by step 1)
3. Validator runs on the rescued plan

Both rescues are no-ops when there's nothing to rescue.

## Prompt strengthening

Added an explicit "single file in one mode" rule to `COMMIT_SPLIT_PROMPT`:

> A SINGLE file is EITHER fully claimed via "files" (its name appears in one group's "files" array) OR fully claimed via "hunks" (every one of its hunk IDs is split across one or more groups). NEVER mix the two modes for the same file. If a file appears in any group's "files" array, that file's hunk IDs MUST NOT appear in any group's "hunks" array.

Aimed at reducing the failure rate at the source so the rescue is a safety net rather than a routine cleanup pass.

## Test plan

- [x] `npm run lint` clean
- [x] `tsc --noEmit` clean
- [x] `npm run test:jest` — **691 suites / 6683 tests pass** (+6 from this PR)
- [ ] Manual: `npm run scenario create dirty-many-files -- --run-ui` → press `S` → plan generates without the mixed-files error
- [ ] Manual: review the plan — `src/index.ts` should appear in exactly one place (either files[] or hunks[], not both)
- [ ] Manual: press `y` → split applies cleanly

## What we'll do if a third rescue is needed

The phantom-hunk + mixed-files rescues together cover the two failure modes seen in #918 and #919 manual testing. If a third validator-failure flavor surfaces (`duplicateFiles`, `partiallyCoveredFiles`, etc.), the answer is probably another targeted rescue function rather than turning the rescue layer into an open-ended cleaner — each rescue's semantic decision (which side of the conflict wins) deserves an explicit name + tests.

Longer-term: most of these are symptoms of `collectHunkInventory` skipping non-modified files. A bigger refactor that treats new/added files as having one synthetic "whole-file hunk" would eliminate the asymmetric inventory that confuses the LLM. Out of scope here.