### PR TITLE
fix(workstation): align history graph after the active-row caret gutter

### DIFF
--- a/src/workstation/surfaces/history/__snapshots__/historyRender.test.ts.snap
+++ b/src/workstation/surfaces/history/__snapshots__/historyRender.test.ts.snap
@@ -67,6 +67,7 @@ exports[`renderHistoryPanel structural snapshot — default 3-commit history 1`]
   <Text
     dimColor={false}
   >
+      
     <Text
       color="cyan"
       dimColor={false}
@@ -113,6 +114,7 @@ exports[`renderHistoryPanel structural snapshot — default 3-commit history 1`]
   <Text
     dimColor={false}
   >
+      
     <Text
       color="cyan"
       dimColor={false}
@@ -159,6 +161,7 @@ exports[`renderHistoryPanel structural snapshot — default 3-commit history 1`]
   <Text
     dimColor={false}
   >
+      
     <Text
       color="cyan"
       dimColor={false}
@@ -261,6 +264,7 @@ exports[`renderHistoryPanel structural snapshot — narrow terminal (tight densi
   <Text
     dimColor={false}
   >
+      
     <Text
       color="cyan"
       dimColor={false}
@@ -301,6 +305,7 @@ exports[`renderHistoryPanel structural snapshot — narrow terminal (tight densi
   <Text
     dimColor={false}
   >
+      
     <Text
       color="cyan"
       dimColor={false}
@@ -341,6 +346,7 @@ exports[`renderHistoryPanel structural snapshot — narrow terminal (tight densi
   <Text
     dimColor={false}
   >
+      
     <Text
       color="cyan"
       dimColor={false}

--- a/src/workstation/surfaces/history/historyRender.test.ts
+++ b/src/workstation/surfaces/history/historyRender.test.ts
@@ -236,5 +236,16 @@ describe('renderHistoryPanel', () => {
       )
       expect(flattenText(tree)).toContain('❯ ')
     })
+
+    it('reserves the gutter on bucket dividers so they align with commit rows', () => {
+      // Regression: the caret gutter was first added to commit rows only,
+      // shifting them right of the (un-shifted) "── <bucket> ──" dividers
+      // and graph-connector lines — the graph column no longer lined up.
+      // Every history line now reserves the gutter, so the divider's
+      // leading em-dash sits in the same column as the commit graph.
+      const flat = flattenText(render(makeState(), { dateBucketingEnabled: true }))
+      expect(flat).toContain(`${'  '}── `) // 2-space gutter, then the divider rule
+      expect(flat).not.toContain('\n── ') // never a divider flush against the left edge
+    })
   })
 })

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -275,6 +275,12 @@ function renderLaneSegmentSpans(
  */
 const ACTIVE_ROW_CARET_WIDTH = 2
 
+/** The blank gutter (no caret) — `ACTIVE_ROW_CARET_WIDTH` spaces. Prepended
+ *  to non-commit history lines (bucket headers, graph-only connector lines)
+ *  so they shift in lockstep with the commit rows' caret gutter and the
+ *  graph column stays vertically aligned. */
+const ACTIVE_ROW_GUTTER = ' '.repeat(ACTIVE_ROW_CARET_WIDTH)
+
 /**
  * The leading caret span: `❯ ` (bold) on the active row, two spaces
  * otherwise. Inherits the row's foreground (so it reads correctly on the
@@ -696,13 +702,16 @@ export function renderHistoryPanel(
         // the divider reads as chrome rather than competing with
         // commit content. Rule fills the panel's interior width
         // (minus border + padding); the label rides inside it.
-        const contentWidth = Math.max(10, width - 4)
+        // Reserve the active-row caret gutter so the divider lines up with
+        // the (gutter-shifted) commit rows below it.
+        const contentWidth = Math.max(10, width - 4 - ACTIVE_ROW_CARET_WIDTH)
         const labelCells = cellWidth(item.label) + 2 // pad the label with surrounding spaces
         const ruleAfter = Math.max(0, contentWidth - 3 - labelCells)
         return h(Text, {
           key: `bucket-${index}-${item.label}`,
           dimColor: true,
         },
+          h(Text, undefined, ACTIVE_ROW_GUTTER),
           h(Text, undefined, '── '),
           h(Text, { bold: true }, item.label),
           h(Text, undefined, ' '),
@@ -730,6 +739,8 @@ export function renderHistoryPanel(
             key: `graph-${index}-${item.graph}`,
             dimColor: !isSpacer,
           },
+            // Blank caret gutter so connector lanes align with commit rows.
+            ACTIVE_ROW_GUTTER,
             ...renderLaneSegmentSpans(
               h, Text, item.laneSegments, theme, visible.graphWidth, `g${index}`,
               { forceDim: !isSpacer }
@@ -739,10 +750,10 @@ export function renderHistoryPanel(
           key: `graph-${index}-${item.graph}`,
           color: theme.noColor ? undefined : theme.colors.muted,
           dimColor: !isSpacer,
-        }, truncateCells(substituteGraphChars(
+        }, `${ACTIVE_ROW_GUTTER}${truncateCells(substituteGraphChars(
           item.graph.padEnd(visible.graphWidth),
           { ascii: theme.ascii }
-        ), Math.max(8, width - 4)))
+        ), Math.max(8, width - 4 - ACTIVE_ROW_CARET_WIDTH))}`)
       }
 
       if (rowMode === 'stacked') {


### PR DESCRIPTION
## Bug

The active-row caret (#1102) added a **2-cell gutter to commit rows only**. The history panel also renders **date-bucket dividers** (`── Today ──`) and **graph-only connector lines** (the `│` lanes between commits) through separate paths that *didn't* get the gutter — so commit rows shifted right while everything else stayed put, and the graph column no longer lined up with the commit dots. (Reported with a screenshot — the topology looked broken.)

## Fix

Reserve the **same gutter on every history line**: prepend the blank 2-space gutter to the bucket-header dividers (shrinking the rule to fit the panel) and to the graph-only lane lines. All rows now shift in lockstep, so the graph stays vertically aligned; the `❯` caret still renders only on the selected commit.

## Verification
- Regenerated the **rich-graph** capture (bucket headers + multi-lane graph + selection) — alignment restored.
- New regression test asserts the divider carries the gutter (`'  ── '`) and never sits flush-left; snapshots updated.
- `tsc` + `eslint` clean; **753** workstation tests pass.

If you'd rather drop the caret gutter entirely instead, say the word and I'll revert #1102's history gutter (the status/branches/etc. `❯` glyph swap doesn't shift anything and can stay).