### PR TITLE
fix(gitlab): self-hosted auth host-scoping + detail fidelity

### DIFF
--- a/src/git/gitlabDetailData.test.ts
+++ b/src/git/gitlabDetailData.test.ts
@@ -20,11 +20,23 @@ describe('GitLab detail parsing (#0.70)', () => {
     ])
   })
 
-  it('maps a head pipeline to a status check', () => {
+  it('maps a head pipeline to a status check and normalizes GitLab status to the renderer vocabulary', () => {
     expect(parsePipelineAsChecks({ status: 'success' })).toEqual([
       { name: 'pipeline', status: 'success', conclusion: 'success' },
     ])
+    // GitLab vocabulary -> the GitHub conclusion words the inspector buckets on.
+    expect(parsePipelineAsChecks({ status: 'failed' })[0].conclusion).toBe('failure')
+    expect(parsePipelineAsChecks({ status: 'running' })[0].conclusion).toBe('in_progress')
+    expect(parsePipelineAsChecks({ status: 'canceled' })[0].conclusion).toBe('cancelled')
+    expect(parsePipelineAsChecks({ status: 'pending' })[0].conclusion).toBe('pending')
+    // Raw status is preserved for reference.
+    expect(parsePipelineAsChecks({ status: 'failed' })[0].status).toBe('failed')
     expect(parsePipelineAsChecks(null)).toEqual([])
+  })
+
+  it('treats a non-array notes body as no comments (no cryptic throw)', () => {
+    expect(parseNotes(JSON.stringify({ message: '404 Not Found' }))).toEqual([])
+    expect(parseNotes('')).toEqual([])
   })
 })
 
@@ -49,9 +61,36 @@ describe('getMergeRequestDetail / getGitLabIssueDetail (#0.70)', () => {
         body: 'body text',
         comments: [{ author: 'a', body: 'c1', createdAt: 't' }],
         reviews: [{ author: 'b', state: 'APPROVED', body: '', submittedAt: '' }],
-        statusCheckRollup: [{ name: 'pipeline', status: 'failed', conclusion: 'failed' }],
+        statusCheckRollup: [{ name: 'pipeline', status: 'failed', conclusion: 'failure' }],
       },
     })
