### PR TITLE
feat(commit-split): leave unplaceable files uncommitted instead of a catch-all

### DIFF
--- a/src/commands/commands.integration.test.ts
+++ b/src/commands/commands.integration.test.ts
@@ -412,6 +412,65 @@ describe('command integration with temp git repos', () => {
     expect(status.files).toHaveLength(0)
   })
 
+  it('leaves files the plan omitted uncommitted in the worktree (#1180)', async () => {
+    mockLoadConfig.mockReturnValue(createConfig({
+      mode: 'stdout',
+    }))
+    // The model groups README.md but omits scratch.md entirely.
+    // rescueMissingFiles tags scratch.md as an `unclaimed` group; the
+    // apply must commit README.md and leave scratch.md behind.
+    mockExecuteChainWithSchema.mockResolvedValueOnce({
+      groups: [
+        {
+          title: 'docs: update readme',
+          body: 'Document the temp repo.',
+          files: ['README.md'],
+        },
+      ],
+    })
+
+    await repo.writeFile('.gitkeep', '\n')
+    await repo.commitAll('chore: initial commit')
+    await repo.writeFile('README.md', '# Temp repo\n')
+    await repo.writeFile('scratch.md', 'scratch notes\n')
+    await repo.git.add(['README.md', 'scratch.md'])
+
+    await commitHandler({
+      $0: 'coco',
+      _: ['commit', 'split'],
+      interactive: false,
+      openInEditor: false,
+      ignoredFiles: [],
+      ignoredExtensions: [],
+      withPreviousCommits: 0,
+      conventional: false,
+      includeBranchName: false,
+      noDiff: false,
+      noVerify: true,
+      split: true,
+      plan: false,
+      apply: true,
+      verbose: false,
+      version: false,
+      help: false,
+    } as Arguments<CommitOptions>, createLogger())
+
+    const log = await repo.git.log()
+    const status = await repo.git.status()
+
+    // Exactly one commit landed — the confident README.md group; the
+    // unclaimed scratch.md group was NOT committed.
+    expect(stdout).toContain('Created 1 split commit(s).')
+    expect(log.all[0].message).toBe('docs: update readme')
+    expect(log.all.map((commit) => commit.message)).not.toContain('Left for you — not committed')
+    // scratch.md survives in the worktree for the user to handle.
+    expect(status.files.map((file) => file.path)).toContain('scratch.md')
+    // The README.md commit doesn't sneak scratch.md in.
+    const headFiles = (await repo.git.raw(['show', '--name-only', '--pretty=format:', 'HEAD'])).trim()
+    expect(headFiles).toContain('README.md')
+    expect(headFiles).not.toContain('scratch.md')
+  })
+
   it('applies a hunk-level commit split plan within a single file', async () => {
     mockLoadConfig.mockReturnValue(createConfig({
       mode: 'stdout',

--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -365,6 +365,15 @@ export async function applyCommitSplitPlan({
   // "git commit with nothing staged" failure mode mid-loop after
   // the up-front `git reset` has already wiped the index.
   const applicableGroups = plan.groups.filter((group) => {
+    // `unclaimed` groups are intentionally NOT committed (#1180): they
+    // hold the files the plan couldn't confidently place. The up-front
+    // `git reset` below unstages everything, and since these never get
+    // re-added they simply stay in the worktree for the user to handle.
+    // They still count as "claimed" for validatePlanForStagedFiles, so
+    // that check (run above) passes.
+    if (group.unclaimed) {
+      return false
+    }
     const fileCount = (group.files || []).length
     const hunkCount = (group.hunks || []).length
     return fileCount + hunkCount > 0

--- a/src/commands/commit/splitPlanGenerator.test.ts
+++ b/src/commands/commit/splitPlanGenerator.test.ts
@@ -198,7 +198,9 @@ describe('generateValidatedCommitSplitPlan', () => {
     expect(result.attempts).toBe(1)
     expect(result.plan.groups).toHaveLength(2)
     expect(result.plan.groups[1].files).toEqual(['b.ts'])
-    expect(result.plan.groups[1].title).toContain('misc')
+    // The recovered files are tagged `unclaimed` — the apply leaves them
+    // in the worktree rather than committing a catch-all group (#1180).
+    expect(result.plan.groups[1].unclaimed).toBe(true)
     expect(mockExecuteChainWithSchema).toHaveBeenCalledTimes(1)
   })
 

--- a/src/commands/commit/splitPlanTypes.ts
+++ b/src/commands/commit/splitPlanTypes.ts
@@ -19,6 +19,14 @@ export const CommitSplitPlanSchema = z.object({
           // that.)
           files: z.array(z.string()).optional(),
           hunks: z.array(z.string()).optional(),
+          // Internal flag (not emitted by the model). Set by
+          // `rescueMissingFiles` on the catch-all group of files the
+          // plan didn't confidently place: the apply step skips
+          // committing these, leaving them in the worktree for the user
+          // to handle, and the review overlay renders them as a "will
+          // stay — not committed" note rather than a numbered commit
+          // (#1180).
+          unclaimed: z.boolean().optional(),
         })
         .refine(
           (group) =>

--- a/src/commands/commit/splitPlanValidation.test.ts
+++ b/src/commands/commit/splitPlanValidation.test.ts
@@ -464,7 +464,9 @@ describe('splitPlanValidation', () => {
       const rescued = rescueMissingFiles(plan, staged, buildHunkInventory({}))
 
       expect(rescued.groups).toHaveLength(2)
-      expect(rescued.groups[1].title).toBe('chore: misc unclaimed changes')
+      // Tagged `unclaimed` so the apply skips committing it and the
+      // files are left in the worktree for the user (#1180).
+      expect(rescued.groups[1].unclaimed).toBe(true)
       expect(rescued.groups[1].files).toEqual(['scratch.md'])
       expect(rescued.groups[1].hunks).toEqual([])
       // First group passes through unchanged.

--- a/src/commands/commit/splitPlanValidation.ts
+++ b/src/commands/commit/splitPlanValidation.ts
@@ -379,11 +379,16 @@ export function rescueMissingFiles(
     groups: [
       ...plan.groups,
       {
-        title: 'chore: misc unclaimed changes',
-        body: 'Files the split plan did not assign to any other commit. Review and re-roll (`r`) if these belong in a specific commit.',
-        rationale: 'Recovered by validator rescue — model omitted these from every group.',
+        // Tagged `unclaimed`: the apply step skips committing this group
+        // (the files are left in the worktree), and the review overlay
+        // renders it as a "will stay — not committed" note rather than a
+        // numbered commit. The confident commits land; these come back
+        // to you on the status screen to handle (#1180).
+        title: 'Left for you — not committed',
+        body: `${missing.length} file${missing.length === 1 ? '' : 's'} the split couldn't confidently place. They stay in your worktree (uncommitted) — you'll land on the status screen to handle them. Re-roll (\`r\`) if they belong in a specific commit.`,
         files: missing,
         hunks: [],
+        unclaimed: true,
       },
     ],
   }

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -2975,9 +2975,20 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     // navigateHome nukes the rest of the stack so `<` after apply
     // doesn't walk back into the now-empty compose / status state
     // the user just left behind.
+    // Did the plan leave files for the user (the `unclaimed` group the
+    // split couldn't confidently place)? They're now sitting unstaged in
+    // the worktree, so land on status — not history — so the user sees
+    // and handles them, rather than dropping them on a clean-looking
+    // history view (#1180).
+    const unclaimedGroup = splitPlan.plan.groups.find((group) => group.unclaimed)
+    const unclaimedFileCount = unclaimedGroup?.files?.length ?? 0
+
     dispatch({ type: 'clearSplitPlan' })
     dispatch({ type: 'commitCompose', action: { type: 'reset' } })
     dispatch({ type: 'navigateHome' })
+    if (unclaimedFileCount > 0) {
+      dispatch({ type: 'pushView', value: 'status' })
+    }
 
     // Refresh BEFORE setting the final status so we can peek at the
     // post-apply worktree state and craft a directive next-step hint
@@ -3037,12 +3048,17 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       untracked,
       result.fallback ? { reason: result.fallback.reason } : undefined
     )
+    // Name the files the split deliberately left behind so the jump to
+    // status reads as intentional, not a surprise (#1180).
+    const unclaimedNote = unclaimedFileCount > 0
+      ? ` · ${unclaimedFileCount} file${unclaimedFileCount === 1 ? '' : 's'} left for you on status`
+      : ''
     // Fallback path uses 'info' kind — apply technically succeeded
     // but the user should know it landed as a single combined commit
     // rather than a real LLM-driven multi-group split.
     dispatch({
       type: 'setStatus',
-      value: successMessage,
+      value: `${successMessage}${unclaimedNote}`,
       kind: result.fallback ? 'info' : 'success',
     })
   }, [dispatch, git, refreshContext, refreshHistoryRows, refreshWorktreeContext, state.splitPlan])

--- a/src/workstation/runtime/overlays.test.ts
+++ b/src/workstation/runtime/overlays.test.ts
@@ -10,7 +10,7 @@ import { createLogInkContextStatus } from '../chrome/context'
 import { createLogInkTheme } from '../chrome/theme'
 import { createLogInkState } from '../../commands/log/inkViewModel'
 import { renderDetailPanel } from './detailPanel'
-import { renderConfirmationPanel } from './overlays'
+import { renderConfirmationPanel, renderSplitPlanOverlay } from './overlays'
 import type { LogInkComponents, LogInkContext } from './types'
 
 type StubProps = Record<string, unknown>
@@ -96,6 +96,41 @@ describe('force-delete-branch confirmation panel', () => {
     const state = { ...createLogInkState([]), pendingConfirmationId: 'delete-branch' }
     const text = flattenText(renderConfirmationPanel(createElement, components, state, 60, theme, false))
     expect(text).toContain('Destructive Git action requires confirmation')
+  })
+})
+
+describe('split-plan overlay — unclaimed group (#1180)', () => {
+  const components: LogInkComponents = { Box, Text }
+
+  function stateWithPlan() {
+    return {
+      ...createLogInkState([]),
+      splitPlan: {
+        status: 'ready' as const,
+        scrollOffset: 0,
+        plan: {
+          groups: [
+            { title: 'feat: real work', files: ['src/a.ts'], hunks: [] },
+            { title: 'Left for you — not committed', files: ['scratch.md'], hunks: [], unclaimed: true },
+          ],
+        },
+      },
+    }
+  }
+
+  it('renders the unclaimed group as a "stays in your worktree" note, not a numbered commit', () => {
+    const text = flattenText(renderSplitPlanOverlay(createElement, components, stateWithPlan(), 100, 40, theme, false))
+    // The confident group is commit #1…
+    expect(text).toContain('1. feat: real work')
+    // …and the unclaimed group is NOT numbered as commit #2.
+    expect(text).not.toContain('2. Left for you')
+    expect(text).toContain('stays in your worktree — not committed')
+  })
+
+  it('counts only committed groups in the header', () => {
+    const text = flattenText(renderSplitPlanOverlay(createElement, components, stateWithPlan(), 100, 40, theme, false))
+    expect(text).toContain('1 commit(s)')
+    expect(text).toContain('1 set stays staged')
   })
 })
 

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -697,9 +697,19 @@ export function renderSplitPlanOverlay(
       h(Text, { dimColor: true }, 'No plan data available.'))
   }
 
+  // Committed groups are numbered 1..N; an `unclaimed` group (the files
+  // the split couldn't place) renders as a distinct "will stay" note
+  // rather than a phantom commit (#1180).
+  const committedGroups = plan.groups.filter((group) => !group.unclaimed)
   const lines: string[] = []
-  plan.groups.forEach((group, index) => {
-    lines.push(`▎ ${index + 1}. ${group.title}`)
+  let commitNumber = 0
+  plan.groups.forEach((group) => {
+    if (group.unclaimed) {
+      lines.push(`⚠ ${group.title}  (stays in your worktree — not committed)`)
+    } else {
+      commitNumber += 1
+      lines.push(`▎ ${commitNumber}. ${group.title}`)
+    }
     if (group.body) {
       group.body.split('\n').forEach((bodyLine) => lines.push(`  ${bodyLine}`))
     }
@@ -726,9 +736,10 @@ export function renderSplitPlanOverlay(
   const scrollOffset = Math.min(overlay.scrollOffset, Math.max(0, totalLines - 1))
   const visible = lines.slice(scrollOffset, scrollOffset + listRows)
 
+  const unclaimedCount = plan.groups.length - committedGroups.length
   const headerRight = overlay.status === 'applying'
     ? `${spinner} applying…`
-    : `${plan.groups.length} commit(s) · ${scrollOffset + 1}–${Math.min(totalLines, scrollOffset + listRows)} / ${totalLines}`
+    : `${committedGroups.length} commit(s)${unclaimedCount ? ' · 1 set stays staged' : ''} · ${scrollOffset + 1}–${Math.min(totalLines, scrollOffset + listRows)} / ${totalLines}`
 
   // Apply errors get the full available width — long validator
   // messages (the failure path that surfaced in PR #916 testing was


### PR DESCRIPTION
Second of two from this round of feedback (the first, #1179, fixes hunk navigation).

When the split planner can't confidently place every staged file, it used to append a catch-all **"chore: misc unclaimed changes"** commit so the plan validated — burying files you never meant to group into a junk commit.

## New behavior (per the agreed flow)

Those files are now left **uncommitted in your worktree**, and only the confident commits land:

- `rescueMissingFiles` tags the leftover group `unclaimed` (so the validator still sees full file coverage — no contract break).
- The apply step **skips committing** the `unclaimed` group; the up-front `git reset` leaves those files in the worktree.
- The review overlay renders the set as a **"stays in your worktree — not committed"** note rather than a numbered commit, and the header counts only real commits (`N commit(s) · 1 set stays staged`).
- After applying, you're routed to the **status screen** (with a `N files left for you` hint) to handle them — instead of a clean-looking history view.

## Tests

- `rescueMissingFiles` tags `unclaimed`; the generator regression asserts the flag.
- **Integration test** (real temp repo + mocked LLM): the model omits a file → exactly the confident commit lands, the omitted file is in no commit and survives in the worktree.
- Overlay render: the unclaimed group shows the "stays staged" treatment and the commit count excludes it.
- `tsc` clean · `eslint src` exit 0 · full suite **212 suites, 2679 passed** · integration suite green.
