### PR TITLE
fix(ui): trim header breadcrumb chrome (drop ← < and ⊘ no PR)

### DIFF
--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -366,14 +366,14 @@ describe('log Ink keymap', () => {
     expect(helpText).toContain('tab Move focus to the next panel.')
   })
 
-  it('formats the navigation breadcrumb with a back-hint cue when nested', () => {
+  it('formats the navigation breadcrumb as pure location (no back-hint)', () => {
     expect(formatLogInkBreadcrumb([])).toBe('')
     expect(formatLogInkBreadcrumb(['history'])).toBe('')
-    expect(formatLogInkBreadcrumb(['status'])).toBe('status   ← <')
-    expect(formatLogInkBreadcrumb(['history', 'diff'])).toBe('history › diff   ← <')
+    expect(formatLogInkBreadcrumb(['status'])).toBe('status')
+    expect(formatLogInkBreadcrumb(['history', 'diff'])).toBe('history › diff')
     expect(formatLogInkBreadcrumb(['history', 'status', 'diff']))
-      .toBe('history › status › diff   ← <')
-    expect(formatLogInkBreadcrumb(['history', 'compose'])).toBe('history › compose   ← <')
+      .toBe('history › status › diff')
+    expect(formatLogInkBreadcrumb(['history', 'compose'])).toBe('history › compose')
   })
 
   describe('formatLogInkRepoBreadcrumb (#931)', () => {
@@ -422,15 +422,15 @@ describe('log Ink keymap', () => {
     })
 
     it('renders only the view crumb when the repo crumb is empty', () => {
-      expect(combineLogInkBreadcrumbSegments('', 'history › diff   ← <'))
-        .toBe('  history › diff   ← <')
+      expect(combineLogInkBreadcrumbSegments('', 'history › diff'))
+        .toBe('  history › diff')
     })
 
     it('joins repo + view with extra spacing when both are present', () => {
       expect(combineLogInkBreadcrumbSegments(
         'coco › vendor/lib   ← esc',
-        'history › diff   ← <',
-      )).toBe('  coco › vendor/lib   ← esc    history › diff   ← <')
+        'history › diff',
+      )).toBe('  coco › vendor/lib   ← esc    history › diff')
     })
 
     it('matches the leading-spaces convention the existing view-only path used', () => {
@@ -438,8 +438,8 @@ describe('log Ink keymap', () => {
       // stack was nested. This contract assertion locks in the legacy
       // behavior so the visible header doesn't shift for non-nested
       // sessions.
-      const viewOnly = combineLogInkBreadcrumbSegments('', 'status   ← <')
-      expect(viewOnly).toBe('  status   ← <')
+      const viewOnly = combineLogInkBreadcrumbSegments('', 'status')
+      expect(viewOnly).toBe('  status')
     })
   })
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -908,9 +908,10 @@ export function formatLogInkBreadcrumb(viewStack: LogInkView[]): string {
     return ''
   }
 
-  // Trailing back-hint (P2.5) reminds the user how to walk back when
-  // they're nested deeper than the root view.
-  return `${viewStack.join(' › ')}   ← <`
+  // Pure location breadcrumb — no trailing back-hint. The footer's
+  // global `< back` hint already names the walk-back key, so repeating
+  // `← <` on every nested view was redundant header chrome (TUI audit).
+  return viewStack.join(' › ')
 }
 
 /**
@@ -918,9 +919,10 @@ export function formatLogInkBreadcrumb(viewStack: LogInkView[]): string {
  * for the chrome header. Returns an empty string for a root-only stack
  * so the header stays compact when nothing has been pushed.
  *
- * The trailing `← esc` reminds the user that Esc is the way out — same
- * shape as the view breadcrumb's `← <` so the two read consistently.
- * The repo breadcrumb shows in addition to the view breadcrumb when
+ * The trailing `← esc` reminds the user that Esc (not `<`) pops the
+ * repo stack — a distinct key from the footer's global `< back`, so
+ * unlike the view breadcrumb (pure location) the repo crumb keeps its
+ * hint. The repo breadcrumb shows in addition to the view breadcrumb when
  * both stacks are non-trivial; the chrome layer is responsible for
  * laying them out side by side.
  *

--- a/src/workstation/chrome/headerChips.test.ts
+++ b/src/workstation/chrome/headerChips.test.ts
@@ -36,14 +36,14 @@ describe('buildHeaderChips', () => {
     // Default state: clean repo, no PR, no breadcrumb, NORMAL mode.
     // The chip order is load-bearing for scan-ability — identity chips
     // (app/repo/branch) come first, then state (dirty/PR), then
-    // navigation (breadcrumb/loading), then mode.
+    // navigation (breadcrumb/loading), then mode. With no PR loaded the
+    // PR chip is omitted entirely (no "no PR" placeholder).
     const chips = buildHeaderChips(makeInput())
     expect(chips.map((c) => c.id)).toEqual([
       'app',
       'repo',
       'branch',
       'dirty',
-      'pr',
       'mode',
     ])
   })
@@ -75,11 +75,9 @@ describe('buildHeaderChips', () => {
     expect(chips.find((c) => c.id === 'bisecting')).toBeUndefined()
   })
 
-  it('renders a muted "no PR" chip when no pull request is loaded', () => {
+  it('omits the PR chip entirely when no pull request is loaded', () => {
     const chips = buildHeaderChips(makeInput({ pullRequest: undefined }))
-    const pr = chips.find((c) => c.id === 'pr')!
-    expect(pr.label).toBe('⊘ no PR')
-    expect(pr.dim).toBe(true)
+    expect(chips.find((c) => c.id === 'pr')).toBeUndefined()
   })
 
   it('renders the PR chip with state and glyph when a pull request is loaded', () => {
@@ -107,7 +105,10 @@ describe('buildHeaderChips', () => {
   })
 
   it('inserts the breadcrumb chip after PR when a view is pushed', () => {
-    const chips = buildHeaderChips(makeInput({ breadcrumb: 'diff · stash' }))
+    const chips = buildHeaderChips(makeInput({
+      breadcrumb: 'diff · stash',
+      pullRequest: { number: 1, state: 'open' },
+    }))
     const ids = chips.map((c) => c.id)
     expect(ids.indexOf('view')).toBe(ids.indexOf('pr') + 1)
     expect(chips.find((c) => c.id === 'view')!.label).toBe('diff · stash')
@@ -150,16 +151,14 @@ describe('buildHeaderChips', () => {
   })
 
   describe('ASCII mode', () => {
-    it('substitutes printable single-char glyphs for the dirty / clean / bisect / no-PR / branch chips', () => {
+    it('substitutes printable single-char glyphs for the dirty / clean / bisect / branch chips', () => {
       const theme = createLogInkTheme({ noColor: false, ascii: true })
       // Clean + no PR + no bisect — the most common state.
       const baseline = buildHeaderChips(makeInput({ theme }))
       const branch = baseline.find((c) => c.id === 'branch')!
       const dirty = baseline.find((c) => c.id === 'dirty')!
-      const pr = baseline.find((c) => c.id === 'pr')!
       expect(branch.label).toBe('git: main')
       expect(dirty.label).toBe('+ clean')
-      expect(pr.label).toBe('- no PR')
 
       // Dirty branch ASCII fallback.
       const dirtyChips = buildHeaderChips(makeInput({ theme, dirty: true }))
@@ -189,9 +188,9 @@ describe('measureHeaderChipsWidth', () => {
       theme: createLogInkTheme({ noColor: false, ascii: true }),
     }))
     // 'AB' (2) + ' · ' (3) + 'CD' (2) + ' · ' (3) + 'git: EF' (7) +
-    // ' · ' (3) + '+ clean' (7) + ' · ' (3) + '- no PR' (7) +
-    // ' · ' (3) + '[NORMAL]' (8) = 48
-    expect(measureHeaderChipsWidth(chips)).toBe(48)
+    // ' · ' (3) + '+ clean' (7) + ' · ' (3) + '[NORMAL]' (8) = 38.
+    // No PR loaded → no PR chip (and no extra separator).
+    expect(measureHeaderChipsWidth(chips)).toBe(38)
   })
 })
 

--- a/src/workstation/chrome/headerChips.ts
+++ b/src/workstation/chrome/headerChips.ts
@@ -76,7 +76,7 @@ export type BuildHeaderChipsInput = {
   bisecting: boolean
   /**
    * Pull request state for the current branch, if any. `undefined`
-   * renders the muted "no PR" chip instead.
+   * omits the PR chip entirely (no "no PR" placeholder).
    */
   pullRequest: { number: number; state: string; isDraft?: boolean } | undefined
   /**
@@ -175,10 +175,11 @@ export function buildHeaderChips(input: BuildHeaderChipsInput): HeaderChip[] {
     })
   }
 
-  // PR state. When present, the chip uses the PR-state glyph + a short
-  // label ("PR #1234 OPEN" / "PR #1234 DRAFT"). When absent, a muted
-  // "no PR" chip so users know the system DID look (vs. the bar just
-  // being blank).
+  // PR state. Shown only when a PR actually exists — the chip uses the
+  // PR-state glyph + a short label ("PR #1234 OPEN" / "PR #1234 DRAFT").
+  // The old always-on "no PR" chip spent a permanent header segment to
+  // report a negative default state on every screen; dropping it keeps
+  // the state cluster about what *is* true (TUI audit).
   if (input.pullRequest) {
     const prGlyph = getPullRequestStateGlyph(
       { ...input.pullRequest, isDraft: Boolean(input.pullRequest.isDraft) },
@@ -195,14 +196,6 @@ export function buildHeaderChips(input: BuildHeaderChipsInput): HeaderChip[] {
       label,
       color: prGlyph.color,
       dim: prGlyph.dim,
-      bold: false,
-    })
-  } else {
-    chips.push({
-      id: 'pr',
-      label: theme.ascii ? '- no PR' : '⊘ no PR',
-      color: theme.colors.muted,
-      dim: true,
       bold: false,
     })
   }

--- a/src/workstation/runtime/header.ts
+++ b/src/workstation/runtime/header.ts
@@ -2,7 +2,10 @@
  * Title-bar renderer. Surfaces the workstation's identity + navigation
  * state as a row of small visually-distinct chips:
  *
- *   coco · gfargo/coco · ⎇ main · ✓ clean · ⊘ no PR · [NORMAL]
+ *   coco · gfargo/coco · ⎇ main · ✓ clean · [NORMAL]
+ *
+ * The PR chip is appended only when a pull request exists (e.g.
+ * `· ⊠ PR #1234 OPEN`); there's no "no PR" placeholder chip.
  *
  * Per-chip color/glyph treatment lets the user scan in chunks ("what
  * app, what repo, what branch, how clean, what PR state, what mode")


### PR DESCRIPTION
## What

Two clutter cuts from the TUI audit — both remove header chrome that restates something already available elsewhere.

### 1. Drop the trailing `← <` back-hint from the view breadcrumb

The breadcrumb showed `history › diff   ← <` on every nested view. The footer's global hint row already carries `< back`, so the `← <` was a navigation hint duplicated into the header. The view breadcrumb is now a pure **location** indicator (`history › diff`).

The *repo* breadcrumb keeps its `← esc` cue — Esc-pops-repo-stack is a distinct key the footer's `< back` doesn't name, so that hint still earns its place.

### 2. Drop the always-on `⊘ no PR` chip

The header rendered a muted `⊘ no PR` chip on every screen where the branch had no PR — a permanent segment reporting a negative default state. The PR chip now appears **only when a PR exists** (`⊠ PR #1234 OPEN`).

Net: the header's state cluster (`repo · branch · ✓ clean · [NORMAL]`) now only says what *is* true.

## Test

- `npx tsc --noEmit` clean
- `npx jest src/workstation/chrome src/workstation/runtime` — 635 passed
- `npx jest src/commands/log/inkKeymap.test.ts` — passed
- `npx eslint` clean
- Updated `headerChips`/breadcrumb tests, the width-math test, and stale doc comments