### PR TITLE
fix(security): strip control/ANSI bytes from forge-rendered text

### DIFF
--- a/src/git/forgeText.test.ts
+++ b/src/git/forgeText.test.ts
@@ -1,0 +1,109 @@
+import {
+  sanitizeIssueDetail,
+  sanitizeIssueListItem,
+  sanitizePullRequestDetail,
+  sanitizePullRequestListItem,
+  stripControl,
+  stripControlMultiline,
+} from './forgeText'
+
+// Build control bytes from codes so no literal control char lives in source.
+const ESC = String.fromCharCode(0x1b)
+const BEL = String.fromCharCode(0x07)
+const CR = String.fromCharCode(0x0d)
+const TAB = String.fromCharCode(0x09)
+
+describe('forge text sanitization (terminal-injection hardening)', () => {
+  describe('stripControl', () => {
+    it('removes ESC / CR / C0 / C1 control bytes but keeps printable text', () => {
+      expect(stripControl(`${ESC}[2J${ESC}[31mhi${ESC}[0m`)).toBe('[2J[31mhi[0m')
+      expect(stripControl(`line1${CR}\nline2`)).toBe('line1line2')
+      expect(stripControl(`tab${TAB}here`)).toBe('tabhere')
+      expect(stripControl('plain title')).toBe('plain title')
+    })
+
+    it('strips OSC clipboard-write sequences (no ESC, no BEL survive)', () => {
+      const cleaned = stripControl(`${ESC}]52;c;ZXZpbA==${BEL}`)
+      expect(cleaned).not.toContain(ESC)
+      expect(cleaned).not.toContain(BEL)
+      expect(cleaned).toBe(']52;c;ZXZpbA==')
+    })
+
+    it('keeps wide / unicode characters', () => {
+      expect(stripControl('日本語 🚀')).toBe('日本語 🚀')
+    })
+  })
+
+  describe('stripControlMultiline', () => {
+    it('keeps newlines but strips ESC and other control bytes', () => {
+      expect(stripControlMultiline(`para1${ESC}[31m\npara2`)).toBe('para1[31m\npara2')
+    })
+    it('normalizes CRLF / CR to LF', () => {
+      expect(stripControlMultiline(`a${CR}\nb${CR}c`)).toBe('a\nb\nc')
+    })
+  })
+
+  describe('view-model sanitizers', () => {
+    it('strips control bytes from every rendered PR list field', () => {
+      const out = sanitizePullRequestListItem({
+        number: 1,
+        title: `${ESC}[2JOwned`,
+        url: `https://x/${ESC}`,
+        state: 'OPEN',
+        isDraft: false,
+        headRefName: `feat/${ESC}[31m`,
+        baseRefName: 'main',
+        author: `al${ESC}ice`,
+        assignees: [`bo${ESC}b`],
+        labels: [`bu${ESC}g`],
+        createdAt: 't',
+        updatedAt: 't',
+      })
+      expect(out.title).toBe('[2JOwned')
+      expect(out.url).toBe('https://x/')
+      expect(out.headRefName).toBe('feat/[31m')
+      expect(out.author).toBe('alice')
+      expect(out.assignees).toEqual(['bob'])
+      expect(out.labels).toEqual(['bug'])
+    })
+
+    it('strips control bytes from issue list fields', () => {
+      const out = sanitizeIssueListItem({
+        number: 2,
+        title: `${ESC}]0;evil`,
+        url: 'https://x',
+        state: 'OPEN',
+        author: `${ESC}x`,
+        labels: [`${ESC}l`],
+        createdAt: 't',
+        updatedAt: 't',
+      })
+      expect(out.title).not.toContain(ESC)
+      expect(out.author).toBe('x')
+      expect(out.labels).toEqual(['l'])
+    })
+
+    it('strips PR detail body/comments/reviews while preserving newlines in bodies', () => {
+      const out = sanitizePullRequestDetail({
+        number: 3,
+        body: `line1${ESC}[31m\nline2`,
+        comments: [{ author: `${ESC}a`, body: `c${ESC}1`, createdAt: 't' }],
+        reviews: [{ author: `${ESC}r`, state: 'APPROVED', body: `${ESC}ok`, submittedAt: 't' }],
+        statusCheckRollup: [],
+      })
+      expect(out.body).toBe('line1[31m\nline2')
+      expect(out.comments[0]).toEqual({ author: 'a', body: 'c1', createdAt: 't' })
+      expect(out.reviews[0]).toEqual({ author: 'r', state: 'APPROVED', body: 'ok', submittedAt: 't' })
+    })
+
+    it('strips issue detail body + comments', () => {
+      const out = sanitizeIssueDetail({
+        number: 4,
+        body: `${ESC}[2Jhi`,
+        comments: [{ author: 'a', body: `x${ESC}y`, createdAt: 't' }],
+      })
+      expect(out.body).toBe('[2Jhi')
+      expect(out.comments[0].body).toBe('xy')
+    })
+  })
+})

