### PR TITLE
feat(log-tui): submodules-view drill-in (#931 PR 4)

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -1246,6 +1246,113 @@ describe('log Ink input interactions', () => {
       expect(state.repoStack).toHaveLength(2)
     })
 
+    describe('submodules-view drill-in (PR 4 / #932)', () => {
+      function submodulesViewState() {
+        return createLogInkState(rows, {
+          activeView: 'submodules',
+          repoLabel: 'coco',
+          repoWorkdir: '/abs/coco',
+        })
+      }
+
+      it('Enter on a submodule row dispatches pushRepoFrame with label + workdir', () => {
+        const state = submodulesViewState()
+        const events = getLogInkInputEvents(state, '', { return: true }, {
+          submoduleCount: 1,
+          submoduleSelectedPath: 'vendor/lib',
+          submoduleViewDrillIn: {
+            label: 'vendor/lib',
+            workdir: '/abs/coco/vendor/lib',
+          },
+        })
+        const actionEvents = events
+          .filter((event): event is Extract<typeof event, { type: 'action' }> => event.type === 'action')
+          .map((event) => event.action)
+        const push = actionEvents.find((a) => a.type === 'pushRepoFrame')
+        expect(push).toEqual({
+          type: 'pushRepoFrame',
+          label: 'vendor/lib',
+          workdir: '/abs/coco/vendor/lib',
+        })
+        // No entryRange — the submodules view doesn't carry diff context.
+        expect((push as { entryRange?: unknown })?.entryRange).toBeUndefined()
+        const status = actionEvents.find((a) => a.type === 'setStatus')
+        expect(status).toEqual({ type: 'setStatus', value: 'entering submodule vendor/lib' })
+      })
+
+      it('Enter without a drill-in target on the submodules view does NOT push a frame', () => {
+        const state = submodulesViewState()
+        const events = getLogInkInputEvents(state, '', { return: true }, {
+          submoduleCount: 1,
+          submoduleSelectedPath: 'vendor/lib',
+          // No submoduleViewDrillIn (e.g., repo root not loaded yet).
+        })
+        const types = events
+          .filter((event): event is Extract<typeof event, { type: 'action' }> => event.type === 'action')
+          .map((event) => event.action.type)
+        expect(types).not.toContain('pushRepoFrame')
+      })
+
+      it('Enter on the submodules view when focus is on the sidebar does NOT drill in', () => {
+        // isSubmodulesActionTarget gates on focus === 'commits'; if the
+        // user is still in the sidebar, the drill-in handler shouldn't
+        // claim the keystroke — the sidebar's Enter handler does.
+        let state = submodulesViewState()
+        state = applyLogInkAction(state, { type: 'setFocus', value: 'sidebar' })
+        const events = getLogInkInputEvents(state, '', { return: true }, {
+          submoduleCount: 1,
+          submoduleViewDrillIn: {
+            label: 'vendor/lib',
+            workdir: '/abs/coco/vendor/lib',
+          },
+        })
+        const types = events
+          .filter((event): event is Extract<typeof event, { type: 'action' }> => event.type === 'action')
+          .map((event) => event.action.type)
+        expect(types).not.toContain('pushRepoFrame')
+      })
+
+      it('Enter dispatch + reducer apply lands on history with parent return snapshot', () => {
+        let state = submodulesViewState()
+        const events = getLogInkInputEvents(state, '', { return: true }, {
+          submoduleCount: 2,
+          submoduleViewDrillIn: {
+            label: 'vendor/lib',
+            workdir: '/abs/coco/vendor/lib',
+          },
+        })
+        state = events
+          .filter((event): event is Extract<typeof event, { type: 'action' }> => event.type === 'action')
+          .reduce((curr, event) => applyLogInkAction(curr, event.action), state)
+
+        expect(state.repoStack).toHaveLength(2)
+        expect(state.repoStack[1].label).toBe('vendor/lib')
+        expect(state.repoStack[1].workdir).toBe('/abs/coco/vendor/lib')
+        expect(state.repoStack[1].entryRange).toBeUndefined()
+        expect(state.activeView).toBe('history')
+        // parentReturn captures activeView=submodules so Esc walks back.
+        expect(state.repoStack[1].parentReturn?.activeView).toBe('submodules')
+      })
+
+      it('Enter on history view does NOT trigger submodule drill-in even if context payload is set', () => {
+        // Defensive: if a stale drill-in payload arrives while the user
+        // is on history, the activeView gate keeps the handler from
+        // firing — the history-Enter (open-diff) handler claims it.
+        const state = createLogInkState(rows, { activeView: 'history', repoLabel: 'coco' })
+        const events = getLogInkInputEvents(state, '', { return: true }, {
+          submoduleCount: 1,
+          submoduleViewDrillIn: {
+            label: 'vendor/lib',
+            workdir: '/abs/coco/vendor/lib',
+          },
+        })
+        const types = events
+          .filter((event): event is Extract<typeof event, { type: 'action' }> => event.type === 'action')
+          .map((event) => event.action.type)
+        expect(types).not.toContain('pushRepoFrame')
+      })
+    })
+
     describe('commit-diff drill-in (PR 3b)', () => {
       function commitDiffState() {
         const state = createLogInkState(rows, { activeView: 'diff', repoLabel: 'coco', repoWorkdir: '/abs/coco' })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -167,6 +167,18 @@ export type LogInkInputContext = {
     entryRange?: { oldSha: string; newSha: string }
   }
   /**
+   * Resolved drill-in target for the row currently under the cursor in
+   * the dedicated submodules view (#931 PR 4 / #932). Set by the runtime
+   * when the cursored entry has a workdir AND the active frame's repo
+   * root has been resolved; undefined otherwise. The Enter handler in
+   * the submodules view dispatches `pushRepoFrame` with this payload —
+   * no entry range because there's no diff context in this view.
+   */
+  submoduleViewDrillIn?: {
+    label: string
+    workdir: string
+  }
+  /**
    * True when the worktree has any staged, unstaged, or untracked changes.
    * Drives the synthetic "(+) new commit" row at the top of the history
    * list — pressing up at `selectedIndex === 0` transitions onto it; the
@@ -2136,6 +2148,28 @@ export function getLogInkInputEvents(
         label: target.label,
         workdir: target.workdir,
         entryRange: target.entryRange,
+      }),
+      action({ type: 'setStatus', value: `entering submodule ${target.label}` }),
+    ]
+  }
+
+  // #931 PR 4 / #932 — Enter on a row in the dedicated submodules view
+  // drills into that submodule's history. Same mental model as the
+  // commit-diff drill-in (PR 3b) — pushing a frame is the equivalent
+  // of `cd vendor/lib && coco ui`. No entry range here; the submodules
+  // view doesn't carry diff context, so the frame lands on the
+  // submodule's full history.
+  if (
+    key.return &&
+    isSubmodulesActionTarget(state) &&
+    context.submoduleViewDrillIn
+  ) {
+    const target = context.submoduleViewDrillIn
+    return [
+      action({
+        type: 'pushRepoFrame',
+        label: target.label,
+        workdir: target.workdir,
       }),
       action({ type: 'setStatus', value: `entering submodule ${target.label}` }),
     ]

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -92,7 +92,10 @@ import { hasSeenOnboarding, markOnboardingSeen } from '../chrome/onboarding'
 import { formatSplitApplySuccess } from '../chrome/postApplyHints'
 import { SPINNER_TICK_MS } from '../chrome/spinner'
 import { createInitialContextStatus, createRepoFrameRuntime } from './repoFrameFactory'
-import { resolveCommitDiffDrillInTarget } from './repoFrameDrillIn'
+import {
+  resolveCommitDiffDrillInTarget,
+  resolveSubmoduleViewDrillInTarget,
+} from './repoFrameDrillIn'
 import {
   getActiveRepoFrameRuntime,
   syncRepoStackRuntimes,
@@ -3656,6 +3659,20 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
                 ? filePreview.submoduleChange
                 : undefined,
             },
+            submodules: context.submodules,
+            activeRepoRoot,
+          })
+        : undefined,
+      // #931 PR 4 / #932 — Submodule drill-in target for the cursored
+      // row in the dedicated submodules view. Resolved per-render so
+      // the Enter handler in `inkInput.ts` doesn't have to re-walk the
+      // submodule overview. Gated on `activeView === 'submodules'` so
+      // a stale resolution from a different view can't accidentally
+      // fire — the runtime only ever populates it when the user is
+      // actually on the view.
+      submoduleViewDrillIn: state.activeView === 'submodules'
+        ? resolveSubmoduleViewDrillInTarget({
+            selectedIndex: state.selectedSubmoduleIndex,
             submodules: context.submodules,
             activeRepoRoot,
           })

--- a/src/workstation/runtime/repoFrameDrillIn.test.ts
+++ b/src/workstation/runtime/repoFrameDrillIn.test.ts
@@ -1,4 +1,7 @@
-import { resolveCommitDiffDrillInTarget } from './repoFrameDrillIn'
+import {
+  resolveCommitDiffDrillInTarget,
+  resolveSubmoduleViewDrillInTarget,
+} from './repoFrameDrillIn'
 
 const baseOverview = {
   hasSubmodules: true,
@@ -136,5 +139,87 @@ describe('resolveCommitDiffDrillInTarget', () => {
     })
     expect(target?.entryRange).toBeUndefined()
     expect(target?.label).toBe('vendor/lib')
+  })
+})
+
+describe('resolveSubmoduleViewDrillInTarget (#931 PR 4)', () => {
+  it('returns undefined when activeRepoRoot is unknown (boot in flight)', () => {
+    expect(resolveSubmoduleViewDrillInTarget({
+      selectedIndex: 0,
+      submodules: baseOverview,
+      activeRepoRoot: undefined,
+    })).toBeUndefined()
+  })
+
+  it('returns undefined when the submodule overview is unknown', () => {
+    expect(resolveSubmoduleViewDrillInTarget({
+      selectedIndex: 0,
+      submodules: undefined,
+      activeRepoRoot: '/abs/coco',
+    })).toBeUndefined()
+  })
+
+  it('returns undefined when no submodules are registered', () => {
+    expect(resolveSubmoduleViewDrillInTarget({
+      selectedIndex: 0,
+      submodules: { hasSubmodules: false, entries: [] },
+      activeRepoRoot: '/abs/coco',
+    })).toBeUndefined()
+  })
+
+  it('returns undefined when the cursor is past the end of the entries', () => {
+    expect(resolveSubmoduleViewDrillInTarget({
+      selectedIndex: 99,
+      submodules: baseOverview,
+      activeRepoRoot: '/abs/coco',
+    })).toBeUndefined()
+  })
+
+  it('returns undefined when the cursored entry has no path', () => {
+    const overview = {
+      hasSubmodules: true,
+      entries: [{
+        name: 'orphan',
+        path: '',
+        pinnedSha: 'cccccccc',
+        flag: 'clean' as const,
+      }],
+    }
+    expect(resolveSubmoduleViewDrillInTarget({
+      selectedIndex: 0,
+      submodules: overview,
+      activeRepoRoot: '/abs/coco',
+    })).toBeUndefined()
+  })
+
+  it('resolves the first entry with label + absolute workdir', () => {
+    expect(resolveSubmoduleViewDrillInTarget({
+      selectedIndex: 0,
+      submodules: baseOverview,
+      activeRepoRoot: '/abs/coco',
+    })).toEqual({
+      label: 'vendor/lib',
+      workdir: '/abs/coco/vendor/lib',
+    })
+  })
+
+  it('resolves a nested-path entry against the active repo root', () => {
+    expect(resolveSubmoduleViewDrillInTarget({
+      selectedIndex: 1,
+      submodules: baseOverview,
+      activeRepoRoot: '/abs/coco',
+    })).toEqual({
+      label: 'tools',
+      workdir: '/abs/coco/packages/tools',
+    })
+  })
+
+  it('never carries an entryRange — the submodules view has no diff context', () => {
+    const target = resolveSubmoduleViewDrillInTarget({
+      selectedIndex: 0,
+      submodules: baseOverview,
+      activeRepoRoot: '/abs/coco',
+    })
+    expect(target).not.toHaveProperty('entryRange')
   })
 })

--- a/src/workstation/runtime/repoFrameDrillIn.ts
+++ b/src/workstation/runtime/repoFrameDrillIn.ts
@@ -89,3 +89,56 @@ function deriveEntryRange(
   }
   return undefined
 }
+
+/**
+ * Drill-in target for the dedicated submodules view (#931 PR 4 / #932).
+ * Same shape as the commit-diff drill-in but without the `entryRange`
+ * field — the submodules view doesn't carry diff context, so the frame
+ * lands on the submodule's full history rather than a (oldPin, newPin)
+ * range.
+ */
+export type SubmoduleViewDrillInTarget = {
+  label: string
+  workdir: string
+}
+
+export type ResolveSubmoduleViewDrillInArgs = {
+  /** Index of the cursored row in the submodules view (`state.selectedSubmoduleIndex`). */
+  selectedIndex: number
+  /** Submodule overview loaded from `getSubmoduleOverview` for the active frame. */
+  submodules: SubmoduleOverview | undefined
+  /** Active frame's repo root (resolved from `git.revparse --show-toplevel`). */
+  activeRepoRoot: string | undefined
+}
+
+/**
+ * Pure resolver for the submodules-view drill-in (#931 PR 4 / #932).
+ * Given the cursored row index + the submodule overview + the active
+ * frame's repo root, build the `pushRepoFrame` payload Enter should
+ * dispatch. Returns undefined when:
+ *
+ *   - The active repo root hasn't loaded yet.
+ *   - The submodule overview hasn't loaded (or is empty).
+ *   - The cursor is past the end of the entries (race between a
+ *     refresh that removed a submodule and a key press still in
+ *     flight against the old length).
+ *   - The cursored entry has no `path` recorded. The `.gitmodules`
+ *     parser already filters these out upstream, but the resolver
+ *     defends against it so the cursor can't yank the user into a
+ *     workdir-less frame.
+ */
+export function resolveSubmoduleViewDrillInTarget(
+  args: ResolveSubmoduleViewDrillInArgs,
+): SubmoduleViewDrillInTarget | undefined {
+  const { selectedIndex, submodules, activeRepoRoot } = args
+  if (!activeRepoRoot) return undefined
+  if (!submodules || !submodules.hasSubmodules) return undefined
+
+  const entry = submodules.entries[selectedIndex]
+  if (!entry || !entry.path) return undefined
+
+  return {
+    label: entry.name,
+    workdir: join(activeRepoRoot, entry.path),
+  }
+}


### PR DESCRIPTION
## Summary

Second drill-in entry point: Enter on a row in the dedicated submodules view (`gM` / #932) pushes a nested frame against that submodule, mirroring the commit-diff drill-in shipped in #986.

Symmetric to PR 3b but without the entry-range concept — the submodules view doesn't carry diff context, so the frame lands on the submodule's full history rather than a `(oldPin, newPin)` range. Users who want the ranged lens trigger it from the commit diff.

## What's in this PR

### Pure resolver ([repoFrameDrillIn.ts](src/workstation/runtime/repoFrameDrillIn.ts))

`resolveSubmoduleViewDrillInTarget(args)` next to the existing commit-diff resolver. Same shape, same "five edge cases return undefined" contract:

- Active repo root unknown (boot in flight)
- Submodule overview unknown
- No submodules registered
- Cursor past the end of the entries (refresh race)
- Cursored entry has no `path` recorded

### Input context ([inkInput.ts](src/commands/log/inkInput.ts))

New `submoduleViewDrillIn?: { label, workdir }` field on `LogInkInputContext`. Populated per-render by `app.ts` when `state.activeView === 'submodules'`.

### Input handler

New Enter clause gated on `isSubmodulesActionTarget(state)` + the resolved drill-in payload. Sits alongside the PR 3b commit-diff clause; both share the `entering submodule <label>` status hint shape so the chrome feels consistent across entry points.

### App.ts wiring

The resolver result threads through the input dispatch context. Gated on `state.activeView === 'submodules'` so a stale resolution from a different view can't accidentally fire.

## Test plan

`npm run test:jest` — 173 suites, **2032 passed** (+13 new):

- **`repoFrameDrillIn.test.ts`** (8): pure resolver — undefined on missing repo root / overview / no submodules / cursor past end / pathless entry; resolves first / nested-path entries; never carries an `entryRange` field.
- **`inkInput.test.ts`** (5): Enter dispatch with payload; no-drill-in fallthrough; sidebar-focus gating; end-to-end reducer apply lands on history with `activeView: 'submodules'` captured in `parentReturn` (so Esc walks back to the submodules view); active-view gate keeps a stale history-view dispatch from accidentally firing.

Full validation green:
- [x] `npm run lint`
- [x] `npm run test:jest` — 173 suites, 2032 passed
- [x] `npm run build` (no schema regen)
- [x] `npm run test:cli` — 10/10
- [x] `npm run release:dry-run`

## What's next

- **PR 5** — Polish:
  - Cache-aware pop (skip refetch when parent context is already loaded)
  - In-flight load tagging to close the refresh-during-push race
  - Per-frame persistence (so a nested frame's sidebar tab / sort modes survive drill-in / drill-out)
  - Docs (CLAUDE.md + workstation README updates)

Refs #931, builds on #941 / #982 / #983 / #984 / #985 / #986.