### PR TITLE
feat(scenario): --remote <url> flag on `scenario create` so triage views can be tested

### DIFF
--- a/bin/scenario.ts
+++ b/bin/scenario.ts
@@ -9,6 +9,9 @@
  *   npm run scenario create <name>                 # create in /tmp
  *   npm run scenario create <name> --path <dir>    # create at <dir>
  *   npm run scenario create <name> --run-ui        # create AND launch `coco ui`
+ *   npm run scenario create <name> --remote <url>  # add an `origin` remote
+ *                                                  # (lets the triage views detect
+ *                                                  #  a GitHub remote on launch)
  *
  * By default, `create` PERSISTS the scenario (doesn't auto-clean) —
  * that's what manual testing wants. Use `--ephemeral` to clean up on
@@ -80,6 +83,12 @@ function printHelp(): void {
     '  Create options:',
     '    --path <dir>     Materialize the scenario at <dir> instead of /tmp',
     '    --run-ui         Launch `coco ui` against the scenario after creation',
+    '    --remote <url>   Add `origin` pointing at <url> so the GitHub triage',
+    '                     views (gi / gP) detect a remote on launch. Pass any',
+    '                     gh-shaped URL — `git@github.com:gfargo/coco.git` for',
+    '                     real data, or a fake like `git@github.com:coco-test/',
+    '                     sample.git` to render the views without risking',
+    '                     destructive actions against a real repo.',
     '    --ephemeral      Remove the scenario directory when the CLI exits',
     '                     (default: persist, print the cleanup hint)',
     '',
@@ -135,7 +144,12 @@ function commandDescribe(name: string): number {
 
 async function commandCreate(
   name: string,
-  options: { targetPath?: string; runUi?: boolean; ephemeral?: boolean }
+  options: {
+    targetPath?: string
+    runUi?: boolean
+    ephemeral?: boolean
+    remote?: string
+  }
 ): Promise<number> {
   const scenario = findScenario(name)
   if (!scenario) {
@@ -155,6 +169,21 @@ async function commandCreate(
   } catch (error) {
     console.error(`Scenario setup failed: ${(error as Error).message}`)
     return 1
+  }
+
+  // Optional origin remote (#882 follow-up). Scenarios default to no
+  // remote so the test isolation story stays simple, but `--remote`
+  // lets `--run-ui` testers exercise the GitHub triage views (`gi`,
+  // `gP`) against a real-shaped URL — without it, those views render
+  // "No GitHub remote detected" because `getGitHubRepository` returns
+  // undefined for the bare `git init` repo.
+  if (options.remote) {
+    try {
+      await repo.git.addRemote('origin', options.remote)
+    } catch (error) {
+      console.error(`Failed to add origin remote: ${(error as Error).message}`)
+      return 1
+    }
   }
 
   let finalPath = repo.path
@@ -262,6 +291,7 @@ async function main(): Promise<void> {
       targetPath: typeof flags.path === 'string' ? flags.path : undefined,
       runUi: Boolean(flags['run-ui']),
       ephemeral: Boolean(flags.ephemeral),
+      remote: typeof flags.remote === 'string' ? flags.remote : undefined,
     })
     process.exit(code)
   }

--- a/src/lib/testUtils/README.md
+++ b/src/lib/testUtils/README.md
@@ -106,6 +106,8 @@ npm run scenario create feature-pr-ready           # materialize in /tmp/coco-gi
 npm run scenario create feature-pr-ready -- --path ~/sandbox/widget   # custom location
 npm run scenario create feature-pr-ready -- --run-ui                  # materialize + launch coco ui
 npm run scenario create feature-pr-ready -- --ephemeral               # auto-clean on exit
+npm run scenario create rich-history-graph -- --run-ui \
+  --remote git@github.com:gfargo/coco.git           # add an origin so gi / gP have data
 ```
 
 ### Flags
@@ -114,6 +116,7 @@ npm run scenario create feature-pr-ready -- --ephemeral               # auto-cle
 |---|---|
 | `--path <dir>` | Materialize at `<dir>` instead of `/tmp`. Useful when you want to `cd` into it later and poke around. |
 | `--run-ui` | After materializing, spawn `coco ui` against the scenario dir (cwd = scenario dir, not the coco repo). Tightest dev loop for trying workstation changes. |
+| `--remote <url>` | Add `origin` pointing at `<url>` so the GitHub triage views (`gi` / `gP`) detect a remote on launch. Pass any gh-shaped URL. Use a real one (`git@github.com:gfargo/coco.git`) to render the views with live data; use a fake one (`git@github.com:coco-test/sample.git`) to render the views safely against an empty / gh-unauthenticated remote. Without this flag the triage views show "No GitHub remote detected" — the scenario repo is a bare `git init` by default. |
 | `--ephemeral` | Auto-clean the temp dir on CLI exit. Skip for normal use — without `--ephemeral`, the dir persists so you can re-inspect after `coco ui` quits. |
 
 ### Cleanup

--- a/src/lib/testUtils/scenarios/rich-history-graph.ts
+++ b/src/lib/testUtils/scenarios/rich-history-graph.ts
@@ -25,6 +25,20 @@
  * Manual driver:
  *   npm run scenario create rich-history-graph -- --run-ui
  *
+ * To also exercise the GitHub triage views (`gi` / `gP`), tack on a
+ * `--remote <url>` so the scratch repo has an `origin` for
+ * `getGitHubRepository` to find:
+ *
+ *   # Render the views against a real repo's data (be careful with
+ *   # destructive actions — `x` / `m` etc. would hit the real PRs!):
+ *   npm run scenario create rich-history-graph -- --run-ui \
+ *     --remote git@github.com:gfargo/coco.git
+ *
+ *   # Or use a fake URL to render the views safely against an empty /
+ *   # gh-unauthenticated remote:
+ *   npm run scenario create rich-history-graph -- --run-ui \
+ *     --remote git@github.com:coco-test/sample.git
+ *
  * EXTRACTION DISCIPLINE: no coco-specific imports. Date overrides
  * are plumbed through `GIT_AUTHOR_DATE` / `GIT_COMMITTER_DATE` so
  * the scenario stays as a pure git-state factory.


### PR DESCRIPTION
## What happened

You ran `npm run scenario create rich-history-graph -- --run-ui` and saw both the Pull Request panel (`gp`) and the Issues panel (`gi`) show "No GitHub remote detected". After investigating, this is **not a bug in the triage feature** — it's the correct behavior for the scenario CLI:

1. `createTempGitRepo` runs `git init` in `/tmp/coco-git-test-<rand>` with config + an empty `main` branch — **no `origin` remote**.
2. `getGitHubRepository(git)` walks `git.getRemotes(true)` finds nothing and returns `undefined`.
3. Both views render their "No GitHub remote detected" / "Issues require a GitHub remote" empty state, which is the right thing for a remote-less repo.

The data layer works correctly when called against the real coco repo. The mismatch is purely that scenario repos are isolated by design and don't get a remote.

## The fix

A new `--remote <url>` flag on `npm run scenario create` that calls `git remote add origin <url>` on the scratch repo after the scenario's setup completes. With it, the triage views detect a GitHub remote on launch and exercise their real code paths.

```bash
# Real data (the triage views populate with gfargo/coco's actual issues + PRs):
npm run scenario create rich-history-graph -- --run-ui \\
  --remote git@github.com:gfargo/coco.git

# Or use a fake URL — views render safely against an empty / gh-unauthenticated remote:
npm run scenario create rich-history-graph -- --run-ui \\
  --remote git@github.com:coco-test/sample.git
```

The flag is **opt-in**. Existing scenario invocations continue to build remote-less repos, preserving the test-isolation story.

## Files changed

- `bin/scenario.ts` — parse `--remote`, call `git.addRemote('origin', url)` after setup, before the optional `--path` move (so the move preserves the remote)
- `src/lib/testUtils/scenarios/rich-history-graph.ts` — docstring updated with both safe / live-data invocations
- `src/lib/testUtils/README.md` — flag added to the CLI examples + flag table

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:jest --testPathPatterns="scenario|spinUp"` — 60 tests pass (no regressions)
- [x] Manual: `npm run scenario create rich-history-graph --remote git@github.com:gfargo/coco.git` materializes the repo with origin set correctly (verified via `git remote -v` in the scratch dir)
- [ ] Manual: `--run-ui --remote git@github.com:gfargo/coco.git` should now populate the `gi` / `gP` views with real coco triage data

## Safety note

Pointing the scenario at a real repo means destructive triage actions (`x` close, `m` merge, `a` approve, `R` request-changes) will hit the **real** repo's API surface. The flag's help text and the README spell this out and recommend a fake URL when only rendering needs to be tested.