### PR TITLE
feat(workstation): Esc cancel for in-flight PR body draft (#881 phase 4)

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -2028,6 +2028,54 @@ describe('log Ink input interactions', () => {
     })
   })
 
+  describe('Esc cancels in-flight PR body draft (#881 phase 4)', () => {
+    it('dispatches cancelPullRequestBodyDraft when Esc is pressed during the draft', () => {
+      // While `pendingPullRequestBodyDraft` is true, Esc routes to the
+      // soft-cancel handler so the user can bail before the prompt
+      // opens. Unlike the compose-loading cancel binding above, this
+      // is NOT gated on `activeView` — the C keystroke can be fired
+      // from anywhere via the palette, so cancel has to work from
+      // anywhere too.
+      const state = applyLogInkAction(createLogInkState(rows), {
+        type: 'setPendingPullRequestBodyDraft',
+        value: true,
+      })
+      expect(state.pendingPullRequestBodyDraft).toBe(true)
+
+      const events = getLogInkInputEvents(state, '', { escape: true })
+      expect(events).toEqual([{ type: 'cancelPullRequestBodyDraft' }])
+    })
+
+    it('does not fire when no PR body draft is pending (normal Esc preserved)', () => {
+      // Sanity: the cancel binding only fires when the flag is set.
+      // With no draft pending, Esc falls through to the global handler
+      // (which pops view stack, etc. — not asserted here, just that
+      // we don't steal the keystroke).
+      const events = getLogInkInputEvents(createLogInkState(rows), '', { escape: true })
+      expect(events).not.toContainEqual({ type: 'cancelPullRequestBodyDraft' })
+    })
+
+    it('takes precedence over the compose-cancel binding when both could match', () => {
+      // Edge case: both `pendingPullRequestBodyDraft` AND
+      // `commitCompose.loading` are true simultaneously (unusual but
+      // recoverable state). The compose handler sits above PR-body
+      // in the input pipeline, so compose cancel wins. Document the
+      // precedence here so a future reorder doesn't silently swap it.
+      let state = applyLogInkAction(createLogInkState(rows), {
+        type: 'setPendingPullRequestBodyDraft',
+        value: true,
+      })
+      state = applyLogInkAction(state, { type: 'pushView', value: 'compose' })
+      state = applyLogInkAction(state, {
+        type: 'commitCompose',
+        action: { type: 'setLoading', value: true },
+      })
+
+      const events = getLogInkInputEvents(state, '', { escape: true })
+      expect(events).toEqual([{ type: 'cancelAiCommitDraft' }])
+    })
+  })
+
   describe('s cycles sort modes (P4.2)', () => {
     it('cycles branch sort when active view is branches', () => {
       let state = createLogInkState(rows)

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -52,6 +52,7 @@ export type LogInkInputEvent =
   | { type: 'runAiCommitDraft' }
   | { type: 'cancelAiCommitDraft' }
   | { type: 'startCreatePullRequest' }
+  | { type: 'cancelPullRequestBodyDraft' }
   | { type: 'startChangelogView' }
   | { type: 'regenerateChangelog' }
   | { type: 'yankChangelog' }
@@ -935,6 +936,24 @@ export function getLogInkInputEvents(
   // the precedence explicit if that ever changes.
   if (state.activeView === 'compose' && state.commitCompose.loading && key.escape) {
     return [{ type: 'cancelAiCommitDraft' }]
+  }
+
+  // Cancel in-flight PR body draft (#881 phase 4). The `C` keystroke
+  // kicks off a changelog-based draft that runs for 5-15 seconds
+  // before the input prompt opens. While the draft is pending, Esc
+  // tells the runtime to skip the prompt and surface a "cancelled"
+  // status. Unlike the compose cancel above, this is a *soft* cancel
+  // — the background LLM call still completes, but its result is
+  // discarded. Acceptable trade-off for now; deeper signal threading
+  // through `changelogHandler` lands in a follow-up if real cancel
+  // becomes a request.
+  //
+  // Sits unconditionally on the global Esc check (no `activeView`
+  // gate) because the draft can be initiated from any view via the
+  // palette `C` binding; Esc must work wherever the user is when
+  // they decide to bail.
+  if (state.pendingPullRequestBodyDraft && key.escape) {
+    return [{ type: 'cancelPullRequestBodyDraft' }]
   }
 
   if (state.commitCompose.editing) {

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -1793,4 +1793,42 @@ describe('triage filter preset cycling (#882 phase 6)', () => {
     state = applyLogInkAction(state, { type: 'cycleIssueFilter' })
     expect(state.pendingKey).toBeUndefined()
   })
+
+  describe('setPendingPullRequestBodyDraft (#881 phase 4)', () => {
+    it('starts undefined and flips on / off via the action', () => {
+      // The flag gates the Esc cancel binding in the input handler.
+      // `startCreatePullRequest` sets it true before awaiting the
+      // workflow and clears it in a `finally` so a thrown error can't
+      // strand the user in a cancellable state.
+      const state = createLogInkState(rows)
+      expect(state.pendingPullRequestBodyDraft).toBeUndefined()
+
+      const pending = applyLogInkAction(state, {
+        type: 'setPendingPullRequestBodyDraft',
+        value: true,
+      })
+      expect(pending.pendingPullRequestBodyDraft).toBe(true)
+
+      const cleared = applyLogInkAction(pending, {
+        type: 'setPendingPullRequestBodyDraft',
+        value: false,
+      })
+      // Cleared to `undefined` rather than `false` so the flag's
+      // absence is uniform — readers can shorthand the check with
+      // `!state.pendingPullRequestBodyDraft` either way.
+      expect(cleared.pendingPullRequestBodyDraft).toBeUndefined()
+    })
+
+    it('clears the pending key (chord prefix) on toggle', () => {
+      // Same hygiene as the other dispatched actions: any incoming
+      // dispatch resets a half-typed chord (`g`-prefix) so we don't
+      // accumulate stale prefixes across async workflow events.
+      const seeded = { ...createLogInkState(rows), pendingKey: 'g' }
+      const next = applyLogInkAction(seeded, {
+        type: 'setPendingPullRequestBodyDraft',
+        value: true,
+      })
+      expect(next.pendingKey).toBeUndefined()
+    })
+  })
 })

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -360,6 +360,15 @@ export type LogInkState = {
    */
   statusLoading?: boolean
   /**
+   * Set while the `C` keystroke's PR body draft is in flight (#881
+   * phase 4). The input handler reads this to gate the Esc cancel
+   * binding: pressing Esc while a draft is pending dispatches
+   * `cancelPullRequestBodyDraft` (soft cancel — skip opening the
+   * follow-up prompt) instead of falling through to the global Esc
+   * handler. Cleared by the workflow callback in `finally`.
+   */
+  pendingPullRequestBodyDraft?: boolean
+  /**
    * Set by `navigateOpenDiffForCommit` / `navigateOpenDiffForWorktreeFile`
    * to disambiguate the diff view when both a worktree file and a commit
    * are selectable. Cleared when the diff view is popped or replaced.
@@ -717,6 +726,7 @@ export type LogInkAction =
   | { type: 'setSidebarTab'; value: LogInkSidebarTab }
   | { type: 'restoreSidebarTab'; value: LogInkSidebarTab }
   | { type: 'setStatus'; value?: string; kind?: 'info' | 'error' | 'success'; loading?: boolean }
+  | { type: 'setPendingPullRequestBodyDraft'; value: boolean }
   | { type: 'setWorkflowAction'; value?: string }
   | { type: 'setPendingConfirmation'; value?: string; payload?: string }
   | { type: 'setPendingMutationConfirmation'; value?: LogInkMutationConfirmation }
@@ -1896,6 +1906,17 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         // doesn't explicitly opt in (loading: true) clears the flag so
         // a stale spinner doesn't linger after the LLM call finishes.
         statusLoading: !action.value ? undefined : (action.loading ? true : undefined),
+        pendingKey: undefined,
+      }
+    case 'setPendingPullRequestBodyDraft':
+      // PR-body draft tracker (#881 phase 4). Set true while
+      // `startCreatePullRequest` is awaiting the changelog-based
+      // body generation; gates the Esc cancel binding in the input
+      // handler so pressing Esc during the wait skips opening the
+      // follow-up prompt instead of falling through to global Esc.
+      return {
+        ...state,
+        pendingPullRequestBodyDraft: action.value || undefined,
         pendingKey: undefined,
       }
     case 'setWorkflowAction':

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -1881,6 +1881,19 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // missing) we surface the failure on the status line and skip the
   // prompt entirely — better than opening a prompt the user can't
   // actually submit successfully.
+  // Soft-cancel handle for the PR body draft (#881 phase 4). A mutable
+  // ref rather than state because the cancel decision needs to be
+  // visible synchronously inside the async workflow without forcing
+  // re-renders. Owned by the in-flight invocation: the cancel callback
+  // mutates `.cancelled` on the live ref; the workflow checks it after
+  // `await` resolves and decides whether to open the follow-up prompt.
+  //
+  // The LLM call itself keeps running (no AbortSignal threaded through
+  // `changelogHandler` today). The user-visible outcome — "PR draft
+  // cancelled, no prompt opens" — is identical to a hard cancel, at
+  // the cost of paying for the in-flight tokens. Deeper threading
+  // lands in a follow-up if hard cancel becomes a request.
+  const pullRequestBodyCancelRef = React.useRef<{ cancelled: boolean } | null>(null)
   const startCreatePullRequest = React.useCallback(async () => {
     const head = context.branches?.currentBranch || context.provider?.currentBranch
     if (!head) {
@@ -1910,34 +1923,65 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       return
     }
 
+    // Set up the cancel handle BEFORE flipping the pending flag so a
+    // race between the flag-set and a synchronous Esc keystroke can't
+    // leave the input handler dispatching cancel without a ref to
+    // mutate. The cancel callback no-ops cleanly when the ref is null
+    // (call already settled).
+    const cancelHandle = { cancelled: false }
+    pullRequestBodyCancelRef.current = cancelHandle
+
+    dispatch({ type: 'setPendingPullRequestBodyDraft', value: true })
     dispatch({
       type: 'setStatus',
-      value: `generating PR body from changelog (vs ${defaultBranch})…`,
+      value: `generating PR body from changelog (vs ${defaultBranch}) — Esc to cancel`,
       loading: true,
     })
-    const body = await runPullRequestBodyWorkflow({ baseBranch: defaultBranch })
 
-    // Fallback shape when the changelog generation fails — open the
-    // prompt with empty title + body rather than aborting, so the user
-    // can still author the PR manually. The status line surfaces why
-    // we couldn't pre-fill.
-    const initialTitle = body.title || head.replace(/^(feat|fix|chore|docs|refactor|test)\//, '').replace(/[-_]/g, ' ')
-    const initialBody = body.body || ''
-    const initial = initialBody ? `${initialTitle}\n\n${initialBody}` : initialTitle
+    try {
+      const body = await runPullRequestBodyWorkflow({ baseBranch: defaultBranch })
 
-    if (!body.ok) {
-      dispatch({ type: 'setStatus', value: `PR body generation failed: ${body.message}. Edit manually.` })
-    } else {
-      dispatch({ type: 'setStatus', value: 'PR body drafted — review and Ctrl+D to submit.' })
+      // Soft-cancel check (#881 phase 4). If the user pressed Esc
+      // while the workflow was awaiting, skip opening the prompt and
+      // surface a neutral status. The underlying LLM call has
+      // already settled — its result is discarded. Hard cancel
+      // (aborting the HTTP request mid-flight) is a follow-up.
+      if (cancelHandle.cancelled) {
+        dispatch({ type: 'setStatus', value: 'PR draft cancelled.' })
+        return
+      }
+
+      // Fallback shape when the changelog generation fails — open the
+      // prompt with empty title + body rather than aborting, so the user
+      // can still author the PR manually. The status line surfaces why
+      // we couldn't pre-fill.
+      const initialTitle = body.title || head.replace(/^(feat|fix|chore|docs|refactor|test)\//, '').replace(/[-_]/g, ' ')
+      const initialBody = body.body || ''
+      const initial = initialBody ? `${initialTitle}\n\n${initialBody}` : initialTitle
+
+      if (!body.ok) {
+        dispatch({ type: 'setStatus', value: `PR body generation failed: ${body.message}. Edit manually.` })
+      } else {
+        dispatch({ type: 'setStatus', value: 'PR body drafted — review and Ctrl+D to submit.' })
+      }
+
+      dispatch({
+        type: 'openInputPrompt',
+        kind: 'create-pr',
+        label: `Create PR: ${head} → ${defaultBranch}  (line 1 title · rest body · Enter newline · Ctrl+D submit)`,
+        initial,
+        multiline: true,
+      })
+    } finally {
+      // Clear the flag + the ref so a subsequent draft starts clean.
+      // Only clear the ref if we still own it — a second invocation
+      // would have already taken ownership in which case the cancel
+      // duty has rolled over.
+      dispatch({ type: 'setPendingPullRequestBodyDraft', value: false })
+      if (pullRequestBodyCancelRef.current === cancelHandle) {
+        pullRequestBodyCancelRef.current = null
+      }
     }
-
-    dispatch({
-      type: 'openInputPrompt',
-      kind: 'create-pr',
-      label: `Create PR: ${head} → ${defaultBranch}  (line 1 title · rest body · Enter newline · Ctrl+D submit)`,
-      initial,
-      multiline: true,
-    })
   }, [
     context.branches?.currentBranch,
     context.provider?.currentBranch,
@@ -1946,6 +1990,24 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     context.pullRequest?.currentPullRequest,
     dispatch,
   ])
+
+  /**
+   * Soft-cancel the in-flight PR body draft (#881 phase 4). The
+   * cancel ref's `.cancelled` flag is checked after the workflow's
+   * await resolves; setting it true causes the workflow to skip the
+   * prompt-open and surface a neutral "cancelled" status. The LLM
+   * call itself isn't aborted (no signal threaded through the
+   * `changelogHandler` chain) so the user still pays for the in-flight
+   * tokens. Acceptable for a 5-15s draft; hard cancel lands in a
+   * follow-up if it becomes a real ask.
+   *
+   * Idempotent — calling without an active draft is a no-op.
+   */
+  const cancelPullRequestBodyDraft = React.useCallback(() => {
+    const handle = pullRequestBodyCancelRef.current
+    if (!handle) return
+    handle.cancelled = true
+  }, [])
 
   // Copy an arbitrary string to the system clipboard. Distinct from
   // `yankFromActiveView` which derives the value from the current view
@@ -4003,6 +4065,8 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         cancelAiCommitDraft()
       } else if (event.type === 'startCreatePullRequest') {
         void startCreatePullRequest()
+      } else if (event.type === 'cancelPullRequestBodyDraft') {
+        cancelPullRequestBodyDraft()
       } else if (event.type === 'startChangelogView') {
         void startChangelogView()
       } else if (event.type === 'regenerateChangelog') {


### PR DESCRIPTION
## Summary

Fourth and likely final phase of #881. Same Esc cancel affordance from the compose AI draft (Phase 3), now applied to the `C` keystroke's PR body draft. When the user fires `C` and decides mid-wait they don't want a PR yet, Esc skips the follow-up input prompt and the status line reads "PR draft cancelled."

## Scope tradeoff

This is **soft cancel** — the background LLM call still completes (no `AbortSignal` threaded through the `changelogHandler` → `generateAndReviewLoop` → `executeChain` chain today). The user-visible outcome is identical to a hard cancel:

- No prompt opens.
- Status line shows the neutral cancel message.
- User can fire `C` again or move on.

The tradeoff is paying for the in-flight tokens on the discarded call. For a 5-15 second changelog draft (~$0.01-0.05), that's an acceptable cost for a ~200-LOC patch vs the deeper CLI-handler refactor a hard cancel would need.

## What you'll see

```
status: generating PR body from changelog (vs main) — Esc to cancel
```

Press Esc → prompt does NOT open. Status line:

```
status: PR draft cancelled.
```

The user can fire `C` again immediately; the next draft works exactly as before.

## Implementation

| Layer | Change |
|---|---|
| `LogInkState.pendingPullRequestBodyDraft?: boolean` | Tracks in-flight state. Gates the Esc cancel binding. |
| `setPendingPullRequestBodyDraft` reducer | Flips the flag; clears chord prefix on dispatch. |
| `cancelPullRequestBodyDraft` event + dispatch | Standard input → runtime wiring. |
| `startCreatePullRequest` | Flips flag, stashes `{cancelled}` handle in a ref, status line includes "Esc to cancel" hint. After `await`, checks the handle — if cancelled, skips prompt-open. Clears flag in `finally`. |
| `cancelPullRequestBodyDraft` runtime callback | Mutates `.cancelled = true` on the ref. Idempotent. |
| Input handler | Esc dispatches cancel when flag is set. **Not** gated on `activeView` because `C` can fire from anywhere via the palette. Compose cancel (Phase 3) takes precedence when both flags are set. |

## Deferred (for follow-ups if needed)

- **Streaming preview during the draft.** No natural surface — the user is on whatever view they were on when they pressed `C`. Compose preview pane fit inside the compose panel; PR-body has no equivalent host.
- **Hard cancel via `AbortSignal`.** Would require threading signal through `changelogHandler` → `generateAndReviewLoop` → `executeChain`. Real work; defer until users actually ask.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] 7 new tests covering: reducer flag flip, chord-prefix hygiene, Esc fires cancel when flag is set, normal Esc preserved when not set, compose-cancel precedence when both flags simultaneously active
- [x] `npm run test:jest --testPathPatterns="(inkInput|inkViewModel)"` — 443/443 pass
- [x] Broader sweep `(workstation|commands/log|commit|langchain|git)` — 1759/1759 pass
- [ ] Manual: press `C` on a feature branch, watch status line show "generating PR body — Esc to cancel". Press Esc mid-wait. Verify status reads "PR draft cancelled." and no prompt opens.
- [ ] Manual: press `C`, let the draft complete. Verify prompt opens with seeded content as before — cancel doesn't interfere with success path.
- [ ] Manual: press `C`, navigate to another view, then Esc. Verify cancel still fires (binding isn't gated on view).

## State of #881 after this PR

- ✅ Phase 1 (#1028) — `executeChainStreaming` helper
- ✅ Phase 2 (#1029) — TUI live preview behind config flag
- ✅ Phase 3 (#1031) — Esc cancel via AbortController for compose AI draft
- ✅ Phase 4 (this PR) — Esc soft cancel for PR body draft

I think this can close #881. The original issue's main use cases (commit message, PR body, review) are addressed for the streaming-meaningful ones (commit), with soft cancel for the rest. Review streaming was deferred because of the stdout contract + sort-on-complete UX wrinkles documented in earlier comments.

If you want to keep #881 open for the review work, this PR closes the phase plan but leaves the issue itself open. Let me know which you prefer.