### PR TITLE
feat(workstation): add remove-worktree resolutions to the checkout conflict

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -4715,5 +4715,21 @@ describe('triage filter cycling (#882 phase 6)', () => {
       expect(after.repoStack.length).toBe(state.repoStack.length)
       expect(after.worktreeCheckoutConflict).toBeUndefined()
     })
+
+    it('r runs the remove-worktree-&-checkout workflow and closes the prompt', () => {
+      const state = conflictState()
+      const events = getLogInkInputEvents(state, 'r')
+      expect(events).toContainEqual({ type: 'runWorkflowAction', id: 'conflict-remove-worktree-checkout' })
+      // The runtime owns clearing the conflict (it reads it first), so
+      // the input layer only closes the confirm prompt.
+      const after = applyInput(state, 'r')
+      expect(after.pendingConfirmationId).toBeUndefined()
+    })
+
+    it('x runs the remove-worktree-&-branch workflow and closes the prompt', () => {
+      const state = conflictState()
+      const events = getLogInkInputEvents(state, 'x')
+      expect(events).toContainEqual({ type: 'runWorkflowAction', id: 'conflict-remove-worktree-branch' })
+    })
   })
 })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -1168,6 +1168,25 @@ export function getLogInkInputEvents(
   }
 
   if (state.pendingConfirmationId) {
+    // Worktree-conflict removal options (#1175): alongside the y-switch,
+    // `r` removes the conflicting worktree and checks the branch out
+    // here, `x` removes the worktree AND deletes the branch. Both defer
+    // to the runtime (it owns the git ops + the conflict context); the
+    // runtime clears the conflict state once it resolves.
+    if (state.pendingConfirmationId === 'switch-to-conflicting-worktree' && state.worktreeCheckoutConflict) {
+      if (inputValue === 'r') {
+        return [
+          { type: 'runWorkflowAction', id: 'conflict-remove-worktree-checkout' },
+          action({ type: 'setPendingConfirmation', value: undefined }),
+        ]
+      }
+      if (inputValue === 'x') {
+        return [
+          { type: 'runWorkflowAction', id: 'conflict-remove-worktree-branch' },
+          action({ type: 'setPendingConfirmation', value: undefined }),
+        ]
+      }
+    }
     if (inputValue === 'y') {
       // Worktree-conflict switch (#1175): the branch is already checked
       // out elsewhere, so "switch" just opens that worktree as a nested

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -3490,6 +3490,39 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
           context.branches?.localBranches || []
         )
       },
