### PR TITLE
feat(screenshot): demo-stash-workflow GIF recipe

### DIFF
--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -1305,6 +1305,30 @@ export const RECIPES: ScreenshotRecipe[] = [
       { kind: 'sleep', ms: 1800 },
     ],
   },
+  {
+    name: 'demo-stash-workflow',
+    description: 'Stash like a pro: open the Stashes view (rich rows — on <branch> · N files · age), rename one (R), see the row update + inspector preview',
+    scenario: 'stashed-changes',
+    command: 'ui',
+    emitGif: true,
+    dimensions: { cols: 150, rows: 38 },
+    actions: [
+      { kind: 'sleep', ms: 3200 },
+      // Jump to the Stashes view — rows now read "stash@{0}  on main ·
+      // 3 files · 2w  <message>" with the inspector previewing contents.
+      { kind: 'type', text: 'gz' },
+      { kind: 'sleep', ms: 2600 },
+      // Rename the cursored stash — git has no native rename, so coco
+      // re-stores the commit under a new message and drops the old entry.
+      { kind: 'type', text: 'R' },
+      { kind: 'sleep', ms: 900 },
+      { kind: 'type', text: 'auth refactor — wip' },
+      { kind: 'sleep', ms: 900 },
+      { kind: 'key', key: 'Enter' },
+      // The row's message updates in place; the rest of the list is intact.
+      { kind: 'sleep', ms: 2600 },
+    ],
+  },
 ]
 
 export function findRecipe(name: string): ScreenshotRecipe | undefined {


### PR DESCRIPTION
Adds the recipe for an animated capture of the stash v2 / power workflow.

## What
`demo-stash-workflow` (GIF, 150×38, `stashed-changes` scenario): open the Stashes view (`gz`) → the new **rich rows** (`on <branch> · N files · age`) + inspector preview → rename a stash (`R` → type → Enter) → the row updates in place.

Mirrors the existing `demo-staging-hunks` recipe structure.

## Regeneration note
The existing `ui-stash-list`, `ui-single-pane-narrow`, and `ui-single-pane-peek` recipes already render the new UI on re-run — they only need **regeneration**, not recipe changes. Once generated + synced, the four media items land:
1. `demo-stash-workflow.gif` (new)
2. `ui-stash-list.png` (richer rows)
3. `ui-single-pane-narrow.png` / `ui-single-pane-peek.png`
4. themed diff/status refreshes

## Why no generated bytes in this PR
Image generation is currently blocked: the shared `node_modules` lost `@gfargo/git-scenarios` + `tsx` to concurrent-agent churn, and I won't run `npm install` while several agents share the tree. The recipe is the durable source — `npm run screenshot -- --recipe demo-stash-workflow` + `npm run syncScreenshots` produces the assets once the toolchain is whole. The `.www` card wiring will follow with the actual GIF (so there's no broken-image window).