### PR TITLE
feat(workspace): remove-known-repo affordance (`d` + y-confirm)

### DIFF
--- a/src/workstation/chrome/workspaceKnownRepos.test.ts
+++ b/src/workstation/chrome/workspaceKnownRepos.test.ts
@@ -6,6 +6,7 @@ import {
   appendKnownRepo,
   getKnownReposStorePath,
   readKnownRepos,
+  removeKnownRepo,
   writeKnownRepos,
 } from './workspaceKnownRepos'
 
@@ -58,5 +59,17 @@ describe('workspaceKnownRepos persistence', () => {
     fs.writeFileSync(blocker, '')
     process.env.XDG_CACHE_HOME = blocker
     expect(() => writeKnownRepos(['/c'])).not.toThrow()
+  })
+
+  it('removeKnownRepo drops the path from the store + returns the new list', () => {
+    writeKnownRepos(['/a', '/b', '/c'])
+    expect(removeKnownRepo('/b')).toEqual(['/a', '/c'])
+    expect(readKnownRepos()).toEqual(['/a', '/c'])
+  })
+
+  it('removeKnownRepo is a no-op for unknown paths', () => {
+    writeKnownRepos(['/a'])
+    expect(removeKnownRepo('/zzz')).toEqual(['/a'])
+    expect(readKnownRepos()).toEqual(['/a'])
   })
 })

--- a/src/workstation/chrome/workspaceKnownRepos.ts
+++ b/src/workstation/chrome/workspaceKnownRepos.ts
@@ -85,3 +85,18 @@ export function appendKnownRepo(repoPath: string): string[] {
   writeKnownRepos(next)
   return next
 }
+
+/**
+ * Remove an entry from the store. No-op when the path isn't present.
+ * Returns the updated list so the caller can echo it into state
+ * without re-reading from disk.
+ */
+export function removeKnownRepo(repoPath: string): string[] {
+  const existing = readKnownRepos()
+  if (!existing.includes(repoPath)) {
+    return existing
+  }
+  const next = existing.filter((entry) => entry !== repoPath)
+  writeKnownRepos(next)
+  return next
+}

