### PR TITLE
docs(ui): deliberate keymap map + collision-guard test

### DIFF
--- a/src/commands/log/inkKeymap.collisions.test.ts
+++ b/src/commands/log/inkKeymap.collisions.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Keymap collision guard.
+ *
+ * The workstation deliberately overloads single keys across views (see
+ * `src/workstation/KEYMAP.md`). Those overloads live in the imperative
+ * resolver (`inkInput.ts`) and are disambiguated by dispatch precedence —
+ * this test can't see them.
+ *
+ * What it CAN guard is the declarative binding table (`LOG_INK_KEY_BINDINGS`),
+ * the source for the `?` help overlay and the `:` palette. Two bindings that
+ * claim the same key in the same context there is almost always an accident:
+ * one of them will be unreachable or mislabeled. This test fails the build the
+ * moment that happens, so a new binding can't silently shadow an existing one.
+ *
+ * If a collision is ever intentional (e.g. two ids that the resolver gates on
+ * finer state than `contexts` can express), add it to ALLOWED_COLLISIONS with a
+ * comment justifying why — that keeps the exception visible and reviewed.
+ */
+import { LOG_INK_KEY_BINDINGS } from './inkKeymap'
+
+/**
+ * Intentional, reviewed `(context::key)` collisions. Keep empty unless a
+ * specific overload genuinely needs both ids in the same coarse context; each
+ * entry must carry a justification comment.
+ */
+const ALLOWED_COLLISIONS = new Set<string>([])
+
+describe('LOG_INK_KEY_BINDINGS collision guard', () => {
+  it('never binds the same key to two ids in the same context', () => {
+    const seen = new Map<string, string[]>()
+
+    for (const binding of LOG_INK_KEY_BINDINGS) {
+      for (const context of binding.contexts) {
+        for (const key of binding.keys) {
+          const slot = `${context}::${key}`
+          const ids = seen.get(slot) ?? []
+          ids.push(binding.id)
+          seen.set(slot, ids)
+        }
+      }
+    }
+
+    const collisions = [...seen.entries()]
+      .filter(([slot, ids]) => ids.length > 1 && !ALLOWED_COLLISIONS.has(slot))
+      .map(([slot, ids]) => `${slot} → ${ids.join(', ')}`)
+
+    expect(collisions).toEqual([])
+  })
+
+  it('every binding declares at least one key and one context', () => {
+    // A binding with no key or no context can never fire and can never be
+    // discovered — almost certainly a mistake during a refactor.
+    const broken = LOG_INK_KEY_BINDINGS.filter(
+      (b) => b.keys.length === 0 || b.contexts.length === 0
+    ).map((b) => b.id)
+
+    expect(broken).toEqual([])
+  })
+})

