### PR TITLE
fix: --run-ui actually launches the workstation

### DIFF
--- a/bin/scenarioRunner.test.ts
+++ b/bin/scenarioRunner.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for the `npm run scenario` wrapper around `@gfargo/git-scenarios`.
+ *
+ * The wrapper exists to intercept coco's documented `--run-ui` shortcut
+ * (which the base CLI doesn't know about) and rewrite it to the
+ * equivalent `--run "tsx <coco>/src/index.ts ui"`. Without these tests
+ * a stale wrapper would silently drop `--run-ui` again — the exact bug
+ * this file is here to prevent.
+ */
+import path from 'node:path'
+import { RUN_UI_FLAG, rewriteRunUi } from './scenarioRunner/runUiFlag'
+
+// Stable fake repo root so test assertions don't depend on the actual
+// install path of the test runner.
+const FAKE_ROOT = '/tmp/fake-coco-repo'
+const EXPECTED_UI_CMD = `tsx ${path.join(FAKE_ROOT, 'src/index.ts')} ui`
+
+describe('scenarioRunner', () => {
+  describe('RUN_UI_FLAG', () => {
+    it('exports the literal flag string consumers can rely on', () => {
+      // Pinning the literal so a typo refactor surfaces immediately.
+      expect(RUN_UI_FLAG).toBe('--run-ui')
+    })
+  })
+
+  describe('rewriteRunUi', () => {
+    it('replaces a bare --run-ui with --run + the tsx ui spawn command', () => {
+      expect(rewriteRunUi(['create', 'empty-repo', '--run-ui'], FAKE_ROOT))
+        .toEqual(['create', 'empty-repo', '--run', EXPECTED_UI_CMD])
+    })
+
+    it('preserves the position of --run-ui in the argv', () => {
+      // Some users might pass --run-ui before the scenario name or
+      // interleaved with other flags. The rewrite shouldn't reorder.
+      expect(rewriteRunUi(['--run-ui', 'create', 'empty-repo', '--ephemeral'], FAKE_ROOT))
+        .toEqual(['--run', EXPECTED_UI_CMD, 'create', 'empty-repo', '--ephemeral'])
+    })
+
+    it('is a no-op when --run-ui is absent', () => {
+      const argv = ['create', 'feature-pr-ready', '--run', 'lazygit']
+      expect(rewriteRunUi(argv, FAKE_ROOT)).toEqual(argv)
+    })
+
+    it('rewrites every occurrence (rare, but well-defined)', () => {
+      // Defensive: if somehow the user passes --run-ui twice (alias
+      // misconfig, doubled-up via shell quoting), every occurrence
+      // gets the same rewrite. Easier than failing or deduping
+      // unexpectedly.
+      expect(rewriteRunUi(['--run-ui', 'create', 'empty-repo', '--run-ui'], FAKE_ROOT))
+        .toEqual([
+          '--run', EXPECTED_UI_CMD,
+          'create', 'empty-repo',
+          '--run', EXPECTED_UI_CMD,
+        ])
+    })
+
+    it('returns an empty array for empty argv', () => {
+      expect(rewriteRunUi([], FAKE_ROOT)).toEqual([])
+    })
+
+    it('does not match flags that merely contain "run-ui" as a substring', () => {
+      // Defensive: only the exact `--run-ui` token rewrites. Some
+      // hypothetical future flag like `--run-ui-mode` should pass
+      // through unchanged (and trigger a git-scenarios error if it's
+      // not a real flag, surfacing the typo to the user).
+      const argv = ['create', 'empty-repo', '--run-ui-mode', 'foo']
+      expect(rewriteRunUi(argv, FAKE_ROOT)).toEqual(argv)
+    })
+  })
+})

--- a/bin/scenarioRunner.ts
+++ b/bin/scenarioRunner.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env tsx
+/**
+ * `npm run scenario` wrapper.
+ *
+ * `@gfargo/git-scenarios`'s CLI knows about `--run <cmd>` (tool-agnostic
+ * launcher — any shell command). Coco's docs and wiki advertise a
+ * convenience flag `--run-ui` that should spawn the source-tree CLI
+ * (`tsx <coco>/src/index.ts ui`) against the materialized scenario —
+ * but the flag isn't a real `git-scenarios` option, so a bare
+ * passthrough silently dropped it. Users got the scenario but no UI
+ * launch.
+ *
+ * This wrapper intercepts `--run-ui` before forwarding to git-scenarios:
+ *   - If present, it's replaced with the equivalent `--run "<spawn>"`
+ *     where `<spawn>` is `tsx <coco-root>/src/index.ts ui`. The repo
+ *     root is computed relative to this script so the wrapper works
+ *     whether invoked via `npm run scenario`, a yarn alias, or
+ *     directly via `tsx bin/scenarioRunner.ts ...`.
+ *   - If absent, every other arg passes through unchanged. The wrapper
+ *     adds no behavior to the base CLI in that case.
+ *
+ * The wrapper does NOT shell out — it spawns the git-scenarios CLI
+ * directly so signal handling (Ctrl+C, exit code) propagates cleanly.
+ */
+import { spawn } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import { rewriteRunUi } from './scenarioRunner/runUiFlag'
+
+function repoRootFromHere(scriptUrl: string): string {
+  // Resolve `<repo>/bin/scenarioRunner.ts` → `<repo>` regardless of how
+  // the script was invoked. `import.meta.url` is the file URL of this
+  // script; `fileURLToPath` gives us the absolute path on disk.
+  const here = path.dirname(fileURLToPath(scriptUrl))
+  return path.resolve(here, '..')
+}
+
+function main(): void {
+  const root = repoRootFromHere(import.meta.url)
+  const forwardedArgs = rewriteRunUi(process.argv.slice(2), root)
+
+  // Resolve the git-scenarios CLI binary by reading its package.json
+  // off disk and following the `bin.git-scenarios` entry. We
+  // deliberately don't use require.resolve here — the package's
+  // `exports` field doesn't expose `./package.json` or `./dist/bin/cli.js`,
+  // so resolver-based lookup fails. Reading the file directly is
+  // both simpler and more robust.
+  //
+  // The package directory itself is found relative to this script:
+  // `<coco>/bin/scenarioRunner.ts` → `<coco>/node_modules/@gfargo/git-scenarios`.
+  // Walking up via `path.join(root, 'node_modules', '...')` keeps the
+  // resolution under our control rather than at the mercy of any
+  // ambient PATH state.
+  const pkgDir = path.join(root, 'node_modules', '@gfargo', 'git-scenarios')
+  const pkgJsonPath = path.join(pkgDir, 'package.json')
+  if (!existsSync(pkgJsonPath)) {
+    console.error(`@gfargo/git-scenarios not installed at ${pkgDir}. Run \`yarn install\` first.`)
+    process.exit(1)
+  }
+  const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf8')) as {
+    bin?: Record<string, string> | string
+  }
+  const binEntry = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin?.['git-scenarios']
+  if (!binEntry) {
+    console.error('Could not locate @gfargo/git-scenarios CLI binary in package.json `bin` field.')
+    process.exit(1)
+  }
+  const cliBin = path.resolve(pkgDir, binEntry)
+
+  const child = spawn(process.execPath, [cliBin, ...forwardedArgs], {
+    stdio: 'inherit',
+  })
+
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      // Propagate the originating signal so a Ctrl+C in the wrapper
+      // doesn't look like a clean exit upstream.
+      process.kill(process.pid, signal)
+      return
+    }
+    process.exit(code ?? 0)
+  })
+}
+
+// Only spawn when invoked directly. Imports (e.g. tests around the
+// pure rewriteRunUi helper) get the exports without firing the CLI.
+if (fileURLToPath(import.meta.url) === path.resolve(process.argv[1] ?? '')) {
+  main()
+}

