### PR TITLE
fix(ui): suppress spacer rows around git topology rows (no more lane-glyph tearing)

### DIFF
--- a/src/workstation/chrome/historyRows.test.ts
+++ b/src/workstation/chrome/historyRows.test.ts
@@ -310,5 +310,79 @@ describe('Ink history rows', () => {
         expect(trunkSegment?.laneId).toBe(0)
       })
     })
+
+    // Tearing-fix follow-up: spacers must NOT sandwich themselves
+    // between a commit and a git-emitted topology row (`|\` / `|/`),
+    // and must NOT fire on commits whose own graph already carries
+    // the lane-fork glyph (`*\` / `*/`). Both cases produced a
+    // duplicate corner glyph the user saw as misalignment.
+    it('skips the spacer when git\'s next row is a topology graph row', () => {
+      const mergeShapedRows: GitLogRow[] = [
+        {
+          type: 'commit', graph: '*   ', shortHash: 'merge1', hash: 'merge1'.padEnd(40, '0'),
+          parents: ['p1'.padEnd(40, '0'), 'p2'.padEnd(40, '0')],
+          date: '2026-04-23', author: 'Coco', refs: [], message: "Merge branch 'feat/x'",
+        },
+        { type: 'graph', graph: '|\\  ' },
+        {
+          type: 'commit', graph: '| * ', shortHash: 'side1', hash: 'side1'.padEnd(40, '0'),
+          parents: [], date: '2026-04-22', author: 'Coco', refs: [], message: 'feat: side commit',
+        },
+        { type: 'graph', graph: '|/  ' },
+        {
+          type: 'commit', graph: '*   ', shortHash: 'main1', hash: 'main1'.padEnd(40, '0'),
+          parents: [], date: '2026-04-15', author: 'Coco', refs: [], message: 'feat: main below merge',
+        },
+      ]
+      const state = applyLogInkAction(createLogInkState(mergeShapedRows), { type: 'toggleGraph' })
+      const visible = getVisibleLogInkHistory(state, 10, { fullGraphSpacing: true })
+
+      // Expected sequence — no synthetic spacers between the merge
+      // commit and `|\`, between the side commit and `|/`, or
+      // between the last source-graph row and the final commit on
+      // main (graph rows aren't commits so the loop doesn't even
+      // consider them). Only `main1` at the tail gets a spacer
+      // because nothing follows it.
+      expect(visible.items.map((item) => item.type)).toEqual([
+        'commit', // merge
+        'graph',  // |\
+        'commit', // side
+        'graph',  // |/
+        'commit', // main
+        'graph',  // spacer for main (no row after it, but the rule
+                  // only checks `next.type === 'graph'`; an absent
+                  // next still gets a spacer so the trailing commit
+                  // has its breathing row).
+      ])
+    })
+
+    it('skips the spacer when the commit\'s graph carries the compressed fork (`*\\`)', () => {
+      // Compressed-fork form some git versions emit for `--no-ff`
+      // merges: the `\` rides on the commit row itself. The spacer
+      // rewrite would leave the `\` intact, producing a duplicate
+      // `╮` corner directly under the merge glyph.
+      const compressedMergeRows: GitLogRow[] = [
+        {
+          type: 'commit', graph: '*\\  ', shortHash: 'merge1', hash: 'merge1'.padEnd(40, '0'),
+          parents: ['p1'.padEnd(40, '0'), 'p2'.padEnd(40, '0')],
+          date: '2026-04-23', author: 'Coco', refs: [], message: "Merge branch 'feat/x'",
+        },
+        {
+          type: 'commit', graph: '| * ', shortHash: 'side1', hash: 'side1'.padEnd(40, '0'),
+          parents: [], date: '2026-04-22', author: 'Coco', refs: [], message: 'feat: side commit',
+        },
+      ]
+      const state = applyLogInkAction(createLogInkState(compressedMergeRows), { type: 'toggleGraph' })
+      const visible = getVisibleLogInkHistory(state, 10, { fullGraphSpacing: true })
+
+      // No spacer between merge and side: merge's graph has `\` so
+      // `commitGraphIsSimple` returns false. Side gets its trailing
+      // spacer because nothing prevents it.
+      expect(visible.items.map((item) => item.type)).toEqual([
+        'commit', // merge (no trailing spacer — compressed fork)
+        'commit', // side
+        'graph',  // spacer for side
+      ])
+    })
   })
 })

--- a/src/workstation/chrome/historyRows.ts
+++ b/src/workstation/chrome/historyRows.ts
@@ -112,17 +112,41 @@ type ExpandedRow =
  * row that renders as `|` per active lane so consecutive commits have
  * a clear vertical rhythm without losing topology continuity.
  *
