### PR TITLE
refactor(workstation): generalize confirmations into a reusable choice prompt

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -4670,7 +4670,7 @@ describe('triage filter cycling (#882 phase 6)', () => {
     })
   })
 
-  describe('worktree-checkout-conflict switch (#1175)', () => {
+  describe('worktree-checkout-conflict choice prompt (#1175, #1181)', () => {
     function conflictState() {
       let state = createLogInkState(rows)
       state = applyLogInkAction(state, {
@@ -4678,13 +4678,21 @@ describe('triage filter cycling (#882 phase 6)', () => {
         value: { branch: 'feat/x', worktreePath: '/repo/.wt/foo', dirty: false },
       })
       state = applyLogInkAction(state, {
-        type: 'setPendingConfirmation',
-        value: 'switch-to-conflicting-worktree',
+        type: 'setPendingChoice',
+        value: {
+          id: 'worktree-checkout-conflict',
+          title: "'feat/x' is checked out in another worktree",
+          options: [
+            { key: 'y', label: 'Switch to that worktree', intent: 'switch-worktree' },
+            { key: 'r', label: 'Remove worktree & check out here', workflowId: 'conflict-remove-worktree-checkout', destructive: true },
+            { key: 'x', label: 'Remove worktree & delete branch', workflowId: 'conflict-remove-worktree-branch', destructive: true },
+          ],
+        },
       })
       return state
     }
 
-    it('y pushes a repo frame for the conflicting worktree and clears the prompt', () => {
+    it('y (switch intent) pushes a repo frame for the conflicting worktree and clears the prompt', () => {
       const state = conflictState()
       const events = getLogInkInputEvents(state, 'y')
       const pushFrame = events.find(
@@ -4697,7 +4705,7 @@ describe('triage filter cycling (#882 phase 6)', () => {
 
       const after = applyInput(state, 'y')
       expect(after.repoStack.length).toBe(state.repoStack.length + 1)
-      expect(after.pendingConfirmationId).toBeUndefined()
+      expect(after.pendingChoice).toBeUndefined()
       expect(after.worktreeCheckoutConflict).toBeUndefined()
     })
 
@@ -4705,7 +4713,7 @@ describe('triage filter cycling (#882 phase 6)', () => {
       const state = conflictState()
       const after = applyInput(state, 'n')
       expect(after.repoStack.length).toBe(state.repoStack.length)
-      expect(after.pendingConfirmationId).toBeUndefined()
+      expect(after.pendingChoice).toBeUndefined()
       expect(after.worktreeCheckoutConflict).toBeUndefined()
     })
 
@@ -4713,6 +4721,7 @@ describe('triage filter cycling (#882 phase 6)', () => {
       const state = conflictState()
       const after = applyInput(state, '', { escape: true })
       expect(after.repoStack.length).toBe(state.repoStack.length)
+      expect(after.pendingChoice).toBeUndefined()
       expect(after.worktreeCheckoutConflict).toBeUndefined()
     })
 
@@ -4721,15 +4730,23 @@ describe('triage filter cycling (#882 phase 6)', () => {
       const events = getLogInkInputEvents(state, 'r')
       expect(events).toContainEqual({ type: 'runWorkflowAction', id: 'conflict-remove-worktree-checkout' })
       // The runtime owns clearing the conflict (it reads it first), so
-      // the input layer only closes the confirm prompt.
+      // the input layer only closes the choice prompt.
       const after = applyInput(state, 'r')
-      expect(after.pendingConfirmationId).toBeUndefined()
+      expect(after.pendingChoice).toBeUndefined()
     })
 
     it('x runs the remove-worktree-&-branch workflow and closes the prompt', () => {
       const state = conflictState()
       const events = getLogInkInputEvents(state, 'x')
       expect(events).toContainEqual({ type: 'runWorkflowAction', id: 'conflict-remove-worktree-branch' })
+    })
+
+    it('ignores keys that match no option', () => {
+      const state = conflictState()
+      const after = applyInput(state, 'q')
+      // Still showing the prompt; nothing fired.
+      expect(after.pendingChoice).toBeDefined()
+      expect(after.repoStack.length).toBe(state.repoStack.length)
     })
   })
 })

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -1167,47 +1167,49 @@ export function getLogInkInputEvents(
     return []
   }
 
-  if (state.pendingConfirmationId) {
-    // Worktree-conflict removal options (#1175): alongside the y-switch,
-    // `r` removes the conflicting worktree and checks the branch out
-    // here, `x` removes the worktree AND deletes the branch. Both defer
-    // to the runtime (it owns the git ops + the conflict context); the
-    // runtime clears the conflict state once it resolves.
-    if (state.pendingConfirmationId === 'switch-to-conflicting-worktree' && state.worktreeCheckoutConflict) {
-      if (inputValue === 'r') {
-        return [
-          { type: 'runWorkflowAction', id: 'conflict-remove-worktree-checkout' },
-          action({ type: 'setPendingConfirmation', value: undefined }),
-        ]
-      }
-      if (inputValue === 'x') {
-        return [
-          { type: 'runWorkflowAction', id: 'conflict-remove-worktree-branch' },
-          action({ type: 'setPendingConfirmation', value: undefined }),
-        ]
-      }
-    }
-    if (inputValue === 'y') {
-      // Worktree-conflict switch (#1175): the branch is already checked
-      // out elsewhere, so "switch" just opens that worktree as a nested
-      // repo frame (same mechanism as drilling into a submodule) — no
-      // git mutation, hence handled here rather than via the runtime.
-      if (state.pendingConfirmationId === 'switch-to-conflicting-worktree') {
+  // Multi-option prompt (#1181) — the n-way generalization of the y/n
+  // confirmation. Match the keypress against the prompt's options; each
+  // either runs a workflow or fires a built-in navigation intent.
+  if (state.pendingChoice) {
+    const option = state.pendingChoice.options.find((opt) => opt.key === inputValue)
+    if (option) {
+      // `switch-worktree` is pure navigation — open the worktree as a
+      // nested repo frame. Handled here rather than via the workflow
+      // runner, whose post-action context refresh would mis-target the
+      // frame we just pushed.
+      if (option.intent === 'switch-worktree' && state.worktreeCheckoutConflict) {
         const conflict = state.worktreeCheckoutConflict
-        if (conflict) {
-          return [
-            action({ type: 'pushRepoFrame', label: conflict.branch, workdir: conflict.worktreePath }),
-            action({ type: 'setStatus', value: `Switched to worktree ${conflict.worktreePath} (${conflict.branch})` }),
-            action({ type: 'setPendingConfirmation', value: undefined }),
-            action({ type: 'setWorktreeCheckoutConflict', value: undefined }),
-          ]
-        }
         return [
-          action({ type: 'setPendingConfirmation', value: undefined }),
+          action({ type: 'pushRepoFrame', label: conflict.branch, workdir: conflict.worktreePath }),
+          action({ type: 'setStatus', value: `Switched to worktree ${conflict.worktreePath} (${conflict.branch})` }),
+          action({ type: 'setPendingChoice', value: undefined }),
           action({ type: 'setWorktreeCheckoutConflict', value: undefined }),
         ]
       }
+      if (option.workflowId) {
+        // The workflow runner owns the live context + clears any
+        // conflict state once it resolves.
+        return [
+          { type: 'runWorkflowAction', id: option.workflowId },
+          action({ type: 'setPendingChoice', value: undefined }),
+        ]
+      }
+      return [action({ type: 'setPendingChoice', value: undefined })]
+    }
+    if (inputValue === 'n' || key.escape) {
+      return [
+        action({ type: 'setPendingChoice', value: undefined }),
+        ...(state.worktreeCheckoutConflict
+          ? [action({ type: 'setWorktreeCheckoutConflict', value: undefined })]
+          : []),
+        action({ type: 'setStatus', value: 'cancelled' }),
+      ]
+    }
+    return []
+  }
 
+  if (state.pendingConfirmationId) {
+    if (inputValue === 'y') {
       const workflowAction = getLogInkWorkflowActionById(state.pendingConfirmationId)
 
       if (workflowAction?.id === 'ai-commit-summary') {
@@ -1237,11 +1239,6 @@ export function getLogInkInputEvents(
     if (inputValue === 'n' || key.escape) {
       return [
         action({ type: 'setPendingConfirmation', value: undefined }),
-        // Drop any worktree-conflict context so the prompt doesn't
-        // linger after the user declines to switch.
-        ...(state.worktreeCheckoutConflict
-          ? [action({ type: 'setWorktreeCheckoutConflict', value: undefined })]
-          : []),
         action({ type: 'setStatus', value: 'workflow action cancelled' }),
       ]
     }

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -57,6 +57,35 @@ export type LogInkPendingItemAction = {
 }
 
 /**
+ * One selectable answer in a `LogInkChoicePrompt` (#1181). The user
+ * presses `key` to pick it. An option either runs a workflow
+ * (`workflowId`, routed through the runtime's workflow runner) or fires
+ * a built-in `intent` handled directly in the input layer — the latter
+ * for pure navigation (e.g. switching into a worktree) that must not go
+ * through the workflow runner's post-action git/context refresh.
+ */
+export type LogInkChoiceOption = {
+  key: string
+  label: string
+  destructive?: boolean
+  workflowId?: string
+  intent?: 'switch-worktree'
+}
+
+/**
+ * A multi-option prompt — the n-way generalization of the y/n
+ * confirmation. Rendered by `renderChoicePanel`; resolved in the input
+ * layer by matching a keypress against `options[].key` (with `n` / `Esc`
+ * to cancel).
+ */
+export type LogInkChoicePrompt = {
+  id: string
+  title: string
+  warning?: string
+  options: LogInkChoiceOption[]
+}
+
+/**
  * True when `pending` (a `state.pendingItemAction`) targets this exact
  * row. Action-agnostic on purpose — every surface + the sidebar render
  * the same spinner whether the row is being deleted or checked out, so
@@ -383,10 +412,20 @@ export type LogInkState = {
    * already checked out in another worktree (#1175). Carries the branch
    * the user tried to check out and the worktree holding it (+ whether
    * that worktree is dirty) so the conflict prompt can offer to switch
-   * into it or remove it. Lives alongside a
-   * `pendingConfirmationId === 'switch-to-conflicting-worktree'`.
+   * into it or remove it. Read by the conflict-resolution workflow
+   * handlers; surfaced via a `pendingChoice` (see below).
    */
   worktreeCheckoutConflict?: { branch: string; worktreePath: string; dirty: boolean }
+  /**
+   * Multi-option prompt (#1181). Generalizes the y/n confirmation for
+   * situations with more than two answers — the user picks an option by
+   * its key. Each option either runs a workflow (`workflowId`) or fires
+   * a built-in `intent` handled directly in the input layer (used for
+   * pure navigation like switching worktrees, which must not route
+   * through the workflow runner's post-action context refresh). `n` /
+   * `Esc` cancels.
+   */
+  pendingChoice?: LogInkChoicePrompt
   pendingKey?: string
   /**
    * The list item whose deletion is currently in flight, if any. Set by
@@ -878,6 +917,7 @@ export type LogInkAction =
   | { type: 'setWorkflowAction'; value?: string }
   | { type: 'setPendingConfirmation'; value?: string; payload?: string }
   | { type: 'setWorktreeCheckoutConflict'; value?: { branch: string; worktreePath: string; dirty: boolean } }
+  | { type: 'setPendingChoice'; value?: LogInkChoicePrompt }
   | { type: 'setPendingMutationConfirmation'; value?: LogInkMutationConfirmation }
   | { type: 'setPendingItemAction'; value?: LogInkPendingItemAction }
   | { type: 'appendPaletteFilter'; value: string }
@@ -2241,6 +2281,8 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       }
     case 'setWorktreeCheckoutConflict':
       return { ...state, worktreeCheckoutConflict: action.value, pendingKey: undefined }
+    case 'setPendingChoice':
+      return { ...state, pendingChoice: action.value, pendingKey: undefined }
     case 'setPendingMutationConfirmation':
       return {
         ...state,

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -1022,7 +1022,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // use the status line as live feedback for the open task.
   React.useEffect(() => {
     if (!state.statusMessage) return
-    if (state.inputPrompt || state.pendingConfirmationId || state.pendingMutationConfirmation || state.showCommandPalette) {
+    if (state.inputPrompt || state.pendingConfirmationId || state.pendingChoice || state.pendingMutationConfirmation || state.showCommandPalette) {
       return
     }
     // The `setTimeout` callback is a literal arrow function (not a
@@ -1039,6 +1039,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     dispatch,
     state.inputPrompt,
     state.pendingConfirmationId,
+    state.pendingChoice,
     state.pendingMutationConfirmation,
     state.showCommandPalette,
     state.statusMessage,
@@ -3994,18 +3995,31 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     // Checking out a branch that's already checked out in another
     // worktree is rejected by git ("already checked out at <path>").
     // Rather than dead-end on that, capture the conflict and raise a
-    // y-confirm offering to switch into that worktree — the branch IS
-    // checked out, just elsewhere (#1175).
+    // multi-option prompt: switch into that worktree, remove it and
+    // check out here, or remove it and delete the branch (#1175, #1181).
     if (id === 'checkout-branch' && !result?.ok && isBranchCheckedOutElsewhereError(result?.message)) {
       const worktreePath = parseCheckedOutWorktreePath(result?.message)
       const branchName = pendingItemAction?.id
       if (worktreePath && branchName) {
         const worktree = context.worktreeList?.worktrees?.find((w) => w.path === worktreePath)
+        const dirty = worktree?.dirty ?? false
         dispatch({
           type: 'setWorktreeCheckoutConflict',
-          value: { branch: branchName, worktreePath, dirty: worktree?.dirty ?? false },
+          value: { branch: branchName, worktreePath, dirty },
         })
-        dispatch({ type: 'setPendingConfirmation', value: 'switch-to-conflicting-worktree' })
+        dispatch({
+          type: 'setPendingChoice',
+          value: {
+            id: 'worktree-checkout-conflict',
+            title: `'${branchName}' is checked out in another worktree`,
+            warning: `Checked out at ${worktreePath}.${dirty ? ' That worktree has uncommitted changes — removal will be refused until it is clean or stashed.' : ''}`,
+            options: [
+              { key: 'y', label: 'Switch to that worktree', intent: 'switch-worktree' },
+              { key: 'r', label: 'Remove worktree & check out here', workflowId: 'conflict-remove-worktree-checkout', destructive: true },
+              { key: 'x', label: 'Remove worktree & delete branch', workflowId: 'conflict-remove-worktree-branch', destructive: true },
+            ],
+          },
+        })
       } else {
         dispatch({
           type: 'setStatus',
@@ -4963,6 +4977,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         state.gitignorePicker ||
         state.inputPrompt ||
         state.pendingConfirmationId ||
+        state.pendingChoice ||
         state.pendingMutationConfirmation ||
         state.pendingKey
       ? 'inspector'

--- a/src/workstation/runtime/detailPanel.ts
+++ b/src/workstation/runtime/detailPanel.ts
@@ -35,6 +35,7 @@ import {
 } from '../surfaces/detail'
 import {
     renderChordOverlay,
+    renderChoicePanel,
     renderCommandPalette,
     renderConfirmationPanel,
     renderHelpPanel,
@@ -90,6 +91,10 @@ export function renderDetailPanel(
 
   if (state.inputPrompt) {
     return renderInputPromptPanel(h, components, state, width, theme, focused)
+  }
+
+  if (state.pendingChoice) {
+    return renderChoicePanel(h, components, state.pendingChoice, width, theme, focused)
   }
 
   if (state.pendingConfirmationId || state.pendingMutationConfirmation) {

--- a/src/workstation/runtime/footer.ts
+++ b/src/workstation/runtime/footer.ts
@@ -94,6 +94,7 @@ export function renderFooter(
       state.gitignorePicker ||
       state.inputPrompt ||
       state.pendingConfirmationId ||
+      state.pendingChoice ||
       state.pendingMutationConfirmation ||
       state.pendingKey ||
       state.filterMode

--- a/src/workstation/runtime/overlays.test.ts
+++ b/src/workstation/runtime/overlays.test.ts
@@ -10,7 +10,7 @@ import { createLogInkContextStatus } from '../chrome/context'
 import { createLogInkTheme } from '../chrome/theme'
 import { createLogInkState } from '../../commands/log/inkViewModel'
 import { renderDetailPanel } from './detailPanel'
-import { renderConfirmationPanel, renderSplitPlanOverlay } from './overlays'
+import { renderChoicePanel, renderConfirmationPanel, renderSplitPlanOverlay } from './overlays'
 import type { LogInkComponents, LogInkContext } from './types'
 
 type StubProps = Record<string, unknown>
@@ -134,41 +134,34 @@ describe('split-plan overlay — unclaimed group (#1180)', () => {
   })
 })
 
-describe('worktree-checkout-conflict confirmation panel (#1175)', () => {
+describe('choice panel — worktree-checkout conflict (#1175, #1181)', () => {
   const components: LogInkComponents = { Box, Text }
 
-  it('names the branch and worktree, and explains what y does', () => {
-    const state = {
-      ...createLogInkState([]),
-      pendingConfirmationId: 'switch-to-conflicting-worktree',
-      worktreeCheckoutConflict: { branch: 'feat/x', worktreePath: '/repo/.wt/foo', dirty: false },
-    }
-    const text = flattenText(renderConfirmationPanel(createElement, components, state, 100, theme, false))
+  const conflictPrompt = (dirty: boolean) => ({
+    id: 'worktree-checkout-conflict',
+    title: "'feat/x' is checked out in another worktree",
+    warning: `Checked out at /repo/.wt/foo.${dirty ? ' That worktree has uncommitted changes — removal will be refused until it is clean or stashed.' : ''}`,
+    options: [
+      { key: 'y', label: 'Switch to that worktree', intent: 'switch-worktree' as const },
+      { key: 'r', label: 'Remove worktree & check out here', workflowId: 'conflict-remove-worktree-checkout', destructive: true },
+      { key: 'x', label: 'Remove worktree & delete branch', workflowId: 'conflict-remove-worktree-branch', destructive: true },
+    ],
+  })
+
+  it('names the branch + worktree and lists every option with its key', () => {
+    const text = flattenText(renderChoicePanel(createElement, components, conflictPrompt(false), 100, theme, false))
     expect(text).toContain('feat/x')
     expect(text).toContain('/repo/.wt/foo')
-    expect(text).toContain('switch')
-    // Not the generic destructive copy — switching is non-destructive.
+    expect(text).toContain('y  Switch to that worktree')
+    expect(text).toContain('r  Remove worktree & check out here')
+    expect(text).toContain('x  Remove worktree & delete branch')
+    expect(text).toContain('n/Esc  cancel')
+    // Generic confirmation copy must not leak into the choice panel.
     expect(text).not.toContain('Destructive Git action requires confirmation')
   })
 
-  it('enumerates the switch / remove keys', () => {
-    const state = {
-      ...createLogInkState([]),
-      pendingConfirmationId: 'switch-to-conflicting-worktree',
-      worktreeCheckoutConflict: { branch: 'feat/x', worktreePath: '/repo/.wt/foo', dirty: false },
-    }
-    const text = flattenText(renderConfirmationPanel(createElement, components, state, 120, theme, false))
-    expect(text).toContain('remove worktree & check out here')
-    expect(text).toContain('remove worktree & delete branch')
-  })
-
-  it('warns when the conflicting worktree is dirty', () => {
-    const state = {
-      ...createLogInkState([]),
-      pendingConfirmationId: 'switch-to-conflicting-worktree',
-      worktreeCheckoutConflict: { branch: 'feat/x', worktreePath: '/repo/.wt/foo', dirty: true },
-    }
-    const text = flattenText(renderConfirmationPanel(createElement, components, state, 120, theme, false))
+  it('surfaces the dirty-worktree warning', () => {
+    const text = flattenText(renderChoicePanel(createElement, components, conflictPrompt(true), 120, theme, false))
     expect(text).toContain('uncommitted changes')
   })
 })

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -31,7 +31,7 @@ import {
     getLogInkPaletteCommands,
     getLogInkViewKeyBindings,
 } from '../../commands/log/inkKeymap'
-import type { LogInkState } from '../../commands/log/inkViewModel'
+import type { LogInkChoicePrompt, LogInkState } from '../../commands/log/inkViewModel'
 import { filterThemePresets } from '../../commands/log/inkViewModel'
 import { getLogInkWorkflowActionById } from '../../commands/log/inkWorkflows'
 import type { LogInkComponents } from './types'
@@ -105,20 +105,11 @@ export function renderConfirmationPanel(
       : state.pendingMutationConfirmation === 'discard-draft'
         ? 'Quit and discard the in-progress commit draft'
         : undefined
-  // Worktree-conflict switch (#1175): a checkout was rejected because
-  // the branch is checked out elsewhere — name the branch + worktree so
-  // the prompt explains what "y" does (jump into that worktree).
-  const conflict = state.worktreeCheckoutConflict
-  const isWorktreeConflict = state.pendingConfirmationId === 'switch-to-conflicting-worktree'
-  const label = isWorktreeConflict && conflict
-    ? `Switch to the worktree where '${conflict.branch}' is checked out?`
-    : action?.label || mutationLabel || 'Workflow action'
+  const label = action?.label || mutationLabel || 'Workflow action'
   const warning = state.pendingMutationConfirmation === 'discard-draft'
     ? 'You have an unsaved commit draft. Press y to discard it and quit.'
     : state.pendingMutationConfirmation
     ? 'This discards local changes and cannot be undone by Coco.'
-    : isWorktreeConflict && conflict
-    ? `'${conflict.branch}' is checked out at ${conflict.worktreePath}.${conflict.dirty ? ' That worktree has uncommitted changes — removal will be refused until it is clean or stashed.' : ''}`
     // Second-stage confirm raised when a safe delete hit an unmerged
     // branch — name the reason so the force isn't a blind "y again".
     : state.pendingConfirmationId === 'force-delete-branch'
@@ -138,12 +129,41 @@ export function renderConfirmationPanel(
   h(Text, undefined, truncateCells(label, width - 4)),
   h(Text, { dimColor: true }, truncateCells(warning, width - 4)),
   h(Text, undefined, ''),
-  h(Text, undefined, truncateCells(
-    isWorktreeConflict
-      ? 'y switch · r remove worktree & check out here · x remove worktree & delete branch · n/Esc cancel'
-      : 'Press y to confirm or n/Esc to cancel.',
-    width - 4,
-  )))
+  h(Text, undefined, 'Press y to confirm or n/Esc to cancel.'))
+}
+
+/**
+ * Multi-option prompt panel (#1181) — the n-way generalization of the
+ * confirmation panel. Renders the prompt title, an optional warning, and
+ * one row per option (`<key>  <label>`, destructive options in the
+ * danger colour), plus a cancel hint. Resolution happens in the input
+ * layer by matching a keypress against the option keys.
+ */
+export function renderChoicePanel(
+  h: typeof ReactTypes.createElement,
+  components: LogInkComponents,
+  prompt: LogInkChoicePrompt,
+  width: number,
+  theme: LogInkTheme,
+  focused: boolean
+): ReactTypes.ReactElement {
+  const { Box, Text } = components
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    width,
+    paddingX: 1,
+  },
+  h(Text, { bold: true }, panelTitle('Choose', focused)),
+  h(Text, undefined, truncateCells(prompt.title, width - 4)),
+  ...(prompt.warning ? [h(Text, { dimColor: true }, truncateCells(prompt.warning, width - 4))] : []),
+  h(Text, undefined, ''),
+  ...prompt.options.map((option) => h(Text, {
+    key: `choice-${prompt.id}-${option.key}`,
+    color: option.destructive && !theme.noColor ? theme.colors.danger : undefined,
+  }, truncateCells(`  ${option.key}  ${option.label}`, width - 4))),
+  h(Text, { dimColor: true }, '  n/Esc  cancel'))
 }
 
 /**


### PR DESCRIPTION
First of six follow-up improvements from this round.

The worktree-checkout conflict (#1175/#1177) needed three answers but the only prompt primitive was y/n — so it was bolted on with special-cased keys in `inkInput` and bespoke copy in the confirmation overlay. This extracts a reusable multi-option prompt.

## What's new
- **`LogInkChoicePrompt`** — declarative `{ id, title, warning?, options: [{ key, label, destructive?, workflowId? | intent? }] }`.
- Options either run a **workflow** (routed through the runner) or fire a built-in **intent** handled in the input layer. The latter exists for pure navigation like the worktree *switch*, which must NOT go through the runner's post-action context refresh — that would mis-target the repo frame we just pushed.
- **`renderChoicePanel`** renders any prompt generically; the input layer resolves it by matching the key against the options (`n`/`Esc` cancels).
- The worktree-checkout conflict now **declares its three options as data** — the inkInput special-case and the overlay's bespoke conflict branch are deleted. `pendingChoice` is wired into the modal gates (footer, status auto-clear, pane routing).

Future multi-option flows (and the `force-delete-branch` second confirm) can adopt this with no new plumbing.

## Tests
- inkInput: each option key routes correctly (switch intent → pushRepoFrame; r/x → workflow), unknown keys are ignored, n/Esc cancels and clears conflict state.
- overlays: `renderChoicePanel` lists every option with its key + the dirty-worktree warning; generic confirmation copy doesn't leak in.
- `tsc` clean · `eslint src` exit 0 · full suite **2679 passed**.