### PR TITLE
feat(log-tui): collapse LFS pointer diffs to a one-line summary (#884)

### DIFF
--- a/src/commands/log/data.ts
+++ b/src/commands/log/data.ts
@@ -1,4 +1,5 @@
 import { SimpleGit } from 'simple-git'
+import { extractLfsPatchChange, renderLfsSummary } from '../../git/lfsPointer'
 import { LogArgv, LogView } from './config'
 
 export const FIELD_SEPARATOR = '\x1f'
@@ -383,6 +384,15 @@ export async function getCommitFilePreview(
     ))
     .slice(0, limit)
 
+  // #884 — replace the noisy pointer-body hunks for LFS-tracked files
+  // with a one-line summary. The pointer format is recognizable
+  // directly from the patch content, so no `.gitattributes` parsing
+  // or `git lfs` subprocess is required for this win.
+  const lfsChange = extractLfsPatchChange(hunks)
+  const finalHunks = lfsChange
+    ? [renderLfsSummary(lfsChange)]
+    : hunks
+
   return {
     path: file.path,
     oldPath: file.oldPath,
@@ -391,6 +401,6 @@ export async function getCommitFilePreview(
       binary: file.binary,
       deletions: file.deletions,
     },
-    hunks,
+    hunks: finalHunks,
   }
 }

