### PR TITLE
fix(split): post-apply navigation, chord overlay collision, and missing-files rescue

### DIFF
--- a/src/commands/commands.integration.test.ts
+++ b/src/commands/commands.integration.test.ts
@@ -511,14 +511,19 @@ describe('command integration with temp git repos', () => {
       mode: 'stdout',
     }))
 
-    // First attempt drops src/feature.ts entirely; retry covers both files.
+    // First attempt references a file that's NOT in the staged set
+    // (unknownFiles validator error — no rescue available). Retry
+    // covers both real files. Previously this test used "first
+    // attempt drops a file" but rescueMissingFiles now auto-recovers
+    // that case in a single attempt — to actually exercise the retry
+    // loop we need a non-rescuable invalidation.
     mockExecuteChainWithSchema
       .mockResolvedValueOnce({
         groups: [
           {
             title: 'docs: update readme',
             body: 'Document the temp repo.',
-            files: ['README.md'],
+            files: ['README.md', 'ghost.ts'],
             hunks: [],
           },
         ],
@@ -572,8 +577,8 @@ describe('command integration with temp git repos', () => {
     const secondCallVars = mockExecuteChainWithSchema.mock.calls[1][3] as Record<string, string>
 
     expect(firstCallVars.previous_attempt_feedback).toContain('first attempt')
-    expect(secondCallVars.previous_attempt_feedback).toContain('Staged files missing')
-    expect(secondCallVars.previous_attempt_feedback).toContain('src/feature.ts')
+    expect(secondCallVars.previous_attempt_feedback).toContain('NOT in the staged file inventory')
+    expect(secondCallVars.previous_attempt_feedback).toContain('ghost.ts')
     expect(stdout).toContain('docs: update readme')
     expect(stdout).toContain('test: add feature fixture')
   })
@@ -583,12 +588,15 @@ describe('command integration with temp git repos', () => {
       mode: 'stdout',
     }))
 
+    // unknownFiles invalidation (no rescue available) — guarantees
+    // retries actually exhaust. A missing-file invalidation would be
+    // auto-rescued on attempt 1.
     mockExecuteChainWithSchema.mockResolvedValue({
       groups: [
         {
           title: 'docs: update readme',
           body: 'Document the temp repo.',
-          files: ['README.md'],
+          files: ['README.md', 'ghost.ts'],
           hunks: [],
         },
       ],
@@ -620,7 +628,7 @@ describe('command integration with temp git repos', () => {
         version: false,
         help: false,
       } as Arguments<CommitOptions>, createLogger())
-    ).rejects.toThrow(/after 3 attempts.*missing files: src\/feature\.ts/i)
+    ).rejects.toThrow(/after 3 attempts.*unknown files: ghost\.ts/i)
 
     expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(3)
   })

