### PR TITLE
feat(workstation): offer force-delete when a branch isn't fully merged

### DIFF
--- a/src/commands/log/inkWorkflows.test.ts
+++ b/src/commands/log/inkWorkflows.test.ts
@@ -73,6 +73,18 @@ describe('log Ink workflows', () => {
     expect(getLogInkWorkflowActionById('checkout-file-from-commit')?.key).toBe('')
   })
 
+  it('registers force-delete-branch as a keyless, confirmation-gated escalation', () => {
+    // Raised by the runtime as a second confirm when `git branch -d`
+    // rejects an unmerged branch; keyless so no keystroke fires it.
+    const force = getLogInkWorkflowActionById('force-delete-branch')
+    expect(force).toMatchObject({
+      key: '',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    })
+    expect(getLogInkWorkflowActionByKey('')).toBeUndefined()
+  })
+
   // Issue #777 — revert / reset / interactive-rebase wired through the
   // workflow registry as palette-only entries (key: ''). Real keystroke
   // dispatch is per-view scoped in inkInput.ts so they only fire on

--- a/src/commands/log/inkWorkflows.ts
+++ b/src/commands/log/inkWorkflows.ts
@@ -321,6 +321,18 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: true,
     },
     {
+      // No key binding — this is raised by the runtime as a second
+      // confirmation when a safe `delete-branch` (`git branch -d`) is
+      // rejected for an unmerged branch. Reachable from the `:` palette
+      // too, as an explicit force-delete that still gates on y-confirm.
+      id: 'force-delete-branch',
+      key: '',
+      label: 'Force-delete branch',
+      description: 'Force-delete the selected branch even if it is not fully merged (git branch -D).',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
       id: 'delete-tag',
       key: 'T',
       label: 'Delete tag',

--- a/src/git/branchActions.test.ts
+++ b/src/git/branchActions.test.ts
@@ -2,6 +2,7 @@ import {
   checkoutBranch,
   createBranch,
   deleteBranch,
+  isBranchNotFullyMergedError,
   fetchBranch,
   fetchRemotes,
   getBranchActionRefs,
@@ -113,6 +114,44 @@ describe('log branch actions', () => {
     expect(git.raw).toHaveBeenNthCalledWith(3, ['branch', '-d', 'feature/test'])
     expect(git.raw).toHaveBeenNthCalledWith(4, ['fetch', '--all', '--prune'])
     expect(git.raw).toHaveBeenNthCalledWith(5, ['pull', '--ff-only'])
+  })
+
+  describe('deleteBranch force', () => {
+    it('uses -d (safe) by default and -D when forced', async () => {
+      const git = { raw: jest.fn().mockResolvedValue('') }
+
+      await expect(deleteBranch(git as never, localBranch())).resolves.toEqual({
+        ok: true,
+        message: 'Deleted branch feature/test',
+      })
+      expect(git.raw).toHaveBeenLastCalledWith(['branch', '-d', 'feature/test'])
+
+      await expect(deleteBranch(git as never, localBranch(), true)).resolves.toEqual({
+        ok: true,
+        message: 'Force-deleted branch feature/test',
+      })
+      expect(git.raw).toHaveBeenLastCalledWith(['branch', '-D', 'feature/test'])
+    })
+
+    it('surfaces the not-fully-merged failure as a recoverable result', async () => {
+      const git = {
+        raw: jest.fn().mockRejectedValue(
+          new Error("error: the branch 'feature/test' is not fully merged.")
+        ),
+      }
+      const result = await deleteBranch(git as never, localBranch())
+      expect(result.ok).toBe(false)
+      expect(isBranchNotFullyMergedError(result.message)).toBe(true)
+    })
+  })
+
+  describe('isBranchNotFullyMergedError', () => {
+    it('matches git\'s unmerged wording and nothing unrelated', () => {
+      expect(isBranchNotFullyMergedError("error: the branch 'x' is not fully merged.")).toBe(true)
+      expect(isBranchNotFullyMergedError('Not Fully Merged')).toBe(true)
+      expect(isBranchNotFullyMergedError('Cannot delete the current branch.')).toBe(false)
+      expect(isBranchNotFullyMergedError(undefined)).toBe(false)
+    })
   })
 
   describe('pushBranch', () => {

--- a/src/git/branchActions.ts
+++ b/src/git/branchActions.ts
@@ -112,7 +112,11 @@ export function renameBranch(
   )
 }
 
-export function deleteBranch(git: SimpleGit, branch: BranchRef): Promise<BranchActionResult> {
+export function deleteBranch(
+  git: SimpleGit,
+  branch: BranchRef,
+  force = false
+): Promise<BranchActionResult> {
   if (branch.type !== 'local') {
     return Promise.resolve({
       ok: false,
@@ -127,10 +131,22 @@ export function deleteBranch(git: SimpleGit, branch: BranchRef): Promise<BranchA
     })
   }
 
+  // `-d` is the safe delete (refuses unmerged branches); `-D` forces it.
+  // The TUI starts with `-d` and only escalates to `-D` after the user
+  // confirms a second time on the "not fully merged" error.
   return runAction(
-    () => git.raw(['branch', '-d', branch.shortName]),
-    `Deleted branch ${branch.shortName}`
+    () => git.raw(['branch', force ? '-D' : '-d', branch.shortName]),
+    force ? `Force-deleted branch ${branch.shortName}` : `Deleted branch ${branch.shortName}`
   )
+}
+
+/**
+ * True when a failed `git branch -d` was rejected specifically because the
+ * branch isn't fully merged (the one case worth offering a force-delete
+ * for). Matches git's wording across versions ("not fully merged").
+ */
+export function isBranchNotFullyMergedError(message: string | undefined): boolean {
+  return /not fully merged/i.test(message || '')
 }
 
 export function fetchRemotes(git: SimpleGit): Promise<BranchActionResult> {

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -144,6 +144,7 @@ import {
     checkoutBranch,
     createBranch,
     deleteBranch,
+    isBranchNotFullyMergedError,
     fetchBranch,
     fetchRemotes,
     pullBranch,
@@ -406,7 +407,7 @@ function resolvePendingDeletion(
   context: LogInkContext
 ): { kind: LogInkDeletableKind; id: string } | undefined {
   const { filter } = state
-  if (id === 'delete-branch') {
+  if (id === 'delete-branch' || id === 'force-delete-branch') {
     const all = sortBranches(context.branches?.localBranches || [], state.branchSort)
     const visible = filter
       ? all.filter((b) => matchesPromotedFilter([b.shortName, b.upstream || ''], filter))
@@ -3148,6 +3149,15 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         if (!branch) return { ok: false, message: 'No branch selected' }
         return deleteBranch(git, branch)
       },
+      'force-delete-branch': async () => {
+        const all = sortBranches(context.branches?.localBranches || [], state.branchSort)
+        const visible = state.filter
+          ? all.filter((b) => matchesPromotedFilter([b.shortName, b.upstream || ''], state.filter))
+          : all
+        const branch = visible[Math.min(state.selectedBranchIndex, visible.length - 1)]
+        if (!branch) return { ok: false, message: 'No branch selected' }
+        return deleteBranch(git, branch, true)
+      },
       'delete-tag': async () => {
         const all = sortTags(context.tags?.tags || [], state.tagSort)
         const visible = state.filter
@@ -3887,6 +3897,14 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     try {
     const result = await handler()
     dispatch({ type: 'setStatus', value: result?.message || 'Workflow action complete' })
+    // A safe `delete-branch` (`git branch -d`) refuses branches that
+    // aren't fully merged. Rather than dead-end on git's raw error, raise
+    // a second y-confirm offering the force-delete (`git branch -D`). The
+    // cursor hasn't moved (the delete failed), so the force handler
+    // re-resolves the same branch.
+    if (id === 'delete-branch' && !result?.ok && isBranchNotFullyMergedError(result?.message)) {
+      dispatch({ type: 'setPendingConfirmation', value: 'force-delete-branch' })
+    }
     // Refresh history rows AS WELL when the workflow could have
     // changed the commits the user sees (#945 follow-up). The
     // workflow IDs below all either create/rewrite local commits or

--- a/src/workstation/runtime/overlays.test.ts
+++ b/src/workstation/runtime/overlays.test.ts
@@ -10,7 +10,8 @@ import { createLogInkContextStatus } from '../chrome/context'
 import { createLogInkTheme } from '../chrome/theme'
 import { createLogInkState } from '../../commands/log/inkViewModel'
 import { renderDetailPanel } from './detailPanel'
-import type { LogInkContext } from './types'
+import { renderConfirmationPanel } from './overlays'
+import type { LogInkComponents, LogInkContext } from './types'
 
 type StubProps = Record<string, unknown>
 const Text = ((props: StubProps) =>
@@ -76,5 +77,24 @@ describe('view-keys overlay (#1137)', () => {
     const text = flattenText(renderViewKeys('branches'))
     // mark-compare (m) is available wherever commits/branches focus applies.
     expect(text).toContain('mark compare')
+  })
+})
+
+describe('force-delete-branch confirmation panel', () => {
+  const components: LogInkComponents = { Box, Text }
+
+  it('explains the unmerged reason instead of the generic destructive warning', () => {
+    const state = { ...createLogInkState([]), pendingConfirmationId: 'force-delete-branch' }
+    const text = flattenText(renderConfirmationPanel(createElement, components, state, 80, theme, false))
+    expect(text).toContain('Force-delete branch')
+    expect(text).toContain('fully merged')
+    expect(text).toContain('git branch -D')
+    expect(text).not.toContain('Destructive Git action requires confirmation')
+  })
+
+  it('keeps the generic warning for an ordinary destructive confirm', () => {
+    const state = { ...createLogInkState([]), pendingConfirmationId: 'delete-branch' }
+    const text = flattenText(renderConfirmationPanel(createElement, components, state, 60, theme, false))
+    expect(text).toContain('Destructive Git action requires confirmation')
   })
 })

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -110,6 +110,10 @@ export function renderConfirmationPanel(
     ? 'You have an unsaved commit draft. Press y to discard it and quit.'
     : state.pendingMutationConfirmation
     ? 'This discards local changes and cannot be undone by Coco.'
+    // Second-stage confirm raised when a safe delete hit an unmerged
+    // branch — name the reason so the force isn't a blind "y again".
+    : state.pendingConfirmationId === 'force-delete-branch'
+    ? 'Not fully merged. Force-delete (git branch -D) is irreversible.'
     : action?.kind === 'ai'
     ? `AI action requires confirmation. Estimated ${action.estimatedTokens || '<unknown>'} tokens.`
     : 'Destructive Git action requires confirmation.'


### PR DESCRIPTION
The bug from the screenshot: deleting an unmerged branch in `coco ui` ran `git branch -d`, hit git's `the branch 'X' is not fully merged` error, and dead-ended — the raw stderr on the status line, no in-TUI way to actually delete it (you had to drop to a shell for `git branch -D`).

Now that failure **escalates to a second confirmation** offering the force-delete in place.

## Flow
1. `D` (or `:` → Delete branch) → confirm → `git branch -d`.
2. If git rejects it as not-fully-merged, a second confirm appears: **"Force-delete branch — Not fully merged. Force-delete (git branch -D) is irreversible."**
3. `y` runs `git branch -D`; `n`/`Esc` backs out. The cursor hasn't moved (the delete failed), so the force handler re-resolves the same branch.

## How it works
- `deleteBranch(git, branch, force?)` switches `-d` ↔ `-D`; `isBranchNotFullyMergedError(message)` classifies the recoverable failure (vs. e.g. "cannot delete current branch").
- `force-delete-branch` is a **keyless, confirmation-gated** workflow action (the established pattern for palette-/runtime-only entries like `cherry-pick-commit`). It reuses the existing `y → runWorkflowAction(pendingConfirmationId)` path, and the resolver from #1167, so the **pending-deletion spinner shows during the force too**.
- It's also reachable from the `:` palette as an explicit, confirmation-gated force-delete.

## Tests
`branchActions.test.ts` (force uses `-D`, not-merged classification), `inkWorkflows.test.ts` (keyless confirmation-gated registration), `overlays.test.ts` (the specific unmerged warning vs the generic one). `tsc` + `eslint` clean; full suite green (only the env-only tree-sitter WASM suite fails locally for lack of the artifact).

Part 2 of 2 of the delete-UX work (builds on the pending-deletion loader, #1167).