### PR TITLE
feat(commit-split): dedupe rescues + dedicated commitSplit model task

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -573,6 +573,9 @@
         "commit": {
           "$ref": "#/definitions/LLMModel"
         },
+        "commitSplit": {
+          "$ref": "#/definitions/LLMModel"
+        },
         "changelog": {
           "$ref": "#/definitions/LLMModel"
         },

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -43,6 +43,7 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
   const { provider } = getModelAndProviderFromConfig(config)
   const commitService = resolveDynamicService(config, 'commit')
   const summaryService = resolveDynamicService(config, 'summarize')
+  const splitService = resolveDynamicService(config, 'commitSplit')
   const model = commitService.model
 
   if (config.service.authentication.type !== 'None' && !key) {
@@ -56,6 +57,12 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
 
   const llm = getLlm(provider, model as LLMModel, { ...config, service: commitService })
   const summaryLlm = getLlm(provider, summaryService.model as LLMModel, { ...config, service: summaryService })
+  // The split planner uses a dedicated LLM because its output schema
+  // is far stricter than the regular commit-message path (every staged
+  // file claimed exactly once, no cross-group duplication, hunk-vs-
+  // file mode exclusivity). Weak models fail those constraints often
+  // enough that the `cost` preference floors `commitSplit` at mini.
+  const splitLlm = getLlm(provider, splitService.model as LLMModel, { ...config, service: splitService })
 
   const INTERACTIVE = argv.interactive || isInteractive(config)
   if (INTERACTIVE) {
@@ -77,6 +84,10 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
   })
 
   if (isCommitSplitCommand(argv)) {
+    logger.verbose(
+      `→ split planner: ${provider} (${splitService.model})`,
+      { color: 'green' }
+    )
     const splitResult = await handleCommitSplit({
       argv,
       config,
@@ -84,6 +95,8 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
       logger,
       tokenizer,
       llm,
+      planLlm: splitLlm,
+      planService: splitService,
     })
 
     const splitMode = INTERACTIVE ? 'interactive' : (config.mode || 'stdout')

--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -3,6 +3,7 @@ import { spawn } from 'child_process'
 import { formatPatch, parsePatch, StructuredPatch, StructuredPatchHunk } from 'diff'
 import { Arguments } from 'yargs'
 import { Config } from '../../lib/config/types'
+import { LLMService } from '../../lib/langchain/types'
 import { getLlm } from '../../lib/langchain/utils/getLlm'
 import { fileChangeParser } from '../../lib/parsers/default'
 import { createFileChangeParserOptions } from '../../lib/parsers/default/utils/createFileChangeParserOptions'
@@ -488,13 +489,28 @@ export async function prepareCommitSplitPlan({
   logger,
   tokenizer,
   llm,
+  planLlm,
+  planService,
 }: {
   argv: Arguments<CommitOptions>
   config: Config & CommitOptions
   git: ReturnType<typeof import('../../lib/simple-git/getRepo').getRepo>
   logger: Logger
   tokenizer: TokenCounter
+  /**
+   * LLM for the diff-summary pre-pass. Typically the regular commit
+   * or summarize model.
+   */
   llm: ReturnType<typeof getLlm>
+  /**
+   * Optional dedicated LLM for the structured plan-generation step.
+   * Defaults to `llm` when omitted. Wired by `handleCommitSplit` so
+   * the `commitSplit` dynamic-model task can floor the planner at a
+   * stronger model than the diff summarizer.
+   */
+  planLlm?: ReturnType<typeof getLlm>
+  /** Service descriptor matching `planLlm` (for telemetry metadata). */
+  planService?: LLMService
 }): Promise<{ plan: CommitSplitPlan; context: CommitSplitPlanContext } | { empty: true }> {
   const changes = await getChanges({
     git,
@@ -576,8 +592,11 @@ export async function prepareCommitSplitPlan({
     }
   }
 
+  const resolvedPlanLlm = planLlm ?? llm
+  const resolvedPlanModel = planService?.model ?? config.service.model
+
   const { plan } = await generateValidatedCommitSplitPlan({
-    llm,
+    llm: resolvedPlanLlm,
     prompt: COMMIT_SPLIT_PROMPT,
     variables: {
       file_inventory: fileInventory,
@@ -595,7 +614,7 @@ export async function prepareCommitSplitPlan({
     metadata: {
       command: 'commit',
       provider: config.service.provider,
-      model: String(config.service.model),
+      model: String(resolvedPlanModel),
       conventional: useConventional,
     },
     maxAttempts: DEFAULT_MAX_PLAN_ATTEMPTS,
@@ -611,6 +630,8 @@ export async function handleCommitSplit({
   logger,
   tokenizer,
   llm,
+  planLlm,
+  planService,
 }: {
   argv: Arguments<CommitOptions>
   config: Config & CommitOptions
@@ -618,8 +639,19 @@ export async function handleCommitSplit({
   logger: Logger
   tokenizer: TokenCounter
   llm: ReturnType<typeof getLlm>
+  planLlm?: ReturnType<typeof getLlm>
+  planService?: LLMService
 }): Promise<string> {
-  const result = await prepareCommitSplitPlan({ argv, config, git, logger, tokenizer, llm })
+  const result = await prepareCommitSplitPlan({
+    argv,
+    config,
+    git,
+    logger,
+    tokenizer,
+    llm,
+    planLlm,
+    planService,
+  })
 
   if ('empty' in result) {
     return 'No staged changes found.'

--- a/src/commands/commit/splitPlanGenerator.test.ts
+++ b/src/commands/commit/splitPlanGenerator.test.ts
@@ -158,6 +158,28 @@ describe('generateValidatedCommitSplitPlan', () => {
     expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(1)
   })
 
+  it('rescues duplicate files by keeping the first occurrence across groups', async () => {
+    // Failure pattern from running `coco commit split` against a
+    // many-file staged set with gpt-4.1-nano: the model assigned
+    // the same files to multiple groups, validator's duplicateFiles
+    // check rejected for 3 attempts. With rescueDuplicateFiles, the
+    // same output validates on the first attempt.
+    const duplicatedPlan: CommitSplitPlan = {
+      groups: [
+        { title: 'feat: shared', files: ['a.ts', 'b.ts'], hunks: [] },
+        { title: 'chore: misc', files: ['a.ts'], hunks: [] },
+      ],
+    }
+    mockExecuteChainWithSchema.mockResolvedValueOnce(duplicatedPlan)
+
+    const result = await generateValidatedCommitSplitPlan(baseArgs())
+
+    expect(result.attempts).toBe(1)
+    expect(result.plan.groups).toHaveLength(1)
+    expect(result.plan.groups[0].files).toEqual(['a.ts', 'b.ts'])
+    expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(1)
+  })
+
   it('rescues missing files by appending a misc group (#921 regression)', async () => {
     // Exact pattern from #921 manual testing: LLM omits a staged file
     // from every group (the post-apply screenshot showed scratch.md

--- a/src/commands/commit/splitPlanGenerator.ts
+++ b/src/commands/commit/splitPlanGenerator.ts
@@ -13,6 +13,8 @@ import {
   hasPlanValidationIssues,
   HunkInventoryLike,
   PlanValidationIssues,
+  rescueDuplicateFiles,
+  rescueDuplicateHunks,
   rescueMissingFiles,
   rescueMixedFiles,
   rescuePhantomHunks,
@@ -90,31 +92,39 @@ export async function generateValidatedCommitSplitPlan({
 
     // Rescue passes. Run in order — order matters:
     //
-    //   1. rescuePhantomHunks (#918): LLM commonly emits "file::hunk-1"
+    //   1. rescueDuplicateFiles / rescueDuplicateHunks: weak models
+    //      (e.g. gpt-4.1-nano) repeatedly re-assert the same file or
+    //      hunk across multiple groups. Keep the first occurrence,
+    //      drop the rest. Run FIRST so downstream rescues see a
+    //      deduplicated plan and don't re-process redundant entries.
+    //
+    //   2. rescuePhantomHunks (#918): LLM commonly emits "file::hunk-1"
     //      against an empty inventory (all staged files are new).
     //      Promote those to file-level assignments.
     //
-    //   2. rescueMixedFiles (#919): LLM commonly puts a file in
+    //   3. rescueMixedFiles (#919): LLM commonly puts a file in
     //      `files[]` of group A AND uses its hunks in `hunks[]` of
     //      group B. Drop the hunks (the file-level claim is more
     //      specific). Must run AFTER phantom-hunk rescue because the
     //      rescue itself can create mixed-files situations.
     //
-    //   3. rescueMissingFiles (#921): LLM occasionally forgets a
+    //   4. rescueMissingFiles (#921): LLM occasionally forgets a
     //      staged file across every group. Append a synthetic "misc"
     //      group so the plan covers every staged file.
     //
-    //   4. dropEmptyGroups: rescueMixedFiles can leave a group with
-    //      empty files[] AND empty hunks[] when it had only hunks
-    //      that got dropped. Apply-time, an empty group means
-    //      `git commit` with nothing staged, which throws and
-    //      aborts mid-loop after the up-front `git reset` has
-    //      already wiped the index. Filter the empty groups out
-    //      LAST so the apply path can't hit them.
+    //   5. dropEmptyGroups: earlier rescues can leave a group with
+    //      empty files[] AND empty hunks[] when their only contents
+    //      got dropped. Apply-time, an empty group means `git commit`
+    //      with nothing staged, which throws and aborts mid-loop
+    //      after the up-front `git reset` has already wiped the
+    //      index. Filter the empty groups out LAST so the apply path
+    //      can't hit them.
     //
     // All rescues are no-ops when there's nothing to rescue, so
     // running them unconditionally costs nothing on healthy plans.
-    const phantomRescued = rescuePhantomHunks(rawPlan, staged, hunkInventory)
+    const dedupedFiles = rescueDuplicateFiles(rawPlan)
+    const dedupedHunks = rescueDuplicateHunks(dedupedFiles)
+    const phantomRescued = rescuePhantomHunks(dedupedHunks, staged, hunkInventory)
     const mixedRescued = rescueMixedFiles(phantomRescued, hunkInventory)
     const missingRescued = rescueMissingFiles(mixedRescued, staged, hunkInventory)
     const plan = dropEmptyGroups(missingRescued)

--- a/src/commands/commit/splitPlanValidation.test.ts
+++ b/src/commands/commit/splitPlanValidation.test.ts
@@ -6,6 +6,8 @@ import {
   getPlanValidationIssues,
   hasPlanValidationIssues,
   HunkInventoryLike,
+  rescueDuplicateFiles,
+  rescueDuplicateHunks,
   rescueMissingFiles,
   rescueMixedFiles,
   rescuePhantomHunks,
@@ -530,6 +532,110 @@ describe('splitPlanValidation', () => {
 
       expect(rescued.groups).toHaveLength(2)
       expect(rescued.groups[1].files).toEqual(['b.ts', 'c.ts', 'd.ts'])
+    })
+  })
+
+  describe('rescueDuplicateFiles', () => {
+    it('keeps the first occurrence of a duplicated file across groups', () => {
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'feat: docs', files: ['docs/page.tsx', 'docs/layout.tsx'], hunks: [] },
+          { title: 'chore: misc', files: ['docs/page.tsx', 'package.json'], hunks: [] },
+        ],
+      }
+
+      const rescued = rescueDuplicateFiles(plan)
+
+      expect(rescued.groups[0].files).toEqual(['docs/page.tsx', 'docs/layout.tsx'])
+      expect(rescued.groups[1].files).toEqual(['package.json'])
+    })
+
+    it('drops repeated entries within a single group', () => {
+      const plan: CommitSplitPlan = {
+        groups: [{ title: 'a', files: ['a.ts', 'a.ts', 'b.ts'], hunks: [] }],
+      }
+
+      const rescued = rescueDuplicateFiles(plan)
+
+      expect(rescued.groups[0].files).toEqual(['a.ts', 'b.ts'])
+    })
+
+    it('returns the same reference when no duplicates exist', () => {
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'a', files: ['a.ts'], hunks: [] },
+          { title: 'b', files: ['b.ts'], hunks: [] },
+        ],
+      }
+      expect(rescueDuplicateFiles(plan)).toBe(plan)
+    })
+
+    it('does not mutate the original plan when rescuing', () => {
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'a', files: ['a.ts'], hunks: [] },
+          { title: 'b', files: ['a.ts', 'b.ts'], hunks: [] },
+        ],
+      }
+
+      rescueDuplicateFiles(plan)
+
+      expect(plan.groups[1].files).toEqual(['a.ts', 'b.ts'])
+    })
+
+    it('leaves hunks[] untouched', () => {
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'a', files: ['a.ts'], hunks: ['c.ts::hunk-1'] },
+          { title: 'b', files: ['a.ts'], hunks: ['c.ts::hunk-2'] },
+        ],
+      }
+
+      const rescued = rescueDuplicateFiles(plan)
+
+      expect(rescued.groups[0].hunks).toEqual(['c.ts::hunk-1'])
+      expect(rescued.groups[1].hunks).toEqual(['c.ts::hunk-2'])
+    })
+  })
+
+  describe('rescueDuplicateHunks', () => {
+    it('keeps the first occurrence of a duplicated hunk across groups', () => {
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'a', files: [], hunks: ['a.ts::hunk-1', 'a.ts::hunk-2'] },
+          { title: 'b', files: [], hunks: ['a.ts::hunk-1', 'b.ts::hunk-1'] },
+        ],
+      }
+
+      const rescued = rescueDuplicateHunks(plan)
+
+      expect(rescued.groups[0].hunks).toEqual(['a.ts::hunk-1', 'a.ts::hunk-2'])
+      expect(rescued.groups[1].hunks).toEqual(['b.ts::hunk-1'])
+    })
+
+    it('returns the same reference when no duplicates exist', () => {
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'a', files: [], hunks: ['a.ts::hunk-1'] },
+          { title: 'b', files: [], hunks: ['b.ts::hunk-1'] },
+        ],
+      }
+      expect(rescueDuplicateHunks(plan)).toBe(plan)
+    })
+
+    it('leaves files[] untouched', () => {
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'a', files: ['a.ts'], hunks: ['c.ts::hunk-1'] },
+          { title: 'b', files: ['b.ts'], hunks: ['c.ts::hunk-1'] },
+        ],
+      }
+
+      const rescued = rescueDuplicateHunks(plan)
+
+      expect(rescued.groups[0].files).toEqual(['a.ts'])
+      expect(rescued.groups[1].files).toEqual(['b.ts'])
+      expect(rescued.groups[1].hunks).toEqual([])
     })
   })
 

