### PR TITLE
feat(cli): wire --repo into cache / doctor / init handlers

### DIFF
--- a/src/commands/cache/handler.ts
+++ b/src/commands/cache/handler.ts
@@ -7,6 +7,7 @@ import {
   getDiffSummaryCachePath,
 } from '../../lib/parsers/default/utils/diffSummaryCache'
 import { CommandHandler } from '../../lib/types'
+import { applyRepoCwd } from '../utils/applyRepoFlag'
 import { CacheArgv } from './config'
 
 type CacheEntry = {
@@ -40,7 +41,10 @@ function formatBytes(bytes: number): string {
 
 export const handler: CommandHandler<CacheArgv> = async (argv, logger) => {
   const subcommand = (argv as { subcommand?: string }).subcommand
-  const repoPath = process.cwd()
+  // Honor the global --repo flag so `coco cache info --repo <X>`
+  // inspects X's cache, not the launcher's cwd. applyRepoCwd
+  // performs the chdir when needed and returns the canonical path.
+  const repoPath = applyRepoCwd(argv)
   const cachePath = getDiffSummaryCachePath(repoPath)
 
   if (subcommand === 'clear') {

--- a/src/commands/doctor/handler.ts
+++ b/src/commands/doctor/handler.ts
@@ -5,6 +5,7 @@ import { getConfigSources, ConfigSourceInfo } from '../../lib/config/utils/loadC
 import { SCHEMA_PUBLIC_URL } from '../../lib/schema'
 import { CommandHandler } from '../../lib/types'
 import { LOGO } from '../../lib/ui/helpers'
+import { applyRepoCwd } from '../utils/applyRepoFlag'
 import { DoctorArgv, DoctorOptions } from './config'
 import { DiagnosticSeverity, runDiagnostics } from './checks'
 
@@ -42,6 +43,12 @@ function formatSourceInfo(sources: ConfigSourceInfo[]): string[] {
 }
 
 export const handler: CommandHandler<DoctorArgv> = async (argv, logger) => {
+  // Honor the global --repo flag so `coco doctor --repo <X>`
+  // inspects X's config sources, not the launcher's cwd. The chdir
+  // has to happen before loadConfig so `findUp` walks the targeted
+  // repo's tree.
+  applyRepoCwd(argv)
+
   const config = loadConfig<DoctorOptions, DoctorArgv>(argv)
   const sources = getConfigSources()
 

--- a/src/commands/init/handler.ts
+++ b/src/commands/init/handler.ts
@@ -15,10 +15,21 @@ import { CommandHandler } from '../../lib/types'
 import { Logger } from '../../lib/utils/logger'
 import { getPathToUsersGitConfig } from '../../lib/utils/getPathToUsersGitConfig'
 import { getProjectConfigFilePath } from '../../lib/utils/getProjectConfigFilePath'
+import { applyRepoCwd } from '../utils/applyRepoFlag'
 import { InitArgv, InitOptions } from './config'
 import { questions } from './questions'
 
 export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
+  // Honor the global --repo flag so `coco init --repo <X> --scope project`
+  // writes the project config to X, not the launcher's cwd. The
+  // chdir has to happen before getProjectConfigFilePath resolves
+  // its target path (it reads process.cwd).
+  //
+  // `InitArgv` is `Argv<InitOptions>['argv']` which yargs types as a
+  // union including Promise — pass just the `repo` field as a plain
+  // object so the helper's narrow signature stays clean.
+  applyRepoCwd({ repo: (argv as { repo?: string }).repo })
+
   const options = loadConfig<InitOptions, InitArgv>(argv)
 
   logger.log(LOGO)

--- a/src/commands/utils/applyRepoFlag.ts
+++ b/src/commands/utils/applyRepoFlag.ts
@@ -3,24 +3,38 @@ import { getRepo } from '../../lib/simple-git/getRepo'
 import { BaseArgvOptions } from '../types'
 
 /**
- * Apply the global `--repo <dir>` (alias `--cwd`) flag for any
- * command handler. Returns the bound simple-git instance.
+ * Apply the global `--repo <dir>` (alias `--cwd`) flag — the part
+ * that doesn't need git. Performs the chdir if the flag is set and
+ * returns the resolved absolute path (or `process.cwd()` when
+ * omitted).
  *
- * Behavior:
- *   - When `argv.repo` is set, resolves the path to absolute,
- *     `process.chdir`s up-front, and returns `getRepo(repoPath)`.
- *   - When omitted, returns `getRepo()` (defaults to cwd) — original
- *     behavior, no surprise for users on the `cd && coco ...` path.
+ * Use this from non-git commands (cache, doctor, init) where the
+ * full `applyRepoFlag` would allocate a SimpleGit instance the
+ * handler never touches.
  *
  * Why chdir up-front:
  *   Many config / discovery paths (loadConfig's findUp for
  *   `.coco.config.json`, commitlint config detection, etc.) read
- *   `process.cwd()` directly. If we only changed simple-git's
- *   baseDir without chdir-ing, those would resolve against the
- *   original cwd — leading to "coco is reading this repo but
- *   loading config from somewhere else" surprises.
+ *   `process.cwd()` directly. If we don't chdir, those would
+ *   resolve against the original cwd — leading to "coco is
+ *   reading config from somewhere else" surprises.
+ */
+export function applyRepoCwd(argv: Pick<BaseArgvOptions, 'repo'>): string {
+  if (!argv.repo) {
+    return process.cwd()
+  }
+  const repoPath = path.resolve(argv.repo)
+  process.chdir(repoPath)
+  return repoPath
+}
+
+/**
+ * Apply the global `--repo <dir>` flag for git-using commands.
+ * Performs the chdir AND returns a SimpleGit instance bound to the
+ * targeted path.
  *
- * Returns the SimpleGit instance so callers can use it directly:
+ * Composes `applyRepoCwd` so the chdir semantics are identical
+ * across git / non-git handlers.
  *
  * ```ts
  * export const handler: CommandHandler<CommitArgv> = async (argv) => {
@@ -31,10 +45,6 @@ import { BaseArgvOptions } from '../types'
  * ```
  */
 export function applyRepoFlag(argv: Pick<BaseArgvOptions, 'repo'>): ReturnType<typeof getRepo> {
-  if (!argv.repo) {
-    return getRepo()
-  }
-  const repoPath = path.resolve(argv.repo)
-  process.chdir(repoPath)
-  return getRepo(repoPath)
+  const repoPath = applyRepoCwd(argv)
+  return argv.repo ? getRepo(repoPath) : getRepo()
 }


### PR DESCRIPTION
Follow-up to #952 which lifted \`--repo\` to a global flag and wired it into the git-using commands (commit / log / ui / recap / changelog / review). This PR finishes the rollout — every coco subcommand now honors \`--repo\`.

## What this PR changes

Split the shared helper into two pieces so non-git commands don't pay for a SimpleGit instance they don't use:

- **\`applyRepoCwd(argv)\`** — chdir to the target path if \`--repo\` is set, return the resolved repo path. For \`cache\` / \`doctor\` / \`init\`.
- **\`applyRepoFlag(argv)\`** — composes \`applyRepoCwd\` + \`getRepo\`. Returns the bound SimpleGit instance. For git-using commands (unchanged callers).

Three handlers wired:

- **cache** — \`coco cache info --repo <X>\` reads X's cache, not the launcher's cwd. **Verified**: different repos produce different cache-path hashes.
- **doctor** — \`coco doctor --repo <X>\` walks X's config tree for findUp lookups (XDG / project / env) instead of the launcher's.
- **init** — \`coco init --repo <X> --scope project\` writes the project config to X.

## Verified

\`\`\`
$ coco cache info
No diff-summary cache for this repo (/Users/gfargo/.cache/coco/diff-summaries/summaries.b70c352353ae1c70.json)

$ coco cache info --repo /tmp/repo-flag-test
No diff-summary cache for this repo (/Users/gfargo/.cache/coco/diff-summaries/summaries.0d0edf6f23c306d0.json)
\`\`\`

Different hash for different repo — the chdir is correctly retargeting the cache lookup.

## InitArgv type quirk

\`InitArgv\` is \`Argv<InitOptions>['argv']\` which yargs types as a union including Promise. The other handlers use \`Arguments<...>\` (resolved type). Worked around by passing just the \`repo\` field as a plain object — keeps the helper's signature narrow without widening it across all callers.

## Status: complete

Every coco subcommand now honors \`--repo\`:

| Command | Status |
|---|---|
| commit | ✅ #952 |
| log | ✅ #952 |
| ui | ✅ #952 |
| recap | ✅ #952 |
| changelog | ✅ #952 |
| review | ✅ #952 |
| cache | ✅ this PR |
| doctor | ✅ this PR |
| init | ✅ this PR |

The flag is declared once at the yargs root, inherited by all subcommands via \`BaseArgvOptions\`, and acted on via the \`applyRepoCwd\` / \`applyRepoFlag\` helpers. Consistent behavior, single source of truth, easy to extend for any future command.

## Tests

- [x] \`npm run lint\` clean
- [x] \`tsc --noEmit\` clean
- [x] \`npm run test:jest\` — 1680 tests pass (one flaky parallel test unrelated)
- [x] Smoke-tested \`coco cache info --repo\` against a scenario dir
- [x] Smoke-tested \`coco doctor --repo\` against a scenario dir