### PR TITLE
feat(workspace): theme picker in the top-level workspace surface (T)

### DIFF
--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -2437,10 +2437,21 @@ export function filterThemePresets(filter: string): LogInkThemePreset[] {
  * filtered list). `undefined` when the filter matches nothing.
  */
 export function getThemePickerSelection(state: LogInkState): LogInkThemePreset | undefined {
-  const filtered = filterThemePresets(state.themePickerFilter)
+  return getThemePickerSelectionFor(state.themePickerFilter, state.themePickerIndex)
+}
+
+/**
+ * State-model-agnostic variant: the preset under the picker cursor for a
+ * raw `filter` + `index`. Used by the workspace top-level surface, which
+ * keeps its own state shape but shares the picker filtering.
+ */
+export function getThemePickerSelectionFor(
+  filter: string,
+  index: number
+): LogInkThemePreset | undefined {
+  const filtered = filterThemePresets(filter)
   if (filtered.length === 0) {
     return undefined
   }
-  const index = clampIndex(state.themePickerIndex, filtered.length)
-  return filtered[index]
+  return filtered[clampIndex(index, filtered.length)]
 }

--- a/src/workstation/runtime/detailPanel.ts
+++ b/src/workstation/runtime/detailPanel.ts
@@ -118,7 +118,7 @@ export function renderDetailPanel(
   }
 
   if (state.showThemePicker) {
-    return renderThemePickerOverlay(h, components, state, width, theme, focused)
+    return renderThemePickerOverlay(h, components, state.themePickerFilter, state.themePickerIndex, width, theme, focused)
   }
 
   if (state.inputPrompt) {

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -403,31 +403,33 @@ export function renderCommandPalette(
 }
 
 /**
- * Theme picker overlay (`gC`). Renders in the detail column like the
- * command palette so the rest of the workstation live-previews the
- * cursored theme underneath. Type to filter, ↑/↓ to move, Enter applies
- * (and persists), Esc cancels (reverting the preview).
+ * Theme picker overlay (`gC`). Renders like the command palette so the
+ * rest of the surface live-previews the cursored theme underneath. Type to
+ * filter, ↑/↓ to move, Enter applies (and persists), Esc cancels. Takes the
+ * raw `filter` + `index` rather than a `LogInkState` so it's reusable by
+ * the workspace top-level surface, which has its own state model.
  */
 export function renderThemePickerOverlay(
   h: typeof ReactTypes.createElement,
   components: LogInkComponents,
-  state: LogInkState,
+  filter: string,
+  index: number,
   width: number,
   theme: LogInkTheme,
   focused: boolean
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
-  const filtered = filterThemePresets(state.themePickerFilter)
+  const filtered = filterThemePresets(filter)
 
   const selectedIndex = filtered.length === 0
     ? 0
-    : Math.max(0, Math.min(state.themePickerIndex, filtered.length - 1))
+    : Math.max(0, Math.min(index, filtered.length - 1))
 
   const listRows = 14
   const startIndex = Math.max(0, selectedIndex - Math.floor(listRows / 2))
   const visible = filtered.slice(startIndex, startIndex + listRows)
 
-  const inputLine = `> ${state.themePickerFilter}_`
+  const inputLine = `> ${filter}_`
   const matchSummary = filtered.length === 0
     ? 'no matches'
     : `${filtered.length} ${filtered.length === 1 ? 'theme' : 'themes'}`

--- a/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
+++ b/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
@@ -6862,7 +6862,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
         <Text
           dimColor={true}
         >
-          15 bindings
+          16 bindings
         </Text>
       </Box>
       <Text
@@ -6999,6 +6999,35 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
       </Box>
       <Text>
         Drill into the cursored repo (coco ui)
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Box
+        flexShrink={0}
+        width={4}
+      >
+        <Text
+          bold={true}
+          color="cyan"
+        >
+           ◧ 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
+      >
+        <Text
+          bold={true}
+          color="green"
+        >
+          T
+        </Text>
+      </Box>
+      <Text>
+        Theme picker — browse, live-preview & apply a color theme
       </Text>
     </Box>
     <Text />

--- a/src/workstation/surfaces/workspace/input.test.ts
+++ b/src/workstation/surfaces/workspace/input.test.ts
@@ -195,4 +195,53 @@ describe('resolveWorkspaceInput', () => {
     expect(resolveWorkspaceInput('', key({ tab: true }), addRepoState()).kind).toBe('noop')
     expect(resolveWorkspaceInput('a', key(), addRepoState()).kind).toBe('noop')
   })
+
+  describe('theme picker', () => {
+    function pickerState(overrides: Partial<WorkspaceState> = {}): WorkspaceState {
+      return {
+        ...createWorkspaceState({ overview: emptyOverview, roots: ['~/code'] }),
+        showThemePicker: true,
+        ...overrides,
+      }
+    }
+
+    it('opens the picker on T', () => {
+      expect(resolveWorkspaceInput('T', key(), listState())).toEqual({
+        kind: 'action',
+        action: { type: 'toggle-theme-picker' },
+      })
+    })
+
+    it('is modal: arrows move, printable filters, backspace edits', () => {
+      expect(resolveWorkspaceInput('', key({ downArrow: true }), pickerState()).kind).toBe('action')
+      expect(resolveWorkspaceInput('', key({ upArrow: true }), pickerState())).toMatchObject({
+        action: { type: 'move-theme-picker', delta: -1 },
+      })
+      expect(resolveWorkspaceInput('g', key(), pickerState())).toEqual({
+        kind: 'action',
+        action: { type: 'append-theme-picker-filter', value: 'g' },
+      })
+      expect(resolveWorkspaceInput('', key({ backspace: true }), pickerState({ themePickerFilter: 'gr' }))).toEqual({
+        kind: 'action',
+        action: { type: 'backspace-theme-picker-filter' },
+      })
+    })
+
+    it('Enter applies the cursored preset', () => {
+      // Filtering to "gruvbox" puts it at index 0 (best match).
+      const intent = resolveWorkspaceInput('', key({ return: true }), pickerState({ themePickerFilter: 'gruvbox' }))
+      expect(intent).toEqual({ kind: 'apply-theme', preset: 'gruvbox' })
+    })
+
+    it('Esc clears a non-empty filter first, then closes', () => {
+      expect(resolveWorkspaceInput('', key({ escape: true }), pickerState({ themePickerFilter: 'x' }))).toEqual({
+        kind: 'action',
+        action: { type: 'clear-theme-picker-filter' },
+      })
+      expect(resolveWorkspaceInput('', key({ escape: true }), pickerState())).toEqual({
+        kind: 'action',
+        action: { type: 'toggle-theme-picker' },
+      })
+    })
+  })
 })

