### PR TITLE
feat(workstation): remotes view (add / remove / set-url / prune)

### DIFF
--- a/src/git/remoteActions.test.ts
+++ b/src/git/remoteActions.test.ts
@@ -1,0 +1,106 @@
+import { addRemote, pruneRemote, removeRemote, setRemoteUrl } from './remoteActions'
+
+describe('remote actions', () => {
+  it('adds, sets-url, removes, and prunes with the right argv', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+
+    await addRemote(git as never, 'upstream', 'https://example.com/up.git')
+    await setRemoteUrl(git as never, 'origin', 'git@github.com:me/fork.git')
+    await removeRemote(git as never, 'upstream')
+    await pruneRemote(git as never, 'origin')
+
+    expect(git.raw).toHaveBeenNthCalledWith(1, [
+      'remote', 'add', 'upstream', 'https://example.com/up.git',
+    ])
+    expect(git.raw).toHaveBeenNthCalledWith(2, [
+      'remote', 'set-url', 'origin', 'git@github.com:me/fork.git',
+    ])
+    expect(git.raw).toHaveBeenNthCalledWith(3, ['remote', 'remove', 'upstream'])
+    expect(git.raw).toHaveBeenNthCalledWith(4, ['remote', 'prune', 'origin'])
+  })
+
+  it('trims whitespace around name and url', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+    await addRemote(git as never, '  upstream  ', '  https://example.com/up.git  ')
+    expect(git.raw).toHaveBeenCalledWith([
+      'remote', 'add', 'upstream', 'https://example.com/up.git',
+    ])
+  })
+
+  it('returns friendly success messages', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+
+    await expect(addRemote(git as never, 'upstream', 'https://up.git')).resolves.toEqual({
+      ok: true,
+      message: 'Added remote upstream',
+    })
+    await expect(setRemoteUrl(git as never, 'origin', 'https://o.git')).resolves.toEqual({
+      ok: true,
+      message: 'Set origin URL',
+    })
+    await expect(removeRemote(git as never, 'upstream')).resolves.toEqual({
+      ok: true,
+      message: 'Removed remote upstream',
+    })
+    await expect(pruneRemote(git as never, 'origin')).resolves.toEqual({
+      ok: true,
+      message: 'Pruned remote origin',
+    })
+  })
+
+  it('maps a git failure to an error result', async () => {
+    const git = { raw: jest.fn().mockRejectedValue(new Error('boom')) }
+    await expect(addRemote(git as never, 'upstream', 'https://up.git')).resolves.toEqual({
+      ok: false,
+      message: 'boom',
+    })
+  })
+
+  it('rejects an empty name without calling git', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+    await expect(addRemote(git as never, '   ', 'https://up.git')).resolves.toEqual({
+      ok: false,
+      message: 'Remote name required.',
+    })
+    await expect(removeRemote(git as never, '')).resolves.toEqual({
+      ok: false,
+      message: 'Remote name required.',
+    })
+    await expect(pruneRemote(git as never, '')).resolves.toEqual({
+      ok: false,
+      message: 'Remote name required.',
+    })
+    expect(git.raw).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty url without calling git', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+    await expect(addRemote(git as never, 'upstream', '  ')).resolves.toEqual({
+      ok: false,
+      message: 'Remote URL required.',
+    })
+    await expect(setRemoteUrl(git as never, 'origin', '')).resolves.toEqual({
+      ok: false,
+      message: 'Remote URL required.',
+    })
+    expect(git.raw).not.toHaveBeenCalled()
+  })
+
+  it('rejects a flag-like name to avoid arg injection', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+    await expect(addRemote(git as never, '--mirror', 'https://up.git')).resolves.toEqual({
+      ok: false,
+      message: "Remote name '--mirror' cannot start with '-'.",
+    })
+    expect(git.raw).not.toHaveBeenCalled()
+  })
+
+  it('rejects a flag-like url to avoid arg injection', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+    await expect(addRemote(git as never, 'upstream', '--upload-pack=evil')).resolves.toEqual({
+      ok: false,
+      message: "Remote URL '--upload-pack=evil' cannot start with '-'.",
+    })
+    expect(git.raw).not.toHaveBeenCalled()
+  })
+})

--- a/src/git/remoteActions.ts
+++ b/src/git/remoteActions.ts
@@ -1,0 +1,113 @@
+import { SimpleGit } from 'simple-git'
+import { BranchActionResult } from './branchActions'
+import { rejectFlagLike } from './forgeArgGuards'
+
+/**
+ * Remote maintenance actions (#0.71 — expanded git ops).
+ *
+ * The Remotes view lists every configured remote; these four actions
+ * let the user manage remotes without dropping to a shell:
+ *   - `addRemote`    → `git remote add <name> <url>`
+ *   - `removeRemote` → `git remote remove <name>`     (destructive)
+ *   - `setRemoteUrl` → `git remote set-url <name> <url>`
+ *   - `pruneRemote`  → `git remote prune <name>`       (destructive)
+ *
+ * All run through `runAction`, returning `{ ok, message }` — `ok:true`
+ * with a friendly success line, or `ok:false` carrying git's own error
+ * text. Inputs are validated up front: empty name/url is rejected, and
+ * a name or url beginning with `-` is rejected so a value can never be
+ * misparsed by git as a flag (defense-in-depth — argv is passed via
+ * simple-git's execFile, so there's no shell to inject into, but a
+ * leading `-` could still flip an unrelated flag).
+ */
+
+async function runAction(
+  action: () => Promise<unknown>,
+  successMessage: string
+): Promise<BranchActionResult> {
+  try {
+    await action()
+    return { ok: true, message: successMessage }
+  } catch (error) {
+    return { ok: false, message: (error as Error).message }
+  }
+}
+
+function validateName(name: string): string | undefined {
+  const trimmed = name.trim()
+  if (!trimmed) return 'Remote name required.'
+  return rejectFlagLike(trimmed, `Remote name '${trimmed}'`)
+}
+
+function validateUrl(url: string): string | undefined {
+  const trimmed = url.trim()
+  if (!trimmed) return 'Remote URL required.'
+  return rejectFlagLike(trimmed, `Remote URL '${trimmed}'`)
+}
+
+/**
+ * `git remote add <name> <url>`: register a new remote. Validates both
+ * the name and the URL before touching git so a bad value never reaches
+ * argv. Non-destructive — only adds a config entry.
+ */
+export function addRemote(git: SimpleGit, name: string, url: string): Promise<BranchActionResult> {
+  const nameError = validateName(name)
+  if (nameError) return Promise.resolve({ ok: false, message: nameError })
+  const urlError = validateUrl(url)
+  if (urlError) return Promise.resolve({ ok: false, message: urlError })
+  const cleanName = name.trim()
+  const cleanUrl = url.trim()
+  return runAction(
+    () => git.raw(['remote', 'add', cleanName, cleanUrl]),
+    `Added remote ${cleanName}`
+  )
+}
+
+/**
+ * `git remote remove <name>`: delete a remote and its tracking refs.
+ * Destructive — drops the remote's config + remote-tracking branches —
+ * so the TUI gates this behind a y-confirm before calling it.
+ */
+export function removeRemote(git: SimpleGit, name: string): Promise<BranchActionResult> {
+  const nameError = validateName(name)
+  if (nameError) return Promise.resolve({ ok: false, message: nameError })
+  const cleanName = name.trim()
+  return runAction(
+    () => git.raw(['remote', 'remove', cleanName]),
+    `Removed remote ${cleanName}`
+  )
+}
+
+/**
+ * `git remote set-url <name> <url>`: repoint an existing remote at a
+ * new URL. Validates the name + URL like `addRemote`. Non-destructive
+ * to history, but the prompt that collects the URL is the affirmative
+ * gate, so the TUI runs it directly (no y-confirm).
+ */
+export function setRemoteUrl(git: SimpleGit, name: string, url: string): Promise<BranchActionResult> {
+  const nameError = validateName(name)
+  if (nameError) return Promise.resolve({ ok: false, message: nameError })
+  const urlError = validateUrl(url)
+  if (urlError) return Promise.resolve({ ok: false, message: urlError })
+  const cleanName = name.trim()
+  const cleanUrl = url.trim()
+  return runAction(
+    () => git.raw(['remote', 'set-url', cleanName, cleanUrl]),
+    `Set ${cleanName} URL`
+  )
+}
+
+/**
+ * `git remote prune <name>`: delete stale remote-tracking refs that no
+ * longer exist on the remote. Destructive — it removes refs — so the
+ * TUI gates this behind a y-confirm. The remote's config is untouched.
+ */
+export function pruneRemote(git: SimpleGit, name: string): Promise<BranchActionResult> {
+  const nameError = validateName(name)
+  if (nameError) return Promise.resolve({ ok: false, message: nameError })
+  const cleanName = name.trim()
+  return runAction(
+    () => git.raw(['remote', 'prune', cleanName]),
+    `Pruned remote ${cleanName}`
+  )
+}

