### PR TITLE
feat(ui): banner above commits when current branch is behind upstream

### DIFF
--- a/src/workstation/chrome/iconography.test.ts
+++ b/src/workstation/chrome/iconography.test.ts
@@ -3,6 +3,7 @@ import {
   branchRowMarker,
   formatBranchDivergence,
   formatBranchLastTouched,
+  formatUpstreamAheadBanner,
   getPullRequestStateGlyph,
   getStageStatusDotColor,
   sidebarTabCount,
@@ -43,6 +44,76 @@ describe('log Ink iconography', () => {
         { upstream: 'origin/main', ahead: 3, behind: 1 },
         { ascii: true }
       )).toBe('+3/-1 origin/main')
+    })
+  })
+
+  describe('formatUpstreamAheadBanner', () => {
+    it('returns undefined when the branch ref is missing (detached HEAD)', () => {
+      expect(formatUpstreamAheadBanner(undefined)).toBeUndefined()
+    })
+
+    it('returns undefined when there is no upstream configured', () => {
+      expect(formatUpstreamAheadBanner({ ahead: 0, behind: 0 })).toBeUndefined()
+      expect(formatUpstreamAheadBanner({ ahead: 3, behind: 0 })).toBeUndefined()
+    })
+
+    it('returns undefined when behind === 0 (synced or ahead-only)', () => {
+      expect(formatUpstreamAheadBanner(
+        { upstream: 'origin/main', ahead: 0, behind: 0 }
+      )).toBeUndefined()
+      expect(formatUpstreamAheadBanner(
+        { upstream: 'origin/main', ahead: 5, behind: 0 }
+      )).toBeUndefined()
+    })
+
+    describe('behind-only', () => {
+      it('formats N commits behind with fetch + pull hints', () => {
+        expect(formatUpstreamAheadBanner(
+          { upstream: 'origin/main', ahead: 0, behind: 2 }
+        )).toBe('↓ 2 commits behind origin/main · F fetch · U pull')
+      })
+
+      it('uses singular noun for behind === 1', () => {
+        expect(formatUpstreamAheadBanner(
+          { upstream: 'origin/main', ahead: 0, behind: 1 }
+        )).toBe('↓ 1 commit behind origin/main · F fetch · U pull')
+      })
+
+      it('handles arbitrary upstream ref names', () => {
+        expect(formatUpstreamAheadBanner(
+          { upstream: 'upstream/develop', ahead: 0, behind: 7 }
+        )).toBe('↓ 7 commits behind upstream/develop · F fetch · U pull')
+      })
+
+      it('falls back to v + . under ASCII', () => {
+        expect(formatUpstreamAheadBanner(
+          { upstream: 'origin/main', ahead: 0, behind: 2 },
+          { ascii: true }
+        )).toBe('v 2 commits behind origin/main . F fetch . U pull')
+      })
+    })
+
+    describe('diverged', () => {
+      it('formats diverged from <upstream> with both ahead/behind counts', () => {
+        expect(formatUpstreamAheadBanner(
+          { upstream: 'origin/main', ahead: 2, behind: 2 }
+        )).toBe('↑2 ↓2 diverged from origin/main · F fetch · U pull --rebase')
+      })
+
+      it('uses pull --rebase hint (fast-forward impossible when local has work)', () => {
+        const banner = formatUpstreamAheadBanner(
+          { upstream: 'origin/main', ahead: 1, behind: 5 }
+        )
+        expect(banner).toContain('pull --rebase')
+        expect(banner).not.toMatch(/U pull(?! --rebase)/)
+      })
+
+      it('falls back to +N -N under ASCII', () => {
+        expect(formatUpstreamAheadBanner(
+          { upstream: 'origin/main', ahead: 2, behind: 2 },
+          { ascii: true }
+        )).toBe('+2 -2 diverged from origin/main . F fetch . U pull --rebase')
+      })
     })
   })
 

--- a/src/workstation/chrome/iconography.ts
+++ b/src/workstation/chrome/iconography.ts
@@ -49,6 +49,68 @@ export function formatBranchDivergence(
   return `${parts.join(' ')} ${branch.upstream}`
 }
 
