### PR TITLE
feat(workstation): interactive theme picker with live preview (gC)

### DIFF
--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -14,6 +14,8 @@ import {
     LogInkCompareRef,
     LogInkSidebarTab,
     LogInkState,
+    filterThemePresets,
+    getThemePickerSelection,
     isLogInkNestedRepo,
     parseLogInkHistoryFetchPrefix,
 } from './inkViewModel'
@@ -65,6 +67,7 @@ export type LogInkInputEvent =
   | { type: 'openFileInEditor'; path: string }
   | { type: 'yankFromActiveView'; short?: boolean }
   | { type: 'yankText'; value: string; label: string }
+  | { type: 'applyThemePreset'; preset: string }
 
 export type LogInkInputContext = {
   detailFileCount?: number
@@ -667,6 +670,10 @@ export function getLogInkPaletteExecuteEvents(
     case 'commandPalette':
       // Re-toggling closes; the dispatcher will close after execute anyway.
       return []
+    case 'themePicker':
+      // Palette closes on execute (toggleCommandPalette runs first), then
+      // this opens the theme picker.
+      return [action({ type: 'toggleThemePicker' })]
     case 'workflowDeleteBranch':
     case 'workflowDeleteTag':
     case 'workflowDropStash':
@@ -1241,6 +1248,49 @@ export function getLogInkInputEvents(
     return []
   }
 
+  if (state.showThemePicker) {
+    const filtered = filterThemePresets(state.themePickerFilter)
+
+    if (key.escape) {
+      // Two-stage Esc: clear a non-empty filter first, then close (and
+      // revert the live preview to the previously-active theme).
+      if (state.themePickerFilter.length > 0) {
+        return [action({ type: 'clearThemePickerFilter' })]
+      }
+      return [action({ type: 'toggleThemePicker' })]
+    }
+
+    if (key.return) {
+      const selected = getThemePickerSelection(state)
+      if (!selected) {
+        return [action({ type: 'toggleThemePicker' })]
+      }
+      return [
+        action({ type: 'toggleThemePicker' }),
+        { type: 'applyThemePreset', preset: selected },
+      ]
+    }
+
+    if (key.upArrow || (key.ctrl && inputValue === 'p')) {
+      return [action({ type: 'moveThemePicker', delta: -1, presetCount: filtered.length })]
+    }
+    if (key.downArrow || (key.ctrl && inputValue === 'n')) {
+      return [action({ type: 'moveThemePicker', delta: 1, presetCount: filtered.length })]
+    }
+    if (key.backspace || key.delete) {
+      return [action({ type: 'backspaceThemePickerFilter' })]
+    }
+    if (key.ctrl && inputValue === 'u') {
+      return [action({ type: 'clearThemePickerFilter' })]
+    }
+    // All other printable input filters the list (so `j`/`k` type into the
+    // filter rather than navigating — matching the command palette).
+    if (inputValue && !key.ctrl && !key.meta) {
+      return [action({ type: 'appendThemePickerFilter', value: inputValue })]
+    }
+    return []
+  }
+
   if (state.showCommandPalette) {
     const filtered = filterLogInkPaletteCommands(
       getLogInkPaletteCommands(),
@@ -1547,6 +1597,14 @@ export function getLogInkInputEvents(
     return [
       action({ type: 'setPendingKey', value: undefined }),
       action({ type: 'setStatus', value: 'gT creates a tag at the cursored commit on the history view', kind: 'warning' }),
+    ]
+  }
+
+  // gC — open the theme picker (browse + live-preview + apply a color theme).
+  if (state.pendingKey === 'g' && inputValue === 'C') {
+    return [
+      action({ type: 'setPendingKey', value: undefined }),
+      action({ type: 'toggleThemePicker' }),
     ]
   }
 

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -603,4 +603,28 @@ describe('log Ink keymap', () => {
       expect(binding!.keys).toContain('gx')
     })
   })
+
+  describe('theme picker binding (gC)', () => {
+    it('registers themePicker on the gC chord', () => {
+      const binding = LOG_INK_KEY_BINDINGS.find((b) => b.id === 'themePicker')
+      expect(binding).toBeDefined()
+      expect(binding!.keys).toContain('gC')
+    })
+
+    it('surfaces in the g-chord which-key continuations', () => {
+      const continuations = getLogInkChordContinuations('g')
+      expect(continuations.some((c) => c.key === 'C' && c.label === 'theme picker')).toBe(true)
+    })
+
+    it('is reachable from the command palette', () => {
+      const ids = getLogInkPaletteCommands().map((command) => command.id)
+      expect(ids).toContain('themePicker')
+    })
+
+    it('does not collide with any other binding', () => {
+      const withGc = LOG_INK_KEY_BINDINGS.filter((b) => b.keys.includes('gC'))
+      expect(withGc).toHaveLength(1)
+      expect(withGc[0].id).toBe('themePicker')
+    })
+  })
 })

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -8,6 +8,7 @@ import {
 export type LogInkCommandId =
   | 'clearSearch'
   | 'commandPalette'
+  | 'themePicker'
   | 'commit'
   | 'cycleSort'
   | 'editCommit'
@@ -534,6 +535,13 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     contexts: ['history'],
   },
   {
+    id: 'themePicker',
+    keys: ['gC'],
+    label: 'theme picker',
+    description: 'Browse, live-preview, and apply a color theme.',
+    contexts: ['normal'],
+  },
+  {
     id: 'viewChangelog',
     keys: ['L'],
     label: 'changelog',
@@ -689,6 +697,7 @@ const BINDING_CATEGORY_BY_ID: Partial<Record<LogInkCommandId, LogInkBindingCateg
   //    them above everything else.
   help: 'essentials',
   commandPalette: 'essentials',
+  themePicker: 'view',
   quit: 'essentials',
   refresh: 'essentials',
   navigateBack: 'essentials',

--- a/src/commands/log/inkRuntime.ts
+++ b/src/commands/log/inkRuntime.ts
@@ -126,6 +126,7 @@ export async function startInkInteractiveLog(
     React,
     rows,
     theme: createLogInkTheme(options.theme),
+    themeConfig: options.theme,
     resumeRef,
   })
   const instance = ink.render(app, getLogInkRenderOptions({ input, output, error }))

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -3,7 +3,9 @@ import {
     DEFAULT_LOG_INK_STATUS_FILTER_MASK,
     applyLogInkAction,
     createLogInkState,
+    filterThemePresets,
     getActiveLogInkRepoFrame,
+    getThemePickerSelection,
     getLogInkRepoStackLabels,
     getLogInkSidebarTabs,
     getSelectedInkCommit,
@@ -1868,6 +1870,73 @@ describe('triage filter preset cycling (#882 phase 6)', () => {
         value: true,
       })
       expect(next.pendingKey).toBeUndefined()
+    })
+  })
+
+  describe('theme picker', () => {
+    it('starts closed with a clean filter/cursor', () => {
+      const state = createLogInkState(rows)
+      expect(state.showThemePicker).toBe(false)
+      expect(state.themePickerFilter).toBe('')
+      expect(state.themePickerIndex).toBe(0)
+    })
+
+    it('toggleThemePicker opens/closes and closes other overlays', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'toggleHelp' })
+      state = applyLogInkAction(state, { type: 'toggleThemePicker' })
+      expect(state.showThemePicker).toBe(true)
+      expect(state.showHelp).toBe(false)
+      expect(state.showCommandPalette).toBe(false)
+
+      state = applyLogInkAction(state, { type: 'toggleThemePicker' })
+      expect(state.showThemePicker).toBe(false)
+    })
+
+    it('filters presets by case-insensitive substring', () => {
+      expect(filterThemePresets('')).toContain('catppuccin')
+      const tokyo = filterThemePresets('TOKYO')
+      expect(tokyo.length).toBeGreaterThan(0)
+      expect(tokyo.every((p) => p.includes('tokyo'))).toBe(true)
+      expect(filterThemePresets('definitely-not-a-theme')).toHaveLength(0)
+    })
+
+    it('moveThemePicker clamps the cursor to the filtered list', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'toggleThemePicker' })
+      const count = filterThemePresets('').length
+
+      state = applyLogInkAction(state, { type: 'moveThemePicker', delta: -1, presetCount: count })
+      expect(state.themePickerIndex).toBe(0) // clamped at the top
+
+      state = applyLogInkAction(state, { type: 'moveThemePicker', delta: 999, presetCount: count })
+      expect(state.themePickerIndex).toBe(count - 1) // clamped at the bottom
+    })
+
+    it('typing into the filter resets the cursor and getThemePickerSelection follows it', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'toggleThemePicker' })
+      state = applyLogInkAction(state, { type: 'moveThemePicker', delta: 3, presetCount: 50 })
+      expect(state.themePickerIndex).toBe(3)
+
+      state = applyLogInkAction(state, { type: 'appendThemePickerFilter', value: 'gruvbox' })
+      expect(state.themePickerFilter).toBe('gruvbox')
+      expect(state.themePickerIndex).toBe(0)
+      expect(getThemePickerSelection(state)).toBe('gruvbox')
+
+      state = applyLogInkAction(state, { type: 'backspaceThemePickerFilter' })
+      expect(state.themePickerFilter).toBe('gruvbo')
+
+      state = applyLogInkAction(state, { type: 'clearThemePickerFilter' })
+      expect(state.themePickerFilter).toBe('')
+      expect(state.themePickerIndex).toBe(0)
+    })
+
+    it('getThemePickerSelection is undefined when nothing matches', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'toggleThemePicker' })
+      state = applyLogInkAction(state, { type: 'appendThemePickerFilter', value: 'zzzzz' })
+      expect(getThemePickerSelection(state)).toBeUndefined()
     })
   })
 })

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -1,5 +1,6 @@
 import { GitLogCommitRow, GitLogRow, getCommitRows } from './data'
 import { hashesMatchAny } from '../../git/hashes'
