### PR TITLE
test: structural snapshot tests for branch chip rendering

### DIFF
--- a/src/workstation/surfaces/history/__snapshots__/branchTipChipRender.test.ts.snap
+++ b/src/workstation/surfaces/history/__snapshots__/branchTipChipRender.test.ts.snap
@@ -1,0 +1,270 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`renderBranchTipChip — structural snapshots drops pill styling on selected rows (the row inverse carries it) 1`] = `
+{
+  "chip": {
+    "isHead": true,
+    "kind": "head",
+    "name": "main",
+  },
+  "node": {
+    "$$typeof": Symbol(react.transitional.element),
+    "_owner": null,
+    "_store": {},
+    "key": "test-key",
+    "props": {
+      "bold": true,
+      "children": "[main] ",
+    },
+    "type": [Function],
+  },
+  "width": 7,
+}
+`;
+
+exports[`renderBranchTipChip — structural snapshots falls back to the legacy "slash = remote" heuristic when remoteNames is absent 1`] = `
+{
+  "chip": {
+    "isHead": false,
+    "kind": "remote",
+    "name": "feat/widgets",
+  },
+  "node": {
+    "$$typeof": Symbol(react.transitional.element),
+    "_owner": null,
+    "_store": {},
+    "key": null,
+    "props": {
+      "children": [
+        {
+          "$$typeof": Symbol(react.transitional.element),
+          "_owner": null,
+          "_store": {},
+          "key": "test-key",
+          "props": {
+            "bold": false,
+            "children": " feat/widgets ",
+            "color": "yellow",
+            "inverse": true,
+          },
+          "type": [Function],
+        },
+        {
+          "$$typeof": Symbol(react.transitional.element),
+          "_owner": null,
+          "_store": {},
+          "key": "test-key-pad",
+          "props": {
+            "children": " ",
+          },
+          "type": [Function],
+        },
+      ],
+    },
+    "type": [Function],
+  },
+  "width": 15,
+}
+`;
+
+exports[`renderBranchTipChip — structural snapshots renders a plain local branch chip as a blue inverse pill 1`] = `
+{
+  "chip": {
+    "isHead": false,
+    "kind": "local",
+    "name": "develop",
+  },
+  "node": {
+    "$$typeof": Symbol(react.transitional.element),
+    "_owner": null,
+    "_store": {},
+    "key": null,
+    "props": {
+      "children": [
+        {
+          "$$typeof": Symbol(react.transitional.element),
+          "_owner": null,
+          "_store": {},
+          "key": "test-key",
+          "props": {
+            "bold": false,
+            "children": " develop ",
+            "color": "blue",
+            "inverse": true,
+          },
+          "type": [Function],
+        },
+        {
+          "$$typeof": Symbol(react.transitional.element),
+          "_owner": null,
+          "_store": {},
+          "key": "test-key-pad",
+          "props": {
+            "children": " ",
+          },
+          "type": [Function],
+        },
+      ],
+    },
+    "type": [Function],
+  },
+  "width": 10,
+}
+`;
+
+exports[`renderBranchTipChip — structural snapshots renders a remote-tracking ref as a yellow inverse pill 1`] = `
+{
+  "chip": {
+    "isHead": false,
+    "kind": "remote",
+    "name": "origin/main",
+  },
+  "node": {
+    "$$typeof": Symbol(react.transitional.element),
+    "_owner": null,
+    "_store": {},
+    "key": null,
+    "props": {
+      "children": [
+        {
+          "$$typeof": Symbol(react.transitional.element),
+          "_owner": null,
+          "_store": {},
+          "key": "test-key",
+          "props": {
+            "bold": false,
+            "children": " origin/main ",
+            "color": "yellow",
+            "inverse": true,
+          },
+          "type": [Function],
+        },
+        {
+          "$$typeof": Symbol(react.transitional.element),
+          "_owner": null,
+          "_store": {},
+          "key": "test-key-pad",
+          "props": {
+            "children": " ",
+          },
+          "type": [Function],
+        },
+      ],
+    },
+    "type": [Function],
+  },
+  "width": 14,
+}
+`;
+
+exports[`renderBranchTipChip — structural snapshots renders a slashy local branch as a blue pill when remoteNames distinguishes it 1`] = `
+{
+  "chip": {
+    "isHead": false,
+    "kind": "local",
+    "name": "feat/widgets",
+  },
+  "node": {
+    "$$typeof": Symbol(react.transitional.element),
+    "_owner": null,
+    "_store": {},
+    "key": null,
+    "props": {
+      "children": [
+        {
+          "$$typeof": Symbol(react.transitional.element),
+          "_owner": null,
+          "_store": {},
+          "key": "test-key",
+          "props": {
+            "bold": false,
+            "children": " feat/widgets ",
+            "color": "blue",
+            "inverse": true,
+          },
+          "type": [Function],
+        },
+        {
+          "$$typeof": Symbol(react.transitional.element),
+          "_owner": null,
+          "_store": {},
+          "key": "test-key-pad",
+          "props": {
+            "children": " ",
+          },
+          "type": [Function],
+        },
+      ],
+    },
+    "type": [Function],
+  },
+  "width": 15,
+}
+`;
+
+exports[`renderBranchTipChip — structural snapshots renders bracketed fallback in noColor mode 1`] = `
+{
+  "chip": {
+    "isHead": true,
+    "kind": "head",
+    "name": "main",
+  },
+  "node": {
+    "$$typeof": Symbol(react.transitional.element),
+    "_owner": null,
+    "_store": {},
+    "key": "test-key",
+    "props": {
+      "bold": true,
+      "children": "[main] ",
+    },
+    "type": [Function],
+  },
+  "width": 7,
+}
+`;
+
+exports[`renderBranchTipChip — structural snapshots renders the HEAD chip as a green inverse pill 1`] = `
+{
+  "chip": {
+    "isHead": true,
+    "kind": "head",
+    "name": "main",
+  },
+  "node": {
+    "$$typeof": Symbol(react.transitional.element),
+    "_owner": null,
+    "_store": {},
+    "key": null,
+    "props": {
+      "children": [
+        {
+          "$$typeof": Symbol(react.transitional.element),
+          "_owner": null,
+          "_store": {},
+          "key": "test-key",
+          "props": {
+            "bold": true,
+            "children": " main ",
+            "color": "green",
+            "inverse": true,
+          },
+          "type": [Function],
+        },
+        {
+          "$$typeof": Symbol(react.transitional.element),
+          "_owner": null,
+          "_store": {},
+          "key": "test-key-pad",
+          "props": {
+            "children": " ",
+          },
+          "type": [Function],
+        },
+      ],
+    },
+    "type": [Function],
+  },
+  "width": 7,
+}
+`;

