### PR TITLE
feat(workstation): inline spinner on checkout + clear worktree-delete message

### DIFF
--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -31,21 +31,42 @@ export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' 
 export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk' | 'discard-draft'
 
 /**
- * Kinds of list item that support deletion (and therefore an inline
- * pending-spinner while the delete runs). Each maps to a surface + a
- * stable per-row id used by `pendingDeletion`.
+ * Kinds of list item that can carry an inline pending-spinner while an
+ * async action runs against them. Each maps to a surface + a stable
+ * per-row id used by `pendingItemAction`.
  */
-export type LogInkDeletableKind = 'branch' | 'tag' | 'stash' | 'worktree'
+export type LogInkListItemKind = 'branch' | 'tag' | 'stash' | 'worktree'
 
 /**
- * True when `pending` (a `state.pendingDeletion`) targets this exact row.
- * Shared by every deletable surface + the sidebar so the spinner-swap
- * test is identical everywhere. Takes the field value (not the whole
- * state) so it can live next to the type without a forward reference.
+ * Which async action is in flight on the pending row. The inline
+ * spinner is identical across actions; the tag is carried so future
+ * code (and tests) can distinguish a delete-in-flight from a
+ * checkout-in-flight without a second piece of state.
  */
-export function isPendingDeletion(
-  pending: { kind: LogInkDeletableKind; id: string } | undefined,
-  kind: LogInkDeletableKind,
+export type LogInkPendingActionKind = 'delete' | 'checkout'
+
+/**
+ * One in-flight action against a specific list-item row. Keyed by
+ * `kind` + a stable id so it can't accidentally match a same-named row
+ * in a different list rendering at the same time.
+ */
+export type LogInkPendingItemAction = {
+  kind: LogInkListItemKind
+  id: string
+  action: LogInkPendingActionKind
+}
+
+/**
+ * True when `pending` (a `state.pendingItemAction`) targets this exact
+ * row. Action-agnostic on purpose — every surface + the sidebar render
+ * the same spinner whether the row is being deleted or checked out, so
+ * the spinner-swap test stays identical everywhere. Takes the field
+ * value (not the whole state) so it can live next to the type without a
+ * forward reference.
+ */
+export function isPendingItemAction(
+  pending: LogInkPendingItemAction | undefined,
+  kind: LogInkListItemKind,
   id: string
 ): boolean {
   return pending?.kind === kind && pending.id === id
@@ -369,7 +390,7 @@ export type LogInkState = {
    * `worktree.path`) so it can't accidentally match a same-named row in
    * a different list rendering at the same time.
    */
-  pendingDeletion?: { kind: LogInkDeletableKind; id: string }
+  pendingItemAction?: LogInkPendingItemAction
   focus: LogInkFocus
   /**
    * Set while the user is "peeking" the sidebar (#1135 v2) — a momentary
@@ -848,7 +869,7 @@ export type LogInkAction =
   | { type: 'setWorkflowAction'; value?: string }
   | { type: 'setPendingConfirmation'; value?: string; payload?: string }
   | { type: 'setPendingMutationConfirmation'; value?: LogInkMutationConfirmation }
-  | { type: 'setPendingDeletion'; value?: { kind: LogInkDeletableKind; id: string } }
+  | { type: 'setPendingItemAction'; value?: LogInkPendingItemAction }
   | { type: 'appendPaletteFilter'; value: string }
   | { type: 'backspacePaletteFilter' }
   | { type: 'clearPaletteFilter' }
@@ -2191,10 +2212,11 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         workflowActionId: action.value ? undefined : state.workflowActionId,
         pendingKey: undefined,
       }
-    case 'setPendingDeletion':
-      // Pure marker for the in-flight delete; touches nothing else so the
-      // list keeps rendering normally underneath the one spinner'd row.
-      return { ...state, pendingDeletion: action.value }
+    case 'setPendingItemAction':
+      // Pure marker for the in-flight row action (delete / checkout);
+      // touches nothing else so the list keeps rendering normally
+      // underneath the one spinner'd row.
+      return { ...state, pendingItemAction: action.value }
     case 'toggleFilterMode':
       return {
         ...state,

--- a/src/git/branchActions.test.ts
+++ b/src/git/branchActions.test.ts
@@ -2,7 +2,9 @@ import {
   checkoutBranch,
   createBranch,
   deleteBranch,
+  isBranchCheckedOutElsewhereError,
   isBranchNotFullyMergedError,
+  parseCheckedOutWorktreePath,
   fetchBranch,
   fetchRemotes,
   getBranchActionRefs,
@@ -151,6 +153,36 @@ describe('log branch actions', () => {
       expect(isBranchNotFullyMergedError('Not Fully Merged')).toBe(true)
       expect(isBranchNotFullyMergedError('Cannot delete the current branch.')).toBe(false)
       expect(isBranchNotFullyMergedError(undefined)).toBe(false)
+    })
+  })
+
+  describe('isBranchCheckedOutElsewhereError', () => {
+    it('matches git\'s worktree-checkout rejection wording', () => {
+      expect(
+        isBranchCheckedOutElsewhereError("error: Cannot delete branch 'feat/x' checked out at '/repo/.wt/foo'")
+      ).toBe(true)
+      expect(
+        isBranchCheckedOutElsewhereError("fatal: 'feat/x' is already used by worktree at '/repo/wt'")
+      ).toBe(true)
+      // Distinct from the unmerged case, which has its own force-delete path.
+      expect(isBranchCheckedOutElsewhereError("the branch 'x' is not fully merged.")).toBe(false)
+      expect(isBranchCheckedOutElsewhereError(undefined)).toBe(false)
+    })
+  })
+
+  describe('parseCheckedOutWorktreePath', () => {
+    it('extracts the worktree path from either git phrasing', () => {
+      expect(
+        parseCheckedOutWorktreePath("Cannot delete branch 'feat/x' checked out at '/repo/.wt/foo'")
+      ).toBe('/repo/.wt/foo')
+      expect(
+        parseCheckedOutWorktreePath("'feat/x' is already used by worktree at '/repo/wt'")
+      ).toBe('/repo/wt')
+    })
+
+    it('returns undefined when the message carries no path', () => {
+      expect(parseCheckedOutWorktreePath('checked out somewhere')).toBeUndefined()
+      expect(parseCheckedOutWorktreePath(undefined)).toBeUndefined()
     })
   })
 

--- a/src/git/branchActions.ts
+++ b/src/git/branchActions.ts
@@ -149,6 +149,31 @@ export function isBranchNotFullyMergedError(message: string | undefined): boolea
   return /not fully merged/i.test(message || '')
 }
 
+/**
+ * True when a branch delete was rejected because the branch is checked
+ * out in a worktree. Unlike "not fully merged" there's no force escape
+ * hatch — git refuses `git branch -D` on a worktree-checked-out branch
+ * too — so the UI should surface a clear "free up the worktree first"
+ * message rather than offering a force-delete that would fail the same
+ * way. Matches git's wording: `Cannot delete branch 'x' checked out at
+ * '<path>'` / `used by worktree at '<path>'`.
+ */
+export function isBranchCheckedOutElsewhereError(message: string | undefined): boolean {
+  return /checked out at|used by worktree/i.test(message || '')
+}
+
+/**
+ * Pull the worktree path out of git's "checked out at '<path>'" /
+ * "used by worktree at '<path>'" rejection so the UI can name where the
+ * branch is still in use. Returns undefined when the message doesn't
+ * carry a path (older git phrasings) so callers can fall back to a
+ * generic message.
+ */
+export function parseCheckedOutWorktreePath(message: string | undefined): string | undefined {
+  const match = /(?:checked out at|used by worktree at) '([^']+)'/i.exec(message || '')
+  return match?.[1]
+}
+
 export function fetchRemotes(git: SimpleGit): Promise<BranchActionResult> {
   return runAction(
     () => git.raw(['fetch', '--all', '--prune']),

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -129,7 +129,7 @@ import type { LogInkVisiblePane } from '../chrome/layout'
 import { sortBranches, sortTags } from '../chrome/sorting'
 import { IDLE_TIPS_GRACE_MS, IDLE_TIPS_INTERVAL_MS, pickIdleTip } from '../chrome/idleTips'
 import {
-    LogInkDeletableKind,
+    LogInkPendingItemAction,
     LogInkState,
     RemoteOpState,
     applyLogInkAction,
@@ -144,7 +144,9 @@ import {
     checkoutBranch,
     createBranch,
     deleteBranch,
+    isBranchCheckedOutElsewhereError,
     isBranchNotFullyMergedError,
+    parseCheckedOutWorktreePath,
     fetchBranch,
     fetchRemotes,
     pullBranch,
@@ -401,19 +403,32 @@ const REMOTE_OP_LOADERS: Record<string, RemoteOpState> = {
  * Returns `undefined` for non-delete workflows (and when nothing is
  * selected), which the runner treats as "no pending marker".
  */
-function resolvePendingDeletion(
+function resolvePendingItemAction(
   id: string,
   state: LogInkState,
   context: LogInkContext
-): { kind: LogInkDeletableKind; id: string } | undefined {
+): LogInkPendingItemAction | undefined {
   const { filter } = state
+  // Checking out a branch gets the same inline spinner on its row as a
+  // delete does — the action just runs `git checkout` instead of
+  // `git branch -d`. Resolved the same way as the delete branch case
+  // (and identically to the checkout-branch handler) so the spinner
+  // lands on exactly the row the user pressed enter on.
+  if (id === 'checkout-branch') {
+    const all = sortBranches(context.branches?.localBranches || [], state.branchSort)
+    const visible = filter
+      ? all.filter((b) => matchesPromotedFilter([b.shortName, b.upstream || ''], filter))
+      : all
+    const branch = visible[Math.min(state.selectedBranchIndex, visible.length - 1)]
+    return branch ? { kind: 'branch', id: branch.shortName, action: 'checkout' } : undefined
+  }
   if (id === 'delete-branch' || id === 'force-delete-branch') {
     const all = sortBranches(context.branches?.localBranches || [], state.branchSort)
     const visible = filter
       ? all.filter((b) => matchesPromotedFilter([b.shortName, b.upstream || ''], filter))
       : all
     const branch = visible[Math.min(state.selectedBranchIndex, visible.length - 1)]
-    return branch ? { kind: 'branch', id: branch.shortName } : undefined
+    return branch ? { kind: 'branch', id: branch.shortName, action: 'delete' } : undefined
   }
   if (id === 'delete-tag') {
     const all = sortTags(context.tags?.tags || [], state.tagSort)
@@ -421,7 +436,7 @@ function resolvePendingDeletion(
       ? all.filter((t) => matchesPromotedFilter([t.name, t.subject], filter))
       : all
     const tag = visible[Math.min(state.selectedTagIndex, visible.length - 1)]
-    return tag ? { kind: 'tag', id: tag.name } : undefined
+    return tag ? { kind: 'tag', id: tag.name, action: 'delete' } : undefined
   }
   if (id === 'drop-stash') {
     const all = context.stashes?.stashes || []
@@ -429,7 +444,7 @@ function resolvePendingDeletion(
       ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], filter))
       : all
     const stash = visible[Math.min(state.selectedStashIndex, visible.length - 1)]
-    return stash ? { kind: 'stash', id: stash.ref } : undefined
+    return stash ? { kind: 'stash', id: stash.ref, action: 'delete' } : undefined
   }
   if (id === 'remove-worktree') {
     const all = context.worktreeList?.worktrees || []
@@ -439,7 +454,7 @@ function resolvePendingDeletion(
     const wt = visible.length
       ? visible[Math.min(state.selectedWorktreeListIndex, visible.length - 1)]
       : all[Math.min(state.selectedWorktreeListIndex, Math.max(0, all.length - 1))]
-    return wt ? { kind: 'worktree', id: wt.path } : undefined
+    return wt ? { kind: 'worktree', id: wt.path, action: 'delete' } : undefined
   }
   return undefined
 }
@@ -818,9 +833,10 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     state.commitCompose.loading ||
     Boolean(state.remoteOp) ||
     Boolean(state.statusLoading) ||
-    // Keep the shared spinner ticking while a list-item delete is in
-    // flight so its inline pending glyph animates instead of freezing.
-    Boolean(state.pendingDeletion)
+    // Keep the shared spinner ticking while a list-item action (delete
+    // or checkout) is in flight so its inline pending glyph animates
+    // instead of freezing.
+    Boolean(state.pendingItemAction)
   React.useEffect(() => {
     if (!anyLoading) {
       // Reset to 0 so the next loading state starts from a known
@@ -3885,14 +3901,15 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     if (remoteOp) {
       dispatch({ type: 'setRemoteOp', value: remoteOp })
     }
-    // Mark the cursored row as deleting so it shows an inline pending
-    // spinner while the git call runs. Cleared in `finally` after the
-    // refresh, so a successful delete hands straight off to the row
-    // vanishing, and a failed one (e.g. an unmerged branch) restores
-    // the row's normal icon alongside the error status.
-    const pendingDeletion = resolvePendingDeletion(id, state, context)
-    if (pendingDeletion) {
-      dispatch({ type: 'setPendingDeletion', value: pendingDeletion })
+    // Mark the cursored row as busy so it shows an inline pending
+    // spinner while the git call runs (delete or checkout). Cleared in
+    // `finally` after the refresh, so a successful delete hands straight
+    // off to the row vanishing, a checkout to the sidebar repainting
+    // with the new current branch, and a failure (e.g. an unmerged
+    // branch) restores the row's normal icon alongside the error status.
+    const pendingItemAction = resolvePendingItemAction(id, state, context)
+    if (pendingItemAction) {
+      dispatch({ type: 'setPendingItemAction', value: pendingItemAction })
     }
     try {
     const result = await handler()
@@ -3904,6 +3921,26 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     // re-resolves the same branch.
     if (id === 'delete-branch' && !result?.ok && isBranchNotFullyMergedError(result?.message)) {
       dispatch({ type: 'setPendingConfirmation', value: 'force-delete-branch' })
+    }
+    // A branch checked out in a worktree can't be deleted — and unlike
+    // the unmerged case, `git branch -D` won't force it either, so we
+    // don't offer a confirmation. Replace git's raw rejection with a
+    // clear "free up the worktree first" message that names where the
+    // branch is still in use.
+    if (
+      (id === 'delete-branch' || id === 'force-delete-branch') &&
+      !result?.ok &&
+      isBranchCheckedOutElsewhereError(result?.message)
+    ) {
+      const worktreePath = parseCheckedOutWorktreePath(result?.message)
+      const branchName = pendingItemAction?.id
+      dispatch({
+        type: 'setStatus',
+        value: worktreePath
+          ? `Can't delete ${branchName ? `'${branchName}'` : 'branch'} — checked out in worktree ${worktreePath}. Switch that worktree off the branch or remove it first.`
+          : `Can't delete ${branchName ? `'${branchName}'` : 'branch'} — it's checked out in another worktree. Switch that worktree off the branch or remove it first.`,
+        kind: 'warning',
+      })
     }
     // Refresh history rows AS WELL when the workflow could have
     // changed the commits the user sees (#945 follow-up). The
@@ -3941,15 +3978,18 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       await refreshHistoryRows()
     }
 
-    // Checkout-branch is the one workflow where we want a *visible*
-    // refresh so the user sees the branches sidebar repaint with the
-    // new current branch (per #806 follow-up). Snap the cursor to
-    // position 0 first so when the refresh completes and the new
-    // current branch lands at the top (per #809's pin-current rule),
-    // the cursor is already there waiting.
+    // Checkout-branch snaps the cursor to position 0 first so when the
+    // refresh completes and the new current branch lands at the top
+    // (per #809's pin-current rule), the cursor is already there
+    // waiting. The refresh is *silent*: the loud refresh used to blank
+    // every branch name behind a "loading branches…" placeholder (#806),
+    // but the in-flight row now carries its own inline pending spinner
+    // (resolvePendingItemAction → action 'checkout'), so a silent
+    // stale-while-revalidate swap keeps the list readable and just
+    // repaints the current-branch marker once the new context lands.
     if (id === 'checkout-branch' && result?.ok) {
       dispatch({ type: 'resetBranchSelection' })
-      await refreshContext()
+      await refreshContext({ silent: true })
     } else {
       // Silent refresh so the deleted item disappears from the list
       // without flickering the surfaces through a 'loading' phase.
@@ -4003,11 +4043,11 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       if (remoteOp) {
         dispatch({ type: 'setRemoteOp', value: undefined })
       }
-      // Same guarantee for the per-row delete spinner: clear it whether
-      // the delete succeeded, failed, or the refresh threw, so no row is
-      // left spinning forever.
-      if (pendingDeletion) {
-        dispatch({ type: 'setPendingDeletion', value: undefined })
+      // Same guarantee for the per-row pending spinner (delete or
+      // checkout): clear it whether the action succeeded, failed, or the
+      // refresh threw, so no row is left spinning forever.
+      if (pendingItemAction) {
+        dispatch({ type: 'setPendingItemAction', value: undefined })
       }
     }
   }, [context, dispatch, git, refreshContext, refreshHistoryRows, refreshWorktreeContext,

--- a/src/workstation/runtime/pendingItemAction.test.ts
+++ b/src/workstation/runtime/pendingItemAction.test.ts
@@ -1,11 +1,13 @@
 /**
- * Pending-deletion inline spinner (#1137 follow-up).
+ * Pending item-action inline spinner (#1137 follow-up).
  *
- * When a list-item delete is in flight, the targeted row shows an inline
- * spinner in place of its leading status icon (branches / worktrees) or
- * appended to the row (tags / stashes, which have no leading icon). These
- * tests cover the pure helper + reducer and assert the spinner glyph lands
- * on the right row in every deletable surface and in the sidebar.
+ * When an async action is in flight against a list-item row — a delete,
+ * or (since the rename) a branch checkout — the targeted row shows an
+ * inline spinner in place of its leading status icon (branches /
+ * worktrees) or appended to the row (tags / stashes, which have no
+ * leading icon). These tests cover the pure helper + reducer and assert
+ * the spinner glyph lands on the right row in every surface and in the
+ * sidebar, for both the delete and checkout actions.
  *
  * Stub `Text` / `Box` so the React tree can be flattened to text without
  * pulling Ink (ESM) into ts-jest — same pattern as `overlays.test.ts`.
@@ -14,7 +16,8 @@ import { createElement } from 'react'
 import {
   applyLogInkAction,
   createLogInkState,
-  isPendingDeletion,
+  isPendingItemAction,
+  type LogInkPendingItemAction,
 } from '../../commands/log/inkViewModel'
 import { inlineSpinnerGlyph } from '../chrome/spinner'
 import { createLogInkContextStatus } from '../chrome/context'
@@ -77,12 +80,15 @@ const context: LogInkContext = {
   },
 }
 
-function ctxFor(view: 'branches' | 'tags' | 'stash' | 'worktrees', pending?: { kind: never; id: string }): SurfaceRenderContext {
+function ctxFor(
+  view: 'branches' | 'tags' | 'stash' | 'worktrees',
+  pending?: LogInkPendingItemAction
+): SurfaceRenderContext {
   const base = createLogInkState([])
   return {
     h: createElement,
     components,
-    state: { ...base, activeView: view, focus: 'commits', pendingDeletion: pending as never },
+    state: { ...base, activeView: view, focus: 'commits', pendingItemAction: pending },
     context,
     contextStatus: createLogInkContextStatus('ready'),
     bodyRows: 30,
@@ -91,24 +97,29 @@ function ctxFor(view: 'branches' | 'tags' | 'stash' | 'worktrees', pending?: { k
   }
 }
 
-describe('isPendingDeletion', () => {
+describe('isPendingItemAction', () => {
   it('matches only on the same kind AND id', () => {
-    const pending = { kind: 'branch' as const, id: 'feat/x' }
-    expect(isPendingDeletion(pending, 'branch', 'feat/x')).toBe(true)
-    expect(isPendingDeletion(pending, 'branch', 'main')).toBe(false) // id differs
-    expect(isPendingDeletion(pending, 'tag', 'feat/x')).toBe(false) // kind differs
-    expect(isPendingDeletion(undefined, 'branch', 'feat/x')).toBe(false)
+    const pending: LogInkPendingItemAction = { kind: 'branch', id: 'feat/x', action: 'delete' }
+    expect(isPendingItemAction(pending, 'branch', 'feat/x')).toBe(true)
+    expect(isPendingItemAction(pending, 'branch', 'main')).toBe(false) // id differs
+    expect(isPendingItemAction(pending, 'tag', 'feat/x')).toBe(false) // kind differs
+    expect(isPendingItemAction(undefined, 'branch', 'feat/x')).toBe(false)
+  })
+
+  it('is action-agnostic — a checkout in flight spins the same as a delete', () => {
+    const checkout: LogInkPendingItemAction = { kind: 'branch', id: 'feat/x', action: 'checkout' }
+    expect(isPendingItemAction(checkout, 'branch', 'feat/x')).toBe(true)
   })
 })
 
-describe('setPendingDeletion reducer', () => {
+describe('setPendingItemAction reducer', () => {
   it('sets and clears the pending target without touching anything else', () => {
     let state = createLogInkState([])
-    expect(state.pendingDeletion).toBeUndefined()
-    state = applyLogInkAction(state, { type: 'setPendingDeletion', value: { kind: 'stash', id: 'stash@{0}' } })
-    expect(state.pendingDeletion).toEqual({ kind: 'stash', id: 'stash@{0}' })
-    state = applyLogInkAction(state, { type: 'setPendingDeletion', value: undefined })
-    expect(state.pendingDeletion).toBeUndefined()
+    expect(state.pendingItemAction).toBeUndefined()
+    state = applyLogInkAction(state, { type: 'setPendingItemAction', value: { kind: 'stash', id: 'stash@{0}', action: 'delete' } })
+    expect(state.pendingItemAction).toEqual({ kind: 'stash', id: 'stash@{0}', action: 'delete' })
+    state = applyLogInkAction(state, { type: 'setPendingItemAction', value: undefined })
+    expect(state.pendingItemAction).toBeUndefined()
   })
 })
 
@@ -117,26 +128,32 @@ describe('inline pending spinner per surface', () => {
     const plain = flattenText(renderBranchesSurface(ctxFor('branches'), 0))
     expect(plain).not.toContain(SPIN)
 
-    const pending = flattenText(renderBranchesSurface(ctxFor('branches', { kind: 'branch' as never, id: 'feat/x' }), 0))
+    const pending = flattenText(renderBranchesSurface(ctxFor('branches', { kind: 'branch', id: 'feat/x', action: 'delete' }), 0))
     expect(pending).toContain(SPIN)
     expect(pending).toContain('feat/x') // row still shows its name
   })
 
+  it('branches: a pending checkout spins the targeted row too', () => {
+    const pending = flattenText(renderBranchesSurface(ctxFor('branches', { kind: 'branch', id: 'feat/x', action: 'checkout' }), 0))
+    expect(pending).toContain(SPIN)
+    expect(pending).toContain('feat/x')
+  })
+
   it('worktrees: swaps the targeted row marker for a spinner', () => {
-    const pending = flattenText(renderWorktreesSurface(ctxFor('worktrees', { kind: 'worktree' as never, id: '/repo/wt' }), 0))
+    const pending = flattenText(renderWorktreesSurface(ctxFor('worktrees', { kind: 'worktree', id: '/repo/wt', action: 'delete' }), 0))
     expect(pending).toContain(SPIN)
     expect(flattenText(renderWorktreesSurface(ctxFor('worktrees'), 0))).not.toContain(SPIN)
   })
 
   it('tags: appends a spinner (no leading icon to swap)', () => {
-    const pending = flattenText(renderTagsSurface(ctxFor('tags', { kind: 'tag' as never, id: 'v1.1.0' }), 0))
+    const pending = flattenText(renderTagsSurface(ctxFor('tags', { kind: 'tag', id: 'v1.1.0', action: 'delete' }), 0))
     expect(pending).toContain(SPIN)
     expect(pending).toContain('v1.1.0')
     expect(flattenText(renderTagsSurface(ctxFor('tags'), 0))).not.toContain(SPIN)
   })
 
   it('stashes: appends a spinner', () => {
-    const pending = flattenText(renderStashSurface(ctxFor('stash', { kind: 'stash' as never, id: 'stash@{1}' }), 0))
+    const pending = flattenText(renderStashSurface(ctxFor('stash', { kind: 'stash', id: 'stash@{1}', action: 'delete' }), 0))
     expect(pending).toContain(SPIN)
     expect(flattenText(renderStashSurface(ctxFor('stash'), 0))).not.toContain(SPIN)
   })
@@ -145,7 +162,14 @@ describe('inline pending spinner per surface', () => {
 describe('inline pending spinner in the sidebar', () => {
   it('shows the spinner on the targeted branch row of the active tab', () => {
     const base = createLogInkState([])
-    const state = { ...base, sidebarTab: 'branches' as const, focus: 'sidebar' as const, pendingDeletion: { kind: 'branch' as const, id: 'feat/x' } }
+    const state = { ...base, sidebarTab: 'branches' as const, focus: 'sidebar' as const, pendingItemAction: { kind: 'branch' as const, id: 'feat/x', action: 'delete' as const } }
+    const tree = renderSidebar(createElement, components, state, context, createLogInkContextStatus('ready'), 40, 30, theme, 0)
+    expect(flattenText(tree)).toContain(SPIN)
+  })
+
+  it('shows the spinner on a branch being checked out', () => {
+    const base = createLogInkState([])
+    const state = { ...base, sidebarTab: 'branches' as const, focus: 'sidebar' as const, pendingItemAction: { kind: 'branch' as const, id: 'feat/x', action: 'checkout' as const } }
     const tree = renderSidebar(createElement, components, state, context, createLogInkContextStatus('ready'), 40, 30, theme, 0)
     expect(flattenText(tree)).toContain(SPIN)
   })

--- a/src/workstation/runtime/sidebar.ts
+++ b/src/workstation/runtime/sidebar.ts
@@ -27,7 +27,7 @@ import type {
   LogInkSidebarTab,
   LogInkState,
 } from '../../commands/log/inkViewModel'
-import { getLogInkSidebarTabs, isPendingDeletion } from '../../commands/log/inkViewModel'
+import { getLogInkSidebarTabs, isPendingItemAction } from '../../commands/log/inkViewModel'
 import type { LogInkComponents, LogInkContext } from './types'
 import { focusBorderColor, panelTitle, sidebarTabLabel } from './utils'
 
@@ -157,7 +157,7 @@ function renderActiveSidebarContent(
   // shows this spinner in place of its leading marker (branches /
   // worktrees) or appended to the row (tags / stashes, which have no
   // leading status icon). `pending` is the single in-flight target.
-  const pending = state.pendingDeletion
+  const pending = state.pendingItemAction
   const spin = inlineSpinnerGlyph(spinnerFrame, theme.ascii)
   // Available rows for the active tab's list. The sidebar chrome
   // takes ~10 rows (panel title + spacer + 5 tab headers + 4 inter-tab
@@ -202,7 +202,7 @@ function renderActiveSidebarContent(
       ...renderSelectableSidebarRows(
         h, Text, sortedBranches, state.selectedBranchIndex, focused, width, theme,
         (branch) => {
-          const glyph = isPendingDeletion(pending, 'branch', branch.shortName)
+          const glyph = isPendingItemAction(pending, 'branch', branch.shortName)
             ? spin
             : branchRowMarker(branch, { ascii: theme.ascii }).glyph
           return `${glyph} ${branch.shortName}`
@@ -226,7 +226,7 @@ function renderActiveSidebarContent(
         const base = `${truncateCells(tag.name, 16)} ${tag.subject}`
         // Tags have no leading status icon, so the pending spinner is
         // appended to the row instead of replacing a glyph.
-        return isPendingDeletion(pending, 'tag', tag.name) ? `${base} ${spin}` : base
+        return isPendingItemAction(pending, 'tag', tag.name) ? `${base} ${spin}` : base
       },
       'tab-tags', visibleListCount,
     )
@@ -246,7 +246,7 @@ function renderActiveSidebarContent(
         const base = `@{${index}} ${stash.message || '(no message)'}`
         // `@{N}` is the stash ref, not a status icon, so append the
         // spinner rather than replacing it.
-        return isPendingDeletion(pending, 'stash', stash.ref) ? `${base} ${spin}` : base
+        return isPendingItemAction(pending, 'stash', stash.ref) ? `${base} ${spin}` : base
       },
       'tab-stashes', visibleListCount,
     )
@@ -263,7 +263,7 @@ function renderActiveSidebarContent(
   return renderSelectableSidebarRows(
     h, Text, worktrees, state.selectedWorktreeListIndex, focused, width, theme,
     (worktree) => {
-      const marker = isPendingDeletion(pending, 'worktree', worktree.path)
+      const marker = isPendingItemAction(pending, 'worktree', worktree.path)
         ? spin
         : worktree.current ? '*' : ' '
       const wstate = worktree.dirty ? 'dirty' : 'clean'

--- a/src/workstation/surfaces/branches/index.ts
+++ b/src/workstation/surfaces/branches/index.ts
@@ -30,7 +30,7 @@ import {
 } from '../../runtime/promotedFilter'
 import type { SurfaceRenderContext } from '../../runtime/types'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
-import { isPendingDeletion } from '../../../commands/log/inkViewModel'
+import { isPendingItemAction } from '../../../commands/log/inkViewModel'
 
 export function renderBranchesSurface(ctx: SurfaceRenderContext, spinnerFrame: number = 0): ReactTypes.ReactElement {
   const { h, components, state, context, contextStatus, bodyRows, width, theme } = ctx
@@ -76,7 +76,7 @@ export function renderBranchesSurface(ctx: SurfaceRenderContext, spinnerFrame: n
         // While this branch's delete is in flight, its sync-state marker
         // is replaced by an inline spinner (accent-coloured) so the row
         // reads as "deleting" until it vanishes on refresh.
-        const deleting = isPendingDeletion(state.pendingDeletion, 'branch', branch.shortName)
+        const deleting = isPendingItemAction(state.pendingItemAction, 'branch', branch.shortName)
         const glyph = deleting ? inlineSpinnerGlyph(spinnerFrame, theme.ascii) : marker.glyph
         const glyphColor = deleting
           ? (theme.noColor ? undefined : theme.colors.accent)

--- a/src/workstation/surfaces/stash/index.ts
+++ b/src/workstation/surfaces/stash/index.ts
@@ -20,7 +20,7 @@ import {
 } from '../../runtime/promotedFilter'
 import type { SurfaceRenderContext } from '../../runtime/types'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
-import { isPendingDeletion } from '../../../commands/log/inkViewModel'
+import { isPendingItemAction } from '../../../commands/log/inkViewModel'
 
 export function renderStashSurface(ctx: SurfaceRenderContext, spinnerFrame: number = 0): ReactTypes.ReactElement {
   const { h, components, state, context, contextStatus, bodyRows, width, theme } = ctx
@@ -73,7 +73,7 @@ export function renderStashSurface(ctx: SurfaceRenderContext, spinnerFrame: numb
         // The `stash@{N}` ref is an identifier, not a status icon, so a
         // delete-in-flight appends an accent spinner at the row's end
         // (2 cells reserved from the width budget).
-        const deleting = isPendingDeletion(state.pendingDeletion, 'stash', stash.ref)
+        const deleting = isPendingItemAction(state.pendingItemAction, 'stash', stash.ref)
         const spinnerSpan = deleting
           ? h(Text, { color: theme.noColor ? undefined : theme.colors.accent, dimColor: false },
             ` ${inlineSpinnerGlyph(spinnerFrame, theme.ascii)}`)

--- a/src/workstation/surfaces/tags/index.ts
+++ b/src/workstation/surfaces/tags/index.ts
@@ -24,7 +24,7 @@ import {
 } from '../../runtime/promotedFilter'
 import type { SurfaceRenderContext } from '../../runtime/types'
 import { buildRefUrl, focusBorderColor, panelTitle } from '../../runtime/utils'
-import { isPendingDeletion } from '../../../commands/log/inkViewModel'
+import { isPendingItemAction } from '../../../commands/log/inkViewModel'
 
 export function renderTagsSurface(ctx: SurfaceRenderContext, spinnerFrame: number = 0): ReactTypes.ReactElement {
   const { h, components, state, context, contextStatus, bodyRows, width, theme } = ctx
@@ -70,7 +70,7 @@ export function renderTagsSurface(ctx: SurfaceRenderContext, spinnerFrame: numbe
         // Tags have no leading status icon, so a delete-in-flight appends
         // an accent spinner at the row's end. Reserve its 2 cells from the
         // truncation budget so it never pushes the row past the panel.
-        const deleting = isPendingDeletion(state.pendingDeletion, 'tag', tag.name)
+        const deleting = isPendingItemAction(state.pendingItemAction, 'tag', tag.name)
         const spinnerSpan = deleting
           ? h(Text, { color: theme.noColor ? undefined : theme.colors.accent, dimColor: false },
             ` ${inlineSpinnerGlyph(spinnerFrame, theme.ascii)}`)

--- a/src/workstation/surfaces/worktrees/index.ts
+++ b/src/workstation/surfaces/worktrees/index.ts
@@ -19,7 +19,7 @@ import {
 } from '../../runtime/promotedFilter'
 import type { SurfaceRenderContext } from '../../runtime/types'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
-import { isPendingDeletion } from '../../../commands/log/inkViewModel'
+import { isPendingItemAction } from '../../../commands/log/inkViewModel'
 
 export function renderWorktreesSurface(ctx: SurfaceRenderContext, spinnerFrame: number = 0): ReactTypes.ReactElement {
   const { h, components, state, context, contextStatus, bodyRows, width, theme } = ctx
@@ -59,7 +59,7 @@ export function renderWorktreesSurface(ctx: SurfaceRenderContext, spinnerFrame: 
         const index = startIndex + offset
         const isSelected = index === selected
         const cursor = isSelected ? '>' : ' '
-        const marker = isPendingDeletion(state.pendingDeletion, 'worktree', entry.path)
+        const marker = isPendingItemAction(state.pendingItemAction, 'worktree', entry.path)
           ? inlineSpinnerGlyph(spinnerFrame, theme.ascii)
           : entry.current ? '*' : ' '
         const branchLabel = entry.branch ? entry.branch : entry.head || '<detached>'


### PR DESCRIPTION
Two related list-item polish items in the workstation, bundled per request.

## 1. Inline loader on branch checkout

Pressing **enter** to check out a branch fired a *loud* context refresh that blanked every branch name behind a `loading branches…` placeholder. This swaps that for the same **inline per-row pending spinner** that deletes already use: the cursored branch shows a spinner while `git checkout` runs (in both the sidebar and the full branches surface), and the post-checkout refresh is now **silent** (stale-while-revalidate), so names stay on screen and only the current-branch marker repaints when the new context lands.

To share one code path between deletes and checkouts, the pending-row state was generalized:

| before | after |
| --- | --- |
| `state.pendingDeletion` | `state.pendingItemAction` (`{ kind, id, action }`) |
| `isPendingDeletion` | `isPendingItemAction` |
| `setPendingDeletion` | `setPendingItemAction` |
| `LogInkDeletableKind` | `LogInkListItemKind` |
| `resolvePendingDeletion` | `resolvePendingItemAction` (now also resolves `checkout-branch`) |

The spinner render is action-agnostic; the `action` tag (`'delete' | 'checkout'`) is carried so future async row actions can reuse the mechanism without new state.

## 2. Clear message when a branch is checked out in a worktree

Deleting a branch that's checked out in another worktree dead-ended on git's raw `Cannot delete branch 'x' checked out at '<path>'`. Unlike the "not fully merged" case, **`git branch -D` won't force it either**, so we deliberately do *not* offer a force-delete confirmation. Instead we detect the rejection (`isBranchCheckedOutElsewhereError` + `parseCheckedOutWorktreePath`) and surface a clear, actionable message naming the worktree to free up first:

> Can't delete `feat/install-boot-demo` — checked out in worktree `…/festive-shamir-46fdda`. Switch that worktree off the branch or remove it first.

## Tests

- Renamed `pendingDeletion.test.ts` → `pendingItemAction.test.ts`; added coverage that a pending **checkout** spins the targeted row (sidebar + surface) the same as a delete.
- New `branchActions` tests for `isBranchCheckedOutElsewhereError` and `parseCheckedOutWorktreePath` across both git phrasings (`checked out at` / `used by worktree at`).

## Validation

- `npx tsc --noEmit` — clean
- `eslint src` — exit 0
- Full unit suite — **209 suites, 2651 passed**
