### PR TITLE
feat(workstation): render the stash view as an aligned table

### DIFF
--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -126,7 +126,7 @@ export const RECIPES: ScreenshotRecipe[] = [
   },
   {
     name: 'ui-stash-list',
-    description: 'Workstation Stashes view — rich rows (on <branch> · N files · age) + inspector preview',
+    description: 'Workstation Stashes view — aligned table (ref · age · branch · files · message) + inspector preview',
     scenario: 'stashed-changes',
     command: 'ui',
     actions: [
@@ -1363,7 +1363,7 @@ export const RECIPES: ScreenshotRecipe[] = [
   },
   {
     name: 'demo-stash-workflow',
-    description: 'Stash like a pro: open the Stashes view (rich rows — on <branch> · N files · age), rename one (R), see the row update + inspector preview',
+    description: 'Stash like a pro: open the Stashes view (aligned table — ref · age · branch · files · message), rename one (R), see the row update + inspector preview',
     scenario: 'stashed-changes',
     command: 'ui',
     emitGif: true,
@@ -1371,8 +1371,8 @@ export const RECIPES: ScreenshotRecipe[] = [
     actions: [
       // Wait out the cold-cache "loading context" beat before the gz chord.
       { kind: 'sleep', ms: 4000 },
-      // Jump to the Stashes view — rows now read "stash@{0}  on main ·
-      // 3 files · 2w  <message>" with the inspector previewing contents.
+      // Jump to the Stashes view — an aligned table (ref · age · branch ·
+      // files · message) with the inspector previewing contents.
       { kind: 'type', text: 'gz' },
       { kind: 'sleep', ms: 2600 },
       // Rename the cursored stash — git has no native rename, so coco

--- a/src/workstation/surfaces/stash/index.ts
+++ b/src/workstation/surfaces/stash/index.ts
@@ -13,7 +13,7 @@ import { formatCompactRelativeDate } from '../../chrome/dateFormat'
 import { getRenderNow } from '../../chrome/snapshotMode'
 import { inlineSpinnerGlyph } from '../../chrome/spinner'
 import { formatLogInkLoading, formatLogInkStashEmpty } from '../../chrome/surfaceStates'
-import { truncateCells } from '../../chrome/text'
+import { cellWidth, truncateCells } from '../../chrome/text'
 import {
     matchesPromotedFilter,
     renderPromotedFilterAffordance,
@@ -21,6 +21,17 @@ import {
 import type { SurfaceRenderContext } from '../../runtime/types'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
 import { isPendingItemAction } from '../../../commands/log/inkViewModel'
+
+const GAP = 2 // cells between columns
+
+/** Truncate to `w` cells, then pad to `w` (left = padEnd, right = padStart). */
+function cell(value: string, w: number, align: 'left' | 'right' = 'left'): string {
+  const t = truncateCells(value, w)
+  // padStart/padEnd count code units; refs / ages / counts / branch
+  // names are ASCII in practice, matching the branches surface's
+  // padEnd-based column alignment.
+  return align === 'right' ? t.padStart(w) : t.padEnd(w)
+}
 
 export function renderStashSurface(ctx: SurfaceRenderContext, spinnerFrame: number = 0): ReactTypes.ReactElement {
   const { h, components, state, context, contextStatus, bodyRows, width, theme } = ctx
@@ -34,7 +45,9 @@ export function renderStashSurface(ctx: SurfaceRenderContext, spinnerFrame: numb
     )
     : allStashes
   const selected = Math.max(0, Math.min(state.selectedStashIndex, Math.max(0, stashes.length - 1)))
-  const listRows = Math.max(4, bodyRows - 4)
+  // One extra row reserved (vs the other surfaces' `- 4`) for the column
+  // header row below.
+  const listRows = Math.max(4, bodyRows - 5)
   const startIndex = Math.max(0, selected - Math.floor(listRows / 2))
   const visible = stashes.slice(startIndex, startIndex + listRows)
   const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
@@ -44,10 +57,61 @@ export function renderStashSurface(ctx: SurfaceRenderContext, spinnerFrame: numb
   const emptyLabel = formatLogInkStashEmpty({ filter: state.filter })
   const loadingLabel = formatLogInkLoading({ resource: 'stashes' })
   const now = getRenderNow()
-  // Available width for a row: box width minus the 2-cell horizontal
-  // padding. Truncate to it (with a small floor) instead of a magic 140
-  // so the richer meta degrades gracefully on narrow terminals.
-  const rowWidth = Math.max(20, width - 2)
+  // Usable interior width: panel width minus the border (2) and the
+  // paddingX:1 (2). The previous `width - 2` under-counted the border
+  // and made every near-full row overflow by 2 cells and wrap — the
+  // single biggest readability hit in the old list.
+  const contentWidth = Math.max(20, width - 4)
+
+  const ageOf = (s: typeof visible[number]) => formatCompactRelativeDate(s.date, now)
+
+  // Column widths derived from the visible window (#833 pattern) so rows
+  // align without re-measuring the whole list. Each column is at least
+  // as wide as its header label so the header never truncates ("age",
+  // "branch", "files"); age tops out at 5 ("today" is the longest value
+  // formatCompactRelativeDate emits).
+  const refCol = visible.length
+    ? Math.min(11, Math.max(3, ...visible.map((s) => cellWidth(s.ref))))
+    : 9
+  const ageCol = visible.length
+    ? Math.min(5, Math.max(3, ...visible.map((s) => cellWidth(ageOf(s)))))
+    : 3
+  const branchColMax = visible.length
+    ? Math.max(0, ...visible.map((s) => cellWidth(s.branch || '')))
+    : 0
+  const filesCol = visible.length
+    ? Math.max(5, ...visible.map((s) => String(s.files.length).length))
+    : 5
+
+  // Responsive degradation. Keep ref + message always; when the message
+  // floor is threatened, shed columns the preview pane already shows —
+  // branch first, then age, then the file count — before squeezing the
+  // message.
+  // Widen to fit the "branch" header when any stash carries a branch;
+  // stays 0 (column dropped) when none do.
+  let branchCol = branchColMax > 0 ? Math.min(18, Math.max(6, branchColMax)) : 0
+  let showAge = true
+  let showFiles = true
+  const fixedWidth = () =>
+    2 + refCol +
+    (showAge ? GAP + ageCol : 0) +
+    (branchCol > 0 ? GAP + branchCol : 0) +
+    (showFiles ? GAP + filesCol : 0) +
+    GAP // gap before the message column
+  let messageWidth = contentWidth - fixedWidth()
+  if (messageWidth < 24 && branchCol > 0) { branchCol = 0; messageWidth = contentWidth - fixedWidth() }
+  if (messageWidth < 16 && showAge) { showAge = false; messageWidth = contentWidth - fixedWidth() }
+  if (messageWidth < 12 && showFiles) { showFiles = false; messageWidth = contentWidth - fixedWidth() }
+  messageWidth = Math.max(8, messageWidth)
+
+  // Column header. Right-aligned labels over the right-aligned numeric
+  // columns (age, files) so header and data share an edge.
+  let headerText = `  ${cell('ref', refCol)}`
+  if (showAge) headerText += `${' '.repeat(GAP)}${cell('age', ageCol, 'right')}`
+  if (branchCol > 0) headerText += `${' '.repeat(GAP)}${cell('branch', branchCol)}`
+  if (showFiles) headerText += `${' '.repeat(GAP)}${cell('files', filesCol, 'right')}`
+  headerText += `${' '.repeat(GAP)}message`
+
   const lines: ReactTypes.ReactNode[] = loading
     ? [h(Text, { key: 'stash-loading', dimColor: true }, loadingLabel)]
     : stashes.length === 0
@@ -56,33 +120,31 @@ export function renderStashSurface(ctx: SurfaceRenderContext, spinnerFrame: numb
         const index = startIndex + offset
         const isSelected = index === selected
         const cursor = isSelected ? '>' : ' '
-        // Surface the metadata the StashEntry already carries — origin
-        // branch, file count, and relative age — between the ref and the
-        // message, so the list answers "which stash is this?" without an
-        // Enter→diff round trip.
-        const age = formatCompactRelativeDate(stash.date, now)
-        const fileCount = stash.files.length
-        const meta = [
-          stash.branch ? `on ${stash.branch}` : '',
-          fileCount > 0 ? `${fileCount} file${fileCount === 1 ? '' : 's'}` : '',
-          age,
-        ].filter(Boolean).join(' · ')
-        const rowText = meta
-          ? `${cursor} ${stash.ref.padEnd(11)} ${meta}  ${stash.message}`
-          : `${cursor} ${stash.ref.padEnd(11)} ${stash.message}`
+        const deleting = isPendingItemAction(state.pendingItemAction, 'stash', stash.ref)
         // The `stash@{N}` ref is an identifier, not a status icon, so a
         // delete-in-flight appends an accent spinner at the row's end
-        // (2 cells reserved from the width budget).
-        const deleting = isPendingItemAction(state.pendingItemAction, 'stash', stash.ref)
+        // (2 cells reserved from the message budget).
         const spinnerSpan = deleting
           ? h(Text, { color: theme.noColor ? undefined : theme.colors.accent, dimColor: false },
             ` ${inlineSpinnerGlyph(spinnerFrame, theme.ascii)}`)
           : null
+        const message = truncateCells(stash.message, messageWidth - (deleting ? 2 : 0))
+        // ref + message read as primary; age / branch / file-count are
+        // dim metadata (kept dim even on the bold selected row so the
+        // message stays the focal point).
         return h(Text, {
           key: `stash-${index}`,
           bold: isSelected,
           dimColor: !isSelected,
-        }, truncateCells(rowText, rowWidth - (deleting ? 2 : 0)), spinnerSpan)
+        },
+        `${cursor} `,
+        cell(stash.ref, refCol),
+        showAge ? h(Text, { dimColor: true }, `${' '.repeat(GAP)}${cell(ageOf(stash), ageCol, 'right')}`) : null,
+        branchCol > 0 ? h(Text, { dimColor: true }, `${' '.repeat(GAP)}${cell(stash.branch || '', branchCol)}`) : null,
+        showFiles ? h(Text, { dimColor: true }, `${' '.repeat(GAP)}${cell(String(stash.files.length), filesCol, 'right')}`) : null,
+        `${' '.repeat(GAP)}${message}`,
+        spinnerSpan,
+        )
       })
 
   const stashHasMoreAbove = startIndex > 0 && stashes.length > 0
@@ -101,6 +163,10 @@ export function renderStashSurface(ctx: SurfaceRenderContext, spinnerFrame: numb
     h(Text, { dimColor: true }, headerRight)
   ),
   ...renderPromotedFilterAffordance(h, Text, state, theme),
+  // Column header — only when there are rows to label.
+  ...(!loading && stashes.length > 0
+    ? [h(Text, { key: 'stash-col-header', dimColor: true }, truncateCells(headerText, contentWidth))]
+    : []),
   ...(stashHasMoreAbove
     ? [h(Text, { key: 'stash-more-above', dimColor: true }, `  ↑ ${startIndex} more above`)]
     : []),

--- a/src/workstation/surfaces/stash/stashTable.test.ts
+++ b/src/workstation/surfaces/stash/stashTable.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Stash surface table layout.
+ *
+ * The stash list renders as an aligned table — `ref · age · branch ·
+ * files · message` with a column header — instead of the old run-on
+ * `·`-joined string. These tests assert the header is present, the
+ * columns carry their data, rows never exceed the panel's interior width
+ * (the old `width - 2` truncation overflowed by 2 cells and wrapped),
+ * and the branch column sheds on narrow terminals.
+ *
+ * Stub `Text` / `Box` so the tree flattens without pulling Ink (ESM)
+ * into ts-jest — same pattern as `pendingItemAction.test.ts`.
+ */
+import { createElement } from 'react'
+import { createLogInkState } from '../../../commands/log/inkViewModel'
+import { createLogInkContextStatus } from '../../chrome/context'
+import { createLogInkTheme } from '../../chrome/theme'
+import { cellWidth } from '../../chrome/text'
+import { renderStashSurface } from './index'
+import type { LogInkComponents, LogInkContext, SurfaceRenderContext } from '../../runtime/types'
+
+type StubProps = Record<string, unknown>
+const Text = ((props: StubProps) =>
+  createElement('text', props, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+const Box = ((props: StubProps) =>
+  createElement('box', props, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+const components: LogInkComponents = { Box, Text }
+const theme = createLogInkTheme({ noColor: false })
+
+function flattenText(node: unknown): string {
+  if (node == null || node === false) return ''
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(flattenText).join('')
+  const el = node as { props?: { children?: unknown } }
+  if (el.props && 'children' in el.props) return flattenText(el.props.children)
+  return ''
+}
+
+/**
+ * Flatten every top-level line element — the data rows (`stash-<n>`) and
+ * the column header (`stash-col-header`) — identified by React key. We
+ * stop descending once a line is found so nested metadata spans don't
+ * count as separate rows.
+ */
+function leafRows(node: unknown, out: string[] = []): string[] {
+  if (node == null || node === false || typeof node === 'string' || typeof node === 'number') return out
+  if (Array.isArray(node)) { node.forEach((n) => leafRows(n, out)); return out }
+  const el = node as { key?: unknown; props?: { children?: unknown } }
+  if (typeof el.key === 'string' && /^stash-(\d+|col-header)$/.test(el.key)) {
+    out.push(flattenText(el))
+    return out
+  }
+  if (el.props && 'children' in el.props) leafRows(el.props.children, out)
+  return out
+}
+
+const stashes = [
+  { ref: 'stash@{0}', hash: 'a1', baseHash: 'a1p', date: '2024-01-10', branch: 'feat/new-themes', message: 'e721919 regenerate schema for 14 new theme presets and more', files: ['a.ts', 'b.ts'] },
+  { ref: 'stash@{1}', hash: 'b2', baseHash: 'b2p', date: '2024-01-09', branch: 'main', message: '2cbeb35 tighten Ink types (closes #1078)', files: ['c.ts'] },
+  { ref: 'stash@{2}', hash: 'c3', baseHash: 'c3p', date: '2022-02-01', branch: 'chore/resolve-bundle-issues-and-more', message: 'WIP on chore/resolve-bundle-issues', files: ['d.ts', 'e.ts', 'f.ts'] },
+]
+
+const context: LogInkContext = {
+  stashes: { stashes },
+} as unknown as LogInkContext
+
+function ctx(width: number): SurfaceRenderContext {
+  const base = createLogInkState([])
+  return {
+    h: createElement,
+    components,
+    state: { ...base, activeView: 'stash', focus: 'commits' },
+    context,
+    contextStatus: createLogInkContextStatus('ready'),
+    bodyRows: 30,
+    width,
+    theme,
+  }
+}
+
+describe('stash surface — aligned table', () => {
+  it('renders a column header labelling the fields', () => {
+    const flat = flattenText(renderStashSurface(ctx(100), 0))
+    expect(flat).toContain('ref')
+    expect(flat).toContain('age')
+    expect(flat).toContain('branch')
+    expect(flat).toContain('files')
+    expect(flat).toContain('message')
+  })
+
+  it('shows each stash with its ref, branch, and message at a wide width', () => {
+    const flat = flattenText(renderStashSurface(ctx(100), 0))
+    expect(flat).toContain('stash@{0}')
+    expect(flat).toContain('feat/new-themes')
+    expect(flat).toContain('regenerate schema')
+  })
+
+  it('never lets a row exceed the panel interior width (no wrap)', () => {
+    const width = 90
+    const interior = width - 4 // border (2) + paddingX (2)
+    const rows = leafRows(renderStashSurface(ctx(width), 0))
+    expect(rows.length).toBeGreaterThan(0)
+    for (const row of rows) {
+      expect(cellWidth(row)).toBeLessThanOrEqual(interior)
+    }
+  })
+
+  it('sheds the branch column on a narrow terminal', () => {
+    const flat = flattenText(renderStashSurface(ctx(48), 0))
+    // ref + message survive; the branch name is dropped to protect the
+    // message floor (it stays visible in the preview pane).
+    expect(flat).toContain('stash@{0}')
+    expect(flat).not.toContain('feat/new-themes')
+  })
+})


### PR DESCRIPTION
Reworks the Stashes view from a run-on string into a proper aligned table. Built with `/tui-design`.

## Before

Each row was `ref  on <branch> · N files · age  <message>` joined with middots, so:
- the **message started at a different column on every row** (branch names vary wildly in length) → nothing scanned vertically;
- rows truncated to `width - 2` while the panel interior is `width - 4` (border + `paddingX`), so **every near-full row overflowed by 2 cells and wrapped**, shattering the list rhythm (the `s…` / `(clo…` fragments).

## After

A proper aligned table:

```
  ref        age    branch  files  message
> stash@{0}  today  main      1  WIP: experiment-c
  stash@{1}  today  main      1  WIP: experiment-b
  stash@{2}  today  main      1  WIP: experiment-a
```

- Dim column **header** (`ref · age · branch · files · message`) over fixed/derived columns.
- Metadata (age / branch / files) is dim; the **message** fills the remainder and tail-truncates; numeric/age columns right-aligned.
- Each column is **at least as wide as its header label**, so the header never truncates.
- Rows fit the interior exactly — **no wrapping**.
- **Responsive:** when the message floor is threatened, the columns the inspector preview already shows are shed in priority order — branch → age → file count — before squeezing the message; `ref + message` always survive (degrades cleanly to a 60-col tmux split).
- The delete-in-flight accent spinner still appends at the row end.

## Tests

New `stashTable.test.ts` asserts the header is present, the columns carry their data, **no row exceeds the panel interior** (the wrap regression), and the branch column sheds on a narrow terminal.

## Validation

- `tsc --noEmit` — clean · `eslint src` — exit 0 · full suite **210 suites, 2655 passed**
- Regenerated the `ui-stash-list` screenshot to verify the layout; updated the (stale) recipe descriptions.
