### PR TITLE
fix(stash): correct renameStash order — drop then store (was a no-op + wrong drop)

### DIFF
--- a/src/git/stashActions.test.ts
+++ b/src/git/stashActions.test.ts
@@ -83,15 +83,17 @@ describe('log stash actions', () => {
     expect(git.raw).not.toHaveBeenCalled()
   })
 
-  it('renames a stash: store the same commit, then drop the shifted old ref', async () => {
+  it('renames a stash: drop the original entry first, then re-store the commit under the new message', async () => {
     const git = { raw: jest.fn().mockResolvedValue('') }
     const at2: StashEntry = { ...stash, ref: 'stash@{2}', hash: 'deadbeef' }
 
     await expect(renameStash(git as never, at2, ' better name ')).resolves.toMatchObject({ ok: true })
-    // store the same commit under the new message first…
-    expect(git.raw).toHaveBeenNthCalledWith(1, ['stash', 'store', '-m', 'better name', 'deadbeef'])
-    // …then drop the original, whose index shifted +1 after the store.
-    expect(git.raw).toHaveBeenNthCalledWith(2, ['stash', 'drop', 'stash@{3}'])
+    // Drop FIRST — `git stash store` no-ops while the commit is still in
+    // the reflog, so storing first would do nothing and this drop would
+    // hit the wrong entry. Dropping frees the reflog ref…
+    expect(git.raw).toHaveBeenNthCalledWith(1, ['stash', 'drop', 'stash@{2}'])
+    // …then store re-adds the same commit under the new message.
+    expect(git.raw).toHaveBeenNthCalledWith(2, ['stash', 'store', '-m', 'better name', 'deadbeef'])
   })
 
   it('refuses to rename with an empty message or missing hash', async () => {

--- a/src/git/stashActions.ts
+++ b/src/git/stashActions.ts
@@ -98,13 +98,17 @@ export function stashBranch(git: SimpleGit, stash: StashEntry, branchName: strin
 }
 
 /**
- * Rename a stash. Git has no native rename, so re-store the SAME commit
- * under a new message (`git stash store`), then drop the original entry.
+ * Rename a stash. Git has no native rename, so: drop the original entry,
+ * then re-store the SAME commit under the new message.
  *
- * Order matters: `store` prepends a fresh `stash@{0}` and shifts every
- * existing index down by one, so the original `stash@{N}` becomes
- * `stash@{N+1}` — that shifted ref is what we drop. Storing first keeps
- * the commit reachable throughout.
+ * Order matters — and it's the OPPOSITE of what you'd guess. `git stash
+ * store` SILENTLY NO-OPS when the commit is already referenced in the
+ * stash reflog (verified empirically), so storing first does nothing and
+ * a follow-up drop removes the wrong entry. Dropping first removes the
+ * reflog reference (the commit object survives), so the subsequent
+ * `store` actually re-adds it — landing at `stash@{0}` with the new
+ * message. The commit is captured by hash beforehand, so the drop→store
+ * window can't lose it.
  */
 export function renameStash(git: SimpleGit, stash: StashEntry, newMessage: string): Promise<BranchActionResult> {
   const trimmed = newMessage.trim()
@@ -114,15 +118,10 @@ export function renameStash(git: SimpleGit, stash: StashEntry, newMessage: strin
   if (!stash.hash) {
     return Promise.resolve({ ok: false, message: 'Cannot rename: stash commit hash unavailable.' })
   }
-  const match = /stash@\{(\d+)\}/.exec(stash.ref)
-  if (!match) {
-    return Promise.resolve({ ok: false, message: `Cannot rename: unrecognized stash ref ${stash.ref}.` })
-  }
-  const shiftedOldRef = `stash@{${Number(match[1]) + 1}}`
 
   return runAction(async () => {
+    await git.raw(['stash', 'drop', stash.ref])
     await git.raw(['stash', 'store', '-m', trimmed, stash.hash])
-    await git.raw(['stash', 'drop', shiftedOldRef])
   }, `Renamed ${stash.ref} → ${trimmed}`)
 }
 


### PR DESCRIPTION
## Bug (caught by the stash-workflow GIF capture)
`renameStash` (shipped in #1146) did `store -m <new> <hash>` **then** `drop` of the index-shifted ref, assuming `git stash store` prepends a new `stash@{0}`. **It doesn't** — `git stash store` *silently no-ops* when the commit is already referenced in the stash reflog (verified empirically). So the `store` did nothing, indices never shifted, and the follow-up `drop` removed the **wrong** stash — all while the status line reported "Renamed … ✓".

The GIF's final frame showed it red-handed: rename "succeeded" but the list lost `experiment-b` and kept `experiment-c` unchanged.

## Fix
**Drop first, then store.** Dropping the original ref frees the reflog reference (the commit object survives in the object DB), so the subsequent `store` actually re-adds it — landing at `stash@{0}` with the new message. The hash is captured up front, so the drop→store window can't lose it.

Verified against a 3-stash scratch repo:
```
$ git stash drop stash@{0}; git stash store -m "RENAMED-c" <hash>
$ git stash list
stash@{0} RENAMED-c
stash@{1} On main: wip-b
stash@{2} On main: wip-a
```

## Test
Unit test updated to assert the corrected order (`drop stash@{N}` then `store -m … <hash>`). Will also be visible in the regenerated stash-workflow GIF.