### PR TITLE
feat(log-tui): bisect run integration (#879 item 5)

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -927,6 +927,34 @@ describe('log Ink input interactions', () => {
     })
   })
 
+  it('R on an active bisect view opens the bisect-run-command prompt (#879 item 5)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'bisect' })
+
+    const events = getLogInkInputEvents(state, 'R', {}, { bisectActive: true })
+
+    const open = events.find(
+      (event) =>
+        event.type === 'action' &&
+        event.action.type === 'openInputPrompt' &&
+        event.action.kind === 'bisect-run-command'
+    )
+    expect(open).toBeDefined()
+  })
+
+  it('R on the empty bisect view (no active session) does nothing (#879 item 5)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'bisect' })
+
+    const events = getLogInkInputEvents(state, 'R', {}, { bisectActive: false })
+
+    expect(events.find((event) =>
+      event.type === 'action' &&
+      event.action.type === 'openInputPrompt' &&
+      event.action.kind === 'bisect-run-command'
+    )).toBeUndefined()
+  })
+
   it('x on the bisect view opens the y-confirm for reset (#784)', () => {
     let state = createLogInkState(rows)
     state = applyLogInkAction(state, { type: 'pushView', value: 'bisect' })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -702,6 +702,16 @@ function submitInputPrompt(state: LogInkState): LogInkInputEvent[] {
       action({ type: 'closeInputPrompt' }),
     ]
   }
+  if (state.inputPrompt.kind === 'bisect-run-command') {
+    // #879 item 5 — the typed command is the workflow payload. The
+    // runtime hands it to `git bisect run sh -c '<command>'` so shell
+    // features (pipes, env vars, flag-laden invocations) work as the
+    // user expects.
+    return [
+      { type: 'runWorkflowAction', id: 'bisect-run', payload: value },
+      action({ type: 'closeInputPrompt' }),
+    ]
+  }
   if (state.inputPrompt.kind === 'create-pr') {
     // Multi-line content: line 1 is the PR title, lines 2+ are the body
     // (leading blank line tolerated). The generic empty-value guard
@@ -1281,6 +1291,17 @@ export function getLogInkInputEvents(
     }
     if (inputValue === 'x') {
       return [action({ type: 'setPendingConfirmation', value: 'bisect-reset' })]
+    }
+    // #879 item 5 — `R` (capital) on an active bisect view opens an
+    // input prompt for a test command. Only fires when a session is
+    // active because `git bisect run` is meaningless otherwise. Lower-
+    // case `r` stays free for future view-local bindings.
+    if (inputValue === 'R' && context.bisectActive) {
+      return [action({
+        type: 'openInputPrompt',
+        kind: 'bisect-run-command',
+        label: 'Bisect run command (e.g. npm test, pytest -k regression)',
+      })]
     }
   }
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -760,7 +760,7 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
 
   if (options.activeView === 'bisect') {
     return {
-      contextual: ['g good', 'b bad', 's skip', 'x reset', 'esc back'],
+      contextual: ['g good', 'b bad', 's skip', 'R run', 'x reset', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -435,6 +435,7 @@ export type LogInkInputPromptKind =
   | 'pr-comment'
   | 'pr-request-changes'
   | 'create-pr'
+  | 'bisect-run-command'
 
 export type LogInkInputPromptState = {
   kind: LogInkInputPromptKind

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -520,6 +520,20 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: true,
     },
     {
+      // #879 item 5 — `git bisect run <cmd>` integration. Empty `key`
+      // because the supported entry is the input prompt fired by `R`
+      // on the active bisect view; palette execution wouldn't have a
+      // command payload to pass. `kind: 'normal'` because the loop is
+      // recoverable via `git bisect reset`. The prompt itself serves
+      // as the implicit confirmation.
+      id: 'bisect-run',
+      key: '',
+      label: 'Bisect: run command',
+      description: 'Drive the bisect via `git bisect run sh -c <command>` — exit code marks good/bad/skip.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
       // #879 item 4 — in-TUI bisect start wizard. Empty `key` keeps
       // the keybinding out of the global map; the supported entry
       // point is `s` on the bisect empty state, which fires the

--- a/src/git/bisectActions.test.ts
+++ b/src/git/bisectActions.test.ts
@@ -3,6 +3,7 @@ import {
   bisectBad,
   bisectGood,
   bisectReset,
+  bisectRun,
   bisectSkip,
   bisectStart,
   extractBisectRemainingHint,
@@ -47,6 +48,17 @@ describe('bisect action wrappers', () => {
     const git = { raw } as unknown as SimpleGit
     await bisectReset(git)
     expect(raw).toHaveBeenCalledWith(['bisect', 'reset'])
+  })
+
+  it('bisectRun invokes `git bisect run sh -c <command>` (#879 item 5)', async () => {
+    // The `sh -c` form lets users pass shell snippets (pipes, env
+    // vars, flag-laden invocations) without escaping into git's
+    // argv. Verifies the argv contract; the actual loop is git's
+    // responsibility.
+    const raw = jest.fn().mockResolvedValue('')
+    const git = { raw } as unknown as SimpleGit
+    await bisectRun(git, 'npm test -- --bail')
+    expect(raw).toHaveBeenCalledWith(['bisect', 'run', 'sh', '-c', 'npm test -- --bail'])
   })
 })
 

--- a/src/git/bisectActions.ts
+++ b/src/git/bisectActions.ts
@@ -45,6 +45,26 @@ export async function bisectReset(git: SimpleGit): Promise<string> {
 }
 
 /**
+ * Drive an automated bisect run via `git bisect run sh -c '<command>'`
+ * (#879 item 5). Git handles the per-candidate loop itself, running
+ * the command for each commit and interpreting the exit code:
+ *
+ *   0       → mark good
+ *   125     → skip (untestable, e.g. doesn't build)
+ *   1..127  → mark bad (any non-zero except 125)
+ *   128+    → abort (SIGSEGV, killed, etc.)
+ *
+ * The `sh -c` form lets the user pass shell snippets (pipes, env
+ * vars, flag-laden test invocations) without escaping into git's
+ * argv. Runs synchronously from the runtime's perspective — git
+ * blocks until the run terminates and we surface the final result
+ * (typically "<sha> is the first bad commit") via the status line.
+ */
+export async function bisectRun(git: SimpleGit, command: string): Promise<string> {
+  return git.raw(['bisect', 'run', 'sh', '-c', command])
+}
+
+/**
  * Pull the user-facing remaining-revisions hint out of `git bisect`
  * stdout. Looks for the canonical line:
  *

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -272,7 +272,7 @@ import {
     unstageHunk,
 } from '../../git/statusHunks'
 import { getBisectCompletion, getBisectStatus } from '../../git/bisectData'
-import { bisectBad, bisectGood, bisectReset, bisectSkip, bisectStart, extractBisectRemainingHint } from '../../git/bisectActions'
+import { bisectBad, bisectGood, bisectReset, bisectRun, bisectSkip, bisectStart, extractBisectRemainingHint } from '../../git/bisectActions'
 import { getCompareDiff } from '../../git/compareData'
 import { getReflogOverview } from '../../git/reflogData'
 import { getTagOverview } from '../../git/tagData'
@@ -1978,6 +1978,27 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
           return { ok: true, message: 'Bisect reset' }
         } catch (error) {
           return { ok: false, message: `Bisect reset failed: ${(error as Error).message}` }
+        }
+      },
+      'bisect-run': async () => {
+        // #879 item 5 — drive an automated bisect via `git bisect run
+        // sh -c '<command>'`. Synchronous from our perspective: git
+        // runs the loop, blocks until termination, then we surface
+        // the last meaningful line of stdout (typically "<sha> is
+        // the first bad commit") via the status line. Live streaming
+        // + cancel mid-run is a follow-up.
+        if (!context.bisect?.active) return { ok: false, message: 'No bisect in progress' }
+        const command = payload?.trim()
+        if (!command) return { ok: false, message: 'Bisect run needs a command' }
+        try {
+          const stdout = await bisectRun(git, command)
+          await refreshContext({ silent: true })
+          return {
+            ok: true,
+            message: extractBisectRemainingHint(stdout) || `Bisect run finished (${command})`,
+          }
+        } catch (error) {
+          return { ok: false, message: `Bisect run failed: ${(error as Error).message}` }
         }
       },
       'bisect-start-from-history': async () => {

--- a/src/workstation/surfaces/bisect/index.ts
+++ b/src/workstation/surfaces/bisect/index.ts
@@ -213,7 +213,7 @@ export function renderBisectSurface(
 
     lines.push(h(Text, { key: 'bisect-action-spacer' }, ''))
     lines.push(h(Text, { key: 'bisect-action-hint', dimColor: true },
-      truncateCells('Actions: g good · b bad · s skip · x reset', width - 4)))
+      truncateCells('Actions: g good · b bad · s skip · R run · x reset', width - 4)))
   }
 
   return h(Box, {


### PR DESCRIPTION
## Summary
- New \`R\` keystroke on the active bisect view opens an input prompt for a test command, then runs \`git bisect run sh -c '<command>'\`. Git handles the per-candidate loop and exit-code → good/bad/skip mapping.
- \`sh -c\` wrapper lets users pass shell snippets (pipes, env vars, flag-laden invocations) without escaping.
- Footer + surface action hint advertise \`R run\`.

Re-implementation of #889 (never landed on \`main\`).

## Test plan
- [x] \`npx tsc --noEmit\` → 0 errors
- [x] \`npx jest\` → 1477/1477 pass (3 new)
- [x] \`npx eslint\` on touched files → clean
- [ ] Manual: with an active bisect, press \`R\`, type a fast test command (e.g. \`true\`), confirm git iterates through the candidates and emits a "first bad commit" line.

Closes part of #879.