### PR TITLE
chore(security): tune DevSkim to filter test files and false-positive rules

### DIFF
--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -27,6 +27,62 @@ jobs:
 
       - name: Run DevSkim scanner
         uses: microsoft/DevSkim-Action@v1
+        with:
+          # Skip globs that produce noise instead of signal:
+          #
+          #   - **/*.test.ts / **/__fixtures__/** / **/__snapshots__/**
+          #     Test fixtures contain fake tokens, localhost URLs,
+          #     setTimeout patterns, and SHA hashes by design. Flagging
+          #     them as security issues drowns the real signal.
+          #
+          #   - schema.json / src/lib/schema.ts
+          #     Generated JSON Schema document with `http://json-schema.org/...`
+          #     `$id` references — those aren't insecure URLs to fetch,
+          #     they're schema identifiers per spec.
+          #
+          #   - **/__tree_sitter__/** (manifest.ts + download.test.ts)
+          #     The "tokens" DevSkim flags here are SHA-256 integrity
+          #     hashes verifying the wasm files we download. That's a
+          #     security feature, not a leaked secret.
+          #
+          #   - dist/, coverage/, .bench/, .wiki/, .www/
+          #     Build outputs and vendored content shouldn't trigger
+          #     scans against the source tree.
+          ignore-globs: >-
+            **/.git/**,**/bin/**,**/node_modules/**,**/dist/**,**/coverage/**,**/.bench/**,**/.wiki/**,**/.www/**,**/.claude/**,**/*.test.ts,**/__fixtures__/**,**/__snapshots__/**,**/__tree_sitter__/**,schema.json,src/lib/schema.ts
+          # Exclude rules that produce only false positives in this
+          # codebase:
+          #
+          #   - DS162092 (DoNotLeaveDebugCodeInProduction): flags any
+          #     `localhost` reference. The doctor command's network
+          #     probe legitimately checks localhost; everything else
+          #     is in test files we already filtered.
+          #
+          #   - DS172411 (ReviewSettimeoutForUntrustedData): flags any
+          #     `setTimeout(...)` regardless of arguments. We use it
+          #     with literal numeric delays for the idle-tip cycle and
+          #     refresh debounce. No untrusted data ever reaches it.
+          #
+          #   - DS176209 (SuspiciousComment): flags TODO/FIXME/HACK in
+          #     comments. We intentionally use TODOs to mark followup
+          #     work — they're a feature, not a vulnerability.
+          #
+          #   - DS126858 (WeakbrokenHashAlgorithm): flags any sha1 use.
+          #     Every sha1 in this codebase is a non-security cache-key
+          #     derivation (overview cache, sidebar persistence, diff
+          #     view-mode marker, github list cache). No PII or auth
+          #     context is hashed and no collision-resistance against
+          #     an adversary is required. Inline `DevSkim: ignore`
+          #     comments are inconsistently honored, so we exclude the
+          #     rule globally. Re-enable if real crypto is introduced.
+          #
+          #   - DS173237 (DoNotStoreTokensOrKeysInSourceCode): all
+          #     surviving instances after the test-file glob filter
+          #     are SHA-256 integrity hashes for verifying tree-sitter
+          #     wasm downloads — a security feature, not a leaked
+          #     secret. The tree-sitter manifest globs catch these
+          #     too; rule exclusion is belt-and-suspenders.
+          exclude-rules: DS126858,DS162092,DS172411,DS173237,DS176209
 
       - name: Upload DevSkim scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3

--- a/src/git/historyActions.ts
+++ b/src/git/historyActions.ts
@@ -229,6 +229,12 @@ function normalizeRemoteUrl(remoteUrl: string): string | undefined {
     return `https://${sshMatch[1]}/${sshMatch[2]}`
   }
 
+  // Match the remote URL exactly as the user has configured it in
+  // git — including legacy http:// remotes still in use on some
+  // self-hosted GitHub Enterprise / GitLab installations. We only
+  // pass the URL through; coco never fetches it. Upgrading the user's
+  // remote to https isn't our call. DevSkim DS137138 doesn't apply.
+  // DevSkim: ignore DS137138
   if (trimmed.startsWith('https://') || trimmed.startsWith('http://')) {
     return trimmed
   }


### PR DESCRIPTION
Tunes DevSkim configuration to eliminate false-positive noise in code scanning alerts. Sibling to the audit-followup work in #1039.

## Context

GitHub code scanning surfaced 66 open alerts on the repo. Triage showed:
- **3 CodeQL alerts** (genuine pattern matches, all false positives in context)
- **63 DevSkim alerts** (heuristic noise, almost entirely in test fixtures and idiomatic Node patterns)

Of the 63 DevSkim alerts, the vast majority were:
- fake tokens / localhost URLs / setTimeout patterns in `*.test.ts`
- SHA-256 integrity hashes in tree-sitter manifest
- `http://` references in JSON Schema `$id` URLs
- sha1 used for cache keys (non-security)

## Changes

**`.github/workflows/devskim.yml`** — adds `ignore-globs` and `exclude-rules` to the DevSkim action:

`ignore-globs` (filters by file path):
- `**/*.test.ts`, `**/__fixtures__/**`, `**/__snapshots__/**` — test scaffolding
- `**/__tree_sitter__/**` — wasm integrity hashes
- `schema.json`, `src/lib/schema.ts` — JSON Schema `$id`s, not insecure URLs
- `dist/`, `coverage/`, `.bench/`, `.wiki/`, `.www/`, `.claude/` — build outputs and vendored content

`exclude-rules` (filters by rule ID):
- `DS126858` (weak hash) — every sha1 in repo is non-security cache derivation
- `DS162092` (localhost) — `doctor` command legitimately probes localhost
- `DS172411` (setTimeout) — only used with literal numeric delays
- `DS173237` (tokens) — post-filter remainder are wasm hashes
- `DS176209` (suspicious comment) — TODOs are a feature

**`src/git/historyActions.ts`** — adds an inline `DevSkim: ignore DS137138` to `normalizeRemoteUrl`, which parses the user's existing git remote URL including legacy `http://` remotes on self-hosted installations. coco never fetches the URL.

## After this lands

Expected: DevSkim drops from 63 open alerts to 0.

The 3 CodeQL alerts (`js/double-escaping` and 2× `js/incomplete-url-substring-sanitization`) need separate dismissal in the security UI — they're real pattern matches that need a human "yeah, it's fine" with reasoning. Both are documented in the audit notes.

## Verified

- `npm run lint` clean
- DevSkim workflow YAML structure preserved (still uses `microsoft/DevSkim-Action@v1` + `github/codeql-action/upload-sarif@v3`)
