### PR TITLE
docs(ui): drop stale '⊘ no PR' from headerChips example comment

### DIFF
--- a/src/workstation/chrome/headerChips.ts
+++ b/src/workstation/chrome/headerChips.ts
@@ -2,7 +2,10 @@
  * Header chip builder. Turns the workstation's title-bar state into an
  * ordered list of small visually-distinct chips:
  *
- *   coco · gfargo/coco · ⎇ main · ✓ clean · ⊘ no PR · [NORMAL]
+ *   coco · gfargo/coco · ⎇ main · ✓ clean · [NORMAL]
+ *
+ * The PR chip is appended only when a pull request exists (#1133); there
+ * is no "no PR" placeholder chip.
  *
  * Pre-refactor the title bar concatenated every segment into a single
  * Text span, which made the eye read the whole thing as one run of


### PR DESCRIPTION
Comment-only. The title-bar example in the `headerChips.ts` doc comment still showed the `⊘ no PR` chip, which #1133 removed — the PR chip now appears only when a pull request exists. Updates the example to `coco · gfargo/coco · ⎇ main · ✓ clean · [NORMAL]` and notes the chip is conditional.

Last remaining nit from the post-merge docs audit; `src/workstation/README.md` was already refreshed by #1141/#1142, and `CLAUDE.md` (gitignored local steering) was updated in the working copy.