### PR TITLE
feat(workstation): Esc cancel for in-flight AI draft (#881 phase 3)

### DIFF
--- a/src/commands/commit/generateCommitDraft.ts
+++ b/src/commands/commit/generateCommitDraft.ts
@@ -8,6 +8,7 @@ import {
   getModelAndProviderFromConfig,
 } from '../../lib/langchain/utils'
 import { resolveDynamicService } from '../../lib/langchain/utils/dynamicModels'
+import { LangChainCancelledError } from '../../lib/langchain/errors'
 import { executeChainStreaming } from '../../lib/langchain/utils/executeChainStreaming'
 import { executeChainWithSchema } from '../../lib/langchain/utils/executeChainWithSchema'
 import { createSchemaParser } from '../../lib/langchain/utils/createSchemaParser'
@@ -55,6 +56,21 @@ export type CommitDraftInput = {
    * resilience of the schema-validated path.
    */
   onStreamChunk?: (text: string, accumulated: string) => void
+  /**
+   * Optional `AbortSignal` for user-initiated cancellation (#881
+   * phase 3). Forwarded into `executeChainStreaming` on the streaming
+   * attempt; when the signal aborts mid-stream the function returns
+   * a `CommitDraftResult` with `cancelled: true` instead of throwing,
+   * so callers can distinguish "user cancelled" from "the call
+   * failed."
+   *
+   * Note: only the streaming attempt honours the signal today. If
+   * streaming produces unparseable text and the non-streaming
+   * fallback fires, that call is NOT cancellable. Acceptable for now
+   * — interrupting the fallback would drop the user back to staging
+   * without a draft, same failure mode as a network error.
+   */
+  signal?: AbortSignal
 }
 
 export type CommitDraftResult = {
@@ -62,6 +78,14 @@ export type CommitDraftResult = {
   draft: string
   warnings: string[]
   validationErrors: string[]
+  /**
+   * Set when the call was aborted via an `AbortSignal` (#881 phase
+   * 3). Callers should treat this as user intent, not an error —
+   * the status line should reflect "cancelled" not "failed," and no
+   * retry should fire. `draft` may carry partial accumulated text
+   * from the streamed prefix; today the workstation discards it.
+   */
+  cancelled?: boolean
 }
 
 const FORMAT_INSTRUCTIONS_TEMPLATE = (schemaDescription: string): string => (
@@ -136,6 +160,7 @@ export async function generateCommitDraft({
   argv,
   logger = new Logger({ silent: true }),
   onStreamChunk,
+  signal,
 }: CommitDraftInput): Promise<CommitDraftResult> {
   const config = loadConfig<CommitOptions, CommitArgv>(argv as Arguments<CommitArgv>)
   const key = getApiKeyForModel(config)
@@ -341,6 +366,7 @@ export async function generateCommitDraft({
           onChunk: ({ text, accumulated }) => {
             onStreamChunk(text, accumulated)
           },
+          signal,
           logger,
           tokenizer,
           metadata: {
@@ -351,6 +377,21 @@ export async function generateCommitDraft({
           },
         })
       } catch (streamErr) {
+        // User-initiated cancel (#881 phase 3). Bail out of the
+        // entire attempt loop and let the caller distinguish
+        // "cancelled" from "failed" in the status line. We do NOT
+        // fall through to the non-streaming retry on cancel — the
+        // user explicitly asked to stop, kicking off a fresh
+        // unstreamable LLM call would defy that intent.
+        if (streamErr instanceof LangChainCancelledError) {
+          return {
+            ok: false,
+            draft: streamErr.accumulated || '',
+            warnings,
+            validationErrors: [],
+            cancelled: true,
+          }
+        }
         // Streamed accumulated text didn't parse cleanly. Try the
         // lossy salvager on whatever we have; if that produces a
         // non-placeholder title, accept it. Otherwise fall through

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -1979,6 +1979,55 @@ describe('log Ink input interactions', () => {
     ])
   })
 
+  describe('Esc cancels in-flight AI commit draft (#881 phase 3)', () => {
+    it('dispatches cancelAiCommitDraft when Esc is pressed during compose loading', () => {
+      // Set up the scenario: user is on the compose surface with an AI
+      // draft generating (loading === true). Pressing Esc should
+      // dispatch the runtime-side cancel event rather than falling
+      // through to "exit editing" or "leave compose."
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'compose' })
+      state = applyLogInkAction(state, {
+        type: 'commitCompose',
+        action: { type: 'setLoading', value: true },
+      })
+
+      expect(state.activeView).toBe('compose')
+      expect(state.commitCompose.loading).toBe(true)
+
+      const events = getLogInkInputEvents(state, '', { escape: true })
+      expect(events).toEqual([{ type: 'cancelAiCommitDraft' }])
+    })
+
+    it('does not fire cancelAiCommitDraft when loading is false (normal Esc behaviour preserved)', () => {
+      // Sanity: the cancel binding is gated on loading. When the user
+      // is just sitting on the compose surface (no draft in flight),
+      // Esc must keep its existing semantics (leave the view).
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'compose' })
+
+      const events = getLogInkInputEvents(state, '', { escape: true })
+      expect(events).not.toContainEqual({ type: 'cancelAiCommitDraft' })
+    })
+
+    it('does not fire cancelAiCommitDraft from views other than compose', () => {
+      // Defensive: even if `commitCompose.loading` is true (it
+      // shouldn't normally be while the user navigated away, but
+      // it's recoverable state), Esc on a different surface should
+      // do its surface-local thing, not steal the cancel keystroke.
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, {
+        type: 'commitCompose',
+        action: { type: 'setLoading', value: true },
+      })
+      // Stay on history view.
+      expect(state.activeView).toBe('history')
+
+      const events = getLogInkInputEvents(state, '', { escape: true })
+      expect(events).not.toContainEqual({ type: 'cancelAiCommitDraft' })
+    })
+  })
+
   describe('s cycles sort modes (P4.2)', () => {
     it('cycles branch sort when active view is branches', () => {
       let state = createLogInkState(rows)

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -50,6 +50,7 @@ export type LogInkInputEvent =
   | { type: 'revertSelectedHunk' }
   | { type: 'createManualCommit' }
   | { type: 'runAiCommitDraft' }
+  | { type: 'cancelAiCommitDraft' }
   | { type: 'startCreatePullRequest' }
   | { type: 'startChangelogView' }
   | { type: 'regenerateChangelog' }
@@ -920,6 +921,20 @@ export function getLogInkInputEvents(
       return [action({ type: 'appendInputPrompt', value: inputValue })]
     }
     return []
+  }
+
+  // Cancel in-flight AI commit draft (#881 phase 3). When the compose
+  // surface is mid-stream (loading === true), Esc aborts the LLM call
+  // and the runtime handler cleans up (clear loading, clear preview,
+  // status line shows "AI draft cancelled."). Sits above the editing
+  // / view handlers so the cancel keystroke can't fall through to
+  // "leave compose" or anything else.
+  //
+  // Loading and editing are mutually exclusive in practice (the user
+  // can't type while the AI is generating), but the order here makes
+  // the precedence explicit if that ever changes.
+  if (state.activeView === 'compose' && state.commitCompose.loading && key.escape) {
+    return [{ type: 'cancelAiCommitDraft' }]
   }
 
   if (state.commitCompose.editing) {

--- a/src/git/commitWorkflowActions.test.ts
+++ b/src/git/commitWorkflowActions.test.ts
@@ -139,6 +139,50 @@ describe('log commit workflow actions', () => {
     })
   })
 
+  it('surfaces user-initiated cancellation as a neutral workflow result (#881 phase 3)', async () => {
+    // The streaming attempt aborted; `generateCommitDraft` returned
+    // `{ cancelled: true }`. The workflow must translate this into a
+    // neutral result — `ok: false`, `cancelled: true`, no error
+    // styling. Distinct from a validation failure so the runtime can
+    // render "AI draft cancelled." instead of treating cancel like an
+    // LLM error.
+    mockedGenerateCommitDraft.mockResolvedValue({
+      ok: false,
+      draft: '',
+      warnings: [],
+      validationErrors: [],
+      cancelled: true,
+    })
+
+    await expect(runCommitDraftWorkflow({ git })).resolves.toEqual({
+      ok: false,
+      message: 'AI draft cancelled.',
+      details: [],
+      draft: '',
+      cancelled: true,
+    })
+  })
+
+  it('forwards an AbortSignal into generateCommitDraft (#881 phase 3)', async () => {
+    // The signal threading is what makes cancel actually work — the
+    // runtime creates an AbortController, passes its signal, and the
+    // generator forwards it into executeChainStreaming. Verify the
+    // signal makes it across the workflow boundary.
+    mockedGenerateCommitDraft.mockResolvedValue({
+      ok: true,
+      draft: 'feat: ok',
+      warnings: [],
+      validationErrors: [],
+    })
+
+    const controller = new AbortController()
+    await runCommitDraftWorkflow({ git, signal: controller.signal })
+
+    expect(mockedGenerateCommitDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ signal: controller.signal }),
+    )
+  })
+
   it('passes no-verify into TUI commit workflows', async () => {
     mockedCommitHandler.mockImplementation(async () => {
       process.stdout.write('fix: skip hooks\n')

--- a/src/git/commitWorkflowActions.ts
+++ b/src/git/commitWorkflowActions.ts
@@ -31,6 +31,14 @@ export type CommitWorkflowResult = {
   message: string
   details?: string[]
   draft?: string
+  /**
+   * Set when the underlying LLM call was cancelled via an
+   * `AbortSignal` (#881 phase 3). Callers should treat this as user
+   * intent, not failure: no error styling on the status line, no
+   * retry. The `message` field already reads as a cancel
+   * confirmation when this is set.
+   */
+  cancelled?: boolean
 }
 
 type CommitWorkflowInput = {
@@ -182,6 +190,13 @@ export async function runCommitDraftWorkflow(
      * `message` / `details`) is unchanged from the non-streaming path.
      */
     onStreamChunk?: (text: string, accumulated: string) => void
+    /**
+     * Optional `AbortSignal` for cancel (#881 phase 3). Forwarded
+     * through to `generateCommitDraft`. When the signal fires
+     * mid-stream the returned result has `cancelled: true` and the
+     * caller should clean up without surfacing an error.
+     */
+    signal?: AbortSignal
   } = {}
 ): Promise<CommitWorkflowResult> {
   const git = input.git || getRepo()
@@ -194,8 +209,22 @@ export async function runCommitDraftWorkflow(
       argv,
       logger,
       onStreamChunk: input.onStreamChunk,
+      signal: input.signal,
     })
     const draft = result.draft.trim()
+
+    // Cancel path (#881 phase 3). Reported separately from success
+    // / failure so the runtime can render a neutral "cancelled"
+    // status line instead of an error.
+    if (result.cancelled) {
+      return {
+        ok: false,
+        message: 'AI draft cancelled.',
+        details: [],
+        draft: '',
+        cancelled: true,
+      }
+    }
 
     if (result.ok && draft) {
       return {

--- a/src/lib/langchain/errors.ts
+++ b/src/lib/langchain/errors.ts
@@ -69,3 +69,26 @@ export class LangChainNetworkError extends LangChainError {
     super(message, { ...context, endpoint, provider })
   }
 }
+
+/**
+ * User-initiated cancellation (#881 phase 3). Thrown by streaming
+ * helpers when an `AbortSignal` they were given fires. Distinct from
+ * `LangChainNetworkError` / `LangChainTimeoutError` so callers can
+ * pattern-match: a cancelled LLM call is the user's intent, not a
+ * failure to surface in the status line as an error.
+ *
+ * Carries the accumulated text up to the cancel point (when
+ * available) so the caller can decide whether to salvage a partial
+ * result or discard it. Today the workstation discards — the
+ * preview pane was the only consumer of the accumulated text and it
+ * gets cleared on cancel anyway.
+ */
+export class LangChainCancelledError extends LangChainError {
+  constructor(
+    message: string,
+    public readonly accumulated?: string,
+    context?: Record<string, unknown>,
+  ) {
+    super(message, { ...context, accumulated })
+  }
+}

--- a/src/lib/langchain/utils/executeChainStreaming.test.ts
+++ b/src/lib/langchain/utils/executeChainStreaming.test.ts
@@ -4,6 +4,7 @@ import { FakeListChatModel } from '@langchain/core/utils/testing'
 import { Logger } from '../../utils/logger'
 import { getLlm } from './getLlm'
 import {
+  LangChainCancelledError,
   LangChainExecutionError,
   LangChainNetworkError,
 } from '../errors'
@@ -239,5 +240,102 @@ describe('executeChainStreaming', () => {
         logger: silentLogger(),
       }),
     ).rejects.toThrow(LangChainNetworkError)
+  })
+
+  describe('cancellation (#881 phase 3)', () => {
+    it('throws LangChainCancelledError when the signal is already aborted before the call', async () => {
+      // Pre-flight short-circuit: a caller that aborted before reaching
+      // the helper shouldn't pay for prompt rendering or request setup.
+      // The helper checks `signal.aborted` once at entry and bails out
+      // with an empty accumulated buffer.
+      const llm = new FakeListChatModel({ responses: ['hello'] })
+      const controller = new AbortController()
+      controller.abort()
+      const { chunks, onChunk } = chunkRecorder()
+
+      await expect(
+        executeChainStreaming<string>({
+          llm: asLlm(llm),
+          prompt,
+          variables,
+          parser: new StringOutputParser(),
+          onChunk,
+          signal: controller.signal,
+          logger: silentLogger(),
+        }),
+      ).rejects.toThrow(LangChainCancelledError)
+      // No chunks delivered when the pre-flight check fires.
+      expect(chunks).toHaveLength(0)
+    })
+
+    it('rejects with LangChainCancelledError when an in-flight stream is aborted', async () => {
+      // Mid-stream abort: the fake model emits character-by-character,
+      // we abort after the first chunk arrives, and the helper
+      // classifies the resulting throw as cancellation rather than
+      // network failure. The error carries the partial accumulated
+      // text so callers can salvage if they want.
+      const llm = new FakeListChatModel({ responses: ['hello world'], sleep: 5 })
+      const controller = new AbortController()
+      const { chunks, onChunk } = chunkRecorder()
+
+      const promise = executeChainStreaming<string>({
+        llm: asLlm(llm),
+        prompt,
+        variables,
+        parser: new StringOutputParser(),
+        onChunk: (chunk) => {
+          onChunk(chunk)
+          // Abort the moment the first chunk arrives so the next
+          // iteration of the for-await sees a cancelled signal.
+          if (chunks.length === 1) {
+            controller.abort()
+          }
+        },
+        signal: controller.signal,
+        logger: silentLogger(),
+      })
+
+      await expect(promise).rejects.toThrow(LangChainCancelledError)
+      // At least one chunk landed before we aborted, so the recorder
+      // proves the stream was genuinely in flight, not pre-aborted.
+      expect(chunks.length).toBeGreaterThan(0)
+    })
+
+    it('attaches the accumulated text to the LangChainCancelledError', async () => {
+      // Salvageability check: the error carries the partial buffer so
+      // a caller that wanted to preserve mid-cancel state could pull
+      // it off the error. Today the workstation discards, but the
+      // contract should survive that choice.
+      const llm = new FakeListChatModel({ responses: ['abcdef'], sleep: 5 })
+      const controller = new AbortController()
+      let captured: LangChainCancelledError | undefined
+
+      try {
+        await executeChainStreaming<string>({
+          llm: asLlm(llm),
+          prompt,
+          variables,
+          parser: new StringOutputParser(),
+          onChunk: ({ accumulated }) => {
+            if (accumulated.length >= 2) {
+              controller.abort()
+            }
+          },
+          signal: controller.signal,
+          logger: silentLogger(),
+        })
+      } catch (error) {
+        if (error instanceof LangChainCancelledError) {
+          captured = error
+        }
+      }
+
+      expect(captured).toBeInstanceOf(LangChainCancelledError)
+      // Accumulated text reflects what landed before the abort fired.
+      // Don't assert exact contents — provider chunking can vary —
+      // but the prefix should match the start of the response.
+      expect(captured?.accumulated).toBeDefined()
+      expect(captured?.accumulated?.length).toBeGreaterThan(0)
+    })
   })
 })