--- a/src/commands/commit/splitPlanGenerator.test.ts
+++ b/src/commands/commit/splitPlanGenerator.test.ts
@@ -57,8 +57,15 @@ describe('generateValidatedCommitSplitPlan', () => {
   })
 
   it('feeds validator complaints back into a retry attempt and succeeds', async () => {
+    // Uses an `unknownFiles` invalidation — that error has no rescue
+    // function, so the retry loop is the only path to a valid plan.
+    // (Missing-files was the original invalidation but rescueMissingFiles
+    // now auto-recovers that case in a single attempt.)
     const invalidPlan: CommitSplitPlan = {
-      groups: [{ title: 'a', files: ['a.ts'], hunks: [] }],
+      groups: [
+        { title: 'a', files: ['a.ts'], hunks: [] },
+        { title: 'b', files: ['ghost.ts'], hunks: [] },
+      ],
     }
     const validPlan: CommitSplitPlan = {
       groups: [
@@ -75,9 +82,9 @@ describe('generateValidatedCommitSplitPlan', () => {
 
     expect(result.attempts).toBe(2)
     // toStrictEqual rather than toBe — the generator now passes the
-    // raw plan through rescuePhantomHunks which returns a new object,
-    // so reference equality no longer holds. The semantic content is
-    // identical when the plan has no phantom hunks to rescue.
+    // raw plan through rescue passes which return new objects, so
+    // reference equality no longer holds. Semantic content is
+    // identical when there's nothing to rescue.
     expect(result.plan).toStrictEqual(validPlan)
     expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(2)
 
@@ -85,8 +92,8 @@ describe('generateValidatedCommitSplitPlan', () => {
     const secondCallVars = mockExecuteChainWithSchema.mock.calls[1][3] as Record<string, unknown>
 
     expect(firstCallVars.previous_attempt_feedback).toBe(NO_PREVIOUS_FEEDBACK_PLACEHOLDER)
-    expect(String(secondCallVars.previous_attempt_feedback)).toContain('Staged files missing')
-    expect(String(secondCallVars.previous_attempt_feedback)).toContain('b.ts')
+    expect(String(secondCallVars.previous_attempt_feedback)).toContain('NOT in the staged file inventory')
+    expect(String(secondCallVars.previous_attempt_feedback)).toContain('ghost.ts')
   })
 
   it('rescues phantom hunks before validation when the inventory is empty', async () => {
@@ -151,22 +158,55 @@ describe('generateValidatedCommitSplitPlan', () => {
     expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(1)
   })
 
+  it('rescues missing files by appending a misc group (#921 regression)', async () => {
+    // Exact pattern from #921 manual testing: LLM omits a staged file
+    // from every group (the post-apply screenshot showed scratch.md
+    // missing). Validator's missingFiles rejected for 3 attempts.
+    // With rescueMissingFiles, the same output validates on attempt 1.
+    const incompletePlan: CommitSplitPlan = {
+      groups: [
+        { title: 'feat: a', files: ['a.ts'], hunks: [] },
+        // b.ts omitted entirely.
+      ],
+    }
+    mockExecuteChainWithSchema.mockResolvedValueOnce(incompletePlan)
+
+    const result = await generateValidatedCommitSplitPlan(baseArgs())
+
+    expect(result.attempts).toBe(1)
+    expect(result.plan.groups).toHaveLength(2)
+    expect(result.plan.groups[1].files).toEqual(['b.ts'])
+    expect(result.plan.groups[1].title).toContain('misc')
+    expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(1)
+  })
+
   it('throws after exhausting retries with the final validator complaints in the message', async () => {
+    // Uses unknownFiles (no rescue available) so retries actually
+    // exhaust. A missing-files invalidation would be auto-rescued.
     const invalidPlan: CommitSplitPlan = {
-      groups: [{ title: 'a', files: ['a.ts'], hunks: [] }],
+      groups: [
+        { title: 'a', files: ['a.ts'], hunks: [] },
+        { title: 'b', files: ['ghost.ts'], hunks: [] },
+      ],
     }
     mockExecuteChainWithSchema.mockResolvedValue(invalidPlan)
 
     await expect(
       generateValidatedCommitSplitPlan({ ...baseArgs(), maxAttempts: 2 })
-    ).rejects.toThrow(/after 2 attempts.*missing files: b\.ts/i)
+    ).rejects.toThrow(/after 2 attempts.*unknown files: ghost\.ts/i)
 
     expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(2)
   })
 
   it('tags each LLM call with an incrementing planAttempt in metadata', async () => {
+    // Uses unknownFiles (no rescue available) to ensure the retry
+    // actually fires — missing-files invalidation would be auto-rescued
+    // on attempt 1 and the second call would never happen.
     const invalidPlan: CommitSplitPlan = {
-      groups: [{ title: 'a', files: ['a.ts'], hunks: [] }],
+      groups: [
+        { title: 'a', files: ['a.ts'], hunks: [] },
+        { title: 'b', files: ['ghost.ts'], hunks: [] },
+      ],
     }
     const validPlan: CommitSplitPlan = {
       groups: [

--- a/src/commands/commit/splitPlanGenerator.ts
+++ b/src/commands/commit/splitPlanGenerator.ts
@@ -12,6 +12,7 @@ import {
   hasPlanValidationIssues,
   HunkInventoryLike,
   PlanValidationIssues,
+  rescueMissingFiles,
   rescueMixedFiles,
   rescuePhantomHunks,
 } from './splitPlanValidation'
@@ -86,7 +87,7 @@ export async function generateValidatedCommitSplitPlan({
       }
     )
 
-    // Rescue passes (#918, #919). Run in order — order matters:
+    // Rescue passes (#918, #919, #921). Run in order — order matters:
     //
     //   1. rescuePhantomHunks: LLM commonly emits "file::hunk-1"
     //      against an empty inventory (all staged files are new).
@@ -96,14 +97,18 @@ export async function generateValidatedCommitSplitPlan({
     //      of group A AND uses its hunks in `hunks[]` of group B.
     //      Drop the hunks (the file-level claim is more specific).
     //      Must run AFTER phantom-hunk rescue because the rescue
-    //      itself can create mixed-files situations (phantom hunks
-    //      get promoted to files; pre-existing real hunks for the
-    //      same file remain elsewhere and now overlap).
+    //      itself can create mixed-files situations.
     //
-    // Both rescues are no-ops when there's nothing to rescue, so
-    // running them unconditionally costs nothing on healthy plans.
+    //   3. rescueMissingFiles: LLM occasionally forgets a staged
+    //      file across every group. Append a synthetic "misc" group
+    //      so the plan covers every staged file. Must run LAST so
+    //      it has the final claim picture from earlier rescues.
+    //
+    // All three rescues are no-ops when there's nothing to rescue,
+    // so running them unconditionally costs nothing on healthy plans.
     const phantomRescued = rescuePhantomHunks(rawPlan, staged, hunkInventory)
-    const plan = rescueMixedFiles(phantomRescued, hunkInventory)
+    const mixedRescued = rescueMixedFiles(phantomRescued, hunkInventory)
+    const plan = rescueMissingFiles(mixedRescued, staged, hunkInventory)
 
     const issues = getPlanValidationIssues(plan, staged, hunkInventory)
     if (!hasPlanValidationIssues(issues)) {

--- a/src/commands/commit/splitPlanValidation.test.ts
+++ b/src/commands/commit/splitPlanValidation.test.ts
@@ -5,6 +5,7 @@ import {
   getPlanValidationIssues,
   hasPlanValidationIssues,
   HunkInventoryLike,
+  rescueMissingFiles,
   rescueMixedFiles,
   rescuePhantomHunks,
 } from './splitPlanValidation'
@@ -438,6 +439,96 @@ describe('splitPlanValidation', () => {
 
       expect(rescued.groups[0].files).toEqual(['src/index.ts'])
       expect(rescued.groups[0].hunks).toEqual([])
+    })
+  })
+
+  describe('rescueMissingFiles', () => {
+    // The dominant failure pattern from #920 testing on dirty-many-files
+    // after the first split landed: the LLM omitted `scratch.md` from
+    // every group. Validator's missingFiles check rejected. Rescue
+    // appends a synthetic "misc" group so the plan covers every staged
+    // file and survives validation.
+
+    it('appends a misc group containing files no other group claimed', () => {
+      const staged = ['src/a.ts', 'src/b.ts', 'scratch.md'].map(stagedFile)
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'feat: ab', files: ['src/a.ts', 'src/b.ts'], hunks: [] },
+        ],
+      }
+
+      const rescued = rescueMissingFiles(plan, staged, buildHunkInventory({}))
+
+      expect(rescued.groups).toHaveLength(2)
+      expect(rescued.groups[1].title).toBe('chore: misc unclaimed changes')
+      expect(rescued.groups[1].files).toEqual(['scratch.md'])
+      expect(rescued.groups[1].hunks).toEqual([])
+      // First group passes through unchanged.
+      expect(rescued.groups[0]).toEqual(plan.groups[0])
+    })
+
+    it('counts hunk-covered files as claimed (no double-attribution)', () => {
+      // File covered via hunks should not be flagged as missing — the
+      // rescue's claim calculation has to mirror the validator's.
+      const staged = ['src/router.ts'].map(stagedFile)
+      const inventory = buildHunkInventory({
+        'src/router.ts': ['src/router.ts::hunk-1'],
+      })
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'feat: router', files: [], hunks: ['src/router.ts::hunk-1'] },
+        ],
+      }
+
+      const rescued = rescueMissingFiles(plan, staged, inventory)
+
+      // No misc group appended — router.ts is already claimed via hunks.
+      expect(rescued.groups).toHaveLength(1)
+    })
+
+    it('is a no-op when every staged file is already claimed', () => {
+      const staged = ['src/a.ts', 'src/b.ts'].map(stagedFile)
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'feat: a', files: ['src/a.ts'], hunks: [] },
+          { title: 'feat: b', files: ['src/b.ts'], hunks: [] },
+        ],
+      }
+
+      const rescued = rescueMissingFiles(plan, staged, buildHunkInventory({}))
+
+      expect(rescued).toEqual(plan)
+    })
+
+    it('sorts the missing files in the misc group for deterministic output', () => {
+      // LLM output isn't stable across runs; our recovery should be.
+      const staged = ['zeta.ts', 'alpha.ts', 'mu.ts'].map(stagedFile)
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'wip', files: [], hunks: [] },
+        ],
+      }
+
+      const rescued = rescueMissingFiles(plan, staged, buildHunkInventory({}))
+
+      expect(rescued.groups[1].files).toEqual(['alpha.ts', 'mu.ts', 'zeta.ts'])
+    })
+
+    it('handles multiple missing files together in a single misc group', () => {
+      // We don't try to be clever about thematic grouping — every
+      // missing file goes in one bucket. User can re-roll if they
+      // want a specific commit for any of them.
+      const staged = ['a.ts', 'b.ts', 'c.ts', 'd.ts'].map(stagedFile)
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'feat: a', files: ['a.ts'], hunks: [] },
+        ],
+      }
+
+      const rescued = rescueMissingFiles(plan, staged, buildHunkInventory({}))
+
+      expect(rescued.groups).toHaveLength(2)
+      expect(rescued.groups[1].files).toEqual(['b.ts', 'c.ts', 'd.ts'])
     })
   })
 })