--- a/src/workstation/surfaces/history/branchTipChipRender.test.ts
+++ b/src/workstation/surfaces/history/branchTipChipRender.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Structural snapshot tests for `renderBranchTipChip`.
+ *
+ * Why: the chip is colour-coded by kind (`head` → success, `local` →
+ * info, `remote` → warning) and renders subtly differently for
+ * selected rows and `noColor` mode. Easy to break inadvertently
+ * when refactoring nearby code. The shape of the returned React tree
+ * captures every visual decision the function makes, so snapshotting
+ * it pins the contract cleanly.
+ *
+ * These are STRUCTURAL snapshots, not visual frame captures: we
+ * inspect the React element tree directly (Text stubs collect props)
+ * rather than running Ink and capturing terminal escape codes. That
+ * makes the snapshots deterministic across CI and developer terminals
+ * and the diffs human-readable.
+ */
+import { createElement } from 'react'
+import type { GitLogCommitRow } from '../../../commands/log/data'
+import { createLogInkTheme } from '../../chrome/theme'
+import { renderBranchTipChip } from './index'
+
+// Stub Text component: a functional component that wraps its props
+// and children into a synthetic 'text' element so jest's snapshot
+// serializer pretty-prints the React tree without depending on Ink.
+// We coerce to `any` because the real LogInkComponents['Text'] is
+// Ink's Text type and we don't want to import Ink (ESM) inside a
+// ts-jest CJS test. What ends up in the snapshot is what matters.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const Text = ((props: any) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { children, ...rest } = props as any
+  return createElement('text', rest, children)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+}) as any
+
+function makeRow(refs: string[]): GitLogCommitRow {
+  return {
+    type: 'commit',
+    graph: '*',
+    shortHash: 'abc1234',
+    hash: 'abc1234deadbeef',
+    parents: [],
+    date: '2026-05-18',
+    author: 'Alice',
+    refs,
+    message: 'feat: example commit',
+  }
+}
+
+function render(
+  refs: string[],
+  options: {
+    selected?: boolean
+    noColor?: boolean
+    remoteNames?: string[]
+  } = {}
+) {
+  const theme = createLogInkTheme({ noColor: options.noColor })
+  const result = renderBranchTipChip(
+    createElement,
+    Text,
+    makeRow(refs),
+    theme,
+    'test-key',
+    options.selected ?? false,
+    options.remoteNames
+  )
+  return { node: result.node, width: result.width, chip: result.chip }
+}
+
+describe('renderBranchTipChip — structural snapshots', () => {
+  it('renders the HEAD chip as a green inverse pill', () => {
+    expect(render(['HEAD -> main'])).toMatchSnapshot()
+  })
+
+  it('renders a plain local branch chip as a blue inverse pill', () => {
+    expect(render(['develop'])).toMatchSnapshot()
+  })
+
+  it('renders a remote-tracking ref as a yellow inverse pill', () => {
+    expect(render(['origin/main'])).toMatchSnapshot()
+  })
+
+  it('renders a slashy local branch as a blue pill when remoteNames distinguishes it', () => {
+    // The critical regression case: feat/widgets contains a slash but
+    // is NOT a remote ref. With remoteNames=['origin'] the classifier
+    // recognizes this and paints it blue (local), not yellow (remote).
+    expect(render(['feat/widgets'], { remoteNames: ['origin'] })).toMatchSnapshot()
+  })
+
+  it('falls back to the legacy "slash = remote" heuristic when remoteNames is absent', () => {
+    // Without remoteNames, the same feat/widgets ref classifies as
+    // remote and renders yellow. Pin the legacy behaviour so we know
+    // exactly what callers without branch data get.
+    expect(render(['feat/widgets'])).toMatchSnapshot()
+  })
+
+  it('drops pill styling on selected rows (the row inverse carries it)', () => {
+    // When a row is selected we render the chip as bracketed plain
+    // text so the row's outer inverse highlight isn't double-flipped
+    // back to plain by a chip-level inverse.
+    expect(render(['HEAD -> main'], { selected: true })).toMatchSnapshot()
+  })
+
+  it('renders bracketed fallback in noColor mode', () => {
+    expect(render(['HEAD -> main'], { noColor: true })).toMatchSnapshot()
+  })
+
+  it('returns no node for refs without a chip-worthy entry', () => {
+    const result = render(['tag: v1.0.0'])
+    expect(result.node).toBeNull()
+    expect(result.width).toBe(0)
+    expect(result.chip).toBeUndefined()
+  })
+
+  it('reports a non-zero width for the chip-bearing variants', () => {
+    expect(render(['HEAD -> main']).width).toBeGreaterThan(0)
+    expect(render(['origin/main']).width).toBeGreaterThan(0)
+    expect(render(['develop']).width).toBeGreaterThan(0)
+  })
+})

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -109,7 +109,11 @@ const BRANCH_CHIP_MAX_NAME_WIDTH = 20
  * descriptor so the caller can pass it to `filterChippedRefs` and
  * avoid emitting the same branch a second time in the trailing list.
  */
