### PR TITLE
feat(workspace): style parity with `coco ui` (chips, columns, tab counts, footer)

### DIFF
--- a/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
+++ b/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
@@ -8,59 +8,147 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
   <Box
     borderColor="cyan"
     borderStyle="classic"
-    justifyContent="space-between"
     paddingX={1}
   >
     <Text
       bold={true}
+      color="cyan"
+      dimColor={false}
     >
-      coco workspace  roots: ~/code
+      coco
     </Text>
     <Text
       dimColor={true}
     >
-      focus: List  ·  3/3 repos  ·  sort: Recent
+       · 
+    </Text>
+    <Text
+      bold={true}
+      dimColor={false}
+    >
+      workspace
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      dimColor={false}
+    >
+      3/3 repos
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      sort: Recent
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      [List]
     </Text>
   </Box>
   <Box
     flexDirection="row"
-    height={34}
+    height={33}
   >
     <Box
       borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
-      height={34}
+      height={33}
       paddingX={1}
-      width={18}
+      width={22}
     >
       <Text
         bold={true}
       >
         Tabs
       </Text>
-      <Text
-        bold={true}
+      <Box
+        flexDirection="row"
       >
-        › All
-      </Text>
-      <Text>
-          Dirty
-      </Text>
-      <Text>
-          Behind
-      </Text>
-      <Text>
-          PRs
-      </Text>
+        <Text
+          bold={true}
+        >
+          › All      
+        </Text>
+        <Text
+          color="cyan"
+          dimColor={false}
+        >
+           3
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Dirty    
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Behind   
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            PRs      
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
     </Box>
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
-      height={34}
+      height={33}
       paddingX={1}
     >
       <Box
@@ -80,242 +168,351 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={true}
-        >
-          › 
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
+        />
+        <Box
+          flexShrink={0}
+          width={19}
         >
-          <Box
-            marginRight={1}
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={true}
-              dimColor={false}
-            >
-              coco
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            REPO
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            BRANCH
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="yellow"
-              dimColor={false}
-            >
-              ●2 ↑1...
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            STATUS
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              2026-05-01
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            LAST
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              feat: thing
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            SUBJECT
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              /tmp/coco
-            </Text>
-          </Box>
+            PATH
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={true}
+            color="cyan"
+          >
+            › 
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={true}
+            dimColor={false}
+          >
+            coco
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            dimColor={false}
+          >
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="yellow"
+            dimColor={false}
+          >
+            ●2 ↑1...
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            2026-05-01
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            dimColor={false}
+          >
+            feat: thing
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            /tmp/coco
+          </Text>
         </Box>
       </Box>
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
         >
