### PR TITLE
feat(workspace): last-commit subject in rows

### DIFF
--- a/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
+++ b/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
@@ -112,7 +112,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
               color="yellow"
               dimColor={false}
             >
-              ●2 ↑1 pr4
+              ●2 ↑1...
             </Text>
           </Box>
           <Box
@@ -123,6 +123,15 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
               dimColor={false}
             >
               2026-05-01
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              dimColor={false}
+            >
+              feat: thing
             </Text>
           </Box>
           <Box
@@ -167,7 +176,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
               bold={false}
               dimColor={false}
             >
-              feature/landing
+              feature/la...
             </Text>
           </Box>
           <Box
@@ -190,6 +199,16 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
               dimColor={true}
             >
               2026-04-15
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              wip
             </Text>
           </Box>
           <Box
@@ -247,6 +266,17 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
               dimColor={true}
             >
               ·
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              —
             </Text>
           </Box>
           <Box
@@ -422,6 +452,16 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
               color="gray"
               dimColor={false}
             >
+              —
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              color="gray"
+              dimColor={false}
+            >
               /tmp/lib
             </Text>
           </Box>
@@ -575,6 +615,15 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
             marginRight={1}
           >
             <Text
+              dimColor={false}
+            >
+              feat: thing
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
               color="gray"
               dimColor={false}
             >
@@ -613,7 +662,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
               bold={false}
               dimColor={false}
             >
-              feature/landing
+              feature/la...
             </Text>
           </Box>
           <Box
@@ -636,6 +685,16 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
               dimColor={true}
             >
               2026-04-15
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              wip
             </Text>
           </Box>
           <Box
@@ -693,6 +752,17 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
               dimColor={true}
             >
               ·
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              —
             </Text>
           </Box>
           <Box
@@ -1123,6 +1193,15 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
             marginRight={1}
           >
             <Text
+              dimColor={false}
+            >
+              feat: thing
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
               color="gray"
               dimColor={false}
             >
@@ -1161,7 +1240,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
               bold={false}
               dimColor={false}
             >
-              feature/landing
+              feature/la...
             </Text>
           </Box>
           <Box
@@ -1184,6 +1263,16 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
               dimColor={true}
             >
               2026-04-15
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              wip
             </Text>
           </Box>
           <Box
@@ -1241,6 +1330,17 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
               dimColor={true}
             >
               ·
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              —
             </Text>
           </Box>
           <Box
@@ -1612,6 +1712,15 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
             marginRight={1}
           >
             <Text
+              dimColor={false}
+            >
+              feat: thing
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
               color="gray"
               dimColor={false}
             >
@@ -1680,6 +1789,16 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
           >
             <Text
               bold={false}
+              dimColor={false}
+            >
+              wip
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
               color="gray"
               dimColor={true}
             >
@@ -1730,6 +1849,17 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
               dimColor={true}
             >
               ·
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              —
             </Text>
           </Box>
           <Box
@@ -1997,6 +2127,15 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
             marginRight={1}
           >
             <Text
+              dimColor={false}
+            >
+              feat: thing
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
               color="gray"
               dimColor={false}
             >
@@ -2035,7 +2174,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
               bold={false}
               dimColor={false}
             >
-              feature/landing
+              feature/la...
             </Text>
           </Box>
           <Box
@@ -2058,6 +2197,16 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
               dimColor={true}
             >
               2026-04-15
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              wip
             </Text>
           </Box>
           <Box
@@ -2115,6 +2264,17 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
               dimColor={true}
             >
               ·
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              —
             </Text>
           </Box>
           <Box
@@ -2287,6 +2447,15 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
             marginRight={1}
           >
             <Text
+              dimColor={false}
+            >
+              feat: thing
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
               color="gray"
               dimColor={false}
             >
@@ -2325,7 +2494,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
               bold={false}
               dimColor={false}
             >
-              feature/landing
+              feature/la...
             </Text>
           </Box>
           <Box
@@ -2348,6 +2517,16 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
               dimColor={true}
             >
               2026-04-15
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              wip
             </Text>
           </Box>
           <Box
@@ -2405,6 +2584,17 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
               dimColor={true}
             >
               ·
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              —
             </Text>
           </Box>
           <Box
@@ -2572,7 +2762,7 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
             <Text
               dimColor={false}
             >
-              feature/landing
+              feature/la...
             </Text>
           </Box>
           <Box
