### PR TITLE
fix(ui): drop redundant 'Selected file:' line from the diff header

### DIFF
--- a/src/workstation/surfaces/diff/index.ts
+++ b/src/workstation/surfaces/diff/index.ts
@@ -285,7 +285,8 @@ export function renderDiffSurface(
       ? [`Loading diff for ${selectedDetailFile?.path || 'selected file'}...`]
       : previewHunks.length
         ? [
-          `Selected file: ${selectedDetailFile?.path || ''}`,
+          // File path is already shown in the panel title bar (right) —
+          // no redundant "Selected file:" line here.
           currentHunkLabel,
           `Lines ${Math.min(state.diffPreviewOffset + 1, previewHunks.length || 1)}-${Math.min(state.diffPreviewOffset + visiblePreviewHunks.length, previewHunks.length)}/${previewHunks.length}`,
           '',
@@ -338,7 +339,8 @@ export function renderDiffSurface(
       ? [`Loading diff for ${worktreeFile?.path || 'selected file'}...`]
       : worktreeFile
       ? [
-        `Selected file: ${worktreeFile.path}`,
+        // File path is already shown in the panel title bar (right) —
+        // no redundant "Selected file:" line here.
         worktreeHunksLoading
           ? 'Hunks loading...'
           : worktreeHunks?.hunks.length


### PR DESCRIPTION
## Problem

The diff panel showed the file path **twice**, stacked: once in the title bar (right side) and again on a `Selected file: <path>` line directly beneath it. The two read as competing lines, and the title-bar path visibly truncated into the header path (e.g. `Selected file: src/…/jsonStore.test.ts` with `…n/chrome/jsonStore.test.ts` overlapping on the right).

## Fix

Dropped the `Selected file: <path>` line from both the commit-diff and worktree-diff headers. The path still shows in the panel title bar; the header now leads straight with the hunk label + line range:

```
Diff                                          src/…/jsonStore.test.ts
Hunk 1/1
Lines 1-19/40
```

Loading / empty / "too narrow for split" states are unchanged.

## Validation
- `tsc` + `eslint` clean
- `jest`: 779 workstation tests pass (no test asserted the removed text)