### PR TITLE
fix(ui): set upstream for new branches on push

### DIFF
--- a/src/git/branchActions.test.ts
+++ b/src/git/branchActions.test.ts
@@ -107,21 +107,12 @@ describe('log branch actions', () => {
     await deleteBranch(git as never, localBranch())
     await fetchRemotes(git as never)
     await pullCurrentBranch(git as never)
-    await pushCurrentBranch(git as never)
-    await setUpstream(git as never, 'feature/new', 'origin/feature/new')
 
     expect(git.raw).toHaveBeenNthCalledWith(1, ['switch', '-c', 'feature/new', 'abc1234'])
     expect(git.raw).toHaveBeenNthCalledWith(2, ['branch', '-m', 'feature/old', 'feature/new'])
     expect(git.raw).toHaveBeenNthCalledWith(3, ['branch', '-d', 'feature/test'])
     expect(git.raw).toHaveBeenNthCalledWith(4, ['fetch', '--all', '--prune'])
     expect(git.raw).toHaveBeenNthCalledWith(5, ['pull', '--ff-only'])
-    expect(git.raw).toHaveBeenNthCalledWith(6, ['push'])
-    expect(git.raw).toHaveBeenNthCalledWith(7, [
-      'branch',
-      '--set-upstream-to',
-      'origin/feature/new',
-      'feature/new',
-    ])
   })
 
   describe('pushBranch', () => {
@@ -140,14 +131,28 @@ describe('log branch actions', () => {
       expect(git.raw).toHaveBeenCalledWith(['push', 'origin', 'feat/widgets'])
     })
 
-    it('refuses when the branch has no upstream', async () => {
-      const git = { raw: jest.fn() }
+    it('pushes with -u to create+track when the branch has no upstream', async () => {
+      const git = {
+        raw: jest.fn().mockResolvedValue(''),
+        getRemotes: jest.fn().mockResolvedValue([{ name: 'origin' }]),
+      }
+      const branch = localBranch({ shortName: 'local-only' })
+
+      const result = await pushBranch(git as never, branch)
+
+      expect(result.ok).toBe(true)
+      expect(result.message).toContain('set upstream to origin/local-only')
+      expect(git.raw).toHaveBeenCalledWith(['push', '-u', 'origin', 'local-only'])
+    })
+
+    it('refuses when there is no upstream and no remote configured', async () => {
+      const git = { raw: jest.fn(), getRemotes: jest.fn().mockResolvedValue([]) }
       const branch = localBranch({ shortName: 'local-only' })
 
       const result = await pushBranch(git as never, branch)
 
       expect(result.ok).toBe(false)
-      expect(result.message).toContain('no upstream')
+      expect(result.message).toContain('no remote is configured')
       expect(git.raw).not.toHaveBeenCalled()
     })
 
@@ -157,6 +162,81 @@ describe('log branch actions', () => {
 
       expect(result.ok).toBe(false)
       expect(result.message).toContain('Only local branches')
+      expect(git.raw).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('pushCurrentBranch', () => {
+    it('pushes plainly when the current branch already has an upstream', async () => {
+      const git = { raw: jest.fn().mockResolvedValue('') }
+
+      const result = await pushCurrentBranch(git as never)
+
+      expect(result.ok).toBe(true)
+      expect(git.raw).toHaveBeenCalledWith(['push'])
+    })
+
+    it('pushes with -u when the current branch has no upstream yet', async () => {
+      const git = {
+        raw: jest
+          .fn()
+          .mockRejectedValueOnce(new Error('no upstream configured')) // rev-parse @{upstream}
+          .mockResolvedValueOnce('feat/new\n') // rev-parse HEAD
+          .mockResolvedValue(''), // push -u
+        getRemotes: jest.fn().mockResolvedValue([{ name: 'origin' }]),
+      }
+
+      const result = await pushCurrentBranch(git as never)
+
+      expect(result.ok).toBe(true)
+      expect(result.message).toContain('set upstream to origin/feat/new')
+      expect(git.raw).toHaveBeenCalledWith(['push', '-u', 'origin', 'feat/new'])
+    })
+  })
+
+  describe('setUpstream', () => {
+    it('links to an existing remote-tracking branch', async () => {
+      const git = {
+        raw: jest.fn().mockResolvedValue(''), // show-ref (exists) + set-upstream-to
+        getRemotes: jest.fn().mockResolvedValue([{ name: 'origin' }]),
+      }
+
+      const result = await setUpstream(git as never, 'feature/x', 'origin/feature/x')
+
+      expect(result.ok).toBe(true)
+      expect(git.raw).toHaveBeenCalledWith([
+        'branch',
+        '--set-upstream-to',
+        'origin/feature/x',
+        'feature/x',
+      ])
+    })
+
+    it('pushes -u to create the remote branch when it does not exist yet', async () => {
+      const git = {
+        raw: jest
+          .fn()
+          .mockRejectedValueOnce(new Error('not a valid ref')) // show-ref (missing)
+          .mockResolvedValue(''), // push -u
+        getRemotes: jest.fn().mockResolvedValue([{ name: 'origin' }]),
+      }
+
+      // Bare `main` defaults to origin/main; the remote branch is absent
+      // so we push -u rather than silently mis-setting the local ref.
+      const result = await setUpstream(git as never, 'main', 'main')
+
+      expect(result.ok).toBe(true)
+      expect(result.message).toContain('set upstream')
+      expect(git.raw).toHaveBeenCalledWith(['push', '-u', 'origin', 'main:main'])
+    })
+
+    it('refuses when no remote is configured', async () => {
+      const git = { raw: jest.fn(), getRemotes: jest.fn().mockResolvedValue([]) }
+
+      const result = await setUpstream(git as never, 'main', 'main')
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toContain('No remote configured')
       expect(git.raw).not.toHaveBeenCalled()
     })
   })

--- a/src/git/branchActions.ts
+++ b/src/git/branchActions.ts
@@ -45,6 +45,35 @@ async function runAction(action: () => Promise<unknown>, successMessage: string)
   }
 }
 
+/** Configured remote names (best-effort; `[]` if the call fails). */
+async function listRemotes(git: SimpleGit): Promise<string[]> {
+  try {
+    return (await git.getRemotes()).map((remote) => remote.name).filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Remote to push a not-yet-tracked branch to: `origin` when it exists,
+ * else the first configured remote, else `undefined` (no remotes).
+ */
+async function resolveDefaultRemote(git: SimpleGit): Promise<string | undefined> {
+  const remotes = await listRemotes(git)
+  if (remotes.length === 0) return undefined
+  return remotes.includes('origin') ? 'origin' : remotes[0]
+}
+
+/** Whether the remote-tracking ref `refs/remotes/<remote>/<branch>` exists locally. */
+async function remoteBranchExists(git: SimpleGit, remote: string, branch: string): Promise<boolean> {
+  try {
+    await git.raw(['show-ref', '--verify', '--quiet', `refs/remotes/${remote}/${branch}`])
+    return true
+  } catch {
+    return false
+  }
+}
+
 export function checkoutBranch(git: SimpleGit, branch: BranchRef): Promise<BranchActionResult> {
   const refs = getBranchActionRefs(branch)
 
@@ -118,21 +147,71 @@ export function pullCurrentBranch(git: SimpleGit): Promise<BranchActionResult> {
   )
 }
 
-export function pushCurrentBranch(git: SimpleGit): Promise<BranchActionResult> {
+export async function pushCurrentBranch(git: SimpleGit): Promise<BranchActionResult> {
+  const hasUpstream = await git
+    .raw(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'])
+    .then(() => true)
+    .catch(() => false)
+  if (hasUpstream) {
+    return runAction(() => git.raw(['push']), 'Pushed current branch')
+  }
+  // No upstream yet — push with `-u` to create the remote branch AND set
+  // tracking, instead of failing with git's bare "has no upstream" error.
+  const remote = await resolveDefaultRemote(git)
+  if (!remote) {
+    return { ok: false, message: 'No upstream and no remote configured — add one with `git remote add origin <url>`.' }
+  }
+  const current = (await git.raw(['rev-parse', '--abbrev-ref', 'HEAD'])).trim()
   return runAction(
-    () => git.raw(['push']),
-    'Pushed current branch'
+    () => git.raw(['push', '-u', remote, current]),
+    `Pushed ${current} and set upstream to ${remote}/${current}`
   )
 }
 
-export function setUpstream(
+/**
+ * Set (or create) the upstream for a local branch from a user-typed target.
+ *
+ * The target may be a bare branch name (`main` → `<default-remote>/main`) or
+ * a `remote/branch` ref (`origin/main`). If that remote-tracking branch
+ * already exists, we just link to it (`git branch --set-upstream-to`). If it
+ * does NOT exist yet — the common "I just created this branch" case — we
+ * `git push -u` to create the remote branch and set tracking in one step.
+ * The old behavior ran `--set-upstream-to <bare-name>`, which silently
+ * resolved `main` to the *local* branch and left push still complaining.
+ */
+export async function setUpstream(
   git: SimpleGit,
   localBranch: string,
-  upstreamBranch: string
+  target: string
 ): Promise<BranchActionResult> {
+  const cleaned = target.trim()
+  if (!cleaned) return { ok: false, message: 'Upstream ref required' }
+
+  const remotes = await listRemotes(git)
+  const slash = cleaned.indexOf('/')
+  let remote: string | undefined
+  let remoteBranch: string
+  if (slash > 0 && remotes.includes(cleaned.slice(0, slash))) {
+    remote = cleaned.slice(0, slash)
+    remoteBranch = cleaned.slice(slash + 1)
+  } else {
+    remote = remotes.includes('origin') ? 'origin' : remotes[0]
+    remoteBranch = cleaned
+  }
+  if (!remote) {
+    return { ok: false, message: 'No remote configured — add one with `git remote add origin <url>` first.' }
+  }
+
+  if (await remoteBranchExists(git, remote, remoteBranch)) {
+    return runAction(
+      () => git.raw(['branch', '--set-upstream-to', `${remote}/${remoteBranch}`, localBranch]),
+      `Set ${localBranch} to track ${remote}/${remoteBranch}`
+    )
+  }
+  // Remote branch doesn't exist yet — push it and set upstream in one step.
   return runAction(
-    () => git.raw(['branch', '--set-upstream-to', upstreamBranch, localBranch]),
-    `Set ${localBranch} upstream to ${upstreamBranch}`
+    () => git.raw(['push', '-u', remote, `${localBranch}:${remoteBranch}`]),
+    `Pushed ${localBranch} → ${remote}/${remoteBranch} and set upstream`
   )
 }
 
@@ -145,22 +224,28 @@ export function setUpstream(
  * Pairs with `pushCurrentBranch` (no-arg variant); the workstation
  * dispatcher picks one or the other based on where the cursor is.
  */
-export function pushBranch(
+export async function pushBranch(
   git: SimpleGit,
   branch: BranchRef
 ): Promise<BranchActionResult> {
   if (branch.type !== 'local') {
-    return Promise.resolve({
-      ok: false,
-      message: 'Only local branches can be pushed.',
-    })
+    return { ok: false, message: 'Only local branches can be pushed.' }
   }
 
   if (!branch.upstream || !branch.remote) {
-    return Promise.resolve({
-      ok: false,
-      message: `${branch.shortName} has no upstream — checkout the branch and run \`git push -u <remote> ${branch.shortName}\` first.`,
-    })
+    // No upstream yet — push with `-u` to create the remote branch AND set
+    // tracking, rather than refusing and sending the user to the shell.
+    const remote = await resolveDefaultRemote(git)
+    if (!remote) {
+      return {
+        ok: false,
+        message: `${branch.shortName} has no upstream and no remote is configured — add one with \`git remote add origin <url>\`.`,
+      }
+    }
+    return runAction(
+      () => git.raw(['push', '-u', remote, branch.shortName]),
+      `Pushed ${branch.shortName} and set upstream to ${remote}/${branch.shortName}`
+    )
   }
 
   return runAction(


### PR DESCRIPTION
## Problem

In the `coco ui` workstation, a freshly-created local branch with no upstream (e.g. you just ran `git switch -c main` or created `main` in a new repo) couldn't be pushed:

> ℹ main has no upstream — checkout the branch and run `git push -u <remote> main` first.
> ℹ main has no upstream — nothing to pull.

Worse, the `u` (set-upstream) flow accepted a bare `main`, reported success — *"Set main upstream to main"* — but didn't create a usable upstream. It ran `git branch --set-upstream-to main`, which resolves `main` to the **local** branch (tracking itself), so every subsequent push/pull still errored with "no upstream."

## Fix

- **`pushBranch` / `pushCurrentBranch`** — when the branch has no upstream, push with `git push -u <remote> <branch>` to create the remote branch and set tracking in one step. Default remote is `origin`, else the first configured remote.
- **`setUpstream`** — parse the user's target into `<remote>/<branch>` (a bare name defaults to `origin/<name>`). If the remote-tracking ref already exists, link to it with `--set-upstream-to`; otherwise `git push -u` to create it.
- All three paths refuse cleanly with an actionable message when **no remote** is configured (instead of mis-reporting success).

New helpers: `listRemotes`, `resolveDefaultRemote`, `remoteBranchExists`.

## Validation

- `npx tsc --noEmit` — clean
- `npx jest src/git/branchActions.test.ts` — 20 passed (added coverage for the create-and-track paths and the no-remote refusals)
- `npx eslint` — clean