### PR TITLE
feat(ui): tactile hunk staging — visible selection, badges, ↑/↓ nav

### DIFF
--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -854,6 +854,21 @@ export const RECIPES: ScreenshotRecipe[] = [
     actions: [{ kind: 'sleep', ms: 3000 }],
   },
 
+  {
+    name: 'ui-staging-hunks',
+    description: 'Worktree staging diff — per-hunk badges, selected-hunk bar, staged progress',
+    scenario: 'dirty-many-files',
+    command: 'ui --view status',
+    dimensions: { cols: 150, rows: 38 },
+    actions: [
+      { kind: 'sleep', ms: 3200 },
+      { kind: 'key', key: 'Down' },
+      { kind: 'sleep', ms: 400 },
+      { kind: 'key', key: 'Enter' },
+      { kind: 'sleep', ms: 2200 },
+    ],
+  },
+
   // ─────────────────────────────────────────────────────────────────
   // `coco ui` — interactive overlays and focus states
   // ─────────────────────────────────────────────────────────────────

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -295,21 +295,22 @@ describe('log Ink input interactions', () => {
     state = applyInput(state, '', { pageDown: true }, { worktreeDiffLineCount: 30 })
     expect(state.worktreeDiffOffset).toBe(8)
 
-    // j now scrolls the diff one line at a time (line-level scroll), so
-    // after pageDown(+8) a single j advances to offset 9. Hunk navigation
-    // moved to ]/[.
+    // In the worktree (staging) diff, j/↓ navigate HUNKS (the unit you
+    // stage) when there's more than one — auto-scrolling to the selected
+    // hunk, like `]`. (Single-hunk files fall back to line scroll.)
     state = applyInput(state, 'j', {}, {
       worktreeDiffLineCount: 30,
       worktreeHunkOffsets: [2, 12, 20],
     })
-    expect(state.worktreeDiffOffset).toBe(9)
+    expect(state.selectedWorktreeHunkIndex).toBe(1)
+    expect(state.worktreeDiffOffset).toBe(12)
 
     state = applyInput(state, ']', {}, {
       worktreeDiffLineCount: 30,
       worktreeHunkOffsets: [2, 12, 20],
     })
-    expect(state.worktreeDiffOffset).toBe(12)
-    expect(state.selectedWorktreeHunkIndex).toBe(1)
+    expect(state.worktreeDiffOffset).toBe(20)
+    expect(state.selectedWorktreeHunkIndex).toBe(2)
 
     state = applyInput(state, '', { escape: true })
     expect(state.activeView).toBe('status')

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -2050,10 +2050,17 @@ export function getLogInkInputEvents(
       })]
     }
 
