### PR TITLE
feat(workstation): DAG-based commit-graph lane layout engine (#1190 stage 1)

### DIFF
--- a/src/workstation/chrome/graphLayout.test.ts
+++ b/src/workstation/chrome/graphLayout.test.ts
@@ -1,0 +1,161 @@
+import { computeGraphLayout, LayoutCommit } from './graphLayout'
+
+/** Terse fixture builder: `c('A', 'B')` → commit A with parent B. */
+function c(hash: string, ...parents: string[]): LayoutCommit {
+  return { hash, parents }
+}
+
+describe('computeGraphLayout', () => {
+  it('lays linear history in a single column', () => {
+    const layout = computeGraphLayout([c('A', 'B'), c('B', 'C'), c('C')])
+
+    expect(layout.maxWidth).toBe(1)
+    expect(layout.rows.map((r) => r.column)).toEqual([0, 0, 0])
+    expect(layout.rows.map((r) => r.laneId)).toEqual([0, 0, 0])
+    expect(layout.rows.every((r) => r.passthrough.length === 0)).toBe(true)
+    // A→B and B→C continue straight; C is a root with no edge below.
+    expect(layout.rows[0].edges).toEqual([{ laneId: 0, from: 0, to: 0 }])
+    expect(layout.rows[1].edges).toEqual([{ laneId: 0, from: 0, to: 0 }])
+    expect(layout.rows[2].edges).toEqual([])
+    expect(layout.rows[2].isRoot).toBe(true)
+  })
+
+  it('routes a fork-and-merge through a feature lane', () => {
+    // M is a merge of main (A) and feature (F); F branches off and
+    // rejoins at A.
+    const layout = computeGraphLayout([
+      c('M', 'A', 'F'),
+      c('F', 'A'),
+      c('A', 'Z'),
+      c('Z'),
+    ])
+    const [m, f, a, z] = layout.rows
+
+    expect(layout.maxWidth).toBe(2)
+
+    // Merge commit sits on the trunk; opens the feature lane to the right.
+    expect(m).toMatchObject({ column: 0, laneId: 0, isMerge: true })
+    expect(m.passthrough).toEqual([])
+    expect(m.edges).toEqual([
+      { laneId: 0, from: 0, to: 0 }, // trunk continues toward A
+      { laneId: 1, from: 0, to: 1 }, // feature lane diverges right
+    ])
+
+    // Feature commit on lane 1; trunk passes through on the left.
+    expect(f).toMatchObject({ column: 1, laneId: 1 })
+    expect(f.passthrough).toEqual([{ laneId: 0, column: 0 }])
+    expect(f.edges).toEqual([
+      { laneId: 0, from: 0, to: 0 }, // trunk straight down to A
+      { laneId: 1, from: 1, to: 0 }, // feature converges left into A
+    ])
+
+    // A absorbs the feature lane (no passthrough — it merged above).
+    expect(a).toMatchObject({ column: 0, laneId: 0 })
+    expect(a.passthrough).toEqual([])
+    expect(a.edges).toEqual([{ laneId: 0, from: 0, to: 0 }])
+
+    // Z is the root.
+    expect(z).toMatchObject({ column: 0, laneId: 0, isRoot: true })
+    expect(z.edges).toEqual([])
+  })
+
+  it('keeps two independent branches in stable, distinct lanes', () => {
+    // Two unrelated lines (e.g. under `--all`): A→C and B→D, no merge.
+    const layout = computeGraphLayout([
+      c('A', 'C'),
+      c('B', 'D'),
+      c('C'),
+      c('D'),
+    ])
+    const [a, b, cc, d] = layout.rows
+
+    expect(layout.maxWidth).toBe(2)
+    expect(a).toMatchObject({ column: 0, laneId: 0 })
+    expect(b).toMatchObject({ column: 1, laneId: 1 })
+    // While B's line is alive, A's lane (0) passes through B's row.
+    expect(b.passthrough).toEqual([{ laneId: 0, column: 0 }])
+    expect(cc).toMatchObject({ column: 0, laneId: 0, isRoot: true })
+    // D's lane (1) passes through C's row before terminating.
+    expect(cc.passthrough).toEqual([{ laneId: 1, column: 1 }])
+    expect(d).toMatchObject({ column: 1, laneId: 1, isRoot: true })
+    // Lane ids stay attached to their branch throughout.
+    expect(a.laneId).not.toBe(b.laneId)
+  })
+
+  it('opens one lane per extra parent for an octopus merge', () => {
+    const layout = computeGraphLayout([
+      c('O', 'P1', 'P2', 'P3'),
+      c('P1'),
+      c('P2'),
+      c('P3'),
+    ])
+    const o = layout.rows[0]
+
+    expect(o.isMerge).toBe(true)
+    expect(o.column).toBe(0)
+    expect(layout.maxWidth).toBe(3)
+    // Three prongs fan out from the merge dot at column 0.
+    expect(o.edges).toEqual([
+      { laneId: 0, from: 0, to: 0 },
+      { laneId: 1, from: 0, to: 1 },
+      { laneId: 2, from: 0, to: 2 },
+    ])
+  })
+
+  it('reuses a freed column for a new branch but assigns a fresh lane id', () => {
+    // A→B ends at the root B (column 0 freed); C is a new tip that
+    // reuses column 0 but must get a NEW lane id so its color differs.
+    const layout = computeGraphLayout([c('A', 'B'), c('B'), c('C', 'D'), c('D')])
+    const [a, b, cc] = layout.rows
+
+    expect(a).toMatchObject({ column: 0, laneId: 0 })
+    expect(b).toMatchObject({ column: 0, laneId: 0, isRoot: true })
+    expect(cc.column).toBe(0)
+    expect(cc.laneId).toBe(1) // reused column, new lane id → new color
+  })
+
+  it('shares one lane when two merge parents point at the same commit', () => {
+    // M merges P twice (degenerate but valid): only one lane to P.
+    const layout = computeGraphLayout([c('M', 'P', 'Q'), c('Q', 'P'), c('P')])
+    const m = layout.rows[0]
+
+    // M opens lane 1 for Q; Q's parent P reuses M's trunk lane (which
+    // already expects P), so P never needs a third column.
+    expect(layout.maxWidth).toBe(2)
+    expect(m.edges).toEqual([
+      { laneId: 0, from: 0, to: 0 },
+      { laneId: 1, from: 0, to: 1 },
+    ])
+  })
+
+  it('does not crash when a parent hash is outside the loaded window', () => {
+    // A's parent was never loaded (paginated off): its lane simply runs
+    // to the bottom of the window with a straight edge, no throw.
+    const layout = computeGraphLayout([c('A', 'OFFSCREEN')])
+
+    expect(layout.maxWidth).toBe(1)
+    expect(layout.rows[0]).toMatchObject({ column: 0, laneId: 0 })
+    expect(layout.rows[0].edges).toEqual([{ laneId: 0, from: 0, to: 0 }])
+  })
+
+  it('keeps width bounded under merge-heavy history', () => {
+    // Repeated branch/merge cycles must not let columns drift right:
+    // width should track peak concurrency (2 lanes), not commit count.
+    const commits: LayoutCommit[] = []
+    for (let i = 0; i < 12; i += 1) {
+      const main = `m${i}`
+      const feat = `f${i}`
+      const nextMain = `m${i + 1}`
+      commits.push(c(main, nextMain, feat)) // merge feature into main
+      commits.push(c(feat, nextMain)) // feature commit off the next main
+    }
+    commits.push(c('m12'))
+
+    const layout = computeGraphLayout(commits)
+    expect(layout.maxWidth).toBe(2)
+  })
+
+  it('handles an empty commit list', () => {
+    expect(computeGraphLayout([])).toEqual({ rows: [], maxWidth: 1 })
+  })
+})

--- a/src/workstation/chrome/graphLayout.ts
+++ b/src/workstation/chrome/graphLayout.ts
@@ -1,0 +1,243 @@
+/**
+ * DAG-based commit-graph lane layout (#1190, stage 1).
+ *
+ * Today the history graph is rendered by parsing the ASCII topology
+ * `git log --graph` emits. That ASCII lays lanes out on a 2-column
+ * pitch, which makes it impossible to route a junction corner directly
+ * under the commit it joins — so fork/merge connectors always read as
+ * slightly detached. The fix is to stop parsing git's ASCII and compute
+ * the lane layout ourselves from the commit DAG, which we already have:
+ * every `GitLogCommitRow` carries `parents: string[]` (from `%P`).
+ *
+ * This module is the pure layout engine. It takes the ordered commit
+ * list (newest first, exactly as `git log` returns it) and produces a
+ * structured per-commit model — column assignment, lane ids for
+ * coloring, the lanes passing through each commit row, and the edges
+ * that must be drawn in the transition row beneath each commit. A
+ * separate renderer (stage 2) turns this model into glyph segments;
+ * keeping the two apart means the layout can be unit-tested on data
+ * alone, with no Ink or glyph concerns.
+ *
+ * ## Algorithm — swimlane assignment
+ *
+ * We walk commits top-to-bottom maintaining a list of *active lanes*,
+ * one per column. Each active lane "expects" a specific parent hash:
+ * it is the descending edge that will connect to that parent when we
+ * reach it. For each commit:
+ *
+ *   - Its column is the leftmost active lane expecting its hash. Any
+ *     other lanes expecting the same hash *converge* into that column
+ *     (multiple children of one commit) and are freed.
+ *   - If no lane expects it, the commit is a branch tip with no loaded
+ *     child — it opens a fresh lane in the leftmost free column.
+ *   - Its first parent continues straight down in the commit's column.
+ *     Each additional parent (a merge) opens a new lane to carry that
+ *     edge; merges that share a parent reuse one lane rather than
+ *     duplicating columns.
+ *   - A commit with no parents (a root) terminates its lane.
+ *
+ * Existing lanes never shift columns — a freed column is only reused by
+ * a *new* lane, which keeps width bounded to the peak concurrent lane
+ * count without lanes sliding sideways for no reason. A lane id is
+ * assigned once when the lane is born and carried for its whole life,
+ * so `getLaneColor` paints a logical branch one stable color even as
+ * other lanes come and go around it.
+ *
+ * ## Edges
+ *
+ * The transition row beneath commit `i` connects commit `i` to commit
+ * `i+1`. Each lane alive in that gap has a top attachment (where it
+ * leaves row `i`) and a bottom attachment (where it enters row `i+1`):
+ *
+ *   - top    = the commit's column if the lane is the commit's own lane
+ *              or a freshly-opened parent lane (both emanate from the
+ *              dot); otherwise the lane's own column (a pass-through
+ *              dropping straight down).
+ *   - bottom = commit `i+1`'s column if the lane converges into it
+ *              (it expects `i+1`'s hash); otherwise the lane's column.
+ *
+ * `from === to` is a straight vertical; `to < from` converges left;
+ * `to > from` diverges right. Computing the bottom attachment needs one
+ * commit of lookahead, so layout runs in two passes.
+ */
+import type { GitLogCommitRow } from '../../commands/log/data'
+
+/**
+ * One edge in the transition row below a commit. `from` is the column
+ * it leaves the commit row at, `to` the column it enters the next row
+ * at. Equal columns → vertical; `to < from` → converge; `to > from` →
+ * diverge.
+ */
+export type LaneEdge = {
+  laneId: number
+  from: number
+  to: number
+}
+
+/** Per-commit layout — everything the renderer needs for one commit. */
+export type CommitLayoutRow = {
+  hash: string
+  /** Column (0-based) the commit dot sits in. */
+  column: number
+  /** Stable lane id for coloring; reuse `getLaneColor(laneId, theme)`. */
+  laneId: number
+  /** Lanes crossing this commit row that are not the commit itself. */
+  passthrough: { laneId: number; column: number }[]
+  /** Edges routed in the transition row beneath this commit. */
+  edges: LaneEdge[]
+  /** `parents.length > 1` — drawn with the merge glyph. */
+  isMerge: boolean
+  /** `parents.length === 0` — the lane terminates here. */
+  isRoot: boolean
+  /** Columns occupied at this row (max column + 1); for width math. */
+  width: number
+}
+
+export type GraphLayout = {
+  rows: CommitLayoutRow[]
+  /** Widest row in the layout; feeds the dynamic graph-column width. */
+  maxWidth: number
+}
+
+/** Minimal commit shape the engine needs — `GitLogCommitRow` satisfies it. */
+export type LayoutCommit = Pick<GitLogCommitRow, 'hash' | 'parents'>
+
+/** An active descending edge waiting to connect to `expecting`. */
+type Lane = { laneId: number; expecting: string }
+
+/** Leftmost free column (a hole left by a freed lane), else a new one. */
+function firstFreeColumn(lanes: (Lane | null)[]): number {
+  const hole = lanes.findIndex((lane) => lane === null)
+  return hole === -1 ? lanes.length : hole
+}
+
+/** Drop trailing holes so width tracks the rightmost live lane. */
+function trimTrailingHoles(lanes: (Lane | null)[]): void {
+  while (lanes.length > 0 && lanes[lanes.length - 1] === null) {
+    lanes.pop()
+  }
+}
+
+type LayoutNode = {
+  hash: string
+  column: number
+  laneId: number
+  isMerge: boolean
+  isRoot: boolean
+  /** Lane ids opened by this commit's extra (merge) parents. */
+  bornParents: Set<number>
+  /** Lane snapshot entering this commit row. */
+  before: (Lane | null)[]
+  /** Lane snapshot leaving this commit row (entering the next). */
+  after: (Lane | null)[]
+}
+
+export function computeGraphLayout(commits: LayoutCommit[]): GraphLayout {
+  const lanes: (Lane | null)[] = []
+  let nextLaneId = 0
+  const nodes: LayoutNode[] = []
+
+  // Pass 1 — assign each commit a column + lane id, snapshotting the
+  // lane state on either side so pass 2 can route the edge rows.
+  for (const commit of commits) {
+    const before = lanes.map((lane) => (lane ? { ...lane } : null))
+
+    const matching: number[] = []
+    for (let c = 0; c < lanes.length; c += 1) {
+      if (lanes[c]?.expecting === commit.hash) matching.push(c)
+    }
+
+    let column: number
+    let laneId: number
+    if (matching.length === 0) {
+      // Branch tip with no loaded child — open a fresh lane.
+      column = firstFreeColumn(lanes)
+      laneId = nextLaneId
+      nextLaneId += 1
+    } else {
+      // Leftmost expecting lane is our column; the rest converge in.
+      column = matching[0]
+      laneId = lanes[column]!.laneId
+    }
+    for (const c of matching) {
+      if (c !== column) lanes[c] = null
+    }
+
+    const isRoot = commit.parents.length === 0
+    const isMerge = commit.parents.length > 1
+    const bornParents = new Set<number>()
+
+    if (isRoot) {
+      lanes[column] = null
+    } else {
+      lanes[column] = { laneId, expecting: commit.parents[0] }
+      for (let p = 1; p < commit.parents.length; p += 1) {
+        const parentHash = commit.parents[p]
+        // Reuse a lane already waiting for this parent so two merges
+        // that share a parent share its lane.
+        let target = lanes.findIndex((lane) => lane?.expecting === parentHash)
+        if (target === -1) {
+          target = firstFreeColumn(lanes)
+          const newLaneId = nextLaneId
+          nextLaneId += 1
+          lanes[target] = { laneId: newLaneId, expecting: parentHash }
+          bornParents.add(newLaneId)
+        }
+      }
+    }
+
+    trimTrailingHoles(lanes)
+    const after = lanes.map((lane) => (lane ? { ...lane } : null))
+    nodes.push({ hash: commit.hash, column, laneId, isMerge, isRoot, bornParents, before, after })
+  }
+
+  // Pass 2 — derive pass-throughs and edge rows (one commit lookahead).
+  const rows: CommitLayoutRow[] = []
+  let maxWidth = 1
+  for (let i = 0; i < nodes.length; i += 1) {
+    const node = nodes[i]
+    const next = nodes[i + 1]
+
+    const passthrough: { laneId: number; column: number }[] = []
+    for (let c = 0; c < node.before.length; c += 1) {
+      const lane = node.before[c]
+      if (!lane) continue
+      if (c === node.column) continue
+      // Lanes converging into this commit merged in the edge row above,
+      // so they are not drawn again on the commit row itself.
+      if (lane.expecting === node.hash) continue
+      passthrough.push({ laneId: lane.laneId, column: c })
+    }
+
+    const edges: LaneEdge[] = []
+    for (let c = 0; c < node.after.length; c += 1) {
+      const lane = node.after[c]
+      if (!lane) continue
+      const emanatesFromDot = lane.laneId === node.laneId || node.bornParents.has(lane.laneId)
+      const from = emanatesFromDot ? node.column : c
+      const to = next && lane.expecting === next.hash ? next.column : c
+      edges.push({ laneId: lane.laneId, from, to })
+    }
+
+    const width =
+      Math.max(
+        node.column,
+        ...passthrough.map((p) => p.column),
+        ...edges.flatMap((e) => [e.from, e.to])
+      ) + 1
+    maxWidth = Math.max(maxWidth, width)
+
+    rows.push({
+      hash: node.hash,
+      column: node.column,
+      laneId: node.laneId,
+      passthrough,
+      edges,
+      isMerge: node.isMerge,
+      isRoot: node.isRoot,
+      width,
+    })
+  }
+
+  return { rows, maxWidth }
+}


### PR DESCRIPTION
First stage of the orthogonal commit-graph redesign tracked in #1190.

## What

Adds `src/workstation/chrome/graphLayout.ts` — a **pure, unwired** lane-layout engine that computes the commit graph from the DAG instead of parsing git's `--graph` ASCII. We already capture every commit's `parents` (via `%P`), so `computeGraphLayout(commits)` can assign lanes itself — the prerequisite for routing junction corners directly under their commits (which git's 2-column ASCII pitch makes impossible).

The engine runs a standard swimlane assignment:
- each commit's column = leftmost active lane expecting its hash; other expecting lanes converge in; a branch tip with no loaded child opens a fresh lane
- first parent continues straight down; extra (merge) parents open new lanes; merges sharing a parent share one lane
- existing lanes never shift columns — a freed column is reused only by a *new* lane, so width stays bounded to peak concurrent lanes
- lane ids are assigned once and kept for life, so a logical branch keeps one stable color

It returns, per commit: `column`, `laneId`, `passthrough` lanes, and the `edges` for the transition row beneath it (`from`/`to` columns → vertical / converge / diverge), plus `isMerge`/`isRoot`/`width`. Edges need one commit of lookahead, so it's a two-pass walk.

## Why a separate, unwired PR

Per the small-focused-PR cadence: this stage is pure logic, fully unit-testable on data alone with no Ink/glyph concerns, and nothing imports it yet — so it can't regress the live graph. The renderer (stage 2) and integration (stage 3) follow.

## Scope / not in this PR

- No rendering, no glyphs, no wiring into `historyRows.ts` — the live graph is unchanged.
- The interim diagonal-fidelity fix is a separate PR (#1191).

## Test plan

`src/workstation/chrome/graphLayout.test.ts` — 9 cases on DAG fixtures: linear; fork+merge (feature lane, converge under the commit); two independent branches (stable distinct lane ids + passthrough); octopus (3 parents → 3 prongs); lane recycling (freed column reused → **new** lane id/color); shared merge parent (one lane); off-window parent hash (no crash, lane runs to bottom); merge-heavy history stays width-bounded; empty list.

- Full `jest`: 216 suites / 2934 tests / 35 snapshots pass
- `npm run lint` clean, `npx tsc --noEmit` clean

Refs #1190.