--- a/src/workstation/surfaces/workspace/input.ts
+++ b/src/workstation/surfaces/workspace/input.ts
@@ -1,5 +1,6 @@
 import type { Key as InkKey } from 'ink'
 
+import { filterThemePresets, getThemePickerSelectionFor } from '../../../commands/log/inkViewModel'
 import type { WorkspaceAction, WorkspaceState } from './state'
 
 /**
@@ -24,6 +25,7 @@ export type WorkspaceInputIntent =
   | { kind: 'add-repo' }
   | { kind: 'request-delete' }
   | { kind: 'confirm-delete' }
+  | { kind: 'apply-theme'; preset: string }
   | { kind: 'noop' }
 
 /**
@@ -63,6 +65,38 @@ export function resolveWorkspaceInput(
   if (state.showHelp) {
     if (key.escape || input === '?' || input === 'q') {
       return { kind: 'action', action: { type: 'close-help' } }
+    }
+    return { kind: 'noop' }
+  }
+
+  // Theme picker is modal (like `coco ui`'s gC): type to filter, ↑/↓ to
+  // move, Enter applies + persists, Esc clears the filter then closes.
+  if (state.showThemePicker) {
+    const filtered = filterThemePresets(state.themePickerFilter)
+    if (key.escape) {
+      if (state.themePickerFilter.length > 0) {
+        return { kind: 'action', action: { type: 'clear-theme-picker-filter' } }
+      }
+      return { kind: 'action', action: { type: 'toggle-theme-picker' } }
+    }
+    if (key.return) {
+      const selected = getThemePickerSelectionFor(state.themePickerFilter, state.themePickerIndex)
+      if (!selected) {
+        return { kind: 'action', action: { type: 'toggle-theme-picker' } }
+      }
+      return { kind: 'apply-theme', preset: selected }
+    }
+    if (key.upArrow || (key.ctrl && input === 'p')) {
+      return { kind: 'action', action: { type: 'move-theme-picker', delta: -1, presetCount: filtered.length } }
+    }
+    if (key.downArrow || (key.ctrl && input === 'n')) {
+      return { kind: 'action', action: { type: 'move-theme-picker', delta: 1, presetCount: filtered.length } }
+    }
+    if (key.backspace || key.delete) {
+      return { kind: 'action', action: { type: 'backspace-theme-picker-filter' } }
+    }
+    if (input && !key.ctrl && !key.meta) {
+      return { kind: 'action', action: { type: 'append-theme-picker-filter', value: input } }
     }
     return { kind: 'noop' }
   }
@@ -191,6 +225,13 @@ export function resolveWorkspaceInput(
   }
   if (input === '?') {
     return { kind: 'action', action: { type: 'toggle-help' } }
+  }
+
+  // `T` opens the theme picker (browse + live-preview + apply a color
+  // theme). Single key here rather than `coco ui`'s gC chord since the
+  // workspace keymap is flat (no g-prefix continuations).
+  if (input === 'T') {
+    return { kind: 'action', action: { type: 'toggle-theme-picker' } }
   }
 
   return { kind: 'noop' }

--- a/src/workstation/surfaces/workspace/render.ts
+++ b/src/workstation/surfaces/workspace/render.ts
@@ -685,6 +685,7 @@ export function buildWorkspaceHelpSections(): WorkspaceHelpSection[] {
         { glyph: '⎋', keys: 'esc', description: 'Clear filter / close overlay / cancel prompt' },
         { glyph: '◴', keys: 'q · ctrl+c', description: 'Quit the workspace surface' },
         { glyph: '↵', keys: 'enter', description: 'Drill into the cursored repo (coco ui)' },
+        { glyph: '◧', keys: 'T', description: 'Theme picker — browse, live-preview & apply a color theme' },
       ],
     },
     {

--- a/src/workstation/surfaces/workspace/runtime.ts
+++ b/src/workstation/surfaces/workspace/runtime.ts
@@ -55,7 +55,10 @@ import {
   createLogInkTheme,
   type LogInkTheme,
   type LogInkThemeConfig,
+  type LogInkThemePreset,
 } from '../../chrome/theme'
+import { saveThemePreset } from '../../chrome/themePersistence'
+import { getThemePickerSelectionFor } from '../../../commands/log/inkViewModel'
 import {
   readCachedWorkspace,
   writeCachedWorkspace,
@@ -269,6 +272,7 @@ export async function startWorkspace(
     ink,
     React,
     theme,
+    themeConfig: options.theme,
     resumeRef,
   })
 
@@ -437,6 +441,9 @@ type WorkspaceInkAppProps = {
   ink: WorkspaceInkRuntime['ink']
   React: typeof ReactTypes
   theme: LogInkTheme
+  /** Theme config the built `theme` came from — lets the picker rebuild a
+   *  live preview preserving ascii/border/noColor semantics. */
+  themeConfig?: LogInkThemeConfig
   resumeRef: { current: (() => void) | null }
 }
 
