### PR TITLE
feat(parser): structural-extract eval harness (#934)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,9 @@ specs/
 # COCO_BENCH=1 stays local too.
 .bench/run-*.json
 .coco-bench.json
+
+# Structural-extract eval output (#934). Each run lands under
+# .bench/structural-extract-eval/<timestamp>/ — JSON + Markdown per
+# input. These are local artifacts; no committed baseline yet
+# (regression-detection follow-up).
+.bench/structural-extract-eval/

--- a/bin/structuralExtractEval.ts
+++ b/bin/structuralExtractEval.ts
@@ -1,0 +1,220 @@
+#!/usr/bin/env tsx
+/**
+ * CLI driver for the structural-extract eval (#934).
+ *
+ * Walks the scenario library, builds a `FileDiff[]` per commit, and
+ * runs each scenario through the structural-extract A/B harness
+ * (baseline vs. languageAware-enabled). Writes a per-scenario JSON
+ * result plus a Markdown summary into `.bench/structural-extract-eval/
+ * <timestamp>/`, and prints an aggregate table to stdout.
+ *
+ * Usage:
+ *   npm run eval:structural-extract                       # all scenarios
+ *   npm run eval:structural-extract -- --scenario X       # one scenario
+ *   npm run eval:structural-extract -- --languages ts,js  # narrow opt-in
+ *   npm run eval:structural-extract -- --out <dir>        # custom output
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs'
+import * as path from 'node:path'
+import {
+  EvalRunConfig,
+  StructuralLanguageId,
+  renderEvalReportMarkdown,
+  runStructuralExtractEval,
+} from '../src/lib/parsers/default/__evals__/structuralExtractEval'
+import { evalFixtures } from '../src/lib/parsers/default/__evals__/fixtures'
+import { buildScenarioFixtures } from '../src/lib/parsers/default/__evals__/scenarioInputs'
+import { allScenarios } from '../src/lib/testUtils/scenarios'
+
+type CliArgs = {
+  scenarios: string[]
+  /** When true (default), include the hand-crafted fixtures in the run. */
+  includeFixtures: boolean
+  /** When true, skip the scenario adapter and run fixtures only. */
+  fixturesOnly: boolean
+  languages: StructuralLanguageId[]
+  outDir: string
+  help: boolean
+}
+
+const KNOWN_LANGUAGES = new Set<StructuralLanguageId>(['ts', 'js', 'py', 'rs', 'go'])
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    scenarios: [],
+    includeFixtures: true,
+    fixturesOnly: false,
+    languages: [],
+    outDir: '',
+    help: false,
+  }
+  for (let i = 0; i < argv.length; i += 1) {
+    const value = argv[i]
+    if (value === '--help' || value === '-h') {
+      args.help = true
+    } else if (value === '--scenario') {
+      const next = argv[++i]
+      if (next) args.scenarios.push(next)
+    } else if (value === '--no-fixtures') {
+      args.includeFixtures = false
+    } else if (value === '--fixtures-only') {
+      args.fixturesOnly = true
+    } else if (value === '--languages') {
+      const next = argv[++i] || ''
+      for (const lang of next.split(',').map((s) => s.trim()).filter(Boolean)) {
+        if (KNOWN_LANGUAGES.has(lang as StructuralLanguageId)) {
+          args.languages.push(lang as StructuralLanguageId)
+        } else {
+          console.error(`! Unknown language "${lang}" — ignored. Known: ${[...KNOWN_LANGUAGES].join(', ')}`)
+        }
+      }
+    } else if (value === '--out') {
+      const next = argv[++i]
+      if (next) args.outDir = next
+    }
+  }
+  return args
+}
+
+function printHelp(): void {
+  console.log(`structural-extract eval (#934)
+
+Usage:
+  npm run eval:structural-extract                       run all scenarios + fixtures
+  npm run eval:structural-extract -- --scenario NAME    run one scenario
+  npm run eval:structural-extract -- --fixtures-only    skip scenarios (fast)
+  npm run eval:structural-extract -- --no-fixtures      scenarios only
+  npm run eval:structural-extract -- --languages ts,js  narrow opt-in
+  npm run eval:structural-extract -- --out DIR          custom output dir
+
+Output:
+  Per-input JSON + Markdown reports under .bench/structural-extract-eval/<timestamp>/.
+  Aggregate summary printed to stdout.
+
+Inputs:
+  - Scenarios: deterministic git states from src/lib/testUtils/scenarios/
+    (these mostly trigger the lossless trivial-shape path; useful for
+    "what does the natural distribution look like").
+  - Fixtures: hand-crafted modification diffs in __evals__/fixtures.ts
+    that target the language-aware path specifically.
+
+Scenarios: ${allScenarios.map((s) => s.name).join(', ')}
+Fixtures:  ${evalFixtures.map((f) => f.name).join(', ')}
+`)
+}
+
+async function main(): Promise<number> {
+  const args = parseArgs(process.argv.slice(2))
+  if (args.help) {
+    printHelp()
+    return 0
+  }
+
+  const scenarioTarget = args.fixturesOnly
+    ? []
+    : args.scenarios.length > 0
+      ? args.scenarios
+      : allScenarios.map((s) => s.name)
+  const fixtureTarget = args.includeFixtures || args.fixturesOnly
+    ? evalFixtures
+    : []
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+  const outDir = args.outDir || path.join('.bench', 'structural-extract-eval', timestamp)
+  mkdirSync(outDir, { recursive: true })
+
+  const configs: EvalRunConfig[] = [
+    { label: 'baseline' },
+    {
+      label: args.languages.length > 0
+        ? `languageAware(${args.languages.join(',')})`
+        : 'languageAware-all',
+      fastPath: {
+        languageAware: {
+          enabled: true,
+          ...(args.languages.length > 0 ? { languages: args.languages } : {}),
+        },
+      },
+    },
+  ]
+
+  // Aggregate totals across scenarios — printed at the end so the user
+  // sees the top-line impact without having to read every file.
+  let aggregateBaselineCalls = 0
+  let aggregateEnabledCalls = 0
+  let aggregateFastPathHits = 0
+  let aggregateInputFiles = 0
+
+  console.log(`\nstructural-extract eval — ${timestamp}\n`)
+  console.log(`output: ${outDir}\n`)
+  console.log(`configs:`)
+  for (const config of configs) console.log(`  - ${config.label}`)
+  console.log('')
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function recordReport(kind: 'scenario' | 'fixture', name: string, report: any): void {
+    aggregateInputFiles += report.inputFileCount
+    if (report.runs[0]) aggregateBaselineCalls += report.runs[0].llmCalls
+    if (report.runs[1]) aggregateEnabledCalls += report.runs[1].llmCalls
+    if (report.deltas[0]) aggregateFastPathHits += report.deltas[0].fastPathHitCount
+
+    const slug = `${kind}-${name}`
+    writeFileSync(path.join(outDir, `${slug}.json`), JSON.stringify(report, null, 2))
+    writeFileSync(
+      path.join(outDir, `${slug}.md`),
+      renderEvalReportMarkdown(report, `structural-extract eval — ${kind} · ${name}`),
+    )
+    const saved = report.deltas[0]?.llmCallsSaved ?? 0
+    const hits = report.deltas[0]?.fastPathHitCount ?? 0
+    console.log(
+      `${report.inputFileCount} files · ${report.runs[0]?.llmCalls ?? 0} → ${report.runs[1]?.llmCalls ?? 0} LLM calls (saved ${saved}, fast-path hits ${hits})`,
+    )
+  }
+
+  for (const scenarioName of scenarioTarget) {
+    process.stdout.write(`· scenario ${scenarioName} … `)
+    let repoCleanup: (() => Promise<void>) | undefined
+    try {
+      const { repo, fixtures } = await buildScenarioFixtures(scenarioName)
+      repoCleanup = () => repo.cleanup()
+      const diffs = fixtures.commits.flatMap((c) => c.diffs)
+      const report = await runStructuralExtractEval(diffs, configs)
+      recordReport('scenario', scenarioName, report)
+    } catch (error) {
+      console.log(`error: ${(error as Error).message}`)
+    } finally {
+      if (repoCleanup) await repoCleanup()
+    }
+  }
+
+  for (const fixture of fixtureTarget) {
+    process.stdout.write(`· fixture  ${fixture.name} … `)
+    try {
+      const report = await runStructuralExtractEval(fixture.diffs, configs)
+      recordReport('fixture', fixture.name, report)
+    } catch (error) {
+      console.log(`error: ${(error as Error).message}`)
+    }
+  }
+
+  console.log('')
+  console.log(`Aggregate:`)
+  console.log(`  scenarios:        ${scenarioTarget.length}`)
+  console.log(`  fixtures:         ${fixtureTarget.length}`)
+  console.log(`  input files:      ${aggregateInputFiles}`)
+  console.log(`  baseline LLM:     ${aggregateBaselineCalls}`)
+  console.log(`  enabled LLM:      ${aggregateEnabledCalls}`)
+  console.log(`  LLM calls saved:  ${aggregateBaselineCalls - aggregateEnabledCalls}`)
+  console.log(`  fast-path hits:   ${aggregateFastPathHits}`)
+  console.log('')
+  console.log(`Reports written to: ${outDir}`)
+  return 0
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:cli": "tsx bin/smokeCli.ts",
     "bench": "tsx bin/benchmark.ts",
     "scenario": "tsx bin/scenario.ts",
+    "eval:structural-extract": "tsx bin/structuralExtractEval.ts",
     "pretest:jest": "npm run build:info",
     "test:jest": "jest",
     "test:jest:watch": "jest --watch",

--- a/src/lib/parsers/default/__evals__/README.md
+++ b/src/lib/parsers/default/__evals__/README.md
@@ -1,0 +1,137 @@
+# `__evals__/` — structural-extract eval harness
+
+Scaffolding for #934. Measures the structural-extract fast path's
+behavior (regex extractors today, tree-sitter when that lands) by
+running the parser pipeline twice against a fixed input set — once
+with `fastPath.languageAware.enabled: false` (LLM baseline), once
+with it on — and reporting LLM-calls-saved, fast-path hit count, and
+token deltas per file.
+
+## Why this exists
+
+Unit tests of the individual extractors (`tsStructuralDiff.test.ts`
+et al.) verify that `parseStructuralLine('export function foo() {}')`
+returns the right symbol. They don't verify the *resulting commit
+message* is still good when the fast path fires. Without an eval
+harness:
+
+- We can't ship `languageAware.enabled: true` as the default with
+  confidence — it stays opt-in.
+- We can't compare tree-sitter vs. regex quantitatively (#933).
+- Extractor regressions are invisible until a user complains.
+
+The harness produces a deterministic, mechanical signal: did the
+fast path fire? did the LLM call go away? It doesn't yet judge
+"is the resulting message better" — that's a separate axis
+(human review, eventually a real-LLM live-mode harness).
+
+## Layout
+
+```
+__evals__/
+├── README.md                  (this file)
+├── structuralExtractEval.ts   (the A/B harness)
+├── structuralExtractEval.test.ts
+├── scenarioInputs.ts          (scenario → FileDiff[] adapter)
+├── scenarioInputs.test.ts
+└── fixtures.ts                (hand-crafted modification diffs)
+```
+
+The CLI driver lives at `bin/structuralExtractEval.ts` and is wired
+via the `eval:structural-extract` npm script.
+
+## Inputs
+
+The eval consumes two input sources:
+
+1. **Scenarios** (`scenarioInputs.ts`). Each scenario in the
+   `src/lib/testUtils/scenarios/` library is materialized into a temp
+   repo, then its commits are walked and converted to `FileDiff[]`.
+   Mostly trigger the lossless trivial-shape short-circuit (pure
+   additions); useful for measuring the natural distribution.
+
+2. **Fixtures** (`fixtures.ts`). Hand-crafted modification diffs that
+   specifically target the language-aware path. One fixture per
+   language so a regression in any single extractor surfaces in its
+   own outcome row rather than being averaged out.
+
+Both are deterministic — same input set across runs, same machine or
+not. That's what makes the harness suitable for regression detection
+even without a committed baseline.
+
+## Running
+
+```bash
+npm run eval:structural-extract                       # scenarios + fixtures
+npm run eval:structural-extract -- --fixtures-only    # fast path coverage only
+npm run eval:structural-extract -- --no-fixtures      # scenarios only
+npm run eval:structural-extract -- --scenario NAME    # one scenario
+npm run eval:structural-extract -- --languages ts,js  # narrow opt-in
+npm run eval:structural-extract -- --out DIR          # custom output
+```
+
+Output lands in `.bench/structural-extract-eval/<timestamp>/`:
+
+- `scenario-<name>.json` / `scenario-<name>.md`
+- `fixture-<name>.json` / `fixture-<name>.md`
+
+The aggregate summary prints to stdout.
+
+## Reading the report
+
+Each report has two sections:
+
+1. **Per-run totals** — LLM calls fired, input/output tokens for each
+   config.
+2. **Deltas vs baseline** — LLM calls saved, token reduction
+   (informational; can be positive OR negative since templated
+   summaries differ in length from LLM mocks), fast-path hit count.
+
+The load-bearing metric for #934 is `llmCallsSaved`. Token reduction
+is reported for completeness but isn't asserted with a sign — the
+templated summary can be longer or shorter than the mock LLM summary
+depending on input shape.
+
+## What's NOT here (yet)
+
+- **Committed baseline + regression check**. Today the harness reports
+  one-run output; comparing run-to-run for CI gating is a follow-up.
+  The pattern from `.bench/baseline.json` (#845) is the template.
+- **Real-LLM live mode**. Mock-mode is fast + deterministic + free;
+  real-LLM eval is slow + paid + non-deterministic, but lets us
+  compare actual generated messages side-by-side. Layer it onto the
+  existing harness via a `mode: 'mock' | 'live'` option when the cost
+  is justified.
+- **Rust / Go fixture generators**. The `__fixtures__/generators.ts`
+  module only covers TS + Python today. Scenario coverage for Rust /
+  Go languages is purely zero-modification (the deterministic
+  generator defaults to TypeScript). Hand-crafted Rust/Go fixtures
+  in `fixtures.ts` partially compensate.
+- **Per-language breakdown**. Aggregate metrics are by-scenario today;
+  a per-language pivot ("Python fast-path coverage = X%") would help
+  prioritize extractor work. Easy to add once the harness has a
+  consumer asking for it.
+
+## Adding a fixture
+
+Append to `fixtures.ts`. Keep it focused — one structural change per
+fixture (added export, removed function, signature change). The
+fixture's `diffs` array is fed directly into the harness, so it
+needs to be a realistic unified-diff body for a single file.
+
+```ts
+{
+  name: 'ts-something-new',
+  description: 'What this exercises.',
+  diffs: [
+    buildDiff('src/something.ts', [
+      '@@ -1,2 +1,2 @@',
+      '-export function before() {}',
+      '+export function after() {}',
+    ].join('\n')),
+  ],
+},
+```
+
+Then re-run the eval — the new fixture appears in the output. No
+registration step.

--- a/src/lib/parsers/default/__evals__/fixtures.ts
+++ b/src/lib/parsers/default/__evals__/fixtures.ts
@@ -1,0 +1,179 @@
+/**
+ * Hand-crafted eval fixtures for the structural-extract harness (#934).
+ *
+ * These complement the scenario-derived inputs in `scenarioInputs.ts`:
+ *
+ *   - **Scenarios** measure the natural distribution. Most scenario
+ *     commits are pure additions, which hit the lossless trivial-shape
+ *     short-circuit BEFORE the language-aware path runs — useful for
+ *     showing what the fast path doesn't need to do.
+ *
+ *   - **Fixtures** (this file) are modification-shaped commits that
+ *     DO reach the language-aware branch, so the eval can report a
+ *     non-zero fast-path hit rate. Each fixture is a small, focused
+ *     case that exercises one language's extractor against a realistic
+ *     diff shape.
+ *
+ * Adding a fixture: append to `evalFixtures`. Keep them small and
+ * focused — one structural change per fixture (added export, removed
+ * function, signature change, etc.) — so a regression in any single
+ * extractor surfaces visibly in the per-fixture outcome rather than
+ * being averaged out.
+ */
+
+import type { FileDiff } from '../../../types'
+
+export type EvalFixture = {
+  /** Stable identifier — appears in the per-fixture outcome row. */
+  name: string
+  /** What this fixture is meant to exercise. */
+  description: string
+  /** The diffs the eval feeds into the parser. */
+  diffs: FileDiff[]
+}
+
+function buildDiff(file: string, diff: string): FileDiff {
+  return { file, diff, summary: '', tokenCount: Math.ceil(diff.length / 4) }
+}
+
+export const evalFixtures: readonly EvalFixture[] = [
+  {
+    name: 'ts-export-add-remove',
+    description: 'TS module gains parseRequest, loses legacyParse — both top-level exports.',
+    diffs: [
+      buildDiff('src/parser.ts', [
+        '@@ -1,8 +1,12 @@',
+        ' import { Logger } from "./logger"',
+        ' ',
+        '-export function legacyParse() {',
+        '-  return {}',
+        '-}',
+        '+export function parseRequest(input: string) {',
+        '+  return JSON.parse(input)',
+        '+}',
+        '+',
+        '+export const PARSE_VERSION = 2',
+        ' ',
+        ' export class ParserContext {',
+        '   constructor(private readonly log: Logger) {}',
+        ' }',
+      ].join('\n')),
+    ],
+  },
+  {
+    name: 'ts-signature-change',
+    description: 'TS function gains a parameter — both buckets carry parseRequest, surfaces as signature change.',
+    diffs: [
+      buildDiff('src/parser.ts', [
+        '@@ -1,4 +1,4 @@',
+        ' import { Logger } from "./logger"',
+        ' ',
+        '-export function parseRequest(input: string) {',
+        '+export function parseRequest(input: string, schema: Schema) {',
+        '   return JSON.parse(input)',
+        ' }',
+      ].join('\n')),
+    ],
+  },
+  {
+    name: 'python-class-method-add',
+    description: 'Python module replaces a legacy helper with a class + factory.',
+    diffs: [
+      buildDiff('src/handler.py', [
+        '@@ -1,8 +1,14 @@',
+        ' import json',
+        ' ',
+        '-def legacy_handler(log):',
+        '-    return {"log": log}',
+        '+class RequestHandler:',
+        '+    def __init__(self, log):',
+        '+        self._log = log',
+        '+',
+        '+def build_handler(log):',
+        '+    return RequestHandler(log)',
+        ' ',
+        ' TIMEOUT = 30',
+      ].join('\n')),
+    ],
+  },
+  {
+    name: 'rust-impl-block',
+    description: 'Rust file replaces a legacy fn with a struct + impl block + trait impl.',
+    diffs: [
+      buildDiff('src/widget.rs', [
+        '@@ -1,8 +1,16 @@',
+        ' use crate::base::Base;',
+        ' ',
+        '-pub fn legacy_widget() -> &str { "old" }',
+        '+pub struct Widget;',
+        '+',
+        '+impl Widget {',
+        '+    pub fn new() -> Self { Widget }',
+        '+}',
+        '+',
+        '+impl Base for Widget {',
+        '+    fn name(&self) -> &str { "widget" }',
+        '+}',
+        ' ',
+        ' pub const VERSION: u32 = 2;',
+      ].join('\n')),
+    ],
+  },
+  {
+    name: 'go-method-receiver',
+    description: 'Go file replaces a free function with a struct + constructor + method.',
+    diffs: [
+      buildDiff('widget.go', [
+        '@@ -1,6 +1,12 @@',
+        ' package widget',
+        ' ',
+        '-func LegacyName() string { return "old" }',
+        '+type Widget struct {',
+        '+    name string',
+        '+}',
+        '+',
+        '+func New(name string) *Widget { return &Widget{name: name} }',
+        '+',
+        '+func (w *Widget) Name() string { return w.name }',
+        ' ',
+        ' const Version = 2',
+      ].join('\n')),
+    ],
+  },
+  {
+    name: 'markdown-structural',
+    description: 'Markdown doc gains and removes heading-level sections.',
+    diffs: [
+      buildDiff('docs/intro.md', [
+        '@@ -1,8 +1,10 @@',
+        ' # Intro',
+        ' ',
+        '-## Old section',
+        '-Some old prose.',
+        '+## New section',
+        '+New prose explaining the new section.',
+        ' ',
+        ' ## Keep me',
+        ' I stay.',
+        '+',
+        '+## Bonus section',
+        '+More prose.',
+      ].join('\n')),
+    ],
+  },
+  {
+    name: 'ts-body-only-fallthrough',
+    description: 'TS file with body-only edits — no top-level signal, falls through to LLM.',
+    diffs: [
+      buildDiff('src/util.ts', [
+        '@@ -1,5 +1,5 @@',
+        ' export function compute(x: number) {',
+        '-  return x * 2',
+        '+  return x * 3',
+        ' }',
+        ' ',
+        ' export const TAG = "util"',
+      ].join('\n')),
+    ],
+  },
+]

--- a/src/lib/parsers/default/__evals__/scenarioInputs.test.ts
+++ b/src/lib/parsers/default/__evals__/scenarioInputs.test.ts
@@ -1,0 +1,51 @@
+import { buildScenarioFixtures } from './scenarioInputs'
+
+describe('buildScenarioFixtures', () => {
+  it('throws on unknown scenario names', async () => {
+    await expect(buildScenarioFixtures('not-a-real-scenario')).rejects.toThrow(/Unknown scenario/)
+  })
+
+  it('produces a fixture per commit with per-file diffs', async () => {
+    const { repo, fixtures } = await buildScenarioFixtures('feature-pr-ready')
+    try {
+      expect(fixtures.scenario).toBe('feature-pr-ready')
+      expect(fixtures.commits.length).toBeGreaterThan(0)
+      // Each commit fixture carries a sha + subject + at least one
+      // file diff (the scenario writes a fresh file per commit).
+      for (const commit of fixtures.commits) {
+        expect(commit.shortSha).toMatch(/^[0-9a-f]{8}$/)
+        expect(commit.subject.length).toBeGreaterThan(0)
+        expect(commit.diffs.length).toBeGreaterThan(0)
+        // Every diff has a token count and a non-empty patch body.
+        for (const diff of commit.diffs) {
+          expect(diff.tokenCount).toBeGreaterThan(0)
+          expect(diff.diff.length).toBeGreaterThan(0)
+        }
+      }
+      // The scenario lands on the feat branch; the adapter records it
+      // for downstream display.
+      expect(fixtures.branch).toBe('feat/widget-v2')
+    } finally {
+      await repo.cleanup()
+    }
+  })
+
+  it('extracts the same byte-identical fixture set across runs (determinism)', async () => {
+    const a = await buildScenarioFixtures('single-staged-file')
+    const b = await buildScenarioFixtures('single-staged-file')
+    try {
+      expect(a.fixtures.commits.length).toBe(b.fixtures.commits.length)
+      for (let i = 0; i < a.fixtures.commits.length; i += 1) {
+        // shortSha will differ between runs (different temp dir →
+        // different commit tree). Compare the diff bodies instead —
+        // those are the eval input and are content-deterministic.
+        const aDiffs = a.fixtures.commits[i].diffs.map((d) => d.diff)
+        const bDiffs = b.fixtures.commits[i].diffs.map((d) => d.diff)
+        expect(aDiffs).toEqual(bDiffs)
+      }
+    } finally {
+      await a.repo.cleanup()
+      await b.repo.cleanup()
+    }
+  })
+})

--- a/src/lib/parsers/default/__evals__/scenarioInputs.ts
+++ b/src/lib/parsers/default/__evals__/scenarioInputs.ts
@@ -1,0 +1,139 @@
+/**
+ * Adapter: scenario → eval inputs (#934).
+ *
+ * Walks a scenario's commit history and produces one `CommitFixture`
+ * per commit with the per-file diffs the parser would normally see
+ * during a commit-message run. Each scenario's commits become a
+ * deterministic input set for the structural-extract eval harness.
+ *
+ * Why scenarios for the golden set: they're already deterministic
+ * (same scenario → byte-identical content each run), they cover a
+ * range of realistic shapes (worktree dirty, mid-merge, multi-commit
+ * feature branches), and they're maintained by the test layer
+ * regardless of the eval — so the golden set stays in sync with the
+ * test suite naturally.
+ */
+
+import type { SimpleGit } from 'simple-git'
+import type { FileDiff } from '../../../types'
+import { findScenario } from '../../../testUtils/scenarios'
+import { createTempGitRepo, type TempGitRepo } from '../../../testUtils/tempGitRepo'
+
+export type CommitFixture = {
+  /** Short sha — for display in the eval report. */
+  shortSha: string
+  /** Commit subject line. */
+  subject: string
+  /** Per-file diffs as `summarizeLargeFiles` would receive them. */
+  diffs: FileDiff[]
+}
+
+export type ScenarioFixtureSet = {
+  scenario: string
+  /** Branch the scenario ends on, when known. Informational. */
+  branch?: string
+  commits: CommitFixture[]
+}
+
+const TOKEN_FACTOR = 4
+
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / TOKEN_FACTOR)
+}
+
+/**
+ * Pull the per-file diff for one commit. Uses `git show --numstat`
+ * to enumerate changed files, then `git show <sha> -- <file>` for
+ * each to get the per-file patch in isolation — matching the shape
+ * `summarizeLargeFiles` consumes.
+ */
+async function diffsForCommit(git: SimpleGit, sha: string): Promise<FileDiff[]> {
+  const numstat = await git.raw(['show', '--format=', '--numstat', '--find-renames', sha])
+  const files: string[] = []
+  for (const line of numstat.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    const parts = trimmed.split('\t')
+    if (parts.length < 3) continue
+    // Rename rows look like "added\tdeleted\told -> new" or
+    // "added\tdeleted\told\tnew" depending on git version. Take the
+    // last path segment in either form — that's the post-rename name
+    // the parser would receive.
+    let path = parts[parts.length - 1]
+    if (path.includes(' -> ')) {
+      path = path.split(' -> ')[1]
+    }
+    if (path) files.push(path)
+  }
+
+  const diffs: FileDiff[] = []
+  for (const path of files) {
+    let patch = ''
+    try {
+      patch = await git.raw([
+        'show',
+        '--format=',
+        '--find-renames',
+        '--color=never',
+        '--unified=3',
+        sha,
+        '--',
+        path,
+      ])
+    } catch {
+      patch = ''
+    }
+    diffs.push({
+      file: path,
+      diff: patch,
+      summary: '',
+      tokenCount: estimateTokens(patch),
+    })
+  }
+  return diffs
+}
+
+/**
+ * Spin up a scenario in a fresh temp repo and extract a fixture per
+ * commit. Returns the repo handle so the caller can call `cleanup()`
+ * after consuming the fixtures.
+ */
+export async function buildScenarioFixtures(scenarioName: string): Promise<{
+  repo: TempGitRepo
+  fixtures: ScenarioFixtureSet
+}> {
+  const scenario = findScenario(scenarioName)
+  if (!scenario) {
+    throw new Error(`Unknown scenario: ${scenarioName}`)
+  }
+
+  const repo = await createTempGitRepo()
+  await scenario.setup(repo)
+
+  const log = await repo.git.log()
+  const commits: CommitFixture[] = []
+  for (const entry of log.all) {
+    const diffs = await diffsForCommit(repo.git, entry.hash)
+    commits.push({
+      shortSha: entry.hash.slice(0, 8),
+      subject: entry.message,
+      diffs,
+    })
+  }
+
+  let branch: string | undefined
+  try {
+    branch = (await repo.git.branchLocal()).current || undefined
+  } catch {
+    branch = undefined
+  }
+
+  return {
+    repo,
+    fixtures: {
+      scenario: scenario.name,
+      branch,
+      commits,
+    },
+  }
+}

