### PR TITLE
docs: refresh README + CONTRIBUTING for 0.49.x workflow surfaces

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,20 @@ const repo = await spinUpScenario('two-commit-feature')
 
 See `src/lib/testUtils/README.md` for the full list of scenarios, the programmatic API, and the discipline for adding new scenarios.
 
+### Targeting an arbitrary repo without `cd`
+
+Every coco command (including `ui` / `log`) accepts a global `--repo <dir>` flag (alias `--cwd`). Useful when you want to drive coco against a checkout in another directory without changing your shell's working directory:
+
+```bash
+# Run the workstation against any project from your current shell
+node_modules/.bin/tsx src/index.ts ui --repo ~/work/some-other-project
+
+# Smoke-test commit message generation against an arbitrary repo
+node_modules/.bin/tsx src/index.ts commit --repo ~/work/some-other-project --dry-run
+```
+
+The handlers chdir to the targeted path up-front so config lookup, simple-git baseDir, commitlint discovery, and downstream path resolution all see the same root. Lives in `src/commands/utils/applyRepoFlag.ts` if you need to wire it into a new command.
+
 ## Documentation
 
 The GitHub wiki is the canonical source for user-facing documentation. The local wiki checkout lives at `.wiki/` and can be managed with:

--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ An AI-powered git assistant that generates meaningful commit messages, creates c
 **✨ Key Features:**
 
 - 🤖 **AI-Powered Commit Messages** - Generate contextual commits from your staged changes
-- 📋 **Conventional Commits** - Full support with automatic validation and formatting  
+- 📋 **Conventional Commits** - Full support with automatic validation and formatting (extends to `coco commit --split` too — every group's title respects the spec)
 - 🔧 **Commitlint Integration** - Seamless integration with your existing commitlint configuration
 - 🏠 **Local AI Support** - Run completely offline with Ollama (no API costs, full privacy)
-- 🖥️ **Coco UI Git Workstation** - Twelve top-level views (history, status, diff, compose, branches, tags, stash, worktrees, pull-request, conflicts, reflog, bisect) reachable via `g`-prefixed chords, with an interactive command palette (`:`), global search (`/`), and cross-view flows like compare-two-refs and the bisect decision keys
+- 🖥️ **Coco UI Git Workstation** - Thirteen top-level views (history, status, diff, compose, branches, tags, stash, worktrees, pull-request, conflicts, reflog, bisect, changelog) reachable via `g`-prefixed chords, with an interactive command palette (`:`), global search (`/`), and one-keystroke workflows: `S` split staged changes, `L` generate a changelog, `C` create a PR seeded from changelog, `E` open the commit draft in `$EDITOR`
+- 🎯 **`--repo <dir>` global flag** - Drive any coco command against any repository without `cd`-ing first
 - 📦 **Package Manager Friendly** - Works with npm, yarn, and pnpm
 - 👥 **Team Ready** - Shared configurations and enterprise deployment
 


### PR DESCRIPTION
Catches up the headline docs to what \`coco ui\` actually ships today.

## README.md

- "Twelve" → "Thirteen" top-level views (changelog view landed in 0.49.0 via #914)
- Adds the one-keystroke workflow line: \`S\` split / \`L\` changelog / \`C\` create-PR / \`E\` open-in-\$EDITOR
- Calls out the new global \`--repo <dir>\` / \`--cwd\` flag — drive any subcommand against any repo without \`cd\`
- Notes that conventional-commits formatting now extends to \`coco commit --split\` (every group's title respects the spec)

## CONTRIBUTING.md

New \`### Targeting an arbitrary repo without cd\` subsection under "Development Setup":

- Documents the global \`--repo\` flag for contributor smoke-testing
- Points at \`src/commands/utils/applyRepoFlag.ts\` for the helper any new command should wire through

Reinforces the "no cd needed" loop that's especially useful when validating changes against scenario dirs (\`npm run scenario create <name> -- --path <X>\` + \`coco ui --repo <X>\`).

## Compatibility

Docs only. No behavior changes. No code touched.

## Companion docs updates landing separately

This PR covers the two markdown files in the repo. The same session ships:
- **GitHub wiki** (\`.wiki/Coco-UI.md\`, \`Commit-Split.md\`, \`Command-Reference.md\`, \`Home.md\`, \`TUI-Navigation.md\`) — pushed to the \`coco.wiki\` repo as a separate commit
- **Marketing site** (\`.www/src/app/workstation/page.tsx\`) — pushed to the \`git-co.co\` repo as a separate commit