@@ -470,6 +477,22 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
   // (see effect below) so idle workspaces don't burn CPU on animation
   // frames.
   const [spinnerTick, setSpinnerTick] = React.useState(0)
+
+  // Theme picker (`T`) — reactive theme so the chrome live-previews the
+  // cursored theme. `themePreviewPreset` follows the picker cursor while
+  // open; `themeSessionPreset` is the applied choice. The effective theme
+  // rebuilds from the original config; when neither is set we use the
+  // static `props.theme` unchanged (mirrors `coco ui`).
+  const [themePreviewPreset, setThemePreviewPreset] = React.useState<LogInkThemePreset | undefined>(undefined)
+  const [themeSessionPreset, setThemeSessionPreset] = React.useState<LogInkThemePreset | undefined>(undefined)
+  const effectiveThemePreset = themePreviewPreset ?? themeSessionPreset
+  const theme = React.useMemo(
+    () =>
+      effectiveThemePreset
+        ? createLogInkTheme({ ...props.themeConfig, preset: effectiveThemePreset })
+        : props.theme,
+    [effectiveThemePreset, props.themeConfig, props.theme]
+  )
 
   const dispatch = React.useCallback((action: WorkspaceAction) => {
     setState((prev) => applyWorkspaceAction(prev, action))
@@ -848,6 +871,13 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
       case 'action':
         dispatch(intent.action)
         break
+      case 'apply-theme':
+        // Apply for the session + persist to the global config (best-effort),
+        // then close the picker (clearing the preview via the sync effect).
+        setThemeSessionPreset(intent.preset as LogInkThemePreset)
+        saveThemePreset(intent.preset as LogInkThemePreset)
+        dispatch({ type: 'toggle-theme-picker' })
+        break
       case 'quit':
         workspaceDebug('→ exit() called from quit intent')
         exitRefHolder.current.current = { kind: 'quit' }
@@ -904,11 +934,21 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
     })
   }, [props.roots, state.sortMode, state.tab, state.filter])
 
