### PR TITLE
feat(ui): stage-all (A) + stage-by-pathspec (+) from compose & status

### DIFF
--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -689,6 +689,14 @@ export function getLogInkPaletteExecuteEvents(
       // Runtime resolves the cursored worktree file and opens the picker
       // (no-ops with a warning when there's no file under the cursor).
       return [{ type: 'openGitignorePicker' }]
+    case 'stageAll':
+      return [{ type: 'runWorkflowAction', id: 'stage-all' }]
+    case 'stagePathspec':
+      return [action({
+        type: 'openInputPrompt',
+        kind: 'stage-pathspec',
+        label: 'Stage pathspec (e.g. `.`, `src/`, `*.ts`, or a space-separated list)',
+      })]
     case 'workflowDeleteBranch':
     case 'workflowDeleteTag':
     case 'workflowDropStash':
@@ -787,6 +795,12 @@ function submitInputPrompt(state: LogInkState): LogInkInputEvent[] {
   if (state.inputPrompt.kind === 'gitignore-pattern') {
     return [
       { type: 'runWorkflowAction', id: 'add-to-gitignore', payload: value },
+      action({ type: 'closeInputPrompt' }),
+    ]
+  }
+  if (state.inputPrompt.kind === 'stage-pathspec') {
+    return [
+      { type: 'runWorkflowAction', id: 'stage-pathspec', payload: value },
       action({ type: 'closeInputPrompt' }),
     ]
   }
@@ -3178,6 +3192,20 @@ export function getLogInkInputEvents(
 
   if (inputValue === ' ' && state.activeView === 'status' && context.worktreeFileCount) {
     return [{ type: 'toggleSelectedFileStage' }]
+  }
+
+  // `A` — stage everything (git add -A); `+` — stage by typed pathspec.
+  // Both available from the status AND compose views so you can stage
+  // without leaving the message editor.
+  if (inputValue === 'A' && (state.activeView === 'status' || state.activeView === 'compose')) {
+    return [{ type: 'runWorkflowAction', id: 'stage-all' }]
+  }
+  if (inputValue === '+' && (state.activeView === 'status' || state.activeView === 'compose')) {
+    return [action({
+      type: 'openInputPrompt',
+      kind: 'stage-pathspec',
+      label: 'Stage pathspec (e.g. `.`, `src/`, `*.ts`, or a space-separated list)',
+    })]
   }
 
   if (inputValue === ' ' && state.activeView === 'diff' && context.worktreeHunkOffsets?.length) {

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -32,7 +32,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ files', 'enter diff', 'space stage', 'z revert', 'i ignore', 'e/c compose', 'y yank'],
+      contextual: ['↑/↓ files', 'enter diff', 'space stage', 'A stage all', 'z revert', 'i ignore', 'e/c compose'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 
@@ -69,7 +69,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['e edit', 'E $EDITOR', 'c commit', 'S split', 'I AI draft', 'gs hunks', 'esc back'],
+      contextual: ['e edit', 'c commit', 'A stage all', '+ stage…', 'S split', 'I AI draft', 'esc back'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -12,6 +12,8 @@ export type LogInkCommandId =
   | 'openProjectConfig'
   | 'openGlobalConfig'
   | 'gitignoreFile'
+  | 'stageAll'
+  | 'stagePathspec'
   | 'commit'
   | 'cycleSort'
   | 'editCommit'
@@ -566,6 +568,20 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     contexts: ['status'],
   },
   {
+    id: 'stageAll',
+    keys: ['A'],
+    label: 'stage all',
+    description: 'Stage every change in the worktree (git add -A).',
+    contexts: ['status', 'compose'],
+  },
+  {
+    id: 'stagePathspec',
+    keys: ['+'],
+    label: 'stage paths',
+    description: 'Stage files matching a typed pathspec (. / src/ / *.ts / a list).',
+    contexts: ['status', 'compose'],
+  },
+  {
     id: 'viewChangelog',
     keys: ['L'],
     label: 'changelog',
@@ -725,6 +741,8 @@ const BINDING_CATEGORY_BY_ID: Partial<Record<LogInkCommandId, LogInkBindingCateg
   openProjectConfig: 'view',
   openGlobalConfig: 'view',
   gitignoreFile: 'mutate',
+  stageAll: 'mutate',
+  stagePathspec: 'mutate',
   quit: 'essentials',
   refresh: 'essentials',
   navigateBack: 'essentials',
@@ -1071,7 +1089,7 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
 
   if (options.activeView === 'status') {
     return {
-      contextual: ['↑/↓ files', 'enter diff', 'space stage', 'z revert', 'i ignore', 'e/c compose', 'y yank'],
+      contextual: ['↑/↓ files', 'enter diff', 'space stage', 'A stage all', 'z revert', 'i ignore', 'e/c compose'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }
@@ -1114,7 +1132,7 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
 
   if (options.activeView === 'compose') {
     return {
-      contextual: ['e edit', 'E $EDITOR', 'c commit', 'S split', 'I AI draft', 'gs hunks', 'esc back'],
+      contextual: ['e edit', 'c commit', 'A stage all', '+ stage…', 'S split', 'I AI draft', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -678,6 +678,7 @@ export type LogInkInputPromptKind =
   | 'set-upstream'
   | 'create-stash'
   | 'gitignore-pattern'
+  | 'stage-pathspec'
   | 'reset-mode'
   | 'pr-merge-strategy'
   | 'pr-comment'

--- a/src/git/statusActions.test.ts
+++ b/src/git/statusActions.test.ts
@@ -1,4 +1,4 @@
-import { revertFile, stageFile, unstageFile } from './statusActions'
+import { revertFile, stageAll, stageFile, stagePathspec, unstageFile } from './statusActions'
 import { WorktreeFile } from './statusData'
 
 const file: WorktreeFile = {
@@ -38,5 +38,44 @@ describe('log status actions', () => {
       message: 'Untracked files are not reverted automatically.',
     })
     expect(git.raw).not.toHaveBeenCalled()
+  })
+
+  describe('stageAll', () => {
+    it('runs git add -A', async () => {
+      const git = { raw: jest.fn().mockResolvedValue('') }
+      const result = await stageAll(git as never)
+      expect(result.ok).toBe(true)
+      expect(result.message).toBe('Staged all changes')
+      expect(git.raw).toHaveBeenCalledWith(['add', '-A'])
+    })
+  })
+
+  describe('stagePathspec', () => {
+    it('stages a single pathspec', async () => {
+      const git = { raw: jest.fn().mockResolvedValue('') }
+      const result = await stagePathspec(git as never, 'src/')
+      expect(result.ok).toBe(true)
+      expect(git.raw).toHaveBeenCalledWith(['add', '--', 'src/'])
+    })
+
+    it('splits a space-separated list into multiple pathspecs', async () => {
+      const git = { raw: jest.fn().mockResolvedValue('') }
+      await stagePathspec(git as never, '  src/  *.ts  ')
+      expect(git.raw).toHaveBeenCalledWith(['add', '--', 'src/', '*.ts'])
+    })
+
+    it('passes globs through to git unquoted (no shell)', async () => {
+      const git = { raw: jest.fn().mockResolvedValue('') }
+      await stagePathspec(git as never, '*.json')
+      expect(git.raw).toHaveBeenCalledWith(['add', '--', '*.json'])
+    })
+
+    it('refuses an empty pathspec', async () => {
+      const git = { raw: jest.fn() }
+      const result = await stagePathspec(git as never, '   ')
+      expect(result.ok).toBe(false)
+      expect(result.message).toMatch(/Enter a pathspec/)
+      expect(git.raw).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/git/statusActions.ts
+++ b/src/git/statusActions.ts
@@ -82,3 +82,33 @@ export function unstageAllFiles(
     `Unstaged ${files.length} ${files.length === 1 ? 'file' : 'files'}`
   )
 }
+
+/**
+ * Stage everything in the worktree — modifications, new files, and
+ * deletions — in one shot (`git add -A`). The `A` hotkey + the `:`
+ * palette's "stage all" both route here.
+ */
+export function stageAll(git: SimpleGit): Promise<StatusActionResult> {
+  return runAction(
+    () => git.raw(['add', '-A']),
+    'Staged all changes'
+  )
+}
+
+/**
+ * Stage files matching one or more git pathspecs (`git add -- <spec…>`).
+ * Powers the typed "stage…" prompt (`+`): the user types a path, a
+ * directory, a glob like `*.ts`, or a space-separated list, and git's
+ * own pathspec matching does the rest. Args are passed directly (no
+ * shell), so the globs are interpreted by git, not the shell.
+ */
+export function stagePathspec(git: SimpleGit, pathspec: string): Promise<StatusActionResult> {
+  const specs = pathspec.trim().split(/\s+/).filter(Boolean)
+  if (specs.length === 0) {
+    return Promise.resolve({ ok: false, message: 'Enter a pathspec to stage (e.g. . or src/ or *.ts).' })
+  }
+  return runAction(
+    () => git.raw(['add', '--', ...specs]),
+    `Staged ${specs.join(' ')}`
+  )
+}

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -215,8 +215,10 @@ import {
 } from '../../git/stashData'
 import {
     revertFile,
+    stageAll,
     stageAllFiles,
     stageFile,
+    stagePathspec,
     unstageAllFiles,
     unstageFile,
 } from '../../git/statusActions'
@@ -3741,6 +3743,8 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         ).filter((file) => file.state === 'untracked')
         return stageAllFiles(git, files)
       },
+      'stage-all': async () => stageAll(git),
+      'stage-pathspec': async () => stagePathspec(git, payload || ''),
     }
     const handler = handlers[id]
     if (!handler) {
@@ -3834,6 +3838,11 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     // the status list immediately (the silent context refresh above
     // doesn't always re-read the worktree file set).
     if (result?.ok && id === 'add-to-gitignore') {
+      await refreshWorktreeContext()
+    }
+    // Stage-all / stage-pathspec change staged/unstaged counts — refresh
+    // the worktree so the status list + compose summary reflect it.
+    if (result?.ok && (id === 'stage-all' || id === 'stage-pathspec')) {
       await refreshWorktreeContext()
     }
     if (result?.ok && id === 'drop-stash') {


### PR DESCRIPTION
Two staging shortcuts in the **compose** and **status** views, so you can stage without leaving the message editor.

## What

- **`A` — stage all.** `git add -A` — every modification, new file, and deletion in one keystroke.
- **`+` — stage by pathspec.** Opens a typed prompt; enter a path, a directory, a glob like `*.ts`, or a space-separated list (`src/ *.json`) → `git add -- <spec…>`. Args go straight to git (no shell), so git's own pathspec/glob matching applies.

Both are reachable from the **`:` command palette** ("stage all" / "stage paths") and the **`?` help overlay**, with footer hints (`A stage all`, `+ stage…`). After staging, the worktree refreshes so the status list and the compose summary update immediately. (In the compose view, both only fire when you're *not* mid-edit — typing into the message still types normally.)

## On hunk staging (your other question)

Already shipped — no work needed. In the **diff view** (`Enter` on a file, or `gd`): `j`/`k` move between hunks, **`space`** stages/unstages the cursored hunk, **`H`** applies it. This PR fills the complementary "stage a lot at once" gap.

## Design

The layered "simple key + typed power-path" approach you asked about: `A` for the 90% case, `+`/palette for precise `git add` targeting. Reuses the existing input-prompt + workflow-runner plumbing.

## Validation
- `tsc` + `eslint` clean
- `jest`: 1091 workstation tests green; new `stageAll` / `stagePathspec` unit tests (single spec, space-separated list, glob passthrough, empty-input guard); updated status + compose footer-hint assertions