### PR TITLE
feat(testUtils): rich-history-graph scenario for compact + full-graph rendering

### DIFF
--- a/src/lib/testUtils/README.md
+++ b/src/lib/testUtils/README.md
@@ -79,7 +79,7 @@ The CLI driver lives at `bin/scenario.ts` and is wired via the
 
 ## Available scenarios
 
-Run `npm run scenario list` for the live list. Current set (9 scenarios across 4 kinds):
+Run `npm run scenario list` for the live list. Current set (10 scenarios across 5 kinds):
 
 | Name | Kind | What you get |
 |---|---|---|
@@ -91,6 +91,7 @@ Run `npm run scenario list` for the live list. Current set (9 scenarios across 4
 | `dirty-many-files` | worktree | 12 staged + 6 unstaged + 3 untracked files across `src/`, `tests/`, `docs/` — for the future split flow |
 | `mid-bisect` | operation | 20 commits + active `git bisect`, HEAD at midpoint — for the bisect view |
 | `mid-merge-conflict` | operation | in-progress merge with 1 unresolved conflict on `src/widget.ts` — for the conflicts view |
+| `rich-history-graph` | history | 20+ commits across 6 date buckets, 2 `--no-ff` merges, 1 live unmerged `feat/wip` — for compact + full-graph rendering (bucket dividers, type coloring, branch chips, lane topology) |
 | `stashed-changes` | stash | clean `main` + 3 stashes (LIFO ordered, each touching a distinct file) — for the stash view |
 
 `npm run scenario describe <name>` prints the full description and

--- a/src/lib/testUtils/scenarios/index.ts
+++ b/src/lib/testUtils/scenarios/index.ts
@@ -18,6 +18,7 @@ import { featurePrReadyScenario } from './feature-pr-ready'
 import { midBisectScenario } from './mid-bisect'
 import { midMergeConflictScenario } from './mid-merge-conflict'
 import { multiCommitBranchScenario } from './multi-commit-branch'
+import { richHistoryGraphScenario } from './rich-history-graph'
 import { singleStagedFileScenario } from './single-staged-file'
 import { stashedChangesScenario } from './stashed-changes'
 import { twoCommitFeatureScenario } from './two-commit-feature'
@@ -39,6 +40,8 @@ export const allScenarios: readonly Scenario[] = [
   // in-progress operations
   midBisectScenario,
   midMergeConflictScenario,
+  // history shapes
+  richHistoryGraphScenario,
   // stash shapes
   stashedChangesScenario,
 ]
@@ -59,6 +62,7 @@ export { featurePrReadyScenario } from './feature-pr-ready'
 export { midBisectScenario } from './mid-bisect'
 export { midMergeConflictScenario } from './mid-merge-conflict'
 export { multiCommitBranchScenario } from './multi-commit-branch'
+export { richHistoryGraphScenario } from './rich-history-graph'
 export { singleStagedFileScenario } from './single-staged-file'
 export { stashedChangesScenario } from './stashed-changes'
 export { twoCommitFeatureScenario } from './two-commit-feature'

--- a/src/lib/testUtils/scenarios/rich-history-graph.test.ts
+++ b/src/lib/testUtils/scenarios/rich-history-graph.test.ts
@@ -1,0 +1,110 @@
+import { richHistoryGraphScenario } from './rich-history-graph'
+import { createTempGitRepo, type TempGitRepo } from '../tempGitRepo'
+
+describe('rich-history-graph scenario', () => {
+  let repo: TempGitRepo
+
+  beforeAll(async () => {
+    repo = await createTempGitRepo()
+    await richHistoryGraphScenario.setup(repo)
+  }, 60_000)
+
+  afterAll(async () => {
+    await repo?.cleanup()
+  })
+
+  it('lands with main checked out and a clean worktree', async () => {
+    const status = await repo.git.status()
+    expect(status.current).toBe('main')
+    expect(status.isClean()).toBe(true)
+  })
+
+  it('keeps feat/wip unmerged so the chip renderer has a target', async () => {
+    const branches = await repo.git.branchLocal()
+    expect(branches.all).toContain('feat/wip')
+
+    // feat/wip exists as a ref but is not reachable from main — that's
+    // exactly the shape the branch-tip chip needs to render at a tip
+    // that isn't HEAD.
+    const reachable = await repo.git.raw(['rev-list', '--count', 'main..feat/wip'])
+    expect(parseInt(reachable.trim(), 10)).toBeGreaterThan(0)
+  })
+
+  it('keeps feat/auth and feat/payments reachable from main via merge commits', async () => {
+    const branches = await repo.git.branchLocal()
+    expect(branches.all).toContain('feat/auth')
+    expect(branches.all).toContain('feat/payments')
+
+    // Both feature branches should be reachable from main (they got
+    // merged), but main should NOT be reachable from them — the
+    // merge commit is the convergence point on the main side.
+    const authReachable = await repo.git.raw(['rev-list', '--count', 'feat/auth..main'])
+    const paymentsReachable = await repo.git.raw(['rev-list', '--count', 'feat/payments..main'])
+    expect(parseInt(authReachable.trim(), 10)).toBeGreaterThan(0)
+    expect(parseInt(paymentsReachable.trim(), 10)).toBeGreaterThan(0)
+  })
+
+  it('produces at least two --no-ff merge commits on main', async () => {
+    // `--merges` filters to commits with more than one parent. Two
+    // explicit merges (feat/auth + feat/payments) should appear.
+    const merges = await repo.git.raw(['log', '--merges', '--format=%s', 'main'])
+    const lines = merges.trim().split('\n').filter(Boolean)
+    expect(lines.length).toBeGreaterThanOrEqual(2)
+    expect(lines.some((l) => l.includes('feat/auth'))).toBe(true)
+    expect(lines.some((l) => l.includes('feat/payments'))).toBe(true)
+  })
+
+  it('spans at least 6 distinct date buckets across the log', async () => {
+    // Pull author dates in YYYY-MM-DD form and bucket them coarsely:
+    // today / yesterday / this-week / last-week / + each older
+    // calendar month (one bucket per month). The scenario should
+    // produce at least 6 distinct buckets so the divider renderer
+    // has a real ladder to walk.
+    const out = await repo.git.raw(['log', '--all', '--date=short', '--pretty=%ad'])
+    const dates = out.trim().split('\n').filter(Boolean)
+
+    const now = new Date()
+    const oneDay = 24 * 60 * 60 * 1000
+    const nowUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+    const buckets = new Set<string>()
+    for (const iso of dates) {
+      const [y, m, d] = iso.split('-').map((n) => parseInt(n, 10))
+      const commitUtc = Date.UTC(y, m - 1, d)
+      const days = Math.floor((nowUtc - commitUtc) / oneDay)
+      if (days <= 0) buckets.add('today')
+      else if (days === 1) buckets.add('yesterday')
+      else if (days < 7) buckets.add('this-week')
+      else if (days < 14) buckets.add('last-week')
+      else buckets.add(`${y}-${String(m).padStart(2, '0')}`)
+    }
+    expect(buckets.size).toBeGreaterThanOrEqual(6)
+  })
+
+  it('exercises every conventional-commit type the renderer maps', async () => {
+    const log = await repo.git.log(['--all'])
+    const subjects = log.all.map((entry) => entry.message.split('\n')[0])
+    const typeTokens = new Set(
+      subjects
+        .map((s) => /^([a-z]+)(\([^)]+\))?(!)?:/.exec(s)?.[1])
+        .filter(Boolean) as string[]
+    )
+
+    for (const expected of ['feat', 'fix', 'chore', 'docs', 'refactor', 'test', 'perf', 'revert']) {
+      expect(typeTokens.has(expected)).toBe(true)
+    }
+  })
+
+  it('includes a breaking-change marker on at least one commit', async () => {
+    const log = await repo.git.log(['--all'])
+    const subjects = log.all.map((entry) => entry.message.split('\n')[0])
+    expect(subjects.some((s) => /^[a-z]+(\([^)]+\))?!:/.test(s))).toBe(true)
+  })
+
+  it('has at least one commit dated today (the freshest bucket)', async () => {
+    const out = await repo.git.raw(['log', '--date=short', '--pretty=%ad', 'main'])
+    const dates = out.trim().split('\n').filter(Boolean)
+    const today = new Date()
+    const todayIso = `${today.getUTCFullYear()}-${String(today.getUTCMonth() + 1).padStart(2, '0')}-${String(today.getUTCDate()).padStart(2, '0')}`
+    expect(dates).toContain(todayIso)
+  })
+})

