### PR TITLE
test: give real-git-repo suites realistic timeouts

### DIFF
--- a/src/commands/log/data.test.ts
+++ b/src/commands/log/data.test.ts
@@ -20,6 +20,13 @@ import {
 } from './data'
 import { LogOptions } from './config'
 
+// Several tests here spin up a real temp git repo (mkdtemp + git init +
+// many commits) and shell out to walk the log. The default 5s budget is
+// too tight for that I/O once the full suite runs all workers in parallel
+// (e.g. during `npm run release`), producing flaky timeouts that aren't
+// real failures. Give the whole file a generous budget instead.
+jest.setTimeout(30_000)
+
 function argv(overrides: Partial<LogOptions> = {}): Arguments<LogOptions> {
   return {
     $0: 'coco',

--- a/src/lib/parsers/default/__evals__/scenarioInputs.test.ts
+++ b/src/lib/parsers/default/__evals__/scenarioInputs.test.ts
@@ -11,7 +11,7 @@ describe('buildScenarioFixtures', () => {
     // the feature-pr-ready scenario, then walks the log calling
     // `git show --numstat` + per-file `git show` for each commit.
     // Under load (parallel jest workers) the shell-out cost adds
-    // up. The 15s budget is comfortably under any reasonable CI
+    // up. The 30s budget is comfortably under any reasonable CI
     // run-time and avoids the periodic flake we saw under default.
     const { repo, fixtures } = await buildScenarioFixtures('feature-pr-ready')
     try {
@@ -35,10 +35,10 @@ describe('buildScenarioFixtures', () => {
     } finally {
       await repo.cleanup()
     }
-  }, 15_000)
+  }, 30_000)
 
   it('extracts the same byte-identical fixture set across runs (determinism)', async () => {
-    // Same 15s budget as the sibling test — this one spins up
+    // Same 30s budget as the sibling test — this one spins up
     // TWO temp git repos serially (to verify determinism), so the
     // cost is roughly double. Same rationale as the other test:
     // shell-out cost under parallel jest load can exceed 5s.
@@ -58,5 +58,5 @@ describe('buildScenarioFixtures', () => {
       await a.repo.cleanup()
       await b.repo.cleanup()
     }
-  }, 15_000)
+  }, 30_000)
 })

--- a/src/lib/simple-git/isEmptyRepo.test.ts
+++ b/src/lib/simple-git/isEmptyRepo.test.ts
@@ -4,6 +4,12 @@ import { join } from 'path'
 import { simpleGit, type SimpleGit } from 'simple-git'
 import { isEmptyRepo } from './isEmptyRepo'
 
+// Every test spins up a real temp git repo (mkdtemp + git init + config +
+// branch). The default 5s budget is too tight for that subprocess I/O once
+// the full suite saturates all jest workers in parallel (e.g. during
+// `npm run release`), producing flaky timeouts that aren't real failures.
+jest.setTimeout(30_000)
+
 async function makeFreshRepo(): Promise<{ git: SimpleGit; path: string }> {
   const path = await mkdtemp(join(tmpdir(), 'coco-empty-repo-test-'))
   const git = simpleGit(path)


### PR DESCRIPTION
## Why

`npm run release` aborted at the `npm test` hook with timeout failures — **not** logic failures. The affected tests spin up real temp git repos (`mkdtemp` + `git init` + commits) and shell out to git. At the default 5s budget they time out once the full 194-suite run saturates every jest worker in parallel (release-it runs the whole suite at once). They pass in isolation and in CI.

## Fix

Budgets only — no production code:
- `src/commands/log/data.test.ts` — file-level `jest.setTimeout(30_000)` (4 real-repo tests, previously default 5s; one reliably exceeded it).
- `src/lib/simple-git/isEmptyRepo.test.ts` — file-level `jest.setTimeout(30_000)` (3 real-repo tests on default 5s).
- `src/lib/parsers/default/__evals__/scenarioInputs.test.ts` — 15s → 30s (still tipped over under full-suite load).

## Verified

The three files pass together (32 tests); `eslint` clean. Targets the genuinely under-budgeted default-5s real-git tests so the release gate stops flaking.