### PR TITLE
fix(ws): keymap help overlay collapses title onto first category

### DIFF
--- a/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
+++ b/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
@@ -7978,10 +7978,12 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     borderColor="cyan"
     borderStyle="classic"
     flexDirection="column"
+    flexShrink={0}
     paddingX={1}
   >
     <Box
       flexDirection="row"
+      flexShrink={0}
       justifyContent="space-between"
     >
       <Box
@@ -8026,6 +8028,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     </Text>
     <Box
       flexDirection="row"
+      flexShrink={0}
     >
       <Box
         flexShrink={0}
@@ -8055,6 +8058,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     </Box>
     <Box
       flexDirection="row"
+      flexShrink={0}
     >
       <Box
         flexShrink={0}
@@ -8084,6 +8088,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     </Box>
     <Box
       flexDirection="row"
+      flexShrink={0}
     >
       <Box
         flexShrink={0}
@@ -8113,6 +8118,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     </Box>
     <Box
       flexDirection="row"
+      flexShrink={0}
     >
       <Box
         flexShrink={0}
@@ -8142,6 +8148,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     </Box>
     <Box
       flexDirection="row"
+      flexShrink={0}
     >
       <Box
         flexShrink={0}
@@ -8183,6 +8190,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     </Text>
     <Box
       flexDirection="row"
+      flexShrink={0}
     >
       <Box
         flexShrink={0}
@@ -8212,6 +8220,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     </Box>
     <Box
       flexDirection="row"
+      flexShrink={0}
     >
       <Box
         flexShrink={0}
@@ -8241,6 +8250,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     </Box>
     <Box
       flexDirection="row"
+      flexShrink={0}
     >
       <Box
         flexShrink={0}
@@ -8270,6 +8280,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     </Box>
     <Box
       flexDirection="row"
+      flexShrink={0}
     >
       <Box
         flexShrink={0}
@@ -8299,6 +8310,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     </Box>
     <Box
       flexDirection="row"
+      flexShrink={0}
     >
       <Box
         flexShrink={0}
@@ -8335,6 +8347,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     </Text>
     <Box
       flexDirection="row"
+      flexShrink={0}
     >
       <Box
         flexShrink={0}
@@ -8364,6 +8377,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     </Box>
     <Box
       flexDirection="row"
+      flexShrink={0}
     >
       <Box
         flexShrink={0}
@@ -8405,6 +8419,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     </Text>
     <Box
       flexDirection="row"
+      flexShrink={0}
     >
       <Box
         flexShrink={0}
@@ -8434,6 +8449,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     </Box>
     <Box
       flexDirection="row"
+      flexShrink={0}
     >
       <Box
         flexShrink={0}
@@ -8463,6 +8479,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     </Box>
     <Box
       flexDirection="row"
+      flexShrink={0}
     >
       <Box
         flexShrink={0}
@@ -8492,6 +8509,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     </Box>
     <Box
       flexDirection="row"
+      flexShrink={0}
     >
       <Box
         flexShrink={0}
@@ -8521,6 +8539,7 @@ exports[`renderWorkspaceApp snapshots the keymap help overlay when toggled on 1`
     </Box>
     <Box
       flexDirection="row"
+      flexShrink={0}
     >
       <Box
         flexShrink={0}

--- a/src/workstation/surfaces/workspace/input.test.ts
+++ b/src/workstation/surfaces/workspace/input.test.ts
@@ -188,10 +188,8 @@ describe('resolveWorkspaceInput', () => {
     })
   })
 
