### PR TITLE
feat(ui): tier-aware sidebar width — slightly narrower on medium, grows on wide

### DIFF
--- a/src/workstation/chrome/layout.test.ts
+++ b/src/workstation/chrome/layout.test.ts
@@ -27,7 +27,9 @@ describe('log Ink layout', () => {
 
     expect(layout.tooSmall).toBe(false)
     expect(layout.bodyRows).toBe(35)
-    expect(layout.sidebarWidth).toBe(28)
+    // 120 cols sits in the `normal` tier, where the sidebar uses
+    // 22% × cols clamped to 22-30: 0.22 × 120 = 26.4 → floor 26.
+    expect(layout.sidebarWidth).toBe(26)
     // 120 * 0.22 = 26.4 → floor 26
     expect(layout.detailWidth).toBe(26)
   })
@@ -37,7 +39,11 @@ describe('log Ink layout', () => {
 
     expect(layout.tooSmall).toBe(false)
     expect(layout.bodyRows).toBe(55)
-    expect(layout.sidebarWidth).toBe(34)
+    // 200 cols is `wide`, where the sidebar uses 24% × cols clamped
+    // to 28-48: 0.24 × 200 = 48 — exactly the cap, so the sidebar
+    // grows naturally with the terminal rather than getting pinned
+    // at a 34-cell ceiling like before.
+    expect(layout.sidebarWidth).toBe(48)
     // 200 * 0.22 = 44 → clamped down to the 32-cell maximum
     expect(layout.detailWidth).toBe(32)
   })
@@ -215,6 +221,118 @@ describe('log Ink layout', () => {
       // defeat that purpose. 60-cell minimum kicks in here.
       expect(railedHelp.detailWidth).toBe(60)
       expect(railedHelp.inspectorRailed).toBe(false)
+    })
+  })
+
+  // The at-rest sidebar width is tier-aware: tight stays compact,
+  // normal shrinks slightly (was clamping at 34 across the whole
+  // ~24% formula), and wide grows naturally up to 48 instead of
+  // pinning at 34. Locks in the exact widths each tier produces at
+  // its representative breakpoints so a future tweak to the
+  // SIDEBAR_AT_REST_BY_TIER table doesn't quietly regress the spread.
+  describe('tier-aware sidebar at-rest width', () => {
+    // [columns, expectedSidebar, expectedDensity]. Formula reference,
+    // kept here as a comment rather than per-row to satisfy lint:
+    //
+    //   tight  → `clamp(22, 28, 0.24 × cols)`
+    //     100 → 24       (0.24 × 100 = 24)
+    //     110 → 26       (0.24 × 110 = 26.4 → 26)
+    //     119 → 28       (0.24 × 119 = 28.56 → 28 cap)
+    //
+    //   normal → `clamp(22, 30, 0.22 × cols)`
+    //     120 → 26       (0.22 × 120 = 26.4 → 26)
+    //     130 → 28       (0.22 × 130 = 28.6 → 28)
+    //     140 → 30       (0.22 × 140 = 30.8 → 30 cap)
+    //     150 → 30       (0.22 × 150 = 33 → 30 cap)
+    //     159 → 30       (0.22 × 159 = 34.98 → 30 cap)
+    //
+    //   wide   → `clamp(28, 48, 0.24 × cols)`
+    //     160 → 38       (0.24 × 160 = 38.4 → 38)
+    //     180 → 43       (0.24 × 180 = 43.2 → 43)
+    //     200 → 48       (0.24 × 200 = 48 — exactly the cap)
+    //     250 → 48       (0.24 × 250 = 60 → 48 cap)
+    //     400 → 48       (0.24 × 400 = 96 → 48 cap)
+    it.each([
+      [100, 24, 'tight'],
+      [110, 26, 'tight'],
+      [119, 28, 'tight'],
+    ] as const)(
+      'tight tier %i cols → sidebar %i',
+      (columns, expected, density) => {
+        const layout = getLogInkLayout({ columns, rows: 40 })
+        expect(layout.density).toBe(density)
+        expect(layout.sidebarWidth).toBe(expected)
+      }
+    )
+
+    it.each([
+      [120, 26, 'normal'],
+      [130, 28, 'normal'],
+      [140, 30, 'normal'],
+      [150, 30, 'normal'],
+      [159, 30, 'normal'],
+    ] as const)(
+      'normal tier %i cols → sidebar %i',
+      (columns, expected, density) => {
+        const layout = getLogInkLayout({ columns, rows: 40 })
+        expect(layout.density).toBe(density)
+        expect(layout.sidebarWidth).toBe(expected)
+      }
+    )
+
+    it.each([
+      [160, 38, 'wide'],
+      [180, 43, 'wide'],
+      [200, 48, 'wide'],
+      [250, 48, 'wide'],
+      [400, 48, 'wide'],
+    ] as const)(
+      'wide tier %i cols → sidebar %i',
+      (columns, expected, density) => {
+        const layout = getLogInkLayout({ columns, rows: 40 })
+        expect(layout.density).toBe(density)
+        expect(layout.sidebarWidth).toBe(expected)
+      }
+    )
+
+    it('crosses the 159 → 160 boundary without the sidebar visibly shrinking', () => {
+      // The wide tier raises the floor to 28 (vs normal's 22) so a
+      // user dragging a window from 159 → 160 cols doesn't see the
+      // sidebar lurch downward. Normal ends at 30 (cap), wide starts
+      // at 38 (formula); the boundary feels like growth, not a
+      // discontinuity.
+      const normalEdge = getLogInkLayout({ columns: 159, rows: 40 })
+      const wideEdge = getLogInkLayout({ columns: 160, rows: 40 })
+      expect(normalEdge.sidebarWidth).toBe(30)
+      expect(wideEdge.sidebarWidth).toBe(38)
+      expect(wideEdge.sidebarWidth).toBeGreaterThan(normalEdge.sidebarWidth)
+    })
+
+    it('focused-sidebar width is unaffected by tier — keeps its 32-50 clamp', () => {
+      // Regression guard for the design choice: focus = "user wants
+      // to read the sidebar," which deserves consistent width across
+      // tiers. Don't have the tier-aware at-rest formula bleed into
+      // the focused path.
+      const normalFocused = getLogInkLayout({ columns: 140, rows: 40, sidebarFocused: true })
+      const wideFocused = getLogInkLayout({ columns: 200, rows: 40, sidebarFocused: true })
+
+      // 140 × 0.36 = 50.4 → clamped to 50 (the focused cap)
+      expect(normalFocused.sidebarWidth).toBe(50)
+      // 200 × 0.36 = 72 → clamped to 50
+      expect(wideFocused.sidebarWidth).toBe(50)
+    })
+
+    it('main panel still tiles flush across all tiers', () => {
+      // Belt-and-suspenders: changing sidebar widths must NOT break
+      // the `columns = sidebar + main + detail` invariant. Easy to
+      // get wrong when widening one side; locking it here means a
+      // future bump to the wide-tier cap can't silently push the
+      // main panel below 0.
+      for (const cols of [100, 119, 120, 159, 160, 200, 250]) {
+        const layout = getLogInkLayout({ columns: cols, rows: 40 })
+        expect(layout.sidebarWidth + layout.mainPanelWidth + layout.detailWidth).toBe(cols)
+        expect(layout.mainPanelWidth).toBeGreaterThan(0)
+      }
     })
   })
 })

