### PR TITLE
fix(split): drop empty groups before apply + nav cue in success message

### DIFF
--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -297,9 +297,24 @@ export async function applyCommitSplitPlan({
   validatePlanForStagedFiles(plan, changes.staged, hunkInventory)
   assertNoUnstagedOverlap(plan, changes, hunkInventory)
 
+  // Defensive: drop any group with empty files[] AND empty hunks[].
+  // `dropEmptyGroups` runs in the generator's rescue chain but we
+  // re-filter here so a direct caller (or a future rescue that
+  // forgets to compose with dropEmptyGroups) can't hit the
+  // "git commit with nothing staged" failure mode mid-loop after
+  // the up-front `git reset` has already wiped the index.
+  const applicableGroups = plan.groups.filter((group) => {
+    const fileCount = (group.files || []).length
+    const hunkCount = (group.hunks || []).length
+    return fileCount + hunkCount > 0
+  })
+  if (applicableGroups.length === 0) {
+    throw new Error('Split plan has no applicable groups (every group was empty).')
+  }
+
   await git.raw(['reset'])
 
-  for (const group of plan.groups) {
+  for (const group of applicableGroups) {
     const groupFiles = getGroupFiles(group)
     const groupHunks = getGroupHunks(group).map((hunkId) => hunkInventory.byId.get(hunkId))
 
@@ -312,11 +327,14 @@ export async function applyCommitSplitPlan({
       await applyPatchToIndex(patch, git)
     }
 
-    await createCommit(`${group.title}\n\n${group.body}`.trim(), git, undefined, { noVerify })
+    // Avoid the literal string "undefined" in the commit body when
+    // the LLM omitted the body field — fall back to title-only.
+    const body = group.body ? `\n\n${group.body}` : ''
+    await createCommit(`${group.title}${body}`.trim(), git, undefined, { noVerify })
     logger.verbose(`Created split commit: ${group.title}`, { color: 'green' })
   }
 
-  return `Created ${plan.groups.length} split commit(s).`
+  return `Created ${applicableGroups.length} split commit(s).`
 }
 
 /**

--- a/src/commands/commit/splitPlanGenerator.ts
+++ b/src/commands/commit/splitPlanGenerator.ts
@@ -6,6 +6,7 @@ import { TokenCounter } from '../../lib/utils/tokenizer'
 import { FileChange } from '../../lib/types'
 import { CommitSplitPlan, CommitSplitPlanSchema } from './splitPlanTypes'
 import {
+  dropEmptyGroups,
   formatPlanValidationFeedback,
   formatPlanValidationIssuesError,
   getPlanValidationIssues,
@@ -87,28 +88,36 @@ export async function generateValidatedCommitSplitPlan({
       }
     )
 
-    // Rescue passes (#918, #919, #921). Run in order — order matters:
+    // Rescue passes. Run in order — order matters:
     //
-    //   1. rescuePhantomHunks: LLM commonly emits "file::hunk-1"
+    //   1. rescuePhantomHunks (#918): LLM commonly emits "file::hunk-1"
     //      against an empty inventory (all staged files are new).
     //      Promote those to file-level assignments.
     //
-    //   2. rescueMixedFiles: LLM commonly puts a file in `files[]`
-    //      of group A AND uses its hunks in `hunks[]` of group B.
-    //      Drop the hunks (the file-level claim is more specific).
-    //      Must run AFTER phantom-hunk rescue because the rescue
-    //      itself can create mixed-files situations.
+    //   2. rescueMixedFiles (#919): LLM commonly puts a file in
+    //      `files[]` of group A AND uses its hunks in `hunks[]` of
+    //      group B. Drop the hunks (the file-level claim is more
+    //      specific). Must run AFTER phantom-hunk rescue because the
+    //      rescue itself can create mixed-files situations.
     //
-    //   3. rescueMissingFiles: LLM occasionally forgets a staged
-    //      file across every group. Append a synthetic "misc" group
-    //      so the plan covers every staged file. Must run LAST so
-    //      it has the final claim picture from earlier rescues.
+    //   3. rescueMissingFiles (#921): LLM occasionally forgets a
+    //      staged file across every group. Append a synthetic "misc"
+    //      group so the plan covers every staged file.
     //
-    // All three rescues are no-ops when there's nothing to rescue,
-    // so running them unconditionally costs nothing on healthy plans.
+    //   4. dropEmptyGroups: rescueMixedFiles can leave a group with
+    //      empty files[] AND empty hunks[] when it had only hunks
+    //      that got dropped. Apply-time, an empty group means
+    //      `git commit` with nothing staged, which throws and
+    //      aborts mid-loop after the up-front `git reset` has
+    //      already wiped the index. Filter the empty groups out
+    //      LAST so the apply path can't hit them.
+    //
+    // All rescues are no-ops when there's nothing to rescue, so
+    // running them unconditionally costs nothing on healthy plans.
     const phantomRescued = rescuePhantomHunks(rawPlan, staged, hunkInventory)
     const mixedRescued = rescueMixedFiles(phantomRescued, hunkInventory)
-    const plan = rescueMissingFiles(mixedRescued, staged, hunkInventory)
+    const missingRescued = rescueMissingFiles(mixedRescued, staged, hunkInventory)
+    const plan = dropEmptyGroups(missingRescued)
 
     const issues = getPlanValidationIssues(plan, staged, hunkInventory)
     if (!hasPlanValidationIssues(issues)) {

--- a/src/commands/commit/splitPlanValidation.test.ts
+++ b/src/commands/commit/splitPlanValidation.test.ts
@@ -1,5 +1,6 @@
 import { FileChange } from '../../lib/types'
 import {
+  dropEmptyGroups,
   formatPlanValidationFeedback,
   formatPlanValidationIssuesError,
   getPlanValidationIssues,
@@ -529,6 +530,53 @@ describe('splitPlanValidation', () => {
 
       expect(rescued.groups).toHaveLength(2)
       expect(rescued.groups[1].files).toEqual(['b.ts', 'c.ts', 'd.ts'])
+    })
+  })
+
+  describe('dropEmptyGroups', () => {
+    it('removes groups with empty files[] AND empty hunks[]', () => {
+      // Reproduces the failure pattern that broke apply: a group
+      // left empty after rescueMixedFiles dropped its only hunks.
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'feat: a', files: ['a.ts'], hunks: [] },
+          { title: 'feat: leftover', files: [], hunks: [] },
+          { title: 'feat: b', files: ['b.ts'], hunks: [] },
+        ],
+      }
+
+      const cleaned = dropEmptyGroups(plan)
+
+      expect(cleaned.groups).toHaveLength(2)
+      expect(cleaned.groups.map((g) => g.title)).toEqual(['feat: a', 'feat: b'])
+    })
+
+    it('keeps groups that have files but no hunks', () => {
+      // File-only groups are the normal new-files case — must not
+      // be confused with "empty".
+      const plan: CommitSplitPlan = {
+        groups: [{ title: 'feat: a', files: ['a.ts'], hunks: [] }],
+      }
+      expect(dropEmptyGroups(plan)).toEqual(plan)
+    })
+
+    it('keeps groups that have hunks but no files', () => {
+      // Hunk-only groups are normal partial-file claims — must not
+      // be dropped either.
+      const plan: CommitSplitPlan = {
+        groups: [{ title: 'feat: a', files: [], hunks: ['a.ts::hunk-1'] }],
+      }
+      expect(dropEmptyGroups(plan)).toEqual(plan)
+    })
+
+    it('is a no-op when every group has content', () => {
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'feat: a', files: ['a.ts'], hunks: [] },
+          { title: 'feat: b', files: [], hunks: ['b.ts::hunk-1'] },
+        ],
+      }
+      expect(dropEmptyGroups(plan)).toBe(plan)
     })
   })
 })

--- a/src/commands/commit/splitPlanValidation.ts
+++ b/src/commands/commit/splitPlanValidation.ts
@@ -318,6 +318,44 @@ export function rescueMissingFiles(
   }
 }
 
+/**
+ * Drop groups that ended up with no claims at all — empty `files[]`
+ * AND empty `hunks[]`. These can be produced by the earlier rescue
+ * passes:
+ *   - `rescueMixedFiles` drops all of a group's hunks when the file
+ *     is claimed via `files[]` elsewhere. If the group had ONLY those
+ *     hunks (no files of its own), it's left empty.
+ *   - LLM output can independently produce empty groups (rare but
+ *     observed once the schema's `groups.min(1)` validation passes —
+ *     each group only needs the array to exist, not to be non-empty).
+ *
+ * Apply-time, an empty group means `git add []` (no-op) followed by
+ * `git commit` with nothing staged — which throws "nothing to commit"
+ * and aborts the entire split-apply mid-loop. The user sees no
+ * commits land but their staged set is gone (the up-front
+ * `git reset` ran). This filter removes the failure mode entirely.
+ *
+ * Run LAST in the rescue chain so the filter sees the final state
+ * after `rescuePhantomHunks` + `rescueMixedFiles` have done their
+ * work and `rescueMissingFiles` has filled in unclaimed files.
+ *
+ * Returns a NEW plan object. If every group survives, the schema
+ * still requires `groups.min(1)` — but if every group dropped, we
+ * return an empty groups array and let the validator's coverage
+ * check (missingFiles or similar) surface the right error.
+ */
+export function dropEmptyGroups(plan: CommitSplitPlan): CommitSplitPlan {
+  const surviving = plan.groups.filter((group) => {
+    const fileCount = (group.files || []).length
+    const hunkCount = (group.hunks || []).length
+    return fileCount + hunkCount > 0
+  })
+  if (surviving.length === plan.groups.length) {
+    return plan
+  }
+  return { ...plan, groups: surviving }
+}
+
 export function formatPlanValidationFeedback(issues: PlanValidationIssues): string {
   const sections: string[] = []
 

--- a/src/workstation/chrome/postApplyHints.test.ts
+++ b/src/workstation/chrome/postApplyHints.test.ts
@@ -1,4 +1,4 @@
-import { formatRemainingWorktreeHint } from './postApplyHints'
+import { formatRemainingWorktreeHint, formatSplitApplySuccess } from './postApplyHints'
 
 describe('formatRemainingWorktreeHint', () => {
   it('returns an empty string when nothing is left to commit', () => {
@@ -39,5 +39,41 @@ describe('formatRemainingWorktreeHint', () => {
     expect(formatRemainingWorktreeHint(-1, -1)).toBe('')
     expect(formatRemainingWorktreeHint(-5, 3)).toContain('3 untracked')
     expect(formatRemainingWorktreeHint(5, -3)).toContain('5 unstaged')
+  })
+})
+
+describe('formatSplitApplySuccess', () => {
+  it('surfaces the commit count + nav cue + remaining-work hint', () => {
+    const msg = formatSplitApplySuccess(5, 6, 3)
+    expect(msg).toContain('Created 5 commits')
+    expect(msg).toContain('press gh to view them in history')
+    expect(msg).toContain('6 unstaged')
+    expect(msg).toContain('3 untracked')
+    expect(msg).toContain('press gs to stage')
+  })
+
+  it('uses singular grammar when exactly one commit was created', () => {
+    // "Created 1 commits" reads as broken English; the helper
+    // branches on count for the singular case.
+    const msg = formatSplitApplySuccess(1, 0, 0)
+    expect(msg).toContain('Created 1 commit')
+    expect(msg).not.toContain('Created 1 commits')
+  })
+
+  it('elides the remaining-work hint when the worktree is clean', () => {
+    const msg = formatSplitApplySuccess(3, 0, 0)
+    expect(msg).toContain('Created 3 commits')
+    expect(msg).toContain('Worktree is clean')
+    expect(msg).not.toContain('remaining')
+  })
+
+  it('always surfaces the nav cue regardless of remaining work', () => {
+    // The nav cue ("press gh to view them in history") is the key
+    // closure for the "what should I expect to see?" confusion — it
+    // should appear in every successful apply, whether or not there's
+    // residue.
+    expect(formatSplitApplySuccess(5, 0, 0)).toContain('gh')
+    expect(formatSplitApplySuccess(5, 6, 3)).toContain('gh')
+    expect(formatSplitApplySuccess(1, 0, 3)).toContain('gh')
   })
 })

--- a/src/workstation/chrome/postApplyHints.ts
+++ b/src/workstation/chrome/postApplyHints.ts
@@ -50,3 +50,38 @@ export function formatRemainingWorktreeHint(unstaged: number, untracked: number)
   }
   return `${counts} remaining — press gs to stage them, then I for an AI draft.`
 }
+
+/**
+ * Format the full post-apply success message: count of commits
+ * created + where to see them + what's left + how to act on it.
+ *
+ * The user feedback that motivated this: "I click apply and at the
+ * end the staged files just disappear — what should I expect to see
+ * in my git history graph when I navigate back to it?" The previous
+ * success message was just "Created N split commits" with no nav
+ * cue. New users (and even experienced ones returning to the
+ * workstation) don't immediately know that the new commits are now
+ * in the history view.
+ *
+ * Output shape:
+ *   "Created N commits — press gh to view them in history.
+ *    6 unstaged + 3 untracked remaining — press gs to stage, I to draft AI commit message."
+ *
+ * When the worktree is clean post-apply:
+ *   "Created N commits — press gh to view them in history. Worktree is clean."
+ */
+export function formatSplitApplySuccess(
+  commitCount: number,
+  unstaged: number,
+  untracked: number
+): string {
+  const created = commitCount === 1
+    ? 'Created 1 commit'
+    : `Created ${commitCount} commits`
+  const navCue = `${created} — press gh to view them in history.`
+  const remainingHint = formatRemainingWorktreeHint(unstaged, untracked)
+  if (!remainingHint) {
+    return `${navCue} Worktree is clean.`
+  }
+  return `${navCue} ${remainingHint}`
+}

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -89,7 +89,7 @@ import {
     getLogInkInputEvents,
 } from '../../commands/log/inkInput'
 import { hasSeenOnboarding, markOnboardingSeen } from '../chrome/onboarding'
-import { formatRemainingWorktreeHint } from '../chrome/postApplyHints'
+import { formatSplitApplySuccess } from '../chrome/postApplyHints'
 import { SPINNER_TICK_MS } from '../chrome/spinner'
 
 
@@ -1884,19 +1884,22 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     const fresh = await getWorktreeOverview(git).catch(() => undefined)
     const unstaged = fresh?.unstagedCount || 0
     const untracked = fresh?.untrackedCount || 0
-    const remaining = unstaged + untracked
 
     // Compute the freshly-created commit hashes and mark them so the
     // history surface renders them with a "new" indicator. Auto-
     // clears after 5s so the marker doesn't linger across later
     // operations. Best-effort — a rev-list failure (e.g. headBefore
     // capture failed earlier) just skips the marker, no impact on
-    // the apply itself.
+    // the apply itself. The count from this rev-list also drives
+    // the success message — counting hashes is more accurate than
+    // parsing the workflow's string result.
+    let commitCount = 0
     if (headBefore) {
       try {
         const range = `${headBefore}..HEAD`
         const raw = await git.raw(['rev-list', range])
         const hashes = raw.split('\n').map((line) => line.trim()).filter(Boolean)
+        commitCount = hashes.length
         if (hashes.length > 0) {
           dispatch({ type: 'markRecentCommits', hashes })
           // DevSkim: ignore DS172411 — function literal, fixed delay,
@@ -1906,10 +1909,19 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       } catch { /* ignore — marker is a nice-to-have, not load-bearing */ }
     }
 
-    const baseMessage = result.message || 'Applied split plan.'
-    const successMessage = remaining > 0
-      ? `${baseMessage} ${formatRemainingWorktreeHint(unstaged, untracked)}`
-      : `${baseMessage} Worktree is clean.`
+    // Fall back to parsing the workflow result message ("Created N
+    // split commit(s).") if the rev-list path didn't yield a count.
+    if (commitCount === 0 && result.message) {
+      const match = result.message.match(/^Created (\d+)/)
+      if (match) commitCount = parseInt(match[1], 10) || 0
+    }
+
+    // Compose the success message with explicit nav cue (where to
+    // see the commits) + remaining-work hint. Closes the loop on the
+    // "what should I expect to see?" confusion from manual testing.
+    const successMessage = commitCount > 0
+      ? formatSplitApplySuccess(commitCount, unstaged, untracked)
+      : (result.message || 'Applied split plan.')
 
     dispatch({ type: 'setStatus', value: successMessage, kind: 'success' })
   }, [dispatch, git, refreshContext, refreshWorktreeContext, state.activeView, state.splitPlan, state.viewStack.length])


### PR DESCRIPTION
Direct fix for the manual-testing report: "I click apply and it processes and at the end the staged files just seem to disappear."

## Root cause

The rescue chain can produce a group with empty `files[]` AND empty `hunks[]`. `rescueMixedFiles` is the main culprit — it drops all of a group's hunks when those files are claimed via `files[]` elsewhere. A group that originally had ONLY hunks gets left empty.

Apply-time, an empty group means `git add []` (no-op) followed by `git commit` with nothing staged → throws "nothing to commit" → the for-loop aborts mid-iteration. But the up-front `git reset` has already wiped the index. **Net result: zero new commits, zero staged files. Looks like the operation just deleted everything.**

## Fix: two-layer guard

1. **`dropEmptyGroups` rescue pass** added LAST in the generator's rescue chain. After phantom-hunks + mixed-files + missing-files rescues have done their work, any group still empty gets filtered out before the validator sees the plan.
2. **Defensive filter in `applyCommitSplitPlan`** itself. Same logic — re-filters empty groups before the apply loop runs. Belt-and-suspenders for any caller that bypasses the generator (or a future rescue that forgets to compose with dropEmptyGroups). Throws a clear error if every group ended up empty so the failure mode is loud instead of silent.

Bonus cleanup: avoided the literal string `"undefined"` in commit bodies when the LLM omits the `body` field. Falls back to title-only.

## UX: answering "where did my commits go?"

User feedback: "what should I expect to see in my git history graph when I navigate back to it?"

The previous success message was just "Created N split commits" — no nav cue. New users (and even returning ones) don't immediately know to press `gh` for history view.

New `formatSplitApplySuccess(count, unstaged, untracked)` produces:

> "Created 5 commits — press gh to view them in history. 6 unstaged + 3 untracked remaining — press gs to stage, I to draft AI commit message."

> "Created 1 commit — press gh to view them in history. Worktree is clean."

Pluralization-aware (1 commit vs N commits). Nav cue always present regardless of remaining work.

## Conceptual clarification (since you asked)

Here's exactly what split-apply does end to end:

1. **Plan phase** (`prepareCommitSplitPlan`): runs `coco changelog` against the staged set + an inventory of hunks. LLM returns a JSON plan with N groups, each with a proposed conventional-commit title, body, rationale, and a list of files (or hunk IDs) to include.

2. **Review phase** (the overlay): renders the plan for you to scroll/edit/cancel/regenerate.

3. **Apply phase** (`applyCommitSplitPlan`):
   - `git reset` — unstages everything first
   - For each group:
     - `git add <group's files>` (or `git apply --cached <hunk patch>` for hunk-level groups)
     - `git commit -m "<group's AI-generated title>\\n\\n<group's AI-generated body>"`
   - That's a real native `git commit` — NOT a `coco commit -a` call. The AI work happened during the plan phase; apply is just `git` mechanics.

You should see N new commits at the top of `git log` (or in coco's history view), each with the title + body the plan showed you. The just-landed marker (`▎` accent bar from #938) highlights them for ~5s.

## Test plan

- [x] `npm run lint` clean
- [x] `tsc --noEmit` clean
- [x] `npm run test:jest` — 1660 tests pass (+13 from this PR)
- [ ] Manual: `npm run scenario create dirty-many-files -- --run-ui` → `S` → review → `y` apply → land on status with "Created N commits — press gh to view them in history…" → `gh` → see the N new commits at the top with marker
- [ ] Manual: verify the apply actually creates the commits (run `git log -n 10 --oneline` in the scenario dir after apply)