### PR TITLE
fix(workstation): keep selected-row text readable on every theme

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1114,6 +1114,10 @@
         "selection": {
           "type": "string"
         },
+        "selectionForeground": {
+          "type": "string",
+          "description": "Foreground for text sitting on the `selection` background. Derived automatically from `selection` (black on light, white on dark) so the selected row stays readable regardless of the user's terminal default foreground — but can be overridden per theme via `options.colors`."
+        },
         "success": {
           "type": "string"
         },

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1125,6 +1125,10 @@ export const schema = {
         "selection": {
           "type": "string"
         },
+        "selectionForeground": {
+          "type": "string",
+          "description": "Foreground for text sitting on the `selection` background. Derived automatically from `selection` (black on light, white on dark) so the selected row stays readable regardless of the user's terminal default foreground — but can be overridden per theme via `options.colors`."
+        },
         "success": {
           "type": "string"
         },

--- a/src/workstation/chrome/colorSupport.test.ts
+++ b/src/workstation/chrome/colorSupport.test.ts
@@ -1,4 +1,4 @@
-import { getColorLevel, presetUsesTrueColor } from './colorSupport'
+import { getColorLevel, presetUsesTrueColor, readableForegroundFor } from './colorSupport'
 
 describe('log Ink color support (P5.2)', () => {
   describe('getColorLevel', () => {
@@ -54,6 +54,45 @@ describe('log Ink color support (P5.2)', () => {
       expect(presetUsesTrueColor('default')).toBe(false)
       expect(presetUsesTrueColor('monochrome')).toBe(false)
       expect(presetUsesTrueColor(undefined)).toBe(false)
+    })
+  })
+
+  describe('readableForegroundFor', () => {
+    it('picks white text on dark selection backgrounds', () => {
+      // The selection bars that caused unreadable rows (catppuccin,
+      // tokyo-night) are dark — they must pair with white text.
+      expect(readableForegroundFor('#45475a')).toBe('#ffffff') // catppuccin
+      expect(readableForegroundFor('#33467c')).toBe('#ffffff') // tokyo-night
+      expect(readableForegroundFor('#1a3a4a')).toBe('#ffffff') // default
+      expect(readableForegroundFor('#000000')).toBe('#ffffff')
+    })
+
+    it('picks black text on light selection backgrounds', () => {
+      expect(readableForegroundFor('#eee8d5')).toBe('#000000') // solarized-light
+      expect(readableForegroundFor('#b7c1e3')).toBe('#000000') // tokyo-night-day
+      expect(readableForegroundFor('#ffffff')).toBe('#000000')
+    })
+
+    it('accepts hex with or without the leading #', () => {
+      expect(readableForegroundFor('45475a')).toBe('#ffffff')
+    })
+
+    it('returns undefined for non-hex or empty backgrounds', () => {
+      expect(readableForegroundFor('gray')).toBeUndefined()
+      expect(readableForegroundFor('')).toBeUndefined()
+      expect(readableForegroundFor(undefined)).toBeUndefined()
+    })
+
+    it('guarantees a contrasting choice for every built-in selection color', () => {
+      // Every preset's selection bg must resolve to black or white — never
+      // undefined — so no theme can regress to an uncontrolled foreground.
+      const selections = [
+        '#45475a', '#504945', '#33467c', '#264f78', '#2a273f', '#ccd0da',
+        '#ddf4ff', '#ebdbb2', '#e5e5e6', '#c0deff', '#0d3a58', '#232323',
+      ]
+      for (const bg of selections) {
+        expect(['#000000', '#ffffff']).toContain(readableForegroundFor(bg))
+      }
     })
   })
 })

--- a/src/workstation/chrome/colorSupport.ts
+++ b/src/workstation/chrome/colorSupport.ts
@@ -78,3 +78,41 @@ const TRUECOLOR_PRESETS = new Set<string>(['catppuccin', 'gruvbox', 'dracula', '
 export function presetUsesTrueColor(preset: string | undefined): boolean {
   return preset !== undefined && TRUECOLOR_PRESETS.has(preset)
 }
+
+/**
+ * WCAG 2.x relative luminance of a `#rrggbb` color, 0 (black) … 1 (white).
+ * Returns `null` for anything that isn't a 6-digit hex (e.g. ANSI-named
+ * colors), so callers can fall back rather than guess.
+ */
+function relativeLuminance(hex: string): number | null {
+  const match = /^#?([0-9a-f]{6})$/i.exec(hex.trim())
+  if (!match) return null
+  const int = parseInt(match[1]!, 16)
+  const channel = (c: number): number => {
+    const x = c / 255
+    return x <= 0.03928 ? x / 12.92 : ((x + 0.055) / 1.055) ** 2.4
+  }
+  const r = channel((int >> 16) & 0xff)
+  const g = channel((int >> 8) & 0xff)
+  const b = channel(int & 0xff)
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+/**
+ * Pick a foreground guaranteed to stay readable on `bg` — black for light
+ * backgrounds, white for dark ones. The 0.179 threshold is the luminance
+ * crossover where black and white yield identical contrast, so the choice
+ * always maximizes it; every background clears WCAG AA (≥ 4.5:1).
+ *
+ * This is how the selected-row text stays legible across every theme:
+ * coco controls the selection *background* but not the user's terminal
+ * default foreground, so it must supply its own contrasting foreground
+ * instead of hoping the terminal's happens to contrast. Returns
+ * `undefined` for non-hex backgrounds (let the caller leave color alone).
+ */
+export function readableForegroundFor(bg: string | undefined): string | undefined {
+  if (!bg) return undefined
+  const luminance = relativeLuminance(bg)
+  if (luminance === null) return undefined
+  return luminance > 0.179 ? '#000000' : '#ffffff'
+}

--- a/src/workstation/chrome/theme.test.ts
+++ b/src/workstation/chrome/theme.test.ts
@@ -94,4 +94,50 @@ describe('log Ink theme', () => {
       expect(downgraded.colors.selection).toBe('#45475a')
     })
   })
+
+  describe('selection foreground', () => {
+    it('derives a white foreground for dark-selection themes', () => {
+      const theme = createLogInkTheme({
+        env: { COLORTERM: 'truecolor' },
+        preset: 'catppuccin',
+      })
+      expect(theme.colors.selection).toBe('#45475a')
+      expect(theme.colors.selectionForeground).toBe('#ffffff')
+    })
+
+    it('derives a black foreground for light-selection themes', () => {
+      const theme = createLogInkTheme({
+        env: { COLORTERM: 'truecolor' },
+        preset: 'solarized-light',
+      })
+      expect(theme.colors.selection).toBe('#eee8d5')
+      expect(theme.colors.selectionForeground).toBe('#000000')
+    })
+
+    it('keeps a readable selection foreground through the non-truecolor downgrade', () => {
+      // A light theme on a 16-color terminal downgrades its palette to
+      // `default` but preserves its own light selection bg — the derived
+      // foreground must follow the *preserved* bg, not default's dark one.
+      const theme = createLogInkTheme({
+        env: { TERM: 'xterm' },
+        preset: 'solarized-light',
+      })
+      expect(theme.colors.selection).toBe('#eee8d5')
+      expect(theme.colors.selectionForeground).toBe('#000000')
+    })
+
+    it('honors an explicit selectionForeground override', () => {
+      const theme = createLogInkTheme({
+        colors: { selectionForeground: '#abcdef' },
+        env: { COLORTERM: 'truecolor' },
+        preset: 'catppuccin',
+      })
+      expect(theme.colors.selectionForeground).toBe('#abcdef')
+    })
+
+    it('sets no selection foreground for no-color themes', () => {
+      const theme = createLogInkTheme({ noColor: true, preset: 'catppuccin' })
+      expect(theme.colors.selectionForeground).toBeUndefined()
+    })
+  })
 })

