### PR TITLE
feat(parser): lazy-load infrastructure + Python tree-sitter parser (#933 phase 3)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,24 @@ y.command<CacheOptions>(
   cache.handler
 )
 
-y.help().parse(process.argv.slice(2))
+// `COCO_PREFETCH` hook (#933 phase 3). When set, downloads any
+// requested lazy-load tree-sitter parsers into the user's cache
+// dir before yargs hands control to a subcommand. No-op when
+// unset, so the typical CLI path pays zero overhead.
+//
+// Errors here are non-fatal: a failed download prints a warning
+// to stderr; the subcommand still runs (just with the regex
+// fallback for that language).
+import { runPrefetchFromEnv } from './lib/parsers/default/__tree_sitter__/prefetch'
+
+async function main(): Promise<void> {
+  await runPrefetchFromEnv()
+  y.help().parse(process.argv.slice(2))
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})
 
 export { cache, changelog, commit, Config, doctor, init, log, recap, types, ui }

--- a/src/lib/parsers/default/__evals__/scenarioInputs.test.ts
+++ b/src/lib/parsers/default/__evals__/scenarioInputs.test.ts
@@ -6,6 +6,13 @@ describe('buildScenarioFixtures', () => {
   })
 
   it('produces a fixture per commit with per-file diffs', async () => {
+    // Heavier than the default 5s timeout: this spins up a real
+    // temp git repo, runs `git init` + multiple `git commit`s for
+    // the feature-pr-ready scenario, then walks the log calling
+    // `git show --numstat` + per-file `git show` for each commit.
+    // Under load (parallel jest workers) the shell-out cost adds
+    // up. The 15s budget is comfortably under any reasonable CI
+    // run-time and avoids the periodic flake we saw under default.
     const { repo, fixtures } = await buildScenarioFixtures('feature-pr-ready')
     try {
       expect(fixtures.scenario).toBe('feature-pr-ready')
@@ -28,7 +35,7 @@ describe('buildScenarioFixtures', () => {
     } finally {
       await repo.cleanup()
     }
-  })
+  }, 15_000)
 
   it('extracts the same byte-identical fixture set across runs (determinism)', async () => {
     const a = await buildScenarioFixtures('single-staged-file')

--- a/src/lib/parsers/default/__tree_sitter__/cache.test.ts
+++ b/src/lib/parsers/default/__tree_sitter__/cache.test.ts
@@ -1,0 +1,54 @@
+import { platform } from 'node:os'
+import {
+  getCacheRootDir,
+  getCachedWasmPath,
+  getTreeSitterCacheDir,
+} from './cache'
+
+describe('cache directory resolution', () => {
+  describe('getCacheRootDir', () => {
+    afterEach(() => {
+      delete process.env.XDG_CACHE_HOME
+      delete process.env.LOCALAPPDATA
+    })
+
+    it('honors XDG_CACHE_HOME on Unix when set', () => {
+      if (platform() === 'win32') return
+      process.env.XDG_CACHE_HOME = '/tmp/xdg-cache-test'
+      expect(getCacheRootDir()).toBe('/tmp/xdg-cache-test/coco')
+    })
+
+    it('falls back to ~/.cache/coco on Unix when XDG is unset', () => {
+      if (platform() === 'win32') return
+      delete process.env.XDG_CACHE_HOME
+      expect(getCacheRootDir()).toMatch(/\.cache\/coco$/)
+    })
+
+    it('uses LOCALAPPDATA on Windows when set', () => {
+      if (platform() !== 'win32') return
+      process.env.LOCALAPPDATA = 'C:\\Users\\Test\\AppData\\Local'
+      expect(getCacheRootDir()).toMatch(/coco[\\/]+Cache$/)
+    })
+  })
+
+  describe('getTreeSitterCacheDir', () => {
+    it('is the tree-sitter subdir of the cache root', () => {
+      const root = getCacheRootDir()
+      const sub = getTreeSitterCacheDir()
+      expect(sub).toBe(`${root}/tree-sitter`.replace(/\//g, platform() === 'win32' ? /[\\/]/.source : '/').replace(/\[.+\]/, '/'))
+      // Loose check that handles platform separator without
+      // rebuilding the path: tree-sitter subdir must startWith
+      // the root and end with `tree-sitter`.
+      expect(sub.startsWith(root)).toBe(true)
+      expect(sub).toMatch(/tree-sitter$/)
+    })
+  })
+
+  describe('getCachedWasmPath', () => {
+    it('returns a path under the tree-sitter cache dir', () => {
+      const path = getCachedWasmPath('python')
+      expect(path).toMatch(/tree-sitter[\\/]+tree-sitter-python\.wasm$/)
+      expect(path.startsWith(getTreeSitterCacheDir())).toBe(true)
+    })
+  })
+})

--- a/src/lib/parsers/default/__tree_sitter__/cache.ts
+++ b/src/lib/parsers/default/__tree_sitter__/cache.ts
@@ -1,0 +1,115 @@
+/**
+ * Cache directory resolution for lazy-loaded tree-sitter parsers
+ * (#933 phase 3).
+ *
+ * Languages NOT bundled with coco (Python, Rust, Go) ship their
+ * `.wasm` parsers via lazy-download from a CDN, validated against
+ * a manifest in `manifest.ts`. This module owns the on-disk
+ * location: where the downloads land, and how runtime resolves a
+ * language id back to a `.wasm` path.
+ *
+ * Layout follows the XDG Base Directory spec where applicable:
+ *
+ *   - Linux/macOS: `$XDG_CACHE_HOME/coco/tree-sitter/` if set,
+ *     else `~/.cache/coco/tree-sitter/`.
+ *   - Windows: `%LOCALAPPDATA%/coco/Cache/tree-sitter/` if set,
+ *     else `%USERPROFILE%/AppData/Local/coco/Cache/tree-sitter/`.
+ *
+ * The cache is shared across all projects on the machine — once a
+ * user opts into a language's parser, every coco invocation
+ * (across every repo) reuses it.
+ *
+ * The cache is also a one-way write target: this module exposes
+ * the path resolution + a `ensureCacheDir()` helper that creates
+ * the directory on demand. Eviction / `coco cache clear` is a
+ * polish-phase concern; today, users `rm -rf` the dir manually.
+ */
+
+import { existsSync, mkdirSync } from 'node:fs'
+import { homedir, platform } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * Tree-sitter language identifiers eligible for the lazy-load path.
+ * Bundled languages (`typescript`, `tsx`) are intentionally NOT in
+ * this list — they ship in `dist/tree-sitter/` via the postbuild
+ * copy step. Adding a lazy-loaded language: extend this union AND
+ * add the matching entry to `TREE_SITTER_MANIFEST`.
+ */
+export type LazyTreeSitterLanguageId = 'python'
+
+/**
+ * Resolve the root cache directory for coco. Honors three env-var
+ * overrides in priority order:
+ *
+ *   1. `COCO_CACHE_DIR` — direct override of the cache root.
+ *      Useful for CI (pin a known location) and for tests
+ *      (each test file points at its own temp dir so parallel
+ *      workers don't stomp on each other).
+ *   2. `XDG_CACHE_HOME` (Unix) / `LOCALAPPDATA` (Windows) —
+ *      respects the platform-canonical override.
+ *   3. Platform default — `~/.cache/coco` on Unix,
+ *      `%USERPROFILE%\AppData\Local\coco\Cache` on Windows.
+ *
+ * No filesystem operations — pure path computation. Callers that
+ * actually want to write should pass through `ensureCacheDir`.
+ */
+export function getCacheRootDir(): string {
+  const direct = process.env.COCO_CACHE_DIR
+  if (direct) return direct
+  if (platform() === 'win32') {
+    const local = process.env.LOCALAPPDATA
+    if (local) return join(local, 'coco', 'Cache')
+    return join(homedir(), 'AppData', 'Local', 'coco', 'Cache')
+  }
+  // Linux/macOS — XDG-style. macOS technically has its own
+  // `~/Library/Caches/<app>` convention but most CLI tools use the
+  // XDG layout there for consistency with Linux. The XDG env var
+  // takes precedence when set, which lets containerized / sandboxed
+  // setups override.
+  const xdg = process.env.XDG_CACHE_HOME
+  if (xdg) return join(xdg, 'coco')
+  return join(homedir(), '.cache', 'coco')
+}
+
+/**
+ * Tree-sitter cache subdir: where lazy-loaded `.wasm` parsers
+ * land. Sibling to any other cache dirs coco might grow.
+ */
+export function getTreeSitterCacheDir(): string {
+  return join(getCacheRootDir(), 'tree-sitter')
+}
+
+/**
+ * Filesystem path for a lazy-loaded language's cached `.wasm`.
+ * Filenames mirror what the runtime expects in `dist/tree-sitter/`
+ * for bundled languages, so the resolver can fall through cleanly
+ * between bundled and cached locations.
+ */
+export function getCachedWasmPath(language: LazyTreeSitterLanguageId): string {
+  return join(getTreeSitterCacheDir(), `tree-sitter-${language}.wasm`)
+}
+
+/**
+ * Create the tree-sitter cache directory (and any missing
+ * parents). Idempotent — safe to call before every write.
+ *
+ * Returns the directory path so the caller can use it directly.
+ * Errors here would otherwise cascade into confusing
+ * "ENOENT" reports during download; the explicit ensure step
+ * keeps failures observable at the right layer.
+ */
+export function ensureTreeSitterCacheDir(): string {
+  const dir = getTreeSitterCacheDir()
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+/**
+ * True when a lazy-loaded language's `.wasm` is already cached
+ * locally. Used by the runtime to decide whether to short-circuit
+ * to the cached file or fall through to the regex parser.
+ */
+export function isLanguageCached(language: LazyTreeSitterLanguageId): boolean {
+  return existsSync(getCachedWasmPath(language))
+}

--- a/src/lib/parsers/default/__tree_sitter__/download.test.ts
+++ b/src/lib/parsers/default/__tree_sitter__/download.test.ts
@@ -1,0 +1,135 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// Per-test-file cache override — keeps parallel jest workers from
+// racing on a shared `~/.cache/coco/tree-sitter/`. Must be set
+// BEFORE the cache module is imported so its first read picks it up.
+process.env.COCO_CACHE_DIR = mkdtempSync(join(tmpdir(), 'coco-cache-download-test-'))
+
+import { downloadTreeSitterParser, formatDownloadOutcome } from './download'
+import { getCachedWasmPath, getTreeSitterCacheDir } from './cache'
+import { TREE_SITTER_MANIFEST } from './manifest'
+
+const PY_BYTES = new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef])
+// SHA-256 of the PY_BYTES fixture above — recomputed if PY_BYTES changes.
+const PY_HASH = 'b600e3f7b5cc87bc0f00020de1d51f557e628e659eb02fd5e18aac9871a3e479'
+
+describe('downloadTreeSitterParser', () => {
+  let originalSha: string
+
+  beforeAll(() => {
+    // Stub the manifest sha to match our fake-bytes hash so the
+    // verify step accepts our test payload. Restore in afterAll.
+    originalSha = TREE_SITTER_MANIFEST.python.sha256
+    TREE_SITTER_MANIFEST.python.sha256 = PY_HASH
+  })
+
+  afterAll(() => {
+    TREE_SITTER_MANIFEST.python.sha256 = originalSha
+    // Wipe the whole test-file cache once at end.
+    try {
+      rmSync(process.env.COCO_CACHE_DIR as string, { recursive: true, force: true })
+    } catch {
+      // ignore — best effort
+    }
+  })
+
+  afterEach(() => {
+    // Wipe the per-language cache between tests so each starts
+    // from empty (but leave the dir itself in place for the next
+    // test's write).
+    try {
+      rmSync(getTreeSitterCacheDir(), { recursive: true, force: true })
+    } catch {
+      // First-time runs may not have created it
+    }
+  })
+
+  it('writes the cached wasm and returns ok when the hash matches', async () => {
+    const fakeFetch: typeof globalThis.fetch = async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      arrayBuffer: async () => PY_BYTES.buffer,
+    } as unknown as Response)
+
+    const outcome = await downloadTreeSitterParser('python', { fetchImpl: fakeFetch })
+    expect(outcome.ok).toBe(true)
+    if (!outcome.ok) return
+
+    expect(outcome.path).toBe(getCachedWasmPath('python'))
+    expect(outcome.bytes).toBe(PY_BYTES.byteLength)
+    const onDisk = readFileSync(outcome.path)
+    expect(onDisk.equals(Buffer.from(PY_BYTES))).toBe(true)
+  })
+
+  it('refuses to write when the SHA doesn\'t match the manifest', async () => {
+    const tamperedBytes = new Uint8Array([...PY_BYTES, 0xff])
+    const fakeFetch: typeof globalThis.fetch = async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      arrayBuffer: async () => tamperedBytes.buffer,
+    } as unknown as Response)
+
+    const outcome = await downloadTreeSitterParser('python', { fetchImpl: fakeFetch })
+    expect(outcome.ok).toBe(false)
+    if (outcome.ok) return
+    expect(outcome.reason).toBe('sha-mismatch')
+  })
+
+  it('returns a network error on non-2xx responses', async () => {
+    const fakeFetch: typeof globalThis.fetch = async () => ({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      arrayBuffer: async () => new ArrayBuffer(0),
+    } as unknown as Response)
+
+    const outcome = await downloadTreeSitterParser('python', { fetchImpl: fakeFetch })
+    expect(outcome.ok).toBe(false)
+    if (outcome.ok || outcome.reason !== 'network') {
+      throw new Error('expected a network outcome')
+    }
+    expect(outcome.message).toContain('404')
+  })
+
+  it('returns a network error when fetch itself throws', async () => {
+    const fakeFetch: typeof globalThis.fetch = async () => {
+      throw new Error('ECONNREFUSED')
+    }
+
+    const outcome = await downloadTreeSitterParser('python', { fetchImpl: fakeFetch })
+    expect(outcome.ok).toBe(false)
+    if (outcome.ok) throw new Error('expected failure')
+    if (outcome.reason !== 'network') throw new Error('expected network reason')
+    expect(outcome.message).toBe('ECONNREFUSED')
+  })
+})
+
+describe('formatDownloadOutcome', () => {
+  it('renders a check + cache path on success', () => {
+    const line = formatDownloadOutcome('python', { ok: true, path: '/tmp/x.wasm', bytes: 1024 })
+    expect(line).toMatch(/✓ Python parser cached/)
+    expect(line).toContain('/tmp/x.wasm')
+  })
+
+  it('renders an x + reason on network failure', () => {
+    const line = formatDownloadOutcome('python', { ok: false, reason: 'network', message: 'oops' })
+    expect(line).toMatch(/✗ Python: network error/)
+    expect(line).toContain('oops')
+  })
+
+  it('renders a hash-mismatch warning with short hashes', () => {
+    const line = formatDownloadOutcome('python', {
+      ok: false,
+      reason: 'sha-mismatch',
+      expected: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      actual: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    })
+    expect(line).toMatch(/SHA-256 mismatch/)
+    expect(line).toContain('aaaaaaaaaaaa')
+    expect(line).toContain('bbbbbbbbbbbb')
+  })
+})

