### PR TITLE
feat(ui): stash power actions — rename, branch, undo-drop, apply-index, create options

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -782,6 +782,46 @@ describe('log Ink input interactions', () => {
     })
   })
 
+  describe('stash view power actions', () => {
+    function stashViewState() {
+      return applyLogInkAction(createLogInkState(rows), { type: 'pushView', value: 'stash' })
+    }
+
+    it('R opens the rename-stash prompt', () => {
+      const events = getLogInkInputEvents(stashViewState(), 'R', {}, { stashCount: 2 })
+      expect(events[0]).toMatchObject({ type: 'action', action: { type: 'openInputPrompt', kind: 'rename-stash' } })
+    })
+
+    it('b opens the stash-branch prompt', () => {
+      const events = getLogInkInputEvents(stashViewState(), 'b', {}, { stashCount: 2 })
+      expect(events[0]).toMatchObject({ type: 'action', action: { type: 'openInputPrompt', kind: 'stash-branch' } })
+    })
+
+    it('A applies restoring the index', () => {
+      const events = getLogInkInputEvents(stashViewState(), 'A', {}, { stashCount: 2 })
+      expect(events).toEqual([{ type: 'runWorkflowAction', id: 'apply-stash-index' }])
+    })
+
+    it('u undoes the last drop — available even when the list is now empty', () => {
+      const events = getLogInkInputEvents(stashViewState(), 'u', {}, { stashCount: 0 })
+      expect(events).toEqual([{ type: 'runWorkflowAction', id: 'undo-drop-stash' }])
+    })
+
+    it('submitting an EMPTY create-stash prompt fires a WIP stash (does not bounce)', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, {
+        type: 'openInputPrompt',
+        kind: 'create-stash',
+        label: 'Stash message (empty = WIP)',
+      })
+      const events = getLogInkInputEvents(state, '', { return: true })
+      expect(events).toEqual([
+        { type: 'runWorkflowAction', id: 'create-stash', payload: '' },
+        { type: 'action', action: { type: 'closeInputPrompt' } },
+      ])
+    })
+  })
+
   it('moves the selected branch with arrow keys when in branches view', () => {
     let state = createLogInkState(rows)
     state = applyLogInkAction(state, { type: 'pushView', value: 'branches' })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -801,6 +801,15 @@ function hasUnsavedComposeDraft(state: LogInkState): boolean {
 function submitInputPrompt(state: LogInkState): LogInkInputEvent[] {
   if (!state.inputPrompt) return []
   const value = state.inputPrompt.value.trim()
+  // create-stash allows an EMPTY value → quick WIP stash (git supplies its
+  // own "WIP on <branch>" subject). Handled before the generic empty guard
+  // so an empty stash prompt commits a WIP stash instead of bouncing.
+  if (state.inputPrompt.kind === 'create-stash') {
+    return [
+      { type: 'runWorkflowAction', id: 'create-stash', payload: value },
+      action({ type: 'closeInputPrompt' }),
+    ]
+  }
   if (!value) {
     return [action({ type: 'setStatus', value: 'enter a value or press esc to cancel', kind: 'warning' })]
   }
@@ -2710,6 +2719,25 @@ export function getLogInkInputEvents(
   }
   if (inputValue === 'p' && isStashActionTarget(state) && context.stashCount) {
     return [{ type: 'runWorkflowAction', id: 'pop-stash' }]
+  }
+  // `A` applies restoring the staged/unstaged split (`git stash apply
+  // --index`) — distinct from `a` (plain apply).
+  if (inputValue === 'A' && isStashActionTarget(state) && context.stashCount) {
+    return [{ type: 'runWorkflowAction', id: 'apply-stash-index' }]
+  }
+  // `b` turns the cursored stash into a new branch (`git stash branch`).
+  if (inputValue === 'b' && isStashActionTarget(state) && context.stashCount) {
+    return [action({ type: 'openInputPrompt', kind: 'stash-branch', label: 'New branch from stash' })]
+  }
+  // `R` renames the cursored stash (store-under-new-message + drop old).
+  if (inputValue === 'R' && isStashActionTarget(state) && context.stashCount) {
+    return [action({ type: 'openInputPrompt', kind: 'rename-stash', label: 'Rename stash' })]
+  }
+  // `u` undoes the last drop. Gated on the view, NOT the count, so it
+  // still works right after you drop your only stash (the list is empty
+  // but the dropped commit is recoverable by hash).
+  if (inputValue === 'u' && isStashActionTarget(state)) {
+    return [{ type: 'runWorkflowAction', id: 'undo-drop-stash' }]
   }
   // Per-view tag action: `P` pushes the selected tag to origin. Letter
   // is scoped to the tags target so it doesn't collide with `p` for

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -136,7 +136,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ stashes', 'enter diff', 'a apply', 'p pop', 'X drop', 'y yank'],
+      contextual: ['↑/↓ stashes', 'enter diff', 'a/A apply', 'p pop', 'R rename', 'b branch', 'X drop · u undo'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -1259,7 +1259,7 @@ function computeLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogInkF
 
   if (options.activeView === 'stash') {
     return {
-      contextual: ['↑/↓ stashes', 'enter diff', 'a apply', 'p pop', 'X drop', 'y yank'],
+      contextual: ['↑/↓ stashes', 'enter diff', 'a/A apply', 'p pop', 'R rename', 'b branch', 'X drop · u undo'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -688,6 +688,8 @@ export type LogInkInputPromptKind =
   | 'rename-branch'
   | 'set-upstream'
   | 'create-stash'
+  | 'rename-stash'
+  | 'stash-branch'
   | 'gitignore-pattern'
   | 'stage-pathspec'
   | 'reset-mode'

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -337,6 +337,25 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: true,
     },
     {
+      // Palette-only create variants (empty `key`): no global hotkey to
+      // collide with `S` / `gZ`, reachable from `:`. Both stash a quick
+      // WIP entry with the requested scope.
+      id: 'stash-staged',
+      key: '',
+      label: 'Stash staged only',
+      description: 'Stash just the staged (index) changes — `git stash push --staged`.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      id: 'stash-keep-index',
+      key: '',
+      label: 'Stash keeping index',
+      description: 'Stash everything but leave the index intact for an immediate commit — `git stash push --keep-index`.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
       id: 'remove-worktree',
       key: 'W',
       label: 'Remove worktree',

--- a/src/git/stashActions.test.ts
+++ b/src/git/stashActions.test.ts
@@ -1,4 +1,13 @@
-import { applyStash, createStash, dropStash, popStash } from './stashActions'
+import {
+  applyStash,
+  applyStashKeepIndex,
+  createStash,
+  dropStash,
+  popStash,
+  renameStash,
+  restoreStash,
+  stashBranch,
+} from './stashActions'
 import { StashEntry } from './stashData'
 
 const stash: StashEntry = {
@@ -40,5 +49,61 @@ describe('log stash actions', () => {
     // Empty message → bare `git stash push -u`; git supplies its own
     // "WIP on <branch>" subject. Naming is optional, not required.
     expect(git.raw).toHaveBeenCalledWith(['stash', 'push', '-u'])
+  })
+
+  it('builds create-stash args for the option variants', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+
+    await createStash(git as never, 'wip', { keepIndex: true })
+    expect(git.raw).toHaveBeenLastCalledWith(['stash', 'push', '-u', '--keep-index', '-m', 'wip'])
+
+    await createStash(git as never, 'idx', { stagedOnly: true })
+    // --staged is index-only: no -u, no --keep-index.
+    expect(git.raw).toHaveBeenLastCalledWith(['stash', 'push', '--staged', '-m', 'idx'])
+
+    await createStash(git as never, '', { pathspec: 'src/a.ts  src/b.ts' })
+    expect(git.raw).toHaveBeenLastCalledWith(['stash', 'push', '-u', '--', 'src/a.ts', 'src/b.ts'])
+  })
+
+  it('applies with --index to restore the staged split', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+    await expect(applyStashKeepIndex(git as never, stash)).resolves.toMatchObject({ ok: true })
+    expect(git.raw).toHaveBeenCalledWith(['stash', 'apply', '--index', 'stash@{0}'])
+  })
+
+  it('creates a branch from a stash', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+    await expect(stashBranch(git as never, stash, ' feat/x ')).resolves.toMatchObject({ ok: true })
+    expect(git.raw).toHaveBeenCalledWith(['stash', 'branch', 'feat/x', 'stash@{0}'])
+  })
+
+  it('rejects a stash-branch with an empty name without touching git', async () => {
+    const git = { raw: jest.fn() }
+    await expect(stashBranch(git as never, stash, '   ')).resolves.toMatchObject({ ok: false })
+    expect(git.raw).not.toHaveBeenCalled()
+  })
+
+  it('renames a stash: store the same commit, then drop the shifted old ref', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+    const at2: StashEntry = { ...stash, ref: 'stash@{2}', hash: 'deadbeef' }
+
+    await expect(renameStash(git as never, at2, ' better name ')).resolves.toMatchObject({ ok: true })
+    // store the same commit under the new message first…
+    expect(git.raw).toHaveBeenNthCalledWith(1, ['stash', 'store', '-m', 'better name', 'deadbeef'])
+    // …then drop the original, whose index shifted +1 after the store.
+    expect(git.raw).toHaveBeenNthCalledWith(2, ['stash', 'drop', 'stash@{3}'])
+  })
+
+  it('refuses to rename with an empty message or missing hash', async () => {
+    const git = { raw: jest.fn() }
+    await expect(renameStash(git as never, stash, '  ')).resolves.toMatchObject({ ok: false })
+    await expect(renameStash(git as never, { ...stash, hash: '' }, 'x')).resolves.toMatchObject({ ok: false })
+    expect(git.raw).not.toHaveBeenCalled()
+  })
+
+  it('restores a dropped stash by hash (undo)', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+    await expect(restoreStash(git as never, 'abc123', 'save docs')).resolves.toMatchObject({ ok: true })
+    expect(git.raw).toHaveBeenCalledWith(['stash', 'store', '-m', 'save docs', 'abc123'])
   })
 })

--- a/src/git/stashActions.ts
+++ b/src/git/stashActions.ts
@@ -19,22 +19,125 @@ async function runAction(action: () => Promise<unknown>, successMessage: string)
   }
 }
 
