### PR TITLE
feat(workstation): restructure header into color-coded chips with separators

### DIFF
--- a/src/workstation/chrome/headerChips.test.ts
+++ b/src/workstation/chrome/headerChips.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for the header chip builder. Snapshots aren't appropriate here
+ * — chip semantics (which kind, what color category) matter more than
+ * exact pixel-level layout, and a snapshot would discourage tweaking
+ * label copy (e.g. swapping ⊘ for ◯). Instead the tests assert on
+ * chip IDs, colors-by-role, and edge cases that have bitten before.
+ */
+import { createLogInkTheme } from './theme'
+import {
+  HEADER_CHIP_SEPARATOR,
+  buildHeaderChips,
+  measureHeaderChipsWidth,
+  type BuildHeaderChipsInput,
+} from './headerChips'
+
+function makeInput(overrides: Partial<BuildHeaderChipsInput> = {}): BuildHeaderChipsInput {
+  const theme = overrides.theme || createLogInkTheme({ noColor: false })
+  return {
+    appLabel: 'coco',
+    repo: 'gfargo/coco',
+    branch: 'main',
+    dirty: false,
+    bisecting: false,
+    pullRequest: undefined,
+    breadcrumb: '',
+    loading: '',
+    mode: 'NORMAL',
+    search: '',
+    theme,
+    ...overrides,
+  }
+}
+
+describe('buildHeaderChips', () => {
+  it('emits the baseline chip set in identity → state → mode order', () => {
+    // Default state: clean repo, no PR, no breadcrumb, NORMAL mode.
+    // The chip order is load-bearing for scan-ability — identity chips
+    // (app/repo/branch) come first, then state (dirty/PR), then
+    // navigation (breadcrumb/loading), then mode.
+    const chips = buildHeaderChips(makeInput())
+    expect(chips.map((c) => c.id)).toEqual([
+      'app',
+      'repo',
+      'branch',
+      'dirty',
+      'pr',
+      'mode',
+    ])
+  })
+
+  it('flips the dirty chip to warning when the worktree is dirty', () => {
+    const clean = buildHeaderChips(makeInput({ dirty: false }))
+    const dirty = buildHeaderChips(makeInput({ dirty: true }))
+    const cleanChip = clean.find((c) => c.id === 'dirty')!
+    const dirtyChip = dirty.find((c) => c.id === 'dirty')!
+    expect(cleanChip.label).toBe('✓ clean')
+    expect(cleanChip.color).toBe('green') // theme.colors.success
+    expect(dirtyChip.label).toBe('● dirty')
+    expect(dirtyChip.color).toBe('yellow') // theme.colors.warning
+  })
+
+  it('inserts a BISECTING chip with warning color when bisect is active', () => {
+    // Critical for users entering the TUI mid-bisect — they need to
+    // see the state immediately, before they hunt for `gB`.
+    const chips = buildHeaderChips(makeInput({ bisecting: true }))
+    const bisect = chips.find((c) => c.id === 'bisecting')!
+    expect(bisect).toBeDefined()
+    expect(bisect.label).toBe('⚠ BISECTING')
+    expect(bisect.color).toBe('yellow')
+    expect(bisect.bold).toBe(true)
+  })
+
+  it('omits the bisect chip when bisect is not active', () => {
+    const chips = buildHeaderChips(makeInput({ bisecting: false }))
+    expect(chips.find((c) => c.id === 'bisecting')).toBeUndefined()
+  })
+
+  it('renders a muted "no PR" chip when no pull request is loaded', () => {
+    const chips = buildHeaderChips(makeInput({ pullRequest: undefined }))
+    const pr = chips.find((c) => c.id === 'pr')!
+    expect(pr.label).toBe('⊘ no PR')
+    expect(pr.dim).toBe(true)
+  })
+
+  it('renders the PR chip with state and glyph when a pull request is loaded', () => {
+    const chips = buildHeaderChips(makeInput({
+      pullRequest: { number: 1234, state: 'open' },
+    }))
+    const pr = chips.find((c) => c.id === 'pr')!
+    expect(pr.label).toContain('PR #1234')
+    expect(pr.label).toContain('OPEN')
+    expect(pr.color).toBe('green') // theme.colors.success for OPEN
+  })
+
+  it('uses DRAFT label when the pull request is a draft', () => {
+    const chips = buildHeaderChips(makeInput({
+      pullRequest: { number: 99, state: 'open', isDraft: true },
+    }))
+    const pr = chips.find((c) => c.id === 'pr')!
+    expect(pr.label).toContain('DRAFT')
+    expect(pr.label).not.toContain('OPEN')
+  })
+
+  it('omits the breadcrumb chip when no view is pushed', () => {
+    const chips = buildHeaderChips(makeInput({ breadcrumb: '' }))
+    expect(chips.find((c) => c.id === 'view')).toBeUndefined()
+  })
+
+  it('inserts the breadcrumb chip after PR when a view is pushed', () => {
+    const chips = buildHeaderChips(makeInput({ breadcrumb: 'diff · stash' }))
+    const ids = chips.map((c) => c.id)
+    expect(ids.indexOf('view')).toBe(ids.indexOf('pr') + 1)
+    expect(chips.find((c) => c.id === 'view')!.label).toBe('diff · stash')
+  })
+
+  it('renders the loading chip dim when boot/context loading is in flight', () => {
+    const chips = buildHeaderChips(makeInput({ loading: 'loading commits' }))
+    const loading = chips.find((c) => c.id === 'loading')!
+    expect(loading.label).toBe('loading commits')
+    expect(loading.dim).toBe(true)
+  })
+
+  it('colors the mode chip accent when NORMAL, warning when EDIT or FILTER', () => {
+    // Users should sense at a glance "your keystrokes mean something
+    // different right now" — that's why EDIT/FILTER share the warning
+    // color with the dirty / bisect chips.
+    const normal = buildHeaderChips(makeInput({ mode: 'NORMAL' })).find((c) => c.id === 'mode')!
+    const edit = buildHeaderChips(makeInput({ mode: 'EDIT' })).find((c) => c.id === 'mode')!
+    const filter = buildHeaderChips(makeInput({ mode: 'FILTER' })).find((c) => c.id === 'mode')!
+    expect(normal.label).toBe('[NORMAL]')
+    expect(normal.color).toBe('cyan') // theme.colors.accent
+    expect(edit.color).toBe('yellow') // theme.colors.warning
+    expect(filter.color).toBe('yellow')
+  })
+
+  it('appends the search chip when there is search/filter input', () => {
+    const chips = buildHeaderChips(makeInput({ search: 'filter: foo' }))
+    const search = chips.find((c) => c.id === 'search')!
+    expect(search).toBeDefined()
+    expect(search.dim).toBe(true)
+    // Search comes after mode — the input is a transient overlay on
+    // the otherwise-stable header state.
+    const ids = chips.map((c) => c.id)
+    expect(ids.indexOf('search')).toBe(ids.indexOf('mode') + 1)
+  })
+
+  it('omits the search chip when neither filter nor search input is active', () => {
+    const chips = buildHeaderChips(makeInput({ search: '' }))
+    expect(chips.find((c) => c.id === 'search')).toBeUndefined()
+  })
+
+  describe('ASCII mode', () => {
+    it('substitutes printable single-char glyphs for the dirty / clean / bisect / no-PR / branch chips', () => {
+      const theme = createLogInkTheme({ noColor: false, ascii: true })
+      // Clean + no PR + no bisect — the most common state.
+      const baseline = buildHeaderChips(makeInput({ theme }))
+      const branch = baseline.find((c) => c.id === 'branch')!
+      const dirty = baseline.find((c) => c.id === 'dirty')!
+      const pr = baseline.find((c) => c.id === 'pr')!
+      expect(branch.label).toBe('git: main')
+      expect(dirty.label).toBe('+ clean')
+      expect(pr.label).toBe('- no PR')
+
+      // Dirty branch ASCII fallback.
+      const dirtyChips = buildHeaderChips(makeInput({ theme, dirty: true }))
+      expect(dirtyChips.find((c) => c.id === 'dirty')!.label).toBe('* dirty')
+
+      // Bisect ASCII fallback.
+      const bisectChips = buildHeaderChips(makeInput({ theme, bisecting: true }))
+      expect(bisectChips.find((c) => c.id === 'bisecting')!.label).toBe('! BISECTING')
+    })
+  })
+})
+
+describe('measureHeaderChipsWidth', () => {
+  it('returns 0 for an empty chip list', () => {
+    expect(measureHeaderChipsWidth([])).toBe(0)
+  })
+
+  it('sums label widths plus N-1 separator widths', () => {
+    // Three chips with simple ASCII labels: total = sum of labels +
+    // 2 separators. The separator literal is " · " (3 cells with the
+    // narrow midpoint). Use ASCII-safe input so the test is not
+    // sensitive to font metrics across CI runners.
+    const chips = buildHeaderChips(makeInput({
+      appLabel: 'AB',
+      repo: 'CD',
+      branch: 'EF',
+      theme: createLogInkTheme({ noColor: false, ascii: true }),
+    }))
+    // 'AB' (2) + ' · ' (3) + 'CD' (2) + ' · ' (3) + 'git: EF' (7) +
+    // ' · ' (3) + '+ clean' (7) + ' · ' (3) + '- no PR' (7) +
+    // ' · ' (3) + '[NORMAL]' (8) = 48
+    expect(measureHeaderChipsWidth(chips)).toBe(48)
+  })
+})
+
+describe('HEADER_CHIP_SEPARATOR', () => {
+  it('exposes the literal so tests + width math + consumer all agree', () => {
+    // If this constant ever moves, search for places that hardcoded
+    // " · " — that's the trap to avoid.
+    expect(HEADER_CHIP_SEPARATOR).toBe(' · ')
+  })
+})

