### PR TITLE
feat(ui): responsive density tiers for narrow terminals

### DIFF
--- a/src/workstation/chrome/dateFormat.test.ts
+++ b/src/workstation/chrome/dateFormat.test.ts
@@ -1,0 +1,55 @@
+import { formatCompactRelativeDate, COMPACT_RELATIVE_DATE_MAX_WIDTH } from './dateFormat'
+
+describe('formatCompactRelativeDate', () => {
+  const NOW = new Date(Date.UTC(2026, 4, 14)) // 2026-05-14
+
+  it('returns today for the same UTC day', () => {
+    expect(formatCompactRelativeDate('2026-05-14', NOW)).toBe('today')
+  })
+
+  it('returns N d for 1-13 day spans', () => {
+    expect(formatCompactRelativeDate('2026-05-13', NOW)).toBe('1d')
+    expect(formatCompactRelativeDate('2026-05-01', NOW)).toBe('13d')
+  })
+
+  it('switches to weeks at 14 days', () => {
+    expect(formatCompactRelativeDate('2026-04-30', NOW)).toBe('2w')
+    expect(formatCompactRelativeDate('2026-03-20', NOW)).toBe('7w')
+  })
+
+  it('switches to months past 8 weeks', () => {
+    // 2026-05-14 minus 90 days = 2026-02-13 → 90/30 = 3mo
+    expect(formatCompactRelativeDate('2026-02-13', NOW)).toBe('3mo')
+  })
+
+  it('switches to years past 12 months', () => {
+    // 2 years back, give or take leap days
+    expect(formatCompactRelativeDate('2024-05-14', NOW)).toBe('2y')
+    expect(formatCompactRelativeDate('2020-01-01', NOW)).toBe('6y')
+  })
+
+  it('collapses future-dated inputs to today (tolerates clock skew)', () => {
+    expect(formatCompactRelativeDate('2026-06-01', NOW)).toBe('today')
+  })
+
+  it('returns empty string for malformed or missing input', () => {
+    expect(formatCompactRelativeDate(undefined, NOW)).toBe('')
+    expect(formatCompactRelativeDate('', NOW)).toBe('')
+    expect(formatCompactRelativeDate('not a date', NOW)).toBe('')
+  })
+
+  it('accepts ISO timestamps with a time component (uses only the date)', () => {
+    expect(formatCompactRelativeDate('2026-05-13T09:00:00Z', NOW)).toBe('1d')
+  })
+
+  it('outputs never exceed COMPACT_RELATIVE_DATE_MAX_WIDTH', () => {
+    const samples = [
+      '2026-05-14', '2026-05-01', '2026-04-30', '2026-02-13',
+      '2024-05-14', '2010-01-01',
+    ]
+    for (const iso of samples) {
+      const out = formatCompactRelativeDate(iso, NOW)
+      expect(out.length).toBeLessThanOrEqual(COMPACT_RELATIVE_DATE_MAX_WIDTH)
+    }
+  })
+})

--- a/src/workstation/chrome/dateFormat.ts
+++ b/src/workstation/chrome/dateFormat.ts
@@ -1,0 +1,61 @@
+/**
+ * Date formatting helpers for the Ink TUI surfaces.
+ *
+ * The branch list already ships its own "X ago" formatter
+ * (`formatBranchLastTouched` in iconography.ts) sized for a sidebar
+ * row with room to breathe. The history surface needs a tighter
+ * variant: the date column is fixed-width and competes with the
+ * commit message for cells, so a 2-3 character form is the budget.
+ *
+ * Inputs match what `git log --date=short` produces:
+ * `YYYY-MM-DD`. Caller passes `now` so tests can pin the reference
+ * instant.
+ *
+ * Outputs (rounded toward the nearest unit, no `ago` suffix):
+ *   - `today` for same UTC day
+ *   - `1d` … `13d` for 1-13 days
+ *   - `2w` … `8w` for 2-8 weeks
+ *   - `2mo` … `11mo` for 2-11 months
+ *   - `2y`+ for older
+ *   - `''` for malformed inputs (caller renders nothing)
+ *
+ * Day comparison is in UTC so a commit dated "yesterday" never reads
+ * "today" depending on the operator's timezone.
+ */
+export function formatCompactRelativeDate(iso: string | undefined, now: Date): string {
+  if (!iso) return ''
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso)
+  if (!match) return ''
+
+  const year = Number.parseInt(match[1], 10)
+  const month = Number.parseInt(match[2], 10)
+  const day = Number.parseInt(match[3], 10)
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return ''
+
+  const commitUtc = Date.UTC(year, month - 1, day)
+  const nowUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  const oneDay = 24 * 60 * 60 * 1000
+  const days = Math.floor((nowUtc - commitUtc) / oneDay)
+
+  if (days <= 0) return 'today'
+  if (days < 14) return `${days}d`
+
+  const weeks = Math.floor(days / 7)
+  if (weeks < 9) return `${weeks}w`
+
+  const months = Math.floor(days / 30)
+  if (months < 12) return `${months}mo`
+
+  const years = Math.floor(days / 365)
+  return `${years}y`
+}
+
+/**
+ * Maximum cell width any output from `formatCompactRelativeDate` will
+ * occupy. Used by row-layout math that needs to reserve a fixed
+ * column width up front rather than measuring each formatted string.
+ *
+ * `today` (5) is the longest single output; `99mo` would be 4. We pin
+ * to 5 to leave headroom for the `today` case without re-measuring.
+ */
+export const COMPACT_RELATIVE_DATE_MAX_WIDTH = 5

