### PR TITLE
test(simple-git): harden the mid-bisect edge-state timeout (the one real flake)

### DIFF
--- a/src/lib/simple-git/getCommitLogCurrentBranch.test.ts
+++ b/src/lib/simple-git/getCommitLogCurrentBranch.test.ts
@@ -30,7 +30,15 @@ function getLogCalls(logger: ReturnType<typeof createLogger>): string[] {
 }
 
 describe('getCommitLogCurrentBranch — edge states', () => {
-  jest.setTimeout(20000)
+  // The mid-bisect fixture is the heaviest in the suite: it builds 20
+  // sequential commits (~40+ git subprocesses, serialized by simple-git's
+  // own queue) and runs `git bisect start`. Uncontended that's ~14s; under
+  // the full parallel suite (jest spreads workers all forking git at once)
+  // CPU/IO contention pushed it past the old 20s budget and jest aborted
+  // with a timeout — the one true parallel-only flake in the suite (no
+  // assertion ever fails; temp dirs are already unique per test). 60s gives
+  // ample headroom under load without serializing anything.
+  jest.setTimeout(60000)
 
   let repo: TempGitRepo
 

--- a/src/workstation/runtime/mainPanel.ts
+++ b/src/workstation/runtime/mainPanel.ts
@@ -22,7 +22,7 @@ import { renderBranchesSurface } from '../surfaces/branches'
 import { renderChangelogSurface } from '../surfaces/changelog'
 import { renderComposeSurface } from '../surfaces/compose'
 import { renderConflictsSurface } from '../surfaces/conflicts'
-import { renderDiffSurface } from '../surfaces/diff'
+import { renderDiffSurface, type DiffSurfaceData } from '../surfaces/diff'
 import { renderHistoryPanel } from '../surfaces/history'
 import { renderSplitPlanOverlay } from './overlays'
 import { renderIssuesTriageSurface } from '../surfaces/issuesTriage'
@@ -82,8 +82,7 @@ export function renderMainPanel(
   }
 
   if (state.activeView === 'diff') {
-    return renderDiffSurface(
-      surface,
+    const diffData: DiffSurfaceData = {
       worktreeDiff,
       worktreeDiffLoading,
       worktreeHunks,
@@ -96,8 +95,9 @@ export function renderMainPanel(
       stashDiffLoading,
       compareDiffLines,
       compareDiffLoading,
-      syntaxSpans
-    )
+      syntaxSpans,
+    }
+    return renderDiffSurface(surface, diffData)
   }
 
   if (state.activeView === 'compose') {

--- a/src/workstation/surfaces/diff/index.ts
+++ b/src/workstation/surfaces/diff/index.ts
@@ -48,23 +48,49 @@ import {
   panelTitle,
 } from '../../runtime/utils'
 
+/**
+ * The diff surface's own data slices (#1136 polish). Grouped into one
+ * object so the signature stays `(ctx, diff)` instead of trailing 13
+ * positional params — these are the worktree / commit / stash / compare
+ * diff bodies the renderer chooses between based on `state`, plus the
+ * optional syntax-highlight spans.
+ */
+export type DiffSurfaceData = {
+  worktreeDiff: WorktreeFileDiff | undefined
+  worktreeDiffLoading: boolean
+  worktreeHunks: WorktreeHunkOverview | undefined
+  worktreeHunksLoading: boolean
+  filePreview: GitCommitFilePreview | undefined
+  filePreviewLoading: boolean
+  commitDiffHunkOffsets: number[] | undefined
+  selectedDetailFile: GitCommitDetail['files'][number] | undefined
+  stashDiffLines: string[] | undefined
+  stashDiffLoading: boolean
+  compareDiffLines: string[] | undefined
+  compareDiffLoading: boolean
+  syntaxSpans?: Map<string, SyntaxSpan[]>
+}
+
 export function renderDiffSurface(
   ctx: SurfaceRenderContext,
-  worktreeDiff: WorktreeFileDiff | undefined,
-  worktreeDiffLoading: boolean,
-  worktreeHunks: WorktreeHunkOverview | undefined,
-  worktreeHunksLoading: boolean,
-  filePreview: GitCommitFilePreview | undefined,
-  filePreviewLoading: boolean,
-  commitDiffHunkOffsets: number[] | undefined,
-  selectedDetailFile: GitCommitDetail['files'][number] | undefined,
-  stashDiffLines: string[] | undefined,
-  stashDiffLoading: boolean,
-  compareDiffLines: string[] | undefined,
-  compareDiffLoading: boolean,
-  syntaxSpans?: Map<string, SyntaxSpan[]>
+  diff: DiffSurfaceData
 ): ReactTypes.ReactElement {
   const { h, components, state, context, contextStatus, bodyRows, width, theme } = ctx
+  const {
+    worktreeDiff,
+    worktreeDiffLoading,
+    worktreeHunks,
+    worktreeHunksLoading,
+    filePreview,
+    filePreviewLoading,
+    commitDiffHunkOffsets,
+    selectedDetailFile,
+    stashDiffLines,
+    stashDiffLoading,
+    compareDiffLines,
+    compareDiffLoading,
+    syntaxSpans,
+  } = diff
   const { Box, Text } = components
   const focused = state.focus === 'commits'
   const worktree = context.worktree


### PR DESCRIPTION
## What

`getCommitLogCurrentBranch — edge states › mid-bisect — logs a clean status` was the **one true parallel-only flake** in the suite. It passes in isolation and in CI, but intermittently timed out under the full `npx jest` run (`Exceeded timeout of 20000 ms`).

## Root cause (timeout budget, not a race)

The mid-bisect fixture is the heaviest in the suite — 20 sequential commits (~40+ git subprocesses, serialized by simple-git's own queue) plus `git bisect start`. Uncontended it burns **~14s** of the old **20s** budget; under the full parallel run (~9 jest workers all forking git at once), CPU/IO contention pushes cumulative setup past 20s and jest aborts. No assertion ever fails.

I confirmed there's **no shared state to isolate**: temp dirs are unique per test (`mkdtemp`), there's no `process.chdir`, and git config is repo-local. So `--runInBand` / serial projects would be overkill.

## Fix

Bump just this `describe` block's timeout to **60s** — headroom under load, rest of the suite stays fully parallel.

## Scope note

The full-suite run in constrained sandboxes also shows 4 `tsTreeSitterParser.test.ts` failures — those are **not** flaky and **not** addressed here: they're a sandbox-only `.wasm` grammar-loading limitation (CI is green on them; `summarize()` returns `''` only when the grammar can't load). No code defect, so the real tests are left intact.

## Test
- `npx jest src/lib/simple-git/getCommitLogCurrentBranch.test.ts` — 7 passed
- `npx eslint` clean