### PR TITLE
feat(log-tui): wire per-frame runtime into LogInkApp (#931 PR 3a)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -91,6 +91,14 @@ import {
 import { hasSeenOnboarding, markOnboardingSeen } from '../chrome/onboarding'
 import { formatSplitApplySuccess } from '../chrome/postApplyHints'
 import { SPINNER_TICK_MS } from '../chrome/spinner'
+import { createInitialContextStatus, createRepoFrameRuntime } from './repoFrameFactory'
+import {
+  getActiveRepoFrameRuntime,
+  syncRepoStackRuntimes,
+  updateRepoFrameRuntime,
+  type RepoFrameRuntime,
+  type RepoStackRuntimes,
+} from './repoStackRuntime'
 
 
 async function safe<T>(promise: Promise<T>): Promise<T | undefined> {
@@ -441,7 +449,7 @@ function enrichFilterActionWithRectification(
 }
 
 export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
-  const { appLabel, clipboardRunner, dateBucketingEnabled, git, idleTipsEnabled, ink, initialView, loadRows, logArgv, React, resumeRef, rows, theme } = deps
+  const { appLabel, clipboardRunner, dateBucketingEnabled, git: rootGit, idleTipsEnabled, ink, initialView, loadRows, logArgv, React, resumeRef, rows, theme } = deps
   const { Box, Text, useApp, useInput, useWindowSize } = ink
   const h = React.createElement
   const { exit } = useApp()
@@ -474,20 +482,80 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       bootLoading: Boolean(loadRows),
     })
   )
-  const [context, setContext] = React.useState<LogInkContext>({})
-  const [contextStatus, setContextStatus] = React.useState<LogInkContextStatus>(() => {
-    // Boot starts every fetched key in 'loading' so the surfaces show
-    // their loading hints immediately. `pullRequest` is the exception
-    // (#808) — it isn't part of the boot fetch entries; it lazy-loads
-    // when the user enters the PR view. Marking it 'idle' avoids a
-    // permanent "loading" flag in the chrome and lets the dedicated
-    // PR view's own load effect drive its loading state.
-    return updateLogInkContextStatus(
-      createLogInkContextStatus('loading'),
-      'pullRequest',
-      'idle'
-    )
-  })
+  // Nested-repo runtime stack (#931). Each frame holds the live
+  // `SimpleGit`, the loaded `LogInkContext`, and the per-key load
+  // status the chrome reads. The active (top-of-stack) entry drives
+  // every loader and surface; popping a frame restores the parent's
+  // cached entry so a drill-in / drill-out round trip doesn't re-pay
+  // the context load cost. Seeded with a single root runtime against
+  // the cwd `coco ui` was launched in.
+  const [runtimes, setRuntimes] = React.useState<RepoStackRuntimes>(() => [{
+    git: rootGit,
+    context: {},
+    contextStatus: createInitialContextStatus(),
+  }])
+  // Sync `runtimes` against the view-model stack on every push / pop.
+  // The sync is monotone — push appends a new runtime via the factory,
+  // pop slices off the top runtime; the parent's cached state survives.
+  // The factory is wrapped to capture `rootGit` so a defensively-pushed
+  // frame without a workdir still has a working `SimpleGit` bound.
+  React.useEffect(() => {
+    setRuntimes((prev) => {
+      const { runtimes: next } = syncRepoStackRuntimes(
+        prev,
+        state.repoStack,
+        (frame) => createRepoFrameRuntime(frame, rootGit),
+      )
+      return next
+    })
+  }, [state.repoStack, rootGit])
+  // Active-frame projection (#931). `git`, `context`, `contextStatus`
+  // — every existing closure / effect / surface reads these names; the
+  // only thing this PR changes is where they come from. When the user
+  // drills into a submodule, the top-of-stack runtime swaps, every
+  // dep array that lists `git` re-fires, and the loaders refetch
+  // against the submodule's working tree.
+  const activeRuntime: RepoFrameRuntime = getActiveRepoFrameRuntime(runtimes) ?? {
+    git: rootGit,
+    context: {},
+    contextStatus: createInitialContextStatus(),
+  }
+  const git = activeRuntime.git
+  const context = activeRuntime.context
+  const contextStatus = activeRuntime.contextStatus
+  // Wrappers that delegate to the active frame's runtime entry so the
+  // existing call sites stay byte-identical. Support both function-
+  // updater and value-updater forms (the codebase uses both).
+  const setContext = React.useCallback(
+    (arg: LogInkContext | ((prev: LogInkContext) => LogInkContext)) => {
+      setRuntimes((prev) => {
+        const depth = prev.length - 1
+        if (depth < 0) return prev
+        return updateRepoFrameRuntime(prev, depth, (frame) => ({
+          ...frame,
+          context: typeof arg === 'function'
+            ? (arg as (p: LogInkContext) => LogInkContext)(frame.context)
+            : arg,
+        }))
+      })
+    },
+    [],
+  )
+  const setContextStatus = React.useCallback(
+    (arg: LogInkContextStatus | ((prev: LogInkContextStatus) => LogInkContextStatus)) => {
+      setRuntimes((prev) => {
+        const depth = prev.length - 1
+        if (depth < 0) return prev
+        return updateRepoFrameRuntime(prev, depth, (frame) => ({
+          ...frame,
+          contextStatus: typeof arg === 'function'
+            ? (arg as (p: LogInkContextStatus) => LogInkContextStatus)(frame.contextStatus)
+            : arg,
+        }))
+      })
+    },
+    [],
+  )
   const [detail, setDetail] = React.useState<GitCommitDetail | undefined>(undefined)
   const [detailLoading, setDetailLoading] = React.useState(false)
   const [filePreview, setFilePreview] = React.useState<GitCommitFilePreview | undefined>(undefined)

