### PR TITLE
feat(workstation): per-item body / comments / reviews in triage inspector

### DIFF
--- a/src/git/issueDetailData.test.ts
+++ b/src/git/issueDetailData.test.ts
@@ -1,0 +1,93 @@
+import { getIssueDetail, ISSUE_DETAIL_JSON_FIELDS } from './issueDetailData'
+
+describe('getIssueDetail', () => {
+  it('invokes `gh issue view <#> --json body,comments,...` with the centralized field list', async () => {
+    const runner = jest.fn().mockResolvedValue(JSON.stringify({
+      number: 882,
+      body: 'A pair of new top-level commands…',
+      comments: [],
+    }))
+
+    const result = await getIssueDetail(882, runner)
+
+    expect(runner).toHaveBeenCalledWith([
+      'issue',
+      'view',
+      '882',
+      '--json',
+      ISSUE_DETAIL_JSON_FIELDS,
+    ])
+    expect(result).toEqual({
+      ok: true,
+      detail: {
+        number: 882,
+        body: 'A pair of new top-level commands…',
+        comments: [],
+      },
+    })
+  })
+
+  it('parses comment entries with author + body + createdAt', async () => {
+    const runner = jest.fn().mockResolvedValue(JSON.stringify({
+      number: 7,
+      body: 'help wanted',
+      comments: [
+        {
+          author: { login: 'reviewer-a' },
+          body: 'taking a look',
+          createdAt: '2026-05-15T01:00:00Z',
+        },
+        {
+          author: { login: 'reviewer-b' },
+          body: 'lgtm',
+          createdAt: '2026-05-15T02:00:00Z',
+        },
+      ],
+    }))
+
+    const result = await getIssueDetail(7, runner)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('unreachable')
+    expect(result.detail.comments).toEqual([
+      { author: 'reviewer-a', body: 'taking a look', createdAt: '2026-05-15T01:00:00Z' },
+      { author: 'reviewer-b', body: 'lgtm', createdAt: '2026-05-15T02:00:00Z' },
+    ])
+  })
+
+  it('defaults missing fields to empty rather than crashing', async () => {
+    const runner = jest.fn().mockResolvedValue(JSON.stringify({ number: 1 }))
+    const result = await getIssueDetail(1, runner)
+
+    expect(result).toEqual({
+      ok: true,
+      detail: { number: 1, body: '', comments: [] },
+    })
+  })
+
+  it('returns ok: false with a descriptive message on empty gh output', async () => {
+    const runner = jest.fn().mockResolvedValue('')
+    const result = await getIssueDetail(1, runner)
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('unreachable')
+    expect(result.message).toContain('Empty response')
+  })
+
+  it('surfaces runner errors as ok: false', async () => {
+    const runner = jest.fn().mockRejectedValue(new Error('rate limited'))
+    const result = await getIssueDetail(1, runner)
+
+    expect(result).toEqual({ ok: false, message: 'rate limited' })
+  })
+
+  it('returns ok: false when the payload lacks a numeric `number` field', async () => {
+    // Defensive against a future gh shape change — if `number` ever
+    // becomes a string we want to fail loudly here rather than
+    // poisoning the cache with a junk entry.
+    const runner = jest.fn().mockResolvedValue(JSON.stringify({ number: 'one' }))
+    const result = await getIssueDetail(1, runner)
+
+    expect(result.ok).toBe(false)
+  })
+})

--- a/src/git/issueDetailData.ts
+++ b/src/git/issueDetailData.ts
@@ -1,0 +1,92 @@
+/**
+ * Per-item issue detail fetcher (#882 inspector hydration). The list
+ * payload from `gh issue list` deliberately omits bodies and
+ * comments to keep the list fetch cheap; this module fills those in
+ * on demand when the user rests the cursor on a specific issue.
+ *
+ * Called from the workstation runtime with a debounced timer so
+ * rapid j/k navigation doesn't spam `gh`. Results land in a
+ * `Map<number, IssueDetail>` cache on `LogInkContext` keyed by
+ * issue number, so cursoring back to a previously-fetched item
+ * shows instantly.
+ */
+
+import { defaultGhRunner, type GhRunner } from './githubCli'
+
+export type IssueComment = {
+  author?: string
+  body: string
+  createdAt: string
+}
+
+export type IssueDetail = {
+  number: number
+  body: string
+  comments: IssueComment[]
+}
+
+/**
+ * `gh issue view <#> --json` field list. Kept separate from the
+ * list-view field list since the detail view only needs the
+ * fields that the list payload doesn't already carry.
+ */
+export const ISSUE_DETAIL_JSON_FIELDS = ['number', 'body', 'comments'].join(',')
+
+function parseIssueComments(value: unknown): IssueComment[] {
+  if (!Array.isArray(value)) return []
+  return value.map((entry) => {
+    const raw = entry as Record<string, unknown>
+    const author =
+      raw.author && typeof raw.author === 'object' && 'login' in raw.author
+        ? String((raw.author as { login: unknown }).login)
+        : undefined
+    return {
+      author,
+      body: typeof raw.body === 'string' ? raw.body : '',
+      createdAt: typeof raw.createdAt === 'string' ? raw.createdAt : '',
+    }
+  })
+}
+
+function parseIssueDetail(output: string): IssueDetail | undefined {
+  const trimmed = output.trim()
+  if (!trimmed) return undefined
+
+  const raw = JSON.parse(trimmed) as Record<string, unknown>
+  if (typeof raw.number !== 'number') return undefined
+
+  return {
+    number: raw.number,
+    body: typeof raw.body === 'string' ? raw.body : '',
+    comments: parseIssueComments(raw.comments),
+  }
+}
+
+export type IssueDetailResult =
+  | { ok: true; detail: IssueDetail }
+  | { ok: false; message: string }
+
+export async function getIssueDetail(
+  issueNumber: number,
+  runner: GhRunner = defaultGhRunner
+): Promise<IssueDetailResult> {
+  try {
+    const output = await runner([
+      'issue',
+      'view',
+      String(issueNumber),
+      '--json',
+      ISSUE_DETAIL_JSON_FIELDS,
+    ])
+    const detail = parseIssueDetail(output)
+    if (!detail) {
+      return { ok: false, message: `Empty response from gh for issue #${issueNumber}` }
+    }
+    return { ok: true, detail }
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : String(error),
+    }
+  }
+}

