### PR TITLE
chore: bump @gfargo/git-scenarios to ^0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@commitlint/types": "^20.5.0",
-    "@gfargo/git-scenarios": "^0.1.0",
+    "@gfargo/git-scenarios": "^0.1.1",
     "@rollup/plugin-commonjs": "^29.0.0",
     "@rollup/plugin-eslint": "^9.0.5",
     "@rollup/plugin-json": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -653,10 +653,10 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
-"@gfargo/git-scenarios@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@gfargo/git-scenarios/-/git-scenarios-0.1.0.tgz#a6d703e935734f6deb66ddc06049fc25ea75bc1c"
-  integrity sha512-ZhgXUQ7+8P4H0a2orNqT68Ixyxxqdov5qvbgxCIPXKz+GCxoAscQeNKDC9JRUNfLn39Vt8Zf63TRNarbeDoRGg==
+"@gfargo/git-scenarios@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@gfargo/git-scenarios/-/git-scenarios-0.1.1.tgz#28912fc29ed0238a5a197068979b50316fa2747a"
+  integrity sha512-54fnJt3WeZors0JhGbbAGvcRLXWKjJv19J6Z3r4SO29laClZ4OgdryFGfilBoapWMR1vW5XKsQ/7r6kWRlB3fQ==
 
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"


### PR DESCRIPTION
Pulls in the submodule-clone identity fix from `@gfargo/git-scenarios` v0.1.1 (https://github.com/gfargo/git-scenarios/releases/tag/v0.1.1). Coco's existing tests don't currently exercise the buggy code path (\`insideSubmodule(path, addCommit(...))\`), but future scenarios that do will get the fix automatically via the caret range.

Follow-up to #997 (which merged at v0.1.0 before this bump landed on the branch).

## Test plan

- [x] `yarn install` resolves @gfargo/git-scenarios@0.1.1
- [x] `npm run lint` clean
- [x] `npm run test:jest` — 160 suites / 1973 tests passing