### PR TITLE
fix(tooling): repair bin/ lint and bring it under the lint scope

### DIFF
--- a/bin/benchmark.ts
+++ b/bin/benchmark.ts
@@ -27,7 +27,6 @@ import * as path from 'node:path'
 import * as os from 'node:os'
 
 import { RecursiveCharacterTextSplitter } from '@langchain/textsplitters'
-import { loadSummarizationChain } from '@langchain/classic/chains'
 import type { Document } from '@langchain/classic/document'
 
 import { fileChangeParser } from '../src/lib/parsers/default'

--- a/bin/structuralExtractEval.ts
+++ b/bin/structuralExtractEval.ts
@@ -93,7 +93,7 @@ Output:
   Aggregate summary printed to stdout.
 
 Inputs:
-  - Scenarios: deterministic git states from `@gfargo/git-scenarios`
+  - Scenarios: deterministic git states from \`@gfargo/git-scenarios\`
     (these mostly trigger the lossless trivial-shape path; useful for
     "what does the natural distribution look like").
   - Fixtures: hand-crafted modification diffs in __evals__/fixtures.ts

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build:info": "tsx bin/generateBuildInfo.ts",
     "build:watch": "rollup -c -w",
     "clean": "npx rimraf dist && npx rimraf coverage",
-    "lint": "eslint src",
+    "lint": "eslint src bin",
     "lint:fix": "eslint --fix src",
     "test": "npm run test:jest && npm run test:publish",
     "test:publish": "npm run lint && npm run build && npm run test:cli && npm pack --dry-run",


### PR DESCRIPTION
Closes the lint-coverage gap (#5 of the follow-ups). `npm run lint` was `eslint src` only, so two pre-existing `bin/` errors never reached CI:

- **`bin/structuralExtractEval.ts`** — the `printHelp` template literal had unescaped backticks (around `@gfargo/git-scenarios`) that terminated the string early. A genuine syntax error — it broke **esbuild/tsx too**, so `npm run eval:structural-extract` couldn't actually run. `tsc` missed it because `bin/` isn't in the main tsconfig's check. Escaped the backticks.
- **`bin/benchmark.ts`** — removed an unused `loadSummarizationChain` import.

Then extended the script to **`eslint src bin`** so `bin/` stays covered.

## Verified
- `npm run lint` (now `src bin`) — exit 0
- `npx esbuild bin/structuralExtractEval.ts` — parses (the file was previously unparseable)
- full unit suite **2679 passed**