-export function createStash(git: SimpleGit, message: string): Promise<BranchActionResult> {
-  const trimmedMessage = message.trim()
+export type CreateStashOptions = {
+  /** `--keep-index`: stash everything but leave the index intact. */
+  keepIndex?: boolean
+  /** `--staged`: stash only the staged (index) changes. */
+  stagedOnly?: boolean
+  /** `-- <paths>`: stash only the matching paths (partial stash). */
+  pathspec?: string
+}
 
-  // Empty message → a quick WIP stash. Naming is optional: git generates
-  // its own `WIP on <branch>: <sha> <subject>` message, same as a bare
-  // `git stash`. Both paths pass `-u` so untracked files come along.
-  if (!trimmedMessage) {
-    return runAction(
-      () => git.raw(['stash', 'push', '-u']),
-      'Created WIP stash'
-    )
+export function createStash(
+  git: SimpleGit,
+  message: string,
+  options: CreateStashOptions = {}
+): Promise<BranchActionResult> {
+  const trimmedMessage = message.trim()
+  const args = ['stash', 'push']
+
+  // `--staged` is index-only, so untracked / `--keep-index` don't apply;
+  // every other mode includes untracked (`-u`). `--keep-index` leaves the
+  // index populated for an immediate follow-up commit.
+  if (options.stagedOnly) {
+    args.push('--staged')
+  } else {
+    args.push('-u')
+    if (options.keepIndex) args.push('--keep-index')
   }
 
+  if (trimmedMessage) args.push('-m', trimmedMessage)
+
+  const paths = options.pathspec?.trim()
+  if (paths) args.push('--', ...paths.split(/\s+/))
+
+  const what = options.stagedOnly
+    ? 'staged changes'
+    : paths
+      ? `“${paths}”`
+      : options.keepIndex
+        ? 'changes (index kept)'
+        : ''
+  const success = trimmedMessage
+    ? `Created stash: ${trimmedMessage}`
+    : what
+      ? `Stashed ${what}`
+      : 'Created WIP stash'
+
+  return runAction(() => git.raw(args), success)
+}
+
+/**
+ * Apply a stash while restoring the original staged/unstaged split via
+ * `--index`. Faithfully reinstates what was staged at stash time; git
+ * errors (surfaced to the user) if the index can no longer be replayed,
+ * in which case plain `applyStash` is the fallback.
+ */
+export function applyStashKeepIndex(git: SimpleGit, stash: StashEntry): Promise<BranchActionResult> {
   return runAction(
-    () => git.raw(['stash', 'push', '-u', '-m', trimmedMessage]),
-    `Created stash: ${trimmedMessage}`
+    () => git.raw(['stash', 'apply', '--index', stash.ref]),
+    `Applied ${stash.ref} (index restored)`
+  )
+}
+
+/**
+ * Create a new branch from a stash's base commit, apply the stash onto
+ * it, and drop the stash on success — `git stash branch`. The canonical
+ * recovery when a stash no longer applies cleanly onto the current
+ * branch (the branch starts at the exact commit the stash was made on).
+ */
+export function stashBranch(git: SimpleGit, stash: StashEntry, branchName: string): Promise<BranchActionResult> {
+  const trimmed = branchName.trim()
+  if (!trimmed) {
+    return Promise.resolve({ ok: false, message: 'Cancelled: empty branch name.' })
+  }
+  return runAction(
+    () => git.raw(['stash', 'branch', trimmed, stash.ref]),
+    `Created branch ${trimmed} from ${stash.ref}`
+  )
+}
+
+/**
+ * Rename a stash. Git has no native rename, so re-store the SAME commit
+ * under a new message (`git stash store`), then drop the original entry.
+ *
+ * Order matters: `store` prepends a fresh `stash@{0}` and shifts every
+ * existing index down by one, so the original `stash@{N}` becomes
+ * `stash@{N+1}` — that shifted ref is what we drop. Storing first keeps
+ * the commit reachable throughout.
+ */
+export function renameStash(git: SimpleGit, stash: StashEntry, newMessage: string): Promise<BranchActionResult> {
+  const trimmed = newMessage.trim()
+  if (!trimmed) {
+    return Promise.resolve({ ok: false, message: 'Rename cancelled: empty message.' })
+  }
+  if (!stash.hash) {
+    return Promise.resolve({ ok: false, message: 'Cannot rename: stash commit hash unavailable.' })
+  }
+  const match = /stash@\{(\d+)\}/.exec(stash.ref)
+  if (!match) {
+    return Promise.resolve({ ok: false, message: `Cannot rename: unrecognized stash ref ${stash.ref}.` })
+  }
+  const shiftedOldRef = `stash@{${Number(match[1]) + 1}}`
+
+  return runAction(async () => {
+    await git.raw(['stash', 'store', '-m', trimmed, stash.hash])
+    await git.raw(['stash', 'drop', shiftedOldRef])
+  }, `Renamed ${stash.ref} → ${trimmed}`)
+}
+
+/**
+ * Re-store a previously dropped stash by its commit hash — the undo for
+ * a `dropStash`. The dropped stash's commit stays in the object database
+ * until git gc, so storing it back recreates the entry (at `stash@{0}`).
+ */
+export function restoreStash(git: SimpleGit, hash: string, message: string): Promise<BranchActionResult> {
+  if (!hash) {
+    return Promise.resolve({ ok: false, message: 'Nothing to restore.' })
+  }
+  return runAction(
+    () => git.raw(['stash', 'store', '-m', message || 'restored stash', hash]),
+    'Restored dropped stash'
   )
 }
 

--- a/src/workstation/KEYMAP.md
+++ b/src/workstation/KEYMAP.md
@@ -239,8 +239,17 @@ The hunk is the unit of action here.
 |-----|--------|
 | `Enter` | Open the stash diff |
 | `a` | Apply (keep) |
+| `A` | Apply restoring the staged/unstaged split (`git stash apply --index`) |
 | `p` | Pop (apply + drop) |
+| `R` | Rename the stash (re-store under a new message, drop the old) |
+| `b` | Create a branch from the stash (`git stash branch`) |
 | `X` | Drop (confirm) |
+| `u` | Undo the last drop (re-store by commit hash) |
+| `y` | Yank the stash ref |
+
+Create a stash with `gZ` (any view) or `S` (outside the staging triad). The
+`:` palette also carries **stash staged only** and **stash keeping index**
+variants.
 
 ### Conflicts
 

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -170,7 +170,7 @@ import {
     revertCommit,
     startInteractiveRebase,
 } from '../../git/historyActions'
-import { applyStash, checkoutFileFromStash, createStash, dropStash, popStash } from '../../git/stashActions'
+import { applyStash, applyStashKeepIndex, checkoutFileFromStash, createStash, dropStash, popStash, renameStash, restoreStash, stashBranch } from '../../git/stashActions'
 import { ApplyHunkTarget, applyHunkPatch } from '../../git/hunkActions'
 import { removeWorktree, removeWorktreeAndBranch } from '../../git/worktreeActions'
 import { abortOperation, continueOperation, resolveConflictOurs, resolveConflictTheirs, stageConflictResolved } from '../../git/operationActions'
@@ -710,6 +710,10 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   const loadingMoreCommitsRef = React.useRef(false)
   const loadMoreRequestRef = React.useRef(0)
   const mountedRef = React.useRef(true)
+  // Last dropped stash {hash, message}, captured before `drop-stash` runs
+  // so `undo-drop-stash` can re-store it. The dropped commit survives in
+  // the object DB until gc, so the hash is enough to bring it back.
+  const lastDroppedStashRef = React.useRef<{ hash: string; message: string } | null>(null)
 
   // P4.3 — idle tip rotation. tickIndex 0 ⇒ no tip; the hook bumps it after
   // a grace window of empty statusMessage and then on a steady cadence, so
@@ -3100,7 +3104,16 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
           : all
         const stash = visible[Math.min(state.selectedStashIndex, visible.length - 1)]
         if (!stash) return { ok: false, message: 'No stash selected' }
+        // Remember the dropped commit so `u` can undo it.
+        if (stash.hash) lastDroppedStashRef.current = { hash: stash.hash, message: stash.message }
         return dropStash(git, stash)
+      },
+      'undo-drop-stash': async () => {
+        const dropped = lastDroppedStashRef.current
+        if (!dropped) return { ok: false, message: 'Nothing to undo — no stash dropped this session' }
+        const result = await restoreStash(git, dropped.hash, dropped.message)
+        if (result.ok) lastDroppedStashRef.current = null
+        return result
       },
       'apply-stash': async () => {
         const all = context.stashes?.stashes || []
@@ -3111,6 +3124,15 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         if (!stash) return { ok: false, message: 'No stash selected' }
         return applyStash(git, stash)
       },
+      'apply-stash-index': async () => {
+        const all = context.stashes?.stashes || []
+        const visible = state.filter
+          ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], state.filter))
+          : all
+        const stash = visible[Math.min(state.selectedStashIndex, visible.length - 1)]
+        if (!stash) return { ok: false, message: 'No stash selected' }
+        return applyStashKeepIndex(git, stash)
+      },
       'pop-stash': async () => {
         const all = context.stashes?.stashes || []
         const visible = state.filter
@@ -3119,6 +3141,24 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         const stash = visible[Math.min(state.selectedStashIndex, visible.length - 1)]
         if (!stash) return { ok: false, message: 'No stash selected' }
         return popStash(git, stash)
+      },
+      'rename-stash': async () => {
+        const all = context.stashes?.stashes || []
+        const visible = state.filter
+          ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], state.filter))
+          : all
+        const stash = visible[Math.min(state.selectedStashIndex, visible.length - 1)]
+        if (!stash) return { ok: false, message: 'No stash selected' }
+        return renameStash(git, stash, payload ?? '')
+      },
+      'stash-branch': async () => {
+        const all = context.stashes?.stashes || []
+        const visible = state.filter
+          ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], state.filter))
+          : all
+        const stash = visible[Math.min(state.selectedStashIndex, visible.length - 1)]
+        if (!stash) return { ok: false, message: 'No stash selected' }
+        return stashBranch(git, stash, payload ?? '')
       },
       'bisect-good': async () => {
         if (!context.bisect?.active) return { ok: false, message: 'No bisect in progress' }
@@ -3499,6 +3539,8 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         // (git's own `WIP on <branch>` subject). Naming is optional.
         return createStash(git, payload ?? '')
       },