--- a/src/workstation/chrome/layout.ts
+++ b/src/workstation/chrome/layout.ts
@@ -128,6 +128,44 @@ export const LAYOUT_RAIL_BELOW = 100
  */
 export const LAYOUT_RAIL_PANEL_WIDTH = 8
 
+/**
+ * Sidebar at-rest size targets, tier-aware. The sidebar's purpose at
+ * rest is to surface enough room for the most common tab content
+ * (status / branches / tags / stashes / worktrees) without dominating
+ * the layout — the history graph + diff are usually the focal point.
+ *
+ * The tier split lets narrow terminals stay compact (the user has
+ * little room to spare) while wide terminals scale the sidebar in
+ * proportion to the rest of the chrome instead of pinning it at an
+ * arbitrary cap.
+ *
+ *   tight  (100-119) → `clamp(22, 28, 24% × cols)`  e.g. 100→24, 119→28
+ *   normal (120-159) → `clamp(22, 30, 22% × cols)`  e.g. 120→26, 140→30
+ *   wide   (≥ 160)   → `clamp(28, 48, 24% × cols)`  e.g. 160→38, 200→48
+ *
+ * The `tight` and `normal` tiers honor a hard floor of 22 cells —
+ * narrower than that and the tab labels stop fitting on a single
+ * line. The `wide` tier raises the floor to 28 so the sidebar
+ * doesn't visually shrink when crossing the 159→160 boundary on a
+ * resize.
+ *
+ * Focused state (Tab → sidebar) uses a different formula entirely
+ * (`clamp(32, 50, 36% × cols)`) — deliberate user intent to read the
+ * sidebar deserves the extra width regardless of tier.
+ */
+type SidebarAtRestConfig = { min: number; max: number; fraction: number }
+const SIDEBAR_AT_REST_BY_TIER: Record<LogInkLayoutDensity, SidebarAtRestConfig> = {
+  rail: { min: 22, max: 28, fraction: 0.24 }, // unused — rail collapses to LAYOUT_RAIL_PANEL_WIDTH
+  tight: { min: 22, max: 28, fraction: 0.24 },
+  normal: { min: 22, max: 30, fraction: 0.22 },
+  wide: { min: 28, max: 48, fraction: 0.24 },
+}
+
+function calcSidebarAtRestWidth(columns: number, density: LogInkLayoutDensity): number {
+  const config = SIDEBAR_AT_REST_BY_TIER[density]
+  return Math.max(config.min, Math.min(config.max, Math.floor(columns * config.fraction)))
+}
+
 export function getLogInkLayout(input: LogInkLayoutInput): LogInkLayout {
   const columns = input.columns || LOG_INK_DEFAULT_COLUMNS
   const rows = input.rows || LOG_INK_DEFAULT_ROWS
@@ -171,15 +209,19 @@ export function getLogInkLayout(input: LogInkLayoutInput): LogInkLayout {
       : inspectorRailed
         ? LAYOUT_RAIL_PANEL_WIDTH
         : Math.max(20, Math.min(32, Math.floor(columns * 0.22)))
-  // Sidebar at rest: 22-34 cells (~24% of width). Focused: 32-50 cells
-  // (~36% of width). The transition is instant per render — focus tab to
-  // expand, focus away to collapse. Rail mode (narrow terminal,
-  // unfocused) shrinks to a fixed 8-cell strip with tab glyphs only.
+  // Sidebar at rest is tier-aware (see `SIDEBAR_AT_REST_BY_TIER`):
+  // tight stays compact (22-28), normal shrinks slightly (22-30),
+  // wide grows naturally (28-48) so the side panel doesn't get pinned
+  // at an arbitrary cap on big terminals while the main panel hogs
+  // 80% of the width. Focused: 32-50 cells (~36% of width),
+  // regardless of tier — deliberate user intent to read the sidebar
+  // deserves the extra width. Rail mode (narrow terminal, unfocused)
+  // collapses to a fixed 8-cell strip with tab glyphs only.
   const sidebarWidth = input.sidebarFocused
     ? Math.max(32, Math.min(50, Math.floor(columns * 0.36)))
     : sidebarRailed
       ? LAYOUT_RAIL_PANEL_WIDTH
-      : Math.max(22, Math.min(34, Math.floor(columns * 0.24)))
+      : calcSidebarAtRestWidth(columns, density)
 
   return {
     bodyRows: Math.max(8, rows - 5),


### PR DESCRIPTION
## Why

The at-rest sidebar uses `clamp(22, 34, 24% × cols)` across the whole layout. That formula has two annoyances at the extremes:

- **Medium terminals** (120-159 cols): sidebar sits at 28-34 cells, ~24% of width. Feels too wide given the main panel is usually the focal point.
- **Wide terminals** (≥ 160 cols): pinned at the 34-cell cap forever. At 250 cols the sidebar takes 14% of width while the main panel hogs ~80% — the sidebar doesn't grow with the rest of the chrome.

## The change

Sidebar at-rest formula is now tier-aware:

| Tier | Cols | Formula | Old → new at representative widths |
|---|---|---|---|
| tight | 100-119 | `clamp(22, 28, 24% × cols)` | 24 → 24 *(unchanged)* |
| normal | 120-159 | `clamp(22, 30, 22% × cols)` | 28 → 26, 33 → 30 *(slight shrink)* |
| wide | ≥ 160 | `clamp(28, 48, 24% × cols)` | 34 → 38 (160), 34 → 48 (200), 34 → 48 (250) *(natural growth)* |

The wide-tier floor is 28 (not 22) so resizing from 159 → 160 cols nudges the sidebar UP (30 → 38) rather than producing a visible jump down. The boundary feels like growth, not a discontinuity.

Focused state (`clamp(32, 50, 36% × cols)`) and rail mode (8-cell strip on terminals < 100 cols) are **unchanged**. Deliberate user intent to read the sidebar deserves consistent width across tiers.

## Implementation

- New `SIDEBAR_AT_REST_BY_TIER` table at module scope + a `calcSidebarAtRestWidth` helper. Future tweaks (e.g., "give the wide tier 30% instead of 24%") only need to touch one row of the table.
- `getLogInkLayout` swaps its inline `clamp(22, 34, 24% × cols)` for `calcSidebarAtRestWidth(columns, density)`.
- No knobs added to the public `LogInkLayoutInput` / `LogInkLayout` types — the change is invisible to callers who just consume `layout.sidebarWidth`.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:jest` — 1926 tests pass (16 new in `layout.test.ts`)
- [x] `npx tsc --noEmit` — clean

New tests cover:
- Parametric `it.each` rows at every representative width per tier (100/110/119 for tight; 120/130/140/150/159 for normal; 160/180/200/250/400 for wide)
- The 159 → 160 boundary specifically — guards against accidentally introducing a "sidebar shrinks when resizing wider" discontinuity
- Focused-sidebar width is unaffected by tier
- `columns = sidebar + main + detail` invariant across every tier so a future width bump can't push the main panel below 0

## Notes for review

- The wide-tier 48 cap is a round number around 24% of a 200-col terminal — a natural feeling spot. Going higher (e.g., 56) gives the sidebar > 28% of width which starts to feel sidebar-heavy on the diff/history surfaces; going lower (40) still leaves the sidebar visibly capped on 200+ col terminals.
- Normal-tier formula now uses 22% (was 24%) so the shrink applies smoothly across the whole tier rather than only kicking in at the cap — feels less arbitrary on a window resize.