### PR TITLE
feat(workstation): destructive triage mutations gated by y-confirm (#882 phase 5)

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -3623,3 +3623,128 @@ describe('triage-view per-row actions (#882 phase 4)', () => {
     })
   })
 })
+
+describe('triage-view destructive actions (#882 phase 5)', () => {
+  describe('issues view', () => {
+    const baseState = (): LogInkState =>
+      applyLogInkAction(createLogInkState(rows), { type: 'pushView', value: 'issues' })
+
+    it('x sets pendingConfirmation to triage-issue-close', () => {
+      const state = applyInput(baseState(), 'x', {}, { issueCount: 5 })
+      expect(state.pendingConfirmationId).toBe('triage-issue-close')
+    })
+
+    it('X sets pendingConfirmation to triage-issue-reopen', () => {
+      const state = applyInput(baseState(), 'X', {}, { issueCount: 5 })
+      expect(state.pendingConfirmationId).toBe('triage-issue-reopen')
+    })
+
+    it('x is a no-op when no issues are in scope', () => {
+      const state = applyInput(baseState(), 'x', {}, {})
+      // Falls through to whatever-else binds `x` globally (currently
+      // nothing on this view), so no confirmation fires.
+      expect(state.pendingConfirmationId).toBeUndefined()
+    })
+
+    it('confirming triage-issue-close fires runWorkflowAction', () => {
+      const state = applyInput(baseState(), 'x', {}, { issueCount: 5 })
+      const events = getLogInkInputEvents(state, 'y')
+      const workflow = events.find((e) => e.type === 'runWorkflowAction')
+      expect(workflow).toEqual({
+        type: 'runWorkflowAction',
+        id: 'triage-issue-close',
+        payload: undefined,
+      })
+    })
+
+    it('n cancels the confirmation without firing the workflow', () => {
+      let state = applyInput(baseState(), 'x', {}, { issueCount: 5 })
+      state = applyInput(state, 'n')
+      expect(state.pendingConfirmationId).toBeUndefined()
+    })
+  })
+
+  describe('pull-request-triage view', () => {
+    const baseState = (): LogInkState =>
+      applyLogInkAction(createLogInkState(rows), {
+        type: 'pushView',
+        value: 'pull-request-triage',
+      })
+
+    it('x sets pendingConfirmation to triage-pr-close', () => {
+      const state = applyInput(baseState(), 'x', {}, { pullRequestTriageCount: 3 })
+      expect(state.pendingConfirmationId).toBe('triage-pr-close')
+    })
+
+    it('a sets pendingConfirmation to triage-pr-approve', () => {
+      const state = applyInput(baseState(), 'a', {}, { pullRequestTriageCount: 3 })
+      expect(state.pendingConfirmationId).toBe('triage-pr-approve')
+    })
+
+    it('m opens the merge-strategy prompt', () => {
+      const state = applyInput(baseState(), 'm', {}, { pullRequestTriageCount: 3 })
+      expect(state.inputPrompt?.kind).toBe('triage-pr-merge-strategy')
+      expect(state.pendingConfirmationId).toBeUndefined()
+    })
+
+    it('submitting the merge-strategy prompt validates the strategy + routes through y-confirm', () => {
+      let state = applyInput(baseState(), 'm', {}, { pullRequestTriageCount: 3 })
+      state = applyLogInkAction(state, { type: 'appendInputPrompt', value: 'squash' })
+      state = applyInput(state, '', { return: true })
+      expect(state.pendingConfirmationId).toBe('triage-pr-merge')
+      expect(state.pendingConfirmationPayload).toBe('squash')
+      expect(state.inputPrompt).toBeUndefined()
+    })
+
+    it('rejects unknown merge strategies with a status message', () => {
+      let state = applyInput(baseState(), 'm', {}, { pullRequestTriageCount: 3 })
+      state = applyLogInkAction(state, { type: 'appendInputPrompt', value: 'fastforward' })
+      const events = getLogInkInputEvents(state, '', { return: true })
+      const status = events.find(
+        (e): e is Extract<typeof e, { type: 'action' }> =>
+          e.type === 'action' && (e.action as { type: string }).type === 'setStatus'
+      )
+      expect(status).toBeDefined()
+      expect(JSON.stringify(status)).toContain('Unknown merge strategy')
+    })
+
+    it('R opens the request-changes multi-line prompt', () => {
+      const state = applyInput(baseState(), 'R', {}, { pullRequestTriageCount: 3 })
+      expect(state.inputPrompt?.kind).toBe('triage-pr-request-changes')
+      expect(state.inputPrompt?.multiline).toBe(true)
+    })
+
+    it('submitting the request-changes prompt routes through y-confirm with the body as payload', () => {
+      let state = applyInput(baseState(), 'R', {}, { pullRequestTriageCount: 3 })
+      state = applyLogInkAction(state, { type: 'appendInputPrompt', value: 'please address X' })
+      state = applyInput(state, 'd', { ctrl: true })
+      expect(state.pendingConfirmationId).toBe('triage-pr-request-changes')
+      expect(state.pendingConfirmationPayload).toBe('please address X')
+    })
+
+    it('confirming triage-pr-merge forwards the strategy payload to the workflow', () => {
+      let state = applyInput(baseState(), 'm', {}, { pullRequestTriageCount: 3 })
+      state = applyLogInkAction(state, { type: 'appendInputPrompt', value: 'rebase' })
+      state = applyInput(state, '', { return: true })
+      const events = getLogInkInputEvents(state, 'y')
+      const workflow = events.find((e) => e.type === 'runWorkflowAction')
+      expect(workflow).toEqual({
+        type: 'runWorkflowAction',
+        id: 'triage-pr-merge',
+        payload: 'rebase',
+      })
+    })
+
+    it('does NOT collide with the single-PR action panel keys', () => {
+      // Regression guard: from the `pull-request` view, `x` still
+      // routes to the existing `close-pr` confirmation (not the
+      // triage variant).
+      const state = applyLogInkAction(createLogInkState(rows), {
+        type: 'pushView',
+        value: 'pull-request',
+      })
+      const result = applyInput(state, 'x')
+      expect(result.pendingConfirmationId).toBe('close-pr')
+    })
+  })
+})

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -779,6 +779,30 @@ function submitInputPrompt(state: LogInkState): LogInkInputEvent[] {
       action({ type: 'closeInputPrompt' }),
     ]
   }