--- a/src/workstation/chrome/headerChips.ts
+++ b/src/workstation/chrome/headerChips.ts
@@ -1,0 +1,278 @@
+/**
+ * Header chip builder. Turns the workstation's title-bar state into an
+ * ordered list of small visually-distinct chips:
+ *
+ *   coco · gfargo/coco · ⎇ main · ✓ clean · ⊘ no PR · [NORMAL]
+ *
+ * Pre-refactor the title bar concatenated every segment into a single
+ * Text span, which made the eye read the whole thing as one run of
+ * words (the same problem the footer had). Splitting into chips with a
+ * fixed separator lets each segment carry its own color and lets the
+ * user scan the bar in chunks — "what app, what repo, what branch,
+ * how clean, what PR state, what mode" — instead of parsing left-to-
+ * right.
+ *
+ * Why a separate module: the header runtime renders chips and handles
+ * truncation; chip construction is pure transformation of state +
+ * context + theme. Splitting them keeps the chips testable in
+ * isolation and keeps the runtime small.
+ *
+ * Truncation strategy lives in the consumer, not here — when the total
+ * width exceeds the column budget, the header falls back to the
+ * pre-redesign single-fragment truncated string so the ellipsis can't
+ * land mid-glyph. We always return the FULL chip list; the consumer
+ * decides whether to drop chips, fall back, or render all of them.
+ */
+
+import { cellWidth } from './text'
+import type { LogInkTheme } from './theme'
+import { getPullRequestStateGlyph } from './iconography'
+
+export type HeaderChip = {
+  /**
+   * The chip's primary identity — used by tests and snapshots. Stable
+   * across theme / preset switches so a test can assert "the branch
+   * chip says X" without coupling to color decisions.
+   */
+  id: HeaderChipId
+  /**
+   * The label text rendered to the user. Already includes any glyph
+   * prefix the chip wants (so the cell-width math is honest about
+   * what will actually appear). Glyphs come from `theme.ascii`-aware
+   * helpers; consumers just render the label verbatim.
+   */
+  label: string
+  /** Optional foreground color. `undefined` means default / inherit. */
+  color: string | undefined
+  /** Dim treatment — for chips that should fade into chrome (idle / muted). */
+  dim: boolean
+  /** Bold treatment — used on identity chips (app, branch, mode). */
+  bold: boolean
+}
+
+export type HeaderChipId =
+  | 'app'
+  | 'repo'
+  | 'branch'
+  | 'dirty'
+  | 'bisecting'
+  | 'pr'
+  | 'view'
+  | 'loading'
+  | 'mode'
+  | 'search'
+
+export type BuildHeaderChipsInput = {
+  appLabel: string
+  repo: string
+  branch: string
+  /**
+   * Branch dirty/clean signal. The chip stays positive ("✓ clean") in
+   * the clean case and switches to warning ("● dirty") in the dirty
+   * case. Bisect mid-state gets its own chip — see `bisecting`.
+   */
+  dirty: boolean
+  /** True when `context.bisect.active` — renders its own warning chip. */
+  bisecting: boolean
+  /**
+   * Pull request state for the current branch, if any. `undefined`
+   * renders the muted "no PR" chip instead.
+   */
+  pullRequest: { number: number; state: string; isDraft?: boolean } | undefined
+  /**
+   * Combined repo + view breadcrumb (e.g. "submodule/lib › diff").
+   * Rendered only when non-empty.
+   */
+  breadcrumb: string
+  /** "loading commits" / "loading context" / "" — rendered only when non-empty. */
+  loading: string
+  /** Mode indicator: 'NORMAL' / 'EDIT' / 'FILTER'. Brackets are added here. */
+  mode: 'NORMAL' | 'EDIT' | 'FILTER'
+  /** Active filter / search input copy, '' when neither is active. */
+  search: string
+  theme: LogInkTheme
+}
+
+/**
+ * Default separator inserted between chips by the consumer. Exported as
+ * a constant so tests and width math agree on what they're measuring.
+ * The trailing/leading spaces are part of the separator — `·` alone
+ * would butt against adjacent chip labels.
+ */
+export const HEADER_CHIP_SEPARATOR = ' · '
+
+/**
+ * Build the ordered chip list for the header. Chips not relevant to the
+ * current state (no PR loaded, no breadcrumb, no search input, …) are
+ * omitted entirely rather than rendered as empty placeholders, so the
+ * consumer can just `chips.map(render)` without checking for empties.
+ */
+export function buildHeaderChips(input: BuildHeaderChipsInput): HeaderChip[] {
+  const { theme } = input
+  const chips: HeaderChip[] = []
+
+  // App label — the constant identity. Accent + bold so it anchors the
+  // left edge of the bar.
+  chips.push({
+    id: 'app',
+    label: input.appLabel,
+    color: theme.colors.accent,
+    dim: false,
+    bold: true,
+  })
+
+  // Repo. Default color — it's contextual but not the headline.
+  chips.push({
+    id: 'repo',
+    label: input.repo,
+    color: undefined,
+    dim: false,
+    bold: false,
+  })
+
+  // Branch. Carries the branch glyph (⎇ / ASCII fallback) so the chip
+  // is identifiable even when the branch name is generic ("main" /
+  // "master").
+  const branchGlyph = theme.ascii ? 'git:' : '⎇'
+  chips.push({
+    id: 'branch',
+    label: `${branchGlyph} ${input.branch}`,
+    color: theme.colors.accent,
+    dim: false,
+    bold: true,
+  })
+
+  // Dirty/clean. Positive framing on clean (success color + ✓), warning
+  // on dirty (warning color + ●). ASCII fallbacks keep the chip
+  // identifiable on dumb terminals.
+  const dirtyChip: HeaderChip = input.dirty
+    ? {
+      id: 'dirty',
+      label: theme.ascii ? '* dirty' : '● dirty',
+      color: theme.colors.warning,
+      dim: false,
+      bold: false,
+    }
+    : {
+      id: 'dirty',
+      label: theme.ascii ? '+ clean' : '✓ clean',
+      color: theme.colors.success,
+      dim: false,
+      bold: false,
+    }
+  chips.push(dirtyChip)
+
+  // Bisect — only when active. Distinct chip so users entering the TUI
+  // mid-bisect see it immediately (#784). Warning color because bisect
+  // is an "in progress, requires user action" state.
+  if (input.bisecting) {
+    chips.push({
+      id: 'bisecting',
+      label: theme.ascii ? '! BISECTING' : '⚠ BISECTING',
+      color: theme.colors.warning,
+      dim: false,
+      bold: true,
+    })
+  }
+
+  // PR state. When present, the chip uses the PR-state glyph + a short
+  // label ("PR #1234 OPEN" / "PR #1234 DRAFT"). When absent, a muted
+  // "no PR" chip so users know the system DID look (vs. the bar just
+  // being blank).
+  if (input.pullRequest) {
+    const prGlyph = getPullRequestStateGlyph(
+      { ...input.pullRequest, isDraft: Boolean(input.pullRequest.isDraft) },
+      theme
+    )
+    const stateLabel = input.pullRequest.isDraft
+      ? 'DRAFT'
+      : input.pullRequest.state.toUpperCase()
+    const label = prGlyph.glyph
+      ? `${prGlyph.glyph} PR #${input.pullRequest.number} ${stateLabel}`
+      : `PR #${input.pullRequest.number} ${stateLabel}`
+    chips.push({
+      id: 'pr',
+      label,
+      color: prGlyph.color,
+      dim: prGlyph.dim,
+      bold: false,
+    })
+  } else {
+    chips.push({
+      id: 'pr',
+      label: theme.ascii ? '- no PR' : '⊘ no PR',
+      color: theme.colors.muted,
+      dim: true,
+      bold: false,
+    })
+  }
+
+  // View breadcrumb. Rendered only when there's content (`coco ui`
+  // root view → no breadcrumb chip; pushed into a sub-view → chip
+  // appears). Comes AFTER PR so the "state" group (app/repo/branch/
+  // dirty/PR) reads as one cluster and the "navigation" group (view
+  // breadcrumb / loading) reads as a separate cluster.
+  if (input.breadcrumb) {
+    chips.push({
+      id: 'view',
+      label: input.breadcrumb,
+      color: theme.colors.muted,
+      dim: true,
+      bold: false,
+    })
+  }
+
+  if (input.loading) {
+    chips.push({
+      id: 'loading',
+      label: input.loading.trim(),
+      color: theme.colors.muted,
+      dim: true,
+      bold: false,
+    })
+  }
+
+  // Mode — the explicit input-mode indicator (#P2.2). Always present
+  // so users never wonder why `q` doesn't quit while they're editing.
+  // EDIT / FILTER use the warning color to signal "your keystrokes
+  // mean something different right now"; NORMAL uses accent (matches
+  // the app chip's home base).
+  const modeColor = input.mode === 'NORMAL'
+    ? theme.colors.accent
+    : theme.colors.warning
+  chips.push({
+    id: 'mode',
+    label: `[${input.mode}]`,
+    color: modeColor,
+    dim: false,
+    bold: true,
+  })
+
+  // Search — only when active. Dim so it doesn't compete with the
+  // identity chips for attention; the user knows it's there because
+  // they're typing into it.
+  if (input.search) {
+    chips.push({
+      id: 'search',
+      label: input.search,
+      color: theme.colors.muted,
+      dim: true,
+      bold: false,
+    })
+  }
+
+  return chips
+}
+
+/**
+ * Total rendered width of a chip list assuming `HEADER_CHIP_SEPARATOR`
+ * between every pair. Used by the consumer to decide whether the
+ * chip layout fits the column budget or whether to fall back to the
+ * single-fragment truncated path.
+ */
+export function measureHeaderChipsWidth(chips: ReadonlyArray<HeaderChip>): number {
+  if (chips.length === 0) return 0
+  const labels = chips.map((chip) => cellWidth(chip.label))
+  const separators = (chips.length - 1) * cellWidth(HEADER_CHIP_SEPARATOR)
+  return labels.reduce((sum, w) => sum + w, 0) + separators
+}

