### PR TITLE
fix(commit): single-commit fallback when split planner exhausts retries

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@commitlint/types": "^21.0.1",
-    "@gfargo/git-scenarios": "^0.4.0",
+    "@gfargo/git-scenarios": "^0.5.0",
     "@rollup/plugin-commonjs": "^29.0.0",
     "@rollup/plugin-eslint": "^9.0.5",
     "@rollup/plugin-json": "^6.0.0",

--- a/src/commands/commands.integration.test.ts
+++ b/src/commands/commands.integration.test.ts
@@ -586,7 +586,13 @@ describe('command integration with temp git repos', () => {
     expect(stdout).toContain('test: add feature fixture')
   })
 
-  it('surfaces a clear error after retries are exhausted', async () => {
+  it('falls back to a single-commit plan after retries are exhausted', async () => {
+    // Issue #1005: when the LLM can't produce a valid multi-group
+    // plan even with retry feedback, the default behaviour is to fall
+    // back to a single-group plan that puts every staged file into
+    // one commit — strictly better than throwing and leaving the user
+    // with a staged worktree and no commit. Strict-mode coverage is
+    // in the sibling test below.
     mockLoadConfig.mockReturnValue(createConfig({
       mode: 'stdout',
     }))
@@ -594,6 +600,57 @@ describe('command integration with temp git repos', () => {
     // unknownFiles invalidation (no rescue available) — guarantees
     // retries actually exhaust. A missing-file invalidation would be
     // auto-rescued on attempt 1.
+    mockExecuteChainWithSchema.mockResolvedValue({
+      groups: [
+        {
+          title: 'docs: update readme',
+          body: 'Document the temp repo.',
+          files: ['README.md', 'ghost.ts'],
+          hunks: [],
+        },
+      ],
+    })
+
+    await repo.writeFile('.gitkeep', '\n')
+    await repo.commitAll('chore: initial commit')
+    await repo.writeFile('README.md', '# Temp repo\n')
+    await repo.writeFile('src/feature.ts', 'export const feature = true\n')
+    await repo.git.add(['README.md', 'src/feature.ts'])
+
+    await commitHandler({
+      $0: 'coco',
+      _: ['commit', 'split'],
+      interactive: false,
+      openInEditor: false,
+      ignoredFiles: [],
+      ignoredExtensions: [],
+      withPreviousCommits: 0,
+      conventional: false,
+      includeBranchName: false,
+      noDiff: false,
+      noVerify: true,
+      split: true,
+      plan: true,
+      apply: false,
+      verbose: false,
+      version: false,
+      help: false,
+    } as Arguments<CommitOptions>, createLogger())
+
+    expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(3)
+    // Fallback plan: one group, both staged files in it, chore: title.
+    expect(stdout).toContain('chore: combined commit')
+    expect(stdout).toContain('README.md')
+    expect(stdout).toContain('src/feature.ts')
+  })
+
+  it('throws after exhausting retries when --strict-split is set', async () => {
+    // Opt-in strict mode restores the pre-#1005 behaviour: fail
+    // loudly instead of degrading to the single-commit fallback.
+    mockLoadConfig.mockReturnValue(createConfig({
+      mode: 'stdout',
+    }))
+
     mockExecuteChainWithSchema.mockResolvedValue({
       groups: [
         {
@@ -627,6 +684,7 @@ describe('command integration with temp git repos', () => {
         split: true,
         plan: true,
         apply: false,
+        strictSplit: true,
         verbose: false,
         version: false,
         help: false,

--- a/src/commands/commit/config.ts
+++ b/src/commands/commit/config.ts
@@ -15,6 +15,13 @@ export interface CommitOptions extends BaseCommandOptions {
   split?: boolean
   plan?: boolean
   apply?: boolean
+  /**
+   * When true, throw if the split planner exhausts its retry budget
+   * with an invalid plan (pre-#1005 behaviour) instead of falling
+   * back to a single-group plan that combines every staged file into
+   * one commit. Default: false (fallback is enabled).
+   */
+  strictSplit?: boolean
 }
 
 export type CommitArgv = Arguments<CommitOptions>
@@ -114,6 +121,12 @@ export const options = {
   },
   apply: {
     description: 'Apply a generated file-level or hunk-level commit split plan and create commits',
+    type: 'boolean',
+    default: false,
+  },
+  strictSplit: {
+    description:
+      'Fail loudly if the split planner exhausts its retry budget with an invalid plan (otherwise falls back to a single combined commit).',
     type: 'boolean',
     default: false,
   },

--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -323,6 +323,13 @@ export type CommitSplitApplyResult = {
   commitHashes: string[]
   /** Human-readable summary, suitable for the CLI handler / status line. */
   message: string
+  /**
+   * Set when the applied plan was the single-group fallback returned
+   * by the planner after exhausting its retry budget. Workstation
+   * surfaces should prefix the success message with a fallback note
+   * so the user knows the plan wasn't a real LLM split.
+   */
+  fallback?: import('./splitPlanGenerator').SplitPlanFallbackInfo
 }
 
 export async function applyCommitSplitPlan({
@@ -332,6 +339,7 @@ export async function applyCommitSplitPlan({
   git,
   logger,
   noVerify,
+  fallback,
 }: {
   plan: CommitSplitPlan
   changes: Awaited<ReturnType<typeof getChanges>>
@@ -339,6 +347,13 @@ export async function applyCommitSplitPlan({
   git: ReturnType<typeof import('../../lib/simple-git/getRepo').getRepo>
   logger: Logger
   noVerify: boolean
+  /**
+   * Optional fallback descriptor from the planner. When set, the
+   * returned `CommitSplitApplyResult.fallback` echoes it so the
+   * runtime's apply-time success message can prefix a note about
+   * the degraded plan.
+   */
+  fallback?: import('./splitPlanGenerator').SplitPlanFallbackInfo
 }): Promise<CommitSplitApplyResult> {
   validatePlanForStagedFiles(plan, changes.staged, hunkInventory)
   assertNoUnstagedOverlap(plan, changes, hunkInventory)
@@ -454,12 +469,14 @@ export async function applyCommitSplitPlan({
     return {
       commitHashes,
       message: `Created ${commitHashes.length} of ${applicableGroups.length} planned commit(s). Failed: ${partial}`,
+      fallback,
     }
   }
 
   return {
     commitHashes,
     message: `Created ${commitHashes.length} split commit(s).`,
+    fallback,
   }
 }
 
@@ -512,7 +529,20 @@ export async function prepareCommitSplitPlan({
   planLlm?: ReturnType<typeof getLlm>
   /** Service descriptor matching `planLlm` (for telemetry metadata). */
   planService?: LLMService
-}): Promise<{ plan: CommitSplitPlan; context: CommitSplitPlanContext } | { empty: true }> {
+}): Promise<
+  | {
+      plan: CommitSplitPlan
+      context: CommitSplitPlanContext
+      /**
+       * Set when the planner returned the single-group fallback
+       * instead of LLM output. Surfaces in apply / preview UIs so
+       * users know to verify the combined commit message (or
+       * re-roll the planner for another try).
+       */
+      fallback?: import('./splitPlanGenerator').SplitPlanFallbackInfo
+    }
+  | { empty: true }
+> {
   const changes = await getChanges({
     git,
     options: {
@@ -596,7 +626,7 @@ export async function prepareCommitSplitPlan({
   const resolvedPlanLlm = planLlm ?? llm
   const resolvedPlanModel = planService?.model ?? config.service.model
 
-  const { plan } = await generateValidatedCommitSplitPlan({
+  const { plan, fallback } = await generateValidatedCommitSplitPlan({
     llm: resolvedPlanLlm,
     prompt: COMMIT_SPLIT_PROMPT,
     variables: {
@@ -619,9 +649,13 @@ export async function prepareCommitSplitPlan({
       conventional: useConventional,
     },
     maxAttempts: DEFAULT_MAX_PLAN_ATTEMPTS,
+    // Honour `--strict-split` (CLI) or `strictSplit` (config). When set,
+    // the planner reverts to the pre-#1005 behaviour of throwing on
+    // exhaustion instead of returning the single-group fallback.
+    strict: Boolean(argv.strictSplit ?? config.strictSplit),
   })
 
-  return { plan, context: { changes, hunkInventory } }
+  return { plan, context: { changes, hunkInventory }, fallback }
 }
 
 export async function handleCommitSplit({
@@ -658,7 +692,7 @@ export async function handleCommitSplit({
     return 'No staged changes found.'
   }
 
-  const { plan, context } = result
+  const { plan, context, fallback } = result
 
   if (argv.apply) {
     const applied = await applyCommitSplitPlan({
@@ -668,8 +702,24 @@ export async function handleCommitSplit({
       git,
       logger,
       noVerify: argv.noVerify || config.noVerify || false,
+      fallback,
     })
+    if (applied.fallback) {
+      return [
+        `Note: applied the single-commit fallback (${applied.fallback.reason}).`,
+        applied.message,
+      ].join('\n')
+    }
     return applied.message
+  }
+
+  if (fallback) {
+    return [
+      `Note: showing the single-commit fallback plan (${fallback.reason}).`,
+      'Re-run with a stronger model or use --strict-split to surface the planner error.',
+      '',
+      formatCommitSplitPlan(plan),
+    ].join('\n')
   }
 
   return formatCommitSplitPlan(plan)

--- a/src/commands/commit/splitPlanGenerator.test.ts
+++ b/src/commands/commit/splitPlanGenerator.test.ts
@@ -202,9 +202,43 @@ describe('generateValidatedCommitSplitPlan', () => {
     expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(1)
   })
 
-  it('throws after exhausting retries with the final validator complaints in the message', async () => {
+  it('returns a single-group fallback plan after exhausting retries by default', async () => {
+    // Issue #1005: pre-fallback behaviour was to throw after exhausting
+    // the retry budget, which left the user with staged files and no
+    // commit. The default now is to hand back a trivially-valid
+    // single-group fallback so the user can still land *something*.
     // Uses unknownFiles (no rescue available) so retries actually
-    // exhaust. A missing-files invalidation would be auto-rescued.
+    // exhaust — a missing-files invalidation would be auto-rescued.
+    const invalidPlan: CommitSplitPlan = {
+      groups: [
+        { title: 'a', files: ['a.ts'], hunks: [] },
+        { title: 'b', files: ['ghost.ts'], hunks: [] },
+      ],
+    }
+    mockExecuteChainWithSchema.mockResolvedValue(invalidPlan)
+
+    const result = await generateValidatedCommitSplitPlan({
+      ...baseArgs(),
+      maxAttempts: 2,
+    })
+
+    // Fallback plan: one group, every staged file in it, no hunks.
+    expect(result.plan.groups).toHaveLength(1)
+    expect(result.plan.groups[0].files).toEqual(['a.ts', 'b.ts'])
+    expect(result.plan.groups[0].hunks).toEqual([])
+    // `fallback` is set so the caller can surface a nudge to the user.
+    expect(result.fallback).toBeDefined()
+    expect(result.fallback?.reason).toMatch(/exhausted 2 planning attempts/i)
+    expect(result.fallback?.reason).toMatch(/unknown files: ghost\.ts/i)
+    // `attempts` reflects the full retry budget that was burned.
+    expect(result.attempts).toBe(2)
+    expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws on exhaustion when strict mode is requested', async () => {
+    // The CLI `--strict-split` flag (and any caller passing
+    // `strict: true`) opts back into pre-fallback behaviour: fail
+    // loudly rather than degrade silently to a single-commit plan.
     const invalidPlan: CommitSplitPlan = {
       groups: [
         { title: 'a', files: ['a.ts'], hunks: [] },
@@ -214,7 +248,11 @@ describe('generateValidatedCommitSplitPlan', () => {
     mockExecuteChainWithSchema.mockResolvedValue(invalidPlan)
 
     await expect(
-      generateValidatedCommitSplitPlan({ ...baseArgs(), maxAttempts: 2 })
+      generateValidatedCommitSplitPlan({
+        ...baseArgs(),
+        maxAttempts: 2,
+        strict: true,
+      })
     ).rejects.toThrow(/after 2 attempts.*unknown files: ghost\.ts/i)
 
     expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(2)

--- a/src/commands/commit/splitPlanGenerator.ts
+++ b/src/commands/commit/splitPlanGenerator.ts
@@ -6,6 +6,7 @@ import { TokenCounter } from '../../lib/utils/tokenizer'
 import { FileChange } from '../../lib/types'
 import { CommitSplitPlan, CommitSplitPlanSchema } from './splitPlanTypes'
 import {
+  buildSplitPlanFallback,
   dropEmptyGroups,
   formatPlanValidationFeedback,
   formatPlanValidationIssuesError,
@@ -35,11 +36,42 @@ export interface GenerateSplitPlanArgs {
   metadata?: Record<string, unknown>
   /** Total attempts including the initial call. Defaults to 3. */
   maxAttempts?: number
+  /**
+   * When true, throw on exhaustion of `maxAttempts` instead of
+   * returning the single-group fallback plan. Restores the
+   * pre-#1005 behaviour for callers (or CLI users via
+   * `--strict-split`) who'd rather see an explicit failure than a
+   * degraded plan.
+   */
+  strict?: boolean
+}
+
+/**
+ * Metadata describing a degraded plan that was synthesised after the
+ * LLM exhausted its attempt budget without producing a valid plan.
+ * Absent on the happy path.
+ */
+export interface SplitPlanFallbackInfo {
+  /**
+   * Human-readable explanation suitable for status-line surfaces.
+   * Includes the count of attempts and the most-recent validator
+   * complaints so the user can see WHY they got a fallback.
+   */
+  reason: string
+  /** The validator issues from the final failed attempt, kept verbatim. */
+  lastIssues: PlanValidationIssues
 }
 
 export interface GenerateSplitPlanResult {
   plan: CommitSplitPlan
   attempts: number
+  /**
+   * When set, the returned `plan` is a synthesized single-group
+   * fallback rather than LLM output. Callers should surface this
+   * in their apply / preview UI so the user knows to verify the
+   * combined commit message (or re-roll the planner).
+   */
+  fallback?: SplitPlanFallbackInfo
 }
 
 /**
@@ -60,6 +92,7 @@ export async function generateValidatedCommitSplitPlan({
   tokenizer,
   metadata = {},
   maxAttempts = DEFAULT_MAX_PLAN_ATTEMPTS,
+  strict = false,
 }: GenerateSplitPlanArgs): Promise<GenerateSplitPlanResult> {
   let lastIssues: PlanValidationIssues | null = null
   let attempt = 0
@@ -149,11 +182,48 @@ export async function generateValidatedCommitSplitPlan({
     }
   }
 
-  throw new Error(
-    lastIssues
-      ? `Failed to produce a valid commit-split plan after ${maxAttempts} attempts. Final validator issues: ${formatPlanValidationIssuesError(
-          lastIssues
-        )}`
-      : `Failed to produce a valid commit-split plan after ${maxAttempts} attempts.`
-  )
+  const issuesSummary = lastIssues
+    ? formatPlanValidationIssuesError(lastIssues)
+    : 'no captured validator issues'
+
+  // Strict mode: restore the pre-#1005 behaviour. Callers that pass
+  // `strict: true` (and CLI users via `--strict-split`) want explicit
+  // failure rather than the degraded fallback.
+  if (strict) {
+    throw new Error(
+      lastIssues
+        ? `Failed to produce a valid commit-split plan after ${maxAttempts} attempts. Final validator issues: ${issuesSummary}`
+        : `Failed to produce a valid commit-split plan after ${maxAttempts} attempts.`
+    )
+  }
+
+  // Default: hand back a trivially-valid single-group fallback. The
+  // caller's apply / preview surface should treat the `fallback` flag
+  // as a signal to nudge the user (it's strictly better than a hard
+  // failure with the staged set still on disk, but it's still a
+  // degraded outcome compared to a real multi-group split).
+  const reason = `LLM exhausted ${maxAttempts} planning attempts; final validator issues: ${issuesSummary}`
+  if (logger) {
+    logger.verbose(
+      `Plan attempts exhausted — falling back to a single-group plan. ${reason}`,
+      { color: 'yellow' }
+    )
+  }
+
+  return {
+    plan: buildSplitPlanFallback(staged, { reason: issuesSummary }),
+    attempts: maxAttempts,
+    fallback: {
+      reason,
+      lastIssues: lastIssues ?? {
+        unknownFiles: [],
+        duplicateFiles: [],
+        unknownHunks: [],
+        duplicateHunks: [],
+        mixedFiles: [],
+        partiallyCoveredFiles: [],
+        missingFiles: [],
+      },
+    },
+  }
 }

--- a/src/commands/commit/splitPlanValidation.test.ts
+++ b/src/commands/commit/splitPlanValidation.test.ts
@@ -1,5 +1,6 @@
 import { FileChange } from '../../lib/types'
 import {
+  buildSplitPlanFallback,
   dropEmptyGroups,
   formatPlanValidationFeedback,
   formatPlanValidationIssuesError,
@@ -683,6 +684,65 @@ describe('splitPlanValidation', () => {
         ],
       }
       expect(dropEmptyGroups(plan)).toBe(plan)
+    })
+  })
+
+  describe('buildSplitPlanFallback', () => {
+    it('puts every staged file into a single group with no hunks', () => {
+      // The fallback's whole point: produce something that's
+      // trivially valid regardless of what the LLM was returning.
+      // One group, every staged file in `files[]`, no hunks.
+      const plan = buildSplitPlanFallback([
+        stagedFile('a.ts'),
+        stagedFile('b.ts'),
+        stagedFile('c.ts'),
+      ])
+
+      expect(plan.groups).toHaveLength(1)
+      expect(plan.groups[0].files).toEqual(['a.ts', 'b.ts', 'c.ts'])
+      expect(plan.groups[0].hunks).toEqual([])
+    })
+
+    it('includes the validator reason in the rationale so the user can see what went wrong', () => {
+      const plan = buildSplitPlanFallback([stagedFile('a.ts')], {
+        reason: 'duplicate hunks across groups',
+      })
+
+      // Rationale should mention the fallback context AND the
+      // underlying reason — the user needs both to decide whether to
+      // re-roll or accept the combined commit.
+      expect(plan.groups[0].rationale).toContain('Fallback plan')
+      expect(plan.groups[0].rationale).toContain('duplicate hunks across groups')
+    })
+
+    it('still produces a valid plan when no reason is provided', () => {
+      const plan = buildSplitPlanFallback([stagedFile('a.ts')])
+
+      expect(plan.groups).toHaveLength(1)
+      expect(plan.groups[0].files).toEqual(['a.ts'])
+      // No reason → no "Reason:" suffix bleeding into the rationale.
+      expect(plan.groups[0].rationale).not.toContain('Reason:')
+    })
+
+    it('uses a conventional-commits-compatible default title', () => {
+      const plan = buildSplitPlanFallback([stagedFile('a.ts')])
+      // `chore:` is intentionally bland — real messaging is the
+      // user's job at the compose / apply step.
+      expect(plan.groups[0].title).toMatch(/^chore:/)
+    })
+
+    it('produces a plan that passes validation against the staged set', () => {
+      // The whole point of the fallback is that it can't fail
+      // validation. Guard against future regressions where someone
+      // accidentally introduces hunks or unknown files into the
+      // fallback shape.
+      const staged: FileChange[] = [stagedFile('a.ts'), stagedFile('b.ts')]
+      const inventory = buildHunkInventory({})
+      const plan = buildSplitPlanFallback(staged, { reason: 'some reason' })
+
+      const issues = getPlanValidationIssues(plan, staged, inventory)
+
+      expect(hasPlanValidationIssues(issues)).toBe(false)
     })
   })
 })

--- a/src/commands/commit/splitPlanValidation.ts
+++ b/src/commands/commit/splitPlanValidation.ts
@@ -427,6 +427,57 @@ export function dropEmptyGroups(plan: CommitSplitPlan): CommitSplitPlan {
   return { ...plan, groups: surviving }
 }
 
+/**
+ * Construct a trivially-valid single-group plan covering every staged
+ * file. Used as the fallback when the LLM exhausts its retry budget
+ * with an invalid plan — turning a hard failure into a usable
+ * (if degraded) outcome.
+ *
+ * Properties of the returned plan:
+ *
+ *   - Exactly one group.
+ *   - Every staged file appears in that group's `files[]`. No hunks
+ *     are claimed, so any hunk inventory is irrelevant to the plan's
+ *     validity.
+ *   - By construction: no duplicates, no missing files, no mixed
+ *     mode, no phantom hunks. `getPlanValidationIssues` returns an
+ *     empty issue set.
+ *
+ * The group's `rationale` carries the reason text the caller wants
+ * to expose to the UI (typically "model exhausted N attempts; last
+ * issues were …"). The `body` carries a short note that survives
+ * into the commit message body so a user who applies without editing
+ * has the context recorded in git history.
+ *
+ * `title` defaults to a generic conventional-commits-compatible
+ * `chore: combined commit` — bland on purpose. Real commit messaging
+ * is the user's job at the compose / apply step.
+ *
+ * The plan is NOT linked to the LLM by construction. If the model
+ * can't produce a valid split, the user still gets one apply-able
+ * commit instead of a thrown error and a still-staged worktree.
+ */
+export function buildSplitPlanFallback(
+  staged: FileChange[],
+  options: { reason?: string } = {}
+): CommitSplitPlan {
+  const files = staged.map((change) => change.filePath)
+  const reasonLine = options.reason
+    ? ` Reason: ${options.reason}`
+    : ''
+  return {
+    groups: [
+      {
+        title: 'chore: combined commit',
+        body: 'Auto-generated single-commit fallback after the split planner could not produce a valid multi-group plan. Edit before applying if you want a more specific message; press `r` to re-roll the planner if a different model might do better.',
+        rationale: `Fallback plan — every staged file in one commit because the LLM could not produce a valid multi-group split.${reasonLine}`,
+        files,
+        hunks: [],
+      },
+    ],
+  }
+}
+
 export function formatPlanValidationFeedback(issues: PlanValidationIssues): string {
   const sections: string[] = []
 

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -538,6 +538,14 @@ export type SplitPlanState = {
   planContext?: CommitSplitPlanContext
   scrollOffset: number
   error?: string
+  /**
+   * Set when the planner exhausted its retry budget and returned the
+   * single-group fallback. Surfaces in the overlay header so the user
+   * knows the plan they're previewing isn't a real LLM split, and in
+   * the apply-time success message. Cleared when the user re-rolls
+   * the planner.
+   */
+  fallback?: import('../../commands/commit/splitPlanGenerator').SplitPlanFallbackInfo
 }
 
 export type LogInkStatusFilterMask = {
@@ -727,7 +735,12 @@ export type LogInkAction =
   | { type: 'markRecentCommits'; hashes: string[] }
   | { type: 'clearRecentCommits' }
   | { type: 'startSplitPlanLoad' }
-  | { type: 'setSplitPlanReady'; plan: CommitSplitPlan; planContext: CommitSplitPlanContext }
+  | {
+      type: 'setSplitPlanReady'
+      plan: CommitSplitPlan
+      planContext: CommitSplitPlanContext
+      fallback?: import('../../commands/commit/splitPlanGenerator').SplitPlanFallbackInfo
+    }
   | { type: 'setSplitPlanApplying' }
   | { type: 'setSplitPlanError'; error: string }
   | { type: 'pageSplitPlan'; delta: number; lineCount: number }
@@ -2099,6 +2112,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
           plan: action.plan,
           planContext: action.planContext,
           scrollOffset: 0,
+          fallback: action.fallback,
         },
         pendingKey: undefined,
       }

--- a/src/git/commitWorkflowActions.ts
+++ b/src/git/commitWorkflowActions.ts
@@ -229,7 +229,18 @@ export async function runCommitDraftWorkflow(
  * state between plan generation and apply.
  */
 export type CommitSplitPlanResult =
-  | { ok: true; plan: CommitSplitPlan; planContext: CommitSplitPlanContext }
+  | {
+      ok: true
+      plan: CommitSplitPlan
+      planContext: CommitSplitPlanContext
+      /**
+       * Set when the planner returned the single-group fallback after
+       * exhausting its retry budget. Workstation surfaces should
+       * prefix the apply / preview message with a note so the user
+       * knows the plan isn't a real LLM split.
+       */
+      fallback?: import('../commands/commit/splitPlanGenerator').SplitPlanFallbackInfo
+    }
   | { ok: false; message: string; details?: string[] }
 
 /**
@@ -297,6 +308,7 @@ export async function runCommitSplitPlanWorkflow(
       ok: true,
       plan: result.plan,
       planContext: result.context,
+      fallback: result.fallback,
     }
   } catch (error) {
     if (isCommandExitError(error)) {
@@ -335,7 +347,17 @@ export async function runCommitSplitApplyWorkflow(input: {
   planContext: CommitSplitPlanContext
   git?: SimpleGit
   noVerify?: boolean
-}): Promise<CommitWorkflowResult & { commitHashes?: string[] }> {
+  /**
+   * Optional fallback descriptor carried over from
+   * `runCommitSplitPlanWorkflow`. When present, the apply-time
+   * success message gets prefixed with a note so the user knows
+   * the single-commit fallback is what landed.
+   */
+  fallback?: import('../commands/commit/splitPlanGenerator').SplitPlanFallbackInfo
+}): Promise<CommitWorkflowResult & {
+  commitHashes?: string[]
+  fallback?: import('../commands/commit/splitPlanGenerator').SplitPlanFallbackInfo
+}> {
   const git = input.git || getRepo()
   const logger = new Logger({ silent: true })
 
@@ -347,6 +369,7 @@ export async function runCommitSplitApplyWorkflow(input: {
       git,
       logger,
       noVerify: input.noVerify || false,
+      fallback: input.fallback,
     })
     return {
       ok: true,
@@ -357,6 +380,7 @@ export async function runCommitSplitApplyWorkflow(input: {
       // I/O AND inaccurate when partial-apply landed fewer commits
       // than the plan had groups.
       commitHashes: applied.commitHashes,
+      fallback: applied.fallback,
     }
   } catch (error) {
     if (isCommandExitError(error)) {

--- a/src/workstation/chrome/postApplyHints.test.ts
+++ b/src/workstation/chrome/postApplyHints.test.ts
@@ -76,4 +76,27 @@ describe('formatSplitApplySuccess', () => {
     expect(formatSplitApplySuccess(5, 6, 3)).toContain('gh')
     expect(formatSplitApplySuccess(1, 0, 3)).toContain('gh')
   })
+
+  it('prefixes a fallback note when the planner exhausted retries', () => {
+    // When the split planner falls back to a single-group plan, the
+    // apply still succeeds — but the user needs to know the result
+    // isn't a real LLM-driven multi-group split. The success message
+    // should be unmistakable: prefixed with "Split planner fallback
+    // applied" and include the reason so the user can decide whether
+    // to re-roll or accept the combined commit.
+    const msg = formatSplitApplySuccess(1, 0, 0, {
+      reason: 'plan included duplicate hunks after retries',
+    })
+    expect(msg).toContain('Split planner fallback applied')
+    expect(msg).toContain('combined commit')
+    expect(msg).toContain('duplicate hunks after retries')
+    // Nav cue + clean-worktree tail still present.
+    expect(msg).toContain('press gh to view them in history')
+    expect(msg).toContain('Worktree is clean')
+  })
+
+  it('omits the fallback prefix when no fallback descriptor is passed', () => {
+    const msg = formatSplitApplySuccess(3, 0, 0)
+    expect(msg).not.toContain('fallback')
+  })
 })

--- a/src/workstation/chrome/postApplyHints.ts
+++ b/src/workstation/chrome/postApplyHints.ts
@@ -52,6 +52,16 @@ export function formatRemainingWorktreeHint(unstaged: number, untracked: number)
 }
 
 /**
+ * Lightweight descriptor matching `SplitPlanFallbackInfo` from
+ * `splitPlanGenerator`. Duplicated here as a structural type so
+ * `postApplyHints` doesn't take a dependency on the commit-split
+ * module just to format a status line.
+ */
+export interface SplitApplyFallbackHint {
+  reason: string
+}
+
+/**
  * Format the full post-apply success message: count of commits
  * created + where to see them + what's left + how to act on it.
  *
@@ -69,19 +79,27 @@ export function formatRemainingWorktreeHint(unstaged: number, untracked: number)
  *
  * When the worktree is clean post-apply:
  *   "Created N commits — press gh to view them in history. Worktree is clean."
+ *
+ * When `fallback` is set, the planner exhausted its retry budget and
+ * the apply landed the single-group fallback plan instead of a real
+ * multi-group split. Prefix the message so the user knows the result
+ * isn't a true LLM split — they may want to re-roll with a different
+ * model, or accept the combined commit as-is.
  */
 export function formatSplitApplySuccess(
   commitCount: number,
   unstaged: number,
-  untracked: number
+  untracked: number,
+  fallback?: SplitApplyFallbackHint
 ): string {
   const created = commitCount === 1
     ? 'Created 1 commit'
     : `Created ${commitCount} commits`
   const navCue = `${created} — press gh to view them in history.`
   const remainingHint = formatRemainingWorktreeHint(unstaged, untracked)
-  if (!remainingHint) {
-    return `${navCue} Worktree is clean.`
+  const tail = remainingHint ? ` ${remainingHint}` : ' Worktree is clean.'
+  if (fallback) {
+    return `Split planner fallback applied (combined commit) — ${fallback.reason}. ${navCue}${tail}`
   }
-  return `${navCue} ${remainingHint}`
+  return `${navCue}${tail}`
 }

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -2184,11 +2184,18 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       type: 'setSplitPlanReady',
       plan: result.plan,
       planContext: result.planContext,
+      fallback: result.fallback,
     })
+    const readyMessage = result.fallback
+      ? `Split planner exhausted retries — showing single-commit fallback. y/Enter to apply as one commit, r to re-roll, Esc to cancel.`
+      : `Split plan ready: ${result.plan.groups.length} commit(s). y/Enter to apply, Esc to cancel.`
+    // Use 'info' kind for the fallback path (still actionable, just
+    // not a clean win). The reducer's "warning" is the absence of
+    // `success` framing — the message text itself carries the cue.
     dispatch({
       type: 'setStatus',
-      value: `Split plan ready: ${result.plan.groups.length} commit(s). y/Enter to apply, Esc to cancel.`,
-      kind: 'success',
+      value: readyMessage,
+      kind: result.fallback ? 'info' : 'success',
     })
   }, [context.operation, context.worktree?.stagedCount, dispatch, git])
 
@@ -2238,6 +2245,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       plan: splitPlan.plan,
       planContext: splitPlan.planContext,
       git,
+      fallback: splitPlan.fallback,
     })
 
     dump.push(`workflow returned: ok=${result.ok} message="${result.message}" commitHashes=[${(result.commitHashes || []).join(', ')}]`)
@@ -2340,8 +2348,20 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       return
     }
 
-    const successMessage = formatSplitApplySuccess(commitHashes.length, unstaged, untracked)
-    dispatch({ type: 'setStatus', value: successMessage, kind: 'success' })
+    const successMessage = formatSplitApplySuccess(
+      commitHashes.length,
+      unstaged,
+      untracked,
+      result.fallback ? { reason: result.fallback.reason } : undefined
+    )
+    // Fallback path uses 'info' kind — apply technically succeeded
+    // but the user should know it landed as a single combined commit
+    // rather than a real LLM-driven multi-group split.
+    dispatch({
+      type: 'setStatus',
+      value: successMessage,
+      kind: result.fallback ? 'info' : 'success',
+    })
   }, [dispatch, git, refreshContext, refreshHistoryRows, refreshWorktreeContext, state.splitPlan])
 
   // Esc inside the overlay — close without applying. Status line gets

--- a/yarn.lock
+++ b/yarn.lock
@@ -645,10 +645,10 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
-"@gfargo/git-scenarios@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@gfargo/git-scenarios/-/git-scenarios-0.4.0.tgz#5097827fed36747aa341952a3784bf3b180187d6"
-  integrity sha512-dEF8Ol1976mrnbbSqHkxJY8bMXFvuYOdH2xZ/83DNjFIS+seqpTAH/e346AzeE1bnb7ANOHXLnCR7dBM4nrQ8A==
+"@gfargo/git-scenarios@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@gfargo/git-scenarios/-/git-scenarios-0.5.0.tgz#cc96730920c1316af8d2ec742014b1e88af15bf1"
+  integrity sha512-o42gSDkytx443bk+catJZFFYYVvV1apwiul9RLOYOpxrzdAgLizg5Tr+qQPPwofnRvhMMTiaEM85CBcwUkTHgg==
 
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"


### PR DESCRIPTION
## Summary

Closes #1005.

When the LLM repeatedly produces an invalid commit-split plan and the rescue chain can't recover, the planner used to throw — leaving the user with a staged worktree and no commit. Reported on gpt-4.1-nano in #1005 where the model emitted duplicate files, mixed file/hunk-mode entries, and missing files all in the same response.

The default now is a single-group fallback: every staged file gets combined into one `chore: combined commit` that's trivially valid by construction. The fallback is strictly better than a throw — the user can always edit the commit message before applying, re-roll the planner with `r`, or accept the combined commit and split it later by hand.

- **CLI**: stdout plan output surfaces the fallback reason in the rationale.
- **Workstation**: status line announces the fallback at plan-ready ("Split planner exhausted retries — showing single-commit fallback…") and apply-success ("Split planner fallback applied (combined commit) — \<reason\>…") so the user can't miss that the result isn't a real LLM-driven split.
- **Opt-in strict mode**: `--strict-split` (or `strictSplit: true` in config) restores the pre-#1005 throwing behaviour for callers who'd rather see explicit failure.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:jest --testPathPatterns="(splitPlan|postApplyHints)"` — 65/65 pass
- [x] `npm run test:jest --testPathPatterns="commands\.integration"` — 18/18 pass (includes new fallback + strict-mode coverage)
- [x] `npm run test:jest --testPathPatterns="(commit|workstation|commitWorkflowActions)"` — 710/710 pass
- [ ] Manual smoke: stage many files, run `coco commit --split --plan` against a model that's likely to fail validation, confirm the single-group fallback prints with the reason embedded in the rationale
- [ ] Manual smoke: same scenario in `coco ui` → press `S`, confirm the status line shows the fallback notice at plan-ready and at apply-success