### PR TITLE
feat(workspace): persist sort/tab/filter across launches

### DIFF
--- a/src/workstation/chrome/workspacePreferences.test.ts
+++ b/src/workstation/chrome/workspacePreferences.test.ts
@@ -1,0 +1,83 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import {
+  getWorkspacePreferencesPath,
+  readWorkspacePreferences,
+  workspacePreferencesKey,
+  writeWorkspacePreferences,
+} from './workspacePreferences'
+
+describe('workspacePreferences', () => {
+  let tmpHome: string
+  let originalXdg: string | undefined
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-ws-prefs-'))
+    originalXdg = process.env.XDG_CACHE_HOME
+    process.env.XDG_CACHE_HOME = tmpHome
+  })
+
+  afterEach(() => {
+    if (originalXdg === undefined) {
+      delete process.env.XDG_CACHE_HOME
+    } else {
+      process.env.XDG_CACHE_HOME = originalXdg
+    }
+    fs.rmSync(tmpHome, { recursive: true, force: true })
+  })
+
+  it('round-trips sort mode, tab, and filter through the store', () => {
+    expect(readWorkspacePreferences(['~/code'])).toEqual({})
+    writeWorkspacePreferences(['~/code'], {
+      sortMode: 'dirty',
+      tab: 'behind',
+      filter: 'api',
+    })
+    expect(readWorkspacePreferences(['~/code'])).toEqual({
+      sortMode: 'dirty',
+      tab: 'behind',
+      filter: 'api',
+    })
+    expect(fs.existsSync(getWorkspacePreferencesPath(['~/code']))).toBe(true)
+  })
+
+  it('keys per root set so different configurations stay independent', () => {
+    expect(workspacePreferencesKey(['~/code'])).not.toBe(
+      workspacePreferencesKey(['~/work'])
+    )
+    expect(workspacePreferencesKey(['~/code', '~/work'])).toBe(
+      workspacePreferencesKey(['~/work', '~/code'])
+    )
+  })
+
+  it('drops unknown sort modes / tabs as if absent', () => {
+    fs.mkdirSync(path.dirname(getWorkspacePreferencesPath(['~/code'])), { recursive: true })
+    fs.writeFileSync(
+      getWorkspacePreferencesPath(['~/code']),
+      JSON.stringify({
+        version: 1,
+        savedAt: '2026-05-27',
+        preferences: { sortMode: 'rainbow', tab: 'frogs', filter: 'ok' },
+      })
+    )
+    expect(readWorkspacePreferences(['~/code'])).toEqual({ filter: 'ok' })
+  })
+
+  it('treats a schema mismatch as no preferences', () => {
+    fs.mkdirSync(path.dirname(getWorkspacePreferencesPath(['~/code'])), { recursive: true })
+    fs.writeFileSync(
+      getWorkspacePreferencesPath(['~/code']),
+      JSON.stringify({ version: 99, preferences: { sortMode: 'name' } })
+    )
+    expect(readWorkspacePreferences(['~/code'])).toEqual({})
+  })
+
+  it('swallows write failures silently', () => {
+    const blocker = path.join(tmpHome, 'blocker')
+    fs.writeFileSync(blocker, '')
+    process.env.XDG_CACHE_HOME = blocker
+    expect(() => writeWorkspacePreferences(['~/code'], { tab: 'all' })).not.toThrow()
+  })
+})

