### PR TITLE
feat(log-tui): dedicated submodules view (#932)

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -639,6 +639,23 @@ describe('log Ink input interactions', () => {
     expect(state.selectedReflogIndex).toBe(0)
   })
 
+  it('moves the selected submodule with arrow keys when in submodules view (#932)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'submodules' })
+
+    state = applyInput(state, 'j', {}, { submoduleCount: 3 })
+    state = applyInput(state, 'j', {}, { submoduleCount: 3 })
+    expect(state.selectedSubmoduleIndex).toBe(2)
+
+    state = applyInput(state, 'k', {}, { submoduleCount: 3 })
+    expect(state.selectedSubmoduleIndex).toBe(1)
+
+    // Clamped at zero going up past the boundary.
+    state = applyInput(state, 'k', {}, { submoduleCount: 3 })
+    state = applyInput(state, 'k', {}, { submoduleCount: 3 })
+    expect(state.selectedSubmoduleIndex).toBe(0)
+  })
+
   it('Enter on a reflog row drills into the diff for that hash (#781)', () => {
     let state = createLogInkState(rows)
     state = applyLogInkAction(state, { type: 'pushView', value: 'reflog' })
@@ -826,6 +843,50 @@ describe('log Ink input interactions', () => {
     expect(state.viewStack).toEqual(['history', 'bisect'])
     expect(state.activeView).toBe('bisect')
     expect(state.statusMessage).toBe('jumped to bisect')
+  })
+
+  it('pushes submodules with the gM chord (#932)', () => {
+    let state = createLogInkState(rows)
+
+    state = applyInput(state, 'g')
+    state = applyInput(state, 'M')
+
+    expect(state.viewStack).toEqual(['history', 'submodules'])
+    expect(state.activeView).toBe('submodules')
+    expect(state.statusMessage).toBe('jumped to submodules')
+  })
+
+  it('j/k on the submodules view dispatches moveSubmodule (#932)', () => {
+    let state = createLogInkState(rows, { activeView: 'submodules' })
+    state = applyLogInkAction(state, { type: 'setBootLoading', value: false })
+
+    const downEvents = getLogInkInputEvents(state, 'j', {}, { submoduleCount: 3 })
+    expect(downEvents).toContainEqual({
+      type: 'action',
+      action: { type: 'moveSubmodule', delta: 1, count: 3 },
+    })
+
+    const upEvents = getLogInkInputEvents(state, 'k', {}, { submoduleCount: 3 })
+    expect(upEvents).toContainEqual({
+      type: 'action',
+      action: { type: 'moveSubmodule', delta: -1, count: 3 },
+    })
+
+    // Zero submodules → no move action (falls through to the default).
+    const emptyEvents = getLogInkInputEvents(state, 'j', {}, { submoduleCount: 0 })
+    expect(emptyEvents.find((e) =>
+      e.type === 'action' && (e.action as { type: string }).type === 'moveSubmodule'
+    )).toBeUndefined()
+  })
+
+  it('y / Y on the submodules view yank path / sha (#932)', () => {
+    const state = createLogInkState(rows, { activeView: 'submodules' })
+
+    const yEvents = getLogInkInputEvents(state, 'y', {}, { submoduleCount: 2 })
+    expect(yEvents).toContainEqual({ type: 'yankFromActiveView', short: false })
+
+    const yShiftEvents = getLogInkInputEvents(state, 'Y', {}, { submoduleCount: 2 })
+    expect(yShiftEvents).toContainEqual({ type: 'yankFromActiveView', short: true })
   })
 
   it('lower-case g on the bisect view marks good (no chord trigger) (#784)', () => {

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -92,6 +92,10 @@ export type LogInkInputContext = {
   reflogCount?: number
   /** Hash of the cursored reflog entry (#781). Used by Enter to drill into the diff. */
   reflogSelectedHash?: string
+  /** Number of registered submodules (#932). Drives j/k navigation on the submodules view. */
+  submoduleCount?: number
+  /** Repo-relative path of the cursored submodule (#932). Reserved for future per-entry actions. */
+  submoduleSelectedPath?: string
   worktreeListCount?: number
   /** Ref of the stash currently under the cursor (e.g. `stash@{0}`). */
   stashSelectedRef?: string
@@ -360,6 +364,14 @@ function isReflogActionTarget(state: LogInkState): boolean {
   return state.activeView === 'reflog' && state.focus === 'commits'
 }
 
+/**
+ * Submodules has no sidebar tab either — only the dedicated promoted
+ * view (#932). Same shape as `isReflogActionTarget`.
+ */
+function isSubmodulesActionTarget(state: LogInkState): boolean {
+  return state.activeView === 'submodules' && state.focus === 'commits'
+}
+
 function isWorktreeActionTarget(state: LogInkState): boolean {
   return (state.activeView === 'worktrees' && state.focus === 'commits') ||
     (state.focus === 'sidebar' && state.sidebarTab === 'worktrees')
@@ -528,6 +540,8 @@ export function getLogInkPaletteExecuteEvents(
       return [action({ type: 'pushView', value: 'reflog' })]
     case 'navigateBisect':
       return [action({ type: 'pushView', value: 'bisect' })]
+    case 'navigateSubmodules':
+      return [action({ type: 'pushView', value: 'submodules' })]
     case 'markForCompare':
       // Palette context can't reach the cursored ref (filtered branch /
       // tag lists live in runtime state, not the reducer). Surface a
@@ -1211,6 +1225,18 @@ export function getLogInkInputEvents(
     ]
   }
 
+  // `gM` chord: jump to the dedicated submodules view (#932). Capital
+  // M disambiguates from `gm` (not currently a chord, but the
+  // single-letter `m` already means "mark compare base"). Always
+  // navigates — even when no submodules are registered — so the
+  // empty-state copy can tell the user how to add one.
+  if (state.pendingKey === 'g' && inputValue === 'M') {
+    return [
+      action({ type: 'pushView', value: 'submodules' }),
+      action({ type: 'setStatus', value: 'jumped to submodules' }),
+    ]
+  }
+
   // `gH` chord: apply the cursored hunk to the index (`git apply
   // --cached`). Sibling of bare `H` which targets the worktree.
   // Discoverable via the footer hint on diff views and the help
@@ -1652,6 +1678,10 @@ export function getLogInkInputEvents(
       return [action({ type: 'moveReflog', delta: -1, count: context.reflogCount })]
     }
 
+    if (isSubmodulesActionTarget(state) && context.submoduleCount) {
+      return [action({ type: 'moveSubmodule', delta: -1, count: context.submoduleCount })]
+    }
+
     if (isWorktreeActionTarget(state) && context.worktreeListCount) {
       return [action({ type: 'moveWorktreeListEntry', delta: -1, count: context.worktreeListCount })]
     }
@@ -1751,6 +1781,10 @@ export function getLogInkInputEvents(
 
     if (isReflogActionTarget(state) && context.reflogCount) {
       return [action({ type: 'moveReflog', delta: 1, count: context.reflogCount })]
+    }
+
+    if (isSubmodulesActionTarget(state) && context.submoduleCount) {
+      return [action({ type: 'moveSubmodule', delta: 1, count: context.submoduleCount })]
     }
 
     if (isWorktreeActionTarget(state) && context.worktreeListCount) {
@@ -2492,6 +2526,13 @@ export function getLogInkInputEvents(
     // here to copy; surfacing it via the same y/Y idiom (Y = short)
     // is faster than dropping to shell.
     if (state.activeView === 'bisect' && context.bisectCompletionSha) {
+      return [{ type: 'yankFromActiveView', short }]
+    }
+    // #932 — submodules view: y yanks the cursored submodule's path
+    // (most useful for `git submodule update <path>` etc.); Y yanks
+    // the pinned commit sha (in either full or short form, like the
+    // history view's Y).
+    if (isSubmodulesActionTarget(state) && context.submoduleCount) {
       return [{ type: 'yankFromActiveView', short }]
     }
   }

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -30,6 +30,7 @@ export type LogInkCommandId =
   | 'navigatePullRequest'
   | 'navigateReflog'
   | 'navigateStash'
+  | 'navigateSubmodules'
   | 'navigateWorktrees'
   | 'navigateStatus'
   | 'navigateTags'
@@ -281,6 +282,13 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     keys: ['gB'],
     label: 'bisect',
     description: 'Push the bisect workflow view (#784). Capital B disambiguates from gb (branches). Available whenever a bisect is in progress; surfaces the current candidate and the good / bad / skip / reset action keys.',
+    contexts: ['normal'],
+  },
+  {
+    id: 'navigateSubmodules',
+    keys: ['gM'],
+    label: 'submodules',
+    description: 'Push the submodules view (#932). Lists every registered submodule with status / pinned commit / tracking branch / remote. Capital M disambiguates from the single-letter `m` (mark compare base).',
     contexts: ['normal'],
   },
   {
@@ -754,6 +762,13 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
   if (options.activeView === 'reflog') {
     return {
       contextual: ['↑/↓ entries', 'enter inspect', 'esc back'],
+      global: NORMAL_GLOBAL_HINTS,
+    }
+  }
+
+  if (options.activeView === 'submodules') {
+    return {
+      contextual: ['↑/↓ entries', 'y yank path', 'Y yank sha', '/ filter', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -19,7 +19,7 @@ import {
 export type LogInkFocus = 'sidebar' | 'commits' | 'detail'
 
 export type LogInkSidebarTab = 'status' | 'branches' | 'tags' | 'stashes' | 'worktrees'
-export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash' | 'worktrees' | 'pull-request' | 'conflicts' | 'reflog' | 'bisect' | 'changelog'
+export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash' | 'worktrees' | 'pull-request' | 'conflicts' | 'reflog' | 'bisect' | 'changelog' | 'submodules'
 export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk' | 'discard-draft'
 /**
  * Tracks which kind of diff the user pushed into. `commit` means they
@@ -106,6 +106,13 @@ export type LogInkState = {
    * and back should keep the user's place in the list.
    */
   selectedReflogIndex: number
+  /**
+   * Cursor for the dedicated submodules view (#932). Same lifecycle as
+   * the other promoted-view indices — preserved across navigations so
+   * the user can drill out and back into a submodule without losing
+   * their place.
+   */
+  selectedSubmoduleIndex: number
   /**
    * Sort modes for the promoted views (P4.2). `s` cycles through the
    * available modes; the surface header shows a `▼ <mode>` indicator.
@@ -493,6 +500,7 @@ export type LogInkAction =
   | { type: 'moveTag'; delta: number; count: number }
   | { type: 'moveStash'; delta: number; count: number }
   | { type: 'moveReflog'; delta: number; count: number }
+  | { type: 'moveSubmodule'; delta: number; count: number }
   | { type: 'moveWorktreeListEntry'; delta: number; count: number }
   | { type: 'moveConflictFile'; delta: number; count: number }
   | { type: 'moveToBottom' }
@@ -906,6 +914,7 @@ export function createLogInkState(
     selectedWorktreeListIndex: 0,
     selectedConflictFileIndex: 0,
     selectedReflogIndex: 0,
+    selectedSubmoduleIndex: 0,
     branchSort: DEFAULT_BRANCH_SORT_MODE,
     tagSort: DEFAULT_TAG_SORT_MODE,
     paletteFilter: '',
@@ -1169,6 +1178,12 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         selectedReflogIndex: clampIndex(state.selectedReflogIndex + action.delta, action.count),
+        pendingKey: undefined,
+      }
+    case 'moveSubmodule':
+      return {
+        ...state,
+        selectedSubmoduleIndex: clampIndex(state.selectedSubmoduleIndex + action.delta, action.count),
         pendingKey: undefined,
       }
     case 'moveWorktreeListEntry':

--- a/src/workstation/chrome/surfaceStates.ts
+++ b/src/workstation/chrome/surfaceStates.ts
@@ -102,3 +102,14 @@ export function formatLogInkComposeEmpty({ hasStaged }: LogInkComposeEmptyArgs):
   }
   return 'No staged changes to commit. Press gs to stage files, then gc to come back here.'
 }
+
+export type LogInkSubmodulesEmptyArgs = {
+  filter: string
+}
+
+export function formatLogInkSubmodulesEmpty({ filter }: LogInkSubmodulesEmptyArgs): string {
+  if (filter.trim()) {
+    return `No submodules match filter '${filter}'. Press ctrl+u to clear.`
+  }
+  return 'No submodules registered. Add one with `git submodule add <url> <path>` from the shell.'
+}

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -639,6 +639,16 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       )
     )
   }, [context.reflog?.entries, state.filter])
+  const filteredSubmoduleList = React.useMemo(() => {
+    const all = context.submodules?.entries || []
+    if (!state.filter) return all
+    return all.filter((entry) =>
+      matchesPromotedFilter(
+        [entry.name, entry.path, entry.trackingBranch || '', entry.url || ''],
+        state.filter,
+      )
+    )
+  }, [context.submodules?.entries, state.filter])
 
   const dispatch = React.useCallback((action: Parameters<typeof applyLogInkAction>[1]) => {
     setState((current) => applyLogInkAction(current, action))
@@ -2491,6 +2501,31 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         value = path
         label = `path ${path}`
       }
+    } else if (view === 'submodules') {
+      // #932 — yank from the dedicated submodules view. `y` (default)
+      // copies the cursored submodule's path; `Y` (short) copies the
+      // pinned commit's short sha. Either is what the user most
+      // likely wants — path for `git submodule update <path>`, sha
+      // for cross-referencing in logs or other repos.
+      const entries = context.submodules?.entries || []
+      const filtered = state.filter
+        ? entries.filter((entry) => matchesPromotedFilter(
+          [entry.name, entry.path, entry.trackingBranch || '', entry.url || ''],
+          state.filter,
+        ))
+        : entries
+      const entry = filtered[Math.min(state.selectedSubmoduleIndex, Math.max(0, filtered.length - 1))]
+      if (entry) {
+        if (short) {
+          if (entry.pinnedSha) {
+            value = entry.pinnedSha.slice(0, 8)
+            label = `short sha ${value} (submodule ${entry.name})`
+          }
+        } else {
+          value = entry.path
+          label = `submodule path ${entry.path}`
+        }
+      }
     } else if (view === 'bisect') {
       // #879 item 3 — yank the first-bad commit sha from the
       // completion panel. The headline answer is what the user
@@ -2554,6 +2589,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     context.bisect,
     context.branches,
     context.stashes,
+    context.submodules,
     context.tags,
     dispatch,
     selected,
@@ -2569,6 +2605,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     state.selectedBranchIndex,
     state.selectedIndex,
     state.selectedStashIndex,
+    state.selectedSubmoduleIndex,
     state.selectedTagIndex,
     state.selectedWorktreeFileIndex,
     state.tagSort,
@@ -2828,6 +2865,10 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     const reflogSelectedHash = filteredReflogList[
       Math.min(state.selectedReflogIndex, Math.max(0, filteredReflogList.length - 1))
     ]?.hash
+    const submoduleVisibleCount = filteredSubmoduleList.length
+    const submoduleSelectedPath = filteredSubmoduleList[
+      Math.min(state.selectedSubmoduleIndex, Math.max(0, filteredSubmoduleList.length - 1))
+    ]?.path
     const worktreeVisibleCount = filteredWorktreeList.length
 
     // When the diff view is showing a stash patch, swap the previewLineCount
@@ -2861,6 +2902,8 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       stashCount: stashVisibleCount,
       reflogCount: reflogVisibleCount,
       reflogSelectedHash,
+      submoduleCount: submoduleVisibleCount,
+      submoduleSelectedPath,
       stashSelectedRef,
       stashDiffFileOffsets: stashDiffFileOffsets.length ? stashDiffFileOffsets : undefined,
       stashDiffSelectedPath,

--- a/src/workstation/runtime/detailPanel.ts
+++ b/src/workstation/runtime/detailPanel.ts
@@ -28,6 +28,7 @@ import {
   renderComposeContextPanel,
   renderHistoryInspector,
   renderStashPreviewPanel,
+  renderSubmodulePreviewPanel,
   renderTagPreviewPanel,
 } from '../surfaces/detail'
 import {
@@ -125,6 +126,10 @@ export function renderDetailPanel(
   }
   if (state.activeView === 'stash') {
     return renderStashPreviewPanel(h, components, state, context, contextStatus, width, theme, focused)
+  }
+
+  if (state.activeView === 'submodules') {
+    return renderSubmodulePreviewPanel(h, components, state, context, contextStatus, width, theme, focused)
   }
 
   return renderHistoryInspector(

--- a/src/workstation/runtime/mainPanel.ts
+++ b/src/workstation/runtime/mainPanel.ts
@@ -30,6 +30,7 @@ import { renderPullRequestSurface } from '../surfaces/pullRequest'
 import { renderReflogSurface } from '../surfaces/reflog'
 import { renderStashSurface } from '../surfaces/stash'
 import { renderStatusSurface } from '../surfaces/status'
+import { renderSubmodulesSurface } from '../surfaces/submodules'
 import { renderTagsSurface } from '../surfaces/tags'
 import { renderWorktreesSurface } from '../surfaces/worktrees'
 import type { LogInkComponents, LogInkContext } from './types'
@@ -127,6 +128,10 @@ export function renderMainPanel(
 
   if (state.activeView === 'worktrees') {
     return renderWorktreesSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
+  }
+
+  if (state.activeView === 'submodules') {
+    return renderSubmodulesSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
   }
 
   if (state.activeView === 'pull-request') {

--- a/src/workstation/surfaces/detail/index.ts
+++ b/src/workstation/surfaces/detail/index.ts
@@ -260,7 +260,7 @@ function renderSubmoduleInspectorBlock(
   return renderSubmoduleEntryLines(h, Text, width, entry)
 }
 
-function renderSubmoduleEntryLines(
+export function renderSubmoduleEntryLines(
   h: typeof ReactTypes.createElement,
   Text: LogInkComponents['Text'],
   width: number,
@@ -690,6 +690,57 @@ export function renderStashPreviewPanel(
   const stash = visible[index]
   return renderPreviewPanel(h, { Box, Text }, 'Stash preview',
     formatStashPreview(stash), width, theme, focused)
+}
+
+export function renderSubmodulePreviewPanel(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  width: number,
+  theme: LogInkTheme,
+  focused: boolean,
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  if (isLogInkContextKeyLoading(contextStatus, 'submodules')) {
+    return renderPreviewPanel(h, { Box, Text }, 'Submodule preview',
+      [{ text: formatLogInkLoading({ resource: 'submodules' }), emphasis: 'dim' }],
+      width, theme, focused)
+  }
+  const all = context.submodules?.entries || []
+  const visible = state.filter
+    ? all.filter((entry) => matchesPromotedFilter(
+      [entry.name, entry.path, entry.trackingBranch || '', entry.url || ''],
+      state.filter,
+    ))
+    : all
+  const index = Math.max(0, Math.min(state.selectedSubmoduleIndex, Math.max(0, visible.length - 1)))
+  const entry = visible[index]
+  if (!entry) {
+    return renderPreviewPanel(h, { Box, Text }, 'Submodule preview',
+      [{ text: 'No submodule under cursor.', emphasis: 'dim' }],
+      width, theme, focused)
+  }
+  const flagLabel = entry.flag === 'clean' ? 'clean'
+    : entry.flag === 'modified' ? 'modified'
+      : entry.flag === 'uninitialized' ? 'uninitialized'
+        : 'conflicted'
+  const sha = entry.pinnedSha ? entry.pinnedSha.slice(0, 8) : '<unknown>'
+  const lines: PreviewLine[] = [
+    { text: entry.name, emphasis: 'heading' },
+    { text: `path:      ${entry.path}` },
+    { text: `pinned:    ${sha}` },
+    { text: `status:    ${flagLabel}` },
+    ...(entry.trackingBranch
+      ? [{ text: `tracking:  ${entry.trackingBranch}` }]
+      : []),
+    ...(entry.url
+      ? [{ text: `remote:    ${entry.url}`, emphasis: 'dim' as const }]
+      : []),
+  ]
+  return renderPreviewPanel(h, { Box, Text }, 'Submodule preview',
+    lines, width, theme, focused)
 }
 
 export function renderCommitPanel(

--- a/src/workstation/surfaces/submodules/index.ts
+++ b/src/workstation/surfaces/submodules/index.ts
@@ -1,0 +1,126 @@
+/**
+ * Submodules surface — promoted view listing every registered
+ * submodule in the repo with status / pinned commit / tracking
+ * branch / remote at a glance (#932). Mirrors the
+ * branches / tags / stash surfaces.
+ *
+ * The richer per-submodule metadata block (the same one the inspector
+ * side-panel renders when the cursored file is a submodule) is
+ * rendered by `detail/index.ts`; this surface owns the list view +
+ * cursor + filter only.
+ */
+
+import type * as ReactTypes from 'react'
+import type { LogInkContextStatus } from '../../chrome/context'
+import { isLogInkContextKeyLoading } from '../../chrome/context'
+import {
+  formatLogInkLoading,
+  formatLogInkSubmodulesEmpty,
+} from '../../chrome/surfaceStates'
+import { cellWidth, truncateCells } from '../../chrome/text'
+import type { LogInkTheme } from '../../chrome/theme'
+import type { LogInkState } from '../../../commands/log/inkViewModel'
+import type { SubmoduleEntry } from '../../../git/submoduleData'
+import {
+  matchesPromotedFilter,
+  renderPromotedFilterAffordance,
+} from '../../runtime/promotedFilter'
+import type { LogInkComponents, LogInkContext } from '../../runtime/types'
+import { focusBorderColor, panelTitle } from '../../runtime/utils'
+
+const FLAG_LABEL: Record<SubmoduleEntry['flag'], string> = {
+  clean: 'clean',
+  modified: 'modified',
+  uninitialized: 'uninit',
+  conflicted: 'conflict',
+}
+
+function flagColor(flag: SubmoduleEntry['flag'], theme: LogInkTheme): string | undefined {
+  if (theme.noColor) return undefined
+  if (flag === 'modified') return theme.colors.warning
+  if (flag === 'uninitialized') return theme.colors.muted
+  if (flag === 'conflicted') return theme.colors.danger
+  return undefined
+}
+
+export function renderSubmodulesSurface(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  bodyRows: number,
+  width: number,
+  theme: LogInkTheme,
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const focused = state.focus === 'commits'
+  const loading = isLogInkContextKeyLoading(contextStatus, 'submodules')
+  const all = context.submodules?.entries || []
+  const filtered = state.filter
+    ? all.filter((entry) =>
+      matchesPromotedFilter([entry.name, entry.path, entry.trackingBranch || '', entry.url || ''], state.filter)
+    )
+    : all
+  const selected = Math.max(0, Math.min(state.selectedSubmoduleIndex, Math.max(0, filtered.length - 1)))
+  const listRows = Math.max(4, bodyRows - 4)
+  const startIndex = Math.max(0, selected - Math.floor(listRows / 2))
+  const visible = filtered.slice(startIndex, startIndex + listRows)
+  const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
+  const headerRight = loading
+    ? 'loading submodules'
+    : `${filtered.length}/${all.length} submodules${filterLabel}`
+  const emptyLabel = formatLogInkSubmodulesEmpty({ filter: state.filter })
+  const loadingLabel = formatLogInkLoading({ resource: 'submodules' })
+
+  // Per-window column widths so short names don't leave a wide gutter
+  // and long names don't push the trailing columns off-screen. Cap
+  // matches the branches/tags surfaces for visual consistency.
+  const nameColWidth = visible.length === 0
+    ? 20
+    : Math.min(28, Math.max(8, ...visible.map((entry) => cellWidth(entry.name))))
+  const pathColWidth = visible.length === 0
+    ? 24
+    : Math.min(36, Math.max(8, ...visible.map((entry) => cellWidth(entry.path))))
+
+  const lines: ReactTypes.ReactNode[] = loading
+    ? [h(Text, { key: 'submodules-loading', dimColor: true }, loadingLabel)]
+    : filtered.length === 0
+      ? [h(Text, { key: 'submodules-empty', dimColor: true }, emptyLabel)]
+      : visible.map((entry, offset) => {
+        const index = startIndex + offset
+        const isSelected = index === selected
+        const cursor = isSelected ? '>' : ' '
+        const sha = entry.pinnedSha ? entry.pinnedSha.slice(0, 8) : '--------'
+        const namePadded = truncateCells(entry.name, nameColWidth).padEnd(nameColWidth)
+        const pathPadded = truncateCells(entry.path, pathColWidth).padEnd(pathColWidth)
+        const flagText = FLAG_LABEL[entry.flag]
+        const branch = entry.trackingBranch ? ` · ${entry.trackingBranch}` : ''
+        const lineText = truncateCells(
+          `${cursor} ${namePadded} ${pathPadded} ${sha} ${flagText}${branch}`,
+          Math.max(20, width - 4),
+        )
+        const color = flagColor(entry.flag, theme)
+        return h(Text, {
+          key: `submodule-${index}`,
+          bold: isSelected,
+          dimColor: !isSelected && entry.flag === 'clean',
+          color,
+        }, lineText)
+      })
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    flexShrink: 0,
+    paddingX: 1,
+    width,
+  },
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle('Submodules', focused)),
+    h(Text, { dimColor: true }, headerRight),
+  ),
+  ...renderPromotedFilterAffordance(h, Text, state, theme),
+  ...lines)
+}


### PR DESCRIPTION
## Summary

New top-level surface listing every registered submodule with status / pinned commit / tracking branch / remote. Mirrors \`g b\` / \`g t\` / \`g z\` / \`g w\`. Reuses the data layer from #930 so the inspector side-panel + this view share the same overview.

- \`gM\` chord pushes the view (capital M disambiguates from \`m\` = mark compare base).
- j / k navigate; \`y\` yanks path, \`Y\` yanks pinned sha; \`/\` filters across name + path + tracking branch + url.
- Status-colored rows: \`modified\` → warning, \`conflicted\` → danger, \`uninitialized\` → dim, \`clean\` → plain.
- Empty state directs the user to \`git submodule add\` from the shell.
- Detail panel uses the structured preview pattern (parity with tag / stash previews).

## Test plan

- [x] \`npx tsc --noEmit\` → 0 errors
- [x] \`npx jest\` → 1606/1606 pass (4 new + 1 added)
- [x] \`npx eslint\` on touched files → clean
- [ ] Manual: in a repo with a submodule, run \`coco ui\`, press \`gM\`, confirm the list renders with the right metadata; \`y\` yanks path, \`Y\` yanks short sha.

Closes #932.