-  it('drops every keystroke while the help overlay is up except esc/?/q', () => {
+  it('closes the help overlay on esc/?/q', () => {
     const state = { ...listState(), showHelp: true }
-    expect(resolveWorkspaceInput('j', key(), state).kind).toBe('noop')
-    expect(resolveWorkspaceInput('', key({ return: true }), state).kind).toBe('noop')
     expect(resolveWorkspaceInput('', key({ escape: true }), state)).toEqual({
       kind: 'action',
       action: { type: 'close-help' },
@@ -204,6 +202,40 @@ describe('resolveWorkspaceInput', () => {
       kind: 'action',
       action: { type: 'close-help' },
     })
+  })
+
+  it('scrolls the help overlay with j/k/↑/↓ and ctrl+d/u', () => {
+    const state = { ...listState(), showHelp: true }
+    expect(resolveWorkspaceInput('j', key(), state)).toEqual({
+      kind: 'action',
+      action: { type: 'scroll-help', delta: 1 },
+    })
+    expect(resolveWorkspaceInput('', key({ downArrow: true }), state)).toEqual({
+      kind: 'action',
+      action: { type: 'scroll-help', delta: 1 },
+    })
+    expect(resolveWorkspaceInput('k', key(), state)).toEqual({
+      kind: 'action',
+      action: { type: 'scroll-help', delta: -1 },
+    })
+    expect(resolveWorkspaceInput('', key({ upArrow: true }), state)).toEqual({
+      kind: 'action',
+      action: { type: 'scroll-help', delta: -1 },
+    })
+    expect(resolveWorkspaceInput('d', key({ ctrl: true }), state)).toEqual({
+      kind: 'action',
+      action: { type: 'scroll-help', delta: 10 },
+    })
+    expect(resolveWorkspaceInput('u', key({ ctrl: true }), state)).toEqual({
+      kind: 'action',
+      action: { type: 'scroll-help', delta: -10 },
+    })
+  })
+
+  it('drops other keystrokes while the help overlay is up', () => {
+    const state = { ...listState(), showHelp: true }
+    expect(resolveWorkspaceInput('', key({ return: true }), state).kind).toBe('noop')
+    expect(resolveWorkspaceInput('a', key(), state).kind).toBe('noop')
   })
 
   it('routes escape out of the add-repo prompt and lets the runtime own other keys', () => {

--- a/src/workstation/surfaces/workspace/input.ts
+++ b/src/workstation/surfaces/workspace/input.ts
@@ -67,6 +67,21 @@ export function resolveWorkspaceInput(
     if (key.escape || input === '?' || input === 'q') {
       return { kind: 'action', action: { type: 'close-help' } }
     }
+    // The keymap is taller than the panel on short terminals — let
+    // j/k/↑/↓ and ctrl+d/u scroll the windowed body. Mirrors the
+    // `coco ui` help overlay.
+    if (key.downArrow || input === 'j') {
+      return { kind: 'action', action: { type: 'scroll-help', delta: 1 } }
+    }
+    if (key.upArrow || input === 'k') {
+      return { kind: 'action', action: { type: 'scroll-help', delta: -1 } }
+    }
+    if (key.ctrl && input === 'd') {
+      return { kind: 'action', action: { type: 'scroll-help', delta: 10 } }
+    }
+    if (key.ctrl && input === 'u') {
+      return { kind: 'action', action: { type: 'scroll-help', delta: -10 } }
+    }
     return { kind: 'noop' }
   }
 

--- a/src/workstation/surfaces/workspace/state.test.ts
+++ b/src/workstation/surfaces/workspace/state.test.ts
@@ -186,10 +186,30 @@ describe('workspace state reducer', () => {
     expect(closed.showHelp).toBe(false)
   })
 
-  it('close-help only clears the help flag', () => {
+  it('close-help clears the help flag and resets the scroll offset', () => {
     const opened = applyWorkspaceAction(baseState, { type: 'toggle-help' })
-    const closed = applyWorkspaceAction(opened, { type: 'close-help' })
+    const scrolled = applyWorkspaceAction(opened, { type: 'scroll-help', delta: 5 })
+    const closed = applyWorkspaceAction(scrolled, { type: 'close-help' })
     expect(closed.showHelp).toBe(false)
+    expect(closed.helpScrollOffset).toBe(0)
+  })
+
+  it('scroll-help accumulates the offset and floor-clamps at zero', () => {
+    const opened = applyWorkspaceAction(baseState, { type: 'toggle-help' })
+    expect(opened.helpScrollOffset).toBe(0)
+    const down = applyWorkspaceAction(opened, { type: 'scroll-help', delta: 3 })
+    expect(down.helpScrollOffset).toBe(3)
+    const up = applyWorkspaceAction(down, { type: 'scroll-help', delta: -10 })
+    expect(up.helpScrollOffset).toBe(0)
+  })
+
+  it('reopening the help overlay resets the scroll offset to the top', () => {
+    const opened = applyWorkspaceAction(baseState, { type: 'toggle-help' })
+    const scrolled = applyWorkspaceAction(opened, { type: 'scroll-help', delta: 6 })
+    const closed = applyWorkspaceAction(scrolled, { type: 'toggle-help' })
+    const reopened = applyWorkspaceAction(closed, { type: 'toggle-help' })
+    expect(reopened.showHelp).toBe(true)
+    expect(reopened.helpScrollOffset).toBe(0)
   })
 
   it('dismiss-onboarding clears just the banner flag', () => {

--- a/src/workstation/surfaces/workspace/state.ts
+++ b/src/workstation/surfaces/workspace/state.ts
@@ -75,6 +75,14 @@ export type WorkspaceState = {
   roots: ReadonlyArray<string>
   /** Keymap help overlay toggle. */
   showHelp: boolean
+  /**
+   * Scroll offset (in body rows) for the keymap help overlay. The
+   * keymap is taller than the panel on short terminals, so the
+   * renderer windows the body against the available height and pins
+   * the title; this is the top of that window. Mirrors `coco ui`'s
+   * `helpScrollOffset`.
+   */
+  helpScrollOffset: number
   /** First-run onboarding overlay toggle. Self-dismisses on first user action. */
   showOnboarding: boolean
   /**
@@ -127,6 +135,7 @@ export type WorkspaceAction =
   | { type: 'set-status'; status?: string }
   | { type: 'toggle-help' }
   | { type: 'close-help' }
+  | { type: 'scroll-help'; delta: number }
   | { type: 'toggle-theme-picker' }
   | { type: 'move-theme-picker'; delta: number; presetCount: number }
   | { type: 'append-theme-picker-filter'; value: string }
@@ -175,6 +184,7 @@ export function createWorkspaceState(init: WorkspaceStateInit): WorkspaceState {
     showThemePicker: false,
     themePickerFilter: '',
     themePickerIndex: 0,
+    helpScrollOffset: 0,
     knownRepoPaths: init.knownRepoPaths ?? [],
     pullRequestFetching: [],
   }
@@ -348,10 +358,17 @@ export function applyWorkspaceAction(
       return { ...state, status: action.status }
     }
     case 'toggle-help': {
-      return { ...state, showHelp: !state.showHelp, showOnboarding: false }
+      // Always reopen at the top — picking up the last scroll position
+      // is more surprising than predictable for a reference overlay.
+      return { ...state, showHelp: !state.showHelp, helpScrollOffset: 0, showOnboarding: false }
     }
     case 'close-help': {
-      return { ...state, showHelp: false }
+      return { ...state, showHelp: false, helpScrollOffset: 0 }
+    }
+    case 'scroll-help': {
+      // Floor-clamp at 0 only; the renderer ceiling-clamps against the
+      // real content height so `j` past the end sticks at the last row.
+      return { ...state, helpScrollOffset: Math.max(0, state.helpScrollOffset + action.delta) }
     }
     case 'toggle-theme-picker': {
       return {

--- a/src/workstation/surfaces/workspace/view.ts
+++ b/src/workstation/surfaces/workspace/view.ts
@@ -527,7 +527,7 @@ function renderHelpRow(
   const { Box, Text } = ink
   return React.createElement(
     Box,
-    { key, flexDirection: 'row' },
+    { key, flexShrink: 0, flexDirection: 'row' },
     React.createElement(
       Box,
       { width: glyphWidth, flexShrink: 0 },
@@ -565,15 +565,69 @@ function renderHelpOverlay(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElemen
     allRows.reduce((acc, row) => Math.max(acc, row.keys.length), 0) + 4
   )
 
+  // Body lines — every scrollable row below the pinned title. Built as
+  // a flat list (section title → optional subtitle → rows → inter-section
+  // spacer) so we can window it against the available height. Each entry
+  // is `flexShrink: 0` so Ink never crushes rows on top of each other
+  // when the keymap is taller than the panel (which used to collapse the
+  // title and the first category onto the same line).
+  const body: ReactTypes.ReactNode[] = []
+  sections.forEach((section, sIndex) => {
+    body.push(
+      React.createElement(
+        Text,
+        {
+          key: `section-${sIndex}-title`,
+          bold: true,
+          color: theme.noColor ? undefined : theme.colors.muted,
+        },
+        section.title.toUpperCase()
+      )
+    )
+    if (section.subtitle) {
+      body.push(
+        React.createElement(
+          Text,
+          { key: `section-${sIndex}-subtitle`, dimColor: true },
+          ` ${section.subtitle}`
+        )
+      )
+    }
+    section.rows.forEach((row, rIndex) => {
+      body.push(
+        renderHelpRow(deps, row, glyphWidth, keysWidth, `row-${sIndex}-${rIndex}`)
+      )
+    })
+    if (sIndex < sections.length - 1) {
+      body.push(React.createElement(Text, { key: `section-${sIndex}-spacer` }, ''))
+    }
+  })
+
+  // Vertical budget: the overlay shares the column with the header
+  // (3 rows) and footer (FOOTER_HEIGHT). Its own chrome eats the border
+  // (2), the pinned title (1) and the title/body separator (1). Whatever
+  // is left is the window we slide the body through.
+  const HEADER_ROWS = 3
+  const overlayChromeRows = 4
+  const visibleRows = Math.max(
+    4,
+    deps.rows - HEADER_ROWS - FOOTER_HEIGHT - overlayChromeRows
+  )
+  // Ceiling-clamp the offset here (the reducer only floors at 0) so
+  // scrolling past the end sticks at the last row instead of revealing
+  // blank space.
+  const maxOffset = Math.max(0, body.length - visibleRows)
+  const offset = Math.min(deps.state.helpScrollOffset, maxOffset)
+
   const children: ReactTypes.ReactNode[] = []
 
   // Title bar — accent-tinged, matches the chip-style header on the
   // main surface so the help reads as the same app, just a different
-  // panel.
+  // panel. Pinned above the scrolling body.
   children.push(
     React.createElement(
       Box,
-      { key: 'title', flexDirection: 'row', justifyContent: 'space-between' },
+      { key: 'title', flexShrink: 0, flexDirection: 'row', justifyContent: 'space-between' },
       React.createElement(
         Box,
         { key: 'title-left', flexDirection: 'row' },
@@ -594,38 +648,36 @@ function renderHelpOverlay(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElemen
   )
   children.push(React.createElement(Text, { key: 'title-sep', dimColor: true }, ''))
 
-  // Sections — each gets a title in accent, optional subtitle dim,
-  // then its rows, then a blank line.
-  sections.forEach((section, sIndex) => {
+  // "more above" / "more below" hints each consume a window row so they
+  // don't push body content off-screen. Mirrors the `coco ui` overlay.
+  let windowSize = visibleRows
+  const hasMoreAbove = offset > 0
+  if (hasMoreAbove) {
+    windowSize -= 1
     children.push(
       React.createElement(
         Text,
-        {
-          key: `section-${sIndex}-title`,
-          bold: true,
-          color: theme.noColor ? undefined : theme.colors.muted,
-        },
-        section.title.toUpperCase()
+        { key: 'more-above', dimColor: true },
+        ' ↑ more above (j/k or ↑/↓ to scroll)'
       )
     )
-    if (section.subtitle) {
-      children.push(
-        React.createElement(
-          Text,
-          { key: `section-${sIndex}-subtitle`, dimColor: true },
-          ` ${section.subtitle}`
-        )
+  }
+  const hasMoreBelow = offset + windowSize < body.length
+  if (hasMoreBelow) {
+    windowSize -= 1
+  }
+
+  children.push(...body.slice(offset, offset + windowSize))
+
+  if (hasMoreBelow) {
+    children.push(
+      React.createElement(
+        Text,
+        { key: 'more-below', dimColor: true },
+        ' ↓ more below (j/k or ↑/↓ to scroll)'
       )
-    }
-    section.rows.forEach((row, rIndex) => {
-      children.push(
-        renderHelpRow(deps, row, glyphWidth, keysWidth, `row-${sIndex}-${rIndex}`)
-      )
-    })
-    if (sIndex < sections.length - 1) {
-      children.push(React.createElement(Text, { key: `section-${sIndex}-spacer` }, ''))
-    }
-  })
+    )
+  }
 
   return React.createElement(
     Box,
@@ -633,6 +685,7 @@ function renderHelpOverlay(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElemen
       borderColor: focusBorderColor(theme, true),
       borderStyle: theme.borderStyle,
       flexDirection: 'column',
+      flexShrink: 0,
       paddingX: 1,
     },
     ...children


### PR DESCRIPTION
## Problem

Opening the `coco ws` workspace keymap with `?` produced a garbled header on common terminal sizes — the panel title and the first category (`ESSENTIALS`) rendered on the same row, e.g. `ESSENTIALSorkspace keymap`.

## Root cause

The overlay rendered the entire keymap (~27 rows) into the height-locked root column (`header + overlay + footer` inside a fixed `height`). Whenever the keymap was taller than the available space — which includes everyday **100×30** and **80×24** terminals — Yoga had to absorb the negative vertical space and packed rows on top of one another, collapsing the title and the first category onto the same line. (At a tall terminal like 120×40 it fit and looked fine, which is why it wasn't always visible.)

## Fix

Window the help body against the available height and pin the title — the same approach `coco ui`'s help overlay already uses (`helpScrollOffset` + "more above/below" hints):

- **state** — add `helpScrollOffset` and a `scroll-help` action; reset to `0` on open/close so the overlay always starts at the top.
- **input** — `j` / `k` / `↑` / `↓` and `ctrl+d` / `ctrl+u` scroll the windowed body while help is up; `esc` / `?` / `q` still close.
- **view** — build the keymap as a flat body list, slice it to the rows that fit the panel, pin the title, and surface `↑/↓ more` hints when the list is clipped. `flexShrink: 0` on the panel and rows stops Ink from crushing rows together if content still overflows a very small terminal.

The title now always renders on its own line with `ESSENTIALS` cleanly below it at every terminal size.

## Validation

- `npx jest src/workstation/surfaces/workspace` — 132 passed (help-overlay snapshot updated; new scroll reducer + input coverage).
- `tsc --noEmit` clean.
- `eslint` clean on the changed files.
- Verified the rendered frame with real Ink at 80×24, 100×30, and 120×40 (and mid-scroll): title on its own line, `ESSENTIALS` below, footer intact, scroll hints appear only when the keymap is clipped.