### PR TITLE
fix(security): harden gh/glab arg construction against flag injection

### DIFF
--- a/src/git/forgeArgGuards.ts
+++ b/src/git/forgeArgGuards.ts
@@ -1,0 +1,18 @@
+/**
+ * Defensive guards for values that flow into gh/glab argv. With execFile (no
+ * shell) there is no command injection, but a value beginning with '-' can be
+ * misparsed by gh/glab as a flag, and glab comma-splits assignee/label lists.
+ * Action builders pass values as `--flag=value` (so flag injection is already
+ * neutralized), and these guards reject the few shapes that could still alter
+ * operation semantics.
+ */
+export function rejectFlagLike(value: string, label: string): string | undefined {
+  if (value.startsWith('-')) return `${label} cannot start with '-'.`
+  return undefined
+}
+
+export function rejectUnsafeUsername(value: string): string | undefined {
+  if (value.startsWith('-')) return `Username '${value}' cannot start with '-'.`
+  if (/[,\s]/.test(value)) return `Username '${value}' cannot contain commas or whitespace.`
+  return undefined
+}

--- a/src/git/gitlabIssueActions.test.ts
+++ b/src/git/gitlabIssueActions.test.ts
@@ -20,9 +20,9 @@ describe('GitLab issue action arg contracts (#0.70)', () => {
     await closeGitLabIssue(7, runner)
     await reopenGitLabIssue(7, runner)
     expect(calls).toEqual([
-      ['issue', 'note', '7', '--message', 'hi'],
-      ['issue', 'update', '7', '--label', 'bug'],
-      ['issue', 'update', '7', '--assignee', '+bob'],
+      ['issue', 'note', '7', '--message=hi'],
+      ['issue', 'update', '7', '--label=bug'],
+      ['issue', 'update', '7', '--assignee=+bob'],
       ['issue', 'close', '7'],
       ['issue', 'reopen', '7'],
     ])
@@ -33,6 +33,14 @@ describe('GitLab issue action arg contracts (#0.70)', () => {
     expect((await commentGitLabIssue(7, '   ')).ok).toBe(false)
     expect((await addGitLabIssueLabel(7, '')).ok).toBe(false)
     expect((await addGitLabIssueAssignee(7, '')).ok).toBe(false)
+    expect(calls).toHaveLength(0)
+  })
+
+  it('rejects flag-like / unsafe arg shapes without shelling out', async () => {
+    const { calls, runner } = capturingRunner()
+    expect((await addGitLabIssueLabel(7, '--delete', runner)).ok).toBe(false)
+    expect((await addGitLabIssueAssignee(7, '-rf', runner)).ok).toBe(false)
+    expect((await addGitLabIssueAssignee(7, 'bob,carol', runner)).ok).toBe(false)
     expect(calls).toHaveLength(0)
   })
 

--- a/src/git/gitlabIssueActions.ts
+++ b/src/git/gitlabIssueActions.ts
@@ -1,4 +1,5 @@
 import { defaultGlabRunner, resolveGlabActionError, type GlabRunner } from './glabCli'
+import { rejectFlagLike, rejectUnsafeUsername } from './forgeArgGuards'
 import type { IssueActionResult } from './issueActions'
 
 /**
@@ -33,7 +34,7 @@ export function commentGitLabIssue(
   }
   return runGlabAction(
     runner,
-    ['issue', 'note', String(issueNumber), '--message', body],
+    ['issue', 'note', String(issueNumber), `--message=${body}`],
     (output) => ({
       ok: true,
       message: output.trim() || `Commented on issue #${issueNumber}`,
@@ -49,9 +50,11 @@ export function addGitLabIssueLabel(
   if (!label.trim()) {
     return Promise.resolve({ ok: false, message: 'Label name required' })
   }
+  const bad = rejectFlagLike(label, 'Label')
+  if (bad) return Promise.resolve({ ok: false, message: bad })
   return runGlabAction(
     runner,
-    ['issue', 'update', String(issueNumber), '--label', label],
+    ['issue', 'update', String(issueNumber), `--label=${label}`],
     () => ({
       ok: true,
       message: `Added label '${label}' to issue #${issueNumber}`,
@@ -67,10 +70,12 @@ export function addGitLabIssueAssignee(
   if (!assignee.trim()) {
     return Promise.resolve({ ok: false, message: 'Assignee username required' })
   }
+  const bad = rejectUnsafeUsername(assignee)
+  if (bad) return Promise.resolve({ ok: false, message: bad })
   return runGlabAction(
     runner,
     // `+` prefix ADDS to existing assignees; a bare username would replace them.
-    ['issue', 'update', String(issueNumber), '--assignee', `+${assignee}`],
+    ['issue', 'update', String(issueNumber), `--assignee=+${assignee}`],
     () => ({
       ok: true,
       message: `Assigned ${assignee} to issue #${issueNumber}`,

--- a/src/git/issueActions.test.ts
+++ b/src/git/issueActions.test.ts
@@ -23,7 +23,7 @@ describe('issueActions', () => {
         ok: true,
         message: 'https://github.com/gfargo/coco/issues/882#comment-1',
       })
-      expect(runner).toHaveBeenCalledWith(['issue', 'comment', '882', '--body', 'lgtm'])
+      expect(runner).toHaveBeenCalledWith(['issue', 'comment', '882', '--body=lgtm'])
     })
 
     it('falls back to a synthesized message when gh output is empty', async () => {
@@ -75,7 +75,7 @@ describe('issueActions', () => {
         ok: true,
         message: "Added label 'enhancement' to issue #882",
       })
-      expect(runner).toHaveBeenCalledWith(['issue', 'edit', '882', '--add-label', 'enhancement'])
+      expect(runner).toHaveBeenCalledWith(['issue', 'edit', '882', '--add-label=enhancement'])
     })
   })
 
@@ -95,7 +95,22 @@ describe('issueActions', () => {
         ok: true,
         message: 'Assigned @me to issue #882',
       })
-      expect(runner).toHaveBeenCalledWith(['issue', 'edit', '882', '--add-assignee', '@me'])
+      expect(runner).toHaveBeenCalledWith(['issue', 'edit', '882', '--add-assignee=@me'])
+    })
+
+    it('rejects flag-like / comma-bearing logins without invoking gh', async () => {
+      const runner = jest.fn()
+      expect((await addIssueAssignee(882, '-rf', runner)).ok).toBe(false)
+      expect((await addIssueAssignee(882, 'bob,carol', runner)).ok).toBe(false)
+      expect(runner).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('addIssueLabel guards', () => {
+    it('rejects flag-like labels without invoking gh', async () => {
+      const runner = jest.fn()
+      expect((await addIssueLabel(882, '--delete', runner)).ok).toBe(false)
+      expect(runner).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/git/issueActions.ts
+++ b/src/git/issueActions.ts
@@ -12,6 +12,7 @@
  */
 
 import { defaultGhRunner, resolveGhActionError, type GhRunner } from './githubCli'
+import { rejectFlagLike, rejectUnsafeUsername } from './forgeArgGuards'
 
 export type IssueActionResult = {
   ok: boolean
@@ -47,7 +48,7 @@ export function commentIssue(
   }
   return runGhAction(
     runner,
-    ['issue', 'comment', String(issueNumber), '--body', body],
+    ['issue', 'comment', String(issueNumber), `--body=${body}`],
     (output) => ({
       ok: true,
       message: output.trim() || `Commented on issue #${issueNumber}`,
@@ -63,9 +64,11 @@ export function addIssueLabel(
   if (!label.trim()) {
     return Promise.resolve({ ok: false, message: 'Label name required' })
   }
+  const bad = rejectFlagLike(label, 'Label')
+  if (bad) return Promise.resolve({ ok: false, message: bad })
   return runGhAction(
     runner,
-    ['issue', 'edit', String(issueNumber), '--add-label', label],
+    ['issue', 'edit', String(issueNumber), `--add-label=${label}`],
     () => ({
       ok: true,
       message: `Added label '${label}' to issue #${issueNumber}`,
@@ -81,9 +84,11 @@ export function addIssueAssignee(
   if (!assignee.trim()) {
     return Promise.resolve({ ok: false, message: 'Assignee login required' })
   }
+  const bad = rejectUnsafeUsername(assignee)
+  if (bad) return Promise.resolve({ ok: false, message: bad })
   return runGhAction(
     runner,
-    ['issue', 'edit', String(issueNumber), '--add-assignee', assignee],
+    ['issue', 'edit', String(issueNumber), `--add-assignee=${assignee}`],
     () => ({
       ok: true,
       message: `Assigned ${assignee} to issue #${issueNumber}`,

--- a/src/git/mergeRequestActions.test.ts
+++ b/src/git/mergeRequestActions.test.ts
@@ -28,14 +28,10 @@ describe('buildCreateMergeRequestArgs (#0.70)', () => {
     ).toEqual([
       'mr',
       'create',
-      '--source-branch',
-      'feature/x',
-      '--target-branch',
-      'main',
-      '--title',
-      'T',
-      '--description',
-      'B',
+      '--source-branch=feature/x',
+      '--target-branch=main',
+      '--title=T',
+      '--description=B',
       '--push',
       '--yes',
     ])
@@ -97,10 +93,10 @@ describe('MR mutating action arg contracts (#0.70)', () => {
       ['mr', 'merge', '5', '--yes'],
       ['mr', 'approve', '5'],
       ['mr', 'close', '5'],
-      ['mr', 'note', 'create', '5', '--message', 'hi'],
-      ['mr', 'note', 'create', '5', '--message', 'Requested changes: fix it'],
-      ['mr', 'update', '5', '--label', 'bug'],
-      ['mr', 'update', '5', '--assignee', '+bob'],
+      ['mr', 'note', 'create', '5', '--message=hi'],
+      ['mr', 'note', 'create', '5', '--message=Requested changes: fix it'],
+      ['mr', 'update', '5', '--label=bug'],
+      ['mr', 'update', '5', '--assignee=+bob'],
     ])
   })
 
@@ -114,7 +110,7 @@ describe('MR mutating action arg contracts (#0.70)', () => {
       ['mr', 'merge', '--rebase', '--yes'],
       ['mr', 'close'],
       ['mr', 'approve'],
-      ['mr', 'note', 'create', '--message', 'hello'],
+      ['mr', 'note', 'create', '--message=hello'],
     ])
   })
 
@@ -122,5 +118,14 @@ describe('MR mutating action arg contracts (#0.70)', () => {
     expect((await commentMergeRequestByNumber(5, '  ')).ok).toBe(false)
     expect((await addMergeRequestLabel(5, '')).ok).toBe(false)
     expect((await addMergeRequestAssignee(5, '')).ok).toBe(false)
+  })
+
+  it('rejects flag-like / unsafe arg shapes without invoking glab', async () => {
+    const { calls, runner } = capturingRunner()
+    expect((await addMergeRequestLabel(5, '--delete', runner)).ok).toBe(false)
+    expect((await addMergeRequestAssignee(5, '-rf', runner)).ok).toBe(false)
+    expect((await addMergeRequestAssignee(5, 'bob,carol', runner)).ok).toBe(false)
+    expect((await createMergeRequest({ base: 'main', head: '--foo', title: 'T', body: 'B' }, runner)).ok).toBe(false)
+    expect(calls).toEqual([])
   })
 })

--- a/src/git/mergeRequestActions.ts
+++ b/src/git/mergeRequestActions.ts
@@ -1,4 +1,5 @@
 import { defaultGlabRunner, resolveGlabActionError, type GlabRunner } from './glabCli'
+import { rejectFlagLike, rejectUnsafeUsername } from './forgeArgGuards'
 import type { PullRequestActionResult } from './pullRequestActions'
 
 /**
@@ -43,14 +44,10 @@ export function buildCreateMergeRequestArgs(input: CreateMergeRequestInput): str
   const args = [
     'mr',
     'create',
-    '--source-branch',
-    input.head,
-    '--target-branch',
-    input.base,
-    '--title',
-    input.title,
-    '--description',
-    input.body,
+    `--source-branch=${input.head}`,
+    `--target-branch=${input.base}`,
+    `--title=${input.title}`,
+    `--description=${input.body}`,
     // Push the (committed) source branch as part of creation so the MR can be
     // opened even when the branch isn't on the remote yet — mirrors how the
     // GitHub flow expects a pushed branch.
@@ -69,6 +66,8 @@ export function createMergeRequest(
   input: CreateMergeRequestInput,
   runner: GlabRunner = defaultGlabRunner
 ): Promise<PullRequestActionResult> {
+  const bad = rejectFlagLike(input.head, 'Branch name') || rejectFlagLike(input.base, 'Branch name')
+  if (bad) return Promise.resolve({ ok: false, message: bad })
   return runGlabAction(runner, buildCreateMergeRequestArgs(input), (output) => {
     const url = parseCreatedMergeRequestUrl(output)
     return {
@@ -153,7 +152,7 @@ export function commentMergeRequestByNumber(
   }
   return runGlabAction(
     runner,
-    ['mr', 'note', 'create', String(mergeRequestNumber), '--message', body],
+    ['mr', 'note', 'create', String(mergeRequestNumber), `--message=${body}`],
     (output) => ({
       ok: true,
       message: output.trim() || `Commented on merge request !${mergeRequestNumber}`,
@@ -176,7 +175,7 @@ export function requestChangesMergeRequestByNumber(
   }
   return runGlabAction(
     runner,
-    ['mr', 'note', 'create', String(mergeRequestNumber), '--message', `Requested changes: ${body}`],
+    ['mr', 'note', 'create', String(mergeRequestNumber), `--message=Requested changes: ${body}`],
     (output) => ({
       ok: true,
       message: output.trim() || `Requested changes on merge request !${mergeRequestNumber}`,
@@ -192,9 +191,11 @@ export function addMergeRequestLabel(
   if (!label.trim()) {
     return Promise.resolve({ ok: false, message: 'Label name required' })
   }
+  const bad = rejectFlagLike(label, 'Label')
+  if (bad) return Promise.resolve({ ok: false, message: bad })
   return runGlabAction(
     runner,
-    ['mr', 'update', String(mergeRequestNumber), '--label', label],
+    ['mr', 'update', String(mergeRequestNumber), `--label=${label}`],
     () => ({
       ok: true,
       message: `Added label '${label}' to merge request !${mergeRequestNumber}`,
@@ -210,10 +211,12 @@ export function addMergeRequestAssignee(
   if (!assignee.trim()) {
     return Promise.resolve({ ok: false, message: 'Assignee username required' })
   }
+  const bad = rejectUnsafeUsername(assignee)
+  if (bad) return Promise.resolve({ ok: false, message: bad })
   return runGlabAction(
     runner,
     // `+` prefix ADDS to existing assignees; a bare username would replace them.
-    ['mr', 'update', String(mergeRequestNumber), '--assignee', `+${assignee}`],
+    ['mr', 'update', String(mergeRequestNumber), `--assignee=+${assignee}`],
     () => ({
       ok: true,
       message: `Assigned ${assignee} to merge request !${mergeRequestNumber}`,
@@ -259,7 +262,7 @@ export function commentMergeRequest(
   if (!body.trim()) {
     return Promise.resolve({ ok: false, message: 'Comment body required' })
   }
-  return runGlabAction(runner, ['mr', 'note', 'create', '--message', body], (output) => ({
+  return runGlabAction(runner, ['mr', 'note', 'create', `--message=${body}`], (output) => ({
     ok: true,
     message: output.trim() || 'Comment added',
   }))
@@ -272,7 +275,7 @@ export function requestChangesMergeRequest(
   if (!body.trim()) {
     return Promise.resolve({ ok: false, message: 'Review body required for change-request' })
   }
-  return runGlabAction(runner, ['mr', 'note', 'create', '--message', `Requested changes: ${body}`], (output) => ({
+  return runGlabAction(runner, ['mr', 'note', 'create', `--message=Requested changes: ${body}`], (output) => ({
     ok: true,
     message: output.trim() || 'Requested changes',
   }))

--- a/src/git/pullRequestActions.test.ts
+++ b/src/git/pullRequestActions.test.ts
@@ -28,14 +28,10 @@ describe('log pull request actions', () => {
     })).toEqual([
       'pr',
       'create',
-      '--base',
-      'main',
-      '--head',
-      'feature/pr',
-      '--title',
-      'Add PR workflow',
-      '--body',
-      'Generated body',
+      '--base=main',
+      '--head=feature/pr',
+      '--title=Add PR workflow',
+      '--body=Generated body',
     ])
 
     expect(buildCreatePullRequestArgs({
@@ -69,6 +65,13 @@ describe('log pull request actions', () => {
       url: 'https://github.com/gfargo/coco/pull/123',
     })
     expect(runner).toHaveBeenLastCalledWith(['pr', 'view', '--web'])
+  })
+
+  it('rejects flag-like branch names on create without invoking gh', async () => {
+    const runner = jest.fn()
+    expect((await createPullRequest({ base: 'main', head: '--foo', title: 'T', body: 'B' }, runner)).ok).toBe(false)
+    expect((await createPullRequest({ base: '-x', head: 'feature/pr', title: 'T', body: 'B' }, runner)).ok).toBe(false)
+    expect(runner).not.toHaveBeenCalled()
   })
 
   // #783 — full PR action panel. Each action wraps a single
@@ -119,14 +122,14 @@ describe('log pull request actions', () => {
         message: 'Requested changes',
       })
       expect(runner).toHaveBeenLastCalledWith([
-        'pr', 'review', '--request-changes', '--body', 'please address X',
+        'pr', 'review', '--request-changes', '--body=please address X',
       ])
 
       await expect(commentPullRequest('lgtm', runner)).resolves.toEqual({
         ok: true,
         message: 'Comment added',
       })
-      expect(runner).toHaveBeenLastCalledWith(['pr', 'comment', '--body', 'lgtm'])
+      expect(runner).toHaveBeenLastCalledWith(['pr', 'comment', '--body=lgtm'])
     })
 
     it('rejects empty bodies for request-changes and comment without invoking gh', async () => {
@@ -198,7 +201,7 @@ describe('triage-by-number PR actions (#882 phase 4)', () => {
         ok: true,
         message: 'Commented on pull request #962',
       })
-      expect(runner).toHaveBeenCalledWith(['pr', 'comment', '962', '--body', 'lgtm'])
+      expect(runner).toHaveBeenCalledWith(['pr', 'comment', '962', '--body=lgtm'])
     })
   })
 
@@ -218,9 +221,15 @@ describe('triage-by-number PR actions (#882 phase 4)', () => {
         ok: true,
         message: "Added label 'enhancement' to pull request #962",
       })
-      expect(runner).toHaveBeenCalledWith(['pr', 'edit', '962', '--add-label', 'enhancement'])
+      expect(runner).toHaveBeenCalledWith(['pr', 'edit', '962', '--add-label=enhancement'])
     })
-  })
+
+    it('rejects flag-like labels without invoking gh', async () => {
+      const runner = jest.fn()
+      expect((await addPullRequestLabel(962, '--delete', runner)).ok).toBe(false)
+      expect(runner).not.toHaveBeenCalled()
+    })
+})
 
   describe('addPullRequestAssignee', () => {
     it('rejects empty assignees', async () => {
@@ -237,7 +246,14 @@ describe('triage-by-number PR actions (#882 phase 4)', () => {
         ok: true,
         message: 'Assigned @me to pull request #962',
       })
-      expect(runner).toHaveBeenCalledWith(['pr', 'edit', '962', '--add-assignee', '@me'])
+      expect(runner).toHaveBeenCalledWith(['pr', 'edit', '962', '--add-assignee=@me'])
+    })
+
+    it('rejects flag-like / comma-bearing logins without invoking gh', async () => {
+      const runner = jest.fn()
+      expect((await addPullRequestAssignee(962, '-rf', runner)).ok).toBe(false)
+      expect((await addPullRequestAssignee(962, 'bob,carol', runner)).ok).toBe(false)
+      expect(runner).not.toHaveBeenCalled()
     })
 
     it('surfaces gh errors as ok: false', async () => {
@@ -321,7 +337,7 @@ describe('destructive PR by-number actions (#882 phase 5)', () => {
         message: 'Requested changes on pull request #962',
       })
       expect(runner).toHaveBeenCalledWith([
-        'pr', 'review', '962', '--request-changes', '--body', 'please address X',
+        'pr', 'review', '962', '--request-changes', '--body=please address X',
       ])
     })
   })

--- a/src/git/pullRequestActions.ts
+++ b/src/git/pullRequestActions.ts
@@ -1,5 +1,6 @@
 import { GhRunner, defaultGhRunner } from './pullRequestData'
 import { resolveGhActionError } from './githubCli'
+import { rejectFlagLike, rejectUnsafeUsername } from './forgeArgGuards'
 
 export type PullRequestActionResult = {
   ok: boolean
@@ -45,14 +46,10 @@ export function buildCreatePullRequestArgs(input: CreatePullRequestInput): strin
   const args = [
     'pr',
     'create',
-    '--base',
-    input.base,
-    '--head',
-    input.head,
-    '--title',
-    input.title,
-    '--body',
-    input.body,
+    `--base=${input.base}`,
+    `--head=${input.head}`,
+    `--title=${input.title}`,
+    `--body=${input.body}`,
   ]
 
   if (input.draft) {
@@ -66,6 +63,8 @@ export function createPullRequest(
   input: CreatePullRequestInput,
   runner: GhRunner = defaultGhRunner
 ): Promise<PullRequestActionResult> {
+  const bad = rejectFlagLike(input.head, 'Branch name') || rejectFlagLike(input.base, 'Branch name')
+  if (bad) return Promise.resolve({ ok: false, message: bad })
   return runGhAction(runner, buildCreatePullRequestArgs(input), (output) => {
     const url = parseCreatedPullRequestUrl(output)
 
@@ -151,7 +150,7 @@ export function requestChangesPullRequest(
   if (!body.trim()) {
     return Promise.resolve({ ok: false, message: 'Review body required for change-request' })
   }
-  return runGhAction(runner, ['pr', 'review', '--request-changes', '--body', body], (output) => ({
+  return runGhAction(runner, ['pr', 'review', '--request-changes', `--body=${body}`], (output) => ({
     ok: true,
     message: output.trim() || 'Requested changes',
   }))
@@ -164,7 +163,7 @@ export function commentPullRequest(
   if (!body.trim()) {
     return Promise.resolve({ ok: false, message: 'Comment body required' })
   }
-  return runGhAction(runner, ['pr', 'comment', '--body', body], (output) => ({
+  return runGhAction(runner, ['pr', 'comment', `--body=${body}`], (output) => ({
     ok: true,
     message: output.trim() || 'Comment added',
   }))
@@ -189,7 +188,7 @@ export function commentPullRequestByNumber(
   }
   return runGhAction(
     runner,
-    ['pr', 'comment', String(pullRequestNumber), '--body', body],
+    ['pr', 'comment', String(pullRequestNumber), `--body=${body}`],
     (output) => ({
       ok: true,
       message: output.trim() || `Commented on pull request #${pullRequestNumber}`,
@@ -205,9 +204,11 @@ export function addPullRequestLabel(
   if (!label.trim()) {
     return Promise.resolve({ ok: false, message: 'Label name required' })
   }
+  const bad = rejectFlagLike(label, 'Label')
+  if (bad) return Promise.resolve({ ok: false, message: bad })
   return runGhAction(
     runner,
-    ['pr', 'edit', String(pullRequestNumber), '--add-label', label],
+    ['pr', 'edit', String(pullRequestNumber), `--add-label=${label}`],
     () => ({
       ok: true,
       message: `Added label '${label}' to pull request #${pullRequestNumber}`,
@@ -223,9 +224,11 @@ export function addPullRequestAssignee(
   if (!assignee.trim()) {
     return Promise.resolve({ ok: false, message: 'Assignee login required' })
   }
+  const bad = rejectUnsafeUsername(assignee)
+  if (bad) return Promise.resolve({ ok: false, message: bad })
   return runGhAction(
     runner,
-    ['pr', 'edit', String(pullRequestNumber), '--add-assignee', assignee],
+    ['pr', 'edit', String(pullRequestNumber), `--add-assignee=${assignee}`],
     () => ({
       ok: true,
       message: `Assigned ${assignee} to pull request #${pullRequestNumber}`,
@@ -294,7 +297,7 @@ export function requestChangesPullRequestByNumber(
   }
   return runGhAction(
     runner,
-    ['pr', 'review', String(pullRequestNumber), '--request-changes', '--body', body],
+    ['pr', 'review', String(pullRequestNumber), '--request-changes', `--body=${body}`],
     (output) => ({
       ok: true,
       message:


### PR DESCRIPTION
## Summary

Defense-in-depth hardening of how user/remote-controlled values flow into `gh`/`glab` argv, from the security audit.

- Convert every user-controlled flag value (PR/MR titles, bodies, descriptions, branch refs, labels, assignees) from separated `--flag value` pairs into a single joined `` `--flag=value` `` element across `mergeRequestActions.ts`, `gitlabIssueActions.ts`, `pullRequestActions.ts`, and `issueActions.ts`.
- Add a small guard helper `src/git/forgeArgGuards.ts` (`rejectFlagLike` / `rejectUnsafeUsername`) and wire it into the create (branch refs), add-label, and add-assignee action entry points, returning the existing `{ ok: false, message }` shape on bad input.
- Static flags (`--push`, `--yes`, `--request-changes`, `--web`, `--state`, `--draft`) and numeric `String(n)` positionals are left unchanged.

## Why

Not currently reachable as an exploit: coco shells out via `execFile` (no shell, so no command injection), values are already flag-bound or numeric positionals, and the wrappers reject empty input. This is defense-in-depth:

- `--flag=value` guarantees a value beginning with `-` can never be re-parsed by `gh`/`glab` as a flag.
- The username guard rejects the comma/whitespace shapes that `glab` would otherwise comma-split into multiple assignees.

## Tests

- Updated the arg-array assertions in the four `*.test.ts` files to the new `--flag=value` form.
- Added guard-rejection tests: each guard rejects a leading-dash value / comma-bearing username and asserts the runner was not invoked.

Full suite green: lint + jest (3310 passed) + build + cli smoke + pack.