### PR TITLE
feat(workspace): trim footer + restructure help into sections

### DIFF
--- a/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
+++ b/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
@@ -523,7 +523,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
+      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -915,7 +915,7 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
+      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -1453,7 +1453,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
+      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -1879,7 +1879,7 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
+      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -2413,7 +2413,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
+      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       color="yellow"
@@ -2800,7 +2800,7 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
+      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -3334,7 +3334,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
+      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -3659,7 +3659,7 @@ exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading fals
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
+      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -4193,7 +4193,7 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
     <Text
       dimColor={true}
     >
-      type filter · enter to apply · esc to clear
+      type to filter · enter apply · esc cancel
     </Text>
     <Text
       dimColor={true}
@@ -5128,7 +5128,7 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
+      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -6063,7 +6063,7 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
+      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -6617,7 +6617,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
+      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -6707,139 +6707,256 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     flexDirection="column"
     paddingX={1}
   >
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
+    >
+      <Box
+        flexDirection="row"
+      >
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           ?  coco workspace
+        </Text>
+        <Text
+          dimColor={true}
+        >
+            keymap · 
+        </Text>
+        <Text
+          dimColor={true}
+        >
+          15 bindings
+        </Text>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+        esc / ? to close 
+      </Text>
+    </Box>
+    <Text
+      dimColor={true}
+    />
     <Text
       bold={true}
+      color="gray"
     >
-      Workspace keymap
+      NAVIGATE
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       Move the cursor and switch focus between panels.
     </Text>
     <Box
       flexDirection="row"
     >
-      <Text
-        color="green"
+      <Box
+        flexShrink={0}
+        width={4}
       >
-        tab / shift-tab  
-      </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           ↕ 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
+      >
+        <Text
+          bold={true}
+          color="green"
+        >
+          j / k / ↑ / ↓
+        </Text>
+      </Box>
       <Text>
-        Move focus between sidebar and list
+        Move cursor up & down (list) · cycle tab (sidebar)
       </Text>
     </Box>
     <Box
       flexDirection="row"
     >
-      <Text
-        color="green"
+      <Box
+        flexShrink={0}
+        width={4}
       >
-        j / ↓            
-      </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           ⇥ 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
+      >
+        <Text
+          bold={true}
+          color="green"
+        >
+          tab / shift-tab
+        </Text>
+      </Box>
       <Text>
-        List: move cursor down · Sidebar: next tab
+        Toggle focus between sidebar and list
       </Text>
     </Box>
     <Box
       flexDirection="row"
     >
-      <Text
-        color="green"
+      <Box
+        flexShrink={0}
+        width={4}
       >
-        k / ↑            
-      </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           ← 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
+      >
+        <Text
+          bold={true}
+          color="green"
+        >
+          h
+        </Text>
+      </Box>
       <Text>
-        List: move cursor up · Sidebar: previous tab
+        Jump focus to the sidebar
       </Text>
     </Box>
     <Box
       flexDirection="row"
     >
-      <Text
-        color="green"
+      <Box
+        flexShrink={0}
+        width={4}
       >
-        h / ←            
-      </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           → 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
+      >
+        <Text
+          bold={true}
+          color="green"
+        >
+          l
+        </Text>
+      </Box>
       <Text>
-        List → sidebar focus
+        Jump focus to the list
       </Text>
     </Box>
     <Box
       flexDirection="row"
     >
-      <Text
-        color="green"
+      <Box
+        flexShrink={0}
+        width={4}
       >
-        l / →            
-      </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           ⤒ 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
+      >
+        <Text
+          bold={true}
+          color="green"
+        >
+          g / G
+        </Text>
+      </Box>
       <Text>
-        Sidebar → list focus (also enter)
+        Jump to top / bottom of the list
       </Text>
     </Box>
     <Box
       flexDirection="row"
     >
-      <Text
-        color="green"
+      <Box
+        flexShrink={0}
+        width={4}
       >
-        g / G            
-      </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           ↵ 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
+      >
+        <Text
+          bold={true}
+          color="green"
+        >
+          enter
+        </Text>
+      </Box>
       <Text>
-        List: jump to top / bottom
+        Drill into the cursored repo (coco ui)
       </Text>
     </Box>
+    <Text />
+    <Text
+      bold={true}
+      color="gray"
+    >
+      FILTER & SORT
+    </Text>
     <Box
       flexDirection="row"
     >
-      <Text
-        color="green"
+      <Box
+        flexShrink={0}
+        width={4}
       >
