### PR TITLE
feat(workstation): submodule init / update / sync actions

### DIFF
--- a/src/git/submoduleActions.test.ts
+++ b/src/git/submoduleActions.test.ts
@@ -1,0 +1,80 @@
+import { SubmoduleEntry } from './submoduleData'
+import { initSubmodule, syncSubmodule, updateSubmodule } from './submoduleActions'
+
+const entry: SubmoduleEntry = {
+  name: 'vendor-lib',
+  path: 'vendor/lib',
+  pinnedSha: 'abc1234',
+  flag: 'uninitialized',
+  trackingBranch: 'main',
+  url: 'https://example.com/vendor/lib.git',
+}
+
+describe('submodule actions', () => {
+  it('inits, updates, and syncs a submodule scoped by path', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+
+    await initSubmodule(git as never, entry)
+    await updateSubmodule(git as never, entry, { init: true })
+    await syncSubmodule(git as never, entry)
+
+    expect(git.raw).toHaveBeenNthCalledWith(1, ['submodule', 'init', '--', 'vendor/lib'])
+    expect(git.raw).toHaveBeenNthCalledWith(2, ['submodule', 'update', '--init', '--', 'vendor/lib'])
+    expect(git.raw).toHaveBeenNthCalledWith(3, ['submodule', 'sync', '--', 'vendor/lib'])
+  })
+
+  it('omits --init on a plain update', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+
+    await updateSubmodule(git as never, entry)
+
+    expect(git.raw).toHaveBeenCalledWith(['submodule', 'update', '--', 'vendor/lib'])
+  })
+
+  it('returns friendly success messages', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+
+    await expect(initSubmodule(git as never, entry)).resolves.toEqual({
+      ok: true,
+      message: 'Initialized vendor-lib',
+    })
+    await expect(updateSubmodule(git as never, entry, { init: true })).resolves.toEqual({
+      ok: true,
+      message: 'Updated vendor-lib',
+    })
+    await expect(syncSubmodule(git as never, entry)).resolves.toEqual({
+      ok: true,
+      message: 'Synced vendor-lib URL',
+    })
+  })
+
+  it('maps a git failure to an error result', async () => {
+    const git = {
+      raw: jest.fn().mockRejectedValue(new Error('boom')),
+    }
+
+    await expect(initSubmodule(git as never, entry)).resolves.toEqual({
+      ok: false,
+      message: 'boom',
+    })
+  })
+
+  it('refuses to act when the entry has no path', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+    const pathless = { ...entry, path: '' }
+
+    await expect(initSubmodule(git as never, pathless)).resolves.toEqual({
+      ok: false,
+      message: 'No submodule selected.',
+    })
+    await expect(updateSubmodule(git as never, pathless)).resolves.toEqual({
+      ok: false,
+      message: 'No submodule selected.',
+    })
+    await expect(syncSubmodule(git as never, pathless)).resolves.toEqual({
+      ok: false,
+      message: 'No submodule selected.',
+    })
+    expect(git.raw).not.toHaveBeenCalled()
+  })
+})

