### PR TITLE
fix(split-apply): per-group commit tracking + HEAD verification + surface partial failures

### DIFF
--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -279,6 +279,20 @@ async function applyPatchToIndex(
   })
 }
 
+/**
+ * Result of applying a split plan. Distinguishes the no-op case
+ * (`message` only) from the actually-created-commits case
+ * (`commitHashes` populated) so the workstation surface can render
+ * an accurate "N commits landed" message and skip the post-apply
+ * `git rev-list` round-trip.
+ */
+export type CommitSplitApplyResult = {
+  /** SHA of every commit created by this apply, in order. */
+  commitHashes: string[]
+  /** Human-readable summary, suitable for the CLI handler / status line. */
+  message: string
+}
+
 export async function applyCommitSplitPlan({
   plan,
   changes,
@@ -293,7 +307,7 @@ export async function applyCommitSplitPlan({
   git: ReturnType<typeof import('../../lib/simple-git/getRepo').getRepo>
   logger: Logger
   noVerify: boolean
-}): Promise<string> {
+}): Promise<CommitSplitApplyResult> {
   validatePlanForStagedFiles(plan, changes.staged, hunkInventory)
   assertNoUnstagedOverlap(plan, changes, hunkInventory)
 
@@ -312,29 +326,109 @@ export async function applyCommitSplitPlan({
     throw new Error('Split plan has no applicable groups (every group was empty).')
   }
 
+  // Capture HEAD up-front so we can verify each commit actually
+  // advanced the tip — silent no-op commits (empty index, hook
+  // returning success without committing, etc.) get caught and
+  // surface as a loud error instead of returning a misleading
+  // "Created N commits" message when zero commits actually landed.
+  let previousHead: string
+  try {
+    previousHead = (await git.revparse(['HEAD'])).trim()
+  } catch (error) {
+    // Brand-new repo with no commits — `git revparse HEAD` fails.
+    // Use the empty-tree sentinel so the post-commit comparison
+    // still detects "no change".
+    previousHead = 'EMPTY'
+  }
+
   await git.raw(['reset'])
+
+  const commitHashes: string[] = []
+  const failures: { title: string; reason: string }[] = []
 
   for (const group of applicableGroups) {
     const groupFiles = getGroupFiles(group)
     const groupHunks = getGroupHunks(group).map((hunkId) => hunkInventory.byId.get(hunkId))
 
-    if (groupFiles.length > 0) {
-      await git.add(groupFiles)
-    }
+    try {
+      if (groupFiles.length > 0) {
+        await git.add(groupFiles)
+      }
 
-    if (groupHunks.length > 0) {
-      const patch = buildPatchForHunks(groupHunks.filter((hunk): hunk is StagedHunk => Boolean(hunk)))
-      await applyPatchToIndex(patch, git)
-    }
+      if (groupHunks.length > 0) {
+        const patch = buildPatchForHunks(groupHunks.filter((hunk): hunk is StagedHunk => Boolean(hunk)))
+        await applyPatchToIndex(patch, git)
+      }
 
-    // Avoid the literal string "undefined" in the commit body when
-    // the LLM omitted the body field — fall back to title-only.
-    const body = group.body ? `\n\n${group.body}` : ''
-    await createCommit(`${group.title}${body}`.trim(), git, undefined, { noVerify })
-    logger.verbose(`Created split commit: ${group.title}`, { color: 'green' })
+      // Sanity-check the staged set before committing — if everything
+      // got dropped (e.g. .gitignore filtered all the group's files,
+      // or the paths point at things that don't exist on disk), git
+      // commit would throw "nothing to commit" mid-loop. Surface a
+      // clearer error instead.
+      const status = await git.status()
+      const stagedAfterAdd = status.staged.length + status.created.length + status.renamed.length
+      if (stagedAfterAdd === 0) {
+        failures.push({
+          title: group.title,
+          reason: `git add succeeded but nothing ended up staged — paths may not exist on disk or be gitignored. files=[${groupFiles.join(', ')}]`,
+        })
+        continue
+      }
+
+      // Avoid the literal string "undefined" in the commit body when
+      // the LLM omitted the body field — fall back to title-only.
+      const body = group.body ? `\n\n${group.body}` : ''
+      await createCommit(`${group.title}${body}`.trim(), git, undefined, { noVerify })
+
+      // Verify the commit actually advanced HEAD. Some hooks can
+      // exit success without committing (e.g. `--no-verify`-mode
+      // hooks misconfigured to skip silently). If HEAD didn't move,
+      // we didn't create a commit — record it as a failure instead
+      // of returning a misleading success.
+      const newHead = (await git.revparse(['HEAD'])).trim()
+      if (newHead === previousHead) {
+        failures.push({
+          title: group.title,
+          reason: 'git commit returned success but HEAD did not advance — commit may have been silently skipped',
+        })
+        continue
+      }
+      commitHashes.push(newHead)
+      previousHead = newHead
+      logger.verbose(`Created split commit ${newHead.slice(0, 8)}: ${group.title}`, { color: 'green' })
+    } catch (error) {
+      failures.push({
+        title: group.title,
+        reason: error instanceof Error ? error.message : String(error),
+      })
+    }
   }
 
-  return `Created ${applicableGroups.length} split commit(s).`
+  // If every group failed, throw — there's nothing to recover and
+  // the caller needs a clear error path. Partial-success (some
+  // groups landed, some failed) is returned with a warning summary
+  // so the user keeps the work that did land.
+  if (commitHashes.length === 0) {
+    const detail = failures.map((f) => `  - ${f.title}: ${f.reason}`).join('\n')
+    throw new Error(
+      `Split apply created zero commits across ${applicableGroups.length} group(s).\n${detail}`
+    )
+  }
+
+  if (failures.length > 0) {
+    const partial = failures
+      .map((f) => `${f.title} (${f.reason.split('\n')[0]})`)
+      .join('; ')
+    return {
+      commitHashes,
+      message: `Created ${commitHashes.length} of ${applicableGroups.length} planned commit(s). Failed: ${partial}`,
+    }
+  }
+
+  return {
+    commitHashes,
+    message: `Created ${commitHashes.length} split commit(s).`,
+  }
 }
 
 /**
@@ -453,7 +547,7 @@ export async function handleCommitSplit({
   const { plan, context } = result
 
   if (argv.apply) {
-    return await applyCommitSplitPlan({
+    const applied = await applyCommitSplitPlan({
       plan,
       changes: context.changes,
       hunkInventory: context.hunkInventory,
@@ -461,6 +555,7 @@ export async function handleCommitSplit({
       logger,
       noVerify: argv.noVerify || config.noVerify || false,
     })
+    return applied.message
   }
 
   return formatCommitSplitPlan(plan)

--- a/src/git/commitWorkflowActions.ts
+++ b/src/git/commitWorkflowActions.ts
@@ -328,12 +328,12 @@ export async function runCommitSplitApplyWorkflow(input: {
   planContext: CommitSplitPlanContext
   git?: SimpleGit
   noVerify?: boolean
-}): Promise<CommitWorkflowResult> {
+}): Promise<CommitWorkflowResult & { commitHashes?: string[] }> {
   const git = input.git || getRepo()
   const logger = new Logger({ silent: true })
 
   try {
-    const message = await applyCommitSplitPlan({
+    const applied = await applyCommitSplitPlan({
       plan: input.plan,
       changes: input.planContext.changes,
       hunkInventory: input.planContext.hunkInventory,
@@ -343,7 +343,13 @@ export async function runCommitSplitApplyWorkflow(input: {
     })
     return {
       ok: true,
-      message: message || 'Applied commit split plan.',
+      message: applied.message || 'Applied commit split plan.',
+      // Pass the actually-created commit hashes through. The runtime
+      // uses them for the just-landed marker; previously it had to do
+      // a post-apply `git rev-list` round-trip which was both extra
+      // I/O AND inaccurate when partial-apply landed fewer commits
+      // than the plan had groups.
+      commitHashes: applied.commitHashes,
     }
   } catch (error) {
     if (isCommandExitError(error)) {

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -1829,12 +1829,6 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       return
     }
 
-    // Capture HEAD before the apply so we can compute exactly which
-    // commits the operation created (rev-list headBefore..HEAD after
-    // success). Best-effort — if revparse fails we skip the
-    // newest-commits marker, no degradation of the apply itself.
-    const headBefore = await git.revparse(['HEAD']).then((sha) => sha.trim()).catch(() => undefined)
-
     dispatch({ type: 'setSplitPlanApplying' })
     dispatch({ type: 'setStatus', value: 'Applying split plan…', loading: true })
 
@@ -1885,44 +1879,35 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     const unstaged = fresh?.unstagedCount || 0
     const untracked = fresh?.untrackedCount || 0
 
-    // Compute the freshly-created commit hashes and mark them so the
-    // history surface renders them with a "new" indicator. Auto-
-    // clears after 5s so the marker doesn't linger across later
-    // operations. Best-effort — a rev-list failure (e.g. headBefore
-    // capture failed earlier) just skips the marker, no impact on
-    // the apply itself. The count from this rev-list also drives
-    // the success message — counting hashes is more accurate than
-    // parsing the workflow's string result.
-    let commitCount = 0
-    if (headBefore) {
-      try {
-        const range = `${headBefore}..HEAD`
-        const raw = await git.raw(['rev-list', range])
-        const hashes = raw.split('\n').map((line) => line.trim()).filter(Boolean)
-        commitCount = hashes.length
-        if (hashes.length > 0) {
-          dispatch({ type: 'markRecentCommits', hashes })
-          // DevSkim: ignore DS172411 — function literal, fixed delay,
-          // no caller-supplied data flowing through.
-          setTimeout(() => dispatch({ type: 'clearRecentCommits' }), 5000)
-        }
-      } catch { /* ignore — marker is a nice-to-have, not load-bearing */ }
+    // The workflow now returns the actually-created commit hashes
+    // directly (verified against HEAD inside applyCommitSplitPlan —
+    // each commit confirmed to have advanced the tip). Drive the
+    // just-landed marker AND the success-message commit count from
+    // that exact data instead of doing a second rev-list round-trip
+    // that could disagree with reality on partial-apply.
+    const commitHashes = result.commitHashes || []
+    if (commitHashes.length > 0) {
+      dispatch({ type: 'markRecentCommits', hashes: commitHashes })
+      // DevSkim: ignore DS172411 — function literal, fixed delay,
+      // no caller-supplied data flowing through.
+      setTimeout(() => dispatch({ type: 'clearRecentCommits' }), 5000)
     }
 
-    // Fall back to parsing the workflow result message ("Created N
-    // split commit(s).") if the rev-list path didn't yield a count.
-    if (commitCount === 0 && result.message) {
-      const match = result.message.match(/^Created (\d+)/)
-      if (match) commitCount = parseInt(match[1], 10) || 0
+    // If the workflow reported success but zero commits actually
+    // landed, surface that as an error — the spinner-then-silence
+    // failure mode from #940 manual testing where the apply appeared
+    // to succeed but the worktree got wiped with no commits made.
+    if (commitHashes.length === 0) {
+      const detail = result.message || 'No commits were created.'
+      dispatch({
+        type: 'setStatus',
+        value: `Split apply produced zero commits: ${detail}`,
+        kind: 'error',
+      })
+      return
     }
 
-    // Compose the success message with explicit nav cue (where to
-    // see the commits) + remaining-work hint. Closes the loop on the
-    // "what should I expect to see?" confusion from manual testing.
-    const successMessage = commitCount > 0
-      ? formatSplitApplySuccess(commitCount, unstaged, untracked)
-      : (result.message || 'Applied split plan.')
-
+    const successMessage = formatSplitApplySuccess(commitHashes.length, unstaged, untracked)
     dispatch({ type: 'setStatus', value: successMessage, kind: 'success' })
   }, [dispatch, git, refreshContext, refreshWorktreeContext, state.activeView, state.splitPlan, state.viewStack.length])
 