--- a/src/git/forgeText.ts
+++ b/src/git/forgeText.ts
@@ -1,0 +1,117 @@
+/**
+ * Sanitize untrusted forge-authored text before it reaches the terminal.
+ *
+ * MR/issue/PR titles, bodies, comments, author names, labels, and branch names
+ * come from the GitHub/GitLab APIs and are rendered into the CLI output and the
+ * Ink TUI — interleaved with coco's own chalk/ANSI, so the render layer can't
+ * just be stripped. A hostile author can embed ANSI / control sequences to wipe
+ * scrollback, spoof triage rows (fake "approved", impersonate an MR number),
+ * rewrite the terminal title, or drive OSC 52 clipboard writes. We strip
+ * control bytes here, at the data boundary, so every downstream surface (both
+ * forges, CLI and TUI) only ever renders inert text.
+ *
+ * Control bytes stripped: C0 (0x00-0x1f, includes ESC 0x1b and CR) and DEL/C1
+ * (0x7f-0x9f). The multi-line variant preserves the newline (0x0a) so body and
+ * comment paragraphs survive; the inline variant strips everything for
+ * single-line cells (titles, authors, branches, labels) where a stray newline
+ * would also break the row layout.
+ */
+import type { PullRequestListItem } from './pullRequestListData'
+import type { IssueListItem } from './issuesListData'
+import type { PullRequestDetail } from './pullRequestDetailData'
+import type { IssueComment, IssueDetail } from './issueDetailData'
+import type { PullRequestInfo } from './pullRequestData'
+
+function isControl(codePoint: number, keepNewline: boolean): boolean {
+  if (keepNewline && codePoint === 0x0a) return false
+  return codePoint < 0x20 || (codePoint >= 0x7f && codePoint <= 0x9f)
+}
+
+function strip(value: string, keepNewline: boolean): string {
+  let out = ''
+  for (const ch of value) {
+    const code = ch.codePointAt(0)
+    if (code !== undefined && isControl(code, keepNewline)) continue
+    out += ch
+  }
+  return out
+}
+
+/** Strip all control bytes — single-line fields (title, author, branch, label, url). */
+export function stripControl(value: string): string {
+  return strip(value, false)
+}
+
+/** Strip control bytes but keep newlines — multi-line fields (body, comment). */
+export function stripControlMultiline(value: string): string {
+  return strip(value.replace(/\r\n?/g, '\n'), true)
+}
+
+function clean(value: string | undefined): string | undefined {
+  return value === undefined ? undefined : stripControl(value)
+}
+
+function cleanArray(values: string[] | undefined): string[] | undefined {
+  return values?.map(stripControl)
+}
+
+export function sanitizePullRequestListItem(item: PullRequestListItem): PullRequestListItem {
+  return {
+    ...item,
+    title: stripControl(item.title),
+    url: stripControl(item.url),
+    headRefName: stripControl(item.headRefName),
+    baseRefName: stripControl(item.baseRefName),
+    author: clean(item.author),
+    assignees: cleanArray(item.assignees),
+    labels: cleanArray(item.labels),
+  }
+}
+
+export function sanitizeIssueListItem(item: IssueListItem): IssueListItem {
+  return {
+    ...item,
+    title: stripControl(item.title),
+    url: stripControl(item.url),
+    author: clean(item.author),
+    assignees: cleanArray(item.assignees),
+    labels: cleanArray(item.labels),
+  }
+}
+
+function sanitizeComment(comment: IssueComment): IssueComment {
+  return { ...comment, author: clean(comment.author), body: stripControlMultiline(comment.body) }
+}
+
+export function sanitizePullRequestDetail(detail: PullRequestDetail): PullRequestDetail {
+  return {
+    ...detail,
+    body: stripControlMultiline(detail.body),
+    comments: detail.comments.map(sanitizeComment),
+    reviews: detail.reviews.map((review) => ({
+      ...review,
+      author: clean(review.author),
+      body: stripControlMultiline(review.body),
+    })),
+  }
+}
+
+export function sanitizeIssueDetail(detail: IssueDetail): IssueDetail {
+  return {
+    ...detail,
+    body: stripControlMultiline(detail.body),
+    comments: detail.comments.map(sanitizeComment),
+  }
+}
+
+export function sanitizePullRequestInfo(info: PullRequestInfo): PullRequestInfo {
+  return {
+    ...info,
+    title: stripControl(info.title),
+    url: stripControl(info.url),
+    headRefName: stripControl(info.headRefName),
+    baseRefName: stripControl(info.baseRefName),
+    body: info.body === undefined ? undefined : stripControlMultiline(info.body),
+    author: clean(info.author),
+  }
+}

