### PR TITLE
fix(screenshot): mask forwarded secrets in VHS output

### DIFF
--- a/bin/screenshot.ts
+++ b/bin/screenshot.ts
@@ -25,7 +25,7 @@ import { tmpdir } from 'os'
 import { dirname, join, resolve } from 'path'
 import { fromScenario, listRegistered } from '@gfargo/git-scenarios'
 import { findRecipe, listRecipeNames, RECIPES, type ScreenshotRecipe } from './screenshot/recipes'
-import { buildTape } from './screenshot/tape'
+import { buildTape, createSecretRedactor, hasForwardedSecrets } from './screenshot/tape'
 
 const REPO_ROOT = resolve(__dirname, '..')
 
@@ -267,8 +267,14 @@ async function runRecipe(recipe: ScreenshotRecipe, options: { keepTape: boolean 
     })
     writeFileSync(tapePath, tape, 'utf8')
 
+    // Capture VHS output (rather than `stdio: 'inherit'`) so we can mask
+    // forwarded secrets before surfacing it: VHS echoes every tape
+    // command it runs, including the `export OPENAI_API_KEY=…` lines, so
+    // inheriting stdout would stream raw keys/tokens to the terminal.
+    const redact = createSecretRedactor()
     const result = spawnSync('vhs', [tapePath], {
-      stdio: 'inherit',
+      stdio: ['inherit', 'pipe', 'pipe'],
+      encoding: 'utf8',
       // Run VHS from the scenario dir so `Screenshot screenshot.png`
       // lands there (VHS resolves relative paths from its cwd).
       cwd: repo.path,
@@ -277,6 +283,8 @@ async function runRecipe(recipe: ScreenshotRecipe, options: { keepTape: boolean 
         PATH: process.env.PATH,
       },
     })
+    if (result.stdout) process.stdout.write(redact(result.stdout))
+    if (result.stderr) process.stderr.write(redact(result.stderr))
 
     if (result.status !== 0) {
       throw new Error(`vhs exited with status ${result.status} for recipe ${recipe.name}`)
@@ -311,6 +319,12 @@ async function runRecipe(recipe: ScreenshotRecipe, options: { keepTape: boolean 
   } finally {
     if (!options.keepTape && existsSync(tapePath)) {
       rmSync(tapePath, { force: true })
+    } else if (options.keepTape && existsSync(tapePath) && hasForwardedSecrets()) {
+      // The tape has to embed the literal `export KEY=value` lines for
+      // the in-VHS shell to pick them up, so a kept tape contains live
+      // credentials in plaintext. Warn loudly rather than silently
+      // leaving a secret-bearing file in `.screenshots/`.
+      console.log(`  ⚠ ${tapePath} contains forwarded credentials in plaintext — delete it when done debugging.`)
     }
     if (ghMockDir) {
       rmSync(ghMockDir, { recursive: true, force: true })

--- a/bin/screenshot/tape.test.ts
+++ b/bin/screenshot/tape.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Secret redaction for the screenshot harness.
+ *
+ * The VHS tape embeds `Type "export OPENAI_API_KEY=…"` lines so the
+ * in-VHS shell can make real LLM / GitHub calls for demo captures, and
+ * VHS echoes every command it runs to stdout. `createSecretRedactor`
+ * masks those forwarded values before the driver surfaces VHS output so
+ * live keys/tokens never reach the logs.
+ */
+import { createSecretRedactor, hasForwardedSecrets } from './tape'
+
+const SECRET_KEYS = [
+  'OPENAI_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'OPENROUTER_API_KEY',
+  'GH_TOKEN',
+  'GITHUB_TOKEN',
+]
+
+describe('createSecretRedactor', () => {
+  const saved: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const key of SECRET_KEYS) {
+      saved[key] = process.env[key]
+      delete process.env[key]
+    }
+  })
+
+  afterEach(() => {
+    for (const key of SECRET_KEYS) {
+      if (saved[key] === undefined) delete process.env[key]
+      else process.env[key] = saved[key]
+    }
+  })
+
+  it('masks forwarded secret values wherever they appear', () => {
+    process.env.OPENAI_API_KEY = 'sk-proj-abcdefghijklmnop1234567890'
+    process.env.GH_TOKEN = 'gho_ABCDEFGHIJKLMNOP1234567890'
+    const redact = createSecretRedactor()
+
+    const line = `Type "export OPENAI_API_KEY=${process.env.OPENAI_API_KEY}"\nType "export GH_TOKEN=${process.env.GH_TOKEN}"`
+    const out = redact(line)
+
+    expect(out).not.toContain('sk-proj-abcdefghijklmnop1234567890')
+    expect(out).not.toContain('gho_ABCDEFGHIJKLMNOP1234567890')
+    expect(out).toContain('OPENAI_API_KEY=[redacted]')
+    expect(out).toContain('GH_TOKEN=[redacted]')
+  })
+
+  it('is an identity function when nothing sensitive is set', () => {
+    const redact = createSecretRedactor()
+    const text = 'Type "export OLLAMA_HOST=localhost"\nSleep 100ms'
+    expect(redact(text)).toBe(text)
+  })
+
+  it('leaves short, non-secret values alone (no over-masking)', () => {
+    // A short value (< 8 chars) shouldn't be treated as a secret — it
+    // would otherwise blank out incidental substrings of the log.
+    process.env.GH_TOKEN = 'short'
+    const redact = createSecretRedactor()
+    expect(redact('the short straw and a shortcut')).toBe('the short straw and a shortcut')
+  })
+
+  it('masks a value that is a substring of a longer one in full', () => {
+    process.env.OPENAI_API_KEY = 'sk-aaaaaaaa'
+    process.env.GH_TOKEN = 'sk-aaaaaaaa-extended-suffix'
+    const redact = createSecretRedactor()
+    const out = redact(`a=${process.env.GH_TOKEN} b=${process.env.OPENAI_API_KEY}`)
+    expect(out).toBe('a=[redacted] b=[redacted]')
+  })
+})
+
+describe('hasForwardedSecrets', () => {
+  const saved: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    // Clear every forwarded key — the real env (or a loaded .env) may
+    // already have some set, which would mask the assertions below.
+    for (const key of SECRET_KEYS) {
+      saved[key] = process.env[key]
+      delete process.env[key]
+    }
+  })
+
+  afterEach(() => {
+    for (const key of SECRET_KEYS) {
+      if (saved[key] === undefined) delete process.env[key]
+      else process.env[key] = saved[key]
+    }
+  })
+
+  it('is true when a forwarded key holds a secret-length value', () => {
+    process.env.OPENAI_API_KEY = 'sk-proj-longenoughvalue'
+    expect(hasForwardedSecrets()).toBe(true)
+  })
+
+  it('is false when only short values are set', () => {
+    process.env.OPENAI_API_KEY = 'tiny'
+    expect(hasForwardedSecrets()).toBe(false)
+  })
+})

