### PR TITLE
feat(screenshot): real PR / triage / issues views via a mock gh

### DIFF
--- a/bin/screenshot.ts
+++ b/bin/screenshot.ts
@@ -203,6 +203,28 @@ async function runRecipe(recipe: ScreenshotRecipe, options: { keepTape: boolean 
   const pngPath = join(SCREENSHOTS_DIR, `${recipe.name}.png`)
   const gifPath = recipe.emitGif ? join(SCREENSHOTS_DIR, `${recipe.name}.gif`) : undefined
 
+  // GitHub-integration recipes: give the scenario repo an `origin` that
+  // coco recognizes as a GitHub remote, and stage a deterministic mock
+  // `gh` on a temp dir we prepend to PATH (so the PR / triage / issues
+  // views render canned data instead of hitting the real CLI).
+  let ghMockDir: string | undefined
+  if (recipe.githubRemote || recipe.ghMock) {
+    const { execSync } = await import('child_process')
+    if (recipe.githubRemote) {
+      execSync(
+        `git -C "${repo.path}" remote add origin "${recipe.githubRemote}" 2>/dev/null || git -C "${repo.path}" remote set-url origin "${recipe.githubRemote}"`,
+        { stdio: 'ignore' }
+      )
+    }
+    if (recipe.ghMock) {
+      const { copyFileSync, chmodSync } = await import('fs')
+      ghMockDir = mkdtempSync(join(tmpdir(), 'coco-gh-mock-'))
+      const dest = join(ghMockDir, 'gh')
+      copyFileSync(join(REPO_ROOT, 'bin', 'screenshot', 'mock-gh'), dest)
+      chmodSync(dest, 0o755)
+    }
+  }
+
   try {
     const tape = buildTape(recipe, {
       cwd: repo.path,
@@ -211,6 +233,7 @@ async function runRecipe(recipe: ScreenshotRecipe, options: { keepTape: boolean 
       cocoCommand: COCO_CLI,
       repoRoot: REPO_ROOT,
       nodeBinDir: NODE_BIN_DIR,
+      ghMockDir,
     })
     writeFileSync(tapePath, tape, 'utf8')
 
@@ -255,6 +278,9 @@ async function runRecipe(recipe: ScreenshotRecipe, options: { keepTape: boolean 
   } finally {
     if (!options.keepTape && existsSync(tapePath)) {
       rmSync(tapePath, { force: true })
+    }
+    if (ghMockDir) {
+      rmSync(ghMockDir, { recursive: true, force: true })
     }
     await repo.cleanup()
   }

--- a/bin/screenshot/mock-gh
+++ b/bin/screenshot/mock-gh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Deterministic mock of the GitHub CLI (`gh`) for the screenshot pipeline.
+#
+# coco's pull-request / PR-triage / issues views shell out to real `gh`
+# (see src/git/githubCli.ts → execFile('gh', …)), which can't be captured
+# in a temp-repo screenshot. Recipes that set `ghMock: true` get this
+# script prepended to PATH so those views render canned, stable data.
+#
+# It switches on `$1 $2` and echoes JSON matching the `--json` field lists
+# coco requests (a superset is fine — gh would return only the requested
+# fields, but coco just reads the ones it needs). Dates are fixed near the
+# COCO_SNAPSHOT_NOW the pipeline pins, so relative ages don't drift.
+
+set -euo pipefail
+cmd="${1:-} ${2:-}"
+
+case "$cmd" in
+  "auth status")
+    # coco only checks the exit code; real gh writes to stderr.
+    echo "github.com: logged in to github.com as octocat (oauth_token)" >&2
+    exit 0
+    ;;
+
+  "pr list")
+    # Workspace per-repo count call: `pr list -R <repo> --state open --json number`.
+    if [[ "$*" == *"--json number"* && "$*" != *"title"* ]]; then
+      echo '[{"number":1234},{"number":1230},{"number":1228}]'
+      exit 0
+    fi
+    cat <<'JSON'
+[
+  {"number":1234,"title":"feat(ui): tactile hunk staging — badges + ↑/↓ nav","url":"https://github.com/gfargo/coco/pull/1234","state":"OPEN","isDraft":false,"headRefName":"feat/hunk-staging","baseRefName":"main","author":{"login":"octocat"},"assignees":[{"login":"gfargo"}],"labels":[{"name":"enhancement"},{"name":"workstation"}],"reviewDecision":"APPROVED","mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","createdAt":"2026-05-28T14:10:00Z","updatedAt":"2026-06-02T09:30:00Z"},
+  {"number":1230,"title":"feat(ui): stash power actions — rename, branch, undo-drop","url":"https://github.com/gfargo/coco/pull/1230","state":"OPEN","isDraft":true,"headRefName":"feat/stash-power","baseRefName":"main","author":{"login":"gfargo"},"assignees":[],"labels":[{"name":"workstation"}],"reviewDecision":"REVIEW_REQUIRED","mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","createdAt":"2026-05-30T11:00:00Z","updatedAt":"2026-06-03T08:00:00Z"},
+  {"number":1228,"title":"fix(stash): show stash@{N} index refs","url":"https://github.com/gfargo/coco/pull/1228","state":"OPEN","isDraft":false,"headRefName":"fix/stash-refs","baseRefName":"main","author":{"login":"contrib-dev"},"assignees":[{"login":"octocat"}],"labels":[{"name":"bug"}],"reviewDecision":"CHANGES_REQUESTED","mergeable":"CONFLICTING","mergeStateStatus":"DIRTY","createdAt":"2026-05-29T16:20:00Z","updatedAt":"2026-06-01T13:45:00Z"}
+]
+JSON
+    ;;
+
+  "pr view")
+    if [[ "${3:-}" =~ ^[0-9]+$ ]]; then
+      # PR detail (inspector): `pr view <#> --json number,body,comments,reviews,statusCheckRollup`.
+      cat <<'JSON'
+{"number":1234,"body":"Makes per-hunk staging deliberate and visible: an accent gutter bar on the selected hunk, ●/○ staged badges on each @@ header, and ↑/↓ to walk hunks.","comments":[{"author":{"login":"gfargo"},"body":"Love the badges — ship it.","createdAt":"2026-06-02T09:00:00Z"}],"reviews":[{"author":{"login":"gfargo"},"state":"APPROVED","body":"Clean. Footer hints match the keys now.","submittedAt":"2026-06-02T09:25:00Z"}],"statusCheckRollup":[{"name":"Test (Node 22)","status":"COMPLETED","conclusion":"SUCCESS"},{"name":"Test (Node 24)","status":"COMPLETED","conclusion":"SUCCESS"},{"name":"Lint","status":"COMPLETED","conclusion":"SUCCESS"},{"name":"Build & package","status":"COMPLETED","conclusion":"SUCCESS"}]}
+JSON
+    else
+      # Current-branch PR (g p): `pr view --json <view fields>`.
+      cat <<'JSON'
+{"number":1234,"title":"feat(ui): tactile hunk staging — badges + ↑/↓ nav","url":"https://github.com/gfargo/coco/pull/1234","state":"OPEN","isDraft":false,"headRefName":"feat/hunk-staging","baseRefName":"main","body":"Makes per-hunk staging deliberate and visible: an accent gutter bar on the selected hunk, ●/○ staged badges on each @@ header, and ↑/↓ to walk hunks.","author":{"login":"octocat"},"reviewDecision":"APPROVED","mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","statusCheckRollup":[{"name":"Test (Node 22)","status":"COMPLETED","conclusion":"SUCCESS"},{"name":"Test (Node 24)","status":"COMPLETED","conclusion":"SUCCESS"},{"name":"Lint","status":"COMPLETED","conclusion":"SUCCESS"},{"name":"Build & package","status":"COMPLETED","conclusion":"SUCCESS"}],"reviews":[{"author":{"login":"gfargo"},"state":"APPROVED"}]}
+JSON
+    fi
+    ;;
+
+  "issue list")
+    cat <<'JSON'
+[
+  {"number":312,"title":"Single-pane fallback for narrow terminals (<100 cols)","url":"https://github.com/gfargo/coco/issues/312","state":"OPEN","author":{"login":"gfargo"},"assignees":[{"login":"gfargo"}],"labels":[{"name":"enhancement"},{"name":"workstation"}],"comments":4,"createdAt":"2026-05-22T10:00:00Z","updatedAt":"2026-06-02T18:00:00Z"},
+  {"number":308,"title":"Renamed stash loses its origin branch (shows <unknown>)","url":"https://github.com/gfargo/coco/issues/308","state":"OPEN","author":{"login":"contrib-dev"},"assignees":[],"labels":[{"name":"bug"}],"comments":2,"createdAt":"2026-05-31T09:15:00Z","updatedAt":"2026-06-03T07:40:00Z"},
+  {"number":301,"title":"Document the deliberate keymap + overload table","url":"https://github.com/gfargo/coco/issues/301","state":"OPEN","author":{"login":"octocat"},"assignees":[{"login":"gfargo"}],"labels":[{"name":"documentation"}],"comments":1,"createdAt":"2026-05-18T12:00:00Z","updatedAt":"2026-05-29T15:00:00Z"},
+  {"number":295,"title":"Stash from any view (gZ) — proposal","url":"https://github.com/gfargo/coco/issues/295","state":"OPEN","author":{"login":"gfargo"},"assignees":[],"labels":[{"name":"enhancement"}],"comments":6,"createdAt":"2026-05-15T08:30:00Z","updatedAt":"2026-05-30T20:10:00Z"}
+]
+JSON
+    ;;
+
+  "issue view")
+    cat <<'JSON'
+{"number":312,"body":"Below ~100 columns the three-pane layout collapses the sidebar and inspector into 8-cell icon rails that waste ~16-20 of 80 columns. At the 80×24 floor that's worse than no panel. Proposal: fold to a single full-width pane, Tab-cycled, with a v peek.","comments":[{"author":{"login":"octocat"},"body":"Yes — an 80×24 tmux split should be first-class.","createdAt":"2026-05-23T11:00:00Z"},{"author":{"login":"gfargo"},"body":"Shipped in 0.60.0 — Tab cycles panes, v peeks the sidebar.","createdAt":"2026-06-02T18:00:00Z"}]}
+JSON
+    ;;
+
+  *)
+    exit 0
+    ;;
+esac

