### PR TITLE
feat(workspace): keymap help overlay + first-run onboarding

### DIFF
--- a/src/workstation/chrome/workspaceOnboarding.test.ts
+++ b/src/workstation/chrome/workspaceOnboarding.test.ts
@@ -1,0 +1,47 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import {
+  getWorkspaceOnboardingMarkerPath,
+  hasSeenWorkspaceOnboarding,
+  markWorkspaceOnboardingSeen,
+} from './workspaceOnboarding'
+
+describe('workspaceOnboarding', () => {
+  let tmpHome: string
+  let originalXdg: string | undefined
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-ws-onboarding-'))
+    originalXdg = process.env.XDG_CACHE_HOME
+    process.env.XDG_CACHE_HOME = tmpHome
+  })
+
+  afterEach(() => {
+    if (originalXdg === undefined) {
+      delete process.env.XDG_CACHE_HOME
+    } else {
+      process.env.XDG_CACHE_HOME = originalXdg
+    }
+    fs.rmSync(tmpHome, { recursive: true, force: true })
+  })
+
+  it('reports unseen until the marker is written', () => {
+    expect(hasSeenWorkspaceOnboarding()).toBe(false)
+    markWorkspaceOnboardingSeen()
+    expect(hasSeenWorkspaceOnboarding()).toBe(true)
+    expect(fs.existsSync(getWorkspaceOnboardingMarkerPath())).toBe(true)
+  })
+
+  it('uses a distinct marker filename so the ui surface stays independent', () => {
+    expect(getWorkspaceOnboardingMarkerPath()).toMatch(/workspace-onboarding\.seen$/)
+  })
+
+  it('swallows write failures silently', () => {
+    const blocker = path.join(tmpHome, 'blocker')
+    fs.writeFileSync(blocker, '')
+    process.env.XDG_CACHE_HOME = blocker
+    expect(() => markWorkspaceOnboardingSeen()).not.toThrow()
+  })
+})

--- a/src/workstation/chrome/workspaceOnboarding.ts
+++ b/src/workstation/chrome/workspaceOnboarding.ts
@@ -1,0 +1,46 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+/**
+ * First-run onboarding marker for the workspace surface (#880
+ * follow-up). Sibling of `chrome/onboarding.ts` — kept separate so
+ * dismissing the workspace's first-run hint doesn't suppress the
+ * existing `coco ui` overlay (and vice versa).
+ *
+ * Best-effort persistence: read/write failures fall back to "already
+ * seen" so we never block boot or pester the user on a write-only
+ * filesystem.
+ */
+
+const MARKER_BASENAME = 'workspace-onboarding.seen'
+
+function resolveCacheDir(): string {
+  const xdg = process.env.XDG_CACHE_HOME
+  if (xdg && xdg.trim().length > 0) {
+    return path.join(xdg, 'coco')
+  }
+  return path.join(os.homedir(), '.cache', 'coco')
+}
+
+export function getWorkspaceOnboardingMarkerPath(): string {
+  return path.join(resolveCacheDir(), MARKER_BASENAME)
+}
+
+export function hasSeenWorkspaceOnboarding(): boolean {
+  try {
+    return fs.existsSync(getWorkspaceOnboardingMarkerPath())
+  } catch {
+    return true
+  }
+}
+
+export function markWorkspaceOnboardingSeen(): void {
+  const markerPath = getWorkspaceOnboardingMarkerPath()
+  try {
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true })
+    fs.writeFileSync(markerPath, '')
+  } catch {
+    // Best-effort persistence; swallow.
+  }
+}