--- a/src/git/pullRequestDetailData.test.ts
+++ b/src/git/pullRequestDetailData.test.ts
@@ -1,0 +1,108 @@
+import {
+  getPullRequestDetail,
+  PULL_REQUEST_DETAIL_JSON_FIELDS,
+} from './pullRequestDetailData'
+
+describe('getPullRequestDetail', () => {
+  it('invokes `gh pr view <#> --json …` with the centralized field list', async () => {
+    const runner = jest.fn().mockResolvedValue(JSON.stringify({
+      number: 962,
+      body: 'fixed it',
+      comments: [],
+      reviews: [],
+      statusCheckRollup: [],
+    }))
+
+    const result = await getPullRequestDetail(962, runner)
+
+    expect(runner).toHaveBeenCalledWith([
+      'pr',
+      'view',
+      '962',
+      '--json',
+      PULL_REQUEST_DETAIL_JSON_FIELDS,
+    ])
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('unreachable')
+    expect(result.detail).toEqual({
+      number: 962,
+      body: 'fixed it',
+      comments: [],
+      reviews: [],
+      statusCheckRollup: [],
+    })
+  })
+
+  it('parses reviews + status checks', async () => {
+    const runner = jest.fn().mockResolvedValue(JSON.stringify({
+      number: 1,
+      body: '',
+      comments: [],
+      reviews: [
+        { author: { login: 'a' }, state: 'APPROVED', body: 'lgtm', submittedAt: '2026-05-15T00:00:00Z' },
+        { author: { login: 'b' }, state: 'CHANGES_REQUESTED', body: 'needs work', submittedAt: '2026-05-15T01:00:00Z' },
+      ],
+      statusCheckRollup: [
+        { name: 'lint', status: 'COMPLETED', conclusion: 'SUCCESS' },
+        { name: 'test', status: 'COMPLETED', conclusion: 'FAILURE' },
+        { name: 'build', status: 'IN_PROGRESS' },
+      ],
+    }))
+
+    const result = await getPullRequestDetail(1, runner)
+
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.detail.reviews).toEqual([
+      { author: 'a', state: 'APPROVED', body: 'lgtm', submittedAt: '2026-05-15T00:00:00Z' },
+      { author: 'b', state: 'CHANGES_REQUESTED', body: 'needs work', submittedAt: '2026-05-15T01:00:00Z' },
+    ])
+    expect(result.detail.statusCheckRollup).toEqual([
+      { name: 'lint', status: 'COMPLETED', conclusion: 'SUCCESS' },
+      { name: 'test', status: 'COMPLETED', conclusion: 'FAILURE' },
+      { name: 'build', status: 'IN_PROGRESS', conclusion: undefined },
+    ])
+  })
+
+  it('strips reviews whose author is missing AND whose body is empty', async () => {
+    // Deleted-account reviews come back without an author. If the body
+    // is also empty there's nothing to render, so filtering them out
+    // keeps the inspector from showing anonymous "@anonymous ()" rows.
+    const runner = jest.fn().mockResolvedValue(JSON.stringify({
+      number: 1,
+      body: '',
+      comments: [],
+      reviews: [
+        { author: null, state: 'COMMENTED', body: '', submittedAt: '' },
+        { author: null, state: 'COMMENTED', body: 'still useful', submittedAt: '' },
+      ],
+      statusCheckRollup: [],
+    }))
+
+    const result = await getPullRequestDetail(1, runner)
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.detail.reviews).toHaveLength(1)
+    expect(result.detail.reviews[0].body).toBe('still useful')
+  })
+
+  it('defaults missing optional fields gracefully', async () => {
+    const runner = jest.fn().mockResolvedValue(JSON.stringify({ number: 1 }))
+    const result = await getPullRequestDetail(1, runner)
+
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.detail).toEqual({
+      number: 1,
+      body: '',
+      comments: [],
+      reviews: [],
+      statusCheckRollup: [],
+    })
+  })
+
+  it('surfaces runner errors as ok: false', async () => {
+    const runner = jest.fn().mockRejectedValue(new Error('not authenticated'))
+    await expect(getPullRequestDetail(1, runner)).resolves.toEqual({
+      ok: false,
+      message: 'not authenticated',
+    })
+  })
+})