--- a/src/commands/commit/splitPlanValidation.ts
+++ b/src/commands/commit/splitPlanValidation.ts
@@ -251,6 +251,73 @@ export function rescueMixedFiles(
   return { ...plan, groups: rescuedGroups }
 }
 
+/**
+ * Salvage a plan where one or more staged files aren't claimed by any
+ * group at all. The validator calls this `missingFiles` and rejects.
+ *
+ * Recovery: append a synthetic "misc" group containing every missing
+ * file. The user can re-roll (`r`) if the model's grouping forgot a
+ * critical file they wanted in a specific commit, but a salvageable
+ * plan that surfaces ALL staged work is strictly better than
+ * exhausting 3 retry attempts and ending in the failure modal.
+ *
+ * Why append (not distribute across existing groups): each existing
+ * group has a thematic identity (title + body + rationale). Quietly
+ * inserting a forgotten file into one of them would muddy that
+ * theme. A separate "misc" group is honest about what happened ("the
+ * model didn't have an obvious home for these — review before
+ * applying") and the user can always edit / reject the plan.
+ *
+ * Run AFTER `rescuePhantomHunks` and `rescueMixedFiles` so any
+ * partial recovery from those passes is reflected in the
+ * "what's already claimed" calculation.
+ *
+ * Returns a NEW plan object — original is not mutated. No-op when
+ * every staged file is already claimed somewhere.
+ */
+export function rescueMissingFiles(
+  plan: CommitSplitPlan,
+  staged: FileChange[],
+  hunkInventory?: HunkInventoryLike
+): CommitSplitPlan {
+  const stagedFiles = new Set(staged.map((change) => change.filePath))
+  const claimed = new Set<string>()
+
+  // A file is claimed if it appears in any group's files[] OR if any
+  // of its hunks appear in any group's hunks[] (mirrors the validator's
+  // missingFiles check).
+  plan.groups.forEach((group) => {
+    (group.files || []).forEach((file) => claimed.add(file))
+    ;(group.hunks || []).forEach((hunkId) => {
+      const hunk = hunkInventory?.byId.get(hunkId)
+      if (hunk) claimed.add(hunk.filePath)
+    })
+  })
+
+  const missing = [...stagedFiles].filter((file) => !claimed.has(file))
+  if (missing.length === 0) {
+    return plan
+  }
+
+  // Sort missing files for deterministic output — the LLM's group
+  // ordering isn't stable, but our recovery should be.
+  missing.sort()
+
+  return {
+    ...plan,
+    groups: [
+      ...plan.groups,
+      {
+        title: 'chore: misc unclaimed changes',
+        body: 'Files the split plan did not assign to any other commit. Review and re-roll (`r`) if these belong in a specific commit.',
+        rationale: 'Recovered by validator rescue — model omitted these from every group.',
+        files: missing,
+        hunks: [],
+      },
+    ],
+  }
+}
+
 export function formatPlanValidationFeedback(issues: PlanValidationIssues): string {
   const sections: string[] = []
 

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -1820,15 +1820,25 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
 
     // Success — close the overlay, reset compose (the staged set is
-    // now empty since the plan committed everything), and refresh so
-    // the new commits appear in history.
+    // now empty since the plan committed everything), and pop the
+    // compose view so the user lands on whatever was beneath (usually
+    // status, sometimes history). An empty compose pane after the
+    // commits land is a dead end; the surface beneath shows real
+    // state — remaining unstaged/untracked files, or the freshly
+    // landed commits in history. Either is more useful than staring
+    // at an empty draft.
     dispatch({ type: 'clearSplitPlan' })
     dispatch({ type: 'commitCompose', action: { type: 'reset' } })
+    // Only pop if compose is on top — the apply could have been
+    // invoked from a deeper stack and we don't want to over-pop.
+    if (state.activeView === 'compose' && state.viewStack.length > 1) {
+      dispatch({ type: 'popView' })
+    }
     dispatch({ type: 'setStatus', value: result.message, kind: 'success' })
     await refreshWorktreeContext()
     // Re-fetch the commit log so the new commits show up in history.
     await refreshContext()
-  }, [dispatch, git, refreshContext, refreshWorktreeContext, state.splitPlan])
+  }, [dispatch, git, refreshContext, refreshWorktreeContext, state.activeView, state.splitPlan, state.viewStack.length])
 
   // Esc inside the overlay — close without applying. Status line gets
   // a confirmation so the user knows the operation was abandoned.

