### PR TITLE
feat(ui): momentary sidebar peek on narrow terminals (v) — #1135 v2

### DIFF
--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -133,6 +133,23 @@ export const RECIPES: ScreenshotRecipe[] = [
     ],
   },
   {
+    name: 'ui-single-pane-peek',
+    description: 'Single-pane sidebar "peek" (v) at the 80×24 floor — momentary glance with v/esc → main',
+    scenario: 'feature-pr-ready',
+    command: 'ui --view history --no-all',
+    // `v` momentarily peeks the sidebar from the main pane without
+    // losing your place — one key out, one key (v/esc) back. The shot
+    // captures the full-width sidebar mid-glance plus the footer's
+    // `v/esc → main` snap-back affordance that distinguishes a peek from
+    // a Tab-cycle focus move.
+    dimensions: { cols: 80, rows: 24 },
+    actions: [
+      { kind: 'sleep', ms: 800 },
+      { kind: 'type', text: 'v' },
+      { kind: 'sleep', ms: 400 },
+    ],
+  },
+  {
     name: 'ui-branches-sync-showcase',
     description: 'Branches view showing 5 branches in different upstream sync states',
     scenario: 'branch-sync-showcase',

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -4475,4 +4475,63 @@ describe('triage filter cycling (#882 phase 6)', () => {
     expect(state.selectedIssueFilter).toBe('open')
     expect(state.selectedPullRequestFilter).toBe('open')
   })
+
+  // #1135 v2 — momentary sidebar "peek" on narrow (single-pane)
+  // terminals: `v` jumps to the sidebar with a return ticket; `v`/Esc
+  // snaps back to where you were; browsing the sidebar keeps it open;
+  // any explicit focus change or drill-in cancels the ticket.
+  describe('peek (single-pane sidebar glance)', () => {
+    const singlePane = { singlePane: true }
+
+    it('v opens a sidebar peek from the main pane and stores the return focus', () => {
+      let state = createLogInkState(rows)
+      expect(state.focus).toBe('commits')
+
+      state = applyInput(state, 'v', {}, singlePane)
+      expect(state.focus).toBe('sidebar')
+      expect(state.peekReturnFocus).toBe('commits')
+    })
+
+    it('v again snaps back to the original pane and clears the ticket', () => {
+      let state = createLogInkState(rows)
+      state = applyInput(state, 'v', {}, singlePane)
+      state = applyInput(state, 'v', {}, singlePane)
+      expect(state.focus).toBe('commits')
+      expect(state.peekReturnFocus).toBeUndefined()
+    })
+
+    it('Esc closes a peek back to the original pane', () => {
+      let state = createLogInkState(rows)
+      state = applyInput(state, 'v', {}, singlePane)
+      state = applyInput(state, '', { escape: true }, singlePane)
+      expect(state.focus).toBe('commits')
+      expect(state.peekReturnFocus).toBeUndefined()
+    })
+
+    it('keeps the peek open while browsing the sidebar (←/→ tab switch)', () => {
+      let state = createLogInkState(rows)
+      state = applyInput(state, 'v', {}, singlePane)
+      expect(state.sidebarTab).toBe('branches')
+
+      state = applyInput(state, '', { rightArrow: true }, singlePane)
+      expect(state.sidebarTab).not.toBe('branches')
+      // Still peeking — the glance survives sidebar navigation.
+      expect(state.focus).toBe('sidebar')
+      expect(state.peekReturnFocus).toBe('commits')
+    })
+
+    it('Tab cancels the peek ticket (explicit focus change)', () => {
+      let state = createLogInkState(rows)
+      state = applyInput(state, 'v', {}, singlePane)
+      state = applyInput(state, '', { tab: true }, singlePane)
+      expect(state.peekReturnFocus).toBeUndefined()
+    })
+
+    it('v is a no-op in the three-pane layout (not single-pane)', () => {
+      let state = createLogInkState(rows)
+      state = applyInput(state, 'v', {}, { singlePane: false })
+      expect(state.focus).toBe('commits')
+      expect(state.peekReturnFocus).toBeUndefined()
+    })
+  })
 })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -77,6 +77,12 @@ export type LogInkInputEvent =
   | { type: 'openGitignorePicker' }
 
 export type LogInkInputContext = {
+  /**
+   * True on narrow terminals where only one pane renders at a time
+   * (#1135). Gates the `v` peek key — peeking the sidebar is meaningless
+   * in the three-pane layout where every pane is already visible.
+   */
+  singlePane?: boolean
   detailFileCount?: number
   worktreeHunkOffsets?: number[]
   previewLineCount?: number
@@ -1478,6 +1484,16 @@ export function getLogInkInputEvents(
     return events
   }
 
+  // #1135 v2 — while peeking the sidebar, Esc or the peek key (`v`)
+  // snaps back to the pane the user came from. Placed before the
+  // generic Esc → popView so a peek glance returns to main rather than
+  // walking the view stack. Every other key falls through to normal
+  // handling (focus is on the sidebar during a peek), so ←/→ and ↑/↓
+  // browse the sidebar and keep the peek open until an explicit exit.
+  if (state.peekReturnFocus !== undefined && (key.escape || inputValue === 'v')) {
+    return [action({ type: 'togglePeek' })]
+  }
+
   if (key.escape && state.viewStack.length > 1) {
     return [action({ type: 'popView' })]
   }
@@ -1951,6 +1967,14 @@ export function getLogInkInputEvents(
 
   if (key.tab) {
     return [action({ type: key.shift ? 'focusPrevious' : 'focusNext' })]
+  }
+
+  // #1135 v2 — `v` peeks the sidebar from the main / inspector pane on
+  // narrow (single-pane) terminals: a momentary glance that snaps back
+  // with `v` / Esc (handled above once peeking). No-op in the three-pane
+  // layout (every pane is already on screen) and from the sidebar itself.
+  if (inputValue === 'v' && context.singlePane && state.focus !== 'sidebar') {
+    return [action({ type: 'togglePeek' })]
   }
 
   // ←/→ on the sidebar switch tabs (Status ↔ Branches ↔ Tags ↔

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -647,6 +647,12 @@ export type GetLogInkFooterHintsOptions = {
    * prepends a pane switcher showing which pane is active so the user
    * keeps their orientation without the other two panes on screen. */
   singlePane?: boolean
+  /**
+   * True while the user is peeking the sidebar (#1135 v2) — a momentary
+   * single-pane glance. The footer swaps the switcher for the snap-back
+   * affordance (`v/esc → main`) since the user is mid-glance, not
+   * navigating. */
+  peeking?: boolean
 }
 
 export type LogInkChordContinuation = {
@@ -990,15 +996,30 @@ function singlePaneSwitcherHint(focus: LogInkFocus): string {
 
 export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogInkFooterHints {
   const hints = computeLogInkFooterHints(options)
+  // While peeking the sidebar (#1135 v2) the footer shows the snap-back
+  // affordance instead of the switcher — the user is mid-glance, not
+  // navigating, so `v`/Esc returning to main is the relevant action.
+  if (options.peeking) {
+    return {
+      contextual: ['v/esc → main', ...hints.contextual],
+      global: hints.global,
+    }
+  }
   // On narrow terminals only one pane is on screen, so prepend a Tab
   // pane switcher for orientation. The caller (footer) only sets
   // `singlePane` in the plain per-pane states — while an overlay or
   // filter owns the screen the visible pane is forced (or input is
   // captured) and Tab does something else, so the switcher is
-  // suppressed there to avoid showing a pane that isn't active.
+  // suppressed there to avoid showing a pane that isn't active. From the
+  // main / inspector pane we also surface `v peek` so the momentary
+  // sidebar glance is discoverable.
   if (options.singlePane) {
+    const lead =
+      options.focus === 'sidebar'
+        ? [singlePaneSwitcherHint(options.focus)]
+        : [singlePaneSwitcherHint(options.focus), 'v peek']
     return {
-      contextual: [singlePaneSwitcherHint(options.focus), ...hints.contextual],
+      contextual: [...lead, ...hints.contextual],
       global: hints.global,
     }
   }

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -1977,3 +1977,55 @@ describe('triage filter preset cycling (#882 phase 6)', () => {
     })
   })
 })
+
+// #1135 v2 — peek is "focus the sidebar with a return ticket." The
+// reducer holds the prior focus in `peekReturnFocus`; the toggle
+// restores it, and any deliberate navigation (focus change or view
+// push/pop) cancels the ticket so the user is never snapped back
+// somewhere unexpected.
+describe('sidebar peek (#1135 v2)', () => {
+  it('togglePeek from a non-sidebar pane jumps to the sidebar and stores the return focus', () => {
+    let state = createLogInkState(rows)
+    expect(state.focus).toBe('commits')
+
+    state = applyLogInkAction(state, { type: 'togglePeek' })
+    expect(state.focus).toBe('sidebar')
+    expect(state.peekReturnFocus).toBe('commits')
+  })
+
+  it('togglePeek again restores the stashed focus and clears the ticket', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'setFocus', value: 'detail' })
+    state = applyLogInkAction(state, { type: 'togglePeek' })
+    expect(state.focus).toBe('sidebar')
+    expect(state.peekReturnFocus).toBe('detail')
+
+    state = applyLogInkAction(state, { type: 'togglePeek' })
+    expect(state.focus).toBe('detail')
+    expect(state.peekReturnFocus).toBeUndefined()
+  })
+
+  it('togglePeek is a no-op when already focused on the sidebar', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'setFocus', value: 'sidebar' })
+    state = applyLogInkAction(state, { type: 'togglePeek' })
+    expect(state.focus).toBe('sidebar')
+    expect(state.peekReturnFocus).toBeUndefined()
+  })
+
+  it('drilling into a view cancels a pending peek', () => {
+    let state = applyLogInkAction(createLogInkState(rows), { type: 'togglePeek' })
+    expect(state.peekReturnFocus).toBe('commits')
+
+    state = applyLogInkAction(state, { type: 'pushView', value: 'branches' })
+    expect(state.peekReturnFocus).toBeUndefined()
+  })
+
+  it('Tab (focusNext) cancels a pending peek', () => {
+    let state = applyLogInkAction(createLogInkState(rows), { type: 'togglePeek' })
+    expect(state.peekReturnFocus).toBe('commits')
+
+    state = applyLogInkAction(state, { type: 'focusNext' })
+    expect(state.peekReturnFocus).toBeUndefined()
+  })
+})

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -330,6 +330,17 @@ export type LogInkState = {
   pendingMutationConfirmation?: LogInkMutationConfirmation
   pendingKey?: string
   focus: LogInkFocus
+  /**
+   * Set while the user is "peeking" the sidebar (#1135 v2) — a momentary
+   * single-pane glance that snaps back to where they were. Holds the
+   * focus to restore when the peek ends; `undefined` when not peeking.
+   * Peek is just "focus the sidebar with a return ticket": opening sets
+   * `focus = 'sidebar'` and stashes the prior focus here; the toggle key
+   * or Esc restores it. Any explicit focus change (Tab) or view drill-in
+   * cancels the ticket so the user isn't snapped back unexpectedly.
+   * Single-pane only — above the breakpoint all panes are already visible.
+   */
+  peekReturnFocus?: LogInkFocus
   sidebarTab: LogInkSidebarTab
   /**
    * The user's last *explicit* sidebar tab choice. Only changes when
@@ -784,6 +795,7 @@ export type LogInkAction =
   | { type: 'focusPendingCommit' }
   | { type: 'unfocusPendingCommit' }
   | { type: 'setFocus'; value: LogInkFocus }
+  | { type: 'togglePeek' }
   | { type: 'setPendingKey'; value?: string }
   | { type: 'setSidebarTab'; value: LogInkSidebarTab }
   | { type: 'restoreSidebarTab'; value: LogInkSidebarTab }
@@ -964,7 +976,7 @@ function topOfStack(stack: LogInkView[]): LogInkView {
 
 function withPushedView(state: LogInkState, value: LogInkView): LogInkState {
   if (topOfStack(state.viewStack) === value) {
-    return { ...state, pendingKey: undefined }
+    return { ...state, peekReturnFocus: undefined, pendingKey: undefined }
   }
 
   const viewStack = [...state.viewStack, value]
@@ -988,13 +1000,16 @@ function withPushedView(state: LogInkState, value: LogInkView): LogInkState {
     compareHead: value === 'diff' ? state.compareHead : undefined,
     pendingCommitFocused: value === 'history' ? state.pendingCommitFocused : false,
     statusGroupHeaderFocused: value === 'status' ? state.statusGroupHeaderFocused : false,
+    // Changing the view is a deliberate destination — cancel any pending
+    // peek return so the user isn't snapped back afterward.
+    peekReturnFocus: undefined,
     pendingKey: undefined,
   }
 }
 
 function withPoppedView(state: LogInkState): LogInkState {
   if (state.viewStack.length <= 1) {
-    return { ...state, pendingKey: undefined }
+    return { ...state, peekReturnFocus: undefined, pendingKey: undefined }
   }
 
   const viewStack = state.viewStack.slice(0, -1)
@@ -1022,6 +1037,8 @@ function withPoppedView(state: LogInkState): LogInkState {
     compareHead: next === 'diff' ? state.compareHead : undefined,
     pendingCommitFocused: next === 'history' ? state.pendingCommitFocused : false,
     statusGroupHeaderFocused: next === 'status' ? state.statusGroupHeaderFocused : false,
+    // Backing out is a deliberate navigation — cancel any peek return.
+    peekReturnFocus: undefined,
     pendingKey: undefined,
   }
 }
@@ -1140,7 +1157,7 @@ function withPoppedRepoFrame(state: LogInkState): LogInkState {
 
 function withReplacedView(state: LogInkState, value: LogInkView): LogInkState {
   if (topOfStack(state.viewStack) === value) {
-    return { ...state, pendingKey: undefined }
+    return { ...state, peekReturnFocus: undefined, pendingKey: undefined }
   }
 
   const viewStack = [...state.viewStack.slice(0, -1), value]
@@ -1155,6 +1172,9 @@ function withReplacedView(state: LogInkState, value: LogInkView): LogInkState {
     compareHead: value === 'diff' ? state.compareHead : undefined,
     pendingCommitFocused: value === 'history' ? state.pendingCommitFocused : false,
     statusGroupHeaderFocused: value === 'status' ? state.statusGroupHeaderFocused : false,
+    // Changing the view is a deliberate destination — cancel any pending
+    // peek return so the user isn't snapped back afterward.
+    peekReturnFocus: undefined,
     pendingKey: undefined,
   }
 }
@@ -1432,6 +1452,9 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         // from 'commits' should always land back on a real file when
         // the user returns.
         statusGroupHeaderFocused: false,
+        // Explicit focus cycle cancels a pending peek return — the
+        // user has taken manual control of the focus.
+        peekReturnFocus: undefined,
         pendingKey: undefined,
       }
     case 'focusPrevious':
@@ -1440,6 +1463,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         focus: cycleValue(FOCUS_ORDER, state.focus, -1),
         sidebarHeaderFocused: false,
         statusGroupHeaderFocused: false,
+        peekReturnFocus: undefined,
         pendingKey: undefined,
       }
     case 'move':
@@ -1963,8 +1987,35 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         // the status view — clear when focus moves away so a
         // re-entry starts on a real file.
         statusGroupHeaderFocused: action.value === 'commits' ? state.statusGroupHeaderFocused : false,
+        // An explicit focus set cancels a pending peek return.
+        peekReturnFocus: undefined,
         pendingKey: undefined,
       }
+    case 'togglePeek': {
+      // Peek = "focus the sidebar with a return ticket." Closing returns
+      // to the stashed focus; opening (only from a non-sidebar pane)
+      // stashes the current focus and jumps to the sidebar. The render
+      // layer needs no special case — `focus: 'sidebar'` already drives
+      // the single-pane layout to show the sidebar full-width.
+      if (state.peekReturnFocus !== undefined) {
+        return {
+          ...state,
+          focus: state.peekReturnFocus,
+          peekReturnFocus: undefined,
+          sidebarHeaderFocused: false,
+          pendingKey: undefined,
+        }
+      }
+      if (state.focus === 'sidebar') {
+        return state
+      }
+      return {
+        ...state,
+        focus: 'sidebar',
+        peekReturnFocus: state.focus,
+        pendingKey: undefined,
+      }
+    }
     case 'setPendingKey':
       return {
         ...state,

--- a/src/workstation/KEYMAP.md
+++ b/src/workstation/KEYMAP.md
@@ -84,6 +84,7 @@ Available in every view (unless an overlay/mode has claimed the keyboard):
 | `<` | Pop view / go back |
 | `Esc` | Pop view; pop nested-repo frame; close overlay |
 | `Tab` / `Shift+Tab` | Focus next / previous pane |
+| `v` | Peek the sidebar (narrow / single-pane terminals only) — momentary glance, `v`/`Esc` snaps back to where you were |
 | `↑`/`k`, `↓`/`j` | Move selection / scroll |
 | `←`/`→` | Switch sidebar or inspector tab (focus-dependent) |
 | `PageUp` / `PageDown` | Page scroll |

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -121,6 +121,7 @@ import {
     LOG_INK_DEFAULT_COLUMNS,
     LOG_INK_DEFAULT_ROWS,
     LOG_INK_MIN_COLUMNS,
+    LAYOUT_SINGLE_PANE_BELOW,
     LOG_INK_MIN_ROWS,
     getLogInkLayout,
 } from '../chrome/layout'
@@ -4480,6 +4481,12 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       : undefined
 
     getLogInkInputEvents(state, inputValue, key, {
+      // Narrow terminals show one pane at a time (#1135) — gates the `v`
+      // peek key. Derived the same way the layout does, since `layout`
+      // is computed later in the render path (not in this callback).
+      singlePane:
+        (windowSize.columns || process.stdout.columns || LOG_INK_DEFAULT_COLUMNS) <
+        LAYOUT_SINGLE_PANE_BELOW,
       detailFileCount: detail?.files.length,
       previewLineCount: diffPreviewLineCount,
       worktreeDiffLineCount: worktreeDiff?.lines.length,

--- a/src/workstation/runtime/footer.test.ts
+++ b/src/workstation/runtime/footer.test.ts
@@ -276,6 +276,23 @@ describe('renderFooter', () => {
       // be misleading since Tab moves help focus, not the pane.
       expect(contextualText(renderSinglePane(makeState({ showHelp: true })))).not.toContain('tab:')
     })
+
+    // #1135 v2 — peek discoverability + the in-peek snap-back affordance.
+    it('surfaces "v peek" from the main / inspector pane', () => {
+      expect(contextualText(renderSinglePane(makeState()))).toContain('v peek')
+      expect(contextualText(renderSinglePane(makeState({ focus: 'detail' })))).toContain('v peek')
+      // Not from the sidebar itself — you're already there.
+      expect(contextualText(renderSinglePane(makeState({ focus: 'sidebar' })))).not.toContain('v peek')
+    })
+
+    it('swaps the switcher for the snap-back hint while peeking', () => {
+      const peeking = makeState({ focus: 'sidebar', peekReturnFocus: 'commits' })
+      const text = contextualText(renderSinglePane(peeking))
+      expect(text).toContain('v/esc → main')
+      // Mid-glance: the switcher / peek-open hint step aside.
+      expect(text).not.toContain('tab:')
+      expect(text).not.toContain('v peek')
+    })
   })
 
   // Snapshot covers the no-status default — the layout most users see

--- a/src/workstation/runtime/footer.ts
+++ b/src/workstation/runtime/footer.ts
@@ -111,6 +111,11 @@ export function renderFooter(
     compareBaseSet: Boolean(state.compareBase),
     splitPlanStatus: state.splitPlan?.status,
     singlePane: singlePane && !overlayForcesPane,
+    // Peeking (#1135 v2) is a single-pane glance with focus on the
+    // sidebar; the footer shows `v/esc → main` instead of the switcher.
+    // Suppressed under an overlay (which owns the footer) just like the
+    // switcher.
+    peeking: Boolean(state.peekReturnFocus) && singlePane && !overlayForcesPane,
   })
   // Real status messages always win; idle tips only fill the slot when it
   // would otherwise be empty.


### PR DESCRIPTION
Follow-up to #1139 — implements the deferred **v2 "peek"** from #1135.

## What

The single-pane fallback Tab-cycles sidebar → main → inspector, which moves focus *permanently*. Peek adds a momentary glance: from the main (or inspector) pane on narrow terminals, **`v`** shows the sidebar full-width and **`v`/`Esc`** snaps you straight back to where you were — no walking the focus cycle, no losing your place in main.

## Design — "focus the sidebar with a return ticket"

Peek needs **zero new render code**. Opening stashes the prior focus in `state.peekReturnFocus` and sets `focus = 'sidebar'`; the single-pane layout already renders the focused pane full-width and routes all sidebar input (tabs, selection). The toggle key or `Esc` restores the stashed focus.

- **Stays open** while you browse the sidebar (`←/→` tabs, `↑/↓` select, `1–5` jump).
- **Cancels the return ticket** on any *explicit* focus change (`Tab`) or view drill-in (`Enter` → push/replace/pop view), so you're never snapped back somewhere unexpected.
- **Single-pane only** — `v` is a no-op in the three-pane layout (every pane is already visible), gated via a `singlePane` flag added to the input context.
- **Footer**: surfaces `v peek` from the main/inspector pane; swaps to `v/esc → main` while peeking. Both suppressed under an overlay that owns the footer.

Per the AskUserQuestion decisions: **overlay-peek** (full-width, snap back) + **toggle** interaction. I deliberately did *not* register `v` in the keymap table — that would surface it in the command palette as a width-dependent no-op; discoverability is footer-driven (the surface that matters for single-pane users) plus a `KEYMAP.md` row.

## Touch points
`inkViewModel.ts` (state field, `togglePeek` reducer, ticket-cancel in focus/view actions) · `inkInput.ts` (open/close routing + `singlePane` context flag) · `inkKeymap.ts` + `footer.ts` (footer hints) · `app.ts` (pass `singlePane`).

## Tests / validation
- `tsc` ✓ · `eslint` ✓ · full `jest` suite green (208 suites, 2597 passed).
- Reducer: toggle open/close, no-op-on-sidebar, cancel on drill-in / Tab.
- Input: `v` open, `v`/`Esc` close, browse-keeps-open, three-pane no-op.
- Footer: `v peek` discoverability + `v/esc → main` while peeking.
- `bin/screenshot/recipes.ts`: `ui-single-pane-peek` 80×24 recipe.

Closes the v2 item on #1135.