### PR TITLE
fix(ui): split diff turns all-purple when scrolling past the hunk header

### DIFF
--- a/src/workstation/chrome/splitDiff.test.ts
+++ b/src/workstation/chrome/splitDiff.test.ts
@@ -1,4 +1,4 @@
-import { buildSplitDiffRows } from './splitDiff'
+import { buildSplitDiffRows, computeDiffContext } from './splitDiff'
 
 describe('buildSplitDiffRows', () => {
   it('returns an empty array for empty input', () => {
@@ -218,5 +218,66 @@ describe('buildSplitDiffRows', () => {
     expect(rows[2].left.kind).toBe('context')
     expect(rows[2].right.kind).toBe('context')
     expect(rows[2].left.text).toBe('\\ No newline at end of file')
+  })
+
+  // Regression for #1114: when the split renderer windows the diff to a
+  // scroll offset that lands PAST the `@@` header, the lines handed to
+  // buildSplitDiffRows have no hunk header. Without a seed, `inHunk`
+  // starts false and every visible line is misclassified as a header —
+  // which painted the whole window in the accent color when scrolling.
+  describe('windowed (seeded) parsing', () => {
+    const fullDiff = [
+      '@@ -1,4 +1,4 @@',
+      ' context a',
+      ' context b',
+      '-removed c',
+      '+added c',
+      ' context d',
+      ' context e',
+    ]
+
+    it('misclassifies a mid-hunk window as all-header WITHOUT a seed (the bug)', () => {
+      // Slice starting after the @@ header — the unfixed path.
+      const slice = fullDiff.slice(3) // ['-removed c', '+added c', ' context d', ' context e']
+      const rows = buildSplitDiffRows(slice)
+      // Every row collapses to a header (accent color) — the reported bug.
+      expect(rows.every((row) => row.left.kind === 'header')).toBe(true)
+    })
+
+    it('classifies a mid-hunk window correctly WHEN seeded with the hunk context', () => {
+      const offset = 3
+      const seed = computeDiffContext(fullDiff, offset)
+      expect(seed.inHunk).toBe(true)
+
+      const slice = fullDiff.slice(offset)
+      const rows = buildSplitDiffRows(slice, seed)
+
+      // No header rows — real change + context, just like the full parse.
+      expect(rows.some((row) => row.left.kind === 'header')).toBe(false)
+      const change = rows.find((row) => row.right.kind === 'add')
+      expect(change?.right.text).toBe('added c')
+      expect(change?.left.text).toBe('removed c')
+    })
+
+    it('seeds continuous line numbers across the cut', () => {
+      // Full parse line numbers for the trailing context rows…
+      const full = buildSplitDiffRows(fullDiff)
+      const lastContext = full[full.length - 1]
+      expect(lastContext.left.kind).toBe('context')
+
+      // …match what the windowed+seeded parse produces for the same row.
+      const offset = 5 // start at ' context d'
+      const seed = computeDiffContext(fullDiff, offset)
+      const windowed = buildSplitDiffRows(fullDiff.slice(offset), seed)
+      const windowedLast = windowed[windowed.length - 1]
+      expect(windowedLast.left.lineNumber).toBe(lastContext.left.lineNumber)
+      expect(windowedLast.right.lineNumber).toBe(lastContext.right.lineNumber)
+    })
+
+    it('computeDiffContext reports not-in-hunk before the first header', () => {
+      const lines = ['diff --git a/f b/f', '@@ -1,1 +1,1 @@', '-x', '+y']
+      expect(computeDiffContext(lines, 1)).toMatchObject({ inHunk: false })
+      expect(computeDiffContext(lines, 2)).toMatchObject({ inHunk: true })
+    })
   })
 })

--- a/src/workstation/chrome/splitDiff.ts
+++ b/src/workstation/chrome/splitDiff.ts
@@ -42,6 +42,25 @@ export type SplitDiffRow = {
   right: SplitDiffSide
 }
 
+/**
+ * Hunk-parse state at a given point in a unified diff: whether we're
+ * inside a hunk body and the next old/new line numbers to emit.
+ *
+ * The split renderer windows the diff by slicing the unified-line
+ * array BEFORE parsing (so it only builds rows for the visible rows).
+ * That slice can start partway through a hunk — past the `@@` header
+ * that seeds `inHunk` and the line-number cursors. Without this seed,
+ * `buildSplitDiffRows` starts with `inHunk = false` and classifies
+ * every line in the window as a header (#1114) — which paints the
+ * whole visible diff in the accent color. Callers compute the context
+ * for the slice start with `computeDiffContext` and pass it in.
+ */
+export type DiffHunkContext = {
+  inHunk: boolean
+  oldLineNo: number
+  newLineNo: number
+}
+
 const EMPTY_LEFT: SplitDiffSide = { text: '', kind: 'empty' }
 const EMPTY_RIGHT: SplitDiffSide = { text: '', kind: 'empty' }
 
@@ -95,11 +114,54 @@ function flushChangeBlock(
   additions.length = 0
 }
 
-export function buildSplitDiffRows(unifiedLines: string[]): SplitDiffRow[] {
-  const rows: SplitDiffRow[] = []
+/**
+ * Replay the hunk parser over `unifiedLines[0..upTo)` (exclusive) and
+ * return the parse state at that boundary. Used by the split renderer
+ * to seed `buildSplitDiffRows` with the correct in-hunk flag and
+ * line-number cursors when it windows the diff to a scroll offset that
+ * starts partway through a hunk. Counting mirrors `buildSplitDiffRows`
+ * exactly so the seeded line numbers stay continuous across the cut.
+ */
+export function computeDiffContext(unifiedLines: string[], upTo: number): DiffHunkContext {
   let oldLineNo = 0
   let newLineNo = 0
   let inHunk = false
+  const bound = Math.max(0, Math.min(upTo, unifiedLines.length))
+  for (let i = 0; i < bound; i++) {
+    const raw = unifiedLines[i]
+    if (raw.startsWith('@@')) {
+      const [oldStart, newStart] = parseHunkHeader(raw)
+      oldLineNo = oldStart
+      newLineNo = newStart
+      inHunk = true
+      continue
+    }
+    if (!inHunk || isDiffHeader(raw)) {
+      continue
+    }
+    if (raw.startsWith('-')) {
+      oldLineNo += 1
+      continue
+    }
+    if (raw.startsWith('+')) {
+      newLineNo += 1
+      continue
+    }
+    // Context line (or `\ No newline` marker) advances both cursors.
+    oldLineNo += 1
+    newLineNo += 1
+  }
+  return { inHunk, oldLineNo, newLineNo }
+}
+
+export function buildSplitDiffRows(
+  unifiedLines: string[],
+  seed?: DiffHunkContext
+): SplitDiffRow[] {
+  const rows: SplitDiffRow[] = []
+  let oldLineNo = seed?.oldLineNo ?? 0
+  let newLineNo = seed?.newLineNo ?? 0
+  let inHunk = seed?.inHunk ?? false
   const removals: SplitDiffSide[] = []
   const additions: SplitDiffSide[] = []
 

--- a/src/workstation/runtime/splitDiff.ts
+++ b/src/workstation/runtime/splitDiff.ts
@@ -11,7 +11,7 @@
  */
 
 import type * as ReactTypes from 'react'
-import { SplitDiffRow, buildSplitDiffRows } from '../chrome/splitDiff'
+import { SplitDiffRow, buildSplitDiffRows, computeDiffContext } from '../chrome/splitDiff'
 import { truncateCells } from '../chrome/text'
 import type { LogInkTheme } from '../chrome/theme'
 import type { LogInkState } from '../../commands/log/inkViewModel'
@@ -84,21 +84,31 @@ export function formatSplitDiffCell(
 }
 
 /**
- * Render the split-diff body as a list of two-column rows. The caller
- * is responsible for slicing the unified-line array to the visible
- * window — the helper just transforms that slice into Ink nodes.
+ * Render the split-diff body as a list of two-column rows.
+ *
+ * Takes the FULL unified-line array plus the scroll offset + visible
+ * row budget, and windows it internally. The windowing has to live
+ * here (not the caller) because the parser is stateful: a window that
+ * starts partway through a hunk needs the hunk context (in-hunk flag +
+ * line-number cursors) that precedes it, or every visible line gets
+ * misclassified as a header and painted in the accent color (#1114).
+ * We compute that context from the lines before the window and seed
+ * the parser with it.
  */
 export function renderSplitDiffBody(
   h: typeof ReactTypes.createElement,
   components: LogInkComponents,
-  unifiedSlice: string[],
+  unifiedLines: string[],
   startOffset: number,
+  visibleRows: number,
   width: number,
   theme: LogInkTheme,
   keyPrefix: string
 ): ReactTypes.ReactElement[] {
   const { Box, Text } = components
-  const rows = buildSplitDiffRows(unifiedSlice)
+  const seed = computeDiffContext(unifiedLines, startOffset)
+  const unifiedSlice = unifiedLines.slice(startOffset, startOffset + visibleRows)
+  const rows = buildSplitDiffRows(unifiedSlice, seed)
   // Reserve 3 columns of gutter (1 left padding from the Box + 1 column
   // separator + 1 right padding) so neither side touches the border.
   const usable = Math.max(20, width - 4)

--- a/src/workstation/surfaces/diff/index.ts
+++ b/src/workstation/surfaces/diff/index.ts
@@ -130,7 +130,7 @@ export function renderDiffSurface(
       ? []
       : splitActive
         ? renderSplitDiffBody(
-          h, components, visibleLines, state.diffPreviewOffset, width, theme,
+          h, components, lines, state.diffPreviewOffset, visibleRows, width, theme,
           'stash-diff-split'
         )
         : visibleLines.map((line, index) => {
@@ -226,7 +226,7 @@ export function renderDiffSurface(
       ? []
       : splitActive
         ? renderSplitDiffBody(
-          h, components, visibleLines, state.diffPreviewOffset, width, theme,
+          h, components, lines, state.diffPreviewOffset, visibleRows, width, theme,
           'compare-diff-split'
         )
         : visibleLines.map((line, index) => h(Text, {
@@ -297,7 +297,7 @@ export function renderDiffSurface(
       ? []
       : splitActive
         ? renderSplitDiffBody(
-          h, components, visiblePreviewHunks, state.diffPreviewOffset, width, theme,
+          h, components, previewHunks, state.diffPreviewOffset, visibleRows, width, theme,
           'commit-diff-split'
         )
         : visiblePreviewHunks.map((line, index) => h(Text, {


### PR DESCRIPTION
## The bug

In the side-by-side (split) diff view, scrolling down far enough that the `@@` hunk header leaves the visible window makes **every line turn the accent color (purple/magenta)** — syntax/diff coloring vanishes and the whole panel goes one flat color. (Two-frame repro: one `↓` press flips a normally-colored window to all-purple.)

## Root cause

`buildSplitDiffRows` is a **stateful parser** — an `@@` header seeds an `inHunk` flag plus the old/new line-number cursors. The renderer windowed the diff by slicing the unified-line array **before** parsing, so any scroll offset past the `@@` header handed the parser a header-less slice. With `inHunk` starting `false`, this guard:

```ts
if (!inHunk || isDiffHeader(raw)) { flushHeader(raw); continue }
```

classified **every** visible line as a header — and header rows render in `theme.colors.accent`. Hence: scroll past the header → everything purple.

## Fix

Move the windowing **inside** `renderSplitDiffBody` and seed the parser with the hunk context that precedes the visible slice:

- **`computeDiffContext(lines, upTo)`** — replays the parse up to the window start, returning `{ inHunk, oldLineNo, newLineNo }`.
- **`buildSplitDiffRows(lines, seed?)`** — a new optional `seed` so a windowed slice resumes with the correct in-hunk state and line numbers.
- `renderSplitDiffBody` now takes the full line array + offset + `visibleRows` and slices internally (all three call sites — stash / compare / commit diffs — updated).

**Bonus:** the split view's line-number gutter is now **continuous** when scrolled into a hunk, instead of restarting from the hunk header's values.

## Note on syntax highlighting

There is currently **no syntax highlighting in the diff** — only diff coloring (add=green, remove=red, header=accent). The "purple" here was that accent color leaking onto everything, not a highlighter misfiring. Happy to add real per-language syntax highlighting in diffs as a separate enhancement if you want it.

## Validation

- `npx tsc --noEmit` — clean
- `npx jest src/workstation` — 754 passed (added regression tests: unseeded misclassification = the bug, seeded fix, continuous line numbers across the cut)
- `npx eslint` on all touched files — clean