### PR TITLE
feat(ui): graph fidelity bundle — branch chips, spacer rows, compact stays minimal

### DIFF
--- a/src/workstation/chrome/branchTip.test.ts
+++ b/src/workstation/chrome/branchTip.test.ts
@@ -1,0 +1,44 @@
+import { getBranchTipChip } from './branchTip'
+
+describe('getBranchTipChip', () => {
+  it('returns the HEAD branch when refs include HEAD -> X', () => {
+    expect(getBranchTipChip(['HEAD -> main'])).toEqual({ name: 'main', isHead: true })
+    expect(getBranchTipChip(['HEAD -> feat/foo', 'origin/feat/foo']))
+      .toEqual({ name: 'feat/foo', isHead: true })
+  })
+
+  it('prefers HEAD over plain branch tips even when both are present', () => {
+    expect(getBranchTipChip(['other', 'HEAD -> main']))
+      .toEqual({ name: 'main', isHead: true })
+  })
+
+  it('returns the first plain local branch when HEAD is not present', () => {
+    expect(getBranchTipChip(['feat/foo'])).toEqual({ name: 'feat/foo', isHead: false })
+    expect(getBranchTipChip(['feat/foo', 'origin/feat/foo']))
+      // feat/foo contains a slash so it is treated as remote-like; first
+      // truly-plain branch wins. With only slashy refs we fall through
+      // to the remote-tracking fallback below.
+      .toEqual({ name: 'feat/foo', isHead: false })
+  })
+
+  it('falls back to a remote-tracking branch when nothing local is on the tip', () => {
+    expect(getBranchTipChip(['origin/main'])).toEqual({ name: 'origin/main', isHead: false })
+  })
+
+  it('ignores tags entirely', () => {
+    expect(getBranchTipChip(['tag: v1.0.0'])).toBeUndefined()
+    expect(getBranchTipChip(['tag: v1.0.0', 'tag: latest'])).toBeUndefined()
+  })
+
+  it('ignores bare HEAD (detached)', () => {
+    expect(getBranchTipChip(['HEAD'])).toBeUndefined()
+  })
+
+  it('returns undefined for an empty refs list', () => {
+    expect(getBranchTipChip([])).toBeUndefined()
+  })
+
+  it('skips a HEAD -> with an empty branch name', () => {
+    expect(getBranchTipChip(['HEAD -> '])).toBeUndefined()
+  })
+})

--- a/src/workstation/chrome/branchTip.ts
+++ b/src/workstation/chrome/branchTip.ts
@@ -1,0 +1,59 @@
+/**
+ * Extract a branch-tip chip from a commit's refs. The chip is shown
+ * as a colored prefix before the commit message in full-graph mode so
+ * branch tips read as distinct visual anchors rather than getting
+ * lost in the trailing `[ref] [ref]` list.
+ *
+ * Selection priority:
+ *   1. `HEAD -> X` — current branch wins. Returned with `isHead: true`.
+ *   2. The first "plain" local branch (not a tag, not a HEAD marker,
+ *      not a remote ref) — typical for commits that are tips of
+ *      other local branches.
+ *   3. The first remote-tracking branch (`origin/X`) — last-resort
+ *      so a commit at the tip of a remote branch you don't have
+ *      locally still gets a chip.
+ *
+ * Tags are deliberately excluded from chip selection — they belong in
+ * the trailing ref list so the chip column stays branch-only and the
+ * eye can rely on "leading chip = branch tip".
+ *
+ * Returns `undefined` when nothing chip-worthy is present; the
+ * renderer then skips the prefix entirely so unmarked commits don't
+ * pay any width budget.
+ */
+export type BranchTipChip = {
+  name: string
+  isHead: boolean
+}
+
+export function getBranchTipChip(refs: string[]): BranchTipChip | undefined {
+  for (const ref of refs) {
+    if (ref.startsWith('HEAD -> ')) {
+      const name = ref.slice('HEAD -> '.length).trim()
+      if (name) return { name, isHead: true }
+    }
+  }
+
+  for (const ref of refs) {
+    if (
+      ref === 'HEAD' ||
+      ref.startsWith('HEAD -> ') ||
+      ref.startsWith('tag: ') ||
+      ref.includes('/')
+    ) {
+      continue
+    }
+    if (ref.trim()) return { name: ref.trim(), isHead: false }
+  }
+
+  for (const ref of refs) {
+    if (ref.startsWith('tag: ') || ref === 'HEAD' || ref.startsWith('HEAD -> ')) {
+      continue
+    }
+    if (ref.includes('/') && ref.trim()) {
+      return { name: ref.trim(), isHead: false }
+    }
+  }
+
+  return undefined
+}

