### PR TITLE
feat(workstation): directive post-apply hint with next-step keystrokes

### DIFF
--- a/src/workstation/chrome/postApplyHints.test.ts
+++ b/src/workstation/chrome/postApplyHints.test.ts
@@ -1,0 +1,43 @@
+import { formatRemainingWorktreeHint } from './postApplyHints'
+
+describe('formatRemainingWorktreeHint', () => {
+  it('returns an empty string when nothing is left to commit', () => {
+    // The caller branches on remaining > 0 before invoking, but
+    // belt-and-suspenders empty-input handling keeps the helper safe
+    // to call unconditionally.
+    expect(formatRemainingWorktreeHint(0, 0)).toBe('')
+  })
+
+  it('combines unstaged and untracked counts in one hint', () => {
+    const hint = formatRemainingWorktreeHint(6, 3)
+    expect(hint).toContain('6 unstaged')
+    expect(hint).toContain('3 untracked')
+    expect(hint).toContain('press gs to stage')
+    expect(hint).toContain('I to draft AI commit message')
+  })
+
+  it('elides untracked when the count is zero', () => {
+    const hint = formatRemainingWorktreeHint(6, 0)
+    expect(hint).toContain('6 unstaged')
+    expect(hint).not.toContain('untracked')
+    // Unstaged-only hint still suggests reviewing before drafting.
+    expect(hint).toContain('press gs to stage')
+  })
+
+  it('elides unstaged when the count is zero', () => {
+    const hint = formatRemainingWorktreeHint(0, 3)
+    expect(hint).toContain('3 untracked')
+    expect(hint).not.toContain('unstaged')
+    // Untracked-only path uses slightly different action copy since
+    // there's nothing to "review" — the files are new additions.
+    expect(hint).toContain('press gs to stage them, then I for an AI draft')
+  })
+
+  it('does not invent action hints when no files match a category', () => {
+    // Defensive — negative inputs treated like zero (clamped at the
+    // caller, but the helper doesn't blow up on them).
+    expect(formatRemainingWorktreeHint(-1, -1)).toBe('')
+    expect(formatRemainingWorktreeHint(-5, 3)).toContain('3 untracked')
+    expect(formatRemainingWorktreeHint(5, -3)).toContain('5 unstaged')
+  })
+})

--- a/src/workstation/chrome/postApplyHints.ts
+++ b/src/workstation/chrome/postApplyHints.ts
@@ -1,0 +1,52 @@
+/**
+ * Status-line hints for "what to do next" after a workflow that
+ * mutates the worktree (split-apply, etc.). Pure formatting — the
+ * runtime computes the counts and the helpers turn them into
+ * directive copy.
+ *
+ * The goal is to keep momentum after a successful operation. An
+ * empty success message ("Applied 4 commits.") reads as a dead end
+ * when there are still uncommitted changes to deal with. A directive
+ * hint ("Applied 4 commits. 6 unstaged + 3 untracked remaining —
+ * press gs to stage, I to draft AI commit message.") tells the user
+ * exactly what their next move can be without forcing them to scan
+ * panes for state.
+ */
+
+/**
+ * Format the "what's left after the split" suffix that follows a
+ * successful split-apply message. Returns a string suitable for
+ * concatenation, NOT a standalone sentence.
+ *
+ * Inputs are non-negative integer counts; behavior is undefined for
+ * negatives (the caller should clamp before passing). The hint
+ * elides categories with zero counts so we don't say "0 untracked"
+ * — just the non-zero ones.
+ *
+ * Examples:
+ *   formatRemainingWorktreeHint(6, 3)
+ *     → "6 unstaged + 3 untracked remaining — press gs to stage, I to draft AI commit message."
+ *   formatRemainingWorktreeHint(0, 3)
+ *     → "3 untracked remaining — press gs to stage them, then I for an AI draft."
+ *   formatRemainingWorktreeHint(6, 0)
+ *     → "6 unstaged remaining — press gs to review, I to draft AI commit message."
+ *   formatRemainingWorktreeHint(0, 0)
+ *     → ''  (caller should branch on "remaining > 0" before calling)
+ */
+export function formatRemainingWorktreeHint(unstaged: number, untracked: number): string {
+  if (unstaged <= 0 && untracked <= 0) {
+    return ''
+  }
+  const parts: string[] = []
+  if (unstaged > 0) parts.push(`${unstaged} unstaged`)
+  if (untracked > 0) parts.push(`${untracked} untracked`)
+  const counts = parts.join(' + ')
+  // Tailor the action hint slightly based on whether there's
+  // anything to actually review-and-stage vs just track. With
+  // untracked-only, "review" doesn't fit — the files are new
+  // additions, not diffs to scan.
+  if (unstaged > 0) {
+    return `${counts} remaining — press gs to stage, I to draft AI commit message.`
+  }
+  return `${counts} remaining — press gs to stage them, then I for an AI draft.`
+}

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -89,6 +89,7 @@ import {
     getLogInkInputEvents,
 } from '../../commands/log/inkInput'
 import { hasSeenOnboarding, markOnboardingSeen } from '../chrome/onboarding'
