### PR TITLE
fix(ui): trim single-pane footer to the 80-col floor + refresh workstation README

### DIFF
--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -735,6 +735,20 @@ const GLOBAL_BINDING_IDS: LogInkCommandId[] = [
 const NORMAL_GLOBAL_HINTS = ['g jump', '< back', '? help', ': cmds', 'q quit']
 
 /**
+ * Narrow single-pane footer budget (#1135). On terminals below the
+ * single-pane breakpoint the pane switcher (`tab: …`, ~29 cells) plus
+ * the snap-back / peek affordance already claim most of an 80-cell row,
+ * so the per-view hint tail and the global cluster are trimmed to what
+ * fits without clipping — the switcher is the orientation anchor and
+ * must stay whole. The dropped bindings remain one `?` (help) away.
+ *
+ *   - keep only the first view hint (the most actionable for the view)
+ *   - shrink the global cluster to the two recovery essentials
+ */
+const SINGLE_PANE_GLOBAL_HINTS = ['? help', 'q quit']
+const SINGLE_PANE_VIEW_HINT_LIMIT = 1
+
+/**
  * Per-binding category mapping. Used to subdivide the help overlay's
  * Global and view sections into named clusters so users don't face a
  * 30-row wall of keys with no visual structure.
@@ -998,11 +1012,13 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
   const hints = computeLogInkFooterHints(options)
   // While peeking the sidebar (#1135 v2) the footer shows the snap-back
   // affordance instead of the switcher — the user is mid-glance, not
-  // navigating, so `v`/Esc returning to main is the relevant action.
+  // navigating, so `v`/Esc returning to main is the relevant action. The
+  // view-hint tail + globals are trimmed to fit the narrow row (see
+  // SINGLE_PANE_GLOBAL_HINTS).
   if (options.peeking) {
     return {
-      contextual: ['v/esc → main', ...hints.contextual],
-      global: hints.global,
+      contextual: ['v/esc → main', ...hints.contextual.slice(0, SINGLE_PANE_VIEW_HINT_LIMIT)],
+      global: SINGLE_PANE_GLOBAL_HINTS,
     }
   }
   // On narrow terminals only one pane is on screen, so prepend a Tab
@@ -1012,15 +1028,17 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
   // captured) and Tab does something else, so the switcher is
   // suppressed there to avoid showing a pane that isn't active. From the
   // main / inspector pane we also surface `v peek` so the momentary
-  // sidebar glance is discoverable.
+  // sidebar glance is discoverable. The full per-view hint cluster +
+  // global cluster don't fit alongside the switcher at the 80-col floor,
+  // so both are trimmed (the dropped keys stay reachable via `?`).
   if (options.singlePane) {
     const lead =
       options.focus === 'sidebar'
         ? [singlePaneSwitcherHint(options.focus)]
         : [singlePaneSwitcherHint(options.focus), 'v peek']
     return {
-      contextual: [...lead, ...hints.contextual],
-      global: hints.global,
+      contextual: [...lead, ...hints.contextual.slice(0, SINGLE_PANE_VIEW_HINT_LIMIT)],
+      global: SINGLE_PANE_GLOBAL_HINTS,
     }
   }
   return hints

--- a/src/workstation/README.md
+++ b/src/workstation/README.md
@@ -16,7 +16,7 @@ src/
 │   ├── data.ts               ← `getLogRows` + `getCommitDetail` + GitLogRow / GitCommitDetail types
 │   ├── render.ts             ← stdout formatter for the non-interactive path
 │   ├── interactive.ts        ← non-TTY (CI / pipe) snapshot fallback
-│   ├── inkRuntime.ts         ← `LogInkApp` React component + render*Surface helpers
+│   ├── inkRuntime.ts         ← Boot shim only: TTY vs non-TTY path, dynamic ESM import of ink/react, mounts `LogInkApp`, installs lifecycle handlers (render layer now lives in `workstation/runtime/` — see Migration)
 │   ├── inkInput.ts           ← Global onKey switch — routes keypresses to view-specific handlers
 │   ├── inkViewModel.ts       ← `LogInkState`, `LogInkAction`, `applyLogInkAction` reducer
 │   ├── inkKeymap.ts          ← Chord prefix model, key bindings, footer hint generation
@@ -52,6 +52,18 @@ src/
 │   └── aiActions.ts          ← Drives AI-generated commit messages / changelogs
 │
 └── workstation/
+    ├── runtime/              ← Render layer + app shell (phase 5 of #890 — promoted out of `commands/log/inkRuntime.ts`)
+    │   ├── app.ts            ← `LogInkApp` component: state, effects, async dispatchers, top-level render tree
+    │   ├── header.ts         ← Header / breadcrumb renderer
+    │   ├── sidebar.ts        ← Repository sidebar (accordion tabs)
+    │   ├── mainPanel.ts      ← Main-panel dispatcher → per-view surface
+    │   ├── detailPanel.ts    ← Inspector-panel dispatcher → per-view detail / overlay
+    │   ├── footer.ts         ← Two-row status + hint footer
+    │   ├── overlays.ts       ← Help / palette / confirmation / chord / onboarding overlays
+    │   └── …                 ← repo-stack runtime, diff line render, drill-in resolvers, types
+    │
+    ├── surfaces/<view>/      ← Per-view render modules (history, status, diff, branches, tags, stash, compose, conflicts, reflog, bisect, …)
+    │
     └── chrome/               ← Cross-cutting visual + state + lifecycle utilities (this directory's reason for existing)
         ├── theme.ts          ← `LogInkTheme` resolver, color preset registry, `NO_COLOR` honoring
         ├── colorSupport.ts   ← Terminal color-level detection (`COLORTERM`, `TERM`)
@@ -103,8 +115,10 @@ inkWorkflows.ts    ← workflow registry → handler runs (often async, hits src
 inkViewModel.ts    ← applyLogInkAction(state, action) → next LogInkState
      │
      ▼
-inkRuntime.ts      ← LogInkApp re-renders with new state
-     │             ← renderHeader, renderSidebar, render<View>Surface, renderFooter
+workstation/runtime/app.ts
+     │             ← LogInkApp re-renders with new state
+     │             ← renderHeader · renderSidebar · renderMainPanel · renderDetailPanel · renderFooter
+     │               (per-view render under workstation/surfaces/<view>/)
      ▼
 Ink                ← reconciles to terminal
 ```
@@ -158,10 +172,10 @@ The bisect view (`g B`) is the most recent worked example — see PRs [#868, #88
 4. **Keymap** (`src/commands/log/inkKeymap.ts`) — add the chord binding (`g <letter>`) and the per-view footer hint.
 5. **Workflows** (`src/commands/log/inkWorkflows.ts`) — register any palette-reachable workflows (mutations, multi-step flows). Inline keypress handlers don't need a registration.
 6. **Input dispatch** (`src/commands/log/inkInput.ts`) — add the per-view branch in the `onKey` switch.
-7. **Render** (`src/commands/log/inkRuntime.ts`) — write `renderXxxSurface(state, theme, layout, ...)` and wire it into `renderMainPanel`. Use `chrome/surfaceStates.ts` for empty / loading copy.
+7. **Render** (`src/workstation/surfaces/<view>/`) — write the view's render module and wire it into `workstation/runtime/mainPanel.ts` (and `detailPanel.ts` for the inspector surface). Use `chrome/surfaceStates.ts` for empty / loading copy.
 8. **Tests** — at minimum: data parser fixtures, reducer state transitions, a render snapshot of empty / populated / error states.
 
-Once phases 5–7 of [#890](https://github.com/gfargo/coco/issues/890) land, steps 3 / 6 / 7 will move into per-surface modules under `workstation/state/`, `workstation/state/input/`, and `workstation/surfaces/<view>/`.
+Phase 5 of [#890](https://github.com/gfargo/coco/issues/890) has landed, so step 7 already lives under `workstation/surfaces/<view>/`. Once phases 6–7 land, steps 3 and 6 will likewise move into per-surface modules under `workstation/state/` and `workstation/state/input/`.
 
 ## Adding a new key binding
 
@@ -241,7 +255,7 @@ Scenarios match common workstation states: feature branch ready to PR, dirty wor
 
 - **`src/workstation/`** depends on **`src/git/`** and **`src/lib/`**. Never the other way.
 - **`src/git/`** depends on **`src/lib/`** and other `src/commands/<x>/` modules it integrates with (`commit`, `changelog`, `ui`). It does not depend on `src/workstation/`.
-- **`src/commands/log/`** is the log command. The orchestration files (`inkRuntime`, `inkInput`, `inkViewModel`, `inkKeymap`, `inkWorkflows`) live here today as a **transitional home** until phases 5–7 of [#890](https://github.com/gfargo/coco/issues/890) move them into `src/workstation/`.
+- **`src/commands/log/`** is the log command. The render layer has already moved to `src/workstation/runtime/` + `surfaces/` (phase 5). The state/orchestration files (`inkInput`, `inkViewModel`, `inkKeymap`, `inkWorkflows`) still live here as a **transitional home** until phases 6–7 of [#890](https://github.com/gfargo/coco/issues/890) move them into `src/workstation/state/`; `inkRuntime` stays as a thin boot shim.
 
 If you find yourself wanting `src/git/` to import from `src/workstation/`, the right move is almost always to push the workstation-specific shaping back into the workstation. The data layer should expose neutral overview types; the workstation decides how to render them.
 
@@ -252,8 +266,8 @@ The current layout reflects an in-flight refactor tracked in [#890](https://gith
 - ✅ **Phase 2** (#891) — pruned dead Inquirer-era branch from `interactive.ts`.
 - ✅ **Phase 3** (#894) — promoted shared git-data layer from `commands/log/` to `src/git/`.
 - ✅ **Phase 4** (#893) — promoted workstation chrome to `src/workstation/chrome/` (this directory). Dropped the `ink*` prefix.
-- ⏳ **Phase 5** — split `inkRuntime.ts` (6,039 LOC) into `workstation/runtime/app.tsx` + per-surface modules under `workstation/surfaces/<view>/`.
-- ⏳ **Phase 6** — split `inkInput.ts` (2,259 LOC) into per-surface key handlers under `workstation/state/input/`.
-- ⏳ **Phase 7** — split `inkViewModel.ts` (1,526 LOC) into per-surface state slices under `workstation/state/`.
+- ✅ **Phase 5** — split the old ~6k-LOC `inkRuntime.ts` into `workstation/runtime/app.ts` + the chrome renderers (`runtime/{header,sidebar,mainPanel,detailPanel,footer,overlays}.ts`) + per-surface modules under `workstation/surfaces/<view>/`. `commands/log/inkRuntime.ts` is now a ~150-LOC boot shim only.
+- ⏳ **Phase 6** — split `inkInput.ts` (~3,400 LOC) into per-surface key handlers under `workstation/state/input/`.
+- ⏳ **Phase 7** — split `inkViewModel.ts` (~2,600 LOC) into per-surface state slices under `workstation/state/`.
 
-When you see an `ink*.ts` file in `src/commands/log/`, treat it as a transitional resident. The 5 that remain (`inkRuntime`, `inkInput`, `inkViewModel`, `inkKeymap`, `inkWorkflows`) are exactly the targets of phases 5–7.
+The render layer (phase 5) has landed under `workstation/runtime/` + `workstation/surfaces/`. What remains in `src/commands/log/` are the four state/orchestration residents still targeted by phases 6–7 — `inkInput`, `inkViewModel`, `inkKeymap`, `inkWorkflows` — plus the thin `inkRuntime` boot shim. Treat those as transitional; new render code belongs under `workstation/`.

--- a/src/workstation/runtime/footer.test.ts
+++ b/src/workstation/runtime/footer.test.ts
@@ -258,6 +258,10 @@ describe('renderFooter', () => {
       const contextual = childAt(childAt(tree, 0), 0)
       return String(contextual.props.children)
     }
+    const globalText = (tree: Node): string => {
+      const global = childAt(childAt(tree, 0), 1)
+      return String(global.props.children)
+    }
 
     it('prepends the switcher with the focused pane bracketed', () => {
       // Default focus is the commit list ('commits') → main is active.
@@ -292,6 +296,47 @@ describe('renderFooter', () => {
       // Mid-glance: the switcher / peek-open hint step aside.
       expect(text).not.toContain('tab:')
       expect(text).not.toContain('v peek')
+    })
+
+    // #1135 — the switcher (~29 cells) + peek affordance already claim
+    // most of an 80-cell row, so the per-view hint tail and globals are
+    // trimmed to fit the narrow floor without clipping.
+    it('trims the global cluster to the recovery essentials', () => {
+      // Drops g jump / < back / : cmds — those stay reachable via `?`.
+      expect(globalText(renderSinglePane(makeState()))).toBe('? help · q quit')
+      expect(globalText(renderSinglePane(makeState({ activeView: 'status' })))).toBe('? help · q quit')
+    })
+
+    it('keeps the single-pane footer within the 80-col floor', () => {
+      const FLOOR = 80
+      const cases: Array<Partial<LogInkState>> = [
+        {}, // history / main
+        { activeView: 'status' },
+        { activeView: 'compose' },
+        { activeView: 'diff', diffSource: 'worktree' },
+        { focus: 'detail' }, // inspector visible
+        { focus: 'sidebar' }, // sidebar via Tab
+        { focus: 'sidebar', peekReturnFocus: 'commits' }, // peeking
+      ]
+      for (const overrides of cases) {
+        const tree = renderSinglePane(makeState(overrides))
+        const ctx = contextualText(tree)
+        const glob = globalText(tree)
+        // Row 1 width = contextual (joined) + global (joined) + paddingX(2)
+        // + at least one cell of space-between gap. Arrow / dot glyphs are
+        // single-width, so string length is a faithful column proxy here.
+        expect(ctx.length + glob.length + 2 + 1).toBeLessThanOrEqual(FLOOR)
+        // …and the orientation anchor is never the thing that gets cut.
+        expect(ctx).toContain(overrides.peekReturnFocus ? 'v/esc → main' : 'tab:')
+      }
+    })
+
+    it('keeps only the leading per-view hint in single-pane', () => {
+      // Full three-pane history footer leads with `↑/↓ move`, `enter
+      // diff`, … — single-pane keeps the first and drops the tail.
+      const text = contextualText(renderSinglePane(makeState()))
+      expect(text).toContain('↑/↓ move')
+      expect(text).not.toContain('enter diff')
     })
   })
 


### PR DESCRIPTION
Two small, independent cleanups from the #1135 single-pane work, kept as separate commits.

## 1. `fix(ui)`: trim the single-pane footer to fit the 80-col floor
The pane switcher (`tab: sidebar [main] inspector`, ~29 cells) plus the `v peek` / snap-back affordance already claim most of an 80-cell row, so appending the **full** per-view hint cluster + the five-item global cluster overflowed — Ink wrapped row 1 onto a second line, which the height-2 footer then clipped (the status line and half the hints vanished).

Now the narrow single-pane footer keeps the switcher (the orientation anchor) whole, the peek affordance, and **only the leading per-view hint**; the global cluster shrinks to the two recovery essentials (`? help · q quit`). Dropped bindings stay one `?` away. **Three-pane footers are unchanged.**

A new footer test pins row 1 within the 80-col budget across representative views (history / status / compose / diff / inspector / sidebar / peeking) so a future hint addition can't silently re-overflow.

## 2. `docs(ws)`: refresh the workstation README for the landed runtime/surface split
The README still described the pre-refactor world — `inkRuntime.ts` as the `LogInkApp` component, a file tree with only `chrome/`, a keypress-flow diagram ending at `inkRuntime.ts`, and phase 5 marked pending with stale LOC figures (6,039 / 2,259 / 1,526).

Reality: **phase 5 of #890 has landed.** The render layer lives in `workstation/runtime/` (app + header/sidebar/mainPanel/detailPanel/footer/overlays) and `workstation/surfaces/<view>/`; `inkRuntime.ts` is a ~150-LOC boot shim. Phases 6–7 (input/state → `workstation/state/`) are still pending. Updated the file tree, the flow diagram, the "add a new view" render step, the Boundaries note, and the Migration checklist to match what's actually on disk. Docs only.

## Validation
- `tsc` ✓ · `eslint` ✓ · the touched suites (footer + keymap, 64 tests) pass.
- Full local `jest`: only the three known heavy/environmental suites flaked (LLM integration, an LLM parser eval, and the git-timing suite — all near their timeout ceilings under full-parallel load); none are in this change's blast radius. Letting CI confirm on isolated runners.