### PR DESCRIPTION
Direct fix for the silent-failure report: "I see the applying spinner but no commits land and no staged/unstaged remain."

## Root cause hypothesis (now diagnosable)

The previous `applyCommitSplitPlan` returned a string `"Created N split commit(s)."` regardless of whether any commits actually landed. If:

- An exception got swallowed mid-loop somewhere
- `git commit` returned success without advancing HEAD (some hook configs do this)
- A group's staged set was somehow empty when `git commit` ran

…the message lied and the user lost both the staged set (from up-front `git reset`) and any signal that something went wrong.

## What this PR changes

`applyCommitSplitPlan` is now defensive at every step:

1. **Captures HEAD up-front** (with EMPTY-tree fallback for brand-new repos)
2. For each group:
   - Stages files / applies hunk patches
   - **Validates the staged set is non-empty before calling `git commit`** (catches `.gitignore`-filtered files, missing-on-disk paths)
   - Calls `createCommit`
   - **Re-reads HEAD afterward — if it didn't advance, records the group as a failure and continues** instead of returning misleading success
3. Returns structured `CommitSplitApplyResult` with `commitHashes` (actually landed) + `message`
4. **Throws if ZERO commits landed across N groups** with per-group reasons in the error
5. Returns partial-success when some landed / some failed, with failures summarized

