### PR TITLE
chore: bump @gfargo/git-scenarios to ^0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@commitlint/types": "^20.5.0",
-    "@gfargo/git-scenarios": "^0.1.1",
+    "@gfargo/git-scenarios": "^0.2.0",
     "@rollup/plugin-commonjs": "^29.0.0",
     "@rollup/plugin-eslint": "^9.0.5",
     "@rollup/plugin-json": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -653,10 +653,10 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
-"@gfargo/git-scenarios@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@gfargo/git-scenarios/-/git-scenarios-0.1.1.tgz#28912fc29ed0238a5a197068979b50316fa2747a"
-  integrity sha512-54fnJt3WeZors0JhGbbAGvcRLXWKjJv19J6Z3r4SO29laClZ4OgdryFGfilBoapWMR1vW5XKsQ/7r6kWRlB3fQ==
+"@gfargo/git-scenarios@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@gfargo/git-scenarios/-/git-scenarios-0.2.0.tgz#7036b31404c2a54a312b94038ce9b8efa6b7c87a"
+  integrity sha512-/XX66Z7TTV4vGMWVMrlg8kF3fgU9BMjgcJ9PHvxxQfEEiYFM6/UHxvfJApKezXX6OG/HizUDhjYr3kPytcwqCA==
 
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"


### PR DESCRIPTION
Pulls in [`@gfargo/git-scenarios@0.2.0`](https://github.com/gfargo/git-scenarios/releases/tag/v0.2.0):

**New atoms unlocked for coco**
- **Rebase**: \`startRebase(onto, { allowConflict? })\`, \`abortRebase()\`, \`continueRebase()\`
- **Working tree**: \`deleteFiles(...paths)\`, \`renameFile(from, to)\`
- **Control flow**: \`conditionally(condition, step)\`

Plus the upstream README badges + cookbook entries for mid-rebase conflict and rename detection.

Coco's existing tests don't exercise the new atoms yet — this is a non-functional bump for the current test surface but unlocks the new capabilities for future scenarios.

## Test plan

- [x] \`yarn install\` resolves \`@gfargo/git-scenarios@0.2.0\`
- [x] \`npm run lint\` clean
- [x] \`npm run test:jest\` — 160 suites / 1966 tests passing (7 skipped)