+ * The spacer is suppressed in two cases where it would create visible
+ * "tearing" on the graph column:
+ *
+ *   1. The next row is git's own graph-only topology row (`|\` /
+ *      `|/` / `| |`). That row already provides vertical breathing
+ *      AND draws the lane transition; sandwiching our spacer between
+ *      the commit and the transition produces an extra all-pipes row
+ *      that reads as misalignment.
+ *
+ *   2. The current commit's graph contains a backslash or forward
+ *      slash (the compressed forms git uses for `*\` / `*` followed
+ *      by slash, when it draws the fork on the same row as the
+ *      commit). The spacer's commit-glyph → lane-bar rewrite would
+ *      leave the diagonal intact, rendering a second corner glyph
+ *      immediately below the merge — a duplicate that looks like a
+ *      glyph stutter.
+ *
  * When `withSpacers` is false the list is identity-mapped from
  * source rows, preserving the legacy zero-padding behavior for any
  * caller that wants raw git topology (filters, tests, etc.).
  */
+function commitGraphIsSimple(graph: string): boolean {
+  return !/[\\/]/.test(graph)
+}
+
 function expandRowsWithSpacers(rows: GitLogRow[], withSpacers: boolean): ExpandedRow[] {
   const out: ExpandedRow[] = []
-  for (const row of rows) {
+  for (let i = 0; i < rows.length; i += 1) {
+    const row = rows[i]
     out.push({ kind: 'source', row })
-    if (withSpacers && row.type === 'commit') {
-      out.push({ kind: 'spacer', sourceCommit: row })
-    }
+    if (!withSpacers || row.type !== 'commit') continue
+    if (!commitGraphIsSimple(row.graph || '*')) continue
+    const next = rows[i + 1]
+    if (next && next.type === 'graph') continue
+    out.push({ kind: 'spacer', sourceCommit: row })
   }
   return out
 }


### PR DESCRIPTION
## Summary

Your screenshots from the `rich-history-graph` scenario showed visible misalignment around merges:

```
●  fa10b4c refactor(api): centralise error shapes
◆  96b2f12 Merge branch 'feat/auth'
│                                              ← spacer (mine)
├╮                                             ← git's own fork
│ ●  66dd0be test: cover session edge cases
│ │                                            ← spacer (mine)
│ ●  61afc0f feat(auth): session middleware
│ │                                            ← spacer (mine)
├╯                                             ← git's own close
●  5d44e4a docs: project README
```

Two of those spacer rows are doing nothing useful — git's own fork/close rows already provide the vertical breathing AND draw the topology. The spacer just adds an "extra all-pipes row" between the commit and the transition, which reads as a stutter or a broken lane.

## Two narrow conditions, both fixed

**1. Next row is a git topology row** (`|\` / `|/` / `| |`). The spacer is redundant because git's next row already moves the eye down one cell while drawing the lane transition. Skip the spacer.

**2. Current commit's own graph carries a diagonal** (compressed `*\` form some git versions emit for `--no-ff` merges). The spacer's `*` → `|` rewrite leaves the `\` intact, so the spacer rendered a second `╮` corner directly below the merge dot. Skip the spacer.

After the fix:

```
●  fa10b4c refactor(api): centralise error shapes
◆  96b2f12 Merge branch 'feat/auth'
├╮                                             ← git's fork, directly below merge
│ ●  66dd0be test: cover session edge cases
│ │                                            ← spacer (legitimate, both linear)
│ ●  61afc0f feat(auth): session middleware
├╯                                             ← git's close, directly below side
●  5d44e4a docs: project README
```

Linear stretches still get their spacer for vertical rhythm — that was the original motivation and remains unchanged.

## Test plan

- [x] `chrome/historyRows.test.ts` — 2 new tests covering: (a) the standard `|\` fork + `|/` close pattern producing the expected `commit / graph / commit / graph / commit` sequence with no synthetic spacers; (b) the compressed `*\` merge graph producing no trailing spacer after the merge.
- [x] Existing 18 tests in the same file still pass — linear-history rhythm preserved.
- [x] Full jest suite: 1845 pass / 7 skipped, no regressions.
- [x] `npm run lint` clean.
- [x] `npm run build` produces dist bundles.
- [x] `npm run test:cli` smoke tests pass.
- [ ] Manual UI verification — sandbox can't render TTY. Reviewer should re-run `npm run scenario create rich-history-graph -- --run-ui`, toggle full graph (`g`), and check the merge areas: no extra rows between merge dot and `├╮`, no extra rows between last side commit and `├╯`.

## Notes

- `commitGraphIsSimple` is a tiny private helper — just `!/[\\\\/]/.test(graph)`. Co-located with `expandRowsWithSpacers` since it's only meaningful there.
- The "next row is a graph row" check uses a lookahead into the raw `state.rows`, before any of the expansion logic — so it sees what git actually emitted, not the post-expansion view.
- I considered ALSO skipping spacer when the previous row was a graph row, but that turns out to be wrong: a graph row followed by a commit followed by another commit still wants a spacer between the two commits.