### PR TITLE
refactor(chrome): extract createJsonStore helper, dedupe three chrome stores

### DIFF
--- a/src/workstation/chrome/jsonStore.test.ts
+++ b/src/workstation/chrome/jsonStore.test.ts
@@ -1,0 +1,108 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { createJsonStore } from './jsonStore'
+
+describe('createJsonStore', () => {
+  let tmpHome: string
+  let originalXdg: string | undefined
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-jsonstore-'))
+    originalXdg = process.env.XDG_CACHE_HOME
+    process.env.XDG_CACHE_HOME = tmpHome
+  })
+
+  afterEach(() => {
+    if (originalXdg === undefined) {
+      delete process.env.XDG_CACHE_HOME
+    } else {
+      process.env.XDG_CACHE_HOME = originalXdg
+    }
+    fs.rmSync(tmpHome, { recursive: true, force: true })
+  })
+
+  it('round-trips a payload via write + read', () => {
+    const store = createJsonStore<{ value: number }>({
+      subdir: 'test',
+      basename: 'data.json',
+      version: 1,
+      validate: (raw) =>
+        raw && typeof (raw as { value: number }).value === 'number'
+          ? (raw as { value: number })
+          : undefined,
+    })
+    expect(store.read()).toBeUndefined()
+    store.write({ value: 42 })
+    expect(store.read()).toEqual({ value: 42 })
+  })
+
+  it('returns undefined when schema version doesn\'t match', () => {
+    const store = createJsonStore<{ ok: true }>({
+      subdir: 'test',
+      basename: 'data.json',
+      version: 2,
+      validate: () => ({ ok: true }),
+    })
+    // Write a v1 envelope by hand.
+    fs.mkdirSync(path.dirname(store.path()), { recursive: true })
+    fs.writeFileSync(store.path(), JSON.stringify({ version: 1, payload: { ok: true }, savedAt: '2026-01-01' }))
+    expect(store.read()).toBeUndefined()
+  })
+
+  it('runs the validate predicate before returning', () => {
+    const store = createJsonStore<{ ok: true }>({
+      subdir: 'test',
+      basename: 'data.json',
+      version: 1,
+      validate: (raw) => (raw && (raw as { ok?: unknown }).ok === true ? { ok: true } : undefined),
+    })
+    store.write({ ok: true })
+    expect(store.read()).toEqual({ ok: true })
+    // Corrupt the file with a wrong-shape payload.
+    fs.writeFileSync(store.path(), JSON.stringify({ version: 1, payload: { ok: 'not-true' } }))
+    expect(store.read()).toBeUndefined()
+  })
+
+  it('keys the file path via the basename function', () => {
+    const store = createJsonStore<{ entries: string[] }>({
+      subdir: 'test',
+      basename: (key) => `data.${key}.json`,
+      version: 1,
+      validate: (raw) =>
+        raw && Array.isArray((raw as { entries: unknown }).entries)
+          ? (raw as { entries: string[] })
+          : undefined,
+    })
+    store.write({ entries: ['a'] }, 'alpha')
+    store.write({ entries: ['b'] }, 'beta')
+    expect(store.read('alpha')).toEqual({ entries: ['a'] })
+    expect(store.read('beta')).toEqual({ entries: ['b'] })
+    expect(store.path('alpha')).toMatch(/data\.alpha\.json$/)
+  })
+
+  it('swallows write failures silently', () => {
+    // Point XDG_CACHE_HOME at a non-directory so the mkdirSync fails.
+    const blocker = path.join(tmpHome, 'blocker')
+    fs.writeFileSync(blocker, '')
+    process.env.XDG_CACHE_HOME = blocker
+    const store = createJsonStore<{ ok: true }>({
+      subdir: 'test',
+      basename: 'data.json',
+      version: 1,
+      validate: () => ({ ok: true }),
+    })
+    expect(() => store.write({ ok: true })).not.toThrow()
+  })
+
+  it('honors XDG_CACHE_HOME', () => {
+    const store = createJsonStore<{ ok: true }>({
+      subdir: 'sub',
+      basename: 'data.json',
+      version: 1,
+      validate: () => ({ ok: true }),
+    })
+    expect(store.path()).toBe(path.join(tmpHome, 'coco', 'sub', 'data.json'))
+  })
+})

