### PR TITLE
feat(log-tui): per-frame runtime module (#931 PR 2b)

### DIFF
--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -1408,6 +1408,16 @@ describe('log Ink view model', () => {
       expect(state.repoStack[0].label).toBe('coco')
     })
 
+    it('records the supplied repoWorkdir on the root frame', () => {
+      const state = createLogInkState(rows, { repoLabel: 'coco', repoWorkdir: '/abs/coco' })
+      expect(state.repoStack[0].workdir).toBe('/abs/coco')
+    })
+
+    it('leaves workdir undefined on the root frame when repoWorkdir is omitted', () => {
+      const state = createLogInkState(rows)
+      expect(state.repoStack[0].workdir).toBeUndefined()
+    })
+
     it('getActiveLogInkRepoFrame returns the top of the stack', () => {
       const state = createLogInkState(rows, { repoLabel: 'coco' })
       expect(getActiveLogInkRepoFrame(state).label).toBe('coco')
@@ -1497,6 +1507,18 @@ describe('log Ink view model', () => {
         entryRange: { oldSha: 'aaa', newSha: 'bbb' },
       })
       expect(after.repoStack[1].entryRange).toEqual({ oldSha: 'aaa', newSha: 'bbb' })
+    })
+
+    it('pushRepoFrame records the optional workdir on the new frame', () => {
+      const before = createLogInkState(rows, { repoLabel: 'coco', repoWorkdir: '/abs/coco' })
+      const after = applyLogInkAction(before, {
+        type: 'pushRepoFrame',
+        label: 'vendor/lib',
+        workdir: '/abs/coco/vendor/lib',
+      })
+      expect(after.repoStack[1].workdir).toBe('/abs/coco/vendor/lib')
+      // Root frame's workdir is preserved on push.
+      expect(after.repoStack[0].workdir).toBe('/abs/coco')
     })
 
     it('pushRepoFrame resets per-frame navigation state', () => {

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -62,6 +62,15 @@ export type LogInkRepoFrame = {
    * entered from the dedicated submodules view (`gM`).
    */
   entryRange?: LogInkRepoFrameEntryRange
+  /**
+   * Absolute working-directory path the frame binds against. Drives
+   * the runtime's `SimpleGit` factory (PR 2c) — nested frames bind a
+   * fresh `simpleGit(workdir)`; the root frame's workdir is the cwd
+   * `coco ui` was launched from. Optional only for back-compat with
+   * states created before this field landed (notably tests that
+   * direct-construct frames); production code paths always set it.
+   */
+  workdir?: string
 }
 
 /**
@@ -139,6 +148,13 @@ export type CreateLogInkStateOptions = {
    * cwd or the package name.
    */
   repoLabel?: string
+  /**
+   * Absolute working-directory path for the root frame (#931). The
+   * runtime layer reads it to know which `SimpleGit` instance backs
+   * the root frame. Optional only so back-compat callers (tests
+   * direct-constructing state) don't have to thread it through.
+   */
+  repoWorkdir?: string
 }
 
 export type LogInkState = {
@@ -651,7 +667,7 @@ export type LogInkAction =
   | { type: 'pushView'; value: LogInkView }
   | { type: 'popView' }
   | { type: 'replaceView'; value: LogInkView }
-  | { type: 'pushRepoFrame'; label: string; entryRange?: LogInkRepoFrameEntryRange }
+  | { type: 'pushRepoFrame'; label: string; workdir?: string; entryRange?: LogInkRepoFrameEntryRange }
   | { type: 'popRepoFrame' }
   | { type: 'navigateHome' }
   | { type: 'navigateOpenDiffForCommit'; sha: string; commitIndex: number; fileIndex?: number }
@@ -913,10 +929,11 @@ function withPoppedView(state: LogInkState): LogInkState {
  */
 function withPushedRepoFrame(
   state: LogInkState,
-  payload: { label: string; entryRange?: LogInkRepoFrameEntryRange }
+  payload: { label: string; workdir?: string; entryRange?: LogInkRepoFrameEntryRange }
 ): LogInkState {
   const newFrame: LogInkRepoFrame = {
     label: payload.label,
+    workdir: payload.workdir,
     entryRange: payload.entryRange,
     parentReturn: {
       activeView: state.activeView,
@@ -1150,7 +1167,7 @@ export function createLogInkState(
     selectedPullRequestTriageIndex: 0,
     selectedIssueFilter: 'open',
     selectedPullRequestFilter: 'open',
-    repoStack: [{ label: options.repoLabel || 'root' }],
+    repoStack: [{ label: options.repoLabel || 'root', workdir: options.repoWorkdir }],
     branchSort: DEFAULT_BRANCH_SORT_MODE,
     tagSort: DEFAULT_TAG_SORT_MODE,
     paletteFilter: '',
@@ -1673,7 +1690,11 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
     case 'replaceView':
       return withReplacedView(state, action.value)
     case 'pushRepoFrame':
-      return withPushedRepoFrame(state, { label: action.label, entryRange: action.entryRange })
+      return withPushedRepoFrame(state, {
+        label: action.label,
+        workdir: action.workdir,
+        entryRange: action.entryRange,
+      })
     case 'popRepoFrame':
       return withPoppedRepoFrame(state)
     case 'navigateHome': {

--- a/src/workstation/runtime/repoStackRuntime.test.ts
+++ b/src/workstation/runtime/repoStackRuntime.test.ts
@@ -1,0 +1,171 @@
+import type { SimpleGit } from 'simple-git'
+import type { LogInkRepoFrame } from '../../commands/log/inkViewModel'
+import { createLogInkContextStatus } from '../chrome/context'
+import {
+  getActiveRepoFrameRuntime,
+  syncRepoStackRuntimes,
+  updateRepoFrameRuntime,
+  type RepoFrameRuntime,
+  type RepoStackRuntimes,
+} from './repoStackRuntime'
+
+// Each test fakes `SimpleGit` with a tagged stub; we only care about
+// identity preservation here, not real git behavior. Calls into the
+// runtime never reach the actual library.
+function fakeGit(tag: string): SimpleGit {
+  return { __tag: tag } as unknown as SimpleGit
+}
+
+function makeRuntime(tag: string): RepoFrameRuntime {
+  return {
+    git: fakeGit(tag),
+    context: {},
+    contextStatus: createLogInkContextStatus('idle'),
+  }
+}
+
+function frame(label: string, workdir?: string): LogInkRepoFrame {
+  return { label, workdir }
+}
+
+describe('syncRepoStackRuntimes', () => {
+  it('returns prev unchanged when the stack length is unchanged', () => {
+    const prev: RepoStackRuntimes = [makeRuntime('root')]
+    const result = syncRepoStackRuntimes(
+      prev,
+      [frame('root', '/repo')],
+      () => makeRuntime('should-not-build'),
+    )
+    expect(result.runtimes).toBe(prev)
+    expect(result.newlyAddedIndices).toEqual([])
+  })
+
+  it('appends a new runtime when the stack grew by one (push)', () => {
+    const prev: RepoStackRuntimes = [makeRuntime('root')]
+    const stack = [frame('root', '/repo'), frame('vendor/lib', '/repo/vendor/lib')]
+
+    const factoryCalls: Array<{ frame: LogInkRepoFrame; depth: number }> = []
+    const result = syncRepoStackRuntimes(prev, stack, (f, d) => {
+      factoryCalls.push({ frame: f, depth: d })
+      return makeRuntime(`${f.label}@${d}`)
+    })
+
+    expect(factoryCalls).toEqual([{ frame: stack[1], depth: 1 }])
+    expect(result.newlyAddedIndices).toEqual([1])
+    expect(result.runtimes).toHaveLength(2)
+    expect(result.runtimes[0]).toBe(prev[0])
+    expect((result.runtimes[1].git as unknown as { __tag: string }).__tag).toBe('vendor/lib@1')
+  })
+
+  it('appends multiple runtimes when the stack grew by more than one', () => {
+    const prev: RepoStackRuntimes = [makeRuntime('root')]
+    const stack = [
+      frame('root', '/repo'),
+      frame('vendor/lib', '/repo/vendor/lib'),
+      frame('vendor/lib/deep', '/repo/vendor/lib/deep'),
+    ]
+    const result = syncRepoStackRuntimes(prev, stack, (f, d) => makeRuntime(`${f.label}@${d}`))
+    expect(result.newlyAddedIndices).toEqual([1, 2])
+    expect(result.runtimes).toHaveLength(3)
+    expect(result.runtimes[0]).toBe(prev[0])
+  })
+
+  it('slices off the dropped runtimes when the stack shrank (pop)', () => {
+    const prev: RepoStackRuntimes = [
+      makeRuntime('root'),
+      makeRuntime('vendor/lib'),
+      makeRuntime('vendor/lib/deep'),
+    ]
+    const result = syncRepoStackRuntimes(
+      prev,
+      [frame('root', '/repo'), frame('vendor/lib', '/repo/vendor/lib')],
+      () => makeRuntime('should-not-build'),
+    )
+    expect(result.runtimes).toHaveLength(2)
+    expect(result.runtimes[0]).toBe(prev[0])
+    expect(result.runtimes[1]).toBe(prev[1])
+    expect(result.newlyAddedIndices).toEqual([])
+  })
+
+  it('handles a multi-level pop by slicing to the new stack length', () => {
+    const prev: RepoStackRuntimes = [
+      makeRuntime('root'),
+      makeRuntime('vendor/lib'),
+      makeRuntime('vendor/lib/deep'),
+    ]
+    const result = syncRepoStackRuntimes(
+      prev,
+      [frame('root', '/repo')],
+      () => makeRuntime('should-not-build'),
+    )
+    expect(result.runtimes).toHaveLength(1)
+    expect(result.runtimes[0]).toBe(prev[0])
+  })
+
+  it('builds a root runtime when starting from an empty list', () => {
+    const result = syncRepoStackRuntimes(
+      [],
+      [frame('root', '/repo')],
+      (f, d) => makeRuntime(`${f.label}@${d}`),
+    )
+    expect(result.newlyAddedIndices).toEqual([0])
+    expect(result.runtimes).toHaveLength(1)
+  })
+
+  it('passes the matching frame and depth into the factory for each new index', () => {
+    const calls: Array<{ label: string; depth: number; workdir?: string }> = []
+    syncRepoStackRuntimes(
+      [makeRuntime('root')],
+      [
+        frame('root', '/repo'),
+        frame('vendor/lib', '/repo/vendor/lib'),
+        frame('vendor/lib/deep', '/repo/vendor/lib/deep'),
+      ],
+      (f, d) => {
+        calls.push({ label: f.label, depth: d, workdir: f.workdir })
+        return makeRuntime(f.label)
+      },
+    )
+    expect(calls).toEqual([
+      { label: 'vendor/lib', depth: 1, workdir: '/repo/vendor/lib' },
+      { label: 'vendor/lib/deep', depth: 2, workdir: '/repo/vendor/lib/deep' },
+    ])
+  })
+})
+
+describe('getActiveRepoFrameRuntime', () => {
+  it('returns the top of the runtime list', () => {
+    const runtimes: RepoStackRuntimes = [makeRuntime('root'), makeRuntime('vendor/lib')]
+    expect(getActiveRepoFrameRuntime(runtimes)).toBe(runtimes[1])
+  })
+
+  it('returns undefined for an empty list', () => {
+    expect(getActiveRepoFrameRuntime([])).toBeUndefined()
+  })
+
+  it('returns the only entry for a single-frame list', () => {
+    const runtimes: RepoStackRuntimes = [makeRuntime('root')]
+    expect(getActiveRepoFrameRuntime(runtimes)).toBe(runtimes[0])
+  })
+})
+
+describe('updateRepoFrameRuntime', () => {
+  it('replaces the entry at the given index using the updater', () => {
+    const runtimes: RepoStackRuntimes = [makeRuntime('root'), makeRuntime('vendor/lib')]
+    const swapped = updateRepoFrameRuntime(runtimes, 1, (prev) => ({
+      ...prev,
+      context: { provider: { kind: 'github' } } as unknown as RepoFrameRuntime['context'],
+    }))
+    expect(swapped).not.toBe(runtimes)
+    expect(swapped).toHaveLength(2)
+    expect(swapped[0]).toBe(runtimes[0])
+    expect(swapped[1]).not.toBe(runtimes[1])
+    expect(swapped[1].context).toEqual({ provider: { kind: 'github' } })
+  })
+
+  it('returns prev unchanged when the index is out of range', () => {
+    const runtimes: RepoStackRuntimes = [makeRuntime('root')]
+    expect(updateRepoFrameRuntime(runtimes, 5, () => makeRuntime('nope'))).toBe(runtimes)
+    expect(updateRepoFrameRuntime(runtimes, -1, () => makeRuntime('nope'))).toBe(runtimes)
+  })
+})

--- a/src/workstation/runtime/repoStackRuntime.ts
+++ b/src/workstation/runtime/repoStackRuntime.ts
@@ -1,0 +1,124 @@
+import type { SimpleGit } from 'simple-git'
+import type { LogInkRepoFrame } from '../../commands/log/inkViewModel'
+import type { LogInkContextStatus } from '../chrome/context'
+import type { LogInkContext } from './types'
+
+/**
+ * Per-frame runtime (#931 PR 2b). The view-model side of the repo
+ * stack (`LogInkState.repoStack`) is pure data — labels, return
+ * snapshots, optional entry ranges. The runtime side, kept here in
+ * parallel, holds the *live* objects each frame binds against:
+ *
+ *   - `git` — a `SimpleGit` instance bound to the frame's workdir
+ *     (root cwd for the root frame, submodule absolute path for
+ *     nested frames). Every loader (`getBranchOverview`, the row
+ *     fetcher, the diff helpers, etc.) consumes this.
+ *   - `context` — the per-frame loaded context (branches / tags /
+ *     stashes / submodules / …). Persisted across drill-in / drill-
+ *     out cycles so popping back to a parent doesn't re-pay the load
+ *     cost.
+ *   - `contextStatus` — the per-key load progress for `context`,
+ *     used by the chrome to show loading hints in the right column.
+ *
+ * Live runtime objects can't live in the reducer (they'd break
+ * referential purity and serialization). They sit in a structural
+ * array indexed by frame depth so push / pop manipulations stay a
+ * trivial append / slice.
+ */
+export type RepoFrameRuntime = {
+  git: SimpleGit
+  context: LogInkContext
+  contextStatus: LogInkContextStatus
+}
+
+/**
+ * Ordered list of frame runtimes, root-first. The index of a runtime
+ * in the list equals its depth in `LogInkState.repoStack` — runtime
+ * 0 backs the root frame, runtime 1 backs the first push, etc.
+ *
+ * Kept as a plain readonly array (not a `Map`) so push is `.concat`,
+ * pop is `.slice`, and reads are O(1) — exactly the operations the
+ * sync helper performs.
+ */
+export type RepoStackRuntimes = readonly RepoFrameRuntime[]
+
+/**
+ * Reconcile the per-frame runtime list against the current view-model
+ * stack. Three cases:
+ *
+ *   - **No change** — same length, returns `prev` unchanged so React
+ *     reference equality skips downstream re-renders.
+ *   - **Pop** — stack shrunk, returns `prev.slice(0, stack.length)`.
+ *     The dropped runtimes are released to the GC; the surviving
+ *     runtimes (root + any intermediate frames) keep their cached
+ *     `git` + `context` so a re-push lands on warm state.
+ *   - **Push** — stack grew, builds a fresh runtime via the supplied
+ *     `createRuntime(frame, depth)` factory for each newly-deeper
+ *     frame. The caller is responsible for the factory's content;
+ *     this module never imports `simple-git` or `loadLogInkContext`
+ *     directly so it stays unit-testable without a real repo on disk.
+ *
+ * Returns `newlyAddedIndices` so the caller's effect knows which
+ * frames need their initial context fetch kicked off. On a no-op or
+ * pop, the list is empty.
+ *
+ * The reducer's `pushRepoFrame` / `popRepoFrame` actions are the only
+ * things that mutate `state.repoStack`; both are monotone — push
+ * appends one, pop drops one — so this helper never needs to handle
+ * "frame at index i changed identity in place." If that invariant ever
+ * loosens, this helper should error rather than silently mis-bind a
+ * `SimpleGit` to the wrong working directory.
+ */
+export function syncRepoStackRuntimes(
+  prev: RepoStackRuntimes,
+  stack: readonly LogInkRepoFrame[],
+  createRuntime: (frame: LogInkRepoFrame, depth: number) => RepoFrameRuntime,
+): { runtimes: RepoStackRuntimes; newlyAddedIndices: number[] } {
+  if (stack.length < prev.length) {
+    return { runtimes: prev.slice(0, stack.length), newlyAddedIndices: [] }
+  }
+  if (stack.length === prev.length) {
+    return { runtimes: prev, newlyAddedIndices: [] }
+  }
+  const next: RepoFrameRuntime[] = prev.slice()
+  const newlyAddedIndices: number[] = []
+  for (let i = prev.length; i < stack.length; i += 1) {
+    next.push(createRuntime(stack[i], i))
+    newlyAddedIndices.push(i)
+  }
+  return { runtimes: next, newlyAddedIndices }
+}
+
+/**
+ * Top-of-stack runtime — the one every active surface, loader, and
+ * action target reads from. Undefined when the runtime list is empty
+ * (which production code never produces — `createLogInkState` always
+ * seeds a root frame, so the corresponding root runtime is built on
+ * mount and the array is non-empty for the lifetime of the session).
+ */
+export function getActiveRepoFrameRuntime(
+  runtimes: RepoStackRuntimes,
+): RepoFrameRuntime | undefined {
+  return runtimes[runtimes.length - 1]
+}
+
+/**
+ * Immutably update one frame's runtime entry. Used by the app shell's
+ * loader effects when a frame's `context` or `contextStatus` changes
+ * — replacing the entry in place lets React's referential equality
+ * skip re-renders on unrelated frames.
+ *
+ * Out-of-range indices are no-ops (return `prev` unchanged) so the
+ * caller doesn't have to guard against race-y stack changes between
+ * the load kickoff and the load-complete callback.
+ */
+export function updateRepoFrameRuntime(
+  runtimes: RepoStackRuntimes,
+  index: number,
+  updater: (prev: RepoFrameRuntime) => RepoFrameRuntime,
+): RepoStackRuntimes {
+  if (index < 0 || index >= runtimes.length) return runtimes
+  const next = runtimes.slice()
+  next[index] = updater(next[index])
+  return next
+}


### PR DESCRIPTION
## Summary

Adds the parallel runtime structure that PRs 2c+ will wire into [LogInkApp](src/workstation/runtime/app.ts) to drive per-frame `SimpleGit` + `LogInkContext` swap on push / pop. The data shape and pure reconcile helpers land in isolation here so the upcoming integration has a known-good target. **No `app.ts` surgery yet, no behavior change.**

PR 1 (#941) shipped the type vocabulary; PR 2a (#982) shipped the reducer push / pop actions. This PR is the matching **runtime side** of those actions — the bit that owns the live `SimpleGit` instances. Slicing it off as its own PR keeps the future `app.ts` change auditable on its own diff.

## What's in this PR

### View-model side ([inkViewModel.ts](src/commands/log/inkViewModel.ts))

Three small, additive fields:

- `LogInkRepoFrame.workdir?: string` — absolute path the frame binds against (root cwd for the root frame, submodule absolute path for nested frames).
- `CreateLogInkStateOptions.repoWorkdir?: string` — forwarded onto the root frame.
- `pushRepoFrame` action gains `workdir?: string`, threaded onto the new frame via `withPushedRepoFrame`.

Optional everywhere for back-compat with existing test states / direct-constructed actions.

### Runtime side ([repoStackRuntime.ts](src/workstation/runtime/repoStackRuntime.ts))

```ts
type RepoFrameRuntime = { git: SimpleGit; context: LogInkContext; contextStatus: LogInkContextStatus }
type RepoStackRuntimes = readonly RepoFrameRuntime[]

syncRepoStackRuntimes(prev, stack, createRuntime): { runtimes, newlyAddedIndices }
getActiveRepoFrameRuntime(runtimes)
updateRepoFrameRuntime(runtimes, index, updater)
```

- `syncRepoStackRuntimes` reconciles the runtime list against the view-model stack. Push appends; pop slices; no-op returns `prev` referentially so React's reference-equality skips downstream re-renders. Returns `newlyAddedIndices` so the integrating effect knows which frames need their initial context-load kicked off.
- The module deliberately doesn't import `simple-git` or `loadLogInkContext`. The factory is passed in. This keeps the runtime unit-testable without a real repo on disk and matches the "pure helpers in their own file" discipline the rest of `workstation/runtime/` follows.

## What's next

- **PR 2c** — integrate the runtime into [app.ts](src/workstation/runtime/app.ts): wrap `git` / `context` / `contextStatus` in a `useState<RepoStackRuntimes>`, re-source the active frame's runtime via `getActiveRepoFrameRuntime`, run the loader effects against the active git. Also lands the breadcrumb chrome (`coco · vendor/lib · …`).
- **PR 2d** — Esc auto-pop in input dispatch when a nested frame is at the root of its own view stack.
- **PR 3** — drill-in from the commit-diff inspector (uses `entryRange` + `workdir`).
- **PR 4** — drill-in from the dedicated submodules view (#932).
- **PR 5** — polish + docs.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test:jest` — 171 suites, 1975 passed (13 new in `repoStackRuntime.test.ts` covering no-op / push by one / push by many / single pop / multi pop / empty-to-root build / factory args; plus active-frame and immutable-update helpers; +1 covering `repoWorkdir` on the root frame and +1 covering `workdir` on push)
- [x] `npm run build` clean (no schema regen)
- [x] `npm run test:cli` — 10/10
- [x] `npm run release:dry-run` clean
- [x] No user-visible change — the runtime module is unreferenced in this PR; existing `git` / `context` / `contextStatus` plumbing in `app.ts` is untouched

Refs #931, builds on #941 / #982.