### PR TITLE
feat(workspace): two-panel focus model + visible focus indicators + drop flexWrap

### DIFF
--- a/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
+++ b/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
@@ -19,7 +19,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
     <Text
       dimColor={true}
     >
-      3/3 repos  ·  sort: Recent
+      focus: List  ·  3/3 repos  ·  sort: Recent
     </Text>
   </Box>
   <Box
@@ -27,7 +27,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
     height={34}
   >
     <Box
-      borderColor="cyan"
+      borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
@@ -38,7 +38,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
       <Text
         bold={true}
       >
-        Tabs *
+        Tabs
       </Text>
       <Text
         bold={true}
@@ -88,7 +88,6 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -161,7 +160,6 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -239,7 +237,6 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -318,7 +315,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -343,7 +340,7 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
     <Text
       dimColor={true}
     >
-      1/3 repos  ·  sort: Recent
+      focus: List  ·  1/3 repos  ·  sort: Recent
     </Text>
   </Box>
   <Box
@@ -351,7 +348,7 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
     height={34}
   >
     <Box
-      borderColor="cyan"
+      borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
@@ -362,7 +359,7 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
       <Text
         bold={true}
       >
-        Tabs *
+        Tabs
       </Text>
       <Text
         bold={true}
@@ -412,7 +409,6 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -486,7 +482,7 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -511,7 +507,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
     <Text
       dimColor={true}
     >
-      3/3 repos  ·  sort: Recent
+      focus: List  ·  3/3 repos  ·  sort: Recent
     </Text>
   </Box>
   <Box
@@ -519,7 +515,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
     height={34}
   >
     <Box
-      borderColor="cyan"
+      borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
@@ -530,7 +526,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
       <Text
         bold={true}
       >
-        Tabs *
+        Tabs
       </Text>
       <Text
         bold={true}
@@ -582,7 +578,6 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -655,7 +650,6 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -733,7 +727,6 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -812,7 +805,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -837,7 +830,7 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
     <Text
       dimColor={true}
     >
-      3/3 repos  ·  sort: Recent
+      focus: List  ·  3/3 repos  ·  sort: Recent
     </Text>
   </Box>
   <Box
@@ -845,7 +838,7 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
     height={34}
   >
     <Box
-      borderColor="cyan"
+      borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
@@ -856,7 +849,7 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
       <Text
         bold={true}
       >
-        Tabs *
+        Tabs
       </Text>
       <Text
         bold={true}
@@ -906,7 +899,6 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -960,7 +952,6 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -1017,7 +1008,6 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -1074,7 +1064,7 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -1099,7 +1089,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
     <Text
       dimColor={true}
     >
-      3/3 repos  ·  sort: Recent
+      focus: List  ·  3/3 repos  ·  sort: Recent
     </Text>
   </Box>
   <Box
@@ -1107,7 +1097,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
     height={33}
   >
     <Box
-      borderColor="cyan"
+      borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
@@ -1118,7 +1108,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
       <Text
         bold={true}
       >
-        Tabs *
+        Tabs
       </Text>
       <Text
         bold={true}
@@ -1168,7 +1158,6 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -1241,7 +1230,6 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -1319,7 +1307,6 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -1398,7 +1385,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       color="yellow"
@@ -1428,7 +1415,7 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
     <Text
       dimColor={true}
     >
-      3/3 repos  ·  sort: Recent
+      focus: List  ·  3/3 repos  ·  sort: Recent
     </Text>
   </Box>
   <Box
@@ -1436,7 +1423,7 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
     height={34}
   >
     <Box
-      borderColor="cyan"
+      borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
@@ -1447,7 +1434,7 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
       <Text
         bold={true}
       >
-        Tabs *
+        Tabs
       </Text>
       <Text
         bold={true}
@@ -1497,7 +1484,6 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -1531,7 +1517,6 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -1566,7 +1551,6 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -1601,7 +1585,7 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -1626,7 +1610,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
     <Text
       dimColor={true}
     >
-      3/3 repos  ·  sort: Recent
+      focus: List  ·  3/3 repos  ·  sort: Recent
     </Text>
   </Box>
   <Box
@@ -1634,7 +1618,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
     height={34}
   >
     <Box
-      borderColor="cyan"
+      borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
@@ -1645,7 +1629,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
       <Text
         bold={true}
       >
-        Tabs *
+        Tabs
       </Text>
       <Text
         bold={true}
