### PR TITLE
feat(workstation): highlight the checked-out branch in green

### DIFF
--- a/src/workstation/runtime/currentBranchHighlight.test.ts
+++ b/src/workstation/runtime/currentBranchHighlight.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Current-branch colour highlight.
+ *
+ * The checked-out branch is painted in the theme's `success` colour so
+ * "where am I?" reads at a glance — in both the full branches surface
+ * and the sidebar branches tab. These tests walk the rendered tree for a
+ * coloured span carrying the current branch's name and assert non-current
+ * branches stay uncoloured.
+ *
+ * Stub `Text` / `Box` so the tree flattens without pulling Ink (ESM)
+ * into ts-jest — same pattern as `pendingItemAction.test.ts`.
+ */
+import { createElement } from 'react'
+import { createLogInkState } from '../../commands/log/inkViewModel'
+import { createLogInkContextStatus } from '../chrome/context'
+import { createLogInkTheme } from '../chrome/theme'
+import { renderBranchesSurface } from '../surfaces/branches'
+import { renderSidebar } from './sidebar'
+import type { LogInkComponents, LogInkContext, SurfaceRenderContext } from './types'
+
+type StubProps = Record<string, unknown>
+const Text = ((props: StubProps) =>
+  createElement('text', props, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+const Box = ((props: StubProps) =>
+  createElement('box', props, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+const components: LogInkComponents = { Box, Text }
+const theme = createLogInkTheme({ noColor: false })
+const SUCCESS = theme.colors.success as string
+
+function flattenText(node: unknown): string {
+  if (node == null || node === false) return ''
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(flattenText).join('')
+  const el = node as { props?: { children?: unknown } }
+  if (el.props && 'children' in el.props) return flattenText(el.props.children)
+  return ''
+}
+
+/** All text rendered under a span whose `color` prop equals `color`. */
+function textWithColor(node: unknown, color: string): string {
+  if (node == null || node === false || typeof node === 'string' || typeof node === 'number') {
+    return ''
+  }
+  if (Array.isArray(node)) return node.map((n) => textWithColor(n, color)).join('')
+  const el = node as { props?: { color?: string; children?: unknown } }
+  if (el.props?.color === color) return flattenText(el.props.children)
+  return el.props && 'children' in el.props ? textWithColor(el.props.children, color) : ''
+}
+
+const context: LogInkContext = {
+  branches: {
+    currentBranch: 'main',
+    dirty: false,
+    remoteBranches: [],
+    localBranches: [
+      { type: 'local', name: 'main', shortName: 'main', hash: 'a1', current: true, date: '2024-01-01', subject: 's', ahead: 0, behind: 0 },
+      { type: 'local', name: 'feat/x', shortName: 'feat/x', hash: 'b2', current: false, upstream: 'origin/feat/x', date: '2024-01-02', subject: 's', ahead: 0, behind: 0 },
+    ],
+  },
+}
+
+function surfaceCtx(): SurfaceRenderContext {
+  const base = createLogInkState([])
+  return {
+    h: createElement,
+    components,
+    state: { ...base, activeView: 'branches', focus: 'commits' },
+    context,
+    contextStatus: createLogInkContextStatus('ready'),
+    bodyRows: 30,
+    width: 70,
+    theme,
+  }
+}
+
+describe('current-branch highlight — branches surface', () => {
+  it('paints the current branch name in the success colour', () => {
+    const tree = renderBranchesSurface(surfaceCtx(), 0)
+    expect(textWithColor(tree, SUCCESS)).toContain('main')
+  })
+
+  it('leaves non-current branches out of the success colour', () => {
+    const tree = renderBranchesSurface(surfaceCtx(), 0)
+    expect(textWithColor(tree, SUCCESS)).not.toContain('feat/x')
+  })
+})
+
+describe('current-branch highlight — sidebar', () => {
+  it('paints the current branch row in the success colour', () => {
+    // Cursor on feat/x (index 1) so the current branch (main, index 0)
+    // is NOT the active selection — the selection's inverse styling
+    // deliberately owns a focused row's colour, so the green only shows
+    // when the current branch isn't the one under the cursor.
+    const base = createLogInkState([])
+    const state = { ...base, sidebarTab: 'branches' as const, focus: 'sidebar' as const, selectedBranchIndex: 1 }
+    const tree = renderSidebar(createElement, components, state, context, createLogInkContextStatus('ready'), 40, 30, theme, 0)
+    expect(textWithColor(tree, SUCCESS)).toContain('main')
+    expect(textWithColor(tree, SUCCESS)).not.toContain('feat/x')
+  })
+})

--- a/src/workstation/runtime/sidebar.ts
+++ b/src/workstation/runtime/sidebar.ts
@@ -49,6 +49,12 @@ function renderSelectableSidebarRows<T>(
   toRowText: (item: T, index: number) => string,
   keyPrefix: string,
   visibleCount?: number,
+  // Optional per-row foreground colour (e.g. the current branch in
+  // green). Applied only when the row is NOT the active selection —
+  // the selection's inverse/background styling owns the row's colour in
+  // that case, and layering a foreground under `inverse` would swap it
+  // into an unexpected background tint.
+  rowColor?: (item: T, index: number) => string | undefined,
 ): ReactTypes.ReactElement[] {
   if (items.length === 0) return []
 
@@ -67,10 +73,12 @@ function renderSelectableSidebarRows<T>(
     if (index >= items.length) break
     const isSelected = focused && index === selectedIndex
     const text = toRowText(items[index], index)
+    const color = isSelected ? undefined : rowColor?.(items[index], index)
     elements.push(h(Text, {
       key: `${keyPrefix}-row-${index}`,
       backgroundColor: isSelected && !theme.noColor ? theme.colors.selection : undefined,
       inverse: isSelected,
+      color,
     }, truncateCells(`  ${text}`, width - 4)))
   }
 
@@ -208,6 +216,10 @@ function renderActiveSidebarContent(
           return `${glyph} ${branch.shortName}`
         },
         'tab-branches', visibleListCount,
+        // Paint the checked-out branch green so "where am I?" reads at a
+        // glance, matching the green HEAD marker the branches surface
+        // already uses. NO_COLOR themes fall back to the `*` glyph alone.
+        (branch) => (branch.current && !theme.noColor ? theme.colors.success : undefined),
       ),
     ]
   }

--- a/src/workstation/surfaces/branches/index.ts
+++ b/src/workstation/surfaces/branches/index.ts
@@ -99,11 +99,16 @@ export function renderBranchesSurface(ctx: SurfaceRenderContext, spinnerFrame: n
         const truncated = truncateCells(fullText, Math.max(20, width - 4))
         // If truncation chopped into the timestamp/divergence portion,
         // fall back to a single Text to keep the visible width honest.
+        // The checked-out branch is painted green (matching its green
+        // HEAD marker) so "where am I?" reads at a glance. NO_COLOR
+        // themes fall back to the `*` glyph alone.
+        const currentColor = branch.current && !theme.noColor ? theme.colors.success : undefined
         if (truncated !== fullText) {
           return h(Text, {
             key: `branch-${index}`,
             bold: isSelected,
             dimColor: lineDim,
+            color: currentColor,
           }, truncated)
         }
         return h(Text, {
@@ -121,7 +126,11 @@ export function renderBranchesSurface(ctx: SurfaceRenderContext, spinnerFrame: n
         // row's dim and read as quiet chrome.
         h(Text, { color: glyphColor, dimColor: glyphColor ? false : undefined },
           glyph),
-        trailingName,
+        // Name span: green for the current branch (dimColor:false keeps
+        // it bright), otherwise it inherits the row's normal styling.
+        currentColor
+          ? h(Text, { color: currentColor, dimColor: false }, trailingName)
+          : trailingName,
         h(Text, { dimColor: true }, timestampPadded),
         trailingDivergence
         )


### PR DESCRIPTION
The currently checked-out branch was only distinguishable by its `*` marker — and in the **sidebar** it wasn't coloured at all, so the current branch blended in with the rest of the list. This paints the checked-out branch's **name** in the theme's `success` colour (green), matching the green HEAD `*` marker the branches surface already uses, so "where am I?" reads at a glance.

## Changes

- **Branches surface** ([surfaces/branches](src/workstation/surfaces/branches/index.ts)): the current branch's name span renders green (and stays bold when it's the cursored row).
- **Sidebar branches tab** ([sidebar.ts](src/workstation/runtime/sidebar.ts)): `renderSelectableSidebarRows` gains an optional per-row colour callback; the current branch row renders green.
- The green is **suppressed on the focused selection**, where the inverse highlight already owns the row's colour (layering a foreground under `inverse` would swap it into an odd background tint). The `*` glyph still marks the current branch in that state.
- **NO_COLOR / ascii** themes fall back to the `*` glyph alone.

## Tests

New `currentBranchHighlight.test.ts` walks the rendered tree and asserts the current branch's name carries the `success` colour (and non-current branches don't), in both the branches surface and the sidebar.

## Validation

- `tsc --noEmit` — clean · `eslint src` — exit 0 · full suite **210 suites, 2654 passed**