--- a/src/git/remoteData.test.ts
+++ b/src/git/remoteData.test.ts
@@ -1,0 +1,106 @@
+import { getRemoteOverview, parseRemoteVerboseOutput } from './remoteData'
+
+describe('parseRemoteVerboseOutput', () => {
+  it('groups fetch + push lines into one entry per remote', () => {
+    const output = [
+      'origin\tgit@github.com:gfargo/coco.git (fetch)',
+      'origin\tgit@github.com:gfargo/coco.git (push)',
+      'upstream\thttps://example.com/upstream.git (fetch)',
+      'upstream\thttps://example.com/upstream.git (push)',
+    ].join('\n')
+
+    expect(parseRemoteVerboseOutput(output)).toEqual([
+      {
+        name: 'origin',
+        fetchUrl: 'git@github.com:gfargo/coco.git',
+        pushUrl: 'git@github.com:gfargo/coco.git',
+      },
+      {
+        name: 'upstream',
+        fetchUrl: 'https://example.com/upstream.git',
+        pushUrl: 'https://example.com/upstream.git',
+      },
+    ])
+  })
+
+  it('keeps distinct fetch and push URLs', () => {
+    const output = [
+      'origin\thttps://example.com/upstream.git (fetch)',
+      'origin\tgit@github.com:me/fork.git (push)',
+    ].join('\n')
+
+    expect(parseRemoteVerboseOutput(output)).toEqual([
+      {
+        name: 'origin',
+        fetchUrl: 'https://example.com/upstream.git',
+        pushUrl: 'git@github.com:me/fork.git',
+      },
+    ])
+  })
+
+  it('falls back to the available URL when one direction is missing', () => {
+    const output = 'origin\tgit@github.com:gfargo/coco.git (fetch)'
+    expect(parseRemoteVerboseOutput(output)).toEqual([
+      {
+        name: 'origin',
+        fetchUrl: 'git@github.com:gfargo/coco.git',
+        pushUrl: 'git@github.com:gfargo/coco.git',
+      },
+    ])
+  })
+
+  it('ignores blank and malformed lines', () => {
+    const output = ['', 'garbage line', 'origin\tgit@host:repo.git (fetch)', '   '].join('\n')
+    expect(parseRemoteVerboseOutput(output)).toEqual([
+      { name: 'origin', fetchUrl: 'git@host:repo.git', pushUrl: 'git@host:repo.git' },
+    ])
+  })
+
+  it('preserves remote order from the output', () => {
+    const output = [
+      'zeta\thttps://z.git (fetch)',
+      'zeta\thttps://z.git (push)',
+      'alpha\thttps://a.git (fetch)',
+      'alpha\thttps://a.git (push)',
+    ].join('\n')
+    expect(parseRemoteVerboseOutput(output).map((e) => e.name)).toEqual(['zeta', 'alpha'])
+  })
+})
+
+describe('getRemoteOverview', () => {
+  it('reports remotes from `git remote -v`', async () => {
+    const git = {
+      raw: jest.fn().mockResolvedValue(
+        'origin\tgit@github.com:gfargo/coco.git (fetch)\norigin\tgit@github.com:gfargo/coco.git (push)\n'
+      ),
+    }
+
+    await expect(getRemoteOverview(git as never)).resolves.toEqual({
+      hasRemotes: true,
+      entries: [
+        {
+          name: 'origin',
+          fetchUrl: 'git@github.com:gfargo/coco.git',
+          pushUrl: 'git@github.com:gfargo/coco.git',
+        },
+      ],
+    })
+    expect(git.raw).toHaveBeenCalledWith(['remote', '-v'])
+  })
+
+  it('returns an empty overview when no remotes are configured', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+    await expect(getRemoteOverview(git as never)).resolves.toEqual({
+      hasRemotes: false,
+      entries: [],
+    })
+  })
+
+  it('falls back to an empty overview when the command fails', async () => {
+    const git = { raw: jest.fn().mockRejectedValue(new Error('not a git repo')) }
+    await expect(getRemoteOverview(git as never)).resolves.toEqual({
+      hasRemotes: false,
+      entries: [],
+    })
+  })
+})