--- a/src/git/submoduleActions.ts
+++ b/src/git/submoduleActions.ts
@@ -1,0 +1,86 @@
+import { SimpleGit } from 'simple-git'
+import { BranchActionResult } from './branchActions'
+import { SubmoduleEntry } from './submoduleData'
+
+/**
+ * Submodule maintenance actions (#0.71 — expanded git ops).
+ *
+ * The submodules view (#932) is a read-only inspector today; these three
+ * actions let the user repair a submodule's working tree without dropping to a
+ * shell. All operate on a single submodule, scoped by its repo-relative path
+ * (`-- <path>`), so an action on the cursored row never disturbs its siblings.
+ *
+ * None are destructive — init / update / sync only register, fetch-and-check-out,
+ * or rewrite the recorded remote URL; none can lose committed work — so they run
+ * directly without the y-confirm gate the destructive workflows use.
+ */
+
+async function runAction(
+  action: () => Promise<unknown>,
+  successMessage: string
+): Promise<BranchActionResult> {
+  try {
+    await action()
+    return { ok: true, message: successMessage }
+  } catch (error) {
+    return { ok: false, message: (error as Error).message }
+  }
+}
+
+/**
+ * `git submodule init -- <path>`: register the submodule in `.git/config` from
+ * its `.gitmodules` entry. Cheap, local, idempotent — it copies the URL into the
+ * parent repo's config so a later `update` knows where to fetch from. Does not
+ * fetch or check anything out on its own.
+ */
+export function initSubmodule(git: SimpleGit, entry: SubmoduleEntry): Promise<BranchActionResult> {
+  if (!entry?.path) {
+    return Promise.resolve({ ok: false, message: 'No submodule selected.' })
+  }
+  return runAction(
+    () => git.raw(['submodule', 'init', '--', entry.path]),
+    `Initialized ${entry.name}`
+  )
+}
+
+export type UpdateSubmoduleOptions = {
+  /** `--init`: register the submodule first if it isn't already (one-shot init+update). */
+  init?: boolean
+}
+
+/**
+ * `git submodule update [--init] -- <path>`: fetch and check the submodule out
+ * at the commit the parent repo has pinned. With `init: true` it also registers
+ * the submodule first, so a single keystroke can take an uninitialized submodule
+ * all the way to checked-out. Non-destructive — it only moves the submodule's
+ * HEAD to the recorded pin.
+ */
+export function updateSubmodule(
+  git: SimpleGit,
+  entry: SubmoduleEntry,
+  options: UpdateSubmoduleOptions = {}
+): Promise<BranchActionResult> {
+  if (!entry?.path) {
+    return Promise.resolve({ ok: false, message: 'No submodule selected.' })
+  }
+  const args = ['submodule', 'update']
+  if (options.init) args.push('--init')
+  args.push('--', entry.path)
+  return runAction(() => git.raw(args), `Updated ${entry.name}`)
+}
+
+/**
+ * `git submodule sync -- <path>`: re-copy the submodule's remote URL from
+ * `.gitmodules` into `.git/config` (and the submodule's own remote). The fix-up
+ * when a submodule's upstream URL changed in `.gitmodules` but the local config
+ * still points at the old remote. Touches only config — never the working tree.
+ */
+export function syncSubmodule(git: SimpleGit, entry: SubmoduleEntry): Promise<BranchActionResult> {
+  if (!entry?.path) {
+    return Promise.resolve({ ok: false, message: 'No submodule selected.' })
+  }
+  return runAction(
+    () => git.raw(['submodule', 'sync', '--', entry.path]),
+    `Synced ${entry.name} URL`
+  )
+}

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -222,6 +222,7 @@ import { bisectBad, bisectGood, bisectReset, bisectRun, bisectSkip, bisectStart,
 import { getCompareDiff } from '../../git/compareData'
 import { getReflogOverview } from '../../git/reflogData'
 import { checkoutReflogEntry } from '../../git/reflogActions'
+import { initSubmodule, syncSubmodule, updateSubmodule } from '../../git/submoduleActions'
 import { getTagOverview } from '../../git/tagData'
 import { getWorktreeListOverview } from '../../git/worktreeData'
 import { WorktreeFileDiff, getWorktreeFileDiff } from '../../git/worktreeDiffData'
@@ -3467,6 +3468,32 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         if (!entry) return { ok: false, message: 'No reflog entry selected' }
         return checkoutReflogEntry(git, entry)
       },
+      // #0.71 — submodule maintenance. Resolve the target from the
+      // filtered list so the cursor index lines up with what's on screen
+      // (a filtered-out submodule can never be the action target). The
+      // post-handler refreshContext reloads the submodule overview so the
+      // row's status flag updates after the action lands.
+      'submodule-init': async () => {
+        const entry = filteredSubmoduleList[
+          Math.min(state.selectedSubmoduleIndex, Math.max(0, filteredSubmoduleList.length - 1))
+        ]
+        if (!entry) return { ok: false, message: 'No submodule selected' }
+        return initSubmodule(git, entry)
+      },
+      'submodule-update': async () => {
+        const entry = filteredSubmoduleList[
+          Math.min(state.selectedSubmoduleIndex, Math.max(0, filteredSubmoduleList.length - 1))
+        ]
+        if (!entry) return { ok: false, message: 'No submodule selected' }
+        return updateSubmodule(git, entry, { init: true })
+      },
+      'submodule-sync': async () => {
+        const entry = filteredSubmoduleList[
+          Math.min(state.selectedSubmoduleIndex, Math.max(0, filteredSubmoduleList.length - 1))
+        ]
+        if (!entry) return { ok: false, message: 'No submodule selected' }
+        return syncSubmodule(git, entry)
+      },
       'create-tag-here': async () => {
         const commit = getSelectedInkCommit(state)
         const name = payload?.trim()
@@ -4188,7 +4215,8 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
   }, [context, dispatch, git, refreshContext, refreshHistoryRows, refreshWorktreeContext,
     state.branchSort, state.filter, state.selectedBranchIndex,
-    state.selectedStashIndex, state.selectedTagIndex, state.selectedWorktreeListIndex, state.stashDiffRef,
+    state.selectedStashIndex, state.selectedSubmoduleIndex, state.selectedTagIndex,
+    state.selectedWorktreeListIndex, state.stashDiffRef,
     state.statusFilterMask, state.tagSort, state.worktreeCheckoutConflict])
 
   // Resolve the active view's "yank target" (commit hash / branch /

