### PR TITLE
fix(history): dedup appended rows so the commit graph can't loop

### DIFF
--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -1,4 +1,4 @@
-import { GitLogRow } from './data'
+import { GitLogRow, getCommitRows } from './data'
 import {
     DEFAULT_LOG_INK_STATUS_FILTER_MASK,
     applyLogInkAction,
@@ -259,6 +259,41 @@ describe('log Ink view model', () => {
 
     expect(state.commits).toHaveLength(4)
     expect(getSelectedInkCommit(state)?.shortHash).toBe('def5678')
+  })
+
+  it('dedups overlapping appended rows so the history graph cannot loop', () => {
+    let state = createLogInkState(rows)
+
+    // Simulate the anchored `loadCommitContext` page: it re-walks
+    // history from the tip, so its rows OVERLAP everything already
+    // loaded (plus one new older commit on the end). Before the fix
+    // these duplicates accumulated in `state.rows` — which the graph
+    // renderer windows over — stacking the newest commit directly
+    // below the oldest and letting the cursor scroll forever.
+    state = applyLogInkAction(state, {
+      type: 'appendRows',
+      rows: [
+        ...rows,
+        {
+          type: 'commit',
+          graph: '*',
+          shortHash: '9999999',
+          hash: '999999900000',
+          parents: [],
+          date: '2026-04-25',
+          author: 'Coco Test',
+          refs: [],
+          message: 'chore: older commit',
+        },
+      ],
+    })
+
+    // The rows the graph renders over carry no duplicate commit hashes.
+    const commitHashes = getCommitRows(state.rows).map((row) => row.hash)
+    expect(new Set(commitHashes).size).toBe(commitHashes.length)
+    // Three originals + the one genuinely-new older commit.
+    expect(state.commits).toHaveLength(4)
+    expect(commitHashes).toHaveLength(4)
   })
 
   it('tracks selected changed files and diff preview paging', () => {

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -1247,7 +1247,41 @@ function replaceRows(state: LogInkState, rows: GitLogRow[]): LogInkState {
 
 function appendRows(state: LogInkState, rows: GitLogRow[]): LogInkState {
   const selected = getSelectedInkCommit(state)
-  const nextRows = [...state.rows, ...rows]
+
+  // Dedup the merged row list by commit hash so the graph renderer —
+  // which windows directly over `state.rows` (toFullGraphItems →
+  // expandRowsWithSpacers) — and the selection list (deduped commits)
+  // agree on one canonical, duplicate-free row order. Overlapping
+  // appends, notably the anchored `loadCommitContext` page that
+  // re-walks history from the tip, otherwise stack the newest commits
+  // below the oldest ones already loaded. The renderer then shows the
+  // initial commit directly above HEAD and the cursor can scroll
+  // forever through the duplicated tail — the history graph "looping
+  // back on itself". Drop graph-only topology rows that trail a dropped
+  // duplicate commit too, since they describe that duplicate's lanes
+  // and would otherwise dangle.
+  const seenHashes = new Set<string>()
+  const nextRows: GitLogRow[] = []
+  let droppingTrailingGraph = false
+  for (const row of [...state.rows, ...rows]) {
+    if (row.type === 'commit') {
+      if (seenHashes.has(row.hash)) {
+        droppingTrailingGraph = true
+        continue
+      }
+      seenHashes.add(row.hash)
+      droppingTrailingGraph = false
+      nextRows.push(row)
+      continue
+    }
+    // Graph-only topology row: keep it unless it trails a just-dropped
+    // duplicate commit (then it belongs to the duplicate page's lanes).
+    if (droppingTrailingGraph) {
+      continue
+    }
+    nextRows.push(row)
+  }
+
   const seen = new Set<string>()
   const commits = getCommitRows(nextRows).filter((commit) => {
     if (seen.has(commit.hash)) {


### PR DESCRIPTION
## The bug

The workstation history graph (`coco ui --view history`) **wraps around infinitely**. Scrolling past the newest commit (top) eventually renders the oldest "initial commit" directly above HEAD, and you can keep scrolling through the whole history forever — the list looping back on itself, with a `N/N commits` counter that never settles.

<!-- repro: 1712-commit repo, cursor a ref whose target isn't in the loaded window, then scroll -->

## Root cause

`appendRows` deduplicated only the derived `commits` / `filteredCommits` lists (which **selection** ranges over) but left **`state.rows` un-deduped**:

```ts
const nextRows = [...state.rows, ...rows]   // never deduped
```

The graph renderer windows directly over `state.rows` (`toFullGraphItems` → `expandRowsWithSpacers(state.rows, …)`). Overlapping appends — notably the anchored `loadCommitContext` page, which re-walks history **from the tip** whenever you cursor a branch/tag/stash whose target isn't in the loaded window — stacked the newest commits below the oldest ones already loaded. The rendered/scrollable list grew unbounded with duplicates while the cursor (bounded to the deduped list) could never reach a true end.

Reproduced deterministically against this repo's real history: after one anchored append, `state.rows` held **1707 duplicate commit hashes** and the render window placed `b31dfcfc (initial commit, 2023)` immediately above `d6a497eb (HEAD, today)` — exactly the reported symptom.

## The fix

Dedup the merged row list by commit hash inside `appendRows`, dropping duplicate commit rows **plus the graph-only topology rows that trail them** (those describe the duplicate page's lanes and would otherwise dangle). Unique commits and their graph/spacer rows are preserved, so lane continuity is unaffected. With the canonical row list deduped, the graph renderer and the selection list agree on one order — newest pinned at the top, oldest at the bottom, hard clamp at both ends.

## Scope

- **Workstation (`coco ui --view history`)** — fixed (only affected path).
- **`coco log` standalone** — unaffected (no incremental loading; `appendRows`/`getVisibleLogInkHistory` aren't used there).

## Tests

- New regression test in `inkViewModel.test.ts`: an overlapping append leaves `state.rows` free of duplicate commit hashes and doesn't inflate the commit count.
- Existing `appendRows` test (non-overlapping append) unchanged and passing — the fix is a no-op for clean pages.
- `inkViewModel` (167) + history render (40, snapshots intact) suites pass; lint + typecheck clean.