### PR TITLE
feat(cli): --repo <dir> on coco ui + coco log to target an arbitrary repo

### DIFF
--- a/src/commands/log/config.ts
+++ b/src/commands/log/config.ts
@@ -15,6 +15,14 @@ export interface LogOptions extends BaseCommandOptions {
   merges?: boolean
   noMerges?: boolean
   path?: string | string[]
+  /**
+   * Repository directory to operate against. When set, log reads
+   * commit data from this path instead of `process.cwd()`. Mirrors
+   * the `--repo` flag on `coco ui` so scripts / shell wrappers /
+   * test scenarios can target arbitrary repos without `cd`-ing.
+   * `--cwd` is an alias.
+   */
+  repo?: string
   since?: string
   until?: string
   view?: LogView
@@ -72,6 +80,11 @@ export const options = {
   path: {
     description: 'Filter commits by changed path',
     type: 'array',
+  },
+  repo: {
+    description: 'Target a specific repository directory instead of the current working directory.',
+    type: 'string',
+    alias: 'cwd',
   },
   since: {
     description: 'Show commits more recent than a date',

--- a/src/commands/log/handler.ts
+++ b/src/commands/log/handler.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path'
 import { CommandHandler } from '../../lib/types'
 import { Config } from '../../lib/config/types'
 import { loadConfig } from '../../lib/config/utils/loadConfig'
@@ -9,8 +10,17 @@ import { formatCommitDetail, formatLogJson, formatLogTable } from './render'
 import { LogArgv } from './config'
 
 export const handler: CommandHandler<LogArgv> = async (argv) => {
+  // `--repo <dir>` (alias `--cwd`) lets users target an arbitrary
+  // repository without `cd`-ing first. Mirrors the same flag on
+  // `coco ui`. chdir up-front so config + git both resolve against
+  // the same canonical path. Resolve to absolute to avoid the
+  // confusion of relative paths interacting with the chdir.
+  if (argv.repo) {
+    process.chdir(path.resolve(argv.repo))
+  }
+
   const config = loadConfig<Config, LogArgv>(argv)
-  const git = getRepo()
+  const git = getRepo(argv.repo ? path.resolve(argv.repo) : undefined)
   const format = argv.format === 'json' ? 'json' : 'table'
 
   if (argv.commit) {

--- a/src/commands/ui/config.ts
+++ b/src/commands/ui/config.ts
@@ -10,6 +10,16 @@ export interface UiOptions extends BaseCommandOptions {
   branch?: string
   limit?: number
   path?: string | string[]
+  /**
+   * Repository directory to operate against. When set, the workstation
+   * binds its git instance + cwd reads to this path instead of
+   * `process.cwd()`. Lets users / scripts / scenarios launch coco
+   * against arbitrary repos without a leading `cd`.
+   *
+   * `--cwd` is exposed as an alias since users reaching for this
+   * flag often think "change directory" before "target this repo."
+   */
+  repo?: string
   theme?: LogInkThemePreset
   view?: UiView
 }
@@ -42,6 +52,11 @@ export const options = {
   path: {
     description: 'Filter history by changed path',
     type: 'array',
+  },
+  repo: {
+    description: 'Target a specific repository directory instead of the current working directory.',
+    type: 'string',
+    alias: 'cwd',
   },
   theme: {
     description: 'TUI theme preset',

--- a/src/commands/ui/handler.ts
+++ b/src/commands/ui/handler.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path'
 import { Arguments } from 'yargs'
 import { SimpleGit } from 'simple-git'
 import { CommandHandler } from '../../lib/types'
@@ -21,6 +22,9 @@ export function createLogArgvFromUiArgv(argv: UiArgv): LogArgv {
     interactive: true,
     limit: argv.limit,
     path: argv.path,
+    // Carry the --repo flag through so the runtime keeps the same
+    // repo target across the ui → log argv handoff.
+    repo: argv.repo,
     verbose: argv.verbose,
     version: argv.version,
     help: argv.help,
@@ -96,10 +100,30 @@ export async function startCocoUiFromLogArgv(
 }
 
 export async function startCocoUi(argv: UiArgv): Promise<void> {
+  // `--repo <dir>` (alias `--cwd`) lets users target an arbitrary
+  // repository without `cd`-ing first. Resolve to absolute up-front
+  // so:
+  //   1. process.chdir gets a stable path (relative paths against
+  //      the original cwd would surprise the user if any later code
+  //      reads cwd after the chdir).
+  //   2. The disk cache key (rooted at repoPath) is canonical.
+  //   3. simple-git's baseDir is unambiguous.
+  // When the flag is omitted, fall back to process.cwd() — original
+  // behavior, no surprise for users who launch via `cd && coco ui`.
+  const repoPath = argv.repo ? path.resolve(argv.repo) : process.cwd()
+
+  // chdir BEFORE loadConfig so .coco.config.json lookup walks up
+  // from the targeted repo, not from wherever the user ran coco
+  // from. Many config-resolution paths (lib/utils/findUp, etc.)
+  // read process.cwd() — keeping them honest means doing the chdir
+  // up-front rather than passing a path everywhere.
+  if (argv.repo) {
+    process.chdir(repoPath)
+  }
+
   const config = loadConfig<Config, UiArgv>(argv)
-  const git = getRepo()
+  const git = getRepo(repoPath)
   const logArgv = createLogArgvFromUiArgv(argv)
-  const repoPath = process.cwd()
 
   // Same three-stage boot as startCocoUiFromLogArgv — mount with
   // cached rows for an instant-paint shell, refresh in background.

--- a/src/lib/simple-git/getRepo.ts
+++ b/src/lib/simple-git/getRepo.ts
@@ -2,14 +2,20 @@ import { simpleGit, SimpleGit } from 'simple-git'
 import { commandExit } from '../utils/commandExit'
 
 /**
- * Retrieves the SimpleGit instance for the repository.
- * @returns {SimpleGit} The SimpleGit instance.
+ * Retrieves a SimpleGit instance for a repository.
+ *
+ * @param baseDir Optional path to the repo root. When omitted, simple-git
+ *   uses `process.cwd()`. Pass this when launching coco against an
+ *   arbitrary directory (e.g. `coco ui --repo <dir>`) so the workstation
+ *   targets that path instead of wherever the user happened to run the
+ *   command from. Useful for testing, scripting, and editor / shell
+ *   integrations that don't want to `cd` first.
  */
-export const getRepo = () => {
+export const getRepo = (baseDir?: string) => {
   let git: SimpleGit
-  
+
   try {
-    git = simpleGit()
+    git = baseDir ? simpleGit(baseDir) : simpleGit()
   } catch (e) {
     console.log('Error initializing git repo', e)
     commandExit(1)


### PR DESCRIPTION
Closes a long-standing friction point: launching coco against a directory other than \`cwd\`.

## The bug

Both \`--path\` flags on \`coco ui\` and \`coco log\` are HISTORY FILTERS (commit filtering by changed-file path), not "use this directory as the repo." The repo target always came from \`process.cwd()\`. This caused:

- Real confusion when users tried \`coco ui --path /some/repo\` (silently runs against cwd, filters history by a nonexistent path)
- Editor / shell integrations couldn't launch coco against a project from elsewhere
- Scenario testing required \`cd\` workarounds — fixed for the scenario CLI in #911 but the underlying gap persisted
- Manual "test against this scenario with my config" required copying config around

## The fix

New \`--repo <dir>\` flag (alias \`--cwd\`) on both \`coco ui\` and \`coco log\`:

\`\`\`bash
# Open workstation against a scenario without cd
coco ui --repo /tmp/coco-scenario

# Inspect another repo's log from the current shell
coco log --repo ~/other-project --limit 10

# Interactive log against an arbitrary repo
coco log -i --repo /tmp/widgets-repo
\`\`\`

## Mechanics

- \`getRepo(baseDir?)\` now accepts an optional baseDir, forwards to \`simpleGit(baseDir)\`. Unchanged default behavior.
- Both handlers resolve \`argv.repo\` to absolute, \`process.chdir\` up-front (so \`loadConfig\` + downstream lookups walk the right tree), then \`getRepo(repoPath)\`.
- \`createLogArgvFromUiArgv\` carries \`argv.repo\` across the ui → log handoff so \`coco ui --repo\` correctly drives the log subsystem.

## Why chdir is in there

Many config / discovery paths (findUp for \`.coco.config.json\`, commitlint config detection, etc.) walk up from \`process.cwd()\`. If we only changed simple-git's baseDir without chdir-ing, those would still resolve against the original cwd — leading to "coco is reading this repo but loading config from somewhere else" surprises. Chdir up-front keeps everything coherent.

## Smoke-tested

- \`coco log --repo <scenario>\` from inside the coco repo shows the scenario's commits (not coco's). ✅
- \`coco ui --help\` shows the new flag with \`--cwd\` alias. ✅

## Test plan

- [x] \`npm run lint\` clean
- [x] \`tsc --noEmit\` clean
- [x] \`npm run test:jest\` — 1665 tests pass (one flaky parallel-execution test unrelated)
- [ ] Manual: \`coco ui --repo /tmp/<scenario>\` from coco repo cwd opens the workstation against the scenario
- [ ] Manual: \`coco log --repo /tmp/<scenario>\` from coco repo cwd shows scenario commits

## Out of scope

- \`--repo\` on \`commit\` / \`review\` / \`recap\` / \`changelog\` — these don't have the same failure mode (they read live worktree state which is usually correct). Lift if a wrapper script actually needs cross-repo support.
- Promoting \`repo\` to \`BaseCommandOptions\` so every command inherits — more invasive, deferred until a second command needs it.