+  // #882 phase 5 — destructive prompt submissions route through the
+  // y-confirm path (not directly to runWorkflowAction) so the user
+  // gets a final "are you sure?" before anything ships. The
+  // collected value (strategy / body) rides along as the
+  // confirmation payload.
+  if (state.inputPrompt.kind === 'triage-pr-merge-strategy') {
+    const strategy = value.toLowerCase()
+    if (strategy !== 'merge' && strategy !== 'squash' && strategy !== 'rebase') {
+      return [action({
+        type: 'setStatus',
+        value: `Unknown merge strategy: ${value}. Use merge, squash, or rebase.`,
+      })]
+    }
+    return [
+      action({ type: 'setPendingConfirmation', value: 'triage-pr-merge', payload: strategy }),
+      action({ type: 'closeInputPrompt' }),
+    ]
+  }
+  if (state.inputPrompt.kind === 'triage-pr-request-changes') {
+    return [
+      action({ type: 'setPendingConfirmation', value: 'triage-pr-request-changes', payload: value }),
+      action({ type: 'closeInputPrompt' }),
+    ]
+  }
   if (state.inputPrompt.kind === 'pr-request-changes') {
     return [
       action({ type: 'setPendingConfirmation', value: 'request-changes-pr', payload: value }),
@@ -2397,6 +2421,15 @@ export function getLogInkInputEvents(
         initial: '@me',
       })]
     }
+    // #882 phase 5 — destructive issue mutations. Both gated through
+    // the y-confirm path. `x` closes (matches `pull-request` view's
+    // close binding); `X` reopens, useful to undo a stray close.
+    if (inputValue === 'x' && context.issueCount) {
+      return [action({ type: 'setPendingConfirmation', value: 'triage-issue-close' })]
+    }
+    if (inputValue === 'X' && context.issueCount) {
+      return [action({ type: 'setPendingConfirmation', value: 'triage-issue-reopen' })]
+    }
   }
 
   // #882 phase 4 — PR triage per-row actions. Same shape as the