--- a/src/workstation/runtime/detailPanel.ts
+++ b/src/workstation/runtime/detailPanel.ts
@@ -74,7 +74,14 @@ export function renderDetailPanel(
   // which-key style overlay — shows the available chord continuations
   // when the user has pressed the prefix and we're waiting for the
   // second key. Mirrors helix / which-key.nvim / doom-emacs.
-  if (state.pendingKey) {
+  //
+  // Suppressed when the split-plan overlay is open (#920 follow-up):
+  // the overlay re-uses `pendingKey='g'` for its own `gg` chord
+  // (jump-to-top scroll), and surfacing the global g-chord menu
+  // (gB / gT / gS / …) at that moment would mislead the user into
+  // thinking the global view-selector overrode the overlay's
+  // navigation. The overlay's footer hint already documents `g/G top/bot`.
+  if (state.pendingKey && !state.splitPlan) {
     return renderChordOverlay(h, components, state, width, theme, focused)
   }
 


### PR DESCRIPTION
Three issues from manual testing of #920.

## 1. Empty compose pane after a successful split

After applying the plan, the user was left on the compose surface with an empty draft and no obvious next step. Compose has nothing to commit (everything went into the split commits) — the "Press gs to stage files, then gc to come back here" placeholder reads as a dead end.

**Fix**: pop the compose view on apply success. User lands on whatever was beneath (usually status, sometimes history) — both show real state. Remaining unstaged / untracked files in status, freshly landed commits in history. Either is more useful than an empty compose. Re-reachable any time via `gc`, `S`, `e`, `E` for the next commit cycle.

Pop is gated on `state.activeView === 'compose' && viewStack.length > 1` — defensive against over-popping if compose was somehow the root view or applied from a deeper stack.

## 2. Global `g` chord menu popped over the split overlay

The split overlay re-uses `pendingKey='g'` for its own `gg` (jump-to-top) chord. But `detailPanel.ts` unconditionally renders the global chord menu (gB / gT / gS / …) whenever `state.pendingKey` is set, surfacing the wrong continuation menu while the split overlay was open. From the user's POV the global view-selector looked like it was overriding the overlay's navigation.

**Fix**: detail panel skips the chord overlay render when `state.splitPlan` is set. The overlay's footer hint already shows `g/G top/bot` so the binding stays discoverable.

## 3. New validator failure: `missingFiles`

LLM occasionally omits a staged file from every group. Manual repro on `dirty-many-files` post-first-apply: `scratch.md` got forgotten across all groups. Phantom-hunk and mixed-files rescues don't cover this — they fix mis-claims, not omissions.

**Fix**: new `rescueMissingFiles(plan, staged, inventory)` pass. Walks the staged set, appends a synthetic `chore: misc unclaimed changes` group containing every file no other group claimed. Sorted output for determinism. User can re-roll (`r`) if the grouping forgot a critical file they wanted somewhere specific, but a salvageable plan that surfaces every staged file is strictly better than exhausting 3 retries to a hard error.

Runs LAST in the rescue chain (after phantomHunks → mixedFiles) so it sees the final claim picture from earlier rescues.

## On the user's "expected AI commit message after apply"

The user mentioned expecting an auto-generated commit message after applying. The split flow already does that — each group in the plan is its own commit with its own AI-generated title + body, which is what landed when they pressed `y`. What was missing was the **navigation cue** that the operation succeeded. The compose-view-pop change addresses that: the user now lands on status (sees what's left to do) or history (sees the new commits) instead of an empty compose.

If we wanted to also auto-progress into the next commit cycle (stage the unstaged residue, AI-draft, etc.), that's a meaningful additional flow worth its own issue — out of scope here.

## Test plan

- [x] `npm run lint` clean
- [x] `tsc --noEmit` clean
- [x] `npm run test:jest` — **8220 tests pass** (+6 from this PR)
- [ ] Manual: `npm run scenario create dirty-many-files -- --run-ui` → `S` → review plan → `y` apply → land on status (not empty compose) with the success message in green footer
- [ ] Manual: in the overlay, press `g` — should NOT see the global chord menu; second `g` jumps to top
- [ ] Manual: trigger a missing-files scenario (e.g. press `S` on a re-staged repo that the model omits a file from) → plan generates with a synthetic "misc unclaimed changes" group at the end

## Tests updated

Existing generator + integration tests previously used `missingFiles` as the invalidation pattern. `rescueMissingFiles` now auto-recovers that case in a single attempt, so the retry-loop paths needed a different invalidation. Switched to `unknownFiles` (LLM references a file not in the staged set — no rescue available) so the retry loop still gets exercised end-to-end.