### PR TITLE
feat(cli): audit improvements — doctor exit codes, richer error context, glyph vocabulary

### DIFF
--- a/src/commands/cache/handler.test.ts
+++ b/src/commands/cache/handler.test.ts
@@ -3,9 +3,9 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 
 import {
-  diffSummaryKey,
-  getDiffSummaryCachePath,
-  writeDiffSummary,
+    diffSummaryKey,
+    getDiffSummaryCachePath,
+    writeDiffSummary,
 } from '../../lib/parsers/default/utils/diffSummaryCache'
 import { handler } from './handler'
 
@@ -63,12 +63,18 @@ describe('coco cache <subcommand>', () => {
     expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('No diff-summary cache'))
   })
 
-  it('rejects unknown subcommands and sets exit code', async () => {
-    const previousExit = process.exitCode
-    await handler({ subcommand: 'panic' } as never, logger as never)
+  it('rejects unknown subcommands and exits non-zero', async () => {
+    // Switched to `commandExit(1)` (throws CommandExitError) so the
+    // wrapping `commandExecutor` can route exit codes uniformly. The
+    // pre-MEDIUM-6 path used a raw `process.exitCode = 1` which the
+    // test asserted directly; now we assert the throw instead.
+    await expect(
+      handler({ subcommand: 'panic' } as never, logger as never)
+    ).rejects.toMatchObject({
+      name: 'CommandExitError',
+      code: 1,
+    })
     expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('Unknown cache subcommand'))
-    expect(process.exitCode).toBe(1)
-    process.exitCode = previousExit
   })
 
   describe('tree-sitter subcommands (#933 phase 7)', () => {

--- a/src/commands/cache/handler.ts
+++ b/src/commands/cache/handler.ts
@@ -3,25 +3,26 @@ import * as fs from 'node:fs'
 import chalk from 'chalk'
 
 import {
-  clearCachedParser,
-  getCachedParserStatus,
-  type LazyTreeSitterLanguageId,
+    clearCachedParser,
+    getCachedParserStatus,
+    type LazyTreeSitterLanguageId,
 } from '../../lib/parsers/default/__tree_sitter__/cache'
 import {
-  listManifestLanguages,
-  TREE_SITTER_MANIFEST,
+    listManifestLanguages,
+    TREE_SITTER_MANIFEST,
 } from '../../lib/parsers/default/__tree_sitter__/manifest'
 import {
-  parsePrefetchEnv,
-  prefetchTreeSitterParsers,
+    parsePrefetchEnv,
+    prefetchTreeSitterParsers,
 } from '../../lib/parsers/default/__tree_sitter__/prefetch'
 import {
-  clearDiffSummaryCache,
-  getDiffSummaryCachePath,
+    clearDiffSummaryCache,
+    getDiffSummaryCachePath,
 } from '../../lib/parsers/default/utils/diffSummaryCache'
 import { clearGitHubListCache } from '../../git/githubListCache'
 import { checkboxPrompt } from '../../lib/ui/inquirerPrompts'
 import { CommandHandler } from '../../lib/types'
+import { commandExit } from '../../lib/utils/commandExit'
 import { applyRepoCwd } from '../utils/applyRepoFlag'
 import { CacheArgv } from './config'
 
@@ -172,8 +173,7 @@ export const handler: CommandHandler<CacheArgv> = async (argv, logger) => {
     const result = clearDiffSummaryCache(repoPath)
     if (!result.ok) {
       logger.log(chalk.red(`Failed to clear diff-summary cache at ${cachePath}`))
-      process.exitCode = 1
-      return
+      commandExit(1, 'cache clear failed')
     }
     if (result.removed) {
       logger.log(chalk.green(`Cleared diff-summary cache at ${cachePath}`))
@@ -221,8 +221,7 @@ export const handler: CommandHandler<CacheArgv> = async (argv, logger) => {
     if (interactive) {
       const picked = await promptLanguageSelection(logger)
       if (!picked) {
-        process.exitCode = 1
-        return
+        commandExit(1, 'cache prefetch cancelled')
       }
       resolved = picked
     }
@@ -241,7 +240,7 @@ export const handler: CommandHandler<CacheArgv> = async (argv, logger) => {
       `${chalk.red(`${result.failed.length} failed`)}`,
     )
     if (result.failed.length > 0) {
-      process.exitCode = 1
+      commandExit(1, `cache prefetch failed for ${result.failed.length} language(s)`)
     }
     return
   }
@@ -277,5 +276,5 @@ export const handler: CommandHandler<CacheArgv> = async (argv, logger) => {
 
   logger.log(chalk.red(`Unknown cache subcommand: ${subcommand}`))
   logger.log(chalk.dim('Use one of: clear, info, parsers, prefetch, clear-parsers, clear-github'))
-  process.exitCode = 1
+  commandExit(1, `unknown cache subcommand: ${subcommand}`)
 }

--- a/src/commands/cache/index.ts
+++ b/src/commands/cache/index.ts
@@ -4,7 +4,7 @@ import { handler } from './handler'
 
 export default {
   command,
-  desc: 'Manage the diff-summary cache (clear, info)',
+  desc: 'Manage coco caches (clear, info, parsers, prefetch, github)',
   builder,
   handler: commandExecutor(handler),
 }

--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -20,6 +20,7 @@ import { getChangesByCommit } from '../../lib/simple-git/getChangesByCommit'
 import { CommandHandler, FileChange } from '../../lib/types'
 import { applyRepoFlag } from '../utils/applyRepoFlag'
 import { generateAndReviewLoop } from '../../lib/ui/generateAndReviewLoop'
+import { handleMissingApiKey } from '../../lib/ui/handleMissingApiKey'
 import { handleResult } from '../../lib/ui/handleResult'
 import { LOGO, isInteractive } from '../../lib/ui/helpers'
 import { logSuccess } from '../../lib/ui/logSuccess'
@@ -83,8 +84,7 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
   }
 
   if (config.service.authentication.type !== 'None' && !key) {
-    logger.log(`No API Key found. 🗝️🚪`, { color: 'red' })
-    commandExit(1)
+    handleMissingApiKey(logger, config, { command: 'changelog' })
   }
 
   const llm = getLlm(provider, model as LLMModel, { ...config, service: changelogService })

--- a/src/commands/commit/conventionalCommitsHandler.test.ts
+++ b/src/commands/commit/conventionalCommitsHandler.test.ts
@@ -181,7 +181,12 @@ describe('Conventional Commits Handler', () => {
       await expect(handler(argv, logger)).rejects.toMatchObject({
         code: 1,
       } satisfies Partial<CommandExitError>)
-      expect(logger.log).toHaveBeenCalledWith('No API Key found. 🗝️🚪', { color: 'red' })
+      // The new helper prints a multi-line structured error pointing
+      // at coco init / coco doctor / the env var. Loose-match the
+      // headline so we don't tie the test to copy tweaks but still
+      // catch a regression that would silently print nothing.
+      const printedLines = (logger.log as jest.Mock).mock.calls.map((call) => call[0]).join('\n')
+      expect(printedLines).toContain('Missing API key')
     })
 
     it('should warn about Ollama model limitations', async () => {

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -19,6 +19,7 @@ import { getPreviousCommits } from '../../lib/simple-git/getPreviousCommits'
 import { CommandHandler, FileChange } from '../../lib/types'
 import { applyRepoFlag } from '../utils/applyRepoFlag'
 import { generateAndReviewLoop } from '../../lib/ui/generateAndReviewLoop'
+import { handleMissingApiKey } from '../../lib/ui/handleMissingApiKey'
 import { handleResult } from '../../lib/ui/handleResult'
 import { LOGO, SEPERATOR, isInteractive } from '../../lib/ui/helpers'
 import { logSuccess } from '../../lib/ui/logSuccess'
@@ -47,8 +48,7 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
   const model = commitService.model
 
   if (config.service.authentication.type !== 'None' && !key) {
-    logger.log(`No API Key found. 🗝️🚪`, { color: 'red' })
-    commandExit(1)
+    handleMissingApiKey(logger, config, { command: 'commit' })
   }
 
   const tokenizer = await getTokenCounter(

--- a/src/commands/doctor/handler.ts
+++ b/src/commands/doctor/handler.ts
@@ -4,15 +4,17 @@ import { loadConfig } from '../../lib/config/utils/loadConfig'
 import { getConfigSources, ConfigSourceInfo } from '../../lib/config/utils/loadConfig'
 import { SCHEMA_PUBLIC_URL } from '../../lib/schema'
 import { CommandHandler } from '../../lib/types'
+import { FAIL, INFO, PASS, WARN } from '../../lib/ui/glyphs'
 import { LOGO } from '../../lib/ui/helpers'
+import { commandExit } from '../../lib/utils/commandExit'
 import { applyRepoCwd } from '../utils/applyRepoFlag'
 import { DoctorArgv, DoctorOptions } from './config'
 import { DiagnosticSeverity, runDiagnostics } from './checks'
 
 const SEVERITY_ICON: Record<DiagnosticSeverity, string> = {
-  error: chalk.red('✖'),
-  warn: chalk.yellow('⚠'),
-  info: chalk.blue('ℹ'),
+  error: FAIL(),
+  warn: WARN(),
+  info: INFO(),
 }
 
 const SEVERITY_LABEL: Record<DiagnosticSeverity, string> = {
@@ -34,9 +36,9 @@ function formatSourceInfo(sources: ConfigSourceInfo[]): string[] {
   for (const source of sources) {
     const label = SOURCE_LABELS[source.source] || source.source
     if (source.path) {
-      lines.push(`  ${chalk.green('✓')} ${label} ${chalk.dim(`(${source.path})`)}`)
+      lines.push(`  ${PASS()} ${label} ${chalk.dim(`(${source.path})`)}`)
     } else {
-      lines.push(`  ${chalk.green('✓')} ${label}`)
+      lines.push(`  ${PASS()} ${label}`)
     }
   }
   return lines
@@ -81,7 +83,7 @@ export const handler: CommandHandler<DoctorArgv> = async (argv, logger) => {
   const diagnostics = runDiagnostics(config)
 
   if (diagnostics.length === 0) {
-    logger.log(chalk.green('✓ No issues found. Your configuration looks good!'))
+    logger.log(chalk.green(`${PASS()} No issues found. Your configuration looks good!`))
     return
   }
 
@@ -153,7 +155,7 @@ export const handler: CommandHandler<DoctorArgv> = async (argv, logger) => {
 
       for (const diagnostic of fixable) {
         diagnostic.autoFix!(raw)
-        logger.log(chalk.green(`  ✓ Fixed: ${diagnostic.message}`))
+        logger.log(chalk.green(`  ${PASS()} Fixed: ${diagnostic.message}`))
       }
 
       // Ensure $schema is present
@@ -171,5 +173,15 @@ export const handler: CommandHandler<DoctorArgv> = async (argv, logger) => {
     if (fixable.length > 0) {
       logger.log(chalk.dim(`${fixable.length} issue(s) can be auto-fixed. Run \`coco doctor --fix\` to apply.`))
     }
+  }
+
+  // Exit non-zero when error-severity diagnostics were surfaced so CI
+  // pipelines can gate on `coco doctor` without parsing its stdout.
+  // Warnings + infos still exit clean — they're informational, not
+  // blockers. Auto-fixed errors keep the non-zero exit so the CI run
+  // surfaces "we patched something for you, please commit it" rather
+  // than masquerading as a passing check.
+  if (errors.length > 0) {
+    commandExit(1, `${errors.length} doctor error(s)`)
   }
 }

--- a/src/commands/doctor/index.ts
+++ b/src/commands/doctor/index.ts
@@ -1,5 +1,5 @@
 import commandExecutor from '../../lib/utils/commandExecutor'
-import { builder, command } from './config'
+import { builder, command, options } from './config'
 import { handler } from './handler'
 
 export default {
@@ -7,4 +7,5 @@ export default {
   desc: 'Check your coco configuration for common issues and suggest fixes',
   builder,
   handler: commandExecutor(handler),
+  options,
 }

--- a/src/commands/init/config.ts
+++ b/src/commands/init/config.ts
@@ -1,15 +1,15 @@
-import { Argv, Options } from 'yargs'
+import { Argv, Arguments, Options } from 'yargs'
 import { getCommandUsageHeader } from '../../lib/ui/helpers'
-import { BaseArgvOptions } from '../types'
+import { BaseCommandOptions } from '../types'
 
 export type InstallationScope = 'global' | 'project'
 
-export interface InitOptions extends BaseArgvOptions {
+export interface InitOptions extends BaseCommandOptions {
   scope?: InstallationScope
   dryRun?: boolean
 }
 
-export type InitArgv = Argv<InitOptions>['argv']
+export type InitArgv = Arguments<InitOptions>
 
 export const command = 'init'
 

--- a/src/commands/init/handler.ts
+++ b/src/commands/init/handler.ts
@@ -1,7 +1,9 @@
 import { appendToEnvFile } from '../../lib/config/services/env'
 import { appendToGitConfig } from '../../lib/config/services/git'
 import { appendToProjectJsonConfig } from '../../lib/config/services/project'
+import chalk from 'chalk'
 import { checkAndHandlePackageInstallation } from '../../lib/ui/checkAndHandlePackageInstall'
+import { FAIL, PASS, WARN } from '../../lib/ui/glyphs'
 import { LOGO } from '../../lib/ui/helpers'
 import { confirmPrompt } from '../../lib/ui/inquirerPrompts'
 import { logResult } from '../../lib/ui/logResult'
@@ -15,6 +17,7 @@ import { CommandHandler } from '../../lib/types'
 import { Logger } from '../../lib/utils/logger'
 import { getPathToUsersGitConfig } from '../../lib/utils/getPathToUsersGitConfig'
 import { getProjectConfigFilePath } from '../../lib/utils/getProjectConfigFilePath'
+import { runDiagnostics } from '../doctor/checks'
 import { applyRepoCwd } from '../utils/applyRepoFlag'
 import { InitArgv, InitOptions } from './config'
 import { questions } from './questions'
@@ -24,11 +27,7 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
   // writes the project config to X, not the launcher's cwd. The
   // chdir has to happen before getProjectConfigFilePath resolves
   // its target path (it reads process.cwd).
-  //
-  // `InitArgv` is `Argv<InitOptions>['argv']` which yargs types as a
-  // union including Promise — pass just the `repo` field as a plain
-  // object so the helper's narrow signature stays clean.
-  applyRepoCwd({ repo: (argv as { repo?: string }).repo })
+  applyRepoCwd(argv)
 
   const options = loadConfig<InitOptions, InitArgv>(argv)
 
@@ -196,6 +195,47 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
     }
 
     logger.log(`\ninit successful! 🦾🤖🎉`, { color: 'green' })
+
+    // Post-write verification — run the same check `coco doctor` runs
+    // so the user finds out about typos / structural issues now,
+    // before their first `coco commit`. Re-load from disk so we
+    // verify the persisted config (not the in-memory shape we just
+    // built), which catches transcription bugs in the appenders.
+    try {
+      const persistedConfig = loadConfig({})
+      const diagnostics = runDiagnostics(persistedConfig)
+      const errors = diagnostics.filter((d) => d.severity === 'error')
+      const warnings = diagnostics.filter((d) => d.severity === 'warn')
+
+      if (errors.length === 0 && warnings.length === 0) {
+        logger.log(`${PASS()} Verified: no issues found in your new config.`, { color: 'green' })
+      } else {
+        if (errors.length > 0) {
+          logger.log(`${FAIL()} ${errors.length} error(s) found in the persisted config:`, { color: 'red' })
+          for (const diagnostic of errors) {
+            logger.log(`  ${chalk.red(diagnostic.message)}`)
+          }
+        }
+        if (warnings.length > 0) {
+          logger.log(`${WARN()} ${warnings.length} warning(s) found in the persisted config:`, { color: 'yellow' })
+          for (const diagnostic of warnings) {
+            logger.log(`  ${chalk.yellow(diagnostic.message)}`)
+          }
+        }
+        logger.log(`${chalk.dim('Run')} ${chalk.cyan('coco doctor')} ${chalk.dim('for the full diagnostic report.')}`)
+      }
+    } catch (verifyError) {
+      // Verification is a polish step, not a blocker. If it crashes
+      // (e.g. config file written to a path the loader can't reach
+      // from the current cwd), fall through to a hint instead of
+      // failing the whole init flow — the config is on disk and
+      // the user can run `coco doctor` themselves.
+      logger.log(
+        `${chalk.dim('Skipped post-init verification:')} ${(verifyError as Error).message}`,
+        { color: 'gray' }
+      )
+      logger.log(`${chalk.dim('Run')} ${chalk.cyan('coco doctor')} ${chalk.dim('to verify your config manually.')}`)
+    }
   } else {
     logger.log('\ninit cancelled.', { color: 'yellow' })
   }

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -4,7 +4,7 @@ import { handler } from './handler'
 
 export default {
   command,
-  desc: 'install & configure coco globally or for the current project',
+  desc: 'Install & configure coco globally or for the current project',
   builder,
   handler: commandExecutor(handler),
   options,

--- a/src/commands/issues/index.ts
+++ b/src/commands/issues/index.ts
@@ -1,5 +1,5 @@
 import commandExecutor from '../../lib/utils/commandExecutor'
-import { builder, command } from './config'
+import { builder, command, options } from './config'
 import { handler } from './handler'
 
 export default {
@@ -7,4 +7,5 @@ export default {
   desc: 'List GitHub issues for the current repository (read-only triage)',
   builder,
   handler: commandExecutor(handler),
+  options,
 }

--- a/src/commands/prs/index.ts
+++ b/src/commands/prs/index.ts
@@ -1,5 +1,5 @@
 import commandExecutor from '../../lib/utils/commandExecutor'
-import { builder, command } from './config'
+import { builder, command, options } from './config'
 import { handler } from './handler'
 
 export default {
@@ -7,4 +7,5 @@ export default {
   desc: 'List GitHub pull requests for the current repository (read-only triage)',
   builder,
   handler: commandExecutor(handler),
+  options,
 }

--- a/src/commands/recap/handler.ts
+++ b/src/commands/recap/handler.ts
@@ -17,6 +17,7 @@ import { getCurrentBranchName } from '../../lib/simple-git/getCurrentBranchName'
 import { getDiffForBranch } from '../../lib/simple-git/getDiffForBranch'
 import { CommandHandler } from '../../lib/types'
 import { generateAndReviewLoop } from '../../lib/ui/generateAndReviewLoop'
+import { handleMissingApiKey } from '../../lib/ui/handleMissingApiKey'
 import { handleResult } from '../../lib/ui/handleResult'
 import { isInteractive, LOGO } from '../../lib/ui/helpers'
 import { logSuccess } from '../../lib/ui/logSuccess'
@@ -38,8 +39,7 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
   const model = recapService.model
 
   if (config.service.authentication.type !== 'None' && !key) {
-    logger.log(`No API Key found. 🗝️🚪`, { color: 'red' })
-    commandExit(1)
+    handleMissingApiKey(logger, config, { command: 'recap' })
   }
 
   const tokenizer = await getTokenCounter(

--- a/src/commands/review/handler.ts
+++ b/src/commands/review/handler.ts
@@ -18,6 +18,7 @@ import { getCurrentBranchName } from '../../lib/simple-git/getCurrentBranchName'
 import { CommandHandler } from '../../lib/types'
 import { applyRepoFlag } from '../utils/applyRepoFlag'
 import { generateAndReviewLoop } from '../../lib/ui/generateAndReviewLoop'
+import { handleMissingApiKey } from '../../lib/ui/handleMissingApiKey'
 import { isInteractive, LOGO, severityColor } from '../../lib/ui/helpers'
 import { TaskList } from '../../lib/ui/TaskList'
 import { commandExit } from '../../lib/utils/commandExit'
@@ -44,8 +45,7 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
   const model = reviewService.model
 
   if (config.service.authentication.type !== 'None' && !key) {
-    logger.log(`No API Key found. 🗝️🚪`, { color: 'red' })
-    commandExit(1)
+    handleMissingApiKey(logger, config, { command: 'review' })
   }
 
   const tokenizer = await getTokenCounter(

--- a/src/git/branchActions.ts
+++ b/src/git/branchActions.ts
@@ -277,7 +277,7 @@ export function fetchBranch(
   if (!branch.upstream || !branch.remote) {
     return Promise.resolve({
       ok: false,
-      message: `${branch.shortName} has no upstream — nothing to fetch.`,
+      message: `${branch.shortName} has no upstream — set one with \`git push -u <remote> ${branch.shortName}\` to enable fetch.`,
     })
   }
 
@@ -326,7 +326,7 @@ export function pullBranch(
   if (!branch.upstream || !branch.remote) {
     return Promise.resolve({
       ok: false,
-      message: `${branch.shortName} has no upstream — nothing to pull.`,
+      message: `${branch.shortName} has no upstream — set one with \`git push -u <remote> ${branch.shortName}\` to enable pull.`,
     })
   }
 

--- a/src/git/githubCli.ts
+++ b/src/git/githubCli.ts
@@ -51,17 +51,96 @@ export async function getGitHubRepository(
 }
 
 /**
- * Probe `gh auth status` and return whether the GitHub CLI is
- * installed AND authenticated. Used by every data fetcher to short-
- * circuit before issuing real API calls — keeps the failure-mode
- * messaging consistent ("CLI missing or not authenticated") instead
- * of leaking through as a generic spawn error.
+ * Discriminated union describing the gh CLI's availability state.
+ * Lets callers route per-failure-mode messaging instead of collapsing
+ * everything to "CLI missing or not authenticated":
+ *
+ *   - `ok`               : gh installed + authenticated to github.com
+ *   - `not-installed`    : `gh` binary missing from PATH (ENOENT)
+ *   - `not-authenticated`: `gh auth status` returned non-zero, but the
+ *                          binary exists. User needs `gh auth login`.
+ *   - `unknown`          : gh failed for some other reason (timeout,
+ *                          permissions, malformed args). Treated as
+ *                          unavailable but logged so the user can
+ *                          inspect.
  */
-export async function isGhAuthenticated(runner: GhRunner): Promise<boolean> {
+export type GhStatus =
+  | { kind: 'ok' }
+  | { kind: 'not-installed' }
+  | { kind: 'not-authenticated'; detail?: string }
+  | { kind: 'unknown'; detail: string }
+
+/**
+ * Probe `gh auth status` and return a structured status describing
+ * exactly which of the failure modes is in play. Used by every data
+ * fetcher to short-circuit before issuing real API calls — and now
+ * lets the caller surface a tailored recovery hint per failure mode
+ * instead of one catch-all message.
+ *
+ * Distinguishing the modes:
+ *   - ENOENT (`gh: command not found`) → `not-installed`
+ *   - `gh auth status` exits non-zero with stderr matching the
+ *     "not logged into" / "authentication required" pattern →
+ *     `not-authenticated`
+ *   - Anything else (permission denied on the binary, timeout, etc.)
+ *     → `unknown` with the underlying error message attached for
+ *     diagnostic display.
+ */
+export async function getGhStatus(runner: GhRunner): Promise<GhStatus> {
   try {
     await runner(['auth', 'status', '--hostname', 'github.com'])
-    return true
-  } catch {
-    return false
+    return { kind: 'ok' }
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException & { stderr?: string; code?: string | number }
+    // ENOENT = the binary itself is missing. exec/spawn surfaces this
+    // as either `code === 'ENOENT'` (Node's spawn error code) or a
+    // message containing "ENOENT". Either form is unambiguous.
+    if (err.code === 'ENOENT' || (err.message && err.message.includes('ENOENT'))) {
+      return { kind: 'not-installed' }
+    }
+    // gh exits non-zero from `auth status` when the user isn't logged
+    // in. The message body contains "not logged into" or "logged in
+    // failed" depending on the gh version. Both patterns are stable
+    // enough to gate on without scope-locking to a specific gh
+    // release.
+    const stderr = err.stderr || err.message || ''
+    if (/not logged into|authentication.*required|you are not/i.test(stderr)) {
+      return { kind: 'not-authenticated', detail: stderr.trim().split('\n')[0] }
+    }
+    // Anything else — permission denied, timeout, etc. Surface the
+    // raw message so the user can read it; treat as unavailable.
+    return { kind: 'unknown', detail: err.message || 'gh auth status failed' }
+  }
+}
+
+/**
+ * Backwards-compatible boolean wrapper around `getGhStatus`. Kept so
+ * existing callers (data loaders, sidebar fetchers) don't all have to
+ * migrate at once. New call sites should use `getGhStatus` directly
+ * to access the discriminated failure modes.
+ */
+export async function isGhAuthenticated(runner: GhRunner): Promise<boolean> {
+  const status = await getGhStatus(runner)
+  return status.kind === 'ok'
+}
+
+/**
+ * Render a user-facing recovery hint for a non-`ok` gh status. Used by
+ * `commands/issues` / `commands/prs` / pull-request workflow surfaces
+ * so every "gh is unavailable" message tells the user the exact next
+ * step. Keeps the wording in sync across surfaces — if a user runs
+ * `coco prs` and `coco issues` back to back, the same broken state
+ * surfaces the same fix.
+ */
+export function describeGhStatus(status: GhStatus): string {
+  switch (status.kind) {
+    case 'ok':
+      return 'GitHub CLI is installed and authenticated.'
+    case 'not-installed':
+      return 'GitHub CLI (`gh`) is not installed. Install it from https://cli.github.com/ and run `gh auth login`.'
+    case 'not-authenticated':
+      return `GitHub CLI is installed but not authenticated. Run \`gh auth login\` (scopes: \`repo\`, \`read:org\`).${status.detail ? ` Details: ${status.detail}` : ''}`
+    case 'unknown':
+      return `GitHub CLI returned an unexpected error: ${status.detail}. Try \`gh auth status\` directly to diagnose.`
   }
 }

--- a/src/git/issuesListData.test.ts
+++ b/src/git/issuesListData.test.ts
@@ -25,11 +25,19 @@ describe('issuesListData', () => {
   })
 
   it('returns unauthenticated when `gh auth status` throws', async () => {
-    const runner = jest.fn().mockRejectedValueOnce(new Error('not installed'))
+    // The MEDIUM-7 refactor (#TBD) tags gh failures with a structured
+    // status (`not-installed` / `not-authenticated` / `unknown`).
+    // ENOENT collapses to `not-installed`; other errors collapse to
+    // `unknown`. Either way the overview's `authenticated` flag is
+    // false — that's the contract the data layer ships.
+    const enoentError = Object.assign(new Error('spawn gh ENOENT'), { code: 'ENOENT' })
+    const runner = jest.fn().mockRejectedValueOnce(enoentError)
     const overview = await getIssueList(githubRemoteGit(), {}, runner)
     expect(overview.authenticated).toBe(false)
     expect(overview.repository).toEqual({ owner: 'gfargo', name: 'coco' })
-    expect(overview.message).toMatch(/missing or not authenticated/)
+    // Match either the ENOENT-specific copy or the generic
+    // unauthenticated message — both are valid for "gh isn't usable".
+    expect(overview.message).toMatch(/not installed|not authenticated/)
   })
 
   it('parses a populated issue list', async () => {

--- a/src/git/issuesListData.ts
+++ b/src/git/issuesListData.ts
@@ -1,10 +1,10 @@
 import { SimpleGit } from 'simple-git'
 import {
-  defaultGhRunner,
-  getGitHubRepository,
-  isGhAuthenticated,
-  type GhRunner,
-  type GitHubRepository,
+    defaultGhRunner,
+    describeGhStatus,
+    getGhStatus,
+    getGitHubRepository, type GhRunner,
+    type GitHubRepository
 } from './githubCli'
 
 export type IssueState = 'open' | 'closed' | 'all'
@@ -138,13 +138,14 @@ export async function getIssueList(
     }
   }
 
-  if (!(await isGhAuthenticated(runner))) {
+  const ghStatus = await getGhStatus(runner)
+  if (ghStatus.kind !== 'ok') {
     return {
       available: true,
       authenticated: false,
       repository,
       filter,
-      message: 'GitHub CLI is missing or not authenticated.',
+      message: describeGhStatus(ghStatus),
     }
   }
 

--- a/src/git/pullRequestListData.ts
+++ b/src/git/pullRequestListData.ts
@@ -1,10 +1,10 @@
 import { SimpleGit } from 'simple-git'
 import {
-  defaultGhRunner,
-  getGitHubRepository,
-  isGhAuthenticated,
-  type GhRunner,
-  type GitHubRepository,
+    defaultGhRunner,
+    describeGhStatus,
+    getGhStatus,
+    getGitHubRepository, type GhRunner,
+    type GitHubRepository
 } from './githubCli'
 
 export type PullRequestState = 'open' | 'closed' | 'merged' | 'all'
@@ -164,13 +164,14 @@ export async function getPullRequestList(
     }
   }
 
-  if (!(await isGhAuthenticated(runner))) {
+  const ghStatus = await getGhStatus(runner)
+  if (ghStatus.kind !== 'ok') {
     return {
       available: true,
       authenticated: false,
       repository,
       filter,
-      message: 'GitHub CLI is missing or not authenticated.',
+      message: describeGhStatus(ghStatus),
     }
   }
 

--- a/src/lib/langchain/errors.ts
+++ b/src/lib/langchain/errors.ts
@@ -40,10 +40,22 @@ export class LangChainExecutionError extends LangChainError {
 
 /**
  * Authentication-related errors (missing API keys, invalid credentials, etc.)
+ *
+ * Carries `provider` + `endpoint` context so the formatter (in
+ * `commandExecutor`) can render provider-specific recovery hints
+ * ("set OPENAI_API_KEY", "run `gh auth login`", etc.) instead of the
+ * generic "verify your API key" copy. Mirrors the shape of
+ * `LangChainNetworkError` so call sites can hand the same fields to
+ * either constructor depending on which condition fired.
  */
 export class LangChainAuthenticationError extends LangChainError {
-  constructor(message: string, context?: Record<string, unknown>) {
-    super(message, context)
+  constructor(
+    message: string,
+    public readonly provider?: string,
+    public readonly endpoint?: string,
+    context?: Record<string, unknown>
+  ) {
+    super(message, { ...context, provider, endpoint })
   }
 }
 

--- a/src/lib/langchain/utils.ts
+++ b/src/lib/langchain/utils.ts
@@ -58,11 +58,17 @@ export function getDefaultServiceApiKey(config: Config): string {
 
   if (service.authentication.type === 'APIKey') {
     const apiKey = service.authentication.credentials?.apiKey
-    
+    // `endpoint` is optional on some service variants (Ollama / OpenAI-
+    // compatible) and absent on others (managed OpenAI / Anthropic).
+    // Read defensively so we still attach it when present.
+    const endpoint = (service as { endpoint?: string }).endpoint
+
     if (requiresAuth && (!apiKey || apiKey.trim() === '')) {
       throw new LangChainAuthenticationError(
         `getDefaultServiceApiKey: API key is required for ${provider} provider but not provided`,
-        { provider, authenticationType: service.authentication.type }
+        provider,
+        endpoint,
+        { authenticationType: service.authentication.type }
       )
     }
     
@@ -71,11 +77,14 @@ export function getDefaultServiceApiKey(config: Config): string {
   
   if (service.authentication.type === 'OAuth') {
     const token = service.authentication.credentials?.token
-    
+    const endpoint = (service as { endpoint?: string }).endpoint
+
     if (requiresAuth && (!token || token.trim() === '')) {
       throw new LangChainAuthenticationError(
         `getDefaultServiceApiKey: OAuth token is required for ${provider} provider but not provided`,
-        { provider, authenticationType: service.authentication.type }
+        provider,
+        endpoint,
+        { authenticationType: service.authentication.type }
       )
     }
     
@@ -84,9 +93,12 @@ export function getDefaultServiceApiKey(config: Config): string {
 
   if (service.authentication.type === 'None') {
     if (requiresAuth) {
+      const endpoint = (service as { endpoint?: string }).endpoint
       throw new LangChainAuthenticationError(
         `getDefaultServiceApiKey: ${provider} provider requires authentication but 'None' was configured`,
-        { provider, authenticationType: service.authentication.type }
+        provider,
+        endpoint,
+        { authenticationType: service.authentication.type }
       )
     }
     

--- a/src/lib/ui/glyphs.ts
+++ b/src/lib/ui/glyphs.ts
@@ -1,0 +1,101 @@
+/**
+ * Centralised glyph + label vocabulary for diagnostic / status copy.
+ *
+ * Before this module each surface (commandExecutor, doctor, footer,
+ * cache, issues, prs, commit-hook flow) picked its own marks for
+ * pass / warn / fail / info — `✓` here, `✔` there, `✖` vs `✗`. Users
+ * couldn't lean on a consistent visual signal to scan output, and the
+ * audit flagged it as one of the bigger inconsistencies in the
+ * codebase.
+ *
+ * The vocabulary mirrors what Linux package managers + git-aware
+ * tools converge on (`pacman`, `apt`, `nala`, `npm doctor`, etc.) —
+ * green check / red fail / yellow warn / blue info. ASCII fallbacks
+ * are first-class so dumb terminals (TERM=dumb / vt100) still render
+ * a meaningful prefix.
+ *
+ * Conventions:
+ *   - Status glyphs (PASS / FAIL / WARN / INFO) — for diagnostic
+ *     output, command exit, doctor severity, footer message kinds.
+ *     Colour-coded variants live alongside as `*_COLORED` helpers
+ *     so callers can use either depending on context.
+ *   - Action glyphs (BULLET, ARROW) — for indented hint lines and
+ *     "next step" callouts.
+ *   - Domain glyphs (CHECK_RUN_*, DECISION_*) — keep their own
+ *     vocabularies (PR reviews, status checks) because their
+ *     semantic shape doesn't map cleanly onto pass/fail/warn/info.
+ *
+ * Use `pickGlyph(unicode, ascii, isAscii)` when you need to honor
+ * `theme.ascii` mode in a single call site.
+ */
+
+import chalk from 'chalk'
+
+/**
+ * Status-severity glyph set. Same vocabulary as the workstation
+ * footer's `kind` field (info / warning / error / success / loading)
+ * plus `pass` for the doctor / "no problem" case.
+ */
+export const GLYPHS = {
+  pass: '✓',
+  fail: '✖',
+  warn: '⚠',
+  info: 'ℹ',
+  // Distinct from `fail` so cross-out-style output (review changes
+  // requested, check failures) doesn't get confused with command
+  // failure output.
+  cross: '✗',
+  pending: '◌',
+  // Spinner glyph is animated separately by `pickSpinnerFrame`; this
+  // is the static fallback for non-animated render paths.
+  spinner: '⠋',
+  bullet: '•',
+  arrow: '→',
+} as const
+
+/**
+ * ASCII-only fallbacks for terminals that can't render unicode (dumb /
+ * vt100 / NO_COLOR + ASCII strict). Map 1:1 to `GLYPHS`.
+ */
+export const ASCII_GLYPHS = {
+  pass: '+',
+  fail: '!',
+  warn: '!',
+  info: 'i',
+  cross: 'x',
+  pending: '.',
+  spinner: '*',
+  bullet: '-',
+  arrow: '->',
+} as const
+
+export type GlyphKey = keyof typeof GLYPHS
+
+/**
+ * Pick the right glyph for a given key, honoring an `ascii` flag.
+ * Lets callers stay declarative — `pickGlyph('pass', theme.ascii)` —
+ * instead of branching on `theme.ascii` at every render site.
+ */
+export function pickGlyph(key: GlyphKey, ascii: boolean = false): string {
+  return ascii ? ASCII_GLYPHS[key] : GLYPHS[key]
+}
+
+/**
+ * Theme-tinted helpers for terminal output. These return chalk-wrapped
+ * strings so callers don't repeat the `chalk.<color>(GLYPHS.<key>)`
+ * pattern. Each maps to the canonical colour the codebase uses for
+ * that severity:
+ *
+ *   - PASS  → green
+ *   - FAIL  → red
+ *   - WARN  → yellow
+ *   - INFO  → blue
+ *
+ * Doctor's `SEVERITY_ICON` lookup is the canonical example — it now
+ * delegates here so the colours stay in sync if the theme palette
+ * shifts in the future.
+ */
+export const PASS = (): string => chalk.green(GLYPHS.pass)
+export const FAIL = (): string => chalk.red(GLYPHS.fail)
+export const WARN = (): string => chalk.yellow(GLYPHS.warn)
+export const INFO = (): string => chalk.blue(GLYPHS.info)

--- a/src/lib/ui/handleMissingApiKey.ts
+++ b/src/lib/ui/handleMissingApiKey.ts
@@ -1,0 +1,71 @@
+import chalk from 'chalk'
+
+import { Config } from '../config/types'
+import { commandExit } from '../utils/commandExit'
+import { Logger } from '../utils/logger'
+import { FAIL, GLYPHS } from './glyphs'
+
+/**
+ * Maps each provider to the env var users should set + the kebab-case
+ * provider label used in the recovery copy. `coco init` and `coco
+ * doctor` both reference these names; keeping the lookup in one place
+ * makes the messages stay aligned when a new provider lands.
+ */
+const PROVIDER_ENV_VARS: Record<string, { envVar: string; label: string }> = {
+  openai: { envVar: 'OPENAI_API_KEY', label: 'OpenAI' },
+  anthropic: { envVar: 'ANTHROPIC_API_KEY', label: 'Anthropic' },
+  ollama: { envVar: 'OLLAMA_API_KEY', label: 'Ollama' },
+  'openai-compatible': { envVar: 'OPENAI_API_KEY', label: 'OpenAI-compatible' },
+}
+
+/**
+ * Print a structured "missing API key" message + exit non-zero.
+ *
+ * Replaces the old `No API Key found. 🗝️🚪` one-liner that used to live
+ * inline in commit / changelog / recap / review handlers. Centralised
+ * because:
+ *
+ *   1. The message names the env var the user actually needs to set
+ *      (different per provider) — that was the single biggest gap in
+ *      the prior message.
+ *   2. It surfaces the configured provider + model so the user can tell
+ *      which of their providers tripped the check (useful when running
+ *      with dynamic model routing).
+ *   3. It points at `coco init` and `coco doctor` as the recovery
+ *      paths, mirroring the discoverability cue every other modern CLI
+ *      uses for first-run config errors.
+ *
+ * Throws `CommandExitError(1)` via `commandExit` — callers do NOT need
+ * to handle the return value.
+ */
+export function handleMissingApiKey(
+  logger: Logger,
+  config: Config,
+  options: { command: string }
+): never {
+  const provider = config.service?.provider || 'unknown'
+  const model = config.service?.model || 'unknown'
+  const providerInfo = PROVIDER_ENV_VARS[provider] || {
+    envVar: 'PROVIDER_API_KEY',
+    label: provider,
+  }
+
+  const lines = [
+    `${FAIL()} ${chalk.bold('Missing API key')} for ${chalk.cyan(providerInfo.label)} (model: ${chalk.cyan(model)})`,
+    '',
+    `${chalk.bold('Next step')} — set up an API key one of these ways:`,
+    `  ${chalk.dim(GLYPHS.bullet)} Run ${chalk.cyan('coco init')} to walk through provider + key setup`,
+    `  ${chalk.dim(GLYPHS.bullet)} Export ${chalk.cyan(providerInfo.envVar)} in your shell`,
+    `  ${chalk.dim(GLYPHS.bullet)} Add the key to ${chalk.cyan('.coco.config.json')} or ${chalk.cyan('~/.gitconfig')} (under ${chalk.cyan('[coco]')})`,
+    '',
+    `${chalk.dim('Run')} ${chalk.cyan('coco doctor')} ${chalk.dim('to diagnose the active config sources.')}`,
+  ]
+
+  for (const line of lines) {
+    logger.log(line)
+  }
+
+  // Tag the exit message with the failing command so process supervisors
+  // / CI logs can grep for it without parsing the full body.
+  commandExit(1, `${options.command}: missing API key for ${providerInfo.label}`)
+}

--- a/src/lib/utils/commandExecutor.ts
+++ b/src/lib/utils/commandExecutor.ts
@@ -40,20 +40,51 @@ function formatNetworkError(error: LangChainNetworkError, logger: Logger): void 
     logger.log('  • Ensure the LLM service is running and accessible', { color: 'white' })
   }
 
+  logger.log('  • Run `coco doctor` to verify your configured provider + endpoint', { color: 'white' })
+
   logger.verbose(`\nOriginal error: ${error.message}`, { color: 'gray' })
 }
 
 /**
- * Formats an authentication error with helpful information
+ * Formats an authentication error with provider-aware troubleshooting.
+ *
+ * Pre-MEDIUM-8 the formatter was generic — "verify your API key,
+ * check it hasn't expired" — because the error class didn't carry
+ * any provider context. Now that `LangChainAuthenticationError`
+ * carries `provider` + `endpoint` (mirroring `LangChainNetworkError`),
+ * we can name the env var the user actually needs to set and route
+ * Ollama / OpenAI-compatible / managed-provider users through the
+ * right next step.
  */
 function formatAuthenticationError(error: LangChainAuthenticationError, logger: Logger): void {
+  const provider = error.provider || 'LLM service'
+  const endpoint = error.endpoint
+
   logger.log('\nFailed to execute command', { color: 'yellow' })
-  logger.log('\nError: Authentication failed', { color: 'red' })
+  logger.log(`\nError: Authentication failed${error.provider ? ` for ${provider}` : ''}`, { color: 'red' })
+
+  if (endpoint) {
+    logger.log(`       Endpoint: ${endpoint}`, { color: 'red' })
+  }
 
   logger.log('\nTroubleshooting:', { color: 'cyan' })
-  logger.log('  • Verify your API key is correct', { color: 'white' })
-  logger.log('  • Check that your API key has not expired', { color: 'white' })
-  logger.log('  • Ensure the API key is set in your environment or config', { color: 'white' })
+  logger.log('  • Verify your API key is correct and has not expired', { color: 'white' })
+
+  // Provider-specific env var hint when we know the provider.
+  if (provider === 'openai' || provider === 'OpenAI') {
+    logger.log('  • Set `OPENAI_API_KEY` in your shell or `service.authentication.credentials.apiKey` in config', { color: 'white' })
+  } else if (provider === 'anthropic' || provider === 'Anthropic') {
+    logger.log('  • Set `ANTHROPIC_API_KEY` in your shell or `service.authentication.credentials.apiKey` in config', { color: 'white' })
+  } else if (provider === 'ollama' || provider === 'Ollama') {
+    logger.log('  • Ollama usually does not need a key — check `service.endpoint` and that `ollama serve` is running', { color: 'white' })
+  } else if (provider === 'openai-compatible') {
+    logger.log('  • OpenAI-compatible endpoints need both `service.endpoint` and a valid API key', { color: 'white' })
+  } else {
+    logger.log('  • Ensure the API key is set in your environment or config', { color: 'white' })
+  }
+
+  logger.log('  • Run `coco init` to (re)configure your provider + key', { color: 'white' })
+  logger.log('  • Run `coco doctor` to inspect the active config sources', { color: 'white' })
 
   logger.verbose(`\nOriginal error: ${error.message}`, { color: 'gray' })
 }


### PR DESCRIPTION
Revives and rebases a set of CLI hardening improvements that had been sitting on an unmerged branch. Rebased cleanly onto current `main`; `tsc`, `eslint`, and the full jest suite pass locally (only the known tree-sitter `.wasm` suite fails in the sandbox for lack of the WASM artifact — green in CI).

## What's in it (5 commits)

- **Centralized glyph vocabulary module** — one source of truth for the status/marker glyphs used across CLI output, instead of scattered literals.
- **Provider-specific missing-API-key errors** — when a key is absent, the error now names the provider and how to set it, instead of a generic message.
- **Differentiated `gh` failure modes + richer auth-error context** — distinguishes "gh not installed" / "not authenticated" / other failures, with actionable context.
- **`doctor` exits non-zero on errors** — `coco doctor` now returns a failing exit code when it finds problems (via the shared `commandExit` helper), so it's usable in CI/scripts; cache paths use `commandExit` too.
- **`init` post-write diagnostics + aligned typing** — `init` runs diagnostics after writing config and tightens its typing.

## Validation
- Rebased onto `main` (was 4 days stale) with no conflicts.
- `npx tsc --noEmit` clean · `eslint src` clean · jest: 208/209 suites (the 1 failure is the env-only tree-sitter WASM suite).