-    // Diff view: j/k scrolls the visible diff one line. Hunk navigation
-    // moved to ]/[ so single-hunk files (longer than the preview pane)
-    // can scroll bidirectionally instead of getting pinned to a hunk
-    // anchor.
+    // Worktree (staging) diff: ↑/↓ move between hunks — the hunk is the
+    // unit you stage, so the cursor walks hunks (auto-scrolling to the
+    // selected one). Single-hunk files fall through to line-scroll so a
+    // long lone hunk stays readable; `[`/`]` remain hunk-jump aliases.
+    if (state.activeView === 'diff' && (context.worktreeHunkOffsets?.length ?? 0) > 1) {
+      return [action({
+        type: 'jumpWorktreeHunk',
+        delta: -1,
+        hunkOffsets: context.worktreeHunkOffsets as number[],
+      })]
+    }
     if (state.activeView === 'diff' && context.worktreeDiffLineCount) {
       return [action({
         type: 'pageWorktreeDiff',
@@ -2188,6 +2195,15 @@ export function getLogInkInputEvents(
       })]
     }
 
+    // Worktree (staging) diff: ↓ walks to the next hunk (see the ↑
+    // handler). Multi-hunk only; single-hunk files line-scroll.
+    if (state.activeView === 'diff' && (context.worktreeHunkOffsets?.length ?? 0) > 1) {
+      return [action({
+        type: 'jumpWorktreeHunk',
+        delta: 1,
+        hunkOffsets: context.worktreeHunkOffsets as number[],
+      })]
+    }
     if (state.activeView === 'diff' && context.worktreeDiffLineCount) {
       return [action({
         type: 'pageWorktreeDiff',
@@ -3210,6 +3226,23 @@ export function getLogInkInputEvents(
 
   if (inputValue === ' ' && state.activeView === 'diff' && context.worktreeHunkOffsets?.length) {
     return [{ type: 'toggleSelectedHunkStage' }]
+  }
+
+  // Worktree diff with no hunks (a new/untracked file) — `space` stages
+  // the whole file, since there's nothing to partial-stage.
+  if (
+    inputValue === ' ' &&
+    state.activeView === 'diff' &&
+    state.diffSource === 'worktree' &&
+    !context.worktreeHunkOffsets?.length
+  ) {
+    return [{ type: 'toggleSelectedFileStage' }]
+  }
+
+  // `a` stages/unstages the WHOLE current file from the staging diff —
+  // an escape hatch out of hunk-by-hunk back to all-or-nothing.
+  if (inputValue === 'a' && state.activeView === 'diff' && state.diffSource === 'worktree') {
+    return [{ type: 'toggleSelectedFileStage' }]
   }
 
   if (inputValue === 'z' && state.activeView === 'status' && context.worktreeFileCount) {

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -32,7 +32,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ files', 'enter diff', 'space stage', 'A stage all', 'z revert', 'i ignore', 'e/c compose'],
+      contextual: ['↑/↓ files', 'enter hunks', 'space stage', 'A stage all', 'z revert', 'i ignore', 'e/c compose'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 
@@ -42,7 +42,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['j/k hunks', 'space stage', 'z revert', 'o edit', 'e/c compose', 'y yank'],
+      contextual: ['↑/↓ hunk', 'space stage', 'a stage file', 'z discard', 'o edit', 'esc back'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -1089,7 +1089,7 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
 
   if (options.activeView === 'status') {
     return {
-      contextual: ['↑/↓ files', 'enter diff', 'space stage', 'A stage all', 'z revert', 'i ignore', 'e/c compose'],
+      contextual: ['↑/↓ files', 'enter hunks', 'space stage', 'A stage all', 'z revert', 'i ignore', 'e/c compose'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }
@@ -1124,8 +1124,11 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
         global: NORMAL_GLOBAL_HINTS,
       }
     }
+    // Worktree (staging) diff. The hunk is the unit of action: ↑/↓ walk
+    // hunks, space stages/unstages the selected one, a stages the whole
+    // file, z discards the hunk.
     return {
-      contextual: ['j/k hunks', 'space stage', 'z revert', 'o edit', 'e/c compose', 'y yank'],
+      contextual: ['↑/↓ hunk', 'space stage', 'a stage file', 'z discard', 'o edit', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/workstation/runtime/worktreeDiffBody.test.ts
+++ b/src/workstation/runtime/worktreeDiffBody.test.ts
@@ -1,0 +1,89 @@
+import { createElement } from 'react'
+import { renderWorktreeDiffBody, type WorktreeDiffBodyParams } from './worktreeDiffBody'
+import type { LogInkTheme } from '../chrome/theme'
+import type { WorktreeHunk } from '../../git/statusHunks'
+import type { LogInkComponents } from './types'
+
+type StubProps = Record<string, unknown>
+const Box = ((props: StubProps) =>
+  createElement('box', props, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+const Text = ((props: StubProps) =>
+  createElement('text', props, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+const components: LogInkComponents = { Box, Text }
+
+const theme: LogInkTheme = {
+  noColor: false,
+  ascii: false,
+  borderStyle: 'round',
+  colors: { accent: 'cyan', gitAdded: 'green', gitDeleted: 'red', muted: 'gray' },
+} as LogInkTheme
+
+// Flatten leaves to { text, color, dimColor }.
+function leaves(node: unknown, out: Array<{ text: string; color?: string; dimColor?: boolean }> = []) {
+  if (typeof node === 'string') { out.push({ text: node }); return out }
+  if (Array.isArray(node)) { node.forEach((c) => leaves(c, out)); return out }
+  if (node && typeof node === 'object' && 'props' in node) {
+    const props = (node as { props: StubProps }).props
+    const children = props.children
+    if (typeof children === 'string') {
+      out.push({ text: children, color: props.color as string | undefined, dimColor: props.dimColor as boolean | undefined })
+    } else leaves(children, out)
+  }
+  return out
+}
+
+// A worktree diff: a staged hunk (lines 0-2) then an unstaged hunk (3-5).
+const lines = [
+  '@@ -1,1 +1,1 @@',      // 0  staged hunk header
+  '-old staged',          // 1
+  '+new staged',          // 2
+  '@@ -5,1 +5,2 @@',      // 3  unstaged hunk header
+  '-old unstaged',        // 4
+  '+new unstaged',        // 5
+]
+const hunks = [
+  { state: 'staged' } as WorktreeHunk,
+  { state: 'unstaged' } as WorktreeHunk,
+]
+
+function render(selectedIndex: number) {
+  const params: WorktreeDiffBodyParams = {
+    lines, offset: 0, visibleRows: 10, width: 120, theme,
+    syntaxSpans: undefined, hunkOffsets: [0, 3], hunks, selectedIndex, keyPrefix: 'k',
+  }
+  return renderWorktreeDiffBody(createElement, components, params)
+}
+
+describe('renderWorktreeDiffBody', () => {
+  it('badges each hunk header by staged state', () => {
+    const segs = leaves(render(1))
+    const all = segs.map((s) => s.text)
+    // Staged hunk badge ● and unstaged badge ○ both present.
+    expect(all).toContain('● ')
+    expect(all).toContain('○ ')
+  })
+
+  it('draws the accent gutter bar down the SELECTED hunk only', () => {
+    const segs = leaves(render(1)) // unstaged hunk (lines 3-5) selected
+    // The accent-colored bar char appears (gutter), and there are both
+    // selected (▎) and unselected ( ) gutter cells.
+    const bars = segs.filter((s) => s.text === '▎' && s.color === 'cyan')
+    const blanks = segs.filter((s) => s.text === ' ' && s.color === 'cyan')
+    expect(bars.length).toBe(3)   // 3 lines of the selected hunk
+    expect(blanks.length).toBe(3) // 3 lines of the non-selected hunk
+  })
+
+  it('dims the body of a staged ("done") hunk', () => {
+    const segs = leaves(render(1))
+    // The staged hunk's body lines render dim.
+    const stagedBody = segs.find((s) => s.text.includes('old staged'))
+    expect(stagedBody?.dimColor).toBe(true)
+  })
+
+  it('moves the bar when a different hunk is selected', () => {
+    const seg0 = leaves(render(0)).filter((s) => s.text === '▎')
+    expect(seg0.length).toBe(3) // still 3 lines, now the first (staged) hunk
+  })
+})

--- a/src/workstation/runtime/worktreeDiffBody.ts
+++ b/src/workstation/runtime/worktreeDiffBody.ts
@@ -1,0 +1,98 @@
+/**
+ * Hunk-aware renderer for the worktree (staging) diff.
+ *
+ * Unlike the read-only commit/stash diff, the worktree diff is a
+ * *staging surface*: the user moves between hunks and stages/unstages
+ * them. To make that tactile we render three cues the plain diff lacks:
+ *
+ *   - a left **accent bar** down the currently-selected hunk, so you can
+ *     see exactly what `space` will act on;
+ *   - a per-hunk **badge** on each `@@` header — `●` (staged, green) /
+ *     `○` (unstaged, dim) — so the staged/unstaged split is visible at a
+ *     glance instead of buried in a header counter;
+ *   - **dimming** of already-staged hunks, so they read as "done" and
+ *     your eye lands on what's left.
+ *
+ * The mapping line→hunk uses `hunkOffsets` (the `@@` line indices in the
+ * diff) which line up 1:1 with `hunks` (staged hunks first, then
+ * unstaged — the same order `getWorktreeHunks` builds).
+ */
+import type * as ReactTypes from 'react'
+import { truncateCells } from '../chrome/text'
+import type { LogInkTheme } from '../chrome/theme'
+import type { WorktreeHunk } from '../../git/statusHunks'
+import type { SyntaxSpan } from '../../lib/syntax/highlightEngine'
+import type { LogInkComponents } from './types'
+import { renderDiffLine } from './diffLineRender'
+
+export type WorktreeDiffBodyParams = {
+  lines: string[]
+  offset: number
+  visibleRows: number
+  width: number
+  theme: LogInkTheme
+  syntaxSpans: Map<string, SyntaxSpan[]> | undefined
+  hunkOffsets: number[]
+  hunks: WorktreeHunk[]
+  selectedIndex: number
+  keyPrefix: string
+}
+
+/** The hunk index owning `absLine`, or -1 for pre-hunk header/label rows. */
+function hunkIndexForLine(absLine: number, hunkOffsets: number[]): number {
+  let index = -1
+  for (let k = 0; k < hunkOffsets.length; k++) {
+    if (hunkOffsets[k] <= absLine) index = k
+    else break
+  }
+  return index
+}
+
+export function renderWorktreeDiffBody(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  params: WorktreeDiffBodyParams
+): ReactTypes.ReactElement[] {
+  const { Box, Text } = components
+  const { lines, offset, visibleRows, width, theme, syntaxSpans, hunkOffsets, hunks, selectedIndex, keyPrefix } = params
+  const headerSet = new Set(hunkOffsets)
+  const accent = theme.noColor ? undefined : theme.colors.accent
+  const added = theme.noColor ? undefined : theme.colors.gitAdded
+  const codeWidth = Math.max(8, width - 5) // 2 chrome + 1 gutter + slack
+
+  const visible = lines.slice(offset, offset + visibleRows)
+  return visible.map((line, i) => {
+    const abs = offset + i
+    const key = `${keyPrefix}-${abs}`
+    const hunkIndex = hunkIndexForLine(abs, hunkOffsets)
+    const hunk = hunkIndex >= 0 ? hunks[hunkIndex] : undefined
+    const isSelected = hunkIndex >= 0 && hunkIndex === selectedIndex
+    const isStaged = hunk?.state === 'staged'
+    const bar = isSelected ? '▎' : ' '
+
+    // `@@` header row — badge + (dim) hunk position, emphasized when selected.
+    if (headerSet.has(abs)) {
+      const badge = theme.ascii ? (isStaged ? '[x] ' : '[ ] ') : (isStaged ? '● ' : '○ ')
+      const badgeColor = theme.noColor ? undefined : isStaged ? added : theme.colors.muted
+      return h(Box, { key, flexDirection: 'row' },
+        h(Text, { color: accent }, bar),
+        h(Text, { color: badgeColor, bold: isSelected }, badge),
+        h(Text, { bold: isSelected, color: isSelected ? accent : (theme.noColor ? undefined : theme.colors.muted) },
+          truncateCells(line, codeWidth))
+      )
+    }
+
+    // Body / context / pre-hunk lines.
+    // A staged hunk that ISN'T selected renders dim ("done", out of
+    // focus); the selected hunk and unstaged hunks keep full diff +
+    // syntax coloring via renderDiffLine so the focus stays vivid.
+    const content = isStaged && !isSelected && hunkIndex >= 0
+      ? h(Text, { key: `${key}-c`, dimColor: true }, truncateCells(line, codeWidth))
+      : renderDiffLine(h, Text, line, theme, syntaxSpans, codeWidth, `${key}-c`)
+
+    return h(Box, { key, flexDirection: 'row' },
+      h(Text, { color: accent }, bar),
+      content
+    )
+  })
+}

--- a/src/workstation/surfaces/diff/index.ts
+++ b/src/workstation/surfaces/diff/index.ts
@@ -43,6 +43,7 @@ import {
   renderSplitDiffBody,
 } from '../../runtime/splitDiff'
 import { renderDiffLine } from '../../runtime/diffLineRender'
+import { renderWorktreeDiffBody } from '../../runtime/worktreeDiffBody'
 import type { SyntaxSpan } from '../../../lib/syntax/highlightEngine'
 import type { LogInkComponents, LogInkContext } from '../../runtime/types'
 import {
@@ -329,10 +330,27 @@ export function renderDiffSurface(
 
   const diffLines = worktreeDiff?.lines || []
   const selectedHunk = worktreeHunks?.hunks[state.selectedWorktreeHunkIndex]
+  const totalHunks = worktreeHunks?.hunks.length ?? 0
+  const stagedHunks = worktreeHunks?.hunks.filter((hunk) => hunk.state === 'staged').length ?? 0
   const visibleDiffLines = diffLines.slice(
     state.worktreeDiffOffset,
     state.worktreeDiffOffset + visibleRows
   )
+  // Hunk-position line: badge + selected hunk's state + a staged/total
+  // progress count, so the user always sees how far through staging they
+  // are. Untracked/new files have no hunks — point them at whole-file
+  // staging instead of a dead-end "no hunks" message.
+  const hunkHeaderLine = worktreeHunksLoading
+    ? 'Hunks loading…'
+    : worktreeDiff?.untracked
+      ? (theme.ascii ? 'New file — press space to stage it whole.' : '✚ New file — press space to stage it whole.')
+      : totalHunks
+        ? `Hunk ${state.selectedWorktreeHunkIndex + 1}/${totalHunks} · ${
+          selectedHunk?.state === 'staged'
+            ? (theme.ascii ? '[x] staged' : '● staged')
+            : (theme.ascii ? '[ ] unstaged' : '○ unstaged')
+        } · ${stagedHunks}/${totalHunks} staged`
+        : 'No stageable hunks for this file.'
   const headerLines: string[] = isLogInkContextKeyLoading(contextStatus, 'worktree')
     ? ['Loading file context...']
     : worktreeDiffLoading
@@ -341,11 +359,7 @@ export function renderDiffSurface(
       ? [
         // File path is already shown in the panel title bar (right) —
         // no redundant "Selected file:" line here.
-        worktreeHunksLoading
-          ? 'Hunks loading...'
-          : worktreeHunks?.hunks.length
-            ? `Hunk ${state.selectedWorktreeHunkIndex + 1}/${worktreeHunks.hunks.length} ${selectedHunk?.state || ''}`
-            : 'No stageable hunks for this file.',
+        hunkHeaderLine,
         `Lines ${Math.min(state.worktreeDiffOffset + 1, diffLines.length || 1)}-${Math.min(state.worktreeDiffOffset + visibleDiffLines.length, diffLines.length)}/${diffLines.length}`,
         '',
       ]
@@ -372,9 +386,17 @@ export function renderDiffSurface(
     dimColor: index > 0,
   }, truncateCells(line, 140))),
   ...(showDiffLines
-    ? visibleDiffLines.map((line, index) => renderDiffLine(
-      h, Text, line, theme, syntaxSpans, 140,
-      `diff-surface-line-${state.worktreeDiffOffset + index}`
-    ))
+    ? renderWorktreeDiffBody(h, components, {
+      lines: diffLines,
+      offset: state.worktreeDiffOffset,
+      visibleRows,
+      width,
+      theme,
+      syntaxSpans,
+      hunkOffsets: worktreeDiff?.hunkOffsets || [],
+      hunks: worktreeHunks?.hunks || [],
+      selectedIndex: state.selectedWorktreeHunkIndex,
+      keyPrefix: 'diff-surface-line',
+    })
     : []))
 }


### PR DESCRIPTION
Redesigns the worktree **staging diff** so per-hunk staging feels deliberate and *visible*, addressing the "I was always staging the entire diff" confusion. (Per-hunk staging already worked mechanically — the problem was you couldn't see it.)

## What changed

**See the hunk you're acting on.** An accent **`▎` gutter bar** runs down the selected hunk; other hunks get a blank gutter. `space` now visibly acts on *that* block.

**See staged state at a glance.** Each `@@` header gets a badge — **`●` staged** (green) / **`○` unstaged** (dim) — and already-staged (non-selected) hunks render dim ("done"), so your eye lands on what's left. The header reads `Hunk 2/5 · ○ unstaged · 1/5 staged` (live progress).

**Keys that match reality.** `↑/↓` (and `j/k`) now walk **hunks** in the worktree diff (auto-scrolling to the selected one) when there's more than one — single-hunk files keep line-scroll, `[`/`]` stay as hunk aliases. The footer no longer lies: `↑/↓ hunk · space stage · a stage file · z discard · esc back` (it used to say `j/k hunks` while `j/k` scrolled lines).

**Escape hatches + edge cases.** `a` stages/unstages the **whole file** from the diff (bail out of granular mode). Untracked/new files (no hunks) now stage whole on `space` with a clear `✚ New file — press space to stage it whole` header instead of the old dead-end "No stageable hunks."

**Discoverability.** The status footer points the way: `enter hunks`.

## Scope
Per the design call: tactile **hunk-level** staging, kept **in the enhanced diff view** (no separate mode, no line-level staging — that's a possible future follow-up).

## Validation
- `tsc` + `eslint` clean
- `jest`: 1134 workstation tests green — new `worktreeDiffBody` render tests (per-hunk badges, selected-hunk bar placement + movement, staged-hunk dimming), updated nav + footer assertions
- Verified visually via a new `ui-staging-hunks` screenshot recipe (badge + bar + progress header + footer all render correctly in a real terminal)