### PR TITLE
feat(workstation): offer to switch worktrees on a checkout conflict

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -4669,4 +4669,51 @@ describe('triage filter cycling (#882 phase 6)', () => {
       expect(state.peekReturnFocus).toBeUndefined()
     })
   })
+
+  describe('worktree-checkout-conflict switch (#1175)', () => {
+    function conflictState() {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, {
+        type: 'setWorktreeCheckoutConflict',
+        value: { branch: 'feat/x', worktreePath: '/repo/.wt/foo', dirty: false },
+      })
+      state = applyLogInkAction(state, {
+        type: 'setPendingConfirmation',
+        value: 'switch-to-conflicting-worktree',
+      })
+      return state
+    }
+
+    it('y pushes a repo frame for the conflicting worktree and clears the prompt', () => {
+      const state = conflictState()
+      const events = getLogInkInputEvents(state, 'y')
+      const pushFrame = events.find(
+        (e): e is Extract<typeof e, { type: 'action' }> =>
+          e.type === 'action' && e.action.type === 'pushRepoFrame'
+      )
+      expect(pushFrame).toBeDefined()
+      expect((pushFrame as { action: { workdir?: string; label?: string } }).action.workdir).toBe('/repo/.wt/foo')
+      expect((pushFrame as { action: { workdir?: string; label?: string } }).action.label).toBe('feat/x')
+
+      const after = applyInput(state, 'y')
+      expect(after.repoStack.length).toBe(state.repoStack.length + 1)
+      expect(after.pendingConfirmationId).toBeUndefined()
+      expect(after.worktreeCheckoutConflict).toBeUndefined()
+    })
+
+    it('n cancels without switching and clears the conflict', () => {
+      const state = conflictState()
+      const after = applyInput(state, 'n')
+      expect(after.repoStack.length).toBe(state.repoStack.length)
+      expect(after.pendingConfirmationId).toBeUndefined()
+      expect(after.worktreeCheckoutConflict).toBeUndefined()
+    })
+
+    it('Esc also cancels and clears the conflict', () => {
+      const state = conflictState()
+      const after = applyInput(state, '', { escape: true })
+      expect(after.repoStack.length).toBe(state.repoStack.length)
+      expect(after.worktreeCheckoutConflict).toBeUndefined()
+    })
+  })
 })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -1169,6 +1169,26 @@ export function getLogInkInputEvents(
 
   if (state.pendingConfirmationId) {
     if (inputValue === 'y') {
+      // Worktree-conflict switch (#1175): the branch is already checked
+      // out elsewhere, so "switch" just opens that worktree as a nested
+      // repo frame (same mechanism as drilling into a submodule) — no
+      // git mutation, hence handled here rather than via the runtime.
+      if (state.pendingConfirmationId === 'switch-to-conflicting-worktree') {
+        const conflict = state.worktreeCheckoutConflict
+        if (conflict) {
+          return [
+            action({ type: 'pushRepoFrame', label: conflict.branch, workdir: conflict.worktreePath }),
+            action({ type: 'setStatus', value: `Switched to worktree ${conflict.worktreePath} (${conflict.branch})` }),
+            action({ type: 'setPendingConfirmation', value: undefined }),
+            action({ type: 'setWorktreeCheckoutConflict', value: undefined }),
+          ]
+        }
+        return [
+          action({ type: 'setPendingConfirmation', value: undefined }),
+          action({ type: 'setWorktreeCheckoutConflict', value: undefined }),
+        ]
+      }
+
       const workflowAction = getLogInkWorkflowActionById(state.pendingConfirmationId)
 
       if (workflowAction?.id === 'ai-commit-summary') {
@@ -1198,6 +1218,11 @@ export function getLogInkInputEvents(
     if (inputValue === 'n' || key.escape) {
       return [
         action({ type: 'setPendingConfirmation', value: undefined }),
+        // Drop any worktree-conflict context so the prompt doesn't
+        // linger after the user declines to switch.
+        ...(state.worktreeCheckoutConflict
+          ? [action({ type: 'setWorktreeCheckoutConflict', value: undefined })]
+          : []),
         action({ type: 'setStatus', value: 'workflow action cancelled' }),
       ]
     }

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -378,6 +378,15 @@ export type LogInkState = {
    */
   pendingConfirmationPayload?: string
   pendingMutationConfirmation?: LogInkMutationConfirmation
+  /**
+   * Set when a `checkout-branch` was rejected because the branch is
+   * already checked out in another worktree (#1175). Carries the branch
+   * the user tried to check out and the worktree holding it (+ whether
+   * that worktree is dirty) so the conflict prompt can offer to switch
+   * into it or remove it. Lives alongside a
+   * `pendingConfirmationId === 'switch-to-conflicting-worktree'`.
+   */
+  worktreeCheckoutConflict?: { branch: string; worktreePath: string; dirty: boolean }
   pendingKey?: string
   /**
    * The list item whose deletion is currently in flight, if any. Set by
@@ -868,6 +877,7 @@ export type LogInkAction =
   | { type: 'setPendingPullRequestBodyDraft'; value: boolean }
   | { type: 'setWorkflowAction'; value?: string }
   | { type: 'setPendingConfirmation'; value?: string; payload?: string }
+  | { type: 'setWorktreeCheckoutConflict'; value?: { branch: string; worktreePath: string; dirty: boolean } }
   | { type: 'setPendingMutationConfirmation'; value?: LogInkMutationConfirmation }
   | { type: 'setPendingItemAction'; value?: LogInkPendingItemAction }
   | { type: 'appendPaletteFilter'; value: string }
@@ -2203,6 +2213,8 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         pendingMutationConfirmation: action.value ? undefined : state.pendingMutationConfirmation,
         pendingKey: undefined,
       }
+    case 'setWorktreeCheckoutConflict':
+      return { ...state, worktreeCheckoutConflict: action.value, pendingKey: undefined }
     case 'setPendingMutationConfirmation':
       return {
         ...state,

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -3942,6 +3942,29 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         kind: 'warning',
       })
     }
+    // Checking out a branch that's already checked out in another
+    // worktree is rejected by git ("already checked out at <path>").
+    // Rather than dead-end on that, capture the conflict and raise a
+    // y-confirm offering to switch into that worktree — the branch IS
+    // checked out, just elsewhere (#1175).
+    if (id === 'checkout-branch' && !result?.ok && isBranchCheckedOutElsewhereError(result?.message)) {
+      const worktreePath = parseCheckedOutWorktreePath(result?.message)
+      const branchName = pendingItemAction?.id
+      if (worktreePath && branchName) {
+        const worktree = context.worktreeList?.worktrees?.find((w) => w.path === worktreePath)
+        dispatch({
+          type: 'setWorktreeCheckoutConflict',
+          value: { branch: branchName, worktreePath, dirty: worktree?.dirty ?? false },
+        })
+        dispatch({ type: 'setPendingConfirmation', value: 'switch-to-conflicting-worktree' })
+      } else {
+        dispatch({
+          type: 'setStatus',
+          value: `'${branchName ?? 'branch'}' is already checked out in another worktree.`,
+          kind: 'warning',
+        })
+      }
+    }
     // Refresh history rows AS WELL when the workflow could have
     // changed the commits the user sees (#945 follow-up). The
     // workflow IDs below all either create/rewrite local commits or

--- a/src/workstation/runtime/overlays.test.ts
+++ b/src/workstation/runtime/overlays.test.ts
@@ -98,3 +98,21 @@ describe('force-delete-branch confirmation panel', () => {
     expect(text).toContain('Destructive Git action requires confirmation')
   })
 })
+
+describe('worktree-checkout-conflict confirmation panel (#1175)', () => {
+  const components: LogInkComponents = { Box, Text }
+
+  it('names the branch and worktree, and explains what y does', () => {
+    const state = {
+      ...createLogInkState([]),
+      pendingConfirmationId: 'switch-to-conflicting-worktree',
+      worktreeCheckoutConflict: { branch: 'feat/x', worktreePath: '/repo/.wt/foo', dirty: false },
+    }
+    const text = flattenText(renderConfirmationPanel(createElement, components, state, 100, theme, false))
+    expect(text).toContain('feat/x')
+    expect(text).toContain('/repo/.wt/foo')
+    expect(text).toContain('switch')
+    // Not the generic destructive copy — switching is non-destructive.
+    expect(text).not.toContain('Destructive Git action requires confirmation')
+  })
+})

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -105,11 +105,20 @@ export function renderConfirmationPanel(
       : state.pendingMutationConfirmation === 'discard-draft'
         ? 'Quit and discard the in-progress commit draft'
         : undefined
-  const label = action?.label || mutationLabel || 'Workflow action'
+  // Worktree-conflict switch (#1175): a checkout was rejected because
+  // the branch is checked out elsewhere — name the branch + worktree so
+  // the prompt explains what "y" does (jump into that worktree).
+  const conflict = state.worktreeCheckoutConflict
+  const isWorktreeConflict = state.pendingConfirmationId === 'switch-to-conflicting-worktree'
+  const label = isWorktreeConflict && conflict
+    ? `Switch to the worktree where '${conflict.branch}' is checked out?`
+    : action?.label || mutationLabel || 'Workflow action'
   const warning = state.pendingMutationConfirmation === 'discard-draft'
     ? 'You have an unsaved commit draft. Press y to discard it and quit.'
     : state.pendingMutationConfirmation
     ? 'This discards local changes and cannot be undone by Coco.'
+    : isWorktreeConflict && conflict
+    ? `'${conflict.branch}' is checked out at ${conflict.worktreePath}. Press y to switch there, n to cancel.`
     // Second-stage confirm raised when a safe delete hit an unmerged
     // branch — name the reason so the force isn't a blind "y again".
     : state.pendingConfirmationId === 'force-delete-branch'


### PR DESCRIPTION
First of two stacked PRs handling the case where you try to check out a branch that's **already checked out in another worktree** (git rejects it with `fatal: 'X' is already checked out at '<path>'`). This PR adds the safe, non-destructive core; a follow-up adds the removal-based resolutions.

## Behavior

On a `checkout-branch` that fails with the worktree-conflict error, instead of surfacing git's raw message coco now:

1. **Captures the conflict** — the branch you tried to check out + the worktree holding it (reusing `isBranchCheckedOutElsewhereError` / `parseCheckedOutWorktreePath` from the delete-conflict work in #1171).
2. **Raises a y-confirm**: *"Switch to the worktree where 'feat/x' is checked out?"* — naming the branch and the worktree path.
3. **`y` switches** by opening that worktree as a nested **repo frame** (the same `pushRepoFrame` mechanism used to drill into a submodule), so you land on the branch where it actually lives. **`n` / `Esc`** cancels and clears the conflict.

The branch *is* checked out — just elsewhere — so "take me there" is the natural default.

## Follow-up (next PR)

The two destructive resolutions build on the `worktreeCheckoutConflict` state this PR introduces:
- remove the conflicting worktree, then check the branch out here (dirty-guarded);
- remove the worktree **and** delete the branch.

## Tests

- `inkInput.test.ts` — `y` pushes a repo frame for the conflict worktree and clears the prompt; `n` / `Esc` cancel without switching.
- `overlays.test.ts` — the confirm panel names the branch + worktree and uses non-destructive copy.
- `tsc` clean · `eslint src` exit 0 · full suite **211 suites, 2662 passed**.
