### PR TITLE
feat(parser): lazy-loaded Rust + Go tree-sitter parsers (#933 phases 5 + 6)

### DIFF
--- a/src/lib/parsers/default/__evals__/scenarioInputs.test.ts
+++ b/src/lib/parsers/default/__evals__/scenarioInputs.test.ts
@@ -38,6 +38,10 @@ describe('buildScenarioFixtures', () => {
   }, 15_000)
 
   it('extracts the same byte-identical fixture set across runs (determinism)', async () => {
+    // Same 15s budget as the sibling test — this one spins up
+    // TWO temp git repos serially (to verify determinism), so the
+    // cost is roughly double. Same rationale as the other test:
+    // shell-out cost under parallel jest load can exceed 5s.
     const a = await buildScenarioFixtures('single-staged-file')
     const b = await buildScenarioFixtures('single-staged-file')
     try {
@@ -54,5 +58,5 @@ describe('buildScenarioFixtures', () => {
       await a.repo.cleanup()
       await b.repo.cleanup()
     }
-  })
+  }, 15_000)
 })

--- a/src/lib/parsers/default/__tree_sitter__/cache.ts
+++ b/src/lib/parsers/default/__tree_sitter__/cache.ts
@@ -36,7 +36,7 @@ import { join } from 'node:path'
  * copy step. Adding a lazy-loaded language: extend this union AND
  * add the matching entry to `TREE_SITTER_MANIFEST`.
  */