--- a/src/lib/parsers/default/__evals__/structuralExtractEval.test.ts
+++ b/src/lib/parsers/default/__evals__/structuralExtractEval.test.ts
@@ -1,0 +1,141 @@
+import type { FileDiff } from '../../../types'
+import {
+  renderEvalReportMarkdown,
+  runStructuralExtractEval,
+} from './structuralExtractEval'
+
+function fileDiff(file: string, diff: string, tokenCount = 600): FileDiff {
+  return { file, diff, summary: '', tokenCount }
+}
+
+describe('runStructuralExtractEval', () => {
+  it('reports zero LLM saves when only one config is supplied', async () => {
+    const diff = [
+      '@@ -1,1 +1,1 @@',
+      '-export function legacyParse() {}',
+      '+export function parseRequest(input: string) {}',
+    ].join('\n')
+
+    const report = await runStructuralExtractEval(
+      [fileDiff('src/parser.ts', diff)],
+      [{ label: 'languageAware-on', fastPath: { languageAware: { enabled: true } } }],
+    )
+
+    expect(report.inputFileCount).toBe(1)
+    expect(report.runs).toHaveLength(1)
+    expect(report.runs[0].label).toBe('languageAware-on')
+    expect(report.runs[0].llmCalls).toBe(0)
+    expect(report.runs[0].files[0].outcome).toBe('languageAware')
+    expect(report.deltas).toEqual([])
+  })
+
+  it('counts LLM calls in the baseline and computes saves vs an enabled config', async () => {
+    const tsDiff = [
+      '@@ -1,1 +1,1 @@',
+      '-export function legacyParse() {}',
+      '+export function parseRequest(input: string) {}',
+    ].join('\n')
+    const mdDiff = [
+      '@@ -1,1 +1,2 @@',
+      '-old paragraph copy that was here before',
+      '+## New section',
+      '+plenty of new prose lines making this large',
+    ].join('\n')
+
+    const diffs = [
+      fileDiff('src/parser.ts', tsDiff),
+      fileDiff('docs/intro.md', mdDiff),
+    ]
+
+    const report = await runStructuralExtractEval(diffs, [
+      { label: 'baseline' },
+      { label: 'fast-paths-on', fastPath: { markdown: true, languageAware: { enabled: true } } },
+    ])
+
+    expect(report.runs).toHaveLength(2)
+    // Baseline: both files exceed the threshold and have no fast path,
+    // so each fires one LLM call.
+    expect(report.runs[0].llmCalls).toBe(2)
+    expect(report.runs[0].files.every((f) => f.outcome === 'llm')).toBe(true)
+    // Fast paths on: TS file hits the language-aware extractor;
+    // markdown file hits the templated extract. Both skip the LLM.
+    expect(report.runs[1].llmCalls).toBe(0)
+    expect(report.runs[1].files.find((f) => f.file.endsWith('.ts'))?.outcome).toBe('languageAware')
+    expect(report.runs[1].files.find((f) => f.file.endsWith('.md'))?.outcome).toBe('markdown')
+
+    expect(report.deltas).toHaveLength(1)
+    expect(report.deltas[0]).toMatchObject({
+      against: 'baseline',
+      label: 'fast-paths-on',
+      llmCallsSaved: 2,
+      fastPathHitCount: 2,
+    })
+    // tokenReduction is reported but intentionally NOT asserted with a
+    // sign — the templated summary can be longer OR shorter than the
+    // mock LLM summary depending on the input shape. The load-bearing
+    // metric for #934 is `llmCallsSaved`; tokenReduction is informational.
+    expect(typeof report.deltas[0].tokenReduction).toBe('number')
+  })
+
+  it('honors the languages allowlist (TS-only opt-in skips Python)', async () => {
+    const tsDiff = [
+      '@@ -1,1 +1,1 @@',
+      '-export function legacyParse() {}',
+      '+export function parseRequest(input: string) {}',
+    ].join('\n')
+    const pyDiff = [
+      '@@ -1,1 +1,1 @@',
+      '-def parse(input):',
+      '+def parse(input, schema):',
+    ].join('\n')
+
+    const report = await runStructuralExtractEval(
+      [fileDiff('a.ts', tsDiff), fileDiff('a.py', pyDiff)],
+      [
+        { label: 'baseline' },
+        { label: 'ts-only', fastPath: { languageAware: { enabled: true, languages: ['ts'] } } },
+      ],
+    )
+
+    expect(report.runs[1].files.find((f) => f.file === 'a.ts')?.outcome).toBe('languageAware')
+    // Python falls through to the LLM because it's not in the allowlist.
+    expect(report.runs[1].files.find((f) => f.file === 'a.py')?.outcome).toBe('llm')
+    expect(report.deltas[0].llmCallsSaved).toBe(1)
+  })
+
+  it('throws when no configs are supplied', async () => {
+    await expect(runStructuralExtractEval([fileDiff('a.ts', '+x')], [])).rejects.toThrow(
+      /at least one config/i,
+    )
+  })
+})
+
+describe('renderEvalReportMarkdown', () => {
+  it('renders a per-run totals table and a delta table when deltas exist', async () => {
+    const tsDiff = [
+      '@@ -1,1 +1,1 @@',
+      '-export function legacyParse() {}',
+      '+export function parseRequest(input: string) {}',
+    ].join('\n')
+
+    const report = await runStructuralExtractEval([fileDiff('a.ts', tsDiff)], [
+      { label: 'baseline' },
+      { label: 'on', fastPath: { languageAware: { enabled: true } } },
+    ])
+
+    const md = renderEvalReportMarkdown(report, 'Test eval')
+    expect(md).toContain('# Test eval')
+    expect(md).toContain('Input files: 1')
+    expect(md).toContain('## Per-run totals')
+    expect(md).toMatch(/\| baseline \|/)
+    expect(md).toMatch(/\| on \|/)
+    expect(md).toContain('## Deltas vs baseline')
+  })
+
+  it('omits the delta table when only one run is present', async () => {
+    const tsDiff = '@@ -1,1 +1,1 @@\n-x\n+y'
+    const report = await runStructuralExtractEval([fileDiff('a.ts', tsDiff)], [{ label: 'only' }])
+    const md = renderEvalReportMarkdown(report, 'Single')
+    expect(md).not.toContain('## Deltas vs baseline')
+  })
+})