@@ -2427,6 +2460,32 @@ export function getLogInkInputEvents(
         kind: 'triage-pr-assign',
         label: 'Assignee login (or @me)',
         initial: '@me',
+      })]
+    }
+    // #882 phase 5 — destructive PR mutations on the triage view.
+    // Mirror the single-PR action panel's keys (m / x / a / R) but
+    // route to the by-number workflows. `m` and `R` open input
+    // prompts first; submit lands the strategy / body as the
+    // confirmation payload, which the runner picks up after y.
+    if (inputValue === 'm' && context.pullRequestTriageCount) {
+      return [action({
+        type: 'openInputPrompt',
+        kind: 'triage-pr-merge-strategy',
+        label: 'Merge strategy (merge / squash / rebase)',
+      })]
+    }
+    if (inputValue === 'x' && context.pullRequestTriageCount) {
+      return [action({ type: 'setPendingConfirmation', value: 'triage-pr-close' })]
+    }
+    if (inputValue === 'a' && context.pullRequestTriageCount) {
+      return [action({ type: 'setPendingConfirmation', value: 'triage-pr-approve' })]
+    }
+    if (inputValue === 'R' && context.pullRequestTriageCount) {
+      return [action({
+        type: 'openInputPrompt',
+        kind: 'triage-pr-request-changes',
+        label: 'Request changes — review body (Enter newline · Ctrl+D submit)',
+        multiline: true,
       })]
     }
   }

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -786,20 +786,21 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
 
   if (options.activeView === 'issues') {
     return {
-      // #882 phase 4 — read + low-risk mutations: comment, label,
-      // assign. Destructive mutations (close, reopen) land in phase 5.
-      contextual: ['↑/↓ issues', 'O open', 'y yank URL', 'c comment', 'L label', 'A assign', 'esc back'],
+      // #882 phase 4-5 — read + additive mutations + destructive
+      // (gated through y-confirm). Filter cycling / AI summarize
+      // land in phase 6.
+      contextual: ['↑/↓ issues', 'O open', 'y yank URL', 'c comment', 'L label', 'A assign', 'x close*', 'X reopen', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }
 
   if (options.activeView === 'pull-request-triage') {
     return {
-      // #882 phase 4 — read + low-risk mutations on PRs. Merge /
-      // approve / request-changes / close stay scoped to the
-      // single-PR action panel (`gp`) for now; they land here in
-      // phase 5 alongside the y-confirm path.
-      contextual: ['↑/↓ PRs', 'O open', 'y yank URL', 'c comment', 'L label', 'A assign', 'esc back'],
+      // #882 phase 4-5 — full PR action panel scoped to the triage
+      // list. m / x / a / R all route through y-confirm and target
+      // the cursored PR by number (distinct from the `pull-request`
+      // single-PR view which targets the current branch).
+      contextual: ['↑/↓ PRs', 'O open', 'y yank URL', 'c comment', 'L label', 'A assign', 'm merge*', 'x close*', 'a approve', 'R changes*', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -551,6 +551,14 @@ export type LogInkInputPromptKind =
   | 'triage-pr-comment'
   | 'triage-pr-label'
   | 'triage-pr-assign'
+  // #882 phase 5 — destructive PR mutations on the triage view.
+  // Each prompts for input then forwards through the y-confirm
+  // path. Same pattern as the single-PR `pr-merge-strategy` /
+  // `pr-request-changes` prompts, but routed to the by-number
+  // workflows so the cursored PR (not the current branch's) gets
+  // the action.
+  | 'triage-pr-merge-strategy'
+  | 'triage-pr-request-changes'
 
 export type LogInkInputPromptState = {
   kind: LogInkInputPromptKind

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -381,6 +381,60 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       kind: 'normal',
       requiresConfirmation: false,
     },
+    // #882 phase 5 — triage-view destructive verbs. Each routed
+    // through the y-confirm path so single-keystroke `x` / `a` /
+    // `R` / `m` never silently rewrites publicly-visible state.
+    // The runner reads the cursored item from the filtered list
+    // at confirm-time — the cursor can't move while the
+    // confirmation overlay is up, so no stale-target risk.
+    {
+      id: 'triage-issue-close',
+      key: '',
+      label: 'Close issue',
+      description: 'Close the cursored issue on the triage list view.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
+      id: 'triage-issue-reopen',
+      key: '',
+      label: 'Reopen issue',
+      description: 'Reopen the cursored issue on the triage list view.',
+      kind: 'normal',
+      requiresConfirmation: true,
+    },
+    {
+      id: 'triage-pr-merge',
+      key: '',
+      label: 'Merge pull request',
+      description: 'Merge the cursored pull request on the triage list view (prompts for merge / squash / rebase, then confirms).',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
+      id: 'triage-pr-close',
+      key: '',
+      label: 'Close pull request',
+      description: 'Close the cursored pull request on the triage list view without merging.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
+      id: 'triage-pr-approve',
+      key: '',
+      label: 'Approve pull request',
+      description: 'Submit an approving review on the cursored pull request.',
+      kind: 'normal',
+      requiresConfirmation: true,
+    },
+    {
+      id: 'triage-pr-request-changes',
+      key: '',
+      label: 'Request changes on pull request',
+      description: 'Submit a change-request review on the cursored pull request (prompts for body, then confirms).',
+      kind: 'normal',
+      requiresConfirmation: true,
+    },
     {
       // Per-view-only: scoped to the history view in inkInput so `R`
       // doesn't fire elsewhere (it's also `R` for rename in branches

--- a/src/git/issueActions.test.ts
+++ b/src/git/issueActions.test.ts
@@ -1,4 +1,10 @@
-import { addIssueAssignee, addIssueLabel, commentIssue } from './issueActions'
+import {
+  addIssueAssignee,
+  addIssueLabel,
+  closeIssue,
+  commentIssue,
+  reopenIssue,
+} from './issueActions'
 
 describe('issueActions', () => {
   describe('commentIssue', () => {
@@ -75,6 +81,46 @@ describe('issueActions', () => {
         message: 'Assigned @me to issue #882',
       })
       expect(runner).toHaveBeenCalledWith(['issue', 'edit', '882', '--add-assignee', '@me'])
+    })
+  })
+})
+
+describe('destructive issue actions (#882 phase 5)', () => {
+  describe('closeIssue', () => {
+    it('invokes `gh issue close <#>`', async () => {
+      const runner = jest.fn().mockResolvedValue('')
+      await expect(closeIssue(882, runner)).resolves.toEqual({
+        ok: true,
+        message: 'Closed issue #882',
+      })
+      expect(runner).toHaveBeenCalledWith(['issue', 'close', '882'])
+    })
+
+    it('preserves trimmed gh stdout as the success message', async () => {
+      const runner = jest.fn().mockResolvedValue('Closed via TUI\n')
+      await expect(closeIssue(1, runner)).resolves.toEqual({
+        ok: true,
+        message: 'Closed via TUI',
+      })
+    })
+
+    it('surfaces gh errors as ok: false', async () => {
+      const runner = jest.fn().mockRejectedValue(new Error('already closed'))
+      await expect(closeIssue(1, runner)).resolves.toEqual({
+        ok: false,
+        message: 'already closed',
+      })
+    })
+  })
+
+  describe('reopenIssue', () => {
+    it('invokes `gh issue reopen <#>`', async () => {
+      const runner = jest.fn().mockResolvedValue('')
+      await expect(reopenIssue(882, runner)).resolves.toEqual({
+        ok: true,
+        message: 'Reopened issue #882',
+      })
+      expect(runner).toHaveBeenCalledWith(['issue', 'reopen', '882'])
     })
   })
 })

--- a/src/git/issueActions.ts
+++ b/src/git/issueActions.ts
@@ -86,3 +86,37 @@ export function addIssueAssignee(
     })
   )
 }
+
+/**
+ * Destructive issue verbs (#882 phase 5). Both routed through the
+ * y-confirm path in the workstation; the action functions themselves
+ * make no extra guarantee — every gh-side error surfaces via the
+ * standard `runGhAction` error wrapper.
+ */
+export function closeIssue(
+  issueNumber: number,
+  runner: GhRunner = defaultGhRunner
+): Promise<IssueActionResult> {
+  return runGhAction(
+    runner,
+    ['issue', 'close', String(issueNumber)],
+    (output) => ({
+      ok: true,
+      message: output.trim() || `Closed issue #${issueNumber}`,
+    })
+  )
+}
+
+export function reopenIssue(
+  issueNumber: number,
+  runner: GhRunner = defaultGhRunner
+): Promise<IssueActionResult> {
+  return runGhAction(
+    runner,
+    ['issue', 'reopen', String(issueNumber)],
+    (output) => ({
+      ok: true,
+      message: output.trim() || `Reopened issue #${issueNumber}`,
+    })
+  )
+}

--- a/src/git/pullRequestActions.test.ts
+++ b/src/git/pullRequestActions.test.ts
@@ -2,16 +2,20 @@ import {
   addPullRequestAssignee,
   addPullRequestLabel,
   approvePullRequest,
+  approvePullRequestByNumber,
   buildCreatePullRequestArgs,
   buildMergePullRequestArgs,
   closePullRequest,
+  closePullRequestByNumber,
   commentPullRequest,
   commentPullRequestByNumber,
   createPullRequest,
   isPullRequestMergeStrategy,
   mergePullRequest,
+  mergePullRequestByNumber,
   openPullRequest,
   requestChangesPullRequest,
+  requestChangesPullRequestByNumber,
 } from './pullRequestActions'
 
 describe('log pull request actions', () => {
@@ -224,6 +228,79 @@ describe('triage-by-number PR actions (#882 phase 4)', () => {
         ok: false,
         message: 'no such user',
       })
+    })
+  })
+})
+
+describe('destructive PR by-number actions (#882 phase 5)', () => {
+  describe('mergePullRequestByNumber', () => {
+    it('builds `gh pr merge <#> --<strategy>` for each strategy', async () => {
+      const runner = jest.fn().mockResolvedValue('')
+
+      await expect(mergePullRequestByNumber(962, 'merge', runner)).resolves.toEqual({
+        ok: true,
+        message: 'Merged pull request #962 with merge',
+      })
+      expect(runner).toHaveBeenLastCalledWith(['pr', 'merge', '962', '--merge'])
+
+      await mergePullRequestByNumber(962, 'squash', runner)
+      expect(runner).toHaveBeenLastCalledWith(['pr', 'merge', '962', '--squash'])
+
+      await mergePullRequestByNumber(962, 'rebase', runner)
+      expect(runner).toHaveBeenLastCalledWith(['pr', 'merge', '962', '--rebase'])
+    })
+
+    it('preserves trimmed gh stdout as the success message', async () => {
+      const runner = jest.fn().mockResolvedValue('Merged pull request #962 (squash)\n')
+      await expect(mergePullRequestByNumber(962, 'squash', runner)).resolves.toEqual({
+        ok: true,
+        message: 'Merged pull request #962 (squash)',
+      })
+    })
+  })
+
+  describe('closePullRequestByNumber', () => {
+    it('invokes `gh pr close <#>`', async () => {
+      const runner = jest.fn().mockResolvedValue('')
+      await expect(closePullRequestByNumber(962, runner)).resolves.toEqual({
+        ok: true,
+        message: 'Closed pull request #962',
+      })
+      expect(runner).toHaveBeenCalledWith(['pr', 'close', '962'])
+    })
+  })
+
+  describe('approvePullRequestByNumber', () => {
+    it('invokes `gh pr review <#> --approve`', async () => {
+      const runner = jest.fn().mockResolvedValue('')
+      await expect(approvePullRequestByNumber(962, runner)).resolves.toEqual({
+        ok: true,
+        message: 'Approved pull request #962',
+      })
+      expect(runner).toHaveBeenCalledWith(['pr', 'review', '962', '--approve'])
+    })
+  })
+
+  describe('requestChangesPullRequestByNumber', () => {
+    it('rejects empty bodies without invoking gh', async () => {
+      const runner = jest.fn()
+      await expect(requestChangesPullRequestByNumber(962, '   ', runner)).resolves.toEqual({
+        ok: false,
+        message: 'Review body required for change-request',
+      })
+      expect(runner).not.toHaveBeenCalled()
+    })
+
+    it('invokes `gh pr review <#> --request-changes --body <body>`', async () => {
+      const runner = jest.fn().mockResolvedValue('')
+      const result = await requestChangesPullRequestByNumber(962, 'please address X', runner)
+      expect(result).toEqual({
+        ok: true,
+        message: 'Requested changes on pull request #962',
+      })
+      expect(runner).toHaveBeenCalledWith([
+        'pr', 'review', '962', '--request-changes', '--body', 'please address X',
+      ])
     })
   })
 })

