### PR TITLE
feat(workspace): density polish — rail sidebar, glyphs, smarter drop priority

### DIFF
--- a/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
+++ b/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
@@ -97,7 +97,18 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
         <Text
           bold={true}
         >
-          › All      
+          › 
+        </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+          ◯ 
+        </Text>
+        <Text
+          bold={true}
+        >
+          All      
         </Text>
         <Text
           color="cyan"
@@ -110,7 +121,15 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
         flexDirection="row"
       >
         <Text>
-            Dirty    
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ● 
+        </Text>
+        <Text>
+          Dirty    
         </Text>
         <Text
           dimColor={true}
@@ -122,7 +141,15 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
         flexDirection="row"
       >
         <Text>
-            Behind   
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ↓ 
+        </Text>
+        <Text>
+          Behind   
         </Text>
         <Text
           dimColor={true}
@@ -134,7 +161,15 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
         flexDirection="row"
       >
         <Text>
-            PRs      
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ⊙ 
+        </Text>
+        <Text>
+          PRs      
         </Text>
         <Text
           dimColor={true}
@@ -254,6 +289,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
           <Text
             bold={true}
             color="cyan"
+            inverse={true}
           >
             › 
           </Text>
@@ -264,7 +300,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
         >
           <Text
             bold={true}
-            dimColor={false}
+            inverse={true}
           >
             coco
           </Text>
@@ -274,7 +310,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
           width={13}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             main
           </Text>
@@ -284,10 +320,9 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
           width={9}
         >
           <Text
-            color="yellow"
-            dimColor={false}
+            inverse={true}
           >
-            ●2 ↑1...
+            ●2 ↑1 ⊙4
           </Text>
         </Box>
         <Box
@@ -295,10 +330,9 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
           width={11}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
-            2026-05-01
+            3w
           </Text>
         </Box>
         <Box
@@ -306,7 +340,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
           width={20}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             feat: thing
           </Text>
@@ -316,8 +350,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
           width={18}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
             /tmp/coco
           </Text>
@@ -332,6 +365,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
@@ -343,6 +377,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             docs
           </Text>
@@ -354,6 +389,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             feature/l...
           </Text>
@@ -366,6 +402,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
             bold={false}
             color="yellow"
             dimColor={false}
+            inverse={false}
           >
             ↓3
           </Text>
@@ -378,8 +415,9 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
-            2026-04-15
+            6w
           </Text>
         </Box>
         <Box
@@ -389,6 +427,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             wip
           </Text>
@@ -401,6 +440,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             /tmp/docs
           </Text>
@@ -415,6 +455,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
@@ -426,6 +467,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             lib
           </Text>
@@ -437,6 +479,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             main
           </Text>
@@ -449,6 +492,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             ·
           </Text>
@@ -461,6 +505,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             —
           </Text>
@@ -473,6 +518,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             —
           </Text>
@@ -485,6 +531,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             /tmp/lib
           </Text>
@@ -626,7 +673,18 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
         <Text
           bold={true}
         >
-          › All      
+          › 
+        </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+          ◯ 
+        </Text>
+        <Text
+          bold={true}
+        >
+          All      
         </Text>
         <Text
           color="cyan"
@@ -639,7 +697,15 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
         flexDirection="row"
       >
         <Text>
-            Dirty    
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ● 
+        </Text>
+        <Text>
+          Dirty    
         </Text>
         <Text
           dimColor={true}
@@ -651,7 +717,15 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
         flexDirection="row"
       >
         <Text>
-            Behind   
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ↓ 
+        </Text>
+        <Text>
+          Behind   
         </Text>
         <Text
           dimColor={true}
@@ -663,7 +737,15 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
         flexDirection="row"
       >
         <Text>
-            PRs      
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ⊙ 
+        </Text>
+        <Text>
+          PRs      
         </Text>
         <Text
           dimColor={true}
@@ -783,6 +865,7 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
           <Text
             bold={true}
             color="cyan"
+            inverse={true}
           >
             › 
           </Text>
@@ -793,7 +876,7 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
         >
           <Text
             bold={true}
-            dimColor={false}
+            inverse={true}
           >
             lib
           </Text>
@@ -803,7 +886,7 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
           width={13}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             main
           </Text>
@@ -813,8 +896,7 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
           width={9}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
             ·
           </Text>
@@ -824,8 +906,7 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
           width={11}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
             —
           </Text>
@@ -835,8 +916,7 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
           width={20}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
             —
           </Text>
@@ -846,8 +926,7 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
           width={18}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
             /tmp/lib
           </Text>
@@ -978,7 +1057,18 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
         <Text
           bold={true}
         >
-          › All      
+          › 
+        </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+          ◯ 
+        </Text>
+        <Text
+          bold={true}
+        >
+          All      
         </Text>
         <Text
           color="cyan"
@@ -991,7 +1081,15 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
         flexDirection="row"
       >
         <Text>
-            Dirty    
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ● 
+        </Text>
+        <Text>
+          Dirty    
         </Text>
         <Text
           dimColor={true}
@@ -1003,7 +1101,15 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
         flexDirection="row"
       >
         <Text>
-            Behind   
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ↓ 
+        </Text>
+        <Text>
+          Behind   
         </Text>
         <Text
           dimColor={true}
@@ -1017,7 +1123,17 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
         <Text
           dimColor={true}
         >
-            PRs      
+            
+        </Text>
+        <Text
+          dimColor={true}
+        >
+          ⊙ 
+        </Text>
+        <Text
+          dimColor={true}
+        >
+          PRs      
         </Text>
         <Text
           dimColor={true}
@@ -1137,6 +1253,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
           <Text
             bold={true}
             color="cyan"
+            inverse={true}
           >
             › 
           </Text>
@@ -1147,7 +1264,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
         >
           <Text
             bold={true}
-            dimColor={false}
+            inverse={true}
           >
             coco
           </Text>
@@ -1157,7 +1274,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
           width={13}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             main
           </Text>
@@ -1167,8 +1284,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
           width={9}
         >
           <Text
-            color="yellow"
-            dimColor={false}
+            inverse={true}
           >
             ●2 ↑1
           </Text>
@@ -1178,10 +1294,9 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
           width={11}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
-            2026-05-01
+            3w
           </Text>
         </Box>
         <Box
@@ -1189,7 +1304,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
           width={20}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             feat: thing
           </Text>
@@ -1199,8 +1314,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
           width={18}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
             /tmp/coco
           </Text>
@@ -1215,6 +1329,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
@@ -1226,6 +1341,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             docs
           </Text>
@@ -1237,6 +1353,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             feature/l...
           </Text>
@@ -1249,6 +1366,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
             bold={false}
             color="yellow"
             dimColor={false}
+            inverse={false}
           >
             ↓3
           </Text>
@@ -1261,8 +1379,9 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
-            2026-04-15
+            6w
           </Text>
         </Box>
         <Box
@@ -1272,6 +1391,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             wip
           </Text>
@@ -1284,6 +1404,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             /tmp/docs
           </Text>
@@ -1298,6 +1419,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
@@ -1309,6 +1431,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             lib
           </Text>
@@ -1320,6 +1443,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             main
           </Text>
@@ -1332,6 +1456,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             ·
           </Text>
@@ -1344,6 +1469,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             —
           </Text>
@@ -1356,6 +1482,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             —
           </Text>
@@ -1368,6 +1495,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             /tmp/lib
           </Text>
@@ -1484,65 +1612,35 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
       flexDirection="column"
       flexShrink={0}
       height={33}
-      paddingX={1}
-      width={22}
+      paddingX={0}
+      width={5}
     >
       <Text
-        bold={true}
+        dimColor={true}
       >
-        Tabs
+         »
       </Text>
-      <Box
-        flexDirection="row"
+      <Text
+        bold={true}
+        color="cyan"
       >
-        <Text
-          bold={true}
-        >
-          › All      
-        </Text>
-        <Text
-          color="cyan"
-          dimColor={false}
-        >
-           3
-        </Text>
-      </Box>
-      <Box
-        flexDirection="row"
+         ◯
+      </Text>
+      <Text
+        dimColor={true}
       >
-        <Text>
-            Dirty    
-        </Text>
-        <Text
-          dimColor={true}
-        >
-           1
-        </Text>
-      </Box>
-      <Box
-        flexDirection="row"
+         ●
+      </Text>
+      <Text
+        dimColor={true}
       >
-        <Text>
-            Behind   
-        </Text>
-        <Text
-          dimColor={true}
-        >
-           1
-        </Text>
-      </Box>
-      <Box
-        flexDirection="row"
+         ↓
+      </Text>
+      <Text
+        dimColor={true}
       >
-        <Text>
-            PRs      
-        </Text>
-        <Text
-          dimColor={true}
-        >
-           ·
-        </Text>
-      </Box>
+         ⊙
+      </Text>
     </Box>
     <Box
       borderColor="cyan"
@@ -1575,7 +1673,7 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
         />
         <Box
           flexShrink={0}
-          width={17}
+          width={16}
         >
           <Text
             color="gray"
