### PR TITLE
fix(config): warn instead of throw on validation failure

### DIFF
--- a/src/lib/config/services/project.test.ts
+++ b/src/lib/config/services/project.test.ts
@@ -56,4 +56,43 @@ describe('loadProjectConfig', () => {
       expect(config.service.endpoint).toBe('http://localhost:11434')
     }
   })
+
+  it('warns instead of throwing when the merged config fails validation', () => {
+    // Reproduces the user-reported crash: the merged config has fields
+    // the schema rejects (often inherited from a stale XDG / git
+    // config layer), and the previous behavior threw, taking down
+    // every coco command. The fix surfaces a warning so the user
+    // can fix the offending field but keeps the merge so the rest
+    // of the tool stays usable.
+    mockFs.existsSync.mockReturnValue(true)
+    // Project file has a valid local override (conventionalCommits)
+    // but the merged result will inherit an invalid service shape
+    // from the incoming `config` argument.
+    mockFs.readFileSync.mockReturnValue(
+      JSON.stringify({ conventionalCommits: true })
+    )
+
+    const invalidIncoming = {
+      service: {
+        // Missing required fields + extra unknown field — guaranteed
+        // to fail any anyOf branch in the service schema.
+        provider: 'openai',
+        model: 'gpt-4o',
+        unknownDriftField: 'something',
+      },
+    } as unknown as Config
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(() => loadProjectJsonConfig(invalidIncoming)).not.toThrow()
+
+    const result = loadProjectJsonConfig(invalidIncoming)
+    // Local override still merged in despite validation failure —
+    // the tool keeps working with the user's intent applied.
+    expect((result as unknown as { conventionalCommits?: boolean }).conventionalCommits).toBe(true)
+    expect(warnSpy).toHaveBeenCalled()
+    expect(warnSpy.mock.calls[0][0]).toContain('config validation issues detected')
+
+    warnSpy.mockRestore()
+  })
 })

--- a/src/lib/config/services/project.ts
+++ b/src/lib/config/services/project.ts
@@ -45,12 +45,46 @@ export function loadProjectJsonConfig<ConfigType = Config>(
       fs.readFileSync(resolvedPath, 'utf-8')
     ) as Partial<Config> & { $schema: string }
 
-    config = { ...config, ...projectConfig } as Config
+    const merged = { ...config, ...projectConfig } as Config
 
-    const isProjectConfigValid = validate(config)
+    // Validate the merged result, but DON'T throw on failure.
+    // Reasons:
+    //
+    //   1. Throwing turns "you have a stale field somewhere in your
+    //      config" into "the whole tool fails to boot" — every coco
+    //      command that loads config crashes. That's a brutal
+    //      regression cost for what's almost always a recoverable
+    //      situation.
+    //
+    //   2. The validation runs on the MERGED config, so the actual
+    //      offending file might be the XDG / git / env layer, not
+    //      the local project file we're nominally loading. Pinning
+    //      the error to "project config" was actively misleading.
+    //
+    //   3. We have sane defaults. A drifted service shape can fall
+    //      back to the default service and the rest of the tool
+    //      keeps working — the user still gets their commits, their
+    //      changelogs, their PR flows, etc.
+    //
+    // Instead: warn loudly to stderr (with the file path AND the
+    // specific schema errors) so the user knows exactly what to fix,
+    // and apply the merge so the user's intent still flows through.
+    // If a downstream component genuinely can't operate without a
+    // valid service shape, it can guard against that locally with a
+    // clear error rather than blowing up at config-load time.
+    const isProjectConfigValid = validate(merged)
     if (!isProjectConfigValid) {
-      throw new Error('Invalid project config', { cause: ajv.errorsText(validate.errors) })
+      const errors = ajv.errorsText(validate.errors)
+      console.warn(
+        `[coco] Warning: config validation issues detected (continuing with merged config).\n` +
+        `  Local file:   ${resolvedPath}\n` +
+        `  Schema issues: ${errors}\n` +
+        `  Fix the offending fields to silence this warning. The validation runs ` +
+        `against the merged result of every config source (defaults, XDG, git, project, env) ` +
+        `— the issue may be in any of those, not necessarily this file.`
+      )
     }
+    config = merged
   }
 
   if (opts?.returnSource) {


### PR DESCRIPTION
User report: every coco command crashes with \`Invalid project config\` when the merged config (defaults + XDG + git + project + env) fails schema validation. The throw originated from \`loadProjectJsonConfig\` but the offending fields are often inherited from EARLIER layers (XDG, git config) — so the error pinned blame on the wrong source AND a stale field anywhere in the chain takes down the whole tool.

## The error

\`\`\`
Error: Invalid project config
  cause: data/service must NOT have additional properties,
         data/service/requestOptions/timeout must be number,
         data/service/requestOptions/maxRetries must be number,
         data/service must have required property 'endpoint',
         data/service must match a schema in anyOf
\`\`\`

Hit during \`coco ui --repo /tmp/scenario\` testing this morning. Reproducible against any real-world XDG config whose service shape has drifted from the strict schema. Adding ANY local \`.coco.config.json\` re-triggers validation of the merged result — inherits invalid XDG service — crashes.

## Fix

\`loadProjectJsonConfig\` no longer throws. Instead:

1. **Logs a clear warning to stderr** with:
   - The path of the local file that triggered validation
   - The specific schema errors
   - A note that validation runs against the MERGED config — the issue may be in any layer
2. **Applies the merge anyway** so the user's intent flows through
3. **Lets downstream components guard locally** against shapes they can't handle

## Why this is the right answer

- Throwing turns "you have a stale field somewhere" into "the tool fails to boot." Brutal cost for a recoverable situation.
- Coco has sane defaults. A drifted service shape can fall back gracefully.
- A downstream consumer that GENUINELY needs a valid service shape can throw a localized error at use-time with concrete next steps, rather than burying the user in opaque "Invalid project config" at boot.

## Verified

Local repro of the user's exact error now produces:

\`\`\`
[coco] Warning: config validation issues detected (continuing with merged config).
  Local file:   .coco.config.json
  Schema issues: data/service must NOT have additional properties, ...
  Fix the offending fields to silence this warning. The validation runs against
  the merged result of every config source (defaults, XDG, git, project, env) —
  the issue may be in any of those, not necessarily this file.
Graph  Commit     Date        Author     Message
*      f13c3f2    2026-05-14  Coco Test  chore: baseline app scaffold  [HEAD -> main]
*      a817234    2026-05-14  Coco Test  chore: initial commit
\`\`\`

Warning fires (so the user knows to fix it eventually) but the tool keeps going.

## Out of scope

The drifted schema itself. The error suggests the service-config schema has gotten stricter than real configs in the wild — worth an audit follow-up to either loosen the schema or document the new required shape. This PR just stops the bleed.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`tsc --noEmit\` clean
- [x] \`npm run test:jest\` — 1666 tests pass (+1 new regression test)
- [ ] Manual: the user's blocked workflow (\`coco ui --repo /tmp/conv-test\`) now boots