### PR TITLE
feat(workspace): responsive column widths

### DIFF
--- a/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
+++ b/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
@@ -136,13 +136,6 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
             </Text>
           </Box>
         </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
-        </Box>
       </Box>
       <Box
         flexDirection="row"
@@ -211,13 +204,6 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
             </Text>
           </Box>
         </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
-        </Box>
       </Box>
       <Box
         flexDirection="row"
@@ -285,13 +271,6 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
               /tmp/lib
             </Text>
           </Box>
-        </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
         </Box>
       </Box>
     </Box>
@@ -446,13 +425,6 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
               /tmp/lib
             </Text>
           </Box>
-        </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
         </Box>
       </Box>
     </Box>
@@ -610,13 +582,6 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
             </Text>
           </Box>
         </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
-        </Box>
       </Box>
       <Box
         flexDirection="row"
@@ -685,13 +650,6 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
             </Text>
           </Box>
         </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
-        </Box>
       </Box>
       <Box
         flexDirection="row"
@@ -759,13 +717,6 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
               /tmp/lib
             </Text>
           </Box>
-        </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
         </Box>
       </Box>
     </Box>
@@ -910,23 +861,6 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
               2026-05-01
             </Text>
           </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              /tmp/coco
-            </Text>
-          </Box>
-        </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
         </Box>
       </Box>
       <Box
@@ -959,7 +893,7 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
               bold={false}
               dimColor={false}
             >
-              feature/landing
+              feature/la...
             </Text>
           </Box>
           <Box
@@ -984,24 +918,6 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
               2026-04-15
             </Text>
           </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              /tmp/docs
-            </Text>
-          </Box>
-        </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
         </Box>
       </Box>
       <Box
@@ -1059,24 +975,6 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
               —
             </Text>
           </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              /tmp/lib
-            </Text>
-          </Box>
-        </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
         </Box>
       </Box>
     </Box>
@@ -1232,13 +1130,6 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
             </Text>
           </Box>
         </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
-        </Box>
       </Box>
       <Box
         flexDirection="row"
@@ -1306,13 +1197,6 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
               /tmp/docs
             </Text>
           </Box>
-        </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
         </Box>
       </Box>
       <Box
@@ -1382,13 +1266,6 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
             </Text>
           </Box>
         </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
-        </Box>
       </Box>
     </Box>
   </Box>
@@ -1407,6 +1284,490 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
       color="yellow"
     >
       Refreshed 3 repos.
