### PR TITLE
chore: bump @gfargo/git-scenarios to ^0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@commitlint/types": "^20.5.0",
-    "@gfargo/git-scenarios": "^0.2.0",
+    "@gfargo/git-scenarios": "^0.3.0",
     "@rollup/plugin-commonjs": "^29.0.0",
     "@rollup/plugin-eslint": "^9.0.5",
     "@rollup/plugin-json": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -653,10 +653,10 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
-"@gfargo/git-scenarios@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@gfargo/git-scenarios/-/git-scenarios-0.2.0.tgz#7036b31404c2a54a312b94038ce9b8efa6b7c87a"
-  integrity sha512-/XX66Z7TTV4vGMWVMrlg8kF3fgU9BMjgcJ9PHvxxQfEEiYFM6/UHxvfJApKezXX6OG/HizUDhjYr3kPytcwqCA==
+"@gfargo/git-scenarios@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@gfargo/git-scenarios/-/git-scenarios-0.3.0.tgz#03f92cf8723ae7a5aeccc967fa81089d79e27372"
+  integrity sha512-oLs42BThkNS0m2IJHDi/1SKOTQ0iaU9qMO2PDPk1acriS3z/p1IKijDNjJNxjbN9t7ycnPg0sPcPqntsa5Im5w==
 
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"


### PR DESCRIPTION
Brings in v0.3.0 of the scenarios package.

## What's new for coco

**3 new atoms** for fabricating upstream-tracking state in inline scenarios / integration tests:
- \`setUpstream(localBranch, remote, remoteBranch?)\`
- \`setRemoteRef(remote, branch, sha)\`
- \`withRemoteTracking(remote, branch, step)\` — clone-and-fetch scope that lets you compose upstream-only commits with normal atoms

**7 new registered scenarios** usable via \`npm run scenario create <name>\` and \`spinUpScenario(...)\` in integration tests:
- \`branch-tracking-upstream\` — synced baseline
- \`branch-ahead-of-upstream\` — 3 commits ahead of origin/main
- \`branch-behind-upstream\` — 3 commits behind (built with \`withRemoteTracking\`)
- \`branch-diverged\` — 2 ahead + 2 behind
- \`multi-remote-with-tracking\` — fork workflow with origin + upstream
- \`detached-head\` — HEAD at main~2
- \`signed-commits-required\` — \`commit.gpgsign=true\` + \`user.signingkey\` set

**Bug fix:** \`continueRebase\` no longer hangs on CI runners without TTY (was setting up a stuck \`git rebase --continue\` waiting for an editor).

## Why now

The scenarios are prereqs for upcoming TUI work — testing the just-merged \"distinct chip colour for remote refs\" (#1002) against actual ahead/behind/diverged states, plus future pull/push workflow design.

## Test plan

- [x] \`yarn add --dev @gfargo/git-scenarios@^0.3.0\` resolves cleanly
- [x] \`npx tsc --noEmit\` — clean (previously had a phantom error in evals/scenarioInputs.ts that was actually about the dep not being resolved in my isolated worktree)
- [x] \`npx jest src/commands/commands.integration.test.ts\` — 16 pass (this is the suite that consumes scenarios end-to-end)
- [ ] Manual: \`npm run scenario list\` — should show all 18 scenarios (11 existing + 7 new)
- [ ] Manual: \`npm run scenario create branch-ahead-of-upstream -- --run-ui\` — verify the chip-colour PR (#1002) renders origin/main with a distinct yellow chip

Release notes: https://github.com/gfargo/git-scenarios/releases/tag/v0.3.0