### PR TITLE
feat(workstation): low-risk per-row actions on issue / PR triage (#882 phase 4)

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -3488,3 +3488,138 @@ describe('issue / pull-request triage chords (#882 phase 3)', () => {
     expect(state.selectedIssueIndex).toBe(0)
   })
 })
+
+describe('triage-view per-row actions (#882 phase 4)', () => {
+  describe('issues view', () => {
+    const baseState = (): LogInkState =>
+      applyLogInkAction(createLogInkState(rows), { type: 'pushView', value: 'issues' })
+
+    it('O dispatches the triage-issue-open workflow when an URL is in scope', () => {
+      const state = baseState()
+      const events = getLogInkInputEvents(state, 'O', {}, {
+        issueCount: 1,
+        issueSelectedUrl: 'https://github.com/gfargo/coco/issues/882',
+      })
+      expect(events).toEqual([{ type: 'runWorkflowAction', id: 'triage-issue-open' }])
+    })
+
+    it('O falls through to the global open-pr workflow when no issue URL is in scope', () => {
+      // Without an issue URL in context, the triage-O handler doesn't
+      // claim the keystroke — it falls through to the global O
+      // binding (which targets the current branch's PR / commit /
+      // repo). Documenting this so the next maintainer doesn't
+      // confuse "no issue cursored" with "no-op".
+      const state = baseState()
+      const events = getLogInkInputEvents(state, 'O', {}, {})
+      expect(events).toEqual([{ type: 'runWorkflowAction', id: 'open-pr' }])
+    })
+
+    it('c opens a multi-line input prompt for triage-issue-comment', () => {
+      const state = applyInput(baseState(), 'c', {}, { issueCount: 5 })
+      expect(state.inputPrompt?.kind).toBe('triage-issue-comment')
+      expect(state.inputPrompt?.multiline).toBe(true)
+    })
+
+    it('L opens an input prompt for triage-issue-label', () => {
+      const state = applyInput(baseState(), 'L', {}, { issueCount: 5 })
+      expect(state.inputPrompt?.kind).toBe('triage-issue-label')
+      expect(state.inputPrompt?.multiline).toBeFalsy()
+    })
+
+    it('A pre-seeds the assignee prompt with @me for ergonomics', () => {
+      const state = applyInput(baseState(), 'A', {}, { issueCount: 5 })
+      expect(state.inputPrompt?.kind).toBe('triage-issue-assign')
+      expect(state.inputPrompt?.value).toBe('@me')
+    })
+
+    it('y dispatches yankFromActiveView when an issue URL is in scope', () => {
+      const state = baseState()
+      const events = getLogInkInputEvents(state, 'y', {}, {
+        issueCount: 1,
+        issueSelectedUrl: 'https://github.com/gfargo/coco/issues/882',
+      })
+      expect(events).toEqual([{ type: 'yankFromActiveView' }])
+    })
+
+    it('submitting the triage-issue-comment prompt (Ctrl+D) fires runWorkflowAction with the body', () => {
+      // The comment prompt is multi-line, so Enter inserts a newline
+      // and Ctrl+D is the submit affordance — mirrors the
+      // pr-comment / pr-request-changes prompts. The single-line
+      // triage-issue-label / triage-issue-assign prompts submit on
+      // Enter (no Ctrl+D needed).
+      let state = baseState()
+      state = applyInput(state, 'c', {}, { issueCount: 5 })
+      state = applyLogInkAction(state, { type: 'appendInputPrompt', value: 'lgtm' })
+
+      const events = getLogInkInputEvents(state, 'd', { ctrl: true })
+      const workflow = events.find((e) => e.type === 'runWorkflowAction')
+      expect(workflow).toEqual({
+        type: 'runWorkflowAction',
+        id: 'triage-issue-comment',
+        payload: 'lgtm',
+      })
+    })
+
+    it('submitting the triage-issue-label prompt (Enter) fires runWorkflowAction', () => {
+      let state = baseState()
+      state = applyInput(state, 'L', {}, { issueCount: 5 })
+      state = applyLogInkAction(state, { type: 'appendInputPrompt', value: 'enhancement' })
+
+      const events = getLogInkInputEvents(state, '', { return: true })
+      const workflow = events.find((e) => e.type === 'runWorkflowAction')
+      expect(workflow).toEqual({
+        type: 'runWorkflowAction',
+        id: 'triage-issue-label',
+        payload: 'enhancement',
+      })
+    })
+
+    it('Enter on a multi-line triage prompt inserts a newline instead of submitting', () => {
+      let state = baseState()
+      state = applyInput(state, 'c', {}, { issueCount: 5 })
+      state = applyInput(state, 'a')
+      state = applyInput(state, '', { return: true })
+      expect(state.inputPrompt?.value).toBe('a\n')
+    })
+  })
+
+  describe('pull-request-triage view', () => {
+    const baseState = (): LogInkState =>
+      applyLogInkAction(createLogInkState(rows), {
+        type: 'pushView',
+        value: 'pull-request-triage',
+      })
+
+    it('O dispatches the triage-pr-open workflow when a PR URL is in scope', () => {
+      const state = baseState()
+      const events = getLogInkInputEvents(state, 'O', {}, {
+        pullRequestTriageCount: 1,
+        pullRequestTriageSelectedUrl: 'https://github.com/gfargo/coco/pull/962',
+      })
+      expect(events).toEqual([{ type: 'runWorkflowAction', id: 'triage-pr-open' }])
+    })
+
+    it('c / L / A open the matching triage-pr-* prompt kinds', () => {
+      let state = applyInput(baseState(), 'c', {}, { pullRequestTriageCount: 3 })
+      expect(state.inputPrompt?.kind).toBe('triage-pr-comment')
+
+      state = applyInput(baseState(), 'L', {}, { pullRequestTriageCount: 3 })
+      expect(state.inputPrompt?.kind).toBe('triage-pr-label')
+
+      state = applyInput(baseState(), 'A', {}, { pullRequestTriageCount: 3 })
+      expect(state.inputPrompt?.kind).toBe('triage-pr-assign')
+    })
+
+    it('does NOT collide with the single-PR action panel keys', () => {
+      // Regression guard: from the `pull-request` view (single, current
+      // branch), `c` still routes to the existing `pr-comment` prompt,
+      // not the triage variant.
+      const state = applyLogInkAction(createLogInkState(rows), {
+        type: 'pushView',
+        value: 'pull-request',
+      })
+      const result = applyInput(state, 'c')
+      expect(result.inputPrompt?.kind).toBe('pr-comment')
+    })
+  })
+})

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -740,6 +740,45 @@ function submitInputPrompt(state: LogInkState): LogInkInputEvent[] {
       action({ type: 'closeInputPrompt' }),
     ]
   }