--- a/src/workstation/runtime/repoFrameFactory.test.ts
+++ b/src/workstation/runtime/repoFrameFactory.test.ts
@@ -1,0 +1,83 @@
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type { SimpleGit } from 'simple-git'
+import { createInitialContextStatus, createRepoFrameRuntime } from './repoFrameFactory'
+
+function fakeGit(tag: string): SimpleGit {
+  return { __tag: tag } as unknown as SimpleGit
+}
+
+// `simpleGit(path)` refuses to bind against a non-existent directory,
+// so the workdir-bound assertions need a real path on disk.
+let realWorkdir: string
+
+beforeAll(() => {
+  realWorkdir = mkdtempSync(join(tmpdir(), 'coco-repo-frame-factory-'))
+})
+
+afterAll(() => {
+  if (realWorkdir) {
+    rmSync(realWorkdir, { recursive: true, force: true })
+  }
+})
+
+describe('createInitialContextStatus', () => {
+  it('seeds every fetched key in loading', () => {
+    const status = createInitialContextStatus()
+    expect(status.branches).toBe('loading')
+    expect(status.tags).toBe('loading')
+    expect(status.stashes).toBe('loading')
+    expect(status.worktree).toBe('loading')
+    expect(status.worktreeList).toBe('loading')
+    expect(status.submodules).toBe('loading')
+  })
+
+  it('seeds pullRequest as idle so the chrome does not stick on loading (#808)', () => {
+    const status = createInitialContextStatus()
+    expect(status.pullRequest).toBe('idle')
+  })
+
+  it('returns a fresh object on each call', () => {
+    const a = createInitialContextStatus()
+    const b = createInitialContextStatus()
+    expect(a).not.toBe(b)
+    expect(a).toEqual(b)
+  })
+})
+
+describe('createRepoFrameRuntime', () => {
+  it('binds simpleGit to the frame workdir when one is set', () => {
+    const rootGit = fakeGit('root')
+    const runtime = createRepoFrameRuntime(
+      { label: 'vendor/lib', workdir: realWorkdir },
+      rootGit,
+    )
+    // We can't easily assert against the real simple-git instance,
+    // but we CAN assert it's not the root. Production binds against
+    // the workdir via simpleGit() — a different instance every time.
+    expect(runtime.git).not.toBe(rootGit)
+  })
+
+  it('falls back to rootGit when the frame has no workdir', () => {
+    const rootGit = fakeGit('root')
+    const runtime = createRepoFrameRuntime({ label: 'orphan' }, rootGit)
+    expect(runtime.git).toBe(rootGit)
+  })
+
+  it('starts the context empty', () => {
+    const runtime = createRepoFrameRuntime(
+      { label: 'vendor/lib', workdir: realWorkdir },
+      fakeGit('root'),
+    )
+    expect(runtime.context).toEqual({})
+  })
+
+  it('seeds the context status with the canonical initial shape', () => {
+    const runtime = createRepoFrameRuntime(
+      { label: 'vendor/lib', workdir: realWorkdir },
+      fakeGit('root'),
+    )
+    expect(runtime.contextStatus).toEqual(createInitialContextStatus())
+  })
+})

