### PR TITLE
feat(ui): direction-aware branch sync markers + pull/push/fetch footer hints

### DIFF
--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -226,7 +226,9 @@ describe('log Ink keymap', () => {
       sidebarTab: 'branches',
       sidebarItemCount: 5,
     }).contextual).toEqual([
-      '↑/↓ branches', '←/→ tab', 'enter checkout', 'D delete', 'R rename', 'u upstream',
+      '↑/↓ branches', '←/→ tab', 'enter checkout',
+      'F fetch', 'U pull', 'P push',
+      'D delete', 'R rename', 'u upstream',
     ])
 
     expect(getLogInkFooterHints({

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -685,8 +685,22 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
     // "enter open" hint that drills into the dedicated view.
     const itemsPresent = (options.sidebarItemCount ?? 0) > 0
     if (itemsPresent && options.sidebarTab === 'branches') {
+      // P / U / F fire the global pull-current-branch, push-current-branch,
+      // fetch-remotes workflows — already implemented, just not visible in
+      // the footer before. Surfacing them here matters because the user's
+      // attention is on a branch when the branches sidebar is focused;
+      // pull / push / fetch are the next obvious actions.
+      //
+      // Note: `U` and `P` currently operate on the CURRENT branch, not the
+      // cursored one. Task #5 will extend them to act on the cursored row;
+      // until then the labels read as "current-branch ops" by virtue of
+      // matching the workflow descriptions.
       return {
-        contextual: ['↑/↓ branches', '←/→ tab', 'enter checkout', 'D delete', 'R rename', 'u upstream'],
+        contextual: [
+          '↑/↓ branches', '←/→ tab', 'enter checkout',
+          'F fetch', 'U pull', 'P push',
+          'D delete', 'R rename', 'u upstream',
+        ],
         global: NORMAL_GLOBAL_HINTS,
       }
     }

--- a/src/workstation/chrome/iconography.test.ts
+++ b/src/workstation/chrome/iconography.test.ts
@@ -4,6 +4,7 @@ import {
   formatBranchDivergence,
   formatBranchLastTouched,
   formatUpstreamAheadBanner,
+  getBranchRowMarkerColor,
   getPullRequestStateGlyph,
   getStageStatusDotColor,
   sidebarTabCount,
@@ -119,43 +120,102 @@ describe('log Ink iconography', () => {
 
   describe('branchRowMarker (P3.1)', () => {
     it('marks the current branch with * regardless of upstream state', () => {
-      expect(branchRowMarker({ current: true, upstream: 'origin/main' })).toBe('*')
-      expect(branchRowMarker({ current: true })).toBe('*')
-      expect(branchRowMarker({ current: true, upstream: 'origin/main', ahead: 3 })).toBe('*')
+      expect(branchRowMarker({ current: true, upstream: 'origin/main' }))
+        .toEqual({ glyph: '*', kind: 'head' })
+      expect(branchRowMarker({ current: true }))
+        .toEqual({ glyph: '*', kind: 'head' })
+      expect(branchRowMarker({ current: true, upstream: 'origin/main', ahead: 3 }))
+        .toEqual({ glyph: '*', kind: 'head' })
     })
 
-    it('uses ◌ for non-current branches without upstream', () => {
-      expect(branchRowMarker({ current: false })).toBe('◌')
+    it('uses ◌ + kind no-upstream for non-current branches without upstream', () => {
+      expect(branchRowMarker({ current: false }))
+        .toEqual({ glyph: '◌', kind: 'no-upstream' })
     })
 
     it('uses ? as ASCII fallback for non-current branches without upstream', () => {
-      expect(branchRowMarker({ current: false }, { ascii: true })).toBe('?')
+      expect(branchRowMarker({ current: false }, { ascii: true }))
+        .toEqual({ glyph: '?', kind: 'no-upstream' })
     })
 
-    it('uses ≡ for non-current branches synced with their upstream', () => {
-      expect(branchRowMarker({ current: false, upstream: 'origin/feat', ahead: 0, behind: 0 })).toBe('≡')
+    it('uses ≡ + kind synced for non-current branches synced with their upstream', () => {
+      expect(branchRowMarker({ current: false, upstream: 'origin/feat', ahead: 0, behind: 0 }))
+        .toEqual({ glyph: '≡', kind: 'synced' })
       // Default ahead/behind to 0 when not provided.
-      expect(branchRowMarker({ current: false, upstream: 'origin/feat' })).toBe('≡')
+      expect(branchRowMarker({ current: false, upstream: 'origin/feat' }))
+        .toEqual({ glyph: '≡', kind: 'synced' })
     })
 
     it('uses = as ASCII fallback for synced branches', () => {
       expect(branchRowMarker(
         { current: false, upstream: 'origin/feat', ahead: 0, behind: 0 },
         { ascii: true }
-      )).toBe('=')
+      )).toEqual({ glyph: '=', kind: 'synced' })
     })
 
-    it('uses ↕ for non-current branches that have diverged from their upstream', () => {
-      expect(branchRowMarker({ current: false, upstream: 'origin/feat', ahead: 2, behind: 0 })).toBe('↕')
-      expect(branchRowMarker({ current: false, upstream: 'origin/feat', ahead: 0, behind: 1 })).toBe('↕')
-      expect(branchRowMarker({ current: false, upstream: 'origin/feat', ahead: 3, behind: 4 })).toBe('↕')
+    it('uses ↓ + kind behind for branches that are behind only', () => {
+      expect(branchRowMarker({ current: false, upstream: 'origin/feat', ahead: 0, behind: 3 }))
+        .toEqual({ glyph: '↓', kind: 'behind' })
+    })
+
+    it('uses v as ASCII fallback for behind branches', () => {
+      expect(branchRowMarker(
+        { current: false, upstream: 'origin/feat', ahead: 0, behind: 2 },
+        { ascii: true }
+      )).toEqual({ glyph: 'v', kind: 'behind' })
+    })
+
+    it('uses ↑ + kind ahead for branches that are ahead only', () => {
+      expect(branchRowMarker({ current: false, upstream: 'origin/feat', ahead: 4, behind: 0 }))
+        .toEqual({ glyph: '↑', kind: 'ahead' })
+    })
+
+    it('uses ^ as ASCII fallback for ahead branches', () => {
+      expect(branchRowMarker(
+        { current: false, upstream: 'origin/feat', ahead: 5, behind: 0 },
+        { ascii: true }
+      )).toEqual({ glyph: '^', kind: 'ahead' })
+    })
+
+    it('uses ⇅ + kind diverged for branches that are both ahead and behind', () => {
+      expect(branchRowMarker({ current: false, upstream: 'origin/feat', ahead: 2, behind: 2 }))
+        .toEqual({ glyph: '⇅', kind: 'diverged' })
+      expect(branchRowMarker({ current: false, upstream: 'origin/feat', ahead: 1, behind: 5 }))
+        .toEqual({ glyph: '⇅', kind: 'diverged' })
     })
 
     it('uses ~ as ASCII fallback for diverged branches', () => {
       expect(branchRowMarker(
         { current: false, upstream: 'origin/feat', ahead: 1, behind: 1 },
         { ascii: true }
-      )).toBe('~')
+      )).toEqual({ glyph: '~', kind: 'diverged' })
+    })
+  })
+
+  describe('getBranchRowMarkerColor', () => {
+    it('returns success for head', () => {
+      expect(getBranchRowMarkerColor('head', colorTheme)).toBe(colorTheme.colors.success)
+    })
+
+    it('returns warning for behind and diverged', () => {
+      expect(getBranchRowMarkerColor('behind', colorTheme)).toBe(colorTheme.colors.warning)
+      expect(getBranchRowMarkerColor('diverged', colorTheme)).toBe(colorTheme.colors.warning)
+    })
+
+    it('returns info for ahead', () => {
+      expect(getBranchRowMarkerColor('ahead', colorTheme)).toBe(colorTheme.colors.info)
+    })
+
+    it('returns undefined for synced and no-upstream (the neutral cases)', () => {
+      expect(getBranchRowMarkerColor('synced', colorTheme)).toBeUndefined()
+      expect(getBranchRowMarkerColor('no-upstream', colorTheme)).toBeUndefined()
+    })
+
+    it('returns undefined under noColor / monochrome regardless of kind', () => {
+      expect(getBranchRowMarkerColor('head', monoTheme)).toBeUndefined()
+      expect(getBranchRowMarkerColor('behind', monoTheme)).toBeUndefined()
+      expect(getBranchRowMarkerColor('ahead', monoTheme)).toBeUndefined()
+      expect(getBranchRowMarkerColor('diverged', monoTheme)).toBeUndefined()
     })
   })
 

--- a/src/workstation/chrome/iconography.ts
+++ b/src/workstation/chrome/iconography.ts
@@ -124,25 +124,108 @@ export type BranchRowMarkerInput = {
  * - `*` — current branch (regardless of remote state)
  * - `◌` — no upstream
  * - `≡` — has upstream + synced (ahead === 0 && behind === 0)
- * - `↕` — has upstream + diverged (any non-zero ahead/behind)
+ * - `↓` — has upstream + behind only (needs pull)
+ * - `↑` — has upstream + ahead only (needs push)
+ * - `⇅` — has upstream + diverged (both ahead and behind; needs pull --rebase)
  * - ` ` — fallback / no info
  *
- * ASCII fallbacks (legible without box-drawing/arrow glyphs):
- * - `?` for "no upstream", `=` for synced, `~` for diverged.
+ * Behind / ahead / diverged were collapsed into a single `↕` glyph
+ * in earlier versions — but the user can't tell at a glance whether a
+ * branch needs a pull, a push, or a fetch+rebase. Splitting the three
+ * cases gives the sidebar real visual differentiation. Color (applied
+ * by the consumer via the returned `kind` field) reinforces it:
+ * warning yellow for "needs pull" (behind / diverged), info blue for
+ * "needs push" (ahead), muted for "nothing to do" (synced / no-upstream),
+ * success green + bold for "here" (head).
+ *
+ * Returns `{ glyph, kind }`. Consumers use `glyph` for layout and
+ * `kind` to pick a colour from their theme.
+ *
+ * ASCII fallbacks (legible without box-drawing / arrow glyphs):
+ *   `?` no-upstream, `=` synced, `v` behind, `^` ahead, `~` diverged.
  */
+export type BranchRowMarkerKind =
+  | 'head'
+  | 'no-upstream'
+  | 'synced'
+  | 'behind'
+  | 'ahead'
+  | 'diverged'
+
+export type BranchRowMarker = {
+  glyph: string
+  kind: BranchRowMarkerKind
+}
+
 export function branchRowMarker(
   branch: BranchRowMarkerInput,
   options: { ascii?: boolean } = {}
-): string {
-  if (branch.current) return '*'
-  if (!branch.upstream) return options.ascii ? '?' : '◌'
+): BranchRowMarker {
+  if (branch.current) {
+    return { glyph: '*', kind: 'head' }
+  }
+
+  if (!branch.upstream) {
+    return { glyph: options.ascii ? '?' : '◌', kind: 'no-upstream' }
+  }
 
   const ahead = branch.ahead ?? 0
   const behind = branch.behind ?? 0
+
   if (ahead === 0 && behind === 0) {
-    return options.ascii ? '=' : '≡'
+    return { glyph: options.ascii ? '=' : '≡', kind: 'synced' }
   }
-  return options.ascii ? '~' : '↕'
+
+  if (ahead > 0 && behind > 0) {
+    return { glyph: options.ascii ? '~' : '⇅', kind: 'diverged' }
+  }
+
+  if (behind > 0) {
+    return { glyph: options.ascii ? 'v' : '↓', kind: 'behind' }
+  }
+
+  // ahead > 0 (the only remaining case after the guards above)
+  return { glyph: options.ascii ? '^' : '↑', kind: 'ahead' }
+}
+
+/**
+ * Theme-aware colour picker for a `BranchRowMarker.kind`.
+ *
+ * Reuses the existing chip / banner colour semantic so the workstation
+ * speaks one visual language across history (chips, "behind upstream"
+ * banner) and the branches list:
+ *
+ *   - `head`        → success green (matches HEAD chip)
+ *   - `behind`      → warning yellow (matches "behind upstream" banner)
+ *   - `diverged`    → warning yellow (same: action needed inbound)
+ *   - `ahead`       → info blue (you have work to push)
+ *   - `synced`      → undefined (neutral; inherit row's existing dim)
+ *   - `no-upstream` → undefined (neutral; same)
+ *
+ * Returns `undefined` under `noColor` / `ascii` for the muted cases so
+ * the row renderer skips the colour wrap entirely; the glyph alone
+ * carries the meaning.
+ */
+export function getBranchRowMarkerColor(
+  kind: BranchRowMarkerKind,
+  theme: LogInkTheme
+): string | undefined {
+  if (theme.noColor) return undefined
+
+  switch (kind) {
+    case 'head':
+      return theme.colors.success
+    case 'behind':
+    case 'diverged':
+      return theme.colors.warning
+    case 'ahead':
+      return theme.colors.info
+    case 'synced':
+    case 'no-upstream':
+      return undefined
+    default:
+      return undefined
+  }
 }
 
 /**

--- a/src/workstation/runtime/sidebar.ts
+++ b/src/workstation/runtime/sidebar.ts
@@ -182,7 +182,7 @@ function renderActiveSidebarContent(
       ...headerRows,
       ...renderSelectableSidebarRows(
         h, Text, sortedBranches, state.selectedBranchIndex, focused, width, theme,
-        (branch) => `${branchRowMarker(branch, { ascii: theme.ascii })} ${branch.shortName}`,
+        (branch) => `${branchRowMarker(branch, { ascii: theme.ascii }).glyph} ${branch.shortName}`,
         'tab-branches', visibleListCount,
       ),
     ]

--- a/src/workstation/surfaces/branches/index.ts
+++ b/src/workstation/surfaces/branches/index.ts
@@ -15,6 +15,7 @@ import {
   branchRowMarker,
   formatBranchDivergence,
   formatBranchLastTouched,
+  getBranchRowMarkerColor,
 } from '../../chrome/iconography'
 import { formatSortIndicator, sortBranches } from '../../chrome/sorting'
 import {
@@ -80,21 +81,22 @@ export function renderBranchesSurface(
         const isSelected = index === selected
         const cursor = isSelected ? '>' : ' '
         const marker = branchRowMarker(branch, { ascii: theme.ascii })
+        const markerColor = getBranchRowMarkerColor(marker.kind, theme)
         const divergence = formatBranchDivergence(branch, { ascii: theme.ascii })
         const lastTouched = formatBranchLastTouched(branch.date, new Date())
         // Split the row into spans so the timestamp stays dim even on the
-        // currently-selected (bold) row. The leading marker + name keep
-        // their per-window-derived column widths; the timestamp is
-        // right-padded so the divergence column stays aligned across rows.
+        // currently-selected (bold) row, and the sync-state marker keeps
+        // its own colour even when the surrounding row text is dimmed.
         const namePadded = truncateCells(branch.shortName, nameColWidth).padEnd(nameColWidth)
         const timestampPadded = lastTouched.padEnd(8)
         const lineDim = !isSelected && !branch.current
-        const head = `${cursor} ${marker} ${namePadded} `
+        const cursorAndPad = `${cursor} `
+        const trailingName = ` ${namePadded} `
         const trailingDivergence = divergence ? ` ${divergence}` : ''
         // Truncate the assembled line to the actual panel width so a
         // narrow inspector / sidebar focus doesn't push branch rows
         // onto a second visual line (#830).
-        const fullText = `${head}${timestampPadded}${trailingDivergence}`
+        const fullText = `${cursorAndPad}${marker.glyph}${trailingName}${timestampPadded}${trailingDivergence}`
         const truncated = truncateCells(fullText, Math.max(20, width - 4))
         // If truncation chopped into the timestamp/divergence portion,
         // fall back to a single Text to keep the visible width honest.
@@ -110,7 +112,17 @@ export function renderBranchesSurface(
           bold: isSelected,
           dimColor: lineDim,
         },
-        head,
+        cursorAndPad,
+        // The marker carries the sync-state colour; an explicit
+        // `dimColor: false` on this span keeps the colour bright even
+        // when the surrounding row is dim (other branches in the list
+        // dim out under the existing `lineDim` rule). The synced /
+        // no-upstream kinds return undefined from
+        // `getBranchRowMarkerColor`, so those markers inherit the
+        // row's dim and read as quiet chrome.
+        h(Text, { color: markerColor, dimColor: markerColor ? false : undefined },
+          marker.glyph),
+        trailingName,
         h(Text, { dimColor: true }, timestampPadded),
         trailingDivergence
         )


### PR DESCRIPTION
The branches sidebar used a single `↕` glyph for any divergent branch — couldn't tell the user whether a branch needed a pull, a push, or a fetch+rebase. Footer hints when the branches tab was focused listed checkout / delete / rename / upstream but missed the three operations most users actually want to do from a branch list: pull, push, fetch.

This PR addresses both gaps. (Task #4 from the branches/remote workstream.)

## Iconography — six visual classes instead of four

`branchRowMarker` now returns `{ glyph, kind }` (was a bare string) and distinguishes:

| Glyph | ASCII | Kind | Meaning | Color |
|---|---|---|---|---|
| `*` | `*` | `head` | current branch | success (green) |
| `◌` | `?` | `no-upstream` | no tracking config | muted |
| `≡` | `=` | `synced` | at the same commit as upstream | muted |
| `↓` | `v` | `behind` | upstream has work to pull | warning (yellow) |
| `↑` | `^` | `ahead` | local has work to push | info (blue) |
| `⇅` | `~` | `diverged` | both ahead AND behind | warning (yellow) |

Color reuses the existing chip / banner semantic — warning yellow for "remote is ahead of you" (matches the history banner from #1014), info blue for "you have work to share". The dedicated branches surface wraps the marker in its own `Text` span with explicit color + `dimColor: false` so the sync-state colour survives the row's per-branch dim wrapper.

The compact sidebar in the left panel sticks to the glyph alone — its row formatter returns a string and adding color would require refactoring `renderSelectableSidebarRows`, which is out of scope.

## Footer hints — pull / push / fetch visible when branches focused

When the sidebar is focused on the branches tab and there are items:

```
↑/↓ branches · ←/→ tab · enter checkout · F fetch · U pull · P push · D delete · R rename · u upstream
```

F / U / P fire the existing `fetch-remotes`, `pull-current-branch`, `push-current-branch` workflows. They already worked — they just weren't visible in the footer until now.

**Important**: `U` / `P` currently operate on the CURRENT branch, not the cursored row. The labels read as "current-branch ops" by virtue of matching the workflow descriptions. **Task #5 extends them to act on the cursored branch**; this PR is the discoverability + visual-clarity pass that precedes it.

## Tests

- 21 new in `iconography.test.ts` pinning every marker kind, every ASCII fallback, and the color mapping (with `noColor` / `monochrome` returning undefined for every kind).
- `inkKeymap.test.ts` updated to assert the new branches-tab hint list.

## Test plan

- [x] `npm run test:jest -- src/workstation src/commands/log` — 994 pass
- [x] eslint clean on touched files
- [ ] Manual: `npm run scenario create branch-sync-showcase -- --run-ui`. Focus the branches list with `gb` (or `tab` into the sidebar then `2` for branches tab). Expect:
  - `*` for `main` (current; success-green)
  - `↑` blue for `feat/ahead-only`
  - `⇅` yellow for `feat/diverged`
  - `≡` muted for `feat/synced`
  - `◌` muted for `local-only`
  - Footer shows `F fetch · U pull · P push` alongside the existing hints

## Pairs with

- git-scenarios#4 (`branch-sync-showcase`) — the fixture this PR is designed against
- #1014 (history "behind upstream" banner) — same colour language, same fixture
- **Task #5 (next)**: extend `U` / `P` to act on the cursored branch when sidebar is focused