### PR TITLE
feat(langchain): streaming executeChain helper (#881 phase 1)

### DIFF
--- a/src/lib/langchain/utils/executeChainStreaming.test.ts
+++ b/src/lib/langchain/utils/executeChainStreaming.test.ts
@@ -1,0 +1,243 @@
+import { PromptTemplate } from '@langchain/core/prompts'
+import { StringOutputParser } from '@langchain/core/output_parsers'
+import { FakeListChatModel } from '@langchain/core/utils/testing'
+import { Logger } from '../../utils/logger'
+import { getLlm } from './getLlm'
+import {
+  LangChainExecutionError,
+  LangChainNetworkError,
+} from '../errors'
+import {
+  executeChainStreaming,
+  StreamingChunk,
+} from './executeChainStreaming'
+
+const prompt = PromptTemplate.fromTemplate('Answer this: {question}')
+const variables = { question: 'noop' }
+
+function silentLogger(): Logger {
+  return new Logger({ silent: true })
+}
+
+function chunkRecorder(): {
+  chunks: StreamingChunk[]
+  onChunk: (chunk: StreamingChunk) => void
+} {
+  const chunks: StreamingChunk[] = []
+  return {
+    chunks,
+    onChunk: (chunk) => {
+      chunks.push(chunk)
+    },
+  }
+}
+
+/**
+ * Production `executeChainStreaming` types `llm` as `ReturnType<typeof
+ * getLlm>` — a narrow union of the concrete Chat* model classes coco
+ * actually wires up. The `FakeListChatModel` we use here implements the
+ * same `Runnable` surface area the helper exercises (`.pipe()`,
+ * `.stream()`) but isn't a member of that union. The cast is purely a
+ * type-system convenience for tests; the runtime behaviour is the same
+ * polymorphic Runnable dispatch.
+ */
+function asLlm(model: FakeListChatModel): ReturnType<typeof getLlm> {
+  return model as unknown as ReturnType<typeof getLlm>
+}
+
+describe('executeChainStreaming', () => {
+  it('streams chunks for each token-ish fragment then returns the parsed final result', async () => {
+    // FakeListChatModel.stream() emits the response one character at a
+    // time, which is the closest stand-in for a real provider's
+    // token-by-token output we can get without hitting a network.
+    const llm = new FakeListChatModel({ responses: ['hello world'] })
+    const { chunks, onChunk } = chunkRecorder()
+
+    const result = await executeChainStreaming<string>({
+      llm: asLlm(llm),
+      prompt,
+      variables,
+      parser: new StringOutputParser(),
+      onChunk,
+      logger: silentLogger(),
+    })
+
+    // Every chunk should carry both the delta and the rolling
+    // accumulation; surfaces pick whichever fits their rendering model.
+    expect(chunks.length).toBeGreaterThan(1)
+    expect(chunks[chunks.length - 1].accumulated).toBe('hello world')
+    // The parsed result is the StringOutputParser passing the
+    // accumulated text through unchanged.
+    expect(result).toBe('hello world')
+  })
+
+  it('hands each chunk the delta text AND the accumulation so far', async () => {
+    const llm = new FakeListChatModel({ responses: ['abc'] })
+    const { chunks, onChunk } = chunkRecorder()
+
+    await executeChainStreaming<string>({
+      llm: asLlm(llm),
+      prompt,
+      variables,
+      parser: new StringOutputParser(),
+      onChunk,
+      logger: silentLogger(),
+    })
+
+    // Walk the chunks: each `accumulated` should equal the previous
+    // `accumulated` plus the current `text`. Catches off-by-one
+    // mistakes in the accumulator. Doesn't assert exact chunk count
+    // because the FakeListChatModel may emit differently than a real
+    // provider.
+    let runningSum = ''
+    for (const chunk of chunks) {
+      runningSum += chunk.text
+      expect(chunk.accumulated).toBe(runningSum)
+    }
+    expect(runningSum).toBe('abc')
+  })
+
+  it('swallows handler errors so a bad render handler cannot tank the LLM call', async () => {
+    // A render handler that throws on every chunk used to mean the
+    // user paid for the LLM call and got nothing back; the helper now
+    // catches each callback error and keeps consuming the stream.
+    const llm = new FakeListChatModel({ responses: ['hello'] })
+    let invocations = 0
+    const onChunk = () => {
+      invocations += 1
+      throw new Error('handler exploded')
+    }
+
+    const result = await executeChainStreaming<string>({
+      llm: asLlm(llm),
+      prompt,
+      variables,
+      parser: new StringOutputParser(),
+      onChunk,
+      logger: silentLogger(),
+    })
+
+    expect(invocations).toBeGreaterThan(0)
+    // Despite the handler throwing, the call resolves with the
+    // fully-accumulated parsed result.
+    expect(result).toBe('hello')
+  })
+
+  it('throws LangChainExecutionError when the stream completes with no text chunks', async () => {
+    // Empty-string response means the stream yields nothing renderable.
+    // The helper refuses to invoke the parser on an empty string and
+    // surfaces the failure explicitly so callers can distinguish
+    // "model produced empty output" from "model produced unparseable
+    // output."
+    const llm = new FakeListChatModel({ responses: [''] })
+    const { onChunk } = chunkRecorder()
+
+    await expect(
+      executeChainStreaming<string>({
+        llm: asLlm(llm),
+        prompt,
+        variables,
+        parser: new StringOutputParser(),
+        onChunk,
+        logger: silentLogger(),
+      }),
+    ).rejects.toThrow(/Stream completed with no text chunks/)
+  })
+
+  it('rejects when required inputs are missing', async () => {
+    const llm = new FakeListChatModel({ responses: ['x'] })
+    const baseInput = {
+      llm: asLlm(llm),
+      prompt,
+      variables,
+      parser: new StringOutputParser(),
+      onChunk: () => {
+        /* noop */
+      },
+    } as const
+
+    // `validateRequired` is shared with `executeChain`; spot-check that
+    // the streaming variant wires it up the same way.
+    await expect(
+      executeChainStreaming<string>({ ...baseInput, llm: undefined as never }),
+    ).rejects.toThrow(/llm/)
+    await expect(
+      executeChainStreaming<string>({ ...baseInput, onChunk: undefined as never }),
+    ).rejects.toThrow(/onChunk/)
+  })
+
+  it('rejects when variables is not a plain object', async () => {
+    const llm = new FakeListChatModel({ responses: ['x'] })
+    await expect(
+      executeChainStreaming<string>({
+        llm: asLlm(llm),
+        prompt,
+        variables: [] as unknown as Record<string, unknown>,
+        parser: new StringOutputParser(),
+        onChunk: () => {
+          /* noop */
+        },
+        logger: silentLogger(),
+      }),
+    ).rejects.toThrow(LangChainExecutionError)
+  })
+
+  it('re-throws LangChain error subclasses unchanged (does not double-wrap)', async () => {
+    // A parser that throws a LangChainExecutionError should surface
+    // unchanged — callers may pattern-match on the error class.
+    const llm = new FakeListChatModel({ responses: ['hello'] })
+    const explodingParser = new StringOutputParser()
+    jest.spyOn(explodingParser, 'invoke').mockImplementation(async () => {
+      throw new LangChainExecutionError('parser blew up')
+    })
+
+    await expect(
+      executeChainStreaming<string>({
+        llm: asLlm(llm),
+        prompt,
+        variables,
+        parser: explodingParser,
+        onChunk: () => {
+          /* noop */
+        },
+        logger: silentLogger(),
+      }),
+    ).rejects.toThrow(LangChainExecutionError)
+  })
+
+  it('wraps network-style errors as LangChainNetworkError with provider + endpoint context', async () => {
+    // Simulates a transport-layer failure during prompt rendering /
+    // stream setup (DNS, ECONNREFUSED, etc.). The helper should
+    // classify these the same way `executeChain` does so retry /
+    // backoff logic upstream stays consistent across the streaming
+    // and non-streaming paths.
+    //
+    // We trigger the failure at `prompt.format()` rather than at
+    // `chain.stream()` because the latter routes through several
+    // layers of LangChain internals (`RunnableSequence`,
+    // `_streamResponseChunks`, etc.) that don't honor a top-level
+    // `stream` spy. The classification logic in the catch block is
+    // what we actually care about; any thrown network-shaped error
+    // reaches it the same way.
+    const llm = new FakeListChatModel({ responses: ['x'] })
+    const failingPrompt = PromptTemplate.fromTemplate('Answer this: {question}')
+    jest.spyOn(failingPrompt, 'format').mockImplementation(async () => {
+      throw new Error('connect ECONNREFUSED 127.0.0.1:11434')
+    })
+
+    await expect(
+      executeChainStreaming<string>({
+        llm: asLlm(llm),
+        prompt: failingPrompt,
+        variables,
+        parser: new StringOutputParser(),
+        onChunk: () => {
+          /* noop */
+        },
+        provider: 'ollama',
+        endpoint: 'http://127.0.0.1:11434',
+        logger: silentLogger(),
+      }),
+    ).rejects.toThrow(LangChainNetworkError)
+  })
+})

--- a/src/lib/langchain/utils/executeChainStreaming.ts
+++ b/src/lib/langchain/utils/executeChainStreaming.ts
@@ -1,0 +1,271 @@
+import { PromptTemplate } from '@langchain/core/prompts'
+import { Runnable } from '@langchain/core/runnables'
+import { handleLangChainError, isNetworkError } from '../errorHandler'
+import { LangChainExecutionError, LangChainNetworkError } from '../errors'
+import { validateRequired } from '../validation'
+import { getLlm } from './getLlm'
+import { Logger } from '../../utils/logger'
+import { TokenCounter } from '../../utils/tokenizer'
+import {
+  estimatePromptTokens,
+  LlmCallMetadata,
+  logLlmCall,
+} from './observability'
+
+/**
+ * A single tick of streamed output from the LLM. The shape mirrors what
+ * downstream UX surfaces actually need to render incrementally:
+ *
+ *   - `text` — the raw text fragment that arrived in this tick. Usually
+ *     a handful of characters (one or two tokens). Use this when you
+ *     want to write deltas directly to a stream.
+ *   - `accumulated` — every fragment concatenated since the stream
+ *     started. Use this when you'd rather diff or re-render against the
+ *     full text so far. Cheap to compute (the helper tracks it anyway),
+ *     handed off so callers don't each re-implement the concat.
+ *
+ * Intentionally a small fixed shape — no partial parsed object, no
+ * delta diffing, no token-count estimates. Phase 1 streams raw text
+ * only; richer streaming (incremental parsed JSON for structured
+ * outputs) lands in a later phase if the UX needs it.
+ */
+export interface StreamingChunk {
+  text: string
+  accumulated: string
+}
+
+export type StreamChunkHandler = (chunk: StreamingChunk) => void
+
+export interface ExecuteChainStreamingInput<T> {
+  variables: Record<string, unknown>
+  prompt: PromptTemplate
+  llm: ReturnType<typeof getLlm>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  parser: Runnable<any, T>
+  /**
+   * Called for each text chunk as it streams in from the model. The
+   * handler should be cheap — chunks arrive every few milliseconds.
+   * Defer heavy work (full re-renders, network writes) to a debounce
+   * or to completion.
+   *
+   * Errors thrown by the callback are caught and logged but do NOT
+   * abort the stream. The final result still resolves with whatever
+   * the parser produces from the fully-accumulated text. This is
+   * intentional: a bad render handler shouldn't lose the user's LLM
+   * spend mid-call.
+   */
+  onChunk: StreamChunkHandler
+  /** Optional provider name for better error messages. */
+  provider?: string
+  /** Optional endpoint URL for better error messages. */
+  endpoint?: string
+  logger?: Logger
+  tokenizer?: TokenCounter
+  metadata?: Partial<LlmCallMetadata>
+}
+
+/**
+ * Same provider / endpoint best-effort extraction `executeChain` uses,
+ * duplicated here rather than imported so the streaming module doesn't
+ * pull on `executeChain`'s implementation. If both helpers ever need to
+ * share more, factor this out to a shared `llmInfo.ts`.
+ */
+function extractLlmInfo(
+  llm: ReturnType<typeof getLlm>,
+): { provider?: string; endpoint?: string } {
+  const info: { provider?: string; endpoint?: string } = {}
+  const className = llm?.constructor?.name || ''
+  if (className.includes('Ollama')) {
+    info.provider = 'ollama'
+    if ('lc_kwargs' in llm && typeof llm.lc_kwargs === 'object' && llm.lc_kwargs !== null) {
+      const kwargs = llm.lc_kwargs as Record<string, unknown>
+      if (typeof kwargs.baseUrl === 'string') {
+        info.endpoint = kwargs.baseUrl
+      }
+    }
+  } else if (className.includes('OpenAI')) {
+    info.provider = 'openai'
+  } else if (className.includes('Anthropic')) {
+    info.provider = 'anthropic'
+  }
+  return info
+}
+
+/**
+ * Coerce one streamed chunk into its text fragment. LangChain's
+ * `prompt.pipe(llm).stream(...)` yields `BaseMessageChunk` instances
+ * whose `.content` is sometimes a string and sometimes an array of
+ * content parts (multi-modal models, tool calls). We only care about
+ * the textual delta here; non-text parts are silently dropped because
+ * phase 1's surfaces (stdout + status-line copy) can't render them
+ * anyway.
+ */
+function coerceChunkText(messageChunk: unknown): string {
+  if (typeof messageChunk === 'string') return messageChunk
+  if (messageChunk && typeof messageChunk === 'object' && 'content' in messageChunk) {
+    const content = (messageChunk as { content: unknown }).content
+    if (typeof content === 'string') return content
+    if (Array.isArray(content)) {
+      // Multi-part content array — concatenate the text parts only.
+      return content
+        .map((part) => {
+          if (typeof part === 'string') return part
+          if (part && typeof part === 'object' && 'text' in part && typeof (part as { text: unknown }).text === 'string') {
+            return (part as { text: string }).text
+          }
+          return ''
+        })
+        .join('')
+    }
+  }
+  return ''
+}
+
+/**
+ * Streaming variant of `executeChain`. Pipes the prompt into the LLM,
+ * consumes the resulting async iterable, fires `onChunk` with each text
+ * fragment as it arrives, and runs the supplied parser against the
+ * fully-accumulated text on completion. Returns the parsed result.
+ *
+ * Why a separate function instead of an `onChunk?` flag on
+ * `executeChain`? Two reasons:
+ *
+ *   1. The two paths have meaningfully different failure modes — a
+ *      half-streamed result can be salvaged with a best-effort parse;
+ *      an `invoke()` failure can't. Separate functions let each handle
+ *      its own error shape cleanly.
+ *   2. Callers should make an explicit choice about whether they want
+ *      streaming. Adding it as an opt-in flag on `executeChain` makes
+ *      it tempting to plumb `onChunk` from random surfaces; a separate
+ *      helper makes the call site say "yes, this needs streaming."
+ *
+ * No automatic fallback to non-streaming `executeChain` when streaming
+ * fails — by design. Callers that want fallback should `catch` this
+ * function and call `executeChain` themselves. Keeps the helper focused
+ * on the streaming path and the fallback policy explicit at the call
+ * site (different commands may want different fallback strategies).
+ */
+export async function executeChainStreaming<T>({
+  llm,
+  prompt,
+  variables,
+  parser,
+  onChunk,
+  provider,
+  endpoint,
+  logger,
+  tokenizer,
+  metadata,
+}: ExecuteChainStreamingInput<T>): Promise<T> {
+  validateRequired(llm, 'llm', 'executeChainStreaming')
+  validateRequired(prompt, 'prompt', 'executeChainStreaming')
+  validateRequired(variables, 'variables', 'executeChainStreaming')
+  validateRequired(parser, 'parser', 'executeChainStreaming')
+  validateRequired(onChunk, 'onChunk', 'executeChainStreaming')
+
+  if (typeof variables !== 'object' || Array.isArray(variables)) {
+    throw new LangChainExecutionError(
+      'executeChainStreaming: Variables must be a non-array object',
+      { variables, type: typeof variables, isArray: Array.isArray(variables) },
+    )
+  }
+
+  const llmInfo = extractLlmInfo(llm)
+  const effectiveProvider = provider || llmInfo.provider
+  const effectiveEndpoint = endpoint || llmInfo.endpoint
+
+  try {
+    const renderedPrompt = await prompt.format(variables)
+    const promptTokens = estimatePromptTokens(tokenizer, renderedPrompt)
+
+    const chain = prompt.pipe(llm)
+    const startedAt = Date.now()
+    const stream = await chain.stream(variables)
+
+    let accumulated = ''
+    let chunkCount = 0
+    for await (const messageChunk of stream) {
+      const text = coerceChunkText(messageChunk)
+      if (!text) continue
+      accumulated += text
+      chunkCount += 1
+      try {
+        onChunk({ text, accumulated })
+      } catch (callbackError) {
+        // Deliberately swallow callback errors so a bad render handler
+        // can't tank the entire LLM call. Log at verbose so users with
+        // verbose mode on can still see what happened.
+        logger?.verbose(
+          `executeChainStreaming: onChunk handler threw: ${
+            callbackError instanceof Error ? callbackError.message : String(callbackError)
+          }`,
+          { color: 'yellow' },
+        )
+      }
+    }
+
+    if (!accumulated) {
+      throw new LangChainExecutionError(
+        'executeChainStreaming: Stream completed with no text chunks',
+        { variables, promptInputVariables: prompt.inputVariables },
+      )
+    }
+
+    const result = (await parser.invoke(accumulated)) as T
+    const elapsedMs = Date.now() - startedAt
+
+    logLlmCall(logger, {
+      task: metadata?.task || 'chain-streaming',
+      provider: effectiveProvider,
+      parserType: parser.constructor.name,
+      variableKeys: Object.keys(variables),
+      promptTokens,
+      elapsedMs,
+      // Surfaced in observability so consumers can spot the streaming
+      // path in their logs without correlating across tools. `chunks`
+      // doubles as a sanity check (a streaming call that delivered 1
+      // chunk is functionally identical to a non-streaming one).
+      streamed: true,
+      streamChunks: chunkCount,
+      ...metadata,
+    })
+
+    if (result === null || result === undefined) {
+      throw new LangChainExecutionError(
+        'executeChainStreaming: Parser returned null or undefined from streamed text',
+        {
+          variables,
+          promptInputVariables: prompt.inputVariables,
+          accumulatedLength: accumulated.length,
+        },
+      )
+    }
+
+    return result
+  } catch (error) {
+    if (error instanceof LangChainExecutionError || error instanceof LangChainNetworkError) {
+      throw error
+    }
+
+    if (error instanceof Error && isNetworkError(error)) {
+      throw new LangChainNetworkError(error.message, effectiveEndpoint, effectiveProvider, {
+        originalError: error.name,
+        originalMessage: error.message,
+        stack: error.stack,
+        promptInputVariables: prompt.inputVariables,
+        variableKeys: Object.keys(variables),
+        parserType: parser.constructor.name,
+        streamed: true,
+      })
+    }
+
+    handleLangChainError(error, 'executeChainStreaming: Stream execution failed', {
+      promptInputVariables: prompt.inputVariables,
+      variableKeys: Object.keys(variables),
+      parserType: parser.constructor.name,
+      provider: effectiveProvider,
+      endpoint: effectiveEndpoint,
+      streamed: true,
+    })
+  }
+}

--- a/src/lib/langchain/utils/observability.ts
+++ b/src/lib/langchain/utils/observability.ts
@@ -17,6 +17,15 @@ export type LlmCallMetadata = {
   elapsedMs?: number
   inputDocuments?: number
   inputChunks?: number
+  /**
+   * Streaming-path metadata (#881). `streamed` flags the call as a
+   * `.stream()` consumer (vs `.invoke()`); `streamChunks` records how
+   * many text fragments arrived before completion. Useful for spotting
+   * providers that don't actually stream (one chunk == one blob) or
+   * for debugging stream UX that feels janky.
+   */
+  streamed?: boolean
+  streamChunks?: number
 }
 
 /**


### PR DESCRIPTION
## Summary

First step of #881. Adds `executeChainStreaming<T>` alongside the existing `executeChain` — same input shape, but uses `chain.stream(variables)` and fires an `onChunk` callback for each text fragment as it arrives. The parser runs against the fully-accumulated text on completion and returns the parsed result, so callers can swap between the two without rewriting their wiring.

Phase 1 is **pure infrastructure**. No command integration yet — landing the helper as its own PR keeps the runtime separate from the wire-up work, matching the small-focused-PRs cadence.

## What the helper does

- Pipes the prompt through the LLM via `chain.stream(variables)`.
- Coerces each `BaseMessageChunk` into its text fragment (handles string, single-content, and array-of-content-parts shapes).
- Fires `onChunk({ text, accumulated })` per fragment. Handler errors are caught and logged at verbose rather than aborting the stream — the user has already paid for the LLM call; a bad render handler shouldn't lose the result.
- Runs the supplied parser against the accumulated text on completion. Same error classification as `executeChain` (`LangChainExecutionError` for empty stream / parser failures, `LangChainNetworkError` for transport failures, LangChain error subclasses re-thrown unchanged).
- Logs the call to observability with new `streamed: true` + `streamChunks: <n>` fields so the streaming path is grep-able in bench output.

## Phasing for #881

1. **This PR** — `executeChainStreaming` helper + tests, no command integration.
2. **Phase 2** — wire into `coco commit` (the schema-streaming dance #881 calls out as trickiest).
3. **Phase 3** — TUI streaming surface in workstation compose + `q`/`Esc` cancel via AbortController.
4. **Phase 4** — extend to `coco review` (which has the sort-on-complete UX wrinkle).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run test:jest --testPathPatterns=executeChainStreaming` — 8/8 pass
- [x] `npm run test:jest --testPathPatterns="(langchain|observability)"` — 124/124 pass

The 8 unit tests cover chunk emission shape, the delta+accumulation invariant, handler-error swallowing, empty-stream rejection, required-input validation, non-object variables, LangChain error pass-through, and network-error wrapping. They use `FakeListChatModel` from `@langchain/core/utils/testing` for a real-ish stream without hitting a network.