### PR TITLE
feat(screenshot): workspace add/clone + workstation demos, themed diff/status recipes

### DIFF
--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -741,6 +741,95 @@ export const RECIPES: ScreenshotRecipe[] = [
     theme: 'gruvbox',
   },
 
+  // Themed showcase set (#workstation marketing) — the diff and status
+  // surfaces across a curated set of dark + light themes. The diff view
+  // is the most color-rich surface (now syntax-highlighted), so it shows
+  // off how a theme recolors code, additions, removals, and chrome.
+  {
+    name: 'ui-diff-theme-dracula',
+    description: 'Diff view with dracula theme',
+    scenario: 'feature-pr-ready',
+    command: 'ui --view diff --theme dracula',
+    theme: 'dracula',
+  },
+  {
+    name: 'ui-diff-theme-tokyo-night',
+    description: 'Diff view with tokyo-night theme',
+    scenario: 'feature-pr-ready',
+    command: 'ui --view diff --theme tokyo-night',
+    theme: 'tokyo-night',
+  },
+  {
+    name: 'ui-diff-theme-nord',
+    description: 'Diff view with nord theme',
+    scenario: 'feature-pr-ready',
+    command: 'ui --view diff --theme nord',
+    theme: 'nord',
+  },
+  {
+    name: 'ui-diff-theme-rose-pine',
+    description: 'Diff view with rose-pine theme',
+    scenario: 'feature-pr-ready',
+    command: 'ui --view diff --theme rose-pine',
+    theme: 'rose-pine',
+  },
+  {
+    name: 'ui-diff-theme-github-light',
+    description: 'Diff view with github-light theme',
+    scenario: 'feature-pr-ready',
+    command: 'ui --view diff --theme github-light',
+    theme: 'github-light',
+  },
+  {
+    name: 'ui-diff-theme-catppuccin-latte',
+    description: 'Diff view with catppuccin-latte (light) theme',
+    scenario: 'feature-pr-ready',
+    command: 'ui --view diff --theme catppuccin-latte',
+    theme: 'catppuccin-latte',
+  },
+  {
+    name: 'ui-status-theme-dracula',
+    description: 'Status view with dracula theme',
+    scenario: 'dirty-many-files',
+    command: 'ui --view status --theme dracula',
+    theme: 'dracula',
+  },
+  {
+    name: 'ui-status-theme-tokyo-night',
+    description: 'Status view with tokyo-night theme',
+    scenario: 'dirty-many-files',
+    command: 'ui --view status --theme tokyo-night',
+    theme: 'tokyo-night',
+  },
+  {
+    name: 'ui-status-theme-nord',
+    description: 'Status view with nord theme',
+    scenario: 'dirty-many-files',
+    command: 'ui --view status --theme nord',
+    theme: 'nord',
+  },
+  {
+    name: 'ui-status-theme-rose-pine',
+    description: 'Status view with rose-pine theme',
+    scenario: 'dirty-many-files',
+    command: 'ui --view status --theme rose-pine',
+    theme: 'rose-pine',
+  },
+  {
+    name: 'ui-status-theme-github-light',
+    description: 'Status view with github-light theme',
+    scenario: 'dirty-many-files',
+    command: 'ui --view status --theme github-light',
+    theme: 'github-light',
+  },
+  {
+    name: 'ui-status-theme-catppuccin-latte',
+    description: 'Status view with catppuccin-latte (light) theme',
+    scenario: 'dirty-many-files',
+    command: 'ui --view status --theme catppuccin-latte',
+    theme: 'catppuccin-latte',
+  },
+
   // ─────────────────────────────────────────────────────────────────
   // `coco ui` — interactive overlays and focus states
   // ─────────────────────────────────────────────────────────────────