--- a/src/git/pullRequestDetailData.ts
+++ b/src/git/pullRequestDetailData.ts
@@ -1,0 +1,149 @@
+/**
+ * Per-item PR detail fetcher (#882 inspector hydration). Mirrors
+ * `issueDetailData.ts`'s shape — pulls body, comments, reviews,
+ * and the status-check rollup on demand when the user rests the
+ * cursor on a PR row.
+ *
+ * Distinct from the existing `pullRequestData.ts` which fetches
+ * the CURRENT BRANCH's PR via `gh pr view` (no number arg). This
+ * fetcher takes an explicit PR number so the triage view can
+ * hydrate any cursored PR, not just the one matching the current
+ * branch.
+ */
+
+import { defaultGhRunner, type GhRunner } from './githubCli'
+import type { IssueComment } from './issueDetailData'
+
+export type PullRequestReview = {
+  author?: string
+  state: string
+  body: string
+  submittedAt: string
+}
+
+export type PullRequestStatusCheck = {
+  name: string
+  status?: string
+  conclusion?: string
+}
+
+export type PullRequestDetail = {
+  number: number
+  body: string
+  comments: IssueComment[]
+  reviews: PullRequestReview[]
+  statusCheckRollup: PullRequestStatusCheck[]
+}
+
+/**
+ * `gh pr view <#> --json` field list. Subset of what
+ * `pullRequestData.ts`'s `PULL_REQUEST_VIEW_JSON_FIELDS` includes —
+ * the triage list payload already carries the structural metadata
+ * (state, isDraft, branches, labels, etc.), so the detail fetch
+ * only needs the heavy/expensive fields that the list omits.
+ */
+export const PULL_REQUEST_DETAIL_JSON_FIELDS = [
+  'number',
+  'body',
+  'comments',
+  'reviews',
+  'statusCheckRollup',
+].join(',')
+
+function parseComments(value: unknown): IssueComment[] {
+  if (!Array.isArray(value)) return []
+  return value.map((entry) => {
+    const raw = entry as Record<string, unknown>
+    const author =
+      raw.author && typeof raw.author === 'object' && 'login' in raw.author
+        ? String((raw.author as { login: unknown }).login)
+        : undefined
+    return {
+      author,
+      body: typeof raw.body === 'string' ? raw.body : '',
+      createdAt: typeof raw.createdAt === 'string' ? raw.createdAt : '',
+    }
+  })
+}
+
+function parseReviews(value: unknown): PullRequestReview[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((entry) => {
+      const raw = entry as Record<string, unknown>
+      const author =
+        raw.author && typeof raw.author === 'object' && 'login' in raw.author
+          ? String((raw.author as { login: unknown }).login)
+          : undefined
+      return {
+        author,
+        state: typeof raw.state === 'string' ? raw.state : '',
+        body: typeof raw.body === 'string' ? raw.body : '',
+        submittedAt: typeof raw.submittedAt === 'string' ? raw.submittedAt : '',
+      }
+    })
+    // gh occasionally returns review entries without an author when the
+    // reviewer's account is deleted. Those are unactionable noise here;
+    // strip them so the inspector doesn't render anonymous rows.
+    .filter((review) => review.author || review.body)
+}
+
+function parseStatusCheckRollup(value: unknown): PullRequestStatusCheck[] {
+  if (!Array.isArray(value)) return []
+  return value.map((entry) => {
+    const raw = entry as Record<string, unknown>
+    return {
+      name: String(raw.name || raw.context || 'check'),
+      status: typeof raw.status === 'string' ? raw.status : undefined,
+      conclusion: typeof raw.conclusion === 'string' ? raw.conclusion : undefined,
+    }
+  })
+}
+
+function parsePullRequestDetail(output: string): PullRequestDetail | undefined {
+  const trimmed = output.trim()
+  if (!trimmed) return undefined
+
+  const raw = JSON.parse(trimmed) as Record<string, unknown>
+  if (typeof raw.number !== 'number') return undefined
+
+  return {
+    number: raw.number,
+    body: typeof raw.body === 'string' ? raw.body : '',
+    comments: parseComments(raw.comments),
+    reviews: parseReviews(raw.reviews),
+    statusCheckRollup: parseStatusCheckRollup(raw.statusCheckRollup),
+  }
+}
+
+export type PullRequestDetailResult =
+  | { ok: true; detail: PullRequestDetail }
+  | { ok: false; message: string }
+
+export async function getPullRequestDetail(
+  pullRequestNumber: number,
+  runner: GhRunner = defaultGhRunner
+): Promise<PullRequestDetailResult> {
+  try {
+    const output = await runner([
+      'pr',
+      'view',
+      String(pullRequestNumber),
+      '--json',
+      PULL_REQUEST_DETAIL_JSON_FIELDS,
+    ])
+    const detail = parsePullRequestDetail(output)
+    if (!detail) {
+      return {
+        ok: false,
+        message: `Empty response from gh for pull request #${pullRequestNumber}`,
+      }
+    }
+    return { ok: true, detail }
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : String(error),
+    }
+  }
+}

--- a/src/workstation/chrome/previewPane.triage.test.ts
+++ b/src/workstation/chrome/previewPane.triage.test.ts
@@ -139,3 +139,146 @@ describe('formatPullRequestTriagePreview', () => {
     expect(lines.some((l) => l.includes('CHANGES_REQUESTED'))).toBe(false)
   })
 })