--- a/src/lib/testUtils/scenarios/rich-history-graph.ts
+++ b/src/lib/testUtils/scenarios/rich-history-graph.ts
@@ -1,0 +1,202 @@
+/**
+ * `rich-history-graph` — a multi-branch repo whose log spans every
+ * date bucket, every conventional-commit type, and several lane-
+ * merging topologies. Built to give the history surface
+ * (compact + full graph) something rich to render: section headers,
+ * type-colored prefixes, branch chips, lane-color transitions, and
+ * a still-active unmerged branch.
+ *
+ * State after setup (relative to "today" at run time):
+ *   - main is checked out, clean worktree
+ *   - 4 merge commits on main + linear stretches between them
+ *   - `feat/wip` exists and is NOT merged into main (chip target)
+ *   - Commit dates span: 60 days ago → today, hitting every bucket
+ *     (today, yesterday, this-week, last-week, two earlier
+ *     calendar months)
+ *
+ * Used to validate the rendering of:
+ *   - date bucket dividers (`── Today ──`, `── April 2026 ──`, …)
+ *   - conventional-commit type coloring (feat / fix / chore / docs /
+ *     refactor / test / perf / revert / `fix!:` breaking marker)
+ *   - branch-tip chips (HEAD branch + unmerged `feat/wip`)
+ *   - lane coloring across forks (`├╮`) and merges (`├╯`)
+ *   - sticky bucket header on deep scroll
+ *
+ * Manual driver:
+ *   npm run scenario create rich-history-graph -- --run-ui
+ *
+ * EXTRACTION DISCIPLINE: no coco-specific imports. Date overrides
+ * are plumbed through `GIT_AUTHOR_DATE` / `GIT_COMMITTER_DATE` so
+ * the scenario stays as a pure git-state factory.
+ */
+
+import type { TempGitRepo } from '../tempGitRepo'
+import type { Scenario } from './types'
+import { writeSeededFiles } from './shared/seededFiles'
+
+const BASE_SEED = 0xc0c0a11e
+
+/**
+ * UTC midnight `daysAgo` days before now, returned as an ISO string
+ * git accepts via `GIT_AUTHOR_DATE` / `GIT_COMMITTER_DATE`. Pinned at
+ * 12:00 UTC so the date portion never drifts across timezones — the
+ * bucket helper compares at day granularity, so the time of day is
+ * irrelevant beyond making the date stable.
+ */
+function isoDaysAgo(daysAgo: number): string {
+  const now = new Date()
+  const d = new Date(Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate() - daysAgo,
+    12, 0, 0,
+  ))
+  return d.toISOString()
+}
+
+/**
+ * Stage everything and commit with both AUTHOR and COMMITTER dates
+ * pinned to `daysAgo`. Uses raw git so we don't depend on simple-git's
+ * `commit()` signature for the date override — that helper only sets
+ * the author date, but `git log --date=short` (and downstream
+ * bucketing) reads the date that's exposed in the formatted output,
+ * which lines up cleanly when both env vars match.
+ */
+async function commitAtDay(
+  repo: TempGitRepo,
+  daysAgo: number,
+  message: string,
+): Promise<void> {
+  const iso = isoDaysAgo(daysAgo)
+  await repo.git.add('.')
+  await repo.git
+    .env({ GIT_AUTHOR_DATE: iso, GIT_COMMITTER_DATE: iso })
+    .raw(['commit', '-m', message])
+}
+
+/**
+ * Write a small per-commit file then call `commitAtDay`. Picking a
+ * fresh file path per commit guarantees git treats every step as a
+ * non-empty change without us having to track the running scenario
+ * state.
+ */
+async function writeAndCommitAtDay(
+  repo: TempGitRepo,
+  daysAgo: number,
+  filePath: string,
+  message: string,
+  seedOffset: number,
+): Promise<void> {
+  await writeSeededFiles(repo, [{ path: filePath, tokens: 60 + seedOffset }], BASE_SEED + seedOffset)
+  await commitAtDay(repo, daysAgo, message)
+}
+
+/**
+ * Always-`--no-ff` merge of `branch` into the current branch at
+ * `daysAgo` with author + committer dates pinned. Forces a merge
+ * commit even when the branch could fast-forward so the graph shows
+ * a real lane closure (`├╯`) instead of a silent linear advance.
+ */
+async function mergeAtDay(
+  repo: TempGitRepo,
+  daysAgo: number,
+  branch: string,
+  message: string,
+): Promise<void> {
+  const iso = isoDaysAgo(daysAgo)
+  await repo.git
+    .env({ GIT_AUTHOR_DATE: iso, GIT_COMMITTER_DATE: iso })
+    .raw(['merge', '--no-ff', branch, '-m', message])
+}
+
+export const richHistoryGraphScenario: Scenario = {
+  name: 'rich-history-graph',
+  summary:
+    'multi-branch history that exercises bucket dividers, type coloring, branch chips, lane topology',
+  description: [
+    'A multi-branch repo built to stress the history surface. Commits',
+    'span every date bucket (today / yesterday / this-week / last-week',
+    'plus two older calendar-month buckets), every conventional-commit',
+    'type the renderer knows (feat / fix / chore / docs / refactor /',
+    'test / perf / revert plus a `fix!:` breaking marker), and three',
+    'distinct branch lifecycles: two feature branches merged back into',
+    'main with --no-ff merge commits, plus one unmerged `feat/wip`',
+    'sitting as a live branch tip.',
+    '',
+    'Run with --run-ui to drive the workstation against it:',
+    '',
+    '  npm run scenario create rich-history-graph -- --run-ui',
+    '',
+    'Toggle `g` to flip between compact and full graph modes; the same',
+    'underlying history exercises both renderers.',
+  ].join('\n'),
+  kind: 'history',
+  contracts: [
+    'main is checked out',
+    'feat/wip exists and is NOT merged into main',
+    'two --no-ff merge commits sit on main (feat/auth, feat/payments)',
+    'worktree is clean',
+    'commits span at least 6 distinct date buckets (today through 2 older months)',
+    'commit messages cover feat / fix / chore / docs / refactor / test / perf / revert and a breaking-change `!:`',
+  ],
+  async setup(repo) {
+    // ── March bucket (oldest) ────────────────────────────────────
+    await writeAndCommitAtDay(repo, 60, 'README.md', 'Initial scaffold', 0)
+    await writeAndCommitAtDay(repo, 45, 'src/api/router.ts', 'feat(api): public router skeleton', 1)
+
+    // ── April bucket (older month) ──────────────────────────────
+    await writeAndCommitAtDay(repo, 30, 'docs/README-extended.md', 'docs: project README and contributor guide', 2)
+
+    // First feature branch — feat/auth — lives 25-22d ago
+    await repo.git.checkoutLocalBranch('feat/auth')
+    await writeAndCommitAtDay(repo, 25, 'src/auth/session.ts', 'feat(auth): session middleware', 3)
+    await writeAndCommitAtDay(repo, 23, 'tests/auth/session.test.ts', 'test: cover session edge cases', 4)
+
+    // Merge feat/auth back to main
+    await repo.git.checkout('main')
+    await mergeAtDay(repo, 22, 'feat/auth', "Merge branch 'feat/auth'")
+
+    await writeAndCommitAtDay(repo, 20, 'src/api/errors.ts', 'refactor(api): centralise error shapes', 5)
+    await writeAndCommitAtDay(repo, 16, 'src/api/router.ts', 'fix(api): route precedence for catch-all', 6)
+
+    // ── Last-week bucket (7-13d) ─────────────────────────────────
+    await writeAndCommitAtDay(repo, 13, 'package.json', 'chore(deps): bump simple-git to 4.x', 7)
+    await writeAndCommitAtDay(repo, 12, 'docs/CONTRIBUTING.md', 'docs: contributor guide', 8)
+
+    // Second feature branch — feat/payments — lives 11-7d ago
+    await repo.git.checkoutLocalBranch('feat/payments')
+    await writeAndCommitAtDay(repo, 11, 'src/payments/checkout.ts', 'feat(payments): stripe checkout adapter', 9)
+    await writeAndCommitAtDay(repo, 10, 'src/payments/3ds.ts', 'fix(payments): handle 3D-secure redirect', 10)
+    await writeAndCommitAtDay(repo, 9, 'tests/payments/checkout.test.ts', 'test: cover stripe checkout flow', 11)
+
+    await repo.git.checkout('main')
+    await mergeAtDay(repo, 7, 'feat/payments', "Merge branch 'feat/payments'")
+
+    // ── This-week bucket (2-6d) ──────────────────────────────────
+    await writeAndCommitAtDay(repo, 6, 'src/api/router.ts', 'perf(api): cache compiled route matcher', 12)
+    await writeAndCommitAtDay(repo, 5, 'src/db/queries.ts', 'fix(db): retry on transient timeout', 13)
+    await writeAndCommitAtDay(repo, 4, 'src/db/migrations/0001_add_index.sql', 'perf(db): index user_id on sessions', 14)
+
+    // Third feature branch — feat/wip — diverged but NOT merged.
+    // Leaves a live unmerged tip so the chip renderer has a target.
+    await repo.git.checkoutLocalBranch('feat/wip')
+    await writeAndCommitAtDay(repo, 3, 'src/search/experimental.ts', 'feat(search): experimental trigram backend', 15)
+    await writeAndCommitAtDay(repo, 2, 'src/search/cache.ts', 'chore(search): prototype lookup cache', 16)
+
+    // Back to main for the final stretch + today's commits.
+    await repo.git.checkout('main')
+
+    // ── Yesterday bucket ─────────────────────────────────────────
+    await writeAndCommitAtDay(repo, 1, 'src/api/router.ts', 'fix!: drop deprecated v1 endpoints', 17)
+
+    // ── Today bucket ─────────────────────────────────────────────
+    await writeAndCommitAtDay(repo, 0, 'src/index.ts', 'chore: tidy imports', 18)
+    await writeAndCommitAtDay(repo, 0, 'src/api/router.ts', 'revert: temporary rollback of v1-shim removal', 19)
+    await writeAndCommitAtDay(repo, 0, 'src/search/index.ts', 'feat(search): trigram-based subject filter', 20)
+
+    // End state: HEAD on main, clean worktree, feat/wip and feat/auth
+    // and feat/payments all preserved as branch refs. feat/auth and
+    // feat/payments are reachable from main via their merge commits;
+    // feat/wip is NOT reachable from main.
+  },
+}