-        enter            
-      </Text>
-      <Text>
-        List: drill into the cursored repo (coco ui)
-      </Text>
-    </Box>
-    <Box
-      flexDirection="row"
-    >
-      <Text
-        color="green"
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           / 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
       >
-        s                
-      </Text>
-      <Text>
-        Cycle sort mode (recency → name → dirty)
-      </Text>
-    </Box>
-    <Box
-      flexDirection="row"
-    >
-      <Text
-        color="green"
-      >
-        r                
-      </Text>
-      <Text>
-        Refresh discovery (all repos)
-      </Text>
-    </Box>
-    <Box
-      flexDirection="row"
-    >
-      <Text
-        color="green"
-      >
-        R                
-      </Text>
-      <Text>
-        Refresh just the cursored repo (faster)
-      </Text>
-    </Box>
-    <Box
-      flexDirection="row"
-    >
-      <Text
-        color="green"
-      >
-        /                
-      </Text>
+        <Text
+          bold={true}
+          color="green"
+        >
+          /
+        </Text>
+      </Box>
       <Text>
         Filter the list by name or branch
       </Text>
@@ -6847,23 +6964,127 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     <Box
       flexDirection="row"
     >
-      <Text
-        color="green"
+      <Box
+        flexShrink={0}
+        width={4}
       >
-        r                
-      </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           ↑↓ 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
+      >
+        <Text
+          bold={true}
+          color="green"
+        >
+          s
+        </Text>
+      </Box>
       <Text>
-        Refresh discovery
+        Cycle sort mode (recency → name → dirty)
+      </Text>
+    </Box>
+    <Text />
+    <Text
+      bold={true}
+      color="gray"
+    >
+      REPOS
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       Add, remove, and refresh the workspace inventory.
+    </Text>
+    <Box
+      flexDirection="row"
+    >
+      <Box
+        flexShrink={0}
+        width={4}
+      >
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           ⟳ 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
+      >
+        <Text
+          bold={true}
+          color="green"
+        >
+          r
+        </Text>
+      </Box>
+      <Text>
+        Refresh all repos (discovery + PR counts)
       </Text>
     </Box>
     <Box
       flexDirection="row"
     >
-      <Text
-        color="green"
+      <Box
+        flexShrink={0}
+        width={4}
       >
-        a                
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           ⟲ 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
+      >
+        <Text
+          bold={true}
+          color="green"
+        >
+          R
+        </Text>
+      </Box>
+      <Text>
+        Refresh just the cursored repo (faster)
       </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Box
+        flexShrink={0}
+        width={4}
+      >
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           ＋ 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
+      >
+        <Text
+          bold={true}
+          color="green"
+        >
+          a
+        </Text>
+      </Box>
       <Text>
         Add a repo via path prompt (tab-completes)
       </Text>
@@ -6871,23 +7092,64 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     <Box
       flexDirection="row"
     >
-      <Text
-        color="green"
+      <Box
+        flexShrink={0}
+        width={4}
       >
-        d                
-      </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           ✕ 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
+      >
+        <Text
+          bold={true}
+          color="green"
+        >
+          d
+        </Text>
+      </Box>
       <Text>
-        Remove the cursored repo from the known-repos store (y-confirm)
+        Remove the cursored repo from the known-repos store
       </Text>
     </Box>
+    <Text />
+    <Text
+      bold={true}
+      color="gray"
+    >
+      GENERAL
+    </Text>
     <Box
       flexDirection="row"
     >
-      <Text
-        color="green"
+      <Box
+        flexShrink={0}
+        width={4}
       >
-        ?                
-      </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           ? 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
+      >
+        <Text
+          bold={true}
+          color="green"
+        >
+          ?
+        </Text>
+      </Box>
       <Text>
         Toggle this help overlay
       </Text>
@@ -6895,32 +7157,61 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     <Box
       flexDirection="row"
     >
-      <Text
-        color="green"
+      <Box
+        flexShrink={0}
+        width={4}
       >
-        esc              
-      </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           ⎋ 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
+      >
+        <Text
+          bold={true}
+          color="green"
+        >
+          esc
+        </Text>
+      </Box>
       <Text>
-        Clear filter or close overlay
+        Clear filter / close overlay / cancel prompt
       </Text>
     </Box>
     <Box
       flexDirection="row"
     >
-      <Text
-        color="green"
+      <Box
+        flexShrink={0}
+        width={4}
       >
-        q                
-      </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           ◴ 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
+      >
+        <Text
+          bold={true}
+          color="green"
+        >
+          q · ctrl+c
+        </Text>
+      </Box>
       <Text>
         Quit the workspace surface
       </Text>
     </Box>