+import { getLogInkThemePresets, type LogInkThemePreset } from '../../workstation/chrome/theme'
 import {
     CommitComposeAction,
     CommitComposeState,
@@ -287,6 +288,15 @@ export type LogInkState = {
   paletteFilter: string
   paletteSelectedIndex: number
   paletteRecent: string[]
+  /**
+   * Theme picker (`gC`) interaction state. `themePickerFilter` is the
+   * typed substring query; `themePickerIndex` is a cursor into the
+   * filtered preset list. While open, the workstation live-previews the
+   * cursored theme (wired in `app.ts`).
+   */
+  showThemePicker: boolean
+  themePickerFilter: string
+  themePickerIndex: number
   workflowActionId?: string
   pendingConfirmationId?: string
   /**
@@ -759,6 +769,11 @@ export type LogInkAction =
   | { type: 'toggleHelp' }
   | { type: 'scrollHelp'; delta: number }
   | { type: 'toggleCommandPalette' }
+  | { type: 'toggleThemePicker' }
+  | { type: 'moveThemePicker'; delta: number; presetCount: number }
+  | { type: 'appendThemePickerFilter'; value: string }
+  | { type: 'backspaceThemePickerFilter' }
+  | { type: 'clearThemePickerFilter' }
   | { type: 'cycleBranchSort' }
   | { type: 'cycleTagSort' }
   | { type: 'openInputPrompt'; kind: LogInkInputPromptKind; label: string; initial?: string; multiline?: boolean }
@@ -1259,6 +1274,9 @@ export function createLogInkState(
     paletteFilter: '',
     paletteSelectedIndex: 0,
     paletteRecent: [],
+    showThemePicker: false,
+    themePickerFilter: '',
+    themePickerIndex: 0,
     commitCompose: createCommitComposeState(),
     diffPreviewOffset: 0,
     worktreeDiffOffset: 0,
@@ -2072,6 +2090,49 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         pendingKey: undefined,
       }
     }
+    case 'toggleThemePicker': {
+      const opening = !state.showThemePicker
+      return {
+        ...state,
+        showThemePicker: opening,
+        // Only one overlay at a time — close help / palette on open.
+        showHelp: false,
+        showCommandPalette: false,
+        themePickerFilter: '',
+        themePickerIndex: 0,
+        pendingKey: undefined,
+      }
+    }
+    case 'moveThemePicker':
+      return {
+        ...state,
+        themePickerIndex: clampIndex(
+          state.themePickerIndex + action.delta,
+          action.presetCount
+        ),
+        pendingKey: undefined,
+      }
+    case 'appendThemePickerFilter':
+      return {
+        ...state,
+        themePickerFilter: `${state.themePickerFilter}${action.value}`,
+        themePickerIndex: 0,
+        pendingKey: undefined,
+      }
+    case 'backspaceThemePickerFilter':
+      return {
+        ...state,
+        themePickerFilter: state.themePickerFilter.slice(0, -1),
+        themePickerIndex: 0,
+        pendingKey: undefined,
+      }
+    case 'clearThemePickerFilter':
+      return {
+        ...state,
+        themePickerFilter: '',
+        themePickerIndex: 0,
+        pendingKey: undefined,
+      }
     case 'setChangelogLoading':
       return {
         ...state,
@@ -2354,4 +2415,32 @@ export function intentOpenComposeForFile(
   }
 
   return { type: 'navigateOpenComposeForFile', fileIndex: idx }
+}
+
+/**
+ * Filter the full preset list by a case-insensitive substring query. An
+ * empty query returns every preset in catalog order. Shared by the theme
+ * picker overlay renderer, the input handler (for cursor bounds), and the
+ * live-preview selector so all three agree on the same filtered list.
+ */
+export function filterThemePresets(filter: string): LogInkThemePreset[] {
+  const query = filter.trim().toLowerCase()
+  const all = getLogInkThemePresets()
+  if (!query) {
+    return all
+  }
+  return all.filter((preset) => preset.toLowerCase().includes(query))
+}
+
+/**
+ * The preset currently under the theme-picker cursor (clamped to the
+ * filtered list). `undefined` when the filter matches nothing.
+ */
+export function getThemePickerSelection(state: LogInkState): LogInkThemePreset | undefined {
+  const filtered = filterThemePresets(state.themePickerFilter)
+  if (filtered.length === 0) {
+    return undefined
+  }
+  const index = clampIndex(state.themePickerIndex, filtered.length)
+  return filtered[index]
 }

--- a/src/workstation/chrome/theme.ts
+++ b/src/workstation/chrome/theme.ts
@@ -739,6 +739,21 @@ export const THEME_PRESET_COLORS: Record<Exclude<LogInkThemePreset, 'monochrome'
   },
 }
 