### PR DESCRIPTION
## Summary

A new \`history\`-kind scenario purpose-built to give the history surface (both compact and full-graph modes) something rich to render. Drives every visual feature we've shipped in the last few PRs:

| Feature                              | What the scenario produces                               |
| ------------------------------------ | -------------------------------------------------------- |
| Date bucket dividers (#968)          | 20+ commits spanning 6 buckets: today, yesterday, this-week, last-week, two older calendar months |
| Conventional commit type coloring (#967) | Messages covering feat / fix / chore / docs / refactor / test / perf / revert + a \`fix!:\` breaking marker |
| Branch tip chips (#963, #966)        | HEAD branch (main) + unmerged \`feat/wip\` chip target   |
| Lane topology + spacer rhythm        | Two \`--no-ff\` merges on main (\`feat/auth\`, \`feat/payments\`) producing real lane-closure curves |
| Responsive density tiers (#961)      | Enough commit volume that the visible window scrolls into older buckets and the sticky header kicks in |

## Manual driver

\`\`\`bash
npm run scenario create rich-history-graph -- --run-ui
\`\`\`

Toggle \`g\` inside \`coco ui\` to flip between compact and full graph modes against the same underlying history.

## Date plumbing

Author + committer dates are pinned via \`GIT_AUTHOR_DATE\` / \`GIT_COMMITTER_DATE\` env vars on each \`git commit\` and \`git merge --no-ff\` so the bucket distribution lands as expected regardless of when the scenario runs. The reference point is \"today at run time\" so manual UI testing always sees fresh \`Today\` / \`Yesterday\` headers.

Helpers (private to the scenario):

- \`isoDaysAgo(n)\` — UTC noon, \`n\` days before now, ISO string
- \`commitAtDay(repo, n, msg)\` — stages + commits with both date env vars pinned
- \`mergeAtDay(repo, n, branch, msg)\` — \`--no-ff\` merge with the same plumbing

## Test plan

- [x] \`rich-history-graph.test.ts\` — 8 contract tests covering: HEAD on main + clean worktree, \`feat/wip\` unmerged, \`feat/auth\` + \`feat/payments\` reachable, \`>= 2\` merge commits, \`>= 6\` distinct date buckets, every conventional type present, at least one breaking marker, at least one commit dated today.
- [x] Full jest suite: 1805 pass / 7 skipped (8 new tests added).
- [x] \`npm run lint\` clean.
- [x] \`npm run build\` produces dist bundles.
- [x] \`npm run scenario list\` shows the new entry under a new \`history:\` group.
- [x] \`npm run scenario describe rich-history-graph\` renders the full description and contracts.
- [ ] Manual: drive \`coco ui\` against the scenario and visually confirm every feature renders. Reviewer should do this since I can't drive a real terminal from here.

## Notes for the reviewer

- Extraction discipline preserved: only imports are \`simple-git\`, Node stdlib, and the existing \`seededFiles\` wrapper. The README's boundary rules still hold.
- The scenario is a \`history\`-kind which is already in the \`ScenarioKind\` union; this PR is the first user of that kind.
- README's scenario table updated to list the new entry alongside the existing 9.