+import { formatRemainingWorktreeHint } from '../chrome/postApplyHints'
 import { SPINNER_TICK_MS } from '../chrome/spinner'
 
 
@@ -1843,11 +1844,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     // Success — close the overlay, reset compose (the staged set is
     // now empty since the plan committed everything), and pop the
     // compose view so the user lands on whatever was beneath (usually
-    // status, sometimes history). An empty compose pane after the
-    // commits land is a dead end; the surface beneath shows real
-    // state — remaining unstaged/untracked files, or the freshly
-    // landed commits in history. Either is more useful than staring
-    // at an empty draft.
+    // status, sometimes history).
     dispatch({ type: 'clearSplitPlan' })
     dispatch({ type: 'commitCompose', action: { type: 'reset' } })
     // Only pop if compose is on top — the apply could have been
@@ -1855,10 +1852,30 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     if (state.activeView === 'compose' && state.viewStack.length > 1) {
       dispatch({ type: 'popView' })
     }
-    dispatch({ type: 'setStatus', value: result.message, kind: 'success' })
+
+    // Refresh BEFORE setting the final status so we can peek at the
+    // post-apply worktree state and craft a directive next-step hint
+    // ("X unstaged + Y untracked remaining — press gs to stage / I
+    // to draft / …"). An empty success message reads as a dead end;
+    // a next-step hint keeps momentum.
     await refreshWorktreeContext()
-    // Re-fetch the commit log so the new commits show up in history.
     await refreshContext()
+
+    // Best-effort peek at the fresh worktree counts. If the second
+    // load fails we just fall back to the bare success message — no
+    // reason to noisily surface a status-line lookup error after a
+    // genuine success.
+    const fresh = await getWorktreeOverview(git).catch(() => undefined)
+    const unstaged = fresh?.unstagedCount || 0
+    const untracked = fresh?.untrackedCount || 0
+    const remaining = unstaged + untracked
+
+    const baseMessage = result.message || 'Applied split plan.'
+    const successMessage = remaining > 0
+      ? `${baseMessage} ${formatRemainingWorktreeHint(unstaged, untracked)}`
+      : `${baseMessage} Worktree is clean.`
+
+    dispatch({ type: 'setStatus', value: successMessage, kind: 'success' })
   }, [dispatch, git, refreshContext, refreshWorktreeContext, state.activeView, state.splitPlan, state.viewStack.length])
 
   // Esc inside the overlay — close without applying. Status line gets


### PR DESCRIPTION
PR B of the polish sequence. Closes the loop on the empty-compose-after-apply feedback from #926.

## What this changes

After a successful split-apply the user previously saw just the bare success message ("Created 4 split commit(s)."). If there were still unstaged or untracked files left, no cue about what to do next.

Now after success the runtime peeks at the post-apply worktree state and crafts a directive hint:

- `6 unstaged + 3 untracked remaining` → "6 unstaged + 3 untracked remaining — press gs to stage, I to draft AI commit message."
- `6 unstaged, 0 untracked` → "6 unstaged remaining — press gs to stage, I to draft AI commit message."
- `0 unstaged, 3 untracked` → "3 untracked remaining — press gs to stage them, then I for an AI draft."
- `0 + 0` → "Worktree is clean."

## How

- New `formatRemainingWorktreeHint(unstaged, untracked)` in `chrome/postApplyHints.ts`. Pure function. Elides categories with zero counts. Untracked-only path uses subtly different action copy ("stage them, then I" vs "stage, I to draft") since untracked files are new additions not diffs to review first.
- `applyCommitSplit` re-orders the success block: refresh BEFORE setStatus, then peek at the fresh worktree counts via a best-effort `getWorktreeOverview` call, then craft and dispatch the final message. The peek is `.catch(() => undefined)` so a failed second-load doesn't noisily replace a genuine success.

## What this does NOT do

The user's stronger interpretation was "auto-stage the residue + auto-draft AI commit message". I deliberately stopped short of that — auto-staging feels magical and surprising for users who expect explicit control. The hint version surfaces the next moves without taking them.

If usage shows everyone always hits gs+I after a split, that's a future "one-keystroke continuation" — but worth seeing the usage data first.

## Test plan

- [x] `npm run lint` clean
- [x] `tsc --noEmit` clean
- [x] `npm run test:jest` — 1635 tests pass (+5 from this PR)
- [ ] Manual: `npm run scenario create dirty-many-files -- --run-ui` → `S` → review → `y` apply → status line shows "Created N commits. 6 unstaged + 3 untracked remaining — press gs to stage, I to draft AI commit message."
- [ ] Manual: split-apply on a scenario where everything was staged → status line shows "… Worktree is clean."