### PR TITLE
feat(ui): help overlay scrolls with j/k without dropping focus

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -490,6 +490,78 @@ describe('log Ink input interactions', () => {
     expect(getLogInkInputEvents(state, 'c')).toEqual([{ type: 'createManualCommit' }])
   })
 
+  describe('help overlay key handling', () => {
+    it('j/k scroll the help overlay without changing focus', () => {
+      let state = createLogInkState(rows)
+      state = applyInput(state, '?')
+      expect(state.showHelp).toBe(true)
+      const focusBefore = state.focus
+
+      state = applyInput(state, 'j')
+      expect(state.helpScrollOffset).toBe(1)
+      expect(state.focus).toBe(focusBefore)
+
+      state = applyInput(state, 'j')
+      expect(state.helpScrollOffset).toBe(2)
+
+      state = applyInput(state, 'k')
+      expect(state.helpScrollOffset).toBe(1)
+      expect(state.focus).toBe(focusBefore)
+    })
+
+    it('arrow keys scroll the help overlay', () => {
+      let state = createLogInkState(rows)
+      state = applyInput(state, '?')
+      state = applyInput(state, '', { downArrow: true })
+      expect(state.helpScrollOffset).toBe(1)
+      state = applyInput(state, '', { upArrow: true })
+      expect(state.helpScrollOffset).toBe(0)
+    })
+
+    it('Ctrl-d / Ctrl-u half-page scroll', () => {
+      let state = createLogInkState(rows)
+      state = applyInput(state, '?')
+      state = applyInput(state, 'd', { ctrl: true })
+      expect(state.helpScrollOffset).toBe(10)
+      state = applyInput(state, 'u', { ctrl: true })
+      expect(state.helpScrollOffset).toBe(0)
+    })
+
+    it('swallows non-scroll keys instead of letting them fall through', () => {
+      let state = createLogInkState(rows)
+      const originalSelectedIndex = state.selectedIndex
+      state = applyInput(state, '?')
+      expect(state.showHelp).toBe(true)
+
+      // Bracket keys would normally switch sidebar tabs — must be a no-op
+      // here. The user can't accidentally walk into a different tab from
+      // help and end up confused when they close it.
+      const sidebarBefore = state.sidebarTab
+      state = applyInput(state, ']')
+      expect(state.sidebarTab).toBe(sidebarBefore)
+      state = applyInput(state, '[')
+      expect(state.sidebarTab).toBe(sidebarBefore)
+
+      // gg would normally jump to top. Help is open, so it's a no-op.
+      state = applyInput(state, 'g')
+      state = applyInput(state, 'g')
+      expect(state.selectedIndex).toBe(originalSelectedIndex)
+
+      // /? would normally start filter mode. Help is open, so it's a no-op.
+      state = applyInput(state, '/')
+      expect(state.filterMode).toBe(false)
+      expect(state.showHelp).toBe(true)
+    })
+
+    it('? toggles help closed from within help mode', () => {
+      let state = createLogInkState(rows)
+      state = applyInput(state, '?')
+      state = applyInput(state, 'j')
+      state = applyInput(state, '?')
+      expect(state.showHelp).toBe(false)
+    })
+  })
+
   it('clears pending key chords after unrelated actions', () => {
     let state = createLogInkState(rows)
 

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -1216,8 +1216,37 @@ export function getLogInkInputEvents(
     return []
   }
 
-  if (key.escape && state.showHelp) {
-    return [action({ type: 'toggleHelp' })]
+  // Help-overlay key handling. While help is open we intercept ALL
+  // keys here and return before they can fall through to scroll /
+  // focus / navigation logic below. Without this, j/k while help is
+  // open routes into `moveDetailFile`-style handlers, which mutates
+  // focus state (`focus: 'detail'` → `'commits'` or `'sidebar'`) —
+  // exactly the "scroll loses focus" bug.
+  //
+  // Allowed: Esc / ? (close), q (quit), j/k/arrows (scroll), Ctrl-d/u
+  // (half-page). Everything else is swallowed by the trailing
+  // `return []` so a stray keypress can't drop the user into the
+  // wrong surface.
+  if (state.showHelp) {
+    if (key.escape || inputValue === '?') {
+      return [action({ type: 'toggleHelp' })]
+    }
+    if (inputValue === 'q') {
+      return [{ type: 'exit' }]
+    }
+    if (key.downArrow || inputValue === 'j') {
+      return [action({ type: 'scrollHelp', delta: 1 })]
+    }
+    if (key.upArrow || inputValue === 'k') {
+      return [action({ type: 'scrollHelp', delta: -1 })]
+    }
+    if (key.ctrl && inputValue === 'd') {
+      return [action({ type: 'scrollHelp', delta: 10 })]
+    }
+    if (key.ctrl && inputValue === 'u') {
+      return [action({ type: 'scrollHelp', delta: -10 })]
+    }
+    return []
   }
 
   // #879 item 4 — Esc cancels an in-flight bisect-start wizard. Runs

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -371,6 +371,54 @@ describe('log Ink view model', () => {
     expect(state.showCommandPalette).toBe(true)
   })
 
+  it('defaults helpScrollOffset to 0 and resets it on toggleHelp', () => {
+    let state = createLogInkState(rows)
+    expect(state.helpScrollOffset).toBe(0)
+
+    // Simulate the user opening help, scrolling, then closing it.
+    state = applyLogInkAction(state, { type: 'toggleHelp' })
+    state = applyLogInkAction(state, { type: 'scrollHelp', delta: 5 })
+    expect(state.helpScrollOffset).toBe(5)
+    state = applyLogInkAction(state, { type: 'toggleHelp' })
+    // Closing clears the offset so the next open starts at the top.
+    expect(state.showHelp).toBe(false)
+    expect(state.helpScrollOffset).toBe(0)
+
+    // Reopening keeps offset at 0.
+    state = applyLogInkAction(state, { type: 'toggleHelp' })
+    expect(state.helpScrollOffset).toBe(0)
+  })
+
+  it('scrollHelp floor-clamps at 0 (no negative offsets)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'toggleHelp' })
+    state = applyLogInkAction(state, { type: 'scrollHelp', delta: -3 })
+    expect(state.helpScrollOffset).toBe(0)
+
+    state = applyLogInkAction(state, { type: 'scrollHelp', delta: 7 })
+    state = applyLogInkAction(state, { type: 'scrollHelp', delta: -100 })
+    expect(state.helpScrollOffset).toBe(0)
+  })
+
+  it('clears helpScrollOffset when opening filter mode or command palette', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'toggleHelp' })
+    state = applyLogInkAction(state, { type: 'scrollHelp', delta: 3 })
+    expect(state.helpScrollOffset).toBe(3)
+
+    // Opening filter mode supersedes help.
+    state = applyLogInkAction(state, { type: 'toggleFilterMode' })
+    expect(state.showHelp).toBe(false)
+    expect(state.helpScrollOffset).toBe(0)
+
+    // And so does the command palette.
+    state = applyLogInkAction(state, { type: 'toggleHelp' })
+    state = applyLogInkAction(state, { type: 'scrollHelp', delta: 4 })
+    state = applyLogInkAction(state, { type: 'toggleCommandPalette' })
+    expect(state.showHelp).toBe(false)
+    expect(state.helpScrollOffset).toBe(0)
+  })
+
   it('defaults the diff view mode to unified', () => {
     const state = createLogInkState(rows)
     expect(state.diffViewMode).toBe('unified')

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -245,6 +245,14 @@ export type LogInkState = {
   filterMode: boolean
   fullGraph: boolean
   showHelp: boolean
+  /**
+   * Row offset into the help overlay's content. Driven by j/k/arrow
+   * keys while `showHelp` is true. Reset to 0 whenever the overlay is
+   * closed so reopening always starts at the top. Bound-checked at
+   * render time against the visible window; no `helpContentRows`
+   * field — the rendered panel does the clamp.
+   */
+  helpScrollOffset: number
   showCommandPalette: boolean
   /**
    * Command-palette interaction state. `paletteFilter` is the user-typed
@@ -697,6 +705,7 @@ export type LogInkAction =
   | { type: 'toggleFilterMode' }
   | { type: 'toggleGraph' }
   | { type: 'toggleHelp' }
+  | { type: 'scrollHelp'; delta: number }
   | { type: 'toggleCommandPalette' }
   | { type: 'cycleBranchSort' }
   | { type: 'cycleTagSort' }
@@ -1180,6 +1189,7 @@ export function createLogInkState(
     filterMode: false,
     fullGraph: false,
     showHelp: false,
+    helpScrollOffset: 0,
     showCommandPalette: false,
     workflowActionId: undefined,
     pendingConfirmationId: undefined,
@@ -1868,6 +1878,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         filterMode: !state.filterMode,
         showCommandPalette: false,
         showHelp: false,
+        helpScrollOffset: 0,
         pendingKey: undefined,
       }
     case 'toggleGraph':
@@ -1876,12 +1887,27 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         fullGraph: !state.fullGraph,
         pendingKey: undefined,
       }
-    case 'toggleHelp':
+    case 'toggleHelp': {
+      const opening = !state.showHelp
       return {
         ...state,
-        showHelp: !state.showHelp,
+        showHelp: opening,
+        // Reset scroll position when toggling either direction so the
+        // next open always starts at the top — feels more predictable
+        // than picking up where the user last scrolled.
+        helpScrollOffset: 0,
         showCommandPalette: false,
         pendingKey: undefined,
+      }
+    }
+    case 'scrollHelp':
+      // No upper-bound clamp here — the renderer caps the offset
+      // against the actual content height at render time. The
+      // reducer just prevents going below 0 so callers can safely
+      // pass negative deltas without us going past the top.
+      return {
+        ...state,
+        helpScrollOffset: Math.max(0, state.helpScrollOffset + action.delta),
       }
     case 'toggleCommandPalette': {
       const opening = !state.showCommandPalette
@@ -1889,6 +1915,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         ...state,
         showCommandPalette: opening,
         showHelp: false,
+        helpScrollOffset: 0,
         // Reset palette interaction state on every open/close so the next
         // session starts from a clean slate.
         paletteFilter: '',

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -235,24 +235,46 @@ export function renderHelpPanel(
   focused: boolean
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
-  const children: ReactTypes.ReactNode[] = [
-    h(Text, { bold: true, key: 'title' }, panelTitle('Help', focused)),
-  ]
 
+  // Build the full list of body rows (everything below the title).
+  // Splitting into title + body lets us window the body by
+  // `state.helpScrollOffset` while keeping the title pinned.
+  const body: ReactTypes.ReactNode[] = []
   const sections = getLogInkHelpSections({
     activeView: state.activeView,
     focus: state.focus,
   })
 
   for (const section of sections) {
-    children.push(h(Text, { key: `${section.title}-spacer` }, ''))
-    children.push(h(Text, { bold: true, key: section.title }, section.title))
+    body.push(h(Text, { key: `${section.title}-spacer` }, ''))
+    body.push(h(Text, { bold: true, key: section.title }, section.title))
     section.bindings.forEach((binding) => {
-      children.push(h(Text, { key: `${section.title}:${binding.id}` },
+      body.push(h(Text, { key: `${section.title}:${binding.id}` },
         truncateCells(`${formatBindingKeys(binding).padEnd(14)} ${binding.description}`, width - 4)
       ))
     })
   }
+
+  // Clamp the offset against actual content length. The reducer
+  // only floor-clamps at 0; here we ceiling-clamp so j past EOF
+  // sticks at the last row rather than scrolling into emptiness.
+  // Reserve one row at the bottom so the user can always see the
+  // tail of the last section.
+  const maxOffset = Math.max(0, body.length - 1)
+  const offset = Math.min(state.helpScrollOffset, maxOffset)
+
+  const children: ReactTypes.ReactNode[] = [
+    h(Text, { bold: true, key: 'title' }, panelTitle('Help', focused)),
+  ]
+
+  // Visual hint that there's content scrolled above. The dim style
+  // matches the rest of the chrome's "metadata" voice and avoids
+  // stealing attention from the bindings themselves.
+  if (offset > 0) {
+    children.push(h(Text, { key: 'more-above', dimColor: true }, '↑ more above'))
+  }
+
+  children.push(...body.slice(offset))
 
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),


### PR DESCRIPTION
## Summary

While help (`?`) is open, j/k previously fell through to the generic scroll handlers (`moveDetailFile`, sidebar nav, etc) — and those mutate `state.focus`. So pressing j inside help silently moved focus from `'detail'` to `'commits'`, and the next keystroke after closing help routed to the wrong surface.

This PR makes help a proper modal — while open, it owns the keymap.

## Behavior

- `j` / `k` / down / up → scroll help by 1 row
- `Ctrl-d` / `Ctrl-u` → half-page scroll (±10)
- `?` / `Esc` → close help
- `q` → exit (preserved)
- everything else → swallowed (return \`[]\`)

Mirrors the existing command-palette modal pattern (\`showCommandPalette\` block at the top of \`inkInput.ts\`).

## Changes

**State** (\`inkViewModel.ts\`):
- New \`helpScrollOffset: number\` field (default 0)
- New \`scrollHelp\` action — floor-clamps at 0 in the reducer
- \`toggleHelp\` / \`toggleFilterMode\` / \`toggleCommandPalette\` now also reset \`helpScrollOffset\` to 0, so reopening always starts at the top

**Input** (\`inkInput.ts\`):
- Added a help-mode interception block right after the \`Esc + showHelp\` handler. All keys route through this block while help is open; nothing falls through.

**Renderer** (\`overlays.ts\`):
- \`renderHelpPanel\` splits the title from the body, windows the body by \`helpScrollOffset\`, ceiling-clamps internally against actual body length (so j past EOF is a no-op), and shows a \`↑ more above\` dim hint when scrolled.

## Tests

8 new — 4 reducer (default / floor-clamp / reset-on-toggle / cross-modal reset), 4 input (j-k arrows / arrows / Ctrl-d-u / swallows non-scroll keys / ? closes from inside help).

## Test plan

- [x] \`npx jest src/commands/log/inkViewModel.test.ts src/commands/log/inkInput.test.ts\` — 428 pass
- [x] \`npx jest src/commands/log/ src/workstation/\` — 957 pass
- [x] eslint clean on touched files
- [ ] Manual: open \`coco ui\`, press \`?\`, press j several times, watch \`↑ more above\` appear, press \`?\` to close — focus should be on whatever surface had it before
- [ ] Manual: open help on the smallest view (e.g. status with empty repo), scroll past the bottom — should clamp, not visibly drift