### PR TITLE
feat(screenshot): staging-hunks demo gif + recipe; fix diff title filename

### DIFF
--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -862,8 +862,10 @@ export const RECIPES: ScreenshotRecipe[] = [
     dimensions: { cols: 150, rows: 38 },
     actions: [
       { kind: 'sleep', ms: 3200 },
-      { kind: 'key', key: 'Down' },
-      { kind: 'sleep', ms: 400 },
+      // Open an unstaged (modified) file so the ○ badge + bar read as
+      // "ready to stage" rather than already-staged.
+      { kind: 'key', key: 'Down', count: 14 },
+      { kind: 'sleep', ms: 600 },
       { kind: 'key', key: 'Enter' },
       { kind: 'sleep', ms: 2200 },
     ],
@@ -1244,6 +1246,29 @@ export const RECIPES: ScreenshotRecipe[] = [
       { kind: 'sleep', ms: 500 },
       { kind: 'type', text: 'q' },
       { kind: 'sleep', ms: 1200 },
+    ],
+  },
+  {
+    name: 'demo-staging-hunks',
+    description: 'Tactile hunk staging: open a changed file, see the ○ badge + selected-hunk bar, stage it (badge flips ●), file moves to Staged',
+    scenario: 'dirty-many-files',
+    command: 'ui --view status',
+    emitGif: true,
+    dimensions: { cols: 150, rows: 38 },
+    actions: [
+      { kind: 'sleep', ms: 3200 },
+      // Drop into the Unstaged group (past the staged files + headers).
+      { kind: 'key', key: 'Down', count: 14 },
+      { kind: 'sleep', ms: 800 },
+      // Open the file's staging diff — ○ unstaged badge + accent hunk bar.
+      { kind: 'key', key: 'Enter' },
+      { kind: 'sleep', ms: 2400 },
+      // Stage the cursored hunk — the ○ badge flips to ● and "0/1" → "1/1".
+      { kind: 'type', text: ' ' },
+      { kind: 'sleep', ms: 2000 },
+      // Back out — the file has moved into the Staged group.
+      { kind: 'type', text: '<' },
+      { kind: 'sleep', ms: 1800 },
     ],
   },
 ]

--- a/bin/syncScreenshots.ts
+++ b/bin/syncScreenshots.ts
@@ -106,6 +106,9 @@ const SITE_RECIPES = [
   'demo-workspace-add-repo',
   'demo-workspace-clone',
   'demo-workstation-using',
+  // Hunk staging
+  'demo-staging-hunks',
+  'ui-staging-hunks',
   // Themed-view showcase — diff + status across a curated theme set
   'ui-diff-theme-catppuccin',
   'ui-diff-theme-gruvbox',
@@ -207,6 +210,8 @@ const FILENAME_MAP: Record<string, string[]> = {
   'demo-workspace-add-repo': ['demo-workspace-add-repo.gif'],
   'demo-workspace-clone': ['demo-workspace-clone.gif'],
   'demo-workstation-using': ['demo-workstation-using.gif'],
+  'demo-staging-hunks': ['demo-staging-hunks.gif'],
+  'ui-staging-hunks': ['staging-hunks.png'],
   'ui-diff-theme-catppuccin': ['diff-theme-catppuccin.png'],
   'ui-diff-theme-gruvbox': ['diff-theme-gruvbox.png'],
   'ui-diff-theme-dracula': ['diff-theme-dracula.png'],

--- a/src/workstation/surfaces/diff/index.ts
+++ b/src/workstation/surfaces/diff/index.ts
@@ -379,7 +379,10 @@ export function renderDiffSurface(
   },
   h(Box, { justifyContent: 'space-between' },
     h(Text, { bold: true }, panelTitle('Diff', focused)),
-    h(Text, { dimColor: true }, worktreeFile ? worktreeFile.path : 'no file')
+    // Use the path of the file actually being diffed (the grouped/visible
+    // selection feeds the loaded diff) — `worktreeFile` indexes the raw,
+    // ungrouped file list and can name a different file than the diff body.
+    h(Text, { dimColor: true }, worktreeDiff?.filePath || worktreeFile?.path || 'no file')
   ),
   ...headerLines.map((line, index) => h(Text, {
     key: `diff-surface-header-${index}`,


### PR DESCRIPTION
Wires up media for the tactile hunk-staging redesign (#1130), plus a small correctness fix.

## Recipes
- **`demo-staging-hunks`** (gif) — open a changed file → `○ unstaged` badge + the selected-hunk accent bar → `space` stages it (`●` + the staged count ticks) → back out, the file has moved into the Staged group.
- **`ui-staging-hunks`** (static) — the staging diff on an unstaged file: badge, selected-hunk bar, and `0/1 staged` progress.
- Both wired into `syncScreenshots` (`demo-staging-hunks.gif` / `staging-hunks.png`).

## Bug fix (surfaced by the screenshot)
The worktree diff **title bar showed the wrong filename** — it indexed the raw, ungrouped file list (`worktree.files[selectedWorktreeFileIndex]`), which can name a different file than the diff body (the body uses the grouped/visible selection). Now it uses the diffed file's own `worktreeDiff.filePath`, so title and content always agree.

## Validation
`tsc` + `eslint` clean; 799 workstation tests green; both recipes generated locally with `vhs` and the static frame verified (title now matches the diff, badge + bar + progress all render).

The `.www` page update (swapping the Key Workflows "hunk staging" demo to this new gif) lands as a separate git-co.co PR.