### PR TITLE
feat(cli): coco issues / coco prs — read-only GitHub triage commands (#882 phase 1)

### DIFF
--- a/src/commands/issues/config.ts
+++ b/src/commands/issues/config.ts
@@ -1,0 +1,63 @@
+import { Arguments, Argv, Options } from 'yargs'
+import { getCommandUsageHeader } from '../../lib/ui/helpers'
+import { BaseCommandOptions } from '../types'
+
+export interface IssuesOptions extends BaseCommandOptions {
+  state?: 'open' | 'closed' | 'all'
+  assignee?: string
+  author?: string
+  label?: string
+  search?: string
+  /** Convenience flag → `--assignee @me`. */
+  mine?: boolean
+  limit?: number
+  /** Print machine-readable JSON instead of the formatted table. */
+  json?: boolean
+}
+
+export type IssuesArgv = Arguments<IssuesOptions>
+
+export const command = 'issues'
+
+export const options = {
+  state: {
+    type: 'string',
+    choices: ['open', 'closed', 'all'] as const,
+    description: 'Filter by issue state.',
+    default: 'open',
+  },
+  assignee: {
+    type: 'string',
+    description: 'Filter by assignee GitHub login (or `@me`).',
+  },
+  author: {
+    type: 'string',
+    description: 'Filter by author GitHub login.',
+  },
+  label: {
+    type: 'string',
+    description: 'Filter by label name (comma-separated for AND).',
+  },
+  search: {
+    type: 'string',
+    description: 'Free-form GitHub issue search query.',
+  },
+  mine: {
+    type: 'boolean',
+    description: 'Shorthand for `--assignee @me`.',
+    default: false,
+  },
+  limit: {
+    type: 'number',
+    description: 'Maximum rows to fetch. Defaults to `gh`\'s own default.',
+  },
+  json: {
+    type: 'boolean',
+    description: 'Print machine-readable JSON instead of a formatted table.',
+    default: false,
+  },
+} as Record<string, Options>
+
+export const builder = (yargs: Argv) => {
+  return yargs.options(options).usage(getCommandUsageHeader(command))
+}

--- a/src/commands/issues/handler.ts
+++ b/src/commands/issues/handler.ts
@@ -1,0 +1,66 @@
+import chalk from 'chalk'
+import { CommandHandler } from '../../lib/types'
+import { commandExit } from '../../lib/utils/commandExit'
+import { formatIssueList } from '../../git/githubListFormatting'
+import { getIssueList, type IssueListFilter } from '../../git/issuesListData'
+import { applyRepoFlag } from '../utils/applyRepoFlag'
+import { IssuesArgv } from './config'
+
+export const handler: CommandHandler<IssuesArgv> = async (argv, logger) => {
+  const git = applyRepoFlag(argv)
+
+  const filter: IssueListFilter = {
+    state: argv.state,
+    assignee: argv.mine ? '@me' : argv.assignee,
+    author: argv.author,
+    label: argv.label,
+    search: argv.search,
+    limit: argv.limit,
+  }
+
+  const overview = await getIssueList(git, filter)
+
+  if (!overview.available) {
+    logger.log(chalk.red(overview.message || 'No GitHub remote detected.'))
+    commandExit(1)
+    return
+  }
+
+  if (!overview.authenticated) {
+    logger.log(chalk.yellow(overview.message || 'GitHub CLI is missing or not authenticated.'))
+    logger.log(chalk.dim('Install `gh` and run `gh auth login` to enable issue triage.'))
+    commandExit(1)
+    return
+  }
+
+  if (overview.message) {
+    logger.log(chalk.red(overview.message))
+    commandExit(1)
+    return
+  }
+
+  const issues = overview.issues || []
+
+  if (argv.json) {
+    logger.log(JSON.stringify(issues, null, 2))
+    return
+  }
+
+  if (overview.repository) {
+    const filterParts: string[] = []
+    if (filter.state && filter.state !== 'open') filterParts.push(`state=${filter.state}`)
+    if (filter.assignee) filterParts.push(`assignee=${filter.assignee}`)
+    if (filter.author) filterParts.push(`author=${filter.author}`)
+    if (filter.label) filterParts.push(`label=${filter.label}`)
+    if (filter.search) filterParts.push(`search=${JSON.stringify(filter.search)}`)
+    const suffix = filterParts.length ? chalk.dim(` (${filterParts.join(', ')})`) : ''
+    logger.log(
+      chalk.bold(`${overview.repository.owner}/${overview.repository.name}`) +
+      chalk.dim(` · ${issues.length} issue${issues.length === 1 ? '' : 's'}`) +
+      suffix
+    )
+    logger.log('')
+  }
+
+  logger.log(formatIssueList(issues))
+}

--- a/src/commands/issues/index.ts
+++ b/src/commands/issues/index.ts
@@ -1,0 +1,10 @@
+import commandExecutor from '../../lib/utils/commandExecutor'
+import { builder, command } from './config'
+import { handler } from './handler'
+
+export default {
+  command,
+  desc: 'List GitHub issues for the current repository (read-only triage)',
+  builder,
+  handler: commandExecutor(handler),
+}

--- a/src/commands/prs/config.ts
+++ b/src/commands/prs/config.ts
@@ -1,0 +1,79 @@
+import { Arguments, Argv, Options } from 'yargs'
+import { getCommandUsageHeader } from '../../lib/ui/helpers'
+import { BaseCommandOptions } from '../types'
+
+export interface PrsOptions extends BaseCommandOptions {
+  state?: 'open' | 'closed' | 'merged' | 'all'
+  assignee?: string
+  author?: string
+  label?: string
+  search?: string
+  base?: string
+  head?: string
+  draft?: boolean
+  /** Convenience flag → `--assignee @me`. */
+  mine?: boolean
+  limit?: number
+  /** Print machine-readable JSON instead of the formatted table. */
+  json?: boolean
+}
+
+export type PrsArgv = Arguments<PrsOptions>
+
+export const command = 'prs'
+
+export const options = {
+  state: {
+    type: 'string',
+    choices: ['open', 'closed', 'merged', 'all'] as const,
+    description: 'Filter by PR state.',
+    default: 'open',
+  },
+  assignee: {
+    type: 'string',
+    description: 'Filter by assignee GitHub login (or `@me`).',
+  },
+  author: {
+    type: 'string',
+    description: 'Filter by author GitHub login.',
+  },
+  label: {
+    type: 'string',
+    description: 'Filter by label name (comma-separated for AND).',
+  },
+  search: {
+    type: 'string',
+    description: 'Free-form GitHub PR search query.',
+  },
+  base: {
+    type: 'string',
+    description: 'Filter to PRs targeting a specific base branch.',
+  },
+  head: {
+    type: 'string',
+    description: 'Filter to PRs originating from a specific head branch.',
+  },
+  draft: {
+    type: 'boolean',
+    description: 'Limit to draft PRs only.',
+    default: false,
+  },
+  mine: {
+    type: 'boolean',
+    description: 'Shorthand for `--assignee @me`.',
+    default: false,
+  },
+  limit: {
+    type: 'number',
+    description: 'Maximum rows to fetch. Defaults to `gh`\'s own default.',
+  },
+  json: {
+    type: 'boolean',
+    description: 'Print machine-readable JSON instead of a formatted table.',
+    default: false,
+  },
+} as Record<string, Options>
+
+export const builder = (yargs: Argv) => {
+  return yargs.options(options).usage(getCommandUsageHeader(command))
+}

--- a/src/commands/prs/handler.ts
+++ b/src/commands/prs/handler.ts
@@ -1,0 +1,75 @@
+import chalk from 'chalk'
+import { CommandHandler } from '../../lib/types'
+import { commandExit } from '../../lib/utils/commandExit'
+import { formatPullRequestList } from '../../git/githubListFormatting'
+import {
+  getPullRequestList,
+  type PullRequestListFilter,
+} from '../../git/pullRequestListData'
+import { applyRepoFlag } from '../utils/applyRepoFlag'
+import { PrsArgv } from './config'
+
+export const handler: CommandHandler<PrsArgv> = async (argv, logger) => {
+  const git = applyRepoFlag(argv)
+
+  const filter: PullRequestListFilter = {
+    state: argv.state,
+    assignee: argv.mine ? '@me' : argv.assignee,
+    author: argv.author,
+    label: argv.label,
+    search: argv.search,
+    base: argv.base,
+    head: argv.head,
+    draft: argv.draft,
+    limit: argv.limit,
+  }
+
+  const overview = await getPullRequestList(git, filter)
+
+  if (!overview.available) {
+    logger.log(chalk.red(overview.message || 'No GitHub remote detected.'))
+    commandExit(1)
+    return
+  }
+
+  if (!overview.authenticated) {
+    logger.log(chalk.yellow(overview.message || 'GitHub CLI is missing or not authenticated.'))
+    logger.log(chalk.dim('Install `gh` and run `gh auth login` to enable PR triage.'))
+    commandExit(1)
+    return
+  }
+
+  if (overview.message) {
+    logger.log(chalk.red(overview.message))
+    commandExit(1)
+    return
+  }
+
+  const prs = overview.pullRequests || []
+
+  if (argv.json) {
+    logger.log(JSON.stringify(prs, null, 2))
+    return
+  }
+
+  if (overview.repository) {
+    const filterParts: string[] = []
+    if (filter.state && filter.state !== 'open') filterParts.push(`state=${filter.state}`)
+    if (filter.assignee) filterParts.push(`assignee=${filter.assignee}`)
+    if (filter.author) filterParts.push(`author=${filter.author}`)
+    if (filter.label) filterParts.push(`label=${filter.label}`)
+    if (filter.search) filterParts.push(`search=${JSON.stringify(filter.search)}`)
+    if (filter.base) filterParts.push(`base=${filter.base}`)
+    if (filter.head) filterParts.push(`head=${filter.head}`)
+    if (filter.draft) filterParts.push('draft')
+    const suffix = filterParts.length ? chalk.dim(` (${filterParts.join(', ')})`) : ''
+    logger.log(
+      chalk.bold(`${overview.repository.owner}/${overview.repository.name}`) +
+      chalk.dim(` · ${prs.length} pull request${prs.length === 1 ? '' : 's'}`) +
+      suffix
+    )
+    logger.log('')
+  }
+
+  logger.log(formatPullRequestList(prs))
+}

--- a/src/commands/prs/index.ts
+++ b/src/commands/prs/index.ts
@@ -1,0 +1,10 @@
+import commandExecutor from '../../lib/utils/commandExecutor'
+import { builder, command } from './config'
+import { handler } from './handler'
+
+export default {
+  command,
+  desc: 'List GitHub pull requests for the current repository (read-only triage)',
+  builder,
+  handler: commandExecutor(handler),
+}

--- a/src/git/githubCli.test.ts
+++ b/src/git/githubCli.test.ts
@@ -1,0 +1,84 @@
+import {
+  isGhAuthenticated,
+  parseGitHubRemoteUrl,
+  getGitHubRepository,
+} from './githubCli'
+
+describe('githubCli', () => {
+  describe('parseGitHubRemoteUrl', () => {
+    it('parses SSH remotes', () => {
+      expect(parseGitHubRemoteUrl('git@github.com:gfargo/coco.git')).toEqual({
+        owner: 'gfargo',
+        name: 'coco',
+      })
+    })
+
+    it('parses HTTPS remotes', () => {
+      expect(parseGitHubRemoteUrl('https://github.com/gfargo/coco.git')).toEqual({
+        owner: 'gfargo',
+        name: 'coco',
+      })
+    })
+
+    it('drops the .git suffix and trailing whitespace', () => {
+      expect(parseGitHubRemoteUrl('  https://github.com/gfargo/coco  ')).toEqual({
+        owner: 'gfargo',
+        name: 'coco',
+      })
+    })
+
+    it('returns undefined for non-GitHub remotes', () => {
+      expect(parseGitHubRemoteUrl('git@gitlab.com:gfargo/coco.git')).toBeUndefined()
+      expect(parseGitHubRemoteUrl('https://bitbucket.org/gfargo/coco.git')).toBeUndefined()
+    })
+
+    it('returns undefined for empty input', () => {
+      expect(parseGitHubRemoteUrl('')).toBeUndefined()
+    })
+  })
+
+  describe('isGhAuthenticated', () => {
+    it('returns true when `gh auth status` succeeds', async () => {
+      const runner = jest.fn().mockResolvedValue('')
+      await expect(isGhAuthenticated(runner)).resolves.toBe(true)
+      expect(runner).toHaveBeenCalledWith(['auth', 'status', '--hostname', 'github.com'])
+    })
+
+    it('returns false when `gh auth status` throws', async () => {
+      const runner = jest.fn().mockRejectedValue(new Error('not installed'))
+      await expect(isGhAuthenticated(runner)).resolves.toBe(false)
+    })
+  })
+
+  describe('getGitHubRepository', () => {
+    it('picks the origin remote when present', async () => {
+      const git = {
+        getRemotes: jest.fn().mockResolvedValue([
+          { name: 'upstream', refs: { fetch: 'git@github.com:other/repo.git', push: '' } },
+          { name: 'origin', refs: { fetch: 'git@github.com:gfargo/coco.git', push: '' } },
+        ]),
+      }
+      await expect(getGitHubRepository(git as never)).resolves.toEqual({
+        owner: 'gfargo',
+        name: 'coco',
+      })
+    })
+
+    it('falls back to the first remote when origin is missing', async () => {
+      const git = {
+        getRemotes: jest.fn().mockResolvedValue([
+          { name: 'upstream', refs: { fetch: 'git@github.com:other/repo.git', push: '' } },
+        ]),
+      }
+      await expect(getGitHubRepository(git as never)).resolves.toEqual({
+        owner: 'other',
+        name: 'repo',
+      })
+    })
+
+    it('returns undefined when no remotes exist', async () => {
+      const git = { getRemotes: jest.fn().mockResolvedValue([]) }
+      await expect(getGitHubRepository(git as never)).resolves.toBeUndefined()
+    })
+  })
+})

--- a/src/git/githubCli.ts
+++ b/src/git/githubCli.ts
@@ -1,0 +1,59 @@
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { SimpleGit } from 'simple-git'
+
+const execFileAsync = promisify(execFile)
+
+export type GhRunner = (args: string[]) => Promise<string>
+
+export type GitHubRepository = {
+  owner: string
+  name: string
+}
+
+export function parseGitHubRemoteUrl(url: string): GitHubRepository | undefined {
+  const trimmed = url.trim().replace(/\.git$/, '')
+  const sshMatch = trimmed.match(/^git@github\.com:([^/]+)\/(.+)$/)
+  const httpsMatch = trimmed.match(/^https:\/\/github\.com\/([^/]+)\/(.+)$/)
+  const match = sshMatch || httpsMatch
+
+  if (!match) {
+    return undefined
+  }
+
+  return {
+    owner: match[1],
+    name: match[2],
+  }
+}
+
+export async function defaultGhRunner(args: string[]): Promise<string> {
+  const result = await execFileAsync('gh', args)
+  return result.stdout
+}
+
+export async function getGitHubRepository(
+  git: SimpleGit
+): Promise<GitHubRepository | undefined> {
+  const remotes = await git.getRemotes(true)
+  const remote = remotes.find((entry) => entry.name === 'origin') || remotes[0]
+  const url = remote?.refs.push || remote?.refs.fetch
+
+  return url ? parseGitHubRemoteUrl(url) : undefined
+}
+
+/**
+ * Probe `gh auth status` and return whether the GitHub CLI is
+ * installed AND authenticated. Used by every data fetcher to short-
+ * circuit before issuing real API calls — keeps the failure-mode
+ * messaging consistent ("CLI missing or not authenticated") instead
+ * of leaking through as a generic spawn error.
+ */
+export async function isGhAuthenticated(runner: GhRunner): Promise<boolean> {
+  try {
+    await runner(['auth', 'status', '--hostname', 'github.com'])
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/git/githubListFormatting.test.ts
+++ b/src/git/githubListFormatting.test.ts
@@ -1,0 +1,112 @@
+import chalk from 'chalk'
+import { formatIssueList, formatPullRequestList } from './githubListFormatting'
+import type { IssueListItem } from './issuesListData'
+import type { PullRequestListItem } from './pullRequestListData'
+
+// Strip ANSI escapes for shape assertions — color is rendered via chalk
+// and we only want to assert on the visible content.
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\[[0-9;]*m/g
+const strip = (s: string) => s.replace(ANSI_RE, '')
+
+describe('formatIssueList', () => {
+  const baseIssue = (overrides: Partial<IssueListItem> = {}): IssueListItem => ({
+    number: 882,
+    title: 'TUI shell · issue / PR triage workflow',
+    url: 'https://github.com/gfargo/coco/issues/882',
+    state: 'OPEN',
+    author: 'gfargo',
+    assignees: [],
+    labels: ['enhancement'],
+    comments: 0,
+    createdAt: '2026-04-01T00:00:00Z',
+    updatedAt: '2026-05-01T00:00:00Z',
+    ...overrides,
+  })
+
+  it('renders empty-state copy when there are no issues', () => {
+    expect(strip(formatIssueList([]))).toBe('No issues match the current filter.')
+  })
+
+  it('renders one row per issue with number, state, author, and title', () => {
+    const output = strip(formatIssueList([baseIssue()]))
+    expect(output).toContain('#882')
+    expect(output).toContain('open')
+    expect(output).toContain('gfargo')
+    expect(output).toContain('TUI shell · issue / PR triage workflow')
+    expect(output).toContain('[enhancement]')
+  })
+
+  it('shows a comment count when greater than zero', () => {
+    const output = strip(formatIssueList([baseIssue({ comments: 5 })]))
+    expect(output).toContain('5c')
+  })
+
+  it('omits comment count when zero or missing', () => {
+    const output = strip(formatIssueList([baseIssue({ comments: 0 })]))
+    expect(output).not.toMatch(/\d+c/)
+  })
+
+  it('color-codes state', () => {
+    const openRow = formatIssueList([baseIssue({ state: 'OPEN' })])
+    const closedRow = formatIssueList([baseIssue({ state: 'CLOSED' })])
+    expect(openRow).toContain(chalk.green('open'))
+    expect(closedRow).toContain(chalk.red('closed'))
+  })
+})
+
+describe('formatPullRequestList', () => {
+  const basePr = (overrides: Partial<PullRequestListItem> = {}): PullRequestListItem => ({
+    number: 962,
+    title: 'feat(commit-split): dedupe rescues',
+    url: 'https://github.com/gfargo/coco/pull/962',
+    state: 'OPEN',
+    isDraft: false,
+    headRefName: 'feature/x',
+    baseRefName: 'main',
+    author: 'gfargo',
+    assignees: [],
+    labels: [],
+    reviewDecision: undefined,
+    mergeable: undefined,
+    mergeStateStatus: undefined,
+    createdAt: '2026-05-14T00:00:00Z',
+    updatedAt: '2026-05-14T00:00:00Z',
+    ...overrides,
+  })
+
+  it('renders empty-state copy when there are no PRs', () => {
+    expect(strip(formatPullRequestList([]))).toBe('No pull requests match the current filter.')
+  })
+
+  it('renders one row per PR with the core triage fields', () => {
+    const output = strip(formatPullRequestList([basePr()]))
+    expect(output).toContain('#962')
+    expect(output).toContain('open')
+    expect(output).toContain('gfargo')
+    expect(output).toContain('feature/x')
+    expect(output).toContain('feat(commit-split): dedupe rescues')
+  })
+
+  it('shows draft state for draft PRs', () => {
+    const output = strip(formatPullRequestList([basePr({ isDraft: true })]))
+    expect(output).toContain('draft')
+    expect(output).not.toMatch(/\bopen\b/)
+  })
+
+  it('renders the approval glyph for approved PRs', () => {
+    const output = formatPullRequestList([basePr({ reviewDecision: 'APPROVED' })])
+    expect(output).toContain(chalk.green('✓'))
+  })
+
+  it('renders the changes-requested glyph for blocked PRs', () => {
+    const output = formatPullRequestList([basePr({ reviewDecision: 'CHANGES_REQUESTED' })])
+    expect(output).toContain(chalk.red('✗'))
+  })
+
+  it('truncates long head branch names', () => {
+    const longBranch = 'feature/this-is-a-very-long-branch-name-that-should-truncate'
+    const output = strip(formatPullRequestList([basePr({ headRefName: longBranch })]))
+    expect(output).toContain('…')
+  })
+})

--- a/src/git/githubListFormatting.ts
+++ b/src/git/githubListFormatting.ts
@@ -1,0 +1,137 @@
+import chalk from 'chalk'
+import type { IssueListItem } from './issuesListData'
+import type { PullRequestListItem } from './pullRequestListData'
+
+/**
+ * Pad a (possibly already-colored) string to `width` visible columns.
+ * We can't naively `String#padEnd` after coloring because ANSI escape
+ * codes inflate `.length` past the visible width. The pattern here is
+ * "measure the plain string, color last" — every formatter below
+ * computes column widths from raw values and passes the visible
+ * length explicitly so `padToVisible` only needs to add spaces.
+ */
+function padToVisible(colored: string, visibleLength: number, width: number): string {
+  if (visibleLength >= width) return colored
+  return colored + ' '.repeat(width - visibleLength)
+}
+
+const STATE_COLORS: Record<string, (s: string) => string> = {
+  OPEN: chalk.green,
+  CLOSED: chalk.red,
+  MERGED: chalk.magenta,
+}
+
+function colorState(state: string): string {
+  const fn = STATE_COLORS[state.toUpperCase()] || chalk.dim
+  return fn(state.toLowerCase())
+}
+
+function formatLabels(labels: string[] | undefined): string {
+  if (!labels || labels.length === 0) return ''
+  return chalk.dim(labels.map((l) => `[${l}]`).join(' '))
+}
+
+function formatReviewDecision(decision: string | undefined): string {
+  if (!decision) return ' '
+  switch (decision) {
+    case 'APPROVED':
+      return chalk.green('✓')
+    case 'CHANGES_REQUESTED':
+      return chalk.red('✗')
+    case 'REVIEW_REQUIRED':
+      return chalk.yellow('?')
+    default:
+      return chalk.dim(decision.slice(0, 1))
+  }
+}
+
+function formatMergeable(mergeable: string | undefined, mergeStateStatus: string | undefined): string {
+  if (mergeStateStatus === 'CLEAN') return chalk.green('●')
+  if (mergeStateStatus === 'BLOCKED') return chalk.yellow('●')
+  if (mergeStateStatus === 'DIRTY' || mergeable === 'CONFLICTING') return chalk.red('●')
+  if (mergeStateStatus === 'BEHIND') return chalk.cyan('●')
+  if (mergeStateStatus === 'UNSTABLE') return chalk.yellow('●')
+  return chalk.dim('●')
+}
+
+export function formatIssueList(items: IssueListItem[]): string {
+  if (items.length === 0) {
+    return chalk.dim('No issues match the current filter.')
+  }
+
+  const numberWidth = Math.max(...items.map((i) => `#${i.number}`.length))
+  const authorWidth = Math.max(
+    ...items.map((i) => (i.author ? i.author.length : 0)),
+    1
+  )
+  const stateWidth = 6
+
+  return items
+    .map((issue) => {
+      const numRaw = `#${issue.number}`
+      const num = padToVisible(chalk.dim(numRaw), numRaw.length, numberWidth)
+
+      const stateRaw = issue.state.toLowerCase()
+      const state = padToVisible(colorState(issue.state), stateRaw.length, stateWidth)
+
+      const authorRaw = issue.author || ''
+      const author = padToVisible(chalk.cyan(authorRaw), authorRaw.length, authorWidth)
+
+      const comments =
+        typeof issue.comments === 'number' && issue.comments > 0
+          ? chalk.dim(` ${issue.comments}c`)
+          : ''
+      const labels = formatLabels(issue.labels)
+
+      const parts = [num, state, author, issue.title]
+      if (labels) parts.push(labels)
+      return parts.join('  ') + comments
+    })
+    .join('\n')
+}
+
+export function formatPullRequestList(items: PullRequestListItem[]): string {
+  if (items.length === 0) {
+    return chalk.dim('No pull requests match the current filter.')
+  }
+
+  const numberWidth = Math.max(...items.map((i) => `#${i.number}`.length))
+  const authorWidth = Math.max(
+    ...items.map((i) => (i.author ? i.author.length : 0)),
+    1
+  )
+  const headWidth = Math.min(
+    Math.max(...items.map((i) => i.headRefName.length), 1),
+    28
+  )
+  const stateWidth = 6
+
+  return items
+    .map((pr) => {
+      const numRaw = `#${pr.number}`
+      const num = padToVisible(chalk.dim(numRaw), numRaw.length, numberWidth)
+
+      const stateRaw = pr.isDraft ? 'draft' : pr.state.toLowerCase()
+      const stateColored = pr.isDraft ? chalk.dim('draft') : colorState(pr.state)
+      const state = padToVisible(stateColored, stateRaw.length, stateWidth)
+
+      const mergeable = formatMergeable(pr.mergeable, pr.mergeStateStatus)
+      const review = formatReviewDecision(pr.reviewDecision)
+
+      const authorRaw = pr.author || ''
+      const author = padToVisible(chalk.cyan(authorRaw), authorRaw.length, authorWidth)
+
+      const branchTruncated =
+        pr.headRefName.length > headWidth
+          ? pr.headRefName.slice(0, headWidth - 1) + '…'
+          : pr.headRefName
+      const branch = padToVisible(chalk.dim(branchTruncated), branchTruncated.length, headWidth)
+
+      const labels = formatLabels(pr.labels)
+
+      const parts = [num, state, mergeable, review, author, branch, pr.title]
+      if (labels) parts.push(labels)
+      return parts.join('  ')
+    })
+    .join('\n')
+}

--- a/src/git/issuesListData.test.ts
+++ b/src/git/issuesListData.test.ts
@@ -1,0 +1,143 @@
+import { getIssueList, ISSUE_LIST_JSON_FIELDS } from './issuesListData'
+
+describe('issuesListData', () => {
+  const githubRemoteGit = (branch = 'main') =>
+    ({
+      getRemotes: jest.fn().mockResolvedValue([
+        { name: 'origin', refs: { fetch: 'git@github.com:gfargo/coco.git', push: '' } },
+      ]),
+      raw: jest.fn().mockResolvedValue(`${branch}\n`),
+    } as never)
+
+  it('returns unavailable when no GitHub remote exists', async () => {
+    const runner = jest.fn()
+    const git = {
+      getRemotes: jest.fn().mockResolvedValue([]),
+    } as never
+
+    await expect(getIssueList(git, {}, runner)).resolves.toEqual({
+      available: false,
+      authenticated: false,
+      filter: {},
+      message: 'No GitHub remote detected.',
+    })
+    expect(runner).not.toHaveBeenCalled()
+  })
+
+  it('returns unauthenticated when `gh auth status` throws', async () => {
+    const runner = jest.fn().mockRejectedValueOnce(new Error('not installed'))
+    const overview = await getIssueList(githubRemoteGit(), {}, runner)
+    expect(overview.authenticated).toBe(false)
+    expect(overview.repository).toEqual({ owner: 'gfargo', name: 'coco' })
+    expect(overview.message).toMatch(/missing or not authenticated/)
+  })
+
+  it('parses a populated issue list', async () => {
+    const payload = [
+      {
+        number: 882,
+        title: 'TUI shell · issue / PR triage workflow',
+        url: 'https://github.com/gfargo/coco/issues/882',
+        state: 'OPEN',
+        author: { login: 'gfargo' },
+        assignees: [{ login: 'reviewer-a' }],
+        labels: [{ name: 'enhancement' }, { name: 'tui' }],
+        comments: 3,
+        createdAt: '2026-04-01T00:00:00Z',
+        updatedAt: '2026-05-01T00:00:00Z',
+      },
+    ]
+    const runner = jest
+      .fn()
+      .mockResolvedValueOnce('') // auth status
+      .mockResolvedValueOnce(JSON.stringify(payload))
+
+    const overview = await getIssueList(githubRemoteGit(), {}, runner)
+
+    expect(overview.authenticated).toBe(true)
+    expect(overview.issues).toEqual([
+      {
+        number: 882,
+        title: 'TUI shell · issue / PR triage workflow',
+        url: 'https://github.com/gfargo/coco/issues/882',
+        state: 'OPEN',
+        author: 'gfargo',
+        assignees: ['reviewer-a'],
+        labels: ['enhancement', 'tui'],
+        comments: 3,
+        createdAt: '2026-04-01T00:00:00Z',
+        updatedAt: '2026-05-01T00:00:00Z',
+      },
+    ])
+  })
+
+  it('threads filter knobs into the gh args', async () => {
+    const runner = jest
+      .fn()
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('[]')
+
+    await getIssueList(
+      githubRemoteGit(),
+      {
+        state: 'closed',
+        assignee: '@me',
+        label: 'bug,critical',
+        search: 'auth flow',
+        limit: 50,
+      },
+      runner
+    )
+
+    expect(runner).toHaveBeenNthCalledWith(2, [
+      'issue',
+      'list',
+      '--json',
+      ISSUE_LIST_JSON_FIELDS,
+      '--state',
+      'closed',
+      '--assignee',
+      '@me',
+      '--label',
+      'bug,critical',
+      '--search',
+      'auth flow',
+      '--limit',
+      '50',
+    ])
+  })
+
+  it('returns an empty issue list rather than crashing on missing fields', async () => {
+    const runner = jest
+      .fn()
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce(JSON.stringify([{ number: 1, title: 'minimal', url: 'x', state: 'OPEN' }]))
+
+    const overview = await getIssueList(githubRemoteGit(), {}, runner)
+    expect(overview.issues).toEqual([
+      {
+        number: 1,
+        title: 'minimal',
+        url: 'x',
+        state: 'OPEN',
+        author: undefined,
+        assignees: undefined,
+        labels: undefined,
+        comments: undefined,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ])
+  })
+
+  it('surfaces the runner error as the overview message when `gh issue list` fails', async () => {
+    const runner = jest
+      .fn()
+      .mockResolvedValueOnce('')
+      .mockRejectedValueOnce(new Error('rate limited'))
+
+    const overview = await getIssueList(githubRemoteGit(), {}, runner)
+    expect(overview.issues).toBeUndefined()
+    expect(overview.message).toContain('rate limited')
+  })
+})

--- a/src/git/issuesListData.ts
+++ b/src/git/issuesListData.ts
@@ -1,0 +1,169 @@
+import { SimpleGit } from 'simple-git'
+import {
+  defaultGhRunner,
+  getGitHubRepository,
+  isGhAuthenticated,
+  type GhRunner,
+  type GitHubRepository,
+} from './githubCli'
+
+export type IssueState = 'open' | 'closed' | 'all'
+
+export type IssueListItem = {
+  number: number
+  title: string
+  url: string
+  state: string // OPEN | CLOSED
+  author?: string
+  assignees?: string[]
+  labels?: string[]
+  comments?: number
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * Filter knobs passed to `gh issue list`. Each maps 1:1 to a `gh` flag —
+ * keeps the surface small and the mental model "anything `gh issue
+ * list` accepts" so users discovering this CLI don't have to learn a
+ * separate vocabulary.
+ */
+export type IssueListFilter = {
+  state?: IssueState
+  /** GitHub login or the literal "@me". Maps to `--assignee`. */
+  assignee?: string
+  /** Maps to `--author`. */
+  author?: string
+  /** Comma-separated label list. Maps to `--label`. */
+  label?: string
+  /** Maps to `--search`. Free-form GitHub issue search syntax. */
+  search?: string
+  /** Maps to `--limit`. Default 30 (gh's own default). */
+  limit?: number
+}
+
+export type IssueListOverview = {
+  available: boolean
+  authenticated: boolean
+  repository?: GitHubRepository
+  issues?: IssueListItem[]
+  /** Filter that produced the list — echoed back so cache layers can key on it. */
+  filter?: IssueListFilter
+  message?: string
+}
+
+/**
+ * `gh issue list --json` field list. Centralized so any future
+ * re-fetch (refresh, cache invalidation) requests the same shape and
+ * the parser can rely on every field being present (even if optional).
+ */
+export const ISSUE_LIST_JSON_FIELDS = [
+  'number',
+  'title',
+  'url',
+  'state',
+  'author',
+  'assignees',
+  'labels',
+  'comments',
+  'createdAt',
+  'updatedAt',
+].join(',')
+
+function parseIssueListItems(output: string): IssueListItem[] {
+  const trimmed = output.trim()
+  if (!trimmed) return []
+
+  const raw = JSON.parse(trimmed) as Array<Record<string, unknown>>
+
+  return raw.map((entry) => {
+    const author =
+      entry.author && typeof entry.author === 'object' && 'login' in entry.author
+        ? String((entry.author as { login: unknown }).login)
+        : undefined
+
+    const assignees = Array.isArray(entry.assignees)
+      ? (entry.assignees as Array<Record<string, unknown>>)
+        .map((a) => (a && 'login' in a ? String((a as { login: unknown }).login) : ''))
+        .filter(Boolean)
+      : undefined
+
+    const labels = Array.isArray(entry.labels)
+      ? (entry.labels as Array<Record<string, unknown>>)
+        .map((l) => (l && 'name' in l ? String((l as { name: unknown }).name) : ''))
+        .filter(Boolean)
+      : undefined
+
+    return {
+      number: entry.number as number,
+      title: String(entry.title || ''),
+      url: String(entry.url || ''),
+      state: String(entry.state || ''),
+      author,
+      assignees,
+      labels,
+      comments: typeof entry.comments === 'number' ? entry.comments : undefined,
+      createdAt: String(entry.createdAt || ''),
+      updatedAt: String(entry.updatedAt || ''),
+    }
+  })
+}
+
+function buildGhArgs(filter: IssueListFilter): string[] {
+  const args = ['issue', 'list', '--json', ISSUE_LIST_JSON_FIELDS]
+
+  if (filter.state) args.push('--state', filter.state)
+  if (filter.assignee) args.push('--assignee', filter.assignee)
+  if (filter.author) args.push('--author', filter.author)
+  if (filter.label) args.push('--label', filter.label)
+  if (filter.search) args.push('--search', filter.search)
+  if (typeof filter.limit === 'number') args.push('--limit', String(filter.limit))
+
+  return args
+}
+
+export async function getIssueList(
+  git: SimpleGit,
+  filter: IssueListFilter = {},
+  runner: GhRunner = defaultGhRunner
+): Promise<IssueListOverview> {
+  const repository = await getGitHubRepository(git)
+
+  if (!repository) {
+    return {
+      available: false,
+      authenticated: false,
+      filter,
+      message: 'No GitHub remote detected.',
+    }
+  }
+
+  if (!(await isGhAuthenticated(runner))) {
+    return {
+      available: true,
+      authenticated: false,
+      repository,
+      filter,
+      message: 'GitHub CLI is missing or not authenticated.',
+    }
+  }
+
+  try {
+    const output = await runner(buildGhArgs(filter))
+    return {
+      available: true,
+      authenticated: true,
+      repository,
+      filter,
+      issues: parseIssueListItems(output),
+    }
+  } catch (error) {
+    return {
+      available: true,
+      authenticated: true,
+      repository,
+      filter,
+      message: error instanceof Error ? error.message : 'Failed to fetch issue list.',
+    }
+  }
+}

--- a/src/git/pullRequestData.ts
+++ b/src/git/pullRequestData.ts
@@ -1,15 +1,21 @@
-import { execFile } from 'child_process'
-import { promisify } from 'util'
 import { SimpleGit } from 'simple-git'
+import {
+  defaultGhRunner,
+  getGitHubRepository,
+  isGhAuthenticated,
+  parseGitHubRemoteUrl as parseGitHubRemoteUrlShared,
+  type GhRunner,
+  type GitHubRepository,
+} from './githubCli'
 
-const execFileAsync = promisify(execFile)
-
-export type GhRunner = (args: string[]) => Promise<string>
-
-export type GitHubRepository = {
-  owner: string
-  name: string
+// Re-export for backwards compatibility — callers that imported from
+// pullRequestData before the shared module existed keep working.
+export {
+  defaultGhRunner,
+  type GhRunner,
+  type GitHubRepository,
 }
+export const parseGitHubRemoteUrl = parseGitHubRemoteUrlShared
 
 export type PullRequestStatusCheck = {
   /** Display name from `gh pr view --json statusCheckRollup`. */
@@ -68,36 +74,6 @@ export type PullRequestOverview = {
   currentBranch?: string
   currentPullRequest?: PullRequestInfo
   message?: string
-}
-
-export function parseGitHubRemoteUrl(url: string): GitHubRepository | undefined {
-  const trimmed = url.trim().replace(/\.git$/, '')
-  const sshMatch = trimmed.match(/^git@github\.com:([^/]+)\/(.+)$/)
-  const httpsMatch = trimmed.match(/^https:\/\/github\.com\/([^/]+)\/(.+)$/)
-  const match = sshMatch || httpsMatch
-
-  if (!match) {
-    return undefined
-  }
-
-  return {
-    owner: match[1],
-    name: match[2],
-  }
-}
-
-export async function defaultGhRunner(args: string[]): Promise<string> {
-  const result = await execFileAsync('gh', args)
-
-  return result.stdout
-}
-
-async function getGitHubRepository(git: SimpleGit): Promise<GitHubRepository | undefined> {
-  const remotes = await git.getRemotes(true)
-  const remote = remotes.find((entry) => entry.name === 'origin') || remotes[0]
-  const url = remote?.refs.push || remote?.refs.fetch
-
-  return url ? parseGitHubRemoteUrl(url) : undefined
 }
 
 function parsePullRequestInfo(output: string): PullRequestInfo | undefined {
@@ -188,9 +164,7 @@ export async function getPullRequestOverview(
     }
   }
 
-  try {
-    await runner(['auth', 'status', '--hostname', 'github.com'])
-  } catch {
+  if (!(await isGhAuthenticated(runner))) {
     return {
       available: true,
       authenticated: false,

--- a/src/git/pullRequestListData.test.ts
+++ b/src/git/pullRequestListData.test.ts
@@ -1,0 +1,151 @@
+import { getPullRequestList, PULL_REQUEST_LIST_JSON_FIELDS } from './pullRequestListData'
+
+describe('pullRequestListData', () => {
+  const githubRemoteGit = () =>
+    ({
+      getRemotes: jest.fn().mockResolvedValue([
+        { name: 'origin', refs: { fetch: 'git@github.com:gfargo/coco.git', push: '' } },
+      ]),
+      raw: jest.fn().mockResolvedValue('main\n'),
+    } as never)
+
+  it('returns unavailable when no GitHub remote exists', async () => {
+    const runner = jest.fn()
+    const git = { getRemotes: jest.fn().mockResolvedValue([]) } as never
+
+    await expect(getPullRequestList(git, {}, runner)).resolves.toEqual({
+      available: false,
+      authenticated: false,
+      filter: {},
+      message: 'No GitHub remote detected.',
+    })
+    expect(runner).not.toHaveBeenCalled()
+  })
+
+  it('parses a populated PR list', async () => {
+    const payload = [
+      {
+        number: 962,
+        title: 'feat(commit-split): dedupe rescues',
+        url: 'https://github.com/gfargo/coco/pull/962',
+        state: 'MERGED',
+        isDraft: false,
+        headRefName: 'claude/x',
+        baseRefName: 'main',
+        author: { login: 'gfargo' },
+        assignees: [],
+        labels: [{ name: 'enhancement' }],
+        reviewDecision: 'APPROVED',
+        mergeable: 'MERGEABLE',
+        mergeStateStatus: 'CLEAN',
+        createdAt: '2026-05-14T00:00:00Z',
+        updatedAt: '2026-05-14T00:00:00Z',
+      },
+    ]
+    const runner = jest
+      .fn()
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce(JSON.stringify(payload))
+
+    const overview = await getPullRequestList(githubRemoteGit(), {}, runner)
+
+    expect(overview.authenticated).toBe(true)
+    expect(overview.pullRequests).toEqual([
+      {
+        number: 962,
+        title: 'feat(commit-split): dedupe rescues',
+        url: 'https://github.com/gfargo/coco/pull/962',
+        state: 'MERGED',
+        isDraft: false,
+        headRefName: 'claude/x',
+        baseRefName: 'main',
+        author: 'gfargo',
+        assignees: [],
+        labels: ['enhancement'],
+        reviewDecision: 'APPROVED',
+        mergeable: 'MERGEABLE',
+        mergeStateStatus: 'CLEAN',
+        createdAt: '2026-05-14T00:00:00Z',
+        updatedAt: '2026-05-14T00:00:00Z',
+      },
+    ])
+  })
+
+  it('threads filter knobs into the gh args', async () => {
+    const runner = jest
+      .fn()
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('[]')
+
+    await getPullRequestList(
+      githubRemoteGit(),
+      {
+        state: 'open',
+        assignee: '@me',
+        draft: true,
+        base: 'main',
+        head: 'feature/x',
+        limit: 25,
+      },
+      runner
+    )
+
+    expect(runner).toHaveBeenNthCalledWith(2, [
+      'pr',
+      'list',
+      '--json',
+      PULL_REQUEST_LIST_JSON_FIELDS,
+      '--state',
+      'open',
+      '--assignee',
+      '@me',
+      '--draft',
+      '--base',
+      'main',
+      '--head',
+      'feature/x',
+      '--limit',
+      '25',
+    ])
+  })
+
+  it('parses a minimal PR payload without enriched fields', async () => {
+    const runner = jest
+      .fn()
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce(
+        JSON.stringify([
+          {
+            number: 7,
+            title: 'minimal',
+            url: 'x',
+            state: 'OPEN',
+            isDraft: false,
+            headRefName: 'wip',
+            baseRefName: 'main',
+          },
+        ])
+      )
+
+    const overview = await getPullRequestList(githubRemoteGit(), {}, runner)
+    expect(overview.pullRequests).toEqual([
+      {
+        number: 7,
+        title: 'minimal',
+        url: 'x',
+        state: 'OPEN',
+        isDraft: false,
+        headRefName: 'wip',
+        baseRefName: 'main',
+        author: undefined,
+        assignees: undefined,
+        labels: undefined,
+        reviewDecision: undefined,
+        mergeable: undefined,
+        mergeStateStatus: undefined,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ])
+  })
+})

--- a/src/git/pullRequestListData.ts
+++ b/src/git/pullRequestListData.ts
@@ -1,0 +1,195 @@
+import { SimpleGit } from 'simple-git'
+import {
+  defaultGhRunner,
+  getGitHubRepository,
+  isGhAuthenticated,
+  type GhRunner,
+  type GitHubRepository,
+} from './githubCli'
+
+export type PullRequestState = 'open' | 'closed' | 'merged' | 'all'
+
+export type PullRequestListItem = {
+  number: number
+  title: string
+  url: string
+  state: string // OPEN | CLOSED | MERGED
+  isDraft: boolean
+  headRefName: string
+  baseRefName: string
+  author?: string
+  assignees?: string[]
+  labels?: string[]
+  reviewDecision?: string
+  mergeable?: string
+  mergeStateStatus?: string
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * Filter knobs passed to `gh pr list`. Mirrors `IssueListFilter`'s
+ * design — every entry maps 1:1 to a `gh` flag so users can reach
+ * for any `gh pr list` knob through coco's wrapper without learning
+ * a new vocabulary.
+ */
+export type PullRequestListFilter = {
+  state?: PullRequestState
+  /** Maps to `--assignee`. Accepts a login or `@me`. */
+  assignee?: string
+  /** Maps to `--author`. */
+  author?: string
+  /** Comma-separated label list. Maps to `--label`. */
+  label?: string
+  /** Maps to `--search`. Free-form GitHub PR search syntax. */
+  search?: string
+  /** Maps to `--draft`. Set true to surface draft PRs only. */
+  draft?: boolean
+  /** Maps to `--limit`. Default 30 (gh's own default). */
+  limit?: number
+  /** Filter to PRs targeting a specific base branch. Maps to `--base`. */
+  base?: string
+  /** Filter to PRs originating from a specific head branch. Maps to `--head`. */
+  head?: string
+}
+
+export type PullRequestListOverview = {
+  available: boolean
+  authenticated: boolean
+  repository?: GitHubRepository
+  pullRequests?: PullRequestListItem[]
+  filter?: PullRequestListFilter
+  message?: string
+}
+
+/**
+ * `gh pr list --json` field list. Trimmer than `pullRequestData.ts`'s
+ * single-PR field set — the triage list view doesn't need bodies,
+ * statusCheckRollup, or per-review breakdowns (those live in the
+ * inspector that opens when the user picks a row).
+ */
+export const PULL_REQUEST_LIST_JSON_FIELDS = [
+  'number',
+  'title',
+  'url',
+  'state',
+  'isDraft',
+  'headRefName',
+  'baseRefName',
+  'author',
+  'assignees',
+  'labels',
+  'reviewDecision',
+  'mergeable',
+  'mergeStateStatus',
+  'createdAt',
+  'updatedAt',
+].join(',')
+
+function parsePullRequestListItems(output: string): PullRequestListItem[] {
+  const trimmed = output.trim()
+  if (!trimmed) return []
+
+  const raw = JSON.parse(trimmed) as Array<Record<string, unknown>>
+
+  return raw.map((entry) => {
+    const author =
+      entry.author && typeof entry.author === 'object' && 'login' in entry.author
+        ? String((entry.author as { login: unknown }).login)
+        : undefined
+
+    const assignees = Array.isArray(entry.assignees)
+      ? (entry.assignees as Array<Record<string, unknown>>)
+        .map((a) => (a && 'login' in a ? String((a as { login: unknown }).login) : ''))
+        .filter(Boolean)
+      : undefined
+
+    const labels = Array.isArray(entry.labels)
+      ? (entry.labels as Array<Record<string, unknown>>)
+        .map((l) => (l && 'name' in l ? String((l as { name: unknown }).name) : ''))
+        .filter(Boolean)
+      : undefined
+
+    return {
+      number: entry.number as number,
+      title: String(entry.title || ''),
+      url: String(entry.url || ''),
+      state: String(entry.state || ''),
+      isDraft: Boolean(entry.isDraft),
+      headRefName: String(entry.headRefName || ''),
+      baseRefName: String(entry.baseRefName || ''),
+      author,
+      assignees,
+      labels,
+      reviewDecision:
+        typeof entry.reviewDecision === 'string' ? entry.reviewDecision : undefined,
+      mergeable: typeof entry.mergeable === 'string' ? entry.mergeable : undefined,
+      mergeStateStatus:
+        typeof entry.mergeStateStatus === 'string' ? entry.mergeStateStatus : undefined,
+      createdAt: String(entry.createdAt || ''),
+      updatedAt: String(entry.updatedAt || ''),
+    }
+  })
+}
+
+function buildGhArgs(filter: PullRequestListFilter): string[] {
+  const args = ['pr', 'list', '--json', PULL_REQUEST_LIST_JSON_FIELDS]
+
+  if (filter.state) args.push('--state', filter.state)
+  if (filter.assignee) args.push('--assignee', filter.assignee)
+  if (filter.author) args.push('--author', filter.author)
+  if (filter.label) args.push('--label', filter.label)
+  if (filter.search) args.push('--search', filter.search)
+  if (filter.draft) args.push('--draft')
+  if (filter.base) args.push('--base', filter.base)
+  if (filter.head) args.push('--head', filter.head)
+  if (typeof filter.limit === 'number') args.push('--limit', String(filter.limit))
+
+  return args
+}
+
+export async function getPullRequestList(
+  git: SimpleGit,
+  filter: PullRequestListFilter = {},
+  runner: GhRunner = defaultGhRunner
+): Promise<PullRequestListOverview> {
+  const repository = await getGitHubRepository(git)
+
+  if (!repository) {
+    return {
+      available: false,
+      authenticated: false,
+      filter,
+      message: 'No GitHub remote detected.',
+    }
+  }
+
+  if (!(await isGhAuthenticated(runner))) {
+    return {
+      available: true,
+      authenticated: false,
+      repository,
+      filter,
+      message: 'GitHub CLI is missing or not authenticated.',
+    }
+  }
+
+  try {
+    const output = await runner(buildGhArgs(filter))
+    return {
+      available: true,
+      authenticated: true,
+      repository,
+      filter,
+      pullRequests: parsePullRequestListItems(output),
+    }
+  } catch (error) {
+    return {
+      available: true,
+      authenticated: true,
+      repository,
+      filter,
+      message: error instanceof Error ? error.message : 'Failed to fetch pull request list.',
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,9 @@ import changelog from './commands/changelog'
 import commit from './commands/commit'
 import doctor from './commands/doctor'
 import init from './commands/init'
+import issues from './commands/issues'
 import log from './commands/log'
+import prs from './commands/prs'
 import recap from './commands/recap'
 import review from './commands/review'
 import ui from './commands/ui'
@@ -15,7 +17,9 @@ import { ChangelogOptions } from './commands/changelog/config'
 import { CommitOptions } from './commands/commit/config'
 import { DoctorOptions } from './commands/doctor/config'
 import { InitOptions } from './commands/init/config'
+import { IssuesOptions } from './commands/issues/config'
 import { LogOptions } from './commands/log/config'
+import { PrsOptions } from './commands/prs/config'
 import { RecapOptions } from './commands/recap/config'
 import { ReviewOptions } from './commands/review/config'
 import { UiOptions } from './commands/ui/config'
@@ -102,6 +106,20 @@ y.command<CacheOptions>(
   cache.handler
 )
 
+y.command<IssuesOptions>(
+  issues.command,
+  issues.desc,
+  issues.builder,
+  issues.handler
+)
+
+y.command<PrsOptions>(
+  prs.command,
+  prs.desc,
+  prs.builder,
+  prs.handler
+)
+
 // `COCO_PREFETCH` hook (#933 phase 3). When set, downloads any
 // requested lazy-load tree-sitter parsers into the user's cache
 // dir before yargs hands control to a subcommand. No-op when
@@ -122,4 +140,17 @@ main().catch((error) => {
   process.exit(1)
 })
 
-export { cache, changelog, commit, Config, doctor, init, log, recap, types, ui }
+export {
+  cache,
+  changelog,
+  commit,
+  Config,
+  doctor,
+  init,
+  issues,
+  log,
+  prs,
+  recap,
+  types,
+  ui,
+}


### PR DESCRIPTION
First slice of [#882](https://github.com/gfargo/coco/issues/882) (TUI shell · issue / PR triage workflow).

## Phasing

[#882](https://github.com/gfargo/coco/issues/882) is tagged "Large effort: new command surface, new data fetchers, new view family." Rather than land the entire thing as one mega-PR, this is the first of six focused slices off main:

| Phase | Scope | Status |
| --- | --- | --- |
| **1** | Data layer + stdout commands. `coco issues [--filter]` and `coco prs [--filter]` shell out to `gh api`, parse JSON, print formatted lists. | **this PR** |
| 2 | Disk-backed caching mirroring `overviewCache.ts` → `~/.cache/coco/github/`. | pending |
| 3 | TUI surfaces (read-only): list left, inspector right. Inherits chord conventions. | pending |
| 4 | Low-risk actions: assign, label, comment. | pending |
| 5 | Mutating actions: merge, approve, close, request-changes. | pending |
| 6 | Filter cycling (`f`) + AI summarize (`I`). | pending |

## Summary

- **New shared `gh` plumbing** in [src/git/githubCli.ts](src/git/githubCli.ts). Hoists `GhRunner` / `parseGitHubRemoteUrl` / `getGitHubRepository` / `isGhAuthenticated` so the existing `pullRequestData.ts` and the two new list fetchers stop duplicating the auth probe + remote detection. `pullRequestData.ts` re-exports the shared types for backwards compatibility with existing callers.
- **List fetchers**: [issuesListData.ts](src/git/issuesListData.ts) + [pullRequestListData.ts](src/git/pullRequestListData.ts). Both accept a filter object that maps 1:1 to `gh issue list` / `gh pr list` flags (state, assignee, author, label, search, limit, draft, base, head). Trimmer field list than the single-PR fetcher — bodies / status rollups / reviews stay out of the list view (those belong in the upcoming inspector surface).
- **Shared formatter** in [githubListFormatting.ts](src/git/githubListFormatting.ts). Color-codes state, decorates draft / mergeable / review-decision, truncates long branch names. Computes column widths from raw values before applying chalk so ANSI escapes don't break alignment.
- **CLI commands** under [src/commands/issues](src/commands/issues) and [src/commands/prs](src/commands/prs). `--mine` is a convenience shim for `--assignee @me`; `--json` skips the table and emits raw JSON for scripting.

## Usage

\`\`\`
coco issues --state open
coco issues --mine --label enhancement
coco issues --search "is:open is:public-good"
coco issues --json | jq '.[] | .title'

coco prs --state all --limit 5
coco prs --draft
coco prs --mine --base main
\`\`\`

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm run test:jest\` — 1731 tests pass, 7 skipped (158 suites). Includes 36 new unit tests across the four new modules + the refactored `pullRequestData.ts`.
- [x] \`npx tsc --noEmit\` — clean
- [x] Manual smoke: \`coco issues --limit 3\` returns the three most recent open issues against this repo
- [x] Manual smoke: \`coco prs --state all --limit 3\` returns the three most recent PRs with state / mergeable glyphs

## Notes for review

- The existing PR action panel surface (the workstation's \`g p\`) is untouched. Phase 3 will plug into the same chord registry to add \`g i\` / \`g r\` entries for these list views.
- No new dependencies. \`gh\` continues to be invoked via the existing \`execFile\` shim.
- No \`.coco.config.json\` schema changes.