+  // Keep the live preview in sync with the preset under the picker cursor
+  // while the overlay is open; clear it on close so the theme reverts to
+  // the applied session preset (or the original config theme).
+  const themePickerSelection = state.showThemePicker
+    ? getThemePickerSelectionFor(state.themePickerFilter, state.themePickerIndex)
+    : undefined
+  React.useEffect(() => {
+    setThemePreviewPreset(state.showThemePicker ? themePickerSelection : undefined)
+  }, [state.showThemePicker, themePickerSelection])
+
   return renderWorkspaceApp({
     React,
     ink: { Box: ink.Box, Text: ink.Text },
     state,
-    theme: props.theme,
+    theme,
     appLabel: props.appLabel,
     filterDraft,
     addRepoDraft,

--- a/src/workstation/surfaces/workspace/state.test.ts
+++ b/src/workstation/surfaces/workspace/state.test.ts
@@ -296,4 +296,32 @@ describe('workspace state reducer', () => {
     const t = applyWorkspaceAction(s, { type: 'mark-pull-request-fetched', path: '/tmp/zzz' })
     expect(t.pullRequestFetching).toEqual(['/tmp/alpha'])
   })
+
+  describe('theme picker', () => {
+    const base = createWorkspaceState({ overview: overview([]), roots: ['~/code'] })
+
+    it('toggles open/closed and closes help/onboarding', () => {
+      let s = applyWorkspaceAction({ ...base, showHelp: true, showOnboarding: true }, { type: 'toggle-theme-picker' })
+      expect(s.showThemePicker).toBe(true)
+      expect(s.showHelp).toBe(false)
+      expect(s.showOnboarding).toBe(false)
+      s = applyWorkspaceAction(s, { type: 'toggle-theme-picker' })
+      expect(s.showThemePicker).toBe(false)
+    })
+
+    it('moves the cursor clamped to the preset count and resets it on filter edits', () => {
+      let s = applyWorkspaceAction(base, { type: 'toggle-theme-picker' })
+      s = applyWorkspaceAction(s, { type: 'move-theme-picker', delta: -1, presetCount: 50 })
+      expect(s.themePickerIndex).toBe(0)
+      s = applyWorkspaceAction(s, { type: 'move-theme-picker', delta: 999, presetCount: 50 })
+      expect(s.themePickerIndex).toBe(49)
+      s = applyWorkspaceAction(s, { type: 'append-theme-picker-filter', value: 'gr' })
+      expect(s.themePickerFilter).toBe('gr')
+      expect(s.themePickerIndex).toBe(0)
+      s = applyWorkspaceAction(s, { type: 'backspace-theme-picker-filter' })
+      expect(s.themePickerFilter).toBe('g')
+      s = applyWorkspaceAction(s, { type: 'clear-theme-picker-filter' })
+      expect(s.themePickerFilter).toBe('')
+    })
+  })
 })