--- a/src/lib/parsers/default/__tree_sitter__/download.ts
+++ b/src/lib/parsers/default/__tree_sitter__/download.ts
@@ -1,0 +1,115 @@
+/**
+ * Tree-sitter parser download + verification (#933 phase 3).
+ *
+ * Owns the contract:
+ *
+ *   1. Fetch the manifest-pinned `.wasm` from the CDN URL
+ *   2. Compute SHA-256 over the bytes
+ *   3. Compare against the manifest-pinned hash; refuse to write
+ *      on mismatch
+ *   4. Write to the cache dir atomically (temp file + rename)
+ *
+ * Errors at any stage surface as a typed result the caller can
+ * branch on, NOT as exceptions — the prefetch orchestrator
+ * processes multiple languages and shouldn't tear down because
+ * one failed.
+ *
+ * No interactive prompts here. The caller (prefetch.ts) decides
+ * whether to ask the user before triggering a download; this
+ * module is a quiet workhorse.
+ */
+
+import { createHash } from 'node:crypto'
+import { renameSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  ensureTreeSitterCacheDir,
+  getCachedWasmPath,
+  LazyTreeSitterLanguageId,
+} from './cache'
+import { TREE_SITTER_MANIFEST, TreeSitterManifestEntry } from './manifest'
+
+export type DownloadOutcome =
+  | { ok: true; path: string; bytes: number }
+  | { ok: false; reason: 'network'; message: string }
+  | { ok: false; reason: 'sha-mismatch'; expected: string; actual: string }
+  | { ok: false; reason: 'write-failed'; message: string }
+
+/**
+ * Fetch the manifest-pinned `.wasm` for a language, verify its
+ * SHA-256 against the manifest, and write it to the cache dir.
+ *
+ * Atomic-write strategy: we fetch the full body into memory
+ * (these files are small — ~450 KB for Python), write to a
+ * sibling `.tmp` file, rename into place. This avoids leaving
+ * a partial / corrupt `.wasm` at the canonical cache path if
+ * the process is interrupted mid-write.
+ *
+ * Returns a structured `DownloadOutcome` rather than throwing.
+ * The orchestrator handles `ok: false` cases by surrendering to
+ * the regex fallback and (optionally) logging.
+ */
+export async function downloadTreeSitterParser(
+  language: LazyTreeSitterLanguageId,
+  options?: { fetchImpl?: typeof globalThis.fetch },
+): Promise<DownloadOutcome> {
+  const entry: TreeSitterManifestEntry = TREE_SITTER_MANIFEST[language]
+  const fetchImpl = options?.fetchImpl || globalThis.fetch
+
+  let body: ArrayBuffer
+  try {
+    const response = await fetchImpl(entry.wasmUrl)
+    if (!response.ok) {
+      return { ok: false, reason: 'network', message: `HTTP ${response.status} ${response.statusText}` }
+    }
+    body = await response.arrayBuffer()
+  } catch (error) {
+    return { ok: false, reason: 'network', message: (error as Error).message }
+  }
+
+  const bytes = new Uint8Array(body)
+  const actualHash = createHash('sha256').update(bytes).digest('hex')
+  if (actualHash !== entry.sha256) {
+    return {
+      ok: false,
+      reason: 'sha-mismatch',
+      expected: entry.sha256,
+      actual: actualHash,
+    }
+  }
+
+  const cacheDir = ensureTreeSitterCacheDir()
+  const finalPath = getCachedWasmPath(language)
+  const tempPath = join(cacheDir, `tree-sitter-${language}.wasm.tmp-${process.pid}-${Date.now()}`)
+  try {
+    writeFileSync(tempPath, bytes)
+    renameSync(tempPath, finalPath)
+  } catch (error) {
+    return { ok: false, reason: 'write-failed', message: (error as Error).message }
+  }
+
+  return { ok: true, path: finalPath, bytes: bytes.byteLength }
+}
+
+/**
+ * Human-readable summary of a `DownloadOutcome`, for status
+ * messages + log output. The orchestrator emits this to stdout/
+ * stderr; tests use it for assertions.
+ */
+export function formatDownloadOutcome(
+  language: LazyTreeSitterLanguageId,
+  outcome: DownloadOutcome,
+): string {
+  const entry = TREE_SITTER_MANIFEST[language]
+  if (outcome.ok) {
+    const kb = (outcome.bytes / 1024).toFixed(0)
+    return `✓ ${entry.displayName} parser cached (${kb} KB) at ${outcome.path}`
+  }
+  if (outcome.reason === 'network') {
+    return `✗ ${entry.displayName}: network error — ${outcome.message}`
+  }
+  if (outcome.reason === 'sha-mismatch') {
+    return `✗ ${entry.displayName}: SHA-256 mismatch (expected ${outcome.expected.slice(0, 12)}…, got ${outcome.actual.slice(0, 12)}…) — refusing to cache`
+  }
+  return `✗ ${entry.displayName}: write failed — ${outcome.message}`
+}

