### PR TITLE
feat(log-tui): .gitattributes-backed LFS badges on file rows (#884)

### DIFF
--- a/src/git/lfsAttributes.test.ts
+++ b/src/git/lfsAttributes.test.ts
@@ -1,0 +1,102 @@
+import {
+  LfsAttributeStatus,
+  isPathLfsTracked,
+  parseLfsAttributes,
+} from './lfsAttributes'
+
+describe('parseLfsAttributes', () => {
+  it('returns only the patterns marked filter=lfs', () => {
+    const body = [
+      '*.bin filter=lfs diff=lfs merge=lfs -text',
+      '*.txt text',
+      'videos/* filter=lfs',
+      '# comment line — should be ignored',
+      '',
+      'docs/*.md export-ignore',
+    ].join('\n')
+
+    const patterns = parseLfsAttributes(body, '')
+    expect(patterns).toEqual([
+      { baseDir: '', pattern: '*.bin' },
+      { baseDir: '', pattern: 'videos/*' },
+    ])
+  })
+
+  it('records the baseDir on each pattern', () => {
+    const patterns = parseLfsAttributes('*.psd filter=lfs', 'assets')
+    expect(patterns).toEqual([{ baseDir: 'assets', pattern: '*.psd' }])
+  })
+
+  it('handles lines with extra whitespace gracefully', () => {
+    const patterns = parseLfsAttributes('   *.png   filter=lfs   diff=lfs', '')
+    expect(patterns).toEqual([{ baseDir: '', pattern: '*.png' }])
+  })
+
+  it('returns an empty list for empty / whitespace-only inputs', () => {
+    expect(parseLfsAttributes('', '')).toEqual([])
+    expect(parseLfsAttributes('   \n  \n', '')).toEqual([])
+  })
+
+  it('ignores pattern-only lines that lack a filter=lfs attribute', () => {
+    expect(parseLfsAttributes('*.bin', '')).toEqual([])
+    expect(parseLfsAttributes('*.bin text', '')).toEqual([])
+  })
+})
+
+describe('isPathLfsTracked', () => {
+  it('returns false when LFS is disabled (no patterns)', () => {
+    const status: LfsAttributeStatus = { enabled: false, patterns: [] }
+    expect(isPathLfsTracked(status, 'foo.bin')).toBe(false)
+  })
+
+  it('matches patterns anchored to the repo root', () => {
+    const status: LfsAttributeStatus = {
+      enabled: true,
+      patterns: [{ baseDir: '', pattern: '*.bin' }],
+    }
+    expect(isPathLfsTracked(status, 'foo.bin')).toBe(true)
+    // matchBase: '*.bin' should match the file in any directory.
+    expect(isPathLfsTracked(status, 'src/nested/foo.bin')).toBe(true)
+    expect(isPathLfsTracked(status, 'foo.txt')).toBe(false)
+  })
+
+  it('scopes patterns to the directory of their .gitattributes file', () => {
+    const status: LfsAttributeStatus = {
+      enabled: true,
+      patterns: [{ baseDir: 'assets', pattern: '*.psd' }],
+    }
+    expect(isPathLfsTracked(status, 'assets/hero.psd')).toBe(true)
+    expect(isPathLfsTracked(status, 'src/hero.psd')).toBe(false)
+  })
+
+  it('respects glob patterns with explicit directory components', () => {
+    const status: LfsAttributeStatus = {
+      enabled: true,
+      patterns: [{ baseDir: '', pattern: 'videos/**/*.mp4' }],
+    }
+    expect(isPathLfsTracked(status, 'videos/foo.mp4')).toBe(true)
+    expect(isPathLfsTracked(status, 'videos/sub/foo.mp4')).toBe(true)
+    expect(isPathLfsTracked(status, 'foo.mp4')).toBe(false)
+  })
+
+  it('treats nested baseDir patterns relative to their own directory', () => {
+    const status: LfsAttributeStatus = {
+      enabled: true,
+      patterns: [{ baseDir: 'docs/assets', pattern: '*.png' }],
+    }
+    expect(isPathLfsTracked(status, 'docs/assets/cover.png')).toBe(true)
+    expect(isPathLfsTracked(status, 'docs/cover.png')).toBe(false)
+    expect(isPathLfsTracked(status, 'src/cover.png')).toBe(false)
+  })
+
+  it('returns false on a path that has no matching pattern', () => {
+    const status: LfsAttributeStatus = {
+      enabled: true,
+      patterns: [
+        { baseDir: '', pattern: '*.bin' },
+        { baseDir: 'assets', pattern: '*.psd' },
+      ],
+    }
+    expect(isPathLfsTracked(status, 'src/parser.ts')).toBe(false)
+  })
+})

--- a/src/git/lfsAttributes.ts
+++ b/src/git/lfsAttributes.ts
@@ -1,0 +1,155 @@
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { minimatch } from 'minimatch'
+import { SimpleGit } from 'simple-git'
+
+/**
+ * `.gitattributes`-based LFS tracking detection (#884).
+ *
+ * The patch-content LFS detection in `lfsPointer.ts` only fires
+ * for modified-but-tracked rows. Two complementary surfaces also
+ * benefit from knowing "this file is LFS-tracked, even if its
+ * pointer hasn't changed":
+ *
+ *   - The status / worktree views can show an "LFS" badge on
+ *     tracked rows so the user knows the on-disk content is a
+ *     pointer, not the real binary.
+ *   - The commit-diff file list can mark LFS-tracked rows so the
+ *     surface can hint "binary file (LFS)" even when the diff
+ *     itself doesn't carry the pointer (e.g. rename without
+ *     content change).
+ *
+ * This module owns the detection. `.gitattributes` files can live
+ * at any depth in the repo and patterns are scoped to the
+ * directory their file sits in (gitignore-style precedence). For
+ * our purposes — flagging LFS rows — we read every `.gitattributes`
+ * the repo's filtered file listing knows about and union their
+ * patterns, anchored to the file's directory.
+ */
+
+export type LfsAttributePattern = {
+  /** Directory the pattern is anchored to (repo-relative). Empty string for the repo root. */
+  baseDir: string
+  /** Raw glob from the `.gitattributes` entry (e.g. `*.bin`, `videos/*`). */
+  pattern: string
+}
+
+export type LfsAttributeStatus = {
+  /** True when any `.gitattributes` defines a `filter=lfs` pattern. */
+  enabled: boolean
+  /** Patterns sourced from every `.gitattributes` discovered. */
+  patterns: LfsAttributePattern[]
+}
+
+const EMPTY_STATUS: LfsAttributeStatus = { enabled: false, patterns: [] }
+
+/**
+ * Parse a single `.gitattributes` body into the LFS-tracked
+ * patterns it declares. Each line in the file has the shape
+ * `<pattern> <attr1> <attr2> ...`. We collect lines that include
+ * a `filter=lfs` attribute (the canonical LFS marker); other
+ * attributes are ignored. Blank lines and comment lines (`#`) are
+ * skipped.
+ *
+ * Exported for direct testing; the loader composes this with file
+ * discovery.
+ */
+export function parseLfsAttributes(body: string, baseDir: string): LfsAttributePattern[] {
+  const patterns: LfsAttributePattern[] = []
+
+  for (const rawLine of body.split('\n')) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+
+    const tokens = line.split(/\s+/)
+    if (tokens.length < 2) continue
+    const pattern = tokens[0]
+    const attrs = tokens.slice(1)
+    if (attrs.includes('filter=lfs')) {
+      patterns.push({ baseDir, pattern })
+    }
+  }
+
+  return patterns
+}
+
+/**
+ * Resolve the repo root using `git rev-parse --show-toplevel`, then
+ * load every `.gitattributes` file the repo tracks (via `git
+ * ls-files`) and union their LFS patterns. Returns the empty status
+ * sentinel when none are present so callers don't pay a refresh
+ * cost on repos without LFS.
+ *
+ * Best-effort: `.gitattributes` files that don't parse, missing
+ * permissions, or a missing repo root all fall through to the
+ * empty status. Errors here would otherwise cripple the worktree
+ * load path for an LFS-detection feature that's strictly additive.
+ */
+export async function getLfsAttributeStatus(git: SimpleGit): Promise<LfsAttributeStatus> {
+  let repoRoot: string
+  try {
+    repoRoot = (await git.revparse(['--show-toplevel'])).trim()
+  } catch {
+    return EMPTY_STATUS
+  }
+  if (!repoRoot) return EMPTY_STATUS
+
+  let trackedFiles: string[]
+  try {
+    const output = await git.raw(['ls-files', '--', '.gitattributes', '**/.gitattributes'])
+    trackedFiles = output.split('\n').map((line) => line.trim()).filter(Boolean)
+  } catch {
+    trackedFiles = []
+  }
+  // Always include a repo-root `.gitattributes` that may exist but
+  // isn't tracked (rare but possible during bootstrap). Untracked
+  // attribute files still influence git's behavior at runtime.
+  const rootAttrs = '.gitattributes'
+  if (!trackedFiles.includes(rootAttrs) && existsSync(join(repoRoot, rootAttrs))) {
+    trackedFiles.push(rootAttrs)
+  }
+
+  const patterns: LfsAttributePattern[] = []
+  for (const relPath of trackedFiles) {
+    const absPath = join(repoRoot, relPath)
+    if (!existsSync(absPath)) continue
+    let body: string
+    try {
+      body = readFileSync(absPath, 'utf8')
+    } catch {
+      continue
+    }
+    const baseDir = relPath === rootAttrs ? '' : relPath.replace(/\/?\.gitattributes$/, '')
+    patterns.push(...parseLfsAttributes(body, baseDir))
+  }
+
+  return { enabled: patterns.length > 0, patterns }
+}
+
+/**
+ * Returns true when a repo-relative path is matched by any of the
+ * tracked LFS patterns. Each pattern is anchored to the directory
+ * its `.gitattributes` file sits in: e.g. a pattern `*.bin` from
+ * `assets/.gitattributes` matches `assets/foo.bin` but not
+ * `src/foo.bin`.
+ *
+ * The matcher uses minimatch (the dependency the rest of the
+ * codebase already relies on). Globstar is enabled so patterns
+ * like `videos/<globstar>/<star>.mp4` behave as users expect.
+ */
+export function isPathLfsTracked(
+  status: LfsAttributeStatus,
+  repoRelativePath: string,
+): boolean {
+  if (!status.enabled) return false
+  for (const { baseDir, pattern } of status.patterns) {
+    if (baseDir && !repoRelativePath.startsWith(`${baseDir}/`) && repoRelativePath !== baseDir) {
+      continue
+    }
+    const scoped = baseDir ? repoRelativePath.slice(baseDir.length + 1) : repoRelativePath
+    if (minimatch(scoped, pattern, { matchBase: !pattern.includes('/'), dot: true })) {
+      return true
+    }
+  }
+  return false
+}

