### PR TITLE
feat(parser): Python / Rust / Go structural extractors (#883 phase 2)

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -309,14 +309,17 @@
                     "type": "string",
                     "enum": [
                       "ts",
-                      "js"
+                      "js",
+                      "py",
+                      "rs",
+                      "go"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`"
             }
           },
           "additionalProperties": false,
@@ -757,14 +760,17 @@
                     "type": "string",
                     "enum": [
                       "ts",
-                      "js"
+                      "js",
+                      "py",
+                      "rs",
+                      "go"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`"
             }
           },
           "additionalProperties": false,
@@ -948,14 +954,17 @@
                     "type": "string",
                     "enum": [
                       "ts",
-                      "js"
+                      "js",
+                      "py",
+                      "rs",
+                      "go"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`"
             }
           },
           "additionalProperties": false,

--- a/src/lib/langchain/types.ts
+++ b/src/lib/langchain/types.ts
@@ -206,6 +206,9 @@ export type BaseLLMService = {
      * Currently supports:
      *   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`
      *   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`
+     *   - 'py' : `.py` / `.pyi`
+     *   - 'rs' : `.rs`
+     *   - 'go' : `.go`
      */
     languageAware?: {
       /**
@@ -219,7 +222,7 @@ export type BaseLLMService = {
        * Languages to opt in. Omit / empty to enable all supported
        * languages.
        */
-      languages?: ('ts' | 'js')[]
+      languages?: ('ts' | 'js' | 'py' | 'rs' | 'go')[]
     }
   }
 }

--- a/src/lib/parsers/default/utils/createFileChangeParserOptions.ts
+++ b/src/lib/parsers/default/utils/createFileChangeParserOptions.ts
@@ -14,7 +14,7 @@ export type FileChangeParserServiceBudget = {
     markdown?: boolean
     languageAware?: {
       enabled?: boolean
-      languages?: ('ts' | 'js')[]
+      languages?: ('ts' | 'js' | 'py' | 'rs' | 'go')[]
     }
   }
 }

--- a/src/lib/parsers/default/utils/goStructuralDiff.test.ts
+++ b/src/lib/parsers/default/utils/goStructuralDiff.test.ts
@@ -1,0 +1,109 @@
+import { FileDiff } from '../../../types'
+import {
+  isGoFile,
+  parseGoStructuralLine,
+  summarizeGoStructuralDiff,
+} from './goStructuralDiff'
+
+function fileDiff(file: string, diff: string): FileDiff {
+  return { file, diff, tokenCount: diff.length, summary: '' } as FileDiff
+}
+
+describe('isGoFile', () => {
+  it('matches .go files only', () => {
+    expect(isGoFile('cmd/main.go')).toBe(true)
+    expect(isGoFile('cmd/main.gomod')).toBe(false)
+    expect(isGoFile('cmd/main.ts')).toBe(false)
+  })
+})
+
+describe('parseGoStructuralLine', () => {
+  it('recognizes top-level funcs and exports based on capitalization', () => {
+    expect(parseGoStructuralLine('func ParseRequest(input string) error {')).toEqual({
+      name: 'ParseRequest', kind: 'function', exported: true,
+    })
+    expect(parseGoStructuralLine('func helper() {}')).toEqual({
+      name: 'helper', kind: 'function', exported: false,
+    })
+  })
+
+  it('recognizes method receivers and renders Receiver.method', () => {
+    const method = parseGoStructuralLine('func (w *Widget) Render(ctx Context) error {')
+    expect(method?.kind).toBe('method')
+    expect(method?.name).toBe('Widget.Render')
+    expect(method?.exported).toBe(true)
+
+    const valueMethod = parseGoStructuralLine('func (w Widget) String() string {')
+    expect(valueMethod?.name).toBe('Widget.String')
+  })
+
+  it('recognizes type struct / interface declarations', () => {
+    expect(parseGoStructuralLine('type Widget struct {')).toEqual({
+      name: 'Widget', kind: 'class', exported: true,
+    })
+    expect(parseGoStructuralLine('type Renderer interface {')).toEqual({
+      name: 'Renderer', kind: 'interface', exported: true,
+    })
+  })
+
+  it('recognizes type aliases', () => {
+    expect(parseGoStructuralLine('type Handler func(Context) error')).toEqual({
+      name: 'Handler', kind: 'type', exported: true,
+    })
+  })
+
+  it('recognizes single-line var / const declarations', () => {
+    expect(parseGoStructuralLine('var DefaultTimeout = 30 * time.Second')).toEqual({
+      name: 'DefaultTimeout', kind: 'const', exported: true,
+    })
+    expect(parseGoStructuralLine('const maxRetries = 3')).toEqual({
+      name: 'maxRetries', kind: 'const', exported: false,
+    })
+    expect(parseGoStructuralLine('const MaxRetries int = 3')).toEqual({
+      name: 'MaxRetries', kind: 'const', exported: true,
+    })
+  })
+
+  it('ignores indented lines', () => {
+    expect(parseGoStructuralLine('    func inner() {')).toBeUndefined()
+    expect(parseGoStructuralLine('\tfunc inner() {')).toBeUndefined()
+  })
+
+  it('returns undefined for non-declaration lines', () => {
+    expect(parseGoStructuralLine('package main')).toBeUndefined()
+    expect(parseGoStructuralLine('import "fmt"')).toBeUndefined()
+    expect(parseGoStructuralLine('// comment')).toBeUndefined()
+    expect(parseGoStructuralLine('')).toBeUndefined()
+  })
+})
+
+describe('summarizeGoStructuralDiff', () => {
+  it('returns undefined for non-Go files', () => {
+    expect(summarizeGoStructuralDiff(fileDiff('README.md', '+x'))).toBeUndefined()
+  })
+
+  it('names added top-level funcs + methods', () => {
+    const diff = [
+      '@@ -0,0 +1,3 @@',
+      '+type Widget struct {}',
+      '+func NewWidget() *Widget { return &Widget{} }',
+      '+func (w *Widget) Render() error { return nil }',
+    ].join('\n')
+    const out = summarizeGoStructuralDiff(fileDiff('widget.go', diff)) || ''
+    expect(out).toContain('Updated Go `widget.go`')
+    expect(out).toMatch(/NewWidget\(\)/)
+    expect(out).toMatch(/Widget\.Render\(\)/)
+    expect(out).toMatch(/class Widget/)
+  })
+
+  it('returns undefined for body-only edits', () => {
+    const diff = [
+      '@@ -1,3 +1,3 @@',
+      ' func Compute(x int) int {',
+      '-    return x',
+      '+    return x * 2',
+      ' }',
+    ].join('\n')
+    expect(summarizeGoStructuralDiff(fileDiff('lib.go', diff))).toBeUndefined()
+  })
+})

--- a/src/lib/parsers/default/utils/goStructuralDiff.ts
+++ b/src/lib/parsers/default/utils/goStructuralDiff.ts
@@ -1,0 +1,90 @@
+import { FileDiff } from '../../../types'
+import {
+  StructuralSymbol,
+  summarizeStructuralDiff,
+} from './structuralDiff'
+
+/**
+ * Go structural fast path (#883, phase 2).
+ *
+ * Recognizes top-level declarations: func (incl. method receivers),
+ * type X struct / interface, var / const blocks. Exported is set
+ * when the identifier starts with an uppercase letter (Go's
+ * canonical export marker).
+ *
+ * Go has no leading indent at file scope and gofmt normalizes
+ * the rest, so we keep the indent gate tight: only lines at
+ * column 0 are recognized as top-level declarations. Methods on
+ * receivers render as `Receiver.method()` to make the surface
+ * change readable in the summary.
+ */
+
+const GO_EXTENSIONS = ['.go']
+
+export function isGoFile(path: string): boolean {
+  const lower = path.toLowerCase()
+  return GO_EXTENSIONS.some((ext) => lower.endsWith(ext))
+}
+
+function isExportedGoName(name: string): boolean {
+  // Go exports an identifier when its first character is upper-case
+  // ASCII or a Unicode letter that's upper-case. Stick to ASCII —
+  // Unicode identifiers exist but are vanishingly rare in idiomatic
+  // Go and a misclassification on those is a non-issue.
+  const first = name[0]
+  return first >= 'A' && first <= 'Z'
+}
+
+export function parseGoStructuralLine(line: string): StructuralSymbol | undefined {
+  // Top-level only.
+  if (line.startsWith(' ') || line.startsWith('\t')) return undefined
+  const body = line
+
+  // Methods: `func (r *Receiver) Name(...) ...`
+  const methodMatch = body.match(/^func\s*\(\s*\w+\s+\*?(\w+)\s*\)\s+([A-Za-z_][\w]*)/)
+  if (methodMatch) {
+    const display = `${methodMatch[1]}.${methodMatch[2]}`
+    return { name: display, kind: 'method', exported: isExportedGoName(methodMatch[2]) }
+  }
+
+  // Plain functions: `func Name(...) ...`
+  const fnMatch = body.match(/^func\s+([A-Za-z_][\w]*)\s*\(/)
+  if (fnMatch) {
+    return { name: fnMatch[1], kind: 'function', exported: isExportedGoName(fnMatch[1]) }
+  }
+
+  // type X struct / interface — surface as 'class' / 'interface'
+  // respectively to align with how the shared renderer formats them.
+  const structMatch = body.match(/^type\s+([A-Za-z_][\w]*)\s+struct\b/)
+  if (structMatch) {
+    return { name: structMatch[1], kind: 'class', exported: isExportedGoName(structMatch[1]) }
+  }
+  const interfaceMatch = body.match(/^type\s+([A-Za-z_][\w]*)\s+interface\b/)
+  if (interfaceMatch) {
+    return { name: interfaceMatch[1], kind: 'interface', exported: isExportedGoName(interfaceMatch[1]) }
+  }
+  // Other `type Foo = X` / `type Foo X` aliases.
+  const typeAliasMatch = body.match(/^type\s+([A-Za-z_][\w]*)\s+/)
+  if (typeAliasMatch) {
+    return { name: typeAliasMatch[1], kind: 'type', exported: isExportedGoName(typeAliasMatch[1]) }
+  }
+
+  // var / const single-line declarations with an identifier. Block
+  // forms (`var ( … )`) span multiple lines; we don't attempt to
+  // promote the inner names — anything inside the parens is
+  // indented, so the indent gate above already skips them.
+  const varMatch = body.match(/^(?:var|const)\s+([A-Za-z_][\w]*)\s+/)
+  if (varMatch) {
+    return { name: varMatch[1], kind: 'const', exported: isExportedGoName(varMatch[1]) }
+  }
+
+  return undefined
+}
+
+export function summarizeGoStructuralDiff(fileDiff: FileDiff): string | undefined {
+  if (!isGoFile(fileDiff.file)) return undefined
+  return summarizeStructuralDiff(fileDiff, {
+    label: 'Go',
+    parseLine: parseGoStructuralLine,
+  })
+}

--- a/src/lib/parsers/default/utils/pythonStructuralDiff.test.ts
+++ b/src/lib/parsers/default/utils/pythonStructuralDiff.test.ts
@@ -1,0 +1,121 @@
+import { FileDiff } from '../../../types'
+import {
+  isPythonFile,
+  parsePythonStructuralLine,
+  summarizePythonStructuralDiff,
+} from './pythonStructuralDiff'
+
+function fileDiff(file: string, diff: string): FileDiff {
+  return { file, diff, tokenCount: diff.length, summary: '' } as FileDiff
+}
+
+describe('isPythonFile', () => {
+  it('matches .py and .pyi', () => {
+    expect(isPythonFile('src/foo.py')).toBe(true)
+    expect(isPythonFile('types/bar.pyi')).toBe(true)
+  })
+  it('rejects unrelated extensions', () => {
+    expect(isPythonFile('src/foo.ts')).toBe(false)
+    expect(isPythonFile('README.md')).toBe(false)
+  })
+})
+
+describe('parsePythonStructuralLine', () => {
+  it('recognizes module-level def / async def', () => {
+    expect(parsePythonStructuralLine('def parse(input):')).toEqual({
+      name: 'parse', kind: 'function', exported: true,
+    })
+    expect(parsePythonStructuralLine('async def fetch(url):')).toEqual({
+      name: 'fetch', kind: 'function', exported: true,
+    })
+  })
+
+  it('marks underscore-prefixed names as not exported', () => {
+    expect(parsePythonStructuralLine('def _internal_helper():')).toEqual({
+      name: '_internal_helper', kind: 'function', exported: false,
+    })
+  })
+
+  it('recognizes class declarations', () => {
+    expect(parsePythonStructuralLine('class Widget(Base):')).toEqual({
+      name: 'Widget', kind: 'class', exported: true,
+    })
+  })
+
+  it('recognizes PEP 695 type aliases', () => {
+    expect(parsePythonStructuralLine('type Handler = Callable[[str], int]')).toEqual({
+      name: 'Handler', kind: 'type', exported: true,
+    })
+  })
+
+  it('recognizes ALL_CAPS module constants but not lowercase assignments', () => {
+    expect(parsePythonStructuralLine('TIMEOUT = 5000')).toEqual({
+      name: 'TIMEOUT', kind: 'const', exported: true,
+    })
+    expect(parsePythonStructuralLine('MAX_RETRIES: int = 3')).toEqual({
+      name: 'MAX_RETRIES', kind: 'const', exported: true,
+    })
+    // Lowercase module-level assignments are too noisy to flag.
+    expect(parsePythonStructuralLine('config = {}')).toBeUndefined()
+  })
+
+  it('ignores indented lines (inside a block)', () => {
+    expect(parsePythonStructuralLine('    def inner():')).toBeUndefined()
+    expect(parsePythonStructuralLine('\tdef inner():')).toBeUndefined()
+    expect(parsePythonStructuralLine('  TIMEOUT = 5')).toBeUndefined()
+  })
+
+  it('ignores decorator lines (the next def carries the signal)', () => {
+    expect(parsePythonStructuralLine('@dataclass')).toBeUndefined()
+    expect(parsePythonStructuralLine('@app.route("/")')).toBeUndefined()
+  })
+
+  it('returns undefined for non-declaration lines', () => {
+    expect(parsePythonStructuralLine('import os')).toBeUndefined()
+    expect(parsePythonStructuralLine('# a comment')).toBeUndefined()
+    expect(parsePythonStructuralLine('')).toBeUndefined()
+    // `==` comparison must not be misread as a constant assignment
+    expect(parsePythonStructuralLine('IF FOO == BAR:')).toBeUndefined()
+  })
+})
+
+describe('summarizePythonStructuralDiff', () => {
+  it('returns undefined for non-Python files', () => {
+    expect(summarizePythonStructuralDiff(fileDiff('README.md', '+x'))).toBeUndefined()
+  })
+
+  it('names added top-level defs', () => {
+    const diff = [
+      '@@ -1,1 +1,4 @@',
+      ' import json',
+      '+def parse_request(input):',
+      '+    return json.loads(input)',
+      '+TIMEOUT = 30',
+    ].join('\n')
+    const out = summarizePythonStructuralDiff(fileDiff('src/parser.py', diff)) || ''
+    expect(out).toContain('Updated Python `src/parser.py`')
+    expect(out).toContain('parse_request()')
+    expect(out).toContain('const TIMEOUT')
+    expect(out).toContain('+3/-0 lines')
+  })
+
+  it('returns undefined for paragraph-only / body-only edits', () => {
+    const diff = [
+      '@@ -1,3 +1,3 @@',
+      ' def parse(x):',
+      '-    return x',
+      '+    return x * 2',
+    ].join('\n')
+    expect(summarizePythonStructuralDiff(fileDiff('src/p.py', diff))).toBeUndefined()
+  })
+
+  it('groups signature changes', () => {
+    const diff = [
+      '@@ -1,1 +1,1 @@',
+      '-def parse(input):',
+      '+def parse(input, schema):',
+    ].join('\n')
+    const out = summarizePythonStructuralDiff(fileDiff('src/p.py', diff)) || ''
+    expect(out).toContain('signature change: parse()')
+  })
+})

--- a/src/lib/parsers/default/utils/pythonStructuralDiff.ts
+++ b/src/lib/parsers/default/utils/pythonStructuralDiff.ts
@@ -1,0 +1,82 @@
+import { FileDiff } from '../../../types'
+import {
+  StructuralSymbol,
+  summarizeStructuralDiff,
+} from './structuralDiff'
+
+/**
+ * Python structural fast path (#883, phase 2).
+ *
+ * Mirrors the TS extractor: recognize module-level declarations
+ * (def, class, type aliases via `T = …`) and emit a templated
+ * summary when a diff names at least one of them.
+ *
+ * Python's indentation-as-syntax makes "top-level" cheap to check:
+ * a declaration at column 0 is module-scope; anything indented is
+ * inside a block (class body, function body) and we leave it for
+ * the LLM. Decorators belong to the following def — we recognize
+ * them as a soft signal and attribute the symbol to its decorated
+ * name on the next non-decorator line. For simplicity (and because
+ * the per-line parser is stateless), we just skip decorator lines
+ * and let the def below them carry the signal.
+ */
+
+const PYTHON_EXTENSIONS = ['.py', '.pyi']
+
+export function isPythonFile(path: string): boolean {
+  const lower = path.toLowerCase()
+  return PYTHON_EXTENSIONS.some((ext) => lower.endsWith(ext))
+}
+
+export function parsePythonStructuralLine(line: string): StructuralSymbol | undefined {
+  // Module-scope only — Python indents matter. Strip a single
+  // leading space (the diff's column-0 alignment) and reject any
+  // further indentation. `\t` at the start of a real line is also
+  // a non-module-scope signal.
+  if (line.startsWith('\t')) return undefined
+  const trimmed = line.replace(/^ /, '')
+  if (trimmed.startsWith(' ') || trimmed.startsWith('\t')) return undefined
+
+  // Decorator line. The next def/class line carries the actual
+  // symbol; without state we can't promote the decorator into a
+  // symbol of its own, so skip.
+  if (trimmed.startsWith('@')) return undefined
+
+  // def / async def
+  const fnMatch = trimmed.match(/^(?:async\s+)?def\s+([A-Za-z_][\w]*)\s*\(/)
+  if (fnMatch) {
+    return { name: fnMatch[1], kind: 'function', exported: !fnMatch[1].startsWith('_') }
+  }
+
+  // class
+  const classMatch = trimmed.match(/^class\s+([A-Za-z_][\w]*)/)
+  if (classMatch) {
+    return { name: classMatch[1], kind: 'class', exported: !classMatch[1].startsWith('_') }
+  }
+
+  // Module-level type alias (PEP 695: `type Name = ...`)
+  const pep695Match = trimmed.match(/^type\s+([A-Za-z_][\w]*)\s*=/)
+  if (pep695Match) {
+    return { name: pep695Match[1], kind: 'type', exported: !pep695Match[1].startsWith('_') }
+  }
+
+  // Module-level CONSTANTS or annotated assignments. Restrict to
+  // ALL_CAPS identifiers — module-level lowercase assignments are
+  // common (config dicts, etc.) and surfacing them all would be
+  // noisy. ALL_CAPS is the Python convention for "this is a
+  // named module-level value worth flagging".
+  const constMatch = trimmed.match(/^([A-Z][A-Z0-9_]*)\s*(?::|=[^=])/)
+  if (constMatch) {
+    return { name: constMatch[1], kind: 'const', exported: true }
+  }
+
+  return undefined
+}
+
+export function summarizePythonStructuralDiff(fileDiff: FileDiff): string | undefined {
+  if (!isPythonFile(fileDiff.file)) return undefined
+  return summarizeStructuralDiff(fileDiff, {
+    label: 'Python',
+    parseLine: parsePythonStructuralLine,
+  })
+}

--- a/src/lib/parsers/default/utils/rustStructuralDiff.test.ts
+++ b/src/lib/parsers/default/utils/rustStructuralDiff.test.ts
@@ -1,0 +1,130 @@
+import { FileDiff } from '../../../types'
+import {
+  isRustFile,
+  parseRustStructuralLine,
+  summarizeRustStructuralDiff,
+} from './rustStructuralDiff'
+
+function fileDiff(file: string, diff: string): FileDiff {
+  return { file, diff, tokenCount: diff.length, summary: '' } as FileDiff
+}
+
+describe('isRustFile', () => {
+  it('matches .rs files only', () => {
+    expect(isRustFile('src/main.rs')).toBe(true)
+    expect(isRustFile('src/main.ts')).toBe(false)
+  })
+})
+
+describe('parseRustStructuralLine', () => {
+  it('recognizes pub fn / pub async fn / pub const fn', () => {
+    expect(parseRustStructuralLine('pub fn parse(input: &str) -> Result<(), Error> {')).toEqual({
+      name: 'parse', kind: 'function', exported: true,
+    })
+    expect(parseRustStructuralLine('pub async fn fetch(url: &str) -> Bytes {')).toEqual({
+      name: 'fetch', kind: 'function', exported: true,
+    })
+    expect(parseRustStructuralLine('pub const fn compute() -> usize {')).toEqual({
+      name: 'compute', kind: 'function', exported: true,
+    })
+  })
+
+  it('marks non-pub fns as not exported', () => {
+    expect(parseRustStructuralLine('fn helper() {}')).toEqual({
+      name: 'helper', kind: 'function', exported: false,
+    })
+  })
+
+  it('handles visibility modifiers (pub(crate), pub(super))', () => {
+    expect(parseRustStructuralLine('pub(crate) fn helper() {}')?.exported).toBe(true)
+    expect(parseRustStructuralLine('pub(super) struct Inner;')?.exported).toBe(true)
+  })
+
+  it('recognizes struct / enum / trait declarations', () => {
+    expect(parseRustStructuralLine('pub struct Widget {')).toEqual({
+      name: 'Widget', kind: 'class', exported: true,
+    })
+    expect(parseRustStructuralLine('pub enum Color {')).toEqual({
+      name: 'Color', kind: 'enum', exported: true,
+    })
+    expect(parseRustStructuralLine('pub trait Renderable {')).toEqual({
+      name: 'Renderable', kind: 'trait', exported: true,
+    })
+  })
+
+  it('recognizes impl blocks (both Trait-for-Type and plain Type)', () => {
+    const plain = parseRustStructuralLine('impl Widget {')
+    expect(plain?.kind).toBe('impl')
+    expect(plain?.name).toBe('Widget')
+
+    const traitImpl = parseRustStructuralLine('impl Renderable for Widget {')
+    expect(traitImpl?.kind).toBe('impl')
+    expect(traitImpl?.name).toBe('Renderable for Widget')
+  })
+
+  it('recognizes type aliases', () => {
+    expect(parseRustStructuralLine('pub type Handler = fn(Request) -> Response')).toEqual({
+      name: 'Handler', kind: 'type', exported: true,
+    })
+  })
+
+  it('recognizes ALL_CAPS const / static', () => {
+    expect(parseRustStructuralLine('pub const TIMEOUT: u32 = 30')).toEqual({
+      name: 'TIMEOUT', kind: 'const', exported: true,
+    })
+    expect(parseRustStructuralLine('static MAX_BUFFER: usize = 4096')).toEqual({
+      name: 'MAX_BUFFER', kind: 'const', exported: false,
+    })
+  })
+
+  it('recognizes mod declarations', () => {
+    expect(parseRustStructuralLine('pub mod parser;')).toEqual({
+      name: 'parser', kind: 'module', exported: true,
+    })
+    expect(parseRustStructuralLine('mod internal {')).toEqual({
+      name: 'internal', kind: 'module', exported: false,
+    })
+  })
+
+  it('ignores deeply indented lines', () => {
+    expect(parseRustStructuralLine('        fn deep() {}')).toBeUndefined()
+  })
+
+  it('returns undefined for non-declaration lines', () => {
+    expect(parseRustStructuralLine('use std::io;')).toBeUndefined()
+    expect(parseRustStructuralLine('// a comment')).toBeUndefined()
+    expect(parseRustStructuralLine('let x = 1;')).toBeUndefined()
+    expect(parseRustStructuralLine('')).toBeUndefined()
+  })
+})
+
+describe('summarizeRustStructuralDiff', () => {
+  it('returns undefined for non-Rust files', () => {
+    expect(summarizeRustStructuralDiff(fileDiff('README.md', '+x'))).toBeUndefined()
+  })
+
+  it('names added top-level fns and the impl block they appear in', () => {
+    const diff = [
+      '@@ -0,0 +1,4 @@',
+      '+pub fn parse_request(input: &str) {}',
+      '+pub struct Widget;',
+      '+impl Renderable for Widget {}',
+    ].join('\n')
+    const out = summarizeRustStructuralDiff(fileDiff('src/lib.rs', diff)) || ''
+    expect(out).toContain('Updated Rust `src/lib.rs`')
+    expect(out).toMatch(/parse_request\(\)/)
+    expect(out).toMatch(/class Widget/)
+    expect(out).toMatch(/impl Renderable for Widget/)
+  })
+
+  it('returns undefined for body-only edits', () => {
+    const diff = [
+      '@@ -1,3 +1,3 @@',
+      ' pub fn parse() -> u32 {',
+      '-    1',
+      '+    2',
+      ' }',
+    ].join('\n')
+    expect(summarizeRustStructuralDiff(fileDiff('src/lib.rs', diff))).toBeUndefined()
+  })
+})

--- a/src/lib/parsers/default/utils/rustStructuralDiff.ts
+++ b/src/lib/parsers/default/utils/rustStructuralDiff.ts
@@ -1,0 +1,95 @@
+import { FileDiff } from '../../../types'
+import {
+  StructuralSymbol,
+  summarizeStructuralDiff,
+} from './structuralDiff'
+
+/**
+ * Rust structural fast path (#883, phase 2).
+ *
+ * Recognizes top-level / impl-block-level declarations: fn, struct,
+ * enum, trait, impl, type aliases, pub const / pub static. The
+ * "exported" flag tracks `pub` visibility — Rust's primary public
+ * surface marker.
+ *
+ * Indentation in Rust isn't load-bearing, but real-world rustfmt
+ * output keeps `impl` blocks and free fns at column 0 / 4 (one
+ * level inside a module). We accept up to 4 spaces of leading
+ * indent so the common rustfmt patterns get caught; anything
+ * deeper is almost certainly inside a body.
+ */
+
+const RUST_EXTENSIONS = ['.rs']
+
+export function isRustFile(path: string): boolean {
+  const lower = path.toLowerCase()
+  return RUST_EXTENSIONS.some((ext) => lower.endsWith(ext))
+}
+
+export function parseRustStructuralLine(line: string): StructuralSymbol | undefined {
+  // Up to 4 spaces of indent accepted — see header comment. Tabs
+  // are rarer in Rust but we accept one if present.
+  const trimmed = line.replace(/^[ \t]{0,4}/, '')
+  const leftover = trimmed.replace(/^[ \t]+/, '')
+  if (leftover !== trimmed) return undefined
+
+  let body = trimmed
+  let exported = false
+  // `pub(crate)`, `pub(super)`, `pub(in path)` — all visibility-
+  // modifier forms count as "exported" for our purposes.
+  const pubMatch = body.match(/^pub(?:\([^)]+\))?\s+/)
+  if (pubMatch) {
+    exported = true
+    body = body.slice(pubMatch[0].length)
+  }
+  // Skip `unsafe` / `async` / `extern "C"` / `const` modifiers
+  // ahead of fn so the fn matcher gets the bare keyword. Order
+  // matters: `const fn` is a const-eval function.
+  body = body.replace(/^(?:unsafe\s+)?(?:async\s+)?(?:extern\s+"[^"]*"\s+)?/, '')
+
+  // const fn / async fn / unsafe fn — match the fn after the
+  // modifier strip above.
+  const fnMatch = body.match(/^(?:const\s+)?fn\s+([A-Za-z_][\w]*)/)
+  if (fnMatch) return { name: fnMatch[1], kind: 'function', exported }
+
+  const structMatch = body.match(/^struct\s+([A-Za-z_][\w]*)/)
+  if (structMatch) return { name: structMatch[1], kind: 'class', exported }
+
+  const enumMatch = body.match(/^enum\s+([A-Za-z_][\w]*)/)
+  if (enumMatch) return { name: enumMatch[1], kind: 'enum', exported }
+
+  const traitMatch = body.match(/^trait\s+([A-Za-z_][\w]*)/)
+  if (traitMatch) return { name: traitMatch[1], kind: 'trait', exported }
+
+  // `impl Trait for Type` and `impl Type` — surface the impl block
+  // header so the user sees which type's surface area changed. The
+  // shared renderer formats `impl X` with the kind label.
+  const implMatch = body.match(/^impl(?:\s*<[^>]+>)?\s+(?:(\w[\w:<>]*)\s+for\s+)?([A-Za-z_][\w:<>]*)/)
+  if (implMatch) {
+    const traitName = implMatch[1]
+    const typeName = implMatch[2]
+    const display = traitName ? `${traitName} for ${typeName}` : typeName
+    return { name: display, kind: 'impl', exported }
+  }
+
+  const typeMatch = body.match(/^type\s+([A-Za-z_][\w]*)\s*[=<]/)
+  if (typeMatch) return { name: typeMatch[1], kind: 'type', exported }
+
+  const constMatch = body.match(/^(?:const|static)\s+([A-Z_][A-Z0-9_]*)\s*:/)
+  if (constMatch) return { name: constMatch[1], kind: 'const', exported }
+
+  // `mod foo;` / `mod foo { ... }` at module scope. Submodules are
+  // load-bearing structural signals in Rust crates.
+  const modMatch = body.match(/^mod\s+([A-Za-z_][\w]*)\s*[;{]/)
+  if (modMatch) return { name: modMatch[1], kind: 'module', exported }
+
+  return undefined
+}
+
+export function summarizeRustStructuralDiff(fileDiff: FileDiff): string | undefined {
+  if (!isRustFile(fileDiff.file)) return undefined
+  return summarizeStructuralDiff(fileDiff, {
+    label: 'Rust',
+    parseLine: parseRustStructuralLine,
+  })
+}

--- a/src/lib/parsers/default/utils/structuralDiff.ts
+++ b/src/lib/parsers/default/utils/structuralDiff.ts
@@ -1,0 +1,133 @@
+/**
+ * Shared rendering / scaffolding for language-aware structural
+ * extractors (#883). Each language module supplies a per-line
+ * symbol parser; this module owns the diff walking, the
+ * added/removed/updated bucketing, and the summary formatting so
+ * the per-language modules stay focused on language-specific
+ * recognition.
+ */
+
+import { FileDiff } from '../../../types'
+
+export type StructuralSymbolKind =
+  | 'function'
+  | 'class'
+  | 'interface'
+  | 'type'
+  | 'const'
+  | 'enum'
+  | 'default'
+  | 'method'
+  | 'impl'
+  | 'trait'
+  | 'module'
+
+export type StructuralSymbol = {
+  /**
+   * Display name. For methods on a known receiver, render as
+   * `Receiver::name` (Rust) / `Receiver.name` (Python). The
+   * per-language parser owns that choice — the shared renderer
+   * just prints what it gets.
+   */
+  name: string
+  kind: StructuralSymbolKind
+  exported: boolean
+}
+
+const MAX_SYMBOLS_PER_BUCKET = 8
+
+export type StructuralLineParser = (line: string) => StructuralSymbol | undefined
+
+export type StructuralDiffSummaryOptions = {
+  /** Human label, e.g. "TypeScript" / "Python". Appears in the summary's leading clause. */
+  label: string
+  /** Per-line parser for this language. */
+  parseLine: StructuralLineParser
+}
+
+/**
+ * Walk a unified diff and emit a templated summary when at least
+ * one top-level symbol changes. Returns undefined when the diff
+ * has no body changes (caller falls through to nothing) or no
+ * structural signals (caller falls through to the LLM so paragraph-
+ * only / cosmetic edits keep their full-fidelity summary).
+ */
+export function summarizeStructuralDiff(
+  fileDiff: FileDiff,
+  options: StructuralDiffSummaryOptions,
+): string | undefined {
+  const added = new Map<string, StructuralSymbol>()
+  const removed = new Map<string, StructuralSymbol>()
+  let addedLines = 0
+  let removedLines = 0
+
+  for (const line of fileDiff.diff.split('\n')) {
+    if (isPatchHeader(line)) continue
+    if (line.startsWith('+')) {
+      addedLines++
+      const symbol = options.parseLine(line.slice(1))
+      if (symbol) added.set(keyOf(symbol), symbol)
+    } else if (line.startsWith('-')) {
+      removedLines++
+      const symbol = options.parseLine(line.slice(1))
+      if (symbol) removed.set(keyOf(symbol), symbol)
+    }
+  }
+
+  if (addedLines === 0 && removedLines === 0) return undefined
+  if (added.size === 0 && removed.size === 0) return undefined
+
+  const updatedKeys = new Set([...added.keys()].filter((k) => removed.has(k)))
+  const pureAdded = [...added.values()].filter((s) => !updatedKeys.has(keyOf(s)))
+  const pureRemoved = [...removed.values()].filter((s) => !updatedKeys.has(keyOf(s)))
+  const updated = [...updatedKeys].map((k) => added.get(k) as StructuralSymbol)
+
+  const parts: string[] = [`Updated ${options.label} \`${fileDiff.file}\``]
+  if (pureAdded.length) parts.push(`added: ${formatSymbolList(pureAdded)}`)
+  if (pureRemoved.length) parts.push(`removed: ${formatSymbolList(pureRemoved)}`)
+  if (updated.length) parts.push(`signature change: ${formatSymbolList(updated)}`)
+  parts.push(`+${addedLines}/-${removedLines} lines`)
+
+  return `${parts.join('. ')}.`
+}
+
+export function isPatchHeader(line: string): boolean {
+  return (
+    line.startsWith('diff --git') ||
+    line.startsWith('index ') ||
+    line.startsWith('--- ') ||
+    line.startsWith('+++ ') ||
+    line.startsWith('@@') ||
+    line.startsWith('new file mode') ||
+    line.startsWith('deleted file mode') ||
+    line.startsWith('similarity index') ||
+    line.startsWith('rename from ') ||
+    line.startsWith('rename to ') ||
+    line.startsWith('Binary files ')
+  )
+}
+
+function keyOf(symbol: StructuralSymbol): string {
+  return `${symbol.kind}:${symbol.name}`
+}
+
+function formatSymbolList(symbols: StructuralSymbol[]): string {
+  const labeled = symbols.map((s) => formatSymbol(s))
+  if (labeled.length <= MAX_SYMBOLS_PER_BUCKET) return labeled.join(', ')
+  const shown = labeled.slice(0, MAX_SYMBOLS_PER_BUCKET)
+  const remainder = labeled.length - shown.length
+  return `${shown.join(', ')} (+${remainder} more)`
+}
+
+function formatSymbol(symbol: StructuralSymbol): string {
+  // Functions / methods / default-exports read most naturally as
+  // `name()`. Everything else gets a kind prefix to disambiguate.
+  if (
+    symbol.kind === 'function' ||
+    symbol.kind === 'default' ||
+    symbol.kind === 'method'
+  ) {
+    return `${symbol.name}()`
+  }
+  return `${symbol.kind} ${symbol.name}`
+}

