### PR TITLE
fix(workstation): improve history graph line fidelity

### DIFF
--- a/src/workstation/chrome/graphChars.test.ts
+++ b/src/workstation/chrome/graphChars.test.ts
@@ -26,63 +26,57 @@ describe('substituteGraphChars', () => {
 
   // #791 stage 1 — pattern-based junctions. Real git emits `|\` / `|/`
   // (no space between the pipe and the diagonal) for fork / converge.
-  // The 1-to-1 substitution renders these as `│╲` / `│╱` which read as
-  // overlapping pipes; the box-drawing junctions ├╮ / ├╯ make it clear
-  // that the trunk is forking off / receiving a lane.
-  describe('pattern-based junctions (#791)', () => {
-    it('emits ├╮ for the |\\ fork pattern', () => {
-      expect(substituteGraphChars('|\\', { ascii: false })).toBe('├╮')
+  // We render these as diagonals (`│╲` / `│╱`) rather than corner
+  // junctions (├╮ / ├╯): git lanes sit on a 2-column pitch and a single
+  // diagonal spans that step, so the line stays continuous into the
+  // commit above/below. Corners assume a 1-column step and land one
+  // column shy of the commit, leaving a detached hook (#791 revisited).
+  describe('fork / converge diagonals (#791)', () => {
+    it('emits │╲ for the |\\ fork pattern', () => {
+      expect(substituteGraphChars('|\\', { ascii: false })).toBe('│╲')
     })
 
-    it('emits ├╯ for the |/ converge pattern', () => {
-      expect(substituteGraphChars('|/', { ascii: false })).toBe('├╯')
+    it('emits │╱ for the |/ converge pattern', () => {
+      expect(substituteGraphChars('|/', { ascii: false })).toBe('│╱')
     })
 
-    it('preserves trailing padding around junction patterns', () => {
-      expect(substituteGraphChars('|\\  ', { ascii: false })).toBe('├╮  ')
-      expect(substituteGraphChars('|/  ', { ascii: false })).toBe('├╯  ')
+    it('preserves trailing padding around fork / converge patterns', () => {
+      expect(substituteGraphChars('|\\  ', { ascii: false })).toBe('│╲  ')
+      expect(substituteGraphChars('|/  ', { ascii: false })).toBe('│╱  ')
     })
 
-    it('handles junctions deeper in the row', () => {
+    it('handles fork / converge deeper in the row', () => {
       // Lane 0 vertical, lane 1 vertical, lane 2 forking off.
-      expect(substituteGraphChars('| | |\\', { ascii: false })).toBe('│ │ ├╮')
-      expect(substituteGraphChars('| | |/', { ascii: false })).toBe('│ │ ├╯')
+      expect(substituteGraphChars('| | |\\', { ascii: false })).toBe('│ │ │╲')
+      expect(substituteGraphChars('| | |/', { ascii: false })).toBe('│ │ │╱')
     })
 
-    it('falls back to single-char diagonals when not part of a junction', () => {
-      // `\` not preceded by `|` or `*` — keep the legacy diagonal so we
-      // do not accidentally render unrelated lane shifts as junctions.
+    it('renders standalone diagonals the same as lane diagonals', () => {
+      // A `\` / `/` not preceded by `|` or `*` is just a lane shift; it
+      // renders as the same diagonal — there is no special-cased junction
+      // glyph to drift away from.
       expect(substituteGraphChars(' \\ ', { ascii: false })).toBe(' ╲ ')
       expect(substituteGraphChars(' / ', { ascii: false })).toBe(' ╱ ')
     })
 
-    it('handles consecutive junctions in the same row', () => {
-      // Two adjacent forks: rare in practice but the tokenizer must
-      // consume each bigram cleanly without leaking diagonals across
-      // lane boundaries.
-      expect(substituteGraphChars('|\\|\\', { ascii: false })).toBe('├╮├╮')
-    })
-
     it('renders *\\ and */ commit-row variants with the configured commit glyph', () => {
-      // Uncommon — git typically puts the fork on its own row — but
-      // when it does emit a commit + diagonal we still want a clean
-      // junction so the commit glyph is preserved.
-      expect(substituteGraphChars('*\\', { ascii: false })).toBe('●╮')
-      expect(substituteGraphChars('*/', { ascii: false })).toBe('●╯')
+      // Uncommon — git typically puts the fork on its own row — but when
+      // it does emit a commit + diagonal the commit glyph is preserved
+      // and the diagonal carries the branching lane.
+      expect(substituteGraphChars('*\\', { ascii: false })).toBe('●╲')
+      expect(substituteGraphChars('*/', { ascii: false })).toBe('●╱')
     })
 
-    it('honors commitGlyph option for stage-3 merge / HEAD glyphs', () => {
-      // Stage 3 of #791 will pass ◆ for merges and ◉ for HEAD; verify
-      // the option threads through both standalone commits and the
-      // commit-with-diagonal patterns.
+    it('honors commitGlyph option for merge / HEAD glyphs', () => {
+      // ◆ for merges and ◉ for HEAD; verify the option threads through
+      // both standalone commits and the commit-with-diagonal patterns.
       expect(substituteGraphChars('*', { ascii: false, commitGlyph: '◆' })).toBe('◆')
-      expect(substituteGraphChars('*\\', { ascii: false, commitGlyph: '◉' })).toBe('◉╮')
+      expect(substituteGraphChars('*\\', { ascii: false, commitGlyph: '◉' })).toBe('◉╲')
       expect(substituteGraphChars('| *', { ascii: false, commitGlyph: '◆' })).toBe('│ ◆')
     })
 
-    it('keeps ASCII output untouched even when bigrams are present', () => {
-      // ascii bypass is the safety net for legacy terminals — junction
-      // tokenization must not run when ascii is true.
+    it('keeps ASCII output untouched', () => {
+      // ascii bypass is the safety net for legacy terminals.
       expect(substituteGraphChars('|\\', { ascii: true })).toBe('|\\')
       expect(substituteGraphChars('|/', { ascii: true })).toBe('|/')
     })

--- a/src/workstation/chrome/graphChars.ts
+++ b/src/workstation/chrome/graphChars.ts
@@ -1,13 +1,17 @@
 /**
  * The chars `git log --graph` emits for branch topology — `*`, `|`, `\`,
- * `/`, `_`, ` `. ASCII-only output is bulletproof for legacy terminals
- * but the angles read poorly when many branches overlap.
+ * `/`, `_`, ` ` — mapped 1-to-1 to box-drawing glyphs.
  *
- * `substituteGraphChars` walks the row left-to-right with one-char
- * lookahead so it can recognize git's two-char junction patterns and
- * emit proper box-drawing junctions (├╮ / ├╯) instead of overlapping
- * pipes (│╲ / │╱). Anything that isn't part of a recognized pattern
- * falls back to the legacy 1-to-1 substitution.
+ * `substituteGraphChars` walks the row and substitutes each char via
+ * `ASCII_TO_UNICODE_MAP` (with `*` overridable to a commit glyph). The
+ * fork/converge diagonals (`\` → `╲`, `/` → `╱`) are kept as diagonals
+ * rather than rewritten to corner glyphs (├╮ / ├╯): git lays its lanes
+ * out on a 2-column pitch (lane N at column 2N), and a single diagonal
+ * spans exactly that 2-column step, so it visually connects the lane
+ * above to the lane below. A corner glyph assumes a 1-column step and
+ * therefore lands one column shy of the commit it should meet, leaving
+ * a detached "hook" and a floating commit (#791 revisited — the corners
+ * read cleaner in isolation but break the line continuity).
  *
  * `theme.ascii` (TERM=dumb / vt100) bypasses substitution entirely so
  * legacy terminals get the raw `git log --graph` output. `theme.noColor`
@@ -47,25 +51,6 @@ export type SubstituteGraphCharsOptions = {
   commitGlyph?: string
 }
 
-/**
- * Recognized 2-char junction patterns. The key is the bigram git emits
- * (lane char + spacer char); the value is the box-drawing pair we render.
- *
- * - `|\` (fork): trunk lane gains a right-T (├) and the spacer becomes
- *   the upper-right corner (╮) starting the new lane below.
- * - `|/` (converge): trunk lane gains a right-T (├) and the spacer
- *   becomes the upper-left corner (╯) absorbing the side lane from
- *   above.
- *
- * `*\` and `* /` (commit-row variants) are handled the same way, but
- * the commit glyph itself stays configurable via `commitGlyph` so
- * stage 3 can swap in `◆` / `◉` for merges and HEAD.
- */
-const PIPE_FORK = '├╮'
-const PIPE_CONVERGE = '├╯'
-const FORK_SPACER = '╮'
-const CONVERGE_SPACER = '╯'
-
 export function substituteGraphChars(
   graph: string,
   options: SubstituteGraphCharsOptions
@@ -76,41 +61,13 @@ export function substituteGraphChars(
 
   const commitGlyph = options.commitGlyph ?? DEFAULT_COMMIT_GLYPH
   let output = ''
-  let i = 0
-
-  while (i < graph.length) {
-    const a = graph[i]
-    const b = i + 1 < graph.length ? graph[i + 1] : ''
-
-    if (a === '|' && b === '\\') {
-      output += PIPE_FORK
-      i += 2
-      continue
-    }
-    if (a === '|' && b === '/') {
-      output += PIPE_CONVERGE
-      i += 2
-      continue
-    }
-    if (a === '*' && b === '\\') {
-      output += commitGlyph + FORK_SPACER
-      i += 2
-      continue
-    }
-    if (a === '*' && b === '/') {
-      output += commitGlyph + CONVERGE_SPACER
-      i += 2
-      continue
-    }
-
-    if (a === '*') {
+  for (const character of graph) {
+    if (character === '*') {
       output += commitGlyph
     } else {
-      output += ASCII_TO_UNICODE_MAP[a] ?? a
+      output += ASCII_TO_UNICODE_MAP[character] ?? character
     }
-    i += 1
   }
-
   return output
 }
 

--- a/src/workstation/chrome/graphLanes.test.ts
+++ b/src/workstation/chrome/graphLanes.test.ts
@@ -40,12 +40,13 @@ describe('renderGraphRowSegments', () => {
     renderGraphRowSegments('*', tracker, { ascii: false })
     const fork = renderGraphRowSegments('|\\', tracker, { ascii: false })
 
-    // Two segments: ├ on lane 0 (the trunk continuing) and ╮ on lane 1
-    // (the freshly-spawned branch). The renderer paints them in
-    // different palette colors so the fork is immediately legible.
+    // Two segments: │ on lane 0 (the trunk continuing straight) and ╲ on
+    // lane 1 (the freshly-spawned branch peeling off down-right). The
+    // renderer paints them in different palette colors so the fork is
+    // immediately legible.
     expect(fork).toEqual([
-      { text: '├', laneId: 0 },
-      { text: '╮', laneId: 1 },
+      { text: '│', laneId: 0 },
+      { text: '╲', laneId: 1 },
     ])
     expect(tracker.columnLanes.get(0)).toBe(0)
     expect(tracker.columnLanes.get(1)).toBe(1)
@@ -71,12 +72,12 @@ describe('renderGraphRowSegments', () => {
     renderGraphRowSegments('| *', tracker, { ascii: false })
     const converge = renderGraphRowSegments('|/', tracker, { ascii: false })
 
-    // The ╯ keeps the absorbed lane's color so the side branch's tail
+    // The ╱ keeps the absorbed lane's color so the side branch's tail
     // visually terminates on its own color before merging into the
     // trunk.
     expect(converge).toEqual([
-      { text: '├', laneId: 0 },
-      { text: '╯', laneId: 1 },
+      { text: '│', laneId: 0 },
+      { text: '╱', laneId: 1 },
     ])
     expect(tracker.columnLanes.has(1)).toBe(false)
 
@@ -112,7 +113,7 @@ describe('renderGraphRowSegments', () => {
     expect(renderGraphRowSegments('*\\', tracker2, { ascii: false, commitGlyph: '◉' }))
       .toEqual([
         { text: '◉', laneId: 0 },
-        { text: '╮', laneId: 1 },
+        { text: '╲', laneId: 1 },
       ])
   })
 
@@ -143,8 +144,8 @@ describe('advanceTrackerThrough', () => {
     // stable, which is what scrolling needs to preserve coloring.
     const next = renderGraphRowSegments('|/', tracker, { ascii: false })
     expect(next).toEqual([
-      { text: '├', laneId: 0 },
-      { text: '╯', laneId: 1 },
+      { text: '│', laneId: 0 },
+      { text: '╱', laneId: 1 },
     ])
   })
 

--- a/src/workstation/chrome/graphLanes.ts
+++ b/src/workstation/chrome/graphLanes.ts
@@ -91,19 +91,25 @@ export function renderGraphRowSegments(
       const laneId = tracker.columnLanes.get(col)
       const glyph = c === '|' ? '│' : commitGlyph
 
+      // Fork (`|\`) / converge (`|/`): the lane on THIS column carries
+      // straight down (`│`, or the commit glyph) and the spacer holds a
+      // diagonal that bridges to the adjacent lane. Diagonals — not
+      // corner glyphs — because git's lanes sit on a 2-column pitch and a
+      // single `╲`/`╱` spans exactly that step, keeping the line
+      // continuous into the commit above/below (see graphChars header).
       if (next === '\\') {
         const newLaneId = tracker.nextLaneId++
         tracker.columnLanes.set(col + 1, newLaneId)
-        push(c === '|' ? '├' : commitGlyph, laneId)
-        push('╮', newLaneId)
+        push(c === '|' ? '│' : commitGlyph, laneId)
+        push('╲', newLaneId)
         i += 2
         continue
       }
 
       if (next === '/') {
         const absorbedLaneId = tracker.columnLanes.get(col + 1)
-        push(c === '|' ? '├' : commitGlyph, laneId)
-        push('╯', absorbedLaneId)
+        push(c === '|' ? '│' : commitGlyph, laneId)
+        push('╱', absorbedLaneId)
         tracker.columnLanes.delete(col + 1)
         i += 2
         continue

--- a/src/workstation/chrome/historyRows.test.ts
+++ b/src/workstation/chrome/historyRows.test.ts
@@ -105,10 +105,11 @@ describe('Ink history rows', () => {
         { text: '◉', laneId: 0 },
         { text: '   ', laneId: undefined },
       ])
-      // |\  fork row: trunk on lane 0, new branch lane id assigned.
+      // |\  fork row: trunk continues on lane 0, new branch lane peels
+      // off as a diagonal with its own lane id.
       expect(visible.items[1].laneSegments).toEqual([
-        { text: '├', laneId: 0 },
-        { text: '╮', laneId: 1 },
+        { text: '│', laneId: 0 },
+        { text: '╲', laneId: 1 },
         { text: '  ', laneId: undefined },
       ])
     })
@@ -408,7 +409,7 @@ describe('Ink history rows', () => {
       // Compressed-fork form some git versions emit for `--no-ff`
       // merges: the `\` rides on the commit row itself. The spacer
       // rewrite would leave the `\` intact, producing a duplicate
-      // `╮` corner directly under the merge glyph.
+      // `╲` diagonal directly under the merge glyph.
       const compressedMergeRows: GitLogRow[] = [
         {
           type: 'commit', graph: '*\\  ', shortHash: 'merge1', hash: 'merge1'.padEnd(40, '0'),

--- a/src/workstation/surfaces/history/__snapshots__/historyRender.test.ts.snap
+++ b/src/workstation/surfaces/history/__snapshots__/historyRender.test.ts.snap
@@ -28,6 +28,7 @@ exports[`renderHistoryPanel structural snapshot — default 3-commit history 1`]
     color="#ffffff"
   >
     <Text
+      bold={true}
       dimColor={false}
     >
       ◉
@@ -59,10 +60,9 @@ exports[`renderHistoryPanel structural snapshot — default 3-commit history 1`]
       add something
     </Text>
   </Text>
-  <Text
-    dimColor={false}
-  >
+  <Text>
     <Text
+      bold={true}
       color="cyan"
       dimColor={false}
     >
@@ -71,6 +71,7 @@ exports[`renderHistoryPanel structural snapshot — default 3-commit history 1`]
   </Text>
   <Text>
     <Text
+      bold={true}
       color="cyan"
       dimColor={false}
     >
@@ -100,10 +101,9 @@ exports[`renderHistoryPanel structural snapshot — default 3-commit history 1`]
       resolve regression
     </Text>
   </Text>
-  <Text
-    dimColor={false}
-  >
+  <Text>
     <Text
+      bold={true}
       color="cyan"
       dimColor={false}
     >
@@ -112,6 +112,7 @@ exports[`renderHistoryPanel structural snapshot — default 3-commit history 1`]
   </Text>
   <Text>
     <Text
+      bold={true}
       color="cyan"
       dimColor={false}
     >
@@ -141,10 +142,9 @@ exports[`renderHistoryPanel structural snapshot — default 3-commit history 1`]
       update README
     </Text>
   </Text>
-  <Text
-    dimColor={false}
-  >
+  <Text>
     <Text
+      bold={true}
       color="cyan"
       dimColor={false}
     >
@@ -213,6 +213,7 @@ exports[`renderHistoryPanel structural snapshot — narrow terminal (tight densi
     color="#ffffff"
   >
     <Text
+      bold={true}
       dimColor={false}
     >
       ◉
@@ -238,10 +239,9 @@ exports[`renderHistoryPanel structural snapshot — narrow terminal (tight densi
       add something
     </Text>
   </Text>
-  <Text
-    dimColor={false}
-  >
+  <Text>
     <Text
+      bold={true}
       color="cyan"
       dimColor={false}
     >
@@ -250,6 +250,7 @@ exports[`renderHistoryPanel structural snapshot — narrow terminal (tight densi
   </Text>
   <Text>
     <Text
+      bold={true}
       color="cyan"
       dimColor={false}
     >
@@ -273,10 +274,9 @@ exports[`renderHistoryPanel structural snapshot — narrow terminal (tight densi
       resolve regression
     </Text>
   </Text>
-  <Text
-    dimColor={false}
-  >
+  <Text>
     <Text
+      bold={true}
       color="cyan"
       dimColor={false}
     >
@@ -285,6 +285,7 @@ exports[`renderHistoryPanel structural snapshot — narrow terminal (tight densi
   </Text>
   <Text>
     <Text
+      bold={true}
       color="cyan"
       dimColor={false}
     >
@@ -308,10 +309,9 @@ exports[`renderHistoryPanel structural snapshot — narrow terminal (tight densi
       update README
     </Text>
   </Text>
-  <Text
-    dimColor={false}
-  >
+  <Text>
     <Text
+      bold={true}
       color="cyan"
       dimColor={false}
     >

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -244,18 +244,30 @@ function renderLaneSegmentSpans(
   theme: LogInkTheme,
   padTo: number,
   keyPrefix: string,
-  options: { forceDim?: boolean; suppressColor?: boolean } = {}
+  options: { suppressColor?: boolean } = {}
 ): ReactTypes.ReactElement[] {
   const muted = theme.noColor ? undefined : theme.colors.muted
   const elements: ReactTypes.ReactElement[] = []
   let totalLen = 0
 
   segments.forEach((seg, idx) => {
+    // Weight follows the lane, not the row. A tracked lane (`│`, the
+    // commit glyph, the fork/converge diagonals `╲ ╱` — anything that
+    // carries a `laneId`) renders bold so it reads at a consistent
+    // bright weight everywhere it appears: without the bold the base
+    // ANSI palette colors (`cyan`, `magenta`, …) sit a notch duller
+    // than the `*Bright` entries (#791), and earlier the whole fork/
+    // close row was dimmed (#831) — which made a single lane flicker
+    // bright→dim→bright as it passed through each junction. Genuine
+    // non-lane decoration (spaces, standalone `╲`/`╱`, no `laneId`)
+    // stays unbold in the muted color so it recedes on its own.
+    const hasLane = seg.laneId !== undefined
     const laneColor = options.suppressColor ? undefined : (getLaneColor(seg.laneId, theme) ?? muted)
     elements.push(h(Text, {
       key: `${keyPrefix}-${idx}`,
       color: laneColor,
-      dimColor: options.forceDim || (theme.noColor && seg.laneId === undefined),
+      bold: hasLane,
+      dimColor: theme.noColor && !hasLane,
     }, seg.text))
     totalLen += seg.text.length
   })
@@ -738,34 +750,28 @@ export function renderHistoryPanel(
       }
 
       if (item.type === 'graph') {
-        // Graph-only rows split into two visual categories:
-        //
-        //   - git's own lane-closure scaffolding (`|/`, `|\`, etc.)
-        //     stays dim-on-dim so it reads as connector chrome that
-        //     recedes behind the commits it joins (#831). The eye
-        //     should never confuse a fork/close row for a commit
-        //     somebody accidentally skipped.
-        //
-        //   - synthetic spacers we inject between linear commits
-        //     (`spacer: true`) render at FULL lane brightness so the
-        //     trunk lane bar visibly connects consecutive commits.
-        //     They are explicitly NOT scaffolding — they exist to
-        //     make linear-history rhythm read as one continuous lane.
-        const isSpacer = item.spacer === true
+        // Graph-only rows — git's fork/close junctions plus the
+        // synthetic spacers we inject between linear commits. Both just
+        // carry lanes between commits, so they render at the same lane
+        // weight as the commit rows; `renderLaneSegmentSpans` bolds the
+        // tracked lanes and mutes the non-lane decoration per-segment,
+        // so the row no longer needs a blanket dim (which used to make a
+        // lane flicker dim every time it crossed a junction — #831).
         if (item.laneSegments && !theme.ascii) {
           return h(Text, {
             key: `graph-${index}-${item.graph}`,
-            dimColor: !isSpacer,
           },
             ...renderLaneSegmentSpans(
-              h, Text, item.laneSegments, theme, visible.graphWidth, `g${index}`,
-              { forceDim: !isSpacer }
+              h, Text, item.laneSegments, theme, visible.graphWidth, `g${index}`
             ))
         }
+        // Legacy / ASCII fallback (no lane segments): the trunk has no
+        // per-lane color, so dim the synthetic spacers a touch less than
+        // git's own connectors to preserve the old vertical rhythm.
         return h(Text, {
           key: `graph-${index}-${item.graph}`,
           color: theme.noColor ? undefined : theme.colors.muted,
-          dimColor: !isSpacer,
+          dimColor: item.spacer !== true,
         }, truncateCells(substituteGraphChars(
           item.graph.padEnd(visible.graphWidth),
           { ascii: theme.ascii }


### PR DESCRIPTION
## What

Improves the readability of the history graph's lane lines — the visual centerpiece of the workstation view. Three related fidelity fixes:

1. **Bold the colored lane glyphs.** The default lane palette mixes base ANSI names (`cyan`, `magenta`, …) with `*Bright` variants; without `bold` the base colors render a notch duller, so the graph read as a mix of bold and non-bold lanes. Bolding promotes the base colors to their bright weight for a uniform look.
2. **Weight follows the lane, not the row.** Any *tracked* lane (bars, commit glyphs, junction connectors — anything carrying a `laneId`) now renders bold/bright on every row it crosses. Previously git's whole fork/close rows were dimmed, which made a single lane flicker bright→dim→bright as it passed each junction. Genuine non-lane decoration still recedes via the muted color.
3. **Fork/converge render as diagonals, not corners.** git lays lanes out on a **2-column pitch**; a single `╲`/`╱` spans that step and stays continuous into the commit above/below. The old corner glyphs (`├╮` / `├╯`) assume a 1-column step and landed one column shy of the commit — a detached hook and a floating commit. This also removes a hidden inconsistency where lane-tracked junctions drew corners while uncovered slashes fell back to diagonals.

## Why

Interim polish for `main` while the full **orthogonal-routing redesign (#1190)** is queued. This is strictly better than the corners currently shipping; #1190 is the pixel-perfect endgame (own layout from the commit DAG, corners directly under commits).

## Before / after

```
   corners (on main)      diagonals (this PR)
   │ ●                    │ ●
   ├╯  ← hook to empty     │╱  ← spans the 2-col step:
   ●     col; commit       ●     touches commit above-right
         floats                  AND trunk below-left
```

## Test plan

- `npm run lint` — clean
- `npx tsc --noEmit` — clean
- Full `jest` suite — 215 suites / 2924 tests / 35 snapshots pass (graphChars, graphLanes, historyRows unit tests + historyRender snapshots updated to the diagonal glyphs)
- Manual: `npm run dev:tui` → history → full-graph (`F`); trace a lane through a merge — holds one weight top-to-bottom, connectors meet the commits.

Refs #1190.