-function renderBranchTipChip(
+// Exported for unit / snapshot testing in branchTipChipRender.test.ts.
+// The function isn't part of the public surface of this module — the
+// rest of the file is internal — but the chip-rendering logic is
+// dense enough that structural snapshot tests pay for themselves.
+export function renderBranchTipChip(
   h: typeof ReactTypes.createElement,
   Text: LogInkComponents['Text'],
   commit: GitLogCommitRow,


### PR DESCRIPTION
Adds 9 tests around \`renderBranchTipChip\` — the function in the history surface that turns a commit's refs into the coloured pill chip prefix.

## What's covered

The unit-level \`branchTip.test.ts\` already pins the metadata contract (kind discriminator, name extraction, remote-classification heuristic). This new suite pins the **visual output**:

- Which colour does each chip kind use? (head → green/success, local → blue/info, remote → yellow/warning)
- Does the pill use \`inverse: true\`?
- Does \`bold\` only apply to HEAD chips?
- What does the bracketed fallback look like for selected rows?
- What does \`noColor\` mode produce?
- Width math correct?

## How it works

- Exports \`renderBranchTipChip\` from \`src/workstation/surfaces/history/index.ts\` (was file-internal; rest of the module stays private)
- Stubs \`Text\` so we don't have to load Ink (ESM) in a ts-jest CJS test — the stub passes props + children to a synthetic \`'text'\` element so jest's snapshot serializer prints the React tree readably
- 7 \`toMatchSnapshot\` cases + 2 plain assertions

## Sample of what a snapshot looks like

\`\`\`
exports[\`... renders a remote-tracking ref as a yellow inverse pill 1\`] = \`
{
  "chip": { "isHead": false, "kind": "remote", "name": "origin/main" },
  "node": {
    "props": {
      "children": [
        { "props": { "color": "yellow", "inverse": true, "bold": false,
                     "children": " origin/main " } },
        { "props": { "children": " " } }
      ]
    }
  },
  "width": 13,
}
\`;
\`\`\`

Anyone breaking the chip colour mapping, dropping inverse, or changing the padding will see a noisy snapshot diff — easier than visual inspection.

## Test plan

- [x] \`npx jest src/workstation src/commands/log\` — 973 pass (was 964 + 9 new)
- [x] eslint clean on touched files
- [x] No public API change to the history module — function was already internal, just gets an \`export\` keyword for the test