### PR TITLE
feat(workstation): at-a-glance hunk staging rail in the diff header

### DIFF
--- a/src/workstation/surfaces/diff/diffSurface.test.ts
+++ b/src/workstation/surfaces/diff/diffSurface.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Worktree-staging diff header — the hunk-staging progress rail (#1184).
+ *
+ * The header shows `Hunk n/N` + a rail with one marker per hunk
+ * (filled = staged, hollow = unstaged, current bracketed) + a
+ * staged/total count, so staging progress reads at a glance.
+ *
+ * Stub `Text` / `Box` so the tree flattens without pulling Ink (ESM)
+ * into ts-jest — same pattern as the other surface tests.
+ */
+import { createElement } from 'react'
+import { createLogInkState } from '../../../commands/log/inkViewModel'
+import { createLogInkContextStatus } from '../../chrome/context'
+import { createLogInkTheme } from '../../chrome/theme'
+import { renderDiffSurface } from './index'
+import type { LogInkComponents, LogInkContext, SurfaceRenderContext } from '../../runtime/types'
+import type { DiffSurfaceData } from './index'
+
+type StubProps = Record<string, unknown>
+const Text = ((props: StubProps) =>
+  createElement('text', props, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+const Box = ((props: StubProps) =>
+  createElement('box', props, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+const components: LogInkComponents = { Box, Text }
+const theme = createLogInkTheme({ noColor: false })
+
+function flattenText(node: unknown): string {
+  if (node == null || node === false) return ''
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(flattenText).join('')
+  const el = node as { props?: { children?: unknown } }
+  if (el.props && 'children' in el.props) return flattenText(el.props.children)
+  return ''
+}
+
+// Four hunks: #1 staged, #2 unstaged, #3 staged, #4 unstaged.
+const hunkStates = ['staged', 'unstaged', 'staged', 'unstaged'] as const
+
+function render(selectedHunkIndex: number): string {
+  const base = createLogInkState([])
+  const ctx = {
+    h: createElement,
+    components,
+    state: {
+      ...base,
+      activeView: 'diff',
+      diffSource: 'worktree',
+      focus: 'commits',
+      selectedWorktreeFileIndex: 0,
+      selectedWorktreeHunkIndex: selectedHunkIndex,
+      worktreeDiffOffset: 0,
+    },
+    context: {
+      worktree: {
+        files: [{ path: 'src/a.ts', indexStatus: 'M', worktreeStatus: 'M', state: 'unstaged' }],
+        stagedCount: 2,
+        unstagedCount: 2,
+        untrackedCount: 0,
+      },
+    } as unknown as LogInkContext,
+    contextStatus: createLogInkContextStatus('ready'),
+    bodyRows: 30,
+    width: 100,
+    theme,
+  } as unknown as SurfaceRenderContext
+
+  const diff = {
+    worktreeDiff: {
+      filePath: 'src/a.ts',
+      untracked: false,
+      lines: ['@@ -1 +1 @@', '-old', '+new'],
+      hunkOffsets: [0],
+    },
+    worktreeDiffLoading: false,
+    worktreeHunks: { hunks: hunkStates.map((state) => ({ state })) },
+    worktreeHunksLoading: false,
+    filePreview: undefined,
+    filePreviewLoading: false,
+    commitDiffHunkOffsets: undefined,
+    selectedDetailFile: undefined,
+    stashDiffLines: undefined,
+    stashDiffLoading: false,
+    compareDiffLines: undefined,
+    compareDiffLoading: false,
+    syntaxSpans: undefined,
+  } as unknown as DiffSurfaceData
+
+  return flattenText(renderDiffSurface(ctx, diff))
+}
+
+describe('worktree diff — hunk staging rail (#1184)', () => {
+  it('renders a marker per hunk with the current one bracketed', () => {
+    // Cursor on hunk 2 (index 1, unstaged): ● [○] ● ○
+    const text = render(1)
+    expect(text).toContain('●[○]●○')
+  })
+
+  it('moves the bracket to the cursored hunk', () => {
+    // Cursor on hunk 3 (index 2, staged): ● ○ [●] ○
+    const text = render(2)
+    expect(text).toContain('●○[●]○')
+  })
+
+  it('shows the staged/total count and hunk position', () => {
+    const text = render(0)
+    expect(text).toContain('Hunk 1/4')
+    expect(text).toContain('2/4 staged')
+  })
+})

--- a/src/workstation/surfaces/diff/index.ts
+++ b/src/workstation/surfaces/diff/index.ts
@@ -346,27 +346,34 @@ export function renderDiffSurface(
   }
 
   const diffLines = worktreeDiff?.lines || []
-  const selectedHunk = worktreeHunks?.hunks[state.selectedWorktreeHunkIndex]
   const totalHunks = worktreeHunks?.hunks.length ?? 0
   const stagedHunks = worktreeHunks?.hunks.filter((hunk) => hunk.state === 'staged').length ?? 0
   const visibleDiffLines = diffLines.slice(
     state.worktreeDiffOffset,
     state.worktreeDiffOffset + visibleRows
   )
-  // Hunk-position line: badge + selected hunk's state + a staged/total
-  // progress count, so the user always sees how far through staging they
-  // are. Untracked/new files have no hunks — point them at whole-file
-  // staging instead of a dead-end "no hunks" message.
+  // Hunk-position line: `Hunk n/N` + an at-a-glance staging rail + a
+  // staged/total count, so the user sees how far through staging they
+  // are without reading each hunk. The rail shows one marker per hunk —
+  // filled = staged, hollow = unstaged — with the current hunk bracketed
+  // (which also conveys whether the current hunk is staged, replacing
+  // the old standalone "● staged / ○ unstaged" badge). Untracked/new
+  // files have no hunks — point them at whole-file staging instead of a
+  // dead-end "no hunks" message.
+  const railMarker = (staged: boolean) =>
+    staged ? (theme.ascii ? 'x' : '●') : (theme.ascii ? '.' : '○')
+  const hunkRail = (worktreeHunks?.hunks ?? [])
+    .map((hunk, index) => {
+      const marker = railMarker(hunk.state === 'staged')
+      return index === state.selectedWorktreeHunkIndex ? `[${marker}]` : marker
+    })
+    .join('')
   const hunkHeaderLine = worktreeHunksLoading
     ? 'Hunks loading…'
     : worktreeDiff?.untracked
       ? (theme.ascii ? 'New file — press space to stage it whole.' : '✚ New file — press space to stage it whole.')
       : totalHunks
-        ? `Hunk ${state.selectedWorktreeHunkIndex + 1}/${totalHunks} · ${
-          selectedHunk?.state === 'staged'
-            ? (theme.ascii ? '[x] staged' : '● staged')
-            : (theme.ascii ? '[ ] unstaged' : '○ unstaged')
-        } · ${stagedHunks}/${totalHunks} staged`
+        ? `Hunk ${state.selectedWorktreeHunkIndex + 1}/${totalHunks}  ${hunkRail}  ${stagedHunks}/${totalHunks} staged`
         : 'No stageable hunks for this file.'
   const headerLines: string[] = isLogInkContextKeyLoading(contextStatus, 'worktree')
     ? ['Loading file context...']


### PR DESCRIPTION
#3 of the follow-ups. Builds on the viewport-derived hunk fix (#1179).

Adds a **staging rail** to the worktree diff header: one marker per hunk — filled (`●`) staged, hollow (`○`) unstaged — with the current hunk **bracketed**:

```
Hunk 2/4  ●[○]●○  2/4 staged
```

The bracketed marker also shows the current hunk's staged state, so it **replaces** the old standalone `● staged / ○ unstaged` badge (net clutter reduction, not addition). ascii themes use `x` / `.` / `[ ]`. Staging progress now reads at a glance without walking each hunk.

## Tests
New `diffSurface.test.ts` — the rail renders a marker per hunk with the current one bracketed, the bracket follows the cursor, and the `n/N` + `staged/total` counts are present.

`npm run lint` (src bin) exit 0 · full suite **2682 passed**.