--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -62,6 +62,20 @@ export type ScreenshotRecipe = {
    * the main candidates.
    */
   emitGif?: boolean
+  /**
+   * Add an `origin` remote with this URL to the scenario repo before
+   * coco launches. Needed for GitHub-integration views — coco's
+   * `getGitHubRepository` parses `github.com/<owner>/<repo>` out of the
+   * origin URL. Use `git@github.com:owner/repo.git`.
+   */
+  githubRemote?: string
+  /**
+   * When true, prepend a deterministic mock `gh` (bin/screenshot/mock-gh)
+   * to PATH so the pull-request / PR-triage / issues views render canned
+   * data instead of shelling out to the real GitHub CLI. Pair with
+   * `githubRemote`.
+   */
+  ghMock?: boolean
 }
 
 /**
@@ -1359,13 +1373,13 @@ export const RECIPES: ScreenshotRecipe[] = [
     dimensions: { cols: 150, rows: 38 },
     actions: [
       { kind: 'sleep', ms: 3500 },
-      { kind: 'type', text: 'gb' },           // branches view
+      { kind: 'type', text: 'gb' },         // branches view
       { kind: 'sleep', ms: 1200 },
-      { kind: 'type', text: 'm' },            // mark the cursored branch as compare base
+      { kind: 'type', text: 'm' },          // mark the cursored branch as compare base
       { kind: 'sleep', ms: 1000 },
       { kind: 'key', key: 'Down', count: 2 }, // move to another branch
       { kind: 'sleep', ms: 600 },
-      { kind: 'key', key: 'Enter' },          // open the compare diff (git diff base..head)
+      { kind: 'key', key: 'Enter' },        // open the compare diff (git diff base..head)
       { kind: 'sleep', ms: 1800 },
     ],
   },
@@ -1381,6 +1395,48 @@ export const RECIPES: ScreenshotRecipe[] = [
       { kind: 'sleep', ms: 800 },
       { kind: 'type', text: 'src/*.ts' },   // a glob — goes straight to git, no shell
       { kind: 'sleep', ms: 1200 },
+    ],
+  },
+  {
+    name: 'ui-pull-request',
+    description: 'Pull-request view (g p) — the current branch\'s PR with checks, reviews, and actions (mock gh)',
+    scenario: 'feature-pr-ready',
+    command: 'ui',
+    githubRemote: 'git@github.com:gfargo/coco.git',
+    ghMock: true,
+    dimensions: { cols: 150, rows: 38 },
+    actions: [
+      { kind: 'sleep', ms: 4000 },
+      { kind: 'type', text: 'gp' },
+      { kind: 'sleep', ms: 2000 },
+    ],
+  },
+  {
+    name: 'ui-pr-triage',
+    description: 'PR triage view (g P) — multi-PR list with state/draft/review badges + filter cycling (mock gh)',
+    scenario: 'feature-pr-ready',
+    command: 'ui',
+    githubRemote: 'git@github.com:gfargo/coco.git',
+    ghMock: true,
+    dimensions: { cols: 150, rows: 38 },
+    actions: [
+      { kind: 'sleep', ms: 4000 },
+      { kind: 'type', text: 'gP' },
+      { kind: 'sleep', ms: 2000 },
+    ],
+  },
+  {
+    name: 'ui-issues',
+    description: 'Issues view (g i) — open issues with labels/assignees + inspector body preview (mock gh)',
+    scenario: 'feature-pr-ready',
+    command: 'ui',
+    githubRemote: 'git@github.com:gfargo/coco.git',
+    ghMock: true,
+    dimensions: { cols: 150, rows: 38 },
+    actions: [
+      { kind: 'sleep', ms: 4000 },
+      { kind: 'type', text: 'gi' },
+      { kind: 'sleep', ms: 2000 },
     ],
   },
 ]

--- a/bin/screenshot/tape.ts
+++ b/bin/screenshot/tape.ts
@@ -54,6 +54,12 @@ type TapeOptions = {
    * at runtime inside the VHS shell.
    */
   nodeBinDir: string