--- a/src/git/lfsPointer.test.ts
+++ b/src/git/lfsPointer.test.ts
@@ -1,0 +1,165 @@
+import {
+  extractLfsPatchChange,
+  parseLfsPointer,
+  renderLfsSummary,
+} from './lfsPointer'
+
+describe('parseLfsPointer', () => {
+  const VALID_POINTER = [
+    'version https://git-lfs.github.com/spec/v1',
+    'oid sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+    'size 12345',
+    '',
+  ].join('\n')
+
+  it('returns the oid + size from a well-formed pointer body', () => {
+    expect(parseLfsPointer(VALID_POINTER)).toEqual({
+      oid: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+      size: 12345,
+    })
+  })
+
+  it('returns undefined when the version line is missing', () => {
+    const noVersion = [
+      'oid sha256:1234567890abcdef',
+      'size 12345',
+    ].join('\n')
+    expect(parseLfsPointer(noVersion)).toBeUndefined()
+  })
+
+  it('returns undefined when the oid is missing', () => {
+    const noOid = [
+      'version https://git-lfs.github.com/spec/v1',
+      'size 12345',
+    ].join('\n')
+    expect(parseLfsPointer(noOid)).toBeUndefined()
+  })
+
+  it('returns undefined when the size is missing or non-numeric', () => {
+    const noSize = [
+      'version https://git-lfs.github.com/spec/v1',
+      'oid sha256:abc',
+    ].join('\n')
+    expect(parseLfsPointer(noSize)).toBeUndefined()
+
+    const badSize = [
+      'version https://git-lfs.github.com/spec/v1',
+      'oid sha256:abc',
+      'size not-a-number',
+    ].join('\n')
+    expect(parseLfsPointer(badSize)).toBeUndefined()
+  })
+
+  it('rejects bodies that are too large to be pointer files', () => {
+    // Pointer files are ~130 bytes. Reject anything that's clearly
+    // a regular file with the version marker buried in it, to avoid
+    // scanning megabytes of source code.
+    const huge = `${'x'.repeat(2048)}\nversion https://git-lfs.github.com/spec/v1\noid sha256:abc\nsize 1`
+    expect(parseLfsPointer(huge)).toBeUndefined()
+  })
+})
+
+describe('extractLfsPatchChange', () => {
+  const POINTER_LINES = [
+    'version https://git-lfs.github.com/spec/v1',
+    'oid sha256:1111111111111111111111111111111111111111111111111111111111111111',
+    'size 1024',
+  ]
+  const NEW_POINTER_LINES = [
+    'version https://git-lfs.github.com/spec/v1',
+    'oid sha256:2222222222222222222222222222222222222222222222222222222222222222',
+    'size 2048',
+  ]
+
+  it('detects a newly-added LFS file', () => {
+    const patch = [
+      '@@ -0,0 +1,3 @@',
+      ...POINTER_LINES.map((line) => `+${line}`),
+    ]
+    const change = extractLfsPatchChange(patch)
+    expect(change?.kind).toBe('added')
+    if (change?.kind === 'added') {
+      expect(change.after.size).toBe(1024)
+      expect(change.after.oid).toMatch(/^1+$/)
+    }
+  })
+
+  it('detects a removed LFS file', () => {
+    const patch = [
+      '@@ -1,3 +0,0 @@',
+      ...POINTER_LINES.map((line) => `-${line}`),
+    ]
+    const change = extractLfsPatchChange(patch)
+    expect(change?.kind).toBe('removed')
+  })
+
+  it('detects an LFS pointer rev (modify) carrying both before and after', () => {
+    const patch = [
+      '@@ -1,3 +1,3 @@',
+      ...POINTER_LINES.map((line) => `-${line}`),
+      ...NEW_POINTER_LINES.map((line) => `+${line}`),
+    ]
+    const change = extractLfsPatchChange(patch)
+    expect(change?.kind).toBe('modified')
+    if (change?.kind === 'modified') {
+      expect(change.before.size).toBe(1024)
+      expect(change.after.size).toBe(2048)
+    }
+  })
+
+  it('returns undefined for a normal (non-LFS) patch', () => {
+    const patch = [
+      '@@ -1,3 +1,3 @@',
+      ' context line',
+      '-old line',
+      '+new line',
+    ]
+    expect(extractLfsPatchChange(patch)).toBeUndefined()
+  })
+
+  it('ignores `---` / `+++` header lines so they do not corrupt parsing', () => {
+    // The file-preview loader already strips these in some paths but
+    // not all; the extractor must not treat them as additions /
+    // deletions.
+    const patch = [
+      '--- a/asset.bin',
+      '+++ b/asset.bin',
+      '@@ -1,3 +1,3 @@',
+      ...POINTER_LINES.map((line) => `-${line}`),
+      ...NEW_POINTER_LINES.map((line) => `+${line}`),
+    ]
+    expect(extractLfsPatchChange(patch)?.kind).toBe('modified')
+  })
+})
+
+describe('renderLfsSummary', () => {
+  it('formats added pointers with shortened oid + human size', () => {
+    expect(renderLfsSummary({
+      kind: 'added',
+      after: { oid: '1234567890abcdef', size: 1024 * 1024 * 5 },
+    })).toBe('binary file added (LFS): 12345678…, 5.0 MB')
+  })
+
+  it('formats removed pointers symmetrically', () => {
+    expect(renderLfsSummary({
+      kind: 'removed',
+      before: { oid: 'abcdef1234567890', size: 512 },
+    })).toBe('binary file removed (LFS): abcdef12…, 512 B')
+  })
+
+  it('formats modifications with both oids and both sizes', () => {
+    const out = renderLfsSummary({
+      kind: 'modified',
+      before: { oid: '1111111111111111', size: 1024 },
+      after: { oid: '2222222222222222', size: 2048 },
+    })
+    expect(out).toBe('binary file modified (LFS): 11111111… → 22222222…, 1.0 KB → 2.0 KB')
+  })
+
+  it('keeps the full oid when it is already short', () => {
+    expect(renderLfsSummary({
+      kind: 'added',
+      after: { oid: 'abc', size: 100 },
+    })).toBe('binary file added (LFS): abc, 100 B')
+  })
+})

