### PR TITLE
diag(workspace): file-based debug log to chase the restart bug

### DIFF
--- a/src/commands/workspace/handler.ts
+++ b/src/commands/workspace/handler.ts
@@ -68,6 +68,7 @@ export function buildDrillInUiArgv(argv: WorkspaceArgv): UiArgv {
 }
 
 import type { WorkspaceExitResult } from '../../workstation/surfaces/workspace'
+import { workspaceDebug } from '../../workstation/surfaces/workspace/runtime'
 
 export type WorkspaceLoopDeps = {
   startWorkspace: (
@@ -88,16 +89,23 @@ export type WorkspaceLoopDeps = {
  */
 export async function runWorkspaceLoop(deps: WorkspaceLoopDeps): Promise<void> {
   let resume: WorkspaceResumeState | undefined
+  let iteration = 0
   // eslint-disable-next-line no-constant-condition
   while (true) {
+    iteration += 1
+    workspaceDebug(`loop iteration=${iteration} resume=${JSON.stringify(resume)}`)
     const result = await deps.startWorkspace(resume)
+    workspaceDebug(`loop result kind=${result.kind}`)
     if (result.kind === 'quit') {
+      workspaceDebug('loop returning (quit)')
       return
     }
     resume = result.resume
     try {
       deps.chdir(result.repo.path)
+      workspaceDebug(`loop running ui for ${result.repo.path}`)
       await deps.runUiForRepo(result.repo.path)
+      workspaceDebug('loop ui finished')
     } finally {
       deps.chdir(deps.baseCwd)
     }

--- a/src/workstation/surfaces/workspace/runtime.ts
+++ b/src/workstation/surfaces/workspace/runtime.ts
@@ -180,6 +180,8 @@ export function mergeKnownRepos(
 export async function startWorkspace(
   options: WorkspaceStartOptions
 ): Promise<WorkspaceExitResult> {
+  installWorkspaceDebugHandlers()
+  workspaceDebug(`startWorkspace called roots=${options.roots.join(',')} hasResume=${Boolean(options.resume)}`)
   const streams = options.streams ?? {}
   const input = streams.input ?? process.stdin
   const output = streams.output ?? process.stdout
@@ -271,17 +273,68 @@ export async function startWorkspace(
 }
 
 /**
- * Tiny diagnostic logger toggled by COCO_DEBUG_WORKSPACE=1. Writes a
- * single line to stderr (preserved across alt-screen exits) so users
- * can share what the workspace runtime saw without us having to ship
- * a debugger build.
+ * Diagnostic logger toggled by COCO_DEBUG_WORKSPACE=1. Writes to a
+ * file (NOT stderr) because alt-screen mode buries stderr output
+ * under the rendered frames — by the time the user exits the alt
+ * screen, scrollback usually loses the diagnostic lines.
+ *
+ * Each entry is timestamped relative to process start so the user
+ * can spot timing-related restarts. Default path is
+ * `/tmp/coco-workspace-debug.log`; override via the env var
+ * `COCO_DEBUG_WORKSPACE_PATH`.
+ *
+ * One-time process-level handlers (installed on first call) log:
+ *   - uncaught exceptions / unhandled rejections (the most likely
+ *     restart trigger — panics from useInput callbacks)
+ *   - process.exit codes (so we can tell whether tsx watch restarted
+ *     us vs. we exited cleanly)
+ *   - SIGINT / SIGTERM (terminal-driven kills)
  */
-function workspaceDebug(message: string): void {
-  if (!process.env.COCO_DEBUG_WORKSPACE) {
-    return
-  }
+
+const WORKSPACE_DEBUG_START = Date.now()
+let workspaceDebugPath: string | undefined
+let workspaceDebugInstalled = false
+
+function workspaceDebugEnabled(): boolean {
+  return Boolean(process.env.COCO_DEBUG_WORKSPACE)
+}
+
+function resolveWorkspaceDebugPath(): string {
+  if (workspaceDebugPath) return workspaceDebugPath
+  workspaceDebugPath = process.env.COCO_DEBUG_WORKSPACE_PATH || '/tmp/coco-workspace-debug.log'
+  return workspaceDebugPath
+}
+
+function installWorkspaceDebugHandlers(): void {
+  if (workspaceDebugInstalled || !workspaceDebugEnabled()) return
+  workspaceDebugInstalled = true
+  process.on('uncaughtException', (err) => {
+    workspaceDebug(`uncaughtException: ${err instanceof Error ? err.stack || err.message : String(err)}`)
+  })
+  process.on('unhandledRejection', (reason) => {
+    workspaceDebug(`unhandledRejection: ${reason instanceof Error ? reason.stack || reason.message : String(reason)}`)
+  })
+  process.on('exit', (code) => {
+    workspaceDebug(`process.exit code=${code}`)
+  })
+  process.on('SIGINT', () => workspaceDebug('SIGINT'))
+  process.on('SIGTERM', () => workspaceDebug('SIGTERM'))
+  process.on('SIGHUP', () => workspaceDebug('SIGHUP'))
+  workspaceDebug(`debug log opened pid=${process.pid} cwd=${process.cwd()}`)
+}
+
+export function workspaceDebug(message: string): void {
+  if (!workspaceDebugEnabled()) return
+  installWorkspaceDebugHandlers()
+  const ts = Date.now() - WORKSPACE_DEBUG_START
+  const line = `[+${String(ts).padStart(6, ' ')}ms] ${message}\n`
   try {
-    process.stderr.write(`[workspace] ${message}\n`)
+    // appendFileSync is sync + creates the file if missing; on a panic
+    // path this is the only way to guarantee the line lands before
+    // process.exit fires.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const fs = require('node:fs') as typeof import('node:fs')
+    fs.appendFileSync(resolveWorkspaceDebugPath(), line)
   } catch {
     // best-effort
   }
@@ -538,6 +591,17 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
   }, [addRepoDraft, dispatch, props])
 
   useInput((rawInput: string, key: WorkspaceInputKey) => {
+    // Diagnostic: log every keypress with its raw bytes + flags +
+    // current focus + visible repo count. Without this, restart bugs
+    // are guesswork — this gives us a forensic trail.
+    const charCode = rawInput ? rawInput.charCodeAt(0) : -1
+    const flags = Object.entries(key)
+      .filter(([, value]) => value)
+      .map(([name]) => name)
+      .join(',') || '(none)'
+    workspaceDebug(
+      `useInput rawInput="${rawInput}" code=${charCode} flags=${flags} focus=${state.focus} showOnboarding=${state.showOnboarding} showHelp=${state.showHelp}`
+    )
     // First-run onboarding is non-modal — any keypress dismisses it
     // and persists the marker. The keypress still flows through to
     // the normal handler below so the user's first action isn't
@@ -597,15 +661,20 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
     }
 
     const intent = resolveWorkspaceInput(rawInput, key, state)
+    workspaceDebug(
+      `resolved intent=${intent.kind}${intent.kind === 'action' ? ` actionType=${intent.action.type}` : ''}`
+    )
     switch (intent.kind) {
       case 'action':
         dispatch(intent.action)
         break
       case 'quit':
+        workspaceDebug('intent=quit → calling exit()')
         props.exitRef.current = { kind: 'quit' }
         exit()
         break
       case 'drill-in':
+        workspaceDebug('intent=drill-in → calling drillIn()')
         drillIn()
         break
       case 'refresh':


### PR DESCRIPTION
The restart bug isn't fully understood — fixing it blindly with PR1053/1054/1056 hasn't worked. This PR ships a comprehensive trace so we can **see** exactly what's happening on the user's terminal.

## What it captures

Enable with \`COCO_DEBUG_WORKSPACE=1\`. Writes to \`/tmp/coco-workspace-debug.log\` by default (override with \`COCO_DEBUG_WORKSPACE_PATH\`). File-based instead of stderr because alt-screen mode buries stderr output by the time the user can read it.

Each line is timestamped relative to process start. Captured events:

- \`startWorkspace\` calls with the resume seed
- **Every keypress**: raw byte + char code + key flags + current focus + onboarding/help flags
- The resolved input intent + action type
- Explicit drill-in and quit transitions
- Loop iterations — so we can tell if the workspace is remounting because the loop iterated (drill-in) vs. because the process actually restarted (tsx watch / panic / signal)
- One-time process handlers for uncaughtException, unhandledRejection, process.on('exit'), SIGINT, SIGTERM, SIGHUP

## How to use

\`\`\`bash
rm -f /tmp/coco-workspace-debug.log
COCO_DEBUG_WORKSPACE=1 yarn dev workspace
# trigger the restart
cat /tmp/coco-workspace-debug.log
\`\`\`

If a restart is from a panic, we'll see \`uncaughtException: …\` followed by \`process.exit code=…\` then a fresh \`debug log opened pid=…\` from the new process. If it's a drill-in misfire we'll see \`intent=drill-in\` and a new \`loop iteration=2\`. If it's something else, we'll see the signal that caught the process.

## Test plan

- [x] Lint clean
- [x] Workspace + handler tests pass: 116 tests
- [x] No production behavior change when env var is unset