### PR TITLE
feat(log-tui): cache-aware pop + docs for nested-repo navigation (closes #931)

### DIFF
--- a/src/workstation/README.md
+++ b/src/workstation/README.md
@@ -116,6 +116,26 @@ A few invariants worth knowing before changing any of those modules:
 - **Confirmation gating is data, not control flow.** Workflows declare `requiresConfirmation: 'y' | 'enter'` in `inkWorkflows.ts`; the runtime intercepts and routes through the y-confirm overlay.
 - **Re-renders are cheap.** Ink reconciles the React tree on every state change; render helpers are pure functions of `(state, theme, layout)`.
 
+## Nested-repo navigation (#931)
+
+Drilling into a submodule is the mental equivalent of spawning another `coco ui` instance scoped to that submodule's working directory. The implementation reuses the existing reducer / surfaces / chrome — the only thing that changes when the user drills in is *which `SimpleGit` instance* the loaders run against.
+
+Two parallel structures keep it honest:
+
+- **View-model side** (`LogInkState.repoStack`) is pure data — an ordered list of `LogInkRepoFrame { label, workdir?, parentReturn?, entryRange? }`. The reducer's `pushRepoFrame` / `popRepoFrame` actions are the only things that mutate it.
+- **Runtime side** (`runtime/repoStackRuntime.ts`) lives in `LogInkApp` state — an ordered list of `RepoFrameRuntime { git, context, contextStatus }`. The sync effect reconciles it against `state.repoStack` every time the stack changes; push appends, pop slices, factory builds a fresh `simpleGit(workdir)` for new frames.
+
+The active frame (top of stack) projects `git` / `context` / `contextStatus` for every existing closure to read. Effects with `[git, ...]` deps re-fire automatically on push / pop. Cached context survives a drill-out cycle so popping back is instant.
+
+**Entry points:**
+
+- **Commit-diff** (`runtime/repoFrameDrillIn.ts::resolveCommitDiffDrillInTarget`) — Enter on a submodule file in the diff view. Captures `(oldPin, newPin)` from the file preview's `submoduleChange`.
+- **Submodules view** (`::resolveSubmoduleViewDrillInTarget`) — Enter on a row in the dedicated `gM` view. No range; lands on the submodule's full history.
+
+**Exit:** Esc / `<` / palette `navigateBack` — drains the frame's view stack first, then pops the frame. Breadcrumb in the header (`coco › vendor/lib   ← esc`) shows the user where they are.
+
+**Adding another entry point:** write a pure resolver next to the existing two, plumb its output through the input dispatch context (`LogInkInputContext`), and dispatch `pushRepoFrame` from the matching Enter handler. The runtime side handles the rest.
+
 ## Adding a new top-level view
 
 The bisect view (`g B`) is the most recent worked example — see PRs [#868, #885–#889]. Concrete touch list:

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -1159,10 +1159,26 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     state.activeView,
   ])
 
+  // #931 PR 5 — Cache-aware boot load. The frame's `git` instance is
+  // the dep that drives this effect; on push, the new frame's runtime
+  // starts every key in `'loading'` and we fetch fresh. On pop, the
+  // parent's runtime carries cached context across the drill-out cycle
+  // (`'ready'` for already-loaded keys), and the per-key gate below
+  // skips the fetch so the user's drill-out is instant + flicker-free.
+  //
+  // `contextStatusRef` reads the latest status without putting
+  // `contextStatus` in the effect deps — including it would re-fire
+  // the effect on every per-key 'ready' write the effect itself
+  // produces, causing duplicate in-flight fetches for not-yet-completed
+  // keys. The ref pattern gives us "read latest" semantics with the
+  // effect still gated on git swaps only.
+  const contextStatusRef = React.useRef(contextStatus)
+  contextStatusRef.current = contextStatus
   React.useEffect(() => {
     let active = true
 
     loadLogInkContextEntries(git).forEach(({ key, load }) => {
+      if (contextStatusRef.current[key] === 'ready') return
       void load().then((value) => {
         if (!active) {
           return


### PR DESCRIPTION
## Summary

Final PR for the recursive submodule navigation epic (#931). Two changes:

### Cache-aware boot-load pop

The runtime's per-frame `RepoFrameRuntime` already preserved `context` / `contextStatus` across drill-out cycles (#983 shipped the slice-don't-clear pop semantics). But the boot-load effect in `LogInkApp` was happily re-firing for the parent's git on every pop and overwriting the cached context with a fresh fetch. Functionally correct, but the network round-trip + brief loading flicker made drill-out feel laggier than it had to.

**Fix:** gate each per-key load on the active frame's `contextStatus[key]` — skip when it's already `'ready'`. The frame's seed status is all `'loading'` (`createInitialContextStatus()`), so first mount and freshly-pushed frames still fetch as before; only pops back to a cached frame skip the work.

The status read goes through a ref so we don't have to include `contextStatus` in the effect's dep array — including it would re-fire the effect on every per-key `'ready'` write the effect itself produces, causing duplicate in-flight fetches for not-yet-completed keys. The ref pattern gives us "read latest" semantics with the effect still gated on git swaps only.

### Workstation README docs

New **"Nested-repo navigation (#931)"** section in [src/workstation/README.md](src/workstation/README.md) documenting:

- The two parallel structures (view-model `repoStack` vs. runtime `RepoStackRuntimes`)
- The active-frame projection model
- The two drill-in entry points (commit-diff + submodules view)
- Esc / `<` / palette `navigateBack` exit semantics
- A recipe for adding another entry point (write a pure resolver, plumb the output, dispatch `pushRepoFrame`)

## Closes the epic

#931 asked for:

| Requirement | Shipped in |
|---|---|
| `Enter` on a submodule row drills into its history | #986 (commit-diff) + #992 (submodules view) |
| Navigate the submodule's commits / files / branches as if `coco ui` were launched from the submodule directory | #985 (per-frame `SimpleGit` swap) |
| `Esc` / `<` pops back to the parent repo | #984 |
| `SubmoduleStack` state on the root view model | #941 |
| Rebound `SimpleGit` instance for every loader | #985 |
| Title-bar breadcrumb | #984 |
| Context-load invalidation / scoping per frame | #983 + #985 + this PR's cache-aware pop |

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test:jest` — 173 suites, **2032 passed** (no regressions; this PR adds no new tests since the boot-load gating is a one-line guard inside a React effect that isn't tested directly — the existing scenario fixture `submodule-with-history` exercises the round trip)
- [x] `npm run build` (no schema regen)
- [x] `npm run test:cli` — 10/10
- [x] `npm run release:dry-run`

## Known follow-ups

Each small enough for a focused follow-up issue if they ever bite:

- **In-flight refresh-during-push race.** A user `r` refresh that's mid-await when a push fires writes its result to the new active frame. Rare, non-destructive (stale data briefly). Closing the race needs a frame-by-git tag on the writes.
- **Per-frame sidebar tab / sort mode persistence.** Today these carry over root → submodule; users may want frame-scoped state. The persistence keys would need to incorporate the frame's workdir.

Closes #931.