--- a/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
+++ b/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
@@ -2473,6 +2473,546 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
 </Box>
 `;
 
+exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
+<Box
+  flexDirection="column"
+>
+  <Box
+    borderColor="cyan"
+    borderStyle="classic"
+    justifyContent="space-between"
+    paddingX={1}
+  >
+    <Text
+      bold={true}
+    >
+      coco workspace  roots: ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+      3/3 repos  ·  sort: Recent
+    </Text>
+  </Box>
+  <Box
+    flexDirection="row"
+  >
+    <Box
+      borderColor="cyan"
+      borderStyle="classic"
+      flexDirection="column"
+      flexShrink={0}
+      paddingX={1}
+      width={18}
+    >
+      <Text
+        bold={true}
+      >
+        Tabs *
+      </Text>
+      <Text
+        bold={true}
+      >
+        › All
+      </Text>
+      <Text>
+          Dirty
+      </Text>
+      <Text>
+          Behind
+      </Text>
+      <Text>
+          PRs
+      </Text>
+    </Box>
+    <Box
+      borderColor="cyan"
+      borderStyle="classic"
+      flexDirection="column"
+      flexGrow={1}
+      paddingX={1}
+    >
+      <Box
+        justifyContent="space-between"
+      >
+        <Text
+          bold={true}
+        >
+          Workspace *
+        </Text>
+        <Text
+          dimColor={true}
+        >
+          3 visible
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text
+          bold={true}
+        >
+          › 
+        </Text>
+        <Box
+          flexDirection="row"
+          flexShrink={1}
+          flexWrap="wrap"
+        >
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={true}
+              dimColor={false}
+            >
+              coco
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              dimColor={false}
+            >
+              main
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              color="yellow"
+              dimColor={false}
+            >
+              ●2 ↑1
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              color="gray"
+              dimColor={false}
+            >
+              2026-05-01
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              color="gray"
+              dimColor={false}
+            >
+              /tmp/coco
+            </Text>
+          </Box>
+        </Box>
+        <Box
+          flexShrink={0}
+        >
+          <Text
+            dimColor={true}
+          />
+        </Box>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text
+          bold={false}
+        >
+            
+        </Text>
+        <Box
+          flexDirection="row"
+          flexShrink={1}
+          flexWrap="wrap"
+        >
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              docs
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              feature/landing
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="yellow"
+              dimColor={false}
+            >
+              ↓3
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              2026-04-15
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              /tmp/docs
+            </Text>
+          </Box>
+        </Box>
+        <Box
+          flexShrink={0}
+        >
+          <Text
+            dimColor={true}
+          />
+        </Box>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text
+          bold={false}
+        >
+            
+        </Text>
+        <Box
+          flexDirection="row"
+          flexShrink={1}
+          flexWrap="wrap"
+        >
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              lib
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              main
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              ·
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              —
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              /tmp/lib
+            </Text>
+          </Box>
+        </Box>
+        <Box
+          flexShrink={0}
+        >
+          <Text
+            dimColor={true}
+          />
+        </Box>
+      </Box>
+    </Box>
+  </Box>
+  <Box
+    borderColor="cyan"
+    borderStyle="classic"
+    flexDirection="column"
+    paddingX={1}
+  >
+    <Text
+      bold={true}
+    >
+      Welcome to \`coco workspace\`
+    </Text>
+    <Text>
+      Press \`enter\` to open a repo · \`?\` for the full keymap · \`a\` to add a repo by path.
+    </Text>
+    <Text
+      dimColor={true}
+    >
+      Any keypress dismisses this banner.
+    </Text>
+  </Box>
+  <Box
+    borderColor="gray"
+    borderStyle="classic"
+    flexDirection="column"
+    paddingX={1}
+  >
+    <Text
+      dimColor={true}
+    >
+      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · q quit
+    </Text>
+  </Box>
+</Box>
+`;
+
+exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`] = `
+<Box
+  flexDirection="column"
+>
+  <Box
+    borderColor="cyan"
+    borderStyle="classic"
+    justifyContent="space-between"
+    paddingX={1}
+  >
+    <Text
+      bold={true}
+    >
+      coco workspace  roots: ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+      3/3 repos  ·  sort: Recent
+    </Text>
+  </Box>
+  <Box
+    borderColor="cyan"
+    borderStyle="classic"
+    flexDirection="column"
+    paddingX={1}
+  >
+    <Text
+      bold={true}
+    >
+      Workspace keymap
+    </Text>
+    <Box
+      flexDirection="row"
+    >
+      <Text
+        color="green"
+      >
+        j / ↓            
+      </Text>
+      <Text>
+        Move cursor down
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Text
+        color="green"
+      >
+        k / ↑            
+      </Text>
+      <Text>
+        Move cursor up
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Text
+        color="green"
+      >
+        g / G            
+      </Text>
+      <Text>
+        Jump to top / bottom
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Text
+        color="green"
+      >
+        enter            
+      </Text>
+      <Text>
+        Drill into the cursored repo (coco ui)
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Text
+        color="green"
+      >
+        tab / shift-tab  
+      </Text>
+      <Text>
+        Cycle sidebar tab forward / backward
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Text
+        color="green"
+      >
+        h / l            
+      </Text>
+      <Text>
+        Cycle sidebar tab (Vim-style)
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Text
+        color="green"
+      >
+        s                
+      </Text>
+      <Text>
+        Cycle sort mode (recency → name → dirty)
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Text
+        color="green"
+      >
+        /                
+      </Text>
+      <Text>
+        Filter the list by name or branch
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Text
+        color="green"
+      >
+        r                
+      </Text>
+      <Text>
+        Refresh discovery
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Text
+        color="green"
+      >
+        a                
+      </Text>
+      <Text>
+        Add a repo via path prompt (tab-completes)
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Text
+        color="green"
+      >
+        ?                
+      </Text>
+      <Text>
+        Toggle this help overlay
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Text
+        color="green"
+      >
+        esc              
+      </Text>
+      <Text>
+        Clear filter or close overlay
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Text
+        color="green"
+      >
+        q                
+      </Text>
+      <Text>
+        Quit the workspace surface
+      </Text>
+    </Box>
+    <Text
+      dimColor={true}
+    >
+      esc / ? / q close · auto-refresh disabled while help is open
+    </Text>
+  </Box>
+  <Box
+    borderColor="gray"
+    borderStyle="classic"
+    flexDirection="column"
+    paddingX={1}
+  >
+    <Text
+      dimColor={true}
+    >
+      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · q quit
+    </Text>
+  </Box>
+</Box>
+`;
+
 exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is in flight 1`] = `
 <Box
   flexDirection="column"

--- a/src/workstation/surfaces/workspace/input.test.ts
+++ b/src/workstation/surfaces/workspace/input.test.ts
@@ -111,6 +111,31 @@ describe('resolveWorkspaceInput', () => {
     expect(resolveWorkspaceInput('a', key(), filterState()).kind).toBe('noop')
   })
 
+  it('routes ? to toggle-help while focused on the list', () => {
+    expect(resolveWorkspaceInput('?', key(), listState())).toEqual({
+      kind: 'action',
+      action: { type: 'toggle-help' },
+    })
+  })
+
+  it('drops every keystroke while the help overlay is up except esc/?/q', () => {
+    const state = { ...listState(), showHelp: true }
+    expect(resolveWorkspaceInput('j', key(), state).kind).toBe('noop')
+    expect(resolveWorkspaceInput('', key({ return: true }), state).kind).toBe('noop')
+    expect(resolveWorkspaceInput('', key({ escape: true }), state)).toEqual({
+      kind: 'action',
+      action: { type: 'close-help' },
+    })
+    expect(resolveWorkspaceInput('?', key(), state)).toEqual({
+      kind: 'action',
+      action: { type: 'close-help' },
+    })
+    expect(resolveWorkspaceInput('q', key(), state)).toEqual({
+      kind: 'action',
+      action: { type: 'close-help' },
+    })
+  })
+
   it('routes escape out of the add-repo prompt and lets the runtime own other keys', () => {
     expect(resolveWorkspaceInput('', key({ escape: true }), addRepoState())).toEqual({
       kind: 'action',

--- a/src/workstation/surfaces/workspace/input.ts
+++ b/src/workstation/surfaces/workspace/input.ts
@@ -61,6 +61,16 @@ export function resolveWorkspaceInput(
   key: WorkspaceInputKey,
   state: WorkspaceState
 ): WorkspaceInputIntent {
+  // Help overlay is modal — Esc / `?` close it, every other key is
+  // dropped so the underlying state doesn't move while the user is
+  // reading the keymap.
+  if (state.showHelp) {
+    if (key.escape || input === '?' || input === 'q') {
+      return { kind: 'action', action: { type: 'close-help' } }
+    }
+    return { kind: 'noop' }
+  }
+
   if (state.focus === 'filter') {
     if (key.escape) {
       return { kind: 'action', action: { type: 'clear-filter' } }
@@ -138,6 +148,9 @@ export function resolveWorkspaceInput(
   }
   if (input === 'a') {
     return { kind: 'add-repo' }
+  }
+  if (input === '?') {
+    return { kind: 'action', action: { type: 'toggle-help' } }
   }
 
   return { kind: 'noop' }

--- a/src/workstation/surfaces/workspace/render.test.ts
+++ b/src/workstation/surfaces/workspace/render.test.ts
@@ -3,7 +3,9 @@ import { WorkspaceOverview, WorkspaceRepoSummary } from '../../../git/workspaceD
 import {
   buildWorkspaceFooter,
   buildWorkspaceHeader,
+  buildWorkspaceHelpRows,
   buildWorkspaceListRows,
+  buildWorkspaceOnboarding,
   buildWorkspaceSidebar,
 } from './render'
 import { applyWorkspaceAction, createWorkspaceState } from './state'
@@ -130,5 +132,29 @@ describe('workspace render builders', () => {
   it('footer hint flips to the add-repo prompt when add-repo focus is active', () => {
     const focused = applyWorkspaceAction(state, { type: 'set-focus', focus: 'add-repo' })
     expect(buildWorkspaceFooter(focused).hint).toContain('tab to complete')
+  })
+
+  it('help rows cover every binding wired by the input resolver', () => {
+    const rows = buildWorkspaceHelpRows()
+    const allKeys = rows.map((row) => row.keys).join(' | ')
+    for (const expected of ['j', 'k', 'g', 'G', 's', '/', 'r', 'a', '?', 'q', 'enter', 'tab', 'esc']) {
+      expect(allKeys).toContain(expected)
+    }
+  })
+
+  it('onboarding model returns show=false unless the flag is set', () => {
+    expect(buildWorkspaceOnboarding(state)).toEqual({ show: false })
+  })
+
+  it('onboarding model surfaces empty + populated hints based on overview shape', () => {
+    const populated = { ...state, showOnboarding: true }
+    expect(buildWorkspaceOnboarding(populated).populatedHint).toContain('enter')
+    const empty = {
+      ...state,
+      showOnboarding: true,
+      overview: { ...state.overview, repos: [] },
+    }
+    expect(buildWorkspaceOnboarding(empty).emptyHint).toContain('No repos found')
+    expect(buildWorkspaceOnboarding(empty).populatedHint).toBeUndefined()
   })
 })

--- a/src/workstation/surfaces/workspace/render.ts
+++ b/src/workstation/surfaces/workspace/render.ts
@@ -179,3 +179,55 @@ export function describeSortModesForLegend(): Record<WorkspaceSortMode, string> 
     dirty: 'Most working-tree changes first',
   }
 }
+
+export type WorkspaceHelpRow = {
+  keys: string
+  description: string
+}
+
+/**
+ * Keymap legend rendered by the help overlay (`?`). Sectionless flat
+ * list so the overlay stays short — every binding fits in one screen
+ * even on a 24-row terminal.
+ */
+export function buildWorkspaceHelpRows(): WorkspaceHelpRow[] {
+  return [
+    { keys: 'j / ↓', description: 'Move cursor down' },
+    { keys: 'k / ↑', description: 'Move cursor up' },
+    { keys: 'g / G', description: 'Jump to top / bottom' },
+    { keys: 'enter', description: 'Drill into the cursored repo (coco ui)' },
+    { keys: 'tab / shift-tab', description: 'Cycle sidebar tab forward / backward' },
+    { keys: 'h / l', description: 'Cycle sidebar tab (Vim-style)' },
+    { keys: 's', description: 'Cycle sort mode (recency → name → dirty)' },
+    { keys: '/', description: 'Filter the list by name or branch' },
+    { keys: 'r', description: 'Refresh discovery' },
+    { keys: 'a', description: 'Add a repo via path prompt (tab-completes)' },
+    { keys: '?', description: 'Toggle this help overlay' },
+    { keys: 'esc', description: 'Clear filter or close overlay' },
+    { keys: 'q', description: 'Quit the workspace surface' },
+  ]
+}
+
+export type WorkspaceOnboardingModel = {
+  show: boolean
+  /** Short hint shown on first run when discovery returns no repos. */
+  emptyHint?: string
+  /** Short hint shown on first run when discovery returned repos. */
+  populatedHint?: string
+}
+
+export function buildWorkspaceOnboarding(state: WorkspaceState): WorkspaceOnboardingModel {
+  if (!state.showOnboarding) {
+    return { show: false }
+  }
+  const empty = state.overview.repos.length === 0
+  return {
+    show: true,
+    emptyHint: empty
+      ? 'No repos found. Press `a` to add one by path, or set workspace.roots in your config.'
+      : undefined,
+    populatedHint: empty
+      ? undefined
+      : 'Press `enter` to open a repo · `?` for the full keymap · `a` to add a repo by path.',
+  }
+}

--- a/src/workstation/surfaces/workspace/runtime.ts
+++ b/src/workstation/surfaces/workspace/runtime.ts
@@ -61,6 +61,10 @@ import {
   appendKnownRepo,
   readKnownRepos,
 } from '../../chrome/workspaceKnownRepos'
+import {
+  hasSeenWorkspaceOnboarding,
+  markWorkspaceOnboardingSeen,
+} from '../../chrome/workspaceOnboarding'
 import { isGitWorkingTree } from '../../../git/workspaceData'
 
 type DynamicImport = <T>(specifier: string) => Promise<T>
@@ -306,6 +310,7 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
       tab: props.resume?.tab,
       filter: props.resume?.filter,
       selectedRepoPath: props.resume?.selectedRepoPath,
+      showOnboarding: !hasSeenWorkspaceOnboarding(),
     })
   )
 
@@ -438,6 +443,14 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
   }, [addRepoDraft, dispatch, props])
 
   useInput((rawInput: string, key: WorkspaceInputKey) => {
+    // First-run onboarding is non-modal — any keypress dismisses it
+    // and persists the marker. The keypress still flows through to
+    // the normal handler below so the user's first action isn't
+    // wasted.
+    if (state.showOnboarding) {
+      markWorkspaceOnboardingSeen()
+      dispatch({ type: 'dismiss-onboarding' })
+    }
     if (state.focus === 'filter') {
       if (key.escape) {
         setFilterDraft('')

--- a/src/workstation/surfaces/workspace/state.test.ts
+++ b/src/workstation/surfaces/workspace/state.test.ts
@@ -154,4 +154,26 @@ describe('workspace state reducer', () => {
     })
     expect(anchored.selectedIndex).toBe(baseState.selectedIndex)
   })
+
+  it('toggles the help overlay and auto-dismisses any onboarding banner', () => {
+    const seeded = { ...baseState, showOnboarding: true }
+    const opened = applyWorkspaceAction(seeded, { type: 'toggle-help' })
+    expect(opened.showHelp).toBe(true)
+    expect(opened.showOnboarding).toBe(false)
+    const closed = applyWorkspaceAction(opened, { type: 'toggle-help' })
+    expect(closed.showHelp).toBe(false)
+  })
+
+  it('close-help only clears the help flag', () => {
+    const opened = applyWorkspaceAction(baseState, { type: 'toggle-help' })
+    const closed = applyWorkspaceAction(opened, { type: 'close-help' })
+    expect(closed.showHelp).toBe(false)
+  })
+
+  it('dismiss-onboarding clears just the banner flag', () => {
+    const seeded = { ...baseState, showOnboarding: true }
+    const dismissed = applyWorkspaceAction(seeded, { type: 'dismiss-onboarding' })
+    expect(dismissed.showOnboarding).toBe(false)
+    expect(dismissed.showHelp).toBe(false)
+  })
 })

--- a/src/workstation/surfaces/workspace/state.ts
+++ b/src/workstation/surfaces/workspace/state.ts
@@ -56,6 +56,10 @@ export type WorkspaceState = {
    * without the renderer reaching back into the runtime closure.
    */
   roots: ReadonlyArray<string>
+  /** Keymap help overlay toggle. */
+  showHelp: boolean
+  /** First-run onboarding overlay toggle. Self-dismisses on first user action. */
+  showOnboarding: boolean
 }
 
 export type WorkspaceAction =
@@ -73,6 +77,9 @@ export type WorkspaceAction =
   | { type: 'set-cursor'; index: number }
   | { type: 'set-loading'; loading: boolean }
   | { type: 'set-status'; status?: string }
+  | { type: 'toggle-help' }
+  | { type: 'close-help' }
+  | { type: 'dismiss-onboarding' }
 
 export type WorkspaceStateInit = {
   overview: WorkspaceOverview
@@ -88,6 +95,8 @@ export type WorkspaceStateInit = {
    * cursor lands back on the repo the user just exited.
    */
   selectedRepoPath?: string
+  /** Render the first-run onboarding overlay. */
+  showOnboarding?: boolean
 }
 
 export function createWorkspaceState(init: WorkspaceStateInit): WorkspaceState {
@@ -101,6 +110,8 @@ export function createWorkspaceState(init: WorkspaceStateInit): WorkspaceState {
     selectedIndex: 0,
     loading: Boolean(init.loading),
     roots: init.roots,
+    showHelp: false,
+    showOnboarding: Boolean(init.showOnboarding),
   }
   if (!init.selectedRepoPath) {
     return base
@@ -223,6 +234,15 @@ export function applyWorkspaceAction(
     }
     case 'set-status': {
       return { ...state, status: action.status }
+    }
+    case 'toggle-help': {
+      return { ...state, showHelp: !state.showHelp, showOnboarding: false }
+    }
+    case 'close-help': {
+      return { ...state, showHelp: false }
+    }
+    case 'dismiss-onboarding': {
+      return { ...state, showOnboarding: false }
     }
     default:
       return state

--- a/src/workstation/surfaces/workspace/view.test.ts
+++ b/src/workstation/surfaces/workspace/view.test.ts
@@ -216,6 +216,18 @@ describe('renderWorkspaceApp', () => {
     expect(tree).toMatchSnapshot()
   })
 
+  it('snapshots the keymap help overlay when toggled on', () => {
+    const state = applyWorkspaceAction(baseState(), { type: 'toggle-help' })
+    const tree = render(state)
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('snapshots the first-run onboarding banner', () => {
+    const state = { ...baseState(), showOnboarding: true }
+    const tree = render(state)
+    expect(tree).toMatchSnapshot()
+  })
+
   it('shifts borderColor between focus modes', () => {
     const list = render(baseState())
     const filter = render(applyWorkspaceAction(baseState(), { type: 'set-focus', focus: 'filter' }))

--- a/src/workstation/surfaces/workspace/view.ts
+++ b/src/workstation/surfaces/workspace/view.ts
@@ -18,7 +18,9 @@ import { type PathCompletionResult } from './pathCompletion'
 import {
   buildWorkspaceFooter,
   buildWorkspaceHeader,
+  buildWorkspaceHelpRows,
   buildWorkspaceListRows,
+  buildWorkspaceOnboarding,
   buildWorkspaceSidebar,
   type WorkspaceListColumn,
 } from './render'
@@ -188,6 +190,65 @@ function renderListBody(
   )
 }
 
+function renderHelpOverlay(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement | null {
+  if (!deps.state.showHelp) {
+    return null
+  }
+  const { React, ink, theme } = deps
+  const { Box, Text } = ink
+  const rows = buildWorkspaceHelpRows()
+  const widest = rows.reduce((acc, row) => Math.max(acc, row.keys.length), 0)
+  return React.createElement(
+    Box,
+    {
+      borderColor: focusBorderColor(theme, true),
+      borderStyle: theme.borderStyle,
+      flexDirection: 'column',
+      paddingX: 1,
+    },
+    React.createElement(Text, { bold: true }, 'Workspace keymap'),
+    ...rows.map((row, index) =>
+      React.createElement(
+        Box,
+        { key: index, flexDirection: 'row' },
+        React.createElement(
+          Text,
+          { color: toneColor('ok', theme) },
+          row.keys.padEnd(widest + 2)
+        ),
+        React.createElement(Text, null, row.description)
+      )
+    ),
+    React.createElement(
+      Text,
+      { dimColor: true },
+      'esc / ? / q close · auto-refresh disabled while help is open'
+    )
+  )
+}
+
+function renderOnboardingBanner(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement | null {
+  const model = buildWorkspaceOnboarding(deps.state)
+  if (!model.show) {
+    return null
+  }
+  const { React, ink, theme } = deps
+  const { Box, Text } = ink
+  const lines = [model.emptyHint, model.populatedHint].filter(Boolean) as string[]
+  return React.createElement(
+    Box,
+    {
+      borderColor: focusBorderColor(theme, true),
+      borderStyle: theme.borderStyle,
+      flexDirection: 'column',
+      paddingX: 1,
+    },
+    React.createElement(Text, { bold: true }, 'Welcome to `coco workspace`'),
+    ...lines.map((line, idx) => React.createElement(Text, { key: idx }, line)),
+    React.createElement(Text, { dimColor: true }, 'Any keypress dismisses this banner.')
+  )
+}
+
 function renderAddRepoPrompt(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement | null {
   if (deps.state.focus !== 'add-repo') {
     return null
@@ -240,6 +301,18 @@ export function renderWorkspaceApp(deps: RenderWorkspaceAppDeps): ReactTypes.Rea
   const { React, ink } = deps
   const { Box } = ink
   const bodyWidth = Math.max(40, deps.columns - 4)
+  // Help is modal — when it's up, replace the main list/sidebar pair
+  // with the help panel so the user isn't distracted by background
+  // updates while reading.
+  if (deps.state.showHelp) {
+    return React.createElement(
+      Box,
+      { flexDirection: 'column' },
+      renderHeader(deps),
+      renderHelpOverlay(deps),
+      renderFooter(deps)
+    )
+  }
   return React.createElement(
     Box,
     { flexDirection: 'column' },
@@ -250,6 +323,7 @@ export function renderWorkspaceApp(deps: RenderWorkspaceAppDeps): ReactTypes.Rea
       renderSidebar(deps),
       renderListBody(deps, bodyWidth - 22)
     ),
+    renderOnboardingBanner(deps),
     renderAddRepoPrompt(deps),
     renderFooter(deps)
   )


### PR DESCRIPTION
Closes one of the gaps I flagged after #1040. Adds `?` for a keymap legend and a first-run banner so new users have somewhere to start.

## Summary

- **Per-surface first-run marker** (`chrome/workspaceOnboarding.ts`) sibling of the existing `chrome/onboarding.ts`. Keeping them separate so dismissing the workspace banner doesn't suppress the `coco ui` overlay (and vice versa). XDG-friendly, best-effort writes.
- **Help overlay**: `?` toggles a keymap legend that replaces the sidebar+main split. Modal — every key except `esc`/`?`/`q` is dropped while it's up so the underlying state can't move while the user is reading. Opening help auto-dismisses any onboarding banner.
- **Onboarding banner**: First-run users see a hint between the main panel and the footer. Copy diverges: empty discovery → "press `a` to add one"; populated → "press enter to drill in · `?` for the keymap · `a` to add a repo". Any keypress dismisses + persists the marker; the keypress still flows through to the normal handler so the user's first action isn't wasted.

## Commits

1. `feat(workspace): per-surface first-run marker` — chrome module + tests
2. `feat(workspace): help overlay + onboarding state slices` — reducer + input resolver + render builders + 12 tests
3. `feat(workspace): wire help overlay + first-run banner into the runtime` — view rendering + runtime seed + 2 new snapshots

## Test plan

- [x] Lint + typecheck clean
- [x] Full Jest suite: 186 suites, 2357 passing, 7 skipped, 30 snapshots