--- a/src/lib/parsers/default/__evals__/structuralExtractEval.ts
+++ b/src/lib/parsers/default/__evals__/structuralExtractEval.ts
@@ -1,0 +1,263 @@
+/**
+ * Structural-extract A/B eval harness (#934).
+ *
+ * Runs `summarizeLargeFiles` against a fixed set of `FileDiff[]` twice —
+ * once with `fastPath.languageAware.enabled: false` (the LLM baseline),
+ * once with it enabled — and reports per-file outcomes plus aggregate
+ * metrics: how many LLM calls were saved, what percentage of files hit
+ * the fast path, and the resulting summary text in each config.
+ *
+ * Mocks the LLM call. Real-LLM evals are slow and non-deterministic;
+ * the goal here is mechanical regression detection (does a parser
+ * change reduce fast-path hits? does an extractor change increase
+ * them?), which doesn't need real model output. A separate "live"
+ * harness mode can be layered on top once it's worth the cost.
+ *
+ * Inputs come from the scenario library (`src/lib/testUtils/scenarios/`)
+ * via `scenarioInputs.ts` — each scenario's commits produce a
+ * deterministic set of file diffs, so eval runs are byte-identical
+ * across machines.
+ */
+
+import type { FileDiff } from '../../../types'
+import { summarizeLargeFiles } from '../utils/summarizeLargeFiles'
+
+export type StructuralLanguageId = 'ts' | 'js' | 'py' | 'rs' | 'go'
+
+/** Config for a single eval run. */
+export type EvalRunConfig = {
+  /** Short label for the run, e.g. "baseline" / "languageAware-on". */
+  label: string
+  /** Forwarded to `summarizeLargeFiles`. */
+  fastPath?: {
+    markdown?: boolean
+    languageAware?: {
+      enabled?: boolean
+      languages?: StructuralLanguageId[]
+    }
+  }
+  /**
+   * Override the summarization thresholds for this run. The defaults
+   * are tuned for the eval — lower than the production parser defaults
+   * so the harness actually exercises the summarization path on the
+   * compact files scenarios produce. Production runs use much higher
+   * thresholds (~25% of `maxTokens`), so eval results are NOT a
+   * faithful proxy for production behavior on a single file; they
+   * measure the *relative* fast-path vs. LLM split when summarization
+   * fires.
+   */
+  maxFileTokens?: number
+  minTokensForSummary?: number
+}
+
+const DEFAULT_EVAL_MAX_FILE_TOKENS = 20
+const DEFAULT_EVAL_MIN_TOKENS_FOR_SUMMARY = 10
+
+/** Per-file outcome inside a single run. */
+export type EvalFileOutcome = {
+  file: string
+  /** Token count before any rewrite. Mirrors the input `FileDiff.tokenCount`. */
+  inputTokens: number
+  /** Token count after rewrite (whether by fast path or LLM). */
+  outputTokens: number
+  /**
+   * What rewrote the file's diff. `'unchanged'` when the file fell below
+   * the size threshold; the other values match the explicit branches in
+   * `summarizeFileDiff`. We infer the branch from the file's output
+   * shape (LLM produces a fixed-shape mock string; templated paths
+   * produce recognizable substrings). Imperfect but deterministic.
+   */
+  outcome: 'unchanged' | 'trivial' | 'markdown' | 'languageAware' | 'llm'
+}
+
+export type EvalRunResult = {
+  label: string
+  /** Total LLM calls fired during this run. */
+  llmCalls: number
+  /** Sum of token counts across all output files. */
+  totalOutputTokens: number
+  /** Sum of token counts across all input files (constant across runs). */
+  totalInputTokens: number
+  files: EvalFileOutcome[]
+}
+
+export type EvalReport = {
+  /** Number of input diffs evaluated. */
+  inputFileCount: number
+  /** One entry per `EvalRunConfig` supplied. Order matches the input. */
+  runs: EvalRunResult[]
+  /**
+   * Pairwise delta from the first (baseline) run to each subsequent
+   * run. Empty when only one run was supplied.
+   */
+  deltas: Array<{
+    against: string
+    label: string
+    llmCallsSaved: number
+    tokenReduction: number
+    fastPathHitCount: number
+  }>
+}
+
+/**
+ * Mock-mode LLM stand-in. Produces a fixed-shape string we can
+ * recognize when classifying outcomes, while keeping the harness
+ * deterministic + offline. The shape carries the input file count so
+ * tests can assert against it without needing to know exact tokens.
+ */
+const MOCK_LLM_PREFIX = '<<llm-mock>> summarized'
+
+function classifyOutcome(input: FileDiff, output: FileDiff): EvalFileOutcome['outcome'] {
+  if (output.diff === input.diff && output.tokenCount === input.tokenCount) return 'unchanged'
+  if (output.diff.startsWith(MOCK_LLM_PREFIX)) return 'llm'
+  if (output.diff.startsWith('Updated markdown ')) return 'markdown'
+  if (output.diff.match(/^Updated (TypeScript|JavaScript|Python|Rust|Go) /)) return 'languageAware'
+  // The trivial-shape path emits short templated strings like "Added
+  // X. Removed Y." / "Renamed A -> B." / "Binary file changed."
+  // No exact prefix to assert on, so this branch is the catch-all for
+  // "diff changed but no recognized prefix" — almost always the
+  // trivial-shape path.
+  return 'trivial'
+}
+
+/**
+ * Run a single configuration against the supplied diffs and return a
+ * structured result.
+ */
+async function runOne(
+  diffs: FileDiff[],
+  config: EvalRunConfig,
+): Promise<EvalRunResult> {
+  // Dependency-injection mock: `summarizeLargeFiles` forwards the
+  // supplied `chain` + `textSplitter` to `summarize()`, which calls
+  // `chain.invoke()` per LLM call. Providing fakes here means we
+  // count + short-circuit the LLM without patching the module — works
+  // in CLI runs (no jest globals available) and tests alike.
+  let llmCalls = 0
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = {
+    invoke: async (input: { input_documents: Array<{ pageContent: string }> }) => {
+      llmCalls += 1
+      const totalLength = (input.input_documents || []).reduce(
+        (sum: number, doc) => sum + (doc.pageContent?.length || 0),
+        0,
+      )
+      const text = `${MOCK_LLM_PREFIX} ${(input.input_documents || []).length} document(s), ${totalLength} chars`
+      return { text }
+    },
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const textSplitter: any = {
+    splitDocuments: async (docs: unknown) => docs,
+  }
+
+  const result = await summarizeLargeFiles(diffs, {
+    maxFileTokens: config.maxFileTokens ?? DEFAULT_EVAL_MAX_FILE_TOKENS,
+    minTokensForSummary: config.minTokensForSummary ?? DEFAULT_EVAL_MIN_TOKENS_FOR_SUMMARY,
+    maxConcurrent: 4,
+    fastPath: config.fastPath,
+    tokenizer: (text) => Math.ceil(text.length / 4),
+    logger: {
+      verbose: () => undefined,
+      log: () => undefined,
+      startSpinner: () => undefined,
+      stopSpinner: () => undefined,
+      startTimer: () => undefined,
+      stopTimer: () => undefined,
+    } as never,
+    chain,
+    textSplitter,
+  })
+
+  const files: EvalFileOutcome[] = diffs.map((input, index) => {
+    const output = result[index] || input
+    return {
+      file: input.file,
+      inputTokens: input.tokenCount,
+      outputTokens: output.tokenCount,
+      outcome: classifyOutcome(input, output),
+    }
+  })
+
+  return {
+    label: config.label,
+    llmCalls,
+    totalInputTokens: diffs.reduce((sum, d) => sum + d.tokenCount, 0),
+    totalOutputTokens: files.reduce((sum, f) => sum + f.outputTokens, 0),
+    files,
+  }
+}
+
+/**
+ * Run all configs against the same input set and compute pairwise
+ * deltas vs the first run. The harness assumes the first run is the
+ * baseline you want to compare against; pass it first.
+ */
+export async function runStructuralExtractEval(
+  diffs: FileDiff[],
+  configs: EvalRunConfig[],
+): Promise<EvalReport> {
+  if (configs.length === 0) {
+    throw new Error('runStructuralExtractEval requires at least one config')
+  }
+
+  const runs: EvalRunResult[] = []
+  for (const config of configs) {
+    runs.push(await runOne(diffs, config))
+  }
+
+  const baseline = runs[0]
+  const deltas = runs.slice(1).map((run) => {
+    const fastPathHits = run.files.filter((f) =>
+      f.outcome === 'languageAware' || f.outcome === 'markdown'
+    ).length
+    return {
+      against: baseline.label,
+      label: run.label,
+      llmCallsSaved: baseline.llmCalls - run.llmCalls,
+      tokenReduction: baseline.totalOutputTokens - run.totalOutputTokens,
+      fastPathHitCount: fastPathHits,
+    }
+  })
+
+  return {
+    inputFileCount: diffs.length,
+    runs,
+    deltas,
+  }
+}
+
+/**
+ * Render an `EvalReport` as a human-readable Markdown summary. Suitable
+ * for both CLI stdout and a Markdown file written to disk for PR
+ * review.
+ */
+export function renderEvalReportMarkdown(report: EvalReport, title: string): string {
+  const lines: string[] = []
+  lines.push(`# ${title}`, '')
+  lines.push(`Input files: ${report.inputFileCount}`, '')
+
+  lines.push('## Per-run totals', '')
+  lines.push('| Label | LLM calls | Input tokens | Output tokens |')
+  lines.push('|---|---:|---:|---:|')
+  for (const run of report.runs) {
+    lines.push(
+      `| ${run.label} | ${run.llmCalls} | ${run.totalInputTokens} | ${run.totalOutputTokens} |`,
+    )
+  }
+  lines.push('')
+
+  if (report.deltas.length > 0) {
+    lines.push('## Deltas vs baseline', '')
+    lines.push('| Label | LLM calls saved | Token reduction | Fast-path hits |')
+    lines.push('|---|---:|---:|---:|')
+    for (const delta of report.deltas) {
+      lines.push(
+        `| ${delta.label} | ${delta.llmCallsSaved} | ${delta.tokenReduction} | ${delta.fastPathHitCount} |`,
+      )
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}

--- a/src/lib/testUtils/README.md
+++ b/src/lib/testUtils/README.md
@@ -421,6 +421,28 @@ expect(result.text).toContain('feat: my deterministic title')
 The scenario sets up the git state; the mock sets up the LLM output.
 Together they make the workflow test deterministic top to bottom.
 
+## Consumers outside of tests
+
+The scenario library is also the golden-set provider for the
+structural-extract eval harness (#934). Each scenario's commits are
+walked into per-file diffs and fed through the parser pipeline with
+the language-aware fast path toggled on vs. off; the harness reports
+LLM-calls-saved + fast-path hit rate per input.
+
+```bash
+npm run eval:structural-extract                 # all scenarios + fixtures
+npm run eval:structural-extract -- --scenario feature-pr-ready
+npm run eval:structural-extract -- --fixtures-only
+```
+
+The adapter lives at
+`src/lib/parsers/default/__evals__/scenarioInputs.ts` and the
+extraction-boundary rule still holds: it imports from
+`src/lib/testUtils/scenarios` and the public `findScenario` helper,
+not from any individual scenario module. When the testUtils layer
+moves out to its own package, the eval depends on the published
+package the same way any other consumer would.
+
 ## Extraction discipline
 
 This layer is intentionally **git-tool-agnostic** and a candidate for


### PR DESCRIPTION
## Summary

A/B harness for the language-aware fast path. Runs the parser pipeline twice against a fixed input set — once with \`fastPath.languageAware.enabled: false\` (LLM baseline), once with it on — and reports LLM calls saved, fast-path hit count, and token deltas per file.

The scenario library from #908 is reused as the golden-set provider — every scenario's commits become deterministic eval inputs without inventing new infrastructure for "where do the test commits come from".

## Key pieces

- \`runStructuralExtractEval(diffs, configs)\` — typed harness with pairwise deltas vs. the first config.
- \`buildScenarioFixtures(scenarioName)\` — scenario → \`FileDiff[]\` adapter that walks each scenario's commit log.
- Hand-crafted \`fixtures.ts\` — modification diffs targeting the language-aware path specifically (scenarios mostly trigger the lossless trivial-shape skip).
- \`bin/structuralExtractEval.ts\` + \`npm run eval:structural-extract\` — CLI that writes per-input JSON/Markdown reports and prints an aggregate summary.

## Sample output

Full run (scenarios + fixtures): 64 input files, 9 baseline LLM calls → 3 with languageAware on. 6 saved, 6 fast-path hits. All 5 language fixtures (TS×2, Python, Rust, Go) correctly trigger the fast path; markdown / body-only fall through to the LLM as expected.

## Test plan

- [x] \`npx tsc --noEmit\` → 0 errors
- [x] \`npx jest\` → 1597/1597 pass (9 new)
- [x] \`npx eslint\` on touched code → clean
- [x] Manual: \`npm run eval:structural-extract\` produces meaningful per-input reports + aggregate summary

## Out of scope (each tracked separately)

- Committed baseline + CI regression check
- Real-LLM live-mode harness
- Per-language breakdown pivot in the report

Closes the harness scaffolding portion of #934.