### PR TITLE
fix(gitlab): forge-aware copy, open-in-browser, and MR/issue list pagination

### DIFF
--- a/src/commands/prCreate/handler.ts
+++ b/src/commands/prCreate/handler.ts
@@ -6,6 +6,7 @@ import { getProviderOverview } from '../../git/providerData'
 import { runPullRequestBodyWorkflow } from '../../git/aiActions'
 import { createPullRequest, openPullRequest } from '../../git/pullRequestActions'
 import { createMergeRequest, openMergeRequest } from '../../git/mergeRequestActions'
+import { forgeNouns } from '../../workstation/chrome/forgeNouns'
 import { commandExit } from '../../lib/utils/commandExit'
 import { emitJson } from '../../lib/ui/emitJson'
 import { isInteractive, LOGO } from '../../lib/ui/helpers'
@@ -30,6 +31,7 @@ export const handler: CommandHandler<PrCreateArgv> = async (argv, logger) => {
 
   const overview = await getProviderOverview(git)
   const provider = overview.repository.provider
+  const nouns = forgeNouns(provider)
 
   if (provider !== 'github' && provider !== 'gitlab') {
     logger.log(
@@ -58,7 +60,7 @@ export const handler: CommandHandler<PrCreateArgv> = async (argv, logger) => {
   const base = argv.base || overview.repository.defaultBranch || 'main'
   if (head === base) {
     logger.log(
-      `You're on the base branch ('${base}'). Check out a feature branch before creating a PR.`,
+      `You're on the base branch ('${base}'). Check out a feature branch before creating a ${nouns.abbrev}.`,
       { color: 'yellow' }
     )
     commandExit(1)
@@ -67,7 +69,7 @@ export const handler: CommandHandler<PrCreateArgv> = async (argv, logger) => {
 
   if (overview.currentPullRequest) {
     logger.log(
-      `A pull request already exists for '${head}': #${overview.currentPullRequest.number} (${overview.currentPullRequest.state}).`,
+      `A ${nouns.singularLower} already exists for '${head}': #${overview.currentPullRequest.number} (${overview.currentPullRequest.state}).`,
       { color: 'yellow' }
     )
     commandExit(0)
@@ -86,7 +88,7 @@ export const handler: CommandHandler<PrCreateArgv> = async (argv, logger) => {
   if (!title || !body) {
     const generated = await runPullRequestBodyWorkflow({ baseBranch: base })
     if (!generated.ok) {
-      logger.log(generated.message || 'Failed to generate a pull request body.', { color: 'red' })
+      logger.log(generated.message || `Failed to generate a ${nouns.singularLower} body.`, { color: 'red' })
       commandExit(1)
       return
     }
@@ -95,7 +97,7 @@ export const handler: CommandHandler<PrCreateArgv> = async (argv, logger) => {
   }
 
   if (!title) {
-    logger.log('Could not produce a pull request title.', { color: 'red' })
+    logger.log(`Could not produce a ${nouns.singularLower} title.`, { color: 'red' })
     commandExit(1)
     return
   }
@@ -119,7 +121,7 @@ export const handler: CommandHandler<PrCreateArgv> = async (argv, logger) => {
     logger.log('')
 
     const choice = await selectPrompt<'create' | 'edit' | 'cancel'>({
-      message: 'Create this pull request?',
+      message: `Create this ${nouns.singularLower}?`,
       choices: [
         { name: '✅ Create', value: 'create' },
         { name: '✏️  Edit & create', value: 'edit' },
@@ -128,7 +130,7 @@ export const handler: CommandHandler<PrCreateArgv> = async (argv, logger) => {
     })
 
     if (choice === 'cancel') {
-      logger.log('Pull request creation cancelled.', { color: 'yellow' })
+      logger.log(`${nouns.singular} creation cancelled.`, { color: 'yellow' })
       commandExit(0)
       return
     }
@@ -140,7 +142,7 @@ export const handler: CommandHandler<PrCreateArgv> = async (argv, logger) => {
       })
       const reparsed = splitTitleBody(edited)
       if (!reparsed.title) {
-        logger.log('Empty title — pull request creation cancelled.', { color: 'yellow' })
+        logger.log(`Empty title — ${nouns.singularLower} creation cancelled.`, { color: 'yellow' })
         commandExit(0)
         return
       }

--- a/src/commands/prs/handler.ts
+++ b/src/commands/prs/handler.ts
@@ -22,6 +22,7 @@ export const handler = createGitHubListHandler<
 >({
   kind: 'prs',
   noun: 'pull request',
+  gitlabNoun: 'merge request',
   triageLabel: 'PR triage',
   buildFilter: (argv) => ({
     state: argv.state,

--- a/src/commands/utils/githubListCommand.ts
+++ b/src/commands/utils/githubListCommand.ts
@@ -53,6 +53,11 @@ export type GitHubListCommandSpec<
   kind: Cached['kind']
   /** Singular noun for the count line, e.g. 'issue' | 'pull request'. */
   noun: string
+  /**
+   * Forge-specific singular noun used when the detected remote is GitLab
+   * (e.g. 'merge request'). Falls back to `noun` when unset.
+   */
+  gitlabNoun?: string
   /** Short label for the auth hint, e.g. 'issue triage' | 'PR triage'. */
   triageLabel: string
   buildFilter: (argv: Argv) => Filter
@@ -60,7 +65,8 @@ export type GitHubListCommandSpec<
   fetch: (git: SimpleGit, filter: Filter, provider: GitProviderType | undefined) => Promise<Overview>
   extractItems: (overview: Overview) => Item[] | undefined
   toCachePayload: (items: Item[]) => Cached
-  formatList: (items: Item[]) => string
+  /** Render the list body. `nounLower` is the forge-aware singular noun. */
+  formatList: (items: Item[], nounLower?: string) => string
   summarizeFilter: (filter: Filter) => string[]
 }
 
@@ -152,6 +158,9 @@ export function createGitHubListHandler<
       return
     }
 
+    const listNoun =
+      provider === 'gitlab' && spec.gitlabNoun ? spec.gitlabNoun : spec.noun
+
     if (repository?.owner && repository?.name) {
       const filterParts = spec.summarizeFilter(filter)
       const suffix = filterParts.length ? chalk.dim(` (${filterParts.join(', ')})`) : ''
@@ -161,13 +170,13 @@ export function createGitHubListHandler<
           : ''
       logger.log(
         chalk.bold(`${repository.owner}/${repository.name}`) +
-          chalk.dim(` · ${items.length} ${spec.noun}${items.length === 1 ? '' : 's'}`) +
+          chalk.dim(` · ${items.length} ${listNoun}${items.length === 1 ? '' : 's'}`) +
           suffix +
           cacheTag
       )
       logger.log('')
     }
 
-    logger.log(spec.formatList(items))
+    logger.log(spec.formatList(items, listNoun))
   }
 }

--- a/src/git/githubListFormatting.ts
+++ b/src/git/githubListFormatting.ts
@@ -90,9 +90,12 @@ export function formatIssueList(items: IssueListItem[]): string {
     .join('\n')
 }
 
-export function formatPullRequestList(items: PullRequestListItem[]): string {
+export function formatPullRequestList(
+  items: PullRequestListItem[],
+  nounLower = 'pull request'
+): string {
   if (items.length === 0) {
-    return chalk.dim('No pull requests match the current filter.')
+    return chalk.dim(`No ${nounLower}s match the current filter.`)
   }
 
   const numberWidth = Math.max(...items.map((i) => `#${i.number}`.length))

--- a/src/git/gitlabListData.test.ts
+++ b/src/git/gitlabListData.test.ts
@@ -244,4 +244,45 @@ describe('getMergeRequestList / getGitLabIssueList (#0.70)', () => {
     const overview = await getMergeRequestList(git, {}, async () => '')
     expect(overview).toMatchObject({ available: false, message: 'No GitLab remote detected.' })
   })
+
+  it('paginates beyond one page to satisfy a large --limit', async () => {
+    const mk = (start: number, count: number) =>
+      JSON.stringify(
+        Array.from({ length: count }, (_, i) => ({
+          iid: start + i,
+          title: 't',
+          web_url: 'u',
+          state: 'opened',
+          source_branch: 's',
+          target_branch: 't',
+          created_at: '',
+          updated_at: '',
+        }))
+      )
+    const calls: string[] = []
+    let page = 0
+    const runner = async (args: string[]) => {
+      if (args[0] === 'auth') return ''
+      calls.push(args[1])
+      page += 1
+      // 100 on page 1 (== per_page, keep paging), 30 on page 2 (short, stop).
+      return page === 1 ? mk(1, 100) : mk(101, 30)
+    }
+    const overview = await getMergeRequestList(fakeGit(), { limit: 130 }, runner)
+    expect(overview.pullRequests).toHaveLength(130)
+    // per_page is clamped to GitLab's 100 max even though limit is 130.
+    expect(calls[0]).toContain('per_page=100')
+    expect(calls.some((c) => c.includes('&page=1'))).toBe(true)
+    expect(calls.some((c) => c.includes('&page=2'))).toBe(true)
+  })
+
+  it('surfaces the GitLab error body when the API returns a non-array', async () => {
+    const runner = async (args: string[]) => {
+      if (args[0] === 'auth') return ''
+      return JSON.stringify({ message: '404 Project Not Found' })
+    }
+    const overview = await getMergeRequestList(fakeGit(), {}, runner)
+    expect(overview.message).toContain('404 Project Not Found')
+    expect(overview.pullRequests).toBeUndefined()
+  })
 })

--- a/src/git/gitlabListData.ts
+++ b/src/git/gitlabListData.ts
@@ -29,6 +29,54 @@ function encodeProjectPath(path: string): string {
   return encodeURIComponent(path)
 }
 
+/**
+ * Build a clear error from a non-array `glab api` response. GitLab returns a
+ * JSON object like `{ "message": "404 Not Found" }` on errors (not an array),
+ * so without this the list parsers would throw a cryptic "raw.map is not a
+ * function" instead of surfacing the real API message.
+ */
+function gitlabListError(raw: unknown, resource: string): Error {
+  const detail =
+    raw && typeof raw === 'object'
+      ? String(
+          (raw as Record<string, unknown>).message ??
+            (raw as Record<string, unknown>).error ??
+            ''
+        )
+      : ''
+  return new Error(
+    detail
+      ? `GitLab API error fetching ${resource}: ${detail}`
+      : `Unexpected GitLab API response while fetching ${resource}.`
+  )
+}
+
+/**
+ * Fetch up to `want` rows from a paginated `glab api` list endpoint. GitLab
+ * caps `per_page` at 100, so a single request silently truncates large result
+ * sets; page through (`per_page` is baked into `baseEndpoint`) until we have
+ * `want` rows or reach the last page. Mirrors how `gh` paginates internally so
+ * `--limit N` behaves the same on both forges. The `page <= 100` ceiling is a
+ * safety stop against a misbehaving API.
+ */
+async function fetchAllPages<T>(
+  runner: GlabRunner,
+  baseEndpoint: string,
+  parse: (output: string) => T[],
+  want: number,
+  perPage: number
+): Promise<T[]> {
+  const acc: T[] = []
+  let page = 1
+  while (acc.length < want && page <= 100) {
+    const batch = parse(await runner(['api', `${baseEndpoint}&page=${page}`]))
+    acc.push(...batch)
+    if (batch.length < perPage) break
+    page += 1
+  }
+  return acc.slice(0, want)
+}
+
 /** Map a GitLab MR/issue `state` to coco's uppercased state vocabulary. */
 function normalizeState(raw: unknown): string {
   const s = String(raw || '').toLowerCase()
@@ -108,8 +156,9 @@ function mrStateParam(state: PullRequestListFilter['state']): string | undefined
 function parseMergeRequests(output: string): PullRequestListItem[] {
   const trimmed = output.trim()
   if (!trimmed) return []
-  const raw = JSON.parse(trimmed) as Array<Record<string, unknown>>
-  return raw.map((mr) => ({
+  const raw = JSON.parse(trimmed)
+  if (!Array.isArray(raw)) throw gitlabListError(raw, 'merge requests')
+  return (raw as Array<Record<string, unknown>>).map((mr) => ({
     number: Number(mr.iid),
     title: String(mr.title || ''),
     url: String(mr.web_url || ''),
@@ -137,7 +186,7 @@ function buildMergeRequestEndpoint(path: string, filter: PullRequestListFilter):
     search: filter.search,
     source_branch: filter.head,
     target_branch: filter.base,
-    per_page: filter.limit ?? 30,
+    per_page: Math.min(filter.limit ?? 30, 100),
   })
   return `projects/${encodeProjectPath(path)}/merge_requests${query}`
 }
@@ -164,8 +213,14 @@ export async function getMergeRequestList(
   }
 
   try {
-    const output = await runner(['api', buildMergeRequestEndpoint(project.path, filter)])
-    let pullRequests = parseMergeRequests(output)
+    const want = filter.limit ?? 30
+    let pullRequests = await fetchAllPages(
+      runner,
+      buildMergeRequestEndpoint(project.path, filter),
+      parseMergeRequests,
+      want,
+      Math.min(want, 100)
+    )
     // The REST API has no stable cross-version "draft only" filter; apply it
     // client-side so `--draft` behaves the same as on GitHub.
     if (filter.draft) pullRequests = pullRequests.filter((mr) => mr.isDraft)
@@ -203,8 +258,9 @@ function issueStateParam(state: IssueListFilter['state']): string | undefined {
 function parseIssues(output: string): IssueListItem[] {
   const trimmed = output.trim()
   if (!trimmed) return []
-  const raw = JSON.parse(trimmed) as Array<Record<string, unknown>>
-  return raw.map((issue) => ({
+  const raw = JSON.parse(trimmed)
+  if (!Array.isArray(raw)) throw gitlabListError(raw, 'issues')
+  return (raw as Array<Record<string, unknown>>).map((issue) => ({
     number: Number(issue.iid),
     title: String(issue.title || ''),
     url: String(issue.web_url || ''),
@@ -224,7 +280,7 @@ function buildIssueEndpoint(path: string, filter: IssueListFilter): string {
     ...userScopeParams(filter.author, filter.assignee),
     labels: filter.label,
     search: filter.search,
-    per_page: filter.limit ?? 30,
+    per_page: Math.min(filter.limit ?? 30, 100),
   })
   return `projects/${encodeProjectPath(path)}/issues${query}`
 }
@@ -251,13 +307,20 @@ export async function getGitLabIssueList(
   }
 
   try {
-    const output = await runner(['api', buildIssueEndpoint(project.path, filter)])
+    const want = filter.limit ?? 30
+    const issues = await fetchAllPages(
+      runner,
+      buildIssueEndpoint(project.path, filter),
+      parseIssues,
+      want,
+      Math.min(want, 100)
+    )
     return {
       available: true,
       authenticated: true,
       repository: { owner: project.owner, name: project.name },
       filter,
-      issues: parseIssues(output),
+      issues,
     }
   } catch (error) {
     return {

--- a/src/workstation/chrome/forgeNouns.ts
+++ b/src/workstation/chrome/forgeNouns.ts
@@ -15,6 +15,10 @@ export type ForgeNouns = {
   plural: string
   singularLower: string
   pluralLower: string
+  /** The forge's CLI binary ("gh" / "glab") for install/auth hints. */
+  cli: string
+  /** Human display name of the forge ("GitHub" / "GitLab"). */
+  name: string
 }
 
 export function forgeNouns(provider: GitProviderType | undefined): ForgeNouns {
@@ -25,6 +29,8 @@ export function forgeNouns(provider: GitProviderType | undefined): ForgeNouns {
       plural: 'Merge requests',
       singularLower: 'merge request',
       pluralLower: 'merge requests',
+      cli: 'glab',
+      name: 'GitLab',
     }
   }
   return {
@@ -33,5 +39,7 @@ export function forgeNouns(provider: GitProviderType | undefined): ForgeNouns {
     plural: 'Pull requests',
     singularLower: 'pull request',
     pluralLower: 'pull requests',
+    cli: 'gh',
+    name: 'GitHub',
   }
 }

--- a/src/workstation/chrome/previewPane.ts
+++ b/src/workstation/chrome/previewPane.ts
@@ -300,10 +300,11 @@ export function formatIssueTriagePreview(
  */
 export function formatPullRequestTriagePreview(
   pr: PullRequestListItem | undefined,
-  detail?: PullRequestDetail
+  detail?: PullRequestDetail,
+  nounLower = 'pull request'
 ): PreviewLine[] {
   if (!pr) {
-    return [dim('Select a pull request to preview.')]
+    return [dim(`Select a ${nounLower} to preview.`)]
   }
 
   const out: PreviewLine[] = [

--- a/src/workstation/chrome/surfaceStates.triage.test.ts
+++ b/src/workstation/chrome/surfaceStates.triage.test.ts
@@ -1,6 +1,6 @@
 import {
-  formatLogInkGitHubNoRemote,
-  formatLogInkGitHubUnauthenticated,
+  formatLogInkForgeNoRemote,
+  formatLogInkForgeUnauthenticated,
   formatLogInkIssuesEmpty,
   formatLogInkPullRequestTriageEmpty,
 } from './surfaceStates'
@@ -17,6 +17,10 @@ describe('triage surface empty-state messages', () => {
       expect(msg).toContain('open')
       expect(msg).not.toContain("''")
     })
+
+    it('is forge-neutral (no hardcoded GitHub)', () => {
+      expect(formatLogInkIssuesEmpty({ filter: '' })).not.toContain('GitHub')
+    })
   })
 
   describe('formatLogInkPullRequestTriageEmpty', () => {
@@ -29,26 +33,39 @@ describe('triage surface empty-state messages', () => {
     })
   })
 
-  describe('formatLogInkGitHubUnauthenticated', () => {
+  describe('formatLogInkForgeUnauthenticated', () => {
     it('embeds the resource noun', () => {
-      expect(formatLogInkGitHubUnauthenticated({ resource: 'Issues' })).toContain('Issues')
-      expect(formatLogInkGitHubUnauthenticated({ resource: 'Pull requests' })).toContain(
+      expect(formatLogInkForgeUnauthenticated({ resource: 'Issues' })).toContain('Issues')
+      expect(formatLogInkForgeUnauthenticated({ resource: 'Pull requests' })).toContain(
         'Pull requests'
       )
     })
 
-    it('points the user at gh auth login', () => {
-      expect(formatLogInkGitHubUnauthenticated({ resource: 'Issues' })).toContain('gh auth login')
+    it('points the user at gh auth login by default (GitHub)', () => {
+      expect(formatLogInkForgeUnauthenticated({ resource: 'Issues' })).toContain('gh auth login')
+      expect(formatLogInkForgeUnauthenticated({ resource: 'Issues' })).toContain('GitHub')
+    })
+
+    it('points the user at glab auth login for GitLab', () => {
+      const msg = formatLogInkForgeUnauthenticated({
+        resource: 'Merge requests',
+        cli: 'glab',
+        forge: 'GitLab',
+      })
+      expect(msg).toContain('glab auth login')
+      expect(msg).toContain('GitLab')
+      expect(msg).not.toContain('gh auth login')
     })
   })
 
-  describe('formatLogInkGitHubNoRemote', () => {
+  describe('formatLogInkForgeNoRemote', () => {
     it('embeds the resource noun', () => {
-      expect(formatLogInkGitHubNoRemote({ resource: 'Issues' })).toContain('Issues')
+      expect(formatLogInkForgeNoRemote({ resource: 'Issues' })).toContain('Issues')
     })
 
-    it('mentions GitHub explicitly', () => {
-      expect(formatLogInkGitHubNoRemote({ resource: 'Issues' })).toContain('GitHub')
+    it('mentions GitHub by default and GitLab when asked', () => {
+      expect(formatLogInkForgeNoRemote({ resource: 'Issues' })).toContain('GitHub')
+      expect(formatLogInkForgeNoRemote({ resource: 'Issues', forge: 'GitLab' })).toContain('GitLab')
     })
   })
 })

--- a/src/workstation/chrome/surfaceStates.ts
+++ b/src/workstation/chrome/surfaceStates.ts
@@ -122,7 +122,7 @@ export function formatLogInkIssuesEmpty({ filter }: LogInkIssuesEmptyArgs): stri
   if (filter.trim()) {
     return `No issues match filter '${filter}'. Press ctrl+u to clear.`
   }
-  return 'No issues match the current GitHub filter (default: open issues).'
+  return 'No issues match the current filter (default: open issues).'
 }
 
 export type LogInkPullRequestTriageEmptyArgs = {
@@ -144,29 +144,38 @@ export function formatLogInkPullRequestTriageEmpty({
   return `No ${noun} match the current filter (default: open).`
 }
 
-export type LogInkGitHubUnauthenticatedArgs = {
-  /** Short noun for the resource: "issues", "pull requests". */
+export type LogInkForgeUnavailableArgs = {
+  /** Short noun for the resource: "issues", "pull requests" / "merge requests". */
   resource: string
+  /** Forge CLI binary ("gh" / "glab"). Defaults to the GitHub wording. */
+  cli?: string
+  /** Forge display name ("GitHub" / "GitLab"). Defaults to GitHub. */
+  forge?: string
 }
 
 /**
- * Surface-level fallback when the GitHub CLI is missing or not
+ * Surface-level fallback when the forge CLI is missing or not
  * authenticated. The triage views (#882) all share this empty-state
  * copy — the underlying problem is the same regardless of which
- * surface the user is on, and the recovery is identical.
+ * surface the user is on, and the recovery is identical. `cli`/`forge`
+ * default to the GitHub wording so GitHub callers stay correct; GitLab
+ * surfaces pass `glab`/`GitLab`.
  */
-export function formatLogInkGitHubUnauthenticated({
+export function formatLogInkForgeUnauthenticated({
   resource,
-}: LogInkGitHubUnauthenticatedArgs): string {
-  return `${resource} require the GitHub CLI. Install \`gh\` and run \`gh auth login\` to enable triage.`
+  cli = 'gh',
+  forge = 'GitHub',
+}: LogInkForgeUnavailableArgs): string {
+  return `${resource} require the ${forge} CLI. Install \`${cli}\` and run \`${cli} auth login\` to enable triage.`
 }
 
 /**
- * Surface-level fallback when the repo has no GitHub remote. Same
- * shared message across the triage surfaces.
+ * Surface-level fallback when the repo has no remote for the active
+ * forge. Same shared message across the triage surfaces.
  */
-export function formatLogInkGitHubNoRemote({
+export function formatLogInkForgeNoRemote({
   resource,
-}: LogInkGitHubUnauthenticatedArgs): string {
-  return `${resource} require a GitHub remote (origin or fallback). None detected for this repo.`
+  forge = 'GitHub',
+}: LogInkForgeUnavailableArgs): string {
+  return `${resource} require a ${forge} remote (origin or fallback). None detected for this repo.`
 }

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -90,6 +90,7 @@ import {
     getInspectorActionsForState,
     getLogInkInputEvents,
 } from '../../workstation/runtime/inkInput'
+import { forgeNouns } from '../chrome/forgeNouns'
 import { hasSeenOnboarding, markOnboardingSeen } from '../chrome/onboarding'
 import { createLogInkTheme, type LogInkThemePreset } from '../chrome/theme'
 import { saveThemePreset } from '../chrome/themePersistence'
@@ -2271,9 +2272,10 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // lands in a follow-up if hard cancel becomes a request.
   const pullRequestBodyCancelRef = React.useRef<{ cancelled: boolean } | null>(null)
   const startCreatePullRequest = React.useCallback(async () => {
+    const nouns = forgeNouns(forgeProvider)
     const head = context.branches?.currentBranch || context.provider?.currentBranch
     if (!head) {
-      dispatch({ type: 'setStatus', value: 'No current branch to create a PR from.', kind: 'warning' })
+      dispatch({ type: 'setStatus', value: `No current branch to create a ${nouns.abbrev} from.`, kind: 'warning' })
       return
     }
     const defaultBranch = context.provider?.repository.defaultBranch
@@ -2294,8 +2296,8 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       dispatch({
         type: 'setStatus',
         value: existing
-          ? `PR #${existing.number} already open for ${head}. Use the PR view to manage it.`
-          : `A pull request is already open for ${head}.`,
+          ? `${nouns.abbrev} #${existing.number} already open for ${head}. Use the ${nouns.abbrev} view to manage it.`
+          : `A ${nouns.singularLower} is already open for ${head}.`,
         kind: 'warning',
       })
       return
@@ -2317,7 +2319,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     // misled into thinking they're saving tokens.
     dispatch({
       type: 'setStatus',
-      value: `generating PR body from changelog (vs ${defaultBranch}) — Esc to skip prompt`,
+      value: `generating ${nouns.abbrev} body from changelog (vs ${defaultBranch}) — Esc to skip prompt`,
       loading: true,
     })
 
@@ -2330,7 +2332,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       // already settled — its result is discarded. Hard cancel
       // (aborting the HTTP request mid-flight) is a follow-up.
       if (cancelHandle.cancelled) {
-        dispatch({ type: 'setStatus', value: 'PR draft cancelled.' })
+        dispatch({ type: 'setStatus', value: `${nouns.abbrev} draft cancelled.` })
         return
       }
 
@@ -2343,9 +2345,9 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       const initial = initialBody ? `${initialTitle}\n\n${initialBody}` : initialTitle
 
       if (!body.ok) {
-        dispatch({ type: 'setStatus', value: `PR body generation failed: ${body.message}. Edit manually.`, kind: 'error' })
+        dispatch({ type: 'setStatus', value: `${nouns.abbrev} body generation failed: ${body.message}. Edit manually.`, kind: 'error' })
       } else {
-        dispatch({ type: 'setStatus', value: 'PR body drafted — review and Ctrl+D to submit.', kind: 'success' })
+        dispatch({ type: 'setStatus', value: `${nouns.abbrev} body drafted — review and Ctrl+D to submit.`, kind: 'success' })
       }
 
       // Audit finding #11: clear the pending flag BEFORE opening the
@@ -2361,7 +2363,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       dispatch({
         type: 'openInputPrompt',
         kind: 'create-pr',
-        label: `Create PR: ${head} → ${defaultBranch}  (line 1 title · rest body · Enter newline · Ctrl+D submit)`,
+        label: `Create ${nouns.abbrev}: ${head} → ${defaultBranch}  (line 1 title · rest body · Enter newline · Ctrl+D submit)`,
         initial,
         multiline: true,
       })
@@ -2384,6 +2386,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     context.provider?.currentPullRequest,
     context.provider?.repository.defaultBranch,
     context.pullRequest?.currentPullRequest,
+    forgeProvider,
     dispatch,
   ])
 
@@ -3613,8 +3616,10 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       },
       'open-pr': async () => {
         const repo = context.provider?.repository
-        if (!repo || repo.provider !== 'github' || !repo.owner || !repo.name) {
-          return { ok: false, message: 'No GitHub remote detected for this repo' }
+        // Any detected forge works here: buildProviderUrl emits the correct
+        // GitHub or GitLab web URLs. Only reject genuinely unsupported remotes.
+        if (!repo || repo.provider === 'unsupported' || !repo.owner || !repo.name) {
+          return { ok: false, message: 'No supported forge remote detected for this repo' }
         }
         // History view: prefer the cursored commit's URL so `O` from
         // a commit context lands the user on the commit page rather
@@ -3718,17 +3723,18 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         // The input-prompt submit handler validates non-empty title
         // already; this is the defensive belt-and-suspenders for
         // future palette callers passing in a raw payload.
+        const nouns = forgeNouns(forgeProvider)
         const text = (payload || '').trim()
         if (!text) {
-          return { ok: false, message: 'Pull request title is required (first line of the prompt).' }
+          return { ok: false, message: `${nouns.singular} title is required (first line of the prompt).` }
         }
         const lines = text.split('\n')
         const title = lines[0].trim()
         if (!title) {
-          return { ok: false, message: 'Pull request title cannot be blank.' }
+          return { ok: false, message: `${nouns.singular} title cannot be blank.` }
         }
         // Body: lines 2+, with the leading blank line tolerated. Empty
-        // body is allowed — GitHub renders an empty PR body fine.
+        // body is allowed — the forge renders an empty body fine.
         const body = lines.slice(1).join('\n').replace(/^\n+/, '').trimEnd()
         const head = context.branches?.currentBranch || context.provider?.currentBranch
         const base = context.provider?.repository.defaultBranch
@@ -3736,7 +3742,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
           return { ok: false, message: 'No current branch detected.' }
         }
         if (!base) {
-          return { ok: false, message: 'No default branch detected. Configure the GitHub remote.' }
+          return { ok: false, message: `No default branch detected. Configure the ${nouns.name} remote.` }
         }
         return forge.createPullRequest({ base, head, title, body })
       },

--- a/src/workstation/surfaces/detail/index.ts
+++ b/src/workstation/surfaces/detail/index.ts
@@ -982,5 +982,5 @@ export function renderPullRequestTriagePreviewPanel(
     ? context.pullRequestDetailByNumber?.get(pr.number)
     : undefined
   return renderPreviewPanel(h, { Box, Text }, `${nouns.singular} preview`,
-    formatPullRequestTriagePreview(pr, detail), width, theme, focused)
+    formatPullRequestTriagePreview(pr, detail, nouns.singularLower), width, theme, focused)
 }

--- a/src/workstation/surfaces/issuesTriage/__snapshots__/issuesTriageRender.test.ts.snap
+++ b/src/workstation/surfaces/issuesTriage/__snapshots__/issuesTriageRender.test.ts.snap
@@ -26,7 +26,7 @@ exports[`renderIssuesTriageSurface structural snapshot — empty list 1`] = `
   <Text
     dimColor={true}
   >
-    No issues match the current GitHub filter (default: open issues).
+    No issues match the current filter (default: open issues).
   </Text>
 </Box>
 `;

--- a/src/workstation/surfaces/issuesTriage/index.ts
+++ b/src/workstation/surfaces/issuesTriage/index.ts
@@ -12,9 +12,10 @@
 import type * as ReactTypes from 'react'
 import type { IssueListItem } from '../../../git/issuesListData'
 import { isLogInkContextKeyLoading } from '../../chrome/context'
+import { forgeNouns } from '../../chrome/forgeNouns'
 import {
-  formatLogInkGitHubNoRemote,
-  formatLogInkGitHubUnauthenticated,
+  formatLogInkForgeNoRemote,
+  formatLogInkForgeUnauthenticated,
   formatLogInkIssuesEmpty,
   formatLogInkLoading,
 } from '../../chrome/surfaceStates'
@@ -57,6 +58,7 @@ export function renderIssuesTriageSurface(ctx: SurfaceRenderContext): ReactTypes
   const focused = state.focus === 'commits'
   const overview = context.issueList
   const loading = isLogInkContextKeyLoading(contextStatus, 'issueList')
+  const forge = forgeNouns(context.provider?.repository.provider)
 
   // Resolve the "what should the panel say" headline first, then fan
   // out to the row body. The chrome (border + title + headerRight) is
@@ -74,13 +76,13 @@ export function renderIssuesTriageSurface(ctx: SurfaceRenderContext): ReactTypes
     headerRight = 'unavailable'
     bodyLines = [
       h(Text, { key: 'issues-no-remote', dimColor: true },
-        formatLogInkGitHubNoRemote({ resource: 'Issues' })),
+        formatLogInkForgeNoRemote({ resource: 'Issues', forge: forge.name })),
     ]
   } else if (!overview.authenticated) {
-    headerRight = 'gh not authenticated'
+    headerRight = `${forge.cli} not authenticated`
     bodyLines = [
       h(Text, { key: 'issues-unauth', dimColor: true },
-        formatLogInkGitHubUnauthenticated({ resource: 'Issues' })),
+        formatLogInkForgeUnauthenticated({ resource: 'Issues', cli: forge.cli, forge: forge.name })),
     ]
   } else if (overview.message && !overview.issues) {
     headerRight = 'error'

--- a/src/workstation/surfaces/pullRequestTriage/index.ts
+++ b/src/workstation/surfaces/pullRequestTriage/index.ts
@@ -15,8 +15,8 @@ import type { PullRequestListItem } from '../../../git/pullRequestListData'
 import { isLogInkContextKeyLoading } from '../../chrome/context'
 import { forgeNouns } from '../../chrome/forgeNouns'
 import {
-  formatLogInkGitHubNoRemote,
-  formatLogInkGitHubUnauthenticated,
+  formatLogInkForgeNoRemote,
+  formatLogInkForgeUnauthenticated,
   formatLogInkLoading,
   formatLogInkPullRequestTriageEmpty,
 } from '../../chrome/surfaceStates'
@@ -123,13 +123,13 @@ export function renderPullRequestTriageSurface(ctx: SurfaceRenderContext): React
     headerRight = 'unavailable'
     bodyLines = [
       h(Text, { key: 'pr-triage-no-remote', dimColor: true },
-        formatLogInkGitHubNoRemote({ resource: nouns.plural })),
+        formatLogInkForgeNoRemote({ resource: nouns.plural, forge: nouns.name })),
     ]
   } else if (!overview.authenticated) {
-    headerRight = 'gh not authenticated'
+    headerRight = `${nouns.cli} not authenticated`
     bodyLines = [
       h(Text, { key: 'pr-triage-unauth', dimColor: true },
-        formatLogInkGitHubUnauthenticated({ resource: nouns.plural })),
+        formatLogInkForgeUnauthenticated({ resource: nouns.plural, cli: nouns.cli, forge: nouns.name })),
     ]
   } else if (overview.message && !overview.pullRequests) {
     headerRight = 'error'


### PR DESCRIPTION
Follow-up patches from a post-release review of the multi-forge work shipped in `0.70.1`. Everything here is GitLab-only or only visible on a GitLab repo; GitHub behavior is unchanged.

## Fixes
| Sev | Fix |
|-----|-----|
| 🔴 High | **Open-in-browser (`O`) was dead on GitLab.** The handler was hard-gated to `provider === 'github'` and returned a misleading "No GitHub remote detected", even though `buildProviderUrl` already emits correct GitLab URLs (`/-/merge_requests/N`, `/-/commit/…`). Now rejects only genuinely `unsupported` remotes. |
| 🟠 Med | **Forge-aware copy.** Triage unauth/no-remote hints told GitLab users to install `gh` / run `gh auth login`; the in-TUI create flow and `coco pr create` said "PR"/"pull request"; `coco prs` printed "pull requests"; preview/empty states said "pull request". All now derive the noun + CLI name from the detected forge. `forgeNouns` gains `cli` (`gh`/`glab`) and `name` (`GitHub`/`GitLab`) as the single source. |
| 🟠 Med | **List pagination.** GitLab MR/issue loaders sent only `per_page` (GitLab caps it at 100) with no second-page fetch, so `--limit > 100` silently truncated. They now page through to satisfy the limit, mirroring how `gh` paginates internally; `per_page` clamped to 100. |
| 🟡 Low | **Non-array API responses.** `glab api` returns `{ "message": "404 …" }` on errors, not an array — the parsers now surface that real message instead of a cryptic `raw.map is not a function`. |

## Tests
- Forge-variant assertions for the triage unauth/no-remote hints (`gh` vs `glab`, GitHub vs GitLab).
- New loader tests: multi-page pagination satisfies a large `--limit` (and clamps `per_page` to 100), and a non-array response surfaces the GitLab error body.
- Updated the issues-empty snapshot (dropped the stray "GitHub").
- Full suite green (lint + jest + build + CLI smoke + pack).

## Deliberately deferred (noted in the review)
- **Self-hosted GitLab auth host-scoping** — `getGlabStatus` isn't scoped to the repo's host; wants a self-hosted instance to verify before changing.
- **Detail-view notes pagination** (inspector caps comments at 100) and **cosmetic keymap/idle-tip "PR" labels** — lower impact, separate follow-up.