### PR TITLE
fix(split-overlay): footer hints + scroll-key aliases

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -3111,24 +3111,76 @@ describe('log Ink input interactions', () => {
       ])
     })
 
-    it('intercepts j/k as line scroll, PgUp/PgDn as 10-line scroll', () => {
+    it('intercepts j/k and ↑/↓ as line scroll', () => {
       const state = applyLogInkAction(createLogInkState(rows), {
         type: 'setSplitPlanReady',
         plan: mockPlan,
         planContext: mockPlanContext,
       })
 
+      // j/k (vim convention)
       expect(getLogInkInputEvents(state, 'j', {}, { splitPlanLineCount: 50 })).toEqual([
         { type: 'action', action: { type: 'pageSplitPlan', delta: 1, lineCount: 50 } },
       ])
       expect(getLogInkInputEvents(state, 'k', {}, { splitPlanLineCount: 50 })).toEqual([
         { type: 'action', action: { type: 'pageSplitPlan', delta: -1, lineCount: 50 } },
       ])
+
+      // Arrow keys (universal convention) — same dispatch.
+      expect(getLogInkInputEvents(state, '', { downArrow: true }, { splitPlanLineCount: 50 })).toEqual([
+        { type: 'action', action: { type: 'pageSplitPlan', delta: 1, lineCount: 50 } },
+      ])
+      expect(getLogInkInputEvents(state, '', { upArrow: true }, { splitPlanLineCount: 50 })).toEqual([
+        { type: 'action', action: { type: 'pageSplitPlan', delta: -1, lineCount: 50 } },
+      ])
+    })
+
+    it('intercepts PgUp/PgDn and space/b as page scroll', () => {
+      const state = applyLogInkAction(createLogInkState(rows), {
+        type: 'setSplitPlanReady',
+        plan: mockPlan,
+        planContext: mockPlanContext,
+      })
+
+      // PgDown / PgUp
       expect(getLogInkInputEvents(state, '', { pageDown: true }, { splitPlanLineCount: 50 })).toEqual([
         { type: 'action', action: { type: 'pageSplitPlan', delta: 10, lineCount: 50 } },
       ])
       expect(getLogInkInputEvents(state, '', { pageUp: true }, { splitPlanLineCount: 50 })).toEqual([
         { type: 'action', action: { type: 'pageSplitPlan', delta: -10, lineCount: 50 } },
+      ])
+
+      // space / b — vim-style aliases, work in every terminal even when
+      // PgUp/PgDn don't deliver cleanly through Ink.
+      expect(getLogInkInputEvents(state, ' ', {}, { splitPlanLineCount: 50 })).toEqual([
+        { type: 'action', action: { type: 'pageSplitPlan', delta: 10, lineCount: 50 } },
+      ])
+      expect(getLogInkInputEvents(state, 'b', {}, { splitPlanLineCount: 50 })).toEqual([
+        { type: 'action', action: { type: 'pageSplitPlan', delta: -10, lineCount: 50 } },
+      ])
+    })
+
+    it('G jumps to bottom, gg jumps to top', () => {
+      let state = applyLogInkAction(createLogInkState(rows), {
+        type: 'setSplitPlanReady',
+        plan: mockPlan,
+        planContext: mockPlanContext,
+      })
+
+      // G — single keystroke, jumps to bottom (delta = lineCount).
+      expect(getLogInkInputEvents(state, 'G', {}, { splitPlanLineCount: 50 })).toEqual([
+        { type: 'action', action: { type: 'pageSplitPlan', delta: 50, lineCount: 50 } },
+      ])
+
+      // First g sets pendingKey for the gg chord.
+      expect(getLogInkInputEvents(state, 'g', {}, { splitPlanLineCount: 50 })).toEqual([
+        { type: 'action', action: { type: 'setPendingKey', value: 'g' } },
+      ])
+
+      // Second g (with pendingKey === 'g') jumps to top.
+      state = applyLogInkAction(state, { type: 'setPendingKey', value: 'g' })
+      expect(getLogInkInputEvents(state, 'g', {}, { splitPlanLineCount: 50 })).toEqual([
+        { type: 'action', action: { type: 'pageSplitPlan', delta: -50, lineCount: 50 } },
       ])
     })
 

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -953,17 +953,36 @@ export function getLogInkInputEvents(
     }
 
     if (state.splitPlan.status === 'ready' && lineCount > 0) {
-      if (inputValue === 'j') {
+      // Line-step scroll: j/k OR ↑/↓ arrows. Both feel natural —
+      // vim users reach for j/k, everyone else for arrows.
+      if (inputValue === 'j' || key.downArrow) {
         return [action({ type: 'pageSplitPlan', delta: 1, lineCount })]
       }
-      if (inputValue === 'k') {
+      if (inputValue === 'k' || key.upArrow) {
         return [action({ type: 'pageSplitPlan', delta: -1, lineCount })]
       }
-      if (key.pageDown) {
+      // Page-step scroll: PgDn/PgUp, plus space/b as vim-style aliases.
+      // Some terminals don't deliver PgDn/PgUp cleanly through Ink
+      // (the original report from #919 was that PgUp/PgDn didn't seem
+      // to work) — space/b gives a reliable fallback that works on
+      // every terminal.
+      if (key.pageDown || inputValue === ' ') {
         return [action({ type: 'pageSplitPlan', delta: 10, lineCount })]
       }
-      if (key.pageUp) {
+      if (key.pageUp || inputValue === 'b') {
         return [action({ type: 'pageSplitPlan', delta: -10, lineCount })]
+      }
+      // gg / G for top / bottom — matches the rest of the workstation
+      // (history view, diff view, etc. all use gg/G for first/last).
+      if (inputValue === 'G') {
+        return [action({ type: 'pageSplitPlan', delta: lineCount, lineCount })]
+      }
+      if (inputValue === 'g') {
+        // gg chord: first `g` sets pendingKey, second `g` jumps to top.
+        if (state.pendingKey === 'g') {
+          return [action({ type: 'pageSplitPlan', delta: -lineCount, lineCount })]
+        }
+        return [action({ type: 'setPendingKey', value: 'g' })]
       }
     }
 

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -71,6 +71,43 @@ describe('log Ink keymap', () => {
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 
+    // Split-plan overlay claims the footer while open — underlying
+    // view's bindings are all intercepted, so surfacing them would
+    // mislead the user about what works. Each phase gets its own
+    // hint set since most keys no-op during loading / applying.
+    expect(getLogInkFooterHints({
+      activeView: 'compose',
+      filterMode: false,
+      focus: 'commits',
+      showHelp: false,
+      splitPlanStatus: 'ready',
+    })).toEqual({
+      contextual: ['↑/↓ scroll', 'pg up/dn', 'g/G top/bot', 'y apply', 'r regen', 'esc cancel'],
+      global: ['q quit'],
+    })
+
+    expect(getLogInkFooterHints({
+      activeView: 'compose',
+      filterMode: false,
+      focus: 'commits',
+      showHelp: false,
+      splitPlanStatus: 'loading',
+    })).toEqual({
+      contextual: ['generating plan…', 'esc cancel'],
+      global: ['q quit'],
+    })
+
+    expect(getLogInkFooterHints({
+      activeView: 'compose',
+      filterMode: false,
+      focus: 'commits',
+      showHelp: false,
+      splitPlanStatus: 'applying',
+    })).toEqual({
+      contextual: ['applying split…'],
+      global: ['q quit'],
+    })
+
     expect(getLogInkFooterHints({
       activeView: 'branches',
       filterMode: false,

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -399,6 +399,15 @@ export type GetLogInkFooterHintsOptions = {
   focus: LogInkFocus
   showHelp: boolean
   showCommandPalette?: boolean
+  /**
+   * Split-plan overlay state (#907 / #919). When `'ready'`, the footer
+   * surfaces overlay-local bindings (y apply / r regen / esc cancel /
+   * scroll keys) instead of the underlying compose-view hints — the
+   * underlying view's keystrokes are all intercepted while the
+   * overlay is open. `'loading'` and `'applying'` get simpler hints
+   * since most keys are no-ops in those phases.
+   */
+  splitPlanStatus?: 'loading' | 'ready' | 'applying'
   /** Set when the user has pressed a chord prefix (e.g. `g`) and the
    * dispatcher is waiting for the second key. The footer surfaces the
    * available continuations inline as a fallback for the popup overlay. */
@@ -558,6 +567,36 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
     return {
       contextual: [': close', 'D/T/X confirm', 'I/M AI'],
       global: ['? help', 'q quit'],
+    }
+  }
+
+  // Split-plan overlay claims the footer while open — the underlying
+  // view's keystrokes are intercepted, so surfacing them would be
+  // misleading. Each phase gets its own hint set since most keys
+  // no-op during loading / applying.
+  if (options.splitPlanStatus === 'ready') {
+    return {
+      contextual: [
+        '↑/↓ scroll',
+        'pg up/dn',
+        'g/G top/bot',
+        'y apply',
+        'r regen',
+        'esc cancel',
+      ],
+      global: ['q quit'],
+    }
+  }
+  if (options.splitPlanStatus === 'loading') {
+    return {
+      contextual: ['generating plan…', 'esc cancel'],
+      global: ['q quit'],
+    }
+  }
+  if (options.splitPlanStatus === 'applying') {
+    return {
+      contextual: ['applying split…'],
+      global: ['q quit'],
     }
   }
 

--- a/src/workstation/runtime/footer.ts
+++ b/src/workstation/runtime/footer.ts
@@ -51,6 +51,7 @@ export function renderFooter(
     sidebarTab: state.sidebarTab,
     sidebarItemCount,
     compareBaseSet: Boolean(state.compareBase),
+    splitPlanStatus: state.splitPlan?.status,
   })
   // Real status messages always win; idle tips only fill the slot when it
   // would otherwise be empty.


### PR DESCRIPTION
Two small fixes from manual testing of the working split flow in #919.

## Issue 1: Footer was lying about the keymap

The footer kept showing the underlying compose-view bindings while the split-plan overlay was active:

> `e edit · E \$EDITOR · c commit · S split · I AI draft · gs hunks · esc back`

But those keystrokes are all intercepted by the overlay — none of them actually work. The user has no idea what their actual options are from looking at the footer.

**Fix**: footer hint function now takes `splitPlanStatus` and returns overlay-specific hints:
- `'ready'` → `↑/↓ scroll · pg up/dn · g/G top/bot · y apply · r regen · esc cancel`
- `'loading'` → `generating plan… · esc cancel`
- `'applying'` → `applying split…` (no escape — past the point of clean cancel)

## Issue 2: PgUp/PgDn not working in some terminals

User reported only j/k worked. Some terminals don't deliver PgUp/PgDn cleanly through Ink — known quirk.

**Fix**: added universally-available aliases:
- `↑/↓` arrows as aliases for `k/j` (line scroll)
- `space/b` as aliases for `PgDn/PgUp` (page scroll) — vim convention, works on every terminal
- `G` / `gg` chord for jump-to-bottom / jump-to-top — matches history, diff, and other scrollable views in the workstation

Original keys (j/k, PgUp/PgDn, y/Enter, r, Esc) still work — additive aliases, no breaking changes.

## Side answer to the user's other question

> "wondering what the next step is from here once I've created the 'plan'"

From the plan-review screen, the options are:
- **`y` or `Enter`** — apply the plan (creates the commits)
- **`r`** — regenerate (re-runs the LLM with the same staged set)
- **`Esc` or `<`** — cancel the overlay, back to compose
- Scroll keys as above

The new footer hint makes this discoverable without having to read the source.

## Test plan

- [x] `npm run lint` clean
- [x] `tsc --noEmit` clean
- [x] `npm run test:jest` — **691 suites / 6685 tests pass** (+2 from this PR)
- [ ] Manual: `npm run scenario create dirty-many-files -- --run-ui` → `S` → footer shows the new overlay-specific hints, arrow keys + space/b all work for scroll