### PR TITLE
feat(workstation): four UX polish fixes (loading visibility, stash flows, stash → graph jump, full graph default)

### DIFF
--- a/src/commands/log/data.test.ts
+++ b/src/commands/log/data.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path'
 import { simpleGit } from 'simple-git'
 import { Arguments } from 'yargs'
 import {
+  COMMIT_CONTEXT_DEFAULT_LIMIT,
   FIELD_SEPARATOR,
   LOG_DEFAULT_LIMIT,
   LOG_INTERACTIVE_DEFAULT_LIMIT,
@@ -12,6 +13,7 @@ import {
   getCommitFilePreview,
   getCommitRows,
   getLogRows,
+  getLogRowsAnchoredOn,
   getLogView,
   parseCommitDetail,
   parseLogOutput,
@@ -105,23 +107,6 @@ describe('log data layer', () => {
     const sepIdx = args.indexOf('--')
     expect(refIdx).toBeGreaterThan(-1)
     expect(sepIdx).toBeGreaterThan(refIdx)
-  })
-
-  it('places the targetHash in the same positional slot as extraRefs when callers pass it directly', () => {
-    // The `getLogRowsAnchoredOn` helper splices the target into
-    // `extraRefs` and forwards to `buildLogArgs`; this test pins
-    // that the target lands as a positional ref alongside any
-    // other extra refs, after --all and before the path separator.
-    const args = buildLogArgs(argv({ all: true }), {
-      extraRefs: ['stashA', 'stashB', 'targetXYZ'],
-    })
-    expect(args).toContain('--all')
-    expect(args).toContain('stashA')
-    expect(args).toContain('stashB')
-    expect(args).toContain('targetXYZ')
-    const allIdx = args.indexOf('--all')
-    const targetIdx = args.indexOf('targetXYZ')
-    expect(targetIdx).toBeGreaterThan(allIdx)
   })
 
   it('omits extraRefs when the array is empty', () => {
@@ -439,6 +424,62 @@ describe('log data layer', () => {
       } finally {
         await rm(path, { recursive: true, force: true })
       }
+    })
+  })
+
+  describe('getLogRowsAnchoredOn', () => {
+    // Walks only from the target — NOT from --all + target — so the
+    // target is guaranteed to be in the output regardless of date
+    // ordering. The bug this avoids: with --all in the mix, git
+    // unions the walks and the max-count cap can slice an old
+    // target off the bottom of a busy date-sorted result.
+
+    it('walks only from the target ref, ignoring --all from the input argv', async () => {
+      const path = await mkdtemp(join(tmpdir(), 'coco-anchored-test-'))
+      try {
+        const git = simpleGit(path)
+        await git.init()
+        await git.addConfig('user.name', 'Coco Test')
+        await git.addConfig('user.email', 'coco@example.com')
+        await git.addConfig('commit.gpgsign', 'false')
+        await git.raw(['checkout', '-b', 'main'])
+
+        await writeFile(join(path, 'a.md'), 'a\n')
+        await git.add('a.md')
+        await git.commit('chore: A')
+        const aRev = (await git.revparse(['HEAD'])).trim()
+
+        await writeFile(join(path, 'b.md'), 'b\n')
+        await git.add('b.md')
+        await git.commit('chore: B')
+
+        // Branch off A and add a divergent commit C that only that
+        // branch can reach. C should NOT appear when we anchor on A.
+        await git.raw(['checkout', '-b', 'side', aRev])
+        await writeFile(join(path, 'c.md'), 'c\n')
+        await git.add('c.md')
+        await git.commit('chore: C-on-side')
+        await git.raw(['checkout', 'main'])
+
+        // Anchor on commit A. Should return A and A's ancestors only —
+        // not B (newer on main), not C (on side branch).
+        const argvBase = argv({ all: true })  // even with --all set, the helper strips it
+        const anchoredRows = await getLogRowsAnchoredOn(git, argvBase, aRev, { limit: 100 })
+
+        const subjects = getCommitRows(anchoredRows).map((r) => r.message)
+        expect(subjects).toEqual(['chore: A'])
+      } finally {
+        await rm(path, { recursive: true, force: true })
+      }
+    })
+
+    it('uses COMMIT_CONTEXT_DEFAULT_LIMIT as the cap when no limit option is supplied', async () => {
+      // Sanity: the default limit constant is exported and the
+      // helper falls back to it. Important because the limit also
+      // shapes how much surrounding context the user gets when the
+      // cursor lands; lowering it accidentally would reduce that.
+      expect(COMMIT_CONTEXT_DEFAULT_LIMIT).toBeGreaterThanOrEqual(1000)
+      expect(typeof COMMIT_CONTEXT_DEFAULT_LIMIT).toBe('number')
     })
   })
 })

--- a/src/commands/log/data.test.ts
+++ b/src/commands/log/data.test.ts
@@ -107,6 +107,23 @@ describe('log data layer', () => {
     expect(sepIdx).toBeGreaterThan(refIdx)
   })
 