+
+describe('hydrated triage preview sections (inspector hydration follow-up)', () => {
+  const issue = {
+    number: 882,
+    title: 't',
+    url: 'u',
+    state: 'OPEN',
+    createdAt: '',
+    updatedAt: '',
+    comments: 2,
+  }
+
+  it('issue preview shows "Loading…" hint when no detail is cached AND comments > 0', () => {
+    const lines = formatIssueTriagePreview(issue).map(stripLine)
+    expect(lines.some((l) => l.toLowerCase().includes('loading'))).toBe(true)
+  })
+
+  it('issue preview omits the loading hint when there are zero comments', () => {
+    const lines = formatIssueTriagePreview({ ...issue, comments: 0 }).map(stripLine)
+    expect(lines.some((l) => l.toLowerCase().includes('loading'))).toBe(false)
+  })
+
+  it('issue preview renders body excerpt + comments when detail is provided', () => {
+    const detail = {
+      number: 882,
+      body: 'First line.\n\nSecond paragraph.\nThird line.',
+      comments: [
+        { author: 'reviewer-a', body: 'taking a look', createdAt: '2026-05-15T00:00:00Z' },
+        { author: 'reviewer-b', body: 'lgtm', createdAt: '2026-05-15T01:00:00Z' },
+      ],
+    }
+    const lines = formatIssueTriagePreview(issue, detail).map(stripLine)
+
+    expect(lines).toContain('Body')
+    expect(lines).toContain('First line.')
+    expect(lines.some((l) => l.startsWith('Comments ('))).toBe(true)
+    expect(lines.some((l) => l.includes('@reviewer-a'))).toBe(true)
+    expect(lines.some((l) => l.includes('@reviewer-b'))).toBe(true)
+    // Loading hint disappears once detail lands.
+    expect(lines.some((l) => l.toLowerCase().includes('loading'))).toBe(false)
+  })
+
+  it('issue preview shows a truncation trailer when the body exceeds the maxLines cap', () => {
+    const bigBody = Array.from({ length: 12 }, (_, i) => `line ${i}`).join('\n')
+    const detail = { number: 1, body: bigBody, comments: [] }
+    const lines = formatIssueTriagePreview(
+      { ...issue, comments: 0 },
+      detail
+    ).map(stripLine)
+
+    expect(lines.some((l) => l.includes('more line'))).toBe(true)
+  })
+
+  const pr = {
+    number: 962,
+    title: 't',
+    url: 'u',
+    state: 'OPEN',
+    isDraft: false,
+    headRefName: 'h',
+    baseRefName: 'm',
+    createdAt: '',
+    updatedAt: '',
+  }
+
+  it('PR preview shows a loading hint pre-hydration', () => {
+    const lines = formatPullRequestTriagePreview(pr).map(stripLine)
+    expect(lines.some((l) => l.toLowerCase().includes('loading'))).toBe(true)
+  })
+
+  it('PR preview renders body + checks + reviews + comments when detail is provided', () => {
+    const detail = {
+      number: 962,
+      body: 'Fixes the dedupe rescue gap.',
+      comments: [
+        { author: 'commenter', body: 'thanks', createdAt: '2026-05-15T00:00:00Z' },
+      ],
+      reviews: [
+        { author: 'reviewer-a', state: 'APPROVED', body: 'lgtm', submittedAt: '2026-05-15T00:00:00Z' },
+        { author: 'reviewer-b', state: 'CHANGES_REQUESTED', body: 'fix x', submittedAt: '2026-05-15T00:00:00Z' },
+      ],
+      statusCheckRollup: [
+        { name: 'lint', status: 'COMPLETED', conclusion: 'SUCCESS' },
+        { name: 'test', status: 'COMPLETED', conclusion: 'FAILURE' },
+      ],
+    }
+    const lines = formatPullRequestTriagePreview(pr, detail).map(stripLine)
+
+    expect(lines).toContain('Body')
+    expect(lines).toContain('Fixes the dedupe rescue gap.')
+
+    expect(lines.some((l) => l.startsWith('Checks ('))).toBe(true)
+    expect(lines.some((l) => l.includes('1 pass'))).toBe(true)
+    expect(lines.some((l) => l.includes('1 fail'))).toBe(true)
+
+    expect(lines.some((l) => l.startsWith('Reviews ('))).toBe(true)
+    expect(lines.some((l) => l.includes('@reviewer-a (approved)'))).toBe(true)
+    expect(lines.some((l) => l.includes('@reviewer-b (changes requested)'))).toBe(true)
+
+    expect(lines.some((l) => l.startsWith('Comments ('))).toBe(true)
+    expect(lines.some((l) => l.includes('@commenter'))).toBe(true)
+  })
+
+  it('PR preview omits empty hydrated sections', () => {
+    const detail = {
+      number: 962,
+      body: '',
+      comments: [],
+      reviews: [],
+      statusCheckRollup: [],
+    }
+    const lines = formatPullRequestTriagePreview(pr, detail).map(stripLine)
+
+    expect(lines).not.toContain('Body')
+    expect(lines.some((l) => l.startsWith('Comments ('))).toBe(false)
+    expect(lines.some((l) => l.startsWith('Reviews ('))).toBe(false)
+    expect(lines.some((l) => l.startsWith('Checks ('))).toBe(false)
+  })
+
+  it('comments section truncates to the most recent N + summarizes the rest', () => {
+    const detail = {
+      number: 1,
+      body: '',
+      comments: Array.from({ length: 7 }, (_, i) => ({
+        author: `reviewer-${i}`,
+        body: `comment ${i}`,
+        createdAt: '',
+      })),
+    }
+    const lines = formatIssueTriagePreview(
+      { ...issue, comments: 7 },
+      detail
+    ).map(stripLine)
+
+    // Last 3 visible.
+    expect(lines.some((l) => l.includes('@reviewer-6'))).toBe(true)
+    expect(lines.some((l) => l.includes('@reviewer-5'))).toBe(true)
+    expect(lines.some((l) => l.includes('@reviewer-4'))).toBe(true)
+    // Older ones summarized.
+    expect(lines.some((l) => l.includes('earlier comment'))).toBe(true)
+    expect(lines.some((l) => l.includes('@reviewer-0'))).toBe(false)
+  })
+})

--- a/src/workstation/chrome/previewPane.ts
+++ b/src/workstation/chrome/previewPane.ts
@@ -11,7 +11,9 @@
  */
 
 import { BranchRef } from '../../git/branchData'
+import type { IssueDetail } from '../../git/issueDetailData'
 import type { IssueListItem } from '../../git/issuesListData'
+import type { PullRequestDetail } from '../../git/pullRequestDetailData'
 import type { PullRequestListItem } from '../../git/pullRequestListData'
 import { StashEntry } from '../../git/stashData'
 import { GitTagRef } from '../../git/tagData'
@@ -131,22 +133,113 @@ export function formatStashPreview(
   return out
 }
 
