### PR TITLE
fix(workstation): track the current staging hunk by viewport position

### DIFF
--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -2198,6 +2198,7 @@ export function getLogInkInputEvents(
         type: 'pageWorktreeDiff',
         delta: -1,
         lineCount: context.worktreeDiffLineCount,
+        hunkOffsets: context.worktreeHunkOffsets,
       })]
     }
 
@@ -2341,6 +2342,7 @@ export function getLogInkInputEvents(
         type: 'pageWorktreeDiff',
         delta: 1,
         lineCount: context.worktreeDiffLineCount,
+        hunkOffsets: context.worktreeHunkOffsets,
       })]
     }
 
@@ -2413,6 +2415,7 @@ export function getLogInkInputEvents(
         type: 'pageWorktreeDiff',
         delta: -8,
         lineCount: context.worktreeDiffLineCount,
+        hunkOffsets: context.worktreeHunkOffsets,
       })]
     }
 
@@ -2441,6 +2444,7 @@ export function getLogInkInputEvents(
         type: 'pageWorktreeDiff',
         delta: 8,
         lineCount: context.worktreeDiffLineCount,
+        hunkOffsets: context.worktreeHunkOffsets,
       })]
     }
 

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -9,6 +9,7 @@ import {
     getLogInkRepoStackLabels,
     getLogInkSidebarTabs,
     getSelectedInkCommit,
+    hunkIndexAtOffset,
     intentGoHome,
     intentOpenComposeForFile,
     intentOpenDiffForCommit,
@@ -2140,5 +2141,51 @@ describe('sidebar peek (#1135 v2)', () => {
 
     state = applyLogInkAction(state, { type: 'focusNext' })
     expect(state.peekReturnFocus).toBeUndefined()
+  })
+})
+
+describe('worktree hunk navigation — viewport-derived current hunk (#1179)', () => {
+  // @@ headers at line offsets 0, 10, 25, 40 → four hunks.
+  const offsets = [0, 10, 25, 40]
+
+  describe('hunkIndexAtOffset', () => {
+    it('returns the last hunk whose header is at or above the viewport top', () => {
+      expect(hunkIndexAtOffset(0, offsets)).toBe(0)
+      expect(hunkIndexAtOffset(5, offsets)).toBe(0)   // inside hunk 1
+      expect(hunkIndexAtOffset(10, offsets)).toBe(1)  // on hunk 2 header
+      expect(hunkIndexAtOffset(30, offsets)).toBe(2)  // inside hunk 3
+      expect(hunkIndexAtOffset(50, offsets)).toBe(3)  // past the last header
+    })
+
+    it('defaults to 0 with no hunks', () => {
+      expect(hunkIndexAtOffset(99, [])).toBe(0)
+    })
+  })
+
+  it('page-scrolling keeps the selected hunk in sync with the offset', () => {
+    let state = createLogInkState([])
+    // Scroll a full page down past hunk boundaries.
+    state = applyLogInkAction(state, { type: 'pageWorktreeDiff', delta: 30, lineCount: 53, hunkOffsets: offsets })
+    expect(state.worktreeDiffOffset).toBe(30)
+    // Old behavior left this stuck at 0 ("Hunk 1/4"); now it tracks the view.
+    expect(state.selectedWorktreeHunkIndex).toBe(2)
+  })
+
+  it('jumping hunks derives the index from where it lands (not a fragile indexOf)', () => {
+    let state = createLogInkState([])
+    state = applyLogInkAction(state, { type: 'jumpWorktreeHunk', delta: 1, hunkOffsets: offsets })
+    expect(state.worktreeDiffOffset).toBe(10)
+    expect(state.selectedWorktreeHunkIndex).toBe(1)
+    state = applyLogInkAction(state, { type: 'jumpWorktreeHunk', delta: 1, hunkOffsets: offsets })
+    expect(state.worktreeDiffOffset).toBe(25)
+    expect(state.selectedWorktreeHunkIndex).toBe(2)
+  })
+
+  it('page-scroll without hunk offsets leaves the selected hunk untouched', () => {
+    let state = createLogInkState([])
+    state = applyLogInkAction(state, { type: 'jumpWorktreeHunk', delta: 1, hunkOffsets: offsets })
+    expect(state.selectedWorktreeHunkIndex).toBe(1)
+    state = applyLogInkAction(state, { type: 'pageWorktreeDiff', delta: 5, lineCount: 53 })
+    expect(state.selectedWorktreeHunkIndex).toBe(1)
   })
 })

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -846,7 +846,7 @@ export type LogInkAction =
   | { type: 'nextSidebarTab' }
   | { type: 'page'; delta: number }
   | { type: 'pageDetailPreview'; delta: number; previewLineCount: number }
-  | { type: 'pageWorktreeDiff'; delta: number; lineCount: number }
+  | { type: 'pageWorktreeDiff'; delta: number; lineCount: number; hunkOffsets?: number[] }
   | { type: 'previousSidebarTab' }
   | { type: 'setFilter'; value: string; promotedSelections?: PromotedSelectionsSnapshot }
   | { type: 'setActiveView'; value: LogInkView }