+/**
+ * Format a one-line banner for the history view announcing that the
+ * current branch is behind (or diverged from) its upstream — work
+ * the user can pull / fetch. Returns `undefined` when there's nothing
+ * to surface (no upstream, fully synced, or ahead-only).
+ *
+ * Two variants, chosen by ahead-count:
+ *
+ *   - **Behind-only** (behind > 0, ahead === 0):
+ *     `↓ N commits behind <upstream> · F fetch · U pull`
+ *     Matches `git status` wording, compressed.
+ *
+ *   - **Diverged** (behind > 0, ahead > 0):
+ *     `↑N ↓N diverged from <upstream> · F fetch · U pull --rebase`
+ *     Reuses the `↑N ↓N` symbols from `formatBranchDivergence`.
+ *     `--rebase` hint because fast-forward pull isn't possible with
+ *     local work present.
+ *
+ * Why no "ahead-only" banner: the question this surface answers is
+ * "what work do you have to PULL in?" — ahead-only means there's
+ * nothing to pull. Push affordances live on the branches sidebar
+ * where the cursor names a specific branch.
+ *
+ * Why no banner for synced / no-upstream / detached: same reason —
+ * nothing inbound. Detached HEAD also has no `currentBranch`, so
+ * callers passing `undefined` get `undefined` back automatically.
+ *
+ * ASCII fallback mirrors `formatBranchDivergence`: `v` for `↓`,
+ * `+N/-N` for `↑N ↓N`, `.` for `·`.
+ */
+export type BranchUpstreamAheadInput = {
+  upstream?: string
+  ahead: number
+  behind: number
+}
+
+export function formatUpstreamAheadBanner(
+  branch: BranchUpstreamAheadInput | undefined,
+  options: { ascii?: boolean } = {}
+): string | undefined {
+  if (!branch?.upstream || branch.behind <= 0) {
+    return undefined
+  }
+
+  const sep = options.ascii ? '.' : '·'
+
+  if (branch.ahead > 0) {
+    // Diverged — local has work too, fast-forward pull is impossible.
+    // Suggest pull --rebase as the cleaner-history default; users who
+    // prefer merge can do that themselves.
+    const symbols = options.ascii
+      ? `+${branch.ahead} -${branch.behind}`
+      : `↑${branch.ahead} ↓${branch.behind}`
+    return `${symbols} diverged from ${branch.upstream} ${sep} F fetch ${sep} U pull --rebase`
+  }
+
+  // Behind-only — fast-forward pull works.
+  const arrow = options.ascii ? 'v' : '↓'
+  const noun = branch.behind === 1 ? 'commit' : 'commits'
+  return `${arrow} ${branch.behind} ${noun} behind ${branch.upstream} ${sep} F fetch ${sep} U pull`
+}
+
 export type BranchRowMarkerInput = {
   current: boolean
   upstream?: string

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -17,6 +17,7 @@
 
 import type * as ReactTypes from 'react'
 import { filterChippedRefs, getBranchTipChip } from '../../chrome/branchTip'
+import { formatUpstreamAheadBanner } from '../../chrome/iconography'
 import {
   getConventionalCommitColor,
   parseConventionalCommitPrefix,
@@ -604,6 +605,24 @@ export function renderHistoryPanel(
     h(Text, { bold: true }, panelTitle('Commits', focused)),
     h(Text, { dimColor: true }, `${title} | ${graphMode} | ${loadState}`)
   ),
+  // Upstream-ahead banner. Surfaces "the remote has work you don't"
+  // for the current branch — distinct from the chip work in 0.52.0
+  // which colours remote refs IN the row set. On a behind branch the
+  // upstream commits aren't reachable from local HEAD, so the chips
+  // alone can't signal "fetch / pull needed." This single line does.
+  //
+  // Two wording variants (behind-only vs diverged) live in the
+  // helper; render is identical aside from the formatted string.
+  // Warning yellow = same semantic as the remote-tracking chip kind.
+  ...((() => {
+    const currentBranchRef = context.branches?.localBranches.find((branch) => branch.current)
+    const banner = formatUpstreamAheadBanner(currentBranchRef, { ascii: theme.ascii })
+    if (!banner) return []
+    return [h(Text, {
+      key: 'upstream-ahead-banner',
+      color: theme.noColor ? undefined : theme.colors.warning,
+    }, banner)]
+  })()),
   // Server-side filter indicator (#776). Only rendered when the user
   // has an active path:/author: prefix; clears when they Ctrl+U.
   ...(state.historyFetchArgs


### PR DESCRIPTION
Adds a one-line banner to the history view that announces "the remote has work you don't" for the current branch. Fills a real gap: the chip work in 0.52.0 made remote refs visually distinct *when they appear in the row set*, but on a behind branch the upstream-only commits aren't reachable from local HEAD, so chips alone never signal it.

## What it looks like

**Behind-only** (current branch is N commits behind, no local commits ahead):

```
Commits *                                  143/143 commits | compact graph | loaded
↓ 2 commits behind origin/main · F fetch · U pull
●─  feat: foo                  [HEAD -> main]
●─  refactor: bar
```

**Diverged** (both ahead AND behind — fast-forward pull is impossible):

```
Commits *                                  145/145 commits | compact graph | loaded
↑2 ↓2 diverged from origin/main · F fetch · U pull --rebase
●─  feat: local-only-A         [HEAD -> main]
●─  feat: local-only-B
```

## Design choices

| Question | Choice | Why |
|---|---|---|
| Color | Warning yellow | Same semantic as the remote-tracking chip kind from 0.52.0 |
| Behind-only wording | `↓ N commits behind <upstream>` | Matches `git status` for familiarity |
| Diverged wording | `↑N ↓N diverged from <upstream>` | Reuses the `↑N ↓N` symbols from `formatBranchDivergence` |
| Pull hint when diverged | `U pull --rebase` | Fast-forward pull is impossible with local work; rebase keeps history linear |
| Show on ahead-only? | No | Nothing inbound to pull. Push affordances live on the branches sidebar |
| Show on synced / no-upstream / detached HEAD? | No | Nothing inbound. Detached HEAD has no `currentBranch` ref |
| Change row set / auto-fetch? | No | Pure chrome. Surface the affordance, not the action |

ASCII fallback mirrors `formatBranchDivergence`: `v` for `↓`, `+N/-N` for `↑N ↓N`, `.` for `·`, no color.

## Implementation

- **New helper** `formatUpstreamAheadBanner` in `src/workstation/chrome/iconography.ts` (~30 LOC). Two variants, plural-correct, ASCII-fallback, returns `undefined` when there's nothing to surface.
- **One render branch** in `src/workstation/surfaces/history/index.ts` injecting the banner between the panel header and the existing filter indicator. Reads `context.branches.localBranches.find(b => b.current)` for the branch ref.
- **No new actions / keybindings.** The `F` and `U` hints point at the existing `fetch-remotes` and `pull-current-branch` global workflows.

## Tests

12 new in `iconography.test.ts`:

- undefined branch (detached HEAD) → no banner
- no upstream → no banner
- behind === 0 (synced or ahead-only) → no banner
- behind-only: N commits, singular noun for behind === 1, arbitrary upstream names, ASCII fallback
- diverged: `↑N ↓N` format, `pull --rebase` hint, ASCII fallback

## Test plan

- [x] `npm run test:jest -- src/workstation src/commands/log` — 985 pass (was 973 + 12 new)
- [x] `npm run lint` — clean on touched files
- [ ] Manual: `npm run scenario create branch-sync-showcase -- --run-ui` — HEAD is on `main` which is 2 behind `origin/main`. Banner should read `↓ 2 commits behind origin/main · F fetch · U pull` in warning yellow above the commit list. Press `F` or `U` and verify the existing workflows fire.
- [ ] Manual: from the same scenario, `git checkout feat/diverged` and re-run. Banner should read `↑2 ↓2 diverged from origin/feat/diverged · F fetch · U pull --rebase`.
- [ ] Manual: `git checkout feat/synced` and re-run. No banner (synced).

## Pairs with

- git-scenarios#4 (`branch-sync-showcase` v0.3.3) — the fixture this PR is designed against
- #1013 (coco dep bump to ^0.3.3) — landed first
- Upcoming task #4 (branches sidebar iconography + per-branch hotkeys) — same scenario as fixture