### PR TITLE
feat(screenshot): add worktree-aware checkout-conflict demo recipe

### DIFF
--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -1387,6 +1387,34 @@ export const RECIPES: ScreenshotRecipe[] = [
     ],
   },
   {
+    name: 'demo-checkout-worktree-conflict',
+    description: 'Worktree-aware checkout: enter on a branch checked out in another worktree raises a prompt — switch there (y), remove & checkout here (r), or remove & delete branch (x)',
+    // multiple-worktrees: main here, feat/alpha · feat/beta · hotfix/urgent
+    // each checked out in their own linked worktrees — so a checkout from
+    // the branches view hits the "already checked out" conflict.
+    scenario: 'multiple-worktrees',
+    command: 'ui',
+    emitGif: true,
+    dimensions: { cols: 150, rows: 38 },
+    actions: [
+      { kind: 'sleep', ms: 4000 },
+      // Branches view, then cursor onto a worktree-held branch (row 1 —
+      // main is pinned at row 0) and press Enter to attempt the checkout.
+      { kind: 'type', text: 'gb' },
+      { kind: 'sleep', ms: 1200 },
+      { kind: 'key', key: 'Down' },
+      { kind: 'sleep', ms: 800 },
+      { kind: 'key', key: 'Enter' },
+      // The conflict prompt: y switch · r remove & checkout here · x
+      // remove & delete branch · n cancel.
+      { kind: 'sleep', ms: 2400 },
+      // y switches into that worktree (opened as a nested repo frame),
+      // landing on the branch where it actually lives.
+      { kind: 'type', text: 'y' },
+      { kind: 'sleep', ms: 2400 },
+    ],
+  },
+  {
     name: 'ui-which-key',
     description: 'Which-key chord overlay — press g to see the live menu of g-chord view selectors',
     scenario: 'feature-pr-ready',

--- a/bin/syncScreenshots.ts
+++ b/bin/syncScreenshots.ts
@@ -112,6 +112,8 @@ const SITE_RECIPES = [
   'ui-staging-hunks',
   // Stash workflow (rich rows + rename)
   'demo-stash-workflow',
+  // Worktree-aware checkout conflict (switch / remove+checkout / remove+branch)
+  'demo-checkout-worktree-conflict',
   // Motion demos for features that only had static shots
   'demo-single-pane',
   'demo-conflicts',
@@ -238,6 +240,7 @@ const FILENAME_MAP: Record<string, string[]> = {
   'demo-workstation-using': ['demo-workstation-using.gif'],
   'demo-staging-hunks': ['demo-staging-hunks.gif'],
   'demo-stash-workflow': ['demo-stash-workflow.gif'],
+  'demo-checkout-worktree-conflict': ['demo-checkout-worktree-conflict.gif'],
   'demo-single-pane': ['demo-single-pane.gif'],
   'demo-conflicts': ['demo-conflicts.gif'],
   'demo-bisect': ['demo-bisect.gif'],


### PR DESCRIPTION
Adds a GIF recipe capturing the new worktree-aware checkout conflict (shipped in #1175 / #1177).

Using the `multiple-worktrees` scenario (`main` here; `feat/alpha` · `feat/beta` · `hotfix/urgent` each in their own linked worktree), the demo opens the branches view, presses Enter on a worktree-held branch to hit the `already checked out at <path>` conflict, then `y` to switch into that worktree (opened as a nested repo frame). Wired into `syncScreenshots` → `demo-checkout-worktree-conflict.gif`.

`tsc` clean · screenshot tests pass · GIF verified (510 KB; final frame lands in the feat/alpha worktree frame, confirming the switch).