--- a/src/workstation/KEYMAP.md
+++ b/src/workstation/KEYMAP.md
@@ -1,0 +1,356 @@
+# Workstation Keymap — the deliberate map
+
+The workstation is keyboard-only and key-dense (lazygit-style): single letters
+do a lot, and the *same* letter often means different things in different
+views. That density is intentional, but it only stays safe if the overloads are
+**deliberate** — every reused key disambiguated by a known rule, never by
+accident.
+
+This document is the canonical map. It exists to answer three questions:
+
+1. **What does key X do here?** → the per-view tables.
+2. **Is key X free to use for a new action in view Y?** → the overload table +
+   the dispatch model.
+3. **Why didn't my new binding fire?** → the dispatch precedence rules.
+
+It is paired with a regression guard: `inkKeymap.collisions.test.ts` fails the
+build if two declarative bindings (`LOG_INK_KEY_BINDINGS`) ever claim the same
+key in the same context. The guard can't see the imperative overloads in
+`inkInput.ts` — those are what this doc is for.
+
+> Source of truth is the code. `inkInput.ts` is the resolver (what each key
+> *does*); `inkKeymap.ts` holds the declarative binding table, footer hints,
+> and help sections. When you change a binding, update this map in the same PR.
+
+---
+
+## The dispatch model (read this first)
+
+`resolveLogInkInput` (in `inkInput.ts`) is a single ordered function. A keypress
+walks the branches **top to bottom** and the *first* match wins. The order
+encodes precedence:
+
+```
+1.  Overlays & modes        Help open? input-prompt open? filter mode?  ← claim the key first
+2.  Global chords           `g`-prefix pending → chord continuation
+3.  Global single keys      q, ?, /, :, <, Ctrl+C, Tab, arrows, page keys
+4.  Exact-context handlers   activeView + diffSource + focus all checked
+                             e.g. (diff && diffSource==='stash' && selectedFile)
+5.  Predicate handlers       isBranchActionTarget(), isCompareFlowTarget(), …
+                             (view OR sidebar-tab equivalence)
+6.  Fallback workflow lookup getLogInkWorkflowActionByKey() — the LAST resort
+```
+
+Two consequences worth internalizing:
+
+- **Context-specific always beats global.** A view that intercepts `D`
+  (worktrees) or `C` (conflicts) returns before the fallback workflow
+  dispatcher can fire. That's how the same key safely means different things.
+- **Negation guards are fragile.** Some globals are gated as
+  `activeView !== 'conflicts'`. Adding a new view that wants that key means
+  finding and updating the negation. Prefer an explicit allowlist of views when
+  you add a new global. (See *Risks* below.)
+
+---
+
+## Modes (input gating)
+
+The header's `[MODE]` chip tells the user which keystroke contract is live:
+
+| Mode | Entered by | What changes |
+|------|------------|--------------|
+| `NORMAL` | default | Single-key bindings active. |
+| `EDIT` | `e` (inline commit-message edit) | Typing edits the buffer; most bindings suppressed. |
+| `FILTER` | `/` | Typing builds the filter; `Enter` applies, `Esc` cancels. |
+
+Input prompts (branch name, merge strategy, pathspec, PR comment, …) and the
+split-plan overlay also claim the keyboard while open — their footer hint sets
+replace the view's, because the underlying bindings are intercepted.
+
+---
+
+## Global keys
+
+Available in every view (unless an overlay/mode has claimed the keyboard):
+
+| Key | Action |
+|-----|--------|
+| `q` | Quit |
+| `Ctrl+C` | Quit (hard) |
+| `?` | Toggle help overlay |
+| `:` | Command palette |
+| `/` | Enter filter mode |
+| `g` | Chord prefix (see below) |
+| `<` | Pop view / go back |
+| `Esc` | Pop view; pop nested-repo frame; close overlay |
+| `Tab` / `Shift+Tab` | Focus next / previous pane |
+| `↑`/`k`, `↓`/`j` | Move selection / scroll |
+| `←`/`→` | Switch sidebar or inspector tab (focus-dependent) |
+| `PageUp` / `PageDown` | Page scroll |
+| `n` / `N` | Next / previous search match |
+| `y` / `Y` | Yank identifier (long / short) for the cursored item |
+
+> `<` and `Esc` both walk back, but `Esc` also pops the **repo** stack — that's
+> why the repo breadcrumb shows `← esc` while the view breadcrumb is pure
+> location. The footer's global `< back` covers the common case.
+
+---
+
+## `g`-chord continuations (view selectors)
+
+`g` then a second key jumps to a view. This is the primary navigation surface;
+the which-key overlay lists them live when you press `g`.
+
+| Chord | Jumps to |
+|-------|----------|
+| `g h` | History |
+| `g s` | Status (staging) |
+| `g d` | Diff (worktree) |
+| `g c` | Compose (commit message) |
+| `g b` | Branches |
+| `g t` | Tags |
+| `g z` | Stashes |
+| `g w` | Worktrees |
+| `g p` | Pull request |
+| `g P` | PR triage |
+| `g i` | Issues |
+| `g x` | Conflicts |
+| `g r` | Reflog |
+| `g B` | Bisect |
+| `g M` | Submodules |
+| `g T` | Changelog |
+| `g H` | Apply cursored hunk to index (`git apply --cached`) |
+
+---
+
+## Per-view keys
+
+Only the view-local keys are listed; global keys and `g`-chords apply
+everywhere. "↑/↓ select" is implied in every list view.
+
+### History / log
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Open diff for the selected commit |
+| `d` | Toggle unified / split diff |
+| `\` | Toggle the graph column |
+| `c` | Cherry-pick the commit |
+| `R` | Revert the commit |
+| `Z` | Reset branch tip here (mode prompt) |
+| `i` | Interactive rebase from the commit's parent |
+| `B` | Create branch here |
+| `s` | Sort / skip |
+| `r` | Refresh |
+
+### Status (staging)
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Open the file's hunk diff |
+| `Space` | Stage / unstage the cursored file |
+| `A` | Stage everything (`git add -A`) |
+| `+` | Stage by pathspec (prompt) |
+| `z` | Revert the file (confirm) |
+| `i` | Open the `.gitignore` picker |
+| `o` | Open the file in `$EDITOR` |
+| `1`/`2`/`3` | Toggle staged / unstaged / untracked visibility |
+| `e` / `c` | Compose: inline edit / commit |
+
+### Diff — worktree (staging diff)
+
+The hunk is the unit of action here.
+
+| Key | Action |
+|-----|--------|
+| `↑`/`↓` | Walk hunks (single-hunk files fall back to line-scroll) |
+| `[` / `]` | Previous / next hunk |
+| `Space` | Stage / unstage the selected hunk (whole file if untracked) |
+| `a` | Stage / unstage the whole file |
+| `z` | Discard the hunk (confirm) |
+| `o` | Open the file in `$EDITOR` |
+
+### Diff — commit (read-only exploration)
+
+| Key | Action |
+|-----|--------|
+| `j`/`k` | Line-scroll the diff body |
+| `[` / `]` | Previous / next hunk |
+| `c` | Cherry-pick the cursored file into the worktree |
+| `H` | Apply the cursored hunk to the worktree |
+| `d` | Toggle unified / split |
+
+### Diff — stash (read-only)
+
+| Key | Action |
+|-----|--------|
+| `j`/`k` | Line-scroll the diff body |
+| `[` / `]` | Previous / next **file** (stash diffs index by file) |
+| `c` | Restore the cursored file from the stash |
+| `H` | Apply the cursored hunk to the worktree |
+| `o` | Open the file in `$EDITOR` |
+| `d` | Toggle unified / split |
+
+### Diff — compare (two refs)
+
+| Key | Action |
+|-----|--------|
+| `j`/`k` | Line-scroll |
+| `d` | Toggle unified / split |
+
+### Compose (commit message)
+
+| Key | Action |
+|-----|--------|
+| `e` | Inline edit the message |
+| `E` | Edit in `$EDITOR` |
+| `c` | Commit |
+| `I` | AI-draft the message |
+| `S` | Start the commit-split flow |
+| `A` | Stage everything |
+| `+` | Stage by pathspec |
+
+### Branches
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Check out |
+| `+` | Create branch (prompt) |
+| `R` | Rename (prompt) |
+| `D` | Delete (confirm) |
+| `u` | Set upstream (prompt) |
+| `F` / `U` / `P` | Fetch / pull / push the branch |
+| `m` | Mark / unmark compare base |
+
+### Tags
+
+| Key | Action |
+|-----|--------|
+| `+` | Create tag (prompt) |
+| `P` | Push tag to origin |
+| `T` / `R` | Delete tag (remote) |
+| `m` | Mark / unmark compare base |
+
+### Stashes
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Open the stash diff |
+| `a` | Apply (keep) |
+| `p` | Pop (apply + drop) |
+| `X` | Drop (confirm) |
+
+### Conflicts
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Open the conflicted file's diff |
+| `s` | Stage (mark resolved) |
+| `u` / `U` | Keep theirs / keep ours |
+| `o` | Open in `$EDITOR` |
+| `C` | Continue the in-progress operation (only when no conflicts remain) |
+
+### Pull request / PR triage
+
+| Key | Action |
+|-----|--------|
+| `m` | Merge (strategy prompt) |
+| `a` | Approve (confirm) |
+| `R` | Request changes (review prompt) |
+| `c` | Comment (prompt) |
+| `x` | Close (confirm) |
+| `O` | Open in browser (triage) |
+| `L` / `A` | Label / assign (triage, prompt) |
+| `f` | Cycle the PR filter (triage) |
+
+### Issues
+
+| Key | Action |
+|-----|--------|
+| `O` | Open in browser |
+| `c` | Comment (prompt) |
+| `L` / `A` | Label / assign (prompt) |
+| `x` / `X` | Close / reopen (confirm) |
+| `f` | Cycle the issue filter |
+
+### Bisect
+
+| Key | Action |
+|-----|--------|
+| `g=` | Mark good |
+| `b` | Mark bad |
+| `s` | Skip / start wizard |
+| `x` | Reset bisect |
+| `R` | Run custom command |
+
+### Worktrees
+
+| Key | Action |
+|-----|--------|
+| `D` | Remove worktree **and** delete its branch (intercepts the global branch-delete) |
+| `W` | Remove worktree only |
+
+---
+
+## The overload table
+
+These keys mean different things in different views. **Before binding one of
+these in a new view, confirm your view's meaning doesn't surprise a user
+arriving from another view.** Disambiguation is by the dispatch model above.
+
+| Key | Meanings by context |
+|-----|---------------------|
+| `c` | history → cherry-pick commit · commit/stash diff → cherry-pick/restore file · status/diff/compose → commit · PR/PR-triage → comment · issues → comment |
+| `C` | conflicts → continue operation · compose → *blocked* (guard against fat-finger PR-create) · elsewhere → create PR |
+| `R` | history → revert · branches → rename · tags → delete-remote · PR/PR-triage → request changes · bisect → run command |
+| `a` | status/worktree-diff → stage whole file · stashes → apply · PR/PR-triage → approve |
+| `m` | branches/tags/history (compare flow) → mark compare base · PR/PR-triage → merge |
+| `i` | status → open `.gitignore` picker · history → interactive rebase |
+| `S` | status/diff/compose → commit-split flow · elsewhere → create stash |
+| `P` | branches → push branch · tags → push tag (takes precedence over the global push) |
+| `D` | worktrees → remove worktree + branch · branches → delete branch |
+| `x` / `X` | PR → close · issues → close / reopen · stashes → drop (`X`) |
+| `L` | history/branches → generate changelog · PR-triage/issues → add label |
+| `f` | PR-triage → cycle PR filter · issues → cycle issue filter |
+| `o` | status/diff/conflicts → open file in `$EDITOR` (consistent — different file resolution only) |
+| `[` / `]` | worktree diff → hunk · commit diff → hunk · stash diff → **file** · sidebar/inspector focus → cycle tab |
+
+The three highest-risk overloads, because they're guard-heavy or
+context-subtle, are `c`, `C`, and `[`/`]`. Touch their handlers carefully.
+
+---
+
+## Rules for adding or changing a binding
+
+1. **Check this map and the overload table first.** If the key is already
+   overloaded, make sure your new meaning is unsurprising for the view and that
+   the dispatch order puts your handler before any global that would shadow it.
+2. **Add the handler in the correct precedence slot** of `inkInput.ts` — an
+   exact-context check (`activeView`/`diffSource`/`focus`) or a predicate, never
+   relying on the fallback dispatcher for a view-specific action.
+3. **Register the declarative binding** in `LOG_INK_KEY_BINDINGS`
+   (`inkKeymap.ts`) with its `keys` + `contexts` so it shows up in `?` help and
+   the `:` palette. The collision guard will fail the build if your
+   `(key, context)` pair is already taken — that's the safety net.
+4. **Keep the footer honest.** If you add the key to a view's footer hint, the
+   label must name what the handler actually does. A footer that names a key
+   doing something else is a bug (this exact class of bug was an audit finding).
+5. **Update this map** in the same PR.
+6. **Prefer allowlists over negation guards** for new globals (`activeView in
+   [...]` rather than `activeView !== 'x'`), so the next new view doesn't
+   silently inherit your key.
+
+---
+
+## Known risks (carried from the TUI audit)
+
+- **Negation-guarded globals** (`C` create-PR gated by `!== 'conflicts'`,
+  `S` create-stash gated away from the status/diff/compose triad). Each new view
+  must be checked against these.
+- **`[` / `]` is the most overloaded navigation key** — hunk vs. file vs. tab,
+  decided by `activeView` + `diffSource` + `focus`. A wrong/stale focus value
+  sends the keypress to the wrong axis.
+- **The declarative table can't model fine-grained gating** (selected-item
+  presence, count > 0). The collision guard covers the coarse `(key, context)`
+  case only; the imperative overloads above are your responsibility to keep
+  deliberate.

--- a/src/workstation/README.md
+++ b/src/workstation/README.md
@@ -165,11 +165,21 @@ Once phases 5–7 of [#890](https://github.com/gfargo/coco/issues/890) land, ste
 
 ## Adding a new key binding
 
+**Read [`KEYMAP.md`](./KEYMAP.md) first** — it's the deliberate map of every
+key, the overload table (which letters already mean different things in
+different views), and the dispatch-precedence rules that keep those overloads
+safe. Single keys are dense here; check the map before claiming one.
+
 For an inline keypress on an existing view, you only need:
 
 1. The handler in the per-view branch of `inkInput.ts`.
-2. The footer hint in `inkKeymap.ts`.
-3. (If the action needs y-confirm) a workflow registration in `inkWorkflows.ts` with `requiresConfirmation`.
+2. The footer hint in `inkKeymap.ts` — it must name what the handler actually
+   does (a footer that lies about a key is a bug).
+3. The declarative entry in `LOG_INK_KEY_BINDINGS` (so it shows in `?` help and
+   the `:` palette). `inkKeymap.collisions.test.ts` fails the build if your
+   `(key, context)` pair is already taken.
+4. (If the action needs y-confirm) a workflow registration in `inkWorkflows.ts` with `requiresConfirmation`.
+5. Update `KEYMAP.md` in the same PR.
 
 For a global chord (e.g. a new `g <letter>` view selector), the chord goes in `inkKeymap.ts` plus the route into the action / view-switch in the reducer.
 


### PR DESCRIPTION
## What

The workstation is keyboard-only and key-dense (lazygit-style) — single letters do a lot, and the same letter often means different things in different views (`c`, `R`, `a`, `m`, `i`, `S`, `C`, `[/]`, …). That density is intentional, but it only stays safe if every overload is **deliberate**. This adds the canonical reference and a regression guard, per the TUI audit.

### `src/workstation/KEYMAP.md` — the deliberate map
- **Dispatch-precedence model** — the ordered resolver (overlays → chords → globals → exact-context → predicate → fallback workflow) that makes overloads safe, plus why first-match-wins matters.
- **Global keys**, **`g`-chord** view selectors, and **per-view key tables** for every context.
- **The overload table** — every reused key mapped to its meaning in each context, with the three highest-risk overloads (`c`, `C`, `[`/`]`) called out.
- **Rules for adding a binding** + the **known risks** carried from the audit (negation guards, `[/]` axis ambiguity, coarse declarative gating).

### `inkKeymap.collisions.test.ts` — the guard
Fails the build if two declarative bindings in `LOG_INK_KEY_BINDINGS` ever claim the same key in the same `context` — the accidental-shadow case (a new binding silently making an old one unreachable or mislabeled). **Zero collisions today**; the test locks that in. Intentional exceptions go in an explicit, commented `ALLOWED_COLLISIONS` allowlist. Also asserts no binding has an empty key/context list.

### README
"Adding a new key binding" now points at the map and names the declarative-registration + footer-honesty steps.

## Why no line numbers in the doc
Line numbers rot. The map documents *behavior* and the *dispatch model*; the code stays the source of truth, and the collision test enforces the one invariant that can be machine-checked.

## Test
- `npx jest src/commands/log/inkKeymap.collisions.test.ts` — 2 passed
- `npx eslint` clean
- Docs-only otherwise; no runtime change.