### PR TITLE
feat(workspace): restore cursor on filter clear

### DIFF
--- a/src/workstation/surfaces/workspace/state.test.ts
+++ b/src/workstation/surfaces/workspace/state.test.ts
@@ -201,6 +201,44 @@ describe('workspace state reducer', () => {
     expect(requested.pendingDeletePath).toBe('/tmp/bravo')
   })
 
+  it('restores the cursor onto the previously-selected repo when clear-filter fires', () => {
+    // Cursor on bravo (index 1) before opening the filter.
+    const positioned = applyWorkspaceAction(baseState, { type: 'move-cursor', delta: 1 })
+    expect(positioned.selectedIndex).toBe(1)
+    const opened = applyWorkspaceAction(positioned, { type: 'set-focus', focus: 'filter' })
+    const filtered = applyWorkspaceAction(opened, { type: 'set-filter', filter: 'char' })
+    // Filtered list is now [charlie] at index 0.
+    expect(selectFocusedRepo(filtered)?.name).toBe('charlie')
+    const cleared = applyWorkspaceAction(filtered, { type: 'clear-filter' })
+    // Cursor should land back on bravo.
+    expect(selectFocusedRepo(cleared)?.name).toBe('bravo')
+    expect(cleared.cursorBeforeFilter).toBeUndefined()
+  })
+
+  it('falls back to index 0 when the pre-filter row no longer exists', () => {
+    const positioned = applyWorkspaceAction(baseState, { type: 'move-cursor', delta: 1 })
+    const opened = applyWorkspaceAction(positioned, { type: 'set-focus', focus: 'filter' })
+    // Replace the overview while filter is open so the pre-filter
+    // row goes away entirely.
+    const replaced = applyWorkspaceAction(opened, {
+      type: 'replace-overview',
+      overview: {
+        ...baseState.overview,
+        repos: [baseState.overview.repos[0]], // only alpha survives
+      },
+    })
+    const cleared = applyWorkspaceAction(replaced, { type: 'clear-filter' })
+    expect(cleared.selectedIndex).toBe(0)
+    expect(selectFocusedRepo(cleared)?.name).toBe('alpha')
+  })
+
+  it('committing the filter (focus → list) clears the snapshot so a later Esc does not restore', () => {
+    const opened = applyWorkspaceAction(baseState, { type: 'set-focus', focus: 'filter' })
+    expect(opened.cursorBeforeFilter).toBeDefined()
+    const committed = applyWorkspaceAction(opened, { type: 'set-focus', focus: 'list' })
+    expect(committed.cursorBeforeFilter).toBeUndefined()
+  })
+
   it('cancel-delete returns focus to the list and clears the pending path', () => {
     const known = applyWorkspaceAction(baseState, {
       type: 'replace-known-repos',

--- a/src/workstation/surfaces/workspace/state.ts
+++ b/src/workstation/surfaces/workspace/state.ts
@@ -68,6 +68,13 @@ export type WorkspaceState = {
   knownRepoPaths: ReadonlyArray<string>
   /** Path the user is being asked to confirm deletion for. */
   pendingDeletePath?: string
+  /**
+   * Repo path the cursor was on right before the user opened the
+   * filter prompt. Used to restore the cursor when the filter is
+   * cleared (Esc) — without it, the cursor would land at index 0
+   * which is a papercut every time you cancel a filter.
+   */
+  cursorBeforeFilter?: string
 }
 
 export type WorkspaceAction =
@@ -227,9 +234,45 @@ export function applyWorkspaceAction(
       return rectifySelection({ ...state, filter: action.filter, selectedIndex: 0 })
     }
     case 'clear-filter': {
-      return rectifySelection({ ...state, filter: '', focus: 'list', selectedIndex: 0 })
+      // Drop the filter, return to list focus, and try to restore the
+      // cursor onto the row that was selected before we entered the
+      // filter prompt. Falls back to index 0 when the snapshot row no
+      // longer exists in the visible list (e.g., it was removed
+      // between filter open and clear).
+      const restored: WorkspaceState = {
+        ...state,
+        filter: '',
+        focus: 'list',
+        selectedIndex: 0,
+        cursorBeforeFilter: undefined,
+      }
+      if (!state.cursorBeforeFilter) {
+        return restored
+      }
+      const visible = selectVisibleRepos(restored)
+      const idx = visible.findIndex((entry) => entry.path === state.cursorBeforeFilter)
+      if (idx < 0) {
+        return restored
+      }
+      return { ...restored, selectedIndex: idx }
     }
     case 'set-focus': {
+      // Snapshot the cursor when the user opens the filter prompt so
+      // we can put them back where they were if they bail with Esc.
+      if (action.focus === 'filter' && state.focus !== 'filter') {
+        const focused = selectFocusedRepo(state)
+        return {
+          ...state,
+          focus: action.focus,
+          cursorBeforeFilter: focused?.path ?? state.cursorBeforeFilter,
+        }
+      }
+      // Committing the filter from inside the prompt (focus → list)
+      // clears the snapshot — the user is keeping the filtered view,
+      // so any cancel from here on should restart the cycle.
+      if (action.focus === 'list' && state.focus === 'filter') {
+        return { ...state, focus: action.focus, cursorBeforeFilter: undefined }
+      }
       return { ...state, focus: action.focus }
     }
     case 'move-cursor': {


### PR DESCRIPTION
Last pre-test polish item. Closes the papercut where canceling a filter dumps you at index 0 instead of back on the repo you were inspecting.

## Summary

- New \`cursorBeforeFilter\` snapshot on \`WorkspaceState\`. Set when the user opens the filter prompt (\`set-focus → 'filter'\`); cleared on \`clear-filter\` (after restoring) or on \`set-focus → 'list'\` (committing the filtered view).
- \`clear-filter\` looks up the snapshotted path in the post-clear visible list and anchors the cursor on it. Falls back to index 0 when the row no longer exists (e.g., a background refresh removed it between open and clear).
- Three new state tests: happy path, missing-row fallback, snapshot-cleared-on-commit.

## Test plan

- [x] Lint + typecheck clean
- [x] Full Jest suite: 187 suites, 2386 passing, 7 skipped, 33 snapshots