+/* ------------------------- detail-section helpers ----------------------- */
+
+/**
+ * Render the first `maxLines` non-empty lines of an issue / PR body
+ * as preview lines. Returns an empty array when the body itself is
+ * empty (or whitespace only) so callers can `out.push(...body(...))`
+ * without an extra guard. Trailer appears only when content was
+ * actually truncated.
+ */
+function bodyExcerptLines(body: string, maxLines: number): PreviewLine[] {
+  if (!body.trim()) return []
+  const lines = body.replace(/\r\n/g, '\n').split('\n')
+  // Drop leading blanks so the excerpt opens on the first real line
+  // rather than rendering an awkward "blank line, then body".
+  while (lines.length > 0 && !lines[0].trim()) lines.shift()
+  const shown = lines.slice(0, maxLines)
+  const truncated = lines.length > maxLines
+  const out: PreviewLine[] = [
+    heading('Body'),
+    ...shown.map((l) => line(l)),
+  ]
+  if (truncated) {
+    out.push(dim(`… ${lines.length - maxLines} more line(s)`))
+  }
+  return out
+}
+
+function shortenLine(value: string, maxLength: number): string {
+  const flattened = value.replace(/\s+/g, ' ').trim()
+  if (flattened.length <= maxLength) return flattened
+  return `${flattened.slice(0, Math.max(0, maxLength - 1))}…`
+}
+
+function commentsSection(
+  comments: ReadonlyArray<{ author?: string; body: string }>,
+  maxShown: number
+): PreviewLine[] {
+  if (comments.length === 0) return []
+  const recent = comments.slice(-maxShown)
+  const out: PreviewLine[] = [heading(`Comments (${comments.length})`)]
+  for (const comment of recent) {
+    const who = comment.author || 'anonymous'
+    out.push(line(`@${who}: ${shortenLine(comment.body, 80)}`))
+  }
+  if (comments.length > recent.length) {
+    out.push(dim(`… ${comments.length - recent.length} earlier comment(s)`))
+  }
+  return out
+}
+
+function reviewsSection(
+  reviews: ReadonlyArray<{ author?: string; state: string; body: string }>
+): PreviewLine[] {
+  if (reviews.length === 0) return []
+  const out: PreviewLine[] = [heading(`Reviews (${reviews.length})`)]
+  for (const review of reviews) {
+    const who = review.author || 'anonymous'
+    const stateLabel = (review.state || 'commented').toLowerCase().replace(/_/g, ' ')
+    const inlineBody = review.body ? ` — ${shortenLine(review.body, 60)}` : ''
+    out.push(line(`@${who} (${stateLabel})${inlineBody}`))
+  }
+  return out
+}
+
+function statusChecksSection(
+  checks: ReadonlyArray<{ name: string; status?: string; conclusion?: string }>
+): PreviewLine[] {
+  if (checks.length === 0) return []
+  const grouped = {
+    success: 0,
+    failure: 0,
+    pending: 0,
+    other: 0,
+  }
+  for (const check of checks) {
+    const result = check.conclusion?.toLowerCase() ?? check.status?.toLowerCase() ?? ''
+    if (result === 'success') grouped.success++
+    else if (result === 'failure' || result === 'cancelled' || result === 'timed_out')
+      grouped.failure++
+    else if (result === 'pending' || result === 'queued' || result === 'in_progress')
+      grouped.pending++
+    else grouped.other++
+  }
+  const parts: string[] = []
+  if (grouped.success) parts.push(`${grouped.success} pass`)
+  if (grouped.failure) parts.push(`${grouped.failure} fail`)
+  if (grouped.pending) parts.push(`${grouped.pending} pending`)
+  if (grouped.other) parts.push(`${grouped.other} other`)
+  return [
+    heading(`Checks (${checks.length})`),
+    line(parts.join(' · ')),
+  ]
+}
+
 /* -------------------------------- issue -------------------------------- */
 
 /**
- * Format an issue triage entry into preview lines (#882 phase 3).
- * Returns a uniform "select to preview" message when nothing is
- * cursored; otherwise renders #/state/author/labels/assignees, a
- * timestamp pair, and a short body excerpt clipped at 6 lines.
- *
- * The list payload from `gh issue list --json` doesn't include body
- * text — that's a deliberate scope cut in phase 1 to keep the list
- * fetch cheap. The preview pane therefore omits the body section
- * entirely; phase 4 will introduce a per-issue fetch that hydrates
- * the body on demand when the cursor rests.
+ * Format an issue triage entry into preview lines (#882 phase 3,
+ * body + comments added in the inspector-hydration follow-up).
+ * The list payload from `gh issue list --json` carries metadata
+ * only; the optional `detail` argument is filled by the runtime's
+ * debounced hydration effect when the cursor rests on a row, and
+ * unlocks the body / comments sections.
  */
 export function formatIssueTriagePreview(
-  issue: IssueListItem | undefined
+  issue: IssueListItem | undefined,
+  detail?: IssueDetail
 ): PreviewLine[] {
   if (!issue) {
     return [dim('Select an issue to preview.')]
@@ -173,20 +266,41 @@ export function formatIssueTriagePreview(
   out.push(blank())
   out.push(dim(issue.url))
 
+  // Hydrated sections (body + recent comments). Inserted only when
+  // the runtime has finished the per-cursor-rest detail fetch and
+  // populated the cache.
+  if (detail) {
+    const body = bodyExcerptLines(detail.body, 6)
+    if (body.length > 0) {
+      out.push(blank())
+      out.push(...body)
+    }
+    const comments = commentsSection(detail.comments, 3)
+    if (comments.length > 0) {
+      out.push(blank())
+      out.push(...comments)
+    }
+  } else if (typeof issue.comments === 'number' && issue.comments > 0) {
+    // Pre-hydration affordance — tell the user the body / comments
+    // section is coming, so a 250ms wait doesn't look like a bug.
+    out.push(blank())
+    out.push(dim('Loading body + comments…'))
+  }
+
   return out
 }
 
 /* ----------------------------- pull request ---------------------------- */
 
 /**
- * Format a pull-request triage entry into preview lines (#882 phase 3).
- * Renders #/state/author/branches/labels/mergeable/review-decision and
- * a timestamp pair. Like the issue preview, the body is not included
- * — list payloads from `gh pr list --json` don't carry bodies; phase 4
- * will hydrate one per cursor rest.
+ * Format a pull-request triage entry into preview lines (#882 phase 3,
+ * body / comments / reviews / checks added in the inspector-hydration
+ * follow-up). Optional `detail` argument is filled by the runtime's
+ * debounced hydration effect when the cursor rests on a row.
  */
 export function formatPullRequestTriagePreview(
-  pr: PullRequestListItem | undefined
+  pr: PullRequestListItem | undefined,
+  detail?: PullRequestDetail
 ): PreviewLine[] {
   if (!pr) {
     return [dim('Select a pull request to preview.')]
@@ -217,6 +331,37 @@ export function formatPullRequestTriagePreview(
   if (pr.updatedAt) out.push(line(`Updated:   ${pr.updatedAt}`))
   out.push(blank())
   out.push(dim(pr.url))
+
+  // Hydrated sections — body, status checks, reviews, comments.
+  // Status checks come BEFORE reviews because failing CI is usually
+  // what a triager wants to see first; reviews come second because
+  // they're the human-judgment layer on top.
+  if (detail) {
+    const body = bodyExcerptLines(detail.body, 6)
+    if (body.length > 0) {
+      out.push(blank())
+      out.push(...body)
+    }
+    const checks = statusChecksSection(detail.statusCheckRollup)
+    if (checks.length > 0) {
+      out.push(blank())
+      out.push(...checks)
+    }
+    const reviews = reviewsSection(detail.reviews)
+    if (reviews.length > 0) {
+      out.push(blank())
+      out.push(...reviews)
+    }
+    const comments = commentsSection(detail.comments, 3)
+    if (comments.length > 0) {
+      out.push(blank())
+      out.push(...comments)
+    }
+  } else {
+    // Pre-hydration affordance — same as the issue preview.
+    out.push(blank())
+    out.push(dim('Loading body + reviews + comments…'))
+  }
 
   return out
 }

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -251,6 +251,7 @@ import { applyStash, checkoutFileFromStash, createStash, dropStash, popStash } f
 import { ApplyHunkTarget, applyHunkPatch } from '../../git/hunkActions'
 import { removeWorktree, removeWorktreeAndBranch } from '../../git/worktreeActions'
 import { abortOperation, continueOperation, resolveConflictOurs, resolveConflictTheirs, stageConflictResolved } from '../../git/operationActions'
+import { getIssueDetail } from '../../git/issueDetailData'
 import { getIssueList } from '../../git/issuesListData'
 import {
   addIssueAssignee,
@@ -259,6 +260,7 @@ import {
   commentIssue,
   reopenIssue,
 } from '../../git/issueActions'
+import { getPullRequestDetail } from '../../git/pullRequestDetailData'
 import { getPullRequestOverview } from '../../git/pullRequestData'
 import { getPullRequestList } from '../../git/pullRequestListData'
 import { clearGitHubListCache } from '../../git/githubListCache'
@@ -1177,6 +1179,89 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     )
     setContextStatus((current) => updateLogInkContextStatus(current, 'pullRequestList', 'idle'))
   }, [state.selectedPullRequestFilter])
+
+  // Per-item inspector hydration (#882 follow-up to phase 6). When
+  // the user rests the cursor on an issue / PR row for ~250ms, fetch
+  // the body + comments (+ reviews + status checks for PRs) and
+  // cache the result keyed by number. Cursoring back to a previously-
+  // fetched item shows the cached entry instantly; rapid j/k
+  // navigation never fires a `gh` call because the debounce timer
+  // resets on every cursor move.
+  //
+  // The cache lives on `context.{issueDetailByNumber,
+  // pullRequestDetailByNumber}` so it survives the per-keystroke
+  // re-renders. It's intentionally Maps — `new Map(prev).set(k, v)`
+  // keeps the immutable update story simple, and entries persist
+  // until either the list is invalidated (post-mutation) or the
+  // process exits.
+  const DETAIL_HYDRATION_DELAY_MS = 250
+
+  React.useEffect(() => {
+    if (state.activeView !== 'issues') return
+    const cursored = filteredIssueList[
+      Math.min(state.selectedIssueIndex, Math.max(0, filteredIssueList.length - 1))
+    ]
+    if (!cursored) return
+    if (context.issueDetailByNumber?.has(cursored.number)) return
+
+    let active = true
+    const timer = setTimeout(async () => {
+      const result = await getIssueDetail(cursored.number)
+      if (!active || !result.ok) return
+      setContext((current) => ({
+        ...current,
+        issueDetailByNumber: new Map(current.issueDetailByNumber || []).set(
+          result.detail.number,
+          result.detail
+        ),
+      }))
+    }, DETAIL_HYDRATION_DELAY_MS)
+
+    return () => {
+      active = false
+      clearTimeout(timer)
+    }
+  }, [
+    state.activeView,
+    state.selectedIssueIndex,
+    filteredIssueList,
+    context.issueDetailByNumber,
+  ])
+
+  React.useEffect(() => {
+    if (state.activeView !== 'pull-request-triage') return
+    const cursored = filteredPullRequestTriageList[
+      Math.min(
+        state.selectedPullRequestTriageIndex,
+        Math.max(0, filteredPullRequestTriageList.length - 1)
+      )
+    ]
+    if (!cursored) return
+    if (context.pullRequestDetailByNumber?.has(cursored.number)) return
+
+    let active = true
+    const timer = setTimeout(async () => {
+      const result = await getPullRequestDetail(cursored.number)
+      if (!active || !result.ok) return
+      setContext((current) => ({
+        ...current,
+        pullRequestDetailByNumber: new Map(current.pullRequestDetailByNumber || []).set(
+          result.detail.number,
+          result.detail
+        ),
+      }))
+    }, DETAIL_HYDRATION_DELAY_MS)
+
+    return () => {
+      active = false
+      clearTimeout(timer)
+    }
+  }, [
+    state.activeView,
+    state.selectedPullRequestTriageIndex,
+    filteredPullRequestTriageList,
+    context.pullRequestDetailByNumber,
+  ])
 
   React.useEffect(() => {
     let active = true
@@ -2188,13 +2273,40 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     //      5-minute TTL window. Sledgehammer rather than scalpel —
     //      clearing per (repo, filter) tuple would require more
     //      bookkeeping than the cache is worth.
-    const invalidateIssueListCaches = (): void => {
-      setContext((current) => ({ ...current, issueList: undefined }))
+    const invalidateIssueListCaches = (issueNumber?: number): void => {
+      setContext((current) => {
+        const next = { ...current, issueList: undefined }
+        // Drop only the mutated issue's detail entry so other
+        // hydrated entries survive — they're still accurate. When
+        // no number is given (rare), wipe the whole detail map.
+        if (current.issueDetailByNumber) {
+          if (typeof issueNumber === 'number') {
+            const trimmed = new Map(current.issueDetailByNumber)
+            trimmed.delete(issueNumber)
+            next.issueDetailByNumber = trimmed
+          } else {
+            next.issueDetailByNumber = undefined
+          }
+        }
+        return next
+      })
       setContextStatus((current) => updateLogInkContextStatus(current, 'issueList', 'idle'))
       clearGitHubListCache()
     }
-    const invalidatePullRequestListCaches = (): void => {
-      setContext((current) => ({ ...current, pullRequestList: undefined }))
+    const invalidatePullRequestListCaches = (pullRequestNumber?: number): void => {
+      setContext((current) => {
+        const next = { ...current, pullRequestList: undefined }
+        if (current.pullRequestDetailByNumber) {
+          if (typeof pullRequestNumber === 'number') {
+            const trimmed = new Map(current.pullRequestDetailByNumber)
+            trimmed.delete(pullRequestNumber)
+            next.pullRequestDetailByNumber = trimmed
+          } else {
+            next.pullRequestDetailByNumber = undefined
+          }
+        }
+        return next
+      })
       setContextStatus((current) => updateLogInkContextStatus(current, 'pullRequestList', 'idle'))
       clearGitHubListCache()
     }
@@ -2700,7 +2812,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         ]
         if (!issue) return { ok: false, message: 'No issue under cursor' }
         const result = await commentIssue(issue.number, body)
-        if (result.ok) invalidateIssueListCaches()
+        if (result.ok) invalidateIssueListCaches(issue.number)
         return result
       },
       'triage-issue-label': async () => {
@@ -2711,7 +2823,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         ]
         if (!issue) return { ok: false, message: 'No issue under cursor' }
         const result = await addIssueLabel(issue.number, label)
-        if (result.ok) invalidateIssueListCaches()
+        if (result.ok) invalidateIssueListCaches(issue.number)
         return result
       },
       'triage-issue-assign': async () => {
@@ -2722,7 +2834,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         ]
         if (!issue) return { ok: false, message: 'No issue under cursor' }
         const result = await addIssueAssignee(issue.number, assignee)
-        if (result.ok) invalidateIssueListCaches()
+        if (result.ok) invalidateIssueListCaches(issue.number)
         return result
       },
       'triage-pr-open': async () => {
@@ -2745,7 +2857,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         ]
         if (!pr) return { ok: false, message: 'No pull request under cursor' }
         const result = await commentPullRequestByNumber(pr.number, body)
-        if (result.ok) invalidatePullRequestListCaches()
+        if (result.ok) invalidatePullRequestListCaches(pr.number)
         return result
       },
       'triage-pr-label': async () => {
@@ -2756,7 +2868,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         ]
         if (!pr) return { ok: false, message: 'No pull request under cursor' }
         const result = await addPullRequestLabel(pr.number, label)
-        if (result.ok) invalidatePullRequestListCaches()
+        if (result.ok) invalidatePullRequestListCaches(pr.number)
         return result
       },
       'triage-pr-assign': async () => {
@@ -2767,7 +2879,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         ]
         if (!pr) return { ok: false, message: 'No pull request under cursor' }
         const result = await addPullRequestAssignee(pr.number, assignee)
