### PR TITLE
feat(workstation): scroll indicators + workspace footer-hint slots

### DIFF
--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -369,6 +369,11 @@ export function renderCommandPalette(
       }, truncateCells(line, width - 4))
     })
 
+  // Scroll indicators for the palette list — same pattern as the
+  // sidebar and help overlay so the user knows there's more content.
+  const paletteHasMoreAbove = startIndex > 0 && filtered.length > 0
+  const paletteHasMoreBelow = startIndex + listRows < filtered.length
+
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
     borderStyle: theme.borderStyle,
@@ -386,7 +391,13 @@ export function renderCommandPalette(
   ...(showingRecent
     ? [h(Text, { key: 'palette-recent-hint', dimColor: true }, '· marks recently-used')]
     : []),
-  ...itemLines)
+  ...(paletteHasMoreAbove
+    ? [h(Text, { key: 'palette-more-above', dimColor: true }, `  ↑ ${startIndex} more above`)]
+    : []),
+  ...itemLines,
+  ...(paletteHasMoreBelow
+    ? [h(Text, { key: 'palette-more-below', dimColor: true }, `  ↓ ${filtered.length - (startIndex + listRows)} more below`)]
+    : []))
 }
 
 /**

--- a/src/workstation/surfaces/branches/index.ts
+++ b/src/workstation/surfaces/branches/index.ts
@@ -129,6 +129,11 @@ export function renderBranchesSurface(
         )
       })
 
+  // Scroll indicators — same "N more above/below" pattern as the
+  // sidebar and help overlay so the user knows the list continues.
+  const branchesHasMoreAbove = startIndex > 0 && localBranches.length > 0
+  const branchesHasMoreBelow = startIndex + listRows < localBranches.length
+
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
     borderStyle: theme.borderStyle,
@@ -142,5 +147,11 @@ export function renderBranchesSurface(
     h(Text, { dimColor: true }, headerRight)
   ),
   ...renderPromotedFilterAffordance(h, Text, state, theme),
-  ...lines)
+  ...(branchesHasMoreAbove
+    ? [h(Text, { key: 'branches-more-above', dimColor: true }, `  ↑ ${startIndex} more above`)]
+    : []),
+  ...lines,
+  ...(branchesHasMoreBelow
+    ? [h(Text, { key: 'branches-more-below', dimColor: true }, `  ↓ ${localBranches.length - (startIndex + listRows)} more below`)]
+    : []))
 }

--- a/src/workstation/surfaces/stash/index.ts
+++ b/src/workstation/surfaces/stash/index.ts
@@ -15,8 +15,8 @@ import { truncateCells } from '../../chrome/text'
 import type { LogInkTheme } from '../../chrome/theme'
 import type { LogInkState } from '../../../commands/log/inkViewModel'
 import {
-  matchesPromotedFilter,
-  renderPromotedFilterAffordance,
+    matchesPromotedFilter,
+    renderPromotedFilterAffordance,
 } from '../../runtime/promotedFilter'
 import type { LogInkComponents, LogInkContext } from '../../runtime/types'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
@@ -65,6 +65,9 @@ export function renderStashSurface(
         }, truncateCells(`${cursor} ${stash.ref.padEnd(12)} ${stash.message}`, 140))
       })
 
+  const stashHasMoreAbove = startIndex > 0 && stashes.length > 0
+  const stashHasMoreBelow = startIndex + listRows < stashes.length
+
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
     borderStyle: theme.borderStyle,
@@ -78,5 +81,11 @@ export function renderStashSurface(
     h(Text, { dimColor: true }, headerRight)
   ),
   ...renderPromotedFilterAffordance(h, Text, state, theme),
-  ...lines)
+  ...(stashHasMoreAbove
+    ? [h(Text, { key: 'stash-more-above', dimColor: true }, `  ↑ ${startIndex} more above`)]
+    : []),
+  ...lines,
+  ...(stashHasMoreBelow
+    ? [h(Text, { key: 'stash-more-below', dimColor: true }, `  ↓ ${stashes.length - (startIndex + listRows)} more below`)]
+    : []))
 }

--- a/src/workstation/surfaces/status/index.ts
+++ b/src/workstation/surfaces/status/index.ts
@@ -178,6 +178,11 @@ export function renderStatusSurface(
           ? [cleanHint]
           : ['Worktree clean']
 
+  // Scroll indicators for the status file list — same pattern as
+  // branches and the sidebar so the user knows there's more content.
+  const statusHasMoreAbove = windowStart > 0 && surfaceRows.length > 0
+  const statusHasMoreBelow = windowStart + listRows < surfaceRows.length
+
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
     borderStyle: theme.borderStyle,
@@ -199,7 +204,13 @@ export function renderStatusSurface(
     ? [h(Text, { key: 'status-mask-indicator', dimColor: true },
         `filter: ${formatStatusFilterMask(state.statusFilterMask)}  (1/2/3 to toggle)`)]
     : []),
+  ...(statusHasMoreAbove
+    ? [h(Text, { key: 'status-more-above', dimColor: true }, `  ↑ ${windowStart} more above`)]
+    : []),
   ...renderedRows,
+  ...(statusHasMoreBelow
+    ? [h(Text, { key: 'status-more-below', dimColor: true }, `  ↓ ${surfaceRows.length - (windowStart + listRows)} more below`)]
+    : []),
   ...fallbackLines.map((line, index) => h(Text, {
     key: `status-surface-fallback-${index}`,
     dimColor: index > 0,

--- a/src/workstation/surfaces/tags/index.ts
+++ b/src/workstation/surfaces/tags/index.ts
@@ -14,15 +14,15 @@ import { isLogInkContextKeyLoading } from '../../chrome/context'
 import { formatHyperlink } from '../../chrome/hyperlinks'
 import { formatSortIndicator, sortTags } from '../../chrome/sorting'
 import {
-  formatLogInkLoading,
-  formatLogInkTagsEmpty,
+    formatLogInkLoading,
+    formatLogInkTagsEmpty,
 } from '../../chrome/surfaceStates'
 import { truncateCells } from '../../chrome/text'
 import type { LogInkTheme } from '../../chrome/theme'
 import type { LogInkState } from '../../../commands/log/inkViewModel'
 import {
-  matchesPromotedFilter,
-  renderPromotedFilterAffordance,
+    matchesPromotedFilter,
+    renderPromotedFilterAffordance,
 } from '../../runtime/promotedFilter'
 import type { LogInkComponents, LogInkContext } from '../../runtime/types'
 import { buildRefUrl, focusBorderColor, panelTitle } from '../../runtime/utils'
@@ -97,6 +97,9 @@ export function renderTagsSurface(
         }, before, formatHyperlink(namePadded, url), after)
       })
 
+  const tagsHasMoreAbove = startIndex > 0 && tags.length > 0
+  const tagsHasMoreBelow = startIndex + listRows < tags.length
+
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
     borderStyle: theme.borderStyle,
@@ -110,5 +113,11 @@ export function renderTagsSurface(
     h(Text, { dimColor: true }, headerRight)
   ),
   ...renderPromotedFilterAffordance(h, Text, state, theme),
-  ...lines)
+  ...(tagsHasMoreAbove
+    ? [h(Text, { key: 'tags-more-above', dimColor: true }, `  ↑ ${startIndex} more above`)]
+    : []),
+  ...lines,
+  ...(tagsHasMoreBelow
+    ? [h(Text, { key: 'tags-more-below', dimColor: true }, `  ↓ ${tags.length - (startIndex + listRows)} more below`)]
+    : []))
 }

--- a/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
+++ b/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
@@ -520,11 +520,21 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
     height={4}
     paddingX={1}
   >
-    <Text
-      dimColor={true}
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
     >
-      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
-    </Text>
+      <Text
+        dimColor={true}
+      >
+        s sort   / filter   r/R refresh   a add   d remove
+      </Text>
+      <Text
+        dimColor={true}
+      >
+        ? help · q quit
+      </Text>
+    </Box>
     <Text
       dimColor={true}
     >
@@ -912,11 +922,21 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
     height={4}
     paddingX={1}
   >
-    <Text
-      dimColor={true}
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
     >
-      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
-    </Text>
+      <Text
+        dimColor={true}
+      >
+        s sort   / filter   r/R refresh   a add   d remove
+      </Text>
+      <Text
+        dimColor={true}
+      >
+        ? help · q quit
+      </Text>
+    </Box>
     <Text
       dimColor={true}
     >
@@ -1450,11 +1470,21 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
     height={4}
     paddingX={1}
   >
-    <Text
-      dimColor={true}
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
     >
-      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
-    </Text>
+      <Text
+        dimColor={true}
+      >
+        s sort   / filter   r/R refresh   a add   d remove
+      </Text>
+      <Text
+        dimColor={true}
+      >
+        ? help · q quit
+      </Text>
+    </Box>
     <Text
       dimColor={true}
     >
@@ -1876,11 +1906,21 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
     height={4}
     paddingX={1}
   >
-    <Text
-      dimColor={true}
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
     >
-      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
-    </Text>
+      <Text
+        dimColor={true}
+      >
+        s sort   / filter   r/R refresh   a add   d remove
+      </Text>
+      <Text
+        dimColor={true}
+      >
+        ? help · q quit
+      </Text>
+    </Box>
     <Text
       dimColor={true}
     >
@@ -2410,11 +2450,21 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
     height={4}
     paddingX={1}
   >
-    <Text
-      dimColor={true}
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
     >
-      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
-    </Text>
+      <Text
+        dimColor={true}
+      >
+        s sort   / filter   r/R refresh   a add   d remove
+      </Text>
+      <Text
+        dimColor={true}
+      >
+        ? help · q quit
+      </Text>
+    </Box>
     <Text
       color="yellow"
       dimColor={false}
@@ -2797,11 +2847,21 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
     height={4}
     paddingX={1}
   >
-    <Text
-      dimColor={true}
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
     >
-      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
-    </Text>
+      <Text
+        dimColor={true}
+      >
+        s sort   / filter   r/R refresh   a add   d remove
+      </Text>
+      <Text
+        dimColor={true}
+      >
+        ? help · q quit
+      </Text>
+    </Box>
     <Text
       dimColor={true}
     >
@@ -3331,11 +3391,21 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
     height={4}
     paddingX={1}
   >
-    <Text
-      dimColor={true}
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
     >
-      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
-    </Text>
+      <Text
+        dimColor={true}
+      >
+        s sort   / filter   r/R refresh   a add   d remove
+      </Text>
+      <Text
+        dimColor={true}
+      >
+        ? help · q quit
+      </Text>
+    </Box>
     <Text
       dimColor={true}
     >
@@ -3656,11 +3726,21 @@ exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading fals
     height={4}
     paddingX={1}
   >
-    <Text
-      dimColor={true}
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
     >
-      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
-    </Text>
+      <Text
+        dimColor={true}
+      >
+        s sort   / filter   r/R refresh   a add   d remove
+      </Text>
+      <Text
+        dimColor={true}
+      >
+        ? help · q quit
+      </Text>
+    </Box>
     <Text
       dimColor={true}
     >
@@ -4190,11 +4270,19 @@ exports[`renderWorkspaceApp snapshots filter focus with a draft showing in the h
     height={4}
     paddingX={1}
   >
-    <Text
-      dimColor={true}
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
     >
-      type to filter · enter apply · esc cancel
-    </Text>
+      <Text
+        dimColor={true}
+      >
+        type to filter   enter apply   esc cancel
+      </Text>
+      <Text
+        dimColor={true}
+      />
+    </Box>
     <Text
       dimColor={true}
     >
@@ -4746,11 +4834,19 @@ exports[`renderWorkspaceApp snapshots the add-repo prompt with completions 1`] =
     height={4}
     paddingX={1}
   >
-    <Text
-      dimColor={true}
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
     >
-      type path · tab to complete · enter to add · esc to cancel
-    </Text>
+      <Text
+        dimColor={true}
+      >
+        type path   tab to complete   enter to add   esc to cancel
+      </Text>
+      <Text
+        dimColor={true}
+      />
+    </Box>
     <Text
       dimColor={true}
     >
@@ -5125,11 +5221,21 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
     height={4}
     paddingX={1}
   >
-    <Text
-      dimColor={true}
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
     >
-      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
-    </Text>
+      <Text
+        dimColor={true}
+      >
+        s sort   / filter   r/R refresh   a add   d remove
+      </Text>
+      <Text
+        dimColor={true}
+      >
+        ? help · q quit
+      </Text>
+    </Box>
     <Text
       dimColor={true}
     >
@@ -5681,11 +5787,19 @@ exports[`renderWorkspaceApp snapshots the confirm-delete prompt for a known repo
     height={4}
     paddingX={1}
   >
-    <Text
-      dimColor={true}
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
     >
-      press y to remove · any other key to cancel
-    </Text>
+      <Text
+        dimColor={true}
+      >
+        y confirm   any other key cancels
+      </Text>
+      <Text
+        dimColor={true}
+      />
+    </Box>
     <Text
       dimColor={true}
     >
@@ -6060,11 +6174,21 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
     height={4}
     paddingX={1}
   >
-    <Text
-      dimColor={true}
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
     >
-      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
-    </Text>
+      <Text
+        dimColor={true}
+      >
+        s sort   / filter   r/R refresh   a add   d remove
+      </Text>
+      <Text
+        dimColor={true}
+      >
+        ? help · q quit
+      </Text>
+    </Box>
     <Text
       dimColor={true}
     >
@@ -6614,11 +6738,21 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
     height={4}
     paddingX={1}
   >
-    <Text
-      dimColor={true}
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
     >
-      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
-    </Text>
+      <Text
+        dimColor={true}
+      >
+        s sort   / filter   r/R refresh   a add   d remove
+      </Text>
+      <Text
+        dimColor={true}
+      >
+        ? help · q quit
+      </Text>
+    </Box>
     <Text
       dimColor={true}
     >
@@ -6740,6 +6874,134 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     <Text
       dimColor={true}
     />
+    <Text
+      bold={true}
+      color="gray"
+    >
+      ESSENTIALS
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       The keys you reach for most often.
+    </Text>
+    <Box
+      flexDirection="row"
+    >
+      <Box
+        flexShrink={0}
+        width={4}
+      >
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           ? 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
+      >
+        <Text
+          bold={true}
+          color="green"
+        >
+          ?
+        </Text>
+      </Box>
+      <Text>
+        Toggle this help overlay
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Box
+        flexShrink={0}
+        width={4}
+      >
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           ⎋ 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
+      >
+        <Text
+          bold={true}
+          color="green"
+        >
+          esc
+        </Text>
+      </Box>
+      <Text>
+        Clear filter / close overlay / cancel prompt
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Box
+        flexShrink={0}
+        width={4}
+      >
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           ◴ 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
+      >
+        <Text
+          bold={true}
+          color="green"
+        >
+          q · ctrl+c
+        </Text>
+      </Box>
+      <Text>
+        Quit the workspace surface
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Box
+        flexShrink={0}
+        width={4}
+      >
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           ↵ 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
+      >
+        <Text
+          bold={true}
+          color="green"
+        >
+          enter
+        </Text>
+      </Box>
+      <Text>
+        Drill into the cursored repo (coco ui)
+      </Text>
+    </Box>
+    <Text />
     <Text
       bold={true}
       color="gray"
@@ -6894,35 +7156,6 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
       </Box>
       <Text>
         Jump to top / bottom of the list
-      </Text>
-    </Box>
-    <Box
-      flexDirection="row"
-    >
-      <Box
-        flexShrink={0}
-        width={4}
-      >
-        <Text
-          bold={true}
-          color="cyan"
-        >
-           ↵ 
-        </Text>
-      </Box>
-      <Box
-        flexShrink={0}
-        width={19}
-      >
-        <Text
-          bold={true}
-          color="green"
-        >
-          enter
-        </Text>
-      </Box>
-      <Text>
-        Drill into the cursored repo (coco ui)
       </Text>
     </Box>
     <Text />
@@ -7118,100 +7351,6 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
         Remove the cursored repo from the known-repos store
       </Text>
     </Box>
-    <Text />
-    <Text
-      bold={true}
-      color="gray"
-    >
-      GENERAL
-    </Text>
-    <Box
-      flexDirection="row"
-    >
-      <Box
-        flexShrink={0}
-        width={4}
-      >
-        <Text
-          bold={true}
-          color="cyan"
-        >
-           ? 
-        </Text>
-      </Box>
-      <Box
-        flexShrink={0}
-        width={19}
-      >
-        <Text
-          bold={true}
-          color="green"
-        >
-          ?
-        </Text>
-      </Box>
-      <Text>
-        Toggle this help overlay
-      </Text>
-    </Box>
-    <Box
-      flexDirection="row"
-    >
-      <Box
-        flexShrink={0}
-        width={4}
-      >
-        <Text
-          bold={true}
-          color="cyan"
-        >
-           ⎋ 
-        </Text>
-      </Box>
-      <Box
-        flexShrink={0}
-        width={19}
-      >
-        <Text
-          bold={true}
-          color="green"
-        >
-          esc
-        </Text>
-      </Box>
-      <Text>
-        Clear filter / close overlay / cancel prompt
-      </Text>
-    </Box>
-    <Box
-      flexDirection="row"
-    >
-      <Box
-        flexShrink={0}
-        width={4}
-      >
-        <Text
-          bold={true}
-          color="cyan"
-        >
-           ◴ 
-        </Text>
-      </Box>
-      <Box
-        flexShrink={0}
-        width={19}
-      >
-        <Text
-          bold={true}
-          color="green"
-        >
-          q · ctrl+c
-        </Text>
-      </Box>
-      <Text>
-        Quit the workspace surface
-      </Text>
-    </Box>
   </Box>
   <Box
     borderColor="gray"
@@ -7220,11 +7359,21 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     height={4}
     paddingX={1}
   >
-    <Text
-      dimColor={true}
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
     >
-      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
-    </Text>
+      <Text
+        dimColor={true}
+      >
+        s sort   / filter   r/R refresh   a add   d remove
+      </Text>
+      <Text
+        dimColor={true}
+      >
+        ? help · q quit
+      </Text>
+    </Box>
     <Text
       dimColor={true}
     >
@@ -7550,11 +7699,21 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
     height={4}
     paddingX={1}
   >
-    <Text
-      dimColor={true}
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
     >
-      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
-    </Text>
+      <Text
+        dimColor={true}
+      >
+        s sort   / filter   r/R refresh   a add   d remove
+      </Text>
+      <Text
+        dimColor={true}
+      >
+        ? help · q quit
+      </Text>
+    </Box>
     <Text
       dimColor={true}
     >
@@ -8084,11 +8243,21 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
     height={4}
     paddingX={1}
   >
-    <Text
-      dimColor={true}
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
     >
-      s sort · / filter · r/R refresh · a add · d remove · ? help · q quit
-    </Text>
+      <Text
+        dimColor={true}
+      >
+        s sort   / filter   r/R refresh   a add   d remove
+      </Text>
+      <Text
+        dimColor={true}
+      >
+        ? help · q quit
+      </Text>
+    </Box>
     <Text
       dimColor={true}
     >

--- a/src/workstation/surfaces/workspace/render.test.ts
+++ b/src/workstation/surfaces/workspace/render.test.ts
@@ -1,14 +1,14 @@
 import { WorkspaceOverview, WorkspaceRepoSummary } from '../../../git/workspaceData'
 
 import {
-  assignWorkspaceColumnWidths,
-  buildWorkspaceFooter,
-  buildWorkspaceHeader,
-  buildWorkspaceHelpRows,
-  buildWorkspaceListRows,
-  buildWorkspaceListWindow,
-  buildWorkspaceOnboarding,
-  buildWorkspaceSidebar,
+    assignWorkspaceColumnWidths,
+    buildWorkspaceFooter,
+    buildWorkspaceHeader,
+    buildWorkspaceHelpRows,
+    buildWorkspaceListRows,
+    buildWorkspaceListWindow,
+    buildWorkspaceOnboarding,
+    buildWorkspaceSidebar,
 } from './render'
 import { applyWorkspaceAction, createWorkspaceState } from './state'
 
@@ -251,7 +251,7 @@ describe('workspace render builders', () => {
       type: 'request-delete',
       path: state.overview.repos[0].path,
     })
-    expect(buildWorkspaceFooter(requested).hint).toContain('press y')
+    expect(buildWorkspaceFooter(requested).hint).toContain('y confirm')
   })
 
   it('onboarding model returns show=false unless the flag is set', () => {

--- a/src/workstation/surfaces/workspace/render.ts
+++ b/src/workstation/surfaces/workspace/render.ts
@@ -1,10 +1,10 @@
 import type { WorkspaceRepoSummary } from '../../../git/workspaceData'
 import { truncateCells, truncatePathCells } from '../../chrome/text'
 import {
-  workspaceTabGlyph,
-  workspaceTabLabel,
-  WORKSPACE_TABS,
-  type WorkspaceTab,
+    workspaceTabGlyph,
+    workspaceTabLabel,
+    WORKSPACE_TABS,
+    type WorkspaceTab,
 } from './filter'
 import { workspaceSortLabel } from './sort'
 import { selectVisibleRepos, type WorkspaceState } from './state'
@@ -589,40 +589,61 @@ export function buildWorkspaceHeaderChips(
 }
 
 export type WorkspaceFooterModel = {
+  /** Backwards-compat: full hint string. Kept for tests + simple consumers. */
   hint: string
