### PR TITLE
feat(log-tui): collapse submodule diffs to a one-line summary (#884)

### DIFF
--- a/src/commands/log/data.ts
+++ b/src/commands/log/data.ts
@@ -1,5 +1,6 @@
 import { SimpleGit } from 'simple-git'
 import { extractLfsPatchChange, renderLfsSummary } from '../../git/lfsPointer'
+import { extractSubmoduleChange, renderSubmoduleSummary } from '../../git/submoduleDiff'
 import { LogArgv, LogView } from './config'
 
 export const FIELD_SEPARATOR = '\x1f'
@@ -384,14 +385,18 @@ export async function getCommitFilePreview(
     ))
     .slice(0, limit)
 
-  // #884 — replace the noisy pointer-body hunks for LFS-tracked files
-  // with a one-line summary. The pointer format is recognizable
-  // directly from the patch content, so no `.gitattributes` parsing
-  // or `git lfs` subprocess is required for this win.
+  // #884 — replace LFS pointer hunks and submodule "Subproject
+  // commit" hunks with one-line summaries. Both detections are
+  // mutually exclusive (a file is either LFS-tracked or a
+  // submodule, never both) so the priority order doesn't matter;
+  // we check LFS first because the pattern is more specific.
   const lfsChange = extractLfsPatchChange(hunks)
+  const submoduleChange = lfsChange ? undefined : extractSubmoduleChange(hunks)
   const finalHunks = lfsChange
     ? [renderLfsSummary(lfsChange)]