-        if (result.ok) invalidatePullRequestListCaches()
+        if (result.ok) invalidatePullRequestListCaches(pr.number)
         return result
       },
       // #882 phase 5 — destructive triage mutations. Each is gated
@@ -2782,7 +2894,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         ]
         if (!issue) return { ok: false, message: 'No issue under cursor' }
         const result = await closeIssue(issue.number)
-        if (result.ok) invalidateIssueListCaches()
+        if (result.ok) invalidateIssueListCaches(issue.number)
         return result
       },
       'triage-issue-reopen': async () => {
@@ -2791,7 +2903,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         ]
         if (!issue) return { ok: false, message: 'No issue under cursor' }
         const result = await reopenIssue(issue.number)
-        if (result.ok) invalidateIssueListCaches()
+        if (result.ok) invalidateIssueListCaches(issue.number)
         return result
       },
       'triage-pr-merge': async () => {
@@ -2807,7 +2919,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         ]
         if (!pr) return { ok: false, message: 'No pull request under cursor' }
         const result = await mergePullRequestByNumber(pr.number, strategy)
-        if (result.ok) invalidatePullRequestListCaches()
+        if (result.ok) invalidatePullRequestListCaches(pr.number)
         return result
       },
       'triage-pr-close': async () => {
@@ -2816,7 +2928,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         ]
         if (!pr) return { ok: false, message: 'No pull request under cursor' }
         const result = await closePullRequestByNumber(pr.number)
