### PR TITLE
feat(workstation): canned filter cycling on issue / PR triage (#882 phase 6)

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -3748,3 +3748,42 @@ describe('triage-view destructive actions (#882 phase 5)', () => {
     })
   })
 })
+
+describe('triage filter cycling (#882 phase 6)', () => {
+  it('f on the issues view cycles the issue filter preset', () => {
+    let state = applyLogInkAction(createLogInkState(rows), {
+      type: 'pushView',
+      value: 'issues',
+    })
+    expect(state.selectedIssueFilter).toBe('open')
+
+    state = applyInput(state, 'f')
+    expect(state.selectedIssueFilter).toBe('closed')
+
+    state = applyInput(state, 'f')
+    expect(state.selectedIssueFilter).toBe('mine')
+  })
+
+  it('f on the pull-request-triage view cycles the PR filter preset', () => {
+    let state = applyLogInkAction(createLogInkState(rows), {
+      type: 'pushView',
+      value: 'pull-request-triage',
+    })
+    expect(state.selectedPullRequestFilter).toBe('open')
+
+    state = applyInput(state, 'f')
+    expect(state.selectedPullRequestFilter).toBe('draft')
+  })
+
+  it('f on the history view does not touch either triage preset', () => {
+    // Regression guard: `f` is a single-letter key with no global
+    // binding currently. Adding it as a triage-scoped chord must
+    // not accidentally claim it elsewhere.
+    let state = createLogInkState(rows)
+    expect(state.activeView).toBe('history')
+
+    state = applyInput(state, 'f')
+    expect(state.selectedIssueFilter).toBe('open')
+    expect(state.selectedPullRequestFilter).toBe('open')
+  })
+})

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -2430,6 +2430,14 @@ export function getLogInkInputEvents(
     if (inputValue === 'X' && context.issueCount) {
       return [action({ type: 'setPendingConfirmation', value: 'triage-issue-reopen' })]
     }
+    // #882 phase 6 — cycle the canned filter preset (open → closed
+    // → mine → assigned → open). The effect in app.ts watches
+    // `state.selectedIssueFilter` and refetches with the matching
+    // filter object, so the list updates without an explicit
+    // refresh keystroke.
+    if (inputValue === 'f') {
+      return [action({ type: 'cycleIssueFilter' })]
+    }
   }
 
   // #882 phase 4 — PR triage per-row actions. Same shape as the
@@ -2487,6 +2495,13 @@ export function getLogInkInputEvents(
         label: 'Request changes — review body (Enter newline · Ctrl+D submit)',
         multiline: true,
       })]