+    </Text>
+  </Box>
+</Box>
+`;
+
+exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — path drops out 1`] = `
+<Box
+  flexDirection="column"
+>
+  <Box
+    borderColor="cyan"
+    borderStyle="classic"
+    justifyContent="space-between"
+    paddingX={1}
+  >
+    <Text
+      bold={true}
+    >
+      coco workspace  roots: ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+      3/3 repos  ·  sort: Recent
+    </Text>
+  </Box>
+  <Box
+    flexDirection="row"
+  >
+    <Box
+      borderColor="cyan"
+      borderStyle="classic"
+      flexDirection="column"
+      flexShrink={0}
+      paddingX={1}
+      width={18}
+    >
+      <Text
+        bold={true}
+      >
+        Tabs *
+      </Text>
+      <Text
+        bold={true}
+      >
+        › All
+      </Text>
+      <Text>
+          Dirty
+      </Text>
+      <Text>
+          Behind
+      </Text>
+      <Text>
+          PRs
+      </Text>
+    </Box>
+    <Box
+      borderColor="cyan"
+      borderStyle="classic"
+      flexDirection="column"
+      flexGrow={1}
+      paddingX={1}
+    >
+      <Box
+        justifyContent="space-between"
+      >
+        <Text
+          bold={true}
+        >
+          Workspace *
+        </Text>
+        <Text
+          dimColor={true}
+        >
+          3 visible
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text
+          bold={true}
+        >
+          › 
+        </Text>
+        <Box
+          flexDirection="row"
+          flexShrink={1}
+          flexWrap="wrap"
+        >
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={true}
+              dimColor={false}
+            >
+              coco
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              dimColor={false}
+            >
+              main
+            </Text>
+          </Box>
+        </Box>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text
+          bold={false}
+        >
+            
+        </Text>
+        <Box
+          flexDirection="row"
+          flexShrink={1}
+          flexWrap="wrap"
+        >
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              docs
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              feature/lan...
+            </Text>
+          </Box>
+        </Box>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text
+          bold={false}
+        >
+            
+        </Text>
+        <Box
+          flexDirection="row"
+          flexShrink={1}
+          flexWrap="wrap"
+        >
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              lib
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              main
+            </Text>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  </Box>
+  <Box
+    borderColor="gray"
+    borderStyle="classic"
+    flexDirection="column"
+    paddingX={1}
+  >
+    <Text
+      dimColor={true}
+    >
+      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+    </Text>
+  </Box>
+</Box>
+`;
+
+exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns grow up to their caps 1`] = `
+<Box
+  flexDirection="column"
+>
+  <Box
+    borderColor="cyan"
+    borderStyle="classic"
+    justifyContent="space-between"
+    paddingX={1}
+  >
+    <Text
+      bold={true}
+    >
+      coco workspace  roots: ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+      3/3 repos  ·  sort: Recent
+    </Text>
+  </Box>
+  <Box
+    flexDirection="row"
+  >
+    <Box
+      borderColor="cyan"
+      borderStyle="classic"
+      flexDirection="column"
+      flexShrink={0}
+      paddingX={1}
+      width={18}
+    >
+      <Text
+        bold={true}
+      >
+        Tabs *
+      </Text>
+      <Text
+        bold={true}
+      >
+        › All
+      </Text>
+      <Text>
+          Dirty
+      </Text>
+      <Text>
+          Behind
+      </Text>
+      <Text>
+          PRs
+      </Text>
+    </Box>
+    <Box
+      borderColor="cyan"
+      borderStyle="classic"
+      flexDirection="column"
+      flexGrow={1}
+      paddingX={1}
+    >
+      <Box
+        justifyContent="space-between"
+      >
+        <Text
+          bold={true}
+        >
+          Workspace *
+        </Text>
+        <Text
+          dimColor={true}
+        >
+          3 visible
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text
+          bold={true}
+        >
+          › 
+        </Text>
+        <Box
+          flexDirection="row"
+          flexShrink={1}
+          flexWrap="wrap"
+        >
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={true}
+              dimColor={false}
+            >
+              coco
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              dimColor={false}
+            >
+              main
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              color="yellow"
+              dimColor={false}
+            >
+              ●2 ↑1
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              color="gray"
+              dimColor={false}
+            >
+              2026-05-01
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              color="gray"
+              dimColor={false}
+            >
+              /tmp/coco
+            </Text>
+          </Box>
+        </Box>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text
+          bold={false}
+        >
+            
+        </Text>
+        <Box
+          flexDirection="row"
+          flexShrink={1}
+          flexWrap="wrap"
+        >
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              docs
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              feature/landing
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="yellow"
+              dimColor={false}
+            >
+              ↓3
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              2026-04-15
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              /tmp/docs
+            </Text>
+          </Box>
+        </Box>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text
+          bold={false}
+        >
+            
+        </Text>
+        <Box
+          flexDirection="row"
+          flexShrink={1}
+          flexWrap="wrap"
+        >
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              lib
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              main
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              ·
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              —
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              /tmp/lib
+            </Text>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  </Box>
+  <Box
+    borderColor="gray"
+    borderStyle="classic"
+    flexDirection="column"
+    paddingX={1}
+  >
+    <Text
+      dimColor={true}
+    >
+      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -1643,13 +2004,6 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
             </Text>
           </Box>
         </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
-        </Box>
       </Box>
       <Box
         flexDirection="row"
@@ -1718,13 +2072,6 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
             </Text>
           </Box>
         </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
-        </Box>
       </Box>
       <Box
         flexDirection="row"
@@ -1792,13 +2139,6 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
               /tmp/lib
             </Text>
           </Box>
-        </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
         </Box>
       </Box>
     </Box>
@@ -1954,13 +2294,6 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
             </Text>
           </Box>
         </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
-        </Box>
       </Box>
       <Box
         flexDirection="row"
@@ -2029,13 +2362,6 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
             </Text>
           </Box>
         </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
-        </Box>
       </Box>
       <Box
         flexDirection="row"
@@ -2103,13 +2429,6 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
               /tmp/lib
             </Text>
           </Box>
-        </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
         </Box>
       </Box>
     </Box>
@@ -2287,13 +2606,6 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
             </Text>
           </Box>
         </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
-        </Box>
       </Box>
     </Box>
   </Box>
