### PR TITLE
feat(workspace): per-row inline loaders + per-row refresh (R)

### DIFF
--- a/src/git/workspacePullRequestData.ts
+++ b/src/git/workspacePullRequestData.ts
@@ -166,6 +166,13 @@ export type GetWorkspacePullRequestCountsOptions = {
   concurrency?: number
   /** Per-call timeout in ms. Default `WORKSPACE_PR_COUNT_TIMEOUT_MS`. */
   timeoutMs?: number
+  /**
+   * Fired as each repo finishes — `count` is undefined when the repo
+   * has no GitHub remote or the gh call failed/timed out. Lets the UI
+   * surface per-row spinner state and drop the spinner the moment a
+   * row's data lands, rather than waiting for the whole batch.
+   */
+  onRepoComplete?: (repoPath: string, count: number | undefined) => void
 }
 
 async function mapWithConcurrency<T, U>(
@@ -202,16 +209,19 @@ export async function getWorkspacePullRequestCounts(
   await mapWithConcurrency(repoPaths, concurrency, async (repoPath) => {
     const url = options.remoteUrls?.get(repoPath) ?? readOriginRemoteUrl(repoPath)
     if (!url) {
+      options.onRepoComplete?.(repoPath, undefined)
       return
     }
     const repo = parseGitHubRemoteUrl(url)
     if (!repo) {
+      options.onRepoComplete?.(repoPath, undefined)
       return
     }
     const count = await fetchPullRequestCount(runner, repo, timeoutMs)
     if (typeof count === 'number') {
       counts[repoPath] = count
     }
+    options.onRepoComplete?.(repoPath, count)
   })
 
   return { authenticated: true, counts }

--- a/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
+++ b/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
@@ -554,7 +554,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -949,7 +949,7 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -1518,7 +1518,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -1971,7 +1971,7 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -2536,7 +2536,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       color="yellow"
@@ -2944,7 +2944,7 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -3509,7 +3509,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -3834,7 +3834,7 @@ exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading fals
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -5370,7 +5370,7 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -6341,7 +6341,7 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -6926,7 +6926,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -7123,6 +7123,30 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
       <Text
         color="green"
       >
+        r                
+      </Text>
+      <Text>
+        Refresh discovery (all repos)
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Text
+        color="green"
+      >
+        R                
+      </Text>
+      <Text>
+        Refresh just the cursored repo (faster)
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Text
+        color="green"
+      >
         /                
       </Text>
       <Text>
@@ -7217,7 +7241,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -7547,7 +7571,7 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -8112,7 +8136,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit
+      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}

--- a/src/workstation/surfaces/workspace/input.ts
+++ b/src/workstation/surfaces/workspace/input.ts
@@ -27,6 +27,7 @@ export type WorkspaceInputIntent =
   | { kind: 'quit' }
   | { kind: 'drill-in' }
   | { kind: 'refresh' }
+  | { kind: 'refresh-row' }
   | { kind: 'add-repo' }
   | { kind: 'request-delete' }
   | { kind: 'confirm-delete' }
@@ -183,6 +184,9 @@ export function resolveWorkspaceInput(
   }
   if (input === 'r') {
     return { kind: 'refresh' }
+  }
+  if (input === 'R') {
+    return { kind: 'refresh-row' }
   }
   if (input === 'a') {
     return { kind: 'add-repo' }

--- a/src/workstation/surfaces/workspace/render.test.ts
+++ b/src/workstation/surfaces/workspace/render.test.ts
@@ -92,6 +92,18 @@ describe('workspace render builders', () => {
     expect(rows[1].columns[2].text).toContain('⊙4')
   })
 
+  it('shows a spinner glyph in the status cell while a row is fetching its PR count', () => {
+    const fetching = applyWorkspaceAction(state, {
+      type: 'set-pull-request-fetching',
+      paths: [state.overview.repos[1].path],
+    })
+    const rows = buildWorkspaceListRows(fetching, { spinnerTick: 3 })
+    // Spinner frame at tick 3 is the fourth Braille glyph.
+    expect(rows[1].columns[2].text).toContain('⠸')
+    // Non-fetching row stays unaffected.
+    expect(rows[0].columns[2].text).not.toContain('⠸')
+  })
+
   it('omits pr tokens when gh is unauthenticated', () => {
     const next = applyWorkspaceAction(state, {
       type: 'replace-pull-request-counts',

--- a/src/workstation/surfaces/workspace/render.ts
+++ b/src/workstation/surfaces/workspace/render.ts
@@ -161,11 +161,24 @@ export function assignWorkspaceColumnWidths(budget: number): WorkspaceColumnWidt
   return widths
 }
 
+/**
+ * Spinner frames cycled by the runtime tick. Same Braille-style
+ * spinner the existing `chrome/spinner.ts` uses so workspace +
+ * coco ui feel consistent.
+ */
+export const WORKSPACE_SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'] as const
+
+export function workspaceSpinnerFrame(tick: number): string {
+  return WORKSPACE_SPINNER_FRAMES[tick % WORKSPACE_SPINNER_FRAMES.length]
+}
+
 function formatStatusCell(
   repo: WorkspaceRepoSummary,
   width: number,
-  ghAuthenticated?: boolean,
-  prCount?: number
+  ghAuthenticated: boolean | undefined,
+  prCount: number | undefined,
+  isFetchingPr: boolean,
+  spinnerFrame: string
 ): WorkspaceListColumn {
   const tokens: string[] = []
   if (repo.dirty > 0) {
@@ -177,7 +190,12 @@ function formatStatusCell(
   if (repo.behind > 0) {
     tokens.push(`↓${repo.behind}`)
   }
-  if (ghAuthenticated && typeof prCount === 'number' && prCount > 0) {
+  if (isFetchingPr) {
+    // Animated spinner replaces the PR token while the gh call is
+    // in flight. Same glyph family as the existing TUI's
+    // workspace-wide loading indicator so users learn one shape.
+    tokens.push(spinnerFrame)
+  } else if (ghAuthenticated && typeof prCount === 'number' && prCount > 0) {
     // `⊙ N` matches the PRs tab glyph so the status column reads as a
     // glance-grokable summary of the same data the tabs filter on.
     tokens.push(`⊙${prCount}`)
@@ -240,6 +258,13 @@ export type BuildWorkspaceListRowsOptions = {
    * determinism; the view layer passes `new Date()`.
    */
   now?: Date
+  /**
+   * Tick counter for the spinner frame. The runtime increments this
+   * on a setInterval while any row is fetching its PR count, so the
+   * Braille spinner animates without keeping React busy when nothing
+   * is in flight.
+   */
+  spinnerTick?: number
 }
 
 const DEFAULT_ROW_WIDTH = 120
@@ -265,6 +290,8 @@ export function buildWorkspaceListRows(
   const widths = assignWorkspaceColumnWidths(rowWidth)
   const dateMode = options.dateMode ?? pickWorkspaceDateMode(rowWidth)
   const now = options.now ?? new Date()
+  const spinner = workspaceSpinnerFrame(options.spinnerTick ?? 0)
+  const fetchingSet = new Set(state.pullRequestFetching)
   return visible.map((repo, index) => {
     const cursor = index === state.selectedIndex
     const nameTone: WorkspaceListColumn['tone'] = repo.error ? 'warn' : 'default'
@@ -288,7 +315,14 @@ export function buildWorkspaceListRows(
     }
     if (widths.status !== undefined) {
       columns.push(
-        formatStatusCell(repo, widths.status, state.ghAuthenticated, state.pullRequestCounts[repo.path])
+        formatStatusCell(
+          repo,
+          widths.status,
+          state.ghAuthenticated,
+          state.pullRequestCounts[repo.path],
+          fetchingSet.has(repo.path),
+          spinner
+        )
       )
     }
     if (widths.date !== undefined) {
@@ -362,9 +396,12 @@ export type WorkspaceListWindow = {
  */
 export function buildWorkspaceListWindow(
   state: WorkspaceState,
-  options: { width?: number; rows: number } = { rows: 20 }
+  options: { width?: number; rows: number; spinnerTick?: number } = { rows: 20 }
 ): WorkspaceListWindow {
-  const all = buildWorkspaceListRows(state, { width: options.width })
+  const all = buildWorkspaceListRows(state, {
+    width: options.width,
+    spinnerTick: options.spinnerTick,
+  })
   const visibleCount = Math.max(1, options.rows)
   if (all.length <= visibleCount) {
     return {
@@ -556,7 +593,7 @@ export type WorkspaceFooterModel = {
   filterMode: boolean
 }
 
-const LIST_HINT = 'j/k move · enter open · tab → sidebar · s sort · / filter · r refresh · a add · d remove · ? help · q quit'
+const LIST_HINT = 'j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit'
 const SIDEBAR_HINT = 'j/k change tab · enter / l → list · tab → list · ? help · q quit'
 const FILTER_HINT = 'type filter · enter to apply · esc to clear'
 const ADD_REPO_HINT = 'type path · tab to complete · enter to add · esc to cancel'
@@ -614,6 +651,8 @@ export function buildWorkspaceHelpRows(): WorkspaceHelpRow[] {
     { keys: 'g / G', description: 'List: jump to top / bottom' },
     { keys: 'enter', description: 'List: drill into the cursored repo (coco ui)' },
     { keys: 's', description: 'Cycle sort mode (recency → name → dirty)' },
+    { keys: 'r', description: 'Refresh discovery (all repos)' },
+    { keys: 'R', description: 'Refresh just the cursored repo (faster)' },
     { keys: '/', description: 'Filter the list by name or branch' },
     { keys: 'r', description: 'Refresh discovery' },
     { keys: 'a', description: 'Add a repo via path prompt (tab-completes)' },

--- a/src/workstation/surfaces/workspace/runtime.ts
+++ b/src/workstation/surfaces/workspace/runtime.ts
@@ -156,9 +156,15 @@ export type WorkspaceStartOptions = {
     roots: ReadonlyArray<string>,
     knownRepos: ReadonlyArray<string>
   ) => Promise<WorkspaceOverview>
-  /** Override gh PR-count fetch (used by tests + when caller already has data). */
+  /**
+   * Override gh PR-count fetch (used by tests + when caller already
+   * has data). Second arg lets the runtime watch per-repo completion
+   * so the surface can clear the per-row spinner the moment each
+   * repo's count lands, instead of waiting for the whole batch.
+   */
   loadPullRequestCounts?: (
-    repos: ReadonlyArray<WorkspaceRepoSummary>
+    repos: ReadonlyArray<WorkspaceRepoSummary>,
+    onRepoComplete?: (path: string, count: number | undefined) => void
   ) => Promise<WorkspacePullRequestCounts>
   streams?: {
     input?: NodeJS.ReadStream
@@ -196,10 +202,16 @@ export async function startWorkspace(
     ((roots: ReadonlyArray<string>, repos: ReadonlyArray<string>) =>
       getWorkspaceOverview(roots, { knownRepos: repos, maxDepth: options.maxDepth }))
 
-  const loadPullRequestCounts =
+  const loadPullRequestCounts: (
+    repos: ReadonlyArray<WorkspaceRepoSummary>,
+    onRepoComplete?: (path: string, count: number | undefined) => void
+  ) => Promise<WorkspacePullRequestCounts> =
     options.loadPullRequestCounts ??
-    ((repos: ReadonlyArray<WorkspaceRepoSummary>) =>
-      getWorkspacePullRequestCounts(repos.map((entry) => entry.path)))
+    ((repos, onRepoComplete) =>
+      getWorkspacePullRequestCounts(
+        repos.map((entry) => entry.path),
+        { onRepoComplete }
+      ))
 
   const cached = readCachedWorkspace(options.roots) ?? EMPTY_OVERVIEW(options.roots)
   const persisted = readWorkspacePreferences(options.roots)
@@ -400,7 +412,8 @@ type WorkspaceInkAppProps = {
     knownRepos: ReadonlyArray<string>
   ) => Promise<WorkspaceOverview>
   loadPullRequestCounts: (
-    repos: ReadonlyArray<WorkspaceRepoSummary>
+    repos: ReadonlyArray<WorkspaceRepoSummary>,
+    onRepoComplete?: (path: string, count: number | undefined) => void
   ) => Promise<WorkspacePullRequestCounts>
   onAddRepo?: () => Promise<string | undefined>
   resume?: WorkspaceResumeState
@@ -436,10 +449,25 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
   const [addRepoCompletion, setAddRepoCompletion] = React.useState<PathCompletionResult>(() =>
     completePath('~/')
   )
+  // Tick counter for the per-row PR-fetch spinner. Bumped on a
+  // setInterval that only runs while at least one row is mid-fetch
+  // (see effect below) so idle workspaces don't burn CPU on animation
+  // frames.
+  const [spinnerTick, setSpinnerTick] = React.useState(0)
 
   const dispatch = React.useCallback((action: WorkspaceAction) => {
     setState((prev) => applyWorkspaceAction(prev, action))
   }, [])
+
+  // Spinner tick — only ticks while at least one row is fetching a
+  // PR count. Stops as soon as the fetching set empties so the
+  // workspace idles at zero render cost.
+  const fetchingCount = state.pullRequestFetching.length
+  React.useEffect(() => {
+    if (fetchingCount === 0) return
+    const id = setInterval(() => setSpinnerTick((tick) => (tick + 1) % 1000), 80)
+    return () => clearInterval(id)
+  }, [fetchingCount])
 
   // Track an unmount flag in a ref so async work scheduled by the
   // input handler (refresh, drillIn, etc.) can short-circuit when the
@@ -476,13 +504,27 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
         if (props.resume?.selectedRepoPath) {
           dispatch({ type: 'anchor-cursor-by-path', path: props.resume.selectedRepoPath })
         }
-        const pr = await props.loadPullRequestCounts(overview.repos)
+        // Mark every repo as "fetching PRs" up front so the row
+        // spinners light up immediately. As each repo's gh call
+        // completes, mark-pull-request-fetched clears just that row.
+        dispatch({
+          type: 'set-pull-request-fetching',
+          paths: overview.repos.map((entry) => entry.path),
+        })
+        const pr = await props.loadPullRequestCounts(overview.repos, (path) => {
+          if (cancelled || unmountedRef.current) return
+          dispatch({ type: 'mark-pull-request-fetched', path })
+        })
         if (cancelled || unmountedRef.current) return
         dispatch({
           type: 'replace-pull-request-counts',
           counts: pr.counts,
           authenticated: pr.authenticated,
         })
+        // Belt-and-suspenders: clear any stragglers in the fetching set
+        // (e.g. repos without a GitHub remote that the data layer
+        // skipped silently in older versions).
+        dispatch({ type: 'set-pull-request-fetching', paths: [] })
         if (!pr.authenticated) {
           dispatch({
             type: 'set-status',
@@ -491,6 +533,7 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
         }
       } catch (err) {
         if (cancelled || unmountedRef.current) return
+        dispatch({ type: 'set-pull-request-fetching', paths: [] })
         dispatch({ type: 'set-loading', loading: false })
         dispatch({
           type: 'set-status',
@@ -513,19 +556,63 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
       writeCachedWorkspace(props.roots, overview)
       dispatch({ type: 'replace-overview', overview })
       dispatch({ type: 'set-status', status: `Refreshed ${overview.repos.length} repos.` })
-      const pr = await props.loadPullRequestCounts(overview.repos)
+      dispatch({
+        type: 'set-pull-request-fetching',
+        paths: overview.repos.map((entry) => entry.path),
+      })
+      const pr = await props.loadPullRequestCounts(overview.repos, (path) => {
+        if (unmountedRef.current) return
+        dispatch({ type: 'mark-pull-request-fetched', path })
+      })
       if (unmountedRef.current) return
       dispatch({
         type: 'replace-pull-request-counts',
         counts: pr.counts,
         authenticated: pr.authenticated,
       })
+      dispatch({ type: 'set-pull-request-fetching', paths: [] })
     } catch (err) {
       if (unmountedRef.current) return
       dispatch({ type: 'set-loading', loading: false })
       dispatch({
         type: 'set-status',
         status: err instanceof Error ? err.message : 'Discovery failed.',
+      })
+    }
+  }, [dispatch, props])
+
+  const refreshRow = React.useCallback(async () => {
+    const focused = selectFocusedRepo(stateRef.current)
+    if (!focused) return
+    dispatch({ type: 'set-pull-request-fetching', paths: [focused.path] })
+    dispatch({ type: 'set-status', status: `Refreshing ${focused.name}…` })
+    try {
+      const pr = await props.loadPullRequestCounts([focused], (path) => {
+        if (unmountedRef.current) return
+        dispatch({ type: 'mark-pull-request-fetched', path })
+      })
+      if (unmountedRef.current) return
+      // Merge into existing counts rather than replacing them — a
+      // per-row refresh shouldn't clobber other rows' counts.
+      const merged: Record<string, number> = { ...stateRef.current.pullRequestCounts }
+      if (typeof pr.counts[focused.path] === 'number') {
+        merged[focused.path] = pr.counts[focused.path]
+      } else {
+        delete merged[focused.path]
+      }
+      dispatch({
+        type: 'replace-pull-request-counts',
+        counts: merged,
+        authenticated: pr.authenticated,
+      })
+      dispatch({ type: 'set-pull-request-fetching', paths: [] })
+      dispatch({ type: 'set-status', status: `Refreshed ${focused.name}.` })
+    } catch (err) {
+      if (unmountedRef.current) return
+      dispatch({ type: 'set-pull-request-fetching', paths: [] })
+      dispatch({
+        type: 'set-status',
+        status: err instanceof Error ? err.message : 'Row refresh failed.',
       })
     }
   }, [dispatch, props])
@@ -634,6 +721,8 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
   drillInRef.current = drillIn
   const refreshRef = React.useRef(refresh)
   refreshRef.current = refresh
+  const refreshRowRef = React.useRef(refreshRow)
+  refreshRowRef.current = refreshRow
   const openAddRepoRef = React.useRef(openAddRepo)
   openAddRepoRef.current = openAddRepo
   const requestDeleteRef = React.useRef(requestDelete)
@@ -755,6 +844,9 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
       case 'refresh':
         void refreshRef.current()
         break
+      case 'refresh-row':
+        void refreshRowRef.current()
+        break
       case 'add-repo':
         openAddRepoRef.current()
         break
@@ -807,5 +899,6 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
     addRepoCompletion,
     columns,
     rows,
+    spinnerTick,
   })
 }

--- a/src/workstation/surfaces/workspace/state.test.ts
+++ b/src/workstation/surfaces/workspace/state.test.ts
@@ -270,4 +270,30 @@ describe('workspace state reducer', () => {
     expect(cancelled.focus).toBe('list')
     expect(cancelled.pendingDeletePath).toBeUndefined()
   })
+
+  it('set-pull-request-fetching replaces the whole fetching set', () => {
+    const next = applyWorkspaceAction(baseState, {
+      type: 'set-pull-request-fetching',
+      paths: ['/tmp/alpha', '/tmp/bravo'],
+    })
+    expect(next.pullRequestFetching).toEqual(['/tmp/alpha', '/tmp/bravo'])
+  })
+
+  it('mark-pull-request-fetched removes the path from the fetching set', () => {
+    let s = applyWorkspaceAction(baseState, {
+      type: 'set-pull-request-fetching',
+      paths: ['/tmp/alpha', '/tmp/bravo'],
+    })
+    s = applyWorkspaceAction(s, { type: 'mark-pull-request-fetched', path: '/tmp/alpha' })
+    expect(s.pullRequestFetching).toEqual(['/tmp/bravo'])
+  })
+
+  it('mark-pull-request-fetched is a no-op for an unknown path', () => {
+    const s = applyWorkspaceAction(baseState, {
+      type: 'set-pull-request-fetching',
+      paths: ['/tmp/alpha'],
+    })
+    const t = applyWorkspaceAction(s, { type: 'mark-pull-request-fetched', path: '/tmp/zzz' })
+    expect(t.pullRequestFetching).toEqual(['/tmp/alpha'])
+  })
 })

--- a/src/workstation/surfaces/workspace/state.ts
+++ b/src/workstation/surfaces/workspace/state.ts
@@ -85,6 +85,13 @@ export type WorkspaceState = {
   /** Path the user is being asked to confirm deletion for. */
   pendingDeletePath?: string
   /**
+   * Repo paths whose PR count is currently being fetched. Used by the
+   * row renderer to show a spinner glyph in the status cell while
+   * the gh call is in flight, and to surface in-flight state for
+   * per-row refreshes (Shift+R).
+   */
+  pullRequestFetching: ReadonlyArray<string>
+  /**
    * Repo path the cursor was on right before the user opened the
    * filter prompt. Used to restore the cursor when the filter is
    * cleared (Esc) — without it, the cursor would land at index 0
@@ -115,6 +122,8 @@ export type WorkspaceAction =
   | { type: 'replace-known-repos'; paths: ReadonlyArray<string> }
   | { type: 'request-delete'; path: string }
   | { type: 'cancel-delete' }
+  | { type: 'set-pull-request-fetching'; paths: ReadonlyArray<string> }
+  | { type: 'mark-pull-request-fetched'; path: string }
 
 export type WorkspaceStateInit = {
   overview: WorkspaceOverview
@@ -150,6 +159,7 @@ export function createWorkspaceState(init: WorkspaceStateInit): WorkspaceState {
     showHelp: false,
     showOnboarding: Boolean(init.showOnboarding),
     knownRepoPaths: init.knownRepoPaths ?? [],
+    pullRequestFetching: [],
   }
   if (!init.selectedRepoPath) {
     return base
@@ -344,6 +354,18 @@ export function applyWorkspaceAction(
     case 'cancel-delete': {
       return { ...state, focus: 'list', pendingDeletePath: undefined }
     }
+    case 'set-pull-request-fetching': {
+      // Replace the whole fetching set. Used at the start of a batch
+      // load (mark every queued repo as fetching) or to clear.
+      return { ...state, pullRequestFetching: [...action.paths] }
+    }
+    case 'mark-pull-request-fetched': {
+      if (!state.pullRequestFetching.includes(action.path)) return state
+      return {
+        ...state,
+        pullRequestFetching: state.pullRequestFetching.filter((entry) => entry !== action.path),
+      }
+    }
     default:
       return state
   }
@@ -351,6 +373,10 @@ export function applyWorkspaceAction(
 
 export function isRepoRemovable(state: WorkspaceState, repoPath: string): boolean {
   return state.knownRepoPaths.includes(repoPath)
+}
+
+export function isRepoFetchingPullRequest(state: WorkspaceState, repoPath: string): boolean {
+  return state.pullRequestFetching.includes(repoPath)
 }
 
 export function selectFocusedRepo(state: WorkspaceState): WorkspaceRepoSummary | undefined {

--- a/src/workstation/surfaces/workspace/view.test.ts
+++ b/src/workstation/surfaces/workspace/view.test.ts
@@ -118,6 +118,7 @@ function render(
       } as ReturnType<typeof completePath>),
     columns: options.columns ?? 120,
     rows: options.rows ?? 40,
+    spinnerTick: 0,
   })
 }
 

--- a/src/workstation/surfaces/workspace/view.ts
+++ b/src/workstation/surfaces/workspace/view.ts
@@ -42,6 +42,11 @@ type RenderWorkspaceAppDeps = {
   columns: number
   /** Terminal height in rows. Caller resolves via Ink's useWindowSize. */
   rows: number
+  /**
+   * Tick counter for the per-row PR-fetch spinner. Caller increments
+   * this on a setInterval while any row is mid-fetch.
+   */
+  spinnerTick: number
 }
 
 function toneColor(tone: WorkspaceListColumn['tone'], theme: LogInkTheme): string | undefined {
@@ -412,7 +417,11 @@ function renderListBody(
   // render at least one row of content.
   const reservedChrome = 5
   const listRows = Math.max(1, height - reservedChrome)
-  const windowed = buildWorkspaceListWindow(state, { width, rows: listRows })
+  const windowed = buildWorkspaceListWindow(state, {
+    width,
+    rows: listRows,
+    spinnerTick: deps.spinnerTick,
+  })
   const visibleRepos = selectVisibleRepos(state)
 
   const filterChip = state.filter


### PR DESCRIPTION
Two complementary visibility improvements for the PR-count data.

## 1. Per-row spinner during the gh fetch

The aggregate fetcher (\`getWorkspacePullRequestCounts\`) gains an \`onRepoComplete\` callback that fires the moment each repo's gh call resolves. The runtime marks the whole repo set as fetching at the start of the batch, then clears each path as the callback fires.

Row renderer shows a Braille spinner glyph (\`⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏\`) in the status cell while a repo is mid-fetch — drops the moment that row's data lands.

Tick driver only runs while \`pullRequestFetching.length > 0\` so idle workspaces burn zero CPU on the animation frame.

## 2. Per-row refresh via Shift+R

- \`r\` continues to refresh the whole workspace (discovery + all PR counts).
- \`R\` (Shift+R) refreshes just the cursored repo — useful when you've fixed something in one repo and want fresh data on it without re-querying gh for the other ~60. Merged counts are written back without clobbering other rows.

Help legend + footer hint both updated.

## Test plan

- [x] Lint + typecheck clean
- [x] Full Jest suite: 188 suites, 2414 passing, 33 snapshots
- [ ] Manual: \`yarn dev:tui workspace\` — observe per-row spinners on initial load and on \`R\` press; \`r\` still refreshes everything