### PR TITLE
feat(log-tui): commit-diff submodule drill-in (#931 PR 3b)

### DIFF
--- a/src/commands/log/data.test.ts
+++ b/src/commands/log/data.test.ts
@@ -266,8 +266,8 @@ describe('log data layer', () => {
   it('surfaces the structured submoduleChange for a modified-submodule file (#931)', async () => {
     const git = {
       raw: jest.fn().mockResolvedValue([
-        '-Subproject commit 1111111111111111111111111111111111111111',
-        '+Subproject commit 2222222222222222222222222222222222222222',
+        '-Subproject commit 11111111',
+        '+Subproject commit 22222222',
       ].join('\n')),
     }
 
@@ -281,8 +281,8 @@ describe('log data layer', () => {
 
     expect(preview.submoduleChange).toEqual({
       kind: 'modified',
-      before: '1111111111111111111111111111111111111111',
-      after: '2222222222222222222222222222222222222222',
+      before: '11111111',
+      after: '22222222',
     })
     // The summarized hunks are unchanged from before — the structured
     // field is purely additive.
@@ -310,10 +310,10 @@ describe('log data layer', () => {
 
   it('surfaces submoduleChange for added (no -line) and removed (no +line) submodules', async () => {
     const addedGit = {
-      raw: jest.fn().mockResolvedValue('+Subproject commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+      raw: jest.fn().mockResolvedValue('+Subproject commit aaaaaaaa'),
     }
     const removedGit = {
-      raw: jest.fn().mockResolvedValue('-Subproject commit bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'),
+      raw: jest.fn().mockResolvedValue('-Subproject commit bbbbbbbb'),
     }
 
     const added = await getCommitFilePreview(addedGit as never, 'abc1234', {
@@ -321,7 +321,7 @@ describe('log data layer', () => {
     })
     expect(added.submoduleChange).toEqual({
       kind: 'added',
-      after: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      after: 'aaaaaaaa',
     })
 
     const removed = await getCommitFilePreview(removedGit as never, 'abc1234', {
@@ -329,7 +329,7 @@ describe('log data layer', () => {
     })
     expect(removed.submoduleChange).toEqual({
       kind: 'removed',
-      before: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      before: 'bbbbbbbb',
     })
   })
 })

--- a/src/commands/log/data.test.ts
+++ b/src/commands/log/data.test.ts
@@ -259,6 +259,77 @@ describe('log data layer', () => {
         binary: false,
         deletions: 1,
       },
+      submoduleChange: undefined,
+    })
+  })
+
+  it('surfaces the structured submoduleChange for a modified-submodule file (#931)', async () => {
+    const git = {
+      raw: jest.fn().mockResolvedValue([
+        '-Subproject commit 1111111111111111111111111111111111111111',
+        '+Subproject commit 2222222222222222222222222222222222222222',
+      ].join('\n')),
+    }
+
+    const preview = await getCommitFilePreview(git as never, 'abc1234', {
+      additions: 1,
+      binary: false,
+      deletions: 1,
+      path: 'vendor/lib',
+      status: 'M',
+    })
+
+    expect(preview.submoduleChange).toEqual({
+      kind: 'modified',
+      before: '1111111111111111111111111111111111111111',
+      after: '2222222222222222222222222222222222222222',
+    })
+    // The summarized hunks are unchanged from before — the structured
+    // field is purely additive.
+    expect(preview.hunks).toHaveLength(1)
+    expect(preview.hunks[0]).toMatch(/^submodule modified:/)
+  })
+
+  it('omits submoduleChange for non-submodule files', async () => {
+    const git = {
+      raw: jest.fn().mockResolvedValue([
+        '@@ -1,1 +1,1 @@',
+        '-old',
+        '+new',
+      ].join('\n')),
+    }
+    const preview = await getCommitFilePreview(git as never, 'abc1234', {
+      additions: 1,
+      binary: false,
+      deletions: 1,
+      path: 'src/index.ts',
+      status: 'M',
+    })
+    expect(preview.submoduleChange).toBeUndefined()
+  })
+
+  it('surfaces submoduleChange for added (no -line) and removed (no +line) submodules', async () => {
+    const addedGit = {
+      raw: jest.fn().mockResolvedValue('+Subproject commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+    }
+    const removedGit = {
+      raw: jest.fn().mockResolvedValue('-Subproject commit bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'),
+    }
+
+    const added = await getCommitFilePreview(addedGit as never, 'abc1234', {
+      additions: 1, binary: false, deletions: 0, path: 'vendor/new', status: 'A',
+    })
+    expect(added.submoduleChange).toEqual({
+      kind: 'added',
+      after: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    })
+
+    const removed = await getCommitFilePreview(removedGit as never, 'abc1234', {
+      additions: 0, binary: false, deletions: 1, path: 'vendor/gone', status: 'D',
+    })
+    expect(removed.submoduleChange).toEqual({
+      kind: 'removed',
+      before: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
     })
   })
 })

--- a/src/commands/log/data.ts
+++ b/src/commands/log/data.ts
@@ -1,6 +1,6 @@
 import { SimpleGit } from 'simple-git'
 import { extractLfsPatchChange, renderLfsSummary } from '../../git/lfsPointer'
-import { extractSubmoduleChange, renderSubmoduleSummary } from '../../git/submoduleDiff'
+import { extractSubmoduleChange, renderSubmoduleSummary, type SubmoduleChange } from '../../git/submoduleDiff'
 import { LogArgv, LogView } from './config'
 
 export const FIELD_SEPARATOR = '\x1f'
@@ -67,6 +67,16 @@ export type GitCommitFilePreview = {
     deletions?: number
   }
   hunks: string[]
+  /**
+   * When the file is a submodule (gitlink) change, the structured
+   * `Subproject commit <sha>` extraction (#884). The `hunks` array
+   * is already summarized to a single human-readable line; this
+   * field carries the raw before/after shas so consumers like the
+   * recursive submodule navigation drill-in (#931) can build a
+   * concrete `entryRange` without re-running the diff extraction.
+   * Undefined for non-submodule files.
+   */
+  submoduleChange?: SubmoduleChange
 }
 
 export function toArray(value: string | string[] | undefined): string[] {
@@ -407,5 +417,6 @@ export async function getCommitFilePreview(
       deletions: file.deletions,
     },
     hunks: finalHunks,
+    submoduleChange,
   }
 }

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -1262,8 +1262,8 @@ describe('log Ink input interactions', () => {
             label: 'vendor/lib',
             workdir: '/abs/coco/vendor/lib',
             entryRange: {
-              oldSha: '1111111111111111111111111111111111111111',
-              newSha: '2222222222222222222222222222222222222222',
+              oldSha: '11111111',
+              newSha: '22222222',
             },
           },
         })
@@ -1276,8 +1276,8 @@ describe('log Ink input interactions', () => {
           label: 'vendor/lib',
           workdir: '/abs/coco/vendor/lib',
           entryRange: {
-            oldSha: '1111111111111111111111111111111111111111',
-            newSha: '2222222222222222222222222222222222222222',
+            oldSha: '11111111',
+            newSha: '22222222',
           },
         })
         // Status hint accompanies the push so the user gets feedback.

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -1246,6 +1246,125 @@ describe('log Ink input interactions', () => {
       expect(state.repoStack).toHaveLength(2)
     })
 
+    describe('commit-diff drill-in (PR 3b)', () => {
+      function commitDiffState() {
+        const state = createLogInkState(rows, { activeView: 'diff', repoLabel: 'coco', repoWorkdir: '/abs/coco' })
+        return {
+          ...state,
+          diffSource: 'commit' as const,
+        } as LogInkState
+      }
+
+      it('Enter on a submodule file dispatches pushRepoFrame with the drill-in payload', () => {
+        const state = commitDiffState()
+        const events = getLogInkInputEvents(state, '', { return: true }, {
+          commitDiffSubmoduleDrillIn: {
+            label: 'vendor/lib',
+            workdir: '/abs/coco/vendor/lib',
+            entryRange: {
+              oldSha: '1111111111111111111111111111111111111111',
+              newSha: '2222222222222222222222222222222222222222',
+            },
+          },
+        })
+        const actionEvents = events
+          .filter((event): event is Extract<typeof event, { type: 'action' }> => event.type === 'action')
+          .map((event) => event.action)
+        const push = actionEvents.find((a) => a.type === 'pushRepoFrame')
+        expect(push).toEqual({
+          type: 'pushRepoFrame',
+          label: 'vendor/lib',
+          workdir: '/abs/coco/vendor/lib',
+          entryRange: {
+            oldSha: '1111111111111111111111111111111111111111',
+            newSha: '2222222222222222222222222222222222222222',
+          },
+        })
+        // Status hint accompanies the push so the user gets feedback.
+        const status = actionEvents.find((a) => a.type === 'setStatus')
+        expect(status).toEqual({ type: 'setStatus', value: 'entering submodule vendor/lib' })
+      })
+
+      it('Enter without a drill-in target on the diff view does NOT push a frame', () => {
+        const state = commitDiffState()
+        const events = getLogInkInputEvents(state, '', { return: true }, {})
+        const types = events
+          .filter((event): event is Extract<typeof event, { type: 'action' }> => event.type === 'action')
+          .map((event) => event.action.type)
+        expect(types).not.toContain('pushRepoFrame')
+      })
+
+      it('Enter on a worktree-source diff is not a drill-in target even if drill-in payload is set', () => {
+        // Worktree diffs come from `coco ui` against the live tree, not
+        // a historical commit. The drill-in target is gated on
+        // `diffSource === 'commit'` so a stray drill-in payload from a
+        // race doesn't accidentally fire from the worktree diff view.
+        const baseState = createLogInkState(rows, { activeView: 'diff' })
+        const state = { ...baseState, diffSource: 'worktree' as const } as LogInkState
+        const events = getLogInkInputEvents(state, '', { return: true }, {
+          commitDiffSubmoduleDrillIn: {
+            label: 'vendor/lib',
+            workdir: '/abs/coco/vendor/lib',
+          },
+        })
+        const types = events
+          .filter((event): event is Extract<typeof event, { type: 'action' }> => event.type === 'action')
+          .map((event) => event.action.type)
+        expect(types).not.toContain('pushRepoFrame')
+      })
+
+      it('Enter dispatch + reducer apply lands on history of the new frame with the cached parent return', () => {
+        let state = commitDiffState()
+        state = applyLogInkAction(state, { type: 'move', delta: 1 })
+        const parentSelected = state.selectedIndex
+
+        const events = getLogInkInputEvents(state, '', { return: true }, {
+          commitDiffSubmoduleDrillIn: {
+            label: 'vendor/lib',
+            workdir: '/abs/coco/vendor/lib',
+          },
+        })
+        state = events
+          .filter((event): event is Extract<typeof event, { type: 'action' }> => event.type === 'action')
+          .reduce((curr, event) => applyLogInkAction(curr, event.action), state)
+
+        expect(state.repoStack).toHaveLength(2)
+        expect(state.repoStack[1].label).toBe('vendor/lib')
+        expect(state.repoStack[1].workdir).toBe('/abs/coco/vendor/lib')
+        // The new frame lands on history with a clean cursor.
+        expect(state.activeView).toBe('history')
+        expect(state.viewStack).toEqual(['history'])
+        expect(state.selectedIndex).toBe(0)
+        // Parent's view position is captured in parentReturn so Esc /
+        // < / popRepoFrame restores it.
+        expect(state.repoStack[1].parentReturn).toEqual(expect.objectContaining({
+          activeView: 'diff',
+          selectedIndex: parentSelected,
+        }))
+      })
+
+      it('Enter drill-in works without an entryRange (e.g. added submodule)', () => {
+        const state = commitDiffState()
+        const events = getLogInkInputEvents(state, '', { return: true }, {
+          commitDiffSubmoduleDrillIn: {
+            label: 'vendor/lib',
+            workdir: '/abs/coco/vendor/lib',
+            // No entryRange (added / removed case).
+          },
+        })
+        const push = events
+          .filter((event): event is Extract<typeof event, { type: 'action' }> => event.type === 'action')
+          .map((event) => event.action)
+          .find((a) => a.type === 'pushRepoFrame')
+        expect(push).toEqual({
+          type: 'pushRepoFrame',
+          label: 'vendor/lib',
+          workdir: '/abs/coco/vendor/lib',
+          entryRange: undefined,
+        })
+      })
+    })
+
     it('popping the frame restores the parent view position', () => {
       let state = createLogInkState(rows, { repoLabel: 'coco' })
       // Move the parent off defaults so we can verify the pop restored.

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -154,6 +154,19 @@ export type LogInkInputContext = {
    */
   commitDiffSelectedSha?: string
   /**
+   * Resolved drill-in target for the file currently under the diff-view
+   * cursor (#931 PR 3b). Set by the runtime when the cursored file is a
+   * registered submodule AND the active frame's repo root has been
+   * resolved; undefined otherwise. The Enter handler in the diff view
+   * dispatches `pushRepoFrame` with this payload, opening the nested
+   * frame against the submodule's working directory.
+   */
+  commitDiffSubmoduleDrillIn?: {
+    label: string
+    workdir: string
+    entryRange?: { oldSha: string; newSha: string }
+  }
+  /**
    * True when the worktree has any staged, unstaged, or untracked changes.
    * Drives the synthetic "(+) new commit" row at the top of the history
    * list — pressing up at `selectedIndex === 0` transitions onto it; the
@@ -2100,6 +2113,32 @@ export function getLogInkInputEvents(
         }]
       }
     }
+  }
+
+  // #931 PR 3b — Enter on a submodule file in a commit diff drills into
+  // the submodule's history (the "spawn a coco ui scoped to the
+  // submodule" mental model from the design doc). The runtime decides
+  // whether the cursored file is a drill-in candidate and resolves the
+  // workdir + entryRange ahead of time; the handler here only fires
+  // when that target is populated. Ordered before the generic file-
+  // list Enter handler so the drill-in takes precedence over the
+  // detail-panel diff-refocus path.
+  if (
+    key.return &&
+    state.activeView === 'diff' &&
+    state.diffSource === 'commit' &&
+    context.commitDiffSubmoduleDrillIn
+  ) {
+    const target = context.commitDiffSubmoduleDrillIn
+    return [
+      action({
+        type: 'pushRepoFrame',
+        label: target.label,
+        workdir: target.workdir,
+        entryRange: target.entryRange,
+      }),
+      action({ type: 'setStatus', value: `entering submodule ${target.label}` }),
+    ]
   }
 
   if (

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -92,6 +92,7 @@ import { hasSeenOnboarding, markOnboardingSeen } from '../chrome/onboarding'
 import { formatSplitApplySuccess } from '../chrome/postApplyHints'
 import { SPINNER_TICK_MS } from '../chrome/spinner'
 import { createInitialContextStatus, createRepoFrameRuntime } from './repoFrameFactory'
+import { resolveCommitDiffDrillInTarget } from './repoFrameDrillIn'
 import {
   getActiveRepoFrameRuntime,
   syncRepoStackRuntimes,
@@ -556,6 +557,31 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     },
     [],
   )
+  // #931 PR 3b — Absolute repo root for the active frame's `git`.
+  // Resolved asynchronously after every `git` swap (push / pop /
+  // boot) so the commit-diff drill-in helper can construct absolute
+  // workdirs for submodule paths recorded in `.gitmodules` (which
+  // are repo-relative). Undefined during the brief moment between
+  // git swap and the revparse callback resolving.
+  const [activeRepoRoot, setActiveRepoRoot] = React.useState<string | undefined>(undefined)
+  React.useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const root = (await git.revparse(['--show-toplevel'])).trim()
+        if (!cancelled && root) {
+          setActiveRepoRoot(root)
+        }
+      } catch {
+        if (!cancelled) {
+          setActiveRepoRoot(undefined)
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [git])
   const [detail, setDetail] = React.useState<GitCommitDetail | undefined>(undefined)
   const [detailLoading, setDetailLoading] = React.useState(false)
   const [filePreview, setFilePreview] = React.useState<GitCommitFilePreview | undefined>(undefined)
@@ -3616,6 +3642,23 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         : undefined,
       commitDiffSelectedSha: state.diffSource === 'commit'
         ? selected?.hash
+        : undefined,
+      // #931 PR 3b — Submodule drill-in target for the cursored file
+      // in a commit diff. Resolved per-render so the Enter handler in
+      // `inkInput.ts` doesn't have to re-walk the submodule overview;
+      // undefined whenever the cursored file isn't a registered
+      // submodule (or the overview / repo root haven't loaded yet).
+      commitDiffSubmoduleDrillIn: state.diffSource === 'commit' && selectedDetailFile
+        ? resolveCommitDiffDrillInTarget({
+            selectedFile: {
+              path: selectedDetailFile.path,
+              submoduleChange: filePreview?.path === selectedDetailFile.path
+                ? filePreview.submoduleChange
+                : undefined,
+            },
+            submodules: context.submodules,
+            activeRepoRoot,
+          })
         : undefined,
       worktreeDirty,
       conflictFileCount: context.operation?.conflictedFiles.length,

--- a/src/workstation/runtime/repoFrameDrillIn.test.ts
+++ b/src/workstation/runtime/repoFrameDrillIn.test.ts
@@ -6,7 +6,7 @@ const baseOverview = {
     {
       name: 'vendor/lib',
       path: 'vendor/lib',
-      pinnedSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      pinnedSha: 'aaaaaaaa',
       flag: 'clean' as const,
       trackingBranch: 'main',
       url: '/abs/source/vendor/lib',
@@ -14,7 +14,7 @@ const baseOverview = {
     {
       name: 'tools',
       path: 'packages/tools',
-      pinnedSha: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      pinnedSha: 'bbbbbbbb',
       flag: 'clean' as const,
     },
   ],
@@ -59,8 +59,8 @@ describe('resolveCommitDiffDrillInTarget', () => {
         path: 'vendor/lib',
         submoduleChange: {
           kind: 'modified',
-          before: '1111111111111111111111111111111111111111',
-          after: '2222222222222222222222222222222222222222',
+          before: '11111111',
+          after: '22222222',
         },
       },
       submodules: baseOverview,
@@ -70,8 +70,8 @@ describe('resolveCommitDiffDrillInTarget', () => {
       label: 'vendor/lib',
       workdir: '/abs/coco/vendor/lib',
       entryRange: {
-        oldSha: '1111111111111111111111111111111111111111',
-        newSha: '2222222222222222222222222222222222222222',
+        oldSha: '11111111',
+        newSha: '22222222',
       },
     })
   })
@@ -82,8 +82,8 @@ describe('resolveCommitDiffDrillInTarget', () => {
         path: 'packages/tools',
         submoduleChange: {
           kind: 'modified',
-          before: 'cccccccccccccccccccccccccccccccccccccccc',
-          after: 'dddddddddddddddddddddddddddddddddddddddd',
+          before: 'cccccccc',
+          after: 'dddddddd',
         },
       },
       submodules: baseOverview,
@@ -99,7 +99,7 @@ describe('resolveCommitDiffDrillInTarget', () => {
         path: 'vendor/lib',
         submoduleChange: {
           kind: 'added',
-          after: '2222222222222222222222222222222222222222',
+          after: '22222222',
         },
       },
       submodules: baseOverview,
@@ -116,7 +116,7 @@ describe('resolveCommitDiffDrillInTarget', () => {
         path: 'vendor/lib',
         submoduleChange: {
           kind: 'removed',
-          before: '1111111111111111111111111111111111111111',
+          before: '11111111',
         },
       },
       submodules: baseOverview,

--- a/src/workstation/runtime/repoFrameDrillIn.test.ts
+++ b/src/workstation/runtime/repoFrameDrillIn.test.ts
@@ -1,0 +1,140 @@
+import { resolveCommitDiffDrillInTarget } from './repoFrameDrillIn'
+
+const baseOverview = {
+  hasSubmodules: true,
+  entries: [
+    {
+      name: 'vendor/lib',
+      path: 'vendor/lib',
+      pinnedSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      flag: 'clean' as const,
+      trackingBranch: 'main',
+      url: '/abs/source/vendor/lib',
+    },
+    {
+      name: 'tools',
+      path: 'packages/tools',
+      pinnedSha: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      flag: 'clean' as const,
+    },
+  ],
+}
+
+describe('resolveCommitDiffDrillInTarget', () => {
+  it('returns undefined when activeRepoRoot is unknown (boot in flight)', () => {
+    expect(resolveCommitDiffDrillInTarget({
+      selectedFile: { path: 'vendor/lib' },
+      submodules: baseOverview,
+      activeRepoRoot: undefined,
+    })).toBeUndefined()
+  })
+
+  it('returns undefined when submodules overview is unknown', () => {
+    expect(resolveCommitDiffDrillInTarget({
+      selectedFile: { path: 'vendor/lib' },
+      submodules: undefined,
+      activeRepoRoot: '/abs/coco',
+    })).toBeUndefined()
+  })
+
+  it('returns undefined when no submodules are registered', () => {
+    expect(resolveCommitDiffDrillInTarget({
+      selectedFile: { path: 'vendor/lib' },
+      submodules: { hasSubmodules: false, entries: [] },
+      activeRepoRoot: '/abs/coco',
+    })).toBeUndefined()
+  })
+
+  it('returns undefined when the cursored path is not a submodule', () => {
+    expect(resolveCommitDiffDrillInTarget({
+      selectedFile: { path: 'src/index.ts' },
+      submodules: baseOverview,
+      activeRepoRoot: '/abs/coco',
+    })).toBeUndefined()
+  })
+
+  it('resolves a modified-submodule entry with label / workdir / entryRange', () => {
+    const target = resolveCommitDiffDrillInTarget({
+      selectedFile: {
+        path: 'vendor/lib',
+        submoduleChange: {
+          kind: 'modified',
+          before: '1111111111111111111111111111111111111111',
+          after: '2222222222222222222222222222222222222222',
+        },
+      },
+      submodules: baseOverview,
+      activeRepoRoot: '/abs/coco',
+    })
+    expect(target).toEqual({
+      label: 'vendor/lib',
+      workdir: '/abs/coco/vendor/lib',
+      entryRange: {
+        oldSha: '1111111111111111111111111111111111111111',
+        newSha: '2222222222222222222222222222222222222222',
+      },
+    })
+  })
+
+  it('resolves a submodule whose path nests under a subdirectory', () => {
+    const target = resolveCommitDiffDrillInTarget({
+      selectedFile: {
+        path: 'packages/tools',
+        submoduleChange: {
+          kind: 'modified',
+          before: 'cccccccccccccccccccccccccccccccccccccccc',
+          after: 'dddddddddddddddddddddddddddddddddddddddd',
+        },
+      },
+      submodules: baseOverview,
+      activeRepoRoot: '/abs/coco',
+    })
+    expect(target?.workdir).toBe('/abs/coco/packages/tools')
+    expect(target?.label).toBe('tools')
+  })
+
+  it('omits entryRange for an added submodule (no before sha)', () => {
+    const target = resolveCommitDiffDrillInTarget({
+      selectedFile: {
+        path: 'vendor/lib',
+        submoduleChange: {
+          kind: 'added',
+          after: '2222222222222222222222222222222222222222',
+        },
+      },
+      submodules: baseOverview,
+      activeRepoRoot: '/abs/coco',
+    })
+    expect(target?.entryRange).toBeUndefined()
+    expect(target?.label).toBe('vendor/lib')
+    expect(target?.workdir).toBe('/abs/coco/vendor/lib')
+  })
+
+  it('omits entryRange for a removed submodule (no after sha)', () => {
+    const target = resolveCommitDiffDrillInTarget({
+      selectedFile: {
+        path: 'vendor/lib',
+        submoduleChange: {
+          kind: 'removed',
+          before: '1111111111111111111111111111111111111111',
+        },
+      },
+      submodules: baseOverview,
+      activeRepoRoot: '/abs/coco',
+    })
+    expect(target?.entryRange).toBeUndefined()
+  })
+
+  it('omits entryRange when submoduleChange is missing entirely', () => {
+    // Possible when the file preview hasn't been fetched yet but the
+    // user still triggers Enter. We resolve the frame label / workdir
+    // from the overview so the drill-in can proceed without the range.
+    const target = resolveCommitDiffDrillInTarget({
+      selectedFile: { path: 'vendor/lib' },
+      submodules: baseOverview,
+      activeRepoRoot: '/abs/coco',
+    })
+    expect(target?.entryRange).toBeUndefined()
+    expect(target?.label).toBe('vendor/lib')
+  })
+})

--- a/src/workstation/runtime/repoFrameDrillIn.ts
+++ b/src/workstation/runtime/repoFrameDrillIn.ts
@@ -1,0 +1,91 @@
+import { join } from 'path'
+import type { SubmoduleChange } from '../../git/submoduleDiff'
+import type { GitCommitFilePreview } from '../../commands/log/data'
+import type { LogInkRepoFrameEntryRange } from '../../commands/log/inkViewModel'
+import { findSubmoduleByPath, type SubmoduleOverview } from '../../git/submoduleData'
+
+/**
+ * Resolved target for a commit-diff drill-in (#931 PR 3b). When the
+ * user presses Enter on a file row in the diff view AND that file is
+ * a submodule (gitlink), the runtime builds one of these and dispatches
+ * a matching `pushRepoFrame` action. Undefined means "the cursored
+ * file is not a drill-in candidate" — the input handler falls through
+ * to its usual diff-view Enter behavior.
+ */
+export type CommitDiffSubmoduleDrillInTarget = {
+  /** Display label for the new frame — the submodule's name from `.gitmodules`. */
+  label: string
+  /**
+   * Absolute working-directory path for `simpleGit(workdir)`. Resolved
+   * against the current frame's repo root so this helper stays usable
+   * for recursive submodule drill-ins (a sub-submodule's workdir is
+   * `${parentSubmoduleAbsolutePath}/${subPath}`).
+   */
+  workdir: string
+  /**
+   * The `(oldPin, newPin)` sha pair captured at push time. Drives the
+   * breadcrumb hint and the default landing view scoped to that range.
+   * Undefined when the diff is an `added` submodule (no oldPin) or
+   * `removed` (no newPin) — those drill-ins still work but land on
+   * the submodule's full history without a range filter.
+   */
+  entryRange?: LogInkRepoFrameEntryRange
+}
+
+export type ResolveDrillInArgs = {
+  /** The file the diff-view cursor is on. */
+  selectedFile: Pick<GitCommitFilePreview, 'path' | 'submoduleChange'>
+  /** Submodule overview loaded from `getSubmoduleOverview` for the active frame. */
+  submodules: SubmoduleOverview | undefined
+  /** Active frame's repo root (resolved from `git.revparse --show-toplevel`). */
+  activeRepoRoot: string | undefined
+}
+
+/**
+ * Pure resolver: given the cursored file + the active frame's
+ * submodule overview + repo root, decide whether a commit-diff Enter
+ * keystroke should drill into a submodule and, if so, what payload
+ * the `pushRepoFrame` action should carry.
+ *
+ * Returns undefined when:
+ *   - We don't know the active repo root yet (boot still in flight).
+ *   - The file's path doesn't correspond to a registered submodule.
+ *   - The submodule overview hasn't loaded yet for the active frame.
+ *
+ * The `submoduleChange` on the file preview is the source of truth
+ * for the entry range; we never need to re-run the diff to populate
+ * the (oldSha, newSha) pair.
+ */
+export function resolveCommitDiffDrillInTarget(
+  args: ResolveDrillInArgs,
+): CommitDiffSubmoduleDrillInTarget | undefined {
+  const { selectedFile, submodules, activeRepoRoot } = args
+  if (!activeRepoRoot) return undefined
+  if (!submodules || !submodules.hasSubmodules) return undefined
+
+  const entry = findSubmoduleByPath(submodules, selectedFile.path)
+  if (!entry) return undefined
+
+  return {
+    label: entry.name,
+    workdir: join(activeRepoRoot, entry.path),
+    entryRange: deriveEntryRange(selectedFile.submoduleChange),
+  }
+}
+
+/**
+ * Convert the structured `SubmoduleChange` (from `extractSubmoduleChange`)
+ * into the `entryRange` shape `LogInkRepoFrame` carries. Modified
+ * submodules surface both shas; added / removed surface only one,
+ * which isn't enough to scope a history range — those cases return
+ * undefined and the frame lands on the submodule's full history.
+ */
+function deriveEntryRange(
+  change: SubmoduleChange | undefined,
+): LogInkRepoFrameEntryRange | undefined {
+  if (!change) return undefined
+  if (change.kind === 'modified') {
+    return { oldSha: change.before, newSha: change.after }
+  }
+  return undefined
+}


### PR DESCRIPTION
## Summary

Wires the **first user-visible drill-in entry point** for the nested-repo navigation work. With the runtime parallel structure online (#985) and the breadcrumb / Esc auto-pop already in (#984), this PR closes the loop:

1. User opens a commit's diff (e.g. `chore: add vendor/lib submodule`)
2. Cursor lands on the `vendor/lib` file row — the runtime sees that row is a registered submodule and resolves a drill-in target
3. **Enter** dispatches `pushRepoFrame` with the submodule's name, absolute workdir, and (when present) the `(oldPin, newPin)` entry range
4. The runtime sync effect builds a fresh `SimpleGit(workdir)` for the new frame; existing loader effects re-fire against it; the breadcrumb shows `coco › vendor/lib   ← esc`; the user can navigate the submodule's commits / files / branches as if they had `cd vendor/lib && coco ui`
5. **Esc / `<`** walks back out to the parent's cached frame

## What's in this PR

### Data layer ([data.ts](src/commands/log/data.ts))

`getCommitFilePreview` now surfaces the raw `SubmoduleChange` alongside the summarized hunks (additive — the existing `hunks` summary is unchanged). The structured before/after shas drive the entry range without re-running the diff extraction.

### Runtime helper ([repoFrameDrillIn.ts](src/workstation/runtime/repoFrameDrillIn.ts))

`resolveCommitDiffDrillInTarget(args)` — pure resolver. Decides whether the cursored file is a drill-in candidate. Returns undefined in five distinct edge cases so the input handler can fall through cleanly:

- No repo root yet (boot still in flight)
- No submodule overview yet
- Overview is loaded but no submodules registered
- File path doesn't correspond to a submodule
- Submodule change kind is `added` / `removed` (no full range) — the drill-in still works, the entry range just doesn't fill in

### App.ts integration

- Resolves the active frame's repo root via `git.revparse --show-toplevel` on every git swap (push / pop / boot), stores it as React state
- Threads the resolver's output through the input dispatch context as `commitDiffSubmoduleDrillIn`

### Input handler ([inkInput.ts](src/commands/log/inkInput.ts))

New Enter clause, ordered before the generic file-list Enter handler so the drill-in takes precedence over the detail-panel diff-refocus path. Gated on `diffSource === 'commit'` so the worktree-diff view never accidentally fires.

## Test plan

`npm run test:jest` — 173 suites, **2019 passed** (+17 new):

- **`repoFrameDrillIn.test.ts`** (8): pure resolver contracts — undefined on missing repo root / overview / non-submodule path; modified / added / removed paths; nested-path workdir resolution; missing `submoduleChange` falls back without range.
- **`data.test.ts`** (4): `getCommitFilePreview` surfaces `submoduleChange` for modified / added / removed; undefined for non-submodule files.
- **`inkInput.test.ts`** (5): Enter dispatch with full payload; no-drill-in fallthrough; worktree-source gating; end-to-end reducer apply lands on history with `parentReturn` snapshot; range-less push for added submodules.

Manual smoke against the [`submodule-with-history`](src/lib/testUtils/scenarios/submodule-with-history.ts) scenario from #981 confirms the diff shape (`+Subproject commit ...` for the submodule-add commit) matches the resolver's `added`-case path.

Full validation green:
- [x] `npm run lint`
- [x] `npm run test:jest` — 173 suites, 2019 passed
- [x] `npm run build` (no schema regen)
- [x] `npm run test:cli` — 10/10
- [x] `npm run release:dry-run`

## What's next

- **PR 4** — Drill-in from the dedicated submodules view (#932): pressing Enter on a submodule row in the `gM` view pushes a frame against that submodule's workdir. Same plumbing as this PR; new entry point.
- **PR 5** — Polish: cache-aware pop (don't refetch parent context when already loaded), in-flight load tagging to close the refresh-during-push race, breadcrumb-key updates to persistence so per-frame sidebar tab state survives, docs.

Refs #931, builds on #941 / #982 / #983 / #984 / #985.