### PR TITLE
feat(ui): conventional commit type coloring in history rows

### DIFF
--- a/src/workstation/chrome/conventionalCommit.test.ts
+++ b/src/workstation/chrome/conventionalCommit.test.ts
@@ -1,0 +1,128 @@
+import {
+  getConventionalCommitColor,
+  parseConventionalCommitPrefix,
+} from './conventionalCommit'
+import type { LogInkTheme } from './theme'
+
+const theme: LogInkTheme = {
+  ascii: false,
+  noColor: false,
+  borderStyle: 'round',
+  colors: {
+    accent: '#cba6f7',
+    muted: '#7f849c',
+    selection: '#313244',
+    success: '#a6e3a1',
+    warning: '#f9e2af',
+    danger: '#f38ba8',
+    info: '#89b4fa',
+  },
+}
+
+describe('parseConventionalCommitPrefix', () => {
+  it('parses a bare type prefix', () => {
+    expect(parseConventionalCommitPrefix('feat: add login flow')).toEqual({
+      prefix: 'feat: ',
+      rest: 'add login flow',
+      type: 'feat',
+      scope: undefined,
+      breaking: false,
+    })
+  })
+
+  it('parses a typed prefix with a scope', () => {
+    expect(parseConventionalCommitPrefix('feat(cli): wire --repo flag')).toEqual({
+      prefix: 'feat(cli): ',
+      rest: 'wire --repo flag',
+      type: 'feat',
+      scope: 'cli',
+      breaking: false,
+    })
+  })
+
+  it('captures the breaking marker without a scope', () => {
+    expect(parseConventionalCommitPrefix('fix!: drop legacy field')).toMatchObject({
+      type: 'fix',
+      scope: undefined,
+      breaking: true,
+    })
+  })
+
+  it('captures the breaking marker with a scope', () => {
+    expect(parseConventionalCommitPrefix('chore(deps)!: bump react')).toMatchObject({
+      type: 'chore',
+      scope: 'deps',
+      breaking: true,
+    })
+  })
+
+  it('returns undefined for unconventional subjects', () => {
+    expect(parseConventionalCommitPrefix('Add login flow')).toBeUndefined()
+    expect(parseConventionalCommitPrefix('Merge branch foo into bar')).toBeUndefined()
+    expect(parseConventionalCommitPrefix('')).toBeUndefined()
+  })
+
+  it('does not match types with uppercase characters', () => {
+    expect(parseConventionalCommitPrefix('Feat: add thing')).toBeUndefined()
+    expect(parseConventionalCommitPrefix('FIX: typo')).toBeUndefined()
+  })
+
+  it('requires a space after the colon', () => {
+    // Conventional spec: prefix is `type: ` with whitespace; without
+    // the space we shouldn't claim a match (otherwise `noun: phrase`
+    // sentences would all parse as a type).
+    expect(parseConventionalCommitPrefix('feat:add thing')).toBeUndefined()
+  })
+
+  it('handles multi-character scopes including slashes', () => {
+    expect(parseConventionalCommitPrefix('feat(parser/ts): bundle wasm')).toMatchObject({
+      type: 'feat',
+      scope: 'parser/ts',
+    })
+  })
+})
+
+describe('getConventionalCommitColor', () => {
+  const parse = (msg: string) => parseConventionalCommitPrefix(msg)!
+
+  it('maps feat to success', () => {
+    expect(getConventionalCommitColor(parse('feat: x'), theme)).toBe(theme.colors.success)
+  })
+
+  it('maps fix to warning', () => {
+    expect(getConventionalCommitColor(parse('fix: x'), theme)).toBe(theme.colors.warning)
+  })
+
+  it('maps docs / refactor / perf to info', () => {
+    for (const msg of ['docs: x', 'refactor: x', 'perf: x']) {
+      expect(getConventionalCommitColor(parse(msg), theme)).toBe(theme.colors.info)
+    }
+  })
+
+  it('maps housekeeping types to muted', () => {
+    for (const msg of ['test: x', 'style: x', 'build: x', 'ci: x', 'chore: x']) {
+      expect(getConventionalCommitColor(parse(msg), theme)).toBe(theme.colors.muted)
+    }
+  })
+
+  it('maps revert to danger', () => {
+    expect(getConventionalCommitColor(parse('revert: x'), theme)).toBe(theme.colors.danger)
+  })
+
+  it('falls through to accent for unknown types', () => {
+    expect(getConventionalCommitColor(parse('wip: x'), theme)).toBe(theme.colors.accent)
+  })
+
+  it('overrides type color with danger when the change is breaking', () => {
+    // Breaking feat still reads as "stop and look" — the danger color
+    // wins over the per-type mapping.
+    expect(getConventionalCommitColor(parse('feat!: x'), theme)).toBe(theme.colors.danger)
+    expect(getConventionalCommitColor(parse('chore(deps)!: x'), theme)).toBe(theme.colors.danger)
+  })
+
+  it('returns undefined under noColor regardless of type', () => {
+    const noColorTheme = { ...theme, noColor: true }
+    expect(getConventionalCommitColor(parse('feat: x'), noColorTheme)).toBeUndefined()
+    expect(getConventionalCommitColor(parse('fix!: x'), noColorTheme)).toBeUndefined()
+  })
+})