--- a/src/workstation/chrome/layout.test.ts
+++ b/src/workstation/chrome/layout.test.ts
@@ -1,4 +1,5 @@
 import {
+  LAYOUT_RAIL_PANEL_WIDTH,
   LOG_INK_MIN_COLUMNS,
   LOG_INK_MIN_ROWS,
   getLogInkLayout,
@@ -13,9 +14,12 @@ describe('log Ink layout', () => {
 
     expect(layout.tooSmall).toBe(false)
     expect(layout.bodyRows).toBe(19)
-    expect(layout.sidebarWidth).toBe(22)
-    // 80 * 0.22 = 17.6 → floor 17 → clamped up to the 20-cell minimum
-    expect(layout.detailWidth).toBe(20)
+    // 80 columns falls into the rail tier (< 100), so both side
+    // panels collapse to the fixed rail width and the history panel
+    // takes everything they gave up.
+    expect(layout.density).toBe('rail')
+    expect(layout.sidebarWidth).toBe(LAYOUT_RAIL_PANEL_WIDTH)
+    expect(layout.detailWidth).toBe(LAYOUT_RAIL_PANEL_WIDTH)
   })
 
   it('uses a balanced layout at the default terminal size', () => {
@@ -38,11 +42,15 @@ describe('log Ink layout', () => {
     expect(layout.detailWidth).toBe(32)
   })
 
-  it('clamps the inspector at rest to its 20-32 cell range', () => {
-    const tiny = getLogInkLayout({ columns: 80, rows: 24 })
+  it('clamps the inspector at rest to its 20-32 cell range above the rail tier', () => {
+    // 100 columns is the lower bound of the tight tier — rail
+    // collapse no longer applies, so the at-rest clamp wins.
+    // 100 * 0.22 = 22 → in the 20-32 range, no clamp needed.
+    const tight = getLogInkLayout({ columns: 100, rows: 24 })
     const huge = getLogInkLayout({ columns: 400, rows: 80 })
 
-    expect(tiny.detailWidth).toBe(20)
+    expect(tight.density).toBe('tight')
+    expect(tight.detailWidth).toBe(22)
     expect(huge.detailWidth).toBe(32)
   })
 
@@ -135,6 +143,78 @@ describe('log Ink layout', () => {
       })
       const helpOnly = getLogInkLayout({ columns: 160, rows: 40, helpOverlayActive: true })
       expect(both.detailWidth).toBe(helpOnly.detailWidth)
+    })
+  })
+
+  // Responsive density tiers — drive history-row column dropping,
+  // relative-date formatting, row stacking, and side-panel rail
+  // collapse. Breakpoints live in `LAYOUT_*_BELOW` constants so the
+  // layout function + tests + downstream renderers share the same
+  // numbers.
+  describe('density tiers', () => {
+    it('classifies wide / normal / tight / rail by column count', () => {
+      expect(getLogInkLayout({ columns: 200, rows: 40 }).density).toBe('wide')
+      expect(getLogInkLayout({ columns: 160, rows: 40 }).density).toBe('wide')
+      expect(getLogInkLayout({ columns: 159, rows: 40 }).density).toBe('normal')
+      expect(getLogInkLayout({ columns: 120, rows: 40 }).density).toBe('normal')
+      expect(getLogInkLayout({ columns: 119, rows: 40 }).density).toBe('tight')
+      expect(getLogInkLayout({ columns: 100, rows: 40 }).density).toBe('tight')
+      expect(getLogInkLayout({ columns: 99, rows: 40 }).density).toBe('rail')
+      expect(getLogInkLayout({ columns: 80, rows: 24 }).density).toBe('rail')
+    })
+
+    it('stacks history rows only at the rail tier', () => {
+      expect(getLogInkLayout({ columns: 200, rows: 40 }).historyRowMode).toBe('single')
+      expect(getLogInkLayout({ columns: 120, rows: 40 }).historyRowMode).toBe('single')
+      expect(getLogInkLayout({ columns: 100, rows: 40 }).historyRowMode).toBe('single')
+      expect(getLogInkLayout({ columns: 90, rows: 40 }).historyRowMode).toBe('stacked')
+    })
+
+    it('rails the sidebar and inspector at rail tier when unfocused', () => {
+      const layout = getLogInkLayout({ columns: 90, rows: 40 })
+
+      expect(layout.sidebarRailed).toBe(true)
+      expect(layout.inspectorRailed).toBe(true)
+      expect(layout.sidebarWidth).toBe(LAYOUT_RAIL_PANEL_WIDTH)
+      expect(layout.detailWidth).toBe(LAYOUT_RAIL_PANEL_WIDTH)
+      // History gets everything the side panels gave up.
+      expect(layout.mainPanelWidth).toBe(90 - LAYOUT_RAIL_PANEL_WIDTH * 2)
+    })
+
+    it('un-rails a panel when it takes focus, even on a narrow terminal', () => {
+      const sidebarFocused = getLogInkLayout({ columns: 90, rows: 40, sidebarFocused: true })
+      expect(sidebarFocused.sidebarRailed).toBe(false)
+      // 90 * 0.36 = 32.4 → floor 32; clamps stay 32-50 so this lands at 32.
+      expect(sidebarFocused.sidebarWidth).toBe(32)
+      // Inspector stays railed since the user isn't reading it.
+      expect(sidebarFocused.inspectorRailed).toBe(true)
+      expect(sidebarFocused.detailWidth).toBe(LAYOUT_RAIL_PANEL_WIDTH)
+
+      const inspectorFocused = getLogInkLayout({ columns: 90, rows: 40, inspectorFocused: true })
+      expect(inspectorFocused.inspectorRailed).toBe(false)
+      // 90 * 0.40 = 36 → clamps to 36-60 lower bound.
+      expect(inspectorFocused.detailWidth).toBe(36)
+      expect(inspectorFocused.sidebarRailed).toBe(true)
+    })
+
+    it('keeps panels at normal widths above the rail breakpoint', () => {
+      const tight = getLogInkLayout({ columns: 110, rows: 40 })
+      expect(tight.sidebarRailed).toBe(false)
+      expect(tight.inspectorRailed).toBe(false)
+      // 110 * 0.24 = 26.4 → floor 26 (in the 22-34 unfocused range)
+      expect(tight.sidebarWidth).toBe(26)
+    })
+
+    it('lets the help overlay override inspector rail', () => {
+      const railedHelp = getLogInkLayout({
+        columns: 90,
+        rows: 40,
+        helpOverlayActive: true,
+      })
+      // Help wants room for hotkey descriptions; rail collapse would
+      // defeat that purpose. 60-cell minimum kicks in here.
+      expect(railedHelp.detailWidth).toBe(60)
+      expect(railedHelp.inspectorRailed).toBe(false)
     })
   })
 })