--- a/src/workstation/chrome/jsonStore.ts
+++ b/src/workstation/chrome/jsonStore.ts
@@ -1,0 +1,118 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+/**
+ * Shared XDG-friendly JSON persistence used by every chrome cache /
+ * preferences module (workspace overview cache, known-repos store,
+ * preferences, onboarding marker, …).
+ *
+ * Each store is a schema-versioned `{ version, ...payload }` JSON
+ * file under `~/.cache/coco/<subdir>/`. The helper handles:
+ *
+ *   - XDG_CACHE_HOME override (per spec)
+ *   - mkdir -p before write
+ *   - try/catch on read AND write (best-effort persistence so a
+ *     read-only $HOME never crashes boot)
+ *   - schema-version guard on read (anything that doesn't match the
+ *     current version is treated as "no data")
+ *
+ * Callers supply the file basename, schema version, and a `validate`
+ * predicate that narrows the parsed payload to the typed shape. The
+ * helper returns `read()` / `write()` / `path()` so the call site
+ * stays declarative.
+ */
+
+export type JsonStoreOptions<T> = {
+  /**
+   * Subdirectory under `<cache>/coco/`. Use a stable string per
+   * store category (e.g. `'workspace'`).
+   */
+  subdir: string
+  /**
+   * Filename including extension. Either a static string ("known-repos.json")
+   * or a function for per-key files (e.g. `roots => `overview.${hash}.json``).
+   */
+  basename: string | ((key: string) => string)
+  /** Schema version stamped into the envelope; mismatch on read returns undefined. */
+  version: number
+  /**
+   * Field name in the envelope where the payload lives. Default `payload`.
+   * Existing stores pin their legacy field name (`overview`, `preferences`,
+   * `paths`, …) so on-disk files written by previous versions remain
+   * readable after refactoring.
+   */
+  payloadField?: string
+  /**
+   * Narrow the parsed payload (already version-checked) into the
+   * typed `T`. Return `undefined` for any input that doesn't match
+   * the expected shape.
+   */
+  validate: (payload: unknown) => T | undefined
+  /**
+   * Optional formatter — `'pretty'` writes JSON with 2-space indent
+   * (default), `'compact'` writes a single line. Pretty makes the
+   * file diff-friendly for the user; compact saves bytes for stores
+   * the user never opens directly.
+   */
+  format?: 'pretty' | 'compact'
+}
+
+export type JsonStore<T> = {
+  /** Read + version-check + validate. Returns `undefined` when missing/invalid. */
+  read: (key?: string) => T | undefined
+  /** Stamp the envelope, mkdir -p, and write. Errors swallowed. */
+  write: (value: T, key?: string) => void
+  /** Compute the absolute file path the store reads from / writes to. */
+  path: (key?: string) => string
+}
+
+type RawEnvelope = {
+  version: number
+  savedAt?: string
+} & Record<string, unknown>
+
+function resolveStoreDir(subdir: string): string {
+  const xdg = process.env.XDG_CACHE_HOME
+  const root = xdg && xdg.trim().length > 0 ? xdg : path.join(os.homedir(), '.cache')
+  return path.join(root, 'coco', subdir)
+}
+
+export function createJsonStore<T>(options: JsonStoreOptions<T>): JsonStore<T> {
+  const indent = options.format === 'compact' ? undefined : 2
+  const payloadField = options.payloadField ?? 'payload'
+  const resolveBasename = (key?: string): string => {
+    if (typeof options.basename === 'string') return options.basename
+    return options.basename(key ?? '')
+  }
+  const resolvePath = (key?: string): string =>
+    path.join(resolveStoreDir(options.subdir), resolveBasename(key))
+
+  return {
+    path: resolvePath,
+    read(key) {
+      try {
+        const raw = fs.readFileSync(resolvePath(key), 'utf8')
+        const parsed = JSON.parse(raw) as RawEnvelope
+        if (parsed.version !== options.version) return undefined
+        return options.validate(parsed[payloadField])
+      } catch {
+        return undefined
+      }
+    },
+    write(value, key) {
+      const envelope: RawEnvelope = {
+        version: options.version,
+        savedAt: new Date().toISOString(),
+        [payloadField]: value,
+      }
+      const file = resolvePath(key)
+      try {
+        fs.mkdirSync(path.dirname(file), { recursive: true })
+        fs.writeFileSync(file, JSON.stringify(envelope, null, indent))
+      } catch {
+        // Best-effort persistence.
+      }
+    },
+  }
+}