+  // #882 phase 4 — triage-view mutation prompts. Each kind routes to
+  // its by-number workflow id; the runner reads the cursored item
+  // from state + filtered list and runs the matching `gh` action.
+  if (state.inputPrompt.kind === 'triage-issue-comment') {
+    return [
+      { type: 'runWorkflowAction', id: 'triage-issue-comment', payload: value },
+      action({ type: 'closeInputPrompt' }),
+    ]
+  }
+  if (state.inputPrompt.kind === 'triage-issue-label') {
+    return [
+      { type: 'runWorkflowAction', id: 'triage-issue-label', payload: value },
+      action({ type: 'closeInputPrompt' }),
+    ]
+  }
+  if (state.inputPrompt.kind === 'triage-issue-assign') {
+    return [
+      { type: 'runWorkflowAction', id: 'triage-issue-assign', payload: value },
+      action({ type: 'closeInputPrompt' }),
+    ]
+  }
+  if (state.inputPrompt.kind === 'triage-pr-comment') {
+    return [
+      { type: 'runWorkflowAction', id: 'triage-pr-comment', payload: value },
+      action({ type: 'closeInputPrompt' }),
+    ]
+  }
+  if (state.inputPrompt.kind === 'triage-pr-label') {
+    return [
+      { type: 'runWorkflowAction', id: 'triage-pr-label', payload: value },
+      action({ type: 'closeInputPrompt' }),
+    ]
+  }
+  if (state.inputPrompt.kind === 'triage-pr-assign') {
+    return [
+      { type: 'runWorkflowAction', id: 'triage-pr-assign', payload: value },
+      action({ type: 'closeInputPrompt' }),
+    ]
+  }
   if (state.inputPrompt.kind === 'pr-request-changes') {
     return [
       action({ type: 'setPendingConfirmation', value: 'request-changes-pr', payload: value }),
@@ -2326,6 +2365,72 @@ export function getLogInkInputEvents(
     })]
   }
 