-        if (result.ok) invalidatePullRequestListCaches()
+        if (result.ok) invalidatePullRequestListCaches(pr.number)
         return result
       },
       'triage-pr-approve': async () => {
@@ -2825,7 +2937,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         ]
         if (!pr) return { ok: false, message: 'No pull request under cursor' }
         const result = await approvePullRequestByNumber(pr.number)
-        if (result.ok) invalidatePullRequestListCaches()
+        if (result.ok) invalidatePullRequestListCaches(pr.number)
         return result
       },
       'triage-pr-request-changes': async () => {
@@ -2836,7 +2948,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         ]
         if (!pr) return { ok: false, message: 'No pull request under cursor' }
         const result = await requestChangesPullRequestByNumber(pr.number, body)
-        if (result.ok) invalidatePullRequestListCaches()
+        if (result.ok) invalidatePullRequestListCaches(pr.number)
         return result
       },
       // Status surface group-level batch ops (#791 follow-up). The

--- a/src/workstation/runtime/types.ts
+++ b/src/workstation/runtime/types.ts
@@ -20,7 +20,9 @@ import type { LfsAttributeStatus } from '../../git/lfsAttributes'
 import type { SubmoduleOverview } from '../../git/submoduleData'
 import type { GitOperationOverview } from '../../git/operationData'
 import type { ProviderOverview } from '../../git/providerData'
+import type { IssueDetail } from '../../git/issueDetailData'
 import type { IssueListOverview } from '../../git/issuesListData'
+import type { PullRequestDetail } from '../../git/pullRequestDetailData'
 import type { PullRequestOverview } from '../../git/pullRequestData'
 import type { PullRequestListOverview } from '../../git/pullRequestListData'
 import type { ReflogOverview } from '../../git/reflogData'
