### PR TITLE
fix: harden .gitignore against a node_modules symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,10 @@ dist/**/*
 dist/stats.html
 
 # Dependency directories
-node_modules/
+# No trailing slash: ignore a node_modules *directory* AND a stray
+# node_modules *symlink* (a symlink is a file, so `node_modules/` alone
+# misses it — that's how a machine-specific symlink got committed; #1152).
+node_modules
 
 # Logs
 logs


### PR DESCRIPTION
Follow-up to #1152, which removed the stray `node_modules` symlink but left `.gitignore` as `node_modules/` (the unstaged half of the original fix). Changes it to `node_modules` (no trailing slash) so a *symlink file* named node_modules is ignored too — preventing the same machine-specific link from being re-committed. `git check-ignore node_modules` now reports it ignored.