--- a/src/workstation/chrome/workspacePreferences.ts
+++ b/src/workstation/chrome/workspacePreferences.ts
@@ -1,0 +1,105 @@
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import {
+  WORKSPACE_SORT_MODES,
+  type WorkspaceSortMode,
+} from '../surfaces/workspace/sort'
+import {
+  WORKSPACE_TABS,
+  type WorkspaceTab,
+} from '../surfaces/workspace/filter'
+
+/**
+ * Persist sort mode, sidebar tab, and filter text between
+ * `coco workspace` launches. Keyed per root set so two different
+ * configured root lists keep separate preferences. Mirrors the
+ * existing `chrome/sidebarPersistence.ts` pattern.
+ *
+ * Best-effort: read/write failures fall back to defaults so a stale
+ * file or sandboxed FS never blocks boot.
+ */
+
+const SCHEMA_VERSION = 1
+const STORE_DIR_NAME = 'workspace'
+
+export type WorkspacePreferences = {
+  sortMode?: WorkspaceSortMode
+  tab?: WorkspaceTab
+  filter?: string
+}
+
+type Envelope = {
+  version: number
+  savedAt: string
+  preferences: WorkspacePreferences
+}
+
+function resolveCacheDir(): string {
+  const xdg = process.env.XDG_CACHE_HOME
+  if (xdg && xdg.trim().length > 0) {
+    return path.join(xdg, 'coco', STORE_DIR_NAME)
+  }
+  return path.join(os.homedir(), '.cache', 'coco', STORE_DIR_NAME)
+}
+
+export function workspacePreferencesKey(roots: ReadonlyArray<string>): string {
+  const normalized = [...roots].map((entry) => entry.trim()).filter(Boolean).sort()
+  return crypto.createHash('sha1').update(normalized.join('\n')).digest('hex').slice(0, 16) // DevSkim: ignore DS126858
+}
+
+export function getWorkspacePreferencesPath(roots: ReadonlyArray<string>): string {
+  return path.join(resolveCacheDir(), `preferences.${workspacePreferencesKey(roots)}.json`)
+}
+
+function isValidSortMode(value: unknown): value is WorkspaceSortMode {
+  return typeof value === 'string' && (WORKSPACE_SORT_MODES as ReadonlyArray<string>).includes(value)
+}
+
+function isValidTab(value: unknown): value is WorkspaceTab {
+  return typeof value === 'string' && (WORKSPACE_TABS as ReadonlyArray<string>).includes(value)
+}
+
+export function readWorkspacePreferences(roots: ReadonlyArray<string>): WorkspacePreferences {
+  try {
+    const raw = fs.readFileSync(getWorkspacePreferencesPath(roots), 'utf8')
+    const parsed = JSON.parse(raw) as Envelope
+    if (parsed.version !== SCHEMA_VERSION) {
+      return {}
+    }
+    const prefs = parsed.preferences ?? {}
+    const validated: WorkspacePreferences = {}
+    if (isValidSortMode(prefs.sortMode)) {
+      validated.sortMode = prefs.sortMode
+    }
+    if (isValidTab(prefs.tab)) {
+      validated.tab = prefs.tab
+    }
+    if (typeof prefs.filter === 'string') {
+      validated.filter = prefs.filter
+    }
+    return validated
+  } catch {
+    return {}
+  }
+}
+
+export function writeWorkspacePreferences(
+  roots: ReadonlyArray<string>,
+  preferences: WorkspacePreferences
+): void {
+  const envelope: Envelope = {
+    version: SCHEMA_VERSION,
+    savedAt: new Date().toISOString(),
+    preferences,
+  }
+  const file = getWorkspacePreferencesPath(roots)
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true })
+    fs.writeFileSync(file, JSON.stringify(envelope, null, 2))
+  } catch {
+    // Best-effort persistence.
+  }
+}

--- a/src/workstation/surfaces/workspace/runtime.ts
+++ b/src/workstation/surfaces/workspace/runtime.ts
@@ -66,6 +66,10 @@ import {
   hasSeenWorkspaceOnboarding,
   markWorkspaceOnboardingSeen,
 } from '../../chrome/workspaceOnboarding'
+import {
+  readWorkspacePreferences,
+  writeWorkspacePreferences,
+} from '../../chrome/workspacePreferences'
 import { isGitWorkingTree } from '../../../git/workspaceData'
 
 type DynamicImport = <T>(specifier: string) => Promise<T>
@@ -193,6 +197,15 @@ export async function startWorkspace(
       getWorkspacePullRequestCounts(repos.map((entry) => entry.path)))
 
   const cached = readCachedWorkspace(options.roots) ?? EMPTY_OVERVIEW(options.roots)
+  const persisted = readWorkspacePreferences(options.roots)
+  // Resume (post-drill-in) takes precedence over the persisted store —
+  // mid-session intent shouldn't lose to last-launch defaults.
+  const effectiveResume: WorkspaceResumeState = {
+    sortMode: options.resume?.sortMode ?? persisted.sortMode,
+    tab: options.resume?.tab ?? persisted.tab,
+    filter: options.resume?.filter ?? persisted.filter,
+    selectedRepoPath: options.resume?.selectedRepoPath,
+  }
 
   if (!canStartLogInkTui(input, output)) {
     // Non-TTY snapshot fallback. Print the visible repo list and
@@ -218,7 +231,7 @@ export async function startWorkspace(
     loadOverview,
     loadPullRequestCounts,
     onAddRepo: options.onAddRepo,
-    resume: options.resume,
+    resume: effectiveResume,
     exitRef,
     ink,
     React,
@@ -583,6 +596,17 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
       props.resumeRef.current = null
     }
   }, [props.resumeRef])
+
+  // Persist user preferences whenever a relevant slice changes. The
+  // disk write is best-effort and synchronous; the cost is sub-ms on
+  // a typical SSD so we don't bother with a debounce.
+  React.useEffect(() => {
+    writeWorkspacePreferences(props.roots, {
+      sortMode: state.sortMode,
+      tab: state.tab,
+      filter: state.filter,
+    })
+  }, [props.roots, state.sortMode, state.tab, state.filter])
 
   return renderWorkspaceApp({
     React,


### PR DESCRIPTION
Second pre-test polish item. Relaunching \`coco workspace\` no longer resets your view — sort mode, sidebar tab, and filter text survive between sessions.

## Summary

- New \`workspacePreferences\` chrome module — XDG-friendly best-effort persistence keyed by the sorted root list. Two root configurations stay independent.
- Schema-versioned envelope + input validation. An unknown sort mode or tab in a stale file is dropped silently; the surface gets defaults rather than crashing.
- Runtime reads on mount (merged into the resume seed; drill-in resume still wins for any slice it carries) and writes synchronously on every change to sortMode / tab / filter.

## Test plan

- [x] Lint + typecheck clean
- [x] Full Jest suite: 187 suites, 2383 passing, 7 skipped, 33 snapshots