--- a/src/workstation/runtime/header.ts
+++ b/src/workstation/runtime/header.ts
@@ -1,27 +1,34 @@
 /**
- * Title-bar renderer. Surfaces:
- *   - the app label (e.g. "coco ui")
- *   - current repo owner/name (or "local repository")
- *   - current branch + dirty / BISECTING flag
- *   - PR glyph + label when one is detected
- *   - breadcrumb of the view stack
- *   - loading hint for boot / context fetches
- *   - mode indicator: [NORMAL] / [EDIT] / [FILTER]
- *   - active filter / search input
+ * Title-bar renderer. Surfaces the workstation's identity + navigation
+ * state as a row of small visually-distinct chips:
  *
- * Truncation: when the assembled title overruns the available columns we
- * fall back to a single-fragment Text (truncating the joined string) so
- * the ellipsis can't land mid-glyph. The split-fragment path keeps the PR
- * glyph in its own colored span when there's headroom.
+ *   coco · gfargo/coco · ⎇ main · ✓ clean · ⊘ no PR · [NORMAL]
  *
- * Extracted from `src/commands/log/inkRuntime.ts` as part of phase 5a.7
- * of #890. No behavior change.
+ * Per-chip color/glyph treatment lets the user scan in chunks ("what
+ * app, what repo, what branch, how clean, what PR state, what mode")
+ * instead of parsing one long sentence. Chip construction is in
+ * `chrome/headerChips.ts`; this runtime just renders.
+ *
+ * Truncation: when the assembled chip row overruns the available
+ * columns we fall back to a single Text fragment (truncating the
+ * joined chip labels) so the ellipsis can't land mid-glyph. This is
+ * the same defensive pattern the pre-redesign single-fragment code
+ * used, applied at the chip-list level instead of the inline glyph
+ * split.
+ *
+ * Extracted from `src/commands/log/inkRuntime.ts` as part of phase
+ * 5a.7 of #890. Chip restructuring introduced post-0.54.2.
  */
 
 import type * as ReactTypes from 'react'
 import type { LogInkContextStatus } from '../chrome/context'
 import { isLogInkContextLoading } from '../chrome/context'