+/**
+ * Ordered list of every selectable theme preset, for the `coco ui` theme
+ * picker and any UI that enumerates themes. `monochrome` isn't a key in
+ * `THEME_PRESET_COLORS` (it's handled via `noColor`), so it's spliced in
+ * right after `default` — the two non-color baselines sit together at the
+ * top, followed by the color themes in catalog order.
+ */
+export function getLogInkThemePresets(): LogInkThemePreset[] {
+  const keys = Object.keys(THEME_PRESET_COLORS) as Exclude<LogInkThemePreset, 'monochrome'>[]
+  const [first, ...rest] = keys
+  return first === 'default'
+    ? ['default', 'monochrome', ...rest]
+    : ['monochrome', ...keys]
+}
+
 function shouldUseAscii(term: string | undefined): boolean {
   if (!term) {
     return false

--- a/src/workstation/chrome/themePersistence.test.ts
+++ b/src/workstation/chrome/themePersistence.test.ts
@@ -1,0 +1,100 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { getSavedThemePreset, getXdgConfigPath, saveThemePreset } from './themePersistence'
+
+describe('theme preset persistence', () => {
+  let tmpRoot: string
+  let originalXdgConfigHome: string | undefined
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-theme-pref-'))
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME
+    process.env.XDG_CONFIG_HOME = tmpRoot
+  })
+
+  afterEach(() => {
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome
+    }
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('resolves the config path under XDG_CONFIG_HOME', () => {
+    expect(getXdgConfigPath()).toBe(path.join(tmpRoot, 'coco', 'config.json'))
+  })
+
+  it('falls back to ~/.config when XDG_CONFIG_HOME is unset', () => {
+    delete process.env.XDG_CONFIG_HOME
+    expect(getXdgConfigPath()).toBe(path.join(os.homedir(), '.config', 'coco', 'config.json'))
+  })
+
+  it('round-trips a saved preset', () => {
+    expect(getSavedThemePreset()).toBeUndefined()
+    expect(saveThemePreset('gruvbox')).toBe(true)
+    expect(getSavedThemePreset()).toBe('gruvbox')
+
+    expect(saveThemePreset('catppuccin')).toBe(true)
+    expect(getSavedThemePreset()).toBe('catppuccin')
+  })
+
+  it('writes logTui.theme.preset into a fresh config', () => {
+    saveThemePreset('tokyo-night')
+    const written = JSON.parse(fs.readFileSync(getXdgConfigPath(), 'utf8'))
+    expect(written).toEqual({ logTui: { theme: { preset: 'tokyo-night' } } })
+  })
+
+  it('preserves every other key in an existing config', () => {
+    const file = getXdgConfigPath()
+    fs.mkdirSync(path.dirname(file), { recursive: true })
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        $schema: './schema.json',
+        mode: 'interactive',
+        service: { provider: 'openai', model: 'gpt-4o' },
+        logTui: { idleTips: true, theme: { borderStyle: 'single' } },
+      })
+    )
+
+    expect(saveThemePreset('nord')).toBe(true)
+    const written = JSON.parse(fs.readFileSync(file, 'utf8'))
+    // Existing top-level + logTui sibling keys survive; only the preset is added.
+    expect(written.$schema).toBe('./schema.json')
+    expect(written.mode).toBe('interactive')
+    expect(written.service).toEqual({ provider: 'openai', model: 'gpt-4o' })
+    expect(written.logTui.idleTips).toBe(true)
+    expect(written.logTui.theme).toEqual({ borderStyle: 'single', preset: 'nord' })
+  })
+
+  it('accepts the monochrome + default baselines', () => {
+    expect(saveThemePreset('monochrome')).toBe(true)
+    expect(getSavedThemePreset()).toBe('monochrome')
+    expect(saveThemePreset('default')).toBe(true)
+    expect(getSavedThemePreset()).toBe('default')
+  })
+
+  it('rejects an unknown preset without writing', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(saveThemePreset('not-a-real-theme' as any)).toBe(false)
+    expect(fs.existsSync(getXdgConfigPath())).toBe(false)
+  })
+
+  it('ignores a malformed existing config rather than throwing', () => {
+    const file = getXdgConfigPath()
+    fs.mkdirSync(path.dirname(file), { recursive: true })
+    fs.writeFileSync(file, '{ this is not json')
+
+    expect(() => saveThemePreset('dracula')).not.toThrow()
+    expect(getSavedThemePreset()).toBe('dracula')
+  })
+
+  it('is best-effort: returns false (no throw) when the path cannot be written', () => {
+    process.env.XDG_CONFIG_HOME = '/dev/null/forbidden'
+    expect(() => saveThemePreset('gruvbox')).not.toThrow()
+    expect(saveThemePreset('gruvbox')).toBe(false)
+  })
+})