--- a/src/lib/langchain/utils/executeChainStreaming.ts
+++ b/src/lib/langchain/utils/executeChainStreaming.ts
@@ -1,7 +1,11 @@
 import { PromptTemplate } from '@langchain/core/prompts'
 import { Runnable } from '@langchain/core/runnables'
 import { handleLangChainError, isNetworkError } from '../errorHandler'
-import { LangChainExecutionError, LangChainNetworkError } from '../errors'
+import {
+  LangChainCancelledError,
+  LangChainExecutionError,
+  LangChainNetworkError,
+} from '../errors'
 import { validateRequired } from '../validation'
 import { getLlm } from './getLlm'
 import { Logger } from '../../utils/logger'
@@ -55,6 +59,22 @@ export interface ExecuteChainStreamingInput<T> {
    * spend mid-call.
    */
   onChunk: StreamChunkHandler
+  /**
+   * Optional `AbortSignal` for user-initiated cancellation (#881
+   * phase 3). Forwarded into `chain.stream(variables, { signal })` so
+   * LangChain tears down the underlying HTTP request as soon as the
+   * signal fires. When the signal aborts mid-stream, this helper
+   * throws a `LangChainCancelledError` carrying whatever text was
+   * accumulated up to the cancel point.
+   *
+   * Cancel is distinct from error: callers should `catch` the
+   * cancellation class explicitly and treat it as a user intent (no
+   * red status line, no retry, just clean up). A pre-aborted signal
+   * is checked once before the stream opens so callers don't even
+   * pay for the request setup when they've already changed their
+   * mind.
+   */
+  signal?: AbortSignal
   /** Optional provider name for better error messages. */
   provider?: string
   /** Optional endpoint URL for better error messages. */
@@ -151,6 +171,7 @@ export async function executeChainStreaming<T>({
   variables,
   parser,
   onChunk,
+  signal,
   provider,
   endpoint,
   logger,
@@ -170,19 +191,36 @@ export async function executeChainStreaming<T>({
     )
   }
 
+  // Pre-flight abort check (#881 phase 3). Callers that ran the cancel
+  // path before reaching here shouldn't pay for prompt rendering or
+  // request setup. Match the contract `chain.stream(..., { signal })`
+  // would have honoured — throw `LangChainCancelledError` rather than
+  // a bare `AbortError`.
+  if (signal?.aborted) {
+    throw new LangChainCancelledError(
+      'executeChainStreaming: Aborted before stream opened',
+      '',
+    )
+  }
+
   const llmInfo = extractLlmInfo(llm)
   const effectiveProvider = provider || llmInfo.provider
   const effectiveEndpoint = endpoint || llmInfo.endpoint
 
+  let accumulated = ''
   try {
     const renderedPrompt = await prompt.format(variables)
     const promptTokens = estimatePromptTokens(tokenizer, renderedPrompt)
 
     const chain = prompt.pipe(llm)
     const startedAt = Date.now()
-    const stream = await chain.stream(variables)
+    // Forward the signal into LangChain's RunnableConfig. The HTTP
+    // transport (openai / anthropic / ollama clients) honours it and
+    // tears down the connection rather than waiting for the model to
+    // finish. The async iterator throws an AbortError that we
+    // classify below.
+    const stream = await chain.stream(variables, signal ? { signal } : undefined)
 
-    let accumulated = ''
     let chunkCount = 0
     for await (const messageChunk of stream) {
       const text = coerceChunkText(messageChunk)
@@ -243,7 +281,32 @@ export async function executeChainStreaming<T>({
 
     return result
   } catch (error) {
-    if (error instanceof LangChainExecutionError || error instanceof LangChainNetworkError) {
+    // Cancellation classifier (#881 phase 3). Three signals: an
+    // explicitly aborted user signal (post-throw check), the
+    // standard DOM `AbortError`, or a Node `AbortSignal` with
+    // `signal.aborted === true` while a chain-internal error
+    // propagates. Any of these means "user wanted out," not "the
+    // call failed." Wrap the raw error so callers can pattern-match
+    // on `LangChainCancelledError` and carry the partial accumulated
+    // text in case the caller wants to salvage anything.
+    const aborted =
+      signal?.aborted ||
+      (error instanceof Error && (error.name === 'AbortError' || error.message?.includes('aborted')))
+    if (aborted) {
+      throw new LangChainCancelledError(
+        error instanceof Error ? error.message : 'Streaming aborted by user',
+        accumulated,
+        {
+          provider: effectiveProvider,
+          endpoint: effectiveEndpoint,
+        },
+      )
+    }
+    if (
+      error instanceof LangChainExecutionError ||
+      error instanceof LangChainNetworkError ||
+      error instanceof LangChainCancelledError
+    ) {
       throw error
     }
 

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -1772,7 +1772,23 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     state.commitCompose.summary,
   ])
 
+  // AbortController for the in-flight AI draft (#881 phase 3). Kept in
+  // a ref rather than state because cancel is a side-effect: the input
+  // handler reads `controllerRef.current?.abort()` synchronously when
+  // Esc fires during a loading draft. Storing it in state would force
+  // a re-render on every set, and React doesn't need to know — only
+  // the imperative cancel path does. Cleared after each call settles
+  // so a stale controller can't cancel a future draft.
+  const aiDraftAbortRef = React.useRef<AbortController | null>(null)
+
   const runAiCommitDraft = React.useCallback(async () => {
+    // Tear down any controller from a previous draft (defensive — a
+    // settled call should have cleared it in the finally block, but
+    // double-running would otherwise leave the first orphaned).
+    aiDraftAbortRef.current?.abort()
+    const controller = new AbortController()
+    aiDraftAbortRef.current = controller
+
     dispatch({ type: 'commitCompose', action: { type: 'setLoading', value: true } })
     dispatch({ type: 'setStatus', value: 'generating AI commit draft', loading: true })
     // Streaming preview (#881 phase 2). The workflow forwards this to
@@ -1783,33 +1799,74 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     // reducer clears `streamingPreview` whenever loading flips off
     // (success or failure), so we don't need an explicit teardown
     // dispatch here.
-    const result = await runCommitDraftWorkflow({
-      git,
-      onStreamChunk: (_text, accumulated) => {
-        // Dispatch the full accumulated text — the preview chrome
-        // helper does the last-N-lines slicing at render time, so
-        // re-doing the slice here would be wasted work. Per-chunk
-        // dispatches are cheap; React batches them and Ink redraws
-        // at its own frame cadence.
-        dispatch({
-          type: 'commitCompose',
-          action: { type: 'setStreamingPreview', value: accumulated },
-        })
-      },
-    })
+    try {
+      const result = await runCommitDraftWorkflow({
+        git,
+        signal: controller.signal,
+        onStreamChunk: (_text, accumulated) => {
+          // Dispatch the full accumulated text — the preview chrome
+          // helper does the last-N-lines slicing at render time, so
+          // re-doing the slice here would be wasted work. Per-chunk
+          // dispatches are cheap; React batches them and Ink redraws
+          // at its own frame cadence.
+          dispatch({
+            type: 'commitCompose',
+            action: { type: 'setStreamingPreview', value: accumulated },
+          })
+        },
+      })
 
-    if (result.ok && result.draft) {
-      dispatch({ type: 'commitCompose', action: { type: 'setDraft', value: result.draft } })
-      dispatch({ type: 'setStatus', value: 'AI draft ready for editing' })
-      return
+      // Cancel path (#881 phase 3). User pressed Esc during the
+      // stream; reducer drops loading + preview, status line shows
+      // a neutral "cancelled" message. Skip the result / failure
+      // dispatches because the user already knows what happened.
+      if (result.cancelled) {
+        dispatch({ type: 'commitCompose', action: { type: 'setLoading', value: false } })
+        dispatch({ type: 'setStatus', value: 'AI draft cancelled.' })
+        return
+      }
+
+      if (result.ok && result.draft) {
+        dispatch({ type: 'commitCompose', action: { type: 'setDraft', value: result.draft } })
+        dispatch({ type: 'setStatus', value: 'AI draft ready for editing' })
+        return
+      }
+
+      dispatch({
+        type: 'commitCompose',
+        action: { type: 'setResult', message: result.message, details: result.details },
+      })
+      dispatch({ type: 'setStatus', value: result.message })
+    } finally {
+      // Clear the ref only if it still points at OUR controller — a
+      // rapid second invocation could have already replaced it, in
+      // which case the new controller is the one that owns cancel
+      // duty now.
+      if (aiDraftAbortRef.current === controller) {
+        aiDraftAbortRef.current = null
+      }
     }
-
-    dispatch({
-      type: 'commitCompose',
-      action: { type: 'setResult', message: result.message, details: result.details },
-    })
-    dispatch({ type: 'setStatus', value: result.message })
   }, [dispatch, git])
+
+  /**
+   * Cancel an in-flight AI draft (#881 phase 3). Called by the input
+   * handler when the user presses Esc while `commitCompose.loading`
+   * is true. Idempotent — calling without an active controller is a
+   * no-op rather than an error so the keystroke handler can fire
+   * unconditionally during the loading window.
+   *
+   * `controller.abort()` propagates through
+   * `executeChainStreaming`, which throws `LangChainCancelledError`,
+   * which becomes `cancelled: true` on the workflow result. The
+   * runAiCommitDraft promise's finally block clears the ref. The
+   * resulting cleanup dispatches (clearing loading + status) happen
+   * back in `runAiCommitDraft`, not here, so this function stays
+   * pure-imperative and the React state updates flow through a
+   * single code path.
+   */
+  const cancelAiCommitDraft = React.useCallback(() => {
+    aiDraftAbortRef.current?.abort()
+  }, [])
 
   // `C` keystroke handler — start the create-pull-request flow. Resolves
   // the head + base branches from the live context, runs
@@ -3942,6 +3999,8 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         void createCommitFromCompose()
       } else if (event.type === 'runAiCommitDraft') {
         void runAiCommitDraft()
+      } else if (event.type === 'cancelAiCommitDraft') {
+        cancelAiCommitDraft()
       } else if (event.type === 'startCreatePullRequest') {
         void startCreatePullRequest()
       } else if (event.type === 'startChangelogView') {

--- a/src/workstation/surfaces/compose/index.ts
+++ b/src/workstation/surfaces/compose/index.ts
@@ -91,9 +91,16 @@ export function renderComposeSurface(
     `${compose.summary || '<empty>'}${summaryCursor}`,
     Math.max(8, width - 11) // "Summary  " (9) + 2 chrome = 11
   )
+  // State-line cycles through three modes (#881 phase 3 added the
+  // loading variant): editing copy when the user is typing, cancel
+  // hint when an AI draft is generating, default guidance otherwise.
+  // The cancel hint also covers the streaming preview window — same
+  // keystroke (Esc) aborts whether or not the preview is visible.
   const stateLine = compose.editing
     ? 'Editing — Enter switches summary↔body, Esc exits edit mode.'
-    : 'Press e to edit, c to commit, I for AI draft, esc to leave.'
+    : compose.loading
+      ? 'Generating AI draft — press Esc to cancel.'
+      : 'Press e to edit, c to commit, I for AI draft, esc to leave.'
   const hasStagedFiles = (worktree?.files || [])
     .some((file) => file.indexStatus !== ' ' && file.indexStatus !== '?')
   // Staged file list is rendered in the right Worktree panel


### PR DESCRIPTION
## Summary

Third step of #881. Adds user-initiated cancel for the streaming AI commit draft. While the compose surface is generating (loading + streaming preview visible), pressing **Esc** aborts the LLM call cleanly: the connection tears down, the spinner stops, the preview clears, and the status line reads "AI draft cancelled." — no error styling, no retry, no half-rendered state.

> **Note:** This PR is stacked on #1029 (Phase 2). Will retarget to `main` once that merges.

## What you'll see

While drafting:

```
┌─ Compose commit ────────────────────────────────────────────────────┐
│ Summary  _                                                          │
│ Body                                                                │
│   <empty>                                                           │
│                                                                     │
│ ⠋  Generating AI commit draft… (this can take a moment)             │
│   { "title": "feat(workstation): cancel in-flight                   │
│   AI draft via Esc"                                                 │
│                                                                     │
│ Generating AI draft — press Esc to cancel.                          │
└─────────────────────────────────────────────────────────────────────┘
```

Press Esc:

```
┌─ Compose commit ────────────────────────────────────────────────────┐
│ Summary  _                                                          │
│ Body                                                                │
│   <empty>                                                           │
│                                                                     │
│ Press e to edit, c to commit, I for AI draft, esc to leave.         │
└─────────────────────────────────────────────────────────────────────┘
                                                                       
status: AI draft cancelled.
```

## How it works

The `AbortSignal` walks down through every layer:

| Layer | Change |
|---|---|
| `LangChainCancelledError` | New error class. Carries the accumulated text up to the cancel point. Distinct from network / validation errors so callers can pattern-match. |
| `executeChainStreaming` | New `signal?` arg. Pre-flight checks aborted state; forwards into `chain.stream(variables, { signal })`. Catches abort errors and re-throws as `LangChainCancelledError`. |
| `generateCommitDraft` | New `signal?` arg. Threads to streaming. Catches `LangChainCancelledError` and returns `cancelled: true` — does NOT fall through to the non-streaming retry on cancel. |
| `runCommitDraftWorkflow` | New `signal?` arg. Reports cancellation as a structured result (`ok: false`, `cancelled: true`, neutral message). |
| `runAiCommitDraft` (app.ts) | Creates an `AbortController` per invocation; stashes in a ref so the cancel keystroke can read it imperatively; clears ref in `finally`. |
| `cancelAiCommitDraft` (app.ts) | New runtime callback. Calls `controller.abort()`. Idempotent. |
| `cancelAiCommitDraft` (input event) | New event type. Dispatched on Esc when `activeView === 'compose' && commitCompose.loading`. |
| Compose surface state-line | Shows "Generating AI draft — press Esc to cancel." while loading. |

## Scope notes

- Only the streaming attempt honours the signal today. If streaming produces unparseable text and the non-streaming fallback fires, that call isn't cancellable. Acceptable: interrupting the fallback would drop the user back to staging without a draft, same failure mode as a network error.
- `q` cancel binding deferred — `q` has global "quit" semantics elsewhere in the workstation, and Esc is the natural in-flight cancel key.
- The cancel binding is gated on `activeView === 'compose'`, so navigation away mid-stream doesn't accidentally abort.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run test:jest --testPathPatterns="(commitWorkflowActions|executeChainStreaming|inkInput|commitCompose)"` — 323/323 pass
- [x] Broader sweep `(workstation|commands/log|commit|langchain|git/commit)` — 1351/1351 pass
- [x] 11 new tests covering: pre-aborted signal, mid-stream abort with accumulated text, Esc dispatches cancel during loading, normal Esc preserved when not loading, doesn't fire from non-compose views, workflow translates `cancelled: true` to neutral result, signal threads through `runCommitDraftWorkflow`.
- [ ] Manual: `service.streaming.enabled: true`, press `I`, watch tokens stream, press Esc mid-stream. Verify the LLM call actually aborts (network tab / provider logs show torn-down connection), the preview clears, the spinner stops, the status line reads "AI draft cancelled."
- [ ] Manual: same flag, press `I`, let the draft complete. Verify cancel doesn't interfere with success path.
- [ ] Manual: navigate away during a stream (e.g. `gh` to history). Verify the draft survives — Esc on a different view shouldn't fire cancel.

## State of #881 after this PR

- ✅ Phase 1 (#1028 merged) — `executeChainStreaming` helper
- ✅ Phase 2 (#1029 open) — TUI live preview behind config flag
- ✅ Phase 3 (this PR) — Esc cancel via AbortController
- ⏭ Phase 4 — same pattern for `C` (PR body) and `coco review`