@@ -1586,7 +1684,7 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
         </Box>
         <Box
           flexShrink={0}
-          width={14}
+          width={13}
         >
           <Text
             color="gray"
@@ -1608,13 +1706,24 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
         </Box>
         <Box
           flexShrink={0}
-          width={10}
+          width={11}
         >
           <Text
             color="gray"
             dimColor={true}
           >
             LAST
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            SUBJECT
           </Text>
         </Box>
       </Box>
@@ -1633,27 +1742,28 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
           <Text
             bold={true}
             color="cyan"
+            inverse={true}
           >
             › 
           </Text>
         </Box>
         <Box
           flexShrink={0}
-          width={17}
+          width={16}
         >
           <Text
             bold={true}
-            dimColor={false}
+            inverse={true}
           >
             coco
           </Text>
         </Box>
         <Box
           flexShrink={0}
-          width={14}
+          width={13}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             main
           </Text>
@@ -1663,21 +1773,29 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
           width={9}
         >
           <Text
-            color="yellow"
-            dimColor={false}
+            inverse={true}
           >
             ●2 ↑1
           </Text>
         </Box>
         <Box
           flexShrink={0}
-          width={10}
+          width={11}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
-            2026-05-01
+            3w
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            inverse={true}
+          >
+            feat: thing
           </Text>
         </Box>
       </Box>
@@ -1690,30 +1808,33 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
         </Box>
         <Box
           flexShrink={0}
-          width={17}
+          width={16}
         >
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             docs
           </Text>
         </Box>
         <Box
           flexShrink={0}
-          width={14}
+          width={13}
         >
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
-            feature/la...
+            feature/l...
           </Text>
         </Box>
         <Box
@@ -1724,20 +1845,34 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
             bold={false}
             color="yellow"
             dimColor={false}
+            inverse={false}
           >
             ↓3
           </Text>
         </Box>
         <Box
           flexShrink={0}
-          width={10}
+          width={11}
         >
           <Text
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
-            2026-04-15
+            6w
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            bold={false}
+            dimColor={false}
+            inverse={false}
+          >
+            wip
           </Text>
         </Box>
       </Box>
@@ -1750,28 +1885,31 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
         </Box>
         <Box
           flexShrink={0}
-          width={17}
+          width={16}
         >
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             lib
           </Text>
         </Box>
         <Box
           flexShrink={0}
-          width={14}
+          width={13}
         >
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             main
           </Text>
@@ -1784,18 +1922,33 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             ·
           </Text>
         </Box>
         <Box
           flexShrink={0}
-          width={10}
+          width={11}
         >
           <Text
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
+          >
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+            inverse={false}
           >
             —
           </Text>
@@ -1926,7 +2079,18 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
         <Text
           bold={true}
         >
-          › All      
+          › 
+        </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+          ◯ 
+        </Text>
+        <Text
+          bold={true}
+        >
+          All      
         </Text>
         <Text
           color="cyan"
@@ -1939,7 +2103,15 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
         flexDirection="row"
       >
         <Text>
-            Dirty    
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ● 
+        </Text>
+        <Text>
+          Dirty    
         </Text>
         <Text
           dimColor={true}
@@ -1951,7 +2123,15 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
         flexDirection="row"
       >
         <Text>
-            Behind   
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ↓ 
+        </Text>
+        <Text>
+          Behind   
         </Text>
         <Text
           dimColor={true}
@@ -1963,7 +2143,15 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
         flexDirection="row"
       >
         <Text>
-            PRs      
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ⊙ 
+        </Text>
+        <Text>
+          PRs      
         </Text>
         <Text
           dimColor={true}
@@ -2083,6 +2271,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
           <Text
             bold={true}
             color="cyan"
+            inverse={true}
           >
             › 
           </Text>
@@ -2093,7 +2282,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
         >
           <Text
             bold={true}
-            dimColor={false}
+            inverse={true}
           >
             coco
           </Text>
@@ -2103,7 +2292,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
           width={13}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             main
           </Text>
@@ -2113,8 +2302,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
           width={9}
         >
           <Text
-            color="yellow"
-            dimColor={false}
+            inverse={true}
           >
             ●2 ↑1
           </Text>
@@ -2124,10 +2312,9 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
           width={11}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
-            2026-05-01
+            3w
           </Text>
         </Box>
         <Box
@@ -2135,7 +2322,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
           width={20}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             feat: thing
           </Text>
@@ -2145,8 +2332,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
           width={18}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
             /tmp/coco
           </Text>
@@ -2161,6 +2347,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
@@ -2172,6 +2359,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             docs
           </Text>
@@ -2183,6 +2371,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             feature/l...
           </Text>
@@ -2195,6 +2384,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
             bold={false}
             color="yellow"
             dimColor={false}
+            inverse={false}
           >
             ↓3
           </Text>
@@ -2207,8 +2397,9 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
-            2026-04-15
+            6w
           </Text>
         </Box>
         <Box
@@ -2218,6 +2409,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             wip
           </Text>
@@ -2230,6 +2422,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             /tmp/docs
           </Text>
@@ -2244,6 +2437,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
@@ -2255,6 +2449,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             lib
           </Text>
@@ -2266,6 +2461,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             main
           </Text>
@@ -2278,6 +2474,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             ·
           </Text>
@@ -2290,6 +2487,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             —
           </Text>
@@ -2302,6 +2500,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             —
           </Text>
@@ -2314,6 +2513,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             /tmp/lib
           </Text>
@@ -2431,65 +2631,35 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
       flexDirection="column"
       flexShrink={0}
       height={33}
-      paddingX={1}
-      width={22}
+      paddingX={0}
+      width={5}
     >
       <Text
-        bold={true}
+        dimColor={true}
       >
-        Tabs
+         »
       </Text>
-      <Box
-        flexDirection="row"
+      <Text
+        bold={true}
+        color="cyan"
       >
-        <Text
-          bold={true}
-        >
-          › All      
-        </Text>
-        <Text
-          color="cyan"
-          dimColor={false}
-        >
-           3
-        </Text>
-      </Box>
-      <Box
-        flexDirection="row"
+         ◯
+      </Text>
+      <Text
+        dimColor={true}
       >
-        <Text>
-            Dirty    
-        </Text>
-        <Text
-          dimColor={true}
-        >
-           1
-        </Text>
-      </Box>
-      <Box
-        flexDirection="row"
+         ●
+      </Text>
+      <Text
+        dimColor={true}
       >
-        <Text>
-            Behind   
-        </Text>
-        <Text
-          dimColor={true}
-        >
-           1
-        </Text>
-      </Box>
-      <Box
-        flexDirection="row"
+         ↓
+      </Text>
+      <Text
+        dimColor={true}
       >
-        <Text>
-            PRs      
-        </Text>
-        <Text
-          dimColor={true}
-        >
-           ·
-        </Text>
-      </Box>
+         ⊙
+      </Text>
     </Box>
     <Box
       borderColor="cyan"
@@ -2522,7 +2692,7 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
         />
         <Box
           flexShrink={0}
-          width={17}
+          width={15}
         >
           <Text
             color="gray"
@@ -2542,6 +2712,28 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
             BRANCH
           </Text>
         </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            STATUS
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={10}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            LAST
+          </Text>
+        </Box>
       </Box>
       <Text
         dimColor={true}
@@ -2558,17 +2750,18 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
           <Text
             bold={true}
             color="cyan"
+            inverse={true}
           >
             › 
           </Text>
         </Box>
         <Box
           flexShrink={0}
-          width={17}
+          width={15}
         >
           <Text
             bold={true}
-            dimColor={false}
+            inverse={true}
           >
             coco
           </Text>
@@ -2578,9 +2771,29 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
           width={13}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            inverse={true}
+          >
+            ●2 ↑1
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={10}
+        >
+          <Text
+            inverse={true}
+          >
+            3w
           </Text>
         </Box>
       </Box>
@@ -2593,17 +2806,19 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
         </Box>
         <Box
           flexShrink={0}
-          width={17}
+          width={15}
         >
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             docs
           </Text>
@@ -2615,8 +2830,35 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
-            feature/la...
+            feature/l...
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            bold={false}
+            color="yellow"
+            dimColor={false}
+            inverse={false}
+          >
+            ↓3
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={10}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+            inverse={false}
+          >
+            6w
           </Text>
         </Box>
       </Box>
@@ -2629,17 +2871,19 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
         </Box>
         <Box
           flexShrink={0}
-          width={17}
+          width={15}
         >
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             lib
           </Text>
@@ -2651,8 +2895,35 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+            inverse={false}
+          >
+            ·
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={10}
+        >
+          <Text
+            bold={false}
+            color="gray"
+            dimColor={true}
+            inverse={false}
+          >
+            —
           </Text>
         </Box>
       </Box>
@@ -2781,7 +3052,18 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
         <Text
           bold={true}
         >
-          › All      
+          › 
+        </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+          ◯ 
+        </Text>
+        <Text
+          bold={true}
+        >
+          All      
         </Text>
         <Text
           color="cyan"
