### PR TITLE
fix(workspace): never quit on bare ESC (fixes 'every keypress restarts')

### DIFF
--- a/src/workstation/surfaces/workspace/input.test.ts
+++ b/src/workstation/surfaces/workspace/input.test.ts
@@ -27,9 +27,12 @@ function addRepoState(): WorkspaceState {
 }
 
 describe('resolveWorkspaceInput', () => {
-  it('quits on q or escape (no filter active)', () => {
+  it('quits on q only — escape never quits because terminals can deliver bare ESC on arrow keys', () => {
     expect(resolveWorkspaceInput('q', key(), listState()).kind).toBe('quit')
-    expect(resolveWorkspaceInput('', key({ escape: true }), listState()).kind).toBe('quit')
+    // Bare ESC must NOT quit; it would crash the app every time the
+    // user pressed an arrow key on terminals that deliver ESC + [ + A
+    // as separate keypresses.
+    expect(resolveWorkspaceInput('', key({ escape: true }), listState()).kind).toBe('noop')
   })
 
   it('clears the filter on escape when a filter is set', () => {

--- a/src/workstation/surfaces/workspace/input.ts
+++ b/src/workstation/surfaces/workspace/input.ts
@@ -100,13 +100,21 @@ export function resolveWorkspaceInput(
     return { kind: 'action', action: { type: 'cancel-delete' } }
   }
 
+  // Escape clears a filter or closes overlays only — it MUST NOT quit
+  // the app. Some terminals deliver arrow keys as separate bytes
+  // (ESC + [ + letter) and Ink may surface the bare ESC as its own
+  // keypress before the rest arrives. Treating that as quit caused
+  // "any navigation key restarts the app" because the loop would
+  // exit cleanly and tsx watch would relaunch the process.
   if (key.escape) {
     if (state.filter) {
       return { kind: 'action', action: { type: 'clear-filter' } }
     }
-    return { kind: 'quit' }
+    return { kind: 'noop' }
   }
 
+  // Quit is bound to `q` (or Ctrl+C, which Ink handles at the render
+  // layer). Same shape as the existing `coco ui` keymap.
   if (input === 'q' && !key.ctrl && !key.meta) {
     return { kind: 'quit' }
   }


### PR DESCRIPTION
**Critical bug fix** for the \"every keypress restarts the app\" report.

## Root cause

Some terminals — Apple Terminal, screen sessions, certain SSH multiplexers — deliver arrow keys as **separate keypresses**: \`ESC\` + \`[\` + \`A\`. Ink surfaces the bare \`ESC\` as its own keypress before the rest of the sequence arrives.

The workspace input resolver had escape mapped to quit when no filter was active. So pressing any arrow key would:

1. Ink delivers \`{ escape: true }\` for the lone ESC byte
2. \`resolveWorkspaceInput\` returns \`{ kind: 'quit' }\`
3. Runtime calls \`exit()\`; \`waitUntilExit\` resolves
4. \`startWorkspace\` returns \`{ kind: 'quit' }\`
5. \`runWorkspaceLoop\` returns; handler returns; process exits
6. \`tsx watch\` relaunches the process — **looks like a restart**

\`coco ui\`'s keymap binds quit to \`q\` and \`ctrl+c\` only — never escape — for exactly this reason. Workspace now matches.

## Change

- Bare ESC is a no-op when there's nothing to dismiss (filter, prompt, overlay)
- Quit stays bound to \`q\`; \`Ctrl+C\` continues to work via Ink's built-in handler
- Updated test asserts the new behavior + comments the historical foot-gun

## Test plan

- [x] Lint + typecheck clean
- [x] Full Jest suite: 187 suites, 2398 passing, 33 snapshots