### PR TITLE
feat(split): planner orders groups by logical dependency

### DIFF
--- a/src/commands/commit/split.test.ts
+++ b/src/commands/commit/split.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests pinning the structural contract of the COMMIT_SPLIT_PROMPT
+ * template. The full prompt text is too long to snapshot wholesale,
+ * but a few key rules are load-bearing for the planner's output
+ * quality — losing them silently would degrade results in ways that
+ * only show up in eval runs days later. These tests catch the
+ * regression at the boundary.
+ */
+import { COMMIT_SPLIT_PROMPT } from './split'
+
+describe('COMMIT_SPLIT_PROMPT', () => {
+  // The langchain PromptTemplate exposes the raw template string on
+  // `.template`. Type it as unknown then narrow so we don't rely on
+  // a runtime cast inside individual assertions.
+  const template = String((COMMIT_SPLIT_PROMPT as unknown as { template: string }).template)
+
+  describe('structural rules block', () => {
+    it('declares the every-file-exactly-once rule', () => {
+      expect(template).toMatch(/Every staged file MUST be assigned exactly once/)
+    })
+
+    it('forbids mixing file-mode and hunk-mode for one file', () => {
+      expect(template).toMatch(/NEVER mix the two modes for the same file/)
+    })
+
+    it('requires complete hunk coverage when a file is split by hunks', () => {
+      expect(template).toMatch(/you MUST assign EVERY hunk for that file/)
+    })
+
+    it('restricts hunk IDs to those listed in the inventory', () => {
+      expect(template).toMatch(/Only use hunk IDs LITERALLY copied/)
+    })
+
+    it('prefers 2-5 commits as the default group count', () => {
+      expect(template).toMatch(/Prefer 2-5 commits/)
+    })
+
+    // Pin the dependency-ordering rule. The applier commits in array
+    // order, so this rule is what makes the resulting git history
+    // read in the order the code was logically built — foundational
+    // changes first, consumers after. Losing this bullet would
+    // silently degrade output quality for any split where two
+    // groups depend on each other.
+    it('asks the planner to order groups by logical dependency', () => {
+      expect(template).toMatch(/Order the groups in the sequence they would logically be built/)
+      expect(template).toMatch(/foundational changes first, consumers after/)
+      expect(template).toMatch(/A MUST appear before B/)
+    })
+  })
+
+  describe('commit message style block', () => {
+    it('requires imperative subjects under 72 chars', () => {
+      expect(template).toMatch(/imperative mood/)
+      expect(template).toMatch(/under 72 chars/)
+    })
+
+    it('discourages "this commit" / "this change" wording', () => {
+      expect(template).toMatch(/Avoid phrases like "this commit"/)
+    })
+  })
+
+  describe('placeholders', () => {
+    it('threads in commit_message_rules, commitlint_rules_context, branch_name_context', () => {
+      expect(template).toMatch(/\{commit_message_rules\}/)
+      expect(template).toMatch(/\{commitlint_rules_context\}/)
+      expect(template).toMatch(/\{branch_name_context\}/)
+    })
+
+    it('threads in the file + hunk + summary + feedback context', () => {
+      expect(template).toMatch(/\{file_inventory\}/)
+      expect(template).toMatch(/\{hunk_inventory\}/)
+      expect(template).toMatch(/\{summary\}/)
+      expect(template).toMatch(/\{previous_attempt_feedback\}/)
+    })
+  })
+})

--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -52,7 +52,7 @@ const CONVENTIONAL_COMMITS_RULES = `Each group's "title" MUST follow the Convent
 - subject is imperative mood, no trailing period, <72 chars
 - For breaking changes, the body must include a "BREAKING CHANGE:" footer explaining the break.`
 
-const COMMIT_SPLIT_PROMPT = PromptTemplate.fromTemplate(`You are helping split staged git changes into a small sequence of coherent commits.
+export const COMMIT_SPLIT_PROMPT = PromptTemplate.fromTemplate(`You are helping split staged git changes into a small sequence of coherent commits.
 
 Return ONLY valid JSON matching this schema:
 {{
@@ -76,6 +76,7 @@ Structural rules:
 - Only use hunk IDs LITERALLY copied from the "Staged hunk inventory" section below. Do not invent or guess hunk IDs.
 - If the hunk inventory says "No hunk-level inventory available" then EVERY group's "hunks" array MUST be empty (use only "files"). Do not write hunk IDs like "path::hunk-1" when no hunk inventory exists — those are not valid.
 - Prefer 2-5 commits unless the changes are truly all one topic.
+- Order the groups in the sequence they would logically be built — foundational changes first, consumers after. If group B uses a symbol, function, type, or file introduced in group A, A MUST appear before B in the array. The applier commits in array order, so this order becomes the git history. Example: a "feat: add helpers" group that introduces \`formatX()\` must come before a "feat: wire helpers into renderer" group that calls \`formatX()\`, even if the staged diff is presented in the opposite order. When two groups have no dependency relationship, prefer the one closer to a "scaffold" (types, config, new files) before the one closer to a "use site" (existing files modified to consume the new code).
 
 Commit message style:
 - Write each "title" in the imperative mood ("add", not "added"), under 72 chars.


### PR DESCRIPTION
The split planner produces N groups (each → one commit), and the applier commits them in array order. That order becomes the git history.

Before this PR, the prompt left ordering unspecified, and the planner frequently arranged groups by the shape of the staged diff rather than by the order the code was logically built. Result: histories where a \"wire helpers into renderer\" commit landed *before* the \"add helpers\" commit that introduces the symbols it consumes. The applier doesn't catch this (each commit is self-consistent at apply time because all staged content is in the worktree) but \`git log\` reads strangely and \`git bisect\` becomes harder than it should be.

## Change

One new bullet under the prompt's **Structural rules** block:

> Order the groups in the sequence they would logically be built — foundational changes first, consumers after. If group B uses a symbol, function, type, or file introduced in group A, A MUST appear before B in the array. The applier commits in array order, so this order becomes the git history. Example: a \"feat: add helpers\" group that introduces \`formatX()\` must come before a \"feat: wire helpers into renderer\" group that calls \`formatX()\`, even if the staged diff is presented in the opposite order. When two groups have no dependency relationship, prefer the one closer to a \"scaffold\" (types, config, new files) before the one closer to a \"use site\" (existing files modified to consume the new code).

## Tests

New \`split.test.ts\` pins the load-bearing parts of \`COMMIT_SPLIT_PROMPT\` against the rendered template string, including:

- the new dependency-ordering bullet (the one this PR adds)
- the file-exactly-once rule
- the no-mixing-modes rule
- the every-hunk-when-split rule
- the conventional-commit subject style rules
- the placeholder threading (\`{file_inventory}\`, \`{hunk_inventory}\`, etc.)

\`COMMIT_SPLIT_PROMPT\` is now \`export\`ed — needed so the test can read \`.template\` directly. The const becomes the public source of truth for the prompt structure.

## Test plan

- [x] \`npm run test:jest -- src/commands/commit/split.test.ts\` — 10 pass
- [x] \`npm run test:jest -- src/commands/commit src/workstation\` — 574 pass
- [x] eslint clean on touched files
- [ ] Manual eval: split a real staged set with dependency-shaped changes (a new helper + a consumer of the helper in the same plan) and verify the resulting git history reads in build order

## Pairs with

#1011 lands the user on history after split-apply, where this PR's ordering improvement is visible.