@@ -2794,7 +3076,15 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
         flexDirection="row"
       >
         <Text>
-            Dirty    
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ● 
+        </Text>
+        <Text>
+          Dirty    
         </Text>
         <Text
           dimColor={true}
@@ -2806,7 +3096,15 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
         flexDirection="row"
       >
         <Text>
-            Behind   
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ↓ 
+        </Text>
+        <Text>
+          Behind   
         </Text>
         <Text
           dimColor={true}
@@ -2818,7 +3116,15 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
         flexDirection="row"
       >
         <Text>
-            PRs      
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ⊙ 
+        </Text>
+        <Text>
+          PRs      
         </Text>
         <Text
           dimColor={true}
@@ -2938,6 +3244,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
           <Text
             bold={true}
             color="cyan"
+            inverse={true}
           >
             › 
           </Text>
@@ -2948,7 +3255,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
         >
           <Text
             bold={true}
-            dimColor={false}
+            inverse={true}
           >
             coco
           </Text>
@@ -2958,7 +3265,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
           width={29}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             main
           </Text>
@@ -2968,8 +3275,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
           width={17}
         >
           <Text
-            color="yellow"
-            dimColor={false}
+            inverse={true}
           >
             ●2 ↑1
           </Text>
@@ -2979,8 +3285,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
           width={11}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
             2026-05-01
           </Text>
@@ -2990,7 +3295,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
           width={51}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             feat: thing
           </Text>
@@ -3000,8 +3305,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
           width={25}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
             /tmp/coco
           </Text>
@@ -3016,6 +3320,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
@@ -3027,6 +3332,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             docs
           </Text>
@@ -3038,6 +3344,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             feature/landing
           </Text>
@@ -3050,6 +3357,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
             bold={false}
             color="yellow"
             dimColor={false}
+            inverse={false}
           >
             ↓3
           </Text>
@@ -3062,6 +3370,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             2026-04-15
           </Text>
@@ -3073,6 +3382,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             wip
           </Text>
@@ -3085,6 +3395,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             /tmp/docs
           </Text>
@@ -3099,6 +3410,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
@@ -3110,6 +3422,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             lib
           </Text>
@@ -3121,6 +3434,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             main
           </Text>
@@ -3133,6 +3447,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             ·
           </Text>
@@ -3145,6 +3460,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             —
           </Text>
@@ -3157,6 +3473,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             —
           </Text>
@@ -3169,6 +3486,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             /tmp/lib
           </Text>
@@ -3299,7 +3617,18 @@ exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading fals
         <Text
           bold={true}
         >
-          › All      
+          › 
+        </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+          ◯ 
+        </Text>
+        <Text
+          bold={true}
+        >
+          All      
         </Text>
         <Text
           color="cyan"
@@ -3312,7 +3641,15 @@ exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading fals
         flexDirection="row"
       >
         <Text>
-            Dirty    
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ● 
+        </Text>
+        <Text>
+          Dirty    
         </Text>
         <Text
           dimColor={true}
@@ -3324,7 +3661,15 @@ exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading fals
         flexDirection="row"
       >
         <Text>
-            Behind   
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ↓ 
+        </Text>
+        <Text>
+          Behind   
         </Text>
         <Text
           dimColor={true}
@@ -3336,7 +3681,15 @@ exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading fals
         flexDirection="row"
       >
         <Text>
-            PRs      
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ⊙ 
+        </Text>
+        <Text>
+          PRs      
         </Text>
         <Text
           dimColor={true}
@@ -3446,11 +3799,24 @@ exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading fals
       >
          
       </Text>
-      <Text
-        dimColor={true}
+      <Box
+        alignItems="center"
+        flexDirection="column"
+        marginTop={2}
+        width={92}
       >
