### PR TITLE
feat(parser): bundled tree-sitter TS/TSX parser via WASM (#933 phase 1.1)

### DIFF
--- a/bin/copyTreeSitterWasm.mjs
+++ b/bin/copyTreeSitterWasm.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Bundle tree-sitter `.wasm` files into the distribution (#933 phase 1.1).
+ *
+ * Runs as a postbuild step. Copies the bundled language parsers and the
+ * web-tree-sitter engine WASM from `node_modules/` (where they ship with
+ * their respective packages) into `dist/tree-sitter/` so the published
+ * npm tarball carries them. Runtime resolution in
+ * `src/lib/parsers/default/__tree_sitter__/runtime.ts` finds them
+ * relative to the running module's `__dirname`.
+ *
+ * Why a postbuild script instead of a rollup plugin: rollup is set up
+ * to bundle JS only; static assets like WASM are simpler to copy with
+ * a plain Node script than to wire through the plugin pipeline. The
+ * script lives in `bin/` next to the other CLI / build helpers.
+ *
+ * Languages bundled (phase 1.1):
+ *   - tree-sitter-typescript.wasm  (TS + TSX)
+ *   - tree-sitter-tsx.wasm
+ *   - web-tree-sitter.wasm         (the engine itself)
+ *
+ * JavaScript joins in phase 2; Python / Rust / Go ship via the lazy-
+ * load infrastructure in phase 3+ (no bundle step).
+ */
+
+import { existsSync, mkdirSync, copyFileSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const projectRoot = resolve(__dirname, '..')
+const targetDir = join(projectRoot, 'dist', 'tree-sitter')
+
+// Each entry: [source path relative to project root, destination filename]
+// The destination keeps the package's filename so runtime resolution
+// matches what web-tree-sitter expects for the engine WASM
+// (`web-tree-sitter.wasm` lives next to the JS module by default).
+const wasmFiles = [
+  ['node_modules/web-tree-sitter/web-tree-sitter.wasm', 'web-tree-sitter.wasm'],
+  ['node_modules/tree-sitter-typescript/tree-sitter-typescript.wasm', 'tree-sitter-typescript.wasm'],
+  ['node_modules/tree-sitter-typescript/tree-sitter-tsx.wasm', 'tree-sitter-tsx.wasm'],
+]
+
+mkdirSync(targetDir, { recursive: true })
+
+let copied = 0
+let totalBytes = 0
+for (const [srcRel, destName] of wasmFiles) {
+  const src = join(projectRoot, srcRel)
+  const dest = join(targetDir, destName)
+  if (!existsSync(src)) {
+    console.error(`! missing tree-sitter WASM source: ${srcRel}`)
+    process.exit(1)
+  }
+  copyFileSync(src, dest)
+  totalBytes += statSync(dest).size
+  copied += 1
+}
+
+const mb = (totalBytes / (1024 * 1024)).toFixed(2)
+console.log(`✓ copied ${copied} tree-sitter .wasm file(s) to dist/tree-sitter/ (${mb} MB total)`)

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dev": "tsx watch src/index.ts",
     "prebuild": "npm run build:schema && npm run build:info",
     "build": "rollup -c",
+    "postbuild": "node bin/copyTreeSitterWasm.mjs",
     "build:schema": "tsx bin/generateSchema.ts",
     "build:info": "tsx bin/generateBuildInfo.ts",
     "build:watch": "rollup -c -w",
@@ -83,6 +84,7 @@
     "rollup-plugin-preserve-shebangs": "^0.2.0",
     "rollup-plugin-typescript2": "^0.37.0",
     "rollup-plugin-visualizer": "^7.0.1",
+    "tree-sitter-typescript": "^0.23.2",
     "ts-jest": "^29.1.0",
     "ts-json-schema-generator": "^2.9.0",
     "ts-node": "^10.9.1",
@@ -111,6 +113,7 @@
     "react-devtools-core": "7.0.1",
     "simple-git": "3.36.0",
     "tiktoken": "^1.0.21",
+    "web-tree-sitter": "^0.26.8",
     "yargs": "17.7.2"
   },
   "resolutions": {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -21,6 +21,21 @@ const config = [
         sourcemap: enableBenchmarking,
         inlineDynamicImports: true,
         format: 'esm',
+        // ESM has no built-in `__dirname` — it's a CJS construct.
+        // The tree-sitter runtime (and any future filesystem-relative
+        // code) reads `__dirname` to locate bundled assets like
+        // `dist/tree-sitter/*.wasm`. This intro derives the equivalent
+        // from `import.meta.url` so source code can stay format-
+        // agnostic. The CJS output below gets `__dirname` for free
+        // and needs no shim. ts-jest tests compile to CJS so they
+        // also get `__dirname` natively. tsx (dev mode) provides
+        // its own `__dirname` shim. (#933 phase 1.1)
+        intro: [
+          "import { fileURLToPath as __cocoFileURLToPath } from 'node:url'",
+          "import { dirname as __cocoDirname } from 'node:path'",
+          "const __filename = __cocoFileURLToPath(import.meta.url)",
+          "const __dirname = __cocoDirname(__filename)",
+        ].join('\n'),
       },
       {
         file: 'dist/index.js',

--- a/src/lib/parsers/default/__tree_sitter__/runtime.ts
+++ b/src/lib/parsers/default/__tree_sitter__/runtime.ts
@@ -1,0 +1,225 @@
+/**
+ * web-tree-sitter runtime wrapper (#933 phase 1.1).
+ *
+ * Owns the engine lifecycle (one-time `Parser.init`) and the
+ * loaded-language cache (one `Language` per .wasm file, kept alive
+ * for the process). Consumers (the per-language `StructuralParser`
+ * implementations) ask for a parser via `getParser(language)` and
+ * get back a `{ parser, language }` pair ready to call `parse()` on,
+ * OR `undefined` when the .wasm files aren't available (dev mode
+ * before postbuild has run, or a future test runner) — letting the
+ * caller surrender to the regex parser in the registry chain.
+ *
+ * Path resolution: tree-sitter .wasm files are copied into
+ * `dist/tree-sitter/` by the `copyTreeSitterWasm.mjs` postbuild
+ * script. In a built dist this module sits at
+ * `dist/index.js` (rolled-up bundle), so the .wasm directory is
+ * one level down: `dist/tree-sitter/<lang>.wasm`. In dev (`tsx`
+ * running source files directly), the same relative layout works
+ * because tsx executes from the project root and `dist/tree-sitter`
+ * is the only known location either way.
+ *
+ * Lazy + memoized: the first call pays init + load; subsequent
+ * calls are free. Failure on first call (missing .wasm,
+ * Parser.init throws, etc.) caches the failure so we don't retry
+ * on every diff — the regex fallback is the correct steady state
+ * in that case.
+ */
+
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Dynamic-import shim. `web-tree-sitter` is `"type": "module"` (pure
+ * ESM); a bare `await import('web-tree-sitter')` gets rewritten by
+ * ts-jest's CJS transform into `await require('web-tree-sitter')`,
+ * which fails because `require()` can't load ESM-only packages.
+ * The `Function` constructor wraps the dynamic import in a string
+ * body that survives TS compilation untouched, so the actual
+ * `import()` call runs at runtime as native ESM dynamic import.
+ *
+ * Mirrors the pattern in `src/commands/log/inkRuntime.ts` and
+ * `src/lib/ui/inquirerPrompts.ts` — the codebase's standard escape
+ * hatch for ESM-only deps.
+ */
+type DynamicImport = <T>(specifier: string) => Promise<T>
+const dynamicImport = new Function('specifier', 'return import(specifier)') as DynamicImport
+
+/**
+ * Language identifiers this runtime knows how to load. Mirrors the
+ * .wasm files copied into `dist/tree-sitter/` by the postbuild
+ * script. Adding a language: drop the .wasm into the postbuild
+ * file list, add an entry here, then build a `<Lang>StructuralParser`
+ * against the runtime.
+ */
+export type TreeSitterLanguageId = 'typescript' | 'tsx'
+
+type ResolvedWasmLocations = {
+  enginePath: string
+  languagePaths: Record<TreeSitterLanguageId, string>
+}
+
+/**
+ * Locate the bundled .wasm files. Tries the dist layout first (the
+ * common case for installed packages), then falls back to the
+ * dev layout (running from source via tsx / ts-jest). Returns
+ * undefined when neither contains the engine .wasm — caller
+ * surrenders.
+ *
+ * Dual-format note: this module is bundled into BOTH the CJS output
+ * (`dist/index.js`) and the ESM output (`dist/index.esm.mjs`). We
+ * use `__dirname` at the source level because:
+ *   - CJS bundle: `__dirname` is a built-in.
+ *   - ESM bundle: rollup's `output.intro` for the .mjs target
+ *     injects a shim deriving `__dirname` from `import.meta.url`
+ *     (see rollup.config.mjs). Source code stays format-agnostic.
+ *   - ts-jest tests: compiled to CJS, `__dirname` is a built-in.
+ *   - tsx dev mode: tsx provides `__dirname` as a shim.
+ */
+function resolveWasmLocations(): ResolvedWasmLocations | undefined {
+  const here = __dirname
+
+  // Candidates in priority order. Each is a directory expected to
+  // contain `web-tree-sitter.wasm` + the language .wasm files.
+  // The dist layout is what `npm install -g coco` produces; the
+  // dev layout is what `npm run dev` / `tsx` / `ts-jest` runs
+  // against (resolving from the source module location).
+  const candidates: string[] = [
+    // Built dist: `dist/index.js` (or `dist/index.esm.mjs`) →
+    // `dist/tree-sitter/`
+    join(here, 'tree-sitter'),
+    // Dev layout (source running via tsx / ts-jest):
+    // `src/lib/parsers/default/__tree_sitter__/runtime.ts` →
+    // project root + `dist/tree-sitter/`
+    join(here, '..', '..', '..', '..', '..', 'dist', 'tree-sitter'),
+  ]
+
+  for (const dir of candidates) {
+    const enginePath = join(dir, 'web-tree-sitter.wasm')
+    if (!existsSync(enginePath)) continue
+    return {
+      enginePath,
+      languagePaths: {
+        typescript: join(dir, 'tree-sitter-typescript.wasm'),
+        tsx: join(dir, 'tree-sitter-tsx.wasm'),
+      },
+    }
+  }
+  return undefined
+}
+
+// Memoized init promise. Either resolves with the loaded module
+// surface or with `undefined` (a sentinel meaning "tree-sitter
+// isn't available; use the fallback"). The promise itself is
+// cached, so concurrent callers share the same init.
+let initPromise: Promise<TreeSitterRuntime | undefined> | undefined
+
+export type TreeSitterRuntime = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Parser: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Language: any
+  locations: ResolvedWasmLocations
+}
+
+async function ensureRuntime(): Promise<TreeSitterRuntime | undefined> {
+  if (initPromise) return initPromise
+  initPromise = (async () => {
+    const locations = resolveWasmLocations()
+    if (!locations) return undefined
+
+    let mod: { Parser: { init(opts?: unknown): Promise<void> }; Language: unknown }
+    try {
+      mod = await dynamicImport<{
+        Parser: { init(opts?: unknown): Promise<void> }
+        Language: unknown
+      }>('web-tree-sitter')
+    } catch {
+      return undefined
+    }
+
+    try {
+      // `locateFile` is the Emscripten hook that web-tree-sitter
+      // uses to find its own engine .wasm. By default it looks
+      // next to the JS module; we override so the dist layout
+      // (`dist/tree-sitter/web-tree-sitter.wasm`) is honored.
+      await mod.Parser.init({
+        locateFile: (file: string) => {
+          if (file.endsWith('.wasm')) return locations.enginePath
+          return file
+        },
+      })
+    } catch {
+      return undefined
+    }
+
+    return {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      Parser: (mod as any).Parser,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      Language: (mod as any).Language,
+      locations,
+    }
+  })()
+  return initPromise
+}
+
+// Per-language Parser cache. Keyed on language id; reused for the
+// life of the process. Parsers are stateless w.r.t. previous
+// parses, so sharing a single instance per language is safe.
+const parserCache = new Map<TreeSitterLanguageId, unknown>()
+
+export type LoadedParser = {
+  /** A `web-tree-sitter` Parser instance with the language attached. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  parser: any
+  language: TreeSitterLanguageId
+}
+
+/**
+ * Return a parser ready to parse the given language's source. The
+ * first call per-language pays the language .wasm load cost
+ * (~15ms); subsequent calls are free. Returns undefined when the
+ * .wasm files aren't available — callers surrender to the regex
+ * parser in the registry chain.
+ *
+ * Errors during load are swallowed and cached as "unavailable"
+ * for THIS language; other languages can still load independently.
+ */
+export async function getTreeSitterParser(
+  language: TreeSitterLanguageId,
+): Promise<LoadedParser | undefined> {
+  const runtime = await ensureRuntime()
+  if (!runtime) return undefined
+
+  const cached = parserCache.get(language)
+  if (cached) {
+    return { parser: cached, language }
+  }
+
+  const langWasmPath = runtime.locations.languagePaths[language]
+  if (!existsSync(langWasmPath)) {
+    parserCache.set(language, undefined as never)
+    return undefined
+  }
+
+  try {
+    const lang = await runtime.Language.load(langWasmPath)
+    const parser = new runtime.Parser()
+    parser.setLanguage(lang)
+    parserCache.set(language, parser)
+    return { parser, language }
+  } catch {
+    parserCache.set(language, undefined as never)
+    return undefined
+  }
+}
+
+/**
+ * Test seam — resets all memoized state so a test can simulate
+ * fresh init / load. NOT a public API.
+ */
+export function _resetTreeSitterRuntimeForTesting(): void {
+  initPromise = undefined
+  parserCache.clear()
+}

--- a/src/lib/parsers/default/__tree_sitter__/tsTreeSitterParser.test.ts
+++ b/src/lib/parsers/default/__tree_sitter__/tsTreeSitterParser.test.ts
@@ -1,0 +1,139 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import type { FileDiff } from '../../../types'
+import { treeSitterTsParser } from './tsTreeSitterParser'
+import { _resetTreeSitterRuntimeForTesting } from './runtime'
+
+function fileDiff(file: string, diff: string): FileDiff {
+  return { file, diff, summary: '', tokenCount: Math.ceil(diff.length / 4) }
+}
+
+// Tree-sitter integration tests require TWO things to actually exercise
+// the .wasm code path:
+//   1. The .wasm files copied into `dist/tree-sitter/` by the postbuild
+//      script (only present after `npm run build`).
+//   2. Jest running with `NODE_OPTIONS=--experimental-vm-modules` so the
+//      `web-tree-sitter` package (`"type": "module"`) can be loaded via
+//      the dynamic-import shim in `runtime.ts`. Without the flag, Jest
+//      throws "A dynamic import callback was invoked without
+//      --experimental-vm-modules" and the runtime surrenders.
+//
+// When either is missing, the suite skips itself — the production code
+// path (regex fallback) is still tested via the registry-level tests in
+// `structuralParserRegistry.test.ts`, and end-to-end tree-sitter
+// validation runs via the eval harness CLI (#934), which executes under
+// vanilla Node with full ESM support and is the right tool for
+// integration verification anyway.
+//
+// Opt in locally with:
+//   NODE_OPTIONS=--experimental-vm-modules COCO_TEST_TREE_SITTER=1 npx jest ...
+const wasmDir = join(__dirname, '..', '..', '..', '..', '..', 'dist', 'tree-sitter')
+const wasmAvailable = existsSync(join(wasmDir, 'web-tree-sitter.wasm')) &&
+  existsSync(join(wasmDir, 'tree-sitter-typescript.wasm')) &&
+  existsSync(join(wasmDir, 'tree-sitter-tsx.wasm'))
+const esmEnabled = process.env.COCO_TEST_TREE_SITTER === '1'
+
+const describeWithWasm = (wasmAvailable && esmEnabled) ? describe : describe.skip
+
+describeWithWasm('treeSitterTsParser (.wasm-backed)', () => {
+  beforeEach(() => {
+    // Each test gets a fresh runtime so we exercise the init path
+    // at least once and don't rely on inter-test cache state.
+    _resetTreeSitterRuntimeForTesting()
+  })
+
+  it('returns undefined for non-TS / non-JS file paths', async () => {
+    expect(await treeSitterTsParser.summarize(fileDiff('README.md', '+x'))).toBeUndefined()
+    expect(await treeSitterTsParser.summarize(fileDiff('lib.rs', '+pub fn foo() {}'))).toBeUndefined()
+  })
+
+  it('names a top-level export function (matches regex output)', async () => {
+    const diff = [
+      '@@ -1,1 +1,1 @@',
+      '-export function legacyParse() {}',
+      '+export function parseRequest(input: string) {}',
+    ].join('\n')
+    const out = await treeSitterTsParser.summarize(fileDiff('src/p.ts', diff)) || ''
+    expect(out).toContain('Updated TypeScript `src/p.ts`')
+    expect(out).toContain('parseRequest()')
+    expect(out).toContain('legacyParse()')
+  })
+
+  it('classifies an arrow-function export as a function, not a const (regex miss)', async () => {
+    // Regex extractor returns `const handler` for this line because
+    // the const-with-arrow shape isn't classified as a function.
+    // Tree-sitter sees the arrow_function in the declarator value
+    // and classifies the binding as a function, producing `handler()`
+    // in the summary instead.
+    const diff = [
+      '@@ -0,0 +1,1 @@',
+      '+export const handler = (req: Request) => process(req)',
+    ].join('\n')
+    const out = await treeSitterTsParser.summarize(fileDiff('src/api.ts', diff)) || ''
+    expect(out).toContain('Updated TypeScript `src/api.ts`')
+    expect(out).toMatch(/handler\(\)/)
+    expect(out).not.toMatch(/const handler/)
+  })
+
+  it('returns undefined for body-only edits (no structural signal)', async () => {
+    const diff = [
+      '@@ -1,3 +1,3 @@',
+      ' export function compute(x: number) {',
+      '-  return x * 2',
+      '+  return x * 3',
+      ' }',
+    ].join('\n')
+    expect(await treeSitterTsParser.summarize(fileDiff('src/util.ts', diff))).toBeUndefined()
+  })
+
+  it('handles TSX files via the tsx grammar', async () => {
+    // The tsx grammar parses JSX cleanly. The regex extractor doesn't
+    // recognize this as a top-level structural signal beyond the
+    // function declaration itself; tree-sitter agrees on the
+    // function name but won't trip on the JSX body.
+    const diff = [
+      '@@ -1,3 +1,3 @@',
+      '-export function OldButton() { return <div>old</div> }',
+      '+export function NewButton(props: Props) { return <button onClick={props.onClick}>{props.label}</button> }',
+    ].join('\n')
+    const out = await treeSitterTsParser.summarize(fileDiff('src/Button.tsx', diff)) || ''
+    expect(out).toContain('Updated TypeScript `src/Button.tsx`')
+    expect(out).toMatch(/NewButton\(\)/)
+    expect(out).toMatch(/OldButton\(\)/)
+  })
+
+  it('catches class declarations and interfaces', async () => {
+    const diff = [
+      '@@ -0,0 +1,3 @@',
+      '+export class Widget {}',
+      '+export interface Renderable {}',
+      '+export type Handler = (req: Request) => Response',
+    ].join('\n')
+    const out = await treeSitterTsParser.summarize(fileDiff('src/api.ts', diff)) || ''
+    expect(out).toMatch(/class Widget/)
+    expect(out).toMatch(/interface Renderable/)
+    expect(out).toMatch(/type Handler/)
+  })
+
+  it('ignores keywords inside string literals (regex false-positive case)', async () => {
+    // The regex parser would NOT actually trip on this line (its
+    // pattern requires a leading word boundary) but tree-sitter
+    // guarantees correctness — this test pins the AST-awareness
+    // expectation in place so future regex tweaks don't regress.
+    const diff = [
+      '@@ -0,0 +1,1 @@',
+      '+const ban = "function exfiltrate() {}"',
+    ].join('\n')
+    const out = await treeSitterTsParser.summarize(fileDiff('src/x.ts', diff))
+    // We expect either undefined (no top-level function detected)
+    // or a `const ban` entry — we should NOT see an `exfiltrate()`
+    // entry in the summary.
+    if (out) expect(out).not.toContain('exfiltrate')
+  })
+})
+
+describe('treeSitterTsParser (wasm-missing fallthrough)', () => {
+  it('id is reported as tree-sitter regardless of runtime state', () => {
+    expect(treeSitterTsParser.id).toBe('tree-sitter')
+  })
+})

--- a/src/lib/parsers/default/__tree_sitter__/tsTreeSitterParser.ts
+++ b/src/lib/parsers/default/__tree_sitter__/tsTreeSitterParser.ts
@@ -1,0 +1,225 @@
+/**
+ * Tree-sitter TS / TSX / JS structural parser (#933 phase 1.1).
+ *
+ * Plugs into the structural parser registry as the priority parser
+ * for `ts` and `js`. Returns undefined when the .wasm files aren't
+ * loaded, surrendering to the regex parser in the chain — the user-
+ * facing behavior matches the regex case when tree-sitter is
+ * unavailable.
+ *
+ * What it catches that the regex doesn't:
+ *
+ *   - Arrow-function exports (`export const foo = () => { }`)
+ *     The regex captures `foo` as a `const`; tree-sitter sees the
+ *     arrow function value and classifies it as a function so the
+ *     summary reads `foo()` instead of `const foo`.
+ *   - String-embedded keywords. A line like `const x = "function fake() {}"`
+ *     trips the regex into a false positive; tree-sitter knows the
+ *     `function` keyword is inside a string literal and skips it.
+ *   - JSX-in-TSX. The TSX grammar parses `<Component prop={value} />`
+ *     cleanly while the regex would see nothing.
+ *
+ * What stays the same:
+ *
+ *   - Output shape — produces the same `StructuralSymbol[]` the
+ *     regex parser does, fed through the shared
+ *     `summarizeStructuralDiff` scaffolding. Caller sees identical
+ *     summary text for cases both extractors handle.
+ *   - Per-line operation. We parse each `+` / `-` line as a
+ *     standalone snippet. Tree-sitter recovers gracefully from the
+ *     incomplete code (missing function body, dangling commas)
+ *     because it always returns a partial parse with ERROR nodes
+ *     mixed in. Multi-line declarations are NOT yet handled — phase
+ *     1.2 will reconstruct the after-state for that. Today the
+ *     regex fallback covers any case tree-sitter misses on a single
+ *     line.
+ */
+
+import type { FileDiff } from '../../../types'
+import type {
+  StructuralParser,
+  StructuralParserKind,
+} from '../utils/structuralParserRegistry'
+import type { StructuralSymbol } from '../utils/structuralDiff'
+import { summarizeStructuralDiff } from '../utils/structuralDiff'
+import { detectTsLanguage } from '../utils/tsStructuralDiff'
+import { getTreeSitterParser, type TreeSitterLanguageId } from './runtime'
+
+const PARSER_KIND: StructuralParserKind = 'tree-sitter'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type TSNode = any
+
+/**
+ * Map a coco language identifier (the `'ts'`/`'js'` from the
+ * registry) to the tree-sitter grammar to use. TSX files prefer
+ * the tsx grammar; everything else uses the typescript grammar
+ * (which handles plain JS too — tree-sitter-typescript is a
+ * superset).
+ */
+function grammarFor(filePath: string): TreeSitterLanguageId {
+  return filePath.toLowerCase().endsWith('.tsx') ||
+    filePath.toLowerCase().endsWith('.jsx')
+    ? 'tsx'
+    : 'typescript'
+}
+
+/**
+ * Walk an export_statement / lexical_declaration / function_declaration
+ * / class_declaration / interface_declaration / type_alias_declaration
+ * / enum_declaration node and produce a `StructuralSymbol` describing
+ * it.
+ *
+ * Returns undefined when the node isn't a recognized top-level
+ * declaration kind. The caller falls back to the regex parser via
+ * the registry chain in that case.
+ */
+function symbolFromTopLevelNode(node: TSNode): StructuralSymbol | undefined {
+  // `export_statement` wraps the actual declaration. Recurse one
+  // level in and tag the result as exported.
+  if (node.type === 'export_statement') {
+    // `export default` — the declaration may be anonymous.
+    if (node.text.startsWith('export default')) {
+      return defaultExportSymbol(node)
+    }
+    const inner = node.namedChildren.find((c: TSNode) => c.type !== 'export_clause')
+    if (!inner) return undefined
+    const sym = symbolFromTopLevelNode(inner)
+    if (!sym) return undefined
+    return { ...sym, exported: true }
+  }
+
+  if (node.type === 'function_declaration') {
+    const name = nameOfChild(node, 'name') || nameOfChild(node, 'identifier')
+    if (!name) return undefined
+    return { name, kind: 'function', exported: false }
+  }
+
+  if (node.type === 'class_declaration') {
+    const name = nameOfChild(node, 'name')
+    if (!name) return undefined
+    return { name, kind: 'class', exported: false }
+  }
+
+  if (node.type === 'interface_declaration') {
+    const name = nameOfChild(node, 'name')
+    if (!name) return undefined
+    return { name, kind: 'interface', exported: false }
+  }
+
+  if (node.type === 'type_alias_declaration') {
+    const name = nameOfChild(node, 'name')
+    if (!name) return undefined
+    return { name, kind: 'type', exported: false }
+  }
+
+  if (node.type === 'enum_declaration') {
+    const name = nameOfChild(node, 'name')
+    if (!name) return undefined
+    return { name, kind: 'enum', exported: false }
+  }
+
+  // `lexical_declaration` is `const`/`let` (and `var_declaration`
+  // for `var`). Walk to the first variable_declarator. If its value
+  // is an arrow function or function expression, classify the
+  // binding as a function — this is the marquee improvement over
+  // the regex extractor.
+  if (node.type === 'lexical_declaration' || node.type === 'variable_declaration') {
+    const declarator = node.namedChildren.find(
+      (c: TSNode) => c.type === 'variable_declarator',
+    )
+    if (!declarator) return undefined
+    const nameNode = declarator.namedChildren.find((c: TSNode) => c.type === 'identifier')
+    if (!nameNode) return undefined
+    const name = nameNode.text
+    const value = declarator.namedChildren.find(
+      (c: TSNode) => c.type === 'arrow_function' || c.type === 'function_expression' ||
+        c.type === 'function',
+    )
+    if (value) {
+      return { name, kind: 'function', exported: false }
+    }
+    return { name, kind: 'const', exported: false }
+  }
+
+  return undefined
+}
+
+function defaultExportSymbol(node: TSNode): StructuralSymbol {
+  // `export default function foo` / `export default class Foo`
+  // carry an inner declaration whose name we can use; anonymous
+  // defaults (`export default function () {}`, `export default {}`)
+  // get the literal `default` name. Walk one level in to look.
+  const inner = node.namedChildren.find((c: TSNode) => c.type !== 'export_clause')
+  if (inner) {
+    if (inner.type === 'function_declaration' || inner.type === 'class_declaration') {
+      const named = nameOfChild(inner, 'name')
+      if (named) return { name: named, kind: 'default', exported: true }
+    }
+  }
+  return { name: 'default', kind: 'default', exported: true }
+}
+
+function nameOfChild(node: TSNode, fieldName: string): string | undefined {
+  const child = node.childForFieldName?.(fieldName) ||
+    node.namedChildren.find((c: TSNode) => c.type === 'identifier' || c.type === 'type_identifier')
+  return child?.text
+}
+
+/**
+ * Per-line extractor. Parses the line as TS source, walks the
+ * first-level children, returns the symbol for the first
+ * recognized top-level declaration.
+ *
+ * Tree-sitter's error recovery means a partial line like
+ * `export function foo(input: string,` parses cleanly into a
+ * function_declaration with the parameters available. We don't
+ * fail on incomplete input.
+ */
+function extractSymbolFromLine(parser: TSNode, line: string): StructuralSymbol | undefined {
+  // Empty / whitespace-only — no symbol.
+  if (!line.trim()) return undefined
+  // Lines starting with whitespace are body lines, not top-level —
+  // matches the regex extractor's `leadingIndent > 1` gate. We're
+  // strict here so we don't surface method names from inside a
+  // class body as if they were top-level functions.
+  if (line.startsWith(' ') || line.startsWith('\t')) return undefined
+
+  let tree: TSNode
+  try {
+    tree = parser.parse(line)
+  } catch {
+    return undefined
+  }
+  if (!tree) return undefined
+
+  const program = tree.rootNode
+  for (const child of program.namedChildren as TSNode[]) {
+    const symbol = symbolFromTopLevelNode(child)
+    if (symbol) return symbol
+  }
+  return undefined
+}
+
+/**
+ * The actual parser instance. Captures the loaded tree-sitter
+ * Parser in a closure so the per-line callback the shared
+ * `summarizeStructuralDiff` calls is sync — required because the
+ * scaffolding walks the diff synchronously once it has the
+ * callback.
+ */
+export const treeSitterTsParser: StructuralParser = {
+  id: PARSER_KIND,
+  async summarize(fileDiff: FileDiff): Promise<string | undefined> {
+    const language = detectTsLanguage(fileDiff.file)
+    if (!language) return undefined
+
+    const loaded = await getTreeSitterParser(grammarFor(fileDiff.file))
+    if (!loaded) return undefined
+
+    return summarizeStructuralDiff(fileDiff, {
+      label: language === 'ts' ? 'TypeScript' : 'JavaScript',
+      parseLine: (line) => extractSymbolFromLine(loaded.parser, line),
+    })
+  },
+}

--- a/src/lib/parsers/default/utils/structuralParserRegistry.ts
+++ b/src/lib/parsers/default/utils/structuralParserRegistry.ts
@@ -25,6 +25,7 @@
  */
 
 import type { FileDiff } from '../../../types'
+import { treeSitterTsParser } from '../__tree_sitter__/tsTreeSitterParser'
 import { summarizeGoStructuralDiff } from './goStructuralDiff'
 import { summarizePythonStructuralDiff } from './pythonStructuralDiff'
 import { summarizeRustStructuralDiff } from './rustStructuralDiff'
@@ -85,14 +86,16 @@ const regexRs = regexParser(summarizeRustStructuralDiff)
 const regexGo = regexParser(summarizeGoStructuralDiff)
 
 /**
- * Per-language parser chains, in priority order. Phase 1.0 has
- * only regex parsers; phase 1.1 will prepend tree-sitter parsers
- * for `ts` and `js`. Later phases add tree-sitter for the lazy-
- * loaded languages.
+ * Per-language parser chains, in priority order. Tree-sitter is
+ * preferred for `ts` and `js` (phase 1.1); when the .wasm files
+ * aren't loaded the tree-sitter parser surrenders to the regex
+ * parser without any caller-visible change. Lazy-loaded languages
+ * (Python / Rust / Go) get their tree-sitter parsers prepended in
+ * phase 4–6 as their lazy-load infrastructure lands.
  */
 const REGISTRY: Record<StructuralLanguageId, StructuralParser[]> = {
-  ts: [regexTs],
-  js: [regexJs],
+  ts: [treeSitterTsParser, regexTs],
+  js: [treeSitterTsParser, regexJs],
   py: [regexPy],
   rs: [regexRs],
   go: [regexGo],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,7 +4,7 @@
 
 "@alcalzone/ansi-tokenize@^0.3.0":
   version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.3.0.tgz#8216cc5f2f34ef4a8266d2407e7e3b70ba20e0f6"
+  resolved "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.3.0.tgz"
   integrity sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==
   dependencies:
     ansi-styles "^6.2.1"
@@ -20,21 +20,12 @@
 
 "@anthropic-ai/sdk@^0.90.0":
   version "0.90.0"
-  resolved "https://registry.yarnpkg.com/@anthropic-ai/sdk/-/sdk-0.90.0.tgz#99a89683a3c2c7297e04e72f62640cb04c3da21d"
+  resolved "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz"
   integrity sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==
   dependencies:
     json-schema-to-ts "^3.1.1"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz"
-  integrity sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.27.1"
-    js-tokens "^4.0.0"
-    picocolors "^1.1.1"
-
-"@babel/code-frame@^7.29.0":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.27.1", "@babel/code-frame@^7.29.0":
   version "7.29.0"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz"
   integrity sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==
@@ -113,12 +104,7 @@
     "@babel/helper-validator-identifier" "^7.27.1"
     "@babel/traverse" "^7.27.3"
 
-"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.8.0":
-  version "7.24.8"
-  resolved "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz"
-  integrity sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==
-
-"@babel/helper-plugin-utils@^7.27.1":
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.27.1", "@babel/helper-plugin-utils@^7.8.0":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz"
   integrity sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==
@@ -128,12 +114,7 @@
   resolved "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz"
   integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
 
-"@babel/helper-validator-identifier@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz"
-  integrity sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==
-
-"@babel/helper-validator-identifier@^7.28.5":
+"@babel/helper-validator-identifier@^7.27.1", "@babel/helper-validator-identifier@^7.28.5":
   version "7.28.5"
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz"
   integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
@@ -277,15 +258,10 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/runtime@^7.14.0":
+"@babel/runtime@^7.14.0", "@babel/runtime@^7.18.3":
   version "7.28.2"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz"
   integrity sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==
-
-"@babel/runtime@^7.18.3":
-  version "7.28.4"
-  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz"
-  integrity sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==
 
 "@babel/template@^7.27.2":
   version "7.27.2"
@@ -329,7 +305,7 @@
 
 "@commitlint/config-validator@^21.0.0":
   version "21.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/config-validator/-/config-validator-21.0.0.tgz#8976991244135efc5225701fa834c729b1c827e6"
+  resolved "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-21.0.0.tgz"
   integrity sha512-v0UplTYryNUB463X5WrelzKq5/qyYm9/iUNk38S7ZLnd56Uuk2T9awhYKGlgD2/4L5YuN2gsKkyy4EHpRPPz2Q==
   dependencies:
     "@commitlint/types" "^21.0.0"
@@ -337,7 +313,7 @@
 
 "@commitlint/core@^21.0.0":
   version "21.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/core/-/core-21.0.0.tgz#87b611e0baf5e334133dd440869fed86b449e211"
+  resolved "https://registry.npmjs.org/@commitlint/core/-/core-21.0.0.tgz"
   integrity sha512-KcPKFyp738aCJ61FxtHfhzHBLhWHGbA6zPcHlok+A0Qj7uHBAQ0sadva31xkc48s+3X3r5eHrI9zTTZe7YHoKQ==
   dependencies:
     "@commitlint/format" "^21.0.0"
@@ -347,7 +323,7 @@
 
 "@commitlint/ensure@^21.0.0":
   version "21.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/ensure/-/ensure-21.0.0.tgz#8bb8335048ca1889256116ad388f92f5bab1163b"
+  resolved "https://registry.npmjs.org/@commitlint/ensure/-/ensure-21.0.0.tgz"
   integrity sha512-n+OYs0Ws9GKC2WlmAeLNoPz9CUg6n/ZyYMkFF8rJ0aMn2kDTDTG0VqK/2Dco0EB4fhuF3JPIllJmU9/LKTl4aw==
   dependencies:
     "@commitlint/types" "^21.0.0"
@@ -355,12 +331,12 @@
 
 "@commitlint/execute-rule@^21.0.0":
   version "21.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/execute-rule/-/execute-rule-21.0.0.tgz#40afe10fc60933bef7154dc30b00f502b1e12304"
+  resolved "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-21.0.0.tgz"
   integrity sha512-3OhTq2gQX1tEheMsbDNqxfcNHsAM6g9cub9plf05I9jCxtbNfn8Y+mhClKyUwhX4dbtmC4OLZ9i+HNmoL1aksA==
 
 "@commitlint/format@^21.0.0":
   version "21.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/format/-/format-21.0.0.tgz#ee3d002fcc6c37abed1f8d520989754616302fe0"
+  resolved "https://registry.npmjs.org/@commitlint/format/-/format-21.0.0.tgz"
   integrity sha512-RTfGSrueEgofs1piqwi42U05d85wfxiMH2ncMCZnltx1XqPR3N2S48oACBtTy4xRAhWlf5XlHkK2RaDzEQu3dA==
   dependencies:
     "@commitlint/types" "^21.0.0"
@@ -368,7 +344,7 @@
 
 "@commitlint/is-ignored@^21.0.0":
   version "21.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/is-ignored/-/is-ignored-21.0.0.tgz#738e6142c403bf939cf6e2d1f8b33c78f5a8d714"
+  resolved "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.0.0.tgz"
   integrity sha512-K3SaaOTVY9VKhge7vl0R3ng7GENRzJQ9MPV43Tu53kAwEgSx/E0HF4US3AcVqdvlvsDUbF2yXvED95dhela83w==
   dependencies:
     "@commitlint/types" "^21.0.0"
@@ -376,7 +352,7 @@
 
 "@commitlint/lint@^21.0.0":
   version "21.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/lint/-/lint-21.0.0.tgz#218f2febad6abc6000c6393f985e93a3df67c7be"
+  resolved "https://registry.npmjs.org/@commitlint/lint/-/lint-21.0.0.tgz"
   integrity sha512-dlUJA0Ka14R1YaR46JVRWE3m/8dOQAgE/D0heUfzYua5Jogtq/zzu2ITAIaB/u25DaKjtEO6kuvASzsFDyrPMw==
   dependencies:
     "@commitlint/is-ignored" "^21.0.0"
@@ -386,7 +362,7 @@
 
 "@commitlint/load@^21.0.0":
   version "21.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/load/-/load-21.0.0.tgz#9de58aef5c9524b55bccff3a30127ff247cd565b"
+  resolved "https://registry.npmjs.org/@commitlint/load/-/load-21.0.0.tgz"
   integrity sha512-l0nBfO/20PKcJXHZqDIgh7kw/TWVVwn8zZJOkVGBK/ig/h328jBu9jK7OiDl2oZr5mLphmKGjYDR2ffEyb2lIA==
   dependencies:
     "@commitlint/config-validator" "^21.0.0"
@@ -401,12 +377,12 @@
 
 "@commitlint/message@^21.0.0":
   version "21.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/message/-/message-21.0.0.tgz#66fa96bf07bf261902060cbe309b58d3f66bb343"
+  resolved "https://registry.npmjs.org/@commitlint/message/-/message-21.0.0.tgz"
   integrity sha512-+daU92JaOHhI2En9KcH+2mvZGJ6D4YSxb/32QDwqkOwSj1Vanjio8PbAqX7dneACdg6B7RgQ7i3mpyYZAws4nw==
 
 "@commitlint/parse@^21.0.0":
   version "21.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/parse/-/parse-21.0.0.tgz#0a49dfa9e6c75499a6072ae562f0893f9880d705"
+  resolved "https://registry.npmjs.org/@commitlint/parse/-/parse-21.0.0.tgz"
   integrity sha512-1dbvFBcQK79aTbpc2QCrgEDc6/MMkQ0Mdz4gGmYkN4AHMnAK9HesSewTHqGTrW5mALrMlYSgcWyvKjloY2w19A==
   dependencies:
     "@commitlint/types" "^21.0.0"
@@ -415,7 +391,7 @@
 
 "@commitlint/read@^21.0.0":
   version "21.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/read/-/read-21.0.0.tgz#325f32ad1a92f11e8e373b2742f564e2422303f0"
+  resolved "https://registry.npmjs.org/@commitlint/read/-/read-21.0.0.tgz"
   integrity sha512-8VKLKLl2vBSKoTMm1LwcySsyxrBeotnqcT5qJi9pPuPfqSapdAD870Ckgh79c41UFywL6kMqtiyY+kxtfcqZGg==
   dependencies:
     "@commitlint/top-level" "^21.0.0"
@@ -425,7 +401,7 @@
 
 "@commitlint/resolve-extends@^21.0.0":
   version "21.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/resolve-extends/-/resolve-extends-21.0.0.tgz#d35ecd7470f20250c24c5301f72a4a5fb9701923"
+  resolved "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.0.0.tgz"
   integrity sha512-hrJYSZRpmecmSoxYrpuJ/1Q4J9JHt4AVVtr5/Ac6upLO/jJ1DnIm2AjD+38gru3KGOec4aHCVqETuWWLJhydWw==
   dependencies:
     "@commitlint/config-validator" "^21.0.0"
@@ -436,7 +412,7 @@
 
 "@commitlint/rules@^21.0.0":
   version "21.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/rules/-/rules-21.0.0.tgz#12de94939663889b560f9c8ea0b6c1baed215c50"
+  resolved "https://registry.npmjs.org/@commitlint/rules/-/rules-21.0.0.tgz"
   integrity sha512-NgQhX1qENA+rbrMw5KKyvVZpZG4D/0wgK8Z4INtcwKbfKtVDFMbn0oNc/Rs8wdyBPBj7ue8Lo/GllUL2Mqjwkg==
   dependencies:
     "@commitlint/ensure" "^21.0.0"
@@ -446,19 +422,19 @@
 
 "@commitlint/to-lines@^21.0.0":
   version "21.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/to-lines/-/to-lines-21.0.0.tgz#a094c2b7a499da1a3064b697d2030d9ed30b74f4"
+  resolved "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-21.0.0.tgz"
   integrity sha512-qMwvrJK/x3dPcXsIAtQAMKV5Q0wTioyqyHKR06vVN4wmBF4cCrrLq5x81FDeY3Ba+GWgDt0/P3Zw/IHGM8lwgg==
 
 "@commitlint/top-level@^21.0.0":
   version "21.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/top-level/-/top-level-21.0.0.tgz#1a1355462d7108cbdbd5cd10797387218b5e32ed"
+  resolved "https://registry.npmjs.org/@commitlint/top-level/-/top-level-21.0.0.tgz"
   integrity sha512-8jPqyWZueuN4hU6/ArKVsZ6i8xWtjIrbzHEOaLaTGUfjhhbZNBfXef/DGjzxy55hAv3yFNxHLINfI1bCJ0/MzA==
   dependencies:
     escalade "^3.2.0"
 
 "@commitlint/types@^20.5.0":
   version "20.5.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/types/-/types-20.5.0.tgz#65be36ca38183757563bd69451dbe465a5d001ef"
+  resolved "https://registry.npmjs.org/@commitlint/types/-/types-20.5.0.tgz"
   integrity sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA==
   dependencies:
     conventional-commits-parser "^6.3.0"
@@ -466,7 +442,7 @@
 
 "@commitlint/types@^21.0.0":
   version "21.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/types/-/types-21.0.0.tgz#3c22abea1300956d594065490131fbecebe171da"
+  resolved "https://registry.npmjs.org/@commitlint/types/-/types-21.0.0.tgz"
   integrity sha512-6nEz+M7I90iix4sviA8NLwskOuyt0M98KUU2aYgiKbn46jMSxUm1l2ACtzRd9ec+y38aKyJhW4Fp6NW0z35kJQ==
   dependencies:
     conventional-commits-parser "^6.3.0"
@@ -474,7 +450,7 @@
 
 "@conventional-changelog/git-client@^2.6.0":
   version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@conventional-changelog/git-client/-/git-client-2.7.0.tgz#07ea8202fd822e71d32c54aaed08b2c5ae9cc7c2"
+  resolved "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz"
   integrity sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==
   dependencies:
     "@simple-libs/child-process-utils" "^1.0.0"
@@ -489,17 +465,17 @@
     "@jridgewell/trace-mapping" "0.3.9"
 
 "@emnapi/core@^1.4.3":
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.2.tgz#3870265ecffc7352d01ead62d8d83d8358a2d034"
-  integrity sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.10.0.tgz#380ccc8f2412ea22d1d972df7f8ee23a3b9c7467"
+  integrity sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==
   dependencies:
     "@emnapi/wasi-threads" "1.2.1"
     tslib "^2.4.0"
 
 "@emnapi/runtime@^1.4.3":
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.9.2.tgz#8b469a3db160817cadb1de9050211a9d1ea84fa2"
-  integrity sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.10.0.tgz#4b260c0d3534204e98c6110b8db1a987d26ec87c"
+  integrity sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==
   dependencies:
     tslib "^2.4.0"
 
@@ -532,7 +508,7 @@
 
 "@esbuild/darwin-arm64@0.27.3":
   version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz#9f6cac72b3a8532298a6a4493ed639a8988e8abd"
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz"
   integrity sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==
 
 "@esbuild/darwin-x64@0.27.3":
@@ -592,7 +568,7 @@
 
 "@esbuild/linux-x64@0.27.3":
   version "0.27.3"
-  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz#12383dcbf71b7cf6513e58b4b08d95a710bf52a5"
   integrity sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==
 
 "@esbuild/netbsd-arm64@0.27.3":
@@ -693,12 +669,12 @@
 
 "@inquirer/ansi@^2.0.5":
   version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@inquirer/ansi/-/ansi-2.0.5.tgz#7b7e121f6a0c40128711daf20325e6ff2cdff8b7"
+  resolved "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz"
   integrity sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==
 
 "@inquirer/checkbox@^5.1.4":
   version "5.1.4"
-  resolved "https://registry.yarnpkg.com/@inquirer/checkbox/-/checkbox-5.1.4.tgz#dd209aec1a37cb2e0bfa1ee216b310176d3c6dbf"
+  resolved "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.4.tgz"
   integrity sha512-w6KF8ZYRvqHhROkOTHXYC3qIV/KYEu5o12oLqQySvch61vrYtRxNSHTONSdJqWiFJPlCUQAHT5OgOIyuTr+MHQ==
   dependencies:
     "@inquirer/ansi" "^2.0.5"
@@ -708,7 +684,7 @@
 
 "@inquirer/confirm@^6.0.12":
   version "6.0.12"
-  resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-6.0.12.tgz#7a317aec813214cec2f5339b9fa0926c20bf0dbe"
+  resolved "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.12.tgz"
   integrity sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==
   dependencies:
     "@inquirer/core" "^11.1.9"
@@ -716,7 +692,7 @@
 
 "@inquirer/core@^11.1.9":
   version "11.1.9"
-  resolved "https://registry.yarnpkg.com/@inquirer/core/-/core-11.1.9.tgz#97f099f5217f50f168c12db00ac07f51ab550fbb"
+  resolved "https://registry.npmjs.org/@inquirer/core/-/core-11.1.9.tgz"
   integrity sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==
   dependencies:
     "@inquirer/ansi" "^2.0.5"
@@ -729,7 +705,7 @@
 
 "@inquirer/editor@^5.1.1":
   version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@inquirer/editor/-/editor-5.1.1.tgz#dd36105ee655c1951f3300f84a2ed0bb188e3b1b"
+  resolved "https://registry.npmjs.org/@inquirer/editor/-/editor-5.1.1.tgz"
   integrity sha512-6y11LgmNpmn5D2aB5FgnCfBUBK8ZstwLCalyJmORcJZ/WrhOjm16mu6eSqIx8DnErxDqSLr+Jkp+GP8/Nwd5tA==
   dependencies:
     "@inquirer/core" "^11.1.9"
@@ -738,7 +714,7 @@
 
 "@inquirer/expand@^5.0.13":
   version "5.0.13"
-  resolved "https://registry.yarnpkg.com/@inquirer/expand/-/expand-5.0.13.tgz#86f1310d6dd389e8f94af8781b8ca62ed8e53f0d"
+  resolved "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.13.tgz"
   integrity sha512-dF2zvrFo9LshkcB23/O1il13kBkBltWIXzut1evfbuBLXMiGIuC45c+ZQ0uukjCDsvI8OWqun4FRYMnzFCQa3g==
   dependencies:
     "@inquirer/core" "^11.1.9"
@@ -746,7 +722,7 @@
 
 "@inquirer/external-editor@^3.0.0":
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@inquirer/external-editor/-/external-editor-3.0.0.tgz#915e7d3f808e3d2213c4fe0f525dcd7ea890e78a"
+  resolved "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.0.tgz"
   integrity sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg==
   dependencies:
     chardet "^2.1.1"
@@ -754,12 +730,12 @@
 
 "@inquirer/figures@^2.0.5":
   version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@inquirer/figures/-/figures-2.0.5.tgz#d12f4889ac6ea7731ebc52bd9c066ca51d8fdee7"
+  resolved "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz"
   integrity sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==
 
 "@inquirer/input@^5.0.12":
   version "5.0.12"
-  resolved "https://registry.yarnpkg.com/@inquirer/input/-/input-5.0.12.tgz#3da22915b88867b0474d2ca6306616e38ba3942d"
+  resolved "https://registry.npmjs.org/@inquirer/input/-/input-5.0.12.tgz"
   integrity sha512-uiMFBl4LqFzJClh80Q3f9hbOFJ6kgkDWI4LjAeBuyO6EanVVMF69AgOvpi1qdqjDSjDN6578B6nky9ceEpI+1Q==
   dependencies:
     "@inquirer/core" "^11.1.9"
@@ -767,7 +743,7 @@
 
 "@inquirer/number@^4.0.12":
   version "4.0.12"
-  resolved "https://registry.yarnpkg.com/@inquirer/number/-/number-4.0.12.tgz#964a68783c55fc2a9a0bce5a0ebd6f17818a79a6"
+  resolved "https://registry.npmjs.org/@inquirer/number/-/number-4.0.12.tgz"
   integrity sha512-/vrwhEf7Xsuh+YlHF4IjSy3g1cyrQuPaSiHIxCEbLu8qnfvrcvJyCkoktOOF+xV9gSb77/G0n3h04RbMDW2sIg==
   dependencies:
     "@inquirer/core" "^11.1.9"
@@ -775,7 +751,7 @@
 
 "@inquirer/password@^5.0.12":
   version "5.0.12"
-  resolved "https://registry.yarnpkg.com/@inquirer/password/-/password-5.0.12.tgz#c1dcf197258a8cfba800325b78287fa55a5a3ef8"
+  resolved "https://registry.npmjs.org/@inquirer/password/-/password-5.0.12.tgz"
   integrity sha512-CBh7YHju623lxJRcAOo498ZUwIuMy63bqW/vVq0tQAZVv+lkWlHkP9ealYE1utWSisEShY5VMdzIXRmyEODzcQ==
   dependencies:
     "@inquirer/ansi" "^2.0.5"
@@ -784,7 +760,7 @@
 
 "@inquirer/prompts@8.4.2":
   version "8.4.2"
-  resolved "https://registry.yarnpkg.com/@inquirer/prompts/-/prompts-8.4.2.tgz#725131d95853b2afe610bdbd945ca10f093a1de8"
+  resolved "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.2.tgz"
   integrity sha512-XJmn/wY4AX56l1BRU+ZjDrFtg9+2uBEi4JvJQj82kwJDQKiPgSn4CEsbfGGygS4Gw6rkL4W18oATjfVfaqub2Q==
   dependencies:
     "@inquirer/checkbox" "^5.1.4"
@@ -800,7 +776,7 @@
 
 "@inquirer/rawlist@^5.2.8":
   version "5.2.8"
-  resolved "https://registry.yarnpkg.com/@inquirer/rawlist/-/rawlist-5.2.8.tgz#38e17d3967cbe03555a8bfff405d01fe6bfee6da"
+  resolved "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.8.tgz"
   integrity sha512-Su7FQvp5buZmCymN3PPoYv31ZQQX4ve2j02k7piGgKAWgE+AQRB5YoYVveGXcl3TZ9ldgRMSxj56YfDFmmaqLg==
   dependencies:
     "@inquirer/core" "^11.1.9"
@@ -808,7 +784,7 @@
 
 "@inquirer/search@^4.1.8":
   version "4.1.8"
-  resolved "https://registry.yarnpkg.com/@inquirer/search/-/search-4.1.8.tgz#1ff32d80ac0859772bd9c38fbccc82818862ee85"
+  resolved "https://registry.npmjs.org/@inquirer/search/-/search-4.1.8.tgz"
   integrity sha512-fGiHKGD6DyPIYUWxoXnQTeXeyYqSOUrasDMABBmMHUalH/LxkuzY0xVRtimXAt1sUeeyYkVuKQx1bebMuN11Kw==
   dependencies:
     "@inquirer/core" "^11.1.9"
@@ -817,7 +793,7 @@
 
 "@inquirer/select@^5.1.4":
   version "5.1.4"
-  resolved "https://registry.yarnpkg.com/@inquirer/select/-/select-5.1.4.tgz#651374b766a8c38157975257f23732e8bc689452"
+  resolved "https://registry.npmjs.org/@inquirer/select/-/select-5.1.4.tgz"
   integrity sha512-2kWcGKPMLAXAWRp1AH1SLsQmX+j0QjeljyXMUji9WMZC8nRDO0b7qquIGr6143E7KMLt3VAIGNXzwa/6PXQs4Q==
   dependencies:
     "@inquirer/ansi" "^2.0.5"
@@ -827,7 +803,7 @@
 
 "@inquirer/type@^4.0.5":
   version "4.0.5"
-  resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-4.0.5.tgz#a02d90e5da8a36dce27ac8e7237a50c99a9003a3"
+  resolved "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz"
   integrity sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==
 
 "@isaacs/cliui@^8.0.2":
@@ -860,7 +836,7 @@
 
 "@jest/console@30.3.0":
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/console/-/console-30.3.0.tgz#42ccc3f995d400a8fe35b8850cfe10a8d4804cdf"
+  resolved "https://registry.npmjs.org/@jest/console/-/console-30.3.0.tgz"
   integrity sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==
   dependencies:
     "@jest/types" "30.3.0"
@@ -872,7 +848,7 @@
 
 "@jest/core@30.3.0":
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/core/-/core-30.3.0.tgz#d06bb8456f35350f6494fd2405bcec4abb97b994"
+  resolved "https://registry.npmjs.org/@jest/core/-/core-30.3.0.tgz"
   integrity sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==
   dependencies:
     "@jest/console" "30.3.0"
@@ -903,19 +879,14 @@
     pretty-format "30.3.0"
     slash "^3.0.0"
 
-"@jest/diff-sequences@30.0.1":
-  version "30.0.1"
-  resolved "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz"
-  integrity sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==
-
 "@jest/diff-sequences@30.3.0":
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz#25b0818d3d83f00b9c7b04e069b8810f9014b143"
+  resolved "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz"
   integrity sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==
 
 "@jest/environment@30.3.0":
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-30.3.0.tgz#b0657c2944b6ef3352f7b25903cc3a23e6ab70f6"
+  resolved "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz"
   integrity sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==
   dependencies:
     "@jest/fake-timers" "30.3.0"
@@ -923,23 +894,16 @@
     "@types/node" "*"
     jest-mock "30.3.0"
 
-"@jest/expect-utils@30.2.0":
-  version "30.2.0"
-  resolved "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.2.0.tgz"
-  integrity sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==
-  dependencies:
-    "@jest/get-type" "30.1.0"
-
 "@jest/expect-utils@30.3.0":
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-30.3.0.tgz#c45b2da9802ffed33bf43b3e019ddb95e5ad95e8"
+  resolved "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz"
   integrity sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==
   dependencies:
     "@jest/get-type" "30.1.0"
 
 "@jest/expect@30.3.0":
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/expect/-/expect-30.3.0.tgz#08ee7f5b610167b0068743246c0b568f4c40c773"
+  resolved "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz"
   integrity sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==
   dependencies:
     expect "30.3.0"
@@ -947,7 +911,7 @@
 
 "@jest/fake-timers@30.3.0":
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-30.3.0.tgz#2b2868130c1d28233a79566874c42cae1c5a70bc"
+  resolved "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz"
   integrity sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==
   dependencies:
     "@jest/types" "30.3.0"
@@ -964,7 +928,7 @@
 
 "@jest/globals@30.3.0":
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-30.3.0.tgz#40f4c90e5602629ecda1ca773a8fb21575bb64ea"
+  resolved "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz"
   integrity sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==
   dependencies:
     "@jest/environment" "30.3.0"
@@ -982,7 +946,7 @@
 
 "@jest/reporters@30.3.0":
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-30.3.0.tgz#0c1065f6c892665e5a051df22b19df4466ed816b"
+  resolved "https://registry.npmjs.org/@jest/reporters/-/reporters-30.3.0.tgz"
   integrity sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==
   dependencies:
     "@bcoe/v8-coverage" "^0.2.3"
@@ -1018,7 +982,7 @@
 
 "@jest/snapshot-utils@30.3.0":
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz#ca003c91a3e1e4e4956dee716a2aaf04b6707f31"
+  resolved "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz"
   integrity sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==
   dependencies:
     "@jest/types" "30.3.0"
@@ -1037,7 +1001,7 @@
 
 "@jest/test-result@30.3.0":
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-30.3.0.tgz#cd8882d683d467fcffb98c09501a65687a76aae9"
+  resolved "https://registry.npmjs.org/@jest/test-result/-/test-result-30.3.0.tgz"
   integrity sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==
   dependencies:
     "@jest/console" "30.3.0"
@@ -1047,7 +1011,7 @@
 
 "@jest/test-sequencer@30.3.0":
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-30.3.0.tgz#27002b2093f4e0d9e0e1ebb0bc274a242fdadc14"
+  resolved "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.3.0.tgz"
   integrity sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==
   dependencies:
     "@jest/test-result" "30.3.0"
@@ -1057,7 +1021,7 @@
 
 "@jest/transform@30.3.0":
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-30.3.0.tgz#9e6f78ffa205449bf956e269fd707c160f47ce2f"
+  resolved "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz"
   integrity sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==
   dependencies:
     "@babel/core" "^7.27.4"
@@ -1075,22 +1039,9 @@
     slash "^3.0.0"
     write-file-atomic "^5.0.1"
 
-"@jest/types@30.2.0":
-  version "30.2.0"
-  resolved "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz"
-  integrity sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==
-  dependencies:
-    "@jest/pattern" "30.0.1"
-    "@jest/schemas" "30.0.5"
-    "@types/istanbul-lib-coverage" "^2.0.6"
-    "@types/istanbul-reports" "^3.0.4"
-    "@types/node" "*"
-    "@types/yargs" "^17.0.33"
-    chalk "^4.1.2"
-
 "@jest/types@30.3.0":
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-30.3.0.tgz#cada800d323cb74945c24ac74615fdb312a6c85f"
+  resolved "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz"
   integrity sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==
   dependencies:
     "@jest/pattern" "30.0.1"
@@ -1101,21 +1052,12 @@
     "@types/yargs" "^17.0.33"
     chalk "^4.1.2"
 
-"@jridgewell/gen-mapping@^0.3.12":
+"@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.12"
   resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz"
   integrity sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.0"
-    "@jridgewell/trace-mapping" "^0.3.24"
-
-"@jridgewell/gen-mapping@^0.3.5":
-  version "0.3.5"
-  resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz"
-  integrity sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==
-  dependencies:
-    "@jridgewell/set-array" "^1.2.1"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.24"
 
 "@jridgewell/remapping@^2.3.5":
@@ -1131,11 +1073,6 @@
   resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz"
   integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
 
-"@jridgewell/set-array@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz"
-  integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
-
 "@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0", "@jridgewell/sourcemap-codec@^1.5.5":
   version "1.5.5"
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
@@ -1149,15 +1086,7 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.24":
-  version "0.3.25"
-  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz"
-  integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.1.0"
-    "@jridgewell/sourcemap-codec" "^1.4.14"
-
-"@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
   version "0.3.29"
   resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz"
   integrity sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==
@@ -1179,7 +1108,7 @@
 
 "@langchain/anthropic@^1.0.0":
   version "1.3.28"
-  resolved "https://registry.yarnpkg.com/@langchain/anthropic/-/anthropic-1.3.28.tgz#8812bbd10c14de26520aa5aa340c1bfd4638b6ae"
+  resolved "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-1.3.28.tgz"
   integrity sha512-gOF8oXJL8xDdYes2KXNI9vFm/9TldBBBHOjuCdt27kganVaQKzLvTw5kV6R4mjbnFagV5CWteNH7APLZYCpdwg==
   dependencies:
     "@anthropic-ai/sdk" "^0.90.0"
@@ -1187,7 +1116,7 @@
 
 "@langchain/classic@^1.0.27":
   version "1.0.32"
-  resolved "https://registry.yarnpkg.com/@langchain/classic/-/classic-1.0.32.tgz#502ce49ff9ce899a793e6ac429ef9dba19fd9ce6"
+  resolved "https://registry.npmjs.org/@langchain/classic/-/classic-1.0.32.tgz"
   integrity sha512-Unv3aRVNOwtJKfTyo0kS7u0ytrHtOw38ojBM8pIz7HAdai6vvCAr+rvT8mCkSKv5o78Rhrm+cn9ggTBhNukjgg==
   dependencies:
     "@langchain/openai" "1.4.5"
@@ -1203,7 +1132,7 @@
 
 "@langchain/community@^1.0.0":
   version "1.1.28"
-  resolved "https://registry.yarnpkg.com/@langchain/community/-/community-1.1.28.tgz#78ff19b5ed4a7402cddfc8d70820e9ed18aa48f1"
+  resolved "https://registry.npmjs.org/@langchain/community/-/community-1.1.28.tgz"
   integrity sha512-Mb6vmLE4a7LLkH/flxNJgzNXCbrLH/osAvuplXTRqfsysfL8/EjtN7B98kuj/4HwLtBpn8pUQ5HbJIRXLrhP8Q==
   dependencies:
     "@langchain/classic" "^1.0.27"
@@ -1218,7 +1147,7 @@
 
 "@langchain/core@^1.1.34":
   version "1.1.44"
-  resolved "https://registry.yarnpkg.com/@langchain/core/-/core-1.1.44.tgz#75643c88244f5d54fe7b0186e95d489bef719c3c"
+  resolved "https://registry.npmjs.org/@langchain/core/-/core-1.1.44.tgz"
   integrity sha512-RePW1IjGCHr9ua2vcby3aE8mOOz3EnwDZxMEGbNDT91kf14eqkJqxDXvaZFviGdcN9DTrxM5RPQNAHmwSm4tbg==
   dependencies:
     "@cfworker/json-schema" "^4.0.2"
@@ -1234,14 +1163,14 @@
 
 "@langchain/ollama@^1.2.7":
   version "1.2.7"
-  resolved "https://registry.yarnpkg.com/@langchain/ollama/-/ollama-1.2.7.tgz#a1d6ed8105ebcefdb7d30ebf7daa0f35c7a32e31"
+  resolved "https://registry.npmjs.org/@langchain/ollama/-/ollama-1.2.7.tgz"
   integrity sha512-7Gu17q1dn4nKGB3ZYJyaaL8H/2k7LHvcL6V25S8cVDniTTSvd0fWzI5MzPJvbf9WPxBhvmf+rDDLAhOWljHEtQ==
   dependencies:
     ollama "^0.6.3"
 
 "@langchain/openai@1.4.5", "@langchain/openai@^1.4.1", "@langchain/openai@^1.4.5":
   version "1.4.5"
-  resolved "https://registry.yarnpkg.com/@langchain/openai/-/openai-1.4.5.tgz#e2d243d7f6ce64db9bc57dc22ac927ff785dc7be"
+  resolved "https://registry.npmjs.org/@langchain/openai/-/openai-1.4.5.tgz"
   integrity sha512-bQ2WMIZfSh02trJLYSAtiIcD3j6EBCiAm9nw0dZWQsVaUxmWc3JJqs8uUte6AkMazmLHzcUIw+14UkXO5fRJvQ==
   dependencies:
     js-tiktoken "^1.0.12"
@@ -1292,7 +1221,7 @@
 
 "@octokit/core@^7.0.6":
   version "7.0.6"
-  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-7.0.6.tgz#0d58704391c6b681dec1117240ea4d2a98ac3916"
+  resolved "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz"
   integrity sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==
   dependencies:
     "@octokit/auth-token" "^6.0.0"
@@ -1305,7 +1234,7 @@
 
 "@octokit/endpoint@^11.0.3":
   version "11.0.3"
-  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-11.0.3.tgz#acf5f7feddde4e12185d5312ee38ff77235d8205"
+  resolved "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz"
   integrity sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==
   dependencies:
     "@octokit/types" "^16.0.0"
@@ -1313,7 +1242,7 @@
 
 "@octokit/graphql@^9.0.3":
   version "9.0.3"
-  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-9.0.3.tgz#5b8341c225909e924b466705c13477face869456"
+  resolved "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz"
   integrity sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==
   dependencies:
     "@octokit/request" "^10.0.6"
@@ -1322,12 +1251,12 @@
 
 "@octokit/openapi-types@^27.0.0":
   version "27.0.0"
-  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-27.0.0.tgz#374ea53781965fd02a9d36cacb97e152cefff12d"
+  resolved "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz"
   integrity sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==
 
 "@octokit/plugin-paginate-rest@^14.0.0":
   version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz#44dc9fff2dacb148d4c5c788b573ddc044503026"
+  resolved "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz"
   integrity sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==
   dependencies:
     "@octokit/types" "^16.0.0"
@@ -1339,21 +1268,21 @@
 
 "@octokit/plugin-rest-endpoint-methods@^17.0.0":
   version "17.0.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz#8c54397d3a4060356a1c8a974191ebf945924105"
+  resolved "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz"
   integrity sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==
   dependencies:
     "@octokit/types" "^16.0.0"
 
 "@octokit/request-error@^7.0.2":
   version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-7.1.0.tgz#440fa3cae310466889778f5a222b47a580743638"
+  resolved "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz"
   integrity sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==
   dependencies:
     "@octokit/types" "^16.0.0"
 
 "@octokit/request@^10.0.6":
   version "10.0.8"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-10.0.8.tgz#6609a5a38ad6f8ee203d9eb8ac9361d906a4414e"
+  resolved "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz"
   integrity sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==
   dependencies:
     "@octokit/endpoint" "^11.0.3"
@@ -1365,7 +1294,7 @@
 
 "@octokit/rest@22.0.1":
   version "22.0.1"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-22.0.1.tgz#4d866c32b76b711d3f736f91992e2b534163b416"
+  resolved "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz"
   integrity sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==
   dependencies:
     "@octokit/core" "^7.0.6"
@@ -1375,7 +1304,7 @@
 
 "@octokit/types@^16.0.0":
   version "16.0.0"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-16.0.0.tgz#fbd7fa590c2ef22af881b1d79758bfaa234dbb7c"
+  resolved "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz"
   integrity sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==
   dependencies:
     "@octokit/openapi-types" "^27.0.0"
@@ -1397,7 +1326,7 @@
 
 "@rollup/plugin-commonjs@^29.0.0":
   version "29.0.2"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-29.0.2.tgz#d2d84c49d0983d071f2ab96f4cfe02fe80abd602"
+  resolved "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-29.0.2.tgz"
   integrity sha512-S/ggWH1LU7jTyi9DxZOKyxpVd4hF/OZ0JrEbeLjXk/DFXwRny0tjD2c992zOUYQobLrVkRVMDdmHP16HKP7GRg==
   dependencies:
     "@rollup/pluginutils" "^5.0.1"
@@ -1410,7 +1339,7 @@
 
 "@rollup/plugin-eslint@^9.0.5":
   version "9.2.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-eslint/-/plugin-eslint-9.2.0.tgz#590f973628c602f15f2bdad64cf41f8b6d5a49ff"
+  resolved "https://registry.npmjs.org/@rollup/plugin-eslint/-/plugin-eslint-9.2.0.tgz"
   integrity sha512-WirwxltNtaCX6j4MVFMKiXkLGFfv0ewiz5PmJOuz4qoKrTAzTqC76rQzJvxlwXz0xZEw/bfnl6PMBgUecYETOw==
   dependencies:
     "@rollup/pluginutils" "^5.0.1"
@@ -1462,7 +1391,7 @@
 
 "@rollup/rollup-darwin-arm64@4.60.2":
   version "4.60.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz#3b8463e03ba2a393453fea70e7d907379c27b649"
+  resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz"
   integrity sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==
 
 "@rollup/rollup-darwin-x64@4.60.2":
@@ -1577,26 +1506,26 @@
 
 "@simple-git/args-pathspec@^1.0.3":
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz#9ef4a2ad5f49ab4056362d03f93f775b93118ca5"
+  resolved "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz"
   integrity sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==
 
 "@simple-git/argv-parser@^1.1.0":
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz#275b839c6eeb5030872c73b1ea839a416885da9d"
+  resolved "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz"
   integrity sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==
   dependencies:
     "@simple-git/args-pathspec" "^1.0.3"
 
 "@simple-libs/child-process-utils@^1.0.0":
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz#cb182d310c9bed3ace200b26258e090d898a1736"
+  resolved "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz"
   integrity sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==
   dependencies:
     "@simple-libs/stream-utils" "^1.2.0"
 
 "@simple-libs/stream-utils@^1.2.0":
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz#5af724b826f1ab4d7f2826d31d3efccec124102b"
+  resolved "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz"
   integrity sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==
 
 "@sinclair/typebox@^0.34.0":
@@ -1613,7 +1542,7 @@
 
 "@sinonjs/fake-timers@^15.0.0":
   version "15.3.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz#afecc36681e26aab9e0fe809fd9ad578096a3058"
+  resolved "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz"
   integrity sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==
   dependencies:
     "@sinonjs/commons" "^3.0.1"
@@ -1644,9 +1573,9 @@
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
 "@tybys/wasm-util@^0.10.0":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"
-  integrity sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.2.tgz#12b3a1b33db1f9cad4ddff1f604ab7dd00bf464e"
+  integrity sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==
   dependencies:
     tslib "^2.4.0"
 
@@ -1734,7 +1663,7 @@
 
 "@types/node@*", "@types/node@^25.0.10":
   version "25.6.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.6.2.tgz#8c491201373690e4ef2a2ffed0dfb510a5830b92"
+  resolved "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz"
   integrity sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==
   dependencies:
     undici-types "~7.19.0"
@@ -1748,7 +1677,7 @@
 
 "@types/react@19.2.14":
   version "19.2.14"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.14.tgz#39604929b5e3957e3a6fa0001dafb17c7af70bad"
+  resolved "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz"
   integrity sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==
   dependencies:
     csstype "^3.2.2"
@@ -1873,7 +1802,7 @@
 
 "@unrs/resolver-binding-darwin-arm64@1.11.1":
   version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz#b4a8556f42171fb9c9f7bac8235045e82aa0cbdf"
+  resolved "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz"
   integrity sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==
 
 "@unrs/resolver-binding-darwin-x64@1.11.1":
@@ -1928,12 +1857,12 @@
 
 "@unrs/resolver-binding-linux-x64-gnu@1.11.1":
   version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz#36fb318eebdd690f6da32ac5e0499a76fa881935"
   integrity sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==
 
 "@unrs/resolver-binding-linux-x64-musl@1.11.1":
   version "1.11.1"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz#bfb9af75f783f98f6a22c4244214efe4df1853d6"
   integrity sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==
 
 "@unrs/resolver-binding-wasm32-wasi@1.11.1":
@@ -1977,7 +1906,7 @@ acorn@^8.11.0, acorn@^8.4.1, acorn@^8.9.0:
 
 agent-base@8.0.0:
   version "8.0.0"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-8.0.0.tgz#3eb7c2c198ccb93368c77969530594e725b804b5"
+  resolved "https://registry.npmjs.org/agent-base/-/agent-base-8.0.0.tgz"
   integrity sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==
 
 ajv@^6.12.4:
@@ -2009,7 +1938,7 @@ ansi-escapes@^4.3.2:
 
 ansi-escapes@^7.3.0:
   version "7.3.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-7.3.0.tgz#5395bb74b2150a4a1d6e3c2565f4aeca78d28627"
+  resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz"
   integrity sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==
   dependencies:
     environment "^1.0.0"
@@ -2092,12 +2021,12 @@ async-retry@1.3.3:
 
 auto-bind@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/auto-bind/-/auto-bind-5.0.1.tgz#50d8e63ea5a1dddcb5e5e36451c1a8266ffbb2ae"
+  resolved "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz"
   integrity sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==
 
 babel-jest@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-30.3.0.tgz#3ff5553fa3bcbb8738d2d7335a4dbdc3bd1a0eb5"
+  resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz"
   integrity sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==
   dependencies:
     "@jest/transform" "30.3.0"
@@ -2121,7 +2050,7 @@ babel-plugin-istanbul@^7.0.1:
 
 babel-plugin-jest-hoist@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz#235ad714a45c18b12566becf439e1c604e277015"
+  resolved "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz"
   integrity sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==
   dependencies:
     "@types/babel__core" "^7.20.5"
@@ -2149,7 +2078,7 @@ babel-preset-current-node-syntax@^1.2.0:
 
 babel-preset-jest@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz#21cf3d19a6f5e9924426c879ee0b7f092636d043"
+  resolved "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz"
   integrity sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==
   dependencies:
     babel-plugin-jest-hoist "30.3.0"
@@ -2172,7 +2101,7 @@ base64-js@^1.3.1, base64-js@^1.5.1:
 
 basic-ftp@^5.0.2:
   version "5.2.2"
-  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.2.2.tgz#4cb2422deddf432896bdb3c9b8f13b944ad4842c"
+  resolved "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz"
   integrity sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==
 
 before-after-hook@^4.0.0:
@@ -2206,13 +2135,6 @@ brace-expansion@^5.0.2:
   version "5.0.3"
   resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz"
   integrity sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==
-  dependencies:
-    balanced-match "^4.0.2"
-
-brace-expansion@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
-  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
   dependencies:
     balanced-match "^4.0.2"
 
@@ -2269,7 +2191,7 @@ bundle-name@^4.1.0:
 
 c12@3.3.3:
   version "3.3.3"
-  resolved "https://registry.yarnpkg.com/c12/-/c12-3.3.3.tgz#cab6604e6e6117fc9e62439a8e8144bbbe5edcd6"
+  resolved "https://registry.npmjs.org/c12/-/c12-3.3.3.tgz"
   integrity sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q==
   dependencies:
     chokidar "^5.0.0"
@@ -2325,19 +2247,19 @@ char-regex@^1.0.2:
 
 chardet@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/chardet/-/chardet-2.1.1.tgz#5c75593704a642f71ee53717df234031e65373c8"
+  resolved "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz"
   integrity sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==
 
 chokidar@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-5.0.0.tgz#949c126a9238a80792be9a0265934f098af369a5"
+  resolved "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz"
   integrity sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==
   dependencies:
     readdirp "^5.0.0"
 
 ci-info@^4.2.0, ci-info@^4.4.0:
   version "4.4.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.4.0.tgz#7d54eff9f54b45b62401c26032696eb59c8bd18c"
+  resolved "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz"
   integrity sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==
 
 citty@^0.1.6:
@@ -2354,7 +2276,7 @@ cjs-module-lexer@^2.1.0:
 
 cli-boxes@^4.0.1:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-4.0.1.tgz#7267f4ae32ecbb52b5af77fef48be219f666c57c"
+  resolved "https://registry.npmjs.org/cli-boxes/-/cli-boxes-4.0.1.tgz"
   integrity sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==
 
 cli-cursor@^3.1.0:
@@ -2366,7 +2288,7 @@ cli-cursor@^3.1.0:
 
 cli-cursor@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-4.0.0.tgz#3cecfe3734bf4fe02a8361cbdc0f6fe28c6a57ea"
+  resolved "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz"
   integrity sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==
   dependencies:
     restore-cursor "^4.0.0"
@@ -2390,7 +2312,7 @@ cli-spinners@^3.2.0:
 
 cli-truncate@^6.0.0:
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-6.0.0.tgz#9e7c9b64649e4bd35e6a77919797c30ba7dc0095"
+  resolved "https://registry.npmjs.org/cli-truncate/-/cli-truncate-6.0.0.tgz"
   integrity sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA==
   dependencies:
     slice-ansi "^9.0.0"
@@ -2431,7 +2353,7 @@ co@^4.6.0:
 
 code-excerpt@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/code-excerpt/-/code-excerpt-4.0.0.tgz#2de7d46e98514385cb01f7b3b741320115f4c95e"
+  resolved "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz"
   integrity sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==
   dependencies:
     convert-to-spaces "^2.0.1"
@@ -2455,7 +2377,7 @@ color-name@~1.1.4:
 
 commander@^14.0.3:
   version "14.0.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-14.0.3.tgz#425d79b48f9af82fcd9e4fc1ea8af6c5ec07bbc2"
+  resolved "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz"
   integrity sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==
 
 commondir@^1.0.1:
@@ -2488,14 +2410,14 @@ consola@^3.2.3, consola@^3.4.0, consola@^3.4.2:
 
 conventional-changelog-angular@^8.2.0:
   version "8.3.1"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz#0b015e25ca7f2766a8c5352ab6488dcb76a9d881"
+  resolved "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz"
   integrity sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==
   dependencies:
     compare-func "^2.0.0"
 
 conventional-commits-parser@^6.3.0:
   version "6.4.0"
-  resolved "https://registry.yarnpkg.com/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz#8ac1c12ec467354ed4d73ec940efe380e1e83686"
+  resolved "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz"
   integrity sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==
   dependencies:
     "@simple-libs/stream-utils" "^1.2.0"
@@ -2508,7 +2430,7 @@ convert-source-map@^2.0.0:
 
 convert-to-spaces@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz#61a6c98f8aa626c16b296b862a91412a33bceb6b"
+  resolved "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz"
   integrity sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==
 
 cosmiconfig-typescript-loader@^6.1.0:
@@ -2520,7 +2442,7 @@ cosmiconfig-typescript-loader@^6.1.0:
 
 cosmiconfig@^9.0.1:
   version "9.0.1"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-9.0.1.tgz#df110631a8547b5d1a98915271986f06e3011379"
+  resolved "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz"
   integrity sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==
   dependencies:
     env-paths "^2.2.1"
@@ -2544,12 +2466,12 @@ cross-spawn@7.0.6, cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
 
 csstype@^3.2.2:
   version "3.2.3"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
+  resolved "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz"
   integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
 data-uri-to-buffer@7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-7.0.0.tgz#26af0bf7326516465a51a05313095a009bf3eb5d"
+  resolved "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-7.0.0.tgz"
   integrity sha512-CuRUx0TXGSbbWdEci3VK/XOZGP3n0P4pIKpsqpVtBqaIIuj3GKK8H45oAqA4Rg8FHipc+CzRdUzmD4YQXxv66Q==
 
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0:
@@ -2606,12 +2528,12 @@ define-lazy-prop@^3.0.0:
 
 defu@^6.1.4, defu@^6.1.7:
   version "6.1.7"
-  resolved "https://registry.yarnpkg.com/defu/-/defu-6.1.7.tgz#72543567c8e9f97ff13ce402b6dbe09ac5ae4d23"
+  resolved "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz"
   integrity sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==
 
 degenerator@6.0.0:
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/degenerator/-/degenerator-6.0.0.tgz#87262e7c534dc7bd2dc5d5d15f67aeb2e9b1b3e7"
+  resolved "https://registry.npmjs.org/degenerator/-/degenerator-6.0.0.tgz"
   integrity sha512-j5MdXdefrecJeSqTpUrgZd4fBsD2IxZx0JlJD+n1Q7+aTf7/HcyXSfHsicPW6ekPurX159v1ZYla6OJgSPh2Dw==
   dependencies:
     ast-types "^0.13.4"
@@ -2630,7 +2552,7 @@ detect-newline@^3.1.0:
 
 diff@*, diff@9.0.0:
   version "9.0.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-9.0.0.tgz#297c31cd7c280f13dfe335791ec2063bd4a73a6f"
+  resolved "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz"
   integrity sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==
 
 diff@^4.0.1:
@@ -2661,7 +2583,7 @@ dot-prop@^5.1.0:
 
 dotenv@^17.2.3:
   version "17.4.2"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.4.2.tgz#c07e54a746e11eba021dd9e1047ced5afdc1c034"
+  resolved "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz"
   integrity sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==
 
 eastasianwidth@^0.2.0:
@@ -2701,7 +2623,7 @@ env-paths@^2.2.1:
 
 environment@^1.0.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/environment/-/environment-1.1.0.tgz#8e86c66b180f363c7ab311787e0259665f45a9f1"
+  resolved "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz"
   integrity sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==
 
 error-ex@^1.3.1:
@@ -2713,7 +2635,7 @@ error-ex@^1.3.1:
 
 es-toolkit@^1.45.1, es-toolkit@^1.46.0:
   version "1.46.1"
-  resolved "https://registry.yarnpkg.com/es-toolkit/-/es-toolkit-1.46.1.tgz#38ca27191a98a867fc544b81cf1477a68947fb06"
+  resolved "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz"
   integrity sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==
 
 esbuild@~0.27.0:
@@ -2876,7 +2798,7 @@ esutils@^2.0.2:
 
 eta@4.5.1:
   version "4.5.1"
-  resolved "https://registry.yarnpkg.com/eta/-/eta-4.5.1.tgz#f27e45160c1a0eeb8139b52c48959addc086c0d1"
+  resolved "https://registry.npmjs.org/eta/-/eta-4.5.1.tgz"
   integrity sha512-EaNCGm+8XEIU7YNcc+THptWAO5NfKBHHARxt+wxZljj9bTr/+arRoOm9/MpGt4n6xn9fLnPFRSoLD0WFYGFUxQ==
 
 eventemitter3@^3.1.0:
@@ -2909,9 +2831,9 @@ exit-x@^0.2.2:
   resolved "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz"
   integrity sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==
 
-expect@30.3.0:
+expect@30.3.0, expect@^30.0.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-30.3.0.tgz#1b82111517d1ab030f3db0cf1b4061c8aa644f61"
+  resolved "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz"
   integrity sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==
   dependencies:
     "@jest/expect-utils" "30.3.0"
@@ -2921,26 +2843,9 @@ expect@30.3.0:
     jest-mock "30.3.0"
     jest-util "30.3.0"
 
-expect@^30.0.0:
-  version "30.2.0"
-  resolved "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz"
-  integrity sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==
-  dependencies:
-    "@jest/expect-utils" "30.2.0"
-    "@jest/get-type" "30.1.0"
-    jest-matcher-utils "30.2.0"
-    jest-message-util "30.2.0"
-    jest-mock "30.2.0"
-    jest-util "30.2.0"
-
-exsolve@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz"
-  integrity sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==
-
-exsolve@^1.0.8:
+exsolve@^1.0.7, exsolve@^1.0.8:
   version "1.0.8"
-  resolved "https://registry.yarnpkg.com/exsolve/-/exsolve-1.0.8.tgz#7f5e34da61cd1116deda5136e62292c096f50613"
+  resolved "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz"
   integrity sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==
 
 fast-content-type-parse@^3.0.0:
@@ -2976,24 +2881,24 @@ fast-levenshtein@^2.0.6:
 
 fast-string-truncated-width@^3.0.2:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz#23afe0da67d752ca0727538f1e6967759728ce49"
+  resolved "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz"
   integrity sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==
 
 fast-string-width@^3.0.2:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/fast-string-width/-/fast-string-width-3.0.2.tgz#16dbabb491ce5585b5ecb675b65c165d71688eeb"
+  resolved "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz"
   integrity sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==
   dependencies:
     fast-string-truncated-width "^3.0.2"
 
 fast-uri@^3.0.1:
   version "3.1.2"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
+  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz"
   integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
 fast-wrap-ansi@^0.2.0:
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz#c0ae3f3982d061c3d657ec927196fbb47e22fe64"
+  resolved "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz"
   integrity sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==
   dependencies:
     fast-string-width "^3.0.2"
@@ -3099,7 +3004,7 @@ fs.realpath@^1.0.0:
 
 fsevents@^2.3.3, fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
@@ -3117,7 +3022,7 @@ get-caller-file@^2.0.5:
   resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-east-asian-width@^1.0.0, get-east-asian-width@^1.3.0, get-east-asian-width@^1.3.1, get-east-asian-width@^1.5.0:
+get-east-asian-width@^1.0.0, get-east-asian-width@^1.3.1, get-east-asian-width@^1.5.0:
   version "1.5.0"
   resolved "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz"
   integrity sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==
@@ -3141,7 +3046,7 @@ get-tsconfig@^4.7.5:
 
 get-uri@7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/get-uri/-/get-uri-7.0.0.tgz#c2f0ff109d6f5ff4d9061f19ad44f6f34deaba36"
+  resolved "https://registry.npmjs.org/get-uri/-/get-uri-7.0.0.tgz"
   integrity sha512-ZsC7KQxm1Hra8yO0RvMZ4lGJT7vnBtSNpEHKq39MPN7vjuvCiu1aQ8rkXUaIXG1y/TSDez97Gmv04ibnYqCp/A==
   dependencies:
     basic-ftp "^5.0.2"
@@ -3162,7 +3067,7 @@ giget@^2.0.0:
 
 git-raw-commits@^5.0.0:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-5.0.1.tgz#e91d8fd4e3a264142166956fe1a23d08c069657e"
+  resolved "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-5.0.1.tgz"
   integrity sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==
   dependencies:
     "@conventional-changelog/git-client" "^2.6.0"
@@ -3199,7 +3104,7 @@ glob-parent@^6.0.2:
 
 glob@^10.5.0:
   version "10.5.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
+  resolved "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz"
   integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
   dependencies:
     foreground-child "^3.1.0"
@@ -3211,7 +3116,7 @@ glob@^10.5.0:
 
 glob@^13.0.6:
   version "13.0.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-13.0.6.tgz#078666566a425147ccacfbd2e332deb66a2be71d"
+  resolved "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz"
   integrity sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==
   dependencies:
     minimatch "^10.2.2"
@@ -3232,7 +3137,7 @@ glob@^7.1.3, glob@^7.1.4:
 
 global-directory@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/global-directory/-/global-directory-5.0.0.tgz#0f66a94212acd0f81ee838d0a991e88d1c2836cf"
+  resolved "https://registry.npmjs.org/global-directory/-/global-directory-5.0.0.tgz"
   integrity sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==
   dependencies:
     ini "6.0.0"
@@ -3268,7 +3173,7 @@ graphemer@^1.4.0:
 
 handlebars@^4.7.9:
   version "4.7.9"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.9.tgz#6f139082ab58dc4e5a0e51efe7db5ae890d56a0f"
+  resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz"
   integrity sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==
   dependencies:
     minimist "^1.2.5"
@@ -3297,7 +3202,7 @@ html-escaper@^2.0.0:
 
 http-proxy-agent@8.0.0:
   version "8.0.0"
-  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-8.0.0.tgz#ea48d0b7a5104ce7e82c4b97a44e447e4353ddff"
+  resolved "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-8.0.0.tgz"
   integrity sha512-7pose0uGgrCJeH2Qh4JcNhWZp3u/oNrWjNYDK4ydOLxOpTw8V8ogHFAmkz0VWq96JBFj4umVJpvmQi287rSYLg==
   dependencies:
     agent-base "8.0.0"
@@ -3305,7 +3210,7 @@ http-proxy-agent@8.0.0:
 
 https-proxy-agent@8.0.0:
   version "8.0.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-8.0.0.tgz#2ab138d2706d473ede6d1f5e7158d7586d5ca738"
+  resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-8.0.0.tgz"
   integrity sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ==
   dependencies:
     agent-base "8.0.0"
@@ -3318,7 +3223,7 @@ human-signals@^2.1.0:
 
 iconv-lite@^0.7.2:
   version "0.7.2"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.2.tgz#d0bdeac3f12b4835b7359c2ad89c422a4d1cc72e"
+  resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz"
   integrity sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
@@ -3356,7 +3261,7 @@ imurmurhash@^0.1.4:
 
 indent-string@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-5.0.0.tgz#4fd2980fccaf8622d14c64d694f4cf33c81951a5"
+  resolved "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz"
   integrity sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==
 
 inflight@^1.0.4:
@@ -3379,17 +3284,17 @@ ini@6.0.0:
 
 ini@7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-7.0.0.tgz#d8b3ecbf9425a8581bd95921eb3be1a7948531d4"
+  resolved "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz"
   integrity sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==
 
 ink-testing-library@4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ink-testing-library/-/ink-testing-library-4.0.0.tgz#7071dac9a3d783e7bab2ee05fdf1d01a2cd3bb0d"
+  resolved "https://registry.npmjs.org/ink-testing-library/-/ink-testing-library-4.0.0.tgz"
   integrity sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==
 
 ink@7.0.1:
   version "7.0.1"
-  resolved "https://registry.yarnpkg.com/ink/-/ink-7.0.1.tgz#d5cf8d62b3ba04b5a576066af59f7cf6859e6897"
+  resolved "https://registry.npmjs.org/ink/-/ink-7.0.1.tgz"
   integrity sha512-o6LAC268PLawlGVYrXTyaTfke4VtJftEheuwbgkQf7yvSXyWp1nRwBbAyKEkWXFZZsW/la5wrMuNbuBvZK2C1w==
   dependencies:
     "@alcalzone/ansi-tokenize" "^0.3.0"
@@ -3455,7 +3360,7 @@ is-fullwidth-code-point@^3.0.0:
 
 is-fullwidth-code-point@^5.0.0, is-fullwidth-code-point@^5.1.0:
   version "5.1.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz#046b2a6d4f6b156b2233d3207d4b5a9783999b98"
+  resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz"
   integrity sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==
   dependencies:
     get-east-asian-width "^1.3.1"
@@ -3474,7 +3379,7 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
 
 is-in-ci@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-in-ci/-/is-in-ci-2.0.0.tgz#e4b3471c555b47509a8311869c377c234967079f"
+  resolved "https://registry.npmjs.org/is-in-ci/-/is-in-ci-2.0.0.tgz"
   integrity sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==
 
 is-in-ssh@^1.0.0:
@@ -3521,7 +3426,7 @@ is-path-inside@^3.0.3:
 
 is-plain-obj@^4.1.0:
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
+  resolved "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz"
   integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
 
 is-reference@1.2.1:
@@ -3629,7 +3534,7 @@ jackspeak@^3.1.2:
 
 jest-changed-files@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-30.3.0.tgz#055849df695f9a9fcde0ae44024f815bbc627f3a"
+  resolved "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.3.0.tgz"
   integrity sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==
   dependencies:
     execa "^5.1.1"
@@ -3638,7 +3543,7 @@ jest-changed-files@30.3.0:
 
 jest-circus@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-30.3.0.tgz#153614c11ab35867f371bd93496ecb9690b92077"
+  resolved "https://registry.npmjs.org/jest-circus/-/jest-circus-30.3.0.tgz"
   integrity sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==
   dependencies:
     "@jest/environment" "30.3.0"
@@ -3664,7 +3569,7 @@ jest-circus@30.3.0:
 
 jest-cli@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-30.3.0.tgz#5ed75a337f486a1f1c5acbb2de8acddb106ead6c"
+  resolved "https://registry.npmjs.org/jest-cli/-/jest-cli-30.3.0.tgz"
   integrity sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==
   dependencies:
     "@jest/core" "30.3.0"
@@ -3680,7 +3585,7 @@ jest-cli@30.3.0:
 
 jest-config@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-30.3.0.tgz#b969e0aaaf5964419e62953bb712c16d15972425"
+  resolved "https://registry.npmjs.org/jest-config/-/jest-config-30.3.0.tgz"
   integrity sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==
   dependencies:
     "@babel/core" "^7.27.4"
@@ -3707,19 +3612,9 @@ jest-config@30.3.0:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
-jest-diff@30.2.0:
-  version "30.2.0"
-  resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz"
-  integrity sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==
-  dependencies:
-    "@jest/diff-sequences" "30.0.1"
-    "@jest/get-type" "30.1.0"
-    chalk "^4.1.2"
-    pretty-format "30.2.0"
-
 jest-diff@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-30.3.0.tgz#e0a4c84ef350ffd790ffd5b0016acabeecf5f759"
+  resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz"
   integrity sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==
   dependencies:
     "@jest/diff-sequences" "30.3.0"
@@ -3736,7 +3631,7 @@ jest-docblock@30.2.0:
 
 jest-each@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-30.3.0.tgz#faa7229bf7a9fa6426dc604057a7d2a173493b1e"
+  resolved "https://registry.npmjs.org/jest-each/-/jest-each-30.3.0.tgz"
   integrity sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==
   dependencies:
     "@jest/get-type" "30.1.0"
@@ -3747,7 +3642,7 @@ jest-each@30.3.0:
 
 jest-environment-node@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-30.3.0.tgz#aa8a57c5d0c4af0f8b1f7403ba737fec6b3aabbe"
+  resolved "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.3.0.tgz"
   integrity sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==
   dependencies:
     "@jest/environment" "30.3.0"
@@ -3760,7 +3655,7 @@ jest-environment-node@30.3.0:
 
 jest-haste-map@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-30.3.0.tgz#1ea6843e6e45c077d91270666a4fcba958c24cd5"
+  resolved "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz"
   integrity sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==
   dependencies:
     "@jest/types" "30.3.0"
@@ -3778,25 +3673,15 @@ jest-haste-map@30.3.0:
 
 jest-leak-detector@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz#a695a851e353f517a554a2f5c91c2742fc131c98"
+  resolved "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz"
   integrity sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==
   dependencies:
     "@jest/get-type" "30.1.0"
     pretty-format "30.3.0"
 
-jest-matcher-utils@30.2.0:
-  version "30.2.0"
-  resolved "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz"
-  integrity sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==
-  dependencies:
-    "@jest/get-type" "30.1.0"
-    chalk "^4.1.2"
-    jest-diff "30.2.0"
-    pretty-format "30.2.0"
-
 jest-matcher-utils@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz#d6c739fec1ecd33809f2d2b1348f6ab01d2f2493"
+  resolved "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz"
   integrity sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==
   dependencies:
     "@jest/get-type" "30.1.0"
@@ -3804,24 +3689,9 @@ jest-matcher-utils@30.3.0:
     jest-diff "30.3.0"
     pretty-format "30.3.0"
 
-jest-message-util@30.2.0:
-  version "30.2.0"
-  resolved "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz"
-  integrity sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==
-  dependencies:
-    "@babel/code-frame" "^7.27.1"
-    "@jest/types" "30.2.0"
-    "@types/stack-utils" "^2.0.3"
-    chalk "^4.1.2"
-    graceful-fs "^4.2.11"
-    micromatch "^4.0.8"
-    pretty-format "30.2.0"
-    slash "^3.0.0"
-    stack-utils "^2.0.6"
-
 jest-message-util@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-30.3.0.tgz#4d723544d36890ba862ac3961db52db5b0d1ba39"
+  resolved "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz"
   integrity sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==
   dependencies:
     "@babel/code-frame" "^7.27.1"
@@ -3834,18 +3704,9 @@ jest-message-util@30.3.0:
     slash "^3.0.0"
     stack-utils "^2.0.6"
 
-jest-mock@30.2.0:
-  version "30.2.0"
-  resolved "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz"
-  integrity sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==
-  dependencies:
-    "@jest/types" "30.2.0"
-    "@types/node" "*"
-    jest-util "30.2.0"
-
 jest-mock@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-30.3.0.tgz#e0fa4184a596a6c4fdec53d4f412158418923747"
+  resolved "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz"
   integrity sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==
   dependencies:
     "@jest/types" "30.3.0"
@@ -3864,7 +3725,7 @@ jest-regex-util@30.0.1:
 
 jest-resolve-dependencies@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-30.3.0.tgz#4d638c9f0d93a62a6ed25dec874bfd7e756c8ce5"
+  resolved "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.3.0.tgz"
   integrity sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==
   dependencies:
     jest-regex-util "30.0.1"
@@ -3872,7 +3733,7 @@ jest-resolve-dependencies@30.3.0:
 
 jest-resolve@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-30.3.0.tgz#b7bee9927279805b1b50715d2170a545553b87ff"
+  resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz"
   integrity sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==
   dependencies:
     chalk "^4.1.2"
@@ -3886,7 +3747,7 @@ jest-resolve@30.3.0:
 
 jest-runner@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-30.3.0.tgz#fa970fc4e45d418ad7e7d581b24cac7af5944cb7"
+  resolved "https://registry.npmjs.org/jest-runner/-/jest-runner-30.3.0.tgz"
   integrity sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==
   dependencies:
     "@jest/console" "30.3.0"
@@ -3914,7 +3775,7 @@ jest-runner@30.3.0:
 
 jest-runtime@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-30.3.0.tgz#1a9bec7a9b68db12dfe4136bbe41ab883ea2c996"
+  resolved "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.3.0.tgz"
   integrity sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==
   dependencies:
     "@jest/environment" "30.3.0"
@@ -3942,7 +3803,7 @@ jest-runtime@30.3.0:
 
 jest-snapshot@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-30.3.0.tgz#6e7ea75069dda86e36311a0f73189e830d4f51ad"
+  resolved "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz"
   integrity sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==
   dependencies:
     "@babel/core" "^7.27.4"
@@ -3967,21 +3828,9 @@ jest-snapshot@30.3.0:
     semver "^7.7.2"
     synckit "^0.11.8"
 
-jest-util@30.2.0:
-  version "30.2.0"
-  resolved "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz"
-  integrity sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==
-  dependencies:
-    "@jest/types" "30.2.0"
-    "@types/node" "*"
-    chalk "^4.1.2"
-    ci-info "^4.2.0"
-    graceful-fs "^4.2.11"
-    picomatch "^4.0.2"
-
 jest-util@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-30.3.0.tgz#95a4fbacf2dac20e768e2f1744b70519f2ba7980"
+  resolved "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz"
   integrity sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==
   dependencies:
     "@jest/types" "30.3.0"
@@ -3993,7 +3842,7 @@ jest-util@30.3.0:
 
 jest-validate@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-30.3.0.tgz#215e11b8fcc5e2ca4b99ea5d730a5b4c969e4355"
+  resolved "https://registry.npmjs.org/jest-validate/-/jest-validate-30.3.0.tgz"
   integrity sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==
   dependencies:
     "@jest/get-type" "30.1.0"
@@ -4005,7 +3854,7 @@ jest-validate@30.3.0:
 
 jest-watcher@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-30.3.0.tgz#3afa1af355b9fe80f0261eb8a23981a315858596"
+  resolved "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.3.0.tgz"
   integrity sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==
   dependencies:
     "@jest/test-result" "30.3.0"
@@ -4019,7 +3868,7 @@ jest-watcher@30.3.0:
 
 jest-worker@30.3.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-30.3.0.tgz#ae4dc1f1d93d0cba1415624fcedaec40ea764f14"
+  resolved "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz"
   integrity sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==
   dependencies:
     "@types/node" "*"
@@ -4030,7 +3879,7 @@ jest-worker@30.3.0:
 
 jest@^30.0.5:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-30.3.0.tgz#6460b889dd805e9677400505f16f1d9b14c285a3"
+  resolved "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz"
   integrity sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==
   dependencies:
     "@jest/core" "30.3.0"
@@ -4115,7 +3964,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
 
 json-with-bigint@^3.5.3:
   version "3.5.8"
-  resolved "https://registry.yarnpkg.com/json-with-bigint/-/json-with-bigint-3.5.8.tgz#1b1edb55a1bc4816ca87ac684297591acd822383"
+  resolved "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz"
   integrity sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==
 
 json5@^2.2.3:
@@ -4146,7 +3995,7 @@ keyv@^4.5.3:
 
 "langsmith@>=0.4.0 <1.0.0", "langsmith@>=0.5.0 <1.0.0":
   version "0.5.20"
-  resolved "https://registry.yarnpkg.com/langsmith/-/langsmith-0.5.20.tgz#4021847d2ccd5a86c5eb96060f9bb5f19f80eca5"
+  resolved "https://registry.npmjs.org/langsmith/-/langsmith-0.5.20.tgz"
   integrity sha512-ULhLM8RswvQDXufLtNtvclHrWCBx8Cb5UPI6lAZC+8Dq59iHsVPz/3Ac9khWNm1VIvChRsuykixD/WrmzuuA3Q==
   dependencies:
     p-queue "6.6.2"
@@ -4242,7 +4091,7 @@ lru-cache@^10.2.0:
 
 lru-cache@^11.0.0:
   version "11.3.5"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.3.5.tgz#29047d348c0b2793e3112a01c739bb7c6d855637"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz"
   integrity sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==
 
 lru-cache@^5.1.1:
@@ -4259,7 +4108,7 @@ lru-cache@^7.14.1:
 
 macos-release@^3.4.0:
   version "3.4.0"
-  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-3.4.0.tgz#1b223706b13106c158e2b40cb81ba35dd74d7856"
+  resolved "https://registry.npmjs.org/macos-release/-/macos-release-3.4.0.tgz"
   integrity sha512-wpGPwyg/xrSp4H4Db4xYSeAr6+cFQGHfspHzDUdYxswDnUW0L5Ov63UuJiSr8NMSpyaChO4u1n0MXUvVPtrN6A==
 
 magic-string@^0.25.7:
@@ -4309,7 +4158,7 @@ math-expression-evaluator@^2.0.0:
 
 meow@^13.0.0:
   version "13.2.0"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-13.2.0.tgz#6b7d63f913f984063b3cc261b6e8800c4cd3474f"
+  resolved "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz"
   integrity sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==
 
 merge-stream@^2.0.0:
@@ -4337,7 +4186,7 @@ mime-db@^1.54.0:
 
 mime-types@3.0.2:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-3.0.2.tgz#39002d4182575d5af036ffa118100f2524b2e2ab"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz"
   integrity sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==
   dependencies:
     mime-db "^1.54.0"
@@ -4352,14 +4201,7 @@ mimic-function@^5.0.0:
   resolved "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz"
   integrity sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==
 
-minimatch@^10.2.2:
-  version "10.2.5"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
-  integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
-  dependencies:
-    brace-expansion "^5.0.5"
-
-minimatch@^10.2.4:
+minimatch@^10.2.2, minimatch@^10.2.4:
   version "10.2.4"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz"
   integrity sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==
@@ -4385,14 +4227,9 @@ minimist@^1.2.5:
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz"
-  integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
-
-minipass@^7.1.3:
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2, minipass@^7.1.3:
   version "7.1.3"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
 ms@^2.1.3:
@@ -4407,7 +4244,7 @@ mustache@^4.2.0:
 
 mute-stream@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-3.0.0.tgz#cd8014dd2acb72e1e91bb67c74f0019e620ba2d1"
+  resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz"
   integrity sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==
 
 napi-postinstall@^0.3.0:
@@ -4437,10 +4274,20 @@ new-github-release-url@2.0.0:
   dependencies:
     type-fest "^2.5.1"
 
+node-addon-api@^8.2.2:
+  version "8.7.0"
+  resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz"
+  integrity sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==
+
 node-fetch-native@^1.6.6:
   version "1.6.7"
   resolved "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz"
   integrity sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==
+
+node-gyp-build@^4.8.2:
+  version "4.8.4"
+  resolved "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz"
+  integrity sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -4482,7 +4329,7 @@ ohash@^2.0.11:
 
 ollama@^0.6.3:
   version "0.6.3"
-  resolved "https://registry.yarnpkg.com/ollama/-/ollama-0.6.3.tgz#b188573dd0ccb3b4759c1f8fa85067cb17f6673c"
+  resolved "https://registry.npmjs.org/ollama/-/ollama-0.6.3.tgz"
   integrity sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg==
   dependencies:
     whatwg-fetch "^3.6.20"
@@ -4522,7 +4369,7 @@ open@11.0.0, open@^11.0.0:
 
 openai@^6.34.0:
   version "6.35.0"
-  resolved "https://registry.yarnpkg.com/openai/-/openai-6.35.0.tgz#3f3fdf2a03b9009b3c85d1b386f41ad0284d4b5d"
+  resolved "https://registry.npmjs.org/openai/-/openai-6.35.0.tgz"
   integrity sha512-L/skwIGnt5xQZHb0UfTu9uAUKbis3ehKypOuJKi20QvG7UStV6C8IC3myGYHcdiF4kms/bAvOJ9UqqNWqi8x/Q==
 
 openapi-types@^12.1.3:
@@ -4559,7 +4406,7 @@ ora@5.4.1:
 
 ora@9.3.0:
   version "9.3.0"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-9.3.0.tgz#187c87cc1062350f549f481de32bf91424c2b0e3"
+  resolved "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz"
   integrity sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==
   dependencies:
     chalk "^5.6.2"
@@ -4573,7 +4420,7 @@ ora@9.3.0:
 
 os-name@7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/os-name/-/os-name-7.0.0.tgz#426f4dd32c1a83e3460caf56bf4b73aba22e8199"
+  resolved "https://registry.npmjs.org/os-name/-/os-name-7.0.0.tgz"
   integrity sha512-/HfRU/lPPr4T2VigM+cvM3cU77es+XF4OEAa4aE5zpdvrxHGD2NmH0AFIWpMNAb+CsZL45rlcIO49Re0ZcRseg==
   dependencies:
     macos-release "^3.4.0"
@@ -4621,7 +4468,7 @@ p-queue@5.0.0:
 
 p-queue@6.6.2, p-queue@^6.6.2:
   version "6.6.2"
-  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
+  resolved "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz"
   integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
   dependencies:
     eventemitter3 "^4.0.4"
@@ -4641,7 +4488,7 @@ p-try@^2.0.0:
 
 pac-proxy-agent@8.0.0:
   version "8.0.0"
-  resolved "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-8.0.0.tgz#1906efa0599f27fc88182bc7bd8bbe1b486a8fe4"
+  resolved "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-8.0.0.tgz"
   integrity sha512-HyCoVbyQ/nbVlQ/R6wBu0YXhbG2oAnEK5BQ3xMyj1OffQmU5NoOnpLzgPlKHaobUzz5NK0+AZHby4TdydAEBUA==
   dependencies:
     agent-base "8.0.0"
@@ -4655,7 +4502,7 @@ pac-proxy-agent@8.0.0:
 
 pac-resolver@8.0.0:
   version "8.0.0"
-  resolved "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-8.0.0.tgz#078269210225e3508eea93048b03d1c1b6508f42"
+  resolved "https://registry.npmjs.org/pac-resolver/-/pac-resolver-8.0.0.tgz"
   integrity sha512-SVNzOxVq2zuTew3WAt7U8UghwzJzuWYuJryd3y8FxyLTZdjVoCzY8kLP39PpEqQCDvlMWdQXwViu0sYT3eiU2w==
   dependencies:
     degenerator "6.0.0"
@@ -4705,7 +4552,7 @@ parse-url@^9.2.0:
 
 patch-console@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/patch-console/-/patch-console-2.0.0.tgz#9023f4665840e66f40e9ce774f904a63167433bb"
+  resolved "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz"
   integrity sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==
 
 path-exists@^4.0.0:
@@ -4738,7 +4585,7 @@ path-scurry@^1.11.1:
 
 path-scurry@^2.0.2:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-2.0.2.tgz#6be0d0ee02a10d9e0de7a98bae65e182c9061f85"
+  resolved "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz"
   integrity sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==
   dependencies:
     lru-cache "^11.0.0"
@@ -4807,7 +4654,7 @@ powershell-utils@^0.1.0:
 
 powershell-utils@^0.2.0:
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/powershell-utils/-/powershell-utils-0.2.0.tgz#bb075dcadc1564f3bd80fddda4f0a481ccbdcf36"
+  resolved "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz"
   integrity sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==
 
 prelude-ls@^1.2.1:
@@ -4815,18 +4662,9 @@ prelude-ls@^1.2.1:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-pretty-format@30.2.0, pretty-format@^30.0.0:
-  version "30.2.0"
-  resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz"
-  integrity sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==
-  dependencies:
-    "@jest/schemas" "30.0.5"
-    ansi-styles "^5.2.0"
-    react-is "^18.3.1"
-
-pretty-format@30.3.0:
+pretty-format@30.3.0, pretty-format@^30.0.0:
   version "30.3.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-30.3.0.tgz#e977eed4bcd1b6195faed418af8eac68b9ea1f29"
+  resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz"
   integrity sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==
   dependencies:
     "@jest/schemas" "30.0.5"
@@ -4847,7 +4685,7 @@ protocols@^2.0.0, protocols@^2.0.1:
 
 proxy-agent@7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-7.0.0.tgz#fe0762d831740b1546e2c153b2e6535db865bc9f"
+  resolved "https://registry.npmjs.org/proxy-agent/-/proxy-agent-7.0.0.tgz"
   integrity sha512-okTgt79rHTvMHkr/Ney5rZpgCHh3g1g3tI5uhkgN5b7OeI3n0Q/ui1uv9OdrnZNJM9WIZJqZPh/UJs+YtO/TMQ==
   dependencies:
     agent-base "8.0.0"
@@ -4881,7 +4719,7 @@ queue-microtask@^1.2.2:
 
 quickjs-wasi@^0.0.1:
   version "0.0.1"
-  resolved "https://registry.yarnpkg.com/quickjs-wasi/-/quickjs-wasi-0.0.1.tgz#a2087b982a76ac0eb3bdcb93d7e51f178457d0fb"
+  resolved "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-0.0.1.tgz"
   integrity sha512-fBWNLTBkxkLAhe1AzF1hyXEvuA+N+vV1WMP2D6iiMUblvmOt8Pp5t8zUcgvz7aYA1ldUdxDlgUse15dmcKjkNg==
 
 rc9@^2.1.2:
@@ -4894,7 +4732,7 @@ rc9@^2.1.2:
 
 react-devtools-core@7.0.1:
   version "7.0.1"
-  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-7.0.1.tgz#9bc83ac5317b34d0445f765eb17279d62a23f6ee"
+  resolved "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-7.0.1.tgz"
   integrity sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw==
   dependencies:
     shell-quote "^1.6.1"
@@ -4907,14 +4745,14 @@ react-is@^18.3.1:
 
 react-reconciler@^0.33.0:
   version "0.33.0"
-  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.33.0.tgz#9dd20208d45baa5b0b4701781f858236657f15e1"
+  resolved "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz"
   integrity sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==
   dependencies:
     scheduler "^0.27.0"
 
 react@19.2.5:
   version "19.2.5"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.2.5.tgz#c888ab8b8ef33e2597fae8bdb2d77edbdb42858b"
+  resolved "https://registry.npmjs.org/react/-/react-19.2.5.tgz"
   integrity sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==
 
 readable-stream@^3.4.0:
@@ -4928,12 +4766,12 @@ readable-stream@^3.4.0:
 
 readdirp@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-5.0.0.tgz#fbf1f71a727891d685bb1786f9ba74084f6e2f91"
+  resolved "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz"
   integrity sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==
 
 release-it@^20.0.1:
   version "20.0.1"
-  resolved "https://registry.yarnpkg.com/release-it/-/release-it-20.0.1.tgz#ae9885002dc78010ed3fe6651d72b84179de1c0b"
+  resolved "https://registry.npmjs.org/release-it/-/release-it-20.0.1.tgz"
   integrity sha512-3ob1P1aV+3+ZOoR7qgobfYyMlQbpitzOK09iKTtQ145vFi4rWxlRTgHwtVl8kokCvqiF/cJPxRlfcmZmF5aDJA==
   dependencies:
     "@inquirer/prompts" "8.4.2"
@@ -5011,7 +4849,7 @@ restore-cursor@^3.1.0:
 
 restore-cursor@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-4.0.0.tgz#519560a4318975096def6e609d44100edaa4ccb9"
+  resolved "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz"
   integrity sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==
   dependencies:
     onetime "^5.1.0"
@@ -5075,7 +4913,7 @@ rollup-plugin-preserve-shebangs@^0.2.0:
 
 rollup-plugin-typescript2@^0.37.0:
   version "0.37.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.37.0.tgz#7e244d7d0e321673a43bc723b6d0c81789627c4e"
+  resolved "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.37.0.tgz"
   integrity sha512-S1r/4Ufi13Yg/chPlh4iSHWq2Zs/sIAodW5SKUoCQfy/DEQhkS2XRFEtv+NRq3iBO4WHHfqKtDPOC5lJTYm7OQ==
   dependencies:
     "@rollup/pluginutils" "^4.1.2"
@@ -5096,7 +4934,7 @@ rollup-plugin-visualizer@^7.0.1:
 
 rollup@^4.50.0:
   version "4.60.2"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.60.2.tgz#ac23fe4bd530304cef9fa61e639d7098b6762cf4"
+  resolved "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz"
   integrity sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==
   dependencies:
     "@types/estree" "1.0.8"
@@ -5157,12 +4995,12 @@ safe-stable-stringify@^2.5.0:
 
 scheduler@^0.27.0:
   version "0.27.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
+  resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz"
   integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 semver@7.7.4, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.7.2, semver@^7.7.4:
   version "7.7.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
 
 semver@^6.0.0, semver@^6.3.1:
@@ -5184,7 +5022,7 @@ shebang-regex@^3.0.0:
 
 shell-quote@^1.6.1:
   version "1.8.3"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.3.tgz#55e40ef33cf5c689902353a3d8cd1a6725f08b4b"
+  resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz"
   integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
 
 signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
@@ -5199,7 +5037,7 @@ signal-exit@^4.0.1, signal-exit@^4.1.0:
 
 simple-git@3.36.0:
   version "3.36.0"
-  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.36.0.tgz#019b28c0a35847ee34299c6fb63770ab1b2dffb7"
+  resolved "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz"
   integrity sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==
   dependencies:
     "@kwsites/file-exists" "^1.1.1"
@@ -5215,7 +5053,7 @@ slash@^3.0.0:
 
 slice-ansi@^9.0.0:
   version "9.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-9.0.0.tgz#8ed38fdc31f16b607a56cf86c3160d2684f1b61b"
+  resolved "https://registry.npmjs.org/slice-ansi/-/slice-ansi-9.0.0.tgz"
   integrity sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==
   dependencies:
     ansi-styles "^6.2.3"
@@ -5228,7 +5066,7 @@ smart-buffer@^4.2.0:
 
 socks-proxy-agent@9.0.0:
   version "9.0.0"
-  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-9.0.0.tgz#de6683fc7caef7266957692da6169ab85b46f323"
+  resolved "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-9.0.0.tgz"
   integrity sha512-fFlbMlfsXhK02ZB8aZY7Hwxh/IHBV9b1Oq9bvBk6tkFWXvdAxUgA0wbw/NYR5liU3Y5+KI6U4FH3kYJt9QYv0w==
   dependencies:
     agent-base "8.0.0"
@@ -5285,7 +5123,7 @@ stack-utils@^2.0.6:
 
 stdin-discarder@^0.3.1:
   version "0.3.2"
-  resolved "https://registry.yarnpkg.com/stdin-discarder/-/stdin-discarder-0.3.2.tgz#998ab3b9a988661e6036a9bfdc96f43649e8e83e"
+  resolved "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz"
   integrity sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==
 
 string-length@^4.0.2:
@@ -5296,16 +5134,7 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5332,17 +5161,9 @@ string-width@^7.0.0, string-width@^7.2.0:
     get-east-asian-width "^1.0.0"
     strip-ansi "^7.1.0"
 
-string-width@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz"
-  integrity sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==
-  dependencies:
-    get-east-asian-width "^1.3.0"
-    strip-ansi "^7.1.0"
-
-string-width@^8.2.0:
+string-width@^8.1.0, string-width@^8.2.0:
   version "8.2.1"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-8.2.1.tgz#165089cfa527cc88fbc23dd73313f5e334af1ea1"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz"
   integrity sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==
   dependencies:
     get-east-asian-width "^1.5.0"
@@ -5355,14 +5176,7 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5426,12 +5240,12 @@ synckit@^0.11.8:
 
 tagged-tag@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/tagged-tag/-/tagged-tag-1.0.0.tgz#a0b5917c2864cba54841495abfa3f6b13edcf4d6"
+  resolved "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz"
   integrity sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==
 
 terminal-size@^4.0.1:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/terminal-size/-/terminal-size-4.0.1.tgz#4fe8cb7482aae253f042bcd0c67b61f2dde97901"
+  resolved "https://registry.npmjs.org/terminal-size/-/terminal-size-4.0.1.tgz"
   integrity sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==
 
 test-exclude@^6.0.0:
@@ -5478,6 +5292,23 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tree-sitter-javascript@^0.23.1:
+  version "0.23.1"
+  resolved "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.23.1.tgz"
+  integrity sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==
+  dependencies:
+    node-addon-api "^8.2.2"
+    node-gyp-build "^4.8.2"
+
+tree-sitter-typescript@^0.23.2:
+  version "0.23.2"
+  resolved "https://registry.yarnpkg.com/tree-sitter-typescript/-/tree-sitter-typescript-0.23.2.tgz#70bc615a2f664a8e9c87c533382beca587f28ab3"
+  integrity sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==
+  dependencies:
+    node-addon-api "^8.2.2"
+    node-gyp-build "^4.8.2"
+    tree-sitter-javascript "^0.23.1"
+
 ts-algebra@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz"
@@ -5490,7 +5321,7 @@ ts-api-utils@^1.3.0:
 
 ts-jest@^29.1.0:
   version "29.4.9"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.4.9.tgz#47dc33d0f5c36bddcedd16afefae285e0b049d2d"
+  resolved "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz"
   integrity sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==
   dependencies:
     bs-logger "^0.2.6"
@@ -5505,7 +5336,7 @@ ts-jest@^29.1.0:
 
 ts-json-schema-generator@^2.9.0:
   version "2.9.0"
-  resolved "https://registry.yarnpkg.com/ts-json-schema-generator/-/ts-json-schema-generator-2.9.0.tgz#cc2b99db0e64ee9ee6898c8c74905337536ef9fc"
+  resolved "https://registry.npmjs.org/ts-json-schema-generator/-/ts-json-schema-generator-2.9.0.tgz"
   integrity sha512-NR5ZE108uiPtBHBJNGnhwoUaUx5vWTDJzDFG9YlRoqxPU76n+5FClRh92dcGgysbe1smRmYalM9Saj97GW1J4Q==
   dependencies:
     "@types/json-schema" "^7.0.15"
@@ -5585,7 +5416,7 @@ type-fest@^4.41.0:
 
 type-fest@^5.5.0:
   version "5.6.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-5.6.0.tgz#502f7a003b7309e96a7e17052cc2ab2c7e5c7a31"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz"
   integrity sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==
   dependencies:
     tagged-tag "^1.0.0"
@@ -5597,7 +5428,7 @@ typescript@^5.9.3:
 
 typescript@^6.0.3:
   version "6.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz"
   integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 uglify-js@^3.1.4:
@@ -5607,12 +5438,12 @@ uglify-js@^3.1.4:
 
 undici-types@~7.19.0:
   version "7.19.2"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.19.2.tgz#1b67fc26d0f157a0cba3a58a5b5c1e2276b8ba2a"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz"
   integrity sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==
 
 undici@7.24.5:
   version "7.24.5"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.24.5.tgz#7debcf5623df2d1cb469b6face01645d9c852ae2"
+  resolved "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz"
   integrity sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==
 
 universal-user-agent@^7.0.0, universal-user-agent@^7.0.2:
@@ -5684,7 +5515,7 @@ uuid@10.0.0:
 
 uuid@^14.0.0:
   version "14.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz"
   integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
 v8-compile-cache-lib@^3.0.1:
@@ -5715,6 +5546,11 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
+web-tree-sitter@^0.26.8:
+  version "0.26.8"
+  resolved "https://registry.yarnpkg.com/web-tree-sitter/-/web-tree-sitter-0.26.8.tgz#807cb38aed0f25fc4b52994147f1db6b7a92a584"
+  integrity sha512-4sUwi7ZyOrIk5KLgYLkc2A/F0LFMQnBhfb+2Cdl7ik4ePJ6JD+fk4ofI2sA5eGawBKBaK4Vntt7Ww5KcEsay4A==
+
 whatwg-fetch@^3.6.20:
   version "3.6.20"
   resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz"
@@ -5729,7 +5565,7 @@ which@^2.0.1:
 
 widest-line@^6.0.0:
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-6.0.0.tgz#6a8638af837059501d61c5d3bdf72cb934f6c792"
+  resolved "https://registry.npmjs.org/widest-line/-/widest-line-6.0.0.tgz"
   integrity sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==
   dependencies:
     string-width "^8.1.0"
@@ -5741,7 +5577,7 @@ wildcard-match@5.1.4:
 
 windows-release@^7.1.0:
   version "7.1.1"
-  resolved "https://registry.yarnpkg.com/windows-release/-/windows-release-7.1.1.tgz#a4d452a6614f6cefe04a112101aec27d502a9cae"
+  resolved "https://registry.npmjs.org/windows-release/-/windows-release-7.1.1.tgz"
   integrity sha512-0GBwC9WmR8Bm3WYiz3FC391054BsFHZ2gzBVdYj9uj5eIVYzbn/YPYCYW9SWdh9vwnLuzpn1UGwJKiMG4F236w==
   dependencies:
     powershell-utils "^0.2.0"
@@ -5756,7 +5592,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -5767,21 +5603,12 @@ wordwrap@^1.0.0:
 
 wrap-ansi@^10.0.0:
   version "10.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-10.0.0.tgz#b83ddcc14dbc5596f1b07e153bf6f863c1acbb57"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz"
   integrity sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==
   dependencies:
     ansi-styles "^6.2.3"
     string-width "^8.2.0"
     strip-ansi "^7.1.2"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
 
 wrap-ansi@^8.1.0:
   version "8.1.0"
@@ -5816,13 +5643,13 @@ write-file-atomic@^5.0.1:
 
 ws@^7:
   version "7.5.10"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
+  resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
 ws@^8.20.0:
-  version "8.20.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.0.tgz#4cd9532358eba60bc863aad1623dfb045a4d4af8"
-  integrity sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==
+  version "8.20.1"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz"
+  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
 
 wsl-utils@^0.3.0:
   version "0.3.1"
@@ -5844,7 +5671,7 @@ yallist@^3.0.2:
 
 yaml@^2.8.3:
   version "2.8.3"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.3.tgz#a0d6bd2efb3dd03c59370223701834e60409bd7d"
+  resolved "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz"
   integrity sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==
 
 yargs-parser@22.0.0, yargs-parser@^22.0.0:
@@ -5899,7 +5726,7 @@ yoctocolors@^2.1.1:
 
 yoga-layout@~3.2.1:
   version "3.2.1"
-  resolved "https://registry.yarnpkg.com/yoga-layout/-/yoga-layout-3.2.1.tgz#d2d1ba06f0e81c2eb650c3e5ad8b0b4adde1e843"
+  resolved "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz"
   integrity sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==
 
 "zod@^3.25.76 || ^4":


### PR DESCRIPTION
## Summary

First actual tree-sitter parser plugged into the registry from #950. `ts` / `js` extraction now prefers tree-sitter; the regex parser stays in the chain as the fallback. No change to user-visible config — gated by the same `languageAware.enabled` flag.

## What lands

- **Bundle**: `web-tree-sitter` (runtime), `tree-sitter-typescript` (devDep, only the .wasm files ship).
- **Postbuild script** copies the engine + tsx + ts wasms to `dist/tree-sitter/` (~2.9 MB total).
- **Rollup ESM intro** defines `__dirname` from `import.meta.url` so source code can use `__dirname` in both CJS and ESM outputs (per discussion about future-proofness — see commit body).
- **Runtime wrapper** with memoized engine init, per-language parser cache, and graceful surrender when wasms aren't available.
- **TS/TSX extractor** — per-line AST extraction matching the regex output shape. Catches arrow-function exports, string-embedded keywords, and JSX-in-TSX (which the regex either misses or could false-positive on).
- **Registry**: `ts`/`js` chains become `[treeSitterTsParser, regexTs]`. Steady-state behavior unchanged for users without wasms loaded.

## What lights up vs. regex

- `export const handler = (req) => process(req)` now reads as `handler()` (function), not `const handler`.
- TSX with JSX bodies parses cleanly.
- Tokens inside string literals are correctly ignored.

## Tests

- **8 integration tests** for the TS extractor, gated on `COCO_TEST_TREE_SITTER=1 NODE_OPTIONS=--experimental-vm-modules`. Run them locally with that flag set; CI can opt in. Default `npx jest` skips them and relies on the registry-level tests (regex fallback path) plus the eval-harness CLI (#934) for integration verification — eval runs as vanilla Node with full ESM, which is the right tool for this check.
- **Existing 1640 tests** still pass with no changes.

## Decisions explained in commit body

- Why WASM and not native bindings
- Why `__dirname` + rollup intro vs. `import.meta.url` everywhere
- Why the Function-constructor dynamic-import shim
- Why the integration suite is opt-in (jest ESM limitations)
- Why yarn.lock has a big diff (legit: cleans up stale transitive deps that have been out of sync, in addition to the 2 direct adds)

## Out of scope (future phases)

- **Phase 2** — JS parser (`tree-sitter-javascript`)
- **Phase 3** — lazy-load infra (cache dir, first-use prompt, manifest)
- **Phase 4–6** — Python / Rust / Go via lazy-load
- **Phase 7** — eval-harness baseline comparison + `coco cache` subcommand

## Test plan

- [x] `npx tsc --noEmit` → 0 errors
- [x] `npx jest` → 1640/1647 pass, 7 skipped (default mode)
- [x] `NODE_OPTIONS=--experimental-vm-modules COCO_TEST_TREE_SITTER=1 npx jest src/lib/parsers/default/__tree_sitter__` → 8/8 pass
- [x] `npx eslint` on touched files → clean
- [x] `node bin/copyTreeSitterWasm.mjs` → copies 3 wasms (2.91 MB)
- [ ] Manual: full build (`npm run build`) → confirms postbuild copies wasms to dist
- [ ] Manual: in a TS project, run with `languageAware.enabled: true` and confirm tree-sitter fires (verbose log shows "language-aware fast-path skip")

Refs #933.