### PR TITLE
chore(workspace): dedupe util, drop dead exports, tighten tests + comments

### DIFF
--- a/src/git/workspaceData.ts
+++ b/src/git/workspaceData.ts
@@ -3,6 +3,8 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import simpleGit, { SimpleGit } from 'simple-git'
 
+import { mapWithConcurrency } from '../lib/utils/mapWithConcurrency'
+
 const FIELD_SEPARATOR = '\x1f'
 
 /**
@@ -368,23 +370,6 @@ export type GetWorkspaceOverviewOptions = WorkspaceDiscoveryOptions & {
 }
 
 const DEFAULT_CONCURRENCY = 8
-
-async function mapWithConcurrency<T, U>(
-  inputs: ReadonlyArray<T>,
-  limit: number,
-  fn: (input: T) => Promise<U>
-): Promise<U[]> {
-  const results: U[] = []
-  let cursor = 0
-  const workers = Array.from({ length: Math.min(limit, inputs.length) }, async () => {
-    while (cursor < inputs.length) {
-      const idx = cursor++
-      results[idx] = await fn(inputs[idx])
-    }
-  })
-  await Promise.all(workers)
-  return results
-}
 
 export async function getWorkspaceOverview(
   roots: ReadonlyArray<string>,

--- a/src/git/workspacePullRequestData.test.ts
+++ b/src/git/workspacePullRequestData.test.ts
@@ -108,6 +108,26 @@ describe('getWorkspacePullRequestCounts', () => {
     expect(result).toBe('[]')
   })
 
+  it('runGhWithTimeout swallows a post-abort runner rejection', async () => {
+    // After timeout aborts the signal, the runner may still reject
+    // with the abort reason. That late rejection must not surface as
+    // an unhandled rejection — the helper's `try { … } catch {}`
+    // should absorb it and the overall result stays `undefined`.
+    let abortReject!: () => void
+    const runner = jest.fn(async (_args: string[], opts?: { signal?: AbortSignal }) => {
+      return new Promise<string>((_, reject) => {
+        abortReject = () => reject(new Error('AbortError'))
+        opts?.signal?.addEventListener('abort', abortReject)
+      })
+    })
+    const result = await runGhWithTimeout(runner, ['pr', 'list'], 10)
+    expect(result).toBeUndefined()
+    // Now imagine the runner's promise was still pending when the
+    // timeout fired — give it one more microtask to reject and
+    // ensure nothing else throws.
+    await new Promise((resolve) => setImmediate(resolve))
+  })
+
   it('issues one gh pr list per repo with a GitHub remote and records the count', async () => {
     const remoteUrls = new Map<string, string>([
       ['/tmp/repo-a', 'git@github.com:owner/repo-a.git'],

--- a/src/git/workspacePullRequestData.ts
+++ b/src/git/workspacePullRequestData.ts
@@ -1,6 +1,8 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 
+import { mapWithConcurrency } from '../lib/utils/mapWithConcurrency'
+
 import {
   defaultGhRunner,
   isGhAuthenticated,
@@ -173,23 +175,6 @@ export type GetWorkspacePullRequestCountsOptions = {
    * row's data lands, rather than waiting for the whole batch.
    */
   onRepoComplete?: (repoPath: string, count: number | undefined) => void