--- a/src/workstation/chrome/themePersistence.ts
+++ b/src/workstation/chrome/themePersistence.ts
@@ -1,0 +1,83 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { getLogInkThemePresets, type LogInkThemePreset } from './theme'
+
+/**
+ * Persist the user's chosen `coco ui` theme preset to the global XDG
+ * config (`$XDG_CONFIG_HOME/coco/config.json`, default `~/.config/...`),
+ * so a theme picked in the workstation sticks across every repo and
+ * launch. This is the same file `loadXDGConfig` reads.
+ *
+ * Read-modify-write that preserves every other key (we only touch
+ * `logTui.theme.preset`), unlike the whole-object project-config writer.
+ * Best-effort: a read-only HOME or malformed file never throws — the
+ * picker still applies the theme for the session.
+ */
+
+const VALID_PRESETS = new Set<string>(getLogInkThemePresets())
+
+export function getXdgConfigPath(): string {
+  const home = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config')
+  return path.join(home, 'coco', 'config.json')
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Write `logTui.theme.preset = <preset>` into the global config, merging
+ * into any existing content. Returns `true` on success, `false` if the
+ * preset is unknown or the write failed (caller treats failure as
+ * "applied for this session only").
+ */
+export function saveThemePreset(preset: LogInkThemePreset): boolean {
+  if (!VALID_PRESETS.has(preset)) {
+    return false
+  }
+  const file = getXdgConfigPath()
+  try {
+    let config: Record<string, unknown> = {}
+    try {
+      const parsed: unknown = JSON.parse(fs.readFileSync(file, 'utf8'))
+      if (isRecord(parsed)) {
+        config = parsed
+      }
+    } catch {
+      // No existing file (or unreadable/malformed) — start fresh.
+      config = {}
+    }
+
+    const logTui = isRecord(config.logTui) ? config.logTui : {}
+    const theme = isRecord(logTui.theme) ? logTui.theme : {}
+    config.logTui = { ...logTui, theme: { ...theme, preset } }
+
+    fs.mkdirSync(path.dirname(file), { recursive: true })
+    fs.writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Read back the persisted preset (used by tests and any caller that
+ * wants to reflect the saved value). Returns `undefined` when nothing
+ * valid is stored.
+ */
+export function getSavedThemePreset(): LogInkThemePreset | undefined {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(getXdgConfigPath(), 'utf8'))
+    if (!isRecord(parsed)) return undefined
+    const logTui = isRecord(parsed.logTui) ? parsed.logTui : undefined
+    const theme = logTui && isRecord(logTui.theme) ? logTui.theme : undefined
+    const preset = theme?.preset
+    return typeof preset === 'string' && VALID_PRESETS.has(preset)
+      ? (preset as LogInkThemePreset)
+      : undefined
+  } catch {
+    return undefined
+  }
+}

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -91,6 +91,8 @@ import {
     getLogInkInputEvents,
 } from '../../commands/log/inkInput'
 import { hasSeenOnboarding, markOnboardingSeen } from '../chrome/onboarding'
+import { createLogInkTheme, type LogInkThemePreset } from '../chrome/theme'
+import { saveThemePreset } from '../chrome/themePersistence'
 import { formatSplitApplySuccess } from '../chrome/postApplyHints'
 import { SPINNER_TICK_MS } from '../chrome/spinner'
 import { createInitialContextStatus, createRepoFrameRuntime } from './repoFrameFactory'
@@ -129,6 +131,7 @@ import {
     applyLogInkAction,
     createLogInkState,
     getSelectedInkCommit,
+    getThemePickerSelection,
 } from '../../commands/log/inkViewModel'
 import { getGitOperationOverview } from '../../git/operationData'
 import { openProviderUrl } from '../../git/providerActions'
@@ -463,9 +466,26 @@ function enrichFilterActionWithRectification(
 }
 
 export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
-  const { appLabel, clipboardRunner, dateBucketingEnabled, git: rootGit, idleTipsEnabled, ink, initialView, loadRows, logArgv, React, resumeRef, rows, theme } = deps
+  const { appLabel, clipboardRunner, dateBucketingEnabled, git: rootGit, idleTipsEnabled, ink, initialView, loadRows, logArgv, React, resumeRef, rows, theme: baseTheme, themeConfig } = deps
   const { Box, Text, useApp, useInput, useWindowSize } = ink
   const h = React.createElement
+
+  // Theme picker (gC) — live preview + apply. `themePreviewPreset` follows
+  // the picker cursor while the overlay is open; `themeSessionPreset` is the
+  // applied choice that survives close. The effective theme is rebuilt from
+  // the original `themeConfig` so ascii/border/noColor + truecolor-downgrade
+  // semantics are preserved; when neither override is set we use the static
+  // `baseTheme` unchanged (so behavior is identical until the picker is used).
+  const [themePreviewPreset, setThemePreviewPreset] = React.useState<LogInkThemePreset | undefined>(undefined)
+  const [themeSessionPreset, setThemeSessionPreset] = React.useState<LogInkThemePreset | undefined>(undefined)
+  const effectiveThemePreset = themePreviewPreset ?? themeSessionPreset
+  const theme = React.useMemo(
+    () =>
+      effectiveThemePreset
+        ? createLogInkTheme({ ...themeConfig, preset: effectiveThemePreset })
+        : baseTheme,
+    [effectiveThemePreset, themeConfig, baseTheme]
+  )
   const { exit } = useApp()
   const windowSize = useWindowSize()
   // Bumping this on SIGCONT forces the existing tree to repaint so users
@@ -496,6 +516,19 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       bootLoading: Boolean(loadRows),
     })
   )
