### PR TITLE
feat(cli): disk-backed cache for coco issues / coco prs (#882 phase 2)

### DIFF
--- a/src/commands/cache/config.ts
+++ b/src/commands/cache/config.ts
@@ -33,6 +33,7 @@ export const CACHE_SUBCOMMANDS = [
   'parsers',
   'prefetch',
   'clear-parsers',
+  'clear-github',
 ] as const
 
 export type CacheSubcommand = typeof CACHE_SUBCOMMANDS[number]

--- a/src/commands/cache/handler.ts
+++ b/src/commands/cache/handler.ts
@@ -19,6 +19,7 @@ import {
   clearDiffSummaryCache,
   getDiffSummaryCachePath,
 } from '../../lib/parsers/default/utils/diffSummaryCache'
+import { clearGitHubListCache } from '../../git/githubListCache'
 import { checkboxPrompt } from '../../lib/ui/inquirerPrompts'
 import { CommandHandler } from '../../lib/types'
 import { applyRepoCwd } from '../utils/applyRepoFlag'
@@ -245,6 +246,17 @@ export const handler: CommandHandler<CacheArgv> = async (argv, logger) => {
     return
   }
 
+  if (subcommand === 'clear-github') {
+    const result = clearGitHubListCache()
+    if (result.removed === 0) {
+      logger.log(chalk.dim('No GitHub triage cache to clear.'))
+      return
+    }
+    logger.log(chalk.green(`✓ cleared ${result.removed} cached GitHub triage list${result.removed === 1 ? '' : 's'}`))
+    logger.log(chalk.dim('Cleared from ~/.cache/coco/github/'))
+    return
+  }
+
   if (subcommand === 'clear-parsers') {
     const languages = listManifestLanguages()
     let cleared = 0
@@ -264,6 +276,6 @@ export const handler: CommandHandler<CacheArgv> = async (argv, logger) => {
   }
 
   logger.log(chalk.red(`Unknown cache subcommand: ${subcommand}`))
-  logger.log(chalk.dim('Use one of: clear, info, parsers, prefetch, clear-parsers'))
+  logger.log(chalk.dim('Use one of: clear, info, parsers, prefetch, clear-parsers, clear-github'))
   process.exitCode = 1
 }

--- a/src/commands/issues/config.ts
+++ b/src/commands/issues/config.ts
@@ -13,6 +13,16 @@ export interface IssuesOptions extends BaseCommandOptions {
   limit?: number
   /** Print machine-readable JSON instead of the formatted table. */
   json?: boolean
+  /**
+   * Force a fresh `gh` call even if the cached entry is within
+   * the TTL. The fresh result still gets written back to cache.
+   */
+  refresh?: boolean
+  /**
+   * Disable cache entirely — skip read AND write. Useful when
+   * piping into tooling that manages its own freshness.
+   */
+  noCache?: boolean
 }
 
 export type IssuesArgv = Arguments<IssuesOptions>
@@ -54,6 +64,16 @@ export const options = {
   json: {
     type: 'boolean',
     description: 'Print machine-readable JSON instead of a formatted table.',
+    default: false,
+  },
+  refresh: {
+    type: 'boolean',
+    description: 'Force fresh `gh` call (writes through to cache).',
+    default: false,
+  },
+  'no-cache': {
+    type: 'boolean',
+    description: 'Skip the disk cache entirely (no read, no write).',
     default: false,
   },
 } as Record<string, Options>

--- a/src/commands/issues/handler.ts
+++ b/src/commands/issues/handler.ts
@@ -1,13 +1,23 @@
 import chalk from 'chalk'
 import { CommandHandler } from '../../lib/types'
 import { commandExit } from '../../lib/utils/commandExit'
+import { getGitHubRepository } from '../../git/githubCli'
 import { formatIssueList } from '../../git/githubListFormatting'
-import { getIssueList, type IssueListFilter } from '../../git/issuesListData'
+import { readCachedList, writeCachedList } from '../../git/githubListCache'
+import {
+  getIssueList,
+  type IssueListFilter,
+  type IssueListItem,
+} from '../../git/issuesListData'
 import { applyRepoFlag } from '../utils/applyRepoFlag'
 import { IssuesArgv } from './config'
 
 export const handler: CommandHandler<IssuesArgv> = async (argv, logger) => {
   const git = applyRepoFlag(argv)
+  // `applyRepoFlag` chdir'd to the repo path (or kept process.cwd
+  // when --repo was omitted), so the cache key derives from a stable
+  // absolute path either way.
+  const repoPath = process.cwd()
 
   const filter: IssueListFilter = {
     state: argv.state,
@@ -18,35 +28,65 @@ export const handler: CommandHandler<IssuesArgv> = async (argv, logger) => {
     limit: argv.limit,
   }
 
-  const overview = await getIssueList(git, filter)
+  const cacheEnabled = !argv.noCache
+  let issues: IssueListItem[] | undefined
+  let fromCache = false
+  let cacheAgeMs: number | undefined
 
-  if (!overview.available) {
-    logger.log(chalk.red(overview.message || 'No GitHub remote detected.'))
-    commandExit(1)
-    return
+  // Repository metadata is needed for the header in both code paths
+  // (cache hit and fresh fetch). The cache hit path skips
+  // `getIssueList` entirely, so probe it directly here. Cheap — no
+  // network, just a single `git remote` parse.
+  const repository = await getGitHubRepository(git)
+
+  if (cacheEnabled && !argv.refresh) {
+    const cached = readCachedList<{ kind: 'issues'; items: IssueListItem[] }>(
+      'issues',
+      repoPath,
+      filter
+    )
+    if (cached?.fresh) {
+      issues = cached.payload.items
+      fromCache = true
+      cacheAgeMs = cached.ageMs
+    }
   }
 
-  if (!overview.authenticated) {
-    logger.log(chalk.yellow(overview.message || 'GitHub CLI is missing or not authenticated.'))
-    logger.log(chalk.dim('Install `gh` and run `gh auth login` to enable issue triage.'))
-    commandExit(1)
-    return
-  }
+  if (!issues) {
+    const overview = await getIssueList(git, filter)
 
-  if (overview.message) {
-    logger.log(chalk.red(overview.message))
-    commandExit(1)
-    return
-  }
+    if (!overview.available) {
+      logger.log(chalk.red(overview.message || 'No GitHub remote detected.'))
+      commandExit(1)
+      return
+    }
 
-  const issues = overview.issues || []
+    if (!overview.authenticated) {
+      logger.log(chalk.yellow(overview.message || 'GitHub CLI is missing or not authenticated.'))
+      logger.log(chalk.dim('Install `gh` and run `gh auth login` to enable issue triage.'))
+      commandExit(1)
+      return
+    }
+
+    if (overview.message) {
+      logger.log(chalk.red(overview.message))
+      commandExit(1)
+      return
+    }
+
+    issues = overview.issues || []
+
+    if (cacheEnabled) {
+      writeCachedList(repoPath, filter, { kind: 'issues', items: issues })
+    }
+  }
 
   if (argv.json) {
     logger.log(JSON.stringify(issues, null, 2))
     return
   }
 
-  if (overview.repository) {
+  if (repository) {
     const filterParts: string[] = []
     if (filter.state && filter.state !== 'open') filterParts.push(`state=${filter.state}`)
     if (filter.assignee) filterParts.push(`assignee=${filter.assignee}`)
@@ -54,10 +94,14 @@ export const handler: CommandHandler<IssuesArgv> = async (argv, logger) => {
     if (filter.label) filterParts.push(`label=${filter.label}`)
     if (filter.search) filterParts.push(`search=${JSON.stringify(filter.search)}`)
     const suffix = filterParts.length ? chalk.dim(` (${filterParts.join(', ')})`) : ''
+    const cacheTag = fromCache && typeof cacheAgeMs === 'number'
+      ? chalk.dim(` · cached ${Math.round(cacheAgeMs / 1000)}s ago`)
+      : ''
     logger.log(
-      chalk.bold(`${overview.repository.owner}/${overview.repository.name}`) +
+      chalk.bold(`${repository.owner}/${repository.name}`) +
       chalk.dim(` · ${issues.length} issue${issues.length === 1 ? '' : 's'}`) +
-      suffix
+      suffix +
+      cacheTag
     )
     logger.log('')
   }

--- a/src/commands/prs/config.ts
+++ b/src/commands/prs/config.ts
@@ -16,6 +16,16 @@ export interface PrsOptions extends BaseCommandOptions {
   limit?: number
   /** Print machine-readable JSON instead of the formatted table. */
   json?: boolean
+  /**
+   * Force a fresh `gh` call even if the cached entry is within
+   * the TTL. The fresh result still gets written back to cache.
+   */
+  refresh?: boolean
+  /**
+   * Disable cache entirely — skip read AND write. Useful when
+   * piping into tooling that manages its own freshness.
+   */
+  noCache?: boolean
 }
 
 export type PrsArgv = Arguments<PrsOptions>
@@ -70,6 +80,16 @@ export const options = {
   json: {
     type: 'boolean',
     description: 'Print machine-readable JSON instead of a formatted table.',
+    default: false,
+  },
+  refresh: {
+    type: 'boolean',
+    description: 'Force fresh `gh` call (writes through to cache).',
+    default: false,
+  },
+  'no-cache': {
+    type: 'boolean',
+    description: 'Skip the disk cache entirely (no read, no write).',
     default: false,
   },
 } as Record<string, Options>

--- a/src/commands/prs/handler.ts
+++ b/src/commands/prs/handler.ts
@@ -1,16 +1,20 @@
 import chalk from 'chalk'
 import { CommandHandler } from '../../lib/types'
 import { commandExit } from '../../lib/utils/commandExit'
+import { getGitHubRepository } from '../../git/githubCli'
 import { formatPullRequestList } from '../../git/githubListFormatting'
+import { readCachedList, writeCachedList } from '../../git/githubListCache'
 import {
   getPullRequestList,
   type PullRequestListFilter,
+  type PullRequestListItem,
 } from '../../git/pullRequestListData'
 import { applyRepoFlag } from '../utils/applyRepoFlag'
 import { PrsArgv } from './config'
 
 export const handler: CommandHandler<PrsArgv> = async (argv, logger) => {
   const git = applyRepoFlag(argv)
+  const repoPath = process.cwd()
 
   const filter: PullRequestListFilter = {
     state: argv.state,
@@ -24,35 +28,60 @@ export const handler: CommandHandler<PrsArgv> = async (argv, logger) => {
     limit: argv.limit,
   }
 
-  const overview = await getPullRequestList(git, filter)
+  const cacheEnabled = !argv.noCache
+  let prs: PullRequestListItem[] | undefined
+  let fromCache = false
+  let cacheAgeMs: number | undefined
 
-  if (!overview.available) {
-    logger.log(chalk.red(overview.message || 'No GitHub remote detected.'))
-    commandExit(1)
-    return
+  const repository = await getGitHubRepository(git)
+
+  if (cacheEnabled && !argv.refresh) {
+    const cached = readCachedList<{
+      kind: 'prs'
+      items: PullRequestListItem[]
+    }>('prs', repoPath, filter)
+    if (cached?.fresh) {
+      prs = cached.payload.items
+      fromCache = true
+      cacheAgeMs = cached.ageMs
+    }
   }
 
-  if (!overview.authenticated) {
-    logger.log(chalk.yellow(overview.message || 'GitHub CLI is missing or not authenticated.'))
-    logger.log(chalk.dim('Install `gh` and run `gh auth login` to enable PR triage.'))
-    commandExit(1)
-    return
-  }
+  if (!prs) {
+    const overview = await getPullRequestList(git, filter)
 
-  if (overview.message) {
-    logger.log(chalk.red(overview.message))
-    commandExit(1)
-    return
-  }
+    if (!overview.available) {
+      logger.log(chalk.red(overview.message || 'No GitHub remote detected.'))
+      commandExit(1)
+      return
+    }
 
-  const prs = overview.pullRequests || []
+    if (!overview.authenticated) {
+      logger.log(chalk.yellow(overview.message || 'GitHub CLI is missing or not authenticated.'))
+      logger.log(chalk.dim('Install `gh` and run `gh auth login` to enable PR triage.'))
+      commandExit(1)
+      return
+    }
+
+    if (overview.message) {
+      logger.log(chalk.red(overview.message))
+      commandExit(1)
+      return
+    }
+
+    prs = overview.pullRequests || []
+
+    if (cacheEnabled) {
+      writeCachedList(repoPath, filter, { kind: 'prs', items: prs })
+    }
+  }
 
   if (argv.json) {
     logger.log(JSON.stringify(prs, null, 2))
     return
   }
 
-  if (overview.repository) {
+  if (repository) {
     const filterParts: string[] = []
     if (filter.state && filter.state !== 'open') filterParts.push(`state=${filter.state}`)
     if (filter.assignee) filterParts.push(`assignee=${filter.assignee}`)
@@ -63,10 +92,14 @@ export const handler: CommandHandler<PrsArgv> = async (argv, logger) => {
     if (filter.head) filterParts.push(`head=${filter.head}`)
     if (filter.draft) filterParts.push('draft')
     const suffix = filterParts.length ? chalk.dim(` (${filterParts.join(', ')})`) : ''
+    const cacheTag = fromCache && typeof cacheAgeMs === 'number'
+      ? chalk.dim(` · cached ${Math.round(cacheAgeMs / 1000)}s ago`)
+      : ''
     logger.log(
-      chalk.bold(`${overview.repository.owner}/${overview.repository.name}`) +
+      chalk.bold(`${repository.owner}/${repository.name}`) +
       chalk.dim(` · ${prs.length} pull request${prs.length === 1 ? '' : 's'}`) +
-      suffix
+      suffix +
+      cacheTag
     )
     logger.log('')
   }

--- a/src/git/githubListCache.test.ts
+++ b/src/git/githubListCache.test.ts
@@ -1,0 +1,173 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import {
+  canonicalizeFilter,
+  clearGitHubListCache,
+  getCachePath,
+  readCachedList,
+  writeCachedList,
+  DEFAULT_CACHE_TTL_MS,
+} from './githubListCache'
+
+const ORIGINAL_XDG = process.env.XDG_CACHE_HOME
+
+describe('githubListCache', () => {
+  let tmpRoot: string
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-gh-cache-test-'))
+    process.env.XDG_CACHE_HOME = tmpRoot
+  })
+
+  afterEach(() => {
+    if (ORIGINAL_XDG === undefined) {
+      delete process.env.XDG_CACHE_HOME
+    } else {
+      process.env.XDG_CACHE_HOME = ORIGINAL_XDG
+    }
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  describe('canonicalizeFilter', () => {
+    it('produces the same string for equivalent filters with different key order', () => {
+      const a = canonicalizeFilter({ state: 'open', assignee: '@me' })
+      const b = canonicalizeFilter({ assignee: '@me', state: 'open' })
+      expect(a).toBe(b)
+    })
+
+    it('drops undefined / null / empty-string values', () => {
+      const a = canonicalizeFilter({ state: 'open' })
+      const b = canonicalizeFilter({ state: 'open', assignee: undefined, label: '' })
+      expect(a).toBe(b)
+    })
+
+    it('produces different strings for different filter values', () => {
+      expect(canonicalizeFilter({ state: 'open' })).not.toBe(
+        canonicalizeFilter({ state: 'closed' })
+      )
+    })
+  })
+
+  describe('getCachePath', () => {
+    it('namespaces issues and prs cache files separately', () => {
+      const issuesPath = getCachePath('issues', '/repo', { state: 'open' })
+      const prsPath = getCachePath('prs', '/repo', { state: 'open' })
+      expect(issuesPath).not.toBe(prsPath)
+      expect(path.basename(issuesPath)).toMatch(/^issues\./)
+      expect(path.basename(prsPath)).toMatch(/^prs\./)
+    })
+
+    it('respects XDG_CACHE_HOME', () => {
+      const p = getCachePath('issues', '/repo', {})
+      expect(p.startsWith(path.join(tmpRoot, 'coco', 'github'))).toBe(true)
+    })
+
+    it('produces different paths for different filters', () => {
+      const open = getCachePath('issues', '/repo', { state: 'open' })
+      const closed = getCachePath('issues', '/repo', { state: 'closed' })
+      expect(open).not.toBe(closed)
+    })
+
+    it('produces different paths for different repos', () => {
+      const a = getCachePath('issues', '/repo-a', { state: 'open' })
+      const b = getCachePath('issues', '/repo-b', { state: 'open' })
+      expect(a).not.toBe(b)
+    })
+  })
+
+  describe('write/read roundtrip', () => {
+    it('reads back what was written', () => {
+      writeCachedList('/repo', { state: 'open' }, {
+        kind: 'issues',
+        items: [{
+          number: 1,
+          title: 't',
+          url: 'u',
+          state: 'OPEN',
+          createdAt: '',
+          updatedAt: '',
+        }],
+      })
+
+      const result = readCachedList('issues', '/repo', { state: 'open' })
+
+      expect(result).toBeDefined()
+      expect(result?.payload.kind).toBe('issues')
+      expect(result?.payload.items).toEqual([{
+        number: 1,
+        title: 't',
+        url: 'u',
+        state: 'OPEN',
+        createdAt: '',
+        updatedAt: '',
+      }])
+    })
+
+    it('returns undefined when the cache file is missing', () => {
+      expect(readCachedList('issues', '/repo', { state: 'open' })).toBeUndefined()
+    })
+
+    it('reports fresh: true when within the TTL', () => {
+      writeCachedList('/repo', {}, { kind: 'issues', items: [] })
+      const result = readCachedList('issues', '/repo', {})
+      expect(result?.fresh).toBe(true)
+      expect(result?.ageMs).toBeGreaterThanOrEqual(0)
+      expect(result?.ageMs).toBeLessThan(DEFAULT_CACHE_TTL_MS)
+    })
+
+    it('reports fresh: false when older than the TTL', () => {
+      writeCachedList('/repo', {}, { kind: 'issues', items: [] })
+      // Read with a 0ms TTL — anything is stale.
+      const result = readCachedList('issues', '/repo', {}, 0)
+      expect(result?.fresh).toBe(false)
+    })
+
+    it('returns undefined for kind mismatch (issues file read as prs)', () => {
+      writeCachedList('/repo', {}, { kind: 'issues', items: [] })
+      // Force the wrong kind via path collision — write issues, read prs
+      // at the same key. The cache paths differ, so this naturally
+      // returns undefined; but assert it explicitly.
+      expect(readCachedList('prs', '/repo', {})).toBeUndefined()
+    })
+
+    it('returns undefined when the envelope is malformed', () => {
+      const file = getCachePath('issues', '/repo', {})
+      fs.mkdirSync(path.dirname(file), { recursive: true })
+      fs.writeFileSync(file, '{not-json')
+      expect(readCachedList('issues', '/repo', {})).toBeUndefined()
+    })
+
+    it('returns undefined when the schema version doesn\'t match', () => {
+      const file = getCachePath('issues', '/repo', {})
+      fs.mkdirSync(path.dirname(file), { recursive: true })
+      fs.writeFileSync(
+        file,
+        JSON.stringify({
+          version: 999,
+          savedAt: new Date().toISOString(),
+          payload: { kind: 'issues', items: [] },
+        })
+      )
+      expect(readCachedList('issues', '/repo', {})).toBeUndefined()
+    })
+  })
+
+  describe('clearGitHubListCache', () => {
+    it('removes every cached file under the github cache dir', () => {
+      writeCachedList('/repo-a', { state: 'open' }, { kind: 'issues', items: [] })
+      writeCachedList('/repo-b', { state: 'closed' }, { kind: 'prs', items: [] })
+
+      const result = clearGitHubListCache()
+      expect(result.removed).toBe(2)
+
+      expect(readCachedList('issues', '/repo-a', { state: 'open' })).toBeUndefined()
+      expect(readCachedList('prs', '/repo-b', { state: 'closed' })).toBeUndefined()
+    })
+
+    it('returns removed: 0 when the cache dir doesn\'t exist', () => {
+      const result = clearGitHubListCache()
+      expect(result.removed).toBe(0)
+    })
+  })
+})

--- a/src/git/githubListCache.ts
+++ b/src/git/githubListCache.ts
@@ -1,0 +1,182 @@
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import type { IssueListItem, IssueListFilter } from './issuesListData'
+import type {
+  PullRequestListItem,
+  PullRequestListFilter,
+} from './pullRequestListData'
+
+/**
+ * Disk-backed cache for `coco issues` / `coco prs` list fetches
+ * (#882 phase 2). Triage is bursty — a user runs `coco issues` a
+ * dozen times in a few minutes, then doesn't touch it for hours —
+ * so a short TTL (default 5 minutes) buys a lot of latency back
+ * without serving stale data outside that window.
+ *
+ * Best-effort, same as `overviewCache.ts`: read failures fall back
+ * to "no cache" (the fetcher does a fresh `gh` call), write failures
+ * are swallowed silently (next call just re-fetches). The cache is
+ * never load-bearing — `gh` is always the source of truth.
+ *
+ * Keying: `{kind}.{repoHash}.{filterHash}.json` where:
+ *   - `kind` is `'issues'` or `'prs'` so the two surfaces don't
+ *     collide.
+ *   - `repoHash` is a stable short hash of the absolute repo path
+ *     (same scheme as `overviewCache.ts`).
+ *   - `filterHash` is a stable short hash of the canonicalized
+ *     filter object so different `--state` / `--assignee` / `--label`
+ *     combinations cache independently.
+ *
+ * No PII in filenames; no auth context is hashed; no
+ * collision-resistance against an adversary is required.
+ */
+
+export const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000
+
+const CACHE_SCHEMA_VERSION = 1
+const CACHE_DIR_NAME = 'github'
+
+export type GitHubListCacheKind = 'issues' | 'prs'
+
+export type CachedIssueList = {
+  kind: 'issues'
+  items: IssueListItem[]
+}
+
+export type CachedPullRequestList = {
+  kind: 'prs'
+  items: PullRequestListItem[]
+}
+
+export type CachedList = CachedIssueList | CachedPullRequestList
+
+type CacheEnvelope<T extends CachedList> = {
+  version: number
+  savedAt: string
+  payload: T
+}
+
+export type CacheReadResult<T extends CachedList> = {
+  payload: T
+  savedAt: Date
+  ageMs: number
+  fresh: boolean
+}
+
+function resolveCacheDir(): string {
+  const xdg = process.env.XDG_CACHE_HOME
+  if (xdg && xdg.trim().length > 0) {
+    return path.join(xdg, 'coco', CACHE_DIR_NAME)
+  }
+  return path.join(os.homedir(), '.cache', 'coco', CACHE_DIR_NAME)
+}
+
+function shortHash(input: string): string {
+  // sha1 here is a non-security cache-key derivation — we just need a
+  // deterministic short identifier so two repos / filters at different
+  // values never collide in the cache directory. No PII or auth
+  // context is hashed and no collision-resistance against an adversary
+  // is required.
+  // DevSkim: ignore DS126858
+  return crypto.createHash('sha1').update(input).digest('hex').slice(0, 16)
+}
+
+/**
+ * Canonicalize the filter object into a stable string before hashing.
+ * Sorts keys + drops undefined entries so equivalent filters
+ * (`{state: 'open'}` and `{state: 'open', limit: undefined}`) hash to
+ * the same key and share cached data.
+ */
+export function canonicalizeFilter(
+  filter: IssueListFilter | PullRequestListFilter
+): string {
+  const entries = Object.entries(filter)
+    .filter(([, value]) => value !== undefined && value !== null && value !== '')
+    .sort(([a], [b]) => a.localeCompare(b))
+  return JSON.stringify(entries)
+}
+
+export function getCachePath(
+  kind: GitHubListCacheKind,
+  repoPath: string,
+  filter: IssueListFilter | PullRequestListFilter
+): string {
+  const repoHash = shortHash(repoPath)
+  const filterHash = shortHash(canonicalizeFilter(filter))
+  return path.join(resolveCacheDir(), `${kind}.${repoHash}.${filterHash}.json`)
+}
+
+export function readCachedList<T extends CachedList>(
+  kind: T['kind'],
+  repoPath: string,
+  filter: IssueListFilter | PullRequestListFilter,
+  ttlMs: number = DEFAULT_CACHE_TTL_MS
+): CacheReadResult<T> | undefined {
+  try {
+    const raw = fs.readFileSync(getCachePath(kind, repoPath, filter), 'utf8')
+    const parsed = JSON.parse(raw) as CacheEnvelope<T>
+
+    if (parsed.version !== CACHE_SCHEMA_VERSION) return undefined
+    if (!parsed.payload || parsed.payload.kind !== kind) return undefined
+    if (!Array.isArray((parsed.payload as CachedList).items)) return undefined
+
+    const savedAt = new Date(parsed.savedAt)
+    if (Number.isNaN(savedAt.getTime())) return undefined
+
+    const ageMs = Date.now() - savedAt.getTime()
+    return {
+      payload: parsed.payload,
+      savedAt,
+      ageMs,
+      fresh: ageMs < ttlMs,
+    }
+  } catch {
+    return undefined
+  }
+}
+
+export function writeCachedList<T extends CachedList>(
+  repoPath: string,
+  filter: IssueListFilter | PullRequestListFilter,
+  payload: T
+): void {
+  const file = getCachePath(payload.kind, repoPath, filter)
+  const envelope: CacheEnvelope<T> = {
+    version: CACHE_SCHEMA_VERSION,
+    savedAt: new Date().toISOString(),
+    payload,
+  }
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true })
+    fs.writeFileSync(file, JSON.stringify(envelope))
+  } catch {
+    // Best-effort persistence; swallow.
+  }
+}
+
+/**
+ * Drop every cached file under the github cache directory. Used by
+ * `--no-cache` / explicit purge commands. Best-effort: ENOENT on a
+ * never-populated cache directory is treated as success.
+ */
+export function clearGitHubListCache(): { removed: number } {
+  const dir = resolveCacheDir()
+  let removed = 0
+  try {
+    const entries = fs.readdirSync(dir)
+    for (const entry of entries) {
+      try {
+        fs.unlinkSync(path.join(dir, entry))
+        removed++
+      } catch {
+        // Skip individual file failures; keep counting the rest.
+      }
+    }
+  } catch {
+    // Directory missing → nothing to clear, treat as success.
+  }
+  return { removed }
+}


### PR DESCRIPTION
Phase 2 of [#882](https://github.com/gfargo/coco/issues/882). Builds on [#964](https://github.com/gfargo/coco/pull/964) which shipped the data layer + stdout commands.

## Why

Triage is bursty — a user runs \`coco issues\` a dozen times in a few minutes, then doesn't touch it for hours. A 5-minute TTL cache buys back most of the per-call latency without serving stale data outside that window. The issue's own design notes called this out as "5-minute cache TTL might be fine."

## Summary

- **New cache module**: [src/git/githubListCache.ts](src/git/githubListCache.ts). Disk-backed, mirroring the existing [overviewCache.ts](src/workstation/chrome/overviewCache.ts) pattern. Keys on \`{kind}.{repoHash}.{filterHash}\` so the same repo can hold many cached filters independently (open vs closed, \`--mine\` vs all, etc.). Versioned envelope; schema mismatch silently invalidates. Best-effort throughout — every fs call is wrapped so cache failures never break the actual fetch path.
- **Handler-layer caching**: kept the data fetchers ([issuesListData.ts](src/git/issuesListData.ts), [pullRequestListData.ts](src/git/pullRequestListData.ts)) pure. Cache read/write lives in the two CLI handlers so phase 3's TUI surface can reuse the fetcher modules without inheriting fs side effects.
- **New CLI flags**: \`--refresh\` forces a fresh \`gh\` call (writes through to cache); \`--no-cache\` disables read AND write.
- **New cache subcommand**: \`coco cache clear-github\` purges the entire triage cache directory — companion to \`coco cache clear-parsers\`.
- **UX touch**: the repo header surfaces a \`cached Ns ago\` tag on cache hits, so users see at a glance whether they're looking at a live or recent-ish snapshot.

## Latency

Smoke test against this repo (\`coco issues --limit 2\`):
\`\`\`
cold cache:    2.18s  (gh issue list + gh auth status)
warm cache:    1.34s  (no gh calls, just node startup)
forced refresh: 1.96s  (gh call, writes back to cache)
\`\`\`

In compiled form (without the tsx warmup overhead) the warm-cache savings would be larger; the bulk of the remaining 1.34s is Node + module load, not the cache lookup itself.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm run test:jest\` — 1759 tests pass, 7 skipped (160 suites). Includes 16 new unit tests covering filter canonicalization, key derivation, write/read roundtrip, TTL fresh/stale boundary, malformed/version-mismatched envelopes, and \`clearGitHubListCache\`.
- [x] \`npx tsc --noEmit\` — clean
- [x] Manual smoke: cold/warm/refresh paths against this repo (\`coco issues --limit 2\`) all behave as expected, with the cached-age tag appearing on warm cache.
- [x] Manual smoke: \`coco cache clear-github\` reports the right cleared count and prints the empty-state message on the second run.

## Notes for review

- The cache TTL is hard-coded to 5 minutes. A user-facing knob feels premature — but the constant is exported, so a future config field can plug in trivially.
- Cache writes happen post-fetch and on the success path only. A \`gh\` error keeps the previous cache entry intact (so the next call still serves it if still within TTL).
- No new dependencies. No \`.coco.config.json\` schema changes. \`coco cache info\` is untouched (it still describes the diff-summary cache; the github cache is intentionally separate since its shape is different).