@@ -1695,7 +1679,6 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -1768,7 +1751,6 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -1846,7 +1828,6 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -1925,7 +1906,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -1950,7 +1931,7 @@ exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading fals
     <Text
       dimColor={true}
     >
-      0/0 repos  ·  sort: Recent
+      focus: List  ·  0/0 repos  ·  sort: Recent
     </Text>
   </Box>
   <Box
@@ -1958,7 +1939,7 @@ exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading fals
     height={34}
   >
     <Box
-      borderColor="cyan"
+      borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
@@ -1969,7 +1950,7 @@ exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading fals
       <Text
         bold={true}
       >
-        Tabs *
+        Tabs
       </Text>
       <Text
         bold={true}
@@ -2024,7 +2005,7 @@ exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading fals
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -2049,7 +2030,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
     <Text
       dimColor={true}
     >
-      3/3 repos  ·  sort: Recent
+      focus: Filter  ·  3/3 repos  ·  sort: Recent
     </Text>
   </Box>
   <Box
@@ -2086,7 +2067,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
       </Text>
     </Box>
     <Box
-      borderColor="gray"
+      borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
@@ -2099,7 +2080,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
         <Text
           bold={true}
         >
-          Workspace
+          Workspace *
         </Text>
         <Text
           dimColor={true}
@@ -2118,7 +2099,6 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -2191,7 +2171,6 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -2269,7 +2248,6 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -2373,7 +2351,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
     <Text
       dimColor={true}
     >
-      3/3 repos  ·  sort: Recent
+      focus: Add  ·  3/3 repos  ·  sort: Recent
     </Text>
   </Box>
   <Box
@@ -2442,7 +2420,6 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -2515,7 +2492,6 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -2593,7 +2569,6 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -2719,7 +2694,7 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
     <Text
       dimColor={true}
     >
-      1/3 repos  ·  sort: Recent
+      focus: List  ·  1/3 repos  ·  sort: Recent
     </Text>
   </Box>
   <Box
@@ -2727,7 +2702,7 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
     height={34}
   >
     <Box
-      borderColor="cyan"
+      borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
@@ -2738,7 +2713,7 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
       <Text
         bold={true}
       >
-        Tabs *
+        Tabs
       </Text>
       <Text>
           All
@@ -2788,7 +2763,6 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -2861,7 +2835,7 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -2886,7 +2860,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
     <Text
       dimColor={true}
     >
-      3/3 repos  ·  sort: Recent
+      focus: Confirm  ·  3/3 repos  ·  sort: Recent
     </Text>
   </Box>
   <Box
@@ -2955,7 +2929,6 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -3028,7 +3001,6 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -3106,7 +3078,6 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -3232,7 +3203,7 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
     <Text
       dimColor={true}
     >
-      1/3 repos  ·  sort: Recent
+      focus: List  ·  1/3 repos  ·  sort: Recent
     </Text>
   </Box>
   <Box
@@ -3240,7 +3211,7 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
     height={34}
   >
     <Box
-      borderColor="cyan"
+      borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
@@ -3251,7 +3222,7 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
       <Text
         bold={true}
       >
-        Tabs *
+        Tabs
       </Text>
       <Text>
           All
@@ -3301,7 +3272,6 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -3374,7 +3344,7 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -3399,7 +3369,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
     <Text
       dimColor={true}
     >
-      3/3 repos  ·  sort: Recent
+      focus: List  ·  3/3 repos  ·  sort: Recent
     </Text>
   </Box>
   <Box
@@ -3407,7 +3377,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
     height={29}
   >
     <Box
-      borderColor="cyan"
+      borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
@@ -3418,7 +3388,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
       <Text
         bold={true}
       >
-        Tabs *
+        Tabs
       </Text>
       <Text
         bold={true}
@@ -3468,7 +3438,6 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -3541,7 +3510,6 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -3619,7 +3587,6 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -3718,7 +3685,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -3743,7 +3710,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     <Text
       dimColor={true}
     >
-      3/3 repos  ·  sort: Recent
+      focus: List  ·  3/3 repos  ·  sort: Recent
     </Text>
   </Box>
   <Box
@@ -3763,10 +3730,22 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
       <Text
         color="green"
       >
+        tab / shift-tab  
+      </Text>
+      <Text>
+        Move focus between sidebar and list
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Text
+        color="green"
+      >
         j / ↓            
       </Text>
       <Text>
