### PR TITLE
fix(workspace): lock root to terminal height + viewport-window the row list

### DIFF
--- a/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
+++ b/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is authenticated 1`] = `
 <Box
   flexDirection="column"
+  height={40}
 >
   <Box
     borderColor="cyan"
@@ -23,12 +24,14 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
   </Box>
   <Box
     flexDirection="row"
+    height={34}
   >
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
+      height={34}
       paddingX={1}
       width={18}
     >
@@ -57,6 +60,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
+      height={34}
       paddingX={1}
     >
       <Box
@@ -323,6 +327,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
 exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`] = `
 <Box
   flexDirection="column"
+  height={40}
 >
   <Box
     borderColor="cyan"
@@ -343,12 +348,14 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
   </Box>
   <Box
     flexDirection="row"
+    height={34}
   >
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
+      height={34}
       paddingX={1}
       width={18}
     >
@@ -377,6 +384,7 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
+      height={34}
       paddingX={1}
     >
       <Box
@@ -487,6 +495,7 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
 exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs sidebar tab 1`] = `
 <Box
   flexDirection="column"
+  height={40}
 >
   <Box
     borderColor="cyan"
@@ -507,12 +516,14 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
   </Box>
   <Box
     flexDirection="row"
+    height={34}
   >
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
+      height={34}
       paddingX={1}
       width={18}
     >
@@ -543,6 +554,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
+      height={34}
       paddingX={1}
     >
       <Box
@@ -809,6 +821,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
 exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-budget regressions surface 1`] = `
 <Box
   flexDirection="column"
+  height={40}
 >
   <Box
     borderColor="cyan"
@@ -829,12 +842,14 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
   </Box>
   <Box
     flexDirection="row"
+    height={34}
   >
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
+      height={34}
       paddingX={1}
       width={18}
     >
@@ -863,6 +878,7 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
+      height={34}
       paddingX={1}
     >
       <Box
@@ -1067,6 +1083,7 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
 exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`] = `
 <Box
   flexDirection="column"
+  height={40}
 >
   <Box
     borderColor="cyan"
@@ -1087,12 +1104,14 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
   </Box>
   <Box
     flexDirection="row"
+    height={33}
   >
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
+      height={33}
       paddingX={1}
       width={18}
     >
@@ -1121,6 +1140,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
+      height={33}
       paddingX={1}
     >
       <Box
@@ -1392,6 +1412,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
 exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — path drops out 1`] = `
 <Box
   flexDirection="column"
+  height={40}
 >
   <Box
     borderColor="cyan"
@@ -1412,12 +1433,14 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
   </Box>
   <Box
     flexDirection="row"
+    height={34}
   >
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
+      height={34}
       paddingX={1}
       width={18}
     >
@@ -1446,6 +1469,7 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
+      height={34}
       paddingX={1}
     >
       <Box
@@ -1586,6 +1610,7 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
 exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns grow up to their caps 1`] = `
 <Box
   flexDirection="column"
+  height={40}
 >
   <Box
     borderColor="cyan"
@@ -1606,12 +1631,14 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
   </Box>
   <Box
     flexDirection="row"
+    height={34}
   >
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
+      height={34}
       paddingX={1}
       width={18}
     >
@@ -1640,6 +1667,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
+      height={34}
       paddingX={1}
     >
       <Box
@@ -1906,6 +1934,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
 exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading false) 1`] = `
 <Box
   flexDirection="column"
+  height={40}
 >
   <Box
     borderColor="cyan"
@@ -1926,12 +1955,14 @@ exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading fals
   </Box>
   <Box
     flexDirection="row"
+    height={34}
   >
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
+      height={34}
       paddingX={1}
       width={18}
     >
@@ -1960,6 +1991,7 @@ exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading fals
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
+      height={34}
       paddingX={1}
     >
       <Box
@@ -2001,6 +2033,7 @@ exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading fals
 exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the header chip 1`] = `
 <Box
   flexDirection="column"
