### PR TITLE
feat(ui): stash v2 — richer rows, stash-from-anywhere (gZ), quick WIP stash

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/gfargo/dev/gfargo/coco/node_modules

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -756,6 +756,32 @@ describe('log Ink input interactions', () => {
     expect(state.statusMessage).toBe('jumped to stash')
   })
 
+  it('stashes all changes with the gZ chord — even from status, where bare S is the split flow', () => {
+    let state = createLogInkState(rows)
+    // status is one of the views where `S` is claimed by commit-split, so
+    // the chord is the only single-gesture stash-create path here.
+    state = applyLogInkAction(state, { type: 'pushView', value: 'status' })
+    state = applyInput(state, 'g')
+
+    const events = getLogInkInputEvents(state, 'Z')
+    expect(events[0]).toMatchObject({
+      type: 'action',
+      action: { type: 'openInputPrompt', kind: 'create-stash' },
+    })
+  })
+
+  it('opens the stash prompt from the createStash palette command', () => {
+    const state = createLogInkState(rows)
+    const command = getLogInkPaletteCommands().find((c) => c.id === 'createStash')
+    if (!command) throw new Error('createStash palette command missing')
+
+    const events = getLogInkPaletteExecuteEvents(command, state)
+    expect(events[0]).toMatchObject({
+      type: 'action',
+      action: { type: 'openInputPrompt', kind: 'create-stash' },
+    })
+  })
+
   it('moves the selected branch with arrow keys when in branches view', () => {
     let state = createLogInkState(rows)
     state = applyLogInkAction(state, { type: 'pushView', value: 'branches' })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -590,6 +590,12 @@ export function getLogInkPaletteExecuteEvents(
       return [action({ type: 'toggleGraph' })]
     case 'navigateHome':
       return [action({ type: 'navigateHome' })]
+    case 'createStash':
+      return [action({
+        type: 'openInputPrompt',
+        kind: 'create-stash',
+        label: 'Stash message (empty = WIP)',
+      })]
     case 'navigateStatus':
       return [action({ type: 'pushView', value: 'status' })]
     case 'navigateDiff':
@@ -1570,6 +1576,18 @@ export function getLogInkInputEvents(
       action({ type: 'pushView', value: 'stash' }),
       action({ type: 'setStatus', value: 'jumped to stash' }),
     ]
+  }
+
+  // `gZ` chord: stash all changes from ANY view — including status / diff /
+  // compose, where bare `S` is claimed by the commit-split flow. Mnemonic
+  // pair with `gz` (jump to the stash *view*). Opens the same message
+  // prompt; an empty message creates a quick WIP stash.
+  if (state.pendingKey === 'g' && inputValue === 'Z') {
+    return [action({
+      type: 'openInputPrompt',
+      kind: 'create-stash',
+      label: 'Stash message (empty = WIP)',
+    })]
   }
 
   if (state.pendingKey === 'g' && inputValue === 'w') {
@@ -2932,7 +2950,7 @@ export function getLogInkInputEvents(
     return [action({
       type: 'openInputPrompt',
       kind: 'create-stash',
-      label: 'Stash message',
+      label: 'Stash message (empty = WIP)',
     })]
   }
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -15,6 +15,7 @@ export type LogInkCommandId =
   | 'gitignoreFile'
   | 'stageAll'
   | 'stagePathspec'
+  | 'createStash'
   | 'commit'
   | 'cycleSort'
   | 'editCommit'
@@ -294,6 +295,13 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     keys: ['gz'],
     label: 'stash',
     description: 'Push the stash view (gz; gs is reserved for status).',
+    contexts: ['normal'],
+  },
+  {
+    id: 'createStash',
+    keys: ['gZ'],
+    label: 'stash changes',
+    description: 'Stash all changes (tracked + untracked) with an optional message — works from any view, including status/diff/compose. Empty message creates a quick WIP stash.',
     contexts: ['normal'],
   },
   {
@@ -770,6 +778,7 @@ const BINDING_CATEGORY_BY_ID: Partial<Record<LogInkCommandId, LogInkBindingCateg
   gitignoreFile: 'mutate',
   stageAll: 'mutate',
   stagePathspec: 'mutate',
+  createStash: 'mutate',
   quit: 'essentials',
   refresh: 'essentials',
   navigateBack: 'essentials',

--- a/src/git/stashActions.test.ts
+++ b/src/git/stashActions.test.ts
@@ -28,15 +28,17 @@ describe('log stash actions', () => {
     expect(git.raw).toHaveBeenNthCalledWith(4, ['stash', 'drop', 'stash@{0}'])
   })
 
-  it('rejects empty stash messages before invoking git', async () => {
+  it('creates a quick WIP stash (no -m) when the message is empty', async () => {
     const git = {
-      raw: jest.fn(),
+      raw: jest.fn().mockResolvedValue(''),
     }
 
     await expect(createStash(git as never, '   ')).resolves.toEqual({
-      ok: false,
-      message: 'Stash cancelled: empty message.',
+      ok: true,
+      message: 'Created WIP stash',
     })
-    expect(git.raw).not.toHaveBeenCalled()
+    // Empty message → bare `git stash push -u`; git supplies its own
+    // "WIP on <branch>" subject. Naming is optional, not required.
+    expect(git.raw).toHaveBeenCalledWith(['stash', 'push', '-u'])
   })
 })

--- a/src/git/stashActions.ts
+++ b/src/git/stashActions.ts
@@ -22,11 +22,14 @@ async function runAction(action: () => Promise<unknown>, successMessage: string)
 export function createStash(git: SimpleGit, message: string): Promise<BranchActionResult> {
   const trimmedMessage = message.trim()
 
+  // Empty message → a quick WIP stash. Naming is optional: git generates
+  // its own `WIP on <branch>: <sha> <subject>` message, same as a bare
+  // `git stash`. Both paths pass `-u` so untracked files come along.
   if (!trimmedMessage) {
-    return Promise.resolve({
-      ok: false,
-      message: 'Stash cancelled: empty message.',
-    })
+    return runAction(
+      () => git.raw(['stash', 'push', '-u']),
+      'Created WIP stash'
+    )
   }
 
   return runAction(

--- a/src/workstation/KEYMAP.md
+++ b/src/workstation/KEYMAP.md
@@ -110,7 +110,8 @@ the which-key overlay lists them live when you press `g`.
 | `g c` | Compose (commit message) |
 | `g b` | Branches |
 | `g t` | Tags |
-| `g z` | Stashes |
+| `g z` | Stashes (the view) |
+| `g Z` | **Stash all changes** (action, not nav) — opens the message prompt; works from *any* view incl. status/diff/compose. Empty message = quick WIP stash. |
 | `g w` | Worktrees |
 | `g p` | Pull request |
 | `g P` | PR triage |
@@ -307,7 +308,7 @@ arriving from another view.** Disambiguation is by the dispatch model above.
 | `a` | status/worktree-diff → stage whole file · stashes → apply · PR/PR-triage → approve |
 | `m` | branches/tags/history (compare flow) → mark compare base · PR/PR-triage → merge |
 | `i` | status → open `.gitignore` picker · history → interactive rebase |
-| `S` | status/diff/compose → commit-split flow · elsewhere → create stash |
+| `S` | status/diff/compose → commit-split flow · elsewhere → create stash (the view-agnostic create path is `gZ`, which also works in the staging triad) |
 | `P` | branches → push branch · tags → push tag (takes precedence over the global push) |
 | `D` | worktrees → remove worktree + branch · branches → delete branch |
 | `x` / `X` | PR → close · issues → close / reopen · stashes → drop (`X`) |

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -3495,9 +3495,9 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         return deleteRemoteTag(git, tag.name)
       },
       'create-stash': async () => {
-        const message = payload?.trim()
-        if (!message) return { ok: false, message: 'Stash message required' }
-        return createStash(git, message)
+        // Empty is allowed — createStash turns it into a quick WIP stash
+        // (git's own `WIP on <branch>` subject). Naming is optional.
+        return createStash(git, payload ?? '')
       },
       // #783 — full PR action panel handlers. Each wraps the matching
       // pullRequestActions verb. Strategy / body arrives via `payload`

--- a/src/workstation/surfaces/stash/index.ts
+++ b/src/workstation/surfaces/stash/index.ts
@@ -9,6 +9,8 @@
 
 import type * as ReactTypes from 'react'
 import { isLogInkContextKeyLoading } from '../../chrome/context'
+import { formatCompactRelativeDate } from '../../chrome/dateFormat'
+import { getRenderNow } from '../../chrome/snapshotMode'
 import { formatLogInkLoading, formatLogInkStashEmpty } from '../../chrome/surfaceStates'
 import { truncateCells } from '../../chrome/text'
 import {
@@ -39,6 +41,11 @@ export function renderStashSurface(ctx: SurfaceRenderContext): ReactTypes.ReactE
     : `${stashes.length}/${allStashes.length} stashes${filterLabel}`
   const emptyLabel = formatLogInkStashEmpty({ filter: state.filter })
   const loadingLabel = formatLogInkLoading({ resource: 'stashes' })
+  const now = getRenderNow()
+  // Available width for a row: box width minus the 2-cell horizontal
+  // padding. Truncate to it (with a small floor) instead of a magic 140
+  // so the richer meta degrades gracefully on narrow terminals.
+  const rowWidth = Math.max(20, width - 2)
   const lines: ReactTypes.ReactNode[] = loading
     ? [h(Text, { key: 'stash-loading', dimColor: true }, loadingLabel)]
     : stashes.length === 0
@@ -47,11 +54,25 @@ export function renderStashSurface(ctx: SurfaceRenderContext): ReactTypes.ReactE
         const index = startIndex + offset
         const isSelected = index === selected
         const cursor = isSelected ? '>' : ' '
+        // Surface the metadata the StashEntry already carries — origin
+        // branch, file count, and relative age — between the ref and the
+        // message, so the list answers "which stash is this?" without an
+        // Enter→diff round trip.
+        const age = formatCompactRelativeDate(stash.date, now)
+        const fileCount = stash.files.length
+        const meta = [
+          stash.branch ? `on ${stash.branch}` : '',
+          fileCount > 0 ? `${fileCount} file${fileCount === 1 ? '' : 's'}` : '',
+          age,
+        ].filter(Boolean).join(' · ')
+        const rowText = meta
+          ? `${cursor} ${stash.ref.padEnd(11)} ${meta}  ${stash.message}`
+          : `${cursor} ${stash.ref.padEnd(11)} ${stash.message}`
         return h(Text, {
           key: `stash-${index}`,
           bold: isSelected,
           dimColor: !isSelected,
-        }, truncateCells(`${cursor} ${stash.ref.padEnd(12)} ${stash.message}`, 140))
+        }, truncateCells(rowText, rowWidth))
       })
 
   const stashHasMoreAbove = startIndex > 0 && stashes.length > 0


### PR DESCRIPTION
The "friction-fix" cluster from the stash-workflow audit — the everyday papercuts.

## 1. Richer list rows
The stash list showed only `ref + message`, while every `StashEntry` already carries `date`, origin `branch`, and `files[]`. Rows now read:

```
> stash@{0}  on main · 3 files · 2w  refactor: extract parser
```

Age comes from the snapshot-safe `getRenderNow()` clock (no test time-drift), and rows truncate to the real pane width instead of a magic `140`. Pure presentation — no new git calls.

## 2. Stash from any view — the `gZ` chord
Bare `S` is claimed by the commit-split flow in **status / diff / compose** — exactly the views where you're looking at changes you might want to stash. New global **`gZ`** chord opens the stash-message prompt from *any* view (mnemonic pair with `gz` = jump to the stash *view*).

Registered in `LOG_INK_KEY_BINDINGS`, so it appears in the which-key overlay, the `:` command palette, and `?` help — and the collision-guard test confirms it's conflict-free.

## 3. Quick WIP stash
Naming is no longer mandatory. An empty message runs bare `git stash push -u` and lets git supply its own `WIP on <branch>` subject. The prompt label now hints `(empty = WIP)`.

## Files
- `git/stashActions.ts` — empty message → WIP stash
- `workstation/runtime/app.ts` — drop the "message required" rejection
- `commands/log/inkInput.ts` — `gZ` chord handler + `createStash` palette execute case + prompt-label hint
- `commands/log/inkKeymap.ts` — `createStash` command id + binding (`gZ`) + category
- `workstation/surfaces/stash/index.ts` — richer rows
- `workstation/KEYMAP.md` — `gZ` chord + `S` overload note

## Test
- `npx tsc --noEmit` clean · `npx eslint` clean
- New tests: `stashActions` (empty → WIP), `inkInput` (`gZ` chord + `createStash` palette)
- Collision guard passes (gZ conflict-free); full touched-area suite green — **1264 tests**

Next up: the **power PR** (rename, stash-branch, staged-only/keep-index, inspector preview, undo-drop, partial stash).