-          <Box
-            marginRight={1}
+          <Text
+            bold={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              docs
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              feature/la...
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            docs
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="yellow"
-              dimColor={false}
-            >
-              ↓3
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            feature/l...
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            bold={false}
+            color="yellow"
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              2026-04-15
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            ↓3
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              wip
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            2026-04-15
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              /tmp/docs
-            </Text>
-          </Box>
+            wip
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/docs
+          </Text>
         </Box>
       </Box>
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
         >
-          <Box
-            marginRight={1}
+          <Text
+            bold={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              lib
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            lib
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              ·
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              —
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            ·
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              —
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              /tmp/lib
-            </Text>
-          </Box>
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/lib
+          </Text>
         </Box>
       </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
     </Box>
   </Box>
   <Box
     borderColor="gray"
     borderStyle="classic"
     flexDirection="column"
+    height={4}
     paddingX={1}
   >
     <Text
       dimColor={true}
     >
       j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       
     </Text>
   </Box>
 </Box>
@@ -329,59 +526,158 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
   <Box
     borderColor="cyan"
     borderStyle="classic"
-    justifyContent="space-between"
     paddingX={1}
   >
     <Text
       bold={true}
+      color="cyan"
+      dimColor={false}
     >
-      coco workspace  roots: ~/code
+      coco
     </Text>
     <Text
       dimColor={true}
     >
-      focus: List  ·  1/3 repos  ·  sort: Recent
+       · 
+    </Text>
+    <Text
+      bold={true}
+      dimColor={false}
+    >
+      workspace
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      dimColor={false}
+    >
+      1/3 repos
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      sort: Recent
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="yellow"
+      dimColor={false}
+    >
+      filter: lib
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      [List]
     </Text>
   </Box>
   <Box
     flexDirection="row"
-    height={34}
+    height={33}
   >
     <Box
       borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
-      height={34}
+      height={33}
       paddingX={1}
-      width={18}
+      width={22}
     >
       <Text
         bold={true}
       >
         Tabs
       </Text>
-      <Text
-        bold={true}
+      <Box
+        flexDirection="row"
       >
-        › All
-      </Text>
-      <Text>
-          Dirty
-      </Text>
-      <Text>
-          Behind
-      </Text>
-      <Text>
-          PRs
-      </Text>
+        <Text
+          bold={true}
+        >
+          › All      
+        </Text>
+        <Text
+          color="cyan"
+          dimColor={false}
+        >
+           3
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Dirty    
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Behind   
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            PRs      
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
     </Box>
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
-      height={34}
+      height={33}
       paddingX={1}
     >
       <Box
@@ -401,88 +697,185 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={true}
-        >
-          › 
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
+        />
+        <Box
+          flexShrink={0}
+          width={19}
         >
-          <Box
-            marginRight={1}
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={true}
-              dimColor={false}
-            >
-              lib
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            REPO
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            BRANCH
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              ·
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            STATUS
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              —
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            LAST
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              —
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            SUBJECT
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              /tmp/lib
-            </Text>
-          </Box>
+            PATH
+          </Text>
         </Box>
       </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={true}
+            color="cyan"
+          >
+            › 
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={true}
+            dimColor={false}
+          >
+            lib
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            dimColor={false}
+          >
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            ·
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            /tmp/lib
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
     </Box>
   </Box>
   <Box
     borderColor="gray"
     borderStyle="classic"
     flexDirection="column"
+    height={4}
     paddingX={1}
   >
     <Text
       dimColor={true}
     >
       j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       
     </Text>
   </Box>
 </Box>
@@ -496,600 +889,69 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
   <Box
     borderColor="cyan"
     borderStyle="classic"
-    justifyContent="space-between"
     paddingX={1}
   >
     <Text
       bold={true}
+      color="cyan"
+      dimColor={false}
     >
-      coco workspace  roots: ~/code
+      coco
     </Text>
     <Text
       dimColor={true}
     >
-      focus: List  ·  3/3 repos  ·  sort: Recent
+       · 
     </Text>
-  </Box>
-  <Box
-    flexDirection="row"
-    height={34}
-  >
-    <Box
-      borderColor="gray"
-      borderStyle="classic"
-      flexDirection="column"
-      flexShrink={0}
-      height={34}
-      paddingX={1}
-      width={18}
-    >
-      <Text
-        bold={true}
-      >
-        Tabs
-      </Text>
-      <Text
-        bold={true}
-      >
-        › All
-      </Text>
-      <Text>
-          Dirty
-      </Text>
-      <Text>
-          Behind
-      </Text>
-      <Text
-        dimColor={true}
-      >
-          PRs
-      </Text>
-    </Box>
-    <Box
-      borderColor="cyan"
-      borderStyle="classic"
-      flexDirection="column"
-      flexGrow={1}
-      height={34}
-      paddingX={1}
-    >
-      <Box
-        justifyContent="space-between"
-      >
-        <Text
-          bold={true}
-        >
-          Workspace *
-        </Text>
-        <Text
-          dimColor={true}
-        >
-          3 visible
-        </Text>
-      </Box>
-      <Box
-        flexDirection="row"
-      >
-        <Text
-          bold={true}
-        >
-          › 
-        </Text>
-        <Box
-          flexDirection="row"
-          flexShrink={1}
-        >
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={true}
-              dimColor={false}
-            >
-              coco
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              color="yellow"
-              dimColor={false}
-            >
-              ●2 ↑1
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              2026-05-01
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              dimColor={false}
-            >
-              feat: thing
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              /tmp/coco
-            </Text>
-          </Box>
-        </Box>
-      </Box>
-      <Box
-        flexDirection="row"
-      >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
-        <Box
-          flexDirection="row"
-          flexShrink={1}
-        >
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              docs
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              feature/la...
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              color="yellow"
-              dimColor={false}
-            >
-              ↓3
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              2026-04-15
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              wip
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              /tmp/docs
-            </Text>
-          </Box>
-        </Box>
-      </Box>
-      <Box
-        flexDirection="row"
-      >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
-        <Box
-          flexDirection="row"
-          flexShrink={1}
-        >
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              lib
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              ·
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              —
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              —
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              /tmp/lib
-            </Text>
-          </Box>
-        </Box>
-      </Box>
-    </Box>
-  </Box>
-  <Box
-    borderColor="gray"
-    borderStyle="classic"
-    flexDirection="column"
-    paddingX={1}
-  >
-    <Text
-      dimColor={true}
-    >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
-    </Text>
-  </Box>
-</Box>
-`;
-
-exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-budget regressions surface 1`] = `
-<Box
-  flexDirection="column"
-  height={40}
->
-  <Box
-    borderColor="cyan"
-    borderStyle="classic"
-    justifyContent="space-between"
-    paddingX={1}
-  >
     <Text
       bold={true}
+      dimColor={false}
     >
-      coco workspace  roots: ~/code
+      workspace
     </Text>
     <Text
       dimColor={true}
     >
-      focus: List  ·  3/3 repos  ·  sort: Recent
+       · 
     </Text>
-  </Box>
-  <Box
-    flexDirection="row"
-    height={34}
-  >
-    <Box
-      borderColor="gray"
-      borderStyle="classic"
-      flexDirection="column"
-      flexShrink={0}
-      height={34}
-      paddingX={1}
-      width={18}
+    <Text
+      color="gray"
+      dimColor={true}
     >
-      <Text
-        bold={true}
-      >
-        Tabs
-      </Text>
-      <Text
-        bold={true}
-      >
-        › All
-      </Text>
-      <Text>
-          Dirty
-      </Text>
-      <Text>
-          Behind
-      </Text>
-      <Text>
-          PRs
-      </Text>
-    </Box>
-    <Box
-      borderColor="cyan"
-      borderStyle="classic"
-      flexDirection="column"
-      flexGrow={1}
-      height={34}
-      paddingX={1}
-    >
-      <Box
-        justifyContent="space-between"
-      >
-        <Text
-          bold={true}
-        >
-          Workspace *
-        </Text>
-        <Text
-          dimColor={true}
-        >
-          3 visible
-        </Text>
-      </Box>
-      <Box
-        flexDirection="row"
-      >
-        <Text
-          bold={true}
-        >
-          › 
-        </Text>
-        <Box
-          flexDirection="row"
-          flexShrink={1}
-        >
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={true}
-              dimColor={false}
-            >
-              coco
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              color="yellow"
-              dimColor={false}
-            >
-              ●2 ↑1
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              2026-05-01
-            </Text>
-          </Box>
-        </Box>
-      </Box>
-      <Box
-        flexDirection="row"
-      >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
-        <Box
-          flexDirection="row"
-          flexShrink={1}
-        >
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              docs
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              feature/la...
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              color="yellow"
-              dimColor={false}
-            >
-              ↓3
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              2026-04-15
-            </Text>
-          </Box>
-        </Box>
-      </Box>
-      <Box
-        flexDirection="row"
-      >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
-        <Box
-          flexDirection="row"
-          flexShrink={1}
-        >
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              lib
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              ·
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
-          >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              —
-            </Text>
-          </Box>
-        </Box>
-      </Box>
-    </Box>
-  </Box>
-  <Box
-    borderColor="gray"
-    borderStyle="classic"
-    flexDirection="column"
-    paddingX={1}
-  >
+      ~/code
+    </Text>
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+       · 
     </Text>
-  </Box>
-</Box>
-`;
-
-exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`] = `
-<Box
-  flexDirection="column"
-  height={40}
->
-  <Box
-    borderColor="cyan"
-    borderStyle="classic"
-    justifyContent="space-between"
-    paddingX={1}
-  >
+    <Text
+      dimColor={false}
+    >
+      3/3 repos
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      sort: Recent
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
     <Text
       bold={true}
+      color="cyan"
+      dimColor={false}
     >
-      coco workspace  roots: ~/code
-    </Text>
-    <Text
-      dimColor={true}
-    >
-      focus: List  ·  3/3 repos  ·  sort: Recent
+      [List]
     </Text>
   </Box>
   <Box
@@ -1103,27 +965,66 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
       flexShrink={0}
       height={33}
       paddingX={1}
-      width={18}
+      width={22}
     >
       <Text
         bold={true}
       >
         Tabs
       </Text>
-      <Text
-        bold={true}
+      <Box
+        flexDirection="row"
       >
-        › All
-      </Text>
-      <Text>
-          Dirty
-      </Text>
-      <Text>
-          Behind
-      </Text>
-      <Text>
-          PRs
-      </Text>
+        <Text
+          bold={true}
+        >
+          › All      
+        </Text>
+        <Text
+          color="cyan"
+          dimColor={false}
+        >
+           3
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Dirty    
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Behind   
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text
+          dimColor={true}
+        >
+            PRs      
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
     </Box>
     <Box
       borderColor="cyan"
@@ -1150,236 +1051,1286 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={true}
-        >
-          › 
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
+        />
+        <Box
+          flexShrink={0}
+          width={19}
         >
-          <Box
-            marginRight={1}
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={true}
-              dimColor={false}
-            >
-              coco
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            REPO
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            BRANCH
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="yellow"
-              dimColor={false}
-            >
-              ●2 ↑1
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            STATUS
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              2026-05-01
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            LAST
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              feat: thing
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            SUBJECT
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              /tmp/coco
-            </Text>
-          </Box>
+            PATH
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={true}
+            color="cyan"
+          >
+            › 
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={true}
+            dimColor={false}
+          >
+            coco
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            dimColor={false}
+          >
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="yellow"
+            dimColor={false}
+          >
+            ●2 ↑1
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            2026-05-01
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            dimColor={false}
+          >
+            feat: thing
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            /tmp/coco
+          </Text>
         </Box>
       </Box>
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
         >
-          <Box
-            marginRight={1}
+          <Text
+            bold={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              docs
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              feature/la...
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            docs
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="yellow"
-              dimColor={false}
-            >
-              ↓3
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            feature/l...
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            bold={false}
+            color="yellow"
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              2026-04-15
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            ↓3
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              wip
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            2026-04-15
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              /tmp/docs
-            </Text>
-          </Box>
+            wip
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/docs
+          </Text>
         </Box>
       </Box>
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
         >
-          <Box
-            marginRight={1}
+          <Text
+            bold={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              lib
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            lib
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              ·
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              —
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            ·
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              —
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              /tmp/lib
-            </Text>
-          </Box>
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/lib
+          </Text>
         </Box>
       </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
     </Box>
   </Box>
   <Box
     borderColor="gray"
     borderStyle="classic"
     flexDirection="column"
+    height={4}
+    paddingX={1}
+  >
+    <Text
+      dimColor={true}
+    >
+      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       
+    </Text>
+  </Box>
+</Box>
+`;
+
+exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-budget regressions surface 1`] = `
+<Box
+  flexDirection="column"
+  height={40}
+>
+  <Box
+    borderColor="cyan"
+    borderStyle="classic"
+    paddingX={1}
+  >
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      coco
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      dimColor={false}
+    >
+      workspace
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      dimColor={false}
+    >
+      3/3 repos
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      sort: Recent
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      [List]
+    </Text>
+  </Box>
+  <Box
+    flexDirection="row"
+    height={33}
+  >
+    <Box
+      borderColor="gray"
+      borderStyle="classic"
+      flexDirection="column"
+      flexShrink={0}
+      height={33}
+      paddingX={1}
+      width={22}
+    >
+      <Text
+        bold={true}
+      >
+        Tabs
+      </Text>
+      <Box
+        flexDirection="row"
+      >
+        <Text
+          bold={true}
+        >
+          › All      
+        </Text>
+        <Text
+          color="cyan"
+          dimColor={false}
+        >
+           3
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Dirty    
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Behind   
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            PRs      
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
+    </Box>
+    <Box
+      borderColor="cyan"
+      borderStyle="classic"
+      flexDirection="column"
+      flexGrow={1}
+      height={33}
+      paddingX={1}
+    >
+      <Box
+        justifyContent="space-between"
+      >
+        <Text
+          bold={true}
+        >
+          Workspace *
+        </Text>
+        <Text
+          dimColor={true}
+        >
+          3 visible
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        />
+        <Box
+          flexShrink={0}
+          width={17}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            REPO
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={14}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            BRANCH
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            STATUS
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={10}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            LAST
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={true}
+            color="cyan"
+          >
+            › 
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={17}
+        >
+          <Text
+            bold={true}
+            dimColor={false}
+          >
+            coco
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={14}
+        >
+          <Text
+            dimColor={false}
+          >
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="yellow"
+            dimColor={false}
+          >
+            ●2 ↑1
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={10}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            2026-05-01
+          </Text>
+        </Box>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={false}
+          >
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={17}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
+          >
+            docs
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={14}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
+          >
+            feature/la...
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            bold={false}
+            color="yellow"
+            dimColor={false}
+          >
+            ↓3
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={10}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            2026-04-15
+          </Text>
+        </Box>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={false}
+          >
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={17}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
+          >
+            lib
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={14}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
+          >
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            ·
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={10}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            —
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
+    </Box>
+  </Box>
+  <Box
+    borderColor="gray"
+    borderStyle="classic"
+    flexDirection="column"
+    height={4}
+    paddingX={1}
+  >
+    <Text
+      dimColor={true}
+    >
+      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       
+    </Text>
+  </Box>
+</Box>
+`;
+
+exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`] = `
+<Box
+  flexDirection="column"
+  height={40}
+>
+  <Box
+    borderColor="cyan"
+    borderStyle="classic"
+    paddingX={1}
+  >
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      coco
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      dimColor={false}
+    >
+      workspace
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      dimColor={false}
+    >
+      3/3 repos
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      sort: Recent
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      [List]
+    </Text>
+  </Box>
+  <Box
+    flexDirection="row"
+    height={33}
+  >
+    <Box
+      borderColor="gray"
+      borderStyle="classic"
+      flexDirection="column"
+      flexShrink={0}
+      height={33}
+      paddingX={1}
+      width={22}
+    >
+      <Text
+        bold={true}
+      >
+        Tabs
+      </Text>
+      <Box
+        flexDirection="row"
+      >
+        <Text
+          bold={true}
+        >
+          › All      
+        </Text>
+        <Text
+          color="cyan"
+          dimColor={false}
+        >
+           3
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Dirty    
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Behind   
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            PRs      
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
+    </Box>
+    <Box
+      borderColor="cyan"
+      borderStyle="classic"
+      flexDirection="column"
+      flexGrow={1}
+      height={33}
+      paddingX={1}
+    >
+      <Box
+        justifyContent="space-between"
+      >
+        <Text
+          bold={true}
+        >
+          Workspace *
+        </Text>
+        <Text
+          dimColor={true}
+        >
+          3 visible
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        />
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            REPO
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            BRANCH
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            STATUS
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            LAST
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            SUBJECT
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            PATH
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={true}
+            color="cyan"
+          >
+            › 
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={true}
+            dimColor={false}
+          >
+            coco
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            dimColor={false}
+          >
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="yellow"
+            dimColor={false}
+          >
+            ●2 ↑1
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            2026-05-01
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            dimColor={false}
+          >
+            feat: thing
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            /tmp/coco
+          </Text>
+        </Box>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={false}
+          >
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
+          >
+            docs
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
+          >
+            feature/l...
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            bold={false}
+            color="yellow"
+            dimColor={false}
+          >
+            ↓3
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            2026-04-15
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
+          >
+            wip
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/docs
+          </Text>
+        </Box>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={false}
+          >
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
+          >
+            lib
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
+          >
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            ·
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/lib
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
+    </Box>
+  </Box>
+  <Box
+    borderColor="gray"
+    borderStyle="classic"
+    flexDirection="column"
+    height={4}
     paddingX={1}
   >
     <Text
@@ -1389,6 +2340,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
     </Text>
     <Text
       color="yellow"
+      dimColor={false}
     >
       Refreshed 3 repos.
     </Text>
@@ -1404,59 +2356,147 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
   <Box
     borderColor="cyan"
     borderStyle="classic"
-    justifyContent="space-between"
     paddingX={1}
   >
     <Text
       bold={true}
+      color="cyan"
+      dimColor={false}
     >
-      coco workspace  roots: ~/code
+      coco
     </Text>
     <Text
       dimColor={true}
     >
-      focus: List  ·  3/3 repos  ·  sort: Recent
+       · 
+    </Text>
+    <Text
+      bold={true}
+      dimColor={false}
+    >
+      workspace
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      dimColor={false}
+    >
+      3/3 repos
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      sort: Recent
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      [List]
     </Text>
   </Box>
   <Box
     flexDirection="row"
-    height={34}
+    height={33}
   >
     <Box
       borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
-      height={34}
+      height={33}
       paddingX={1}
-      width={18}
+      width={22}
     >
       <Text
         bold={true}
       >
         Tabs
       </Text>
-      <Text
-        bold={true}
+      <Box
+        flexDirection="row"
       >
-        › All
-      </Text>
-      <Text>
-          Dirty
-      </Text>
-      <Text>
-          Behind
-      </Text>
-      <Text>
-          PRs
-      </Text>
+        <Text
+          bold={true}
+        >
+          › All      
+        </Text>
+        <Text
+          color="cyan"
+          dimColor={false}
+        >
+           3
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Dirty    
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Behind   
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            PRs      
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
     </Box>
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
-      height={34}
+      height={33}
       paddingX={1}
     >
       <Box
@@ -1476,116 +2516,169 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={true}
-        >
-          › 
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
+        />
+        <Box
+          flexShrink={0}
+          width={17}
         >
-          <Box
-            marginRight={1}
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={true}
-              dimColor={false}
-            >
-              coco
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            REPO
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
+            BRANCH
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={true}
+            color="cyan"
+          >
+            › 
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={17}
+        >
+          <Text
+            bold={true}
+            dimColor={false}
+          >
+            coco
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            dimColor={false}
+          >
+            main
+          </Text>
         </Box>
       </Box>
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
         >
-          <Box
-            marginRight={1}
+          <Text
+            bold={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              docs
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={17}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              feature/lan...
-            </Text>
-          </Box>
+            docs
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
+          >
+            feature/la...
+          </Text>
         </Box>
       </Box>
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
         >
-          <Box
-            marginRight={1}
+          <Text
+            bold={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              lib
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={17}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
+            lib
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
+          >
+            main
+          </Text>
         </Box>
       </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
     </Box>
   </Box>
   <Box
     borderColor="gray"
     borderStyle="classic"
     flexDirection="column"
+    height={4}
     paddingX={1}
   >
     <Text
       dimColor={true}
     >
       j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       
     </Text>
   </Box>
 </Box>
@@ -1599,59 +2692,147 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
   <Box
     borderColor="cyan"
     borderStyle="classic"
-    justifyContent="space-between"
     paddingX={1}
   >
     <Text
       bold={true}
+      color="cyan"
+      dimColor={false}
     >
-      coco workspace  roots: ~/code
+      coco
     </Text>
     <Text
       dimColor={true}
     >
-      focus: List  ·  3/3 repos  ·  sort: Recent
+       · 
+    </Text>
+    <Text
+      bold={true}
+      dimColor={false}
+    >
+      workspace
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      dimColor={false}
+    >
+      3/3 repos
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      sort: Recent
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      [List]
     </Text>
   </Box>
   <Box
     flexDirection="row"
-    height={34}
+    height={33}
   >
     <Box
       borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
-      height={34}
+      height={33}
       paddingX={1}
-      width={18}
+      width={22}
     >
       <Text
         bold={true}
       >
         Tabs
       </Text>
-      <Text
-        bold={true}
+      <Box
+        flexDirection="row"
       >
-        › All
-      </Text>
-      <Text>
-          Dirty
-      </Text>
-      <Text>
-          Behind
-      </Text>
-      <Text>
-          PRs
-      </Text>
+        <Text
+          bold={true}
+        >
+          › All      
+        </Text>
+        <Text
+          color="cyan"
+          dimColor={false}
+        >
+           3
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Dirty    
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Behind   
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            PRs      
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
     </Box>
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
-      height={34}
+      height={33}
       paddingX={1}
     >
       <Box
@@ -1671,242 +2852,351 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={true}
-        >
-          › 
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
+        />
+        <Box
+          flexShrink={0}
+          width={37}
         >
-          <Box
-            marginRight={1}
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={true}
-              dimColor={false}
-            >
-              coco
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            REPO
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={29}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            BRANCH
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={17}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="yellow"
-              dimColor={false}
-            >
-              ●2 ↑1
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            STATUS
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              2026-05-01
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            LAST
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={51}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              feat: thing
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            SUBJECT
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={25}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              /tmp/coco
-            </Text>
-          </Box>
+            PATH
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={true}
+            color="cyan"
+          >
+            › 
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={37}
+        >
+          <Text
+            bold={true}
+            dimColor={false}
+          >
+            coco
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={29}
+        >
+          <Text
+            dimColor={false}
+          >
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={17}
+        >
+          <Text
+            color="yellow"
+            dimColor={false}
+          >
+            ●2 ↑1
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            2026-05-01
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={51}
+        >
+          <Text
+            dimColor={false}
+          >
+            feat: thing
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={25}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            /tmp/coco
+          </Text>
         </Box>
       </Box>
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
         >
-          <Box
-            marginRight={1}
+          <Text
+            bold={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              docs
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={37}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              feature/landing
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            docs
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={29}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="yellow"
-              dimColor={false}
-            >
-              ↓3
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            feature/landing
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={17}
+        >
+          <Text
+            bold={false}
+            color="yellow"
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              2026-04-15
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            ↓3
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              wip
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            2026-04-15
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={51}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              /tmp/docs
-            </Text>
-          </Box>
+            wip
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={25}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/docs
+          </Text>
         </Box>
       </Box>
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
         >
-          <Box
-            marginRight={1}
+          <Text
+            bold={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              lib
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={37}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            lib
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={29}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              ·
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={17}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              —
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            ·
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              —
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={51}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              /tmp/lib
-            </Text>
-          </Box>
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={25}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/lib
+          </Text>
         </Box>
       </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
     </Box>
   </Box>
   <Box
     borderColor="gray"
     borderStyle="classic"
     flexDirection="column"
+    height={4}
     paddingX={1}
   >
     <Text
       dimColor={true}
     >
       j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       
     </Text>
   </Box>
 </Box>
@@ -1920,59 +3210,147 @@ exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading fals
   <Box
     borderColor="cyan"
     borderStyle="classic"
-    justifyContent="space-between"
     paddingX={1}
   >
     <Text
       bold={true}
+      color="cyan"
+      dimColor={false}
     >
-      coco workspace  roots: ~/code
+      coco
     </Text>
     <Text
       dimColor={true}
     >
-      focus: List  ·  0/0 repos  ·  sort: Recent
+       · 
+    </Text>
+    <Text
+      bold={true}
+      dimColor={false}
+    >
+      workspace
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      dimColor={false}
+    >
+      0/0 repos
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      sort: Recent
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      [List]
     </Text>
   </Box>
   <Box
     flexDirection="row"
-    height={34}
+    height={33}
   >
     <Box
       borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
-      height={34}
+      height={33}
       paddingX={1}
-      width={18}
+      width={22}
     >
       <Text
         bold={true}
       >
         Tabs
       </Text>
-      <Text
-        bold={true}
+      <Box
+        flexDirection="row"
       >
-        › All
-      </Text>
-      <Text>
-          Dirty
-      </Text>
-      <Text>
-          Behind
-      </Text>
-      <Text>
-          PRs
-      </Text>
+        <Text
+          bold={true}
+        >
+          › All      
+        </Text>
+        <Text
+          color="cyan"
+          dimColor={false}
+        >
+           ·
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Dirty    
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Behind   
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            PRs      
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
     </Box>
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
-      height={34}
+      height={33}
       paddingX={1}
     >
       <Box
@@ -1989,10 +3367,94 @@ exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading fals
           0 visible
         </Text>
       </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        />
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            REPO
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            BRANCH
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            STATUS
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            LAST
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            SUBJECT
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            PATH
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
       <Text
         dimColor={true}
       >
         No repositories discovered. Configure workspace.roots and try again.
+      </Text>
+      <Text
+        dimColor={true}
+      >
+         
       </Text>
     </Box>
   </Box>
@@ -2000,12 +3462,18 @@ exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading fals
     borderColor="gray"
     borderStyle="classic"
     flexDirection="column"
+    height={4}
     paddingX={1}
   >
     <Text
       dimColor={true}
     >
       j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       
     </Text>
   </Box>
 </Box>
@@ -2019,59 +3487,147 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
   <Box
     borderColor="cyan"
     borderStyle="classic"
-    justifyContent="space-between"
     paddingX={1}
   >
     <Text
       bold={true}
+      color="cyan"
+      dimColor={false}
     >
-      coco workspace  roots: ~/code
+      coco
     </Text>
     <Text
       dimColor={true}
     >
-      focus: Filter  ·  3/3 repos  ·  sort: Recent
+       · 
+    </Text>
+    <Text
+      bold={true}
+      dimColor={false}
+    >
+      workspace
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      dimColor={false}
+    >
+      3/3 repos
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      sort: Recent
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      [Filter]
     </Text>
   </Box>
   <Box
     flexDirection="row"
-    height={34}
+    height={33}
   >
     <Box
       borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
-      height={34}
+      height={33}
       paddingX={1}
-      width={18}
+      width={22}
     >
       <Text
         bold={true}
       >
         Tabs
       </Text>
-      <Text
-        bold={true}
+      <Box
+        flexDirection="row"
       >
-        › All
-      </Text>
-      <Text>
-          Dirty
-      </Text>
-      <Text>
-          Behind
-      </Text>
-      <Text>
-          PRs
-      </Text>
+        <Text
+          bold={true}
+        >
+          › All      
+        </Text>
+        <Text
+          color="cyan"
+          dimColor={false}
+        >
+           3
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Dirty    
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Behind   
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            PRs      
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
     </Box>
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
-      height={34}
+      height={33}
       paddingX={1}
     >
       <Box
@@ -2091,242 +3647,351 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={true}
-        >
-          › 
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
+        />
+        <Box
+          flexShrink={0}
+          width={19}
         >
-          <Box
-            marginRight={1}
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={true}
-              dimColor={false}
-            >
-              coco
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            REPO
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            BRANCH
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="yellow"
-              dimColor={false}
-            >
-              ●2 ↑1
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            STATUS
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              2026-05-01
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            LAST
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              feat: thing
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            SUBJECT
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              /tmp/coco
-            </Text>
-          </Box>
+            PATH
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={true}
+            color="cyan"
+          >
+            › 
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={true}
+            dimColor={false}
+          >
+            coco
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            dimColor={false}
+          >
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="yellow"
+            dimColor={false}
+          >
+            ●2 ↑1
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            2026-05-01
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            dimColor={false}
+          >
+            feat: thing
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            /tmp/coco
+          </Text>
         </Box>
       </Box>
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
         >
-          <Box
-            marginRight={1}
+          <Text
+            bold={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              docs
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              feature/la...
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            docs
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="yellow"
-              dimColor={false}
-            >
-              ↓3
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            feature/l...
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            bold={false}
+            color="yellow"
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              2026-04-15
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            ↓3
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              wip
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            2026-04-15
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              /tmp/docs
-            </Text>
-          </Box>
+            wip
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/docs
+          </Text>
         </Box>
       </Box>
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
         >
-          <Box
-            marginRight={1}
+          <Text
+            bold={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              lib
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            lib
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              ·
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              —
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            ·
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              —
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              /tmp/lib
-            </Text>
-          </Box>
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/lib
+          </Text>
         </Box>
       </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
     </Box>
   </Box>
   <Box
     borderColor="gray"
     borderStyle="classic"
     flexDirection="column"
+    height={4}
     paddingX={1}
   >
     <Text
       dimColor={true}
     >
       type filter · enter to apply · esc to clear
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       
     </Text>
   </Box>
 </Box>
@@ -2340,59 +4005,147 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
   <Box
     borderColor="cyan"
     borderStyle="classic"
-    justifyContent="space-between"
     paddingX={1}
   >
     <Text
       bold={true}
+      color="cyan"
+      dimColor={false}
     >
-      coco workspace  roots: ~/code
+      coco
     </Text>
     <Text
       dimColor={true}
     >
-      focus: Add  ·  3/3 repos  ·  sort: Recent
+       · 
+    </Text>
+    <Text
+      bold={true}
+      dimColor={false}
+    >
+      workspace
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      dimColor={false}
+    >
+      3/3 repos
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      sort: Recent
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      [Add]
     </Text>
   </Box>
   <Box
     flexDirection="row"
-    height={29}
+    height={28}
   >
     <Box
       borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
-      height={29}
+      height={28}
       paddingX={1}
-      width={18}
+      width={22}
     >
       <Text
         bold={true}
       >
         Tabs
       </Text>
-      <Text
-        bold={true}
+      <Box
+        flexDirection="row"
       >
-        › All
-      </Text>
-      <Text>
-          Dirty
-      </Text>
-      <Text>
-          Behind
-      </Text>
-      <Text>
-          PRs
-      </Text>
+        <Text
+          bold={true}
+        >
+          › All      
+        </Text>
+        <Text
+          color="cyan"
+          dimColor={false}
+        >
+           3
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Dirty    
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Behind   
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            PRs      
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
     </Box>
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
-      height={29}
+      height={28}
       paddingX={1}
     >
       <Box
@@ -2412,230 +4165,333 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={true}
-        >
-          › 
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
+        />
+        <Box
+          flexShrink={0}
+          width={19}
         >
-          <Box
-            marginRight={1}
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={true}
-              dimColor={false}
-            >
-              coco
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            REPO
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            BRANCH
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="yellow"
-              dimColor={false}
-            >
-              ●2 ↑1
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            STATUS
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              2026-05-01
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            LAST
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              feat: thing
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            SUBJECT
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              /tmp/coco
-            </Text>
-          </Box>
+            PATH
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={true}
+            color="cyan"
+          >
+            › 
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={true}
+            dimColor={false}
+          >
+            coco
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            dimColor={false}
+          >
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="yellow"
+            dimColor={false}
+          >
+            ●2 ↑1
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            2026-05-01
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            dimColor={false}
+          >
+            feat: thing
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            /tmp/coco
+          </Text>
         </Box>
       </Box>
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
         >
-          <Box
-            marginRight={1}
+          <Text
+            bold={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              docs
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              feature/la...
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            docs
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="yellow"
-              dimColor={false}
-            >
-              ↓3
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            feature/l...
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            bold={false}
+            color="yellow"
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              2026-04-15
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            ↓3
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              wip
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            2026-04-15
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              /tmp/docs
-            </Text>
-          </Box>
+            wip
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/docs
+          </Text>
         </Box>
       </Box>
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
         >
-          <Box
-            marginRight={1}
+          <Text
+            bold={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              lib
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            lib
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              ·
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              —
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            ·
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              —
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              /tmp/lib
-            </Text>
-          </Box>
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/lib
+          </Text>
         </Box>
       </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
     </Box>
   </Box>
   <Box
@@ -2664,12 +4520,18 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
     borderColor="gray"
     borderStyle="classic"
     flexDirection="column"
+    height={4}
     paddingX={1}
   >
     <Text
       dimColor={true}
     >
       type path · tab to complete · enter to add · esc to cancel
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       
     </Text>
   </Box>
 </Box>
@@ -2683,59 +4545,147 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
   <Box
     borderColor="cyan"
     borderStyle="classic"
-    justifyContent="space-between"
     paddingX={1}
   >
     <Text
       bold={true}
+      color="cyan"
+      dimColor={false}
     >
-      coco workspace  roots: ~/code
+      coco
     </Text>
     <Text
       dimColor={true}
     >
-      focus: List  ·  1/3 repos  ·  sort: Recent
+       · 
+    </Text>
+    <Text
+      bold={true}
+      dimColor={false}
+    >
+      workspace
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      dimColor={false}
+    >
+      1/3 repos
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      sort: Recent
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      [List]
     </Text>
   </Box>
   <Box
     flexDirection="row"
-    height={34}
+    height={33}
   >
     <Box
       borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
-      height={34}
+      height={33}
       paddingX={1}
-      width={18}
+      width={22}
     >
       <Text
         bold={true}
       >
         Tabs
       </Text>
-      <Text>
-          All
-      </Text>
-      <Text>
-          Dirty
-      </Text>
-      <Text
-        bold={true}
+      <Box
+        flexDirection="row"
       >
-        › Behind
-      </Text>
-      <Text>
-          PRs
-      </Text>
+        <Text>
+            All      
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           3
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Dirty    
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text
+          bold={true}
+        >
+          › Behind   
+        </Text>
+        <Text
+          color="cyan"
+          dimColor={false}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            PRs      
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
     </Box>
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
-      height={34}
+      height={33}
       paddingX={1}
     >
       <Box
@@ -2755,87 +4705,184 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={true}
-        >
-          › 
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
+        />
+        <Box
+          flexShrink={0}
+          width={19}
         >
-          <Box
-            marginRight={1}
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={true}
-              dimColor={false}
-            >
-              docs
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            REPO
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              feature/la...
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            BRANCH
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="yellow"
-              dimColor={false}
-            >
-              ↓3
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            STATUS
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              2026-04-15
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            LAST
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              wip
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            SUBJECT
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              /tmp/docs
-            </Text>
-          </Box>
+            PATH
+          </Text>
         </Box>
       </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={true}
+            color="cyan"
+          >
+            › 
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={true}
+            dimColor={false}
+          >
+            docs
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            dimColor={false}
+          >
+            feature/l...
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="yellow"
+            dimColor={false}
+          >
+            ↓3
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            2026-04-15
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            dimColor={false}
+          >
+            wip
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            /tmp/docs
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
     </Box>
   </Box>
   <Box
     borderColor="gray"
     borderStyle="classic"
     flexDirection="column"
+    height={4}
     paddingX={1}
   >
     <Text
       dimColor={true}
     >
       j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       
     </Text>
   </Box>
 </Box>
@@ -2849,59 +4896,147 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
   <Box
     borderColor="cyan"
     borderStyle="classic"
-    justifyContent="space-between"
     paddingX={1}
   >
     <Text
       bold={true}
+      color="cyan"
+      dimColor={false}
     >
-      coco workspace  roots: ~/code
+      coco
     </Text>
     <Text
       dimColor={true}
     >
-      focus: Confirm  ·  3/3 repos  ·  sort: Recent
+       · 
+    </Text>
+    <Text
+      bold={true}
+      dimColor={false}
+    >
+      workspace
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      dimColor={false}
+    >
+      3/3 repos
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      sort: Recent
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      [Confirm]
     </Text>
   </Box>
   <Box
     flexDirection="row"
-    height={29}
+    height={28}
   >
     <Box
       borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
-      height={29}
+      height={28}
       paddingX={1}
-      width={18}
+      width={22}
     >
       <Text
         bold={true}
       >
         Tabs
       </Text>
-      <Text
-        bold={true}
+      <Box
+        flexDirection="row"
       >
-        › All
-      </Text>
-      <Text>
-          Dirty
-      </Text>
-      <Text>
-          Behind
-      </Text>
-      <Text>
-          PRs
-      </Text>
+        <Text
+          bold={true}
+        >
+          › All      
+        </Text>
+        <Text
+          color="cyan"
+          dimColor={false}
+        >
+           3
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Dirty    
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Behind   
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            PRs      
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
     </Box>
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
-      height={29}
+      height={28}
       paddingX={1}
     >
       <Box
@@ -2921,230 +5056,333 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={true}
-        >
-          › 
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
+        />
+        <Box
+          flexShrink={0}
+          width={19}
         >
-          <Box
-            marginRight={1}
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={true}
-              dimColor={false}
-            >
-              coco
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            REPO
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            BRANCH
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="yellow"
-              dimColor={false}
-            >
-              ●2 ↑1
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            STATUS
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              2026-05-01
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            LAST
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              feat: thing
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            SUBJECT
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              /tmp/coco
-            </Text>
-          </Box>
+            PATH
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={true}
+            color="cyan"
+          >
+            › 
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={true}
+            dimColor={false}
+          >
+            coco
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            dimColor={false}
+          >
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="yellow"
+            dimColor={false}
+          >
+            ●2 ↑1
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            2026-05-01
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            dimColor={false}
+          >
+            feat: thing
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            /tmp/coco
+          </Text>
         </Box>
       </Box>
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
         >
-          <Box
-            marginRight={1}
+          <Text
+            bold={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              docs
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              feature/la...
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            docs
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="yellow"
-              dimColor={false}
-            >
-              ↓3
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            feature/l...
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            bold={false}
+            color="yellow"
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              2026-04-15
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            ↓3
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              wip
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            2026-04-15
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              /tmp/docs
-            </Text>
-          </Box>
+            wip
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/docs
+          </Text>
         </Box>
       </Box>
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
         >
-          <Box
-            marginRight={1}
+          <Text
+            bold={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              lib
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            lib
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              ·
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              —
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            ·
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              —
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              /tmp/lib
-            </Text>
-          </Box>
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/lib
+          </Text>
         </Box>
       </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
     </Box>
   </Box>
   <Box
@@ -3173,12 +5411,18 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
     borderColor="gray"
     borderStyle="classic"
     flexDirection="column"
+    height={4}
     paddingX={1}
   >
     <Text
       dimColor={true}
     >
       press y to remove · any other key to cancel
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       
     </Text>
   </Box>
 </Box>
@@ -3192,59 +5436,147 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
   <Box
     borderColor="cyan"
     borderStyle="classic"
-    justifyContent="space-between"
     paddingX={1}
   >
     <Text
       bold={true}
+      color="cyan"
+      dimColor={false}
     >
-      coco workspace  roots: ~/code
+      coco
     </Text>
     <Text
       dimColor={true}
     >
-      focus: List  ·  1/3 repos  ·  sort: Recent
+       · 
+    </Text>
+    <Text
+      bold={true}
+      dimColor={false}
+    >
+      workspace
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      dimColor={false}
+    >
+      1/3 repos
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      sort: Recent
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      [List]
     </Text>
   </Box>
   <Box
     flexDirection="row"
-    height={34}
+    height={33}
   >
     <Box
       borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
-      height={34}
+      height={33}
       paddingX={1}
-      width={18}
+      width={22}
     >
       <Text
         bold={true}
       >
         Tabs
       </Text>
-      <Text>
-          All
-      </Text>
-      <Text
-        bold={true}
+      <Box
+        flexDirection="row"
       >
-        › Dirty
-      </Text>
-      <Text>
-          Behind
-      </Text>
-      <Text>
-          PRs
-      </Text>
+        <Text>
+            All      
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           3
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text
+          bold={true}
+        >
+          › Dirty    
+        </Text>
+        <Text
+          color="cyan"
+          dimColor={false}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Behind   
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            PRs      
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
     </Box>
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
-      height={34}
+      height={33}
       paddingX={1}
     >
       <Box
@@ -3264,87 +5596,184 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={true}
-        >
-          › 
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
+        />
+        <Box
+          flexShrink={0}
+          width={19}
         >
-          <Box
-            marginRight={1}
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={true}
-              dimColor={false}
-            >
-              coco
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            REPO
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            BRANCH
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="yellow"
-              dimColor={false}
-            >
-              ●2 ↑1
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            STATUS
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              2026-05-01
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            LAST
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              feat: thing
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            SUBJECT
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              /tmp/coco
-            </Text>
-          </Box>
+            PATH
+          </Text>
         </Box>
       </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={true}
+            color="cyan"
+          >
+            › 
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={true}
+            dimColor={false}
+          >
+            coco
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            dimColor={false}
+          >
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="yellow"
+            dimColor={false}
+          >
+            ●2 ↑1
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            2026-05-01
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            dimColor={false}
+          >
+            feat: thing
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            /tmp/coco
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
     </Box>
   </Box>
   <Box
     borderColor="gray"
     borderStyle="classic"
     flexDirection="column"
+    height={4}
     paddingX={1}
   >
     <Text
       dimColor={true}
     >
       j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       
     </Text>
   </Box>
 </Box>
@@ -3358,59 +5787,147 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
   <Box
     borderColor="cyan"
     borderStyle="classic"
-    justifyContent="space-between"
     paddingX={1}
   >
     <Text
       bold={true}
+      color="cyan"
+      dimColor={false}
     >
-      coco workspace  roots: ~/code
+      coco
     </Text>
     <Text
       dimColor={true}
     >
-      focus: List  ·  3/3 repos  ·  sort: Recent
+       · 
+    </Text>
+    <Text
+      bold={true}
+      dimColor={false}
+    >
+      workspace
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      dimColor={false}
+    >
+      3/3 repos
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      sort: Recent
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      [List]
     </Text>
   </Box>
   <Box
     flexDirection="row"
-    height={29}
+    height={28}
   >
     <Box
       borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
-      height={29}
+      height={28}
       paddingX={1}
-      width={18}
+      width={22}
     >
       <Text
         bold={true}
       >
         Tabs
       </Text>
-      <Text
-        bold={true}
+      <Box
+        flexDirection="row"
       >
-        › All
-      </Text>
-      <Text>
-          Dirty
-      </Text>
-      <Text>
-          Behind
-      </Text>
-      <Text>
-          PRs
-      </Text>
+        <Text
+          bold={true}
+        >
+          › All      
+        </Text>
+        <Text
+          color="cyan"
+          dimColor={false}
+        >
+           3
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Dirty    
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Behind   
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            PRs      
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
     </Box>
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
-      height={29}
+      height={28}
       paddingX={1}
     >
       <Box
@@ -3430,230 +5947,333 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={true}
-        >
-          › 
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
+        />
+        <Box
+          flexShrink={0}
+          width={19}
         >
-          <Box
-            marginRight={1}
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={true}
-              dimColor={false}
-            >
-              coco
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            REPO
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            BRANCH
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="yellow"
-              dimColor={false}
-            >
-              ●2 ↑1
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            STATUS
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              2026-05-01
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            LAST
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              feat: thing
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            SUBJECT
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              /tmp/coco
-            </Text>
-          </Box>
+            PATH
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={true}
+            color="cyan"
+          >
+            › 
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={true}
+            dimColor={false}
+          >
+            coco
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            dimColor={false}
+          >
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="yellow"
+            dimColor={false}
+          >
+            ●2 ↑1
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            2026-05-01
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            dimColor={false}
+          >
+            feat: thing
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            /tmp/coco
+          </Text>
         </Box>
       </Box>
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
         >
-          <Box
-            marginRight={1}
+          <Text
+            bold={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              docs
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              feature/la...
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            docs
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="yellow"
-              dimColor={false}
-            >
-              ↓3
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            feature/l...
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            bold={false}
+            color="yellow"
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              2026-04-15
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            ↓3
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              wip
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            2026-04-15
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              /tmp/docs
-            </Text>
-          </Box>
+            wip
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/docs
+          </Text>
         </Box>
       </Box>
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
         >
-          <Box
-            marginRight={1}
+          <Text
+            bold={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              lib
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            lib
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              ·
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              —
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            ·
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              —
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              /tmp/lib
-            </Text>
-          </Box>
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/lib
+          </Text>
         </Box>
       </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
     </Box>
   </Box>
   <Box
@@ -3680,12 +6300,18 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
     borderColor="gray"
     borderStyle="classic"
     flexDirection="column"
+    height={4}
     paddingX={1}
   >
     <Text
       dimColor={true}
     >
       j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       
     </Text>
   </Box>
 </Box>
@@ -3699,18 +6325,69 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
   <Box
     borderColor="cyan"
     borderStyle="classic"
-    justifyContent="space-between"
     paddingX={1}
   >
     <Text
       bold={true}
+      color="cyan"
+      dimColor={false}
     >
-      coco workspace  roots: ~/code
+      coco
     </Text>
     <Text
       dimColor={true}
     >
-      focus: List  ·  3/3 repos  ·  sort: Recent
+       · 
+    </Text>
+    <Text
+      bold={true}
+      dimColor={false}
+    >
+      workspace
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      dimColor={false}
+    >
+      3/3 repos
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      sort: Recent
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      [List]
     </Text>
   </Box>
   <Box
@@ -3914,12 +6591,18 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     borderColor="gray"
     borderStyle="classic"
     flexDirection="column"
+    height={4}
     paddingX={1}
   >
     <Text
       dimColor={true}
     >
       j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       
     </Text>
   </Box>
 </Box>
@@ -3933,59 +6616,158 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
   <Box
     borderColor="cyan"
     borderStyle="classic"
-    justifyContent="space-between"
     paddingX={1}
   >
     <Text
       bold={true}
+      color="cyan"
+      dimColor={false}
     >
-      coco workspace  roots: ~/code
+      coco
     </Text>
     <Text
       dimColor={true}
     >
-      focus: List  ·  0/0 repos  ·  sort: Recent  ·  refreshing…
+       · 
+    </Text>
+    <Text
+      bold={true}
+      dimColor={false}
+    >
+      workspace
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      dimColor={false}
+    >
+      0/0 repos
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      sort: Recent
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="yellow"
+      dimColor={false}
+    >
+      refreshing…
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      [List]
     </Text>
   </Box>
   <Box
     flexDirection="row"
-    height={34}
+    height={33}
   >
     <Box
       borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
-      height={34}
+      height={33}
       paddingX={1}
-      width={18}
+      width={22}
     >
       <Text
         bold={true}
       >
         Tabs
       </Text>
-      <Text
-        bold={true}
+      <Box
+        flexDirection="row"
       >
-        › All
-      </Text>
-      <Text>
-          Dirty
-      </Text>
-      <Text>
-          Behind
-      </Text>
-      <Text>
-          PRs
-      </Text>
+        <Text
+          bold={true}
+        >
+          › All      
+        </Text>
+        <Text
+          color="cyan"
+          dimColor={false}
+        >
+           ·
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Dirty    
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Behind   
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            PRs      
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
     </Box>
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
-      height={34}
+      height={33}
       paddingX={1}
     >
       <Box
@@ -4002,10 +6784,94 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
           loading repos…
         </Text>
       </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        />
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            REPO
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            BRANCH
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            STATUS
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            LAST
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            SUBJECT
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            PATH
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
       <Text
         dimColor={true}
       >
         Scanning configured roots…
+      </Text>
+      <Text
+        dimColor={true}
+      >
+         
       </Text>
     </Box>
   </Box>
@@ -4013,12 +6879,18 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
     borderColor="gray"
     borderStyle="classic"
     flexDirection="column"
+    height={4}
     paddingX={1}
   >
     <Text
       dimColor={true}
     >
       j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       
     </Text>
   </Box>
 </Box>
@@ -4032,59 +6904,147 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
   <Box
     borderColor="cyan"
     borderStyle="classic"
-    justifyContent="space-between"
     paddingX={1}
   >
     <Text
       bold={true}
+      color="cyan"
+      dimColor={false}
     >
-      coco workspace  roots: ~/code
+      coco
     </Text>
     <Text
       dimColor={true}
     >
-      focus: List  ·  3/3 repos  ·  sort: Recent
+       · 
+    </Text>
+    <Text
+      bold={true}
+      dimColor={false}
+    >
+      workspace
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      dimColor={false}
+    >
+      3/3 repos
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      sort: Recent
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      [List]
     </Text>
   </Box>
   <Box
     flexDirection="row"
-    height={34}
+    height={33}
   >
     <Box
       borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
-      height={34}
+      height={33}
       paddingX={1}
-      width={18}
+      width={22}
     >
       <Text
         bold={true}
       >
         Tabs
       </Text>
-      <Text
-        bold={true}
+      <Box
+        flexDirection="row"
       >
-        › All
-      </Text>
-      <Text>
-          Dirty
-      </Text>
-      <Text>
-          Behind
-      </Text>
-      <Text>
-          PRs
-      </Text>
+        <Text
+          bold={true}
+        >
+          › All      
+        </Text>
+        <Text
+          color="cyan"
+          dimColor={false}
+        >
+           3
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Dirty    
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            Behind   
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            PRs      
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
     </Box>
     <Box
       borderColor="cyan"
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
-      height={34}
+      height={33}
       paddingX={1}
     >
       <Box
@@ -4104,242 +7064,351 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={true}
-        >
-          › 
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
+        />
+        <Box
+          flexShrink={0}
+          width={19}
         >
-          <Box
-            marginRight={1}
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={true}
-              dimColor={false}
-            >
-              coco
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            REPO
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            BRANCH
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="yellow"
-              dimColor={false}
-            >
-              ●2 ↑1
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            STATUS
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              2026-05-01
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            LAST
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              dimColor={false}
-            >
-              feat: thing
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            SUBJECT
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              color="gray"
-              dimColor={false}
-            >
-              /tmp/coco
-            </Text>
-          </Box>
+            PATH
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={true}
+            color="cyan"
+          >
+            › 
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={true}
+            dimColor={false}
+          >
+            coco
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            dimColor={false}
+          >
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="yellow"
+            dimColor={false}
+          >
+            ●2 ↑1
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            2026-05-01
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            dimColor={false}
+          >
+            feat: thing
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={false}
+          >
+            /tmp/coco
+          </Text>
         </Box>
       </Box>
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
         >
-          <Box
-            marginRight={1}
+          <Text
+            bold={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              docs
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              feature/la...
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            docs
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="yellow"
-              dimColor={false}
-            >
-              ↓3
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            feature/l...
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            bold={false}
+            color="yellow"
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              2026-04-15
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            ↓3
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              wip
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            2026-04-15
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              /tmp/docs
-            </Text>
-          </Box>
+            wip
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/docs
+          </Text>
         </Box>
       </Box>
       <Box
         flexDirection="row"
       >
-        <Text
-          bold={false}
-        >
-            
-        </Text>
         <Box
-          flexDirection="row"
-          flexShrink={1}
+          flexShrink={0}
+          width={2}
         >
-          <Box
-            marginRight={1}
+          <Text
+            bold={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              lib
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              dimColor={false}
-            >
-              main
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            lib
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              ·
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              —
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            ·
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              —
-            </Text>
-          </Box>
-          <Box
-            marginRight={1}
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
           >
-            <Text
-              bold={false}
-              color="gray"
-              dimColor={true}
-            >
-              /tmp/lib
-            </Text>
-          </Box>
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/lib
+          </Text>
         </Box>
       </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
     </Box>
   </Box>
   <Box
     borderColor="gray"
     borderStyle="classic"
     flexDirection="column"
+    height={4}
     paddingX={1}
   >
     <Text
       dimColor={true}
     >
       j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       
     </Text>
   </Box>
 </Box>

--- a/src/workstation/surfaces/workspace/render.ts
+++ b/src/workstation/surfaces/workspace/render.ts
@@ -19,8 +19,12 @@ import { selectVisibleRepos, type WorkspaceState } from './state'
  */
 
 export type WorkspaceListColumn = {
-  /** Right-padded text — already truncated to the column width. */
+  /** Cell content. Truncated to width; the view layer pads to fill. */
   text: string
+  /** Resolved column width in cells. Set by the row builder so the view can render a fixed-width Box for table alignment across rows. */
+  width: number
+  /** Column identity — used by the view for header row + tone selection. */
+  key: WorkspaceColumnKey
   /** True for the column that should grow on screen (the name). */
   primary?: boolean
   /** Hint for the renderer: `'dim'` for muted, `'warn'` for behind/dirty. */
@@ -36,6 +40,8 @@ export type WorkspaceListRow = {
 export type WorkspaceSidebarTabRow = {
   tab: WorkspaceTab
   label: string
+  /** Number of repos in the overview that match this tab's predicate. */
+  count: number
   active: boolean
   /** True when this tab is unavailable (e.g. PRs without gh auth). */
   disabled: boolean
@@ -154,16 +160,16 @@ function formatStatusCell(
   }
   const text = tokens.length === 0 ? '·' : tokens.join(' ')
   const tone: WorkspaceListColumn['tone'] = repo.behind > 0 || repo.dirty > 0 ? 'warn' : 'dim'
-  return { text: truncateCells(text, width), tone }
+  return { text: truncateCells(text, width), width, key: 'status', tone }
 }
 
 function formatDateCell(repo: WorkspaceRepoSummary, width: number): WorkspaceListColumn {
   const date = repo.lastCommit?.date
   if (!date) {
-    return { text: truncateCells('—', width), tone: 'dim' }
+    return { text: truncateCells('—', width), width, key: 'date', tone: 'dim' }
   }
   // Trim ISO date to YYYY-MM-DD — full precision is noise in the row.
-  return { text: truncateCells(date.slice(0, 10), width), tone: 'dim' }
+  return { text: truncateCells(date.slice(0, 10), width), width, key: 'date', tone: 'dim' }
 }
 
 export type BuildWorkspaceListRowsOptions = {
@@ -186,6 +192,8 @@ export function buildWorkspaceListRows(
     if (widths.name !== undefined) {
       columns.push({
         text: truncateCells(repo.name, widths.name),
+        width: widths.name,
+        key: 'name',
         primary: true,
         tone: nameTone,
       })
@@ -193,6 +201,8 @@ export function buildWorkspaceListRows(
     if (widths.branch !== undefined) {
       columns.push({
         text: truncateCells(repo.branch ?? '—', widths.branch),
+        width: widths.branch,
+        key: 'branch',
         tone: repo.branch ? 'default' : 'dim',
       })
     }
@@ -208,17 +218,49 @@ export function buildWorkspaceListRows(
       const subject = repo.lastCommit?.subject ?? '—'
       columns.push({
         text: truncateCells(subject, widths.subject),
+        width: widths.subject,
+        key: 'subject',
         tone: repo.lastCommit?.subject ? 'default' : 'dim',
       })
     }
     if (widths.path !== undefined) {
       columns.push({
         text: truncatePathCells(repo.path, widths.path),
+        width: widths.path,
+        key: 'path',
         tone: 'dim',
       })
     }
     return { repo, cursor, columns }
   })
+}
+
+/**
+ * Column headings shown above the rows. Mirrors the column key order
+ * the row builder produces so the view can lay them out under the
+ * same widths.
+ */
+export type WorkspaceColumnHeader = {
+  key: WorkspaceColumnKey
+  label: string
+  width: number
+}
+
+const COLUMN_LABELS: Record<WorkspaceColumnKey, string> = {
+  name: 'REPO',
+  branch: 'BRANCH',
+  status: 'STATUS',
+  date: 'LAST',
+  subject: 'SUBJECT',
+  path: 'PATH',
+}
+
+export function buildWorkspaceColumnHeaders(width: number): WorkspaceColumnHeader[] {
+  const widths = assignWorkspaceColumnWidths(width)
+  const order: WorkspaceColumnKey[] = ['name', 'branch', 'status', 'date', 'subject', 'path']
+  return order
+    .filter((key) => widths[key] !== undefined)
+    .map((key) => ({ key, label: COLUMN_LABELS[key], width: widths[key]! }))
 }
 
 export type WorkspaceListWindow = {
@@ -276,11 +318,30 @@ export function buildWorkspaceListWindow(
 }
 
 export function buildWorkspaceSidebar(state: WorkspaceState): WorkspaceSidebarTabRow[] {
+  const repos = state.overview.repos
   return WORKSPACE_TABS.map((tab) => {
     const disabled = tab === 'pull-requests' && state.ghAuthenticated === false
+    let count = repos.length
+    switch (tab) {
+      case 'dirty':
+        count = repos.filter((repo) => repo.dirty > 0).length
+        break
+      case 'behind':
+        count = repos.filter((repo) => repo.behind > 0).length
+        break
+      case 'pull-requests': {
+        const counts = state.pullRequestCounts
+        count = repos.filter((repo) => (counts[repo.path] ?? 0) > 0).length
+        break
+      }
+      case 'all':
+      default:
+        count = repos.length
+    }
     return {
       tab,
       label: workspaceTabLabel(tab),
+      count,
       active: state.tab === tab,
       disabled,
     }
@@ -312,6 +373,85 @@ export function buildWorkspaceHeader(
     loading: state.loading,
     filter: state.filter || undefined,
   }
+}
+
+/**
+ * Chip-style header model. Mirrors the `chrome/headerChips.ts` shape
+ * used by `coco ui` so the two surfaces feel like the same app.
+ */
+export type WorkspaceHeaderChipId =
+  | 'app'
+  | 'verb'
+  | 'roots'
+  | 'repos'
+  | 'sort'
+  | 'filter'
+  | 'loading'
+  | 'focus'
+
+export type WorkspaceHeaderChip = {
+  id: WorkspaceHeaderChipId
+  label: string
+  tone: 'accent' | 'default' | 'dim' | 'warn'
+  bold?: boolean
+}
+
+export function buildWorkspaceHeaderChips(
+  state: WorkspaceState,
+  options: { appLabel?: string; focusLabel: string } = { focusLabel: 'List' }
+): WorkspaceHeaderChip[] {
+  const chips: WorkspaceHeaderChip[] = []
+
+  // App identity — accent + bold, anchors the left edge.
+  chips.push({ id: 'app', label: 'coco', tone: 'accent', bold: true })
+  chips.push({ id: 'verb', label: options.appLabel?.replace(/^coco\s+/i, '') ?? 'workspace', tone: 'default', bold: true })
+
+  // Roots — dim chrome.
+  chips.push({
+    id: 'roots',
+    label: state.roots.join(', ') || '—',
+    tone: 'dim',
+  })
+
+  // Repos count — visible / total.
+  const visibleCount = selectVisibleRepos(state).length
+  chips.push({
+    id: 'repos',
+    label: `${visibleCount}/${state.overview.repos.length} repos`,
+    tone: 'default',
+  })
+
+  // Sort mode.
+  chips.push({
+    id: 'sort',
+    label: `sort: ${workspaceSortLabel(state.sortMode)}`,
+    tone: 'dim',
+  })
+
+  // Filter — only when active.
+  if (state.filter) {
+    chips.push({
+      id: 'filter',
+      label: `filter: ${state.filter}`,
+      tone: 'warn',
+    })
+  }
+
+  // Loading — only when refresh is in flight.
+  if (state.loading) {
+    chips.push({ id: 'loading', label: 'refreshing…', tone: 'warn' })
+  }
+
+  // Focus indicator — bracketed accent chip at the end so it reads
+  // like coco ui's `[NORMAL]` mode chip.
+  chips.push({
+    id: 'focus',
+    label: `[${options.focusLabel}]`,
+    tone: 'accent',
+    bold: true,
+  })
+
+  return chips
 }
 
 export type WorkspaceFooterModel = {

--- a/src/workstation/surfaces/workspace/view.ts
+++ b/src/workstation/surfaces/workspace/view.ts
@@ -15,12 +15,14 @@ import { focusBorderColor, panelTitle } from '../../runtime/utils'
 import type { WorkspaceComponents } from './runtime'
 import { type PathCompletionResult } from './pathCompletion'
 import {
+  buildWorkspaceColumnHeaders,
   buildWorkspaceFooter,
-  buildWorkspaceHeader,
+  buildWorkspaceHeaderChips,
   buildWorkspaceHelpRows,
   buildWorkspaceListWindow,
   buildWorkspaceOnboarding,
   buildWorkspaceSidebar,
+  type WorkspaceHeaderChip,
   type WorkspaceListColumn,
   type WorkspaceListRow,
 } from './render'
@@ -75,27 +77,65 @@ function focusLabel(focus: WorkspaceState['focus']): string {
   }
 }
 
+function chipColor(tone: WorkspaceHeaderChip['tone'], theme: LogInkTheme): string | undefined {
+  if (theme.noColor) return undefined
+  switch (tone) {
+    case 'accent':
+      return theme.colors.accent
+    case 'warn':
+      return theme.colors.warning
+    case 'dim':
+      return theme.colors.muted
+    case 'default':
+    default:
+      return undefined
+  }
+}
+
 function renderHeader(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement {
   const { React, ink, state, theme, appLabel } = deps
   const { Box, Text } = ink
-  const model = buildWorkspaceHeader(state, { appLabel })
-  const focusChip = `focus: ${focusLabel(state.focus)}`
-  const left = `${model.appLabel}  roots: ${model.rootsLabel || '—'}`
-  const right = [
-    focusChip,
-    `${model.visibleCount}/${model.repoCount} repos`,
-    `sort: ${model.sortLabel}`,
-    model.loading ? 'refreshing…' : '',
-  ]
-    .filter(Boolean)
-    .join('  ·  ')
+  const chips = buildWorkspaceHeaderChips(state, {
+    appLabel,
+    focusLabel: focusLabel(state.focus),
+  })
+  const separator = ' · '
+  // Interleave chips with a dim separator. Each chip gets its own Text
+  // so its color survives the render — same shape as `coco ui`'s
+  // chip header.
+  const nodes: ReactTypes.ReactNode[] = []
+  chips.forEach((chip, index) => {
+    if (index > 0) {
+      nodes.push(
+        React.createElement(Text, { key: `sep-${index}`, dimColor: true }, separator)
+      )
+    }
+    nodes.push(
+      React.createElement(
+        Text,
+        {
+          key: chip.id,
+          bold: chip.bold,
+          dimColor: chip.tone === 'dim',
+          color: chipColor(chip.tone, theme),
+        },
+        chip.label
+      )
+    )
+  })
   return React.createElement(
     Box,
-    { borderColor: focusBorderColor(theme, true), borderStyle: theme.borderStyle, paddingX: 1, justifyContent: 'space-between' },
-    React.createElement(Text, { bold: true }, left),
-    React.createElement(Text, { dimColor: true }, right)
+    {
+      borderColor: focusBorderColor(theme, true),
+      borderStyle: theme.borderStyle,
+      paddingX: 1,
+    },
+    ...nodes
   )
 }
+
+const SIDEBAR_WIDTH = 22
+const SIDEBAR_LABEL_WIDTH = 9 // " Dirty " etc. — enough for the longest tab label
 
 function renderSidebar(
   deps: RenderWorkspaceAppDeps,
@@ -106,13 +146,11 @@ function renderSidebar(
   // Sidebar owns the focus when the user is cycling tabs.
   const focused = state.focus === 'sidebar'
   const tabs = buildWorkspaceSidebar(state)
+  const widest = tabs.reduce((acc, row) => Math.max(acc, row.label.length), SIDEBAR_LABEL_WIDTH)
   const rows = tabs.map((row) => {
     const props: Record<string, unknown> = { key: row.tab }
     if (row.active) {
       props.bold = true
-      // While the sidebar is focused, the active tab gets the
-      // accent color so users can tell at a glance that their
-      // j/k presses are landing on a tab cycle.
       if (focused && !theme.noColor) {
         props.color = theme.colors.accent
       }
@@ -120,7 +158,21 @@ function renderSidebar(
       props.dimColor = true
     }
     const cursor = row.active ? '›' : ' '
-    return React.createElement(Text, props, `${cursor} ${row.label}`)
+    const paddedLabel = row.label.padEnd(widest)
+    const countText = row.count > 0 ? String(row.count) : '·'
+    // Render label + count on the same line so the count is always
+    // right after the label and reads as part of the tab. Count is
+    // dim so the label keeps visual priority.
+    return React.createElement(
+      Box,
+      { key: row.tab, flexDirection: 'row' },
+      React.createElement(Text, props, `${cursor} ${paddedLabel}`),
+      React.createElement(
+        Text,
+        { dimColor: !row.active, color: row.active && !theme.noColor ? theme.colors.accent : undefined },
+        ` ${countText}`
+      )
+    )
   })
   return React.createElement(
     Box,
@@ -131,12 +183,15 @@ function renderSidebar(
       flexShrink: 0,
       height,
       paddingX: 1,
-      width: 18,
+      width: SIDEBAR_WIDTH,
     },
     React.createElement(Text, { bold: true }, panelTitle('Tabs', focused)),
     ...rows
   )
 }
+
+const COLUMN_GAP = 1
+const CURSOR_PREFIX_WIDTH = 2
 
 function renderListRow(
   deps: RenderWorkspaceAppDeps,
@@ -147,9 +202,16 @@ function renderListRow(
   const { Box, Text } = ink
   const cursor = row.cursor ? '›' : ' '
   const cells = row.columns.map((column, index) =>
+    // Fixed-width Box per column — this is what was missing before.
+    // Without it, cells with shorter content collapsed and the
+    // table rows wandered out of alignment across rows.
     React.createElement(
       Box,
-      { key: index, marginRight: 1 },
+      {
+        key: column.key,
+        width: column.width + (index < row.columns.length - 1 ? COLUMN_GAP : 0),
+        flexShrink: 0,
+      },
       React.createElement(
         Text,
         {
@@ -164,11 +226,46 @@ function renderListRow(
   return React.createElement(
     Box,
     { key, flexDirection: 'row' },
-    React.createElement(Text, { bold: row.cursor }, `${cursor} `),
-    // flexWrap removed deliberately — wrapping caused extra layout
-    // passes per render and contributed to the alt-screen flicker.
-    // The column-width helper already truncates each cell to fit.
-    React.createElement(Box, { flexDirection: 'row', flexShrink: 1 }, ...cells)
+    React.createElement(
+      Box,
+      { width: CURSOR_PREFIX_WIDTH, flexShrink: 0 },
+      React.createElement(
+        Text,
+        { bold: row.cursor, color: row.cursor && !theme.noColor ? theme.colors.accent : undefined },
+        `${cursor} `
+      )
+    ),
+    ...cells
+  )
+}
+
+function renderColumnHeader(
+  deps: RenderWorkspaceAppDeps,
+  width: number
+): ReactTypes.ReactElement {
+  const { React, ink, theme } = deps
+  const { Box, Text } = ink
+  const headers = buildWorkspaceColumnHeaders(width)
+  const cells = headers.map((header, index) =>
+    React.createElement(
+      Box,
+      {
+        key: header.key,
+        width: header.width + (index < headers.length - 1 ? COLUMN_GAP : 0),
+        flexShrink: 0,
+      },
+      React.createElement(
+        Text,
+        { dimColor: true, color: theme.noColor ? undefined : theme.colors.muted },
+        header.label
+      )
+    )
+  )
+  return React.createElement(
+    Box,
+    { flexDirection: 'row' },
+    React.createElement(Box, { width: CURSOR_PREFIX_WIDTH, flexShrink: 0 }),
+    ...cells
   )
 }
 
@@ -179,18 +276,16 @@ function renderListBody(
 ): ReactTypes.ReactElement {
   const { React, ink, state, theme } = deps
   const { Box, Text } = ink
-  // List panel is "focused" when j/k means cursor movement — i.e.
-  // when the user is in list mode or a modal that was opened from
-  // the list (filter, add-repo, confirm-delete). Sidebar focus
-  // dims the list panel border to make the active panel obvious.
   const focused = state.focus !== 'sidebar'
-  // Reserve: 1 row for the panel header, 1 for each scroll indicator
-  // (if shown), 2 for the border. Floor at 1 so the panel always
-  // renders at least one row.
-  const reservedChrome = 3
+
+  // Reserve: 1 row each for panel title, column header, top chevron,
+  // bottom chevron, plus 2 for the border. Floor at 1 so we always
+  // render at least one row of content.
+  const reservedChrome = 5
   const listRows = Math.max(1, height - reservedChrome)
   const windowed = buildWorkspaceListWindow(state, { width, rows: listRows })
   const visibleRepos = selectVisibleRepos(state)
+
   const filterChip = state.filter
     ? `  ·  filter: ${state.filter}`
     : state.focus === 'filter'
@@ -199,6 +294,7 @@ function renderListBody(
   const headerRight = state.loading
     ? 'loading repos…'
     : `${visibleRepos.length} visible${filterChip}`
+
   const lines: ReactTypes.ReactNode[] = windowed.rows.length === 0
     ? [
       React.createElement(
@@ -214,20 +310,21 @@ function renderListBody(
     : windowed.rows.map((row, index) =>
       renderListRow(deps, row, `row-${windowed.hiddenAbove + index}`)
     )
-  const topChevron = windowed.hiddenAbove > 0
-    ? React.createElement(
-      Text,
-      { key: 'chevron-top', dimColor: true },
-      `↑ ${windowed.hiddenAbove} more`
-    )
-    : null
-  const bottomChevron = windowed.hiddenBelow > 0
-    ? React.createElement(
-      Text,
-      { key: 'chevron-bottom', dimColor: true },
-      `↓ ${windowed.hiddenBelow} more`
-    )
-    : null
+
+  // Scroll chevrons render as fixed-height single-cell rows. Always
+  // present (blank when nothing hidden) so the panel layout doesn't
+  // shift as the user scrolls — keeps the visual frame steady.
+  const topChevron = React.createElement(
+    Text,
+    { key: 'chevron-top', dimColor: true },
+    windowed.hiddenAbove > 0 ? `↑ ${windowed.hiddenAbove} more` : ' '
+  )
+  const bottomChevron = React.createElement(
+    Text,
+    { key: 'chevron-bottom', dimColor: true },
+    windowed.hiddenBelow > 0 ? `↓ ${windowed.hiddenBelow} more` : ' '
+  )
+
   return React.createElement(
     Box,
     {
@@ -238,12 +335,15 @@ function renderListBody(
       height,
       paddingX: 1,
     },
+    // Panel title — kept on its own row, never crowded by the
+    // scroll indicator (which used to overlap when content reflowed).
     React.createElement(
       Box,
       { justifyContent: 'space-between' },
       React.createElement(Text, { bold: true }, panelTitle('Workspace', focused)),
       React.createElement(Text, { dimColor: true }, headerRight)
     ),
+    renderColumnHeader(deps, width),
     topChevron,
     ...lines,
     bottomChevron
@@ -362,10 +462,17 @@ function renderAddRepoPrompt(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElem
   )
 }
 
+const FOOTER_HEIGHT = 4 // 2 borders + hint row + status row
+
 function renderFooter(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement {
   const { React, ink, state, theme } = deps
   const { Box, Text } = ink
   const model = buildWorkspaceFooter(state)
+  // Always render the status row (placeholder when empty) so the
+  // footer height never changes with state. Without this, the body
+  // height shifted by a row every time a status banner came and went,
+  // forcing the panel chrome to reflow.
+  const statusContent = model.status ?? ''
   return React.createElement(
     Box,
     {
@@ -373,11 +480,17 @@ function renderFooter(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement {
       borderStyle: theme.borderStyle,
       paddingX: 1,
       flexDirection: 'column',
+      height: FOOTER_HEIGHT,
     },
     React.createElement(Text, { dimColor: true }, model.hint),
-    model.status
-      ? React.createElement(Text, { color: toneColor('warn', theme) }, model.status)
-      : null
+    React.createElement(
+      Text,
+      {
+        color: model.status ? toneColor('warn', theme) : undefined,
+        dimColor: !model.status,
+      },
+      statusContent || ' '
+    )
   )
 }
 
@@ -390,7 +503,9 @@ function renderFooter(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement {
  */
 function computeBodyHeight(deps: RenderWorkspaceAppDeps): number {
   const HEADER_ROWS = 3
-  const FOOTER_ROWS = deps.state.status ? 4 : 3
+  // Footer height is now fixed (#1063 polish) so the body height
+  // doesn't shift as status banners appear / disappear.
+  const FOOTER_ROWS = FOOTER_HEIGHT
   const onboardingRows = buildWorkspaceOnboarding(deps.state).show ? 5 : 0
   const addRepoRows = deps.state.focus === 'add-repo' ? 5 : 0
   const confirmRows = deps.state.focus === 'confirm-delete' ? 5 : 0
@@ -426,7 +541,7 @@ export function renderWorkspaceApp(deps: RenderWorkspaceAppDeps): ReactTypes.Rea
       Box,
       { flexDirection: 'row', height: bodyHeight },
       renderSidebar(deps, bodyHeight),
-      renderListBody(deps, bodyWidth - 22, bodyHeight)
+      renderListBody(deps, bodyWidth - SIDEBAR_WIDTH - 2, bodyHeight)
     ),
     renderOnboardingBanner(deps),
     renderAddRepoPrompt(deps),


### PR DESCRIPTION
Polish pass addressing the four points raised on the screenshot comparison:

1. **Inconsistent column sizes**
2. **Header doesn't feel as polished as \`coco ui\`**
3. **Tabs could improve / be extended**
4. **Bottom bar consistent sizing**

## Changes

**1. Chip-style header (matches \`coco ui\`'s header pattern).**
Replaces the flat \`coco workspace  roots: ...\` text with discrete chips separated by dim \` · \`:

- \`coco\` — accent + bold (identity)
- \`workspace\` — bold (verb)
- roots — dim
- repos / sort — default
- filter / refreshing — warn (only when active)
- \`[List]\` / \`[Tabs]\` / \`[Filter]\` — accent + bold (mode indicator, mirrors coco ui's \`[NORMAL]\`)

**2. Fixed-width columns (fixes sloppy row misalignment).**
Each cell now wraps in a Box with explicit \`width\` matching its allocated column width. Before, cells used \`marginRight\` without a width prop, so short content collapsed and rows wandered. Added a column-header row (\`REPO BRANCH STATUS LAST SUBJECT PATH\`) above the list, dim-rendered.

**3. Tabs with counts.**
Sidebar now shows \`All  64\`, \`Dirty  3\`, \`Behind  12\`, \`PRs  5\`. Counts compute from the overview + PR data. Sidebar width 18→22 to fit.

**4. Fixed-height footer.**
Footer is now always 4 rows (2 borders + hint + status placeholder). Status row renders a dim placeholder when empty so the body height never shifts as banners come and go.

**Bonus**: scroll chevrons (\`↑ N more\` / \`↓ N more\`) are now their own rows with a placeholder when nothing is hidden — fixes the \`↑ 12 more *\` title overlap visible in the screenshots.

## Test plan

- [x] Lint clean
- [x] Full Jest suite: 188 suites, 2408 passing, 33 snapshots (17 workspace snapshots refreshed)
- [ ] Manual: \`yarn dev:tui workspace\` — header reads as discrete chips, columns line up across rows, tab counts visible, footer height stays put when status banners appear