### PR TITLE
feat(workspace): multi-repo workspace view (`coco workspace`)

### DIFF
--- a/bin/smokeCli.ts
+++ b/bin/smokeCli.ts
@@ -164,6 +164,11 @@ try {
     args: ['ui', '--help'],
     label: 'packaged ui command help',
   })
+  runHelpCheck({
+    command: packagedBinPath(prefix),
+    args: ['workspace', '--help'],
+    label: 'packaged workspace command help',
+  })
   runCheck({
     command: packagedBinPath(prefix),
     args: ['init', '--dry-run', '--scope', 'project'],

--- a/schema.json
+++ b/schema.json
@@ -126,6 +126,36 @@
           },
           "additionalProperties": false,
           "description": "Interactive log TUI settings."
+        },
+        "workspace": {
+          "type": "object",
+          "properties": {
+            "roots": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Directories to scan for git repositories. Each entry may use a `~` prefix; resolved against the user's home directory. Defaults to `['~/code']` when omitted.",
+              "default": [
+                "~/code"
+              ]
+            },
+            "knownRepos": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Repositories outside the configured roots that should still appear in the workspace view. Useful for one-off projects kept somewhere other than the main `code` tree. Entries may use a `~` prefix.",
+              "default": []
+            },
+            "maxDepth": {
+              "type": "number",
+              "description": "Maximum depth to recurse into each configured root when looking for `.git/` directories. Stops descending as soon as a directory is identified as a repo.",
+              "default": 3
+            }
+          },
+          "additionalProperties": false,
+          "description": "Multi-repo workspace surface settings (`coco workspace`)."
         }
       },
       "required": [

--- a/src/commands/workspace/config.ts
+++ b/src/commands/workspace/config.ts
@@ -1,0 +1,41 @@
+import { Arguments, Argv, Options } from 'yargs'
+
+import { getCommandUsageHeader } from '../../lib/ui/helpers'
+import { LogInkThemePreset } from '../../workstation/chrome/theme'
+import { BaseCommandOptions } from '../types'
+
+export interface WorkspaceOptions extends BaseCommandOptions {
+  /**
+   * Override `workspace.roots` from config. Repeatable.
+   */
+  root?: string | string[]
+  /** Recursion depth into each root. */
+  maxDepth?: number
+  /** TUI theme preset. */
+  theme?: LogInkThemePreset
+}
+
+export type WorkspaceArgv = Arguments<WorkspaceOptions>
+
+export const command = ['workspace', 'ws']
+
+export const options = {
+  root: {
+    description:
+      'Directory to scan for repositories. Overrides `workspace.roots` from config. Repeatable.',
+    type: 'array',
+    alias: 'r',
+  },
+  maxDepth: {
+    description: 'Maximum recursion depth into each root. Defaults to 3.',
+    type: 'number',
+  },
+  theme: {
+    description: 'TUI theme preset',
+    choices: ['default', 'monochrome', 'catppuccin', 'gruvbox'],
+  },
+} as Record<string, Options>
+
+export const builder = (yargs: Argv): Argv => {
+  return yargs.options(options).usage(getCommandUsageHeader('workspace'))
+}

--- a/src/commands/workspace/handler.test.ts
+++ b/src/commands/workspace/handler.test.ts
@@ -1,9 +1,13 @@
 import {
+  buildDrillInUiArgv,
   resolveWorkspaceKnownRepos,
   resolveWorkspaceMaxDepth,
   resolveWorkspaceRoots,
+  runWorkspaceLoop,
+  type WorkspaceLoopDeps,
 } from './handler'
 import type { WorkspaceArgv } from './config'
+import type { WorkspaceExitResult } from '../../workstation/surfaces/workspace'
 
 function argv(overrides: Partial<WorkspaceArgv> = {}): WorkspaceArgv {
   return ({
@@ -54,5 +58,102 @@ describe('workspace handler argv resolution', () => {
     ).toBe(2)
     expect(resolveWorkspaceMaxDepth(argv(), {})).toBeUndefined()
     expect(resolveWorkspaceMaxDepth(argv({ maxDepth: 0 }), { workspace: { maxDepth: 2 } })).toBe(2)
+  })
+
+  it('buildDrillInUiArgv produces an interactive history argv', () => {
+    const drill = buildDrillInUiArgv(argv({ theme: 'gruvbox', verbose: true }))
+    expect(drill.interactive).toBe(true)
+    expect(drill.all).toBe(true)
+    expect(drill.theme).toBe('gruvbox')
+    expect(drill.verbose).toBe(true)
+  })
+})
+
+describe('runWorkspaceLoop', () => {
+  function quit(): WorkspaceExitResult {
+    return { kind: 'quit' }
+  }
+
+  function drillTo(path: string): WorkspaceExitResult {
+    return {
+      kind: 'drill-in',
+      repo: { path, name: 'r', branch: 'main', ahead: 0, behind: 0, dirty: 0 },
+      resume: { sortMode: 'recency', tab: 'all', filter: '', selectedRepoPath: path },
+    }
+  }
+
+  it('returns immediately when the user quits the first mount', async () => {
+    const startWorkspace: WorkspaceLoopDeps['startWorkspace'] = jest.fn(async () => quit())
+    const runUiForRepo = jest.fn()
+    const chdir = jest.fn()
+
+    await runWorkspaceLoop({
+      startWorkspace,
+      runUiForRepo,
+      chdir,
+      baseCwd: '/start',
+    })
+
+    expect(startWorkspace).toHaveBeenCalledTimes(1)
+    expect(runUiForRepo).not.toHaveBeenCalled()
+    expect(chdir).not.toHaveBeenCalled()
+  })
+
+  it('chdirs into the drill-in target, runs ui, restores cwd, and loops back with the resume seed', async () => {
+    const order: string[] = []
+    let calls = 0
+    const startWorkspace: WorkspaceLoopDeps['startWorkspace'] = jest.fn(
+      async (resume) => {
+        calls += 1
+        order.push(`workspace(${resume?.selectedRepoPath ?? 'none'})`)
+        if (calls === 1) {
+          return drillTo('/repos/a')
+        }
+        return quit()
+      }
+    )
+    const runUiForRepo = jest.fn(async (path: string) => {
+      order.push(`ui(${path})`)
+    })
+    const chdir = jest.fn((target: string) => {
+      order.push(`chdir(${target})`)
+    })
+
+    await runWorkspaceLoop({
+      startWorkspace,
+      runUiForRepo,
+      chdir,
+      baseCwd: '/start',
+    })
+
+    expect(order).toEqual([
+      'workspace(none)',
+      'chdir(/repos/a)',
+      'ui(/repos/a)',
+      'chdir(/start)',
+      'workspace(/repos/a)',
+    ])
+  })
+
+  it('restores cwd even when ui throws', async () => {
+    const startWorkspace: WorkspaceLoopDeps['startWorkspace'] = jest.fn(async () =>
+      drillTo('/repos/broken')
+    )
+    const runUiForRepo = jest.fn(async () => {
+      throw new Error('boom')
+    })
+    const chdir = jest.fn()
+
+    await expect(
+      runWorkspaceLoop({
+        startWorkspace,
+        runUiForRepo,
+        chdir,
+        baseCwd: '/start',
+      })
+    ).rejects.toThrow('boom')
+
+    expect(chdir).toHaveBeenNthCalledWith(1, '/repos/broken')
+    expect(chdir).toHaveBeenLastCalledWith('/start')
   })
 })

--- a/src/commands/workspace/handler.test.ts
+++ b/src/commands/workspace/handler.test.ts
@@ -1,0 +1,58 @@
+import {
+  resolveWorkspaceKnownRepos,
+  resolveWorkspaceMaxDepth,
+  resolveWorkspaceRoots,
+} from './handler'
+import type { WorkspaceArgv } from './config'
+
+function argv(overrides: Partial<WorkspaceArgv> = {}): WorkspaceArgv {
+  return ({
+    _: ['workspace'],
+    $0: 'coco',
+    interactive: true,
+    verbose: false,
+    version: false,
+    help: false,
+    ...overrides,
+  } as unknown) as WorkspaceArgv
+}
+
+describe('workspace handler argv resolution', () => {
+  it('prefers explicit --root over config and default', () => {
+    expect(
+      resolveWorkspaceRoots(argv({ root: ['/tmp/a', '/tmp/b'] }), {
+        workspace: { roots: ['~/code'] },
+      })
+    ).toEqual(['/tmp/a', '/tmp/b'])
+  })
+
+  it('falls back to config.workspace.roots when --root is missing', () => {
+    expect(
+      resolveWorkspaceRoots(argv(), { workspace: { roots: ['~/work', '~/oss'] } })
+    ).toEqual(['~/work', '~/oss'])
+  })
+
+  it('defaults to [~/code] when no config and no flag are present', () => {
+    expect(resolveWorkspaceRoots(argv(), {})).toEqual(['~/code'])
+  })
+
+  it('passes through known repos from config', () => {
+    expect(
+      resolveWorkspaceKnownRepos({
+        workspace: { knownRepos: ['~/tmp/one'] },
+      })
+    ).toEqual(['~/tmp/one'])
+    expect(resolveWorkspaceKnownRepos({})).toEqual([])
+  })
+
+  it('prefers --max-depth over config and rejects zero/negative values', () => {
+    expect(
+      resolveWorkspaceMaxDepth(argv({ maxDepth: 4 }), { workspace: { maxDepth: 2 } })
+    ).toBe(4)
+    expect(
+      resolveWorkspaceMaxDepth(argv(), { workspace: { maxDepth: 2 } })
+    ).toBe(2)
+    expect(resolveWorkspaceMaxDepth(argv(), {})).toBeUndefined()
+    expect(resolveWorkspaceMaxDepth(argv({ maxDepth: 0 }), { workspace: { maxDepth: 2 } })).toBe(2)
+  })
+})

--- a/src/commands/workspace/handler.ts
+++ b/src/commands/workspace/handler.ts
@@ -1,8 +1,14 @@
 import { CommandHandler } from '../../lib/types'
 import { Config } from '../../lib/config/types'
 import { loadConfig } from '../../lib/config/utils/loadConfig'
-import { startWorkspace } from '../../workstation/surfaces/workspace'
+import { getRepo } from '../../lib/simple-git/getRepo'
+import {
+  startWorkspace,
+  type WorkspaceResumeState,
+} from '../../workstation/surfaces/workspace'
 import { applyRepoFlag } from '../utils/applyRepoFlag'
+import { createLogArgvFromUiArgv, startCocoUiFromLogArgv } from '../ui/handler'
+import type { UiArgv } from '../ui/config'
 
 import { WorkspaceArgv } from './config'
 
@@ -41,6 +47,63 @@ export function resolveWorkspaceMaxDepth(
   return config.workspace?.maxDepth
 }
 
+/**
+ * Build the synthetic UI argv the workspace uses to drill into a repo.
+ * Mirrors `createLogArgvFromUiArgv` but seeded from the workspace's own
+ * argv shape so the user's --no-all / --branch-style flags carry through
+ * if they happened to set them.
+ */
+export function buildDrillInUiArgv(argv: WorkspaceArgv): UiArgv {
+  return ({
+    _: ['ui'],
+    $0: argv.$0,
+    interactive: true,
+    verbose: argv.verbose,
+    version: false,
+    help: false,
+    theme: argv.theme,
+    all: true,
+    repo: undefined,
+  } as unknown) as UiArgv
+}
+
+import type { WorkspaceExitResult } from '../../workstation/surfaces/workspace'
+
+export type WorkspaceLoopDeps = {
+  startWorkspace: (
+    resume: WorkspaceResumeState | undefined
+  ) => Promise<WorkspaceExitResult>
+  runUiForRepo: (repoPath: string) => Promise<void>
+  chdir: (target: string) => void
+  baseCwd: string
+}
+
+/**
+ * Pure loop: workspace ↔ ui drill-in. Each round-trip rewinds cwd
+ * back to the original directory so the next workspace mount sees a
+ * stable config-lookup root.
+ *
+ * Extracted from `startCocoWorkspace` so the loop is testable
+ * without mounting real Ink instances or shelling out.
+ */
+export async function runWorkspaceLoop(deps: WorkspaceLoopDeps): Promise<void> {
+  let resume: WorkspaceResumeState | undefined
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const result = await deps.startWorkspace(resume)
+    if (result.kind === 'quit') {
+      return
+    }
+    resume = result.resume
+    try {
+      deps.chdir(result.repo.path)
+      await deps.runUiForRepo(result.repo.path)
+    } finally {
+      deps.chdir(deps.baseCwd)
+    }
+  }
+}
+
 export async function startCocoWorkspace(argv: WorkspaceArgv): Promise<void> {
   // `--repo` still applies — useful if the user wants to scope a
   // single root override and have it interpreted relative to a target
@@ -53,13 +116,28 @@ export async function startCocoWorkspace(argv: WorkspaceArgv): Promise<void> {
   const roots = resolveWorkspaceRoots(argv, config)
   const knownRepos = resolveWorkspaceKnownRepos(config)
   const maxDepth = resolveWorkspaceMaxDepth(argv, config)
+  const baseCwd = process.cwd()
 
-  await startWorkspace({
-    roots,
-    knownRepos,
-    maxDepth,
-    appLabel: 'coco workspace',
-    theme: argv.theme ? { ...config.logTui?.theme, preset: argv.theme } : config.logTui?.theme,
+  await runWorkspaceLoop({
+    baseCwd,
+    chdir: (target) => process.chdir(target),
+    startWorkspace: (resume) =>
+      startWorkspace({
+        roots,
+        knownRepos,
+        maxDepth,
+        appLabel: 'coco workspace',
+        theme: argv.theme
+          ? { ...config.logTui?.theme, preset: argv.theme }
+          : config.logTui?.theme,
+        resume,
+      }),
+    runUiForRepo: async (repoPath) => {
+      const drillArgv = buildDrillInUiArgv(argv)
+      const logArgv = createLogArgvFromUiArgv(drillArgv)
+      const git = getRepo(repoPath)
+      await startCocoUiFromLogArgv(logArgv, { git })
+    },
   })
 }
 

--- a/src/commands/workspace/handler.ts
+++ b/src/commands/workspace/handler.ts
@@ -1,0 +1,68 @@
+import { CommandHandler } from '../../lib/types'
+import { Config } from '../../lib/config/types'
+import { loadConfig } from '../../lib/config/utils/loadConfig'
+import { startWorkspace } from '../../workstation/surfaces/workspace'
+import { applyRepoFlag } from '../utils/applyRepoFlag'
+
+import { WorkspaceArgv } from './config'
+
+const DEFAULT_ROOTS = ['~/code']
+
+export function resolveWorkspaceRoots(
+  argv: WorkspaceArgv,
+  config: Pick<Config, 'workspace'>
+): string[] {
+  const raw = argv.root
+  if (Array.isArray(raw) && raw.length > 0) {
+    return raw.map((entry) => String(entry))
+  }
+  if (typeof raw === 'string' && raw) {
+    return [raw]
+  }
+  if (config.workspace?.roots && config.workspace.roots.length > 0) {
+    return [...config.workspace.roots]
+  }
+  return [...DEFAULT_ROOTS]
+}
+
+export function resolveWorkspaceKnownRepos(
+  config: Pick<Config, 'workspace'>
+): string[] {
+  return config.workspace?.knownRepos ? [...config.workspace.knownRepos] : []
+}
+
+export function resolveWorkspaceMaxDepth(
+  argv: WorkspaceArgv,
+  config: Pick<Config, 'workspace'>
+): number | undefined {
+  if (typeof argv.maxDepth === 'number' && argv.maxDepth > 0) {
+    return argv.maxDepth
+  }
+  return config.workspace?.maxDepth
+}
+
+export async function startCocoWorkspace(argv: WorkspaceArgv): Promise<void> {
+  // `--repo` still applies — useful if the user wants to scope a
+  // single root override and have it interpreted relative to a target
+  // directory. The workspace surface itself never operates on a single
+  // SimpleGit; this just keeps config loading consistent with the
+  // other commands.
+  applyRepoFlag(argv)
+
+  const config = loadConfig<Config, WorkspaceArgv>(argv)
+  const roots = resolveWorkspaceRoots(argv, config)
+  const knownRepos = resolveWorkspaceKnownRepos(config)
+  const maxDepth = resolveWorkspaceMaxDepth(argv, config)
+
+  await startWorkspace({
+    roots,
+    knownRepos,
+    maxDepth,
+    appLabel: 'coco workspace',
+    theme: argv.theme ? { ...config.logTui?.theme, preset: argv.theme } : config.logTui?.theme,
+  })
+}
+
+export const handler: CommandHandler<WorkspaceArgv> = async (argv) => {
+  await startCocoWorkspace(argv)
+}

--- a/src/commands/workspace/index.ts
+++ b/src/commands/workspace/index.ts
@@ -1,0 +1,12 @@
+import commandExecutor from '../../lib/utils/commandExecutor'
+
+import { builder, command, options } from './config'
+import { handler } from './handler'
+
+export default {
+  command,
+  desc: 'Open the multi-repo workspace TUI.',
+  builder,
+  handler: commandExecutor(handler),
+  options,
+}

--- a/src/git/workspaceData.test.ts
+++ b/src/git/workspaceData.test.ts
@@ -1,0 +1,244 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { SimpleGit } from 'simple-git'
+
+import {
+  countPorcelainEntries,
+  discoverRepos,
+  discoverReposInRoot,
+  expandHome,
+  getRepoSummary,
+  getWorkspaceOverview,
+  isGitWorkingTree,
+  parseDivergence,
+  parseHeadRef,
+  parseLastCommit,
+  WorkspaceRepoSummary,
+} from './workspaceData'
+
+function fakeGit(impl: (args: string[]) => Promise<string> | string): SimpleGit {
+  return ({
+    raw: jest.fn(async (args: string[]) => impl(args)),
+  } as unknown) as SimpleGit
+}
+
+const FIELD_SEPARATOR = '\x1f'
+
+describe('workspaceData parsers', () => {
+  it('expands ~ to the user home directory', () => {
+    expect(expandHome('~')).toBe(os.homedir())
+    expect(expandHome('~/code')).toBe(path.join(os.homedir(), 'code'))
+    expect(expandHome('/tmp')).toBe('/tmp')
+  })
+
+  it('parses the HEAD ref line into branch + upstream', () => {
+    expect(parseHeadRef(['main', 'origin/main'].join(FIELD_SEPARATOR))).toEqual({
+      branch: 'main',
+      upstream: 'origin/main',
+    })
+    expect(parseHeadRef(['feature', ''].join(FIELD_SEPARATOR))).toEqual({
+      branch: 'feature',
+      upstream: undefined,
+    })
+    expect(parseHeadRef('')).toEqual({ branch: undefined, upstream: undefined })
+  })
+
+  it('parses the last-commit line into hash/date/subject', () => {
+    expect(
+      parseLastCommit(
+        ['abc1234', '2026-05-01T12:34:56-04:00', 'feat: thing'].join(FIELD_SEPARATOR)
+      )
+    ).toEqual({
+      hash: 'abc1234',
+      date: '2026-05-01T12:34:56-04:00',
+      subject: 'feat: thing',
+    })
+    expect(parseLastCommit('')).toBeUndefined()
+  })
+
+  it('parses divergence as ahead/behind counts', () => {
+    expect(parseDivergence('2\t5\n')).toEqual({ ahead: 5, behind: 2 })
+    expect(parseDivergence('')).toEqual({ ahead: 0, behind: 0 })
+  })
+
+  it('counts porcelain entries from --porcelain output', () => {
+    expect(countPorcelainEntries('')).toBe(0)
+    expect(countPorcelainEntries(' M src/a.ts\n?? src/b.ts\n')).toBe(2)
+  })
+})
+
+function createTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'coco-workspace-'))
+}
+
+function makeFakeRepo(root: string, name: string): string {
+  const repo = path.join(root, name)
+  fs.mkdirSync(path.join(repo, '.git'), { recursive: true })
+  return repo
+}
+
+describe('workspaceData discovery', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = createTempDir()
+  })
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it('finds repos directly under the root', () => {
+    const a = makeFakeRepo(root, 'project-a')
+    const b = makeFakeRepo(root, 'project-b')
+    fs.mkdirSync(path.join(root, 'not-a-repo'))
+
+    const repos = discoverReposInRoot(root)
+    expect(repos.sort()).toEqual([a, b].sort().map((p) => fs.realpathSync(p)))
+  })
+
+  it('treats both .git directories and .git pointer files as working trees', () => {
+    const dir = path.join(root, 'submodule')
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(path.join(dir, '.git'), 'gitdir: ../../.git/modules/submodule\n')
+    expect(isGitWorkingTree(dir)).toBe(true)
+  })
+
+  it('respects maxDepth', () => {
+    const nested = path.join(root, 'a', 'b', 'c', 'deep')
+    fs.mkdirSync(path.join(nested, '.git'), { recursive: true })
+
+    expect(discoverReposInRoot(root, { maxDepth: 2 })).toEqual([])
+    expect(discoverReposInRoot(root, { maxDepth: 4 })).toEqual([
+      fs.realpathSync(nested),
+    ])
+  })
+
+  it('prunes node_modules and hidden directories', () => {
+    makeFakeRepo(root, 'node_modules/should-not-discover')
+    makeFakeRepo(root, '.hidden/should-not-discover')
+    const visible = makeFakeRepo(root, 'visible')
+
+    expect(discoverReposInRoot(root)).toEqual([fs.realpathSync(visible)])
+  })
+
+  it('stops descending into a directory once it is identified as a repo', () => {
+    const outer = makeFakeRepo(root, 'outer')
+    // A nested .git inside an outer repo should not be discovered
+    // separately during discovery — submodules show up via their own
+    // listing later, not via root walking.
+    fs.mkdirSync(path.join(outer, 'vendor', 'inner', '.git'), { recursive: true })
+
+    expect(discoverReposInRoot(root)).toEqual([fs.realpathSync(outer)])
+  })
+
+  it('merges knownRepos into the discovered set and drops missing entries', () => {
+    const inRoot = makeFakeRepo(root, 'in-root')
+    const elsewhere = path.join(createTempDir(), 'elsewhere')
+    fs.mkdirSync(path.join(elsewhere, '.git'), { recursive: true })
+    const ghost = path.join(root, 'does-not-exist')
+
+    const repos = discoverRepos([root], [elsewhere, ghost])
+    expect(repos.sort()).toEqual([fs.realpathSync(inRoot), fs.realpathSync(elsewhere)].sort())
+  })
+
+  it('returns an empty list for a missing root', () => {
+    expect(discoverReposInRoot('/this/path/should/not/exist')).toEqual([])
+  })
+})
+
+describe('workspaceData per-repo summary', () => {
+  it('captures branch, dirty count, divergence, and last commit', async () => {
+    const git = fakeGit((args) => {
+      if (args[0] === 'for-each-ref') {
+        return ['main', 'origin/main'].join(FIELD_SEPARATOR) + '\n'
+      }
+      if (args[0] === 'status') {
+        return ' M src/a.ts\n?? src/b.ts\n'
+      }
+      if (args[0] === 'log') {
+        return (
+          ['abc1234', '2026-05-01T12:34:56-04:00', 'feat: thing'].join(FIELD_SEPARATOR) +
+          '\n'
+        )
+      }
+      if (args[0] === 'rev-list') {
+        return '1\t3\n'
+      }
+      return ''
+    })
+
+    const summary = await getRepoSummary('/tmp/example-repo', { git })
+
+    expect(summary).toMatchObject<Partial<WorkspaceRepoSummary>>({
+      name: 'example-repo',
+      branch: 'main',
+      ahead: 3,
+      behind: 1,
+      dirty: 2,
+      lastCommit: {
+        hash: 'abc1234',
+        date: '2026-05-01T12:34:56-04:00',
+        subject: 'feat: thing',
+      },
+    })
+    expect(summary.error).toBeUndefined()
+  })
+
+  it('falls back to a short hash when HEAD is detached', async () => {
+    const git = fakeGit((args) => {
+      if (args[0] === 'for-each-ref') return ''
+      if (args[0] === 'status') return ''
+      if (args[0] === 'log') {
+        return ['deadbee', '2026-05-01T00:00:00Z', 'wip'].join(FIELD_SEPARATOR) + '\n'
+      }
+      if (args[0] === 'rev-parse') return 'deadbee\n'
+      return ''
+    })
+
+    const summary = await getRepoSummary('/tmp/detached', { git })
+    expect(summary.branch).toBe('(deadbee)')
+  })
+
+  it('captures an error message without throwing when git invocation fails', async () => {
+    const git = fakeGit(() => {
+      throw new Error('not a git repository')
+    })
+
+    const summary = await getRepoSummary('/tmp/broken', { git })
+    expect(summary.error).toBe('not a git repository')
+    expect(summary.branch).toBeUndefined()
+  })
+})
+
+describe('workspaceData overview', () => {
+  it('runs the per-repo loader for every discovered path and returns a stable scan envelope', async () => {
+    const root = createTempDir()
+    try {
+      const a = makeFakeRepo(root, 'project-a')
+      const b = makeFakeRepo(root, 'project-b')
+
+      const loadSummary = jest.fn(async (repoPath: string): Promise<WorkspaceRepoSummary> => ({
+        path: repoPath,
+        name: path.basename(repoPath),
+        ahead: 0,
+        behind: 0,
+        dirty: 0,
+      }))
+
+      const overview = await getWorkspaceOverview([root], { loadSummary })
+
+      expect(loadSummary).toHaveBeenCalledTimes(2)
+      expect(overview.repos.map((entry) => entry.name).sort()).toEqual(['project-a', 'project-b'])
+      expect(overview.roots).toEqual([fs.realpathSync(root)])
+      expect(overview.scannedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+      // Ensure both fake paths showed up via discovery.
+      expect(overview.repos.find((entry) => entry.path === fs.realpathSync(a))).toBeDefined()
+      expect(overview.repos.find((entry) => entry.path === fs.realpathSync(b))).toBeDefined()
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/git/workspaceData.ts
+++ b/src/git/workspaceData.ts
@@ -1,0 +1,403 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import simpleGit, { SimpleGit } from 'simple-git'
+
+const FIELD_SEPARATOR = '\x1f'
+
+/**
+ * Discovery + per-repo summary loader for the workspace surface
+ * (#880). The surface lists multiple repos at once; this module
+ * walks a configured root, identifies git directories, and pulls a
+ * minimal summary per repo so the workspace view can render rows
+ * without diving into the full log/history loader stack.
+ *
+ * Keeps the cost-per-repo small (one batched `for-each-ref` /
+ * `status --porcelain` / `log -1` per repo) so a root with a dozen
+ * repos stays sub-second on warm fs cache.
+ */
+
+export type WorkspaceRepoSummary = {
+  /** Absolute, resolved repo path. Stable cache key. */
+  path: string
+  /** Human label — directory basename unless the caller overrides. */
+  name: string
+  /** Current branch, or detached-HEAD short hash, or undefined on error. */
+  branch?: string
+  /** Upstream-tracking divergence. Both 0 when no upstream is set. */
+  ahead: number
+  behind: number
+  /** Number of porcelain entries (unstaged + staged + untracked). */
+  dirty: number
+  /** Last commit; missing on empty repos. */
+  lastCommit?: {
+    hash: string
+    /** ISO-8601 committer date. */
+    date: string
+    subject: string
+  }
+  /** Loader error message — surface should render the row dimmed with the error in the detail pane. */
+  error?: string
+}
+
+export type WorkspaceDiscoveryOptions = {
+  /** Recursion cap from each root. Default 3. */
+  maxDepth?: number
+  /** Directory names that short-circuit descent. */
+  pruneDirs?: ReadonlySet<string>
+  /** Follow symlinks during discovery. Default false. */
+  followSymlinks?: boolean
+}
+
+const DEFAULT_MAX_DEPTH = 3
+
+const DEFAULT_PRUNE_DIRS: ReadonlySet<string> = new Set([
+  'node_modules',
+  '.cache',
+  '.next',
+  '.nuxt',
+  '.turbo',
+  '.parcel-cache',
+  'dist',
+  'build',
+  'target',
+  'coverage',
+  '__pycache__',
+  '.venv',
+  'venv',
+  '.idea',
+  '.vscode',
+])
+
+/**
+ * Expand a user-facing root path. Supports `~` and `~user` prefixes
+ * since the config is hand-edited and we don't want users typing
+ * absolute paths everywhere. Returns the resolved absolute path; the
+ * caller is responsible for the existence check.
+ */
+export function expandHome(rootPath: string): string {
+  if (rootPath === '~') {
+    return os.homedir()
+  }
+  if (rootPath.startsWith('~/')) {
+    return path.join(os.homedir(), rootPath.slice(2))
+  }
+  return path.resolve(rootPath)
+}
+
+/**
+ * Resolve a path through any symlinks, falling back to the resolved
+ * input when the target doesn't exist (so callers can keep going with
+ * a sensible best-effort value). This unifies `/var/...` and
+ * `/private/var/...` on macOS, plus any user-side `~/code` symlink
+ * shenanigans, into a single canonical key.
+ */
+export function canonicalize(rootPath: string): string {
+  const expanded = expandHome(rootPath)
+  try {
+    return fs.realpathSync(expanded)
+  } catch {
+    return expanded
+  }
+}
+
+/**
+ * True iff `dir` is a working tree (regular `.git/` directory OR
+ * a worktree pointer file). Submodules are also treated as repos —
+ * the workspace surface will list them as their own rows so the user
+ * can drill in. Bare repos are intentionally skipped (no working
+ * tree to summarize).
+ */
+export function isGitWorkingTree(dir: string): boolean {
+  const gitPath = path.join(dir, '.git')
+  try {
+    const stat = fs.lstatSync(gitPath)
+    if (stat.isDirectory()) {
+      return true
+    }
+    if (stat.isFile()) {
+      // worktree or submodule pointer
+      return true
+    }
+    return false
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Walk a single root, returning every directory that looks like a
+ * git working tree. Stops descending into a directory as soon as
+ * we've identified it as a repo (no point recursing into submodules
+ * during discovery — they'd be discovered separately if their
+ * containing path is itself a configured root).
+ *
+ * Discovery is intentionally cheap: pure fs reads, no git invocation.
+ */
+export function discoverReposInRoot(
+  rootPath: string,
+  options: WorkspaceDiscoveryOptions = {}
+): string[] {
+  const maxDepth = options.maxDepth ?? DEFAULT_MAX_DEPTH
+  const pruneDirs = options.pruneDirs ?? DEFAULT_PRUNE_DIRS
+  const followSymlinks = options.followSymlinks ?? false
+  const root = expandHome(rootPath)
+
+  let rootStat: fs.Stats
+  try {
+    rootStat = fs.statSync(root)
+  } catch {
+    return []
+  }
+  if (!rootStat.isDirectory()) {
+    return []
+  }
+
+  const found: string[] = []
+  const visited = new Set<string>()
+
+  const walk = (dir: string, depth: number) => {
+    let real: string
+    try {
+      real = fs.realpathSync(dir)
+    } catch {
+      return
+    }
+    if (visited.has(real)) {
+      return
+    }
+    visited.add(real)
+
+    if (isGitWorkingTree(dir)) {
+      found.push(real)
+      return
+    }
+
+    if (depth >= maxDepth) {
+      return
+    }
+
+    let entries: fs.Dirent[]
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+
+    for (const entry of entries) {
+      if (entry.name.startsWith('.')) {
+        continue
+      }
+      if (pruneDirs.has(entry.name)) {
+        continue
+      }
+      const child = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        walk(child, depth + 1)
+      } else if (followSymlinks && entry.isSymbolicLink()) {
+        try {
+          const childStat = fs.statSync(child)
+          if (childStat.isDirectory()) {
+            walk(child, depth + 1)
+          }
+        } catch {
+          // Broken symlink — skip silently.
+        }
+      }
+    }
+  }
+
+  walk(root, 0)
+  return found
+}
+
+/**
+ * Walk every configured root + merge in user-pinned `knownRepos`.
+ * Dedupes by resolved path, drops entries that no longer exist on
+ * disk.
+ */
+export function discoverRepos(
+  roots: ReadonlyArray<string>,
+  knownRepos: ReadonlyArray<string> = [],
+  options: WorkspaceDiscoveryOptions = {}
+): string[] {
+  const all = new Set<string>()
+  for (const root of roots) {
+    for (const repo of discoverReposInRoot(root, options)) {
+      all.add(repo)
+    }
+  }
+  for (const known of knownRepos) {
+    const resolved = canonicalize(known)
+    if (isGitWorkingTree(resolved)) {
+      all.add(resolved)
+    }
+  }
+  return [...all].sort()
+}
+
+export function parseHeadRef(line: string): { branch?: string; upstream?: string } {
+  const [branch = '', upstream = ''] = line.split(FIELD_SEPARATOR)
+  return {
+    branch: branch || undefined,
+    upstream: upstream || undefined,
+  }
+}
+
+export function parseLastCommit(
+  line: string
+): { hash: string; date: string; subject: string } | undefined {
+  const trimmed = line.trim()
+  if (!trimmed) {
+    return undefined
+  }
+  const [hash = '', date = '', subject = ''] = trimmed.split(FIELD_SEPARATOR)
+  if (!hash) {
+    return undefined
+  }
+  return { hash, date, subject }
+}
+
+export function parseDivergence(output: string): { ahead: number; behind: number } {
+  const [behind = '0', ahead = '0'] = output.trim().split(/\s+/)
+  return {
+    ahead: Number.parseInt(ahead, 10) || 0,
+    behind: Number.parseInt(behind, 10) || 0,
+  }
+}
+
+export function countPorcelainEntries(output: string): number {
+  return output.split('\n').filter((line) => line.length > 0).length
+}
+
+/**
+ * Resolve a per-repo summary. One git instance per repo, three
+ * batched reads (HEAD ref + status + last commit) plus an optional
+ * fourth for upstream divergence. All errors are caught and reported
+ * via `error` so a single unhealthy repo never poisons the workspace.
+ */
+export async function getRepoSummary(
+  repoPath: string,
+  options: { git?: SimpleGit } = {}
+): Promise<WorkspaceRepoSummary> {
+  const resolved = path.resolve(repoPath)
+  const summary: WorkspaceRepoSummary = {
+    path: resolved,
+    name: path.basename(resolved),
+    ahead: 0,
+    behind: 0,
+    dirty: 0,
+  }
+
+  const git = options.git ?? simpleGit(resolved)
+
+  try {
+    const [headOutput, statusOutput, lastCommitOutput] = await Promise.all([
+      git.raw([
+        'for-each-ref',
+        `--format=%(refname:short)${FIELD_SEPARATOR}%(upstream:short)`,
+        '--points-at=HEAD',
+        'refs/heads',
+      ]),
+      git.raw(['status', '--porcelain']),
+      git
+        .raw([
+          'log',
+          '-1',
+          `--format=%H${FIELD_SEPARATOR}%cI${FIELD_SEPARATOR}%s`,
+        ])
+        .catch(() => ''),
+    ])
+
+    const headLine = headOutput.split('\n').map((line) => line.trim()).find(Boolean) || ''
+    const parsedHead = parseHeadRef(headLine)
+
+    if (parsedHead.branch) {
+      summary.branch = parsedHead.branch
+    } else {
+      // Detached HEAD — show short hash. Falls back to undefined on
+      // an empty repo (no commits yet).
+      try {
+        const sha = (await git.raw(['rev-parse', '--short', 'HEAD'])).trim()
+        summary.branch = sha ? `(${sha})` : undefined
+      } catch {
+        summary.branch = undefined
+      }
+    }
+
+    summary.dirty = countPorcelainEntries(statusOutput)
+    summary.lastCommit = parseLastCommit(lastCommitOutput)
+
+    if (parsedHead.upstream && parsedHead.branch) {
+      try {
+        const divergence = await git.raw([
+          'rev-list',
+          '--left-right',
+          '--count',
+          `${parsedHead.upstream}...${parsedHead.branch}`,
+        ])
+        const { ahead, behind } = parseDivergence(divergence)
+        summary.ahead = ahead
+        summary.behind = behind
+      } catch {
+        // Upstream might not be fetched locally; treat as 0/0.
+      }
+    }
+  } catch (err) {
+    summary.error = err instanceof Error ? err.message : String(err)
+  }
+
+  return summary
+}
+
+export type WorkspaceOverview = {
+  /** Resolved per-root paths that were actually scanned. */
+  roots: string[]
+  /** Per-repo summary, sorted by path. */
+  repos: WorkspaceRepoSummary[]
+  /** ISO-8601 timestamp the overview was produced. */
+  scannedAt: string
+}
+
+export type GetWorkspaceOverviewOptions = WorkspaceDiscoveryOptions & {
+  knownRepos?: ReadonlyArray<string>
+  /** Override the per-repo loader (used by tests). */
+  loadSummary?: (repoPath: string) => Promise<WorkspaceRepoSummary>
+  /** Maximum number of repos summarized in parallel. Default 8. */
+  concurrency?: number
+}
+
+const DEFAULT_CONCURRENCY = 8
+
+async function mapWithConcurrency<T, U>(
+  inputs: ReadonlyArray<T>,
+  limit: number,
+  fn: (input: T) => Promise<U>
+): Promise<U[]> {
+  const results: U[] = []
+  let cursor = 0
+  const workers = Array.from({ length: Math.min(limit, inputs.length) }, async () => {
+    while (cursor < inputs.length) {
+      const idx = cursor++
+      results[idx] = await fn(inputs[idx])
+    }
+  })
+  await Promise.all(workers)
+  return results
+}
+
+export async function getWorkspaceOverview(
+  roots: ReadonlyArray<string>,
+  options: GetWorkspaceOverviewOptions = {}
+): Promise<WorkspaceOverview> {
+  const resolvedRoots = roots.map(canonicalize)
+  const repoPaths = discoverRepos(roots, options.knownRepos ?? [], options)
+  const loader = options.loadSummary ?? ((repoPath: string) => getRepoSummary(repoPath))
+  const concurrency = Math.max(1, options.concurrency ?? DEFAULT_CONCURRENCY)
+  const repos = await mapWithConcurrency(repoPaths, concurrency, loader)
+  return {
+    roots: resolvedRoots,
+    repos,
+    scannedAt: new Date().toISOString(),
+  }
+}

--- a/src/git/workspacePullRequestData.test.ts
+++ b/src/git/workspacePullRequestData.test.ts
@@ -1,0 +1,94 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import {
+  extractOriginUrl,
+  getWorkspacePullRequestCounts,
+  parseOpenPullRequestCount,
+  readOriginRemoteUrl,
+} from './workspacePullRequestData'
+
+describe('workspacePullRequestData parsers', () => {
+  it('extracts the origin URL from a git config block', () => {
+    const config = `
+[core]
+	repositoryformatversion = 0
+[remote "upstream"]
+	url = git@github.com:other/repo.git
+[remote "origin"]
+	url = git@github.com:gfargo/coco.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+`
+    expect(extractOriginUrl(config)).toBe('git@github.com:gfargo/coco.git')
+  })
+
+  it('returns undefined when no origin remote is configured', () => {
+    expect(extractOriginUrl('[core]\nrepositoryformatversion = 0\n')).toBeUndefined()
+  })
+
+  it('counts JSON-encoded PR arrays', () => {
+    expect(parseOpenPullRequestCount('[]')).toBe(0)
+    expect(parseOpenPullRequestCount('[{"number":1},{"number":2}]')).toBe(2)
+    expect(parseOpenPullRequestCount('not json')).toBeUndefined()
+  })
+
+  it('reads the origin remote from .git/config', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-pr-data-'))
+    try {
+      fs.mkdirSync(path.join(tmp, '.git'), { recursive: true })
+      fs.writeFileSync(
+        path.join(tmp, '.git', 'config'),
+        '[remote "origin"]\n\turl = https://github.com/gfargo/coco\n'
+      )
+      expect(readOriginRemoteUrl(tmp)).toBe('https://github.com/gfargo/coco')
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('getWorkspacePullRequestCounts', () => {
+  it('returns authenticated:false when gh auth status fails', async () => {
+    const runner = jest.fn(async (args: string[]) => {
+      if (args[0] === 'auth') throw new Error('not logged in')
+      return ''
+    })
+
+    const result = await getWorkspacePullRequestCounts(['/tmp/a'], { ghRunner: runner })
+
+    expect(result).toEqual({ authenticated: false, counts: {} })
+    // Only the auth probe should have been issued.
+    expect(runner).toHaveBeenCalledTimes(1)
+  })
+
+  it('issues one gh pr list per repo with a GitHub remote and records the count', async () => {
+    const remoteUrls = new Map<string, string>([
+      ['/tmp/repo-a', 'git@github.com:owner/repo-a.git'],
+      ['/tmp/repo-b', 'https://github.com/owner/repo-b'],
+      ['/tmp/repo-c', 'git@gitlab.com:owner/repo-c.git'],
+    ])
+
+    const runner = jest.fn(async (args: string[]) => {
+      if (args[0] === 'auth') return 'ok'
+      if (args[0] === 'pr') {
+        const repoArg = args[args.indexOf('-R') + 1]
+        if (repoArg === 'owner/repo-a') return '[{"number":1},{"number":2}]'
+        if (repoArg === 'owner/repo-b') return '[]'
+        throw new Error('repo not found')
+      }
+      return ''
+    })
+
+    const result = await getWorkspacePullRequestCounts(
+      ['/tmp/repo-a', '/tmp/repo-b', '/tmp/repo-c'],
+      { ghRunner: runner, remoteUrls }
+    )
+
+    expect(result.authenticated).toBe(true)
+    expect(result.counts).toEqual({
+      '/tmp/repo-a': 2,
+      '/tmp/repo-b': 0,
+    })
+  })
+})

--- a/src/git/workspacePullRequestData.ts
+++ b/src/git/workspacePullRequestData.ts
@@ -1,0 +1,167 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import {
+  defaultGhRunner,
+  isGhAuthenticated,
+  parseGitHubRemoteUrl,
+  type GhRunner,
+  type GitHubRepository,
+} from './githubCli'
+
+/**
+ * Open-PR counts for the workspace surface (#880). One `gh` invocation
+ * per repo with a GitHub remote, cheap enough to fan out across a
+ * dozen repos. Hidden entirely when `gh` is missing or unauthenticated
+ * — the surface drops the PR column rather than rendering "N/A".
+ *
+ * Per-repo failures are swallowed and reported as `undefined` so a
+ * single 4xx never poisons the whole panel.
+ */
+
+export type WorkspacePullRequestCounts = {
+  authenticated: boolean
+  /** Per-repo-path → open PR count. Missing keys = no count available. */
+  counts: Record<string, number>
+}
+
+/**
+ * Read the origin remote URL straight from the on-disk git config so
+ * we don't have to spawn a SimpleGit instance per repo just to ask
+ * for remotes. Falls back to undefined on any read failure.
+ */
+export function readOriginRemoteUrl(repoPath: string): string | undefined {
+  const candidates = [
+    path.join(repoPath, '.git', 'config'),
+    // Worktrees and submodules use a .git pointer file. Best effort —
+    // we'll just skip if the pointer resolution gets complicated.
+  ]
+  for (const candidate of candidates) {
+    try {
+      const text = fs.readFileSync(candidate, 'utf8')
+      const url = extractOriginUrl(text)
+      if (url) {
+        return url
+      }
+    } catch {
+      // Not the right candidate; try the next.
+    }
+  }
+  return undefined
+}
+
+export function extractOriginUrl(configText: string): string | undefined {
+  const lines = configText.split('\n')
+  let inOrigin = false
+  for (const rawLine of lines) {
+    const line = rawLine.trim()
+    if (line.startsWith('[remote ')) {
+      inOrigin = /\[remote\s+"origin"\]/.test(line)
+      continue
+    }
+    if (line.startsWith('[')) {
+      inOrigin = false
+      continue
+    }
+    if (!inOrigin) {
+      continue
+    }
+    const match = line.match(/^url\s*=\s*(.+)$/)
+    if (match) {
+      return match[1].trim()
+    }
+  }
+  return undefined
+}
+
+export function parseOpenPullRequestCount(json: string): number | undefined {
+  try {
+    const parsed = JSON.parse(json)
+    if (Array.isArray(parsed)) {
+      return parsed.length
+    }
+  } catch {
+    return undefined
+  }
+  return undefined
+}
+
+async function fetchPullRequestCount(
+  runner: GhRunner,
+  repository: GitHubRepository
+): Promise<number | undefined> {
+  try {
+    const out = await runner([
+      'pr',
+      'list',
+      '-R',
+      `${repository.owner}/${repository.name}`,
+      '--state',
+      'open',
+      '--json',
+      'number',
+      '--limit',
+      '100',
+    ])
+    return parseOpenPullRequestCount(out)
+  } catch {
+    return undefined
+  }
+}
+
+export type GetWorkspacePullRequestCountsOptions = {
+  /** Inject a `gh` runner for testing. */
+  ghRunner?: GhRunner
+  /** Pre-resolved remote URL per path — saves a fs read each. */
+  remoteUrls?: ReadonlyMap<string, string>
+  /** Maximum number of concurrent gh calls. Default 4. */
+  concurrency?: number
+}
+
+async function mapWithConcurrency<T, U>(
+  inputs: ReadonlyArray<T>,
+  limit: number,
+  fn: (input: T) => Promise<U>
+): Promise<U[]> {
+  const results: U[] = []
+  let cursor = 0
+  const workers = Array.from({ length: Math.min(limit, inputs.length) }, async () => {
+    while (cursor < inputs.length) {
+      const idx = cursor++
+      results[idx] = await fn(inputs[idx])
+    }
+  })
+  await Promise.all(workers)
+  return results
+}
+
+export async function getWorkspacePullRequestCounts(
+  repoPaths: ReadonlyArray<string>,
+  options: GetWorkspacePullRequestCountsOptions = {}
+): Promise<WorkspacePullRequestCounts> {
+  const runner = options.ghRunner ?? defaultGhRunner
+  const authenticated = await isGhAuthenticated(runner)
+  if (!authenticated) {
+    return { authenticated: false, counts: {} }
+  }
+
+  const counts: Record<string, number> = {}
+  const concurrency = Math.max(1, options.concurrency ?? 4)
+
+  await mapWithConcurrency(repoPaths, concurrency, async (repoPath) => {
+    const url = options.remoteUrls?.get(repoPath) ?? readOriginRemoteUrl(repoPath)
+    if (!url) {
+      return
+    }
+    const repo = parseGitHubRemoteUrl(url)
+    if (!repo) {
+      return
+    }
+    const count = await fetchPullRequestCount(runner, repo)
+    if (typeof count === 'number') {
+      counts[repoPath] = count
+    }
+  })
+
+  return { authenticated: true, counts }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import prs from './commands/prs'
 import recap from './commands/recap'
 import review from './commands/review'
 import ui from './commands/ui'
+import workspace from './commands/workspace'
 
 import { CacheOptions } from './commands/cache/config'
 import { ChangelogOptions } from './commands/changelog/config'
@@ -23,6 +24,7 @@ import { PrsOptions } from './commands/prs/config'
 import { RecapOptions } from './commands/recap/config'
 import { ReviewOptions } from './commands/review/config'
 import { UiOptions } from './commands/ui/config'
+import { WorkspaceOptions } from './commands/workspace/config'
 import { Config } from './lib/config/types'
 import * as types from './lib/types'
 
@@ -99,6 +101,13 @@ y.command<UiOptions>(
   ui.handler
 )
 
+y.command<WorkspaceOptions>(
+  workspace.command,
+  workspace.desc,
+  workspace.builder,
+  workspace.handler
+)
+
 y.command<CacheOptions>(
   cache.command,
   cache.desc,
@@ -153,4 +162,5 @@ export {
   recap,
   types,
   ui,
+  workspace,
 }

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -122,6 +122,39 @@ type BaseConfig = {
      */
     dateBucketing?: boolean
   }
+
+  /**
+   * Multi-repo workspace surface settings (`coco workspace`).
+   */
+  workspace?: {
+    /**
+     * Directories to scan for git repositories. Each entry may use a
+     * `~` prefix; resolved against the user's home directory. Defaults
+     * to `['~/code']` when omitted.
+     *
+     * @default ['~/code']
+     */
+    roots?: string[]
+
+    /**
+     * Repositories outside the configured roots that should still
+     * appear in the workspace view. Useful for one-off projects kept
+     * somewhere other than the main `code` tree. Entries may use a
+     * `~` prefix.
+     *
+     * @default []
+     */
+    knownRepos?: string[]
+
+    /**
+     * Maximum depth to recurse into each configured root when looking
+     * for `.git/` directories. Stops descending as soon as a directory
+     * is identified as a repo.
+     *
+     * @default 3
+     */
+    maxDepth?: number
+  }
 }
 
 export type ConfigWithServiceObject = BaseConfig &

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -137,6 +137,36 @@ export const schema = {
           },
           "additionalProperties": false,
           "description": "Interactive log TUI settings."
+        },
+        "workspace": {
+          "type": "object",
+          "properties": {
+            "roots": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Directories to scan for git repositories. Each entry may use a `~` prefix; resolved against the user's home directory. Defaults to `['~/code']` when omitted.",
+              "default": [
+                "~/code"
+              ]
+            },
+            "knownRepos": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Repositories outside the configured roots that should still appear in the workspace view. Useful for one-off projects kept somewhere other than the main `code` tree. Entries may use a `~` prefix.",
+              "default": []
+            },
+            "maxDepth": {
+              "type": "number",
+              "description": "Maximum depth to recurse into each configured root when looking for `.git/` directories. Stops descending as soon as a directory is identified as a repo.",
+              "default": 3
+            }
+          },
+          "additionalProperties": false,
+          "description": "Multi-repo workspace surface settings (`coco workspace`)."
         }
       },
       "required": [

--- a/src/workstation/chrome/workspaceCache.test.ts
+++ b/src/workstation/chrome/workspaceCache.test.ts
@@ -1,0 +1,100 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { WorkspaceOverview } from '../../git/workspaceData'
+
+import {
+  getWorkspaceCachePath,
+  readCachedWorkspace,
+  workspaceCacheKey,
+  writeCachedWorkspace,
+} from './workspaceCache'
+
+const baseOverview: WorkspaceOverview = {
+  roots: ['/home/me/code'],
+  scannedAt: '2026-05-26T12:00:00.000Z',
+  repos: [
+    {
+      path: '/home/me/code/proj',
+      name: 'proj',
+      branch: 'main',
+      ahead: 0,
+      behind: 0,
+      dirty: 0,
+    },
+  ],
+}
+
+describe('workspaceCacheKey', () => {
+  it('is stable under root reordering and whitespace', () => {
+    expect(workspaceCacheKey(['~/code', '~/work'])).toBe(workspaceCacheKey(['~/work', '~/code']))
+    expect(workspaceCacheKey([' ~/code ', '~/work'])).toBe(workspaceCacheKey(['~/code', '~/work']))
+  })
+
+  it('differs when the set of roots differs', () => {
+    expect(workspaceCacheKey(['~/code'])).not.toBe(workspaceCacheKey(['~/code', '~/work']))
+  })
+})
+
+describe('workspace cache read/write', () => {
+  let tmpHome: string
+  let originalXdg: string | undefined
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-workspace-cache-'))
+    originalXdg = process.env.XDG_CACHE_HOME
+    process.env.XDG_CACHE_HOME = tmpHome
+  })
+
+  afterEach(() => {
+    if (originalXdg === undefined) {
+      delete process.env.XDG_CACHE_HOME
+    } else {
+      process.env.XDG_CACHE_HOME = originalXdg
+    }
+    fs.rmSync(tmpHome, { recursive: true, force: true })
+  })
+
+  it('round-trips an overview through the cache', () => {
+    const roots = ['~/code']
+    expect(readCachedWorkspace(roots)).toBeUndefined()
+
+    writeCachedWorkspace(roots, baseOverview)
+
+    const cachePath = getWorkspaceCachePath(roots)
+    expect(fs.existsSync(cachePath)).toBe(true)
+    expect(readCachedWorkspace(roots)).toEqual(baseOverview)
+  })
+
+  it('treats a schema mismatch as no cache', () => {
+    const roots = ['~/code']
+    const cachePath = getWorkspaceCachePath(roots)
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true })
+    fs.writeFileSync(
+      cachePath,
+      JSON.stringify({ version: 999, savedAt: '2020-01-01', overview: baseOverview })
+    )
+
+    expect(readCachedWorkspace(roots)).toBeUndefined()
+  })
+
+  it('returns undefined when the envelope is malformed', () => {
+    const roots = ['~/code']
+    const cachePath = getWorkspaceCachePath(roots)
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true })
+    fs.writeFileSync(cachePath, 'not json')
+
+    expect(readCachedWorkspace(roots)).toBeUndefined()
+  })
+
+  it('swallows write failures silently', () => {
+    // Point XDG at a path inside a file rather than a directory so
+    // mkdirSync throws — the cache write should swallow.
+    const blocker = path.join(tmpHome, 'blocker')
+    fs.writeFileSync(blocker, '')
+    process.env.XDG_CACHE_HOME = blocker
+
+    expect(() => writeCachedWorkspace(['~/code'], baseOverview)).not.toThrow()
+  })
+})

--- a/src/workstation/chrome/workspaceCache.ts
+++ b/src/workstation/chrome/workspaceCache.ts
@@ -43,8 +43,7 @@ export function workspaceCacheKey(roots: ReadonlyArray<string>): string {
   const normalized = [...roots].map((entry) => entry.trim()).filter(Boolean).sort()
   // sha1 here is a non-security cache-key derivation. DevSkim DS126858
   // does not apply.
-  // DevSkim: ignore DS126858
-  return crypto.createHash('sha1').update(normalized.join('\n')).digest('hex').slice(0, 16)
+  return crypto.createHash('sha1').update(normalized.join('\n')).digest('hex').slice(0, 16) // DevSkim: ignore DS126858
 }
 
 export function getWorkspaceCachePath(roots: ReadonlyArray<string>): string {

--- a/src/workstation/chrome/workspaceCache.ts
+++ b/src/workstation/chrome/workspaceCache.ts
@@ -1,0 +1,88 @@
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { WorkspaceOverview } from '../../git/workspaceData'
+
+/**
+ * Disk cache of the most recent workspace overview (#880). Discovery
+ * walks every configured root, which can take a noticeable amount of
+ * time on machines with many sibling repos and cold filesystem cache.
+ * On subsequent boots the workspace surface paints from this cache
+ * immediately and then refreshes in the background, mirroring the
+ * three-stage boot the `coco ui` command already uses for commits
+ * (see `overviewCache.ts`).
+ *
+ * Best-effort: read failures silently fall back to "no cache" and
+ * write failures are swallowed.
+ *
+ * The cache is keyed by a hash of the sorted root list — different
+ * `workspace.roots` configurations don't collide and don't poison
+ * each other's caches when the user toggles between two setups.
+ */
+
+const CACHE_SCHEMA_VERSION = 1
+const CACHE_DIR_NAME = 'workspace'
+
+type CacheEnvelope = {
+  version: number
+  savedAt: string
+  overview: WorkspaceOverview
+}
+
+function resolveCacheDir(): string {
+  const xdg = process.env.XDG_CACHE_HOME
+  if (xdg && xdg.trim().length > 0) {
+    return path.join(xdg, 'coco', CACHE_DIR_NAME)
+  }
+  return path.join(os.homedir(), '.cache', 'coco', CACHE_DIR_NAME)
+}
+
+export function workspaceCacheKey(roots: ReadonlyArray<string>): string {
+  const normalized = [...roots].map((entry) => entry.trim()).filter(Boolean).sort()
+  // sha1 here is a non-security cache-key derivation. DevSkim DS126858
+  // does not apply.
+  // DevSkim: ignore DS126858
+  return crypto.createHash('sha1').update(normalized.join('\n')).digest('hex').slice(0, 16)
+}
+
+export function getWorkspaceCachePath(roots: ReadonlyArray<string>): string {
+  return path.join(resolveCacheDir(), `overview.${workspaceCacheKey(roots)}.json`)
+}
+
+export function readCachedWorkspace(
+  roots: ReadonlyArray<string>
+): WorkspaceOverview | undefined {
+  try {
+    const raw = fs.readFileSync(getWorkspaceCachePath(roots), 'utf8')
+    const parsed = JSON.parse(raw) as CacheEnvelope
+    if (parsed.version !== CACHE_SCHEMA_VERSION) {
+      return undefined
+    }
+    if (!parsed.overview || !Array.isArray(parsed.overview.repos)) {
+      return undefined
+    }
+    return parsed.overview
+  } catch {
+    return undefined
+  }
+}
+
+export function writeCachedWorkspace(
+  roots: ReadonlyArray<string>,
+  overview: WorkspaceOverview
+): void {
+  const file = getWorkspaceCachePath(roots)
+  const envelope: CacheEnvelope = {
+    version: CACHE_SCHEMA_VERSION,
+    savedAt: new Date().toISOString(),
+    overview,
+  }
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true })
+    fs.writeFileSync(file, JSON.stringify(envelope))
+  } catch {
+    // Best-effort persistence; swallow.
+  }
+}

