### PR TITLE
fix: untrack the committed node_modules symlink

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/gfargo/dev/gfargo/coco/node_modules


### PR DESCRIPTION
## Bug
A `node_modules` **symlink** (git mode `120000`) pointing at the machine-specific absolute path `/Users/gfargo/dev/gfargo/coco/node_modules` was committed to `main`. `.gitignore` had `node_modules/` (a *directory* pattern), which doesn't match a symlink *file* named `node_modules` — so the stray link slipped past the ignore (swept in by a `git add -A` in a worktree that symlinked its deps).

**Effect:** every fresh `git clone` / `git worktree` / `git reset --hard` recreated `node_modules` as a symlink to one shared directory, so `npm install` wrote through the link and concurrent checkouts stomped each other's dependencies (`tsx`, `eslint`, `@gfargo/git-scenarios` kept vanishing mid-task).

## Fix
- `git rm --cached node_modules` — untrack the symlink (working tree untouched).
- `.gitignore`: `node_modules/` → `node_modules`, so both a directory and a stray symlink are ignored at any depth (`git check-ignore node_modules` now reports it ignored).

## After merge
Contributors with the stray symlink should `rm node_modules && npm install` for a real dependency tree.