### PR TITLE
feat(log-tui): submodule status loader + inspector side-panel (#884)

### DIFF
--- a/src/git/submoduleData.test.ts
+++ b/src/git/submoduleData.test.ts
@@ -1,0 +1,103 @@
+import {
+  findSubmoduleByPath,
+  parseGitmodules,
+  parseSubmoduleStatusOutput,
+} from './submoduleData'
+
+describe('parseGitmodules', () => {
+  it('returns one block per [submodule "name"] section with its path / url / branch', () => {
+    const body = [
+      '[submodule "vendor/lib"]',
+      '  path = vendor/lib',
+      '  url = git@github.com:org/lib.git',
+      '  branch = main',
+      '',
+      '[submodule "tools"]',
+      '  path = tools',
+      '  url = git@github.com:org/tools.git',
+    ].join('\n')
+    expect(parseGitmodules(body)).toEqual([
+      { name: 'vendor/lib', path: 'vendor/lib', url: 'git@github.com:org/lib.git', branch: 'main' },
+      { name: 'tools', path: 'tools', url: 'git@github.com:org/tools.git' },
+    ])
+  })
+
+  it('tolerates comments / blank lines / mixed indentation', () => {
+    const body = [
+      '# leading comment',
+      '[submodule "a"]',
+      '\tpath = a',
+      ';   url = ignored',
+      '   url    =   ssh://example.com/a',
+      '',
+      '[submodule "b"]',
+      'path=b',
+    ].join('\n')
+    expect(parseGitmodules(body)).toEqual([
+      { name: 'a', path: 'a', url: 'ssh://example.com/a' },
+      { name: 'b', path: 'b' },
+    ])
+  })
+
+  it('returns an empty list when no submodule sections are present', () => {
+    expect(parseGitmodules('')).toEqual([])
+    expect(parseGitmodules('# just comments\n[other]\nfoo = bar')).toEqual([])
+  })
+})
+
+describe('parseSubmoduleStatusOutput', () => {
+  it('parses the leading status char into a structured flag', () => {
+    const output = [
+      ' 1111111111111111111111111111111111111111 sub-clean (heads/main)',
+      '+2222222222222222222222222222222222222222 sub-modified (heads/main)',
+      '-3333333333333333333333333333333333333333 sub-uninit',
+      'U4444444444444444444444444444444444444444 sub-conflict',
+    ].join('\n')
+
+    expect(parseSubmoduleStatusOutput(output)).toEqual([
+      { flag: 'clean', pinnedSha: '1111111111111111111111111111111111111111', path: 'sub-clean' },
+      { flag: 'modified', pinnedSha: '2222222222222222222222222222222222222222', path: 'sub-modified' },
+      { flag: 'uninitialized', pinnedSha: '3333333333333333333333333333333333333333', path: 'sub-uninit' },
+      { flag: 'conflicted', pinnedSha: '4444444444444444444444444444444444444444', path: 'sub-conflict' },
+    ])
+  })
+
+  it('skips blank lines and lines that are too short to parse', () => {
+    // Three lines: empty (skipped), single-token (skipped — no path),
+    // and a well-formed two-token row (parsed).
+    const output = ['', ' shortrow', ' abcdef path'].join('\n')
+    expect(parseSubmoduleStatusOutput(output)).toEqual([
+      { flag: 'clean', pinnedSha: 'abcdef', path: 'path' },
+    ])
+  })
+
+  it('returns an empty list for empty input', () => {
+    expect(parseSubmoduleStatusOutput('')).toEqual([])
+  })
+})
+
+describe('findSubmoduleByPath', () => {
+  it('returns the matching submodule entry', () => {
+    const overview = {
+      hasSubmodules: true,
+      entries: [
+        { name: 'a', path: 'a', pinnedSha: '1', flag: 'clean' as const },
+        { name: 'b', path: 'b', pinnedSha: '2', flag: 'modified' as const },
+      ],
+    }
+    expect(findSubmoduleByPath(overview, 'a')?.name).toBe('a')
+    expect(findSubmoduleByPath(overview, 'b')?.flag).toBe('modified')
+  })
+
+  it('returns undefined when no entry matches', () => {
+    const overview = {
+      hasSubmodules: true,
+      entries: [{ name: 'a', path: 'a', pinnedSha: '1', flag: 'clean' as const }],
+    }
+    expect(findSubmoduleByPath(overview, 'unknown')).toBeUndefined()
+  })
+
+  it('returns undefined on an empty overview', () => {
+    expect(findSubmoduleByPath({ hasSubmodules: false, entries: [] }, 'anything')).toBeUndefined()
+  })
+})

--- a/src/git/submoduleData.ts
+++ b/src/git/submoduleData.ts
@@ -1,0 +1,211 @@
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { SimpleGit } from 'simple-git'
+
+/**
+ * Submodule overview loader (#884).
+ *
+ * Surfaces the per-submodule metadata a TUI inspector needs to
+ * explain a submodule row: which submodule it is (name + path),
+ * what commit it's pinned at, whether its tree currently matches
+ * that pin, and the tracking branch declared in `.gitmodules`.
+ *
+ * Detection is via `.gitmodules` (mandatory for any registered
+ * submodule) plus `git submodule status` (which reports the pinned
+ * commit and any modified / uninitialized state). Both are local,
+ * cheap reads — we never need to contact the submodule's remote
+ * for any of these fields.
+ *
+ * The deeper "drill into the submodule's history" navigation is
+ * a separate concern (a recursive context loader + view stack
+ * isolation); this module is the data foundation for both the
+ * inspector side-panel and that future navigation.
+ */
+
+export type SubmoduleStatusFlag =
+  /** Current commit matches the pin (clean). */
+  | 'clean'
+  /** Pinned commit differs from HEAD inside the submodule (`+`). */
+  | 'modified'
+  /** Submodule not initialized — needs `git submodule update --init` (`-`). */
+  | 'uninitialized'
+  /** Merge conflicts in the submodule entry (`U`). */
+  | 'conflicted'
+
+export type SubmoduleEntry = {
+  /** Logical name declared in `.gitmodules` (the `[submodule "name"]` header). */
+  name: string
+  /** Repo-relative path the submodule mounts at. */
+  path: string
+  /** Pinned commit sha as recorded by the parent repo. */
+  pinnedSha: string
+  /** Status of the submodule's working tree relative to the pin. */
+  flag: SubmoduleStatusFlag
+  /**
+   * Branch the submodule's `[submodule "name"]` block declares for
+   * tracking, when present. Independent of the pinned commit — a
+   * submodule can declare `branch = main` but still be pinned at an
+   * older sha on that branch.
+   */
+  trackingBranch?: string
+  /** Remote URL recorded in `.gitmodules`, when present. */
+  url?: string
+}
+
+export type SubmoduleOverview = {
+  /** True when at least one submodule is registered. */
+  hasSubmodules: boolean
+  entries: SubmoduleEntry[]
+}
+
+const EMPTY_OVERVIEW: SubmoduleOverview = { hasSubmodules: false, entries: [] }
+
+type GitmodulesBlock = {
+  name: string
+  path?: string
+  url?: string
+  branch?: string
+}
+
+/**
+ * Parse a `.gitmodules` file into one `GitmodulesBlock` per
+ * `[submodule "<name>"]` section. The file follows git-config
+ * syntax — section headers + indented key = value pairs — so we
+ * use a tiny line-based parser rather than pulling in a full
+ * config library.
+ */
+export function parseGitmodules(body: string): GitmodulesBlock[] {
+  const blocks: GitmodulesBlock[] = []
+  let current: GitmodulesBlock | undefined
+
+  for (const rawLine of body.split('\n')) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#') || line.startsWith(';')) continue
+
+    const headerMatch = line.match(/^\[submodule\s+"([^"]+)"\]$/)
+    if (headerMatch) {
+      if (current) blocks.push(current)
+      current = { name: headerMatch[1] }
+      continue
+    }
+
+    if (!current) continue
+
+    const kvMatch = line.match(/^([A-Za-z][\w-]*)\s*=\s*(.*)$/)
+    if (!kvMatch) continue
+    const key = kvMatch[1].toLowerCase()
+    const value = kvMatch[2].trim()
+    if (key === 'path') current.path = value
+    else if (key === 'url') current.url = value
+    else if (key === 'branch') current.branch = value
+  }
+
+  if (current) blocks.push(current)
+  return blocks
+}
+
+/**
+ * Parse the output of `git submodule status`. The format is one
+ * line per submodule:
+ *
+ *   ` <sha> <path> (<describe>)`   – clean
+ *   `+<sha> <path> (<describe>)`   – modified
+ *   `-<sha> <path>`                – uninitialized
+ *   `U<sha> <path>`                – conflicted
+ *
+ * The leading space / +/-/U is the status flag. `<describe>` (if
+ * present) is `git describe`-style ref output for the pinned
+ * commit — purely informational, ignored by this parser.
+ */
+export function parseSubmoduleStatusOutput(output: string): Array<{
+  flag: SubmoduleStatusFlag
+  pinnedSha: string
+  path: string
+}> {
+  const rows: Array<{ flag: SubmoduleStatusFlag; pinnedSha: string; path: string }> = []
+  for (const rawLine of output.split('\n')) {
+    if (!rawLine.length) continue
+    const flagChar = rawLine[0]
+    const rest = rawLine.slice(1).trim()
+    const tokens = rest.split(/\s+/)
+    if (tokens.length < 2) continue
+    const [pinnedSha, path] = tokens
+    const flag: SubmoduleStatusFlag =
+      flagChar === '+' ? 'modified' :
+        flagChar === '-' ? 'uninitialized' :
+          flagChar === 'U' ? 'conflicted' : 'clean'
+    rows.push({ flag, pinnedSha, path })
+  }
+  return rows
+}
+
+/**
+ * Load the submodule overview by reading `.gitmodules` and joining
+ * with `git submodule status` output. Returns the empty-overview
+ * sentinel when no `.gitmodules` is present so callers don't pay
+ * the round-trip cost on repos without submodules.
+ *
+ * Best-effort: any failure on either input falls through to an
+ * empty overview rather than disrupting the surrounding context
+ * load.
+ */
+export async function getSubmoduleOverview(git: SimpleGit): Promise<SubmoduleOverview> {
+  let repoRoot: string
+  try {
+    repoRoot = (await git.revparse(['--show-toplevel'])).trim()
+  } catch {
+    return EMPTY_OVERVIEW
+  }
+  if (!repoRoot) return EMPTY_OVERVIEW
+
+  const gitmodulesPath = join(repoRoot, '.gitmodules')
+  if (!existsSync(gitmodulesPath)) return EMPTY_OVERVIEW
+
+  let body: string
+  try {
+    body = readFileSync(gitmodulesPath, 'utf8')
+  } catch {
+    return EMPTY_OVERVIEW
+  }
+  const blocks = parseGitmodules(body)
+  if (blocks.length === 0) return EMPTY_OVERVIEW
+
+  let statusOutput = ''
+  try {
+    statusOutput = await git.raw(['submodule', 'status'])
+  } catch {
+    statusOutput = ''
+  }
+  const statusRows = parseSubmoduleStatusOutput(statusOutput)
+  const statusByPath = new Map(statusRows.map((row) => [row.path, row]))
+
+  const entries: SubmoduleEntry[] = blocks
+    .filter((block) => Boolean(block.path))
+    .map((block) => {
+      const path = block.path as string
+      const status = statusByPath.get(path)
+      return {
+        name: block.name,
+        path,
+        pinnedSha: status?.pinnedSha || '',
+        flag: status?.flag || 'uninitialized',
+        trackingBranch: block.branch,
+        url: block.url,
+      }
+    })
+
+  return { hasSubmodules: entries.length > 0, entries }
+}
+
+/**
+ * Lookup helper: returns the submodule entry that owns a given
+ * repo-relative path, or undefined when the path isn't a submodule
+ * root. Used by the diff renderer + inspector to decide whether to
+ * route a row through submodule-aware rendering.
+ */
+export function findSubmoduleByPath(
+  overview: SubmoduleOverview,
+  repoRelativePath: string,
+): SubmoduleEntry | undefined {
+  return overview.entries.find((entry) => entry.path === repoRelativePath)
+}