@@ -60,6 +62,22 @@ export type LogInkContext = {
    * Issues triage list (#882). Hydrated on entry to the `issues` view.
    */
   issueList?: IssueListOverview
+  /**
+   * Per-issue detail cache keyed by issue number (#882 inspector
+   * hydration). Filled on demand when the user rests the cursor on
+   * an issue row in the triage list. Cursoring back to a
+   * previously-fetched issue shows the cached entry immediately.
+   * The list fetcher deliberately omits bodies / comments — they're
+   * expensive to fetch + render, so the lazy hydration keeps the
+   * list snappy.
+   */
+  issueDetailByNumber?: Map<number, IssueDetail>
+  /**
+   * Per-PR detail cache keyed by pull-request number (#882
+   * inspector hydration). Mirrors `issueDetailByNumber` — fetched
+   * via `gh pr view <#>` and cached per session.
+   */
+  pullRequestDetailByNumber?: Map<number, PullRequestDetail>
   reflog?: ReflogOverview
   stashes?: StashOverview
   /**

--- a/src/workstation/surfaces/detail/index.ts
+++ b/src/workstation/surfaces/detail/index.ts
@@ -867,8 +867,11 @@ export function renderIssueTriagePreviewPanel(
     : all
   const index = Math.max(0, Math.min(state.selectedIssueIndex, Math.max(0, visible.length - 1)))
   const issue = visible[index]
+  const detail = issue
+    ? context.issueDetailByNumber?.get(issue.number)
+    : undefined
   return renderPreviewPanel(h, { Box, Text }, 'Issue preview',
-    formatIssueTriagePreview(issue), width, theme, focused)
+    formatIssueTriagePreview(issue, detail), width, theme, focused)
 }
 
 /**
@@ -910,6 +913,9 @@ export function renderPullRequestTriagePreviewPanel(
     : all
   const index = Math.max(0, Math.min(state.selectedPullRequestTriageIndex, Math.max(0, visible.length - 1)))
   const pr = visible[index]
+  const detail = pr
+    ? context.pullRequestDetailByNumber?.get(pr.number)
+    : undefined
   return renderPreviewPanel(h, { Box, Text }, 'Pull request preview',
-    formatPullRequestTriagePreview(pr), width, theme, focused)
+    formatPullRequestTriagePreview(pr, detail), width, theme, focused)
 }


### PR DESCRIPTION
First of two follow-ups deferred from [#882 phase 6](https://github.com/gfargo/coco/pull/974). Closes the inspector hydration gap that's been noted since phase 3.

## What lands

The right-pane preview on the issue + PR triage views now hydrates with the per-item body, comments (and reviews + status checks for PRs) when the cursor rests on a row. The list payloads from \`gh issue list\` / \`gh pr list\` deliberately omit those fields to keep the list fetch cheap; this PR fills them in lazily.

### Issues view (\`gi\`)
Preview gains:
- **Body excerpt** — first 6 non-empty lines with a truncation trailer
- **Comments section** — total count + 3 most recent in \`@author: body\` form, with an "earlier comment(s)" trailer when older ones are summarized

### PR triage view (\`gP\`)
Preview gains:
- **Body excerpt**
- **Status checks** — pass / fail / pending counts
- **Reviews** — per-reviewer state (\`approved\` / \`changes requested\` / …) + inline body excerpt
- **Comments** — same shape as issues

## Architecture

- **\`src/git/issueDetailData.ts\`** — new module wrapping \`gh issue view <#> --json body,comments\`. Pure data fetcher.
- **\`src/git/pullRequestDetailData.ts\`** — sibling module for \`gh pr view <#> --json body,comments,reviews,statusCheckRollup\`. Distinct from \`pullRequestData.ts\` (which fetches the current branch's PR with no number arg).
- **\`LogInkContext\`** gains \`issueDetailByNumber\` / \`pullRequestDetailByNumber\` Maps keyed by item number. Cursoring back to a previously-fetched item shows instantly — no re-fetch.
- **Two new \`useEffect\` hooks** in \`runtime/app.ts\` debounce the fetch (250ms). Rapid j/k navigation never fires a \`gh\` call — only when the cursor rests does the fetch trigger.
- **Preview formatters** gain optional \`detail\` parameters. Pre-hydration they render a "Loading body + comments…" hint; post-hydration the sections appear inline.
- **Cache invalidation** extended: the existing \`invalidate*ListCaches\` helpers now also drop the mutated item's detail entry (per-number scalpel) so the next render refetches just that one rather than the whole map.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm run test:jest\` — 1909 tests pass, 7 skipped (168 suites). 21 new tests across:
  - \`issueDetailData.test.ts\` — args shape, comment parsing, default handling, empty + runtime + payload-shape errors
  - \`pullRequestDetailData.test.ts\` — args shape, reviews + status checks parsing, deleted-author filtering, defaults, error path
  - \`previewPane.triage.test.ts\` — pre-hydration loading hint visibility, body excerpt rendering + truncation trailer, comments section ordering + summary trailer, PR checks/reviews/comments sections, empty-section omission
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: \`coco ui\` → \`gi\` → cursor an issue with comments → wait 250ms → body + comments appear in right pane
- [ ] Manual: \`gP\` → cursor a PR → status checks / reviews / comments materialize after debounce
- [ ] Manual: rapid j/k through 10+ rows → only the resting row hydrates; no \`gh\` call storm

## What's left for #882

- **AI summarize (\`I\`)** — the last deferred item. Now unblocked: with body + comments available in the context cache, the summarize workflow can read straight from there. Estimated as a small overlay component + LLM prompt + workflow runner. Likely the final PR for #882.

## Notes for review

- Debounce delay (\`DETAIL_HYDRATION_DELAY_MS = 250\`) is a single tunable constant. Felt like the right value for "intentional cursor rest" without being noticeably laggy. If users find it sluggish we can drop to ~150ms.
- The detail cache survives across navigations within the same session (and across mutations, except for the mutated item's own entry which gets dropped). It does NOT persist to disk — would be premature; the in-session benefit is what users perceive and the on-disk-cache complexity isn't worth it for what's typically <30 items per session.
- Empty hydrated sections are omitted from the preview entirely (no "Comments (0)" rows) so a low-activity issue / PR doesn't pad the right pane with empty headings.