### PR TITLE
feat(ui): history polish — pill chips, brighter spacers, file pluralization

### DIFF
--- a/src/workstation/chrome/historyRows.test.ts
+++ b/src/workstation/chrome/historyRows.test.ts
@@ -278,7 +278,50 @@ describe('Ink history rows', () => {
       // The spacers carry vertical lane markers (rendered as the
       // box-drawing `│`), not the commit dot.
       expect(visible.items[1].graph).toBe('| ')
-      expect(visible.items[1].laneSegments?.find((s) => s.text === '│')).toBeDefined()
+      const spacer = visible.items[1] as {
+        laneSegments?: Array<{ text: string }>
+        spacer?: boolean
+      }
+      expect(spacer.laneSegments?.find((s) => s.text === '│')).toBeDefined()
+      // The `spacer: true` flag distinguishes our injected lane
+      // continuation from git's own topology rows so the renderer
+      // can keep spacers at full lane brightness while topology
+      // rows stay dim as scaffolding.
+      expect(spacer.spacer).toBe(true)
+    })
+
+    it('only marks synthetic spacers, not git\'s own topology rows', () => {
+      // Build a row list with an explicit topology row inside so we
+      // can verify that injected spacers carry `spacer: true` while
+      // git's natural graph rows do not.
+      const mergeShapedRows: GitLogRow[] = [
+        {
+          type: 'commit', graph: '*   ', shortHash: 'main1', hash: 'main1'.padEnd(40, '0'),
+          parents: [], date: '2026-05-15', author: 'Coco', refs: [], message: 'feat: main commit',
+        },
+        {
+          type: 'commit', graph: '*   ', shortHash: 'main0', hash: 'main0'.padEnd(40, '0'),
+          parents: ['p1'.padEnd(40, '0'), 'p2'.padEnd(40, '0')],
+          date: '2026-04-23', author: 'Coco', refs: [], message: "Merge branch 'feat/x'",
+        },
+        { type: 'graph', graph: '|\\  ' },
+        {
+          type: 'commit', graph: '| * ', shortHash: 'side1', hash: 'side1'.padEnd(40, '0'),
+          parents: [], date: '2026-04-22', author: 'Coco', refs: [], message: 'feat: side',
+        },
+      ]
+      const state = applyLogInkAction(createLogInkState(mergeShapedRows), { type: 'toggleGraph' })
+      const visible = getVisibleLogInkHistory(state, 10, { fullGraphSpacing: true })
+
+      const items = visible.items as Array<{ type: string; spacer?: boolean }>
+      // Find graph rows and partition by `spacer` flag.
+      const graphRows = items.filter((i) => i.type === 'graph')
+      const synthetic = graphRows.filter((i) => i.spacer === true)
+      const natural = graphRows.filter((i) => i.spacer !== true)
+
+      // At least one of each kind should be present in this shape.
+      expect(synthetic.length).toBeGreaterThan(0)
+      expect(natural.length).toBeGreaterThan(0)
     })
 
     it('does not inject spacers when fullGraphSpacing is off', () => {

--- a/src/workstation/chrome/historyRows.ts
+++ b/src/workstation/chrome/historyRows.ts
@@ -50,6 +50,16 @@ export type LogInkHistoryGraphItem = {
   type: 'graph'
   graph: string
   laneSegments?: LaneSegment[]
+  /**
+   * True for the synthetic vertical-only rows we inject between two
+   * commits to give linear-history stretches a comfortable rhythm,
+   * false (or undefined) for git's own topology rows (`|/` close,
+   * `|\` fork). The renderer uses this to keep spacers at full lane
+   * brightness — they read as "this is the same lane, continuing" —
+   * while topology rows stay dimmed as scaffolding that should
+   * recede behind the commits they connect.
+   */
+  spacer?: boolean
 }
 
 export type LogInkHistoryItem = LogInkHistoryCommitItem | LogInkHistoryGraphItem
@@ -194,6 +204,7 @@ function toFullGraphItems(
         type: 'graph',
         graph,
         laneSegments: renderGraphRowSegments(graph, tracker, { ascii: false }),
+        spacer: true,
       }
     }
 

--- a/src/workstation/surfaces/detail/index.ts
+++ b/src/workstation/surfaces/detail/index.ts
@@ -79,6 +79,17 @@ import {
  * minimum from `getLogInkLayout`) so an overflowing label never wraps and
  * collides with the next row.
  */
+
+/**
+ * Format the file-count portion of the inspector stats line. Pluralize
+ * "files" only when the count is not 1 so `1 file +12/-22` reads
+ * naturally instead of `1 files`.
+ */
+function formatCommitStatLine(stats: { filesChanged: number; insertions: number; deletions: number }): string {
+  const label = stats.filesChanged === 1 ? 'file' : 'files'
+  return `${stats.filesChanged} ${label}  +${stats.insertions}/-${stats.deletions}`
+}
+
 function renderInspectorActionsSection(
   h: typeof ReactTypes.createElement,
   Text: LogInkComponents['Text'],
@@ -332,7 +343,7 @@ export function renderHistoryInspector(
     }))
   }
 
