### PR TITLE
fix(stash): keep origin branch when renaming a stash

### DIFF
--- a/src/git/stashActions.test.ts
+++ b/src/git/stashActions.test.ts
@@ -92,8 +92,18 @@ describe('log stash actions', () => {
     // the reflog, so storing first would do nothing and this drop would
     // hit the wrong entry. Dropping frees the reflog ref…
     expect(git.raw).toHaveBeenNthCalledWith(1, ['stash', 'drop', 'stash@{2}'])
-    // …then store re-adds the same commit under the new message.
-    expect(git.raw).toHaveBeenNthCalledWith(2, ['stash', 'store', '-m', 'better name', 'deadbeef'])
+    // …then store re-adds the same commit under the new message, keeping
+    // git's `On <branch>:` prefix so the renamed stash retains its origin
+    // branch (fixture branch = 'main') instead of rendering `on <unknown>`.
+    expect(git.raw).toHaveBeenNthCalledWith(2, ['stash', 'store', '-m', 'On main: better name', 'deadbeef'])
+  })
+
+  it('renames without a branch prefix when the origin branch is unknown', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+    const orphan: StashEntry = { ...stash, ref: 'stash@{0}', hash: 'cafef00d', branch: '<unknown>' }
+
+    await expect(renameStash(git as never, orphan, 'just a name')).resolves.toMatchObject({ ok: true })
+    expect(git.raw).toHaveBeenNthCalledWith(2, ['stash', 'store', '-m', 'just a name', 'cafef00d'])
   })
 
   it('refuses to rename with an empty message or missing hash', async () => {

--- a/src/git/stashActions.ts
+++ b/src/git/stashActions.ts
@@ -119,9 +119,17 @@ export function renameStash(git: SimpleGit, stash: StashEntry, newMessage: strin
     return Promise.resolve({ ok: false, message: 'Cannot rename: stash commit hash unavailable.' })
   }
 
+  // Preserve git's `On <branch>: <subject>` convention so the renamed
+  // stash keeps its origin-branch context. The list + inspector parse the
+  // branch out of that prefix (`parseStashSubject`); a bare message would
+  // render `on <unknown>`. Falls back to the bare message when the branch
+  // is unknown so we never store a misleading `On <unknown>:`.
+  const branch = stash.branch && stash.branch !== '<unknown>' ? stash.branch : ''
+  const storedMessage = branch ? `On ${branch}: ${trimmed}` : trimmed
+
   return runAction(async () => {
     await git.raw(['stash', 'drop', stash.ref])
-    await git.raw(['stash', 'store', '-m', trimmed, stash.hash])
+    await git.raw(['stash', 'store', '-m', storedMessage, stash.hash])
   }, `Renamed ${stash.ref} → ${trimmed}`)
 }
 


### PR DESCRIPTION
A renamed stash rendered `on <unknown>` in the list + inspector — storing the user's bare message dropped git's `On <branch>:` subject prefix that `parseStashSubject` keys on to recover the origin branch.

**Fix:** store the new message as `On <branch>: <subject>` (git's own convention) when the branch is known, so the renamed stash keeps its branch context **and** still displays the clean typed message (the parser strips the prefix). Falls back to the bare message when the branch is unknown.

Surfaced by the stash-workflow marketing GIF, where the renamed row read `on <unknown>`. New test covers both the branch-known and branch-unknown paths.