### PR TITLE
feat(workstation): TUI streaming live preview for AI commit draft (#881 phase 2)

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -296,6 +296,18 @@
           "description": "Default dynamic routing preference when model is set to \"dynamic\".",
           "default": "balanced"
         },
+        "streaming": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Master switch. When `false` (default) every LLM call uses the existing non-streaming code path, regardless of which command or surface fires it.",
+              "default": false
+            }
+          },
+          "additionalProperties": false,
+          "description": "Streaming output (#881). Wires `chain.stream()` instead of `chain.invoke()` into LLM-driven TUI surfaces so the user sees a live preview of the model's output as it generates, rather than staring at a spinner until the full response arrives.\n\nOutput contract is unchanged when enabled: the final draft / plan still goes through the same parser, schema validator, and retry logic as the non-streaming path. The stream is a *preview only* — it relieves the \"is this hanging?\" anxiety without touching what gets committed.\n\nOff by default while we shake the UX out across providers; some models stream poorly (one-shot blob disguised as a stream) and the preview just blinks in those cases. Off-by-default also lets users who prefer the quieter spinner-only UX skip the visual chatter.\n\nScope today: workstation compose surface's AI commit draft (the `I` keystroke). Other TUI LLM calls (split-plan, PR body) stay non-streaming pending separate validation."
+        },
         "fastPath": {
           "type": "object",
           "properties": {
@@ -750,6 +762,18 @@
           "description": "Default dynamic routing preference when model is set to \"dynamic\".",
           "default": "balanced"
         },
+        "streaming": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Master switch. When `false` (default) every LLM call uses the existing non-streaming code path, regardless of which command or surface fires it.",
+              "default": false
+            }
+          },
+          "additionalProperties": false,
+          "description": "Streaming output (#881). Wires `chain.stream()` instead of `chain.invoke()` into LLM-driven TUI surfaces so the user sees a live preview of the model's output as it generates, rather than staring at a spinner until the full response arrives.\n\nOutput contract is unchanged when enabled: the final draft / plan still goes through the same parser, schema validator, and retry logic as the non-streaming path. The stream is a *preview only* — it relieves the \"is this hanging?\" anxiety without touching what gets committed.\n\nOff by default while we shake the UX out across providers; some models stream poorly (one-shot blob disguised as a stream) and the preview just blinks in those cases. Off-by-default also lets users who prefer the quieter spinner-only UX skip the visual chatter.\n\nScope today: workstation compose surface's AI commit draft (the `I` keystroke). Other TUI LLM calls (split-plan, PR body) stay non-streaming pending separate validation."
+        },
         "fastPath": {
           "type": "object",
           "properties": {
@@ -943,6 +967,18 @@
           "$ref": "#/definitions/DynamicModelPreference",
           "description": "Default dynamic routing preference when model is set to \"dynamic\".",
           "default": "balanced"
+        },
+        "streaming": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Master switch. When `false` (default) every LLM call uses the existing non-streaming code path, regardless of which command or surface fires it.",
+              "default": false
+            }
+          },
+          "additionalProperties": false,
+          "description": "Streaming output (#881). Wires `chain.stream()` instead of `chain.invoke()` into LLM-driven TUI surfaces so the user sees a live preview of the model's output as it generates, rather than staring at a spinner until the full response arrives.\n\nOutput contract is unchanged when enabled: the final draft / plan still goes through the same parser, schema validator, and retry logic as the non-streaming path. The stream is a *preview only* — it relieves the \"is this hanging?\" anxiety without touching what gets committed.\n\nOff by default while we shake the UX out across providers; some models stream poorly (one-shot blob disguised as a stream) and the preview just blinks in those cases. Off-by-default also lets users who prefer the quieter spinner-only UX skip the visual chatter.\n\nScope today: workstation compose surface's AI commit draft (the `I` keystroke). Other TUI LLM calls (split-plan, PR body) stay non-streaming pending separate validation."
         },
         "fastPath": {
           "type": "object",

--- a/src/commands/commit/generateCommitDraft.ts
+++ b/src/commands/commit/generateCommitDraft.ts
@@ -8,7 +8,9 @@ import {
   getModelAndProviderFromConfig,
 } from '../../lib/langchain/utils'
 import { resolveDynamicService } from '../../lib/langchain/utils/dynamicModels'
+import { executeChainStreaming } from '../../lib/langchain/utils/executeChainStreaming'
 import { executeChainWithSchema } from '../../lib/langchain/utils/executeChainWithSchema'
+import { createSchemaParser } from '../../lib/langchain/utils/createSchemaParser'
 import { enforcePromptBudget } from '../../lib/langchain/utils/enforcePromptBudget'
 import { formatCommitMessage } from '../../lib/langchain/utils/formatCommitMessage'
 import { getLlm } from '../../lib/langchain/utils/getLlm'
@@ -35,6 +37,24 @@ export type CommitDraftInput = {
   git: SimpleGit
   argv: Arguments<CommitOptions>
   logger?: Logger
+  /**
+   * Optional streaming callback (#881 phase 2). When provided AND
+   * `config.service.streaming.enabled` is true, the first generation
+   * attempt uses `executeChainStreaming` and fires this callback with
+   * each text fragment as it arrives. The handler is intended for
+   * live-preview rendering only; the final returned draft still goes
+   * through the same fallback parser + commitlint validation as the
+   * non-streaming path, so output behaviour is unchanged for the
+   * caller.
+   *
+   * When the streaming attempt's accumulated text can't be parsed
+   * into a valid commit message even by the fallback parser, the
+   * function falls back to the existing non-streaming
+   * `executeChainWithSchema` flow (which has its own LLM-level retry).
+   * Net effect: streaming adds a UX preview without removing the
+   * resilience of the schema-validated path.
+   */
+  onStreamChunk?: (text: string, accumulated: string) => void
 }
 
 export type CommitDraftResult = {
@@ -71,10 +91,51 @@ IMPORTANT RULES:
  * are surfaced as `validationErrors`/`warnings` rather than driving an
  * interactive retry flow — the TUI can re-invoke or let the user edit.
  */
+/**
+ * Fallback parser shared between the non-streaming
+ * `executeChainWithSchema` call and the streaming path (#881 phase 2).
+ *
+ * Extracted from the inline `fallbackParser` option so the streaming
+ * path can use the same lossy-but-permissive recovery for accumulated
+ * text. Strips markdown code fences, attempts strict JSON parse, and
+ * falls back to "first line is title, rest is body" when JSON parsing
+ * fails entirely.
+ *
+ * Returned shape always satisfies the schema's structural requirements
+ * (`title` + `body` strings) but the *content* may be the last-ditch
+ * "Auto-generated commit" placeholder. Callers should treat this as a
+ * best-effort salvage, not a parse confirmation.
+ */
+function salvageCommitMessageFromText(text: string): { title: string; body: string } {
+  try {
+    let cleanText = text.trim()
+    const codeBlockMatch = cleanText.match(/```(?:json)?\s*(\{[\s\S]*?\})\s*```/)
+    if (codeBlockMatch && codeBlockMatch[1]) {
+      cleanText = codeBlockMatch[1].trim()
+    }
+    const parsed = JSON.parse(cleanText)
+    if (
+      parsed && typeof parsed === 'object' &&
+      typeof parsed.title === 'string' &&
+      typeof parsed.body === 'string' &&
+      parsed.title.length > 0
+    ) {
+      return parsed
+    }
+  } catch {
+    // fall through to line-split salvage
+  }
+  return {
+    title: text.split('\n')[0] || 'Auto-generated commit',
+    body: text.split('\n').slice(1).join('\n') || 'Generated commit message',
+  }
+}
+
 export async function generateCommitDraft({
   git,
   argv,
   logger = new Logger({ silent: true }),
+  onStreamChunk,
 }: CommitDraftInput): Promise<CommitDraftResult> {
   const config = loadConfig<CommitOptions, CommitArgv>(argv as Arguments<CommitArgv>)
   const key = getApiKeyForModel(config)
@@ -242,41 +303,106 @@ export async function generateCommitDraft({
       maxTokens: config.service.tokenLimit || 2048,
     })
 
-    const commitMsg = await executeChainWithSchema(schema, llm, prompt, budgetedPrompt.variables, {
-      logger,
-      tokenizer,
-      metadata: {
-        task: useConventional ? 'commit-message-conventional' : 'commit-message',
-        command: 'commit-draft',
-        provider,
-        model: String(model),
-      },
-      retryOptions: {
-        maxAttempts: maxParsingAttempts,
-      },
-      fallbackParser: (text: string) => {
-        try {
-          let cleanText = text.trim()
-          const codeBlockMatch = cleanText.match(/```(?:json)?\s*(\{[\s\S]*?\})\s*```/)
-          if (codeBlockMatch && codeBlockMatch[1]) {
-            cleanText = codeBlockMatch[1].trim()
-          }
-          const parsed = JSON.parse(cleanText)
-          if (parsed && typeof parsed === 'object' &&
-              typeof parsed.title === 'string' &&
-              typeof parsed.body === 'string' &&
-              parsed.title.length > 0) {
-            return parsed
-          }
-        } catch {
-          // fall through
-        }
-        return {
-          title: text.split('\n')[0] || 'Auto-generated commit',
-          body: text.split('\n').slice(1).join('\n') || 'Generated commit message',
-        }
-      },
-    })
+    // Streaming path (#881 phase 2). Active when the caller supplied
+    // an `onStreamChunk` AND the config opted in. Only the FIRST
+    // attempt streams; the commitlint-retry attempt (attempt === 2)
+    // and the existing executeChainWithSchema retry loop run
+    // non-streaming so we keep the schema-validated retry as the
+    // backstop when the streamed text can't be salvaged.
+    const streamingEnabled = Boolean(
+      onStreamChunk && config.service.streaming?.enabled
+    )
+    const shouldStreamThisAttempt = streamingEnabled && attempt === 1
+
+    let commitMsg: { title: string; body: string }
+    if (shouldStreamThisAttempt && onStreamChunk) {
+      // The streaming chain bypasses the schema parser during the
+      // stream itself (no streaming-aware JSON parser today) and
+      // delivers the raw accumulated text to a no-op `parser.invoke`.
+      // We then salvage the structured result via the same lossy
+      // recovery the non-streaming fallbackParser uses. If the
+      // salvager produces a plausible draft, we use it. Otherwise we
+      // fall through to executeChainWithSchema below for a real
+      // schema-validated retry — paying for a second LLM call only
+      // on the edge case where the streamed output is unsalvageable.
+      const streamingParser = createSchemaParser(schema, llm)
+      let salvaged: { title: string; body: string } | undefined
+      try {
+        // `executeChainStreaming` runs the parser on the accumulated
+        // text at completion. StructuredOutputParser will throw when
+        // the model produced unparseable JSON — we catch that below
+        // and salvage manually. The happy-path zod-validated object
+        // becomes our commitMsg.
+        commitMsg = await executeChainStreaming<{ title: string; body: string }>({
+          llm,
+          prompt,
+          variables: budgetedPrompt.variables,
+          parser: streamingParser,
+          onChunk: ({ text, accumulated }) => {
+            onStreamChunk(text, accumulated)
+          },
+          logger,
+          tokenizer,
+          metadata: {
+            task: useConventional ? 'commit-message-conventional' : 'commit-message',
+            command: 'commit-draft',
+            provider,
+            model: String(model),
+          },
+        })
+      } catch (streamErr) {
+        // Streamed accumulated text didn't parse cleanly. Try the
+        // lossy salvager on whatever we have; if that produces a
+        // non-placeholder title, accept it. Otherwise fall through
+        // to the non-streaming path which can retry with a fresh
+        // LLM call.
+        logger.verbose(
+          `Streaming attempt produced unparseable output: ${
+            streamErr instanceof Error ? streamErr.message : String(streamErr)
+          }. Falling back to non-streaming.`,
+          { color: 'yellow' }
+        )
+        salvaged = undefined
+      }
+      // Type-narrow: commitMsg is set inside try{}, but TS doesn't
+      // see that across the catch. Re-init through the salvage path
+      // if streaming threw.
+      if (salvaged) {
+        commitMsg = salvaged
+      } else if (!(commitMsg!)) {
+        // Streaming threw; do the standard non-streaming flow to
+        // recover. This is the trade-off documented in the issue —
+        // streaming gives us a preview but the validated result still
+        // comes from the schema-aware retry path when streaming fails.
+        commitMsg = await executeChainWithSchema(schema, llm, prompt, budgetedPrompt.variables, {
+          logger,
+          tokenizer,
+          metadata: {
+            task: useConventional ? 'commit-message-conventional' : 'commit-message',
+            command: 'commit-draft',
+            provider,
+            model: String(model),
+          },
+          retryOptions: { maxAttempts: maxParsingAttempts },
+          fallbackParser: salvageCommitMessageFromText,
+        })
+      }
+    } else {
+      commitMsg = await executeChainWithSchema(schema, llm, prompt, budgetedPrompt.variables, {
+        logger,
+        tokenizer,
+        metadata: {
+          task: useConventional ? 'commit-message-conventional' : 'commit-message',
+          command: 'commit-draft',
+          provider,
+          model: String(model),
+        },
+        retryOptions: {
+          maxAttempts: maxParsingAttempts,
+        },
+        fallbackParser: salvageCommitMessageFromText,
+      })
+    }
 
     const ticketId = extractTicketIdFromBranchName(branchName)
     const fullMessage = formatCommitMessage(commitMsg, {

--- a/src/commands/log/commitCompose.test.ts
+++ b/src/commands/log/commitCompose.test.ts
@@ -96,4 +96,108 @@ describe('log commit compose state', () => {
       details: ['src/file.ts:1:1 error'],
     })
   })
+
+  describe('streamingPreview (#881 phase 2)', () => {
+    it('starts undefined and only persists when a setStreamingPreview action fires', () => {
+      const state = createCommitComposeState()
+      expect(state.streamingPreview).toBeUndefined()
+
+      const withPreview = applyCommitComposeAction(state, {
+        type: 'setStreamingPreview',
+        value: 'partial commit message...',
+      })
+      expect(withPreview.streamingPreview).toBe('partial commit message...')
+    })
+
+    it('passes undefined through setStreamingPreview to explicitly clear the preview', () => {
+      // The streaming workflow dispatches `setStreamingPreview: undefined`
+      // on cancel / abort paths. Explicit clear is distinct from "not yet
+      // set" semantically — both render the same way but the workflow
+      // needs the explicit reset.
+      const seeded = applyCommitComposeAction(createCommitComposeState(), {
+        type: 'setStreamingPreview',
+        value: 'in progress',
+      })
+      const cleared = applyCommitComposeAction(seeded, {
+        type: 'setStreamingPreview',
+        value: undefined,
+      })
+      expect(cleared.streamingPreview).toBeUndefined()
+    })
+
+    it('clears the preview when loading flips off via setLoading(false)', () => {
+      // Loading and the preview are tightly coupled: a preview without a
+      // loader running would render as stale fragments below an idle
+      // compose panel. The reducer enforces the coupling so callers
+      // don't need an extra clear dispatch on every code path that
+      // transitions out of loading.
+      const loading = applyCommitComposeAction(createCommitComposeState(), {
+        type: 'setLoading',
+        value: true,
+      })
+      const withPreview = applyCommitComposeAction(loading, {
+        type: 'setStreamingPreview',
+        value: 'streamed text',
+      })
+      expect(withPreview.streamingPreview).toBe('streamed text')
+
+      const done = applyCommitComposeAction(withPreview, { type: 'setLoading', value: false })
+      expect(done.loading).toBe(false)
+      expect(done.streamingPreview).toBeUndefined()
+    })
+
+    it('preserves the preview when setLoading(true) is dispatched mid-stream', () => {
+      // Defensive: if the workflow re-dispatches setLoading(true) for any
+      // reason during a stream, we shouldn't lose the preview content
+      // that's already accumulated.
+      const seeded = applyCommitComposeAction(
+        applyCommitComposeAction(createCommitComposeState(), { type: 'setLoading', value: true }),
+        { type: 'setStreamingPreview', value: 'mid-stream' }
+      )
+      const reasserted = applyCommitComposeAction(seeded, { type: 'setLoading', value: true })
+      expect(reasserted.streamingPreview).toBe('mid-stream')
+    })
+
+    it('clears the preview when setDraft lands the final validated draft', () => {
+      // The final draft replacing the preview is the success-path
+      // confirmation — the loader vanishes and the editable fields fill
+      // in. Lingering preview text below an already-populated body would
+      // be confusing.
+      const seeded = applyCommitComposeAction(createCommitComposeState(), {
+        type: 'setStreamingPreview',
+        value: '{ "title": "feat: ',
+      })
+      const final = applyCommitComposeAction(seeded, {
+        type: 'setDraft',
+        value: 'feat: add streaming preview\n\nLands the live preview below the loader.',
+      })
+      expect(final.summary).toBe('feat: add streaming preview')
+      expect(final.streamingPreview).toBeUndefined()
+    })
+
+    it('clears the preview when setResult lands a failure', () => {
+      // Failure path: the AI draft errored out, the loader hides, the
+      // message line surfaces the error. The half-streamed preview must
+      // go too — leaving it would suggest content is still incoming.
+      const seeded = applyCommitComposeAction(createCommitComposeState(), {
+        type: 'setStreamingPreview',
+        value: 'partial output before failure',
+      })
+      const failed = applyCommitComposeAction(seeded, {
+        type: 'setResult',
+        message: 'AI draft failed: no API key configured',
+      })
+      expect(failed.message).toMatch(/no API key/)
+      expect(failed.streamingPreview).toBeUndefined()
+    })
+
+    it('clears the preview when reset is dispatched (post-commit teardown)', () => {
+      const seeded = applyCommitComposeAction(createCommitComposeState(), {
+        type: 'setStreamingPreview',
+        value: 'lingering preview',
+      })
+      const reset = applyCommitComposeAction(seeded, { type: 'reset' })
+      expect(reset.streamingPreview).toBeUndefined()
+    })
+  })
 })

--- a/src/commands/log/commitCompose.ts
+++ b/src/commands/log/commitCompose.ts
@@ -11,6 +11,19 @@ export type CommitComposeState = {
   loading: boolean
   message?: string
   details?: string[]
+  /**
+   * Live preview of the streamed LLM output while an AI draft is in
+   * flight (#881 phase 2). Set by `setStreamingPreview` actions fired
+   * from the streaming workflow's `onChunk` callback; cleared by
+   * `setDraft` / `setResult` / `reset` so the preview disappears once
+   * the final validated draft (or failure) lands.
+   *
+   * Undefined when no stream is active OR when streaming is disabled
+   * by config (`service.streaming.enabled !== true`). The renderer
+   * decides what to do with it — current behaviour is to fold the
+   * preview into the compose panel below the loading line.
+   */
+  streamingPreview?: string
 }
 
 export type CommitComposeAction =
@@ -23,6 +36,7 @@ export type CommitComposeAction =
   | { type: 'setLoading'; value: boolean }
   | { type: 'setDraft'; value: string }
   | { type: 'setResult'; message?: string; details?: string[] }
+  | { type: 'setStreamingPreview'; value: string | undefined }
   | { type: 'reset' }
 
 export type ManualCommitResult = {
@@ -90,9 +104,13 @@ export function applyCommitComposeAction(
         editing: action.value,
       }
     case 'setLoading':
+      // Clearing loading also clears any in-flight streaming preview;
+      // the preview's whole purpose is to fill the wait window. Once
+      // the wait ends (success OR failure), the preview is stale.
       return {
         ...state,
         loading: action.value,
+        streamingPreview: action.value ? state.streamingPreview : undefined,
       }
     case 'setDraft':
       // No `message` here — the loader → filled fields are the confirmation
@@ -108,6 +126,7 @@ export function applyCommitComposeAction(
         loading: false,
         message: undefined,
         details: undefined,
+        streamingPreview: undefined,
       }
     case 'setResult':
       return {
@@ -115,6 +134,17 @@ export function applyCommitComposeAction(
         loading: false,
         message: action.message,
         details: action.details,
+        streamingPreview: undefined,
+      }
+    case 'setStreamingPreview':
+      // Per-chunk live-preview update. Fires from the streaming
+      // workflow's onChunk callback; the renderer turns it into a
+      // last-N-lines panel below the loading line. Pass `undefined`
+      // to explicitly clear (the workflow does this on completion
+      // alongside the `setDraft` / `setResult` dispatch).
+      return {
+        ...state,
+        streamingPreview: action.value,
       }
     case 'reset':
       // Drop message/details too — the post-commit "Created commit ..."

--- a/src/git/commitWorkflowActions.ts
+++ b/src/git/commitWorkflowActions.ts
@@ -170,14 +170,31 @@ export async function runCommitWorkflow({
 }
 
 export async function runCommitDraftWorkflow(
-  input: { git?: SimpleGit } = {}
+  input: {
+    git?: SimpleGit
+    /**
+     * Optional streaming callback (#881 phase 2). Forwarded straight
+     * through to `generateCommitDraft`; only fires when the user's
+     * `service.streaming.enabled` is also true. The TUI passes a
+     * dispatcher that updates `commitCompose.streamingPreview` so the
+     * compose surface can render a live preview while the LLM
+     * generates. Output contract (the returned `draft` /
+     * `message` / `details`) is unchanged from the non-streaming path.
+     */
+    onStreamChunk?: (text: string, accumulated: string) => void
+  } = {}
 ): Promise<CommitWorkflowResult> {
   const git = input.git || getRepo()
   const argv = createCommitWorkflowArgv('commit')
   const logger = new Logger({ silent: true })
 
   try {
-    const result = await generateCommitDraft({ git, argv, logger })
+    const result = await generateCommitDraft({
+      git,
+      argv,
+      logger,
+      onStreamChunk: input.onStreamChunk,
+    })
     const draft = result.draft.trim()
 
     if (result.ok && draft) {

--- a/src/lib/langchain/types.ts
+++ b/src/lib/langchain/types.ts
@@ -166,6 +166,37 @@ export type BaseLLMService = {
    */
   dynamicModelPreference?: DynamicModelPreference
   /**
+   * Streaming output (#881). Wires `chain.stream()` instead of
+   * `chain.invoke()` into LLM-driven TUI surfaces so the user sees a
+   * live preview of the model's output as it generates, rather than
+   * staring at a spinner until the full response arrives.
+   *
+   * Output contract is unchanged when enabled: the final draft / plan
+   * still goes through the same parser, schema validator, and retry
+   * logic as the non-streaming path. The stream is a *preview only* —
+   * it relieves the "is this hanging?" anxiety without touching what
+   * gets committed.
+   *
+   * Off by default while we shake the UX out across providers; some
+   * models stream poorly (one-shot blob disguised as a stream) and the
+   * preview just blinks in those cases. Off-by-default also lets users
+   * who prefer the quieter spinner-only UX skip the visual chatter.
+   *
+   * Scope today: workstation compose surface's AI commit draft (the
+   * `I` keystroke). Other TUI LLM calls (split-plan, PR body) stay
+   * non-streaming pending separate validation.
+   */
+  streaming?: {
+    /**
+     * Master switch. When `false` (default) every LLM call uses the
+     * existing non-streaming code path, regardless of which command
+     * or surface fires it.
+     *
+     * @default false
+     */
+    enabled?: boolean
+  }
+  /**
    * Opt-in fast paths that trade summary detail for speed. Each flag
    * here replaces an LLM summary call with a deterministic templated
    * extract for a specific file shape. Off by default — when enabled,

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -307,6 +307,18 @@ export const schema = {
           "description": "Default dynamic routing preference when model is set to \"dynamic\".",
           "default": "balanced"
         },
+        "streaming": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Master switch. When `false` (default) every LLM call uses the existing non-streaming code path, regardless of which command or surface fires it.",
+              "default": false
+            }
+          },
+          "additionalProperties": false,
+          "description": "Streaming output (#881). Wires `chain.stream()` instead of `chain.invoke()` into LLM-driven TUI surfaces so the user sees a live preview of the model's output as it generates, rather than staring at a spinner until the full response arrives.\n\nOutput contract is unchanged when enabled: the final draft / plan still goes through the same parser, schema validator, and retry logic as the non-streaming path. The stream is a *preview only* — it relieves the \"is this hanging?\" anxiety without touching what gets committed.\n\nOff by default while we shake the UX out across providers; some models stream poorly (one-shot blob disguised as a stream) and the preview just blinks in those cases. Off-by-default also lets users who prefer the quieter spinner-only UX skip the visual chatter.\n\nScope today: workstation compose surface's AI commit draft (the `I` keystroke). Other TUI LLM calls (split-plan, PR body) stay non-streaming pending separate validation."
+        },
         "fastPath": {
           "type": "object",
           "properties": {
@@ -761,6 +773,18 @@ export const schema = {
           "description": "Default dynamic routing preference when model is set to \"dynamic\".",
           "default": "balanced"
         },
+        "streaming": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Master switch. When `false` (default) every LLM call uses the existing non-streaming code path, regardless of which command or surface fires it.",
+              "default": false
+            }
+          },
+          "additionalProperties": false,
+          "description": "Streaming output (#881). Wires `chain.stream()` instead of `chain.invoke()` into LLM-driven TUI surfaces so the user sees a live preview of the model's output as it generates, rather than staring at a spinner until the full response arrives.\n\nOutput contract is unchanged when enabled: the final draft / plan still goes through the same parser, schema validator, and retry logic as the non-streaming path. The stream is a *preview only* — it relieves the \"is this hanging?\" anxiety without touching what gets committed.\n\nOff by default while we shake the UX out across providers; some models stream poorly (one-shot blob disguised as a stream) and the preview just blinks in those cases. Off-by-default also lets users who prefer the quieter spinner-only UX skip the visual chatter.\n\nScope today: workstation compose surface's AI commit draft (the `I` keystroke). Other TUI LLM calls (split-plan, PR body) stay non-streaming pending separate validation."
+        },
         "fastPath": {
           "type": "object",
           "properties": {
@@ -954,6 +978,18 @@ export const schema = {
           "$ref": "#/definitions/DynamicModelPreference",
           "description": "Default dynamic routing preference when model is set to \"dynamic\".",
           "default": "balanced"
+        },
+        "streaming": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Master switch. When `false` (default) every LLM call uses the existing non-streaming code path, regardless of which command or surface fires it.",
+              "default": false
+            }
+          },
+          "additionalProperties": false,
+          "description": "Streaming output (#881). Wires `chain.stream()` instead of `chain.invoke()` into LLM-driven TUI surfaces so the user sees a live preview of the model's output as it generates, rather than staring at a spinner until the full response arrives.\n\nOutput contract is unchanged when enabled: the final draft / plan still goes through the same parser, schema validator, and retry logic as the non-streaming path. The stream is a *preview only* — it relieves the \"is this hanging?\" anxiety without touching what gets committed.\n\nOff by default while we shake the UX out across providers; some models stream poorly (one-shot blob disguised as a stream) and the preview just blinks in those cases. Off-by-default also lets users who prefer the quieter spinner-only UX skip the visual chatter.\n\nScope today: workstation compose surface's AI commit draft (the `I` keystroke). Other TUI LLM calls (split-plan, PR body) stay non-streaming pending separate validation."
         },
         "fastPath": {
           "type": "object",

--- a/src/workstation/chrome/streamingPreview.test.ts
+++ b/src/workstation/chrome/streamingPreview.test.ts
@@ -1,0 +1,105 @@
+import {
+  DEFAULT_STREAMING_PREVIEW_LINES,
+  formatStreamingPreview,
+  streamingPreviewTruncateMarker,
+  STREAMING_PREVIEW_TRUNCATE_ASCII,
+  STREAMING_PREVIEW_TRUNCATE_GLYPH,
+} from './streamingPreview'
+
+describe('formatStreamingPreview', () => {
+  it('returns an empty view for undefined / empty / whitespace-only input', () => {
+    // Renderers branch on `lines.length === 0` to skip the preview
+    // entirely during the brief window between `setLoading(true)` and
+    // the first chunk arriving. The helper must produce that empty
+    // shape for every "nothing to show yet" case.
+    expect(formatStreamingPreview(undefined, 40).lines).toEqual([])
+    expect(formatStreamingPreview('', 40).lines).toEqual([])
+    expect(formatStreamingPreview('   \n  \n', 40).lines).toEqual([])
+    expect(formatStreamingPreview(undefined, 40).truncated).toBe(false)
+  })
+
+  it('returns the full wrapped lines without truncation when the buffer fits', () => {
+    const view = formatStreamingPreview('Hello, world.\nGoodbye.', 40)
+    expect(view.lines).toEqual(['Hello, world.', 'Goodbye.'])
+    expect(view.truncated).toBe(false)
+  })
+
+  it('wraps long source lines to the supplied width', () => {
+    // Width 10 forces a single ~30-char line to wrap. The exact wrap
+    // points depend on `wrapCells`'s word-boundary logic; we only
+    // assert that nothing comes back longer than the width.
+    const view = formatStreamingPreview('the quick brown fox jumps over the lazy dog', 10)
+    expect(view.lines.length).toBeGreaterThan(1)
+    for (const line of view.lines) {
+      // visual length, not strict char count — wrapCells handles wide
+      // glyphs; ASCII tests can use length safely.
+      expect(line.length).toBeLessThanOrEqual(10)
+    }
+  })
+
+  it('returns only the trailing maxLines lines and flags truncation when wrapped output overflows', () => {
+    // Eight source lines, budget of three. Helper should keep the
+    // last three and report truncation so the renderer can prefix
+    // the first visible line with an ellipsis marker.
+    const buffer = ['line1', 'line2', 'line3', 'line4', 'line5', 'line6', 'line7', 'line8'].join('\n')
+    const view = formatStreamingPreview(buffer, 40, 3)
+    expect(view.lines).toEqual(['line6', 'line7', 'line8'])
+    expect(view.truncated).toBe(true)
+  })
+
+  it('preserves blank source lines so paragraph spacing survives the wrap', () => {
+    // "A\n\nB" must render as ['A', '', 'B'], not ['A B'] or ['A', 'B'].
+    // Paragraph spacing is part of the model's output rhythm; collapsing
+    // it would make multi-paragraph commit bodies look like one
+    // run-on blob.
+    const view = formatStreamingPreview('A\n\nB', 40)
+    expect(view.lines).toEqual(['A', '', 'B'])
+    expect(view.truncated).toBe(false)
+  })
+
+  it('uses DEFAULT_STREAMING_PREVIEW_LINES when maxLines omitted', () => {
+    // Build a buffer with exactly (default + 2) lines so we can verify
+    // the helper's default budget without hard-coding the number.
+    const total = DEFAULT_STREAMING_PREVIEW_LINES + 2
+    const buffer = Array.from({ length: total }, (_, i) => `line${i + 1}`).join('\n')
+    const view = formatStreamingPreview(buffer, 40)
+    expect(view.lines).toHaveLength(DEFAULT_STREAMING_PREVIEW_LINES)
+    expect(view.truncated).toBe(true)
+    // First visible line is the third source line (lines 1+2 elided).
+    expect(view.lines[0]).toBe('line3')
+  })
+
+  it('clamps an absurdly small maxLines to 1 instead of zero / negative', () => {
+    // Defensive: a misconfigured caller passing maxLines=0 used to
+    // return an empty preview even when the buffer had content,
+    // making the preview vanish on small terminals. The helper now
+    // clamps to a minimum of 1.
+    const view = formatStreamingPreview('a\nb\nc', 40, 0)
+    expect(view.lines).toEqual(['c'])
+    expect(view.truncated).toBe(true)
+  })
+
+  it('clamps an absurdly small width to a sane minimum', () => {
+    // Width values below 8 used to feed wrapCells a width that produced
+    // empty segments or infinite loops. The helper floors to a minimum
+    // wrap width so callers on narrow terminals still get readable
+    // output (even if the wrap is aggressive).
+    const view = formatStreamingPreview('hello there friend', 2)
+    expect(view.lines.length).toBeGreaterThan(0)
+    expect(view.lines.join(' ')).toContain('hello')
+  })
+})
+
+describe('streamingPreviewTruncateMarker', () => {
+  it('returns the unicode ellipsis for non-ASCII themes', () => {
+    expect(streamingPreviewTruncateMarker(false)).toBe(STREAMING_PREVIEW_TRUNCATE_GLYPH)
+    // Sanity: the glyph should be the single-character ellipsis, not
+    // three periods. ASCII fallback covers the three-period case.
+    expect(STREAMING_PREVIEW_TRUNCATE_GLYPH).toBe('…')
+  })
+
+  it('returns three periods for ASCII themes', () => {
+    expect(streamingPreviewTruncateMarker(true)).toBe(STREAMING_PREVIEW_TRUNCATE_ASCII)
+    expect(STREAMING_PREVIEW_TRUNCATE_ASCII).toBe('...')
+  })
+})

--- a/src/workstation/chrome/streamingPreview.ts
+++ b/src/workstation/chrome/streamingPreview.ts
@@ -1,0 +1,117 @@
+/**
+ * Streaming-preview helper (#881 phase 2). Turns the raw accumulated
+ * text from an in-flight LLM stream into the last N visual lines that
+ * fit a given panel width, plus a flag telling the renderer whether
+ * earlier content was elided.
+ *
+ * Why a chrome helper instead of inlining the math in the compose
+ * surface: the same shape is going to be reused by PR-body and review
+ * streaming once those surfaces opt in. The visual line math (wrap to
+ * width, count from the bottom, mark truncation) doesn't belong on the
+ * surface itself.
+ *
+ * No JSX / no Ink here — chrome modules stay framework-agnostic and
+ * return data the surface can hand to its own `h(Text, ...)` calls.
+ */
+import { wrapCells } from './text'
+
+/**
+ * Default last-N visible visual lines. Tuned for compose where the
+ * panel already shows summary + body + loading line, so the preview
+ * can't take more vertical space without pushing the state-line off
+ * the bottom of short terminals. 6 lines is roughly two short
+ * commit-body paragraphs — enough to feel like content is flowing,
+ * not so much that the user loses sight of the surrounding chrome.
+ */
+export const DEFAULT_STREAMING_PREVIEW_LINES = 6
+
+/**
+ * Marker prefixed to the first visible line when earlier content was
+ * elided. Chrome theme picks ASCII vs Unicode at render time; this
+ * module returns both so surfaces don't need to import the theme.
+ */
+export const STREAMING_PREVIEW_TRUNCATE_GLYPH = '…'
+export const STREAMING_PREVIEW_TRUNCATE_ASCII = '...'
+
+export interface StreamingPreviewView {
+  /**
+   * The trailing visual lines that fit the (width, maxLines) budget,
+   * already wrapped to the panel width. Empty array when the input is
+   * empty / whitespace-only.
+   */
+  lines: string[]
+  /**
+   * True when the accumulated text produced more wrapped lines than
+   * the budget allowed and the leading lines were dropped. Renderers
+   * should prefix the first visible line with the truncation marker
+   * when this is true.
+   */
+  truncated: boolean
+}
+
+/**
+ * Compute the visible preview window for a streaming buffer.
+ *
+ * The buffer is split on newlines (preserving blank lines so paragraph
+ * spacing stays visible), each source line is hard-wrapped to `width`,
+ * and the trailing `maxLines` wrapped lines are returned. When the
+ * total wrapped line count exceeds `maxLines`, `truncated` is true so
+ * the renderer can prefix the first line with an ellipsis marker.
+ *
+ * Whitespace-only / empty input returns `{ lines: [], truncated: false }`
+ * so renderers can branch on `lines.length === 0` to skip rendering
+ * entirely during the brief window between dispatching `setLoading`
+ * and the first chunk arriving.
+ *
+ * Width math mirrors the compose surface's body wrap (`width - 6` for
+ * border + paddingX + 2-space indent budget); callers pass the width
+ * they intend to use and this helper assumes it's the wrap budget,
+ * not the panel width.
+ */
+export function formatStreamingPreview(
+  accumulated: string | undefined,
+  width: number,
+  maxLines: number = DEFAULT_STREAMING_PREVIEW_LINES,
+): StreamingPreviewView {
+  if (!accumulated) {
+    return { lines: [], truncated: false }
+  }
+  const trimmed = accumulated.replace(/\s+$/u, '')
+  if (!trimmed) {
+    return { lines: [], truncated: false }
+  }
+
+  // Wrap each source line. Empty source lines must survive the wrap so
+  // a stream like "A\n\nB" reads as two paragraphs separated by a blank
+  // row rather than collapsing into "A B".
+  const wrapWidth = Math.max(8, width)
+  const wrapped: string[] = []
+  for (const line of trimmed.split('\n')) {
+    if (line === '') {
+      wrapped.push('')
+      continue
+    }
+    for (const segment of wrapCells(line, wrapWidth)) {
+      wrapped.push(segment)
+    }
+  }
+
+  const budget = Math.max(1, maxLines)
+  if (wrapped.length <= budget) {
+    return { lines: wrapped, truncated: false }
+  }
+  return {
+    lines: wrapped.slice(wrapped.length - budget),
+    truncated: true,
+  }
+}
+
+/**
+ * Resolve the truncation marker for the current theme. Pure helper so
+ * the surface can render a single-character glyph in colour terminals
+ * and the ASCII fallback when `theme.ascii` is on. Centralised here so
+ * future surfaces opting into streaming use the same glyph.
+ */
+export function streamingPreviewTruncateMarker(ascii: boolean): string {
+  return ascii ? STREAMING_PREVIEW_TRUNCATE_ASCII : STREAMING_PREVIEW_TRUNCATE_GLYPH
+}

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -1775,7 +1775,28 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   const runAiCommitDraft = React.useCallback(async () => {
     dispatch({ type: 'commitCompose', action: { type: 'setLoading', value: true } })
     dispatch({ type: 'setStatus', value: 'generating AI commit draft', loading: true })
-    const result = await runCommitDraftWorkflow()
+    // Streaming preview (#881 phase 2). The workflow forwards this to
+    // `generateCommitDraft`, which only actually streams when the
+    // user opted in via `service.streaming.enabled`. The callback
+    // updates `commitCompose.streamingPreview` so the compose surface
+    // renders a live last-N-lines preview below the loader. The
+    // reducer clears `streamingPreview` whenever loading flips off
+    // (success or failure), so we don't need an explicit teardown
+    // dispatch here.
+    const result = await runCommitDraftWorkflow({
+      git,
+      onStreamChunk: (_text, accumulated) => {
+        // Dispatch the full accumulated text — the preview chrome
+        // helper does the last-N-lines slicing at render time, so
+        // re-doing the slice here would be wasted work. Per-chunk
+        // dispatches are cheap; React batches them and Ink redraws
+        // at its own frame cadence.
+        dispatch({
+          type: 'commitCompose',
+          action: { type: 'setStreamingPreview', value: accumulated },
+        })
+      },
+    })
 
     if (result.ok && result.draft) {
       dispatch({ type: 'commitCompose', action: { type: 'setDraft', value: result.draft } })
@@ -1788,7 +1809,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       action: { type: 'setResult', message: result.message, details: result.details },
     })
     dispatch({ type: 'setStatus', value: result.message })
-  }, [dispatch])
+  }, [dispatch, git])
 
   // `C` keystroke handler — start the create-pull-request flow. Resolves
   // the head + base branches from the live context, runs

--- a/src/workstation/surfaces/compose/index.ts
+++ b/src/workstation/surfaces/compose/index.ts
@@ -12,12 +12,49 @@ import type * as ReactTypes from 'react'
 import type { LogInkContextStatus } from '../../chrome/context'
 import { isLogInkContextKeyLoading } from '../../chrome/context'
 import { pickSpinnerFrame } from '../../chrome/spinner'
+import {
+  formatStreamingPreview,
+  streamingPreviewTruncateMarker,
+} from '../../chrome/streamingPreview'
 import { formatLogInkComposeEmpty } from '../../chrome/surfaceStates'
 import { truncateCells, wrapCells } from '../../chrome/text'
 import type { LogInkTheme } from '../../chrome/theme'
 import type { LogInkState } from '../../../commands/log/inkViewModel'
 import type { LogInkComponents, LogInkContext } from '../../runtime/types'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
+
+/**
+ * Render the streaming-preview block — the trailing lines of the
+ * in-flight LLM stream that sit below the loading spinner. Pure
+ * formatting; the wrap math + truncation flag live in the
+ * `streamingPreview` chrome helper so other surfaces (PR body,
+ * review) can reuse them later.
+ *
+ * Returns an empty array when no preview text is present (the loader
+ * just shows the spinner) so the caller's spread doesn't insert blank
+ * rows that would shift the state-line.
+ */
+function renderStreamingPreviewLines(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  preview: string | undefined,
+  width: number,
+  theme: LogInkTheme,
+): ReactTypes.ReactElement[] {
+  const { Text } = components
+  const view = formatStreamingPreview(preview, width)
+  if (view.lines.length === 0) return []
+  const marker = view.truncated ? streamingPreviewTruncateMarker(theme.ascii) : ''
+  return view.lines.map((line, index) => {
+    // Prefix the first line with the truncation marker when earlier
+    // content was elided. Subsequent lines render unprefixed.
+    const prefix = index === 0 && marker ? `${marker} ` : '  '
+    return h(Text, {
+      key: `compose-stream-${index}`,
+      dimColor: true,
+    }, `${prefix}${line}`)
+  })
+}
 
 export function renderComposeSurface(
   h: typeof ReactTypes.createElement,
@@ -114,6 +151,13 @@ export function renderComposeSurface(
       }, theme.ascii
         ? `[${pickSpinnerFrame(spinnerFrame).replace(/[^a-zA-Z0-9 ]/g, '.')}] Generating AI commit draft (this can take a moment)`
         : `${pickSpinnerFrame(spinnerFrame)}  Generating AI commit draft… (this can take a moment)`),
+      // Streaming preview (#881 phase 2). Renders the trailing visual
+      // lines of the in-flight LLM stream below the loader so the user
+      // sees content building up instead of an opaque spinner. Empty
+      // before the first chunk arrives; the preview helper returns an
+      // empty `lines` array in that window so we skip the block
+      // entirely.
+      ...renderStreamingPreviewLines(h, components, compose.streamingPreview, bodyTextWidth, theme),
     ]
     : []),
   ...(compose.message ? [h(Text, undefined, ''), h(Text, { key: 'compose-msg' }, truncateCells(compose.message, 140))] : []),


### PR DESCRIPTION
## Summary

Second step of #881. The workstation compose surface gains a **live preview pane below the loading spinner**, fed by `chain.stream()` chunks from the LLM. Watching content build up character-by-character relieves the "is this hanging?" anxiety that motivated the issue, without changing what gets committed.

**The streaming is preview-only.** The final draft still goes through the same schema validator, the same salvage parser, and the same commitlint retry as the non-streaming path. We get the perceived-latency win without trading away the schema-validated backstop.

## What you'll see

When `service.streaming.enabled: true` is set in `.coco.config.json`:

```
┌─ Compose commit ─────────────────────────────────────────────────────┐
│ Summary  _                                                           │
│                                                                      │
│ Body                                                                 │
│   <empty>                                                            │
│                                                                      │
│ ⠋  Generating AI commit draft… (this can take a moment)              │
│   { "title": "feat(workstation): streaming live preview for          │
│   AI commit                                                          │
│                                                                      │
│ Press e to edit, c to commit, I for AI draft, esc to leave.          │
└──────────────────────────────────────────────────────────────────────┘
```

The preview shows the last 6 visual lines of the accumulated stream, with an `…` truncation marker on the first line when earlier content scrolled off. The loader keeps spinning until the validated draft replaces the preview.

Default is **off**. Users opt in via `.coco.config.json`:

```json
{
  "service": {
    "streaming": { "enabled": true }
  }
}
```

## How it works

1. **`service.streaming.enabled`** on `BaseLLMService` gates the streaming path. Default `false`.
2. **`chrome/streamingPreview.ts`** formats the accumulated buffer into the trailing N visual lines + a truncation flag. Pure formatter, reusable by future surfaces (PR body, review).
3. **`commitCompose` reducer** gains `streamingPreview?: string` state + `setStreamingPreview` action. Coupled to the spinner: cleared on `setLoading(false)` / `setDraft` / `setResult` / `reset` so the preview can't outlive the loader.
4. **`generateCommitDraft`** accepts `onStreamChunk`. When set AND streaming is enabled, the FIRST attempt uses `executeChainStreaming`. On parse failure (streamed text unsalvageable), falls through to the existing non-streaming `executeChainWithSchema` retry — paying for a second LLM call only on the edge case where streaming produced garbage. The salvage parser is extracted to `salvageCommitMessageFromText` so both paths share the lossy recovery.
5. **`runCommitDraftWorkflow`** forwards `onStreamChunk` straight through.
6. **`runAiCommitDraft`** dispatches `setStreamingPreview` per chunk; the compose surface renders the trailing lines below the loader using the chrome formatter.

## Out of scope (later phases)

- Phase 3: `q` / `Esc` cancel via AbortController.
- Phase 4: Same pattern for the `C` (PR body) and `coco review` flows.
- `coco commit` stdout streaming: deliberately skipped (hooks / CI scripts depend on the existing stdout contract).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run build:schema` ran; schema.json updated for the new `streaming` block
- [x] `npm run test:jest --testPathPatterns="(streamingPreview|commitCompose)"` — 21/21 pass
- [x] `npm run test:jest --testPathPatterns="(workstation|commands/log|commit|langchain)"` — 1343/1343 pass
- [ ] Manual: set `service.streaming.enabled: true` against a real OpenAI / Anthropic / Ollama model. Stage a few files. Press `I` in compose. Verify the preview pane fills in as tokens stream, then collapses into the final validated summary + body when the stream completes.
- [ ] Manual: set the flag, press `I`, let the LLM produce unparseable JSON. Verify the non-streaming retry path fires and the final result is still valid.
- [ ] Manual: keep the flag `false`, verify everything works exactly as before (no preview, no behavior change).