--- a/src/workstation/chrome/workspaceKnownRepos.test.ts
+++ b/src/workstation/chrome/workspaceKnownRepos.test.ts
@@ -1,0 +1,62 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import {
+  appendKnownRepo,
+  getKnownReposStorePath,
+  readKnownRepos,
+  writeKnownRepos,
+} from './workspaceKnownRepos'
+
+describe('workspaceKnownRepos persistence', () => {
+  let tmpHome: string
+  let originalXdg: string | undefined
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-known-repos-'))
+    originalXdg = process.env.XDG_CACHE_HOME
+    process.env.XDG_CACHE_HOME = tmpHome
+  })
+
+  afterEach(() => {
+    if (originalXdg === undefined) {
+      delete process.env.XDG_CACHE_HOME
+    } else {
+      process.env.XDG_CACHE_HOME = originalXdg
+    }
+    fs.rmSync(tmpHome, { recursive: true, force: true })
+  })
+
+  it('returns an empty list when the store has not been initialized', () => {
+    expect(readKnownRepos()).toEqual([])
+  })
+
+  it('round-trips paths through the store', () => {
+    writeKnownRepos(['/a', '/b', '/a'])
+    expect(readKnownRepos()).toEqual(['/a', '/b'])
+    expect(fs.existsSync(getKnownReposStorePath())).toBe(true)
+  })
+
+  it('treats a schema mismatch as no store', () => {
+    fs.mkdirSync(path.dirname(getKnownReposStorePath()), { recursive: true })
+    fs.writeFileSync(
+      getKnownReposStorePath(),
+      JSON.stringify({ version: 99, paths: ['/x'], updatedAt: '2020-01-01' })
+    )
+    expect(readKnownRepos()).toEqual([])
+  })
+
+  it('appendKnownRepo de-dupes', () => {
+    appendKnownRepo('/a')
+    expect(appendKnownRepo('/a')).toEqual(['/a'])
+    expect(appendKnownRepo('/b')).toEqual(['/a', '/b'])
+  })
+
+  it('swallows write failures silently', () => {
+    const blocker = path.join(tmpHome, 'blocker-file')
+    fs.writeFileSync(blocker, '')
+    process.env.XDG_CACHE_HOME = blocker
+    expect(() => writeKnownRepos(['/c'])).not.toThrow()
+  })
+})

