### PR TITLE
feat(ui): polish the AI commit-draft compose experience

### DIFF
--- a/src/commands/log/commitCompose.test.ts
+++ b/src/commands/log/commitCompose.test.ts
@@ -251,7 +251,7 @@ describe('log commit compose state', () => {
       // AI draft is staged.
       expect(state.pendingAiDraft).toBe('feat: AI version\n\nAI generated body')
       // Confirmation message surfaces.
-      expect(state.message).toMatch(/Press R to replace/)
+      expect(state.message).toMatch(/Press Enter \(or R\) to replace/)
     })
 
     it('routes setDraft to summary/body directly when fields are empty (no clobber risk)', () => {

--- a/src/commands/log/commitCompose.ts
+++ b/src/commands/log/commitCompose.ts
@@ -155,7 +155,7 @@ export function applyCommitComposeAction(
           streamingPreview: undefined,
           pendingAiDraft: action.value,
           message:
-            'AI draft ready. Press R to replace your text, or Esc to keep what you have.',
+            'AI draft ready. Press Enter (or R) to replace your text, or Esc to keep what you have.',
           details: undefined,
         }
       }
@@ -204,7 +204,7 @@ export function applyCommitComposeAction(
         loading: false,
         streamingPreview: undefined,
         pendingAiDraft: action.value,
-        message: 'AI draft ready. Press R to replace your text, or Esc to keep what you have.',
+        message: 'AI draft ready. Press Enter (or R) to replace your text, or Esc to keep what you have.',
         details: undefined,
       }
     case 'acceptPendingAiDraft':

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -1027,7 +1027,9 @@ export function getLogInkInputEvents(
   // draft was pending should see the original `R` / Esc semantics of
   // wherever they are now.
   if (state.activeView === 'compose' && state.commitCompose.pendingAiDraft) {
-    if (inputValue === 'R' && !key.ctrl && !key.meta) {
+    // `R` or `Enter` accept the swap (the AI draft becomes the new
+    // content); `Enter` is the natural "yes, use it" confirmation.
+    if ((inputValue === 'R' && !key.ctrl && !key.meta) || key.return) {
       return [action({ type: 'commitCompose', action: { type: 'acceptPendingAiDraft' } })]
     }
     if (key.escape) {

--- a/src/workstation/chrome/aiErrors.test.ts
+++ b/src/workstation/chrome/aiErrors.test.ts
@@ -1,0 +1,40 @@
+import { humanizeAiError } from './aiErrors'
+
+describe('humanizeAiError', () => {
+  it('classifies rate-limit / 429 / quota errors', () => {
+    expect(humanizeAiError('executeChain: Chain execution failed: 429 You exceeded your current quota'))
+      .toMatch(/Rate limited.*429.*retry/i)
+    expect(humanizeAiError('Error: rate limit reached for requests')).toMatch(/Rate limited/i)
+    expect(humanizeAiError('429 Too Many Requests')).toMatch(/Rate limited/i)
+  })
+
+  it('classifies auth / API key errors', () => {
+    expect(humanizeAiError('401 Incorrect API key provided')).toMatch(/API key/i)
+    expect(humanizeAiError('AuthenticationError: invalid api key')).toMatch(/API key/i)
+  })
+
+  it('classifies context-length errors', () => {
+    expect(humanizeAiError("This model's maximum context length is 8192 tokens"))
+      .toMatch(/context window.*stage fewer/i)
+  })
+
+  it('classifies network errors', () => {
+    expect(humanizeAiError('FetchError: request to https://api… failed, reason: ETIMEDOUT'))
+      .toMatch(/Network error.*retry/i)
+    expect(humanizeAiError('socket hang up')).toMatch(/Network error/i)
+  })
+
+  it('strips the noisy chain-execution prefix for unknown errors', () => {
+    expect(humanizeAiError('executeChain: Chain execution failed: Something weird happened'))
+      .toBe('Something weird happened')
+  })
+
+  it('keeps only the first line of an unknown multi-line error', () => {
+    expect(humanizeAiError('Boom\nstack frame 1\nstack frame 2')).toBe('Boom')
+  })
+
+  it('falls back gracefully for empty input', () => {
+    expect(humanizeAiError('')).toBe('AI request failed.')
+    expect(humanizeAiError(undefined)).toBe('AI request failed.')
+  })
+})

--- a/src/workstation/chrome/aiErrors.ts
+++ b/src/workstation/chrome/aiErrors.ts
@@ -1,0 +1,43 @@
+/**
+ * Humanize raw AI-provider / LangChain error strings into a short,
+ * actionable line for the compose surface.
+ *
+ * The underlying errors are verbose and developer-facing — e.g.
+ * `executeChain: Chain execution failed: 429 You exceeded your current
+ * quota …`. We classify the common failure modes (rate limit, auth,
+ * network, context length) into a concise message that tells the user
+ * what happened and what to do, and fall back to the original (trimmed)
+ * text for anything we don't recognize. Pure + tested.
+ */
+export function humanizeAiError(raw: string | undefined): string {
+  const message = (raw || '').trim()
+  if (!message) return 'AI request failed.'
+
+  const lower = message.toLowerCase()
+
+  // Rate limit / quota — the 429 in the screenshot.
+  if (/\b429\b/.test(message) || /rate.?limit|too many requests|exceeded your current quota|quota/i.test(lower)) {
+    return 'Rate limited by your AI provider (429) — too many requests or quota exceeded. Wait a moment, then press I to retry.'
+  }
+
+  // Auth / API key problems.
+  if (/\b401\b|\b403\b/.test(message) || /unauthor|forbidden|invalid api key|incorrect api key|no api key|authentication/i.test(lower)) {
+    return 'AI provider rejected the request — check your API key (run `coco init`, or press gK to edit the global config).'
+  }
+
+  // Context window overflow.
+  if (/context length|maximum context|too many tokens|reduce the length|context_length_exceeded/i.test(lower)) {
+    return 'The staged diff is too large for the model’s context window — stage fewer changes (or split the commit) and retry with I.'
+  }
+
+  // Network / connectivity.
+  if (/etimedout|econnreset|enotfound|econnrefused|network error|fetch failed|socket hang up|timeout/i.test(lower)) {
+    return 'Network error reaching the AI provider — check your connection, then press I to retry.'
+  }
+
+  // Unknown: strip the noisy `executeChain: Chain execution failed:`
+  // prefix if present so the meaningful part leads, and keep it to one
+  // line so it doesn't blow out the panel.
+  const stripped = message.replace(/^.*?chain execution failed:\s*/i, '').trim() || message
+  return stripped.split('\n')[0]
+}

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -152,6 +152,7 @@ import {
 } from '../../git/branchActions'
 import { addToGitignore } from '../../git/gitignore'
 import { highlightDiffCode, type SyntaxSpan } from '../../lib/syntax/highlightEngine'
+import { humanizeAiError } from '../chrome/aiErrors'
 import { createLightweightTag, deleteLocalTag, deleteRemoteTag, pushTag } from '../../git/tagActions'
 import {
     ClipboardRunner,
@@ -2094,11 +2095,15 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         return
       }
 
+      // Humanize provider errors (rate limit / auth / context / network)
+      // into a short actionable line; success-but-no-draft keeps its
+      // message as-is.
+      const composeMessage = result.ok ? result.message : humanizeAiError(result.message)
       dispatch({
         type: 'commitCompose',
-        action: { type: 'setResult', message: result.message, details: result.details },
+        action: { type: 'setResult', message: composeMessage, details: result.details },
       })
-      dispatch({ type: 'setStatus', value: result.message })
+      dispatch({ type: 'setStatus', value: composeMessage, kind: result.ok ? undefined : 'error' })
     } catch (error) {
       // Audit finding #3: defensive recovery for unexpected throws
       // from the workflow. The workflow catches its own errors

--- a/src/workstation/surfaces/detail/index.ts
+++ b/src/workstation/surfaces/detail/index.ts
@@ -818,21 +818,16 @@ export function renderCommitPanel(
   const bodyVisualLines: string[] = bodyHasContent
     ? compose.body.split('\n').flatMap((line) => wrapCells(line, bodyTextWidth)).slice(0, 12)
     : ['<empty>']
-  const summaryWrapped = wrapCells(`${compose.summary || '<empty>'}${summaryCursor}`, bodyTextWidth)
-  const summaryFirst = `${compose.field === 'summary' && compose.editing ? '>' : ' '} Summary: ${summaryWrapped[0] || ''}`
-  const summaryRest = summaryWrapped.slice(1).map((line) => `           ${line}`)
-  const headerLines = [
-    statusLine,
-    '',
-    summaryFirst,
-    ...summaryRest,
-    `${compose.field === 'body' && compose.editing ? '>' : ' '} Body:`,
-    ...bodyVisualLines.map((line, index) => {
-      const isLast = index === bodyVisualLines.length - 1
-      return `  ${line}${bodyCursor && isLast ? bodyCursor : ''}`
-    }),
-    '',
-  ]
+  const hasSummary = Boolean(compose.summary)
+  const summaryMarker = compose.field === 'summary' && compose.editing ? '>' : ' '
+  const bodyMarker = compose.field === 'body' && compose.editing ? '>' : ' '
+  // The generated subject is the thing the user is looking for — render
+  // it bold + accent so it pops out of the inspector instead of blending
+  // into the dim label/body text. The `Summary:` label stays dim.
+  const summaryLabel = `${summaryMarker} Summary: `
+  const summaryColor = hasSummary && !theme.noColor ? theme.colors.accent : undefined
+  const summaryValueWidth = Math.max(4, width - 4 - cellWidth(summaryLabel))
+  const summaryWrapped = wrapCells(`${compose.summary || '<empty>'}${summaryCursor}`, summaryValueWidth)
   const trailerLines = [
     ...(compose.message ? ['', compose.message] : []),
     ...(compose.details || []).map((line) => `  ${line}`),
@@ -849,10 +844,34 @@ export function renderCommitPanel(
     paddingX: 1,
   },
   h(Text, { bold: true }, panelTitle('Commit', focused)),
-  ...headerLines.map((line, index) => h(Text, {
-    key: `commit-header-${index}`,
-    dimColor: index < 2 || line.startsWith('  ') || line === '<empty>',
-  }, truncateCells(line, width - 4))),
+  h(Text, { key: 'commit-status', dimColor: true }, truncateCells(statusLine, width - 4)),
+  h(Text, { key: 'commit-spacer-1' }, ''),
+  // Summary: dim label + the subject value emphasized so it's easy to spot.
+  h(Text, { key: 'commit-summary' },
+    h(Text, { dimColor: true }, summaryLabel),
+    h(Text, {
+      bold: hasSummary,
+      color: summaryColor,
+      dimColor: !hasSummary,
+    }, summaryWrapped[0] || '<empty>')
+  ),
+  ...summaryWrapped.slice(1).map((line, index) => h(Text, {
+    key: `commit-summary-rest-${index}`,
+    bold: true,
+    color: summaryColor,
+  }, truncateCells(`${' '.repeat(cellWidth(summaryLabel))}${line}`, width - 4))),
+  h(Text, {
+    key: 'commit-body-label',
+    dimColor: !(compose.field === 'body' && compose.editing),
+  }, truncateCells(`${bodyMarker} Body:`, width - 4)),
+  ...bodyVisualLines.map((line, index) => {
+    const isLast = index === bodyVisualLines.length - 1
+    return h(Text, {
+      key: `commit-body-${index}`,
+      dimColor: true,
+    }, truncateCells(`  ${line}${bodyCursor && isLast ? bodyCursor : ''}`, width - 4))
+  }),
+  h(Text, { key: 'commit-spacer-2' }, ''),
   // Loading indicator + commit result/details stay inline with the body
   // (they describe what just happened to the fields above). The action
   // hint ("e edit | c commit | I AI draft") moves to the bottom of the


### PR DESCRIPTION
Three related tweaks to the AI commit-draft flow, prompted by a rate-limit error showing up raw in the compose inspector.

## 1. Friendlier AI errors
Raw provider / LangChain strings — `executeChain: Chain execution failed: 429 You exceeded your current quota…` — are now classified into a short, actionable line:
- **Rate limit / 429 / quota** → "Rate limited by your AI provider (429) … Wait a moment, then press I to retry."
- **Auth / API key** → "…check your API key (run `coco init`, or press gK to edit the global config)."
- **Context length** → "…too large for the model's context window — stage fewer changes (or split the commit)…"
- **Network** → "Network error reaching the AI provider — check your connection, then press I to retry."
- **Unknown** → strips the noisy `Chain execution failed:` prefix and clamps to one line.

New pure helper `humanizeAiError` (unit-tested), applied where the draft result lands in the compose surface.

## 2. `Enter` accepts a pending AI draft
When a generated draft lands over text you'd already typed, the confirm previously accepted only `R`. **`Enter` now accepts it too** — the natural "yes, use it." Prompt copy updated to `Press Enter (or R) to replace your text, or Esc to keep what you have.`

## 3. The generated subject pops
In the commit inspector (right panel), the summary value rendered at the same dim weight as its label and the body, so the generated subject was hard to pick out. It now renders **bold + accent** (the `Summary:` label stays dim), so the subject stands out at a glance.

## Validation
- `tsc` + `eslint` clean
- `jest`: 786 workstation tests green; adds `humanizeAiError` unit tests (rate-limit/auth/context/network/unknown/empty); updated the pending-draft prompt assertion