-  const statLine = `${detail.stats.filesChanged} files  +${detail.stats.insertions}/-${detail.stats.deletions}`
+  const statLine = formatCommitStatLine(detail.stats)
   // P5.1 — link the commit hash and each ref out to GitHub when we know
   // the remote. OSC 8 escapes embed inline; supportsHyperlinks() decides
   // whether to wrap or fall through to plain text.
@@ -496,7 +507,7 @@ export function renderCommitDiffDetail(
     }, truncateCells(line, width - 4))))
   }
 
-  const statLine = `${detail.stats.filesChanged} files  +${detail.stats.insertions}/-${detail.stats.deletions}`
+  const statLine = formatCommitStatLine(detail.stats)
   const headerLines = [
     detail.message,
     '',

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -79,11 +79,25 @@ function pickDateText(
 const BRANCH_CHIP_MAX_NAME_WIDTH = 20
 
 /**
- * Render a colored bracket chip for a branch tip. Current branch
- * (HEAD -> X) gets the success color + bold; other branch tips get
- * info color. Tags are never chipped — they stay in the trailing ref
- * list. The chip emits its own trailing space so callers concatenate
- * it directly into the row without a separator.
+ * Render a pill-style chip for a branch tip — colored background
+ * with the branch name reverse-printed inside, so the chip reads as
+ * a distinct visual category (block) rather than colored text (which
+ * collides with `docs:`/`refactor:`/`perf:` conventional-commit
+ * prefixes that also use `info`). Current branch (HEAD -> X) uses
+ * success-green; other branch tips use info-blue.
+ *
+ * Implementation: `inverse: true` + `color: <accent>` is the
+ * portable way to render "colored background with terminal-default
+ * foreground" — it adapts to dark vs light terminals without
+ * hardcoding a black/white fg. Tags are never chipped; they stay in
+ * the trailing ref list. The chip emits its own trailing space so
+ * callers concatenate it directly into the row without a separator.
+ *
+ * Selection styling is opt-out: when the row is selected, the outer
+ * `inverse: true` + selection background already covers everything,
+ * and a second `inverse` on the chip would flip it back to plain. We
+ * drop the pill styling for selected rows and let the row's own
+ * inverse highlight carry through cleanly.
  *
  * Returns the rendered node alongside its cell width AND the chip
  * descriptor so the caller can pass it to `filterChippedRefs` and
@@ -94,7 +108,8 @@ function renderBranchTipChip(
   Text: LogInkComponents['Text'],
   commit: GitLogCommitRow,
   theme: LogInkTheme,
-  key: string
+  key: string,
+  selected: boolean
 ): {
   node: ReactTypes.ReactElement | null
   width: number
@@ -104,15 +119,32 @@ function renderBranchTipChip(
   if (!chip) return { node: null, width: 0, chip }
 
   const truncated = truncateCells(chip.name, BRANCH_CHIP_MAX_NAME_WIDTH)
-  const label = `[${truncated}] `
-  const color = theme.noColor
-    ? undefined
-    : chip.isHead
-      ? theme.colors.success
-      : theme.colors.info
+  // Inner pill body is `name`; the trailing space sits OUTSIDE the
+  // colored block so the bg doesn't bleed into the message column.
+  // The brackets are gone — the colored block is its own visual
+  // affordance and the brackets would add 2 cells of chrome that
+  // duplicate the affordance.
+  const body = ` ${truncated} `
+
+  // Selected row OR noColor mode → drop pill styling. Selected rows
+  // get the row-level inverse highlight; noColor terminals fall
+  // back to bracketed text so the chip still parses visually.
+  if (selected || theme.noColor) {
+    const fallbackLabel = `[${truncated}] `
+    return {
+      node: h(Text, { key, bold: chip.isHead }, fallbackLabel),
+      width: cellWidth(fallbackLabel),
+      chip,
+    }
+  }
+
+  const accent = chip.isHead ? theme.colors.success : theme.colors.info
   return {
-    node: h(Text, { key, color, bold: chip.isHead }, label),
-    width: cellWidth(label),
+    node: h(Text, {},
+      h(Text, { key, inverse: true, color: accent, bold: chip.isHead }, body),
+      h(Text, { key: `${key}-pad` }, ' '),
+    ),
+    width: cellWidth(body) + 1,
     chip,
   }
 }
@@ -250,7 +282,7 @@ function renderCommitHistoryRow(
   // out whatever the chip already shows so the row doesn't print
   // `[main] feat: x [HEAD -> main]` with the same info on both ends.
   const chip = fullGraph
-    ? renderBranchTipChip(h, Text, commit, theme, `${commit.hash}-${index}-chip`)
+    ? renderBranchTipChip(h, Text, commit, theme, `${commit.hash}-${index}-chip`, selected)
     : { node: null, width: 0, chip: undefined }
   const refs = formatInkRefLabels(filterChippedRefs(commit.refs, chip.chip))
   const fixedWidth =
@@ -351,7 +383,7 @@ function renderStackedCommitHistoryRow(
   // same way as the single-line variant, but only in full-graph mode.
   const recentMarkerWidth = isRecent ? 2 : 0
   const chip = fullGraph
-    ? renderBranchTipChip(h, Text, commit, theme, `${commit.hash}-${index}-stk-chip`)
+    ? renderBranchTipChip(h, Text, commit, theme, `${commit.hash}-${index}-stk-chip`, selected)
     : { node: null, width: 0, chip: undefined }
   const lineOneFixed =
     graphWidth + 1 + commit.shortHash.length + 1 + recentMarkerWidth + chip.width
@@ -533,23 +565,34 @@ export function renderHistoryPanel(
         }))
     : visible.items.map((item, index) => {
       if (item.type === 'graph') {
-        // Graph-only rows are git's lane-closure scaffolding (`|/`,
-        // `|\`, etc.) — they're real topology but visually they look
-        // like blank rows that the user might wonder if they
-        // accidentally skipped a commit on (#831). Render dim-on-dim
-        // so they retreat as connectors rather than competing with
-        // commit rows for the eye's attention.
+        // Graph-only rows split into two visual categories:
+        //
+        //   - git's own lane-closure scaffolding (`|/`, `|\`, etc.)
+        //     stays dim-on-dim so it reads as connector chrome that
+        //     recedes behind the commits it joins (#831). The eye
+        //     should never confuse a fork/close row for a commit
+        //     somebody accidentally skipped.
+        //
+        //   - synthetic spacers we inject between linear commits
+        //     (`spacer: true`) render at FULL lane brightness so the
+        //     trunk lane bar visibly connects consecutive commits.
+        //     They are explicitly NOT scaffolding — they exist to
+        //     make linear-history rhythm read as one continuous lane.
+        const isSpacer = item.spacer === true
         if (item.laneSegments && !theme.ascii) {
-          return h(Text, { key: `graph-${index}-${item.graph}`, dimColor: true },
+          return h(Text, {
+            key: `graph-${index}-${item.graph}`,
+            dimColor: !isSpacer,
+          },
             ...renderLaneSegmentSpans(
               h, Text, item.laneSegments, theme, visible.graphWidth, `g${index}`,
-              { forceDim: true }
+              { forceDim: !isSpacer }
             ))
         }
         return h(Text, {
           key: `graph-${index}-${item.graph}`,
           color: theme.noColor ? undefined : theme.colors.muted,
-          dimColor: true,
+          dimColor: !isSpacer,
         }, truncateCells(substituteGraphChars(
           item.graph.padEnd(visible.graphWidth),
           { ascii: theme.ascii }


### PR DESCRIPTION
## Summary

Three small refinements based on the screenshot review of the merged scenario:

### 1. Pill-style branch tip chips

Branch names render as a **colored block with reverse-printed text** instead of bracketed text in colored fg:

\`\`\`
Before:  [main] feat(search): trigram-based subject filter
After:    main  feat(search): trigram-based subject filter
         ^^^^ colored block (green for HEAD, blue for other tips)
\`\`\`

This solves the color collision we noted: \`[main]\` was using \`info\` color, and so were \`docs:\` / \`refactor:\` / \`perf:\` prefixes. A quick scan would briefly read them as the same visual category. The pill makes chips a distinct *shape* (block vs text), not just a different color.

Implementation uses \`inverse: true\` + \`color: <accent>\` — the portable way to render "colored bg with terminal-default fg," adapting to dark vs light terminals without hardcoding black/white.

**Selection styling:** when the row is selected, the outer \`inverse: true\` + selection bg already covers everything, and a second \`inverse\` on the chip would flip it back to plain text. We drop the pill in that case and let the row-level highlight carry through.

**noColor fallback:** terminals without color fall back to the bracketed-text form so the chip still parses visually.

### 2. Brighter spacer lane bars

The synthetic vertical-only rows between linear commits were rendering with the same forced-dim treatment as git's own \`|/\` close / \`|\\\` fork rows. That made trunk lane bars in linear stretches read as empty space rather than as continuation:

\`\`\`
Before:  ●  f563363  (dim, almost-invisible │)  ●  2e47d08
After:   ●  f563363  (full-brightness │)         ●  2e47d08
\`\`\`

The data layer now marks synthetic spacers with \`spacer: true\`; the surface checks the flag and skips the \`dimColor\` / \`forceDim\` treatment for those. Git's natural topology rows stay dim as scaffolding — the visual hierarchy (commit > spacer > topology) reads cleanly.

### 3. "1 file" pluralization

Inspector's stats line was rendering \`1 files +12/-22\` for single-file commits. New \`formatCommitStatLine\` helper pluralizes correctly: \`1 file\` / \`2 files\`.

## Deferred to follow-up

Ahead-counts on non-HEAD chips (the fourth refinement we discussed). Implementation requires a new \`aheadOfDefault: number\` field on \`BranchRef\` populated via \`git rev-list --count main..branch\`, plus context plumbing through \`getBranchOverview\`. That's a data-layer change with its own test surface, so it gets a focused PR rather than riding along with these pure-surface tweaks.

## Test plan

- [x] \`chrome/historyRows.test.ts\` — 1 new test verifying \`spacer: true\` distinguishes synthetic spacers from git's natural topology rows; existing 20 tests still pass.
- [x] Full jest suite: 1891 pass / 7 skipped, no regressions.
- [x] \`npm run lint\` clean.
- [x] \`npm run build\` produces dist bundles.
- [x] \`npm run test:cli\` smoke tests pass.
- [ ] Manual UI verification — sandbox can't render TTY. Reviewer should re-run \`npm run scenario create rich-history-graph -- --run-ui\` and check (a) the pill chip on \`[main]\` and the unmerged \`[feat/wip]\`, (b) the trunk \`│\` lane bar between linear main commits, (c) the \`Stats: 1 file\` line in the inspector for any single-file commit.

## Notes for the reviewer

- The chip width math accounts for the trailing space outside the pill (so the bg color doesn't bleed into the message column).
- Spacer brightness only affects the synthetic spacer flag — all existing graph-row rendering paths (compact mode, git's natural rows, ASCII fallback) are unchanged.
- Pill chip width is now \`name.length + 2\` (spaces inside the block) \`+ 1\` (trailing space). Slightly different from the old \`[name].length + 1\`. The truncation math takes the new width into account before sizing the message column.