### PR TITLE
fix(deps): clear flatted + picomatch dev advisories via resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,8 @@
     "brace-expansion": "^5.0.6",
     "@anthropic-ai/sdk": "^0.91.1",
     "ip-address": "^10.1.1",
-    "shell-quote": "^1.8.4"
+    "shell-quote": "^1.8.4",
+    "flatted": "^3.4.2",
+    "picomatch": "^4.0.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3447,10 +3447,10 @@ flat@^5.0.2:
   resolved "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
-flatted@^3.2.9:
-  version "3.3.3"
-  resolved "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz"
-  integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
+flatted@^3.2.9, flatted@^3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
+  integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
 foreground-child@^3.1.0:
   version "3.3.1"
@@ -4665,10 +4665,17 @@ minimatch@^10.2.2, minimatch@^10.2.5:
   dependencies:
     brace-expansion "^5.0.5"
 
-minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
+minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@^3.1.2, minimatch@^3.1.3:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -5078,15 +5085,10 @@ picocolors@^1.1.1:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.0.4, picomatch@^2.2.2, picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
-picomatch@^4.0.2, picomatch@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
-  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+picomatch@^2.0.4, picomatch@^2.2.2, picomatch@^2.3.1, picomatch@^4.0.2, picomatch@^4.0.3, picomatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 pirates@^4.0.7:
   version "4.0.7"


### PR DESCRIPTION
Clears 3 of the 4 open Dependabot alerts. **All are devDependency-tree only** — coco publishes `dist/` exclusively (eslint/jest/rollup/flat-cache never reach a user's install), so real-world user exposure is nil; this keeps the dev/CI tree clean.

## Cleared (via Yarn `resolutions`)
| Sev | Package | Fix | Source |
|---|---|---|---|
| 🟠 high | `flatted` | `^3.4.2` (was 3.3.3, advisory ≤ 3.4.1) | eslint → flat-cache |
| 🟡 medium | `picomatch` | `^4.0.4` (clears `< 2.3.2` **and** `4.0.0–4.0.3`) | rollup plugins, jest, release-it |

Full suite green, so forcing the transitive `picomatch@2.x` copy up to v4 did **not** break the rollup build.

## Not fixed here — `minimatch < 3.1.3` (high, dev-only)
The vulnerable `minimatch@3.1.2` copies sit under eslint's `@humanwhocodes/config-array`, jest's `test-exclude`, and `rimraf`. It can't be cleanly resolved:
- A **global** `minimatch` resolution would wrongly downgrade coco's **direct** `minimatch@10` (we use the v10 API).
- **Yarn 1 nested resolutions** (`eslint/minimatch` etc.) don't reliably target the transitive copies here.

The real fix is upgrading those dev tools (eslint 8 → 9, etc.), which is a larger maintenance task tracked separately. **Zero user exposure** in the meantime.