--- a/bin/scenarioRunner/runUiFlag.ts
+++ b/bin/scenarioRunner/runUiFlag.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure helper for rewriting the `--run-ui` shortcut documented by coco
+ * into the `--run <cmd>` form that `@gfargo/git-scenarios`'s CLI
+ * actually understands.
+ *
+ * Lives in its own module (separate from the entry script
+ * `bin/scenarioRunner.ts`) so unit tests can import it without
+ * pulling in the script's `import.meta.url` direct-invocation guard
+ * — that line is ESM-only and ts-jest's CJS transform chokes on it.
+ */
+import path from 'node:path'
+
+export const RUN_UI_FLAG = '--run-ui'
+
+/**
+ * Rewrite every occurrence of `--run-ui` in `argv` to the equivalent
+ * `--run "tsx <root>/src/index.ts ui"` so the underlying git-scenarios
+ * CLI can launch the workstation. Every other arg passes through
+ * unchanged; the function is a no-op when `--run-ui` is absent.
+ *
+ * `root` is the coco repository root (passed in so callers can resolve
+ * it however they want — from `import.meta.url`, `process.cwd()`, or
+ * a fixed path under test).
+ */
+export function rewriteRunUi(argv: string[], root: string): string[] {
+  const out: string[] = []
+  for (const arg of argv) {
+    if (arg === RUN_UI_FLAG) {
+      out.push('--run', `tsx ${path.join(root, 'src/index.ts')} ui`)
+      continue
+    }
+    out.push(arg)
+  }
+  return out
+}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test:publish": "npm run lint && npm run build && npm run test:cli && npm pack --dry-run",
     "test:cli": "tsx bin/smokeCli.ts",
     "bench": "tsx bin/benchmark.ts",
