### PR TITLE
fix(deps): bump shell-quote to >=1.8.4 (clears critical advisory)

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "cross-spawn": "7.0.6",
     "brace-expansion": "^5.0.6",
     "@anthropic-ai/sdk": "^0.91.1",
-    "ip-address": "^10.1.1"
+    "ip-address": "^10.1.1",
+    "shell-quote": "^1.8.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5488,10 +5488,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@^1.6.1:
-  version "1.8.3"
-  resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz"
-  integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
+shell-quote@^1.6.1, shell-quote@^1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
+  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
 
 signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"


### PR DESCRIPTION
## What
Pins `shell-quote >= 1.8.4` via the Yarn `resolutions` block to clear the one open **critical** Dependabot alert.

## Why
`shell-quote <= 1.8.3` (`quote()` does not escape newlines in object `.op` values) reaches the dependency tree transitively:
```
git-coco → react-devtools-core → shell-quote@1.8.3
```
coco has **zero** direct usage of `shell-quote` (grep of `src`/`bin` is clean), and the vulnerable path is only exercised by the Ink devtools socket, which normal CLI/TUI usage never activates — so real-world risk is low. But it's an open critical alert and the fix is trivial.

## How
- This is a **Yarn** project (CI runs `yarn install --frozen-lockfile`; ci.yml even guards against a committed `package-lock.json`), so the pin goes in `resolutions`, not npm `overrides`.
- `yarn install` re-resolved react-devtools-core's `shell-quote@^1.6.1` to **1.8.4** (`yarn why shell-quote` → Found 1.8.4).
- No source change.

## Validation
Full suite green: lint + 3300 jest tests + build + packaged-CLI smoke + pack.