### PR TITLE
feat(log-tui): push / pop repo-frame reducer actions (#931 PR 2a)

### DIFF
--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -1447,6 +1447,132 @@ describe('log Ink view model', () => {
       ])
     })
   })
+
+  describe('pushRepoFrame / popRepoFrame (#931 PR 2)', () => {
+    function nudgeParentState(s: ReturnType<typeof createLogInkState>) {
+      // Move the parent off defaults so we can verify snapshot + restore.
+      // Filter first so the move's clamping is computed against the
+      // filtered list, not retroactively shrunken by the filter.
+      let next = applyLogInkAction(s, { type: 'setFilter', value: 'feat:' })
+      next = applyLogInkAction(next, { type: 'move', delta: 1 })
+      next = applyLogInkAction(next, { type: 'setActiveView', value: 'branches' })
+      return next
+    }
+
+    it('pushRepoFrame appends a new frame with the supplied label', () => {
+      const before = createLogInkState(rows, { repoLabel: 'coco' })
+      const after = applyLogInkAction(before, {
+        type: 'pushRepoFrame',
+        label: 'vendor/lib',
+      })
+      expect(after.repoStack).toHaveLength(2)
+      expect(after.repoStack[0].label).toBe('coco')
+      expect(after.repoStack[1].label).toBe('vendor/lib')
+      expect(isLogInkNestedRepo(after)).toBe(true)
+      expect(getActiveLogInkRepoFrame(after).label).toBe('vendor/lib')
+    })
+
+    it('pushRepoFrame snapshots the parent view position into parentReturn', () => {
+      const before = nudgeParentState(createLogInkState(rows, { repoLabel: 'coco' }))
+      const after = applyLogInkAction(before, {
+        type: 'pushRepoFrame',
+        label: 'vendor/lib',
+      })
+      const ret = after.repoStack[1].parentReturn
+      expect(ret).toEqual({
+        activeView: 'branches',
+        selectedIndex: before.selectedIndex,
+        selectedFileIndex: 0,
+        selectedSubmoduleIndex: 0,
+        filter: 'feat:',
+      })
+      expect(before.selectedIndex).toBeGreaterThan(0)
+    })
+
+    it('pushRepoFrame records the optional entryRange', () => {
+      const before = createLogInkState(rows, { repoLabel: 'coco' })
+      const after = applyLogInkAction(before, {
+        type: 'pushRepoFrame',
+        label: 'vendor/lib',
+        entryRange: { oldSha: 'aaa', newSha: 'bbb' },
+      })
+      expect(after.repoStack[1].entryRange).toEqual({ oldSha: 'aaa', newSha: 'bbb' })
+    })
+
+    it('pushRepoFrame resets per-frame navigation state', () => {
+      const before = nudgeParentState(createLogInkState(rows, { repoLabel: 'coco' }))
+      const after = applyLogInkAction(before, {
+        type: 'pushRepoFrame',
+        label: 'vendor/lib',
+      })
+      expect(after.activeView).toBe('history')
+      expect(after.viewStack).toEqual(['history'])
+      expect(after.selectedIndex).toBe(0)
+      expect(after.selectedFileIndex).toBe(0)
+      expect(after.selectedSubmoduleIndex).toBe(0)
+      expect(after.filter).toBe('')
+      expect(after.filterMode).toBe(false)
+    })
+
+    it('pushRepoFrame preserves carry-over preferences (sort modes, palette, sidebar)', () => {
+      let before = createLogInkState(rows, { repoLabel: 'coco' })
+      before = applyLogInkAction(before, { type: 'setSidebarTab', value: 'tags' })
+      before = applyLogInkAction(before, { type: 'cycleBranchSort' })
+      before = applyLogInkAction(before, { type: 'recordPaletteRecent', value: 'history.goHome' })
+
+      const after = applyLogInkAction(before, { type: 'pushRepoFrame', label: 'vendor/lib' })
+      expect(after.sidebarTab).toBe(before.sidebarTab)
+      expect(after.userSidebarTab).toBe(before.userSidebarTab)
+      expect(after.branchSort).toBe(before.branchSort)
+      expect(after.paletteRecent).toEqual(before.paletteRecent)
+    })
+
+    it('popRepoFrame is a no-op at the root frame', () => {
+      const before = createLogInkState(rows, { repoLabel: 'coco' })
+      const after = applyLogInkAction(before, { type: 'popRepoFrame' })
+      expect(after.repoStack).toHaveLength(1)
+      expect(isLogInkNestedRepo(after)).toBe(false)
+    })
+
+    it('pushRepoFrame followed by popRepoFrame restores the parent position', () => {
+      const before = nudgeParentState(createLogInkState(rows, { repoLabel: 'coco' }))
+      const pushed = applyLogInkAction(before, {
+        type: 'pushRepoFrame',
+        label: 'vendor/lib',
+      })
+      const popped = applyLogInkAction(pushed, { type: 'popRepoFrame' })
+
+      expect(popped.repoStack).toHaveLength(1)
+      expect(popped.activeView).toBe('branches')
+      expect(popped.viewStack).toEqual(['branches'])
+      expect(popped.selectedIndex).toBe(before.selectedIndex)
+      expect(popped.filter).toBe('feat:')
+      expect(isLogInkNestedRepo(popped)).toBe(false)
+    })
+
+    it('popRepoFrame on a 3-deep stack drops only the top frame', () => {
+      let state = createLogInkState(rows, { repoLabel: 'coco' })
+      state = applyLogInkAction(state, { type: 'pushRepoFrame', label: 'vendor/lib' })
+      state = applyLogInkAction(state, { type: 'pushRepoFrame', label: 'vendor/lib/deep' })
+      expect(getLogInkRepoStackLabels(state)).toEqual(['coco', 'vendor/lib', 'vendor/lib/deep'])
+
+      state = applyLogInkAction(state, { type: 'popRepoFrame' })
+      expect(getLogInkRepoStackLabels(state)).toEqual(['coco', 'vendor/lib'])
+      expect(isLogInkNestedRepo(state)).toBe(true)
+    })
+
+    it('pushRepoFrame clears in-flight confirmation state', () => {
+      let before = createLogInkState(rows, { repoLabel: 'coco' })
+      before = applyLogInkAction(before, {
+        type: 'setPendingConfirmation',
+        value: 'revert-file',
+        payload: 'src/foo.ts',
+      })
+      const after = applyLogInkAction(before, { type: 'pushRepoFrame', label: 'vendor/lib' })
+      expect(after.pendingConfirmationId).toBeUndefined()
+      expect(after.pendingConfirmationPayload).toBeUndefined()
+    })
+  })
 })
 
 describe('issue / pull-request triage navigation (#882 phase 3)', () => {

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -61,7 +61,18 @@ export type LogInkRepoFrame = {
    * user remembers what they were looking at. Undefined when
    * entered from the dedicated submodules view (`gM`).
    */
-  entryRange?: { oldSha: string; newSha: string }
+  entryRange?: LogInkRepoFrameEntryRange
+}
+
+/**
+ * `(oldPin, newPin)` sha pair captured at push time from a commit
+ * diff. Extracted as its own type so action payloads, the runtime's
+ * parallel structure, and any future helpers can refer to one shape
+ * instead of re-declaring the inline record.
+ */
+export type LogInkRepoFrameEntryRange = {
+  oldSha: string
+  newSha: string
 }
 
 export type LogInkRepoFrameReturn = {
@@ -640,6 +651,8 @@ export type LogInkAction =
   | { type: 'pushView'; value: LogInkView }
   | { type: 'popView' }
   | { type: 'replaceView'; value: LogInkView }
+  | { type: 'pushRepoFrame'; label: string; entryRange?: LogInkRepoFrameEntryRange }
+  | { type: 'popRepoFrame' }
   | { type: 'navigateHome' }
   | { type: 'navigateOpenDiffForCommit'; sha: string; commitIndex: number; fileIndex?: number }
   | { type: 'navigateOpenDiffForWorktreeFile'; fileIndex: number }
@@ -877,6 +890,97 @@ function withPoppedView(state: LogInkState): LogInkState {
     pendingCommitFocused: next === 'history' ? state.pendingCommitFocused : false,
     statusGroupHeaderFocused: next === 'status' ? state.statusGroupHeaderFocused : false,
     pendingKey: undefined,
+  }
+}
+
+/**
+ * Push a nested-repo frame onto `state.repoStack` (#931). Snapshots
+ * the active view position into the new frame's `parentReturn` so a
+ * subsequent pop lands the user back where they came from, then
+ * resets the per-frame navigation state (active view, view stack,
+ * row / file / submodule cursors, filter) so the nested frame opens
+ * in a clean slate — the mental equivalent of a fresh `coco ui`
+ * launched against the submodule's working dir.
+ *
+ * Carry-over preferences (sidebar tab, branch / tag sort, palette
+ * recents, inspector tab, diff view mode) are intentionally left
+ * untouched. They're user-level choices that should persist across
+ * frames, the same way they persist across view pushes today.
+ *
+ * Live runtime objects (`SimpleGit`, loaded `LogInkContext`) live
+ * outside the reducer in `app.ts`'s parallel ref structure — this
+ * helper only manages the pure view-model side of the push.
+ */
+function withPushedRepoFrame(
+  state: LogInkState,
+  payload: { label: string; entryRange?: LogInkRepoFrameEntryRange }
+): LogInkState {
+  const newFrame: LogInkRepoFrame = {
+    label: payload.label,
+    entryRange: payload.entryRange,
+    parentReturn: {
+      activeView: state.activeView,
+      selectedIndex: state.selectedIndex,
+      selectedFileIndex: state.selectedFileIndex,
+      selectedSubmoduleIndex: state.selectedSubmoduleIndex,
+      filter: state.filter,
+    },
+  }
+  return {
+    ...state,
+    repoStack: [...state.repoStack, newFrame],
+    activeView: 'history',
+    viewStack: ['history'],
+    selectedIndex: 0,
+    selectedFileIndex: 0,
+    selectedSubmoduleIndex: 0,
+    filter: '',
+    filterMode: false,
+    pendingCommitFocused: false,
+    pendingKey: undefined,
+    pendingConfirmationId: undefined,
+    pendingConfirmationPayload: undefined,
+    pendingMutationConfirmation: undefined,
+  }
+}
+
+/**
+ * Pop the top repo frame off `state.repoStack` (#931) and restore
+ * the parent's view position from the captured `parentReturn`. A
+ * no-op when the stack is already at its single root frame so this
+ * action is safe to dispatch from generic input handlers (e.g. the
+ * Esc auto-pop wiring that lands in a follow-up PR).
+ *
+ * The defensive `parentReturn` fallback handles the never-supposed-
+ * to-happen case where a non-root frame somehow has no return state
+ * recorded — drop the frame but leave the user's view position
+ * alone rather than crash mid-session.
+ */
+function withPoppedRepoFrame(state: LogInkState): LogInkState {
+  if (state.repoStack.length <= 1) {
+    return { ...state, pendingKey: undefined }
+  }
+  const topFrame = state.repoStack[state.repoStack.length - 1]
+  const ret = topFrame.parentReturn
+  const repoStack = state.repoStack.slice(0, -1)
+  if (!ret) {
+    return { ...state, repoStack, pendingKey: undefined }
+  }
+  return {
+    ...state,
+    repoStack,
+    activeView: ret.activeView,
+    viewStack: [ret.activeView],
+    selectedIndex: ret.selectedIndex,
+    selectedFileIndex: ret.selectedFileIndex,
+    selectedSubmoduleIndex: ret.selectedSubmoduleIndex,
+    filter: ret.filter,
+    filterMode: false,
+    pendingCommitFocused: false,
+    pendingKey: undefined,
+    pendingConfirmationId: undefined,
+    pendingConfirmationPayload: undefined,
+    pendingMutationConfirmation: undefined,
   }
 }
 
@@ -1568,6 +1672,10 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return withPoppedView(state)
     case 'replaceView':
       return withReplacedView(state, action.value)
+    case 'pushRepoFrame':
+      return withPushedRepoFrame(state, { label: action.label, entryRange: action.entryRange })
+    case 'popRepoFrame':
+      return withPoppedRepoFrame(state)
     case 'navigateHome': {
       if (state.viewStack.length === 1 && topOfStack(state.viewStack) === HOME_VIEW) {
         return { ...state, pendingKey: undefined }


### PR DESCRIPTION
## Summary

Adds the pure reducer-side push / pop primitives for the nested-repo navigation stack introduced in #941. The action paths are pure data — no SimpleGit binding, no chrome, no input wiring. Subsequent PRs layer the runtime parallel structure, breadcrumb chrome, and Esc auto-pop on top.

PR 1/5 (#941) intentionally shipped only the type vocabulary + selectors with the note that "push / pop semantics, the runtime parallel structure that holds the per-frame `SimpleGit` + loaded context, and the breadcrumb chrome land in subsequent PRs." That PR's planned PR 2 bundled four pieces — push / pop, runtime parallel structure, breadcrumb, Esc auto-pop. This branch is **PR 2a**: just the reducer actions, kept in the 100-500 LOC band per the TUI shell PR cadence. PR 2b–d will follow as separate branches off main.

## What's in this PR

- **`pushRepoFrame` action.** Snapshots the active view position (active view, row / file / submodule cursors, filter) into the new frame's `parentReturn`, appends the frame to `state.repoStack`, then resets per-frame navigation state so the nested frame opens on the `history` view with a clean cursor — mentally equivalent to a fresh `coco ui` against the submodule's working dir. Carry-over preferences (sidebar tab, branch / tag sort, palette recents, inspector tab) are intentionally left alone so user-level choices persist across frames. Also clears in-flight confirmation state so a half-typed `y`-confirm can't bleed across a frame push.
- **`popRepoFrame` action.** Drops the top frame and restores the view position from its `parentReturn`. A no-op on the root frame so the upcoming Esc auto-pop wiring can dispatch this unconditionally.
- **`LogInkRepoFrameEntryRange` type extraction.** The inline `{ oldSha; newSha }` record on `LogInkRepoFrame.entryRange` is promoted to its own exported type so action payloads and the upcoming runtime parallel structure can refer to one shape rather than re-declaring it.

## What's next

- **PR 2b** — runtime parallel structure: per-frame `SimpleGit` + loaded `LogInkContext` ref in `app.ts`, keyed on stack depth, with the bind-swap that runs after `pushRepoFrame` / `popRepoFrame`.
- **PR 2c** — breadcrumb chrome (`coco · vendor/lib · …`) in the header.
- **PR 2d** — Esc auto-pop in input dispatch when a nested frame is at the root of its own view stack.
- **PR 3** — drill-in from the commit-diff inspector (uses `entryRange`).
- **PR 4** — drill-in from the dedicated submodules view (#932).
- **PR 5** — polish, boundary cases, docs.

The `submodule-with-history` scenario from #981 (in review) is the test fixture for PRs 2b–4.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test:jest` — 169 suites, 1951 passed (9 new under `inkViewModel.test.ts` covering push, pop, parent-return snapshot/restore, 3-deep stack pop, no-op at root, carry-over preferences preserved, in-flight confirmation cleared)
- [x] `npm run build` clean (no schema regen)
- [x] `npm run test:cli` — 10/10
- [x] `npm run release:dry-run` clean
- [x] No user-visible change — `pushRepoFrame` is never dispatched in this PR; existing tests still pass against the same state shape

Refs #931, builds on #941.