@@ -2448,13 +2760,6 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
             </Text>
           </Box>
         </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
-        </Box>
       </Box>
       <Box
         flexDirection="row"
@@ -2523,13 +2828,6 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
             </Text>
           </Box>
         </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
-        </Box>
       </Box>
       <Box
         flexDirection="row"
@@ -2597,13 +2895,6 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
               /tmp/lib
             </Text>
           </Box>
-        </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
         </Box>
       </Box>
     </Box>
@@ -2781,13 +3072,6 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
             </Text>
           </Box>
         </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
-        </Box>
       </Box>
     </Box>
   </Box>
@@ -2942,13 +3226,6 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
             </Text>
           </Box>
         </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
-        </Box>
       </Box>
       <Box
         flexDirection="row"
@@ -3017,13 +3294,6 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
             </Text>
           </Box>
         </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
-        </Box>
       </Box>
       <Box
         flexDirection="row"
@@ -3091,13 +3361,6 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
               /tmp/lib
             </Text>
           </Box>
-        </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
         </Box>
       </Box>
     </Box>
@@ -3589,13 +3852,6 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
             </Text>
           </Box>
         </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
-        </Box>
       </Box>
       <Box
         flexDirection="row"
@@ -3664,13 +3920,6 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
             </Text>
           </Box>
         </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
-        </Box>
       </Box>
       <Box
         flexDirection="row"
@@ -3738,13 +3987,6 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
               /tmp/lib
             </Text>
           </Box>
-        </Box>
-        <Box
-          flexShrink={0}
-        >
-          <Text
-            dimColor={true}
-          />
         </Box>
       </Box>
     </Box>