@@ -2593,6 +2783,15 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
               dimColor={false}
             >
               2026-04-15
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              dimColor={false}
+            >
+              wip
             </Text>
           </Box>
           <Box
@@ -2753,6 +2952,15 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
             marginRight={1}
           >
             <Text
+              dimColor={false}
+            >
+              feat: thing
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
               color="gray"
               dimColor={false}
             >
@@ -2791,7 +2999,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
               bold={false}
               dimColor={false}
             >
-              feature/landing
+              feature/la...
             </Text>
           </Box>
           <Box
@@ -2814,6 +3022,16 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
               dimColor={true}
             >
               2026-04-15
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              wip
             </Text>
           </Box>
           <Box
@@ -2871,6 +3089,17 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
               dimColor={true}
             >
               ·
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              —
             </Text>
           </Box>
           <Box
@@ -3065,6 +3294,15 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
             marginRight={1}
           >
             <Text
+              dimColor={false}
+            >
+              feat: thing
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
               color="gray"
               dimColor={false}
             >
@@ -3219,6 +3457,15 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
             marginRight={1}
           >
             <Text
+              dimColor={false}
+            >
+              feat: thing
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
               color="gray"
               dimColor={false}
             >
@@ -3257,7 +3504,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
               bold={false}
               dimColor={false}
             >
-              feature/landing
+              feature/la...
             </Text>
           </Box>
           <Box
@@ -3280,6 +3527,16 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
               dimColor={true}
             >
               2026-04-15
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              wip
             </Text>
           </Box>
           <Box
@@ -3337,6 +3594,17 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
               dimColor={true}
             >
               ·
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              —
             </Text>
           </Box>
           <Box
@@ -3845,6 +4113,15 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
             marginRight={1}
           >
             <Text
+              dimColor={false}
+            >
+              feat: thing
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
               color="gray"
               dimColor={false}
             >
@@ -3883,7 +4160,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
               bold={false}
               dimColor={false}
             >
-              feature/landing
+              feature/la...
             </Text>
           </Box>
           <Box
@@ -3906,6 +4183,16 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
               dimColor={true}
             >
               2026-04-15
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              dimColor={false}
+            >
+              wip
             </Text>
           </Box>
           <Box
@@ -3963,6 +4250,17 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
               dimColor={true}
             >
               ·
+            </Text>
+          </Box>
+          <Box
+            marginRight={1}
+          >
+            <Text
+              bold={false}
+              color="gray"
+              dimColor={true}
+            >
+              —
             </Text>
           </Box>
           <Box

--- a/src/workstation/surfaces/workspace/render.test.ts
+++ b/src/workstation/surfaces/workspace/render.test.ts
@@ -52,13 +52,14 @@ describe('workspace render builders', () => {
     expect(rows.map((row) => row.repo.name)).toEqual(['coco', 'docs'])
     expect(rows[0].cursor).toBe(true)
     expect(rows[1].cursor).toBe(false)
-    const [name, branch, status, date, path] = rows[0].columns
+    const [name, branch, status, date, subject, path] = rows[0].columns
     expect(name.text.startsWith('coco')).toBe(true)
     expect(branch.text.startsWith('main')).toBe(true)
     expect(status.text).toContain('●2')
     expect(status.text).toContain('↑1')
     expect(status.text).toContain('↓3')
     expect(date.text.startsWith('2026-05-01')).toBe(true)
+    expect(subject.text).toContain('feat: thing')
     expect(path.text).toContain('/tmp/coco')
   })
 