+  /**
+   * Optional directory holding a mock `gh`. Prepended to PATH (ahead of
+   * everything) so the pull-request / triage / issues views render
+   * canned data instead of the real GitHub CLI.
+   */
+  ghMockDir?: string
 }
 
 const DEFAULT_DIMENSIONS = { cols: 140, rows: 40 } as const
@@ -180,7 +186,7 @@ export function buildTape(recipe: ScreenshotRecipe, options: TapeOptions): strin
     // Ensure the VHS shell can find node + tsx + git + gh + system utils.
     // Include /usr/local/bin and /opt/homebrew/bin for tools like gh.
     // $PATH expands to the shell's existing PATH (includes /usr/bin etc).
-    `Type "export PATH=${quoteTapeString(options.repoRoot)}/node_modules/.bin:${quoteTapeString(options.nodeBinDir)}:/usr/local/bin:/opt/homebrew/bin:$PATH"`,
+    `Type "export PATH=${options.ghMockDir ? `${quoteTapeString(options.ghMockDir)}:` : ''}${quoteTapeString(options.repoRoot)}/node_modules/.bin:${quoteTapeString(options.nodeBinDir)}:/usr/local/bin:/opt/homebrew/bin:$PATH"`,
     `Enter`,
     `Sleep 300ms`,
     // Snapshot mode pin — freezes wall-clock `now` for relative