--- a/src/workstation/chrome/workspaceKnownRepos.ts
+++ b/src/workstation/chrome/workspaceKnownRepos.ts
@@ -1,0 +1,87 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+/**
+ * Per-user list of "known" repos added via the workspace add-repo
+ * prompt (#880). Persisted separately from the user's config so we
+ * don't have to write back into a hand-edited (and potentially
+ * version-controlled) `.coco.config.json`.
+ *
+ * The discovery layer merges this list with `config.workspace.knownRepos`
+ * — config wins for de-dupe so users can pin repos that the
+ * add-repo prompt removed via the in-app delete affordance later
+ * (out of scope for v1).
+ *
+ * Best-effort: read failures return an empty list, write failures
+ * are swallowed silently.
+ */
+
+const STORE_SCHEMA_VERSION = 1
+const STORE_DIR_NAME = 'workspace'
+const STORE_FILE_NAME = 'known-repos.json'
+
+type Envelope = {
+  version: number
+  paths: string[]
+  updatedAt: string
+}
+
+function resolveStoreDir(): string {
+  const xdg = process.env.XDG_CACHE_HOME
+  if (xdg && xdg.trim().length > 0) {
+    return path.join(xdg, 'coco', STORE_DIR_NAME)
+  }
+  return path.join(os.homedir(), '.cache', 'coco', STORE_DIR_NAME)
+}
+
+export function getKnownReposStorePath(): string {
+  return path.join(resolveStoreDir(), STORE_FILE_NAME)
+}
+
+export function readKnownRepos(): string[] {
+  try {
+    const raw = fs.readFileSync(getKnownReposStorePath(), 'utf8')
+    const parsed = JSON.parse(raw) as Envelope
+    if (parsed.version !== STORE_SCHEMA_VERSION) {
+      return []
+    }
+    if (!Array.isArray(parsed.paths)) {
+      return []
+    }
+    return parsed.paths.filter((entry): entry is string => typeof entry === 'string')
+  } catch {
+    return []
+  }
+}
+
+export function writeKnownRepos(paths: ReadonlyArray<string>): void {
+  const envelope: Envelope = {
+    version: STORE_SCHEMA_VERSION,
+    paths: [...new Set(paths)],
+    updatedAt: new Date().toISOString(),
+  }
+  const file = getKnownReposStorePath()
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true })
+    fs.writeFileSync(file, JSON.stringify(envelope, null, 2))
+  } catch {
+    // Best-effort persistence.
+  }
+}
+
+/**
+ * Add a new entry and persist. Returns the updated, de-duplicated
+ * list. Caller is responsible for resolving the input path before
+ * passing it (e.g., realpath / home-prefix expansion) so the stored
+ * value is canonical.
+ */
+export function appendKnownRepo(repoPath: string): string[] {
+  const existing = readKnownRepos()
+  if (existing.includes(repoPath)) {
+    return existing
+  }
+  const next = [...existing, repoPath]
+  writeKnownRepos(next)
+  return next
+}

