### PR TITLE
feat(compose): return to history or status after creating a commit

### DIFF
--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -106,6 +106,53 @@ describe('log Ink view model', () => {
     expect(state.activeView).toBe('diff')
   })
 
+  describe('returnFromCommit navigation', () => {
+    it('returns to status when the tree is still dirty after committing from status', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'status' })
+      state = applyLogInkAction(state, { type: 'pushView', value: 'compose' })
+
+      state = applyLogInkAction(state, { type: 'returnFromCommit', stillDirty: true })
+
+      expect(state.activeView).toBe('status')
+      expect(state.viewStack).toEqual(['history', 'status'])
+    })
+
+    it('returns to history when the tree is clean even if it came from status', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'status' })
+      state = applyLogInkAction(state, { type: 'pushView', value: 'compose' })
+
+      state = applyLogInkAction(state, { type: 'returnFromCommit', stillDirty: false })
+
+      expect(state.activeView).toBe('history')
+      expect(state.viewStack).toEqual(['history'])
+    })
+
+    it('returns to history when composing straight from history', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'compose' })
+
+      // Dirty, but there is no status frame to return to.
+      state = applyLogInkAction(state, { type: 'returnFromCommit', stillDirty: true })
+
+      expect(state.activeView).toBe('history')
+      expect(state.viewStack).toEqual(['history'])
+    })
+
+    it('unwinds an intermediate diff frame back to status when still dirty', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'status' })
+      state = applyLogInkAction(state, { type: 'pushView', value: 'diff' })
+      state = applyLogInkAction(state, { type: 'pushView', value: 'compose' })
+
+      state = applyLogInkAction(state, { type: 'returnFromCommit', stillDirty: true })
+
+      expect(state.activeView).toBe('status')
+      expect(state.viewStack).toEqual(['history', 'status'])
+    })
+  })
+
   it('moves selected commits and clamps at list bounds', () => {
     let state = createLogInkState(rows)
 

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -785,6 +785,7 @@ export type LogInkAction =
   | { type: 'pushRepoFrame'; label: string; workdir?: string; entryRange?: LogInkRepoFrameEntryRange }
   | { type: 'popRepoFrame' }
   | { type: 'navigateHome' }
+  | { type: 'returnFromCommit'; stillDirty: boolean }
   | { type: 'navigateOpenDiffForCommit'; sha: string; commitIndex: number; fileIndex?: number }
   | { type: 'navigateOpenDiffForWorktreeFile'; fileIndex: number }
   | { type: 'navigateOpenDiffForStash'; ref: string; stashIndex?: number }
@@ -1939,6 +1940,23 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         pendingCommitFocused: false,
         pendingKey: undefined,
       }
+    }
+    case 'returnFromCommit': {
+      // After a successful commit we leave the compose view automatically.
+      // Where to: a still-dirty tree the user was staging from returns to
+      // the Status view so they can finish the rest; an otherwise-complete
+      // commit returns to the History view, where the new commit now shows.
+      // We pop frames one at a time (reusing withPoppedView) so sidebar-tab
+      // and diff-state restoration stays identical to manual Esc/back —
+      // this also unwinds an intermediate `diff` frame (status → diff →
+      // compose) back to the status frame it sits under.
+      const target: LogInkView =
+        action.stillDirty && state.viewStack.includes('status') ? 'status' : HOME_VIEW
+      let next = state
+      while (next.viewStack.length > 1 && topOfStack(next.viewStack) !== target) {
+        next = withPoppedView(next)
+      }
+      return { ...next, pendingKey: undefined }
     }
     case 'navigateOpenDiffForCommit': {
       const next = withPushedView(state, 'diff')

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -1065,6 +1065,10 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       (current) => updateLogInkContextStatus(current, 'worktree', 'ready'),
       issuedAtDepth,
     )
+    // Returned so callers needing the *fresh* overview (e.g. post-commit
+    // navigation) can read it directly instead of racing the async
+    // `setContext` update, which won't be visible in their closure.
+    return worktree
   }, [git, runtimes.length, setContext, setContextStatus])
 
   // Live refresh: watch .git metadata + the working tree root and reload
@@ -2022,7 +2026,16 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       // and see the pre-commit log (same silent-failure shape as
       // the split-apply case caught in this PR).
       await refreshHistoryRows()
-      await refreshWorktreeContext()
+      const worktree = await refreshWorktreeContext()
+      // Leave the compose view automatically: a still-dirty tree returns
+      // to Status (so the user can keep staging), an otherwise-complete
+      // commit returns to History (where the new commit now shows). The
+      // reducer inspects the live viewStack to pick the destination.
+      const stillDirty = Boolean(
+        worktree &&
+          worktree.stagedCount + worktree.unstagedCount + worktree.untrackedCount > 0,
+      )
+      dispatch({ type: 'returnFromCommit', stillDirty })
     }
   }, [
     context.worktree?.stagedCount,


### PR DESCRIPTION
## What

After a successful commit from the compose view, the app now leaves the (now-empty) compose form automatically and returns the user somewhere useful.

- **Still dirty** (any staged/unstaged/untracked remain) **and** a `status` frame is in the back-stack → return to **Status**, so the user can keep staging the rest.
- **Clean now, or composed straight from History** → return to **History**, where the new commit is already refreshed in.

## How

- New `returnFromCommit` reducer action picks the destination from the **live** `viewStack` and pops frames via the existing `withPoppedView`, so sidebar-tab / diff-state restoration is identical to pressing Esc — including unwinding an intermediate `diff` frame (`status → diff → compose`) back to the status frame beneath it.
- `refreshWorktreeContext()` now returns the freshly-fetched worktree overview so the commit handler reads **post-commit** dirtiness directly instead of racing the async `setContext` update (the closure's `context.worktree` is the pre-commit snapshot).
- The success status message still shows in the footer after navigating, so confirmation lands wherever the user ends up.

## Testing

- 4 new reducer tests: status+dirty→status, status+clean→history, history-origin→history, and status→diff→compose+dirty→status.
- Full unit suite green (2602 passed); `tsc`/`eslint` clean.