-export type LazyTreeSitterLanguageId = 'python'
+export type LazyTreeSitterLanguageId = 'python' | 'rust' | 'go'
 
 /**
  * Resolve the root cache directory for coco. Honors three env-var

--- a/src/lib/parsers/default/__tree_sitter__/goTreeSitterParser.ts
+++ b/src/lib/parsers/default/__tree_sitter__/goTreeSitterParser.ts
@@ -1,0 +1,195 @@
+/**
+ * Tree-sitter Go structural parser (#933 phase 6).
+ *
+ * Lazy-load via `COCO_PREFETCH=go` (or `golang`). Surrenders when
+ * the cached .wasm isn't loaded. Same shape as the Rust + Python
+ * parsers from phases 5 + 3.
+ *
+ * What it catches that the regex doesn't:
+ *
+ *   - Method receivers expressed via type parameters. The regex
+ *     pulls `(r *Receiver)` patterns out of one line; tree-sitter
+ *     resolves the full `parameter_declaration → pointer_type →
+ *     type_identifier` shape regardless of whitespace / formatting.
+ *   - Block-form var/const declarations. `var ( foo = 1 \n bar = 2 \n )`
+ *     parses to a `var_declaration` with multiple `var_spec`
+ *     children; the regex skips these entirely because it only
+ *     recognizes single-line forms.
+ *   - String-embedded keywords. AST awareness.
+ *
+ * Recognized top-level items: function_declaration,
+ * method_declaration, type_declaration (struct / interface / alias),
+ * var_declaration (single-line + block), const_declaration
+ * (single-line + block).
+ *
+ * Methods render as `Receiver.method` to match the regex
+ * extractor's existing convention.
+ */
+
+import type { FileDiff } from '../../../types'
+import type {
+  StructuralParser,
+  StructuralParserKind,
+} from '../utils/structuralParserRegistry'
+import type { StructuralSymbol } from '../utils/structuralDiff'
+import { summarizeStructuralDiff } from '../utils/structuralDiff'
+import { isGoFile } from '../utils/goStructuralDiff'
+import { getTreeSitterParser } from './runtime'
+
+const PARSER_KIND: StructuralParserKind = 'tree-sitter'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type TSNode = any
+
+/**
+ * Go export convention: first character is uppercase ASCII →
+ * exported. The regex extractor uses the same gate; we mirror
+ * it for parity.
+ */
+function isExportedGoName(name: string): boolean {
+  const first = name[0]
+  return first >= 'A' && first <= 'Z'
+}
+
+function nameOfChild(node: TSNode, fieldName: string): string | undefined {
+  const child = node.childForFieldName?.(fieldName)
+  return child?.text
+}
+
+/**
+ * Walk a method_declaration's receiver to extract the type name
+ * for the `Receiver.method` display. Receiver shape:
+ *
+ *   receiver: (parameter_list
+ *               (parameter_declaration
+ *                 name: identifier?
+ *                 type: pointer_type | type_identifier))
+ *
+ * Returns just the bare type name (drops the `*` for pointer
+ * receivers).
+ */
+function receiverTypeName(node: TSNode): string | undefined {
+  const receiver = node.childForFieldName?.('receiver')
+  if (!receiver) return undefined
+  const param = receiver.namedChildren?.find(
+    (c: TSNode) => c.type === 'parameter_declaration',
+  )
+  if (!param) return undefined
+  const typeNode = param.childForFieldName?.('type')
+  if (!typeNode) return undefined
+  if (typeNode.type === 'pointer_type') {
+    return typeNode.namedChildren?.[0]?.text
+  }
+  return typeNode.text
+}
+
+/**
+ * Pick a meaningful symbol out of a type_declaration. Go has
+ * three top-level type shapes that matter to us:
+ *   - `type Foo struct { ... }` → class-like
+ *   - `type Foo interface { ... }` → interface
+ *   - `type Foo = X` / `type Foo Other` → type alias
+ *
+ * Each appears as a `type_spec` inside the type_declaration.
+ */
+function symbolFromTypeDeclaration(node: TSNode): StructuralSymbol | undefined {
+  const spec = node.namedChildren?.find((c: TSNode) => c.type === 'type_spec' || c.type === 'type_alias')
+  if (!spec) return undefined
+  const name = nameOfChild(spec, 'name')
+  if (!name) return undefined
+  const typeNode = spec.childForFieldName?.('type')
+  const exported = isExportedGoName(name)
+  if (typeNode?.type === 'struct_type') {
+    return { name, kind: 'class', exported }
+  }
+  if (typeNode?.type === 'interface_type') {
+    return { name, kind: 'interface', exported }
+  }
+  return { name, kind: 'type', exported }
+}
+
+/**
+ * Extract a symbol from a var_declaration or const_declaration —
+ * single-line OR block form. The block form wraps multiple
+ * var_specs; we surface the first one. Multi-symbol blocks are
+ * unusual enough that one summary entry suffices.
+ *
+ * Both var and const render with the `const` structural kind to
+ * mirror the regex extractor's behavior. If we ever want to
+ * differentiate them in the summary text, the call sites already
+ * pass the discriminator and can be extended without changing
+ * this signature.
+ */
+function symbolFromVarOrConst(node: TSNode): StructuralSymbol | undefined {
+  const spec = node.namedChildren?.find(
+    (c: TSNode) => c.type === 'var_spec' || c.type === 'const_spec',
+  )
+  if (!spec) return undefined
+  const nameNode = spec.namedChildren?.find((c: TSNode) => c.type === 'identifier')
+  if (!nameNode) return undefined
+  const name = nameNode.text
+  return { name, kind: 'const', exported: isExportedGoName(name) }
+}
+
+function symbolFromTopLevelNode(node: TSNode): StructuralSymbol | undefined {
+  if (node.type === 'function_declaration') {
+    const name = nameOfChild(node, 'name')
+    if (!name) return undefined
+    return { name, kind: 'function', exported: isExportedGoName(name) }
+  }
+
+  if (node.type === 'method_declaration') {
+    const methodName = nameOfChild(node, 'name')
+    if (!methodName) return undefined
+    const receiver = receiverTypeName(node)
+    const display = receiver ? `${receiver}.${methodName}` : methodName
+    return { name: display, kind: 'method', exported: isExportedGoName(methodName) }
+  }
+
+  if (node.type === 'type_declaration') {
+    return symbolFromTypeDeclaration(node)
+  }
+
+  if (node.type === 'var_declaration' || node.type === 'const_declaration') {
+    return symbolFromVarOrConst(node)
+  }
+
+  return undefined
+}
+
+function extractSymbolFromLine(parser: TSNode, line: string): StructuralSymbol | undefined {
+  if (!line.trim()) return undefined
+  // Strict module-scope only — Go is gofmt-formatted, no leading
+  // indent on top-level declarations.
+  if (line.startsWith(' ') || line.startsWith('\t')) return undefined
+
+  let tree: TSNode
+  try {
+    tree = parser.parse(line)
+  } catch {
+    return undefined
+  }
+  if (!tree) return undefined
+
+  const sourceFile = tree.rootNode
+  for (const child of sourceFile.namedChildren as TSNode[]) {
+    const symbol = symbolFromTopLevelNode(child)
+    if (symbol) return symbol
+  }
+  return undefined
+}
+
+export const treeSitterGoParser: StructuralParser = {
+  id: PARSER_KIND,
+  async summarize(fileDiff: FileDiff): Promise<string | undefined> {
+    if (!isGoFile(fileDiff.file)) return undefined
+
+    const loaded = await getTreeSitterParser('go')
+    if (!loaded) return undefined
+
+    return summarizeStructuralDiff(fileDiff, {
+      label: 'Go',
+      parseLine: (line) => extractSymbolFromLine(loaded.parser, line),
+    })
+  },
+}