--- a/src/workstation/chrome/historyRows.test.ts
+++ b/src/workstation/chrome/historyRows.test.ts
@@ -250,4 +250,65 @@ describe('Ink history rows', () => {
       expect(visible.items[2].laneSegments).toEqual([{ text: '●', laneId: undefined }])
     })
   })
+
+  // Full-graph spacing — visual fidelity follow-up. With
+  // `fullGraphSpacing: true` the row builder injects a synthetic
+  // vertical-only graph row after every commit so the eye reads
+  // consecutive commits with comfortable rhythm rather than a stack.
+  describe('fullGraphSpacing', () => {
+    const linearRows: GitLogRow[] = Array.from({ length: 4 }, (_, i) => ({
+      type: 'commit',
+      graph: '* ',
+      shortHash: `hash${i}`,
+      hash: `hash${i}`.padEnd(40, '0'),
+      parents: [],
+      date: '2026-04-30',
+      author: 'Coco',
+      refs: [],
+      message: `commit ${i}`,
+    }))
+
+    it('injects a vertical-only graph row after every commit in full mode', () => {
+      const state = applyLogInkAction(createLogInkState(linearRows), { type: 'toggleGraph' })
+      const visible = getVisibleLogInkHistory(state, 8, { fullGraphSpacing: true })
+
+      expect(visible.items.map((item) => item.type)).toEqual([
+        'commit', 'graph', 'commit', 'graph', 'commit', 'graph', 'commit', 'graph',
+      ])
+      // The spacers carry vertical lane markers (rendered as the
+      // box-drawing `│`), not the commit dot.
+      expect(visible.items[1].graph).toBe('| ')
+      expect(visible.items[1].laneSegments?.find((s) => s.text === '│')).toBeDefined()
+    })
+
+    it('does not inject spacers when fullGraphSpacing is off', () => {
+      const state = applyLogInkAction(createLogInkState(linearRows), { type: 'toggleGraph' })
+      const visible = getVisibleLogInkHistory(state, 8)
+
+      expect(visible.items.every((item) => item.type === 'commit')).toBe(true)
+    })
+
+    it('does not inject spacers in compact mode regardless of option', () => {
+      const state = createLogInkState(linearRows)
+      const visible = getVisibleLogInkHistory(state, 8, { fullGraphSpacing: true })
+
+      expect(visible.items.every((item) => item.type === 'commit')).toBe(true)
+    })
+
+    it('preserves trunk lane id 0 across spacers when scrolling', () => {
+      const state = applyLogInkAction(createLogInkState(linearRows), { type: 'toggleGraph' })
+      const scrolled = applyLogInkAction(state, { type: 'move', delta: 2 })
+      const visible = getVisibleLogInkHistory(scrolled, 4, { fullGraphSpacing: true })
+
+      // Every commit and every spacer should still place the trunk
+      // glyph / lane bar on lane 0 — the fast-forward prefix has to
+      // include the synthetic spacers so the tracker stays in sync.
+      visible.items.forEach((item) => {
+        const trunkSegment = item.laneSegments?.find(
+          (seg) => seg.text === '●' || seg.text === '◉' || seg.text === '◆' || seg.text === '│'
+        )
+        expect(trunkSegment?.laneId).toBe(0)
+      })
+    })
+  })
 })

--- a/src/workstation/chrome/historyRows.ts
+++ b/src/workstation/chrome/historyRows.ts
@@ -91,24 +91,89 @@ function isSelectedCommit(row: GitLogRow, selected: GitLogCommitRow | undefined)
   return row.type === 'commit' && selected ? commitKey(row) === commitKey(selected) : false
 }
 
