### PR TITLE
feat(ui): default sidebar tab is 'branches' on first launch

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -198,18 +198,20 @@ describe('log Ink input interactions', () => {
     state = applyInput(state, 'k')
     expect(state.selectedIndex).toBe(0)
 
+    // Default sidebar tab is 'branches' — arrow / bracket navigation
+    // starts from there.
     state = applyLogInkAction(state, { type: 'setFocus', value: 'sidebar' })
     state = applyInput(state, '', { downArrow: true })
-    expect(state.sidebarTab).toBe('branches')
+    expect(state.sidebarTab).toBe('tags')
 
     state = applyInput(state, '', { upArrow: true })
-    expect(state.sidebarTab).toBe('status')
-
-    state = applyInput(state, ']')
     expect(state.sidebarTab).toBe('branches')
 
+    state = applyInput(state, ']')
+    expect(state.sidebarTab).toBe('tags')
+
     state = applyInput(state, '[')
-    expect(state.sidebarTab).toBe('status')
+    expect(state.sidebarTab).toBe('branches')
 
     state = applyInput(state, '5')
     expect(state.sidebarTab).toBe('worktrees')

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -65,7 +65,7 @@ describe('log Ink view model', () => {
     expect(state.worktreeDiffOffset).toBe(0)
     expect(state.commitCompose.summary).toBe('')
     expect(state.focus).toBe('commits')
-    expect(state.sidebarTab).toBe('status')
+    expect(state.sidebarTab).toBe('branches')
     expect(state.showHelp).toBe(false)
     expect(state.showCommandPalette).toBe(false)
     expect(state.pendingMutationConfirmation).toBeUndefined()
@@ -149,11 +149,13 @@ describe('log Ink view model', () => {
 
     expect(getLogInkSidebarTabs()).toEqual(['status', 'branches', 'tags', 'stashes', 'worktrees'])
 
+    // Default sidebar tab is 'branches' — moving next from there lands
+    // on 'tags', moving previous returns to 'branches'.
     state = applyLogInkAction(state, { type: 'nextSidebarTab' })
-    expect(state.sidebarTab).toBe('branches')
+    expect(state.sidebarTab).toBe('tags')
 
     state = applyLogInkAction(state, { type: 'previousSidebarTab' })
-    expect(state.sidebarTab).toBe('status')
+    expect(state.sidebarTab).toBe('branches')
 
     state = applyLogInkAction(state, { type: 'setSidebarTab', value: 'worktrees' })
     expect(state.sidebarTab).toBe('worktrees')

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -1187,8 +1187,13 @@ export function createLogInkState(
     pendingMutationConfirmation: undefined,
     pendingKey: undefined,
     focus: 'commits',
-    sidebarTab: 'status',
-    userSidebarTab: 'status',
+    // Default first-time tab is 'branches' — it's the most useful
+    // landing surface in the workstation (current branch + recent
+    // branches with ahead/behind, switch target, etc.). Users who
+    // pick a different tab have their choice persisted per-repo via
+    // sidebarPersistence.ts and won't see this default again.
+    sidebarTab: 'branches',
+    userSidebarTab: 'branches',
     sidebarHeaderFocused: false,
     statusGroupHeaderFocused: false,
     statusFilterMask: { ...DEFAULT_LOG_INK_STATUS_FILTER_MASK },


### PR DESCRIPTION
## Summary

- Changes the bootstrap default sidebar tab from \`status\` → \`branches\` in \`createLogInkState()\`.
- Per-repo persistence (\`sidebarPersistence.ts\`) is unchanged — existing users keep whatever tab they last had open. Only fresh runs / new clones see the new default.
- The auto-switch logic in \`inkViewModel.ts:866\` (which already preferred 'branches' when entering compose/status views) is consistent with the new default — no change needed there.

## Why

The status tab is fine but doesn't showcase the workstation when there's nothing dirty — first-time users can land on a near-empty surface. Branches is the most useful landing tab: shows the current branch with ahead/behind counts, switch targets, recent branches. This was raised as a UX gap during v0.3.0 git-scenarios planning.

## Tests

Updated two assertions to reflect the new starting tab:
- \`inkViewModel.test.ts\` — initial \`sidebarTab\` is 'branches'; next/prev navigation indexes from 'branches' (next → 'tags', prev → 'branches' loops back).
- \`inkInput.test.ts\` — same shift in arrow/bracket key expectations.

## Test plan

- [x] \`npx jest src/commands/log/inkViewModel.test.ts src/commands/log/inkInput.test.ts\` — 420 tests pass
- [ ] Manual: \`npm run scenario create feature-pr-ready -- --run-ui\` — sidebar should land on branches
- [ ] Manual: open coco ui on a repo where you previously selected a different tab — should restore your saved tab, not the new default