@@ -1036,6 +1125,86 @@ export const RECIPES: ScreenshotRecipe[] = [
     dimensions: { cols: 100, rows: 30 },
     actions: [
       { kind: 'sleep', ms: 4000 },
+    ],
+  },
+  {
+    name: 'demo-workspace-add-repo',
+    description: 'Workspace → `a` add-a-repo prompt with tab path-completion',
+    scenario: '_workspace',
+    command: 'workspace --root . --maxDepth 1',
+    emitGif: true,
+    actions: [
+      { kind: 'sleep', ms: 2000 },
+      // Open the add-repo prompt (draft starts at `~/`).
+      { kind: 'type', text: 'a' },
+      { kind: 'sleep', ms: 900 },
+      // Tab-complete the home directory to reveal the completion list.
+      { kind: 'key', key: 'Tab' },
+      { kind: 'sleep', ms: 1400 },
+      // Type a fragment, then complete again to show it narrowing.
+      { kind: 'type', text: 'd' },
+      { kind: 'sleep', ms: 700 },
+      { kind: 'key', key: 'Tab' },
+      { kind: 'sleep', ms: 1400 },
+      { kind: 'key', key: 'Escape' },
+      { kind: 'sleep', ms: 700 },
+      { kind: 'type', text: 'q' },
+      { kind: 'sleep', ms: 1500 },
+    ],
+  },
+  {
+    name: 'demo-workspace-clone',
+    description: 'Workspace → `c` clone a remote → URL prompt auto-derives the destination',
+    scenario: '_workspace',
+    command: 'workspace --root . --maxDepth 1',
+    emitGif: true,
+    actions: [
+      { kind: 'sleep', ms: 2000 },
+      // Open the clone prompt.
+      { kind: 'type', text: 'c' },
+      { kind: 'sleep', ms: 900 },
+      // Type a remote URL — the destination derives as you type.
+      { kind: 'type', text: 'git@github.com:gfargo/coco.git' },
+      { kind: 'sleep', ms: 1600 },
+      // Enter advances to the (auto-filled, editable) destination field.
+      { kind: 'key', key: 'Enter' },
+      { kind: 'sleep', ms: 1800 },
+      { kind: 'key', key: 'Escape' },
+      { kind: 'sleep', ms: 700 },
+      { kind: 'type', text: 'q' },
+      { kind: 'sleep', ms: 1500 },
+    ],
+  },
+  {
+    name: 'demo-workstation-using',
+    description: 'Using the workstation: history → open a syntax-highlighted diff → status → branches → help',
+    scenario: 'feature-pr-ready',
+    command: 'ui --view history --no-all',
+    emitGif: true,
+    dimensions: { cols: 150, rows: 40 },
+    actions: [
+      { kind: 'sleep', ms: 3200 },
+      // Walk the history, then open a commit's (syntax-highlighted) diff.
+      { kind: 'key', key: 'Down' },
+      { kind: 'sleep', ms: 600 },
+      { kind: 'key', key: 'Down' },
+      { kind: 'sleep', ms: 600 },
+      { kind: 'key', key: 'Enter' },
+      { kind: 'sleep', ms: 2200 },
+      // Back to history, then tour a couple of other surfaces.
+      { kind: 'type', text: '<' },
+      { kind: 'sleep', ms: 900 },
+      { kind: 'type', text: 'gs' },
+      { kind: 'sleep', ms: 1500 },
+      { kind: 'type', text: 'gb' },
+      { kind: 'sleep', ms: 1500 },
+      // Help overlay, then close + quit.
+      { kind: 'type', text: '?' },
+      { kind: 'sleep', ms: 1800 },
+      { kind: 'key', key: 'Escape' },
+      { kind: 'sleep', ms: 500 },
+      { kind: 'type', text: 'q' },
+      { kind: 'sleep', ms: 1200 },
     ],
   },
 ]