--- a/src/workstation/surfaces/workspace/filter.test.ts
+++ b/src/workstation/surfaces/workspace/filter.test.ts
@@ -1,0 +1,85 @@
+import { WorkspaceRepoSummary } from '../../../git/workspaceData'
+
+import {
+  filterWorkspaceRepos,
+  matchesWorkspaceTab,
+  matchesWorkspaceText,
+  nextWorkspaceTab,
+  previousWorkspaceTab,
+  workspaceTabLabel,
+  WORKSPACE_TABS,
+} from './filter'
+
+function repo(overrides: Partial<WorkspaceRepoSummary>): WorkspaceRepoSummary {
+  return {
+    path: `/tmp/${overrides.name ?? 'r'}`,
+    name: overrides.name ?? 'r',
+    branch: overrides.branch ?? 'main',
+    ahead: 0,
+    behind: 0,
+    dirty: 0,
+    ...overrides,
+  }
+}
+
+describe('workspace filter tabs', () => {
+  it('cycles forward and backward stably', () => {
+    expect(nextWorkspaceTab('all')).toBe('dirty')
+    expect(nextWorkspaceTab('pull-requests')).toBe('all')
+    expect(previousWorkspaceTab('all')).toBe('pull-requests')
+    expect(previousWorkspaceTab('dirty')).toBe('all')
+  })
+
+  it('labels each tab', () => {
+    expect(WORKSPACE_TABS.map(workspaceTabLabel)).toEqual(['All', 'Dirty', 'Behind', 'PRs'])
+  })
+
+  it('all tab matches every repo', () => {
+    expect(matchesWorkspaceTab(repo({ name: 'a' }), 'all')).toBe(true)
+  })
+
+  it('dirty tab matches repos with at least one porcelain entry', () => {
+    expect(matchesWorkspaceTab(repo({ name: 'a', dirty: 0 }), 'dirty')).toBe(false)
+    expect(matchesWorkspaceTab(repo({ name: 'a', dirty: 5 }), 'dirty')).toBe(true)
+  })
+
+  it('behind tab matches repos that are behind their upstream', () => {
+    expect(matchesWorkspaceTab(repo({ name: 'a', behind: 0 }), 'behind')).toBe(false)
+    expect(matchesWorkspaceTab(repo({ name: 'a', behind: 2 }), 'behind')).toBe(true)
+  })
+
+  it('pull-requests tab requires count > 0 from context', () => {
+    const entry = repo({ name: 'a' })
+    expect(matchesWorkspaceTab(entry, 'pull-requests')).toBe(false)
+    expect(
+      matchesWorkspaceTab(entry, 'pull-requests', { pullRequestCounts: { [entry.path]: 0 } })
+    ).toBe(false)
+    expect(
+      matchesWorkspaceTab(entry, 'pull-requests', { pullRequestCounts: { [entry.path]: 3 } })
+    ).toBe(true)
+  })
+
+  it('filterWorkspaceRepos applies the predicate without mutating input', () => {
+    const repos = [
+      repo({ name: 'clean', dirty: 0 }),
+      repo({ name: 'dirty-1', dirty: 1 }),
+      repo({ name: 'dirty-2', dirty: 4 }),
+    ]
+    expect(filterWorkspaceRepos(repos, 'dirty').map((entry) => entry.name)).toEqual([
+      'dirty-1',
+      'dirty-2',
+    ])
+    expect(repos).toHaveLength(3)
+  })
+})
+
+describe('matchesWorkspaceText', () => {
+  it('matches against name, branch and path case-insensitively', () => {
+    const entry = repo({ name: 'coco', branch: 'feature/foo', path: '/Users/me/code/coco' })
+    expect(matchesWorkspaceText(entry, '')).toBe(true)
+    expect(matchesWorkspaceText(entry, 'COCO')).toBe(true)
+    expect(matchesWorkspaceText(entry, 'feature')).toBe(true)
+    expect(matchesWorkspaceText(entry, 'users/me')).toBe(true)
+    expect(matchesWorkspaceText(entry, 'zzz')).toBe(false)
+  })
+})

--- a/src/workstation/surfaces/workspace/filter.ts
+++ b/src/workstation/surfaces/workspace/filter.ts
@@ -1,0 +1,78 @@
+import type { WorkspaceRepoSummary } from '../../../git/workspaceData'
+
+/**
+ * Sidebar tabs for the workspace surface. Each tab is a predicate on
+ * the repo summary plus an optional dependency on PR data — tabs whose
+ * predicate would yield zero rows in absence of PR data are gated so
+ * the surface can dim them rather than show empty lists.
+ */
+export const WORKSPACE_TABS = ['all', 'dirty', 'behind', 'pull-requests'] as const
+
+export type WorkspaceTab = (typeof WORKSPACE_TABS)[number]
+
+const TAB_LABELS: Record<WorkspaceTab, string> = {
+  all: 'All',
+  dirty: 'Dirty',
+  behind: 'Behind',
+  'pull-requests': 'PRs',
+}
+
+export function workspaceTabLabel(tab: WorkspaceTab): string {
+  return TAB_LABELS[tab]
+}
+
+export function nextWorkspaceTab(current: WorkspaceTab): WorkspaceTab {
+  const idx = WORKSPACE_TABS.indexOf(current)
+  return WORKSPACE_TABS[(idx + 1) % WORKSPACE_TABS.length]
+}
+
+export function previousWorkspaceTab(current: WorkspaceTab): WorkspaceTab {
+  const idx = WORKSPACE_TABS.indexOf(current)
+  return WORKSPACE_TABS[(idx - 1 + WORKSPACE_TABS.length) % WORKSPACE_TABS.length]
+}
+
+export type WorkspaceTabContext = {
+  pullRequestCounts?: Readonly<Record<string, number>>
+}
+
+export function matchesWorkspaceTab(
+  repo: WorkspaceRepoSummary,
+  tab: WorkspaceTab,
+  context: WorkspaceTabContext = {}
+): boolean {
+  switch (tab) {
+    case 'all':
+      return true
+    case 'dirty':
+      return repo.dirty > 0
+    case 'behind':
+      return repo.behind > 0
+    case 'pull-requests': {
+      const count = context.pullRequestCounts?.[repo.path] ?? 0
+      return count > 0
+    }
+    default:
+      return true
+  }
+}
+
+export function filterWorkspaceRepos(
+  repos: ReadonlyArray<WorkspaceRepoSummary>,
+  tab: WorkspaceTab,
+  context: WorkspaceTabContext = {}
+): WorkspaceRepoSummary[] {
+  return repos.filter((entry) => matchesWorkspaceTab(entry, tab, context))
+}
+
+/**
+ * Case-insensitive substring match against the repo name + branch.
+ * Used by the surface's filter prompt; the surface decides whether to
+ * also apply the sidebar tab filter on top.
+ */
+export function matchesWorkspaceText(repo: WorkspaceRepoSummary, query: string): boolean {
+  if (!query) {
+    return true
+  }
+  const haystack = [repo.name, repo.branch ?? '', repo.path].join('').toLowerCase()
+  return haystack.includes(query.toLowerCase())
+}

--- a/src/workstation/surfaces/workspace/index.ts
+++ b/src/workstation/surfaces/workspace/index.ts
@@ -1,0 +1,26 @@
+export { startWorkspace, type WorkspaceStartOptions } from './runtime'
+export { resolveWorkspaceInput, type WorkspaceInputIntent, type WorkspaceInputKey } from './input'
+export {
+  applyWorkspaceAction,
+  createWorkspaceState,
+  selectFocusedRepo,
+  selectVisibleRepos,
+  type WorkspaceAction,
+  type WorkspaceState,
+} from './state'
+export {
+  buildWorkspaceFooter,
+  buildWorkspaceHeader,
+  buildWorkspaceListRows,
+  buildWorkspaceSidebar,
+} from './render'
+export {
+  WORKSPACE_SORT_MODES,
+  workspaceSortLabel,
+  type WorkspaceSortMode,
+} from './sort'
+export {
+  WORKSPACE_TABS,
+  workspaceTabLabel,
+  type WorkspaceTab,
+} from './filter'