-    : hunks
+    : submoduleChange
+      ? [renderSubmoduleSummary(submoduleChange)]
+      : hunks
 
   return {
     path: file.path,

--- a/src/git/submoduleDiff.test.ts
+++ b/src/git/submoduleDiff.test.ts
@@ -1,0 +1,112 @@
+import { extractSubmoduleChange, renderSubmoduleSummary } from './submoduleDiff'
+
+describe('extractSubmoduleChange', () => {
+  it('detects a submodule modification (most common case)', () => {
+    const patch = [
+      'diff --git a/vendor/sub b/vendor/sub',
+      '--- a/vendor/sub',
+      '+++ b/vendor/sub',
+      '@@ -1 +1 @@',
+      '-Subproject commit 1111111111111111111111111111111111111111',
+      '+Subproject commit 2222222222222222222222222222222222222222',
+    ]
+    const change = extractSubmoduleChange(patch)
+    expect(change?.kind).toBe('modified')
+    if (change?.kind === 'modified') {
+      expect(change.before).toMatch(/^1+$/)
+      expect(change.after).toMatch(/^2+$/)
+    }
+  })
+
+  it('detects a newly-added submodule', () => {
+    const patch = [
+      '@@ -0,0 +1 @@',
+      '+Subproject commit 1234567890abcdef1234567890abcdef12345678',
+    ]
+    const change = extractSubmoduleChange(patch)
+    expect(change?.kind).toBe('added')
+    if (change?.kind === 'added') {
+      expect(change.after.slice(0, 4)).toBe('1234')
+    }
+  })
+
+  it('detects a removed submodule', () => {
+    const patch = [
+      '@@ -1 +0,0 @@',
+      '-Subproject commit abcdef1234567890abcdef1234567890abcdef12',
+    ]
+    const change = extractSubmoduleChange(patch)
+    expect(change?.kind).toBe('removed')
+  })
+
+  it('returns undefined for a normal (non-submodule) patch', () => {
+    const patch = [
+      '@@ -1,3 +1,3 @@',
+      ' context line',
+      '-old line',
+      '+new line',
+    ]
+    expect(extractSubmoduleChange(patch)).toBeUndefined()
+  })
+
+  it('ignores `---` / `+++` header lines so they do not corrupt parsing', () => {
+    // Defensive: the loader contract sometimes preserves diff
+    // headers in the lines array. They must not be misread as
+    // additions / deletions.
+    const patch = [
+      '--- a/vendor/sub',
+      '+++ b/vendor/sub',
+      '-Subproject commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      '+Subproject commit bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    ]
+    expect(extractSubmoduleChange(patch)?.kind).toBe('modified')
+  })
+
+  it('handles whitespace after the sha gracefully', () => {
+    const patch = [
+      '-Subproject commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  ',
+      '+Subproject commit bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    ]
+    const change = extractSubmoduleChange(patch)
+    expect(change?.kind).toBe('modified')
+    if (change?.kind === 'modified') {
+      // Trailing whitespace must not contaminate the parsed sha.
+      expect(change.before).toMatch(/^a+$/)
+    }
+  })
+})
+
+describe('renderSubmoduleSummary', () => {
+  it('formats added submodules', () => {
+    expect(renderSubmoduleSummary({
+      kind: 'added',
+      after: '1234567890abcdef1234567890abcdef12345678',
+    })).toBe('submodule added: 12345678…')
+  })
+
+  it('formats removed submodules', () => {
+    expect(renderSubmoduleSummary({
+      kind: 'removed',
+      before: 'abcdef1234567890abcdef1234567890abcdef12',
+    })).toBe('submodule removed: abcdef12…')
+  })
+
+  it('formats modifications with both shas', () => {
+    const out = renderSubmoduleSummary({
+      kind: 'modified',
+      before: '1111111111111111111111111111111111111111',
+      after: '2222222222222222222222222222222222222222',
+    })
+    expect(out).toBe('submodule modified: 11111111… → 22222222…')
+  })
+
+  it('does not truncate short shas (defensive)', () => {
+    // Theoretical: a tiny sha shouldn't get an ellipsis. Real-world
+    // submodule pointers are always full 40-char shas, but the
+    // renderer should still handle the edge.
+    expect(renderSubmoduleSummary({
+      kind: 'added',
+      after: 'abc',
+    })).toBe('submodule added: abc')
+  })
+})

--- a/src/git/submoduleDiff.ts
+++ b/src/git/submoduleDiff.ts
@@ -1,0 +1,82 @@
+/**
+ * Submodule diff summarization (#884).
+ *
+ * Submodule changes render in `git diff` as a two-line gist:
+ *
+ *     -Subproject commit abcdef1234567890…
+ *     +Subproject commit 1234567890abcdef…
+ *
+ * That's accurate but uninformative — the user can't tell what
+ * the submodule actually points at, just that the SHA changed.
+ * This module detects those patches and produces a one-line
+ * replacement summary the surface can swap in.
+ *
+ * Detection is purely textual — no `git submodule` subprocess
+ * required for the patch-level rewrite. The richer side-panel
+ * inspector (submodule name · branch · HEAD message) needs
+ * `git submodule status` and `.gitmodules` parsing; that's a
+ * follow-up.
+ */
+
+const SUBPROJECT_PREFIX = 'Subproject commit '
+
+export type SubmoduleChange =
+  | { kind: 'added'; after: string }
+  | { kind: 'removed'; before: string }
+  | { kind: 'modified'; before: string; after: string }
+
+/**
+ * Scan a `git diff`'s addition / deletion lines for the
+ * `Subproject commit <sha>` markers that signify a submodule
+ * change. Returns the before / after pinned shas when detected,
+ * undefined for normal patches.
+ *
+ * A submodule patch typically contains exactly one or two of
+ * these markers (one for the old pinned commit, one for the new).
+ * Both forms exist:
+ *   - **added**    : `+Subproject commit …`  (submodule newly registered)
+ *   - **removed**  : `-Subproject commit …`  (submodule unregistered)
+ *   - **modified** : one of each              (most common case)
+ */
+export function extractSubmoduleChange(lines: string[]): SubmoduleChange | undefined {
+  let after: string | undefined
+  let before: string | undefined
+
+  for (const line of lines) {
+    if (line.startsWith('+++') || line.startsWith('---')) continue
+    if (line.startsWith('+') && line.slice(1).startsWith(SUBPROJECT_PREFIX)) {
+      after = line.slice(1 + SUBPROJECT_PREFIX.length).trim()
+    } else if (line.startsWith('-') && line.slice(1).startsWith(SUBPROJECT_PREFIX)) {
+      before = line.slice(1 + SUBPROJECT_PREFIX.length).trim()
+    }
+  }
+
+  if (before && after) return { kind: 'modified', before, after }
+  if (after) return { kind: 'added', after }
+  if (before) return { kind: 'removed', before }
+  return undefined
+}
+
+/**
+ * Format a `SubmoduleChange` as a one-line human-readable summary.
+ * Examples:
+ *   `submodule added: 1234567a…`
+ *   `submodule modified: 1234567a… → abcdef12…`
+ *   `submodule removed: 1234567a…`
+ */
+export function renderSubmoduleSummary(change: SubmoduleChange): string {
+  if (change.kind === 'added') {
+    return `submodule added: ${shortenSha(change.after)}`
+  }
+  if (change.kind === 'removed') {
+    return `submodule removed: ${shortenSha(change.before)}`
+  }
+  return `submodule modified: ${shortenSha(change.before)} → ${shortenSha(change.after)}`
+}
+
+function shortenSha(sha: string): string {
+  // `Subproject commit` lines carry full 40-char shas. Trim to 8
+  // (the same short-hash convention the rest of the TUI uses) and
+  // add an ellipsis so the user knows it's truncated.
+  return sha.length > 8 ? `${sha.slice(0, 8)}…` : sha
+}

--- a/src/git/worktreeDiffData.ts
+++ b/src/git/worktreeDiffData.ts
@@ -1,5 +1,6 @@
 import { SimpleGit } from 'simple-git'
 import { extractLfsPatchChange, renderLfsSummary } from './lfsPointer'
+import { extractSubmoduleChange, renderSubmoduleSummary } from './submoduleDiff'
 import { WorktreeFile } from './statusData'
 
 export type WorktreeFileDiff = {
@@ -15,12 +16,17 @@ function sectionLines(title: string, diff: string): string[] {
   const lines = diff.split('\n').map((line) => line.trimEnd())
   const body = lines.filter(Boolean)
 
-  // #884 — replace pointer-body hunks for LFS-tracked files with a
-  // single human-readable summary. Operates on the post-trim body so
-  // the rest of the section (title + structure) is preserved.
+  // #884 — replace pointer-body hunks (LFS) and `Subproject commit`
+  // hunks (submodules) with one-line summaries. Both are checked
+  // in priority order; mutually exclusive in practice (a file is
+  // either LFS-tracked or a submodule path, never both).
   const lfsChange = extractLfsPatchChange(body)
   if (lfsChange) {
     return [title, renderLfsSummary(lfsChange)]
+  }
+  const submoduleChange = extractSubmoduleChange(body)
+  if (submoduleChange) {
+    return [title, renderSubmoduleSummary(submoduleChange)]
   }
 
   return [title, ...body]


### PR DESCRIPTION
## Summary
- New \`src/git/submoduleDiff.ts\` module recognizes \`Subproject commit <sha>\` patch lines and emits a structured \`SubmoduleChange\` (added / removed / modified).
- \`getCommitFilePreview\` and \`getWorktreeFileDiff\` swap the raw \`-Subproject commit … / +Subproject commit …\` rows for a one-liner like \`submodule modified: 11111111… → 22222222…\`.
- Detection is purely textual — no \`git submodule\` subprocess or \`.gitmodules\` parsing required for this slice.

Second slice of #884. The richer side-panel inspector (submodule name · branch · HEAD message) and the "Enter to drill into the submodule's history" navigation remain for a follow-up — those need \`git submodule status\` plus a recursive context loader.

## Test plan
- [x] \`npx tsc --noEmit\` → 0 errors
- [x] \`npx jest\` → 1501/1501 pass (10 new)
- [x] \`npx eslint\` on touched files → clean
- [ ] Manual: in a repo with a submodule, open a commit that bumps its pinned sha and confirm the diff renders the one-line summary instead of the \`Subproject commit …\` lines.

Refs #884.