@@ -1397,10 +1397,28 @@ function nextHunkOffset(currentOffset: number, hunkOffsets: number[], delta: num
   return previousOffset === undefined ? currentOffset : previousOffset
 }
 
-function nextHunkIndex(currentOffset: number, hunkOffsets: number[], delta: number): number {
-  const offset = nextHunkOffset(currentOffset, hunkOffsets, delta)
-
-  return Math.max(0, hunkOffsets.indexOf(offset))
+/**
+ * Which hunk the viewport is currently showing — the index of the last
+ * hunk whose `@@` header offset is at or above the viewport top
+ * (`offset`). This is the single source of truth for the worktree
+ * staging diff's "current hunk" (#1179): deriving it from the scroll
+ * position keeps the header, the in-body highlight, and `space`/`z`
+ * (stage / revert) all pointed at the hunk you're actually looking at,
+ * whether you got there by hunk-jump (↑/↓) or page-scroll (PgUp/PgDn).
+ * The old `indexOf(landedOffset)` approach reset to hunk 0 whenever the
+ * offset wasn't exactly on a boundary, and page-scroll never updated it
+ * at all — so the indicator stuck at "1/N".
+ */
+export function hunkIndexAtOffset(offset: number, hunkOffsets: number[]): number {
+  let index = 0
+  for (let i = 0; i < hunkOffsets.length; i += 1) {
+    if (hunkOffsets[i] <= offset) {
+      index = i
+    } else {
+      break
+    }
+  }
+  return index
 }
 
 export function getLogInkSidebarTabs(): LogInkSidebarTab[] {
@@ -1944,27 +1962,35 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         ),
         pendingKey: undefined,
       }
-    case 'pageWorktreeDiff':
+    case 'pageWorktreeDiff': {
+      const worktreeDiffOffset = clampIndex(state.worktreeDiffOffset + action.delta, action.lineCount)
       return {
         ...state,
-        worktreeDiffOffset: clampIndex(state.worktreeDiffOffset + action.delta, action.lineCount),
+        worktreeDiffOffset,
+        // Keep the staging hunk in sync with the scroll position so the
+        // header / highlight / stage target track what's on screen even
+        // when paging past hunk boundaries (#1179).
+        selectedWorktreeHunkIndex: action.hunkOffsets?.length
+          ? hunkIndexAtOffset(worktreeDiffOffset, action.hunkOffsets)
+          : state.selectedWorktreeHunkIndex,
         pendingKey: undefined,
       }
-    case 'jumpWorktreeHunk':
+    }
+    case 'jumpWorktreeHunk': {
+      const worktreeDiffOffset = nextHunkOffset(
+        state.worktreeDiffOffset,
+        action.hunkOffsets,
+        action.delta
+      )
       return {
         ...state,
-        worktreeDiffOffset: nextHunkOffset(
-          state.worktreeDiffOffset,
-          action.hunkOffsets,
-          action.delta
-        ),
-        selectedWorktreeHunkIndex: nextHunkIndex(
-          state.worktreeDiffOffset,
-          action.hunkOffsets,
-          action.delta
-        ),
+        worktreeDiffOffset,
+        // Derive the current hunk from where we landed — robust whether
+        // or not the offset sits exactly on a boundary (#1179).
+        selectedWorktreeHunkIndex: hunkIndexAtOffset(worktreeDiffOffset, action.hunkOffsets),
         pendingKey: undefined,
       }
+    }
     case 'jumpCommitDiffHunk':
       return {
         ...state,


### PR DESCRIPTION
Fixes the worktree-staging diff where the `Hunk N/M` indicator got stuck at `1/N` and the active-hunk highlight didn't track what you were looking at.

## Root cause

The "current hunk" (`selectedWorktreeHunkIndex`) drives the header, the in-body `▎` highlight, and the `space` / `z` (stage / revert) target. It was separate state that:
- only updated on hunk-jump, via `indexOf(landedOffset)` — which returns `-1` (→ clamped to **hunk 0 / "1/N"**) whenever the scroll offset isn't exactly on a hunk boundary; and
- was **never updated by page-scroll** (PgUp/PgDn).

So scrolling to the bottom of a file left the header reading `1/4` with the `▎` bar parked off-screen on hunk 1.

## Fix (viewport-derived, per the agreed model)

- New `hunkIndexAtOffset(offset, hunkOffsets)` — the last hunk whose `@@` header is at or above the viewport top — is the single source of truth.
- `jumpWorktreeHunk` and `pageWorktreeDiff` both recompute the index from the resulting scroll offset; page-scroll dispatches now pass the hunk offsets through.
- Header, highlight, and stage/revert all follow what's on screen, whether you move by hunk (`↑/↓`) or by page (PgUp/PgDn). Removed the now-dead `nextHunkIndex`.

## Tests

- `hunkIndexAtOffset` unit cases (inside hunk / on header / past last / empty).
- Reducer: page-scroll keeps the selected hunk in sync with the offset (the stuck-at-0 regression); hunk-jump derives the index from where it lands; page-scroll with no offsets leaves the selection untouched.
- `tsc` clean · `eslint src` exit 0 · full suite **212 suites, 2677 passed**.

_(First of two from this round of feedback; the commit-split "leave unclaimed files staged" change follows separately.)_