+      // Worktree-checkout-conflict resolutions (#1175). Unlike the
+      // cursor-targeted handlers above, these act on the worktree
+      // captured in `state.worktreeCheckoutConflict` (the one git named
+      // when it refused the checkout), not the worktrees-view cursor.
+      'conflict-remove-worktree-checkout': async () => {
+        const conflict = state.worktreeCheckoutConflict
+        dispatch({ type: 'setWorktreeCheckoutConflict', value: undefined })
+        if (!conflict) return { ok: false, message: 'No worktree conflict to resolve.' }
+        const worktree = context.worktreeList?.worktrees?.find((w) => w.path === conflict.worktreePath)
+        if (!worktree) return { ok: false, message: `Worktree ${conflict.worktreePath} not found.` }
+        // removeWorktree refuses a dirty / current worktree and returns
+        // a clear message — surface it rather than forcing.
+        const removed = await removeWorktree(git, worktree)
+        if (!removed.ok) return removed
+        const branch = (context.branches?.localBranches || []).find(
+          (b) => b.type === 'local' && b.shortName === conflict.branch
+        )
+        if (!branch) {
+          return { ok: true, message: `Removed worktree ${worktree.path}; branch ${conflict.branch} not found to check out.` }
+        }
+        const checkout = await checkoutBranch(git, branch)
+        return checkout.ok
+          ? { ok: true, message: `Removed worktree ${worktree.path} and checked out ${conflict.branch}` }
+          : { ok: false, message: `Removed worktree ${worktree.path}, but checkout failed: ${checkout.message}` }
+      },
+      'conflict-remove-worktree-branch': async () => {
+        const conflict = state.worktreeCheckoutConflict
+        dispatch({ type: 'setWorktreeCheckoutConflict', value: undefined })
+        if (!conflict) return { ok: false, message: 'No worktree conflict to resolve.' }
+        const worktree = context.worktreeList?.worktrees?.find((w) => w.path === conflict.worktreePath)
+        if (!worktree) return { ok: false, message: `Worktree ${conflict.worktreePath} not found.` }
+        return removeWorktreeAndBranch(git, worktree, context.branches?.localBranches || [])
+      },
       'abort-operation': async () => {
         const operation = context.operation?.operation
         if (!operation) {
@@ -3974,6 +4007,10 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     // metadata-only mutations (delete-tag, set-upstream, etc.).
     const historyMutatingIds = new Set([
       'checkout-branch',
+      // Resolving a checkout conflict changes HEAD (checkout) and/or the
+      // ref set (branch delete), so the graph needs a refresh.
+      'conflict-remove-worktree-checkout',
+      'conflict-remove-worktree-branch',
       'continue-operation',
       'pull-current-branch',
       // Fetch / pull / push bring in new commits and move
@@ -4010,7 +4047,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     // (resolvePendingItemAction → action 'checkout'), so a silent
     // stale-while-revalidate swap keeps the list readable and just
     // repaints the current-branch marker once the new context lands.
-    if (id === 'checkout-branch' && result?.ok) {
+    if ((id === 'checkout-branch' || id === 'conflict-remove-worktree-checkout') && result?.ok) {
       dispatch({ type: 'resetBranchSelection' })
       await refreshContext({ silent: true })
     } else {
@@ -4076,7 +4113,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   }, [context, dispatch, git, refreshContext, refreshHistoryRows, refreshWorktreeContext,
     state.branchSort, state.filter, state.selectedBranchIndex,
     state.selectedStashIndex, state.selectedTagIndex, state.selectedWorktreeListIndex, state.stashDiffRef,
-    state.statusFilterMask, state.tagSort])
+    state.statusFilterMask, state.tagSort, state.worktreeCheckoutConflict])
 
   // Resolve the active view's "yank target" (commit hash / branch /
   // tag / stash ref / file path) against the live filtered+sorted list,

--- a/src/workstation/runtime/overlays.test.ts
+++ b/src/workstation/runtime/overlays.test.ts
@@ -115,4 +115,25 @@ describe('worktree-checkout-conflict confirmation panel (#1175)', () => {
     // Not the generic destructive copy — switching is non-destructive.
     expect(text).not.toContain('Destructive Git action requires confirmation')
   })
+
+  it('enumerates the switch / remove keys', () => {
+    const state = {
+      ...createLogInkState([]),
+      pendingConfirmationId: 'switch-to-conflicting-worktree',
+      worktreeCheckoutConflict: { branch: 'feat/x', worktreePath: '/repo/.wt/foo', dirty: false },
+    }
+    const text = flattenText(renderConfirmationPanel(createElement, components, state, 120, theme, false))
+    expect(text).toContain('remove worktree & check out here')
+    expect(text).toContain('remove worktree & delete branch')
+  })
+
+  it('warns when the conflicting worktree is dirty', () => {
+    const state = {
+      ...createLogInkState([]),
+      pendingConfirmationId: 'switch-to-conflicting-worktree',
+      worktreeCheckoutConflict: { branch: 'feat/x', worktreePath: '/repo/.wt/foo', dirty: true },
+    }
+    const text = flattenText(renderConfirmationPanel(createElement, components, state, 120, theme, false))
+    expect(text).toContain('uncommitted changes')
+  })
 })

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -118,7 +118,7 @@ export function renderConfirmationPanel(
     : state.pendingMutationConfirmation
     ? 'This discards local changes and cannot be undone by Coco.'
     : isWorktreeConflict && conflict
-    ? `'${conflict.branch}' is checked out at ${conflict.worktreePath}. Press y to switch there, n to cancel.`
+    ? `'${conflict.branch}' is checked out at ${conflict.worktreePath}.${conflict.dirty ? ' That worktree has uncommitted changes — removal will be refused until it is clean or stashed.' : ''}`
     // Second-stage confirm raised when a safe delete hit an unmerged
     // branch — name the reason so the force isn't a blind "y again".
     : state.pendingConfirmationId === 'force-delete-branch'
@@ -138,7 +138,12 @@ export function renderConfirmationPanel(
   h(Text, undefined, truncateCells(label, width - 4)),
   h(Text, { dimColor: true }, truncateCells(warning, width - 4)),
   h(Text, undefined, ''),
-  h(Text, undefined, 'Press y to confirm or n/Esc to cancel.'))
+  h(Text, undefined, truncateCells(
+    isWorktreeConflict
+      ? 'y switch · r remove worktree & check out here · x remove worktree & delete branch · n/Esc cancel'
+      : 'Press y to confirm or n/Esc to cancel.',
+    width - 4,
+  )))
 }
 
 /**


### PR DESCRIPTION
Adds the two destructive resolutions to the checkout-conflict prompt introduced in #1175 (now merged).

_(Supersedes #1176, which GitHub auto-closed when its stacked base branch was deleted on merge of #1175. Rebased onto `main`; this PR is just the removal commit.)_

## Behavior

When a checkout is rejected because the branch is checked out in another worktree, the confirm prompt offers:

- **`y` switch** — open that worktree (from #1175).
- **`r` remove worktree & check out here** — remove the conflicting worktree, then check the branch out in the current one. Refused with git's clear message if that worktree is **dirty** or current; the prompt also **warns up front** when it's dirty.
- **`x` remove worktree & delete branch** — `removeWorktreeAndBranch`, the full wind-down.
- **`n` / `Esc`** cancel.

Both removal paths target the worktree git named in the rejection (not the worktrees-view cursor), run through the existing workflow runner (history + context refresh; branch-selection reset on the checkout path), and clear the conflict once resolved. Dirty/current guards are inherited from the existing helpers.

## Tests

- `inkInput.test.ts` — `r` / `x` emit the right `runWorkflowAction` and close the prompt.
- `overlays.test.ts` — the prompt enumerates the switch/remove keys and warns when the worktree is dirty.
- `tsc` clean · `eslint src` exit 0 · full suite **211 suites, 2666 passed**.
