### PR TITLE
feat(workstation): split workflow bindings and group help by category

### DIFF
--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -667,8 +667,22 @@ export function getLogInkPaletteExecuteEvents(
     case 'commandPalette':
       // Re-toggling closes; the dispatcher will close after execute anyway.
       return []
-    case 'workflowActions':
-      // Aggregate entry; individual workflows are surfaced separately.
+    case 'workflowDeleteBranch':
+    case 'workflowDeleteTag':
+    case 'workflowDropStash':
+    case 'workflowRemoveWorktree':
+    case 'workflowAbortOperation':
+    case 'workflowAiCommitSummary':
+    case 'workflowAiConflictHelp':
+    case 'viewCherryPick':
+    case 'viewRevert':
+    case 'viewReset':
+    case 'viewInteractiveRebase':
+    case 'viewCreateBranchHere':
+    case 'viewCreateTagHere':
+    case 'viewChangelog':
+      // Individual workflow entries; actual dispatch handled by the
+      // workflow action lookup below.
       return []
     case 'quit':
       if (hasUnsavedComposeDraft(state)) {

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -358,7 +358,10 @@ describe('log Ink keymap', () => {
     expect(helpText).toContain('z Ask to revert the selected file or hunk.')
     expect(helpText).toContain('e Edit the manual commit summary or body inline.')
     expect(helpText).toContain('E Open the current commit draft in $EDITOR (or $VISUAL) for full editing, write-back on save.')
-    expect(helpText).toContain('c Create a commit from staged changes with the current draft.')
+    // On history view, `c` is cherry-pick (the `c commit` binding is
+    // scoped to status/diff/compose where it actually fires).
+    expect(helpText).toContain('c Cherry-pick the cursored commit onto the current branch.')
+    expect(helpText).toContain('B Create a branch at the cursored commit (does not switch).')
     expect(helpText).toContain('q/ctrl+c Quit the interactive log.')
     expect(helpText).toContain('tab Move focus to the next panel.')
   })
@@ -523,8 +526,11 @@ describe('log Ink keymap', () => {
       keys: ':',
       label: 'commands',
     })
-    expect(palette.find((item) => item.id === 'workflowActions')).toMatchObject({
-      label: 'workflows',
+    expect(palette.find((item) => item.id === 'workflowDeleteBranch')).toMatchObject({
+      label: 'delete branch',
+    })
+    expect(palette.find((item) => item.id === 'workflowAiCommitSummary')).toMatchObject({
+      label: 'AI commit summary',
     })
   })
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -52,20 +52,58 @@ export type LogInkCommandId =
   | 'search'
   | 'toggleDiffViewMode'
   | 'toggleGraph'
-  | 'workflowActions'
+  | 'workflowDeleteBranch'
+  | 'workflowDeleteTag'
+  | 'workflowDropStash'
+  | 'workflowRemoveWorktree'
+  | 'workflowAbortOperation'
+  | 'workflowAiCommitSummary'
+  | 'workflowAiConflictHelp'
+  | 'viewCherryPick'
+  | 'viewRevert'
+  | 'viewReset'
+  | 'viewInteractiveRebase'
+  | 'viewCreateBranchHere'
+  | 'viewCreateTagHere'
+  | 'viewChangelog'
   | 'yankClipboard'
+
+export type LogInkBindingCategory =
+  | 'essentials'
+  | 'navigation'
+  | 'movement'
+  | 'view'
+  | 'edit'
+  | 'mutate'
+  | 'history-actions'
 
 export type LogInkKeyBinding = {
   id: LogInkCommandId
   keys: string[]
   label: string
   description: string
-  contexts: Array<'normal' | 'search' | LogInkFocus>
+  contexts: Array<'normal' | 'search' | LogInkFocus | LogInkView>
+}
+
+export type LogInkHelpSubgroup = {
+  category: LogInkBindingCategory
+  /** Display label for the subgroup heading (e.g. "Essentials"). */
+  title: string
+  bindings: LogInkKeyBinding[]
 }
 
 export type LogInkHelpSection = {
   title: string
   bindings: LogInkKeyBinding[]
+  /**
+   * Bindings grouped by category, ordered by how commonly users reach
+   * for each group. The legacy `bindings` field stays in place for
+   * back-compat — renderers that don't care about subgroups can keep
+   * iterating it. Subgroup ordering is fixed by the help section
+   * builder so the same section in the same view always renders in
+   * the same order.
+   */
+  subgroups: LogInkHelpSubgroup[]
 }
 
 export type LogInkCommandPaletteItem = {
@@ -368,7 +406,7 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     keys: ['c'],
     label: 'commit',
     description: 'Create a commit from staged changes with the current draft.',
-    contexts: ['commits'],
+    contexts: ['status', 'diff', 'compose'],
   },
   {
     id: 'cycleSort',
@@ -399,11 +437,108 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     contexts: ['normal'],
   },
   {
-    id: 'workflowActions',
-    keys: ['D', 'T', 'X', 'W', 'A', 'I', 'M'],
-    label: 'workflows',
-    description: 'Open workflow actions with confirmation for destructive or AI operations.',
+    id: 'workflowDeleteBranch',
+    keys: ['D'],
+    label: 'delete branch',
+    description: 'Delete the selected branch after confirmation.',
     contexts: ['normal', 'sidebar', 'detail'],
+  },
+  {
+    id: 'workflowDeleteTag',
+    keys: ['T'],
+    label: 'delete tag',
+    description: 'Delete the selected tag after confirmation.',
+    contexts: ['normal', 'sidebar', 'detail'],
+  },
+  {
+    id: 'workflowDropStash',
+    keys: ['X'],
+    label: 'drop stash',
+    description: 'Drop the selected stash after confirmation.',
+    contexts: ['normal', 'sidebar', 'detail'],
+  },
+  {
+    id: 'workflowRemoveWorktree',
+    keys: ['W'],
+    label: 'remove worktree',
+    description: 'Remove the selected linked worktree after confirmation.',
+    contexts: ['normal', 'sidebar', 'detail'],
+  },
+  {
+    id: 'workflowAbortOperation',
+    keys: ['A'],
+    label: 'abort operation',
+    description: 'Abort the in-progress Git operation after confirmation.',
+    contexts: ['normal', 'sidebar', 'detail'],
+  },
+  {
+    id: 'workflowAiCommitSummary',
+    keys: ['I'],
+    label: 'AI commit summary',
+    description: 'Summarize the selected commit with AI (token/cost awareness).',
+    contexts: ['normal', 'sidebar', 'detail'],
+  },
+  {
+    id: 'workflowAiConflictHelp',
+    keys: ['M'],
+    label: 'AI conflict help',
+    description: 'Explain conflicted files and suggest resolution steps with AI.',
+    contexts: ['normal', 'sidebar', 'detail'],
+  },
+  // ── History-view-only mutating bindings ───────────────────────────
+  // These keys are dispatched contextually in inkInput.ts when the
+  // user is on the history view. Documented as proper bindings here
+  // so they show up in the "This view (history)" help section. The
+  // descriptions match the workflow registry entries that actually
+  // execute when the keys fire.
+  {
+    id: 'viewCherryPick',
+    keys: ['c'],
+    label: 'cherry-pick',
+    description: 'Cherry-pick the cursored commit onto the current branch.',
+    contexts: ['history'],
+  },
+  {
+    id: 'viewRevert',
+    keys: ['R'],
+    label: 'revert commit',
+    description: 'Revert the cursored commit (adds an inverse commit on HEAD).',
+    contexts: ['history'],
+  },
+  {
+    id: 'viewReset',
+    keys: ['Z'],
+    label: 'reset to commit',
+    description: 'Move the branch tip to the cursored commit (prompts for soft/mixed/hard).',
+    contexts: ['history'],
+  },
+  {
+    id: 'viewInteractiveRebase',
+    keys: ['i'],
+    label: 'interactive rebase',
+    description: 'Start an interactive rebase from the cursored commit.',
+    contexts: ['history'],
+  },
+  {
+    id: 'viewCreateBranchHere',
+    keys: ['B'],
+    label: 'create branch here',
+    description: 'Create a branch at the cursored commit (does not switch).',
+    contexts: ['history'],
+  },
+  {
+    id: 'viewCreateTagHere',
+    keys: ['gT'],
+    label: 'create tag here',
+    description: 'Create a lightweight tag at the cursored commit.',
+    contexts: ['history'],
+  },
+  {
+    id: 'viewChangelog',
+    keys: ['L'],
+    label: 'changelog',
+    description: 'Generate a changelog from the current view context.',
+    contexts: ['history', 'branches'],
   },
   {
     id: 'quit',
@@ -508,7 +643,13 @@ export type LogInkFooterHints = {
 const GLOBAL_BINDING_IDS: LogInkCommandId[] = [
   'help',
   'commandPalette',
-  'workflowActions',
+  'workflowDeleteBranch',
+  'workflowDeleteTag',
+  'workflowDropStash',
+  'workflowRemoveWorktree',
+  'workflowAbortOperation',
+  'workflowAiCommitSummary',
+  'workflowAiConflictHelp',
   'focusNext',
   'focusPrevious',
   'refresh',
@@ -531,6 +672,163 @@ const GLOBAL_BINDING_IDS: LogInkCommandId[] = [
 ]
 
 const NORMAL_GLOBAL_HINTS = ['g jump', '< back', '? help', ': cmds', 'q quit']
+
+/**
+ * Per-binding category mapping. Used to subdivide the help overlay's
+ * Global and view sections into named clusters so users don't face a
+ * 30-row wall of keys with no visual structure.
+ *
+ * Bindings without an explicit entry default to `'movement'` (for
+ * commit-list / sidebar movement) or `'navigation'` (for globals).
+ * The categorization is intentionally coarse — too many groups
+ * fragments the help and forces users to remember a category
+ * taxonomy on top of the bindings themselves.
+ */
+const BINDING_CATEGORY_BY_ID: Partial<Record<LogInkCommandId, LogInkBindingCategory>> = {
+  // ── Essentials: most-used keys, surfaced first so newcomers see
+  //    them above everything else.
+  help: 'essentials',
+  commandPalette: 'essentials',
+  quit: 'essentials',
+  refresh: 'essentials',
+  navigateBack: 'essentials',
+  // ── Navigation: focus + view jumps. The g-prefix navigation chords
+  //    cluster here so users learn them as a set.
+  focusNext: 'navigation',
+  focusPrevious: 'navigation',
+  navigateHome: 'navigation',
+  navigateStatus: 'navigation',
+  navigateDiff: 'navigation',
+  navigateCompose: 'navigation',
+  navigateBranches: 'navigation',
+  navigateTags: 'navigation',
+  navigateStash: 'navigation',
+  navigateWorktrees: 'navigation',
+  navigatePullRequest: 'navigation',
+  navigatePullRequestTriage: 'navigation',
+  navigateIssues: 'navigation',
+  navigateConflicts: 'navigation',
+  navigateReflog: 'navigation',
+  navigateBisect: 'navigation',
+  navigateSubmodules: 'navigation',
+  // ── Movement: cursor movement + search navigation within a view.
+  moveUp: 'movement',
+  moveDown: 'movement',
+  pageUp: 'movement',
+  pageDown: 'movement',
+  moveToTop: 'movement',
+  moveToBottom: 'movement',
+  nextMatch: 'movement',
+  previousMatch: 'movement',
+  nextHunk: 'movement',
+  previousHunk: 'movement',
+  nextSidebarTab: 'movement',
+  previousSidebarTab: 'movement',
+  // ── View: visual toggles + search/filter that change what's shown
+  //    without mutating the repo.
+  search: 'view',
+  clearSearch: 'view',
+  toggleGraph: 'view',
+  toggleDiffViewMode: 'view',
+  markForCompare: 'view',
+  openSelected: 'view',
+  cycleSort: 'view',
+  yankClipboard: 'view',
+  // ── Edit: compose-surface authoring keys.
+  commit: 'edit',
+  editCommit: 'edit',
+  editCommitExternal: 'edit',
+  commitSplit: 'edit',
+  revertSelection: 'edit',
+  // ── Mutate: destructive / AI workflows that fire from anywhere
+  //    (hence the global confirmation gating).
+  workflowDeleteBranch: 'mutate',
+  workflowDeleteTag: 'mutate',
+  workflowDropStash: 'mutate',
+  workflowRemoveWorktree: 'mutate',
+  workflowAbortOperation: 'mutate',
+  workflowAiCommitSummary: 'mutate',
+  workflowAiConflictHelp: 'mutate',
+  // ── History actions: per-view-only mutations scoped to the history
+  //    surface. Distinct from the global mutate cluster so users see
+  //    them grouped under their actual context.
+  viewCherryPick: 'history-actions',
+  viewRevert: 'history-actions',
+  viewReset: 'history-actions',
+  viewInteractiveRebase: 'history-actions',
+  viewCreateBranchHere: 'history-actions',
+  viewCreateTagHere: 'history-actions',
+  viewChangelog: 'history-actions',
+}
+
+/**
+ * Display order + display title for each category in help sections.
+ * The order is "what users reach for most often, first" — essentials
+ * before everything, mutations last because they're confirmation-gated
+ * power moves rather than everyday operations.
+ */
+const CATEGORY_ORDER: LogInkBindingCategory[] = [
+  'essentials',
+  'navigation',
+  'movement',
+  'view',
+  'edit',
+  'history-actions',
+  'mutate',
+]
+
+const CATEGORY_TITLES: Record<LogInkBindingCategory, string> = {
+  essentials: 'Essentials',
+  navigation: 'Navigate',
+  movement: 'Move',
+  view: 'View & search',
+  edit: 'Edit & compose',
+  'history-actions': 'History actions',
+  mutate: 'Workflows (confirm)',
+}
+
+function categorizeBinding(
+  binding: LogInkKeyBinding,
+  isGlobal: boolean
+): LogInkBindingCategory {
+  const explicit = BINDING_CATEGORY_BY_ID[binding.id]
+  if (explicit) return explicit
+  // Sensible defaults for any binding that hasn't been categorized
+  // yet — globals fall into navigation, view-scoped fall into
+  // movement. New bindings stay reachable in the help without
+  // requiring a category entry up front.
+  return isGlobal ? 'navigation' : 'movement'
+}
+
+function buildSubgroups(
+  bindings: LogInkKeyBinding[],
+  isGlobal: boolean
+): LogInkHelpSubgroup[] {
+  const buckets = new Map<LogInkBindingCategory, LogInkKeyBinding[]>()
+  for (const binding of bindings) {
+    const category = categorizeBinding(binding, isGlobal)
+    const bucket = buckets.get(category)
+    if (bucket) {
+      bucket.push(binding)
+    } else {
+      buckets.set(category, [binding])
+    }
+  }
+
+  const subgroups: LogInkHelpSubgroup[] = []
+  for (const category of CATEGORY_ORDER) {
+    const bucketBindings = buckets.get(category)
+    if (bucketBindings && bucketBindings.length > 0) {
+      subgroups.push({
+        category,
+        title: CATEGORY_TITLES[category],
+        bindings: bucketBindings,
+      })
+    }
+  }
+
+  return subgroups
+}
 
 export function formatBindingKeys(binding: LogInkKeyBinding): string {
   return binding.keys.join('/')
@@ -929,6 +1227,10 @@ function bindingMatchesViewContext(
     return true
   }
 
+  if (binding.contexts.includes(options.activeView)) {
+    return true
+  }
+
   if (binding.contexts.includes('normal')) {
     return true
   }
@@ -958,8 +1260,16 @@ export function getLogInkHelpSections(
   )
 
   return [
-    { title: 'Global', bindings: globals },
-    { title: `This view (${options.activeView})`, bindings: viewBindings },
+    {
+      title: 'Global',
+      bindings: globals,
+      subgroups: buildSubgroups(globals, true),
+    },
+    {
+      title: `This view (${options.activeView})`,
+      bindings: viewBindings,
+      subgroups: buildSubgroups(viewBindings, false),
+    },
   ]
 }
 

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -63,9 +63,9 @@ import { getLfsAttributeStatus } from '../../git/lfsAttributes'
 import { getSubmoduleOverview } from '../../git/submoduleData'
 import { createManualCommit, formatCommitComposeMessage } from '../../commands/log/commitCompose'
 import {
-  runCommitDraftWorkflow,
-  runCommitSplitApplyWorkflow,
-  runCommitSplitPlanWorkflow,
+    runCommitDraftWorkflow,
+    runCommitSplitApplyWorkflow,
+    runCommitSplitPlanWorkflow,
 } from '../../git/commitWorkflowActions'
 import { runChangelogTextWorkflow } from '../../git/aiActions'
 import {
@@ -95,16 +95,144 @@ import { formatSplitApplySuccess } from '../chrome/postApplyHints'
 import { SPINNER_TICK_MS } from '../chrome/spinner'
 import { createInitialContextStatus, createRepoFrameRuntime } from './repoFrameFactory'
 import {
-  resolveCommitDiffDrillInTarget,
-  resolveSubmoduleViewDrillInTarget,
+    resolveCommitDiffDrillInTarget,
+    resolveSubmoduleViewDrillInTarget,
 } from './repoFrameDrillIn'
 import {
-  getActiveRepoFrameRuntime,
-  syncRepoStackRuntimes,
-  updateRepoFrameRuntime,
-  type RepoFrameRuntime,
-  type RepoStackRuntimes,
+    getActiveRepoFrameRuntime,
+    syncRepoStackRuntimes,
+    updateRepoFrameRuntime,
+    type RepoFrameRuntime,
+    type RepoStackRuntimes,
 } from './repoStackRuntime'
+import { getSavedDiffViewMode, saveDiffViewMode } from '../chrome/diffViewModePersistence'
+import { getSavedSidebarTab, saveSidebarTab } from '../chrome/sidebarPersistence'
+import {
+    PromotedSelectionsSnapshot,
+    rectifyPromotedSelectionIndex,
+} from '../chrome/selectionRectify'
+import {
+    LogInkRefreshWatcher,
+    createRefreshWatcher,
+} from '../chrome/refreshWatcher'
+import {
+    LOG_INK_DEFAULT_COLUMNS,
+    LOG_INK_DEFAULT_ROWS,
+    LOG_INK_MIN_COLUMNS,
+    LOG_INK_MIN_ROWS,
+    getLogInkLayout,
+} from '../chrome/layout'
+import { sortBranches, sortTags } from '../chrome/sorting'
+import { IDLE_TIPS_GRACE_MS, IDLE_TIPS_INTERVAL_MS, pickIdleTip } from '../chrome/idleTips'
+import {
+    LogInkState,
+    applyLogInkAction,
+    createLogInkState,
+    getSelectedInkCommit,
+} from '../../commands/log/inkViewModel'
+import { getGitOperationOverview } from '../../git/operationData'
+import { openProviderUrl } from '../../git/providerActions'
+import { getProviderOverview } from '../../git/providerData'
+import {
+    checkoutBranch,
+    createBranch,
+    deleteBranch,
+    fetchBranch,
+    fetchRemotes,
+    pullBranch,
+    pullCurrentBranch,
+    pushBranch,
+    pushCurrentBranch,
+    renameBranch,
+    setUpstream,
+} from '../../git/branchActions'
+import { createLightweightTag, deleteLocalTag, deleteRemoteTag, pushTag } from '../../git/tagActions'
+import {
+    ClipboardRunner,
+    ResetMode,
+    checkoutFileFromCommit,
+    cherryPickCommit,
+    createBranchFromCommit,
+    createTagAtCommit,
+    defaultClipboardRunner,
+    defaultOpenUrlRunner,
+    isResetMode,
+    resetToCommit,
+    revertCommit,
+    startInteractiveRebase,
+} from '../../git/historyActions'
+import { applyStash, checkoutFileFromStash, createStash, dropStash, popStash } from '../../git/stashActions'
+import { ApplyHunkTarget, applyHunkPatch } from '../../git/hunkActions'
+import { removeWorktree, removeWorktreeAndBranch } from '../../git/worktreeActions'
+import { abortOperation, continueOperation, resolveConflictOurs, resolveConflictTheirs, stageConflictResolved } from '../../git/operationActions'
+import { getIssueDetail } from '../../git/issueDetailData'
+import { getIssueList } from '../../git/issuesListData'
+import {
+    addIssueAssignee,
+    addIssueLabel,
+    closeIssue,
+    commentIssue,
+    reopenIssue,
+} from '../../git/issueActions'
+import { getPullRequestDetail } from '../../git/pullRequestDetailData'
+import { getPullRequestOverview } from '../../git/pullRequestData'
+import { getPullRequestList } from '../../git/pullRequestListData'
+import { clearGitHubListCache } from '../../git/githubListCache'
+import {
+    issueFilterForPreset,
+    pullRequestFilterForPreset,
+} from '../../git/triageFilterPresets'
+import {
+    addPullRequestAssignee,
+    addPullRequestLabel,
+    approvePullRequest,
+    approvePullRequestByNumber,
+    closePullRequest,
+    closePullRequestByNumber,
+    commentPullRequest,
+    commentPullRequestByNumber,
+    createPullRequest,
+    isPullRequestMergeStrategy,
+    mergePullRequest,
+    mergePullRequestByNumber,
+    requestChangesPullRequest,
+    requestChangesPullRequestByNumber,
+} from '../../git/pullRequestActions'
+import { runPullRequestBodyWorkflow } from '../../git/aiActions'
+import {
+    findStashFileForOffset,
+    getStashCommitHashes,
+    getStashDiff,
+    getStashOverview,
+    parseStashDiffFiles,
+} from '../../git/stashData'
+import {
+    revertFile,
+    stageAllFiles,
+    stageFile,
+    unstageAllFiles,
+    unstageFile,
+} from '../../git/statusActions'
+import {
+    applyStatusFilterMask,
+    flattenWorktreeGroups,
+    getWorktreeOverview,
+    groupWorktreeFiles,
+} from '../../git/statusData'
+import {
+    WorktreeHunkOverview,
+    getWorktreeHunks,
+    revertHunk,
+    stageHunk,
+    unstageHunk,
+} from '../../git/statusHunks'
+import { getBisectCompletion, getBisectStatus } from '../../git/bisectData'
+import { bisectBad, bisectGood, bisectReset, bisectRun, bisectSkip, bisectStart, extractBisectRemainingHint } from '../../git/bisectActions'
+import { getCompareDiff } from '../../git/compareData'
+import { getReflogOverview } from '../../git/reflogData'
+import { getTagOverview } from '../../git/tagData'
+import { getWorktreeListOverview } from '../../git/worktreeData'
+import { WorktreeFileDiff, getWorktreeFileDiff } from '../../git/worktreeDiffData'
 
 
 async function safe<T>(promise: Promise<T>): Promise<T | undefined> {
@@ -208,134 +336,6 @@ function loadLogInkContextEntries(git: SimpleGit): Array<{
     },
   ]
 }
-import { getSavedDiffViewMode, saveDiffViewMode } from '../chrome/diffViewModePersistence'
-import { getSavedSidebarTab, saveSidebarTab } from '../chrome/sidebarPersistence'
-import {
-    PromotedSelectionsSnapshot,
-    rectifyPromotedSelectionIndex,
-} from '../chrome/selectionRectify'
-import {
-    LogInkRefreshWatcher,
-    createRefreshWatcher,
-} from '../chrome/refreshWatcher'
-import {
-    LOG_INK_DEFAULT_COLUMNS,
-    LOG_INK_DEFAULT_ROWS,
-    LOG_INK_MIN_COLUMNS,
-    LOG_INK_MIN_ROWS,
-    getLogInkLayout,
-} from '../chrome/layout'
-import { sortBranches, sortTags } from '../chrome/sorting'
-import { IDLE_TIPS_GRACE_MS, IDLE_TIPS_INTERVAL_MS, pickIdleTip } from '../chrome/idleTips'
-import {
-    LogInkState,
-    applyLogInkAction,
-    createLogInkState,
-    getSelectedInkCommit,
-} from '../../commands/log/inkViewModel'
-import { getGitOperationOverview } from '../../git/operationData'
-import { openProviderUrl } from '../../git/providerActions'
-import { getProviderOverview } from '../../git/providerData'
-import {
-    checkoutBranch,
-    createBranch,
-    deleteBranch,
-    fetchBranch,
-    fetchRemotes,
-    pullBranch,
-    pullCurrentBranch,
-    pushBranch,
-    pushCurrentBranch,
-    renameBranch,
-    setUpstream,
-} from '../../git/branchActions'
-import { createLightweightTag, deleteLocalTag, deleteRemoteTag, pushTag } from '../../git/tagActions'
-import {
-    ClipboardRunner,
-    ResetMode,
-    checkoutFileFromCommit,
-    cherryPickCommit,
-    createBranchFromCommit,
-    createTagAtCommit,
-    defaultClipboardRunner,
-    defaultOpenUrlRunner,
-    isResetMode,
-    resetToCommit,
-    revertCommit,
-    startInteractiveRebase,
-} from '../../git/historyActions'
-import { applyStash, checkoutFileFromStash, createStash, dropStash, popStash } from '../../git/stashActions'
-import { ApplyHunkTarget, applyHunkPatch } from '../../git/hunkActions'
-import { removeWorktree, removeWorktreeAndBranch } from '../../git/worktreeActions'
-import { abortOperation, continueOperation, resolveConflictOurs, resolveConflictTheirs, stageConflictResolved } from '../../git/operationActions'
-import { getIssueDetail } from '../../git/issueDetailData'
-import { getIssueList } from '../../git/issuesListData'
-import {
-  addIssueAssignee,
-  addIssueLabel,
-  closeIssue,
-  commentIssue,
-  reopenIssue,
-} from '../../git/issueActions'
-import { getPullRequestDetail } from '../../git/pullRequestDetailData'
-import { getPullRequestOverview } from '../../git/pullRequestData'
-import { getPullRequestList } from '../../git/pullRequestListData'
-import { clearGitHubListCache } from '../../git/githubListCache'
-import {
-  issueFilterForPreset,
-  pullRequestFilterForPreset,
-} from '../../git/triageFilterPresets'
-import {
-    addPullRequestAssignee,
-    addPullRequestLabel,
-    approvePullRequest,
-    approvePullRequestByNumber,
-    closePullRequest,
-    closePullRequestByNumber,
-    commentPullRequest,
-    commentPullRequestByNumber,
-    createPullRequest,
-    isPullRequestMergeStrategy,
-    mergePullRequest,
-    mergePullRequestByNumber,
-    requestChangesPullRequest,
-    requestChangesPullRequestByNumber,
-} from '../../git/pullRequestActions'
-import { runPullRequestBodyWorkflow } from '../../git/aiActions'
-import {
-    findStashFileForOffset,
-    getStashCommitHashes,
-    getStashDiff,
-    getStashOverview,
-    parseStashDiffFiles,
-} from '../../git/stashData'
-import {
-    revertFile,
-    stageAllFiles,
-    stageFile,
-    unstageAllFiles,
-    unstageFile,
-} from '../../git/statusActions'
-import {
-    applyStatusFilterMask,
-    flattenWorktreeGroups,
-    getWorktreeOverview,
-    groupWorktreeFiles,
-} from '../../git/statusData'
-import {
-    WorktreeHunkOverview,
-    getWorktreeHunks,
-    revertHunk,
-    stageHunk,
-    unstageHunk,
-} from '../../git/statusHunks'
-import { getBisectCompletion, getBisectStatus } from '../../git/bisectData'
-import { bisectBad, bisectGood, bisectReset, bisectRun, bisectSkip, bisectStart, extractBisectRemainingHint } from '../../git/bisectActions'
-import { getCompareDiff } from '../../git/compareData'
-import { getReflogOverview } from '../../git/reflogData'
-import { getTagOverview } from '../../git/tagData'
-import { getWorktreeListOverview } from '../../git/worktreeData'
-import { WorktreeFileDiff, getWorktreeFileDiff } from '../../git/worktreeDiffData'
 // Entry-point types (LogInkStreams, LogInkOptions) and the orchestration
 // types (DynamicImport, LogInkRuntime) stay in inkRuntime.ts since they're
 // only needed by startInkInteractiveLog.
@@ -348,8 +348,8 @@ import type { LogArgv } from '../../commands/log/config'
 // LogInkState filter-mode shape.
 import { matchesPromotedFilter } from '../runtime/promotedFilter'
 import {
-  buildLoadedHashSet,
-  resolveCursorSyncDecision,
+    buildLoadedHashSet,
+    resolveCursorSyncDecision,
 } from './cursorSyncResolver'
 
 // Chrome + overlay + dispatcher renderers extracted in phase 5a.7. The
@@ -4554,7 +4554,8 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         layout.detailWidth,
         layout.inspectorTabbed,
         theme,
-        layout.inspectorRailed
+        layout.inspectorRailed,
+        layout.bodyRows
       )
     ),
     renderFooter(h, { Box, Text }, state, context, theme, idleTip, spinnerFrame)

--- a/src/workstation/runtime/detailPanel.ts
+++ b/src/workstation/runtime/detailPanel.ts
@@ -17,30 +17,30 @@ import type * as ReactTypes from 'react'
 import type { LogInkContextStatus } from '../chrome/context'
 import type { LogInkTheme } from '../chrome/theme'
 import type {
-  GitCommitDetail,
-  GitCommitFilePreview,
+    GitCommitDetail,
+    GitCommitFilePreview,
 } from '../../commands/log/data'
 import { getSelectedInkCommit } from '../../commands/log/inkViewModel'
 import type { LogInkState } from '../../commands/log/inkViewModel'
 import { focusBorderColor, panelTitle } from './utils'
 import {
-  renderBranchPreviewPanel,
-  renderCommitDiffDetail,
-  renderCommitPanel,
-  renderComposeContextPanel,
-  renderHistoryInspector,
-  renderIssueTriagePreviewPanel,
-  renderPullRequestTriagePreviewPanel,
-  renderStashPreviewPanel,
-  renderSubmodulePreviewPanel,
-  renderTagPreviewPanel,
+    renderBranchPreviewPanel,
+    renderCommitDiffDetail,
+    renderCommitPanel,
+    renderComposeContextPanel,
+    renderHistoryInspector,
+    renderIssueTriagePreviewPanel,
+    renderPullRequestTriagePreviewPanel,
+    renderStashPreviewPanel,
+    renderSubmodulePreviewPanel,
+    renderTagPreviewPanel,
 } from '../surfaces/detail'
 import {
-  renderChordOverlay,
-  renderCommandPalette,
-  renderConfirmationPanel,
-  renderHelpPanel,
-  renderInputPromptPanel,
+    renderChordOverlay,
+    renderCommandPalette,
+    renderConfirmationPanel,
+    renderHelpPanel,
+    renderInputPromptPanel,
 } from './overlays'
 import type { LogInkComponents, LogInkContext } from './types'
 
@@ -99,7 +99,8 @@ export function renderDetailPanel(
   width: number,
   tabbed: boolean,
   theme: LogInkTheme,
-  railed: boolean = false
+  railed: boolean = false,
+  bodyRows: number = 0
 ): ReactTypes.ReactElement {
   const focused = state.focus === 'detail'
 
@@ -108,7 +109,7 @@ export function renderDetailPanel(
   // via the help-overlay layout branch — and railing those would
   // defeat their whole purpose (the user is reading them).
   if (state.showHelp) {
-    return renderHelpPanel(h, components, state, width, theme, focused)
+    return renderHelpPanel(h, components, state, width, theme, focused, bodyRows)
   }
 
   if (state.showCommandPalette) {

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -21,11 +21,11 @@ import { pickSpinnerFrame } from '../chrome/spinner'
 import { truncateCells } from '../chrome/text'
 import type { LogInkTheme } from '../chrome/theme'
 import {
-  filterLogInkPaletteCommands,
-  formatBindingKeys,
-  getLogInkChordContinuations,
-  getLogInkHelpSections,
-  getLogInkPaletteCommands,
+    filterLogInkPaletteCommands,
+    formatBindingKeys,
+    getLogInkChordContinuations,
+    getLogInkHelpSections,
+    getLogInkPaletteCommands,
 } from '../../commands/log/inkKeymap'
 import type { LogInkState } from '../../commands/log/inkViewModel'
 import { getLogInkWorkflowActionById } from '../../commands/log/inkWorkflows'
@@ -232,7 +232,8 @@ export function renderHelpPanel(
   state: LogInkState,
   width: number,
   theme: LogInkTheme,
-  focused: boolean
+  focused: boolean,
+  bodyRows: number = 0
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
 
@@ -248,19 +249,39 @@ export function renderHelpPanel(
   for (const section of sections) {
     body.push(h(Text, { key: `${section.title}-spacer` }, ''))
     body.push(h(Text, { bold: true, key: section.title }, section.title))
-    section.bindings.forEach((binding) => {
-      body.push(h(Text, { key: `${section.title}:${binding.id}` },
-        truncateCells(`${formatBindingKeys(binding).padEnd(14)} ${binding.description}`, width - 4)
-      ))
+    section.subgroups.forEach((subgroup, subgroupIndex) => {
+      // Dim subgroup heading; first subgroup follows the section
+      // title directly so we skip the leading spacer to keep the
+      // visual hierarchy tight (section title → subgroup → bindings).
+      if (subgroupIndex > 0) {
+        body.push(h(Text, { key: `${section.title}:${subgroup.category}:spacer` }, ''))
+      }
+      body.push(h(Text, {
+        dimColor: true,
+        key: `${section.title}:${subgroup.category}`,
+      }, `  ${subgroup.title}`))
+      subgroup.bindings.forEach((binding) => {
+        body.push(h(Text, { key: `${section.title}:${subgroup.category}:${binding.id}` },
+          truncateCells(`  ${formatBindingKeys(binding).padEnd(12)} ${binding.description}`, width - 4)
+        ))
+      })
     })
   }
+
+  // Reserve rows for: title (1), border (2), padding (0). The "more
+  // above" / "more below" hints take 1 row each when present and are
+  // accounted for inside the window calculation below. When no
+  // bodyRows is provided, fall back to rendering everything (legacy
+  // path; tests pass undefined).
+  const titleAndChromeRows = 3
+  const visibleRows = bodyRows > 0
+    ? Math.max(4, bodyRows - titleAndChromeRows)
+    : body.length
 
   // Clamp the offset against actual content length. The reducer
   // only floor-clamps at 0; here we ceiling-clamp so j past EOF
   // sticks at the last row rather than scrolling into emptiness.
-  // Reserve one row at the bottom so the user can always see the
-  // tail of the last section.
-  const maxOffset = Math.max(0, body.length - 1)
+  const maxOffset = Math.max(0, body.length - visibleRows)
   const offset = Math.min(state.helpScrollOffset, maxOffset)
 
   const children: ReactTypes.ReactNode[] = [
@@ -271,10 +292,21 @@ export function renderHelpPanel(
   // matches the rest of the chrome's "metadata" voice and avoids
   // stealing attention from the bindings themselves.
   if (offset > 0) {
-    children.push(h(Text, { key: 'more-above', dimColor: true }, '↑ more above'))
+    children.push(h(Text, { key: 'more-above', dimColor: true }, '↑ more above (j/k or ↑/↓ to scroll)'))
   }
 
-  children.push(...body.slice(offset))
+  // Reserve a row each for the visible "more above" / "more below"
+  // hints so they don't push body content off-screen.
+  let windowSize = visibleRows
+  if (offset > 0) windowSize -= 1
+  const hasMoreBelow = offset + windowSize < body.length
+  if (hasMoreBelow) windowSize -= 1
+
+  children.push(...body.slice(offset, offset + windowSize))
+
+  if (hasMoreBelow) {
+    children.push(h(Text, { key: 'more-below', dimColor: true }, '↓ more below (j/k or ↑/↓ to scroll)'))
+  }
 
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),


### PR DESCRIPTION
Splits the catch-all `workflowActions` keymap binding into per-key bindings and adds subgroup categories to the help overlay so capital-letter workflow keys self-describe instead of hiding behind a generic "workflows" label.

## Why

The pre-change help overlay listed:

```
D/T/X/W/A/I/M    workflows    Open workflow actions with confirmation for...
```

Users couldn't tell what `D` did vs `T` vs `W` without trying each one. The 50-key flat help list also didn't differentiate between movement keys, view-switching keys, and destructive workflows — so scanning the overlay didn't translate to "what can I do right now."

## What

**`inkKeymap.ts`**
- Replace the `workflowActions` catch-all with 7 dedicated workflow bindings: `workflowDeleteBranch`, `workflowDeleteTag`, `workflowDropStash`, `workflowRemoveWorktree`, `workflowAbortOperation`, `workflowAiCommitSummary`, `workflowAiConflictHelp` — each with its own description and context list.
- Add 7 view-launch bindings: `viewCherryPick`, `viewRevert`, `viewReset`, `viewInteractiveRebase`, `viewCreateBranchHere`, `viewCreateTagHere`, `viewChangelog`.
- Introduce `LogInkBindingCategory` (`essentials | navigation | movement | view | edit | mutate | history-actions`) and `LogInkHelpSubgroup` so help sections group bindings under headings.
- Contexts can now reference `LogInkView` (`status`, `diff`, `compose`) in addition to focus regions. The `c` commit binding moves to the views where users actually commit.

**`overlays.ts`**
- `renderHelpPanel` takes `bodyRows` and windows the help body correctly. Pre-fix, the offset clamp reserved a single row, so `j` past EOF stuck *before* the last entry. Now the entire body is reachable.
- Subgroup headings render dimmed under the section title so the hierarchy reads as: section title → subgroup → bindings.

**`app.ts`, `detailPanel.ts`, `inkInput.ts`**
- Thread the new binding ids through input dispatch and detail-panel hint rendering.

**`inkKeymap.test.ts`**
- Updated for the new binding shape and subgroup grouping.

## Verified

- `npm run lint` clean
- 2351 tests pass (was 2240; the +111 is from the workspace feature merge that landed between branches)
- Stash applied cleanly onto current main despite predating the workspace + security tuning merges

## Note

This branch was originally `feat/improve-help` but the work lived as uncommitted WIP — when the audit + security PRs landed, the original branch ended up behind main and the WIP was preserved in a stash. This branch (`feat/improve-help-rebased`) replays the stash on top of current main as a clean commit.
