### PR TITLE
feat(testUtils): submodule-with-history scenario (#931 prep)

### DIFF
--- a/src/lib/testUtils/README.md
+++ b/src/lib/testUtils/README.md
@@ -71,7 +71,8 @@ testUtils/
     ├── dirty-many-files.ts
     ├── mid-bisect.ts
     ├── mid-merge-conflict.ts
-    └── stashed-changes.ts
+    ├── stashed-changes.ts
+    └── submodule-with-history.ts
 ```
 
 The CLI driver lives at `bin/scenario.ts` and is wired via the
@@ -79,7 +80,7 @@ The CLI driver lives at `bin/scenario.ts` and is wired via the
 
 ## Available scenarios
 
-Run `npm run scenario list` for the live list. Current set (10 scenarios across 5 kinds):
+Run `npm run scenario list` for the live list. Current set (11 scenarios across 6 kinds):
 
 | Name | Kind | What you get |
 |---|---|---|
@@ -93,6 +94,7 @@ Run `npm run scenario list` for the live list. Current set (10 scenarios across 
 | `mid-merge-conflict` | operation | in-progress merge with 1 unresolved conflict on `src/widget.ts` — for the conflicts view |
 | `rich-history-graph` | history | 20+ commits across 6 date buckets, 2 `--no-ff` merges, 1 live unmerged `feat/wip` — for compact + full-graph rendering (bucket dividers, type coloring, branch chips, lane topology) |
 | `stashed-changes` | stash | clean `main` + 3 stashes (LIFO ordered, each touching a distinct file) — for the stash view |
+| `submodule-with-history` | submodule | parent with 4 commits + `vendor/lib` submodule (clean pin, 4 commits, `branch = main`) — for recursive submodule navigation (#931) |
 
 `npm run scenario describe <name>` prints the full description and
 the contract assertions for a single scenario.
@@ -262,7 +264,7 @@ export type Scenario = {
   /** Multi-line description shown in `npm run scenario describe <name>`. */
   description: string
   /** Filtering category for the list view. */
-  kind: 'branch' | 'worktree' | 'operation' | 'history' | 'stash'
+  kind: 'branch' | 'worktree' | 'operation' | 'history' | 'stash' | 'submodule'
   /** The actual state factory. Mutates the given repo. */
   setup: (repo: TempGitRepo) => Promise<void>
   /**

--- a/src/lib/testUtils/scenarios/index.test.ts
+++ b/src/lib/testUtils/scenarios/index.test.ts
@@ -25,7 +25,7 @@ describe('scenarios registry', () => {
   })
 
   it('every scenario declares a valid kind', () => {
-    const validKinds = new Set(['branch', 'worktree', 'operation', 'history', 'stash'])
+    const validKinds = new Set(['branch', 'worktree', 'operation', 'history', 'stash', 'submodule'])
     for (const scenario of allScenarios) {
       expect(validKinds.has(scenario.kind)).toBe(true)
     }

--- a/src/lib/testUtils/scenarios/index.ts
+++ b/src/lib/testUtils/scenarios/index.ts
@@ -21,6 +21,7 @@ import { multiCommitBranchScenario } from './multi-commit-branch'
 import { richHistoryGraphScenario } from './rich-history-graph'
 import { singleStagedFileScenario } from './single-staged-file'
 import { stashedChangesScenario } from './stashed-changes'
+import { submoduleWithHistoryScenario } from './submodule-with-history'
 import { twoCommitFeatureScenario } from './two-commit-feature'
 
 /**
@@ -44,6 +45,8 @@ export const allScenarios: readonly Scenario[] = [
   richHistoryGraphScenario,
   // stash shapes
   stashedChangesScenario,
+  // submodule shapes
+  submoduleWithHistoryScenario,
 ]
 
 /**
@@ -65,4 +68,5 @@ export { multiCommitBranchScenario } from './multi-commit-branch'
 export { richHistoryGraphScenario } from './rich-history-graph'
 export { singleStagedFileScenario } from './single-staged-file'
 export { stashedChangesScenario } from './stashed-changes'
+export { submoduleWithHistoryScenario } from './submodule-with-history'
 export { twoCommitFeatureScenario } from './two-commit-feature'

--- a/src/lib/testUtils/scenarios/submodule-with-history.test.ts
+++ b/src/lib/testUtils/scenarios/submodule-with-history.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { simpleGit } from 'simple-git'
+
+import { createTempGitRepo, type TempGitRepo } from '../tempGitRepo'
+import { submoduleWithHistoryScenario } from './submodule-with-history'
+
+describe('submodule-with-history scenario', () => {
+  let repo: TempGitRepo
+
+  beforeAll(async () => {
+    repo = await createTempGitRepo()
+    await submoduleWithHistoryScenario.setup(repo)
+  }, 60_000)
+
+  afterAll(async () => {
+    await repo?.cleanup()
+  })
+
+  it('has 4 commits on parent main', async () => {
+    const log = await repo.git.log(['main'])
+    expect(log.total).toBe(4)
+  })
+
+  it('has main checked out on the parent', async () => {
+    const status = await repo.git.status()
+    expect(status.current).toBe('main')
+  })
+
+  it('records vendor/lib in .gitmodules with branch = main', () => {
+    const body = readFileSync(join(repo.path, '.gitmodules'), 'utf8')
+    expect(body).toMatch(/\[submodule "vendor\/lib"\]/)
+    expect(body).toMatch(/path\s*=\s*vendor\/lib/)
+    expect(body).toMatch(/branch\s*=\s*main/)
+  })
+
+  it('reports vendor/lib as a clean submodule (leading space in status)', async () => {
+    const out = await repo.git.raw(['submodule', 'status'])
+    // Format: " <sha> vendor/lib (refs/...)" — leading space = clean.
+    expect(out).toMatch(/^ [0-9a-f]{7,40}\s+vendor\/lib/m)
+  })
+
+  it('vendor/lib has 4 commits of its own', async () => {
+    const subGit = simpleGit(join(repo.path, 'vendor/lib'))
+    const log = await subGit.log()
+    expect(log.total).toBe(4)
+  })
+
+  it('vendor/lib HEAD matches the pin recorded in the parent', async () => {
+    const out = await repo.git.raw(['submodule', 'status'])
+    const match = out.match(/^[ +\-U]([0-9a-f]{40})\s+vendor\/lib/m)
+    expect(match).not.toBeNull()
+    const pinned = match![1]
+    const subGit = simpleGit(join(repo.path, 'vendor/lib'))
+    const head = (await subGit.revparse(['HEAD'])).trim()
+    expect(head).toBe(pinned)
+  })
+
+  it('preserves the expected commit subjects on the parent in order', async () => {
+    const log = await repo.git.log()
+    const subjects = log.all.map((entry) => entry.message.split('\n')[0])
+    expect(subjects).toEqual([
+      'feat: integrate vendor/lib into entry point',
+      'chore: add vendor/lib submodule',
+      'feat: app shell',
+      'chore: initial scaffold',
+    ])
+  })
+
+  it('preserves the expected commit subjects on the submodule in order', async () => {
+    const subGit = simpleGit(join(repo.path, 'vendor/lib'))
+    const log = await subGit.log()
+    const subjects = log.all.map((entry) => entry.message.split('\n')[0])
+    expect(subjects).toEqual([
+      'test: add coverage',
+      'feat: add main API',
+      'feat: add core types',
+      'chore: initial scaffold',
+    ])
+  })
+
+  it('has a clean parent worktree', async () => {
+    const status = await repo.git.status()
+    expect(status.isClean()).toBe(true)
+  })
+})

--- a/src/lib/testUtils/scenarios/submodule-with-history.ts
+++ b/src/lib/testUtils/scenarios/submodule-with-history.ts
@@ -1,0 +1,199 @@
+/**
+ * `submodule-with-history` — a parent repo that registers a single
+ * submodule (`vendor/lib`), where both sides have real commit history.
+ *
+ * State after setup:
+ *   - parent `main` has 4 commits:
+ *       1. chore: initial scaffold
+ *       2. feat: app shell
+ *       3. chore: add vendor/lib submodule
+ *       4. feat: integrate vendor/lib into entry point
+ *   - submodule mounted at `vendor/lib`, tracking branch `main`,
+ *     with 4 commits of its own:
+ *       1. chore: initial scaffold
+ *       2. feat: add core types
+ *       3. feat: add main API
+ *       4. test: add coverage
+ *   - parent pin matches the submodule's HEAD (clean — flag = ` `)
+ *   - both worktrees are clean
+ *   - no remote configured on either side
+ *
+ * Designed for #931 (recursive submodule navigation): the user should
+ * be able to `Enter` on the `vendor/lib` row from the parent's status /
+ * submodule view, drill into the submodule's history, navigate its 4
+ * commits as if they had `cd vendor/lib && coco ui`, and `Esc` back out
+ * to the parent.
+ *
+ * The submodule source is built in an out-of-tree temp dir, cloned into
+ * the parent via `git submodule add`, then the source dir is removed.
+ * After setup the cloned submodule is fully self-contained — the URL
+ * recorded in `.gitmodules` points at the (now-gone) source path, but
+ * read-only operations on `vendor/lib` work fine offline. Do not run
+ * `git submodule update --remote` or `git submodule sync` against a
+ * materialized scenario; both rely on the URL being live.
+ *
+ * EXTRACTION DISCIPLINE: no coco-specific imports. The submodule
+ * builder reaches into the same Node stdlib (`fs/promises`, `os`,
+ * `path`) and `simple-git` the base `tempGitRepo` helper does.
+ */
+
+import { execFile } from 'child_process'
+import { mkdir, mkdtemp, rm, writeFile as writeFileContent } from 'fs/promises'
+import { tmpdir } from 'os'
+import { dirname, join } from 'path'
+import { simpleGit, type SimpleGit } from 'simple-git'
+import { promisify } from 'util'
+
+import type { Scenario } from './types'
+import { seededContent, writeSeededFiles } from './shared/seededFiles'
+
+const execFileAsync = promisify(execFile)
+
+const PARENT_SEED = 0x5ba_a1c0
+const SUBMODULE_SEED = 0x5bc0_de00
+
+type SubmoduleCommit = {
+  path: string
+  tokens: number
+  message: string
+}
+
+const SUBMODULE_COMMITS: SubmoduleCommit[] = [
+  // Commit 1 — initial scaffold (README only, no seed)
+  { path: 'README.md', tokens: 0, message: 'chore: initial scaffold' },
+  // Commit 2 — core types
+  { path: 'src/types.ts', tokens: 80, message: 'feat: add core types' },
+  // Commit 3 — main API
+  { path: 'src/index.ts', tokens: 140, message: 'feat: add main API' },
+  // Commit 4 — coverage
+  { path: 'tests/lib.test.ts', tokens: 110, message: 'test: add coverage' },
+]
+
+/**
+ * Build a self-contained git repo on disk (outside the parent's
+ * worktree) that will serve as the clone source for `git submodule
+ * add`. Returns the absolute path. The caller is responsible for
+ * removing the directory once `submodule add` has copied the history
+ * out — keeping it around would only leak the same objects already
+ * stored under `.git/modules/<name>` inside the parent.
+ */
+async function buildSubmoduleSource(): Promise<string> {
+  const sourcePath = await mkdtemp(join(tmpdir(), 'coco-submodule-source-'))
+  const git: SimpleGit = simpleGit(sourcePath)
+
+  await git.init()
+  await git.addConfig('user.name', 'Coco Test')
+  await git.addConfig('user.email', 'coco@example.com')
+  await git.addConfig('commit.gpgsign', 'false')
+  await git.raw(['checkout', '-b', 'main'])
+
+  for (let i = 0; i < SUBMODULE_COMMITS.length; i += 1) {
+    const commit = SUBMODULE_COMMITS[i]
+    const absolute = join(sourcePath, commit.path)
+    await mkdir(dirname(absolute), { recursive: true })
+    const content = commit.tokens === 0
+      ? '# vendor-lib\n\nA hypothetical vendor library used by the parent repo.\n'
+      : seededContent(commit.path, commit.tokens, SUBMODULE_SEED + i)
+    await writeFileContent(absolute, content)
+    await git.add('.')
+    await git.commit(commit.message)
+  }
+
+  return sourcePath
+}
+
+export const submoduleWithHistoryScenario: Scenario = {
+  name: 'submodule-with-history',
+  summary: 'parent with 4 commits + vendor/lib submodule pinned at its 4-commit HEAD',
+  description: [
+    'A parent repo on `main` with 4 commits, including the addition of a',
+    'submodule mounted at `vendor/lib`. The submodule itself has 4 commits',
+    'of its own, tracks branch `main`, and is currently clean (the parent',
+    'pin matches the submodule\'s HEAD).',
+    '',
+    'Useful for testing:',
+    '  - submodule metadata loaders (`.gitmodules` + `git submodule status`)',
+    '  - the submodule inspector side-panel (name / pinned / tracking)',
+    '  - recursive submodule navigation (#931): `Enter` on the submodule',
+    '    row should drill into the submodule\'s history view, where the',
+    '    user can navigate its 4 commits as if `coco ui` were launched',
+    '    from `vendor/lib`. `Esc` / `<` pops back to the parent.',
+    '',
+    'No remote is configured on either side. The URL recorded in',
+    '`.gitmodules` points at the temp dir the submodule was cloned from',
+    '(now removed) — read-only operations work fine offline, but do not',
+    'run `git submodule update --remote` or `git submodule sync`.',
+  ].join('\n'),
+  kind: 'submodule',
+  contracts: [
+    'parent main has 4 commits',
+    'main is checked out',
+    '.gitmodules registers vendor/lib with branch = main',
+    'vendor/lib is a clean submodule (pin matches HEAD)',
+    'vendor/lib has 4 commits of its own',
+    'parent worktree is clean',
+  ],
+  setup: async (repo) => {
+    // === Parent main: 2-commit baseline before the submodule lands ===
+    await repo.writeFile('README.md', [
+      '# Parent',
+      '',
+      'A hypothetical parent project that vendors `vendor/lib` as a git',
+      'submodule.',
+      '',
+    ].join('\n'))
+    await repo.writeFile(
+      'package.json',
+      JSON.stringify({ name: 'parent', version: '0.1.0', main: 'src/index.ts' }, null, 2) + '\n',
+    )
+    await repo.commitAll('chore: initial scaffold')
+
+    await writeSeededFiles(
+      repo,
+      [
+        { path: 'src/index.ts', tokens: 60 },
+        { path: 'src/app.ts', tokens: 100 },
+      ],
+      PARENT_SEED,
+    )
+    await repo.commitAll('feat: app shell')
+
+    // === Build the submodule source out-of-tree, then add as submodule ===
+    const sourcePath = await buildSubmoduleSource()
+    try {
+      // `-b main` records `branch = main` in `.gitmodules`, which the
+      // submodule overview loader (`src/git/submoduleData.ts`) surfaces
+      // as `trackingBranch`.
+      //
+      // `protocol.file.allow=always` is required on git ≥ 2.38 — without
+      // it, file-protocol submodule URLs are refused (CVE-2022-39253).
+      // We shell out directly here because simple-git's unsafe-ops
+      // plugin blocks the `-c protocol.allow=...` override.
+      await execFileAsync(
+        'git',
+        [
+          '-c',
+          'protocol.file.allow=always',
+          'submodule',
+          'add',
+          '-b',
+          'main',
+          sourcePath,
+          'vendor/lib',
+        ],
+        { cwd: repo.path },
+      )
+      await repo.commitAll('chore: add vendor/lib submodule')
+    } finally {
+      await rm(sourcePath, { recursive: true, force: true })
+    }
+
+    // === A post-submodule follow-up so `submodule add` isn't HEAD ===
+    await writeSeededFiles(
+      repo,
+      [{ path: 'src/integration.ts', tokens: 90 }],
+      PARENT_SEED + 1,
+    )
+    await repo.commitAll('feat: integrate vendor/lib into entry point')
+  },
+}

--- a/src/lib/testUtils/scenarios/types.ts
+++ b/src/lib/testUtils/scenarios/types.ts
@@ -23,8 +23,9 @@ import type { TempGitRepo } from '../tempGitRepo'
  *   - `operation`  — in-progress git operations (bisect, merge, rebase)
  *   - `history`    — history-shape scenarios (large logs, many tags)
  *   - `stash`      — stashed changes
+ *   - `submodule`  — repos with one or more registered submodules
  */
-export type ScenarioKind = 'branch' | 'worktree' | 'operation' | 'history' | 'stash'
+export type ScenarioKind = 'branch' | 'worktree' | 'operation' | 'history' | 'stash' | 'submodule'
 
 /**
  * A named, deterministic git-state factory. Given a fresh `TempGitRepo`


### PR DESCRIPTION
## Summary

Adds a deterministic `submodule-with-history` scenario to the test-utilities layer so the recursive-submodule-navigation work (#931, PR 2+ in the 5-PR plan from #941) has a real on-disk parent + submodule to drive against. Today every scenario in the registry is a flat single-repo shape — there's nothing to push / pop against, so the upcoming push / pop / breadcrumb work would have to either mock the submodule loaders or hand-build the same `tempGitRepo + git submodule add` setup in every test.

Two consumers:

- **Manual testing**: `npm run scenario create submodule-with-history -- --run-ui` materializes a parent with a `vendor/lib` submodule and launches `coco ui` against it. Tightest dev loop for trying push / pop / breadcrumb interactively as those PRs land.
- **Integration tests**: `spinUpScenario('submodule-with-history')` returns a `TempGitRepo` already in the named state. The submodule push / pop / drill-in tests in PR 2–4 will reach for this instead of mocking.

The scenario is also the "nested-submodule scenario" item from PR 5/5 in #941's plan, pulled forward so it can serve PRs 2–4 instead of landing last.

## Shape

| | Parent | `vendor/lib` (submodule) |
|---|---|---|
| Branch | `main` | `main` (tracked) |
| Commits | 4 (`chore: initial scaffold` → `feat: app shell` → `chore: add vendor/lib submodule` → `feat: integrate vendor/lib into entry point`) | 4 (`chore: initial scaffold` → `feat: add core types` → `feat: add main API` → `test: add coverage`) |
| Worktree | clean | clean (pin matches HEAD) |
| Remote | none | none |

## What's in this PR

- New scenario at `src/lib/testUtils/scenarios/submodule-with-history.ts` + paired test (9 contract assertions).
- New `'submodule'` `ScenarioKind` in `types.ts` so the CLI groups it apart from `branch` / `worktree` / `operation` / `history` / `stash`.
- Registered in `scenarios/index.ts`; the CLI picks it up automatically.
- README table + tree refreshed; scenario count goes 10 → 11, kind count goes 5 → 6.

## Implementation notes

- The submodule source is built in an out-of-tree temp dir, cloned into the parent via `git submodule add -b main`, then removed. The clone under `vendor/lib` is fully self-contained for read-only ops. The stale URL in `.gitmodules` only matters for `submodule update --remote` / `submodule sync`, which the scenario explicitly disclaims.
- `git submodule add` is shelled out via `child_process`, not simple-git, because simple-git's unsafe-operations plugin blocks the `-c protocol.file.allow=always` runtime override required on git ≥ 2.38 for file-protocol submodule URLs. Same pattern can be reused in future scenarios that need submodules.
- No coco-specific imports inside `scenarios/` — extraction discipline preserved (see `src/lib/testUtils/README.md`).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test:jest` — 170 suites, 1951 passed (9 new under `scenarios/submodule-with-history.test.ts`)
- [x] `npm run build` clean (no schema regen)
- [x] `npm run test:cli` — 10/10
- [x] `npm run release:dry-run` clean
- [x] `npm run scenario describe submodule-with-history` renders summary + contracts
- [x] `npm run scenario create submodule-with-history` produces a parent with the expected log + a `vendor/lib` submodule with its own 4-commit log + clean status

Refs #931.