--- a/src/git/lfsPointer.ts
+++ b/src/git/lfsPointer.ts
@@ -1,0 +1,137 @@
+/**
+ * Git LFS pointer parsing + diff summarization (#884).
+ *
+ * Without this layer, an LFS pointer file renders in the TUI as
+ * a few lines of meaningless metadata (the pointer's text form):
+ *
+ *     version https://git-lfs.github.com/spec/v1
+ *     oid sha256:1234567890abcdef…
+ *     size 12345
+ *
+ * That's technically the file's content — git LFS substitutes
+ * pointers for the real binary blob — but it's useless to a human
+ * looking at a "binary file changed" event. This module detects
+ * pointer files and produces a one-line replacement summary
+ * ("binary file (LFS): <oid>, <size> bytes") that the surface
+ * can swap in for the noisy hunk lines.
+ *
+ * The detection is purely textual — no `git lfs` subprocess, no
+ * `.gitattributes` parsing. The pointer format is well-defined,
+ * deterministic, and embedded directly in the diff content, so
+ * the parser is the single source of truth. `.gitattributes`-based
+ * detection (for "is this path LFS-tracked even when unmodified?")
+ * is a separate concern handled by a follow-up.
+ */
+
+const POINTER_VERSION_PREFIX = 'version https://git-lfs.github.com/spec/v1'
+const OID_PREFIX = 'oid sha256:'
+const SIZE_PREFIX = 'size '
+
+export type LfsPointer = {
+  /** sha256 OID of the underlying binary (no `sha256:` prefix). */
+  oid: string
+  /** Byte size of the underlying binary, as recorded in the pointer. */
+  size: number
+}
+
+/**
+ * Parse a raw pointer-file body into structured data, or return
+ * undefined when the body isn't a recognized pointer. Tolerates
+ * trailing newlines and whitespace; requires the canonical
+ * version + oid + size triple in any order (real LFS pointers
+ * always emit them in that order, but defensive parsing keeps
+ * downstream surfaces robust against odd line endings or future
+ * fields).
+ */
+export function parseLfsPointer(text: string): LfsPointer | undefined {
+  // Pointer files are always small (~130 bytes); reject anything
+  // that's clearly too large to be a pointer to avoid scanning
+  // megabytes of source code looking for the version prefix.
+  if (text.length > 1024) return undefined
+
+  const lines = text.split('\n').map((line) => line.trim())
+  if (!lines.some((line) => line === POINTER_VERSION_PREFIX)) return undefined
+
+  let oid: string | undefined
+  let size: number | undefined
+  for (const line of lines) {
+    if (line.startsWith(OID_PREFIX)) {
+      oid = line.slice(OID_PREFIX.length).trim()
+    } else if (line.startsWith(SIZE_PREFIX)) {
+      const parsed = Number.parseInt(line.slice(SIZE_PREFIX.length).trim(), 10)
+      if (Number.isFinite(parsed) && parsed >= 0) size = parsed
+    }
+  }
+  if (!oid || size === undefined) return undefined
+
+  return { oid, size }
+}
+
+export type LfsPatchChange =
+  | { kind: 'added'; after: LfsPointer }
+  | { kind: 'removed'; before: LfsPointer }
+  | { kind: 'modified'; before: LfsPointer; after: LfsPointer }
+
+/**
+ * Scan a `git diff`'s addition / deletion lines to identify when
+ * the patch is just an LFS pointer change. Returns the structured
+ * before/after pointers when detected, or undefined for normal
+ * (non-LFS) patches.
+ *
+ * Accepts the raw diff lines (the same shape `getCommitFilePreview`
+ * already produces) and ignores hunk headers / context lines.
+ * Three cases:
+ *
+ *   - **added**    : only `+`-prefixed pointer body lines (new LFS file)
+ *   - **removed**  : only `-`-prefixed pointer body lines (deleted LFS file)
+ *   - **modified** : both `-` and `+` pointer bodies (LFS content rev'd)
+ */
+export function extractLfsPatchChange(lines: string[]): LfsPatchChange | undefined {
+  const additions: string[] = []
+  const deletions: string[] = []
+  for (const line of lines) {
+    if (line.startsWith('+++') || line.startsWith('---')) continue
+    if (line.startsWith('+')) additions.push(line.slice(1))
+    else if (line.startsWith('-')) deletions.push(line.slice(1))
+  }
+
+  const after = additions.length > 0 ? parseLfsPointer(additions.join('\n')) : undefined
+  const before = deletions.length > 0 ? parseLfsPointer(deletions.join('\n')) : undefined
+
+  if (after && before) return { kind: 'modified', before, after }
+  if (after) return { kind: 'added', after }
+  if (before) return { kind: 'removed', before }
+  return undefined
+}
+
+/**
+ * Format a `LfsPatchChange` as a one-line human-readable summary
+ * suitable for swapping into the diff renderer in place of the
+ * noisy pointer-body hunks. The output is intentionally terse —
+ * surfaces add their own framing.
+ *
+ * Examples:
+ *   `binary file added (LFS): 1234567a…, 12.3 MB`
+ *   `binary file modified (LFS): 1234567a… → 89abcdef…, 12.3 MB → 14.1 MB`
+ *   `binary file removed (LFS): 1234567a…, 12.3 MB`
+ */
+export function renderLfsSummary(change: LfsPatchChange): string {
+  if (change.kind === 'added') {
+    return `binary file added (LFS): ${shortenOid(change.after.oid)}, ${humanSize(change.after.size)}`
+  }
+  if (change.kind === 'removed') {
+    return `binary file removed (LFS): ${shortenOid(change.before.oid)}, ${humanSize(change.before.size)}`
+  }
+  return `binary file modified (LFS): ${shortenOid(change.before.oid)} → ${shortenOid(change.after.oid)}, ${humanSize(change.before.size)} → ${humanSize(change.after.size)}`
+}
+
+function shortenOid(oid: string): string {
+  return oid.length > 8 ? `${oid.slice(0, 8)}…` : oid
+}
+
+function humanSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`
+}

--- a/src/git/worktreeDiffData.ts
+++ b/src/git/worktreeDiffData.ts
@@ -1,4 +1,5 @@
 import { SimpleGit } from 'simple-git'
+import { extractLfsPatchChange, renderLfsSummary } from './lfsPointer'
 import { WorktreeFile } from './statusData'
 
 export type WorktreeFileDiff = {
@@ -12,11 +13,17 @@ export type WorktreeFileDiff = {
 
 function sectionLines(title: string, diff: string): string[] {
   const lines = diff.split('\n').map((line) => line.trimEnd())
+  const body = lines.filter(Boolean)
 
-  return [
-    title,
-    ...lines.filter(Boolean),
-  ]
+  // #884 — replace pointer-body hunks for LFS-tracked files with a
+  // single human-readable summary. Operates on the post-trim body so
+  // the rest of the section (title + structure) is preserved.
+  const lfsChange = extractLfsPatchChange(body)
+  if (lfsChange) {
+    return [title, renderLfsSummary(lfsChange)]
+  }
+
+  return [title, ...body]
 }
 
 export async function getWorktreeFileDiff(


### PR DESCRIPTION
## Summary
- New \`src/git/lfsPointer.ts\` module parses LFS pointer text and extracts before/after pointers from patch lines (added / removed / modified).
- \`getCommitFilePreview\` and \`getWorktreeFileDiff\` swap pointer-body hunks for a one-liner like \`binary file modified (LFS): 12345678… → abcdef12…, 5.0 MB → 6.2 MB\`.
- Detection is purely textual — no \`git lfs\` subprocess, no \`.gitattributes\` parsing.

First slice of #884. The "LFS badge on file rows" piece (which needs \`.gitattributes\` detection so unmodified-but-tracked rows can also be flagged) is a follow-up. Submodule awareness is a separate PR.

## Test plan
- [x] \`npx tsc --noEmit\` → 0 errors
- [x] \`npx jest\` → 1491/1491 pass (14 new)
- [x] \`npx eslint\` on touched files → clean
- [ ] Manual: in a repo with an LFS-tracked file, open a commit that modifies it and confirm the diff renders the one-line summary instead of the pointer body.

Refs #884.