+  // #882 phase 4 — issue triage per-row actions. Scoped to the
+  // `'issues'` view + commits focus so the single-letter keys stay
+  // free elsewhere. Each prompts; submit dispatches the matching
+  // `triage-issue-*` workflow which routes through `gh issue` and
+  // invalidates both the in-memory + disk caches on success.
+  if (state.activeView === 'issues' && state.focus === 'commits') {
+    if (inputValue === 'O' && context.issueSelectedUrl) {
+      return [{ type: 'runWorkflowAction', id: 'triage-issue-open' }]
+    }
+    if (inputValue === 'c' && context.issueCount) {
+      return [action({
+        type: 'openInputPrompt',
+        kind: 'triage-issue-comment',
+        label: 'Comment body (Enter newline · Ctrl+D submit)',
+        multiline: true,
+      })]
+    }
+    if (inputValue === 'L' && context.issueCount) {
+      return [action({
+        type: 'openInputPrompt',
+        kind: 'triage-issue-label',
+        label: 'Label name to add',
+      })]
+    }
+    if (inputValue === 'A' && context.issueCount) {
+      return [action({
+        type: 'openInputPrompt',
+        kind: 'triage-issue-assign',
+        label: 'Assignee login (or @me)',
+        initial: '@me',
+      })]
+    }
+  }
+
+  // #882 phase 4 — PR triage per-row actions. Same shape as the
+  // issue handlers above; distinct view id so the keys don't
+  // collide with the single-PR action panel (`pull-request`).
+  if (state.activeView === 'pull-request-triage' && state.focus === 'commits') {
+    if (inputValue === 'O' && context.pullRequestTriageSelectedUrl) {
+      return [{ type: 'runWorkflowAction', id: 'triage-pr-open' }]
+    }
+    if (inputValue === 'c' && context.pullRequestTriageCount) {
+      return [action({
+        type: 'openInputPrompt',
+        kind: 'triage-pr-comment',
+        label: 'Comment body (Enter newline · Ctrl+D submit)',
+        multiline: true,
+      })]
+    }
+    if (inputValue === 'L' && context.pullRequestTriageCount) {
+      return [action({
+        type: 'openInputPrompt',
+        kind: 'triage-pr-label',
+        label: 'Label name to add',
+      })]
+    }
+    if (inputValue === 'A' && context.pullRequestTriageCount) {
+      return [action({
+        type: 'openInputPrompt',
+        kind: 'triage-pr-assign',
+        label: 'Assignee login (or @me)',
+        initial: '@me',
+      })]
+    }
+  }
+
   // Global stash hotkey: `S` opens a stash-message prompt and
   // `createStash` runs once submitted. Available everywhere there's
   // not a more modal handler in front of it.