--- a/bin/syncScreenshots.ts
+++ b/bin/syncScreenshots.ts
@@ -102,6 +102,27 @@ const SITE_RECIPES = [
   'ui-theme-picker',
   'ui-search-filter',
   'ui-inspector-focused',
+  // Workspace demos (add a repo by path, clone a remote)
+  'demo-workspace-add-repo',
+  'demo-workspace-clone',
+  'demo-workstation-using',
+  // Themed-view showcase — diff + status across a curated theme set
+  'ui-diff-theme-catppuccin',
+  'ui-diff-theme-gruvbox',
+  'ui-diff-theme-dracula',
+  'ui-diff-theme-tokyo-night',
+  'ui-diff-theme-nord',
+  'ui-diff-theme-rose-pine',
+  'ui-diff-theme-github-light',
+  'ui-diff-theme-catppuccin-latte',
+  'ui-status-theme-catppuccin',
+  'ui-status-theme-gruvbox',
+  'ui-status-theme-dracula',
+  'ui-status-theme-tokyo-night',
+  'ui-status-theme-nord',
+  'ui-status-theme-rose-pine',
+  'ui-status-theme-github-light',
+  'ui-status-theme-catppuccin-latte',
 ]
 
 /**
@@ -183,6 +204,25 @@ const FILENAME_MAP: Record<string, string[]> = {
   'demo-ui-view-switching': ['demo-ui-view-switching.gif'],
   'demo-hunk-staging': ['demo-hunk-staging.gif'],
   'demo-search-filter': ['demo-search-filter.gif'],
+  'demo-workspace-add-repo': ['demo-workspace-add-repo.gif'],
+  'demo-workspace-clone': ['demo-workspace-clone.gif'],
+  'demo-workstation-using': ['demo-workstation-using.gif'],
+  'ui-diff-theme-catppuccin': ['diff-theme-catppuccin.png'],
+  'ui-diff-theme-gruvbox': ['diff-theme-gruvbox.png'],
+  'ui-diff-theme-dracula': ['diff-theme-dracula.png'],
+  'ui-diff-theme-tokyo-night': ['diff-theme-tokyo-night.png'],
+  'ui-diff-theme-nord': ['diff-theme-nord.png'],
+  'ui-diff-theme-rose-pine': ['diff-theme-rose-pine.png'],
+  'ui-diff-theme-github-light': ['diff-theme-github-light.png'],
+  'ui-diff-theme-catppuccin-latte': ['diff-theme-catppuccin-latte.png'],
+  'ui-status-theme-catppuccin': ['status-theme-catppuccin.png'],
+  'ui-status-theme-gruvbox': ['status-theme-gruvbox.png'],
+  'ui-status-theme-dracula': ['status-theme-dracula.png'],
+  'ui-status-theme-tokyo-night': ['status-theme-tokyo-night.png'],
+  'ui-status-theme-nord': ['status-theme-nord.png'],
+  'ui-status-theme-rose-pine': ['status-theme-rose-pine.png'],
+  'ui-status-theme-github-light': ['status-theme-github-light.png'],
+  'ui-status-theme-catppuccin-latte': ['status-theme-catppuccin-latte.png'],
 }
 
 function main() {


### PR DESCRIPTION
Adds the recipes behind the new `.www` workstation-page media (the page + generated images land in a separate git-co.co PR).

## New GIF demos
- **`demo-workspace-add-repo`** — workspace `a` add-by-path prompt with tab completion
- **`demo-workspace-clone`** — workspace `c` clone: typing a URL auto-derives the destination (showcases the new clone feature)
- **`demo-workstation-using`** — a workstation tour: history → a syntax-highlighted diff → status → branches → help overlay

## New themed screenshots
- `ui-diff-theme-*` and `ui-status-theme-*` for 6 more themes (dracula, tokyo-night, nord, rose-pine, github-light, catppuccin-latte) joining the existing catppuccin/gruvbox — an 8-theme set spanning dark + light.

## Sync wiring
All wired into `syncScreenshots.ts` `SITE_RECIPES` + `FILENAME_MAP` → `diff-theme-<name>.png` / `status-theme-<name>.png` / `demo-*.gif`, so `npm run screenshot:sync` regenerates and copies them into `.www/public/screenshots/`.

`eslint` clean; recipes verified via `--list` and generated locally with `vhs`.