-        No repositories discovered. Configure workspace.roots and try again.
-      </Text>
+        <Text
+          bold={true}
+          color="gray"
+        >
+          ∅  No repositories discovered
+        </Text>
+        <Text
+          dimColor={true}
+        >
+          Press \`a\` to add a repo by path, or configure \`workspace.roots\`.
+        </Text>
+      </Box>
       <Text
         dimColor={true}
       >
@@ -3576,7 +3942,18 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
         <Text
           bold={true}
         >
-          › All      
+          › 
+        </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+          ◯ 
+        </Text>
+        <Text
+          bold={true}
+        >
+          All      
         </Text>
         <Text
           color="cyan"
@@ -3589,7 +3966,15 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
         flexDirection="row"
       >
         <Text>
-            Dirty    
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ● 
+        </Text>
+        <Text>
+          Dirty    
         </Text>
         <Text
           dimColor={true}
@@ -3601,7 +3986,15 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
         flexDirection="row"
       >
         <Text>
-            Behind   
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ↓ 
+        </Text>
+        <Text>
+          Behind   
         </Text>
         <Text
           dimColor={true}
@@ -3613,7 +4006,15 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
         flexDirection="row"
       >
         <Text>
-            PRs      
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ⊙ 
+        </Text>
+        <Text>
+          PRs      
         </Text>
         <Text
           dimColor={true}
@@ -3733,6 +4134,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
           <Text
             bold={true}
             color="cyan"
+            inverse={true}
           >
             › 
           </Text>
@@ -3743,7 +4145,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
         >
           <Text
             bold={true}
-            dimColor={false}
+            inverse={true}
           >
             coco
           </Text>
@@ -3753,7 +4155,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
           width={13}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             main
           </Text>
@@ -3763,8 +4165,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
           width={9}
         >
           <Text
-            color="yellow"
-            dimColor={false}
+            inverse={true}
           >
             ●2 ↑1
           </Text>
@@ -3774,10 +4175,9 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
           width={11}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
-            2026-05-01
+            3w
           </Text>
         </Box>
         <Box
@@ -3785,7 +4185,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
           width={20}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             feat: thing
           </Text>
@@ -3795,8 +4195,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
           width={18}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
             /tmp/coco
           </Text>
@@ -3811,6 +4210,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
@@ -3822,6 +4222,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             docs
           </Text>
@@ -3833,6 +4234,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             feature/l...
           </Text>
@@ -3845,6 +4247,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
             bold={false}
             color="yellow"
             dimColor={false}
+            inverse={false}
           >
             ↓3
           </Text>
@@ -3857,8 +4260,9 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
-            2026-04-15
+            6w
           </Text>
         </Box>
         <Box
@@ -3868,6 +4272,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             wip
           </Text>
@@ -3880,6 +4285,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             /tmp/docs
           </Text>
@@ -3894,6 +4300,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
@@ -3905,6 +4312,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             lib
           </Text>
@@ -3916,6 +4324,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             main
           </Text>
@@ -3928,6 +4337,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             ·
           </Text>
@@ -3940,6 +4350,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             —
           </Text>
@@ -3952,6 +4363,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             —
           </Text>
@@ -3964,6 +4376,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             /tmp/lib
           </Text>
@@ -4094,7 +4507,18 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
         <Text
           bold={true}
         >
-          › All      
+          › 
+        </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+          ◯ 
+        </Text>
+        <Text
+          bold={true}
+        >
+          All      
         </Text>
         <Text
           color="cyan"
@@ -4107,7 +4531,15 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
         flexDirection="row"
       >
         <Text>
-            Dirty    
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ● 
+        </Text>
+        <Text>
+          Dirty    
         </Text>
         <Text
           dimColor={true}
@@ -4119,7 +4551,15 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
         flexDirection="row"
       >
         <Text>
-            Behind   
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ↓ 
+        </Text>
+        <Text>
+          Behind   
         </Text>
         <Text
           dimColor={true}
@@ -4131,7 +4571,15 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
         flexDirection="row"
       >
         <Text>
-            PRs      
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ⊙ 
+        </Text>
+        <Text>
+          PRs      
         </Text>
         <Text
           dimColor={true}
@@ -4251,6 +4699,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
           <Text
             bold={true}
             color="cyan"
+            inverse={true}
           >
             › 
           </Text>
@@ -4261,7 +4710,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
         >
           <Text
             bold={true}
-            dimColor={false}
+            inverse={true}
           >
             coco
           </Text>
@@ -4271,7 +4720,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
           width={13}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             main
           </Text>
@@ -4281,8 +4730,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
           width={9}
         >
           <Text
-            color="yellow"
-            dimColor={false}
+            inverse={true}
           >
             ●2 ↑1
           </Text>
@@ -4292,10 +4740,9 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
           width={11}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
-            2026-05-01
+            3w
           </Text>
         </Box>
         <Box
@@ -4303,7 +4750,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
           width={20}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             feat: thing
           </Text>
@@ -4313,8 +4760,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
           width={18}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
             /tmp/coco
           </Text>
@@ -4329,6 +4775,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
@@ -4340,6 +4787,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             docs
           </Text>
@@ -4351,6 +4799,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             feature/l...
           </Text>
@@ -4363,6 +4812,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
             bold={false}
             color="yellow"
             dimColor={false}
+            inverse={false}
           >
             ↓3
           </Text>
@@ -4375,8 +4825,9 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
-            2026-04-15
+            6w
           </Text>
         </Box>
         <Box
@@ -4386,6 +4837,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             wip
           </Text>
@@ -4398,6 +4850,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             /tmp/docs
           </Text>
@@ -4412,6 +4865,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
@@ -4423,6 +4877,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             lib
           </Text>
@@ -4434,6 +4889,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             main
           </Text>
@@ -4446,6 +4902,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             ·
           </Text>
@@ -4458,6 +4915,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             —
           </Text>
@@ -4470,6 +4928,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             —
           </Text>
@@ -4482,6 +4941,7 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             /tmp/lib
           </Text>
@@ -4632,7 +5092,15 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
         flexDirection="row"
       >
         <Text>
-            All      
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ◯ 
+        </Text>
+        <Text>
+          All      
         </Text>
         <Text
           dimColor={true}
@@ -4644,7 +5112,15 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
         flexDirection="row"
       >
         <Text>
-            Dirty    
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ● 
+        </Text>
+        <Text>
+          Dirty    
         </Text>
         <Text
           dimColor={true}
@@ -4658,7 +5134,18 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
         <Text
           bold={true}
         >
-          › Behind   
+          › 
+        </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+          ↓ 
+        </Text>
+        <Text
+          bold={true}
+        >
+          Behind   
         </Text>
         <Text
           color="cyan"
@@ -4671,7 +5158,15 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
         flexDirection="row"
       >
         <Text>
-            PRs      
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ⊙ 
+        </Text>
+        <Text>
+          PRs      
         </Text>
         <Text
           dimColor={true}
@@ -4791,6 +5286,7 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
           <Text
             bold={true}
             color="cyan"
+            inverse={true}
           >
             › 
           </Text>
@@ -4801,7 +5297,7 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
         >
           <Text
             bold={true}
-            dimColor={false}
+            inverse={true}
           >
             docs
           </Text>
@@ -4811,7 +5307,7 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
           width={13}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             feature/l...
           </Text>
@@ -4821,8 +5317,7 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
           width={9}
         >
           <Text
-            color="yellow"
-            dimColor={false}
+            inverse={true}
           >
             ↓3
           </Text>
@@ -4832,10 +5327,9 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
           width={11}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
-            2026-04-15
+            6w
           </Text>
         </Box>
         <Box
@@ -4843,7 +5337,7 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
           width={20}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             wip
           </Text>
@@ -4853,8 +5347,7 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
           width={18}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
             /tmp/docs
           </Text>
@@ -4985,7 +5478,18 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
         <Text
           bold={true}
         >
-          › All      
+          › 
+        </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+          ◯ 
+        </Text>
+        <Text
+          bold={true}
+        >
+          All      
         </Text>
         <Text
           color="cyan"
@@ -4998,7 +5502,15 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
         flexDirection="row"
       >
         <Text>
-            Dirty    
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ● 
+        </Text>
+        <Text>
+          Dirty    
         </Text>
         <Text
           dimColor={true}
@@ -5010,7 +5522,15 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
         flexDirection="row"
       >
         <Text>
-            Behind   
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ↓ 
+        </Text>
+        <Text>
+          Behind   
         </Text>
         <Text
           dimColor={true}
@@ -5022,7 +5542,15 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
         flexDirection="row"
       >
         <Text>
-            PRs      
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ⊙ 
+        </Text>
+        <Text>
+          PRs      
         </Text>
         <Text
           dimColor={true}
@@ -5142,6 +5670,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
           <Text
             bold={true}
             color="cyan"
+            inverse={true}
           >
             › 
           </Text>
@@ -5152,7 +5681,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
         >
           <Text
             bold={true}
-            dimColor={false}
+            inverse={true}
           >
             coco
           </Text>
@@ -5162,7 +5691,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
           width={13}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             main
           </Text>
@@ -5172,8 +5701,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
           width={9}
         >
           <Text
-            color="yellow"
-            dimColor={false}
+            inverse={true}
           >
             ●2 ↑1
           </Text>
@@ -5183,10 +5711,9 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
           width={11}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
-            2026-05-01
+            3w
           </Text>
         </Box>
         <Box
@@ -5194,7 +5721,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
           width={20}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             feat: thing
           </Text>
@@ -5204,8 +5731,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
           width={18}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
             /tmp/coco
           </Text>
@@ -5220,6 +5746,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
@@ -5231,6 +5758,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             docs
           </Text>
@@ -5242,6 +5770,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             feature/l...
           </Text>
@@ -5254,6 +5783,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
             bold={false}
             color="yellow"
             dimColor={false}
+            inverse={false}
           >
             ↓3
           </Text>
@@ -5266,8 +5796,9 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
-            2026-04-15
+            6w
           </Text>
         </Box>
         <Box
@@ -5277,6 +5808,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             wip
           </Text>
@@ -5289,6 +5821,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             /tmp/docs
           </Text>
@@ -5303,6 +5836,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
@@ -5314,6 +5848,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             lib
           </Text>
@@ -5325,6 +5860,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             main
           </Text>
@@ -5337,6 +5873,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             ·
           </Text>
@@ -5349,6 +5886,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             —
           </Text>
@@ -5361,6 +5899,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             —
           </Text>
@@ -5373,6 +5912,7 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             /tmp/lib
           </Text>
@@ -5523,7 +6063,15 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
         flexDirection="row"
       >
         <Text>
-            All      
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ◯ 
+        </Text>
+        <Text>
+          All      
         </Text>
         <Text
           dimColor={true}
@@ -5537,7 +6085,18 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
         <Text
           bold={true}
         >
-          › Dirty    
+          › 
+        </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+          ● 
+        </Text>
+        <Text
+          bold={true}
+        >
+          Dirty    
         </Text>
         <Text
           color="cyan"
@@ -5550,7 +6109,15 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
         flexDirection="row"
       >
         <Text>
-            Behind   
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ↓ 
+        </Text>
+        <Text>
+          Behind   
         </Text>
         <Text
           dimColor={true}
@@ -5562,7 +6129,15 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
         flexDirection="row"
       >
         <Text>
-            PRs      
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ⊙ 
+        </Text>
+        <Text>
+          PRs      
         </Text>
         <Text
           dimColor={true}
@@ -5682,6 +6257,7 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
           <Text
             bold={true}
             color="cyan"
+            inverse={true}
           >
             › 
           </Text>
@@ -5692,7 +6268,7 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
         >
           <Text
             bold={true}
-            dimColor={false}
+            inverse={true}
           >
             coco
           </Text>
@@ -5702,7 +6278,7 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
           width={13}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             main
           </Text>
@@ -5712,8 +6288,7 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
           width={9}
         >
           <Text
-            color="yellow"
-            dimColor={false}
+            inverse={true}
           >
             ●2 ↑1
           </Text>
@@ -5723,10 +6298,9 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
           width={11}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
-            2026-05-01
+            3w
           </Text>
         </Box>
         <Box
@@ -5734,7 +6308,7 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
           width={20}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             feat: thing
           </Text>
@@ -5744,8 +6318,7 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
           width={18}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
             /tmp/coco
           </Text>
@@ -5876,7 +6449,18 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
         <Text
           bold={true}
         >
-          › All      
+          › 
+        </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+          ◯ 
+        </Text>
+        <Text
+          bold={true}
+        >
+          All      
         </Text>
         <Text
           color="cyan"
@@ -5889,7 +6473,15 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
         flexDirection="row"
       >
         <Text>
-            Dirty    
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ● 
+        </Text>
+        <Text>
+          Dirty    
         </Text>
         <Text
           dimColor={true}
@@ -5901,7 +6493,15 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
         flexDirection="row"
       >
         <Text>
-            Behind   
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ↓ 
+        </Text>
+        <Text>
+          Behind   
         </Text>
         <Text
           dimColor={true}
@@ -5913,7 +6513,15 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
         flexDirection="row"
       >
         <Text>
-            PRs      
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ⊙ 
+        </Text>
+        <Text>
+          PRs      
         </Text>
         <Text
           dimColor={true}
@@ -6033,6 +6641,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
           <Text
             bold={true}
             color="cyan"
+            inverse={true}
           >
             › 
           </Text>
@@ -6043,7 +6652,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
         >
           <Text
             bold={true}
-            dimColor={false}
+            inverse={true}
           >
             coco
           </Text>
@@ -6053,7 +6662,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
           width={13}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             main
           </Text>
@@ -6063,8 +6672,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
           width={9}
         >
           <Text
-            color="yellow"
-            dimColor={false}
+            inverse={true}
           >
             ●2 ↑1
           </Text>
@@ -6074,10 +6682,9 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
           width={11}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
-            2026-05-01
+            3w
           </Text>
         </Box>
         <Box
@@ -6085,7 +6692,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
           width={20}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             feat: thing
           </Text>
@@ -6095,8 +6702,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
           width={18}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
             /tmp/coco
           </Text>
@@ -6111,6 +6717,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
@@ -6122,6 +6729,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             docs
           </Text>
@@ -6133,6 +6741,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             feature/l...
           </Text>
@@ -6145,6 +6754,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
             bold={false}
             color="yellow"
             dimColor={false}
+            inverse={false}
           >
             ↓3
           </Text>
@@ -6157,8 +6767,9 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
-            2026-04-15
+            6w
           </Text>
         </Box>
         <Box
@@ -6168,6 +6779,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             wip
           </Text>
@@ -6180,6 +6792,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             /tmp/docs
           </Text>
@@ -6194,6 +6807,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
@@ -6205,6 +6819,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             lib
           </Text>
@@ -6216,6 +6831,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             main
           </Text>
@@ -6228,6 +6844,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             ·
           </Text>
@@ -6240,6 +6857,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             —
           </Text>
@@ -6252,6 +6870,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             —
           </Text>
@@ -6264,6 +6883,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             /tmp/lib
           </Text>
@@ -6716,7 +7336,18 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
         <Text
           bold={true}
         >
-          › All      
+          › 
+        </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+          ◯ 
+        </Text>
+        <Text
+          bold={true}
+        >
+          All      
         </Text>
         <Text
           color="cyan"
@@ -6729,7 +7360,15 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
         flexDirection="row"
       >
         <Text>
-            Dirty    
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ● 
+        </Text>
+        <Text>
+          Dirty    
         </Text>
         <Text
           dimColor={true}
@@ -6741,7 +7380,15 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
         flexDirection="row"
       >
         <Text>
-            Behind   
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ↓ 
+        </Text>
+        <Text>
+          Behind   
         </Text>
         <Text
           dimColor={true}
@@ -6753,7 +7400,15 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
         flexDirection="row"
       >
         <Text>
-            PRs      
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ⊙ 
+        </Text>
+        <Text>
+          PRs      
         </Text>
         <Text
           dimColor={true}
@@ -6781,7 +7436,7 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
         <Text
           dimColor={true}
         >
-          loading repos…
+          ◐ loading repos…
         </Text>
       </Box>
       <Box
@@ -6863,11 +7518,18 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
       >
          
       </Text>
-      <Text
-        dimColor={true}
+      <Box
+        alignItems="center"
+        flexDirection="column"
+        marginTop={2}
+        width={92}
       >
-        Scanning configured roots…
-      </Text>
+        <Text
+          bold={true}
+        >
+          ◐  Scanning configured roots…
+        </Text>
+      </Box>
       <Text
         dimColor={true}
       >
@@ -6993,7 +7655,18 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
         <Text
           bold={true}
         >
-          › All      
+          › 
+        </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+          ◯ 
+        </Text>
+        <Text
+          bold={true}
+        >
+          All      
         </Text>
         <Text
           color="cyan"
@@ -7006,7 +7679,15 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
         flexDirection="row"
       >
         <Text>
-            Dirty    
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ● 
+        </Text>
+        <Text>
+          Dirty    
         </Text>
         <Text
           dimColor={true}
@@ -7018,7 +7699,15 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
         flexDirection="row"
       >
         <Text>
-            Behind   
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ↓ 
+        </Text>
+        <Text>
+          Behind   
         </Text>
         <Text
           dimColor={true}
@@ -7030,7 +7719,15 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
         flexDirection="row"
       >
         <Text>
-            PRs      
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ⊙ 
+        </Text>
+        <Text>
+          PRs      
         </Text>
         <Text
           dimColor={true}
@@ -7150,6 +7847,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
           <Text
             bold={true}
             color="cyan"
+            inverse={true}
           >
             › 
           </Text>
@@ -7160,7 +7858,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
         >
           <Text
             bold={true}
-            dimColor={false}
+            inverse={true}
           >
             coco
           </Text>
@@ -7170,7 +7868,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
           width={13}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             main
           </Text>
@@ -7180,8 +7878,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
           width={9}
         >
           <Text
-            color="yellow"
-            dimColor={false}
+            inverse={true}
           >
             ●2 ↑1
           </Text>
@@ -7191,10 +7888,9 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
           width={11}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
-            2026-05-01
+            3w
           </Text>
         </Box>
         <Box
@@ -7202,7 +7898,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
           width={20}
         >
           <Text
-            dimColor={false}
+            inverse={true}
           >
             feat: thing
           </Text>
@@ -7212,8 +7908,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
           width={18}
         >
           <Text
-            color="gray"
-            dimColor={false}
+            inverse={true}
           >
             /tmp/coco
           </Text>
@@ -7228,6 +7923,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
@@ -7239,6 +7935,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             docs
           </Text>
@@ -7250,6 +7947,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             feature/l...
           </Text>
@@ -7262,6 +7960,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
             bold={false}
             color="yellow"
             dimColor={false}
+            inverse={false}
           >
             ↓3
           </Text>
@@ -7274,8 +7973,9 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
-            2026-04-15
+            6w
           </Text>
         </Box>
         <Box
@@ -7285,6 +7985,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             wip
           </Text>
@@ -7297,6 +7998,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             /tmp/docs
           </Text>
@@ -7311,6 +8013,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
         >
           <Text
             bold={false}
+            inverse={false}
           >
               
           </Text>
@@ -7322,6 +8025,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             lib
           </Text>
@@ -7333,6 +8037,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
           <Text
             bold={false}
             dimColor={false}
+            inverse={false}
           >
             main
           </Text>
@@ -7345,6 +8050,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             ·
           </Text>
@@ -7357,6 +8063,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             —
           </Text>
@@ -7369,6 +8076,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             —
           </Text>
@@ -7381,6 +8089,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
             bold={false}
             color="gray"
             dimColor={true}
+            inverse={false}
           >
             /tmp/lib
           </Text>

--- a/src/workstation/surfaces/workspace/filter.ts
+++ b/src/workstation/surfaces/workspace/filter.ts
@@ -17,8 +17,37 @@ const TAB_LABELS: Record<WorkspaceTab, string> = {
   'pull-requests': 'PRs',
 }
 
+/**
+ * Tab glyphs — semantic, color-paired in the renderer:
+ *   ◯ All     (neutral / circle)
+ *   ● Dirty   (warn / filled)
+ *   ↓ Behind  (warn / down)
+ *   ⊙ PRs     (accent / target)
+ *
+ * Used in two places: as a label prefix in the expanded sidebar,
+ * and as the standalone icon when the sidebar is rail-collapsed at
+ * narrow terminal widths.
+ */
+const TAB_GLYPHS: Record<WorkspaceTab, string> = {
+  all: '◯',
+  dirty: '●',
+  behind: '↓',
+  'pull-requests': '⊙',
+}
+
+const TAB_GLYPHS_ASCII: Record<WorkspaceTab, string> = {
+  all: 'o',
+  dirty: '*',
+  behind: 'v',
+  'pull-requests': '@',
+}
+
 export function workspaceTabLabel(tab: WorkspaceTab): string {
   return TAB_LABELS[tab]
+}
+
+export function workspaceTabGlyph(tab: WorkspaceTab, ascii = false): string {
+  return ascii ? TAB_GLYPHS_ASCII[tab] : TAB_GLYPHS[tab]
 }
 
 export function nextWorkspaceTab(current: WorkspaceTab): WorkspaceTab {

--- a/src/workstation/surfaces/workspace/render.test.ts
+++ b/src/workstation/surfaces/workspace/render.test.ts
@@ -48,8 +48,8 @@ describe('workspace render builders', () => {
     roots: ['~/code'],
   })
 
-  it('builds a list row per visible repo with the expected columns', () => {
-    const rows = buildWorkspaceListRows(state)
+  it('builds a list row per visible repo with the expected columns (absolute dates)', () => {
+    const rows = buildWorkspaceListRows(state, { width: 160, dateMode: 'absolute' })
     expect(rows.map((row) => row.repo.name)).toEqual(['coco', 'docs'])
     expect(rows[0].cursor).toBe(true)
     expect(rows[1].cursor).toBe(false)
@@ -62,6 +62,16 @@ describe('workspace render builders', () => {
     expect(date.text.startsWith('2026-05-01')).toBe(true)
     expect(subject.text).toContain('feat: thing')
     expect(path.text).toContain('/tmp/coco')
+  })
+
+  it('relative date mode formats the date column compactly', () => {
+    const rows = buildWorkspaceListRows(state, {
+      width: 120,
+      dateMode: 'relative',
+      now: new Date('2026-05-30T00:00:00Z'),
+    })
+    // coco's lastCommit is 2026-05-01 → 29 days → 4w
+    expect(rows[0].columns[3].text.trim()).toMatch(/^(\d+(d|w|mo|y)|now|\dh|\d+m)$/)
   })
 
   it('renders the placeholder · for a clean repo and dims the status cell', () => {
@@ -78,7 +88,8 @@ describe('workspace render builders', () => {
       authenticated: true,
     })
     const rows = buildWorkspaceListRows(next)
-    expect(rows[1].columns[2].text).toContain('pr4')
+    // PR token uses the ⊙ glyph matching the PRs tab.
+    expect(rows[1].columns[2].text).toContain('⊙4')
   })
 
   it('omits pr tokens when gh is unauthenticated', () => {
@@ -88,7 +99,7 @@ describe('workspace render builders', () => {
       authenticated: false,
     })
     const rows = buildWorkspaceListRows(next)
-    expect(rows[1].columns[2].text).not.toContain('pr4')
+    expect(rows[1].columns[2].text).not.toContain('⊙4')
   })
 
   it('dims the PRs sidebar tab when gh is unauthenticated', () => {
@@ -147,9 +158,7 @@ describe('workspace render builders', () => {
 
   describe('assignWorkspaceColumnWidths', () => {
     it('drops the path column first on narrow terminals', () => {
-      // All six minimums total ~87 cells once gaps + cursor are
-      // included; budgets in [68, 86) keep subject but drop path.
-      const widths = assignWorkspaceColumnWidths(72)
+      const widths = assignWorkspaceColumnWidths(70)
       expect(widths.name).toBeDefined()
       expect(widths.branch).toBeDefined()
       expect(widths.status).toBeDefined()
@@ -158,8 +167,8 @@ describe('workspace render builders', () => {
       expect(widths.path).toBeUndefined()
     })
 
-    it('drops the subject column next when even path-less is too wide', () => {
-      const widths = assignWorkspaceColumnWidths(56)
+    it('drops the subject column next', () => {
+      const widths = assignWorkspaceColumnWidths(50)
       expect(widths.name).toBeDefined()
       expect(widths.branch).toBeDefined()
       expect(widths.status).toBeDefined()
@@ -168,14 +177,24 @@ describe('workspace render builders', () => {
       expect(widths.path).toBeUndefined()
     })
 
-    it('drops date when very narrow', () => {
-      const widths = assignWorkspaceColumnWidths(42)
+    it('drops date next when very narrow', () => {
+      const widths = assignWorkspaceColumnWidths(40)
       expect(widths.name).toBeDefined()
       expect(widths.branch).toBeDefined()
       expect(widths.status).toBeDefined()
       expect(widths.date).toBeUndefined()
       expect(widths.subject).toBeUndefined()
       expect(widths.path).toBeUndefined()
+    })
+
+    it('keeps status longer than branch — status drops only after branch', () => {
+      // Branch min 12 + cursor 2 + status 8 + gap 1 = 23 → budget 25 fits
+      // name+status. Below that we drop status too.
+      const widths = assignWorkspaceColumnWidths(28)
+      expect(widths.name).toBeDefined()
+      expect(widths.status).toBeDefined()
+      expect(widths.branch).toBeUndefined()
+      expect(widths.date).toBeUndefined()
     })
 
     it('keeps every column at standard width', () => {
@@ -197,8 +216,11 @@ describe('workspace render builders', () => {
       expect(widths.subject).toBeLessThanOrEqual(60)
     })
 
-    it('returns the empty map when no column can fit', () => {
-      expect(assignWorkspaceColumnWidths(0)).toEqual({})
+    it('keeps name as the irreducible minimum even at zero budget', () => {
+      const widths = assignWorkspaceColumnWidths(0)
+      expect(widths.name).toBeDefined()
+      expect(widths.branch).toBeUndefined()
+      expect(widths.status).toBeUndefined()
     })
 
     it('builds list rows with only the surviving columns at narrow widths', () => {

--- a/src/workstation/surfaces/workspace/render.ts
+++ b/src/workstation/surfaces/workspace/render.ts
@@ -1,6 +1,7 @@
 import type { WorkspaceRepoSummary } from '../../../git/workspaceData'
 import { truncateCells, truncatePathCells } from '../../chrome/text'
 import {
+  workspaceTabGlyph,
   workspaceTabLabel,
   WORKSPACE_TABS,
   type WorkspaceTab,
@@ -40,6 +41,8 @@ export type WorkspaceListRow = {
 export type WorkspaceSidebarTabRow = {
   tab: WorkspaceTab
   label: string
+  /** Single-cell glyph for the tab (used in rail mode + as a label prefix). */
+  glyph: string
   /** Number of repos in the overview that match this tab's predicate. */
   count: number
   active: boolean
@@ -55,8 +58,12 @@ export type WorkspaceSidebarTabRow = {
  * by the layout helper, so the budget passed in here is purely the
  * cell-content width.
  *
- * Drop priority on a narrow terminal: path → date → status → branch.
- * Name always stays.
+ * Display order (left → right): name · branch · status · date · subject · path.
+ * Drop order (first dropped → last kept): path · subject · date · branch · status · name.
+ *
+ * Status is kept longer than branch because it's the most actionable
+ * signal — "what needs my attention" reads cleaner from
+ * `coco ●2 ↓3` than from `coco main`. Name is always kept.
  */
 export type WorkspaceColumnKey = 'name' | 'branch' | 'status' | 'date' | 'subject' | 'path'
 
@@ -67,6 +74,7 @@ type ColumnSpec = {
   max?: number
 }
 
+// Display order is fixed — this is the left-to-right layout in the row.
 const COLUMN_SPECS: ColumnSpec[] = [
   { key: 'name', min: 14, weight: 3, max: 36 },
   { key: 'branch', min: 12, weight: 2, max: 28 },
@@ -76,6 +84,17 @@ const COLUMN_SPECS: ColumnSpec[] = [
   // terminals get a meaningful "what changed" line per row.
   { key: 'subject', min: 18, weight: 4, max: 60 },
   { key: 'path', min: 18, weight: 1 },
+]
+
+// Drop order — when the row can't fit, these get removed first.
+// First entry drops first; last entry survives longest. Name is
+// not in this list because it never drops.
+const COLUMN_DROP_ORDER: WorkspaceColumnKey[] = [
+  'path',
+  'subject',
+  'date',
+  'branch',
+  'status',
 ]
 
 /** Inter-cell gap reserved by the layout helper. */
@@ -93,14 +112,17 @@ export type WorkspaceColumnWidths = Partial<Record<WorkspaceColumnKey, number>>
  */
 export function assignWorkspaceColumnWidths(budget: number): WorkspaceColumnWidths {
   const usable = Math.max(0, budget - CURSOR_WIDTH)
-  const kept: ColumnSpec[] = [...COLUMN_SPECS]
-  while (kept.length > 0) {
+  // Keep all columns in display order. Drop by walking the
+  // COLUMN_DROP_ORDER list — earlier entries drop first.
+  const droppedKeys = new Set<WorkspaceColumnKey>()
+  let kept: ColumnSpec[] = COLUMN_SPECS.filter((spec) => !droppedKeys.has(spec.key))
+  for (const dropKey of COLUMN_DROP_ORDER) {
     const minTotal = kept.reduce((acc, spec) => acc + spec.min, 0)
     const gapTotal = Math.max(0, kept.length - 1) * COLUMN_GAP
-    if (minTotal + gapTotal <= usable) {
-      break
-    }
-    kept.pop()
+    if (minTotal + gapTotal <= usable) break
+    droppedKeys.add(dropKey)
+    kept = COLUMN_SPECS.filter((spec) => !droppedKeys.has(spec.key))
+    if (kept.length === 0) break
   }
   if (kept.length === 0) {
     return {}
@@ -156,35 +178,93 @@ function formatStatusCell(
     tokens.push(`↓${repo.behind}`)
   }
   if (ghAuthenticated && typeof prCount === 'number' && prCount > 0) {
-    tokens.push(`pr${prCount}`)
+    // `⊙ N` matches the PRs tab glyph so the status column reads as a
+    // glance-grokable summary of the same data the tabs filter on.
+    tokens.push(`⊙${prCount}`)
   }
   const text = tokens.length === 0 ? '·' : tokens.join(' ')
   const tone: WorkspaceListColumn['tone'] = repo.behind > 0 || repo.dirty > 0 ? 'warn' : 'dim'
   return { text: truncateCells(text, width), width, key: 'status', tone }
 }
 
-function formatDateCell(repo: WorkspaceRepoSummary, width: number): WorkspaceListColumn {
+/**
+ * Relative-date formatter for narrow terminals. Returns ≤4 chars when
+ * possible (`2d`, `3w`, `5mo`, `1y`) so the date column compresses
+ * naturally. Wide terminals get the full ISO date through
+ * formatDateCell's wide path.
+ */
+function formatRelativeDate(iso: string, now: Date): string {
+  const past = new Date(iso).getTime()
+  if (!Number.isFinite(past)) return '—'
+  const seconds = Math.max(0, Math.floor((now.getTime() - past) / 1000))
+  if (seconds < 60) return 'now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h`
+  const days = Math.floor(hours / 24)
+  if (days < 14) return `${days}d`
+  const weeks = Math.floor(days / 7)
+  if (weeks < 8) return `${weeks}w`
+  const months = Math.floor(days / 30)
+  if (months < 24) return `${months}mo`
+  const years = Math.floor(days / 365)
+  return `${years}y`
+}
+
+export type WorkspaceDateMode = 'absolute' | 'relative'
+
+function formatDateCell(
+  repo: WorkspaceRepoSummary,
+  width: number,
+  mode: WorkspaceDateMode,
+  now: Date
+): WorkspaceListColumn {
   const date = repo.lastCommit?.date
   if (!date) {
     return { text: truncateCells('—', width), width, key: 'date', tone: 'dim' }
   }
-  // Trim ISO date to YYYY-MM-DD — full precision is noise in the row.
-  return { text: truncateCells(date.slice(0, 10), width), width, key: 'date', tone: 'dim' }
+  const text = mode === 'relative'
+    ? formatRelativeDate(date, now)
+    : date.slice(0, 10) // YYYY-MM-DD — full precision is noise in the row otherwise.
+  return { text: truncateCells(text, width), width, key: 'date', tone: 'dim' }
 }
 
 export type BuildWorkspaceListRowsOptions = {
   /** Available row width (before cursor + separators). Default 120. */
   width?: number
+  /** Date format mode. Default `absolute` (use `relative` on narrow widths). */
+  dateMode?: WorkspaceDateMode
+  /**
+   * Reference timestamp for relative-date math. Tests pin this for
+   * determinism; the view layer passes `new Date()`.
+   */
+  now?: Date
 }
 
 const DEFAULT_ROW_WIDTH = 120