-import { getPullRequestStateGlyph } from '../chrome/iconography'
+import {
+  HEADER_CHIP_SEPARATOR,
+  buildHeaderChips,
+  measureHeaderChipsWidth,
+  type HeaderChip,
+} from '../chrome/headerChips'
 import { truncateCells } from '../chrome/text'
 import type { LogInkTheme } from '../chrome/theme'
 import {
@@ -43,57 +50,60 @@ export function renderHeader(
   appLabel: string
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
+
+  // Pull the source state into the small "describe what to render"
+  // shape the chip builder expects. Keeps the runtime decoupled from
+  // the chip layout — the builder doesn't know about LogInkState /
+  // LogInkContext, just plain values.
   const branch = context.branches?.currentBranch || context.provider?.currentBranch || '<detached>'
-  // #784 — surface bisect-in-progress in the title bar so users entering
-  // the TUI mid-bisect see it immediately, before they navigate to gB.
-  const dirtyBase = context.branches?.dirty ? 'dirty' : 'clean'
-  const dirty = context.bisect?.active ? `${dirtyBase} · BISECTING` : dirtyBase
+  const dirty = Boolean(context.branches?.dirty)
+  const bisecting = Boolean(context.bisect?.active)
   const repo = context.provider?.repository.owner && context.provider.repository.name
     ? `${context.provider.repository.owner}/${context.provider.repository.name}`
     : 'local repository'
   const prInfo = context.provider?.currentPullRequest || context.pullRequest?.currentPullRequest
-  const prGlyph = prInfo ? getPullRequestStateGlyph(prInfo, theme) : null
-  const prLabel = prInfo
-    ? `PR #${prInfo.number} ${prInfo.isDraft ? 'DRAFT' : prInfo.state}`
-    : 'no PR'
-  const search = state.filterMode ? `search: ${state.filter}_` : state.filter ? `filter: ${state.filter}` : ''
-  // Boot loading wins over the per-context loading hint because it
-  // tells the user the headline thing they care about (commits aren't
-  // ready yet) — the context fetches finish independently and surface
-  // their own per-section loading copy in the sidebars.
+  // Boot loading wins over the per-context loading hint — same
+  // priority as pre-redesign. Context fetches still surface their own
+  // copy in the sidebars.
   const loading = state.bootLoading
-    ? '  loading commits'
-    : isLogInkContextLoading(contextStatus) ? '  loading context' : ''
+    ? 'loading commits'
+    : isLogInkContextLoading(contextStatus) ? 'loading context' : ''
   const breadcrumb = formatLogInkBreadcrumb(state.viewStack)
   const repoCrumb = formatLogInkRepoBreadcrumb(state.repoStack)
-  // Repo breadcrumb (when nested) comes first so the user sees which
-  // submodule they're in at a glance, then the view breadcrumb (when
-  // pushed deeper than the root view). The truncate fallback in the
-  // title row still applies — when both fight for space, the ellipsis
-  // lands at the end of whichever segment overflows.
   const view = combineLogInkBreadcrumbSegments(repoCrumb, breadcrumb)
-  // Mode indicator (P2.2) — surfaces the current input mode so users
-  // never wonder why `q` doesn't quit while they're editing or filtering.
-  const mode = state.commitCompose.editing
-    ? '[EDIT]'
+  const mode: 'NORMAL' | 'EDIT' | 'FILTER' = state.commitCompose.editing
+    ? 'EDIT'
     : state.filterMode
-      ? '[FILTER]'
-      : '[NORMAL]'
-  const titlePrefix = `${appLabel}  ${repo}  ${branch}  ${dirty}  `
-  const glyphPart = prGlyph?.glyph ? `${prGlyph.glyph} ` : ''
-  const titleSuffix = `${view}${loading}`
-  const fullTitle = `${titlePrefix}${glyphPart}${prLabel}${titleSuffix}`
-  const titleBudget = columns - mode.length - 4
-  const truncatedTitle = truncateCells(fullTitle, titleBudget)
-  // Only split into colored fragments when the prefix + glyph + label all
-  // fit unmodified — otherwise the truncate ellipsis can land mid-fragment
-  // and we'd render half a glyph in the wrong color.
-  const splitFragments = truncatedTitle === fullTitle && glyphPart.length > 0
-  const modeColor = theme.noColor
-    ? undefined
-    : state.filterMode || state.commitCompose.editing
-      ? theme.colors.warning
-      : theme.colors.accent
+      ? 'FILTER'
+      : 'NORMAL'
+  const search = state.filterMode
+    ? `search: ${state.filter}_`
+    : state.filter
+      ? `filter: ${state.filter}`
+      : ''
+
+  const chips = buildHeaderChips({
+    appLabel,
+    repo,
+    branch,
+    dirty,
+    bisecting,
+    pullRequest: prInfo ? {
+      number: prInfo.number,
+      state: prInfo.state,
+      isDraft: prInfo.isDraft,
+    } : undefined,
+    breadcrumb: view,
+    loading,
+    mode,
+    search: search ? truncateCells(search, 36) : '',
+    theme,
+  })
+
+  // Truncation budget. Header line gets the full terminal width minus
+  // the box's horizontal padding (2 cells) and a small safety margin.
+  const budget = Math.max(0, columns - 4)
+  const chipsWidth = measureHeaderChipsWidth(chips)
 
   return h(Box, {
     borderColor: theme.colors.border,
@@ -101,15 +111,54 @@ export function renderHeader(
     height: 3,
     paddingX: 1,
   },
-  splitFragments
-    ? h(Text, { bold: true, color: theme.colors.accent }, titlePrefix)
-    : h(Text, { bold: true, color: theme.colors.accent }, truncatedTitle),
-  splitFragments
-    ? h(Text, { bold: true, color: prGlyph?.color, dimColor: prGlyph?.dim }, glyphPart)
-    : undefined,
-  splitFragments
-    ? h(Text, { bold: true, color: theme.colors.accent }, `${prLabel}${titleSuffix}`)
-    : undefined,
-  h(Text, { bold: true, color: modeColor }, `  ${mode}`),
-  search ? h(Text, { dimColor: true }, `  ${truncateCells(search, 36)}`) : undefined)
+  chipsWidth <= budget
+    ? renderChipRow(h, Text, chips)
+    : renderFallback(h, Text, chips, theme, budget))
+}
+
+/**
+ * Render every chip as its own Text span with its own color/style,
+ * interleaved with dim separator spans. This is the path used when
+ * everything fits — the eye gets the full chip treatment.
+ */
+function renderChipRow(
+  h: typeof ReactTypes.createElement,
+  Text: LogInkComponents['Text'],
+  chips: ReadonlyArray<HeaderChip>
+): ReactTypes.ReactNode {
+  const nodes: ReactTypes.ReactNode[] = []
+  chips.forEach((chip, index) => {
+    if (index > 0) {
+      // Separator is intentionally dim so the eye can use it as a
+      // visual delimiter without it competing with chip labels for
+      // attention.
+      nodes.push(h(Text, { key: `sep-${index}`, dimColor: true }, HEADER_CHIP_SEPARATOR))
+    }
+    nodes.push(h(Text, {
+      key: chip.id,
+      color: chip.color,
+      dimColor: chip.dim,
+      bold: chip.bold,
+    }, chip.label))
+  })
+  return nodes
+}
+
+/**
+ * Fallback path for narrow terminals. Concatenates every chip label
+ * with separators, then truncates the whole string with
+ * `truncateCells` so the ellipsis lands at a cell boundary. Loses the
+ * per-chip color treatment in exchange for guaranteed legibility on
+ * narrow displays — the same trade-off the pre-redesign single-
+ * fragment code made for its inline glyph color split.
+ */
+function renderFallback(
+  h: typeof ReactTypes.createElement,
+  Text: LogInkComponents['Text'],
+  chips: ReadonlyArray<HeaderChip>,
+  theme: LogInkTheme,
+  budget: number
+): ReactTypes.ReactNode {
+  const joined = chips.map((chip) => chip.label).join(HEADER_CHIP_SEPARATOR)
+  return h(Text, { bold: true, color: theme.colors.accent }, truncateCells(joined, budget))
 }


### PR DESCRIPTION
Same readability fix the footer got, applied to the title bar.

## Problem

The header concatenated every segment into a single Text span:

\`\`\`
coco  gfargo/coco  main  clean  no PR    [NORMAL]
\`\`\`

Eye reads it as one undifferentiated run of words. Hard to scan "what app, what repo, what branch, how clean, what PR state, what mode" — you have to parse left-to-right every time.

## Fix

Split into discrete chips with explicit visual separation and per-chip color treatment:

\`\`\`
coco · gfargo/coco · ⎇ main · ✓ clean · ⊘ no PR · [NORMAL]
\`\`\`

## Chip taxonomy

| chip      | label                  | color                  | when                          |
| --------- | ---------------------- | ---------------------- | ----------------------------- |
| app       | \`coco\`                 | accent + bold          | always                        |
| repo      | \`gfargo/coco\`          | default                | always                        |
| branch    | \`⎇ main\`               | accent + bold          | always                        |
| dirty     | \`✓ clean\` / \`● dirty\`  | success / warning      | always (state-flipped)        |
| bisecting | \`⚠ BISECTING\`          | warning + bold         | only when bisect is active    |
| pr        | \`◉ PR #1234 OPEN\` etc. | success/danger/muted   | always (muted when no PR)     |
| view      | breadcrumb             | muted dim              | only when a sub-view is pushed |
| loading   | \`loading commits\`      | muted dim              | only during boot / fetch       |
| mode      | \`[NORMAL]\`/\`[EDIT]\` etc | accent / warning       | always                        |
| search    | \`filter: foo\`          | muted dim              | only when active              |

ASCII fallbacks for every glyph (\`theme.ascii\` / TERM=dumb / vt100):
\`⎇ → git:\`, \`✓ → +\`, \`● → *\`, \`⚠ → !\`, \`⊘ → -\`

## Architecture

- **\`src/workstation/chrome/headerChips.ts\`** — pure builder that turns state into an ordered \`HeaderChip[]\`. No Ink dependency, fully unit-testable.
- **\`src/workstation/runtime/header.ts\`** — consumes the chip array, renders Ink Text spans interleaved with dim separator spans. Falls back to the pre-redesign single-fragment truncated string when the chip row exceeds the column budget (so the ellipsis can't land mid-glyph).

Follows the codebase's "helpers separated from runtime" discipline (per CLAUDE.md and the workstation README).

## Truncation behaviour

When chips fit the budget: render each as its own colored span with dim separators between them.
When chips overflow: concatenate labels + separators into one string, truncate with \`truncateCells\`, render as a single accent-colored span. Per-chip color is lost on narrow terminals, but legibility is preserved.

## Test plan

- [x] 17 new unit tests in \`chrome/headerChips.test.ts\` covering: baseline chip order, dirty/clean flip, bisect insertion, PR states (open / draft), breadcrumb omission, mode coloring, search visibility, ASCII degradation, width measurement
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [x] 1098 tests pass across \`workstation\` + \`commands/log\`
- [ ] Visual confirmation on a real terminal — header should now show distinct chips with separators; resize narrow to confirm truncation fallback still works

## Risk

Surgical. \`renderHeader\`'s exported signature is unchanged so no call-site updates needed. The truncation fallback uses the same accent-bold styling as the pre-redesign all-in-one span, so visually-narrow terminals see no regression. New helper file is isolated under \`chrome/\` with its own tests.