### PR TITLE
fix(screenshot): strip trailing quit from GIF recipes so demos don't end on the shell

### DIFF
--- a/bin/screenshot/tape.ts
+++ b/bin/screenshot/tape.ts
@@ -220,7 +220,23 @@ export function buildTape(recipe: ScreenshotRecipe, options: TapeOptions): strin
     ...(recipe.emitGif ? [`Show`, `Sleep 500ms`, `Output "${options.outputGif}"`, ``] : []),
   ]
 
-  const actionLines = (recipe.actions || []).flatMap((action) => renderAction(action))
+  // For GIF recipes, strip any trailing quit (`q`) the recipe baked into
+  // its actions — plus everything after it. Quitting coco mid-recording
+  // drops to the shell, and that post-exit prompt gets captured as the
+  // GIF's final frame. The recording should end on the last rendered UI
+  // frame; VHS terminates the PTY cleanly when the tape ends, so coco
+  // doesn't need an explicit quit. Screenshot-only recipes keep the quit
+  // (it runs after the PNG is captured and promptly releases the PTY).
+  let actions = recipe.actions || []
+  if (recipe.emitGif) {
+    const lastQuit = actions.reduce(
+      (acc, action, i) =>
+        action.kind === 'type' && action.text.trim() === 'q' ? i : acc,
+      -1,
+    )
+    if (lastQuit !== -1) actions = actions.slice(0, lastQuit)
+  }
+  const actionLines = actions.flatMap((action) => renderAction(action))
 
   // Final settle before VHS captures the closing frame — gives any
   // late-arriving render (e.g. async scenario context loaders) time
@@ -233,12 +249,11 @@ export function buildTape(recipe: ScreenshotRecipe, options: TapeOptions): strin
     // a bare filename; the driver moves it to the final location.
     `Screenshot screenshot.png`,
     `Sleep 200ms`,
-    // For GIF recipes: Hide before quitting so the recording ends
-    // on the last rendered UI frame, not the shell prompt after exit.
-    ...(recipe.emitGif ? [`Hide`] : []),
-    // Quit the workstation cleanly so VHS doesn't hold the PTY open.
-    `Type "q"`,
-    `Sleep 200ms`,
+    // GIF recipes end the recording HERE, on the last rendered UI frame —
+    // their trailing quit is stripped from the actions above, and VHS
+    // terminates the PTY cleanly at tape end. Screenshot-only recipes quit
+    // now (the PNG is already captured, so this just releases the PTY).
+    ...(recipe.emitGif ? [] : [`Type "q"`, `Sleep 200ms`]),
   ]
 
   return [


### PR DESCRIPTION
## The problem

Every demo GIF ended on a stray frame of the **post-exit shell prompt** — the terminal after coco quit, with the raw `tsx … src/index.ts workspace …` launch command still visible. Most visible on the `/workstation` marketing page's `c — clone` and `a — add` demos.

## Root cause

Several `emitGif` recipes bake a `q` quit into their **action list** (not the tape trailer):

- `demo-workstation-tour`
- `demo-workspace-to-ui`
- `demo-workspace-add-repo`
- `demo-workspace-clone`
- `demo-workstation-using`

VHS records that `q` keystroke → coco exits → the shell prompt sits there for the trailing `Sleep` → captured as the GIF's final frame. The previous `Hide`-before-quit wrap in the trailer didn't reliably exclude it (VHS captures the terminal's final state at tape end regardless).

## The fix

In `buildTape`: for GIF recipes, strip the trailing `q` (and everything after it) from the actions, and drop the trailer's quit entirely. The recording now ends on the **last rendered UI frame**; VHS terminates the PTY cleanly when the tape ends. Screenshot-only recipes keep the quit — it runs *after* the PNG is captured and just releases the PTY promptly.

Future-proof: any new GIF recipe that bakes in a quit is handled automatically — no per-recipe edits.

## Verification

Regenerated `demo-workspace-clone` end-to-end and confirmed the final frame is the clean workspace repo-list UI (not the shell). Lint + typecheck clean. Regenerated GIFs are synced to the marketing site separately (`.www`).