### PR TITLE
fix(workspace): clean exit on quit (process.exit + unmount + abort-on-unmount)

### DIFF
--- a/src/commands/workspace/handler.ts
+++ b/src/commands/workspace/handler.ts
@@ -143,4 +143,13 @@ export async function startCocoWorkspace(argv: WorkspaceArgv): Promise<void> {
 
 export const handler: CommandHandler<WorkspaceArgv> = async (argv) => {
   await startCocoWorkspace(argv)
+  // Force-exit on clean quit. Without this, a still-pending background
+  // gh PR-count fetch (or any other child process) keeps the event
+  // loop alive after the user hits `q`, and the process lingers until
+  // the gh timeout (5s by default) fires. Users perceive that delay
+  // as the UI being stuck; pressing more keys then races with the
+  // half-torn-down stdin handler and surfaces as a TTY EIO. The
+  // workspace surface doesn't have any side effects worth waiting on
+  // past this point, so process.exit(0) is the right call.
+  process.exit(0)
 }

--- a/src/workstation/surfaces/workspace/runtime.ts
+++ b/src/workstation/surfaces/workspace/runtime.ts
@@ -254,9 +254,37 @@ export async function startWorkspace(
   try {
     await instance.waitUntilExit()
   } finally {
+    // Belt-and-suspenders: explicit unmount after waitUntilExit
+    // resolves. Ink usually handles this, but on some terminals the
+    // stdin handler outlives the resolution by a tick, which then
+    // races with the next mount in runWorkspaceLoop and surfaces as
+    // a TTY EIO. Calling unmount() here is idempotent.
+    try {
+      instance.unmount()
+    } catch {
+      // ignore — already unmounted
+    }
     lifecycle.dispose()
   }
+  workspaceDebug(`exit: kind=${exitRef.current.kind}`)
   return exitRef.current
+}
+
+/**
+ * Tiny diagnostic logger toggled by COCO_DEBUG_WORKSPACE=1. Writes a
+ * single line to stderr (preserved across alt-screen exits) so users
+ * can share what the workspace runtime saw without us having to ship
+ * a debugger build.
+ */
+function workspaceDebug(message: string): void {
+  if (!process.env.COCO_DEBUG_WORKSPACE) {
+    return
+  }
+  try {
+    process.stderr.write(`[workspace] ${message}\n`)
+  } catch {
+    // best-effort
+  }
 }
 
 function renderWorkspaceSnapshot(
@@ -339,6 +367,13 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
     setState((prev) => applyWorkspaceAction(prev, action))
   }, [])
 
+  // Track an unmount flag in a ref so async work scheduled by the
+  // input handler (refresh, drillIn, etc.) can short-circuit when the
+  // user has already quit. Without this, a pending gh call from `r`
+  // could keep the event loop alive after the user hit `q`, making
+  // the process linger and stdin race against the next loop iteration.
+  const unmountedRef = React.useRef(false)
+
   // Background discovery + PR-count refresh on mount.
   React.useEffect(() => {
     let cancelled = false
@@ -346,14 +381,14 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
     void (async () => {
       try {
         const overview = await props.loadOverview(props.roots, props.knownRepos)
-        if (cancelled) return
+        if (cancelled || unmountedRef.current) return
         writeCachedWorkspace(props.roots, overview)
         dispatch({ type: 'replace-overview', overview })
         if (props.resume?.selectedRepoPath) {
           dispatch({ type: 'anchor-cursor-by-path', path: props.resume.selectedRepoPath })
         }
         const pr = await props.loadPullRequestCounts(overview.repos)
-        if (cancelled) return
+        if (cancelled || unmountedRef.current) return
         dispatch({
           type: 'replace-pull-request-counts',
           counts: pr.counts,
@@ -366,7 +401,7 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
           })
         }
       } catch (err) {
-        if (cancelled) return
+        if (cancelled || unmountedRef.current) return
         dispatch({ type: 'set-loading', loading: false })
         dispatch({
           type: 'set-status',
@@ -376,6 +411,7 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
     })()
     return () => {
       cancelled = true
+      unmountedRef.current = true
     }
     // Mount-only effect. Refreshes go through the input handler.
   }, [])
@@ -384,16 +420,19 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
     dispatch({ type: 'set-loading', loading: true })
     try {
       const overview = await props.loadOverview(props.roots, props.knownRepos)
+      if (unmountedRef.current) return
       writeCachedWorkspace(props.roots, overview)
       dispatch({ type: 'replace-overview', overview })
       dispatch({ type: 'set-status', status: `Refreshed ${overview.repos.length} repos.` })
       const pr = await props.loadPullRequestCounts(overview.repos)
+      if (unmountedRef.current) return
       dispatch({
         type: 'replace-pull-request-counts',
         counts: pr.counts,
         authenticated: pr.authenticated,
       })
     } catch (err) {
+      if (unmountedRef.current) return
       dispatch({ type: 'set-loading', loading: false })
       dispatch({
         type: 'set-status',


### PR DESCRIPTION
Follow-up to #1053 — the bare-ESC fix unblocked navigation but the user is still hitting two related symptoms:

> When I hit \`q\` sometimes it restarts the process again until I hit ctrl+c multiple times then get \`Error: read EIO at TTY.onStreamRead\`

## Root cause

A still-pending \`gh pr list\` from the mount-time background load (or an \`r\` refresh) keeps the Node event loop alive after the user hits \`q\`. The handler returns cleanly but the process lingers until \`gh\` finishes or times out (up to 5s). During that window:

- The user thinks the UI is stuck and presses more keys
- Stdin handlers haven't fully torn down → keys race against \`tsx watch\`'s SIGTERM (when it eventually fires for any reason)
- Eventually the user hits Ctrl+C multiple times, and the TTY reader surfaces \`read EIO\` because the descriptor was torn down mid-read

## Three layers of defense

1. **Explicit \`instance.unmount()\` after \`waitUntilExit\`** in the workspace runtime. Idempotent — Ink usually handles it — but removes a race window where the next mount in \`runWorkspaceLoop\` could conflict.
2. **\`unmountedRef\` shared between mount-effect cleanup and async callbacks** (refresh, drill-in, add-repo). They check it before dispatching so a pending \`gh\` result can't land a setState after Ink has torn down.
3. **\`process.exit(0)\` at clean handler return.** The workspace has no shutdown side effects worth waiting for past quit. Exits the process immediately instead of letting it linger on the pending child.

Also adds a tiny \`COCO_DEBUG_WORKSPACE=1\` env-gated stderr logger that prints the exit reason — preserved across alt-screen exits, so we can diagnose without a debugger build if anything else surfaces.

## Test plan

- [x] Lint clean
- [x] Full Jest suite: 188 suites, 2404 passing, 33 snapshots