--- a/src/workstation/runtime/repoFrameFactory.ts
+++ b/src/workstation/runtime/repoFrameFactory.ts
@@ -1,0 +1,63 @@
+import { simpleGit, type SimpleGit } from 'simple-git'
+import type { LogInkRepoFrame } from '../../commands/log/inkViewModel'
+import {
+  createLogInkContextStatus,
+  updateLogInkContextStatus,
+  type LogInkContextStatus,
+} from '../chrome/context'
+import type { RepoFrameRuntime } from './repoStackRuntime'
+
+/**
+ * Build the initial `LogInkContextStatus` for a freshly-created frame
+ * (#931). Every fetched key starts in `'loading'` so surfaces show the
+ * loading hint immediately; `pullRequest` is the exception (#808) —
+ * it's lazy-loaded on entry to the PR view, so we seed it `'idle'`
+ * instead of leaving it stuck as a permanent "loading" flag in the
+ * chrome.
+ *
+ * Extracted so the root runtime (built at boot inside `LogInkApp`) and
+ * the per-frame factory below share one canonical seed. The status
+ * surfaces depend on the exact `'pullRequest' = 'idle'` initialization
+ * to avoid spurious loading hints; locking it down in one helper means
+ * the two code paths can't drift.
+ */
+export function createInitialContextStatus(): LogInkContextStatus {
+  return updateLogInkContextStatus(
+    createLogInkContextStatus('loading'),
+    'pullRequest',
+    'idle',
+  )
+}
+
+/**
+ * Factory that builds a fresh `RepoFrameRuntime` for a newly-pushed
+ * frame (#931). The frame's `workdir` (set by the push action) drives
+ * which working tree the `SimpleGit` instance binds against:
+ *
+ *   - **Has workdir** → `simpleGit(workdir)`. Production case for any
+ *     nested submodule frame.
+ *   - **No workdir** → falls back to `rootGit`. Defensive: only the
+ *     root frame is expected to lack a workdir, and the root frame's
+ *     runtime is built directly from `rootGit` in `LogInkApp`'s state
+ *     initializer — this fallback only kicks in if a future push path
+ *     forgets to pass `workdir`. Binding to the root keeps the session
+ *     functional (the user still sees data) at the cost of the frame
+ *     being a duplicate of the root.
+ *
+ * `context` starts empty; `contextStatus` starts in the same initial
+ * "loading + pullRequest idle" shape the root frame seeds with. The
+ * sync effect in `LogInkApp` is responsible for kicking off the
+ * per-key context loads against the new frame's `git`; we don't do
+ * that here so the factory stays pure and unit-testable without a
+ * real repo on disk.
+ */
+export function createRepoFrameRuntime(
+  frame: LogInkRepoFrame,
+  rootGit: SimpleGit,
+): RepoFrameRuntime {
+  return {
+    git: frame.workdir ? simpleGit(frame.workdir) : rootGit,
+    context: {},
+    contextStatus: createInitialContextStatus(),
+  }
+}


### PR DESCRIPTION
## Summary

