### PR TITLE
feat(ui): syntax-highlight the side-by-side (split) diff

### DIFF
--- a/src/workstation/runtime/splitDiff.test.ts
+++ b/src/workstation/runtime/splitDiff.test.ts
@@ -1,0 +1,79 @@
+import { createElement } from 'react'
+import { renderSplitDiffBody } from './splitDiff'
+import type { LogInkTheme } from '../chrome/theme'
+import type { SyntaxSpan } from '../../lib/syntax/highlightEngine'
+import type { LogInkComponents } from './types'
+
+// Stub <Box>/<Text> that record props/children into synthetic elements
+// (same approach as historyRender.test.ts) so we can introspect the tree.
+type StubProps = Record<string, unknown>
+const Box = ((props: StubProps) =>
+  createElement('box', props, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+const Text = ((props: StubProps) =>
+  createElement('text', props, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+const components: LogInkComponents = { Box, Text }
+
+const theme: LogInkTheme = {
+  noColor: false,
+  ascii: false,
+  borderStyle: 'round',
+  colors: { gitAdded: 'green', gitDeleted: 'red', accent: 'cyan' },
+} as LogInkTheme
+
+// Collect [{ text, color, dimColor }] leaves from the rendered tree.
+function leaves(
+  node: unknown,
+  out: Array<{ text: string; color?: string; dimColor?: boolean }> = []
+): Array<{ text: string; color?: string; dimColor?: boolean }> {
+  if (typeof node === 'string') {
+    out.push({ text: node })
+    return out
+  }
+  if (Array.isArray(node)) {
+    node.forEach((child) => leaves(child, out))
+    return out
+  }
+  if (node && typeof node === 'object' && 'props' in node) {
+    const props = (node as { props: StubProps }).props
+    const children = props.children
+    if (typeof children === 'string') {
+      out.push({ text: children, color: props.color as string | undefined, dimColor: props.dimColor as boolean | undefined })
+    } else {
+      leaves(children, out)
+    }
+  }
+  return out
+}
+
+const unified = ['@@ -1,1 +1,1 @@', '-const a = 1', '+const a = 2']
+
+describe('renderSplitDiffBody syntax highlighting', () => {
+  it('renders plain cells when no spans are supplied', () => {
+    const rows = renderSplitDiffBody(createElement, components, unified, 0, 10, 200, theme, 'k')
+    const text = leaves(rows).map((l) => l.text).join(' ')
+    // The code is present and not split into per-token colored spans.
+    expect(text).toContain('const a = 1')
+    expect(text).toContain('const a = 2')
+  })
+
+  it('colors the gutter by add/remove and the code by token when spans exist', () => {
+    const spans = new Map<string, SyntaxSpan[]>([
+      ['const a = 1', [{ start: 0, end: 5, token: 'keyword' }, { start: 5, end: 11, token: 'plain' }]],
+      ['const a = 2', [{ start: 0, end: 5, token: 'keyword' }, { start: 5, end: 11, token: 'plain' }]],
+    ])
+    const rows = renderSplitDiffBody(createElement, components, unified, 0, 10, 200, theme, 'k', spans)
+    const segs = leaves(rows)
+
+    // The `const` keyword renders magenta on both sides.
+    const keywords = segs.filter((s) => s.text === 'const')
+    expect(keywords.length).toBe(2)
+    expect(keywords.every((s) => s.color === 'magenta')).toBe(true)
+
+    // The removal-side gutter is red, the addition-side gutter is green.
+    const gutters = segs.filter((s) => /^\s*\d+\s$/.test(s.text))
+    expect(gutters.some((g) => g.color === 'red')).toBe(true)
+    expect(gutters.some((g) => g.color === 'green')).toBe(true)
+  })
+})

--- a/src/workstation/runtime/splitDiff.ts
+++ b/src/workstation/runtime/splitDiff.ts
@@ -12,8 +12,10 @@
 
 import type * as ReactTypes from 'react'
 import { SplitDiffRow, buildSplitDiffRows, computeDiffContext } from '../chrome/splitDiff'
-import { truncateCells } from '../chrome/text'
+import { cellWidth, truncateCells } from '../chrome/text'
+import { resolveSyntaxColor } from '../chrome/syntaxColors'
 import type { LogInkTheme } from '../chrome/theme'
+import type { SyntaxSpan } from '../../lib/syntax/highlightEngine'
 import type { LogInkState } from '../../commands/log/inkViewModel'
 import type { LogInkComponents } from './types'
 
@@ -84,6 +86,63 @@ export function formatSplitDiffCell(
 }
 
 /**
+ * Render one split-diff column as an Ink node — syntax-highlighted when
+ * spans are available for the line, plain otherwise.
+ *
+ * Highlighted cells keep the 4-digit line-number gutter but color IT
+ * with the add/remove cue (green/red, dim for context) so the code body
+ * is free to carry its syntax colors — the split layout's position
+ * (old | new) plus the colored gutter still tells you what changed.
+ * Width is budgeted exactly like `formatSplitDiffCell` (gutter + 1 space
+ * + truncated code) so columns never drift.
+ */
+function renderSplitDiffCell(
+  h: typeof ReactTypes.createElement,
+  Text: LogInkComponents['Text'],
+  side: SplitDiffRow['left'] | SplitDiffRow['right'],
+  columnWidth: number,
+  theme: LogInkTheme,
+  syntaxSpans: Map<string, SyntaxSpan[]> | undefined,
+  key: string
+): ReactTypes.ReactElement {
+  const text = side.text.replace(/\n$/, '')
+  const spans =
+    side.kind === 'add' || side.kind === 'remove' || side.kind === 'context'
+      ? syntaxSpans?.get(text)
+      : undefined
+  if (!spans || spans.length === 0) {
+    return h(Text, { key, ...splitDiffSideProps(side.kind, theme) }, formatSplitDiffCell(side, columnWidth))
+  }
+
+  const lineNo = side.lineNumber !== undefined ? String(side.lineNumber).padStart(4) : '    '
+  const textRoom = Math.max(1, columnWidth - 5)
+  const gutterColor =
+    side.kind === 'add'
+      ? theme.colors.gitAdded
+      : side.kind === 'remove'
+        ? theme.colors.gitDeleted
+        : undefined
+
+  const children: ReactTypes.ReactElement[] = []
+  let used = 0
+  for (const span of spans) {
+    if (used >= textRoom) break
+    const segment = truncateCells(text.slice(span.start, span.end), textRoom - used)
+    if (!segment) continue
+    used += cellWidth(segment)
+    children.push(
+      h(Text, { key: `${key}-s${span.start}`, color: resolveSyntaxColor(span.token, theme) }, segment)
+    )
+  }
+  return h(
+    Text,
+    { key },
+    h(Text, { key: `${key}-g`, color: gutterColor, dimColor: !gutterColor }, `${lineNo} `),
+    ...children
+  )
+}
+
+/**
  * Render the split-diff body as a list of two-column rows.
  *
  * Takes the FULL unified-line array plus the scroll offset + visible
@@ -103,7 +162,8 @@ export function renderSplitDiffBody(
   visibleRows: number,
   width: number,
   theme: LogInkTheme,
-  keyPrefix: string
+  keyPrefix: string,
+  syntaxSpans?: Map<string, SyntaxSpan[]>
 ): ReactTypes.ReactElement[] {
   const { Box, Text } = components
   const seed = computeDiffContext(unifiedLines, startOffset)
@@ -115,20 +175,17 @@ export function renderSplitDiffBody(
   const gutter = 1
   const half = Math.max(10, Math.floor((usable - gutter) / 2))
   return rows.map((row, index) => {
-    const leftProps = splitDiffSideProps(row.left.kind, theme)
-    const rightProps = splitDiffSideProps(row.right.kind, theme)
-    const leftText = formatSplitDiffCell(row.left, half)
-    const rightText = formatSplitDiffCell(row.right, half)
+    const rowKey = `${keyPrefix}-${startOffset + index}`
     return h(Box, {
-      key: `${keyPrefix}-${startOffset + index}`,
+      key: rowKey,
       flexDirection: 'row',
     },
     h(Box, { width: half, flexShrink: 0 },
-      h(Text, leftProps, leftText)
+      renderSplitDiffCell(h, Text, row.left, half, theme, syntaxSpans, `${rowKey}-l`)
     ),
     h(Box, { width: gutter, flexShrink: 0 }, h(Text, { dimColor: true }, ' ')),
     h(Box, { width: half, flexShrink: 0 },
-      h(Text, rightProps, rightText)
+      renderSplitDiffCell(h, Text, row.right, half, theme, syntaxSpans, `${rowKey}-r`)
     )
     )
   })

--- a/src/workstation/surfaces/diff/index.ts
+++ b/src/workstation/surfaces/diff/index.ts
@@ -133,7 +133,7 @@ export function renderDiffSurface(
       : splitActive
         ? renderSplitDiffBody(
           h, components, lines, state.diffPreviewOffset, visibleRows, width, theme,
-          'stash-diff-split'
+          'stash-diff-split', syntaxSpans
         )
         : visibleLines.map((line, index) => {
           const absoluteIndex = state.diffPreviewOffset + index
@@ -229,7 +229,7 @@ export function renderDiffSurface(
       : splitActive
         ? renderSplitDiffBody(
           h, components, lines, state.diffPreviewOffset, visibleRows, width, theme,
-          'compare-diff-split'
+          'compare-diff-split', syntaxSpans
         )
         : visibleLines.map((line, index) => renderDiffLine(
           h, Text, line, theme, syntaxSpans, width - 4,
@@ -300,7 +300,7 @@ export function renderDiffSurface(
       : splitActive
         ? renderSplitDiffBody(
           h, components, previewHunks, state.diffPreviewOffset, visibleRows, width, theme,
-          'commit-diff-split'
+          'commit-diff-split', syntaxSpans
         )
         : visiblePreviewHunks.map((line, index) => renderDiffLine(
           h, Text, line, theme, syntaxSpans, 140,


### PR DESCRIPTION
Extends diff syntax highlighting (#1117 engine / #1119 unified view) to the **split (side-by-side) view** — where the screenshots that kicked this whole thread off came from.

## What

`renderSplitDiffBody` now highlights each column cell when spans are available:
- The 4-digit **line-number gutter carries the add/remove cue** (green / red, dim for context) so the code body is free to render its syntax colors. Split layout's position (old | new) + the colored gutter still tells you exactly what changed.
- Width is budgeted exactly like the plain `formatSplitDiffCell` path (gutter + space + truncated code) so **columns never drift**.
- Non-code rows (file headers, empty padding) and the no-spans / `noColor` cases fall back to the existing single-color cell — zero change there.

## How it reuses the existing pipeline

The spans map (computed once per diff by the effect in `app.ts`) **already covers split mode** — split is just a different rendering of the *same* unified lines, and `buildSplitDiffRows` strips the `+`/`-` marker, so `side.text` matches the map keys directly. Just threaded `syntaxSpans` through the three `renderSplitDiffBody` call sites (stash / compare / commit).

No new config, no new async — it rides the `logTui.syntaxHighlight` flag and the existing tokenization effect.

## Validation
- `tsc` + `eslint` clean
- `jest`: 779 workstation tests green; new structural render test asserts per-token colors on **both** sides and the red/green gutter cue