### PR TITLE
feat(ui): single-pane fallback for narrow terminals (<100 cols)

### DIFF
--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -116,6 +116,23 @@ export const RECIPES: ScreenshotRecipe[] = [
   // `coco ui` — additional views and scenarios
   // ─────────────────────────────────────────────────────────────────
   {
+    name: 'ui-single-pane-narrow',
+    description: 'Single-pane fallback at the 80×24 floor — sidebar pane full-width, Tab-cycled',
+    scenario: 'feature-pr-ready',
+    command: 'ui --view history --no-all',
+    // 80×24 is the supported floor and a common tmux-split / SSH size.
+    // Below 100 cols the three-panel layout drops to a single full-width
+    // pane (no 8-cell rails). Tab twice (commits → inspector → sidebar)
+    // to land on the sidebar so the shot shows the full-width accordion
+    // that replaced the rail, plus the footer's `tab: [sidebar] …` switcher.
+    dimensions: { cols: 80, rows: 24 },
+    actions: [
+      { kind: 'sleep', ms: 800 },
+      { kind: 'key', key: 'Tab', count: 2 },
+      { kind: 'sleep', ms: 400 },
+    ],
+  },
+  {
     name: 'ui-branches-sync-showcase',
     description: 'Branches view showing 5 branches in different upstream sync states',
     scenario: 'branch-sync-showcase',

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -2,6 +2,7 @@ import { GitLogRow } from './data'
 import { getLogInkInputEvents, getLogInkPaletteExecuteEvents } from './inkInput'
 import { getLogInkPaletteCommands } from './inkKeymap'
 import { LogInkState, applyLogInkAction, createLogInkState } from './inkViewModel'
+import { getLogInkLayout } from '../../workstation/chrome/layout'
 
 const rows: GitLogRow[] = [
   {
@@ -189,6 +190,36 @@ describe('log Ink input interactions', () => {
     state = applyInput(state, 'g')
     expect(state.selectedIndex).toBe(0)
     expect(state.statusMessage).toBe('jumped to first commit')
+  })
+
+  it('Tab/Shift+Tab cycles the visible pane in single-pane mode', () => {
+    // On narrow terminals the visible pane is derived from focus, so
+    // the existing focus-cycle binding drives the pane switch with no
+    // new key. Cycle order (FOCUS_ORDER): sidebar → main → inspector.
+    const paneFor = (state: LogInkState) =>
+      getLogInkLayout({
+        columns: 80,
+        rows: 24,
+        sidebarFocused: state.focus === 'sidebar',
+        inspectorFocused: state.focus === 'detail',
+      }).visiblePane
+
+    let state = createLogInkState(rows)
+    expect(state.focus).toBe('commits')
+    expect(paneFor(state)).toBe('main')
+
+    state = applyInput(state, '', { tab: true })
+    expect(paneFor(state)).toBe('inspector')
+
+    state = applyInput(state, '', { tab: true })
+    expect(paneFor(state)).toBe('sidebar')
+
+    state = applyInput(state, '', { tab: true })
+    expect(paneFor(state)).toBe('main')
+
+    // Shift+Tab walks the cycle the other way.
+    state = applyInput(state, '', { tab: true, shift: true })
+    expect(paneFor(state)).toBe('sidebar')
   })
 
   it('moves commits and sidebar tabs with arrows, vim keys, and direct jumps', () => {

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -1,4 +1,5 @@
 import { LogInkFocus, LogInkView } from './inkViewModel'
+import type { LogInkVisiblePane } from '../../workstation/chrome/layout'
 import {
     LogInkWorkflowAction,
     LogInkWorkflowActionKind,
@@ -640,6 +641,12 @@ export type GetLogInkFooterHintsOptions = {
    * separate cancel key.
    */
   compareBaseSet?: boolean
+  /**
+   * True on narrow terminals where only one pane renders at a time
+   * (sidebar / main / inspector, Tab-cycled). When set, the footer
+   * prepends a pane switcher showing which pane is active so the user
+   * keeps their orientation without the other two panes on screen. */
+  singlePane?: boolean
 }
 
 export type LogInkChordContinuation = {
@@ -967,7 +974,38 @@ export function combineLogInkBreadcrumbSegments(repoCrumb: string, viewCrumb: st
   return ''
 }
 
+/**
+ * Single-pane pane switcher hint, e.g. `tab: [sidebar] main inspector`.
+ * The active pane (derived from focus: sidebar → sidebar, detail →
+ * inspector, otherwise main) is bracketed so the user can see which of
+ * the three panes Tab will move them away from. Surfaced only on narrow
+ * terminals where the other two panes aren't on screen.
+ */
+function singlePaneSwitcherHint(focus: LogInkFocus): string {
+  const active: LogInkVisiblePane =
+    focus === 'sidebar' ? 'sidebar' : focus === 'detail' ? 'inspector' : 'main'
+  const label = (pane: LogInkVisiblePane) => (pane === active ? `[${pane}]` : pane)
+  return `tab: ${label('sidebar')} ${label('main')} ${label('inspector')}`
+}
+
 export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogInkFooterHints {
+  const hints = computeLogInkFooterHints(options)
+  // On narrow terminals only one pane is on screen, so prepend a Tab
+  // pane switcher for orientation. The caller (footer) only sets
+  // `singlePane` in the plain per-pane states — while an overlay or
+  // filter owns the screen the visible pane is forced (or input is
+  // captured) and Tab does something else, so the switcher is
+  // suppressed there to avoid showing a pane that isn't active.
+  if (options.singlePane) {
+    return {
+      contextual: [singlePaneSwitcherHint(options.focus), ...hints.contextual],
+      global: hints.global,
+    }
+  }
+  return hints
+}
+
+function computeLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogInkFooterHints {
   if (options.pendingKey) {
     const continuations = getLogInkChordContinuations(options.pendingKey)
     if (continuations.length > 0) {

--- a/src/workstation/chrome/layout.test.ts
+++ b/src/workstation/chrome/layout.test.ts
@@ -1,5 +1,5 @@
 import {
-  LAYOUT_RAIL_PANEL_WIDTH,
+  LAYOUT_SINGLE_PANE_BELOW,
   LOG_INK_MIN_COLUMNS,
   LOG_INK_MIN_ROWS,
   getLogInkLayout,
@@ -14,12 +14,16 @@ describe('log Ink layout', () => {
 
     expect(layout.tooSmall).toBe(false)
     expect(layout.bodyRows).toBe(19)
-    // 80 columns falls into the rail tier (< 100), so both side
-    // panels collapse to the fixed rail width and the history panel
-    // takes everything they gave up.
+    // 80 columns falls below the single-pane breakpoint (< 100), so
+    // exactly one full-width pane renders. With no focus flags set the
+    // main pane is visible and takes the whole terminal; the side panes
+    // are hidden (width 0), not railed.
     expect(layout.density).toBe('rail')
-    expect(layout.sidebarWidth).toBe(LAYOUT_RAIL_PANEL_WIDTH)
-    expect(layout.detailWidth).toBe(LAYOUT_RAIL_PANEL_WIDTH)
+    expect(layout.singlePane).toBe(true)
+    expect(layout.visiblePane).toBe('main')
+    expect(layout.mainPanelWidth).toBe(80)
+    expect(layout.sidebarWidth).toBe(0)
+    expect(layout.detailWidth).toBe(0)
   })
 
   it('uses a balanced layout at the default terminal size', () => {
@@ -112,11 +116,14 @@ describe('log Ink layout', () => {
     expect(expanded.mainPanelWidth).toBe(120 - expanded.sidebarWidth - expanded.detailWidth)
   })
 
-  it('clamps the focused inspector to its 36-60 cell range', () => {
-    const narrow = getLogInkLayout({ columns: 80, rows: 24, inspectorFocused: true })
+  it('clamps the focused inspector to its 36-60 cell range in three-pane tiers', () => {
+    // The 36-cell floor is only reachable below the single-pane
+    // breakpoint, where the inspector instead takes the full width, so
+    // the lowest three-pane focused width is floor(100 × 0.40) = 40.
+    const narrow = getLogInkLayout({ columns: 100, rows: 24, inspectorFocused: true })
     const wide = getLogInkLayout({ columns: 200, rows: 60, inspectorFocused: true })
 
-    expect(narrow.detailWidth).toBe(36)
+    expect(narrow.detailWidth).toBe(40)
     expect(wide.detailWidth).toBe(60)
   })
 
@@ -149,11 +156,14 @@ describe('log Ink layout', () => {
     expect(expanded.mainPanelWidth).toBe(120 - expanded.sidebarWidth - expanded.detailWidth)
   })
 
-  it('clamps the focused sidebar to its 32–50 cell range', () => {
-    const narrow = getLogInkLayout({ columns: 80, rows: 24, sidebarFocused: true })
+  it('clamps the focused sidebar to its 32–50 cell range in three-pane tiers', () => {
+    // The 32-cell floor is only reachable below the single-pane
+    // breakpoint, where the sidebar instead takes the full width, so
+    // the lowest three-pane focused width is floor(100 × 0.36) = 36.
+    const narrow = getLogInkLayout({ columns: 100, rows: 24, sidebarFocused: true })
     const wide = getLogInkLayout({ columns: 200, rows: 60, sidebarFocused: true })
 
-    expect(narrow.sidebarWidth).toBe(32)
+    expect(narrow.sidebarWidth).toBe(36)
     expect(wide.sidebarWidth).toBe(50)
   })
 
@@ -174,7 +184,9 @@ describe('log Ink layout', () => {
     })
 
     it('clamps the help-overlay detail width to its 60-100 cell range', () => {
-      const narrow = getLogInkLayout({ columns: 80, rows: 24, helpOverlayActive: true })
+      // 100 cols is the narrowest three-pane terminal; below it the
+      // single-pane override gives the inspector the full width instead.
+      const narrow = getLogInkLayout({ columns: 100, rows: 24, helpOverlayActive: true })
       const wide = getLogInkLayout({ columns: 240, rows: 60, helpOverlayActive: true })
       expect(narrow.detailWidth).toBe(60)
       expect(wide.detailWidth).toBe(100)
@@ -216,51 +228,39 @@ describe('log Ink layout', () => {
       expect(getLogInkLayout({ columns: 90, rows: 40 }).historyRowMode).toBe('stacked')
     })
 
-    it('rails the sidebar and inspector at rail tier when unfocused', () => {
+    it('drops to single-pane mode below the rail breakpoint', () => {
       const layout = getLogInkLayout({ columns: 90, rows: 40 })
 
-      expect(layout.sidebarRailed).toBe(true)
-      expect(layout.inspectorRailed).toBe(true)
-      expect(layout.sidebarWidth).toBe(LAYOUT_RAIL_PANEL_WIDTH)
-      expect(layout.detailWidth).toBe(LAYOUT_RAIL_PANEL_WIDTH)
-      // History gets everything the side panels gave up.
-      expect(layout.mainPanelWidth).toBe(90 - LAYOUT_RAIL_PANEL_WIDTH * 2)
+      expect(layout.singlePane).toBe(true)
+      // With no focus flags the main pane is visible, full-width; the
+      // side panes are hidden (width 0), not railed.
+      expect(layout.visiblePane).toBe('main')
+      expect(layout.mainPanelWidth).toBe(90)
+      expect(layout.sidebarWidth).toBe(0)
+      expect(layout.detailWidth).toBe(0)
     })
 
-    it('un-rails a panel when it takes focus, even on a narrow terminal', () => {
+    it('shows the focused pane full-width in single-pane mode', () => {
       const sidebarFocused = getLogInkLayout({ columns: 90, rows: 40, sidebarFocused: true })
-      expect(sidebarFocused.sidebarRailed).toBe(false)
-      // 90 * 0.36 = 32.4 → floor 32; clamps stay 32-50 so this lands at 32.
-      expect(sidebarFocused.sidebarWidth).toBe(32)
-      // Inspector stays railed since the user isn't reading it.
-      expect(sidebarFocused.inspectorRailed).toBe(true)
-      expect(sidebarFocused.detailWidth).toBe(LAYOUT_RAIL_PANEL_WIDTH)
+      expect(sidebarFocused.visiblePane).toBe('sidebar')
+      expect(sidebarFocused.sidebarWidth).toBe(90)
+      expect(sidebarFocused.mainPanelWidth).toBe(0)
+      expect(sidebarFocused.detailWidth).toBe(0)
 
       const inspectorFocused = getLogInkLayout({ columns: 90, rows: 40, inspectorFocused: true })
-      expect(inspectorFocused.inspectorRailed).toBe(false)
-      // 90 * 0.40 = 36 → clamps to 36-60 lower bound.
-      expect(inspectorFocused.detailWidth).toBe(36)
-      expect(inspectorFocused.sidebarRailed).toBe(true)
+      expect(inspectorFocused.visiblePane).toBe('inspector')
+      expect(inspectorFocused.detailWidth).toBe(90)
+      expect(inspectorFocused.sidebarWidth).toBe(0)
+      expect(inspectorFocused.mainPanelWidth).toBe(0)
     })
 
-    it('keeps panels at normal widths above the rail breakpoint', () => {
+    it('keeps the three-pane layout above the rail breakpoint', () => {
       const tight = getLogInkLayout({ columns: 110, rows: 40 })
-      expect(tight.sidebarRailed).toBe(false)
-      expect(tight.inspectorRailed).toBe(false)
-      // 110 * 0.24 = 26.4 → floor 26 (in the 22-34 unfocused range)
+      expect(tight.singlePane).toBe(false)
+      // 110 * 0.24 = 26.4 → floor 26 (in the 22-28 unfocused range)
       expect(tight.sidebarWidth).toBe(26)
-    })
-
-    it('lets the help overlay override inspector rail', () => {
-      const railedHelp = getLogInkLayout({
-        columns: 90,
-        rows: 40,
-        helpOverlayActive: true,
-      })
-      // Help wants room for hotkey descriptions; rail collapse would
-      // defeat that purpose. 60-cell minimum kicks in here.
-      expect(railedHelp.detailWidth).toBe(60)
-      expect(railedHelp.inspectorRailed).toBe(false)
+      // All three panes tile flush.
+      expect(tight.sidebarWidth + tight.mainPanelWidth + tight.detailWidth).toBe(110)
     })
   })
 
@@ -378,6 +378,66 @@ describe('log Ink layout', () => {
         expect(layout.sidebarWidth + layout.mainPanelWidth + layout.detailWidth).toBe(cols)
         expect(layout.mainPanelWidth).toBeGreaterThan(0)
       }
+    })
+  })
+
+  // Single-pane fallback (#1135) — below LAYOUT_SINGLE_PANE_BELOW the
+  // three-panel layout retires in favour of one full-width pane, the
+  // focused one, Tab-cycled. Replaces the old 8-cell icon rails.
+  describe('single-pane mode', () => {
+    it('flips singlePane exactly at the breakpoint', () => {
+      expect(getLogInkLayout({ columns: LAYOUT_SINGLE_PANE_BELOW, rows: 40 }).singlePane).toBe(false)
+      expect(getLogInkLayout({ columns: LAYOUT_SINGLE_PANE_BELOW - 1, rows: 40 }).singlePane).toBe(true)
+      expect(getLogInkLayout({ columns: 80, rows: 24 }).singlePane).toBe(true)
+    })
+
+    it('derives visiblePane from focus', () => {
+      const base = { columns: 80, rows: 24 }
+      expect(getLogInkLayout(base).visiblePane).toBe('main')
+      expect(getLogInkLayout({ ...base, sidebarFocused: true }).visiblePane).toBe('sidebar')
+      expect(getLogInkLayout({ ...base, inspectorFocused: true }).visiblePane).toBe('inspector')
+    })
+
+    it('only ever shows one pane — the visible one is full-width, the rest are zero', () => {
+      for (const focus of [{}, { sidebarFocused: true }, { inspectorFocused: true }] as const) {
+        const layout = getLogInkLayout({ columns: 80, rows: 24, ...focus })
+        const widths = [layout.sidebarWidth, layout.mainPanelWidth, layout.detailWidth]
+        // Exactly one pane is full-width (80); the other two are hidden.
+        expect(widths.filter((w) => w === 80)).toHaveLength(1)
+        expect(widths.filter((w) => w === 0)).toHaveLength(2)
+      }
+    })
+
+    it('lets an overlay forcedPane override the focus-derived pane', () => {
+      // The split-plan overlay lives in the main panel; while focus is
+      // on the sidebar the runtime forces 'main' so the overlay shows.
+      const splitPlan = getLogInkLayout({
+        columns: 80,
+        rows: 24,
+        sidebarFocused: true,
+        forcedPane: 'main',
+      })
+      expect(splitPlan.visiblePane).toBe('main')
+      expect(splitPlan.mainPanelWidth).toBe(80)
+
+      // Help / palette / confirmation overlays force the inspector.
+      const help = getLogInkLayout({
+        columns: 80,
+        rows: 24,
+        helpOverlayActive: true,
+        forcedPane: 'inspector',
+      })
+      expect(help.visiblePane).toBe('inspector')
+      expect(help.detailWidth).toBe(80)
+    })
+
+    it('ignores forcedPane above the breakpoint (all panes render)', () => {
+      const layout = getLogInkLayout({ columns: 140, rows: 40, forcedPane: 'inspector' })
+      expect(layout.singlePane).toBe(false)
+      // forcedPane only applies in single-pane mode; visiblePane falls
+      // back to the focus-derived default (main) and all three tile.
+      expect(layout.visiblePane).toBe('main')
+      expect(layout.sidebarWidth + layout.mainPanelWidth + layout.detailWidth).toBe(140)
     })
   })
 })

--- a/src/workstation/chrome/layout.ts
+++ b/src/workstation/chrome/layout.ts
@@ -23,7 +23,24 @@ export type LogInkLayoutInput = {
    * open is fine — the user is paused on the help, not navigating.
    */
   helpOverlayActive?: boolean
+  /**
+   * Single-pane only. When an overlay needs a specific pane visible the
+   * runtime passes it here so single-pane mode surfaces the overlay
+   * instead of hiding it behind whatever pane focus points at:
+   * split-plan renders in the main panel; help / palette / confirmation
+   * / input-prompt / chord overlays all render in the inspector. Ignored
+   * at or above `LAYOUT_SINGLE_PANE_BELOW` (every pane is visible there).
+   */
+  forcedPane?: LogInkVisiblePane
 }
+
+/**
+ * Which of the three panes renders below `LAYOUT_SINGLE_PANE_BELOW`,
+ * where only one shows at a time. Derived from focus (`sidebar` →
+ * sidebar, `commits` → main, `detail` → inspector) so the existing Tab
+ * focus cycle drives the pane switch with no new binding.
+ */
+export type LogInkVisiblePane = 'sidebar' | 'main' | 'inspector'
 
 /**
  * Responsive tier for the whole UI, derived from terminal width. Higher
@@ -33,8 +50,8 @@ export type LogInkLayoutInput = {
  *   - wide   (>= 160 cols) — absolute `YYYY-MM-DD` dates, full chrome
  *   - normal (120–159)     — compact relative dates (`2d`, `3w`)
  *   - tight  (100–119)     — date column dropped entirely
- *   - rail   (< 100)       — history rows stack on two lines; sidebar
- *     and inspector collapse to a thin icon rail when not focused
+ *   - rail   (< 100)       — history rows stack on two lines; the UI
+ *     drops to single-pane mode (one full-width pane, Tab-cycled)
  */
 export type LogInkLayoutDensity = 'rail' | 'tight' | 'normal' | 'wide'
 
@@ -63,24 +80,23 @@ export type LogInkLayout = {
   inspectorTabbed: boolean
   /**
    * Width-derived tier that gates date formatting and row stacking in
-   * the history surface; also drives panel rail collapse below.
+   * the history surface. Below the `rail` breakpoint the UI also drops
+   * to single-pane mode (see `singlePane`).
    */
   density: LogInkLayoutDensity
   /**
-   * True when the sidebar should render as a thin icon rail (tab
-   * glyph + count, no expanded tab content). Held to `density === 'rail'
-   * && !sidebarFocused` so focusing the sidebar always pops it back
-   * to its normal expanded form — same affordance as the existing
-   * focus-grow pattern, just starting from a much smaller resting
-   * state on narrow terminals.
+   * True when the terminal is too narrow to tile three panes, so the UI
+   * shows exactly one full-width pane (`visiblePane`) and Tab cycles
+   * which one. Replaces the retired 8-cell icon rails — an 8-cell stub
+   * was worse than no panel. Gated on `columns < LAYOUT_SINGLE_PANE_BELOW`.
    */
-  sidebarRailed: boolean
+  singlePane: boolean
   /**
-   * True when the inspector should render as a thin rail (selected
-   * shortHash + a focus hint, no commit body / file list / actions).
-   * Same focus-rescue contract as `sidebarRailed`.
+   * In single-pane mode, which pane renders. Derived from focus (and an
+   * active overlay's `forcedPane`); meaningless when `singlePane` is
+   * false (all three panes render).
    */
-  inspectorRailed: boolean
+  visiblePane: LogInkVisiblePane
   /**
    * `single` — each commit takes one row (current behavior).
    * `stacked` — each commit takes two rows: graph + hash + message on
@@ -113,20 +129,21 @@ export const INSPECTOR_TABBED_BELOW_ROWS = 28
  *   wide   >= 160 — plenty of room; keep absolute dates
  *   normal >= 120 — relative dates save 8-ish cells without hiding info
  *   tight  >= 100 — drop date entirely; subject + refs are the priority
- *   rail   <  100 — even with side panels collapsed the row is tight;
- *                   stack to two lines and rail the side panels at rest
+ *   rail   <  100 — history rows stack to two lines; the UI also drops
+ *                   to single-pane mode (see `LAYOUT_SINGLE_PANE_BELOW`)
  */
 export const LAYOUT_TIGHT_BELOW = 120
 export const LAYOUT_NORMAL_BELOW = 160
 export const LAYOUT_RAIL_BELOW = 100
 
 /**
- * Fixed cell width for a railed side panel. Just wide enough for a
- * 1-cell icon + a 2-3 digit count after subtracting border (2) and
- * padding (2). Going narrower clips the count; going wider defeats
- * the purpose of railing in the first place.
+ * Width below which the three-panel layout can't tile without starving
+ * every pane, so the UI shows exactly one full-width pane (the focused
+ * one) and Tab cycles which pane is visible. Coincides with the `rail`
+ * density breakpoint — single-pane mode replaces the old 8-cell icon
+ * rails that used to render at this width.
  */
-export const LAYOUT_RAIL_PANEL_WIDTH = 8
+export const LAYOUT_SINGLE_PANE_BELOW = LAYOUT_RAIL_BELOW
 
 /**
  * Sidebar at-rest size targets, tier-aware. The sidebar's purpose at
@@ -160,7 +177,7 @@ export const LAYOUT_RAIL_PANEL_WIDTH = 8
  */
 type SidebarAtRestConfig = { min: number; max: number; fraction: number }
 const SIDEBAR_AT_REST_BY_TIER: Record<LogInkLayoutDensity, SidebarAtRestConfig> = {
-  rail: { min: 22, max: 28, fraction: 0.24 }, // unused — rail collapses to LAYOUT_RAIL_PANEL_WIDTH
+  rail: { min: 22, max: 28, fraction: 0.24 }, // unused at rest — single-pane mode overrides the width
   tight: { min: 22, max: 28, fraction: 0.24 },
   normal: { min: 22, max: 30, fraction: 0.22 },
   wide: { min: 28, max: 32, fraction: 0.20 },
@@ -183,15 +200,26 @@ export function getLogInkLayout(input: LogInkLayoutInput): LogInkLayout {
           ? 'tight'
           : 'rail'
 
-  // Rail collapse: only happens at the narrowest tier, and only for
-  // the panel that does NOT currently hold focus AND is not being
-  // commandeered by the help overlay. Focus always wins — pressing
-  // tab to the sidebar pops it back open even on an 80-cell terminal
-  // so the user can actually use it. The help overlay also wins for
-  // the inspector since that's where its descriptions render.
-  const sidebarRailed = density === 'rail' && !input.sidebarFocused
-  const inspectorRailed =
-    density === 'rail' && !input.inspectorFocused && !input.helpOverlayActive
+  // Below the single-pane breakpoint the three-panel layout can't tile
+  // without starving every pane, so we show exactly one full-width pane
+  // — the focused one — and Tab cycles which pane is visible. This
+  // replaces the retired 8-cell icon rails (an 8-cell stub showed a tab
+  // glyph + count and nothing actionable).
+  const singlePane = columns < LAYOUT_SINGLE_PANE_BELOW
+
+  // Which pane shows in single-pane mode. Defaults to the focused pane
+  // (focus and visibility coalesce, so the existing Tab focus cycle
+  // drives it). An active overlay can force a specific pane via
+  // `forcedPane` so its surface isn't hidden behind whatever pane focus
+  // points at.
+  const focusPane: LogInkVisiblePane = input.sidebarFocused
+    ? 'sidebar'
+    : input.inspectorFocused
+      ? 'inspector'
+      : 'main'
+  const visiblePane: LogInkVisiblePane = singlePane
+    ? input.forcedPane ?? focusPane
+    : focusPane
 
   // Inspector width — at rest 20-32 cells (~22% of width), focused
   // 36-60 cells (~40% of width). Narrow rest state keeps the commit
@@ -204,42 +232,49 @@ export function getLogInkLayout(input: LogInkLayoutInput): LogInkLayout {
   // "Move focus...". Capped at 100 cells so a wide terminal doesn't
   // waste an absurd amount of horizontal space on the cheat sheet.
   //
-  // Rail collapse wins over the at-rest range but loses to focus and
-  // to the help overlay — both of those represent deliberate user
-  // intent to read the panel.
+  // (In single-pane mode these three-panel widths are recomputed below
+  // so the visible pane gets the full terminal.)
   const detailWidth = input.helpOverlayActive
     ? Math.max(60, Math.min(100, Math.floor(columns * 0.50)))
     : input.inspectorFocused
       ? Math.max(36, Math.min(60, Math.floor(columns * 0.40)))
-      : inspectorRailed
-        ? LAYOUT_RAIL_PANEL_WIDTH
-        : Math.max(20, Math.min(32, Math.floor(columns * 0.22)))
+      : Math.max(20, Math.min(32, Math.floor(columns * 0.22)))
   // Sidebar at rest is tier-aware (see `SIDEBAR_AT_REST_BY_TIER`):
   // tight stays compact (22-28), normal shrinks slightly (22-30),
   // wide grows naturally (28-48) so the side panel doesn't get pinned
   // at an arbitrary cap on big terminals while the main panel hogs
   // 80% of the width. Focused: 32-50 cells (~36% of width),
   // regardless of tier — deliberate user intent to read the sidebar
-  // deserves the extra width. Rail mode (narrow terminal, unfocused)
-  // collapses to a fixed 8-cell strip with tab glyphs only.
+  // deserves the extra width.
   const sidebarWidth = input.sidebarFocused
     ? Math.max(32, Math.min(50, Math.floor(columns * 0.36)))
-    : sidebarRailed
-      ? LAYOUT_RAIL_PANEL_WIDTH
-      : calcSidebarAtRestWidth(columns, density)
+    : calcSidebarAtRestWidth(columns, density)
+
+  // Single-pane mode: exactly one pane renders, full-width; the other
+  // two are hidden (width 0), not railed. Above the breakpoint the
+  // three panels tile flush across the terminal.
+  const paneWidths = singlePane
+    ? {
+        sidebarWidth: visiblePane === 'sidebar' ? columns : 0,
+        mainPanelWidth: visiblePane === 'main' ? columns : 0,
+        detailWidth: visiblePane === 'inspector' ? columns : 0,
+      }
+    : {
+        sidebarWidth,
+        mainPanelWidth: Math.max(20, columns - sidebarWidth - detailWidth),
+        detailWidth,
+      }
 
   return {
     bodyRows: Math.max(8, rows - 5),
     columns,
-    detailWidth,
-    mainPanelWidth: Math.max(20, columns - sidebarWidth - detailWidth),
     rows,
-    sidebarWidth,
     tooSmall: columns < LOG_INK_MIN_COLUMNS || rows < LOG_INK_MIN_ROWS,
     inspectorTabbed: rows < INSPECTOR_TABBED_BELOW_ROWS,
     density,
-    sidebarRailed,
-    inspectorRailed,
+    singlePane,
+    visiblePane,
     historyRowMode: density === 'rail' ? 'stacked' : 'single',
+    ...paneWidths,
   }
 }

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -124,6 +124,7 @@ import {
     LOG_INK_MIN_ROWS,
     getLogInkLayout,
 } from '../chrome/layout'
+import type { LogInkVisiblePane } from '../chrome/layout'
 import { sortBranches, sortTags } from '../chrome/sorting'
 import { IDLE_TIPS_GRACE_MS, IDLE_TIPS_INTERVAL_MS, pickIdleTip } from '../chrome/idleTips'
 import {
@@ -4680,6 +4681,25 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     })
   })
 
+  // In single-pane mode (narrow terminals) only one pane renders, so an
+  // active overlay must pull its own pane into view rather than stay
+  // hidden behind whatever pane focus points at. The split-plan overlay
+  // lives in the main panel; every other overlay (help / palette / theme
+  // / gitignore / input prompt / confirmation / chord) renders in the
+  // inspector. Ignored above the single-pane breakpoint (all panes show).
+  const forcedPane: LogInkVisiblePane | undefined = state.splitPlan
+    ? 'main'
+    : state.showHelp ||
+        state.showCommandPalette ||
+        state.showThemePicker ||
+        state.gitignorePicker ||
+        state.inputPrompt ||
+        state.pendingConfirmationId ||
+        state.pendingMutationConfirmation ||
+        state.pendingKey
+      ? 'inspector'
+      : undefined
+
   // Layout depends on focus (sidebar grows when focused), so it's
   // computed here — after state is in scope but before the render path.
   const layout = getLogInkLayout({
@@ -4688,6 +4708,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     sidebarFocused: state.focus === 'sidebar',
     inspectorFocused: state.focus === 'detail',
     helpOverlayActive: state.showHelp,
+    forcedPane,
   })
 
   // Runtime Context provider (#1136). Bundles the five most-drilled
@@ -4724,60 +4745,78 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     return renderOnboardingOverlay(h, { Box, Text }, layout.rows, layout.columns, theme, appLabel)
   }
 
+  // Panel renderers are thunks so single-pane mode can build only the
+  // visible pane — the main-panel render in particular is expensive, so
+  // we don't want to invoke the two hidden ones just to drop them.
+  const sidebarPanel = () =>
+    renderSidebar(h, { Box, Text }, state, context, contextStatus, layout.sidebarWidth, layout.bodyRows, theme)
+  const mainPanel = () =>
+    renderMainPanel(
+      h,
+      { Box, Text },
+      state,
+      context,
+      contextStatus,
+      worktreeDiff,
+      worktreeDiffLoading,
+      worktreeHunks,
+      worktreeHunksLoading,
+      filePreview,
+      filePreviewLoading,
+      commitDiffHunkOffsets,
+      selectedDetailFile,
+      stashDiffLines,
+      stashDiffLoading,
+      compareDiffLines,
+      compareDiffLoading,
+      bisectCandidateDetail,
+      bisectCandidateLoading,
+      layout.bodyRows,
+      layout.mainPanelWidth,
+      theme,
+      hasMoreCommits,
+      loadingMoreCommits,
+      spinnerFrame,
+      layout.density,
+      layout.historyRowMode,
+      Boolean(dateBucketingEnabled),
+      diffSyntaxSpans
+    )
+  const detailPanel = () =>
+    renderDetailPanel(
+      h,
+      { Box, Text },
+      state,
+      context,
+      contextStatus,
+      detail,
+      detailLoading,
+      filePreview,
+      filePreviewLoading,
+      layout.detailWidth,
+      layout.inspectorTabbed,
+      theme,
+      layout.bodyRows
+    )
+
+  // Single-pane mode (narrow terminals): exactly one full-width pane,
+  // chosen by `layout.visiblePane`; Tab cycles which one. Above the
+  // breakpoint all three tile side by side as before.
+  const bodyPanels = layout.singlePane
+    ? [
+        layout.visiblePane === 'sidebar'
+          ? sidebarPanel()
+          : layout.visiblePane === 'inspector'
+            ? detailPanel()
+            : mainPanel(),
+      ]
+    : [sidebarPanel(), mainPanel(), detailPanel()]
+
   return h(RuntimeContext.Provider, { value: runtimeContextValue },
     h(Box, { flexDirection: 'column', height: layout.rows },
     renderHeader(h, { Box, Text }, state, context, contextStatus, layout.columns, theme, appLabel),
-    h(Box, { flexDirection: 'row', height: layout.bodyRows },
-      renderSidebar(h, { Box, Text }, state, context, contextStatus, layout.sidebarWidth, layout.bodyRows, theme, layout.sidebarRailed),
-      renderMainPanel(
-        h,
-        { Box, Text },
-        state,
-        context,
-        contextStatus,
-        worktreeDiff,
-        worktreeDiffLoading,
-        worktreeHunks,
-        worktreeHunksLoading,
-        filePreview,
-        filePreviewLoading,
-        commitDiffHunkOffsets,
-        selectedDetailFile,
-        stashDiffLines,
-        stashDiffLoading,
-        compareDiffLines,
-        compareDiffLoading,
-        bisectCandidateDetail,
-        bisectCandidateLoading,
-        layout.bodyRows,
-        layout.mainPanelWidth,
-        theme,
-        hasMoreCommits,
-        loadingMoreCommits,
-        spinnerFrame,
-        layout.density,
-        layout.historyRowMode,
-        Boolean(dateBucketingEnabled),
-        diffSyntaxSpans
-      ),
-      renderDetailPanel(
-        h,
-        { Box, Text },
-        state,
-        context,
-        contextStatus,
-        detail,
-        detailLoading,
-        filePreview,
-        filePreviewLoading,
-        layout.detailWidth,
-        layout.inspectorTabbed,
-        theme,
-        layout.inspectorRailed,
-        layout.bodyRows
-      )
-    ),
-    renderFooter(h, { Box, Text }, state, context, theme, idleTip, spinnerFrame)
+    h(Box, { flexDirection: 'row', height: layout.bodyRows }, ...bodyPanels),
+    renderFooter(h, { Box, Text }, state, context, theme, idleTip, spinnerFrame, layout.singlePane)
     )
   )
 }

--- a/src/workstation/runtime/detailPanel.ts
+++ b/src/workstation/runtime/detailPanel.ts
@@ -20,9 +20,7 @@ import type {
     GitCommitDetail,
     GitCommitFilePreview,
 } from '../../commands/log/data'
-import { getSelectedInkCommit } from '../../commands/log/inkViewModel'
 import type { LogInkState } from '../../commands/log/inkViewModel'
-import { focusBorderColor, panelTitle } from './utils'
 import {
     renderBranchPreviewPanel,
     renderCommitDiffDetail,
@@ -46,48 +44,6 @@ import {
 } from './overlays'
 import type { LogInkComponents, LogInkContext } from './types'
 
-/**
- * Rail-mode inspector — shown on terminals < 100 columns when the
- * detail panel does not hold focus. The full inspector (commit body,
- * file list, actions) does not survive truncation to ~4 content cells
- * so we collapse to a stack with the panel label and the selected
- * commit's shortHash. Focus pops the panel back to its expanded
- * widths via the layout, so this renderer is only reached at rest.
- *
- * Help / overlay states are still handled by their own renderers
- * above; this short-circuit only kicks in for the regular "view the
- * commit" cases.
- */
-function renderInspectorRail(
-  h: typeof ReactTypes.createElement,
-  components: LogInkComponents,
-  state: LogInkState,
-  detail: GitCommitDetail | undefined,
-  width: number,
-  theme: LogInkTheme,
-  focused: boolean
-): ReactTypes.ReactElement {
-  const { Box, Text } = components
-  // Prefer the loaded detail's hash (canonical) but fall back to the
-  // selected list row's shortHash so the rail isn't blank on the
-  // first render before getCommitDetail resolves.
-  const selectedRow = getSelectedInkCommit(state)
-  const hashText = detail?.hash.slice(0, 4)
-    ?? selectedRow?.shortHash.slice(0, 4)
-    ?? '····'
-
-  return h(Box, {
-    borderColor: focusBorderColor(theme, focused),
-    borderStyle: theme.borderStyle,
-    flexDirection: 'column',
-    width,
-    paddingX: 1,
-  },
-  h(Text, { bold: true, dimColor: !focused }, panelTitle('Insp', focused)),
-  h(Text, { dimColor: true }, '────'),
-  h(Text, { color: theme.noColor ? undefined : theme.colors.accent }, hashText))
-}
-
 export function renderDetailPanel(
   h: typeof ReactTypes.createElement,
   components: LogInkComponents,
@@ -101,15 +57,13 @@ export function renderDetailPanel(
   width: number,
   tabbed: boolean,
   theme: LogInkTheme,
-  railed: boolean = false,
   bodyRows: number = 0
 ): ReactTypes.ReactElement {
   const focused = state.focus === 'detail'
 
   // Overlays (help / palette / input / confirmation / chord) take
-  // precedence over rail because they always claim the panel's width
-  // via the help-overlay layout branch — and railing those would
-  // defeat their whole purpose (the user is reading them).
+  // precedence over every per-view surface because they claim the
+  // panel's full width via the help-overlay layout branch.
   if (state.showHelp) {
     return renderHelpPanel(h, components, state, width, theme, focused, bodyRows)
   }
@@ -146,16 +100,6 @@ export function renderDetailPanel(
   // navigation. The overlay's footer hint already documents `g/G top/bot`.
   if (state.pendingKey && !state.splitPlan) {
     return renderChordOverlay(h, components, state, width, theme, focused)
-  }
-
-  // Rail mode applies only after every overlay above has had its say
-  // — those would all be unreadable at 4 cells of content. The layout
-  // also clears `railed` whenever the inspector takes focus, so we
-  // can safely short-circuit the per-view dispatch here without
-  // worrying about hiding the panel from a user who's actively
-  // reading it.
-  if (railed) {
-    return renderInspectorRail(h, components, state, detail, width, theme, focused)
   }
 
   // The synthetic "(+) new commit" row routes the inspector through the

--- a/src/workstation/runtime/footer.test.ts
+++ b/src/workstation/runtime/footer.test.ts
@@ -238,6 +238,46 @@ describe('renderFooter', () => {
     expect(global.props.dimColor).toBe(true)
   })
 
+  // Single-pane fallback (#1135) — narrow terminals show one pane at a
+  // time, so the footer prepends a Tab pane switcher for orientation.
+  describe('single-pane pane switcher', () => {
+    const renderSinglePane = (state: LogInkState) =>
+      asNode(
+        renderFooter(
+          createElement,
+          { Box, Text },
+          state,
+          baseContext,
+          createLogInkTheme({ noColor: false }),
+          undefined,
+          0,
+          true
+        )
+      )
+    const contextualText = (tree: Node): string => {
+      const contextual = childAt(childAt(tree, 0), 0)
+      return String(contextual.props.children)
+    }
+
+    it('prepends the switcher with the focused pane bracketed', () => {
+      // Default focus is the commit list ('commits') → main is active.
+      expect(contextualText(renderSinglePane(makeState()))).toContain('tab: sidebar [main] inspector')
+      expect(contextualText(renderSinglePane(makeState({ focus: 'sidebar' })))).toContain('tab: [sidebar] main inspector')
+      expect(contextualText(renderSinglePane(makeState({ focus: 'detail' })))).toContain('tab: sidebar main [inspector]')
+    })
+
+    it('omits the switcher when not in single-pane mode', () => {
+      const tree = asNode(render(makeState()))
+      expect(contextualText(tree)).not.toContain('tab:')
+    })
+
+    it('omits the switcher while an overlay owns the footer', () => {
+      // The help overlay returns its own bindings; the switcher would
+      // be misleading since Tab moves help focus, not the pane.
+      expect(contextualText(renderSinglePane(makeState({ showHelp: true })))).not.toContain('tab:')
+    })
+  })
+
   // Snapshot covers the no-status default — the layout most users see
   // most of the time — to catch incidental structural drift.
   it('structural snapshot — default no-status footer', () => {

--- a/src/workstation/runtime/footer.ts
+++ b/src/workstation/runtime/footer.ts
@@ -62,7 +62,8 @@ export function renderFooter(
   context: LogInkContext,
   theme: LogInkTheme,
   idleTip?: string,
-  spinnerFrame: number = 0
+  spinnerFrame: number = 0,
+  singlePane: boolean = false
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   // Sidebar item count drives the per-tab footer hints — when items are
@@ -77,6 +78,25 @@ export function renderFooter(
       default: return undefined
     }
   })()
+  // The single-pane pane switcher only makes sense in the plain
+  // per-pane states. While an overlay or filter owns the screen the
+  // visible pane is forced (split-plan → main; help / palette / theme /
+  // gitignore / input prompt / confirmation / chord → inspector) or
+  // input is captured, and Tab does something else — so the switcher
+  // would point at a pane that isn't on screen. Suppress it then. Mirror
+  // of the runtime's `forcedPane` derivation in `app.ts`.
+  const overlayForcesPane = Boolean(
+    state.splitPlan ||
+      state.showHelp ||
+      state.showCommandPalette ||
+      state.showThemePicker ||
+      state.gitignorePicker ||
+      state.inputPrompt ||
+      state.pendingConfirmationId ||
+      state.pendingMutationConfirmation ||
+      state.pendingKey ||
+      state.filterMode
+  )
   const hints = getLogInkFooterHints({
     activeView: state.activeView,
     diffSource: state.diffSource,
@@ -90,6 +110,7 @@ export function renderFooter(
     sidebarItemCount,
     compareBaseSet: Boolean(state.compareBase),
     splitPlanStatus: state.splitPlan?.status,
+    singlePane: singlePane && !overlayForcesPane,
   })
   // Real status messages always win; idle tips only fill the slot when it
   // would otherwise be empty.

--- a/src/workstation/runtime/sidebar.ts
+++ b/src/workstation/runtime/sidebar.ts
@@ -248,78 +248,6 @@ function renderActiveSidebarContent(
   )
 }
 
-/**
- * Single-letter glyph for a sidebar tab in rail mode. Letters always
- * carry the meaning so this stays useful under ASCII; the rail is too
- * narrow to fit the full tab label. Pairs with `sidebarTabCount` for
- * the trailing count.
- */
-function sidebarTabRailGlyph(tab: LogInkSidebarTab): string {
-  switch (tab) {
-    case 'status':
-      return 'S'
-    case 'branches':
-      return 'B'
-    case 'tags':
-      return 'T'
-    case 'stashes':
-      return '$'
-    case 'worktrees':
-      return 'W'
-    default:
-      return '·'
-  }
-}
-
-/**
- * Rail-mode sidebar — shown on terminals < 100 columns when the
- * sidebar does not hold focus. Five vertically stacked tab glyphs
- * with optional counts; the active tab is bracketed. Pressing Tab to
- * focus the sidebar pops it back to the full accordion (the layout
- * un-rails it on focus, this renderer is never called in that case).
- */
-function renderSidebarRail(
-  h: typeof ReactTypes.createElement,
-  components: LogInkComponents,
-  state: LogInkState,
-  context: LogInkContext,
-  width: number,
-  theme: LogInkTheme,
-  focused: boolean,
-  tabs: LogInkSidebarTab[]
-): ReactTypes.ReactElement {
-  const { Box, Text } = components
-
-  return h(Box, {
-    borderColor: focusBorderColor(theme, focused),
-    borderStyle: theme.borderStyle,
-    flexDirection: 'column',
-    width,
-    paddingX: 1,
-  },
-  h(Text, { bold: true, dimColor: !focused }, 'Repo'),
-  h(Text, { dimColor: true }, '────'),
-  ...tabs.map((tab) => {
-    const isActive = tab === state.sidebarTab
-    const glyph = sidebarTabRailGlyph(tab)
-    const count = sidebarTabCount(tab, context)
-    // Count fits in 2 cells (rail content area is ~4 cells); 99+
-    // collapses to `+` so we never overflow.
-    const countText = count === undefined
-      ? ''
-      : count > 99
-        ? '+'
-        : String(count)
-    const body = isActive ? `[${glyph}]` : ` ${glyph} `
-    const text = countText ? `${body}${countText}` : body
-    return h(Text, {
-      key: `rail-${tab}`,
-      bold: isActive,
-      dimColor: !isActive,
-    }, text)
-  }))
-}
-
 export function renderSidebar(
   h: typeof ReactTypes.createElement,
   components: LogInkComponents,
@@ -328,16 +256,11 @@ export function renderSidebar(
   contextStatus: LogInkContextStatus,
   width: number,
   bodyRows: number,
-  theme: LogInkTheme,
-  railed: boolean = false
+  theme: LogInkTheme
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const focused = state.focus === 'sidebar'
   const tabs = getLogInkSidebarTabs()
-
-  if (railed) {
-    return renderSidebarRail(h, components, state, context, width, theme, focused, tabs)
-  }
 
   // Accordion layout — every tab's title is visible on its own line, but
   // only the active tab expands its content underneath. Switching tabs

--- a/src/workstation/runtime/singlePane.test.ts
+++ b/src/workstation/runtime/singlePane.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Render smoke test for the single-pane fallback (#1135).
+ *
+ * At the 80×24 supported floor the workstation drops its three-panel
+ * layout for one full-width pane (the focused one), Tab-cycled. This
+ * exercises the two panes that used to collapse to useless 8-cell icon
+ * rails — the sidebar and the inspector — at the full single-pane width,
+ * confirming they render the real surface (not a stub) without throwing.
+ *
+ * Structural, not visual: stub `Text` / `Box` collect props into a
+ * synthetic React tree so we can read the outer `width` without pulling
+ * Ink (ESM) into ts-jest. Same trick as `footer.test.ts`.
+ */
+import { createElement } from 'react'
+import { createLogInkState } from '../../commands/log/inkViewModel'
+import { createLogInkContextStatus } from '../chrome/context'
+import { getLogInkLayout } from '../chrome/layout'
+import { createLogInkTheme } from '../chrome/theme'
+import { renderDetailPanel } from './detailPanel'
+import { renderSidebar } from './sidebar'
+import type { LogInkContext } from './types'
+
+type StubProps = Record<string, unknown>
+const Text = ((props: StubProps) =>
+  createElement('text', props, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+const Box = ((props: StubProps) =>
+  createElement('box', props, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+
+type Node = { props: StubProps }
+const asNode = (value: unknown): Node => value as Node
+
+const theme = createLogInkTheme({ noColor: false })
+const context: LogInkContext = {}
+const contextStatus = createLogInkContextStatus('ready')
+
+describe('single-pane render smoke (80×24 floor)', () => {
+  it('renders the sidebar full-width when it is the visible pane', () => {
+    const state = createLogInkState([])
+    const layout = getLogInkLayout({ columns: 80, rows: 24, sidebarFocused: true })
+
+    expect(layout.singlePane).toBe(true)
+    expect(layout.visiblePane).toBe('sidebar')
+
+    const tree = asNode(
+      renderSidebar(
+        createElement,
+        { Box, Text },
+        state,
+        context,
+        contextStatus,
+        layout.sidebarWidth,
+        layout.bodyRows,
+        theme
+      )
+    )
+    // The full accordion sidebar renders at the whole terminal width —
+    // not the retired 8-cell rail.
+    expect(tree.props.width).toBe(80)
+  })
+
+  it('renders the inspector full-width when it is the visible pane', () => {
+    const state = createLogInkState([])
+    const layout = getLogInkLayout({ columns: 80, rows: 24, inspectorFocused: true })
+
+    expect(layout.singlePane).toBe(true)
+    expect(layout.visiblePane).toBe('inspector')
+
+    const tree = asNode(
+      renderDetailPanel(
+        createElement,
+        { Box, Text },
+        state,
+        context,
+        contextStatus,
+        undefined,
+        false,
+        undefined,
+        false,
+        layout.detailWidth,
+        layout.inspectorTabbed,
+        theme,
+        layout.bodyRows
+      )
+    )
+    expect(tree.props.width).toBe(80)
+  })
+})


### PR DESCRIPTION
Closes #1135.

## Problem

Below ~100 cols the workstation kept its three-panel IDE layout: the sidebar and inspector collapsed to **8-cell icon rails** (`density: 'rail'`), spending ~16–20 of 80 columns on stubs that showed a tab glyph + count and nothing actionable. At the supported floor — **80×24**, a common tmux-split / SSH size — that was worse than no panel (flagged by the TUI audit).

## Change

Replace the rail tier with a **single-pane mode**: below `LAYOUT_SINGLE_PANE_BELOW` (100) exactly **one full-width pane** renders — the focused one — and `Tab`/`Shift+Tab` cycles which pane is visible (**Sidebar → Main → Inspector**). Focus and visibility coalesce, so the existing focus-cycle binding drives it with **no new key**.

- **Decision confirmed:** the 8-cell rails are retired entirely below 100 in favour of single-pane — simpler, and removes the near-useless stub. `renderSidebarRail` / `renderInspectorRail` and the `sidebarRailed` / `inspectorRailed` layout fields are gone.
- **Overlays stay reachable.** An active overlay forces its own pane into view so its surface isn't hidden behind whatever pane focus points at: split-plan → main; help / palette / theme / gitignore / input-prompt / confirmation / chord → inspector. This is what keeps 80×24 fully usable for **stage → diff → commit**.
- **Footer orientation.** A single-pane footer variant prepends a pane switcher with the active pane bracketed, e.g. `tab: [sidebar] main inspector`. Suppressed while an overlay or filter owns the screen (where the visible pane is forced and Tab does something else).
- Header breadcrumb + footer stay. The diff view already folds split→unified below its min width; in single-pane the main pane gets the full terminal — strictly better than before. The 80×24 min-size guard is unchanged.

## Where it lands

- `chrome/layout.ts` — `LAYOUT_SINGLE_PANE_BELOW`, `singlePane`, `visiblePane` (focus-derived), `forcedPane` input; retires the rail fields + `LAYOUT_RAIL_PANEL_WIDTH`.
- `runtime/app.ts` — renders only `layout.visiblePane` in single-pane (panel renderers are thunks so the two hidden panes aren't built); computes `forcedPane`.
- `runtime/sidebar.ts` / `runtime/detailPanel.ts` — drop the rail renderers + `railed` params.
- `runtime/footer.ts` + `commands/log/inkKeymap.ts` — pane-switcher footer hint.

## Tests / validation

- `npx tsc --noEmit` ✓ · `npx eslint <touched>` ✓
- `layout.test.ts` — breakpoint, `visiblePane` derivation, `forcedPane` override, full-width-pane invariant.
- `footer.test.ts` — switcher with the focused pane bracketed; omitted when not single-pane / while an overlay owns the footer.
- `inkInput.test.ts` — `Tab`/`Shift+Tab` cycles the visible pane.
- `runtime/singlePane.test.ts` — render smoke at the 80×24 floor (sidebar + inspector full-width).
- `bin/screenshot/recipes.ts` — `ui-single-pane-narrow` 80×24 recipe (regression + marketing).

Full `jest` suite green except one unrelated git-timing suite (`getCommitLogCurrentBranch.test.ts`) that only times out under full-parallel load and passes in isolation.