### PR TITLE
docs(workstation): correct top-level view count

### DIFF
--- a/src/workstation/README.md
+++ b/src/workstation/README.md
@@ -1,6 +1,6 @@
 # Workstation
 
-The Ink-based TUI that ships behind `coco ui` and `coco log -i`. Twelve top-level views, chord-driven (`g<key>`) navigation, keyboard-only by design.
+The Ink-based TUI that ships behind `coco ui` and `coco log -i`. Sixteen top-level views, chord-driven (`g<key>`) navigation, keyboard-only by design.
 
 For user-facing docs:
 - [Interactive Log TUI](https://github.com/gfargo/coco/wiki/Interactive-Log-TUI) — keymap, configuration, screenshots.


### PR DESCRIPTION
One-line fix to `src/workstation/README.md` — the opener said "Twelve top-level views" but the canonical `LogInkView` union in `src/commands/log/inkViewModel.ts` lists sixteen entries, and the [Coco-UI wiki page](https://github.com/gfargo/coco/wiki/Coco-UI) already says sixteen.

The line had been stale since the initial extraction — pullRequestTriage, issuesTriage, changelog, submodules, etc. all landed without bumping the count.

## Note

I also updated local-only steering documents (`.kiro/steering/*.md` and `AGENTS.md`, both gitignored by design) with related corrections:
- New test scripts (`test:unit`, `test:integration`, `test:coverage`) and the parallel CI structure
- The scenario library extraction to `@gfargo/git-scenarios`
- DevSkim tuning context for security-scanning workflows
- Surface count corrections (`13 dirs` → `18 dirs` accurately broken down as 16 views + `detail/` dispatcher + `workspace/`)
- `inkRuntime.ts` size update from "132-LOC" to "~145 LOC"

Those persist locally for agent context but don't ship.
