### PR TITLE
fix(themes): light themes' selected row renders dark on non-truecolor terminals

### DIFF
--- a/src/workstation/chrome/theme.test.ts
+++ b/src/workstation/chrome/theme.test.ts
@@ -76,5 +76,22 @@ describe('log Ink theme', () => {
       expect(lowColor.colors.accent).toBe('cyan')
       expect(highColor.colors.accent).toBe('cyan')
     })
+
+    it('preserves a light preset selection through the downgrade (no dark bar on light themes)', () => {
+      // Regression: on a non-truecolor terminal a light theme used to inherit
+      // the default preset's dark selection (#1a3a4a), rendering the selected
+      // row as a dark bar on a light background. The downgrade must keep the
+      // requested theme's own (light) selection.
+      const downgraded = createLogInkTheme({ env: { TERM: 'xterm-256color' }, preset: 'one-light' })
+      expect(downgraded.colors.accent).toBe('cyan') // syntax still downgrades…
+      expect(downgraded.colors.selection).toBe('#e5e5e6') // …but the selection stays light
+      const truecolor = createLogInkTheme({ env: { COLORTERM: 'truecolor' }, preset: 'one-light' })
+      expect(truecolor.colors.selection).toBe('#e5e5e6')
+    })
+
+    it('preserves a dark preset selection through the downgrade too', () => {
+      const downgraded = createLogInkTheme({ env: { TERM: 'xterm' }, preset: 'catppuccin' })
+      expect(downgraded.colors.selection).toBe('#45475a')
+    })
   })
 })

--- a/src/workstation/chrome/theme.ts
+++ b/src/workstation/chrome/theme.ts
@@ -757,6 +757,14 @@ export function createLogInkTheme(options: CreateLogInkThemeOptions = {}): LogIn
     ? {}
     : {
       ...THEME_PRESET_COLORS[preset],
+      // Preserve the requested theme's selection background even when the
+      // rest of the palette downgrades to `default`. The selection is a
+      // single background color the terminal can approximate; without this,
+      // a light theme inherits `default`'s dark selection (#1a3a4a) and the
+      // selected row renders as a dark bar on a light background.
+      ...(preset !== requestedPreset && THEME_PRESET_COLORS[requestedPreset]?.selection
+        ? { selection: THEME_PRESET_COLORS[requestedPreset]!.selection }
+        : {}),
       ...options.colors,
     }
 


### PR DESCRIPTION
## Bug

On every **light** theme, the active/selected row in the history view rendered as a **dark bar** on the light background.

## Root cause

When a terminal doesn't advertise truecolor, coco downgrades hex presets to the `default` palette (so ANSI-named colors render faithfully on 16/256-color terminals). But the downgrade replaced the **entire** palette — including `default`'s `selection` (`#1a3a4a`, a dark teal hex). So every light theme inherited a dark selection, and the selected row became a dark bar on a light background. (This is also why it showed up in the VHS screenshots — the capture shell isn't truecolor.)

## Fix

Preserve the requested theme's own `selection` through the downgrade — it's a single background color the terminal can approximate. Light themes keep their light selection; dark themes keep their own (rather than the generic default). + regression tests.

## Validation
- 503 chrome tests pass (incl. 2 new regression tests).
- Verified by re-rendering one-light: the selected row is now a light highlight instead of a dark bar.

Pairs with a site PR regenerating the light-theme gallery images.