--- a/src/git/remoteData.ts
+++ b/src/git/remoteData.ts
@@ -1,0 +1,95 @@
+import { SimpleGit } from 'simple-git'
+
+/**
+ * Remote overview loader (#0.71 — expanded git ops).
+ *
+ * Surfaces the per-remote metadata the Remotes view needs to render a
+ * row: which remote it is (name) and the fetch / push URLs it points
+ * at. A remote can carry distinct fetch and push URLs (a common
+ * read-from-upstream / push-to-fork setup), so both are reported.
+ *
+ * Detection is via `git remote -v`, which lists one `<name>\t<url>
+ * (fetch)` / `<name>\t<url> (push)` line per remote — a single cheap,
+ * local read. No network round-trip is ever required.
+ *
+ * Best-effort: any failure falls through to the empty-overview
+ * sentinel rather than disrupting the surrounding context load,
+ * matching `submoduleData.ts`.
+ */
+
+export type RemoteEntry = {
+  /** Remote name (the `[remote "name"]` short name, e.g. `origin`). */
+  name: string
+  /** URL git fetches from. */
+  fetchUrl: string
+  /**
+   * URL git pushes to. Equals `fetchUrl` for the common single-URL
+   * remote; differs when a separate push URL is configured.
+   */
+  pushUrl: string
+}
+
+export type RemoteOverview = {
+  /** True when at least one remote is configured. */
+  hasRemotes: boolean
+  entries: RemoteEntry[]
+}
+
+const EMPTY_OVERVIEW: RemoteOverview = { hasRemotes: false, entries: [] }
+
+/**
+ * Parse the output of `git remote -v`. The format is two lines per
+ * remote:
+ *
+ *   `origin\t<url> (fetch)`
+ *   `origin\t<url> (push)`
+ *
+ * Remotes are grouped by name; the fetch line seeds `fetchUrl`, the
+ * push line seeds `pushUrl`. A remote with only one of the two (rare,
+ * but possible with a custom config) falls back to the URL it does
+ * have for the missing direction so a row never renders a blank URL.
+ */
+export function parseRemoteVerboseOutput(output: string): RemoteEntry[] {
+  const byName = new Map<string, { fetchUrl?: string; pushUrl?: string }>()
+  const order: string[] = []
+
+  for (const rawLine of output.split('\n')) {
+    const line = rawLine.trim()
+    if (!line) continue
+    // `<name>\t<url> (fetch|push)` — split the leading name off the
+    // tab, then peel the trailing ` (fetch)` / ` (push)` marker.
+    const match = line.match(/^(\S+)\s+(.*?)\s+\((fetch|push)\)$/)
+    if (!match) continue
+    const [, name, url, direction] = match
+    if (!byName.has(name)) {
+      byName.set(name, {})
+      order.push(name)
+    }
+    const slot = byName.get(name) as { fetchUrl?: string; pushUrl?: string }
+    if (direction === 'fetch') slot.fetchUrl = url
+    else slot.pushUrl = url
+  }
+
+  return order.map((name) => {
+    const slot = byName.get(name) as { fetchUrl?: string; pushUrl?: string }
+    const fetchUrl = slot.fetchUrl || slot.pushUrl || ''
+    const pushUrl = slot.pushUrl || slot.fetchUrl || ''
+    return { name, fetchUrl, pushUrl }
+  })
+}
+
+/**
+ * Load the remote overview from `git remote -v`. Returns the
+ * empty-overview sentinel when no remotes are configured (or the
+ * command fails), so callers don't pay any cost on remote-less repos.
+ */
+export async function getRemoteOverview(git: SimpleGit): Promise<RemoteOverview> {
+  let output = ''
+  try {
+    output = await git.raw(['remote', '-v'])
+  } catch {
+    return EMPTY_OVERVIEW
+  }
+  const entries = parseRemoteVerboseOutput(output)
+  return { hasRemotes: entries.length > 0, entries }
+}

