### PR TITLE
feat(parser): TypeScript / JavaScript structural fast path (#883 phase 1)

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -294,6 +294,29 @@
               "type": "boolean",
               "description": "Replace the LLM summary with a templated heading extract for `.md` / `.mdx` / `.markdown` modification diffs that have clear heading-level structural changes. Diffs without structural signals (paragraph-only edits) still go to the LLM regardless of this flag.\n\nBench impact (synthetic): collapses docs-update-shaped commits from ~24s cold to ~3ms (no LLM calls fire for the markdown files). Real-world wall-clock savings depend on per-call LLM latency.",
               "default": false
+            },
+            "languageAware": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Master switch. When false (default) the languageAware path is skipped entirely regardless of `languages`.",
+                  "default": false
+                },
+                "languages": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "ts",
+                      "js"
+                    ]
+                  },
+                  "description": "Languages to opt in. Omit / empty to enable all supported languages."
+                }
+              },
+              "additionalProperties": false,
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`"
             }
           },
           "additionalProperties": false,
@@ -719,6 +742,29 @@
               "type": "boolean",
               "description": "Replace the LLM summary with a templated heading extract for `.md` / `.mdx` / `.markdown` modification diffs that have clear heading-level structural changes. Diffs without structural signals (paragraph-only edits) still go to the LLM regardless of this flag.\n\nBench impact (synthetic): collapses docs-update-shaped commits from ~24s cold to ~3ms (no LLM calls fire for the markdown files). Real-world wall-clock savings depend on per-call LLM latency.",
               "default": false
+            },
+            "languageAware": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Master switch. When false (default) the languageAware path is skipped entirely regardless of `languages`.",
+                  "default": false
+                },
+                "languages": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "ts",
+                      "js"
+                    ]
+                  },
+                  "description": "Languages to opt in. Omit / empty to enable all supported languages."
+                }
+              },
+              "additionalProperties": false,
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`"
             }
           },
           "additionalProperties": false,
@@ -887,6 +933,29 @@
               "type": "boolean",
               "description": "Replace the LLM summary with a templated heading extract for `.md` / `.mdx` / `.markdown` modification diffs that have clear heading-level structural changes. Diffs without structural signals (paragraph-only edits) still go to the LLM regardless of this flag.\n\nBench impact (synthetic): collapses docs-update-shaped commits from ~24s cold to ~3ms (no LLM calls fire for the markdown files). Real-world wall-clock savings depend on per-call LLM latency.",
               "default": false
