### PR TITLE
fix(screenshot): render exact recipe dimensions (vhs padding compensation)

### DIFF
--- a/bin/screenshot/tape.ts
+++ b/bin/screenshot/tape.ts
@@ -142,8 +142,15 @@ export function buildTape(recipe: ScreenshotRecipe, options: TapeOptions): strin
     ``,
     `Set Shell "bash"`,
     `Set FontSize 14`,
-    `Set Width ${dims.cols * 9}`,
-    `Set Height ${dims.rows * 20}`,
+    // Explicit padding + measured per-cell size (≈9.35w × 16.55h at
+    // FontSize 14) so the terminal renders EXACTLY `dims.cols × dims.rows`.
+    // vhs's default padding (~65px/side) otherwise ate ~14 cols / ~8 rows,
+    // which silently shrank the 80×24 single-pane recipes below the
+    // "terminal too small" floor (they captured the fallback message
+    // instead of the UI). Calibrated empirically against Padding 0.
+    `Set Padding 30`,
+    `Set Width ${Math.round(dims.cols * 9.35 + 60)}`,
+    `Set Height ${Math.round(dims.rows * 16.55 + 60)}`,
     `Set TypingSpeed 50ms`,
     `Set CursorBlink false`,
     // Pin the *terminal's* palette to match coco's --theme. coco presets


### PR DESCRIPTION
## Bug
The tape used `Width = cols*9` / `Height = rows*20` and left vhs's **default padding (~65px/side)** in place. That padding ate ~14 cols and ~8 rows, so the **80×24 single-pane recipes** (#1139/#1140) actually rendered at **~63×21** — below coco's 80×24 floor — and captured the "terminal too small" fallback instead of the single-pane UI. (Those recipes were committed without a verified capture.)

## Fix
Set an explicit `Padding 30` and size from the measured per-cell metrics (≈9.35w × 16.55h at FontSize 14) plus the padding, so the terminal renders **exactly** `dims.cols × dims.rows`.

Calibrated against a Padding-0 control: Width 720 → 77 cols, Height 480 → 29 rows ⇒ 9.35px/col, 16.55px/row.

## Verified
- `ui-single-pane-narrow` now renders the real 80×24 single-pane fallback (full-width sidebar pane, no "too small").
- Larger recipes (`ui-stash-list` 140×40, the 150×38 demo GIFs) still look correct — with tighter, intentional padding.