--- a/src/workstation/chrome/layout.ts
+++ b/src/workstation/chrome/layout.ts
@@ -25,6 +25,19 @@ export type LogInkLayoutInput = {
   helpOverlayActive?: boolean
 }
 
+/**
+ * Responsive tier for the whole UI, derived from terminal width. Higher
+ * tiers progressively drop and reformat row segments to keep narrow
+ * terminals readable:
+ *
+ *   - wide   (>= 160 cols) — absolute `YYYY-MM-DD` dates, full chrome
+ *   - normal (120–159)     — compact relative dates (`2d`, `3w`)
+ *   - tight  (100–119)     — date column dropped entirely
+ *   - rail   (< 100)       — history rows stack on two lines; sidebar
+ *     and inspector collapse to a thin icon rail when not focused
+ */
+export type LogInkLayoutDensity = 'rail' | 'tight' | 'normal' | 'wide'
+
 export type LogInkLayout = {
   bodyRows: number
   columns: number
@@ -48,6 +61,33 @@ export type LogInkLayout = {
    * single value.
    */
   inspectorTabbed: boolean
+  /**
+   * Width-derived tier that gates date formatting and row stacking in
+   * the history surface; also drives panel rail collapse below.
+   */
+  density: LogInkLayoutDensity
+  /**
+   * True when the sidebar should render as a thin icon rail (tab
+   * glyph + count, no expanded tab content). Held to `density === 'rail'
+   * && !sidebarFocused` so focusing the sidebar always pops it back
+   * to its normal expanded form — same affordance as the existing
+   * focus-grow pattern, just starting from a much smaller resting
+   * state on narrow terminals.
+   */
+  sidebarRailed: boolean
+  /**
+   * True when the inspector should render as a thin rail (selected
+   * shortHash + a focus hint, no commit body / file list / actions).
+   * Same focus-rescue contract as `sidebarRailed`.
+   */
+  inspectorRailed: boolean
+  /**
+   * `single` — each commit takes one row (current behavior).
+   * `stacked` — each commit takes two rows: graph + hash + message on
+   * line 1, date + refs dim on line 2. Used at `density === 'rail'`
+   * where even tight-tier truncation would eat the subject.
+   */
+  historyRowMode: 'single' | 'stacked'
 }
 
 export const LOG_INK_MIN_COLUMNS = 80
@@ -64,9 +104,52 @@ export const LOG_INK_DEFAULT_ROWS = 40
  */
 export const INSPECTOR_TABBED_BELOW_ROWS = 28
 
+/**
+ * Density-tier breakpoints in columns. Picked so the three legacy
+ * panels (sidebar ~24-32 + inspector ~20-32 + main) still leave the
+ * history panel with at least ~40 usable cells before we start
+ * collapsing chrome:
+ *
+ *   wide   >= 160 — plenty of room; keep absolute dates
+ *   normal >= 120 — relative dates save 8-ish cells without hiding info
+ *   tight  >= 100 — drop date entirely; subject + refs are the priority
+ *   rail   <  100 — even with side panels collapsed the row is tight;
+ *                   stack to two lines and rail the side panels at rest
+ */
+export const LAYOUT_TIGHT_BELOW = 120
+export const LAYOUT_NORMAL_BELOW = 160
+export const LAYOUT_RAIL_BELOW = 100
+
+/**
+ * Fixed cell width for a railed side panel. Just wide enough for a
+ * 1-cell icon + a 2-3 digit count after subtracting border (2) and
+ * padding (2). Going narrower clips the count; going wider defeats
+ * the purpose of railing in the first place.
+ */
+export const LAYOUT_RAIL_PANEL_WIDTH = 8
+
 export function getLogInkLayout(input: LogInkLayoutInput): LogInkLayout {
   const columns = input.columns || LOG_INK_DEFAULT_COLUMNS
   const rows = input.rows || LOG_INK_DEFAULT_ROWS
+  const density: LogInkLayoutDensity =
+    columns >= LAYOUT_NORMAL_BELOW
+      ? 'wide'
+      : columns >= LAYOUT_TIGHT_BELOW
+        ? 'normal'
+        : columns >= LAYOUT_RAIL_BELOW
+          ? 'tight'
+          : 'rail'
+
+  // Rail collapse: only happens at the narrowest tier, and only for
+  // the panel that does NOT currently hold focus AND is not being
+  // commandeered by the help overlay. Focus always wins — pressing
+  // tab to the sidebar pops it back open even on an 80-cell terminal
+  // so the user can actually use it. The help overlay also wins for
+  // the inspector since that's where its descriptions render.
+  const sidebarRailed = density === 'rail' && !input.sidebarFocused
+  const inspectorRailed =
+    density === 'rail' && !input.inspectorFocused && !input.helpOverlayActive
+
   // Inspector width — at rest 20-32 cells (~22% of width), focused
   // 36-60 cells (~40% of width). Narrow rest state keeps the commit
   // graph dominant; focus expansion gives the inspector room for long
@@ -77,17 +160,26 @@ export function getLogInkLayout(input: LogInkLayoutInput): LogInkLayout {
   // hotkey descriptions render in full instead of truncating to
   // "Move focus...". Capped at 100 cells so a wide terminal doesn't
   // waste an absurd amount of horizontal space on the cheat sheet.
+  //
+  // Rail collapse wins over the at-rest range but loses to focus and
+  // to the help overlay — both of those represent deliberate user
+  // intent to read the panel.
   const detailWidth = input.helpOverlayActive
     ? Math.max(60, Math.min(100, Math.floor(columns * 0.50)))
     : input.inspectorFocused
       ? Math.max(36, Math.min(60, Math.floor(columns * 0.40)))
-      : Math.max(20, Math.min(32, Math.floor(columns * 0.22)))
+      : inspectorRailed
+        ? LAYOUT_RAIL_PANEL_WIDTH
+        : Math.max(20, Math.min(32, Math.floor(columns * 0.22)))
   // Sidebar at rest: 22-34 cells (~24% of width). Focused: 32-50 cells
   // (~36% of width). The transition is instant per render — focus tab to
-  // expand, focus away to collapse.
+  // expand, focus away to collapse. Rail mode (narrow terminal,
+  // unfocused) shrinks to a fixed 8-cell strip with tab glyphs only.
   const sidebarWidth = input.sidebarFocused
     ? Math.max(32, Math.min(50, Math.floor(columns * 0.36)))
-    : Math.max(22, Math.min(34, Math.floor(columns * 0.24)))
+    : sidebarRailed
+      ? LAYOUT_RAIL_PANEL_WIDTH
+      : Math.max(22, Math.min(34, Math.floor(columns * 0.24)))
 
   return {
     bodyRows: Math.max(8, rows - 5),
@@ -98,5 +190,9 @@ export function getLogInkLayout(input: LogInkLayoutInput): LogInkLayout {
     sidebarWidth,
     tooSmall: columns < LOG_INK_MIN_COLUMNS || rows < LOG_INK_MIN_ROWS,
     inspectorTabbed: rows < INSPECTOR_TABBED_BELOW_ROWS,
+    density,
+    sidebarRailed,
+    inspectorRailed,
+    historyRowMode: density === 'rail' ? 'stacked' : 'single',
   }
 }

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -3213,7 +3213,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   return h(Box, { flexDirection: 'column', height: layout.rows },
     renderHeader(h, { Box, Text }, state, context, contextStatus, layout.columns, theme, appLabel),
     h(Box, { flexDirection: 'row', height: layout.bodyRows },
-      renderSidebar(h, { Box, Text }, state, context, contextStatus, layout.sidebarWidth, layout.bodyRows, theme),
+      renderSidebar(h, { Box, Text }, state, context, contextStatus, layout.sidebarWidth, layout.bodyRows, theme, layout.sidebarRailed),
       renderMainPanel(
         h,
         { Box, Text },
@@ -3239,7 +3239,9 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         theme,
         hasMoreCommits,
         loadingMoreCommits,
-        spinnerFrame
+        spinnerFrame,
+        layout.density,
+        layout.historyRowMode
       ),
       renderDetailPanel(
         h,
@@ -3253,7 +3255,8 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         filePreviewLoading,
         layout.detailWidth,
         layout.inspectorTabbed,
-        theme
+        theme,
+        layout.inspectorRailed
       )
     ),
     renderFooter(h, { Box, Text }, state, context, theme, idleTip, spinnerFrame)

--- a/src/workstation/runtime/detailPanel.ts
+++ b/src/workstation/runtime/detailPanel.ts
@@ -20,7 +20,9 @@ import type {
   GitCommitDetail,
   GitCommitFilePreview,
 } from '../../commands/log/data'
+import { getSelectedInkCommit } from '../../commands/log/inkViewModel'
 import type { LogInkState } from '../../commands/log/inkViewModel'
+import { focusBorderColor, panelTitle } from './utils'
 import {
   renderBranchPreviewPanel,
   renderCommitDiffDetail,
@@ -40,6 +42,48 @@ import {
 } from './overlays'
 import type { LogInkComponents, LogInkContext } from './types'
 
+/**
+ * Rail-mode inspector — shown on terminals < 100 columns when the
+ * detail panel does not hold focus. The full inspector (commit body,
+ * file list, actions) does not survive truncation to ~4 content cells
+ * so we collapse to a stack with the panel label and the selected
+ * commit's shortHash. Focus pops the panel back to its expanded
+ * widths via the layout, so this renderer is only reached at rest.
+ *
+ * Help / overlay states are still handled by their own renderers
+ * above; this short-circuit only kicks in for the regular "view the
+ * commit" cases.
+ */
+function renderInspectorRail(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  detail: GitCommitDetail | undefined,
+  width: number,
+  theme: LogInkTheme,
+  focused: boolean
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  // Prefer the loaded detail's hash (canonical) but fall back to the
+  // selected list row's shortHash so the rail isn't blank on the
+  // first render before getCommitDetail resolves.
+  const selectedRow = getSelectedInkCommit(state)
+  const hashText = detail?.hash.slice(0, 4)
+    ?? selectedRow?.shortHash.slice(0, 4)
+    ?? '····'
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    width,
+    paddingX: 1,
+  },
+  h(Text, { bold: true, dimColor: !focused }, panelTitle('Insp', focused)),
+  h(Text, { dimColor: true }, '────'),
+  h(Text, { color: theme.noColor ? undefined : theme.colors.accent }, hashText))
+}
+
 export function renderDetailPanel(
   h: typeof ReactTypes.createElement,
   components: LogInkComponents,
@@ -52,10 +96,15 @@ export function renderDetailPanel(
   filePreviewLoading: boolean,
   width: number,
   tabbed: boolean,
-  theme: LogInkTheme
+  theme: LogInkTheme,
+  railed: boolean = false
 ): ReactTypes.ReactElement {
   const focused = state.focus === 'detail'
 
+  // Overlays (help / palette / input / confirmation / chord) take
+  // precedence over rail because they always claim the panel's width
+  // via the help-overlay layout branch — and railing those would
+  // defeat their whole purpose (the user is reading them).
   if (state.showHelp) {
     return renderHelpPanel(h, components, state, width, theme, focused)
   }
@@ -84,6 +133,16 @@ export function renderDetailPanel(
   // navigation. The overlay's footer hint already documents `g/G top/bot`.
   if (state.pendingKey && !state.splitPlan) {
     return renderChordOverlay(h, components, state, width, theme, focused)
+  }
+
+  // Rail mode applies only after every overlay above has had its say
+  // — those would all be unreadable at 4 cells of content. The layout
+  // also clears `railed` whenever the inspector takes focus, so we
+  // can safely short-circuit the per-view dispatch here without
+  // worrying about hiding the panel from a user who's actively
+  // reading it.
+  if (railed) {
+    return renderInspectorRail(h, components, state, detail, width, theme, focused)
   }
 
   // The synthetic "(+) new commit" row routes the inspector through the

--- a/src/workstation/runtime/mainPanel.ts
+++ b/src/workstation/runtime/mainPanel.ts
@@ -10,6 +10,7 @@
 
 import type * as ReactTypes from 'react'
 import type { LogInkContextStatus } from '../chrome/context'
+import type { LogInkLayoutDensity } from '../chrome/layout'
 import type { LogInkTheme } from '../chrome/theme'
 import type {
   GitCommitDetail,
@@ -60,7 +61,9 @@ export function renderMainPanel(
   theme: LogInkTheme,
   hasMoreCommits: boolean,
   loadingMoreCommits: boolean,
-  spinnerFrame: number
+  spinnerFrame: number,
+  density: LogInkLayoutDensity,
+  rowMode: 'single' | 'stacked'
 ): ReactTypes.ReactElement {
   // Split-plan overlay (#907 polish): renders in the MAIN panel (not
   // detail) when active, because the content — multiple commit groups
@@ -155,6 +158,8 @@ export function renderMainPanel(
     width,
     theme,
     hasMoreCommits,
-    loadingMoreCommits
+    loadingMoreCommits,
+    density,
+    rowMode
   )
 }

--- a/src/workstation/runtime/sidebar.ts
+++ b/src/workstation/runtime/sidebar.ts
@@ -237,6 +237,78 @@ function renderActiveSidebarContent(
   )
 }
 
+/**
+ * Single-letter glyph for a sidebar tab in rail mode. Letters always
+ * carry the meaning so this stays useful under ASCII; the rail is too
+ * narrow to fit the full tab label. Pairs with `sidebarTabCount` for
+ * the trailing count.
+ */
+function sidebarTabRailGlyph(tab: LogInkSidebarTab): string {
+  switch (tab) {
+    case 'status':
+      return 'S'
+    case 'branches':
+      return 'B'
+    case 'tags':
+      return 'T'
+    case 'stashes':
+      return '$'
+    case 'worktrees':
+      return 'W'
+    default:
+      return '·'
+  }
+}
+
+/**
+ * Rail-mode sidebar — shown on terminals < 100 columns when the
+ * sidebar does not hold focus. Five vertically stacked tab glyphs
+ * with optional counts; the active tab is bracketed. Pressing Tab to
+ * focus the sidebar pops it back to the full accordion (the layout
+ * un-rails it on focus, this renderer is never called in that case).
+ */
+function renderSidebarRail(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  width: number,
+  theme: LogInkTheme,
+  focused: boolean,
+  tabs: LogInkSidebarTab[]
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    width,
+    paddingX: 1,
+  },
+  h(Text, { bold: true, dimColor: !focused }, 'Repo'),
+  h(Text, { dimColor: true }, '────'),
+  ...tabs.map((tab) => {
+    const isActive = tab === state.sidebarTab
+    const glyph = sidebarTabRailGlyph(tab)
+    const count = sidebarTabCount(tab, context)
+    // Count fits in 2 cells (rail content area is ~4 cells); 99+
+    // collapses to `+` so we never overflow.
+    const countText = count === undefined
+      ? ''
+      : count > 99
+        ? '+'
+        : String(count)
+    const body = isActive ? `[${glyph}]` : ` ${glyph} `
+    const text = countText ? `${body}${countText}` : body
+    return h(Text, {
+      key: `rail-${tab}`,
+      bold: isActive,
+      dimColor: !isActive,
+    }, text)
+  }))
+}
+
 export function renderSidebar(
   h: typeof ReactTypes.createElement,
   components: LogInkComponents,
@@ -245,11 +317,16 @@ export function renderSidebar(
   contextStatus: LogInkContextStatus,
   width: number,
   bodyRows: number,
-  theme: LogInkTheme
+  theme: LogInkTheme,
+  railed: boolean = false
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const focused = state.focus === 'sidebar'
   const tabs = getLogInkSidebarTabs()
+
+  if (railed) {
+    return renderSidebarRail(h, components, state, context, width, theme, focused, tabs)
+  }
 
   // Accordion layout — every tab's title is visible on its own line, but
   // only the active tab expands its content underneath. Switching tabs

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -16,6 +16,7 @@
  */
 
 import type * as ReactTypes from 'react'
+import { formatCompactRelativeDate } from '../../chrome/dateFormat'
 import { substituteGraphChars } from '../../chrome/graphChars'
 import type { LaneSegment } from '../../chrome/graphLanes'
 import { getLaneColor } from '../../chrome/graphLanes'
@@ -23,6 +24,7 @@ import {
   formatInkRefLabels,
   getVisibleLogInkHistory,
 } from '../../chrome/historyRows'
+import type { LogInkLayoutDensity } from '../../chrome/layout'
 import {
   formatLogInkHistoryEmpty,
   formatLogInkLoading,
@@ -36,6 +38,19 @@ import type {
 } from '../../../commands/log/inkViewModel'
 import type { LogInkComponents, LogInkContext } from '../../runtime/types'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
+
+/**
+ * How the date column should render for a given density tier:
+ *   - wide   → absolute `YYYY-MM-DD` (current behavior)
+ *   - normal → compact relative form (`2d`, `3w`, `2mo`)
+ *   - tight  → hidden entirely (column dropped)
+ *   - rail   → caller picks `rowMode='stacked'`; this fn isn't consulted
+ */
+function pickDateText(commit: GitLogCommitRow, density: LogInkLayoutDensity, now: Date): string {
+  if (density === 'wide') return commit.date
+  if (density === 'normal') return formatCompactRelativeDate(commit.date, now)
+  return ''
+}
 
 function formatHistoryFetchArgs(args: LogInkHistoryFetchArgs): string {
   const parts: string[] = []
@@ -111,6 +126,8 @@ function renderCommitHistoryRow(
   theme: LogInkTheme,
   index: number,
   panelWidth: number,
+  density: LogInkLayoutDensity,
+  now: Date,
   laneSegments?: LaneSegment[],
   isRecent: boolean = false
 ): ReactTypes.ReactElement {
@@ -122,7 +139,9 @@ function renderCommitHistoryRow(
   // continuation rather than its own commit (#830). Subtracting 4
   // accounts for the panel's left + right border + 1-cell padding.
   const totalWidth = Math.max(20, panelWidth - 4)
-  const fixedWidth = graphWidth + 1 + commit.shortHash.length + 1 + commit.date.length + 1
+  const dateText = pickDateText(commit, density, now)
+  const dateSegmentWidth = dateText ? dateText.length + 1 : 0
+  const fixedWidth = graphWidth + 1 + commit.shortHash.length + 1 + dateSegmentWidth
   // Refs trail the message and shrink first when the row is narrow:
   // the user can always see the full ref list in the inspector, so
   // the headline subject keeps priority over decoration.
@@ -169,10 +188,101 @@ function renderCommitHistoryRow(
     bold: selected || isRecent,
   }, commit.shortHash),
   ' ',
-  h(Text, { dimColor: true }, commit.date),
-  ' ',
+  // Date column drops out entirely at `tight` density — no spacer
+  // either, so the message column slides left into the freed cells.
+  dateText
+    ? h(Text, { key: `${commit.hash}-${index}-date`, dimColor: true }, dateText, ' ')
+    : null,
   h(Text, undefined, message),
   refsTrunc ? h(Text, { color: accent }, refsTrunc) : null)
+}
+
+/**
+ * Stacked variant used at `rowMode='stacked'` (rail tier). Each
+ * commit takes two lines so the message never has to share its row
+ * with the date / refs / hash on a sub-90-cell terminal:
+ *   line 1: graph · shortHash · subject
+ *   line 2: dim padding · date · refs
+ *
+ * Selection styling lives on the line-1 outer span; the secondary
+ * line stays dim regardless of selection so it doesn't pull the eye
+ * away from the subject.
+ */
+function renderStackedCommitHistoryRow(
+  h: typeof ReactTypes.createElement,
+  Text: LogInkComponents['Text'],
+  Box: LogInkComponents['Box'],
+  commit: GitLogCommitRow,
+  graph: string,
+  graphWidth: number,
+  selected: boolean,
+  theme: LogInkTheme,
+  index: number,
+  panelWidth: number,
+  now: Date,
+  laneSegments?: LaneSegment[],
+  isRecent: boolean = false
+): ReactTypes.ReactElement {
+  const totalWidth = Math.max(20, panelWidth - 4)
+  const accent = theme.noColor ? undefined : theme.colors.accent
+  const muted = theme.noColor ? undefined : theme.colors.muted
+  const selectedBg = selected && !theme.noColor ? theme.colors.selection : undefined
+
+  // Line 1 — subject row. Mostly mirrors the single-line layout but
+  // skips the date and refs so the message has the whole tail to
+  // itself.
+  const recentMarkerWidth = isRecent ? 2 : 0
+  const lineOneFixed = graphWidth + 1 + commit.shortHash.length + 1 + recentMarkerWidth
+  const subject = truncateCells(commit.message, Math.max(8, totalWidth - lineOneFixed))
+
+  const graphChildren = laneSegments && !theme.ascii
+    ? renderLaneSegmentSpans(h, Text, laneSegments, theme, graphWidth, `cs${index}`)
+    : [h(Text, { color: muted, dimColor: theme.noColor },
+        substituteGraphChars(graph.padEnd(graphWidth), { ascii: theme.ascii }))]
+
+  const lineOne = h(Text, {
+    key: `${commit.hash}-${index}-l1`,
+    backgroundColor: selectedBg,
+    inverse: selected,
+  },
+  ...graphChildren,
+  ' ',
+  isRecent
+    ? h(Text, { color: accent, bold: true }, theme.ascii ? '* ' : '▎ ')
+    : null,
+  h(Text, { color: accent, bold: selected || isRecent }, commit.shortHash),
+  ' ',
+  h(Text, undefined, subject))
+
+  // Line 2 — metadata row, padded to align with the start of the
+  // shortHash on line 1 so the eye still groups them as one commit.
+  // Selection background does not extend here so we don't get a thick
+  // double-row highlight on a tight terminal.
+  const indent = ' '.repeat(graphWidth + 1)
+  const dateText = formatCompactRelativeDate(commit.date, now)
+  const refs = formatInkRefLabels(commit.refs)
+  const metaRoom = Math.max(8, totalWidth - indent.length - (dateText ? dateText.length + 1 : 0))
+  const refsTrunc = refs ? truncateCells(refs, metaRoom) : ''
+  // If both pieces are empty (date unparseable + no refs), show a
+  // bullet so the row's structure still reads as two-line and the
+  // user doesn't think they hit a render bug.
+  const metaContent = dateText || refsTrunc
+    ? [
+        dateText ? h(Text, { key: `${commit.hash}-${index}-l2-date` }, dateText) : null,
+        dateText && refsTrunc ? h(Text, { key: `${commit.hash}-${index}-l2-sep` }, ' ') : null,
+        refsTrunc ? h(Text, { key: `${commit.hash}-${index}-l2-refs` }, refsTrunc) : null,
+      ].filter(Boolean)
+    : [h(Text, { key: `${commit.hash}-${index}-l2-empty` }, '·')]
+
+  const lineTwo = h(Text, {
+    key: `${commit.hash}-${index}-l2`,
+    dimColor: true,
+  }, indent, ...metaContent)
+
+  return h(Box, {
+    key: `${commit.hash}-${index}-stack`,
+    flexDirection: 'column',
+  }, lineOne, lineTwo)
 }
 
 /**
@@ -219,7 +329,10 @@ export function renderHistoryPanel(
   width: number,
   theme: LogInkTheme,
   hasMoreCommits: boolean,
-  loadingMoreCommits: boolean
+  loadingMoreCommits: boolean,
+  density: LogInkLayoutDensity,
+  rowMode: 'single' | 'stacked',
+  now: Date = new Date()
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const focused = state.focus === 'commits'
@@ -238,7 +351,12 @@ export function renderHistoryPanel(
   const showPendingRow = worktreeDirty &&
     !state.filter &&
     state.selectedIndex === 0
-  const listRows = Math.max(3, bodyRows - (showPendingRow ? 5 : 4))
+  // Stacked rows take two terminal lines each, so the visible item
+  // budget is halved before the pending-row / chrome subtraction.
+  const chromeRows = showPendingRow ? 5 : 4
+  const listRows = rowMode === 'stacked'
+    ? Math.max(2, Math.floor((bodyRows - chromeRows) / 2))
+    : Math.max(3, bodyRows - chromeRows)
   const visible = getVisibleLogInkHistory(state, listRows)
   const loadState = loadingMoreCommits
     ? 'loading older commits'
@@ -308,10 +426,18 @@ export function renderHistoryPanel(
         ), Math.max(8, width - 4)))
       }
 
+      if (rowMode === 'stacked') {
+        return renderStackedCommitHistoryRow(
+          h, Text, Box, item.commit, item.graph, visible.graphWidth,
+          Boolean(item.selected) && !realSelectionSuppressed, theme, index,
+          width, now, item.laneSegments,
+          recentCommitsSet.has(item.commit.hash)
+        )
+      }
       return renderCommitHistoryRow(
         h, Text, item.commit, item.graph, visible.graphWidth,
         Boolean(item.selected) && !realSelectionSuppressed, theme, index,
-        width, item.laneSegments,
+        width, density, now, item.laneSegments,
         recentCommitsSet.has(item.commit.hash)
       )
     }))


### PR DESCRIPTION
## Summary

Width-driven responsive behavior for the log/history UI so coco stays readable on terminals as narrow as 80 columns. Four density tiers control date formatting, column dropping, row stacking, and side-panel rail collapse.

| Tier   | Columns   | Effect                                                                 |
| ------ | --------- | ---------------------------------------------------------------------- |
| wide   | >= 160    | Current behavior — absolute `YYYY-MM-DD` dates                         |
| normal | 120–159   | Compact relative dates (`2d`, `3w`, `2mo`)                             |
| tight  | 100–119   | Date column dropped entirely                                           |
| rail   | < 100     | Stacked 2-line history rows; sidebar + inspector rail when not focused |

Focus always wins: tabbing into a railed sidebar or inspector pops it back to the expanded width via the existing focus-grow contract — same pattern coco already uses. The help overlay also overrides inspector rail since that's where its descriptions render.

### Files changed

- `chrome/layout.ts` — new `density`, `sidebarRailed`, `inspectorRailed`, `historyRowMode` fields on `LogInkLayout`; rail width via `LAYOUT_RAIL_PANEL_WIDTH = 8`. Single source of truth shared by all renderers + tests.
- `chrome/dateFormat.ts` (new) — `formatCompactRelativeDate` outputs `today` / `Nd` / `Nw` / `Nmo` / `Ny`. Tighter cousin of the existing `formatBranchLastTouched` helper.
- `surfaces/history/index.ts` — density-aware column dropping in `renderCommitHistoryRow`; new `renderStackedCommitHistoryRow` for `rowMode='stacked'`.
- `runtime/sidebar.ts` — new `renderSidebarRail` (single-letter tab glyphs + counts, active tab bracketed).
- `runtime/detailPanel.ts` — `renderInspectorRail` short-circuits the per-view dispatch when railed; runs after all overlay checks so help / palette / chord still take the full width.

## Test plan

- [x] Layout tests cover all four tiers, the focus-rescue contract, and help-overlay override (`layout.test.ts`).
- [x] Relative-date helper has full unit coverage (`dateFormat.test.ts`).
- [x] Full jest suite: 1682 pass / 7 skipped, no regressions.
- [x] `npm run lint` clean.
- [x] `npm run build` produces dist bundles.
- [x] `npm run test:cli` smoke tests pass (commit / log / ui commands all start).
- [ ] **Manual UI verification at each tier** — I do not have access to a live terminal in this sandbox, so I have NOT visually confirmed the rendered output at 80 / 110 / 130 / 180 columns. Reviewer should resize a terminal across the breakpoints and verify the transitions look right before merging.

## Notes for the reviewer

- The `Date` parameter on `renderHistoryPanel` defaults to `new Date()` so existing callers don't have to thread `now` through. Tests that need a stable reference pass it explicitly.
- The existing 80x24 layout test expected `sidebarWidth=22, detailWidth=20`. With rail mode that drops to `LAYOUT_RAIL_PANEL_WIDTH=8` for both — test updated to assert the rail tier instead, and a separate "above the rail tier" test pins the legacy at-rest clamps at 100 columns.
- Help overlay precedence is preserved: `inspectorRailed` is gated on `!helpOverlayActive` so we don't render a 4-cell rail when the user is trying to read hotkey descriptions.