### PR TITLE
fix(history): refresh state.rows for every history-mutating workflow

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -2172,6 +2172,11 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         if (!command) return { ok: false, message: 'Bisect run needs a command' }
         try {
           const stdout = await bisectRun(git, command)
+          // Bisect run can advance HEAD across many commits when
+          // testing — refresh both the metadata context AND the
+          // history rows so the user sees what `git log` actually
+          // shows now.
+          await refreshHistoryRows()
           await refreshContext({ silent: true })
           return {
             ok: true,
@@ -2209,6 +2214,9 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
           const stdout = await bisectStart(git, badRef, goodRef)
           dispatch({ type: 'clearBisectPickMode' })
           dispatch({ type: 'pushView', value: 'bisect' })
+          // Bisect start checks out the midpoint commit — HEAD moves,
+          // history view needs the fresh row set.
+          await refreshHistoryRows()
           await refreshContext({ silent: true })
           return {
             ok: true,
@@ -2549,6 +2557,32 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
     const result = await handler()
     dispatch({ type: 'setStatus', value: result?.message || 'Workflow action complete' })
+    // Refresh history rows AS WELL when the workflow could have
+    // changed the commits the user sees (#945 follow-up). The
+    // workflow IDs below all either create/rewrite local commits or
+    // change which branch's history is being viewed — without this
+    // the history pane shows stale data even after the operation
+    // succeeds. Cheap one-off `git log` call; doesn't fire on
+    // metadata-only mutations (delete-tag, set-upstream, etc.).
+    const historyMutatingIds = new Set([
+      'checkout-branch',
+      'continue-operation',
+      'pull-current-branch',
+      'cherry-pick-commit',
+      'revert-commit',
+      'reset-hard-to-commit',
+      'reset-soft-to-commit',
+      'reset-mixed-to-commit',
+      'interactive-rebase-to-commit',
+      'bisect-good',
+      'bisect-bad',
+      'bisect-skip',
+      'bisect-reset',
+    ])
+    if (result?.ok && historyMutatingIds.has(id)) {
+      await refreshHistoryRows()
+    }
+
     // Checkout-branch is the one workflow where we want a *visible*
     // refresh so the user sees the branches sidebar repaint with the
     // new current branch (per #806 follow-up). Snap the cursor to
@@ -2563,7 +2597,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       // without flickering the surfaces through a 'loading' phase.
       await refreshContext({ silent: true })
     }
-  }, [context, dispatch, git, refreshContext, state.branchSort, state.filter, state.selectedBranchIndex,
+  }, [context, dispatch, git, refreshContext, refreshHistoryRows, state.branchSort, state.filter, state.selectedBranchIndex,
     state.selectedStashIndex, state.selectedTagIndex, state.selectedWorktreeListIndex, state.stashDiffRef,
     state.statusFilterMask, state.tagSort])
 


### PR DESCRIPTION
Contributor question: "We'll likely want to tie refreshHistoryRows to other commands that are creating updates in the git history too, right?"

Yes — #944 wired it into split-apply and createCommitFromCompose, but the workflow runner had a dozen other paths that mutate history without re-fetching `state.rows`. Same silent-failure shape: operation succeeds, history view stays stale, user concludes nothing happened.

## Workflow IDs that now refresh history rows

Added to an explicit allow-set inside `runWorkflowAction`:

- `checkout-branch` — switching branches changes what `git log` returns
- `continue-operation` — creates a commit when continuing merge/rebase/cherry-pick
- `pull-current-branch` — fast-forwards or creates merge commit
- `cherry-pick-commit` — creates commit
- `revert-commit` — creates commit
- `reset-hard-to-commit` / `reset-soft-to-commit` / `reset-mixed-to-commit` — rewrites HEAD
- `interactive-rebase-to-commit` — rewrites history
- `bisect-good` / `bisect-bad` / `bisect-skip` / `bisect-reset` — moves HEAD

Plus the two direct-call bisect ops outside the workflow runner (`bisect-run`, `bisect-start-from-history`) get an inline `refreshHistoryRows()` next to their existing `refreshContext`.

## What this does NOT do

- Doesn't fire on metadata-only mutations (`delete-tag`, `set-upstream`, `rename-branch`, `create-stash`, `delete-branch`, etc.) — those don't change what `git log` returns from the current branch's perspective, so refreshing rows would be wasted work.
- Doesn't fire on read-only or worktree-only ops (`stage-all-unstaged`, `resolve-conflict-stage`, etc.).

The allow-set is explicit-not-inferred so future workflow IDs have to opt in by name — keeps it predictable and easy to audit. If a new history-mutating workflow lands without being added to the list, the history view will go stale for it; that's a single line of code to fix and a clear bug shape if it shows up.

## Cost

One extra `git log` call per history-mutating op (~80ms typical). Negligible compared to the cost of running the operation itself, and worth it to keep the workstation's view of the world in sync with reality.

## Test plan

- [x] `npm run lint` clean
- [x] `tsc --noEmit` clean
- [x] `npm run test:jest` — 1665 tests pass
- [ ] Manual: cherry-pick a commit from history → press `gh` → see the new commit at HEAD
- [ ] Manual: reset hard to an older commit → press `gh` → see only commits up to that point
- [ ] Manual: bisect good/bad → see history view track the moving HEAD