### PR TITLE
feat(log-tui): repo breadcrumb chrome + Esc / < auto-pop (#931 PR 2c+2d)

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -1,5 +1,6 @@
 import { GitLogRow } from './data'
 import { getLogInkInputEvents, getLogInkPaletteExecuteEvents } from './inkInput'
+import { getLogInkPaletteCommands } from './inkKeymap'
 import { LogInkState, applyLogInkAction, createLogInkState } from './inkViewModel'
 
 const rows: GitLogRow[] = [
@@ -1095,6 +1096,174 @@ describe('log Ink input interactions', () => {
     state = applyInput(state, '', { escape: true })
     expect(state.viewStack).toEqual(['history'])
     expect(state.activeView).toBe('history')
+  })
+
+  describe('Esc / < auto-pop for nested repo frames (#931)', () => {
+    function pushSubmoduleFrame(s: LogInkState): LogInkState {
+      return applyLogInkAction(s, {
+        type: 'pushRepoFrame',
+        label: 'vendor/lib',
+        workdir: '/abs/coco/vendor/lib',
+      })
+    }
+
+    it('Esc at the root view of a nested frame pops the frame', () => {
+      let state = createLogInkState(rows, { repoLabel: 'coco' })
+      state = pushSubmoduleFrame(state)
+      expect(state.repoStack).toHaveLength(2)
+      expect(state.viewStack).toEqual(['history'])
+
+      state = applyInput(state, '', { escape: true })
+
+      expect(state.repoStack).toHaveLength(1)
+      expect(state.repoStack[0].label).toBe('coco')
+    })
+
+    it('Esc inside a nested frame drains the view stack before popping the frame', () => {
+      let state = createLogInkState(rows, { repoLabel: 'coco' })
+      state = pushSubmoduleFrame(state)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'diff' })
+      expect(state.viewStack).toEqual(['history', 'diff'])
+      expect(state.repoStack).toHaveLength(2)
+
+      // First Esc: pops the diff view inside the nested frame.
+      state = applyInput(state, '', { escape: true })
+      expect(state.viewStack).toEqual(['history'])
+      expect(state.repoStack).toHaveLength(2)
+
+      // Second Esc: now at the root view of the frame, pops the frame.
+      state = applyInput(state, '', { escape: true })
+      expect(state.viewStack).toEqual(['history'])
+      expect(state.repoStack).toHaveLength(1)
+    })
+
+    it('Esc at the root of the root frame is a no-op (no popRepoFrame underflow)', () => {
+      const state = createLogInkState(rows, { repoLabel: 'coco' })
+      const events = getLogInkInputEvents(state, '', { escape: true })
+      // Either no events or events that don't include popRepoFrame /
+      // popView. The two-stage filter-mode escape is also gated by
+      // filterMode being true; here we never entered filter mode.
+      const types = events
+        .filter((event): event is Extract<typeof event, { type: 'action' }> => event.type === 'action')
+        .map((event) => event.action.type)
+      expect(types).not.toContain('popRepoFrame')
+      expect(types).not.toContain('popView')
+    })
+
+    it('Esc through a 3-deep nest unwinds one frame at a time', () => {
+      let state = createLogInkState(rows, { repoLabel: 'coco' })
+      state = pushSubmoduleFrame(state)
+      state = applyLogInkAction(state, {
+        type: 'pushRepoFrame',
+        label: 'vendor/lib/inner',
+      })
+      expect(state.repoStack.map((f) => f.label)).toEqual([
+        'coco',
+        'vendor/lib',
+        'vendor/lib/inner',
+      ])
+
+      state = applyInput(state, '', { escape: true })
+      expect(state.repoStack.map((f) => f.label)).toEqual(['coco', 'vendor/lib'])
+
+      state = applyInput(state, '', { escape: true })
+      expect(state.repoStack.map((f) => f.label)).toEqual(['coco'])
+
+      state = applyInput(state, '', { escape: true })
+      expect(state.repoStack.map((f) => f.label)).toEqual(['coco'])
+    })
+
+    it('`<` keystroke pops the frame at the root of a nested frame', () => {
+      let state = createLogInkState(rows, { repoLabel: 'coco' })
+      state = pushSubmoduleFrame(state)
+      state = applyInput(state, '<')
+      expect(state.repoStack).toHaveLength(1)
+    })
+
+    it('`<` drains the view stack before popping the frame', () => {
+      let state = createLogInkState(rows, { repoLabel: 'coco' })
+      state = pushSubmoduleFrame(state)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'diff' })
+
+      state = applyInput(state, '<')
+      expect(state.viewStack).toEqual(['history'])
+      expect(state.repoStack).toHaveLength(2)
+
+      state = applyInput(state, '<')
+      expect(state.repoStack).toHaveLength(1)
+    })
+
+    it('palette navigateBack mirrors the same logic', () => {
+      let state = createLogInkState(rows, { repoLabel: 'coco' })
+      state = pushSubmoduleFrame(state)
+      const navigateBackCommand = getLogInkPaletteCommands().find((c) => c.id === 'navigateBack')
+      if (!navigateBackCommand) throw new Error('navigateBack palette command missing')
+      const events = getLogInkPaletteExecuteEvents(navigateBackCommand, state)
+      const types = events
+        .filter((event): event is Extract<typeof event, { type: 'action' }> => event.type === 'action')
+        .map((event) => event.action.type)
+      expect(types).toContain('popRepoFrame')
+      expect(types).not.toContain('popView')
+    })
+
+    it('filter-mode escape wins over auto-pop while filterMode is active', () => {
+      let state = createLogInkState(rows, { repoLabel: 'coco' })
+      state = pushSubmoduleFrame(state)
+      // Enter filter mode and type a couple chars inside the nested frame.
+      state = applyInput(state, '/')
+      state = applyInput(state, 'f')
+      expect(state.filterMode).toBe(true)
+      expect(state.filter).toBe('f')
+      expect(state.repoStack).toHaveLength(2)
+
+      // First Esc: clears the filter text but stays in filter mode.
+      state = applyInput(state, '', { escape: true })
+      expect(state.filter).toBe('')
+      expect(state.filterMode).toBe(true)
+      expect(state.repoStack).toHaveLength(2)
+
+      // Second Esc: exits filter mode. Should NOT pop the frame.
+      state = applyInput(state, '', { escape: true })
+      expect(state.filterMode).toBe(false)
+      expect(state.repoStack).toHaveLength(2)
+
+      // Third Esc: now at root view of nested frame with no filter
+      // mode, the frame pops.
+      state = applyInput(state, '', { escape: true })
+      expect(state.repoStack).toHaveLength(1)
+    })
+
+    it('help overlay escape wins over auto-pop while help is open', () => {
+      let state = createLogInkState(rows, { repoLabel: 'coco' })
+      state = pushSubmoduleFrame(state)
+      state = applyLogInkAction(state, { type: 'toggleHelp' })
+      expect(state.showHelp).toBe(true)
+      expect(state.repoStack).toHaveLength(2)
+
+      // Esc closes the help overlay — does NOT pop the frame.
+      state = applyInput(state, '', { escape: true })
+      expect(state.showHelp).toBe(false)
+      expect(state.repoStack).toHaveLength(2)
+    })
+
+    it('popping the frame restores the parent view position', () => {
+      let state = createLogInkState(rows, { repoLabel: 'coco' })
+      // Move the parent off defaults so we can verify the pop restored.
+      state = applyLogInkAction(state, { type: 'setActiveView', value: 'branches' })
+      state = applyLogInkAction(state, { type: 'move', delta: 1 })
+      const parentSelected = state.selectedIndex
+
+      state = pushSubmoduleFrame(state)
+      // Inside the nested frame we land on history with cursor 0.
+      expect(state.activeView).toBe('history')
+      expect(state.selectedIndex).toBe(0)
+
+      state = applyInput(state, '', { escape: true })
+
+      expect(state.repoStack).toHaveLength(1)
+      expect(state.activeView).toBe('branches')
+      expect(state.selectedIndex).toBe(parentSelected)
+    })
   })
 
   it('opens diff for the selected commit with enter from history view', () => {

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -14,6 +14,7 @@ import {
     LogInkCompareRef,
     LogInkSidebarTab,
     LogInkState,
+    isLogInkNestedRepo,
     parseLogInkHistoryFetchPrefix,
 } from './inkViewModel'
 import {
@@ -583,6 +584,14 @@ export function getLogInkPaletteExecuteEvents(
         value: 'open branches / tags / history and press m on the cursored ref',
       })]
     case 'navigateBack':
+      // Mirror the Esc / `<` semantics (#931): drain the frame's view
+      // stack first, then pop the frame itself when nested.
+      if (state.viewStack.length > 1) {
+        return [action({ type: 'popView' })]
+      }
+      if (isLogInkNestedRepo(state)) {
+        return [action({ type: 'popRepoFrame' })]
+      }
       return [action({ type: 'popView' })]
     case 'openSelected': {
       // From history → diff for selected commit; from status → diff for
@@ -1207,6 +1216,16 @@ export function getLogInkInputEvents(
     return [action({ type: 'popView' })]
   }
 
+  // #931 — Esc auto-pop. When the user has drilled into a submodule
+  // (nested repo frame) AND they're at the root of that frame's own
+  // view stack, Esc walks back out to the parent repo. Ordered after
+  // the view-stack pop above so Esc still drains a frame's view stack
+  // before popping the frame itself — the user sees a predictable
+  // "back, back, back" path out.
+  if (key.escape && isLogInkNestedRepo(state)) {
+    return [action({ type: 'popRepoFrame' })]
+  }
+
   if (inputValue === 'q') {
     if (hasUnsavedComposeDraft(state)) {
       return [action({ type: 'setPendingMutationConfirmation', value: 'discard-draft' })]
@@ -1517,6 +1536,17 @@ export function getLogInkInputEvents(
   }
 
   if (inputValue === '<') {
+    // #931 — `<` is the keymap-driven mirror of Esc auto-pop. When the
+    // view stack has somewhere to go, pop a view; otherwise, if we're
+    // in a nested submodule frame, walk back out to the parent. The
+    // `popView` action is itself a no-op at the root of a frame's
+    // view stack, so this ordering can't double-pop.
+    if (state.viewStack.length > 1) {
+      return [action({ type: 'popView' })]
+    }
+    if (isLogInkNestedRepo(state)) {
+      return [action({ type: 'popRepoFrame' })]
+    }
     return [action({ type: 'popView' })]
   }
 

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -1,7 +1,9 @@
 import {
     LOG_INK_KEY_BINDINGS,
+    combineLogInkBreadcrumbSegments,
     filterLogInkPaletteCommands,
     formatLogInkBreadcrumb,
+    formatLogInkRepoBreadcrumb,
     getLogInkChordContinuations,
     getLogInkCommandPaletteItems,
     getLogInkFooterHints,
@@ -367,6 +369,73 @@ describe('log Ink keymap', () => {
     expect(formatLogInkBreadcrumb(['history', 'status', 'diff']))
       .toBe('history › status › diff   ← <')
     expect(formatLogInkBreadcrumb(['history', 'compose'])).toBe('history › compose   ← <')
+  })
+
+  describe('formatLogInkRepoBreadcrumb (#931)', () => {
+    it('returns empty for an empty stack', () => {
+      expect(formatLogInkRepoBreadcrumb([])).toBe('')
+    })
+
+    it('returns empty for a single-frame (root-only) stack', () => {
+      expect(formatLogInkRepoBreadcrumb([{ label: 'root' }])).toBe('')
+      expect(formatLogInkRepoBreadcrumb([{ label: 'coco' }])).toBe('')
+    })
+
+    it('renders a two-frame stack with the back-hint cue', () => {
+      expect(formatLogInkRepoBreadcrumb([
+        { label: 'coco' },
+        { label: 'vendor/lib' },
+      ])).toBe('coco › vendor/lib   ← esc')
+    })
+
+    it('renders a deeper stack with frames joined by the same separator', () => {
+      expect(formatLogInkRepoBreadcrumb([
+        { label: 'coco' },
+        { label: 'vendor/lib' },
+        { label: 'vendor/lib/inner' },
+      ])).toBe('coco › vendor/lib › vendor/lib/inner   ← esc')
+    })
+
+    it('reads only the label off each frame and ignores other fields', () => {
+      // Frames will carry `parentReturn`, `entryRange`, `workdir`, etc.
+      // The formatter must not surface any of that in the chrome line.
+      expect(formatLogInkRepoBreadcrumb([
+        { label: 'coco', workdir: '/abs/coco' } as { label: string },
+        { label: 'vendor/lib', workdir: '/abs/coco/vendor/lib' } as { label: string },
+      ])).toBe('coco › vendor/lib   ← esc')
+    })
+  })
+
+  describe('combineLogInkBreadcrumbSegments (#931)', () => {
+    it('returns empty when both segments are empty', () => {
+      expect(combineLogInkBreadcrumbSegments('', '')).toBe('')
+    })
+
+    it('renders only the repo crumb when the view crumb is empty', () => {
+      expect(combineLogInkBreadcrumbSegments('coco › vendor/lib   ← esc', ''))
+        .toBe('  coco › vendor/lib   ← esc')
+    })
+
+    it('renders only the view crumb when the repo crumb is empty', () => {
+      expect(combineLogInkBreadcrumbSegments('', 'history › diff   ← <'))
+        .toBe('  history › diff   ← <')
+    })
+
+    it('joins repo + view with extra spacing when both are present', () => {
+      expect(combineLogInkBreadcrumbSegments(
+        'coco › vendor/lib   ← esc',
+        'history › diff   ← <',
+      )).toBe('  coco › vendor/lib   ← esc    history › diff   ← <')
+    })
+
+    it('matches the leading-spaces convention the existing view-only path used', () => {
+      // Before #931 the chrome did `  ${breadcrumb}` when only the view
+      // stack was nested. This contract assertion locks in the legacy
+      // behavior so the visible header doesn't shift for non-nested
+      // sessions.
+      const viewOnly = combineLogInkBreadcrumbSegments('', 'status   ← <')
+      expect(viewOnly).toBe('  status   ← <')
+    })
   })
 
   it('exposes the gc compose chord as a global navigation binding', () => {

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -561,6 +561,58 @@ export function formatLogInkBreadcrumb(viewStack: LogInkView[]): string {
   return `${viewStack.join(' › ')}   ← <`
 }
 
+/**
+ * Render the nested-repo navigation stack (#931) as a breadcrumb suitable
+ * for the chrome header. Returns an empty string for a root-only stack
+ * so the header stays compact when nothing has been pushed.
+ *
+ * The trailing `← esc` reminds the user that Esc is the way out — same
+ * shape as the view breadcrumb's `← <` so the two read consistently.
+ * The repo breadcrumb shows in addition to the view breadcrumb when
+ * both stacks are non-trivial; the chrome layer is responsible for
+ * laying them out side by side.
+ *
+ * Examples:
+ *   `[root]`                     → ''
+ *   `[coco, vendor/lib]`         → 'coco › vendor/lib   ← esc'
+ *   `[coco, vendor/lib, deep]`   → 'coco › vendor/lib › deep   ← esc'
+ */
+export function formatLogInkRepoBreadcrumb(repoStack: ReadonlyArray<{ label: string }>): string {
+  if (repoStack.length <= 1) {
+    return ''
+  }
+  return `${repoStack.map((frame) => frame.label).join(' › ')}   ← esc`
+}
+
+/**
+ * Combine the repo-stack and view-stack breadcrumb segments for the
+ * header chrome (#931). Each segment is independently rendered by its
+ * formatter and may be empty; this helper interleaves the leading
+ * spacing so the header builder doesn't have to branch on four cases.
+ *
+ *   repoCrumb=''       viewCrumb=''       → ''
+ *   repoCrumb='X'      viewCrumb=''       → '  X'
+ *   repoCrumb=''       viewCrumb='Y'      → '  Y'
+ *   repoCrumb='X'      viewCrumb='Y'      → '  X    Y'
+ *
+ * Two leading spaces match the existing chrome — they separate the
+ * breadcrumb from the trailing repo/branch segment in the title row.
+ * Four spaces between segments give the repo crumb visual breathing
+ * room before the view crumb begins.
+ */
+export function combineLogInkBreadcrumbSegments(repoCrumb: string, viewCrumb: string): string {
+  if (repoCrumb && viewCrumb) {
+    return `  ${repoCrumb}    ${viewCrumb}`
+  }
+  if (repoCrumb) {
+    return `  ${repoCrumb}`
+  }
+  if (viewCrumb) {
+    return `  ${viewCrumb}`
+  }
+  return ''
+}
+
 export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogInkFooterHints {
   if (options.pendingKey) {
     const continuations = getLogInkChordContinuations(options.pendingKey)

--- a/src/workstation/runtime/header.ts
+++ b/src/workstation/runtime/header.ts
@@ -24,7 +24,11 @@ import { isLogInkContextLoading } from '../chrome/context'
 import { getPullRequestStateGlyph } from '../chrome/iconography'
 import { truncateCells } from '../chrome/text'
 import type { LogInkTheme } from '../chrome/theme'
-import { formatLogInkBreadcrumb } from '../../commands/log/inkKeymap'
+import {
+  combineLogInkBreadcrumbSegments,
+  formatLogInkBreadcrumb,
+  formatLogInkRepoBreadcrumb,
+} from '../../commands/log/inkKeymap'
 import type { LogInkState } from '../../commands/log/inkViewModel'
 import type { LogInkComponents, LogInkContext } from './types'
 
@@ -61,7 +65,13 @@ export function renderHeader(
     ? '  loading commits'
     : isLogInkContextLoading(contextStatus) ? '  loading context' : ''
   const breadcrumb = formatLogInkBreadcrumb(state.viewStack)
-  const view = breadcrumb ? `  ${breadcrumb}` : ''
+  const repoCrumb = formatLogInkRepoBreadcrumb(state.repoStack)
+  // Repo breadcrumb (when nested) comes first so the user sees which
+  // submodule they're in at a glance, then the view breadcrumb (when
+  // pushed deeper than the root view). The truncate fallback in the
+  // title row still applies — when both fight for space, the ellipsis
+  // lands at the end of whichever segment overflows.
+  const view = combineLogInkBreadcrumbSegments(repoCrumb, breadcrumb)
   // Mode indicator (P2.2) — surfaces the current input mode so users
   // never wonder why `q` doesn't quit while they're editing or filtering.
   const mode = state.commitCompose.editing


### PR DESCRIPTION
## Summary

Bundles the breadcrumb chrome (PR 2c) and the Esc / `<` auto-pop input wiring (PR 2d) into one PR per request. With #982 (reducer push / pop) and #983 (runtime parallel structure) already merged, this is the last "infrastructure-only" slice of the original PR 2/5 scope — once it lands, the moment a drill-in entry point fires in PR 3 the user will see a real breadcrumb in the header and be able to Esc back out.

The app.ts runtime integration (originally bundled into PR 2c) is deferred to PR 3 — that's the first PR where it becomes load-bearing, so it'll diff cleanly alongside the commit-diff drill-in workflow.

## What's in this PR

### Breadcrumb chrome (PR 2c piece)

- **`formatLogInkRepoBreadcrumb(repoStack)`** in [inkKeymap.ts](src/commands/log/inkKeymap.ts) — renders `coco › vendor/lib   ← esc`. Matches the view breadcrumb's `← <` shape. Returns `''` for a root-only stack so non-nested sessions look identical to before.
- **`combineLogInkBreadcrumbSegments(repoCrumb, viewCrumb)`** — new helper that interleaves the leading spacing between the repo and view breadcrumb segments. Pure, four-quadrant input space, fully tested.
- **[header.ts](src/workstation/runtime/header.ts)** composes both via the new helper; non-nested sessions render byte-identically.

### Esc / `<` auto-pop (PR 2d piece)

In [inkInput.ts](src/commands/log/inkInput.ts):

- Esc clause added after the existing view-pop clause: when nested AND at the root of the frame's view stack, dispatch `popRepoFrame`. Ordering preserves a "back, back, back" path — drain views in the frame first, then pop the frame itself.
- `<` keystroke and the palette `navigateBack` command mirror the same logic so keyboard and palette stay in sync.
- All earlier Esc handlers (filter mode, help overlay, bisect wizard, mutation confirmations) keep their precedence. Locked in by tests.

## Test plan

`npm run test:jest` — 171 suites, 1995 passed (+20 new):

`inkKeymap.test.ts`:
- `formatLogInkRepoBreadcrumb` — empty / single-frame / two-frame / three-frame / ignores non-label fields
- `combineLogInkBreadcrumbSegments` — all four input quadrants + a regression assertion locking in the legacy view-only chrome string

`inkInput.test.ts`:
- Esc at root view of nested frame pops the frame
- Esc inside nested frame drains the view stack first, then pops the frame
- Esc at root of root frame is a no-op (no underflow)
- Esc through a 3-deep nest unwinds one frame at a time
- `<` mirrors Esc
- Palette `navigateBack` mirrors Esc / `<`
- Pop restores the parent's view position (verified against a parent that's on `branches` view with a non-zero cursor)
- Filter-mode escape precedence — filter clear (twice) happens before any frame pop
- Help-overlay escape precedence — closes help, doesn't pop frame

Full validation green:
- [x] `npm run lint`
- [x] `npm run test:jest` — 171 suites, 1995 passed
- [x] `npm run build`
- [x] `npm run test:cli` — 10/10
- [x] `npm run release:dry-run`

No visible change yet for non-nested sessions — every test covering existing chrome / Esc semantics still passes against the new code paths. The breadcrumb only renders when `repoStack.length > 1` (which today is unreachable without a `pushRepoFrame` dispatch, coming in PR 3).

## What's next

- **PR 3** — app.ts runtime integration + drill-in from commit-diff inspector. The runtime parallel structure shipped in #983 finally gets wired; pressing Enter on a submodule row in the diff inspector pushes a frame, the breadcrumb shows, Esc walks back out.
- **PR 4** — drill-in from the dedicated submodules view (#932).
- **PR 5** — polish + docs.

Refs #931, builds on #941 / #982 / #983.