-function toFullGraphItems(state: LogInkState, visibleCount: number): LogInkHistoryItem[] {
+/**
+ * Build the vertical-only graph string that follows a commit row when
+ * `withSpacers` is enabled. Every commit-cell glyph (`*`) is rewritten
+ * to a lane bar (`|`) so the synthetic row continues every open lane
+ * without re-rendering the commit dot. All other graph chars pass
+ * through unchanged, so a commit graph like `* | |` becomes `| | |`.
+ */
+function buildSpacerGraph(commitGraph: string): string {
+  return commitGraph.replace(/\*/g, '|')
+}
+
+type ExpandedRow =
+  | { kind: 'source'; row: GitLogRow }
+  | { kind: 'spacer'; sourceCommit: GitLogCommitRow }
+
+/**
+ * Walk `state.rows` and inject a synthetic spacer entry after every
+ * commit row when `withSpacers` is true. The spacer is a graph-only
+ * row that renders as `|` per active lane so consecutive commits have
+ * a clear vertical rhythm without losing topology continuity.
+ *
+ * When `withSpacers` is false the list is identity-mapped from
+ * source rows, preserving the legacy zero-padding behavior for any
+ * caller that wants raw git topology (filters, tests, etc.).
+ */
+function expandRowsWithSpacers(rows: GitLogRow[], withSpacers: boolean): ExpandedRow[] {
+  const out: ExpandedRow[] = []
+  for (const row of rows) {
+    out.push({ kind: 'source', row })
+    if (withSpacers && row.type === 'commit') {
+      out.push({ kind: 'spacer', sourceCommit: row })
+    }
+  }
+  return out
+}
+
+function toFullGraphItems(
+  state: LogInkState,
+  visibleCount: number,
+  options: { withSpacers: boolean } = { withSpacers: false }
+): LogInkHistoryItem[] {
   const selected = state.filteredCommits[state.selectedIndex]
-  const selectedRowIndex = state.rows.findIndex((row) => isSelectedCommit(row, selected))
+  const expanded = expandRowsWithSpacers(state.rows, options.withSpacers)
+  const selectedExpandedIndex = expanded.findIndex(
+    (entry) => entry.kind === 'source' && isSelectedCommit(entry.row, selected)
+  )
   const start = clampWindowStart(
-    selectedRowIndex >= 0 ? selectedRowIndex : 0,
-    state.rows.length,
+    selectedExpandedIndex >= 0 ? selectedExpandedIndex : 0,
+    expanded.length,
     visibleCount
   )
 
   // Lane tracking is order-dependent — fast-forward the tracker through
   // every row above the visible window so lane ids stay stable as the
   // user scrolls. Without this, scrolling would re-color lanes from a
-  // fresh tracker each time.
+  // fresh tracker each time. Spacers contribute their vertical-only
+  // graph to the prefix so the tracker sees a no-op advance and lane
+  // state stays consistent at the window boundary.
   const tracker = createLaneTrackerState()
-  const allGraphs = state.rows.map((row) => (row.type === 'commit' ? row.graph || '*' : row.graph))
-  advanceTrackerThrough(allGraphs, tracker, start)
+  const prefixGraphs: string[] = []
+  for (let k = 0; k < start; k += 1) {
+    const entry = expanded[k]
+    if (entry.kind === 'spacer') {
+      prefixGraphs.push(buildSpacerGraph(entry.sourceCommit.graph || '*'))
+      continue
+    }
+    prefixGraphs.push(
+      entry.row.type === 'commit' ? entry.row.graph || '*' : entry.row.graph
+    )
+  }
+  advanceTrackerThrough(prefixGraphs, tracker, prefixGraphs.length)
 
-  return state.rows.slice(start, start + visibleCount).map((row) => {
+  return expanded.slice(start, start + visibleCount).map((entry) => {
+    if (entry.kind === 'spacer') {
+      const graph = buildSpacerGraph(entry.sourceCommit.graph || '*')
+      return {
+        type: 'graph',
+        graph,
+        laneSegments: renderGraphRowSegments(graph, tracker, { ascii: false }),
+      }
+    }
+
+    const { row } = entry
     if (row.type === 'graph') {
       return {
         type: 'graph',
@@ -129,12 +194,24 @@ function toFullGraphItems(state: LogInkState, visibleCount: number): LogInkHisto
   })
 }
 
+export type GetVisibleLogInkHistoryOptions = {
+  /**
+   * When true and we're in full-graph mode, inject a vertical-only
+   * graph row after every commit row so consecutive commits have a
+   * comfortable vertical rhythm. Off by default to keep tests and
+   * non-rendering callers (filters, snapshots) on the legacy zero
+   * padding.
+   */
+  fullGraphSpacing?: boolean
+}
+
 export function getVisibleLogInkHistory(
   state: LogInkState,
-  visibleCount: number
+  visibleCount: number,
+  options: GetVisibleLogInkHistoryOptions = {}
 ): VisibleLogInkHistory {
   const items = state.fullGraph && !state.filter
-    ? toFullGraphItems(state, visibleCount)
+    ? toFullGraphItems(state, visibleCount, { withSpacers: Boolean(options.fullGraphSpacing) })
     : toCompactItems(state, visibleCount)
 
   return {

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -16,6 +16,7 @@
  */
 
 import type * as ReactTypes from 'react'
+import { getBranchTipChip } from '../../chrome/branchTip'
 import { formatCompactRelativeDate } from '../../chrome/dateFormat'
 import { substituteGraphChars } from '../../chrome/graphChars'
 import type { LaneSegment } from '../../chrome/graphLanes'
@@ -41,15 +42,58 @@ import { focusBorderColor, panelTitle } from '../../runtime/utils'
 
 /**
  * How the date column should render for a given density tier:
- *   - wide   → absolute `YYYY-MM-DD` (current behavior)
+ *   - wide   → absolute `YYYY-MM-DD`
  *   - normal → compact relative form (`2d`, `3w`, `2mo`)
  *   - tight  → hidden entirely (column dropped)
  *   - rail   → caller picks `rowMode='stacked'`; this fn isn't consulted
+ *
+ * Compact mode (the user toggling away from the full graph) forces
+ * the tight behavior regardless of density. Compact is the "scan
+ * mode" — the date is the first thing the user is willing to drop in
+ * exchange for more visible commits per screen.
  */
-function pickDateText(commit: GitLogCommitRow, density: LogInkLayoutDensity, now: Date): string {
+function pickDateText(
+  commit: GitLogCommitRow,
+  density: LogInkLayoutDensity,
+  fullGraph: boolean,
+  now: Date
+): string {
+  if (!fullGraph) return ''
   if (density === 'wide') return commit.date
   if (density === 'normal') return formatCompactRelativeDate(commit.date, now)
   return ''
+}
+
+/**
+ * Render a colored bracket chip for a branch tip. Current branch
+ * (HEAD -> X) gets the success color + bold; other branch tips get
+ * info color. Tags are never chipped — they stay in the trailing ref
+ * list. The chip emits its own trailing space so callers concatenate
+ * it directly into the row without a separator.
+ *
+ * Returns `[chip, width]` so the row's truncation math knows how many
+ * cells the chip will consume up front.
+ */
+function renderBranchTipChip(
+  h: typeof ReactTypes.createElement,
+  Text: LogInkComponents['Text'],
+  commit: GitLogCommitRow,
+  theme: LogInkTheme,
+  key: string
+): { node: ReactTypes.ReactElement | null; width: number } {
+  const chip = getBranchTipChip(commit.refs)
+  if (!chip) return { node: null, width: 0 }
+
+  const label = `[${chip.name}] `
+  const color = theme.noColor
+    ? undefined
+    : chip.isHead
+      ? theme.colors.success
+      : theme.colors.info
+  return {
+    node: h(Text, { key, color, bold: chip.isHead }, label),
+    width: label.length,
+  }
 }
 
 function formatHistoryFetchArgs(args: LogInkHistoryFetchArgs): string {
@@ -127,6 +171,7 @@ function renderCommitHistoryRow(
   index: number,
   panelWidth: number,
   density: LogInkLayoutDensity,
+  fullGraph: boolean,
   now: Date,
   laneSegments?: LaneSegment[],
   isRecent: boolean = false
@@ -139,9 +184,17 @@ function renderCommitHistoryRow(
   // continuation rather than its own commit (#830). Subtracting 4
   // accounts for the panel's left + right border + 1-cell padding.
   const totalWidth = Math.max(20, panelWidth - 4)
-  const dateText = pickDateText(commit, density, now)
+  const dateText = pickDateText(commit, density, fullGraph, now)
   const dateSegmentWidth = dateText ? dateText.length + 1 : 0
-  const fixedWidth = graphWidth + 1 + commit.shortHash.length + 1 + dateSegmentWidth
+  // Branch chip prefix — only renders in full-graph mode so compact
+  // (scan) mode stays minimal. Chip occupies cells immediately after
+  // the shortHash and before the message; truncation math reserves
+  // its width before sizing the message column.
+  const chip = fullGraph
+    ? renderBranchTipChip(h, Text, commit, theme, `${commit.hash}-${index}-chip`)
+    : { node: null, width: 0 }
+  const fixedWidth =
+    graphWidth + 1 + commit.shortHash.length + 1 + dateSegmentWidth + chip.width
   // Refs trail the message and shrink first when the row is narrow:
   // the user can always see the full ref list in the inspector, so
   // the headline subject keeps priority over decoration.
@@ -193,6 +246,9 @@ function renderCommitHistoryRow(
   dateText
     ? h(Text, { key: `${commit.hash}-${index}-date`, dimColor: true }, dateText, ' ')
     : null,
+  // Branch chip prefix (full-graph mode only) lands right before the
+  // message so the eye reads "branch · subject" as a unit.
+  chip.node,
   h(Text, undefined, message),
   refsTrunc ? h(Text, { color: accent }, refsTrunc) : null)
 }
@@ -219,6 +275,7 @@ function renderStackedCommitHistoryRow(
   theme: LogInkTheme,
   index: number,
   panelWidth: number,
+  fullGraph: boolean,
   now: Date,
   laneSegments?: LaneSegment[],
   isRecent: boolean = false
@@ -230,9 +287,14 @@ function renderStackedCommitHistoryRow(
 
   // Line 1 — subject row. Mostly mirrors the single-line layout but
   // skips the date and refs so the message has the whole tail to
-  // itself.
+  // itself. Branch chip rides between the hash and the subject the
+  // same way as the single-line variant, but only in full-graph mode.
   const recentMarkerWidth = isRecent ? 2 : 0
-  const lineOneFixed = graphWidth + 1 + commit.shortHash.length + 1 + recentMarkerWidth
+  const chip = fullGraph
+    ? renderBranchTipChip(h, Text, commit, theme, `${commit.hash}-${index}-stk-chip`)
+    : { node: null, width: 0 }
+  const lineOneFixed =
+    graphWidth + 1 + commit.shortHash.length + 1 + recentMarkerWidth + chip.width
   const subject = truncateCells(commit.message, Math.max(8, totalWidth - lineOneFixed))
 
   const graphChildren = laneSegments && !theme.ascii
@@ -252,6 +314,7 @@ function renderStackedCommitHistoryRow(
     : null,
   h(Text, { color: accent, bold: selected || isRecent }, commit.shortHash),
   ' ',
+  chip.node,
   h(Text, undefined, subject))
 
   // Line 2 — metadata row, padded to align with the start of the
@@ -353,11 +416,16 @@ export function renderHistoryPanel(
     state.selectedIndex === 0
   // Stacked rows take two terminal lines each, so the visible item
   // budget is halved before the pending-row / chrome subtraction.
+  // Full-graph mode injects a spacer row after every commit for
+  // comfortable rhythm — the data-layer items still count 1 per row,
+  // so the listRows budget passes straight through; the spacer rows
+  // just consume some of that budget instead of additional commits.
+  const fullGraphSpacing = state.fullGraph && !state.filter
   const chromeRows = showPendingRow ? 5 : 4
   const listRows = rowMode === 'stacked'
     ? Math.max(2, Math.floor((bodyRows - chromeRows) / 2))
     : Math.max(3, bodyRows - chromeRows)
-  const visible = getVisibleLogInkHistory(state, listRows)
+  const visible = getVisibleLogInkHistory(state, listRows, { fullGraphSpacing })
   const loadState = loadingMoreCommits
     ? 'loading older commits'
     : hasMoreCommits
@@ -430,14 +498,14 @@ export function renderHistoryPanel(
         return renderStackedCommitHistoryRow(
           h, Text, Box, item.commit, item.graph, visible.graphWidth,
           Boolean(item.selected) && !realSelectionSuppressed, theme, index,
-          width, now, item.laneSegments,
+          width, state.fullGraph, now, item.laneSegments,
           recentCommitsSet.has(item.commit.hash)
         )
       }
       return renderCommitHistoryRow(
         h, Text, item.commit, item.graph, visible.graphWidth,
         Boolean(item.selected) && !realSelectionSuppressed, theme, index,
-        width, density, now, item.laneSegments,
+        width, density, state.fullGraph, now, item.laneSegments,
         recentCommitsSet.has(item.commit.hash)
       )
     }))


### PR DESCRIPTION
## Summary

Leans into coco's existing **full graph** / **compact graph** split (the `g` toggle): full mode becomes the readability view, compact becomes the scan view. Three changes bundled:

### 1. Vertical rhythm in full mode

After every commit row, the data layer now injects a vertical-only graph row (a `|` per active lane). Consecutive commits read like:

```
●  64e1757 [main] feat: do thing
│
●  817dc35 chore: bump deps
│
●  2618207 docs: update README
```

instead of the previous tight stack. Topology continuity is preserved — the lane tracker fast-forwards through synthetic spacers in the prefix so trunk colors stay stable as the user scrolls.

### 2. Branch tip chips

Commits at the tip of a branch get a colored bracket chip before the subject. Selection priority:

1. `HEAD -> X` — current branch, **bold + success color**
2. First plain local branch — info color
3. First remote-tracking branch (fallback) — info color

Tags are deliberately excluded from chip selection so the chip column is branch-only and the eye learns "leading chip = branch tip." Tags still trail the row in the existing ref list.

### 3. Compact mode stays minimal

Compact mode now always drops the date column regardless of terminal width — it's the "scan many commits fast" mode, so even on a 200-cell terminal you no longer pay for a YYYY-MM-DD column there. Full mode keeps the density-tier behavior from #961 (`wide` → absolute, `normal` → relative, etc.).

## Files changed

- `chrome/branchTip.ts` (new) — `getBranchTipChip(refs)` extraction with priority order. Full unit test coverage.
- `chrome/historyRows.ts` — new `expandRowsWithSpacers` + `buildSpacerGraph` helpers; `getVisibleLogInkHistory` accepts a `fullGraphSpacing` option that's off by default (preserves existing test callers).
- `surfaces/history/index.ts` — `renderBranchTipChip` helper; `pickDateText` now compact-aware; both row renderers (`renderCommitHistoryRow`, `renderStackedCommitHistoryRow`) accept `fullGraph` and render the chip inline before the subject; `renderHistoryPanel` opts into `fullGraphSpacing` when `state.fullGraph && !state.filter`.

## Test plan

- [x] `chrome/branchTip.test.ts` — 8 new tests covering HEAD priority, plain branches, remote fallback, tag exclusion, detached HEAD, empty refs.
- [x] `chrome/historyRows.test.ts` — 4 new tests covering spacer injection, off-by-default behavior, compact-mode skip, lane stability across spacers during scroll.
- [x] Full jest suite: 1694 pass / 7 skipped, no regressions.
- [x] `npm run lint` clean.
- [x] `npm run build` produces dist bundles.
- [x] `npm run test:cli` smoke tests pass.
- [ ] **Manual UI verification** — I do not have access to a live terminal in this sandbox, so I have NOT visually confirmed the rendered output. Reviewer should toggle between full graph (`g`) and compact in a repo with several branch tips and scroll through to verify the chips, spacers, and selection styling look right.

## Notes for the reviewer

- The spacer rows are produced by the existing graph-row render path, so they inherit lane colors, dimming, and forceDim-on-graph-only behavior automatically.
- I considered an in-renderer spacer (insert a blank `<Text>` between commit nodes) instead of the data-layer approach but went with data-layer so the lane tracker stays the source of truth for what each row should render.
- `messageRoom` truncation now subtracts the chip width up front so a chip on a narrow terminal trims the subject rather than overflowing the row.
- This deliberately does NOT touch `graphChars.ts` — the curved-corner substitution there is already quite refined and I didn't want to risk regressions in the bundle. If we want to push further on lane glyphs later, that's its own focused change.