+            },
+            "languageAware": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Master switch. When false (default) the languageAware path is skipped entirely regardless of `languages`.",
+                  "default": false
+                },
+                "languages": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "ts",
+                      "js"
+                    ]
+                  },
+                  "description": "Languages to opt in. Omit / empty to enable all supported languages."
+                }
+              },
+              "additionalProperties": false,
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`"
             }
           },
           "additionalProperties": false,

--- a/src/lib/langchain/types.ts
+++ b/src/lib/langchain/types.ts
@@ -192,6 +192,35 @@ export type BaseLLMService = {
      * @default false
      */
     markdown?: boolean
+    /**
+     * Language-aware structural fast path (#883). Replace the LLM
+     * summary with a symbol-level extract ("added parseRequest();
+     * removed legacyParse()") for source files in the listed
+     * languages. Off by default; quality is harder to validate than
+     * the markdown fast path so we don't enable it without opt-in.
+     *
+     * Diffs without top-level structural signals (paragraph-only
+     * body edits, formatting changes) still go to the LLM regardless
+     * of this flag.
+     *
+     * Currently supports:
+     *   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`
+     *   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`
+     */
+    languageAware?: {
+      /**
+       * Master switch. When false (default) the languageAware path
+       * is skipped entirely regardless of `languages`.
+       *
+       * @default false
+       */
+      enabled?: boolean
+      /**
+       * Languages to opt in. Omit / empty to enable all supported
+       * languages.
+       */
+      languages?: ('ts' | 'js')[]
+    }
   }
 }
 

--- a/src/lib/parsers/default/utils/createFileChangeParserOptions.ts
+++ b/src/lib/parsers/default/utils/createFileChangeParserOptions.ts
@@ -12,6 +12,10 @@ export type FileChangeParserServiceBudget = {
   maxConcurrent?: number
   fastPath?: {
     markdown?: boolean
+    languageAware?: {
+      enabled?: boolean
+      languages?: ('ts' | 'js')[]
+    }
   }
 }
 

--- a/src/lib/parsers/default/utils/summarizeDiffs.ts
+++ b/src/lib/parsers/default/utils/summarizeDiffs.ts
@@ -184,6 +184,10 @@ export type SummarizeDiffsOptions = {
    */
   fastPath?: {
     markdown?: boolean
+    languageAware?: {
+      enabled?: boolean
+      languages?: ('ts' | 'js')[]
+    }
   }
   handleOutput?: typeof defaultOutputCallback
 } & SummarizeContext

--- a/src/lib/parsers/default/utils/summarizeLargeFiles.test.ts
+++ b/src/lib/parsers/default/utils/summarizeLargeFiles.test.ts
@@ -299,6 +299,82 @@ describe('summarizeLargeFiles', () => {
     expect(result[0].diff).toContain('New section')
   })
 
+  it('routes TS modification diffs to the structural extract when fastPath.languageAware is enabled (#883)', async () => {
+    const tsDiff = [
+      'diff --git a/src/parser.ts b/src/parser.ts',
+      'index aaa..bbb 100644',
+      '--- a/src/parser.ts',
+      '+++ b/src/parser.ts',
+      '@@ -1,5 +1,8 @@',
+      ' import { Logger } from "./logger"',
+      '-export function legacyParse() {',
+      '-  return {}',
+      '-}',
+      '+export function parseRequest(input: string) {',
+      '+  return JSON.parse(input)',
+      '+}',
+      '+export const PARSE_VERSION = 2',
+    ].join('\n')
+
+    const diffs: FileDiff[] = [
+      {
+        file: 'src/parser.ts',
+        diff: tsDiff,
+        summary: 'src/parser.ts',
+        tokenCount: 600,
+      },
+    ]
+
+    const result = await summarizeLargeFiles(diffs, {
+      maxFileTokens: 500,
+      minTokensForSummary: 400,
+      maxConcurrent: 4,
+      fastPath: { languageAware: { enabled: true } },
+      tokenizer: mockTokenizer,
+      logger: mockLogger as never,
+      chain: mockChain,
+      textSplitter: mockTextSplitter,
+    })
+
+    expect(mockSummarize).not.toHaveBeenCalled()
+    expect(result[0].diff).toContain('Updated TypeScript')
+    expect(result[0].diff).toContain('parseRequest()')
+    expect(result[0].diff).toContain('legacyParse()')
+  })
+
+  it('keeps the LLM path when languageAware is enabled but the file language is not opted in (#883)', async () => {
+    // Modification (not a pure addition) so the trivial-shape skip
+    // doesn't preempt the fast-path branch we're exercising.
+    const tsDiff = [
+      '@@ -1,2 +1,2 @@',
+      '-export function hello() {}',
+      '+export function hello(name: string) {}',
+    ].join('\n')
+
+    const diffs: FileDiff[] = [
+      {
+        file: 'src/foo.ts',
+        diff: tsDiff,
+        summary: 'src/foo.ts',
+        tokenCount: 600,
+      },
+    ]
+
+    await summarizeLargeFiles(diffs, {
+      maxFileTokens: 500,
+      minTokensForSummary: 400,
+      maxConcurrent: 4,
+      // Explicitly opt in to JS only — TS files should fall through.
+      fastPath: { languageAware: { enabled: true, languages: ['js'] } },
+      tokenizer: mockTokenizer,
+      logger: mockLogger as never,
+      chain: mockChain,
+      textSplitter: mockTextSplitter,
+    })
+
+    expect(mockSummarize).toHaveBeenCalledTimes(1)
+  })
+
   it('should respect maxConcurrent limit', async () => {
     const diffs: FileDiff[] = Array.from({ length: 10 }, (_, i) => ({
       file: `file${i}.ts`,

--- a/src/lib/parsers/default/utils/summarizeLargeFiles.ts
+++ b/src/lib/parsers/default/utils/summarizeLargeFiles.ts
@@ -10,6 +10,7 @@ import {
   writeDiffSummary,
 } from './diffSummaryCache'
 import { summarizeMarkdownDiff } from './markdownDiff'
+import { detectStructuralLanguage, summarizeTsStructuralDiff } from './tsStructuralDiff'
 import { summarizeTrivialDiff } from './trivialDiff'
 
 /**
@@ -48,6 +49,19 @@ export type SummarizeLargeFilesOptions = {
    */
   fastPath?: {
     markdown?: boolean
+    /**
+     * Language-aware structural extract (#883). When enabled for a
+     * given language, modification diffs to source files in that
+     * language render as a templated symbol-level summary
+     * ("added parseRequest(); removed legacyParse()") instead of
+     * going through the LLM. Off by default — lossy by design and
+     * quality is harder to validate than the markdown fast path,
+     * so we don't enable it without explicit opt-in.
+     */
+    languageAware?: {
+      enabled?: boolean
+      languages?: ('ts' | 'js')[]
+    }
   }
   tokenizer: TokenCounter
   logger: Logger
@@ -110,6 +124,33 @@ async function summarizeFileDiff(
         ...fileDiff,
         diff: markdownSummary,
         tokenCount: tokenizer(markdownSummary),
+      }
+    }
+  }
+
+  // Language-aware structural fast path (#883, phase 1). Same
+  // contract as the markdown skip: opt-in only, falls through to
+  // the LLM when the diff has no top-level structural signal, and
+  // emits a templated summary when it does. Currently covers TS/JS
+  // via regex extraction; richer (tree-sitter-backed) languages
+  // arrive in follow-up PRs.
+  if (fastPath?.languageAware?.enabled) {
+    const language = detectStructuralLanguage(fileDiff.file)
+    const allowed = fastPath.languageAware.languages
+    const languageEnabled = language !== undefined &&
+      (!allowed || allowed.length === 0 || allowed.includes(language))
+    if (languageEnabled) {
+      const structuralSummary = summarizeTsStructuralDiff(fileDiff)
+      if (structuralSummary !== undefined) {
+        logger.verbose(
+          ` - ${fileDiff.file}: language-aware fast-path skip (no LLM call)`,
+          { color: 'gray' }
+        )
+        return {
+          ...fileDiff,
+          diff: structuralSummary,
+          tokenCount: tokenizer(structuralSummary),
+        }
       }
     }
   }

--- a/src/lib/parsers/default/utils/tsStructuralDiff.test.ts
+++ b/src/lib/parsers/default/utils/tsStructuralDiff.test.ts
@@ -1,0 +1,202 @@
+import { FileDiff } from '../../../types'
+import {
+  detectStructuralLanguage,
+  parseStructuralLine,
+  summarizeTsStructuralDiff,
+} from './tsStructuralDiff'
+
+function fileDiff(file: string, diff: string): FileDiff {
+  return {
+    file,
+    diff,
+    tokenCount: diff.length,
+    summary: '',
+  } as FileDiff
+}
+
+describe('detectStructuralLanguage', () => {
+  it('returns "ts" for TypeScript-ish extensions', () => {
+    expect(detectStructuralLanguage('src/foo.ts')).toBe('ts')
+    expect(detectStructuralLanguage('src/foo.tsx')).toBe('ts')
+    expect(detectStructuralLanguage('src/foo.mts')).toBe('ts')
+    expect(detectStructuralLanguage('src/foo.cts')).toBe('ts')
+  })
+
+  it('returns "js" for JavaScript-ish extensions', () => {
+    expect(detectStructuralLanguage('src/foo.js')).toBe('js')
+    expect(detectStructuralLanguage('src/foo.jsx')).toBe('js')
+    expect(detectStructuralLanguage('src/foo.mjs')).toBe('js')
+    expect(detectStructuralLanguage('src/foo.cjs')).toBe('js')
+  })
+
+  it('returns undefined for unrelated files', () => {
+    expect(detectStructuralLanguage('README.md')).toBeUndefined()
+    expect(detectStructuralLanguage('src/foo.rs')).toBeUndefined()
+  })
+})
+
+describe('parseStructuralLine', () => {
+  it('recognizes plain function declarations', () => {
+    expect(parseStructuralLine('function foo() {}')).toEqual({
+      name: 'foo', kind: 'function', exported: false,
+    })
+  })
+
+  it('recognizes exported / async functions', () => {
+    expect(parseStructuralLine('export async function fetchUser(id: string) {')).toEqual({
+      name: 'fetchUser', kind: 'function', exported: true,
+    })
+  })
+
+  it('recognizes class / abstract class declarations', () => {
+    expect(parseStructuralLine('export class Widget extends Base {')).toEqual({
+      name: 'Widget', kind: 'class', exported: true,
+    })
+    expect(parseStructuralLine('abstract class Frame {')).toEqual({
+      name: 'Frame', kind: 'class', exported: false,
+    })
+  })
+
+  it('recognizes interface / type / enum declarations', () => {
+    expect(parseStructuralLine('export interface RequestOptions {')).toEqual({
+      name: 'RequestOptions', kind: 'interface', exported: true,
+    })
+    expect(parseStructuralLine('type Handler = (req: Req) => Res')).toEqual({
+      name: 'Handler', kind: 'type', exported: false,
+    })
+    expect(parseStructuralLine('export const enum Color { Red, Blue }')).toEqual({
+      name: 'Color', kind: 'enum', exported: true,
+    })
+  })
+
+  it('recognizes top-level const / let / var with an assignment', () => {
+    expect(parseStructuralLine('export const TIMEOUT = 5000')).toEqual({
+      name: 'TIMEOUT', kind: 'const', exported: true,
+    })
+    expect(parseStructuralLine('const config: Config = {')).toEqual({
+      name: 'config', kind: 'const', exported: false,
+    })
+  })
+
+  it('recognizes export default forms', () => {
+    expect(parseStructuralLine('export default function Page() {')).toEqual({
+      name: 'Page', kind: 'default', exported: true,
+    })
+    expect(parseStructuralLine('export default class App {')).toEqual({
+      name: 'App', kind: 'default', exported: true,
+    })
+    expect(parseStructuralLine('export default {')).toEqual({
+      name: 'default', kind: 'default', exported: true,
+    })
+  })
+
+  it('ignores indented lines (likely inside a block)', () => {
+    expect(parseStructuralLine('    function inner() {')).toBeUndefined()
+    expect(parseStructuralLine('        const x = 1')).toBeUndefined()
+  })
+
+  it('returns undefined for non-declaration lines', () => {
+    expect(parseStructuralLine('  if (x > 0) return')).toBeUndefined()
+    expect(parseStructuralLine('console.log("hi")')).toBeUndefined()
+    expect(parseStructuralLine('// a comment')).toBeUndefined()
+    expect(parseStructuralLine('')).toBeUndefined()
+  })
+})
+
+describe('summarizeTsStructuralDiff', () => {
+  it('returns undefined for non-TS/JS files', () => {
+    expect(summarizeTsStructuralDiff(fileDiff('README.md', '+ new line'))).toBeUndefined()
+  })
+
+  it('returns undefined when the diff has no body changes', () => {
+    expect(summarizeTsStructuralDiff(fileDiff('src/foo.ts', ''))).toBeUndefined()
+  })
+
+  it('returns undefined when changed lines have no structural signal (paragraph-only edit)', () => {
+    // Only comment / body edits → no top-level signal → fall through
+    // to LLM so we don't lose fidelity on cosmetic diffs.
+    const diff = [
+      '@@ -1,3 +1,3 @@',
+      ' export function foo() {',
+      '-  return 1',
+      '+  return 2',
+      ' }',
+    ].join('\n')
+    expect(summarizeTsStructuralDiff(fileDiff('src/foo.ts', diff))).toBeUndefined()
+  })
+
+  it('names added top-level symbols and the +/- line totals', () => {
+    const diff = [
+      '@@ -1,1 +1,5 @@',
+      ' import { Logger } from "./logger"',
+      '+export function parseRequest(input: string) {',
+      '+  return JSON.parse(input)',
+      '+}',
+      '+export const PARSE_VERSION = 2',
+    ].join('\n')
+    const out = summarizeTsStructuralDiff(fileDiff('src/parser.ts', diff))
+    expect(out).toContain('Updated TypeScript `src/parser.ts`')
+    expect(out).toContain('added: parseRequest()')
+    expect(out).toContain('const PARSE_VERSION')
+    expect(out).toContain('+4/-0 lines')
+  })
+
+  it('names removed top-level symbols separately', () => {
+    const diff = [
+      '@@ -1,3 +1,1 @@',
+      '-export function legacyParse() {',
+      '-  return {}',
+      '-}',
+      ' export const KEEP = 1',
+    ].join('\n')
+    const out = summarizeTsStructuralDiff(fileDiff('src/parser.ts', diff))
+    expect(out).toContain('removed: legacyParse()')
+    expect(out).toContain('+0/-3 lines')
+  })
+
+  it('groups symbols present in both buckets under "signature change"', () => {
+    // A renamed / re-signatured export — the declaration line itself
+    // changes, so the parser sees the symbol on both sides. Surface
+    // it as updated rather than as a separate add + remove.
+    const diff = [
+      '@@ -1,1 +1,1 @@',
+      '-export function parseRequest(input: string) {',
+      '+export function parseRequest(input: string, schema: Schema) {',
+    ].join('\n')
+    const out = summarizeTsStructuralDiff(fileDiff('src/parser.ts', diff))
+    expect(out).toContain('signature change: parseRequest()')
+    expect(out).not.toContain('added:')
+    expect(out).not.toContain('removed:')
+  })
+
+  it('renders class / interface / type / const kinds with their kind label', () => {
+    const diff = [
+      '@@ -0,0 +1,4 @@',
+      '+export class Widget extends Base {}',
+      '+export interface WidgetOptions {}',
+      '+export type WidgetHandler = () => void',
+      '+export const DEFAULT_WIDGETS = []',
+    ].join('\n')
+    const out = summarizeTsStructuralDiff(fileDiff('src/widget.ts', diff)) || ''
+    expect(out).toMatch(/class Widget/)
+    expect(out).toMatch(/interface WidgetOptions/)
+    expect(out).toMatch(/type WidgetHandler/)
+    expect(out).toMatch(/const DEFAULT_WIDGETS/)
+  })
+
+  it('handles JavaScript files with the "JavaScript" label', () => {
+    const diff = [
+      '@@ -0,0 +1,1 @@',
+      '+export function hello() {}',
+    ].join('\n')
+    const out = summarizeTsStructuralDiff(fileDiff('src/foo.js', diff))
+    expect(out).toContain('Updated JavaScript `src/foo.js`')
+  })
+
+  it('caps the symbol list and adds a "+N more" overflow', () => {
+    const additions = Array.from({ length: 12 }, (_, i) => `+export function fn${i}() {}`).join('\n')
+    const diff = ['@@ -0,0 +1,12 @@', additions].join('\n')
+    const out = summarizeTsStructuralDiff(fileDiff('src/many.ts', diff)) || ''
+    expect(out).toMatch(/\(\+\d+ more\)/)
+  })
+})

--- a/src/lib/parsers/default/utils/tsStructuralDiff.ts
+++ b/src/lib/parsers/default/utils/tsStructuralDiff.ts
@@ -1,0 +1,218 @@
+import { FileDiff } from '../../../types'
+
+/**
+ * TypeScript / JavaScript structural fast path (#883, phase 1).
+ *
+ * Mirrors `summarizeMarkdownDiff` from #861 / angle 5: when a diff
+ * has clear top-level symbol changes (added / removed / renamed
+ * exports, functions, classes, interfaces, types), emit a templated
+ * summary that names the changes instead of paying for an LLM call.
+ *
+ * Quality trade-off, on purpose: an LLM summary of a TS diff is
+ * usually wordier ("refactored the parser to extract a helper")
+ * but most of that detail isn't load-bearing for a commit message —
+ * the structural skeleton ("added parseRequest, removed
+ * legacyParse") is the part the model uses to write a useful subject
+ * line. The structural extract names that skeleton in a fraction
+ * of the tokens.
+ *
+ * This is a regex-first cut intended to ship as the foundation
+ * for #883. Tree-sitter integration (which is per-language binary
+ * weight of 200KB–2 MB) is a follow-up: it gives us scopes,
+ * receiver types, signature deltas — better fidelity at higher
+ * build cost. The current implementation catches the high-signal
+ * cases (added / removed top-level symbols) and falls through to
+ * the LLM when the diff has no structural signal so paragraph-only
+ * / cosmetic changes keep their full-fidelity summary.
+ *
+ * Off by default. The user opts in via
+ * `service.fastPath.languageAware: { enabled: true; languages: [...] }`.
+ * Per the project convention (and the same logic that gated the
+ * markdown fast path), lossy optimizations stay off by default.
+ */
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts']
+const JS_EXTENSIONS = ['.js', '.jsx', '.mjs', '.cjs']
+const MAX_SYMBOLS_PER_BUCKET = 8
+
+export type StructuralLanguage = 'ts' | 'js'
+
+export function detectStructuralLanguage(path: string): StructuralLanguage | undefined {
+  const lower = path.toLowerCase()
+  if (TS_EXTENSIONS.some((ext) => lower.endsWith(ext))) return 'ts'
+  if (JS_EXTENSIONS.some((ext) => lower.endsWith(ext))) return 'js'
+  return undefined
+}
+
+export type StructuralSymbol = {
+  /**
+   * Display name of the declared symbol. For multi-word forms
+   * (e.g. `export default function foo`) only the identifier
+   * itself is captured.
+   */
+  name: string
+  /**
+   * Coarse-grained kind. Used to group the summary buckets; not
+   * structural beyond that.
+   */
+  kind: 'function' | 'class' | 'interface' | 'type' | 'const' | 'enum' | 'default'
+  /** True when the declaration is `export`ed. */
+  exported: boolean
+}
+
+/**
+ * Recognize top-level symbol declarations in a single source line.
+ * Returns the matched symbol or undefined when the line isn't a
+ * recognized declaration. Intentionally conservative: matches only
+ * patterns that look like top-level declarations from a glance, so
+ * we don't surface noise from a `function` keyword buried inside
+ * another function body.
+ *
+ * Exported for direct testing — the extractor depends on this being
+ * deterministic for individual line cases.
+ */
+export function parseStructuralLine(line: string): StructuralSymbol | undefined {
+  // Strip the leading +/- and any single space of indent that git
+  // diffs often emit. Anything beyond that level of indent isn't a
+  // top-level declaration we care about.
+  const trimmed = line.replace(/^\s+/, '')
+  // Skip lines that look like they're inside a block (indented in
+  // the source by anything other than the diff marker itself).
+  const leadingIndent = line.length - trimmed.length
+  if (leadingIndent > 1) return undefined
+
+  let body = trimmed
+  let exported = false
+  if (body.startsWith('export ')) {
+    exported = true
+    body = body.slice('export '.length).trimStart()
+  }
+
+  // export default function foo(... | export default class Foo | export default <expression>
+  if (body.startsWith('default ')) {
+    const rest = body.slice('default '.length).trimStart()
+    const fnMatch = rest.match(/^(?:async\s+)?function\s*\*?\s*([A-Za-z_$][\w$]*)?/)
+    if (fnMatch) {
+      return { name: fnMatch[1] || 'default', kind: 'default', exported: true }
+    }
+    const classMatch = rest.match(/^(?:abstract\s+)?class\s+([A-Za-z_$][\w$]*)/)
+    if (classMatch) {
+      return { name: classMatch[1], kind: 'default', exported: true }
+    }
+    return { name: 'default', kind: 'default', exported: true }
+  }
+
+  const fnMatch = body.match(/^(?:async\s+)?function\s*\*?\s+([A-Za-z_$][\w$]*)/)
+  if (fnMatch) return { name: fnMatch[1], kind: 'function', exported }
+
+  const classMatch = body.match(/^(?:abstract\s+)?class\s+([A-Za-z_$][\w$]*)/)
+  if (classMatch) return { name: classMatch[1], kind: 'class', exported }
+
+  const interfaceMatch = body.match(/^interface\s+([A-Za-z_$][\w$]*)/)
+  if (interfaceMatch) return { name: interfaceMatch[1], kind: 'interface', exported }
+
+  const typeMatch = body.match(/^type\s+([A-Za-z_$][\w$]*)\s*[=<]/)
+  if (typeMatch) return { name: typeMatch[1], kind: 'type', exported }
+
+  const enumMatch = body.match(/^(?:const\s+)?enum\s+([A-Za-z_$][\w$]*)/)
+  if (enumMatch) return { name: enumMatch[1], kind: 'enum', exported }
+
+  // const / let / var with an identifier we can capture. Only the
+  // first identifier — destructuring patterns at top level are
+  // unusual and the LLM fallback can name them better than we can.
+  const constMatch = body.match(/^(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*[=:]/)
+  if (constMatch) return { name: constMatch[1], kind: 'const', exported }
+
+  return undefined
+}
+
+export function summarizeTsStructuralDiff(fileDiff: FileDiff): string | undefined {
+  const language = detectStructuralLanguage(fileDiff.file)
+  if (!language) return undefined
+
+  const added = new Map<string, StructuralSymbol>()
+  const removed = new Map<string, StructuralSymbol>()
+  let addedLines = 0
+  let removedLines = 0
+
+  for (const line of fileDiff.diff.split('\n')) {
+    if (isPatchHeader(line)) continue
+    if (line.startsWith('+')) {
+      addedLines++
+      const symbol = parseStructuralLine(line.slice(1))
+      if (symbol) added.set(keyOf(symbol), symbol)
+    } else if (line.startsWith('-')) {
+      removedLines++
+      const symbol = parseStructuralLine(line.slice(1))
+      if (symbol) removed.set(keyOf(symbol), symbol)
+    }
+  }
+
+  if (addedLines === 0 && removedLines === 0) return undefined
+
+  // No structural signal → fall through to LLM. We only fast-path
+  // when the diff names at least one top-level declaration; pure
+  // body-edit / formatting changes keep their full-fidelity summary.
+  if (added.size === 0 && removed.size === 0) return undefined
+
+  // A symbol that appears in both buckets is likely a signature
+  // change (kept around but its declaration line changed). Surface
+  // these as "updated" so the user sees they aren't strictly
+  // added/removed.
+  const updatedKeys = new Set([...added.keys()].filter((k) => removed.has(k)))
+  const pureAdded = [...added.values()].filter((s) => !updatedKeys.has(keyOf(s)))
+  const pureRemoved = [...removed.values()].filter((s) => !updatedKeys.has(keyOf(s)))
+  const updated = [...updatedKeys].map((k) => added.get(k) as StructuralSymbol)
+
+  const parts: string[] = [`Updated ${language === 'ts' ? 'TypeScript' : 'JavaScript'} \`${fileDiff.file}\``]
+  if (pureAdded.length) {
+    parts.push(`added: ${formatSymbolList(pureAdded)}`)
+  }
+  if (pureRemoved.length) {
+    parts.push(`removed: ${formatSymbolList(pureRemoved)}`)
+  }
+  if (updated.length) {
+    parts.push(`signature change: ${formatSymbolList(updated)}`)
+  }
+  parts.push(`+${addedLines}/-${removedLines} lines`)
+
+  return `${parts.join('. ')}.`
+}
+
+function isPatchHeader(line: string): boolean {
+  return (
+    line.startsWith('diff --git') ||
+    line.startsWith('index ') ||
+    line.startsWith('--- ') ||
+    line.startsWith('+++ ') ||
+    line.startsWith('@@') ||
+    line.startsWith('new file mode') ||
+    line.startsWith('deleted file mode') ||
+    line.startsWith('similarity index') ||
+    line.startsWith('rename from ') ||
+    line.startsWith('rename to ') ||
+    line.startsWith('Binary files ')
+  )
+}
+
+function keyOf(symbol: StructuralSymbol): string {
+  return `${symbol.kind}:${symbol.name}`
+}
+
+function formatSymbolList(symbols: StructuralSymbol[]): string {
+  const labeled = symbols.map((s) => formatSymbol(s))
+  if (labeled.length <= MAX_SYMBOLS_PER_BUCKET) return labeled.join(', ')
+  const shown = labeled.slice(0, MAX_SYMBOLS_PER_BUCKET)
+  const remainder = labeled.length - shown.length
+  return `${shown.join(', ')} (+${remainder} more)`
+}
+
+function formatSymbol(symbol: StructuralSymbol): string {
+  // Render `<kind> <name>` for non-functions to keep the summary
+  // unambiguous. Functions are by far the most common; rendering
+  // them as `name()` reads naturally inline.
+  if (symbol.kind === 'function' || symbol.kind === 'default') {
+    return `${symbol.name}()`
+  }
+  return `${symbol.kind} ${symbol.name}`
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -305,6 +305,29 @@ export const schema = {
               "type": "boolean",
               "description": "Replace the LLM summary with a templated heading extract for `.md` / `.mdx` / `.markdown` modification diffs that have clear heading-level structural changes. Diffs without structural signals (paragraph-only edits) still go to the LLM regardless of this flag.\n\nBench impact (synthetic): collapses docs-update-shaped commits from ~24s cold to ~3ms (no LLM calls fire for the markdown files). Real-world wall-clock savings depend on per-call LLM latency.",
               "default": false
+            },
+            "languageAware": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Master switch. When false (default) the languageAware path is skipped entirely regardless of `languages`.",
+                  "default": false
+                },
+                "languages": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "ts",
+                      "js"
+                    ]
+                  },
+                  "description": "Languages to opt in. Omit / empty to enable all supported languages."
+                }
+              },
+              "additionalProperties": false,
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`"
             }
           },
           "additionalProperties": false,
@@ -730,6 +753,29 @@ export const schema = {
               "type": "boolean",
               "description": "Replace the LLM summary with a templated heading extract for `.md` / `.mdx` / `.markdown` modification diffs that have clear heading-level structural changes. Diffs without structural signals (paragraph-only edits) still go to the LLM regardless of this flag.\n\nBench impact (synthetic): collapses docs-update-shaped commits from ~24s cold to ~3ms (no LLM calls fire for the markdown files). Real-world wall-clock savings depend on per-call LLM latency.",
               "default": false
+            },
+            "languageAware": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Master switch. When false (default) the languageAware path is skipped entirely regardless of `languages`.",
+                  "default": false
+                },
+                "languages": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "ts",
+                      "js"
+                    ]
+                  },
+                  "description": "Languages to opt in. Omit / empty to enable all supported languages."
+                }
+              },
+              "additionalProperties": false,
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`"
             }
           },
           "additionalProperties": false,