--- a/src/lib/parsers/default/utils/summarizeDiffs.ts
+++ b/src/lib/parsers/default/utils/summarizeDiffs.ts
@@ -186,7 +186,7 @@ export type SummarizeDiffsOptions = {
     markdown?: boolean
     languageAware?: {
       enabled?: boolean
-      languages?: ('ts' | 'js')[]
+      languages?: ('ts' | 'js' | 'py' | 'rs' | 'go')[]
     }
   }
   handleOutput?: typeof defaultOutputCallback

--- a/src/lib/parsers/default/utils/summarizeLargeFiles.ts
+++ b/src/lib/parsers/default/utils/summarizeLargeFiles.ts
@@ -10,8 +10,46 @@ import {
   writeDiffSummary,
 } from './diffSummaryCache'
 import { summarizeMarkdownDiff } from './markdownDiff'
-import { detectStructuralLanguage, summarizeTsStructuralDiff } from './tsStructuralDiff'
+import { summarizeGoStructuralDiff, isGoFile } from './goStructuralDiff'
+import { summarizePythonStructuralDiff, isPythonFile } from './pythonStructuralDiff'
+import { summarizeRustStructuralDiff, isRustFile } from './rustStructuralDiff'
+import { detectTsLanguage, summarizeTsStructuralDiff } from './tsStructuralDiff'
 import { summarizeTrivialDiff } from './trivialDiff'
