### PR TITLE
feat(ui): distinct chip colour for remote-tracking branch tips

### DIFF
--- a/src/workstation/chrome/branchTip.test.ts
+++ b/src/workstation/chrome/branchTip.test.ts
@@ -2,27 +2,41 @@ import { filterChippedRefs, getBranchTipChip } from './branchTip'
 
 describe('getBranchTipChip', () => {
   it('returns the HEAD branch when refs include HEAD -> X', () => {
-    expect(getBranchTipChip(['HEAD -> main'])).toEqual({ name: 'main', isHead: true })
+    expect(getBranchTipChip(['HEAD -> main']))
+      .toEqual({ name: 'main', isHead: true, kind: 'head' })
     expect(getBranchTipChip(['HEAD -> feat/foo', 'origin/feat/foo']))
-      .toEqual({ name: 'feat/foo', isHead: true })
+      .toEqual({ name: 'feat/foo', isHead: true, kind: 'head' })
   })
 
   it('prefers HEAD over plain branch tips even when both are present', () => {
     expect(getBranchTipChip(['other', 'HEAD -> main']))
-      .toEqual({ name: 'main', isHead: true })
+      .toEqual({ name: 'main', isHead: true, kind: 'head' })
   })
 
   it('returns the first plain local branch when HEAD is not present', () => {
-    expect(getBranchTipChip(['feat/foo'])).toEqual({ name: 'feat/foo', isHead: false })
-    expect(getBranchTipChip(['feat/foo', 'origin/feat/foo']))
-      // feat/foo contains a slash so it is treated as remote-like; first
-      // truly-plain branch wins. With only slashy refs we fall through
-      // to the remote-tracking fallback below.
-      .toEqual({ name: 'feat/foo', isHead: false })
+    expect(getBranchTipChip(['feat/foo']))
+      // feat/foo contains a slash so it is treated as remote-like;
+      // falls through to the third loop and is labeled 'remote'. The
+      // chip system can't tell a local-branch-with-slash from an actual
+      // remote ref without a list of remote names to compare against.
+      .toEqual({ name: 'feat/foo', isHead: false, kind: 'remote' })
+    expect(getBranchTipChip(['main']))
+      .toEqual({ name: 'main', isHead: false, kind: 'local' })
   })
 
   it('falls back to a remote-tracking branch when nothing local is on the tip', () => {
-    expect(getBranchTipChip(['origin/main'])).toEqual({ name: 'origin/main', isHead: false })
+    expect(getBranchTipChip(['origin/main']))
+      .toEqual({ name: 'origin/main', isHead: false, kind: 'remote' })
+  })
+
+  it('marks slashless local branches with kind: "local"', () => {
+    expect(getBranchTipChip(['develop']))
+      .toEqual({ name: 'develop', isHead: false, kind: 'local' })
+  })
+
+  it('marks remote-tracking refs with kind: "remote"', () => {
+    expect(getBranchTipChip(['upstream/main']))
+      .toEqual({ name: 'upstream/main', isHead: false, kind: 'remote' })
   })
 
   it('ignores tags entirely', () => {
@@ -46,19 +60,19 @@ describe('getBranchTipChip', () => {
 describe('filterChippedRefs', () => {
   it('removes HEAD -> X and bare X when X is the chip', () => {
     const refs = ['HEAD -> main', 'main', 'origin/main', 'origin/HEAD']
-    const chip = { name: 'main', isHead: true }
+    const chip = { name: 'main', isHead: true, kind: 'head' as const }
     expect(filterChippedRefs(refs, chip)).toEqual(['origin/main', 'origin/HEAD'])
   })
 
   it('removes only the exact chip name for non-HEAD tips', () => {
     const refs = ['claude/issues-prs-cli', 'origin/claude/issues-prs-cli']
-    const chip = { name: 'claude/issues-prs-cli', isHead: false }
+    const chip = { name: 'claude/issues-prs-cli', isHead: false, kind: 'remote' as const }
     expect(filterChippedRefs(refs, chip)).toEqual(['origin/claude/issues-prs-cli'])
   })
 
   it('removes the chip ref entirely when it is the only ref', () => {
     const refs = ['origin/claude/issues-prs-cache']
-    const chip = { name: 'origin/claude/issues-prs-cache', isHead: false }
+    const chip = { name: 'origin/claude/issues-prs-cache', isHead: false, kind: 'remote' as const }
     expect(filterChippedRefs(refs, chip)).toEqual([])
   })
 
@@ -69,15 +83,15 @@ describe('filterChippedRefs', () => {
 
   it('preserves tags even when they appear alongside the chipped branch', () => {
     const refs = ['HEAD -> main', 'main', 'tag: v1.0.0', 'origin/main']
-    const chip = { name: 'main', isHead: true }
+    const chip = { name: 'main', isHead: true, kind: 'head' as const }
     expect(filterChippedRefs(refs, chip)).toEqual(['tag: v1.0.0', 'origin/main'])
   })
 
   it('strips bare HEAD only when the chip is the HEAD branch', () => {
     const refs = ['HEAD', 'main']
-    const headChip = { name: 'main', isHead: true }
+    const headChip = { name: 'main', isHead: true, kind: 'head' as const }
     expect(filterChippedRefs(refs, headChip)).toEqual([])
-    const nonHeadChip = { name: 'main', isHead: false }
+    const nonHeadChip = { name: 'main', isHead: false, kind: 'local' as const }
     expect(filterChippedRefs(refs, nonHeadChip)).toEqual(['HEAD'])
   })
 })

--- a/src/workstation/chrome/branchTip.ts
+++ b/src/workstation/chrome/branchTip.ts
@@ -5,13 +5,17 @@
  * lost in the trailing `[ref] [ref]` list.
  *
  * Selection priority:
- *   1. `HEAD -> X` — current branch wins. Returned with `isHead: true`.
+ *   1. `HEAD -> X` — current branch wins. Returned with `kind: 'head'`.
  *   2. The first "plain" local branch (not a tag, not a HEAD marker,
- *      not a remote ref) — typical for commits that are tips of
- *      other local branches.
- *   3. The first remote-tracking branch (`origin/X`) — last-resort
- *      so a commit at the tip of a remote branch you don't have
- *      locally still gets a chip.
+ *      not a remote ref) — `kind: 'local'`.
+ *   3. The first remote-tracking branch (`origin/X`) — `kind: 'remote'`,
+ *      last-resort so a commit at the tip of a remote branch you don't
+ *      have locally still gets a chip with a distinct color.
+ *
+ * `isHead` is kept for backwards compatibility with consumers that
+ * only care about "is this the current branch"; `kind` is the richer
+ * source of truth for renderers that want to colour remote-tracking
+ * tips differently from local ones (the "where is upstream?" cue).
  *
  * Tags are deliberately excluded from chip selection — they belong in
  * the trailing ref list so the chip column stays branch-only and the
@@ -21,9 +25,12 @@
  * renderer then skips the prefix entirely so unmarked commits don't
  * pay any width budget.
  */
+export type BranchTipChipKind = 'head' | 'local' | 'remote'
+
 export type BranchTipChip = {
   name: string
   isHead: boolean
+  kind: BranchTipChipKind
 }
 
 /**
@@ -56,7 +63,7 @@ export function getBranchTipChip(refs: string[]): BranchTipChip | undefined {
   for (const ref of refs) {
     if (ref.startsWith('HEAD -> ')) {
       const name = ref.slice('HEAD -> '.length).trim()
-      if (name) return { name, isHead: true }
+      if (name) return { name, isHead: true, kind: 'head' }
     }
   }
 
@@ -69,7 +76,7 @@ export function getBranchTipChip(refs: string[]): BranchTipChip | undefined {
     ) {
       continue
     }
-    if (ref.trim()) return { name: ref.trim(), isHead: false }
+    if (ref.trim()) return { name: ref.trim(), isHead: false, kind: 'local' }
   }
 
   for (const ref of refs) {
@@ -77,7 +84,7 @@ export function getBranchTipChip(refs: string[]): BranchTipChip | undefined {
       continue
     }
     if (ref.includes('/') && ref.trim()) {
-      return { name: ref.trim(), isHead: false }
+      return { name: ref.trim(), isHead: false, kind: 'remote' }
     }
   }
 

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -144,7 +144,24 @@ function renderBranchTipChip(
     }
   }
 
-  const accent = chip.isHead ? theme.colors.success : theme.colors.info
+  // Three-way colour assignment matches `BranchTipChipKind`:
+  //
+  //   - HEAD  → success (the user's current branch — bright green)
+  //   - local → info    (other local branches — calm blue)
+  //   - remote → warning (remote-tracking refs like origin/main —
+  //                      distinct so "where is upstream?" reads at a glance)
+  //
+  // Without the remote/local split, a chip on `origin/main` looked
+  // identical to a local-branch chip, so users couldn't tell from the
+  // commit list where their upstream actually pointed. The warning hue
+  // (typically a muted yellow / orange) is purposeful: not alarming,
+  // but visibly different from the local blue.
+  const accent =
+    chip.kind === 'head'
+      ? theme.colors.success
+      : chip.kind === 'remote'
+        ? theme.colors.warning
+        : theme.colors.info
   return {
     node: h(Text, {},
       h(Text, { key, inverse: true, color: accent, bold: chip.isHead }, body),


### PR DESCRIPTION
## Summary

Before: a commit at the tip of \`origin/main\` got the same blue chip as a commit at the tip of local \`main\`. When both pointed at the same commit, only the local chip showed and the remote was buried in trailing \`[origin/main]\` text — making "where is upstream?" hard to read.

After: \`BranchTipChip\` carries a \`kind\` discriminator and remote-tracking refs get a warning-yellow chip distinct from the local blue.

| Ref shape | \`kind\` | Colour |
|---|---|---|
| \`HEAD -> X\` | \`'head'\` | success (green) |
| First plain (slashless) local branch | \`'local'\` | info (blue) |
| First slashy / remote ref | \`'remote'\` | warning (yellow) |

\`isHead\` is retained on the type for backwards compatibility but new code should prefer \`kind\` since it carries the local-vs-remote split.

## Known heuristic limitation

The \`'remote'\` classification is "anything with a slash that isn't a tag", same as the existing pre-PR fallback. That means local feature branches like \`feat/x\` are classified as \`'remote'\` too. Fixing this properly needs the repo's list of remote names (\`origin\`, \`upstream\`) piped into the chip selector — flagged as follow-up. For now the win is that \`origin/X\` looks visually distinct from \`main\`, which is the cue users were asking for.

## Tests

\`branchTip.test.ts\` now asserts every chip shape includes \`kind\`. Two new tests pin the local-vs-remote split explicitly.

## Test plan

- [x] \`npx jest src/workstation src/commands/log\` — 951 pass
- [x] eslint clean on touched files
- [ ] Manual (post-0.3.0 dep bump): \`npm run scenario create branch-ahead-of-upstream -- --run-ui\` — \`origin/main\` chip should be yellow and \`main\` chip green/blue
- [ ] Manual: \`npm run scenario create multi-remote-with-tracking -- --run-ui\` — \`upstream/main\` and \`origin/feat/fork-work\` chips both yellow, local chips blue/green

## Pairs well with

The new git-scenarios v0.3.0 scenarios (\`branch-ahead-of-upstream\`, \`branch-behind-upstream\`, \`branch-diverged\`, \`multi-remote-with-tracking\`) — once those land, this PR's visual change is testable in seconds.