+  height={40}
 >
   <Box
     borderColor="cyan"
@@ -2021,12 +2054,14 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
   </Box>
   <Box
     flexDirection="row"
+    height={34}
   >
     <Box
       borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
+      height={34}
       paddingX={1}
       width={18}
     >
@@ -2055,6 +2090,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
+      height={34}
       paddingX={1}
     >
       <Box
@@ -2321,6 +2357,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
 exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] = `
 <Box
   flexDirection="column"
+  height={40}
 >
   <Box
     borderColor="cyan"
@@ -2341,12 +2378,14 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
   </Box>
   <Box
     flexDirection="row"
+    height={29}
   >
     <Box
       borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
+      height={29}
       paddingX={1}
       width={18}
     >
@@ -2375,6 +2414,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
+      height={29}
       paddingX={1}
     >
       <Box
@@ -2663,6 +2703,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
 exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
 <Box
   flexDirection="column"
+  height={40}
 >
   <Box
     borderColor="cyan"
@@ -2683,12 +2724,14 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
   </Box>
   <Box
     flexDirection="row"
+    height={34}
   >
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
+      height={34}
       paddingX={1}
       width={18}
     >
@@ -2717,6 +2760,7 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
+      height={34}
       paddingX={1}
     >
       <Box
@@ -2826,6 +2870,7 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
 exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo 1`] = `
 <Box
   flexDirection="column"
+  height={40}
 >
   <Box
     borderColor="cyan"
@@ -2846,12 +2891,14 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
   </Box>
   <Box
     flexDirection="row"
+    height={29}
   >
     <Box
       borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
+      height={29}
       paddingX={1}
       width={18}
     >
@@ -2880,6 +2927,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
+      height={29}
       paddingX={1}
     >
       <Box
@@ -3168,6 +3216,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
 exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
 <Box
   flexDirection="column"
+  height={40}
 >
   <Box
     borderColor="cyan"
@@ -3188,12 +3237,14 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
   </Box>
   <Box
     flexDirection="row"
+    height={34}
   >
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
+      height={34}
       paddingX={1}
       width={18}
     >
@@ -3222,6 +3273,7 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
+      height={34}
       paddingX={1}
     >
       <Box
@@ -3331,6 +3383,7 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
 exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
 <Box
   flexDirection="column"
+  height={40}
 >
   <Box
     borderColor="cyan"
@@ -3351,12 +3404,14 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
   </Box>
   <Box
     flexDirection="row"
+    height={29}
   >
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
+      height={29}
       paddingX={1}
       width={18}
     >
@@ -3385,6 +3440,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
+      height={29}
       paddingX={1}
     >
       <Box
@@ -3671,6 +3727,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
 exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`] = `
 <Box
   flexDirection="column"
+  height={40}
 >
   <Box
     borderColor="cyan"
@@ -3892,6 +3949,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
 exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is in flight 1`] = `
 <Box
   flexDirection="column"
+  height={40}
 >
   <Box
     borderColor="cyan"
@@ -3912,12 +3970,14 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
   </Box>
   <Box
     flexDirection="row"
+    height={34}
   >
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
+      height={34}
       paddingX={1}
       width={18}
     >
@@ -3946,6 +4006,7 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
+      height={34}
       paddingX={1}
     >
       <Box
@@ -3987,6 +4048,7 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
 exports[`renderWorkspaceApp snapshots the populated workspace with the default tab + sort 1`] = `
 <Box
   flexDirection="column"
+  height={40}
 >
   <Box
     borderColor="cyan"
@@ -4007,12 +4069,14 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
   </Box>
   <Box
     flexDirection="row"
+    height={34}
   >
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
+      height={34}
       paddingX={1}
       width={18}
     >
@@ -4041,6 +4105,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
+      height={34}
       paddingX={1}
     >
       <Box