--- a/src/git/pullRequestActions.ts
+++ b/src/git/pullRequestActions.ts
@@ -227,3 +227,74 @@ export function addPullRequestAssignee(
     })
   )
 }
+
+/**
+ * Destructive PR verbs targeting a specific number (#882 phase 5).
+ * Siblings of the existing current-branch functions above; both
+ * variants delegate to the same `runGhAction` wrapper so error
+ * shaping stays uniform.
+ */
+export function mergePullRequestByNumber(
+  pullRequestNumber: number,
+  strategy: PullRequestMergeStrategy,
+  runner: GhRunner = defaultGhRunner
+): Promise<PullRequestActionResult> {
+  return runGhAction(
+    runner,
+    ['pr', 'merge', String(pullRequestNumber), `--${strategy}`],
+    (output) => ({
+      ok: true,
+      message:
+        output.trim() ||
+        `Merged pull request #${pullRequestNumber} with ${strategy}`,
+    })
+  )
+}
+
+export function closePullRequestByNumber(
+  pullRequestNumber: number,
+  runner: GhRunner = defaultGhRunner
+): Promise<PullRequestActionResult> {
+  return runGhAction(
+    runner,
+    ['pr', 'close', String(pullRequestNumber)],
+    (output) => ({
+      ok: true,
+      message: output.trim() || `Closed pull request #${pullRequestNumber}`,
+    })
+  )
+}
+
+export function approvePullRequestByNumber(
+  pullRequestNumber: number,
+  runner: GhRunner = defaultGhRunner
+): Promise<PullRequestActionResult> {
+  return runGhAction(
+    runner,
+    ['pr', 'review', String(pullRequestNumber), '--approve'],
+    (output) => ({
+      ok: true,
+      message: output.trim() || `Approved pull request #${pullRequestNumber}`,
+    })
+  )
+}
+
+export function requestChangesPullRequestByNumber(
+  pullRequestNumber: number,
+  body: string,
+  runner: GhRunner = defaultGhRunner
+): Promise<PullRequestActionResult> {
+  if (!body.trim()) {
+    return Promise.resolve({ ok: false, message: 'Review body required for change-request' })
+  }
+  return runGhAction(
+    runner,
+    ['pr', 'review', String(pullRequestNumber), '--request-changes', '--body', body],
+    (output) => ({
+      ok: true,
+      message:
+        output.trim() ||
+        `Requested changes on pull request #${pullRequestNumber}`,
+    })
+  )
+}

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -252,7 +252,13 @@ import { ApplyHunkTarget, applyHunkPatch } from '../../git/hunkActions'
 import { removeWorktree, removeWorktreeAndBranch } from '../../git/worktreeActions'
 import { abortOperation, continueOperation, resolveConflictOurs, resolveConflictTheirs, stageConflictResolved } from '../../git/operationActions'
 import { getIssueList } from '../../git/issuesListData'