@@ -898,6 +944,29 @@ export const schema = {
               "type": "boolean",
               "description": "Replace the LLM summary with a templated heading extract for `.md` / `.mdx` / `.markdown` modification diffs that have clear heading-level structural changes. Diffs without structural signals (paragraph-only edits) still go to the LLM regardless of this flag.\n\nBench impact (synthetic): collapses docs-update-shaped commits from ~24s cold to ~3ms (no LLM calls fire for the markdown files). Real-world wall-clock savings depend on per-call LLM latency.",
               "default": false
+            },
+            "languageAware": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Master switch. When false (default) the languageAware path is skipped entirely regardless of `languages`.",
+                  "default": false
+                },
+                "languages": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "ts",
+                      "js"
+                    ]
+                  },
+                  "description": "Languages to opt in. Omit / empty to enable all supported languages."
+                }
+              },
+              "additionalProperties": false,
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`"
             }
           },
           "additionalProperties": false,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -80,6 +80,22 @@ export interface BaseParserOptions {
      * @default false
      */
     markdown?: boolean
+    /**
+     * Language-aware structural fast path (#883). Replaces the LLM
+     * summary with a symbol-level extract ("added parseRequest();
+     * removed legacyParse()") for source files in the listed
+     * languages. Off by default — lossy by design, and quality is
+     * harder to validate than the markdown fast path.
+     */
+    languageAware?: {
+      enabled?: boolean
+      /**
+       * Languages to opt in. Omit / empty to enable all currently
+       * supported languages. Today: 'ts' (covers .ts/.tsx/.mts/.cts),
+       * 'js' (covers .js/.jsx/.mjs/.cjs).
+       */
+      languages?: ('ts' | 'js')[]
+    }
   }
   metadata?: Partial<LlmCallMetadata>
 }


### PR DESCRIPTION
## Summary
- New \`tsStructuralDiff\` utility: recognizes top-level TS/JS declarations (function, class, interface, type, enum, const/let/var, export default) in a unified diff and emits a templated symbol-level summary (\`Updated TypeScript \\\`path\\\`. added: parseRequest(). removed: legacyParse(). +4/-3 lines.\`).
- \`summarizeFileDiff\` gains a new fast-path branch under \`fastPath.languageAware.enabled\`, with an optional \`languages\` allowlist. Off by default — lossy by design, quality not yet validated against real commits, so opt-in only (mirrors the markdown fast path convention).
- Config: new \`service.fastPath.languageAware: { enabled, languages }\` knob, threaded through \`LLMService\`, the parser-options factory, and the JSON schema (regenerated).
- Diffs without top-level structural signals (pure body / formatting edits) still go to the LLM so we don't lose fidelity on cosmetic changes.

Phase 1 of #883. This ships a regex-first extractor; tree-sitter-backed languages (Python, Rust, Go) and signature-delta detail are follow-ups. The opt-in flag means the worst case for a user enabling it pre-tree-sitter is "no improvement on languages we don't yet support," not "worse summaries."

## Test plan
- [x] \`npx tsc --noEmit\` → 0 errors
- [x] \`npx jest\` → 1523/1523 pass (24 new)
- [x] \`npx eslint\` on touched files → clean
- [x] \`npm run build:schema\` regenerated \`schema.json\` + \`schema.ts\` (\`languageAware\` appears in all three \`fastPath\` blocks)
- [ ] Manual: opt in via config, stage a TS file with both an added and a removed top-level export, run \`coco commit\` with verbose logging, confirm the file's verbose line reads \`language-aware fast-path skip\`.

Refs #883.