### PR TITLE
ci(0.71): Integration job + experimental Windows matrix cell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
   test:
     name: Test (Node ${{ matrix.node-version }} on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    # Experimental matrix cells (currently Windows) surface failures
+    # without blocking the PR until they're reliably green.
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
       matrix:
@@ -78,6 +81,14 @@ jobs:
           # enough confidence on its own.
           - os: macos-latest
             node-version: 22.22.2
+          # Windows matrix cell (0.71). The workflow has long flagged
+          # path-separator concerns; this exercises them. Marked
+          # experimental (continue-on-error above) so newly-surfaced
+          # Windows-only failures don't block PRs while we stabilize.
+          # Promote to a required cell once it's reliably green.
+          - os: windows-latest
+            node-version: 22.22.2
+            experimental: true
 
     steps:
       - name: Checkout
@@ -204,3 +215,39 @@ jobs:
 
       - name: Run packaged CLI smoke
         run: npm run test:cli
+
+  # Integration tests exercise the real CLI / data paths end-to-end via
+  # the dedicated `test:integration` script (previously unused in CI).
+  # The non-live suite always runs; the live GitLab suite is gated on
+  # COCO_GITLAB_IT + a test project and self-skips unless those repo
+  # secrets are configured, so the default flow needs no GitLab creds.
+  integration:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.22.2
+          cache: yarn
+          cache-dependency-path: yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Configure git identity
+        # commands.integration spins up temp repos and commits to them.
+        run: |
+          git config --global user.name "Coco CI"
+          git config --global user.email "ci@example.com"
+
+      - name: Run integration tests
+        # Live GitLab tests activate only when these secrets are set;
+        # otherwise they self-skip (describe.skip).
+        env:
+          COCO_GITLAB_IT: ${{ secrets.COCO_GITLAB_IT }}
+          COCO_GITLAB_TEST_PROJECT: ${{ secrets.COCO_GITLAB_TEST_PROJECT }}
+        run: npm run test:integration

--- a/src/commands/utils/applyRepoFlag.test.ts
+++ b/src/commands/utils/applyRepoFlag.test.ts
@@ -1,3 +1,5 @@
+import * as path from 'node:path'
+
 import { applyRepoFlag } from './applyRepoFlag'
 
 jest.mock('../../lib/simple-git/getRepo', () => ({
@@ -35,11 +37,16 @@ describe('applyRepoFlag', () => {
   })
 
   it('returns getRepo(absolutePath) and chdirs when --repo is set', () => {
-    applyRepoFlag({ repo: '/tmp/some-repo' })
+    // An already-absolute input is passed through `path.resolve`, which
+    // normalizes to the OS-native form (`/tmp/some-repo` on POSIX,
+    // `<drive>:\tmp\some-repo` on Windows). Build the expectation the
+    // same way so the assertion holds on every platform.
+    const repo = path.resolve('/tmp/some-repo')
+    applyRepoFlag({ repo })
 
     expect(chdirSpy).toHaveBeenCalledTimes(1)
-    expect(chdirSpy).toHaveBeenCalledWith('/tmp/some-repo')
-    expect(mockedGetRepo).toHaveBeenCalledWith('/tmp/some-repo')
+    expect(chdirSpy).toHaveBeenCalledWith(repo)
+    expect(mockedGetRepo).toHaveBeenCalledWith(repo)
   })
 
   it('resolves a relative --repo path to absolute before chdir', () => {
@@ -51,8 +58,11 @@ describe('applyRepoFlag', () => {
 
     expect(chdirSpy).toHaveBeenCalledTimes(1)
     const target = chdirSpy.mock.calls[0][0] as string
-    expect(target.startsWith('/')).toBe(true)
-    expect(target.endsWith('/fixture')).toBe(true)
+    // Assert it was resolved to an absolute, OS-native path ending in
+    // `fixture` — without pinning the POSIX separator so this holds on
+    // Windows too.
+    expect(path.isAbsolute(target)).toBe(true)
+    expect(path.basename(target)).toBe('fixture')
     expect(mockedGetRepo).toHaveBeenCalledWith(target)
   })
 

--- a/src/git/workspaceData.test.ts
+++ b/src/git/workspaceData.test.ts
@@ -30,7 +30,10 @@ describe('workspaceData parsers', () => {
   it('expands ~ to the user home directory', () => {
     expect(expandHome('~')).toBe(os.homedir())
     expect(expandHome('~/code')).toBe(path.join(os.homedir(), 'code'))
-    expect(expandHome('/tmp')).toBe('/tmp')
+    // A plain absolute path is returned resolved (OS-native: `/tmp` on
+    // POSIX, `<drive>:\tmp` on Windows) — build the expectation the same
+    // way the implementation does so the assertion is platform-agnostic.
+    expect(expandHome('/tmp')).toBe(path.resolve('/tmp'))
   })
 
   it('parses the HEAD ref line into branch + upstream', () => {

--- a/src/lib/parsers/default/__tree_sitter__/cache.test.ts
+++ b/src/lib/parsers/default/__tree_sitter__/cache.test.ts
@@ -1,4 +1,5 @@
 import { platform } from 'node:os'
+import { join } from 'node:path'
 import {
   getCacheRootDir,
   getCachedWasmPath,
@@ -35,10 +36,10 @@ describe('cache directory resolution', () => {
     it('is the tree-sitter subdir of the cache root', () => {
       const root = getCacheRootDir()
       const sub = getTreeSitterCacheDir()
-      expect(sub).toBe(`${root}/tree-sitter`.replace(/\//g, platform() === 'win32' ? /[\\/]/.source : '/').replace(/\[.+\]/, '/'))
-      // Loose check that handles platform separator without
-      // rebuilding the path: tree-sitter subdir must startWith
-      // the root and end with `tree-sitter`.
+      // Rebuild with path.join so the separator is OS-native; the
+      // invariant is "the tree-sitter subdir lives directly under the
+      // cache root", not the `/` vs `\` style.
+      expect(sub).toBe(join(root, 'tree-sitter'))
       expect(sub.startsWith(root)).toBe(true)
       expect(sub).toMatch(/tree-sitter$/)
     })

--- a/src/lib/parsers/default/utils/diffSummaryCache.test.ts
+++ b/src/lib/parsers/default/utils/diffSummaryCache.test.ts
@@ -70,8 +70,13 @@ describe('diffSummaryCache (#845, PR 5)', () => {
 
     it('falls back to ~/.cache/coco when XDG_CACHE_HOME is unset', () => {
       delete process.env.XDG_CACHE_HOME
-      expect(getDiffSummaryCachePath('/repo/x'))
-        .toMatch(new RegExp(`^${os.homedir()}/.cache/coco/diff-summaries/`))
+      // Build the expected prefix with path.join so the separator is
+      // OS-native (POSIX `/` vs Windows `\`) — the invariant under test
+      // is the cache *location*, not the separator style.
+      const expectedDir = path.join(os.homedir(), '.cache', 'coco', 'diff-summaries')
+      const cachePath = getDiffSummaryCachePath('/repo/x')
+      expect(cachePath.startsWith(expectedDir + path.sep)).toBe(true)
+      expect(cachePath).toMatch(/summaries\.[a-f0-9]{16}\.json$/)
     })
   })
 

--- a/src/workstation/chrome/themePersistence.test.ts
+++ b/src/workstation/chrome/themePersistence.test.ts
@@ -1,6 +1,29 @@
-import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
+
+// Mock node:fs but keep every real implementation — `writeFileSync` is
+// wrapped in a jest.fn that delegates to the real impl by default, so
+// individual tests can override it (e.g. to simulate an EACCES failure) in
+// a deterministic, OS-agnostic way. Native module properties are
+// non-configurable and the namespace import is getter-only under ts-jest,
+// so neither jest.spyOn(fs, ...) nor direct reassignment works here.
+jest.mock('node:fs', () => {
+  const actual = jest.requireActual('node:fs')
+  return { ...actual, writeFileSync: jest.fn() }
+})
+
+import * as fs from 'node:fs'
+
+const actualFs = jest.requireActual('node:fs') as typeof fs
+const mockedWriteFileSync = fs.writeFileSync as jest.MockedFunction<typeof fs.writeFileSync>
+
+// Default to the real implementation so every other test writes for real;
+// individual tests override this to simulate write failures.
+beforeEach(() => {
+  mockedWriteFileSync.mockImplementation(
+    (...args: Parameters<typeof actualFs.writeFileSync>) => actualFs.writeFileSync(...args)
+  )
+})
 
 import { getSavedThemePreset, getXdgConfigPath, saveThemePreset } from './themePersistence'
 
@@ -93,7 +116,14 @@ describe('theme preset persistence', () => {
   })
 
   it('is best-effort: returns false (no throw) when the path cannot be written', () => {
-    process.env.XDG_CONFIG_HOME = '/dev/null/forbidden'
+    // Force the write to fail deterministically on every platform by
+    // mocking the fs call the writer uses, rather than relying on an
+    // OS-specific "unwritable" path (e.g. `/dev/null/forbidden`, which
+    // is not unwritable on Windows).
+    mockedWriteFileSync.mockImplementation(() => {
+      throw new Error('EACCES: permission denied')
+    })
+
     expect(() => saveThemePreset('gruvbox')).not.toThrow()
     expect(saveThemePreset('gruvbox')).toBe(false)
   })

--- a/src/workstation/runtime/repoFrameDrillIn.test.ts
+++ b/src/workstation/runtime/repoFrameDrillIn.test.ts
@@ -1,7 +1,15 @@
+import { join } from 'node:path'
+
 import {
   resolveCommitDiffDrillInTarget,
   resolveSubmoduleViewDrillInTarget,
 } from './repoFrameDrillIn'
+
+// The resolvers build workdirs with `path.join(activeRepoRoot, entry.path)`,
+// so the expected value is OS-native (`/abs/coco/...` on POSIX,
+// `\abs\coco\...` on Windows). Build expectations through `join` too so the
+// assertions are platform-agnostic instead of pinning the POSIX separator.
+const ABS_REPO_ROOT = '/abs/coco'
 
 const baseOverview = {
   hasSubmodules: true,
@@ -71,7 +79,7 @@ describe('resolveCommitDiffDrillInTarget', () => {
     })
     expect(target).toEqual({
       label: 'vendor/lib',
-      workdir: '/abs/coco/vendor/lib',
+      workdir: join(ABS_REPO_ROOT, 'vendor/lib'),
       entryRange: {
         oldSha: '11111111',
         newSha: '22222222',
@@ -92,7 +100,7 @@ describe('resolveCommitDiffDrillInTarget', () => {
       submodules: baseOverview,
       activeRepoRoot: '/abs/coco',
     })
-    expect(target?.workdir).toBe('/abs/coco/packages/tools')
+    expect(target?.workdir).toBe(join(ABS_REPO_ROOT, 'packages/tools'))
     expect(target?.label).toBe('tools')
   })
 
@@ -110,7 +118,7 @@ describe('resolveCommitDiffDrillInTarget', () => {
     })
     expect(target?.entryRange).toBeUndefined()
     expect(target?.label).toBe('vendor/lib')
-    expect(target?.workdir).toBe('/abs/coco/vendor/lib')
+    expect(target?.workdir).toBe(join(ABS_REPO_ROOT, 'vendor/lib'))
   })
 
   it('omits entryRange for a removed submodule (no after sha)', () => {
@@ -199,7 +207,7 @@ describe('resolveSubmoduleViewDrillInTarget (#931 PR 4)', () => {
       activeRepoRoot: '/abs/coco',
     })).toEqual({
       label: 'vendor/lib',
-      workdir: '/abs/coco/vendor/lib',
+      workdir: join(ABS_REPO_ROOT, 'vendor/lib'),
     })
   })
 
@@ -210,7 +218,7 @@ describe('resolveSubmoduleViewDrillInTarget (#931 PR 4)', () => {
       activeRepoRoot: '/abs/coco',
     })).toEqual({
       label: 'tools',
-      workdir: '/abs/coco/packages/tools',
+      workdir: join(ABS_REPO_ROOT, 'packages/tools'),
     })
   })
 


### PR DESCRIPTION
First of the two 0.71 "CI & continuous discovery" items.

## Integration job
The `test:integration` script existed but no CI step ran it. Adds a dedicated **Integration** job:
- The non-live suite (`commands.integration`) always runs.
- The **live GitLab suite** (`gitlab.integration`) self-skips via `describe.skip` unless `COCO_GITLAB_IT` + `COCO_GITLAB_TEST_PROJECT` repo secrets are set — so the default flow and forks need **no** GitLab credentials. Setting those secrets is all it takes to light up live MR/issue integration in CI.

*(Verified `npm run test:integration` green locally: 49 passed, GitLab suite skipped.)*

## Windows matrix cell
ci.yml has long flagged path-separator concerns but only ran Linux + macOS. Adds `windows-latest` (Node 22.22.2) as an **experimental** cell with job-level `continue-on-error: ${{ matrix.experimental || false }}`, so Windows-only failures **surface on the PR without blocking it** while we stabilize. Promote to a required cell once it's reliably green.

## Note for you
- This PR's own CI will be the first Windows run — if it reveals path-separator bugs, they'll show as a non-blocking ❌ on the Windows cell; I can follow up to fix them.
- To enable the live GitLab integration job, add the `COCO_GITLAB_IT` (=`1`), `COCO_GITLAB_TEST_PROJECT`, and (if needed) `GITLAB_TOKEN` repo secrets.