### PR TITLE
chore: bump @gfargo/git-scenarios to ^0.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@commitlint/types": "^20.5.0",
-    "@gfargo/git-scenarios": "^0.3.0",
+    "@gfargo/git-scenarios": "^0.3.3",
     "@rollup/plugin-commonjs": "^29.0.0",
     "@rollup/plugin-eslint": "^9.0.5",
     "@rollup/plugin-json": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -653,10 +653,10 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
-"@gfargo/git-scenarios@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@gfargo/git-scenarios/-/git-scenarios-0.3.0.tgz#03f92cf8723ae7a5aeccc967fa81089d79e27372"
-  integrity sha512-oLs42BThkNS0m2IJHDi/1SKOTQ0iaU9qMO2PDPk1acriS3z/p1IKijDNjJNxjbN9t7ycnPg0sPcPqntsa5Im5w==
+"@gfargo/git-scenarios@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@gfargo/git-scenarios/-/git-scenarios-0.3.3.tgz#08efd5d82aaa75f6341908639647596146bcccf8"
+  integrity sha512-wmlCu9q4BTiaFvLx8htdBHeRKmVp9RXWVnAUNUb0KD6P11KedaDnvNwEViTYzBUa6utuYoseggrs00MpMNv/bg==
 
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"


### PR DESCRIPTION
Brings in v0.3.3 of the scenarios package.

## What's new for coco

**New scenario** — \`branch-sync-showcase\`. A single repo with five local branches, each in a different upstream sync state:

| Branch | State |
|---|---|
| \`main\` (CHECKED OUT) | **2 behind** \`origin/main\` |
| \`feat/ahead-only\` | 3 ahead |
| \`feat/diverged\` | 2 ahead + 2 behind |
| \`feat/synced\` | at the same commit |
| \`local-only\` | no upstream configured |

Designed as the common fixture for the upcoming:
- **History-view "remote is ahead" banner** (task #3) — HEAD is on the behind branch, so the banner fires naturally
- **Branches-sidebar iconography + per-branch hotkeys** (task #4) — five different sync states visible at once

## Test plan

- [x] \`yarn add --dev @gfargo/git-scenarios@^0.3.3\` resolves cleanly
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx jest src/commands/commands.integration.test.ts\` — 17 pass
- [ ] Manual: \`npm run scenario create branch-sync-showcase -- --run-ui\` — should land on \`main\` with five branches visible in the branches sidebar tab

Release notes: https://github.com/gfargo/git-scenarios/releases/tag/v0.3.3