@@ -144,34 +145,45 @@ describe('workspace render builders', () => {
   })
 
   describe('assignWorkspaceColumnWidths', () => {
-    it('drops the path column when it cannot fit the row budget', () => {
-      // All five minimums total 66 cells once gaps + cursor are
-      // included; budgets in [49, 68) drop path but keep date.
-      const widths = assignWorkspaceColumnWidths(58)
+    it('drops the path column first on narrow terminals', () => {
+      // All six minimums total ~87 cells once gaps + cursor are
+      // included; budgets in [68, 86) keep subject but drop path.
+      const widths = assignWorkspaceColumnWidths(72)
       expect(widths.name).toBeDefined()
       expect(widths.branch).toBeDefined()
       expect(widths.status).toBeDefined()
       expect(widths.date).toBeDefined()
+      expect(widths.subject).toBeDefined()
       expect(widths.path).toBeUndefined()
     })
 
-    it('drops both path and date when very narrow', () => {
-      // Below ~49 cells, date also drops; status is the last
-      // non-essential to go before we're down to name + branch.
+    it('drops the subject column next when even path-less is too wide', () => {
+      const widths = assignWorkspaceColumnWidths(56)
+      expect(widths.name).toBeDefined()
+      expect(widths.branch).toBeDefined()
+      expect(widths.status).toBeDefined()
+      expect(widths.date).toBeDefined()
+      expect(widths.subject).toBeUndefined()
+      expect(widths.path).toBeUndefined()
+    })
+
+    it('drops date when very narrow', () => {
       const widths = assignWorkspaceColumnWidths(42)
       expect(widths.name).toBeDefined()
       expect(widths.branch).toBeDefined()
       expect(widths.status).toBeDefined()
       expect(widths.date).toBeUndefined()
+      expect(widths.subject).toBeUndefined()
       expect(widths.path).toBeUndefined()
     })
 
     it('keeps every column at standard width', () => {
-      const widths = assignWorkspaceColumnWidths(120)
+      const widths = assignWorkspaceColumnWidths(140)
       expect(widths.name).toBeGreaterThanOrEqual(14)
       expect(widths.branch).toBeGreaterThanOrEqual(12)
       expect(widths.status).toBeGreaterThanOrEqual(8)
       expect(widths.date).toBe(10)
+      expect(widths.subject).toBeGreaterThanOrEqual(18)
       expect(widths.path).toBeGreaterThanOrEqual(18)
     })
 
@@ -181,6 +193,7 @@ describe('workspace render builders', () => {
       expect(widths.branch).toBeLessThanOrEqual(28)
       expect(widths.status).toBeLessThanOrEqual(16)
       expect(widths.date).toBe(10)
+      expect(widths.subject).toBeLessThanOrEqual(60)
     })
 
     it('returns the empty map when no column can fit', () => {

--- a/src/workstation/surfaces/workspace/render.ts
+++ b/src/workstation/surfaces/workspace/render.ts
@@ -52,7 +52,7 @@ export type WorkspaceSidebarTabRow = {
  * Drop priority on a narrow terminal: path → date → status → branch.
  * Name always stays.
  */
-export type WorkspaceColumnKey = 'name' | 'branch' | 'status' | 'date' | 'path'
+export type WorkspaceColumnKey = 'name' | 'branch' | 'status' | 'date' | 'subject' | 'path'
 
 type ColumnSpec = {
   key: WorkspaceColumnKey
@@ -66,7 +66,10 @@ const COLUMN_SPECS: ColumnSpec[] = [
   { key: 'branch', min: 12, weight: 2, max: 28 },
   { key: 'status', min: 8, weight: 1, max: 16 },
   { key: 'date', min: 10, weight: 0, max: 10 },
-  { key: 'path', min: 18, weight: 3 },
+  // Subject grows aggressively at the expense of path so wide
+  // terminals get a meaningful "what changed" line per row.
+  { key: 'subject', min: 18, weight: 4, max: 60 },
+  { key: 'path', min: 18, weight: 1 },
 ]
 
 /** Inter-cell gap reserved by the layout helper. */
@@ -200,6 +203,13 @@ export function buildWorkspaceListRows(
     }
     if (widths.date !== undefined) {
       columns.push(formatDateCell(repo, widths.date))
+    }
+    if (widths.subject !== undefined) {
+      const subject = repo.lastCommit?.subject ?? '—'
+      columns.push({
+        text: truncateCells(subject, widths.subject),
+        tone: repo.lastCommit?.subject ? 'default' : 'dim',
+      })
     }
     if (widths.path !== undefined) {
       columns.push({


### PR DESCRIPTION
Highest-impact UX polish from the pre-test list. The discovery loader already fetched the last commit; this PR finally surfaces the subject in the row so users get a "what changed" signal beyond branch name and dirty count.

## Summary

- New \`subject\` column slotted between date and path
- Min 18, weight 4 (grows aggressively at the expense of path), capped at 60 so a long subject doesn't crowd everything else
- Drop priority: \`path → subject → date → status → branch\`. Wide terminals get subject+path; standard terminals get subject; narrow terminals drop both
- Updated drop-threshold tests + existing column-index tests; 12 snapshots refreshed to include the new column

## Test plan

- [x] Lint + typecheck clean
- [x] Full Jest suite: 186 suites, 2378 passing, 7 skipped, 33 snapshots