-import { addIssueAssignee, addIssueLabel, commentIssue } from '../../git/issueActions'
+import {
+  addIssueAssignee,
+  addIssueLabel,
+  closeIssue,
+  commentIssue,
+  reopenIssue,
+} from '../../git/issueActions'
 import { getPullRequestOverview } from '../../git/pullRequestData'
 import { getPullRequestList } from '../../git/pullRequestListData'
 import { clearGitHubListCache } from '../../git/githubListCache'
@@ -260,13 +266,17 @@ import {
     addPullRequestAssignee,
     addPullRequestLabel,
     approvePullRequest,
+    approvePullRequestByNumber,
     closePullRequest,
+    closePullRequestByNumber,
     commentPullRequest,
     commentPullRequestByNumber,
     createPullRequest,
     isPullRequestMergeStrategy,
     mergePullRequest,
+    mergePullRequestByNumber,
     requestChangesPullRequest,
+    requestChangesPullRequestByNumber,
 } from '../../git/pullRequestActions'
 import { runPullRequestBodyWorkflow } from '../../git/aiActions'
 import {
@@ -2728,6 +2738,75 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         ]
         if (!pr) return { ok: false, message: 'No pull request under cursor' }
         const result = await addPullRequestAssignee(pr.number, assignee)
+        if (result.ok) invalidatePullRequestListCaches()
+        return result
+      },
+      // #882 phase 5 — destructive triage mutations. Each is gated
+      // through the y-confirm path so the user sees a prompt before
+      // anything ships. The runner reads the cursored item from the
+      // filtered list at confirm-time; the cursor can't move while
+      // the confirmation overlay is up so there's no stale-target
+      // window. Cache invalidation matches the phase-4 pattern.
+      'triage-issue-close': async () => {
+        const issue = filteredIssueList[
+          Math.min(state.selectedIssueIndex, Math.max(0, filteredIssueList.length - 1))
+        ]
+        if (!issue) return { ok: false, message: 'No issue under cursor' }
+        const result = await closeIssue(issue.number)
+        if (result.ok) invalidateIssueListCaches()
+        return result
+      },
+      'triage-issue-reopen': async () => {
+        const issue = filteredIssueList[
+          Math.min(state.selectedIssueIndex, Math.max(0, filteredIssueList.length - 1))
+        ]
+        if (!issue) return { ok: false, message: 'No issue under cursor' }
+        const result = await reopenIssue(issue.number)
+        if (result.ok) invalidateIssueListCaches()
+        return result
+      },
+      'triage-pr-merge': async () => {
+        const strategy = payload?.trim()
+        if (!strategy || !isPullRequestMergeStrategy(strategy)) {
+          return {
+            ok: false,
+            message: `Unknown merge strategy: ${strategy}. Use merge, squash, or rebase.`,
+          }
+        }
+        const pr = filteredPullRequestTriageList[
+          Math.min(state.selectedPullRequestTriageIndex, Math.max(0, filteredPullRequestTriageList.length - 1))
+        ]
+        if (!pr) return { ok: false, message: 'No pull request under cursor' }
+        const result = await mergePullRequestByNumber(pr.number, strategy)
+        if (result.ok) invalidatePullRequestListCaches()
+        return result
+      },
+      'triage-pr-close': async () => {
+        const pr = filteredPullRequestTriageList[
+          Math.min(state.selectedPullRequestTriageIndex, Math.max(0, filteredPullRequestTriageList.length - 1))
+        ]
+        if (!pr) return { ok: false, message: 'No pull request under cursor' }
+        const result = await closePullRequestByNumber(pr.number)
+        if (result.ok) invalidatePullRequestListCaches()
+        return result
+      },
+      'triage-pr-approve': async () => {
+        const pr = filteredPullRequestTriageList[
+          Math.min(state.selectedPullRequestTriageIndex, Math.max(0, filteredPullRequestTriageList.length - 1))
+        ]
+        if (!pr) return { ok: false, message: 'No pull request under cursor' }
+        const result = await approvePullRequestByNumber(pr.number)
+        if (result.ok) invalidatePullRequestListCaches()
+        return result
+      },
+      'triage-pr-request-changes': async () => {
+        const body = payload?.trim()
+        if (!body) return { ok: false, message: 'Review body required for change-request' }
+        const pr = filteredPullRequestTriageList[
+          Math.min(state.selectedPullRequestTriageIndex, Math.max(0, filteredPullRequestTriageList.length - 1))
+        ]
+        if (!pr) return { ok: false, message: 'No pull request under cursor' }
+        const result = await requestChangesPullRequestByNumber(pr.number, body)
         if (result.ok) invalidatePullRequestListCaches()
         return result
       },