--- a/src/git/gitlabDetailData.ts
+++ b/src/git/gitlabDetailData.ts
@@ -1,4 +1,5 @@
 import { defaultGlabRunner, type GlabRunner } from './glabCli'
+import { sanitizeIssueDetail, sanitizePullRequestDetail } from './forgeText'
 import type { IssueComment, IssueDetail, IssueDetailResult } from './issueDetailData'
 import type {
   PullRequestDetail,
@@ -163,7 +164,7 @@ export async function getMergeRequestDetail(
       reviews: parseApprovalsAsReviews(approvals),
       statusCheckRollup: parsePipelineAsChecks(mr.head_pipeline),
     }
-    return { ok: true, detail }
+    return { ok: true, detail: sanitizePullRequestDetail(detail) }
   } catch (error) {
     return { ok: false, message: error instanceof Error ? error.message : String(error) }
   }
@@ -190,7 +191,7 @@ export async function getGitLabIssueDetail(
       body: issue.description || '',
       comments,
     }
-    return { ok: true, detail }
+    return { ok: true, detail: sanitizeIssueDetail(detail) }
   } catch (error) {
     return { ok: false, message: error instanceof Error ? error.message : String(error) }
   }

--- a/src/git/gitlabListData.ts
+++ b/src/git/gitlabListData.ts
@@ -11,6 +11,11 @@ import type {
   PullRequestListOverview,
 } from './pullRequestListData'
 import type { PullRequestInfo, PullRequestOverview } from './pullRequestData'
+import {
+  sanitizeIssueListItem,
+  sanitizePullRequestInfo,
+  sanitizePullRequestListItem,
+} from './forgeText'
 
 /**
  * GitLab list loaders. These produce the SAME overview shapes as the GitHub
@@ -229,7 +234,7 @@ export async function getMergeRequestList(
       authenticated: true,
       repository: { owner: project.owner, name: project.name },
       filter,
-      pullRequests,
+      pullRequests: pullRequests.map(sanitizePullRequestListItem),
     }
   } catch (error) {
     return {
@@ -320,7 +325,7 @@ export async function getGitLabIssueList(
       authenticated: true,
       repository: { owner: project.owner, name: project.name },
       filter,
-      issues,
+      issues: issues.map(sanitizeIssueListItem),
     }
   } catch (error) {
     return {
@@ -397,7 +402,7 @@ export async function getMergeRequestOverview(
       authenticated: true,
       repository,
       currentBranch,
-      currentPullRequest: mr ? mrToPullRequestInfo(mr) : undefined,
+      currentPullRequest: mr ? sanitizePullRequestInfo(mrToPullRequestInfo(mr)) : undefined,
       ...(mr ? {} : { message: `No merge request found for ${currentBranch}.` }),
     }
   } catch (error) {

--- a/src/git/issueDetailData.ts
+++ b/src/git/issueDetailData.ts
@@ -12,6 +12,7 @@
  */
 
 import { defaultGhRunner, type GhRunner } from './githubCli'
