### PR TITLE
feat(screenshot): expand recipe catalog to 19 scenes + document VHS gotchas

### DIFF
--- a/bin/screenshot/README.md
+++ b/bin/screenshot/README.md
@@ -32,6 +32,20 @@ The screenshots have to look identical between runs to be useful. The harness co
 - **Theme colours** — recipes can lock to a specific preset (`default` / `monochrome` / `catppuccin` / `gruvbox`) via the `theme` field.
 - **Terminal palette** — the VHS tape pins the *terminal's* theme to "Catppuccin Mocha" so the xterm.js render is consistent regardless of the upstream VHS default.
 
+## VHS shell environment (critical gotchas)
+
+VHS spawns a fresh `bash` shell that does NOT inherit the parent process's environment. This caused several hard-to-debug issues during development:
+
+1. **PATH must use unquoted `$PATH`** — VHS's `Type "..."` command types literal characters. If you single-quote the PATH export (`'...:$PATH'`), bash treats `$PATH` as a literal string and the shell loses access to `git`, `sleep`, and all system binaries. The tape uses `export PATH=.../node_modules/.bin:.../node/bin:$PATH` (no quotes around the value) so `$PATH` expands correctly.
+
+2. **Settle time must account for tsx cold-start** — Inside VHS, tsx takes 2-3 seconds to cold-start (vs ~500ms in a warm terminal). The `POST_LAUNCH_SETTLE_MS` constant (currently 5000ms) gives enough time for tsx boot + the workstation's async git data load. If screenshots show "loading commits" or empty state, increase this value.
+
+3. **macOS `/var` → `/private/var` symlink** — Temp dirs created by Node live at `/var/folders/...` but the real path is `/private/var/folders/...`. Git's `safe.directory` checks can fail on the symlinked path. The driver resolves symlinks via `realpathSync()` and the tape runs `git config --global --add safe.directory '*'` in the hidden setup.
+
+4. **`--repo` flag is required** — VHS's `cd` command changes the shell's cwd, but coco's `process.chdir()` in the `--repo` handler is what actually binds the git instance. Always pass `--repo <path>` explicitly rather than relying on cwd.
+
+5. **`Screenshot` vs `Output`** — VHS's `Output "foo.png"` records the entire session as a frame-sequence directory. Use `Screenshot filename.png` (bare filename, no path) to capture a single frame. The driver runs VHS with `cwd` set to the scenario dir so the screenshot lands there, then moves it to the final output path.
+
 ## Adding a recipe
 
 Append to `RECIPES` in `bin/screenshot/recipes.ts`:

--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -113,6 +113,74 @@ export const RECIPES: ScreenshotRecipe[] = [
   },
 
   // ─────────────────────────────────────────────────────────────────
+  // `coco ui` — additional views and scenarios
+  // ─────────────────────────────────────────────────────────────────
+  {
+    name: 'ui-branches-sync-showcase',
+    description: 'Branches view showing 5 branches in different upstream sync states',
+    scenario: 'branch-sync-showcase',
+    command: 'ui',
+    actions: [
+      { kind: 'sleep', ms: 800 },
+      { kind: 'type', text: 'gb' },
+      { kind: 'sleep', ms: 400 },
+    ],
+  },
+  {
+    name: 'ui-diff-feature-branch',
+    description: 'Diff view showing a commit diff on a feature branch',
+    scenario: 'feature-pr-ready',
+    command: 'ui --view diff',
+  },
+  {
+    name: 'ui-merge-conflict',
+    description: 'Workstation during an active merge conflict',
+    scenario: 'mid-merge-conflict',
+    command: 'ui --view history',
+  },
+  {
+    name: 'ui-rebase-conflict',
+    description: 'Workstation during an active rebase conflict',
+    scenario: 'mid-rebase-conflict',
+    command: 'ui --view history',
+  },
+  {
+    name: 'ui-multi-commit-branch',
+    description: 'History view with 8 varied conventional commits (feat/fix/chore/docs/refactor/test)',
+    scenario: 'multi-commit-branch',
+    command: 'ui --view history --no-all',
+  },
+  {
+    name: 'ui-large-repo',
+    description: 'History view with 115 commits across 3 branches — pagination stress test',
+    scenario: 'large-repo',
+    command: 'ui --view history',
+  },
+  {
+    name: 'ui-worktrees',
+    description: 'Worktrees view showing 3 linked worktrees on different branches',
+    scenario: 'multiple-worktrees',
+    command: 'ui',
+    actions: [
+      { kind: 'sleep', ms: 800 },
+      { kind: 'type', text: 'gw' },
+      { kind: 'sleep', ms: 400 },
+    ],
+  },
+  {
+    name: 'ui-submodule',
+    description: 'History view of a repo with a submodule',
+    scenario: 'submodule-with-history',
+    command: 'ui --view history --no-all',
+  },
+  {
+    name: 'ui-detached-head',
+    description: 'Workstation in detached HEAD state',
+    scenario: 'detached-head',
+    command: 'ui --view history --no-all',
+  },
+
+  // ─────────────────────────────────────────────────────────────────
   // `coco log` — stdout / non-interactive renders
   // ─────────────────────────────────────────────────────────────────
   {
@@ -121,6 +189,13 @@ export const RECIPES: ScreenshotRecipe[] = [
     scenario: 'two-commit-feature',
     command: 'log --limit 10 --no-color',
     dimensions: { cols: 120, rows: 24 },
+  },
+  {
+    name: 'log-stdout-rich-graph',
+    description: 'Stdout `coco log` with full graph on a multi-branch repo',
+    scenario: 'rich-history-graph',
+    command: 'log --limit 20 --all --no-color',
+    dimensions: { cols: 140, rows: 30 },
   },
 
   // ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Adds 10 new recipes (branches, diff, conflicts, worktrees, submodules, large-repo, detached-head, stdout graph) and documents the VHS shell environment gotchas that caused the empty-repo debugging session. Total: 19 recipes, all passing locally.