### PR TITLE
feat(screenshot): recipes for compare-refs, which-key overlay, bulk staging

### DIFF
--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -1337,6 +1337,52 @@ export const RECIPES: ScreenshotRecipe[] = [
       { kind: 'sleep', ms: 2600 },
     ],
   },
+  {
+    name: 'ui-which-key',
+    description: 'Which-key chord overlay — press g to see the live menu of g-chord view selectors',
+    scenario: 'feature-pr-ready',
+    command: 'ui',
+    dimensions: { cols: 150, rows: 38 },
+    actions: [
+      { kind: 'sleep', ms: 3500 },
+      // `g` enters chord-pending mode and pops the which-key overlay
+      // listing every g-continuation (the discoverability surface).
+      { kind: 'type', text: 'g' },
+      { kind: 'sleep', ms: 900 },
+    ],
+  },
+  {
+    name: 'ui-compare-refs',
+    description: 'Compare two refs — mark a branch with m, Enter on another to diff base..head (#779)',
+    scenario: 'branch-sync-showcase',
+    command: 'ui',
+    dimensions: { cols: 150, rows: 38 },
+    actions: [
+      { kind: 'sleep', ms: 3500 },
+      { kind: 'type', text: 'gb' },           // branches view
+      { kind: 'sleep', ms: 1200 },
+      { kind: 'type', text: 'm' },            // mark the cursored branch as compare base
+      { kind: 'sleep', ms: 1000 },
+      { kind: 'key', key: 'Down', count: 2 }, // move to another branch
+      { kind: 'sleep', ms: 600 },
+      { kind: 'key', key: 'Enter' },          // open the compare diff (git diff base..head)
+      { kind: 'sleep', ms: 1800 },
+    ],
+  },
+  {
+    name: 'ui-stage-pathspec',
+    description: 'Bulk staging — + opens a pathspec prompt to stage matching files at once (A stages everything)',
+    scenario: 'dirty-many-files',
+    command: 'ui --view status',
+    dimensions: { cols: 150, rows: 38 },
+    actions: [
+      { kind: 'sleep', ms: 3500 },
+      { kind: 'type', text: '+' },          // open the stage-by-pathspec prompt
+      { kind: 'sleep', ms: 800 },
+      { kind: 'type', text: 'src/*.ts' },   // a glob — goes straight to git, no shell
+      { kind: 'sleep', ms: 1200 },
+    ],
+  },
 ]
 
 export function findRecipe(name: string): ScreenshotRecipe | undefined {

--- a/bin/syncScreenshots.ts
+++ b/bin/syncScreenshots.ts
@@ -114,6 +114,10 @@ const SITE_RECIPES = [
   // Single-pane fallback (narrow terminals)
   'ui-single-pane-narrow',
   'ui-single-pane-peek',
+  // Feature shots that previously had no recipe
+  'ui-which-key',
+  'ui-compare-refs',
+  'ui-stage-pathspec',
   // Themed-view showcase — diff + status across a curated theme set
   'ui-diff-theme-catppuccin',
   'ui-diff-theme-gruvbox',
@@ -219,6 +223,9 @@ const FILENAME_MAP: Record<string, string[]> = {
   'demo-stash-workflow': ['demo-stash-workflow.gif'],
   'ui-single-pane-narrow': ['single-pane-narrow.png'],
   'ui-single-pane-peek': ['single-pane-peek.png'],
+  'ui-which-key': ['which-key.png'],
+  'ui-compare-refs': ['view-compare.png'],
+  'ui-stage-pathspec': ['stage-pathspec.png'],
   'ui-staging-hunks': ['staging-hunks.png'],
   'ui-diff-theme-catppuccin': ['diff-theme-catppuccin.png'],
   'ui-diff-theme-gruvbox': ['diff-theme-gruvbox.png'],


### PR DESCRIPTION
Three features had **no screenshot recipe**; this adds deterministic ones (each verified against its scenario):

- **`ui-which-key`** — press `g` → the which-key chord overlay (the `g`-chord discoverability menu, rendered in the inspector).
- **`ui-compare-refs`** — mark a branch with `m`, `Enter` on another → the cross-ref compare diff (#779), captured on `branch-sync-showcase` (real `feat/ahead-only → feat/synced` diff).
- **`ui-stage-pathspec`** — the `+` stage-by-pathspec prompt on a dirty worktree (companion to `A` stage-all).

Wired into `SITE_RECIPES` + `FILENAME_MAP` → `which-key.png` / `view-compare.png` / `stage-pathspec.png`, so they regenerate + sync with every `screenshot:sync`.