--- a/src/workstation/surfaces/workspace/state.ts
+++ b/src/workstation/surfaces/workspace/state.ts
@@ -77,6 +77,14 @@ export type WorkspaceState = {
   /** First-run onboarding overlay toggle. Self-dismisses on first user action. */
   showOnboarding: boolean
   /**
+   * Theme picker (`gC`) overlay state — mirrors `coco ui`. While open the
+   * workspace chrome live-previews the cursored theme; Enter persists it to
+   * the global config so every surface (and the next launch) picks it up.
+   */
+  showThemePicker: boolean
+  themePickerFilter: string
+  themePickerIndex: number
+  /**
    * Paths added through the add-repo prompt. Only entries in this set
    * can be removed via the delete affordance — repos discovered via
    * configured roots would just come back on the next refresh.
@@ -118,6 +126,11 @@ export type WorkspaceAction =
   | { type: 'set-status'; status?: string }
   | { type: 'toggle-help' }
   | { type: 'close-help' }
+  | { type: 'toggle-theme-picker' }
+  | { type: 'move-theme-picker'; delta: number; presetCount: number }
+  | { type: 'append-theme-picker-filter'; value: string }
+  | { type: 'backspace-theme-picker-filter' }
+  | { type: 'clear-theme-picker-filter' }
   | { type: 'dismiss-onboarding' }
   | { type: 'replace-known-repos'; paths: ReadonlyArray<string> }
   | { type: 'request-delete'; path: string }
@@ -158,6 +171,9 @@ export function createWorkspaceState(init: WorkspaceStateInit): WorkspaceState {
     roots: init.roots,
     showHelp: false,
     showOnboarding: Boolean(init.showOnboarding),
+    showThemePicker: false,
+    themePickerFilter: '',
+    themePickerIndex: 0,
     knownRepoPaths: init.knownRepoPaths ?? [],
     pullRequestFetching: [],
   }
@@ -335,6 +351,39 @@ export function applyWorkspaceAction(
     }
     case 'close-help': {
       return { ...state, showHelp: false }
+    }
+    case 'toggle-theme-picker': {
+      return {
+        ...state,
+        showThemePicker: !state.showThemePicker,
+        showHelp: false,
+        showOnboarding: false,
+        themePickerFilter: '',
+        themePickerIndex: 0,
+      }
+    }
+    case 'move-theme-picker': {
+      return {
+        ...state,
+        themePickerIndex: clampCursor(state.themePickerIndex + action.delta, action.presetCount),
+      }
+    }
+    case 'append-theme-picker-filter': {
+      return {
+        ...state,
+        themePickerFilter: `${state.themePickerFilter}${action.value}`,
+        themePickerIndex: 0,
+      }
+    }
+    case 'backspace-theme-picker-filter': {
+      return {
+        ...state,
+        themePickerFilter: state.themePickerFilter.slice(0, -1),
+        themePickerIndex: 0,
+      }
+    }
+    case 'clear-theme-picker-filter': {
+      return { ...state, themePickerFilter: '', themePickerIndex: 0 }
     }
     case 'dismiss-onboarding': {
       return { ...state, showOnboarding: false }

--- a/src/workstation/surfaces/workspace/view.ts
+++ b/src/workstation/surfaces/workspace/view.ts
@@ -11,6 +11,7 @@ import type * as ReactTypes from 'react'
 import type { TextProps } from 'ink'
 
 import type { LogInkTheme } from '../../chrome/theme'
+import { renderThemePickerOverlay } from '../../runtime/overlays'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
 
 import type { WorkspaceComponents } from './runtime'
@@ -784,6 +785,25 @@ export function renderWorkspaceApp(deps: RenderWorkspaceAppDeps): ReactTypes.Rea
       { flexDirection: 'column', height: rootHeight },
       renderHeader(deps),
       renderHelpOverlay(deps),
+      renderFooter(deps)
+    )
+  }
+  // Theme picker is modal too — the chrome live-previews underneath via
+  // the reactive `deps.theme`, while the overlay replaces the body.
+  if (deps.state.showThemePicker) {
+    return React.createElement(
+      Box,
+      { flexDirection: 'column', height: rootHeight },
+      renderHeader(deps),
+      renderThemePickerOverlay(
+        React.createElement,
+        { Box: ink.Box, Text: ink.Text },
+        deps.state.themePickerFilter,
+        deps.state.themePickerIndex,
+        bodyWidth,
+        deps.theme,
+        true
+      ),
       renderFooter(deps)
     )
   }


### PR DESCRIPTION
Theme-picker follow-up (Phase 4): bring the picker to the **`coco workspace` top-level list**. The drill-in already had it (it mounts `coco ui`); this covers the workspace chrome itself.

## What
Press **`T`** to open a picker overlay; the workspace chrome **live-previews** the cursored theme underneath. Type to filter, ↑/↓ to move, **Enter** applies + persists to the global config (so every surface and the next launch pick it up), **Esc** reverts.

## How
- **Reusable overlay:** `renderThemePickerOverlay` now takes `(filter, index)` instead of a `LogInkState`, and `getThemePickerSelectionFor(filter, index)` is extracted — so the workspace (its own state model) shares the exact picker filtering/selection + overlay. The `coco ui` call site is updated.
- **Workspace state:** `showThemePicker` + `themePickerFilter`/`themePickerIndex` + reducer actions (toggle / move / append / backspace / clear).
- **Workspace input:** modal picker handling + the `T` binding + a new `apply-theme` intent.
- **Workspace runtime:** reactive theme via the same `useMemo`-shadowing pattern as `coco ui` (preview + session preset), a live-preview sync effect, and the apply→persist handler.
- **Help overlay** gains the `T` row.

Single key (not `gC`) because the workspace keymap is flat (no g-prefix chords).

## Verification
`tsc` + `eslint` clean; **1328** workstation/log/ui tests pass (incl. new workspace state + input coverage; the `coco ui` picker is unaffected by the overlay-signature refactor).