+    }
+    // #882 phase 6 — cycle the canned filter preset (open → draft
+    // → mine → assigned → closed → merged → open). The effect in
+    // app.ts watches `state.selectedPullRequestFilter` and refetches
+    // with the matching filter object.
+    if (inputValue === 'f') {
+      return [action({ type: 'cyclePullRequestTriageFilter' })]
     }
   }
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -786,21 +786,20 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
 
   if (options.activeView === 'issues') {
     return {
-      // #882 phase 4-5 — read + additive mutations + destructive
-      // (gated through y-confirm). Filter cycling / AI summarize
-      // land in phase 6.
-      contextual: ['↑/↓ issues', 'O open', 'y yank URL', 'c comment', 'L label', 'A assign', 'x close*', 'X reopen', 'esc back'],
+      // #882 phase 4-6 — read + additive mutations + destructive
+      // (gated through y-confirm) + filter cycling. AI summarize
+      // (`I`) deferred to a follow-up.
+      contextual: ['↑/↓ issues', 'f filter', 'O open', 'y yank URL', 'c comment', 'L label', 'A assign', 'x close*', 'X reopen', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }
 
   if (options.activeView === 'pull-request-triage') {
     return {
-      // #882 phase 4-5 — full PR action panel scoped to the triage
-      // list. m / x / a / R all route through y-confirm and target
-      // the cursored PR by number (distinct from the `pull-request`
-      // single-PR view which targets the current branch).
-      contextual: ['↑/↓ PRs', 'O open', 'y yank URL', 'c comment', 'L label', 'A assign', 'm merge*', 'x close*', 'a approve', 'R changes*', 'esc back'],
+      // #882 phase 4-6 — full PR action panel scoped to the triage
+      // list + filter cycling. AI summarize (`I`) deferred to a
+      // follow-up.
+      contextual: ['↑/↓ PRs', 'f filter', 'O open', 'y yank URL', 'c comment', 'L label', 'A assign', 'm merge*', 'x close*', 'a approve', 'R changes*', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -1501,3 +1501,54 @@ describe('issue / pull-request triage navigation (#882 phase 3)', () => {
     expect(state.viewStack).toContain('pull-request-triage')
   })
 })
+
+describe('triage filter preset cycling (#882 phase 6)', () => {
+  it('seeds selectedIssueFilter / selectedPullRequestFilter to "open"', () => {
+    const state = createLogInkState(rows)
+    expect(state.selectedIssueFilter).toBe('open')
+    expect(state.selectedPullRequestFilter).toBe('open')
+  })
+
+  it('cycleIssueFilter advances through the preset list and wraps', () => {
+    let state = createLogInkState(rows)
+    expect(state.selectedIssueFilter).toBe('open')
+
+    state = applyLogInkAction(state, { type: 'cycleIssueFilter' })
+    expect(state.selectedIssueFilter).toBe('closed')
+
+    state = applyLogInkAction(state, { type: 'cycleIssueFilter' })
+    expect(state.selectedIssueFilter).toBe('mine')
+
+    state = applyLogInkAction(state, { type: 'cycleIssueFilter' })
+    expect(state.selectedIssueFilter).toBe('assigned')
+
+    state = applyLogInkAction(state, { type: 'cycleIssueFilter' })
+    expect(state.selectedIssueFilter).toBe('open')
+  })
+
+  it('cycleIssueFilter snaps the cursor to the top of the (newly filtered) list', () => {
+    let state = createLogInkState(rows)
+    state = { ...state, selectedIssueIndex: 5 }
+
+    state = applyLogInkAction(state, { type: 'cycleIssueFilter' })
+    expect(state.selectedIssueIndex).toBe(0)
+  })
+
+  it('cyclePullRequestTriageFilter advances and wraps independently', () => {
+    let state = createLogInkState(rows)
+
+    state = applyLogInkAction(state, { type: 'cyclePullRequestTriageFilter' })
+    expect(state.selectedPullRequestFilter).toBe('draft')
+
+    // Cycling PRs leaves the issue preset alone.
+    expect(state.selectedIssueFilter).toBe('open')
+  })
+
+  it('cycle actions clear any pending chord prefix', () => {
+    let state = createLogInkState(rows)
+    state = { ...state, pendingKey: 'g' }
+
+    state = applyLogInkAction(state, { type: 'cycleIssueFilter' })
+    expect(state.pendingKey).toBeUndefined()
+  })
+})

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -6,6 +6,12 @@ import {
     createCommitComposeState,
 } from './commitCompose'
 import type { CommitSplitPlan, CommitSplitPlanContext } from '../commit/split'
+import {
+  cycleIssueFilterPreset,
+  cyclePullRequestFilterPreset,
+  type IssueFilterPreset,
+  type PullRequestFilterPreset,
+} from '../../git/triageFilterPresets'
 import { PromotedSelectionsSnapshot } from '../../workstation/chrome/selectionRectify'
 import {
     BranchSortMode,
@@ -178,6 +184,16 @@ export type LogInkState = {
    * drives the multi-PR list view (`pull-request-triage`).
    */
   selectedPullRequestTriageIndex: number
+  /**
+   * Canned filter presets for the triage views (#882 phase 6).
+   * `f` on each view cycles through the matching preset list (see
+   * `triageFilterPresets.ts`); the active preset drives both the
+   * data fetcher's filter object and the surface header's label.
+   * Persisted on root state so navigating away and back keeps the
+   * user's chosen lens.
+   */
+  selectedIssueFilter: IssueFilterPreset
+  selectedPullRequestFilter: PullRequestFilterPreset
   /**
    * Nested-repo navigation stack (#931). Always at least one entry
    * — the root frame for the repo `coco ui` was launched against.
@@ -608,6 +624,8 @@ export type LogInkAction =
   | { type: 'moveSubmodule'; delta: number; count: number }
   | { type: 'moveIssue'; delta: number; count: number }
   | { type: 'movePullRequestTriage'; delta: number; count: number }
+  | { type: 'cycleIssueFilter' }
+  | { type: 'cyclePullRequestTriageFilter' }
   | { type: 'moveWorktreeListEntry'; delta: number; count: number }
   | { type: 'moveConflictFile'; delta: number; count: number }
   | { type: 'moveToBottom' }
@@ -1026,6 +1044,8 @@ export function createLogInkState(
     selectedSubmoduleIndex: 0,
     selectedIssueIndex: 0,
     selectedPullRequestTriageIndex: 0,
+    selectedIssueFilter: 'open',
+    selectedPullRequestFilter: 'open',
     repoStack: [{ label: options.repoLabel || 'root' }],
     branchSort: DEFAULT_BRANCH_SORT_MODE,
     tagSort: DEFAULT_TAG_SORT_MODE,
@@ -1341,6 +1361,24 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
           state.selectedPullRequestTriageIndex + action.delta,
           action.count
         ),
+        pendingKey: undefined,
+      }
+    case 'cycleIssueFilter':
+      // Advance the preset, snap the cursor to the top of the
+      // (newly filtered) list — same UX rule as `cycleBranchSort`.
+      // The list refetches on preset change via the effect in
+      // app.ts, so the cursor at 0 lands on whatever was promoted.
+      return {
+        ...state,
+        selectedIssueFilter: cycleIssueFilterPreset(state.selectedIssueFilter),
+        selectedIssueIndex: 0,
+        pendingKey: undefined,
+      }
+    case 'cyclePullRequestTriageFilter':
+      return {
+        ...state,
+        selectedPullRequestFilter: cyclePullRequestFilterPreset(state.selectedPullRequestFilter),
+        selectedPullRequestTriageIndex: 0,
         pendingKey: undefined,
       }
     case 'moveWorktreeListEntry':

--- a/src/git/triageFilterPresets.test.ts
+++ b/src/git/triageFilterPresets.test.ts
@@ -1,0 +1,79 @@
+import {
+  cycleIssueFilterPreset,
+  cyclePullRequestFilterPreset,
+  ISSUE_FILTER_LABELS,
+  ISSUE_FILTER_PRESETS,
+  issueFilterForPreset,
+  PULL_REQUEST_FILTER_LABELS,
+  PULL_REQUEST_FILTER_PRESETS,
+  pullRequestFilterForPreset,
+} from './triageFilterPresets'
+
+describe('issue filter presets', () => {
+  it('cycles through every preset in declaration order then wraps', () => {
+    const visited: string[] = []
+    let current = ISSUE_FILTER_PRESETS[0]
+    for (let i = 0; i < ISSUE_FILTER_PRESETS.length + 1; i++) {
+      visited.push(current)
+      current = cycleIssueFilterPreset(current)
+    }
+    expect(visited).toEqual([...ISSUE_FILTER_PRESETS, ISSUE_FILTER_PRESETS[0]])
+  })
+
+  it('has a label for every preset (no implicit default)', () => {
+    for (const preset of ISSUE_FILTER_PRESETS) {
+      expect(ISSUE_FILTER_LABELS[preset]).toBeTruthy()
+    }
+  })
+
+  it.each(ISSUE_FILTER_PRESETS)(
+    'maps %s to a filter object with at least one knob set',
+    (preset) => {
+      const filter = issueFilterForPreset(preset)
+      const knobs = Object.values(filter).filter((v) => v !== undefined && v !== '')
+      expect(knobs.length).toBeGreaterThan(0)
+    }
+  )
+
+  it('mine implies state=open + assignee=@me', () => {
+    expect(issueFilterForPreset('mine')).toEqual({ state: 'open', assignee: '@me' })
+  })
+
+  it('assigned maps to assignee=@me without forcing a state', () => {
+    expect(issueFilterForPreset('assigned')).toEqual({ assignee: '@me' })
+  })
+})
+
+describe('pull request filter presets', () => {
+  it('cycles through every preset in declaration order then wraps', () => {
+    const visited: string[] = []
+    let current = PULL_REQUEST_FILTER_PRESETS[0]
+    for (let i = 0; i < PULL_REQUEST_FILTER_PRESETS.length + 1; i++) {
+      visited.push(current)
+      current = cyclePullRequestFilterPreset(current)
+    }
+    expect(visited).toEqual([...PULL_REQUEST_FILTER_PRESETS, PULL_REQUEST_FILTER_PRESETS[0]])
+  })
+
+  it('has a label for every preset', () => {
+    for (const preset of PULL_REQUEST_FILTER_PRESETS) {
+      expect(PULL_REQUEST_FILTER_LABELS[preset]).toBeTruthy()
+    }
+  })
+
+  it('mine implies state=open + author=@me (not assignee)', () => {
+    // PRs are work people POST, so "mine" means "I authored it".
+    // Distinct from `assigned` which means assignee=@me.
+    expect(pullRequestFilterForPreset('mine')).toEqual({ state: 'open', author: '@me' })
+    expect(pullRequestFilterForPreset('assigned')).toEqual({ assignee: '@me' })
+  })
+
+  it('draft forces state=open + draft=true', () => {
+    expect(pullRequestFilterForPreset('draft')).toEqual({ state: 'open', draft: true })
+  })
+
+  it('merged maps to state=merged (distinct from closed)', () => {
+    expect(pullRequestFilterForPreset('merged')).toEqual({ state: 'merged' })
+    expect(pullRequestFilterForPreset('closed')).toEqual({ state: 'closed' })
+  })
+})

--- a/src/git/triageFilterPresets.ts
+++ b/src/git/triageFilterPresets.ts
@@ -1,0 +1,131 @@
+/**
+ * Canned filter presets for the issue / PR triage TUI views
+ * (#882 phase 6). Each preset compiles to the same shape the
+ * underlying list fetchers (`getIssueList` / `getPullRequestList`)
+ * already accept — there's no new `gh` surface area, just a
+ * curated set of common triage angles surfaced as a single
+ * keystroke (`f` cycles).
+ *
+ * The presets are deliberately *not* a 1:1 mirror across the two
+ * surfaces:
+ *
+ *   - Issues have no draft / mergeable concept, so `draft` /
+ *     `mergeable` are skipped on the issue list.
+ *   - PRs have a `merged` state distinct from `closed`; issues
+ *     don't.
+ *   - `mine` semantics differ subtly: for issues it tends to
+ *     mean "I'm the assignee" (issues are tasks people pick up);
+ *     for PRs it means "I'm the author" (PRs are work people
+ *     post). The presets bake those in so the user doesn't have
+ *     to think about it.
+ */
+
+import type { IssueListFilter } from './issuesListData'
+import type { PullRequestListFilter } from './pullRequestListData'
+
+export type IssueFilterPreset =
+  | 'open'
+  | 'closed'
+  | 'mine'
+  | 'assigned'
+
+export type PullRequestFilterPreset =
+  | 'open'
+  | 'draft'
+  | 'mine'
+  | 'assigned'
+  | 'closed'
+  | 'merged'
+
+/** Cycle order — must match the keystroke walk on `f`. */
+export const ISSUE_FILTER_PRESETS: IssueFilterPreset[] = [
+  'open',
+  'closed',
+  'mine',
+  'assigned',
+]
+
+export const PULL_REQUEST_FILTER_PRESETS: PullRequestFilterPreset[] = [
+  'open',
+  'draft',
+  'mine',
+  'assigned',
+  'closed',
+  'merged',
+]
+
+export const ISSUE_FILTER_LABELS: Record<IssueFilterPreset, string> = {
+  open: 'open',
+  closed: 'closed',
+  mine: 'mine (assigned)',
+  assigned: 'assigned to me',
+}
+
+export const PULL_REQUEST_FILTER_LABELS: Record<PullRequestFilterPreset, string> = {
+  open: 'open',
+  draft: 'draft',
+  mine: 'mine (authored)',
+  assigned: 'assigned to me',
+  closed: 'closed',
+  merged: 'merged',
+}
+
+/**
+ * Resolve a preset to the filter object the data fetcher accepts.
+ * Pure mapping — no `gh` calls. Kept separate from `getIssueList` /
+ * `getPullRequestList` so unit tests can assert the mapping
+ * independently from the fetch pipeline.
+ */
+export function issueFilterForPreset(preset: IssueFilterPreset): IssueListFilter {
+  switch (preset) {
+    case 'open':
+      return { state: 'open' }
+    case 'closed':
+      return { state: 'closed' }
+    case 'mine':
+      // Issues are tasks — "mine" is what *I'm working on*, i.e.
+      // assigned to me + still open. Same as `assigned` plus the
+      // open-state filter for ergonomic single-keystroke focus on
+      // the active backlog.
+      return { state: 'open', assignee: '@me' }
+    case 'assigned':
+      return { assignee: '@me' }
+  }
+}
+
+export function pullRequestFilterForPreset(
+  preset: PullRequestFilterPreset
+): PullRequestListFilter {
+  switch (preset) {
+    case 'open':
+      return { state: 'open' }
+    case 'draft':
+      // gh's `--draft` flag implies `--state open`; surface that
+      // explicitly so the canonicalize step doesn't elide it.
+      return { state: 'open', draft: true }
+    case 'mine':
+      // PRs are work — "mine" is what *I authored*. Most useful
+      // when looking at one's own backlog of in-flight PRs.
+      return { state: 'open', author: '@me' }
+    case 'assigned':
+      return { assignee: '@me' }
+    case 'closed':
+      return { state: 'closed' }
+    case 'merged':
+      return { state: 'merged' }
+  }
+}
+
+export function cycleIssueFilterPreset(current: IssueFilterPreset): IssueFilterPreset {
+  const index = ISSUE_FILTER_PRESETS.indexOf(current)
+  const next = (index + 1) % ISSUE_FILTER_PRESETS.length
+  return ISSUE_FILTER_PRESETS[next]
+}
+
+export function cyclePullRequestFilterPreset(
+  current: PullRequestFilterPreset
+): PullRequestFilterPreset {
+  const index = PULL_REQUEST_FILTER_PRESETS.indexOf(current)
+  const next = (index + 1) % PULL_REQUEST_FILTER_PRESETS.length
+  return PULL_REQUEST_FILTER_PRESETS[next]
+}

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -263,6 +263,10 @@ import { getPullRequestOverview } from '../../git/pullRequestData'
 import { getPullRequestList } from '../../git/pullRequestListData'
 import { clearGitHubListCache } from '../../git/githubListCache'
 import {
+  issueFilterForPreset,
+  pullRequestFilterForPreset,
+} from '../../git/triageFilterPresets'
+import {
     addPullRequestAssignee,
     addPullRequestLabel,
     approvePullRequest,
@@ -1104,17 +1108,19 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
   }, [git, state.activeView, context.pullRequest])
 
-  // Lazy-load the issue triage list (#882 phase 3). Mirrors the
-  // single-PR effect above: only fires on entry to the dedicated
-  // view, and only when we don't already have data. The default
-  // filter (`state: 'open'`) matches the CLI's default so the
-  // workstation and `coco issues` show the same set on first entry.
+  // Lazy-load the issue triage list (#882 phase 3, filter-aware
+  // since phase 6). Fires on entry to the view AND on filter
+  // preset changes (`f` cycles the preset; the dep on
+  // `state.selectedIssueFilter` triggers the refetch). The
+  // existing `context.issueList` guard collapses to a no-op when
+  // the preset hasn't changed and data is already loaded.
   React.useEffect(() => {
     if (state.activeView !== 'issues') return
     if (context.issueList) return
     let active = true
     setContextStatus((current) => updateLogInkContextStatus(current, 'issueList', 'loading'))
-    void safe(getIssueList(git, { state: 'open' })).then((value) => {
+    const filter = issueFilterForPreset(state.selectedIssueFilter)
+    void safe(getIssueList(git, filter)).then((value) => {
       if (!active) return
       setContext((current) => ({
         ...current,
@@ -1125,18 +1131,33 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     return () => {
       active = false
     }
-  }, [git, state.activeView, context.issueList])
+  }, [git, state.activeView, context.issueList, state.selectedIssueFilter])
 
-  // Lazy-load the PR triage list (#882 phase 3). Distinct from the
-  // single-PR `pullRequest` effect above — that fetches the current
-  // branch's PR via `gh pr view`; this fetches the full repo PR list
-  // via `gh pr list`.
+  // Filter cycling: when the preset changes, drop the cached list
+  // so the effect above re-fires with the new filter. Done as a
+  // separate effect (rather than folded into the cycle reducer)
+  // because the reducer is pure — fs / network side-effects live
+  // in `useEffect`.
+  React.useEffect(() => {
+    if (state.activeView !== 'issues') return
+    setContext((current) => (current.issueList ? { ...current, issueList: undefined } : current))
+    setContextStatus((current) => updateLogInkContextStatus(current, 'issueList', 'idle'))
+    // We deliberately depend ONLY on the preset — not on
+    // activeView — so re-entering the view doesn't re-fire and
+    // discard the just-loaded data. The activeView guard above
+    // keeps us from clearing data while the user is on a
+    // different surface.
+  }, [state.selectedIssueFilter])
+
+  // Lazy-load the PR triage list (#882 phase 3, filter-aware
+  // since phase 6). Same pattern as the issue effect above.
   React.useEffect(() => {
     if (state.activeView !== 'pull-request-triage') return
     if (context.pullRequestList) return
     let active = true
     setContextStatus((current) => updateLogInkContextStatus(current, 'pullRequestList', 'loading'))
-    void safe(getPullRequestList(git, { state: 'open' })).then((value) => {
+    const filter = pullRequestFilterForPreset(state.selectedPullRequestFilter)
+    void safe(getPullRequestList(git, filter)).then((value) => {
       if (!active) return
       setContext((current) => ({
         ...current,
@@ -1147,7 +1168,15 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     return () => {
       active = false
     }
-  }, [git, state.activeView, context.pullRequestList])
+  }, [git, state.activeView, context.pullRequestList, state.selectedPullRequestFilter])
+
+  React.useEffect(() => {
+    if (state.activeView !== 'pull-request-triage') return
+    setContext((current) =>
+      current.pullRequestList ? { ...current, pullRequestList: undefined } : current
+    )
+    setContextStatus((current) => updateLogInkContextStatus(current, 'pullRequestList', 'idle'))
+  }, [state.selectedPullRequestFilter])
 
   React.useEffect(() => {
     let active = true

--- a/src/workstation/surfaces/issuesTriage/index.ts
+++ b/src/workstation/surfaces/issuesTriage/index.ts
@@ -22,6 +22,7 @@ import {
 import { truncateCells } from '../../chrome/text'
 import type { LogInkTheme } from '../../chrome/theme'
 import type { LogInkState } from '../../../commands/log/inkViewModel'
+import { ISSUE_FILTER_LABELS } from '../../../git/triageFilterPresets'
 import { matchesPromotedFilter } from '../../runtime/promotedFilter'
 import type { LogInkComponents, LogInkContext } from '../../runtime/types'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
@@ -107,10 +108,11 @@ export function renderIssuesTriageSurface(
     const startIndex = Math.max(0, selected - Math.floor(listRows / 2))
     const windowed = visible.slice(startIndex, startIndex + listRows)
     const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
+    const presetLabel = `▼ ${ISSUE_FILTER_LABELS[state.selectedIssueFilter]}`
     const repoLabel = overview.repository
       ? `${overview.repository.owner}/${overview.repository.name}`
       : ''
-    headerRight = `${repoLabel ? `${repoLabel} · ` : ''}${visible.length}/${all.length}${filterLabel}`
+    headerRight = `${repoLabel ? `${repoLabel} · ` : ''}${visible.length}/${all.length} | ${presetLabel}${filterLabel}`
 
     if (visible.length === 0) {
       bodyLines = [

--- a/src/workstation/surfaces/pullRequestTriage/index.ts
+++ b/src/workstation/surfaces/pullRequestTriage/index.ts
@@ -23,6 +23,7 @@ import {
 import { truncateCells } from '../../chrome/text'
 import type { LogInkTheme } from '../../chrome/theme'
 import type { LogInkState } from '../../../commands/log/inkViewModel'
+import { PULL_REQUEST_FILTER_LABELS } from '../../../git/triageFilterPresets'
 import { matchesPromotedFilter } from '../../runtime/promotedFilter'
 import type { LogInkComponents, LogInkContext } from '../../runtime/types'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
@@ -160,10 +161,11 @@ export function renderPullRequestTriageSurface(
     const startIndex = Math.max(0, selected - Math.floor(listRows / 2))
     const windowed = visible.slice(startIndex, startIndex + listRows)
     const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
+    const presetLabel = `▼ ${PULL_REQUEST_FILTER_LABELS[state.selectedPullRequestFilter]}`
     const repoLabel = overview.repository
       ? `${overview.repository.owner}/${overview.repository.name}`
       : ''
-    headerRight = `${repoLabel ? `${repoLabel} · ` : ''}${visible.length}/${all.length}${filterLabel}`
+    headerRight = `${repoLabel ? `${repoLabel} · ` : ''}${visible.length}/${all.length} | ${presetLabel}${filterLabel}`
 
     if (visible.length === 0) {
       bodyLines = [


### PR DESCRIPTION
Phase 6 of [#882](https://github.com/gfargo/coco/issues/882). Builds on the destructive mutations shipped in phase 5 ([#972](https://github.com/gfargo/coco/pull/972)).

## What lands

\`f\` on each triage view cycles through canned filter presets. Each preset compiles to the same shape the underlying list fetchers already accept — no new \`gh\` surface area, just a curated set of common triage angles surfaced as a single keystroke.

### Issues view (chord \`gi\`)
\`open\` → \`closed\` → \`mine\` (open + assigned to me) → \`assigned\` → wrap

### PR triage view (chord \`gP\`)
\`open\` → \`draft\` → \`mine\` (authored by me) → \`assigned\` → \`closed\` → \`merged\` → wrap

The active preset shows in the surface header as \`▼ open\` / \`▼ mine\` / etc., next to the existing repo + count + filter labels.

## Why the preset lists aren't symmetric

- Issues have no draft / mergeable concept, so those presets are skipped on the issue list.
- PRs have a \`merged\` state distinct from \`closed\`; issues don't.
- \`mine\` semantics differ subtly: for issues it means "I'm the assignee" (issues are tasks people pick up); for PRs it means "I'm the author" (PRs are work people post). The presets bake those in so the user doesn't have to think about it.

## Summary

- **\`src/git/triageFilterPresets.ts\`** — pure module: enums for the preset names, label maps for the surface header, mapping functions to \`IssueListFilter\` / \`PullRequestListFilter\` shapes, and cycle helpers.
- **New view-model state**: \`selectedIssueFilter\` and \`selectedPullRequestFilter\`, both default to \`'open'\`. Persisted on root state so navigating away and back keeps the user's chosen lens.
- **New reducer actions**: \`cycleIssueFilter\` and \`cyclePullRequestTriageFilter\` — same shape as \`cycleBranchSort\` / \`cycleTagSort\`. Snap the cursor to 0 on cycle so the user always sees what was promoted to the top.
- **Data effects** in \`app.ts\` watch the preset fields and refetch with the matching filter object. A companion effect drops the cached list on preset change so the load effect re-fires (rather than serving stale data through the existing \`context.issueList\` short-circuit guard).
- **Surface headers** show the active preset alongside the existing labels.

## Cache interaction

The preset feeds into the filter object that's passed to \`getIssueList\` / \`getPullRequestList\`. The disk cache from phase 2 keys on the canonicalized filter, so each preset gets its own cache entry — switching presets doesn't blow away the cache for the previous preset. Users who cycle back to a recently-seen preset get a cache hit.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm run test:jest\` — 1888 tests pass, 7 skipped (166 suites). 21 new tests across:
  - \`triageFilterPresets.test.ts\` — cycle wrap-around, label completeness, preset-to-filter mapping for every preset, the issue-vs-PR \`mine\` divergence
  - \`inkViewModel.test.ts\` — reducer init defaults, cycle action advancement + wrap, cursor reset on cycle, independence between issue / PR presets, pending-key clearance
  - \`inkInput.test.ts\` — \`f\` dispatch on each view + regression guard that \`f\` from the history view doesn't accidentally claim either preset
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: \`coco ui\` → \`gi\` → \`f\` → header swaps to \`▼ closed\`, list refetches with closed issues
- [ ] Manual: \`gP\` → \`f\` → \`▼ draft\` → list shows draft PRs only
- [ ] Manual: cycle back to a previously-seen preset → cache hit (no extra \`gh\` call)

## Out of scope (follow-ups)

- **AI summarize \`I\`** — uses the existing AI infrastructure to generate a one-paragraph summary of the cursored item. Needs a new overlay component to display multi-line output (the existing status line is single-line). Naturally pairs with per-item body hydration below.
- **Body / comments / reviews in inspector** — needs a per-cursor-rest \`gh\` fetch (debounced) plus an expanded inspector pane. Substantial UX work; deserves its own PR.

These two were originally bundled into Phase 6 in my plan, but each needs new UI surfaces beyond what the existing chrome supports, and shipping them here would have ballooned this diff well past the "small focused PRs" cadence. They're tracked as follow-ups; #882 itself is functionally complete with this PR for the read + triage + mutate flow.

## Notes for review

- The cycle order is hard-coded in \`ISSUE_FILTER_PRESETS\` / \`PULL_REQUEST_FILTER_PRESETS\`. A reverse-cycle chord (\`F\` for shift-f?) could come later if users ask for it; for now a single direction matches the \`s sort\` muscle memory from the branches / tags views.
- The eslint config doesn't have \`react-hooks/exhaustive-deps\`, so the two-effect pattern that drops the cache on preset change relies on documentation rather than enforcement to keep its dep list intentional. Comments in the code call this out.