### PR TITLE
fix(stash): show stash@{N} index refs (drop --date=iso, use %cI)

### DIFF
--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -102,13 +102,16 @@ export const RECIPES: ScreenshotRecipe[] = [
   },
   {
     name: 'ui-stash-list',
-    description: 'Workstation sidebar Stashes tab with multiple stashes',
+    description: 'Workstation Stashes view — rich rows (on <branch> · N files · age) + inspector preview',
     scenario: 'stashed-changes',
     command: 'ui',
     actions: [
-      { kind: 'sleep', ms: 800 },
+      // Cold-cache first paint shows "loading context" for a beat; wait it
+      // out so `gz` lands after the stash context is ready and the promoted
+      // view actually opens (otherwise the capture catches the history view).
+      { kind: 'sleep', ms: 3500 },
       { kind: 'type', text: 'gz' },
-      { kind: 'sleep', ms: 400 },
+      { kind: 'sleep', ms: 1200 },
     ],
   },
 
@@ -1313,7 +1316,8 @@ export const RECIPES: ScreenshotRecipe[] = [
     emitGif: true,
     dimensions: { cols: 150, rows: 38 },
     actions: [
-      { kind: 'sleep', ms: 3200 },
+      // Wait out the cold-cache "loading context" beat before the gz chord.
+      { kind: 'sleep', ms: 4000 },
       // Jump to the Stashes view — rows now read "stash@{0}  on main ·
       // 3 files · 2w  <message>" with the inspector previewing contents.
       { kind: 'type', text: 'gz' },

--- a/src/git/stashData.ts
+++ b/src/git/stashData.ts
@@ -108,10 +108,18 @@ export async function getStashOverview(git: SimpleGit): Promise<StashOverview> {
   //   %gd  — stash reflog selector (stash@{N})
   //   %H   — stash commit hash
   //   %P   — space-separated parent hashes (first = base, see StashEntry.baseHash)
-  //   %ci  — committer date, ISO format
+  //   %cI  — committer date, strict ISO 8601
   //   %gs  — reflog subject ("WIP on main: <subject>")
+  //
+  // NOTE: we deliberately do NOT pass `--date=iso`. That flag rewrites the
+  // `%gd` selector from the index form (`stash@{0}`) into a timestamp
+  // (`stash@{2026-06-03 17:29:23 -0400}`), which is noisy in the list, eats
+  // row width, and — critically — breaks `renameStash`, which parses the
+  // `stash@{N}` index out of the ref. `%cI` gives a strict-ISO date that's
+  // independent of `--date`, so we get both a clean index ref and a
+  // parseable date.
   const stashes = parseStashList(
-    await git.raw(['stash', 'list', '--date=iso', '--format=%gd%x1f%H%x1f%P%x1f%ci%x1f%gs'])
+    await git.raw(['stash', 'list', '--format=%gd%x1f%H%x1f%P%x1f%cI%x1f%gs'])
   )
 
   return {


### PR DESCRIPTION
## Bug
`git stash list --date=iso` rewrites the `%gd` reflog selector from the index form (`stash@{0}`) into a full timestamp (`stash@{2026-06-03 17:29:23 -0400}`). That:
- is noisy in the Stashes list and eats row width (messages truncate to `WI…`), and
- **breaks `renameStash`** (#1146), which parses the `stash@{N}` index out of the ref to compute the post-`store` drop target.

## Fix
Drop `--date=iso` and switch the date field to `%cI` (strict ISO 8601, independent of `--date`). Net: clean index refs **and** a parseable date — no other behavior change.

Verified end-to-end against a `stashed-changes` scenario: the Stashes view now reads `stash@{0}  on main · 1 file · today  WIP: …` with the message intact (was `stash@{2026-06-03 17:29:23 -0400} … WI…`).

Also bumps the `ui-stash-list` + `demo-stash-workflow` screenshot recipes' settle so the `gz` chord lands *after* the cold-cache context load (otherwise the capture catches the history view).

## Test
- `stashData` tests mock the git output (no list-command arg assertion) and still parse the `stash@{0}` form — unaffected.
- Validated functionally by regenerating the stash screenshot in a clean checkout (coco runs correctly with the change).