-    <Text
-      dimColor={true}
-    >
-      esc / ? / q close · auto-refresh disabled while help is open
-    </Text>
   </Box>
   <Box
     borderColor="gray"
@@ -6932,7 +7223,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
+      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -7262,7 +7553,7 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
+      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}
@@ -7796,7 +8087,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
     <Text
       dimColor={true}
     >
-      j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
+      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
     </Text>
     <Text
       dimColor={true}

--- a/src/workstation/surfaces/workspace/render.test.ts
+++ b/src/workstation/surfaces/workspace/render.test.ts
@@ -146,7 +146,7 @@ describe('workspace render builders', () => {
     const focused = applyWorkspaceAction(state, { type: 'set-focus', focus: 'filter' })
     const footer = buildWorkspaceFooter(focused)
     expect(footer.filterMode).toBe(true)
-    expect(footer.hint).toContain('type filter')
+    expect(footer.hint).toContain('type to filter')
   })
 
   it('footer shows status when the runtime set one', () => {

--- a/src/workstation/surfaces/workspace/render.ts
+++ b/src/workstation/surfaces/workspace/render.ts
@@ -597,9 +597,13 @@ export type WorkspaceFooterModel = {
   filterMode: boolean
 }
 
-const LIST_HINT = 'j/k move · enter open · tab → sidebar · s sort · / filter · r/R refresh · a add · d remove · ? help · q quit'
-const SIDEBAR_HINT = 'j/k change tab · enter / l → list · tab → list · ? help · q quit'
-const FILTER_HINT = 'type filter · enter to apply · esc to clear'
+// Footer hints prioritize discoverable / forgettable actions and
+// drop the bindings users can find on their own (arrow keys, Enter
+// for "open", Tab for "switch panels"). The full keymap lives behind
+// `?` so nothing is hidden, just decluttered.
+const LIST_HINT = 's sort · / filter · r/R refresh · a add · d remove · ? help · q quit'
+const SIDEBAR_HINT = '? help · q quit'
+const FILTER_HINT = 'type to filter · enter apply · esc cancel'
 const ADD_REPO_HINT = 'type path · tab to complete · enter to add · esc to cancel'
 const CONFIRM_DELETE_HINT = 'press y to remove · any other key to cancel'
 
@@ -638,33 +642,73 @@ export function describeSortModesForLegend(): Record<WorkspaceSortMode, string> 
 export type WorkspaceHelpRow = {
   keys: string
   description: string
+  /** Optional glyph rendered to the left of the keys — adds visual texture without competing with content. */
+  glyph?: string
+}
+
+export type WorkspaceHelpSection = {
+  title: string
+  /** Short subtitle line under the section title (dim). */
+  subtitle?: string
+  rows: WorkspaceHelpRow[]
 }
 
 /**
- * Keymap legend rendered by the help overlay (`?`). Sectionless flat
- * list so the overlay stays short — every binding fits in one screen
- * even on a 24-row terminal.
+ * Keymap legend rendered by the help overlay (`?`). Grouped into
+ * sections so users can scan by intent ("how do I navigate?" "how
+ * do I act?") rather than reading a flat alphabetized list.
+ *
+ * The view layer composes these into a panel with section titles,
+ * a leading app/title bar, and a closing hint at the bottom.
+ */
+export function buildWorkspaceHelpSections(): WorkspaceHelpSection[] {
+  return [
+    {
+      title: 'Navigate',
+      subtitle: 'Move the cursor and switch focus between panels.',
+      rows: [
+        { glyph: '↕', keys: 'j / k / ↑ / ↓', description: 'Move cursor up & down (list) · cycle tab (sidebar)' },
+        { glyph: '⇥', keys: 'tab / shift-tab', description: 'Toggle focus between sidebar and list' },
+        { glyph: '←', keys: 'h', description: 'Jump focus to the sidebar' },
+        { glyph: '→', keys: 'l', description: 'Jump focus to the list' },
+        { glyph: '⤒', keys: 'g / G', description: 'Jump to top / bottom of the list' },
+        { glyph: '↵', keys: 'enter', description: 'Drill into the cursored repo (coco ui)' },
+      ],
+    },
+    {
+      title: 'Filter & sort',
+      rows: [
+        { glyph: '/', keys: '/', description: 'Filter the list by name or branch' },
+        { glyph: '↑↓', keys: 's', description: 'Cycle sort mode (recency → name → dirty)' },
+      ],
+    },
+    {
+      title: 'Repos',
+      subtitle: 'Add, remove, and refresh the workspace inventory.',
+      rows: [
+        { glyph: '⟳', keys: 'r', description: 'Refresh all repos (discovery + PR counts)' },
+        { glyph: '⟲', keys: 'R', description: 'Refresh just the cursored repo (faster)' },
+        { glyph: '＋', keys: 'a', description: 'Add a repo via path prompt (tab-completes)' },
+        { glyph: '✕', keys: 'd', description: 'Remove the cursored repo from the known-repos store' },
+      ],
+    },
+    {
+      title: 'General',
+      rows: [
+        { glyph: '?', keys: '?', description: 'Toggle this help overlay' },
+        { glyph: '⎋', keys: 'esc', description: 'Clear filter / close overlay / cancel prompt' },
+        { glyph: '◴', keys: 'q · ctrl+c', description: 'Quit the workspace surface' },
+      ],
+    },
+  ]
+}
+
+/**
+ * Flattened view of the keymap for tests + the global command palette.
+ * Returns every row across every section in display order.
  */
 export function buildWorkspaceHelpRows(): WorkspaceHelpRow[] {
-  return [
-    { keys: 'tab / shift-tab', description: 'Move focus between sidebar and list' },
-    { keys: 'j / ↓', description: 'List: move cursor down · Sidebar: next tab' },
-    { keys: 'k / ↑', description: 'List: move cursor up · Sidebar: previous tab' },
-    { keys: 'h / ←', description: 'List → sidebar focus' },
-    { keys: 'l / →', description: 'Sidebar → list focus (also enter)' },
-    { keys: 'g / G', description: 'List: jump to top / bottom' },
-    { keys: 'enter', description: 'List: drill into the cursored repo (coco ui)' },
-    { keys: 's', description: 'Cycle sort mode (recency → name → dirty)' },
-    { keys: 'r', description: 'Refresh discovery (all repos)' },
-    { keys: 'R', description: 'Refresh just the cursored repo (faster)' },
-    { keys: '/', description: 'Filter the list by name or branch' },
-    { keys: 'r', description: 'Refresh discovery' },
-    { keys: 'a', description: 'Add a repo via path prompt (tab-completes)' },
-    { keys: 'd', description: 'Remove the cursored repo from the known-repos store (y-confirm)' },
-    { keys: '?', description: 'Toggle this help overlay' },
-    { keys: 'esc', description: 'Clear filter or close overlay' },
-    { keys: 'q', description: 'Quit the workspace surface' },
-  ]
+  return buildWorkspaceHelpSections().flatMap((section) => section.rows)
 }
 
 export type WorkspaceOnboardingModel = {

--- a/src/workstation/surfaces/workspace/view.ts
+++ b/src/workstation/surfaces/workspace/view.ts
@@ -18,12 +18,13 @@ import {
   buildWorkspaceColumnHeaders,
   buildWorkspaceFooter,
   buildWorkspaceHeaderChips,
-  buildWorkspaceHelpRows,
+  buildWorkspaceHelpSections,
   buildWorkspaceListWindow,
   buildWorkspaceOnboarding,
   buildWorkspaceSidebar,
   shouldRailWorkspaceSidebar,
   type WorkspaceHeaderChip,
+  type WorkspaceHelpRow,
   type WorkspaceListColumn,
   type WorkspaceListRow,
 } from './render'
@@ -511,14 +512,117 @@ function renderListBody(
   )
 }
 
+function renderHelpRow(
+  deps: RenderWorkspaceAppDeps,
+  row: WorkspaceHelpRow,
+  glyphWidth: number,
+  keysWidth: number,
+  key: string
+): ReactTypes.ReactElement {
+  const { React, ink, theme } = deps
+  const { Box, Text } = ink
+  return React.createElement(
+    Box,
+    { key, flexDirection: 'row' },
+    React.createElement(
+      Box,
+      { width: glyphWidth, flexShrink: 0 },
+      React.createElement(
+        Text,
+        { color: theme.noColor ? undefined : theme.colors.accent, bold: true },
+        ` ${row.glyph ?? ' '} `
+      )
+    ),
+    React.createElement(
+      Box,
+      { width: keysWidth, flexShrink: 0 },
+      React.createElement(
+        Text,
+        { color: theme.noColor ? undefined : theme.colors.success, bold: true },
+        row.keys
+      )
+    ),
+    React.createElement(Text, null, row.description)
+  )
+}
+
 function renderHelpOverlay(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement | null {
   if (!deps.state.showHelp) {
     return null
   }
   const { React, ink, theme } = deps
   const { Box, Text } = ink
-  const rows = buildWorkspaceHelpRows()
-  const widest = rows.reduce((acc, row) => Math.max(acc, row.keys.length), 0)
+  const sections = buildWorkspaceHelpSections()
+  const allRows = sections.flatMap((section) => section.rows)
+  // Columns: glyph cell (4 cells) · keys (padded to longest) · description.
+  const glyphWidth = 4
+  const keysWidth = Math.max(
+    14,
+    allRows.reduce((acc, row) => Math.max(acc, row.keys.length), 0) + 4
+  )
+
+  const children: ReactTypes.ReactNode[] = []
+
+  // Title bar — accent-tinged, matches the chip-style header on the
+  // main surface so the help reads as the same app, just a different
+  // panel.
+  children.push(
+    React.createElement(
+      Box,
+      { key: 'title', flexDirection: 'row', justifyContent: 'space-between' },
+      React.createElement(
+        Box,
+        { key: 'title-left', flexDirection: 'row' },
+        React.createElement(
+          Text,
+          { bold: true, color: theme.noColor ? undefined : theme.colors.accent },
+          ' ?  coco workspace'
+        ),
+        React.createElement(Text, { dimColor: true }, '  keymap · '),
+        React.createElement(Text, { dimColor: true }, `${allRows.length} bindings`)
+      ),
+      React.createElement(
+        Text,
+        { dimColor: true },
+        'esc / ? to close '
+      )
+    )
+  )
+  children.push(React.createElement(Text, { key: 'title-sep', dimColor: true }, ''))
+
+  // Sections — each gets a title in accent, optional subtitle dim,
+  // then its rows, then a blank line.
+  sections.forEach((section, sIndex) => {
+    children.push(
+      React.createElement(
+        Text,
+        {
+          key: `section-${sIndex}-title`,
+          bold: true,
+          color: theme.noColor ? undefined : theme.colors.muted,
+        },
+        section.title.toUpperCase()
+      )
+    )
+    if (section.subtitle) {
+      children.push(
+        React.createElement(
+          Text,
+          { key: `section-${sIndex}-subtitle`, dimColor: true },
+          ` ${section.subtitle}`
+        )
+      )
+    }
+    section.rows.forEach((row, rIndex) => {
+      children.push(
+        renderHelpRow(deps, row, glyphWidth, keysWidth, `row-${sIndex}-${rIndex}`)
+      )
+    })
+    if (sIndex < sections.length - 1) {
+      children.push(React.createElement(Text, { key: `section-${sIndex}-spacer` }, ''))
+    }
+  })
+
   return React.createElement(
     Box,
     {
@@ -527,24 +631,7 @@ function renderHelpOverlay(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElemen
       flexDirection: 'column',
       paddingX: 1,
     },
-    React.createElement(Text, { bold: true }, 'Workspace keymap'),
-    ...rows.map((row, index) =>
-      React.createElement(
-        Box,
-        { key: index, flexDirection: 'row' },
-        React.createElement(
-          Text,
-          { color: toneColor('ok', theme) },
-          row.keys.padEnd(widest + 2)
-        ),
-        React.createElement(Text, null, row.description)
-      )
-    ),
-    React.createElement(
-      Text,
-      { dimColor: true },
-      'esc / ? / q close · auto-refresh disabled while help is open'
-    )
+    ...children
   )
 }
 


### PR DESCRIPTION
Two related polish moves.

## 1. Trim the footer to forgettable actions only

Self-evident bindings (j/k, arrows, Enter, Tab) come out of the footer. They're still in the global \`?\` help so nothing is hidden — just decluttered.

\`\`\`
before: j/k move · enter open · tab → sidebar · s sort ·
        / filter · r/R refresh · a add · d remove · ? help · q quit
after:  s sort · / filter · r/R refresh · a add · d remove ·
        ? help · q quit
\`\`\`

Sidebar focus footer simplifies to \`? help · q quit\` since j/k/enter/tab cycling the panels is intuitive once you've discovered Tab. Filter copy tightens to \`type to filter · enter apply · esc cancel\`.

## 2. Help overlay grouped into sections

Replaces the flat keymap list with four titled sections:

- **NAVIGATE** — Move the cursor and switch focus between panels.
- **FILTER & SORT**
- **REPOS** — Add, remove, and refresh the workspace inventory.
- **GENERAL**

Each row gets a leading glyph (\`↕ ⇥ ← → ⤒ ↵ / ↑↓ ⟳ ⟲ ＋ ✕ ? ⎋ ◴\`), keys in success/accent color, then the description. Panel header reads \`?  coco workspace  keymap · N bindings\` with \`esc / ? to close\` on the right. Section titles render in muted uppercase to feel like chapter markers.

## Test plan

- [x] Lint clean
- [x] Full Jest suite: 188 suites, 2414 passing, 33 snapshots