-        Move cursor down
+        List: move cursor down · Sidebar: next tab
       </Text>
     </Box>
     <Box
@@ -3778,7 +3757,31 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
         k / ↑            
       </Text>
       <Text>
-        Move cursor up
+        List: move cursor up · Sidebar: previous tab
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Text
+        color="green"
+      >
+        h / ←            
+      </Text>
+      <Text>
+        List → sidebar focus
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Text
+        color="green"
+      >
+        l / →            
+      </Text>
+      <Text>
+        Sidebar → list focus (also enter)
       </Text>
     </Box>
     <Box
@@ -3790,7 +3793,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
         g / G            
       </Text>
       <Text>
-        Jump to top / bottom
+        List: jump to top / bottom
       </Text>
     </Box>
     <Box
@@ -3802,31 +3805,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
         enter            
       </Text>
       <Text>
-        Drill into the cursored repo (coco ui)
-      </Text>
-    </Box>
-    <Box
-      flexDirection="row"
-    >
-      <Text
-        color="green"
-      >
-        tab / shift-tab  
-      </Text>
-      <Text>
-        Cycle sidebar tab forward / backward
-      </Text>
-    </Box>
-    <Box
-      flexDirection="row"
-    >
-      <Text
-        color="green"
-      >
-        h / l            
-      </Text>
-      <Text>
-        Cycle sidebar tab (Vim-style)
+        List: drill into the cursored repo (coco ui)
       </Text>
     </Box>
     <Box
@@ -3940,7 +3919,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -3965,7 +3944,7 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
     <Text
       dimColor={true}
     >
-      0/0 repos  ·  sort: Recent  ·  refreshing…
+      focus: List  ·  0/0 repos  ·  sort: Recent  ·  refreshing…
     </Text>
   </Box>
   <Box
@@ -3973,7 +3952,7 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
     height={34}
   >
     <Box
-      borderColor="cyan"
+      borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
@@ -3984,7 +3963,7 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
       <Text
         bold={true}
       >
-        Tabs *
+        Tabs
       </Text>
       <Text
         bold={true}
@@ -4039,7 +4018,7 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>
@@ -4064,7 +4043,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
     <Text
       dimColor={true}
     >
-      3/3 repos  ·  sort: Recent
+      focus: List  ·  3/3 repos  ·  sort: Recent
     </Text>
   </Box>
   <Box
@@ -4072,7 +4051,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
     height={34}
   >
     <Box
-      borderColor="cyan"
+      borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
@@ -4083,7 +4062,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
       <Text
         bold={true}
       >
-        Tabs *
+        Tabs
       </Text>
       <Text
         bold={true}
@@ -4133,7 +4112,6 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -4206,7 +4184,6 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -4284,7 +4261,6 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
         <Box
           flexDirection="row"
           flexShrink={1}
-          flexWrap="wrap"
         >
           <Box
             marginRight={1}
@@ -4363,7 +4339,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
     </Text>
   </Box>
 </Box>

--- a/src/workstation/surfaces/workspace/input.test.ts
+++ b/src/workstation/surfaces/workspace/input.test.ts
@@ -42,7 +42,7 @@ describe('resolveWorkspaceInput', () => {
     })
   })
 