--- a/src/workstation/surfaces/workspace/render.test.ts
+++ b/src/workstation/surfaces/workspace/render.test.ts
@@ -6,6 +6,7 @@ import {
   buildWorkspaceHeader,
   buildWorkspaceHelpRows,
   buildWorkspaceListRows,
+  buildWorkspaceListWindow,
   buildWorkspaceOnboarding,
   buildWorkspaceSidebar,
 } from './render'
@@ -233,5 +234,62 @@ describe('workspace render builders', () => {
     }
     expect(buildWorkspaceOnboarding(empty).emptyHint).toContain('No repos found')
     expect(buildWorkspaceOnboarding(empty).populatedHint).toBeUndefined()
+  })
+
+  describe('buildWorkspaceListWindow', () => {
+    function bigState(count: number) {
+      const repos = Array.from({ length: count }, (_, i) =>
+        repo({
+          name: `repo-${String(i).padStart(2, '0')}`,
+          path: `/tmp/repo-${i}`,
+          lastCommit: { hash: `h${i}`, date: '2026-05-01', subject: `subject ${i}` },
+        })
+      )
+      return createWorkspaceState({
+        overview: overview(repos),
+        roots: ['~/code'],
+      })
+    }
+
+    it('returns every row when the list fits the viewport', () => {
+      const win = buildWorkspaceListWindow(bigState(5), { rows: 10 })
+      expect(win.rows).toHaveLength(5)
+      expect(win.hiddenAbove).toBe(0)
+      expect(win.hiddenBelow).toBe(0)
+      expect(win.totalRows).toBe(5)
+    })
+
+    it('windows the list to the viewport height when overflowing', () => {
+      const win = buildWorkspaceListWindow(bigState(50), { rows: 10 })
+      expect(win.rows).toHaveLength(10)
+      expect(win.hiddenAbove + win.rows.length + win.hiddenBelow).toBe(50)
+    })
+
+    it('keeps the cursor inside the window when scrolled to the bottom', () => {
+      const state = bigState(50)
+      const moved = applyWorkspaceAction(state, { type: 'set-cursor', index: 49 })
+      const win = buildWorkspaceListWindow(moved, { rows: 10 })
+      expect(win.hiddenBelow).toBe(0)
+      expect(win.hiddenAbove).toBe(40)
+      // Cursor row should appear in the window.
+      const cursorRow = win.rows.find((row) => row.cursor)
+      expect(cursorRow).toBeDefined()
+      expect(cursorRow?.repo.name).toBe('repo-49')
+    })
+
+    it('keeps the cursor about a third from the top when scrolling through the middle', () => {
+      const state = bigState(50)
+      const moved = applyWorkspaceAction(state, { type: 'set-cursor', index: 25 })
+      const win = buildWorkspaceListWindow(moved, { rows: 12 })
+      // restAbove = floor(12 / 3) = 4 → start = max(0, 25 - 4) = 21
+      expect(win.hiddenAbove).toBe(21)
+      expect(win.rows[4].repo.name).toBe('repo-25')
+      expect(win.rows[4].cursor).toBe(true)
+    })
+
+    it('floors viewport rows at 1 even when given 0', () => {
+      const win = buildWorkspaceListWindow(bigState(5), { rows: 0 })
+      expect(win.rows.length).toBeGreaterThanOrEqual(1)
+    })
   })
 })

--- a/src/workstation/surfaces/workspace/render.ts
+++ b/src/workstation/surfaces/workspace/render.ts
@@ -221,6 +221,60 @@ export function buildWorkspaceListRows(
   })
 }
 