@@ -2607,6 +2712,17 @@ export function getLogInkInputEvents(
     // history view's Y).
     if (isSubmodulesActionTarget(state) && context.submoduleCount) {
       return [{ type: 'yankFromActiveView', short }]
+    }
+    // #882 phase 4 — triage views: y yanks the cursored issue / PR
+    // URL so the user can paste it into a chat / PR description
+    // without dropping back to the browser. Y is a no-op on these
+    // views — there's no compact alternate identifier worth a
+    // second key.
+    if (isIssueActionTarget(state) && context.issueSelectedUrl) {
+      return [{ type: 'yankFromActiveView' }]
+    }
+    if (isPullRequestTriageActionTarget(state) && context.pullRequestTriageSelectedUrl) {
+      return [{ type: 'yankFromActiveView' }]
     }
   }
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -786,19 +786,20 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
 
   if (options.activeView === 'issues') {
     return {
-      // #882 phase 3 — read-only triage list. Per-row actions
-      // (label, assign, comment, close) land in phase 4-5.
-      contextual: ['↑/↓ issues', 'esc back'],
+      // #882 phase 4 — read + low-risk mutations: comment, label,
+      // assign. Destructive mutations (close, reopen) land in phase 5.
+      contextual: ['↑/↓ issues', 'O open', 'y yank URL', 'c comment', 'L label', 'A assign', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }
 
   if (options.activeView === 'pull-request-triage') {
     return {
-      // #882 phase 3 — read-only triage list. Per-row actions
-      // (merge, approve, request-changes, close, comment) land
-      // in phase 4-5.
-      contextual: ['↑/↓ PRs', 'esc back'],
+      // #882 phase 4 — read + low-risk mutations on PRs. Merge /
+      // approve / request-changes / close stay scoped to the
+      // single-PR action panel (`gp`) for now; they land here in
+      // phase 5 alongside the y-confirm path.
+      contextual: ['↑/↓ PRs', 'O open', 'y yank URL', 'c comment', 'L label', 'A assign', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -541,6 +541,16 @@ export type LogInkInputPromptKind =
   | 'pr-request-changes'
   | 'create-pr'
   | 'bisect-run-command'
+  // #882 phase 4 — triage-view mutations. Distinct from the
+  // single-PR `pr-comment` / `pr-request-changes` kinds above so
+  // the submit handler routes to the by-number workflows (the
+  // single-PR equivalents target the current branch's PR).
+  | 'triage-issue-comment'
+  | 'triage-issue-label'
+  | 'triage-issue-assign'
+  | 'triage-pr-comment'
+  | 'triage-pr-label'
+  | 'triage-pr-assign'
 
 export type LogInkInputPromptState = {
   kind: LogInkInputPromptKind

--- a/src/git/issueActions.test.ts
+++ b/src/git/issueActions.test.ts
@@ -1,0 +1,80 @@
+import { addIssueAssignee, addIssueLabel, commentIssue } from './issueActions'
+
+describe('issueActions', () => {
+  describe('commentIssue', () => {
+    it('rejects empty bodies without invoking gh', async () => {
+      const runner = jest.fn()
+      await expect(commentIssue(882, '   ', runner)).resolves.toEqual({
+        ok: false,
+        message: 'Comment body required',
+      })
+      expect(runner).not.toHaveBeenCalled()
+    })
+
+    it('invokes `gh issue comment <#> --body <body>` and surfaces success', async () => {
+      const runner = jest.fn().mockResolvedValue('https://github.com/gfargo/coco/issues/882#comment-1')
+      await expect(commentIssue(882, 'lgtm', runner)).resolves.toEqual({
+        ok: true,
+        message: 'https://github.com/gfargo/coco/issues/882#comment-1',
+      })
+      expect(runner).toHaveBeenCalledWith(['issue', 'comment', '882', '--body', 'lgtm'])
+    })
+
+    it('falls back to a synthesized message when gh output is empty', async () => {
+      const runner = jest.fn().mockResolvedValue('')
+      await expect(commentIssue(7, 'thanks!', runner)).resolves.toEqual({
+        ok: true,
+        message: 'Commented on issue #7',
+      })
+    })
+
+    it('surfaces runner errors as ok: false', async () => {
+      const runner = jest.fn().mockRejectedValue(new Error('rate limited'))
+      await expect(commentIssue(1, 'hello', runner)).resolves.toEqual({
+        ok: false,
+        message: 'rate limited',
+      })
+    })
+  })
+
+  describe('addIssueLabel', () => {
+    it('rejects empty label names', async () => {
+      const runner = jest.fn()
+      await expect(addIssueLabel(1, '', runner)).resolves.toEqual({
+        ok: false,
+        message: 'Label name required',
+      })
+      expect(runner).not.toHaveBeenCalled()
+    })
+
+    it('invokes `gh issue edit <#> --add-label <label>`', async () => {
+      const runner = jest.fn().mockResolvedValue('')
+      const result = await addIssueLabel(882, 'enhancement', runner)
+      expect(result).toEqual({
+        ok: true,
+        message: "Added label 'enhancement' to issue #882",
+      })
+      expect(runner).toHaveBeenCalledWith(['issue', 'edit', '882', '--add-label', 'enhancement'])
+    })
+  })
+
+  describe('addIssueAssignee', () => {
+    it('rejects empty assignee values', async () => {
+      const runner = jest.fn()
+      await expect(addIssueAssignee(1, '   ', runner)).resolves.toEqual({
+        ok: false,
+        message: 'Assignee login required',
+      })
+      expect(runner).not.toHaveBeenCalled()
+    })
+
+    it('invokes `gh issue edit <#> --add-assignee <login>`', async () => {
+      const runner = jest.fn().mockResolvedValue('')
+      await expect(addIssueAssignee(882, '@me', runner)).resolves.toEqual({
+        ok: true,
+        message: 'Assigned @me to issue #882',
+      })
+      expect(runner).toHaveBeenCalledWith(['issue', 'edit', '882', '--add-assignee', '@me'])
+    })
+  })
+})

--- a/src/git/issueActions.ts
+++ b/src/git/issueActions.ts
@@ -1,0 +1,88 @@
+/**
+ * Low-risk issue mutations driven from the issue-triage TUI (#882
+ * phase 4). Mirrors `pullRequestActions.ts`'s shape — each function
+ * wraps a single `gh issue <verb>` invocation through the shared
+ * runner indirection so tests can mock the shell-out cleanly.
+ *
+ * "Low risk" here means: reversible by re-invoking with the
+ * opposite flag (`--add-label` ↔ `--remove-label`), or strictly
+ * additive (comment). The destructive verbs (`close`, `reopen`,
+ * `delete`) land in phase 5 alongside the PR-level destructive
+ * mutations, all gated through the y-confirm path.
+ */
+
+import { defaultGhRunner, type GhRunner } from './githubCli'
+
+export type IssueActionResult = {
+  ok: boolean
+  message: string
+}
+
+async function runGhAction(
+  runner: GhRunner,
+  args: string[],
+  successMessage: (output: string) => IssueActionResult
+): Promise<IssueActionResult> {
+  try {
+    return successMessage(await runner(args))
+  } catch (error) {
+    return {
+      ok: false,
+      message: (error as Error).message,
+    }
+  }
+}
+
+export function commentIssue(
+  issueNumber: number,
+  body: string,
+  runner: GhRunner = defaultGhRunner
+): Promise<IssueActionResult> {
+  if (!body.trim()) {
+    return Promise.resolve({ ok: false, message: 'Comment body required' })
+  }
+  return runGhAction(
+    runner,
+    ['issue', 'comment', String(issueNumber), '--body', body],
+    (output) => ({
+      ok: true,
+      message: output.trim() || `Commented on issue #${issueNumber}`,
+    })
+  )
+}
+
+export function addIssueLabel(
+  issueNumber: number,
+  label: string,
+  runner: GhRunner = defaultGhRunner
+): Promise<IssueActionResult> {
+  if (!label.trim()) {
+    return Promise.resolve({ ok: false, message: 'Label name required' })
+  }
+  return runGhAction(
+    runner,
+    ['issue', 'edit', String(issueNumber), '--add-label', label],
+    () => ({
+      ok: true,
+      message: `Added label '${label}' to issue #${issueNumber}`,
+    })
+  )
+}
+
+export function addIssueAssignee(
+  issueNumber: number,
+  assignee: string,
+  runner: GhRunner = defaultGhRunner
+): Promise<IssueActionResult> {
+  if (!assignee.trim()) {
+    return Promise.resolve({ ok: false, message: 'Assignee login required' })
+  }
+  return runGhAction(
+    runner,
+    ['issue', 'edit', String(issueNumber), '--add-assignee', assignee],
+    () => ({
+      ok: true,
+      message: `Assigned ${assignee} to issue #${issueNumber}`,
+    })
+  )
+}

--- a/src/git/pullRequestActions.test.ts
+++ b/src/git/pullRequestActions.test.ts
@@ -1,9 +1,12 @@
 import {
+  addPullRequestAssignee,
+  addPullRequestLabel,
   approvePullRequest,
   buildCreatePullRequestArgs,
   buildMergePullRequestArgs,
   closePullRequest,
   commentPullRequest,
+  commentPullRequestByNumber,
   createPullRequest,
   isPullRequestMergeStrategy,
   mergePullRequest,
@@ -151,6 +154,75 @@ describe('log pull request actions', () => {
       await expect(mergePullRequest('squash', runner)).resolves.toEqual({
         ok: true,
         message: 'Merged pull request #42 (squash)',
+      })
+    })
+  })
+})
+
+describe('triage-by-number PR actions (#882 phase 4)', () => {
+  describe('commentPullRequestByNumber', () => {
+    it('rejects empty bodies without invoking gh', async () => {
+      const runner = jest.fn()
+      await expect(commentPullRequestByNumber(962, '   ', runner)).resolves.toEqual({
+        ok: false,
+        message: 'Comment body required',
+      })
+      expect(runner).not.toHaveBeenCalled()
+    })
+
+    it('targets a specific PR number, distinct from the current-branch variant', async () => {
+      const runner = jest.fn().mockResolvedValue('')
+      await expect(commentPullRequestByNumber(962, 'lgtm', runner)).resolves.toEqual({
+        ok: true,
+        message: 'Commented on pull request #962',
+      })
+      expect(runner).toHaveBeenCalledWith(['pr', 'comment', '962', '--body', 'lgtm'])
+    })
+  })
+
+  describe('addPullRequestLabel', () => {
+    it('rejects empty labels', async () => {
+      const runner = jest.fn()
+      await expect(addPullRequestLabel(1, '', runner)).resolves.toEqual({
+        ok: false,
+        message: 'Label name required',
+      })
+    })
+
+    it('invokes `gh pr edit <#> --add-label <label>`', async () => {
+      const runner = jest.fn().mockResolvedValue('')
+      const result = await addPullRequestLabel(962, 'enhancement', runner)
+      expect(result).toEqual({
+        ok: true,
+        message: "Added label 'enhancement' to pull request #962",
+      })
+      expect(runner).toHaveBeenCalledWith(['pr', 'edit', '962', '--add-label', 'enhancement'])
+    })
+  })
+
+  describe('addPullRequestAssignee', () => {
+    it('rejects empty assignees', async () => {
+      const runner = jest.fn()
+      await expect(addPullRequestAssignee(1, '   ', runner)).resolves.toEqual({
+        ok: false,
+        message: 'Assignee login required',
+      })
+    })
+
+    it('invokes `gh pr edit <#> --add-assignee <login>`', async () => {
+      const runner = jest.fn().mockResolvedValue('')
+      await expect(addPullRequestAssignee(962, '@me', runner)).resolves.toEqual({
+        ok: true,
+        message: 'Assigned @me to pull request #962',
+      })
+      expect(runner).toHaveBeenCalledWith(['pr', 'edit', '962', '--add-assignee', '@me'])
+    })
+
+    it('surfaces gh errors as ok: false', async () => {
+      const runner = jest.fn().mockRejectedValue(new Error('no such user'))
+      await expect(addPullRequestAssignee(1, 'ghost', runner)).resolves.toEqual({
+        ok: false,
+        message: 'no such user',
       })
     })
   })

--- a/src/git/pullRequestActions.ts
+++ b/src/git/pullRequestActions.ts
@@ -164,3 +164,66 @@ export function commentPullRequest(
     message: output.trim() || 'Comment added',
   }))
 }
+
+/**
+ * Triage-view variants (#882 phase 4). Same shape as
+ * `commentPullRequest` above but target a specific PR by number,
+ * which is what the multi-PR triage list needs (the cursor isn't
+ * necessarily on the current branch's PR). Kept as siblings rather
+ * than overloads so the single-PR call sites stay untouched and
+ * the API stays readable at the call site (no need to pass
+ * `undefined` to skip the number arg).
+ */
+export function commentPullRequestByNumber(
+  pullRequestNumber: number,
+  body: string,
+  runner: GhRunner = defaultGhRunner
+): Promise<PullRequestActionResult> {
+  if (!body.trim()) {
+    return Promise.resolve({ ok: false, message: 'Comment body required' })
+  }
+  return runGhAction(
+    runner,
+    ['pr', 'comment', String(pullRequestNumber), '--body', body],
+    (output) => ({
+      ok: true,
+      message: output.trim() || `Commented on pull request #${pullRequestNumber}`,
+    })
+  )
+}
+
+export function addPullRequestLabel(
+  pullRequestNumber: number,
+  label: string,
+  runner: GhRunner = defaultGhRunner
+): Promise<PullRequestActionResult> {
+  if (!label.trim()) {
+    return Promise.resolve({ ok: false, message: 'Label name required' })
+  }
+  return runGhAction(
+    runner,
+    ['pr', 'edit', String(pullRequestNumber), '--add-label', label],
+    () => ({
+      ok: true,
+      message: `Added label '${label}' to pull request #${pullRequestNumber}`,
+    })
+  )
+}
+
+export function addPullRequestAssignee(
+  pullRequestNumber: number,
+  assignee: string,
+  runner: GhRunner = defaultGhRunner
+): Promise<PullRequestActionResult> {
+  if (!assignee.trim()) {
+    return Promise.resolve({ ok: false, message: 'Assignee login required' })
+  }
+  return runGhAction(
+    runner,
+    ['pr', 'edit', String(pullRequestNumber), '--add-assignee', assignee],
+    () => ({
+      ok: true,
+      message: `Assigned ${assignee} to pull request #${pullRequestNumber}`,
+    })
+  )
+}

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -241,6 +241,7 @@ import {
     createBranchFromCommit,
     createTagAtCommit,
     defaultClipboardRunner,
+    defaultOpenUrlRunner,
     isResetMode,
     resetToCommit,
     revertCommit,
@@ -251,12 +252,17 @@ import { ApplyHunkTarget, applyHunkPatch } from '../../git/hunkActions'
 import { removeWorktree, removeWorktreeAndBranch } from '../../git/worktreeActions'
 import { abortOperation, continueOperation, resolveConflictOurs, resolveConflictTheirs, stageConflictResolved } from '../../git/operationActions'
 import { getIssueList } from '../../git/issuesListData'
+import { addIssueAssignee, addIssueLabel, commentIssue } from '../../git/issueActions'
 import { getPullRequestOverview } from '../../git/pullRequestData'
 import { getPullRequestList } from '../../git/pullRequestListData'
+import { clearGitHubListCache } from '../../git/githubListCache'
 import {
+    addPullRequestAssignee,
+    addPullRequestLabel,
     approvePullRequest,
     closePullRequest,
     commentPullRequest,
+    commentPullRequestByNumber,
     createPullRequest,
     isPullRequestMergeStrategy,
     mergePullRequest,
@@ -2132,6 +2138,28 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       return applyHunkPatch(git, patchText, { target: effectiveTarget })
     }
 
+    // #882 phase 4 — post-mutation cache invalidation for the
+    // issue / PR triage views. Each helper does two things:
+    //   1. Clears the in-memory `context.issueList` /
+    //      `context.pullRequestList` entry so the view's `useEffect`
+    //      retriggers on the next render and the user sees their
+    //      change reflected immediately.
+    //   2. Wipes the disk cache so a follow-up `coco issues` /
+    //      `coco prs` CLI call doesn't serve stale data from the
+    //      5-minute TTL window. Sledgehammer rather than scalpel —
+    //      clearing per (repo, filter) tuple would require more
+    //      bookkeeping than the cache is worth.
+    const invalidateIssueListCaches = (): void => {
+      setContext((current) => ({ ...current, issueList: undefined }))
+      setContextStatus((current) => updateLogInkContextStatus(current, 'issueList', 'idle'))
+      clearGitHubListCache()
+    }
+    const invalidatePullRequestListCaches = (): void => {
+      setContext((current) => ({ ...current, pullRequestList: undefined }))
+      setContextStatus((current) => updateLogInkContextStatus(current, 'pullRequestList', 'idle'))
+      clearGitHubListCache()
+    }
+
     const handlers: Record<string, () => Promise<{ ok: boolean; message: string } | undefined>> = {
       'create-branch': async () => {
         const name = payload?.trim()
@@ -2604,6 +2632,105 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         if (!body) return { ok: false, message: 'Comment body required' }
         return commentPullRequest(body)
       },
+      // #882 phase 4 — triage-view low-risk mutations. Each picks
+      // the cursored item from the *filtered* list (matching what
+      // the user sees on screen), runs the corresponding `gh` action,
+      // and on success clears both the in-memory context entry and
+      // the disk cache so the next view entry refetches. Comment
+      // is additive; label / assign are toggleable via re-invocation
+      // with --remove-* (deferred to phase 5 as part of the y-confirm
+      // suite). Open / yank don't mutate so they skip the
+      // invalidation step entirely.
+      'triage-issue-open': async () => {
+        const issue = filteredIssueList[
+          Math.min(state.selectedIssueIndex, Math.max(0, filteredIssueList.length - 1))
+        ]
+        if (!issue) return { ok: false, message: 'No issue under cursor' }
+        try {
+          await defaultOpenUrlRunner(issue.url)
+          return { ok: true, message: `Opened ${issue.url}` }
+        } catch (error) {
+          return { ok: false, message: (error as Error).message }
+        }
+      },
+      'triage-issue-comment': async () => {
+        const body = payload?.trim()
+        if (!body) return { ok: false, message: 'Comment body required' }
+        const issue = filteredIssueList[
+          Math.min(state.selectedIssueIndex, Math.max(0, filteredIssueList.length - 1))
+        ]
+        if (!issue) return { ok: false, message: 'No issue under cursor' }
+        const result = await commentIssue(issue.number, body)
+        if (result.ok) invalidateIssueListCaches()
+        return result
+      },
+      'triage-issue-label': async () => {
+        const label = payload?.trim()
+        if (!label) return { ok: false, message: 'Label name required' }
+        const issue = filteredIssueList[
+          Math.min(state.selectedIssueIndex, Math.max(0, filteredIssueList.length - 1))
+        ]
+        if (!issue) return { ok: false, message: 'No issue under cursor' }
+        const result = await addIssueLabel(issue.number, label)
+        if (result.ok) invalidateIssueListCaches()
+        return result
+      },
+      'triage-issue-assign': async () => {
+        const assignee = payload?.trim()
+        if (!assignee) return { ok: false, message: 'Assignee login required' }
+        const issue = filteredIssueList[
+          Math.min(state.selectedIssueIndex, Math.max(0, filteredIssueList.length - 1))
+        ]
+        if (!issue) return { ok: false, message: 'No issue under cursor' }
+        const result = await addIssueAssignee(issue.number, assignee)
+        if (result.ok) invalidateIssueListCaches()
+        return result
+      },
+      'triage-pr-open': async () => {
+        const pr = filteredPullRequestTriageList[
+          Math.min(state.selectedPullRequestTriageIndex, Math.max(0, filteredPullRequestTriageList.length - 1))
+        ]
+        if (!pr) return { ok: false, message: 'No pull request under cursor' }
+        try {
+          await defaultOpenUrlRunner(pr.url)
+          return { ok: true, message: `Opened ${pr.url}` }
+        } catch (error) {
+          return { ok: false, message: (error as Error).message }
+        }
+      },
+      'triage-pr-comment': async () => {
+        const body = payload?.trim()
+        if (!body) return { ok: false, message: 'Comment body required' }
+        const pr = filteredPullRequestTriageList[
+          Math.min(state.selectedPullRequestTriageIndex, Math.max(0, filteredPullRequestTriageList.length - 1))
+        ]
+        if (!pr) return { ok: false, message: 'No pull request under cursor' }
+        const result = await commentPullRequestByNumber(pr.number, body)
+        if (result.ok) invalidatePullRequestListCaches()
+        return result
+      },
+      'triage-pr-label': async () => {
+        const label = payload?.trim()
+        if (!label) return { ok: false, message: 'Label name required' }
+        const pr = filteredPullRequestTriageList[
+          Math.min(state.selectedPullRequestTriageIndex, Math.max(0, filteredPullRequestTriageList.length - 1))
+        ]
+        if (!pr) return { ok: false, message: 'No pull request under cursor' }
+        const result = await addPullRequestLabel(pr.number, label)
+        if (result.ok) invalidatePullRequestListCaches()
+        return result
+      },
+      'triage-pr-assign': async () => {
+        const assignee = payload?.trim()
+        if (!assignee) return { ok: false, message: 'Assignee login required' }
+        const pr = filteredPullRequestTriageList[
+          Math.min(state.selectedPullRequestTriageIndex, Math.max(0, filteredPullRequestTriageList.length - 1))
+        ]
+        if (!pr) return { ok: false, message: 'No pull request under cursor' }
+        const result = await addPullRequestAssignee(pr.number, assignee)
+        if (result.ok) invalidatePullRequestListCaches()
+        return result
+      },
       // Status surface group-level batch ops (#791 follow-up). The
       // input handler dispatches these when the user presses Enter on a
       // group header. We re-derive the file list from the live
@@ -2766,6 +2893,31 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
           label = `submodule path ${entry.path}`
         }
       }
+    } else if (view === 'issues') {
+      // #882 phase 4 — y yanks the cursored issue's URL so the user
+      // can paste it into Slack / a PR description / etc. without
+      // dropping back to the browser. Short form (`Y`) is a no-op
+      // here — there's no compact identifier worth a second key.
+      const issue = filteredIssueList[
+        Math.min(state.selectedIssueIndex, Math.max(0, filteredIssueList.length - 1))
+      ]
+      if (issue) {
+        value = issue.url
+        label = `issue #${issue.number} URL`
+      }
+    } else if (view === 'pull-request-triage') {
+      // #882 phase 4 — same URL-yank pattern for the multi-PR list.
+      // Distinct from `pull-request` (single, current-branch); that
+      // view falls through to the generic "Nothing to yank" path
+      // below since the action panel already exposes O for browser
+      // open.
+      const pr = filteredPullRequestTriageList[
+        Math.min(state.selectedPullRequestTriageIndex, Math.max(0, filteredPullRequestTriageList.length - 1))
+      ]
+      if (pr) {
+        value = pr.url
+        label = `pull request #${pr.number} URL`
+      }
     } else if (view === 'bisect') {
       // #879 item 3 — yank the first-bad commit sha from the
       // completion panel. The headline answer is what the user
@@ -2832,6 +2984,8 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     context.submodules,
     context.tags,
     dispatch,
+    filteredIssueList,
+    filteredPullRequestTriageList,
     selected,
     selectedDetailFile,
     stashDiffLines,
@@ -2844,6 +2998,8 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     state.filteredCommits,
     state.selectedBranchIndex,
     state.selectedIndex,
+    state.selectedIssueIndex,
+    state.selectedPullRequestTriageIndex,
     state.selectedStashIndex,
     state.selectedSubmoduleIndex,
     state.selectedTagIndex,


### PR DESCRIPTION
Phase 4 of [#882](https://github.com/gfargo/coco/issues/882). Builds on the read-only TUI surfaces shipped in phase 3 ([#969](https://github.com/gfargo/coco/pull/969)).

## What lands

Five per-row keystrokes scoped to the two triage views from phase 3:

| Key | Action |
| --- | --- |
| \`O\` | Open the cursored item's URL in the browser |
| \`y\` | Yank the cursored item's URL to the clipboard |
| \`c\` | Comment (multi-line prompt; Ctrl+D submit) |
| \`L\` | Add label (single-line prompt) |
| \`A\` | Add assignee (single-line prompt; defaults to \`@me\`) |

Each works identically across the \`issues\` (chord \`gi\`) and \`pull-request-triage\` (chord \`gP\`) views. Destructive mutations (close, reopen, merge, approve, request-changes for the triage list) stay deferred to phase 5 — they need the y-confirm path.

## Summary

- **New \`src/git/issueActions.ts\`** — mirrors \`pullRequestActions.ts\`'s shape. Three functions (\`commentIssue\`, \`addIssueLabel\`, \`addIssueAssignee\`), each wrapping a single \`gh issue <verb>\` through the shared runner indirection.
- **New by-number variants in \`pullRequestActions.ts\`**: \`commentPullRequestByNumber\`, \`addPullRequestLabel\`, \`addPullRequestAssignee\`. Existing single-PR functions are untouched so the \`gp\` action-panel call sites stay working.
- **Six new \`LogInkInputPromptKind\`s** (\`triage-issue-{comment,label,assign}\` + \`triage-pr-{comment,label,assign}\`) wired through \`submitInputPrompt\`.
- **Workflow runners in \`runtime/app.ts\`** resolve the cursored item from the *filtered* list (so what's on screen is what gets mutated), run the action, and on success invalidate both the in-memory context entry and the disk cache via two new helpers (\`invalidateIssueListCaches\` / \`invalidatePullRequestListCaches\`).
- **Input dispatch in \`inkInput.ts\`** opens the right prompt kind per view and per key. Regression test guards that \`c\` from the single-PR \`pull-request\` view still routes to \`pr-comment\` (not the triage variant).
- **\`yankFromActiveView\` extended** with \`issues\` and \`pull-request-triage\` cases that yank the cursored URL.

## Empty-input handling

Every mutation function validates the input before running gh:
- Empty comment body → \`"Comment body required"\`
- Empty label → \`"Label name required"\`
- Empty assignee → \`"Assignee login required"\`

So a typo in the prompt surfaces as a friendly status line rather than \`gh: invalid argument\` noise.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm run test:jest\` — 1835 tests pass, 7 skipped (164 suites). 49 new tests across:
  - \`issueActions.test.ts\` — happy path, empty-input rejection, gh runner errors
  - \`pullRequestActions.test.ts\` — by-number variants, args shape, error path
  - \`inkInput.test.ts\` — chord dispatch on both views, multi-line vs single-line prompts, fall-through to \`open-pr\` when no URL, regression guard for \`pull-request\` view's \`c\`
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: \`coco ui\` → \`gi\` → \`c\` → enter body → Ctrl+D → comment lands on the cursored issue
- [ ] Manual: \`gP\` → \`L\` → enter label → Enter → label added, list refetches with the new label visible
- [ ] Manual: \`A\` defaults to \`@me\`, Enter assigns the current user

## Out of scope (Phase 5 / 6)

- **Destructive mutations** (close, reopen, merge, approve, request-changes for triage list) → phase 5 with y-confirm
- **Toggle behavior** for label / assign (remove if already set) → phase 5
- **Filter cycling \`f\`** + AI summarize \`I\` → phase 6
- **Body / comments / reviews in inspector** → could come in phase 5 alongside the mutating actions; needs per-item \`gh\` fetch

## Notes for review

- The cache invalidation is sledgehammer-style: \`clearGitHubListCache()\` wipes the entire \`~/.cache/coco/github/\` directory rather than the specific (repo, filter) tuple. Per-tuple invalidation would require more bookkeeping than the cache is worth — it's a 5-minute TTL anyway and refetch is cheap.
- The single-line \`L\` / \`A\` prompts submit on Enter; the multi-line \`c\` prompt submits on Ctrl+D. Mirrors the existing single-PR \`pr-comment\` / \`pr-request-changes\` prompts so muscle memory carries over.