### PR TITLE
fix(changelog): handle detached HEAD / no-origin / mid-op gracefully

### DIFF
--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -213,7 +213,13 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
     }
 
     if (!data.commits || data.commits.length === 0) {
-      return `## ${data.branch}\n\nNo commits found.`
+      // Short-circuit with an empty context so the review loop drops
+      // into `noResult` instead of spending an LLM call summarising
+      // "No commits found." into a fake changelog entry. The
+      // upstream helper (getCommitLogCurrentBranch) already logged
+      // the reason (detached HEAD, missing comparison ref, branch at
+      // baseline, etc.) in a friendly status line.
+      return ''
     }
 
     let result = `## ${data.branch}\n\n`
@@ -307,11 +313,16 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
     },
     noResult: async () => {
       if (config.range) {
-        logger.log(`No commits found in the provided range.`, { color: 'red' })
+        logger.log(`No commits found in the provided range.`, { color: 'yellow' })
         commandExit(0)
       }
 
-      logger.log(`No commits found in the current branch.`, { color: 'red' })
+      // Yellow rather than red — for the no-commits-on-current-branch
+      // case the upstream helper has already explained the reason in
+      // a friendly status line (detached HEAD, no comparison ref,
+      // branch at baseline). This is the trailing summary, not an
+      // error.
+      logger.log(`No commits found in the current branch.`, { color: 'yellow' })
       commandExit(0)
     },
   })

--- a/src/commands/commands.integration.test.ts
+++ b/src/commands/commands.integration.test.ts
@@ -20,10 +20,12 @@ import { Config } from '../commands/types'
 import {
   createTempGitRepo,
   TempGitRepo,
+  detachedHeadScenario,
   featureBranchOneCommitScenario,
   singleStagedFileScenario,
   twoCommitFeatureScenario,
 } from '@gfargo/git-scenarios'
