### PR TITLE
fix(workstation): default history to --all on the bare `coco` route (#1169)

### DIFF
--- a/src/commands/defaultRouter.test.ts
+++ b/src/commands/defaultRouter.test.ts
@@ -1,4 +1,15 @@
-import { decideDefaultRoute } from './defaultRouter'
+import { buildSyntheticArgv, decideDefaultRoute, type DefaultRouteArgv } from './defaultRouter'
+import { createLogArgvFromUiArgv } from './ui/handler'
+import { UiArgv } from './ui/config'
+import { buildLogArgs, getLogView } from './log/data'
+
+function routeArgv(overrides: Partial<DefaultRouteArgv> = {}): DefaultRouteArgv {
+  return {
+    _: ['$0'],
+    $0: 'coco',
+    ...overrides,
+  } as DefaultRouteArgv
+}
 
 describe('decideDefaultRoute', () => {
   it('routes fresh installs (no config sources) to init', () => {
@@ -77,5 +88,47 @@ describe('decideDefaultRoute', () => {
         envOverride: 'something-else',
       })
     ).toEqual({ kind: 'workspace', reason: 'config-no-repo' })
+  })
+})
+
+describe('bare `coco` → workstation history view (#1169 regression)', () => {
+  // The bug: bare `coco` routes through buildSyntheticArgv, which
+  // bypasses yargs, so the `all: true` default from ui/config.ts never
+  // applied. The workstation booted in compact (`--first-parent
+  // --no-merges`) mode — fewer commits, branches ahead of HEAD hidden,
+  // and a graph that looped back to the initial commit when cursoring a
+  // branch whose tip wasn't in the compact window. These tests lock the
+  // full composed path: route argv → synthetic ui argv → log argv →
+  // git log args.
+
+  it('the synthetic ui argv leaves `all` unset (the gap being compensated for)', () => {
+    // Documents the root cause: this projection does NOT carry the
+    // ui command's yargs default. If a future refactor sets `all` here
+    // directly, the `?? true` fallback downstream becomes belt-and-
+    // suspenders rather than the sole guard — worth knowing.
+    const synthetic = buildSyntheticArgv<UiArgv>(routeArgv())
+    expect(synthetic.all).toBeUndefined()
+  })
+
+  it('resolves to the all-refs view end to end', () => {
+    const synthetic = buildSyntheticArgv<UiArgv>(routeArgv())
+    const logArgv = createLogArgvFromUiArgv(synthetic)
+
+    expect(logArgv.all).toBe(true)
+    // `getLogView` is what picks compact vs full; `all` must win so the
+    // workstation walks every ref, not just HEAD's first-parent line.
+    expect(getLogView(logArgv)).toBe('full')
+  })
+
+  it('emits `--all` and not the compact-mode flags', () => {
+    const synthetic = buildSyntheticArgv<UiArgv>(routeArgv())
+    const logArgv = createLogArgvFromUiArgv(synthetic)
+    const args = buildLogArgs(logArgv)
+
+    expect(args).toContain('--all')
+    // Compact mode is exactly what produced the dropped count + looping
+    // graph in #1169 — these must be absent on the bare-`coco` path.
+    expect(args).not.toContain('--first-parent')
+    expect(args).not.toContain('--no-merges')
   })
 })

--- a/src/commands/defaultRouter.ts
+++ b/src/commands/defaultRouter.ts
@@ -141,8 +141,13 @@ async function probeIsGitRepo(): Promise<boolean> {
  * `InitArgv`, `UiArgv`, `WorkspaceArgv`) so we can't just spread the
  * raw default argv — we have to project the shared fields and let
  * the handler fill in command-specific defaults.