+      'stash-staged': async () => createStash(git, payload ?? '', { stagedOnly: true }),
+      'stash-keep-index': async () => createStash(git, payload ?? '', { keepIndex: true }),
       // #783 — full PR action panel handlers. Each wraps the matching
       // pullRequestActions verb. Strategy / body arrives via `payload`
       // — input prompts validate before they reach here, but the


### PR DESCRIPTION
The "power" cluster from the stash-workflow audit, built on stash v2 (#1145).

## Stash-view actions
| Key | Action |
|-----|--------|
| `R` | **Rename** — git has no native rename, so re-store the same commit under a new message, then drop the original (store first to keep the commit reachable; the old ref's index shifts +1). |
| `b` | **Stash → branch** (`git stash branch`) — the canonical recovery when a stash no longer applies onto the current branch. |
| `A` | **Apply restoring the index** (`git stash apply --index`) — faithfully reinstates the staged/unstaged split; distinct from plain `a`. |
| `u` | **Undo the last drop** — `drop` now remembers the dropped commit hash; `u` re-stores it (recoverable until gc). Gated on the *view*, not the count, so it works right after you drop your last stash. |

## Create options
The `:` palette carries **Stash staged only** (`--staged`) and **Stash keeping index** (`--keep-index`) — palette-only workflows, no global hotkey to collide with `S`/`gZ`. `createStash` gained a `CreateStashOptions` param (`keepIndex` / `stagedOnly` / `pathspec`).

## Bug fix (latent, from #1145)
Submitting an **empty** create-stash prompt was bounced by the generic empty-value guard *before* reaching the WIP path — so the advertised "empty = WIP" was unreachable via the UI. `create-stash` is now handled before that guard. Covered by a new end-to-end submit test.

## Already done
- **Inspector preview (item 7)** already exists — `formatStashPreview` shows ref / branch / commit / date / message / file list. No change needed.

## Deferred (one item)
- **Partial / pathspec stash (item 9, "hard")** — the git-action layer (`createStash({ pathspec })`) is built and **unit-tested**, but the right UI gesture is an open UX question (no clean key is free; `gS` risks fat-fingering `gs`=status). Wiring it is a small follow-up once we pick the trigger. Flagging rather than forcing a bad binding.

## Test
- `npx tsc --noEmit` clean · `npx eslint` clean
- New tests: action layer (rename/branch/apply-index/restore/options), inkInput wiring (`R`/`b`/`A`/`u` + empty-submit), footer hints
- **1826 tests green** across git / commands / workstation, incl. the collision guard