--- a/src/workstation/chrome/context.ts
+++ b/src/workstation/chrome/context.ts
@@ -8,6 +8,7 @@ export const LOG_INK_CONTEXT_KEYS = [
   'pullRequest',
   'pullRequestList',
   'reflog',
+  'remotes',
   'stashes',
   'submodules',
   'tags',

--- a/src/workstation/chrome/surfaceStates.ts
+++ b/src/workstation/chrome/surfaceStates.ts
@@ -114,6 +114,17 @@ export function formatLogInkSubmodulesEmpty({ filter }: LogInkSubmodulesEmptyArg
   return 'No submodules registered. Add one with `git submodule add <url> <path>` from the shell.'
 }
 
+export type LogInkRemotesEmptyArgs = {
+  filter: string
+}
+
+export function formatLogInkRemotesEmpty({ filter }: LogInkRemotesEmptyArgs): string {
+  if (filter.trim()) {
+    return `No remotes match filter '${filter}'. Press ctrl+u to clear.`
+  }
+  return 'No remotes configured. Press a to add one.'
+}
+
 export type LogInkIssuesEmptyArgs = {
   filter: string
 }

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -61,6 +61,7 @@ import { getBranchOverview } from '../../git/branchData'
 import { hashesMatchAny } from '../../git/hashes'
 import { getLfsAttributeStatus } from '../../git/lfsAttributes'
 import { getSubmoduleOverview } from '../../git/submoduleData'
+import { getRemoteOverview } from '../../git/remoteData'
 import { createManualCommit, formatCommitComposeMessage } from '../../commands/log/commitCompose'
 import {
     runCommitDraftWorkflow,
@@ -223,6 +224,7 @@ import { getCompareDiff } from '../../git/compareData'
 import { getReflogOverview } from '../../git/reflogData'
 import { checkoutReflogEntry } from '../../git/reflogActions'
 import { initSubmodule, syncSubmodule, updateSubmodule } from '../../git/submoduleActions'
+import { addRemote, pruneRemote, removeRemote, setRemoteUrl } from '../../git/remoteActions'
 import { getTagOverview } from '../../git/tagData'
 import { getWorktreeListOverview } from '../../git/worktreeData'
 import { WorktreeFileDiff, getWorktreeFileDiff } from '../../git/worktreeDiffData'
@@ -237,7 +239,7 @@ async function safe<T>(promise: Promise<T>): Promise<T | undefined> {
 }
 
 async function loadLogInkContext(git: SimpleGit): Promise<LogInkContext> {
-  const [branches, pullRequest, tags, worktree, stashes, worktreeList, operation, provider, reflog, bisect, lfs, submodules] =
+  const [branches, pullRequest, tags, worktree, stashes, worktreeList, operation, provider, reflog, bisect, lfs, submodules, remotes] =
     await Promise.all([
       safe(getBranchOverview(git)),
       safe(getForgePullRequestOverview(git)),
@@ -251,6 +253,7 @@ async function loadLogInkContext(git: SimpleGit): Promise<LogInkContext> {
       safe(getBisectStatus(git)),
       safe(getLfsAttributeStatus(git)),
       safe(getSubmoduleOverview(git)),
+      safe(getRemoteOverview(git)),
     ])
 
   return {
@@ -261,6 +264,7 @@ async function loadLogInkContext(git: SimpleGit): Promise<LogInkContext> {
     provider,
     pullRequest,
     reflog,
+    remotes,
     stashes,
     submodules,
     tags,
@@ -306,6 +310,10 @@ function loadLogInkContextEntries(git: SimpleGit): Array<{
     {
       key: 'submodules',
       load: () => safe(getSubmoduleOverview(git)),
+    },
+    {
+      key: 'remotes',
+      load: () => safe(getRemoteOverview(git)),
     },
     {
       key: 'worktree',
@@ -925,6 +933,13 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       )
     )
   }, [context.submodules?.entries, state.filter])
+  const filteredRemoteList = React.useMemo(() => {
+    const all = context.remotes?.entries || []
+    if (!state.filter) return all
+    return all.filter((entry) =>
+      matchesPromotedFilter([entry.name, entry.fetchUrl, entry.pushUrl], state.filter)
+    )
+  }, [context.remotes?.entries, state.filter])
   // Issues + PR triage filtered lists (#882 phase 3). Same memo
   // pattern as the other promoted views — collapses per-keystroke
   // filter work to one pass per (data, filter) change.
@@ -3494,6 +3509,44 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         if (!entry) return { ok: false, message: 'No submodule selected' }
         return syncSubmodule(git, entry)
       },
+      // #0.71 — remote management. add parses a single `name url` line
+      // from the prompt payload; set-url / remove / prune resolve the
+      // target from the filtered list so the cursor index lines up with
+      // what's on screen. The post-handler refreshContext reloads the
+      // remote overview so the list reflects the change.
+      'remote-add': async () => {
+        const raw = (payload || '').trim()
+        if (!raw) return { ok: false, message: 'Remote name and URL required' }
+        // Single-line `name url` prompt: first whitespace-run splits the
+        // name from the URL. A missing URL falls through to the action's
+        // own validation, which returns a friendly error.
+        const firstSpace = raw.search(/\s/)
+        const name = firstSpace === -1 ? raw : raw.slice(0, firstSpace)
+        const url = firstSpace === -1 ? '' : raw.slice(firstSpace).trim()
+        return addRemote(git, name, url)
+      },
+      'remote-set-url': async () => {
+        const entry = filteredRemoteList[
+          Math.min(state.selectedRemoteIndex, Math.max(0, filteredRemoteList.length - 1))
+        ]
+        if (!entry) return { ok: false, message: 'No remote selected' }
+        const url = (payload || '').trim()
+        return setRemoteUrl(git, entry.name, url)
+      },
+      'remote-remove': async () => {
+        const entry = filteredRemoteList[
+          Math.min(state.selectedRemoteIndex, Math.max(0, filteredRemoteList.length - 1))
+        ]
+        if (!entry) return { ok: false, message: 'No remote selected' }
+        return removeRemote(git, entry.name)
+      },
+      'remote-prune': async () => {
+        const entry = filteredRemoteList[
+          Math.min(state.selectedRemoteIndex, Math.max(0, filteredRemoteList.length - 1))
+        ]
+        if (!entry) return { ok: false, message: 'No remote selected' }
+        return pruneRemote(git, entry.name)
+      },
       'create-tag-here': async () => {
         const commit = getSelectedInkCommit(state)
         const name = payload?.trim()
@@ -4215,7 +4268,8 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
   }, [context, dispatch, git, refreshContext, refreshHistoryRows, refreshWorktreeContext,
     state.branchSort, state.filter, state.selectedBranchIndex,
-    state.selectedStashIndex, state.selectedSubmoduleIndex, state.selectedTagIndex,
+    state.selectedStashIndex, state.selectedSubmoduleIndex, state.selectedRemoteIndex,
+    state.selectedTagIndex,
     state.selectedWorktreeListIndex, state.stashDiffRef,
     state.statusFilterMask, state.tagSort, state.worktreeCheckoutConflict])
 
@@ -4299,6 +4353,18 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
           value = entry.path
           label = `submodule path ${entry.path}`
         }
+      }
+    } else if (view === 'remotes') {
+      // #0.71 — yank from the dedicated remotes view. `y` copies the
+      // cursored remote's fetch URL (the value the user most often
+      // needs for a clone / config command). Short form (`Y`) is a
+      // no-op — there's no compact alternate worth a second key.
+      const entry = filteredRemoteList[
+        Math.min(state.selectedRemoteIndex, Math.max(0, filteredRemoteList.length - 1))
+      ]
+      if (entry && entry.fetchUrl) {
+        value = entry.fetchUrl
+        label = `remote ${entry.name} URL`
       }
     } else if (view === 'issues') {
       // #882 phase 4 — y yanks the cursored issue's URL so the user
@@ -4393,6 +4459,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     dispatch,
     filteredIssueList,
     filteredPullRequestTriageList,
+    filteredRemoteList,
     selected,
     selectedDetailFile,
     stashDiffLines,
@@ -4407,6 +4474,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     state.selectedIndex,
     state.selectedIssueIndex,
     state.selectedPullRequestTriageIndex,
+    state.selectedRemoteIndex,
     state.selectedStashIndex,
     state.selectedSubmoduleIndex,
     state.selectedTagIndex,
@@ -4801,6 +4869,10 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     const submoduleSelectedPath = filteredSubmoduleList[
       Math.min(state.selectedSubmoduleIndex, Math.max(0, filteredSubmoduleList.length - 1))
     ]?.path
+    const remoteVisibleCount = filteredRemoteList.length
+    const remoteSelectedName = filteredRemoteList[
+      Math.min(state.selectedRemoteIndex, Math.max(0, filteredRemoteList.length - 1))
+    ]?.name
     const issueVisibleCount = filteredIssueList.length
     const issueSelectedUrl = filteredIssueList[
       Math.min(state.selectedIssueIndex, Math.max(0, filteredIssueList.length - 1))
@@ -4850,6 +4922,8 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       reflogSelectedHash,
       submoduleCount: submoduleVisibleCount,
       submoduleSelectedPath,
+      remoteCount: remoteVisibleCount,
+      remoteSelectedName,
       issueCount: issueVisibleCount,
       issueSelectedUrl,
       pullRequestTriageCount: pullRequestTriageVisibleCount,

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -116,6 +116,10 @@ export type LogInkInputContext = {
   submoduleCount?: number
   /** Repo-relative path of the cursored submodule (#932). Reserved for future per-entry actions. */
   submoduleSelectedPath?: string
+  /** Number of configured remotes (#0.71). Drives j/k navigation on the remotes view. */
+  remoteCount?: number
+  /** Name of the cursored remote (#0.71). Used as the yank target on the remotes view. */
+  remoteSelectedName?: string
   /** Number of issues in the triage list view (#882 phase 3). Drives j/k navigation. */
   issueCount?: number
   /** URL of the cursored issue (#882 phase 3). Used by `O` to open in the browser. */
@@ -433,14 +437,14 @@ function isReflogActionTarget(state: LogInkState): boolean {
 const CREATE_PR_VIEWS: readonly LogInkView[] = [
   'history', 'status', 'diff', 'compose', 'branches', 'tags', 'stash',
   'worktrees', 'pull-request', 'pull-request-triage', 'issues', 'reflog',
-  'bisect', 'changelog', 'submodules',
+  'bisect', 'changelog', 'submodules', 'remotes',
 ]
 // Bare `S` creates a stash everywhere EXCEPT the commit triad
 // (compose / status / diff), where `S` starts the commit-split flow.
 const CREATE_STASH_VIEWS: readonly LogInkView[] = [
   'history', 'branches', 'tags', 'stash', 'worktrees', 'pull-request',
   'pull-request-triage', 'issues', 'conflicts', 'reflog', 'bisect',
-  'changelog', 'submodules',
+  'changelog', 'submodules', 'remotes',
 ]
 
 /** True when bare `C` should create a PR in the active view. */
@@ -459,6 +463,14 @@ export function isCreateStashView(view: LogInkView): boolean {
  */
 function isSubmodulesActionTarget(state: LogInkState): boolean {
   return state.activeView === 'submodules' && state.focus === 'commits'
+}
+
+/**
+ * Remotes has no sidebar tab — only the dedicated promoted view
+ * (#0.71). Same shape as `isReflogActionTarget` / `isSubmodulesActionTarget`.
+ */
+function isRemotesActionTarget(state: LogInkState): boolean {
+  return state.activeView === 'remotes' && state.focus === 'commits'
 }
 
 /**
@@ -660,6 +672,8 @@ export function getLogInkPaletteExecuteEvents(
       return [action({ type: 'pushView', value: 'bisect' })]
     case 'navigateSubmodules':
       return [action({ type: 'pushView', value: 'submodules' })]
+    case 'navigateRemotes':
+      return [action({ type: 'pushView', value: 'remotes' })]
     case 'markForCompare':
       // Palette context can't reach the cursored ref (filtered branch /
       // tag lists live in runtime state, not the reducer). Surface a
@@ -966,6 +980,22 @@ function submitInputPrompt(state: LogInkState): LogInkInputEvent[] {
   if (state.inputPrompt.kind === 'pr-request-changes') {
     return [
       action({ type: 'setPendingConfirmation', value: 'request-changes-pr', payload: value }),
+      action({ type: 'closeInputPrompt' }),
+    ]
+  }
+  // #0.71 — remotes view prompts. Both forward the typed value to their
+  // workflow id; the runtime parses `name url` (add) or applies the URL
+  // to the cursored remote (set-url). The prompt is the affirmative
+  // gate, so neither routes through the y-confirm path.
+  if (state.inputPrompt.kind === 'add-remote') {
+    return [
+      { type: 'runWorkflowAction', id: 'remote-add', payload: value },
+      action({ type: 'closeInputPrompt' }),
+    ]
+  }
+  if (state.inputPrompt.kind === 'set-remote-url') {
+    return [
+      { type: 'runWorkflowAction', id: 'remote-set-url', payload: value },
       action({ type: 'closeInputPrompt' }),
     ]
   }
@@ -1791,6 +1821,17 @@ export function getLogInkInputEvents(
     ]
   }
 
+  // `gn` chord: jump to the dedicated remotes view (#0.71). `n` for
+  // network/remotes; `gr` is already reflog. Always navigates — even
+  // when no remotes are configured — so the empty-state copy can point
+  // the user at `a add`.
+  if (state.pendingKey === 'g' && inputValue === 'n') {
+    return [
+      action({ type: 'pushView', value: 'remotes' }),
+      action({ type: 'setStatus', value: 'jumped to remotes' }),
+    ]
+  }
+
   // `gH` chord: apply the cursored hunk to the index (`git apply
   // --cached`). Sibling of bare `H` which targets the worktree.
   // Discoverable via the footer hint on diff views and the help
@@ -2277,6 +2318,10 @@ export function getLogInkInputEvents(
       return [action({ type: 'moveReflog', delta: -1, count: context.reflogCount })]
     }
 
+    if (isRemotesActionTarget(state) && context.remoteCount) {
+      return [action({ type: 'moveRemote', delta: -1, count: context.remoteCount })]
+    }
+
     if (isSubmodulesActionTarget(state) && context.submoduleCount) {
       return [action({ type: 'moveSubmodule', delta: -1, count: context.submoduleCount })]
     }
@@ -2395,6 +2440,10 @@ export function getLogInkInputEvents(
 
     if (isReflogActionTarget(state) && context.reflogCount) {
       return [action({ type: 'moveReflog', delta: 1, count: context.reflogCount })]
+    }
+
+    if (isRemotesActionTarget(state) && context.remoteCount) {
+      return [action({ type: 'moveRemote', delta: 1, count: context.remoteCount })]
     }
 
     if (isSubmodulesActionTarget(state) && context.submoduleCount) {
@@ -3337,6 +3386,34 @@ export function getLogInkInputEvents(
     return [{ type: 'runWorkflowAction', id: 'submodule-sync' }]
   }
 
+  // #0.71 — remote management on the remotes view. Scoped per-view so
+  // the bare keys don't collide elsewhere. `a` add and `e` set-url open
+  // an input prompt (the prompt is the affirmative gate). `x` remove and
+  // `p` prune are destructive (they drop refs), so they route through
+  // the y-confirm path via setPendingConfirmation rather than running
+  // directly. add works with zero remotes (it's how you create the
+  // first); set-url / remove / prune require a cursored row.
+  if (inputValue === 'a' && isRemotesActionTarget(state)) {
+    return [action({
+      type: 'openInputPrompt',
+      kind: 'add-remote',
+      label: 'Add remote — name url (e.g. upstream https://example.com/up.git)',
+    })]
+  }
+  if (inputValue === 'e' && isRemotesActionTarget(state) && context.remoteCount) {
+    return [action({
+      type: 'openInputPrompt',
+      kind: 'set-remote-url',
+      label: `New URL for ${context.remoteSelectedName || 'remote'}`,
+    })]
+  }
+  if (inputValue === 'x' && isRemotesActionTarget(state) && context.remoteCount) {
+    return [action({ type: 'setPendingConfirmation', value: 'remote-remove' })]
+  }
+  if (inputValue === 'p' && isRemotesActionTarget(state) && context.remoteCount) {
+    return [action({ type: 'setPendingConfirmation', value: 'remote-prune' })]
+  }
+
   // `y` / `Y` yank the contextually relevant identifier from the active
   // view to the system clipboard:
   //   history    → cursored commit hash (Y for short hash)
@@ -3387,6 +3464,12 @@ export function getLogInkInputEvents(
     // history view's Y).
     if (isSubmodulesActionTarget(state) && context.submoduleCount) {
       return [{ type: 'yankFromActiveView', short }]
+    }
+    // #0.71 — remotes view: y yanks the cursored remote's fetch URL so
+    // the user can paste it into a clone / config command. Y is a no-op
+    // (no compact alternate identifier worth a second key).
+    if (isRemotesActionTarget(state) && context.remoteCount) {
+      return [{ type: 'yankFromActiveView' }]
     }
     // #882 phase 4 — triage views: y yanks the cursored issue / PR
     // URL so the user can paste it into a chat / PR description

--- a/src/workstation/runtime/inkKeymap.ts
+++ b/src/workstation/runtime/inkKeymap.ts
@@ -39,6 +39,7 @@ export type LogInkCommandId =
   | 'navigatePullRequest'
   | 'navigatePullRequestTriage'
   | 'navigateReflog'
+  | 'navigateRemotes'
   | 'navigateStash'
   | 'navigateSubmodules'
   | 'navigateWorktrees'
@@ -359,6 +360,13 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     keys: ['gM'],
     label: 'submodules',
     description: 'Push the submodules view (#932). Lists every registered submodule with status / pinned commit / tracking branch / remote. Capital M disambiguates from the single-letter `m` (mark compare base).',
+    contexts: ['normal'],
+  },
+  {
+    id: 'navigateRemotes',
+    keys: ['gn'],
+    label: 'remotes',
+    description: 'Push the remotes view (#0.71). Lists every configured remote with its fetch / push URLs and offers add / remove / set-url / prune actions. `n` for network/remotes; gr is already reflog.',
     contexts: ['normal'],
   },
   {
@@ -809,6 +817,7 @@ const BINDING_CATEGORY_BY_ID: Partial<Record<LogInkCommandId, LogInkBindingCateg
   navigateReflog: 'navigation',
   navigateBisect: 'navigation',
   navigateSubmodules: 'navigation',
+  navigateRemotes: 'navigation',
   // ── Movement: cursor movement + search navigation within a view.
   moveUp: 'movement',
   moveDown: 'movement',
@@ -1328,6 +1337,16 @@ function computeLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogInkF
   if (options.activeView === 'submodules') {
     return {
       contextual: ['↑/↓ entries', 'i init', 'u update', 's sync', 'y yank path', 'Y yank sha', '/ filter', 'esc back'],
+      global: NORMAL_GLOBAL_HINTS,
+    }
+  }
+
+  if (options.activeView === 'remotes') {
+    return {
+      // #0.71 — remote management. add / set-url prompt for input
+      // (the prompt is the gate); remove / prune route through the
+      // y-confirm path (`*` marks the destructive ones).
+      contextual: ['↑/↓ remotes', 'a add', 'e set-url', 'x remove*', 'p prune*', 'y yank url', '/ filter', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/workstation/runtime/inkViewModel.ts
+++ b/src/workstation/runtime/inkViewModel.ts
@@ -27,7 +27,7 @@ import {
 export type LogInkFocus = 'sidebar' | 'commits' | 'detail'
 
 export type LogInkSidebarTab = 'status' | 'branches' | 'tags' | 'stashes' | 'worktrees'
-export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash' | 'worktrees' | 'pull-request' | 'pull-request-triage' | 'issues' | 'conflicts' | 'reflog' | 'bisect' | 'changelog' | 'submodules'
+export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash' | 'worktrees' | 'pull-request' | 'pull-request-triage' | 'issues' | 'conflicts' | 'reflog' | 'bisect' | 'changelog' | 'submodules' | 'remotes'
 export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk' | 'discard-draft'
 
 /**
@@ -306,6 +306,13 @@ export type LogInkState = {
    * their place.
    */
   selectedSubmoduleIndex: number
+  /**
+   * Cursor for the dedicated remotes view (#0.71). Same lifecycle as
+   * the other promoted-view indices — preserved across navigations so
+   * the user keeps their place in the list when they drill out and
+   * back.
+   */
+  selectedRemoteIndex: number
   /**
    * Cursor for the issues triage view (#882). Same lifecycle as the
    * other promoted-view indices — preserved across navigations so
@@ -807,6 +814,13 @@ export type LogInkInputPromptKind =
   | 'pr-request-changes'
   | 'create-pr'
   | 'bisect-run-command'
+  // #0.71 — remotes view mutations. `add-remote` collects a single
+  // `name url` line (space-separated, parsed in the submit handler);
+  // `set-remote-url` collects just a URL applied to the cursored
+  // remote. The prompt itself is the affirmative gate for both, so
+  // neither routes through the y-confirm path.
+  | 'add-remote'
+  | 'set-remote-url'
   // #882 phase 4 — triage-view mutations. Distinct from the
   // single-PR `pr-comment` / `pr-request-changes` kinds above so
   // the submit handler routes to the by-number workflows (the
@@ -873,6 +887,7 @@ export type LogInkAction =
   | { type: 'moveStash'; delta: number; count: number }
   | { type: 'moveReflog'; delta: number; count: number }
   | { type: 'moveSubmodule'; delta: number; count: number }
+  | { type: 'moveRemote'; delta: number; count: number }
   | { type: 'moveIssue'; delta: number; count: number }
   | { type: 'movePullRequestTriage'; delta: number; count: number }
   | { type: 'cycleIssueFilter' }
@@ -1484,6 +1499,7 @@ export function createLogInkState(
     selectedConflictFileIndex: 0,
     selectedReflogIndex: 0,
     selectedSubmoduleIndex: 0,
+    selectedRemoteIndex: 0,
     selectedIssueIndex: 0,
     selectedPullRequestTriageIndex: 0,
     selectedIssueFilter: 'open',
@@ -1823,6 +1839,12 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         selectedSubmoduleIndex: clampIndex(state.selectedSubmoduleIndex + action.delta, action.count),
+        pendingKey: undefined,
+      }
+    case 'moveRemote':
+      return {
+        ...state,
+        selectedRemoteIndex: clampIndex(state.selectedRemoteIndex + action.delta, action.count),
         pendingKey: undefined,
       }
     case 'moveIssue':

--- a/src/workstation/runtime/inkWorkflows.ts
+++ b/src/workstation/runtime/inkWorkflows.ts
@@ -610,6 +610,45 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: false,
     },
     {
+      // #0.71 — remote management. All four are scoped per-view in
+      // inkInput (active only when activeView === 'remotes') so their
+      // single-letter keys (a / e / x / p) stay free elsewhere. Empty
+      // `key` keeps them palette-discoverable. add / set-url collect
+      // input via a prompt (the prompt is the affirmative gate); remove
+      // and prune are destructive (they drop refs) so they route through
+      // the y-confirm path.
+      id: 'remote-add',
+      key: '',
+      label: 'Remote: add',
+      description: 'Add a new remote (prompts for `name url`).',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      id: 'remote-set-url',
+      key: '',
+      label: 'Remote: set URL',
+      description: 'Repoint the cursored remote at a new URL (prompts for the URL).',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
+      id: 'remote-remove',
+      key: '',
+      label: 'Remote: remove',
+      description: 'Remove the cursored remote and its tracking refs after confirmation.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
+      id: 'remote-prune',
+      key: '',
+      label: 'Remote: prune',
+      description: 'Prune stale remote-tracking refs for the cursored remote after confirmation.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
       // #784 — bisect workflow actions. All four are scoped per-view in
       // inkInput (active only when activeView === 'bisect') so the
       // single-letter keys stay free elsewhere. Empty `key` keeps them

--- a/src/workstation/runtime/mainPanel.ts
+++ b/src/workstation/runtime/mainPanel.ts
@@ -29,6 +29,7 @@ import { renderIssuesTriageSurface } from '../surfaces/issuesTriage'
 import { renderPullRequestSurface } from '../surfaces/pullRequest'
 import { renderPullRequestTriageSurface } from '../surfaces/pullRequestTriage'
 import { renderReflogSurface } from '../surfaces/reflog'
+import { renderRemotesSurface } from '../surfaces/remotes'
 import { renderStashSurface } from '../surfaces/stash'
 import { renderStatusSurface } from '../surfaces/status'
 import { renderSubmodulesSurface } from '../surfaces/submodules'
@@ -164,6 +165,10 @@ export function renderMainPanel(
 
   if (state.activeView === 'submodules') {
     return renderSubmodulesSurface(surface)
+  }
+
+  if (state.activeView === 'remotes') {
+    return renderRemotesSurface(surface)
   }
 
   if (state.activeView === 'pull-request') {

--- a/src/workstation/runtime/types.ts
+++ b/src/workstation/runtime/types.ts
@@ -17,6 +17,7 @@ import type { SimpleGit } from 'simple-git'
 import type { BisectStatus } from '../../git/bisectData'
 import type { BranchOverview } from '../../git/branchData'
 import type { LfsAttributeStatus } from '../../git/lfsAttributes'
+import type { RemoteOverview } from '../../git/remoteData'
 import type { SubmoduleOverview } from '../../git/submoduleData'
 import type { GitOperationOverview } from '../../git/operationData'
 import type { ProviderOverview } from '../../git/providerData'
@@ -80,6 +81,12 @@ export type LogInkContext = {
    */
   pullRequestDetailByNumber?: Map<number, PullRequestDetail>
   reflog?: ReflogOverview
+  /**
+   * Remote overview (#0.71). Carries every configured remote's name +
+   * fetch / push URLs parsed from `git remote -v`. Drives the dedicated
+   * Remotes view (`gn`) and its add / remove / set-url / prune actions.
+   */
+  remotes?: RemoteOverview
   stashes?: StashOverview
   /**
    * Submodule overview (#884). Carries per-submodule metadata

--- a/src/workstation/surfaces/remotes/__snapshots__/remotesRender.test.ts.snap
+++ b/src/workstation/surfaces/remotes/__snapshots__/remotesRender.test.ts.snap
@@ -1,0 +1,96 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`renderRemotesSurface structural snapshot — divergent push URL 1`] = `
+<Box
+  borderColor="cyan"
+  borderStyle="round"
+  flexDirection="column"
+  flexShrink={0}
+  paddingX={1}
+  width={120}
+>
+  <Box
+    justifyContent="space-between"
+  >
+    <Text
+      bold={true}
+    >
+      Remotes *
+    </Text>
+    <Text
+      dimColor={true}
+    >
+      1/1 remotes
+    </Text>
+  </Box>
+  <Text
+    bold={true}
+    dimColor={false}
+  >
+    &gt; origin git@github.com:gfargo/coco.git ↑ git@github.com:me/fork.git
+  </Text>
+</Box>
+`;
+
+exports[`renderRemotesSurface structural snapshot — empty 1`] = `
+<Box
+  borderColor="cyan"
+  borderStyle="round"
+  flexDirection="column"
+  flexShrink={0}
+  paddingX={1}
+  width={120}
+>
+  <Box
+    justifyContent="space-between"
+  >
+    <Text
+      bold={true}
+    >
+      Remotes *
+    </Text>
+    <Text
+      dimColor={true}
+    >
+      0/0 remotes
+    </Text>
+  </Box>
+  <Text
+    dimColor={true}
+  >
+    No remotes configured. Press a to add one.
+  </Text>
+</Box>
+`;
+
+exports[`renderRemotesSurface structural snapshot — populated 1`] = `
+<Box
+  borderColor="cyan"
+  borderStyle="round"
+  flexDirection="column"
+  flexShrink={0}
+  paddingX={1}
+  width={120}
+>
+  <Box
+    justifyContent="space-between"
+  >
+    <Text
+      bold={true}
+    >
+      Remotes *
+    </Text>
+    <Text
+      dimColor={true}
+    >
+      1/1 remotes
+    </Text>
+  </Box>
+  <Text
+    bold={true}
+    dimColor={false}
+  >
+    &gt; origin git@github.com:gfargo/coco.git
+  </Text>
+</Box>
+`;

--- a/src/workstation/surfaces/remotes/index.ts
+++ b/src/workstation/surfaces/remotes/index.ts
@@ -1,0 +1,96 @@
+/**
+ * Remotes surface — promoted view listing every configured git remote
+ * with its fetch / push URLs at a glance (#0.71 — expanded git ops).
+ * Mirrors the submodules / branches / tags surfaces: this surface owns
+ * the list view + cursor + filter only; the per-row actions (add /
+ * remove / set-url / prune) live in the input + workflow layers.
+ */
+
+import type * as ReactTypes from 'react'
+import { isLogInkContextKeyLoading } from '../../chrome/context'
+import {
+  formatLogInkLoading,
+  formatLogInkRemotesEmpty,
+} from '../../chrome/surfaceStates'
+import { cellWidth, truncateCells } from '../../chrome/text'
+import type { RemoteEntry } from '../../../git/remoteData'
+import {
+  matchesPromotedFilter,
+  renderPromotedFilterAffordance,
+} from '../../runtime/promotedFilter'
+import type { SurfaceRenderContext } from '../../runtime/types'
+import { focusBorderColor, panelTitle } from '../../runtime/utils'
+
+export function renderRemotesSurface(ctx: SurfaceRenderContext): ReactTypes.ReactElement {
+  const { h, components, state, context, contextStatus, bodyRows, width, theme } = ctx
+  const { Box, Text } = components
+  const focused = state.focus === 'commits'
+  const loading = isLogInkContextKeyLoading(contextStatus, 'remotes')
+  const all = context.remotes?.entries || []
+  const filtered = state.filter
+    ? all.filter((entry) =>
+      matchesPromotedFilter([entry.name, entry.fetchUrl, entry.pushUrl], state.filter)
+    )
+    : all
+  const selected = Math.max(0, Math.min(state.selectedRemoteIndex, Math.max(0, filtered.length - 1)))
+  const listRows = Math.max(4, bodyRows - 4)
+  const startIndex = Math.max(0, selected - Math.floor(listRows / 2))
+  const visible = filtered.slice(startIndex, startIndex + listRows)
+  const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
+  const headerRight = loading
+    ? 'loading remotes'
+    : `${filtered.length}/${all.length} remotes${filterLabel}`
+  const emptyLabel = formatLogInkRemotesEmpty({ filter: state.filter })
+  const loadingLabel = formatLogInkLoading({ resource: 'remotes' })
+
+  // Per-window name column so short remote names ('origin') don't leave
+  // a wide gutter and long ones don't shove the URL off-screen. Cap
+  // matches the other promoted surfaces for visual consistency.
+  const nameColWidth = visible.length === 0
+    ? 12
+    : Math.min(20, Math.max(6, ...visible.map((entry) => cellWidth(entry.name))))
+
+  const lines: ReactTypes.ReactNode[] = loading
+    ? [h(Text, { key: 'remotes-loading', dimColor: true }, loadingLabel)]
+    : filtered.length === 0
+      ? [h(Text, { key: 'remotes-empty', dimColor: true }, emptyLabel)]
+      : visible.map((entry, offset) => {
+        const index = startIndex + offset
+        const isSelected = index === selected
+        const cursor = isSelected ? '>' : ' '
+        const namePadded = truncateCells(entry.name, nameColWidth).padEnd(nameColWidth)
+        // Show the fetch URL inline; surface a distinct push URL with a
+        // `↑` marker only when it diverges (the common case is a single
+        // shared URL, where a second column would just be noise).
+        const pushDiffers = entry.pushUrl && entry.pushUrl !== entry.fetchUrl
+        const urlText = pushDiffers
+          ? `${entry.fetchUrl} ↑ ${entry.pushUrl}`
+          : entry.fetchUrl || '(no url)'
+        const lineText = truncateCells(
+          `${cursor} ${namePadded} ${urlText}`,
+          Math.max(20, width - 4),
+        )
+        return h(Text, {
+          key: `remote-${index}`,
+          bold: isSelected,
+          dimColor: !isSelected,
+        }, lineText)
+      })
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    flexShrink: 0,
+    paddingX: 1,
+    width,
+  },
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle('Remotes', focused)),
+    h(Text, { dimColor: true }, headerRight),
+  ),
+  ...renderPromotedFilterAffordance(h, Text, state, theme),
+  ...lines)
+}
+
+export type { RemoteEntry }

--- a/src/workstation/surfaces/remotes/remotesRender.test.ts
+++ b/src/workstation/surfaces/remotes/remotesRender.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Structural tests for `renderRemotesSurface`. Stubs `Text` / `Box` per the
+ * `surfaces/submodules/submodulesRender.test.ts` pattern.
+ */
+import { createElement, type ReactElement } from 'react'
+import { createLogInkState, type LogInkState } from '../../../workstation/runtime/inkViewModel'
+import { createLogInkTheme } from '../../chrome/theme'
+import {
+  createLogInkContextStatus,
+  updateLogInkContextStatus,
+} from '../../chrome/context'
+import type { RemoteEntry, RemoteOverview } from '../../../git/remoteData'
+import type { LogInkContext, LogInkComponents } from '../../runtime/types'
+import { renderRemotesSurface } from './index'
+
+type StubProps = Record<string, unknown>
+const Text = ((props: StubProps) =>
+  createElement('text', props, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+const Box = ((props: StubProps) =>
+  createElement('box', props, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+
+const components: LogInkComponents = { Box, Text }
+
+function makeState(overrides: Partial<LogInkState> = {}): LogInkState {
+  return { ...createLogInkState([]), ...overrides }
+}
+
+function makeEntry(overrides: Partial<RemoteEntry> = {}): RemoteEntry {
+  return {
+    name: 'origin',
+    fetchUrl: 'git@github.com:gfargo/coco.git',
+    pushUrl: 'git@github.com:gfargo/coco.git',
+    ...overrides,
+  }
+}
+
+function render(
+  state: LogInkState,
+  options: { remotes?: RemoteOverview; loading?: boolean } = {}
+): ReactElement {
+  const theme = createLogInkTheme({})
+  const context: LogInkContext = options.remotes ? { remotes: options.remotes } : {}
+  const contextStatus = options.loading
+    ? updateLogInkContextStatus(createLogInkContextStatus('idle'), 'remotes', 'loading')
+    : createLogInkContextStatus('ready')
+  return renderRemotesSurface({
+    h: createElement,
+    components,
+    state,
+    context,
+    contextStatus,
+    bodyRows: 30,
+    width: 120,
+    theme,
+  })
+}
+
+describe('renderRemotesSurface', () => {
+  it('renders an empty state when no remotes are configured', () => {
+    const tree = render(makeState(), { remotes: { hasRemotes: false, entries: [] } })
+    expect(tree).toBeDefined()
+    expect(tree.type).toBe(Box)
+  })
+
+  it('renders a loading placeholder while remotes hydrate', () => {
+    expect(render(makeState(), { loading: true })).toBeDefined()
+  })
+
+  it('renders rows for populated remotes', () => {
+    const tree = render(makeState(), {
+      remotes: {
+        hasRemotes: true,
+        entries: [
+          makeEntry(),
+          makeEntry({ name: 'upstream', fetchUrl: 'https://example.com/up.git', pushUrl: 'https://example.com/up.git' }),
+        ],
+      },
+    })
+    expect(tree).toBeDefined()
+  })
+
+  it('reflects focus state via border color', () => {
+    const populated: RemoteOverview = { hasRemotes: true, entries: [makeEntry()] }
+    const focused = render(makeState({ focus: 'commits' }), { remotes: populated })
+    const blurred = render(makeState({ focus: 'sidebar' }), { remotes: populated })
+    expect((focused.props as StubProps).borderColor).not.toBe(
+      (blurred.props as StubProps).borderColor
+    )
+  })
+
+  it('structural snapshot — empty', () => {
+    expect(
+      render(makeState(), { remotes: { hasRemotes: false, entries: [] } })
+    ).toMatchSnapshot()
+  })
+
+  it('structural snapshot — populated', () => {
+    expect(
+      render(makeState(), { remotes: { hasRemotes: true, entries: [makeEntry()] } })
+    ).toMatchSnapshot()
+  })
+
+  it('structural snapshot — divergent push URL', () => {
+    expect(
+      render(makeState(), {
+        remotes: {
+          hasRemotes: true,
+          entries: [makeEntry({ pushUrl: 'git@github.com:me/fork.git' })],
+        },
+      })
+    ).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
**PR 2 of the 0.71 "expanded git ops" release.** Adds a `remotes` workstation surface, opened with the `gn` chord (n for network; `gr` is reflog). Lists every configured remote with its fetch / push URLs, built on the submodules surface template.

## Per-row actions (scoped to the remotes view)
| Key | Action | Command |
|---|---|---|
| `a` | add | `git remote add <name> <url>` (prompt: `name url`) |
| `e` | set-url | `git remote set-url <name> <url>` (prompt: url, cursored remote) |
| `x` | remove * | `git remote remove <name>` |
| `p` | prune * | `git remote prune <name>` |
| `y` | yank url | copies the cursored remote's URL |

`*` **remove / prune are destructive** — `kind: destructive` + `requiresConfirmation`, routed through the y/n gate. `add` / `set-url` are prompt-as-confirmation (typing is the affirmative).

## Safety
Name + URL inputs are validated with `rejectFlagLike` (reuses `forgeArgGuards`), so a leading-`-` value can't be misparsed as a git flag. The `gn` chord and per-row keys are collision-checked (`inkKeymap.collisions.test.ts`).

## Tests
`remoteData` + `remoteActions` (argv + ok/error + guard rejection), `remotesRender` snapshots (empty/populated/focus), input-dispatch coverage. Full suite green (lint + 3354 jest + build + cli + pack).

Follows PR 1 (submodule actions, #1212). Next: PR 3 (blame / file-history), then PR 4 (rebase-onto).