### PR TITLE
feat(screenshot): capture the diff recipe in side-by-side (split) mode

### DIFF
--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -128,9 +128,19 @@ export const RECIPES: ScreenshotRecipe[] = [
   },
   {
     name: 'ui-diff-feature-branch',
-    description: 'Diff view showing a commit diff on a feature branch',
+    description: 'Side-by-side (split) diff view of a commit on a feature branch',
     scenario: 'feature-pr-ready',
     command: 'ui --view diff',
+    // Press `d` once to switch unified → side-by-side. Split needs the diff
+    // panel ≥ MIN_SPLIT_DIFF_WIDTH (120) — and the diff view also shows the
+    // sidebar + commit inspector, so the terminal has to be wide enough to
+    // leave the diff column ≥ 120 after both.
+    dimensions: { cols: 230, rows: 42 },
+    actions: [
+      { kind: 'sleep', ms: 800 },
+      { kind: 'type', text: 'd' },
+      { kind: 'sleep', ms: 500 },
+    ],
   },
   {
     name: 'ui-merge-conflict',


### PR DESCRIPTION
The `ui-diff-feature-branch` recipe (→ `view-diff.png` on the marketing site) showed the **unified** diff. The site's *Side-by-side diff* workflow card (and the 16-view grid's "Diff" entry, whose description literally says "side-by-side") want the split view.

Press `d` once after launch to toggle unified → side-by-side, and widen the terminal to **230 cols** so the diff panel clears `MIN_SPLIT_DIFF_WIDTH` (120) **after** the sidebar + commit inspector — at narrower widths the view falls back to unified with a "terminal too narrow" notice (confirmed: 170 cols wasn't enough).

Verified the capture renders the two-column "Diff (split)" layout. The refreshed `view-diff.png` ships in a paired `.www` PR.