+
+/**
+ * Language identifier shared by the `service.fastPath.languageAware`
+ * config knob and the dispatcher below. Adding a new language is two
+ * lines: append the identifier to this union (mirrored in
+ * `lib/langchain/types.ts` for schema generation), and add a case to
+ * `dispatchStructuralSummary`.
+ */
+type StructuralLanguageId = 'ts' | 'js' | 'py' | 'rs' | 'go'
+
+function detectStructuralLanguageId(path: string): StructuralLanguageId | undefined {
+  const ts = detectTsLanguage(path)
+  if (ts) return ts
+  if (isPythonFile(path)) return 'py'
+  if (isRustFile(path)) return 'rs'
+  if (isGoFile(path)) return 'go'
+  return undefined
+}
+
+function dispatchStructuralSummary(
+  language: StructuralLanguageId,
+  fileDiff: import('../../../types').FileDiff,
+): string | undefined {
+  switch (language) {
+    case 'ts':
+    case 'js':
+      return summarizeTsStructuralDiff(fileDiff)
+    case 'py':
+      return summarizePythonStructuralDiff(fileDiff)
+    case 'rs':
+      return summarizeRustStructuralDiff(fileDiff)
+    case 'go':
+      return summarizeGoStructuralDiff(fileDiff)
+  }
+}
 
 /**
  * Cache opt-out: COCO_NO_CACHE=1 disables both reads and writes
@@ -60,7 +98,7 @@ export type SummarizeLargeFilesOptions = {
      */
     languageAware?: {
       enabled?: boolean
-      languages?: ('ts' | 'js')[]
+      languages?: ('ts' | 'js' | 'py' | 'rs' | 'go')[]
     }
   }
   tokenizer: TokenCounter
