### PR TITLE
feat(workstation): g? which-key strip for per-view single keys (#1137)

### DIFF
--- a/bin/screenshot.ts
+++ b/bin/screenshot.ts
@@ -19,7 +19,7 @@
  *   brew install vhs
  */
 
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from 'fs'
 import { spawnSync } from 'child_process'
 import { tmpdir } from 'os'
 import { dirname, join, resolve } from 'path'
@@ -129,6 +129,36 @@ Requires: vhs on PATH (https://github.com/charmbracelet/vhs).`)
 function checkVhsAvailable(): boolean {
   const result = spawnSync('vhs', ['--version'], { stdio: 'pipe' })
   return result.status === 0
+}
+
+/**
+ * Lossless GIF shrink. VHS writes full, undeduplicated frames, so a
+ * short terminal demo lands at 10–20 MB even though almost nothing
+ * changes between frames. `gifsicle -O3` rewrites the file with
+ * inter-frame transparency optimization — typically a 20–30× reduction
+ * with ZERO pixel changes (no `--lossy`, no colour quantization), which
+ * is what keeps marketing-site GIFs viable.
+ *
+ * Best-effort: if `gifsicle` isn't on PATH we leave the raw GIF in place
+ * and print an install hint rather than failing the capture. Optimizing
+ * in the pipeline (not by hand) means `screenshot:sync` regenerations
+ * stay small without anyone remembering a post-step.
+ */
+function optimizeGif(gifPath: string): void {
+  const probe = spawnSync('gifsicle', ['--version'], { stdio: 'pipe' })
+  if (probe.status !== 0) {
+    console.log('  · gifsicle not found — GIF left unoptimized (brew install gifsicle)')
+    return
+  }
+  const before = existsSync(gifPath) ? statSync(gifPath).size : 0
+  const result = spawnSync('gifsicle', ['-O3', '--batch', gifPath], { stdio: 'pipe' })
+  if (result.status !== 0) {
+    console.log('  · gifsicle optimization failed — GIF left unoptimized')
+    return
+  }
+  const after = statSync(gifPath).size
+  const mb = (n: number) => (n / 1048576).toFixed(1)
+  console.log(`  · gifsicle -O3 (lossless): ${mb(before)} MB → ${mb(after)} MB`)
 }
 
 /**
@@ -274,7 +304,10 @@ async function runRecipe(recipe: ScreenshotRecipe, options: { keepTape: boolean 
     }
 
     console.log(`  ✓ ${pngPath}`)
-    if (gifPath) console.log(`  ✓ ${gifPath}`)
+    if (gifPath && existsSync(gifPath)) {
+      optimizeGif(gifPath)
+      console.log(`  ✓ ${gifPath}`)
+    }
   } finally {
     if (!options.keepTape && existsSync(tapePath)) {
       rmSync(tapePath, { force: true })

--- a/bin/screenshot/README.md
+++ b/bin/screenshot/README.md
@@ -116,6 +116,8 @@ Run `npm run screenshot -- --list` for the live list. Current catalog:
 | `ui-command-palette` | `:` command palette |
 | `ui-search-filter` | `/feat` live filter |
 | `ui-inspector-focused` | Tab-focused inspector |
+| `ui-which-key` | `g`-chord which-key overlay |
+| `ui-view-keys` | `g?` per-view single-key strip (#1137) |
 
 ### Workspace (1 screenshot)
 | Recipe | What it shows |
@@ -156,6 +158,7 @@ preset (both on the Catppuccin Mocha terminal palette).
 | `demo-workspace-to-ui` | Workspace → repo → ui → quit back | ~12s |
 | `demo-commit-flow` | `coco commit --dry-run` | ~5s |
 | `demo-changelog` | `coco changelog --branch main` | ~5s |
+| `demo-view-keys` | `g?` per-view key strip, list changes per view (#1137) | ~9s |
 
 ## Environment variables
 
@@ -183,6 +186,10 @@ Keys already in your shell environment take precedence over `.env` values.
 The `.www/` Next.js site previously used hand-drawn artistic terminal mockups. Replace those with real captures from this pipeline. The PNGs are pixel-accurate, work in light + dark themes (different recipes), and update with the workstation rather than drifting out of sync.
 
 For animated demos (e.g. workflow walk-throughs), set `emitGif: true` on the recipe — VHS produces both the still PNG and a GIF in one pass.
+
+### GIF optimization (lossless)
+
+VHS writes full, undeduplicated frames, so even a short demo lands at 10–20 MB — far too heavy for a web page. The driver runs `gifsicle -O3 --batch` on every emitted GIF as a final step: this is **lossless** inter-frame transparency optimization (no `--lossy`, no colour quantization), typically a 20–30× reduction with zero pixel changes (e.g. `demo-view-keys`: 15 MB → 0.4 MB). It's part of the pipeline so `screenshot:sync` regenerations stay small without a manual post-step. `gifsicle` is best-effort — if it isn't on PATH the raw GIF is kept and you'll see an install hint (`brew install gifsicle`).
 
 ## Visual regression checks (future)
 

--- a/bin/screenshot/README.md
+++ b/bin/screenshot/README.md
@@ -69,6 +69,34 @@ Append to `RECIPES` in `bin/screenshot/recipes.ts`:
 
 Then run `npm run screenshot -- --recipe ui-something-new` to capture. If the rendered image looks wrong, pass `--keep-tape` to inspect the generated tape file under `.screenshots/`.
 
+## Authoring motion (GIF) demos
+
+Animated demos are the same recipe shape with `emitGif: true`. They reward a different mindset than stills — a still freezes one moment, a GIF tells a short story — and they have one sharp gotcha (raw file size) that's easy to miss until a 19 MB asset lands in a PR. The conventions and lessons below come from building the demo catalog.
+
+**Conventions**
+
+- **Name them `demo-*`** (motion) vs `ui-*` (stills). The `demo-` prefix is how the catalog, the sync list, and reviewers tell the two apart at a glance.
+- **One story per demo.** A demo should make a single point and end. `demo-view-keys` opens the `g?` strip on history, then on branches — the whole story is "the list is per-view." Resist tacking on extra beats; each one costs both attention and bytes.
+- **Show contrast, not completeness.** Two views proving a behavior changes beats six views enumerating it. The `?` help overlay, theme pickers, and other full-pane takeovers are tempting but dilute the point (and balloon the file — see below).
+- **Register it** in `bin/syncScreenshots.ts` (`SITE_RECIPES` + `FILENAME_MAP`) only if it's used on the marketing site, then `npm run screenshot:sync`.
+
+**Timing**
+
+- GIFs don't need the long PNG settle. Stills use ~3500ms so the single frame is crisp and fully loaded; GIFs record from boot, so a 1200–1500ms lead-in is fine — the early "loading commits" frames read as natural startup, not a bug.
+- Budget **read time** after each action: ~2400–2600ms to let a viewer actually read an overlay, ~1200–1300ms for a view switch, ~500–800ms between quick keystrokes. Too fast and the demo is unreadable; too slow and it drags (and grows).
+- Chords type as one `type` action (`{ kind: 'type', text: 'g?' }`). The brief chord-pending flash that produces is a feature — it shows the relationship between the keys.
+- Don't bake a trailing `q` to quit — the tape builder strips it for GIFs so the recording ends on the last rendered UI frame, not an empty shell prompt.
+
+**File size — the one that bites**
+
+VHS writes **full, undeduplicated frames**, so size scales with `duration × framerate × changing-pixel area`. A short demo routinely lands at 10–20 MB raw — far too heavy for a web page. Three levers, in order of impact:
+
+1. **Optimize losslessly (automatic).** The driver runs `gifsicle -O3 --batch` on every emitted GIF as a final step: **lossless** inter-frame transparency optimization (no `--lossy`, no colour quantization), typically a **20–30× reduction with zero pixel changes** (`demo-view-keys`: 15 MB → 0.4 MB). This is in the pipeline — not a manual post-step — so `screenshot:sync` regenerations stay small. `gifsicle` is best-effort: if it isn't on PATH the raw GIF is kept and you'll see an install hint (`brew install gifsicle`). This single step is why recent demos are ~300 KB while older, pre-optimization ones in the asset history are still 18 MB.
+2. **Trim the story.** Less duration and fewer full-pane redraws = fewer/cheaper frames *before* optimization even runs. Dropping a full-help-overlay beat from `demo-view-keys` took it 19 MB → 13 MB raw on its own; gifsicle then finished the job.
+3. **Shrink dimensions** only as a last resort — it costs legibility and breaks visual consistency with the other demos on the site (keep `150×38` / the `140×40` default unless there's a reason).
+
+Rule of thumb: author for the *story* and timing; let the lossless pass handle the bytes. If a synced GIF is still multi-MB after optimization, the recipe is doing too much — tighten the story rather than reaching for `--lossy`.
+
 ## Scenarios
 
 The list of named scenarios comes from `@gfargo/git-scenarios`. Run `npm run scenario list` to see them. Common picks for screenshot recipes:
@@ -185,11 +213,7 @@ Keys already in your shell environment take precedence over `.env` values.
 
 The `.www/` Next.js site previously used hand-drawn artistic terminal mockups. Replace those with real captures from this pipeline. The PNGs are pixel-accurate, work in light + dark themes (different recipes), and update with the workstation rather than drifting out of sync.
 
-For animated demos (e.g. workflow walk-throughs), set `emitGif: true` on the recipe — VHS produces both the still PNG and a GIF in one pass.
-
-### GIF optimization (lossless)
-
-VHS writes full, undeduplicated frames, so even a short demo lands at 10–20 MB — far too heavy for a web page. The driver runs `gifsicle -O3 --batch` on every emitted GIF as a final step: this is **lossless** inter-frame transparency optimization (no `--lossy`, no colour quantization), typically a 20–30× reduction with zero pixel changes (e.g. `demo-view-keys`: 15 MB → 0.4 MB). It's part of the pipeline so `screenshot:sync` regenerations stay small without a manual post-step. `gifsicle` is best-effort — if it isn't on PATH the raw GIF is kept and you'll see an install hint (`brew install gifsicle`).
+For animated demos (e.g. workflow walk-throughs), set `emitGif: true` on the recipe — VHS produces both the still PNG and a GIF in one pass. The driver then optimizes every GIF losslessly so synced assets stay web-ready (typically 20–30× smaller, zero quality loss); see [Authoring motion (GIF) demos](#authoring-motion-gif-demos) for that and the recipe-design rules that keep demos small and on-point.
 
 ## Visual regression checks (future)
 

--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -1142,6 +1142,31 @@ export const RECIPES: ScreenshotRecipe[] = [
     ],
   },
   {
+    name: 'demo-view-keys',
+    description: 'UI: g? surfaces the single-key actions for the current view; the list changes per view (#1137)',
+    scenario: 'feature-pr-ready',
+    command: 'ui --view history --no-all',
+    emitGif: true,
+    actions: [
+      { kind: 'sleep', ms: 1500 },
+      // g? opens the per-view strip on the history view (cherry-pick c,
+      // revert R, reset Z, …). The brief g-chord flash shows the relationship.
+      { kind: 'type', text: 'g?' },
+      { kind: 'sleep', ms: 2600 },
+      { kind: 'key', key: 'Escape' },
+      { kind: 'sleep', ms: 600 },
+      // Jump to the branches view, then g? again — the strip now lists a
+      // different set (mark-compare m, sort s, yank y, …), proving it's
+      // sourced live from the active view's bindings.
+      { kind: 'type', text: 'gb' },
+      { kind: 'sleep', ms: 1300 },
+      { kind: 'type', text: 'g?' },
+      { kind: 'sleep', ms: 2600 },
+      { kind: 'key', key: 'Escape' },
+      { kind: 'sleep', ms: 700 },
+    ],
+  },
+  {
     name: 'demo-search-filter',
     description: 'UI: open search, type query, see results filter live, clear',
     scenario: 'multi-commit-branch',
@@ -1362,6 +1387,20 @@ export const RECIPES: ScreenshotRecipe[] = [
       // `g` enters chord-pending mode and pops the which-key overlay
       // listing every g-continuation (the discoverability surface).
       { kind: 'type', text: 'g' },
+      { kind: 'sleep', ms: 900 },
+    ],
+  },
+  {
+    name: 'ui-view-keys',
+    description: 'View-keys which-key strip (g?) — the single-key actions available in the current view (#1137)',
+    scenario: 'feature-pr-ready',
+    command: 'ui',
+    dimensions: { cols: 150, rows: 38 },
+    actions: [
+      { kind: 'sleep', ms: 3500 },
+      // `g?` opens the per-view strip listing the bare single keys
+      // (cherry-pick c, revert R, …) live for the current view.
+      { kind: 'type', text: 'g?' },
       { kind: 'sleep', ms: 900 },
     ],
   },

--- a/bin/syncScreenshots.ts
+++ b/bin/syncScreenshots.ts
@@ -120,6 +120,8 @@ const SITE_RECIPES = [
   'ui-single-pane-peek',
   // Feature shots that previously had no recipe
   'ui-which-key',
+  'ui-view-keys',
+  'demo-view-keys',
   'ui-compare-refs',
   'ui-stage-pathspec',
   // GitHub-integration views (mock-gh) — real data, no longer stubbed
@@ -240,6 +242,8 @@ const FILENAME_MAP: Record<string, string[]> = {
   'ui-single-pane-narrow': ['single-pane-narrow.png'],
   'ui-single-pane-peek': ['single-pane-peek.png'],
   'ui-which-key': ['which-key.png'],
+  'ui-view-keys': ['view-keys.png'],
+  'demo-view-keys': ['demo-view-keys.gif'],
   'ui-compare-refs': ['view-compare.png'],
   'ui-stage-pathspec': ['stage-pathspec.png'],
   'ui-staging-hunks': ['staging-hunks.png'],

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -151,6 +151,72 @@ describe('log Ink input interactions', () => {
     expect(state.filterMode).toBe(true)
   })
 
+  describe('view-keys which-key strip (g?, #1137)', () => {
+    it('opens the strip from the g? chord, leaving bare ? as full help', () => {
+      let state = createLogInkState(rows)
+
+      // Bare ? still toggles full help.
+      state = applyInput(state, '?')
+      expect(state.showHelp).toBe(true)
+      expect(state.showViewKeys).toBe(false)
+      state = applyInput(state, '?')
+      expect(state.showHelp).toBe(false)
+
+      // g then ? opens the per-view strip (not full help).
+      state = applyInput(state, 'g')
+      expect(state.pendingKey).toBe('g')
+      state = applyInput(state, '?')
+      expect(state.showViewKeys).toBe(true)
+      expect(state.showHelp).toBe(false)
+      expect(state.pendingKey).toBeUndefined()
+    })
+
+    it('Esc closes the strip; ? steps up to full help', () => {
+      let state = createLogInkState(rows)
+
+      state = applyInput(state, 'g')
+      state = applyInput(state, '?')
+      expect(state.showViewKeys).toBe(true)
+
+      // Esc closes.
+      state = applyInput(state, '', { escape: true })
+      expect(state.showViewKeys).toBe(false)
+
+      // Reopen, then ? expands to the full categorized help.
+      state = applyInput(state, 'g')
+      state = applyInput(state, '?')
+      expect(state.showViewKeys).toBe(true)
+      state = applyInput(state, '?')
+      expect(state.showViewKeys).toBe(false)
+      expect(state.showHelp).toBe(true)
+    })
+
+    it('swallows other keys while the strip is open and still quits on q', () => {
+      let state = createLogInkState(rows)
+      state = applyInput(state, 'g')
+      state = applyInput(state, '?')
+      expect(state.showViewKeys).toBe(true)
+
+      // A per-view action key is swallowed — the strip stays open and no
+      // selection moves (the user peeks, then dismisses).
+      const before = state.selectedIndex
+      state = applyInput(state, 'j')
+      expect(state.showViewKeys).toBe(true)
+      expect(state.selectedIndex).toBe(before)
+
+      // q still quits (emits a non-action exit event).
+      const events = getLogInkInputEvents(state, 'q')
+      expect(events).toEqual([{ type: 'exit' }])
+    })
+
+    it('opens the strip from the command palette entry', () => {
+      const command = getLogInkPaletteCommands().find((c) => c.id === 'viewKeys')
+      expect(command).toBeDefined()
+      const events = getLogInkPaletteExecuteEvents(command!, createLogInkState(rows))
+      expect(events).toEqual([{ type: 'action', action: { type: 'toggleViewKeys' } }])
+    })
+  })
+
   it('toggles help, command palette, focus, and graph interactions', () => {
     let state = createLogInkState(rows)
 

--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -742,8 +742,11 @@ describe('log Ink input interactions', () => {
     state = applyInput(state, 'g')
     expect(state.pendingKey).toBe('g')
 
-    state = applyInput(state, '?')
-    expect(state.showHelp).toBe(true)
+    // `/` is not a `g`-continuation, so it resolves as the global filter
+    // toggle and clears the stale chord. (`?` is no longer "unrelated" — it
+    // forms the `g?` view-keys chord, covered separately below.)
+    state = applyInput(state, '/')
+    expect(state.filterMode).toBe(true)
     expect(state.pendingKey).toBeUndefined()
   })
 

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -693,6 +693,10 @@ export function getLogInkPaletteExecuteEvents(
       // Palette closes on execute (toggleCommandPalette runs first), then
       // this opens the theme picker.
       return [action({ type: 'toggleThemePicker' })]
+    case 'viewKeys':
+      // Palette closes on execute (toggleCommandPalette runs first), then
+      // this opens the per-view which-key strip (#1137).
+      return [action({ type: 'toggleViewKeys' })]
     case 'openProjectConfig':
       return [{ type: 'openConfigInEditor', scope: 'project' }]
     case 'openGlobalConfig':
@@ -1482,6 +1486,27 @@ export function getLogInkInputEvents(
     return []
   }
 
+  // #1137 — the `g?` which-key strip. While it's open the keyboard is
+  // claimed (mirrors the help overlay) so a stray keystroke can't drop
+  // the user into a per-view action they didn't mean to trigger. Esc
+  // closes; `?` is the progressive-disclosure step up to the full
+  // categorized help; `q` still quits. Everything else is swallowed —
+  // the user peeks, dismisses, then presses the key they came for.
+  if (state.showViewKeys) {
+    if (key.escape) {
+      return [action({ type: 'toggleViewKeys' })]
+    }
+    if (inputValue === '?') {
+      // Expand the compact strip into the full help overlay. `toggleHelp`
+      // clears `showViewKeys` so the two never render at once.
+      return [action({ type: 'toggleHelp' })]
+    }
+    if (inputValue === 'q') {
+      return [{ type: 'exit' }]
+    }
+    return []
+  }
+
   // #879 item 4 — Esc cancels an in-flight bisect-start wizard. Runs
   // BEFORE the generic `popView` so we both clear the wizard state
   // and walk back to the bisect view in one keystroke. Without this
@@ -1528,6 +1553,18 @@ export function getLogInkInputEvents(
       return [action({ type: 'setPendingMutationConfirmation', value: 'discard-draft' })]
     }
     return [{ type: 'exit' }]
+  }
+
+  // `g?` chord (#1137) — open the per-view which-key strip. Placed
+  // BEFORE the bare `?` (full help) check below so the chord is read as
+  // a unit: with `g` pending, `?` opens the view-keys strip rather than
+  // toggling full help. Surfaces automatically in the `g` which-key menu
+  // because its key is a two-char `g`-prefixed binding.
+  if (state.pendingKey === 'g' && inputValue === '?') {
+    return [
+      action({ type: 'setPendingKey', value: undefined }),
+      action({ type: 'toggleViewKeys' }),
+    ]
   }
 
   if (inputValue === '?') {

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -2,6 +2,7 @@ import {
     LOG_INK_KEY_BINDINGS,
     combineLogInkBreadcrumbSegments,
     filterLogInkPaletteCommands,
+    formatBindingBareKeys,
     formatLogInkBreadcrumb,
     formatLogInkRepoBreadcrumb,
     getLogInkChordContinuations,
@@ -9,6 +10,7 @@ import {
     getLogInkFooterHints,
     getLogInkHelpSections,
     getLogInkPaletteCommands,
+    getLogInkViewKeyBindings,
 } from './inkKeymap'
 
 describe('log Ink keymap', () => {
@@ -601,6 +603,75 @@ describe('log Ink keymap', () => {
       const binding = LOG_INK_KEY_BINDINGS.find((b) => b.id === 'navigateConflicts')
       expect(binding).toBeDefined()
       expect(binding!.keys).toContain('gx')
+    })
+  })
+
+  describe('view-keys which-key strip (g?, #1137)', () => {
+    it('registers viewKeys on the g? chord', () => {
+      const binding = LOG_INK_KEY_BINDINGS.find((b) => b.id === 'viewKeys')
+      expect(binding).toBeDefined()
+      expect(binding!.keys).toEqual(['g?'])
+    })
+
+    it('surfaces in the g-chord which-key continuations', () => {
+      const continuations = getLogInkChordContinuations('g')
+      expect(continuations.some((c) => c.key === '?' && c.label === 'keys')).toBe(true)
+    })
+
+    it('is reachable from the command palette', () => {
+      const ids = getLogInkPaletteCommands().map((command) => command.id)
+      expect(ids).toContain('viewKeys')
+    })
+
+    it('lists single-key view actions sourced from the binding table', () => {
+      const bindings = getLogInkViewKeyBindings({ activeView: 'history', focus: 'commits' })
+      const ids = bindings.map((b) => b.id)
+      // History overloads the issue calls out: cherry-pick (c), revert (R), etc.
+      expect(ids).toContain('viewCherryPick')
+      expect(ids).toContain('revertSelection')
+      // Every entry exposes at least one bare single key.
+      expect(bindings.every((b) => b.keys.some((k) => k.length === 1))).toBe(true)
+    })
+
+    it('excludes chord-only and global bindings', () => {
+      const bindings = getLogInkViewKeyBindings({ activeView: 'history', focus: 'commits' })
+      const ids = bindings.map((b) => b.id)
+      // Globals (help/quit) and chord-only nav (gh/gs/…) are not single-key
+      // per-view actions and stay out of the strip.
+      expect(ids).not.toContain('help')
+      expect(ids).not.toContain('quit')
+      expect(ids).not.toContain('navigateHome')
+      expect(ids).not.toContain('viewKeys')
+    })
+
+    it('changes with the active view context', () => {
+      const branches = getLogInkViewKeyBindings({ activeView: 'branches', focus: 'commits' })
+        .map((b) => b.id)
+      // markForCompare (m) is a branches/tags/history action.
+      expect(branches).toContain('markForCompare')
+      // Sidebar-only tab cycling shouldn't appear when focus is on commits.
+      const sidebar = getLogInkViewKeyBindings({ activeView: 'history', focus: 'sidebar' })
+        .map((b) => b.id)
+      expect(sidebar).toContain('nextSidebarTab')
+    })
+
+    it('sorts entries by their first bare key', () => {
+      const bindings = getLogInkViewKeyBindings({ activeView: 'history', focus: 'commits' })
+      const keys = bindings.map((b) => formatBindingBareKeys(b).charAt(0))
+      expect(keys).toEqual([...keys].sort((a, b) => a.localeCompare(b)))
+    })
+  })
+
+  describe('formatBindingBareKeys', () => {
+    it('keeps only bare single keys, dropping named and chord keys', () => {
+      const moveUp = LOG_INK_KEY_BINDINGS.find((b) => b.id === 'moveUp')!
+      // keys: ['up', 'k'] → only 'k' is bare.
+      expect(formatBindingBareKeys(moveUp)).toBe('k')
+    })
+
+    it('joins multiple bare keys with a slash', () => {
+      const binding = { id: 'x', keys: ['a', 'A'], label: '', description: '', contexts: [] } as never
+      expect(formatBindingBareKeys(binding)).toBe('a / A')
     })
   })
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -60,6 +60,7 @@ export type LogInkCommandId =
   | 'search'
   | 'toggleDiffViewMode'
   | 'toggleGraph'
+  | 'viewKeys'
   | 'workflowDeleteBranch'
   | 'workflowDeleteTag'
   | 'workflowDropStash'
@@ -547,6 +548,13 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     label: 'create tag here',
     description: 'Create a lightweight tag at the cursored commit.',
     contexts: ['history'],
+  },
+  {
+    id: 'viewKeys',
+    keys: ['g?'],
+    label: 'keys',
+    description: 'Show the single-key actions available in the current view (which-key strip).',
+    contexts: ['normal'],
   },
   {
     id: 'themePicker',
@@ -1419,6 +1427,55 @@ export function getLogInkHelpSections(
       subgroups: buildSubgroups(viewBindings, false),
     },
   ]
+}
+
+/**
+ * True when a key string is a single, bare printable key (e.g. `c`, `R`,
+ * `[`) rather than a chord (`gh`, `gg`) or a named special key (`up`,
+ * `page down`). Used by the which-key view-keys strip, which surfaces only
+ * the single-key overloads — the chord set already has its own overlay.
+ */
+function isBareSingleKey(key: string): boolean {
+  return key.length === 1 && key !== ' '
+}
+
+/**
+ * Single-key bindings available in the current view (#1137). Powers the
+ * `g?` which-key strip: the per-view counterpart to the `g`-chord overlay.
+ *
+ * Sourced entirely from `LOG_INK_KEY_BINDINGS` (no duplicated key data) and
+ * filtered the same way the help overlay's "This view" section is — by
+ * `contexts` against the active view + focus — then narrowed to bindings
+ * that expose at least one bare single key. Globals (`q`, `?`, `/`, `:`, …)
+ * are excluded: they're always available and already live in the footer and
+ * onboarding tour, so the strip stays focused on the deliberate per-view
+ * overloads (`c`, `R`, `a`, `m`, `S`, `[`/`]`, …) the keymap guard protects.
+ *
+ * Sorted by the first bare key for stable, scannable output.
+ */
+export function getLogInkViewKeyBindings(
+  options: GetLogInkHelpSectionsOptions
+): LogInkKeyBinding[] {
+  return LOG_INK_KEY_BINDINGS
+    .filter((binding) =>
+      !GLOBAL_BINDING_IDS.includes(binding.id) &&
+      bindingMatchesViewContext(binding, options) &&
+      binding.keys.some(isBareSingleKey)
+    )
+    .sort((a, b) => {
+      const aKey = a.keys.find(isBareSingleKey) ?? ''
+      const bKey = b.keys.find(isBareSingleKey) ?? ''
+      return aKey.localeCompare(bKey)
+    })
+}
+
+/**
+ * Format only the bare single keys of a binding for the view-keys strip
+ * (e.g. `['up', 'k']` → `k`). Named/chord keys are dropped — the strip is
+ * about the single-key affordance, and the full key list lives in `?` help.
+ */
+export function formatBindingBareKeys(binding: LogInkKeyBinding): string {
+  return binding.keys.filter(isBareSingleKey).join(' / ')
 }
 
 export function getLogInkCommandPaletteItems(): LogInkCommandPaletteItem[] {

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -455,6 +455,37 @@ describe('log Ink view model', () => {
     expect(state.helpScrollOffset).toBe(0)
   })
 
+  it('toggles the view-keys strip and keeps it mutually exclusive with other overlays (#1137)', () => {
+    let state = createLogInkState(rows)
+    expect(state.showViewKeys).toBe(false)
+
+    // g? opens the strip.
+    state = applyLogInkAction(state, { type: 'toggleViewKeys' })
+    expect(state.showViewKeys).toBe(true)
+
+    // Toggling again closes it.
+    state = applyLogInkAction(state, { type: 'toggleViewKeys' })
+    expect(state.showViewKeys).toBe(false)
+
+    // Opening full help supersedes the strip (the progressive-disclosure step).
+    state = applyLogInkAction(state, { type: 'toggleViewKeys' })
+    state = applyLogInkAction(state, { type: 'toggleHelp' })
+    expect(state.showViewKeys).toBe(false)
+    expect(state.showHelp).toBe(true)
+
+    // Opening the strip closes help.
+    state = applyLogInkAction(state, { type: 'toggleViewKeys' })
+    expect(state.showHelp).toBe(false)
+    expect(state.showViewKeys).toBe(true)
+
+    // And the palette / filter mode also supersede the strip.
+    state = applyLogInkAction(state, { type: 'toggleCommandPalette' })
+    expect(state.showViewKeys).toBe(false)
+    state = applyLogInkAction(state, { type: 'toggleViewKeys' })
+    state = applyLogInkAction(state, { type: 'toggleFilterMode' })
+    expect(state.showViewKeys).toBe(false)
+  })
+
   it('scrollHelp floor-clamps at 0 (no negative offsets)', () => {
     let state = createLogInkState(rows)
     state = applyLogInkAction(state, { type: 'toggleHelp' })

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -291,6 +291,14 @@ export type LogInkState = {
    * field — the rendered panel does the clamp.
    */
   helpScrollOffset: number
+  /**
+   * Which-key view-keys strip (#1137). When true, the detail panel shows a
+   * compact list of the single-key actions available in the current view,
+   * sourced from `LOG_INK_KEY_BINDINGS`. Opened by the `g?` chord; the
+   * per-view counterpart to the `g`-chord continuation overlay. Mutually
+   * exclusive with the other overlays.
+   */
+  showViewKeys: boolean
   showCommandPalette: boolean
   /**
    * Command-palette interaction state. `paletteFilter` is the user-typed
@@ -815,6 +823,7 @@ export type LogInkAction =
   | { type: 'toggleGraph' }
   | { type: 'toggleHelp' }
   | { type: 'scrollHelp'; delta: number }
+  | { type: 'toggleViewKeys' }
   | { type: 'toggleCommandPalette' }
   | { type: 'toggleThemePicker' }
   | { type: 'moveThemePicker'; delta: number; presetCount: number }
@@ -1386,6 +1395,7 @@ export function createLogInkState(
     fullGraph: options.fullGraph ?? true,
     showHelp: false,
     helpScrollOffset: 0,
+    showViewKeys: false,
     showCommandPalette: false,
     workflowActionId: undefined,
     pendingConfirmationId: undefined,
@@ -2136,6 +2146,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         showCommandPalette: false,
         showHelp: false,
         helpScrollOffset: 0,
+        showViewKeys: false,
         pendingKey: undefined,
       }
     case 'toggleGraph':
@@ -2154,9 +2165,24 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         // than picking up where the user last scrolled.
         helpScrollOffset: 0,
         showCommandPalette: false,
+        // Opening full help supersedes the compact view-keys strip — this
+        // is the progressive-disclosure step (`?` from the strip expands
+        // to the full categorized help, #1137).
+        showViewKeys: false,
         pendingKey: undefined,
       }
     }
+    case 'toggleViewKeys':
+      return {
+        ...state,
+        showViewKeys: !state.showViewKeys,
+        // The view-keys strip is mutually exclusive with the other
+        // overlays; opening it closes anything else that was showing.
+        showHelp: false,
+        helpScrollOffset: 0,
+        showCommandPalette: false,
+        pendingKey: undefined,
+      }
     case 'scrollHelp':
       // No upper-bound clamp here — the renderer caps the offset
       // against the actual content height at render time. The
@@ -2173,6 +2199,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         showCommandPalette: opening,
         showHelp: false,
         helpScrollOffset: 0,
+        showViewKeys: false,
         // Reset palette interaction state on every open/close so the next
         // session starts from a clean slate.
         paletteFilter: '',
@@ -2223,8 +2250,9 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         showThemePicker: opening,
-        // Only one overlay at a time — close help / palette on open.
+        // Only one overlay at a time — close help / palette / view-keys on open.
         showHelp: false,
+        showViewKeys: false,
         showCommandPalette: false,
         themePickerFilter: '',
         themePickerIndex: 0,

--- a/src/workstation/KEYMAP.md
+++ b/src/workstation/KEYMAP.md
@@ -77,7 +77,7 @@ Available in every view (unless an overlay/mode has claimed the keyboard):
 |-----|--------|
 | `q` | Quit |
 | `Ctrl+C` | Quit (hard) |
-| `?` | Toggle help overlay |
+| `?` | Toggle help overlay (full categorized help) |
 | `:` | Command palette |
 | `/` | Enter filter mode |
 | `g` | Chord prefix (see below) |
@@ -122,6 +122,7 @@ the which-key overlay lists them live when you press `g`.
 | `g M` | Submodules |
 | `g T` | Changelog |
 | `g H` | Apply cursored hunk to index (`git apply --cached`) |
+| `g ?` | **Which-key strip** (overlay, not nav) — surfaces the *single-key* actions available in the current view (the deliberate overloads below), sourced live from `LOG_INK_KEY_BINDINGS`. `?` from the strip expands to the full help; `Esc` closes. The per-view counterpart to this very `g`-chord menu. |
 
 ---
 

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -4739,6 +4739,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   const forcedPane: LogInkVisiblePane | undefined = state.splitPlan
     ? 'main'
     : state.showHelp ||
+        state.showViewKeys ||
         state.showCommandPalette ||
         state.showThemePicker ||
         state.gitignorePicker ||

--- a/src/workstation/runtime/detailPanel.ts
+++ b/src/workstation/runtime/detailPanel.ts
@@ -41,6 +41,7 @@ import {
     renderInputPromptPanel,
     renderGitignorePickerOverlay,
     renderThemePickerOverlay,
+    renderViewKeysOverlay,
 } from './overlays'
 import type { LogInkComponents, LogInkContext } from './types'
 
@@ -66,6 +67,13 @@ export function renderDetailPanel(
   // panel's full width via the help-overlay layout branch.
   if (state.showHelp) {
     return renderHelpPanel(h, components, state, width, theme, focused, bodyRows)
+  }
+
+  // #1137 — the `g?` which-key strip lists the current view's single-key
+  // actions. Checked alongside the other overlays; the reducer keeps it
+  // mutually exclusive with help / palette / pickers.
+  if (state.showViewKeys) {
+    return renderViewKeysOverlay(h, components, state, width, theme, focused)
   }
 
   if (state.showCommandPalette) {

--- a/src/workstation/runtime/footer.ts
+++ b/src/workstation/runtime/footer.ts
@@ -88,6 +88,7 @@ export function renderFooter(
   const overlayForcesPane = Boolean(
     state.splitPlan ||
       state.showHelp ||
+      state.showViewKeys ||
       state.showCommandPalette ||
       state.showThemePicker ||
       state.gitignorePicker ||

--- a/src/workstation/runtime/overlays.test.ts
+++ b/src/workstation/runtime/overlays.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Render smoke test for the `g?` view-keys which-key strip (#1137).
+ *
+ * Structural, not visual: stub `Text` / `Box` collect props into a
+ * synthetic React tree so we can flatten the rendered text without
+ * pulling Ink (ESM) into ts-jest. Same trick as `singlePane.test.ts`.
+ */
+import { createElement } from 'react'
+import { createLogInkContextStatus } from '../chrome/context'
+import { createLogInkTheme } from '../chrome/theme'
+import { createLogInkState } from '../../commands/log/inkViewModel'
+import { renderDetailPanel } from './detailPanel'
+import type { LogInkContext } from './types'
+
+type StubProps = Record<string, unknown>
+const Text = ((props: StubProps) =>
+  createElement('text', props, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+const Box = ((props: StubProps) =>
+  createElement('box', props, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+
+const theme = createLogInkTheme({ noColor: true })
+const context: LogInkContext = {}
+const contextStatus = createLogInkContextStatus('ready')
+
+// Walk the synthetic tree and concatenate every string child into one
+// blob, so a test can assert on what the user would read on screen.
+function flattenText(node: unknown): string {
+  if (node == null || node === false) return ''
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(flattenText).join(' ')
+  const element = node as { props?: { children?: unknown } }
+  if (element.props && 'children' in element.props) {
+    return flattenText(element.props.children)
+  }
+  return ''
+}
+
+function renderViewKeys(activeView: string) {
+  const state = {
+    ...createLogInkState([]),
+    showViewKeys: true,
+    activeView: activeView as never,
+  }
+  return renderDetailPanel(
+    createElement,
+    { Box, Text },
+    state,
+    context,
+    contextStatus,
+    undefined,
+    false,
+    undefined,
+    false,
+    60,
+    false,
+    theme,
+    24
+  )
+}
+
+describe('view-keys overlay (#1137)', () => {
+  it('lists the current view’s single-key actions with labels', () => {
+    const text = flattenText(renderViewKeys('history'))
+    // The history overloads the issue calls out are present, by label.
+    expect(text).toContain('cherry-pick')
+    expect(text).toContain('revert')
+    // Title names the view; footer documents the progressive-disclosure hint.
+    expect(text).toContain('keys')
+    expect(text).toContain('history')
+    expect(text).toContain('? full help')
+  })
+
+  it('reflects a different view’s context', () => {
+    const text = flattenText(renderViewKeys('branches'))
+    // mark-compare (m) is available wherever commits/branches focus applies.
+    expect(text).toContain('mark compare')
+  })
+})

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -24,10 +24,12 @@ import type { LogInkTheme } from '../chrome/theme'
 import { THEME_PRESET_COLORS } from '../chrome/theme'
 import {
     filterLogInkPaletteCommands,
+    formatBindingBareKeys,
     formatBindingKeys,
     getLogInkChordContinuations,
     getLogInkHelpSections,
     getLogInkPaletteCommands,
+    getLogInkViewKeyBindings,
 } from '../../commands/log/inkKeymap'
 import type { LogInkState } from '../../commands/log/inkViewModel'
 import { filterThemePresets } from '../../commands/log/inkViewModel'
@@ -219,6 +221,71 @@ export function renderChordOverlay(
     key: 'chord-hint',
     dimColor: true,
   }, truncateCells('press the second key to jump · esc cancels', width - 4)))
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    width,
+    paddingX: 1,
+  }, ...lines)
+}
+
+/**
+ * Which-key view-keys strip (#1137). The per-view counterpart to the
+ * `g`-chord overlay: opened by `g?`, it lists the single-key actions
+ * available in the current view (the deliberate overloads — `c`, `R`,
+ * `a`, `m`, `S`, `[`/`]`, …) with their labels, sourced from
+ * `LOG_INK_KEY_BINDINGS` filtered by the active view + focus.
+ *
+ * Renders in the detail panel slot like the chord overlay. `?` steps up
+ * to the full categorized help; Esc closes.
+ */
+export function renderViewKeysOverlay(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  state: LogInkState,
+  width: number,
+  theme: LogInkTheme,
+  focused: boolean
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  const bindings = getLogInkViewKeyBindings({
+    activeView: state.activeView,
+    focus: state.focus,
+  })
+  const accent = theme.noColor ? undefined : theme.colors.accent
+
+  const lines: ReactTypes.ReactNode[] = [
+    h(Text, { key: 'view-keys-title', bold: true }, panelTitle(`keys · ${state.activeView}`, focused)),
+    h(Text, { key: 'view-keys-spacer' }, ''),
+  ]
+
+  if (bindings.length === 0) {
+    lines.push(h(Text, {
+      key: 'view-keys-empty',
+      dimColor: true,
+    }, truncateCells('No single-key actions in this view — use ? for the full help.', width - 4)))
+  } else {
+    // Pad keys to the widest entry so labels align into a scannable column.
+    const keyColumn = bindings.reduce(
+      (max, binding) => Math.max(max, formatBindingBareKeys(binding).length),
+      0
+    )
+    for (const binding of bindings) {
+      const keys = formatBindingBareKeys(binding)
+      lines.push(h(Text, { key: `view-keys-${binding.id}` },
+        h(Text, { color: accent, bold: true }, `  ${keys.padEnd(keyColumn)}  `),
+        h(Text, undefined, truncateCells(`${binding.label.padEnd(14)} ${binding.description}`, width - keyColumn - 7))
+      ))
+    }
+  }
+
+  lines.push(h(Text, { key: 'view-keys-foot-spacer' }, ''))
+  lines.push(h(Text, {
+    key: 'view-keys-hint',
+    dimColor: true,
+  }, truncateCells('? full help · esc closes', width - 4)))
 
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),


### PR DESCRIPTION
Closes #1137.

## Problem

The `g`-chord which-key overlay surfaces chord continuations live — press `g` and a menu appears. But the **single-key** overloads (`c`, `R`, `a`, `m`, `S`, `[`/`]`, …), which mean different things per view, had no equivalent live affordance. Discovering them meant the trimmed footer (~6 hints) or the full `?` help overlay.

## What this adds

A `g?` chord that opens a compact **which-key strip** listing the single-key actions available in the *current view* — the per-view counterpart to the `g`-chord overlay.

- **Data, not plumbing.** `getLogInkViewKeyBindings()` reuses the same `bindingMatchesViewContext` predicate the `?` help's "This view" section uses, narrowed to non-global bindings that expose a bare single key, sorted by key. Sourced entirely from `LOG_INK_KEY_BINDINGS` — no duplicated key data.
- **No key changes what it does.** Pure render/affordance addition. `g?` is read as a unit *before* bare `?`, so single-`?` stays full help (no muscle-memory change).
- **Self-discoverable.** `g?` auto-appears in the `g` which-key menu and the command palette. From the strip, `?` steps up to the full categorized help; `Esc` closes.
- The strip joins the overlay set in the reducer (mutually exclusive with help/palette/pickers) and the `forcedPane` derivations in `app.ts` + `footer.ts`.

`src/workstation/KEYMAP.md` documents the new chord in the same PR (keymap-guard discipline).

## Acceptance

- ✅ In any view, the user can surface a live list of that view's single-key actions with labels (`g?`).
- ✅ Sourced from `LOG_INK_KEY_BINDINGS` (no duplicated key data).
- ✅ No change to what any key does.

## Tests

- `inkKeymap.test.ts` — `g?` binding registered, in the `g` chord menu, in the palette; `getLogInkViewKeyBindings` filters by context, excludes globals/chords, sorts by key; `formatBindingBareKeys` drops named/chord keys.
- `inkViewModel.test.ts` — `toggleViewKeys` reducer, mutual exclusivity with help/palette/filter.
- `inkInput.test.ts` — `g?` opens the strip (bare `?` still full help), Esc closes, `?` steps up to help, other keys swallowed, palette entry.
- `overlays.test.ts` (new) — render smoke: the strip lists the view's labels and reflects view context.

Full validation suite green: jest (208 suites / 2616 tests), lint, build, CLI smoke.