--- a/src/workstation/chrome/context.ts
+++ b/src/workstation/chrome/context.ts
@@ -1,6 +1,7 @@
 export const LOG_INK_CONTEXT_KEYS = [
   'bisect',
   'branches',
+  'lfs',
   'operation',
   'provider',
   'pullRequest',

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -58,6 +58,7 @@ import * as nodePath from 'node:path'
 import type * as ReactTypes from 'react'
 import { SimpleGit } from 'simple-git'
 import { getBranchOverview } from '../../git/branchData'
+import { getLfsAttributeStatus } from '../../git/lfsAttributes'
 import { createManualCommit, formatCommitComposeMessage } from '../../commands/log/commitCompose'
 import {
   runCommitDraftWorkflow,
@@ -98,7 +99,7 @@ async function safe<T>(promise: Promise<T>): Promise<T | undefined> {
 }
 
 async function loadLogInkContext(git: SimpleGit): Promise<LogInkContext> {
-  const [branches, pullRequest, tags, worktree, stashes, worktreeList, operation, provider, reflog, bisect] =
+  const [branches, pullRequest, tags, worktree, stashes, worktreeList, operation, provider, reflog, bisect, lfs] =
     await Promise.all([
       safe(getBranchOverview(git)),
       safe(getPullRequestOverview(git)),
@@ -110,11 +111,13 @@ async function loadLogInkContext(git: SimpleGit): Promise<LogInkContext> {
       safe(getProviderOverview(git)),
       safe(getReflogOverview(git)),
       safe(getBisectStatus(git)),
+      safe(getLfsAttributeStatus(git)),
     ])
 
   return {
     bisect,
     branches,
+    lfs,
     operation,
     provider,
     pullRequest,
@@ -155,6 +158,10 @@ function loadLogInkContextEntries(git: SimpleGit): Array<{
     {
       key: 'bisect',
       load: () => safe(getBisectStatus(git)),
+    },
+    {
+      key: 'lfs',
+      load: () => safe(getLfsAttributeStatus(git)),
     },
     {
       key: 'worktree',

--- a/src/workstation/runtime/types.ts
+++ b/src/workstation/runtime/types.ts
@@ -16,6 +16,7 @@ import type * as ReactTypes from 'react'
 import type { SimpleGit } from 'simple-git'
 import type { BisectStatus } from '../../git/bisectData'
 import type { BranchOverview } from '../../git/branchData'
+import type { LfsAttributeStatus } from '../../git/lfsAttributes'
 import type { GitOperationOverview } from '../../git/operationData'
 import type { ProviderOverview } from '../../git/providerData'
 import type { PullRequestOverview } from '../../git/pullRequestData'
@@ -34,6 +35,13 @@ import type { LogInkTheme } from '../chrome/theme'
 export type LogInkContext = {
   bisect?: BisectStatus
   branches?: BranchOverview
+  /**
+   * Repository-wide LFS attribute status (#884). When present, the
+   * UI flags LFS-tracked rows with an "LFS" badge even before any
+   * change has been made to them; the per-patch pointer detection
+   * in `lfsPointer.ts` continues to handle modified rows.
+   */
+  lfs?: LfsAttributeStatus
   operation?: GitOperationOverview
   provider?: ProviderOverview
   pullRequest?: PullRequestOverview

--- a/src/workstation/surfaces/detail/index.ts
+++ b/src/workstation/surfaces/detail/index.ts
@@ -41,6 +41,8 @@ import {
   formatTagPreview,
 } from '../../chrome/previewPane'
 import { formatLogInkLoading } from '../../chrome/surfaceStates'
+import type { LfsAttributeStatus } from '../../../git/lfsAttributes'
+import { isPathLfsTracked } from '../../../git/lfsAttributes'
 import { truncateCells, wrapCells } from '../../chrome/text'
 import type { LogInkTheme } from '../../chrome/theme'
 import type {
@@ -167,7 +169,8 @@ function renderCommitFileList(
   focused: boolean,
   maxRows: number,
   width: number,
-  theme: LogInkTheme
+  theme: LogInkTheme,
+  lfsStatus?: LfsAttributeStatus
 ): ReactTypes.ReactElement[] {
   if (!files.length) {
     return [h(Text, { key: 'commit-file-list-empty', dimColor: true }, 'No changed files found.')]
@@ -184,7 +187,12 @@ function renderCommitFileList(
     const stats = formatChangedFileStats(file)
     const renamed = file.oldPath ? ` (was ${file.oldPath})` : ''
     const statusCode = file.status.padEnd(3)
-    const label = `${cursor} ${statusCode} ${file.path}${renamed}${stats ? `  ${stats}` : ''}`
+    // #884 — append an "LFS" badge when the file is LFS-tracked.
+    // Surface-level signal: complements the patch-content rewrite
+    // in `lfsPointer.ts` so even rename / mode-only rows are
+    // flagged.
+    const lfsBadge = lfsStatus && isPathLfsTracked(lfsStatus, file.path) ? ' [LFS]' : ''
+    const label = `${cursor} ${statusCode} ${file.path}${renamed}${lfsBadge}${stats ? `  ${stats}` : ''}`
 
     return h(Text, {
       key: `commit-file-${index}`,
@@ -314,7 +322,7 @@ export function renderHistoryInspector(
   const fileListFocused = focused && state.inspectorTab === 'inspector'
   const fileListMaxRows = Math.max(4, Math.min(detail.files.length, 10))
   const fileListNodes = renderCommitFileList(
-    h, Text, detail.files, state.selectedFileIndex, fileListFocused, fileListMaxRows, width, theme
+    h, Text, detail.files, state.selectedFileIndex, fileListFocused, fileListMaxRows, width, theme, context.lfs
   )
 
   // Tab indicator. Renders in BOTH tabbed (short-terminal) mode and

--- a/src/workstation/surfaces/status/index.ts
+++ b/src/workstation/surfaces/status/index.ts
@@ -25,6 +25,7 @@ import {
 } from '../../chrome/surfaceStates'
 import { cellWidth, truncateCells } from '../../chrome/text'
 import type { LogInkTheme } from '../../chrome/theme'
+import { isPathLfsTracked } from '../../../git/lfsAttributes'
 import type { WorktreeFile, WorktreeFileGroup } from '../../../git/statusData'
 import { applyStatusFilterMask, groupWorktreeFiles } from '../../../git/statusData'
 import type {
@@ -142,7 +143,13 @@ export function renderStatusSurface(
       const dotColor = getStageStatusDotColor(row.file.state, theme)
       const useDot = dotColor !== undefined
       const dotCells = useDot ? cellWidth(STAGE_STATUS_DOT) + 1 : 0
-      const tail = `${row.file.indexStatus}${row.file.worktreeStatus} ${row.file.path}`
+      // #884 — append an "LFS" badge on rows tracked by a
+      // `.gitattributes` filter=lfs pattern, so the user can tell
+      // the on-disk file is a pointer (not the real binary) even
+      // when the row has no diff. Detection lives in the context
+      // slice we lazily-loaded on boot; missing context → no badge.
+      const lfsBadge = context.lfs && isPathLfsTracked(context.lfs, row.file.path) ? ' LFS' : ''
+      const tail = `${row.file.indexStatus}${row.file.worktreeStatus} ${row.file.path}${lfsBadge}`
       const tailTrunc = truncateCells(tail, Math.max(0, 140 - cellWidth(cursorPart) - dotCells - 2))
       return h(Text, {
         key: `status-file-${row.flatIndex}-${rowIndex}`,


### PR DESCRIPTION
## Summary
- New \`src/git/lfsAttributes.ts\` module: parses every tracked \`.gitattributes\` file, extracts \`filter=lfs\` patterns, and exposes \`isPathLfsTracked(status, path)\` for glob matching (uses the existing \`minimatch\` dep).
- New \`context.lfs\` slice loaded on boot (added to \`LOG_INK_CONTEXT_KEYS\`).
- Status surface appends \` LFS\` after the path on tracked rows; the commit-diff file list appends \` [LFS]\` so the user sees the marker even for rename / mode-only changes.

Third slice of #884. Complements the patch-content rewrite from #924 (which only fires on modified rows).

## Test plan
- [x] \`npx tsc --noEmit\` → 0 errors
- [x] \`npx jest\` → 1579/1579 pass (11 new)
- [x] \`npx eslint\` on touched files → clean
- [ ] Manual: in a repo with a tracked \`.gitattributes\` declaring \`*.bin filter=lfs\`, confirm \`*.bin\` rows show the badge on both the status view and the commit-diff file list.

Refs #884.