### PR TITLE
feat(workstation): issues + PR triage TUI surfaces (#882 phase 3)

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -3412,3 +3412,79 @@ describe('log Ink input interactions', () => {
     })
   })
 })
+
+describe('issue / pull-request triage chords (#882 phase 3)', () => {
+  it('pushes the issues view with the gi chord', () => {
+    let state = createLogInkState(rows)
+
+    state = applyInput(state, 'g')
+    expect(state.pendingKey).toBe('g')
+
+    state = applyInput(state, 'i')
+    expect(state.activeView).toBe('issues')
+    expect(state.viewStack).toContain('issues')
+    expect(state.pendingKey).toBeUndefined()
+  })
+
+  it('pushes the pull-request-triage view with the gP chord', () => {
+    let state = createLogInkState(rows)
+
+    state = applyInput(state, 'g')
+    state = applyInput(state, 'P')
+
+    expect(state.activeView).toBe('pull-request-triage')
+    expect(state.viewStack).toContain('pull-request-triage')
+  })
+
+  it('preserves the existing gp chord for the single-PR action panel', () => {
+    // Regression guard: capital-P must not steal the lowercase-p
+    // binding. The single-PR panel and the multi-PR triage list are
+    // separate surfaces, both reachable from the root.
+    let state = createLogInkState(rows)
+
+    state = applyInput(state, 'g')
+    state = applyInput(state, 'p')
+
+    expect(state.activeView).toBe('pull-request')
+  })
+
+  it('j on the issues view increments selectedIssueIndex when there are items', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'issues' })
+
+    state = applyInput(state, 'j', {}, { issueCount: 5 })
+    expect(state.selectedIssueIndex).toBe(1)
+
+    state = applyInput(state, 'j', {}, { issueCount: 5 })
+    expect(state.selectedIssueIndex).toBe(2)
+  })
+
+  it('k on the issues view decrements selectedIssueIndex', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'issues' })
+    state = { ...state, selectedIssueIndex: 3 }
+
+    state = applyInput(state, 'k', {}, { issueCount: 5 })
+    expect(state.selectedIssueIndex).toBe(2)
+  })
+
+  it('j on the pull-request-triage view increments selectedPullRequestTriageIndex', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'pull-request-triage' })
+
+    state = applyInput(state, 'j', {}, { pullRequestTriageCount: 4 })
+    expect(state.selectedPullRequestTriageIndex).toBe(1)
+  })
+
+  it('j on the issues view falls through to the commit-move fallback when issueCount is 0', () => {
+    // Mirrors the existing pattern for the other promoted views — the
+    // j/k branch only claims the keystroke when there are items to
+    // navigate. Empty list → keystroke falls through to the default
+    // sidebar / move handler.
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'issues' })
+
+    state = applyInput(state, 'j', {}, {})
+    expect(state.selectedIssueIndex).toBe(0)
+  })
+})

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -96,6 +96,14 @@ export type LogInkInputContext = {
   submoduleCount?: number
   /** Repo-relative path of the cursored submodule (#932). Reserved for future per-entry actions. */
   submoduleSelectedPath?: string
+  /** Number of issues in the triage list view (#882 phase 3). Drives j/k navigation. */
+  issueCount?: number
+  /** URL of the cursored issue (#882 phase 3). Used by `O` to open in the browser. */
+  issueSelectedUrl?: string
+  /** Number of PRs in the triage list view (#882 phase 3). Drives j/k navigation. */
+  pullRequestTriageCount?: number
+  /** URL of the cursored PR in the triage list view (#882 phase 3). */
+  pullRequestTriageSelectedUrl?: string
   worktreeListCount?: number
   /** Ref of the stash currently under the cursor (e.g. `stash@{0}`). */
   stashSelectedRef?: string
@@ -372,6 +380,24 @@ function isSubmodulesActionTarget(state: LogInkState): boolean {
   return state.activeView === 'submodules' && state.focus === 'commits'
 }
 
+/**
+ * Issue triage list (#882 phase 3). Same shape as the other promoted
+ * read-only views — j/k move the cursor when the commits pane is
+ * focused on the dedicated view.
+ */
+function isIssueActionTarget(state: LogInkState): boolean {
+  return state.activeView === 'issues' && state.focus === 'commits'
+}
+
+/**
+ * Pull-request triage list (#882 phase 3). Distinct from the existing
+ * `pull-request` single-PR action panel — this is the multi-PR list
+ * surface and its cursor lives in `selectedPullRequestTriageIndex`.
+ */
+function isPullRequestTriageActionTarget(state: LogInkState): boolean {
+  return state.activeView === 'pull-request-triage' && state.focus === 'commits'
+}
+
 function isWorktreeActionTarget(state: LogInkState): boolean {
   return (state.activeView === 'worktrees' && state.focus === 'commits') ||
     (state.focus === 'sidebar' && state.sidebarTab === 'worktrees')
@@ -534,6 +560,10 @@ export function getLogInkPaletteExecuteEvents(
       return [action({ type: 'pushView', value: 'worktrees' })]
     case 'navigatePullRequest':
       return [action({ type: 'pushView', value: 'pull-request' })]
+    case 'navigatePullRequestTriage':
+      return [action({ type: 'pushView', value: 'pull-request-triage' })]
+    case 'navigateIssues':
+      return [action({ type: 'pushView', value: 'issues' })]
     case 'navigateConflicts':
       return [action({ type: 'pushView', value: 'conflicts' })]
     case 'navigateReflog':
@@ -1197,6 +1227,25 @@ export function getLogInkInputEvents(
     ]
   }
 
+  // `gP` chord (#882 phase 3): jump to the multi-PR triage list.
+  // Capital P disambiguates from `gp` (current-branch PR panel).
+  // Pleasingly symmetric with `gi` for issues — both lead to the
+  // read-only list views shipped in #882.
+  if (state.pendingKey === 'g' && inputValue === 'P') {
+    return [
+      action({ type: 'pushView', value: 'pull-request-triage' }),
+      action({ type: 'setStatus', value: 'jumped to PR triage' }),
+    ]
+  }
+
+  // `gi` chord (#882 phase 3): jump to the issue triage list.
+  if (state.pendingKey === 'g' && inputValue === 'i') {
+    return [
+      action({ type: 'pushView', value: 'issues' }),
+      action({ type: 'setStatus', value: 'jumped to issues' }),
+    ]
+  }
+
   if (state.pendingKey === 'g' && inputValue === 'x') {
     return [
       action({ type: 'pushView', value: 'conflicts' }),
@@ -1682,6 +1731,18 @@ export function getLogInkInputEvents(
       return [action({ type: 'moveSubmodule', delta: -1, count: context.submoduleCount })]
     }
 
+    if (isIssueActionTarget(state) && context.issueCount) {
+      return [action({ type: 'moveIssue', delta: -1, count: context.issueCount })]
+    }
+
+    if (isPullRequestTriageActionTarget(state) && context.pullRequestTriageCount) {
+      return [action({
+        type: 'movePullRequestTriage',
+        delta: -1,
+        count: context.pullRequestTriageCount,
+      })]
+    }
+
     if (isWorktreeActionTarget(state) && context.worktreeListCount) {
       return [action({ type: 'moveWorktreeListEntry', delta: -1, count: context.worktreeListCount })]
     }
@@ -1785,6 +1846,18 @@ export function getLogInkInputEvents(
 
     if (isSubmodulesActionTarget(state) && context.submoduleCount) {
       return [action({ type: 'moveSubmodule', delta: 1, count: context.submoduleCount })]
+    }
+
+    if (isIssueActionTarget(state) && context.issueCount) {
+      return [action({ type: 'moveIssue', delta: 1, count: context.issueCount })]
+    }
+
+    if (isPullRequestTriageActionTarget(state) && context.pullRequestTriageCount) {
+      return [action({
+        type: 'movePullRequestTriage',
+        delta: 1,
+        count: context.pullRequestTriageCount,
+      })]
     }
 
     if (isWorktreeActionTarget(state) && context.worktreeListCount) {

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -27,7 +27,9 @@ export type LogInkCommandId =
   | 'navigateDiff'
   | 'navigateHome'
   | 'navigateBisect'
+  | 'navigateIssues'
   | 'navigatePullRequest'
+  | 'navigatePullRequestTriage'
   | 'navigateReflog'
   | 'navigateStash'
   | 'navigateSubmodules'
@@ -261,6 +263,20 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     keys: ['gp'],
     label: 'pull request',
     description: 'Push the dedicated pull-request action panel for the current branch.',
+    contexts: ['normal'],
+  },
+  {
+    id: 'navigatePullRequestTriage',
+    keys: ['gP'],
+    label: 'PR triage',
+    description: 'Push the multi-PR triage list view (#882). Capital P disambiguates from `gp` which targets the single-PR panel for the current branch.',
+    contexts: ['normal'],
+  },
+  {
+    id: 'navigateIssues',
+    keys: ['gi'],
+    label: 'issues',
+    description: 'Push the issue triage list view (#882).',
     contexts: ['normal'],
   },
   {
@@ -506,6 +522,8 @@ const GLOBAL_BINDING_IDS: LogInkCommandId[] = [
   'navigateStash',
   'navigateWorktrees',
   'navigatePullRequest',
+  'navigatePullRequestTriage',
+  'navigateIssues',
   'navigateConflicts',
   'navigateReflog',
   'navigateBisect',
@@ -762,6 +780,25 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
   if (options.activeView === 'reflog') {
     return {
       contextual: ['↑/↓ entries', 'enter inspect', 'esc back'],
+      global: NORMAL_GLOBAL_HINTS,
+    }
+  }
+
+  if (options.activeView === 'issues') {
+    return {
+      // #882 phase 3 — read-only triage list. Per-row actions
+      // (label, assign, comment, close) land in phase 4-5.
+      contextual: ['↑/↓ issues', 'esc back'],
+      global: NORMAL_GLOBAL_HINTS,
+    }
+  }
+
+  if (options.activeView === 'pull-request-triage') {
+    return {
+      // #882 phase 3 — read-only triage list. Per-row actions
+      // (merge, approve, request-changes, close, comment) land
+      // in phase 4-5.
+      contextual: ['↑/↓ PRs', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -1448,3 +1448,56 @@ describe('log Ink view model', () => {
     })
   })
 })
+
+describe('issue / pull-request triage navigation (#882 phase 3)', () => {
+  it('createLogInkState seeds selectedIssueIndex / selectedPullRequestTriageIndex to 0', () => {
+    const state = createLogInkState(rows)
+    expect(state.selectedIssueIndex).toBe(0)
+    expect(state.selectedPullRequestTriageIndex).toBe(0)
+  })
+
+  it('moveIssue advances the cursor and clamps to count - 1', () => {
+    let state = createLogInkState(rows)
+
+    state = applyLogInkAction(state, { type: 'moveIssue', delta: 3, count: 5 })
+    expect(state.selectedIssueIndex).toBe(3)
+
+    // Clamps at count - 1 — no wrap.
+    state = applyLogInkAction(state, { type: 'moveIssue', delta: 10, count: 5 })
+    expect(state.selectedIssueIndex).toBe(4)
+
+    // Negative delta clamps at 0.
+    state = applyLogInkAction(state, { type: 'moveIssue', delta: -99, count: 5 })
+    expect(state.selectedIssueIndex).toBe(0)
+  })
+
+  it('movePullRequestTriage advances independently from selectedIssueIndex', () => {
+    let state = createLogInkState(rows)
+
+    state = applyLogInkAction(state, { type: 'moveIssue', delta: 2, count: 5 })
+    state = applyLogInkAction(state, { type: 'movePullRequestTriage', delta: 1, count: 3 })
+
+    expect(state.selectedIssueIndex).toBe(2)
+    expect(state.selectedPullRequestTriageIndex).toBe(1)
+  })
+
+  it('move actions clear any pending chord prefix', () => {
+    let state = createLogInkState(rows)
+    state = { ...state, pendingKey: 'g' }
+
+    state = applyLogInkAction(state, { type: 'moveIssue', delta: 1, count: 5 })
+    expect(state.pendingKey).toBeUndefined()
+  })
+
+  it('pushView accepts the new triage view ids', () => {
+    let state = createLogInkState(rows)
+
+    state = applyLogInkAction(state, { type: 'pushView', value: 'issues' })
+    expect(state.activeView).toBe('issues')
+    expect(state.viewStack).toContain('issues')
+
+    state = applyLogInkAction(state, { type: 'pushView', value: 'pull-request-triage' })
+    expect(state.activeView).toBe('pull-request-triage')
+    expect(state.viewStack).toContain('pull-request-triage')
+  })
+})

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -19,7 +19,7 @@ import {
 export type LogInkFocus = 'sidebar' | 'commits' | 'detail'
 
 export type LogInkSidebarTab = 'status' | 'branches' | 'tags' | 'stashes' | 'worktrees'
-export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash' | 'worktrees' | 'pull-request' | 'conflicts' | 'reflog' | 'bisect' | 'changelog' | 'submodules'
+export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash' | 'worktrees' | 'pull-request' | 'pull-request-triage' | 'issues' | 'conflicts' | 'reflog' | 'bisect' | 'changelog' | 'submodules'
 export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk' | 'discard-draft'
 
 /**
@@ -165,6 +165,19 @@ export type LogInkState = {
    * their place.
    */
   selectedSubmoduleIndex: number
+  /**
+   * Cursor for the issues triage view (#882). Same lifecycle as the
+   * other promoted-view indices — preserved across navigations so
+   * the user can drill into an issue's preview and back without
+   * losing their place in the list.
+   */
+  selectedIssueIndex: number
+  /**
+   * Cursor for the pull-request triage view (#882). Distinct from
+   * the existing single-PR action panel (`pull-request`); this index
+   * drives the multi-PR list view (`pull-request-triage`).
+   */
+  selectedPullRequestTriageIndex: number
   /**
    * Nested-repo navigation stack (#931). Always at least one entry
    * — the root frame for the repo `coco ui` was launched against.
@@ -575,6 +588,8 @@ export type LogInkAction =
   | { type: 'moveStash'; delta: number; count: number }
   | { type: 'moveReflog'; delta: number; count: number }
   | { type: 'moveSubmodule'; delta: number; count: number }
+  | { type: 'moveIssue'; delta: number; count: number }
+  | { type: 'movePullRequestTriage'; delta: number; count: number }
   | { type: 'moveWorktreeListEntry'; delta: number; count: number }
   | { type: 'moveConflictFile'; delta: number; count: number }
   | { type: 'moveToBottom' }
@@ -991,6 +1006,8 @@ export function createLogInkState(
     selectedConflictFileIndex: 0,
     selectedReflogIndex: 0,
     selectedSubmoduleIndex: 0,
+    selectedIssueIndex: 0,
+    selectedPullRequestTriageIndex: 0,
     repoStack: [{ label: options.repoLabel || 'root' }],
     branchSort: DEFAULT_BRANCH_SORT_MODE,
     tagSort: DEFAULT_TAG_SORT_MODE,
@@ -1291,6 +1308,21 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         selectedSubmoduleIndex: clampIndex(state.selectedSubmoduleIndex + action.delta, action.count),
+        pendingKey: undefined,
+      }
+    case 'moveIssue':
+      return {
+        ...state,
+        selectedIssueIndex: clampIndex(state.selectedIssueIndex + action.delta, action.count),
+        pendingKey: undefined,
+      }
+    case 'movePullRequestTriage':
+      return {
+        ...state,
+        selectedPullRequestTriageIndex: clampIndex(
+          state.selectedPullRequestTriageIndex + action.delta,
+          action.count
+        ),
         pendingKey: undefined,
       }
     case 'moveWorktreeListEntry':

--- a/src/workstation/chrome/context.ts
+++ b/src/workstation/chrome/context.ts
@@ -1,10 +1,12 @@
 export const LOG_INK_CONTEXT_KEYS = [
   'bisect',
   'branches',
+  'issueList',
   'lfs',
   'operation',
   'provider',
   'pullRequest',
+  'pullRequestList',
   'reflog',
   'stashes',
   'submodules',

--- a/src/workstation/chrome/previewPane.triage.test.ts
+++ b/src/workstation/chrome/previewPane.triage.test.ts
@@ -1,0 +1,141 @@
+import {
+  formatIssueTriagePreview,
+  formatPullRequestTriagePreview,
+} from './previewPane'
+import type { IssueListItem } from '../../git/issuesListData'
+import type { PullRequestListItem } from '../../git/pullRequestListData'
+
+const stripLine = (line: { text: string }) => line.text
+
+describe('formatIssueTriagePreview', () => {
+  it('returns a uniform empty-state message when nothing is cursored', () => {
+    const lines = formatIssueTriagePreview(undefined).map(stripLine)
+    expect(lines).toEqual(['Select an issue to preview.'])
+  })
+
+  it('renders the canonical fields when an issue is cursored', () => {
+    const issue: IssueListItem = {
+      number: 882,
+      title: 'TUI shell · issue / PR triage workflow',
+      url: 'https://github.com/gfargo/coco/issues/882',
+      state: 'OPEN',
+      author: 'gfargo',
+      assignees: ['reviewer-a', 'reviewer-b'],
+      labels: ['enhancement', 'tui'],
+      comments: 3,
+      createdAt: '2026-04-01T00:00:00Z',
+      updatedAt: '2026-05-01T00:00:00Z',
+    }
+
+    const lines = formatIssueTriagePreview(issue).map(stripLine)
+
+    expect(lines[0]).toContain('#882')
+    expect(lines[0]).toContain('TUI shell · issue / PR triage workflow')
+    expect(lines.some((l) => l.includes('open'))).toBe(true)
+    expect(lines.some((l) => l.includes('gfargo'))).toBe(true)
+    expect(lines.some((l) => l.includes('reviewer-a, reviewer-b'))).toBe(true)
+    expect(lines.some((l) => l.includes('enhancement, tui'))).toBe(true)
+    expect(lines.some((l) => l.includes('Comments: 3'))).toBe(true)
+    expect(lines.some((l) => l.includes('2026-04-01'))).toBe(true)
+    expect(lines.some((l) => l.includes('https://github.com/gfargo/coco/issues/882'))).toBe(true)
+  })
+
+  it('omits optional rows when the underlying fields are missing', () => {
+    const issue: IssueListItem = {
+      number: 1,
+      title: 'minimal',
+      url: 'u',
+      state: 'CLOSED',
+      createdAt: '',
+      updatedAt: '',
+    }
+
+    const lines = formatIssueTriagePreview(issue).map(stripLine)
+
+    expect(lines.some((l) => l.startsWith('Author:'))).toBe(false)
+    expect(lines.some((l) => l.startsWith('Assigned:'))).toBe(false)
+    expect(lines.some((l) => l.startsWith('Labels:'))).toBe(false)
+    expect(lines.some((l) => l.startsWith('Comments:'))).toBe(false)
+    expect(lines.some((l) => l.includes('closed'))).toBe(true)
+  })
+})
+
+describe('formatPullRequestTriagePreview', () => {
+  it('returns a uniform empty-state message when nothing is cursored', () => {
+    const lines = formatPullRequestTriagePreview(undefined).map(stripLine)
+    expect(lines).toEqual(['Select a pull request to preview.'])
+  })
+
+  it('renders the canonical fields when a PR is cursored', () => {
+    const pr: PullRequestListItem = {
+      number: 962,
+      title: 'feat(commit-split): dedupe rescues',
+      url: 'https://github.com/gfargo/coco/pull/962',
+      state: 'OPEN',
+      isDraft: false,
+      headRefName: 'claude/x',
+      baseRefName: 'main',
+      author: 'gfargo',
+      assignees: ['reviewer'],
+      labels: ['enhancement'],
+      reviewDecision: 'APPROVED',
+      mergeable: 'MERGEABLE',
+      mergeStateStatus: 'CLEAN',
+      createdAt: '2026-05-14T00:00:00Z',
+      updatedAt: '2026-05-14T00:00:00Z',
+    }
+
+    const lines = formatPullRequestTriagePreview(pr).map(stripLine)
+
+    expect(lines[0]).toContain('#962')
+    expect(lines[0]).toContain('feat(commit-split)')
+    expect(lines.some((l) => l.includes('open'))).toBe(true)
+    expect(lines.some((l) => l.includes('claude/x → main'))).toBe(true)
+    expect(lines.some((l) => l.toLowerCase().includes('mergeable'))).toBe(true)
+    expect(lines.some((l) => l.includes('approved'))).toBe(true)
+    expect(lines.some((l) => l.includes('reviewer'))).toBe(true)
+    expect(lines.some((l) => l.includes('enhancement'))).toBe(true)
+    expect(lines.some((l) => l.includes('https://github.com/gfargo/coco/pull/962'))).toBe(true)
+  })
+
+  it('renders the draft state distinctly from open', () => {
+    const pr: PullRequestListItem = {
+      number: 5,
+      title: 'wip',
+      url: 'u',
+      state: 'OPEN',
+      isDraft: true,
+      headRefName: 'wip',
+      baseRefName: 'main',
+      createdAt: '',
+      updatedAt: '',
+    }
+
+    const lines = formatPullRequestTriagePreview(pr).map(stripLine)
+
+    const stateLine = lines.find((l) => l.startsWith('State:'))
+    expect(stateLine).toBeDefined()
+    expect(stateLine).toContain('draft')
+    expect(stateLine).not.toContain('open')
+  })
+
+  it('humanizes review decision underscores', () => {
+    const pr: PullRequestListItem = {
+      number: 5,
+      title: 'wip',
+      url: 'u',
+      state: 'OPEN',
+      isDraft: false,
+      headRefName: 'h',
+      baseRefName: 'm',
+      reviewDecision: 'CHANGES_REQUESTED',
+      createdAt: '',
+      updatedAt: '',
+    }
+
+    const lines = formatPullRequestTriagePreview(pr).map(stripLine)
+
+    expect(lines.some((l) => l.includes('changes requested'))).toBe(true)
+    expect(lines.some((l) => l.includes('CHANGES_REQUESTED'))).toBe(false)
+  })
+})

--- a/src/workstation/chrome/previewPane.ts
+++ b/src/workstation/chrome/previewPane.ts
@@ -11,6 +11,8 @@
  */
 
 import { BranchRef } from '../../git/branchData'
+import type { IssueListItem } from '../../git/issuesListData'
+import type { PullRequestListItem } from '../../git/pullRequestListData'
 import { StashEntry } from '../../git/stashData'
 import { GitTagRef } from '../../git/tagData'
 
@@ -125,6 +127,96 @@ export function formatStashPreview(
     out.push(blank())
     out.push(dim('No files in stash.'))
   }
+
+  return out
+}
+
+/* -------------------------------- issue -------------------------------- */
+
+/**
+ * Format an issue triage entry into preview lines (#882 phase 3).
+ * Returns a uniform "select to preview" message when nothing is
+ * cursored; otherwise renders #/state/author/labels/assignees, a
+ * timestamp pair, and a short body excerpt clipped at 6 lines.
+ *
+ * The list payload from `gh issue list --json` doesn't include body
+ * text — that's a deliberate scope cut in phase 1 to keep the list
+ * fetch cheap. The preview pane therefore omits the body section
+ * entirely; phase 4 will introduce a per-issue fetch that hydrates
+ * the body on demand when the cursor rests.
+ */
+export function formatIssueTriagePreview(
+  issue: IssueListItem | undefined
+): PreviewLine[] {
+  if (!issue) {
+    return [dim('Select an issue to preview.')]
+  }
+
+  const out: PreviewLine[] = [
+    heading(`#${issue.number} · ${issue.title}`),
+    blank(),
+    line(`State:    ${issue.state.toLowerCase()}`),
+  ]
+  if (issue.author) out.push(line(`Author:   ${issue.author}`))
+  if (issue.assignees && issue.assignees.length > 0) {
+    out.push(line(`Assigned: ${issue.assignees.join(', ')}`))
+  }
+  if (issue.labels && issue.labels.length > 0) {
+    out.push(line(`Labels:   ${issue.labels.join(', ')}`))
+  }
+  if (typeof issue.comments === 'number') {
+    out.push(line(`Comments: ${issue.comments}`))
+  }
+  out.push(blank())
+  if (issue.createdAt) out.push(line(`Created:  ${issue.createdAt}`))
+  if (issue.updatedAt) out.push(line(`Updated:  ${issue.updatedAt}`))
+  out.push(blank())
+  out.push(dim(issue.url))
+
+  return out
+}
+
+/* ----------------------------- pull request ---------------------------- */
+
+/**
+ * Format a pull-request triage entry into preview lines (#882 phase 3).
+ * Renders #/state/author/branches/labels/mergeable/review-decision and
+ * a timestamp pair. Like the issue preview, the body is not included
+ * — list payloads from `gh pr list --json` don't carry bodies; phase 4
+ * will hydrate one per cursor rest.
+ */
+export function formatPullRequestTriagePreview(
+  pr: PullRequestListItem | undefined
+): PreviewLine[] {
+  if (!pr) {
+    return [dim('Select a pull request to preview.')]
+  }
+
+  const out: PreviewLine[] = [
+    heading(`#${pr.number} · ${pr.title}`),
+    blank(),
+    line(`State:     ${pr.isDraft ? 'draft' : pr.state.toLowerCase()}`),
+  ]
+  if (pr.author) out.push(line(`Author:    ${pr.author}`))
+  out.push(line(`Branches:  ${pr.headRefName} → ${pr.baseRefName}`))
+  if (pr.mergeable || pr.mergeStateStatus) {
+    const merge = [pr.mergeable, pr.mergeStateStatus].filter(Boolean).join(' / ')
+    out.push(line(`Mergeable: ${merge.toLowerCase()}`))
+  }
+  if (pr.reviewDecision) {
+    out.push(line(`Review:    ${pr.reviewDecision.toLowerCase().replace(/_/g, ' ')}`))
+  }
+  if (pr.assignees && pr.assignees.length > 0) {
+    out.push(line(`Assigned:  ${pr.assignees.join(', ')}`))
+  }
+  if (pr.labels && pr.labels.length > 0) {
+    out.push(line(`Labels:    ${pr.labels.join(', ')}`))
+  }
+  out.push(blank())
+  if (pr.createdAt) out.push(line(`Created:   ${pr.createdAt}`))
+  if (pr.updatedAt) out.push(line(`Updated:   ${pr.updatedAt}`))
+  out.push(blank())
+  out.push(dim(pr.url))
 
   return out
 }

--- a/src/workstation/chrome/surfaceStates.triage.test.ts
+++ b/src/workstation/chrome/surfaceStates.triage.test.ts
@@ -1,0 +1,54 @@
+import {
+  formatLogInkGitHubNoRemote,
+  formatLogInkGitHubUnauthenticated,
+  formatLogInkIssuesEmpty,
+  formatLogInkPullRequestTriageEmpty,
+} from './surfaceStates'
+
+describe('triage surface empty-state messages', () => {
+  describe('formatLogInkIssuesEmpty', () => {
+    it('mentions the filter when one is active', () => {
+      expect(formatLogInkIssuesEmpty({ filter: 'auth' })).toContain("'auth'")
+      expect(formatLogInkIssuesEmpty({ filter: 'auth' })).toContain('ctrl+u')
+    })
+
+    it('references the default open-issues filter when none is set', () => {
+      const msg = formatLogInkIssuesEmpty({ filter: '' })
+      expect(msg).toContain('open')
+      expect(msg).not.toContain("''")
+    })
+  })
+
+  describe('formatLogInkPullRequestTriageEmpty', () => {
+    it('mentions the filter when one is active', () => {
+      expect(formatLogInkPullRequestTriageEmpty({ filter: 'merge' })).toContain("'merge'")
+    })
+
+    it('references the default open-PRs filter when none is set', () => {
+      expect(formatLogInkPullRequestTriageEmpty({ filter: '' })).toContain('open')
+    })
+  })
+
+  describe('formatLogInkGitHubUnauthenticated', () => {
+    it('embeds the resource noun', () => {
+      expect(formatLogInkGitHubUnauthenticated({ resource: 'Issues' })).toContain('Issues')
+      expect(formatLogInkGitHubUnauthenticated({ resource: 'Pull requests' })).toContain(
+        'Pull requests'
+      )
+    })
+
+    it('points the user at gh auth login', () => {
+      expect(formatLogInkGitHubUnauthenticated({ resource: 'Issues' })).toContain('gh auth login')
+    })
+  })
+
+  describe('formatLogInkGitHubNoRemote', () => {
+    it('embeds the resource noun', () => {
+      expect(formatLogInkGitHubNoRemote({ resource: 'Issues' })).toContain('Issues')
+    })
+
+    it('mentions GitHub explicitly', () => {
+      expect(formatLogInkGitHubNoRemote({ resource: 'Issues' })).toContain('GitHub')
+    })
+  })
+})

--- a/src/workstation/chrome/surfaceStates.ts
+++ b/src/workstation/chrome/surfaceStates.ts
@@ -113,3 +113,54 @@ export function formatLogInkSubmodulesEmpty({ filter }: LogInkSubmodulesEmptyArg
   }
   return 'No submodules registered. Add one with `git submodule add <url> <path>` from the shell.'
 }
+
+export type LogInkIssuesEmptyArgs = {
+  filter: string
+}
+
+export function formatLogInkIssuesEmpty({ filter }: LogInkIssuesEmptyArgs): string {
+  if (filter.trim()) {
+    return `No issues match filter '${filter}'. Press ctrl+u to clear.`
+  }
+  return 'No issues match the current GitHub filter (default: open issues).'
+}
+
+export type LogInkPullRequestTriageEmptyArgs = {
+  filter: string
+}
+
+export function formatLogInkPullRequestTriageEmpty({
+  filter,
+}: LogInkPullRequestTriageEmptyArgs): string {
+  if (filter.trim()) {
+    return `No pull requests match filter '${filter}'. Press ctrl+u to clear.`
+  }
+  return 'No pull requests match the current GitHub filter (default: open PRs).'
+}
+
+export type LogInkGitHubUnauthenticatedArgs = {
+  /** Short noun for the resource: "issues", "pull requests". */
+  resource: string
+}
+
+/**
+ * Surface-level fallback when the GitHub CLI is missing or not
+ * authenticated. The triage views (#882) all share this empty-state
+ * copy — the underlying problem is the same regardless of which
+ * surface the user is on, and the recovery is identical.
+ */
+export function formatLogInkGitHubUnauthenticated({
+  resource,
+}: LogInkGitHubUnauthenticatedArgs): string {
+  return `${resource} require the GitHub CLI. Install \`gh\` and run \`gh auth login\` to enable triage.`
+}
+
+/**
+ * Surface-level fallback when the repo has no GitHub remote. Same
+ * shared message across the triage surfaces.
+ */
+export function formatLogInkGitHubNoRemote({
+  resource,
+}: LogInkGitHubUnauthenticatedArgs): string {
+  return `${resource} require a GitHub remote (origin or fallback). None detected for this repo.`
+}

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -250,7 +250,9 @@ import { applyStash, checkoutFileFromStash, createStash, dropStash, popStash } f
 import { ApplyHunkTarget, applyHunkPatch } from '../../git/hunkActions'
 import { removeWorktree, removeWorktreeAndBranch } from '../../git/worktreeActions'
 import { abortOperation, continueOperation, resolveConflictOurs, resolveConflictTheirs, stageConflictResolved } from '../../git/operationActions'
+import { getIssueList } from '../../git/issuesListData'
 import { getPullRequestOverview } from '../../git/pullRequestData'
+import { getPullRequestList } from '../../git/pullRequestListData'
 import {
     approvePullRequest,
     closePullRequest,
@@ -649,6 +651,43 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       )
     )
   }, [context.submodules?.entries, state.filter])
+  // Issues + PR triage filtered lists (#882 phase 3). Same memo
+  // pattern as the other promoted views — collapses per-keystroke
+  // filter work to one pass per (data, filter) change.
+  const filteredIssueList = React.useMemo(() => {
+    const all = context.issueList?.issues || []
+    if (!state.filter) return all
+    return all.filter((issue) =>
+      matchesPromotedFilter(
+        [
+          `#${issue.number}`,
+          issue.title,
+          issue.author || '',
+          ...(issue.labels || []),
+          ...(issue.assignees || []),
+        ],
+        state.filter,
+      )
+    )
+  }, [context.issueList?.issues, state.filter])
+  const filteredPullRequestTriageList = React.useMemo(() => {
+    const all = context.pullRequestList?.pullRequests || []
+    if (!state.filter) return all
+    return all.filter((pr) =>
+      matchesPromotedFilter(
+        [
+          `#${pr.number}`,
+          pr.title,
+          pr.author || '',
+          pr.headRefName,
+          pr.baseRefName,
+          ...(pr.labels || []),
+          ...(pr.assignees || []),
+        ],
+        state.filter,
+      )
+    )
+  }, [context.pullRequestList?.pullRequests, state.filter])
 
   const dispatch = React.useCallback((action: Parameters<typeof applyLogInkAction>[1]) => {
     setState((current) => applyLogInkAction(current, action))
@@ -1048,6 +1087,51 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       active = false
     }
   }, [git, state.activeView, context.pullRequest])
+
+  // Lazy-load the issue triage list (#882 phase 3). Mirrors the
+  // single-PR effect above: only fires on entry to the dedicated
+  // view, and only when we don't already have data. The default
+  // filter (`state: 'open'`) matches the CLI's default so the
+  // workstation and `coco issues` show the same set on first entry.
+  React.useEffect(() => {
+    if (state.activeView !== 'issues') return
+    if (context.issueList) return
+    let active = true
+    setContextStatus((current) => updateLogInkContextStatus(current, 'issueList', 'loading'))
+    void safe(getIssueList(git, { state: 'open' })).then((value) => {
+      if (!active) return
+      setContext((current) => ({
+        ...current,
+        issueList: value,
+      }))
+      setContextStatus((current) => updateLogInkContextStatus(current, 'issueList', 'ready'))
+    })
+    return () => {
+      active = false
+    }
+  }, [git, state.activeView, context.issueList])
+
+  // Lazy-load the PR triage list (#882 phase 3). Distinct from the
+  // single-PR `pullRequest` effect above — that fetches the current
+  // branch's PR via `gh pr view`; this fetches the full repo PR list
+  // via `gh pr list`.
+  React.useEffect(() => {
+    if (state.activeView !== 'pull-request-triage') return
+    if (context.pullRequestList) return
+    let active = true
+    setContextStatus((current) => updateLogInkContextStatus(current, 'pullRequestList', 'loading'))
+    void safe(getPullRequestList(git, { state: 'open' })).then((value) => {
+      if (!active) return
+      setContext((current) => ({
+        ...current,
+        pullRequestList: value,
+      }))
+      setContextStatus((current) => updateLogInkContextStatus(current, 'pullRequestList', 'ready'))
+    })
+    return () => {
+      active = false
+    }
+  }, [git, state.activeView, context.pullRequestList])
 
   React.useEffect(() => {
     let active = true
@@ -3025,6 +3109,14 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     const submoduleSelectedPath = filteredSubmoduleList[
       Math.min(state.selectedSubmoduleIndex, Math.max(0, filteredSubmoduleList.length - 1))
     ]?.path
+    const issueVisibleCount = filteredIssueList.length
+    const issueSelectedUrl = filteredIssueList[
+      Math.min(state.selectedIssueIndex, Math.max(0, filteredIssueList.length - 1))
+    ]?.url
+    const pullRequestTriageVisibleCount = filteredPullRequestTriageList.length
+    const pullRequestTriageSelectedUrl = filteredPullRequestTriageList[
+      Math.min(state.selectedPullRequestTriageIndex, Math.max(0, filteredPullRequestTriageList.length - 1))
+    ]?.url
     const worktreeVisibleCount = filteredWorktreeList.length
 
     // When the diff view is showing a stash patch, swap the previewLineCount
@@ -3060,6 +3152,10 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       reflogSelectedHash,
       submoduleCount: submoduleVisibleCount,
       submoduleSelectedPath,
+      issueCount: issueVisibleCount,
+      issueSelectedUrl,
+      pullRequestTriageCount: pullRequestTriageVisibleCount,
+      pullRequestTriageSelectedUrl,
       stashSelectedRef,
       stashDiffFileOffsets: stashDiffFileOffsets.length ? stashDiffFileOffsets : undefined,
       stashDiffSelectedPath,

--- a/src/workstation/runtime/detailPanel.ts
+++ b/src/workstation/runtime/detailPanel.ts
@@ -29,6 +29,8 @@ import {
   renderCommitPanel,
   renderComposeContextPanel,
   renderHistoryInspector,
+  renderIssueTriagePreviewPanel,
+  renderPullRequestTriagePreviewPanel,
   renderStashPreviewPanel,
   renderSubmodulePreviewPanel,
   renderTagPreviewPanel,
@@ -189,6 +191,14 @@ export function renderDetailPanel(
 
   if (state.activeView === 'submodules') {
     return renderSubmodulePreviewPanel(h, components, state, context, contextStatus, width, theme, focused)
+  }
+
+  if (state.activeView === 'issues') {
+    return renderIssueTriagePreviewPanel(h, components, state, context, contextStatus, width, theme, focused)
+  }
+
+  if (state.activeView === 'pull-request-triage') {
+    return renderPullRequestTriagePreviewPanel(h, components, state, context, contextStatus, width, theme, focused)
   }
 
   return renderHistoryInspector(

--- a/src/workstation/runtime/mainPanel.ts
+++ b/src/workstation/runtime/mainPanel.ts
@@ -27,7 +27,9 @@ import { renderConflictsSurface } from '../surfaces/conflicts'
 import { renderDiffSurface } from '../surfaces/diff'
 import { renderHistoryPanel } from '../surfaces/history'
 import { renderSplitPlanOverlay } from './overlays'
+import { renderIssuesTriageSurface } from '../surfaces/issuesTriage'
 import { renderPullRequestSurface } from '../surfaces/pullRequest'
+import { renderPullRequestTriageSurface } from '../surfaces/pullRequestTriage'
 import { renderReflogSurface } from '../surfaces/reflog'
 import { renderStashSurface } from '../surfaces/stash'
 import { renderStatusSurface } from '../surfaces/status'
@@ -139,6 +141,14 @@ export function renderMainPanel(
 
   if (state.activeView === 'pull-request') {
     return renderPullRequestSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
+  }
+
+  if (state.activeView === 'pull-request-triage') {
+    return renderPullRequestTriageSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
+  }
+
+  if (state.activeView === 'issues') {
+    return renderIssuesTriageSurface(h, components, state, context, contextStatus, bodyRows, width, theme)
   }
 
   if (state.activeView === 'conflicts') {

--- a/src/workstation/runtime/types.ts
+++ b/src/workstation/runtime/types.ts
@@ -20,7 +20,9 @@ import type { LfsAttributeStatus } from '../../git/lfsAttributes'
 import type { SubmoduleOverview } from '../../git/submoduleData'
 import type { GitOperationOverview } from '../../git/operationData'
 import type { ProviderOverview } from '../../git/providerData'
+import type { IssueListOverview } from '../../git/issuesListData'
 import type { PullRequestOverview } from '../../git/pullRequestData'
+import type { PullRequestListOverview } from '../../git/pullRequestListData'
 import type { ReflogOverview } from '../../git/reflogData'
 import type { StashOverview } from '../../git/stashData'
 import type { TagOverview } from '../../git/tagData'
@@ -46,6 +48,18 @@ export type LogInkContext = {
   operation?: GitOperationOverview
   provider?: ProviderOverview
   pullRequest?: PullRequestOverview
+  /**
+   * Multi-PR triage list (#882). Hydrated on entry to the
+   * `pull-request-triage` view. Distinct from `pullRequest` (single,
+   * current-branch) so the two surfaces don't clobber each other and
+   * the disk cache (`coco prs`) can stay separate from the
+   * `gh pr view` cache the single-PR panel uses.
+   */
+  pullRequestList?: PullRequestListOverview
+  /**
+   * Issues triage list (#882). Hydrated on entry to the `issues` view.
+   */
+  issueList?: IssueListOverview
   reflog?: ReflogOverview
   stashes?: StashOverview
   /**

--- a/src/workstation/surfaces/detail/index.ts
+++ b/src/workstation/surfaces/detail/index.ts
@@ -37,6 +37,8 @@ import { getInspectorActions } from '../../chrome/inspectorActions'
 import type { PreviewLine } from '../../chrome/previewPane'
 import {
   formatBranchPreview,
+  formatIssueTriagePreview,
+  formatPullRequestTriagePreview,
   formatStashPreview,
   formatTagPreview,
 } from '../../chrome/previewPane'
@@ -826,4 +828,88 @@ export function renderCommitPanel(
   loading
     ? null
     : h(Text, { key: 'commit-state', dimColor: true }, truncateCells(stateLine, width - 4)))
+}
+
+/**
+ * Issue triage preview pane (#882 phase 3). Mirrors the branch / tag /
+ * stash preview pattern — `renderPreviewPanel` chrome, formatter pulls
+ * the cursored item via `state.selectedIssueIndex`. Shown when
+ * `state.activeView === 'issues'`.
+ */
+export function renderIssueTriagePreviewPanel(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  width: number,
+  theme: LogInkTheme,
+  focused: boolean
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  if (isLogInkContextKeyLoading(contextStatus, 'issueList')) {
+    return renderPreviewPanel(h, { Box, Text }, 'Issue preview',
+      [{ text: formatLogInkLoading({ resource: 'issues' }), emphasis: 'dim' }],
+      width, theme, focused)
+  }
+  const all = context.issueList?.issues || []
+  const visible = state.filter
+    ? all.filter((issue) => matchesPromotedFilter(
+      [
+        `#${issue.number}`,
+        issue.title,
+        issue.author || '',
+        ...(issue.labels || []),
+        ...(issue.assignees || []),
+      ],
+      state.filter,
+    ))
+    : all
+  const index = Math.max(0, Math.min(state.selectedIssueIndex, Math.max(0, visible.length - 1)))
+  const issue = visible[index]
+  return renderPreviewPanel(h, { Box, Text }, 'Issue preview',
+    formatIssueTriagePreview(issue), width, theme, focused)
+}
+
+/**
+ * Pull-request triage preview pane (#882 phase 3). Shown when
+ * `state.activeView === 'pull-request-triage'`. Distinct from the
+ * single-PR action panel's right pane (which renders the full
+ * inspector with status checks, reviews, and action keys).
+ */
+export function renderPullRequestTriagePreviewPanel(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  width: number,
+  theme: LogInkTheme,
+  focused: boolean
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  if (isLogInkContextKeyLoading(contextStatus, 'pullRequestList')) {
+    return renderPreviewPanel(h, { Box, Text }, 'Pull request preview',
+      [{ text: formatLogInkLoading({ resource: 'pull requests' }), emphasis: 'dim' }],
+      width, theme, focused)
+  }
+  const all = context.pullRequestList?.pullRequests || []
+  const visible = state.filter
+    ? all.filter((pr) => matchesPromotedFilter(
+      [
+        `#${pr.number}`,
+        pr.title,
+        pr.author || '',
+        pr.headRefName,
+        pr.baseRefName,
+        ...(pr.labels || []),
+        ...(pr.assignees || []),
+      ],
+      state.filter,
+    ))
+    : all
+  const index = Math.max(0, Math.min(state.selectedPullRequestTriageIndex, Math.max(0, visible.length - 1)))
+  const pr = visible[index]
+  return renderPreviewPanel(h, { Box, Text }, 'Pull request preview',
+    formatPullRequestTriagePreview(pr), width, theme, focused)
 }

--- a/src/workstation/surfaces/issuesTriage/index.ts
+++ b/src/workstation/surfaces/issuesTriage/index.ts
@@ -1,0 +1,184 @@
+/**
+ * Issues triage surface (#882 phase 3). Read-only list view rendered
+ * in the main panel when `state.activeView === 'issues'`. Mirrors the
+ * branches / tags surface pattern: pure renderer, no hooks, no async.
+ * Data flows in via `context.issueList`; the cursor position lives at
+ * `state.selectedIssueIndex`.
+ *
+ * Per-row actions (assign, label, comment, close) and AI summarize
+ * land in phase 4-6. This phase ships navigation only.
+ */
+
+import type * as ReactTypes from 'react'
+import type { IssueListItem } from '../../../git/issuesListData'
+import type { LogInkContextStatus } from '../../chrome/context'
+import { isLogInkContextKeyLoading } from '../../chrome/context'
+import {
+  formatLogInkGitHubNoRemote,
+  formatLogInkGitHubUnauthenticated,
+  formatLogInkIssuesEmpty,
+  formatLogInkLoading,
+} from '../../chrome/surfaceStates'
+import { truncateCells } from '../../chrome/text'
+import type { LogInkTheme } from '../../chrome/theme'
+import type { LogInkState } from '../../../commands/log/inkViewModel'
+import { matchesPromotedFilter } from '../../runtime/promotedFilter'
+import type { LogInkComponents, LogInkContext } from '../../runtime/types'
+import { focusBorderColor, panelTitle } from '../../runtime/utils'
+
+function stateColor(theme: LogInkTheme, state: string): string | undefined {
+  if (theme.noColor) return undefined
+  switch (state.toUpperCase()) {
+    case 'OPEN':
+      return theme.colors.success
+    case 'CLOSED':
+      return theme.colors.danger
+    default:
+      return theme.colors.muted
+  }
+}
+
+function matchesIssueFilter(issue: IssueListItem, filter: string): boolean {
+  if (!filter) return true
+  return matchesPromotedFilter(
+    [
+      `#${issue.number}`,
+      issue.title,
+      issue.author || '',
+      ...(issue.labels || []),
+      ...(issue.assignees || []),
+    ],
+    filter
+  )
+}
+
+export function renderIssuesTriageSurface(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  bodyRows: number,
+  width: number,
+  theme: LogInkTheme
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const focused = state.focus === 'commits'
+  const overview = context.issueList
+  const loading = isLogInkContextKeyLoading(contextStatus, 'issueList')
+
+  // Resolve the "what should the panel say" headline first, then fan
+  // out to the row body. The chrome (border + title + headerRight) is
+  // identical across loading / unavailable / unauthenticated / empty
+  // / populated states; only the body changes.
+  let headerRight = ''
+  let bodyLines: ReactTypes.ReactNode[] = []
+
+  if (loading || !overview) {
+    headerRight = 'loading issues'
+    bodyLines = [
+      h(Text, { key: 'issues-loading', dimColor: true }, formatLogInkLoading({ resource: 'issues' })),
+    ]
+  } else if (!overview.available) {
+    headerRight = 'unavailable'
+    bodyLines = [
+      h(Text, { key: 'issues-no-remote', dimColor: true },
+        formatLogInkGitHubNoRemote({ resource: 'Issues' })),
+    ]
+  } else if (!overview.authenticated) {
+    headerRight = 'gh not authenticated'
+    bodyLines = [
+      h(Text, { key: 'issues-unauth', dimColor: true },
+        formatLogInkGitHubUnauthenticated({ resource: 'Issues' })),
+    ]
+  } else if (overview.message && !overview.issues) {
+    headerRight = 'error'
+    bodyLines = [
+      h(Text, { key: 'issues-error', dimColor: true, color: theme.noColor ? undefined : theme.colors.danger },
+        overview.message),
+    ]
+  } else {
+    const all = overview.issues || []
+    const visible = state.filter
+      ? all.filter((issue) => matchesIssueFilter(issue, state.filter))
+      : all
+    const selected = Math.max(0, Math.min(state.selectedIssueIndex, Math.max(0, visible.length - 1)))
+    const listRows = Math.max(4, bodyRows - 4)
+    const startIndex = Math.max(0, selected - Math.floor(listRows / 2))
+    const windowed = visible.slice(startIndex, startIndex + listRows)
+    const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
+    const repoLabel = overview.repository
+      ? `${overview.repository.owner}/${overview.repository.name}`
+      : ''
+    headerRight = `${repoLabel ? `${repoLabel} · ` : ''}${visible.length}/${all.length}${filterLabel}`
+
+    if (visible.length === 0) {
+      bodyLines = [
+        h(Text, { key: 'issues-empty', dimColor: true }, formatLogInkIssuesEmpty({ filter: state.filter })),
+      ]
+    } else {
+      // Column widths derived from the visible window so columns stay
+      // aligned without one outlier title pushing the rest sideways.
+      // Capped to keep the title column from being squeezed out on
+      // narrow terminals.
+      const numberColWidth = Math.min(
+        6,
+        Math.max(...windowed.map((i) => `#${i.number}`.length), 3)
+      )
+      const authorColWidth = Math.min(
+        16,
+        Math.max(...windowed.map((i) => (i.author || '').length), 4)
+      )
+
+      bodyLines = windowed.map((issue, offset) => {
+        const index = startIndex + offset
+        const isSelected = index === selected
+        const cursor = isSelected ? '>' : ' '
+        const numStr = `#${issue.number}`.padEnd(numberColWidth)
+        const stateStr = issue.state.toLowerCase().padEnd(6)
+        const authorStr = (issue.author || '').padEnd(authorColWidth)
+        const commentsStr =
+          typeof issue.comments === 'number' && issue.comments > 0
+            ? ` ${issue.comments}c`
+            : ''
+        // The title column gets whatever is left after the prefix
+        // columns. Truncate so the row stays a single visual line.
+        const head = `${cursor} `
+        const prefix = `${numStr}  ${stateStr}  ${authorStr}  `
+        const titleBudget = Math.max(8, width - 4 - head.length - prefix.length - commentsStr.length)
+        const titleStr = truncateCells(issue.title, titleBudget)
+        const labelStr = (issue.labels || []).length
+          ? ` [${(issue.labels || []).join(' ')}]`
+          : ''
+
+        return h(Text, {
+          key: `issue-${index}`,
+          bold: isSelected,
+          dimColor: !isSelected,
+        },
+        head,
+        h(Text, { dimColor: true }, numStr + '  '),
+        h(Text, { color: stateColor(theme, issue.state), dimColor: !isSelected }, stateStr + '  '),
+        h(Text, { color: theme.noColor ? undefined : theme.colors.accent, dimColor: !isSelected }, authorStr + '  '),
+        titleStr,
+        h(Text, { dimColor: true }, labelStr),
+        h(Text, { dimColor: true }, commentsStr),
+        )
+      })
+    }
+  }
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    flexShrink: 0,
+    paddingX: 1,
+    width,
+  },
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle('Issues', focused)),
+    h(Text, { dimColor: true }, headerRight)
+  ),
+  ...bodyLines)
+}

--- a/src/workstation/surfaces/pullRequestTriage/index.ts
+++ b/src/workstation/surfaces/pullRequestTriage/index.ts
@@ -1,0 +1,250 @@
+/**
+ * Pull-request triage surface (#882 phase 3). Read-only list view
+ * rendered in the main panel when `state.activeView ===
+ * 'pull-request-triage'`. Distinct from the existing single-PR action
+ * panel (`'pull-request'`, chord `gp`) — this is the multi-PR list
+ * surface (chord `gP`).
+ *
+ * Pure renderer; data flows in via `context.pullRequestList`. Per-row
+ * actions (merge, approve, request-changes, close, comment) and AI
+ * summarize land in phase 4-6.
+ */
+
+import type * as ReactTypes from 'react'
+import type { PullRequestListItem } from '../../../git/pullRequestListData'
+import type { LogInkContextStatus } from '../../chrome/context'
+import { isLogInkContextKeyLoading } from '../../chrome/context'
+import {
+  formatLogInkGitHubNoRemote,
+  formatLogInkGitHubUnauthenticated,
+  formatLogInkLoading,
+  formatLogInkPullRequestTriageEmpty,
+} from '../../chrome/surfaceStates'
+import { truncateCells } from '../../chrome/text'
+import type { LogInkTheme } from '../../chrome/theme'
+import type { LogInkState } from '../../../commands/log/inkViewModel'
+import { matchesPromotedFilter } from '../../runtime/promotedFilter'
+import type { LogInkComponents, LogInkContext } from '../../runtime/types'
+import { focusBorderColor, panelTitle } from '../../runtime/utils'
+
+function stateColor(theme: LogInkTheme, state: string, isDraft: boolean): string | undefined {
+  if (theme.noColor) return undefined
+  if (isDraft) return theme.colors.muted
+  switch (state.toUpperCase()) {
+    case 'OPEN':
+      return theme.colors.success
+    case 'CLOSED':
+      return theme.colors.danger
+    case 'MERGED':
+      return theme.colors.accent
+    default:
+      return theme.colors.muted
+  }
+}
+
+function reviewGlyph(decision: string | undefined): string {
+  switch (decision) {
+    case 'APPROVED':
+      return '✓'
+    case 'CHANGES_REQUESTED':
+      return '✗'
+    case 'REVIEW_REQUIRED':
+      return '?'
+    default:
+      return ' '
+  }
+}
+
+function mergeableGlyph(mergeStateStatus: string | undefined, mergeable: string | undefined): string {
+  if (mergeStateStatus === 'CLEAN') return '●'
+  if (mergeStateStatus === 'BLOCKED') return '●'
+  if (mergeStateStatus === 'DIRTY' || mergeable === 'CONFLICTING') return '●'
+  if (mergeStateStatus === 'BEHIND') return '●'
+  if (mergeStateStatus === 'UNSTABLE') return '●'
+  return '·'
+}
+
+function mergeableColor(theme: LogInkTheme, mergeStateStatus: string | undefined, mergeable: string | undefined): string | undefined {
+  if (theme.noColor) return undefined
+  if (mergeStateStatus === 'CLEAN') return theme.colors.success
+  if (mergeStateStatus === 'BLOCKED' || mergeStateStatus === 'UNSTABLE') return theme.colors.warning
+  if (mergeStateStatus === 'DIRTY' || mergeable === 'CONFLICTING') return theme.colors.danger
+  if (mergeStateStatus === 'BEHIND') return theme.colors.accent
+  return theme.colors.muted
+}
+
+function reviewColor(theme: LogInkTheme, decision: string | undefined): string | undefined {
+  if (theme.noColor) return undefined
+  switch (decision) {
+    case 'APPROVED':
+      return theme.colors.success
+    case 'CHANGES_REQUESTED':
+      return theme.colors.danger
+    case 'REVIEW_REQUIRED':
+      return theme.colors.warning
+    default:
+      return theme.colors.muted
+  }
+}
+
+function matchesPullRequestFilter(pr: PullRequestListItem, filter: string): boolean {
+  if (!filter) return true
+  return matchesPromotedFilter(
+    [
+      `#${pr.number}`,
+      pr.title,
+      pr.author || '',
+      pr.headRefName,
+      pr.baseRefName,
+      ...(pr.labels || []),
+      ...(pr.assignees || []),
+    ],
+    filter
+  )
+}
+
+export function renderPullRequestTriageSurface(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  context: LogInkContext,
+  contextStatus: LogInkContextStatus,
+  bodyRows: number,
+  width: number,
+  theme: LogInkTheme
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const focused = state.focus === 'commits'
+  const overview = context.pullRequestList
+  const loading = isLogInkContextKeyLoading(contextStatus, 'pullRequestList')
+
+  let headerRight = ''
+  let bodyLines: ReactTypes.ReactNode[] = []
+
+  if (loading || !overview) {
+    headerRight = 'loading pull requests'
+    bodyLines = [
+      h(Text, { key: 'pr-triage-loading', dimColor: true }, formatLogInkLoading({ resource: 'pull requests' })),
+    ]
+  } else if (!overview.available) {
+    headerRight = 'unavailable'
+    bodyLines = [
+      h(Text, { key: 'pr-triage-no-remote', dimColor: true },
+        formatLogInkGitHubNoRemote({ resource: 'Pull requests' })),
+    ]
+  } else if (!overview.authenticated) {
+    headerRight = 'gh not authenticated'
+    bodyLines = [
+      h(Text, { key: 'pr-triage-unauth', dimColor: true },
+        formatLogInkGitHubUnauthenticated({ resource: 'Pull requests' })),
+    ]
+  } else if (overview.message && !overview.pullRequests) {
+    headerRight = 'error'
+    bodyLines = [
+      h(Text, {
+        key: 'pr-triage-error',
+        dimColor: true,
+        color: theme.noColor ? undefined : theme.colors.danger,
+      }, overview.message),
+    ]
+  } else {
+    const all = overview.pullRequests || []
+    const visible = state.filter
+      ? all.filter((pr) => matchesPullRequestFilter(pr, state.filter))
+      : all
+    const selected = Math.max(
+      0,
+      Math.min(state.selectedPullRequestTriageIndex, Math.max(0, visible.length - 1))
+    )
+    const listRows = Math.max(4, bodyRows - 4)
+    const startIndex = Math.max(0, selected - Math.floor(listRows / 2))
+    const windowed = visible.slice(startIndex, startIndex + listRows)
+    const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
+    const repoLabel = overview.repository
+      ? `${overview.repository.owner}/${overview.repository.name}`
+      : ''
+    headerRight = `${repoLabel ? `${repoLabel} · ` : ''}${visible.length}/${all.length}${filterLabel}`
+
+    if (visible.length === 0) {
+      bodyLines = [
+        h(Text, { key: 'pr-triage-empty', dimColor: true },
+          formatLogInkPullRequestTriageEmpty({ filter: state.filter })),
+      ]
+    } else {
+      const numberColWidth = Math.min(
+        6,
+        Math.max(...windowed.map((p) => `#${p.number}`.length), 3)
+      )
+      const authorColWidth = Math.min(
+        16,
+        Math.max(...windowed.map((p) => (p.author || '').length), 4)
+      )
+      const branchColWidth = Math.min(
+        24,
+        Math.max(...windowed.map((p) => p.headRefName.length), 6)
+      )
+
+      bodyLines = windowed.map((pr, offset) => {
+        const index = startIndex + offset
+        const isSelected = index === selected
+        const cursor = isSelected ? '>' : ' '
+        const numStr = `#${pr.number}`.padEnd(numberColWidth)
+        const stateLabel = pr.isDraft ? 'draft' : pr.state.toLowerCase()
+        const stateStr = stateLabel.padEnd(6)
+        const mergeStr = mergeableGlyph(pr.mergeStateStatus, pr.mergeable)
+        const reviewStr = reviewGlyph(pr.reviewDecision)
+        const authorStr = (pr.author || '').padEnd(authorColWidth)
+        const branchStr = truncateCells(pr.headRefName, branchColWidth).padEnd(branchColWidth)
+        const labelStr = (pr.labels || []).length
+          ? ` [${(pr.labels || []).join(' ')}]`
+          : ''
+        const head = `${cursor} `
+        const prefix = `${numStr}  ${stateStr}  ${mergeStr}  ${reviewStr}  ${authorStr}  ${branchStr}  `
+        const titleBudget = Math.max(8, width - 4 - head.length - prefix.length)
+        const titleStr = truncateCells(pr.title, titleBudget)
+
+        return h(Text, {
+          key: `pr-triage-${index}`,
+          bold: isSelected,
+          dimColor: !isSelected,
+        },
+        head,
+        h(Text, { dimColor: true }, numStr + '  '),
+        h(Text, {
+          color: stateColor(theme, pr.state, pr.isDraft),
+          dimColor: !isSelected,
+        }, stateStr + '  '),
+        h(Text, {
+          color: mergeableColor(theme, pr.mergeStateStatus, pr.mergeable),
+          dimColor: !isSelected,
+        }, mergeStr + '  '),
+        h(Text, {
+          color: reviewColor(theme, pr.reviewDecision),
+          dimColor: !isSelected,
+        }, reviewStr + '  '),
+        h(Text, {
+          color: theme.noColor ? undefined : theme.colors.accent,
+          dimColor: !isSelected,
+        }, authorStr + '  '),
+        h(Text, { dimColor: true }, branchStr + '  '),
+        titleStr,
+        h(Text, { dimColor: true }, labelStr),
+        )
+      })
+    }
+  }
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    flexShrink: 0,
+    paddingX: 1,
+    width,
+  },
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle('Pull requests', focused)),
+    h(Text, { dimColor: true }, headerRight)
+  ),
+  ...bodyLines)
+}


### PR DESCRIPTION
Phase 3 of [#882](https://github.com/gfargo/coco/issues/882). Builds on the data layer ([#964](https://github.com/gfargo/coco/pull/964)) and cache ([#965](https://github.com/gfargo/coco/pull/965)) from phases 1-2.

## What lands

Two new workstation surfaces — Issues and PR triage — reachable via chord from anywhere inside \`coco ui\`. Read-only; the actions land in phases 4-5.

| Chord | Target |
| --- | --- |
| \`gi\` | Issue triage list |
| \`gP\` | PR triage list (capital P; \`gp\` keeps targeting the existing single-PR action panel) |

Each surface is a three-column listing (number / state / author / branches / title / labels) with a right-pane inspector showing the cursored item's metadata. \`/\` filter, j/k cursor, and \`<\` / \`esc\` back all work out of the box via the existing promoted-view machinery.

## Summary

- **View routing**: extended \`LogInkView\` with \`'issues'\` and \`'pull-request-triage'\`. Two new state fields (\`selectedIssueIndex\`, \`selectedPullRequestTriageIndex\`) hold the cursors. Two new reducer actions (\`moveIssue\`, \`movePullRequestTriage\`). Two new context keys (\`issueList\`, \`pullRequestList\`) hook into the existing loading-state chrome.
- **Surfaces**: \`src/workstation/surfaces/issuesTriage/\` and \`pullRequestTriage/\` — pure renderers following the branches template. Each handles loading / unauthenticated / no-remote / error / empty / populated states with tailored copy.
- **Inspector panels**: \`renderIssueTriagePreviewPanel\` and \`renderPullRequestTriagePreviewPanel\` in \`surfaces/detail/index.ts\` plus matching formatters in \`chrome/previewPane.ts\`. Render the cursored item's number/title/state/author/labels/branches/timestamps. Body text is intentionally omitted — list payloads from \`gh issue/pr list\` don't carry bodies and phase 4 will hydrate per cursor rest.
- **Data effects**: two new \`useEffect\` hooks in \`runtime/app.ts\` call \`getIssueList()\` / \`getPullRequestList()\` on view entry. Default filter is \`state: 'open'\`, matching the CLI defaults so the workstation and \`coco issues\` show the same set.
- **Chords**: bindings in \`inkKeymap.ts\`, dispatch in \`inkInput.ts\`. Footer hints updated for both views.

## Out of scope (deferred to later phases)

- **Per-row actions** (merge, approve, close, comment, assign, label) → phases 4-5
- **Filter cycling \`f\`** (canned open/mine/draft/mergeable presets) → phase 6
- **AI summarize \`I\`** → phase 6
- **Body / comments / reviews in inspector** (needs a per-item \`gh\` fetch) → phase 4 alongside actions
- **\`O\` open in browser from triage views** → phase 4 with the rest of the per-row actions

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm run test:jest\` — 1786 tests pass, 7 skipped (162 suites). Includes 27 new tests across the preview formatters, surface state messages, view-model reducer, and chord/j/k input dispatch.
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: \`coco ui\`, press \`gi\` → issues list renders, j/k scrolls, esc pops, right-pane inspector tracks the cursor.
- [ ] Manual: \`coco ui\`, press \`gP\` → PR triage list renders, draft/mergeable/review glyphs show, \`gp\` still opens the single-PR panel.

## Notes for review

- No new dependencies. No \`.coco.config.json\` schema changes.
- The disk cache from phase 2 is **not** wired into the TUI fetchers in this phase — the workstation always fetches fresh on view entry. Wiring the cache into the workstation effects is a small follow-up; doing it here would bloat the diff and the cache hit-rate inside a single TUI session is low anyway (you'd typically only return to the view if you wanted fresh data).
- Theme colors picked from the semantic palette (\`success\` / \`danger\` / \`warning\` / \`accent\` / \`muted\`) rather than the git-status palette (\`gitAdded\` / \`gitDeleted\` / \`gitModified\`) — the latter are reserved for actual git status indicators per the surrounding code.