### PR TITLE
fix(ui): TUI no longer crashes status line on empty repo

### DIFF
--- a/src/commands/log/data.test.ts
+++ b/src/commands/log/data.test.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { simpleGit } from 'simple-git'
 import { Arguments } from 'yargs'
 import {
   FIELD_SEPARATOR,
@@ -7,6 +11,7 @@ import {
   buildToggleGraphArgs,
   getCommitFilePreview,
   getCommitRows,
+  getLogRows,
   getLogView,
   parseCommitDetail,
   parseLogOutput,
@@ -330,6 +335,48 @@ describe('log data layer', () => {
     expect(removed.submoduleChange).toEqual({
       kind: 'removed',
       before: 'bbbbbbbb',
+    })
+  })
+
+  describe('getLogRows empty-repo handling', () => {
+    it('returns [] on a freshly-initialized repo with no commits', async () => {
+      const path = await mkdtemp(join(tmpdir(), 'coco-log-empty-test-'))
+      try {
+        const git = simpleGit(path)
+        await git.init()
+        await git.addConfig('user.name', 'Coco Test')
+        await git.addConfig('user.email', 'coco@example.com')
+        await git.raw(['checkout', '-b', 'main'])
+
+        // Without the isEmptyRepo short-circuit this would throw with
+        // "your current branch 'main' does not have any commits yet".
+        const rows = await getLogRows(git, argv())
+        expect(rows).toEqual([])
+      } finally {
+        await rm(path, { recursive: true, force: true })
+      }
+    })
+
+    it('returns commit rows on a repo with commits', async () => {
+      const path = await mkdtemp(join(tmpdir(), 'coco-log-onecommit-test-'))
+      try {
+        const git = simpleGit(path)
+        await git.init()
+        await git.addConfig('user.name', 'Coco Test')
+        await git.addConfig('user.email', 'coco@example.com')
+        await git.addConfig('commit.gpgsign', 'false')
+        await git.raw(['checkout', '-b', 'main'])
+        await writeFile(join(path, 'README.md'), '# repo\n')
+        await git.add('README.md')
+        await git.commit('chore: initial')
+
+        const rows = await getLogRows(git, argv())
+        expect(rows.length).toBeGreaterThan(0)
+        const commitRows = getCommitRows(rows)
+        expect(commitRows[0]?.message).toBe('chore: initial')
+      } finally {
+        await rm(path, { recursive: true, force: true })
+      }
     })
   })
 })

--- a/src/commands/log/data.ts
+++ b/src/commands/log/data.ts
@@ -1,6 +1,7 @@
 import { SimpleGit } from 'simple-git'
 import { extractLfsPatchChange, renderLfsSummary } from '../../git/lfsPointer'
 import { extractSubmoduleChange, renderSubmoduleSummary, type SubmoduleChange } from '../../git/submoduleDiff'
+import { isEmptyRepo } from '../../lib/simple-git/isEmptyRepo'
 import { LogArgv, LogView } from './config'
 
 export const FIELD_SEPARATOR = '\x1f'
@@ -334,6 +335,19 @@ export async function getLogRows(
   argv: LogArgv,
   options: LogRowLoadOptions = {}
 ): Promise<GitLogRow[]> {
+  // Unborn HEAD short-circuit. Without this, `git log` on a freshly
+  // `git init`'d repo throws "fatal: your current branch 'main' does
+  // not have any commits yet" — fine when the caller can catch and
+  // translate, painful otherwise (the workstation runtime surfaces it
+  // as "Failed to load commits: fatal: ..." in the status line).
+  //
+  // Returning [] is the natural contract: callers that already render
+  // an empty-history surface (`formatLogInkHistoryEmpty`) get the
+  // right experience automatically; `coco log` retains its own
+  // friendlier message via the handler's isEmptyRepo check.
+  if (await isEmptyRepo(git)) {
+    return []
+  }
   return parseLogOutput(await git.raw(buildLogArgs(argv, options)))
 }
 


### PR DESCRIPTION
## The bug

When \`coco ui\` / \`coco log -i\` mounts against a freshly-\`git init\`'d repo, the background \`loadRows()\` effect calls \`getLogRows()\` which throws the same unborn-HEAD git error fixed in #1008 for the non-interactive path.

In the workstation, the error caught at \`app.ts:829\` surfaces as a status-line message:

\`\`\`
Failed to load commits: fatal: your current branch 'main' does
not have any commits yet
\`\`\`

Confusing UX for a perfectly-valid repo state. The history surface ALREADY has the right empty-state copy (\`No commits yet. Make your first commit to populate the history.\` in \`formatLogInkHistoryEmpty\`) — it just never got to show it because the load failed before the empty-state branch could run.

## The fix

\`getLogRows\` now short-circuits on unborn HEAD and returns \`[]\`. The history surface then renders its existing empty-state cleanly.

Both callers benefit:
- **\`coco ui\` / \`coco log -i\`**: status line stays calm; history surface shows "No commits yet…"
- **\`coco log\` (non-interactive)**: unchanged — the handler's \`isEmptyRepo\` check from #1008 still runs first and emits the friendlier table/JSON output before \`getLogRows\` is called

## Relationship to #1008

This PR depends on the \`isEmptyRepo\` helper introduced in #1008. To keep merge order flexible, that file is included here too — if #1008 merges first the duplicate is a no-op (identical files); if this merges first #1008's rebase sees the file already exists. Either order works.

## Tests

- 2 new integration tests in \`data.test.ts\` — spin up real temp repos (empty + one-commit) and verify the \`[]\` / \`[...rows]\` contracts
- 3 existing \`isEmptyRepo\` unit tests (same as in #1008)

## Test plan

- [x] \`npm run test:jest\` — 1503 workstation+log+lib tests pass
- [x] eslint clean
- [ ] Manual: \`coco ui\` against an empty repo — should mount, history surface shows "No commits yet…", no scary status-line error

## Correction to #1008 description

The "4 pre-existing tree-sitter failures on main" I flagged in #1008 was a false alarm — I was running \`npx jest\` directly without the \`NODE_OPTIONS=--experimental-vm-modules\` flag that \`npm run test:jest\` sets. With the flag on, all parser tests pass. Updated the #1008 description accordingly.