### PR TITLE
feat(workstation): mark just-landed commits in history with a transient indicator

### DIFF
--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -1336,4 +1336,58 @@ describe('log Ink view model', () => {
       expect(state.splitPlan).toBeUndefined()
     })
   })
+
+  describe('recent-commit markers', () => {
+    it('markRecentCommits records the hash list with a timestamp', () => {
+      const before = Date.now()
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, {
+        type: 'markRecentCommits',
+        hashes: ['abc123', 'def456'],
+      })
+
+      expect(state.recentCommitHashes?.hashes).toEqual(['abc123', 'def456'])
+      expect(state.recentCommitHashes?.markedAt).toBeGreaterThanOrEqual(before)
+    })
+
+    it('markRecentCommits with empty list closes the marker', () => {
+      // Allows callers to clear the marker early via the same action
+      // shape — useful when a follow-up op fires before the auto-
+      // clear timeout and we want to wipe old marks first.
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, {
+        type: 'markRecentCommits',
+        hashes: ['abc123'],
+      })
+      state = applyLogInkAction(state, { type: 'markRecentCommits', hashes: [] })
+      expect(state.recentCommitHashes).toBeUndefined()
+    })
+
+    it('clearRecentCommits closes the marker', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, {
+        type: 'markRecentCommits',
+        hashes: ['abc123'],
+      })
+      state = applyLogInkAction(state, { type: 'clearRecentCommits' })
+      expect(state.recentCommitHashes).toBeUndefined()
+    })
+
+    it('overwriting markRecentCommits replaces the previous list', () => {
+      // If a second op fires before the first's auto-clear, the
+      // newer hash set should win — old marks shouldn't bleed into
+      // the new operation's set.
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, {
+        type: 'markRecentCommits',
+        hashes: ['old1', 'old2'],
+      })
+      state = applyLogInkAction(state, {
+        type: 'markRecentCommits',
+        hashes: ['new1'],
+      })
+
+      expect(state.recentCommitHashes?.hashes).toEqual(['new1'])
+    })
+  })
 })

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -341,6 +341,18 @@ export type LogInkState = {
    */
   changelogCache: { [branch: string]: ChangelogCacheEntry }
   /**
+   * Hashes of commits the workstation just created (via split-apply
+   * or regular commit). The history surface renders these with a
+   * visible "new" marker so the user can see at a glance which rows
+   * landed from the operation they just confirmed. Auto-cleared by
+   * the runtime ~5s after marking — long enough to land the message,
+   * short enough not to litter the surface across later operations.
+   *
+   * Stored as a flat string set for fast membership checks inside
+   * the row renderer (called once per visible commit row).
+   */
+  recentCommitHashes?: { hashes: string[]; markedAt: number }
+  /**
    * In-TUI bisect start wizard (#879 item 4). Two-step pick:
    *   - 'bad'  : empty-state entered → user is picking the BAD commit
    *              from history. On Enter, capture the sha and advance.
@@ -553,6 +565,8 @@ export type LogInkAction =
   | { type: 'setChangelogText'; text: string }
   | { type: 'pageChangelog'; delta: number; lineCount: number }
   | { type: 'clearChangelogCache'; branch?: string }
+  | { type: 'markRecentCommits'; hashes: string[] }
+  | { type: 'clearRecentCommits' }
   | { type: 'startSplitPlanLoad' }
   | { type: 'setSplitPlanReady'; plan: CommitSplitPlan; planContext: CommitSplitPlanContext }
   | { type: 'setSplitPlanApplying' }
@@ -1697,6 +1711,20 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       delete next[action.branch]
       return { ...state, changelogCache: next, pendingKey: undefined }
     }
+    case 'markRecentCommits':
+      // Empty hash list closes out the marker — caller may use this
+      // to clear early when a follow-up op fires (so old "new"
+      // markers don't bleed into the next operation's surface).
+      if (action.hashes.length === 0) {
+        return { ...state, recentCommitHashes: undefined, pendingKey: undefined }
+      }
+      return {
+        ...state,
+        recentCommitHashes: { hashes: action.hashes, markedAt: Date.now() },
+        pendingKey: undefined,
+      }
+    case 'clearRecentCommits':
+      return { ...state, recentCommitHashes: undefined, pendingKey: undefined }
     case 'startSplitPlanLoad':
       // Overlay opens immediately so the user sees the loading state
       // (rather than the compose view sitting frozen while the LLM

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -1819,6 +1819,12 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       return
     }
 
+    // Capture HEAD before the apply so we can compute exactly which
+    // commits the operation created (rev-list headBefore..HEAD after
+    // success). Best-effort — if revparse fails we skip the
+    // newest-commits marker, no degradation of the apply itself.
+    const headBefore = await git.revparse(['HEAD']).then((sha) => sha.trim()).catch(() => undefined)
+
     dispatch({ type: 'setSplitPlanApplying' })
     dispatch({ type: 'setStatus', value: 'Applying split plan…', loading: true })
 
@@ -1869,6 +1875,26 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     const unstaged = fresh?.unstagedCount || 0
     const untracked = fresh?.untrackedCount || 0
     const remaining = unstaged + untracked
+
+    // Compute the freshly-created commit hashes and mark them so the
+    // history surface renders them with a "new" indicator. Auto-
+    // clears after 5s so the marker doesn't linger across later
+    // operations. Best-effort — a rev-list failure (e.g. headBefore
+    // capture failed earlier) just skips the marker, no impact on
+    // the apply itself.
+    if (headBefore) {
+      try {
+        const range = `${headBefore}..HEAD`
+        const raw = await git.raw(['rev-list', range])
+        const hashes = raw.split('\n').map((line) => line.trim()).filter(Boolean)
+        if (hashes.length > 0) {
+          dispatch({ type: 'markRecentCommits', hashes })
+          // DevSkim: ignore DS172411 — function literal, fixed delay,
+          // no caller-supplied data flowing through.
+          setTimeout(() => dispatch({ type: 'clearRecentCommits' }), 5000)
+        }
+      } catch { /* ignore — marker is a nice-to-have, not load-bearing */ }
+    }
 
     const baseMessage = result.message || 'Applied split plan.'
     const successMessage = remaining > 0

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -111,7 +111,8 @@ function renderCommitHistoryRow(
   theme: LogInkTheme,
   index: number,
   panelWidth: number,
-  laneSegments?: LaneSegment[]
+  laneSegments?: LaneSegment[],
+  isRecent: boolean = false
 ): ReactTypes.ReactElement {
   const refs = formatInkRefLabels(commit.refs)
   // Total cells available to the row content. Earlier revisions used a
@@ -149,7 +150,24 @@ function renderCommitHistoryRow(
   },
   ...graphChildren,
   ' ',
-  h(Text, { color: accent, bold: selected }, commit.shortHash),
+  // "Just landed" marker — a single thick vertical bar in the
+  // accent color before the short hash. Fades when the runtime
+  // clears state.recentCommitHashes (~5s after the operation).
+  // ASCII fallback uses `*` since terminals without unicode can't
+  // render `▎`.
+  isRecent
+    ? h(Text, {
+        color: theme.noColor ? undefined : theme.colors.accent,
+        bold: true,
+      }, theme.ascii ? '* ' : '▎ ')
+    : null,
+  h(Text, {
+    color: accent,
+    // Bold both selected AND just-landed commits — the marker is
+    // the primary cue but boldness makes the row read as "this is
+    // worth looking at" even without color.
+    bold: selected || isRecent,
+  }, commit.shortHash),
   ' ',
   h(Text, { dimColor: true }, commit.date),
   ' ',
@@ -206,6 +224,10 @@ export function renderHistoryPanel(
   const { Box, Text } = components
   const focused = state.focus === 'commits'
   const worktree = context.worktree
+  // Set of just-landed commit hashes for the "new commit" marker.
+  // Populated for ~5s after a split-apply or other commit-creating
+  // operation; auto-cleared by the runtime so it doesn't linger.
+  const recentCommitsSet = new Set(state.recentCommitHashes?.hashes || [])
   const worktreeDirty = Boolean(
     worktree && (worktree.stagedCount + worktree.unstagedCount + worktree.untrackedCount) > 0
   )
@@ -289,7 +311,8 @@ export function renderHistoryPanel(
       return renderCommitHistoryRow(
         h, Text, item.commit, item.graph, visible.graphWidth,
         Boolean(item.selected) && !realSelectionSuppressed, theme, index,
-        width, item.laneSegments
+        width, item.laneSegments,
+        recentCommitsSet.has(item.commit.hash)
       )
     }))
 }