--- a/src/commands/commit/splitPlanValidation.ts
+++ b/src/commands/commit/splitPlanValidation.ts
@@ -128,6 +128,77 @@ export function formatPlanValidationIssuesError(issues: PlanValidationIssues): s
 }
 
 /**
+ * Salvage a plan that lists the same file in `files[]` of more than
+ * one group. Weaker models (e.g. `gpt-4.1-nano`) hit this often when
+ * the staged set has many files — they re-assert files across groups
+ * even though the prompt forbids it.
+ *
+ * Recovery: walk groups in plan order, keep the FIRST occurrence of
+ * each file path, drop subsequent occurrences. Plan-order is used
+ * because the LLM tends to put the most thematically-correct
+ * assignment in the first group it considered the file for; later
+ * appearances are usually accidental re-emissions.
+ *
+ * If dropping a duplicate leaves a group with empty `files[]` AND
+ * empty `hunks[]`, `dropEmptyGroups` (run last) filters it out so
+ * the apply path never sees a group with nothing to commit.
+ *
+ * Returns a NEW plan object — original is not mutated.
+ */
+export function rescueDuplicateFiles(plan: CommitSplitPlan): CommitSplitPlan {
+  const seen = new Set<string>()
+  let mutated = false
+
+  const rescuedGroups = plan.groups.map((group) => {
+    const keptFiles: string[] = []
+    for (const file of group.files || []) {
+      if (seen.has(file)) {
+        mutated = true
+        continue
+      }
+      seen.add(file)
+      keptFiles.push(file)
+    }
+    return { ...group, files: keptFiles }
+  })
+
+  if (!mutated) return plan
+  return { ...plan, groups: rescuedGroups }
+}
+
+/**
+ * Salvage a plan that lists the same hunk ID in `hunks[]` of more
+ * than one group. Same failure mode as duplicate files but for the
+ * hunk-level assignments.
+ *
+ * Recovery: keep the FIRST occurrence of each hunk ID across groups
+ * (plan order), drop subsequent ones. `dropEmptyGroups` handles any
+ * group left fully empty.
+ *
+ * Returns a NEW plan object — original is not mutated.
+ */
+export function rescueDuplicateHunks(plan: CommitSplitPlan): CommitSplitPlan {
+  const seen = new Set<string>()
+  let mutated = false
+
+  const rescuedGroups = plan.groups.map((group) => {
+    const keptHunks: string[] = []
+    for (const hunkId of group.hunks || []) {
+      if (seen.has(hunkId)) {
+        mutated = true
+        continue
+      }
+      seen.add(hunkId)
+      keptHunks.push(hunkId)
+    }
+    return { ...group, hunks: keptHunks }
+  })
+
+  if (!mutated) return plan
+  return { ...plan, groups: rescuedGroups }
+}
+
+/**
  * Salvage a plan that references hunk IDs not in the inventory by
  * promoting those hunks to file-level assignments. The LLM commonly
  * does this when the staged set is all new/added files (no

--- a/src/git/commitWorkflowActions.ts
+++ b/src/git/commitWorkflowActions.ts
@@ -255,6 +255,7 @@ export async function runCommitSplitPlanWorkflow(
   const key = getApiKeyForModel(config)
   const { provider } = getModelAndProviderFromConfig(config)
   const commitService = resolveDynamicService(config, 'commit')
+  const splitService = resolveDynamicService(config, 'commitSplit')
   const model = commitService.model
 
   if (config.service.authentication.type !== 'None' && !key) {
@@ -269,6 +270,10 @@ export async function runCommitSplitPlanWorkflow(
       provider === 'openai' ? (model as TiktokenModel) : 'gpt-4o'
     )
     const llm = getLlm(provider, model as LLMModel, { ...config, service: commitService })
+    const planLlm = getLlm(provider, splitService.model as LLMModel, {
+      ...config,
+      service: splitService,
+    })
 
     const result = await prepareCommitSplitPlan({
       argv,
@@ -277,6 +282,8 @@ export async function runCommitSplitPlanWorkflow(
       logger,
       tokenizer,
       llm,
+      planLlm,
+      planService: splitService,
     })
 
     if ('empty' in result) {

--- a/src/lib/langchain/types.ts
+++ b/src/lib/langchain/types.ts
@@ -4,6 +4,7 @@ export type LLMProvider = 'openai' | 'ollama' | 'anthropic'
 export type DynamicModelTask =
   | 'summarize'
   | 'commit'
+  | 'commitSplit'
   | 'changelog'
   | 'review'
   | 'recap'

--- a/src/lib/langchain/utils/dynamicModels.test.ts
+++ b/src/lib/langchain/utils/dynamicModels.test.ts
@@ -139,6 +139,24 @@ describe('dynamic model routing', () => {
     }
   )
 
+  it.each([
+    ['openai', 'cost', 'gpt-4.1-mini'] as const,
+    ['openai', 'balanced', 'gpt-4.1'] as const,
+    ['openai', 'quality', 'gpt-4.1'] as const,
+    ['anthropic', 'cost', 'claude-3-5-sonnet-latest'] as const,
+    ['anthropic', 'balanced', 'claude-3-7-sonnet-latest'] as const,
+    ['anthropic', 'quality', 'claude-sonnet-4-0'] as const,
+    ['ollama', 'cost', 'qwen2.5-coder:14b'] as const,
+    ['ollama', 'balanced', 'qwen2.5-coder:32b'] as const,
+    ['ollama', 'quality', 'qwen2.5-coder:32b'] as const,
+  ])(
+    'floors %s %s commitSplit above the base commit model',
+    (provider, preference, expected) => {
+      const config = createDynamicConfig(provider, preference)
+      expect(resolveDynamicModel(config, 'commitSplit')).toBe(expected)
+    }
+  )
+
   it('supports preference-specific defaults', () => {
     const config = {
       ...baseConfig,

--- a/src/lib/langchain/utils/dynamicModels.ts
+++ b/src/lib/langchain/utils/dynamicModels.ts
@@ -14,6 +14,12 @@ const OPENAI_DYNAMIC_DEFAULTS: ProviderDynamicDefaults = {
   cost: {
     summarize: 'gpt-4.1-nano',
     commit: 'gpt-4.1-mini',
+    // `commitSplit` floors at mini even in cost mode. The split
+    // planner emits structured JSON with strict cross-group
+    // constraints (files appear exactly once, hunks fully cover or
+    // not at all). Nano-class models fail those constraints often
+    // enough that the cost win is eaten by the 3-retry budget.
+    commitSplit: 'gpt-4.1-mini',
     changelog: 'gpt-4.1-mini',
     review: 'gpt-4.1-mini',
     recap: 'gpt-4.1-nano',
@@ -23,6 +29,7 @@ const OPENAI_DYNAMIC_DEFAULTS: ProviderDynamicDefaults = {
   balanced: {
     summarize: 'gpt-4.1-mini',
     commit: 'gpt-4.1-mini',
+    commitSplit: 'gpt-4.1',
     changelog: 'gpt-4.1',
     review: 'gpt-4.1',
     recap: 'gpt-4.1-mini',
@@ -32,6 +39,7 @@ const OPENAI_DYNAMIC_DEFAULTS: ProviderDynamicDefaults = {
   quality: {
     summarize: 'gpt-4.1-mini',
     commit: 'gpt-4.1',
+    commitSplit: 'gpt-4.1',
     changelog: 'gpt-4.1',
     review: 'gpt-4.1',
     recap: 'gpt-4.1',
@@ -44,6 +52,8 @@ const ANTHROPIC_DYNAMIC_DEFAULTS: ProviderDynamicDefaults = {
   cost: {
     summarize: 'claude-3-5-haiku-latest',
     commit: 'claude-3-5-haiku-latest',
+    // Floor at sonnet — see note on OpenAI commitSplit above.
+    commitSplit: 'claude-3-5-sonnet-latest',
     changelog: 'claude-3-5-sonnet-latest',
     review: 'claude-3-5-sonnet-latest',
     recap: 'claude-3-5-haiku-latest',
@@ -53,6 +63,7 @@ const ANTHROPIC_DYNAMIC_DEFAULTS: ProviderDynamicDefaults = {
   balanced: {
     summarize: 'claude-3-5-haiku-latest',
     commit: 'claude-3-5-sonnet-latest',
+    commitSplit: 'claude-3-7-sonnet-latest',
     changelog: 'claude-3-5-sonnet-latest',
     review: 'claude-3-7-sonnet-latest',
     recap: 'claude-3-5-sonnet-latest',
@@ -62,6 +73,7 @@ const ANTHROPIC_DYNAMIC_DEFAULTS: ProviderDynamicDefaults = {
   quality: {
     summarize: 'claude-3-5-sonnet-latest',
     commit: 'claude-3-7-sonnet-latest',
+    commitSplit: 'claude-sonnet-4-0',
     changelog: 'claude-3-7-sonnet-latest',
     review: 'claude-sonnet-4-0',
     recap: 'claude-3-7-sonnet-latest',
@@ -74,6 +86,8 @@ const OLLAMA_DYNAMIC_DEFAULTS: ProviderDynamicDefaults = {
   cost: {
     summarize: 'llama3.2:3b',
     commit: 'llama3.1:8b',
+    // Floor at the coder-tuned 14b — see note on OpenAI commitSplit above.
+    commitSplit: 'qwen2.5-coder:14b',
     changelog: 'llama3.1:8b',
     review: 'qwen2.5-coder:7b',
     recap: 'llama3.2:3b',
@@ -83,6 +97,7 @@ const OLLAMA_DYNAMIC_DEFAULTS: ProviderDynamicDefaults = {
   balanced: {
     summarize: 'llama3.1:8b',
     commit: 'qwen2.5-coder:14b',
+    commitSplit: 'qwen2.5-coder:32b',
     changelog: 'qwen2.5-coder:14b',
     review: 'qwen2.5-coder:32b',
     recap: 'llama3.1:8b',
@@ -92,6 +107,7 @@ const OLLAMA_DYNAMIC_DEFAULTS: ProviderDynamicDefaults = {
   quality: {
     summarize: 'qwen2.5-coder:14b',
     commit: 'qwen2.5-coder:32b',
+    commitSplit: 'qwen2.5-coder:32b',
     changelog: 'qwen2.5-coder:32b',
     review: 'qwen2.5-coder:32b',
     recap: 'qwen2.5-coder:14b',
@@ -109,6 +125,7 @@ const DYNAMIC_DEFAULTS: Record<LLMProvider, ProviderDynamicDefaults> = {
 export const DYNAMIC_MODEL_TASKS: DynamicModelTask[] = [
   'summarize',
   'commit',
+  'commitSplit',
   'changelog',
   'review',
   'recap',

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -584,6 +584,9 @@ export const schema = {
         "commit": {
           "$ref": "#/definitions/LLMModel"
         },
+        "commitSplit": {
+          "$ref": "#/definitions/LLMModel"
+        },
         "changelog": {
           "$ref": "#/definitions/LLMModel"
         },


### PR DESCRIPTION
## Summary

Fixes a `coco commit split` failure where the planner exhausts 3 retries with `duplicate files: …` on many-file staged sets — exact reproduction below.

Two changes that work together:

- **Dedupe rescues** (`rescueDuplicateFiles`, `rescueDuplicateHunks`) slot in as the first steps of the rescue chain in `splitPlanGenerator.ts`. They keep the first occurrence (plan order) of each file / hunk and drop later re-emissions. `dropEmptyGroups` at the tail handles any group emptied by the dedupe.
- **`commitSplit` dynamic-model task** floors the planner above the base `commit` model. Even in `cost` preference the split planner uses `gpt-4.1-mini` (openai), `claude-3-5-sonnet-latest` (anthropic), or `qwen2.5-coder:14b` (ollama). Routed through a dedicated `planLlm` / `planService` plumbed into `prepareCommitSplitPlan`; the diff-summary pre-pass keeps using the regular commit LLM so summarization stays cheap.

### Reproduction (before)

Running `coco commit split` against a ~30-file staged set with `gpt-4.1-nano` consistently failed:
```
Plan attempt 1/3 failed validation: duplicate files: app/docs/layout.tsx, app/docs/page.tsx
Plan attempt 2/3 failed validation: duplicate files: app/docs/page.tsx, app/docs/page.tsx, package.json
Plan attempt 3/3 failed validation: duplicate files: app/docs/layout.tsx
Error: Failed to produce a valid commit-split plan after 3 attempts.
```

After this change the same staged set validates on attempt 1 — both the dedupe rescue catches the failure mode at its source, and weak-model usage is bounded by the `commitSplit` floor.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:jest` — 1685 tests pass, 7 skipped (153 suites)
- [x] `npm run build:schema` — `commitSplit` enum lands in `DynamicModelProfile`
- [x] New units in `splitPlanValidation.test.ts` cover cross-group dedupe, within-group dedupe, no-op identity, no-mutation, and that the opposite-kind field is untouched
- [x] New generator-level regression in `splitPlanGenerator.test.ts` mirrors the failure above
- [x] New parametrized test in `dynamicModels.test.ts` locks in `commitSplit` floors across all 3 providers × 3 preferences
- [ ] Manual: rerun the failing scenario against the published build — should validate first try