### PR TITLE
fix(workstation): resolve 13 audit findings (streaming, persistence, input handling)

### DIFF
--- a/src/commands/commit/generateCommitDraft.ts
+++ b/src/commands/commit/generateCommitDraft.ts
@@ -351,6 +351,12 @@ export async function generateCommitDraft({
       // schema-validated retry — paying for a second LLM call only
       // on the edge case where the streamed output is unsalvageable.
       const streamingParser = createSchemaParser(schema, llm)
+      // Capture the final accumulated text out-of-band so we can
+      // attempt salvage if the parser throws on completion (audit
+      // finding #1). Updated on every chunk; the last value is
+      // whatever the stream produced before the parser ran. Empty
+      // string when streaming throws before any chunks arrived.
+      let streamedAccumulated = ''
       let salvaged: { title: string; body: string } | undefined
       try {
         // `executeChainStreaming` runs the parser on the accumulated
@@ -364,6 +370,7 @@ export async function generateCommitDraft({
           variables: budgetedPrompt.variables,
           parser: streamingParser,
           onChunk: ({ text, accumulated }) => {
+            streamedAccumulated = accumulated
             onStreamChunk(text, accumulated)
           },
           signal,
@@ -392,18 +399,32 @@ export async function generateCommitDraft({
             cancelled: true,
           }
         }
-        // Streamed accumulated text didn't parse cleanly. Try the
-        // lossy salvager on whatever we have; if that produces a
-        // non-placeholder title, accept it. Otherwise fall through
-        // to the non-streaming path which can retry with a fresh
-        // LLM call.
-        logger.verbose(
-          `Streaming attempt produced unparseable output: ${
-            streamErr instanceof Error ? streamErr.message : String(streamErr)
-          }. Falling back to non-streaming.`,
-          { color: 'yellow' }
-        )
-        salvaged = undefined
+        // Audit finding #1: try the lossy salvager on the accumulated
+        // text before paying for a second LLM call. The salvager
+        // strips code fences, attempts strict JSON parse, and falls
+        // back to "first line is title, rest is body." We only accept
+        // its output when it produced a real title — the placeholder
+        // title ("Auto-generated commit") means the salvager
+        // couldn't extract anything meaningful and the non-streaming
+        // retry is the better choice.
+        if (streamedAccumulated) {
+          const candidate = salvageCommitMessageFromText(streamedAccumulated)
+          if (candidate.title && candidate.title !== 'Auto-generated commit') {
+            salvaged = candidate
+            logger.verbose(
+              `Streaming parser failed but salvager recovered a draft from ${streamedAccumulated.length} accumulated chars; skipping non-streaming retry.`,
+              { color: 'green' },
+            )
+          }
+        }
+        if (!salvaged) {
+          logger.verbose(
+            `Streaming attempt produced unparseable output: ${
+              streamErr instanceof Error ? streamErr.message : String(streamErr)
+            }. Falling back to non-streaming.`,
+            { color: 'yellow' }
+          )
+        }
       }
       // Type-narrow: commitMsg is set inside try{}, but TS doesn't
       // see that across the catch. Re-init through the salvage path
@@ -411,10 +432,12 @@ export async function generateCommitDraft({
       if (salvaged) {
         commitMsg = salvaged
       } else if (!(commitMsg!)) {
-        // Streaming threw; do the standard non-streaming flow to
-        // recover. This is the trade-off documented in the issue —
-        // streaming gives us a preview but the validated result still
-        // comes from the schema-aware retry path when streaming fails.
+        // Streaming threw AND the salvager couldn't recover anything
+        // useful; fall back to the standard non-streaming flow.
+        // Documented trade-off from the issue: streaming gives us a
+        // preview but the validated result still comes from the
+        // schema-aware retry path when both streaming AND salvage
+        // fail.
         commitMsg = await executeChainWithSchema(schema, llm, prompt, budgetedPrompt.variables, {
           logger,
           tokenizer,

--- a/src/commands/log/commitCompose.test.ts
+++ b/src/commands/log/commitCompose.test.ts
@@ -199,5 +199,132 @@ describe('log commit compose state', () => {
       const reset = applyCommitComposeAction(seeded, { type: 'reset' })
       expect(reset.streamingPreview).toBeUndefined()
     })
+
+    it('clears the preview when setEditing(false) fires AND no draft is in flight (audit #12)', () => {
+      // Defensive: the current input pipeline never lands setEditing
+      // off while a stream is still pumping (loading=true blocks the
+      // user from toggling), but the reducer is the source of truth.
+      const seeded = applyCommitComposeAction(createCommitComposeState({ editing: true }), {
+        type: 'setStreamingPreview',
+        value: 'orphan preview',
+      })
+      const cleared = applyCommitComposeAction(seeded, { type: 'setEditing', value: false })
+      expect(cleared.streamingPreview).toBeUndefined()
+    })
+
+    it('preserves the preview when setEditing(false) fires while loading is still true', () => {
+      // The opposite invariant: streaming workflow drives loading and
+      // preview together. If editing somehow toggles off mid-stream,
+      // the preview should survive because the loader is still showing.
+      const loading = applyCommitComposeAction(createCommitComposeState({ editing: true }), {
+        type: 'setLoading',
+        value: true,
+      })
+      const seeded = applyCommitComposeAction(loading, {
+        type: 'setStreamingPreview',
+        value: 'mid-stream',
+      })
+      const cleared = applyCommitComposeAction(seeded, { type: 'setEditing', value: false })
+      expect(cleared.streamingPreview).toBe('mid-stream')
+    })
+  })
+
+  describe('pendingAiDraft confirmation (audit finding #7)', () => {
+    it('routes setDraft to pendingAiDraft when summary or body has user content', () => {
+      // Before the fix: a user mid-typing who fired the AI draft would
+      // have their work silently clobbered when the draft landed. Now
+      // the draft is staged in `pendingAiDraft` and a confirmation
+      // message appears.
+      let state = applyCommitComposeAction(createCommitComposeState(), {
+        type: 'append',
+        value: 'my partial title',
+      })
+      expect(state.summary).toBe('my partial title')
+
+      state = applyCommitComposeAction(state, {
+        type: 'setDraft',
+        value: 'feat: AI version\n\nAI generated body',
+      })
+      // User's typing is preserved.
+      expect(state.summary).toBe('my partial title')
+      expect(state.body).toBe('')
+      // AI draft is staged.
+      expect(state.pendingAiDraft).toBe('feat: AI version\n\nAI generated body')
+      // Confirmation message surfaces.
+      expect(state.message).toMatch(/Press R to replace/)
+    })
+
+    it('routes setDraft to summary/body directly when fields are empty (no clobber risk)', () => {
+      // Common path: user fires `I` without typing first; AI draft
+      // lands straight into the editable fields as before.
+      const state = applyCommitComposeAction(createCommitComposeState(), {
+        type: 'setDraft',
+        value: 'feat: from scratch\n\nbody text',
+      })
+      expect(state.summary).toBe('feat: from scratch')
+      expect(state.body).toBe('body text')
+      expect(state.pendingAiDraft).toBeUndefined()
+      expect(state.editing).toBe(true)
+    })
+
+    it('treats whitespace-only fields as empty (no false positives on the clobber guard)', () => {
+      // Spaces / newlines in the fields shouldn't trigger the
+      // confirmation flow — those are no-op typing artifacts, not
+      // meaningful content.
+      let state = applyCommitComposeAction(createCommitComposeState(), {
+        type: 'append',
+        value: '   ',
+      })
+      state = applyCommitComposeAction(state, {
+        type: 'setDraft',
+        value: 'feat: real content\n\nbody',
+      })
+      expect(state.summary).toBe('feat: real content')
+      expect(state.pendingAiDraft).toBeUndefined()
+    })
+
+    it('acceptPendingAiDraft swaps the staged draft into summary/body and clears the pending state', () => {
+      const state = applyCommitComposeAction(
+        applyCommitComposeAction(createCommitComposeState(), {
+          type: 'append',
+          value: 'user text',
+        }),
+        { type: 'setDraft', value: 'feat: AI draft\n\nAI body' }
+      )
+      expect(state.pendingAiDraft).toBeDefined()
+
+      const accepted = applyCommitComposeAction(state, { type: 'acceptPendingAiDraft' })
+      expect(accepted.summary).toBe('feat: AI draft')
+      expect(accepted.body).toBe('AI body')
+      expect(accepted.pendingAiDraft).toBeUndefined()
+      expect(accepted.message).toBeUndefined()
+      expect(accepted.editing).toBe(true)
+    })
+
+    it('dismissPendingAiDraft drops the staged draft and preserves user typing', () => {
+      const state = applyCommitComposeAction(
+        applyCommitComposeAction(createCommitComposeState(), {
+          type: 'append',
+          value: 'fix: my typing',
+        }),
+        { type: 'setDraft', value: 'feat: AI version\n\nbody' }
+      )
+      expect(state.summary).toBe('fix: my typing')
+      expect(state.pendingAiDraft).toBeDefined()
+
+      const dismissed = applyCommitComposeAction(state, { type: 'dismissPendingAiDraft' })
+      expect(dismissed.summary).toBe('fix: my typing')
+      expect(dismissed.pendingAiDraft).toBeUndefined()
+      expect(dismissed.message).toBeUndefined()
+    })
+
+    it('acceptPendingAiDraft is a no-op when no draft is staged', () => {
+      // Defensive: if the input handler somehow dispatched accept
+      // without a pending draft (race, stale event, future bug), the
+      // reducer should not throw or corrupt state.
+      const state = createCommitComposeState()
+      const after = applyCommitComposeAction(state, { type: 'acceptPendingAiDraft' })
+      expect(after).toBe(state)
+    })
   })
 })

--- a/src/commands/log/commitCompose.ts
+++ b/src/commands/log/commitCompose.ts
@@ -24,6 +24,25 @@ export type CommitComposeState = {
    * preview into the compose panel below the loading line.
    */
   streamingPreview?: string
+  /**
+   * AI draft awaiting user confirmation when the compose surface
+   * already has user-typed content (audit finding #7). Without this
+   * guard, `setDraft` silently overwrote whatever the user had been
+   * typing in summary / body, losing their work with no undo. The
+   * dispatcher checks for existing content and routes the AI result
+   * here instead of straight to `summary` / `body` when the user
+   * would be clobbered.
+   *
+   * The user accepts via `R` (replace) which swaps the draft into the
+   * editable fields and clears this state, or dismisses via `Esc`
+   * which drops the pending draft and keeps the original typing.
+   *
+   * Holds the full unparsed draft string (summary + body joined with
+   * `\n\n`); `splitCommitDraft` runs at acceptance time so the same
+   * helper produces the fields whether the user accepted immediately
+   * or after deliberation.
+   */
+  pendingAiDraft?: string
 }
 
 export type CommitComposeAction =
@@ -37,6 +56,9 @@ export type CommitComposeAction =
   | { type: 'setDraft'; value: string }
   | { type: 'setResult'; message?: string; details?: string[] }
   | { type: 'setStreamingPreview'; value: string | undefined }
+  | { type: 'setPendingAiDraft'; value: string }
+  | { type: 'acceptPendingAiDraft' }
+  | { type: 'dismissPendingAiDraft' }
   | { type: 'reset' }
 
 export type ManualCommitResult = {
@@ -99,9 +121,16 @@ export function applyCommitComposeAction(
         field: state.field === 'summary' ? 'body' : 'summary',
       }
     case 'setEditing':
+      // Audit finding #12: defensively clear `streamingPreview` when
+      // editing toggles off AND no draft is in flight. The current
+      // input pipeline never triggers this combination, but the
+      // reducer is the source of truth — if a future code path
+      // toggles editing off mid-stream, the preview shouldn't linger
+      // below an idle compose panel.
       return {
         ...state,
         editing: action.value,
+        streamingPreview: !action.value && !state.loading ? undefined : state.streamingPreview,
       }
     case 'setLoading':
       // Clearing loading also clears any in-flight streaming preview;
@@ -113,6 +142,23 @@ export function applyCommitComposeAction(
         streamingPreview: action.value ? state.streamingPreview : undefined,
       }
     case 'setDraft':
+      // Audit finding #7: if the user has typed content in summary or
+      // body, the AI draft would silently clobber their work with no
+      // undo. Route the result to `pendingAiDraft` instead and surface
+      // a confirmation message; the user accepts with `R` (replace)
+      // or dismisses with Esc. Empty fields = safe to replace as
+      // before, since there's nothing to lose.
+      if (state.summary.trim() || state.body.trim()) {
+        return {
+          ...state,
+          loading: false,
+          streamingPreview: undefined,
+          pendingAiDraft: action.value,
+          message:
+            'AI draft ready. Press R to replace your text, or Esc to keep what you have.',
+          details: undefined,
+        }
+      }
       // No `message` here — the loader → filled fields are the confirmation
       // that the AI generated something. A lingering "AI draft ready for
       // editing" line in the panel reads as stale state. The runtime still
@@ -127,6 +173,7 @@ export function applyCommitComposeAction(
         message: undefined,
         details: undefined,
         streamingPreview: undefined,
+        pendingAiDraft: undefined,
       }
     case 'setResult':
       return {
@@ -145,6 +192,45 @@ export function applyCommitComposeAction(
       return {
         ...state,
         streamingPreview: action.value,
+      }
+    case 'setPendingAiDraft':
+      // Audit finding #7: route the AI draft here (instead of straight
+      // to summary/body via `setDraft`) when the user has unsaved
+      // typing the draft would clobber. The dispatcher does the
+      // user-content check; this reducer just stashes the draft and
+      // surfaces a message inviting the user to accept or dismiss.
+      return {
+        ...state,
+        loading: false,
+        streamingPreview: undefined,
+        pendingAiDraft: action.value,
+        message: 'AI draft ready. Press R to replace your text, or Esc to keep what you have.',
+        details: undefined,
+      }
+    case 'acceptPendingAiDraft':
+      // Swap the pending draft into the editable fields and clear it.
+      // Mirrors `setDraft`'s field positioning (focus on summary,
+      // editing on) so the user lands in the same place whether they
+      // accepted immediately or after deliberation.
+      if (!state.pendingAiDraft) return state
+      return {
+        ...state,
+        ...splitCommitDraft(state.pendingAiDraft),
+        field: 'summary',
+        editing: true,
+        loading: false,
+        message: undefined,
+        details: undefined,
+        streamingPreview: undefined,
+        pendingAiDraft: undefined,
+      }
+    case 'dismissPendingAiDraft':
+      // User chose to keep their typing; drop the AI draft.
+      return {
+        ...state,
+        pendingAiDraft: undefined,
+        message: undefined,
+        details: undefined,
       }
     case 'reset':
       // Drop message/details too — the post-commit "Created commit ..."

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -2010,21 +2010,25 @@ describe('log Ink input interactions', () => {
       expect(events).not.toContainEqual({ type: 'cancelAiCommitDraft' })
     })
 
-    it('does not fire cancelAiCommitDraft from views other than compose', () => {
-      // Defensive: even if `commitCompose.loading` is true (it
-      // shouldn't normally be while the user navigated away, but
-      // it's recoverable state), Esc on a different surface should
-      // do its surface-local thing, not steal the cancel keystroke.
+    it('fires cancelAiCommitDraft from any view while loading is true (audit finding #5)', () => {
+      // The original Phase 3 implementation gated cancel on
+      // `activeView === 'compose'`, which made the keystroke
+      // unreachable after chord-navigation away from compose
+      // mid-stream. The audit caught this: user starts AI draft on
+      // compose, presses `g h` to glance at history while waiting,
+      // realizes they want to bail — Esc should still cancel even
+      // though they're not on compose anymore. The fix drops the
+      // activeView gate; this test pins the new behaviour.
       let state = createLogInkState(rows)
       state = applyLogInkAction(state, {
         type: 'commitCompose',
         action: { type: 'setLoading', value: true },
       })
-      // Stay on history view.
+      // Stay on history view (not compose).
       expect(state.activeView).toBe('history')
 
       const events = getLogInkInputEvents(state, '', { escape: true })
-      expect(events).not.toContainEqual({ type: 'cancelAiCommitDraft' })
+      expect(events).toEqual([{ type: 'cancelAiCommitDraft' }])
     })
   })
 
@@ -2055,17 +2059,21 @@ describe('log Ink input interactions', () => {
       expect(events).not.toContainEqual({ type: 'cancelPullRequestBodyDraft' })
     })
 
-    it('takes precedence over the compose-cancel binding when both could match', () => {
+    it('compose cancel takes precedence over PR-body cancel when both could match', () => {
       // Edge case: both `pendingPullRequestBodyDraft` AND
       // `commitCompose.loading` are true simultaneously (unusual but
       // recoverable state). The compose handler sits above PR-body
       // in the input pipeline, so compose cancel wins. Document the
       // precedence here so a future reorder doesn't silently swap it.
+      //
+      // Note: after audit finding #5, neither binding is gated on
+      // `activeView`, so the active view is irrelevant to the
+      // precedence — the order of handlers in the input pipeline
+      // is the only thing that matters.
       let state = applyLogInkAction(createLogInkState(rows), {
         type: 'setPendingPullRequestBodyDraft',
         value: true,
       })
-      state = applyLogInkAction(state, { type: 'pushView', value: 'compose' })
       state = applyLogInkAction(state, {
         type: 'commitCompose',
         action: { type: 'setLoading', value: true },

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -925,16 +925,24 @@ export function getLogInkInputEvents(
   }
 
   // Cancel in-flight AI commit draft (#881 phase 3). When the compose
-  // surface is mid-stream (loading === true), Esc aborts the LLM call
-  // and the runtime handler cleans up (clear loading, clear preview,
-  // status line shows "AI draft cancelled."). Sits above the editing
-  // / view handlers so the cancel keystroke can't fall through to
-  // "leave compose" or anything else.
+  // state has a draft in flight (loading === true), Esc aborts the
+  // LLM call and the runtime handler cleans up (clear loading, clear
+  // preview, status line shows "AI draft cancelled.").
   //
-  // Loading and editing are mutually exclusive in practice (the user
-  // can't type while the AI is generating), but the order here makes
-  // the precedence explicit if that ever changes.
-  if (state.activeView === 'compose' && state.commitCompose.loading && key.escape) {
+  // Audit finding #5: the `activeView === 'compose'` gate from the
+  // original phase 3 implementation made the cancel keystroke
+  // unreachable after the user chord-navigated away from compose
+  // mid-stream (Esc would fall through to popView etc., consuming
+  // the navigation intent while the LLM call silently ran to
+  // completion). Cancel should work wherever the user is — they
+  // can always navigate back to compose afterwards.
+  //
+  // Sits above the editing / view handlers so the cancel keystroke
+  // can't fall through to "leave compose" or anything else. Loading
+  // and editing are mutually exclusive in practice (the user can't
+  // type while the AI is generating), but the order here makes the
+  // precedence explicit if that ever changes.
+  if (state.commitCompose.loading && key.escape) {
     return [{ type: 'cancelAiCommitDraft' }]
   }
 
@@ -954,6 +962,28 @@ export function getLogInkInputEvents(
   // they decide to bail.
   if (state.pendingPullRequestBodyDraft && key.escape) {
     return [{ type: 'cancelPullRequestBodyDraft' }]
+  }
+
+  // Pending AI draft confirmation (audit finding #7). When the AI
+  // draft completes against a non-empty compose surface, it lands in
+  // `pendingAiDraft` instead of overwriting the user's typing. `R`
+  // accepts the swap (user's typing is lost, AI draft becomes the
+  // new content). `Esc` dismisses the AI draft (typing is preserved,
+  // AI draft is lost — the user paid for the tokens but explicitly
+  // chose not to use them).
+  //
+  // Gated on `activeView === 'compose'` because the pending draft is
+  // only meaningful on the compose surface (where the message line
+  // surfaces the prompt). A user who chord-navigated away while the
+  // draft was pending should see the original `R` / Esc semantics of
+  // wherever they are now.
+  if (state.activeView === 'compose' && state.commitCompose.pendingAiDraft) {
+    if (inputValue === 'R' && !key.ctrl && !key.meta) {
+      return [action({ type: 'commitCompose', action: { type: 'acceptPendingAiDraft' } })]
+    }
+    if (key.escape) {
+      return [action({ type: 'commitCompose', action: { type: 'dismissPendingAiDraft' } })]
+    }
   }
 
   if (state.commitCompose.editing) {

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -1391,16 +1391,19 @@ describe('log Ink view model', () => {
   })
 
   describe('recent-commit markers', () => {
-    it('markRecentCommits records the hash list with a timestamp', () => {
-      const before = Date.now()
+    it('markRecentCommits records the hash list with the action-supplied timestamp', () => {
+      // Audit finding #9: `markedAt` is now part of the action payload
+      // so the reducer stays pure. The dispatcher (in app.ts) calls
+      // `Date.now()` and passes the result; the reducer just stores it.
       let state = createLogInkState(rows)
       state = applyLogInkAction(state, {
         type: 'markRecentCommits',
         hashes: ['abc123', 'def456'],
+        markedAt: 1234567890,
       })
 
       expect(state.recentCommitHashes?.hashes).toEqual(['abc123', 'def456'])
-      expect(state.recentCommitHashes?.markedAt).toBeGreaterThanOrEqual(before)
+      expect(state.recentCommitHashes?.markedAt).toBe(1234567890)
     })
 
     it('markRecentCommits with empty list closes the marker', () => {
@@ -1411,8 +1414,9 @@ describe('log Ink view model', () => {
       state = applyLogInkAction(state, {
         type: 'markRecentCommits',
         hashes: ['abc123'],
+        markedAt: 1,
       })
-      state = applyLogInkAction(state, { type: 'markRecentCommits', hashes: [] })
+      state = applyLogInkAction(state, { type: 'markRecentCommits', hashes: [], markedAt: 2 })
       expect(state.recentCommitHashes).toBeUndefined()
     })
 
@@ -1421,6 +1425,7 @@ describe('log Ink view model', () => {
       state = applyLogInkAction(state, {
         type: 'markRecentCommits',
         hashes: ['abc123'],
+        markedAt: 1,
       })
       state = applyLogInkAction(state, { type: 'clearRecentCommits' })
       expect(state.recentCommitHashes).toBeUndefined()
@@ -1434,10 +1439,12 @@ describe('log Ink view model', () => {
       state = applyLogInkAction(state, {
         type: 'markRecentCommits',
         hashes: ['old1', 'old2'],
+        markedAt: 1,
       })
       state = applyLogInkAction(state, {
         type: 'markRecentCommits',
         hashes: ['new1'],
+        markedAt: 2,
       })
 
       expect(state.recentCommitHashes?.hashes).toEqual(['new1'])

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -752,12 +752,12 @@ export type LogInkAction =
   | { type: 'toggleDiffViewMode' }
   | { type: 'setDiffViewMode'; value: LogInkDiffViewMode }
   | { type: 'setChangelogLoading'; branch: string; baseLabel: string }
-  | { type: 'setChangelogReady'; branch: string; baseLabel: string; text: string }
+  | { type: 'setChangelogReady'; branch: string; baseLabel: string; text: string; generatedAt: number }
   | { type: 'setChangelogError'; branch: string; baseLabel: string; error: string }
-  | { type: 'setChangelogText'; text: string }
+  | { type: 'setChangelogText'; text: string; generatedAt: number }
   | { type: 'pageChangelog'; delta: number; lineCount: number }
   | { type: 'clearChangelogCache'; branch?: string }
-  | { type: 'markRecentCommits'; hashes: string[] }
+  | { type: 'markRecentCommits'; hashes: string[]; markedAt: number }
   | { type: 'clearRecentCommits' }
   | { type: 'startSplitPlanLoad' }
   | {
@@ -2050,10 +2050,14 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       // Cache the result so re-entry (or `c` to PR) reuses it instead of
       // re-running the LLM. Keyed by branch so a checkout naturally
       // produces a fresh generation.
+      // Audit finding #9: `generatedAt` arrives on the action payload
+      // instead of being read from `Date.now()` here, so the reducer
+      // stays pure. Dispatchers (currently `runChangelogView` in
+      // app.ts) call `Date.now()` at dispatch time.
       const cached: ChangelogCacheEntry = {
         text: action.text,
         baseLabel: action.baseLabel,
-        generatedAt: Date.now(),
+        generatedAt: action.generatedAt,
       }
       return {
         ...state,
@@ -2107,7 +2111,8 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
             // Updated-at timestamp reflects the edit. Not the original
             // generation time — `r` (regenerate) is the explicit knob
             // for "I want fresh LLM output, not my edits".
-            generatedAt: Date.now(),
+            // Audit finding #9: timestamp arrives on the action.
+            generatedAt: action.generatedAt,
           },
         },
         pendingKey: undefined,
@@ -2146,7 +2151,9 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       }
       return {
         ...state,
-        recentCommitHashes: { hashes: action.hashes, markedAt: Date.now() },
+        // Audit finding #9: timestamp arrives on the action payload
+        // instead of being read from `Date.now()` here.
+        recentCommitHashes: { hashes: action.hashes, markedAt: action.markedAt },
         pendingKey: undefined,
       }
     case 'clearRecentCommits':

--- a/src/lib/langchain/utils/executeChainStreaming.test.ts
+++ b/src/lib/langchain/utils/executeChainStreaming.test.ts
@@ -98,15 +98,19 @@ describe('executeChainStreaming', () => {
     expect(runningSum).toBe('abc')
   })
 
-  it('swallows handler errors so a bad render handler cannot tank the LLM call', async () => {
-    // A render handler that throws on every chunk used to mean the
-    // user paid for the LLM call and got nothing back; the helper now
-    // catches each callback error and keeps consuming the stream.
+  it('swallows transient handler errors (single failure) so the LLM call still resolves', async () => {
+    // A render handler that throws intermittently shouldn't tank the
+    // user's LLM call. The helper catches each callback error and
+    // keeps consuming the stream as long as failures aren't
+    // consecutive past the bail threshold (audit finding #13).
     const llm = new FakeListChatModel({ responses: ['hello'] })
     let invocations = 0
     const onChunk = () => {
       invocations += 1
-      throw new Error('handler exploded')
+      // Throw only on the first chunk — subsequent chunks succeed.
+      if (invocations === 1) {
+        throw new Error('transient handler blip')
+      }
     }
 
     const result = await executeChainStreaming<string>({
@@ -118,10 +122,67 @@ describe('executeChainStreaming', () => {
       logger: silentLogger(),
     })
 
-    expect(invocations).toBeGreaterThan(0)
-    // Despite the handler throwing, the call resolves with the
-    // fully-accumulated parsed result.
+    expect(invocations).toBeGreaterThan(1)
+    // Despite the first chunk's handler throwing, the call resolves
+    // with the fully-accumulated parsed result.
     expect(result).toBe('hello')
+  })
+
+  it('bails the stream after 5 consecutive callback failures (audit finding #13)', async () => {
+    // A genuinely broken render handler (one that throws on every
+    // chunk) used to silently log to verbose for the entire LLM call,
+    // wasting the user's wait. The bail threshold ensures the failure
+    // surfaces as a thrown LangChainExecutionError after MAX_CALLBACK_FAILURES
+    // consecutive throws.
+    const llm = new FakeListChatModel({ responses: ['hello world this is a longer response'] })
+    let invocations = 0
+    const onChunk = () => {
+      invocations += 1
+      throw new Error('handler is completely broken')
+    }
+
+    await expect(
+      executeChainStreaming<string>({
+        llm: asLlm(llm),
+        prompt,
+        variables,
+        parser: new StringOutputParser(),
+        onChunk,
+        logger: silentLogger(),
+      }),
+    ).rejects.toThrow(/render handler failed 5 times in a row/)
+    // Bail kicks in at the threshold so we don't burn through the
+    // whole stream. The fake emits character-by-character; 5+ throws
+    // happen well before the response ends.
+    expect(invocations).toBeGreaterThanOrEqual(5)
+  })
+
+  it('resets the consecutive-failure counter on a successful callback (audit finding #13)', async () => {
+    // The bail counts CONSECUTIVE failures. A handler that fails,
+    // succeeds, fails again should not trigger the bail because the
+    // failure streak got broken. Otherwise a flaky-but-mostly-working
+    // handler would bail spuriously.
+    const llm = new FakeListChatModel({ responses: ['abcdefghij'] })
+    let invocations = 0
+    const onChunk = () => {
+      invocations += 1
+      // Throw on odd invocations only; even ones succeed. Pattern
+      // alternates so the streak never reaches 5.
+      if (invocations % 2 === 1) {
+        throw new Error('intermittent failure')
+      }
+    }
+
+    const result = await executeChainStreaming<string>({
+      llm: asLlm(llm),
+      prompt,
+      variables,
+      parser: new StringOutputParser(),
+      onChunk,
+      logger: silentLogger(),
+    })
+
+    expect(result).toBe('abcdefghij')
   })
 
   it('throws LangChainExecutionError when the stream completes with no text chunks', async () => {

--- a/src/lib/langchain/utils/executeChainStreaming.ts
+++ b/src/lib/langchain/utils/executeChainStreaming.ts
@@ -222,6 +222,14 @@ export async function executeChainStreaming<T>({
     const stream = await chain.stream(variables, signal ? { signal } : undefined)
 
     let chunkCount = 0
+    let callbackFailureCount = 0
+    // Audit finding #13: cap consecutive callback failures so a
+    // genuinely broken render handler can't tie up the LLM call
+    // silently for the user's entire wait. Five strikes (out of an
+    // expected ~50-500 chunks for a normal commit message) is enough
+    // to ride out a transient blip but small enough to bail before
+    // the user finishes waiting on a useless stream.
+    const MAX_CALLBACK_FAILURES = 5
     for await (const messageChunk of stream) {
       const text = coerceChunkText(messageChunk)
       if (!text) continue
@@ -229,16 +237,30 @@ export async function executeChainStreaming<T>({
       chunkCount += 1
       try {
         onChunk({ text, accumulated })
+        // Successful callback resets the consecutive-failure counter —
+        // we only bail on a STREAK of failures, not on isolated ones.
+        callbackFailureCount = 0
       } catch (callbackError) {
         // Deliberately swallow callback errors so a bad render handler
         // can't tank the entire LLM call. Log at verbose so users with
         // verbose mode on can still see what happened.
+        callbackFailureCount += 1
         logger?.verbose(
-          `executeChainStreaming: onChunk handler threw: ${
+          `executeChainStreaming: onChunk handler threw (${callbackFailureCount}/${MAX_CALLBACK_FAILURES}): ${
             callbackError instanceof Error ? callbackError.message : String(callbackError)
           }`,
           { color: 'yellow' },
         )
+        if (callbackFailureCount >= MAX_CALLBACK_FAILURES) {
+          logger?.verbose(
+            `executeChainStreaming: bailing stream — ${MAX_CALLBACK_FAILURES} consecutive callback failures suggest a broken render handler.`,
+            { color: 'red' },
+          )
+          throw new LangChainExecutionError(
+            `executeChainStreaming: render handler failed ${MAX_CALLBACK_FAILURES} times in a row; aborting stream so the failure surfaces to the caller.`,
+            { accumulatedLength: accumulated.length, chunkCount },
+          )
+        }
       }
     }
 
@@ -282,16 +304,23 @@ export async function executeChainStreaming<T>({
     return result
   } catch (error) {
     // Cancellation classifier (#881 phase 3). Three signals: an
-    // explicitly aborted user signal (post-throw check), the
-    // standard DOM `AbortError`, or a Node `AbortSignal` with
-    // `signal.aborted === true` while a chain-internal error
-    // propagates. Any of these means "user wanted out," not "the
-    // call failed." Wrap the raw error so callers can pattern-match
-    // on `LangChainCancelledError` and carry the partial accumulated
-    // text in case the caller wants to salvage anything.
+    // explicitly aborted user signal (post-throw check) or a thrown
+    // `AbortError` from the standard DOM API. Either means "user
+    // wanted out," not "the call failed." Wrap the raw error so
+    // callers can pattern-match on `LangChainCancelledError` and
+    // carry the partial accumulated text in case the caller wants
+    // to salvage anything.
+    //
+    // Audit finding #8: an earlier implementation also fell back to
+    // `error.message.includes('aborted')` as a third signal. That
+    // substring heuristic is footgun-shaped — legitimate provider
+    // errors ("model not aborted properly", future API copy) would
+    // misclassify as user cancels. Dropped; rely on the structured
+    // signal (`signal.aborted`) and the standard error class
+    // (`name === 'AbortError'`).
     const aborted =
       signal?.aborted ||
-      (error instanceof Error && (error.name === 'AbortError' || error.message?.includes('aborted')))
+      (error instanceof Error && error.name === 'AbortError')
     if (aborted) {
       throw new LangChainCancelledError(
         error instanceof Error ? error.message : 'Streaming aborted by user',

--- a/src/workstation/README.md
+++ b/src/workstation/README.md
@@ -111,10 +111,22 @@ Ink                ← reconciles to terminal
 
 A few invariants worth knowing before changing any of those modules:
 
-- **The reducer is pure.** `applyLogInkAction(state, action)` never throws, never reads the file system, never calls git. Side effects belong in workflows.
+- **The reducer is pure.** `applyLogInkAction(state, action)` never throws, never reads the file system, never calls git, never calls `Date.now()`. Side effects (and time, treated as a side effect) belong in workflows; timestamps arrive on action payloads.
 - **Workflows return actions.** A workflow that succeeds dispatches a `LogInkAction` via the runtime; failures dispatch a status-message action. The reducer is the only place state changes.
 - **Confirmation gating is data, not control flow.** Workflows declare `requiresConfirmation: 'y' | 'enter'` in `inkWorkflows.ts`; the runtime intercepts and routes through the y-confirm overlay.
 - **Re-renders are cheap.** Ink reconciles the React tree on every state change; render helpers are pure functions of `(state, theme, layout)`.
+
+## Async LLM calls + cancellation (#881)
+
+LLM-driven workflows have their own conventions because they live across several boundaries (workstation → `src/git/` workflow → `src/lib/langchain/` → provider API) and the user can change their mind mid-call.
+
+- **Streaming is opt-in.** Wire calls through `executeChainStreaming` (sibling of `executeChain`) when the surface has a place to render a live preview. Gated by `service.streaming.enabled` (default `false`). The streaming function returns the final parsed value just like `executeChain`; the only difference is the `onChunk` callback that fires per text fragment.
+- **Cancel via `AbortController`.** The runtime callback that owns an LLM call creates a controller per invocation and stashes it in a ref (`aiDraftAbortRef`, etc.). The input handler's cancel binding reads the ref synchronously and calls `controller.abort()`. The signal threads through the workflow to `executeChainStreaming` which forwards it into `chain.stream(input, { signal })`. The HTTP transport tears down cleanly.
+- **Cancel is a structured result, not an error.** When the signal aborts mid-stream, `executeChainStreaming` throws `LangChainCancelledError` (distinct class so callers can pattern-match). The wrapping workflow (e.g. `runCommitDraftWorkflow`) catches and translates to `{ ok: false, cancelled: true, message: 'AI draft cancelled.' }`. The runtime treats `cancelled` separately from `ok: false` failures — no error styling, no retry, just clean up the spinner and preview.
+- **Streaming preview is preview-only.** The final draft goes through the same parser / schema validator / commitlint retry as the non-streaming path. The `onChunk` callback feeds a chrome formatter (`chrome/streamingPreview.ts`) that produces last-N-lines view; the surface renders it below the loader. When the call settles, the preview clears and the validated final draft lands in the editable fields.
+- **Stdout commands stay non-streaming.** `coco commit --mode stdout` and `coco review` (CLI) have output contracts that pipes, hooks, and CI scripts depend on. Don't add streaming there.
+- **Cancel keystrokes are not view-gated.** The user might chord-navigate away during a long LLM call; Esc cancel must work from any view while the loading flag is set. This was an audit finding (#5) — keep it in mind when adding new cancel bindings.
+- **`pendingAiDraft` confirmation flow.** If the user has typed content in the compose surface and then fires an AI draft, the draft stages in `commitCompose.pendingAiDraft` rather than replacing their typing. `R` accepts (typing → AI draft), `Esc` dismisses (typing preserved). This was audit finding #7; the routing happens inside the `setDraft` reducer based on whether `summary` or `body` has non-whitespace content.
 
 ## Nested-repo navigation (#931)
 

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -584,6 +584,14 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // workdirs for submodule paths recorded in `.gitmodules` (which
   // are repo-relative). Undefined during the brief moment between
   // git swap and the revparse callback resolving.
+  //
+  // Audit finding #10: rapid frame push/pop races are prevented by
+  // the per-effect `cancelled` flag — React fires the cleanup
+  // synchronously BEFORE running the next effect body, so any
+  // pending revparse from the old `git` sees `cancelled === true`
+  // and skips its write. The `git` reference itself is captured by
+  // closure, so each effect run resolves against the right binding.
+  // No additional depth tagging is needed.
   const [activeRepoRoot, setActiveRepoRoot] = React.useState<string | undefined>(undefined)
   React.useEffect(() => {
     let cancelled = false
@@ -1065,17 +1073,47 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     return () => { cancelled = true }
   }, [git, dispatch])
 
+  // Audit finding #2: re-resolve the repo root inline on every save
+  // and key the deps off `git` + the saved value. The original
+  // implementation read from `repoRootRef.current`, which is async-
+  // populated by the resolver effect above and can lag behind a git
+  // swap. After #995's synchronous pop-restore, the parent's freshly
+  // restored sidebar tab was being written into the submodule's
+  // cache because the ref still held the submodule root during the
+  // brief window before the resolver settled.
+  //
+  // The extra `revparse` cost per save is negligible (saves fire
+  // once per user-initiated tab change, not per render) and the
+  // cancellation flag prevents a stale resolution from racing a
+  // newer one in flight.
   React.useEffect(() => {
-    const repoRoot = repoRootRef.current
-    if (!repoRoot) return
-    saveSidebarTab(repoRoot, state.userSidebarTab)
-  }, [state.userSidebarTab])
+    let cancelled = false
+    void (async () => {
+      try {
+        const root = (await git.revparse(['--show-toplevel'])).trim()
+        if (cancelled || !root) return
+        saveSidebarTab(root, state.userSidebarTab)
+      } catch {
+        // Not in a worktree, or revparse failed — silently skip.
+        // The next save attempt will retry.
+      }
+    })()
+    return () => { cancelled = true }
+  }, [state.userSidebarTab, git])
 
   React.useEffect(() => {
-    const repoRoot = repoRootRef.current
-    if (!repoRoot) return
-    saveDiffViewMode(repoRoot, state.diffViewMode)
-  }, [state.diffViewMode])
+    let cancelled = false
+    void (async () => {
+      try {
+        const root = (await git.revparse(['--show-toplevel'])).trim()
+        if (cancelled || !root) return
+        saveDiffViewMode(root, state.diffViewMode)
+      } catch {
+        // Same as above.
+      }
+    })()
+    return () => { cancelled = true }
+  }, [state.diffViewMode, git])
 
   // P-stash-explorer: load `git stash show -p <ref>` once the diff view
   // becomes active with diffSource='stash'. Best-effort — empty stashes
@@ -1804,6 +1842,11 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         git,
         signal: controller.signal,
         onStreamChunk: (_text, accumulated) => {
+          // Audit finding #4: skip dispatching into a torn-down
+          // tree. If the user quit (or otherwise unmounted the
+          // workstation) mid-stream, React warns about updates on
+          // an unmounted component. Drop the chunk silently.
+          if (!mountedRef.current) return
           // Dispatch the full accumulated text — the preview chrome
           // helper does the last-N-lines slicing at render time, so
           // re-doing the slice here would be wasted work. Per-chunk
@@ -1815,6 +1858,11 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
           })
         },
       })
+
+      // Audit finding #4 (unmount race): bail out before any
+      // post-await dispatch if the user quit while the LLM call was
+      // in flight. Same pattern as `refreshHistoryRows` upstream.
+      if (!mountedRef.current) return
 
       // Cancel path (#881 phase 3). User pressed Esc during the
       // stream; reducer drops loading + preview, status line shows
@@ -1837,6 +1885,24 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         action: { type: 'setResult', message: result.message, details: result.details },
       })
       dispatch({ type: 'setStatus', value: result.message })
+    } catch (error) {
+      // Audit finding #3: defensive recovery for unexpected throws
+      // from the workflow. The workflow catches its own errors
+      // today, so this catch is latent — but any future refactor
+      // that lets an error escape would otherwise strand the
+      // spinner permanently with no user-facing recovery short of
+      // quitting. Surface a generic failure and clear the loading
+      // state so the user can re-try.
+      if (mountedRef.current) {
+        dispatch({ type: 'commitCompose', action: { type: 'setLoading', value: false } })
+        dispatch({
+          type: 'setStatus',
+          value: `AI draft failed unexpectedly: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          kind: 'error',
+        })
+      }
     } finally {
       // Clear the ref only if it still points at OUR controller — a
       // rapid second invocation could have already replaced it, in
@@ -1932,9 +1998,14 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     pullRequestBodyCancelRef.current = cancelHandle
 
     dispatch({ type: 'setPendingPullRequestBodyDraft', value: true })
+    // Audit finding #6: soft cancel today — Esc skips opening the
+    // follow-up prompt, but the LLM call itself keeps running to
+    // completion (no AbortSignal threaded through the changelog CLI
+    // chain). Status copy reflects that honestly so the user isn't
+    // misled into thinking they're saving tokens.
     dispatch({
       type: 'setStatus',
-      value: `generating PR body from changelog (vs ${defaultBranch}) — Esc to cancel`,
+      value: `generating PR body from changelog (vs ${defaultBranch}) — Esc to skip prompt`,
       loading: true,
     })
 
@@ -1965,6 +2036,16 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         dispatch({ type: 'setStatus', value: 'PR body drafted — review and Ctrl+D to submit.' })
       }
 
+      // Audit finding #11: clear the pending flag BEFORE opening the
+      // prompt. If a future refactor adds an `await` between the flag
+      // clear (currently in `finally`) and the `openInputPrompt`
+      // dispatch, an Esc keystroke in the gap would dispatch
+      // `cancelPullRequestBodyDraft` AFTER the prompt opens, leaving
+      // the prompt visible with a stale "cancelled" message. Clearing
+      // here moves the flag teardown into the same React batch as the
+      // prompt open, eliminating the race.
+      dispatch({ type: 'setPendingPullRequestBodyDraft', value: false })
+
       dispatch({
         type: 'openInputPrompt',
         kind: 'create-pr',
@@ -1973,11 +2054,14 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         multiline: true,
       })
     } finally {
-      // Clear the flag + the ref so a subsequent draft starts clean.
+      // Belt-and-suspenders: the `try` block clears the flag on the
+      // success path (audit finding #11). This duplicate clear handles
+      // the error / cancel paths where the early-returns skip the
+      // success-path dispatch. Safe to no-op when already false.
+      dispatch({ type: 'setPendingPullRequestBodyDraft', value: false })
       // Only clear the ref if we still own it — a second invocation
       // would have already taken ownership in which case the cancel
       // duty has rolled over.
-      dispatch({ type: 'setPendingPullRequestBodyDraft', value: false })
       if (pullRequestBodyCancelRef.current === cancelHandle) {
         pullRequestBodyCancelRef.current = null
       }
@@ -2080,6 +2164,11 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         branch: head,
         baseLabel: cached.baseLabel,
         text: cached.text,
+        // Audit finding #9: cache-hit path preserves the original
+        // generation timestamp rather than minting a fresh one — the
+        // "X ago" header should reflect when the LLM ran, not when
+        // the cached entry was re-displayed.
+        generatedAt: cached.generatedAt,
       })
       dispatch({
         type: 'setStatus',
@@ -2112,6 +2201,9 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       branch: head,
       baseLabel,
       text: result.text,
+      // Audit finding #9: timestamp captured at dispatch time, not
+      // inside the reducer.
+      generatedAt: Date.now(),
     })
     dispatch({
       type: 'setStatus',
@@ -2212,7 +2304,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     if (editorOk) {
       try {
         const content = readFileSync(file, 'utf8')
-        dispatch({ type: 'setChangelogText', text: content })
+        dispatch({ type: 'setChangelogText', text: content, generatedAt: Date.now() })
         dispatch({ type: 'setStatus', value: 'Changelog updated from editor.' })
       } catch (error) {
         dispatch({
@@ -2572,7 +2664,8 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     // that could disagree with reality on partial-apply.
     const commitHashes = result.commitHashes || []
     if (commitHashes.length > 0) {
-      dispatch({ type: 'markRecentCommits', hashes: commitHashes })
+      // Audit finding #9: timestamp captured at dispatch time.
+      dispatch({ type: 'markRecentCommits', hashes: commitHashes, markedAt: Date.now() })
       // DevSkim: ignore DS172411 — function literal, fixed delay,
       // no caller-supplied data flowing through.
       setTimeout(() => dispatch({ type: 'clearRecentCommits' }), 5000)


### PR DESCRIPTION
## Summary

Post-0.54 audit of the workstation surfaced a mix of real bugs, latent risks, and hygiene cleanups. All 13 findings land in this single coordinated PR — splitting them would have meant a stack of interdependent branches with overlapping test churn, and the changes ride well together.

## HIGH-priority bugs

| # | Where | What it was | Fix |
|---|---|---|---|
| 1 | `generateCommitDraft.ts` | Dead `salvaged` branch — Phase 2 never assigned it, so every parse-failed stream paid for a second LLM call when the accumulated text was perfectly recoverable | Capture streamed text out-of-band, run `salvageCommitMessageFromText` on it, accept when non-placeholder |
| 2 | `app.ts:1068-1078` | Save effects' deps missing `git` — after #995's pop-restore, parent's restored tab got written into submodule's cache during the resolver's settle window | Re-resolve root inline per save with proper cancellation; deps include `git` |
| 5 | `inkInput.ts:937` | `cancelAiCommitDraft` Esc gated on `activeView === 'compose'` — user chord-navs away mid-stream, Esc falls through to popView instead of cancelling | Dropped the gate; cancel works from any view while loading |

## MEDIUM defensive fixes

- **#3** — `runAiCommitDraft` catch block clears loading + surfaces error status on unexpected throws
- **#4** — Three `mountedRef.current` guards added so unmount-during-stream doesn't dispatch into a torn-down tree
- **#6** — Soft-cancel status reworded from "Esc to cancel" to "Esc to skip prompt" (background LLM call still completes — be honest about it)
- **#8** — `executeChainStreaming` cancel classifier no longer uses the `.includes('aborted')` substring heuristic; relies on `signal?.aborted` + `error.name === 'AbortError'` only

## UX + hygiene

- **#7** — `setDraft` clobber guard: when summary or body has user content, the AI draft stages in new `pendingAiDraft` state and surfaces "Press R to replace / Esc to keep what you have." New `acceptPendingAiDraft` / `dismissPendingAiDraft` actions + input bindings (`R` / Esc gated on `activeView === 'compose'` + pending draft)
- **#9** — `setChangelogReady`, `setChangelogText`, `markRecentCommits` now carry timestamps on action payload (no more `Date.now()` inside the reducer)
- **#10** — Investigated; existing `cancelled` flag is the correct safety mechanism. Added a clarifying comment; no code change
- **#11** — `pendingPullRequestBodyDraft` flag clear moved to BEFORE `openInputPrompt` in the success path so no future-added await can race a cancel
- **#12** — `streamingPreview` defensive clear on `setEditing(false)` when no draft is in flight
- **#13** — `onChunk` callback failure counter; bail with `LangChainExecutionError` after 5 consecutive throws (transient blips reset the counter)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] 14 new tests covering the new behaviour:
  - 6 for `pendingAiDraft` accept / dismiss / clobber-routing
  - 2 for `streamingPreview` defensive clear on `setEditing`
  - 3 for `onChunk` failure counter (transient / bail / streak reset)
  - 1 updated for #5 (Esc cancel from non-compose view)
  - 1 updated for #9 (`markRecentCommits` timestamp on action)
  - 1 updated for compose-cancel precedence
- [x] `npm run test:jest --testPathPatterns="(workstation|commands/log|commit|langchain|git/)"` — 1760/1760 pass
- [ ] Manual: stage files, start typing in compose summary, press `I` to fire AI draft. Verify the draft lands in `pendingAiDraft` (not the field) and the confirmation message appears. Press `R` to accept (typing replaced) or Esc to dismiss (typing preserved, AI draft gone).
- [ ] Manual: start AI draft on compose, chord-nav to `gh`, press Esc. Verify draft cancels (status reads "AI draft cancelled.") rather than falling through to view navigation.
- [ ] Manual: drill into a submodule, change sidebar tab, pop back. Verify the parent's tab is restored AND the submodule's saved tab is unchanged on a subsequent drill-in.

## Notable behaviour changes

- **`setDraft` no longer silently overwrites user-typed content.** This is a meaningful UX change. Users who relied on the silent-clobber behaviour will see a new confirmation message on the compose surface; pressing `R` reproduces the old behaviour. If the team prefers silent replacement, we can wire it behind a config flag — but the existing behaviour was a data-loss bug per the audit.
- **Esc cancel for AI commit draft now works from any view, not just compose.** Asymmetric with the original Phase 3 design but matches the PR-body cancel binding and addresses a real UX issue.