### PR DESCRIPTION
PR C of the polish sequence. Closes out the trio.

## What this changes

After a split-apply, the user landed on history with no visual cue about which commits the operation just created. Mixed into a tall log, the new rows blended into older context. Now they're marked with a `▎` accent-colored bar + bold short-hash for ~5 seconds, then auto-clear.

## Mechanics

**State** (`inkViewModel.ts`):
- `state.recentCommitHashes?: { hashes: string[]; markedAt: number }` — present means highlight these
- Actions: `markRecentCommits({ hashes })`, `clearRecentCommits` — empty `hashes` array also closes the marker

**Runtime** (`app.ts` — `applyCommitSplit`):
- Captures `HEAD` BEFORE the apply via `git revparse`
- After success, computes `rev-list <before>..HEAD` for the exact set of new hashes
- Dispatches `markRecentCommits`
- Schedules `setTimeout(5_000)` to dispatch `clearRecentCommits`
- All best-effort — a revparse / rev-list failure just skips the marker, no impact on the apply itself

**Render** (`surfaces/history/index.ts`):
- Builds `recentCommitsSet` from state once per render
- Passes `isRecent` flag to `renderCommitHistoryRow`
- Recent rows get a leading `▎ ` accent-colored bar (ASCII fallback `* `) AND a bold short-hash
- Selection styling still wins on the row level — bold + marker combine cleanly without competing

## Visual example

```
| 7fae19c 2026-05-13 docs: document widget-v2 API and migration path
| 65b3cd9 2026-05-13 test: cover widget-v2 happy path and edge cases
▎ a23170e 2026-05-13 feat: expose widget-v2 from public index    ← just landed
▎ 63d3202 2026-05-13 feat: add widget-v2 entry point and types   ← just landed
| 9ef2109 2026-05-13 test: add baseline widget tests
| 20d012c 2026-05-13 feat: scaffold widget module
```

## Test plan

- [x] `npm run lint` clean
- [x] `tsc --noEmit` clean
- [x] `npm run test:jest` — 1639 tests pass (+4 from this PR)
- [ ] Manual: `npm run scenario create dirty-many-files -- --run-ui` → `S` → review → `y` apply → land back on history → freshly created commits at the top are marked
- [ ] Manual: wait ~5 seconds → markers fade
- [ ] Manual: run another split immediately → markers update to the new set (no bleed-through from previous)

## Out of scope (sensible follow-ups)

- Mark commits created by the regular `c` (single-commit) path — `createCommitFromCompose` doesn't yet have the same before/after HEAD capture pattern. Worth a follow-up but the split case is where the multi-commit visual confusion is sharpest.
- Configurable timeout — 5s is hardcoded; lift to `logTui` config later if users want longer/shorter.