--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -1214,6 +1214,28 @@ describe('log Ink input interactions', () => {
     expect(yShiftEvents).toContainEqual({ type: 'yankFromActiveView', short: true })
   })
 
+  it('i / u / s on the submodules view run init / update / sync (#0.71)', () => {
+    const state = createLogInkState(rows, { activeView: 'submodules' })
+
+    expect(getLogInkInputEvents(state, 'i', {}, { submoduleCount: 2 }))
+      .toContainEqual({ type: 'runWorkflowAction', id: 'submodule-init' })
+    expect(getLogInkInputEvents(state, 'u', {}, { submoduleCount: 2 }))
+      .toContainEqual({ type: 'runWorkflowAction', id: 'submodule-update' })
+    expect(getLogInkInputEvents(state, 's', {}, { submoduleCount: 2 }))
+      .toContainEqual({ type: 'runWorkflowAction', id: 'submodule-sync' })
+  })
+
+  it('submodule init / update / sync keys require a non-empty submodule list (#0.71)', () => {
+    const state = createLogInkState(rows, { activeView: 'submodules' })
+
+    for (const key of ['i', 'u', 's']) {
+      const events = getLogInkInputEvents(state, key, {}, { submoduleCount: 0 })
+      expect(events.find((e) =>
+        e.type === 'runWorkflowAction' && e.id.startsWith('submodule-')
+      )).toBeUndefined()
+    }
+  })
+
   it('lower-case g on the bisect view marks good (no chord trigger) (#784)', () => {
     let state = createLogInkState(rows)
     state = applyLogInkAction(state, { type: 'pushView', value: 'bisect' })

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -3321,6 +3321,22 @@ export function getLogInkInputEvents(
     return [{ type: 'runWorkflowAction', id: 'checkout-reflog-entry' }]
   }
 
+  // #0.71 — submodule maintenance on the cursored row. Scoped to the
+  // submodules view so the bare keys don't collide with the sort `s` /
+  // history `i` / stash+branch `u` bound on other views (the resolver
+  // reaches those earlier only when their own view is active). init /
+  // update / sync are all non-destructive, so they run straight through
+  // to the workflow handler with no y-confirm.
+  if (inputValue === 'i' && isSubmodulesActionTarget(state) && context.submoduleCount) {
+    return [{ type: 'runWorkflowAction', id: 'submodule-init' }]
+  }
+  if (inputValue === 'u' && isSubmodulesActionTarget(state) && context.submoduleCount) {
+    return [{ type: 'runWorkflowAction', id: 'submodule-update' }]
+  }
+  if (inputValue === 's' && isSubmodulesActionTarget(state) && context.submoduleCount) {
+    return [{ type: 'runWorkflowAction', id: 'submodule-sync' }]
+  }
+
   // `y` / `Y` yank the contextually relevant identifier from the active
   // view to the system clipboard:
   //   history    → cursored commit hash (Y for short hash)

--- a/src/workstation/runtime/inkKeymap.ts
+++ b/src/workstation/runtime/inkKeymap.ts
@@ -1327,7 +1327,7 @@ function computeLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogInkF
 
   if (options.activeView === 'submodules') {
     return {
-      contextual: ['↑/↓ entries', 'y yank path', 'Y yank sha', '/ filter', 'esc back'],
+      contextual: ['↑/↓ entries', 'i init', 'u update', 's sync', 'y yank path', 'Y yank sha', '/ filter', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/workstation/runtime/inkWorkflows.ts
+++ b/src/workstation/runtime/inkWorkflows.ts
@@ -580,6 +580,36 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: false,
     },
     {
+      // #0.71 — submodule maintenance actions. All three are scoped
+      // per-view in inkInput (active only when activeView ===
+      // 'submodules') so their single-letter keys (i / u / s) stay free
+      // elsewhere. Empty `key` keeps them palette-discoverable. None are
+      // destructive — init/update/sync can't lose committed work — so
+      // they run immediately, no y-confirm.
+      id: 'submodule-init',
+      key: '',
+      label: 'Submodule: init',
+      description: 'Register the cursored submodule in .git/config from its .gitmodules entry.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      id: 'submodule-update',
+      key: '',
+      label: 'Submodule: update',
+      description: 'Fetch and check out the cursored submodule at the pinned commit (init first if needed).',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      id: 'submodule-sync',
+      key: '',
+      label: 'Submodule: sync URL',
+      description: 'Re-sync the cursored submodule’s remote URL from .gitmodules into config.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
       // #784 — bisect workflow actions. All four are scoped per-view in
       // inkInput (active only when activeView === 'bisect') so the
       // single-letter keys stay free elsewhere. Empty `key` keeps them


### PR DESCRIPTION
First PR of the 0.71 "expanded git ops" release: non-destructive submodule maintenance on the existing workstation submodules surface.

## What

Three view-scoped actions on the submodules view (operate on the cursored row, scoped by repo-relative path so siblings are untouched):

| key | action | git |
| --- | --- | --- |
| `i` | submodule init | `git submodule init -- <path>` |
| `u` | submodule update | `git submodule update --init -- <path>` |
| `s` | submodule sync | `git submodule sync -- <path>` |

None can lose committed work, so they run immediately with **no y-confirm** (same call as the reflog-checkout precedent). The existing post-action `refreshContext` reloads the submodule overview, so a row's status flag (uninitialized → clean, etc.) updates in place.

## How

- **`src/git/submoduleActions.ts`** (+ test): `initSubmodule` / `updateSubmodule(…, { init })` / `syncSubmodule`, each returning the shared `BranchActionResult` `{ ok, message }` shape via the same `runAction` helper used by stash/reflog actions. Friendly success messages (`Initialized <name>` / `Updated <name>` / `Synced <name> URL`); a missing path short-circuits to `{ ok: false }`.
- **`inkWorkflows.ts`**: registers `submodule-init` / `submodule-update` / `submodule-sync` (`key: ''`, `kind: 'normal'`, `requiresConfirmation: false`), mirroring `checkout-reflog-entry` — palette-discoverable.
- **`app.ts`**: three handlers in the `runWorkflowAction` map resolve the target from the existing `filteredSubmoduleList` (cursor index aligns with the on-screen filtered list); `submodule-update` passes `{ init: true }`.
- **`inkInput.ts`**: `i` / `u` / `s` gated on `isSubmodulesActionTarget(state) && context.submoduleCount`, emitting the matching `runWorkflowAction`. Scoped to `activeView === 'submodules'`, so they don't collide with sort `s` / history `i` / stash+branch `u` on other views.
- **`inkKeymap.ts`**: submodules footer hints now read `i init`, `u update`, `s sync`.

## Notes

- Used **`s`** for sync (not `S`): the keymap-collisions test stays green and the input resolver only reaches the branch/tag sort `s` when those views are active, so `s` is free on the submodules view. Confirmed by `inkKeymap.collisions.test.ts` + the new input tests.
- Followed the reflog precedent of documenting view-scoped keys via footer hints rather than adding `submodules` to the `LOG_INK_KEY_BINDINGS` contexts union (reflog's `c checkout` / `B` / `Z` are footer-hint-only too), keeping the declarative table consistent.

## Tests

- `src/git/submoduleActions.test.ts` — exact `git.raw` argv + ok/error + no-path mapping.
- `inkInput.test.ts` — `i`/`u`/`s` on the submodules view emit the right `runWorkflowAction`; gated on a non-empty list.
- Full suite green: 260 suites / 3331 tests passed, 62 snapshots, plus lint + build + cli + pack.