### PR TITLE
feat(workstation): inline pending spinner while a list item is being deleted

### DIFF
--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -31,6 +31,27 @@ export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' 
 export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk' | 'discard-draft'
 
 /**
+ * Kinds of list item that support deletion (and therefore an inline
+ * pending-spinner while the delete runs). Each maps to a surface + a
+ * stable per-row id used by `pendingDeletion`.
+ */
+export type LogInkDeletableKind = 'branch' | 'tag' | 'stash' | 'worktree'
+
+/**
+ * True when `pending` (a `state.pendingDeletion`) targets this exact row.
+ * Shared by every deletable surface + the sidebar so the spinner-swap
+ * test is identical everywhere. Takes the field value (not the whole
+ * state) so it can live next to the type without a forward reference.
+ */
+export function isPendingDeletion(
+  pending: { kind: LogInkDeletableKind; id: string } | undefined,
+  kind: LogInkDeletableKind,
+  id: string
+): boolean {
+  return pending?.kind === kind && pending.id === id
+}
+
+/**
  * One level in the nested-repo navigation stack (#931). Pushing a
  * frame is the mental equivalent of spawning another `coco ui`
  * instance scoped to a submodule's working directory; popping
@@ -337,6 +358,18 @@ export type LogInkState = {
   pendingConfirmationPayload?: string
   pendingMutationConfirmation?: LogInkMutationConfirmation
   pendingKey?: string
+  /**
+   * The list item whose deletion is currently in flight, if any. Set by
+   * the runtime workflow runner the moment a delete starts (after the
+   * y-confirm) and cleared once the command resolves and the list
+   * refreshes. While set, that row renders an inline pending spinner in
+   * place of its status icon (or appended, for rows without one) — the
+   * generalized "this item is being deleted" affordance. Keyed by
+   * `kind` + a stable id (`branch.shortName`, `tag.name`, `stash.ref`,
+   * `worktree.path`) so it can't accidentally match a same-named row in
+   * a different list rendering at the same time.
+   */
+  pendingDeletion?: { kind: LogInkDeletableKind; id: string }
   focus: LogInkFocus
   /**
    * Set while the user is "peeking" the sidebar (#1135 v2) — a momentary
@@ -815,6 +848,7 @@ export type LogInkAction =
   | { type: 'setWorkflowAction'; value?: string }
   | { type: 'setPendingConfirmation'; value?: string; payload?: string }
   | { type: 'setPendingMutationConfirmation'; value?: LogInkMutationConfirmation }
+  | { type: 'setPendingDeletion'; value?: { kind: LogInkDeletableKind; id: string } }
   | { type: 'appendPaletteFilter'; value: string }
   | { type: 'backspacePaletteFilter' }
   | { type: 'clearPaletteFilter' }
@@ -2157,6 +2191,10 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         workflowActionId: action.value ? undefined : state.workflowActionId,
         pendingKey: undefined,
       }
+    case 'setPendingDeletion':
+      // Pure marker for the in-flight delete; touches nothing else so the
+      // list keeps rendering normally underneath the one spinner'd row.
+      return { ...state, pendingDeletion: action.value }
     case 'toggleFilterMode':
       return {
         ...state,

--- a/src/workstation/chrome/spinner.ts
+++ b/src/workstation/chrome/spinner.ts
@@ -28,3 +28,23 @@ export const SPINNER_TICK_MS = 80
 export function pickSpinnerFrame(tick: number): string {
   return SPINNER_FRAMES[Math.max(0, tick) % SPINNER_FRAMES.length]
 }
+
+/**
+ * ASCII-safe spinner frames for `NO_COLOR` / ASCII terminals where the
+ * braille dots either don't render or look like noise. The four-frame
+ * `|/-\` cycle is the classic terminal spinner and reads as motion in
+ * any encoding.
+ */
+export const ASCII_SPINNER_FRAMES = ['|', '/', '-', '\\']
+
+/**
+ * Inline per-item pending glyph — used in place of (or appended to) a
+ * list row's status icon while that row's mutation (a delete) is in
+ * flight. Braille spinner normally; the ASCII cycle under `ascii`
+ * themes so the indicator survives `NO_COLOR` / dumb terminals.
+ */
+export function inlineSpinnerGlyph(tick: number, ascii: boolean): string {
+  return ascii
+    ? ASCII_SPINNER_FRAMES[Math.max(0, tick) % ASCII_SPINNER_FRAMES.length]
+    : pickSpinnerFrame(tick)
+}

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -129,6 +129,7 @@ import type { LogInkVisiblePane } from '../chrome/layout'
 import { sortBranches, sortTags } from '../chrome/sorting'
 import { IDLE_TIPS_GRACE_MS, IDLE_TIPS_INTERVAL_MS, pickIdleTip } from '../chrome/idleTips'
 import {
+    LogInkDeletableKind,
     LogInkState,
     RemoteOpState,
     applyLogInkAction,
@@ -388,6 +389,58 @@ const REMOTE_OP_LOADERS: Record<string, RemoteOpState> = {
   'fetch-selected-branch': { kind: 'fetch', label: 'Fetching branch from remote…' },
   'pull-selected-branch': { kind: 'pull', label: 'Pulling branch from remote…' },
   'push-selected-branch': { kind: 'push', label: 'Pushing branch to remote…' },
+}
+
+/**
+ * Resolve which list row a delete workflow is about to act on, so the
+ * runner can mark it pending (inline spinner) for the duration of the
+ * git call. Mirrors the cursored-target resolution inside each delete
+ * handler exactly — same sort, same promoted-filter, same selection
+ * index — so the spinner lands on the row that actually gets deleted.
+ * Returns `undefined` for non-delete workflows (and when nothing is
+ * selected), which the runner treats as "no pending marker".
+ */
+function resolvePendingDeletion(
+  id: string,
+  state: LogInkState,
+  context: LogInkContext
+): { kind: LogInkDeletableKind; id: string } | undefined {
+  const { filter } = state
+  if (id === 'delete-branch') {
+    const all = sortBranches(context.branches?.localBranches || [], state.branchSort)
+    const visible = filter
+      ? all.filter((b) => matchesPromotedFilter([b.shortName, b.upstream || ''], filter))
+      : all
+    const branch = visible[Math.min(state.selectedBranchIndex, visible.length - 1)]
+    return branch ? { kind: 'branch', id: branch.shortName } : undefined
+  }
+  if (id === 'delete-tag') {
+    const all = sortTags(context.tags?.tags || [], state.tagSort)
+    const visible = filter
+      ? all.filter((t) => matchesPromotedFilter([t.name, t.subject], filter))
+      : all
+    const tag = visible[Math.min(state.selectedTagIndex, visible.length - 1)]
+    return tag ? { kind: 'tag', id: tag.name } : undefined
+  }
+  if (id === 'drop-stash') {
+    const all = context.stashes?.stashes || []
+    const visible = filter
+      ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], filter))
+      : all
+    const stash = visible[Math.min(state.selectedStashIndex, visible.length - 1)]
+    return stash ? { kind: 'stash', id: stash.ref } : undefined
+  }
+  if (id === 'remove-worktree') {
+    const all = context.worktreeList?.worktrees || []
+    const visible = filter
+      ? all.filter((w) => matchesPromotedFilter([w.path, w.branch || ''], filter))
+      : all
+    const wt = visible.length
+      ? visible[Math.min(state.selectedWorktreeListIndex, visible.length - 1)]
+      : all[Math.min(state.selectedWorktreeListIndex, Math.max(0, all.length - 1))]
+    return wt ? { kind: 'worktree', id: wt.path } : undefined
+  }
+  return undefined
 }
 
 function predictNextFilter(
@@ -763,7 +816,10 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     state.changelogView.status === 'loading' ||
     state.commitCompose.loading ||
     Boolean(state.remoteOp) ||
-    Boolean(state.statusLoading)
+    Boolean(state.statusLoading) ||
+    // Keep the shared spinner ticking while a list-item delete is in
+    // flight so its inline pending glyph animates instead of freezing.
+    Boolean(state.pendingDeletion)
   React.useEffect(() => {
     if (!anyLoading) {
       // Reset to 0 so the next loading state starts from a known
@@ -3819,6 +3875,15 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     if (remoteOp) {
       dispatch({ type: 'setRemoteOp', value: remoteOp })
     }
+    // Mark the cursored row as deleting so it shows an inline pending
+    // spinner while the git call runs. Cleared in `finally` after the
+    // refresh, so a successful delete hands straight off to the row
+    // vanishing, and a failed one (e.g. an unmerged branch) restores
+    // the row's normal icon alongside the error status.
+    const pendingDeletion = resolvePendingDeletion(id, state, context)
+    if (pendingDeletion) {
+      dispatch({ type: 'setPendingDeletion', value: pendingDeletion })
+    }
     try {
     const result = await handler()
     dispatch({ type: 'setStatus', value: result?.message || 'Workflow action complete' })
@@ -3919,6 +3984,12 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       // the spinner.
       if (remoteOp) {
         dispatch({ type: 'setRemoteOp', value: undefined })
+      }
+      // Same guarantee for the per-row delete spinner: clear it whether
+      // the delete succeeded, failed, or the refresh threw, so no row is
+      // left spinning forever.
+      if (pendingDeletion) {
+        dispatch({ type: 'setPendingDeletion', value: undefined })
       }
     }
   }, [context, dispatch, git, refreshContext, refreshHistoryRows, refreshWorktreeContext,
@@ -4812,7 +4883,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // visible pane — the main-panel render in particular is expensive, so
   // we don't want to invoke the two hidden ones just to drop them.
   const sidebarPanel = () =>
-    renderSidebar(h, { Box, Text }, state, context, contextStatus, layout.sidebarWidth, layout.bodyRows, theme)
+    renderSidebar(h, { Box, Text }, state, context, contextStatus, layout.sidebarWidth, layout.bodyRows, theme, spinnerFrame)
   const mainSurface: SurfaceRenderContext = {
     h,
     components: { Box, Text },

--- a/src/workstation/runtime/mainPanel.ts
+++ b/src/workstation/runtime/mainPanel.ts
@@ -105,11 +105,11 @@ export function renderMainPanel(
   }
 
   if (state.activeView === 'branches') {
-    return renderBranchesSurface(surface)
+    return renderBranchesSurface(surface, spinnerFrame)
   }
 
   if (state.activeView === 'tags') {
-    return renderTagsSurface(surface)
+    return renderTagsSurface(surface, spinnerFrame)
   }
 
   if (state.activeView === 'reflog') {
@@ -121,11 +121,11 @@ export function renderMainPanel(
   }
 
   if (state.activeView === 'stash') {
-    return renderStashSurface(surface)
+    return renderStashSurface(surface, spinnerFrame)
   }
 
   if (state.activeView === 'worktrees') {
-    return renderWorktreesSurface(surface)
+    return renderWorktreesSurface(surface, spinnerFrame)
   }
 
   if (state.activeView === 'submodules') {

--- a/src/workstation/runtime/pendingDeletion.test.ts
+++ b/src/workstation/runtime/pendingDeletion.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Pending-deletion inline spinner (#1137 follow-up).
+ *
+ * When a list-item delete is in flight, the targeted row shows an inline
+ * spinner in place of its leading status icon (branches / worktrees) or
+ * appended to the row (tags / stashes, which have no leading icon). These
+ * tests cover the pure helper + reducer and assert the spinner glyph lands
+ * on the right row in every deletable surface and in the sidebar.
+ *
+ * Stub `Text` / `Box` so the React tree can be flattened to text without
+ * pulling Ink (ESM) into ts-jest — same pattern as `overlays.test.ts`.
+ */
+import { createElement } from 'react'
+import {
+  applyLogInkAction,
+  createLogInkState,
+  isPendingDeletion,
+} from '../../commands/log/inkViewModel'
+import { inlineSpinnerGlyph } from '../chrome/spinner'
+import { createLogInkContextStatus } from '../chrome/context'
+import { createLogInkTheme } from '../chrome/theme'
+import { renderBranchesSurface } from '../surfaces/branches'
+import { renderTagsSurface } from '../surfaces/tags'
+import { renderStashSurface } from '../surfaces/stash'
+import { renderWorktreesSurface } from '../surfaces/worktrees'
+import { renderSidebar } from './sidebar'
+import type { LogInkComponents, LogInkContext, SurfaceRenderContext } from './types'
+
+type StubProps = Record<string, unknown>
+const Text = ((props: StubProps) =>
+  createElement('text', props, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+const Box = ((props: StubProps) =>
+  createElement('box', props, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+const components: LogInkComponents = { Box, Text }
+const theme = createLogInkTheme({ noColor: false })
+const SPIN = inlineSpinnerGlyph(0, theme.ascii)
+
+function flattenText(node: unknown): string {
+  if (node == null || node === false) return ''
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(flattenText).join(' ')
+  const el = node as { props?: { children?: unknown } }
+  if (el.props && 'children' in el.props) return flattenText(el.props.children)
+  return ''
+}
+
+const context: LogInkContext = {
+  branches: {
+    currentBranch: 'main',
+    dirty: false,
+    remoteBranches: [],
+    localBranches: [
+      { type: 'local', name: 'main', shortName: 'main', hash: 'a1', current: true, date: '2024-01-01', subject: 's', ahead: 0, behind: 0 },
+      { type: 'local', name: 'feat/x', shortName: 'feat/x', hash: 'b2', current: false, date: '2024-01-02', subject: 's', ahead: 0, behind: 0 },
+    ],
+  },
+  tags: {
+    tags: [
+      { name: 'v1.0.0', hash: 'c3', date: '2024-01-01', subject: 'release one' },
+      { name: 'v1.1.0', hash: 'c4', date: '2024-01-02', subject: 'release two' },
+    ],
+  },
+  stashes: {
+    stashes: [
+      { ref: 'stash@{0}', hash: 'd5', baseHash: 'd5p', date: '2024-01-01', branch: 'main', message: 'wip one', files: ['a.ts'] },
+      { ref: 'stash@{1}', hash: 'd6', baseHash: 'd6p', date: '2024-01-02', branch: 'main', message: 'wip two', files: ['b.ts'] },
+    ],
+  },
+  worktreeList: {
+    currentPath: '/repo',
+    worktrees: [
+      { path: '/repo', branch: 'main', detached: false, bare: false, current: true, dirty: false },
+      { path: '/repo/wt', branch: 'feat/x', detached: false, bare: false, current: false, dirty: false },
+    ],
+  },
+}
+
+function ctxFor(view: 'branches' | 'tags' | 'stash' | 'worktrees', pending?: { kind: never; id: string }): SurfaceRenderContext {
+  const base = createLogInkState([])
+  return {
+    h: createElement,
+    components,
+    state: { ...base, activeView: view, focus: 'commits', pendingDeletion: pending as never },
+    context,
+    contextStatus: createLogInkContextStatus('ready'),
+    bodyRows: 30,
+    width: 70,
+    theme,
+  }
+}
+
+describe('isPendingDeletion', () => {
+  it('matches only on the same kind AND id', () => {
+    const pending = { kind: 'branch' as const, id: 'feat/x' }
+    expect(isPendingDeletion(pending, 'branch', 'feat/x')).toBe(true)
+    expect(isPendingDeletion(pending, 'branch', 'main')).toBe(false) // id differs
+    expect(isPendingDeletion(pending, 'tag', 'feat/x')).toBe(false) // kind differs
+    expect(isPendingDeletion(undefined, 'branch', 'feat/x')).toBe(false)
+  })
+})
+
+describe('setPendingDeletion reducer', () => {
+  it('sets and clears the pending target without touching anything else', () => {
+    let state = createLogInkState([])
+    expect(state.pendingDeletion).toBeUndefined()
+    state = applyLogInkAction(state, { type: 'setPendingDeletion', value: { kind: 'stash', id: 'stash@{0}' } })
+    expect(state.pendingDeletion).toEqual({ kind: 'stash', id: 'stash@{0}' })
+    state = applyLogInkAction(state, { type: 'setPendingDeletion', value: undefined })
+    expect(state.pendingDeletion).toBeUndefined()
+  })
+})
+
+describe('inline pending spinner per surface', () => {
+  it('branches: swaps the targeted row marker for a spinner, leaving others alone', () => {
+    const plain = flattenText(renderBranchesSurface(ctxFor('branches'), 0))
+    expect(plain).not.toContain(SPIN)
+
+    const pending = flattenText(renderBranchesSurface(ctxFor('branches', { kind: 'branch' as never, id: 'feat/x' }), 0))
+    expect(pending).toContain(SPIN)
+    expect(pending).toContain('feat/x') // row still shows its name
+  })
+
+  it('worktrees: swaps the targeted row marker for a spinner', () => {
+    const pending = flattenText(renderWorktreesSurface(ctxFor('worktrees', { kind: 'worktree' as never, id: '/repo/wt' }), 0))
+    expect(pending).toContain(SPIN)
+    expect(flattenText(renderWorktreesSurface(ctxFor('worktrees'), 0))).not.toContain(SPIN)
+  })
+
+  it('tags: appends a spinner (no leading icon to swap)', () => {
+    const pending = flattenText(renderTagsSurface(ctxFor('tags', { kind: 'tag' as never, id: 'v1.1.0' }), 0))
+    expect(pending).toContain(SPIN)
+    expect(pending).toContain('v1.1.0')
+    expect(flattenText(renderTagsSurface(ctxFor('tags'), 0))).not.toContain(SPIN)
+  })
+
+  it('stashes: appends a spinner', () => {
+    const pending = flattenText(renderStashSurface(ctxFor('stash', { kind: 'stash' as never, id: 'stash@{1}' }), 0))
+    expect(pending).toContain(SPIN)
+    expect(flattenText(renderStashSurface(ctxFor('stash'), 0))).not.toContain(SPIN)
+  })
+})
+
+describe('inline pending spinner in the sidebar', () => {
+  it('shows the spinner on the targeted branch row of the active tab', () => {
+    const base = createLogInkState([])
+    const state = { ...base, sidebarTab: 'branches' as const, focus: 'sidebar' as const, pendingDeletion: { kind: 'branch' as const, id: 'feat/x' } }
+    const tree = renderSidebar(createElement, components, state, context, createLogInkContextStatus('ready'), 40, 30, theme, 0)
+    expect(flattenText(tree)).toContain(SPIN)
+  })
+})

--- a/src/workstation/runtime/sidebar.ts
+++ b/src/workstation/runtime/sidebar.ts
@@ -20,13 +20,14 @@ import { isLogInkContextKeyLoading } from '../chrome/context'
 import { branchRowMarker, sidebarTabCount } from '../chrome/iconography'
 import { getSidebarVisibleWindow } from '../chrome/sidebarSelection'
 import { sortBranches, sortTags } from '../chrome/sorting'
+import { inlineSpinnerGlyph } from '../chrome/spinner'
 import { cellWidth, truncateCells, truncatePathCells } from '../chrome/text'
 import type { LogInkTheme } from '../chrome/theme'
 import type {
   LogInkSidebarTab,
   LogInkState,
 } from '../../commands/log/inkViewModel'
-import { getLogInkSidebarTabs } from '../../commands/log/inkViewModel'
+import { getLogInkSidebarTabs, isPendingDeletion } from '../../commands/log/inkViewModel'
 import type { LogInkComponents, LogInkContext } from './types'
 import { focusBorderColor, panelTitle, sidebarTabLabel } from './utils'
 
@@ -149,8 +150,15 @@ function renderActiveSidebarContent(
   contextStatus: LogInkContextStatus,
   width: number,
   bodyRows: number,
-  theme: LogInkTheme
+  theme: LogInkTheme,
+  spinnerFrame: number
 ): ReactTypes.ReactElement[] {
+  // Inline pending-delete glyph: while a row's delete is in flight it
+  // shows this spinner in place of its leading marker (branches /
+  // worktrees) or appended to the row (tags / stashes, which have no
+  // leading status icon). `pending` is the single in-flight target.
+  const pending = state.pendingDeletion
+  const spin = inlineSpinnerGlyph(spinnerFrame, theme.ascii)
   // Available rows for the active tab's list. The sidebar chrome
   // takes ~10 rows (panel title + spacer + 5 tab headers + 4 inter-tab
   // spacers); the branches tab eats 3 more for its summary header
@@ -193,7 +201,12 @@ function renderActiveSidebarContent(
       ...headerRows,
       ...renderSelectableSidebarRows(
         h, Text, sortedBranches, state.selectedBranchIndex, focused, width, theme,
-        (branch) => `${branchRowMarker(branch, { ascii: theme.ascii }).glyph} ${branch.shortName}`,
+        (branch) => {
+          const glyph = isPendingDeletion(pending, 'branch', branch.shortName)
+            ? spin
+            : branchRowMarker(branch, { ascii: theme.ascii }).glyph
+          return `${glyph} ${branch.shortName}`
+        },
         'tab-branches', visibleListCount,
       ),
     ]
@@ -209,7 +222,12 @@ function renderActiveSidebarContent(
     }
     return renderSelectableSidebarRows(
       h, Text, tags, state.selectedTagIndex, focused, width, theme,
-      (tag) => `${truncateCells(tag.name, 16)} ${tag.subject}`,
+      (tag) => {
+        const base = `${truncateCells(tag.name, 16)} ${tag.subject}`
+        // Tags have no leading status icon, so the pending spinner is
+        // appended to the row instead of replacing a glyph.
+        return isPendingDeletion(pending, 'tag', tag.name) ? `${base} ${spin}` : base
+      },
       'tab-tags', visibleListCount,
     )
   }
@@ -224,7 +242,12 @@ function renderActiveSidebarContent(
     }
     return renderSelectableSidebarRows(
       h, Text, stashes, state.selectedStashIndex, focused, width, theme,
-      (stash, index) => `@{${index}} ${stash.message || '(no message)'}`,
+      (stash, index) => {
+        const base = `@{${index}} ${stash.message || '(no message)'}`
+        // `@{N}` is the stash ref, not a status icon, so append the
+        // spinner rather than replacing it.
+        return isPendingDeletion(pending, 'stash', stash.ref) ? `${base} ${spin}` : base
+      },
       'tab-stashes', visibleListCount,
     )
   }
@@ -240,7 +263,9 @@ function renderActiveSidebarContent(
   return renderSelectableSidebarRows(
     h, Text, worktrees, state.selectedWorktreeListIndex, focused, width, theme,
     (worktree) => {
-      const marker = worktree.current ? '*' : ' '
+      const marker = isPendingDeletion(pending, 'worktree', worktree.path)
+        ? spin
+        : worktree.current ? '*' : ' '
       const wstate = worktree.dirty ? 'dirty' : 'clean'
       return `${marker} ${worktree.branch || worktree.path} ${wstate}`
     },
@@ -256,7 +281,8 @@ export function renderSidebar(
   contextStatus: LogInkContextStatus,
   width: number,
   bodyRows: number,
-  theme: LogInkTheme
+  theme: LogInkTheme,
+  spinnerFrame: number = 0
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const focused = state.focus === 'sidebar'
@@ -294,7 +320,7 @@ export function renderSidebar(
       inverse: headerSelected,
     }, headerText))
     if (isActive) {
-      blocks.push(...renderActiveSidebarContent(h, Text, tab, state, context, contextStatus, width, bodyRows, theme))
+      blocks.push(...renderActiveSidebarContent(h, Text, tab, state, context, contextStatus, width, bodyRows, theme, spinnerFrame))
     }
     return blocks
   })

--- a/src/workstation/surfaces/branches/index.ts
+++ b/src/workstation/surfaces/branches/index.ts
@@ -18,6 +18,7 @@ import {
     getBranchRowMarkerColor,
 } from '../../chrome/iconography'
 import { formatSortIndicator, sortBranches } from '../../chrome/sorting'
+import { inlineSpinnerGlyph } from '../../chrome/spinner'
 import {
     formatLogInkBranchesEmpty,
     formatLogInkLoading,
@@ -29,8 +30,9 @@ import {
 } from '../../runtime/promotedFilter'
 import type { SurfaceRenderContext } from '../../runtime/types'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
+import { isPendingDeletion } from '../../../commands/log/inkViewModel'
 
-export function renderBranchesSurface(ctx: SurfaceRenderContext): ReactTypes.ReactElement {
+export function renderBranchesSurface(ctx: SurfaceRenderContext, spinnerFrame: number = 0): ReactTypes.ReactElement {
   const { h, components, state, context, contextStatus, bodyRows, width, theme } = ctx
   const { Box, Text } = components
   const focused = state.focus === 'commits'
@@ -71,7 +73,14 @@ export function renderBranchesSurface(ctx: SurfaceRenderContext): ReactTypes.Rea
         const isSelected = index === selected
         const cursor = isSelected ? '>' : ' '
         const marker = branchRowMarker(branch, { ascii: theme.ascii })
-        const markerColor = getBranchRowMarkerColor(marker.kind, theme)
+        // While this branch's delete is in flight, its sync-state marker
+        // is replaced by an inline spinner (accent-coloured) so the row
+        // reads as "deleting" until it vanishes on refresh.
+        const deleting = isPendingDeletion(state.pendingDeletion, 'branch', branch.shortName)
+        const glyph = deleting ? inlineSpinnerGlyph(spinnerFrame, theme.ascii) : marker.glyph
+        const glyphColor = deleting
+          ? (theme.noColor ? undefined : theme.colors.accent)
+          : getBranchRowMarkerColor(marker.kind, theme)
         const divergence = formatBranchDivergence(branch, { ascii: theme.ascii })
         const lastTouched = formatBranchLastTouched(branch.date, getRenderNow())
         // Split the row into spans so the timestamp stays dim even on the
@@ -86,7 +95,7 @@ export function renderBranchesSurface(ctx: SurfaceRenderContext): ReactTypes.Rea
         // Truncate the assembled line to the actual panel width so a
         // narrow inspector / sidebar focus doesn't push branch rows
         // onto a second visual line (#830).
-        const fullText = `${cursorAndPad}${marker.glyph}${trailingName}${timestampPadded}${trailingDivergence}`
+        const fullText = `${cursorAndPad}${glyph}${trailingName}${timestampPadded}${trailingDivergence}`
         const truncated = truncateCells(fullText, Math.max(20, width - 4))
         // If truncation chopped into the timestamp/divergence portion,
         // fall back to a single Text to keep the visible width honest.
@@ -110,8 +119,8 @@ export function renderBranchesSurface(ctx: SurfaceRenderContext): ReactTypes.Rea
         // no-upstream kinds return undefined from
         // `getBranchRowMarkerColor`, so those markers inherit the
         // row's dim and read as quiet chrome.
-        h(Text, { color: markerColor, dimColor: markerColor ? false : undefined },
-          marker.glyph),
+        h(Text, { color: glyphColor, dimColor: glyphColor ? false : undefined },
+          glyph),
         trailingName,
         h(Text, { dimColor: true }, timestampPadded),
         trailingDivergence

--- a/src/workstation/surfaces/stash/index.ts
+++ b/src/workstation/surfaces/stash/index.ts
@@ -11,6 +11,7 @@ import type * as ReactTypes from 'react'
 import { isLogInkContextKeyLoading } from '../../chrome/context'
 import { formatCompactRelativeDate } from '../../chrome/dateFormat'
 import { getRenderNow } from '../../chrome/snapshotMode'
+import { inlineSpinnerGlyph } from '../../chrome/spinner'
 import { formatLogInkLoading, formatLogInkStashEmpty } from '../../chrome/surfaceStates'
 import { truncateCells } from '../../chrome/text'
 import {
@@ -19,8 +20,9 @@ import {
 } from '../../runtime/promotedFilter'
 import type { SurfaceRenderContext } from '../../runtime/types'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
+import { isPendingDeletion } from '../../../commands/log/inkViewModel'
 
-export function renderStashSurface(ctx: SurfaceRenderContext): ReactTypes.ReactElement {
+export function renderStashSurface(ctx: SurfaceRenderContext, spinnerFrame: number = 0): ReactTypes.ReactElement {
   const { h, components, state, context, contextStatus, bodyRows, width, theme } = ctx
   const { Box, Text } = components
   const focused = state.focus === 'commits'
@@ -68,11 +70,19 @@ export function renderStashSurface(ctx: SurfaceRenderContext): ReactTypes.ReactE
         const rowText = meta
           ? `${cursor} ${stash.ref.padEnd(11)} ${meta}  ${stash.message}`
           : `${cursor} ${stash.ref.padEnd(11)} ${stash.message}`
+        // The `stash@{N}` ref is an identifier, not a status icon, so a
+        // delete-in-flight appends an accent spinner at the row's end
+        // (2 cells reserved from the width budget).
+        const deleting = isPendingDeletion(state.pendingDeletion, 'stash', stash.ref)
+        const spinnerSpan = deleting
+          ? h(Text, { color: theme.noColor ? undefined : theme.colors.accent, dimColor: false },
+            ` ${inlineSpinnerGlyph(spinnerFrame, theme.ascii)}`)
+          : null
         return h(Text, {
           key: `stash-${index}`,
           bold: isSelected,
           dimColor: !isSelected,
-        }, truncateCells(rowText, rowWidth))
+        }, truncateCells(rowText, rowWidth - (deleting ? 2 : 0)), spinnerSpan)
       })
 
   const stashHasMoreAbove = startIndex > 0 && stashes.length > 0

--- a/src/workstation/surfaces/tags/index.ts
+++ b/src/workstation/surfaces/tags/index.ts
@@ -12,6 +12,7 @@ import type * as ReactTypes from 'react'
 import { isLogInkContextKeyLoading } from '../../chrome/context'
 import { formatHyperlink } from '../../chrome/hyperlinks'
 import { formatSortIndicator, sortTags } from '../../chrome/sorting'
+import { inlineSpinnerGlyph } from '../../chrome/spinner'
 import {
     formatLogInkLoading,
     formatLogInkTagsEmpty,
@@ -23,8 +24,9 @@ import {
 } from '../../runtime/promotedFilter'
 import type { SurfaceRenderContext } from '../../runtime/types'
 import { buildRefUrl, focusBorderColor, panelTitle } from '../../runtime/utils'
+import { isPendingDeletion } from '../../../commands/log/inkViewModel'
 
-export function renderTagsSurface(ctx: SurfaceRenderContext): ReactTypes.ReactElement {
+export function renderTagsSurface(ctx: SurfaceRenderContext, spinnerFrame: number = 0): ReactTypes.ReactElement {
   const { h, components, state, context, contextStatus, bodyRows, width, theme } = ctx
   const { Box, Text } = components
   const focused = state.focus === 'commits'
@@ -65,16 +67,24 @@ export function renderTagsSurface(ctx: SurfaceRenderContext): ReactTypes.ReactEl
         // intact.
         const url = buildRefUrl(context.provider?.repository, tag.name)
         const namePadded = truncateCells(tag.name, tagNameColWidth).padEnd(tagNameColWidth)
+        // Tags have no leading status icon, so a delete-in-flight appends
+        // an accent spinner at the row's end. Reserve its 2 cells from the
+        // truncation budget so it never pushes the row past the panel.
+        const deleting = isPendingDeletion(state.pendingDeletion, 'tag', tag.name)
+        const spinnerSpan = deleting
+          ? h(Text, { color: theme.noColor ? undefined : theme.colors.accent, dimColor: false },
+            ` ${inlineSpinnerGlyph(spinnerFrame, theme.ascii)}`)
+          : null
         const lineText = truncateCells(
           `${cursor} ${namePadded} ${tag.subject}`,
-          Math.max(20, width - 4)
+          Math.max(20, width - 4 - (deleting ? 2 : 0))
         )
         if (!url || lineText.indexOf(namePadded) < 0) {
           return h(Text, {
             key: `tag-${index}`,
             bold: isSelected,
             dimColor: !isSelected,
-          }, lineText)
+          }, lineText, spinnerSpan)
         }
         const linkStart = lineText.indexOf(namePadded)
         const before = lineText.slice(0, linkStart)
@@ -83,7 +93,7 @@ export function renderTagsSurface(ctx: SurfaceRenderContext): ReactTypes.ReactEl
           key: `tag-${index}`,
           bold: isSelected,
           dimColor: !isSelected,
-        }, before, formatHyperlink(namePadded, url), after)
+        }, before, formatHyperlink(namePadded, url), after, spinnerSpan)
       })
 
   const tagsHasMoreAbove = startIndex > 0 && tags.length > 0

--- a/src/workstation/surfaces/worktrees/index.ts
+++ b/src/workstation/surfaces/worktrees/index.ts
@@ -10,6 +10,7 @@
 
 import type * as ReactTypes from 'react'
 import { isLogInkContextKeyLoading } from '../../chrome/context'
+import { inlineSpinnerGlyph } from '../../chrome/spinner'
 import { formatLogInkLoading } from '../../chrome/surfaceStates'
 import { truncateCells } from '../../chrome/text'
 import {
@@ -18,8 +19,9 @@ import {
 } from '../../runtime/promotedFilter'
 import type { SurfaceRenderContext } from '../../runtime/types'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
+import { isPendingDeletion } from '../../../commands/log/inkViewModel'
 
-export function renderWorktreesSurface(ctx: SurfaceRenderContext): ReactTypes.ReactElement {
+export function renderWorktreesSurface(ctx: SurfaceRenderContext, spinnerFrame: number = 0): ReactTypes.ReactElement {
   const { h, components, state, context, contextStatus, bodyRows, width, theme } = ctx
   const { Box, Text } = components
   const focused = state.focus === 'commits'
@@ -57,7 +59,9 @@ export function renderWorktreesSurface(ctx: SurfaceRenderContext): ReactTypes.Re
         const index = startIndex + offset
         const isSelected = index === selected
         const cursor = isSelected ? '>' : ' '
-        const marker = entry.current ? '*' : ' '
+        const marker = isPendingDeletion(state.pendingDeletion, 'worktree', entry.path)
+          ? inlineSpinnerGlyph(spinnerFrame, theme.ascii)
+          : entry.current ? '*' : ' '
         const branchLabel = entry.branch ? entry.branch : entry.head || '<detached>'
         const stateLabel = entry.dirty ? 'dirty' : 'clean'
         const branchPadded = truncateCells(branchLabel, branchColWidth).padEnd(branchColWidth)


### PR DESCRIPTION
Confirming a delete in `coco ui` (`y` after `D`/`T`/`X`/`W`) used to leave the targeted row looking idle through the git call + refresh. Now that row shows an **inline pending spinner** until it either vanishes (success) or restores its icon with an error (failure). Generalized across every deletable list, in both the sidebar and the promoted view.

## Behavior
- **Branches** and **worktrees** have a leading status marker (`*`/`↑`/`↓`) → it's swapped for the spinner while deleting.
- **Tags** and **stashes** have no leading icon → the spinner is appended at the row's end.
- Exactly the "in place of an icon if it exists, else at the end of the row" rule.

## How it works
- New `pendingDeletion` state (`{ kind, id }`) marks the single in-flight target. The workflow runner resolves the cursored row the **same way each delete handler does** (same sort + promoted-filter + selection index), sets it before `await handler()`, and clears it in `finally`. So a successful delete hands straight off to the row vanishing on refresh, and a failed one (e.g. an unmerged branch) restores the normal icon alongside the error status.
- The shared spinner `setInterval` already ticks while any loading flag is set; `pendingDeletion` joins that `anyLoading` set so the inline glyph animates.
- `inlineSpinnerGlyph` falls back to the ASCII `|/-\` cycle under `ascii` / `NO_COLOR` themes.

The mechanism is deliberately generic (kind + stable id) so future async list-item mutations can reuse it.

## Files
State + helper (`inkViewModel.ts`), spinner helper (`chrome/spinner.ts`), runner hook + target resolver + `anyLoading` (`runtime/app.ts`), `spinnerFrame` threading (`mainPanel.ts`, `sidebar.ts`), and the four surfaces.

## Tests
`runtime/pendingDeletion.test.ts` — the `isPendingDeletion` helper, the `setPendingDeletion` reducer, and per-surface + sidebar render assertions (spinner present on the targeted row, absent otherwise). Full suite green locally (only the env-only tree-sitter WASM suite fails for lack of the WASM artifact; green in CI); `tsc` + `eslint` clean.

Part 1 of 2 from the delete-UX work; the follow-up adds an in-TUI force-delete path for unmerged branches (the raw "not fully merged" error in the screenshot).