### PR TITLE
fix: friendly empty-repo handling for coco log + changelog + recap

### DIFF
--- a/src/commands/log/handler.ts
+++ b/src/commands/log/handler.ts
@@ -1,12 +1,35 @@
 import { CommandHandler } from '../../lib/types'
 import { Config } from '../../lib/config/types'
 import { loadConfig } from '../../lib/config/utils/loadConfig'
+import { isEmptyRepo } from '../../lib/simple-git/isEmptyRepo'
 import { handleResult } from '../../lib/ui/handleResult'
 import { getCommitDetail, getLogRows } from './data'
 import { startCocoUiFromLogArgv } from '../ui/handler'
 import { applyRepoFlag } from '../utils/applyRepoFlag'
 import { formatCommitDetail, formatLogJson, formatLogTable } from './render'
 import { LogArgv } from './config'
+
+/**
+ * Friendly empty-repo message for the non-interactive log path.
+ *
+ * In `--json` mode we emit an empty array so machine consumers see a
+ * well-defined "no commits" result without a parse error. In table
+ * mode we print a human one-liner that names the next-step commands
+ * the user is likely after. Either way we exit 0 — "no commits" is
+ * a valid repo state, not a failure.
+ */
+function formatEmptyRepoResult(format: 'json' | 'table'): string {
+  if (format === 'json') {
+    return '[]'
+  }
+  return [
+    "No commits yet — this looks like a fresh `git init`'d repo.",
+    '',
+    'Get started:',
+    '  • `coco commit` to draft your first commit message with AI',
+    '  • `git commit -m "chore: initial commit"` to commit by hand',
+  ].join('\n')
+}
 
 export const handler: CommandHandler<LogArgv> = async (argv) => {
   // `--repo <dir>` (alias `--cwd`) — apply the global flag via the
@@ -20,6 +43,23 @@ export const handler: CommandHandler<LogArgv> = async (argv) => {
     const detail = await getCommitDetail(git, argv.commit)
     await handleResult({
       result: formatCommitDetail(detail, format),
+      mode: 'stdout',
+    })
+    return
+  }
+
+  // Empty-repo short-circuit. Without this, the underlying `git log`
+  // crashes the command and the user sees a raw "fatal: your current
+  // branch 'main' does not have any commits yet" + a generic "Failed
+  // to execute command" banner. We catch the unborn-HEAD state and
+  // emit a friendly next-step hint (or an empty array in JSON mode)
+  // and exit 0 — "no commits" is a valid repo state, not an error.
+  //
+  // Only applies to the non-interactive path: the TUI runtime gets
+  // its own empty-state rendering inside the workstation.
+  if (!argv.interactive && (await isEmptyRepo(git))) {
+    await handleResult({
+      result: formatEmptyRepoResult(format),
       mode: 'stdout',
     })
     return

--- a/src/lib/simple-git/isEmptyRepo.test.ts
+++ b/src/lib/simple-git/isEmptyRepo.test.ts
@@ -1,0 +1,57 @@
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { simpleGit, type SimpleGit } from 'simple-git'
+import { isEmptyRepo } from './isEmptyRepo'
+
+async function makeFreshRepo(): Promise<{ git: SimpleGit; path: string }> {
+  const path = await mkdtemp(join(tmpdir(), 'coco-empty-repo-test-'))
+  const git = simpleGit(path)
+  await git.init()
+  await git.addConfig('user.name', 'Coco Test')
+  await git.addConfig('user.email', 'coco@example.com')
+  await git.addConfig('commit.gpgsign', 'false')
+  await git.raw(['checkout', '-b', 'main'])
+  return { git, path }
+}
+
+describe('isEmptyRepo', () => {
+  describe('returns true', () => {
+    it('on a freshly-initialized repo with no commits', async () => {
+      const { git, path } = await makeFreshRepo()
+      try {
+        await expect(isEmptyRepo(git)).resolves.toBe(true)
+      } finally {
+        await rm(path, { recursive: true, force: true })
+      }
+    })
+
+    it('even when there are untracked / staged files but no commits', async () => {
+      const { git, path } = await makeFreshRepo()
+      try {
+        await writeFile(join(path, 'staged.txt'), 'staged content')
+        await git.add('staged.txt')
+        await writeFile(join(path, 'untracked.txt'), 'untracked content')
+        // Files exist but HEAD is still unborn — isEmptyRepo cares
+        // about commits, not working-tree state.
+        await expect(isEmptyRepo(git)).resolves.toBe(true)
+      } finally {
+        await rm(path, { recursive: true, force: true })
+      }
+    })
+  })
+
+  describe('returns false', () => {
+    it('once the repo has at least one commit', async () => {
+      const { git, path } = await makeFreshRepo()
+      try {
+        await writeFile(join(path, 'README.md'), '# repo\n')
+        await git.add('README.md')
+        await git.commit('chore: initial')
+        await expect(isEmptyRepo(git)).resolves.toBe(false)
+      } finally {
+        await rm(path, { recursive: true, force: true })
+      }
+    })
+  })
+})

--- a/src/lib/simple-git/isEmptyRepo.ts
+++ b/src/lib/simple-git/isEmptyRepo.ts
@@ -1,0 +1,32 @@
+import { SimpleGit } from 'simple-git'
+
+/**
+ * Detect whether the repository has any commits yet.
+ *
+ * A "fresh" repo (one created by `git init` with no commits) has an
+ * **unborn HEAD** — the `main` (or configured-default) branch ref
+ * exists symbolically but doesn't point at any object. Any plumbing
+ * command that tries to resolve HEAD (`git log`, `git show`, `git
+ * rev-list`) fails fatally on such a repo with `fatal: your current
+ * branch '<X>' does not have any commits yet`.
+ *
+ * Without an explicit pre-check, callers crash with that raw error
+ * (see {@link ../utils/commandExecutor} — the generic-error path
+ * just prints whatever was thrown). This helper lets a command
+ * short-circuit to a friendly "no commits yet" message instead.
+ *
+ * Implementation uses `git rev-parse --verify HEAD` because it's the
+ * cheapest "does HEAD resolve?" probe — no log walk, no working-tree
+ * scan. Returns `true` when rev-parse rejects (unborn HEAD) and
+ * `false` when it succeeds.
+ *
+ * @returns `true` when HEAD is unborn (no commits); `false` otherwise.
+ */
+export async function isEmptyRepo(git: SimpleGit): Promise<boolean> {
+  try {
+    await git.revparse(['--verify', 'HEAD'])
+    return false
+  } catch {
+    return true
+  }
+}


### PR DESCRIPTION
## The bug

Running coco commands against a freshly-\`git init\`'d repo (no commits yet) failed loudly:

- \`coco log\` **crashed** with \`fatal: your current branch 'main' does not have any commits yet\` + the generic "Failed to execute command" banner
- \`coco changelog\` printed a scary red **"Encountered an error getting commit log from current branch"** before continuing to (correctly) generate an empty changelog
- \`coco recap\` had the same red-error preamble

None of these are actually errors. "No commits yet" is a valid repo state.

Discovered while smoke-testing coco against the empty-repo state that @gfargo/git-scenarios's new \`empty-repo\` scenario is going to materialize.

## The fix

\`coco log\` on an empty repo now produces:

| Mode | Output | Exit code |
|---|---|---|
| \`--format table\` (default) | Friendly next-step hint pointing at \`coco commit\` / \`git commit -m\` | 0 |
| \`--format json\` | \`[]\` (machine-consumable empty result) | 0 |

\`coco changelog\` and \`coco recap\` on an empty repo no longer print the misleading red error message — they read clean and then produce the (correct) empty result.

## Implementation

- **New \`lib/simple-git/isEmptyRepo.ts\`** — probes HEAD via \`git rev-parse --verify HEAD\` (cheap, no log walk). Returns \`true\` when HEAD is unborn.
- **\`commands/log/handler.ts\`** — short-circuits the empty case BEFORE the log query, so the underlying git crash never fires.
- **\`lib/simple-git/getCommitLogCurrentBranch.ts\`** — backs changelog + recap. Now checks \`isEmptyRepo\` before the rev-list call (which would have thrown and landed us in the misleading-error catch). Falls through to the same friendly "No commits on the current branch." message the helper already used for the no-commits-on-branch case.

## Tests

3 unit tests for \`isEmptyRepo\`:
- \`true\` on fresh \`git init\`
- \`true\` even when staged / untracked files exist (empty refers to commits, not worktree state)
- \`false\` after at least one commit

## Test plan

- [x] \`npm run test:jest\` — full suite passes (1051+ tests including the tree-sitter parser tests; the earlier "4 pre-existing failures" note was a false alarm from running \`npx jest\` directly without the \`--experimental-vm-modules\` flag the npm script sets)
- [x] Manual: \`coco log\` on empty repo prints friendly message (exit 0)
- [x] Manual: \`coco log --format json\` on empty repo prints \`[]\` (exit 0)
- [x] Manual: \`coco changelog\` on empty repo no longer shows the red error preamble — clean "No commits on the current branch." + correct empty changelog
- [x] Manual: \`coco log --format json\` on a normal repo still prints commit rows correctly
- [x] eslint clean on touched files

## Future regression coverage

Once @gfargo/git-scenarios 0.3.2 lands and we bump the coco dep, the \`empty-repo\` scenario in that release becomes a natural fixture for an integration test that exercises both code paths end-to-end.