### PR TITLE
chore(jest): constrain test discovery to src/ + bin/

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,4 +2,16 @@ export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
   transformIgnorePatterns: ['/node_modules/', '/dist/'],
+  // Constrain test discovery to the directories that actually contain
+  // coco's tests. Without this, jest's default recursion from the
+  // repo root descends into:
+  //   - `.claude/worktrees/*` — Claude Code's per-agent worktrees,
+  //     each containing 150+ duplicate test files
+  //   - `.www/` — the marketing-site sub-project, which has its own
+  //     test runner (and its own nested `node_modules` with hundreds
+  //     of vendored test files)
+  // `<rootDir>` resolves per-config-file location, so each worktree
+  // independently scans its own `src/` + `bin/` and the main checkout
+  // does the same. No cross-contamination.
+  roots: ['<rootDir>/src', '<rootDir>/bin'],
 }


### PR DESCRIPTION
## Summary

Stops \`npm run test:jest\` (and therefore \`npm run release\`) from picking up tests outside the actual coco source tree.

Before this change, jest's default recursion from \`<rootDir>\` descended into:

- \`.claude/worktrees/*\` — Claude Code's per-agent worktrees, each carrying its own full copy of \`src/\` with 150+ test files
- \`.www/\` — the marketing site, which has its own test runner AND its own nested \`node_modules\` with hundreds of vendored test files

Symptom: running the release path from a checkout with even one active worktree picked up 300+ test files instead of the ~170 that belong to coco; multiple worktrees pushed discovery past 1000.

## The fix

One-line config:

\`\`\`ts
roots: ['<rootDir>/src', '<rootDir>/bin'],
\`\`\`

Switches jest from "walk-and-filter" (default) to "start here, never look anywhere else". jest doesn't even open \`.claude/\` or \`.www/\` during test discovery.

\`bin/\` is included because \`bin/validateSchema.test.ts\` is the one legit test outside \`src/\` — it's already declared in \`tsconfig.json\`'s \`include\` array.

## Why this doesn't break worktree testing

\`<rootDir>\` resolves relative to the \`jest.config.ts\` file jest finds when walking up from \`cwd\`. Each worktree is its own checkout with its own copy of \`jest.config.ts\`:

| Where you run | Config jest finds | \`<rootDir>\` resolves to | Scans |
|---|---|---|---|
| \`/coco\` | \`/coco/jest.config.ts\` | \`/coco\` | \`/coco/src\` + \`/coco/bin\` |
| \`/coco/.claude/worktrees/X\` | \`/coco/.claude/worktrees/X/jest.config.ts\` | \`/coco/.claude/worktrees/X\` | \`/coco/.claude/worktrees/X/src\` + \`bin\` |

No cross-contamination. Worktrees keep working exactly as before.

## Test plan

- [x] Discovered test files BEFORE: 319 (148 from one worktree + 7 marketing site + 1 misc + 163 src/)
- [x] Discovered test files AFTER: 153 (matches \`find src bin -name "*.test.ts" | wc -l\`)
- [x] \`npm run test:jest\` → 1674/1674 pass across 3 consecutive runs
- [x] Test count unchanged — no real test was excluded by the new \`roots\`