### PR TITLE
feat(ws): clone a remote repo from the workspace surface (c)

### DIFF
--- a/src/git/cloneRepo.test.ts
+++ b/src/git/cloneRepo.test.ts
@@ -1,0 +1,49 @@
+import { promises as fsp } from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { cloneRepo, deriveRepoName } from './cloneRepo'
+
+describe('deriveRepoName', () => {
+  it('parses https URLs', () => {
+    expect(deriveRepoName('https://github.com/gfargo/coco')).toBe('coco')
+    expect(deriveRepoName('https://github.com/gfargo/coco.git')).toBe('coco')
+    expect(deriveRepoName('https://github.com/gfargo/coco.git/')).toBe('coco')
+  })
+
+  it('parses SSH specs', () => {
+    expect(deriveRepoName('git@github.com:gfargo/coco.git')).toBe('coco')
+    expect(deriveRepoName('git@gitlab.com:group/sub/thing.git')).toBe('thing')
+  })
+
+  it('handles trailing slashes and nested paths', () => {
+    expect(deriveRepoName('https://example.com/a/b/c.git/')).toBe('c')
+  })
+
+  it('falls back to "repo" for unusable input', () => {
+    expect(deriveRepoName('')).toBe('repo')
+    expect(deriveRepoName('   ')).toBe('repo')
+  })
+})
+
+describe('cloneRepo', () => {
+  let dir: string
+  beforeEach(async () => {
+    dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'coco-clone-'))
+  })
+  afterEach(async () => {
+    await fsp.rm(dir, { recursive: true, force: true })
+  })
+
+  it('rejects an empty URL or destination', async () => {
+    expect((await cloneRepo('', '/tmp/x')).ok).toBe(false)
+    expect((await cloneRepo('https://x/y.git', '   ')).ok).toBe(false)
+  })
+
+  it('refuses to clobber an existing path', async () => {
+    const existing = path.join(dir, 'taken')
+    await fsp.mkdir(existing)
+    const result = await cloneRepo('https://github.com/gfargo/coco.git', existing)
+    expect(result.ok).toBe(false)
+    expect(result.message).toMatch(/already exists/)
+  })
+})

--- a/src/git/cloneRepo.ts
+++ b/src/git/cloneRepo.ts
@@ -1,0 +1,52 @@
+/**
+ * Clone a remote repository into a local path — the runtime side of the
+ * workspace surface's `c` (clone) flow.
+ *
+ * `deriveRepoName` is pure (and tested) so the UI can pre-fill the
+ * destination as `<cwd>/<name>` the moment a URL is typed; `cloneRepo`
+ * does the filesystem-touching work and reports a friendly result.
+ */
+import * as fs from 'fs'
+import { simpleGit } from 'simple-git'
+
+export type CloneResult = {
+  ok: boolean
+  message: string
+}
+
+/**
+ * Infer the repository folder name from a clone URL or SSH spec:
+ *   git@github.com:gfargo/coco.git  → coco
+ *   https://github.com/gfargo/coco  → coco
+ *   https://example.com/a/b/c.git/  → c
+ * Falls back to `repo` when nothing usable can be parsed.
+ */
+export function deriveRepoName(url: string): string {
+  const trimmed = url.trim().replace(/\/+$/, '').replace(/\.git$/i, '')
+  if (!trimmed) return 'repo'
+  // Split on both `/` and `:` so `host:owner/name` SSH specs work.
+  const segment = trimmed.split(/[/:]/).filter(Boolean).pop() || ''
+  return segment || 'repo'
+}
+
+/**
+ * Clone `url` into `targetPath`. Refuses to clobber an existing path so
+ * a typo never overwrites a directory. Network / auth failures surface
+ * git's own message (trimmed to one line).
+ */
+export async function cloneRepo(url: string, targetPath: string): Promise<CloneResult> {
+  const remote = url.trim()
+  const dest = targetPath.trim()
+  if (!remote) return { ok: false, message: 'Enter a remote URL to clone.' }
+  if (!dest) return { ok: false, message: 'Enter a destination path.' }
+  if (fs.existsSync(dest)) {
+    return { ok: false, message: `${dest} already exists — choose another path.` }
+  }
+  try {
+    await simpleGit().clone(remote, dest)
+    return { ok: true, message: `Cloned into ${dest}` }
+  } catch (error) {
+    const raw = error instanceof Error ? error.message : String(error)
+    return { ok: false, message: `Clone failed: ${raw.split('\n')[0]}` }
+  }
+}