--- a/src/workstation/surfaces/workspace/index.ts
+++ b/src/workstation/surfaces/workspace/index.ts
@@ -1,4 +1,9 @@
-export { startWorkspace, type WorkspaceStartOptions } from './runtime'
+export {
+  startWorkspace,
+  type WorkspaceExitResult,
+  type WorkspaceResumeState,
+  type WorkspaceStartOptions,
+} from './runtime'
 export { resolveWorkspaceInput, type WorkspaceInputIntent, type WorkspaceInputKey } from './input'
 export {
   applyWorkspaceAction,

--- a/src/workstation/surfaces/workspace/input.test.ts
+++ b/src/workstation/surfaces/workspace/input.test.ts
@@ -22,6 +22,10 @@ function filterState(): WorkspaceState {
   return { ...createWorkspaceState({ overview: emptyOverview, roots: ['~/code'] }), focus: 'filter' }
 }
 
+function addRepoState(): WorkspaceState {
+  return { ...createWorkspaceState({ overview: emptyOverview, roots: ['~/code'] }), focus: 'add-repo' }
+}
+
 describe('resolveWorkspaceInput', () => {
   it('quits on q or escape (no filter active)', () => {
     expect(resolveWorkspaceInput('q', key(), listState()).kind).toBe('quit')
@@ -105,5 +109,15 @@ describe('resolveWorkspaceInput', () => {
       action: { type: 'set-focus', focus: 'list' },
     })
     expect(resolveWorkspaceInput('a', key(), filterState()).kind).toBe('noop')
+  })
+
+  it('routes escape out of the add-repo prompt and lets the runtime own other keys', () => {
+    expect(resolveWorkspaceInput('', key({ escape: true }), addRepoState())).toEqual({
+      kind: 'action',
+      action: { type: 'set-focus', focus: 'list' },
+    })
+    expect(resolveWorkspaceInput('', key({ return: true }), addRepoState()).kind).toBe('noop')
+    expect(resolveWorkspaceInput('', key({ tab: true }), addRepoState()).kind).toBe('noop')
+    expect(resolveWorkspaceInput('a', key(), addRepoState()).kind).toBe('noop')
   })
 })

--- a/src/workstation/surfaces/workspace/input.test.ts
+++ b/src/workstation/surfaces/workspace/input.test.ts
@@ -1,0 +1,109 @@
+import { WorkspaceOverview } from '../../../git/workspaceData'
+
+import { resolveWorkspaceInput, WorkspaceInputKey } from './input'
+import { createWorkspaceState, WorkspaceState } from './state'
+
+function key(overrides: Partial<WorkspaceInputKey> = {}): WorkspaceInputKey {
+  return { ...overrides }
+}
+
+const emptyOverview: WorkspaceOverview = {
+  roots: ['/tmp'],
+  repos: [],
+  scannedAt: '2026-05-26T00:00:00Z',
+}
+
+function listState(filter = ''): WorkspaceState {
+  const base = createWorkspaceState({ overview: emptyOverview, roots: ['~/code'] })
+  return { ...base, filter }
+}
+
+function filterState(): WorkspaceState {
+  return { ...createWorkspaceState({ overview: emptyOverview, roots: ['~/code'] }), focus: 'filter' }
+}
+
+describe('resolveWorkspaceInput', () => {
+  it('quits on q or escape (no filter active)', () => {
+    expect(resolveWorkspaceInput('q', key(), listState()).kind).toBe('quit')
+    expect(resolveWorkspaceInput('', key({ escape: true }), listState()).kind).toBe('quit')
+  })
+
+  it('clears the filter on escape when a filter is set', () => {
+    expect(resolveWorkspaceInput('', key({ escape: true }), listState('foo'))).toEqual({
+      kind: 'action',
+      action: { type: 'clear-filter' },
+    })
+  })
+
+  it('moves the cursor on j/k and arrow keys', () => {
+    expect(resolveWorkspaceInput('j', key(), listState())).toEqual({
+      kind: 'action',
+      action: { type: 'move-cursor', delta: 1 },
+    })
+    expect(resolveWorkspaceInput('', key({ downArrow: true }), listState())).toEqual({
+      kind: 'action',
+      action: { type: 'move-cursor', delta: 1 },
+    })
+    expect(resolveWorkspaceInput('k', key(), listState())).toEqual({
+      kind: 'action',
+      action: { type: 'move-cursor', delta: -1 },
+    })
+    expect(resolveWorkspaceInput('', key({ pageDown: true }), listState())).toEqual({
+      kind: 'action',
+      action: { type: 'move-cursor', delta: 10 },
+    })
+  })
+
+  it('jumps to top with g and bottom with G', () => {
+    expect(resolveWorkspaceInput('g', key(), listState())).toEqual({
+      kind: 'action',
+      action: { type: 'set-cursor', index: 0 },
+    })
+    expect(resolveWorkspaceInput('G', key(), listState())).toEqual({
+      kind: 'action',
+      action: { type: 'set-cursor', index: Number.MAX_SAFE_INTEGER },
+    })
+  })
+
+  it('cycles tabs on tab / shift-tab / h / l', () => {
+    expect(resolveWorkspaceInput('', key({ tab: true }), listState())).toEqual({
+      kind: 'action',
+      action: { type: 'cycle-tab', direction: 'next' },
+    })
+    expect(resolveWorkspaceInput('', key({ tab: true, shift: true }), listState())).toEqual({
+      kind: 'action',
+      action: { type: 'cycle-tab', direction: 'previous' },
+    })
+    expect(resolveWorkspaceInput('h', key(), listState()).kind).toBe('action')
+    expect(resolveWorkspaceInput('l', key(), listState()).kind).toBe('action')
+  })
+
+  it('opens the filter prompt on / and routes drill-in on enter', () => {
+    expect(resolveWorkspaceInput('/', key(), listState())).toEqual({
+      kind: 'action',
+      action: { type: 'set-focus', focus: 'filter' },
+    })
+    expect(resolveWorkspaceInput('', key({ return: true }), listState()).kind).toBe('drill-in')
+  })
+
+  it('cycles sort, refresh, and add-repo intents on their bindings', () => {
+    expect(resolveWorkspaceInput('s', key(), listState())).toEqual({
+      kind: 'action',
+      action: { type: 'cycle-sort' },
+    })
+    expect(resolveWorkspaceInput('r', key(), listState()).kind).toBe('refresh')
+    expect(resolveWorkspaceInput('a', key(), listState()).kind).toBe('add-repo')
+  })
+
+  it('lets escape exit the filter prompt and enter commit it', () => {
+    expect(resolveWorkspaceInput('', key({ escape: true }), filterState())).toEqual({
+      kind: 'action',
+      action: { type: 'clear-filter' },
+    })
+    expect(resolveWorkspaceInput('', key({ return: true }), filterState())).toEqual({
+      kind: 'action',
+      action: { type: 'set-focus', focus: 'list' },
+    })
+    expect(resolveWorkspaceInput('a', key(), filterState()).kind).toBe('noop')
+  })
+})

--- a/src/workstation/surfaces/workspace/input.ts
+++ b/src/workstation/surfaces/workspace/input.ts
@@ -1,0 +1,135 @@
+import type { WorkspaceAction, WorkspaceState } from './state'
+
+/**
+ * Key descriptor for the workspace surface. Mirrors the structural
+ * type from `LogInkInputKey` so we don't pull React/Ink into the pure
+ * input layer — the runtime hands the same shape into both surfaces.
+ */
+export type WorkspaceInputKey = {
+  upArrow?: boolean
+  downArrow?: boolean
+  leftArrow?: boolean
+  rightArrow?: boolean
+  return?: boolean
+  escape?: boolean
+  tab?: boolean
+  shift?: boolean
+  ctrl?: boolean
+  meta?: boolean
+  pageDown?: boolean
+  pageUp?: boolean
+  delete?: boolean
+  backspace?: boolean
+}
+
+export type WorkspaceInputIntent =
+  | { kind: 'action'; action: WorkspaceAction }
+  | { kind: 'quit' }
+  | { kind: 'drill-in' }
+  | { kind: 'refresh' }
+  | { kind: 'add-repo' }
+  | { kind: 'noop' }
+
+/**
+ * Pure key → intent mapping. The runtime decides what to do with the
+ * intent (dispatch an action, exit Ink, kick off a refresh
+ * workflow). Keeps testability tight: the reducer takes actions,
+ * the runtime takes intents, neither one ever needs to mock keypress
+ * machinery.
+ *
+ * Keymap:
+ *   j / ↓             move cursor down
+ *   k / ↑             move cursor up
+ *   g                 jump to top
+ *   G                 jump to bottom
+ *   tab / shift-tab   cycle sidebar tab forward / backward
+ *   s                 cycle sort mode
+ *   /                 enter filter prompt
+ *   esc               clear filter / quit when no filter
+ *   q                 quit
+ *   r                 refresh (rescan roots)
+ *   a                 add-repo prompt (PR4 wires this up)
+ *   enter             drill into the cursored repo (PR3 wires this up)
+ *
+ * The filter-input mode is owned by the runtime (Ink's TextInput-style
+ * shim is hard to model in a pure unit) — when state.focus === 'filter'
+ * this handler returns `noop` for non-escape keys so the runtime can
+ * route them into the prompt. Escape always returns to list focus.
+ */
+export function resolveWorkspaceInput(
+  input: string,
+  key: WorkspaceInputKey,
+  state: WorkspaceState
+): WorkspaceInputIntent {
+  if (state.focus === 'filter') {
+    if (key.escape) {
+      return { kind: 'action', action: { type: 'clear-filter' } }
+    }
+    if (key.return) {
+      return { kind: 'action', action: { type: 'set-focus', focus: 'list' } }
+    }
+    return { kind: 'noop' }
+  }
+
+  if (key.escape) {
+    if (state.filter) {
+      return { kind: 'action', action: { type: 'clear-filter' } }
+    }
+    return { kind: 'quit' }
+  }
+
+  if (input === 'q' && !key.ctrl && !key.meta) {
+    return { kind: 'quit' }
+  }
+
+  if (key.return) {
+    return { kind: 'drill-in' }
+  }
+
+  if (key.downArrow || input === 'j') {
+    return { kind: 'action', action: { type: 'move-cursor', delta: 1 } }
+  }
+  if (key.upArrow || input === 'k') {
+    return { kind: 'action', action: { type: 'move-cursor', delta: -1 } }
+  }
+  if (key.pageDown) {
+    return { kind: 'action', action: { type: 'move-cursor', delta: 10 } }
+  }
+  if (key.pageUp) {
+    return { kind: 'action', action: { type: 'move-cursor', delta: -10 } }
+  }
+  if (input === 'g' && !key.shift) {
+    return { kind: 'action', action: { type: 'set-cursor', index: 0 } }
+  }
+  if (input === 'G' || (input === 'g' && key.shift)) {
+    return { kind: 'action', action: { type: 'set-cursor', index: Number.MAX_SAFE_INTEGER } }
+  }
+
+  if (key.tab) {
+    return {
+      kind: 'action',
+      action: { type: 'cycle-tab', direction: key.shift ? 'previous' : 'next' },
+    }
+  }
+  if (input === 'h' || key.leftArrow) {
+    return { kind: 'action', action: { type: 'cycle-tab', direction: 'previous' } }
+  }
+  if (input === 'l' || key.rightArrow) {
+    return { kind: 'action', action: { type: 'cycle-tab', direction: 'next' } }
+  }
+
+  if (input === 's') {
+    return { kind: 'action', action: { type: 'cycle-sort' } }
+  }
+  if (input === '/') {
+    return { kind: 'action', action: { type: 'set-focus', focus: 'filter' } }
+  }
+  if (input === 'r') {
+    return { kind: 'refresh' }
+  }
+  if (input === 'a') {
+    return { kind: 'add-repo' }
+  }
+
+  return { kind: 'noop' }
+}

--- a/src/workstation/surfaces/workspace/input.ts
+++ b/src/workstation/surfaces/workspace/input.ts
@@ -71,6 +71,15 @@ export function resolveWorkspaceInput(
     return { kind: 'noop' }
   }
 
+  if (state.focus === 'add-repo') {
+    if (key.escape) {
+      return { kind: 'action', action: { type: 'set-focus', focus: 'list' } }
+    }
+    // Enter, Tab, and printable keys are owned by the runtime so it
+    // can drive the path-completion prompt.
+    return { kind: 'noop' }
+  }
+
   if (key.escape) {
     if (state.filter) {
       return { kind: 'action', action: { type: 'clear-filter' } }

--- a/src/workstation/surfaces/workspace/pathCompletion.test.ts
+++ b/src/workstation/surfaces/workspace/pathCompletion.test.ts
@@ -1,0 +1,109 @@
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import {
+  applyTabCompletion,
+  completePath,
+  expandHomePrefix,
+  splitInput,
+} from './pathCompletion'
+
+describe('pathCompletion helpers', () => {
+  it('expands ~ into the home directory', () => {
+    expect(expandHomePrefix('~')).toBe(os.homedir())
+    expect(expandHomePrefix('~/code')).toBe(path.join(os.homedir(), 'code'))
+    expect(expandHomePrefix('/tmp')).toBe('/tmp')
+  })
+
+  it('splits on the last slash; bare names treat home as the parent', () => {
+    expect(splitInput('/tmp/foo/bar')).toEqual({ dir: '/tmp/foo/', prefix: 'bar' })
+    expect(splitInput('/tmp/')).toEqual({ dir: '/tmp/', prefix: '' })
+    expect(splitInput('foo')).toEqual({ dir: os.homedir(), prefix: 'foo' })
+  })
+})
+
+describe('completePath', () => {
+  it('lists directory entries that start with the prefix', () => {
+    const result = completePath('/tmp/co', {
+      readDirectory: () => ['coco', 'docs', 'coffee', 'README'],
+      isDirectory: (entry) => !entry.endsWith('README'),
+    })
+    expect(result.baseDir).toBe('/tmp/')
+    expect(result.prefix).toBe('co')
+    // README filtered out (not a directory), docs filtered out (different prefix)
+    expect(result.completions).toEqual(['coco/', 'coffee/'])
+    expect(result.commonPrefix).toBe('cof'.startsWith('co') ? 'co' : 'co')
+  })
+
+  it('marks git working trees with a trailing star', () => {
+    const result = completePath('/tmp/', {
+      readDirectory: () => ['repo-a', 'repo-b', 'not-a-repo'],
+      isDirectory: () => true,
+      isGitWorkingTree: (entry) => entry.endsWith('repo-a') || entry.endsWith('repo-b'),
+    })
+    expect(result.completions).toEqual(['not-a-repo/', 'repo-a/*', 'repo-b/*'])
+  })
+
+  it('hides dotfiles unless the prefix opts in', () => {
+    const readDirectory = () => ['.hidden', 'visible']
+    const isDirectory = () => true
+    const noDot = completePath('/tmp/', { readDirectory, isDirectory })
+    expect(noDot.completions).toEqual(['visible/'])
+
+    const withDot = completePath('/tmp/.', { readDirectory, isDirectory })
+    expect(withDot.completions).toEqual(['.hidden/'])
+  })
+
+  it('returns no completions on a readdir failure', () => {
+    const result = completePath('/missing/path/x', {
+      readDirectory: () => {
+        throw new Error('ENOENT')
+      },
+      isDirectory: () => false,
+    })
+    expect(result.completions).toEqual([])
+  })
+})
+
+describe('applyTabCompletion', () => {
+  function fakeResult(overrides: {
+    baseDir?: string
+    prefix?: string
+    completions?: string[]
+    commonPrefix?: string
+  } = {}): ReturnType<typeof completePath> {
+    return {
+      baseDir: overrides.baseDir ?? '/tmp/',
+      prefix: overrides.prefix ?? '',
+      completions: overrides.completions ?? [],
+      commonPrefix: overrides.commonPrefix ?? '',
+      isDirectory: false,
+    }
+  }
+
+  it('extends the prefix to the longest common match', () => {
+    expect(
+      applyTabCompletion('/tmp/re', fakeResult({
+        baseDir: '/tmp/',
+        prefix: 're',
+        completions: ['repo-a/', 'repo-b/'],
+        commonPrefix: 'repo-',
+      }))
+    ).toBe('/tmp/repo-')
+  })
+
+  it('commits the only completion when the prefix already equals the common match', () => {
+    expect(
+      applyTabCompletion('/tmp/repo-a', fakeResult({
+        baseDir: '/tmp/',
+        prefix: 'repo-a',
+        completions: ['repo-a/*'],
+        commonPrefix: 'repo-a',
+      }))
+    ).toBe('/tmp/repo-a/')
+  })
+
+  it('is a no-op when there are no completions', () => {
+    expect(applyTabCompletion('/missing/x', fakeResult())).toBe('/missing/x')
+  })
+})

--- a/src/workstation/surfaces/workspace/pathCompletion.ts
+++ b/src/workstation/surfaces/workspace/pathCompletion.ts
@@ -1,0 +1,196 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+/**
+ * Path completion for the workspace add-repo prompt (#880).
+ *
+ * Designed for the workflow "type a path, tab-complete, enter".
+ * The completer:
+ *   - Expands ~ / ~user prefixes
+ *   - Splits the input into a directory + prefix (everything after the
+ *     last slash), lists directory entries with that prefix, and
+ *     returns them sorted
+ *   - Returns the longest common prefix among the completions so the
+ *     runtime can extend the draft on Tab
+ *
+ * Pure-ish — it reads the filesystem, but doesn't mutate anything.
+ * Errors fall back to empty completions so a typo never crashes the
+ * runtime.
+ */
+
+export type PathCompletionResult = {
+  /** Directory that was scanned. */
+  baseDir: string
+  /** The prefix portion of the input (everything after the last slash). */
+  prefix: string
+  /** Matching entries sorted alphabetically; directories tagged with a trailing slash. */
+  completions: string[]
+  /** Longest common prefix shared by every completion (without the directory). */
+  commonPrefix: string
+  /** True if the completer thinks the path itself is already a directory the user could descend into. */
+  isDirectory: boolean
+}
+
+export function expandHomePrefix(input: string): string {
+  if (input === '~') {
+    return os.homedir()
+  }
+  if (input.startsWith('~/')) {
+    return path.join(os.homedir(), input.slice(2))
+  }
+  return input
+}
+
+export function splitInput(input: string): { dir: string; prefix: string } {
+  // No slash at all → treat the user as typing inside the home dir.
+  const expanded = expandHomePrefix(input)
+  if (!expanded) {
+    return { dir: os.homedir(), prefix: '' }
+  }
+
+  const lastSlash = expanded.lastIndexOf('/')
+  if (lastSlash < 0) {
+    return { dir: os.homedir(), prefix: expanded }
+  }
+  const dir = expanded.slice(0, lastSlash + 1) || '/'
+  const prefix = expanded.slice(lastSlash + 1)
+  return { dir, prefix }
+}
+
+function longestCommonPrefix(values: ReadonlyArray<string>): string {
+  if (values.length === 0) {
+    return ''
+  }
+  if (values.length === 1) {
+    return values[0]
+  }
+  let prefix = values[0]
+  for (let i = 1; i < values.length; i++) {
+    const candidate = values[i]
+    let j = 0
+    while (j < prefix.length && j < candidate.length && prefix[j] === candidate[j]) {
+      j++
+    }
+    prefix = prefix.slice(0, j)
+    if (!prefix) {
+      break
+    }
+  }
+  return prefix
+}
+
+export type CompletePathOptions = {
+  /** Override the directory reader (used by tests). */
+  readDirectory?: (dir: string) => string[]
+  /** Override the directory-isness probe (used by tests). */
+  isDirectory?: (entry: string) => boolean
+  /** Override the "is this a working tree" probe — completions ending in a .git directory get a star. */
+  isGitWorkingTree?: (entry: string) => boolean
+  /** Hide files (default true). The workspace only cares about directories. */
+  directoriesOnly?: boolean
+}
+
+const DEFAULT_PRUNE_NAMES: ReadonlySet<string> = new Set(['.git'])
+
+export function completePath(
+  input: string,
+  options: CompletePathOptions = {}
+): PathCompletionResult {
+  const directoriesOnly = options.directoriesOnly ?? true
+  const { dir, prefix } = splitInput(input)
+  const readDirectory =
+    options.readDirectory ??
+    ((target: string) => {
+      try {
+        return fs.readdirSync(target)
+      } catch {
+        return []
+      }
+    })
+  const isDir =
+    options.isDirectory ??
+    ((target: string) => {
+      try {
+        return fs.statSync(target).isDirectory()
+      } catch {
+        return false
+      }
+    })
+  const isWorking =
+    options.isGitWorkingTree ??
+    ((entry: string) => {
+      try {
+        return fs.statSync(path.join(entry, '.git')).isDirectory()
+      } catch {
+        return false
+      }
+    })
+
+  let rawEntries: string[]
+  try {
+    rawEntries = readDirectory(dir)
+  } catch {
+    rawEntries = []
+  }
+
+  const entries = rawEntries.filter((name) => {
+    if (name.startsWith('.') && !prefix.startsWith('.')) {
+      return false
+    }
+    if (DEFAULT_PRUNE_NAMES.has(name)) {
+      return false
+    }
+    if (!name.startsWith(prefix)) {
+      return false
+    }
+    if (directoriesOnly && !isDir(path.join(dir, name))) {
+      return false
+    }
+    return true
+  })
+
+  entries.sort((a, b) => a.localeCompare(b))
+
+  const completions = entries.map((name) => {
+    const full = path.join(dir, name)
+    const trailingSlash = isDir(full) ? '/' : ''
+    const marker = isWorking(full) ? '*' : ''
+    return `${name}${trailingSlash}${marker}`
+  })
+
+  const commonPrefix = longestCommonPrefix(entries)
+  const isDirectoryAtCursor = isDir(expandHomePrefix(input))
+
+  return {
+    baseDir: dir,
+    prefix,
+    completions,
+    commonPrefix,
+    isDirectory: isDirectoryAtCursor,
+  }
+}
+
+/**
+ * Compose the new input after a Tab press. Extends the prefix to the
+ * longest common match. If the prefix already equals the common match
+ * and there's exactly one completion, append it (so a second Tab
+ * commits the entry).
+ */
+export function applyTabCompletion(input: string, result: PathCompletionResult): string {
+  if (result.completions.length === 0) {
+    return input
+  }
+  const desiredPrefix = result.commonPrefix
+  if (desiredPrefix.length > result.prefix.length) {
+    return result.baseDir + desiredPrefix
+  }
+  if (result.completions.length === 1) {
+    const only = result.completions[0]
+    // Strip trailing marker characters added for display (`*`) but
+    // preserve the trailing slash so the user can keep descending.
+    const cleaned = only.replace(/\*$/, '')
+    return result.baseDir + cleaned
+  }
+  return input
+}

--- a/src/workstation/surfaces/workspace/render.test.ts
+++ b/src/workstation/surfaces/workspace/render.test.ts
@@ -126,4 +126,9 @@ describe('workspace render builders', () => {
     const footer = buildWorkspaceFooter(noted)
     expect(footer.status).toBe('Refreshed.')
   })
+
+  it('footer hint flips to the add-repo prompt when add-repo focus is active', () => {
+    const focused = applyWorkspaceAction(state, { type: 'set-focus', focus: 'add-repo' })
+    expect(buildWorkspaceFooter(focused).hint).toContain('tab to complete')
+  })
 })

--- a/src/workstation/surfaces/workspace/render.test.ts
+++ b/src/workstation/surfaces/workspace/render.test.ts
@@ -1,0 +1,129 @@
+import { WorkspaceOverview, WorkspaceRepoSummary } from '../../../git/workspaceData'
+
+import {
+  buildWorkspaceFooter,
+  buildWorkspaceHeader,
+  buildWorkspaceListRows,
+  buildWorkspaceSidebar,
+} from './render'
+import { applyWorkspaceAction, createWorkspaceState } from './state'
+
+function repo(overrides: Partial<WorkspaceRepoSummary>): WorkspaceRepoSummary {
+  return {
+    path: overrides.path ?? `/tmp/${overrides.name ?? 'r'}`,
+    name: overrides.name ?? 'r',
+    branch: overrides.branch ?? 'main',
+    ahead: 0,
+    behind: 0,
+    dirty: 0,
+    ...overrides,
+  }
+}
+
+function overview(repos: WorkspaceRepoSummary[]): WorkspaceOverview {
+  return {
+    roots: ['/home/me/code'],
+    repos,
+    scannedAt: '2026-05-26T12:00:00Z',
+  }
+}
+
+describe('workspace render builders', () => {
+  const state = createWorkspaceState({
+    overview: overview([
+      repo({
+        name: 'coco',
+        branch: 'main',
+        dirty: 2,
+        ahead: 1,
+        behind: 3,
+        lastCommit: { hash: 'abc', date: '2026-05-01T12:00:00Z', subject: 'feat: thing' },
+      }),
+      repo({ name: 'docs', branch: 'feature/x', dirty: 0 }),
+    ]),
+    roots: ['~/code'],
+  })
+
+  it('builds a list row per visible repo with the expected columns', () => {
+    const rows = buildWorkspaceListRows(state)
+    expect(rows.map((row) => row.repo.name)).toEqual(['coco', 'docs'])
+    expect(rows[0].cursor).toBe(true)
+    expect(rows[1].cursor).toBe(false)
+    const [name, branch, status, date, path] = rows[0].columns
+    expect(name.text.startsWith('coco')).toBe(true)
+    expect(branch.text.startsWith('main')).toBe(true)
+    expect(status.text).toContain('●2')
+    expect(status.text).toContain('↑1')
+    expect(status.text).toContain('↓3')
+    expect(date.text.startsWith('2026-05-01')).toBe(true)
+    expect(path.text).toContain('/tmp/coco')
+  })
+
+  it('renders the placeholder · for a clean repo and dims the status cell', () => {
+    const rows = buildWorkspaceListRows(state)
+    const docs = rows[1]
+    expect(docs.columns[2].text.trim()).toBe('·')
+    expect(docs.columns[2].tone).toBe('dim')
+  })
+
+  it('includes pr count in the status cell when gh is authenticated', () => {
+    const next = applyWorkspaceAction(state, {
+      type: 'replace-pull-request-counts',
+      counts: { [state.overview.repos[1].path]: 4 },
+      authenticated: true,
+    })
+    const rows = buildWorkspaceListRows(next)
+    expect(rows[1].columns[2].text).toContain('pr4')
+  })
+
+  it('omits pr tokens when gh is unauthenticated', () => {
+    const next = applyWorkspaceAction(state, {
+      type: 'replace-pull-request-counts',
+      counts: { [state.overview.repos[1].path]: 4 },
+      authenticated: false,
+    })
+    const rows = buildWorkspaceListRows(next)
+    expect(rows[1].columns[2].text).not.toContain('pr4')
+  })
+
+  it('dims the PRs sidebar tab when gh is unauthenticated', () => {
+    const next = applyWorkspaceAction(state, {
+      type: 'replace-pull-request-counts',
+      counts: {},
+      authenticated: false,
+    })
+    const sidebar = buildWorkspaceSidebar(next)
+    const prs = sidebar.find((row) => row.tab === 'pull-requests')!
+    expect(prs.disabled).toBe(true)
+    expect(sidebar.find((row) => row.tab === 'all')!.active).toBe(true)
+  })
+
+  it('marks the active sidebar tab', () => {
+    const next = applyWorkspaceAction(state, { type: 'set-tab', tab: 'dirty' })
+    const sidebar = buildWorkspaceSidebar(next)
+    expect(sidebar.find((row) => row.tab === 'dirty')!.active).toBe(true)
+  })
+
+  it('header reports root list, repo counts and sort label', () => {
+    const next = applyWorkspaceAction(state, { type: 'set-sort', sort: 'name' })
+    const header = buildWorkspaceHeader(next, { appLabel: 'coco workspace' })
+    expect(header.repoCount).toBe(2)
+    expect(header.visibleCount).toBe(2)
+    expect(header.sortLabel).toBe('Name')
+    expect(header.rootsLabel).toBe('~/code')
+    expect(header.appLabel).toBe('coco workspace')
+  })
+
+  it('footer shows filter hint when filter focus is active', () => {
+    const focused = applyWorkspaceAction(state, { type: 'set-focus', focus: 'filter' })
+    const footer = buildWorkspaceFooter(focused)
+    expect(footer.filterMode).toBe(true)
+    expect(footer.hint).toContain('type filter')
+  })
+
+  it('footer shows status when the runtime set one', () => {
+    const noted = applyWorkspaceAction(state, { type: 'set-status', status: 'Refreshed.' })
+    const footer = buildWorkspaceFooter(noted)
+    expect(footer.status).toBe('Refreshed.')
+  })
+})

--- a/src/workstation/surfaces/workspace/render.ts
+++ b/src/workstation/surfaces/workspace/render.ts
@@ -1,0 +1,168 @@
+import type { WorkspaceRepoSummary } from '../../../git/workspaceData'
+import { truncateCells, truncatePathCells } from '../../chrome/text'
+import {
+  workspaceTabLabel,
+  WORKSPACE_TABS,
+  type WorkspaceTab,
+} from './filter'
+import {
+  workspaceSortLabel,
+  type WorkspaceSortMode,
+} from './sort'
+import { selectVisibleRepos, type WorkspaceState } from './state'
+
+/**
+ * Pure render layer for the workspace surface (#880). Each helper
+ * returns a structural model (rows, cells, label/dim flags) rather
+ * than React/Ink elements so the runtime layer can map these models
+ * into `<Text>` nodes and unit tests can assert against plain data.
+ */
+
+export type WorkspaceListColumn = {
+  /** Right-padded text — already truncated to the column width. */
+  text: string
+  /** True for the column that should grow on screen (the name). */
+  primary?: boolean
+  /** Hint for the renderer: `'dim'` for muted, `'warn'` for behind/dirty. */
+  tone?: 'default' | 'dim' | 'warn' | 'ok'
+}
+
+export type WorkspaceListRow = {
+  repo: WorkspaceRepoSummary
+  cursor: boolean
+  columns: WorkspaceListColumn[]
+}
+
+export type WorkspaceSidebarTabRow = {
+  tab: WorkspaceTab
+  label: string
+  active: boolean
+  /** True when this tab is unavailable (e.g. PRs without gh auth). */
+  disabled: boolean
+}
+
+const NAME_WIDTH = 28
+const BRANCH_WIDTH = 22
+const STATUS_WIDTH = 14
+const DATE_WIDTH = 11
+const PATH_WIDTH = 40
+
+function formatStatusCell(repo: WorkspaceRepoSummary, ghAuthenticated?: boolean, prCount?: number): WorkspaceListColumn {
+  const tokens: string[] = []
+  if (repo.dirty > 0) {
+    tokens.push(`●${repo.dirty}`)
+  }
+  if (repo.ahead > 0) {
+    tokens.push(`↑${repo.ahead}`)
+  }
+  if (repo.behind > 0) {
+    tokens.push(`↓${repo.behind}`)
+  }
+  if (ghAuthenticated && typeof prCount === 'number' && prCount > 0) {
+    tokens.push(`pr${prCount}`)
+  }
+  const text = tokens.length === 0 ? '·' : tokens.join(' ')
+  const tone: WorkspaceListColumn['tone'] = repo.behind > 0 || repo.dirty > 0 ? 'warn' : 'dim'
+  return { text: truncateCells(text, STATUS_WIDTH), tone }
+}
+
+function formatDateCell(repo: WorkspaceRepoSummary): WorkspaceListColumn {
+  const date = repo.lastCommit?.date
+  if (!date) {
+    return { text: truncateCells('—', DATE_WIDTH), tone: 'dim' }
+  }
+  // Trim ISO date to YYYY-MM-DD — full precision is noise in the row.
+  return { text: truncateCells(date.slice(0, 10), DATE_WIDTH), tone: 'dim' }
+}
+
+export function buildWorkspaceListRows(state: WorkspaceState): WorkspaceListRow[] {
+  const visible = selectVisibleRepos(state)
+  return visible.map((repo, index) => {
+    const cursor = index === state.selectedIndex
+    const nameTone: WorkspaceListColumn['tone'] = repo.error ? 'warn' : 'default'
+    const name: WorkspaceListColumn = {
+      text: truncateCells(repo.name, NAME_WIDTH),
+      primary: true,
+      tone: nameTone,
+    }
+    const branch: WorkspaceListColumn = {
+      text: truncateCells(repo.branch ?? '—', BRANCH_WIDTH),
+      tone: repo.branch ? 'default' : 'dim',
+    }
+    const status = formatStatusCell(repo, state.ghAuthenticated, state.pullRequestCounts[repo.path])
+    const date = formatDateCell(repo)
+    const path: WorkspaceListColumn = {
+      text: truncatePathCells(repo.path, PATH_WIDTH),
+      tone: 'dim',
+    }
+    return {
+      repo,
+      cursor,
+      columns: [name, branch, status, date, path],
+    }
+  })
+}
+
+export function buildWorkspaceSidebar(state: WorkspaceState): WorkspaceSidebarTabRow[] {
+  return WORKSPACE_TABS.map((tab) => {
+    const disabled = tab === 'pull-requests' && state.ghAuthenticated === false
+    return {
+      tab,
+      label: workspaceTabLabel(tab),
+      active: state.tab === tab,
+      disabled,
+    }
+  })
+}
+
+export type WorkspaceHeaderModel = {
+  appLabel: string
+  scannedAt?: string
+  rootsLabel: string
+  repoCount: number
+  visibleCount: number
+  sortLabel: string
+  loading: boolean
+  filter?: string
+}
+
+export function buildWorkspaceHeader(
+  state: WorkspaceState,
+  options: { appLabel?: string } = {}
+): WorkspaceHeaderModel {
+  return {
+    appLabel: options.appLabel ?? 'coco workspace',
+    scannedAt: state.overview.scannedAt,
+    rootsLabel: state.roots.join(', '),
+    repoCount: state.overview.repos.length,
+    visibleCount: selectVisibleRepos(state).length,
+    sortLabel: workspaceSortLabel(state.sortMode),
+    loading: state.loading,
+    filter: state.filter || undefined,
+  }
+}
+
+export type WorkspaceFooterModel = {
+  hint: string
+  status?: string
+  filterMode: boolean
+}
+
+const LIST_HINT = 'j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · q quit'
+const FILTER_HINT = 'type filter · enter to apply · esc to clear'
+
+export function buildWorkspaceFooter(state: WorkspaceState): WorkspaceFooterModel {
+  return {
+    hint: state.focus === 'filter' ? FILTER_HINT : LIST_HINT,
+    status: state.status,
+    filterMode: state.focus === 'filter',
+  }
+}
+
+export function describeSortModesForLegend(): Record<WorkspaceSortMode, string> {
+  return {
+    recency: 'Most-recent commit first',
+    name: 'Alphabetical',
+    dirty: 'Most working-tree changes first',
+  }
+}

--- a/src/workstation/surfaces/workspace/render.ts
+++ b/src/workstation/surfaces/workspace/render.ts
@@ -150,10 +150,23 @@ export type WorkspaceFooterModel = {
 
 const LIST_HINT = 'j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · q quit'
 const FILTER_HINT = 'type filter · enter to apply · esc to clear'
+const ADD_REPO_HINT = 'type path · tab to complete · enter to add · esc to cancel'
+
+function hintFor(focus: WorkspaceState['focus']): string {
+  switch (focus) {
+    case 'filter':
+      return FILTER_HINT
+    case 'add-repo':
+      return ADD_REPO_HINT
+    case 'list':
+    default:
+      return LIST_HINT
+  }
+}
 
 export function buildWorkspaceFooter(state: WorkspaceState): WorkspaceFooterModel {
   return {
-    hint: state.focus === 'filter' ? FILTER_HINT : LIST_HINT,
+    hint: hintFor(state.focus),
     status: state.status,
     filterMode: state.focus === 'filter',
   }

--- a/src/workstation/surfaces/workspace/runtime.ts
+++ b/src/workstation/surfaces/workspace/runtime.ts
@@ -1,0 +1,416 @@
+/**
+ * Workspace surface runtime (#880). Mounts a standalone Ink app for
+ * the multi-repo workspace view. Independent of the existing log/ui
+ * runtime so it can render before any repository is chosen.
+ *
+ * Boot sequence:
+ *   1. Read disk cache and paint cached rows immediately.
+ *   2. Mount Ink with the cached state (or an empty scan).
+ *   3. Run discovery + per-repo summary in the background; dispatch
+ *      `replace-overview` when fresh data lands.
+ *   4. Fire `gh` PR-count fetch in parallel; dispatch when ready.
+ *
+ * Drill-in and add-repo intents fire callbacks the caller wired in;
+ * the runtime doesn't know how those flows unfold (PR3 + PR4 own
+ * them). For PR2 those callbacks are `undefined` and the intents
+ * just show a footer hint.
+ */
+
+import type * as ReactTypes from 'react'
+
+import {
+  getWorkspaceOverview,
+  type WorkspaceOverview,
+  type WorkspaceRepoSummary,
+} from '../../../git/workspaceData'
+import {
+  getWorkspacePullRequestCounts,
+  type WorkspacePullRequestCounts,
+} from '../../../git/workspacePullRequestData'
+import {
+  canStartLogInkTui,
+  getLogInkRenderOptions,
+} from '../../chrome/terminal'
+import {
+  createLogInkTheme,
+  type LogInkTheme,
+  type LogInkThemeConfig,
+} from '../../chrome/theme'
+import {
+  readCachedWorkspace,
+  writeCachedWorkspace,
+} from '../../chrome/workspaceCache'
+import { installTerminalLifecycle } from '../../chrome/terminalLifecycle'
+
+import { renderWorkspaceApp } from './view'
+import {
+  applyWorkspaceAction,
+  createWorkspaceState,
+  selectFocusedRepo,
+  type WorkspaceAction,
+  type WorkspaceState,
+} from './state'
+import { resolveWorkspaceInput, type WorkspaceInputKey } from './input'
+
+type DynamicImport = <T>(specifier: string) => Promise<T>
+const dynamicImport = new Function('specifier', 'return import(specifier)') as DynamicImport
+
+export type WorkspaceInkRuntime = {
+  ink: {
+    Box: ReactTypes.ComponentType<Record<string, unknown>>
+    Text: ReactTypes.ComponentType<Record<string, unknown>>
+    render: (
+      app: ReactTypes.ReactElement,
+      options: {
+        alternateScreen?: boolean
+        exitOnCtrlC?: boolean
+        patchConsole?: boolean
+        stderr?: NodeJS.WriteStream
+        stdin?: NodeJS.ReadStream
+        stdout?: NodeJS.WriteStream
+      }
+    ) => {
+      waitUntilExit: () => Promise<void>
+      unmount: () => void
+    }
+    useApp: () => { exit: () => void }
+    useInput: (handler: (input: string, key: WorkspaceInputKey) => void) => void
+    useWindowSize: () => { columns: number; rows: number }
+  }
+  React: typeof ReactTypes
+}
+
+export type WorkspaceComponents = Pick<WorkspaceInkRuntime['ink'], 'Box' | 'Text'>
+
+async function loadWorkspaceInkRuntime(): Promise<WorkspaceInkRuntime> {
+  const [ink, React] = await Promise.all([
+    dynamicImport<WorkspaceInkRuntime['ink']>('ink'),
+    dynamicImport<typeof ReactTypes>('react'),
+  ])
+  return { ink, React }
+}
+
+export type WorkspaceStartOptions = {
+  roots: ReadonlyArray<string>
+  knownRepos?: ReadonlyArray<string>
+  maxDepth?: number
+  appLabel?: string
+  theme?: LogInkThemeConfig
+  /**
+   * Test/PR3 seam: invoked when the user presses Enter on a repo
+   * row. Returning a promise pauses workspace input until it
+   * resolves. PR3 fills this in with a launch of the existing ui
+   * runtime for the focused repo; for PR2 it falls back to a footer
+   * status message.
+   */
+  onDrillIn?: (repo: WorkspaceRepoSummary) => Promise<void>
+  /**
+   * Test/PR4 seam: invoked when the user presses `a`. PR4 fills this
+   * in with the fuzzy path prompt.
+   */
+  onAddRepo?: () => Promise<string | undefined>
+  /** Override discovery (used by tests). */
+  loadOverview?: (
+    roots: ReadonlyArray<string>,
+    knownRepos: ReadonlyArray<string>
+  ) => Promise<WorkspaceOverview>
+  /** Override gh PR-count fetch (used by tests + when caller already has data). */
+  loadPullRequestCounts?: (
+    repos: ReadonlyArray<WorkspaceRepoSummary>
+  ) => Promise<WorkspacePullRequestCounts>
+  streams?: {
+    input?: NodeJS.ReadStream
+    output?: NodeJS.WriteStream
+    error?: NodeJS.WriteStream
+  }
+}
+
+const EMPTY_OVERVIEW = (roots: ReadonlyArray<string>): WorkspaceOverview => ({
+  roots: [...roots],
+  repos: [],
+  scannedAt: new Date(0).toISOString(),
+})
+
+export async function startWorkspace(options: WorkspaceStartOptions): Promise<void> {
+  const streams = options.streams ?? {}
+  const input = streams.input ?? process.stdin
+  const output = streams.output ?? process.stdout
+  const error = streams.error ?? process.stderr
+  const knownRepos = options.knownRepos ?? []
+
+  const loadOverview =
+    options.loadOverview ??
+    ((roots: ReadonlyArray<string>, repos: ReadonlyArray<string>) =>
+      getWorkspaceOverview(roots, { knownRepos: repos, maxDepth: options.maxDepth }))
+
+  const loadPullRequestCounts =
+    options.loadPullRequestCounts ??
+    ((repos: ReadonlyArray<WorkspaceRepoSummary>) =>
+      getWorkspacePullRequestCounts(repos.map((entry) => entry.path)))
+
+  const cached = readCachedWorkspace(options.roots) ?? EMPTY_OVERVIEW(options.roots)
+
+  if (!canStartLogInkTui(input, output)) {
+    // Non-TTY snapshot fallback. Print the visible repo list and
+    // exit. Keeps `coco workspace` usable from a pipe / CI.
+    const fresh = await loadOverview(options.roots, knownRepos)
+    writeCachedWorkspace(options.roots, fresh)
+    renderWorkspaceSnapshot(fresh, output)
+    return
+  }
+
+  const runtime = await loadWorkspaceInkRuntime()
+  const { ink, React } = runtime
+  const theme = createLogInkTheme(options.theme)
+
+  const resumeRef: { current: (() => void) | null } = { current: null }
+
+  const app = React.createElement(WorkspaceInkApp, {
+    appLabel: options.appLabel ?? 'coco workspace',
+    initialOverview: cached,
+    roots: options.roots,
+    knownRepos,
+    loadOverview,
+    loadPullRequestCounts,
+    onDrillIn: options.onDrillIn,
+    onAddRepo: options.onAddRepo,
+    ink,
+    React,
+    theme,
+    resumeRef,
+  })
+
+  const instance = ink.render(
+    app,
+    getLogInkRenderOptions({ input, output, error })
+  )
+
+  const lifecycle = installTerminalLifecycle({
+    input,
+    output,
+    instance,
+    onResume: () => resumeRef.current?.(),
+  })
+
+  try {
+    await instance.waitUntilExit()
+  } finally {
+    lifecycle.dispose()
+  }
+}
+
+function renderWorkspaceSnapshot(
+  overview: WorkspaceOverview,
+  output: NodeJS.WriteStream
+): void {
+  if (overview.repos.length === 0) {
+    output.write('No repositories discovered.\n')
+    return
+  }
+  for (const repo of overview.repos) {
+    const tokens: string[] = [repo.name]
+    if (repo.branch) {
+      tokens.push(`(${repo.branch})`)
+    }
+    if (repo.dirty > 0) {
+      tokens.push(`●${repo.dirty}`)
+    }
+    if (repo.ahead > 0) {
+      tokens.push(`↑${repo.ahead}`)
+    }
+    if (repo.behind > 0) {
+      tokens.push(`↓${repo.behind}`)
+    }
+    if (repo.lastCommit) {
+      tokens.push(repo.lastCommit.date.slice(0, 10))
+    }
+    output.write(`${tokens.join('  ')}\n`)
+  }
+}
+
+type WorkspaceInkAppProps = {
+  appLabel: string
+  initialOverview: WorkspaceOverview
+  roots: ReadonlyArray<string>
+  knownRepos: ReadonlyArray<string>
+  loadOverview: (
+    roots: ReadonlyArray<string>,
+    knownRepos: ReadonlyArray<string>
+  ) => Promise<WorkspaceOverview>
+  loadPullRequestCounts: (
+    repos: ReadonlyArray<WorkspaceRepoSummary>
+  ) => Promise<WorkspacePullRequestCounts>
+  onDrillIn?: (repo: WorkspaceRepoSummary) => Promise<void>
+  onAddRepo?: () => Promise<string | undefined>
+  ink: WorkspaceInkRuntime['ink']
+  React: typeof ReactTypes
+  theme: LogInkTheme
+  resumeRef: { current: (() => void) | null }
+}
+
+function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
+  const { React, ink } = props
+  const { useApp, useInput } = ink
+  const { exit } = useApp()
+
+  const [state, setState] = React.useState<WorkspaceState>(() =>
+    createWorkspaceState({
+      overview: props.initialOverview,
+      roots: props.roots,
+      loading: props.initialOverview.repos.length === 0,
+    })
+  )
+
+  const [filterDraft, setFilterDraft] = React.useState<string>('')
+
+  const dispatch = React.useCallback((action: WorkspaceAction) => {
+    setState((prev) => applyWorkspaceAction(prev, action))
+  }, [])
+
+  // Background discovery + PR-count refresh on mount.
+  React.useEffect(() => {
+    let cancelled = false
+    dispatch({ type: 'set-loading', loading: true })
+    void (async () => {
+      try {
+        const overview = await props.loadOverview(props.roots, props.knownRepos)
+        if (cancelled) return
+        writeCachedWorkspace(props.roots, overview)
+        dispatch({ type: 'replace-overview', overview })
+        const pr = await props.loadPullRequestCounts(overview.repos)
+        if (cancelled) return
+        dispatch({
+          type: 'replace-pull-request-counts',
+          counts: pr.counts,
+          authenticated: pr.authenticated,
+        })
+        if (!pr.authenticated) {
+          dispatch({
+            type: 'set-status',
+            status: '`gh` unavailable — PR counts hidden.',
+          })
+        }
+      } catch (err) {
+        if (cancelled) return
+        dispatch({ type: 'set-loading', loading: false })
+        dispatch({
+          type: 'set-status',
+          status: err instanceof Error ? err.message : 'Discovery failed.',
+        })
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+    // Mount-only effect. Refreshes go through the input handler.
+  }, [])
+
+  const refresh = React.useCallback(async () => {
+    dispatch({ type: 'set-loading', loading: true })
+    try {
+      const overview = await props.loadOverview(props.roots, props.knownRepos)
+      writeCachedWorkspace(props.roots, overview)
+      dispatch({ type: 'replace-overview', overview })
+      dispatch({ type: 'set-status', status: `Refreshed ${overview.repos.length} repos.` })
+      const pr = await props.loadPullRequestCounts(overview.repos)
+      dispatch({
+        type: 'replace-pull-request-counts',
+        counts: pr.counts,
+        authenticated: pr.authenticated,
+      })
+    } catch (err) {
+      dispatch({ type: 'set-loading', loading: false })
+      dispatch({
+        type: 'set-status',
+        status: err instanceof Error ? err.message : 'Discovery failed.',
+      })
+    }
+  }, [dispatch, props])
+
+  const drillIn = React.useCallback(async () => {
+    const focused = selectFocusedRepo(state)
+    if (!focused) {
+      return
+    }
+    if (!props.onDrillIn) {
+      dispatch({ type: 'set-status', status: 'Drill-in is wired in PR3.' })
+      return
+    }
+    await props.onDrillIn(focused)
+  }, [dispatch, props, state])
+
+  const addRepo = React.useCallback(async () => {
+    if (!props.onAddRepo) {
+      dispatch({ type: 'set-status', status: 'Add-repo prompt is wired in PR4.' })
+      return
+    }
+    const added = await props.onAddRepo()
+    if (added) {
+      dispatch({ type: 'set-status', status: `Added ${added}.` })
+    }
+  }, [dispatch, props])
+
+  useInput((rawInput: string, key: WorkspaceInputKey) => {
+    if (state.focus === 'filter') {
+      if (key.escape) {
+        setFilterDraft('')
+        dispatch({ type: 'clear-filter' })
+        return
+      }
+      if (key.return) {
+        dispatch({ type: 'set-filter', filter: filterDraft })
+        dispatch({ type: 'set-focus', focus: 'list' })
+        return
+      }
+      if (key.backspace || key.delete) {
+        setFilterDraft((prev) => prev.slice(0, -1))
+        return
+      }
+      if (rawInput && !key.ctrl && !key.meta) {
+        setFilterDraft((prev) => prev + rawInput)
+      }
+      return
+    }
+
+    const intent = resolveWorkspaceInput(rawInput, key, state)
+    switch (intent.kind) {
+      case 'action':
+        dispatch(intent.action)
+        break
+      case 'quit':
+        exit()
+        break
+      case 'drill-in':
+        void drillIn()
+        break
+      case 'refresh':
+        void refresh()
+        break
+      case 'add-repo':
+        void addRepo()
+        break
+      case 'noop':
+      default:
+        break
+    }
+  })
+
+  React.useEffect(() => {
+    props.resumeRef.current = () => {
+      // Force a no-op state update on SIGCONT so the screen repaints.
+      setState((prev) => ({ ...prev }))
+    }
+    return () => {
+      props.resumeRef.current = null
+    }
+  }, [props.resumeRef])
+
+  return renderWorkspaceApp({
+    React,
+    ink,
+    state,
+    theme: props.theme,
+    appLabel: props.appLabel,
+    filterDraft,
+  })
+}

--- a/src/workstation/surfaces/workspace/runtime.ts
+++ b/src/workstation/surfaces/workspace/runtime.ts
@@ -51,6 +51,17 @@ import {
   type WorkspaceState,
 } from './state'
 import { resolveWorkspaceInput, type WorkspaceInputKey } from './input'
+import {
+  applyTabCompletion,
+  completePath,
+  expandHomePrefix,
+  type PathCompletionResult,
+} from './pathCompletion'
+import {
+  appendKnownRepo,
+  readKnownRepos,
+} from '../../chrome/workspaceKnownRepos'
+import { isGitWorkingTree } from '../../../git/workspaceData'
 
 type DynamicImport = <T>(specifier: string) => Promise<T>
 const dynamicImport = new Function('specifier', 'return import(specifier)') as DynamicImport
@@ -150,6 +161,13 @@ const EMPTY_OVERVIEW = (roots: ReadonlyArray<string>): WorkspaceOverview => ({
   scannedAt: new Date(0).toISOString(),
 })
 
+export function mergeKnownRepos(
+  configEntries: ReadonlyArray<string>,
+  cachedEntries: ReadonlyArray<string>
+): string[] {
+  return [...new Set([...configEntries, ...cachedEntries])]
+}
+
 export async function startWorkspace(
   options: WorkspaceStartOptions
 ): Promise<WorkspaceExitResult> {
@@ -157,7 +175,7 @@ export async function startWorkspace(
   const input = streams.input ?? process.stdin
   const output = streams.output ?? process.stdout
   const error = streams.error ?? process.stderr
-  const knownRepos = options.knownRepos ?? []
+  const knownRepos = mergeKnownRepos(options.knownRepos ?? [], readKnownRepos())
 
   const loadOverview =
     options.loadOverview ??
@@ -291,6 +309,10 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
   )
 
   const [filterDraft, setFilterDraft] = React.useState<string>('')
+  const [addRepoDraft, setAddRepoDraft] = React.useState<string>('~/')
+  const [addRepoCompletion, setAddRepoCompletion] = React.useState<PathCompletionResult>(() =>
+    completePath('~/')
+  )
 
   const dispatch = React.useCallback((action: WorkspaceAction) => {
     setState((prev) => applyWorkspaceAction(prev, action))
@@ -377,16 +399,42 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
     exit()
   }, [exit, props.exitRef, state])
 
-  const addRepo = React.useCallback(async () => {
-    if (!props.onAddRepo) {
-      dispatch({ type: 'set-status', status: 'Add-repo prompt is wired in PR4.' })
+  const openAddRepo = React.useCallback(() => {
+    setAddRepoDraft('~/')
+    setAddRepoCompletion(completePath('~/'))
+    dispatch({ type: 'set-focus', focus: 'add-repo' })
+  }, [dispatch])
+
+  const commitAddRepo = React.useCallback(async () => {
+    const candidate = expandHomePrefix(addRepoDraft.trim().replace(/\/+$/, ''))
+    if (!candidate) {
+      dispatch({ type: 'set-status', status: 'Enter a path.' })
       return
     }
-    const added = await props.onAddRepo()
-    if (added) {
-      dispatch({ type: 'set-status', status: `Added ${added}.` })
+    if (!isGitWorkingTree(candidate)) {
+      dispatch({ type: 'set-status', status: `${candidate} is not a git repo.` })
+      return
     }
-  }, [dispatch, props])
+    appendKnownRepo(candidate)
+    dispatch({ type: 'set-focus', focus: 'list' })
+    dispatch({ type: 'set-status', status: `Added ${candidate}.` })
+    // Refresh discovery so the new repo lands in the list and the
+    // cursor anchors onto it.
+    dispatch({ type: 'set-loading', loading: true })
+    try {
+      const merged = mergeKnownRepos(props.knownRepos, readKnownRepos())
+      const overview = await props.loadOverview(props.roots, merged)
+      writeCachedWorkspace(props.roots, overview)
+      dispatch({ type: 'replace-overview', overview })
+      dispatch({ type: 'anchor-cursor-by-path', path: candidate })
+    } catch (err) {
+      dispatch({ type: 'set-loading', loading: false })
+      dispatch({
+        type: 'set-status',
+        status: err instanceof Error ? err.message : 'Refresh failed.',
+      })
+    }
+  }, [addRepoDraft, dispatch, props])
 
   useInput((rawInput: string, key: WorkspaceInputKey) => {
     if (state.focus === 'filter') {
@@ -410,6 +458,35 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
       return
     }
 
+    if (state.focus === 'add-repo') {
+      if (key.escape) {
+        dispatch({ type: 'set-focus', focus: 'list' })
+        return
+      }
+      if (key.return) {
+        void commitAddRepo()
+        return
+      }
+      if (key.tab) {
+        const next = applyTabCompletion(addRepoDraft, addRepoCompletion)
+        setAddRepoDraft(next)
+        setAddRepoCompletion(completePath(next))
+        return
+      }
+      if (key.backspace || key.delete) {
+        const next = addRepoDraft.slice(0, -1)
+        setAddRepoDraft(next)
+        setAddRepoCompletion(completePath(next || '~/'))
+        return
+      }
+      if (rawInput && !key.ctrl && !key.meta) {
+        const next = addRepoDraft + rawInput
+        setAddRepoDraft(next)
+        setAddRepoCompletion(completePath(next))
+      }
+      return
+    }
+
     const intent = resolveWorkspaceInput(rawInput, key, state)
     switch (intent.kind) {
       case 'action':
@@ -426,7 +503,7 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
         void refresh()
         break
       case 'add-repo':
-        void addRepo()
+        openAddRepo()
         break
       case 'noop':
       default:
@@ -451,5 +528,7 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
     theme: props.theme,
     appLabel: props.appLabel,
     filterDraft,
+    addRepoDraft,
+    addRepoCompletion,
   })
 }

--- a/src/workstation/surfaces/workspace/runtime.ts
+++ b/src/workstation/surfaces/workspace/runtime.ts
@@ -90,6 +90,27 @@ async function loadWorkspaceInkRuntime(): Promise<WorkspaceInkRuntime> {
   return { ink, React }
 }
 
+export type WorkspaceExitResult =
+  | { kind: 'quit' }
+  | {
+      kind: 'drill-in'
+      repo: WorkspaceRepoSummary
+      /** Last-rendered surface state — passed back when the caller relaunches workspace after the drill-in. */
+      resume: {
+        sortMode: WorkspaceState['sortMode']
+        tab: WorkspaceState['tab']
+        filter: WorkspaceState['filter']
+        selectedRepoPath: string
+      }
+    }
+
+export type WorkspaceResumeState = {
+  sortMode?: WorkspaceState['sortMode']
+  tab?: WorkspaceState['tab']
+  filter?: WorkspaceState['filter']
+  selectedRepoPath?: string
+}
+
 export type WorkspaceStartOptions = {
   roots: ReadonlyArray<string>
   knownRepos?: ReadonlyArray<string>
@@ -97,13 +118,11 @@ export type WorkspaceStartOptions = {
   appLabel?: string
   theme?: LogInkThemeConfig
   /**
-   * Test/PR3 seam: invoked when the user presses Enter on a repo
-   * row. Returning a promise pauses workspace input until it
-   * resolves. PR3 fills this in with a launch of the existing ui
-   * runtime for the focused repo; for PR2 it falls back to a footer
-   * status message.
+   * Optional resume seed — applied to the new state on mount.
+   * Lets the drill-in loop re-anchor the cursor on the repo the
+   * user just exited and preserve their sort / tab / filter.
    */
-  onDrillIn?: (repo: WorkspaceRepoSummary) => Promise<void>
+  resume?: WorkspaceResumeState
   /**
    * Test/PR4 seam: invoked when the user presses `a`. PR4 fills this
    * in with the fuzzy path prompt.
@@ -131,7 +150,9 @@ const EMPTY_OVERVIEW = (roots: ReadonlyArray<string>): WorkspaceOverview => ({
   scannedAt: new Date(0).toISOString(),
 })
 
-export async function startWorkspace(options: WorkspaceStartOptions): Promise<void> {
+export async function startWorkspace(
+  options: WorkspaceStartOptions
+): Promise<WorkspaceExitResult> {
   const streams = options.streams ?? {}
   const input = streams.input ?? process.stdin
   const output = streams.output ?? process.stdout
@@ -156,7 +177,7 @@ export async function startWorkspace(options: WorkspaceStartOptions): Promise<vo
     const fresh = await loadOverview(options.roots, knownRepos)
     writeCachedWorkspace(options.roots, fresh)
     renderWorkspaceSnapshot(fresh, output)
-    return
+    return { kind: 'quit' }
   }
 
   const runtime = await loadWorkspaceInkRuntime()
@@ -164,6 +185,7 @@ export async function startWorkspace(options: WorkspaceStartOptions): Promise<vo
   const theme = createLogInkTheme(options.theme)
 
   const resumeRef: { current: (() => void) | null } = { current: null }
+  const exitRef: { current: WorkspaceExitResult } = { current: { kind: 'quit' } }
 
   const app = React.createElement(WorkspaceInkApp, {
     appLabel: options.appLabel ?? 'coco workspace',
@@ -172,8 +194,9 @@ export async function startWorkspace(options: WorkspaceStartOptions): Promise<vo
     knownRepos,
     loadOverview,
     loadPullRequestCounts,
-    onDrillIn: options.onDrillIn,
     onAddRepo: options.onAddRepo,
+    resume: options.resume,
+    exitRef,
     ink,
     React,
     theme,
@@ -197,6 +220,7 @@ export async function startWorkspace(options: WorkspaceStartOptions): Promise<vo
   } finally {
     lifecycle.dispose()
   }
+  return exitRef.current
 }
 
 function renderWorkspaceSnapshot(
@@ -240,8 +264,9 @@ type WorkspaceInkAppProps = {
   loadPullRequestCounts: (
     repos: ReadonlyArray<WorkspaceRepoSummary>
   ) => Promise<WorkspacePullRequestCounts>
-  onDrillIn?: (repo: WorkspaceRepoSummary) => Promise<void>
   onAddRepo?: () => Promise<string | undefined>
+  resume?: WorkspaceResumeState
+  exitRef: { current: WorkspaceExitResult }
   ink: WorkspaceInkRuntime['ink']
   React: typeof ReactTypes
   theme: LogInkTheme
@@ -258,6 +283,10 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
       overview: props.initialOverview,
       roots: props.roots,
       loading: props.initialOverview.repos.length === 0,
+      sortMode: props.resume?.sortMode,
+      tab: props.resume?.tab,
+      filter: props.resume?.filter,
+      selectedRepoPath: props.resume?.selectedRepoPath,
     })
   )
 
@@ -277,6 +306,9 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
         if (cancelled) return
         writeCachedWorkspace(props.roots, overview)
         dispatch({ type: 'replace-overview', overview })
+        if (props.resume?.selectedRepoPath) {
+          dispatch({ type: 'anchor-cursor-by-path', path: props.resume.selectedRepoPath })
+        }
         const pr = await props.loadPullRequestCounts(overview.repos)
         if (cancelled) return
         dispatch({
@@ -327,17 +359,23 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
     }
   }, [dispatch, props])
 
-  const drillIn = React.useCallback(async () => {
+  const drillIn = React.useCallback(() => {
     const focused = selectFocusedRepo(state)
     if (!focused) {
       return
     }
-    if (!props.onDrillIn) {
-      dispatch({ type: 'set-status', status: 'Drill-in is wired in PR3.' })
-      return
+    props.exitRef.current = {
+      kind: 'drill-in',
+      repo: focused,
+      resume: {
+        sortMode: state.sortMode,
+        tab: state.tab,
+        filter: state.filter,
+        selectedRepoPath: focused.path,
+      },
     }
-    await props.onDrillIn(focused)
-  }, [dispatch, props, state])
+    exit()
+  }, [exit, props.exitRef, state])
 
   const addRepo = React.useCallback(async () => {
     if (!props.onAddRepo) {
@@ -378,10 +416,11 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
         dispatch(intent.action)
         break
       case 'quit':
+        props.exitRef.current = { kind: 'quit' }
         exit()
         break
       case 'drill-in':
-        void drillIn()
+        drillIn()
         break
       case 'refresh':
         void refresh()

--- a/src/workstation/surfaces/workspace/sort.test.ts
+++ b/src/workstation/surfaces/workspace/sort.test.ts
@@ -1,0 +1,92 @@
+import { WorkspaceRepoSummary } from '../../../git/workspaceData'
+
+import {
+  nextWorkspaceSortMode,
+  sortWorkspaceRepos,
+  workspaceSortLabel,
+  WORKSPACE_SORT_MODES,
+  type WorkspaceSortMode,
+} from './sort'
+
+function repo(overrides: Partial<WorkspaceRepoSummary>): WorkspaceRepoSummary {
+  return {
+    path: `/tmp/${overrides.name ?? 'r'}`,
+    name: overrides.name ?? 'r',
+    branch: 'main',
+    ahead: 0,
+    behind: 0,
+    dirty: 0,
+    ...overrides,
+  }
+}
+
+describe('workspace sort', () => {
+  it('cycles through the sort modes in a stable order', () => {
+    let mode: WorkspaceSortMode = WORKSPACE_SORT_MODES[0]
+    const seen: string[] = []
+    for (let i = 0; i < WORKSPACE_SORT_MODES.length + 1; i++) {
+      seen.push(mode)
+      mode = nextWorkspaceSortMode(mode)
+    }
+    expect(seen).toEqual(['recency', 'name', 'dirty', 'recency'])
+  })
+
+  it('labels each mode with a one-word display string', () => {
+    expect(workspaceSortLabel('recency')).toBe('Recent')
+    expect(workspaceSortLabel('name')).toBe('Name')
+    expect(workspaceSortLabel('dirty')).toBe('Dirty')
+  })
+
+  it('sorts by name alphabetically', () => {
+    const out = sortWorkspaceRepos(
+      [repo({ name: 'gamma' }), repo({ name: 'alpha' }), repo({ name: 'beta' })],
+      'name'
+    )
+    expect(out.map((entry) => entry.name)).toEqual(['alpha', 'beta', 'gamma'])
+  })
+
+  it('sorts by recency with newer first; ties fall back to name', () => {
+    const out = sortWorkspaceRepos(
+      [
+        repo({ name: 'old', lastCommit: { hash: 'a', date: '2024-01-01', subject: 'x' } }),
+        repo({ name: 'newer', lastCommit: { hash: 'b', date: '2026-01-01', subject: 'x' } }),
+        repo({ name: 'same-a', lastCommit: { hash: 'c', date: '2025-06-01', subject: 'x' } }),
+        repo({ name: 'same-b', lastCommit: { hash: 'd', date: '2025-06-01', subject: 'x' } }),
+        repo({ name: 'no-commit' }),
+      ],
+      'recency'
+    )
+    expect(out.map((entry) => entry.name)).toEqual([
+      'newer',
+      'same-a',
+      'same-b',
+      'old',
+      'no-commit',
+    ])
+  })
+
+  it('sorts by dirty count desc with recency tiebreaker', () => {
+    const out = sortWorkspaceRepos(
+      [
+        repo({ name: 'clean', dirty: 0 }),
+        repo({ name: 'a-bit-dirty', dirty: 2, lastCommit: { hash: 'a', date: '2025-01-01', subject: 'x' } }),
+        repo({ name: 'very-dirty', dirty: 8, lastCommit: { hash: 'b', date: '2025-01-01', subject: 'x' } }),
+        repo({ name: 'also-dirty', dirty: 2, lastCommit: { hash: 'c', date: '2026-01-01', subject: 'x' } }),
+      ],
+      'dirty'
+    )
+    expect(out.map((entry) => entry.name)).toEqual([
+      'very-dirty',
+      'also-dirty',
+      'a-bit-dirty',
+      'clean',
+    ])
+  })
+
+  it('does not mutate its input', () => {
+    const input = [repo({ name: 'b' }), repo({ name: 'a' })]
+    const snapshot = input.map((entry) => entry.name)
+    sortWorkspaceRepos(input, 'name')
+    expect(input.map((entry) => entry.name)).toEqual(snapshot)
+  })
+})

--- a/src/workstation/surfaces/workspace/sort.ts
+++ b/src/workstation/surfaces/workspace/sort.ts
@@ -1,0 +1,72 @@
+import type { WorkspaceRepoSummary } from '../../../git/workspaceData'
+
+/**
+ * Sort modes for the workspace surface (#880). Cycle order is
+ * intentional: most users want recency first ("which repos have I
+ * touched recently"), name second ("alphabetical for memory"),
+ * dirty third ("what needs commits before EOD"). Each subsequent tap
+ * of the sort key advances along this cycle.
+ */
+export const WORKSPACE_SORT_MODES = ['recency', 'name', 'dirty'] as const
+
+export type WorkspaceSortMode = (typeof WORKSPACE_SORT_MODES)[number]
+
+const SORT_LABELS: Record<WorkspaceSortMode, string> = {
+  recency: 'Recent',
+  name: 'Name',
+  dirty: 'Dirty',
+}
+
+export function nextWorkspaceSortMode(current: WorkspaceSortMode): WorkspaceSortMode {
+  const idx = WORKSPACE_SORT_MODES.indexOf(current)
+  return WORKSPACE_SORT_MODES[(idx + 1) % WORKSPACE_SORT_MODES.length]
+}
+
+export function workspaceSortLabel(mode: WorkspaceSortMode): string {
+  return SORT_LABELS[mode]
+}
+
+function nameComparator(a: WorkspaceRepoSummary, b: WorkspaceRepoSummary): number {
+  return a.name.localeCompare(b.name)
+}
+
+function recencyComparator(a: WorkspaceRepoSummary, b: WorkspaceRepoSummary): number {
+  const aDate = a.lastCommit?.date ?? ''
+  const bDate = b.lastCommit?.date ?? ''
+  // Newer first — string compare on ISO-8601 dates is correct ordering.
+  if (aDate === bDate) {
+    return nameComparator(a, b)
+  }
+  return aDate < bDate ? 1 : -1
+}
+
+function dirtyComparator(a: WorkspaceRepoSummary, b: WorkspaceRepoSummary): number {
+  if (a.dirty === b.dirty) {
+    return recencyComparator(a, b)
+  }
+  return b.dirty - a.dirty
+}
+
+/**
+ * Stable sort: never mutates the input. The caller passes the array
+ * straight from state, the reducer slices into the result.
+ */
+export function sortWorkspaceRepos(
+  repos: ReadonlyArray<WorkspaceRepoSummary>,
+  mode: WorkspaceSortMode
+): WorkspaceRepoSummary[] {
+  const copy = [...repos]
+  switch (mode) {
+    case 'name':
+      copy.sort(nameComparator)
+      break
+    case 'dirty':
+      copy.sort(dirtyComparator)
+      break
+    case 'recency':
+    default:
+      copy.sort(recencyComparator)
+      break
+  }
+  return copy
+}

--- a/src/workstation/surfaces/workspace/state.test.ts
+++ b/src/workstation/surfaces/workspace/state.test.ts
@@ -120,4 +120,38 @@ describe('workspace state reducer', () => {
     const status = applyWorkspaceAction(loading, { type: 'set-status', status: 'Refreshed.' })
     expect(status.status).toBe('Refreshed.')
   })
+
+  it('seeds the cursor onto the matching repo when selectedRepoPath is provided', () => {
+    const seeded = createWorkspaceState({
+      overview: baseState.overview,
+      roots: ['~/code'],
+      selectedRepoPath: '/tmp/bravo',
+    })
+    expect(seeded.selectedIndex).toBe(1)
+  })
+
+  it('falls back to index 0 when the seed path does not exist in the visible list', () => {
+    const seeded = createWorkspaceState({
+      overview: baseState.overview,
+      roots: ['~/code'],
+      selectedRepoPath: '/tmp/zzz-not-found',
+    })
+    expect(seeded.selectedIndex).toBe(0)
+  })
+
+  it('anchor-cursor-by-path moves the cursor to the matching repo', () => {
+    const anchored = applyWorkspaceAction(baseState, {
+      type: 'anchor-cursor-by-path',
+      path: '/tmp/charlie',
+    })
+    expect(anchored.selectedIndex).toBe(2)
+  })
+
+  it('anchor-cursor-by-path is a no-op when the path is unknown', () => {
+    const anchored = applyWorkspaceAction(baseState, {
+      type: 'anchor-cursor-by-path',
+      path: '/tmp/not-there',
+    })
+    expect(anchored.selectedIndex).toBe(baseState.selectedIndex)
+  })
 })

--- a/src/workstation/surfaces/workspace/state.test.ts
+++ b/src/workstation/surfaces/workspace/state.test.ts
@@ -1,0 +1,123 @@
+import { WorkspaceOverview, WorkspaceRepoSummary } from '../../../git/workspaceData'
+
+import {
+  applyWorkspaceAction,
+  createWorkspaceState,
+  selectFocusedRepo,
+  selectVisibleRepos,
+} from './state'
+
+function repo(overrides: Partial<WorkspaceRepoSummary>): WorkspaceRepoSummary {
+  return {
+    path: `/tmp/${overrides.name ?? 'r'}`,
+    name: overrides.name ?? 'r',
+    branch: overrides.branch ?? 'main',
+    ahead: 0,
+    behind: 0,
+    dirty: 0,
+    ...overrides,
+  }
+}
+
+function overview(repos: WorkspaceRepoSummary[]): WorkspaceOverview {
+  return {
+    roots: ['/home/me/code'],
+    repos,
+    scannedAt: '2026-05-26T12:00:00Z',
+  }
+}
+
+describe('workspace state reducer', () => {
+  const baseState = createWorkspaceState({
+    overview: overview([
+      repo({ name: 'alpha', dirty: 0, lastCommit: { hash: 'a', date: '2026-05-01', subject: 'x' } }),
+      repo({ name: 'bravo', dirty: 3, lastCommit: { hash: 'b', date: '2026-04-15', subject: 'x' } }),
+      repo({ name: 'charlie', dirty: 1, lastCommit: { hash: 'c', date: '2026-04-01', subject: 'x' } }),
+    ]),
+    roots: ['~/code'],
+  })
+
+  it('defaults to recency sort and the all tab', () => {
+    const visible = selectVisibleRepos(baseState)
+    expect(visible.map((entry) => entry.name)).toEqual(['alpha', 'bravo', 'charlie'])
+    expect(baseState.sortMode).toBe('recency')
+    expect(baseState.tab).toBe('all')
+  })
+
+  it('cycles the sort mode and resets the cursor', () => {
+    const moved = applyWorkspaceAction(baseState, { type: 'move-cursor', delta: 2 })
+    expect(moved.selectedIndex).toBe(2)
+    const sorted = applyWorkspaceAction(moved, { type: 'cycle-sort' })
+    expect(sorted.sortMode).toBe('name')
+    expect(sorted.selectedIndex).toBe(0)
+  })
+
+  it('clamps the cursor when the visible list shrinks under a filter', () => {
+    const cursored = applyWorkspaceAction(
+      applyWorkspaceAction(baseState, { type: 'move-cursor', delta: 5 }),
+      { type: 'set-filter', filter: 'bra' }
+    )
+    expect(selectVisibleRepos(cursored).map((entry) => entry.name)).toEqual(['bravo'])
+    expect(cursored.selectedIndex).toBe(0)
+  })
+
+  it('cycles tabs forward and backward', () => {
+    const next = applyWorkspaceAction(baseState, { type: 'cycle-tab', direction: 'next' })
+    expect(next.tab).toBe('dirty')
+    const prev = applyWorkspaceAction(baseState, { type: 'cycle-tab', direction: 'previous' })
+    expect(prev.tab).toBe('pull-requests')
+  })
+
+  it('hides repos with no open PRs when the pull-requests tab is active', () => {
+    const withCounts = applyWorkspaceAction(baseState, {
+      type: 'replace-pull-request-counts',
+      counts: { '/tmp/bravo': 2 },
+      authenticated: true,
+    })
+    const onTab = applyWorkspaceAction(withCounts, { type: 'set-tab', tab: 'pull-requests' })
+    expect(selectVisibleRepos(onTab).map((entry) => entry.name)).toEqual(['bravo'])
+    expect(onTab.ghAuthenticated).toBe(true)
+  })
+
+  it('records gh authentication failures so the renderer can dim the PRs tab', () => {
+    const failed = applyWorkspaceAction(baseState, {
+      type: 'replace-pull-request-counts',
+      counts: {},
+      authenticated: false,
+    })
+    expect(failed.ghAuthenticated).toBe(false)
+  })
+
+  it('replace-overview rectifies the cursor without dropping the sort mode', () => {
+    const sortedByDirty = applyWorkspaceAction(baseState, { type: 'set-sort', sort: 'dirty' })
+    const movedToEnd = applyWorkspaceAction(sortedByDirty, { type: 'move-cursor', delta: 2 })
+    const refreshed = applyWorkspaceAction(movedToEnd, {
+      type: 'replace-overview',
+      overview: overview([repo({ name: 'solo', dirty: 7 })]),
+    })
+    expect(refreshed.sortMode).toBe('dirty')
+    expect(refreshed.selectedIndex).toBe(0)
+    expect(refreshed.loading).toBe(false)
+  })
+
+  it('selectFocusedRepo returns the row under the cursor', () => {
+    const moved = applyWorkspaceAction(baseState, { type: 'move-cursor', delta: 1 })
+    expect(selectFocusedRepo(moved)?.name).toBe('bravo')
+  })
+
+  it('clear-filter drops the query, resets focus, and zero-cursors', () => {
+    const filtered = applyWorkspaceAction(baseState, { type: 'set-filter', filter: 'bra' })
+    const cleared = applyWorkspaceAction(filtered, { type: 'clear-filter' })
+    expect(cleared.filter).toBe('')
+    expect(cleared.focus).toBe('list')
+    expect(cleared.selectedIndex).toBe(0)
+  })
+
+  it('records loading + status updates without touching other fields', () => {
+    const loading = applyWorkspaceAction(baseState, { type: 'set-loading', loading: true })
+    expect(loading.loading).toBe(true)
+    expect(loading.overview).toBe(baseState.overview)
+    const status = applyWorkspaceAction(loading, { type: 'set-status', status: 'Refreshed.' })
+    expect(status.status).toBe('Refreshed.')
+  })
+})

--- a/src/workstation/surfaces/workspace/state.ts
+++ b/src/workstation/surfaces/workspace/state.ts
@@ -23,7 +23,7 @@ import {
  * dispatches them on action payloads.
  */
 
-export type WorkspaceFocus = 'list' | 'filter'
+export type WorkspaceFocus = 'list' | 'filter' | 'add-repo'
 
 export type WorkspaceState = {
   overview: WorkspaceOverview

--- a/src/workstation/surfaces/workspace/state.ts
+++ b/src/workstation/surfaces/workspace/state.ts
@@ -60,6 +60,7 @@ export type WorkspaceState = {
 
 export type WorkspaceAction =
   | { type: 'replace-overview'; overview: WorkspaceOverview }
+  | { type: 'anchor-cursor-by-path'; path: string }
   | { type: 'replace-pull-request-counts'; counts: Readonly<Record<string, number>>; authenticated: boolean }
   | { type: 'set-sort'; sort: WorkspaceSortMode }
   | { type: 'cycle-sort' }
@@ -78,22 +79,38 @@ export type WorkspaceStateInit = {
   roots: ReadonlyArray<string>
   sortMode?: WorkspaceSortMode
   tab?: WorkspaceTab
+  filter?: string
   pullRequestCounts?: Readonly<Record<string, number>>
   loading?: boolean
+  /**
+   * When set, the constructor seeds the cursor onto the row whose
+   * repo path matches. Used by the drill-in loop (#880 PR3) so the
+   * cursor lands back on the repo the user just exited.
+   */
+  selectedRepoPath?: string
 }
 
 export function createWorkspaceState(init: WorkspaceStateInit): WorkspaceState {
-  return {
+  const base: WorkspaceState = {
     overview: init.overview,
     pullRequestCounts: init.pullRequestCounts ?? {},
     sortMode: init.sortMode ?? 'recency',
     tab: init.tab ?? 'all',
-    filter: '',
+    filter: init.filter ?? '',
     focus: 'list',
     selectedIndex: 0,
     loading: Boolean(init.loading),
     roots: init.roots,
   }
+  if (!init.selectedRepoPath) {
+    return base
+  }
+  const visible = selectVisibleRepos(base)
+  const idx = visible.findIndex((entry) => entry.path === init.selectedRepoPath)
+  if (idx < 0) {
+    return base
+  }
+  return { ...base, selectedIndex: idx }
 }
 
 /**
@@ -145,6 +162,14 @@ export function applyWorkspaceAction(
         overview: action.overview,
         loading: false,
       })
+    }
+    case 'anchor-cursor-by-path': {
+      const visible = selectVisibleRepos(state)
+      const idx = visible.findIndex((entry) => entry.path === action.path)
+      if (idx < 0) {
+        return state
+      }
+      return { ...state, selectedIndex: idx }
     }
     case 'replace-pull-request-counts': {
       return rectifySelection({

--- a/src/workstation/surfaces/workspace/state.ts
+++ b/src/workstation/surfaces/workspace/state.ts
@@ -1,0 +1,210 @@
+import type {
+  WorkspaceOverview,
+  WorkspaceRepoSummary,
+} from '../../../git/workspaceData'
+import {
+  filterWorkspaceRepos,
+  matchesWorkspaceText,
+  nextWorkspaceTab,
+  previousWorkspaceTab,
+  type WorkspaceTab,
+} from './filter'
+import {
+  nextWorkspaceSortMode,
+  sortWorkspaceRepos,
+  type WorkspaceSortMode,
+} from './sort'
+
+/**
+ * Workspace surface state + reducer (#880). Mirrors the
+ * `applyLogInkAction` discipline from the existing TUI: pure,
+ * side-effect-free, no fs/git access, no `Date.now()`. The reducer is
+ * the only place state changes; the runtime sources timestamps and
+ * dispatches them on action payloads.
+ */
+
+export type WorkspaceFocus = 'list' | 'filter'
+
+export type WorkspaceState = {
+  overview: WorkspaceOverview
+  /** Open-PR counts keyed by repo path. Empty when gh is unavailable. */
+  pullRequestCounts: Readonly<Record<string, number>>
+  sortMode: WorkspaceSortMode
+  tab: WorkspaceTab
+  /** Free-text filter applied on top of the sidebar tab. */
+  filter: string
+  focus: WorkspaceFocus
+  /** Cursor index into the visible (sorted + filtered) list. */
+  selectedIndex: number
+  /** Background-refresh in flight. */
+  loading: boolean
+  /**
+   * Status banner copy. The runtime sets this from workflow outcomes
+   * (refresh complete, gh missing, etc.); the renderer surfaces it
+   * in the footer.
+   */
+  status?: string
+  /**
+   * gh CLI authentication state. `undefined` = not yet probed,
+   * `true` = available, `false` = missing/unauthenticated. The
+   * "PRs" tab dims itself when this resolves to `false`.
+   */
+  ghAuthenticated?: boolean
+  /**
+   * Roots the workspace surface was launched against. Stored on
+   * state so the footer can render a `roots: ~/code, ~/work` chip
+   * without the renderer reaching back into the runtime closure.
+   */
+  roots: ReadonlyArray<string>
+}
+
+export type WorkspaceAction =
+  | { type: 'replace-overview'; overview: WorkspaceOverview }
+  | { type: 'replace-pull-request-counts'; counts: Readonly<Record<string, number>>; authenticated: boolean }
+  | { type: 'set-sort'; sort: WorkspaceSortMode }
+  | { type: 'cycle-sort' }
+  | { type: 'set-tab'; tab: WorkspaceTab }
+  | { type: 'cycle-tab'; direction: 'next' | 'previous' }
+  | { type: 'set-filter'; filter: string }
+  | { type: 'clear-filter' }
+  | { type: 'set-focus'; focus: WorkspaceFocus }
+  | { type: 'move-cursor'; delta: number }
+  | { type: 'set-cursor'; index: number }
+  | { type: 'set-loading'; loading: boolean }
+  | { type: 'set-status'; status?: string }
+
+export type WorkspaceStateInit = {
+  overview: WorkspaceOverview
+  roots: ReadonlyArray<string>
+  sortMode?: WorkspaceSortMode
+  tab?: WorkspaceTab
+  pullRequestCounts?: Readonly<Record<string, number>>
+  loading?: boolean
+}
+
+export function createWorkspaceState(init: WorkspaceStateInit): WorkspaceState {
+  return {
+    overview: init.overview,
+    pullRequestCounts: init.pullRequestCounts ?? {},
+    sortMode: init.sortMode ?? 'recency',
+    tab: init.tab ?? 'all',
+    filter: '',
+    focus: 'list',
+    selectedIndex: 0,
+    loading: Boolean(init.loading),
+    roots: init.roots,
+  }
+}
+
+/**
+ * Recompute the visible repo list — sort → tab filter → text filter.
+ * The renderer consumes this; the reducer also uses it to rectify the
+ * cursor after a filter/sort change so the selection stays in range.
+ */
+export function selectVisibleRepos(state: WorkspaceState): WorkspaceRepoSummary[] {
+  const sorted = sortWorkspaceRepos(state.overview.repos, state.sortMode)
+  const tabFiltered = filterWorkspaceRepos(sorted, state.tab, {
+    pullRequestCounts: state.pullRequestCounts,
+  })
+  if (!state.filter) {
+    return tabFiltered
+  }
+  return tabFiltered.filter((entry) => matchesWorkspaceText(entry, state.filter))
+}
+
+function clampCursor(index: number, length: number): number {
+  if (length <= 0) {
+    return 0
+  }
+  if (index < 0) {
+    return 0
+  }
+  if (index >= length) {
+    return length - 1
+  }
+  return index
+}
+
+function rectifySelection(state: WorkspaceState): WorkspaceState {
+  const visible = selectVisibleRepos(state)
+  const clamped = clampCursor(state.selectedIndex, visible.length)
+  if (clamped === state.selectedIndex) {
+    return state
+  }
+  return { ...state, selectedIndex: clamped }
+}
+
+export function applyWorkspaceAction(
+  state: WorkspaceState,
+  action: WorkspaceAction
+): WorkspaceState {
+  switch (action.type) {
+    case 'replace-overview': {
+      return rectifySelection({
+        ...state,
+        overview: action.overview,
+        loading: false,
+      })
+    }
+    case 'replace-pull-request-counts': {
+      return rectifySelection({
+        ...state,
+        pullRequestCounts: action.counts,
+        ghAuthenticated: action.authenticated,
+      })
+    }
+    case 'set-sort': {
+      return rectifySelection({ ...state, sortMode: action.sort, selectedIndex: 0 })
+    }
+    case 'cycle-sort': {
+      return rectifySelection({
+        ...state,
+        sortMode: nextWorkspaceSortMode(state.sortMode),
+        selectedIndex: 0,
+      })
+    }
+    case 'set-tab': {
+      return rectifySelection({ ...state, tab: action.tab, selectedIndex: 0 })
+    }
+    case 'cycle-tab': {
+      const tab =
+        action.direction === 'next'
+          ? nextWorkspaceTab(state.tab)
+          : previousWorkspaceTab(state.tab)
+      return rectifySelection({ ...state, tab, selectedIndex: 0 })
+    }
+    case 'set-filter': {
+      return rectifySelection({ ...state, filter: action.filter, selectedIndex: 0 })
+    }
+    case 'clear-filter': {
+      return rectifySelection({ ...state, filter: '', focus: 'list', selectedIndex: 0 })
+    }
+    case 'set-focus': {
+      return { ...state, focus: action.focus }
+    }
+    case 'move-cursor': {
+      const visible = selectVisibleRepos(state)
+      return {
+        ...state,
+        selectedIndex: clampCursor(state.selectedIndex + action.delta, visible.length),
+      }
+    }
+    case 'set-cursor': {
+      const visible = selectVisibleRepos(state)
+      return { ...state, selectedIndex: clampCursor(action.index, visible.length) }
+    }
+    case 'set-loading': {
+      return { ...state, loading: action.loading }
+    }
+    case 'set-status': {
+      return { ...state, status: action.status }
+    }
+    default:
+      return state
+  }
+}
+
+export function selectFocusedRepo(state: WorkspaceState): WorkspaceRepoSummary | undefined {
+  const visible = selectVisibleRepos(state)
+  return visible[state.selectedIndex]
+}

--- a/src/workstation/surfaces/workspace/view.ts
+++ b/src/workstation/surfaces/workspace/view.ts
@@ -1,0 +1,224 @@
+/**
+ * React/Ink view layer for the workspace surface (#880).
+ *
+ * Translates the pure `render.ts` models into `<Text>` / `<Box>`
+ * elements. Kept in its own module so `runtime.ts` doesn't carry
+ * Ink-shaped JSX details and the pure model layer never imports
+ * React.
+ */
+
+import type * as ReactTypes from 'react'
+
+import type { LogInkTheme } from '../../chrome/theme'
+import { truncateCells } from '../../chrome/text'
+import { focusBorderColor, panelTitle } from '../../runtime/utils'
+
+import type { WorkspaceComponents, WorkspaceInkRuntime } from './runtime'
+import {
+  buildWorkspaceFooter,
+  buildWorkspaceHeader,
+  buildWorkspaceListRows,
+  buildWorkspaceSidebar,
+  type WorkspaceListColumn,
+} from './render'
+import { selectVisibleRepos, type WorkspaceState } from './state'
+
+type RenderWorkspaceAppDeps = {
+  React: typeof ReactTypes
+  ink: WorkspaceInkRuntime['ink']
+  state: WorkspaceState
+  theme: LogInkTheme
+  appLabel: string
+  filterDraft: string
+}
+
+function toneColor(tone: WorkspaceListColumn['tone'], theme: LogInkTheme): string | undefined {
+  if (theme.noColor) {
+    return undefined
+  }
+  switch (tone) {
+    case 'warn':
+      return theme.colors.warning
+    case 'ok':
+      return theme.colors.success
+    case 'dim':
+      return theme.colors.muted
+    case 'default':
+    default:
+      return undefined
+  }
+}
+
+function renderHeader(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement {
+  const { React, ink, state, theme, appLabel } = deps
+  const { Box, Text } = ink
+  const model = buildWorkspaceHeader(state, { appLabel })
+  const left = `${model.appLabel}  roots: ${model.rootsLabel || '—'}`
+  const right = [
+    `${model.visibleCount}/${model.repoCount} repos`,
+    `sort: ${model.sortLabel}`,
+    model.loading ? 'refreshing…' : '',
+  ]
+    .filter(Boolean)
+    .join('  ·  ')
+  return React.createElement(
+    Box,
+    { borderColor: focusBorderColor(theme, true), borderStyle: theme.borderStyle, paddingX: 1, justifyContent: 'space-between' },
+    React.createElement(Text, { bold: true }, left),
+    React.createElement(Text, { dimColor: true }, right)
+  )
+}
+
+function renderSidebar(
+  deps: RenderWorkspaceAppDeps
+): ReactTypes.ReactElement {
+  const { React, ink, state, theme } = deps
+  const { Box, Text } = ink
+  const focused = state.focus === 'list'
+  const tabs = buildWorkspaceSidebar(state)
+  const rows = tabs.map((row) => {
+    const props: Record<string, unknown> = { key: row.tab }
+    if (row.active) {
+      props.bold = true
+    } else if (row.disabled) {
+      props.dimColor = true
+    }
+    const cursor = row.active ? '›' : ' '
+    return React.createElement(Text, props, `${cursor} ${row.label}`)
+  })
+  return React.createElement(
+    Box,
+    {
+      borderColor: focusBorderColor(theme, focused),
+      borderStyle: theme.borderStyle,
+      flexDirection: 'column',
+      flexShrink: 0,
+      paddingX: 1,
+      width: 18,
+    },
+    React.createElement(Text, { bold: true }, panelTitle('Tabs', focused)),
+    ...rows
+  )
+}
+
+function renderListRow(
+  deps: RenderWorkspaceAppDeps,
+  row: ReturnType<typeof buildWorkspaceListRows>[number],
+  key: string,
+  width: number
+): ReactTypes.ReactElement {
+  const { React, ink, theme } = deps
+  const { Box, Text } = ink
+  const cursor = row.cursor ? '›' : ' '
+  const cells = row.columns.map((column, index) =>
+    React.createElement(
+      Box,
+      { key: index, marginRight: 1 },
+      React.createElement(
+        Text,
+        {
+          bold: row.cursor && column.primary,
+          dimColor: !row.cursor && column.tone === 'dim',
+          color: toneColor(column.tone, theme),
+        },
+        column.text
+      )
+    )
+  )
+  return React.createElement(
+    Box,
+    { key, flexDirection: 'row' },
+    React.createElement(Text, { bold: row.cursor }, `${cursor} `),
+    React.createElement(Box, { flexDirection: 'row', flexShrink: 1, flexWrap: 'wrap' }, ...cells),
+    React.createElement(Box, { flexShrink: 0 }, React.createElement(Text, { dimColor: true }, truncateCells('', Math.max(0, width)))) // reserve trailing space
+  )
+}
+
+function renderListBody(
+  deps: RenderWorkspaceAppDeps,
+  width: number
+): ReactTypes.ReactElement {
+  const { React, ink, state, theme } = deps
+  const { Box, Text } = ink
+  const focused = state.focus !== 'filter'
+  const rows = buildWorkspaceListRows(state)
+  const visibleRepos = selectVisibleRepos(state)
+  const filterChip = state.filter
+    ? `  ·  filter: ${state.filter}`
+    : state.focus === 'filter'
+      ? `  ·  filter: ${deps.filterDraft}_`
+      : ''
+  const headerRight = state.loading
+    ? 'loading repos…'
+    : `${visibleRepos.length} visible${filterChip}`
+  const lines: ReactTypes.ReactNode[] = rows.length === 0
+    ? [
+      React.createElement(
+        Text,
+        { dimColor: true, key: 'empty' },
+        state.loading
+          ? 'Scanning configured roots…'
+          : state.overview.repos.length === 0
+            ? 'No repositories discovered. Configure workspace.roots and try again.'
+            : 'No repos match the current filter.'
+      ),
+    ]
+    : rows.map((row, index) => renderListRow(deps, row, `row-${index}`, width))
+  return React.createElement(
+    Box,
+    {
+      borderColor: focusBorderColor(theme, focused),
+      borderStyle: theme.borderStyle,
+      flexDirection: 'column',
+      flexGrow: 1,
+      paddingX: 1,
+    },
+    React.createElement(
+      Box,
+      { justifyContent: 'space-between' },
+      React.createElement(Text, { bold: true }, panelTitle('Workspace', focused)),
+      React.createElement(Text, { dimColor: true }, headerRight)
+    ),
+    ...lines
+  )
+}
+
+function renderFooter(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement {
+  const { React, ink, state, theme } = deps
+  const { Box, Text } = ink
+  const model = buildWorkspaceFooter(state)
+  return React.createElement(
+    Box,
+    {
+      borderColor: focusBorderColor(theme, false),
+      borderStyle: theme.borderStyle,
+      paddingX: 1,
+      flexDirection: 'column',
+    },
+    React.createElement(Text, { dimColor: true }, model.hint),
+    model.status
+      ? React.createElement(Text, { color: toneColor('warn', theme) }, model.status)
+      : null
+  )
+}
+
+export function renderWorkspaceApp(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement {
+  const { React, ink } = deps
+  const { Box } = ink
+  const { columns } = ink.useWindowSize()
+  const bodyWidth = Math.max(40, columns - 4)
+  return React.createElement(
+    Box,
+    { flexDirection: 'column' },
+    renderHeader(deps),
+    React.createElement(
+      Box,
+      { flexDirection: 'row' },
+      renderSidebar(deps),
+      renderListBody(deps, bodyWidth - 22)
+    ),
+    renderFooter(deps)
+  )
+}
+
+export type { WorkspaceComponents }

--- a/src/workstation/surfaces/workspace/view.ts
+++ b/src/workstation/surfaces/workspace/view.ts
@@ -14,6 +14,7 @@ import { truncateCells } from '../../chrome/text'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
 
 import type { WorkspaceComponents, WorkspaceInkRuntime } from './runtime'
+import { type PathCompletionResult } from './pathCompletion'
 import {
   buildWorkspaceFooter,
   buildWorkspaceHeader,
@@ -30,6 +31,8 @@ type RenderWorkspaceAppDeps = {
   theme: LogInkTheme
   appLabel: string
   filterDraft: string
+  addRepoDraft: string
+  addRepoCompletion: PathCompletionResult
 }
 
 function toneColor(tone: WorkspaceListColumn['tone'], theme: LogInkTheme): string | undefined {
@@ -183,6 +186,35 @@ function renderListBody(
   )
 }
 
+function renderAddRepoPrompt(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement | null {
+  if (deps.state.focus !== 'add-repo') {
+    return null
+  }
+  const { React, ink, theme, addRepoDraft, addRepoCompletion } = deps
+  const { Box, Text } = ink
+  const completionLine = addRepoCompletion.completions.slice(0, 8).join('  ')
+  const hint =
+    addRepoCompletion.completions.length === 0
+      ? 'no matches'
+      : `${addRepoCompletion.completions.length} match${
+        addRepoCompletion.completions.length === 1 ? '' : 'es'
+      } · tab to extend · * = git repo`
+  return React.createElement(
+    Box,
+    {
+      borderColor: focusBorderColor(theme, true),
+      borderStyle: theme.borderStyle,
+      flexDirection: 'column',
+      paddingX: 1,
+    },
+    React.createElement(Text, { bold: true }, `Add repo: ${addRepoDraft}_`),
+    React.createElement(Text, { dimColor: true }, hint),
+    completionLine
+      ? React.createElement(Text, { color: toneColor('dim', theme) }, completionLine)
+      : null
+  )
+}
+
 function renderFooter(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement {
   const { React, ink, state, theme } = deps
   const { Box, Text } = ink
@@ -217,6 +249,7 @@ export function renderWorkspaceApp(deps: RenderWorkspaceAppDeps): ReactTypes.Rea
       renderSidebar(deps),
       renderListBody(deps, bodyWidth - 22)
     ),
+    renderAddRepoPrompt(deps),
     renderFooter(deps)
   )
 }


### PR DESCRIPTION
Closes #880.

Opt-in `coco workspace` / `coco ws` command that lists every git repo under your configured roots, lets you cycle sort modes and filter tabs, drill into one as a normal `coco ui` session, and add new repos on the fly with a tab-completing path prompt. `coco ui` stays single-repo — this is a separate verb so v1's blast radius is small.

## Summary

- **Discovery + data layer**: walks `workspace.roots` (default `~/code`), identifies git working trees (regular `.git` dirs, worktree pointer files, submodules), prunes node_modules / build dirs, captures branch / ahead / behind / dirty count / last commit per repo, with per-repo errors caught so one unhealthy repo never poisons the surface. Open-PR counts come from `gh` when available and degrade gracefully when not.
- **Workspace TUI**: pure state reducer + sort + filter + input layers + structural render models, mounted by an Ink runtime that mirrors the existing `coco ui` boot sequence (paint disk cache → mount Ink → refresh in background). Sort modes (recency / name / dirty), sidebar tabs (All / Dirty / Behind / PRs), text filter, persistent disk cache.
- **Drill-in & return**: `Enter` on a repo hands off to `startCocoUiFromLogArgv` scoped to that path; when `coco ui` exits, the workspace re-mounts with the cursor back on the repo just exited and the user's sort / tab / filter preserved. The loop body is extracted into `runWorkspaceLoop` so it's unit-tested without mounting real Ink.
- **Add-repo prompt**: `a` opens an inline path prompt seeded at `~/`. Tab extends to the longest common prefix; a single match commits and opens the directory. Matching git working trees are marked with `*`. Validated entries persist to a per-user `known-repos.json` store (separate from the user's config so we don't write into something they may be version-controlling) and refresh fires immediately, anchoring the cursor onto the new repo.

Resolves the open questions from #880:
- Default landing: stays opt-in via `coco workspace`; `coco ui` unchanged.
- Cross-repo workflows: out of scope for v1.
- Monorepos: treated as a single entry (root-level `.git` short-circuits descent).

## Commits

The branch is 11 logical commits — each one type-checks, lints, and full-suite-tests on its own:

1. `discovery + per-repo summary data layer`
2. `pure state, sort, and filter layers`
3. `structural render models + input intents`
4. `Ink runtime and view module`
5. `add \`coco workspace\`/\`coco ws\` command`
6. `cursor anchoring by repo path`
7. `expose drill-in exit reason + resume seed`
8. `drill-in loop that hands off to \`coco ui\``
9. `pure path completion for the add-repo prompt`
10. `per-user known-repos store separate from config`
11. `add-repo prompt with tab-complete + live refresh`

## Test plan

- [x] 80+ new unit tests across surface (state / sort / filter / render / input / runtime loop / path completion), data (`getWorkspaceOverview` / `getRepoSummary` / `getWorkspacePullRequestCounts`), and persistence layers
- [x] Lint + typecheck clean
- [x] Full Jest suite (`--runInBand`) — 182 suites, 2305 passing, 7 skipped
- [x] Smoke CLI gets a `coco workspace --help` assertion
- [ ] Manual: configure `workspace.roots: ['~/code']`, run `coco workspace`, cursor through repos, drill into one with Enter, return with q
- [ ] Manual: press `a`, tab through `~/`, add a non-config repo, confirm it appears
- [ ] Manual: with `gh` logged out, confirm the PRs tab dims itself and the status row doesn't show pr counts