+
+  // Theme picker live preview: keep `themePreviewPreset` in sync with the
+  // preset under the picker cursor while the overlay is open; clear it when
+  // the overlay closes so the theme reverts to the applied session preset
+  // (or the original config theme). The derived-theme `useMemo` above does
+  // the actual re-render from this state.
+  const themePickerSelection = state.showThemePicker
+    ? getThemePickerSelection(state)
+    : undefined
+  React.useEffect(() => {
+    setThemePreviewPreset(state.showThemePicker ? themePickerSelection : undefined)
+  }, [state.showThemePicker, themePickerSelection])
+
   // Nested-repo runtime stack (#931). Each frame holds the live
   // `SimpleGit`, the loaded `LogInkContext`, and the per-key load
   // status the chrome reads. The active (top-of-stack) entry drives
@@ -4466,6 +4499,14 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         openInEditor(event.path)
       } else if (event.type === 'yankFromActiveView') {
         void yankFromActiveView(event.short)
+      } else if (event.type === 'applyThemePreset') {
+        // Apply for the session immediately, and best-effort persist to the
+        // global config so it sticks across launches. The picker has already
+        // dispatched `toggleThemePicker` (closing it), which clears the
+        // preview via the sync effect below — the session preset takes over.
+        const preset = event.preset as LogInkThemePreset
+        setThemeSessionPreset(preset)
+        saveThemePreset(preset)
       } else {
         // P4.5: enrich filter-mutating actions with a precomputed
         // selection snapshot so the reducer can preserve the cursor on

--- a/src/workstation/runtime/detailPanel.ts
+++ b/src/workstation/runtime/detailPanel.ts
@@ -41,6 +41,7 @@ import {
     renderConfirmationPanel,
     renderHelpPanel,
     renderInputPromptPanel,
+    renderThemePickerOverlay,
 } from './overlays'
 import type { LogInkComponents, LogInkContext } from './types'
 
@@ -114,6 +115,10 @@ export function renderDetailPanel(
 
   if (state.showCommandPalette) {
     return renderCommandPalette(h, components, state, width, theme, focused)
+  }
+
+  if (state.showThemePicker) {
+    return renderThemePickerOverlay(h, components, state, width, theme, focused)
   }
 
   if (state.inputPrompt) {

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -20,6 +20,7 @@ import type * as ReactTypes from 'react'
 import { pickSpinnerFrame } from '../chrome/spinner'
 import { truncateCells } from '../chrome/text'
 import type { LogInkTheme } from '../chrome/theme'
+import { THEME_PRESET_COLORS } from '../chrome/theme'
 import {
     filterLogInkPaletteCommands,
     formatBindingKeys,
@@ -28,6 +29,7 @@ import {
     getLogInkPaletteCommands,
 } from '../../commands/log/inkKeymap'
 import type { LogInkState } from '../../commands/log/inkViewModel'
+import { filterThemePresets } from '../../commands/log/inkViewModel'
 import { getLogInkWorkflowActionById } from '../../commands/log/inkWorkflows'
 import type { LogInkComponents } from './types'
 import { focusBorderColor, panelTitle } from './utils'
@@ -397,6 +399,84 @@ export function renderCommandPalette(
   ...itemLines,
   ...(paletteHasMoreBelow
     ? [h(Text, { key: 'palette-more-below', dimColor: true }, `  ↓ ${filtered.length - (startIndex + listRows)} more below`)]
+    : []))
+}
+
+/**
+ * Theme picker overlay (`gC`). Renders in the detail column like the
+ * command palette so the rest of the workstation live-previews the
+ * cursored theme underneath. Type to filter, ↑/↓ to move, Enter applies
+ * (and persists), Esc cancels (reverting the preview).
+ */
+export function renderThemePickerOverlay(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  width: number,
+  theme: LogInkTheme,
+  focused: boolean
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const filtered = filterThemePresets(state.themePickerFilter)
+
+  const selectedIndex = filtered.length === 0
+    ? 0
+    : Math.max(0, Math.min(state.themePickerIndex, filtered.length - 1))
+
+  const listRows = 14
+  const startIndex = Math.max(0, selectedIndex - Math.floor(listRows / 2))
+  const visible = filtered.slice(startIndex, startIndex + listRows)
+
+  const inputLine = `> ${state.themePickerFilter}_`
+  const matchSummary = filtered.length === 0
+    ? 'no matches'
+    : `${filtered.length} ${filtered.length === 1 ? 'theme' : 'themes'}`
+  const hint = '↑/↓ select · type to filter · enter apply · esc close'
+
+  const itemLines = filtered.length === 0
+    ? [h(Text, { key: 'theme-empty', dimColor: true }, 'No themes match the current filter.')]
+    : visible.map((preset, offset) => {
+      const index = startIndex + offset
+      const isSelected = index === selectedIndex
+      const cursor = isSelected ? '>' : ' '
+      // Accent swatch per theme (no swatch for the monochrome baseline or
+      // when color is off). `default` is the only ANSI-named accent.
+      const accent = preset === 'monochrome'
+        ? undefined
+        : THEME_PRESET_COLORS[preset]?.accent
+      const swatch = accent && !theme.noColor
+        ? h(Text, { key: `theme-swatch-${preset}`, color: accent }, '● ')
+        : h(Text, { key: `theme-swatch-${preset}`, dimColor: true }, '· ')
+      return h(Text, {
+        key: `theme-${preset}`,
+        bold: isSelected,
+        dimColor: !isSelected,
+      }, `${cursor} `, swatch, truncateCells(preset, width - 8))
+    })
+
+  const hasMoreAbove = startIndex > 0 && filtered.length > 0
+  const hasMoreBelow = startIndex + listRows < filtered.length
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    width,
+    paddingX: 1,
+  },
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle('Theme picker', focused)),
+    h(Text, { dimColor: true }, matchSummary)
+  ),
+  h(Text, { color: theme.colors.accent }, truncateCells(inputLine, width - 4)),
+  h(Text, { dimColor: true }, truncateCells(hint, width - 4)),
+  h(Text, undefined, ''),
+  ...(hasMoreAbove
+    ? [h(Text, { key: 'theme-more-above', dimColor: true }, `  ↑ ${startIndex} more above`)]
+    : []),
+  ...itemLines,
+  ...(hasMoreBelow
+    ? [h(Text, { key: 'theme-more-below', dimColor: true }, `  ↓ ${filtered.length - (startIndex + listRows)} more below`)]
     : []))
 }
 

