### PR TITLE
feat(screenshot): sync a subset of recipes by name

### DIFF
--- a/bin/screenshot/README.md
+++ b/bin/screenshot/README.md
@@ -222,6 +222,22 @@ The `.www/` Next.js site previously used hand-drawn artistic terminal mockups. R
 
 For animated demos (e.g. workflow walk-throughs), set `emitGif: true` on the recipe — VHS produces both the still PNG and a GIF in one pass. The driver then optimizes every GIF losslessly so synced assets stay web-ready (typically 20–30× smaller, zero quality loss); see [Authoring motion (GIF) demos](#authoring-motion-gif-demos) for that and the recipe-design rules that keep demos small and on-point.
 
+### Syncing assets to `.www/`
+
+`bin/syncScreenshots.ts` regenerates the site recipes and copies them into `.www/public/screenshots/` under their site filenames (the `FILENAME_MAP`). Two modes:
+
+```bash
+# Full sweep — regenerate and sync every recipe in SITE_RECIPES (~150 captures).
+npm run screenshot:sync          # or the explicit alias: npm run screenshot:sync:all
+
+# Subset — regenerate and sync only the named recipes. Much faster after a
+# change that only touched a view or two. Leaves the other captures in place
+# (no clean of .screenshots/). Unknown names abort with a hint.
+npm run screenshot:sync -- ui-stash-list demo-stash-workflow
+```
+
+Pass recipe **names** (the `name` field from `recipes.ts`), not site filenames. Only recipes listed in `SITE_RECIPES` can be synced — others live in `.screenshots/` for local use but aren't part of the site. After a subset sync, `cd .www && yarn dev` to preview just the assets you refreshed.
+
 ## Visual regression checks (future)
 
 The pipeline output is well-suited to PR-level visual diffs (`pixelmatch` or `odiff`). When the recipe catalog matures, add a `npm run screenshot:check` step that compares current renders against `.screenshots/baseline/`. Run it as a manual-trigger CI job rather than on every push — too slow for the hot path, but invaluable for releases.

--- a/bin/syncScreenshots.ts
+++ b/bin/syncScreenshots.ts
@@ -270,19 +270,48 @@ const FILENAME_MAP: Record<string, string[]> = {
   'ui-status-theme-catppuccin-latte': ['status-theme-catppuccin-latte.png'],
 }
 
-function main() {
-  console.log('🖼️  Regenerating marketing site screenshots...\n')
+/**
+ * Resolve which recipes to (re)generate + sync. With no CLI args we do
+ * the full site sweep (all of SITE_RECIPES). Passing recipe names syncs
+ * just those — handy after a change that only touches a view or two,
+ * instead of regenerating ~150 captures. Unknown names abort with the
+ * valid list so a typo doesn't silently sync nothing.
+ */
+function resolveTargetRecipes(argv: string[]): string[] {
+  const requested = argv.filter((arg) => !arg.startsWith('-'))
+  if (requested.length === 0) {
+    return SITE_RECIPES
+  }
+  const known = new Set(SITE_RECIPES)
+  const unknown = requested.filter((name) => !known.has(name))
+  if (unknown.length > 0) {
+    console.error(`Unknown recipe(s): ${unknown.join(', ')}`)
+    console.error('Recipes synced to the site are listed in SITE_RECIPES (bin/syncScreenshots.ts),')
+    console.error('or run `npm run screenshot -- --list` for the full catalog.')
+    process.exit(1)
+  }
+  // Preserve SITE_RECIPES order for deterministic, readable output.
+  return SITE_RECIPES.filter((name) => requested.includes(name))
+}
 
-  // Clean .screenshots/
-  if (existsSync(SCREENSHOTS_DIR)) {
+function main() {
+  const targetRecipes = resolveTargetRecipes(process.argv.slice(2))
+  const isSubset = targetRecipes.length !== SITE_RECIPES.length
+  console.log(isSubset
+    ? `🖼️  Regenerating ${targetRecipes.length} screenshot(s): ${targetRecipes.join(', ')}\n`
+    : '🖼️  Regenerating marketing site screenshots...\n')
+
+  // Full sync starts from a clean slate; a subset sync leaves the other
+  // captures in place and only refreshes the requested recipes' files.
+  if (!isSubset && existsSync(SCREENSHOTS_DIR)) {
     rmSync(SCREENSHOTS_DIR, { recursive: true })
   }
 
-  // Generate all site recipes
+  // Generate the target recipes
   let succeeded = 0
   let failed = 0
 
-  for (const recipe of SITE_RECIPES) {
+  for (const recipe of targetRecipes) {
     const result = spawnSync('npm', ['run', 'screenshot', '--', '--recipe', recipe], {
       cwd: REPO_ROOT,
       stdio: 'pipe',
@@ -314,7 +343,7 @@ function main() {
   }
 
   let synced = 0
-  for (const recipe of SITE_RECIPES) {
+  for (const recipe of targetRecipes) {
     const targets = FILENAME_MAP[recipe]
     if (!targets) continue
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "scenario": "tsx bin/scenarioRunner.ts",
     "screenshot": "tsx bin/screenshot.ts",
     "screenshot:sync": "tsx bin/syncScreenshots.ts",
+    "screenshot:sync:all": "tsx bin/syncScreenshots.ts",
     "eval:structural-extract": "tsx bin/structuralExtractEval.ts",
     "pretest:jest": "npm run build:info && node bin/copyTreeSitterWasm.mjs",
     "test:jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",


### PR DESCRIPTION
`screenshot:sync` regenerated and copied **all ~150** site recipes on every run — overkill after a change that only touches a view or two.

## What's new
- `npm run screenshot:sync -- ui-stash-list demo-stash-workflow` regenerates and syncs **only those recipes**, and (unlike the full sweep) leaves the rest of `.screenshots/` in place.
- No args still does the full sweep; added an explicit **`screenshot:sync:all`** alias for it.
- Unknown recipe names **abort with a hint** (valid list / `--list`) instead of silently syncing nothing.
- Documented both modes in `bin/screenshot/README.md` (new "Syncing assets to .www/" section).

## Verified
- Unknown name → exits 1 with guidance, no generation.
- `npm run screenshot:sync -- ui-stash-list` → regenerated + synced exactly 1 file end-to-end; other captures untouched.
- `tsc` clean · `eslint bin/syncScreenshots.ts` exit 0.