@@ -135,12 +173,12 @@ async function summarizeFileDiff(
   // via regex extraction; richer (tree-sitter-backed) languages
   // arrive in follow-up PRs.
   if (fastPath?.languageAware?.enabled) {
-    const language = detectStructuralLanguage(fileDiff.file)
+    const language = detectStructuralLanguageId(fileDiff.file)
     const allowed = fastPath.languageAware.languages
     const languageEnabled = language !== undefined &&
       (!allowed || allowed.length === 0 || allowed.includes(language))
     if (languageEnabled) {
-      const structuralSummary = summarizeTsStructuralDiff(fileDiff)
+      const structuralSummary = dispatchStructuralSummary(language, fileDiff)
       if (structuralSummary !== undefined) {
         logger.verbose(
           ` - ${fileDiff.file}: language-aware fast-path skip (no LLM call)`,

--- a/src/lib/parsers/default/utils/tsStructuralDiff.ts
+++ b/src/lib/parsers/default/utils/tsStructuralDiff.ts
@@ -1,4 +1,8 @@
 import { FileDiff } from '../../../types'
+import {
+  StructuralSymbol,
+  summarizeStructuralDiff,
+} from './structuralDiff'
 
 /**
  * TypeScript / JavaScript structural fast path (#883, phase 1).
@@ -8,22 +12,10 @@ import { FileDiff } from '../../../types'
  * exports, functions, classes, interfaces, types), emit a templated
  * summary that names the changes instead of paying for an LLM call.
  *
- * Quality trade-off, on purpose: an LLM summary of a TS diff is
- * usually wordier ("refactored the parser to extract a helper")
- * but most of that detail isn't load-bearing for a commit message —
- * the structural skeleton ("added parseRequest, removed
- * legacyParse") is the part the model uses to write a useful subject
- * line. The structural extract names that skeleton in a fraction
- * of the tokens.
- *
- * This is a regex-first cut intended to ship as the foundation
- * for #883. Tree-sitter integration (which is per-language binary
- * weight of 200KB–2 MB) is a follow-up: it gives us scopes,
- * receiver types, signature deltas — better fidelity at higher
- * build cost. The current implementation catches the high-signal
- * cases (added / removed top-level symbols) and falls through to
- * the LLM when the diff has no structural signal so paragraph-only
- * / cosmetic changes keep their full-fidelity summary.
+ * Phase 1 ships a regex-first extractor; per-language modules now
+ * share the diff-walking + rendering scaffolding via
+ * `structuralDiff.ts`. Each language module owns its per-line
+ * recognition only.
  *
  * Off by default. The user opts in via
  * `service.fastPath.languageAware: { enabled: true; languages: [...] }`.
@@ -33,31 +25,19 @@ import { FileDiff } from '../../../types'
 
 const TS_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts']
 const JS_EXTENSIONS = ['.js', '.jsx', '.mjs', '.cjs']
-const MAX_SYMBOLS_PER_BUCKET = 8
 
-export type StructuralLanguage = 'ts' | 'js'
+export type TsLanguage = 'ts' | 'js'
 
-export function detectStructuralLanguage(path: string): StructuralLanguage | undefined {
+/** @deprecated use {@link detectTsLanguage}. Retained for callers in tests. */
+export function detectStructuralLanguage(path: string): TsLanguage | undefined {
+  return detectTsLanguage(path)
+}
+
+export function detectTsLanguage(path: string): TsLanguage | undefined {
   const lower = path.toLowerCase()
   if (TS_EXTENSIONS.some((ext) => lower.endsWith(ext))) return 'ts'
   if (JS_EXTENSIONS.some((ext) => lower.endsWith(ext))) return 'js'
   return undefined
-}
-
-export type StructuralSymbol = {
-  /**
-   * Display name of the declared symbol. For multi-word forms
-   * (e.g. `export default function foo`) only the identifier
-   * itself is captured.
-   */
-  name: string
-  /**
-   * Coarse-grained kind. Used to group the summary buckets; not
-   * structural beyond that.
-   */
-  kind: 'function' | 'class' | 'interface' | 'type' | 'const' | 'enum' | 'default'
-  /** True when the declaration is `export`ed. */
-  exported: boolean
 }
 
 /**
@@ -76,8 +56,6 @@ export function parseStructuralLine(line: string): StructuralSymbol | undefined 
   // diffs often emit. Anything beyond that level of indent isn't a
   // top-level declaration we care about.
   const trimmed = line.replace(/^\s+/, '')
-  // Skip lines that look like they're inside a block (indented in
-  // the source by anything other than the diff marker itself).
   const leadingIndent = line.length - trimmed.length
   if (leadingIndent > 1) return undefined
 
@@ -88,7 +66,6 @@ export function parseStructuralLine(line: string): StructuralSymbol | undefined 
     body = body.slice('export '.length).trimStart()
   }
 
-  // export default function foo(... | export default class Foo | export default <expression>
   if (body.startsWith('default ')) {
     const rest = body.slice('default '.length).trimStart()
     const fnMatch = rest.match(/^(?:async\s+)?function\s*\*?\s*([A-Za-z_$][\w$]*)?/)
@@ -117,9 +94,6 @@ export function parseStructuralLine(line: string): StructuralSymbol | undefined 
   const enumMatch = body.match(/^(?:const\s+)?enum\s+([A-Za-z_$][\w$]*)/)
   if (enumMatch) return { name: enumMatch[1], kind: 'enum', exported }
 
-  // const / let / var with an identifier we can capture. Only the
-  // first identifier — destructuring patterns at top level are
-  // unusual and the LLM fallback can name them better than we can.
   const constMatch = body.match(/^(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*[=:]/)
   if (constMatch) return { name: constMatch[1], kind: 'const', exported }
 
@@ -127,92 +101,11 @@ export function parseStructuralLine(line: string): StructuralSymbol | undefined 
 }
 
 export function summarizeTsStructuralDiff(fileDiff: FileDiff): string | undefined {
-  const language = detectStructuralLanguage(fileDiff.file)
+  const language = detectTsLanguage(fileDiff.file)
   if (!language) return undefined
 
-  const added = new Map<string, StructuralSymbol>()
-  const removed = new Map<string, StructuralSymbol>()
-  let addedLines = 0
-  let removedLines = 0
-
-  for (const line of fileDiff.diff.split('\n')) {
-    if (isPatchHeader(line)) continue
-    if (line.startsWith('+')) {
-      addedLines++
-      const symbol = parseStructuralLine(line.slice(1))
-      if (symbol) added.set(keyOf(symbol), symbol)
-    } else if (line.startsWith('-')) {
-      removedLines++
-      const symbol = parseStructuralLine(line.slice(1))
-      if (symbol) removed.set(keyOf(symbol), symbol)
-    }
-  }
-
-  if (addedLines === 0 && removedLines === 0) return undefined
-
-  // No structural signal → fall through to LLM. We only fast-path
-  // when the diff names at least one top-level declaration; pure
-  // body-edit / formatting changes keep their full-fidelity summary.
-  if (added.size === 0 && removed.size === 0) return undefined
-
-  // A symbol that appears in both buckets is likely a signature
-  // change (kept around but its declaration line changed). Surface
-  // these as "updated" so the user sees they aren't strictly
-  // added/removed.
-  const updatedKeys = new Set([...added.keys()].filter((k) => removed.has(k)))
-  const pureAdded = [...added.values()].filter((s) => !updatedKeys.has(keyOf(s)))
-  const pureRemoved = [...removed.values()].filter((s) => !updatedKeys.has(keyOf(s)))
-  const updated = [...updatedKeys].map((k) => added.get(k) as StructuralSymbol)
-
-  const parts: string[] = [`Updated ${language === 'ts' ? 'TypeScript' : 'JavaScript'} \`${fileDiff.file}\``]
-  if (pureAdded.length) {
-    parts.push(`added: ${formatSymbolList(pureAdded)}`)
-  }
-  if (pureRemoved.length) {
-    parts.push(`removed: ${formatSymbolList(pureRemoved)}`)
-  }
-  if (updated.length) {
-    parts.push(`signature change: ${formatSymbolList(updated)}`)
-  }
-  parts.push(`+${addedLines}/-${removedLines} lines`)
-
-  return `${parts.join('. ')}.`
-}
-
-function isPatchHeader(line: string): boolean {
-  return (
-    line.startsWith('diff --git') ||
-    line.startsWith('index ') ||
-    line.startsWith('--- ') ||
-    line.startsWith('+++ ') ||
-    line.startsWith('@@') ||
-    line.startsWith('new file mode') ||
-    line.startsWith('deleted file mode') ||
-    line.startsWith('similarity index') ||
-    line.startsWith('rename from ') ||
-    line.startsWith('rename to ') ||
-    line.startsWith('Binary files ')
-  )
-}
-
-function keyOf(symbol: StructuralSymbol): string {
-  return `${symbol.kind}:${symbol.name}`
-}
-
-function formatSymbolList(symbols: StructuralSymbol[]): string {
-  const labeled = symbols.map((s) => formatSymbol(s))
-  if (labeled.length <= MAX_SYMBOLS_PER_BUCKET) return labeled.join(', ')
-  const shown = labeled.slice(0, MAX_SYMBOLS_PER_BUCKET)
-  const remainder = labeled.length - shown.length
-  return `${shown.join(', ')} (+${remainder} more)`
-}
-
-function formatSymbol(symbol: StructuralSymbol): string {
-  // Render `<kind> <name>` for non-functions to keep the summary
-  // unambiguous. Functions are by far the most common; rendering
-  // them as `name()` reads naturally inline.
-  if (symbol.kind === 'function' || symbol.kind === 'default') {
-    return `${symbol.name}()`
-  }
-  return `${symbol.kind} ${symbol.name}`
+  return summarizeStructuralDiff(fileDiff, {
+    label: language === 'ts' ? 'TypeScript' : 'JavaScript',
+    parseLine: parseStructuralLine,
+  })
 }

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -320,14 +320,17 @@ export const schema = {
                     "type": "string",
                     "enum": [
                       "ts",
-                      "js"
+                      "js",
+                      "py",
+                      "rs",
+                      "go"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`"
             }
           },
           "additionalProperties": false,
@@ -768,14 +771,17 @@ export const schema = {
                     "type": "string",
                     "enum": [
                       "ts",
-                      "js"
+                      "js",
+                      "py",
+                      "rs",
+                      "go"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`"
             }
           },
           "additionalProperties": false,
@@ -959,14 +965,17 @@ export const schema = {
                     "type": "string",
                     "enum": [
                       "ts",
-                      "js"
+                      "js",
+                      "py",
+                      "rs",
+                      "go"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`"
             }
           },
           "additionalProperties": false,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -94,7 +94,7 @@ export interface BaseParserOptions {
        * supported languages. Today: 'ts' (covers .ts/.tsx/.mts/.cts),
        * 'js' (covers .js/.jsx/.mjs/.cjs).
        */
-      languages?: ('ts' | 'js')[]
+      languages?: ('ts' | 'js' | 'py' | 'rs' | 'go')[]
     }
   }
   metadata?: Partial<LlmCallMetadata>


### PR DESCRIPTION
## Summary
- Three new regex-based extractors — Python (\`.py\`/\`.pyi\`), Rust (\`.rs\`), Go (\`.go\`) — built on a new shared \`structuralDiff.ts\` scaffold. The TS extractor is refactored onto the same scaffold; existing tests continue to pass.
- \`service.fastPath.languageAware.languages\` allowlist expands from \`'ts' | 'js'\` to \`'ts' | 'js' | 'py' | 'rs' | 'go'\` (schema regenerated).
- Adding the next language is now two files (the per-language module + tests) plus a switch case in the dispatcher.

Phase 2 of #883. Tree-sitter integration and quality-eval scaffolding stay in the backlog — both need design discussion before they ship.

## Test plan
- [x] \`npx tsc --noEmit\` → 0 errors
- [x] \`npx jest\` → 1568/1568 pass (49 new)
- [x] \`npx eslint\` on touched files → clean
- [x] \`npm run build:schema\` regenerated; \`py\` / \`rs\` / \`go\` appear in the schema enum.

Refs #883.