Brings the runtime parallel structure shipped in #983 online. The `SimpleGit` instance, `LogInkContext`, and per-key load status that every loader / surface reads now route through the active repo frame's runtime entry; pushing a frame swaps which `SimpleGit` they see and the existing per-effect `[git, ...]` deps re-fire to load the new frame's context.

**No user-visible change yet** — nothing in this PR dispatches `pushRepoFrame`. PR 3b will wire the commit-diff inspector's Enter keystroke to drill into a submodule, which is the first PR where the new code path is actually exercised at runtime. Splitting that out keeps the integration diff (this PR, ~80 LOC of `app.ts` surgery) auditable on its own — the drill-in workflow needs its own design pass for absolute-path resolution and lands in its own focused PR.

## What changed in `app.ts`

- `git` is no longer destructured directly from `deps`; it's renamed to `rootGit`. The per-render `git` is now projected off the active frame's runtime entry.
- `useState<LogInkContext>` and `useState<LogInkContextStatus>` are replaced by a single `useState<RepoStackRuntimes>`, seeded with one root runtime against `rootGit`. Per-render `context` and `contextStatus` are projected off the active entry.
- `setContext` and `setContextStatus` become `useCallback` wrappers that delegate to `updateRepoFrameRuntime`. Both forms (value and function updater) are supported so the ~29 existing call sites stay byte-identical.
- A new sync effect watches `state.repoStack` and reconciles the runtime list via `syncRepoStackRuntimes`. Pushes append a new runtime via the factory below; pops slice the top entry off and the parent's cached context survives. Since the existing loader effects already have `[git, ...]` deps, they re-fire automatically on push to load the new frame's context — no separate "kick off context for new frame" plumbing needed.

## New helper module at [repoFrameFactory.ts](src/workstation/runtime/repoFrameFactory.ts)

- `createInitialContextStatus()` — canonical "every key loading, `pullRequest` idle" seed for both the root runtime and any pushed frame. Locking it in one helper means the chrome can't drift between root and nested frame appearance.
- `createRepoFrameRuntime(frame, rootGit)` — pure factory. Binds `simpleGit(workdir)` when the frame's workdir is set; falls back to `rootGit` when it isn't (defensive — only the root frame is expected to lack a workdir, and the root's runtime is built directly inside `LogInkApp`).

## Known follow-ups

- **Pop currently re-fetches the parent's context.** When the user pops back to a frame whose context is already cached, the existing `[git, ...]` dep on the boot-load effect re-fires and refetches. Functionally correct (data ends up right) but pays the load cost on every pop. PR 5 polish will guard with "context already loaded → skip."
- **In-flight refresh + push race.** A user-triggered `refreshContext` that's mid-await when a push happens will write its result to the new active frame. Rare and not destructive (just stale data briefly), but a `tag-by-depth` guard on the writes will close it. Also slated for PR 5 polish.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test:jest` — 172 suites, 2002 passed (+7 new under `repoFrameFactory.test.ts`)
  - `createInitialContextStatus`: every key loads / `pullRequest` is idle / returns a fresh object
  - `createRepoFrameRuntime`: workdir → bound `simpleGit` / no workdir → falls back to `rootGit` / empty context / canonical status seed
- [x] `npm run build` clean (no schema regen)
- [x] `npm run test:cli` — 10/10
- [x] `npm run release:dry-run` clean
- [x] Existing app.ts behavior tests still pass against the new code paths (proxy: the full 2002-test suite stays green; `app.ts` is exercised indirectly through the reducer / input handler tests and the CLI smoke checks)

## What's next

- **PR 3b** — commit-diff inspector drill-in. Resolve the root repo path at boot via `git.revparse --show-toplevel`, pipe absolute submodule paths into the input dispatch context, dispatch `pushRepoFrame` from the diff-view Enter handler when the cursored file is a submodule entry.
- **PR 4** — drill-in from the dedicated submodules view (#932).
- **PR 5** — polish (cached-context fast pop, in-flight load tagging, docs).

Refs #931, builds on #941 / #982 / #983 / #984.