### PR TITLE
feat(screenshot): add a theme-picker demo recipe

### DIFF
--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -746,6 +746,22 @@ export const RECIPES: ScreenshotRecipe[] = [
     ],
   },
   {
+    name: 'ui-theme-picker',
+    description: 'Theme picker overlay (gC) — browse, filter & live-preview color themes',
+    scenario: 'feature-pr-ready',
+    command: 'ui --view history --no-all',
+    actions: [
+      { kind: 'sleep', ms: 800 },
+      // `gC` chord opens the picker; the workstation live-previews the
+      // cursored theme underneath while the overlay lists every preset.
+      { kind: 'type', text: 'gC' },
+      { kind: 'sleep', ms: 500 },
+      // Type a filter to show the fuzzy/substring narrowing in action.
+      { kind: 'type', text: 'gruv' },
+      { kind: 'sleep', ms: 500 },
+    ],
+  },
+  {
     name: 'ui-search-filter',
     description: 'History view with an active search filter narrowing commits',
     scenario: 'multi-commit-branch',

--- a/bin/syncScreenshots.ts
+++ b/bin/syncScreenshots.ts
@@ -99,6 +99,7 @@ const SITE_RECIPES = [
   // Utility
   'workspace-multi-repo',
   'ui-command-palette',
+  'ui-theme-picker',
   'ui-search-filter',
   'ui-inspector-focused',
 ]
@@ -175,6 +176,7 @@ const FILENAME_MAP: Record<string, string[]> = {
   'ui-history-theme-quiet-light': ['theme-quiet-light.png'],
   'workspace-multi-repo': ['workspace-multi-repo.png'],
   'ui-command-palette': ['feature-palette.png'],
+  'ui-theme-picker': ['theme-picker.png'],
   'ui-search-filter': ['docs-search.png'],
   'ui-inspector-focused': ['workstation-history.png'],
   'demo-workstation-tour': ['demo-workstation-tour.gif'],


### PR DESCRIPTION
Theme-picker follow-up: a VHS capture recipe for the picker.

`ui-theme-picker` launches `coco ui`, opens the picker via the **gC** chord, and types a filter (`gruv`) — capturing the overlay listing matches (`● gruvbox`, `gruvbox-light`) while the history view live-previews the cursored theme underneath.

Wired into `screenshot:sync` (→ `theme-picker.png`) so the marketing/docs site can surface it once a page references the asset.

Verified the capture renders correctly (`npm run screenshot -- --recipe ui-theme-picker`); `tsc` + `eslint` clean; screenshot suite passes.