### PR TITLE
chore: bump @gfargo/git-scenarios to ^0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@commitlint/types": "^20.5.0",
-    "@gfargo/git-scenarios": "^0.3.3",
+    "@gfargo/git-scenarios": "^0.4.0",
     "@rollup/plugin-commonjs": "^29.0.0",
     "@rollup/plugin-eslint": "^9.0.5",
     "@rollup/plugin-json": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -653,10 +653,10 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
-"@gfargo/git-scenarios@^0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@gfargo/git-scenarios/-/git-scenarios-0.3.3.tgz#08efd5d82aaa75f6341908639647596146bcccf8"
-  integrity sha512-wmlCu9q4BTiaFvLx8htdBHeRKmVp9RXWVnAUNUb0KD6P11KedaDnvNwEViTYzBUa6utuYoseggrs00MpMNv/bg==
+"@gfargo/git-scenarios@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@gfargo/git-scenarios/-/git-scenarios-0.4.0.tgz#5097827fed36747aa341952a3784bf3b180187d6"
+  integrity sha512-dEF8Ol1976mrnbbSqHkxJY8bMXFvuYOdH2xZ/83DNjFIS+seqpTAH/e346AzeE1bnb7ANOHXLnCR7dBM4nrQ8A==
 
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"


### PR DESCRIPTION
Brings in v0.4.0 of the scenarios package.

## What's new for coco

**Two new conflict scenarios** that complement the existing \`mid-merge-conflict\`:

| Scenario | What |
|---|---|
| \`mid-rebase-conflict\` | repo mid-rebase with \`.git/rebase-merge/\` and \`REBASE_HEAD\` set, one conflicted file (\`src/config.ts\`) |
| \`mid-cherry-pick-conflict\` | repo mid-cherry-pick with \`CHERRY_PICK_HEAD\` set, one conflicted file (\`src/utils.ts\`) |

These would let us test coco's conflict view against the three different \`.git/\` state files — each of which triggers a different resolution flow. Registry now at **23 scenarios**.

**Eight new atoms across four categories**, none of which we need *today* but unlock future testing:

- **Sparse checkout**: \`enableSparseCheckout\`, \`disableSparseCheckout\`
- **Shallow repo**: \`shallowAt\`, \`unshallow\`
- **Git notes**: \`addNote\`, \`appendNote\`, \`removeNote\`
- **Git hooks**: \`installHook\`, \`removeHook\`

**Two new programmatic APIs**:

- \`fromScenario(name, ...extraSteps)\` — spin up a named scenario + apply additional atoms on top in one line
- \`findScenariosByTag(tags, match?)\` — filter scenarios by tag with \`'any'\` or \`'all'\` matching

## Test plan

- [x] \`yarn add --dev @gfargo/git-scenarios@^0.4.0\` resolves cleanly
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx jest src/commands/commands.integration.test.ts\` — 17 pass
- [x] \`npm run scenario list\` — 23 scenarios visible including the two new conflict ones
- [ ] Manual: \`npm run scenario create mid-rebase-conflict -- --run-ui\` — confirm coco's conflicts view renders against the rebase \`.git/\` state
- [ ] Manual: same with \`mid-cherry-pick-conflict\`

Release notes: https://github.com/gfargo/git-scenarios/releases/tag/v0.4.0