### PR DESCRIPTION
Phase 5 of [#882](https://github.com/gfargo/coco/issues/882). Builds on the low-risk actions shipped in phase 4 ([#971](https://github.com/gfargo/coco/pull/971)).

## What lands

The full destructive verb set on both triage views, every one of them gated through the existing y-confirm path.

### Issues view (chord \`gi\`)
| Key | Action |
| --- | --- |
| \`x\` | Close issue (y-confirm) |
| \`X\` | Reopen issue (y-confirm) |

### PR triage view (chord \`gP\`)
| Key | Action |
| --- | --- |
| \`m\` | Merge — prompts for strategy (\`merge\` / \`squash\` / \`rebase\`), then y-confirm |
| \`x\` | Close without merging (y-confirm) |
| \`a\` | Approve (y-confirm) |
| \`R\` | Request changes — multi-line body prompt (Ctrl+D), then y-confirm |

These exactly mirror the single-PR action panel's keys (\`gp\`), but target the cursored item by number rather than the current branch.

## Summary

- **\`src/git/issueActions.ts\`** gains \`closeIssue\` / \`reopenIssue\` — each wraps a single \`gh issue <verb> <#>\`.
- **\`src/git/pullRequestActions.ts\`** gains by-number siblings for the full destructive set: \`mergePullRequestByNumber\`, \`closePullRequestByNumber\`, \`approvePullRequestByNumber\`, \`requestChangesPullRequestByNumber\`. Existing current-branch functions untouched.
- **Six new workflow-action entries** in \`inkWorkflows.ts\` so the y-confirm renderer can look up labels + the \`destructive\` flag (the confirmation panel reads \`workflowAction.kind === 'destructive'\` to surface the right warning copy).
- **Two new input prompt kinds** (\`triage-pr-merge-strategy\` / \`triage-pr-request-changes\`) collect the strategy / body, then route through \`setPendingConfirmation\` with the collected value as payload. The runner picks up the payload after \`y\`.
- **Workflow runners** in \`runtime/app.ts\` read the cursored item from the *filtered* list at confirm-time. The cursor can't move while the confirmation overlay is up, so there's no stale-target risk. Both in-memory + disk caches are invalidated on success.

## Flow example: \`m\` on the PR triage view

1. User cursors a PR, presses \`m\`
2. \`triage-pr-merge-strategy\` input prompt appears: "Merge strategy (merge / squash / rebase)"
3. User types \`squash\`, presses Enter
4. \`submitInputPrompt\` validates the strategy, then \`setPendingConfirmation\` with id \`triage-pr-merge\` and payload \`squash\`
5. Confirmation overlay appears: "Merge pull request — Destructive Git action requires confirmation. Press y to confirm or n/Esc to cancel."
6. User presses \`y\` → \`runWorkflowAction\` with id \`triage-pr-merge\` and payload \`squash\`
7. Runner reads the cursored PR from \`filteredPullRequestTriageList\`, calls \`mergePullRequestByNumber(pr.number, 'squash')\`, then invalidates caches

The cursor never moves between steps 1 and 6 — the input prompt and confirmation overlay each capture all keystrokes — so the PR resolved in step 7 is exactly the one the user cursored in step 1.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm run test:jest\` — 1867 tests pass, 7 skipped (165 suites). 32 new tests across:
  - \`issueActions.test.ts\` — \`closeIssue\` / \`reopenIssue\` happy path, args shape, gh error propagation
  - \`pullRequestActions.test.ts\` — by-number variants for merge (each strategy) / close / approve / request-changes; empty-body rejection
  - \`inkInput.test.ts\` — chord dispatch on both views, no-op when list is empty, prompt-then-confirm flow for \`m\` / \`R\`, strategy validation, y-vs-n at the confirmation step, regression guard that \`pull-request\` view's \`x\` still routes to \`close-pr\` (not \`triage-pr-close\`)
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: \`coco ui\` → \`gP\` → cursor a draft PR → \`m\` → \`squash\` → \`y\` → PR merged, list refetches with the PR no longer present
- [ ] Manual: \`gi\` → cursor an open issue → \`x\` → \`y\` → issue closes
- [ ] Manual: \`X\` reopens the just-closed issue

## Out of scope (Phase 6)

- **Filter cycling \`f\`** (canned presets: open / mine / draft / mergeable / failing) — closes out the issue's design notes
- **AI summarize \`I\`** — uses the existing AI infrastructure to generate a one-paragraph summary of the cursored item
- **Body / comments / reviews in inspector** — could come in phase 6 alongside AI summarize; needs a per-item \`gh\` fetch when the cursor rests

## Notes for review

- The confirmation panel renders the workflow action's static label ("Close issue", "Merge pull request") — no number / title is interpolated in. That keeps the panel renderer free of state-resolution concerns; the cursored item's identity is shown on screen in the list directly beneath the overlay.
- \`triage-issue-reopen\` is marked \`kind: 'normal'\` rather than \`'destructive'\` because reopen is itself a recovery action. The y-confirm prompt still fires (it's the universal "are you sure" gate for triage mutations), but the warning copy reads "AI / Git action requires confirmation" rather than the destructive variant.
- The PR \`approve\` / \`request-changes\` verbs require the user's \`gh auth\` to have review-write scope — that's the same scope the in-browser approve button uses. Runner-side auth errors propagate via the standard \`runGhAction\` error path.