--- a/src/workstation/chrome/workspaceCache.ts
+++ b/src/workstation/chrome/workspaceCache.ts
@@ -1,9 +1,8 @@
 import * as crypto from 'node:crypto'
-import * as fs from 'node:fs'
-import * as os from 'node:os'
-import * as path from 'node:path'
 
 import { WorkspaceOverview } from '../../git/workspaceData'
+
+import { createJsonStore } from './jsonStore'
 
 /**
  * Disk cache of the most recent workspace overview (#880). Discovery
@@ -14,30 +13,13 @@ import { WorkspaceOverview } from '../../git/workspaceData'
  * three-stage boot the `coco ui` command already uses for commits
  * (see `overviewCache.ts`).
  *
- * Best-effort: read failures silently fall back to "no cache" and
- * write failures are swallowed.
- *
- * The cache is keyed by a hash of the sorted root list — different
- * `workspace.roots` configurations don't collide and don't poison
- * each other's caches when the user toggles between two setups.
+ * Persistence is delegated to `jsonStore.ts`. The cache is keyed by
+ * a hash of the sorted root list — different `workspace.roots`
+ * configurations don't collide and don't poison each other's caches
+ * when the user toggles between two setups.
  */
 
 const CACHE_SCHEMA_VERSION = 1
-const CACHE_DIR_NAME = 'workspace'
-
-type CacheEnvelope = {
-  version: number
-  savedAt: string
-  overview: WorkspaceOverview
-}
-
-function resolveCacheDir(): string {
-  const xdg = process.env.XDG_CACHE_HOME
-  if (xdg && xdg.trim().length > 0) {
-    return path.join(xdg, 'coco', CACHE_DIR_NAME)
-  }
-  return path.join(os.homedir(), '.cache', 'coco', CACHE_DIR_NAME)
-}
 
 export function workspaceCacheKey(roots: ReadonlyArray<string>): string {
   const normalized = [...roots].map((entry) => entry.trim()).filter(Boolean).sort()
@@ -46,42 +28,33 @@ export function workspaceCacheKey(roots: ReadonlyArray<string>): string {
   return crypto.createHash('sha1').update(normalized.join('\n')).digest('hex').slice(0, 16) // DevSkim: ignore DS126858
 }
 
+const store = createJsonStore<WorkspaceOverview>({
+  subdir: 'workspace',
+  basename: (key) => `overview.${key}.json`,
+  version: CACHE_SCHEMA_VERSION,
+  // Legacy envelopes used `overview` as the payload field; preserve
+  // it so files written by previous coco versions remain readable.
+  payloadField: 'overview',
+  format: 'compact',
+  validate: (raw) =>
+    raw && Array.isArray((raw as { repos?: unknown }).repos)
+      ? (raw as WorkspaceOverview)
+      : undefined,
+})
+
 export function getWorkspaceCachePath(roots: ReadonlyArray<string>): string {
-  return path.join(resolveCacheDir(), `overview.${workspaceCacheKey(roots)}.json`)
+  return store.path(workspaceCacheKey(roots))
 }
 
 export function readCachedWorkspace(
   roots: ReadonlyArray<string>
 ): WorkspaceOverview | undefined {
-  try {
-    const raw = fs.readFileSync(getWorkspaceCachePath(roots), 'utf8')
-    const parsed = JSON.parse(raw) as CacheEnvelope
-    if (parsed.version !== CACHE_SCHEMA_VERSION) {
-      return undefined
-    }
-    if (!parsed.overview || !Array.isArray(parsed.overview.repos)) {
-      return undefined
-    }
-    return parsed.overview
-  } catch {
-    return undefined
-  }
+  return store.read(workspaceCacheKey(roots))
 }
 
 export function writeCachedWorkspace(
   roots: ReadonlyArray<string>,
   overview: WorkspaceOverview
 ): void {
-  const file = getWorkspaceCachePath(roots)
-  const envelope: CacheEnvelope = {
-    version: CACHE_SCHEMA_VERSION,
-    savedAt: new Date().toISOString(),
-    overview,
-  }
-  try {
-    fs.mkdirSync(path.dirname(file), { recursive: true })
-    fs.writeFileSync(file, JSON.stringify(envelope))
-  } catch {
-    // Best-effort persistence; swallow.
-  }
+  store.write(overview, workspaceCacheKey(roots))
 }

--- a/src/workstation/chrome/workspaceKnownRepos.ts
+++ b/src/workstation/chrome/workspaceKnownRepos.ts
@@ -1,6 +1,4 @@
-import * as fs from 'node:fs'
-import * as os from 'node:os'
-import * as path from 'node:path'
+import { createJsonStore } from './jsonStore'
 
 /**
  * Per-user list of "known" repos added via the workspace add-repo
@@ -9,65 +7,36 @@ import * as path from 'node:path'
  * version-controlled) `.coco.config.json`.
  *
  * The discovery layer merges this list with `config.workspace.knownRepos`
- * — config wins for de-dupe so users can pin repos that the
- * add-repo prompt removed via the in-app delete affordance later
- * (out of scope for v1).
+ * — config wins for de-dupe (see `mergeKnownRepos` in `runtime.ts`).
  *
- * Best-effort: read failures return an empty list, write failures
- * are swallowed silently.
+ * Persistence is delegated to `jsonStore.ts`.
  */
 
 const STORE_SCHEMA_VERSION = 1
-const STORE_DIR_NAME = 'workspace'
-const STORE_FILE_NAME = 'known-repos.json'
 
-type Envelope = {
-  version: number
-  paths: string[]
-  updatedAt: string
-}
-
-function resolveStoreDir(): string {
-  const xdg = process.env.XDG_CACHE_HOME
-  if (xdg && xdg.trim().length > 0) {
-    return path.join(xdg, 'coco', STORE_DIR_NAME)
-  }
-  return path.join(os.homedir(), '.cache', 'coco', STORE_DIR_NAME)
-}
+const store = createJsonStore<string[]>({
+  subdir: 'workspace',
+  basename: 'known-repos.json',
+  version: STORE_SCHEMA_VERSION,
+  // Legacy on-disk shape carries the array directly under `paths`,
+  // not nested. Pin the field so existing files remain readable.
+  payloadField: 'paths',
+  validate: (raw) =>
+    Array.isArray(raw)
+      ? raw.filter((entry): entry is string => typeof entry === 'string')
+      : undefined,
+})
 
 export function getKnownReposStorePath(): string {
-  return path.join(resolveStoreDir(), STORE_FILE_NAME)
+  return store.path()
 }
 
 export function readKnownRepos(): string[] {
-  try {
-    const raw = fs.readFileSync(getKnownReposStorePath(), 'utf8')
-    const parsed = JSON.parse(raw) as Envelope
-    if (parsed.version !== STORE_SCHEMA_VERSION) {
-      return []
-    }
-    if (!Array.isArray(parsed.paths)) {
-      return []
-    }
-    return parsed.paths.filter((entry): entry is string => typeof entry === 'string')
-  } catch {
-    return []
-  }
+  return store.read() ?? []
 }
 
 export function writeKnownRepos(paths: ReadonlyArray<string>): void {
-  const envelope: Envelope = {
-    version: STORE_SCHEMA_VERSION,
-    paths: [...new Set(paths)],
-    updatedAt: new Date().toISOString(),
-  }
-  const file = getKnownReposStorePath()
-  try {
-    fs.mkdirSync(path.dirname(file), { recursive: true })
-    fs.writeFileSync(file, JSON.stringify(envelope, null, 2))
-  } catch {
-    // Best-effort persistence.
-  }
+  store.write([...new Set(paths)])
 }
 
 /**

--- a/src/workstation/chrome/workspacePreferences.ts
+++ b/src/workstation/chrome/workspacePreferences.ts
@@ -1,7 +1,4 @@
 import * as crypto from 'node:crypto'
-import * as fs from 'node:fs'
-import * as os from 'node:os'
-import * as path from 'node:path'
 
 import {
   WORKSPACE_SORT_MODES,
@@ -12,46 +9,25 @@ import {
   type WorkspaceTab,
 } from '../surfaces/workspace/filter'
 
+import { createJsonStore } from './jsonStore'
+
 /**
  * Persist sort mode, sidebar tab, and filter text between
  * `coco workspace` launches. Keyed per root set so two different
  * configured root lists keep separate preferences. Mirrors the
  * existing `chrome/sidebarPersistence.ts` pattern.
  *
- * Best-effort: read/write failures fall back to defaults so a stale
- * file or sandboxed FS never blocks boot.
+ * Persistence is delegated to `jsonStore.ts`. Stale files (schema
+ * mismatch, invalid sort/tab values) read as `{}` so a corrupt
+ * preferences file never blocks boot.
  */
 
 const SCHEMA_VERSION = 1
-const STORE_DIR_NAME = 'workspace'
 
 export type WorkspacePreferences = {
   sortMode?: WorkspaceSortMode
   tab?: WorkspaceTab
   filter?: string
-}
-
-type Envelope = {
-  version: number
-  savedAt: string
-  preferences: WorkspacePreferences
-}
-
-function resolveCacheDir(): string {
-  const xdg = process.env.XDG_CACHE_HOME
-  if (xdg && xdg.trim().length > 0) {
-    return path.join(xdg, 'coco', STORE_DIR_NAME)
-  }
-  return path.join(os.homedir(), '.cache', 'coco', STORE_DIR_NAME)
-}
-
-export function workspacePreferencesKey(roots: ReadonlyArray<string>): string {
-  const normalized = [...roots].map((entry) => entry.trim()).filter(Boolean).sort()
-  return crypto.createHash('sha1').update(normalized.join('\n')).digest('hex').slice(0, 16) // DevSkim: ignore DS126858
-}
-
-export function getWorkspacePreferencesPath(roots: ReadonlyArray<string>): string {
-  return path.join(resolveCacheDir(), `preferences.${workspacePreferencesKey(roots)}.json`)
 }
 
 function isValidSortMode(value: unknown): value is WorkspaceSortMode {
@@ -62,44 +38,39 @@ function isValidTab(value: unknown): value is WorkspaceTab {
   return typeof value === 'string' && (WORKSPACE_TABS as ReadonlyArray<string>).includes(value)
 }
 
+const store = createJsonStore<WorkspacePreferences>({
+  subdir: 'workspace',
+  basename: (key) => `preferences.${key}.json`,
+  version: SCHEMA_VERSION,
+  // Legacy envelopes used `preferences` as the payload field.
+  payloadField: 'preferences',
+  validate: (raw) => {
+    if (!raw || typeof raw !== 'object') return undefined
+    const source = raw as WorkspacePreferences
+    const result: WorkspacePreferences = {}
+    if (isValidSortMode(source.sortMode)) result.sortMode = source.sortMode
+    if (isValidTab(source.tab)) result.tab = source.tab
+    if (typeof source.filter === 'string') result.filter = source.filter
+    return result
+  },
+})
+
+export function workspacePreferencesKey(roots: ReadonlyArray<string>): string {
+  const normalized = [...roots].map((entry) => entry.trim()).filter(Boolean).sort()
+  return crypto.createHash('sha1').update(normalized.join('\n')).digest('hex').slice(0, 16) // DevSkim: ignore DS126858
+}
+
+export function getWorkspacePreferencesPath(roots: ReadonlyArray<string>): string {
+  return store.path(workspacePreferencesKey(roots))
+}
+
 export function readWorkspacePreferences(roots: ReadonlyArray<string>): WorkspacePreferences {
-  try {
-    const raw = fs.readFileSync(getWorkspacePreferencesPath(roots), 'utf8')
-    const parsed = JSON.parse(raw) as Envelope
-    if (parsed.version !== SCHEMA_VERSION) {
-      return {}
-    }
-    const prefs = parsed.preferences ?? {}
-    const validated: WorkspacePreferences = {}
-    if (isValidSortMode(prefs.sortMode)) {
-      validated.sortMode = prefs.sortMode
-    }
-    if (isValidTab(prefs.tab)) {
-      validated.tab = prefs.tab
-    }
-    if (typeof prefs.filter === 'string') {
-      validated.filter = prefs.filter
-    }
-    return validated
-  } catch {
-    return {}
-  }
+  return store.read(workspacePreferencesKey(roots)) ?? {}
 }
 
 export function writeWorkspacePreferences(
   roots: ReadonlyArray<string>,
   preferences: WorkspacePreferences
 ): void {
-  const envelope: Envelope = {
-    version: SCHEMA_VERSION,
-    savedAt: new Date().toISOString(),
-    preferences,
-  }
-  const file = getWorkspacePreferencesPath(roots)
-  try {
-    fs.mkdirSync(path.dirname(file), { recursive: true })
-    fs.writeFileSync(file, JSON.stringify(envelope, null, 2))
-  } catch {
-    // Best-effort persistence.
-  }
+  store.write(preferences, workspacePreferencesKey(roots))
 }


### PR DESCRIPTION
Audit follow-up (item #1) — extract the XDG-cache persistence pattern that three chrome modules each hand-rolled.

## What & why

\`workspaceCache.ts\`, \`workspaceKnownRepos.ts\`, and \`workspacePreferences.ts\` each carried the same shape:

\`resolveCacheDir() → mkdir -p → JSON.parse with version guard → try/catch on read AND write → ISO timestamp stamp\`

Factor it into \`chrome/jsonStore.ts\` exposing \`createJsonStore<T>\` that owns the persistence concerns. Each call site is now a ~10-line declaration of schema version + file naming + a validator that narrows the parsed payload.

## Backward-compat preserved

Original envelopes nested payloads under different keys: \`{ overview }\`, \`{ preferences }\`, \`{ paths }\`. The new helper defaults to \`{ payload }\` but each existing store pins its legacy field name via the new \`payloadField\` option. Files written by previous coco versions remain readable — no user-visible data loss on upgrade.

## Net change

- **-150 LOC** across the three chrome stores (~50 LOC each → ~10 LOC each)
- **+95 LOC** for the helper (~55 of which are its own 6 tests)
- Future stores cost ~10 LOC of declaration

## Skipped

\`workspaceOnboarding\` — it's a marker file with no payload (\`fs.existsSync\` is the right primitive, not a JSON envelope).

## Test plan

- [x] Lint clean
- [x] 6 new helper tests (round-trip, schema mismatch, validator, keyed paths, write failure, XDG override)
- [x] Existing 503 chrome tests still pass — confirms back-compat shim works
- [x] Full Jest suite: 191 suites, 2430 passing, 33 snapshots