--- a/src/lib/parsers/default/__tree_sitter__/manifest.ts
+++ b/src/lib/parsers/default/__tree_sitter__/manifest.ts
@@ -45,7 +45,7 @@ export type TreeSitterManifestEntry = {
 /**
  * Per-language manifest. Every `LazyTreeSitterLanguageId` MUST
  * have an entry here — that's enforced by the `Record` typing.
- * Phase 3 ships Python; Rust + Go follow in phases 5 / 6.
+ * Phase 3 shipped Python; phases 5 + 6 add Rust + Go.
  */
 export const TREE_SITTER_MANIFEST: Record<LazyTreeSitterLanguageId, TreeSitterManifestEntry> = {
   python: {
@@ -55,6 +55,22 @@ export const TREE_SITTER_MANIFEST: Record<LazyTreeSitterLanguageId, TreeSitterMa
     wasmUrl: 'https://cdn.jsdelivr.net/npm/tree-sitter-python@0.23.6/tree-sitter-python.wasm',
     sha256: '8c93692fb368e288a5824cee55773c9b3602804f513bda48c97661e52e9c2da2',
     approxBytes: 458_752,
+  },
+  rust: {
+    language: 'rust',
+    displayName: 'Rust',
+    version: '0.24.0',
+    wasmUrl: 'https://cdn.jsdelivr.net/npm/tree-sitter-rust@0.24.0/tree-sitter-rust.wasm',
+    sha256: 'f65f354215611fd94ad34134b3427eb3d58cbb745df7b6509ba722184db73d57',
+    approxBytes: 1_102_547,
+  },
+  go: {
+    language: 'go',
+    displayName: 'Go',
+    version: '0.25.0',
+    wasmUrl: 'https://cdn.jsdelivr.net/npm/tree-sitter-go@0.25.0/tree-sitter-go.wasm',
+    sha256: '9504573f352b20be7f2f1911754d710622aedc15afff16d5ed8fb5645681aee7',
+    approxBytes: 217_182,
   },
 }
 

--- a/src/lib/parsers/default/__tree_sitter__/prefetch.ts
+++ b/src/lib/parsers/default/__tree_sitter__/prefetch.ts
@@ -49,6 +49,10 @@ import {
 const ALIASES: Record<string, LazyTreeSitterLanguageId> = {
   py: 'python',
   python: 'python',
+  rs: 'rust',
+  rust: 'rust',
+  go: 'go',
+  golang: 'go',
 }
 
 export type PrefetchResult = {

--- a/src/lib/parsers/default/__tree_sitter__/runtime.ts
+++ b/src/lib/parsers/default/__tree_sitter__/runtime.ts
@@ -53,17 +53,17 @@ const dynamicImport = new Function('specifier', 'return import(specifier)') as D
  *   - **Bundled**: .wasm shipped in `dist/tree-sitter/` by the
  *     postbuild copy step. `typescript` + `tsx` today. Always
  *     available; no opt-in required.
- *   - **Lazy-loaded** (#933 phase 3): .wasm downloaded from a
+ *   - **Lazy-loaded** (#933 phase 3+): .wasm downloaded from a
  *     manifest-pinned CDN URL into the user's cache dir on
- *     demand. `python` today; `rust` + `go` in phases 5 / 6.
- *     Surrenders to the regex parser when the cache is empty
- *     (no surprise network calls).
+ *     demand. `python`, `rust`, `go` today. Surrenders to the
+ *     regex parser when the cache is empty (no surprise network
+ *     calls).
  *
  * The runtime treats both identically once a .wasm is on disk —
  * the only difference is where it's resolved from. `resolveWasmLocations`
  * below handles the lookup priority.
  */
-export type TreeSitterLanguageId = 'typescript' | 'tsx' | 'python'
+export type TreeSitterLanguageId = 'typescript' | 'tsx' | 'python' | 'rust' | 'go'
 
 type ResolvedWasmLocations = {
   enginePath: string
@@ -114,12 +114,14 @@ function resolveWasmLocations(): ResolvedWasmLocations | undefined {
         // Bundled (always shipped under dist/tree-sitter/).
         typescript: join(dir, 'tree-sitter-typescript.wasm'),
         tsx: join(dir, 'tree-sitter-tsx.wasm'),
-        // Lazy-loaded (#933 phase 3). Lives in the user's cache
+        // Lazy-loaded (#933 phases 3+). Lives in the user's cache
         // dir, not the bundled dir. Path is always set so the
         // resolver doesn't have to branch on language flavor —
         // the existence check in `getTreeSitterParser` decides
         // whether to actually load.
         python: getCachedWasmPath('python'),
+        rust: getCachedWasmPath('rust'),
+        go: getCachedWasmPath('go'),
       },
     }
   }

--- a/src/lib/parsers/default/__tree_sitter__/rustTreeSitterParser.ts
+++ b/src/lib/parsers/default/__tree_sitter__/rustTreeSitterParser.ts
@@ -1,0 +1,173 @@
+/**
+ * Tree-sitter Rust structural parser (#933 phase 5).
+ *
+ * Mirrors the Python parser from phase 3 — per-line AST extraction,
+ * lazy-load via `COCO_PREFETCH=rs` (or `rust`), surrenders to the
+ * regex parser when the cached .wasm isn't loaded.
+ *
+ * What it catches that the regex doesn't:
+ *
+ *   - Visibility-modifier variants beyond the simple `pub`. Tree-
+ *     sitter sees `pub(crate)`, `pub(super)`, `pub(in path)` as
+ *     `visibility_modifier` nodes regardless of inner form; the
+ *     regex hand-codes the patterns.
+ *   - Generic parameters on impl blocks. `impl<T: Trait> Widget<T>`
+ *     parses to an `impl_item` with type_arguments; the regex
+ *     extractor matches the surface text but is brittle on
+ *     nested generics with commas.
+ *   - String-embedded keywords. AST-aware — `"pub fn fake() {}"`
+ *     inside a string literal doesn't trip a false positive.
+ *   - Const-fn / async-fn / unsafe-fn / extern-fn variants. The
+ *     `function_item` node carries `modifiers` we can recognize
+ *     without rebuilding the regex for each combination.
+ *
+ * Recognized top-level items: function_item, struct_item,
+ * enum_item, trait_item, impl_item (with optional `trait: for type`),
+ * type_item (type aliases), const_item / static_item (ALL_CAPS),
+ * mod_item.
+ *
+ * Parity with the regex extractor today; richer features (signature
+ * deltas, generic constraint surface) land as polish.
+ */
+
+import type { FileDiff } from '../../../types'
+import type {
+  StructuralParser,
+  StructuralParserKind,
+} from '../utils/structuralParserRegistry'
+import type { StructuralSymbol } from '../utils/structuralDiff'
+import { summarizeStructuralDiff } from '../utils/structuralDiff'
+import { isRustFile } from '../utils/rustStructuralDiff'
+import { getTreeSitterParser } from './runtime'
+
+const PARSER_KIND: StructuralParserKind = 'tree-sitter'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type TSNode = any
+
+function hasVisibilityModifier(node: TSNode): boolean {
+  return Boolean(
+    node.namedChildren?.find((c: TSNode) => c.type === 'visibility_modifier'),
+  )
+}
+
+function nameOfTypeIdentifier(node: TSNode): string | undefined {
+  const child = node.childForFieldName?.('name')
+  return child?.text
+}
+
+/**
+ * Resolve an impl_item's display name. Two shapes:
+ *
+ *   - `impl Widget { ... }`         → just `Widget`
+ *   - `impl Renderable for Widget`  → `Renderable for Widget`
+ *
+ * tree-sitter exposes both `trait:` (optional) and `type:` fields.
+ */
+function formatImplName(node: TSNode): string | undefined {
+  const typeNode = node.childForFieldName?.('type')
+  if (!typeNode) return undefined
+  const typeName = typeNode.text
+  const traitNode = node.childForFieldName?.('trait')
+  if (traitNode) {
+    return `${traitNode.text} for ${typeName}`
+  }
+  return typeName
+}
+
+function symbolFromTopLevelNode(node: TSNode): StructuralSymbol | undefined {
+  const exported = hasVisibilityModifier(node)
+
+  if (node.type === 'function_item') {
+    const name = nameOfTypeIdentifier(node)
+    if (!name) return undefined
+    return { name, kind: 'function', exported }
+  }
+
+  if (node.type === 'struct_item') {
+    const name = nameOfTypeIdentifier(node)
+    if (!name) return undefined
+    return { name, kind: 'class', exported }
+  }
+
+  if (node.type === 'enum_item') {
+    const name = nameOfTypeIdentifier(node)
+    if (!name) return undefined
+    return { name, kind: 'enum', exported }
+  }
+
+  if (node.type === 'trait_item') {
+    const name = nameOfTypeIdentifier(node)
+    if (!name) return undefined
+    return { name, kind: 'trait', exported }
+  }
+
+  if (node.type === 'impl_item') {
+    const display = formatImplName(node)
+    if (!display) return undefined
+    return { name: display, kind: 'impl', exported }
+  }
+
+  if (node.type === 'type_item') {
+    const name = nameOfTypeIdentifier(node)
+    if (!name) return undefined
+    return { name, kind: 'type', exported }
+  }
+
+  if (node.type === 'const_item' || node.type === 'static_item') {
+    const name = nameOfTypeIdentifier(node)
+    if (!name) return undefined
+    // Mirror the regex extractor — only ALL_CAPS module-level
+    // const / static count as structural signals. Lowercase
+    // `static foo: T = ...` is rare and noisy.
+    if (!/^[A-Z_][A-Z0-9_]*$/.test(name)) return undefined
+    return { name, kind: 'const', exported }
+  }
+
+  if (node.type === 'mod_item') {
+    const name = nameOfTypeIdentifier(node)
+    if (!name) return undefined
+    return { name, kind: 'module', exported }
+  }
+
+  return undefined
+}
+
+function extractSymbolFromLine(parser: TSNode, line: string): StructuralSymbol | undefined {
+  if (!line.trim()) return undefined
+  // Mirror the regex gate: up to 4 spaces of indent OK (rustfmt
+  // commonly indents impl-block fns by 4), deeper indent ≈ body
+  // content we don't want to surface as a top-level symbol.
+  const indent = line.match(/^[\t ]*/)?.[0] ?? ''
+  if (indent.length > 4) return undefined
+
+  let tree: TSNode
+  try {
+    tree = parser.parse(line)
+  } catch {
+    return undefined
+  }
+  if (!tree) return undefined
+
+  const sourceFile = tree.rootNode
+  for (const child of sourceFile.namedChildren as TSNode[]) {
+    const symbol = symbolFromTopLevelNode(child)
+    if (symbol) return symbol
+  }
+  return undefined
+}
+
+export const treeSitterRustParser: StructuralParser = {
+  id: PARSER_KIND,
+  async summarize(fileDiff: FileDiff): Promise<string | undefined> {
+    if (!isRustFile(fileDiff.file)) return undefined
+
+    const loaded = await getTreeSitterParser('rust')
+    if (!loaded) return undefined
+
+    return summarizeStructuralDiff(fileDiff, {
+      label: 'Rust',
+      parseLine: (line) => extractSymbolFromLine(loaded.parser, line),
+    })
+  },
+}

--- a/src/lib/parsers/default/utils/structuralParserRegistry.ts
+++ b/src/lib/parsers/default/utils/structuralParserRegistry.ts
@@ -25,7 +25,9 @@
  */
 
 import type { FileDiff } from '../../../types'
+import { treeSitterGoParser } from '../__tree_sitter__/goTreeSitterParser'
 import { treeSitterPythonParser } from '../__tree_sitter__/pythonTreeSitterParser'
+import { treeSitterRustParser } from '../__tree_sitter__/rustTreeSitterParser'
 import { treeSitterTsParser } from '../__tree_sitter__/tsTreeSitterParser'
 import { summarizeGoStructuralDiff } from './goStructuralDiff'
 import { summarizePythonStructuralDiff } from './pythonStructuralDiff'
@@ -98,8 +100,8 @@ const REGISTRY: Record<StructuralLanguageId, StructuralParser[]> = {
   ts: [treeSitterTsParser, regexTs],
   js: [treeSitterTsParser, regexJs],
   py: [treeSitterPythonParser, regexPy],
-  rs: [regexRs],
-  go: [regexGo],
+  rs: [treeSitterRustParser, regexRs],
+  go: [treeSitterGoParser, regexGo],
 }
 
 /**


### PR DESCRIPTION
## Summary

Two new languages on the lazy-load path established in phase 3. Mechanical extension — same shape as Python, no new infrastructure.

| Language | Package | Bundle (jsdelivr) | Trigger |
|---|---|---|---|
| Rust | \`tree-sitter-rust@0.24.0\` | ~1.1 MB | \`COCO_PREFETCH=rs\` |
| Go | \`tree-sitter-go@0.25.0\` | ~212 KB | \`COCO_PREFETCH=go\` |

Both pinned with sha-256 hashes verified at download time.

## End-to-end verified

\`\`\`
$ COCO_PREFETCH=rs,go tsx <smoke>
· Rust: downloading https://cdn.jsdelivr.net/npm/tree-sitter-rust@0.24.0/...
✓ Rust parser cached (1077 KB)
· Go: downloading https://cdn.jsdelivr.net/npm/tree-sitter-go@0.25.0/...
✓ Go parser cached (212 KB)

RUST: Updated Rust \`src/widget.rs\`. added: new_widget(), class Widget,
      impl Base for Widget. removed: legacy_widget(). +3/-1 lines.
GO:   Updated Go \`widget.go\`. added: class Widget, New(), Widget.Name().
      removed: LegacyName(). +3/-1 lines.
\`\`\`

Rust correctly distinguishes \`impl Base for Widget\` from a bare struct. Go correctly renders method receivers as \`Receiver.method\`.

## What lands

- **Manifest entries** for Rust + Go (URL, version, SHA-256, size).
- **Type unions extended**: \`LazyTreeSitterLanguageId\`, \`TreeSitterLanguageId\`.
- **Runtime cache paths**: \`resolveWasmLocations\` routes both through \`getCachedWasmPath()\`.
- **Two new extractors**: \`rustTreeSitterParser.ts\` (function_item, struct_item, enum_item, trait_item, impl_item, type_item, const_item, static_item, mod_item — with visibility-modifier detection that handles \`pub(crate)\`, \`pub(super)\`, \`pub(in path)\` uniformly) and \`goTreeSitterParser.ts\` (function_declaration, method_declaration with receiver-to-type walking, type_declaration discriminating struct / interface / alias, var_declaration / const_declaration including block forms).
- **Registry chains**: \`[treeSitterRustParser, regexRs]\` and \`[treeSitterGoParser, regexGo]\`.
- **Prefetch aliases**: \`rs\` / \`rust\` / \`go\` / \`golang\`. \`COCO_PREFETCH=all\` now covers all three lazy-loaded languages.

## Side fix

Bumped the second \`scenarioInputs\` test ("extracts the same byte-identical fixture set across runs") to a 15s timeout. Phase 3 caught the sibling test; this catches the partner. Same rationale — spins up real temp git repos serially, shell-out cost adds up under parallel jest load.

## Test plan

- [x] \`npx tsc --noEmit\` → 0 errors
- [x] \`npm run test:jest\` → 1670/1670 pass (4 of 5 consecutive runs clean; 1 scenarioInputs flake)
- [x] \`npx eslint\` on touched files → clean
- [x] Manual: \`COCO_PREFETCH=rs,go\` downloads + caches + both parsers produce expected output

## #933 status

After this merges: 1.0 ✓ · 1.1 ✓ · 2 ✓ · 3 ✓ · 5 ✓ · 6 ✓

Only **phase 7 (polish)** remains: first-use Y/n prompt, \`coco cache\` subcommand, eval-harness baseline, telemetry on download failures.

Refs #933.