--- a/bin/screenshot/tape.ts
+++ b/bin/screenshot/tape.ts
@@ -172,6 +172,21 @@ const FORWARDED_ENV_KEYS = [
   'GITHUB_TOKEN',
 ]
 
+/**
+ * The credential subset of FORWARDED_ENV_KEYS — API keys and tokens
+ * whose values must never reach the logs. Kept separate from the
+ * non-secret config keys (provider / model / host / URL) so redaction
+ * targets only real secrets and doesn't blank out, say, a model name or
+ * an Ollama host.
+ */
+const SECRET_ENV_KEYS = [
+  'OPENAI_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'OPENROUTER_API_KEY',
+  'GH_TOKEN',
+  'GITHUB_TOKEN',
+]
+
 function buildEnvExports(): string[] {
   const lines: string[] = []
   for (const key of FORWARDED_ENV_KEYS) {
@@ -185,6 +200,50 @@ function buildEnvExports(): string[] {
     }
   }
   return lines
+}
+
+// Minimum length for a forwarded value to be treated as a secret worth
+// masking. Guards against blanking out short, non-sensitive settings
+// (e.g. an `OLLAMA_HOST` of `localhost`) or empty strings — and against
+// a 1-2 char value matching incidental substrings of the log stream.
+const SECRET_MIN_LENGTH = 8
+
+/**
+ * True when any forwarded env var currently holds a secret-length value.
+ * Lets callers warn (e.g. `--keep-tape`) only when a written tape would
+ * actually contain credentials.
+ */
+export function hasForwardedSecrets(): boolean {
+  return SECRET_ENV_KEYS.some((key) => (process.env[key]?.length ?? 0) >= SECRET_MIN_LENGTH)
+}
+
+/**
+ * Build a function that masks forwarded secret values wherever they
+ * appear in a string. VHS echoes every tape command it runs — including
+ * the `Type "export OPENAI_API_KEY=…"` lines from `buildEnvExports()` —
+ * to its stdout, so without redaction the raw keys/tokens stream into
+ * the terminal and any captured logs.
+ *
+ * Snapshots `process.env` at call time, so call it after the driver has
+ * populated the env (e.g. the `gh auth token` → `GH_TOKEN` fallback).
+ * Returns an identity function when nothing sensitive is set, so callers
+ * can apply it unconditionally.
+ */
+export function createSecretRedactor(): (text: string) => string {
+  const secrets = SECRET_ENV_KEYS
+    .map((key) => process.env[key])
+    .filter((value): value is string => typeof value === 'string' && value.length >= SECRET_MIN_LENGTH)
+    // Longest first so a value that contains a shorter one as a
+    // substring is masked in full before the shorter pass runs.
+    .sort((a, b) => b.length - a.length)
+  if (secrets.length === 0) return (text) => text
+  return (text: string) => {
+    let masked = text
+    for (const secret of secrets) {
+      masked = masked.split(secret).join('[redacted]')
+    }
+    return masked
+  }
 }
 
 /**


### PR DESCRIPTION
Stops the screenshot harness from leaking forwarded API keys / tokens into the terminal and any captured logs.

## The leak

`buildEnvExports()` in `bin/screenshot/tape.ts` types `export OPENAI_API_KEY=<value>` / `export GH_TOKEN=<value>` lines into the VHS tape so the captured shell can make real LLM / GitHub calls for demo GIFs. VHS echoes **every** command it runs to its stdout, and the runner used `stdio: 'inherit'` — so those live secret values streamed straight to the terminal (observed: `Type export OPENAI_API_KEY=sk-proj-…` in plain sight).

## The fix

- **`createSecretRedactor()`** (in `tape.ts`) snapshots the current values of a `SECRET_ENV_KEYS` subset — only the actual credentials (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `GH_TOKEN`, `GITHUB_TOKEN`), **not** the non-secret config keys (model, provider, Ollama host, URLs) — and returns a function that masks each value as `[redacted]`. Values under 8 chars are ignored so it can't blank out incidental substrings; identity function when nothing sensitive is set.
- **`screenshot.ts`** now captures VHS `stdout`/`stderr` (instead of inheriting) and pipes them through the redactor before printing.
- **`hasForwardedSecrets()`** drives a new `--keep-tape` warning: a retained tape necessarily embeds the credentials in plaintext (the in-VHS shell needs them), so we flag it rather than silently leaving a secret-bearing file in `.screenshots/`.

## Verification

- New `bin/screenshot/tape.test.ts` — 6 cases: masking, identity-when-clean, no over-masking of short values, full-masking of substring-overlapping values, and `hasForwardedSecrets` thresholds.
- End-to-end: a real `--recipe ui-stash-list` capture now prints `Type export OPENAI_API_KEY=[redacted]` with **0 raw-secret occurrences** in the output.
- `tsc --noEmit` clean · `eslint src` exit 0 · full suite **212 suites, 2664 passed**.

> Note: this masks *logs*. The transient `.tape` file still contains the values while VHS runs (deleted immediately after unless `--keep-tape`), because the in-VHS shell has to read them — that exposure is now called out by the `--keep-tape` warning.