--- a/bin/syncScreenshots.ts
+++ b/bin/syncScreenshots.ts
@@ -118,6 +118,10 @@ const SITE_RECIPES = [
   'ui-which-key',
   'ui-compare-refs',
   'ui-stage-pathspec',
+  // GitHub-integration views (mock-gh) — real data, no longer stubbed
+  'ui-pull-request',
+  'ui-pr-triage',
+  'ui-issues',
   // Themed-view showcase — diff + status across a curated theme set
   'ui-diff-theme-catppuccin',
   'ui-diff-theme-gruvbox',
@@ -151,7 +155,12 @@ const FILENAME_MAP: Record<string, string[]> = {
   'ui-tags': ['view-tags.png'],
   'ui-stash-list': ['view-stash.png'],
   'ui-worktrees': ['view-worktrees.png'],
-  'ui-history-pr-ready': ['workstation-history.png', 'view-pull-request.png', 'view-pr-triage.png', 'view-issues.png'],
+  'ui-history-pr-ready': ['workstation-history.png'],
+  // The PR / triage / issues views render real (mock-gh) data now, so they
+  // back their own marketing images instead of stubbing to the history shot.
+  'ui-pull-request': ['view-pull-request.png'],
+  'ui-pr-triage': ['view-pr-triage.png'],
+  'ui-issues': ['view-issues.png'],
   'ui-conflicts-merge': ['view-conflicts.png'],
   'ui-reflog': ['view-reflog.png'],
   'ui-bisect-view': ['view-bisect.png'],


### PR DESCRIPTION
## The problem
The **pull-request** (`g p`), **PR-triage** (`g P`), and **issues** (`g i`) views shell out to the real GitHub CLI (`src/git/githubCli.ts` → `execFile('gh', …)`), so they can't be captured in a temp-repo screenshot. The marketing site **stubbed all three with the *history* shot** — `ui-history-pr-ready` mapped to `view-pull-request.png` / `view-pr-triage.png` / `view-issues.png`. The cards literally showed the wrong view.

## The fix — a deterministic mock `gh`
- **`bin/screenshot/mock-gh`** — a bash `gh` that switches on argv (`auth status`, `pr list`, `pr view [#]`, `issue list`, `issue view [#]`) and echoes canned JSON matching coco's exact `--json` field lists (coco-themed PRs + issues; dates pinned near `COCO_SNAPSHOT_NOW` so relative ages don't drift).
- **Recipe opt-ins** `githubRemote` + `ghMock`: the driver adds a `github.com` origin to the scenario repo (so `getGitHubRepository` resolves) and prepends a temp dir holding the mock `gh` to the vhs `PATH`.
- **New recipes** `ui-pull-request` / `ui-pr-triage` / `ui-issues`, which now back `view-pull-request.png` / `view-pr-triage.png` / `view-issues.png` — **un-stubbing** `ui-history-pr-ready`.

## Verified end-to-end (isolated checkout)
- **PR view** — `PR #1234 OPEN`, the full status-check rollup (4 ✓), reviews (approved), description, and the `m merge · a approve · R changes` footer.
- **PR triage** — 3 PRs with state/draft/review badges + labels + filter count + inspector preview (checks, reviews, comments).
- **Issues** — open issues with labels/assignees/comment counts + inspector body + comment preview.

Dev-tooling change; the gh-mock + recipes were validated by generating all three captures.