### PR TITLE
feat(ui): classify branch chips using the repo's remote names

### DIFF
--- a/src/workstation/chrome/branchTip.test.ts
+++ b/src/workstation/chrome/branchTip.test.ts
@@ -13,30 +13,69 @@ describe('getBranchTipChip', () => {
       .toEqual({ name: 'main', isHead: true, kind: 'head' })
   })
 
-  it('returns the first plain local branch when HEAD is not present', () => {
+  it('without remoteNames, falls back to "any slash = remote-like" heuristic', () => {
+    // No remoteNames → feat/foo is treated as remote-like (legacy behavior
+    // preserved for callers without branch overview data).
     expect(getBranchTipChip(['feat/foo']))
-      // feat/foo contains a slash so it is treated as remote-like;
-      // falls through to the third loop and is labeled 'remote'. The
-      // chip system can't tell a local-branch-with-slash from an actual
-      // remote ref without a list of remote names to compare against.
       .toEqual({ name: 'feat/foo', isHead: false, kind: 'remote' })
     expect(getBranchTipChip(['main']))
       .toEqual({ name: 'main', isHead: false, kind: 'local' })
   })
 
+  it('with remoteNames, correctly classifies local feature branches with slashes', () => {
+    // feat/foo is NOT prefixed by any known remote → kind: 'local'.
+    expect(getBranchTipChip(['feat/foo'], ['origin']))
+      .toEqual({ name: 'feat/foo', isHead: false, kind: 'local' })
+    expect(getBranchTipChip(['release/2.0'], ['origin', 'upstream']))
+      .toEqual({ name: 'release/2.0', isHead: false, kind: 'local' })
+  })
+
+  it('with remoteNames, classifies <remoteName>/X as remote', () => {
+    expect(getBranchTipChip(['origin/main'], ['origin']))
+      .toEqual({ name: 'origin/main', isHead: false, kind: 'remote' })
+    expect(getBranchTipChip(['upstream/main'], ['origin', 'upstream']))
+      .toEqual({ name: 'upstream/main', isHead: false, kind: 'remote' })
+  })
+
+  it('with remoteNames, prefers local over remote when both exist at the tip', () => {
+    // The first non-remote ref wins — same precedence rule as before,
+    // just with a sharper remote check.
+    expect(getBranchTipChip(['feat/foo', 'origin/feat/foo'], ['origin']))
+      .toEqual({ name: 'feat/foo', isHead: false, kind: 'local' })
+  })
+
   it('falls back to a remote-tracking branch when nothing local is on the tip', () => {
     expect(getBranchTipChip(['origin/main']))
+      .toEqual({ name: 'origin/main', isHead: false, kind: 'remote' })
+    expect(getBranchTipChip(['origin/main'], ['origin']))
       .toEqual({ name: 'origin/main', isHead: false, kind: 'remote' })
   })
 
   it('marks slashless local branches with kind: "local"', () => {
     expect(getBranchTipChip(['develop']))
       .toEqual({ name: 'develop', isHead: false, kind: 'local' })
+    expect(getBranchTipChip(['develop'], ['origin']))
+      .toEqual({ name: 'develop', isHead: false, kind: 'local' })
   })
 
-  it('marks remote-tracking refs with kind: "remote"', () => {
-    expect(getBranchTipChip(['upstream/main']))
-      .toEqual({ name: 'upstream/main', isHead: false, kind: 'remote' })
+  it('treats empty remoteNames the same as undefined (legacy heuristic)', () => {
+    expect(getBranchTipChip(['feat/foo'], []))
+      .toEqual({ name: 'feat/foo', isHead: false, kind: 'remote' })
+  })
+
+  it('classifies slashed refs with unknown prefixes as local when remoteNames is supplied', () => {
+    // `origin/main` + remoteNames=['upstream']: the only remote we
+    // know about is `upstream`, so `origin/main` doesn't match the
+    // remote check and falls into the local bucket. In practice this
+    // happens with stale remote-tracking refs for a remote that's
+    // since been removed — calling the result 'local' is technically
+    // wrong but harmless (the chip still renders). The alternative
+    // (treating unknown prefixes as remote-like) would make the
+    // remoteNames parameter only partially trusted, which is more
+    // surprising. Keep the contract crisp: when remoteNames is
+    // supplied, ONLY those prefixes count as remote.
+    expect(getBranchTipChip(['origin/main'], ['upstream']))
+      .toEqual({ name: 'origin/main', isHead: false, kind: 'local' })
   })
 
   it('ignores tags entirely', () => {

--- a/src/workstation/chrome/branchTip.ts
+++ b/src/workstation/chrome/branchTip.ts
@@ -6,8 +6,8 @@
  *
  * Selection priority:
  *   1. `HEAD -> X` — current branch wins. Returned with `kind: 'head'`.
- *   2. The first "plain" local branch (not a tag, not a HEAD marker,
- *      not a remote ref) — `kind: 'local'`.
+ *   2. The first local branch (not a tag, not a HEAD marker, not a
+ *      ref prefixed by a known remote name) — `kind: 'local'`.
  *   3. The first remote-tracking branch (`origin/X`) — `kind: 'remote'`,
  *      last-resort so a commit at the tip of a remote branch you don't
  *      have locally still gets a chip with a distinct color.
@@ -20,6 +20,14 @@
  * Tags are deliberately excluded from chip selection — they belong in
  * the trailing ref list so the chip column stays branch-only and the
  * eye can rely on "leading chip = branch tip".
+ *
+ * **The `remoteNames` parameter**: pass the repository's actual remote
+ * names (e.g. `['origin', 'upstream']`) to get a precise local-vs-remote
+ * classification. Refs starting with `<remoteName>/` are classified as
+ * remote; everything else with a slash (`feat/x`, `release/2.0`) stays
+ * local. When omitted, the function falls back to a "any slash is
+ * remote-like" heuristic — workable for the common single-remote case
+ * but misclassifies local feature branches with slashes.
  *
  * Returns `undefined` when nothing chip-worthy is present; the
  * renderer then skips the prefix entirely so unmarked commits don't
@@ -59,7 +67,28 @@ export function filterChippedRefs(refs: string[], chip: BranchTipChip | undefine
   })
 }
 
-export function getBranchTipChip(refs: string[]): BranchTipChip | undefined {
+/**
+ * Returns true if `ref` is a remote-tracking ref under one of the
+ * supplied remote names — i.e. it starts with `<remoteName>/` for some
+ * `remoteName` in `remoteNames`.
+ *
+ * When `remoteNames` is empty (or undefined), the caller's intent is
+ * "I don't know the remotes" — we fall back to the legacy heuristic
+ * of "any ref containing a slash is treated as remote-like." That keeps
+ * the single-remote default behavior intact for callers without
+ * branch overview data on hand.
+ */
+function isRemoteTrackingRef(ref: string, remoteNames: string[] | undefined): boolean {
+  if (remoteNames && remoteNames.length > 0) {
+    return remoteNames.some((name) => ref.startsWith(`${name}/`))
+  }
+  return ref.includes('/')
+}
+
+export function getBranchTipChip(
+  refs: string[],
+  remoteNames?: string[]
+): BranchTipChip | undefined {
   for (const ref of refs) {
     if (ref.startsWith('HEAD -> ')) {
       const name = ref.slice('HEAD -> '.length).trim()
@@ -67,23 +96,31 @@ export function getBranchTipChip(refs: string[]): BranchTipChip | undefined {
     }
   }
 
+  // Pass 2: prefer local refs. With `remoteNames` provided, a local
+  // ref is anything that isn't `<remoteName>/...`, isn't a tag, and
+  // isn't a HEAD decoration — so `feat/x` correctly stays local.
+  // Without `remoteNames`, fall back to "no slash" as the local check.
   for (const ref of refs) {
     if (
       ref === 'HEAD' ||
       ref.startsWith('HEAD -> ') ||
-      ref.startsWith('tag: ') ||
-      ref.includes('/')
+      ref.startsWith('tag: ')
     ) {
+      continue
+    }
+    if (isRemoteTrackingRef(ref, remoteNames)) {
       continue
     }
     if (ref.trim()) return { name: ref.trim(), isHead: false, kind: 'local' }
   }
 
+  // Pass 3: fall back to a remote-tracking ref. Same skip rules but
+  // we accept the remote-ish refs now.
   for (const ref of refs) {
     if (ref.startsWith('tag: ') || ref === 'HEAD' || ref.startsWith('HEAD -> ')) {
       continue
     }
-    if (ref.includes('/') && ref.trim()) {
+    if (isRemoteTrackingRef(ref, remoteNames) && ref.trim()) {
       return { name: ref.trim(), isHead: false, kind: 'remote' }
     }
   }

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -115,13 +115,14 @@ function renderBranchTipChip(
   commit: GitLogCommitRow,
   theme: LogInkTheme,
   key: string,
-  selected: boolean
+  selected: boolean,
+  remoteNames: string[] | undefined
 ): {
   node: ReactTypes.ReactElement | null
   width: number
   chip: ReturnType<typeof getBranchTipChip>
 } {
-  const chip = getBranchTipChip(commit.refs)
+  const chip = getBranchTipChip(commit.refs, remoteNames)
   if (!chip) return { node: null, width: 0, chip }
 
   const truncated = truncateCells(chip.name, BRANCH_CHIP_MAX_NAME_WIDTH)
@@ -288,7 +289,8 @@ function renderCommitHistoryRow(
   bucketed: boolean,
   now: Date,
   laneSegments?: LaneSegment[],
-  isRecent: boolean = false
+  isRecent: boolean = false,
+  remoteNames?: string[]
 ): ReactTypes.ReactElement {
   // Total cells available to the row content. Earlier revisions used a
   // hardcoded 140 here, which let row content overflow whenever the
@@ -306,7 +308,7 @@ function renderCommitHistoryRow(
   // out whatever the chip already shows so the row doesn't print
   // `[main] feat: x [HEAD -> main]` with the same info on both ends.
   const chip = fullGraph
-    ? renderBranchTipChip(h, Text, commit, theme, `${commit.hash}-${index}-chip`, selected)
+    ? renderBranchTipChip(h, Text, commit, theme, `${commit.hash}-${index}-chip`, selected, remoteNames)
     : { node: null, width: 0, chip: undefined }
   const refs = formatInkRefLabels(filterChippedRefs(commit.refs, chip.chip))
   const fixedWidth =
@@ -394,7 +396,8 @@ function renderStackedCommitHistoryRow(
   fullGraph: boolean,
   now: Date,
   laneSegments?: LaneSegment[],
-  isRecent: boolean = false
+  isRecent: boolean = false,
+  remoteNames?: string[]
 ): ReactTypes.ReactElement {
   const totalWidth = Math.max(20, panelWidth - 4)
   const accent = theme.noColor ? undefined : theme.colors.accent
@@ -407,7 +410,7 @@ function renderStackedCommitHistoryRow(
   // same way as the single-line variant, but only in full-graph mode.
   const recentMarkerWidth = isRecent ? 2 : 0
   const chip = fullGraph
-    ? renderBranchTipChip(h, Text, commit, theme, `${commit.hash}-${index}-stk-chip`, selected)
+    ? renderBranchTipChip(h, Text, commit, theme, `${commit.hash}-${index}-stk-chip`, selected, remoteNames)
     : { node: null, width: 0, chip: undefined }
   const lineOneFixed =
     graphWidth + 1 + commit.shortHash.length + 1 + recentMarkerWidth + chip.width
@@ -519,6 +522,23 @@ export function renderHistoryPanel(
   const { Box, Text } = components
   const focused = state.focus === 'commits'
   const worktree = context.worktree
+  // Derive the list of remote names once per panel render so chip
+  // classification can distinguish `origin/X` (remote) from local
+  // refs with slashes (`feat/x`). `BranchRef.remote` is set on every
+  // remote ref by `parseBranchRefs`, so we can map and dedupe in
+  // one pass. When branch overview hasn't loaded yet (`branches` is
+  // undefined), pass undefined to `getBranchTipChip` so it falls back
+  // to the legacy "any slash = remote" heuristic — the chip is
+  // still useful, just less precise.
+  const remoteNames = context.branches?.remoteBranches
+    ? Array.from(
+        new Set(
+          context.branches.remoteBranches
+            .map((b) => b.remote)
+            .filter((name): name is string => Boolean(name))
+        )
+      )
+    : undefined
   // Set of just-landed commit hashes for the "new commit" marker.
   // Populated for ~5s after a split-apply or other commit-creating
   // operation; auto-cleared by the runtime so it doesn't linger.
@@ -657,7 +677,8 @@ export function renderHistoryPanel(
           h, Text, Box, item.commit, item.graph, visible.graphWidth,
           Boolean(item.selected) && !realSelectionSuppressed, theme, index,
           width, state.fullGraph, now, item.laneSegments,
-          recentCommitsSet.has(item.commit.hash)
+          recentCommitsSet.has(item.commit.hash),
+          remoteNames
         )
       }
       return renderCommitHistoryRow(
@@ -665,7 +686,8 @@ export function renderHistoryPanel(
         Boolean(item.selected) && !realSelectionSuppressed, theme, index,
         width, density, state.fullGraph, Boolean(dateBucketingNow), now,
         item.laneSegments,
-        recentCommitsSet.has(item.commit.hash)
+        recentCommitsSet.has(item.commit.hash),
+        remoteNames
       )
     }))
 }


### PR DESCRIPTION
Follow-up to #1002.

## Problem

The 'remote' chip kind was using a "any ref containing a slash" heuristic, so a local feature branch named \`feat/x\` was classified as remote and painted with the warning-yellow chip — same as \`origin/main\`. The visual distinction the user actually wanted was: *local branches blue, upstream-style refs yellow*.

## Fix

\`getBranchTipChip\` now takes an optional \`remoteNames: string[]\` parameter:

| Input | Behaviour |
|---|---|
| \`remoteNames\` supplied | Refs starting with \`<remoteName>/\` → \`'remote'\`; everything else slashy → \`'local'\` |
| \`remoteNames\` omitted / empty | Legacy heuristic: any slash → 'remote' (back-compat for callers without branch data) |

The history surface derives the list once per panel render from \`context.branches?.remoteBranches\` (which already has a \`remote\` field populated by \`parseBranchRefs\`), then threads it through \`renderCommitHistoryRow\` / \`renderStackedCommitHistoryRow\` / \`renderBranchTipChip\`.

## Outcomes

| Ref | remoteNames | kind | colour |
|---|---|---|---|
| \`main\` | n/a | local | blue |
| \`feat/x\` | \`['origin']\` | local | blue |
| \`origin/main\` | \`['origin']\` | remote | yellow |
| \`upstream/main\` | \`['origin', 'upstream']\` | remote | yellow |
| \`feat/x\` | undefined | remote | yellow (legacy heuristic) |
| \`origin/main\` | \`['upstream']\` | local | blue (stale remote ref — paranoia case) |

## Tests

8 new cases in \`branchTip.test.ts\` pinning each row of the table above. 20 chip tests total.

## Test plan

- [x] \`npx jest src/workstation src/commands/log\` — 963 pass
- [x] \`npx tsc --noEmit\` clean
- [x] eslint clean on touched files
- [ ] Manual: \`npm run scenario create branch-ahead-of-upstream -- --run-ui\` — \`origin/main\` chip yellow, \`main\` chip blue
- [ ] Manual: \`npm run scenario create multi-remote-with-tracking -- --run-ui\` — \`upstream/main\` and \`origin/feat/fork-work\` both yellow, \`feat/fork-work\` local chip blue
- [ ] Manual: a real repo where you have a local branch like \`feat/something\` — chip should now be blue (was yellow on main pre-this-PR)