-  it('moves the cursor on j/k and arrow keys', () => {
+  it('moves the cursor on j/k and arrow keys (list focus)', () => {
     expect(resolveWorkspaceInput('j', key(), listState())).toEqual({
       kind: 'action',
       action: { type: 'move-cursor', delta: 1 },
@@ -61,7 +61,7 @@ describe('resolveWorkspaceInput', () => {
     })
   })
 
-  it('jumps to top with g and bottom with G', () => {
+  it('jumps to top with g and bottom with G (list focus)', () => {
     expect(resolveWorkspaceInput('g', key(), listState())).toEqual({
       kind: 'action',
       action: { type: 'set-cursor', index: 0 },
@@ -72,17 +72,46 @@ describe('resolveWorkspaceInput', () => {
     })
   })
 
-  it('cycles tabs on tab / shift-tab / h / l', () => {
+  it('cycles panel focus on tab / shift-tab', () => {
     expect(resolveWorkspaceInput('', key({ tab: true }), listState())).toEqual({
       kind: 'action',
-      action: { type: 'cycle-tab', direction: 'next' },
+      action: { type: 'cycle-panel-focus', direction: 'next' },
     })
     expect(resolveWorkspaceInput('', key({ tab: true, shift: true }), listState())).toEqual({
       kind: 'action',
+      action: { type: 'cycle-panel-focus', direction: 'previous' },
+    })
+  })
+
+  it('list focus: h / ← moves focus to the sidebar', () => {
+    expect(resolveWorkspaceInput('h', key(), listState())).toEqual({
+      kind: 'action',
+      action: { type: 'set-focus', focus: 'sidebar' },
+    })
+    expect(resolveWorkspaceInput('', key({ leftArrow: true }), listState())).toEqual({
+      kind: 'action',
+      action: { type: 'set-focus', focus: 'sidebar' },
+    })
+  })
+
+  it('sidebar focus: j/k cycles the active tab and l/Enter jumps back to the list', () => {
+    const sidebar = { ...listState(), focus: 'sidebar' as const }
+    expect(resolveWorkspaceInput('j', key(), sidebar)).toEqual({
+      kind: 'action',
+      action: { type: 'cycle-tab', direction: 'next' },
+    })
+    expect(resolveWorkspaceInput('k', key(), sidebar)).toEqual({
+      kind: 'action',
       action: { type: 'cycle-tab', direction: 'previous' },
     })
-    expect(resolveWorkspaceInput('h', key(), listState()).kind).toBe('action')
-    expect(resolveWorkspaceInput('l', key(), listState()).kind).toBe('action')
+    expect(resolveWorkspaceInput('l', key(), sidebar)).toEqual({
+      kind: 'action',
+      action: { type: 'set-focus', focus: 'list' },
+    })
+    expect(resolveWorkspaceInput('', key({ return: true }), sidebar)).toEqual({
+      kind: 'action',
+      action: { type: 'set-focus', focus: 'list' },
+    })
   })
 
   it('opens the filter prompt on / and routes drill-in on enter', () => {

--- a/src/workstation/surfaces/workspace/input.ts
+++ b/src/workstation/surfaces/workspace/input.ts
@@ -119,40 +119,60 @@ export function resolveWorkspaceInput(
     return { kind: 'quit' }
   }
 
-  if (key.return) {
-    return { kind: 'drill-in' }
-  }
-
-  if (key.downArrow || input === 'j') {
-    return { kind: 'action', action: { type: 'move-cursor', delta: 1 } }
-  }
-  if (key.upArrow || input === 'k') {
-    return { kind: 'action', action: { type: 'move-cursor', delta: -1 } }
-  }
-  if (key.pageDown) {
-    return { kind: 'action', action: { type: 'move-cursor', delta: 10 } }
-  }
-  if (key.pageUp) {
-    return { kind: 'action', action: { type: 'move-cursor', delta: -10 } }
-  }
-  if (input === 'g' && !key.shift) {
-    return { kind: 'action', action: { type: 'set-cursor', index: 0 } }
-  }
-  if (input === 'G' || (input === 'g' && key.shift)) {
-    return { kind: 'action', action: { type: 'set-cursor', index: Number.MAX_SAFE_INTEGER } }
-  }
-
+  // Tab / Shift+Tab cycles between sidebar and list focus. Always
+  // available (in both list and sidebar modes) so the user can always
+  // pop back to the panel they need.
   if (key.tab) {
     return {
       kind: 'action',
-      action: { type: 'cycle-tab', direction: key.shift ? 'previous' : 'next' },
+      action: { type: 'cycle-panel-focus', direction: key.shift ? 'previous' : 'next' },
     }
   }
-  if (input === 'h' || key.leftArrow) {
-    return { kind: 'action', action: { type: 'cycle-tab', direction: 'previous' } }
+
+  // Sidebar focus: j/k changes the active tab; Enter / l / →
+  // commits the selection and jumps focus to the list.
+  if (state.focus === 'sidebar') {
+    if (key.downArrow || input === 'j') {
+      return { kind: 'action', action: { type: 'cycle-tab', direction: 'next' } }
+    }
+    if (key.upArrow || input === 'k') {
+      return { kind: 'action', action: { type: 'cycle-tab', direction: 'previous' } }
+    }
+    if (key.return || key.rightArrow || input === 'l') {
+      return { kind: 'action', action: { type: 'set-focus', focus: 'list' } }
+    }
+    // Global keys (sort, filter, refresh, etc.) still work while
+    // the sidebar has focus — fall through to the shared handlers
+    // below.
   }
-  if (input === 'l' || key.rightArrow) {
-    return { kind: 'action', action: { type: 'cycle-tab', direction: 'next' } }
+
+  // List focus: j/k moves the cursor; Enter drills in; h / ←
+  // jumps focus to the sidebar.
+  if (state.focus === 'list') {
+    if (key.return) {
+      return { kind: 'drill-in' }
+    }
+    if (key.downArrow || input === 'j') {
+      return { kind: 'action', action: { type: 'move-cursor', delta: 1 } }
+    }
+    if (key.upArrow || input === 'k') {
+      return { kind: 'action', action: { type: 'move-cursor', delta: -1 } }
+    }
+    if (key.pageDown) {
+      return { kind: 'action', action: { type: 'move-cursor', delta: 10 } }
+    }
+    if (key.pageUp) {
+      return { kind: 'action', action: { type: 'move-cursor', delta: -10 } }
+    }
+    if (input === 'g' && !key.shift) {
+      return { kind: 'action', action: { type: 'set-cursor', index: 0 } }
+    }
+    if (input === 'G' || (input === 'g' && key.shift)) {
+      return { kind: 'action', action: { type: 'set-cursor', index: Number.MAX_SAFE_INTEGER } }
+    }
+    if (input === 'h' || key.leftArrow) {
+      return { kind: 'action', action: { type: 'set-focus', focus: 'sidebar' } }
+    }
   }
 
   if (input === 's') {

--- a/src/workstation/surfaces/workspace/render.ts
+++ b/src/workstation/surfaces/workspace/render.ts
@@ -320,13 +320,16 @@ export type WorkspaceFooterModel = {
   filterMode: boolean
 }
 
-const LIST_HINT = 'j/k move · enter open · tab tab · s sort · / filter · r refresh · a add · d remove · ? help · q quit'
+const LIST_HINT = 'j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit'
+const SIDEBAR_HINT = 'j/k change tab · enter / l → list · tab → list · ? help · q quit'
 const FILTER_HINT = 'type filter · enter to apply · esc to clear'
 const ADD_REPO_HINT = 'type path · tab to complete · enter to add · esc to cancel'
 const CONFIRM_DELETE_HINT = 'press y to remove · any other key to cancel'
 
 function hintFor(focus: WorkspaceState['focus']): string {
   switch (focus) {
+    case 'sidebar':
+      return SIDEBAR_HINT
     case 'filter':
       return FILTER_HINT
     case 'add-repo':
@@ -367,12 +370,13 @@ export type WorkspaceHelpRow = {
  */
 export function buildWorkspaceHelpRows(): WorkspaceHelpRow[] {
   return [
-    { keys: 'j / ↓', description: 'Move cursor down' },
-    { keys: 'k / ↑', description: 'Move cursor up' },
-    { keys: 'g / G', description: 'Jump to top / bottom' },
-    { keys: 'enter', description: 'Drill into the cursored repo (coco ui)' },
-    { keys: 'tab / shift-tab', description: 'Cycle sidebar tab forward / backward' },
-    { keys: 'h / l', description: 'Cycle sidebar tab (Vim-style)' },
+    { keys: 'tab / shift-tab', description: 'Move focus between sidebar and list' },
+    { keys: 'j / ↓', description: 'List: move cursor down · Sidebar: next tab' },
+    { keys: 'k / ↑', description: 'List: move cursor up · Sidebar: previous tab' },
+    { keys: 'h / ←', description: 'List → sidebar focus' },
+    { keys: 'l / →', description: 'Sidebar → list focus (also enter)' },
+    { keys: 'g / G', description: 'List: jump to top / bottom' },
+    { keys: 'enter', description: 'List: drill into the cursored repo (coco ui)' },
     { keys: 's', description: 'Cycle sort mode (recency → name → dirty)' },
     { keys: '/', description: 'Filter the list by name or branch' },
     { keys: 'r', description: 'Refresh discovery' },

--- a/src/workstation/surfaces/workspace/state.test.ts
+++ b/src/workstation/surfaces/workspace/state.test.ts
@@ -62,6 +62,27 @@ describe('workspace state reducer', () => {
     expect(cursored.selectedIndex).toBe(0)
   })
 
+  it('cycle-panel-focus toggles between sidebar and list', () => {
+    expect(baseState.focus).toBe('list')
+    const onSidebar = applyWorkspaceAction(baseState, {
+      type: 'cycle-panel-focus',
+      direction: 'next',
+    })
+    expect(onSidebar.focus).toBe('sidebar')
+    const backToList = applyWorkspaceAction(onSidebar, {
+      type: 'cycle-panel-focus',
+      direction: 'next',
+    })
+    expect(backToList.focus).toBe('list')
+  })
+
+  it('cycle-panel-focus is a no-op while a modal focus is active', () => {
+    const inFilter = { ...baseState, focus: 'filter' as const }
+    expect(
+      applyWorkspaceAction(inFilter, { type: 'cycle-panel-focus', direction: 'next' }).focus
+    ).toBe('filter')
+  })
+
   it('cycles tabs forward and backward', () => {
     const next = applyWorkspaceAction(baseState, { type: 'cycle-tab', direction: 'next' })
     expect(next.tab).toBe('dirty')

--- a/src/workstation/surfaces/workspace/state.ts
+++ b/src/workstation/surfaces/workspace/state.ts
@@ -23,7 +23,23 @@ import {
  * dispatches them on action payloads.
  */
 
-export type WorkspaceFocus = 'list' | 'filter' | 'add-repo' | 'confirm-delete'
+/**
+ * Which panel currently receives j/k input. Modeled to match
+ * `coco ui`'s `'sidebar' | 'commits' | 'detail'` so users moving
+ * between the two surfaces don't have to learn a different focus
+ * model.
+ *
+ * - `sidebar`: j/k cycles the tab filter (All / Dirty / Behind / PRs)
+ * - `list`:    j/k moves the cursor through repos
+ * - `filter`:  modal text-input for the search filter
+ * - `add-repo`: modal path-prompt
+ * - `confirm-delete`: modal y-confirm before removing a repo
+ *
+ * Tab / Shift+Tab cycles between `sidebar` and `list`. Modal focuses
+ * are entered/exited via their own keys (`/`, `a`, `d`) and ignore
+ * Tab while open.
+ */
+export type WorkspaceFocus = 'sidebar' | 'list' | 'filter' | 'add-repo' | 'confirm-delete'
 
 export type WorkspaceState = {
   overview: WorkspaceOverview
@@ -85,6 +101,7 @@ export type WorkspaceAction =
   | { type: 'cycle-sort' }
   | { type: 'set-tab'; tab: WorkspaceTab }
   | { type: 'cycle-tab'; direction: 'next' | 'previous' }
+  | { type: 'cycle-panel-focus'; direction: 'next' | 'previous' }
   | { type: 'set-filter'; filter: string }
   | { type: 'clear-filter' }
   | { type: 'set-focus'; focus: WorkspaceFocus }
@@ -229,6 +246,17 @@ export function applyWorkspaceAction(
           ? nextWorkspaceTab(state.tab)
           : previousWorkspaceTab(state.tab)
       return rectifySelection({ ...state, tab, selectedIndex: 0 })
+    }
+    case 'cycle-panel-focus': {
+      // Two-panel cycle: sidebar ↔ list. Modal focuses (filter,
+      // add-repo, confirm-delete) are reached/dismissed via their
+      // own bindings and ignore Tab — explicit modes shouldn't be
+      // exit-able by an accidental Tab press.
+      if (state.focus !== 'sidebar' && state.focus !== 'list') {
+        return state
+      }
+      const next: WorkspaceFocus = state.focus === 'sidebar' ? 'list' : 'sidebar'
+      return { ...state, focus: next }
     }
     case 'set-filter': {
       return rectifySelection({ ...state, filter: action.filter, selectedIndex: 0 })

--- a/src/workstation/surfaces/workspace/view.ts
+++ b/src/workstation/surfaces/workspace/view.ts
@@ -58,12 +58,31 @@ function toneColor(tone: WorkspaceListColumn['tone'], theme: LogInkTheme): strin
   }
 }
 
+function focusLabel(focus: WorkspaceState['focus']): string {
+  switch (focus) {
+    case 'sidebar':
+      return 'Tabs'
+    case 'list':
+      return 'List'
+    case 'filter':
+      return 'Filter'
+    case 'add-repo':
+      return 'Add'
+    case 'confirm-delete':
+      return 'Confirm'
+    default:
+      return 'List'
+  }
+}
+
 function renderHeader(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement {
   const { React, ink, state, theme, appLabel } = deps
   const { Box, Text } = ink
   const model = buildWorkspaceHeader(state, { appLabel })
+  const focusChip = `focus: ${focusLabel(state.focus)}`
   const left = `${model.appLabel}  roots: ${model.rootsLabel || '—'}`
   const right = [
+    focusChip,
     `${model.visibleCount}/${model.repoCount} repos`,
     `sort: ${model.sortLabel}`,
     model.loading ? 'refreshing…' : '',
@@ -84,12 +103,19 @@ function renderSidebar(
 ): ReactTypes.ReactElement {
   const { React, ink, state, theme } = deps
   const { Box, Text } = ink
-  const focused = state.focus === 'list'
+  // Sidebar owns the focus when the user is cycling tabs.
+  const focused = state.focus === 'sidebar'
   const tabs = buildWorkspaceSidebar(state)
   const rows = tabs.map((row) => {
     const props: Record<string, unknown> = { key: row.tab }
     if (row.active) {
       props.bold = true
+      // While the sidebar is focused, the active tab gets the
+      // accent color so users can tell at a glance that their
+      // j/k presses are landing on a tab cycle.
+      if (focused && !theme.noColor) {
+        props.color = theme.colors.accent
+      }
     } else if (row.disabled) {
       props.dimColor = true
     }
@@ -139,7 +165,10 @@ function renderListRow(
     Box,
     { key, flexDirection: 'row' },
     React.createElement(Text, { bold: row.cursor }, `${cursor} `),
-    React.createElement(Box, { flexDirection: 'row', flexShrink: 1, flexWrap: 'wrap' }, ...cells)
+    // flexWrap removed deliberately — wrapping caused extra layout
+    // passes per render and contributed to the alt-screen flicker.
+    // The column-width helper already truncates each cell to fit.
+    React.createElement(Box, { flexDirection: 'row', flexShrink: 1 }, ...cells)
   )
 }
 
@@ -150,7 +179,11 @@ function renderListBody(
 ): ReactTypes.ReactElement {
   const { React, ink, state, theme } = deps
   const { Box, Text } = ink
-  const focused = state.focus !== 'filter'
+  // List panel is "focused" when j/k means cursor movement — i.e.
+  // when the user is in list mode or a modal that was opened from
+  // the list (filter, add-repo, confirm-delete). Sidebar focus
+  // dims the list panel border to make the active panel obvious.
+  const focused = state.focus !== 'sidebar'
   // Reserve: 1 row for the panel header, 1 for each scroll indicator
   // (if shown), 2 for the border. Floor at 1 so the panel always
   // renders at least one row.


### PR DESCRIPTION
Addresses the \"can't tell which panel owns input\" report and the \"every keypress refreshes the whole screen\" flicker.

## What the user sees

**Focus is now obvious at a glance** via three coordinated cues:

1. **Focus chip in the header** — \`focus: List\` / \`focus: Tabs\` / \`focus: Filter\` etc. Always visible, always accurate.
2. **Border + active-row colors switch with focus** — sidebar border drops to gray when the list owns focus; the active tab loses its accent color too. Same shape as \`coco ui\`'s panel-focus pattern.
3. **Footer hint changes per focus** — sidebar focus shows \`j/k change tab · enter / l → list\` so users learn the per-focus keymap from the screen.

**Two-panel focus model** mirrors \`coco ui\`:
- Tab / Shift+Tab cycles between sidebar and list (modal focuses like filter / add-repo / confirm-delete ignore Tab — accidental Tab can't bail out of a half-typed filter).
- **Sidebar focus**: j/k cycles the active tab; Enter / l / → commits back to the list.
- **List focus**: j/k moves the cursor; Enter drills in; h / ← jumps to the sidebar.

## Flicker reduction

Dropped \`flexWrap: 'wrap'\` from the per-row cell container. Wrapping caused extra Yoga layout passes per render and contributed to visible flicker on every keypress. The column-width helper already truncates cells to fit, so wrap was buying nothing.

## Commits

1. \`two-panel focus model (sidebar ↔ list)\` — state + input + 11 new / updated tests
2. \`visible focus indicators + drop flexWrap\` — view rendering + 17 snapshot refreshes

## Test plan

- [x] Lint + typecheck clean
- [x] Full Jest suite: 188 suites, 2408 passing, 33 snapshots
- [ ] Manual: \`yarn dev workspace\`, press Tab — sidebar border turns colored, list border turns gray. Press j/k — tab cycles instead of cursor. Press Tab again — focus flips. Esc/`/`/`a`/`d` modals still work and ignore Tab.