--- a/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
+++ b/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
@@ -527,7 +527,7 @@ exports[`renderWorkspaceApp snapshots PR counts in the status cell when gh is au
       <Text
         dimColor={true}
       >
-        s sort   / filter   r/R refresh   a add   d remove
+        s sort   / filter   r/R refresh   a add   c clone   d remove
       </Text>
       <Text
         dimColor={true}
@@ -929,7 +929,7 @@ exports[`renderWorkspaceApp snapshots a committed filter (focus back to list) 1`
       <Text
         dimColor={true}
       >
-        s sort   / filter   r/R refresh   a add   d remove
+        s sort   / filter   r/R refresh   a add   c clone   d remove
       </Text>
       <Text
         dimColor={true}
@@ -1477,7 +1477,7 @@ exports[`renderWorkspaceApp snapshots a gh-unauthenticated state dimming the PRs
       <Text
         dimColor={true}
       >
-        s sort   / filter   r/R refresh   a add   d remove
+        s sort   / filter   r/R refresh   a add   c clone   d remove
       </Text>
       <Text
         dimColor={true}
@@ -1913,7 +1913,7 @@ exports[`renderWorkspaceApp snapshots a narrow terminal (80 columns) so column-b
       <Text
         dimColor={true}
       >
-        s sort   / filter   r/R refresh   a add   d remove
+        s sort   / filter   r/R refresh   a add   c clone   d remove
       </Text>
       <Text
         dimColor={true}
@@ -2457,7 +2457,7 @@ exports[`renderWorkspaceApp snapshots a status banner from the workflow layer 1`
       <Text
         dimColor={true}
       >
-        s sort   / filter   r/R refresh   a add   d remove
+        s sort   / filter   r/R refresh   a add   c clone   d remove
       </Text>
       <Text
         dimColor={true}
@@ -2854,7 +2854,7 @@ exports[`renderWorkspaceApp snapshots a very narrow terminal (60 columns) — pa
       <Text
         dimColor={true}
       >
-        s sort   / filter   r/R refresh   a add   d remove
+        s sort   / filter   r/R refresh   a add   c clone   d remove
       </Text>
       <Text
         dimColor={true}
@@ -3398,7 +3398,7 @@ exports[`renderWorkspaceApp snapshots a wide terminal (200 columns) — columns 
       <Text
         dimColor={true}
       >
-        s sort   / filter   r/R refresh   a add   d remove
+        s sort   / filter   r/R refresh   a add   c clone   d remove
       </Text>
       <Text
         dimColor={true}
@@ -3733,7 +3733,7 @@ exports[`renderWorkspaceApp snapshots an empty discovery (no repos, loading fals
       <Text
         dimColor={true}
       >
-        s sort   / filter   r/R refresh   a add   d remove
+        s sort   / filter   r/R refresh   a add   c clone   d remove
       </Text>
       <Text
         dimColor={true}
@@ -5228,13 +5228,1152 @@ exports[`renderWorkspaceApp snapshots the behind tab 1`] = `
       <Text
         dimColor={true}
       >
-        s sort   / filter   r/R refresh   a add   d remove
+        s sort   / filter   r/R refresh   a add   c clone   d remove
       </Text>
       <Text
         dimColor={true}
       >
         ? help · q quit
       </Text>
+    </Box>
+    <Text
+      dimColor={true}
+    >
+       
+    </Text>
+  </Box>
+</Box>
+`;
+
+exports[`renderWorkspaceApp snapshots the clone prompt on the URL field 1`] = `
+<Box
+  flexDirection="column"
+  height={40}
+>
+  <Box
+    borderColor="cyan"
+    borderStyle="classic"
+    paddingX={1}
+  >
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      coco
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      dimColor={false}
+    >
+      workspace
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      dimColor={false}
+    >
+      3/3 repos
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      sort: Recent
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      [List]
+    </Text>
+  </Box>
+  <Box
+    flexDirection="row"
+    height={27}
+  >
+    <Box
+      borderColor="gray"
+      borderStyle="classic"
+      flexDirection="column"
+      flexShrink={0}
+      height={27}
+      paddingX={1}
+      width={22}
+    >
+      <Text
+        bold={true}
+      >
+        Tabs
+      </Text>
+      <Box
+        flexDirection="row"
+      >
+        <Text
+          bold={true}
+        >
+          › 
+        </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+          ◯ 
+        </Text>
+        <Text
+          bold={true}
+        >
+          All      
+        </Text>
+        <Text
+          color="cyan"
+          dimColor={false}
+        >
+           3
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ● 
+        </Text>
+        <Text>
+          Dirty    
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ↓ 
+        </Text>
+        <Text>
+          Behind   
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ⊙ 
+        </Text>
+        <Text>
+          PRs      
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
+    </Box>
+    <Box
+      borderColor="cyan"
+      borderStyle="classic"
+      flexDirection="column"
+      flexGrow={1}
+      height={27}
+      paddingX={1}
+    >
+      <Box
+        justifyContent="space-between"
+      >
+        <Text
+          bold={true}
+        >
+          Workspace *
+        </Text>
+        <Text
+          dimColor={true}
+        >
+          3 visible
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        />
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            REPO
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            BRANCH
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            STATUS
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            LAST
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            SUBJECT
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            PATH
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={true}
+            color="cyan"
+          >
+            › 
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={true}
+            color="cyan"
+          >
+            coco
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text>
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="yellow"
+          >
+            ●2 ↑1
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+          >
+            4w
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text>
+            feat: thing
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+          >
+            /tmp/coco
+          </Text>
+        </Box>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={false}
+          >
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            dimColor={false}
+          >
+            docs
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            dimColor={false}
+          >
+            feature/l...
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="yellow"
+            dimColor={false}
+          >
+            ↓3
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            6w
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            dimColor={false}
+          >
+            wip
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/docs
+          </Text>
+        </Box>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={false}
+          >
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            dimColor={false}
+          >
+            lib
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            dimColor={false}
+          >
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            ·
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/lib
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
+    </Box>
+  </Box>
+  <Box
+    borderColor="cyan"
+    borderStyle="classic"
+    flexDirection="column"
+    paddingX={1}
+  >
+    <Text
+      bold={true}
+    >
+      Clone a repository
+    </Text>
+    <Text>
+        URL:  git@github.com:gfargo/coco.git_
+    </Text>
+    <Text
+      color="gray"
+    >
+        Into: /home/dev/coco
+    </Text>
+    <Text
+      dimColor={true}
+    >
+      Paste a remote URL (https or git@…), then enter for the destination.
+    </Text>
+  </Box>
+  <Box
+    borderColor="gray"
+    borderStyle="classic"
+    flexDirection="column"
+    height={4}
+    paddingX={1}
+  >
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
+    >
+      <Text
+        dimColor={true}
+      >
+        enter URL   enter → destination   enter to clone   esc to cancel
+      </Text>
+      <Text
+        dimColor={true}
+      />
+    </Box>
+    <Text
+      dimColor={true}
+    >
+       
+    </Text>
+  </Box>
+</Box>
+`;
+
+exports[`renderWorkspaceApp snapshots the clone prompt on the destination field 1`] = `
+<Box
+  flexDirection="column"
+  height={40}
+>
+  <Box
+    borderColor="cyan"
+    borderStyle="classic"
+    paddingX={1}
+  >
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      coco
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      dimColor={false}
+    >
+      workspace
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      ~/code
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      dimColor={false}
+    >
+      3/3 repos
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      color="gray"
+      dimColor={true}
+    >
+      sort: Recent
+    </Text>
+    <Text
+      dimColor={true}
+    >
+       · 
+    </Text>
+    <Text
+      bold={true}
+      color="cyan"
+      dimColor={false}
+    >
+      [List]
+    </Text>
+  </Box>
+  <Box
+    flexDirection="row"
+    height={27}
+  >
+    <Box
+      borderColor="gray"
+      borderStyle="classic"
+      flexDirection="column"
+      flexShrink={0}
+      height={27}
+      paddingX={1}
+      width={22}
+    >
+      <Text
+        bold={true}
+      >
+        Tabs
+      </Text>
+      <Box
+        flexDirection="row"
+      >
+        <Text
+          bold={true}
+        >
+          › 
+        </Text>
+        <Text
+          bold={true}
+          color="cyan"
+        >
+          ◯ 
+        </Text>
+        <Text
+          bold={true}
+        >
+          All      
+        </Text>
+        <Text
+          color="cyan"
+          dimColor={false}
+        >
+           3
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ● 
+        </Text>
+        <Text>
+          Dirty    
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ↓ 
+        </Text>
+        <Text>
+          Behind   
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           1
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Text>
+            
+        </Text>
+        <Text
+          color="gray"
+        >
+          ⊙ 
+        </Text>
+        <Text>
+          PRs      
+        </Text>
+        <Text
+          dimColor={true}
+        >
+           ·
+        </Text>
+      </Box>
+    </Box>
+    <Box
+      borderColor="cyan"
+      borderStyle="classic"
+      flexDirection="column"
+      flexGrow={1}
+      height={27}
+      paddingX={1}
+    >
+      <Box
+        justifyContent="space-between"
+      >
+        <Text
+          bold={true}
+        >
+          Workspace *
+        </Text>
+        <Text
+          dimColor={true}
+        >
+          3 visible
+        </Text>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        />
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            REPO
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            BRANCH
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            STATUS
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            LAST
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            SUBJECT
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            PATH
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={true}
+            color="cyan"
+          >
+            › 
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            bold={true}
+            color="cyan"
+          >
+            coco
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text>
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="yellow"
+          >
+            ●2 ↑1
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+          >
+            4w
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text>
+            feat: thing
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+          >
+            /tmp/coco
+          </Text>
+        </Box>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={false}
+          >
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            dimColor={false}
+          >
+            docs
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            dimColor={false}
+          >
+            feature/l...
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="yellow"
+            dimColor={false}
+          >
+            ↓3
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            6w
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            dimColor={false}
+          >
+            wip
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/docs
+          </Text>
+        </Box>
+      </Box>
+      <Box
+        flexDirection="row"
+      >
+        <Box
+          flexShrink={0}
+          width={2}
+        >
+          <Text
+            bold={false}
+          >
+              
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={19}
+        >
+          <Text
+            dimColor={false}
+          >
+            lib
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={13}
+        >
+          <Text
+            dimColor={false}
+          >
+            main
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={9}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            ·
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={11}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={20}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            —
+          </Text>
+        </Box>
+        <Box
+          flexShrink={0}
+          width={18}
+        >
+          <Text
+            color="gray"
+            dimColor={true}
+          >
+            /tmp/lib
+          </Text>
+        </Box>
+      </Box>
+      <Text
+        dimColor={true}
+      >
+         
+      </Text>
+    </Box>
+  </Box>
+  <Box
+    borderColor="cyan"
+    borderStyle="classic"
+    flexDirection="column"
+    paddingX={1}
+  >
+    <Text
+      bold={true}
+    >
+      Clone a repository
+    </Text>
+    <Text
+      color="gray"
+    >
+        URL:  git@github.com:gfargo/coco.git
+    </Text>
+    <Text>
+        Into: /home/dev/coco_
+    </Text>
+    <Text
+      dimColor={true}
+    >
+      Edit the destination · tab to complete · enter to clone · esc to cancel
+    </Text>
+    <Text
+      color="gray"
+    >
+      coco/
+    </Text>
+  </Box>
+  <Box
+    borderColor="gray"
+    borderStyle="classic"
+    flexDirection="column"
+    height={4}
+    paddingX={1}
+  >
+    <Box
+      flexDirection="row"
+      justifyContent="space-between"
+    >
+      <Text
+        dimColor={true}
+      >
+        enter URL   enter → destination   enter to clone   esc to cancel
+      </Text>
+      <Text
+        dimColor={true}
+      />
     </Box>
     <Text
       dimColor={true}
@@ -6181,7 +7320,7 @@ exports[`renderWorkspaceApp snapshots the dirty tab 1`] = `
       <Text
         dimColor={true}
       >
-        s sort   / filter   r/R refresh   a add   d remove
+        s sort   / filter   r/R refresh   a add   c clone   d remove
       </Text>
       <Text
         dimColor={true}
@@ -6723,7 +7862,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
       Welcome to \`coco workspace\`
     </Text>
     <Text>
-      Press \`enter\` to open a repo · \`?\` for the full keymap · \`a\` to add a repo by path.
+      Press \`enter\` to open a repo · \`a\` to add by path · \`c\` to clone · \`?\` for the full keymap.
     </Text>
     <Text
       dimColor={true}
@@ -6745,7 +7884,7 @@ exports[`renderWorkspaceApp snapshots the first-run onboarding banner 1`] = `
       <Text
         dimColor={true}
       >
-        s sort   / filter   r/R refresh   a add   d remove
+        s sort   / filter   r/R refresh   a add   c clone   d remove
       </Text>
       <Text
         dimColor={true}
@@ -6862,7 +8001,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
         <Text
           dimColor={true}
         >
-          16 bindings
+          17 bindings
         </Text>
       </Box>
       <Text
@@ -7362,6 +8501,35 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
           bold={true}
           color="cyan"
         >
+           ⬇ 
+        </Text>
+      </Box>
+      <Box
+        flexShrink={0}
+        width={19}
+      >
+        <Text
+          bold={true}
+          color="green"
+        >
+          c
+        </Text>
+      </Box>
+      <Text>
+        Clone a remote repo (defaults into the launch directory)
+      </Text>
+    </Box>
+    <Box
+      flexDirection="row"
+    >
+      <Box
+        flexShrink={0}
+        width={4}
+      >
+        <Text
+          bold={true}
+          color="cyan"
+        >
            ✕ 
         </Text>
       </Box>
@@ -7395,7 +8563,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
       <Text
         dimColor={true}
       >
-        s sort   / filter   r/R refresh   a add   d remove
+        s sort   / filter   r/R refresh   a add   c clone   d remove
       </Text>
       <Text
         dimColor={true}
@@ -7735,7 +8903,7 @@ exports[`renderWorkspaceApp snapshots the loading placeholder when discovery is 
       <Text
         dimColor={true}
       >
-        s sort   / filter   r/R refresh   a add   d remove
+        s sort   / filter   r/R refresh   a add   c clone   d remove
       </Text>
       <Text
         dimColor={true}
@@ -8279,7 +9447,7 @@ exports[`renderWorkspaceApp snapshots the populated workspace with the default t
       <Text
         dimColor={true}
       >
-        s sort   / filter   r/R refresh   a add   d remove
+        s sort   / filter   r/R refresh   a add   c clone   d remove
       </Text>
       <Text
         dimColor={true}

--- a/src/workstation/surfaces/workspace/input.test.ts
+++ b/src/workstation/surfaces/workspace/input.test.ts
@@ -26,7 +26,27 @@ function addRepoState(): WorkspaceState {
   return { ...createWorkspaceState({ overview: emptyOverview, roots: ['~/code'] }), focus: 'add-repo' }
 }
 
+function cloneState(): WorkspaceState {
+  return { ...createWorkspaceState({ overview: emptyOverview, roots: ['~/code'] }), focus: 'clone-repo' }
+}
+
 describe('resolveWorkspaceInput', () => {
+  it('list focus: `c` opens the clone-repo prompt', () => {
+    expect(resolveWorkspaceInput('c', key(), listState()).kind).toBe('clone-repo')
+  })
+
+  it('clone-repo focus: Esc cancels back to the list', () => {
+    expect(resolveWorkspaceInput('', key({ escape: true }), cloneState())).toEqual({
+      kind: 'action',
+      action: { type: 'set-focus', focus: 'list' },
+    })
+  })
+
+  it('clone-repo focus: printable keys are no-ops in the resolver (runtime owns them)', () => {
+    expect(resolveWorkspaceInput('h', key(), cloneState()).kind).toBe('noop')
+    expect(resolveWorkspaceInput('', key({ return: true }), cloneState()).kind).toBe('noop')
+  })
+
   it('quits on q only — escape never quits because terminals can deliver bare ESC on arrow keys', () => {
     expect(resolveWorkspaceInput('q', key(), listState()).kind).toBe('quit')
     // Bare ESC must NOT quit; it would crash the app every time the

--- a/src/workstation/surfaces/workspace/input.ts
+++ b/src/workstation/surfaces/workspace/input.ts
@@ -23,6 +23,7 @@ export type WorkspaceInputIntent =
   | { kind: 'refresh' }
   | { kind: 'refresh-row' }
   | { kind: 'add-repo' }
+  | { kind: 'clone-repo' }
   | { kind: 'request-delete' }
   | { kind: 'confirm-delete' }
   | { kind: 'apply-theme'; preset: string }
@@ -117,6 +118,15 @@ export function resolveWorkspaceInput(
     }
     // Enter, Tab, and printable keys are owned by the runtime so it
     // can drive the path-completion prompt.
+    return { kind: 'noop' }
+  }
+
+  if (state.focus === 'clone-repo') {
+    if (key.escape) {
+      return { kind: 'action', action: { type: 'set-focus', focus: 'list' } }
+    }
+    // Enter/Tab/printable keys drive the URL + destination prompt in the
+    // runtime (it owns the two-field state + path completion).
     return { kind: 'noop' }
   }
 
@@ -219,6 +229,9 @@ export function resolveWorkspaceInput(
   }
   if (input === 'a') {
     return { kind: 'add-repo' }
+  }
+  if (input === 'c') {
+    return { kind: 'clone-repo' }
   }
   if (input === 'd') {
     return { kind: 'request-delete' }

--- a/src/workstation/surfaces/workspace/render.ts
+++ b/src/workstation/surfaces/workspace/render.ts
@@ -606,10 +606,11 @@ export type WorkspaceFooterModel = {
 // The contextual slot drops bindings users can find via the help
 // overlay (arrow keys, tab); the global slot is the safety net so
 // `? help` and `q quit` never disappear.
-const LIST_CONTEXTUAL = ['s sort', '/ filter', 'r/R refresh', 'a add', 'd remove']
+const LIST_CONTEXTUAL = ['s sort', '/ filter', 'r/R refresh', 'a add', 'c clone', 'd remove']
 const SIDEBAR_CONTEXTUAL = ['↑/↓ cycle tab', 'enter open']
 const FILTER_CONTEXTUAL = ['type to filter', 'enter apply', 'esc cancel']
 const ADD_REPO_CONTEXTUAL = ['type path', 'tab to complete', 'enter to add', 'esc to cancel']
+const CLONE_REPO_CONTEXTUAL = ['enter URL', 'enter → destination', 'enter to clone', 'esc to cancel']
 const CONFIRM_DELETE_CONTEXTUAL = ['y confirm', 'any other key cancels']
 const GLOBAL_HINTS = ['? help', 'q quit']
 
@@ -621,6 +622,8 @@ function contextualHintsFor(focus: WorkspaceState['focus']): string[] {
       return FILTER_CONTEXTUAL
     case 'add-repo':
       return ADD_REPO_CONTEXTUAL
+    case 'clone-repo':
+      return CLONE_REPO_CONTEXTUAL
     case 'confirm-delete':
       return CONFIRM_DELETE_CONTEXTUAL
     case 'list':
@@ -637,6 +640,7 @@ export function buildWorkspaceFooter(state: WorkspaceState): WorkspaceFooterMode
   const isModal =
     state.focus === 'filter' ||
     state.focus === 'add-repo' ||
+    state.focus === 'clone-repo' ||
     state.focus === 'confirm-delete'
   const global = isModal ? [] : GLOBAL_HINTS
   const allHints = [...contextual, ...global]
@@ -713,6 +717,7 @@ export function buildWorkspaceHelpSections(): WorkspaceHelpSection[] {
         { glyph: '⟳', keys: 'r', description: 'Refresh all repos (discovery + PR counts)' },
         { glyph: '⟲', keys: 'R', description: 'Refresh just the cursored repo (faster)' },
         { glyph: '＋', keys: 'a', description: 'Add a repo via path prompt (tab-completes)' },
+        { glyph: '⬇', keys: 'c', description: 'Clone a remote repo (defaults into the launch directory)' },
         { glyph: '✕', keys: 'd', description: 'Remove the cursored repo from the known-repos store' },
       ],
     },
@@ -747,6 +752,6 @@ export function buildWorkspaceOnboarding(state: WorkspaceState): WorkspaceOnboar
       : undefined,
     populatedHint: empty
       ? undefined
-      : 'Press `enter` to open a repo · `?` for the full keymap · `a` to add a repo by path.',
+      : 'Press `enter` to open a repo · `a` to add by path · `c` to clone · `?` for the full keymap.',
   }
 }

--- a/src/workstation/surfaces/workspace/runtime.ts
+++ b/src/workstation/surfaces/workspace/runtime.ts
@@ -47,6 +47,7 @@ import {
   getWorkspacePullRequestCounts,
   type WorkspacePullRequestCounts,
 } from '../../../git/workspacePullRequestData'
+import { cloneRepo, deriveRepoName } from '../../../git/cloneRepo'
 import {
   canStartLogInkTui,
   getLogInkRenderOptions,
@@ -472,6 +473,21 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
   const [addRepoCompletion, setAddRepoCompletion] = React.useState<PathCompletionResult>(() =>
     completePath('~/')
   )
+  // Clone-repo modal (`c`). Two fields: the remote URL and the
+  // destination path. `cloneField` tracks which is active; `cloneTarget`
+  // auto-derives `<cwd>/<repo-name>` from the URL until the user edits it
+  // (`cloneTargetEdited`). `cloning` blocks input + shows a spinner while
+  // `git clone` runs. The boot cwd is captured once at mount so it stays
+  // the directory the workspace launched in even after drill-in.
+  const bootCwdRef = React.useRef<string>(process.cwd())
+  const [cloneUrl, setCloneUrl] = React.useState<string>('')
+  const [cloneTarget, setCloneTarget] = React.useState<string>('')
+  const [cloneField, setCloneField] = React.useState<'url' | 'target'>('url')
+  const [cloneTargetEdited, setCloneTargetEdited] = React.useState<boolean>(false)
+  const [cloneCompletion, setCloneCompletion] = React.useState<PathCompletionResult>(() =>
+    completePath('~/')
+  )
+  const [cloning, setCloning] = React.useState<boolean>(false)
   // Tick counter for the per-row PR-fetch spinner. Bumped on a
   // setInterval that only runs while at least one row is mid-fetch
   // (see effect below) so idle workspaces don't burn CPU on animation
@@ -529,6 +545,18 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
   addRepoDraftRef.current = addRepoDraft
   const addRepoCompletionRef = React.useRef(addRepoCompletion)
   addRepoCompletionRef.current = addRepoCompletion
+  const cloneUrlRef = React.useRef(cloneUrl)
+  cloneUrlRef.current = cloneUrl
+  const cloneTargetRef = React.useRef(cloneTarget)
+  cloneTargetRef.current = cloneTarget
+  const cloneFieldRef = React.useRef(cloneField)
+  cloneFieldRef.current = cloneField
+  const cloneTargetEditedRef = React.useRef(cloneTargetEdited)
+  cloneTargetEditedRef.current = cloneTargetEdited
+  const cloneCompletionRef = React.useRef(cloneCompletion)
+  cloneCompletionRef.current = cloneCompletion
+  const cloningRef = React.useRef(cloning)
+  cloningRef.current = cloning
 
   // Background discovery + PR-count refresh on mount.
   React.useEffect(() => {
@@ -752,6 +780,61 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
     }
   }, [addRepoDraft, dispatch, props])
 
+  // Default destination for a clone URL: `<bootCwd>/<repo-name>`.
+  const cloneTargetFor = React.useCallback((url: string): string => {
+    return nodePath.join(bootCwdRef.current, deriveRepoName(url))
+  }, [])
+
+  const openClone = React.useCallback(() => {
+    setCloneUrl('')
+    setCloneTarget('')
+    setCloneField('url')
+    setCloneTargetEdited(false)
+    setCloneCompletion(completePath(`${bootCwdRef.current}/`))
+    dispatch({ type: 'set-focus', focus: 'clone-repo' })
+  }, [dispatch])
+
+  const commitClone = React.useCallback(async () => {
+    const url = cloneUrlRef.current.trim()
+    const target = expandHomePrefix(cloneTargetRef.current.trim().replace(/\/+$/, ''))
+    if (!url) {
+      dispatch({ type: 'set-status', status: 'Enter a remote URL.' })
+      return
+    }
+    if (!target) {
+      dispatch({ type: 'set-status', status: 'Enter a destination path.' })
+      return
+    }
+    setCloning(true)
+    dispatch({ type: 'set-status', status: `Cloning ${deriveRepoName(url)}…` })
+    const result = await cloneRepo(url, target)
+    if (unmountedRef.current) return
+    setCloning(false)
+    if (!result.ok) {
+      // Keep the modal open so the user can fix the URL / path and retry.
+      dispatch({ type: 'set-status', status: result.message })
+      return
+    }
+    const updated = appendKnownRepo(target)
+    dispatch({ type: 'replace-known-repos', paths: updated })
+    dispatch({ type: 'set-focus', focus: 'list' })
+    dispatch({ type: 'set-status', status: result.message })
+    dispatch({ type: 'set-loading', loading: true })
+    try {
+      const merged = mergeKnownRepos(props.knownRepos, readKnownRepos())
+      const overview = await props.loadOverview(props.roots, merged)
+      writeCachedWorkspace(props.roots, overview)
+      dispatch({ type: 'replace-overview', overview })
+      dispatch({ type: 'anchor-cursor-by-path', path: target })
+    } catch (err) {
+      dispatch({ type: 'set-loading', loading: false })
+      dispatch({
+        type: 'set-status',
+        status: err instanceof Error ? err.message : 'Refresh failed.',
+      })
+    }
+  }, [dispatch, props])
+
   // Callback refs so the stable input handler can reach the latest
   // closure without taking them in deps.
   const commitAddRepoRef = React.useRef(commitAddRepo)
@@ -764,6 +847,10 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
   refreshRowRef.current = refreshRow
   const openAddRepoRef = React.useRef(openAddRepo)
   openAddRepoRef.current = openAddRepo
+  const openCloneRef = React.useRef(openClone)
+  openCloneRef.current = openClone
+  const commitCloneRef = React.useRef(commitClone)
+  commitCloneRef.current = commitClone
   const requestDeleteRef = React.useRef(requestDelete)
   requestDeleteRef.current = requestDelete
   const confirmDeleteRef = React.useRef(confirmDelete)
@@ -853,6 +940,70 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
       return
     }
 
+    if (state.focus === 'clone-repo') {
+      // While the clone is running, swallow everything except Esc
+      // (which is a no-op here — the clone is already in flight).
+      if (cloningRef.current) return
+      if (key.escape) {
+        dispatch({ type: 'set-focus', focus: 'list' })
+        return
+      }
+      const field = cloneFieldRef.current
+      const url = cloneUrlRef.current
+      const target = cloneTargetRef.current
+      const targetEdited = cloneTargetEditedRef.current
+
+      if (key.return) {
+        if (field === 'url') {
+          if (!url.trim()) {
+            dispatch({ type: 'set-status', status: 'Enter a remote URL.' })
+            return
+          }
+          // Advance to the (pre-filled, editable) destination field.
+          const derived = targetEdited ? target : cloneTargetFor(url)
+          setCloneTarget(derived)
+          setCloneCompletion(completePath(derived))
+          setCloneField('target')
+          return
+        }
+        void commitCloneRef.current()
+        return
+      }
+      if (key.tab && field === 'target') {
+        const next = applyTabCompletion(target, cloneCompletionRef.current)
+        setCloneTarget(next)
+        setCloneTargetEdited(true)
+        setCloneCompletion(completePath(next))
+        return
+      }
+      if (key.backspace || key.delete) {
+        if (field === 'url') {
+          const next = url.slice(0, -1)
+          setCloneUrl(next)
+          if (!targetEdited) setCloneTarget(next ? cloneTargetFor(next) : '')
+        } else {
+          const next = target.slice(0, -1)
+          setCloneTarget(next)
+          setCloneTargetEdited(true)
+          setCloneCompletion(completePath(next || '~/'))
+        }
+        return
+      }
+      if (rawInput && !key.ctrl && !key.meta) {
+        if (field === 'url') {
+          const next = url + rawInput
+          setCloneUrl(next)
+          if (!targetEdited) setCloneTarget(cloneTargetFor(next))
+        } else {
+          const next = target + rawInput
+          setCloneTarget(next)
+          setCloneTargetEdited(true)
+          setCloneCompletion(completePath(next))
+        }
+      }
+      return
+    }
+
     // Ctrl+C → quit, since we disabled Ink's built-in ctrl+c exit.
     // Handled here (rather than in the pure resolver) because the
     // resolver doesn't have a notion of "raw key with ctrl flag" for
@@ -895,6 +1046,9 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
         break
       case 'add-repo':
         openAddRepoRef.current()
+        break
+      case 'clone-repo':
+        openCloneRef.current()
         break
       case 'request-delete':
         requestDeleteRef.current()
@@ -953,6 +1107,11 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
     filterDraft,
     addRepoDraft,
     addRepoCompletion,
+    cloneUrl,
+    cloneTarget,
+    cloneField,
+    cloneCompletion,
+    cloning,
     columns,
     rows,
     spinnerTick,

--- a/src/workstation/surfaces/workspace/state.ts
+++ b/src/workstation/surfaces/workspace/state.ts
@@ -33,13 +33,14 @@ import {
  * - `list`:    j/k moves the cursor through repos
  * - `filter`:  modal text-input for the search filter
  * - `add-repo`: modal path-prompt
+ * - `clone-repo`: modal URL + destination prompt (git clone)
  * - `confirm-delete`: modal y-confirm before removing a repo
  *
  * Tab / Shift+Tab cycles between `sidebar` and `list`. Modal focuses
- * are entered/exited via their own keys (`/`, `a`, `d`) and ignore
+ * are entered/exited via their own keys (`/`, `a`, `c`, `d`) and ignore
  * Tab while open.
  */
-export type WorkspaceFocus = 'sidebar' | 'list' | 'filter' | 'add-repo' | 'confirm-delete'
+export type WorkspaceFocus = 'sidebar' | 'list' | 'filter' | 'add-repo' | 'clone-repo' | 'confirm-delete'
 
 export type WorkspaceState = {
   overview: WorkspaceOverview

--- a/src/workstation/surfaces/workspace/view.test.ts
+++ b/src/workstation/surfaces/workspace/view.test.ts
@@ -94,6 +94,11 @@ function render(
     filterDraft?: string
     addRepoDraft?: string
     addRepoCompletion?: ReturnType<typeof completePath>
+    cloneUrl?: string
+    cloneTarget?: string
+    cloneField?: 'url' | 'target'
+    cloneCompletion?: ReturnType<typeof completePath>
+    cloning?: boolean
     columns?: number
     rows?: number
   } = {}
@@ -116,6 +121,19 @@ function render(
         commonPrefix: '',
         isDirectory: false,
       } as ReturnType<typeof completePath>),
+    cloneUrl: options.cloneUrl ?? '',
+    cloneTarget: options.cloneTarget ?? '',
+    cloneField: options.cloneField ?? 'url',
+    cloneCompletion:
+      options.cloneCompletion ??
+      ({
+        baseDir: '~/',
+        prefix: '',
+        completions: [],
+        commonPrefix: '',
+        isDirectory: false,
+      } as ReturnType<typeof completePath>),
+    cloning: options.cloning ?? false,
     columns: options.columns ?? 120,
     rows: options.rows ?? 40,
     spinnerTick: 0,
@@ -208,6 +226,33 @@ describe('renderWorkspaceApp', () => {
         prefix: 'co',
         completions: ['coco/*', 'code/', 'coffee/'],
         commonPrefix: 'co',
+        isDirectory: false,
+      } as ReturnType<typeof completePath>,
+    })
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('snapshots the clone prompt on the URL field', () => {
+    const state = applyWorkspaceAction(baseState(), { type: 'set-focus', focus: 'clone-repo' })
+    const tree = render(state, {
+      cloneUrl: 'git@github.com:gfargo/coco.git',
+      cloneTarget: '/home/dev/coco',
+      cloneField: 'url',
+    })
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('snapshots the clone prompt on the destination field', () => {
+    const state = applyWorkspaceAction(baseState(), { type: 'set-focus', focus: 'clone-repo' })
+    const tree = render(state, {
+      cloneUrl: 'git@github.com:gfargo/coco.git',
+      cloneTarget: '/home/dev/coco',
+      cloneField: 'target',
+      cloneCompletion: {
+        baseDir: '/home/dev/',
+        prefix: 'co',
+        completions: ['coco/'],
+        commonPrefix: 'coco',
         isDirectory: false,
       } as ReturnType<typeof completePath>,
     })

--- a/src/workstation/surfaces/workspace/view.ts
+++ b/src/workstation/surfaces/workspace/view.ts
@@ -41,6 +41,12 @@ type RenderWorkspaceAppDeps = {
   filterDraft: string
   addRepoDraft: string
   addRepoCompletion: PathCompletionResult
+  /** Clone-repo modal (`c`) state. */
+  cloneUrl: string
+  cloneTarget: string
+  cloneField: 'url' | 'target'
+  cloneCompletion: PathCompletionResult
+  cloning: boolean
   /** Terminal width in cells. Caller resolves via Ink's useWindowSize. */
   columns: number
   /** Terminal height in rows. Caller resolves via Ink's useWindowSize. */
@@ -708,6 +714,46 @@ function renderAddRepoPrompt(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElem
   )
 }
 
+function renderCloneRepoPrompt(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement | null {
+  if (deps.state.focus !== 'clone-repo') {
+    return null
+  }
+  const { React, ink, theme, cloneUrl, cloneTarget, cloneField, cloneCompletion, cloning } = deps
+  const { Box, Text } = ink
+  const urlActive = cloneField === 'url' && !cloning
+  const targetActive = cloneField === 'target' && !cloning
+  const completionLine = cloneCompletion.completions.slice(0, 8).join('  ')
+  const hint = cloning
+    ? 'Cloning… this can take a moment for large repos.'
+    : cloneField === 'url'
+      ? 'Paste a remote URL (https or git@…), then enter for the destination.'
+      : 'Edit the destination · tab to complete · enter to clone · esc to cancel'
+  return React.createElement(
+    Box,
+    {
+      borderColor: focusBorderColor(theme, true),
+      borderStyle: theme.borderStyle,
+      flexDirection: 'column',
+      paddingX: 1,
+    },
+    React.createElement(Text, { bold: true }, 'Clone a repository'),
+    React.createElement(
+      Text,
+      { color: urlActive ? undefined : toneColor('dim', theme) },
+      `  URL:  ${cloneUrl}${urlActive ? '_' : ''}`
+    ),
+    React.createElement(
+      Text,
+      { color: targetActive ? undefined : toneColor('dim', theme) },
+      `  Into: ${cloneTarget}${targetActive ? '_' : ''}`
+    ),
+    React.createElement(Text, { dimColor: true }, hint),
+    completionLine && targetActive
+      ? React.createElement(Text, { color: toneColor('dim', theme) }, completionLine)
+      : null
+  )
+}
+
 const FOOTER_HEIGHT = 4 // 2 borders + hint row + status row
 
 function renderFooter(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement {
@@ -764,8 +810,10 @@ function computeBodyHeight(deps: RenderWorkspaceAppDeps): number {
   const FOOTER_ROWS = FOOTER_HEIGHT
   const onboardingRows = buildWorkspaceOnboarding(deps.state).show ? 5 : 0
   const addRepoRows = deps.state.focus === 'add-repo' ? 5 : 0
+  // Clone modal is one row taller (URL + Into + hint + completion).
+  const cloneRows = deps.state.focus === 'clone-repo' ? 6 : 0
   const confirmRows = deps.state.focus === 'confirm-delete' ? 5 : 0
-  const reserved = HEADER_ROWS + FOOTER_ROWS + onboardingRows + addRepoRows + confirmRows
+  const reserved = HEADER_ROWS + FOOTER_ROWS + onboardingRows + addRepoRows + cloneRows + confirmRows
   return Math.max(8, deps.rows - reserved)
 }
 
@@ -820,6 +868,7 @@ export function renderWorkspaceApp(deps: RenderWorkspaceAppDeps): ReactTypes.Rea
     ),
     renderOnboardingBanner(deps),
     renderAddRepoPrompt(deps),
+    renderCloneRepoPrompt(deps),
     renderConfirmDelete(deps),
     renderFooter(deps)
   )


### PR DESCRIPTION
Adds a **clone** flow to the multi-repo workspace TUI (`coco ws`), alongside the existing `a` (add by path).

## UX

Press **`c`** to open a two-field modal:
1. **URL** — the remote (https or `git@…`).
2. **Into** — the destination, **pre-filled with `<launch-cwd>/<repo-name>`** derived from the URL (so zero typing in the common case) and **editable** with `tab` path-completion.

`Enter` on the URL field advances to the destination; `Enter` there runs the clone. `Esc` cancels.

- The destination defaults to the directory `coco ws` was launched in (the cwd), captured at mount so it survives drill-in round-trips.
- `git clone` runs **async** with a `Cloning…` state; it **refuses to clobber** an existing path and surfaces a one-line error on failure (keeping the modal open so you can fix the URL/path and retry).
- On success the repo is added to the known-repos store and the **cursor anchors onto it** in the list — exactly the same persistence + refresh path as `a`.

Per the design call: derive `<cwd>/<name>` editable · select-in-list after clone · bound to `c`.

## Implementation

- New helper `src/git/cloneRepo.ts` — `deriveRepoName` (pure, parses https + SSH specs, strips `.git`/trailing slashes) and `cloneRepo` (async, existence-guarded).
- Workspace surface: new `clone-repo` focus + two-field runtime state (URL / target / active-field / derived-vs-edited / completion / cloning), input routing, modal render, and footer/help/empty-state hints.

## Validation

- `tsc` + `eslint` clean
- `jest`: 797 workstation tests green — adds `deriveRepoName` + `cloneRepo` guards, the `c` intent + `clone-repo` focus input tests, and two clone-modal render snapshots (URL field / destination field). Existing footer snapshots refreshed for the new `c clone` hint.