### PR TITLE
feat(workstation): fuzzy-match the theme picker filter

### DIFF
--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -1893,12 +1893,26 @@ describe('triage filter preset cycling (#882 phase 6)', () => {
       expect(state.showThemePicker).toBe(false)
     })
 
-    it('filters presets by case-insensitive substring', () => {
+    it('fuzzy-filters presets case-insensitively', () => {
       expect(filterThemePresets('')).toContain('catppuccin')
-      const tokyo = filterThemePresets('TOKYO')
-      expect(tokyo.length).toBeGreaterThan(0)
-      expect(tokyo.every((p) => p.includes('tokyo'))).toBe(true)
+      // Exact substring still matches…
+      expect(filterThemePresets('TOKYO')).toContain('tokyo-night')
+      // …and a non-contiguous subsequence matches too.
+      const gl = filterThemePresets('gl')
+      expect(gl).toContain('gruvbox-light')
+      expect(gl).toContain('github-light')
+      // Nonsense query that can't appear as a subsequence → no matches.
       expect(filterThemePresets('definitely-not-a-theme')).toHaveLength(0)
+    })
+
+    it('ranks the best fuzzy match first', () => {
+      // Exact preset id outranks the longer one that merely contains it.
+      const gruvbox = filterThemePresets('gruvbox')
+      expect(gruvbox[0]).toBe('gruvbox')
+      expect(gruvbox).toContain('gruvbox-light')
+      // Word-segment matches (after `-`) rank ahead of incidental ones.
+      const cm = filterThemePresets('cm')
+      expect(cm[0]).toBe('catppuccin-macchiato')
     })
 
     it('moveThemePicker clamps the cursor to the filtered list', () => {

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -2418,10 +2418,36 @@ export function intentOpenComposeForFile(
 }
 
 /**
- * Filter the full preset list by a case-insensitive substring query. An
- * empty query returns every preset in catalog order. Shared by the theme
- * picker overlay renderer, the input handler (for cursor bounds), and the
- * live-preview selector so all three agree on the same filtered list.
+ * Fuzzy (subsequence) score for a preset id against a lowercase query.
+ * Returns `null` when the query chars don't appear in order; otherwise a
+ * score where contiguous runs, a start-of-string match, and matches right
+ * after a `-` separator are rewarded — so `gl` ranks `gruvbox-light` /
+ * `github-light` above incidental matches, and `tn` finds `tokyo-night`.
+ */
+function fuzzyScoreThemePreset(preset: string, query: string): number | null {
+  const target = preset.toLowerCase()
+  let qi = 0
+  let score = 0
+  let lastMatch = -2
+  for (let i = 0; i < target.length && qi < query.length; i += 1) {
+    if (target[i] === query[qi]) {
+      score += 1
+      if (i === lastMatch + 1) score += 4 // contiguous run
+      if (i === 0) score += 8 // matches the very start
+      else if (target[i - 1] === '-') score += 4 // start of a word segment
+      lastMatch = i
+      qi += 1
+    }
+  }
+  return qi === query.length ? score : null
+}
+
+/**
+ * Filter the full preset list by a fuzzy (subsequence) query, ranked best
+ * match first (ties broken by catalog order). An empty query returns every
+ * preset in catalog order. Shared by the theme picker overlay renderer, the
+ * input handler (for cursor bounds), and the live-preview selector so all
+ * three agree on the same filtered list.
  */
 export function filterThemePresets(filter: string): LogInkThemePreset[] {
   const query = filter.trim().toLowerCase()
@@ -2429,7 +2455,11 @@ export function filterThemePresets(filter: string): LogInkThemePreset[] {
   if (!query) {
     return all
   }
-  return all.filter((preset) => preset.toLowerCase().includes(query))
+  return all
+    .map((preset, index) => ({ preset, index, score: fuzzyScoreThemePreset(preset, query) }))
+    .filter((entry): entry is { preset: LogInkThemePreset; index: number; score: number } => entry.score !== null)
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map((entry) => entry.preset)
 }
 
 /**


### PR DESCRIPTION
Theme-picker follow-up: replace the substring filter with a **subsequence (fuzzy)** matcher, ranked best-first.

Scoring rewards contiguous runs, a start-of-string match, and matches right after a `-` separator, so:
- `gl` → **gruvbox-light**, **github-light** (non-contiguous subsequence)
- `tn` → **tokyo-night**
- `cm` → **catppuccin-macchiato** (word-segment match after `-`)
- an exact id (`gruvbox`) outranks the longer preset that merely contains it (`gruvbox-light`)

Empty query still returns the full catalog in order. The picker's cursor-bound and live-preview selectors are untouched — they read the same filtered list.

Tests updated for the fuzzy + ranking semantics; `tsc` + `eslint` clean (160 view-model + 364 input/runtime tests pass).