+  /** Per-mode contextual hints (left-aligned in the chrome). */
+  contextual: string[]
+  /** Always-on global hints (right-aligned in the chrome). */
+  global: string[]
   status?: string
   filterMode: boolean
 }
 
-// Footer hints prioritize discoverable / forgettable actions and
-// drop the bindings users can find on their own (arrow keys, Enter
-// for "open", Tab for "switch panels"). The full keymap lives behind
-// `?` so nothing is hidden, just decluttered.
-const LIST_HINT = 's sort · / filter · r/R refresh · a add · d remove · ? help · q quit'
-const SIDEBAR_HINT = '? help · q quit'
-const FILTER_HINT = 'type to filter · enter apply · esc cancel'
-const ADD_REPO_HINT = 'type path · tab to complete · enter to add · esc to cancel'
-const CONFIRM_DELETE_HINT = 'press y to remove · any other key to cancel'
+// Footer hints are split into two slots — same pattern as `coco ui`:
+//   - contextual : per-mode actions (sort, filter, refresh, add/remove)
+//   - global     : always-on essentials (help, quit) — never crowded out
+//
+// The contextual slot drops bindings users can find via the help
+// overlay (arrow keys, tab); the global slot is the safety net so
+// `? help` and `q quit` never disappear.
+const LIST_CONTEXTUAL = ['s sort', '/ filter', 'r/R refresh', 'a add', 'd remove']
+const SIDEBAR_CONTEXTUAL = ['↑/↓ cycle tab', 'enter open']
+const FILTER_CONTEXTUAL = ['type to filter', 'enter apply', 'esc cancel']
+const ADD_REPO_CONTEXTUAL = ['type path', 'tab to complete', 'enter to add', 'esc to cancel']
+const CONFIRM_DELETE_CONTEXTUAL = ['y confirm', 'any other key cancels']
+const GLOBAL_HINTS = ['? help', 'q quit']
 
