### PR TITLE
feat(ui): add to .gitignore from the worktree view (i)

### DIFF
--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -1,3 +1,4 @@
+import { deriveGitignoreOptions } from '../../workstation/chrome/gitignore'
 import { extractDiffHunk } from '../../workstation/chrome/hunkExtraction'
 import {
     InspectorAction,
@@ -68,6 +69,11 @@ export type LogInkInputEvent =
   | { type: 'yankFromActiveView'; short?: boolean }
   | { type: 'yankText'; value: string; label: string }
   | { type: 'applyThemePreset'; preset: string }
+  // Open the "add to .gitignore" picker over the cursored worktree
+  // file. Carries no path — the runtime resolves the cursored file (it
+  // owns the selection→file mapping) and dispatches `openGitignorePicker`
+  // with the resolved path, same pattern as `revertSelectedFile`.
+  | { type: 'openGitignorePicker' }
 
 export type LogInkInputContext = {
   detailFileCount?: number
@@ -674,6 +680,10 @@ export function getLogInkPaletteExecuteEvents(
       // Palette closes on execute (toggleCommandPalette runs first), then
       // this opens the theme picker.
       return [action({ type: 'toggleThemePicker' })]
+    case 'gitignoreFile':
+      // Runtime resolves the cursored worktree file and opens the picker
+      // (no-ops with a warning when there's no file under the cursor).
+      return [{ type: 'openGitignorePicker' }]
     case 'workflowDeleteBranch':
     case 'workflowDeleteTag':
     case 'workflowDropStash':
@@ -768,6 +778,12 @@ function submitInputPrompt(state: LogInkState): LogInkInputEvent[] {
   const value = state.inputPrompt.value.trim()
   if (!value) {
     return [action({ type: 'setStatus', value: 'enter a value or press esc to cancel', kind: 'warning' })]
+  }
+  if (state.inputPrompt.kind === 'gitignore-pattern') {
+    return [
+      { type: 'runWorkflowAction', id: 'add-to-gitignore', payload: value },
+      action({ type: 'closeInputPrompt' }),
+    ]
   }
   if (state.inputPrompt.kind === 'reset-mode') {
     const mode = value.toLowerCase()
@@ -1288,6 +1304,46 @@ export function getLogInkInputEvents(
     if (inputValue && !key.ctrl && !key.meta) {
       return [action({ type: 'appendThemePickerFilter', value: inputValue })]
     }
+    return []
+  }
+
+  if (state.gitignorePicker) {
+    const options = deriveGitignoreOptions(state.gitignorePicker.file)
+    if (key.escape) {
+      return [action({ type: 'closeGitignorePicker' })]
+    }
+    if (key.upArrow || (key.ctrl && inputValue === 'p')) {
+      return [action({ type: 'moveGitignorePicker', delta: -1, count: options.length })]
+    }
+    if (key.downArrow || (key.ctrl && inputValue === 'n')) {
+      return [action({ type: 'moveGitignorePicker', delta: 1, count: options.length })]
+    }
+    if (key.return) {
+      const selected = options[Math.max(0, Math.min(state.gitignorePicker.index, options.length - 1))]
+      if (!selected) {
+        return [action({ type: 'closeGitignorePicker' })]
+      }
+      if (selected.custom) {
+        // Hand off to a free-text prompt seeded with the file path so
+        // the user can type any valid gitignore pattern (negations,
+        // globs, anchored paths) the derived options don't cover.
+        return [
+          action({ type: 'closeGitignorePicker' }),
+          action({
+            type: 'openInputPrompt',
+            kind: 'gitignore-pattern',
+            label: `.gitignore pattern (e.g. ${selected.pattern || '*.log'})`,
+            initial: selected.pattern,
+          }),
+        ]
+      }
+      return [
+        action({ type: 'closeGitignorePicker' }),
+        { type: 'runWorkflowAction', id: 'add-to-gitignore', payload: selected.pattern },
+      ]
+    }
+    // Consume everything else so the underlying status view keys don't
+    // leak through while the picker owns the screen.
     return []
   }
 
@@ -2810,6 +2866,13 @@ export function getLogInkInputEvents(
   // re-renders.
   if (inputValue === 'o' && state.activeView === 'status' && context.worktreeFileCount && context.worktreeSelectedPath) {
     return [{ type: 'openFileInEditor', path: context.worktreeSelectedPath }]
+  }
+  // `i` opens the "add to .gitignore" picker for the cursored worktree
+  // file. The runtime resolves the path + opens the picker (the bare
+  // event carries no path — same selection-resolution pattern as the
+  // revert / stage events).
+  if (inputValue === 'i' && state.activeView === 'status' && context.worktreeFileCount && context.worktreeSelectedPath) {
+    return [{ type: 'openGitignorePicker' }]
   }
   if (inputValue === 'o' && state.activeView === 'diff' && state.diffSource === 'worktree' && context.worktreeSelectedPath) {
     return [{ type: 'openFileInEditor', path: context.worktreeSelectedPath }]

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -32,7 +32,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ files', 'enter diff', 'space stage', 'z revert', 'e/c compose', 'y yank'],
+      contextual: ['↑/↓ files', 'enter diff', 'space stage', 'z revert', 'i ignore', 'e/c compose', 'y yank'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -9,6 +9,7 @@ export type LogInkCommandId =
   | 'clearSearch'
   | 'commandPalette'
   | 'themePicker'
+  | 'gitignoreFile'
   | 'commit'
   | 'cycleSort'
   | 'editCommit'
@@ -542,6 +543,13 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     contexts: ['normal'],
   },
   {
+    id: 'gitignoreFile',
+    keys: ['i'],
+    label: 'gitignore',
+    description: 'Add the cursored file or folder to .gitignore (pick a pattern).',
+    contexts: ['status'],
+  },
+  {
     id: 'viewChangelog',
     keys: ['L'],
     label: 'changelog',
@@ -698,6 +706,7 @@ const BINDING_CATEGORY_BY_ID: Partial<Record<LogInkCommandId, LogInkBindingCateg
   help: 'essentials',
   commandPalette: 'essentials',
   themePicker: 'view',
+  gitignoreFile: 'mutate',
   quit: 'essentials',
   refresh: 'essentials',
   navigateBack: 'essentials',
@@ -1044,7 +1053,7 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
 
   if (options.activeView === 'status') {
     return {
-      contextual: ['↑/↓ files', 'enter diff', 'space stage', 'z revert', 'e/c compose', 'y yank'],
+      contextual: ['↑/↓ files', 'enter diff', 'space stage', 'z revert', 'i ignore', 'e/c compose', 'y yank'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -73,6 +73,29 @@ describe('log Ink view model', () => {
     expect(state.pendingMutationConfirmation).toBeUndefined()
   })
 
+  it('opens, moves, and closes the gitignore picker', () => {
+    let state = createLogInkState(rows, { activeView: 'status' })
+    expect(state.gitignorePicker).toBeUndefined()
+
+    state = applyLogInkAction(state, { type: 'openGitignorePicker', file: '.www/' })
+    expect(state.gitignorePicker).toEqual({ file: '.www/', index: 0 })
+
+    // Move down within a 3-option list (anchored, bare, custom).
+    state = applyLogInkAction(state, { type: 'moveGitignorePicker', delta: 1, count: 3 })
+    expect(state.gitignorePicker?.index).toBe(1)
+
+    // Clamps at the bottom bound.
+    state = applyLogInkAction(state, { type: 'moveGitignorePicker', delta: 5, count: 3 })
+    expect(state.gitignorePicker?.index).toBe(2)
+
+    // Clamps at the top bound.
+    state = applyLogInkAction(state, { type: 'moveGitignorePicker', delta: -10, count: 3 })
+    expect(state.gitignorePicker?.index).toBe(0)
+
+    state = applyLogInkAction(state, { type: 'closeGitignorePicker' })
+    expect(state.gitignorePicker).toBeUndefined()
+  })
+
   it('supports workstation surface selection', () => {
     let state = createLogInkState(rows, { activeView: 'status' })
 

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -310,6 +310,13 @@ export type LogInkState = {
   showThemePicker: boolean
   themePickerFilter: string
   themePickerIndex: number
+  /**
+   * "Add to .gitignore" quick-pick (`i` on the status view). When
+   * defined, the overlay is open over the cursored worktree file:
+   * `file` is the repo-relative path the pattern options are derived
+   * from, `index` is the cursor into that derived option list.
+   */
+  gitignorePicker?: { file: string; index: number }
   workflowActionId?: string
   pendingConfirmationId?: string
   /**
@@ -670,6 +677,7 @@ export type LogInkInputPromptKind =
   | 'rename-branch'
   | 'set-upstream'
   | 'create-stash'
+  | 'gitignore-pattern'
   | 'reset-mode'
   | 'pr-merge-strategy'
   | 'pr-comment'
@@ -798,6 +806,9 @@ export type LogInkAction =
   | { type: 'appendThemePickerFilter'; value: string }
   | { type: 'backspaceThemePickerFilter' }
   | { type: 'clearThemePickerFilter' }
+  | { type: 'openGitignorePicker'; file: string }
+  | { type: 'closeGitignorePicker' }
+  | { type: 'moveGitignorePicker'; delta: number; count: number }
   | { type: 'cycleBranchSort' }
   | { type: 'cycleTagSort' }
   | { type: 'openInputPrompt'; kind: LogInkInputPromptKind; label: string; initial?: string; multiline?: boolean }
@@ -2162,6 +2173,29 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         themePickerIndex: 0,
         pendingKey: undefined,
       }
+    case 'openGitignorePicker':
+      return {
+        ...state,
+        gitignorePicker: { file: action.file, index: 0 },
+        pendingKey: undefined,
+      }
+    case 'closeGitignorePicker':
+      return {
+        ...state,
+        gitignorePicker: undefined,
+        pendingKey: undefined,
+      }
+    case 'moveGitignorePicker':
+      return state.gitignorePicker
+        ? {
+          ...state,
+          gitignorePicker: {
+            ...state.gitignorePicker,
+            index: clampIndex(state.gitignorePicker.index + action.delta, action.count),
+          },
+          pendingKey: undefined,
+        }
+        : state
     case 'setChangelogLoading':
       return {
         ...state,

--- a/src/git/gitignore.test.ts
+++ b/src/git/gitignore.test.ts
@@ -1,0 +1,63 @@
+import { promises as fs } from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { addToGitignore } from './gitignore'
+
+// Minimal SimpleGit stub — only `revparse(['--show-toplevel'])` is used.
+function fakeGit(root: string | null) {
+  return {
+    revparse: jest.fn(async () => (root === null ? Promise.reject(new Error('not a repo')) : `${root}\n`)),
+  } as never
+}
+
+describe('addToGitignore', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'coco-gitignore-'))
+  })
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  const readIgnore = () => fs.readFile(path.join(dir, '.gitignore'), 'utf8')
+
+  it('creates .gitignore when it does not exist', async () => {
+    const result = await addToGitignore(fakeGit(dir), '.www/')
+    expect(result.ok).toBe(true)
+    expect(result.message).toContain('Added .www/')
+    expect(await readIgnore()).toBe('.www/\n')
+  })
+
+  it('appends to an existing file, adding a separating newline when missing', async () => {
+    await fs.writeFile(path.join(dir, '.gitignore'), 'node_modules') // no trailing newline
+    await addToGitignore(fakeGit(dir), '*.log')
+    expect(await readIgnore()).toBe('node_modules\n*.log\n')
+  })
+
+  it('does not duplicate an already-present pattern', async () => {
+    await fs.writeFile(path.join(dir, '.gitignore'), 'dist/\n*.log\n')
+    const result = await addToGitignore(fakeGit(dir), '*.log')
+    expect(result.ok).toBe(true)
+    expect(result.message).toContain('already in .gitignore')
+    expect(await readIgnore()).toBe('dist/\n*.log\n') // unchanged
+  })
+
+  it('trims surrounding whitespace before writing/matching', async () => {
+    await fs.writeFile(path.join(dir, '.gitignore'), '  *.log  \n')
+    const result = await addToGitignore(fakeGit(dir), '*.log')
+    expect(result.message).toContain('already in .gitignore')
+  })
+
+  it('rejects an empty pattern', async () => {
+    const result = await addToGitignore(fakeGit(dir), '   ')
+    expect(result.ok).toBe(false)
+    expect(result.message).toBe('No pattern to add.')
+  })
+
+  it('fails gracefully when the repo root cannot be resolved', async () => {
+    const result = await addToGitignore(fakeGit(null), '*.log')
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('repository root')
+  })
+})

--- a/src/git/gitignore.ts
+++ b/src/git/gitignore.ts
@@ -1,0 +1,70 @@
+/**
+ * Append a pattern to the repository's `.gitignore` (the runtime side of
+ * the "add to .gitignore" quick-pick, `i` on the status view).
+ *
+ * Kept separate from the pure pattern-derivation helper
+ * (`workstation/chrome/gitignore.ts`) because this touches the filesystem
+ * and resolves the repo root via git — neither of which the UI layer
+ * should pull in.
+ */
+import { promises as fs } from 'fs'
+import * as path from 'path'
+import { SimpleGit } from 'simple-git'
+
+export type GitignoreWriteResult = {
+  ok: boolean
+  message: string
+}
+
+/**
+ * Append `pattern` to `<repoRoot>/.gitignore`, creating the file if it
+ * doesn't exist. No-ops (reporting success) when the exact pattern is
+ * already present so re-running is safe. Handles the missing-trailing-
+ * newline case so we never glue the new entry onto the previous line.
+ */
+export async function addToGitignore(
+  git: SimpleGit,
+  pattern: string
+): Promise<GitignoreWriteResult> {
+  const entry = pattern.trim()
+  if (!entry) {
+    return { ok: false, message: 'No pattern to add.' }
+  }
+
+  let root: string
+  try {
+    root = (await git.revparse(['--show-toplevel'])).trim()
+  } catch {
+    return { ok: false, message: 'Could not resolve the repository root.' }
+  }
+  if (!root) {
+    return { ok: false, message: 'Could not resolve the repository root.' }
+  }
+
+  const file = path.join(root, '.gitignore')
+  let existing = ''
+  try {
+    existing = await fs.readFile(file, 'utf8')
+  } catch {
+    // No .gitignore yet — we'll create it.
+    existing = ''
+  }
+
+  // Already ignored (exact line match, ignoring surrounding whitespace)?
+  const alreadyPresent = existing
+    .split('\n')
+    .some((line) => line.trim() === entry)
+  if (alreadyPresent) {
+    return { ok: true, message: `${entry} is already in .gitignore` }
+  }
+
+  const needsLeadingNewline = existing.length > 0 && !existing.endsWith('\n')
+  const addition = `${needsLeadingNewline ? '\n' : ''}${entry}\n`
+  try {
+    await fs.appendFile(file, addition, 'utf8')
+  } catch (error) {
+    return { ok: false, message: (error as Error).message }
+  }
+
+  return { ok: true, message: `Added ${entry} to .gitignore` }
+}

--- a/src/workstation/chrome/gitignore.test.ts
+++ b/src/workstation/chrome/gitignore.test.ts
@@ -1,0 +1,57 @@
+import { deriveGitignoreOptions } from './gitignore'
+
+describe('deriveGitignoreOptions', () => {
+  it('always ends with a custom-pattern escape hatch seeded with the path', () => {
+    const opts = deriveGitignoreOptions('src/foo.ts')
+    const last = opts[opts.length - 1]
+    expect(last.custom).toBe(true)
+    expect(last.label).toBe('Custom pattern…')
+    expect(last.pattern).toBe('src/foo.ts')
+  })
+
+  it('offers exact / by-extension / by-folder / by-name for a nested file', () => {
+    const patterns = deriveGitignoreOptions('src/utils/debug.log').map((o) => o.pattern)
+    expect(patterns).toEqual([
+      'src/utils/debug.log', // this file only
+      '*.log', // by extension
+      'src/utils/', // its folder
+      'debug.log', // by name anywhere
+      'src/utils/debug.log', // custom (seeded with the path)
+    ])
+  })
+
+  it('offers anchored + bare folder forms for a directory (trailing slash)', () => {
+    const opts = deriveGitignoreOptions('.www/')
+    const nonCustom = opts.filter((o) => !o.custom).map((o) => o.pattern)
+    // Anchored-to-root and match-anywhere variants.
+    expect(nonCustom).toEqual(['/.www/', '.www/'])
+  })
+
+  it('handles a nested directory', () => {
+    const nonCustom = deriveGitignoreOptions('packages/app/dist/')
+      .filter((o) => !o.custom)
+      .map((o) => o.pattern)
+    expect(nonCustom).toEqual(['/packages/app/dist/', 'dist/'])
+  })
+
+  it('omits the extension option for a dotfile / extensionless file', () => {
+    const patterns = deriveGitignoreOptions('.env').map((o) => o.pattern)
+    // leading-dot name has no "extension" (lastIndexOf('.') === 0) — no *.x option
+    expect(patterns).not.toContain('*.env')
+    expect(patterns).toContain('.env')
+  })
+
+  it('deduplicates patterns (top-level file: this-file === by-name)', () => {
+    const opts = deriveGitignoreOptions('notes.txt')
+    const nonCustom = opts.filter((o) => !o.custom).map((o) => o.pattern)
+    // 'notes.txt' (this file) and 'notes.txt' (by name) collapse to one;
+    // '*.txt' remains. No parent folder for a top-level file.
+    expect(nonCustom).toEqual(['notes.txt', '*.txt'])
+  })
+
+  it('returns only the custom option for an empty path', () => {
+    const opts = deriveGitignoreOptions('')
+    expect(opts).toHaveLength(1)
+    expect(opts[0].custom).toBe(true)
+  })
+})

--- a/src/workstation/chrome/gitignore.ts
+++ b/src/workstation/chrome/gitignore.ts
@@ -1,0 +1,81 @@
+/**
+ * Derive a short menu of sensible `.gitignore` patterns from the path of
+ * the cursored worktree file (the "add to .gitignore" quick-pick, `i` on
+ * the status view).
+ *
+ * The goal is to turn the common asks — "ignore exactly this", "ignore
+ * everything with this extension", "ignore this whole folder" — into
+ * one-keystroke choices, while always offering a `Custom pattern…` escape
+ * hatch that opens a free-text prompt for anything the menu doesn't cover
+ * (negations, globs, anchored paths, etc.).
+ *
+ * Pure / synchronous so it's trivially unit-testable and reusable from the
+ * reducer, the input handler, and the overlay renderer without pulling in
+ * `fs`.
+ */
+
+export type GitignoreOption = {
+  /**
+   * The pattern written to `.gitignore` when this option is chosen. For
+   * the `custom` option it's the value the free-text prompt is pre-filled
+   * with (so the user starts from the exact path and edits from there).
+   */
+  pattern: string
+  /** Human-readable label shown in the picker. */
+  label: string
+  /**
+   * When true, choosing this option opens a free-text input prompt seeded
+   * with `pattern` instead of writing it directly — for arbitrary valid
+   * gitignore syntax the derived options don't cover.
+   */
+  custom: boolean
+}
+
+/**
+ * Build the option list for a repo-relative path. Git reports untracked
+ * directories with a trailing slash (`.www/`), which is how we tell a
+ * directory from a file. Duplicate patterns are collapsed (e.g. a
+ * top-level dir whose anchored and bare forms would otherwise repeat).
+ */
+export function deriveGitignoreOptions(rawPath: string): GitignoreOption[] {
+  const input = rawPath.trim()
+  const options: GitignoreOption[] = []
+  const seen = new Set<string>()
+  const add = (pattern: string, label: string): void => {
+    if (!pattern || seen.has(pattern)) return
+    seen.add(pattern)
+    options.push({ pattern, label, custom: false })
+  }
+
+  if (input) {
+    const isDir = input.endsWith('/')
+    const clean = input.replace(/\/+$/, '')
+    const segments = clean.split('/').filter(Boolean)
+    const base = segments[segments.length - 1] || clean
+    const parent = segments.slice(0, -1).join('/')
+
+    if (isDir) {
+      // Anchored to the repo root vs. matching any folder of that name.
+      add(`/${clean}/`, `This folder only (/${clean}/)`)
+      add(`${base}/`, `Any “${base}/” folder`)
+    } else {
+      add(input, `This file only (${input})`)
+      const dot = base.lastIndexOf('.')
+      if (dot > 0 && dot < base.length - 1) {
+        const ext = base.slice(dot)
+        add(`*${ext}`, `All ${ext} files (*${ext})`)
+      }
+      if (parent) {
+        add(`${parent}/`, `Its folder (${parent}/)`)
+      }
+      add(base, `Any file named “${base}”`)
+    }
+  }
+
+  options.push({
+    pattern: input,
+    label: 'Custom pattern…',
+    custom: true,
+  })
+  return options
+}

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -150,6 +150,7 @@ import {
     renameBranch,
     setUpstream,
 } from '../../git/branchActions'
+import { addToGitignore } from '../../git/gitignore'
 import { createLightweightTag, deleteLocalTag, deleteRemoteTag, pushTag } from '../../git/tagActions'
 import {
     ClipboardRunner,
@@ -3375,6 +3376,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         if (!branch) return { ok: false, message: 'No branch selected' }
         return pushBranch(git, branch)
       },
+      'add-to-gitignore': async () => addToGitignore(git, payload || ''),
       'rename-branch': async () => {
         const newName = payload?.trim()
         if (!newName) return { ok: false, message: 'New branch name required' }
@@ -3735,6 +3737,12 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     // unambiguous feedback that the drop landed and the list shrank.
     if (result?.ok && (id === 'apply-stash' || id === 'pop-stash')) {
       dispatch({ type: 'pushView', value: 'history' })
+      await refreshWorktreeContext()
+    }
+    // Refresh the worktree so a now-ignored untracked file drops out of
+    // the status list immediately (the silent context refresh above
+    // doesn't always re-read the worktree file set).
+    if (result?.ok && id === 'add-to-gitignore') {
       await refreshWorktreeContext()
     }
     if (result?.ok && id === 'drop-stash') {
@@ -4533,6 +4541,14 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         openInEditor(event.path)
       } else if (event.type === 'yankFromActiveView') {
         void yankFromActiveView(event.short)
+      } else if (event.type === 'openGitignorePicker') {
+        // Resolve the cursored worktree file here (the runtime owns the
+        // selection→file mapping) and open the picker over its path.
+        if (selectedWorktreeFile?.path) {
+          dispatch({ type: 'openGitignorePicker', file: selectedWorktreeFile.path })
+        } else {
+          dispatch({ type: 'setStatus', value: 'No file under the cursor to ignore.', kind: 'warning' })
+        }
       } else if (event.type === 'applyThemePreset') {
         // Apply for the session immediately, and best-effort persist to the
         // global config so it sticks across launches. The picker has already

--- a/src/workstation/runtime/detailPanel.ts
+++ b/src/workstation/runtime/detailPanel.ts
@@ -41,6 +41,7 @@ import {
     renderConfirmationPanel,
     renderHelpPanel,
     renderInputPromptPanel,
+    renderGitignorePickerOverlay,
     renderThemePickerOverlay,
 } from './overlays'
 import type { LogInkComponents, LogInkContext } from './types'
@@ -119,6 +120,10 @@ export function renderDetailPanel(
 
   if (state.showThemePicker) {
     return renderThemePickerOverlay(h, components, state.themePickerFilter, state.themePickerIndex, width, theme, focused)
+  }
+
+  if (state.gitignorePicker) {
+    return renderGitignorePickerOverlay(h, components, state.gitignorePicker.file, state.gitignorePicker.index, width, theme, focused)
   }
 
   if (state.inputPrompt) {

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -17,6 +17,7 @@
  */
 
 import type * as ReactTypes from 'react'
+import { deriveGitignoreOptions } from '../chrome/gitignore'
 import { pickSpinnerFrame } from '../chrome/spinner'
 import { truncateCells } from '../chrome/text'
 import type { LogInkTheme } from '../chrome/theme'
@@ -480,6 +481,56 @@ export function renderThemePickerOverlay(
   ...(hasMoreBelow
     ? [h(Text, { key: 'theme-more-below', dimColor: true }, `  ↓ ${filtered.length - (startIndex + listRows)} more below`)]
     : []))
+}
+
+/**
+ * "Add to .gitignore" quick-pick overlay (`i` on the status view).
+ * Modeled on the theme picker but with a fixed, file-derived option list
+ * (no fuzzy filter — the menu is short): pick exact / by-extension /
+ * by-folder / by-name, or the `Custom pattern…` escape hatch which opens
+ * a free-text prompt. ↑/↓ to move, Enter to choose, Esc to cancel.
+ */
+export function renderGitignorePickerOverlay(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  file: string,
+  index: number,
+  width: number,
+  theme: LogInkTheme,
+  focused: boolean
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const options = deriveGitignoreOptions(file)
+  const selectedIndex = Math.max(0, Math.min(index, options.length - 1))
+  const hint = '↑/↓ select · enter add · esc cancel'
+
+  const itemLines = options.map((option, offset) => {
+    const isSelected = offset === selectedIndex
+    const cursor = isSelected ? '>' : ' '
+    const glyph = option.custom ? '✎ ' : '+ '
+    return h(Text, {
+      key: `gitignore-opt-${offset}`,
+      bold: isSelected,
+      dimColor: !isSelected,
+      color: isSelected && !theme.noColor ? theme.colors.accent : undefined,
+    }, `${cursor} ${glyph}`, truncateCells(option.label, width - 8))
+  })
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    width,
+    paddingX: 1,
+  },
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle('Add to .gitignore', focused)),
+    h(Text, { dimColor: true }, `${options.length} options`)
+  ),
+  h(Text, { color: theme.colors.accent }, truncateCells(file || '(no file)', width - 4)),
+  h(Text, { dimColor: true }, truncateCells(hint, width - 4)),
+  h(Text, undefined, ''),
+  ...itemLines)
 }
 
 /**


### PR DESCRIPTION
## What

Press **`i`** on a worktree file in the status view to add it to `.gitignore` without dropping to the shell. It opens a quick-pick of patterns **derived from the cursored path**, writes your choice to the repo's `.gitignore`, and refreshes the worktree so a now-ignored untracked file vanishes from the list.

Motivated by the common case in the screenshots: an untracked `.www/` folder you just want gone from status.

## The quick-pick

Options adapt to the path:
- **A file** (`src/utils/debug.log`): this file exactly · `*.log` (by extension) · `src/utils/` (its folder) · `debug.log` (any file of that name)
- **A folder** (`.www/`): `/.www/` (anchored to repo root) · `.www/` (match anywhere)
- **Always**: `Custom pattern…` → opens a free-text prompt seeded with the path, for anything the menu doesn't cover (negations, globs, anchored paths).

`↑/↓` to move, `Enter` to add, `Esc` to cancel. Also reachable from the `:` command palette and listed in the `?` help overlay, with an `i ignore` footer hint on the status view.

## How it's built

Mirrors the existing **theme-picker** overlay pattern end to end:
- `gitignorePicker` state field + `openGitignorePicker` / `closeGitignorePicker` / `moveGitignorePicker` reducer actions
- `renderGitignorePickerOverlay` in `overlays.ts`, dispatched from `detailPanel.ts`
- an input short-circuit in `inkInput.ts` while the picker is open; the bare `openGitignorePicker` event is resolved against the cursored file in `app.ts` (same pattern as `revertSelectedFile`)
- a new `add-to-gitignore` workflow action that appends to the file, then triggers a worktree refresh
- new pure helper **`deriveGitignoreOptions`** (UI-side) and **`addToGitignore`** (fs-side)

## Validation

- `npx tsc --noEmit` — clean
- `npx jest` on all affected suites — green, including:
  - `deriveGitignoreOptions` (file/folder/nested/dedup/dotfile/empty)
  - `addToGitignore` (create-if-missing, append + newline handling, dedup, whitespace-trim, empty-pattern + no-root error paths) against a temp repo
  - reducer open/move/clamp/close
  - updated status footer-hint expectation
- `npx eslint` on all touched files — clean
- Full suite: the only failures were the known-flaky real-git integration suites under parallel load (all 120 pass with `--runInBand`); this change touches no git-shelling code.

Ships independently of the other open PRs.