--- a/src/workstation/surfaces/workspace/render.test.ts
+++ b/src/workstation/surfaces/workspace/render.test.ts
@@ -1,6 +1,7 @@
 import { WorkspaceOverview, WorkspaceRepoSummary } from '../../../git/workspaceData'
 
 import {
+  assignWorkspaceColumnWidths,
   buildWorkspaceFooter,
   buildWorkspaceHeader,
   buildWorkspaceHelpRows,
@@ -140,6 +141,57 @@ describe('workspace render builders', () => {
     for (const expected of ['j', 'k', 'g', 'G', 's', '/', 'r', 'a', 'd', '?', 'q', 'enter', 'tab', 'esc']) {
       expect(allKeys).toContain(expected)
     }
+  })
+
+  describe('assignWorkspaceColumnWidths', () => {
+    it('drops the path column when it cannot fit the row budget', () => {
+      // All five minimums total 66 cells once gaps + cursor are
+      // included; budgets in [49, 68) drop path but keep date.
+      const widths = assignWorkspaceColumnWidths(58)
+      expect(widths.name).toBeDefined()
+      expect(widths.branch).toBeDefined()
+      expect(widths.status).toBeDefined()
+      expect(widths.date).toBeDefined()
+      expect(widths.path).toBeUndefined()
+    })
+
+    it('drops both path and date when very narrow', () => {
+      // Below ~49 cells, date also drops; status is the last
+      // non-essential to go before we're down to name + branch.
+      const widths = assignWorkspaceColumnWidths(42)
+      expect(widths.name).toBeDefined()
+      expect(widths.branch).toBeDefined()
+      expect(widths.status).toBeDefined()
+      expect(widths.date).toBeUndefined()
+      expect(widths.path).toBeUndefined()
+    })
+
+    it('keeps every column at standard width', () => {
+      const widths = assignWorkspaceColumnWidths(120)
+      expect(widths.name).toBeGreaterThanOrEqual(14)
+      expect(widths.branch).toBeGreaterThanOrEqual(12)
+      expect(widths.status).toBeGreaterThanOrEqual(8)
+      expect(widths.date).toBe(10)
+      expect(widths.path).toBeGreaterThanOrEqual(18)
+    })
+
+    it('respects per-column max caps when widening', () => {
+      const widths = assignWorkspaceColumnWidths(400)
+      expect(widths.name).toBeLessThanOrEqual(36)
+      expect(widths.branch).toBeLessThanOrEqual(28)
+      expect(widths.status).toBeLessThanOrEqual(16)
+      expect(widths.date).toBe(10)
+    })
+
+    it('returns the empty map when no column can fit', () => {
+      expect(assignWorkspaceColumnWidths(0)).toEqual({})
+    })
+
+    it('builds list rows with only the surviving columns at narrow widths', () => {
+      const rows = buildWorkspaceListRows(state, { width: 50 })
+      // Path drops below ~68 cells; expect <=4 columns per row.
+      expect(rows[0].columns.length).toBeLessThanOrEqual(4)
+    })
   })
 
   it('footer hint flips to the confirm-delete copy when pending', () => {

--- a/src/workstation/surfaces/workspace/render.ts
+++ b/src/workstation/surfaces/workspace/render.ts
@@ -41,13 +41,101 @@ export type WorkspaceSidebarTabRow = {
   disabled: boolean
 }
 
-const NAME_WIDTH = 28
-const BRANCH_WIDTH = 22
-const STATUS_WIDTH = 14
-const DATE_WIDTH = 11
-const PATH_WIDTH = 40
+/**
+ * Responsive column widths for the workspace row list.
+ *
+ * Columns in display order, paired with a minimum cell width and a
+ * growth weight. The cursor caret + per-cell separators are reserved
+ * by the layout helper, so the budget passed in here is purely the
+ * cell-content width.
+ *
+ * Drop priority on a narrow terminal: path → date → status → branch.
+ * Name always stays.
+ */
+export type WorkspaceColumnKey = 'name' | 'branch' | 'status' | 'date' | 'path'
 
-function formatStatusCell(repo: WorkspaceRepoSummary, ghAuthenticated?: boolean, prCount?: number): WorkspaceListColumn {
+type ColumnSpec = {
+  key: WorkspaceColumnKey
+  min: number
+  weight: number
+  max?: number
+}
+
+const COLUMN_SPECS: ColumnSpec[] = [
+  { key: 'name', min: 14, weight: 3, max: 36 },
+  { key: 'branch', min: 12, weight: 2, max: 28 },
+  { key: 'status', min: 8, weight: 1, max: 16 },
+  { key: 'date', min: 10, weight: 0, max: 10 },
+  { key: 'path', min: 18, weight: 3 },
+]
+
+/** Inter-cell gap reserved by the layout helper. */
+const COLUMN_GAP = 1
+/** Width of the cursor caret prefix ("› " or "  "). */
+const CURSOR_WIDTH = 2
+
+export type WorkspaceColumnWidths = Partial<Record<WorkspaceColumnKey, number>>
+
+/**
+ * Resolve per-column widths from a body budget. Drops columns from
+ * the tail when the budget can't fit their minimums; what survives
+ * gets a share of the remaining slack proportional to each spec's
+ * weight, capped at the column's `max`.
+ */
+export function assignWorkspaceColumnWidths(budget: number): WorkspaceColumnWidths {
+  const usable = Math.max(0, budget - CURSOR_WIDTH)
+  const kept: ColumnSpec[] = [...COLUMN_SPECS]
+  while (kept.length > 0) {
+    const minTotal = kept.reduce((acc, spec) => acc + spec.min, 0)
+    const gapTotal = Math.max(0, kept.length - 1) * COLUMN_GAP
+    if (minTotal + gapTotal <= usable) {
+      break
+    }
+    kept.pop()
+  }
+  if (kept.length === 0) {
+    return {}
+  }
+  const minTotal = kept.reduce((acc, spec) => acc + spec.min, 0)
+  const gapTotal = Math.max(0, kept.length - 1) * COLUMN_GAP
+  let slack = Math.max(0, usable - minTotal - gapTotal)
+  const totalWeight = kept.reduce((acc, spec) => acc + spec.weight, 0) || 1
+  const widths: WorkspaceColumnWidths = {}
+  // First pass: distribute slack proportionally to weight, respecting
+  // per-column max caps.
+  for (const spec of kept) {
+    const share = Math.floor((slack * spec.weight) / totalWeight)
+    const targetMax = spec.max ?? Number.POSITIVE_INFINITY
+    const grown = Math.min(spec.min + share, targetMax)
+    widths[spec.key] = grown
+  }
+  // Second pass: any unspent slack (due to caps or rounding) tries to
+  // land on the first uncapped column, otherwise drops on the floor.
+  const used = Object.values(widths).reduce((acc, val) => acc + (val ?? 0), 0)
+  slack = usable - used - gapTotal
+  if (slack > 0) {
+    for (const spec of kept) {
+      const max = spec.max ?? Number.POSITIVE_INFINITY
+      const current = widths[spec.key] ?? spec.min
+      if (current < max) {
+        const grow = Math.min(slack, max - current)
+        widths[spec.key] = current + grow
+        slack -= grow
+        if (slack <= 0) {
+          break
+        }
+      }
+    }
+  }
+  return widths
+}
+
+function formatStatusCell(
+  repo: WorkspaceRepoSummary,
+  width: number,
+  ghAuthenticated?: boolean,
+  prCount?: number
+): WorkspaceListColumn {
   const tokens: string[] = []
   if (repo.dirty > 0) {
     tokens.push(`●${repo.dirty}`)
@@ -63,43 +151,63 @@ function formatStatusCell(repo: WorkspaceRepoSummary, ghAuthenticated?: boolean,
   }
   const text = tokens.length === 0 ? '·' : tokens.join(' ')
   const tone: WorkspaceListColumn['tone'] = repo.behind > 0 || repo.dirty > 0 ? 'warn' : 'dim'
-  return { text: truncateCells(text, STATUS_WIDTH), tone }
+  return { text: truncateCells(text, width), tone }
 }
 
-function formatDateCell(repo: WorkspaceRepoSummary): WorkspaceListColumn {
+function formatDateCell(repo: WorkspaceRepoSummary, width: number): WorkspaceListColumn {
   const date = repo.lastCommit?.date
   if (!date) {
-    return { text: truncateCells('—', DATE_WIDTH), tone: 'dim' }
+    return { text: truncateCells('—', width), tone: 'dim' }
   }
   // Trim ISO date to YYYY-MM-DD — full precision is noise in the row.
-  return { text: truncateCells(date.slice(0, 10), DATE_WIDTH), tone: 'dim' }
+  return { text: truncateCells(date.slice(0, 10), width), tone: 'dim' }
 }
 
-export function buildWorkspaceListRows(state: WorkspaceState): WorkspaceListRow[] {
+export type BuildWorkspaceListRowsOptions = {
+  /** Available row width (before cursor + separators). Default 120. */
+  width?: number
+}
+
+const DEFAULT_ROW_WIDTH = 120
+
+export function buildWorkspaceListRows(
+  state: WorkspaceState,
+  options: BuildWorkspaceListRowsOptions = {}
+): WorkspaceListRow[] {
   const visible = selectVisibleRepos(state)
+  const widths = assignWorkspaceColumnWidths(options.width ?? DEFAULT_ROW_WIDTH)
   return visible.map((repo, index) => {
     const cursor = index === state.selectedIndex
     const nameTone: WorkspaceListColumn['tone'] = repo.error ? 'warn' : 'default'
-    const name: WorkspaceListColumn = {
-      text: truncateCells(repo.name, NAME_WIDTH),
-      primary: true,
-      tone: nameTone,
+    const columns: WorkspaceListColumn[] = []
+    if (widths.name !== undefined) {
+      columns.push({
+        text: truncateCells(repo.name, widths.name),
+        primary: true,
+        tone: nameTone,
+      })
     }
-    const branch: WorkspaceListColumn = {
-      text: truncateCells(repo.branch ?? '—', BRANCH_WIDTH),
-      tone: repo.branch ? 'default' : 'dim',
+    if (widths.branch !== undefined) {
+      columns.push({
+        text: truncateCells(repo.branch ?? '—', widths.branch),
+        tone: repo.branch ? 'default' : 'dim',
+      })
     }
-    const status = formatStatusCell(repo, state.ghAuthenticated, state.pullRequestCounts[repo.path])
-    const date = formatDateCell(repo)
-    const path: WorkspaceListColumn = {
-      text: truncatePathCells(repo.path, PATH_WIDTH),
-      tone: 'dim',
+    if (widths.status !== undefined) {
+      columns.push(
+        formatStatusCell(repo, widths.status, state.ghAuthenticated, state.pullRequestCounts[repo.path])
+      )
     }
-    return {
-      repo,
-      cursor,
-      columns: [name, branch, status, date, path],
+    if (widths.date !== undefined) {
+      columns.push(formatDateCell(repo, widths.date))
     }
+    if (widths.path !== undefined) {
+      columns.push({
+        text: truncatePathCells(repo.path, widths.path),
+        tone: 'dim',
+      })
+    }
+    return { repo, cursor, columns }
   })
 }
 

--- a/src/workstation/surfaces/workspace/view.test.ts
+++ b/src/workstation/surfaces/workspace/view.test.ts
@@ -216,6 +216,16 @@ describe('renderWorkspaceApp', () => {
     expect(tree).toMatchSnapshot()
   })
 
+  it('snapshots a very narrow terminal (60 columns) — path drops out', () => {
+    const tree = render(baseState(), { columns: 60 })
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('snapshots a wide terminal (200 columns) — columns grow up to their caps', () => {
+    const tree = render(baseState(), { columns: 200 })
+    expect(tree).toMatchSnapshot()
+  })
+
   it('snapshots the keymap help overlay when toggled on', () => {
     const state = applyWorkspaceAction(baseState(), { type: 'toggle-help' })
     const tree = render(state)

--- a/src/workstation/surfaces/workspace/view.ts
+++ b/src/workstation/surfaces/workspace/view.ts
@@ -10,7 +10,6 @@
 import type * as ReactTypes from 'react'
 
 import type { LogInkTheme } from '../../chrome/theme'
-import { truncateCells } from '../../chrome/text'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
 
 import type { WorkspaceComponents } from './runtime'
@@ -111,8 +110,7 @@ function renderSidebar(
 function renderListRow(
   deps: RenderWorkspaceAppDeps,
   row: ReturnType<typeof buildWorkspaceListRows>[number],
-  key: string,
-  width: number
+  key: string
 ): ReactTypes.ReactElement {
   const { React, ink, theme } = deps
   const { Box, Text } = ink
@@ -136,8 +134,7 @@ function renderListRow(
     Box,
     { key, flexDirection: 'row' },
     React.createElement(Text, { bold: row.cursor }, `${cursor} `),
-    React.createElement(Box, { flexDirection: 'row', flexShrink: 1, flexWrap: 'wrap' }, ...cells),
-    React.createElement(Box, { flexShrink: 0 }, React.createElement(Text, { dimColor: true }, truncateCells('', Math.max(0, width)))) // reserve trailing space
+    React.createElement(Box, { flexDirection: 'row', flexShrink: 1, flexWrap: 'wrap' }, ...cells)
   )
 }
 
@@ -148,7 +145,7 @@ function renderListBody(
   const { React, ink, state, theme } = deps
   const { Box, Text } = ink
   const focused = state.focus !== 'filter'
-  const rows = buildWorkspaceListRows(state)
+  const rows = buildWorkspaceListRows(state, { width })
   const visibleRepos = selectVisibleRepos(state)
   const filterChip = state.filter
     ? `  ·  filter: ${state.filter}`
@@ -170,7 +167,7 @@ function renderListBody(
             : 'No repos match the current filter.'
       ),
     ]
-    : rows.map((row, index) => renderListRow(deps, row, `row-${index}`, width))
+    : rows.map((row, index) => renderListRow(deps, row, `row-${index}`))
   return React.createElement(
     Box,
     {


### PR DESCRIPTION
Closes the last gap from the #1040 list. The fixed 28/22/14/11/40 column widths overflowed 80-col terminals; this PR makes the row layout responsive.

## Summary

- New `assignWorkspaceColumnWidths(budget)` helper takes the row's content budget and returns per-column widths. Specs live on each column (min / weight / optional max); the helper drops columns from the tail when minimums can't fit, then distributes leftover slack by weight up to each column's cap.
- Drop priority: `path → date → status → branch`. Name always stays.
- View layer passes the resolved row budget into `buildWorkspaceListRows` so the new helper drives the actual layout. Trailing-space hack removed — the variable-cell layout makes it unnecessary.
- Two new snapshots fix the breakpoints: a 60-col terminal (path drops, four columns visible) and a 200-col terminal (caps kick in).

Effect at common widths (terminal cols → row content budget after sidebar + borders):
- 60 cols → 38 cells → name + branch + status (3 cols)
- 80 cols → 54 cells → name + branch + status + date (4 cols)
- 100 cols → 74 cells → all 5 columns
- 200 cols → 174 cells → all 5 columns growing to caps

## Commits

1. `responsive column widths` — render layer + 6 new unit tests for the assignment helper
2. `thread the row budget through the view layer` — view wiring + 2 new snapshots + 12 updated snapshots reflecting the cleaner row shape

## Test plan

- [x] Lint + typecheck clean
- [x] Full Jest suite: 186 suites, 2377 passing, 7 skipped, 33 snapshots