### PR TITLE
feat(screenshot): workspace + utility commands + all view recipes (31 total)

### DIFF
--- a/bin/screenshot.ts
+++ b/bin/screenshot.ts
@@ -95,8 +95,36 @@ async function spinUpAsync(scenarioName: string | null): Promise<{ path: string;
   if (!scenarioName) {
     const dir = mkdtempSync(join(tmpdir(), 'coco-screenshot-'))
     return {
-      path: dir,
+      path: realpathSync(dir),
       cleanup: () => rmSync(dir, { recursive: true, force: true }),
+    }
+  }
+
+  // Special multi-repo workspace scenario: creates 3 repos in
+  // subdirectories of a parent dir for the workspace command to scan.
+  if (scenarioName === '_workspace') {
+    const { mkdirSync: mkdirSyncFs } = await import('fs')
+    const parentDir = mkdtempSync(join(tmpdir(), 'coco-workspace-'))
+    const realParent = realpathSync(parentDir)
+
+    // Create 3 repos as subdirectories
+    const scenarios = ['feature-pr-ready', 'dirty-many-files', 'stashed-changes']
+    const repos: Array<{ cleanup: () => void }> = []
+    for (let i = 0; i < scenarios.length; i++) {
+      const repo = await fromScenario(scenarios[i])
+      const targetDir = join(realParent, ['widget-app', 'dashboard', 'api-server'][i])
+      mkdirSyncFs(targetDir, { recursive: true })
+      const { execSync } = await import('child_process')
+      execSync(`cp -a ${repo.path}/. ${targetDir}/`)
+      repos.push(repo)
+    }
+
+    return {
+      path: realParent,
+      cleanup: async () => {
+        for (const r of repos) await r.cleanup()
+        rmSync(realParent, { recursive: true, force: true })
+      },
     }
   }
 

--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -181,6 +181,134 @@ export const RECIPES: ScreenshotRecipe[] = [
   },
 
   // ─────────────────────────────────────────────────────────────────
+  // `coco ui` — remaining view surfaces for full coverage
+  // ─────────────────────────────────────────────────────────────────
+  {
+    name: 'ui-compose',
+    description: 'Compose view with staged changes ready to commit',
+    scenario: 'single-staged-file',
+    command: 'ui',
+    actions: [
+      { kind: 'sleep', ms: 800 },
+      { kind: 'type', text: 'gc' },
+      { kind: 'sleep', ms: 400 },
+    ],
+  },
+  {
+    name: 'ui-tags',
+    description: 'Tags view on a repo with tagged releases',
+    scenario: 'large-repo',
+    command: 'ui',
+    actions: [
+      { kind: 'sleep', ms: 800 },
+      { kind: 'type', text: 'gt' },
+      { kind: 'sleep', ms: 400 },
+    ],
+  },
+  {
+    name: 'ui-conflicts-merge',
+    description: 'Conflicts view during an active merge conflict',
+    scenario: 'mid-merge-conflict',
+    command: 'ui',
+    actions: [
+      { kind: 'sleep', ms: 800 },
+      { kind: 'type', text: 'gx' },
+      { kind: 'sleep', ms: 400 },
+    ],
+  },
+  {
+    name: 'ui-reflog',
+    description: 'Reflog view showing HEAD movement history',
+    scenario: 'rich-history-graph',
+    command: 'ui',
+    actions: [
+      { kind: 'sleep', ms: 800 },
+      { kind: 'type', text: 'gr' },
+      { kind: 'sleep', ms: 400 },
+    ],
+  },
+  {
+    name: 'ui-bisect-view',
+    description: 'Bisect surface showing the active bisect state and decision log',
+    scenario: 'mid-bisect',
+    command: 'ui',
+    actions: [
+      { kind: 'sleep', ms: 800 },
+      { kind: 'type', text: 'gB' },
+      { kind: 'sleep', ms: 400 },
+    ],
+  },
+  {
+    name: 'ui-changelog',
+    description: 'Changelog view for a feature branch',
+    scenario: 'feature-pr-ready',
+    command: 'ui --no-all',
+    actions: [
+      { kind: 'sleep', ms: 800 },
+      { kind: 'type', text: 'L' },
+      { kind: 'sleep', ms: 400 },
+    ],
+  },
+  {
+    name: 'ui-submodules-view',
+    description: 'Submodules view showing registered submodules with status',
+    scenario: 'submodule-with-history',
+    command: 'ui',
+    actions: [
+      { kind: 'sleep', ms: 800 },
+      { kind: 'type', text: 'gM' },
+      { kind: 'sleep', ms: 400 },
+    ],
+  },
+  {
+    name: 'ui-help-overlay',
+    description: 'Help overlay showing all keybindings grouped by category',
+    scenario: 'feature-pr-ready',
+    command: 'ui --view history --no-all',
+    actions: [
+      { kind: 'sleep', ms: 800 },
+      { kind: 'type', text: '?' },
+      { kind: 'sleep', ms: 400 },
+    ],
+  },
+
+  // ─────────────────────────────────────────────────────────────────
+  // `coco workspace` — multi-repo workspace view
+  // ─────────────────────────────────────────────────────────────────
+  {
+    name: 'workspace-multi-repo',
+    description: 'Workspace view scanning a directory with 3 repos in different states',
+    scenario: '_workspace',
+    command: 'workspace --root . --maxDepth 1',
+    dimensions: { cols: 140, rows: 40 },
+  },
+
+  // ─────────────────────────────────────────────────────────────────
+  // Utility commands — non-interactive stdout captures
+  // ─────────────────────────────────────────────────────────────────
+  {
+    name: 'cmd-help',
+    description: 'Top-level coco --help output',
+    scenario: null,
+    command: '--help',
+    dimensions: { cols: 100, rows: 30 },
+  },
+  {
+    name: 'cmd-doctor',
+    description: 'coco doctor output showing environment checks',
+    scenario: 'feature-pr-ready',
+    command: 'doctor',
+    dimensions: { cols: 100, rows: 30 },
+  },
+  {
+    name: 'cmd-init-dry-run',
+    description: 'coco init --dry-run showing the setup wizard preview',
+    scenario: 'feature-pr-ready',
+    command: 'init --dry-run --scope project',
+    dimensions: { cols: 100, rows: 30 },
+  },
+
+  // ─────────────────────────────────────────────────────────────────
   // `coco log` — stdout / non-interactive renders
   // ─────────────────────────────────────────────────────────────────
   {


### PR DESCRIPTION
Adds 12 new recipes on top of the existing 19, bringing the total to 31. Covers every workstation view plus the workspace command and utility commands.

New view recipes (8): compose, tags, conflicts, reflog, bisect-view, changelog, submodules-view, help-overlay.

New workspace/utility recipes (4): workspace-multi-repo (3 repos in different states), cmd-help, cmd-doctor, cmd-init-dry-run.

Also adds a `_workspace` special scenario handler in the driver that creates 3 repos in subdirectories for the workspace command to scan.

Supersedes #1067 (which only had the 8 view recipes).
