### PR TITLE
fix(ui): honest + trimmed diff/status footer hints

### DIFF
--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -32,7 +32,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ files', 'enter hunks', 'space stage', 'A stage all', 'z revert', 'i ignore', 'e/c compose'],
+      contextual: ['↑/↓ files', 'enter hunks', 'space stage', 'A stage all', 'z revert', 'e/c compose'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -1089,7 +1089,7 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
 
   if (options.activeView === 'status') {
     return {
-      contextual: ['↑/↓ files', 'enter hunks', 'space stage', 'A stage all', 'z revert', 'i ignore', 'e/c compose'],
+      contextual: ['↑/↓ files', 'enter hunks', 'space stage', 'A stage all', 'z revert', 'e/c compose'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }
@@ -1102,16 +1102,19 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
     const splitToggleHint = options.diffViewMode === 'split' ? 'd unified' : 'd split'
     if (options.diffSource === 'stash') {
       return {
-        contextual: ['j/k lines', '[/] file', 'c cherry-pick', 'H apply hunk', 'o edit', splitToggleHint, 'y yank', 'esc back'],
+        contextual: ['j/k lines', '[/] file', 'c cherry-pick', 'H apply hunk', splitToggleHint, 'esc back'],
         global: NORMAL_GLOBAL_HINTS,
       }
     }
     if (options.diffSource === 'commit') {
       // Commit-diff explore: read-only diff, but `c` cherry-picks the
       // cursored file from the commit into the worktree, and `H`
-      // (or `gH` for index) applies just the cursored hunk.
+      // (or `gH` for index) applies just the cursored hunk. `j/k`
+      // line-scroll the diff body; `[`/`]` jump between hunks — the
+      // footer labels match the actual handlers (commit diff has no
+      // per-file `[/]` jump; that's the stash diff).
       return {
-        contextual: ['j/k hunks', '[/] file', 'c cherry-pick', 'H apply hunk', splitToggleHint, 'y/Y yank', 'esc back'],
+        contextual: ['j/k lines', '[/] hunk', 'c cherry-pick', 'H apply hunk', splitToggleHint, 'esc back'],
         global: NORMAL_GLOBAL_HINTS,
       }
     }


### PR DESCRIPTION
## What

Two related footer-hint cleanups surfaced by the TUI audit.

### 1. The commit-diff footer was lying

The commit-diff footer claimed `j/k hunks` and `[/] file`, but the handlers do the **opposite**:
- `j/k` line-scroll the diff body (`pageDetailPreview`)
- `[`/`]` jump between hunks (`jumpCommitDiffHunk` over `commitDiffHunkOffsets`)

Commit diff has no per-file `[/]` jump — that's the *stash* diff (`stashDiffFileOffsets`), whose footer was already honest. Relabeled the commit row to `j/k lines · [/] hunk`.

The footer is a contract; it should never name a key that does something else.

### 2. Trimmed each contextual row to its highest-value actions

Pushed secondary actions to the `?` help overlay (which documents them by context):
- **status:** drop `i ignore`
- **stash:** drop `o edit`, `y yank`
- **commit:** drop `y/Y yank` (plus the honesty relabel)

Worktree-diff and the global hint row are unchanged.

## Test

- `npx tsc --noEmit` clean
- `npx jest src/commands/log/inkKeymap.test.ts` — 42 passed
- `npx eslint` clean