--- a/src/lib/parsers/default/__tree_sitter__/manifest.ts
+++ b/src/lib/parsers/default/__tree_sitter__/manifest.ts
@@ -1,0 +1,67 @@
+/**
+ * Lazy-loaded tree-sitter parser manifest (#933 phase 3).
+ *
+ * The source of truth for "which .wasm files can be lazy-downloaded
+ * and where they live upstream". Each entry pins an explicit
+ * version + SHA-256 so a corrupt or tampered download is rejected
+ * before the file ever touches the parser. Updating a language's
+ * parser version is a deliberate manifest edit, NOT something that
+ * floats with package.json updates — keeps the supply chain
+ * surface area small and explicit.
+ *
+ * URL choice: jsdelivr's CDN-of-npm path serves the raw .wasm file
+ * (~450 KB for Python) from a globally-distributed CDN, without
+ * pulling the full npm tarball (which would be 10× larger for the
+ * same content). The URL pattern is stable across versions; only
+ * the version segment changes. Mirrors (unpkg, fastly) are options
+ * if jsdelivr proves unreliable in practice.
+ *
+ * SHA-256s are computed at manifest-edit time by downloading the
+ * file once and running `shasum -a 256`. The download module
+ * (`download.ts`) re-computes after every fetch and refuses to
+ * write the cached file when the hash doesn't match.
+ */
+
+import type { LazyTreeSitterLanguageId } from './cache'
+
+export type TreeSitterManifestEntry = {
+  /** Language id — matches `LazyTreeSitterLanguageId`. */
+  language: LazyTreeSitterLanguageId
+  /** Human-readable name for log / status messages. */
+  displayName: string
+  /** Upstream package version pinned in the manifest. */
+  version: string
+  /** Direct URL to the `.wasm` file. */
+  wasmUrl: string
+  /**
+   * Lower-case hex sha-256 of the bytes at `wasmUrl`. The download
+   * module verifies before writing to the cache.
+   */
+  sha256: string
+  /** Approximate uncompressed size in bytes — drives the user-facing "~XXX KB" prompt. */
+  approxBytes: number
+}
+
+/**
+ * Per-language manifest. Every `LazyTreeSitterLanguageId` MUST
+ * have an entry here — that's enforced by the `Record` typing.
+ * Phase 3 ships Python; Rust + Go follow in phases 5 / 6.
+ */
+export const TREE_SITTER_MANIFEST: Record<LazyTreeSitterLanguageId, TreeSitterManifestEntry> = {
+  python: {
+    language: 'python',
+    displayName: 'Python',
+    version: '0.23.6',
+    wasmUrl: 'https://cdn.jsdelivr.net/npm/tree-sitter-python@0.23.6/tree-sitter-python.wasm',
+    sha256: '8c93692fb368e288a5824cee55773c9b3602804f513bda48c97661e52e9c2da2',
+    approxBytes: 458_752,
+  },
+}
+
+/**
+ * List the languages known to the lazy-load path. Order is the
+ * iteration order of the manifest entries — informational only.
+ */
+export function listManifestLanguages(): LazyTreeSitterLanguageId[] {
+  return Object.keys(TREE_SITTER_MANIFEST) as LazyTreeSitterLanguageId[]
+}

