### PR TITLE
build: dev:tui script that bypasses tsx watch (fixes 'TUI restarts on Enter')

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "scripts": {
     "start": "npm run dev",
     "dev": "tsx watch src/index.ts",
+    "dev:tui": "tsx src/index.ts",
     "prebuild": "npm run build:schema && npm run build:info",
     "build": "rollup -c",
     "postbuild": "node bin/copyTreeSitterWasm.mjs",


### PR DESCRIPTION
**This is the actual root cause** of every \"workspace restarts on keystroke\" / \"q doesn't quit\" report from the last several sessions.

\`tsx watch\` intercepts Return and Ctrl+C in its TTY as restart / exit triggers, **before** forwarding stdin to the child process. The TUI's \`useInput\` handler never sees those keys. User visible symptom: \`[tsx] Return key Restarting...\` text between rendered frames, plus \`q\` appearing not to quit (because q goes to Ink → Ink calls exit() → tsx watch re-runs the process).

## The actual fix shipped here

\`\`\`json
\"dev:tui\": \"tsx src/index.ts\"
\`\`\`

Same as \`dev\` but without \`watch\`. Users give up auto-reload on file change but get working keyboard handling for any of \`coco workspace\` / \`coco ui\` / \`coco log -i\`.

## Use

\`\`\`bash
# Before — broken on TUIs:
yarn dev workspace

# After — works:
yarn dev:tui workspace
\`\`\`

## Why so many PRs got shipped chasing this

The fixes I shipped along the way are all real improvements and worth keeping:

- **#1053** bare-ESC quit removal — fixed a real footgun for terminals that deliver arrow keys as separate bytes
- **#1054** explicit process.exit on quit — eliminates the gh-pending-call lingering bug
- **#1056** two-panel focus model + flicker reduction — major UX upgrade
- **#1060** stable input handler via callback refs — eliminates stdin churn
- **#1061** ring-buffer diagnostics — keeps a forensic trail available

None of them could have fixed this particular symptom because the bug was outside the workspace code entirely. The trace from #1061 would have shown it (\`startWorkspace\` running, \`process.exit\`, then a NEW \`startWorkspace\` from a fresh pid) — that data plus the user's pasted \`[tsx] Return key Restarting...\` line was what finally pinned it.

## Test plan

- [x] Lint clean
- [ ] Manual: \`yarn dev:tui workspace\` — keystrokes work, q quits, Ctrl+C quits, no surprise restarts