### PR TITLE
refactor(workstation): consistent diff nav + derive the staging hunk (#2, #4)

### DIFF
--- a/src/commands/log/inkInput.test.ts
+++ b/src/commands/log/inkInput.test.ts
@@ -392,14 +392,19 @@ describe('log Ink input interactions', () => {
     state = applyInput(state, '', { pageDown: true }, { worktreeDiffLineCount: 30 })
     expect(state.worktreeDiffOffset).toBe(8)
 
-    // In the worktree (staging) diff, j/↓ navigate HUNKS (the unit you
-    // stage) when there's more than one — auto-scrolling to the selected
-    // hunk, like `]`. (Single-hunk files fall back to line scroll.)
+    // In the worktree (staging) diff, j/↓ scroll LINES — consistent with
+    // the commit/stash diffs (#1185). `[`/`]` jump between hunks.
     state = applyInput(state, 'j', {}, {
       worktreeDiffLineCount: 30,
       worktreeHunkOffsets: [2, 12, 20],
     })
-    expect(state.selectedWorktreeHunkIndex).toBe(1)
+    expect(state.worktreeDiffOffset).toBe(9)
+
+    // `]` jumps the offset onto the next hunk header (12, then 20).
+    state = applyInput(state, ']', {}, {
+      worktreeDiffLineCount: 30,
+      worktreeHunkOffsets: [2, 12, 20],
+    })
     expect(state.worktreeDiffOffset).toBe(12)
 
     state = applyInput(state, ']', {}, {
@@ -407,7 +412,6 @@ describe('log Ink input interactions', () => {
       worktreeHunkOffsets: [2, 12, 20],
     })
     expect(state.worktreeDiffOffset).toBe(20)
-    expect(state.selectedWorktreeHunkIndex).toBe(2)
 
     state = applyInput(state, '', { escape: true })
     expect(state.activeView).toBe('status')

--- a/src/commands/log/inkInput.ts
+++ b/src/commands/log/inkInput.ts
@@ -2179,17 +2179,10 @@ export function getLogInkInputEvents(
       })]
     }
 
-    // Worktree (staging) diff: ↑/↓ move between hunks — the hunk is the
-    // unit you stage, so the cursor walks hunks (auto-scrolling to the
-    // selected one). Single-hunk files fall through to line-scroll so a
-    // long lone hunk stays readable; `[`/`]` remain hunk-jump aliases.
-    if (state.activeView === 'diff' && (context.worktreeHunkOffsets?.length ?? 0) > 1) {
-      return [action({
-        type: 'jumpWorktreeHunk',
-        delta: -1,
-        hunkOffsets: context.worktreeHunkOffsets as number[],
-      })]
-    }
+    // Worktree (staging) diff: ↑/↓ scroll lines — consistent with the
+    // commit / stash diffs (#1185). `[`/`]` jump between hunks (the
+    // staging unit), and the current hunk is derived from the scroll
+    // position, so line-scrolling still walks the staging target.
     if (state.activeView === 'diff' && context.worktreeDiffLineCount) {
       return [action({
         type: 'pageWorktreeDiff',
@@ -2325,15 +2318,8 @@ export function getLogInkInputEvents(
       })]
     }
 
-    // Worktree (staging) diff: ↓ walks to the next hunk (see the ↑
-    // handler). Multi-hunk only; single-hunk files line-scroll.
-    if (state.activeView === 'diff' && (context.worktreeHunkOffsets?.length ?? 0) > 1) {
-      return [action({
-        type: 'jumpWorktreeHunk',
-        delta: 1,
-        hunkOffsets: context.worktreeHunkOffsets as number[],
-      })]
-    }
+    // Worktree (staging) diff: ↓ scrolls lines (see the ↑ handler) —
+    // `[`/`]` jump hunks (#1185).
     if (state.activeView === 'diff' && context.worktreeDiffLineCount) {
       return [action({
         type: 'pageWorktreeDiff',

--- a/src/commands/log/inkKeymap.test.ts
+++ b/src/commands/log/inkKeymap.test.ts
@@ -44,7 +44,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ hunk', 'space stage', 'a stage file', 'z discard', 'o edit', 'esc back'],
+      contextual: ['j/k lines', '[/] hunk', 'space stage', 'a stage file', 'z discard', 'o edit', 'esc back'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/commands/log/inkKeymap.ts
+++ b/src/commands/log/inkKeymap.ts
@@ -1223,11 +1223,12 @@ function computeLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogInkF
         global: NORMAL_GLOBAL_HINTS,
       }
     }
-    // Worktree (staging) diff. The hunk is the unit of action: ↑/↓ walk
-    // hunks, space stages/unstages the selected one, a stages the whole
-    // file, z discards the hunk.
+    // Worktree (staging) diff. Consistent with the commit/stash diffs
+    // (#1185): j/k scroll lines, [/] jump between hunks. space stages /
+    // unstages the hunk under the viewport, a stages the whole file, z
+    // discards the current hunk.
     return {
-      contextual: ['↑/↓ hunk', 'space stage', 'a stage file', 'z discard', 'o edit', 'esc back'],
+      contextual: ['j/k lines', '[/] hunk', 'space stage', 'a stage file', 'z discard', 'o edit', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/commands/log/inkViewModel.test.ts
+++ b/src/commands/log/inkViewModel.test.ts
@@ -378,11 +378,11 @@ describe('log Ink view model', () => {
       hunkOffsets: [3, 12],
     })
     expect(state.worktreeDiffOffset).toBe(12)
-    expect(state.selectedWorktreeHunkIndex).toBe(1)
+    expect(hunkIndexAtOffset(state.worktreeDiffOffset, [3, 12])).toBe(1)
 
     state = applyLogInkAction(state, { type: 'setActiveView', value: 'status' })
     expect(state.worktreeDiffOffset).toBe(0)
-    expect(state.selectedWorktreeHunkIndex).toBe(0)
+    expect(hunkIndexAtOffset(state.worktreeDiffOffset, [3, 12])).toBe(0)
   })
 
   it('jumps commit-diff hunks symmetrically and stays put past the last hunk', () => {
@@ -717,12 +717,12 @@ describe('log Ink view model', () => {
       })
 
       expect(state.worktreeDiffOffset).toBeGreaterThan(0)
-      expect(state.selectedWorktreeHunkIndex).toBeGreaterThan(0)
+      expect(hunkIndexAtOffset(state.worktreeDiffOffset, [10, 20, 30])).toBeGreaterThan(0)
 
       state = applyLogInkAction(state, { type: 'popView' })
       expect(state.activeView).toBe('history')
       expect(state.worktreeDiffOffset).toBe(0)
-      expect(state.selectedWorktreeHunkIndex).toBe(0)
+      expect(hunkIndexAtOffset(state.worktreeDiffOffset, [10, 20, 30])).toBe(0)
     })
 
     it('navigates home, resetting the stack to the history root', () => {
@@ -1268,7 +1268,6 @@ describe('log Ink view model', () => {
       state = applyLogInkAction(state, { type: 'jumpToStatusGroup', targetIndex: 3 })
       expect(state.selectedWorktreeFileIndex).toBe(3)
       expect(state.statusGroupHeaderFocused).toBe(false)
-      expect(state.selectedWorktreeHunkIndex).toBe(0)
       expect(state.worktreeDiffOffset).toBe(0)
     })
 
@@ -2162,30 +2161,22 @@ describe('worktree hunk navigation — viewport-derived current hunk (#1179)', (
     })
   })
 
-  it('page-scrolling keeps the selected hunk in sync with the offset', () => {
+  it('page-scrolling tracks the current hunk via the offset (#1185)', () => {
     let state = createLogInkState([])
-    // Scroll a full page down past hunk boundaries.
-    state = applyLogInkAction(state, { type: 'pageWorktreeDiff', delta: 30, lineCount: 53, hunkOffsets: offsets })
+    // ↑/↓ scroll lines; the current hunk derives from the offset.
+    state = applyLogInkAction(state, { type: 'pageWorktreeDiff', delta: 30, lineCount: 53 })
     expect(state.worktreeDiffOffset).toBe(30)
-    // Old behavior left this stuck at 0 ("Hunk 1/4"); now it tracks the view.
-    expect(state.selectedWorktreeHunkIndex).toBe(2)
+    // Offset 30 sits inside hunk 3 (offsets 0/10/25/40) — derived, not stored.
+    expect(hunkIndexAtOffset(state.worktreeDiffOffset, offsets)).toBe(2)
   })
 
-  it('jumping hunks derives the index from where it lands (not a fragile indexOf)', () => {
+  it('[`/`] jumps the offset onto a hunk header; the index derives from it', () => {
     let state = createLogInkState([])
     state = applyLogInkAction(state, { type: 'jumpWorktreeHunk', delta: 1, hunkOffsets: offsets })
     expect(state.worktreeDiffOffset).toBe(10)
-    expect(state.selectedWorktreeHunkIndex).toBe(1)
+    expect(hunkIndexAtOffset(state.worktreeDiffOffset, offsets)).toBe(1)
     state = applyLogInkAction(state, { type: 'jumpWorktreeHunk', delta: 1, hunkOffsets: offsets })
     expect(state.worktreeDiffOffset).toBe(25)
-    expect(state.selectedWorktreeHunkIndex).toBe(2)
-  })
-
-  it('page-scroll without hunk offsets leaves the selected hunk untouched', () => {
-    let state = createLogInkState([])
-    state = applyLogInkAction(state, { type: 'jumpWorktreeHunk', delta: 1, hunkOffsets: offsets })
-    expect(state.selectedWorktreeHunkIndex).toBe(1)
-    state = applyLogInkAction(state, { type: 'pageWorktreeDiff', delta: 5, lineCount: 53 })
-    expect(state.selectedWorktreeHunkIndex).toBe(1)
+    expect(hunkIndexAtOffset(state.worktreeDiffOffset, offsets)).toBe(2)
   })
 })

--- a/src/commands/log/inkViewModel.ts
+++ b/src/commands/log/inkViewModel.ts
@@ -283,7 +283,6 @@ export type LogInkState = {
   selectedIndex: number
   selectedFileIndex: number
   selectedWorktreeFileIndex: number
-  selectedWorktreeHunkIndex: number
   /**
    * Cursor positions for the promoted top-level views (branches/tags/stash).
    * Persisted on the root state so navigating away and back keeps the user's
@@ -1111,7 +1110,6 @@ function withPushedView(state: LogInkState, value: LogInkView): LogInkState {
     // persistence and pop-view restores the previous tab.
     sidebarTab: value === 'compose' || value === 'status' ? 'branches' : state.sidebarTab,
     worktreeDiffOffset: value === 'diff' ? state.worktreeDiffOffset : 0,
-    selectedWorktreeHunkIndex: value === 'diff' ? state.selectedWorktreeHunkIndex : 0,
     diffSource: value === 'diff' ? state.diffSource : undefined,
     stashDiffRef: value === 'diff' ? state.stashDiffRef : undefined,
     compareHead: value === 'diff' ? state.compareHead : undefined,
@@ -1147,7 +1145,6 @@ function withPoppedView(state: LogInkState): LogInkState {
     // returns the user to whatever they actually had open before.
     sidebarTab: state.userSidebarTab,
     worktreeDiffOffset: next === 'diff' ? state.worktreeDiffOffset : 0,
-    selectedWorktreeHunkIndex: next === 'diff' ? state.selectedWorktreeHunkIndex : 0,
     diffSource: next === 'diff' ? state.diffSource : undefined,
     stashDiffRef: next === 'diff' ? state.stashDiffRef : undefined,
     compareBase: wasOnDiff ? undefined : state.compareBase,
@@ -1283,7 +1280,6 @@ function withReplacedView(state: LogInkState, value: LogInkView): LogInkState {
     activeView: value,
     viewStack,
     worktreeDiffOffset: value === 'diff' ? state.worktreeDiffOffset : 0,
-    selectedWorktreeHunkIndex: value === 'diff' ? state.selectedWorktreeHunkIndex : 0,
     diffSource: value === 'diff' ? state.diffSource : undefined,
     stashDiffRef: value === 'diff' ? state.stashDiffRef : undefined,
     compareHead: value === 'diff' ? state.compareHead : undefined,
@@ -1481,7 +1477,6 @@ export function createLogInkState(
     selectedIndex: 0,
     selectedFileIndex: 0,
     selectedWorktreeFileIndex: 0,
-    selectedWorktreeHunkIndex: 0,
     selectedBranchIndex: 0,
     selectedTagIndex: 0,
     selectedStashIndex: 0,
@@ -1710,7 +1705,6 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
           state.selectedWorktreeFileIndex + action.delta,
           action.fileCount
         ),
-        selectedWorktreeHunkIndex: 0,
         worktreeDiffOffset: 0,
         // Cursor moved to a real file row — drop header focus so the
         // file Enter handler (open diff) is what fires next.
@@ -1754,7 +1748,6 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         selectedWorktreeFileIndex: Math.max(0, action.targetIndex),
-        selectedWorktreeHunkIndex: 0,
         worktreeDiffOffset: 0,
         statusGroupHeaderFocused: false,
         pendingKey: undefined,
@@ -2002,35 +1995,26 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         ),
         pendingKey: undefined,
       }
-    case 'pageWorktreeDiff': {
-      const worktreeDiffOffset = clampIndex(state.worktreeDiffOffset + action.delta, action.lineCount)
+    case 'pageWorktreeDiff':
+      // The current staging hunk is derived from the scroll offset at
+      // the read sites (#1185), so paging only moves the offset.
       return {
         ...state,
-        worktreeDiffOffset,
-        // Keep the staging hunk in sync with the scroll position so the
-        // header / highlight / stage target track what's on screen even
-        // when paging past hunk boundaries (#1179).
-        selectedWorktreeHunkIndex: action.hunkOffsets?.length
-          ? hunkIndexAtOffset(worktreeDiffOffset, action.hunkOffsets)
-          : state.selectedWorktreeHunkIndex,
+        worktreeDiffOffset: clampIndex(state.worktreeDiffOffset + action.delta, action.lineCount),
         pendingKey: undefined,
       }
-    }
-    case 'jumpWorktreeHunk': {
-      const worktreeDiffOffset = nextHunkOffset(
-        state.worktreeDiffOffset,
-        action.hunkOffsets,
-        action.delta
-      )
+    case 'jumpWorktreeHunk':
+      // `[`/`]` move the offset onto the next/previous hunk header; the
+      // current hunk is derived from that offset at the read sites.
       return {
         ...state,
-        worktreeDiffOffset,
-        // Derive the current hunk from where we landed — robust whether
-        // or not the offset sits exactly on a boundary (#1179).
-        selectedWorktreeHunkIndex: hunkIndexAtOffset(worktreeDiffOffset, action.hunkOffsets),
+        worktreeDiffOffset: nextHunkOffset(
+          state.worktreeDiffOffset,
+          action.hunkOffsets,
+          action.delta
+        ),
         pendingKey: undefined,
       }
-    }
     case 'jumpCommitDiffHunk':
       return {
         ...state,
@@ -2077,7 +2061,6 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         activeView: HOME_VIEW,
         viewStack: [HOME_VIEW],
         worktreeDiffOffset: 0,
-        selectedWorktreeHunkIndex: 0,
         pendingCommitFocused: false,
         pendingKey: undefined,
       }
@@ -2117,7 +2100,6 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...next,
         selectedWorktreeFileIndex: Math.max(0, action.fileIndex),
-        selectedWorktreeHunkIndex: 0,
         worktreeDiffOffset: 0,
         diffSource: 'worktree',
       }
@@ -2167,7 +2149,6 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...next,
         selectedWorktreeFileIndex: Math.max(0, action.fileIndex),
-        selectedWorktreeHunkIndex: 0,
         worktreeDiffOffset: 0,
       }
     }

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -136,6 +136,7 @@ import {
     createLogInkState,
     getSelectedInkCommit,
     getThemePickerSelection,
+    hunkIndexAtOffset,
 } from '../../commands/log/inkViewModel'
 import { getGitOperationOverview } from '../../git/operationData'
 import { openProviderUrl } from '../../git/providerActions'
@@ -1999,7 +2000,11 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   }, [dispatch, git, refreshWorktreeContext, selectedWorktreeFile])
 
   const toggleSelectedHunkStage = React.useCallback(async () => {
-    const selectedHunk = worktreeHunks?.hunks[state.selectedWorktreeHunkIndex]
+    // The staging target is the hunk under the viewport (#1185) —
+    // derived from the scroll offset, the single source of truth.
+    const selectedHunk = worktreeHunks?.hunks[
+      hunkIndexAtOffset(state.worktreeDiffOffset, worktreeDiff?.hunkOffsets ?? [])
+    ]
 
     if (!selectedHunk) {
       dispatch({ type: 'setStatus', value: 'no hunk selected', kind: 'warning' })
@@ -2029,7 +2034,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         kind: 'error',
       })
     }
-  }, [dispatch, git, refreshWorktreeContext, state.selectedWorktreeHunkIndex, worktreeHunks])
+  }, [dispatch, git, refreshWorktreeContext, state.worktreeDiffOffset, worktreeDiff, worktreeHunks])
 
   const revertSelectedFile = React.useCallback(async () => {
     if (!selectedWorktreeFile) {
@@ -2047,7 +2052,9 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   }, [dispatch, git, refreshWorktreeContext, selectedWorktreeFile])
 
   const revertSelectedHunk = React.useCallback(async () => {
-    const selectedHunk = worktreeHunks?.hunks[state.selectedWorktreeHunkIndex]
+    const selectedHunk = worktreeHunks?.hunks[
+      hunkIndexAtOffset(state.worktreeDiffOffset, worktreeDiff?.hunkOffsets ?? [])
+    ]
 
     if (!selectedHunk) {
       dispatch({ type: 'setStatus', value: 'no hunk selected', kind: 'warning' })
@@ -2068,7 +2075,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         kind: 'error',
       })
     }
-  }, [dispatch, git, refreshWorktreeContext, state.selectedWorktreeHunkIndex, worktreeHunks])
+  }, [dispatch, git, refreshWorktreeContext, state.worktreeDiffOffset, worktreeDiff, worktreeHunks])
 
   const createCommitFromCompose = React.useCallback(async () => {
     const stagedCount = context.worktree?.stagedCount || 0

--- a/src/workstation/surfaces/diff/diffSurface.test.ts
+++ b/src/workstation/surfaces/diff/diffSurface.test.ts
@@ -38,7 +38,13 @@ function flattenText(node: unknown): string {
 // Four hunks: #1 staged, #2 unstaged, #3 staged, #4 unstaged.
 const hunkStates = ['staged', 'unstaged', 'staged', 'unstaged'] as const
 
-function render(selectedHunkIndex: number): string {
+// Hunk `@@` headers at line offsets 0/5/10/15 → the current hunk is
+// derived from the viewport's scroll offset (#1185): offset 0 → hunk 1,
+// 5 → hunk 2, 10 → hunk 3, 15 → hunk 4.
+const hunkOffsets = [0, 5, 10, 15]
+const diffLines = Array.from({ length: 20 }, (_, i) => (hunkOffsets.includes(i) ? `@@ hunk ${i} @@` : ` line ${i}`))
+
+function render(worktreeDiffOffset: number): string {
   const base = createLogInkState([])
   const ctx = {
     h: createElement,
@@ -49,8 +55,7 @@ function render(selectedHunkIndex: number): string {
       diffSource: 'worktree',
       focus: 'commits',
       selectedWorktreeFileIndex: 0,
-      selectedWorktreeHunkIndex: selectedHunkIndex,
-      worktreeDiffOffset: 0,
+      worktreeDiffOffset,
     },
     context: {
       worktree: {
@@ -70,8 +75,8 @@ function render(selectedHunkIndex: number): string {
     worktreeDiff: {
       filePath: 'src/a.ts',
       untracked: false,
-      lines: ['@@ -1 +1 @@', '-old', '+new'],
-      hunkOffsets: [0],
+      lines: diffLines,
+      hunkOffsets,
     },
     worktreeDiffLoading: false,
     worktreeHunks: { hunks: hunkStates.map((state) => ({ state })) },
@@ -90,17 +95,15 @@ function render(selectedHunkIndex: number): string {
   return flattenText(renderDiffSurface(ctx, diff))
 }
 
-describe('worktree diff — hunk staging rail (#1184)', () => {
-  it('renders a marker per hunk with the current one bracketed', () => {
-    // Cursor on hunk 2 (index 1, unstaged): ● [○] ● ○
-    const text = render(1)
-    expect(text).toContain('●[○]●○')
+describe('worktree diff — hunk staging rail (#1184, #1185)', () => {
+  it('renders a marker per hunk with the current one (by scroll offset) bracketed', () => {
+    // Scrolled to hunk 2 (offset 5, unstaged): ● [○] ● ○
+    expect(render(5)).toContain('●[○]●○')
   })
 
-  it('moves the bracket to the cursored hunk', () => {
-    // Cursor on hunk 3 (index 2, staged): ● ○ [●] ○
-    const text = render(2)
-    expect(text).toContain('●○[●]○')
+  it('moves the bracket to the hunk the viewport is on', () => {
+    // Scrolled to hunk 3 (offset 10, staged): ● ○ [●] ○
+    expect(render(10)).toContain('●○[●]○')
   })
 
   it('shows the staged/total count and hunk position', () => {

--- a/src/workstation/surfaces/diff/index.ts
+++ b/src/workstation/surfaces/diff/index.ts
@@ -29,6 +29,7 @@ import type {
   GitCommitDetail,
   GitCommitFilePreview,
 } from '../../../commands/log/data'
+import { hunkIndexAtOffset } from '../../../commands/log/inkViewModel'
 import {
   findStashFileForOffset,
   parseStashDiffFiles,
@@ -348,6 +349,11 @@ export function renderDiffSurface(
   const diffLines = worktreeDiff?.lines || []
   const totalHunks = worktreeHunks?.hunks.length ?? 0
   const stagedHunks = worktreeHunks?.hunks.filter((hunk) => hunk.state === 'staged').length ?? 0
+  // The "current" hunk is derived from the scroll position (#1185) —
+  // the single source of truth is `worktreeDiffOffset`. ↑/↓ scroll
+  // lines and `[`/`]` jump hunks; either way the header, rail, and
+  // stage/revert target all follow what's on screen.
+  const currentHunkIndex = hunkIndexAtOffset(state.worktreeDiffOffset, worktreeDiff?.hunkOffsets ?? [])
   const visibleDiffLines = diffLines.slice(
     state.worktreeDiffOffset,
     state.worktreeDiffOffset + visibleRows
@@ -365,7 +371,7 @@ export function renderDiffSurface(
   const hunkRail = (worktreeHunks?.hunks ?? [])
     .map((hunk, index) => {
       const marker = railMarker(hunk.state === 'staged')
-      return index === state.selectedWorktreeHunkIndex ? `[${marker}]` : marker
+      return index === currentHunkIndex ? `[${marker}]` : marker
     })
     .join('')
   const hunkHeaderLine = worktreeHunksLoading
@@ -373,7 +379,7 @@ export function renderDiffSurface(
     : worktreeDiff?.untracked
       ? (theme.ascii ? 'New file — press space to stage it whole.' : '✚ New file — press space to stage it whole.')
       : totalHunks
-        ? `Hunk ${state.selectedWorktreeHunkIndex + 1}/${totalHunks}  ${hunkRail}  ${stagedHunks}/${totalHunks} staged`
+        ? `Hunk ${currentHunkIndex + 1}/${totalHunks}  ${hunkRail}  ${stagedHunks}/${totalHunks} staged`
         : 'No stageable hunks for this file.'
   const headerLines: string[] = isLogInkContextKeyLoading(contextStatus, 'worktree')
     ? ['Loading file context...']
@@ -422,7 +428,7 @@ export function renderDiffSurface(
       syntaxSpans,
       hunkOffsets: worktreeDiff?.hunkOffsets || [],
       hunks: worktreeHunks?.hunks || [],
-      selectedIndex: state.selectedWorktreeHunkIndex,
+      selectedIndex: currentHunkIndex,
       keyPrefix: 'diff-surface-line',
     })
     : []))


### PR DESCRIPTION
Two coupled follow-ups (#4 + #2), delivered together because they're the same subsystem.

## #4 — diff-key consistency (you chose "lines everywhere")
`↑/↓` + `j/k` now scroll **lines** in the worktree diff, matching the commit/stash diffs; `[`/`]` jump between **hunks** everywhere. The current hunk follows the viewport, so line-scrolling still walks the staging target, and `space` stages the hunk you're looking at. Footer + keymap hints updated to `j/k lines · [/] hunk`.

## #2 — finish the hunk-index refactor
With `↑/↓` scrolling lines, the current hunk is purely a function of scroll position — so the redundant `selectedWorktreeHunkIndex` state field is **removed**. Header, staging rail, body highlight, and `space`/`z` all derive it from `worktreeDiffOffset` via `hunkIndexAtOffset` at the read sites. No more two-reducer 'keep in sync' bookkeeping (or the forgot-to-sync bugs it invited).

## Tests
- Reworked the hunk-nav reducer tests to assert the derived index (`hunkIndexAtOffset(offset, …)`) instead of the removed field.
- inkInput: `j`/↓ line-scroll, `[`/`]` hunk-jump in the worktree diff.
- diffSurface: the rail's bracket tracks the viewport offset.
- keymap: worktree-diff footer hint asserts `j/k lines · [/] hunk`.
- `tsc` clean · `npm run lint` (src bin) exit 0 · full suite **213 suites, 2681 passed**.