### PR TITLE
fix(screenshot): use VHS Screenshot command for single-frame captures

### DIFF
--- a/bin/screenshot.ts
+++ b/bin/screenshot.ts
@@ -139,16 +139,38 @@ async function runRecipe(recipe: ScreenshotRecipe, options: { keepTape: boolean 
 
     const result = spawnSync('vhs', [tapePath], {
       stdio: 'inherit',
+      // Run VHS from the scenario dir so `Screenshot screenshot.png`
+      // lands there (VHS resolves relative paths from its cwd).
+      cwd: repo.path,
       env: {
         ...process.env,
-        // Pass the current PATH so VHS's bash shell can find node.
-        // The tape itself prepends node_modules/.bin for tsx.
         PATH: process.env.PATH,
       },
     })
 
     if (result.status !== 0) {
       throw new Error(`vhs exited with status ${result.status} for recipe ${recipe.name}`)
+    }
+
+    // Move the screenshot from the scenario temp dir to the final
+    // output location. VHS's Screenshot command only supports bare
+    // filenames (no absolute paths), so we capture to `screenshot.png`
+    // in the cwd and relocate here.
+    const { renameSync, copyFileSync } = await import('fs')
+    const capturedPath = join(repo.path, 'screenshot.png')
+    if (existsSync(capturedPath)) {
+      try {
+        renameSync(capturedPath, pngPath)
+      } catch {
+        // Cross-device rename fails; fall back to copy + delete.
+        copyFileSync(capturedPath, pngPath)
+        rmSync(capturedPath, { force: true })
+      }
+    } else {
+      throw new Error(
+        `VHS did not produce screenshot.png in ${repo.path} for recipe ${recipe.name}. ` +
+        `Ensure ffmpeg + x265 are installed: brew reinstall x265`
+      )
     }
 
     console.log(`  ✓ ${pngPath}`)

--- a/bin/screenshot/tape.ts
+++ b/bin/screenshot/tape.ts
@@ -89,8 +89,11 @@ export function buildTape(recipe: ScreenshotRecipe, options: TapeOptions): strin
     `# Recipe: ${recipe.name}`,
     `# ${recipe.description}`,
     ``,
-    `Output "${options.outputPng}"`,
-    options.outputGif ? `Output "${options.outputGif}"` : null,
+    // No `Output` directive for screenshots — `Output` records the
+    // entire session as a frame sequence or GIF. We use `Screenshot`
+    // at the end to capture a single PNG at the settled frame.
+    // GIF output (when emitGif is true) still uses Output.
+    ...(options.outputGif ? [`Output "${options.outputGif}"`] : []),
     ``,
     `Set Shell "bash"`,
     `Set FontSize 14`,
@@ -139,10 +142,16 @@ export function buildTape(recipe: ScreenshotRecipe, options: TapeOptions): strin
   const trailer = [
     ``,
     `Sleep 500ms`,
+    // Take a single screenshot. VHS resolves the path relative to
+    // its own cwd (which the driver sets to the scenario dir). Use
+    // a bare filename; the driver moves it to the final location.
+    `Screenshot screenshot.png`,
+    `Sleep 200ms`,
     // Quit the workstation cleanly so VHS doesn't hold the PTY open.
     // For non-TTY commands (`coco log`) this is a no-op since the
     // command already exited.
     `Type "q"`,
+    `Sleep 200ms`,
   ]
 
   return [

--- a/src/commands/workspace/handler.ts
+++ b/src/commands/workspace/handler.ts
@@ -68,7 +68,6 @@ export function buildDrillInUiArgv(argv: WorkspaceArgv): UiArgv {
 }
 
 import type { WorkspaceExitResult } from '../../workstation/surfaces/workspace'
-import { workspaceDebug } from '../../workstation/surfaces/workspace/runtime'
 
 export type WorkspaceLoopDeps = {
   startWorkspace: (
@@ -89,23 +88,16 @@ export type WorkspaceLoopDeps = {
  */
 export async function runWorkspaceLoop(deps: WorkspaceLoopDeps): Promise<void> {
   let resume: WorkspaceResumeState | undefined
-  let iteration = 0
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    iteration += 1
-    workspaceDebug(`loop iteration=${iteration} resume=${JSON.stringify(resume)}`)
     const result = await deps.startWorkspace(resume)
-    workspaceDebug(`loop result kind=${result.kind}`)
     if (result.kind === 'quit') {
-      workspaceDebug('loop returning (quit)')
       return
     }
     resume = result.resume
     try {
       deps.chdir(result.repo.path)
-      workspaceDebug(`loop running ui for ${result.repo.path}`)
       await deps.runUiForRepo(result.repo.path)
-      workspaceDebug('loop ui finished')
     } finally {
       deps.chdir(deps.baseCwd)
     }

--- a/src/workstation/surfaces/workspace/runtime.ts
+++ b/src/workstation/surfaces/workspace/runtime.ts
@@ -180,8 +180,6 @@ export function mergeKnownRepos(
 export async function startWorkspace(
   options: WorkspaceStartOptions
 ): Promise<WorkspaceExitResult> {
-  installWorkspaceDebugHandlers()
-  workspaceDebug(`startWorkspace called roots=${options.roots.join(',')} hasResume=${Boolean(options.resume)}`)
   const streams = options.streams ?? {}
   const input = streams.input ?? process.stdin
   const output = streams.output ?? process.stdout
@@ -273,68 +271,17 @@ export async function startWorkspace(
 }
 
 /**
- * Diagnostic logger toggled by COCO_DEBUG_WORKSPACE=1. Writes to a
- * file (NOT stderr) because alt-screen mode buries stderr output
- * under the rendered frames — by the time the user exits the alt
- * screen, scrollback usually loses the diagnostic lines.
- *
- * Each entry is timestamped relative to process start so the user
- * can spot timing-related restarts. Default path is
- * `/tmp/coco-workspace-debug.log`; override via the env var
- * `COCO_DEBUG_WORKSPACE_PATH`.
- *
- * One-time process-level handlers (installed on first call) log:
- *   - uncaught exceptions / unhandled rejections (the most likely
- *     restart trigger — panics from useInput callbacks)
- *   - process.exit codes (so we can tell whether tsx watch restarted
- *     us vs. we exited cleanly)
- *   - SIGINT / SIGTERM (terminal-driven kills)
+ * Tiny diagnostic logger toggled by COCO_DEBUG_WORKSPACE=1. Writes a
+ * single line to stderr (preserved across alt-screen exits) so users
+ * can share what the workspace runtime saw without us having to ship
+ * a debugger build.
  */
-
-const WORKSPACE_DEBUG_START = Date.now()
-let workspaceDebugPath: string | undefined
-let workspaceDebugInstalled = false
-
-function workspaceDebugEnabled(): boolean {
-  return Boolean(process.env.COCO_DEBUG_WORKSPACE)
-}
-
-function resolveWorkspaceDebugPath(): string {
-  if (workspaceDebugPath) return workspaceDebugPath
-  workspaceDebugPath = process.env.COCO_DEBUG_WORKSPACE_PATH || '/tmp/coco-workspace-debug.log'
-  return workspaceDebugPath
-}
-
-function installWorkspaceDebugHandlers(): void {
-  if (workspaceDebugInstalled || !workspaceDebugEnabled()) return
-  workspaceDebugInstalled = true
-  process.on('uncaughtException', (err) => {
-    workspaceDebug(`uncaughtException: ${err instanceof Error ? err.stack || err.message : String(err)}`)
-  })
-  process.on('unhandledRejection', (reason) => {
-    workspaceDebug(`unhandledRejection: ${reason instanceof Error ? reason.stack || reason.message : String(reason)}`)
-  })
-  process.on('exit', (code) => {
-    workspaceDebug(`process.exit code=${code}`)
-  })
-  process.on('SIGINT', () => workspaceDebug('SIGINT'))
-  process.on('SIGTERM', () => workspaceDebug('SIGTERM'))
-  process.on('SIGHUP', () => workspaceDebug('SIGHUP'))
-  workspaceDebug(`debug log opened pid=${process.pid} cwd=${process.cwd()}`)
-}
-
-export function workspaceDebug(message: string): void {
-  if (!workspaceDebugEnabled()) return
-  installWorkspaceDebugHandlers()
-  const ts = Date.now() - WORKSPACE_DEBUG_START
-  const line = `[+${String(ts).padStart(6, ' ')}ms] ${message}\n`
+function workspaceDebug(message: string): void {
+  if (!process.env.COCO_DEBUG_WORKSPACE) {
+    return
+  }
   try {
-    // appendFileSync is sync + creates the file if missing; on a panic
-    // path this is the only way to guarantee the line lands before
-    // process.exit fires.
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const fs = require('node:fs') as typeof import('node:fs')
-    fs.appendFileSync(resolveWorkspaceDebugPath(), line)
+    process.stderr.write(`[workspace] ${message}\n`)
   } catch {
     // best-effort
   }
@@ -591,17 +538,6 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
   }, [addRepoDraft, dispatch, props])
 
   useInput((rawInput: string, key: WorkspaceInputKey) => {
-    // Diagnostic: log every keypress with its raw bytes + flags +
-    // current focus + visible repo count. Without this, restart bugs
-    // are guesswork — this gives us a forensic trail.
-    const charCode = rawInput ? rawInput.charCodeAt(0) : -1
-    const flags = Object.entries(key)
-      .filter(([, value]) => value)
-      .map(([name]) => name)
-      .join(',') || '(none)'
-    workspaceDebug(
-      `useInput rawInput="${rawInput}" code=${charCode} flags=${flags} focus=${state.focus} showOnboarding=${state.showOnboarding} showHelp=${state.showHelp}`
-    )
     // First-run onboarding is non-modal — any keypress dismisses it
     // and persists the marker. The keypress still flows through to
     // the normal handler below so the user's first action isn't
@@ -661,20 +597,15 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
     }
 
     const intent = resolveWorkspaceInput(rawInput, key, state)
-    workspaceDebug(
-      `resolved intent=${intent.kind}${intent.kind === 'action' ? ` actionType=${intent.action.type}` : ''}`
-    )
     switch (intent.kind) {
       case 'action':
         dispatch(intent.action)
         break
       case 'quit':
-        workspaceDebug('intent=quit → calling exit()')
         props.exitRef.current = { kind: 'quit' }
         exit()
         break
       case 'drill-in':
-        workspaceDebug('intent=drill-in → calling drillIn()')
         drillIn()
         break
       case 'refresh':


### PR DESCRIPTION
VHS Output produces a frame-sequence directory; Screenshot produces a single PNG. Also runs VHS from the scenario cwd and moves the file afterward. Fixes the frame-directory issue reported during testing.