### PR TITLE
feat(ui): full-screen history loader during fetch/pull/push

### DIFF
--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -182,6 +182,19 @@ export type CreateLogInkStateOptions = {
   fullGraph?: boolean
 }
 
+/** Kind of remote network operation currently in flight. */
+export type RemoteOpKind = 'fetch' | 'pull' | 'push'
+
+/**
+ * Describes an in-flight remote operation so the history surface can
+ * render a full-screen loader while it runs. `label` is the human
+ * phrase shown under the spinner (e.g. "Fetching all remotes…").
+ */
+export type RemoteOpState = {
+  kind: RemoteOpKind
+  label: string
+}
+
 export type LogInkState = {
   /**
    * Top of `viewStack`. Maintained as a denormalized field so existing call
@@ -488,6 +501,16 @@ export type LogInkState = {
    */
   bootLoading: boolean
   /**
+   * In-flight remote operation (fetch / pull / push). When defined,
+   * the history surface swaps its commit list for a centered, animated
+   * loader so the user gets a clear "talking to origin…" beat instead
+   * of a frozen list that abruptly repaints once the network call
+   * returns. Set by the workflow dispatcher before the git call and
+   * cleared in a `finally` once the subsequent history/context refresh
+   * has landed — so the loader hands straight off to the fresh rows.
+   */
+  remoteOp?: RemoteOpState
+  /**
    * Split-plan overlay state (#907). When defined, the overlay is
    * open. Three phases:
    *   - 'loading'  : plan generation in flight, overlay shows a
@@ -714,6 +737,7 @@ export type LogInkAction =
   | { type: 'moveInspectorAction'; delta: number; actionCount: number }
   | { type: 'resetInspectorActionIndex' }
   | { type: 'setBootLoading'; value: boolean }
+  | { type: 'setRemoteOp'; value: RemoteOpState | undefined }
   | { type: 'moveTag'; delta: number; count: number }
   | { type: 'moveStash'; delta: number; count: number }
   | { type: 'moveReflog'; delta: number; count: number }
@@ -1572,6 +1596,11 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         ...state,
         bootLoading: action.value,
         pendingKey: undefined,
+      }
+    case 'setRemoteOp':
+      return {
+        ...state,
+        remoteOp: action.value,
       }
     case 'moveTag':
       return {

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -128,6 +128,7 @@ import { sortBranches, sortTags } from '../chrome/sorting'
 import { IDLE_TIPS_GRACE_MS, IDLE_TIPS_INTERVAL_MS, pickIdleTip } from '../chrome/idleTips'
 import {
     LogInkState,
+    RemoteOpState,
     applyLogInkAction,
     createLogInkState,
     getSelectedInkCommit,
@@ -366,6 +367,19 @@ import { renderDetailPanel } from '../runtime/detailPanel'
 import { renderOnboardingOverlay } from '../runtime/overlays'
 
 
+
+// Workflow action ids that hit the network (fetch / pull / push) →
+// the loader copy shown over the history surface while they run. Any
+// id NOT in this map runs without the full-screen loader (local-only
+// mutations repaint fast enough that a loader would just flicker).
+const REMOTE_OP_LOADERS: Record<string, RemoteOpState> = {
+  'fetch-remotes': { kind: 'fetch', label: 'Fetching all remotes…' },
+  'pull-current-branch': { kind: 'pull', label: 'Pulling from origin…' },
+  'push-current-branch': { kind: 'push', label: 'Pushing to origin…' },
+  'fetch-selected-branch': { kind: 'fetch', label: 'Fetching branch from remote…' },
+  'pull-selected-branch': { kind: 'pull', label: 'Pulling branch from remote…' },
+  'push-selected-branch': { kind: 'push', label: 'Pushing branch to remote…' },
+}
 
 function predictNextFilter(
   action: Parameters<typeof applyLogInkAction>[1],
@@ -728,6 +742,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     state.splitPlan?.status === 'applying' ||
     state.changelogView.status === 'loading' ||
     state.commitCompose.loading ||
+    Boolean(state.remoteOp) ||
     Boolean(state.statusLoading)
   React.useEffect(() => {
     if (!anyLoading) {
@@ -3649,6 +3664,17 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       dispatch({ type: 'setStatus', value: `Workflow action ${id} not yet wired`, kind: 'warning' })
       return
     }
+    // Remote network ops (fetch / pull / push) get a full-screen
+    // history loader while in flight so the commit list doesn't sit
+    // frozen and then abruptly repaint when the call returns. Cleared
+    // in `finally` *after* the post-op refresh below so the loader
+    // hands straight off to the freshly-fetched rows instead of
+    // flashing the stale list for a frame in between.
+    const remoteOp = REMOTE_OP_LOADERS[id]
+    if (remoteOp) {
+      dispatch({ type: 'setRemoteOp', value: remoteOp })
+    }
+    try {
     const result = await handler()
     dispatch({ type: 'setStatus', value: result?.message || 'Workflow action complete' })
     // Refresh history rows AS WELL when the workflow could have
@@ -3720,6 +3746,14 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       // capture the pre-refresh value. Status message stays generic
       // ("Dropped stash@{N}") — the visible list shrinking is the
       // unambiguous signal that the operation landed.
+    }
+    } finally {
+      // Always clear the loader — even if a refresh threw — so a
+      // failed fetch/pull can't leave the history surface stuck behind
+      // the spinner.
+      if (remoteOp) {
+        dispatch({ type: 'setRemoteOp', value: undefined })
+      }
     }
   }, [context, dispatch, git, refreshContext, refreshHistoryRows, refreshWorktreeContext,
     state.branchSort, state.filter, state.selectedBranchIndex,

--- a/src/workstation/runtime/mainPanel.ts
+++ b/src/workstation/runtime/mainPanel.ts
@@ -172,6 +172,8 @@ export function renderMainPanel(
     loadingMoreCommits,
     density,
     rowMode,
-    dateBucketingEnabled
+    dateBucketingEnabled,
+    undefined,
+    spinnerFrame
   )
 }

--- a/src/workstation/surfaces/history/historyRender.test.ts
+++ b/src/workstation/surfaces/history/historyRender.test.ts
@@ -176,6 +176,33 @@ describe('renderHistoryPanel', () => {
     expect(tree).toBeDefined()
   })
 
+  it('swaps the commit list for a loader while a remote op is in flight', () => {
+    // Collect every string rendered anywhere in the tree.
+    const collectText = (node: unknown, out: string[]): string[] => {
+      if (typeof node === 'string') {
+        out.push(node)
+      } else if (Array.isArray(node)) {
+        node.forEach((child) => collectText(child, out))
+      } else if (node && typeof node === 'object' && 'props' in node) {
+        collectText((node as { props: { children?: unknown } }).props.children, out)
+      }
+      return out
+    }
+
+    const loading = render(makeState({ remoteOp: { kind: 'fetch', label: 'Fetching all remotes…' } }))
+    const normal = render(makeState())
+
+    const loadingText = collectText(loading, []).join(' ')
+    const normalText = collectText(normal, []).join(' ')
+
+    // The loader surfaces its label and hint…
+    expect(loadingText).toContain('Fetching all remotes…')
+    expect(loadingText).toContain('history refreshes automatically')
+    // …and suppresses the actual commit rows that the normal view shows.
+    expect(normalText).toContain('add something')
+    expect(loadingText).not.toContain('add something')
+  })
+
   it('structural snapshot — default 3-commit history', () => {
     expect(render(makeState())).toMatchSnapshot()
   })

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -45,6 +45,7 @@ import type {
 import type { LogInkComponents, LogInkContext } from '../../runtime/types'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
 import { getRenderNow } from '../../chrome/snapshotMode'
+import { pickSpinnerFrame } from '../../chrome/spinner'
 
 /**
  * How the date column should render for a given density tier:
@@ -523,6 +524,65 @@ function renderPendingCommitRow(
   }, truncateCells(label, 140))
 }
 
+/**
+ * Full-panel loader shown over the history surface while a remote
+ * operation (fetch / pull / push) is in flight. Same bordered frame
+ * and `Commits` title row as the real panel so the swap in/out is
+ * seamless: a centered spinner + label + a travelling arrow track
+ * give the user an unmistakable "we're talking to the remote" beat in
+ * place of a frozen, soon-to-abruptly-repaint commit list.
+ */
+function renderRemoteOpLoader(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  width: number,
+  bodyRows: number,
+  theme: LogInkTheme,
+  focused: boolean,
+  spinnerFrame: number
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const op = state.remoteOp
+  if (!op) {
+    return h(Box, { width })
+  }
+  const spinner = pickSpinnerFrame(spinnerFrame)
+  // Directional glyph hints which way the bits are flowing.
+  const glyph = op.kind === 'push' ? '↑' : op.kind === 'pull' ? '↓' : '↕'
+  // A single glyph "travels" along a dotted track each tick so the
+  // motion reads even on terminals that render braille spinners poorly.
+  const trackWidth = 9
+  const pos = Math.max(0, spinnerFrame) % trackWidth
+  const track = Array.from({ length: trackWidth }, (_, i) => (i === pos ? glyph : '·')).join(' ')
+  const accent = theme.noColor ? undefined : theme.colors.accent
+  const innerHeight = Math.max(3, bodyRows - 2)
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    flexShrink: 0,
+    paddingX: 1,
+    width,
+  },
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle('Commits', focused)),
+    h(Text, { dimColor: true }, `${op.kind} in progress`)
+  ),
+  h(Box, {
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: innerHeight,
+  },
+    h(Text, { color: accent, bold: true }, `${spinner}  ${op.label}`),
+    h(Text, undefined, ''),
+    h(Text, { color: accent }, track),
+    h(Text, undefined, ''),
+    h(Text, { dimColor: true }, 'Talking to the remote — history refreshes automatically.')))
+}
+
 export function renderHistoryPanel(
   h: typeof ReactTypes.createElement,
   components: LogInkComponents,
@@ -536,10 +596,20 @@ export function renderHistoryPanel(
   density: LogInkLayoutDensity,
   rowMode: 'single' | 'stacked',
   dateBucketingEnabled: boolean = false,
-  now: Date = getRenderNow()
+  now: Date = getRenderNow(),
+  spinnerFrame: number = 0
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const focused = state.focus === 'commits'
+
+  // Remote op in flight (fetch / pull / push) → swap the commit list
+  // for a centered, animated loader. Keeping the same bordered panel
+  // (same width, same title row) means that when the op completes and
+  // `remoteOp` clears, the fresh rows paint in place without the panel
+  // jumping — smoothing over the "frozen list → sudden repaint" feel.
+  if (state.remoteOp) {
+    return renderRemoteOpLoader(h, components, state, width, bodyRows, theme, focused, spinnerFrame)
+  }
   const worktree = context.worktree
   // Distinct remote names seen across the repo's remote-tracking
   // branches — `['origin']` for a typical fork, `['origin', 'upstream']`


### PR DESCRIPTION
## Problem

When you fetch / pull / push from inside `coco ui`, the git history list sat **frozen** for the duration of the network call, then **abruptly repainted** once it returned. The sudden, delayed repaint felt off — there was no clear "we're talking to the remote" beat, and the only feedback was a tiny dimmed `loaded` → `…` flicker in the panel header.

## Change

Remote ops now flip the history surface to a **centered, animated loader** while the call is in flight:

- A braille **spinner** + the operation label (`Fetching all remotes…`, `Pulling from origin…`, `Pushing to origin…`).
- A directional glyph (`↑`/`↓`/`↕`) that **travels along a dotted track** each tick, so the motion reads even on terminals that render braille poorly.
- The loader reuses the **same bordered frame + `Commits` title row** as the real panel, so when the op finishes and the fresh rows land, they paint **in place** — no panel jump, no frozen-then-snap.

Covers both the current-branch actions (`fetch-remotes`, `pull-current-branch`, `push-current-branch`) and the per-branch sidebar variants (`fetch/pull/push-selected-branch`).

## How it works

- New `remoteOp` field + `setRemoteOp` action on `LogInkState`, wired into the shared `anyLoading` spinner tick (so the existing 80ms animation driver powers it).
- `runWorkflowAction` sets `remoteOp` before the git call and clears it in a `finally` **after** the post-op history/context refresh — so the loader hands straight off to the freshly-fetched rows, and a failed op can't strand the spinner.
- `spinnerFrame` threaded through `mainPanel` → `renderHistoryPanel`.

## Validation

- `npx tsc --noEmit` — clean
- `npx jest src/workstation/runtime src/workstation/surfaces/history src/commands/log/inkViewModel` — all green (added a render test asserting the loader swaps out the commit list and shows its label/hint)
- `npx eslint` on all touched files — clean