## Workstation uses the structured result

`runCommitSplitApplyWorkflow` passes `commitHashes` through. The runtime:
- Uses workflow-returned hashes for the just-landed marker (no more separate `rev-list` that could disagree)
- Drives commit count from `commitHashes.length` directly
- **Surfaces a red error if zero hashes come back despite `ok: true`** — closes the silent-failure loophole

## What you'll see after this lands

If your repro still fails, you'll now get one of:
- A specific per-group error: `"git add succeeded but nothing ended up staged — paths may not exist on disk or be gitignored"`
- A specific per-commit error: `"git commit returned success but HEAD did not advance — commit may have been silently skipped"`
- A specific per-group error from `git.commit`/`git.add` itself with the underlying message
- A `Split apply produced zero commits` red banner with details below

Whichever appears, that's the actual root cause — copy/paste it in a comment and we'll know exactly what to fix next.

## Test plan

- [x] `npm run lint` clean
- [x] `tsc --noEmit` clean
- [x] `npm run test:jest` — 1666 tests pass
- [ ] **The critical manual test**: `npm run scenario create dirty-many-files -- --run-ui` → `S` → review → `y` apply
  - If it now succeeds cleanly: we're done; verify commits land via `gh` in the TUI AND `git log` in a separate terminal
  - If it still silently does nothing: the error message that surfaces will tell us exactly what's failing — paste it here