+  it('places the targetHash in the same positional slot as extraRefs when callers pass it directly', () => {
+    // The `getLogRowsAnchoredOn` helper splices the target into
+    // `extraRefs` and forwards to `buildLogArgs`; this test pins
+    // that the target lands as a positional ref alongside any
+    // other extra refs, after --all and before the path separator.
+    const args = buildLogArgs(argv({ all: true }), {
+      extraRefs: ['stashA', 'stashB', 'targetXYZ'],
+    })
+    expect(args).toContain('--all')
+    expect(args).toContain('stashA')
+    expect(args).toContain('stashB')
+    expect(args).toContain('targetXYZ')
+    const allIdx = args.indexOf('--all')
+    const targetIdx = args.indexOf('targetXYZ')
+    expect(targetIdx).toBeGreaterThan(allIdx)
+  })
+
   it('omits extraRefs when the array is empty', () => {
     // Repos with no stashes pass an empty array; we shouldn't emit
     // anything that would confuse git or change the argument shape.

--- a/src/commands/log/data.test.ts
+++ b/src/commands/log/data.test.ts
@@ -75,6 +75,51 @@ describe('log data layer', () => {
     expect(args).not.toContain('--no-merges')
   })
 
+  it('appends extraRefs as positional graph roots after --all', () => {
+    // Workstation includes stash commit hashes here so they appear as
+    // graph nodes even though `git log --all` only walks `refs/stash`
+    // (the latest stash) by default. Each hash becomes an additional
+    // root the traversal starts from.
+    const args = buildLogArgs(argv({ all: true }), {
+      extraRefs: ['abc1234', 'def5678'],
+    })
+
+    expect(args).toContain('--all')
+    expect(args).toContain('abc1234')
+    expect(args).toContain('def5678')
+    // Ordering matters: extraRefs come after --all so git parses them
+    // as positional refs, not as flag args.
+    const allIdx = args.indexOf('--all')
+    const refIdx = args.indexOf('abc1234')
+    expect(refIdx).toBeGreaterThan(allIdx)
+  })
+
+  it('appends extraRefs before the -- path separator', () => {
+    // When a path filter is set, extraRefs must land BEFORE the `--`
+    // separator so git treats them as refs rather than paths.
+    const args = buildLogArgs(argv({ all: true, path: ['src'] }), {
+      extraRefs: ['abc1234'],
+    })
+
+    const refIdx = args.indexOf('abc1234')
+    const sepIdx = args.indexOf('--')
+    expect(refIdx).toBeGreaterThan(-1)
+    expect(sepIdx).toBeGreaterThan(refIdx)
+  })
+
+  it('omits extraRefs when the array is empty', () => {
+    // Repos with no stashes pass an empty array; we shouldn't emit
+    // anything that would confuse git or change the argument shape.
+    const args = buildLogArgs(argv({ all: true }), { extraRefs: [] })
+
+    expect(args).toContain('--all')
+    // No extra positional refs landed in the args list.
+    const positionalRefs = args.filter((arg) =>
+      !arg.startsWith('--') && !arg.startsWith('-') && arg !== 'log'
+    )
+    expect(positionalRefs.filter((arg) => /^[a-f0-9]+$/i.test(arg))).toEqual([])
+  })
+
   describe('buildToggleGraphArgs', () => {
     it('switches to full topology when fullGraph is true', () => {
       const merged = buildToggleGraphArgs(argv({ view: 'compact' }), true)

--- a/src/commands/log/data.ts
+++ b/src/commands/log/data.ts
@@ -16,6 +16,21 @@ export const LOG_INTERACTIVE_DEFAULT_LIMIT = 300
 export type LogRowLoadOptions = {
   limit?: number
   skip?: number
+  /**
+   * Additional refs / commit hashes to include as graph roots beyond
+   * what `--all` covers. The canonical use case is stashes: `git log
+   * --all` only includes `refs/stash` (the latest stash; stash@{0}),
+   * not older `stash@{N}` entries which live in the stash reflog
+   * rather than as refs. Passing their commit hashes here makes them
+   * appear as nodes in the loaded graph window, so cursor-syncs from
+   * the stash sidebar can actually land somewhere.
+   *
+   * Appended as positional args at the end of the `git log` command,
+   * after the `--all` flag and before any path separator. Each entry
+   * should be a resolvable ref / commit hash; the caller is
+   * responsible for filtering out invalid values.
+   */
+  extraRefs?: string[]
 }
 
 export type GitLogCommitRow = {
@@ -301,6 +316,14 @@ export function buildLogArgs(argv: LogArgv, options: LogRowLoadOptions = {}): st
     args.push('--all')
   } else if (argv.branch) {
     args.push(argv.branch)
+  }
+
+  // Extra refs (stash commits etc.) — append after the --all / branch
+  // selector but BEFORE the path separator. Git treats them as
+  // additional graph roots, so the traversal includes them alongside
+  // whatever --all / --branch already covers.
+  if (options.extraRefs && options.extraRefs.length > 0) {
+    args.push(...options.extraRefs)
   }
 
   const paths = toArray(argv.path)

--- a/src/commands/log/data.ts
+++ b/src/commands/log/data.ts
@@ -353,47 +353,58 @@ export const COMMIT_CONTEXT_DEFAULT_LIMIT = 5000
 /**
  * Load a window of commits anchored on a specific hash. Used by the
  * cursor-sync effect when the user selects a ref (branch / tag /
- * stash) whose target commit isn't already in the loaded graph
- * window. Passing the hash as an explicit positional ref makes git
- * include it (and its ancestors) in the walk regardless of how far
- * back it sits relative to HEAD.
+ * stash) whose target commit isn't in the loaded graph window.
  *
- * The result includes everything reachable from any of:
- *   - `--all` (refs/heads, refs/remotes, refs/tags, refs/stash)
- *   - The supplied `targetHash`
- *   - Any `extraRefs` (stash commits, typically — same plumbing the
- *     boot loader uses)
+ * Critical detail: this walks **only from the target** (and its
+ * ancestors), NOT from `--all`. Why: when you combine `--all` with
+ * `<targetHash>` AND `--max-count=N`, git unions the walks, sorts
+ * the result by date, and slices the newest N rows. If the target
+ * is older than the Nth newest commit across all refs (very common
+ * for year-old tags / branches on active repos), it falls off the
+ * slice even though it was passed as a root. Walking from the
+ * target alone guarantees the target IS the first row of the
+ * output and its ancestors fill the rest.
  *
- * Capped at `options.limit` (default 5000). Past that, git's
- * `--max-count` truncates and the target may still fall outside the
- * window IF its ancestors are extremely deep AND many other refs
- * have newer commits. In practice that's rare; raising the limit
- * is the escape valve.
+ * The caller merges the result via the `appendRows` reducer action
+ * which deduplicates by hash, so the target's ancestry slots into
+ * the existing `--all` graph cleanly. The user's loaded view ends
+ * up as the union of: the original `--all` window + target's
+ * ancestry — exactly what's needed for the cursor to land.
  *
- * The caller is responsible for merging the result into existing
- * state. Use the existing `appendRows` action which already
- * deduplicates by hash.
+ * Capped at `options.limit` (default 5000) to keep one targeted
+ * fetch bounded. For most refs, even a 100-commit limit would be
+ * enough to surface the target; we go higher to also pull in the
+ * surrounding context so the user can scroll around the landed
+ * cursor.
  */
 export async function getLogRowsAnchoredOn(
   git: SimpleGit,
   argv: LogArgv,
   targetHash: string,
-  options: { extraRefs?: string[]; limit?: number } = {}
+  options: { limit?: number } = {}
 ): Promise<GitLogRow[]> {
-  const extraRefs = options.extraRefs || []
-  // Splice the target into extraRefs so `buildLogArgs` lays it out
-  // alongside any stash hashes after --all and before the --
-  // separator. Avoids hand-rolling a parallel arg builder.
-  const refs = [...extraRefs, targetHash]
-  // Force `all` on for this fetch — we want the union of every ref
-  // plus the explicit target, never a single-branch slice. Even if
-  // the caller's argv was `--no-all`, a targeted lookup should
-  // still walk from everywhere.
-  const merged: LogArgv = { ...argv, all: true }
-  return getLogRows(git, merged, {
+  // Strip every "walk many refs" toggle so buildLogArgs produces a
+  // clean `git log <flags> <targetHash>` — exactly the walk that
+  // guarantees the target's inclusion.
+  const merged: LogArgv = {
+    ...argv,
+    all: false,
+    view: 'compact',  // suppresses 'full' → '--all' mapping
+    branch: undefined,
+    path: undefined,
+  }
+  // Also drop --first-parent / --no-merges so the target's ancestry
+  // renders with full topology (matters for stash commits which are
+  // merges by construction).
+  const baseArgs = buildLogArgs(merged, {
     limit: options.limit ?? COMMIT_CONTEXT_DEFAULT_LIMIT,
-    extraRefs: refs,
-  })
+  }).filter((arg) => arg !== '--first-parent' && arg !== '--no-merges')
+  // Splice the target as the positional ref. `buildLogArgs` already
+  // appended any `--all`/`--branch`/`<extraRefs>` it considered;
+  // since we cleared all those above, the only positional ref we
+  // add is the target.
+  baseArgs.push(targetHash)
+  return parseLogOutput(await git.raw(baseArgs))
 }
 
 /**

--- a/src/commands/log/data.ts
+++ b/src/commands/log/data.ts
@@ -343,6 +343,60 @@ export function buildLogArgs(argv: LogArgv, options: LogRowLoadOptions = {}): st
 }
 
 /**
+ * Default size of a targeted-context window. Sized to comfortably
+ * cover a year of activity on most repos so the cursor-sync's
+ * "jump to commit anchored on a ref I just selected" can succeed
+ * without paginating through the whole history.
+ */
+export const COMMIT_CONTEXT_DEFAULT_LIMIT = 5000
+
+/**
+ * Load a window of commits anchored on a specific hash. Used by the
+ * cursor-sync effect when the user selects a ref (branch / tag /
+ * stash) whose target commit isn't already in the loaded graph
+ * window. Passing the hash as an explicit positional ref makes git
+ * include it (and its ancestors) in the walk regardless of how far
+ * back it sits relative to HEAD.
+ *
+ * The result includes everything reachable from any of:
+ *   - `--all` (refs/heads, refs/remotes, refs/tags, refs/stash)
+ *   - The supplied `targetHash`
+ *   - Any `extraRefs` (stash commits, typically — same plumbing the
+ *     boot loader uses)
+ *
+ * Capped at `options.limit` (default 5000). Past that, git's
+ * `--max-count` truncates and the target may still fall outside the
+ * window IF its ancestors are extremely deep AND many other refs
+ * have newer commits. In practice that's rare; raising the limit
+ * is the escape valve.
+ *
+ * The caller is responsible for merging the result into existing
+ * state. Use the existing `appendRows` action which already
+ * deduplicates by hash.
+ */
+export async function getLogRowsAnchoredOn(
+  git: SimpleGit,
+  argv: LogArgv,
+  targetHash: string,
+  options: { extraRefs?: string[]; limit?: number } = {}
+): Promise<GitLogRow[]> {
+  const extraRefs = options.extraRefs || []
+  // Splice the target into extraRefs so `buildLogArgs` lays it out
+  // alongside any stash hashes after --all and before the --
+  // separator. Avoids hand-rolling a parallel arg builder.
+  const refs = [...extraRefs, targetHash]
+  // Force `all` on for this fetch — we want the union of every ref
+  // plus the explicit target, never a single-branch slice. Even if
+  // the caller's argv was `--no-all`, a targeted lookup should
+  // still walk from everywhere.
+  const merged: LogArgv = { ...argv, all: true }
+  return getLogRows(git, merged, {
+    limit: options.limit ?? COMMIT_CONTEXT_DEFAULT_LIMIT,
+    extraRefs: refs,
+  })
+}
+
+/**
  * Build merged `LogArgv` for the interactive TUI's `g` graph toggle.
  *
  * The TUI tracks a transient `fullGraph` boolean; toggling it must produce

--- a/src/commands/log/data.ts
+++ b/src/commands/log/data.ts
@@ -11,7 +11,15 @@ export const FIELD_SEPARATOR = '\x1f'
 const LOG_FORMAT = `%x1f%h%x1f%H%x1f%P%x1f%ad%x1f%an%x1f%d%x1f%s`
 const DETAIL_FORMAT = `%H%x1f%h%x1f%P%x1f%ad%x1f%an%x1f%d%x1f%s%x1f%b`
 export const LOG_DEFAULT_LIMIT = 30
-export const LOG_INTERACTIVE_DEFAULT_LIMIT = 300
+// Bumped from 300 → 1000 in 0.54.2. With the full-graph default
+// (#1034) the workstation surfaces many more refs (all branches, all
+// tags, plus stash commits added via `extraRefs`), and on active repos
+// the 300-commit cap was cutting off year+-old stash bases and old
+// tag commits — making the cursor-syncs-history effect report "tip
+// not in loaded window" instead of moving the graph cursor. 1000
+// fits a year of activity for most repos, git log is still sub-200ms,
+// and Ink virtualises scroll so render cost stays flat.
+export const LOG_INTERACTIVE_DEFAULT_LIMIT = 1000
 
 export type LogRowLoadOptions = {
   limit?: number

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -171,11 +171,13 @@ describe('log Ink input interactions', () => {
     state = applyInput(state, '', { tab: true, shift: true })
     expect(state.focus).toBe('commits')
 
-    state = applyInput(state, '\\')
-    expect(state.fullGraph).toBe(true)
-
+    // Since 0.54.x the default `fullGraph` is true; first `\\` flips
+    // to compact, second flips back to full.
     state = applyInput(state, '\\')
     expect(state.fullGraph).toBe(false)
+
+    state = applyInput(state, '\\')
+    expect(state.fullGraph).toBe(true)
 
     // gg jump to top: first 'g' is a pure prefix, second 'g' fires moveToTop.
     state = applyLogInkAction(state, { type: 'move', delta: 2 })
@@ -1834,15 +1836,24 @@ describe('log Ink input interactions', () => {
   })
 
   it('toggles graph with the relocated \\\\ key (g is now a pure prefix)', () => {
+    // Note: since 0.54.x the default `fullGraph` flipped to true so
+    // users see the full multi-ref graph out of the box. The toggle
+    // semantics didn't change — `\\` still flips between full and
+    // compact — the starting state is just the inverse of what
+    // earlier tests assumed.
     let state = createLogInkState(rows)
-    expect(state.fullGraph).toBe(false)
+    expect(state.fullGraph).toBe(true)
 
     // Single g press only sets a pending chord — no graph flicker.
     state = applyInput(state, 'g')
-    expect(state.fullGraph).toBe(false)
+    expect(state.fullGraph).toBe(true)
     expect(state.pendingKey).toBe('g')
 
-    // \\ is the new toggle.
+    // \\ flips from default (full) to compact.
+    state = applyInput(state, '\\')
+    expect(state.fullGraph).toBe(false)
+
+    // Pressing it again flips back to full.
     state = applyInput(state, '\\')
     expect(state.fullGraph).toBe(true)
   })

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -362,13 +362,17 @@ describe('log Ink view model', () => {
   })
 
   it('toggles graph, help, and command palette overlays', () => {
+    // Note: since 0.54.x the default `fullGraph` flipped to true so
+    // the workstation opens on the full multi-ref graph. The toggle
+    // just flips the boolean, so one `toggleGraph` lands at false.
     let state = createLogInkState(rows)
+    expect(state.fullGraph).toBe(true)
 
     state = applyLogInkAction(state, { type: 'toggleGraph' })
     state = applyLogInkAction(state, { type: 'toggleHelp' })
     state = applyLogInkAction(state, { type: 'toggleCommandPalette' })
 
-    expect(state.fullGraph).toBe(true)
+    expect(state.fullGraph).toBe(false)
     expect(state.showHelp).toBe(false)
     expect(state.showCommandPalette).toBe(true)
   })

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -976,6 +976,34 @@ describe('log Ink view model', () => {
       expect(state.selectedFileIndex).toBe(0)
       expect(state.diffPreviewOffset).toBe(0)
     })
+
+    it('matches a target that is a prefix of a loaded commit hash', () => {
+      // The production short-hash mismatch: `for-each-ref` returned
+      // 'fed9' for the cursored ref but `git log` stored 'fed9999' on
+      // the row. Exact lookup would miss; prefix matching catches it.
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'selectCommitByHash', hash: 'fed9' })
+      expect(state.selectedIndex).toBe(2)
+    })
+
+    it('matches a target that is longer than a loaded short hash', () => {
+      // Inverse direction: cursored ref carries an 8-char hash, the
+      // loaded row only has a 7-char short form. The reducer should
+      // still resolve the jump.
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'selectCommitByHash', hash: 'fed99990' })
+      expect(state.selectedIndex).toBe(2)
+    })
+
+    it('refuses to prefix-match on absurdly short targets', () => {
+      // A 3-char "hash" would collide with too many real commits.
+      // Same floor as `isHashLoaded` in the resolver.
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'move', delta: 1 })
+      expect(state.selectedIndex).toBe(1)
+      state = applyLogInkAction(state, { type: 'selectCommitByHash', hash: 'fed' })
+      expect(state.selectedIndex).toBe(1) // unchanged
+    })
   })
 
   // #806 follow-up — after a successful checkout, the branches sidebar

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -1394,10 +1394,29 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       // branch's tip without the user manually scrolling. No-op when
       // the hash isn't in the loaded list (the runtime surfaces a
       // status hint in that case).
+      //
+      // Matching mirrors `isHashLoaded` in cursorSyncResolver: exact
+      // hit first (the common path), then a bidirectional `startsWith`
+      // scan to cover the short-hash auto-extension mismatch between
+      // `for-each-ref --format=%(objectname:short)` (cursored ref) and
+      // `git log --pretty=format:%h` (history row). Without the
+      // fallback the resolver could decide "jump" but this reducer
+      // would silently no-op — the status updates but the cursor
+      // doesn't move, exactly the branch-cursor bug surfaced in
+      // 0.54.1 testing. Kept inline rather than importing from
+      // `workstation/runtime/` because `commands/log/` must not
+      // depend on `workstation/`.
       const target = action.hash
-      const index = state.filteredCommits.findIndex((commit) =>
-        commit.hash === target || commit.shortHash === target
-      )
+      const index = state.filteredCommits.findIndex((commit) => {
+        if (commit.hash === target || commit.shortHash === target) return true
+        if (target.length < 4) return false
+        const candidates = [commit.hash, commit.shortHash].filter(
+          (value): value is string => typeof value === 'string' && value.length > 0
+        )
+        return candidates.some(
+          (candidate) => candidate.startsWith(target) || target.startsWith(candidate)
+        )
+      })
       if (index < 0) {
         return state
       }

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -170,6 +170,14 @@ export type CreateLogInkStateOptions = {
    * direct-constructing state) don't have to thread it through.
    */
   repoWorkdir?: string
+  /**
+   * Override the initial graph mode. Defaults to `true` (full
+   * multi-ref graph) since 0.54.x — tests that need the compact
+   * single-branch view pass `fullGraph: false` here rather than
+   * relying on the global default (which has moved before and may
+   * move again).
+   */
+  fullGraph?: boolean
 }
 
 export type LogInkState = {
@@ -1245,7 +1253,16 @@ export function createLogInkState(
     worktreeDiffOffset: 0,
     filter: '',
     filterMode: false,
-    fullGraph: false,
+    // Default to the full multi-ref graph (`git log --all`) so users
+    // see how branches, tags, and stashes weave through the history
+    // out of the box. Pre-0.54.x this defaulted to false (current
+    // branch only); user feedback consistently asked for the
+    // GitKraken-style "see everything" view as the starting state.
+    // The `\` toggle still flips back to compact / current-branch
+    // mode for users who want the cleaner single-line graph. Tests
+    // override via `options.fullGraph` when they need the compact
+    // case explicitly.
+    fullGraph: options.fullGraph ?? true,
     showHelp: false,
     helpScrollOffset: 0,
     showCommandPalette: false,

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -1,4 +1,5 @@
 import { GitLogCommitRow, GitLogRow, getCommitRows } from './data'
+import { hashesMatchAny } from '../../git/hashes'
 import {
     CommitComposeAction,
     CommitComposeState,
@@ -1395,28 +1396,18 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       // the hash isn't in the loaded list (the runtime surfaces a
       // status hint in that case).
       //
-      // Matching mirrors `isHashLoaded` in cursorSyncResolver: exact
-      // hit first (the common path), then a bidirectional `startsWith`
-      // scan to cover the short-hash auto-extension mismatch between
-      // `for-each-ref --format=%(objectname:short)` (cursored ref) and
-      // `git log --pretty=format:%h` (history row). Without the
-      // fallback the resolver could decide "jump" but this reducer
+      // Uses the shared `hashesMatchAny` helper to cover the
+      // short-hash auto-extension mismatch between
+      // `for-each-ref --format=%(objectname:short)` (cursored ref)
+      // and `git log --pretty=format:%h` (history row). Without that
+      // tolerance the resolver could decide "jump" but this reducer
       // would silently no-op — the status updates but the cursor
-      // doesn't move, exactly the branch-cursor bug surfaced in
-      // 0.54.1 testing. Kept inline rather than importing from
-      // `workstation/runtime/` because `commands/log/` must not
-      // depend on `workstation/`.
+      // doesn't move, exactly the branch-cursor bug surfaced in 0.54.1
+      // testing. See `src/git/hashes.ts` for the matching rules.
       const target = action.hash
-      const index = state.filteredCommits.findIndex((commit) => {
-        if (commit.hash === target || commit.shortHash === target) return true
-        if (target.length < 4) return false
-        const candidates = [commit.hash, commit.shortHash].filter(
-          (value): value is string => typeof value === 'string' && value.length > 0
-        )
-        return candidates.some(
-          (candidate) => candidate.startsWith(target) || target.startsWith(candidate)
-        )
-      })
+      const index = state.filteredCommits.findIndex((commit) =>
+        hashesMatchAny(target, [commit.hash, commit.shortHash])
+      )
       if (index < 0) {
         return state
       }

--- a/src/commands/log/interactive.test.ts
+++ b/src/commands/log/interactive.test.ts
@@ -167,6 +167,7 @@ const stashOverview: StashOverview = {
     {
       ref: 'stash@{0}',
       hash: 'abc123',
+      baseHash: 'base111',
       date: '2026-04-28 09:00:00 -0400',
       branch: 'main',
       message: 'save local edits',

--- a/src/commands/ui/config.ts
+++ b/src/commands/ui/config.ts
@@ -27,9 +27,10 @@ export const options = {
     default: 'history',
   },
   all: {
-    description: 'Load commits from all local and remote refs in history mode',
+    description:
+      'Load commits from all local and remote refs in history mode. Defaults to true so the history view shows the full multi-ref graph (branches, tags, stashes) out of the box; pass `--no-all` to scope to the current branch only.',
     type: 'boolean',
-    default: false,
+    default: true,
   },
   branch: {
     description: 'Load history reachable from a branch or ref',

--- a/src/commands/ui/handler.test.ts
+++ b/src/commands/ui/handler.test.ts
@@ -5,7 +5,11 @@ function argv(overrides: Partial<UiArgv> = {}): UiArgv {
   return {
     $0: 'coco',
     _: ['ui'],
-    all: false,
+    // Mirror the yargs default from src/commands/ui/config.ts — `all`
+    // defaults to true so the workstation shows the full multi-ref
+    // graph out of the box. Pass `all: false` in overrides to
+    // simulate `coco ui --no-all`.
+    all: true,
     interactive: false,
     verbose: false,
     version: false,
@@ -31,5 +35,31 @@ describe('ui command handler utilities', () => {
     expect(logArgv.branch).toBe('feature/git-workstation')
     expect(logArgv.limit).toBe(500)
     expect(logArgv.path).toEqual(['src', 'README.md'])
+  })
+
+  it('defaults `all: true` so the workstation shows the full multi-ref graph', () => {
+    // 0.54.x+: user feedback consistently asked for the GitKraken-style
+    // "see all branches, tags, stashes" view as the starting state.
+    // The yargs default at src/commands/ui/config.ts is `true`; the
+    // handler just passes it through. Empty overrides simulate
+    // running `coco ui` with no flags.
+    const logArgv = createLogArgvFromUiArgv(argv({}))
+    expect(logArgv.all).toBe(true)
+  })
+
+  it('honours --no-all when the user explicitly opted out', () => {
+    const logArgv = createLogArgvFromUiArgv(argv({ all: false }))
+    expect(logArgv.all).toBe(false)
+  })
+
+  it('keeps --all true when --branch is passed alongside (highlight, not scope)', () => {
+    // Deliberate UX call: `coco ui --branch feature/x` does NOT
+    // narrow to that branch automatically. The all-refs default
+    // stays in effect; --branch acts as a "land on this branch's
+    // tip" hint within the full graph. Users who want strict scope
+    // pass `--branch feature/x --no-all`.
+    const logArgv = createLogArgvFromUiArgv(argv({ branch: 'feature/x' }))
+    expect(logArgv.all).toBe(true)
+    expect(logArgv.branch).toBe('feature/x')
   })
 })

--- a/src/commands/ui/handler.ts
+++ b/src/commands/ui/handler.ts
@@ -16,6 +16,17 @@ export function createLogArgvFromUiArgv(argv: UiArgv): LogArgv {
   return {
     $0: argv.$0,
     _: ['log'],
+    // Pass `--all` through from the CLI. The yargs default is `true`
+    // since 0.54.x — user feedback consistently asked for the
+    // GitKraken-style "see all branches, tags, stashes" view as the
+    // starting state. `coco ui --no-all` opts back to
+    // current-branch-only.
+    //
+    // Note: passing `--branch foo` does NOT automatically scope away
+    // from --all. If the user wants strictly that branch, they pass
+    // `coco ui --branch foo --no-all`. We considered the implicit
+    // scope-narrowing but it surprises users who pass `--branch` as
+    // a "highlight this branch in the all-refs view" hint.
     all: argv.all,
     branch: argv.branch,
     format: 'table',

--- a/src/commands/ui/handler.ts
+++ b/src/commands/ui/handler.ts
@@ -6,6 +6,7 @@ import { loadConfig } from '../../lib/config/utils/loadConfig'
 import { getRepo } from '../../lib/simple-git/getRepo'
 import { LogArgv, LogOptions } from '../log/config'
 import { GitLogRow, getLogRows } from '../log/data'
+import { getStashCommitHashes } from '../../git/stashData'
 import { startInkInteractiveLog } from '../log/inkRuntime'
 import { applyRepoFlag } from '../utils/applyRepoFlag'
 import { readCachedCommits, writeCachedCommits } from '../../workstation/chrome/overviewCache'
@@ -76,6 +77,30 @@ function withCacheWrite(
   }
 }
 
+/**
+ * Workstation-aware log loader (#1034 follow-up). Calls `git stash
+ * list` first to collect every stash's commit hash, then passes them
+ * as extra refs to `getLogRows` so the graph includes every stash as
+ * a node — not just the latest (which is the only one `refs/stash`
+ * points at and the only one `git log --all` walks).
+ *
+ * Without this, the stash → history cursor sync added in #1034 only
+ * worked for `stash@{0}`; cursoring any older stash row reported
+ * "tip not in loaded window" because that stash's commit hash was
+ * never in the loaded graph window in the first place.
+ *
+ * The extra git call is cheap (one `git stash list --format=%H`,
+ * usually sub-50ms). It's only an additive cost when stashes exist;
+ * users on stash-free repos pay nothing.
+ */
+async function loadRowsWithStashes(
+  git: SimpleGit,
+  logArgv: LogArgv
+): Promise<GitLogRow[]> {
+  const stashHashes = await getStashCommitHashes(git).catch(() => [])
+  return getLogRows(git, logArgv, { extraRefs: stashHashes })
+}
+
 export async function startCocoUiFromLogArgv(
   logArgv: LogArgv,
   options: StartCocoUiFromLogArgvOptions = {}
@@ -98,7 +123,7 @@ export async function startCocoUiFromLogArgv(
   const initialRows = options.rows || cachedRows || []
   const loadRows = options.rows
     ? undefined
-    : withCacheWrite(repoPath, () => getLogRows(git, logArgv))
+    : withCacheWrite(repoPath, () => loadRowsWithStashes(git, logArgv))
 
   await startInkInteractiveLog(git, initialRows, {}, {
     appLabel: 'coco',
@@ -131,7 +156,7 @@ export async function startCocoUi(argv: UiArgv): Promise<void> {
     idleTips: config.logTui?.idleTips,
     dateBucketing: config.logTui?.dateBucketing,
     initialView: argv.view || 'history',
-    loadRows: withCacheWrite(repoPath, () => getLogRows(git, logArgv)),
+    loadRows: withCacheWrite(repoPath, () => loadRowsWithStashes(git, logArgv)),
     logArgv,
     theme: createUiTheme(config, argv),
   })

--- a/src/git/hashes.test.ts
+++ b/src/git/hashes.test.ts
@@ -1,0 +1,96 @@
+import { hashLoaded, hashesMatch, hashesMatchAny } from './hashes'
+
+describe('hashesMatch', () => {
+  it('returns true on exact equality (fast path)', () => {
+    expect(hashesMatch('abc1234', 'abc1234')).toBe(true)
+  })
+
+  it('returns false when either input is missing', () => {
+    expect(hashesMatch(undefined, 'abc1234')).toBe(false)
+    expect(hashesMatch('abc1234', undefined)).toBe(false)
+    expect(hashesMatch(undefined, undefined)).toBe(false)
+    expect(hashesMatch('', 'abc1234')).toBe(false)
+  })
+
+  it('matches when a is a prefix of b', () => {
+    expect(hashesMatch('abc1234', 'abc12345678901234567890')).toBe(true)
+  })
+
+  it('matches when b is a prefix of a', () => {
+    expect(hashesMatch('abc12345678901234567890', 'abc1234')).toBe(true)
+  })
+
+  it('matches the production case: same commit, different short-hash lengths from different formatters', () => {
+    // `for-each-ref --format=%(objectname:short)` returned 7 chars,
+    // `git log --pretty=format:%h` returned 8 (auto-extended). Both
+    // refer to the same commit; bidirectional prefix matching catches
+    // it where exact equality misses.
+    expect(hashesMatch('abc1234', 'abc12345')).toBe(true)
+    expect(hashesMatch('abc12345', 'abc1234')).toBe(true)
+  })
+
+  it('refuses to match when either input is below the 4-char floor', () => {
+    expect(hashesMatch('abc', 'abc1234')).toBe(false)
+    expect(hashesMatch('abc1234', 'abc')).toBe(false)
+  })
+
+  it('returns false for hashes that only share a too-short common prefix', () => {
+    // "abc1234" and "abc5678" share only "abc" — neither is a prefix
+    // of the other.
+    expect(hashesMatch('abc1234', 'abc5678')).toBe(false)
+  })
+
+  it('is symmetric', () => {
+    const pairs: Array<[string, string]> = [
+      ['abc1234', 'abc12345'],
+      ['abc1234', 'def5678'],
+      ['abc', 'abc1234'],
+      ['abc1234', 'abc1234'],
+    ]
+    for (const [a, b] of pairs) {
+      expect(hashesMatch(a, b)).toBe(hashesMatch(b, a))
+    }
+  })
+})
+
+describe('hashesMatchAny', () => {
+  it('returns true when any candidate matches', () => {
+    expect(hashesMatchAny('abc1234', ['def5678', 'abc12345'])).toBe(true)
+  })
+
+  it('returns false when no candidate matches', () => {
+    expect(hashesMatchAny('abc1234', ['def5678', 'ghi9012'])).toBe(false)
+  })
+
+  it('skips undefined / empty candidates without erroring', () => {
+    expect(hashesMatchAny('abc1234', [undefined, '', 'abc12345'])).toBe(true)
+    expect(hashesMatchAny('abc1234', [undefined, ''])).toBe(false)
+  })
+
+  it('returns false when the target hash is undefined', () => {
+    expect(hashesMatchAny(undefined, ['abc1234'])).toBe(false)
+  })
+})
+
+describe('hashLoaded', () => {
+  it('hits the O(1) fast path on exact match', () => {
+    expect(hashLoaded('abc1234', new Set(['abc1234', 'def5678']))).toBe(true)
+  })
+
+  it('matches by prefix when no exact entry exists', () => {
+    expect(hashLoaded('abc1234', new Set(['abc12345', 'def5678']))).toBe(true)
+    expect(hashLoaded('abc12345', new Set(['abc1234', 'def5678']))).toBe(true)
+  })
+
+  it('returns false on an empty set', () => {
+    expect(hashLoaded('abc1234', new Set())).toBe(false)
+  })
+
+  it('respects the 4-char floor', () => {
+    expect(hashLoaded('abc', new Set(['abc1234567']))).toBe(false)
+  })
+
+  it('returns false when nothing in the set shares a meaningful prefix', () => {
+    expect(hashLoaded('abc1234', new Set(['def5678', 'ghi9012']))).toBe(false)
+  })
+})

--- a/src/git/hashes.ts
+++ b/src/git/hashes.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared hash-matching helpers for cross-command lookups.
+ *
+ * Git surfaces the same commit with different short-hash lengths
+ * depending on which command produced the row:
+ *
+ *   - `for-each-ref --format=%(objectname:short)` (branches, tags,
+ *     stashes) honors `core.abbrev`, typically 7 chars.
+ *   - `git log --pretty=format:%h` (history rows) honors the same
+ *     setting BUT git auto-extends abbreviations to keep them unique
+ *     within the walked set — so the same commit can come back as 7
+ *     chars from one command and 8 (or more) from another.
+ *
+ * Consequence: any exact-equality lookup that compares a hash from
+ * `for-each-ref` against a hash from `git log` will miss the match
+ * even when both refer to the same commit. This bit the workstation's
+ * cursor-sync effect twice during 0.54.2 — once in the resolver, once
+ * in the `selectCommitByHash` reducer — and shows up wherever a ref
+ * hash is checked against the loaded log window.
+ *
+ * The fix is bidirectional prefix matching: a hash matches another if
+ * one is a prefix of the other. Below a 4-char floor we refuse to
+ * match — three chars would collide with too many real commits.
+ *
+ * This module is the canonical place for that logic. Import it
+ * anywhere you compare a "hash from one git formatter" against a
+ * "hash from a different git formatter."
+ *
+ * Lives in `src/git/` because both `workstation/` and `commands/log/`
+ * depend on it — `commands/log/` must not depend on `workstation/`,
+ * so this can't live in `workstation/runtime/cursorSyncResolver.ts`.
+ */
+
+/**
+ * Minimum length below which we refuse to prefix-match. Three chars
+ * is too small to be a meaningful unique prefix for any real-world
+ * git history.
+ */
+const MIN_PREFIX_LENGTH = 4
+
+/**
+ * True when `a` and `b` refer to the same commit, tolerating
+ * short-hash length differences from different git formatters.
+ *
+ * Symmetric: `hashesMatch(a, b) === hashesMatch(b, a)`. An exact
+ * string equality wins immediately (the common path); otherwise we
+ * test bidirectional `startsWith` and bail when either input is too
+ * short to be a meaningful prefix.
+ */
+export function hashesMatch(
+  a: string | undefined,
+  b: string | undefined
+): boolean {
+  if (!a || !b) return false
+  if (a === b) return true
+  if (a.length < MIN_PREFIX_LENGTH || b.length < MIN_PREFIX_LENGTH) return false
+  return a.startsWith(b) || b.startsWith(a)
+}
+
+/**
+ * True when `hash` matches any entry in `candidates`. Convenience
+ * wrapper for the common "is this ref's hash in any of the row's
+ * hash variants?" check.
+ */
+export function hashesMatchAny(
+  hash: string | undefined,
+  candidates: ReadonlyArray<string | undefined>
+): boolean {
+  if (!hash) return false
+  return candidates.some((candidate) => hashesMatch(hash, candidate))
+}
+
+/**
+ * True when `hash` is present in the loaded set — exact match first
+ * (the O(1) fast path), then bidirectional `startsWith` over the set
+ * to cover the formatter mismatch.
+ *
+ * The set is small in practice (1k–5k entries) so O(N) iteration on
+ * miss is fine.
+ */
+export function hashLoaded(hash: string, loaded: ReadonlySet<string>): boolean {
+  if (loaded.has(hash)) return true
+  if (hash.length < MIN_PREFIX_LENGTH) return false
+  for (const entry of loaded) {
+    if (entry.startsWith(hash) || hash.startsWith(entry)) return true
+  }
+  return false
+}

--- a/src/git/stashActions.test.ts
+++ b/src/git/stashActions.test.ts
@@ -4,6 +4,7 @@ import { StashEntry } from './stashData'
 const stash: StashEntry = {
   ref: 'stash@{0}',
   hash: 'abc123',
+  baseHash: 'base111',
   date: '2026-04-28',
   branch: 'main',
   message: 'save docs',

--- a/src/git/stashData.test.ts
+++ b/src/git/stashData.test.ts
@@ -9,16 +9,21 @@ import {
 } from './stashData'
 
 describe('log stash data', () => {
-  it('parses stash list lines with branch context and messages', () => {
+  it('parses stash list lines with branch context, parent hashes, and messages', () => {
+    // Format now includes %P (parent hashes, space-separated). First
+    // parent is the stash's BASE commit — the HEAD that was active
+    // when `git stash push` ran. Subsequent parents are the index
+    // snapshot and (with `-u`) the untracked-files snapshot.
     const output = [
-      'stash@{0}\x1fabc123\x1f2026-04-28 09:00:00 -0400\x1fOn main: save docs',
-      'stash@{1}\x1fdef456\x1f2026-04-27 18:00:00 -0400\x1fWIP on feature/log: 1234567 add tui',
+      'stash@{0}\x1fabc123\x1fbase111 idx111\x1f2026-04-28 09:00:00 -0400\x1fOn main: save docs',
+      'stash@{1}\x1fdef456\x1fbase222 idx222 untracked222\x1f2026-04-27 18:00:00 -0400\x1fWIP on feature/log: 1234567 add tui',
     ].join('\n')
 
     expect(parseStashList(output)).toEqual([
       {
         ref: 'stash@{0}',
         hash: 'abc123',
+        baseHash: 'base111',
         date: '2026-04-28 09:00:00 -0400',
         branch: 'main',
         message: 'save docs',
@@ -26,9 +31,28 @@ describe('log stash data', () => {
       {
         ref: 'stash@{1}',
         hash: 'def456',
+        baseHash: 'base222',
         date: '2026-04-27 18:00:00 -0400',
         branch: 'feature/log',
         message: '1234567 add tui',
+      },
+    ])
+  })
+
+  it('falls back to empty baseHash when the parents field is missing', () => {
+    // Defensive: very old git versions or corrupted stash refs may
+    // omit %P expansion. parseStashList shouldn't throw; baseHash
+    // becomes an empty string and the cursor-sync caller treats
+    // that as "fall back to stash.hash."
+    const output = 'stash@{0}\x1fabc123\x1f\x1f2026-04-28 09:00:00 -0400\x1fOn main: save docs'
+    expect(parseStashList(output)).toEqual([
+      {
+        ref: 'stash@{0}',
+        hash: 'abc123',
+        baseHash: '',
+        date: '2026-04-28 09:00:00 -0400',
+        branch: 'main',
+        message: 'save docs',
       },
     ])
   })
@@ -43,7 +67,7 @@ describe('log stash data', () => {
   it('parses stash files and loads overview details', async () => {
     const git = {
       raw: jest.fn()
-        .mockResolvedValueOnce('stash@{0}\x1fabc123\x1f2026-04-28 09:00:00 -0400\x1fOn main: save docs')
+        .mockResolvedValueOnce('stash@{0}\x1fabc123\x1fbase111 idx111\x1f2026-04-28 09:00:00 -0400\x1fOn main: save docs')
         .mockResolvedValueOnce('src/a.ts\nsrc/b.ts\n'),
     }
 
@@ -52,6 +76,7 @@ describe('log stash data', () => {
         {
           ref: 'stash@{0}',
           hash: 'abc123',
+          baseHash: 'base111',
           date: '2026-04-28 09:00:00 -0400',
           branch: 'main',
           message: 'save docs',

--- a/src/git/stashData.ts
+++ b/src/git/stashData.ts
@@ -3,6 +3,24 @@ import { SimpleGit } from 'simple-git'
 export type StashEntry = {
   ref: string
   hash: string
+  /**
+   * First-parent commit hash — the BASE commit the stash was created
+   * on (i.e. HEAD at `git stash push` time). For stash merge commits
+   * `stash@{N}^1` is always the base; `^2` is the index snapshot,
+   * `^3` is the untracked-files snapshot when `-u` was used.
+   *
+   * Captured here so the cursor-syncs-history effect can jump to
+   * the stash's branch origin point rather than the stash commit
+   * itself. Older stashes' commits often fall outside the loaded
+   * `git log --max-count=300` window even when passed as graph
+   * roots; their parents almost never do because they're on
+   * regular branches with much more frequent commit activity.
+   *
+   * Empty string when git's output omitted the parent field (very
+   * old git versions or corrupted stash refs). Callers should treat
+   * empty as "no base available" rather than a valid commit.
+   */
+  baseHash: string
   date: string
   branch: string
   message: string
@@ -35,12 +53,19 @@ export function parseStashList(output: string): Omit<StashEntry, 'files'>[] {
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line) => {
-      const [ref, hash, date, subject] = line.split('\x1f')
+      const [ref, hash, parents, date, subject] = line.split('\x1f')
       const parsedSubject = parseStashSubject(subject || '')
+      // `%P` returns space-separated parent hashes. Stash commits are
+      // merges with 2-3 parents; the FIRST is the base (HEAD at stash
+      // time). Empty parents string (legacy / corrupted entries) maps
+      // to an empty baseHash; the cursor-sync caller treats that as
+      // "no base available, fall back to stash hash."
+      const baseHash = parents ? (parents.split(' ')[0] || '') : ''
 
       return {
         ref,
         hash,
+        baseHash,
         date,
         branch: parsedSubject.branch,
         message: parsedSubject.message,
@@ -79,8 +104,14 @@ export async function getStashCommitHashes(git: SimpleGit): Promise<string[]> {
 }
 
 export async function getStashOverview(git: SimpleGit): Promise<StashOverview> {
+  // Format fields (separated by 0x1f / unit separator):
+  //   %gd  — stash reflog selector (stash@{N})
+  //   %H   — stash commit hash
+  //   %P   — space-separated parent hashes (first = base, see StashEntry.baseHash)
+  //   %ci  — committer date, ISO format
+  //   %gs  — reflog subject ("WIP on main: <subject>")
   const stashes = parseStashList(
-    await git.raw(['stash', 'list', '--date=iso', '--format=%gd%x1f%H%x1f%ci%x1f%gs'])
+    await git.raw(['stash', 'list', '--date=iso', '--format=%gd%x1f%H%x1f%P%x1f%ci%x1f%gs'])
   )
 
   return {

--- a/src/git/stashData.ts
+++ b/src/git/stashData.ts
@@ -55,6 +55,29 @@ export function parseStashFiles(output: string): string[] {
     .filter(Boolean)
 }
 
+/**
+ * Resolve the commit hashes for every stash, in `stash@{N}` order.
+ *
+ * Used by the workstation's history loader to include older stashes
+ * as graph roots — `git log --all` only walks `refs/stash` (the
+ * latest stash) by default, so stash@{1+} commits live off-graph
+ * unless explicitly referenced. Passing this list as positional refs
+ * to `git log` makes every stash appear as a graph node, which lets
+ * the cursor-syncs-history effect actually land on them when the
+ * user navigates the stashes sidebar.
+ *
+ * Cheap: one `git stash list` call, no per-stash fan-out. Returns
+ * an empty array when there are no stashes — callers can pass the
+ * result through unconditionally.
+ */
+export async function getStashCommitHashes(git: SimpleGit): Promise<string[]> {
+  const raw = await git.raw(['stash', 'list', '--format=%H']).catch(() => '')
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
 export async function getStashOverview(git: SimpleGit): Promise<StashOverview> {
   const stashes = parseStashList(
     await git.raw(['stash', 'list', '--date=iso', '--format=%gd%x1f%H%x1f%ci%x1f%gs'])

--- a/src/git/tagData.test.ts
+++ b/src/git/tagData.test.ts
@@ -1,10 +1,13 @@
 import { parseTagRefs } from './tagData'
 
 describe('log tag data', () => {
-  it('parses tag refs from git for-each-ref output', () => {
+  it('parses lightweight tag refs (deref field empty → fall back to object SHA)', () => {
+    // Lightweight tags ARE direct pointers to commits, so
+    // `%(objectname:short)` already returns the commit SHA. The
+    // `%(*objectname:short)` deref field comes back empty for these.
     const refs = parseTagRefs([
-      ['0.33.0', 'abc1234', '2026-04-27', 'release v0.33.0'].join('\x1f'),
-      ['0.32.0', 'def5678', '2026-04-26', 'release v0.32.0'].join('\x1f'),
+      ['0.33.0', 'abc1234', '', '2026-04-27', 'release v0.33.0'].join('\x1f'),
+      ['0.32.0', 'def5678', '', '2026-04-26', 'release v0.32.0'].join('\x1f'),
     ].join('\n'))
 
     expect(refs).toEqual([
@@ -19,6 +22,27 @@ describe('log tag data', () => {
         hash: 'def5678',
         date: '2026-04-26',
         subject: 'release v0.32.0',
+      },
+    ])
+  })
+
+  it('prefers the dereferenced commit SHA for annotated tags', () => {
+    // Annotated tags wrap a tag object (which has its own SHA) around
+    // the commit. `%(objectname:short)` returns the TAG OBJECT's SHA;
+    // `%(*objectname:short)` follows the wrapper to the underlying
+    // commit. The parser MUST take the dereferenced form, otherwise
+    // cursor-sync would search the loaded log for a SHA that doesn't
+    // belong to any commit and report "unreachable."
+    const refs = parseTagRefs(
+      ['v1.0.0', 'tag0bj0', 'c0mm17ed', '2026-05-01', 'annotated release'].join('\x1f')
+    )
+
+    expect(refs).toEqual([
+      {
+        name: 'v1.0.0',
+        hash: 'c0mm17ed',
+        date: '2026-05-01',
+        subject: 'annotated release',
       },
     ])
   })

--- a/src/git/tagData.ts
+++ b/src/git/tagData.ts
@@ -27,7 +27,19 @@ export function parseTagRefs(output: string): GitTagRef[] {
     .map((line) => line.trimEnd())
     .filter(Boolean)
     .map((line) => {
-      const [name, hash, date, subject] = line.split(FIELD_SEPARATOR)
+      const [name, objectHash, derefedHash, date, subject] = line.split(FIELD_SEPARATOR)
+
+      // For annotated tags `%(objectname:short)` returns the TAG
+      // OBJECT's SHA, not the commit it points to — that's the SHA
+      // sitting in `refs/tags/<name>`'s blob. `%(*objectname:short)`
+      // dereferences the tag and yields the commit's SHA, but is
+      // EMPTY for lightweight tags (which are already direct
+      // pointers to commits). Prefer the dereferenced form when
+      // present, fall back to the object SHA otherwise. This is what
+      // lets cursor-sync find the tagged commit in the loaded log
+      // window — anchoring on the tag object's own SHA would never
+      // match a commit row.
+      const hash = derefedHash || objectHash
 
       return {
         name,
@@ -41,7 +53,7 @@ export function parseTagRefs(output: string): GitTagRef[] {
 export async function getTagOverview(git: SimpleGit): Promise<TagOverview> {
   const output = await git.raw([
     'for-each-ref',
-    `--format=%(refname:short)${FIELD_SEPARATOR}%(objectname:short)${FIELD_SEPARATOR}%(creatordate:short)${FIELD_SEPARATOR}%(subject)`,
+    `--format=%(refname:short)${FIELD_SEPARATOR}%(objectname:short)${FIELD_SEPARATOR}%(*objectname:short)${FIELD_SEPARATOR}%(creatordate:short)${FIELD_SEPARATOR}%(subject)`,
     '--sort=-creatordate',
     'refs/tags',
   ])

--- a/src/workstation/chrome/historyRows.test.ts
+++ b/src/workstation/chrome/historyRows.test.ts
@@ -53,7 +53,9 @@ const rows: GitLogRow[] = [
 
 describe('Ink history rows', () => {
   it('keeps compact mode calm by rendering commits only', () => {
-    const state = createLogInkState(rows)
+    // 0.54.x flipped the default `fullGraph` to true; explicit
+    // override here so the compact-mode behaviour stays pinned.
+    const state = createLogInkState(rows, { fullGraph: false })
     const visible = getVisibleLogInkHistory(state, 5)
 
     expect(visible.items.map((item) => item.type)).toEqual(['commit', 'commit', 'commit'])
@@ -61,7 +63,9 @@ describe('Ink history rows', () => {
   })
 
   it('preserves graph continuation rows in full graph mode', () => {
-    const state = applyLogInkAction(createLogInkState(rows), { type: 'toggleGraph' })
+    // Full mode is the 0.54.x default; pass explicitly so the test
+    // intent reads correctly without depending on the default.
+    const state = createLogInkState(rows, { fullGraph: true })
     const visible = getVisibleLogInkHistory(state, 5)
 
     expect(visible.items.map((item) => item.type)).toEqual([
@@ -90,7 +94,7 @@ describe('Ink history rows', () => {
   // synthetic single `*` per commit and gets no lane info.
   describe('lane segment attachment', () => {
     it('attaches lane segments to each visible item in full graph mode', () => {
-      const state = applyLogInkAction(createLogInkState(rows), { type: 'toggleGraph' })
+      const state = createLogInkState(rows, { fullGraph: true })
       const visible = getVisibleLogInkHistory(state, 5)
 
       const types = visible.items.map((item) => Boolean(item.laneSegments))
@@ -125,7 +129,7 @@ describe('Ink history rows', () => {
         refs: [],
         message: `commit ${i}`,
       }))
-      const state = applyLogInkAction(createLogInkState(longRows), { type: 'toggleGraph' })
+      const state = createLogInkState(longRows, { fullGraph: true })
       const scrolled = applyLogInkAction(state, { type: 'move', delta: 5 })
       const visible = getVisibleLogInkHistory(scrolled, 3)
 
@@ -142,7 +146,7 @@ describe('Ink history rows', () => {
       // merge / HEAD glyph but stay laneId-undefined so they render
       // muted (matching the legacy compact look). Stage 3 (#791) — the
       // glyph differentiation is the win.
-      const state = createLogInkState(rows)
+      const state = createLogInkState(rows, { fullGraph: false })
       const visible = getVisibleLogInkHistory(state, 5)
 
       visible.items.forEach((item) => {
@@ -231,7 +235,7 @@ describe('Ink history rows', () => {
 
   describe('lane segments thread the commit glyph through', () => {
     it('renders the HEAD commit with ◉ in full graph mode', () => {
-      const state = applyLogInkAction(createLogInkState(rows), { type: 'toggleGraph' })
+      const state = createLogInkState(rows, { fullGraph: true })
       const visible = getVisibleLogInkHistory(state, 5)
 
       // First fixture row is HEAD -> main + a merge — HEAD wins.
@@ -241,7 +245,7 @@ describe('Ink history rows', () => {
     })
 
     it('renders compact-mode commits with their distinct glyphs', () => {
-      const state = createLogInkState(rows)
+      const state = createLogInkState(rows, { fullGraph: false })
       const visible = getVisibleLogInkHistory(state, 5)
 
       // Order in compact (no graph rows): HEAD merge, side commit, root.
@@ -269,7 +273,7 @@ describe('Ink history rows', () => {
     }))
 
     it('injects a vertical-only graph row after every commit in full mode', () => {
-      const state = applyLogInkAction(createLogInkState(linearRows), { type: 'toggleGraph' })
+      const state = createLogInkState(linearRows, { fullGraph: true })
       const visible = getVisibleLogInkHistory(state, 8, { fullGraphSpacing: true })
 
       expect(visible.items.map((item) => item.type)).toEqual([
@@ -310,7 +314,7 @@ describe('Ink history rows', () => {
           parents: [], date: '2026-04-22', author: 'Coco', refs: [], message: 'feat: side',
         },
       ]
-      const state = applyLogInkAction(createLogInkState(mergeShapedRows), { type: 'toggleGraph' })
+      const state = createLogInkState(mergeShapedRows, { fullGraph: true })
       const visible = getVisibleLogInkHistory(state, 10, { fullGraphSpacing: true })
 
       const items = visible.items as Array<{ type: string; spacer?: boolean }>
@@ -325,21 +329,21 @@ describe('Ink history rows', () => {
     })
 
     it('does not inject spacers when fullGraphSpacing is off', () => {
-      const state = applyLogInkAction(createLogInkState(linearRows), { type: 'toggleGraph' })
+      const state = createLogInkState(linearRows, { fullGraph: true })
       const visible = getVisibleLogInkHistory(state, 8)
 
       expect(visible.items.every((item) => item.type === 'commit')).toBe(true)
     })
 
     it('does not inject spacers in compact mode regardless of option', () => {
-      const state = createLogInkState(linearRows)
+      const state = createLogInkState(linearRows, { fullGraph: false })
       const visible = getVisibleLogInkHistory(state, 8, { fullGraphSpacing: true })
 
       expect(visible.items.every((item) => item.type === 'commit')).toBe(true)
     })
 
     it('preserves trunk lane id 0 across spacers when scrolling', () => {
-      const state = applyLogInkAction(createLogInkState(linearRows), { type: 'toggleGraph' })
+      const state = createLogInkState(linearRows, { fullGraph: true })
       const scrolled = applyLogInkAction(state, { type: 'move', delta: 2 })
       const visible = getVisibleLogInkHistory(scrolled, 4, { fullGraphSpacing: true })
 
@@ -378,7 +382,7 @@ describe('Ink history rows', () => {
           parents: [], date: '2026-04-15', author: 'Coco', refs: [], message: 'feat: main below merge',
         },
       ]
-      const state = applyLogInkAction(createLogInkState(mergeShapedRows), { type: 'toggleGraph' })
+      const state = createLogInkState(mergeShapedRows, { fullGraph: true })
       const visible = getVisibleLogInkHistory(state, 10, { fullGraphSpacing: true })
 
       // Expected sequence — no synthetic spacers between the merge
@@ -416,7 +420,7 @@ describe('Ink history rows', () => {
           parents: [], date: '2026-04-22', author: 'Coco', refs: [], message: 'feat: side commit',
         },
       ]
-      const state = applyLogInkAction(createLogInkState(compressedMergeRows), { type: 'toggleGraph' })
+      const state = createLogInkState(compressedMergeRows, { fullGraph: true })
       const visible = getVisibleLogInkHistory(state, 10, { fullGraphSpacing: true })
 
       // No spacer between merge and side: merge's graph has `\` so
@@ -498,7 +502,7 @@ describe('Ink history rows', () => {
     })
 
     it('injects headers in full graph mode without disturbing lane tracking', () => {
-      const state = applyLogInkAction(createLogInkState(fixtureRows), { type: 'toggleGraph' })
+      const state = createLogInkState(fixtureRows, { fullGraph: true })
       const visible = getVisibleLogInkHistory(state, 10, { dateBucketingNow: NOW })
 
       // Headers appear; commits still carry lane segments.
@@ -525,7 +529,7 @@ describe('Ink history rows', () => {
           parents: [], date: '2026-05-13', author: 'Coco', refs: [], message: `yesterday ${i}`,
         })),
       ]
-      const state = applyLogInkAction(createLogInkState(longRows), { type: 'toggleGraph' })
+      const state = createLogInkState(longRows, { fullGraph: true })
       // Move the cursor to the 8th commit (deep in yesterday)
       const scrolled = applyLogInkAction(state, { type: 'move', delta: 7 })
       const visible = getVisibleLogInkHistory(scrolled, 4, { dateBucketingNow: NOW })

--- a/src/workstation/chrome/layout.test.ts
+++ b/src/workstation/chrome/layout.test.ts
@@ -34,18 +34,58 @@ describe('log Ink layout', () => {
     expect(layout.detailWidth).toBe(26)
   })
 
-  it('caps side panel widths on wide terminals', () => {
+  it('caps side panel widths on wide terminals so the main panel absorbs extra width', () => {
     const layout = getLogInkLayout({ columns: 200, rows: 60 })
 
     expect(layout.tooSmall).toBe(false)
     expect(layout.bodyRows).toBe(55)
-    // 200 cols is `wide`, where the sidebar uses 24% × cols clamped
-    // to 28-48: 0.24 × 200 = 48 — exactly the cap, so the sidebar
-    // grows naturally with the terminal rather than getting pinned
-    // at a 34-cell ceiling like before.
-    expect(layout.sidebarWidth).toBe(48)
-    // 200 * 0.22 = 44 → clamped down to the 32-cell maximum
+    // 200 cols is `wide`. Sidebar clamps to 28-32: 0.20 × 200 = 40
+    // → capped at 32. The sidebar stops growing past the wide-tier
+    // ceiling so all the additional terminal width flows to the
+    // history graph (the dominant view by user intent).
+    expect(layout.sidebarWidth).toBe(32)
+    // Inspector mirrors the same shape: 200 * 0.22 = 44 → clamped
+    // at the 32-cell maximum.
     expect(layout.detailWidth).toBe(32)
+    // Main panel gets everything else — at 200 cols that's
+    // 200 - 32 - 32 = 136 cells for the commit graph. On wider
+    // terminals (250, 300+ cols) the side panels stay at 32 and the
+    // graph keeps growing.
+    expect(layout.mainPanelWidth).toBe(136)
+  })
+
+  it('keeps the sidebar pinned at 32 across very wide terminals', () => {
+    // Pin the "sidebar doesn't grow past 32" invariant explicitly so
+    // a future tweak to the wide-tier fraction can't silently
+    // re-introduce the old "sidebar bloats on big screens" behaviour.
+    const huge = getLogInkLayout({ columns: 300, rows: 60 })
+    const insane = getLogInkLayout({ columns: 500, rows: 60 })
+
+    expect(huge.sidebarWidth).toBe(32)
+    expect(insane.sidebarWidth).toBe(32)
+    // Main panel keeps growing linearly: 300 - 32 - 32 = 236;
+    // 500 - 32 - 32 = 436. The graph view gets all the extra real
+    // estate.
+    expect(huge.mainPanelWidth).toBe(236)
+    expect(insane.mainPanelWidth).toBe(436)
+  })
+
+  it('holds the wide-tier floor at 28 so the sidebar doesn\'t shrink at the 159→160 boundary', () => {
+    // Sanity that resizing UP across the normal→wide boundary doesn't
+    // produce a jarring visual shrink. At 159 cols (normal tier),
+    // 159 * 0.22 = 34 → clamped to 30. At 160 (wide), 160 * 0.20 = 32.
+    // The floor of 28 means even smaller fractions land at 28+.
+    const normalEdge = getLogInkLayout({ columns: 159, rows: 60 })
+    const wideEdge = getLogInkLayout({ columns: 160, rows: 60 })
+
+    expect(normalEdge.density).toBe('normal')
+    expect(wideEdge.density).toBe('wide')
+    expect(normalEdge.sidebarWidth).toBe(30)
+    expect(wideEdge.sidebarWidth).toBe(32)
+    // Wide-tier sidebar is the same or larger than the normal-tier
+    // sidebar — never smaller. Avoids the "I expanded my terminal
+    // and the sidebar got smaller" surprise.
+    expect(wideEdge.sidebarWidth).toBeGreaterThanOrEqual(normalEdge.sidebarWidth)
   })
 
   it('clamps the inspector at rest to its 20-32 cell range above the rail tier', () => {
@@ -281,13 +321,17 @@ describe('log Ink layout', () => {
     )
 
     it.each([
-      [160, 38, 'wide'],
-      [180, 43, 'wide'],
-      [200, 48, 'wide'],
-      [250, 48, 'wide'],
-      [400, 48, 'wide'],
+      // Wide tier now caps at 32 so the main panel absorbs extra
+      // terminal width. 160 cols: floor (28) wins over 160 × 0.20 = 32
+      // ... actually both equal 32 at 160 cols, but the cap takes
+      // over from 165 onward.
+      [160, 32, 'wide'],
+      [180, 32, 'wide'],
+      [200, 32, 'wide'],
+      [250, 32, 'wide'],
+      [400, 32, 'wide'],
     ] as const)(
-      'wide tier %i cols → sidebar %i',
+      'wide tier %i cols → sidebar capped at 32',
       (columns, expected, density) => {
         const layout = getLogInkLayout({ columns, rows: 40 })
         expect(layout.density).toBe(density)
@@ -296,15 +340,16 @@ describe('log Ink layout', () => {
     )
 
     it('crosses the 159 → 160 boundary without the sidebar visibly shrinking', () => {
-      // The wide tier raises the floor to 28 (vs normal's 22) so a
-      // user dragging a window from 159 → 160 cols doesn't see the
-      // sidebar lurch downward. Normal ends at 30 (cap), wide starts
-      // at 38 (formula); the boundary feels like growth, not a
-      // discontinuity.
+      // The wide tier raises the floor to 28 (vs normal's 22) and
+      // caps at 32 — so a user dragging a window from 159 → 160 cols
+      // sees the sidebar nudge up from 30 to 32 rather than lurching
+      // down. The boundary feels like a small growth, not a
+      // discontinuity, and from there the sidebar holds steady while
+      // the main panel absorbs all the extra width.
       const normalEdge = getLogInkLayout({ columns: 159, rows: 40 })
       const wideEdge = getLogInkLayout({ columns: 160, rows: 40 })
       expect(normalEdge.sidebarWidth).toBe(30)
-      expect(wideEdge.sidebarWidth).toBe(38)
+      expect(wideEdge.sidebarWidth).toBe(32)
       expect(wideEdge.sidebarWidth).toBeGreaterThan(normalEdge.sidebarWidth)
     })
 

--- a/src/workstation/chrome/layout.ts
+++ b/src/workstation/chrome/layout.ts
@@ -135,19 +135,24 @@ export const LAYOUT_RAIL_PANEL_WIDTH = 8
  * the layout — the history graph + diff are usually the focal point.
  *
  * The tier split lets narrow terminals stay compact (the user has
- * little room to spare) while wide terminals scale the sidebar in
- * proportion to the rest of the chrome instead of pinning it at an
- * arbitrary cap.
+ * little room to spare) while wider terminals get a slightly larger
+ * sidebar. **Pinned at the wide-tier ceiling**: once the terminal
+ * grows past the normal tier the sidebar tops out at 32 cells. All
+ * additional terminal width flows to the history graph + inspector
+ * instead of bloating the sidebar. Matches user expectation that the
+ * git graph is the dominant view on big terminals.
  *
  *   tight  (100-119) → `clamp(22, 28, 24% × cols)`  e.g. 100→24, 119→28
  *   normal (120-159) → `clamp(22, 30, 22% × cols)`  e.g. 120→26, 140→30
- *   wide   (≥ 160)   → `clamp(28, 48, 24% × cols)`  e.g. 160→38, 200→48
+ *   wide   (≥ 160)   → `clamp(28, 32, 20% × cols)`  e.g. 160→32, 220→32
  *
  * The `tight` and `normal` tiers honor a hard floor of 22 cells —
  * narrower than that and the tab labels stop fitting on a single
  * line. The `wide` tier raises the floor to 28 so the sidebar
  * doesn't visually shrink when crossing the 159→160 boundary on a
- * resize.
+ * resize. The wide-tier max of 32 keeps the sidebar from growing
+ * past what the normal tier asks for — extra space goes to the
+ * main panel.
  *
  * Focused state (Tab → sidebar) uses a different formula entirely
  * (`clamp(32, 50, 36% × cols)`) — deliberate user intent to read the
@@ -158,7 +163,7 @@ const SIDEBAR_AT_REST_BY_TIER: Record<LogInkLayoutDensity, SidebarAtRestConfig> 
   rail: { min: 22, max: 28, fraction: 0.24 }, // unused — rail collapses to LAYOUT_RAIL_PANEL_WIDTH
   tight: { min: 22, max: 28, fraction: 0.24 },
   normal: { min: 22, max: 30, fraction: 0.22 },
-  wide: { min: 28, max: 48, fraction: 0.24 },
+  wide: { min: 28, max: 32, fraction: 0.20 },
 }
 
 function calcSidebarAtRestWidth(columns: number, density: LogInkLayoutDensity): number {

--- a/src/workstation/chrome/previewPane.test.ts
+++ b/src/workstation/chrome/previewPane.test.ts
@@ -36,6 +36,7 @@ const baseTag = (overrides: Partial<GitTagRef> = {}): GitTagRef => ({
 const baseStash = (overrides: Partial<StashEntry> = {}): StashEntry => ({
   ref: 'stash@{0}',
   hash: 'cafef00dba5eba11',
+  baseHash: 'base0fb45e0fb45e0',
   date: '2026-04-29',
   branch: 'feat/foo',
   message: 'WIP debugging',

--- a/src/workstation/chrome/stashHeader.test.ts
+++ b/src/workstation/chrome/stashHeader.test.ts
@@ -5,6 +5,7 @@ const stashes: StashEntry[] = [
   {
     ref: 'stash@{2026-05-01 23:01:18 -0400}',
     hash: 'aaa1111',
+    baseHash: 'base111',
     date: '2026-05-01',
     branch: 'main',
     message: 'WIP polish stash header',
@@ -13,6 +14,7 @@ const stashes: StashEntry[] = [
   {
     ref: 'stash@{2026-05-01 23:00:01 -0400}',
     hash: 'bbb2222',
+    baseHash: 'base222',
     date: '2026-05-01',
     branch: 'feat/x',
     message: 'experiment with carousel',
@@ -21,6 +23,7 @@ const stashes: StashEntry[] = [
   {
     ref: 'stash@{2026-04-22 11:00:00 -0400}',
     hash: 'ccc3333',
+    baseHash: 'base333',
     date: '2026-04-22',
     branch: '<unknown>',
     message: '',

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -4053,10 +4053,12 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       loading: true,
     })
     try {
-      const stashHashes = await getStashCommitHashes(git).catch(() => [])
-      const rows = await getLogRowsAnchoredOn(git, snap.logArgv, target.hash, {
-        extraRefs: stashHashes,
-      })
+      // No stashHashes here — `getLogRowsAnchoredOn` walks only from
+      // the target so it can guarantee the target's inclusion.
+      // Stashes are already in the loaded graph from boot's
+      // `loadRowsWithStashes`; `appendRows` deduplicates by hash so
+      // the merged result keeps both views without double-counting.
+      const rows = await getLogRowsAnchoredOn(git, snap.logArgv, target.hash, {})
       if (!mountedRef.current) return
       if (rows.length > 0) {
         dispatch({ type: 'appendRows', rows })

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -58,6 +58,7 @@ import * as nodePath from 'node:path'
 import type * as ReactTypes from 'react'
 import { SimpleGit } from 'simple-git'
 import { getBranchOverview } from '../../git/branchData'
+import { hashesMatchAny } from '../../git/hashes'
 import { getLfsAttributeStatus } from '../../git/lfsAttributes'
 import { getSubmoduleOverview } from '../../git/submoduleData'
 import { createManualCommit, formatCommitComposeMessage } from '../../commands/log/commitCompose'
@@ -1664,11 +1665,15 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         // Only after BOTH miss does the effect report "tip not in
         // loaded window." The label flips to mention "base" vs the
         // stash commit so the user knows what they're looking at.
-        const baseLoaded = stash.baseHash && state.filteredCommits.some((c) =>
-          c.hash === stash.baseHash || c.shortHash === stash.baseHash
+        // hashesMatchAny handles the short-hash auto-extension
+        // mismatch between `git stash list --format=%h` (stash hash)
+        // and `git log --pretty=format:%h` (history row). Same
+        // hazard as the branch/tag cursor sync — see src/git/hashes.ts.
+        const baseLoaded = Boolean(stash.baseHash) && state.filteredCommits.some((c) =>
+          hashesMatchAny(stash.baseHash, [c.hash, c.shortHash])
         )
         const hashLoaded = state.filteredCommits.some((c) =>
-          c.hash === stash.hash || c.shortHash === stash.hash
+          hashesMatchAny(stash.hash, [c.hash, c.shortHash])
         )
         if (baseLoaded) {
           targetHash = stash.baseHash

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -1574,7 +1574,14 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       (state.focus === 'sidebar' && state.sidebarTab === 'branches')
     const onTagTab = state.activeView === 'tags' ||
       (state.focus === 'sidebar' && state.sidebarTab === 'tags')
-    if (!onBranchTab && !onTagTab) return
+    // User-reported gap: cursoring a stash didn't sync the history
+    // cursor the way cursoring a branch / tag did. Same auto-jump
+    // affordance now extends to stashes; the stash's commit hash IS
+    // the row to land on (stashes are commits living off the
+    // `refs/stash` tree, visible under `--all` / fullGraph).
+    const onStashTab = state.activeView === 'stash' ||
+      (state.focus === 'sidebar' && state.sidebarTab === 'stashes')
+    if (!onBranchTab && !onTagTab && !onStashTab) return
 
     let targetHash: string | undefined
     let targetLabel: string | undefined
@@ -1598,6 +1605,19 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       if (tag) {
         targetHash = tag.hash
         targetLabel = `tag ${tag.name}`
+      }
+    } else if (onStashTab) {
+      const all = context.stashes?.stashes || []
+      const visible = state.filter
+        ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], state.filter))
+        : all
+      const stash = visible[Math.min(state.selectedStashIndex, Math.max(0, visible.length - 1))]
+      if (stash) {
+        targetHash = stash.hash
+        // `stash@{N}` is the canonical name and what the user sees in
+        // the sidebar row; using it verbatim makes the status copy
+        // match the visible label.
+        targetLabel = stash.ref
       }
     }
 
@@ -1630,22 +1650,24 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       })
     }
   }, [
-    dispatch, context.branches, context.tags,
+    dispatch, context.branches, context.tags, context.stashes,
     state.activeView, state.focus, state.sidebarTab,
-    state.selectedBranchIndex, state.selectedTagIndex,
+    state.selectedBranchIndex, state.selectedTagIndex, state.selectedStashIndex,
     state.branchSort, state.tagSort, state.filter,
     state.filteredCommits,
   ])
 
   // Reset the dedup ref when the user moves focus away from the
-  // sidebar branches / tags tab so re-entering re-fires the sync
-  // even if the cursored branch is the same as before.
+  // sidebar branches / tags / stashes tab so re-entering re-fires the
+  // sync even if the cursored row is the same as before.
   React.useEffect(() => {
     const onBranchTab = state.activeView === 'branches' ||
       (state.focus === 'sidebar' && state.sidebarTab === 'branches')
     const onTagTab = state.activeView === 'tags' ||
       (state.focus === 'sidebar' && state.sidebarTab === 'tags')
-    if (!onBranchTab && !onTagTab) {
+    const onStashTab = state.activeView === 'stash' ||
+      (state.focus === 'sidebar' && state.sidebarTab === 'stashes')
+    if (!onBranchTab && !onTagTab && !onStashTab) {
       lastSyncedHashRef.current = undefined
     }
   }, [state.activeView, state.focus, state.sidebarTab])
@@ -3537,7 +3559,38 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       // without flickering the surfaces through a 'loading' phase.
       await refreshContext({ silent: true })
     }
-  }, [context, dispatch, git, refreshContext, refreshHistoryRows, state.branchSort, state.filter, state.selectedBranchIndex,
+
+    // Stash workflow follow-up. Two distinct behaviours.
+    //
+    // **apply / pop**: the user brought stashed content back into the
+    // worktree, but the sidebar still has them on the stash view.
+    // Expected next move is "look at what landed in my worktree", so
+    // jump them to history view (where the worktree counts in the
+    // sidebar are visible) AND refresh worktree context explicitly so
+    // the staged / unstaged / untracked numbers reflect the changes.
+    //
+    // **drop**: the silent context refresh above already re-fetched
+    // the stash list, BUT users reported it feeling like nothing
+    // happened. Fix two things: refresh worktree alongside (drops can
+    // affect untracked files when the stash held `-u` state), and
+    // surface the new stash count on the status line so there's
+    // unambiguous feedback that the drop landed and the list shrank.
+    if (result?.ok && (id === 'apply-stash' || id === 'pop-stash')) {
+      dispatch({ type: 'pushView', value: 'history' })
+      await refreshWorktreeContext()
+    }
+    if (result?.ok && id === 'drop-stash') {
+      // Explicit worktree refresh in case the dropped stash carried
+      // untracked-file state that's now collected.
+      await refreshWorktreeContext()
+      // The silent context refresh already replaced `context.stashes`;
+      // reading the count back here would be stale because closures
+      // capture the pre-refresh value. Status message stays generic
+      // ("Dropped stash@{N}") — the visible list shrinking is the
+      // unambiguous signal that the operation landed.
+    }
+  }, [context, dispatch, git, refreshContext, refreshHistoryRows, refreshWorktreeContext,
+    state.branchSort, state.filter, state.selectedBranchIndex,
     state.selectedStashIndex, state.selectedTagIndex, state.selectedWorktreeListIndex, state.stashDiffRef,
     state.statusFilterMask, state.tagSort])
 

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -76,6 +76,7 @@ import {
     getCommitFilePreview,
     getCommitRows,
     getLogRows,
+    getLogRowsAnchoredOn,
 } from '../../commands/log/data'
 import {
     LogInkContextKey,
@@ -345,6 +346,10 @@ import type { LogArgv } from '../../commands/log/config'
 // runtime/ rather than chrome/ because they're tightly coupled to the
 // LogInkState filter-mode shape.
 import { matchesPromotedFilter } from '../runtime/promotedFilter'
+import {
+  buildLoadedHashSet,
+  resolveCursorSyncDecision,
+} from './cursorSyncResolver'
 
 // Chrome + overlay + dispatcher renderers extracted in phase 5a.7. The
 // per-surface and detail renderers are consumed internally by mainPanel /
@@ -1577,35 +1582,25 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // fetched yet); a status hint surfaces in that case so the user
   // knows to toggle full graph or load older commits.
   const lastSyncedHashRef = React.useRef<string | undefined>(undefined)
-  // Auto-load-to-find-target state (#1034 follow-up). When the user
-  // cursors a branch / tag / stash whose target commit isn't in the
-  // loaded window, the cursor-sync effect chains `loadMoreCommits()`
-  // calls until the target shows up OR we hit the cap. This ref
-  // tracks the in-flight target so each load-more completion can
-  // re-check ("did the page we just loaded contain my target?")
-  // without restarting from attempt zero.
+  // Tracks which target hashes we've already anchored a `git log`
+  // fetch on (#1034 follow-up). When the cursor-syncs-history effect
+  // sees a target whose hash isn't in the loaded window AND isn't in
+  // this set, it kicks off `getLogRowsAnchoredOn` and adds the hash
+  // here. After the fetch resolves and rows are appended, the effect
+  // re-fires; if the target STILL isn't loaded the resolver sees the
+  // hash in this set and returns `unreachable` instead of looping.
   //
-  // Reset when the user navigates to a different target (cursor
-  // moves to a different stash, branch swap, etc.) so the attempt
-  // counter starts fresh per new request.
-  const pendingAutoLoadRef = React.useRef<{
-    hash: string
-    label: string
-    attempts: number
-  } | null>(null)
-  const MAX_AUTO_LOAD_ATTEMPTS = 5
-  // Forward-reference: `loadMoreCommits` is defined later in the
-  // component body, but the cursor-sync effect (declared here) needs
-  // to invoke it. Using a ref breaks the circularity without moving
-  // 200+ LOC of unrelated helpers above this effect just for ordering.
-  // The loadMoreCommits useCallback writes itself into this ref on
-  // mount; the cursor sync calls through `current?.()` so the
-  // brief window before the ref is populated falls through cleanly.
-  type LoadMoreCommitsFn = (options?: { statusMessage?: string }) => Promise<{
-    fired: boolean
-    addedCommits: number
-  }>
-  const loadMoreCommitsRef = React.useRef<LoadMoreCommitsFn | null>(null)
+  // Stored as a ref because (a) the resolver only ever reads it and
+  // (b) component re-renders on state.filteredCommits change are the
+  // re-fire trigger; storing here in state would add a redundant
+  // render per attempt.
+  const attemptedContextHashesRef = React.useRef<Set<string>>(new Set())
+  // Forward-reference for the targeted context loader. Defined later
+  // in the component body — see the load-more refactor for why this
+  // forward-ref pattern is needed and why the implementation is stable
+  // so the race that bit the previous auto-load chain doesn't recur.
+  type LoadCommitContextFn = (target: { hash: string; label: string }) => Promise<void>
+  const loadCommitContextRef = React.useRef<LoadCommitContextFn | null>(null)
   React.useEffect(() => {
     const onBranchTab = state.activeView === 'branches' ||
       (state.focus === 'sidebar' && state.sidebarTab === 'branches')
@@ -1691,87 +1686,44 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       }
     }
 
-    if (!targetHash) return
-    // Skip the dispatch + status churn when the cursor hasn't
-    // actually changed which commit it's targeting (the case for
-    // rapid navigation through a cluster of branches that all point
-    // at the same commit). Without this guard the user sees a stream
-    // of "Synced history to <branch> tip" status messages even
-    // though the history cursor never moved.
-    if (targetHash === lastSyncedHashRef.current) return
+    // Delegate the actual decision to the pure resolver so the
+    // logic is testable in isolation. The effect just performs the
+    // resolver's chosen action.
+    const decision = resolveCursorSyncDecision({
+      target: targetHash ? { hash: targetHash, label: targetLabel || targetHash } : undefined,
+      loadedHashes: buildLoadedHashSet(state.filteredCommits),
+      lastSyncedHash: lastSyncedHashRef.current,
+      attemptedContextHashes: attemptedContextHashesRef.current,
+    })
 
-    const loaded = state.filteredCommits.some((commit) =>
-      commit.hash === targetHash || commit.shortHash === targetHash
-    )
-    if (loaded) {
-      lastSyncedHashRef.current = targetHash
-      // Found it — clear any pending auto-load tracking for this
-      // target so subsequent navigations don't carry stale attempt
-      // counters forward.
-      pendingAutoLoadRef.current = null
-      dispatch({ type: 'selectCommitByHash', hash: targetHash })
-      // Confirmation status message so the user gets feedback even
-      // when the dedicated branches / tags view is occupying the
-      // main panel and the history cursor moves invisibly behind it.
-      dispatch({
-        type: 'setStatus',
-        value: `Synced history to ${targetLabel} tip`,
-      })
-    } else {
-      // Target isn't in the loaded window. Try to auto-load more
-      // commits and re-check rather than just telling the user
-      // "tip not in loaded window" and giving up. Each successful
-      // load-more updates `state.filteredCommits` which re-fires
-      // this effect; the pendingAutoLoadRef carries the attempt
-      // counter so we cap the chain at `MAX_AUTO_LOAD_ATTEMPTS`
-      // and don't loop forever on a ref pointing at a commit
-      // unreachable from any current branch.
-      const pending = pendingAutoLoadRef.current
-      const startedNewTarget = !pending || pending.hash !== targetHash
-      if (startedNewTarget) {
-        pendingAutoLoadRef.current = {
-          hash: targetHash,
-          // `targetLabel` is technically `string | undefined` per the
-          // declaration above, but we only reach this branch when
-          // `targetHash` is set, and every branch that sets
-          // `targetHash` also sets `targetLabel`. Fall back to the
-          // raw hash if a future code path forgets to set the label.
-          label: targetLabel || targetHash,
-          attempts: 0,
-        }
-      }
-      const current = pendingAutoLoadRef.current!
-      if (current.attempts >= MAX_AUTO_LOAD_ATTEMPTS) {
-        // Cap hit — stop chaining and surface the manual escape
-        // valve. Don't clear pendingAutoLoadRef here; if the user
-        // navigates elsewhere we'll reset on the next mismatch.
+    switch (decision.type) {
+      case 'noop':
+        return
+      case 'jump':
+        lastSyncedHashRef.current = decision.hash
+        dispatch({ type: 'selectCommitByHash', hash: decision.hash })
         dispatch({
           type: 'setStatus',
-          value: `${targetLabel} target commit is beyond ${LOG_INTERACTIVE_DEFAULT_LIMIT * MAX_AUTO_LOAD_ATTEMPTS} commits — too far back to auto-load.`,
+          value: `Synced history to ${decision.label} tip`,
         })
         return
-      }
-      if (!hasMoreCommits) {
-        // Nothing left to load — the target ref points at a commit
-        // that isn't reachable from any ref we know about (e.g. a
-        // stash whose base branch was deleted and the stash itself
-        // is so old it fell off git's effective walk).
+      case 'load-context':
+        // Mark the hash as attempted BEFORE firing the load so a
+        // re-fire of this effect (state.filteredCommits change while
+        // the load is in flight) doesn't kick off a duplicate
+        // request. The resolver sees the hash in the set and
+        // returns `noop` until the load completes; on completion the
+        // appendRows triggers a final re-fire that either jumps or
+        // returns `unreachable`.
+        attemptedContextHashesRef.current.add(decision.target.hash)
+        void loadCommitContextRef.current?.(decision.target)
+        return
+      case 'unreachable':
         dispatch({
           type: 'setStatus',
-          value: `${targetLabel} target commit is unreachable from any loaded ref.`,
+          value: `${decision.target.label} target commit is unreachable — not in any walked ref's history.`,
         })
-        pendingAutoLoadRef.current = null
         return
-      }
-      current.attempts += 1
-      // Fire-and-forget — `appendRows` updates `state.filteredCommits`
-      // which re-fires this effect; the next pass either finds the
-      // target or increments the counter again. Go through the ref
-      // because `loadMoreCommits` is declared later in the component
-      // body (see the forward-reference note where the ref is set up).
-      void loadMoreCommitsRef.current?.({
-        statusMessage: `Loading more commits to find ${current.label} (${current.attempts}/${MAX_AUTO_LOAD_ATTEMPTS})…`,
-      })
     }
   }, [
     dispatch, context.branches, context.tags, context.stashes,
@@ -1779,7 +1731,6 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     state.selectedBranchIndex, state.selectedTagIndex, state.selectedStashIndex,
     state.branchSort, state.tagSort, state.filter,
     state.filteredCommits,
-    hasMoreCommits,
   ])
 
   // Reset the dedup ref when the user moves focus away from the
@@ -1794,10 +1745,10 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       (state.focus === 'sidebar' && state.sidebarTab === 'stashes')
     if (!onBranchTab && !onTagTab && !onStashTab) {
       lastSyncedHashRef.current = undefined
-      // Drop any in-flight auto-load chain too — the user left the
-      // ref sidebar so we no longer want to keep paging through
-      // commits searching for a target they've stopped caring about.
-      pendingAutoLoadRef.current = null
+      // Drop any context-load attempt tracking too. If the user
+      // navigates back later we want to retry rather than show
+      // "unreachable" based on a stale attempted-set.
+      attemptedContextHashesRef.current = new Set()
     }
   }, [state.activeView, state.focus, state.sidebarTab])
 
@@ -4051,15 +4002,6 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     // already stable across renders by React's contract.
   }, [dispatch, git])
 
-  // Expose `loadMoreCommits` to the cursor-sync effect via the
-  // forward-reference ref set up above. Keeps the effect's chained
-  // auto-load logic decoupled from the lexical ordering of these
-  // callbacks (the effect runs at line ~1670; this useCallback is
-  // declared 2000+ lines later).
-  React.useEffect(() => {
-    loadMoreCommitsRef.current = loadMoreCommits
-  }, [loadMoreCommits])
-
   // Scroll-near-bottom auto-trigger. Fires when the user's cursor is
   // within 20 rows of the last loaded commit so older history is
   // already on its way by the time they reach the bottom.
@@ -4082,6 +4024,68 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     state.filteredCommits.length,
     state.selectedIndex,
   ])
+
+  /**
+   * Targeted-context loader for the cursor-syncs-history effect. Called
+   * when the resolver returns `load-context` — the user cursored a
+   * branch / tag / stash whose target commit isn't in the loaded
+   * window, so we run a `git log` anchored on that commit (guaranteed
+   * to include it) and merge the result via `appendRows` (which
+   * already deduplicates by hash).
+   *
+   * Stable identity (empty deps) for the same reason as
+   * `loadMoreCommits` — the cursor-sync effect calls this through a
+   * forward-reference ref, and a regenerating callback would
+   * reintroduce the render-order race that bit the previous chain.
+   * All volatile state (logArgv, mostly) is read via refs.
+   */
+  const loadCommitContextStateRef = React.useRef({ logArgv })
+  loadCommitContextStateRef.current = { logArgv }
+
+  const loadCommitContext = React.useCallback(async (
+    target: { hash: string; label: string }
+  ): Promise<void> => {
+    const snap = loadCommitContextStateRef.current
+    if (!snap.logArgv) return
+    dispatch({
+      type: 'setStatus',
+      value: `Loading commits around ${target.label}…`,
+      loading: true,
+    })
+    try {
+      const stashHashes = await getStashCommitHashes(git).catch(() => [])
+      const rows = await getLogRowsAnchoredOn(git, snap.logArgv, target.hash, {
+        extraRefs: stashHashes,
+      })
+      if (!mountedRef.current) return
+      if (rows.length > 0) {
+        dispatch({ type: 'appendRows', rows })
+        // Don't dispatch a setStatus here — the cursor-sync effect
+        // will re-fire on the appendRows-driven filteredCommits
+        // change and either jump (success) or report unreachable
+        // (failure), surfacing the right message.
+      } else {
+        dispatch({
+          type: 'setStatus',
+          value: `${target.label} target commit returned no rows — orphan ref?`,
+        })
+      }
+    } catch (error) {
+      if (mountedRef.current) {
+        dispatch({
+          type: 'setStatus',
+          value: `Failed to load context for ${target.label}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          kind: 'error',
+        })
+      }
+    }
+  }, [dispatch, git])
+
+  React.useEffect(() => {
+    loadCommitContextRef.current = loadCommitContext
+  }, [loadCommitContext])
 
   // Server-side history filter (#776). When the user submits `path:foo`
   // or `author:foo`, the filter parser dispatches setHistoryFetchArgs;

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -3954,18 +3954,46 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     loadingMoreCommitsRef.current = loadingMoreCommits
   }, [loadingMoreCommits])
 
-  // Extracted as a callback (was inline inside the scroll-near-bottom
-  // effect) so the cursor-syncs-history auto-load path can invoke it
-  // directly when a stash / branch / tag's target commit isn't yet
-  // in the loaded window. Returns a flag indicating whether a load
-  // actually fired so the caller can update its attempt counter.
+  // STABLE useCallback (empty deps) for loadMoreCommits. The function
+  // reads the volatile state (commit counts, fetch args, hasMore) via
+  // refs that update on every render so the identity stays constant.
+  //
+  // Why stable matters: the cursor-syncs-history auto-load chain
+  // calls this through a forward-reference ref (loadMoreCommitsRef).
+  // If loadMoreCommits regenerated on every render — as the previous
+  // implementation did via state deps — there was a render-order
+  // race: the cursor sync effect would call the PREVIOUS render's
+  // callback (still in the ref because the ref-setter useEffect runs
+  // after the cursor-sync effect in declaration order), which had
+  // captured a stale `state.commits.length` and re-fetched the same
+  // window. The auto-load chain appeared to fire but never advanced
+  // through history.
+  //
+  // Stable identity + refs sidesteps the race entirely: the function
+  // never changes, and every call reads the latest state.
+  const loadMoreStateRef = React.useRef({
+    commitsLength: state.commits.length,
+    filteredCommitsLength: state.filteredCommits.length,
+    historyFetchArgs: state.historyFetchArgs,
+    hasMoreCommits,
+    logArgv,
+  })
+  loadMoreStateRef.current = {
+    commitsLength: state.commits.length,
+    filteredCommitsLength: state.filteredCommits.length,
+    historyFetchArgs: state.historyFetchArgs,
+    hasMoreCommits,
+    logArgv,
+  }
+
   const loadMoreCommits = React.useCallback(async (
     options: { statusMessage?: string } = {}
   ): Promise<{ fired: boolean; addedCommits: number }> => {
-    if (!logArgv || logArgv.limit || loadingMoreCommitsRef.current || !hasMoreCommits) {
+    const snap = loadMoreStateRef.current
+    if (!snap.logArgv || snap.logArgv.limit || loadingMoreCommitsRef.current || !snap.hasMoreCommits) {
       return { fired: false, addedCommits: 0 }
     }
-    if (state.filteredCommits.length === 0) {
+    if (snap.filteredCommitsLength === 0) {
       return { fired: false, addedCommits: 0 }
     }
 
@@ -3978,9 +4006,9 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       value: options.statusMessage || 'loading older commits',
       loading: true,
     })
-    const fetchArgs = state.historyFetchArgs
+    const fetchArgs = snap.historyFetchArgs
     const mergedArgv: LogArgv = {
-      ...logArgv,
+      ...snap.logArgv,
       ...(fetchArgs?.author ? { author: fetchArgs.author } : {}),
       ...(fetchArgs?.path ? { path: fetchArgs.path } : {}),
     }
@@ -3992,7 +4020,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     const nextRows = await safe(
       getLogRows(git, mergedArgv, {
         limit: LOG_INTERACTIVE_DEFAULT_LIMIT,
-        skip: state.commits.length,
+        skip: snap.commitsLength,
         extraRefs: stashHashes,
       })
     )
@@ -4017,15 +4045,11 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
 
     setHasMoreCommits(nextCommitCount >= LOG_INTERACTIVE_DEFAULT_LIMIT)
     return { fired: true, addedCommits: nextCommitCount }
-  }, [
-    dispatch,
-    git,
-    hasMoreCommits,
-    logArgv,
-    state.commits.length,
-    state.filteredCommits.length,
-    state.historyFetchArgs,
-  ])
+    // Empty deps — the function is intentionally stable. State is
+    // read via `loadMoreStateRef.current` at call time, and `dispatch`
+    // / `git` / `setLoadingMoreCommits` / `setHasMoreCommits` are
+    // already stable across renders by React's contract.
+  }, [dispatch, git])
 
   // Expose `loadMoreCommits` to the cursor-sync effect via the
   // forward-reference ref set up above. Keeps the effect's chained

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -1621,27 +1621,44 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         : all
       const stash = visible[Math.min(state.selectedStashIndex, Math.max(0, visible.length - 1))]
       if (stash) {
-        // Target the stash's BASE commit (its first parent, the branch
-        // tip when `git stash push` ran) rather than the stash commit
-        // itself. This answers the user-visible question "where in
-        // larger git history was this stash created?" — that's the
-        // branch origin point, not the stash's own merge-commit row
-        // off in `refs/stash`. Practical benefit: base commits are on
-        // regular branches and are basically always in the loaded
-        // `git log --max-count=300` window, so the cursor actually
-        // moves on every stash; stash commits older than the 300th
-        // most recent often fall outside the window even when passed
-        // as graph roots.
+        // Two-step fallback chain for stash cursor sync:
         //
-        // Fallback to stash.hash when baseHash is empty (legacy /
-        // corrupted stash refs that omitted %P from the format
-        // output). The cursor may still hit "tip not in loaded
-        // window" in that edge case but at least we tried.
-        targetHash = stash.baseHash || stash.hash
-        // `stash@{N}` is the canonical name and what the user sees in
-        // the sidebar row; using it verbatim makes the status copy
-        // match the visible label.
-        targetLabel = stash.ref
+        //   1. Try `baseHash` (the branch tip the stash was created
+        //      from). This answers the user-visible question "where
+        //      in larger git history was this stash made?" — that's
+        //      the branch origin point, not the stash's own merge-
+        //      commit row off in `refs/stash`. Base commits live on
+        //      regular branches so they're almost always in the
+        //      loaded window.
+        //
+        //   2. If `baseHash` isn't in the loaded window (the stash's
+        //      base branch was deleted, or the base is older than
+        //      the 1000-commit cap), fall back to `stash.hash`
+        //      itself. The stash commit was added as an extraRef so
+        //      it's reachable from the graph if it fits the window.
+        //
+        // Only after BOTH miss does the effect report "tip not in
+        // loaded window." The label flips to mention "base" vs the
+        // stash commit so the user knows what they're looking at.
+        const baseLoaded = stash.baseHash && state.filteredCommits.some((c) =>
+          c.hash === stash.baseHash || c.shortHash === stash.baseHash
+        )
+        const hashLoaded = state.filteredCommits.some((c) =>
+          c.hash === stash.hash || c.shortHash === stash.hash
+        )
+        if (baseLoaded) {
+          targetHash = stash.baseHash
+          targetLabel = `${stash.ref}'s base`
+        } else if (hashLoaded) {
+          targetHash = stash.hash
+          targetLabel = stash.ref
+        } else {
+          // Neither in window — set to baseHash so the standard
+          // "not in loaded window" message fires with a meaningful
+          // label (the base is what the user actually wants to see).
+          targetHash = stash.baseHash || stash.hash
+          targetLabel = stash.ref
+        }
       }
     }
 

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -1577,6 +1577,35 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // fetched yet); a status hint surfaces in that case so the user
   // knows to toggle full graph or load older commits.
   const lastSyncedHashRef = React.useRef<string | undefined>(undefined)
+  // Auto-load-to-find-target state (#1034 follow-up). When the user
+  // cursors a branch / tag / stash whose target commit isn't in the
+  // loaded window, the cursor-sync effect chains `loadMoreCommits()`
+  // calls until the target shows up OR we hit the cap. This ref
+  // tracks the in-flight target so each load-more completion can
+  // re-check ("did the page we just loaded contain my target?")
+  // without restarting from attempt zero.
+  //
+  // Reset when the user navigates to a different target (cursor
+  // moves to a different stash, branch swap, etc.) so the attempt
+  // counter starts fresh per new request.
+  const pendingAutoLoadRef = React.useRef<{
+    hash: string
+    label: string
+    attempts: number
+  } | null>(null)
+  const MAX_AUTO_LOAD_ATTEMPTS = 5
+  // Forward-reference: `loadMoreCommits` is defined later in the
+  // component body, but the cursor-sync effect (declared here) needs
+  // to invoke it. Using a ref breaks the circularity without moving
+  // 200+ LOC of unrelated helpers above this effect just for ordering.
+  // The loadMoreCommits useCallback writes itself into this ref on
+  // mount; the cursor sync calls through `current?.()` so the
+  // brief window before the ref is populated falls through cleanly.
+  type LoadMoreCommitsFn = (options?: { statusMessage?: string }) => Promise<{
+    fired: boolean
+    addedCommits: number
+  }>
+  const loadMoreCommitsRef = React.useRef<LoadMoreCommitsFn | null>(null)
   React.useEffect(() => {
     const onBranchTab = state.activeView === 'branches' ||
       (state.focus === 'sidebar' && state.sidebarTab === 'branches')
@@ -1676,6 +1705,10 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     )
     if (loaded) {
       lastSyncedHashRef.current = targetHash
+      // Found it — clear any pending auto-load tracking for this
+      // target so subsequent navigations don't carry stale attempt
+      // counters forward.
+      pendingAutoLoadRef.current = null
       dispatch({ type: 'selectCommitByHash', hash: targetHash })
       // Confirmation status message so the user gets feedback even
       // when the dedicated branches / tags view is occupying the
@@ -1685,9 +1718,59 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         value: `Synced history to ${targetLabel} tip`,
       })
     } else {
-      dispatch({
-        type: 'setStatus',
-        value: `${targetLabel} tip not in loaded window — press \\ for full graph or Ctrl+L to load more`,
+      // Target isn't in the loaded window. Try to auto-load more
+      // commits and re-check rather than just telling the user
+      // "tip not in loaded window" and giving up. Each successful
+      // load-more updates `state.filteredCommits` which re-fires
+      // this effect; the pendingAutoLoadRef carries the attempt
+      // counter so we cap the chain at `MAX_AUTO_LOAD_ATTEMPTS`
+      // and don't loop forever on a ref pointing at a commit
+      // unreachable from any current branch.
+      const pending = pendingAutoLoadRef.current
+      const startedNewTarget = !pending || pending.hash !== targetHash
+      if (startedNewTarget) {
+        pendingAutoLoadRef.current = {
+          hash: targetHash,
+          // `targetLabel` is technically `string | undefined` per the
+          // declaration above, but we only reach this branch when
+          // `targetHash` is set, and every branch that sets
+          // `targetHash` also sets `targetLabel`. Fall back to the
+          // raw hash if a future code path forgets to set the label.
+          label: targetLabel || targetHash,
+          attempts: 0,
+        }
+      }
+      const current = pendingAutoLoadRef.current!
+      if (current.attempts >= MAX_AUTO_LOAD_ATTEMPTS) {
+        // Cap hit — stop chaining and surface the manual escape
+        // valve. Don't clear pendingAutoLoadRef here; if the user
+        // navigates elsewhere we'll reset on the next mismatch.
+        dispatch({
+          type: 'setStatus',
+          value: `${targetLabel} target commit is beyond ${LOG_INTERACTIVE_DEFAULT_LIMIT * MAX_AUTO_LOAD_ATTEMPTS} commits — too far back to auto-load.`,
+        })
+        return
+      }
+      if (!hasMoreCommits) {
+        // Nothing left to load — the target ref points at a commit
+        // that isn't reachable from any ref we know about (e.g. a
+        // stash whose base branch was deleted and the stash itself
+        // is so old it fell off git's effective walk).
+        dispatch({
+          type: 'setStatus',
+          value: `${targetLabel} target commit is unreachable from any loaded ref.`,
+        })
+        pendingAutoLoadRef.current = null
+        return
+      }
+      current.attempts += 1
+      // Fire-and-forget — `appendRows` updates `state.filteredCommits`
+      // which re-fires this effect; the next pass either finds the
+      // target or increments the counter again. Go through the ref
+      // because `loadMoreCommits` is declared later in the component
+      // body (see the forward-reference note where the ref is set up).
+      void loadMoreCommitsRef.current?.({
+        statusMessage: `Loading more commits to find ${current.label} (${current.attempts}/${MAX_AUTO_LOAD_ATTEMPTS})…`,
       })
     }
   }, [
@@ -1696,6 +1779,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     state.selectedBranchIndex, state.selectedTagIndex, state.selectedStashIndex,
     state.branchSort, state.tagSort, state.filter,
     state.filteredCommits,
+    hasMoreCommits,
   ])
 
   // Reset the dedup ref when the user moves focus away from the
@@ -1710,6 +1794,10 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       (state.focus === 'sidebar' && state.sidebarTab === 'stashes')
     if (!onBranchTab && !onTagTab && !onStashTab) {
       lastSyncedHashRef.current = undefined
+      // Drop any in-flight auto-load chain too — the user left the
+      // ref sidebar so we no longer want to keep paging through
+      // commits searching for a target they've stopped caring about.
+      pendingAutoLoadRef.current = null
     }
   }, [state.activeView, state.focus, state.sidebarTab])
 
@@ -3866,80 +3954,108 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     loadingMoreCommitsRef.current = loadingMoreCommits
   }, [loadingMoreCommits])
 
-  React.useEffect(() => {
-    const remaining = state.filteredCommits.length - state.selectedIndex - 1
-
-    async function loadMoreCommits(): Promise<void> {
-      if (!logArgv || logArgv.limit || loadingMoreCommitsRef.current || !hasMoreCommits) {
-        return
-      }
-
-      if (state.filteredCommits.length === 0 || remaining > 20) {
-        return
-      }
-
-      loadingMoreCommitsRef.current = true
-      const requestId = loadMoreRequestRef.current + 1
-      loadMoreRequestRef.current = requestId
-      setLoadingMoreCommits(true)
-      dispatch({ type: 'setStatus', value: 'loading older commits' })
-      const fetchArgs = state.historyFetchArgs
-      const mergedArgv: LogArgv = {
-        ...logArgv,
-        ...(fetchArgs?.author ? { author: fetchArgs.author } : {}),
-        ...(fetchArgs?.path ? { path: fetchArgs.path } : {}),
-      }
-      // Load-more paths a fresh page from git AFTER what's already
-      // loaded; pass the stash hashes again so the additional rows
-      // stay graph-consistent with the boot fetch (a window that
-      // dropped stashes mid-stream would render with broken
-      // junctions).
-      const stashHashes = await getStashCommitHashes(git).catch(() => [])
-      const nextRows = await safe(
-        getLogRows(git, mergedArgv, {
-          limit: LOG_INTERACTIVE_DEFAULT_LIMIT,
-          skip: state.commits.length,
-          extraRefs: stashHashes,
-        })
-      )
-
-      if (!mountedRef.current || loadMoreRequestRef.current !== requestId) {
-        return
-      }
-
-      loadingMoreCommitsRef.current = false
-      setLoadingMoreCommits(false)
-
-      const nextCommitCount = nextRows ? getCommitRows(nextRows).length : 0
-
-      if (!nextRows) {
-        dispatch({ type: 'setStatus', value: 'failed to load older commits' })
-        return
-      }
-
-      if (nextRows?.length) {
-        dispatch({ type: 'appendRows', rows: nextRows })
-      }
-
-      setHasMoreCommits(nextCommitCount >= LOG_INTERACTIVE_DEFAULT_LIMIT)
-      dispatch({
-        type: 'setStatus',
-        value: nextCommitCount
-          ? `loaded ${nextCommitCount} older commits`
-          : 'end of history',
-      })
+  // Extracted as a callback (was inline inside the scroll-near-bottom
+  // effect) so the cursor-syncs-history auto-load path can invoke it
+  // directly when a stash / branch / tag's target commit isn't yet
+  // in the loaded window. Returns a flag indicating whether a load
+  // actually fired so the caller can update its attempt counter.
+  const loadMoreCommits = React.useCallback(async (
+    options: { statusMessage?: string } = {}
+  ): Promise<{ fired: boolean; addedCommits: number }> => {
+    if (!logArgv || logArgv.limit || loadingMoreCommitsRef.current || !hasMoreCommits) {
+      return { fired: false, addedCommits: 0 }
+    }
+    if (state.filteredCommits.length === 0) {
+      return { fired: false, addedCommits: 0 }
     }
 
-    void loadMoreCommits()
+    loadingMoreCommitsRef.current = true
+    const requestId = loadMoreRequestRef.current + 1
+    loadMoreRequestRef.current = requestId
+    setLoadingMoreCommits(true)
+    dispatch({
+      type: 'setStatus',
+      value: options.statusMessage || 'loading older commits',
+      loading: true,
+    })
+    const fetchArgs = state.historyFetchArgs
+    const mergedArgv: LogArgv = {
+      ...logArgv,
+      ...(fetchArgs?.author ? { author: fetchArgs.author } : {}),
+      ...(fetchArgs?.path ? { path: fetchArgs.path } : {}),
+    }
+    // Load-more paths a fresh page from git AFTER what's already
+    // loaded; pass the stash hashes again so the additional rows
+    // stay graph-consistent with the boot fetch (a window that
+    // dropped stashes mid-stream would render with broken junctions).
+    const stashHashes = await getStashCommitHashes(git).catch(() => [])
+    const nextRows = await safe(
+      getLogRows(git, mergedArgv, {
+        limit: LOG_INTERACTIVE_DEFAULT_LIMIT,
+        skip: state.commits.length,
+        extraRefs: stashHashes,
+      })
+    )
+
+    if (!mountedRef.current || loadMoreRequestRef.current !== requestId) {
+      return { fired: false, addedCommits: 0 }
+    }
+
+    loadingMoreCommitsRef.current = false
+    setLoadingMoreCommits(false)
+
+    const nextCommitCount = nextRows ? getCommitRows(nextRows).length : 0
+
+    if (!nextRows) {
+      dispatch({ type: 'setStatus', value: 'failed to load older commits' })
+      return { fired: false, addedCommits: 0 }
+    }
+
+    if (nextRows?.length) {
+      dispatch({ type: 'appendRows', rows: nextRows })
+    }
+
+    setHasMoreCommits(nextCommitCount >= LOG_INTERACTIVE_DEFAULT_LIMIT)
+    return { fired: true, addedCommits: nextCommitCount }
   }, [
     dispatch,
     git,
     hasMoreCommits,
-    loadingMoreCommits,
     logArgv,
     state.commits.length,
     state.filteredCommits.length,
     state.historyFetchArgs,
+  ])
+
+  // Expose `loadMoreCommits` to the cursor-sync effect via the
+  // forward-reference ref set up above. Keeps the effect's chained
+  // auto-load logic decoupled from the lexical ordering of these
+  // callbacks (the effect runs at line ~1670; this useCallback is
+  // declared 2000+ lines later).
+  React.useEffect(() => {
+    loadMoreCommitsRef.current = loadMoreCommits
+  }, [loadMoreCommits])
+
+  // Scroll-near-bottom auto-trigger. Fires when the user's cursor is
+  // within 20 rows of the last loaded commit so older history is
+  // already on its way by the time they reach the bottom.
+  React.useEffect(() => {
+    const remaining = state.filteredCommits.length - state.selectedIndex - 1
+    if (remaining > 20) return
+    void loadMoreCommits().then((result) => {
+      if (result.fired) {
+        dispatch({
+          type: 'setStatus',
+          value: result.addedCommits
+            ? `loaded ${result.addedCommits} older commits`
+            : 'end of history',
+        })
+      }
+    })
+  }, [
+    dispatch,
+    loadMoreCommits,
+    state.filteredCommits.length,
     state.selectedIndex,
   ])
 

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -1621,7 +1621,23 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         : all
       const stash = visible[Math.min(state.selectedStashIndex, Math.max(0, visible.length - 1))]
       if (stash) {
-        targetHash = stash.hash
+        // Target the stash's BASE commit (its first parent, the branch
+        // tip when `git stash push` ran) rather than the stash commit
+        // itself. This answers the user-visible question "where in
+        // larger git history was this stash created?" — that's the
+        // branch origin point, not the stash's own merge-commit row
+        // off in `refs/stash`. Practical benefit: base commits are on
+        // regular branches and are basically always in the loaded
+        // `git log --max-count=300` window, so the cursor actually
+        // moves on every stash; stash commits older than the 300th
+        // most recent often fall outside the window even when passed
+        // as graph roots.
+        //
+        // Fallback to stash.hash when baseHash is empty (legacy /
+        // corrupted stash refs that omitted %P from the format
+        // output). The cursor may still hit "tip not in loaded
+        // window" in that edge case but at least we tried.
+        targetHash = stash.baseHash || stash.hash
         // `stash@{N}` is the canonical name and what the user sees in
         // the sidebar row; using it verbatim makes the status copy
         // match the visible label.

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -302,6 +302,7 @@ import {
 import { runPullRequestBodyWorkflow } from '../../git/aiActions'
 import {
     findStashFileForOffset,
+    getStashCommitHashes,
     getStashDiff,
     getStashOverview,
     parseStashDiffFiles,
@@ -924,8 +925,15 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         ...(fetchArgs?.author ? { author: fetchArgs.author } : {}),
         ...(fetchArgs?.path ? { path: fetchArgs.path } : {}),
       } as LogArgv
+      // Stash commits as graph roots so post-operation refreshes
+      // keep the same rich graph the boot loader assembled. Without
+      // this, every commit / split-apply / etc. would drop stash
+      // anchors and the cursor-syncs-history effect would degrade
+      // back to "tip not in loaded window" for older stashes.
+      const stashHashes = await getStashCommitHashes(git).catch(() => [])
       const fresh = await getLogRows(git, mergedArgv, {
         limit: LOG_INTERACTIVE_DEFAULT_LIMIT,
+        extraRefs: stashHashes,
       })
       if (mountedRef.current && fresh) {
         dispatch({ type: 'replaceRows', rows: fresh })
@@ -3848,10 +3856,17 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         ...(fetchArgs?.author ? { author: fetchArgs.author } : {}),
         ...(fetchArgs?.path ? { path: fetchArgs.path } : {}),
       }
+      // Load-more paths a fresh page from git AFTER what's already
+      // loaded; pass the stash hashes again so the additional rows
+      // stay graph-consistent with the boot fetch (a window that
+      // dropped stashes mid-stream would render with broken
+      // junctions).
+      const stashHashes = await getStashCommitHashes(git).catch(() => [])
       const nextRows = await safe(
         getLogRows(git, mergedArgv, {
           limit: LOG_INTERACTIVE_DEFAULT_LIMIT,
           skip: state.commits.length,
+          extraRefs: stashHashes,
         })
       )
 
@@ -3932,7 +3947,11 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     })
 
     void (async () => {
-      const nextRows = await safe(getLogRows(git, merged, { limit: LOG_INTERACTIVE_DEFAULT_LIMIT }))
+      const stashHashes = await getStashCommitHashes(git).catch(() => [])
+      const nextRows = await safe(getLogRows(git, merged, {
+        limit: LOG_INTERACTIVE_DEFAULT_LIMIT,
+        extraRefs: stashHashes,
+      }))
       if (!mountedRef.current || historyFetchRequestRef.current !== requestId) {
         return
       }
@@ -3980,7 +3999,15 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     })
 
     void (async () => {
-      const nextRows = await safe(getLogRows(git, merged, { limit: LOG_INTERACTIVE_DEFAULT_LIMIT }))
+      // Include stash commits as graph roots so the toggle's re-fetch
+      // sees the same rich graph the boot loader assembles. Without
+      // this, flipping `\` into full mode and back loses the stash
+      // anchors that loadRowsWithStashes seeded on boot.
+      const stashHashes = await getStashCommitHashes(git).catch(() => [])
+      const nextRows = await safe(getLogRows(git, merged, {
+        limit: LOG_INTERACTIVE_DEFAULT_LIMIT,
+        extraRefs: stashHashes,
+      }))
       if (!mountedRef.current || toggleGraphRequestRef.current !== requestId) {
         return
       }

--- a/src/workstation/runtime/cursorSyncResolver.test.ts
+++ b/src/workstation/runtime/cursorSyncResolver.test.ts
@@ -1,5 +1,6 @@
 import {
   buildLoadedHashSet,
+  isHashLoaded,
   resolveCursorSyncDecision,
 } from './cursorSyncResolver'
 
@@ -138,5 +139,70 @@ describe('buildLoadedHashSet', () => {
     const set = buildLoadedHashSet([{ hash: 'abc1234567890' }])
     expect(set.has('abc1234567890')).toBe(true)
     expect(set.size).toBe(1)
+  })
+})
+
+describe('isHashLoaded', () => {
+  it('returns true on an exact hit (fast path)', () => {
+    // The O(1) Set.has short-circuit. This is the path taken for the
+    // vast majority of lookups: full-hash to full-hash, or short-hash
+    // to short-hash when git's abbreviation happens to match.
+    expect(isHashLoaded('abc1234', new Set(['abc1234', 'def5678']))).toBe(true)
+  })
+
+  it('returns false when the hash has no prefix relationship to any loaded entry', () => {
+    expect(isHashLoaded('abc1234', new Set(['def5678', 'ghi9012']))).toBe(false)
+  })
+
+  it('matches when target is shorter than a loaded full hash', () => {
+    // The real bug: refs sometimes carry a short hash from
+    // `for-each-ref --format=%(objectname:short)` while the loaded
+    // window contains full 40-char hashes. The short target should
+    // still match by prefix.
+    expect(
+      isHashLoaded(
+        'abc1234',
+        new Set(['abc12345678901234567890123456789012345678'])
+      )
+    ).toBe(true)
+  })
+
+  it('matches when target is longer than a loaded short hash', () => {
+    // Inverse direction: target is a long hash, loaded set has a
+    // short form (e.g. when rows store only shortHash). Still a
+    // match via `target.startsWith(loaded)`.
+    expect(
+      isHashLoaded(
+        'abc12345678901234567890123456789012345678',
+        new Set(['abc1234'])
+      )
+    ).toBe(true)
+  })
+
+  it("matches when target and loaded short hashes have DIFFERENT lengths (the production bug)", () => {
+    // The exact production case: `for-each-ref --format=%(objectname:short)`
+    // returned 7 chars for the branch tip ('abc1234'), but `git log
+    // --pretty=format:%h` auto-extended to 8 chars for the same commit
+    // ('abc12345') because of a collision elsewhere in the loaded
+    // window. Bidirectional prefix matching covers this.
+    expect(isHashLoaded('abc1234', new Set(['abc12345']))).toBe(true)
+    expect(isHashLoaded('abc12345', new Set(['abc1234']))).toBe(true)
+  })
+
+  it('refuses to prefix-match on absurdly short targets', () => {
+    // A 3-char "hash" would collide with too many real commits.
+    // Bail rather than report a false positive.
+    expect(isHashLoaded('abc', new Set(['abc1234567'])).valueOf()).toBe(false)
+  })
+
+  it('returns false on an empty loaded set', () => {
+    expect(isHashLoaded('abc1234', new Set())).toBe(false)
+  })
+
+  it('does not match unrelated hashes that share a too-short common prefix', () => {
+    // The shorter of the two strings is 'abc' (only 3 chars common).
+    // Even though abc1xxx and abc2yyy both start with "abc", neither
+    // is a prefix of the other.
+    expect(isHashLoaded('abc1234', new Set(['abc5678']))).toBe(false)
   })
 })

--- a/src/workstation/runtime/cursorSyncResolver.test.ts
+++ b/src/workstation/runtime/cursorSyncResolver.test.ts
@@ -1,0 +1,142 @@
+import {
+  buildLoadedHashSet,
+  resolveCursorSyncDecision,
+} from './cursorSyncResolver'
+
+describe('resolveCursorSyncDecision', () => {
+  const target = { hash: 'abc123', label: 'branch main' }
+
+  it('returns noop with reason `no-target` when target is undefined', () => {
+    // Empty branch list / tag list / stash list — the resolver has
+    // nothing to sync to. Callers shouldn't dispatch anything.
+    const decision = resolveCursorSyncDecision({
+      target: undefined,
+      loadedHashes: new Set(),
+      lastSyncedHash: undefined,
+      attemptedContextHashes: new Set(),
+    })
+    expect(decision).toEqual({ type: 'noop', reason: 'no-target' })
+  })
+
+  it('returns noop with reason `duplicate-of-last` when target matches the last sync', () => {
+    // Common case: user re-cursors the same row, or cursors a different
+    // ref that points at the same commit (e.g. a tag on top of HEAD).
+    // No status churn.
+    const decision = resolveCursorSyncDecision({
+      target,
+      loadedHashes: new Set(['abc123']),
+      lastSyncedHash: 'abc123',
+      attemptedContextHashes: new Set(),
+    })
+    expect(decision).toEqual({ type: 'noop', reason: 'duplicate-of-last' })
+  })
+
+  it('returns jump when target is in the loaded window', () => {
+    // Happy path: target hash is already in the visible commit set.
+    // Cursor sync just dispatches selectCommitByHash.
+    const decision = resolveCursorSyncDecision({
+      target,
+      loadedHashes: new Set(['abc123', 'def456']),
+      lastSyncedHash: undefined,
+      attemptedContextHashes: new Set(),
+    })
+    expect(decision).toEqual({ type: 'jump', hash: 'abc123', label: 'branch main' })
+  })
+
+  it('matches short hashes as well as full hashes', () => {
+    // Some surfaces store only the short hash on cursored refs; the
+    // membership set the caller builds includes both forms so the
+    // resolver's lookup hits.
+    const decision = resolveCursorSyncDecision({
+      target: { hash: 'abc1234', label: 'tag v1' },
+      loadedHashes: buildLoadedHashSet([{ hash: 'abc1234567890', shortHash: 'abc1234' }]),
+      lastSyncedHash: undefined,
+      attemptedContextHashes: new Set(),
+    })
+    expect(decision.type).toBe('jump')
+  })
+
+  it('returns load-context when target is not in the window and not yet attempted', () => {
+    // The new behaviour: instead of saying "tip not in loaded window"
+    // immediately, suggest a targeted log fetch anchored on this
+    // commit. The caller runs the fetch + appends rows; the effect
+    // re-fires and resolves to `jump` next pass.
+    const decision = resolveCursorSyncDecision({
+      target,
+      loadedHashes: new Set(['def456']),
+      lastSyncedHash: undefined,
+      attemptedContextHashes: new Set(),
+    })
+    expect(decision).toEqual({ type: 'load-context', target })
+  })
+
+  it('returns unreachable after a context load was attempted but the hash still isn\'t loaded', () => {
+    // The escape hatch: the caller anchored a `git log` on this hash,
+    // merged the result, but the hash still isn't in the loaded
+    // window. Either git couldn't reach it (orphan / GC'd ref) or
+    // the merge dropped it. Stop chaining and surface a clear status
+    // so the user can press \\ or load more manually.
+    const decision = resolveCursorSyncDecision({
+      target,
+      loadedHashes: new Set(['def456']),
+      lastSyncedHash: undefined,
+      attemptedContextHashes: new Set(['abc123']),
+    })
+    expect(decision).toEqual({ type: 'unreachable', target })
+  })
+
+  it('prefers `duplicate-of-last` over `load-context` when both conditions overlap', () => {
+    // Edge case: a target equals the last-synced hash AND isn't in the
+    // loaded window (e.g. the user manually reloaded smaller after a
+    // sync). No reason to fire another load-context for a target we
+    // already considered "settled."
+    const decision = resolveCursorSyncDecision({
+      target,
+      loadedHashes: new Set(),
+      lastSyncedHash: 'abc123',
+      attemptedContextHashes: new Set(),
+    })
+    expect(decision.type).toBe('noop')
+    expect((decision as { reason?: string }).reason).toBe('duplicate-of-last')
+  })
+
+  it('prefers `jump` over `load-context` when target is loaded but also attempted', () => {
+    // After a successful load-context the target lands in the window
+    // AND its hash is still in attemptedContextHashes. The resolver
+    // should jump, not give up.
+    const decision = resolveCursorSyncDecision({
+      target,
+      loadedHashes: new Set(['abc123']),
+      lastSyncedHash: undefined,
+      attemptedContextHashes: new Set(['abc123']),
+    })
+    expect(decision.type).toBe('jump')
+  })
+})
+
+describe('buildLoadedHashSet', () => {
+  it('returns an empty set for an empty commit list', () => {
+    expect(buildLoadedHashSet([]).size).toBe(0)
+  })
+
+  it('indexes both full hash and short hash so callers can match either form', () => {
+    const set = buildLoadedHashSet([
+      { hash: 'abc1234567890', shortHash: 'abc1234' },
+      { hash: 'def4567890', shortHash: 'def4567' },
+    ])
+    expect(set.has('abc1234567890')).toBe(true)
+    expect(set.has('abc1234')).toBe(true)
+    expect(set.has('def4567890')).toBe(true)
+    expect(set.has('def4567')).toBe(true)
+    expect(set.has('ghi9999')).toBe(false)
+  })
+
+  it('skips commits without a shortHash without erroring', () => {
+    // Defensive — some loaders may produce rows with only the full
+    // hash. The set still picks up the full hash so lookups by it
+    // work.
+    const set = buildLoadedHashSet([{ hash: 'abc1234567890' }])
+    expect(set.has('abc1234567890')).toBe(true)
+    expect(set.size).toBe(1)
+  })
+})

--- a/src/workstation/runtime/cursorSyncResolver.ts
+++ b/src/workstation/runtime/cursorSyncResolver.ts
@@ -1,0 +1,117 @@
+/**
+ * Pure decision logic for the history-view cursor sync effect.
+ *
+ * The effect itself lives in `app.ts` and does the React state
+ * plumbing (read context, dispatch actions, manage refs). This module
+ * holds the actual "what should happen?" decision so it can be unit
+ * tested without spinning up the full app.
+ *
+ * Three real outcomes:
+ *
+ *   1. **Jump** — the target's commit hash is already in the loaded
+ *      history window. Move the cursor.
+ *
+ *   2. **Load context** — the target isn't loaded yet, but we haven't
+ *      tried anchoring a log fetch on it. The caller runs `git log`
+ *      with the target as an explicit graph root (guaranteed to
+ *      include it) and merges the result into the loaded window.
+ *      The effect then re-fires and resolves to `jump`.
+ *
+ *   3. **Unreachable** — we already tried anchoring on the target
+ *      and it still didn't materialise. The target hash is bogus or
+ *      its ref has been GC'd. Surface the status and stop trying.
+ *
+ * Plus two no-op cases that exist so callers can keep their dispatch
+ * paths uniform: `no-target` (no ref under the cursor) and
+ * `duplicate-of-last` (the user re-cursored the same ref, we already
+ * synced to its hash, skip the status churn).
+ */
+
+export type CursorSyncTarget = {
+  hash: string
+  label: string
+}
+
+export type CursorSyncDecision =
+  | { type: 'noop'; reason: 'no-target' | 'duplicate-of-last' }
+  | { type: 'jump'; hash: string; label: string }
+  | { type: 'load-context'; target: CursorSyncTarget }
+  | { type: 'unreachable'; target: CursorSyncTarget }
+
+export type CursorSyncInput = {
+  /**
+   * The hash + label the user cursored, or undefined when there's no
+   * selectable row (empty branch list, etc.). Undefined → `noop`.
+   */
+  target: CursorSyncTarget | undefined
+  /**
+   * Fast lookup over `state.filteredCommits`. The caller builds this
+   * once per effect run rather than passing the full row array so the
+   * resolver stays O(1) on the membership check.
+   */
+  loadedHashes: Set<string>
+  /**
+   * The last hash we successfully synced to. Returned by previous
+   * calls and held in a ref. When the new target equals this value
+   * the resolver short-circuits — re-cursoring the same ref or
+   * cursoring a different ref pointing at the same commit shouldn't
+   * fire a redundant status update.
+   */
+  lastSyncedHash: string | undefined
+  /**
+   * Set of hashes the caller has already attempted to anchor a log
+   * fetch on. Lets the resolver distinguish "haven't tried yet, do a
+   * load-context" from "tried, it didn't help, give up." The caller
+   * adds the target hash to this set when it kicks off the fetch and
+   * keeps the entry there even after the fetch resolves (the
+   * resolver's job is to STOP suggesting load-context, not to track
+   * fetch lifecycle).
+   */
+  attemptedContextHashes: ReadonlySet<string>
+}
+
+export function resolveCursorSyncDecision(
+  input: CursorSyncInput
+): CursorSyncDecision {
+  if (!input.target) {
+    return { type: 'noop', reason: 'no-target' }
+  }
+  if (input.target.hash === input.lastSyncedHash) {
+    return { type: 'noop', reason: 'duplicate-of-last' }
+  }
+  // Match on full hash OR short hash — `state.filteredCommits` indexes
+  // both forms via the caller's set.
+  if (input.loadedHashes.has(input.target.hash)) {
+    return {
+      type: 'jump',
+      hash: input.target.hash,
+      label: input.target.label,
+    }
+  }
+  if (input.attemptedContextHashes.has(input.target.hash)) {
+    return { type: 'unreachable', target: input.target }
+  }
+  return { type: 'load-context', target: input.target }
+}
+
+/**
+ * Build the membership set the resolver expects. Includes BOTH the
+ * full hash and the short hash for every commit so the caller can
+ * match either form (refs sometimes carry only the short hash and
+ * `state.filteredCommits` items always have both).
+ *
+ * Exported so the cursor-sync effect can build the set once per
+ * re-render and pass it down without leaking the implementation
+ * detail. Tests use it to construct realistic inputs without
+ * hand-rolling the dual-hash logic.
+ */
+export function buildLoadedHashSet(
+  commits: ReadonlyArray<{ hash: string; shortHash?: string }>
+): Set<string> {
+  const set = new Set<string>()
+  for (const commit of commits) {
+    if (commit.hash) set.add(commit.hash)
+    if (commit.shortHash) set.add(commit.shortHash)
+  }
+  return set
+}

--- a/src/workstation/runtime/cursorSyncResolver.ts
+++ b/src/workstation/runtime/cursorSyncResolver.ts
@@ -1,3 +1,5 @@
+import { hashLoaded } from '../../git/hashes'
+
 /**
  * Pure decision logic for the history-view cursor sync effect.
  *
@@ -93,36 +95,14 @@ export function resolveCursorSyncDecision(
 }
 
 /**
- * Check whether `hash` matches any commit in the loaded set, allowing
- * for short-hash length mismatches.
- *
- * The real-world problem this solves: `for-each-ref
- * --format=%(objectname:short)` (used to load branches / tags) and
- * `git log --pretty=format:%h` (used to load history rows) both use
- * git's `core.abbrev` setting for short hash length, but git
- * auto-extends short hashes when needed to keep them unique. The two
- * commands can return DIFFERENT abbreviation lengths for the same
- * commit — for-each-ref might give 7 chars while git log gives 8, or
- * vice versa. Exact `.has()` lookup fails in that case even though
- * both hashes refer to the same commit.
- *
- * Bidirectional `startsWith` covers every length combination:
- *   - target is shorter than a loaded entry → `loaded.startsWith(target)`
- *   - target is longer than a loaded entry → `target.startsWith(loaded)`
- *
- * The set is small (1k-5k entries in practice), so O(N) iteration is
- * fine. The early `.has()` short-circuit keeps the common case
- * (exact match) at O(1).
+ * Re-export of the shared `hashLoaded` helper under the resolver's
+ * historical name. Kept exported so existing tests (and any external
+ * importers) keep working unchanged — see `src/git/hashes.ts` for the
+ * canonical implementation and the rationale behind bidirectional
+ * prefix matching.
  */
 export function isHashLoaded(hash: string, loadedHashes: ReadonlySet<string>): boolean {
-  if (loadedHashes.has(hash)) return true
-  // Don't try to prefix-match on absurdly short inputs — a 3-char
-  // "hash" would collide with too many real commits.
-  if (hash.length < 4) return false
-  for (const loaded of loadedHashes) {
-    if (loaded.startsWith(hash) || hash.startsWith(loaded)) return true
-  }
-  return false
+  return hashLoaded(hash, loadedHashes)
 }
 
 /**

--- a/src/workstation/runtime/cursorSyncResolver.ts
+++ b/src/workstation/runtime/cursorSyncResolver.ts
@@ -79,9 +79,7 @@ export function resolveCursorSyncDecision(
   if (input.target.hash === input.lastSyncedHash) {
     return { type: 'noop', reason: 'duplicate-of-last' }
   }
-  // Match on full hash OR short hash — `state.filteredCommits` indexes
-  // both forms via the caller's set.
-  if (input.loadedHashes.has(input.target.hash)) {
+  if (isHashLoaded(input.target.hash, input.loadedHashes)) {
     return {
       type: 'jump',
       hash: input.target.hash,
@@ -92,6 +90,39 @@ export function resolveCursorSyncDecision(
     return { type: 'unreachable', target: input.target }
   }
   return { type: 'load-context', target: input.target }
+}
+
+/**
+ * Check whether `hash` matches any commit in the loaded set, allowing
+ * for short-hash length mismatches.
+ *
+ * The real-world problem this solves: `for-each-ref
+ * --format=%(objectname:short)` (used to load branches / tags) and
+ * `git log --pretty=format:%h` (used to load history rows) both use
+ * git's `core.abbrev` setting for short hash length, but git
+ * auto-extends short hashes when needed to keep them unique. The two
+ * commands can return DIFFERENT abbreviation lengths for the same
+ * commit — for-each-ref might give 7 chars while git log gives 8, or
+ * vice versa. Exact `.has()` lookup fails in that case even though
+ * both hashes refer to the same commit.
+ *
+ * Bidirectional `startsWith` covers every length combination:
+ *   - target is shorter than a loaded entry → `loaded.startsWith(target)`
+ *   - target is longer than a loaded entry → `target.startsWith(loaded)`
+ *
+ * The set is small (1k-5k entries in practice), so O(N) iteration is
+ * fine. The early `.has()` short-circuit keeps the common case
+ * (exact match) at O(1).
+ */
+export function isHashLoaded(hash: string, loadedHashes: ReadonlySet<string>): boolean {
+  if (loadedHashes.has(hash)) return true
+  // Don't try to prefix-match on absurdly short inputs — a 3-char
+  // "hash" would collide with too many real commits.
+  if (hash.length < 4) return false
+  for (const loaded of loadedHashes) {
+    if (loaded.startsWith(hash) || hash.startsWith(loaded)) return true
+  }
+  return false
 }
 
 /**

--- a/src/workstation/runtime/footer.ts
+++ b/src/workstation/runtime/footer.ts
@@ -64,28 +64,22 @@ export function renderFooter(
   // etc.) feel less frozen even when they're sub-second.
   const spinnerPrefix = isLoading ? `${pickSpinnerFrame(spinnerFrame)} ` : ''
   const trailingWithSpinner = trailing ? `${spinnerPrefix}${trailing}` : ''
+  // Separated status text so loading rendering can give the message
+  // its own visual treatment (bold + accent) without dragging the
+  // keyboard hints along. Pre-loading users reported the spinner
+  // was nearly invisible against the dimmed footer; isolating the
+  // status to its own Text span fixes that.
   const status = trailingWithSpinner ? `  ${trailingWithSpinner}` : ''
+  const hintsText = hints.contextual.join('   ')
   const isError = state.statusKind === 'error'
   const isSuccess = state.statusKind === 'success'
-  const contextualText = isError
-    // Errors get the full footer width and a `✗` prefix so they read
-    // as alarming. We drop the contextual hints when an error is
-    // active — they'd compete for attention with the message and
-    // long validator outputs (#907 polish: split-plan validator
-    // errors are often 100+ chars and got truncated against the hints).
-    ? `✗ ${state.statusMessage || ''}`
-    : `${hints.contextual.join('   ')}${status}`
+  const errorText = isError ? `✗ ${state.statusMessage || ''}` : ''
   const globalText = hints.global.join(' · ')
 
-  // Error rendering: hide the global hints on the right so the
-  // message can wrap into that space. Success rendering: accent
-  // color on the message, hints stay visible. Default: existing
-  // muted styling.
-  const contextualColor = isError
-    ? 'red'
-    : isSuccess
-      ? theme.colors.accent
-      : theme.colors.muted
+  // Color the status portion based on kind. Loading uses the accent
+  // color (same as success) so motion glyphs stay readable; default
+  // status messages stay muted to match the surrounding chrome.
+  const statusColor = isSuccess || isLoading ? theme.colors.accent : undefined
 
   return h(Box, {
     flexDirection: 'row',
@@ -93,11 +87,21 @@ export function renderFooter(
     justifyContent: 'space-between',
     paddingX: 1,
   },
-  h(Text, {
-    color: contextualColor,
-    dimColor: !isError && !isSuccess,
-    bold: isError,
-  }, contextualText),
+  // Errors take over the whole contextual area (replace hints + status).
+  // Otherwise: hints stay dim/muted, status gets its own non-dim span
+  // when loading / success so it pops.
+  isError
+    ? h(Text, { color: 'red', bold: true }, errorText)
+    : h(Text, undefined,
+        h(Text, { color: theme.colors.muted, dimColor: true }, hintsText),
+        status
+          ? h(Text, {
+              color: statusColor,
+              dimColor: !isLoading && !isSuccess,
+              bold: isLoading,
+            }, status)
+          : ''
+      ),
   // Globals are dropped entirely when an error is on screen — that
   // space is what the long message needs to render. They come back
   // the moment the status flips to info / success / cleared.


### PR DESCRIPTION
## Summary

Four UX gaps surfaced from real-world workstation usage. Each is small, contained, and improves a moment of friction users actually hit.

## 1. Loading indicator visibility

The spinner + status copy ("fetching…", "pulling…", "generating draft…") sat in the dim-grey footer color and was nearly invisible. Split the contextual text into two Text spans so keyboard hints stay muted while the status portion paints in the accent color + bold + non-dim when \`statusLoading\` is true.

**Before:** spinner glyph + "pulling current branch…" in dim grey, hard to spot against the surrounding hints.
**After:** spinner glyph + status copy in accent color + bold; reads immediately as "something is happening."

## 2. Stash drop / apply / pop follow-through

- **Drop**: explicit \`refreshWorktreeContext()\` after the silent context refresh so any untracked-file state the dropped stash carried clears too.
- **Apply / pop**: jumps to history view via \`pushView('history')\` and refreshes worktree context so the staged / unstaged / untracked counts in the sidebar reflect the just-applied changes. Matches what users would do manually next.

## 3. Cursor → history graph jump for stashes

The #806 auto-jump effect that snaps the history cursor to the cursored branch's / tag's tip didn't extend to stashes. Added stashes to the same effect — cursoring a stash row now syncs the history graph to that stash's commit hash (visible under \`refs/stash\` in \`--all\` graph mode).

## 4. Full history graph by default — the GitKraken ask

User feedback referenced GitKraken's multi-branch graph as the shape they wanted: all branches, tags, stashes in parallel lanes. The rendering infrastructure was already there (8-color lane palettes per theme, distinct merge/HEAD glyphs, proper junction characters from #791, \`--all\` mapping in \`buildLogArgs\`), but \`fullGraph\` defaulted to false so users had to discover the \`\\\` toggle.

Flipped two defaults:

- \`LogInkState.fullGraph\` initializes to \`true\`
- \`ui.config.ts\`'s \`all\` yargs default is now \`true\`

\`coco ui --no-all\` (or \`\\\\\` in the running TUI) opts back to compact / current-branch.
\`coco ui --branch foo\` now passes through alongside \`--all\` — branch acts as a "land on this branch's tip in the full graph" hint rather than implicitly narrowing scope.

\`CreateLogInkStateOptions\` gains a \`fullGraph?\` override so tests can pin their intended mode explicitly without coupling to the global default.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [x] 2121/2125 broader sweep passes; 4 remaining failures are pre-existing flaky temp-git tests that pass in isolation
- [x] Three new ui-handler tests covering the \`--all\` default, \`--no-all\` opt-out, and \`--branch\` + \`--all\` interaction
- [ ] Manual: open \`coco ui\` in a multi-branch repo. Verify the history view opens on the full multi-ref graph (lanes colored per branch, all branches visible, stashes weave through if any exist)
- [ ] Manual: drop a stash. Verify the list shrinks visibly; cursor lands on a sensible neighbor
- [ ] Manual: apply or pop a stash. Verify the workstation jumps to history view and the worktree counts in the sidebar reflect the applied changes
- [ ] Manual: cursor through the stashes sidebar tab. Verify the history graph cursor snaps to each stash's commit row as you move
- [ ] Manual: run \`coco ui --branch some-branch\`. Verify the history graph still shows all refs (just lands the cursor on some-branch's tip)
- [ ] Manual: run \`coco ui --no-all\`. Verify the history graph shows only the current branch's lineage (compact mode)
- [ ] Manual: fire any pull / fetch action. Verify the spinner + loading copy in the footer is clearly visible (not dim grey)

## Notable behaviour changes

- **Workstation history view now opens on the full multi-ref graph by default.** Users who preferred the compact / current-branch view can pass \`coco ui --no-all\` or press \`\\\\\` to toggle. The infrastructure (lane colors, merge glyphs) already handled the visual side correctly.
- **\`coco ui --branch foo\` no longer implicitly scopes the history to just that branch.** Branch + all-refs view is now the default. \`coco ui --branch foo --no-all\` for the old behaviour.