+ *
+ * Exported for testing: this is the path bare `coco` takes to the
+ * workstation, and it intentionally does NOT set `all` — yargs's
+ * `default: true` for `coco ui` never runs here, so the ui→log argv
+ * mapping has to re-assert that default (#1169).
  */
-function buildSyntheticArgv<T>(argv: DefaultRouteArgv): T {
+export function buildSyntheticArgv<T>(argv: DefaultRouteArgv): T {
   return ({
     _: ['$0'],
     $0: argv.$0,

--- a/src/commands/ui/handler.test.ts
+++ b/src/commands/ui/handler.test.ts
@@ -53,6 +53,18 @@ describe('ui command handler utilities', () => {
     expect(logArgv.all).toBe(false)
   })
 
+  it('defaults `all: true` when undefined — the synthetic-argv path (#1169)', () => {
+    // Bare `coco` routes through defaultRouteHandler → buildSyntheticArgv,
+    // which bypasses yargs and so never applies the `default: true` from
+    // ui/config.ts. That left `argv.all` undefined and booted the
+    // workstation in compact (`--first-parent --no-merges`) mode: fewer
+    // commits, branches ahead of HEAD hidden, and a looping graph when
+    // cursoring/checking-out a branch not in the compact window. The
+    // handler must re-assert the all-refs default for that path.
+    const logArgv = createLogArgvFromUiArgv(argv({ all: undefined }))
+    expect(logArgv.all).toBe(true)
+  })
+
   it('keeps --all true when --branch is passed alongside (highlight, not scope)', () => {
     // Deliberate UX call: `coco ui --branch feature/x` does NOT
     // narrow to that branch automatically. The all-refs default

--- a/src/commands/ui/handler.ts
+++ b/src/commands/ui/handler.ts
@@ -23,12 +23,23 @@ export function createLogArgvFromUiArgv(argv: UiArgv): LogArgv {
     // starting state. `coco ui --no-all` opts back to
     // current-branch-only.
     //
+    // `?? true` re-asserts that default for the synthetic-argv path:
+    // bare `coco` routes through defaultRouteHandler → buildSyntheticArgv,
+    // which bypasses yargs and so never applies the `default: true` from
+    // ui/config.ts — leaving `argv.all` undefined (#1169). Without the
+    // fallback the workstation booted in compact (`--first-parent
+    // --no-merges`) mode: fewer commits, branches "ahead" of HEAD hidden,
+    // and cursoring/checking-out a branch whose tip wasn't in the compact
+    // window triggered an anchored-context append that looped the graph
+    // back to the initial commit. Explicit `--no-all` (argv.all === false)
+    // is preserved because `false ?? true === false`.
+    //
     // Note: passing `--branch foo` does NOT automatically scope away
     // from --all. If the user wants strictly that branch, they pass
     // `coco ui --branch foo --no-all`. We considered the implicit
     // scope-narrowing but it surprises users who pass `--branch` as
     // a "highlight this branch in the all-refs view" hint.
-    all: argv.all,
+    all: argv.all ?? true,
     branch: argv.branch,
     format: 'table',
     interactive: true,


### PR DESCRIPTION
Fixes #1169.

## Root cause

Bare `coco` routes to the workstation through `defaultRouteHandler` → `buildSyntheticArgv<UiArgv>` (`src/commands/defaultRouter.ts`), which builds the argv **by hand and bypasses yargs**. The `all: true` default declared in `src/commands/ui/config.ts` only applies when yargs parses the `ui` command directly (`coco ui`), so on the bare-`coco` path `argv.all` is `undefined`. `getLogView` then falls back to `'compact'` (`--first-parent --no-merges`), and the workstation boots in compact mode instead of the intended GitKraken-style all-refs view.

This single dropped default explains every symptom in #1169:

- **434 commits / branches-ahead hidden** — the walk is first-parent-only and not `--all`, so it's a much smaller, single-line slice that omits other branches.
- **Graph loops back to the initial commit** — when you cursor or check out a branch whose tip isn't in the compact window, the cursor-sync `load-context` fetch (`getLogRowsAnchoredOn`) appends a *full-topology* anchored page **after** the already-loaded initial commit. I reproduced this directly: the initial commit ended up at index 513 with 1208 commits appended after it.
- **Stale cursor / count sticks after checkout** — `refreshHistoryRows` re-fetches in the same compact mode.

In `all: true` mode (what `coco ui` actually does) none of these reproduce — branch tips are always already in the window, so the out-of-order anchored append never happens.

## Fix

Re-assert the documented default at the ui→log argv chokepoint:

```ts
all: argv.all ?? true,
```

Both `coco ui` and the synthetic-argv path now agree. Explicit `--no-all` is preserved (`false ?? true === false`). A regression test covers the `undefined` (synthetic-argv) case that the existing test helper masked by hardcoding `all: true`.

## Follow-up (out of scope here)

There's a deeper latent bug: a user who *deliberately* runs `coco --no-all` can still hit the looping graph, because the cursor-sync `load-context` path appends an out-of-order anchored page into the windowed `git --graph` output. Hardening that means reworking the graph-merge ordering and is intentionally left for a separate change.

## Validation

- `npx tsc --noEmit` — clean
- `eslint src` — clean (exit 0)
- Full unit suite — 209 suites, 2635 passed / 7 skipped
