### PR TITLE
fix(workstation): isolate submodule frames from parent state (#994, #995)

### DIFF
--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -1539,14 +1539,58 @@ describe('log Ink view model', () => {
         label: 'vendor/lib',
       })
       const ret = after.repoStack[1].parentReturn
+      // The snapshot now also captures sidebar tab + sort preferences
+      // so pop can restore them (#995). Use defaults from createLogInkState
+      // since `nudgeParentState` doesn't touch those fields.
       expect(ret).toEqual({
         activeView: 'branches',
         selectedIndex: before.selectedIndex,
         selectedFileIndex: 0,
         selectedSubmoduleIndex: 0,
         filter: 'feat:',
+        sidebarTab: before.sidebarTab,
+        userSidebarTab: before.userSidebarTab,
+        branchSort: before.branchSort,
+        tagSort: before.tagSort,
       })
       expect(before.selectedIndex).toBeGreaterThan(0)
+    })
+
+    it('popRepoFrame restores the parent\'s sidebar tab and sort modes (#995)', () => {
+      // Simulate the user-reported bleed: user changes sidebar tab +
+      // branch sort inside a submodule frame, then pops back to the
+      // parent. The parent should snap back to whatever it had pre-push,
+      // not inherit the submodule's choices.
+      const root = applyLogInkAction(createLogInkState(rows, { repoLabel: 'coco' }), {
+        type: 'setSidebarTab',
+        value: 'tags',
+      })
+      // Cycle branch sort once so the parent's value diverges from the
+      // default for the assertion.
+      const parent = applyLogInkAction(root, { type: 'cycleBranchSort' })
+      const parentBranchSort = parent.branchSort
+      const parentSidebarTab = parent.userSidebarTab
+      expect(parentSidebarTab).toBe('tags')
+
+      // Push into a submodule, change sidebar tab + cycle sort again,
+      // then pop. The pop should restore the parent's pre-push values.
+      const pushed = applyLogInkAction(parent, {
+        type: 'pushRepoFrame',
+        label: 'vendor/lib',
+      })
+      const insideSubmodule = applyLogInkAction(
+        applyLogInkAction(pushed, { type: 'setSidebarTab', value: 'stashes' }),
+        { type: 'cycleBranchSort' }
+      )
+      expect(insideSubmodule.userSidebarTab).toBe('stashes')
+      expect(insideSubmodule.branchSort).not.toBe(parentBranchSort)
+
+      const popped = applyLogInkAction(insideSubmodule, { type: 'popRepoFrame' })
+      expect(popped.userSidebarTab).toBe(parentSidebarTab)
+      expect(popped.sidebarTab).toBe(parentSidebarTab)
+      expect(popped.branchSort).toBe(parentBranchSort)
+      // Submodule's state is gone; only the root frame remains.
+      expect(popped.repoStack).toHaveLength(1)
     })
 
     it('pushRepoFrame records the optional entryRange', () => {

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -90,6 +90,21 @@ export type LogInkRepoFrameReturn = {
   selectedFileIndex: number
   selectedSubmoduleIndex: number
   filter: string
+  /**
+   * Sidebar tab + sort preferences captured at push time (#995). Today
+   * these live as global fields on `LogInkState`; per-issue, they should
+   * snap back to the parent's values on pop instead of bleeding the
+   * submodule's choice across the boundary. The corresponding fields on
+   * `LogInkState` continue to carry the *active* frame's values — push
+   * just records the parent's so pop can restore them. Persistence
+   * (sidebar tab to disk; sort modes in-memory only) is unchanged: the
+   * existing per-frame `git`-keyed load effect already restores any
+   * submodule-specific saved tab when the frame becomes active.
+   */
+  sidebarTab: LogInkSidebarTab
+  userSidebarTab: LogInkSidebarTab
+  branchSort: BranchSortMode
+  tagSort: TagSortMode
 }
 /**
  * Tracks which kind of diff the user pushed into. `commit` means they
@@ -940,10 +955,17 @@ function withPoppedView(state: LogInkState): LogInkState {
  * in a clean slate — the mental equivalent of a fresh `coco ui`
  * launched against the submodule's working dir.
  *
- * Carry-over preferences (sidebar tab, branch / tag sort, palette
- * recents, inspector tab, diff view mode) are intentionally left
- * untouched. They're user-level choices that should persist across
- * frames, the same way they persist across view pushes today.
+ * Sidebar tab + branch / tag sort are also captured into the return
+ * snapshot (#995) so popping back restores the parent's choices
+ * instead of letting the submodule's tab/sort bleed across the
+ * boundary. The values on the *new* frame are left as-is (carried
+ * over from the parent) — the load effect in app.ts re-reads
+ * persistence keyed on the submodule's workdir and dispatches a
+ * restore if the user has a submodule-specific saved preference.
+ *
+ * Other preferences (palette recents, inspector tab, diff view mode)
+ * stay global by design — the user's preference shouldn't reset when
+ * they cross a submodule boundary.
  *
  * Live runtime objects (`SimpleGit`, loaded `LogInkContext`) live
  * outside the reducer in `app.ts`'s parallel ref structure — this
@@ -963,6 +985,10 @@ function withPushedRepoFrame(
       selectedFileIndex: state.selectedFileIndex,
       selectedSubmoduleIndex: state.selectedSubmoduleIndex,
       filter: state.filter,
+      sidebarTab: state.sidebarTab,
+      userSidebarTab: state.userSidebarTab,
+      branchSort: state.branchSort,
+      tagSort: state.tagSort,
     },
   }
   return {
@@ -1016,6 +1042,15 @@ function withPoppedRepoFrame(state: LogInkState): LogInkState {
     filter: ret.filter,
     filterMode: false,
     pendingCommitFocused: false,
+    // #995 — restore sidebar tab + sort preferences from the captured
+    // parentReturn. Without this, the submodule's tab / sort choice
+    // bleeds back into the parent after pop: the user picks 'tags' in
+    // a vendored submodule, pops back to the parent, and finds the
+    // parent's previously-selected 'branches' tab quietly replaced.
+    sidebarTab: ret.sidebarTab,
+    userSidebarTab: ret.userSidebarTab,
+    branchSort: ret.branchSort,
+    tagSort: ret.tagSort,
     pendingKey: undefined,
     pendingConfirmationId: undefined,
     pendingConfirmationPayload: undefined,

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -533,10 +533,22 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // Wrappers that delegate to the active frame's runtime entry so the
   // existing call sites stay byte-identical. Support both function-
   // updater and value-updater forms (the codebase uses both).
+  //
+  // `targetDepth` (#994) routes the write to a specific frame instead
+  // of the currently-active one. Loaders that capture the depth at
+  // issue-time and pass it here are robust against frame-stack
+  // mutations (push / pop) that happen while the load is in flight —
+  // the write lands on the frame that issued it, or silently drops
+  // if that frame has been popped (`updateRepoFrameRuntime` no-ops on
+  // out-of-range indices). Without the tag, an in-flight refresh on
+  // the parent would clobber a freshly-pushed submodule frame.
   const setContext = React.useCallback(
-    (arg: LogInkContext | ((prev: LogInkContext) => LogInkContext)) => {
+    (
+      arg: LogInkContext | ((prev: LogInkContext) => LogInkContext),
+      targetDepth?: number,
+    ) => {
       setRuntimes((prev) => {
-        const depth = prev.length - 1
+        const depth = targetDepth ?? prev.length - 1
         if (depth < 0) return prev
         return updateRepoFrameRuntime(prev, depth, (frame) => ({
           ...frame,
@@ -549,9 +561,12 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     [],
   )
   const setContextStatus = React.useCallback(
-    (arg: LogInkContextStatus | ((prev: LogInkContextStatus) => LogInkContextStatus)) => {
+    (
+      arg: LogInkContextStatus | ((prev: LogInkContextStatus) => LogInkContextStatus),
+      targetDepth?: number,
+    ) => {
       setRuntimes((prev) => {
-        const depth = prev.length - 1
+        const depth = targetDepth ?? prev.length - 1
         if (depth < 0) return prev
         return updateRepoFrameRuntime(prev, depth, (frame) => ({
           ...frame,
@@ -917,30 +932,50 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     // (stale-while-revalidate) and quietly swap it in once the new fetch
     // resolves — avoids the every-second flicker the watcher would
     // otherwise produce on busy repos.
+    //
+    // #994 — capture the depth this refresh was issued from BEFORE
+    // the await. The callback closure also captured `git` from the
+    // same render, so they're consistent: when the user drills into
+    // a submodule mid-await, the resolved data still lands on the
+    // parent frame (the one whose `git` was used for the fetch),
+    // not on the freshly-pushed submodule frame.
+    const issuedAtDepth = runtimes.length - 1
     if (!options.silent) {
       dispatch({ type: 'setStatus', value: 'refreshing repository context' })
-      setContextStatus(createLogInkContextStatus('loading'))
+      setContextStatus(createLogInkContextStatus('loading'), issuedAtDepth)
     }
     const next = await loadLogInkContext(git)
-    setContext(next)
-    setContextStatus(createLogInkContextStatus('ready'))
+    setContext(next, issuedAtDepth)
+    setContextStatus(createLogInkContextStatus('ready'), issuedAtDepth)
     if (!options.silent) {
       dispatch({ type: 'setStatus', value: 'repository context refreshed' })
     }
-  }, [dispatch, git])
+  }, [dispatch, git, runtimes.length, setContext, setContextStatus])
 
   const refreshWorktreeContext = React.useCallback(async (options: { silent?: boolean } = {}) => {
+    // #994 — same frame-tagging as refreshContext above. Worktree
+    // loads are usually fast but still race-prone on slow disks.
+    const issuedAtDepth = runtimes.length - 1
     if (!options.silent) {
-      setContextStatus((current) => updateLogInkContextStatus(current, 'worktree', 'loading'))
+      setContextStatus(
+        (current) => updateLogInkContextStatus(current, 'worktree', 'loading'),
+        issuedAtDepth,
+      )
     }
     const worktree = await safe(getWorktreeOverview(git))
 
-    setContext((current) => ({
-      ...current,
-      worktree,
-    }))
-    setContextStatus((current) => updateLogInkContextStatus(current, 'worktree', 'ready'))
-  }, [git])
+    setContext(
+      (current) => ({
+        ...current,
+        worktree,
+      }),
+      issuedAtDepth,
+    )
+    setContextStatus(
+      (current) => updateLogInkContextStatus(current, 'worktree', 'ready'),
+      issuedAtDepth,
+    )
+  }, [git, runtimes.length, setContext, setContextStatus])
 
   // Live refresh: watch .git metadata + the working tree root and reload
   // context when something changes outside the TUI (editor save, external
@@ -1178,6 +1213,11 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   const contextStatusRef = React.useRef(contextStatus)
   contextStatusRef.current = contextStatus
   React.useEffect(() => {
+    // #994 — capture the depth this boot load is being issued for.
+    // The git instance in the closure is bound to this frame; tagged
+    // writes ensure resolved values land on the correct runtime entry
+    // even if a subsequent push/pop changes the active frame mid-load.
+    const issuedAtDepth = runtimes.length - 1
     let active = true
 
     loadLogInkContextEntries(git).forEach(({ key, load }) => {
@@ -1187,18 +1227,24 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
           return
         }
 
-        setContext((current) => ({
-          ...current,
-          [key]: value,
-        }))
-        setContextStatus((current) => updateLogInkContextStatus(current, key, 'ready'))
+        setContext(
+          (current) => ({
+            ...current,
+            [key]: value,
+          }),
+          issuedAtDepth,
+        )
+        setContextStatus(
+          (current) => updateLogInkContextStatus(current, key, 'ready'),
+          issuedAtDepth,
+        )
       })
     })
 
     return () => {
       active = false
     }
-  }, [git])
+  }, [git, runtimes.length, setContext, setContextStatus])
 
   // Lazy-load the full pullRequest overview (#808). Only fires when
   // the user actually navigates to the PR view, and only when we
@@ -1211,20 +1257,30 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   React.useEffect(() => {
     if (state.activeView !== 'pull-request') return
     if (context.pullRequest) return
+    const issuedAtDepth = runtimes.length - 1
     let active = true
-    setContextStatus((current) => updateLogInkContextStatus(current, 'pullRequest', 'loading'))
+    setContextStatus(
+      (current) => updateLogInkContextStatus(current, 'pullRequest', 'loading'),
+      issuedAtDepth,
+    )
     void safe(getPullRequestOverview(git)).then((value) => {
       if (!active) return
-      setContext((current) => ({
-        ...current,
-        pullRequest: value,
-      }))
-      setContextStatus((current) => updateLogInkContextStatus(current, 'pullRequest', 'ready'))
+      setContext(
+        (current) => ({
+          ...current,
+          pullRequest: value,
+        }),
+        issuedAtDepth,
+      )
+      setContextStatus(
+        (current) => updateLogInkContextStatus(current, 'pullRequest', 'ready'),
+        issuedAtDepth,
+      )
     })
     return () => {
       active = false
     }
-  }, [git, state.activeView, context.pullRequest])
+  }, [git, runtimes.length, state.activeView, context.pullRequest, setContext, setContextStatus])
 
   // Lazy-load the issue triage list (#882 phase 3, filter-aware
   // since phase 6). Fires on entry to the view AND on filter
@@ -1235,21 +1291,39 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   React.useEffect(() => {
     if (state.activeView !== 'issues') return
     if (context.issueList) return
+    const issuedAtDepth = runtimes.length - 1
     let active = true
-    setContextStatus((current) => updateLogInkContextStatus(current, 'issueList', 'loading'))
+    setContextStatus(
+      (current) => updateLogInkContextStatus(current, 'issueList', 'loading'),
+      issuedAtDepth,
+    )
     const filter = issueFilterForPreset(state.selectedIssueFilter)
     void safe(getIssueList(git, filter)).then((value) => {
       if (!active) return
-      setContext((current) => ({
-        ...current,
-        issueList: value,
-      }))
-      setContextStatus((current) => updateLogInkContextStatus(current, 'issueList', 'ready'))
+      setContext(
+        (current) => ({
+          ...current,
+          issueList: value,
+        }),
+        issuedAtDepth,
+      )
+      setContextStatus(
+        (current) => updateLogInkContextStatus(current, 'issueList', 'ready'),
+        issuedAtDepth,
+      )
     })
     return () => {
       active = false
     }
-  }, [git, state.activeView, context.issueList, state.selectedIssueFilter])
+  }, [
+    git,
+    runtimes.length,
+    state.activeView,
+    context.issueList,
+    state.selectedIssueFilter,
+    setContext,
+    setContextStatus,
+  ])
 
   // Filter cycling: when the preset changes, drop the cached list
   // so the effect above re-fires with the new filter. Done as a
@@ -1272,21 +1346,39 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   React.useEffect(() => {
     if (state.activeView !== 'pull-request-triage') return
     if (context.pullRequestList) return
+    const issuedAtDepth = runtimes.length - 1
     let active = true
-    setContextStatus((current) => updateLogInkContextStatus(current, 'pullRequestList', 'loading'))
+    setContextStatus(
+      (current) => updateLogInkContextStatus(current, 'pullRequestList', 'loading'),
+      issuedAtDepth,
+    )
     const filter = pullRequestFilterForPreset(state.selectedPullRequestFilter)
     void safe(getPullRequestList(git, filter)).then((value) => {
       if (!active) return
-      setContext((current) => ({
-        ...current,
-        pullRequestList: value,
-      }))
-      setContextStatus((current) => updateLogInkContextStatus(current, 'pullRequestList', 'ready'))
+      setContext(
+        (current) => ({
+          ...current,
+          pullRequestList: value,
+        }),
+        issuedAtDepth,
+      )
+      setContextStatus(
+        (current) => updateLogInkContextStatus(current, 'pullRequestList', 'ready'),
+        issuedAtDepth,
+      )
     })
     return () => {
       active = false
     }
-  }, [git, state.activeView, context.pullRequestList, state.selectedPullRequestFilter])
+  }, [
+    git,
+    runtimes.length,
+    state.activeView,
+    context.pullRequestList,
+    state.selectedPullRequestFilter,
+    setContext,
+    setContextStatus,
+  ])
 
   React.useEffect(() => {
     if (state.activeView !== 'pull-request-triage') return
@@ -1320,17 +1412,21 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     if (!cursored) return
     if (context.issueDetailByNumber?.has(cursored.number)) return
 
+    const issuedAtDepth = runtimes.length - 1
     let active = true
     const timer = setTimeout(async () => {
       const result = await getIssueDetail(cursored.number)
       if (!active || !result.ok) return
-      setContext((current) => ({
-        ...current,
-        issueDetailByNumber: new Map(current.issueDetailByNumber || []).set(
-          result.detail.number,
-          result.detail
-        ),
-      }))
+      setContext(
+        (current) => ({
+          ...current,
+          issueDetailByNumber: new Map(current.issueDetailByNumber || []).set(
+            result.detail.number,
+            result.detail
+          ),
+        }),
+        issuedAtDepth,
+      )
     }, DETAIL_HYDRATION_DELAY_MS)
 
     return () => {
@@ -1338,10 +1434,12 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       clearTimeout(timer)
     }
   }, [
+    runtimes.length,
     state.activeView,
     state.selectedIssueIndex,
     filteredIssueList,
     context.issueDetailByNumber,
+    setContext,
   ])
 
   React.useEffect(() => {
@@ -1355,17 +1453,21 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     if (!cursored) return
     if (context.pullRequestDetailByNumber?.has(cursored.number)) return
 
+    const issuedAtDepth = runtimes.length - 1
     let active = true
     const timer = setTimeout(async () => {
       const result = await getPullRequestDetail(cursored.number)
       if (!active || !result.ok) return
-      setContext((current) => ({
-        ...current,
-        pullRequestDetailByNumber: new Map(current.pullRequestDetailByNumber || []).set(
-          result.detail.number,
-          result.detail
-        ),
-      }))
+      setContext(
+        (current) => ({
+          ...current,
+          pullRequestDetailByNumber: new Map(current.pullRequestDetailByNumber || []).set(
+            result.detail.number,
+            result.detail
+          ),
+        }),
+        issuedAtDepth,
+      )
     }, DETAIL_HYDRATION_DELAY_MS)
 
     return () => {
@@ -1373,10 +1475,12 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       clearTimeout(timer)
     }
   }, [
+    runtimes.length,
     state.activeView,
     state.selectedPullRequestTriageIndex,
     filteredPullRequestTriageList,
     context.pullRequestDetailByNumber,
+    setContext,
   ])
 
   React.useEffect(() => {

--- a/src/workstation/runtime/repoStackRuntime.test.ts
+++ b/src/workstation/runtime/repoStackRuntime.test.ts
@@ -168,4 +168,50 @@ describe('updateRepoFrameRuntime', () => {
     expect(updateRepoFrameRuntime(runtimes, 5, () => makeRuntime('nope'))).toBe(runtimes)
     expect(updateRepoFrameRuntime(runtimes, -1, () => makeRuntime('nope'))).toBe(runtimes)
   })
+
+  // #994 — the wrappers in app.ts (`setContext` / `setContextStatus`)
+  // capture an `issuedAtDepth` at the start of every async loader and
+  // pass it here so the resolved value lands on the frame that issued
+  // the load, regardless of which frame is active when the write fires.
+  // These tests document the two race-relevant cases the wrappers rely
+  // on: the issuing frame is still on the stack (write lands on it,
+  // even if it's not the active frame), and the issuing frame has been
+  // popped (write is silently dropped).
+  describe('frame-tagged-write semantics (#994)', () => {
+    it('lands the write on the issuing frame even when it is no longer active', () => {
+      // Simulate the race: refresh fires on root (depth 0), user pushes
+      // a submodule (depth 1) while the await is in flight, the load
+      // resolves with depth=0 captured at issue time. The write must
+      // hit the root entry, NOT the active submodule entry.
+      const rootBefore = makeRuntime('root')
+      const submoduleBefore = makeRuntime('submodule')
+      const runtimes: RepoStackRuntimes = [rootBefore, submoduleBefore]
+
+      const after = updateRepoFrameRuntime(runtimes, 0, (prev) => ({
+        ...prev,
+        context: { branches: { current: 'main' } } as unknown as RepoFrameRuntime['context'],
+      }))
+
+      // Root frame received the data.
+      expect(after[0]).not.toBe(rootBefore)
+      expect(after[0].context).toEqual({ branches: { current: 'main' } })
+      // Active (submodule) frame untouched.
+      expect(after[1]).toBe(submoduleBefore)
+    })
+
+    it('silently drops the write when the issuing frame has been popped', () => {
+      // Simulate the other race: refresh fires on the submodule
+      // (depth 1), user pops back to root before the await resolves,
+      // the load resolves with depth=1 captured at issue time. The
+      // runtime list is now length 1, so depth 1 is out of range and
+      // the write is a no-op (no half-written stale data on root).
+      const rootBefore = makeRuntime('root')
+      const runtimes: RepoStackRuntimes = [rootBefore]
+
+      const after = updateRepoFrameRuntime(runtimes, 1, () => makeRuntime('stale-submodule-data'))
+
+      expect(after).toBe(runtimes)
+      expect(after[0]).toBe(rootBefore)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #994 and #995 — paired #931 follow-ups for the submodule drill-in feature.

### #994 — Frame-tagged context writes

`setContext` / `setContextStatus` now accept an optional `targetDepth` arg. Every async loader (`refreshContext`, `refreshWorktreeContext`, the boot loader, and the lazy `pullRequest` / `issueList` / `pullRequestList` / issue-detail / PR-detail effects) captures `runtimes.length - 1` at issue time and threads it into its writes.

Without the tag, an in-flight refresh on the parent frame would clobber a freshly-pushed submodule frame when the await resolved — the wrapper would route the write to whichever runtime was active at write time, not at issue time. With the tag, the write lands on the frame that issued it; if that frame has been popped during the await, `updateRepoFrameRuntime`'s existing out-of-range guard silently drops the stale value.

### #995 — Sidebar tab + sort modes restore on pop

`LogInkRepoFrameReturn` now captures the four user-preference fields the submodule drill-in shouldn't bleed across the boundary — `sidebarTab`, `userSidebarTab`, `branchSort`, `tagSort`. Push records the parent's values; pop restores them.

Before: user picks 'tags' tab inside a submodule, pops back to the parent, and finds the parent's previous 'branches' choice quietly replaced — even though active view, cursor, and filter restored correctly.

The persistence layer is unchanged. Sidebar-tab disk persistence already keys off the active frame's `git` so each submodule gets its own saved preference. Sort modes were never persisted to disk and still aren't — they're session-only preferences scoped to the frame.

Palette recents, inspector tab, and diff view mode stay global by design.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:jest --testPathPatterns="(inkViewModel|inkInput|repoStackRuntime)"` — 449/449 pass
- [x] `npm run test:jest --testPathPatterns="(workstation|commands/log)"` — 1005/1005 pass
- [x] New tests: `repoStackRuntime.test.ts` documents the two race-relevant semantics for #994; `inkViewModel.test.ts` has a new test covering the push-and-pop sidebar/sort restore for #995
- [ ] Manual: `npm run scenario create submodule-mixed-state -- --run-ui`, drill in, change tab + sort, pop, verify parent state restored