### PR TITLE
chore: bump @gfargo/git-scenarios to ^0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@commitlint/types": "^21.0.1",
-    "@gfargo/git-scenarios": "^0.4.0",
+    "@gfargo/git-scenarios": "^0.5.0",
     "@rollup/plugin-commonjs": "^29.0.0",
     "@rollup/plugin-eslint": "^9.0.5",
     "@rollup/plugin-json": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -645,10 +645,10 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
-"@gfargo/git-scenarios@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@gfargo/git-scenarios/-/git-scenarios-0.4.0.tgz#5097827fed36747aa341952a3784bf3b180187d6"
-  integrity sha512-dEF8Ol1976mrnbbSqHkxJY8bMXFvuYOdH2xZ/83DNjFIS+seqpTAH/e346AzeE1bnb7ANOHXLnCR7dBM4nrQ8A==
+"@gfargo/git-scenarios@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@gfargo/git-scenarios/-/git-scenarios-0.5.0.tgz#cc96730920c1316af8d2ec742014b1e88af15bf1"
+  integrity sha512-o42gSDkytx443bk+catJZFFYYVvV1apwiul9RLOYOpxrzdAgLizg5Tr+qQPPwofnRvhMMTiaEM85CBcwUkTHgg==
 
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"


### PR DESCRIPTION
Brings in v0.5.0 of the scenarios package. Registry expands from 23 to **27 scenarios**, plus a new Jest framework adapter, programmatic scenario registration, and dual ESM/CJS publishing.

## Four new scenarios

| Scenario | Kind | What it tests |
|---|---|---|
| \`shallow-clone\` | branch | Shallow repo (only 3 of 10 commits reachable from HEAD). Edge case for tools that walk history. |
| \`multiple-worktrees\` | worktree | Primary worktree on \`main\` + 3 linked worktrees on feature/hotfix branches. Real fixture for the worktrees view (\`gz\`). |
| \`large-repo\` | history | 115 commits across 3 branches with tags. Pagination + perf testing for the history view. |
| \`mid-revert-conflict\` | operation | In-progress revert with one unresolved conflict. Completes the conflict matrix (we now have **merge / rebase / cherry-pick / revert**). |

## What else 0.5.0 brings

- **Jest framework adapter** at \`@gfargo/git-scenarios/jest\` — \`describeWithScenario\`, \`describeEachScenario\`, \`describeWithScenarioExtended\`. Worth piloting as a refactor target for \`src/commands/commands.integration.test.ts\` in a follow-up if the ergonomics land well.
- **Programmatic scenario registration** — lets coco register coco-specific scenarios at runtime without contributing them upstream.
- **Dual ESM/CJS publishing** via tsup — mostly transparent for us; yarn resolves whichever ts-jest needs.

## Test plan

- [x] \`yarn add --dev @gfargo/git-scenarios@^0.5.0\` resolves cleanly
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx jest src/commands/commands.integration.test.ts\` — 17 pass
- [x] \`npm run scenario list\` shows 27 scenarios including all 4 new ones
- [ ] Manual: \`npm run scenario create mid-revert-conflict -- --run-ui\` — confirm coco's conflicts view renders against the revert \`.git/\` state alongside the merge / rebase / cherry-pick variants
- [ ] Manual: \`npm run scenario create multiple-worktrees -- --run-ui\` — confirm coco's worktrees view (\`gz\`) renders the linked-worktree set correctly
- [ ] Manual: \`npm run scenario create large-repo -- --run-ui\` — sanity check history-view paging and density tier behaviour against a 115-commit log
- [ ] Manual: \`npm run scenario create shallow-clone -- --run-ui\` — confirm \`coco log\` / \`coco changelog\` don't crash on the shallow boundary

Release notes: https://github.com/gfargo/git-scenarios/releases/tag/v0.5.0