+
+/**
+ * Density tier breakpoint — at this width and above we keep absolute
+ * dates; below we switch to relative. Picked to match the breakpoint
+ * where the date column is one of the last to drop, so the relative
+ * format buys real screen real estate.
+ */
+export const WORKSPACE_RELATIVE_DATE_BELOW = 140
+
+export function pickWorkspaceDateMode(width: number): WorkspaceDateMode {
+  return width < WORKSPACE_RELATIVE_DATE_BELOW ? 'relative' : 'absolute'
+}
 
 export function buildWorkspaceListRows(
   state: WorkspaceState,
   options: BuildWorkspaceListRowsOptions = {}
 ): WorkspaceListRow[] {
   const visible = selectVisibleRepos(state)
-  const widths = assignWorkspaceColumnWidths(options.width ?? DEFAULT_ROW_WIDTH)
+  const rowWidth = options.width ?? DEFAULT_ROW_WIDTH
+  const widths = assignWorkspaceColumnWidths(rowWidth)
+  const dateMode = options.dateMode ?? pickWorkspaceDateMode(rowWidth)
+  const now = options.now ?? new Date()
   return visible.map((repo, index) => {
     const cursor = index === state.selectedIndex
     const nameTone: WorkspaceListColumn['tone'] = repo.error ? 'warn' : 'default'
@@ -212,7 +292,7 @@ export function buildWorkspaceListRows(
       )
     }
     if (widths.date !== undefined) {
-      columns.push(formatDateCell(repo, widths.date))
+      columns.push(formatDateCell(repo, widths.date, dateMode, now))
     }
     if (widths.subject !== undefined) {
       const subject = repo.lastCommit?.subject ?? '—'
@@ -317,6 +397,21 @@ export function buildWorkspaceListWindow(
   }
 }
 
+/**
+ * Width threshold for collapsing the sidebar to a rail. Below this
+ * width we render only tab glyphs; above we render the full
+ * label + count. When the sidebar has focus we always expand it
+ * regardless of width (focus-grow pattern).
+ */
+export const WORKSPACE_SIDEBAR_RAIL_BELOW = 100
+
+export function shouldRailWorkspaceSidebar(
+  columns: number,
+  sidebarFocused: boolean
+): boolean {
+  return columns < WORKSPACE_SIDEBAR_RAIL_BELOW && !sidebarFocused
+}
+
 export function buildWorkspaceSidebar(state: WorkspaceState): WorkspaceSidebarTabRow[] {
   const repos = state.overview.repos
   return WORKSPACE_TABS.map((tab) => {
@@ -341,6 +436,7 @@ export function buildWorkspaceSidebar(state: WorkspaceState): WorkspaceSidebarTa
     return {
       tab,
       label: workspaceTabLabel(tab),
+      glyph: workspaceTabGlyph(tab),
       count,
       active: state.tab === tab,
       disabled,

--- a/src/workstation/surfaces/workspace/view.ts
+++ b/src/workstation/surfaces/workspace/view.ts
@@ -22,6 +22,7 @@ import {
   buildWorkspaceListWindow,
   buildWorkspaceOnboarding,
   buildWorkspaceSidebar,
+  shouldRailWorkspaceSidebar,
   type WorkspaceHeaderChip,
   type WorkspaceListColumn,
   type WorkspaceListRow,
@@ -134,8 +135,55 @@ function renderHeader(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement {
   )
 }
 
-const SIDEBAR_WIDTH = 22
+const SIDEBAR_WIDTH_EXPANDED = 22
+const SIDEBAR_WIDTH_RAILED = 5
 const SIDEBAR_LABEL_WIDTH = 9 // " Dirty " etc. — enough for the longest tab label
+
+function sidebarWidthFor(deps: RenderWorkspaceAppDeps): number {
+  const focused = deps.state.focus === 'sidebar'
+  return shouldRailWorkspaceSidebar(deps.columns, focused)
+    ? SIDEBAR_WIDTH_RAILED
+    : SIDEBAR_WIDTH_EXPANDED
+}
+
+function renderSidebarRail(
+  deps: RenderWorkspaceAppDeps,
+  height: number
+): ReactTypes.ReactElement {
+  const { React, ink, state, theme } = deps
+  const { Box, Text } = ink
+  const focused = state.focus === 'sidebar' // never true while railed, but defensive
+  const tabs = buildWorkspaceSidebar(state)
+  const rows = tabs.map((row) => {
+    const tone = row.disabled
+      ? { dimColor: true }
+      : row.active
+        ? { bold: true, color: theme.noColor ? undefined : theme.colors.accent }
+        : { dimColor: true }
+    // Single-glyph rail row. The active tab's glyph keeps its accent
+    // even when the sidebar isn't focused so the user can still see
+    // "which filter is on" at a glance.
+    return React.createElement(
+      Text,
+      { key: row.tab, ...tone },
+      ` ${row.glyph}`
+    )
+  })
+  return React.createElement(
+    Box,
+    {
+      borderColor: focusBorderColor(theme, focused),
+      borderStyle: theme.borderStyle,
+      flexDirection: 'column',
+      flexShrink: 0,
+      height,
+      paddingX: 0,
+      width: SIDEBAR_WIDTH_RAILED,
+    },
+    React.createElement(Text, { dimColor: true }, ' »'),
+    ...rows
+  )
+}
 
 function renderSidebar(
   deps: RenderWorkspaceAppDeps,
@@ -143,30 +191,49 @@ function renderSidebar(
 ): ReactTypes.ReactElement {
   const { React, ink, state, theme } = deps
   const { Box, Text } = ink
-  // Sidebar owns the focus when the user is cycling tabs.
   const focused = state.focus === 'sidebar'
+
+  if (shouldRailWorkspaceSidebar(deps.columns, focused)) {
+    return renderSidebarRail(deps, height)
+  }
+
   const tabs = buildWorkspaceSidebar(state)
   const widest = tabs.reduce((acc, row) => Math.max(acc, row.label.length), SIDEBAR_LABEL_WIDTH)
   const rows = tabs.map((row) => {
-    const props: Record<string, unknown> = { key: row.tab }
+    const labelProps: Record<string, unknown> = { key: 'label' }
+    const glyphProps: Record<string, unknown> = { key: 'glyph' }
     if (row.active) {
-      props.bold = true
+      labelProps.bold = true
+      glyphProps.bold = true
       if (focused && !theme.noColor) {
-        props.color = theme.colors.accent
+        labelProps.color = theme.colors.accent
+        glyphProps.color = theme.colors.accent
+      } else if (!theme.noColor) {
+        // Tab glyph keeps a hint of color even while the sidebar
+        // isn't focused, so users see "which filter is on" without
+        // peering at the bold treatment.
+        glyphProps.color = theme.colors.accent
       }
-    } else if (row.disabled) {
-      props.dimColor = true
+    } else {
+      if (row.disabled) {
+        labelProps.dimColor = true
+        glyphProps.dimColor = true
+      } else if (!theme.noColor) {
+        // Inactive glyphs render in muted color so the column reads
+        // as a visual key — never relying on color alone since the
+        // glyph itself is the primary signal.
+        glyphProps.color = theme.colors.muted
+      }
     }
     const cursor = row.active ? '›' : ' '
     const paddedLabel = row.label.padEnd(widest)
     const countText = row.count > 0 ? String(row.count) : '·'
-    // Render label + count on the same line so the count is always
-    // right after the label and reads as part of the tab. Count is
-    // dim so the label keeps visual priority.
     return React.createElement(
       Box,
       { key: row.tab, flexDirection: 'row' },
-      React.createElement(Text, props, `${cursor} ${paddedLabel}`),
+      React.createElement(Text, labelProps, `${cursor} `),
+      React.createElement(Text, glyphProps, `${row.glyph} `),
+      React.createElement(Text, labelProps, paddedLabel),
       React.createElement(
         Text,
         { dimColor: !row.active, color: row.active && !theme.noColor ? theme.colors.accent : undefined },
@@ -183,7 +250,7 @@ function renderSidebar(
       flexShrink: 0,
       height,
       paddingX: 1,
-      width: SIDEBAR_WIDTH,
+      width: SIDEBAR_WIDTH_EXPANDED,
     },
     React.createElement(Text, { bold: true }, panelTitle('Tabs', focused)),
     ...rows
@@ -201,28 +268,33 @@ function renderListRow(
   const { React, ink, theme } = deps
   const { Box, Text } = ink
   const cursor = row.cursor ? '›' : ' '
-  const cells = row.columns.map((column, index) =>
-    // Fixed-width Box per column — this is what was missing before.
-    // Without it, cells with shorter content collapsed and the
-    // table rows wandered out of alignment across rows.
-    React.createElement(
+  // Cursored rows use reverse video for the strongest selection
+  // signal — the canonical TUI convention since VT100 and the same
+  // affordance coco ui uses for active commits. Reverse video skips
+  // applying per-cell tone colors because the inverted background
+  // makes faint tones unreadable.
+  const cursorReverse = row.cursor
+  const cells = row.columns.map((column, index) => {
+    const textProps: Record<string, unknown> = {
+      bold: row.cursor && column.primary,
+      inverse: cursorReverse,
+    }
+    if (!cursorReverse) {
+      textProps.dimColor = column.tone === 'dim'
+      const color = toneColor(column.tone, theme)
+      if (color) textProps.color = color
+    }
+    // Fixed-width Box per column — table-style alignment across rows.
+    return React.createElement(
       Box,
       {
         key: column.key,
         width: column.width + (index < row.columns.length - 1 ? COLUMN_GAP : 0),
         flexShrink: 0,
       },
-      React.createElement(
-        Text,
-        {
-          bold: row.cursor && column.primary,
-          dimColor: !row.cursor && column.tone === 'dim',
-          color: toneColor(column.tone, theme),
-        },
-        column.text
-      )
+      React.createElement(Text, textProps, column.text)
     )
-  )
+  })
   return React.createElement(
     Box,
     { key, flexDirection: 'row' },
@@ -231,11 +303,68 @@ function renderListRow(
       { width: CURSOR_PREFIX_WIDTH, flexShrink: 0 },
       React.createElement(
         Text,
-        { bold: row.cursor, color: row.cursor && !theme.noColor ? theme.colors.accent : undefined },
+        {
+          bold: row.cursor,
+          inverse: cursorReverse,
+          color: row.cursor && !theme.noColor ? theme.colors.accent : undefined,
+        },
         `${cursor} `
       )
     ),
     ...cells
+  )
+}
+
+/**
+ * Centered empty-state rendered when there's nothing to show in the
+ * list (loading, no repos discovered, or filtered to zero). Uses
+ * Box marginLeft to center horizontally — cheaper than computing a
+ * perfect width and skipping cells, and visually equivalent.
+ */
+function renderEmptyState(
+  deps: RenderWorkspaceAppDeps,
+  width: number
+): ReactTypes.ReactElement {
+  const { React, ink, state, theme } = deps
+  const { Box, Text } = ink
+  const variant: 'loading' | 'no-repos' | 'no-matches' = state.loading
+    ? 'loading'
+    : state.overview.repos.length === 0
+      ? 'no-repos'
+      : 'no-matches'
+  const glyph = variant === 'loading' ? '◐' : variant === 'no-repos' ? '∅' : '○'
+  const headline =
+    variant === 'loading'
+      ? 'Scanning configured roots…'
+      : variant === 'no-repos'
+        ? 'No repositories discovered'
+        : 'No repos match the current filter'
+  const detail =
+    variant === 'no-repos'
+      ? 'Press `a` to add a repo by path, or configure `workspace.roots`.'
+      : variant === 'no-matches'
+        ? 'Press `esc` to clear the filter, or `tab` to change the sidebar tab.'
+        : ''
+  return React.createElement(
+    Box,
+    {
+      key: 'empty',
+      flexDirection: 'column',
+      alignItems: 'center',
+      width,
+      marginTop: 2,
+    },
+    React.createElement(
+      Text,
+      {
+        bold: true,
+        color: variant === 'no-repos' && !theme.noColor ? theme.colors.muted : undefined,
+      },
+      `${glyph}  ${headline}`
+    ),
+    detail
+      ? React.createElement(Text, { dimColor: true, key: 'detail' }, detail)
+      : null
   )
 }
 
@@ -291,22 +420,14 @@ function renderListBody(
     : state.focus === 'filter'
       ? `  ·  filter: ${deps.filterDraft}_`
       : ''
+  // Half-circle ◐ reads as "in progress" without animation; pairs
+  // nicely with the text so the column doesn't depend on color alone.
   const headerRight = state.loading
-    ? 'loading repos…'
+    ? '◐ loading repos…'
     : `${visibleRepos.length} visible${filterChip}`
 
   const lines: ReactTypes.ReactNode[] = windowed.rows.length === 0
-    ? [
-      React.createElement(
-        Text,
-        { dimColor: true, key: 'empty' },
-        state.loading
-          ? 'Scanning configured roots…'
-          : state.overview.repos.length === 0
-            ? 'No repositories discovered. Configure workspace.roots and try again.'
-            : 'No repos match the current filter.'
-      ),
-    ]
+    ? [renderEmptyState(deps, width)]
     : windowed.rows.map((row, index) =>
       renderListRow(deps, row, `row-${windowed.hiddenAbove + index}`)
     )
@@ -541,7 +662,7 @@ export function renderWorkspaceApp(deps: RenderWorkspaceAppDeps): ReactTypes.Rea
       Box,
       { flexDirection: 'row', height: bodyHeight },
       renderSidebar(deps, bodyHeight),
-      renderListBody(deps, bodyWidth - SIDEBAR_WIDTH - 2, bodyHeight)
+      renderListBody(deps, bodyWidth - sidebarWidthFor(deps) - 2, bodyHeight)
     ),
     renderOnboardingBanner(deps),
     renderAddRepoPrompt(deps),


### PR DESCRIPTION
Information-density pass guided by the \`tui-design\` skill principles: \"never use color alone\", \"focus-grow narrow elements\", \"keep the most actionable signal longest\".

## What's new

### 1. Rail-mode sidebar at narrow widths

Below 100 columns the sidebar collapses to a 5-cell icon rail showing just tab glyphs — \`◯ All\`, \`● Dirty\`, \`↓ Behind\`, \`⊙ PRs\`. The active tab keeps its accent color even in rail mode so users see "which filter is on" at a glance.

**Focus-grow**: tabbing focus into the sidebar always expands it back to its full 22-cell width with labels + counts, regardless of terminal size. Same pattern \`coco ui\` uses for its narrow sidebar/inspector.

### 2. Tab glyphs everywhere

Each tab gets a semantic glyph paired with its label (expanded) or standing alone (rail). Color + glyph + count means the tab type reads three ways simultaneously — never color-alone. PR token in the status column switches from \`pr N\` to \`⊙ N\` to match the PRs tab glyph.

### 3. New column drop priority

Display order unchanged (\`name · branch · status · date · subject · path\`). **Drop order** is now \`path → subject → date → branch → status\` — status is kept longer than branch since "what needs my attention" reads cleaner from \`coco ●2 ↓3\` than from \`coco main\`. Name is always kept; at the narrowest widths the user sees just \`name + status\`.

### 4. Density-tiered date format

Wide terminals (≥140 cols) keep the absolute ISO date \`2026-05-27\`. Narrower terminals switch to relative \`2d\` / \`3w\` / \`5mo\` / \`1y\` so the date column compresses without losing the "how recent" signal. Caller can override via \`dateMode\`.

### 5. Reverse-video cursor

Cursored rows use Ink's \`inverse\` prop — the canonical TUI selection signal since VT100. Stronger than bold-only, never color-only, doesn't depend on the user's terminal palette.

### 6. Centered empty + loading states

Three variants of the empty state get distinct glyphs and centered, two-line copy with concrete CTAs:
- \`∅  No repositories discovered\` — "Press \`a\` to add a repo by path, or configure \`workspace.roots\`."
- \`○  No repos match the current filter\` — "Press \`esc\` to clear the filter, or \`tab\` to change the sidebar tab."
- \`◐  Scanning configured roots…\` — used while discovery is in flight.

Loading copy in the panel header switches from \`loading repos…\` to \`◐ loading repos…\` so the chip reads as active work rather than text.

## Test plan

- [x] Lint + typecheck clean
- [x] Full Jest suite: 188 suites, 2410 passing, 33 snapshots
- [ ] Manual: \`yarn dev:tui workspace\` — resize the terminal below 100 cols and watch the sidebar rail; tab into the sidebar and watch it expand; observe the reverse-video cursor row