### PR TITLE
feat(workstation): unify the active-row caret (❯) across all surfaces

### DIFF
--- a/src/workstation/surfaces/branches/index.ts
+++ b/src/workstation/surfaces/branches/index.ts
@@ -80,7 +80,7 @@ export function renderBranchesSurface(
       : visible.map((branch, offset) => {
         const index = startIndex + offset
         const isSelected = index === selected
-        const cursor = isSelected ? '>' : ' '
+        const cursor = isSelected ? (theme.ascii ? '>' : '❯') : ' '
         const marker = branchRowMarker(branch, { ascii: theme.ascii })
         const markerColor = getBranchRowMarkerColor(marker.kind, theme)
         const divergence = formatBranchDivergence(branch, { ascii: theme.ascii })

--- a/src/workstation/surfaces/conflicts/index.ts
+++ b/src/workstation/surfaces/conflicts/index.ts
@@ -106,7 +106,7 @@ export function renderConflictsSurface(
     : visible.map((file, offset) => {
       const index = startIndex + offset
       const isSelected = index === selected
-      const cursor = isSelected ? '>' : ' '
+      const cursor = isSelected ? (theme.ascii ? '>' : '❯') : ' '
       const code = `${file.indexStatus}${file.worktreeStatus}`
       const label = statusLabel(file)
       return h(Text, {

--- a/src/workstation/surfaces/detail/index.ts
+++ b/src/workstation/surfaces/detail/index.ts
@@ -107,9 +107,12 @@ function renderInspectorActionsSection(
   const KEY_COLUMN = 5
   const GAP = '  '
   const DESTRUCTIVE_SUFFIX = '  [!]'
+  // Leading `❯ ` / `  ` active-row caret gutter — unified with the history /
+  // status / diff active-row cue (and the only signal under NO_COLOR).
+  const CARET_GUTTER = 2
   const labelBudget = Math.max(
     4,
-    width - 4 /* border + padX */ - KEY_COLUMN - GAP.length - DESTRUCTIVE_SUFFIX.length
+    width - 4 /* border + padX */ - CARET_GUTTER - KEY_COLUMN - GAP.length - DESTRUCTIVE_SUFFIX.length
   )
 
   const cursorIndex = options.cursorIndex ?? 0
@@ -128,6 +131,10 @@ function renderInspectorActionsSection(
       const keyCell = action.key.padEnd(KEY_COLUMN)
       const label = truncateCells(action.label, labelBudget)
       const children: Array<string | ReactTypes.ReactElement> = [
+        h(Text, {
+          key: `actions-${index}-caret`,
+          bold: isSelected,
+        }, isSelected ? (theme.ascii ? '> ' : '❯ ') : '  '),
         h(Text, {
           key: `actions-${index}-key`,
           color: selectedFg ?? (action.destructive ? theme.colors.danger : theme.colors.accent),
@@ -222,7 +229,7 @@ function renderCommitFileList(
   return visible.map((file, offset) => {
     const index = startIndex + offset
     const isSelected = index === clamped
-    const cursor = isSelected ? '>' : ' '
+    const cursor = isSelected ? (theme.ascii ? '>' : '❯') : ' '
     const stats = formatChangedFileStats(file)
     const renamed = file.oldPath ? ` (was ${file.oldPath})` : ''
     const statusCode = file.status.padEnd(3)

--- a/src/workstation/surfaces/diff/index.ts
+++ b/src/workstation/surfaces/diff/index.ts
@@ -143,7 +143,9 @@ export function renderDiffSurface(
             // active file's header gets selection styling so the user
             // sees at a glance which file the cursor is inside.
             const isActive = absoluteIndex === activeStartLine
-            const arrow = theme.ascii ? '> ' : '▾ '
+            // `❯` (ascii `> `) marks the active file header — unified with
+            // the history / status active-row caret for a consistent cue.
+            const arrow = isActive ? (theme.ascii ? '> ' : '❯ ') : (theme.ascii ? '> ' : '▾ ')
             const activeHeader = isActive && focused && !theme.noColor
             return h(Text, {
               key: `stash-diff-line-${absoluteIndex}`,

--- a/src/workstation/surfaces/issuesTriage/index.ts
+++ b/src/workstation/surfaces/issuesTriage/index.ts
@@ -135,7 +135,7 @@ export function renderIssuesTriageSurface(
       bodyLines = windowed.map((issue, offset) => {
         const index = startIndex + offset
         const isSelected = index === selected
-        const cursor = isSelected ? '>' : ' '
+        const cursor = isSelected ? (theme.ascii ? '>' : '❯') : ' '
         const numStr = `#${issue.number}`.padEnd(numberColWidth)
         const stateStr = issue.state.toLowerCase().padEnd(6)
         const authorStr = (issue.author || '').padEnd(authorColWidth)

--- a/src/workstation/surfaces/pullRequestTriage/index.ts
+++ b/src/workstation/surfaces/pullRequestTriage/index.ts
@@ -189,7 +189,7 @@ export function renderPullRequestTriageSurface(
       bodyLines = windowed.map((pr, offset) => {
         const index = startIndex + offset
         const isSelected = index === selected
-        const cursor = isSelected ? '>' : ' '
+        const cursor = isSelected ? (theme.ascii ? '>' : '❯') : ' '
         const numStr = `#${pr.number}`.padEnd(numberColWidth)
         const stateLabel = pr.isDraft ? 'draft' : pr.state.toLowerCase()
         const stateStr = stateLabel.padEnd(6)

--- a/src/workstation/surfaces/reflog/index.ts
+++ b/src/workstation/surfaces/reflog/index.ts
@@ -78,7 +78,7 @@ export function renderReflogSurface(
       : splitVisible.map(({ entry, parts }, offset) => {
         const index = startIndex + offset
         const isSelected = index === selected
-        const cursor = isSelected ? '>' : ' '
+        const cursor = isSelected ? (theme.ascii ? '>' : '❯') : ' '
         const datePadded = truncateCells(entry.relativeDate, dateColWidth).padEnd(dateColWidth)
         const actionPadded = truncateCells(parts.action, actionColWidth).padEnd(actionColWidth)
         const hashPadded = truncateCells(entry.hash, hashColWidth).padEnd(hashColWidth)

--- a/src/workstation/surfaces/stash/index.ts
+++ b/src/workstation/surfaces/stash/index.ts
@@ -57,7 +57,7 @@ export function renderStashSurface(
       : visible.map((stash, offset) => {
         const index = startIndex + offset
         const isSelected = index === selected
-        const cursor = isSelected ? '>' : ' '
+        const cursor = isSelected ? (theme.ascii ? '>' : '❯') : ' '
         return h(Text, {
           key: `stash-${index}`,
           bold: isSelected,

--- a/src/workstation/surfaces/status/__snapshots__/statusRender.test.ts.snap
+++ b/src/workstation/surfaces/status/__snapshots__/statusRender.test.ts.snap
@@ -96,7 +96,7 @@ exports[`renderStatusSurface structural snapshot — mixed staged + unstaged + u
     color="#ffffff"
     dimColor={false}
   >
-      &gt; 
+      ❯ 
     <Text>
       ●
     </Text>

--- a/src/workstation/surfaces/status/index.ts
+++ b/src/workstation/surfaces/status/index.ts
@@ -139,7 +139,10 @@ export function renderStatusSurface(
         }, truncateCells(text, 140))
       }
       const isSelected = !headerFocused && row.flatIndex === selectedIndex
-      const cursorPart = `${isSelected ? '>' : ' '} `
+      // `❯` (ascii `>`) active-row caret — unified with the history view so
+      // the selected row reads the same way across surfaces (and survives
+      // NO_COLOR, where the selection background is suppressed).
+      const cursorPart = `${isSelected ? (theme.ascii ? '>' : '❯') : ' '} `
       const dotColor = getStageStatusDotColor(row.file.state, theme)
       const useDot = dotColor !== undefined
       const dotCells = useDot ? cellWidth(STAGE_STATUS_DOT) + 1 : 0

--- a/src/workstation/surfaces/submodules/index.ts
+++ b/src/workstation/surfaces/submodules/index.ts
@@ -90,7 +90,7 @@ export function renderSubmodulesSurface(
       : visible.map((entry, offset) => {
         const index = startIndex + offset
         const isSelected = index === selected
-        const cursor = isSelected ? '>' : ' '
+        const cursor = isSelected ? (theme.ascii ? '>' : '❯') : ' '
         const sha = entry.pinnedSha ? entry.pinnedSha.slice(0, 8) : '--------'
         const namePadded = truncateCells(entry.name, nameColWidth).padEnd(nameColWidth)
         const pathPadded = truncateCells(entry.path, pathColWidth).padEnd(pathColWidth)

--- a/src/workstation/surfaces/tags/index.ts
+++ b/src/workstation/surfaces/tags/index.ts
@@ -69,7 +69,7 @@ export function renderTagsSurface(
       : visible.map((tag, offset) => {
         const index = startIndex + offset
         const isSelected = index === selected
-        const cursor = isSelected ? '>' : ' '
+        const cursor = isSelected ? (theme.ascii ? '>' : '❯') : ' '
         // P5.1 — link the tag name to its GitHub tree page when we know
         // the remote. Truncation runs on the visible (pre-OSC) text;
         // formatHyperlink wraps just the tag name, leaving width math

--- a/src/workstation/surfaces/worktrees/index.ts
+++ b/src/workstation/surfaces/worktrees/index.ts
@@ -67,7 +67,7 @@ export function renderWorktreesSurface(
       : visible.map((entry, offset) => {
         const index = startIndex + offset
         const isSelected = index === selected
-        const cursor = isSelected ? '>' : ' '
+        const cursor = isSelected ? (theme.ascii ? '>' : '❯') : ' '
         const marker = entry.current ? '*' : ' '
         const branchLabel = entry.branch ? entry.branch : entry.head || '<detached>'
         const stateLabel = entry.dirty ? 'dirty' : 'clean'


### PR DESCRIPTION
Follow-up to the history active-row caret (#1102): make the selected-row cue **consistent across every list surface**, so the active row reads the same everywhere — and stays identifiable under `NO_COLOR`, where the selection background is suppressed entirely.

## Changes
- **Row cursor `>` → `❯`** (ascii `>`): `status`, `branches`, `tags`, `stash`, `worktrees`, `reflog`, `submodules`, `conflicts`, and the **PR / issue triage** lists, plus `detail`'s changed-files list.
- **`diff`**: the active file header marker `▾` → `❯` (inactive headers keep `▾`, so the active file stands out).
- **`detail` inspector action rows**: gain a leading `❯ ` caret gutter (budget reserved) — they previously relied on a selection background only, invisible under `NO_COLOR`.

(The compose-field editing indicators in `detail` keep `>` — different semantic, not a list cursor.)

## Notes
Glyphs are 1 cell, so the only width-math change is the detail action gutter. The original ask named status/diff/detail; I extended it to the other list surfaces because leaving them on `>` would have *defeated* the consistency goal.

`tsc` + `eslint` clean; **746** workstation tests pass (one status snapshot updated).