--- a/src/workstation/chrome/context.ts
+++ b/src/workstation/chrome/context.ts
@@ -7,6 +7,7 @@ export const LOG_INK_CONTEXT_KEYS = [
   'pullRequest',
   'reflog',
   'stashes',
+  'submodules',
   'tags',
   'worktree',
   'worktreeList',

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -59,6 +59,7 @@ import type * as ReactTypes from 'react'
 import { SimpleGit } from 'simple-git'
 import { getBranchOverview } from '../../git/branchData'
 import { getLfsAttributeStatus } from '../../git/lfsAttributes'
+import { getSubmoduleOverview } from '../../git/submoduleData'
 import { createManualCommit, formatCommitComposeMessage } from '../../commands/log/commitCompose'
 import {
   runCommitDraftWorkflow,
@@ -99,7 +100,7 @@ async function safe<T>(promise: Promise<T>): Promise<T | undefined> {
 }
 
 async function loadLogInkContext(git: SimpleGit): Promise<LogInkContext> {
-  const [branches, pullRequest, tags, worktree, stashes, worktreeList, operation, provider, reflog, bisect, lfs] =
+  const [branches, pullRequest, tags, worktree, stashes, worktreeList, operation, provider, reflog, bisect, lfs, submodules] =
     await Promise.all([
       safe(getBranchOverview(git)),
       safe(getPullRequestOverview(git)),
@@ -112,6 +113,7 @@ async function loadLogInkContext(git: SimpleGit): Promise<LogInkContext> {
       safe(getReflogOverview(git)),
       safe(getBisectStatus(git)),
       safe(getLfsAttributeStatus(git)),
+      safe(getSubmoduleOverview(git)),
     ])
 
   return {
@@ -123,6 +125,7 @@ async function loadLogInkContext(git: SimpleGit): Promise<LogInkContext> {
     pullRequest,
     reflog,
     stashes,
+    submodules,
     tags,
     worktree,
     worktreeList,
@@ -162,6 +165,10 @@ function loadLogInkContextEntries(git: SimpleGit): Array<{
     {
       key: 'lfs',
       load: () => safe(getLfsAttributeStatus(git)),
+    },
+    {
+      key: 'submodules',
+      load: () => safe(getSubmoduleOverview(git)),
     },
     {
       key: 'worktree',

--- a/src/workstation/runtime/types.ts
+++ b/src/workstation/runtime/types.ts
@@ -17,6 +17,7 @@ import type { SimpleGit } from 'simple-git'
 import type { BisectStatus } from '../../git/bisectData'
 import type { BranchOverview } from '../../git/branchData'
 import type { LfsAttributeStatus } from '../../git/lfsAttributes'
+import type { SubmoduleOverview } from '../../git/submoduleData'
 import type { GitOperationOverview } from '../../git/operationData'
 import type { ProviderOverview } from '../../git/providerData'
 import type { PullRequestOverview } from '../../git/pullRequestData'
@@ -47,6 +48,14 @@ export type LogInkContext = {
   pullRequest?: PullRequestOverview
   reflog?: ReflogOverview
   stashes?: StashOverview
+  /**
+   * Submodule overview (#884). Carries per-submodule metadata
+   * (name / path / pinned commit / status flag / tracking branch /
+   * url) parsed from `.gitmodules` + `git submodule status`. The
+   * inspector and diff renderers use this to format submodule rows
+   * with real context instead of raw `Subproject commit` lines.
+   */
+  submodules?: SubmoduleOverview
   tags?: TagOverview
   worktree?: WorktreeOverview
   worktreeList?: WorktreeListOverview

--- a/src/workstation/surfaces/detail/index.ts
+++ b/src/workstation/surfaces/detail/index.ts
@@ -43,6 +43,8 @@ import {
 import { formatLogInkLoading } from '../../chrome/surfaceStates'
 import type { LfsAttributeStatus } from '../../../git/lfsAttributes'
 import { isPathLfsTracked } from '../../../git/lfsAttributes'
+import type { SubmoduleEntry, SubmoduleOverview } from '../../../git/submoduleData'
+import { findSubmoduleByPath } from '../../../git/submoduleData'
 import { truncateCells, wrapCells } from '../../chrome/text'
 import type { LogInkTheme } from '../../chrome/theme'
 import type {
@@ -231,6 +233,61 @@ function renderPreviewPanel(
   }))
 }
 
+/**
+ * Submodule info block (#884). When the cursored file is a
+ * registered submodule, append a short metadata block to the
+ * inspector so the user sees what they're looking at:
+ *
+ *   Submodule: vendor/lib
+ *     pinned:    1234567a  (modified)
+ *     tracking:  main
+ *     remote:    git@github.com:org/lib.git
+ *
+ * Returns an empty array when the cursored file isn't a submodule
+ * or the loader hasn't populated the overview yet — the inspector
+ * falls back to its existing rendering.
+ */
+function renderSubmoduleInspectorBlock(
+  h: typeof ReactTypes.createElement,
+  Text: LogInkComponents['Text'],
+  width: number,
+  cursoredFilePath: string | undefined,
+  submodules: SubmoduleOverview | undefined,
+): ReactTypes.ReactElement[] {
+  if (!cursoredFilePath || !submodules?.hasSubmodules) return []
+  const entry = findSubmoduleByPath(submodules, cursoredFilePath)
+  if (!entry) return []
+  return renderSubmoduleEntryLines(h, Text, width, entry)
+}
+
+function renderSubmoduleEntryLines(
+  h: typeof ReactTypes.createElement,
+  Text: LogInkComponents['Text'],
+  width: number,
+  entry: SubmoduleEntry,
+): ReactTypes.ReactElement[] {
+  const flagLabel = entry.flag === 'clean' ? ''
+    : entry.flag === 'modified' ? '  (modified)'
+      : entry.flag === 'uninitialized' ? '  (uninitialized)'
+        : '  (conflicted)'
+  const sha = entry.pinnedSha ? entry.pinnedSha.slice(0, 8) : '<unknown>'
+  return [
+    h(Text, { key: 'submodule-spacer' }, ''),
+    h(Text, { key: 'submodule-header', bold: true },
+      truncateCells(`Submodule: ${entry.name}`, width - 4)),
+    h(Text, { key: 'submodule-pinned', dimColor: true },
+      truncateCells(`  pinned:    ${sha}${flagLabel}`, width - 4)),
+    ...(entry.trackingBranch
+      ? [h(Text, { key: 'submodule-tracking', dimColor: true },
+        truncateCells(`  tracking:  ${entry.trackingBranch}`, width - 4))]
+      : []),
+    ...(entry.url
+      ? [h(Text, { key: 'submodule-url', dimColor: true },
+        truncateCells(`  remote:    ${entry.url}`, width - 4))]
+      : []),
+  ]
+}
+
 export function renderHistoryInspector(
   h: typeof ReactTypes.createElement,
   components: LogInkComponents,
@@ -324,6 +381,15 @@ export function renderHistoryInspector(
   const fileListNodes = renderCommitFileList(
     h, Text, detail.files, state.selectedFileIndex, fileListFocused, fileListMaxRows, width, theme, context.lfs
   )
+  // #884 — submodule info block. Renders when the cursored file is a
+  // registered submodule; otherwise empty so the inspector keeps its
+  // existing layout.
+  const cursoredFilePath = detail.files[
+    Math.max(0, Math.min(state.selectedFileIndex, detail.files.length - 1))
+  ]?.path
+  const submoduleBlockNodes = renderSubmoduleInspectorBlock(
+    h, Text, width, cursoredFilePath, context.submodules
+  )
 
   // Tab indicator. Renders in BOTH tabbed (short-terminal) mode and
   // tall-stacked mode so the user can always see which tab the cursor
@@ -366,7 +432,7 @@ export function renderHistoryInspector(
     tabHeader,
     h(Text, { key: 'inspector-tabs-spacer' }, ''),
     ...(activeTab === 'inspector'
-      ? [...headerNodes, ...fileListNodes]
+      ? [...headerNodes, ...fileListNodes, ...submoduleBlockNodes]
       : renderInspectorActionsSection(h, Text, 'history-commit', width, theme, {
           cursorIndex: state.inspectorActionIndex,
           cursorActive: focused,
@@ -388,6 +454,7 @@ export function renderHistoryInspector(
   h(Text, { key: 'inspector-tabs-spacer' }, ''),
   ...headerNodes,
   ...fileListNodes,
+  ...submoduleBlockNodes,
   ...renderInspectorActionsSection(h, Text, 'history-commit', width, theme, {
     cursorIndex: state.inspectorActionIndex,
     cursorActive: focused && state.inspectorTab === 'actions',


### PR DESCRIPTION
## Summary
- New \`src/git/submoduleData.ts\` module: parses \`.gitmodules\` (\`parseGitmodules\`), parses \`git submodule status\` output (\`parseSubmoduleStatusOutput\`), and exposes \`getSubmoduleOverview\` + \`findSubmoduleByPath\` helpers. Each submodule entry carries name / path / pinned sha / status flag / tracking branch / remote url.
- New \`context.submodules\` slice loaded on boot (added to \`LOG_INK_CONTEXT_KEYS\`).
- Inspector side-panel: when the cursored file in the commit-diff file list matches a registered submodule, append a block like:
  \`\`\`
  Submodule: vendor/lib
    pinned:    1234567a  (modified)
    tracking:  main
    remote:    git@github.com:org/lib.git
  \`\`\`

Fourth slice of #884. Together with #924 / #925 / #929, the visible parts of "raw submodule / LFS metadata renders as gibberish" are resolved.

Recursive "Enter to drill into the submodule's history" navigation and a dedicated submodules view remain as future work — both flagged in the closing comment on #884.

## Test plan
- [x] \`npx tsc --noEmit\` → 0 errors
- [x] \`npx jest\` → 1588/1588 pass (9 new)
- [x] \`npx eslint\` on touched files → clean
- [ ] Manual: in a repo with a registered submodule, navigate to a commit that bumps its pin, cursor onto the submodule row, confirm the inspector renders the metadata block (name + pinned + tracking + remote).

Refs #884.