-}
-
-async function mapWithConcurrency<T, U>(
-  inputs: ReadonlyArray<T>,
-  limit: number,
-  fn: (input: T) => Promise<U>
-): Promise<U[]> {
-  const results: U[] = []
-  let cursor = 0
-  const workers = Array.from({ length: Math.min(limit, inputs.length) }, async () => {
-    while (cursor < inputs.length) {
-      const idx = cursor++
-      results[idx] = await fn(inputs[idx])
-    }
-  })
-  await Promise.all(workers)
-  return results
 }
 
 export async function getWorkspacePullRequestCounts(

--- a/src/lib/utils/mapWithConcurrency.test.ts
+++ b/src/lib/utils/mapWithConcurrency.test.ts
@@ -1,0 +1,42 @@
+import { mapWithConcurrency } from './mapWithConcurrency'
+
+describe('mapWithConcurrency', () => {
+  it('runs every input through fn and preserves order', async () => {
+    const result = await mapWithConcurrency([1, 2, 3, 4, 5], 2, async (n) => n * 10)
+    expect(result).toEqual([10, 20, 30, 40, 50])
+  })
+
+  it('respects the concurrency limit', async () => {
+    let active = 0
+    let peak = 0
+    const inputs = Array.from({ length: 12 }, (_, i) => i)
+    await mapWithConcurrency(inputs, 3, async (n) => {
+      active += 1
+      peak = Math.max(peak, active)
+      await new Promise((resolve) => setTimeout(resolve, 1))
+      active -= 1
+      return n
+    })
+    expect(peak).toBeLessThanOrEqual(3)
+  })
+
+  it('handles empty input without spawning workers', async () => {
+    const fn = jest.fn()
+    const result = await mapWithConcurrency<number, number>([], 4, fn)
+    expect(result).toEqual([])
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('propagates rejections from any worker', async () => {
+    const fn = async (n: number) => {
+      if (n === 2) throw new Error('boom')
+      return n
+    }
+    await expect(mapWithConcurrency([1, 2, 3], 2, fn)).rejects.toThrow('boom')
+  })
+
+  it('clamps the worker pool when limit > inputs.length', async () => {
+    const result = await mapWithConcurrency([1, 2], 100, async (n) => n)
+    expect(result).toEqual([1, 2])
+  })
+})

--- a/src/lib/utils/mapWithConcurrency.ts
+++ b/src/lib/utils/mapWithConcurrency.ts
@@ -1,0 +1,28 @@
+/**
+ * Run `fn` over each input with at most `limit` workers in flight.
+ * Preserves result order (results[i] corresponds to inputs[i]).
+ *
+ * Used by anywhere we want bounded-parallelism over a collection —
+ * batches of `gh` calls, batches of `git` calls in the workspace
+ * discovery loader, etc. Keeps the call-site free of manual queue
+ * bookkeeping.
+ */
+export async function mapWithConcurrency<T, U>(
+  inputs: ReadonlyArray<T>,
+  limit: number,
+  fn: (input: T) => Promise<U>
+): Promise<U[]> {
+  const results: U[] = []
+  let cursor = 0
+  const workers = Array.from(
+    { length: Math.min(limit, inputs.length) },
+    async () => {
+      while (cursor < inputs.length) {
+        const idx = cursor++
+        results[idx] = await fn(inputs[idx])
+      }
+    }
+  )
+  await Promise.all(workers)
+  return results
+}

--- a/src/workstation/surfaces/workspace/filter.ts
+++ b/src/workstation/surfaces/workspace/filter.ts
@@ -27,6 +27,11 @@ const TAB_LABELS: Record<WorkspaceTab, string> = {
  * Used in two places: as a label prefix in the expanded sidebar,
  * and as the standalone icon when the sidebar is rail-collapsed at
  * narrow terminal widths.
+ *
+ * ASCII fallback isn't wired through yet — none of these glyphs
+ * affect layout (they're width-1), so even on `TERM=dumb` they
+ * render as best the terminal can. Add a `theme.ascii`-aware lookup
+ * here if we hit a real environment where the unicode breaks.
  */
 const TAB_GLYPHS: Record<WorkspaceTab, string> = {
   all: '◯',
@@ -35,19 +40,12 @@ const TAB_GLYPHS: Record<WorkspaceTab, string> = {
   'pull-requests': '⊙',
 }
 
-const TAB_GLYPHS_ASCII: Record<WorkspaceTab, string> = {
-  all: 'o',
-  dirty: '*',
-  behind: 'v',
-  'pull-requests': '@',
-}
-
 export function workspaceTabLabel(tab: WorkspaceTab): string {
   return TAB_LABELS[tab]
 }
 
-export function workspaceTabGlyph(tab: WorkspaceTab, ascii = false): string {
-  return ascii ? TAB_GLYPHS_ASCII[tab] : TAB_GLYPHS[tab]
+export function workspaceTabGlyph(tab: WorkspaceTab): string {
+  return TAB_GLYPHS[tab]
 }
 
 export function nextWorkspaceTab(current: WorkspaceTab): WorkspaceTab {

--- a/src/workstation/surfaces/workspace/index.ts
+++ b/src/workstation/surfaces/workspace/index.ts
@@ -1,31 +1,20 @@
+/**
+ * Public API for the workspace surface. Anything **not** re-exported
+ * here is implementation detail — tests can still import the deep
+ * paths, but external consumers (the command handler, the rest of
+ * coco) go through this barrel.
+ *
+ * Keep this list minimal. Each entry is something an outside caller
+ * actually uses. Internal helpers stay reachable via `./render`,
+ * `./state`, etc. for tests + sibling modules.
+ */
 export {
   startWorkspace,
   type WorkspaceExitResult,
   type WorkspaceResumeState,
   type WorkspaceStartOptions,
 } from './runtime'
-export { resolveWorkspaceInput, type WorkspaceInputIntent, type WorkspaceInputKey } from './input'
-export {
-  applyWorkspaceAction,
-  createWorkspaceState,
-  selectFocusedRepo,
-  selectVisibleRepos,
-  type WorkspaceAction,
-  type WorkspaceState,
-} from './state'
-export {
-  buildWorkspaceFooter,
-  buildWorkspaceHeader,
-  buildWorkspaceListRows,
-  buildWorkspaceSidebar,
-} from './render'
-export {
-  WORKSPACE_SORT_MODES,
-  workspaceSortLabel,
-  type WorkspaceSortMode,
-} from './sort'
-export {
-  WORKSPACE_TABS,
-  workspaceTabLabel,
-  type WorkspaceTab,
-} from './filter'
+
+export type { WorkspaceState } from './state'
+export type { WorkspaceSortMode } from './sort'
+export type { WorkspaceTab } from './filter'

--- a/src/workstation/surfaces/workspace/input.ts
+++ b/src/workstation/surfaces/workspace/input.ts
@@ -165,10 +165,12 @@ export function resolveWorkspaceInput(
     if (key.pageUp) {
       return { kind: 'action', action: { type: 'move-cursor', delta: -10 } }
     }
-    if (input === 'g' && !key.shift) {
+    // Shells deliver Shift+g as the raw byte 'G' (no shift flag),
+    // so a single literal match is enough — no need for `g + shift`.
+    if (input === 'g') {
       return { kind: 'action', action: { type: 'set-cursor', index: 0 } }
     }
-    if (input === 'G' || (input === 'g' && key.shift)) {
+    if (input === 'G') {
       return { kind: 'action', action: { type: 'set-cursor', index: Number.MAX_SAFE_INTEGER } }
     }
     if (input === 'h' || key.leftArrow) {

--- a/src/workstation/surfaces/workspace/render.ts
+++ b/src/workstation/surfaces/workspace/render.ts
@@ -6,10 +6,7 @@ import {
   WORKSPACE_TABS,
   type WorkspaceTab,
 } from './filter'
-import {
-  workspaceSortLabel,
-  type WorkspaceSortMode,
-} from './sort'
+import { workspaceSortLabel } from './sort'
 import { selectVisibleRepos, type WorkspaceState } from './state'
 
 /**
@@ -628,14 +625,6 @@ export function buildWorkspaceFooter(state: WorkspaceState): WorkspaceFooterMode
     hint: hintFor(state.focus),
     status: state.status,
     filterMode: state.focus === 'filter',
-  }
-}
-
-export function describeSortModesForLegend(): Record<WorkspaceSortMode, string> {
-  return {
-    recency: 'Most-recent commit first',
-    name: 'Alphabetical',
-    dirty: 'Most working-tree changes first',
   }
 }
 

--- a/src/workstation/surfaces/workspace/runtime.test.ts
+++ b/src/workstation/surfaces/workspace/runtime.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Tests for the pure helpers exported by `runtime.ts`. The React
+ * component (`WorkspaceInkApp`) is exercised indirectly through
+ * `view.test.ts` snapshots; this file just covers the data utilities
+ * that the runtime exports.
+ */
+
+import { mergeKnownRepos } from './runtime'
+
+describe('mergeKnownRepos', () => {
+  it('combines config + cached entries and de-dupes', () => {
+    expect(mergeKnownRepos(['/a', '/b'], ['/c'])).toEqual(['/a', '/b', '/c'])
+  })
+
+  it('keeps config-first precedence for overlapping entries', () => {
+    // Both lists contain `/shared`. The merged result lists `/shared`
+    // exactly once, in the position the config supplied — so any
+    // future ordering-aware consumer (e.g. "first match wins")
+    // observes the config entry, not the cached one.
+    expect(mergeKnownRepos(['/shared', '/config-only'], ['/cache-only', '/shared'])).toEqual([
+      '/shared',
+      '/config-only',
+      '/cache-only',
+    ])
+  })
+
+  it('returns an empty list when both inputs are empty', () => {
+    expect(mergeKnownRepos([], [])).toEqual([])
+  })
+
+  it('treats config as the canonical source — its order survives', () => {
+    expect(mergeKnownRepos(['/b', '/a'], ['/a', '/b'])).toEqual(['/b', '/a'])
+  })
+})

--- a/src/workstation/surfaces/workspace/runtime.ts
+++ b/src/workstation/surfaces/workspace/runtime.ts
@@ -76,6 +76,18 @@ import {
 import { isGitWorkingTree } from '../../../git/workspaceData'
 
 type DynamicImport = <T>(specifier: string) => Promise<T>
+/**
+ * `import()` smuggle. ts-jest's CJS transform downgrades a bare
+ * `await import(spec)` into `require(spec)`, which fails for the
+ * ESM-only `ink` / `react` packages with "A dynamic import callback
+ * was invoked without --experimental-vm-modules". Wrapping the
+ * import in a `new Function('return import(...)')` body keeps the
+ * import expression as a string at compile time — the runtime then
+ * eval-parses it as native ESM dynamic import.
+ *
+ * Same trick `src/commands/log/inkRuntime.ts` uses; documented in
+ * `src/workstation/README.md`.
+ */
 const dynamicImport = new Function('specifier', 'return import(specifier)') as DynamicImport
 
 export type WorkspaceInkRuntime = {


### PR DESCRIPTION
Audit follow-up (tier 1) — cleanup + test backfill.

## What's in

**Dedupe \`mapWithConcurrency\`** (item #2 on the audit). Identical 17-line implementations lived in \`src/git/workspaceData.ts\` AND \`src/git/workspacePullRequestData.ts\`. Now lives at \`src/lib/utils/mapWithConcurrency.ts\` with its own tests (5 cases: empty input, concurrency cap, propagation, error path, clamp).

**Drop dead exports** (item #5):
- \`describeSortModesForLegend\` — zero callers, deleted.
- \`workspaceTabGlyph(ascii=true)\` — no caller passed ascii; helper takes one arg now.
- The workspace surface's \`./index.ts\` barrel now exports only what's used outside the surface module (\`startWorkspace\` + three state/type re-exports). Tests + sibling modules still reach internals via direct paths.

**Drop unreachable input branches** (item #6). \`input.ts\` had \`(input === 'g' && key.shift)\` separate from \`input === 'G'\`. Terminals deliver Shift+g as the raw byte \`G\` with shift=false — the conjunction never fires. Simplified to literal-only matches.

**Stale comment fix** (item #6). \`runtime.ts:78\` \`dynamicImport = new Function(…)\` is now documented inline so future readers know why we smuggle \`import()\` through a \`new Function\` body.

**Test backfill** (item #7):
- New \`runtime.test.ts\` pins \`mergeKnownRepos\` precedence: config wins, dedupe preserves order.
- New \`runGhWithTimeout\` test pins the post-abort runner-rejection path so a late reject can't surface as an unhandled promise.

## Test plan

- [x] Lint + typecheck clean
- [x] Full Jest suite: 190 suites, 2424 passing, 33 snapshots
- [x] No behavior change (no snapshot drift)