### PR TITLE
feat(workspace): per-call timeout + abort on gh PR-count fetch

### DIFF
--- a/src/git/githubCli.ts
+++ b/src/git/githubCli.ts
@@ -4,7 +4,12 @@ import { SimpleGit } from 'simple-git'
 
 const execFileAsync = promisify(execFile)
 
-export type GhRunner = (args: string[]) => Promise<string>
+export type GhRunOptions = {
+  /** Abort the gh process when the signal fires (Node 16.14+). */
+  signal?: AbortSignal
+}
+
+export type GhRunner = (args: string[], options?: GhRunOptions) => Promise<string>
 
 export type GitHubRepository = {
   owner: string
@@ -27,8 +32,11 @@ export function parseGitHubRemoteUrl(url: string): GitHubRepository | undefined 
   }
 }
 
-export async function defaultGhRunner(args: string[]): Promise<string> {
-  const result = await execFileAsync('gh', args)
+export async function defaultGhRunner(
+  args: string[],
+  options: GhRunOptions = {}
+): Promise<string> {
+  const result = await execFileAsync('gh', args, options.signal ? { signal: options.signal } : {})
   return result.stdout
 }
 

--- a/src/git/workspacePullRequestData.test.ts
+++ b/src/git/workspacePullRequestData.test.ts
@@ -7,6 +7,7 @@ import {
   getWorkspacePullRequestCounts,
   parseOpenPullRequestCount,
   readOriginRemoteUrl,
+  runGhWithTimeout,
 } from './workspacePullRequestData'
 
 describe('workspacePullRequestData parsers', () => {
@@ -60,6 +61,51 @@ describe('getWorkspacePullRequestCounts', () => {
     expect(result).toEqual({ authenticated: false, counts: {} })
     // Only the auth probe should have been issued.
     expect(runner).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops the badge when gh blows past the per-call timeout', async () => {
+    const remoteUrls = new Map<string, string>([
+      ['/tmp/repo-slow', 'git@github.com:owner/repo-slow.git'],
+    ])
+    const runner = jest.fn(async (args: string[], opts?: { signal?: AbortSignal }) => {
+      if (args[0] === 'auth') return 'ok'
+      if (args[0] === 'pr') {
+        // Hang until aborted.
+        return new Promise<string>((_, reject) => {
+          opts?.signal?.addEventListener('abort', () => reject(new Error('aborted')))
+        })
+      }
+      return ''
+    })
+
+    const result = await getWorkspacePullRequestCounts(['/tmp/repo-slow'], {
+      ghRunner: runner,
+      remoteUrls,
+      timeoutMs: 25,
+    })
+
+    expect(result.authenticated).toBe(true)
+    expect(result.counts).toEqual({})
+    // Auth probe + pr list both went out.
+    expect(runner).toHaveBeenCalledTimes(2)
+  })
+
+  it('runGhWithTimeout aborts the signal and resolves undefined on timeout', async () => {
+    const runner = jest.fn(async (_args: string[], opts?: { signal?: AbortSignal }) => {
+      return new Promise<string>((_, reject) => {
+        opts?.signal?.addEventListener('abort', () => reject(new Error('aborted')))
+      })
+    })
+
+    const result = await runGhWithTimeout(runner, ['pr', 'list'], 20)
+    expect(result).toBeUndefined()
+    expect(runner).toHaveBeenCalled()
+  })
+
+  it('runGhWithTimeout returns the stdout when the call finishes before the deadline', async () => {
+    const runner = jest.fn(async () => '[]')
+    const result = await runGhWithTimeout(runner, ['pr', 'list'], 5000)
+    expect(result).toBe('[]')
   })
 
   it('issues one gh pr list per repo with a GitHub remote and records the count', async () => {

--- a/src/git/workspacePullRequestData.ts
+++ b/src/git/workspacePullRequestData.ts
@@ -10,6 +10,16 @@ import {
 } from './githubCli'
 
 /**
+ * Default per-call timeout for the workspace PR-count fetcher.
+ * Sized to land well under the 30s a user would tolerate for the
+ * whole overview to settle, while still leaving headroom for
+ * legitimately slow networks. A hung gh past this is treated as
+ * "no count available" — the surface drops the badge rather than
+ * spinning forever.
+ */
+export const WORKSPACE_PR_COUNT_TIMEOUT_MS = 5000
+
+/**
  * Open-PR counts for the workspace surface (#880). One `gh` invocation
  * per repo with a GitHub remote, cheap enough to fan out across a
  * dozen repos. Hidden entirely when `gh` is missing or unauthenticated
@@ -86,12 +96,48 @@ export function parseOpenPullRequestCount(json: string): number | undefined {
   return undefined
 }
 
+/**
+ * Race a single gh call against a timeout. If the timeout wins, abort
+ * the underlying process (so we don't leak a long-running gh) and
+ * resolve to `undefined` so the caller can drop the badge. Wraps the
+ * runner so a hung gh on any one repo can't stall the whole overview.
+ */
+export async function runGhWithTimeout(
+  runner: GhRunner,
+  args: string[],
+  timeoutMs: number
+): Promise<string | undefined> {
+  const controller = new AbortController()
+  let timer: NodeJS.Timeout | undefined
+  const timeout = new Promise<undefined>((resolve) => {
+    timer = setTimeout(() => {
+      controller.abort()
+      resolve(undefined)
+    }, timeoutMs)
+  })
+  try {
+    const result = await Promise.race([
+      runner(args, { signal: controller.signal }).then((stdout) => stdout),
+      timeout,
+    ])
+    return result
+  } catch {
+    return undefined
+  } finally {
+    if (timer) {
+      clearTimeout(timer)
+    }
+  }
+}
+
 async function fetchPullRequestCount(
   runner: GhRunner,
-  repository: GitHubRepository
+  repository: GitHubRepository,
+  timeoutMs: number
 ): Promise<number | undefined> {
-  try {
-    const out = await runner([
+  const out = await runGhWithTimeout(
+    runner,
+    [
       'pr',
       'list',
       '-R',
@@ -102,11 +148,13 @@ async function fetchPullRequestCount(
       'number',
       '--limit',
       '100',
-    ])
-    return parseOpenPullRequestCount(out)
-  } catch {
+    ],
+    timeoutMs
+  )
+  if (out === undefined) {
     return undefined
   }
+  return parseOpenPullRequestCount(out)
 }
 
 export type GetWorkspacePullRequestCountsOptions = {
@@ -116,6 +164,8 @@ export type GetWorkspacePullRequestCountsOptions = {
   remoteUrls?: ReadonlyMap<string, string>
   /** Maximum number of concurrent gh calls. Default 4. */
   concurrency?: number
+  /** Per-call timeout in ms. Default `WORKSPACE_PR_COUNT_TIMEOUT_MS`. */
+  timeoutMs?: number
 }
 
 async function mapWithConcurrency<T, U>(
@@ -147,6 +197,7 @@ export async function getWorkspacePullRequestCounts(
 
   const counts: Record<string, number> = {}
   const concurrency = Math.max(1, options.concurrency ?? 4)
+  const timeoutMs = options.timeoutMs ?? WORKSPACE_PR_COUNT_TIMEOUT_MS
 
   await mapWithConcurrency(repoPaths, concurrency, async (repoPath) => {
     const url = options.remoteUrls?.get(repoPath) ?? readOriginRemoteUrl(repoPath)
@@ -157,7 +208,7 @@ export async function getWorkspacePullRequestCounts(
     if (!repo) {
       return
     }
-    const count = await fetchPullRequestCount(runner, repo)
+    const count = await fetchPullRequestCount(runner, repo, timeoutMs)
     if (typeof count === 'number') {
       counts[repoPath] = count
     }


### PR DESCRIPTION
Closes the robustness gap I flagged after #1040 — one hung `gh pr list` could stall PR badges across the whole workspace overview.

## Summary

- `GhRunner` now accepts an optional `signal` via a `GhRunOptions` bag; the default execFile-backed runner forwards it so the underlying child process gets killed cleanly when the signal fires. Existing callsites are source-compatible (the options bag is optional).
- New `runGhWithTimeout(runner, args, timeoutMs)` races a single gh call against a `setTimeout` + `AbortController`. On timeout we abort the signal (execFile tears down the child) and resolve `undefined` so the surface drops the badge.
- `getWorkspacePullRequestCounts` wraps every per-repo call with the timeout (default 5000ms, configurable via `timeoutMs`). Concurrency-bounded runner caps total wall-time penalty at one timeout per worker.
- `runGhWithTimeout` is exported so future surfaces can reuse the same race-and-abort recipe.

## Commits

1. `feat(githubCli): forward AbortSignal through GhRunner` — type/runtime plumbing, source-compatible
2. `feat(workspace): per-call timeout + abort on gh PR-count fetch` — wrapper + opt + 5 tests

## Test plan

- [x] Lint + typecheck clean
- [x] Full Jest suite: 186 suites, 2369 passing, 7 skipped, 31 snapshots