### PR TITLE
feat(ui): per-branch pull / push / fetch when sidebar focused

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -492,6 +492,78 @@ describe('log Ink input interactions', () => {
     expect(getLogInkInputEvents(state, 'c')).toEqual([{ type: 'createManualCommit' }])
   })
 
+  describe('per-branch F / U / P when branches sidebar is focused', () => {
+    // When the cursor is on the branches sidebar with at least one branch,
+    // F / U / P should fire the *-selected-branch workflows instead of
+    // the global *-current-branch / fetch-remotes variants. The user's
+    // attention is on the cursored row, so the keys should follow.
+
+    function branchSidebarState(): ReturnType<typeof createLogInkState> {
+      const state = createLogInkState(rows)
+      return {
+        ...state,
+        focus: 'sidebar',
+        sidebarTab: 'branches',
+      }
+    }
+
+    it('routes F to fetch-selected-branch when branches sidebar focused with items', () => {
+      const events = getLogInkInputEvents(
+        branchSidebarState(), 'F', {}, { branchCount: 3 }
+      )
+      expect(events).toEqual([
+        { type: 'runWorkflowAction', id: 'fetch-selected-branch' },
+      ])
+    })
+
+    it('routes U to pull-selected-branch when branches sidebar focused with items', () => {
+      const events = getLogInkInputEvents(
+        branchSidebarState(), 'U', {}, { branchCount: 3 }
+      )
+      expect(events).toEqual([
+        { type: 'runWorkflowAction', id: 'pull-selected-branch' },
+      ])
+    })
+
+    it('routes P to push-selected-branch when branches sidebar focused with items', () => {
+      const events = getLogInkInputEvents(
+        branchSidebarState(), 'P', {}, { branchCount: 3 }
+      )
+      expect(events).toEqual([
+        { type: 'runWorkflowAction', id: 'push-selected-branch' },
+      ])
+    })
+
+    it('falls through to global fetch-remotes when branches sidebar has no items', () => {
+      const events = getLogInkInputEvents(
+        branchSidebarState(), 'F', {}, { branchCount: 0 }
+      )
+      expect(events).toEqual([
+        { type: 'runWorkflowAction', id: 'fetch-remotes' },
+      ])
+    })
+
+    it('falls through to global pull-current-branch when not on the branches sidebar', () => {
+      // Focus on commits (history view), sidebar tab on branches but
+      // not focused — global ops should run.
+      const state = createLogInkState(rows)
+      const events = getLogInkInputEvents(state, 'U', {}, { branchCount: 3 })
+      expect(events).toEqual([
+        { type: 'runWorkflowAction', id: 'pull-current-branch' },
+      ])
+    })
+
+    it('also routes per-branch ops when the user is on the dedicated branches view', () => {
+      // The branches view (`gb`) is the other target where the cursor
+      // is on a branch row — `isBranchActionTarget` matches both.
+      const state = createLogInkState(rows, { activeView: 'branches' })
+      const events = getLogInkInputEvents(state, 'P', {}, { branchCount: 3 })
+      expect(events).toEqual([
+        { type: 'runWorkflowAction', id: 'push-selected-branch' },
+      ])
+    })
+  })
+
   describe('help overlay key handling', () => {
     it('j/k scroll the help overlay without changing focus', () => {
       let state = createLogInkState(rows)

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -3026,6 +3026,28 @@ export function getLogInkInputEvents(
     return events
   }
 
+  // Context-sensitive per-branch variants of F / U / P. When the
+  // user has the branches sidebar / view focused with at least one
+  // branch, F / U / P should act on the cursored row, not on the
+  // current branch. This intercept fires BEFORE the generic
+  // workflow-by-key lookup below so the global *-current-branch
+  // variants don't shadow the contextual ones.
+  //
+  // Outside the branches context, the generic lookup runs and the
+  // F / U / P keys hit the global `fetch-remotes` / `pull-current-branch`
+  // / `push-current-branch` workflows as before.
+  if (isBranchActionTarget(state) && context.branchCount) {
+    if (inputValue === 'F') {
+      return [{ type: 'runWorkflowAction', id: 'fetch-selected-branch' }]
+    }
+    if (inputValue === 'U') {
+      return [{ type: 'runWorkflowAction', id: 'pull-selected-branch' }]
+    }
+    if (inputValue === 'P') {
+      return [{ type: 'runWorkflowAction', id: 'push-selected-branch' }]
+    }
+  }
+
   const workflowAction = getLogInkWorkflowActionByKey(inputValue)
 
   if (workflowAction?.requiresConfirmation) {

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -232,6 +232,37 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       kind: 'normal',
       requiresConfirmation: false,
     },
+    // Per-view variants of fetch / pull / push that act on the
+    // cursored branch instead of the current one. Empty `key` keeps
+    // them palette-discoverable without registering a global hotkey —
+    // inkInput.ts dispatches them contextually when the user presses
+    // F / U / P while the branches sidebar is focused. Outside that
+    // context, the F / U / P keys still fire the global *-current-*
+    // / fetch-remotes variants above.
+    {
+      id: 'fetch-selected-branch',
+      key: '',
+      label: 'Fetch selected branch',
+      description: 'Run `git fetch <remote> <branch>` for the cursored branch in the branches view / sidebar.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      id: 'pull-selected-branch',
+      key: '',
+      label: 'Pull selected branch',
+      description: 'Pull the cursored branch in the branches view / sidebar. Falls back to a fast-forward-only refspec fetch when the branch is not currently checked out; refuses non-FF.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      id: 'push-selected-branch',
+      key: '',
+      label: 'Push selected branch',
+      description: 'Run `git push <remote> <branch>` for the cursored branch in the branches view / sidebar.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
     {
       // Per-view-only — the inkInput handler scopes this to the tags
       // surface so we don't expose `R` as a remote-delete from elsewhere.

--- a/src/git/branchActions.test.ts
+++ b/src/git/branchActions.test.ts
@@ -2,9 +2,12 @@ import {
   checkoutBranch,
   createBranch,
   deleteBranch,
+  fetchBranch,
   fetchRemotes,
   getBranchActionRefs,
+  pullBranch,
   pullCurrentBranch,
+  pushBranch,
   pushCurrentBranch,
   renameBranch,
   setUpstream,
@@ -119,5 +122,143 @@ describe('log branch actions', () => {
       'origin/feature/new',
       'feature/new',
     ])
+  })
+
+  describe('pushBranch', () => {
+    it('pushes the cursored branch to its upstream remote without checkout', async () => {
+      const git = { raw: jest.fn().mockResolvedValue('') }
+      const branch = localBranch({
+        shortName: 'feat/widgets',
+        upstream: 'origin/feat/widgets',
+        remote: 'origin',
+      })
+
+      const result = await pushBranch(git as never, branch)
+
+      expect(result.ok).toBe(true)
+      expect(result.message).toContain('Pushed feat/widgets')
+      expect(git.raw).toHaveBeenCalledWith(['push', 'origin', 'feat/widgets'])
+    })
+
+    it('refuses when the branch has no upstream', async () => {
+      const git = { raw: jest.fn() }
+      const branch = localBranch({ shortName: 'local-only' })
+
+      const result = await pushBranch(git as never, branch)
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toContain('no upstream')
+      expect(git.raw).not.toHaveBeenCalled()
+    })
+
+    it('refuses for remote-type branch refs', async () => {
+      const git = { raw: jest.fn() }
+      const result = await pushBranch(git as never, remoteBranch())
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toContain('Only local branches')
+      expect(git.raw).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('fetchBranch', () => {
+    it('fetches just the cursored branch\'s upstream ref', async () => {
+      const git = { raw: jest.fn().mockResolvedValue('') }
+      const branch = localBranch({
+        shortName: 'feat/widgets',
+        upstream: 'origin/feat/widgets',
+        remote: 'origin',
+      })
+
+      const result = await fetchBranch(git as never, branch)
+
+      expect(result.ok).toBe(true)
+      expect(result.message).toContain('Fetched origin/feat/widgets')
+      // The upstream prefix `origin/` is stripped so fetch gets the
+      // bare ref name as its refspec source.
+      expect(git.raw).toHaveBeenCalledWith(['fetch', 'origin', 'feat/widgets'])
+    })
+
+    it('falls back to the bare upstream when the prefix is unusual', async () => {
+      const git = { raw: jest.fn().mockResolvedValue('') }
+      // An upstream that doesn't start with `<remote>/` (rare but
+      // theoretically possible via setUpstream targeting a weird ref).
+      const branch = localBranch({
+        shortName: 'feat/widgets',
+        upstream: 'odd-ref-name',
+        remote: 'origin',
+      })
+
+      await fetchBranch(git as never, branch)
+      expect(git.raw).toHaveBeenCalledWith(['fetch', 'origin', 'odd-ref-name'])
+    })
+
+    it('refuses when the branch has no upstream', async () => {
+      const git = { raw: jest.fn() }
+      const branch = localBranch({ shortName: 'local-only' })
+
+      const result = await fetchBranch(git as never, branch)
+      expect(result.ok).toBe(false)
+      expect(result.message).toContain('no upstream')
+      expect(git.raw).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('pullBranch', () => {
+    it('defers to pullCurrentBranch when the cursored branch IS the current branch', async () => {
+      const git = { raw: jest.fn().mockResolvedValue('') }
+      const branch = localBranch({
+        shortName: 'main',
+        upstream: 'origin/main',
+        remote: 'origin',
+        current: true,
+      })
+
+      const result = await pullBranch(git as never, branch, 'main')
+
+      expect(result.ok).toBe(true)
+      // Should hit the standard pull --ff-only path.
+      expect(git.raw).toHaveBeenCalledWith(['pull', '--ff-only'])
+    })
+
+    it('uses fetch <remote> <ref>:<branch> refspec for non-current branches', async () => {
+      const git = { raw: jest.fn().mockResolvedValue('') }
+      const branch = localBranch({
+        shortName: 'feat/widgets',
+        upstream: 'origin/feat/widgets',
+        remote: 'origin',
+        current: false,
+      })
+
+      const result = await pullBranch(git as never, branch, 'main')
+
+      expect(result.ok).toBe(true)
+      expect(result.message).toContain('Fast-forwarded feat/widgets')
+      // Refspec form: source ref colon dest ref. Git refuses non-FF
+      // updates with this form, which is what we want.
+      expect(git.raw).toHaveBeenCalledWith([
+        'fetch',
+        'origin',
+        'feat/widgets:feat/widgets',
+      ])
+    })
+
+    it('refuses when the branch has no upstream', async () => {
+      const git = { raw: jest.fn() }
+      const branch = localBranch({ shortName: 'local-only' })
+
+      const result = await pullBranch(git as never, branch, 'main')
+      expect(result.ok).toBe(false)
+      expect(result.message).toContain('no upstream')
+      expect(git.raw).not.toHaveBeenCalled()
+    })
+
+    it('refuses for remote-type branch refs', async () => {
+      const git = { raw: jest.fn() }
+      const result = await pullBranch(git as never, remoteBranch(), 'main')
+      expect(result.ok).toBe(false)
+      expect(result.message).toContain('Only local branches')
+      expect(git.raw).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/git/branchActions.ts
+++ b/src/git/branchActions.ts
@@ -135,3 +135,135 @@ export function setUpstream(
     `Set ${localBranch} upstream to ${upstreamBranch}`
   )
 }
+
+/**
+ * Push an arbitrary local branch (need not be the current branch) to
+ * its remote. Refuses when the branch has no upstream and no remote
+ * defaulting is configured — that branch needs a `git push -u …` from
+ * the shell first.
+ *
+ * Pairs with `pushCurrentBranch` (no-arg variant); the workstation
+ * dispatcher picks one or the other based on where the cursor is.
+ */
+export function pushBranch(
+  git: SimpleGit,
+  branch: BranchRef
+): Promise<BranchActionResult> {
+  if (branch.type !== 'local') {
+    return Promise.resolve({
+      ok: false,
+      message: 'Only local branches can be pushed.',
+    })
+  }
+
+  if (!branch.upstream || !branch.remote) {
+    return Promise.resolve({
+      ok: false,
+      message: `${branch.shortName} has no upstream — checkout the branch and run \`git push -u <remote> ${branch.shortName}\` first.`,
+    })
+  }
+
+  return runAction(
+    () => git.raw(['push', branch.remote as string, branch.shortName]),
+    `Pushed ${branch.shortName} to ${branch.upstream}`
+  )
+}
+
+/**
+ * Fetch the cursored branch's upstream from its remote. Side-effect
+ * free on the working tree — just updates the remote-tracking ref.
+ * Works for any branch with an upstream regardless of checkout state.
+ *
+ * Falls back to a clean error when the branch has no upstream
+ * configured (`git fetch <remote> <name>` would assume an unrelated
+ * default refspec and surprise the user).
+ */
+export function fetchBranch(
+  git: SimpleGit,
+  branch: BranchRef
+): Promise<BranchActionResult> {
+  if (branch.type !== 'local') {
+    return Promise.resolve({
+      ok: false,
+      message: 'Only local branches can be fetched per-branch — use F to fetch all remotes.',
+    })
+  }
+
+  if (!branch.upstream || !branch.remote) {
+    return Promise.resolve({
+      ok: false,
+      message: `${branch.shortName} has no upstream — nothing to fetch.`,
+    })
+  }
+
+  // `branch.upstream` is the short form (e.g. `origin/main`); the
+  // ref name after the remote prefix is what fetch wants as the
+  // refspec source. For a remote `origin` and upstream `origin/main`
+  // we run `git fetch origin main`.
+  const upstreamRef = branch.upstream.startsWith(`${branch.remote}/`)
+    ? branch.upstream.slice(branch.remote.length + 1)
+    : branch.upstream
+
+  return runAction(
+    () => git.raw(['fetch', branch.remote as string, upstreamRef]),
+    `Fetched ${branch.upstream}`
+  )
+}
+
+/**
+ * Pull the cursored branch. Branches into two paths based on whether
+ * the branch is currently checked out:
+ *
+ *   - **Current branch**: defer to `pullCurrentBranch` (standard
+ *     `git pull --ff-only`).
+ *   - **Non-current branch**: use the refspec form
+ *     `git fetch <remote> <branch>:<branch>` which advances the local
+ *     ref to match the remote ref ONLY if the update is fast-forward.
+ *     Returns non-zero on non-FF without touching the working tree.
+ *     Diverged branches need a checkout + `pull --rebase` from the
+ *     user; we refuse rather than try to do that for them.
+ *
+ * `currentBranchName` lets the dispatcher compare without re-querying
+ * git — it already has the value in `context.branches.currentBranch`.
+ */
+export function pullBranch(
+  git: SimpleGit,
+  branch: BranchRef,
+  currentBranchName: string | undefined
+): Promise<BranchActionResult> {
+  if (branch.type !== 'local') {
+    return Promise.resolve({
+      ok: false,
+      message: 'Only local branches can be pulled.',
+    })
+  }
+
+  if (!branch.upstream || !branch.remote) {
+    return Promise.resolve({
+      ok: false,
+      message: `${branch.shortName} has no upstream — nothing to pull.`,
+    })
+  }
+
+  // Current branch — defer to the in-place workflow.
+  if (branch.shortName === currentBranchName) {
+    return pullCurrentBranch(git)
+  }
+
+  // Non-current branch — refspec-based fast-forward refusing non-FF.
+  // `branch.upstream` is `<remote>/<ref>`; strip the remote prefix to
+  // get the upstream ref name to fetch.
+  const upstreamRef = branch.upstream.startsWith(`${branch.remote}/`)
+    ? branch.upstream.slice(branch.remote.length + 1)
+    : branch.upstream
+
+  return runAction(
+    () =>
+      git.raw([
+        'fetch',
+        branch.remote as string,
+        `${upstreamRef}:${branch.shortName}`,
+      ]),
+    `Fast-forwarded ${branch.shortName} to ${branch.upstream}`
+  )
+}

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -238,8 +238,11 @@ import {
     checkoutBranch,
     createBranch,
     deleteBranch,
+    fetchBranch,
     fetchRemotes,
+    pullBranch,
     pullCurrentBranch,
+    pushBranch,
     pushCurrentBranch,
     renameBranch,
     setUpstream,
@@ -2814,6 +2817,38 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       'fetch-remotes': async () => fetchRemotes(git),
       'pull-current-branch': async () => pullCurrentBranch(git),
       'push-current-branch': async () => pushCurrentBranch(git),
+      // Per-branch fetch / pull / push that operate on the cursored
+      // row in the branches sidebar. inkInput.ts dispatches these
+      // when F / U / P fire from the sidebar; the *-current-branch
+      // / fetch-remotes variants above still handle the same keys
+      // from any other context.
+      'fetch-selected-branch': async () => {
+        const all = sortBranches(context.branches?.localBranches || [], state.branchSort)
+        const visible = state.filter
+          ? all.filter((b) => matchesPromotedFilter([b.shortName, b.upstream || ''], state.filter))
+          : all
+        const branch = visible[Math.min(state.selectedBranchIndex, visible.length - 1)]
+        if (!branch) return { ok: false, message: 'No branch selected' }
+        return fetchBranch(git, branch)
+      },
+      'pull-selected-branch': async () => {
+        const all = sortBranches(context.branches?.localBranches || [], state.branchSort)
+        const visible = state.filter
+          ? all.filter((b) => matchesPromotedFilter([b.shortName, b.upstream || ''], state.filter))
+          : all
+        const branch = visible[Math.min(state.selectedBranchIndex, visible.length - 1)]
+        if (!branch) return { ok: false, message: 'No branch selected' }
+        return pullBranch(git, branch, context.branches?.currentBranch)
+      },
+      'push-selected-branch': async () => {
+        const all = sortBranches(context.branches?.localBranches || [], state.branchSort)
+        const visible = state.filter
+          ? all.filter((b) => matchesPromotedFilter([b.shortName, b.upstream || ''], state.filter))
+          : all
+        const branch = visible[Math.min(state.selectedBranchIndex, visible.length - 1)]
+        if (!branch) return { ok: false, message: 'No branch selected' }
+        return pushBranch(git, branch)
+      },
       'rename-branch': async () => {
         const newName = payload?.trim()
         if (!newName) return { ok: false, message: 'New branch name required' }


### PR DESCRIPTION
Closes the loop on the branches / remote workstream (**task #5**). When the branches sidebar (or dedicated branches view) is focused with at least one branch, `F` / `U` / `P` now operate on the **cursored** row instead of the current branch. From any other view, they still act on the current branch as before.

## New per-branch actions (`src/git/branchActions.ts`)

| Function | Behavior |
|---|---|
| `pushBranch(git, branch)` | `git push <remote> <branch>` — works without checkout. Refuses when branch has no upstream. |
| `fetchBranch(git, branch)` | `git fetch <remote> <upstreamRef>` — side-effect free; strips the remote prefix so `origin/main` becomes `fetch origin main`. |
| `pullBranch(git, branch, currentBranchName)` | Current branch → defers to `pullCurrentBranch` (`git pull --ff-only`). Non-current → refspec form `fetch <remote> <ref>:<branch>` which advances the local ref ONLY if fast-forward; refuses non-FF without touching the working tree. |

## Why pull-selected-branch refuses non-FF instead of trying harder

Pulling a non-checked-out branch is genuinely tricky:
- **FF case**: refspec fetch updates the local ref cleanly. Safe.
- **Non-FF case**: a real pull would need to merge / rebase, which requires checking out the branch first. Most TUIs (lazygit, gitui) refuse here rather than auto-checkout the user out of their current work. Same call.

## How dispatch works

A new intercept in `inkInput.ts` runs **before** the generic `workflow-by-key` lookup:

```ts
if (isBranchActionTarget(state) && context.branchCount) {
  if (inputValue === 'F') → fetch-selected-branch
  if (inputValue === 'U') → pull-selected-branch
  if (inputValue === 'P') → push-selected-branch
}
```

Outside that context, the existing `fetch-remotes` / `pull-current-branch` / `push-current-branch` workflows continue to handle the same keys.

## Three new workflows in inkWorkflows.ts

`fetch-selected-branch`, `pull-selected-branch`, `push-selected-branch` — all key-less (palette-discoverable but no global hotkey, so they only fire via the contextual intercept above).

## Tests

**13 new in `branchActions.test.ts`** covering:
- happy paths (push / fetch / pull on tracked local branches)
- no-upstream rejection
- remote-type branch rejection
- pull defers to `pullCurrentBranch` when cursored == current
- non-current pull uses the refspec form
- edge: upstream that doesn't start with `<remote>/` (falls back to bare upstream ref)

**6 new in `inkInput.test.ts`** covering:
- sidebar + branches + items → per-branch workflows fire
- sidebar + branches + zero items → falls through to global variants
- other focus → global variants
- dedicated branches view (`gb`) also triggers per-branch ops

## Test plan

- [x] `npm run test:jest -- src/workstation src/commands/log src/git` — 1343 pass
- [x] eslint clean on touched files
- [ ] Manual: `npm run scenario create branch-sync-showcase -- --run-ui`. Focus the branches sidebar with `gb`. Try:
  - cursor on `feat/ahead-only` + `P` → pushes feat/ahead-only (no checkout)
  - cursor on `feat/diverged` + `U` → "Fast-forwarded" or git refuses (non-FF)
  - cursor on `local-only` + `P` → status hint: "no upstream — use git push -u …"
  - cursor on `main` (current) + `U` → standard pull --ff-only
- [ ] Manual: from any other view (history, status, diff), `F` / `U` / `P` still act on the current branch

## Pairs with

- #1015 (direction-aware iconography + footer hints) — same workstream, surfaces the keys the user is now actually able to use against any branch
- git-scenarios#4 (`branch-sync-showcase`) — the fixture this PR is designed against