### PR TITLE
feat(workstation): split footer + per-kind colors and glyphs for status band

### DIFF
--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -343,20 +343,30 @@ export type LogInkState = {
   statusMessage?: string
   /**
    * Visual category for `statusMessage` — drives footer styling.
-   *   - 'info'    (default) : dim muted text, regular contextual hints
-   *   - 'error'              : red text + footer hides the global hints
-   *                            on the right so long error messages get
-   *                            the full width to render. Set explicitly
-   *                            by failure paths (LLM errors, validator
-   *                            issues, etc.) so users notice them.
-   *   - 'success'            : accent-colored text. Set by ops that
+   *   - 'info'    (default) : info-color text + `ℹ ` glyph (or ASCII
+   *                            `i`). Used for neutral status updates
+   *                            that the user should notice but aren't
+   *                            wins or failures.
+   *   - 'error'              : danger-color (red) + bold + `✗ ` glyph.
+   *                            Set explicitly by failure paths (LLM
+   *                            errors, validator issues, etc.) so
+   *                            users notice them.
+   *   - 'warning'            : warning-color (yellow) + bold + `⚠ `
+   *                            glyph (`!` in ASCII). Set by paths
+   *                            that succeed but with caveats —
+   *                            unupstreamed branch, dirty worktree
+   *                            during sensitive ops, partial fetch.
+   *   - 'success'            : success-color (green) + bold + `✓ `
+   *                            glyph (`+` in ASCII). Set by ops that
    *                            mutate state successfully (commit
    *                            created, split applied, PR opened, …)
-   *                            so the affirmative feedback stands out.
+   *                            so the affirmative feedback stands out
+   *                            from in-flight ops (which use accent /
+   *                            cyan via the spinner).
    * Cleared alongside `statusMessage` when `setStatus` fires without
    * a `kind` (or with `kind: 'info'`).
    */
-  statusKind?: 'info' | 'error' | 'success'
+  statusKind?: 'info' | 'error' | 'success' | 'warning'
   /**
    * Transient loading flag for the status line. When true, the footer
    * prefixes the message with the shared spinner frame so users see
@@ -734,7 +744,7 @@ export type LogInkAction =
   | { type: 'setPendingKey'; value?: string }
   | { type: 'setSidebarTab'; value: LogInkSidebarTab }
   | { type: 'restoreSidebarTab'; value: LogInkSidebarTab }
-  | { type: 'setStatus'; value?: string; kind?: 'info' | 'error' | 'success'; loading?: boolean }
+  | { type: 'setStatus'; value?: string; kind?: 'info' | 'error' | 'success' | 'warning'; loading?: boolean }
   | { type: 'setPendingPullRequestBodyDraft'; value: boolean }
   | { type: 'setWorkflowAction'; value?: string }
   | { type: 'setPendingConfirmation'; value?: string; payload?: string }

--- a/src/workstation/runtime/__snapshots__/footer.test.ts.snap
+++ b/src/workstation/runtime/__snapshots__/footer.test.ts.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`renderFooter structural snapshot — default no-status footer 1`] = `
+<Box
+  flexDirection="column"
+  height={2}
+  paddingX={1}
+>
+  <Box
+    flexDirection="row"
+    justifyContent="space-between"
+  >
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ↑/↓ move   enter diff   c/R/Z/i mutate   B/gT new   m compare   y/Y yank   / search
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      g jump · &lt; back · ? help · : cmds · q quit
+    </Text>
+  </Box>
+  <Text
+    bold={false}
+    dimColor={true}
+  />
+</Box>
+`;
+
+exports[`renderFooter structural snapshot — error keeps hints visible on row 1 1`] = `
+<Box
+  flexDirection="column"
+  height={2}
+  paddingX={1}
+>
+  <Box
+    flexDirection="row"
+    justifyContent="space-between"
+  >
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ↑/↓ move   enter diff   c/R/Z/i mutate   B/gT new   m compare   y/Y yank   / search
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      g jump · &lt; back · ? help · : cmds · q quit
+    </Text>
+  </Box>
+  <Text
+    bold={true}
+    color="red"
+    dimColor={false}
+  >
+    ✗ merge conflict
+  </Text>
+</Box>
+`;
+
+exports[`renderFooter structural snapshot — loading status on row 2 1`] = `
+<Box
+  flexDirection="column"
+  height={2}
+  paddingX={1}
+>
+  <Box
+    flexDirection="row"
+    justifyContent="space-between"
+  >
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ↑/↓ move   enter diff   c/R/Z/i mutate   B/gT new   m compare   y/Y yank   / search
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      g jump · &lt; back · ? help · : cmds · q quit
+    </Text>
+  </Box>
+  <Text
+    bold={true}
+    color="cyan"
+    dimColor={false}
+  >
+    ⠹ fetching…
+  </Text>
+</Box>
+`;

--- a/src/workstation/runtime/footer.test.ts
+++ b/src/workstation/runtime/footer.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Structural snapshot tests for `renderFooter`.
+ *
+ * The footer is the most-glanced surface in the workstation — every
+ * keystroke triggers an idle-tip cycle and most workflows poke a
+ * status message. The two-row layout (hint band on row 1, status
+ * band on row 2) is load-bearing for readability and easy to break by
+ * accident.
+ *
+ * Snapshots are structural, not visual: stub `Text` / `Box` collect
+ * their props and children into synthetic elements so jest pretty-
+ * prints the React tree. Deterministic across CI + dev terminals.
+ */
+import { createElement, type ReactElement } from 'react'
+import { createLogInkState, type LogInkState } from '../../commands/log/inkViewModel'
+import { createLogInkTheme } from '../chrome/theme'
+import { renderFooter } from './footer'
+import type { LogInkContext } from './types'
+
+// Synthetic stub for Ink's <Text> — collects every prop the renderer
+// passes (color, dimColor, bold, children, …) and renders them under
+// a 'text' element so jest's snapshot serializer pretty-prints the
+// tree without us pulling Ink (ESM) into ts-jest. Same trick as
+// `branchTipChipRender.test.ts`.
+type StubProps = Record<string, unknown>
+const Text = ((props: StubProps) =>
+  createElement('text', props as Record<string, unknown>, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+
+const Box = ((props: StubProps) =>
+  createElement('box', props as Record<string, unknown>, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+
+// Element-tree access helper. The renderer returns a real React
+// element whose props.children is itself an array of elements — but
+// the inferred type is React.ReactNode, which doesn't expose `.props`.
+// Casting locally to a narrow `{ props: StubProps }` shape keeps the
+// test bodies readable without scattering `as any` casts everywhere.
+type Node = { props: StubProps & { children?: Node | Node[] } }
+const asNode = (value: unknown): Node => value as Node
+const childAt = (node: Node, index: number): Node => {
+  const children = node.props.children
+  if (!Array.isArray(children)) {
+    throw new Error(`expected children to be an array, got: ${typeof children}`)
+  }
+  return children[index]
+}
+
+// Empty context — the footer only reaches into `branches.localBranches`
+// etc. when sidebar tab counts are needed, and even then it handles
+// `undefined` cleanly. Stripping the fields keeps the test independent
+// of unrelated type evolution in BranchOverview / WorktreeOverview.
+const baseContext: LogInkContext = {}
+
+function makeState(overrides: Partial<LogInkState> = {}): LogInkState {
+  return { ...createLogInkState([]), ...overrides }
+}
+
+function render(
+  state: LogInkState,
+  idleTip?: string,
+  spinnerFrame = 0
+): ReactElement {
+  const theme = createLogInkTheme({ noColor: false })
+  return renderFooter(
+    createElement,
+    { Box, Text },
+    state,
+    baseContext,
+    theme,
+    idleTip,
+    spinnerFrame
+  )
+}
+
+describe('renderFooter', () => {
+  // The two-row layout is the whole point of this refactor — pin it
+  // explicitly so a future "let's go back to one row" refactor breaks
+  // the test loudly instead of regressing the UX.
+  it('always wraps row 1 (hints) and row 2 (status) in a column Box with height 2', () => {
+    const tree = asNode(render(makeState()))
+    expect(tree.props.flexDirection).toBe('column')
+    expect(tree.props.height).toBe(2)
+    expect(tree.props.children).toHaveLength(2)
+  })
+
+  it('row 2 is an empty Text when no status, idle tip, or error is set', () => {
+    const tree = asNode(render(makeState()))
+    const row2 = childAt(tree, 1)
+    expect(row2.props.children).toBe('')
+    // Even an empty row still reserves the line — that's what keeps
+    // the surrounding layout stable when status flips on/off.
+  })
+
+  it('row 2 shows the idle tip dimmed when no status is set', () => {
+    const tree = asNode(render(makeState(), 'press / to filter'))
+    const row2 = childAt(tree, 1)
+    expect(row2.props.children).toBe('press / to filter')
+    expect(row2.props.dimColor).toBe(true)
+    expect(row2.props.bold).toBe(false)
+  })
+
+  it('a real status message wins over an idle tip', () => {
+    // Genuine workflow feedback must never be displaced by the idle
+    // tip cycle — `setStatus` is the loud channel.
+    const tree = asNode(render(
+      makeState({ statusMessage: 'fetching…', statusLoading: true }),
+      'press / to filter',
+      0
+    ))
+    const row2 = childAt(tree, 1)
+    expect(String(row2.props.children)).toContain('fetching…')
+    expect(String(row2.props.children)).not.toContain('press / to filter')
+  })
+
+  it('loading status gets a spinner prefix + accent color + bold + non-dim', () => {
+    const tree = asNode(render(
+      makeState({ statusMessage: 'pulling…', statusLoading: true }),
+      undefined,
+      0
+    ))
+    const row2 = childAt(tree, 1)
+    // The exact spinner glyph depends on `pickSpinnerFrame(0)` but the
+    // body text + styling are what we care about.
+    expect(String(row2.props.children)).toMatch(/.\spulling…$/)
+    expect(row2.props.bold).toBe(true)
+    expect(row2.props.dimColor).toBe(false)
+    expect(row2.props.color).toBeDefined() // accent
+  })
+
+  it('error status takes row 2 with ✗ prefix + red + bold; hints stay on row 1', () => {
+    // Critical UX: errors must NOT take over the hint band like they
+    // did pre-refactor — users often need ?/:/q to recover.
+    const tree = asNode(render(
+      makeState({ statusMessage: 'remote rejected push', statusKind: 'error' })
+    ))
+    const row1 = childAt(tree, 0)
+    const row2 = childAt(tree, 1)
+    expect(row2.props.children).toBe('✗ remote rejected push')
+    expect(row2.props.color).toBe('red')
+    expect(row2.props.bold).toBe(true)
+    expect(row2.props.dimColor).toBe(false)
+    // Row 1 still has both hint clusters.
+    expect(row1.props.flexDirection).toBe('row')
+    expect(row1.props.justifyContent).toBe('space-between')
+    expect(row1.props.children).toHaveLength(2)
+  })
+
+  it('success status gets accent + bold + non-dim, no prefix glyph', () => {
+    const tree = asNode(render(
+      makeState({ statusMessage: 'pushed main to origin', statusKind: 'success' })
+    ))
+    const row2 = childAt(tree, 1)
+    expect(row2.props.children).toBe('pushed main to origin')
+    expect(row2.props.bold).toBe(true)
+    expect(row2.props.dimColor).toBe(false)
+  })
+
+  it('info status is dim+muted with no prefix — matches surrounding chrome', () => {
+    // Default informational status (no kind set) shouldn't compete
+    // with the hint band — same dim treatment as the hints.
+    const tree = asNode(render(makeState({ statusMessage: 'on branch main' })))
+    const row2 = childAt(tree, 1)
+    expect(row2.props.children).toBe('on branch main')
+    expect(row2.props.dimColor).toBe(true)
+    expect(row2.props.bold).toBe(false)
+  })
+
+  it('row 1 splits contextual vs global hints into opposite edges', () => {
+    const tree = asNode(render(makeState()))
+    const row1 = childAt(tree, 0)
+    expect(row1.props.flexDirection).toBe('row')
+    expect(row1.props.justifyContent).toBe('space-between')
+    const contextual = childAt(row1, 0)
+    const global = childAt(row1, 1)
+    // Both clusters get the same muted treatment so neither steals
+    // attention from the status row below.
+    expect(contextual.props.dimColor).toBe(true)
+    expect(global.props.dimColor).toBe(true)
+  })
+
+  // Snapshot covers the no-status default — the layout most users see
+  // most of the time — to catch incidental structural drift.
+  it('structural snapshot — default no-status footer', () => {
+    expect(render(makeState())).toMatchSnapshot()
+  })
+
+  it('structural snapshot — loading status on row 2', () => {
+    expect(
+      render(makeState({ statusMessage: 'fetching…', statusLoading: true }), undefined, 2)
+    ).toMatchSnapshot()
+  })
+
+  it('structural snapshot — error keeps hints visible on row 1', () => {
+    expect(
+      render(makeState({ statusMessage: 'merge conflict', statusKind: 'error' }))
+    ).toMatchSnapshot()
+  })
+})

--- a/src/workstation/runtime/footer.test.ts
+++ b/src/workstation/runtime/footer.test.ts
@@ -59,9 +59,10 @@ function makeState(overrides: Partial<LogInkState> = {}): LogInkState {
 function render(
   state: LogInkState,
   idleTip?: string,
-  spinnerFrame = 0
+  spinnerFrame = 0,
+  options: { ascii?: boolean } = {}
 ): ReactElement {
-  const theme = createLogInkTheme({ noColor: false })
+  const theme = createLogInkTheme({ noColor: false, ascii: options.ascii })
   return renderFooter(
     createElement,
     { Box, Text },
@@ -92,7 +93,12 @@ describe('renderFooter', () => {
     // the surrounding layout stable when status flips on/off.
   })
 
-  it('row 2 shows the idle tip dimmed when no status is set', () => {
+  it('row 2 shows the idle tip dimmed when no status is set (no glyph — passive channel)', () => {
+    // Idle tips are the passive channel — purely educational, never
+    // workflow feedback. They get no glyph prefix and stay dim+muted
+    // so they blend into the chrome and don't compete with the hint
+    // band. The info-kind status (with glyph + color) is the
+    // contrast point.
     const tree = asNode(render(makeState(), 'press / to filter'))
     const row2 = childAt(tree, 1)
     expect(row2.props.children).toBe('press / to filter')
@@ -128,7 +134,7 @@ describe('renderFooter', () => {
     expect(row2.props.color).toBeDefined() // accent
   })
 
-  it('error status takes row 2 with ✗ prefix + red + bold; hints stay on row 1', () => {
+  it('error status renders with ✗ prefix + danger color + bold; hints stay on row 1', () => {
     // Critical UX: errors must NOT take over the hint band like they
     // did pre-refactor — users often need ?/:/q to recover.
     const tree = asNode(render(
@@ -137,6 +143,8 @@ describe('renderFooter', () => {
     const row1 = childAt(tree, 0)
     const row2 = childAt(tree, 1)
     expect(row2.props.children).toBe('✗ remote rejected push')
+    // Uses the theme's danger color (typically red), not a hardcoded
+    // literal — so dark / light / colorblind themes can override it.
     expect(row2.props.color).toBe('red')
     expect(row2.props.bold).toBe(true)
     expect(row2.props.dimColor).toBe(false)
@@ -146,24 +154,75 @@ describe('renderFooter', () => {
     expect(row1.props.children).toHaveLength(2)
   })
 
-  it('success status gets accent + bold + non-dim, no prefix glyph', () => {
+  it('warning status renders with ⚠ prefix + warning color + bold', () => {
+    // The yellow / warning kind sits between info and error — used
+    // for ops that succeeded with caveats (no upstream, dirty
+    // worktree, partial fetch).
     const tree = asNode(render(
-      makeState({ statusMessage: 'pushed main to origin', statusKind: 'success' })
+      makeState({ statusMessage: 'no upstream — nothing to fetch.', statusKind: 'warning' })
     ))
     const row2 = childAt(tree, 1)
-    expect(row2.props.children).toBe('pushed main to origin')
+    expect(row2.props.children).toBe('⚠ no upstream — nothing to fetch.')
+    expect(row2.props.color).toBe('yellow')
     expect(row2.props.bold).toBe(true)
     expect(row2.props.dimColor).toBe(false)
   })
 
-  it('info status is dim+muted with no prefix — matches surrounding chrome', () => {
-    // Default informational status (no kind set) shouldn't compete
-    // with the hint band — same dim treatment as the hints.
+  it('success status renders with ✓ prefix + success color + bold (distinct from loading)', () => {
+    // Pre-redesign success and loading both used `accent` (cyan)
+    // and the user couldn't tell "done" from "in progress" without
+    // squinting at the prefix. Success now uses the theme's success
+    // color (green) so the two states read at a glance.
+    const tree = asNode(render(
+      makeState({ statusMessage: 'pushed main to origin', statusKind: 'success' })
+    ))
+    const row2 = childAt(tree, 1)
+    expect(row2.props.children).toBe('✓ pushed main to origin')
+    expect(row2.props.color).toBe('green')
+    expect(row2.props.bold).toBe(true)
+    expect(row2.props.dimColor).toBe(false)
+  })
+
+  it('info status renders with ℹ prefix + info color + bold (more visible than idle tips)', () => {
+    // Status messages without an explicit kind are deliberate updates
+    // and should be more visible than the passive idle-tip channel.
+    // Idle tips stay dim+muted; info-kind status pops with its own
+    // theme color and glyph.
     const tree = asNode(render(makeState({ statusMessage: 'on branch main' })))
     const row2 = childAt(tree, 1)
-    expect(row2.props.children).toBe('on branch main')
-    expect(row2.props.dimColor).toBe(true)
-    expect(row2.props.bold).toBe(false)
+    expect(row2.props.children).toBe('ℹ on branch main')
+    expect(row2.props.color).toBe('blue')
+    expect(row2.props.bold).toBe(true)
+    expect(row2.props.dimColor).toBe(false)
+  })
+
+  it('ASCII mode degrades unicode glyphs to printable single-char fallbacks', () => {
+    // Under TERM=dumb / vt100, unicode glyphs render as garbage. The
+    // ASCII fallback for each kind: ! for error/warning, + for
+    // success, i for info — printable everywhere.
+    const errorAscii = asNode(render(
+      makeState({ statusMessage: 'oops', statusKind: 'error' }),
+      undefined, 0, { ascii: true }
+    ))
+    expect(childAt(errorAscii, 1).props.children).toBe('! oops')
+
+    const warnAscii = asNode(render(
+      makeState({ statusMessage: 'careful', statusKind: 'warning' }),
+      undefined, 0, { ascii: true }
+    ))
+    expect(childAt(warnAscii, 1).props.children).toBe('! careful')
+
+    const successAscii = asNode(render(
+      makeState({ statusMessage: 'done', statusKind: 'success' }),
+      undefined, 0, { ascii: true }
+    ))
+    expect(childAt(successAscii, 1).props.children).toBe('+ done')
+
+    const infoAscii = asNode(render(
+      makeState({ statusMessage: 'fyi' }),
+      undefined, 0, { ascii: true }
+    ))
+    expect(childAt(infoAscii, 1).props.children).toBe('i fyi')
   })
 
   it('row 1 splits contextual vs global hints into opposite edges', () => {

--- a/src/workstation/runtime/footer.ts
+++ b/src/workstation/runtime/footer.ts
@@ -27,8 +27,25 @@
  * Idle tips fill row 2 only when no real status message is set so the
  * tip cycle never overwrites genuine workflow feedback.
  *
+ * Row 2 styling is kind-aware. Each statusKind gets its own theme
+ * color and glyph prefix so the message is identifiable at a glance
+ * — even with NO_COLOR set, the glyph alone communicates kind:
+ *
+ *   loading  →  spinner + accent  + bold
+ *   error    →  ✗ / !  + danger   + bold
+ *   warning  →  ⚠ / !  + warning  + bold
+ *   success  →  ✓ / +  + success  + bold
+ *   info     →  ℹ / i  + info     + bold
+ *   idle tip →  no glyph + dim muted (passive)
+ *
+ * Pre-redesign success and loading both used `accent` (cyan), so the
+ * user couldn't tell "done" from "in progress" by color alone. Each
+ * kind now uses its dedicated theme color and ships an ASCII glyph
+ * fallback for `theme.ascii` mode (TERM=dumb / vt100).
+ *
  * Extracted from `src/commands/log/inkRuntime.ts` as part of phase
- * 5a.7 of #890. Two-row layout introduced post-0.54.2.
+ * 5a.7 of #890. Two-row layout introduced post-0.54.2; per-kind
+ * colors + glyphs added in the same pass.
  */
 
 import type * as ReactTypes from 'react'
@@ -76,33 +93,63 @@ export function renderFooter(
   })
   // Real status messages always win; idle tips only fill the slot when it
   // would otherwise be empty.
-  const isLoading = Boolean(state.statusLoading && state.statusMessage)
+  const hasStatusMessage = Boolean(state.statusMessage)
+  const isLoading = Boolean(state.statusLoading && hasStatusMessage)
   const isError = state.statusKind === 'error'
+  const isWarning = state.statusKind === 'warning'
   const isSuccess = state.statusKind === 'success'
+  // 'info' is the implicit kind when statusKind is undefined but
+  // statusMessage is set — it's a deliberate status update, not an
+  // idle tip, so it gets info treatment rather than the dim fallback.
+  const isInfo = hasStatusMessage && !isError && !isWarning && !isSuccess && !isLoading
   const rawTrailing = state.statusMessage || idleTip || ''
 
-  // Loading status gets a spinner prefix in front of the message —
-  // motion makes transient LLM calls (create-PR body, PR fetches,
-  // etc.) feel less frozen even when they're sub-second. Errors get
-  // the ✗ glyph; nothing else gets a prefix.
-  const prefix = isError
-    ? '✗ '
-    : isLoading
-      ? `${pickSpinnerFrame(spinnerFrame)} `
-      : ''
-  const statusBody = rawTrailing ? `${prefix}${rawTrailing}` : ''
+  // Glyphs per kind so the message is identifiable even before reading
+  // the color — improves scan-ability and degrades gracefully when the
+  // terminal lacks color. ASCII fallback for `theme.ascii` mode (TERM
+  // = dumb / vt100) where unicode glyphs render as garbage.
+  //   loading  →  spinner (animated)
+  //   error    →  ✗  / !
+  //   warning  →  ⚠  / !
+  //   success  →  ✓  / +
+  //   info     →  ℹ  / i
+  //   idle tip →  no glyph (passive)
+  const glyph = ((): string => {
+    if (isLoading) return pickSpinnerFrame(spinnerFrame)
+    if (isError) return theme.ascii ? '!' : '✗'
+    if (isWarning) return theme.ascii ? '!' : '⚠'
+    if (isSuccess) return theme.ascii ? '+' : '✓'
+    if (isInfo) return theme.ascii ? 'i' : 'ℹ'
+    return ''
+  })()
+  const statusBody = rawTrailing
+    ? glyph
+      ? `${glyph} ${rawTrailing}`
+      : rawTrailing
+    : ''
 
-  // Row 2 color picks: errors red+bold (must pop), loading/success
-  // accent+bold (visible against the muted hint row above), everything
-  // else dim+muted (idle tips and informational status shouldn't
-  // compete with the hint band for attention).
+  // Row 2 color picks. Each kind gets its own theme color so success
+  // and loading are visually distinct (was conflated under `accent`
+  // pre-redesign — users couldn't tell "done" from "in progress").
+  //   loading → accent  (cyan / preset blue)
+  //   error   → danger  (red / preset red)
+  //   warning → warning (yellow)
+  //   success → success (green)
+  //   info    → info    (blue / preset accent in light themes)
+  //   idle    → undefined + dim (passive, blends with chrome)
   const statusColor = isError
-    ? 'red'
-    : (isLoading || isSuccess)
-      ? theme.colors.accent
-      : undefined
-  const statusBold = isError || isLoading || isSuccess
-  const statusDim = !isError && !isLoading && !isSuccess
+    ? theme.colors.danger
+    : isWarning
+      ? theme.colors.warning
+      : isSuccess
+        ? theme.colors.success
+        : isLoading
+          ? theme.colors.accent
+          : isInfo
+            ? theme.colors.info
+            : undefined
+  const statusBold = isError || isWarning || isSuccess || isLoading || isInfo
+  const statusDim = !statusBold
 
   const hintsText = hints.contextual.join('   ')
   const globalText = hints.global.join(' · ')

--- a/src/workstation/runtime/footer.ts
+++ b/src/workstation/runtime/footer.ts
@@ -1,15 +1,34 @@
 /**
- * Status-bar / footer renderer. Two-column layout:
- *   - Left: contextual hints for the active view (built by inkKeymap's
- *     `getLogInkFooterHints`), with the optional status message / idle
- *     tip appended.
- *   - Right: global key hints (`?` help, `:` palette, `q` quit, …).
+ * Status-bar / footer renderer. Two-row layout, using the full
+ * `height: 2` the footer already reserves:
  *
- * Idle tips only fill the slot when no real status message is set so the
+ *   Row 1 — keyboard hint band:
+ *     ┌──── contextual hints ────┐                ┌──── globals ────┐
+ *     ↑/↓ branches  ←/→ tab  …                    ? help · : cmds · q
+ *
+ *   Row 2 — status / feedback band:
+ *     ⠋ main has no upstream — nothing to fetch.
+ *
+ * Row 2 is empty when there's no status message, idle tip, or error.
+ * This is a behaviour change from the pre-0.54.2 single-row layout
+ * where the status message sat awkwardly between the contextual and
+ * global hints, getting visually crushed.
+ *
+ * The separation matters because:
+ *   - status text and key hints serve different cognitive purposes
+ *     (read vs. scan) and competing for the same row makes both
+ *     harder to use,
+ *   - long status messages (especially errors / multi-clause loading
+ *     copy) no longer push global hints off screen or wrap into the
+ *     hint cluster,
+ *   - errors now keep the global hints visible — the user often
+ *     needs `?` / `:` / `q` to *recover* from the error.
+ *
+ * Idle tips fill row 2 only when no real status message is set so the
  * tip cycle never overwrites genuine workflow feedback.
  *
- * Extracted from `src/commands/log/inkRuntime.ts` as part of phase 5a.7
- * of #890. No behavior change.
+ * Extracted from `src/commands/log/inkRuntime.ts` as part of phase
+ * 5a.7 of #890. Two-row layout introduced post-0.54.2.
  */
 
 import type * as ReactTypes from 'react'
@@ -58,54 +77,51 @@ export function renderFooter(
   // Real status messages always win; idle tips only fill the slot when it
   // would otherwise be empty.
   const isLoading = Boolean(state.statusLoading && state.statusMessage)
-  const trailing = state.statusMessage || idleTip || ''
-  // Loading status gets a spinner prefix in front of the message —
-  // motion makes transient LLM calls (create-PR body, PR fetches,
-  // etc.) feel less frozen even when they're sub-second.
-  const spinnerPrefix = isLoading ? `${pickSpinnerFrame(spinnerFrame)} ` : ''
-  const trailingWithSpinner = trailing ? `${spinnerPrefix}${trailing}` : ''
-  // Separated status text so loading rendering can give the message
-  // its own visual treatment (bold + accent) without dragging the
-  // keyboard hints along. Pre-loading users reported the spinner
-  // was nearly invisible against the dimmed footer; isolating the
-  // status to its own Text span fixes that.
-  const status = trailingWithSpinner ? `  ${trailingWithSpinner}` : ''
-  const hintsText = hints.contextual.join('   ')
   const isError = state.statusKind === 'error'
   const isSuccess = state.statusKind === 'success'
-  const errorText = isError ? `✗ ${state.statusMessage || ''}` : ''
+  const rawTrailing = state.statusMessage || idleTip || ''
+
+  // Loading status gets a spinner prefix in front of the message —
+  // motion makes transient LLM calls (create-PR body, PR fetches,
+  // etc.) feel less frozen even when they're sub-second. Errors get
+  // the ✗ glyph; nothing else gets a prefix.
+  const prefix = isError
+    ? '✗ '
+    : isLoading
+      ? `${pickSpinnerFrame(spinnerFrame)} `
+      : ''
+  const statusBody = rawTrailing ? `${prefix}${rawTrailing}` : ''
+
+  // Row 2 color picks: errors red+bold (must pop), loading/success
+  // accent+bold (visible against the muted hint row above), everything
+  // else dim+muted (idle tips and informational status shouldn't
+  // compete with the hint band for attention).
+  const statusColor = isError
+    ? 'red'
+    : (isLoading || isSuccess)
+      ? theme.colors.accent
+      : undefined
+  const statusBold = isError || isLoading || isSuccess
+  const statusDim = !isError && !isLoading && !isSuccess
+
+  const hintsText = hints.contextual.join('   ')
   const globalText = hints.global.join(' · ')
 
-  // Color the status portion based on kind. Loading uses the accent
-  // color (same as success) so motion glyphs stay readable; default
-  // status messages stay muted to match the surrounding chrome.
-  const statusColor = isSuccess || isLoading ? theme.colors.accent : undefined
-
-  return h(Box, {
-    flexDirection: 'row',
-    height: 2,
-    justifyContent: 'space-between',
-    paddingX: 1,
-  },
-  // Errors take over the whole contextual area (replace hints + status).
-  // Otherwise: hints stay dim/muted, status gets its own non-dim span
-  // when loading / success so it pops.
-  isError
-    ? h(Text, { color: 'red', bold: true }, errorText)
-    : h(Text, undefined,
-        h(Text, { color: theme.colors.muted, dimColor: true }, hintsText),
-        status
-          ? h(Text, {
-              color: statusColor,
-              dimColor: !isLoading && !isSuccess,
-              bold: isLoading,
-            }, status)
-          : ''
-      ),
-  // Globals are dropped entirely when an error is on screen — that
-  // space is what the long message needs to render. They come back
-  // the moment the status flips to info / success / cleared.
-  isError
-    ? h(Text, undefined, '')
-    : h(Text, { color: theme.colors.muted, dimColor: true }, globalText))
+  return h(Box, { flexDirection: 'column', height: 2, paddingX: 1 },
+    // Row 1: contextual ↔ global hints. justifyContent pushes them
+    // to opposite edges so the eye can scan each cluster as one
+    // block instead of hunting through a single concatenated line.
+    h(Box, { flexDirection: 'row', justifyContent: 'space-between' },
+      h(Text, { color: theme.colors.muted, dimColor: true }, hintsText),
+      h(Text, { color: theme.colors.muted, dimColor: true }, globalText)
+    ),
+    // Row 2: status / loading / idle tip / error. Empty Text keeps
+    // the row reserved when nothing's set so the surrounding layout
+    // doesn't shift as status flips on/off.
+    h(Text, {
+      color: statusColor,
+      dimColor: statusDim,
+      bold: statusBold,
+    }, statusBody)
+  )
 }


### PR DESCRIPTION
## Problem

User feedback on 0.54.2: the footer was hard to parse when both hotkey hints and a status message appeared at once. Three things competed for one row — contextual hints (left), status message (middle), global hints (right) — and the status got visually squished between the two hint clusters with no separation.

Errors made it worse: they took over the whole contextual area, hiding the very keys (`?` / `:` / `q`) the user needed to recover.

Two follow-up problems on the row-2 status band itself:
- Success and loading both used the same accent color (cyan) — users couldn't tell "done" from "in progress" by color alone.
- Errors used a hardcoded literal `'red'` instead of the theme's `danger` token, so theme overrides (catppuccin, gruvbox) couldn't recolor them.
- Info-kind status got the same dim+muted treatment as idle tips, fading deliberate status updates into passive chrome.
- No warning kind existed for the "succeeded with caveats" middle ground.

## Fix

### Two-row layout (commit `0b15444`)
The footer already reserved `height: 2` but only rendered one row. Promote status to its own dedicated row:

\`\`\`
Row 1:  ↑/↓ branches  ←/→ tab  enter checkout  ...  u upstream           tog jump · < back · ? help · : cmds · q quit
Row 2:  ⠹ fetching…
\`\`\`

When no status, idle tip, or error is set, row 2 stays empty — the line is still reserved so the surrounding layout doesn't shift as status flips on/off.

### Per-kind colors + glyphs (commit `5956ddd`)

Each status kind now gets its own theme color **and** its own glyph prefix, so the message is identifiable at a glance — even with `NO_COLOR` set, the glyph alone communicates the kind:

| kind     | unicode | ASCII | color   | bold |
| -------- | ------- | ----- | ------- | ---- |
| loading  | spinner | spinner | accent (cyan)   | ✓ |
| error    | ✗       | `!`     | danger  (red)    | ✓ |
| **warning**  | ⚠       | `!`     | warning (yellow) | ✓ |
| success  | ✓       | `+`     | success (green)  | ✓ |
| info     | ℹ       | `i`     | info    (blue)   | ✓ |
| idle tip | (none)  | (none)  | dim muted        |   |

`warning` is a new kind — fills the gap between info and error for ops that succeeded with caveats (no upstream, dirty worktree during sensitive ops, partial fetch). Future code can dispatch `setStatus({ value, kind: 'warning' })` without further wiring.

## Behavioural gains

- Long status messages no longer push global hints off screen or wrap into the hint cluster.
- **Errors keep the hint band visible** — `?` / `:` / `q` stay legible so the user can recover without guessing.
- Success and loading are now **visually distinct by color** (green vs cyan).
- Glyphs make the kind scannable even on NO_COLOR / colorblind setups.
- Theme overrides (catppuccin, gruvbox) now control all five kinds via their theme tokens.

## Test plan

- [x] 14 new tests in `src/workstation/runtime/footer.test.ts` — 11 assertions + 3 structural snapshots
- [x] Covers every kind end-to-end (color + glyph + bold + non-dim)
- [x] ASCII degradation tested for error / warning / success / info
- [x] Idle-tip behavior verified as distinct from info-kind status
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] 1081 tests pass across `workstation` + `commands/log`
- [ ] Visual confirmation on a real terminal — `yarn coco ui`, navigate to branches tab on `main` (which has no upstream) and confirm the "no upstream" message reads cleanly on its own line below the hints, with the appropriate kind treatment when status is updated by workflows

## Risk

Surgical: only `src/workstation/runtime/footer.ts`, `src/commands/log/inkViewModel.ts` (extending `statusKind` to include `'warning'`), and test files change. `renderFooter`'s exported signature is unchanged so no call-site updates needed. Visual layout uses the row of vertical space the footer already reserves — no layout shift in the surrounding panel grid. The existing error snapshot is unchanged because `theme.colors.danger` resolves to `'red'` in the default preset; the difference is the source of truth.