+export type WorkspaceListWindow = {
+  rows: WorkspaceListRow[]
+  /** Total visible (sort + filter) row count — for the "N visible" header chip. */
+  totalRows: number
+  /** Number of rows above the window (for the "↑ N more" indicator). */
+  hiddenAbove: number
+  /** Number of rows below the window (for the "↓ N more" indicator). */
+  hiddenBelow: number
+}
+
+/**
+ * Window the row list onto a fixed height so we never render past the
+ * terminal bounds. Keeps the cursor row inside the window using a
+ * "rest in the upper third" heuristic — same shape used by the
+ * history surface — so users see plenty of context below the cursor
+ * for scrolling without the cursor immediately jumping off-screen.
+ */
+export function buildWorkspaceListWindow(
+  state: WorkspaceState,
+  options: { width?: number; rows: number } = { rows: 20 }
+): WorkspaceListWindow {
+  const all = buildWorkspaceListRows(state, { width: options.width })
+  const visibleCount = Math.max(1, options.rows)
+  if (all.length <= visibleCount) {
+    return {
+      rows: all,
+      totalRows: all.length,
+      hiddenAbove: 0,
+      hiddenBelow: 0,
+    }
+  }
+  const cursor = Math.max(
+    0,
+    Math.min(state.selectedIndex, all.length - 1)
+  )
+  // Keep the cursor about a third of the way down so the user has
+  // context above and below. Matches the historyRow behaviour the
+  // existing surfaces have already trained users to expect.
+  const restAbove = Math.floor(visibleCount / 3)
+  let start = Math.max(0, cursor - restAbove)
+  // Don't scroll past the bottom — pin the window so the last row
+  // stays visible when the cursor is near the end of the list.
+  if (start + visibleCount > all.length) {
+    start = all.length - visibleCount
+  }
+  const end = start + visibleCount
+  return {
+    rows: all.slice(start, end),
+    totalRows: all.length,
+    hiddenAbove: start,
+    hiddenBelow: Math.max(0, all.length - end),
+  }
+}
+
 export function buildWorkspaceSidebar(state: WorkspaceState): WorkspaceSidebarTabRow[] {
   return WORKSPACE_TABS.map((tab) => {
     const disabled = tab === 'pull-requests' && state.ghAuthenticated === false

--- a/src/workstation/surfaces/workspace/runtime.ts
+++ b/src/workstation/surfaces/workspace/runtime.ts
@@ -313,7 +313,7 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
   const { React, ink } = props
   const { useApp, useInput, useWindowSize } = ink
   const { exit } = useApp()
-  const { columns } = useWindowSize()
+  const { columns, rows } = useWindowSize()
 
   const [state, setState] = React.useState<WorkspaceState>(() =>
     createWorkspaceState({
@@ -618,5 +618,6 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
     addRepoDraft,
     addRepoCompletion,
     columns,
+    rows,
   })
 }

--- a/src/workstation/surfaces/workspace/view.test.ts
+++ b/src/workstation/surfaces/workspace/view.test.ts
@@ -95,6 +95,7 @@ function render(
     addRepoDraft?: string
     addRepoCompletion?: ReturnType<typeof completePath>
     columns?: number
+    rows?: number
   } = {}
 ): ReactElement {
   const theme = createLogInkTheme({ ascii: true })
@@ -116,6 +117,7 @@ function render(
         isDirectory: false,
       } as ReturnType<typeof completePath>),
     columns: options.columns ?? 120,
+    rows: options.rows ?? 40,
   })
 }
 

--- a/src/workstation/surfaces/workspace/view.ts
+++ b/src/workstation/surfaces/workspace/view.ts
@@ -18,10 +18,11 @@ import {
   buildWorkspaceFooter,
   buildWorkspaceHeader,
   buildWorkspaceHelpRows,
-  buildWorkspaceListRows,
+  buildWorkspaceListWindow,
   buildWorkspaceOnboarding,
   buildWorkspaceSidebar,
   type WorkspaceListColumn,
+  type WorkspaceListRow,
 } from './render'
 import { selectVisibleRepos, type WorkspaceState } from './state'
 
