### PR TITLE
fix(gitlab): polish follow-ups (URL encoding, parser guard, forge-aware hints, dispatch catch, auth host-scoping)

### DIFF
--- a/src/git/forgeActions.ts
+++ b/src/git/forgeActions.ts
@@ -70,6 +70,7 @@ import {
   commentGitLabIssue,
   reopenGitLabIssue,
 } from './gitlabIssueActions'
+import { defaultGlabRunner } from './glabCli'
 
 /**
  * Provider-agnostic forge facade. The workstation runtime dispatches every
@@ -136,7 +137,15 @@ const githubActions: ForgeActions = {
   reopenIssue,
 }
 
-function gitlabActions(path: string | undefined): ForgeActions {
+/**
+ * GitLab facade. `host` is the repo's remote hostname (`gitlab.com` or a
+ * self-hosted instance) — threaded to the mutating actions so their error-path
+ * auth re-probe (`resolveGlabActionError` → `getGlabStatus`) checks the right
+ * GitLab instance instead of defaulting to `gitlab.com`. Passing
+ * `defaultGlabRunner` explicitly keeps the runner default while reaching the
+ * trailing `hostname` slot.
+ */
+function gitlabActions(path: string | undefined, host?: string): ForgeActions {
   return {
     getPullRequestList: (git, filter) => getMergeRequestList(git, filter),
     getIssueList: (git, filter) => getGitLabIssueList(git, filter),
@@ -144,25 +153,25 @@ function gitlabActions(path: string | undefined): ForgeActions {
       path ? getMergeRequestDetail(path, n) : Promise.resolve({ ok: false, message: 'No GitLab project resolved' }),
     getIssueDetail: (n) =>
       path ? getGitLabIssueDetail(path, n) : Promise.resolve({ ok: false, message: 'No GitLab project resolved' }),
-    commentPullRequestByNumber: (n, body) => commentMergeRequestByNumber(n, body),
-    addPullRequestLabel: (n, label) => addMergeRequestLabel(n, label),
-    addPullRequestAssignee: (n, assignee) => addMergeRequestAssignee(n, assignee),
-    mergePullRequestByNumber: (n, strategy) => mergeMergeRequestByNumber(n, strategy),
-    closePullRequestByNumber: (n) => closeMergeRequestByNumber(n),
-    approvePullRequestByNumber: (n) => approveMergeRequestByNumber(n),
-    requestChangesPullRequestByNumber: (n, body) => requestChangesMergeRequestByNumber(n, body),
-    mergePullRequest: (strategy) => mergeMergeRequest(strategy),
-    closePullRequest: () => closeMergeRequest(),
-    approvePullRequest: () => approveMergeRequest(),
-    commentPullRequest: (body) => commentMergeRequest(body),
-    requestChangesPullRequest: (body) => requestChangesMergeRequest(body),
-    createPullRequest: (input) => createMergeRequest(input),
-    openPullRequest: (url) => openMergeRequest(url),
-    commentIssue: (n, body) => commentGitLabIssue(n, body),
-    addIssueLabel: (n, label) => addGitLabIssueLabel(n, label),
-    addIssueAssignee: (n, assignee) => addGitLabIssueAssignee(n, assignee),
-    closeIssue: (n) => closeGitLabIssue(n),
-    reopenIssue: (n) => reopenGitLabIssue(n),
+    commentPullRequestByNumber: (n, body) => commentMergeRequestByNumber(n, body, defaultGlabRunner, host),
+    addPullRequestLabel: (n, label) => addMergeRequestLabel(n, label, defaultGlabRunner, host),
+    addPullRequestAssignee: (n, assignee) => addMergeRequestAssignee(n, assignee, defaultGlabRunner, host),
+    mergePullRequestByNumber: (n, strategy) => mergeMergeRequestByNumber(n, strategy, defaultGlabRunner, host),
+    closePullRequestByNumber: (n) => closeMergeRequestByNumber(n, defaultGlabRunner, host),
+    approvePullRequestByNumber: (n) => approveMergeRequestByNumber(n, defaultGlabRunner, host),
+    requestChangesPullRequestByNumber: (n, body) => requestChangesMergeRequestByNumber(n, body, defaultGlabRunner, host),
+    mergePullRequest: (strategy) => mergeMergeRequest(strategy, defaultGlabRunner, host),
+    closePullRequest: () => closeMergeRequest(defaultGlabRunner, host),
+    approvePullRequest: () => approveMergeRequest(defaultGlabRunner, host),
+    commentPullRequest: (body) => commentMergeRequest(body, defaultGlabRunner, host),
+    requestChangesPullRequest: (body) => requestChangesMergeRequest(body, defaultGlabRunner, host),
+    createPullRequest: (input) => createMergeRequest(input, defaultGlabRunner, host),
+    openPullRequest: (url) => openMergeRequest(url, defaultGlabRunner, host),
+    commentIssue: (n, body) => commentGitLabIssue(n, body, defaultGlabRunner, host),
+    addIssueLabel: (n, label) => addGitLabIssueLabel(n, label, defaultGlabRunner, host),
+    addIssueAssignee: (n, assignee) => addGitLabIssueAssignee(n, assignee, defaultGlabRunner, host),
+    closeIssue: (n) => closeGitLabIssue(n, defaultGlabRunner, host),
+    reopenIssue: (n) => reopenGitLabIssue(n, defaultGlabRunner, host),
   }
 }
 
@@ -170,13 +179,17 @@ function gitlabActions(path: string | undefined): ForgeActions {
  * Select the forge facade for the detected provider. Anything other than
  * `gitlab` (github, GitHub Enterprise, unsupported) keeps the GitHub `gh`
  * implementations, preserving existing behavior. For GitLab, pass the project
- * path (`owner/name`) so the detail loaders can address `glab api` endpoints.
+ * path (`owner/name`) so the detail loaders can address `glab api` endpoints,
+ * and the remote `gitlabHost` so error-path auth re-probes hit the right
+ * instance (self-hosted installs aren't `gitlab.com`).
  */
 export function getForgeActions(
   provider: GitProviderType | undefined,
-  options: { gitlabPath?: string } = {}
+  options: { gitlabPath?: string; gitlabHost?: string } = {}
 ): ForgeActions {
-  return provider === 'gitlab' ? gitlabActions(options.gitlabPath) : githubActions
+  return provider === 'gitlab'
+    ? gitlabActions(options.gitlabPath, options.gitlabHost)
+    : githubActions
 }
 
 /**

--- a/src/git/forgeDispatch.test.ts
+++ b/src/git/forgeDispatch.test.ts
@@ -15,14 +15,18 @@ import * as issues from './gitlabIssueActions'
 import * as lists from './gitlabListData'
 import * as detail from './gitlabDetailData'
 import { getForgeActions } from './forgeActions'
+import { defaultGlabRunner } from './glabCli'
 
 const fakeGit = {} as unknown as SimpleGit
 
 describe('forge GitLab dispatch (#0.70)', () => {
   beforeEach(() => jest.clearAllMocks())
 
-  it('routes MR mutations to the glab implementations', async () => {
-    const forge = getForgeActions('gitlab', { gitlabPath: 'g/p' })
+  it('routes MR mutations to the glab implementations, binding runner + host', async () => {
+    // The facade binds `defaultGlabRunner` + the remote host into every glab
+    // action so the error-path auth re-probe (resolveGlabActionError) scopes to
+    // the right instance. `undefined` host is fine — actions stay host-less.
+    const forge = getForgeActions('gitlab', { gitlabPath: 'g/p', gitlabHost: 'gitlab.acme.com' })
     await forge.mergePullRequestByNumber(5, 'squash')
     await forge.commentPullRequestByNumber(5, 'hi')
     await forge.addPullRequestLabel(5, 'bug')
@@ -32,29 +36,35 @@ describe('forge GitLab dispatch (#0.70)', () => {
     await forge.requestChangesPullRequestByNumber(5, 'fix')
     await forge.createPullRequest({ base: 'main', head: 'f', title: 'T', body: 'B' })
 
-    expect(mr.mergeMergeRequestByNumber).toHaveBeenCalledWith(5, 'squash')
-    expect(mr.commentMergeRequestByNumber).toHaveBeenCalledWith(5, 'hi')
-    expect(mr.addMergeRequestLabel).toHaveBeenCalledWith(5, 'bug')
-    expect(mr.addMergeRequestAssignee).toHaveBeenCalledWith(5, 'bob')
-    expect(mr.approveMergeRequestByNumber).toHaveBeenCalledWith(5)
-    expect(mr.closeMergeRequestByNumber).toHaveBeenCalledWith(5)
-    expect(mr.requestChangesMergeRequestByNumber).toHaveBeenCalledWith(5, 'fix')
-    expect(mr.createMergeRequest).toHaveBeenCalledWith({ base: 'main', head: 'f', title: 'T', body: 'B' })
+    const host = 'gitlab.acme.com'
+    expect(mr.mergeMergeRequestByNumber).toHaveBeenCalledWith(5, 'squash', defaultGlabRunner, host)
+    expect(mr.commentMergeRequestByNumber).toHaveBeenCalledWith(5, 'hi', defaultGlabRunner, host)
+    expect(mr.addMergeRequestLabel).toHaveBeenCalledWith(5, 'bug', defaultGlabRunner, host)
+    expect(mr.addMergeRequestAssignee).toHaveBeenCalledWith(5, 'bob', defaultGlabRunner, host)
+    expect(mr.approveMergeRequestByNumber).toHaveBeenCalledWith(5, defaultGlabRunner, host)
+    expect(mr.closeMergeRequestByNumber).toHaveBeenCalledWith(5, defaultGlabRunner, host)
+    expect(mr.requestChangesMergeRequestByNumber).toHaveBeenCalledWith(5, 'fix', defaultGlabRunner, host)
+    expect(mr.createMergeRequest).toHaveBeenCalledWith(
+      { base: 'main', head: 'f', title: 'T', body: 'B' },
+      defaultGlabRunner,
+      host
+    )
   })
 
-  it('routes issue mutations to the glab implementations', async () => {
-    const forge = getForgeActions('gitlab', {})
+  it('routes issue mutations to the glab implementations, binding runner + host', async () => {
+    const forge = getForgeActions('gitlab', { gitlabHost: 'gitlab.acme.com' })
     await forge.commentIssue(7, 'hi')
     await forge.addIssueLabel(7, 'bug')
     await forge.addIssueAssignee(7, 'bob')
     await forge.closeIssue(7)
     await forge.reopenIssue(7)
 
-    expect(issues.commentGitLabIssue).toHaveBeenCalledWith(7, 'hi')
-    expect(issues.addGitLabIssueLabel).toHaveBeenCalledWith(7, 'bug')
-    expect(issues.addGitLabIssueAssignee).toHaveBeenCalledWith(7, 'bob')
-    expect(issues.closeGitLabIssue).toHaveBeenCalledWith(7)
-    expect(issues.reopenGitLabIssue).toHaveBeenCalledWith(7)
+    const host = 'gitlab.acme.com'
+    expect(issues.commentGitLabIssue).toHaveBeenCalledWith(7, 'hi', defaultGlabRunner, host)
+    expect(issues.addGitLabIssueLabel).toHaveBeenCalledWith(7, 'bug', defaultGlabRunner, host)
+    expect(issues.addGitLabIssueAssignee).toHaveBeenCalledWith(7, 'bob', defaultGlabRunner, host)
+    expect(issues.closeGitLabIssue).toHaveBeenCalledWith(7, defaultGlabRunner, host)
+    expect(issues.reopenGitLabIssue).toHaveBeenCalledWith(7, defaultGlabRunner, host)
   })
 
   it('routes lists + detail to the glab implementations, binding the project path', async () => {

--- a/src/git/gitlabIssueActions.ts
+++ b/src/git/gitlabIssueActions.ts
@@ -14,12 +14,13 @@ import type { IssueActionResult } from './issueActions'
 async function runGlabAction(
   runner: GlabRunner,
   args: string[],
-  onSuccess: (output: string) => IssueActionResult
+  onSuccess: (output: string) => IssueActionResult,
+  hostname?: string
 ): Promise<IssueActionResult> {
   try {
     return onSuccess(await runner(args))
   } catch (error) {
-    const { message, details } = await resolveGlabActionError(error, runner)
+    const { message, details } = await resolveGlabActionError(error, runner, hostname)
     return { ok: false, message, ...(details && details.length ? { details } : {}) }
   }
 }
@@ -27,7 +28,8 @@ async function runGlabAction(
 export function commentGitLabIssue(
   issueNumber: number,
   body: string,
-  runner: GlabRunner = defaultGlabRunner
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
 ): Promise<IssueActionResult> {
   if (!body.trim()) {
     return Promise.resolve({ ok: false, message: 'Comment body required' })
@@ -38,14 +40,16 @@ export function commentGitLabIssue(
     (output) => ({
       ok: true,
       message: output.trim() || `Commented on issue #${issueNumber}`,
-    })
+    }),
+    hostname
   )
 }
 
 export function addGitLabIssueLabel(
   issueNumber: number,
   label: string,
-  runner: GlabRunner = defaultGlabRunner
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
 ): Promise<IssueActionResult> {
   if (!label.trim()) {
     return Promise.resolve({ ok: false, message: 'Label name required' })
@@ -58,14 +62,16 @@ export function addGitLabIssueLabel(
     () => ({
       ok: true,
       message: `Added label '${label}' to issue #${issueNumber}`,
-    })
+    }),
+    hostname
   )
 }
 
 export function addGitLabIssueAssignee(
   issueNumber: number,
   assignee: string,
-  runner: GlabRunner = defaultGlabRunner
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
 ): Promise<IssueActionResult> {
   if (!assignee.trim()) {
     return Promise.resolve({ ok: false, message: 'Assignee username required' })
@@ -79,26 +85,39 @@ export function addGitLabIssueAssignee(
     () => ({
       ok: true,
       message: `Assigned ${assignee} to issue #${issueNumber}`,
-    })
+    }),
+    hostname
   )
 }
 
 export function closeGitLabIssue(
   issueNumber: number,
-  runner: GlabRunner = defaultGlabRunner
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
 ): Promise<IssueActionResult> {
-  return runGlabAction(runner, ['issue', 'close', String(issueNumber)], (output) => ({
-    ok: true,
-    message: output.trim() || `Closed issue #${issueNumber}`,
-  }))
+  return runGlabAction(
+    runner,
+    ['issue', 'close', String(issueNumber)],
+    (output) => ({
+      ok: true,
+      message: output.trim() || `Closed issue #${issueNumber}`,
+    }),
+    hostname
+  )
 }
 
 export function reopenGitLabIssue(
   issueNumber: number,
-  runner: GlabRunner = defaultGlabRunner
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
 ): Promise<IssueActionResult> {
-  return runGlabAction(runner, ['issue', 'reopen', String(issueNumber)], (output) => ({
-    ok: true,
-    message: output.trim() || `Reopened issue #${issueNumber}`,
-  }))
+  return runGlabAction(
+    runner,
+    ['issue', 'reopen', String(issueNumber)],
+    (output) => ({
+      ok: true,
+      message: output.trim() || `Reopened issue #${issueNumber}`,
+    }),
+    hostname
+  )
 }

--- a/src/git/glabCli.test.ts
+++ b/src/git/glabCli.test.ts
@@ -77,6 +77,16 @@ describe('resolveGlabActionError (#0.70)', () => {
     expect(result.message).toBe('line1')
     expect(result.details).toEqual(['line2', 'line3'])
   })
+
+  it('scopes the auth re-probe to the given hostname', async () => {
+    const calls: string[][] = []
+    const runner = async (args: string[]) => {
+      calls.push(args)
+      return ''
+    }
+    await resolveGlabActionError(new Error('failed'), runner, 'gitlab.acme.com')
+    expect(calls[0]).toEqual(['auth', 'status', '--hostname', 'gitlab.acme.com'])
+  })
 })
 
 function fakeGit(remotes: Array<{ name: string; refs: { fetch?: string; push?: string } }>): SimpleGit {

--- a/src/git/glabCli.ts
+++ b/src/git/glabCli.ts
@@ -129,15 +129,20 @@ export function compactGlabError(message: string): GhActionError {
  * Turn a thrown glab error into a user-facing message, probing auth on the
  * error path so a mid-session de-auth yields the curated recovery hint instead
  * of raw glab stderr. Mirrors `resolveGhActionError`.
+ *
+ * Pass `hostname` (the repo's remote host) so the auth re-probe checks the
+ * right instance — self-hosted GitLab installs aren't `gitlab.com`, and a
+ * host-less probe would report on the wrong server.
  */
 export async function resolveGlabActionError(
   error: unknown,
-  runner: GlabRunner
+  runner: GlabRunner,
+  hostname?: string
 ): Promise<GhActionError> {
   const raw = (error as Error)?.message || 'GitLab CLI command failed.'
 
   try {
-    const status = await getGlabStatus(runner)
+    const status = await getGlabStatus(runner, hostname)
     if (status.kind !== 'ok') {
       return { message: describeGlabStatus(status) }
     }

--- a/src/git/issuesListData.test.ts
+++ b/src/git/issuesListData.test.ts
@@ -79,6 +79,17 @@ describe('issuesListData', () => {
     ])
   })
 
+  it('degrades to an empty list when the gh body is not an array', async () => {
+    const runner = jest
+      .fn()
+      .mockResolvedValueOnce('') // auth status
+      .mockResolvedValueOnce(JSON.stringify({ message: 'Not Found' }))
+
+    const overview = await getIssueList(githubRemoteGit(), {}, runner)
+    expect(overview.authenticated).toBe(true)
+    expect(overview.issues).toEqual([])
+  })
+
   it('threads filter knobs into the gh args', async () => {
     const runner = jest
       .fn()

--- a/src/git/issuesListData.ts
+++ b/src/git/issuesListData.ts
@@ -76,6 +76,7 @@ function parseIssueListItems(output: string): IssueListItem[] {
   if (!trimmed) return []
 
   const raw = JSON.parse(trimmed) as Array<Record<string, unknown>>
+  if (!Array.isArray(raw)) return []
 
   return raw.map((entry) => {
     const author =

--- a/src/git/mergeRequestActions.ts
+++ b/src/git/mergeRequestActions.ts
@@ -28,12 +28,13 @@ function parseCreatedMergeRequestUrl(output: string): string | undefined {
 async function runGlabAction(
   runner: GlabRunner,
   args: string[],
-  onSuccess: (output: string) => PullRequestActionResult
+  onSuccess: (output: string) => PullRequestActionResult,
+  hostname?: string
 ): Promise<PullRequestActionResult> {
   try {
     return onSuccess(await runner(args))
   } catch (error) {
-    const { message, details } = await resolveGlabActionError(error, runner)
+    const { message, details } = await resolveGlabActionError(error, runner, hostname)
     return { ok: false, message, ...(details && details.length ? { details } : {}) }
   }
 }
@@ -64,7 +65,8 @@ export function buildCreateMergeRequestArgs(input: CreateMergeRequestInput): str
 
 export function createMergeRequest(
   input: CreateMergeRequestInput,
-  runner: GlabRunner = defaultGlabRunner
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
 ): Promise<PullRequestActionResult> {
   const bad = rejectFlagLike(input.head, 'Branch name') || rejectFlagLike(input.base, 'Branch name')
   if (bad) return Promise.resolve({ ok: false, message: bad })
@@ -75,18 +77,19 @@ export function createMergeRequest(
       message: url ? `Created merge request: ${url}` : 'Created merge request',
       url,
     }
-  })
+  }, hostname)
 }
 
 export function openMergeRequest(
   url: string,
-  runner: GlabRunner = defaultGlabRunner
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
 ): Promise<PullRequestActionResult> {
   return runGlabAction(runner, ['mr', 'view', '--web'], () => ({
     ok: true,
     message: `Opened merge request: ${url}`,
     url,
-  }))
+  }), hostname)
 }
 
 /**
@@ -110,7 +113,8 @@ function mergeStrategyFlags(strategy: MergeRequestMergeStrategy): string[] {
 export function mergeMergeRequestByNumber(
   mergeRequestNumber: number,
   strategy: MergeRequestMergeStrategy,
-  runner: GlabRunner = defaultGlabRunner
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
 ): Promise<PullRequestActionResult> {
   return runGlabAction(
     runner,
@@ -118,34 +122,48 @@ export function mergeMergeRequestByNumber(
     (output) => ({
       ok: true,
       message: output.trim() || `Merged merge request !${mergeRequestNumber} with ${strategy}`,
-    })
+    }),
+    hostname
   )
 }
 
 export function approveMergeRequestByNumber(
   mergeRequestNumber: number,
-  runner: GlabRunner = defaultGlabRunner
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
 ): Promise<PullRequestActionResult> {
-  return runGlabAction(runner, ['mr', 'approve', String(mergeRequestNumber)], (output) => ({
-    ok: true,
-    message: output.trim() || `Approved merge request !${mergeRequestNumber}`,
-  }))
+  return runGlabAction(
+    runner,
+    ['mr', 'approve', String(mergeRequestNumber)],
+    (output) => ({
+      ok: true,
+      message: output.trim() || `Approved merge request !${mergeRequestNumber}`,
+    }),
+    hostname
+  )
 }
 
 export function closeMergeRequestByNumber(
   mergeRequestNumber: number,
-  runner: GlabRunner = defaultGlabRunner
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
 ): Promise<PullRequestActionResult> {
-  return runGlabAction(runner, ['mr', 'close', String(mergeRequestNumber)], (output) => ({
-    ok: true,
-    message: output.trim() || `Closed merge request !${mergeRequestNumber}`,
-  }))
+  return runGlabAction(
+    runner,
+    ['mr', 'close', String(mergeRequestNumber)],
+    (output) => ({
+      ok: true,
+      message: output.trim() || `Closed merge request !${mergeRequestNumber}`,
+    }),
+    hostname
+  )
 }
 
 export function commentMergeRequestByNumber(
   mergeRequestNumber: number,
   body: string,
-  runner: GlabRunner = defaultGlabRunner
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
 ): Promise<PullRequestActionResult> {
   if (!body.trim()) {
     return Promise.resolve({ ok: false, message: 'Comment body required' })
@@ -156,7 +174,8 @@ export function commentMergeRequestByNumber(
     (output) => ({
       ok: true,
       message: output.trim() || `Commented on merge request !${mergeRequestNumber}`,
-    })
+    }),
+    hostname
   )
 }
 
@@ -168,7 +187,8 @@ export function commentMergeRequestByNumber(
 export function requestChangesMergeRequestByNumber(
   mergeRequestNumber: number,
   body: string,
-  runner: GlabRunner = defaultGlabRunner
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
 ): Promise<PullRequestActionResult> {
   if (!body.trim()) {
     return Promise.resolve({ ok: false, message: 'Review body required for change-request' })
@@ -179,14 +199,16 @@ export function requestChangesMergeRequestByNumber(
     (output) => ({
       ok: true,
       message: output.trim() || `Requested changes on merge request !${mergeRequestNumber}`,
-    })
+    }),
+    hostname
   )
 }
 
 export function addMergeRequestLabel(
   mergeRequestNumber: number,
   label: string,
-  runner: GlabRunner = defaultGlabRunner
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
 ): Promise<PullRequestActionResult> {
   if (!label.trim()) {
     return Promise.resolve({ ok: false, message: 'Label name required' })
@@ -199,14 +221,16 @@ export function addMergeRequestLabel(
     () => ({
       ok: true,
       message: `Added label '${label}' to merge request !${mergeRequestNumber}`,
-    })
+    }),
+    hostname
   )
 }
 
 export function addMergeRequestAssignee(
   mergeRequestNumber: number,
   assignee: string,
-  runner: GlabRunner = defaultGlabRunner
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
 ): Promise<PullRequestActionResult> {
   if (!assignee.trim()) {
     return Promise.resolve({ ok: false, message: 'Assignee username required' })
@@ -220,7 +244,8 @@ export function addMergeRequestAssignee(
     () => ({
       ok: true,
       message: `Assigned ${assignee} to merge request !${mergeRequestNumber}`,
-    })
+    }),
+    hostname
   )
 }
 
@@ -229,35 +254,39 @@ export function addMergeRequestAssignee(
 
 export function mergeMergeRequest(
   strategy: MergeRequestMergeStrategy,
-  runner: GlabRunner = defaultGlabRunner
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
 ): Promise<PullRequestActionResult> {
   return runGlabAction(runner, ['mr', 'merge', ...mergeStrategyFlags(strategy), '--yes'], (output) => ({
     ok: true,
     message: output.trim() || `Merged merge request with ${strategy}`,
-  }))
+  }), hostname)
 }
 
 export function closeMergeRequest(
-  runner: GlabRunner = defaultGlabRunner
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
 ): Promise<PullRequestActionResult> {
   return runGlabAction(runner, ['mr', 'close'], (output) => ({
     ok: true,
     message: output.trim() || 'Closed merge request',
-  }))
+  }), hostname)
 }
 
 export function approveMergeRequest(
-  runner: GlabRunner = defaultGlabRunner
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
 ): Promise<PullRequestActionResult> {
   return runGlabAction(runner, ['mr', 'approve'], (output) => ({
     ok: true,
     message: output.trim() || 'Approved merge request',
-  }))
+  }), hostname)
 }
 
 export function commentMergeRequest(
   body: string,
-  runner: GlabRunner = defaultGlabRunner
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
 ): Promise<PullRequestActionResult> {
   if (!body.trim()) {
     return Promise.resolve({ ok: false, message: 'Comment body required' })
@@ -265,12 +294,13 @@ export function commentMergeRequest(
   return runGlabAction(runner, ['mr', 'note', 'create', `--message=${body}`], (output) => ({
     ok: true,
     message: output.trim() || 'Comment added',
-  }))
+  }), hostname)
 }
 
 export function requestChangesMergeRequest(
   body: string,
-  runner: GlabRunner = defaultGlabRunner
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
 ): Promise<PullRequestActionResult> {
   if (!body.trim()) {
     return Promise.resolve({ ok: false, message: 'Review body required for change-request' })
@@ -278,5 +308,5 @@ export function requestChangesMergeRequest(
   return runGlabAction(runner, ['mr', 'note', 'create', `--message=Requested changes: ${body}`], (output) => ({
     ok: true,
     message: output.trim() || 'Requested changes',
-  }))
+  }), hostname)
 }

--- a/src/git/providerData.test.ts
+++ b/src/git/providerData.test.ts
@@ -118,6 +118,12 @@ describe('log provider data', () => {
     )
   })
 
+  it('encodes the commit hash in provider URLs', () => {
+    expect(buildProviderUrl(repository, { type: 'commit', commit: 'refs/tags/v1 rc' })).toBe(
+      'https://github.com/gfargo/coco/commit/refs%2Ftags%2Fv1%20rc'
+    )
+  })
+
   // git.raw now answers three commands during a single getProviderOverview
   // call: branch --show-current, symbolic-ref origin/HEAD (for local
   // default-branch detection), and possibly rev-parse fallbacks. This

--- a/src/git/providerData.ts
+++ b/src/git/providerData.ts
@@ -175,7 +175,7 @@ export function buildProviderUrl(
   }
 
   if (target.type === 'commit') {
-    return `${base}${seg}/commit/${target.commit}`
+    return `${base}${seg}/commit/${encodeURIComponent(target.commit)}`
   }
 
   if (target.type === 'pull-request') {

--- a/src/git/pullRequestListData.test.ts
+++ b/src/git/pullRequestListData.test.ts
@@ -109,6 +109,17 @@ describe('pullRequestListData', () => {
     ])
   })
 
+  it('degrades to an empty list when the gh body is not an array', async () => {
+    const runner = jest
+      .fn()
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce(JSON.stringify({ message: 'Not Found' }))
+
+    const overview = await getPullRequestList(githubRemoteGit(), {}, runner)
+    expect(overview.authenticated).toBe(true)
+    expect(overview.pullRequests).toEqual([])
+  })
+
   it('parses a minimal PR payload without enriched fields', async () => {
     const runner = jest
       .fn()

--- a/src/git/pullRequestListData.ts
+++ b/src/git/pullRequestListData.ts
@@ -92,6 +92,7 @@ function parsePullRequestListItems(output: string): PullRequestListItem[] {
   if (!trimmed) return []
 
   const raw = JSON.parse(trimmed) as Array<Record<string, unknown>>
+  if (!Array.isArray(raw)) return []
 
   return raw.map((entry) => {
     const author =

--- a/src/workstation/chrome/idleTips.test.ts
+++ b/src/workstation/chrome/idleTips.test.ts
@@ -35,6 +35,19 @@ describe('log Ink idle tips (P4.3)', () => {
     expect(pickIdleTip(IDLE_TIPS.length * 3 + 2)).toBe(IDLE_TIPS[1])
   })
 
+  it('substitutes the forge noun into the {abbrev} tip', () => {
+    const abbrevIndex = IDLE_TIPS.findIndex((tip) => tip.includes('{abbrev}'))
+    expect(abbrevIndex).toBeGreaterThanOrEqual(0)
+    const tick = abbrevIndex + 1
+    // No placeholder should survive into the rendered tip.
+    expect(pickIdleTip(tick)).not.toContain('{abbrev}')
+    // GitHub (and the undefined / default case) read "PR"; GitLab reads "MR".
+    expect(pickIdleTip(tick, 'github')).toContain('PR')
+    expect(pickIdleTip(tick)).toContain('PR')
+    expect(pickIdleTip(tick, 'gitlab')).toContain('MR')
+    expect(pickIdleTip(tick, 'gitlab')).not.toContain('PR')
+  })
+
   it('matches the spec timing constants (>10s grace, ~8s rotation)', () => {
     expect(IDLE_TIPS_GRACE_MS).toBeGreaterThanOrEqual(10_000)
     expect(IDLE_TIPS_INTERVAL_MS).toBeGreaterThanOrEqual(5_000)

--- a/src/workstation/chrome/idleTips.ts
+++ b/src/workstation/chrome/idleTips.ts
@@ -14,6 +14,15 @@
  * idle stretches.
  */
 
+import type { GitProviderType } from '../../git/providerData'
+import { forgeNouns } from './forgeNouns'
+
+/**
+ * Idle tips. Forge-specific abbreviations (PR/MR) are written as the
+ * `{abbrev}` placeholder so the same table renders correctly on GitHub
+ * and GitLab — `pickIdleTip` substitutes the active forge's noun
+ * (`forgeNouns(provider).abbrev`) when it builds the tip.
+ */
 export const IDLE_TIPS: string[] = [
   'press : to search every command',
   'g h returns home from anywhere',
@@ -24,7 +33,7 @@ export const IDLE_TIPS: string[] = [
   '< or esc walks the navigation stack back',
   'S splits a large staged set into multiple commits',
   'L generates a changelog for the current branch',
-  'C creates a PR seeded from the changelog',
+  'C creates a {abbrev} seeded from the changelog',
   'E opens the commit draft in $EDITOR or $VISUAL',
   'I drafts an AI commit message from staged changes',
 ]
@@ -39,8 +48,13 @@ export const IDLE_TIPS_GRACE_MS = 10_000
 /** Cadence between subsequent tips in ms. */
 export const IDLE_TIPS_INTERVAL_MS = 8_000
 
-export function pickIdleTip(tickIndex: number): string | undefined {
+export function pickIdleTip(
+  tickIndex: number,
+  provider?: GitProviderType
+): string | undefined {
   if (tickIndex <= 0) return undefined
   if (IDLE_TIPS.length === 0) return undefined
-  return IDLE_TIPS[(tickIndex - 1) % IDLE_TIPS.length]
+  const tip = IDLE_TIPS[(tickIndex - 1) % IDLE_TIPS.length]
+  // Substitute the forge-specific noun so GitLab repos read "MR" not "PR".
+  return tip.replace('{abbrev}', forgeNouns(provider).abbrev)
 }

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -790,7 +790,10 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       if (interval) clearInterval(interval)
     }
   }, [idleTipsEnabled, state.statusMessage])
-  const idleTip = idleTipsEnabled && !state.statusMessage ? pickIdleTip(idleTipIndex) : undefined
+  const idleTip =
+    idleTipsEnabled && !state.statusMessage
+      ? pickIdleTip(idleTipIndex, context.provider?.repository.provider)
+      : undefined
 
   // Animation tick driver for loading states. Increments every 80ms
   // while any overlay/surface is in a loading state — the renderer
@@ -1471,9 +1474,12 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     context.provider?.repository.owner && context.provider?.repository.name
       ? `${context.provider.repository.owner}/${context.provider.repository.name}`
       : undefined
+  // Remote host (`gitlab.com` or a self-hosted instance) — threaded so the
+  // GitLab error-path auth re-probe checks the right server.
+  const forgeGitlabHost = context.provider?.repository.host
   const forge = React.useMemo(
-    () => getForgeActions(forgeProvider, { gitlabPath: forgeGitlabPath }),
-    [forgeProvider, forgeGitlabPath]
+    () => getForgeActions(forgeProvider, { gitlabPath: forgeGitlabPath, gitlabHost: forgeGitlabHost }),
+    [forgeProvider, forgeGitlabPath, forgeGitlabHost]
   )
 
   React.useEffect(() => {
@@ -4155,6 +4161,17 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       // ("Dropped stash@{N}") — the visible list shrinking is the
       // unambiguous signal that the operation landed.
     }
+    } catch (error) {
+      // Defense-in-depth: today every action resolves to a result object
+      // (failures are carried in `result.ok` / `result.message`, not
+      // thrown), so this arm shouldn't fire. If a handler or a refresh
+      // ever rejects, surface a clean error status instead of an
+      // unhandled rejection — and let `finally` still clear the loaders.
+      dispatch({
+        type: 'setStatus',
+        value: error instanceof Error ? error.message : String(error),
+        kind: 'error',
+      })
     } finally {
       // Always clear the loader — even if a refresh threw — so a
       // failed fetch/pull can't leave the history surface stuck behind


### PR DESCRIPTION
Small GitLab polish + hardening follow-up. Five low-severity items from prior review/audit, each with tests.

## Changes

**(a) Encode the commit hash in `buildProviderUrl`** — `src/git/providerData.ts`
The `commit` target now wraps the hash in `encodeURIComponent`, matching the branch/compare path vars. Cosmetic consistency.

**(b) `Array.isArray` guard on the GitHub list parsers** — `src/git/pullRequestListData.ts`, `src/git/issuesListData.ts`
`parsePullRequestListItems` / `parseIssueListItems` now return `[]` for a non-array `gh --json` body instead of throwing `raw.map is not a function`, mirroring the GitLab parsers. (Returning `[]` is fine for GitHub — `gh` errors exit non-zero and are caught upstream.)

**(c) Forge-aware idle tip** — `src/workstation/chrome/idleTips.ts`, `src/workstation/runtime/app.ts`
The "C creates a PR seeded from the changelog" tip now renders "MR" on GitLab. Implemented via a `{abbrev}` placeholder resolved through `forgeNouns`, with the provider threaded cleanly from `context.provider?.repository.provider` into `pickIdleTip`.

> Deferred (noted, not over-engineered): the static `inkKeymap.ts` entry table ("pull request" label, "PR triage" label, descriptions) is built at module load with no provider context. Threading the forge through the whole keymap-render layer to localize those static labels would be disproportionate, so they're left as-is.

**(d) `catch` arm on the TUI forge-action dispatch** — `src/workstation/runtime/app.ts`
Added a `catch (error)` to the `try`/`finally` around the action handler dispatch, surfacing a clean `kind: 'error'` status. Defense-in-depth: today every action resolves to a result object, so nothing rejects — `finally` still clears the loaders.

**(e) Host-scope `resolveGlabActionError`** — `src/git/glabCli.ts` (+ action/facade layers)
`resolveGlabActionError` now takes an optional `hostname` and forwards it to `getGlabStatus`, so the error-path auth re-probe checks the right instance on self-hosted GitLab. The host is threaded end-to-end: `getForgeActions` / `gitlabActions` bind it alongside `gitlabPath`, both `runGlabAction` wrappers and all 19 glab action functions accept it as an optional trailing param, and `app.ts` passes `context.provider?.repository.host`. The param is optional everywhere, so existing call sites are unaffected.

## Validation
`npm test` fully green — lint + jest (3324 passed, 3 skipped, 0 failures) + build + cli smoke + pack.