### PR TITLE
feat(workspace): default discovery root to the current directory

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -135,10 +135,7 @@
               "items": {
                 "type": "string"
               },
-              "description": "Directories to scan for git repositories. Each entry may use a `~` prefix; resolved against the user's home directory. Defaults to `['~/code']` when omitted.",
-              "default": [
-                "~/code"
-              ]
+              "description": "Directories to scan for git repositories. Each entry may use a `~` prefix; resolved against the user's home directory. When omitted (and no `--root` flag is passed), the workspace scans the current working directory — so a bare `coco` / `coco ws` discovers repos wherever you launched it. Set this to pin a fixed tree (e.g. `[\"~/code\"]`) regardless of where you run from.\n\n(No static `@default` — the effective default is the runtime cwd.)"
             },
             "knownRepos": {
               "type": "array",

--- a/src/commands/workspace/handler.test.ts
+++ b/src/commands/workspace/handler.test.ts
@@ -36,8 +36,18 @@ describe('workspace handler argv resolution', () => {
     ).toEqual(['~/work', '~/oss'])
   })
 
-  it('defaults to [~/code] when no config and no flag are present', () => {
-    expect(resolveWorkspaceRoots(argv(), {})).toEqual(['~/code'])
+  it('defaults to the current working directory when no config and no flag are present', () => {
+    // The third arg is the cwd (injected for determinism — the handler
+    // passes process.cwd() after honoring --repo/--cwd).
+    expect(resolveWorkspaceRoots(argv(), {}, '/Users/dev/projects')).toEqual(['/Users/dev/projects'])
+    // Defaults to process.cwd() when the cwd arg is omitted.
+    expect(resolveWorkspaceRoots(argv(), {})).toEqual([process.cwd()])
+  })
+
+  it('still prefers config.workspace.roots over the cwd fallback', () => {
+    expect(
+      resolveWorkspaceRoots(argv(), { workspace: { roots: ['~/code'] } }, '/somewhere/else')
+    ).toEqual(['~/code'])
   })
 
   it('passes through known repos from config', () => {

--- a/src/commands/workspace/handler.ts
+++ b/src/commands/workspace/handler.ts
@@ -12,11 +12,23 @@ import type { UiArgv } from '../ui/config'
 
 import { WorkspaceArgv } from './config'
 
-const DEFAULT_ROOTS = ['~/code']
-
+/**
+ * Resolve the directories the workspace scans for git repos, in
+ * precedence order:
+ *   1. `--root` CLI flag(s)
+ *   2. `workspace.roots` from config
+ *   3. the current working directory (`cwd`)
+ *
+ * Falling back to `cwd` (rather than a hardcoded `~/code`) means a bare
+ * `coco` / `coco ws` discovers repos wherever you launched it — the
+ * handler chdir's to honor `--repo` / `--cwd` before this runs, so `cwd`
+ * already reflects the targeted directory. `cwd` is a parameter (not a
+ * direct `process.cwd()` call) so the resolver stays a pure unit.
+ */
 export function resolveWorkspaceRoots(
   argv: WorkspaceArgv,
-  config: Pick<Config, 'workspace'>
+  config: Pick<Config, 'workspace'>,
+  cwd: string = process.cwd()
 ): string[] {
   const raw = argv.root
   if (Array.isArray(raw) && raw.length > 0) {
@@ -28,7 +40,7 @@ export function resolveWorkspaceRoots(
   if (config.workspace?.roots && config.workspace.roots.length > 0) {
     return [...config.workspace.roots]
   }
-  return [...DEFAULT_ROOTS]
+  return [cwd]
 }
 
 export function resolveWorkspaceKnownRepos(

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -129,10 +129,13 @@ type BaseConfig = {
   workspace?: {
     /**
      * Directories to scan for git repositories. Each entry may use a
-     * `~` prefix; resolved against the user's home directory. Defaults
-     * to `['~/code']` when omitted.
+     * `~` prefix; resolved against the user's home directory. When
+     * omitted (and no `--root` flag is passed), the workspace scans the
+     * current working directory — so a bare `coco` / `coco ws` discovers
+     * repos wherever you launched it. Set this to pin a fixed tree (e.g.
+     * `["~/code"]`) regardless of where you run from.
      *
-     * @default ['~/code']
+     * (No static `@default` — the effective default is the runtime cwd.)
      */
     roots?: string[]
 

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -146,10 +146,7 @@ export const schema = {
               "items": {
                 "type": "string"
               },
-              "description": "Directories to scan for git repositories. Each entry may use a `~` prefix; resolved against the user's home directory. Defaults to `['~/code']` when omitted.",
-              "default": [
-                "~/code"
-              ]
+              "description": "Directories to scan for git repositories. Each entry may use a `~` prefix; resolved against the user's home directory. When omitted (and no `--root` flag is passed), the workspace scans the current working directory — so a bare `coco` / `coco ws` discovers repos wherever you launched it. Set this to pin a fixed tree (e.g. `[\"~/code\"]`) regardless of where you run from.\n\n(No static `@default` — the effective default is the runtime cwd.)"
             },
             "knownRepos": {
               "type": "array",


### PR DESCRIPTION
## Problem

Booting the workstation from anywhere but `~/code` discovered the wrong repos. Running `coco` (or `coco ws`) from `/Users/gfargo/dev/gfargo` showed:

```
coco · workspace · ~/code · 15/15 repos · sort: Recent · [List]
```

`~/code` wasn't from config — it's a hardcoded fallback in `resolveWorkspaceRoots`, hit whenever `workspace.roots` is unset and no `--root` is passed.

## Fix

Default the fallback to the **current working directory** instead of `~/code`. The workspace handler already `chdir`s to honor `--repo`/`--cwd` before resolving, so `process.cwd()` is the launch dir (or `--repo` target). Booting from a folder now discovers the repos beneath it, and the header reflects that path.

**Precedence is otherwise unchanged** (per your call — config still wins):

`--root` flag → `config.workspace.roots` → **cwd** *(was `~/code`)*

Pin `workspace.roots` in config for a fixed tree regardless of where you run from. `resolveWorkspaceRoots` takes `cwd` as a defaulted param so it stays a pure, testable unit.

## Also
- Regenerated the config schema — the default is now dynamic (cwd), so the static `default: ["~/code"]` is dropped from the schema; the description explains the cwd behavior.
- Updated the config-type JSDoc; wiki **Workspace** page updated in a paired push.

## Verification
New resolver tests (cwd fallback + config-still-wins); `tsc` + `eslint` clean; no other code assumes `~/code` as a default (swept — remaining refs are doc examples / test fixtures with explicit roots).