### PR TITLE
chore(screenshot): richer JS diff shot + drop themed-grid recipes

### DIFF
--- a/bin/screenshot.ts
+++ b/bin/screenshot.ts
@@ -24,6 +24,9 @@ import { spawnSync } from 'child_process'
 import { tmpdir } from 'os'
 import { dirname, join, resolve } from 'path'
 import { fromScenario, listRegistered } from '@gfargo/git-scenarios'
+// Side-effect import: registers screenshot-only custom scenarios into the
+// git-scenarios registry before any `fromScenario` / `listRegistered` call.
+import './screenshot/scenarios'
 import { findRecipe, listRecipeNames, RECIPES, type ScreenshotRecipe } from './screenshot/recipes'
 import { buildTape, createSecretRedactor, hasForwardedSecrets } from './screenshot/tape'
 

--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -215,8 +215,11 @@ export const RECIPES: ScreenshotRecipe[] = [
   },
   {
     name: 'ui-diff-feature-branch',
-    description: 'Side-by-side (split) diff view of a commit on a feature branch',
-    scenario: 'feature-pr-ready',
+    description: 'Side-by-side (split) diff view of a JavaScript refactor on a feature branch',
+    // `diff-js-showcase` (registered in ./scenarios) puts a substantial
+    // .js rewrite on the tip commit so the split diff fills with syntax
+    // highlighting — keywords, strings, JSDoc, template literals.
+    scenario: 'diff-js-showcase',
     command: 'ui --view diff',
     // Press `d` once to switch unified → side-by-side. Split needs the diff
     // panel ≥ MIN_SPLIT_DIFF_WIDTH (120) — and the diff view also shows the

--- a/bin/screenshot/scenarios.ts
+++ b/bin/screenshot/scenarios.ts
@@ -1,0 +1,137 @@
+/**
+ * Custom screenshot-only git scenarios, registered into the
+ * `@gfargo/git-scenarios` registry so recipes can reference them by
+ * name just like the built-ins. Importing this module performs the
+ * registration as a side effect; `bin/screenshot.ts` imports it once
+ * at startup, before any `fromScenario` / `listRegistered` call.
+ */
+import {
+  addCommit,
+  chain,
+  checkoutBranch,
+  createBranch,
+  defineScenario,
+  listRegistered,
+  registerScenario,
+} from '@gfargo/git-scenarios'
+
+// A recognizable JavaScript module before/after a real refactor, so the
+// diff view has plenty of syntax to highlight (keywords, strings,
+// comments, JSDoc, template literals) across added, removed, and
+// changed lines. Backs the `view-diff.png` marketing shot.
+const RATE_LIMITER_BEFORE = `// In-memory rate limiter.
+// Tracks request counts per key within a single fixed time window.
+
+const WINDOW_MS = 60_000
+const MAX_REQUESTS = 100
+
+const buckets = new Map()
+
+function hit(key) {
+  const now = Date.now()
+  const bucket = buckets.get(key)
+
+  if (!bucket || now - bucket.start >= WINDOW_MS) {
+    buckets.set(key, { start: now, count: 1 })
+    return { allowed: true, remaining: MAX_REQUESTS - 1 }
+  }
+
+  bucket.count += 1
+  const remaining = MAX_REQUESTS - bucket.count
+  return { allowed: remaining >= 0, remaining: Math.max(remaining, 0) }
+}
+
+function reset(key) {
+  buckets.delete(key)
+}
+
+module.exports = { hit, reset }
+`
+
+const RATE_LIMITER_AFTER = `// Sliding-window rate limiter.
+// Smooths the burst a fixed window allows at the boundary by weighting
+// the previous window's count by how far we are into the current one.
+
+const DEFAULTS = {
+  windowMs: 60_000,
+  max: 100,
+}
+
+/**
+ * Create a rate limiter backed by its own bucket store.
+ *
+ * @param {object} [options]
+ * @param {number} [options.windowMs] Length of the window, in ms.
+ * @param {number} [options.max] Requests allowed per window.
+ * @returns {{ hit: (key: string) => Result, reset: (key: string) => void }}
+ */
+function createRateLimiter(options = {}) {
+  const { windowMs, max } = { ...DEFAULTS, ...options }
+  const buckets = new Map()
+
+  function hit(key) {
+    const now = Date.now()
+    const slot = Math.floor(now / windowMs)
+    const bucket = buckets.get(key) ?? { slot, current: 0, previous: 0 }
+
+    if (slot !== bucket.slot) {
+      bucket.previous = slot === bucket.slot + 1 ? bucket.current : 0
+      bucket.current = 0
+      bucket.slot = slot
+    }
+
+    const elapsed = (now % windowMs) / windowMs
+    const weighted = bucket.previous * (1 - elapsed) + bucket.current
+
+    if (weighted >= max) {
+      buckets.set(key, bucket)
+      return { allowed: false, remaining: 0, retryAfter: windowMs - (now % windowMs) }
+    }
+
+    bucket.current += 1
+    buckets.set(key, bucket)
+    return { allowed: true, remaining: Math.max(0, Math.floor(max - weighted - 1)) }
+  }
+
+  function reset(key) {
+    buckets.delete(key)
+  }
+
+  return { hit, reset }
+}
+
+module.exports = { createRateLimiter, DEFAULTS }
+`
+
+const README = `# api-gateway
+
+Edge service for the public API. See \`src/rate-limiter.js\` for the
+request-budgeting logic.
+`
+
+// Registration is idempotent across repeated imports in one process.
+if (!listRegistered().some((entry) => entry.name === 'diff-js-showcase')) {
+  registerScenario(
+    defineScenario({
+      name: 'diff-js-showcase',
+      summary: 'Feature branch refactoring a JavaScript module — rich syntax-highlighted diff',
+      description:
+        'A clean feature branch whose tip commit rewrites src/rate-limiter.js from a ' +
+        'fixed-window to a sliding-window implementation. Used for the side-by-side diff ' +
+        'marketing screenshot so it shows substantial JS highlighting.',
+      kind: 'branch',
+      setup: chain(
+        addCommit({
+          message: 'feat: add fixed-window rate limiter',
+          files: { 'README.md': README, 'src/rate-limiter.js': RATE_LIMITER_BEFORE },
+        }),
+        createBranch('feature/sliding-window'),
+        checkoutBranch('feature/sliding-window'),
+        addCommit({
+          message: 'refactor(rate-limiter): switch to a sliding-window algorithm',
+          files: { 'src/rate-limiter.js': RATE_LIMITER_AFTER },
+        }),
+      ),
+    })
+  )
+}

--- a/bin/syncScreenshots.ts
+++ b/bin/syncScreenshots.ts
@@ -96,23 +96,6 @@ const SITE_RECIPES = [
   'ui-pull-request',
   'ui-pr-triage',
   'ui-issues',
-  // Themed-view showcase — diff + status across a curated theme set
-  'ui-diff-theme-catppuccin',
-  'ui-diff-theme-gruvbox',
-  'ui-diff-theme-dracula',
-  'ui-diff-theme-tokyo-night',
-  'ui-diff-theme-nord',
-  'ui-diff-theme-rose-pine',
-  'ui-diff-theme-github-light',
-  'ui-diff-theme-catppuccin-latte',
-  'ui-status-theme-catppuccin',
-  'ui-status-theme-gruvbox',
-  'ui-status-theme-dracula',
-  'ui-status-theme-tokyo-night',
-  'ui-status-theme-nord',
-  'ui-status-theme-rose-pine',
-  'ui-status-theme-github-light',
-  'ui-status-theme-catppuccin-latte',
 ]
 
 /**
@@ -174,22 +157,6 @@ const FILENAME_MAP: Record<string, string[]> = {
   'ui-compare-refs': ['view-compare.png'],
   'ui-stage-pathspec': ['stage-pathspec.png'],
   'ui-staging-hunks': ['staging-hunks.png'],
-  'ui-diff-theme-catppuccin': ['diff-theme-catppuccin.png'],
-  'ui-diff-theme-gruvbox': ['diff-theme-gruvbox.png'],
-  'ui-diff-theme-dracula': ['diff-theme-dracula.png'],
-  'ui-diff-theme-tokyo-night': ['diff-theme-tokyo-night.png'],
-  'ui-diff-theme-nord': ['diff-theme-nord.png'],
-  'ui-diff-theme-rose-pine': ['diff-theme-rose-pine.png'],
-  'ui-diff-theme-github-light': ['diff-theme-github-light.png'],
-  'ui-diff-theme-catppuccin-latte': ['diff-theme-catppuccin-latte.png'],
-  'ui-status-theme-catppuccin': ['status-theme-catppuccin.png'],
-  'ui-status-theme-gruvbox': ['status-theme-gruvbox.png'],
-  'ui-status-theme-dracula': ['status-theme-dracula.png'],
-  'ui-status-theme-tokyo-night': ['status-theme-tokyo-night.png'],
-  'ui-status-theme-nord': ['status-theme-nord.png'],
-  'ui-status-theme-rose-pine': ['status-theme-rose-pine.png'],
-  'ui-status-theme-github-light': ['status-theme-github-light.png'],
-  'ui-status-theme-catppuccin-latte': ['status-theme-catppuccin-latte.png'],
 }
 
 /**


### PR DESCRIPTION
Two marketing-screenshot tooling changes that go with the `/workstation` page refresh.

## 1. Richer JS diff for `view-diff.png`

- Adds `bin/screenshot/scenarios.ts` — registers screenshot-only custom git scenarios into the `@gfargo/git-scenarios` registry via a side-effect import in `bin/screenshot.ts` (before any `fromScenario` / `listRegistered` call).
- New `diff-js-showcase` scenario: a feature branch whose tip commit rewrites `src/rate-limiter.js` from a fixed-window to a sliding-window implementation. The diff spans keywords, strings, comments, JSDoc, and template literals, so the split view fills with highlighting.
- Points `ui-diff-feature-branch` at the new scenario (it previously used `feature-pr-ready`, whose tip diff is smaller / mixed).

## 2. Drop the themed diff/status shots from the site sync set

The `/workstation` "Every surface, themed" grid was removed from the marketing site, so the `ui-diff-theme-*` / `ui-status-theme-*` recipes no longer back anything there. Removed them from `SITE_RECIPES` and `FILENAME_MAP` so a full `screenshot:sync` stops regenerating and re-pushing orphaned `diff-theme-*.png` / `status-theme-*.png` assets. The recipe definitions stay in the catalog for ad-hoc use.

## Test plan

- `npx tsc --noEmit` clean; `npm run lint` clean; `jest bin/screenshot` (19) pass.
- `npm run screenshot:sync -- ui-diff-feature-branch` regenerates cleanly (verified the rendered PNG shows the full `rate-limiter.js` rewrite side-by-side with highlighting).

Marketing-only tooling; no runtime/package code changes. The `.www` site already has the regenerated `view-diff.png`, the refreshed history GIFs, and the removed themed section + pruned orphan files.