--- a/src/workstation/chrome/conventionalCommit.ts
+++ b/src/workstation/chrome/conventionalCommit.ts
@@ -1,0 +1,105 @@
+import type { LogInkTheme } from './theme'
+
+/**
+ * Parse the leading conventional-commit prefix out of a subject line
+ * so the history renderer can paint it in a type-specific color.
+ *
+ * Recognized shape:
+ *   <type>[(<scope>)][!]: <description>
+ *
+ * Examples that parse:
+ *   `feat: add login`              → type=feat, scope=undefined, breaking=false
+ *   `feat(cli): wire flag`         → type=feat, scope=cli, breaking=false
+ *   `fix!: drop legacy field`      → type=fix, scope=undefined, breaking=true
+ *   `chore(deps)!: bump react`     → type=chore, scope=deps, breaking=true
+ *
+ * Returns `undefined` for anything that doesn't look conventional —
+ * the renderer then falls through to plain text and the row reads
+ * unchanged. Type must be all-lowercase ASCII so a sentence that
+ * happens to start with `Subject:` doesn't get matched as the
+ * `subject` type.
+ *
+ * `prefix` is the matched text including the trailing `: ` so the
+ * caller can render it as one colored span and the unmatched
+ * remainder as another, without re-measuring widths.
+ */
+export type ConventionalCommitPrefix = {
+  /** Full matched prefix including trailing `: `, ready to render. */
+  prefix: string
+  /** Subject text after the prefix; possibly empty. */
+  rest: string
+  /** The type token (`feat`, `fix`, …). Lowercase by construction. */
+  type: string
+  /** Optional scope captured between parens, or `undefined`. */
+  scope?: string
+  /** True when the prefix contained the breaking-change `!` marker. */
+  breaking: boolean
+}
+
+const PREFIX_PATTERN = /^([a-z]+)(\(([^)]+)\))?(!)?:\s+/
+
+export function parseConventionalCommitPrefix(
+  message: string
+): ConventionalCommitPrefix | undefined {
+  const match = PREFIX_PATTERN.exec(message)
+  if (!match) return undefined
+
+  const [whole, type, , scope, breakingMarker] = match
+  return {
+    prefix: whole,
+    rest: message.slice(whole.length),
+    type,
+    scope: scope || undefined,
+    breaking: Boolean(breakingMarker),
+  }
+}
+
+/**
+ * Pick the theme color used to paint a conventional-commit prefix.
+ *
+ * Rough mapping intent:
+ *   - feat                       → success  (new capability, growth)
+ *   - fix                        → warning  (was a problem; eye-catch)
+ *   - docs / refactor / perf     → info / accent (intent-bearing change)
+ *   - test / style / build / ci  → muted    (mechanical / housekeeping)
+ *   - chore                      → muted
+ *   - revert                     → danger   (signals "this undid something")
+ *
+ * Unknown types fall through to `accent` so a project-specific
+ * convention (`wip:`, `release:`, etc.) still reads as the typed
+ * prefix rather than blending into the subject. Returns `undefined`
+ * under `theme.noColor` so the prefix stays plain — the textual
+ * `feat:` carries the meaning by itself.
+ *
+ * Breaking changes (`!:`) override the type color with `danger` so
+ * the row reads as "stop and look at this" regardless of which type
+ * it is.
+ */
+export function getConventionalCommitColor(
+  parsed: ConventionalCommitPrefix,
+  theme: LogInkTheme
+): string | undefined {
+  if (theme.noColor) return undefined
+  if (parsed.breaking) return theme.colors.danger
+
+  switch (parsed.type) {
+    case 'feat':
+      return theme.colors.success
+    case 'fix':
+      return theme.colors.warning
+    case 'docs':
+    case 'refactor':
+    case 'perf':
+      return theme.colors.info
+    case 'test':
+    case 'style':
+    case 'build':
+    case 'ci':
+    case 'chore':
+      return theme.colors.muted
+    case 'revert':
+      return theme.colors.danger
+    default:
+      return theme.colors.accent
+  }
+}

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -17,6 +17,10 @@
 
 import type * as ReactTypes from 'react'
 import { filterChippedRefs, getBranchTipChip } from '../../chrome/branchTip'
+import {
+  getConventionalCommitColor,
+  parseConventionalCommitPrefix,
+} from '../../chrome/conventionalCommit'
 import { formatCompactRelativeDate } from '../../chrome/dateFormat'
 import { substituteGraphChars } from '../../chrome/graphChars'
 import type { LaneSegment } from '../../chrome/graphLanes'
