### PR TITLE
fix(ui): de-duplicate branch chip with trailing refs + cap chip width

### DIFF
--- a/src/workstation/chrome/branchTip.test.ts
+++ b/src/workstation/chrome/branchTip.test.ts
@@ -1,4 +1,4 @@
-import { getBranchTipChip } from './branchTip'
+import { filterChippedRefs, getBranchTipChip } from './branchTip'
 
 describe('getBranchTipChip', () => {
   it('returns the HEAD branch when refs include HEAD -> X', () => {
@@ -40,5 +40,44 @@ describe('getBranchTipChip', () => {
 
   it('skips a HEAD -> with an empty branch name', () => {
     expect(getBranchTipChip(['HEAD -> '])).toBeUndefined()
+  })
+})
+
+describe('filterChippedRefs', () => {
+  it('removes HEAD -> X and bare X when X is the chip', () => {
+    const refs = ['HEAD -> main', 'main', 'origin/main', 'origin/HEAD']
+    const chip = { name: 'main', isHead: true }
+    expect(filterChippedRefs(refs, chip)).toEqual(['origin/main', 'origin/HEAD'])
+  })
+
+  it('removes only the exact chip name for non-HEAD tips', () => {
+    const refs = ['claude/issues-prs-cli', 'origin/claude/issues-prs-cli']
+    const chip = { name: 'claude/issues-prs-cli', isHead: false }
+    expect(filterChippedRefs(refs, chip)).toEqual(['origin/claude/issues-prs-cli'])
+  })
+
+  it('removes the chip ref entirely when it is the only ref', () => {
+    const refs = ['origin/claude/issues-prs-cache']
+    const chip = { name: 'origin/claude/issues-prs-cache', isHead: false }
+    expect(filterChippedRefs(refs, chip)).toEqual([])
+  })
+
+  it('returns refs unchanged when there is no chip', () => {
+    const refs = ['HEAD -> main', 'origin/main']
+    expect(filterChippedRefs(refs, undefined)).toEqual(refs)
+  })
+
+  it('preserves tags even when they appear alongside the chipped branch', () => {
+    const refs = ['HEAD -> main', 'main', 'tag: v1.0.0', 'origin/main']
+    const chip = { name: 'main', isHead: true }
+    expect(filterChippedRefs(refs, chip)).toEqual(['tag: v1.0.0', 'origin/main'])
+  })
+
+  it('strips bare HEAD only when the chip is the HEAD branch', () => {
+    const refs = ['HEAD', 'main']
+    const headChip = { name: 'main', isHead: true }
+    expect(filterChippedRefs(refs, headChip)).toEqual([])
+    const nonHeadChip = { name: 'main', isHead: false }
+    expect(filterChippedRefs(refs, nonHeadChip)).toEqual(['HEAD'])
   })
 })

--- a/src/workstation/chrome/branchTip.ts
+++ b/src/workstation/chrome/branchTip.ts
@@ -26,6 +26,32 @@ export type BranchTipChip = {
   isHead: boolean
 }
 
+/**
+ * Strip refs that are already represented by a branch tip chip so the
+ * trailing `[ref] [ref]` list doesn't repeat what the chip is already
+ * showing. The chip carries the primary branch name; the trailing
+ * list keeps everything else — including remote-tracking variants
+ * (`origin/X`) and `origin/HEAD` — because those convey "remote is
+ * also at this commit" info the chip alone doesn't.
+ *
+ * Removes:
+ *   - exact match of the chipped name (`main`, `feat/foo`)
+ *   - `HEAD -> <name>` for the chipped name
+ *   - bare `HEAD` when the chip is the HEAD branch (only paranoia;
+ *     git typically emits `HEAD -> name` not both, but a detached
+ *     fixup commit may have produced both)
+ */
+export function filterChippedRefs(refs: string[], chip: BranchTipChip | undefined): string[] {
+  if (!chip) return refs
+  const headDecoration = `HEAD -> ${chip.name}`
+  return refs.filter((ref) => {
+    if (ref === chip.name) return false
+    if (ref === headDecoration) return false
+    if (chip.isHead && ref === 'HEAD') return false
+    return true
+  })
+}
+
 export function getBranchTipChip(refs: string[]): BranchTipChip | undefined {
   for (const ref of refs) {
     if (ref.startsWith('HEAD -> ')) {

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -16,7 +16,7 @@
  */
 
 import type * as ReactTypes from 'react'
-import { getBranchTipChip } from '../../chrome/branchTip'
+import { filterChippedRefs, getBranchTipChip } from '../../chrome/branchTip'
 import { formatCompactRelativeDate } from '../../chrome/dateFormat'
 import { substituteGraphChars } from '../../chrome/graphChars'
 import type { LaneSegment } from '../../chrome/graphLanes'
@@ -65,14 +65,25 @@ function pickDateText(
 }
 
 /**
+ * Maximum cells the chip body (between the brackets) is allowed to
+ * occupy. Anything longer is truncated with an ellipsis so a
+ * `[origin/claude/issues-prs-cache]` chip — 32 cells of chrome —
+ * doesn't eat the whole subject column on a narrow terminal. Picked
+ * empirically: 20 cells fits common branch shapes (`feat/foo`,
+ * `claude/graph-fidelity`, `main`) without truncation.
+ */
+const BRANCH_CHIP_MAX_NAME_WIDTH = 20
+
+/**
  * Render a colored bracket chip for a branch tip. Current branch
  * (HEAD -> X) gets the success color + bold; other branch tips get
  * info color. Tags are never chipped — they stay in the trailing ref
  * list. The chip emits its own trailing space so callers concatenate
  * it directly into the row without a separator.
  *
- * Returns `[chip, width]` so the row's truncation math knows how many
- * cells the chip will consume up front.
+ * Returns the rendered node alongside its cell width AND the chip
+ * descriptor so the caller can pass it to `filterChippedRefs` and
+ * avoid emitting the same branch a second time in the trailing list.
  */
 function renderBranchTipChip(
   h: typeof ReactTypes.createElement,
@@ -80,11 +91,16 @@ function renderBranchTipChip(
   commit: GitLogCommitRow,
   theme: LogInkTheme,
   key: string
-): { node: ReactTypes.ReactElement | null; width: number } {
+): {
+  node: ReactTypes.ReactElement | null
+  width: number
+  chip: ReturnType<typeof getBranchTipChip>
+} {
   const chip = getBranchTipChip(commit.refs)
-  if (!chip) return { node: null, width: 0 }
+  if (!chip) return { node: null, width: 0, chip }
 
-  const label = `[${chip.name}] `
+  const truncated = truncateCells(chip.name, BRANCH_CHIP_MAX_NAME_WIDTH)
+  const label = `[${truncated}] `
   const color = theme.noColor
     ? undefined
     : chip.isHead
@@ -92,7 +108,8 @@ function renderBranchTipChip(
       : theme.colors.info
   return {
     node: h(Text, { key, color, bold: chip.isHead }, label),
-    width: label.length,
+    width: cellWidth(label),
+    chip,
   }
 }
 
@@ -176,7 +193,6 @@ function renderCommitHistoryRow(
   laneSegments?: LaneSegment[],
   isRecent: boolean = false
 ): ReactTypes.ReactElement {
-  const refs = formatInkRefLabels(commit.refs)
   // Total cells available to the row content. Earlier revisions used a
   // hardcoded 140 here, which let row content overflow whenever the
   // panel was narrower than that — Ink would wrap onto a second visual
@@ -189,10 +205,13 @@ function renderCommitHistoryRow(
   // Branch chip prefix — only renders in full-graph mode so compact
   // (scan) mode stays minimal. Chip occupies cells immediately after
   // the shortHash and before the message; truncation math reserves
-  // its width before sizing the message column.
+  // its width before sizing the message column. Trailing refs filter
+  // out whatever the chip already shows so the row doesn't print
+  // `[main] feat: x [HEAD -> main]` with the same info on both ends.
   const chip = fullGraph
     ? renderBranchTipChip(h, Text, commit, theme, `${commit.hash}-${index}-chip`)
-    : { node: null, width: 0 }
+    : { node: null, width: 0, chip: undefined }
+  const refs = formatInkRefLabels(filterChippedRefs(commit.refs, chip.chip))
   const fixedWidth =
     graphWidth + 1 + commit.shortHash.length + 1 + dateSegmentWidth + chip.width
   // Refs trail the message and shrink first when the row is narrow:
@@ -292,7 +311,7 @@ function renderStackedCommitHistoryRow(
   const recentMarkerWidth = isRecent ? 2 : 0
   const chip = fullGraph
     ? renderBranchTipChip(h, Text, commit, theme, `${commit.hash}-${index}-stk-chip`)
-    : { node: null, width: 0 }
+    : { node: null, width: 0, chip: undefined }
   const lineOneFixed =
     graphWidth + 1 + commit.shortHash.length + 1 + recentMarkerWidth + chip.width
   const subject = truncateCells(commit.message, Math.max(8, totalWidth - lineOneFixed))
@@ -320,10 +339,12 @@ function renderStackedCommitHistoryRow(
   // Line 2 — metadata row, padded to align with the start of the
   // shortHash on line 1 so the eye still groups them as one commit.
   // Selection background does not extend here so we don't get a thick
-  // double-row highlight on a tight terminal.
+  // double-row highlight on a tight terminal. Trailing refs are
+  // filtered against the chip so we don't repeat the branch tip both
+  // as a leading chip and a trailing label.
   const indent = ' '.repeat(graphWidth + 1)
   const dateText = formatCompactRelativeDate(commit.date, now)
-  const refs = formatInkRefLabels(commit.refs)
+  const refs = formatInkRefLabels(filterChippedRefs(commit.refs, chip.chip))
   const metaRoom = Math.max(8, totalWidth - indent.length - (dateText ? dateText.length + 1 : 0))
   const refsTrunc = refs ? truncateCells(refs, metaRoom) : ''
   // If both pieces are empty (date unparseable + no refs), show a


### PR DESCRIPTION
## Summary

Follow-up to #963. Reviewer screenshot showed the chip and the trailing ref list printing the same branch on every chipped row — the chip was eating subject width and the trailing list was eating it again to repeat the same name:

```
●  d981ebc2  2026-05-14  [main] feat: x [HEAD -> main] [origin/main]
●  3b00204d  2026-05-14  [origin/...issues-prs-cache] feat(... [origin/...issues-prs-cache...
```

### Two fixes

**1. `filterChippedRefs` strips refs the chip already shows.** When we chip `main`, we drop the bare `main` ref and `HEAD -> main` from the trailing list. Tags and remote-tracking variants (`origin/main`, `origin/HEAD`) stay — those carry remote-sync info the chip alone doesn't convey, so they're not redundant.

**2. Chip name truncates to 20 cells.** A branch like `origin/claude/issues-prs-cache` was consuming 32 cells of chrome and reducing the subject to two characters on common terminal widths. Truncated with the existing `truncateCells` ellipsis behavior.

After the fix:

```
●  d981ebc2  2026-05-14  [main] feat: x [origin/main]
●  3b00204d  2026-05-14  [origin/claude/issu…] feat: y
```

## Test plan

- [x] `chrome/branchTip.test.ts` — 6 new tests covering: HEAD branch filtering, plain-tip filtering, single-ref collapse, no-chip passthrough, tag preservation, bare-HEAD edge.
- [x] Full jest suite passes (1700 tests).
- [x] `npm run lint` clean.
- [x] Typecheck clean.
- [ ] Manual UI verification — sandbox limitation as before. Reviewer should re-test the original screenshot scenario in a repo with several branch tips to confirm the chips no longer duplicate.

## Notes

- `BRANCH_CHIP_MAX_NAME_WIDTH = 20` is in `surfaces/history/index.ts` — happy to push it to layout if we end up wanting density-tier-based caps later, but for now one constant felt right.
- The filter deliberately keeps `origin/HEAD` even when the chip is the HEAD branch, since that's the "remote default points here" signal and visually compact.