### PR TITLE
feat(workstation): unified spinner + idle-tip refresh

### DIFF
--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -201,6 +201,17 @@ export type LogInkState = {
    */
   statusKind?: 'info' | 'error' | 'success'
   /**
+   * Transient loading flag for the status line. When true, the footer
+   * prefixes the message with the shared spinner frame so users see
+   * motion during sub-second LLM calls (create-PR body generation,
+   * tag/PR fetches, etc.) that don't have a dedicated overlay.
+   *
+   * Set via `setStatus({ ..., loading: true })`; cleared on the next
+   * `setStatus` without `loading: true` (or when the message is
+   * cleared entirely).
+   */
+  statusLoading?: boolean
+  /**
    * Set by `navigateOpenDiffForCommit` / `navigateOpenDiffForWorktreeFile`
    * to disambiguate the diff view when both a worktree file and a commit
    * are selectable. Cleared when the diff view is popped or replaced.
@@ -512,7 +523,7 @@ export type LogInkAction =
   | { type: 'setPendingKey'; value?: string }
   | { type: 'setSidebarTab'; value: LogInkSidebarTab }
   | { type: 'restoreSidebarTab'; value: LogInkSidebarTab }
-  | { type: 'setStatus'; value?: string; kind?: 'info' | 'error' | 'success' }
+  | { type: 'setStatus'; value?: string; kind?: 'info' | 'error' | 'success'; loading?: boolean }
   | { type: 'setWorkflowAction'; value?: string }
   | { type: 'setPendingConfirmation'; value?: string; payload?: string }
   | { type: 'setPendingMutationConfirmation'; value?: LogInkMutationConfirmation }
@@ -1479,6 +1490,10 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         // 'error' doesn't bleed into the next info update. Explicit
         // 'info' also clears kind for the same reason.
         statusKind: !action.value || action.kind === 'info' ? undefined : action.kind,
+        // Same clearing semantics for loading — every setStatus that
+        // doesn't explicitly opt in (loading: true) clears the flag so
+        // a stale spinner doesn't linger after the LLM call finishes.
+        statusLoading: !action.value ? undefined : (action.loading ? true : undefined),
         pendingKey: undefined,
       }
     case 'setWorkflowAction':

--- a/src/workstation/chrome/idleTips.test.ts
+++ b/src/workstation/chrome/idleTips.test.ts
@@ -6,9 +6,12 @@ import {
 } from './idleTips'
 
 describe('log Ink idle tips (P4.3)', () => {
-  it('exposes the canonical 6+ tip rotation called out in the spec', () => {
+  it('exposes a short scannable tip rotation', () => {
+    // Floor of 6 from the original P4.3 spec; ceiling raised as new
+    // keystrokes get added so the discoverability rotation can grow
+    // without rewriting this test every release.
     expect(IDLE_TIPS.length).toBeGreaterThanOrEqual(6)
-    expect(IDLE_TIPS.length).toBeLessThanOrEqual(8)
+    expect(IDLE_TIPS.length).toBeLessThanOrEqual(24)
     // Each tip is a short scannable hint.
     IDLE_TIPS.forEach((tip) => {
       expect(tip.length).toBeGreaterThan(8)

--- a/src/workstation/chrome/idleTips.ts
+++ b/src/workstation/chrome/idleTips.ts
@@ -22,6 +22,11 @@ export const IDLE_TIPS: string[] = [
   's cycles sort modes in branches and tags',
   'gz opens the stash view',
   '< or esc walks the navigation stack back',
+  'S splits a large staged set into multiple commits',
+  'L generates a changelog for the current branch',
+  'C creates a PR seeded from the changelog',
+  'E opens the commit draft in $EDITOR or $VISUAL',
+  'I drafts an AI commit message from staged changes',
 ]
 
 /**

--- a/src/workstation/chrome/spinner.ts
+++ b/src/workstation/chrome/spinner.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared spinner frames for any surface that renders a loading state.
+ *
+ * Used by:
+ *   - Split-plan overlay (`'loading'` / `'applying'` phases)
+ *   - Changelog surface (`'loading'` phase)
+ *   - Compose surface (AI commit draft generation)
+ *   - Footer status line (transient LLM calls like create-PR body generation)
+ *
+ * The frames are the braille-dot cycle used by ora / ink-spinner / most other
+ * Node TUI tools — 10 frames, designed to read as smooth motion at 80ms per
+ * frame (~12.5 fps). The actual ticking is driven by a single shared
+ * `setInterval` at the app root that pauses when no loading state is active,
+ * so an idle workstation doesn't re-render every 80ms.
+ */
+export const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+
+/**
+ * Cadence between spinner frame transitions, in ms. 80ms gives a smooth
+ * read without burning CPU. The app's spinner-tick effect uses this constant.
+ */
+export const SPINNER_TICK_MS = 80
+
+/**
+ * Pick the current frame for a given tick index. Wraps modulo
+ * `SPINNER_FRAMES.length` so callers don't need to know the frame count.
+ */
+export function pickSpinnerFrame(tick: number): string {
+  return SPINNER_FRAMES[Math.max(0, tick) % SPINNER_FRAMES.length]
+}

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -89,6 +89,7 @@ import {
     getLogInkInputEvents,
 } from '../../commands/log/inkInput'
 import { hasSeenOnboarding, markOnboardingSeen } from '../chrome/onboarding'
+import { SPINNER_TICK_MS } from '../chrome/spinner'
 
 
 async function safe<T>(promise: Promise<T>): Promise<T | undefined> {
@@ -537,7 +538,9 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   const anyLoading =
     state.splitPlan?.status === 'loading' ||
     state.splitPlan?.status === 'applying' ||
-    state.changelogView.status === 'loading'
+    state.changelogView.status === 'loading' ||
+    state.commitCompose.loading ||
+    Boolean(state.statusLoading)
   React.useEffect(() => {
     if (!anyLoading) {
       // Reset to 0 so the next loading state starts from a known
@@ -547,7 +550,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
     // DevSkim: ignore DS172411 — callback is a function literal, delay
     // is our own constant, no caller-supplied data flows through.
-    const id = setInterval(() => setSpinnerFrame((tick) => tick + 1), 80)
+    const id = setInterval(() => setSpinnerFrame((tick) => tick + 1), SPINNER_TICK_MS)
     return () => clearInterval(id)
   }, [anyLoading])
 
@@ -1282,7 +1285,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
 
   const runAiCommitDraft = React.useCallback(async () => {
     dispatch({ type: 'commitCompose', action: { type: 'setLoading', value: true } })
-    dispatch({ type: 'setStatus', value: 'generating AI commit draft' })
+    dispatch({ type: 'setStatus', value: 'generating AI commit draft', loading: true })
     const result = await runCommitDraftWorkflow()
 
     if (result.ok && result.draft) {
@@ -1340,7 +1343,11 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       return
     }
 
-    dispatch({ type: 'setStatus', value: `generating PR body from changelog (vs ${defaultBranch})…` })
+    dispatch({
+      type: 'setStatus',
+      value: `generating PR body from changelog (vs ${defaultBranch})…`,
+      loading: true,
+    })
     const body = await runPullRequestBodyWorkflow({ baseBranch: defaultBranch })
 
     // Fallback shape when the changelog generation fails — open the
@@ -1456,7 +1463,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     // then run the workflow.
     dispatch({ type: 'pushView', value: 'changelog' })
     dispatch({ type: 'setChangelogLoading', branch: head, baseLabel })
-    dispatch({ type: 'setStatus', value: `generating changelog (${baseLabel})…` })
+    dispatch({ type: 'setStatus', value: `generating changelog (${baseLabel})…`, loading: true })
 
     const result = await runChangelogTextWorkflow(argv)
 
@@ -1774,7 +1781,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
 
     dispatch({ type: 'startSplitPlanLoad' })
-    dispatch({ type: 'setStatus', value: 'Generating split plan (this can take a minute)…' })
+    dispatch({ type: 'setStatus', value: 'Generating split plan (this can take a minute)…', loading: true })
 
     const result = await runCommitSplitPlanWorkflow({ git })
 
@@ -1812,7 +1819,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
 
     dispatch({ type: 'setSplitPlanApplying' })
-    dispatch({ type: 'setStatus', value: 'Applying split plan…' })
+    dispatch({ type: 'setStatus', value: 'Applying split plan…', loading: true })
 
     const result = await runCommitSplitApplyWorkflow({
       plan: splitPlan.plan,
@@ -3033,7 +3040,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         theme
       )
     ),
-    renderFooter(h, { Box, Text }, state, context, theme, idleTip)
+    renderFooter(h, { Box, Text }, state, context, theme, idleTip, spinnerFrame)
   )
 }
 

--- a/src/workstation/runtime/footer.ts
+++ b/src/workstation/runtime/footer.ts
@@ -13,6 +13,7 @@
  */
 
 import type * as ReactTypes from 'react'
+import { pickSpinnerFrame } from '../chrome/spinner'
 import type { LogInkTheme } from '../chrome/theme'
 import { getLogInkFooterHints } from '../../commands/log/inkKeymap'
 import type { LogInkState } from '../../commands/log/inkViewModel'
@@ -24,7 +25,8 @@ export function renderFooter(
   state: LogInkState,
   context: LogInkContext,
   theme: LogInkTheme,
-  idleTip?: string
+  idleTip?: string,
+  spinnerFrame: number = 0
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   // Sidebar item count drives the per-tab footer hints — when items are
@@ -55,8 +57,14 @@ export function renderFooter(
   })
   // Real status messages always win; idle tips only fill the slot when it
   // would otherwise be empty.
+  const isLoading = Boolean(state.statusLoading && state.statusMessage)
   const trailing = state.statusMessage || idleTip || ''
-  const status = trailing ? `  ${trailing}` : ''
+  // Loading status gets a spinner prefix in front of the message —
+  // motion makes transient LLM calls (create-PR body, PR fetches,
+  // etc.) feel less frozen even when they're sub-second.
+  const spinnerPrefix = isLoading ? `${pickSpinnerFrame(spinnerFrame)} ` : ''
+  const trailingWithSpinner = trailing ? `${spinnerPrefix}${trailing}` : ''
+  const status = trailingWithSpinner ? `  ${trailingWithSpinner}` : ''
   const isError = state.statusKind === 'error'
   const isSuccess = state.statusKind === 'success'
   const contextualText = isError

--- a/src/workstation/runtime/mainPanel.ts
+++ b/src/workstation/runtime/mainPanel.ts
@@ -102,7 +102,7 @@ export function renderMainPanel(
   }
 
   if (state.activeView === 'compose') {
-    return renderComposeSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
+    return renderComposeSurface(h, components, state, context, contextStatus, bodyRows, width, theme, spinnerFrame)
   }
 
   if (state.activeView === 'branches') {

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -17,6 +17,7 @@
  */
 
 import type * as ReactTypes from 'react'
+import { pickSpinnerFrame } from '../chrome/spinner'
 import { truncateCells } from '../chrome/text'
 import type { LogInkTheme } from '../chrome/theme'
 import {
@@ -353,10 +354,9 @@ export function renderCommandPalette(
  * Errors during apply keep the overlay open in 'ready' state with
  * an `error` annotation in the header — user can retry or back out.
  */
-// Braille-dot spinner frames — same set used by ora, ink-spinner, and
-// most other Node TUI tools. 10 frames at 80ms each gives a smooth
-// loop that reads as a true spinner rather than a flicker.
-const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+// Spinner frames live in `chrome/spinner.ts` so every surface that
+// renders a loading state (overlays, surfaces, footer) shares one
+// vocabulary of motion.
 
 export function renderSplitPlanOverlay(
   h: typeof ReactTypes.createElement,
@@ -376,7 +376,7 @@ export function renderSplitPlanOverlay(
 
   const maxLineWidth = Math.max(20, width - 4)
   const listRows = Math.max(4, bodyRows - 3)
-  const spinner = SPINNER_FRAMES[spinnerFrame % SPINNER_FRAMES.length]
+  const spinner = pickSpinnerFrame(spinnerFrame)
 
   // Loading state — overlay opens immediately so the user sees the
   // "in flight" feedback without staring at a frozen compose view.

--- a/src/workstation/surfaces/compose/index.ts
+++ b/src/workstation/surfaces/compose/index.ts
@@ -11,6 +11,7 @@
 import type * as ReactTypes from 'react'
 import type { LogInkContextStatus } from '../../chrome/context'
 import { isLogInkContextKeyLoading } from '../../chrome/context'
+import { pickSpinnerFrame } from '../../chrome/spinner'
 import { formatLogInkComposeEmpty } from '../../chrome/surfaceStates'
 import { truncateCells, wrapCells } from '../../chrome/text'
 import type { LogInkTheme } from '../../chrome/theme'
@@ -26,7 +27,8 @@ export function renderComposeSurface(
   contextStatus: LogInkContextStatus,
   bodyRows: number,
   width: number,
-  theme: LogInkTheme
+  theme: LogInkTheme,
+  spinnerFrame: number = 0
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const compose = state.commitCompose
@@ -110,8 +112,8 @@ export function renderComposeSurface(
         bold: true,
         color: theme.noColor ? undefined : theme.colors.accent,
       }, theme.ascii
-        ? '[...] Generating AI commit draft (this can take a moment)'
-        : '⏳ Generating AI commit draft… (this can take a moment)'),
+        ? `[${pickSpinnerFrame(spinnerFrame).replace(/[^a-zA-Z0-9 ]/g, '.')}] Generating AI commit draft (this can take a moment)`
+        : `${pickSpinnerFrame(spinnerFrame)}  Generating AI commit draft… (this can take a moment)`),
     ]
     : []),
   ...(compose.message ? [h(Text, undefined, ''), h(Text, { key: 'compose-msg' }, truncateCells(compose.message, 140))] : []),


### PR DESCRIPTION
PR A of the polish sequence. Two related improvements landing together since they share the same plumbing.

## Unified spinner across LLM flows

Spinner animation existed for the split-plan and changelog overlays only. The other LLM-call paths (`I` AI commit draft, `C` create-PR body generation) showed static "generating…" copy that read as frozen on slow LLM responses.

Three pieces of plumbing:

1. **Shared module** `src/workstation/chrome/spinner.ts` exports `SPINNER_FRAMES`, `SPINNER_TICK_MS`, `pickSpinnerFrame(tick)`. Replaces the inline copy in `overlays.ts` so every surface uses the same vocabulary of motion (braille-dot cycle, 80ms/frame).
2. **`statusLoading` state field** + `setStatus({ loading: true })` action option. Reducer clears the flag on every subsequent `setStatus` that doesn't opt in, so a stale spinner can't linger. Footer renders `<spinner> <message>` when the flag is set — gives transient sub-second LLM calls visible motion without needing their own overlay.
3. **Compose surface animated** during `state.commitCompose.loading` (the `I` flow). Spinner replaces the static `⏳`; ASCII fallback uses a terminal-safe `[<frame>]` shape.

The shared `spinnerFrame` tick at the app root now drives whenever any loading state is active — split, changelog, compose, or statusLoading. Pauses entirely when nothing's loading so an idle workstation doesn't re-render every 80ms.

Marked-as-loading call sites:
- `runAiCommitDraft` → "generating AI commit draft"
- `startCreatePullRequest` → "generating PR body from changelog (vs main)…"
- `startChangelogView` → "generating changelog (vs main)…"
- `startCommitSplit` → "Generating split plan (this can take a minute)…"
- `applyCommitSplit` → "Applying split plan…"

## Idle-tip refresh

The rotation hadn't been updated since older keystrokes shipped. Added 5 new tips covering S/L/C/E/I — the new workstation flows users won't find without `?` help otherwise:

  - "S splits a large staged set into multiple commits"
  - "L generates a changelog for the current branch"
  - "C creates a PR seeded from the changelog"
  - "E opens the commit draft in \$EDITOR or \$VISUAL"
  - "I drafts an AI commit message from staged changes"

Bumped the test ceiling (8 → 24) so future additions don't re-spec the test. Floor of 6 from the original P4.3 spec stays.

## Test plan

- [x] `npm run lint` clean
- [x] `tsc --noEmit` clean
- [x] `npm run test:jest` — 1630 tests pass (main worktree)
- [ ] Manual: `coco ui` → press `I` in compose → spinner animates instead of static `⏳`
- [ ] Manual: press `C` from history → footer shows animated spinner during PR body generation
- [ ] Manual: wait 10s on idle → tip rotation surfaces one of the new S/L/C/E/I hints within a cycle