@@ -118,6 +122,43 @@ function formatHistoryFetchArgs(args: LogInkHistoryFetchArgs): string {
   if (args.author) parts.push(`--author=${args.author}`)
   if (args.path) parts.push(`-- ${args.path}`)
   return parts.join(' ') || 'none'
+}
+
+/**
+ * Render a commit subject with the conventional-commit prefix
+ * (`feat:`, `fix(scope)!:`, …) painted in a type-specific color so
+ * the eye can bucket commits by type while scanning.
+ *
+ * Truncation lives at the message level above this helper — the
+ * caller has already shortened `text` to the available room. We just
+ * split on the parsed prefix length and emit two spans. If the
+ * shortened text is too narrow to include the full prefix (e.g. a
+ * tight panel that cut into `feat`), we fall back to a single plain
+ * span so the partial prefix doesn't read as a malformed colored
+ * fragment.
+ *
+ * Returns the spans flat so the caller can splat them into the row's
+ * outer Text alongside other segments without an extra wrapper.
+ */
+function renderTypedSubject(
+  h: typeof ReactTypes.createElement,
+  Text: LogInkComponents['Text'],
+  text: string,
+  theme: LogInkTheme,
+  key: string
+): ReactTypes.ReactElement[] {
+  const parsed = parseConventionalCommitPrefix(text)
+  if (!parsed) {
+    return [h(Text, { key: `${key}-msg` }, text)]
+  }
+  if (text.length < parsed.prefix.length) {
+    return [h(Text, { key: `${key}-msg` }, text)]
+  }
+  const color = getConventionalCommitColor(parsed, theme)
+  return [
+    h(Text, { key: `${key}-type`, color, bold: parsed.breaking }, parsed.prefix),
+    h(Text, { key: `${key}-rest` }, text.slice(parsed.prefix.length)),
+  ]
 }
 
 /**
@@ -268,7 +309,7 @@ function renderCommitHistoryRow(
   // Branch chip prefix (full-graph mode only) lands right before the
   // message so the eye reads "branch · subject" as a unit.
   chip.node,
-  h(Text, undefined, message),
+  ...renderTypedSubject(h, Text, message, theme, `${commit.hash}-${index}-subj`),
   refsTrunc ? h(Text, { color: accent }, refsTrunc) : null)
 }
 
@@ -334,7 +375,7 @@ function renderStackedCommitHistoryRow(
   h(Text, { color: accent, bold: selected || isRecent }, commit.shortHash),
   ' ',
   chip.node,
-  h(Text, undefined, subject))
+  ...renderTypedSubject(h, Text, subject, theme, `${commit.hash}-${index}-stk-subj`))
 
   // Line 2 — metadata row, padded to align with the start of the
   // shortHash on line 1 so the eye still groups them as one commit.


### PR DESCRIPTION
## Summary

Paint the conventional-commit prefix in a type-specific color so the eye buckets commits by type while scanning the history list. Pure colorization — no width cost, no behavior change.

| Type prefix                                        | Color   | Intent                       |
| -------------------------------------------------- | ------- | ---------------------------- |
| `feat:` / `feat(scope):`                           | success | new capability, growth       |
| `fix:` / `fix(scope):`                             | warning | was a problem, eye-catch     |
| `docs:` / `refactor:` / `perf:`                    | info    | intent-bearing change        |
| `test:` / `style:` / `build:` / `ci:` / `chore:`   | muted   | housekeeping                 |
| `revert:`                                          | danger  | undid something              |
| unknown types (`wip:`, `release:`, …)              | accent  | typed but not in the table   |
| any `!:` (breaking)                                | danger + **bold** | overrides type color |

## How it works

- New parser at [chrome/conventionalCommit.ts](src/workstation/chrome/conventionalCommit.ts) matches `^([a-z]+)(\(scope\))?(!)?:\s+` with two guardrails: lowercase-only type so `Subject: Re: …` doesn't false-match, and required trailing space so `noun:phrase` sentences don't either.
- New `renderTypedSubject` helper in [surfaces/history/index.ts](src/workstation/surfaces/history/index.ts) splits the message into two colored spans for typed commits, one plain span for everything else. Falls back to plain when the row's truncation budget couldn't fit the full prefix.
- Applies in **both** full and compact graph modes since the change costs zero cells.
- Under `theme.noColor` the prefix stays plain — the literal `feat:` already carries the meaning.

## Test plan

- [x] `chrome/conventionalCommit.test.ts` — 16 unit tests covering bare type, scoped, breaking variants, scope with slashes, uppercase rejection, missing-space rejection, every color mapping, unknown-type fallback, breaking override, noColor.
- [x] Full jest suite: 1781 pass / 7 skipped, no regressions.
- [x] `npm run lint` clean.
- [x] `npm run build` produces dist bundles.
- [x] `npm run test:cli` smoke tests pass.
- [ ] Manual UI verification — sandbox can't render TTY. Reviewer should open `coco ui` in a repo with mixed `feat:` / `fix:` / `chore:` commits and confirm the prefixes pop in the expected colors.

## Notes

- Color values come from `theme.colors.{success,warning,info,muted,accent,danger}` which already exist in the theme; no new tokens.
- The breaking-change `!` marker overrides the per-type color globally so a "breaking feat" reads as "stop and look" regardless of its base type.
- Date bucketing (the bigger refactor we discussed) lands as a follow-up PR after this one — keeping the two changes separate so coloring can ship immediately and bucketing can take its time.