--- a/src/workstation/chrome/theme.ts
+++ b/src/workstation/chrome/theme.ts
@@ -1,4 +1,4 @@
-import { ColorEnv, getColorLevel, presetUsesTrueColor } from './colorSupport'
+import { ColorEnv, getColorLevel, presetUsesTrueColor, readableForegroundFor } from './colorSupport'
 
 export type LogInkBorderStyle = 'round' | 'single' | 'classic'
 export type LogInkThemePreset = 'default' | 'monochrome' | 'catppuccin' | 'gruvbox' | 'dracula' | 'nord' | 'solarized-dark' | 'tokyo-night' | 'one-dark' | 'rose-pine' | 'kanagawa' | 'everforest' | 'monokai' | 'synthwave' | 'ayu-dark' | 'palenight' | 'github-dark' | 'horizon' | 'nightfox' | 'carbonfox' | 'tokyonight-storm' | 'catppuccin-latte' | 'solarized-light' | 'github-light' | 'iceberg' | 'material-ocean' | 'moonlight' | 'poimandres' | 'vitesse-dark' | 'vesper' | 'flexoki' | 'mellow' | 'night-owl' | 'cobalt2' | 'oceanic-next' | 'catppuccin-macchiato' | 'gruvbox-light' | 'tokyo-night-day' | 'one-light' | 'ayu-light' | 'rose-pine-dawn' | 'everforest-light' | 'vitesse-light' | 'dayfox' | 'night-owl-light' | 'flexoki-light' | 'material-lighter' | 'papercolor-light' | 'modus-operandi' | 'quiet-light'
