### PR TITLE
fix(commit): accept split-plan groups with only files or only hunks

### DIFF
--- a/src/commands/commit/splitPlanTypes.test.ts
+++ b/src/commands/commit/splitPlanTypes.test.ts
@@ -1,0 +1,47 @@
+import { CommitSplitPlanSchema } from './splitPlanTypes'
+
+describe('CommitSplitPlanSchema', () => {
+  it('parses a group that only supplies files (no hunks key)', () => {
+    const parsed = CommitSplitPlanSchema.parse({
+      groups: [{ title: 'feat: add login', files: ['src/auth/login.ts'] }],
+    })
+
+    expect(parsed.groups[0].files).toEqual(['src/auth/login.ts'])
+    // Missing `hunks` is accepted (left undefined) rather than throwing "Required".
+    expect(parsed.groups[0].hunks).toBeUndefined()
+  })
+
+  it('parses a group that only supplies hunks (no files key)', () => {
+    const parsed = CommitSplitPlanSchema.parse({
+      groups: [{ title: 'fix: tweak handler', hunks: ['src/server.ts:1'] }],
+    })
+
+    expect(parsed.groups[0].hunks).toEqual(['src/server.ts:1'])
+    expect(parsed.groups[0].files).toBeUndefined()
+  })
+
+  it('parses a plan that mixes files-only and hunks-only groups', () => {
+    // This is the exact shape the model emits that previously triggered
+    // OUTPUT_PARSING_FAILURE: each group carries either files or hunks, not both.
+    const parsed = CommitSplitPlanSchema.parse({
+      groups: [
+        { title: 'feat: file-level group', files: ['a.ts', 'b.ts'] },
+        { title: 'refactor: hunk-level group', hunks: ['c.ts:0', 'c.ts:1'] },
+      ],
+    })
+
+    expect(parsed.groups).toHaveLength(2)
+    expect(parsed.groups[0].hunks).toBeUndefined()
+    expect(parsed.groups[1].files).toBeUndefined()
+  })
+
+  it('still rejects a group with neither files nor hunks', () => {
+    expect(() =>
+      CommitSplitPlanSchema.parse({ groups: [{ title: 'empty group' }] })
+    ).toThrow(/at least one file or hunk/)
+  })
+
+  it('still rejects a plan with no groups', () => {
+    expect(() => CommitSplitPlanSchema.parse({ groups: [] })).toThrow()
+  })
+})

--- a/src/commands/commit/splitPlanTypes.ts
+++ b/src/commands/commit/splitPlanTypes.ts
@@ -8,12 +8,25 @@ export const CommitSplitPlanSchema = z.object({
           title: z.string().min(1),
           body: z.string().optional(),
           rationale: z.string().optional(),
-          files: z.array(z.string()),
-          hunks: z.array(z.string()),
+          // Both optional: the model legitimately emits a group with *either*
+          // `files` or `hunks` (a file-level vs hunk-level grouping), not always
+          // both. Requiring both made Zod throw "Required" and the whole split
+          // chain failed to parse before the refine could run. The refine below
+          // still enforces "at least one", and every downstream consumer already
+          // reads these as `group.files || []`. (Kept `.optional()` rather than
+          // `.default([])` so the schema's input and output types stay identical
+          // — `executeChainWithSchema` takes a `z.ZodSchema<T>`, which requires
+          // that.)
+          files: z.array(z.string()).optional(),
+          hunks: z.array(z.string()).optional(),
         })
-        .refine((group) => group.files.length > 0 || group.hunks.length > 0, {
-          message: 'Each group must include at least one file or hunk',
-        })
+        .refine(
+          (group) =>
+            (group.files?.length ?? 0) > 0 || (group.hunks?.length ?? 0) > 0,
+          {
+            message: 'Each group must include at least one file or hunk',
+          }
+        )
     )
     .min(1),
 })

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -4414,7 +4414,8 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
           if (group.body) lines += group.body.split('\n').length + 1
           if (group.rationale) lines += 2
           lines += (group.files?.length || 0) + 1
-          if ((group.hunks?.length || 0) > 0) lines += group.hunks.length + 1
+          const hunkCount = group.hunks?.length || 0
+          if (hunkCount > 0) lines += hunkCount + 1
           return sum + lines
         }, 0)
         : undefined,


### PR DESCRIPTION
## Problem

`coco commit --split` (and the `S` workstation action) failed hard with:

```
OUTPUT_PARSING_FAILURE
... "code": "invalid_type", "expected": "array", "received": "undefined", "path": ["groups", N, "files"], "message": "Required"
```

The `CommitSplitPlanSchema` required **both** `files` and `hunks` on every group. But the model legitimately produces each group with *either* a file-level grouping **or** a hunk-level grouping — rarely both. Zod threw `Required` on the missing key *before* the `.refine("at least one file or hunk")` could run, so the entire split chain failed to parse.

Closes #1092.

## Fix

- Make `files` and `hunks` `.optional()` on the group schema.
- Guard the `.refine` (`group.files?.length ?? 0`) so it still enforces "at least one file or hunk".
- Kept `.optional()` rather than `.default([])`: a defaulted field makes Zod's input type diverge from its output type, which is incompatible with `executeChainWithSchema`'s `z.ZodSchema<T>` parameter. Every downstream consumer already reads these as `group.files || []`, so no consumer change is needed.

## Tests

New `src/commands/commit/splitPlanTypes.test.ts`:
- parses a group with only `files`
- parses a group with only `hunks`
- parses a plan mixing files-only and hunks-only groups (the exact failure shape)
- still rejects a group with neither
- still rejects an empty plan

`npx jest src/commands/commit/` → **130 passed**. `typecheck` clean, `eslint` clean.