--- a/src/lib/parsers/default/__tree_sitter__/prefetch.test.ts
+++ b/src/lib/parsers/default/__tree_sitter__/prefetch.test.ts
@@ -1,0 +1,153 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// Per-test-file cache override — see download.test.ts for rationale.
+process.env.COCO_CACHE_DIR = mkdtempSync(join(tmpdir(), 'coco-cache-prefetch-test-'))
+
+import {
+  parsePrefetchEnv,
+  prefetchTreeSitterParsers,
+  runPrefetchFromEnv,
+} from './prefetch'
+import { getTreeSitterCacheDir, isLanguageCached } from './cache'
+import type { DownloadOutcome } from './download'
+
+afterAll(() => {
+  try {
+    rmSync(process.env.COCO_CACHE_DIR as string, { recursive: true, force: true })
+  } catch {
+    // ignore
+  }
+})
+
+describe('parsePrefetchEnv', () => {
+  it('returns empty when the env var is unset / empty', () => {
+    expect(parsePrefetchEnv(undefined)).toEqual({ resolved: [], unknown: [] })
+    expect(parsePrefetchEnv('')).toEqual({ resolved: [], unknown: [] })
+    expect(parsePrefetchEnv('   ')).toEqual({ resolved: [], unknown: [] })
+  })
+
+  it('resolves short aliases to canonical language ids', () => {
+    expect(parsePrefetchEnv('py')).toEqual({ resolved: ['python'], unknown: [] })
+    expect(parsePrefetchEnv('python')).toEqual({ resolved: ['python'], unknown: [] })
+  })
+
+  it('expands `all` to every manifest language', () => {
+    expect(parsePrefetchEnv('all').resolved).toContain('python')
+  })
+
+  it('deduplicates resolved languages', () => {
+    expect(parsePrefetchEnv('py,python,py').resolved).toEqual(['python'])
+  })
+
+  it('flags unknown tokens but still returns recognized ones', () => {
+    const { resolved, unknown } = parsePrefetchEnv('py,scala,xyz')
+    expect(resolved).toEqual(['python'])
+    expect(unknown).toEqual(['scala', 'xyz'])
+  })
+})
+
+describe('prefetchTreeSitterParsers', () => {
+  afterEach(() => {
+    try {
+      rmSync(getTreeSitterCacheDir(), { recursive: true, force: true })
+    } catch {
+      // ignore
+    }
+  })
+
+  it('skips languages already cached', async () => {
+    const fakeDownload = jest.fn<Promise<DownloadOutcome>, [unknown]>()
+    // Pretend python is cached by creating the file ahead of time.
+    const { mkdirSync, writeFileSync } = await import('node:fs')
+    const { join } = await import('node:path')
+    mkdirSync(getTreeSitterCacheDir(), { recursive: true })
+    writeFileSync(join(getTreeSitterCacheDir(), 'tree-sitter-python.wasm'), 'fake')
+
+    expect(isLanguageCached('python')).toBe(true)
+
+    const result = await prefetchTreeSitterParsers(['python'], {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      download: fakeDownload as any,
+      writeLine: () => undefined,
+    })
+    expect(result.alreadyCached).toEqual(['python'])
+    expect(result.downloaded).toEqual([])
+    expect(fakeDownload).not.toHaveBeenCalled()
+  })
+
+  it('records a successful download', async () => {
+    const fakeDownload = jest.fn(
+      async (): Promise<DownloadOutcome> => ({ ok: true, path: '/tmp/x.wasm', bytes: 100 }),
+    )
+    const result = await prefetchTreeSitterParsers(['python'], {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      download: fakeDownload as any,
+      writeLine: () => undefined,
+    })
+    expect(result.downloaded).toEqual(['python'])
+    expect(result.failed).toEqual([])
+    expect(fakeDownload).toHaveBeenCalledWith('python')
+  })
+
+  it('records a failed download but continues processing', async () => {
+    const fakeDownload = jest.fn(
+      async (): Promise<DownloadOutcome> => ({ ok: false, reason: 'network', message: 'boom' }),
+    )
+    const result = await prefetchTreeSitterParsers(['python'], {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      download: fakeDownload as any,
+      writeLine: () => undefined,
+    })
+    expect(result.downloaded).toEqual([])
+    expect(result.failed).toEqual(['python'])
+  })
+})
+
+describe('runPrefetchFromEnv', () => {
+  it('is a no-op when COCO_PREFETCH is unset', async () => {
+    const fakeDownload = jest.fn()
+    const result = await runPrefetchFromEnv({
+      env: {},
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      download: fakeDownload as any,
+      writeLine: () => undefined,
+    })
+    expect(result.requested).toEqual([])
+    expect(fakeDownload).not.toHaveBeenCalled()
+  })
+
+  it('runs downloads when COCO_PREFETCH names known languages', async () => {
+    const fakeDownload = jest.fn(
+      async (): Promise<DownloadOutcome> => ({ ok: true, path: '/tmp/x.wasm', bytes: 100 }),
+    )
+    const lines: string[] = []
+    const result = await runPrefetchFromEnv({
+      env: { COCO_PREFETCH: 'py' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      download: fakeDownload as any,
+      writeLine: (line) => lines.push(line),
+    })
+    expect(result.requested).toEqual(['python'])
+    expect(result.downloaded).toEqual(['python'])
+    expect(lines.some((l) => l.includes('downloading'))).toBe(true)
+    expect(lines.some((l) => l.includes('Python parser cached'))).toBe(true)
+  })
+
+  it('warns about unknown language tokens but still processes the recognized ones', async () => {
+    const fakeDownload = jest.fn(
+      async (): Promise<DownloadOutcome> => ({ ok: true, path: '/tmp/x.wasm', bytes: 100 }),
+    )
+    const lines: string[] = []
+    const result = await runPrefetchFromEnv({
+      env: { COCO_PREFETCH: 'py,scala' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      download: fakeDownload as any,
+      writeLine: (line) => lines.push(line),
+    })
+    expect(result.unknown).toEqual(['scala'])
+    expect(result.downloaded).toEqual(['python'])
+    expect(lines.some((l) => l.includes('ignoring unknown language(s): scala'))).toBe(true)
+  })
+})

--- a/src/lib/parsers/default/__tree_sitter__/prefetch.ts
+++ b/src/lib/parsers/default/__tree_sitter__/prefetch.ts
@@ -1,0 +1,178 @@
+/**
+ * Prefetch orchestrator for lazy-loaded tree-sitter parsers
+ * (#933 phase 3).
+ *
+ * Reads the `COCO_PREFETCH` environment variable at CLI startup
+ * and downloads any requested-but-missing parsers into the
+ * cache. Wired into `src/index.ts`'s entry path so it runs
+ * before any command logic that might consult the parser.
+ *
+ * Syntax for the env var:
+ *
+ *   COCO_PREFETCH=py            single language
+ *   COCO_PREFETCH=py,rs,go      comma-separated list
+ *   COCO_PREFETCH=all           every language in the manifest
+ *   COCO_PREFETCH=               (empty / unset → no-op)
+ *
+ * Unrecognized language ids are skipped with a warning to stderr.
+ * Already-cached languages are skipped silently. The orchestrator
+ * processes the list serially — five parallel downloads to the
+ * same CDN don't get five-times faster, and serial-with-progress
+ * is a calmer UX.
+ *
+ * Errors don't crash the CLI. A failed download (network outage,
+ * SHA mismatch) prints a warning and continues; the user's
+ * subsequent `coco commit` simply falls through to the regex
+ * parser for that language. The CLI logs surface the failure so
+ * the user knows to retry; we never silently leave the user
+ * thinking they got tree-sitter when they didn't.
+ */
+
+import {
+  isLanguageCached,
+  LazyTreeSitterLanguageId,
+} from './cache'
+import {
+  downloadTreeSitterParser,
+  formatDownloadOutcome,
+} from './download'
+import {
+  listManifestLanguages,
+  TREE_SITTER_MANIFEST,
+} from './manifest'
+
+/**
+ * Short aliases the user can write in the env var. Mirrors the
+ * existing `languageAware.languages` config knob from phase 1
+ * (`'ts' | 'js' | 'py' | 'rs' | 'go'`).
+ */
+const ALIASES: Record<string, LazyTreeSitterLanguageId> = {
+  py: 'python',
+  python: 'python',
+}
+
+export type PrefetchResult = {
+  /** Languages the user asked for that this run resolved to a manifest entry. */
+  requested: LazyTreeSitterLanguageId[]
+  /** Languages already cached at start — no-op skipped. */
+  alreadyCached: LazyTreeSitterLanguageId[]
+  /** Languages successfully downloaded + cached during this run. */
+  downloaded: LazyTreeSitterLanguageId[]
+  /** Languages whose download failed (network / SHA / write). */
+  failed: LazyTreeSitterLanguageId[]
+  /** Aliases the user passed that didn't resolve to a known language. */
+  unknown: string[]
+}
+
+/**
+ * Parse the COCO_PREFETCH env var into a list of language ids.
+ * Returns an empty list when unset, empty, or set to garbage —
+ * the orchestrator turns that into a no-op.
+ *
+ * Exported for direct testing.
+ */
+export function parsePrefetchEnv(raw: string | undefined): {
+  resolved: LazyTreeSitterLanguageId[]
+  unknown: string[]
+} {
+  if (!raw || !raw.trim()) return { resolved: [], unknown: [] }
+  const tokens = raw.split(',').map((t) => t.trim().toLowerCase()).filter(Boolean)
+  if (tokens.includes('all')) {
+    return { resolved: listManifestLanguages(), unknown: [] }
+  }
+  const resolved: LazyTreeSitterLanguageId[] = []
+  const unknown: string[] = []
+  const seen = new Set<LazyTreeSitterLanguageId>()
+  for (const token of tokens) {
+    const resolvedId = ALIASES[token]
+    if (!resolvedId) {
+      unknown.push(token)
+      continue
+    }
+    if (!seen.has(resolvedId)) {
+      seen.add(resolvedId)
+      resolved.push(resolvedId)
+    }
+  }
+  return { resolved, unknown }
+}
+
+/**
+ * Download every requested language that isn't already cached.
+ * Returns a structured result; the caller decides whether to
+ * print summary lines.
+ */
+export async function prefetchTreeSitterParsers(
+  languages: LazyTreeSitterLanguageId[],
+  options?: {
+    /** Test seam — defaults to the real download module. */
+    download?: typeof downloadTreeSitterParser
+    /** Receives each per-language status line. Defaults to stderr. */
+    writeLine?: (line: string) => void
+  },
+): Promise<PrefetchResult> {
+  const download = options?.download || downloadTreeSitterParser
+  const writeLine = options?.writeLine || ((line: string) => process.stderr.write(`${line}\n`))
+
+  const result: PrefetchResult = {
+    requested: languages,
+    alreadyCached: [],
+    downloaded: [],
+    failed: [],
+    unknown: [],
+  }
+
+  for (const language of languages) {
+    if (isLanguageCached(language)) {
+      result.alreadyCached.push(language)
+      continue
+    }
+    const entry = TREE_SITTER_MANIFEST[language]
+    writeLine(`· ${entry.displayName}: downloading ${entry.wasmUrl}…`)
+    const outcome = await download(language)
+    writeLine(formatDownloadOutcome(language, outcome))
+    if (outcome.ok) {
+      result.downloaded.push(language)
+    } else {
+      result.failed.push(language)
+    }
+  }
+
+  return result
+}
+
+/**
+ * The startup hook: read `COCO_PREFETCH` from the environment,
+ * resolve aliases, run any necessary downloads, log the outcome.
+ * No-op when the env var is unset, so the CLI's typical path
+ * pays zero overhead.
+ */
+export async function runPrefetchFromEnv(
+  options?: {
+    env?: NodeJS.ProcessEnv
+    download?: typeof downloadTreeSitterParser
+    writeLine?: (line: string) => void
+  },
+): Promise<PrefetchResult> {
+  const env = options?.env || process.env
+  const writeLine = options?.writeLine || ((line: string) => process.stderr.write(`${line}\n`))
+  const { resolved, unknown } = parsePrefetchEnv(env.COCO_PREFETCH)
+
+  if (resolved.length === 0 && unknown.length === 0) {
+    return {
+      requested: [],
+      alreadyCached: [],
+      downloaded: [],
+      failed: [],
+      unknown: [],
+    }
+  }
+
+  if (unknown.length > 0) {
+    writeLine(`! COCO_PREFETCH: ignoring unknown language(s): ${unknown.join(', ')}. Known: ${listManifestLanguages().join(', ')}`)
+  }
+
+  const result = await prefetchTreeSitterParsers(resolved, { download: options?.download, writeLine })
+  result.unknown = unknown
+  return result
+}

--- a/src/lib/parsers/default/__tree_sitter__/pythonTreeSitterParser.ts
+++ b/src/lib/parsers/default/__tree_sitter__/pythonTreeSitterParser.ts
@@ -1,0 +1,157 @@
+/**
+ * Tree-sitter Python structural parser (#933 phase 3).
+ *
+ * First lazy-loaded language. Mirrors `tsTreeSitterParser.ts` —
+ * per-line AST extraction, surrenders gracefully when the .wasm
+ * isn't cached so the regex parser handles the fallback.
+ *
+ * Lazy-load path: the parser surrenders silently when the
+ * Python .wasm isn't cached locally. Users opt into the
+ * download via `COCO_PREFETCH=py` (or `python`); after that the
+ * cached file is reused forever and tree-sitter takes over for
+ * `.py` / `.pyi` files.
+ *
+ * What it catches that the regex doesn't:
+ *
+ *   - Multi-line function signatures (`def foo(\n  a,\n  b\n):`).
+ *     The regex looks at the first line; tree-sitter sees the
+ *     full def including its parameter list.
+ *   - Decorators attached to their target (the regex skips
+ *     decorator lines on the assumption the next def carries
+ *     the signal, but loses the chained-decorator nuance).
+ *   - Class bodies. The regex extractor refuses to look inside
+ *     classes (indented `def` is skipped); tree-sitter could
+ *     surface methods on the cursored class.
+ *   - String-embedded keywords. Same AST-awareness gain as the
+ *     TS extractor.
+ *
+ * For phase 3 we focus on the parity case (top-level defs +
+ * classes) so the lazy-load infrastructure is the load-bearing
+ * deliverable. Phase 1.2-style polish (multi-line / decorators /
+ * methods) layers on once the infrastructure is proven.
+ */
+
+import type { FileDiff } from '../../../types'
+import type {
+  StructuralParser,
+  StructuralParserKind,
+} from '../utils/structuralParserRegistry'
+import type { StructuralSymbol } from '../utils/structuralDiff'
+import { summarizeStructuralDiff } from '../utils/structuralDiff'
+import { isPythonFile } from '../utils/pythonStructuralDiff'
+import { getTreeSitterParser } from './runtime'
+
+const PARSER_KIND: StructuralParserKind = 'tree-sitter'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type TSNode = any
+
+/**
+ * Convert a recognized top-level Python AST node into a typed
+ * structural symbol. Returns undefined for nodes the regex
+ * extractor would also miss (or that we explicitly defer) so
+ * the registry chain can fall through cleanly.
+ */
+function symbolFromTopLevelNode(node: TSNode): StructuralSymbol | undefined {
+  if (node.type === 'function_definition') {
+    const name = nameOfChild(node, 'name')
+    if (!name) return undefined
+    return {
+      name,
+      kind: 'function',
+      // Python convention: underscore-prefixed = not public.
+      exported: !name.startsWith('_'),
+    }
+  }
+
+  if (node.type === 'class_definition') {
+    const name = nameOfChild(node, 'name')
+    if (!name) return undefined
+    return {
+      name,
+      kind: 'class',
+      exported: !name.startsWith('_'),
+    }
+  }
+
+  // Decorated definitions wrap a function_definition or
+  // class_definition inside a `decorated_definition` node. The
+  // actual definition is one of the named children; recurse.
+  if (node.type === 'decorated_definition') {
+    const inner = node.namedChildren.find(
+      (c: TSNode) => c.type === 'function_definition' || c.type === 'class_definition',
+    )
+    if (!inner) return undefined
+    return symbolFromTopLevelNode(inner)
+  }
+
+  // Module-level ALL_CAPS assignments — matches the regex
+  // extractor's behavior. `TIMEOUT = 30` etc.
+  if (node.type === 'expression_statement') {
+    const assignment = node.namedChildren.find((c: TSNode) => c.type === 'assignment')
+    if (!assignment) return undefined
+    const lhs = assignment.childForFieldName?.('left')
+    if (!lhs || lhs.type !== 'identifier') return undefined
+    const name = lhs.text
+    if (!/^[A-Z][A-Z0-9_]*$/.test(name)) return undefined
+    return { name, kind: 'const', exported: true }
+  }
+
+  // PEP 695 type alias: `type Handler = Callable[[str], int]`.
+  // Surfaces as a `type_alias_statement` in the Python grammar.
+  if (node.type === 'type_alias_statement') {
+    const lhs = node.namedChildren.find((c: TSNode) => c.type === 'type')
+    const identifier = lhs?.namedChildren?.find((c: TSNode) => c.type === 'identifier')
+    if (!identifier) return undefined
+    const name = identifier.text
+    return { name, kind: 'type', exported: !name.startsWith('_') }
+  }
+
+  return undefined
+}
+
+function nameOfChild(node: TSNode, fieldName: string): string | undefined {
+  const child = node.childForFieldName?.(fieldName)
+  return child?.text
+}
+
+/**
+ * Per-line extractor. Strict module-scope (column-0) only — the
+ * regex extractor enforces the same gate and we keep parity for
+ * phase 3. Indented lines are body content and get returned as
+ * undefined.
+ */
+function extractSymbolFromLine(parser: TSNode, line: string): StructuralSymbol | undefined {
+  if (!line.trim()) return undefined
+  if (line.startsWith(' ') || line.startsWith('\t')) return undefined
+
+  let tree: TSNode
+  try {
+    tree = parser.parse(line)
+  } catch {
+    return undefined
+  }
+  if (!tree) return undefined
+
+  const moduleNode = tree.rootNode
+  for (const child of moduleNode.namedChildren as TSNode[]) {
+    const symbol = symbolFromTopLevelNode(child)
+    if (symbol) return symbol
+  }
+  return undefined
+}
+
+export const treeSitterPythonParser: StructuralParser = {
+  id: PARSER_KIND,
+  async summarize(fileDiff: FileDiff): Promise<string | undefined> {
+    if (!isPythonFile(fileDiff.file)) return undefined
+
+    const loaded = await getTreeSitterParser('python')
+    if (!loaded) return undefined
+
+    return summarizeStructuralDiff(fileDiff, {
+      label: 'Python',
+      parseLine: (line) => extractSymbolFromLine(loaded.parser, line),
+    })
+  },
+}

--- a/src/lib/parsers/default/__tree_sitter__/runtime.ts
+++ b/src/lib/parsers/default/__tree_sitter__/runtime.ts
@@ -28,6 +28,7 @@
 
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
+import { getCachedWasmPath } from './cache'
 
 /**
  * Dynamic-import shim. `web-tree-sitter` is `"type": "module"` (pure
@@ -46,13 +47,23 @@ type DynamicImport = <T>(specifier: string) => Promise<T>
 const dynamicImport = new Function('specifier', 'return import(specifier)') as DynamicImport
 
 /**
- * Language identifiers this runtime knows how to load. Mirrors the
- * .wasm files copied into `dist/tree-sitter/` by the postbuild
- * script. Adding a language: drop the .wasm into the postbuild
- * file list, add an entry here, then build a `<Lang>StructuralParser`
- * against the runtime.
+ * Language identifiers this runtime knows how to load.
+ *
+ * Two source flavors per language:
+ *   - **Bundled**: .wasm shipped in `dist/tree-sitter/` by the
+ *     postbuild copy step. `typescript` + `tsx` today. Always
+ *     available; no opt-in required.
+ *   - **Lazy-loaded** (#933 phase 3): .wasm downloaded from a
+ *     manifest-pinned CDN URL into the user's cache dir on
+ *     demand. `python` today; `rust` + `go` in phases 5 / 6.
+ *     Surrenders to the regex parser when the cache is empty
+ *     (no surprise network calls).
+ *
+ * The runtime treats both identically once a .wasm is on disk —
+ * the only difference is where it's resolved from. `resolveWasmLocations`
+ * below handles the lookup priority.
  */
-export type TreeSitterLanguageId = 'typescript' | 'tsx'
+export type TreeSitterLanguageId = 'typescript' | 'tsx' | 'python'
 
 type ResolvedWasmLocations = {
   enginePath: string
@@ -100,8 +111,15 @@ function resolveWasmLocations(): ResolvedWasmLocations | undefined {
     return {
       enginePath,
       languagePaths: {
+        // Bundled (always shipped under dist/tree-sitter/).
         typescript: join(dir, 'tree-sitter-typescript.wasm'),
         tsx: join(dir, 'tree-sitter-tsx.wasm'),
+        // Lazy-loaded (#933 phase 3). Lives in the user's cache
+        // dir, not the bundled dir. Path is always set so the
+        // resolver doesn't have to branch on language flavor —
+        // the existence check in `getTreeSitterParser` decides
+        // whether to actually load.
+        python: getCachedWasmPath('python'),
       },
     }
   }

--- a/src/lib/parsers/default/utils/structuralParserRegistry.ts
+++ b/src/lib/parsers/default/utils/structuralParserRegistry.ts
@@ -25,6 +25,7 @@
  */
 
 import type { FileDiff } from '../../../types'
+import { treeSitterPythonParser } from '../__tree_sitter__/pythonTreeSitterParser'
 import { treeSitterTsParser } from '../__tree_sitter__/tsTreeSitterParser'
 import { summarizeGoStructuralDiff } from './goStructuralDiff'
 import { summarizePythonStructuralDiff } from './pythonStructuralDiff'
@@ -96,7 +97,7 @@ const regexGo = regexParser(summarizeGoStructuralDiff)
 const REGISTRY: Record<StructuralLanguageId, StructuralParser[]> = {
   ts: [treeSitterTsParser, regexTs],
   js: [treeSitterTsParser, regexJs],
-  py: [regexPy],
+  py: [treeSitterPythonParser, regexPy],
   rs: [regexRs],
   go: [regexGo],
 }


### PR DESCRIPTION
## Summary

First lazy-loaded language. Tree-sitter parser for Python is pulled from a manifest-pinned CDN URL into the user's cache dir on opt-in (\`COCO_PREFETCH=py\`); falls through to the regex parser cleanly when the cache is empty (no surprise network calls). End-to-end proven via smoke test:

\`\`\`
$ COCO_PREFETCH=py tsx <smoke>
· Python: downloading https://cdn.jsdelivr.net/npm/tree-sitter-python@0.23.6/tree-sitter-python.wasm…
✓ Python parser cached (447 KB) at ~/.cache/coco/tree-sitter/tree-sitter-python.wasm

OUTPUT: Updated Python \`src/p.py\`. added: parse_request(). removed: legacy_handler(). +1/-1 lines.
\`\`\`

## New modules

- **\`cache.ts\`** — cache dir resolution (honors \`COCO_CACHE_DIR\` / \`XDG_CACHE_HOME\` / platform defaults; Windows-aware).
- **\`manifest.ts\`** — version + SHA-256 pin per language. Python: \`tree-sitter-python@0.23.6\` from jsdelivr (~447 KB).
- **\`download.ts\`** — fetch → SHA verify → atomic write. Returns typed \`DownloadOutcome\` instead of throwing.
- **\`prefetch.ts\`** — \`COCO_PREFETCH\` env var orchestrator. Aliases (\`py\` / \`python\` / \`all\`), skip-if-cached, error-tolerant.
- **\`pythonTreeSitterParser.ts\`** — per-line AST extraction mirroring the TS parser.

## Wiring changes

- \`runtime.ts\` extended to know about lazy-loaded languages; \`resolveWasmLocations\` includes the cache path alongside bundled paths.
- \`structuralParserRegistry\`: \`py\` chain becomes \`[treeSitterPythonParser, regexPy]\`.
- \`src/index.ts\` adds a \`runPrefetchFromEnv()\` hook at CLI startup. No-op when \`COCO_PREFETCH\` is unset.

## Test isolation note

Each test file that touches the cache sets a unique \`COCO_CACHE_DIR\` under \`os.tmpdir()\` — keeps parallel jest workers from racing on \`~/.cache/coco/tree-sitter/\`.

## Side fix

Bumped the \`buildScenarioFixtures\` "produces a fixture per commit" test to 15s. Default 5s was being exceeded under parallel load now that tree-sitter init runs on every test exercising \`summarizeLargeFiles\`. Real heavy work (temp git repo, several commits, walk-the-log) — 15s budget is comfortable.

## Test plan

- [x] \`npx tsc --noEmit\` → 0 errors
- [x] \`npm run test:jest\` → 1670/1670 pass (8 of 9 consecutive runs clean)
- [x] \`npx eslint\` on touched files → clean
- [x] Manual: \`COCO_PREFETCH=py\` downloads + caches + Python parser produces expected output

## Out of scope (later phases)

- **5/6** — Rust + Go via the same lazy-load path
- **7** — first-use Y/n prompt, \`coco cache\` subcommand, eval baseline, telemetry

Refs #933.