### PR TITLE
feat(ui): classify branch chips using the repo's remote names

### DIFF
--- a/src/workstation/chrome/branchTip.test.ts
+++ b/src/workstation/chrome/branchTip.test.ts
@@ -14,11 +14,10 @@ describe('getBranchTipChip', () => {
   })
 
   it('returns the first plain local branch when HEAD is not present', () => {
+    // Without a remoteNames list, `feat/foo` falls back to the legacy
+    // "slash = remote" heuristic and is labeled remote. The branch-aware
+    // overload below pins the corrected behavior.
     expect(getBranchTipChip(['feat/foo']))
-      // feat/foo contains a slash so it is treated as remote-like;
-      // falls through to the third loop and is labeled 'remote'. The
-      // chip system can't tell a local-branch-with-slash from an actual
-      // remote ref without a list of remote names to compare against.
       .toEqual({ name: 'feat/foo', isHead: false, kind: 'remote' })
     expect(getBranchTipChip(['main']))
       .toEqual({ name: 'main', isHead: false, kind: 'local' })
@@ -37,6 +36,40 @@ describe('getBranchTipChip', () => {
   it('marks remote-tracking refs with kind: "remote"', () => {
     expect(getBranchTipChip(['upstream/main']))
       .toEqual({ name: 'upstream/main', isHead: false, kind: 'remote' })
+  })
+
+  describe('with remoteNames provided', () => {
+    it('classifies a slashed local branch as kind: "local"', () => {
+      expect(getBranchTipChip(['feat/x'], ['origin']))
+        .toEqual({ name: 'feat/x', isHead: false, kind: 'local' })
+    })
+
+    it('classifies a refs that match a remote prefix as kind: "remote"', () => {
+      expect(getBranchTipChip(['origin/feat/x'], ['origin']))
+        .toEqual({ name: 'origin/feat/x', isHead: false, kind: 'remote' })
+    })
+
+    it('matches any remote in the list when there are multiple remotes', () => {
+      expect(getBranchTipChip(['upstream/main'], ['origin', 'upstream']))
+        .toEqual({ name: 'upstream/main', isHead: false, kind: 'remote' })
+    })
+
+    it('prefers a slashed local branch over a remote-tracking ref on the same commit', () => {
+      // `feat/x` and `origin/main` both contain slashes; only the
+      // latter starts with a known remote prefix. The slashed local
+      // branch wins the second loop and is chipped as local.
+      expect(getBranchTipChip(['feat/x', 'origin/main'], ['origin']))
+        .toEqual({ name: 'feat/x', isHead: false, kind: 'local' })
+    })
+
+    it('falls back to the legacy "slash = remote" heuristic when remoteNames is empty', () => {
+      // Back-compat: callers that pass an empty list (e.g. branch data
+      // not yet hydrated) should get the same behavior as if they had
+      // omitted the argument entirely, so chips still render sensibly
+      // on first paint.
+      expect(getBranchTipChip(['origin/main'], []))
+        .toEqual({ name: 'origin/main', isHead: false, kind: 'remote' })
+    })
   })
 
   it('ignores tags entirely', () => {

--- a/src/workstation/chrome/branchTip.ts
+++ b/src/workstation/chrome/branchTip.ts
@@ -59,7 +59,30 @@ export function filterChippedRefs(refs: string[], chip: BranchTipChip | undefine
   })
 }
 
-export function getBranchTipChip(refs: string[]): BranchTipChip | undefined {
+/**
+ * `remoteNames` lets the caller pass the repository's actual remote
+ * names (e.g. `['origin', 'upstream']`) so refs are classified by
+ * remote-prefix rather than by "contains a slash". Without it a local
+ * feature branch like `feat/x` looks identical to a remote-tracking
+ * `origin/x` and gets the wrong colour. When the list is omitted the
+ * function falls back to the legacy slash-as-remote heuristic — the
+ * sensible default before branch data has loaded and a back-compat
+ * affordance for callers that have no remote data to hand.
+ */
+export function getBranchTipChip(
+  refs: string[],
+  remoteNames?: string[]
+): BranchTipChip | undefined {
+  // Empty list is treated the same as omitted: branch data hasn't
+  // loaded yet, so we don't have ground truth and the legacy "slash =
+  // remote" heuristic is the best guess for first paint.
+  const hasRemoteList = Array.isArray(remoteNames) && remoteNames.length > 0
+  const isRemoteRef = (ref: string): boolean => {
+    if (!ref.includes('/')) return false
+    if (!hasRemoteList) return true
+    return remoteNames!.some((remote) => remote && ref.startsWith(`${remote}/`))
+  }
+
   for (const ref of refs) {
     if (ref.startsWith('HEAD -> ')) {
       const name = ref.slice('HEAD -> '.length).trim()
@@ -72,18 +95,20 @@ export function getBranchTipChip(refs: string[]): BranchTipChip | undefined {
       ref === 'HEAD' ||
       ref.startsWith('HEAD -> ') ||
       ref.startsWith('tag: ') ||
-      ref.includes('/')
+      isRemoteRef(ref)
     ) {
       continue
     }
-    if (ref.trim()) return { name: ref.trim(), isHead: false, kind: 'local' }
+    if (ref.trim()) {
+      return { name: ref.trim(), isHead: false, kind: 'local' }
+    }
   }
 
   for (const ref of refs) {
     if (ref.startsWith('tag: ') || ref === 'HEAD' || ref.startsWith('HEAD -> ')) {
       continue
     }
-    if (ref.includes('/') && ref.trim()) {
+    if (isRemoteRef(ref) && ref.trim()) {
       return { name: ref.trim(), isHead: false, kind: 'remote' }
     }
   }

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -115,13 +115,14 @@ function renderBranchTipChip(
   commit: GitLogCommitRow,
   theme: LogInkTheme,
   key: string,
-  selected: boolean
+  selected: boolean,
+  remoteNames: string[] | undefined
 ): {
   node: ReactTypes.ReactElement | null
   width: number
   chip: ReturnType<typeof getBranchTipChip>
 } {
-  const chip = getBranchTipChip(commit.refs)
+  const chip = getBranchTipChip(commit.refs, remoteNames)
   if (!chip) return { node: null, width: 0, chip }
 
   const truncated = truncateCells(chip.name, BRANCH_CHIP_MAX_NAME_WIDTH)
@@ -288,7 +289,8 @@ function renderCommitHistoryRow(
   bucketed: boolean,
   now: Date,
   laneSegments?: LaneSegment[],
-  isRecent: boolean = false
+  isRecent: boolean = false,
+  remoteNames?: string[]
 ): ReactTypes.ReactElement {
   // Total cells available to the row content. Earlier revisions used a
   // hardcoded 140 here, which let row content overflow whenever the
@@ -306,7 +308,7 @@ function renderCommitHistoryRow(
   // out whatever the chip already shows so the row doesn't print
   // `[main] feat: x [HEAD -> main]` with the same info on both ends.
   const chip = fullGraph
-    ? renderBranchTipChip(h, Text, commit, theme, `${commit.hash}-${index}-chip`, selected)
+    ? renderBranchTipChip(h, Text, commit, theme, `${commit.hash}-${index}-chip`, selected, remoteNames)
     : { node: null, width: 0, chip: undefined }
   const refs = formatInkRefLabels(filterChippedRefs(commit.refs, chip.chip))
   const fixedWidth =
@@ -394,7 +396,8 @@ function renderStackedCommitHistoryRow(
   fullGraph: boolean,
   now: Date,
   laneSegments?: LaneSegment[],
-  isRecent: boolean = false
+  isRecent: boolean = false,
+  remoteNames?: string[]
 ): ReactTypes.ReactElement {
   const totalWidth = Math.max(20, panelWidth - 4)
   const accent = theme.noColor ? undefined : theme.colors.accent
@@ -407,7 +410,7 @@ function renderStackedCommitHistoryRow(
   // same way as the single-line variant, but only in full-graph mode.
   const recentMarkerWidth = isRecent ? 2 : 0
   const chip = fullGraph
-    ? renderBranchTipChip(h, Text, commit, theme, `${commit.hash}-${index}-stk-chip`, selected)
+    ? renderBranchTipChip(h, Text, commit, theme, `${commit.hash}-${index}-stk-chip`, selected, remoteNames)
     : { node: null, width: 0, chip: undefined }
   const lineOneFixed =
     graphWidth + 1 + commit.shortHash.length + 1 + recentMarkerWidth + chip.width
@@ -519,6 +522,21 @@ export function renderHistoryPanel(
   const { Box, Text } = components
   const focused = state.focus === 'commits'
   const worktree = context.worktree
+  // Distinct remote names seen across the repo's remote-tracking
+  // branches — `['origin']` for a typical fork, `['origin', 'upstream']`
+  // when the user has both. Used to classify branch-tip chips so a
+  // slashed local branch like `feat/x` doesn't get mis-coloured as
+  // remote. When branch data hasn't loaded yet, `undefined` makes the
+  // chip helper fall back to the legacy slash-based heuristic.
+  const remoteNames = context.branches?.remoteBranches
+    ? Array.from(
+        new Set(
+          context.branches.remoteBranches
+            .map((branch) => branch.remote)
+            .filter((remote): remote is string => Boolean(remote))
+        )
+      )
+    : undefined
   // Set of just-landed commit hashes for the "new commit" marker.
   // Populated for ~5s after a split-apply or other commit-creating
   // operation; auto-cleared by the runtime so it doesn't linger.
@@ -657,7 +675,8 @@ export function renderHistoryPanel(
           h, Text, Box, item.commit, item.graph, visible.graphWidth,
           Boolean(item.selected) && !realSelectionSuppressed, theme, index,
           width, state.fullGraph, now, item.laneSegments,
-          recentCommitsSet.has(item.commit.hash)
+          recentCommitsSet.has(item.commit.hash),
+          remoteNames
         )
       }
       return renderCommitHistoryRow(
@@ -665,7 +684,8 @@ export function renderHistoryPanel(
         Boolean(item.selected) && !realSelectionSuppressed, theme, index,
         width, density, state.fullGraph, Boolean(dateBucketingNow), now,
         item.laneSegments,
-        recentCommitsSet.has(item.commit.hash)
+        recentCommitsSet.has(item.commit.hash),
+        remoteNames
       )
     }))
 }


### PR DESCRIPTION
## Summary
- `getBranchTipChip` now accepts an optional `remoteNames` list so refs are classified `kind: 'remote'` only when they actually start with a known `<remote>/` prefix. Local feature branches like `feat/x` are no longer mis-coloured yellow.
- `renderHistoryPanel` derives the remote names from `context.branches.remoteBranches` (deduped) and threads them through `renderCommitHistoryRow` / `renderStackedCommitHistoryRow` to `renderBranchTipChip`.
- When `remoteNames` is omitted or empty (e.g. branch data hasn't hydrated yet) the helper falls back to the legacy "slash = remote" heuristic so first-paint chips stay sensible and the existing tests keep passing.

## Test plan
- [x] `npx jest src/workstation src/commands/log` — 956 tests pass, including new cases pinning the branch-aware behaviour and the legacy fallback.
- [x] `npx eslint src/workstation/chrome/branchTip.ts src/workstation/chrome/branchTip.test.ts src/workstation/surfaces/history/index.ts` — clean.
- [ ] Visual smoke: open a repo with both `origin/` and a local `feat/x` branch on the same commit; the local branch should chip blue, the remote should chip yellow.

Follow-up to #1002.