@@ -36,6 +37,8 @@ type RenderWorkspaceAppDeps = {
   addRepoCompletion: PathCompletionResult
   /** Terminal width in cells. Caller resolves via Ink's useWindowSize. */
   columns: number
+  /** Terminal height in rows. Caller resolves via Ink's useWindowSize. */
+  rows: number
 }
 
 function toneColor(tone: WorkspaceListColumn['tone'], theme: LogInkTheme): string | undefined {
@@ -76,7 +79,8 @@ function renderHeader(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement {
 }
 
 function renderSidebar(
-  deps: RenderWorkspaceAppDeps
+  deps: RenderWorkspaceAppDeps,
+  height: number
 ): ReactTypes.ReactElement {
   const { React, ink, state, theme } = deps
   const { Box, Text } = ink
@@ -99,6 +103,7 @@ function renderSidebar(
       borderStyle: theme.borderStyle,
       flexDirection: 'column',
       flexShrink: 0,
+      height,
       paddingX: 1,
       width: 18,
     },
@@ -109,7 +114,7 @@ function renderSidebar(
 
 function renderListRow(
   deps: RenderWorkspaceAppDeps,
-  row: ReturnType<typeof buildWorkspaceListRows>[number],
+  row: WorkspaceListRow,
   key: string
 ): ReactTypes.ReactElement {
   const { React, ink, theme } = deps
@@ -140,12 +145,18 @@ function renderListRow(
 
 function renderListBody(
   deps: RenderWorkspaceAppDeps,
-  width: number
+  width: number,
+  height: number
 ): ReactTypes.ReactElement {
   const { React, ink, state, theme } = deps
   const { Box, Text } = ink
   const focused = state.focus !== 'filter'
-  const rows = buildWorkspaceListRows(state, { width })
+  // Reserve: 1 row for the panel header, 1 for each scroll indicator
+  // (if shown), 2 for the border. Floor at 1 so the panel always
+  // renders at least one row.
+  const reservedChrome = 3
+  const listRows = Math.max(1, height - reservedChrome)
+  const windowed = buildWorkspaceListWindow(state, { width, rows: listRows })
   const visibleRepos = selectVisibleRepos(state)
   const filterChip = state.filter
     ? `  ·  filter: ${state.filter}`
@@ -155,7 +166,7 @@ function renderListBody(
   const headerRight = state.loading
     ? 'loading repos…'
     : `${visibleRepos.length} visible${filterChip}`
-  const lines: ReactTypes.ReactNode[] = rows.length === 0
+  const lines: ReactTypes.ReactNode[] = windowed.rows.length === 0
     ? [
       React.createElement(
         Text,
@@ -167,7 +178,23 @@ function renderListBody(
             : 'No repos match the current filter.'
       ),
     ]
-    : rows.map((row, index) => renderListRow(deps, row, `row-${index}`))
+    : windowed.rows.map((row, index) =>
+      renderListRow(deps, row, `row-${windowed.hiddenAbove + index}`)
+    )
+  const topChevron = windowed.hiddenAbove > 0
+    ? React.createElement(
+      Text,
+      { key: 'chevron-top', dimColor: true },
+      `↑ ${windowed.hiddenAbove} more`
+    )
+    : null
+  const bottomChevron = windowed.hiddenBelow > 0
+    ? React.createElement(
+      Text,
+      { key: 'chevron-bottom', dimColor: true },
+      `↓ ${windowed.hiddenBelow} more`
+    )
+    : null
   return React.createElement(
     Box,
     {
@@ -175,6 +202,7 @@ function renderListBody(
       borderStyle: theme.borderStyle,
       flexDirection: 'column',
       flexGrow: 1,
+      height,
       paddingX: 1,
     },
     React.createElement(
@@ -183,7 +211,9 @@ function renderListBody(
       React.createElement(Text, { bold: true }, panelTitle('Workspace', focused)),
       React.createElement(Text, { dimColor: true }, headerRight)
     ),
-    ...lines
+    topChevron,
+    ...lines,
+    bottomChevron
   )
 }
 
@@ -318,31 +348,52 @@ function renderFooter(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement {
   )
 }
 
+/**
+ * Lay out vertical space for the workspace. Reserves rows for the
+ * header (3 cells: top border + content + bottom border), the footer
+ * (3 cells minimum, +1 when a status is set), and any overlay panels
+ * currently showing. Body height is what's left, floored at 8 so the
+ * list panel always renders something even on a tiny terminal.
+ */
+function computeBodyHeight(deps: RenderWorkspaceAppDeps): number {
+  const HEADER_ROWS = 3
+  const FOOTER_ROWS = deps.state.status ? 4 : 3
+  const onboardingRows = buildWorkspaceOnboarding(deps.state).show ? 5 : 0
+  const addRepoRows = deps.state.focus === 'add-repo' ? 5 : 0
+  const confirmRows = deps.state.focus === 'confirm-delete' ? 5 : 0
+  const reserved = HEADER_ROWS + FOOTER_ROWS + onboardingRows + addRepoRows + confirmRows
+  return Math.max(8, deps.rows - reserved)
+}
+
 export function renderWorkspaceApp(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement {
   const { React, ink } = deps
   const { Box } = ink
   const bodyWidth = Math.max(40, deps.columns - 4)
+  // Lock the root box to the terminal height so Ink never paints past
+  // the screen. Same shape as `coco ui`'s root.
+  const rootHeight = Math.max(10, deps.rows)
   // Help is modal — when it's up, replace the main list/sidebar pair
   // with the help panel so the user isn't distracted by background
   // updates while reading.
   if (deps.state.showHelp) {
     return React.createElement(
       Box,
-      { flexDirection: 'column' },
+      { flexDirection: 'column', height: rootHeight },
       renderHeader(deps),
       renderHelpOverlay(deps),
       renderFooter(deps)
     )
   }
+  const bodyHeight = computeBodyHeight(deps)
   return React.createElement(
     Box,
-    { flexDirection: 'column' },
+    { flexDirection: 'column', height: rootHeight },
     renderHeader(deps),
     React.createElement(
       Box,
-      { flexDirection: 'row' },
-      renderSidebar(deps),
-      renderListBody(deps, bodyWidth - 22)
+      { flexDirection: 'row', height: bodyHeight },
+      renderSidebar(deps, bodyHeight),
+      renderListBody(deps, bodyWidth - 22, bodyHeight)
     ),
     renderOnboardingBanner(deps),
     renderAddRepoPrompt(deps),


### PR DESCRIPTION
**Critical bug fix.** Without this, navigating with j/k or arrow keys (or scroll wheel) on a workspace with more repos than rows of screen real estate crashes the dev process. Root cause: list renders every row → overflows terminal → mis-decoded scroll-wheel escape sequences interpreted as SIGINT → \`tsx watch\` restarts.

## Summary

- **Root box pinned to terminal height** via \`useWindowSize().rows\`. Same shape as \`coco ui\`'s LogInkApp root — Ink never paints past the bottom edge.
- **Body-height budget** computed from \`computeBodyHeight\` — subtracts header (3) + footer (3-4) + any visible overlay panel (onboarding / add-repo / confirm-delete = 5 each). What's left goes to the list panel + sidebar.
- **Viewport windowing** via new \`buildWorkspaceListWindow(state, { width, rows })\`. Returns the cursor-anchored slice plus \`hiddenAbove\` / \`hiddenBelow\` counts so the panel can render \`↑ N more\` / \`↓ N more\` indicators.
- **Cursor placement**: keeps the selected row about a third from the top of the window. Pins to the bottom when the cursor is near the end of the list so the final row stays visible.

## Commits

1. \`feat(workspace): viewport windowing for the row list\` — pure helper + 5 unit tests
2. \`feat(workspace): lock root height + render only what fits\` — view wiring + runtime hook + snapshot refresh

## Test plan

- [x] Lint + typecheck clean
- [x] Full Jest suite: 187 suites, 2398 passing, 33 snapshots