+  })
+
+  it('paginates notes beyond one page (long discussion threads not truncated)', async () => {
+    const mkNotes = (start: number, count: number) =>
+      JSON.stringify(
+        Array.from({ length: count }, (_, i) => ({
+          body: `c${start + i}`,
+          created_at: 't',
+          system: false,
+          author: { username: 'a' },
+        }))
+      )
+    let notesPage = 0
+    const runner = async (args: string[]): Promise<string> => {
+      const endpoint = args[1]
+      if (endpoint.includes('/notes')) {
+        notesPage += 1
+        // 100 on page 1 (full → keep paging), 5 on page 2 (short → stop).
+        return notesPage === 1 ? mkNotes(1, 100) : mkNotes(101, 5)
+      }
+      if (endpoint.endsWith('/approvals')) return JSON.stringify({ approved_by: [] })
+      return JSON.stringify({ description: 'b', head_pipeline: { status: 'success' } })
+    }
+    const result = await getMergeRequestDetail('group/proj', 1, runner)
+    expect(result.ok).toBe(true)
+    expect(result.ok && result.detail.comments).toHaveLength(105)
+    expect(notesPage).toBe(2)
   })
 
   it('assembles issue detail from issue + notes', async () => {

--- a/src/git/gitlabDetailData.ts
+++ b/src/git/gitlabDetailData.ts
@@ -30,10 +30,8 @@ type GlabNote = {
   author?: { username?: string }
 }
 
-function parseNotes(output: string): IssueComment[] {
-  const trimmed = output.trim()
-  if (!trimmed) return []
-  const notes = JSON.parse(trimmed) as GlabNote[]
+/** Map raw GitLab notes to comments, dropping system (activity) notes. */
+function mapNotes(notes: GlabNote[]): IssueComment[] {
   return notes
     // System notes are activity events (label changes, etc.), not comments.
     .filter((note) => !note.system && (note.body || '').trim())
@@ -42,6 +40,46 @@ function parseNotes(output: string): IssueComment[] {
       body: note.body || '',
       createdAt: note.created_at || '',
     }))
+}
+
+function parseNotes(output: string): IssueComment[] {
+  const trimmed = output.trim()
+  if (!trimmed) return []
+  const raw = JSON.parse(trimmed)
+  // GitLab returns `{ "message": ... }` on errors; treat any non-array as "no
+  // comments" rather than throwing a cryptic "notes.filter is not a function"
+  // that would collapse the entire detail panel.
+  if (!Array.isArray(raw)) return []
+  return mapNotes(raw as GlabNote[])
+}
+
+/**
+ * Page through an MR/issue's notes endpoint. GitLab caps `per_page` at 100, so a
+ * single request silently truncates long discussion threads; accumulate pages
+ * (up to a 2000-note ceiling) until a short page. A failed or malformed page
+ * degrades to whatever was collected rather than failing the whole detail.
+ */
+async function fetchAllNotes(runner: GlabRunner, base: string): Promise<IssueComment[]> {
+  const comments: IssueComment[] = []
+  for (let page = 1; page <= 20; page++) {
+    let out = ''
+    try {
+      out = (await runner(['api', `${base}/notes?per_page=100&page=${page}`])).trim()
+    } catch {
+      break
+    }
+    if (!out) break
+    let raw: unknown
+    try {
+      raw = JSON.parse(out)
+    } catch {
+      break
+    }
+    if (!Array.isArray(raw)) break
+    comments.push(...mapNotes(raw as GlabNote[]))
+    if (raw.length < 100) break
+  }
+  return comments
 }
 
 async function safeJson<T>(runner: GlabRunner, endpoint: string): Promise<T | undefined> {
@@ -66,11 +104,39 @@ function parseApprovalsAsReviews(approvals: unknown): PullRequestReview[] {
     .filter((review) => review.author)
 }
 
+/**
+ * Map a GitLab pipeline status to the GitHub check vocabulary the shared
+ * inspector renderer buckets on (success / failure / pending). Without this,
+ * GitLab's `failed`/`running`/`canceled` fall through to the renderer's "other"
+ * bucket, so a red pipeline shows "1 other" instead of "1 fail".
+ */
+function normalizePipelineConclusion(status: string): string {
+  switch (status) {
+    case 'success':
+      return 'success'
+    case 'failed':
+      return 'failure'
+    case 'canceled':
+      return 'cancelled'
+    case 'running':
+      return 'in_progress'
+    case 'pending':
+    case 'created':
+    case 'scheduled':
+    case 'manual':
+    case 'preparing':
+    case 'waiting_for_resource':
+      return 'pending'
+    default:
+      return status // skipped / unknown → renderer's "other" bucket
+  }
+}
+
 function parsePipelineAsChecks(pipeline: unknown): PullRequestStatusCheck[] {
   const p = pipeline as { status?: string } | null | undefined
   if (!p || typeof p.status !== 'string') return []
   // GitLab pipeline status: success/failed/running/pending/canceled/skipped.
-  return [{ name: 'pipeline', status: p.status, conclusion: p.status }]
+  return [{ name: 'pipeline', status: p.status, conclusion: normalizePipelineConclusion(p.status) }]
 }
 
 export async function getMergeRequestDetail(
@@ -80,9 +146,9 @@ export async function getMergeRequestDetail(
 ): Promise<PullRequestDetailResult> {
   try {
     const base = `projects/${enc(projectPath)}/merge_requests/${mergeRequestNumber}`
-    const [mr, notesOut, approvals] = await Promise.all([
+    const [mr, comments, approvals] = await Promise.all([
       safeJson<{ description?: string; head_pipeline?: unknown }>(runner, base),
-      runner(['api', `${base}/notes?per_page=100`]).catch(() => ''),
+      fetchAllNotes(runner, base),
       safeJson<unknown>(runner, `${base}/approvals`),
     ])
 
@@ -93,7 +159,7 @@ export async function getMergeRequestDetail(
     const detail: PullRequestDetail = {
       number: mergeRequestNumber,
       body: mr.description || '',
-      comments: parseNotes(notesOut),
+      comments,
       reviews: parseApprovalsAsReviews(approvals),
       statusCheckRollup: parsePipelineAsChecks(mr.head_pipeline),
     }
@@ -110,9 +176,9 @@ export async function getGitLabIssueDetail(
 ): Promise<IssueDetailResult> {
   try {
     const base = `projects/${enc(projectPath)}/issues/${issueNumber}`
-    const [issue, notesOut] = await Promise.all([
+    const [issue, comments] = await Promise.all([
       safeJson<{ description?: string }>(runner, base),
-      runner(['api', `${base}/notes?per_page=100`]).catch(() => ''),
+      fetchAllNotes(runner, base),
     ])
 
     if (!issue) {
@@ -122,7 +188,7 @@ export async function getGitLabIssueDetail(
     const detail: IssueDetail = {
       number: issueNumber,
       body: issue.description || '',
-      comments: parseNotes(notesOut),
+      comments,
     }
     return { ok: true, detail }
   } catch (error) {

--- a/src/git/gitlabListData.test.ts
+++ b/src/git/gitlabListData.test.ts
@@ -285,4 +285,15 @@ describe('getMergeRequestList / getGitLabIssueList (#0.70)', () => {
     expect(overview.message).toContain('404 Project Not Found')
     expect(overview.pullRequests).toBeUndefined()
   })
+
+  it('scopes the glab auth probe to the remote host (self-hosted GitLab)', async () => {
+    const calls: string[][] = []
+    const runner = async (args: string[]) => {
+      calls.push(args)
+      return args[0] === 'auth' ? '' : '[]'
+    }
+    await getMergeRequestList(fakeGit('git@gitlab.example.com:group/proj.git'), {}, runner)
+    const authCall = calls.find((a) => a[0] === 'auth')
+    expect(authCall).toEqual(['auth', 'status', '--hostname', 'gitlab.example.com'])
+  })
 })

--- a/src/git/gitlabListData.ts
+++ b/src/git/gitlabListData.ts
@@ -201,7 +201,7 @@ export async function getMergeRequestList(
     return { available: false, authenticated: false, filter, message: 'No GitLab remote detected.' }
   }
 
-  const status = await getGlabStatus(runner)
+  const status = await getGlabStatus(runner, project.host)
   if (status.kind !== 'ok') {
     return {
       available: true,
@@ -295,7 +295,7 @@ export async function getGitLabIssueList(
     return { available: false, authenticated: false, filter, message: 'No GitLab remote detected.' }
   }
 
-  const status = await getGlabStatus(runner)
+  const status = await getGlabStatus(runner, project.host)
   if (status.kind !== 'ok') {
     return {
       available: true,
@@ -379,7 +379,7 @@ export async function getMergeRequestOverview(
 
   const repository = { owner: project.owner, name: project.name }
 
-  const status = await getGlabStatus(runner)
+  const status = await getGlabStatus(runner, project.host)
   if (status.kind !== 'ok') {
     return { available: true, authenticated: false, repository, currentBranch, message: describeGlabStatus(status) }
   }

--- a/src/git/glabCli.test.ts
+++ b/src/git/glabCli.test.ts
@@ -90,6 +90,7 @@ describe('getGitLabProject (#0.70)', () => {
       owner: 'group/sub',
       name: 'proj',
       path: 'group/sub/proj',
+      host: 'gitlab.com',
     })
   })
 

--- a/src/git/glabCli.ts
+++ b/src/git/glabCli.ts
@@ -22,6 +22,8 @@ export type GitLabProject = {
   owner: string
   name: string
   path: string
+  /** Remote host (gitlab.com or a self-hosted instance) for host-scoped auth. */
+  host: string
 }
 
 /**
@@ -62,6 +64,7 @@ export async function getGitLabProject(git: SimpleGit): Promise<GitLabProject | 
     owner: parsed.owner,
     name: parsed.name,
     path: parsed.owner ? `${parsed.owner}/${parsed.name}` : parsed.name,
+    host: parsed.host,
   }
 }
 

--- a/src/git/providerData.ts
+++ b/src/git/providerData.ts
@@ -340,7 +340,7 @@ async function getGitLabProviderOverview(
   localDefaultBranch: string | undefined,
   runner: GlabRunner
 ): Promise<ProviderOverview> {
-  const status = await getGlabStatus(runner)
+  const status = await getGlabStatus(runner, repository.host)
   if (status.kind !== 'ok') {
     return {
       repository: { ...repository, defaultBranch: localDefaultBranch },


### PR DESCRIPTION
Follow-ups from a post-release stability review of the multi-forge work (two background review agents over the GitLab data layer + detail hydration + error paths).

## Fixes
| Sev | Fix |
|-----|-----|
| 🟠 Med | **Self-hosted auth false-negatives.** `getGlabStatus` never received a host, so `glab auth status` checked the default instance (gitlab.com) instead of the repo's. On self-hosted GitLab a logged-in user could see a spurious "not authenticated", or a misleading "ok" that then 401s mid-fetch. `getGitLabProject` now carries the parsed remote host, and the list / issue / single-MR / provider-overview auth probes all pass it through. |
| 🟠 Med | **Failed pipelines miscounted as "other".** `parsePipelineAsChecks` emitted GitLab's raw status (`failed`/`running`/`canceled`) as the check conclusion, but the shared inspector renderer buckets on the GitHub vocabulary — so a red pipeline showed "1 other" instead of "1 fail". Normalized to `success`/`failure`/`in_progress`/`pending` at the source. |
| 🟠 Med | **Detail notes truncated at 100.** MR/issue notes were a single `per_page=100` request. Now pages through (2000-note ceiling) so long discussion threads aren't silently cut off — matching what the list loaders already do. |
| 🟡 Low | **`parseNotes` non-array guard.** GitLab returns `{ "message": ... }` on errors; without a guard the parser threw `notes.filter is not a function`, collapsing the *entire* detail panel. Now degrades to "no comments". (Flagged independently by both review agents.) |

## Tests
New coverage for host-scoping (auth probe receives `--hostname <self-hosted host>`), pipeline-status normalization (`failed`→`failure`, `running`→`in_progress`, `canceled`→`cancelled`), the non-array notes guard, and notes pagination across pages. Full suite green (lint + 3303 jest + build + CLI smoke + pack).

## Note
Self-hosted host-scoping is unit-tested (the probe now passes the right `--hostname`) but hasn't been validated against a live self-hosted instance — worth a real-world check before relying on it heavily.

## Still deferred (low severity, from the review)
- `resolveGlabActionError` re-probes auth without the host (only degrades a hint on an already-failed action — needs host threaded into the action layer).
- TUI forge-action dispatch has `try/finally` but no `catch` (latent defense-in-depth; nothing currently rejects).
- GitHub list parsers lack the `Array.isArray` guard the GitLab ones have (reverse-direction symmetry).
- Cosmetic keymap/idle-tip "PR" labels on GitLab.