--- a/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
+++ b/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
@@ -305,7 +305,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · q quit
+      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -466,7 +466,7 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · q quit
+      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -779,7 +779,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · q quit
+      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -1090,7 +1090,7 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · q quit
+      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -1401,7 +1401,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · q quit
+      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       color="yellow"
@@ -1501,7 +1501,7 @@ exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading fals
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · q quit
+      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -2306,7 +2306,340 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · q quit
+      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+    </Text>
+  </Box>
+</Box>
+`;
+
+exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo 1`] = `
+<Box
+  flexDirection="column"
+>
+  <Box
+    borderColor="cyan"
+    borderStyle="classic"
+    justifyContent="space-between"
+    paddingX={1}
+  >
+    <Text
+      bold={true}
+    >
+      coco workspace  roots: ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+      3/3 repos  ·  sort: Recent
+    </Text>
+  </Box>
+  <Box
+    flexDirection="row"
+  >
+    <Box
+      borderColor="gray"
+      borderStyle="classic"
+      flexDirection="column"
+      flexShrink={0}
+      paddingX={1}
+      width={18}
+    >
+      <Text
+        bold={true}
+      >
+        Tabs
+      </Text>
+      <Text
+        bold={true}
+      >
+        › All
+      </Text>
+      <Text>
+          Dirty
+      </Text>
+      <Text>
+          Behind
+      </Text>
+      <Text>
+          PRs
+      </Text>
+    </Box>
+    <Box
+      borderColor="cyan"
+      borderStyle="classic"
+      flexDirection="column"
+      flexGrow={1}
+      paddingX={1}
+    >
+      <Box
+        justifyContent="space-between"
+      >
+        <Text
+          bold={true}
+        >
+          Workspace *
+        </Text>
+        <Text
+          dimColor={true}
+        >
+          3 visible
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text
+          bold={true}
+        >
+          › 
+        </Text>
+        <Box
+          flexDirection="row"
+          flexShrink={1}
+          flexWrap="wrap"
+        >
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={true}
+              dimColor={false}
+            >
+              coco
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              dimColor={false}
+            >
+              main
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              color="yellow"
+              dimColor={false}
+            >
+              ●2 ↑1
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              color="gray"
+              dimColor={false}
+            >
+              2026-05-01
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              color="gray"
+              dimColor={false}
+            >
+              /tmp/coco
+            </Text>
+          </Box>
+        </Box>
+        <Box
+          flexShrink={0}
+        >
+          <Text
+            dimColor={true}
+          />
+        </Box>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text
+          bold={false}
+        >
+            
+        </Text>
+        <Box
+          flexDirection="row"
+          flexShrink={1}
+          flexWrap="wrap"
+        >
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              docs
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              feature/landing
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="yellow"
+              dimColor={false}
+            >
+              ↓3
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              2026-04-15
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              /tmp/docs
+            </Text>
+          </Box>
+        </Box>
+        <Box
+          flexShrink={0}
+        >
+          <Text
+            dimColor={true}
+          />
+        </Box>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text
+          bold={false}
+        >
+            
+        </Text>
+        <Box
+          flexDirection="row"
+          flexShrink={1}
+          flexWrap="wrap"
+        >
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              lib
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              main
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              ·
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              —
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              /tmp/lib
+            </Text>
+          </Box>
+        </Box>
+        <Box
+          flexShrink={0}
+        >
+          <Text
+            dimColor={true}
+          />
+        </Box>
+      </Box>
+    </Box>
+  </Box>
+  <Box
+    borderColor="cyan"
+    borderStyle="classic"
+    flexDirection="column"
+    paddingX={1}
+  >
+    <Text
+      bold={true}
+    >
+      Remove /tmp/docs?
+    </Text>
+    <Text
+      dimColor={true}
+    >
+      Only removes the entry from the known-repos store · the repo on disk is untouched.
+    </Text>
+    <Text
+      color="yellow"
+    >
+      press y to confirm · any other key to cancel
+    </Text>
+  </Box>
+  <Box
+    borderColor="gray"
+    borderStyle="classic"
+    flexDirection="column"
+    paddingX={1}
+  >
+    <Text
+      dimColor={true}
+    >
+      press y to remove · any other key to cancel
     </Text>
   </Box>
 </Box>
@@ -2467,7 +2800,7 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · q quit
+      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -2798,7 +3131,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · q quit
+      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -2962,6 +3295,18 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
       <Text
         color="green"
       >
+        d                
+      </Text>
+      <Text>
+        Remove the cursored repo from the known-repos store (y-confirm)
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Text
+        color="green"
+      >
         ?                
       </Text>
       <Text>
@@ -3007,7 +3352,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · q quit
+      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -3102,7 +3447,7 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · q quit
+      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -3413,7 +3758,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · q quit
+      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>

--- a/src/workstation/surfaces/workspace/input.test.ts
+++ b/src/workstation/surfaces/workspace/input.test.ts
@@ -111,6 +111,24 @@ describe('resolveWorkspaceInput', () => {
     expect(resolveWorkspaceInput('a', key(), filterState()).kind).toBe('noop')
   })
 
+  it('routes d to request-delete while focused on the list', () => {
+    expect(resolveWorkspaceInput('d', key(), listState()).kind).toBe('request-delete')
+  })
+
+  it('confirm-delete focus accepts only y/Y; every other key cancels', () => {
+    const state = { ...listState(), focus: 'confirm-delete' as const, pendingDeletePath: '/tmp/r' }
+    expect(resolveWorkspaceInput('y', key(), state).kind).toBe('confirm-delete')
+    expect(resolveWorkspaceInput('Y', key(), state).kind).toBe('confirm-delete')
+    expect(resolveWorkspaceInput('n', key(), state)).toEqual({
+      kind: 'action',
+      action: { type: 'cancel-delete' },
+    })
+    expect(resolveWorkspaceInput('', key({ escape: true }), state)).toEqual({
+      kind: 'action',
+      action: { type: 'cancel-delete' },
+    })
+  })
+
   it('routes ? to toggle-help while focused on the list', () => {
     expect(resolveWorkspaceInput('?', key(), listState())).toEqual({
       kind: 'action',

--- a/src/workstation/surfaces/workspace/input.ts
+++ b/src/workstation/surfaces/workspace/input.ts
@@ -28,6 +28,8 @@ export type WorkspaceInputIntent =
   | { kind: 'drill-in' }
   | { kind: 'refresh' }
   | { kind: 'add-repo' }
+  | { kind: 'request-delete' }
+  | { kind: 'confirm-delete' }
   | { kind: 'noop' }
 
 /**
@@ -90,6 +92,14 @@ export function resolveWorkspaceInput(
     return { kind: 'noop' }
   }
 
+  // Confirm-delete is modal: only `y` confirms, anything else cancels.
+  if (state.focus === 'confirm-delete') {
+    if (input === 'y' || input === 'Y') {
+      return { kind: 'confirm-delete' }
+    }
+    return { kind: 'action', action: { type: 'cancel-delete' } }
+  }
+
   if (key.escape) {
     if (state.filter) {
       return { kind: 'action', action: { type: 'clear-filter' } }
@@ -148,6 +158,9 @@ export function resolveWorkspaceInput(
   }
   if (input === 'a') {
     return { kind: 'add-repo' }
+  }
+  if (input === 'd') {
+    return { kind: 'request-delete' }
   }
   if (input === '?') {
     return { kind: 'action', action: { type: 'toggle-help' } }

--- a/src/workstation/surfaces/workspace/render.test.ts
+++ b/src/workstation/surfaces/workspace/render.test.ts
@@ -137,9 +137,21 @@ describe('workspace render builders', () => {
   it('help rows cover every binding wired by the input resolver', () => {
     const rows = buildWorkspaceHelpRows()
     const allKeys = rows.map((row) => row.keys).join(' | ')
-    for (const expected of ['j', 'k', 'g', 'G', 's', '/', 'r', 'a', '?', 'q', 'enter', 'tab', 'esc']) {
+    for (const expected of ['j', 'k', 'g', 'G', 's', '/', 'r', 'a', 'd', '?', 'q', 'enter', 'tab', 'esc']) {
       expect(allKeys).toContain(expected)
     }
+  })
+
+  it('footer hint flips to the confirm-delete copy when pending', () => {
+    const focused = applyWorkspaceAction(state, {
+      type: 'replace-known-repos',
+      paths: [state.overview.repos[0].path],
+    })
+    const requested = applyWorkspaceAction(focused, {
+      type: 'request-delete',
+      path: state.overview.repos[0].path,
+    })
+    expect(buildWorkspaceFooter(requested).hint).toContain('press y')
   })
 
   it('onboarding model returns show=false unless the flag is set', () => {

--- a/src/workstation/surfaces/workspace/render.ts
+++ b/src/workstation/surfaces/workspace/render.ts
@@ -148,9 +148,10 @@ export type WorkspaceFooterModel = {
   filterMode: boolean
 }
 
-const LIST_HINT = 'j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · q quit'
+const LIST_HINT = 'j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit'
 const FILTER_HINT = 'type filter · enter to apply · esc to clear'
 const ADD_REPO_HINT = 'type path · tab to complete · enter to add · esc to cancel'
+const CONFIRM_DELETE_HINT = 'press y to remove · any other key to cancel'
 
 function hintFor(focus: WorkspaceState['focus']): string {
   switch (focus) {
@@ -158,6 +159,8 @@ function hintFor(focus: WorkspaceState['focus']): string {
       return FILTER_HINT
     case 'add-repo':
       return ADD_REPO_HINT
+    case 'confirm-delete':
+      return CONFIRM_DELETE_HINT
     case 'list':
     default:
       return LIST_HINT
@@ -202,6 +205,7 @@ export function buildWorkspaceHelpRows(): WorkspaceHelpRow[] {
     { keys: '/', description: 'Filter the list by name or branch' },
     { keys: 'r', description: 'Refresh discovery' },
     { keys: 'a', description: 'Add a repo via path prompt (tab-completes)' },
+    { keys: 'd', description: 'Remove the cursored repo from the known-repos store (y-confirm)' },
     { keys: '?', description: 'Toggle this help overlay' },
     { keys: 'esc', description: 'Clear filter or close overlay' },
     { keys: 'q', description: 'Quit the workspace surface' },

--- a/src/workstation/surfaces/workspace/runtime.ts
+++ b/src/workstation/surfaces/workspace/runtime.ts
@@ -60,6 +60,7 @@ import {
 import {
   appendKnownRepo,
   readKnownRepos,
+  removeKnownRepo,
 } from '../../chrome/workspaceKnownRepos'
 import {
   hasSeenWorkspaceOnboarding,
@@ -311,6 +312,7 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
       filter: props.resume?.filter,
       selectedRepoPath: props.resume?.selectedRepoPath,
       showOnboarding: !hasSeenWorkspaceOnboarding(),
+      knownRepoPaths: readKnownRepos(),
     })
   )
 
@@ -405,6 +407,46 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
     exit()
   }, [exit, props.exitRef, state])
 
+  const requestDelete = React.useCallback(() => {
+    const focused = selectFocusedRepo(state)
+    if (!focused) {
+      return
+    }
+    if (!state.knownRepoPaths.includes(focused.path)) {
+      dispatch({
+        type: 'set-status',
+        status: 'Only repos added via `a` can be removed. Edit workspace.roots in config to drop a discovered repo.',
+      })
+      return
+    }
+    dispatch({ type: 'request-delete', path: focused.path })
+  }, [dispatch, state])
+
+  const confirmDelete = React.useCallback(async () => {
+    const target = state.pendingDeletePath
+    if (!target) {
+      return
+    }
+    const updated = removeKnownRepo(target)
+    dispatch({ type: 'replace-known-repos', paths: updated })
+    dispatch({ type: 'cancel-delete' })
+    dispatch({ type: 'set-status', status: `Removed ${target}.` })
+    // Refresh discovery so the deleted entry drops out of the list.
+    dispatch({ type: 'set-loading', loading: true })
+    try {
+      const merged = mergeKnownRepos(props.knownRepos, updated)
+      const overview = await props.loadOverview(props.roots, merged)
+      writeCachedWorkspace(props.roots, overview)
+      dispatch({ type: 'replace-overview', overview })
+    } catch (err) {
+      dispatch({ type: 'set-loading', loading: false })
+      dispatch({
+        type: 'set-status',
+        status: err instanceof Error ? err.message : 'Refresh failed.',
+      })
+    }
+  }, [dispatch, props, state.pendingDeletePath])
+
   const openAddRepo = React.useCallback(() => {
     setAddRepoDraft('~/')
     setAddRepoCompletion(completePath('~/'))
@@ -421,7 +463,8 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
       dispatch({ type: 'set-status', status: `${candidate} is not a git repo.` })
       return
     }
-    appendKnownRepo(candidate)
+    const updated = appendKnownRepo(candidate)
+    dispatch({ type: 'replace-known-repos', paths: updated })
     dispatch({ type: 'set-focus', focus: 'list' })
     dispatch({ type: 'set-status', status: `Added ${candidate}.` })
     // Refresh discovery so the new repo lands in the list and the
@@ -518,6 +561,12 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
         break
       case 'add-repo':
         openAddRepo()
+        break
+      case 'request-delete':
+        requestDelete()
+        break
+      case 'confirm-delete':
+        void confirmDelete()
         break
       case 'noop':
       default:

--- a/src/workstation/surfaces/workspace/state.test.ts
+++ b/src/workstation/surfaces/workspace/state.test.ts
@@ -3,6 +3,7 @@ import { WorkspaceOverview, WorkspaceRepoSummary } from '../../../git/workspaceD
 import {
   applyWorkspaceAction,
   createWorkspaceState,
+  isRepoRemovable,
   selectFocusedRepo,
   selectVisibleRepos,
 } from './state'
@@ -175,5 +176,39 @@ describe('workspace state reducer', () => {
     const dismissed = applyWorkspaceAction(seeded, { type: 'dismiss-onboarding' })
     expect(dismissed.showOnboarding).toBe(false)
     expect(dismissed.showHelp).toBe(false)
+  })
+
+  it('replace-known-repos updates the removable-set', () => {
+    const next = applyWorkspaceAction(baseState, {
+      type: 'replace-known-repos',
+      paths: ['/tmp/bravo'],
+    })
+    expect(isRepoRemovable(next, '/tmp/bravo')).toBe(true)
+    expect(isRepoRemovable(next, '/tmp/alpha')).toBe(false)
+  })
+
+  it('request-delete only fires when the path is in the known set', () => {
+    const known = applyWorkspaceAction(baseState, {
+      type: 'replace-known-repos',
+      paths: ['/tmp/bravo'],
+    })
+    const ignored = applyWorkspaceAction(known, { type: 'request-delete', path: '/tmp/alpha' })
+    expect(ignored.focus).toBe('list')
+    expect(ignored.pendingDeletePath).toBeUndefined()
+
+    const requested = applyWorkspaceAction(known, { type: 'request-delete', path: '/tmp/bravo' })
+    expect(requested.focus).toBe('confirm-delete')
+    expect(requested.pendingDeletePath).toBe('/tmp/bravo')
+  })
+
+  it('cancel-delete returns focus to the list and clears the pending path', () => {
+    const known = applyWorkspaceAction(baseState, {
+      type: 'replace-known-repos',
+      paths: ['/tmp/bravo'],
+    })
+    const requested = applyWorkspaceAction(known, { type: 'request-delete', path: '/tmp/bravo' })
+    const cancelled = applyWorkspaceAction(requested, { type: 'cancel-delete' })
+    expect(cancelled.focus).toBe('list')
+    expect(cancelled.pendingDeletePath).toBeUndefined()
   })
 })

--- a/src/workstation/surfaces/workspace/state.ts
+++ b/src/workstation/surfaces/workspace/state.ts
@@ -23,7 +23,7 @@ import {
  * dispatches them on action payloads.
  */
 
-export type WorkspaceFocus = 'list' | 'filter' | 'add-repo'
+export type WorkspaceFocus = 'list' | 'filter' | 'add-repo' | 'confirm-delete'
 
 export type WorkspaceState = {
   overview: WorkspaceOverview
@@ -60,6 +60,14 @@ export type WorkspaceState = {
   showHelp: boolean
   /** First-run onboarding overlay toggle. Self-dismisses on first user action. */
   showOnboarding: boolean
+  /**
+   * Paths added through the add-repo prompt. Only entries in this set
+   * can be removed via the delete affordance — repos discovered via
+   * configured roots would just come back on the next refresh.
+   */
+  knownRepoPaths: ReadonlyArray<string>
+  /** Path the user is being asked to confirm deletion for. */
+  pendingDeletePath?: string
 }
 
 export type WorkspaceAction =
@@ -80,6 +88,9 @@ export type WorkspaceAction =
   | { type: 'toggle-help' }
   | { type: 'close-help' }
   | { type: 'dismiss-onboarding' }
+  | { type: 'replace-known-repos'; paths: ReadonlyArray<string> }
+  | { type: 'request-delete'; path: string }
+  | { type: 'cancel-delete' }
 
 export type WorkspaceStateInit = {
   overview: WorkspaceOverview
@@ -97,6 +108,8 @@ export type WorkspaceStateInit = {
   selectedRepoPath?: string
   /** Render the first-run onboarding overlay. */
   showOnboarding?: boolean
+  /** Paths considered "known" (added via the add-repo prompt). */
+  knownRepoPaths?: ReadonlyArray<string>
 }
 
 export function createWorkspaceState(init: WorkspaceStateInit): WorkspaceState {
@@ -112,6 +125,7 @@ export function createWorkspaceState(init: WorkspaceStateInit): WorkspaceState {
     roots: init.roots,
     showHelp: false,
     showOnboarding: Boolean(init.showOnboarding),
+    knownRepoPaths: init.knownRepoPaths ?? [],
   }
   if (!init.selectedRepoPath) {
     return base
@@ -244,9 +258,28 @@ export function applyWorkspaceAction(
     case 'dismiss-onboarding': {
       return { ...state, showOnboarding: false }
     }
+    case 'replace-known-repos': {
+      return { ...state, knownRepoPaths: action.paths }
+    }
+    case 'request-delete': {
+      // No-op if the cursor target isn't actually in the known set —
+      // the input layer is supposed to gate this, but defensive
+      // gating here keeps the reducer authoritative.
+      if (!state.knownRepoPaths.includes(action.path)) {
+        return state
+      }
+      return { ...state, focus: 'confirm-delete', pendingDeletePath: action.path }
+    }
+    case 'cancel-delete': {
+      return { ...state, focus: 'list', pendingDeletePath: undefined }
+    }
     default:
       return state
   }
+}
+
+export function isRepoRemovable(state: WorkspaceState, repoPath: string): boolean {
+  return state.knownRepoPaths.includes(repoPath)
 }
 
 export function selectFocusedRepo(state: WorkspaceState): WorkspaceRepoSummary | undefined {

--- a/src/workstation/surfaces/workspace/view.test.ts
+++ b/src/workstation/surfaces/workspace/view.test.ts
@@ -222,6 +222,20 @@ describe('renderWorkspaceApp', () => {
     expect(tree).toMatchSnapshot()
   })
 
+  it('snapshots the confirm-delete prompt for a known repo', () => {
+    let state = baseState()
+    state = applyWorkspaceAction(state, {
+      type: 'replace-known-repos',
+      paths: [state.overview.repos[1].path],
+    })
+    state = applyWorkspaceAction(state, {
+      type: 'request-delete',
+      path: state.overview.repos[1].path,
+    })
+    const tree = render(state)
+    expect(tree).toMatchSnapshot()
+  })
+
   it('snapshots the first-run onboarding banner', () => {
     const state = { ...baseState(), showOnboarding: true }
     const tree = render(state)

--- a/src/workstation/surfaces/workspace/view.ts
+++ b/src/workstation/surfaces/workspace/view.ts
@@ -249,6 +249,30 @@ function renderOnboardingBanner(deps: RenderWorkspaceAppDeps): ReactTypes.ReactE
   )
 }
 
+function renderConfirmDelete(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement | null {
+  if (deps.state.focus !== 'confirm-delete' || !deps.state.pendingDeletePath) {
+    return null
+  }
+  const { React, ink, theme } = deps
+  const { Box, Text } = ink
+  return React.createElement(
+    Box,
+    {
+      borderColor: focusBorderColor(theme, true),
+      borderStyle: theme.borderStyle,
+      flexDirection: 'column',
+      paddingX: 1,
+    },
+    React.createElement(Text, { bold: true }, `Remove ${deps.state.pendingDeletePath}?`),
+    React.createElement(
+      Text,
+      { dimColor: true },
+      'Only removes the entry from the known-repos store · the repo on disk is untouched.'
+    ),
+    React.createElement(Text, { color: toneColor('warn', theme) }, 'press y to confirm · any other key to cancel')
+  )
+}
+
 function renderAddRepoPrompt(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement | null {
   if (deps.state.focus !== 'add-repo') {
     return null
@@ -325,6 +349,7 @@ export function renderWorkspaceApp(deps: RenderWorkspaceAppDeps): ReactTypes.Rea
     ),
     renderOnboardingBanner(deps),
     renderAddRepoPrompt(deps),
+    renderConfirmDelete(deps),
     renderFooter(deps)
   )
 }


### PR DESCRIPTION
Closes another gap from the #1040 list. The add-repo prompt could grow the known-repos store but had no way back out — users would have had to edit `~/.cache/coco/workspace/known-repos.json` by hand.

## Summary

- `removeKnownRepo` on the chrome store — counterpart to `appendKnownRepo`, returns the updated list so callers don't re-read from disk.
- New focus mode `confirm-delete` + `pendingDeletePath` slot on `WorkspaceState`. Reducer + input resolver both gate on the new `knownRepoPaths` slice so non-removable rows (discovered via `workspace.roots`) can't open the modal — the runtime drops a footer hint pointing at the config instead.
- `d` requests deletion; confirm focus is modal — `y`/`Y` confirm, everything else cancels.
- View renders a yellow-tinged confirm prompt above the footer. Copy makes clear that only the store entry is affected; the repo on disk is left alone.
- Footer hint and help legend updated for the new binding.

## Commits

1. `removeKnownRepo on the chrome store` — chrome module + tests
2. `remove-known-repo state slice + y-confirm input flow` — reducer + input resolver + render builders + 10 tests
3. `runtime wiring + view banner for the delete prompt` — view rendering + runtime workflow + 1 new snapshot + 12 existing snapshots reflecting the updated footer hint

## Test plan

- [x] Lint + typecheck clean
- [x] Full Jest suite: 186 suites, 2366 passing, 7 skipped, 31 snapshots