@@ -14,6 +14,13 @@ export type LogInkThemeColors = {
   info?: string
   muted?: string
   selection?: string
+  /**
+   * Foreground for text sitting on the `selection` background. Derived
+   * automatically from `selection` (black on light, white on dark) so the
+   * selected row stays readable regardless of the user's terminal default
+   * foreground — but can be overridden per theme via `options.colors`.
+   */
+  selectionForeground?: string
   success?: string
   warning?: string
 }
@@ -767,6 +774,19 @@ export function createLogInkTheme(options: CreateLogInkThemeOptions = {}): LogIn
         : {}),
       ...options.colors,
     }
+
+  // Derive a contrasting foreground for the selected row from its own
+  // selection background, unless the caller supplied one explicitly. coco
+  // owns the selection background but not the terminal's default foreground,
+  // so without this the selected row's text falls back to whatever the
+  // user's terminal foreground is — which may not contrast with the bar at
+  // all (the bug behind unreadable selected rows on many themes).
+  if (!noColor && colors.selection && !colors.selectionForeground) {
+    const selectionForeground = readableForegroundFor(colors.selection)
+    if (selectionForeground) {
+      colors.selectionForeground = selectionForeground
+    }
+  }
 
   return {
     noColor,

--- a/src/workstation/surfaces/detail/index.ts
+++ b/src/workstation/surfaces/detail/index.ts
@@ -120,12 +120,17 @@ function renderInspectorActionsSection(
     h(Text, { key: 'actions-title' }, cursorActive ? '[Actions]' : 'Actions:'),
     ...actions.map((action: InspectorAction, index) => {
       const isSelected = cursorActive && index === cursorIndex
+      // On the selected row, swap every span to the contrast-guaranteed
+      // selection foreground so the key glyph / destructive marker don't
+      // wash out against the selection bar; the row is already highlighted,
+      // and the label text still conveys which actions are destructive.
+      const selectedFg = isSelected && !theme.noColor ? theme.colors.selectionForeground : undefined
       const keyCell = action.key.padEnd(KEY_COLUMN)
       const label = truncateCells(action.label, labelBudget)
       const children: Array<string | ReactTypes.ReactElement> = [
         h(Text, {
           key: `actions-${index}-key`,
-          color: action.destructive ? theme.colors.danger : theme.colors.accent,
+          color: selectedFg ?? (action.destructive ? theme.colors.danger : theme.colors.accent),
         }, keyCell),
         GAP,
         label,
@@ -133,14 +138,14 @@ function renderInspectorActionsSection(
       if (action.destructive) {
         children.push(h(Text, {
           key: `actions-${index}-mark`,
-          color: theme.colors.danger,
+          color: selectedFg ?? theme.colors.danger,
           dimColor: false,
         }, DESTRUCTIVE_SUFFIX))
       }
       return h(Text, {
         key: `actions-${index}`,
         backgroundColor: isSelected && !theme.noColor ? theme.colors.selection : undefined,
-
+        color: selectedFg,
       }, ...children)
     }),
   ]

--- a/src/workstation/surfaces/diff/index.ts
+++ b/src/workstation/surfaces/diff/index.ts
@@ -144,12 +144,19 @@ export function renderDiffSurface(
             // sees at a glance which file the cursor is inside.
             const isActive = absoluteIndex === activeStartLine
             const arrow = theme.ascii ? '> ' : '▾ '
+            const activeHeader = isActive && focused && !theme.noColor
             return h(Text, {
               key: `stash-diff-line-${absoluteIndex}`,
               bold: true,
-              color: theme.noColor ? undefined : theme.colors.accent,
-              backgroundColor: isActive && focused && !theme.noColor ? theme.colors.selection : undefined,
-              inverse: isActive && focused,
+              // Active header sits on the selection bar with a
+              // contrast-guaranteed foreground (matches history/status).
+              // The old `inverse` swap turned the accent into the bar and
+              // left the path in the selection color — low-contrast on
+              // light themes (e.g. accent blue bar + light-gray text).
+              color: activeHeader
+                ? theme.colors.selectionForeground
+                : (theme.noColor ? undefined : theme.colors.accent),
+              backgroundColor: activeHeader ? theme.colors.selection : undefined,
             }, (() => {
               // Smart path truncation for the diff file header: keep
               // the leading arrow glyph and elide middle path

--- a/src/workstation/surfaces/history/__snapshots__/historyRender.test.ts.snap
+++ b/src/workstation/surfaces/history/__snapshots__/historyRender.test.ts.snap
@@ -25,6 +25,7 @@ exports[`renderHistoryPanel structural snapshot — default 3-commit history 1`]
   </Box>
   <Text
     backgroundColor="#1a3a4a"
+    color="#ffffff"
   >
     <Text
       dimColor={false}
@@ -209,6 +210,7 @@ exports[`renderHistoryPanel structural snapshot — narrow terminal (tight densi
   </Box>
   <Text
     backgroundColor="#1a3a4a"
+    color="#ffffff"
   >
     <Text
       dimColor={false}

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -326,12 +326,14 @@ function renderCommitHistoryRow(
   const message = truncateCells(commit.message, messageRoom)
 
   const selectedBg = selected && !theme.noColor ? theme.colors.selection : undefined
-  // Don't use inverse — it makes child colors unreadable. Instead,
-  // use backgroundColor only. The selection color in each theme is
-  // chosen to contrast with the default foreground (light text).
-  // Suppress accent/muted colors on selected rows so all text renders
-  // in the default foreground for maximum contrast against the
-  // selection background.
+  // Don't use inverse — it makes child colors unreadable. Instead, set a
+  // background on the row AND an explicit, contrast-guaranteed foreground
+  // (`selectionForeground`, derived from the selection bg) on the outer
+  // span. Suppressing each child's own color to `undefined` then lets it
+  // inherit that readable foreground — so the whole selected row stays
+  // legible regardless of the user's terminal default foreground, which
+  // is what the old "rely on the default fg" approach got wrong.
+  const selectedFg = selected && !theme.noColor ? theme.colors.selectionForeground : undefined
   const accent = selected ? undefined : (theme.noColor ? undefined : theme.colors.accent)
   const muted = selected ? undefined : (theme.noColor ? undefined : theme.colors.muted)
 
@@ -346,7 +348,7 @@ function renderCommitHistoryRow(
   return h(Text, {
     key: `${commit.hash}-${index}`,
     backgroundColor: selectedBg,
-
+    color: selectedFg,
   },
   ...graphChildren,
   ' ',
@@ -410,11 +412,13 @@ function renderStackedCommitHistoryRow(
   remoteNames?: string[]
 ): ReactTypes.ReactElement {
   const totalWidth = Math.max(20, panelWidth - 4)
-  // Suppress child colors on selected rows so all text renders in
-  // the default foreground for contrast against the selection bg.
+  // Suppress child colors on selected rows so each span inherits the
+  // contrast-guaranteed `selectionForeground` set on the line-1 span,
+  // keeping the selected row readable against the selection bg.
   const accent = selected ? undefined : (theme.noColor ? undefined : theme.colors.accent)
   const muted = selected ? undefined : (theme.noColor ? undefined : theme.colors.muted)
   const selectedBg = selected && !theme.noColor ? theme.colors.selection : undefined
+  const selectedFg = selected && !theme.noColor ? theme.colors.selectionForeground : undefined
 
   // Line 1 — subject row. Mostly mirrors the single-line layout but
   // skips the date and refs so the message has the whole tail to
@@ -436,7 +440,7 @@ function renderStackedCommitHistoryRow(
   const lineOne = h(Text, {
     key: `${commit.hash}-${index}-l1`,
     backgroundColor: selectedBg,
-
+    color: selectedFg,
   },
   ...graphChildren,
   ' ',
@@ -510,8 +514,11 @@ function renderPendingCommitRow(
   return h(Text, {
     key: 'pending-commit-row',
     bold: true,
-    color: theme.noColor ? undefined : theme.colors.accent,
-
+    // On selection, swap to the contrast-guaranteed foreground so the
+    // accent label doesn't wash out against the selection bar.
+    color: selected && !theme.noColor
+      ? theme.colors.selectionForeground
+      : (theme.noColor ? undefined : theme.colors.accent),
     backgroundColor: selected && !theme.noColor ? theme.colors.selection : undefined,
   }, truncateCells(label, 140))
 }

--- a/src/workstation/surfaces/status/__snapshots__/statusRender.test.ts.snap
+++ b/src/workstation/surfaces/status/__snapshots__/statusRender.test.ts.snap
@@ -93,6 +93,7 @@ exports[`renderStatusSurface structural snapshot — mixed staged + unstaged + u
   </Text>
   <Text
     backgroundColor="#1a3a4a"
+    color="#ffffff"
     dimColor={false}
   >
       &gt; 

--- a/src/workstation/surfaces/status/index.ts
+++ b/src/workstation/surfaces/status/index.ts
@@ -135,7 +135,7 @@ export function renderStatusSurface(
           bold: true,
           dimColor: !headerSelected && rowIndex > cursorRowIndex,
           backgroundColor: headerSelected && !theme.noColor ? theme.colors.selection : undefined,
-
+          color: headerSelected && !theme.noColor ? theme.colors.selectionForeground : undefined,
         }, truncateCells(text, 140))
       }
       const isSelected = !headerFocused && row.flatIndex === selectedIndex
@@ -155,11 +155,11 @@ export function renderStatusSurface(
         key: `status-file-${row.flatIndex}-${rowIndex}`,
         dimColor: !isSelected && rowIndex > cursorRowIndex,
         backgroundColor: isSelected && focused && !theme.noColor ? theme.colors.selection : undefined,
-
+        color: isSelected && focused && !theme.noColor ? theme.colors.selectionForeground : undefined,
       },
       `  ${cursorPart}`,
-      // Suppress dot color on selected rows — inverse makes colored
-      // text unreadable against the light background.
+      // Suppress the dot's own color on selected rows so it inherits the
+      // contrast-guaranteed selection foreground set on the row span.
       ...(useDot ? [h(Text, { color: (isSelected && focused) ? undefined : dotColor }, STAGE_STATUS_DOT), ' '] : []),
       tailTrunc)
     })


### PR DESCRIPTION
## Problem

In the history (and status / inspector / diff) views, the active/selected row painted a themed **selection background** but **suppressed every foreground color**, letting the row text fall back to the *terminal's default foreground*. coco controls the selection background but **not** the user's terminal foreground — so on any terminal whose default fg didn't contrast with the theme's selection bar, the selected row was unreadable.

Reported on **Catppuccin** and **Tokyo Night**, but it was latent across many presets — including the light themes (a dark default fg on a light selection bar).

## Approach

Stop relying on the terminal's foreground. Pair every selection background with a **derived, contrast-guaranteed foreground**:

- **`readableForegroundFor(bg)`** (`colorSupport.ts`) — WCAG relative-luminance pick: black on light bars, white on dark. The 0.179 threshold is the luminance crossover where black and white give equal contrast, so the choice always maximizes it.
- **`createLogInkTheme`** derives `colors.selectionForeground` from the selection bg — a new semantic theme token, overridable per theme, that follows the *preserved* selection bg through the non-truecolor downgrade.
- Applied on the selected span in **history** (single / stacked / pending-commit rows), **status** (group header + file rows), **detail** (inspector action rows — key glyph + destructive marker), and **diff** (active file header — replacing the `inverse` swap that went low-contrast on light themes). Suppressed child spans inherit the foreground, so each row renders in one readable color.

### Why not reverse-video / `inverse`?

`inverse` swaps fg/bg per span, so a row of many differently-colored segments ends up striped — the code comments already record learning this. A single contrast-guaranteed foreground keeps the row uniform.

## Audit

Computed the selected-row contrast for **all 49 themes** (selection bg vs derived fg): **every theme clears WCAG AA**, minimum **6.95:1** (oceanic-next), most ≥ 9:1. No theme can regress to an uncontrolled foreground.

## Verification

- Regenerated history captures and confirmed readability on dark (**catppuccin**, **tokyo-night**) and light (**papercolor-light**, **modus-operandi**) themes — selected row is now crisp black/white-on-bar.
- New unit tests: `readableForegroundFor` (dark→white, light→black, non-hex→undefined, every built-in selection resolves) and the `selectionForeground` token (derivation, downgrade, override, no-color).
- Full `src/workstation` suite: **734 passed**; two selected-row snapshots updated (only added a `color`). `tsc --noEmit` clean, `eslint` clean.