-function hintFor(focus: WorkspaceState['focus']): string {
+function contextualHintsFor(focus: WorkspaceState['focus']): string[] {
   switch (focus) {
     case 'sidebar':
-      return SIDEBAR_HINT
+      return SIDEBAR_CONTEXTUAL
     case 'filter':
-      return FILTER_HINT
+      return FILTER_CONTEXTUAL
     case 'add-repo':
-      return ADD_REPO_HINT
+      return ADD_REPO_CONTEXTUAL
     case 'confirm-delete':
-      return CONFIRM_DELETE_HINT
+      return CONFIRM_DELETE_CONTEXTUAL
     case 'list':
     default:
-      return LIST_HINT
+      return LIST_CONTEXTUAL
   }
 }
 
 export function buildWorkspaceFooter(state: WorkspaceState): WorkspaceFooterModel {
+  const contextual = contextualHintsFor(state.focus)
+  // Modal modes (filter / add-repo / confirm-delete) suppress the
+  // global hints — those bindings are not reachable while a prompt
+  // is open and showing them would be misleading.
+  const isModal =
+    state.focus === 'filter' ||
+    state.focus === 'add-repo' ||
+    state.focus === 'confirm-delete'
+  const global = isModal ? [] : GLOBAL_HINTS
+  const allHints = [...contextual, ...global]
   return {
-    hint: hintFor(state.focus),
+    hint: allHints.join(' · '),
+    contextual,
+    global,
     status: state.status,
     filterMode: state.focus === 'filter',
   }
@@ -647,11 +668,25 @@ export type WorkspaceHelpSection = {
  * sections so users can scan by intent ("how do I navigate?" "how
  * do I act?") rather than reading a flat alphabetized list.
  *
+ * Section order mirrors `coco ui`'s help convention — Essentials
+ * first so newcomers see `?`/`esc`/`q` immediately, then move outward
+ * to navigation, modification, and the destructive verbs last.
+ *
  * The view layer composes these into a panel with section titles,
  * a leading app/title bar, and a closing hint at the bottom.
  */
 export function buildWorkspaceHelpSections(): WorkspaceHelpSection[] {
   return [
+    {
+      title: 'Essentials',
+      subtitle: 'The keys you reach for most often.',
+      rows: [
+        { glyph: '?', keys: '?', description: 'Toggle this help overlay' },
+        { glyph: '⎋', keys: 'esc', description: 'Clear filter / close overlay / cancel prompt' },
+        { glyph: '◴', keys: 'q · ctrl+c', description: 'Quit the workspace surface' },
+        { glyph: '↵', keys: 'enter', description: 'Drill into the cursored repo (coco ui)' },
+      ],
+    },
     {
       title: 'Navigate',
       subtitle: 'Move the cursor and switch focus between panels.',
@@ -661,7 +696,6 @@ export function buildWorkspaceHelpSections(): WorkspaceHelpSection[] {
         { glyph: '←', keys: 'h', description: 'Jump focus to the sidebar' },
         { glyph: '→', keys: 'l', description: 'Jump focus to the list' },
         { glyph: '⤒', keys: 'g / G', description: 'Jump to top / bottom of the list' },
-        { glyph: '↵', keys: 'enter', description: 'Drill into the cursored repo (coco ui)' },
       ],
     },
     {
@@ -679,14 +713,6 @@ export function buildWorkspaceHelpSections(): WorkspaceHelpSection[] {
         { glyph: '⟲', keys: 'R', description: 'Refresh just the cursored repo (faster)' },
         { glyph: '＋', keys: 'a', description: 'Add a repo via path prompt (tab-completes)' },
         { glyph: '✕', keys: 'd', description: 'Remove the cursored repo from the known-repos store' },
-      ],
-    },
-    {
-      title: 'General',
-      rows: [
-        { glyph: '?', keys: '?', description: 'Toggle this help overlay' },
-        { glyph: '⎋', keys: 'esc', description: 'Clear filter / close overlay / cancel prompt' },
-        { glyph: '◴', keys: 'q · ctrl+c', description: 'Quit the workspace surface' },
       ],
     },
   ]

--- a/src/workstation/surfaces/workspace/view.ts
+++ b/src/workstation/surfaces/workspace/view.ts
@@ -16,18 +16,18 @@ import { focusBorderColor, panelTitle } from '../../runtime/utils'
 import type { WorkspaceComponents } from './runtime'
 import { type PathCompletionResult } from './pathCompletion'
 import {
-  buildWorkspaceColumnHeaders,
-  buildWorkspaceFooter,
-  buildWorkspaceHeaderChips,
-  buildWorkspaceHelpSections,
-  buildWorkspaceListWindow,
-  buildWorkspaceOnboarding,
-  buildWorkspaceSidebar,
-  shouldRailWorkspaceSidebar,
-  type WorkspaceHeaderChip,
-  type WorkspaceHelpRow,
-  type WorkspaceListColumn,
-  type WorkspaceListRow,
+    buildWorkspaceColumnHeaders,
+    buildWorkspaceFooter,
+    buildWorkspaceHeaderChips,
+    buildWorkspaceHelpSections,
+    buildWorkspaceListWindow,
+    buildWorkspaceOnboarding,
+    buildWorkspaceSidebar,
+    shouldRailWorkspaceSidebar,
+    type WorkspaceHeaderChip,
+    type WorkspaceHelpRow,
+    type WorkspaceListColumn,
+    type WorkspaceListRow,
 } from './render'
 import { selectVisibleRepos, type WorkspaceState } from './state'
 
@@ -718,6 +718,8 @@ function renderFooter(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement {
   // height shifted by a row every time a status banner came and went,
   // forcing the panel chrome to reflow.
   const statusContent = model.status ?? ''
+  const contextualText = model.contextual.join('   ')
+  const globalText = model.global.join(' · ')
   return React.createElement(
     Box,
     {
@@ -727,7 +729,15 @@ function renderFooter(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement {
       flexDirection: 'column',
       height: FOOTER_HEIGHT,
     },
-    React.createElement(Text, { dimColor: true }, model.hint),
+    // Row 1: contextual ↔ global hints. justifyContent pushes them
+    // to opposite edges so the eye scans each cluster as one block —
+    // same shape as `coco ui`'s footer post-0.54.2 redesign.
+    React.createElement(
+      Box,
+      { flexDirection: 'row', justifyContent: 'space-between' },
+      React.createElement(Text, { dimColor: true }, contextualText),
+      React.createElement(Text, { dimColor: true }, globalText)
+    ),
     React.createElement(
       Text,
       {


### PR DESCRIPTION
Properly PR'ing the in-progress workstation UI work that was sitting uncommitted in the working tree (it's complete and tested — just never landed). Two focused commits:

## Scroll indicators on list surfaces
`↑ N more above` / `↓ N more below` hints on the **branches, stash, status, tags** lists and the **command-palette** overlay when content overflows the window — matching the sidebar's existing pattern so overflow is discoverable.

## Workspace footer hints → contextual + global
Mirror the `coco ui` footer in the **workspace** view: a contextual slot (per-mode actions — sort / filter / refresh / add / remove) on the left and an always-on global slot (help / quit) on the right, so essentials are never crowded out. Global hints are suppressed in modal modes. `WorkspaceFooterModel` exposes `contextual` + `global` arrays while keeping the combined `hint` string for backward-compat.

## Validation
- 722 workstation tests pass (incl. the updated `render.test.ts` + view snapshot); typecheck clean.

> Context: this work, plus the `defaultRouter` feature (already on `main`), was uncommitted WIP in the worktree. It got partially bundled into the theme merges by accident — this PR lands the workspace half cleanly on its own.