+import { sanitizeIssueDetail } from './forgeText'
 
 export type IssueComment = {
   author?: string
@@ -82,7 +83,7 @@ export async function getIssueDetail(
     if (!detail) {
       return { ok: false, message: `Empty response from gh for issue #${issueNumber}` }
     }
-    return { ok: true, detail }
+    return { ok: true, detail: sanitizeIssueDetail(detail) }
   } catch (error) {
     return {
       ok: false,

--- a/src/git/issuesListData.ts
+++ b/src/git/issuesListData.ts
@@ -1,4 +1,5 @@
 import { SimpleGit } from 'simple-git'
+import { sanitizeIssueListItem } from './forgeText'
 import {
     defaultGhRunner,
     describeGhStatus,
@@ -156,7 +157,7 @@ export async function getIssueList(
       authenticated: true,
       repository,
       filter,
-      issues: parseIssueListItems(output),
+      issues: parseIssueListItems(output).map(sanitizeIssueListItem),
     }
   } catch (error) {
     return {

--- a/src/git/pullRequestDetailData.ts
+++ b/src/git/pullRequestDetailData.ts
@@ -12,6 +12,7 @@
  */
 
 import { defaultGhRunner, type GhRunner } from './githubCli'
+import { sanitizePullRequestDetail } from './forgeText'
 import type { IssueComment } from './issueDetailData'
 
 export type PullRequestReview = {
@@ -139,7 +140,7 @@ export async function getPullRequestDetail(
         message: `Empty response from gh for pull request #${pullRequestNumber}`,
       }
     }
-    return { ok: true, detail }
+    return { ok: true, detail: sanitizePullRequestDetail(detail) }
   } catch (error) {
     return {
       ok: false,

--- a/src/git/pullRequestListData.ts
+++ b/src/git/pullRequestListData.ts
@@ -1,4 +1,5 @@
 import { SimpleGit } from 'simple-git'
+import { sanitizePullRequestListItem } from './forgeText'
 import {
     defaultGhRunner,
     describeGhStatus,
@@ -182,7 +183,7 @@ export async function getPullRequestList(
       authenticated: true,
       repository,
       filter,
-      pullRequests: parsePullRequestListItems(output),
+      pullRequests: parsePullRequestListItems(output).map(sanitizePullRequestListItem),
     }
   } catch (error) {
     return {

--- a/src/workstation/chrome/hyperlinks.ts
+++ b/src/workstation/chrome/hyperlinks.ts
@@ -11,6 +11,8 @@
  * Sequence:  ESC ] 8 ; ; <url> ESC \  <text>  ESC ] 8 ; ;  ESC \
  */
 
+import { stripControl } from '../../git/forgeText'
+
 const ESC = '\u001b'
 const OSC_PREFIX = `${ESC}]8;;`
 const ST = `${ESC}\\`
@@ -88,5 +90,9 @@ export function formatHyperlink(
   if (!supportsHyperlinks(env)) {
     return text
   }
-  return `${OSC_PREFIX}${url}${ST}${text}${OSC_PREFIX}${ST}`
+  // Strip control bytes from the URL so a hostile `web_url` can't carry an ESC
+  // or ST (string terminator) that closes the OSC 8 sequence early and injects
+  // raw escapes into the terminal.
+  const safeUrl = stripControl(url)
+  return `${OSC_PREFIX}${safeUrl}${ST}${text}${OSC_PREFIX}${ST}`
 }


### PR DESCRIPTION
Hardens the one **HIGH** finding from the security/stability audit of the multi-forge work: terminal/ANSI injection from untrusted forge text.

## The issue
MR/issue/PR **titles, bodies, comments, author names, labels, and branch names** come from the GitHub/GitLab APIs and were rendered into the CLI output and the Ink TUI inspector/triage rows with **no control-character sanitization**. `cellWidth`/`truncateCells` count `ESC`/control bytes as width 0 and pass them through verbatim. An attacker who authors an MR/issue/comment (or names a branch/label) that a victim triages could:
- wipe scrollback / clear the screen,
- **spoof triage rows** — fake an "approved" marker or impersonate a different MR number to trick a merge,
- rewrite the terminal title, or drive **OSC 52 clipboard writes** on permissive terminals,
- defeat truncation limits (control bytes measure as 0 width).

## The fix
The render sink legitimately interleaves coco's own chalk/ANSI, so it can't be blanket-stripped — sanitize at the **data boundary** instead:
- New `src/git/forgeText.ts`: strips C0/C1 control bytes (including `ESC`) via codepoint checks. `stripControl` for single-line fields (title, author, branch, label, url); `stripControlMultiline` keeps newlines for bodies/comments.
- Per-type sanitizers applied in **both forges'** list, detail, and single-MR parsers (`gitlabListData`, `gitlabDetailData`, `pullRequestListData`, `issuesListData`, `pullRequestDetailData`, `issueDetailData`) — so every downstream surface (CLI + TUI) only ever renders inert text.
- The OSC 8 hyperlink helper also strips its URL (prevents an early-terminated escape via a hostile `web_url`).

Sanitization is a no-op on clean data, so existing parser/snapshot tests are unaffected.

## Tests
New `forgeText.test.ts` (control-byte stripping incl. OSC 52, newline preservation, per-type sanitizers). Full suite green: lint + **3312** jest + build + CLI smoke + pack.

## Audit context (the rest was clean)
No RCE/shell injection (execFile + argv), no SSRF/endpoint injection (encodeURIComponent everywhere), no secret leakage, no ReDoS, no DoS (bounded pagination + maxBuffer/timeout), no crash paths. The remaining audit item — argument/flag injection hardening (Medium, defense-in-depth) — follows in a separate PR.