--- a/src/workstation/runtime/types.ts
+++ b/src/workstation/runtime/types.ts
@@ -35,7 +35,7 @@ import type { LogArgv } from '../../commands/log/config'
 import type { GitLogRow } from '../../commands/log/data'
 import type { LogInkView } from '../../commands/log/inkViewModel'
 import type { LogInkInputKey } from '../../commands/log/inkInput'
-import type { LogInkTheme } from '../chrome/theme'
+import type { LogInkTheme, LogInkThemeConfig } from '../chrome/theme'
 
 export type LogInkContext = {
   bisect?: BisectStatus
@@ -151,6 +151,14 @@ export type LogInkComponentDeps = LogInkRuntime & {
    */
   loadRows?: () => Promise<GitLogRow[]>
   theme: LogInkTheme
+  /**
+   * The original theme *config* (preset + ascii/borderStyle/colors) the
+   * built `theme` was derived from. The theme picker rebuilds the live
+   * theme from this (`createLogInkTheme({ ...themeConfig, preset })`) so a
+   * preview preserves ascii/border/noColor semantics. Optional — absent in
+   * older callers, in which case the picker just falls back to `theme`.
+   */
+  themeConfig?: LogInkThemeConfig
   /**
    * Mutable ref the runtime fills with a force-render callback. The
    * terminal-lifecycle module invokes it on `SIGCONT` so users land on a


### PR DESCRIPTION
## What

Browse, **live-preview**, and apply any built-in color theme from inside `coco ui` — opened with the **`gC`** chord or via the `:` command palette. Because it's built into `LogInkApp`, it also works in the `coco workspace` repo drill-in for free.

- **Live preview** — as the cursor moves, the whole workstation re-renders in that theme underneath the overlay.
- **Filter** — type to substring-filter the 49-theme list; `↑/↓` (or `Ctrl-p/n`) to move; **Enter** applies; **Esc** cancels (two-stage: clears a non-empty filter first).
- **Persists** the choice to `logTui.theme.preset` in the **global XDG config** (`~/.config/coco/config.json`), best-effort + merge-preserving, so it sticks across every repo and launch. Cancel reverts to the previously-active theme.

## How (the interesting part)

The theme was a **static dep** threaded as a prop. To get live preview without touching every render call-site, `app.ts` now derives the live `theme` via `useMemo` from two new state hooks — `themePreviewPreset` (cursor-follow) and `themeSessionPreset` (applied) — shadowing the prop. The original `themeConfig` is threaded through `LogInkComponentDeps` so a rebuilt preview preserves ascii / border / `noColor` + the truecolor-downgrade semantics. When neither override is set, behavior is byte-identical to before.

The overlay mirrors the command palette (renders in the detail column), and the state machine / input / keymap all follow the palette's established patterns.

## Files
New: `themePersistence.ts` (+test), `getLogInkThemePresets()`. Modified: `app.ts`, `overlays.ts`, `detailPanel.ts`, `types.ts`, `inkRuntime.ts`, `inkViewModel.ts`, `inkInput.ts`, `inkKeymap.ts` (+ viewmodel/keymap tests).

## Verification
- `tsc --noEmit` clean; `eslint` clean on all touched files; no schema drift.
- **1319** workstation/log/ui tests pass, incl. new coverage: persistence round-trip / merge-preserve / best-effort-failure; reducer + filter/selection; `gC` keymap + palette command + which-key continuation + no-collision.

## Follow-ups (intentionally out of scope)
- Fuzzy (vs substring) filter.
- The workspace **top-level list** chrome (Phase 4) — separate state model.
- A VHS demo recipe for the marketing site.