-    "scenario": "git-scenarios",
+    "scenario": "tsx bin/scenarioRunner.ts",
     "eval:structural-extract": "tsx bin/structuralExtractEval.ts",
     "pretest:jest": "npm run build:info && node bin/copyTreeSitterWasm.mjs",
     "test:jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",


### PR DESCRIPTION
## The bug

`npm run scenario create <name> -- --run-ui` printed the "Scenario ready at …" line and exited without launching `coco ui`. The flag was advertised in the workstation README, the Testing-Scenarios wiki page, and several scenario descriptions, but never actually implemented anywhere.

Repro:

```
$ npm run scenario create branch-sync-showcase -- --run-ui
✓ Scenario "branch-sync-showcase" ready at: /tmp/coco-git-test-…
  (no UI launch, exit 0)
```

## Root cause

`@gfargo/git-scenarios`'s CLI only knows `--run <cmd>`. The `scenario` npm script was a bare `git-scenarios` passthrough, so `--run-ui` got silently dropped during the package's loose flag parsing.

## The fix

New coco-side wrapper `bin/scenarioRunner.ts` that:

1. **Intercepts `--run-ui`** in the forwarded argv and rewrites it to `--run "tsx <coco-root>/src/index.ts ui"`. Position-preserving so users can place the flag anywhere in the command.
2. **Resolves the git-scenarios CLI binary off disk** via `node_modules/@gfargo/git-scenarios/package.json`'s `bin` field. Deliberately doesn't use `require.resolve` — the package's `exports` field doesn't expose `./package.json` or `./dist/bin/cli.js`, so resolver-based lookup fails. Reading directly is also more robust against a stale globally-installed git-scenarios that would otherwise shadow coco's pinned version.
3. **`spawn()` with `stdio: 'inherit'`** so signal handling (Ctrl+C) and exit codes propagate cleanly.

`package.json`'s `scenario` script bumps from the bare passthrough to `tsx bin/scenarioRunner.ts`.

## Architecture

The pure `rewriteRunUi` helper lives in a separate module (`bin/scenarioRunner/runUiFlag.ts`) so unit tests can import it without pulling in the script's `import.meta.url` direct-invocation guard — that line is ESM-only and ts-jest's CJS transform chokes on it. The main script keeps the side-effecting bits (spawn, exit, path resolution).

## Tests

7 new in `bin/scenarioRunner.test.ts` pinning the helper:
- basic rewrite of bare `--run-ui`
- position preservation
- no-op when `--run-ui` is absent
- rewrites every occurrence (defensive — rare doubled-up case)
- empty argv returns empty
- substring match safety (`--run-ui-mode` does NOT match — only the exact token)
- the exported `RUN_UI_FLAG` literal stays `--run-ui`

## Test plan

- [x] `npm run test:jest -- bin/scenarioRunner.test.ts` — 7 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint bin/scenarioRunner.ts bin/scenarioRunner/runUiFlag.ts` — clean
- [x] `npx tsx bin/scenarioRunner.ts list` — passthrough works (21 scenarios)
- [x] `npx tsx bin/scenarioRunner.ts create empty-repo --run-ui --ephemeral --path /tmp/coco-runui-smoke` — prints `Launching \\`tsx /Users/.../coco/src/index.ts ui\\` against the scenario…` and starts the UI
- [ ] Manual: `npm run scenario create branch-sync-showcase -- --run-ui` should now actually open the workstation against the scenario directory (this was the original failing repro)

## Followup considerations

The `--run-ui` flag is a coco-specific shortcut. External consumers of `@gfargo/git-scenarios` keep using `--run "coco ui"` (or any other shell command) — this PR doesn't change the package, only how coco's own `scenario` script invokes it.

If `@gfargo/git-scenarios` ever ships its own `bin/` structure changes (e.g., a different name for the CLI binary), the resolver in this wrapper would need updating — flagged inline in the comment block.