+import { isCommandExitError } from '../lib/utils/commandExit'
 
 jest.mock('@langchain/classic/chains', () => ({
   loadSummarizationChain: jest.fn(),
@@ -663,6 +665,52 @@ describe('command integration with temp git repos', () => {
     expect(stdout).toContain('- Summarized feature work')
     expect(variables.summary).toContain('feat: add feature module')
     expect(variables.summary).toContain('feat/x')
+  })
+
+  // Regression — on a detached HEAD the helper used to emit a yellow
+  // "Unable to determine first and last commit" line and the handler
+  // still walked the LLM through a "No commits found." summarization.
+  // Now the helper emits a clean status line, the parser short-circuits
+  // to noResult, and the changelog handler exits 0 without an LLM call.
+  it('changelog on detached HEAD exits cleanly without an LLM call', async () => {
+    mockLoadConfig.mockImplementation((argv) => createConfig({
+      ...(argv as Record<string, unknown>),
+      mode: 'stdout',
+    }))
+
+    await detachedHeadScenario.setup(repo)
+
+    const logger = createLogger()
+    try {
+      await changelogHandler({
+        $0: 'coco',
+        _: ['changelog'],
+        branch: '',
+        range: '',
+        tag: '',
+        sinceLastTag: false,
+        withDiff: false,
+        onlyDiff: false,
+        interactive: false,
+        verbose: false,
+        version: false,
+        help: false,
+      } as Arguments<ChangelogOptions>, logger)
+    } catch (error) {
+      // commandExit(0) throws CommandExitError — that's the success
+      // signal here. Rethrow anything else.
+      if (!isCommandExitError(error)) {
+        throw error
+      }
+      expect((error as { code: number }).code).toBe(0)
+    }
+
+    const lines = (logger.log as jest.Mock).mock.calls.map(([msg]) => String(msg))
+    const joined = lines.join('\n')
+    expect(joined).toMatch(/HEAD is detached/i)
+    expect(joined).not.toMatch(/Encountered an error/i)
+    expect(joined).not.toMatch(/Unable to determine/i)
+    expect(mockExecuteChain).not.toHaveBeenCalled()
   })
 
   it('reviews real working tree changes from a temp git repo', async () => {

--- a/src/lib/simple-git/getCommitLogCurrentBranch.test.ts
+++ b/src/lib/simple-git/getCommitLogCurrentBranch.test.ts
@@ -1,0 +1,192 @@
+import {
+  addCommit,
+  chain,
+  checkoutBranch,
+  createTempGitRepo,
+  detachedHeadScenario,
+  midBisectScenario,
+  startRebase,
+  switchToBranch,
+  type TempGitRepo,
+} from '@gfargo/git-scenarios'
+
+import { Logger } from '../utils/logger'
+import { getCommitLogCurrentBranch } from './getCommitLogCurrentBranch'
+
+function createLogger() {
+  return {
+    log: jest.fn(),
+    verbose: jest.fn(),
+    setConfig: jest.fn(),
+    startTimer: jest.fn().mockReturnThis(),
+    stopTimer: jest.fn().mockReturnThis(),
+    startSpinner: jest.fn().mockReturnThis(),
+    stopSpinner: jest.fn().mockReturnThis(),
+  } as unknown as Logger & { log: jest.Mock; verbose: jest.Mock }
+}
+
+function getLogCalls(logger: ReturnType<typeof createLogger>): string[] {
+  return (logger.log as jest.Mock).mock.calls.map(([message]) => String(message))
+}
+
+describe('getCommitLogCurrentBranch — edge states', () => {
+  jest.setTimeout(20000)
+
+  let repo: TempGitRepo
+
+  beforeEach(async () => {
+    repo = await createTempGitRepo()
+  })
+
+  afterEach(async () => {
+    await repo.cleanup()
+  })
+
+  // #1 — Detached HEAD. `git rev-parse --abbrev-ref HEAD` returns the
+  // literal string 'HEAD', so we have no branch context to compare
+  // against. The previous behavior was a yellow "Unable to determine
+  // first and last commit" line that read like a failure; the helper
+  // should report this as a state, not an error.
+  it('detached HEAD — logs a clean status, returns []', async () => {
+    await detachedHeadScenario.setup(repo)
+    const logger = createLogger()
+
+    const result = await getCommitLogCurrentBranch({ git: repo.git, logger })
+
+    expect(result).toEqual([])
+    const lines = getLogCalls(logger)
+    expect(lines.join('\n')).toMatch(/HEAD is detached/i)
+    expect(lines.join('\n')).not.toMatch(/Encountered an error/i)
+    expect(lines.join('\n')).not.toMatch(/Unable to determine/i)
+  })
+
+  // #2 — Mid-rebase with unresolved conflicts. During a rebase, git
+  // detaches HEAD onto the rewritten commit. Same handling as detached
+  // HEAD applies.
+  it('mid-rebase with conflicts — logs a clean status, returns []', async () => {
+    await chain(
+      addCommit({ message: 'chore: initial', files: { 'x.ts': 'base\n' } }),
+      switchToBranch('feat/x'),
+      addCommit({ message: 'feat: theirs', files: { 'x.ts': 'theirs\n' } }),
+      checkoutBranch('main'),
+      addCommit({ message: 'feat: ours', files: { 'x.ts': 'ours\n' } }),
+      checkoutBranch('feat/x'),
+      startRebase('main'),
+    )(repo)
+
+    const logger = createLogger()
+    const result = await getCommitLogCurrentBranch({ git: repo.git, logger })
+
+    expect(result).toEqual([])
+    const joined = getLogCalls(logger).join('\n')
+    expect(joined).toMatch(/HEAD is detached|rebase|bisect/i)
+    expect(joined).not.toMatch(/Encountered an error/i)
+  })
+
+  // #3 — Mid-bisect: HEAD is detached at the midpoint candidate.
+  it('mid-bisect — logs a clean status, returns []', async () => {
+    await midBisectScenario.setup(repo)
+    const logger = createLogger()
+
+    const result = await getCommitLogCurrentBranch({ git: repo.git, logger })
+
+    expect(result).toEqual([])
+    const joined = getLogCalls(logger).join('\n')
+    expect(joined).toMatch(/HEAD is detached|rebase|bisect/i)
+    expect(joined).not.toMatch(/Encountered an error/i)
+  })
+
+  // #4 — No origin configured. The same-branch path tries to compare
+  // against `origin/main`; if that ref doesn't resolve, the previous
+  // catch-all printed a red "Encountered an error" banner.
+  it('no origin remote — logs a clean status, returns []', async () => {
+    await chain(
+      addCommit({ message: 'chore: initial', files: { 'README.md': '# repo\n' } }),
+      addCommit({ message: 'feat: a', files: { 'src/a.ts': 'a\n' } }),
+    )(repo)
+
+    const logger = createLogger()
+    // Default comparisonBranch === 'main' === current branch, and
+    // there's no `origin` remote in the temp repo, so `origin/main`
+    // does not resolve.
+    const result = await getCommitLogCurrentBranch({ git: repo.git, logger })
+
+    expect(result).toEqual([])
+    const joined = getLogCalls(logger).join('\n')
+    expect(joined).toMatch(/origin\/main/)
+    expect(joined).not.toMatch(/Encountered an error/i)
+  })
+
+  // Comparison branch missing entirely (different from current). The
+  // helper should surface the missing branch cleanly rather than
+  // throwing into the red catch block.
+  it('comparison branch does not exist — logs a clean status, returns []', async () => {
+    await chain(
+      addCommit({ message: 'chore: initial', files: { 'README.md': '# repo\n' } }),
+      switchToBranch('feat/x'),
+      addCommit({ message: 'feat: a', files: { 'src/a.ts': 'a\n' } }),
+    )(repo)
+
+    const logger = createLogger()
+    const result = await getCommitLogCurrentBranch({
+      git: repo.git,
+      logger,
+      comparisonBranch: 'develop',
+    })
+
+    expect(result).toEqual([])
+    const joined = getLogCalls(logger).join('\n')
+    expect(joined).toMatch(/develop/)
+    expect(joined).not.toMatch(/Encountered an error/i)
+  })
+
+  // Happy path: feature branch with commits ahead of main. Sanity
+  // check that the edge-state probes haven't broken the common case.
+  it('happy path — returns commits ahead of comparison branch', async () => {
+    await chain(
+      addCommit({ message: 'chore: initial', files: { 'README.md': '# repo\n' } }),
+      switchToBranch('feat/x'),
+      addCommit({ message: 'feat: a', files: { 'src/a.ts': 'a\n' } }),
+      addCommit({ message: 'feat: b', files: { 'src/b.ts': 'b\n' } }),
+    )(repo)
+
+    const logger = createLogger()
+    const result = await getCommitLogCurrentBranch({ git: repo.git, logger })
+
+    expect(result.length).toBe(2)
+    // git log default ordering is newest first.
+    expect(result.map((c) => c.message)).toEqual(['feat: b', 'feat: a'])
+    expect(getLogCalls(logger).join('\n')).not.toMatch(/Encountered an error/i)
+  })
+
+  // Same-branch path with a configured remote-tracking ref: should
+  // succeed using `origin/main` as the comparison ref. We fake the
+  // remote by pointing it at a separate local repo so origin/main
+  // resolves.
+  it('same-branch path resolves against origin/main when present', async () => {
+    // Build a "remote" repo with one commit on main.
+    const remote = await createTempGitRepo()
+    try {
+      await chain(
+        addCommit({ message: 'chore: initial', files: { 'README.md': '# remote\n' } }),
+      )(remote)
+
+      // Local repo mirrors the remote so origin/main resolves, then
+      // pushes ahead by one commit on main.
+      await repo.git.addRemote('origin', remote.path)
+      await repo.git.fetch('origin')
+      await repo.git.checkout(['-B', 'main', 'origin/main'])
+      await chain(
+        addCommit({ message: 'feat: local-ahead', files: { 'src/a.ts': 'a\n' } }),
+      )(repo)
+
+      const logger = createLogger()
+      const result = await getCommitLogCurrentBranch({ git: repo.git, logger })
+
+      expect(result.map((c) => c.message)).toEqual(['feat: local-ahead'])
+      expect(getLogCalls(logger).join('\n')).not.toMatch(/Encountered an error/i)
+    } finally {
+      await remote.cleanup()
+    }
+  })
+})

--- a/src/lib/simple-git/getCommitLogCurrentBranch.ts
+++ b/src/lib/simple-git/getCommitLogCurrentBranch.ts
@@ -10,8 +10,39 @@ export type GetCommitLogCurrentBranch = {
   comparisonRemote?: string
 }
 
+async function refExists(git: SimpleGit, ref: string): Promise<boolean> {
+  try {
+    // `--verify --quiet` suppresses stderr noise on a missing ref and
+    // emits the resolved sha on stdout when it exists. simple-git
+    // returns an empty string (rather than throwing) when git exits
+    // 1 under `--quiet`, so the presence/absence check is on the
+    // output, not on whether the call rejected.
+    const out = await git.raw(['rev-parse', '--verify', '--quiet', ref])
+    return out.trim().length > 0
+  } catch {
+    return false
+  }
+}
+
 /**
  * Retrieves the commit log for the current branch.
+ *
+ * Edge states that are not errors and should not be reported as such:
+ *
+ *   - Detached HEAD (including mid-rebase and mid-bisect, which both
+ *     leave HEAD detached). There is no "current branch" to compare
+ *     against; the helper logs a yellow status line and returns [].
+ *   - Comparison ref missing — e.g. the repo has no `origin` remote,
+ *     so `origin/main` does not resolve; or the local comparison
+ *     branch (`main`) simply does not exist. Previously this threw
+ *     and surfaced as a red "Encountered an error" banner. Now we
+ *     probe the ref up front and report a clean status line.
+ *   - Empty rev-list output. The previous yellow "Unable to determine
+ *     first and last commit" wording read like an error; it's just
+ *     "no commits ahead of the comparison ref", which is the normal
+ *     outcome when the branch is at or behind its baseline.
+ *
+ * The catch block is reserved for genuinely unexpected git failures.
  *
  * @param {Object} options - The options for retrieving the commit log.
  * @param {SimpleGit} options.git - The SimpleGit instance.
@@ -26,49 +57,70 @@ export async function getCommitLogCurrentBranch({
   comparisonBranch = 'main',
   comparisonRemote = 'origin',
 }: GetCommitLogCurrentBranch): Promise<CommitDetails[]> {
+  const branchName = await getCurrentBranchName({ git })
+
+  // Detached HEAD: `git rev-parse --abbrev-ref HEAD` returns the literal
+  // string 'HEAD' in this state. Also covers mid-rebase and mid-bisect,
+  // which both detach HEAD onto the picked / midpoint commit. There's
+  // no branch to compare against, so don't pretend there was an error.
+  if (!branchName || branchName === 'HEAD') {
+    logger?.log(
+      'HEAD is detached (or a rebase / bisect is in progress) — no branch context to compare against.',
+      { color: 'yellow' }
+    )
+    return []
+  }
+
   try {
-    const branchName = await getCurrentBranchName({ git })
-
-    const hasCommits = (await git.raw(['rev-list', '--count', branchName])) !== '0'
-    if (!hasCommits) {
-      logger?.log('No commits on the current branch.')
-      return []
-    }
-
-    let uniqueCommits
+    let comparisonRef: string
     if (comparisonBranch === branchName) {
-      // If the comparison branch is the same as the current branch, we compare against the remote.
-      uniqueCommits = (
-        await git.raw(['rev-list', `${comparisonRemote}/${comparisonBranch}..${branchName}`])
-      )
-        .split('\n')
-        .filter(Boolean)
-        .reverse()
+      // Same branch as the comparison target — compare against the
+      // remote-tracking ref. If the remote (or the ref) does not
+      // exist, fall back to a clean status line rather than throwing.
+      const remoteRef = `${comparisonRemote}/${comparisonBranch}`
+      if (!(await refExists(git, remoteRef))) {
+        logger?.log(
+          `No "${remoteRef}" ref to compare against — skipping changelog for "${branchName}".`,
+          { color: 'yellow' }
+        )
+        return []
+      }
+      comparisonRef = remoteRef
     } else {
-      // Your existing code for different branches
-      uniqueCommits = (await git.raw(['rev-list', `${comparisonBranch}..${branchName}`]))
-        .split('\n')
-        .filter(Boolean)
-        .reverse()
+      if (!(await refExists(git, comparisonBranch))) {
+        logger?.log(
+          `Comparison branch "${comparisonBranch}" does not exist — skipping changelog for "${branchName}".`,
+          { color: 'yellow' }
+        )
+        return []
+      }
+      comparisonRef = comparisonBranch
     }
 
-    logger?.verbose(`Found ${uniqueCommits.length} unique commits on "${branchName}"`, {
-      color: 'blue',
-    })
+    const uniqueCommits = (await git.raw(['rev-list', `${comparisonRef}..${branchName}`]))
+      .split('\n')
+      .filter(Boolean)
+      .reverse()
+
+    logger?.verbose(
+      `Found ${uniqueCommits.length} unique commits on "${branchName}" vs "${comparisonRef}"`,
+      { color: 'blue' }
+    )
 
     const firstCommit = uniqueCommits[0]
     const lastCommit = uniqueCommits[uniqueCommits.length - 1]
 
     if (!firstCommit || !lastCommit) {
-      logger?.log('Unable to determine first and last commit on the current branch', {
-        color: 'yellow',
-      })
+      // Empty rev-list output is the normal outcome when the branch is
+      // at or behind its baseline. Not an error.
+      logger?.log(`No commits on "${branchName}" ahead of "${comparisonRef}".`)
       return []
     }
 
     return await getCommitLogRangeDetails(firstCommit, lastCommit, { git, noMerges: true })
   } catch (error) {
     logger?.log('Encountered an error getting commit log from current branch', { color: 'red' })
+    logger?.verbose(error instanceof Error ? error.message : String(error), { color: 'red' })
   }
 
   return []


### PR DESCRIPTION
## Summary

`coco changelog` printed misleading status on several valid repo states:

- **Detached HEAD** (`git checkout --detach …`) → yellow _"Unable to determine first and last commit on the current branch"_
- **Mid-rebase** with conflicts → same yellow _"Unable to determine…"_
- **Mid-bisect** → same yellow _"Unable to determine…"_
- **Local-only repo (no `origin`)** → red _"Encountered an error getting commit log from current branch"_

None of those are errors. The root cause was in [src/lib/simple-git/getCommitLogCurrentBranch.ts](src/lib/simple-git/getCommitLogCurrentBranch.ts): the comparison ref (`origin/main` or `main`) was passed straight to `rev-list` and any non-resolution fell into a catch-all red banner; empty rev-list output produced the misleading yellow line.

### What changed

- **Detached-HEAD short-circuit.** `git rev-parse --abbrev-ref HEAD` returns the literal `'HEAD'` when detached (which also covers mid-rebase and mid-bisect, since both detach HEAD). The helper now logs a single yellow status line and returns `[]`.
- **Comparison-ref probe.** Before calling `rev-list`, the helper runs `rev-parse --verify --quiet` on the target ref. `simple-git` returns `''` (rather than throwing) on a missing ref under `--quiet`, so the check inspects the output — missing refs now produce a clean status line instead of a red banner.
- **Empty rev-list is a state, not an error.** The "no commits ahead of baseline" branch logs a neutral _"No commits on \"X\" ahead of \"Y\"."_ instead of a yellow _"Unable to determine first and last commit"_.
- **Catch block is now reserved for genuinely unexpected git failures** and surfaces the original message in `--verbose`.
- **`coco changelog` consumer**: parser short-circuits an empty commit list to `noResult` (instead of paying an LLM call to summarise _"No commits found."_), and the trailing summary is yellow rather than red — the helper has already explained the cause.

### Tests

[src/lib/simple-git/getCommitLogCurrentBranch.test.ts](src/lib/simple-git/getCommitLogCurrentBranch.test.ts) covers all four reported states plus a missing-comparison-branch case and two happy paths (no-origin same-branch, configured origin/main):

- Detached HEAD — via `detachedHeadScenario`
- Mid-rebase with conflicts — inline atom composition (no scenario for this yet)
- Mid-bisect — via `midBisectScenario`
- No `origin` remote — inline
- Missing comparison branch — inline
- Happy paths — inline

Plus a regression in [src/commands/commands.integration.test.ts](src/commands/commands.integration.test.ts) that runs the full changelog handler against `detachedHeadScenario` and asserts no LLM call and no misleading messages.

Followup to #1008 / #1009 (empty-repo handling) — same family of "valid repo state ≠ error" edge cases.

## Test plan

- [x] `npm run lint`
- [x] `npm run test:jest` — 1989 passed, 7 skipped (4 new in `getCommitLogCurrentBranch.test.ts`, 1 in `commands.integration.test.ts`)
- [x] `npm run build`
- [ ] Manual: `coco changelog` from detached HEAD prints clean yellow status, no red banner, no LLM call
- [ ] Manual: `coco changelog` mid-rebase prints clean status
- [ ] Manual: `coco changelog` on a fresh local repo (no `origin`) prints clean status