### PR TITLE
feat(log-tui): bisect completion panel (#879 item 3)

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -1380,6 +1380,23 @@ describe('log Ink input interactions', () => {
       expect(getLogInkInputEvents(state, 'y', {}, { worktreeFileCount: 0 })).toEqual([])
     })
 
+    it('emits yankFromActiveView from the bisect completion panel (#879 item 3)', () => {
+      // Bisect completion: y / Y yank the first-bad commit sha. The
+      // input dispatcher gates on `bisectCompletionSha` so the bisect
+      // view falls through to the existing bisect-active handlers
+      // (g/b/s/x) when no terminator is present.
+      const state = createLogInkState(rows, { activeView: 'bisect' })
+
+      expect(
+        getLogInkInputEvents(state, 'y', {}, { bisectCompletionSha: 'abc12345' })
+      ).toEqual([{ type: 'yankFromActiveView', short: false }])
+      expect(
+        getLogInkInputEvents(state, 'Y', {}, { bisectCompletionSha: 'abc12345' })
+      ).toEqual([{ type: 'yankFromActiveView', short: true }])
+      // No terminator → falls through.
+      expect(getLogInkInputEvents(state, 'y', {}, {})).toEqual([])
+    })
+
     it('emits yankFromActiveView from diff view across worktree/stash/commit sources', () => {
       const state = createLogInkState(rows, { activeView: 'diff' })
 

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -181,6 +181,12 @@ export type LogInkInputContext = {
    * groups before dispatching to the input handler.
    */
   splitPlanLineCount?: number
+  /**
+   * Short sha of the bisect's "first bad commit" terminator, when
+   * present (#879 item 3). Drives `y` on the bisect-complete panel —
+   * the headline answer is the value the user wants to copy.
+   */
+  bisectCompletionSha?: string
 }
 
 function action(actionValue: LogInkAction): LogInkInputEvent {
@@ -2380,6 +2386,13 @@ export function getLogInkInputEvents(
       ) {
         return [{ type: 'yankFromActiveView', short }]
       }
+    }
+    // #879 item 3: yank the first-bad commit sha from the bisect
+    // completion panel. The headline answer is what the user came
+    // here to copy; surfacing it via the same y/Y idiom (Y = short)
+    // is faster than dropping to shell.
+    if (state.activeView === 'bisect' && context.bisectCompletionSha) {
+      return [{ type: 'yankFromActiveView', short }]
     }
   }
 

--- a/src/git/bisectData.test.ts
+++ b/src/git/bisectData.test.ts
@@ -1,5 +1,5 @@
 import { SimpleGit } from 'simple-git'
-import { getBisectStatus, parseBisectLog } from './bisectData'
+import { getBisectCompletion, getBisectStatus, parseBisectLog } from './bisectData'
 
 jest.mock('fs', () => {
   const actual = jest.requireActual('fs')
@@ -137,6 +137,46 @@ describe('parseBisectLog', () => {
     // comment rows carry the parsed subject text.
     expect(parsed[3]).toMatchObject({ kind: 'bad', sha: 'abc1234' })
     expect(parsed[3].subject).toBeUndefined()
+  })
+})
+
+describe('getBisectCompletion', () => {
+  it('returns undefined when no terminator is present', () => {
+    const log = parseBisectLog(['git bisect start', 'git bisect bad abc1234'].join('\n'))
+    expect(getBisectCompletion(log)).toBeUndefined()
+  })
+
+  it('returns the sha + subject from a well-formed terminator', () => {
+    const log = parseBisectLog(
+      ['git bisect start', '# first bad commit: [abc1234] feat: regression-y change'].join('\n')
+    )
+    expect(getBisectCompletion(log)).toEqual({
+      sha: 'abc1234',
+      subject: 'feat: regression-y change',
+    })
+  })
+
+  it('returns the latest terminator when multiple are present', () => {
+    // Rare but real: a user `git bisect reset` then re-runs in the
+    // same .git directory can leave two terminators in the parsed
+    // log. The latest one is the one that matters.
+    const log = parseBisectLog(
+      [
+        '# first bad commit: [old1111] feat: old answer',
+        'git bisect start',
+        '# first bad commit: [new2222] feat: new answer',
+      ].join('\n')
+    )
+    expect(getBisectCompletion(log)).toEqual({ sha: 'new2222', subject: 'feat: new answer' })
+  })
+
+  it('returns the sha with subject undefined when the comment has no subject', () => {
+    const log = parseBisectLog('# first bad commit: [abc1234]')
+    expect(getBisectCompletion(log)).toEqual({ sha: 'abc1234', subject: undefined })
+  })
+
+  it('returns undefined for an empty log', () => {
+    expect(getBisectCompletion([])).toBeUndefined()
   })
 })
 

--- a/src/git/bisectData.ts
+++ b/src/git/bisectData.ts
@@ -39,6 +39,38 @@ export type BisectStatus = {
   log: BisectLogEntry[]
 }
 
+export type BisectCompletion = {
+  /** The "first bad commit" sha as recorded by git in the log. */
+  sha: string
+  /** Commit subject as recorded in the comment row, if any. */
+  subject?: string
+}
+
+/**
+ * Detect the bisect terminator in a parsed log. When git's binary
+ * search lands on the first bad commit it emits a
+ * `# first bad commit: [<sha>] <subject>` comment row into BISECT_LOG.
+ * The session is technically still "active" (the log file persists
+ * until `git bisect reset`), so callers need an explicit signal that
+ * the answer is in.
+ *
+ * Walks last-to-first so a re-bisect that left a stale terminator at
+ * the top still resolves to the most recent one. Returns undefined
+ * when no terminator is present.
+ */
+export function getBisectCompletion(log: BisectLogEntry[]): BisectCompletion | undefined {
+  for (let i = log.length - 1; i >= 0; i--) {
+    const entry = log[i]
+    if (entry.kind !== 'unknown') continue
+    const match = entry.raw.match(/^#\s+first\s+bad\s+commit:\s+\[([^\]]+)\]\s*(.*)$/)
+    if (match) {
+      const subject = match[2]?.trim()
+      return { sha: match[1], subject: subject || undefined }
+    }
+  }
+  return undefined
+}
+
 const EMPTY_STATUS: BisectStatus = {
   active: false,
   currentSha: '',

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -271,7 +271,7 @@ import {
     stageHunk,
     unstageHunk,
 } from '../../git/statusHunks'
-import { getBisectStatus } from '../../git/bisectData'
+import { getBisectCompletion, getBisectStatus } from '../../git/bisectData'
 import { bisectBad, bisectGood, bisectReset, bisectSkip, extractBisectRemainingHint } from '../../git/bisectActions'
 import { getCompareDiff } from '../../git/compareData'
 import { getReflogOverview } from '../../git/reflogData'
@@ -2385,6 +2385,20 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         value = path
         label = `path ${path}`
       }
+    } else if (view === 'bisect') {
+      // #879 item 3 — yank the first-bad commit sha from the
+      // completion panel. The headline answer is what the user
+      // came here to copy. Y opts into the short form; y returns
+      // the full sha as recorded in BISECT_LOG.
+      const completion = context.bisect?.active
+        ? getBisectCompletion(context.bisect.log)
+        : undefined
+      if (completion) {
+        value = short ? completion.sha.slice(0, 8) : completion.sha
+        label = short
+          ? `short hash ${completion.sha.slice(0, 8)} (first bad)`
+          : `commit ${completion.sha.slice(0, 8)} (first bad)`
+      }
     } else if (view === 'diff') {
       if (state.diffSource === 'worktree') {
         const path = visibleWorktreeFilesGrouped[state.selectedWorktreeFileIndex]?.path
@@ -2431,6 +2445,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
   }, [
     clipboardRunner,
+    context.bisect,
     context.branches,
     context.stashes,
     context.tags,
@@ -2786,6 +2801,12 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       // if any) + blank separator. Used by j/k/PgUp/PgDn to clamp the
       // scroll offset. The exact render math lives in the overlay
       // module — this is a close-enough heuristic for clamping.
+      // #879 item 3 — short sha of the bisect terminator (if any).
+      // Gates `y`/`Y` yank on the completion panel and lets the
+      // runtime resolve the value without re-parsing the log.
+      bisectCompletionSha: context.bisect?.active
+        ? getBisectCompletion(context.bisect.log)?.sha
+        : undefined,
       splitPlanLineCount: state.splitPlan?.plan
         ? state.splitPlan.plan.groups.reduce((sum, group) => {
           let lines = 2 // title + separator

--- a/src/workstation/surfaces/bisect/index.ts
+++ b/src/workstation/surfaces/bisect/index.ts
@@ -19,6 +19,7 @@ import { truncateCells } from '../../chrome/text'
 import type { LogInkTheme } from '../../chrome/theme'
 import type { GitCommitDetail } from '../../../commands/log/data'
 import type { LogInkState } from '../../../commands/log/inkViewModel'
+import { getBisectCompletion } from '../../../git/bisectData'
 import type { LogInkComponents, LogInkContext } from '../../runtime/types'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
 
@@ -39,6 +40,11 @@ export function renderBisectSurface(
   const loading = isLogInkContextKeyLoading(contextStatus, 'bisect')
   const bisect = context.bisect
   const accent = theme.noColor ? undefined : theme.colors.accent
+  // #879 item 3 — detect git's "first bad commit" terminator so we
+  // can swap the in-flight UI for a completion panel. The session is
+  // technically still active until `git bisect reset`, so the answer
+  // panel piggy-backs on the same `bisect.active` branch.
+  const completion = bisect?.active ? getBisectCompletion(bisect.log) : undefined
 
   const lines: ReactTypes.ReactNode[] = []
 
@@ -82,6 +88,54 @@ export function renderBisectSurface(
         color: row.opts?.accent ? accent : undefined,
       }, truncateCells(row.text, width - 4)))
     }
+  } else if (completion) {
+    // Bisect terminated: git emitted the "first bad commit" line into
+    // BISECT_LOG. Render a dedicated answer panel rather than leaving
+    // the surface in the same shape as a regular decision step. HEAD
+    // is parked on the first-bad commit at this point, so the
+    // candidateDetail loaded via #879 item 2 carries the right
+    // author / date / file stats — we reuse it instead of issuing
+    // another git-show round-trip.
+    const shortSha = completion.sha.slice(0, 8)
+    lines.push(h(Text, { key: 'bisect-complete-title', bold: true, color: accent },
+      truncateCells('✓ Bisect complete — first bad commit identified', width - 4)))
+    lines.push(h(Text, { key: 'bisect-complete-spacer-1' }, ''))
+
+    // Headline: short sha + subject, prominent.
+    const subjectText = completion.subject || candidateDetail?.message || '<subject unavailable>'
+    lines.push(h(Text, { key: 'bisect-complete-sha', bold: true },
+      truncateCells(`  ${shortSha}  ${subjectText}`, width - 4)))
+
+    if (candidateLoading) {
+      lines.push(h(Text, { key: 'bisect-complete-loading', dimColor: true },
+        truncateCells('  loading commit detail…', width - 4)))
+    } else if (candidateDetail) {
+      lines.push(h(Text, { key: 'bisect-complete-author', dimColor: true },
+        truncateCells(`  ${candidateDetail.author} · ${candidateDetail.date}`, width - 4)))
+      const { stats, files } = candidateDetail
+      lines.push(h(Text, { key: 'bisect-complete-stats' },
+        truncateCells(
+          `  ${stats.filesChanged} file${stats.filesChanged === 1 ? '' : 's'} · +${stats.insertions} / -${stats.deletions}`,
+          width - 4,
+        )))
+      const sampleFiles = files.slice(0, 3).map((file) => file.path)
+      if (sampleFiles.length > 0) {
+        const overflow = files.length > sampleFiles.length ? ` (+${files.length - sampleFiles.length} more)` : ''
+        lines.push(h(Text, { key: 'bisect-complete-files', dimColor: true },
+          truncateCells(`    ${sampleFiles.join(', ')}${overflow}`, width - 4)))
+      }
+    }
+
+    lines.push(h(Text, { key: 'bisect-complete-spacer-2' }, ''))
+    lines.push(h(Text, { key: 'bisect-complete-next-h', bold: true },
+      truncateCells('Next', width - 4)))
+    lines.push(h(Text, { key: 'bisect-complete-next-1' },
+      truncateCells('  y  yank short sha       x  reset / exit bisect', width - 4)))
+    lines.push(h(Text, { key: 'bisect-complete-next-2', dimColor: true },
+      truncateCells('  <  back to history      esc  back', width - 4)))
+    lines.push(h(Text, { key: 'bisect-complete-spacer-3' }, ''))
+    lines.push(h(Text, { key: 'bisect-complete-tip', dimColor: true },
+      truncateCells('Tip: `git bisect log > /tmp/replay` saves the session for later replay.', width - 4)))
   } else {
     // Active bisect. Three-section body: current candidate (sha +
     // commit summary so the user can judge the diff at a glance),
@@ -171,7 +225,8 @@ export function renderBisectSurface(
   },
   h(Box, { justifyContent: 'space-between' },
     h(Text, { bold: true }, panelTitle('Bisect', focused)),
-    h(Text, { dimColor: true }, bisect?.active ? 'BISECTING' : 'inactive')
+    h(Text, { dimColor: true },
+      completion ? 'COMPLETE' : bisect?.active ? 'BISECTING' : 'inactive')
   ),
   ...lines)
 }


### PR DESCRIPTION
## Summary
- Detect git's `# first bad commit:` terminator in BISECT_LOG and swap the bisect surface for a dedicated completion panel: prominent sha + subject, author/date/stats, "Next" hints (`y` yank, `x` reset, `<` back), and the `git bisect log > /tmp/replay` tip.
- Title-bar badge gains a third state: `inactive` → `BISECTING` → `COMPLETE`.
- `y`/`Y` on the bisect view yank the first-bad commit sha (full / short).

Re-implementation of #887, which got marked merged on GitHub but never landed on `main` (stacked PRs were merged into the parent feature branch instead of `main`).

## Test plan
- [x] `npx tsc --noEmit` → 0 errors
- [x] `npx jest` → 1471/1471 pass (6 new)
- [x] `npx eslint` on touched files → clean
- [ ] Manual: `git bisect start <bad> <good>` then mark good/bad until git emits the terminator; confirm panel renders, `y` yanks the sha, `x` resets.

Closes part of #879.