### PR TITLE
feat(workstation): blame view (on-demand git blame drill-down)

### DIFF
--- a/src/git/blameData.test.ts
+++ b/src/git/blameData.test.ts
@@ -1,0 +1,122 @@
+import { getBlame, parseBlamePorcelain } from './blameData'
+
+// A minimal `git blame --porcelain` fixture: two commits, three lines.
+// The second line reuses the first commit (so it carries only the sha
+// header + content, no metadata) to exercise the per-commit metadata
+// cache. The third line introduces a new commit with its own metadata.
+const PORCELAIN_FIXTURE = [
+  'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678 1 1 2',
+  'author Ada Lovelace',
+  'author-mail <ada@example.com>',
+  'author-time 1700000000',
+  'author-tz +0000',
+  'committer Ada Lovelace',
+  'committer-time 1700000000',
+  'summary first commit',
+  'filename src/example.ts',
+  '\tconst answer = 42',
+  'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678 2 2',
+  '\tconst doubled = answer * 2',
+  '9988776655443322110099887766554433221100 3 3 1',
+  'author Grace Hopper',
+  'author-mail <grace@example.com>',
+  'author-time 1710000000',
+  'author-tz +0000',
+  'committer Grace Hopper',
+  'committer-time 1710000000',
+  'summary second commit',
+  'filename src/example.ts',
+  '\treturn doubled',
+  '',
+].join('\n')
+
+describe('parseBlamePorcelain', () => {
+  it('parses each line with hash, author, time, line number, and content', () => {
+    const lines = parseBlamePorcelain(PORCELAIN_FIXTURE)
+    expect(lines).toEqual([
+      {
+        hash: 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678',
+        shortHash: 'a1b2c3d4',
+        author: 'Ada Lovelace',
+        authorTime: 1700000000,
+        lineNumber: 1,
+        content: 'const answer = 42',
+      },
+      {
+        hash: 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678',
+        shortHash: 'a1b2c3d4',
+        author: 'Ada Lovelace',
+        authorTime: 1700000000,
+        lineNumber: 2,
+        content: 'const doubled = answer * 2',
+      },
+      {
+        hash: '9988776655443322110099887766554433221100',
+        shortHash: '99887766',
+        author: 'Grace Hopper',
+        authorTime: 1710000000,
+        lineNumber: 3,
+        content: 'return doubled',
+      },
+    ])
+  })
+
+  it('reuses cached commit metadata for repeat shas', () => {
+    const lines = parseBlamePorcelain(PORCELAIN_FIXTURE)
+    // Line 2 reuses commit a1b2 without re-emitting author metadata.
+    expect(lines[1].author).toBe('Ada Lovelace')
+    expect(lines[1].authorTime).toBe(1700000000)
+  })
+
+  it('labels not-yet-committed lines with a friendly short hash', () => {
+    const fixture = [
+      '0000000000000000000000000000000000000000 1 1 1',
+      'author Not Committed Yet',
+      'author-time 0',
+      'summary Version of file edited but not committed yet',
+      'filename src/wip.ts',
+      '\tconst wip = true',
+      '',
+    ].join('\n')
+    const lines = parseBlamePorcelain(fixture)
+    expect(lines[0].shortHash).toBe('staged  ')
+    expect(lines[0].author).toBe('Not Committed Yet')
+  })
+
+  it('preserves leading whitespace in line content', () => {
+    const fixture = [
+      'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678 1 1 1',
+      'author Ada',
+      'author-time 1700000000',
+      'filename a.ts',
+      '\t  indented()',
+      '',
+    ].join('\n')
+    const lines = parseBlamePorcelain(fixture)
+    expect(lines[0].content).toBe('  indented()')
+  })
+
+  it('returns an empty array for empty output', () => {
+    expect(parseBlamePorcelain('')).toEqual([])
+  })
+})
+
+describe('getBlame', () => {
+  it('parses `git blame --porcelain` output for the path', async () => {
+    const git = { raw: jest.fn().mockResolvedValue(PORCELAIN_FIXTURE) }
+    const result = await getBlame(git as never, 'src/example.ts')
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.path).toBe('src/example.ts')
+      expect(result.lines).toHaveLength(3)
+      expect(result.lines[0].content).toBe('const answer = 42')
+    }
+    expect(git.raw).toHaveBeenCalledWith(['blame', '--porcelain', '--', 'src/example.ts'])
+  })
+
+  it('returns a best-effort failure result when git blame throws', async () => {
+    const git = { raw: jest.fn().mockRejectedValue(new Error('binary file')) }
+    const result = await getBlame(git as never, 'logo.png')
+    expect(result).toEqual({ ok: false, path: 'logo.png', message: 'binary file' })
+  })
+})

--- a/src/git/blameData.ts
+++ b/src/git/blameData.ts
@@ -1,0 +1,144 @@
+import { SimpleGit } from 'simple-git'
+
+/**
+ * Blame loader (#0.71 — expanded git ops).
+ *
+ * Backs the on-demand blame drill-down: given a repo-relative path,
+ * runs `git blame --porcelain` and parses it into one `BlameLine` per
+ * source line so the blame surface can render a dimmed
+ * `<shorthash> <author>` gutter alongside the line content.
+ *
+ * Architecturally distinct from the boot-loaded overview slices
+ * (`remoteData`, `submoduleData`, …): blame is per-file and expensive,
+ * so it's never loaded at boot. The runtime hydrates it lazily into a
+ * `blameByPath` cache (keyed by path) when the blame view opens,
+ * mirroring the per-item inspector hydration the PR / issue triage
+ * views use.
+ *
+ * Best-effort: any failure (binary file, path outside the repo, not a
+ * git repo) resolves to `{ ok: false, message }` rather than throwing,
+ * so the surface can show a tailored placeholder instead of crashing
+ * the runtime.
+ */
+
+export type BlameLine = {
+  /** Full 40-char commit sha the line is attributed to. */
+  hash: string
+  /** Abbreviated sha (first 8 chars) for the gutter. */
+  shortHash: string
+  /** Commit author name. */
+  author: string
+  /** Author time as a Unix epoch (seconds). 0 when git omits it. */
+  authorTime: number
+  /** 1-based final line number in the blamed file. */
+  lineNumber: number
+  /** The source line's text content (without the trailing newline). */
+  content: string
+}
+
+export type BlameResult =
+  | { ok: true; path: string; lines: BlameLine[] }
+  | { ok: false; path: string; message: string }
+
+/**
+ * Uncommitted / not-yet-committed lines blame as the all-zero sha.
+ * Git emits the literal author "Not Committed Yet" for them; we keep
+ * that author but render a friendlier short hash so the gutter doesn't
+ * show a wall of zeros.
+ */
+const UNCOMMITTED_SHA = '0000000000000000000000000000000000000000'
+
+/**
+ * Parse the output of `git blame --porcelain`.
+ *
+ * The porcelain format emits, per blamed line:
+ *
+ *   `<40-hex-sha> <orig-line> <final-line> [<lines-in-group>]`
+ *   (commit metadata lines — `author …`, `author-time …`, etc., but
+ *    ONLY the first time a given commit is seen)
+ *   `\t<line content>`
+ *
+ * Git caches commit metadata: the second and later lines attributed to
+ * the same commit carry only the sha header + the TAB content line, so
+ * we keep a per-commit metadata map and reuse it for repeat shas.
+ */
+export function parseBlamePorcelain(output: string): BlameLine[] {
+  const lines: BlameLine[] = []
+  // Commit-level metadata cache: git only emits author / author-time on
+  // the first line of each commit, so later lines look it up by sha.
+  const metaByCommit = new Map<string, { author: string; authorTime: number }>()
+
+  const rawLines = output.split('\n')
+  let index = 0
+
+  while (index < rawLines.length) {
+    const header = rawLines[index]
+    // Header is `<sha> <origLine> <finalLine> [<groupLines>]`. Anything
+    // else at this position (trailing blank line) ends the parse.
+    const headerMatch = header.match(/^([0-9a-f]{40})\s+\d+\s+(\d+)(?:\s+\d+)?$/)
+    if (!headerMatch) {
+      index += 1
+      continue
+    }
+    const [, hash, finalLineStr] = headerMatch
+    const lineNumber = Number.parseInt(finalLineStr, 10)
+    index += 1
+
+    let author = metaByCommit.get(hash)?.author
+    let authorTime = metaByCommit.get(hash)?.authorTime
+
+    // Consume metadata lines until the TAB-prefixed content line. On a
+    // repeat commit there are none, so the first iteration already sees
+    // the content line and the loop body's break fires immediately.
+    while (index < rawLines.length) {
+      const metaLine = rawLines[index]
+      if (metaLine.startsWith('\t')) {
+        // The content line. Strip the single leading TAB the porcelain
+        // format prepends; preserve everything after it verbatim.
+        const content = metaLine.slice(1)
+        const resolvedAuthor = author ?? 'Unknown'
+        const resolvedTime = authorTime ?? 0
+        metaByCommit.set(hash, { author: resolvedAuthor, authorTime: resolvedTime })
+        lines.push({
+          hash,
+          shortHash: hash === UNCOMMITTED_SHA ? 'staged  ' : hash.slice(0, 8),
+          author: resolvedAuthor,
+          authorTime: resolvedTime,
+          lineNumber,
+          content,
+        })
+        index += 1
+        break
+      }
+      if (metaLine.startsWith('author ') && !metaLine.startsWith('author-')) {
+        author = metaLine.slice('author '.length)
+      } else if (metaLine.startsWith('author-time ')) {
+        const parsed = Number.parseInt(metaLine.slice('author-time '.length), 10)
+        authorTime = Number.isFinite(parsed) ? parsed : 0
+      }
+      index += 1
+    }
+  }
+
+  // Keep blame lines in file order so windowed rendering around the
+  // cursor maps directly to source lines.
+  lines.sort((a, b) => a.lineNumber - b.lineNumber)
+  return lines
+}
+
+/**
+ * Load blame for a single repo-relative path via
+ * `git blame --porcelain -- <path>`. Best-effort: failures resolve to a
+ * `{ ok: false }` result the surface renders as a placeholder.
+ */
+export async function getBlame(git: SimpleGit, path: string): Promise<BlameResult> {
+  let output = ''
+  try {
+    output = await git.raw(['blame', '--porcelain', '--', path])
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'git blame failed'
+    return { ok: false, path, message }
+  }
+  const lines = parseBlamePorcelain(output)
+  return { ok: true, path, lines }
+}

--- a/src/workstation/chrome/surfaceStates.test.ts
+++ b/src/workstation/chrome/surfaceStates.test.ts
@@ -1,4 +1,5 @@
 import {
+  formatLogInkBlameEmpty,
   formatLogInkBranchesEmpty,
   formatLogInkComposeEmpty,
   formatLogInkHistoryEmpty,
@@ -61,6 +62,21 @@ describe('log Ink surface states', () => {
       const message = formatLogInkStashEmpty({ filter: 'wip' })
       expect(message).toContain("'wip'")
       expect(message).toContain('ctrl+u')
+    })
+  })
+
+  describe('formatLogInkBlameEmpty', () => {
+    it('leads with the git error when blame failed', () => {
+      const message = formatLogInkBlameEmpty({ path: 'logo.png', failureMessage: 'binary file' })
+      expect(message).toContain('logo.png')
+      expect(message).toContain('binary file')
+      expect(message).toContain('esc')
+    })
+
+    it('falls back to a neutral hint for a genuinely empty file', () => {
+      const message = formatLogInkBlameEmpty({ path: 'src/empty.ts' })
+      expect(message).toContain('src/empty.ts')
+      expect(message).toContain('esc')
     })
   })
 

--- a/src/workstation/chrome/surfaceStates.ts
+++ b/src/workstation/chrome/surfaceStates.ts
@@ -125,6 +125,26 @@ export function formatLogInkRemotesEmpty({ filter }: LogInkRemotesEmptyArgs): st
   return 'No remotes configured. Press a to add one.'
 }
 
+export type LogInkBlameEmptyArgs = {
+  /** Repo-relative path being blamed, for a path-aware message. */
+  path?: string
+  /** Best-effort failure message when `git blame` couldn't run. */
+  failureMessage?: string
+}
+
+/**
+ * Empty / failure copy for the on-demand blame view (#0.71). A failed
+ * blame (binary file, path outside the repo) is the common "non-empty
+ * but unrenderable" case, so the message leads with the git error when
+ * present; a genuinely empty file falls through to the neutral hint.
+ */
+export function formatLogInkBlameEmpty({ path, failureMessage }: LogInkBlameEmptyArgs): string {
+  if (failureMessage) {
+    return `Could not blame ${path ?? 'this file'}: ${failureMessage}. Press esc to go back.`
+  }
+  return `No blame data for ${path ?? 'this file'} (empty or untracked). Press esc to go back.`
+}
+
 export type LogInkIssuesEmptyArgs = {
   filter: string
 }

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -61,6 +61,7 @@ import { getBranchOverview } from '../../git/branchData'
 import { hashesMatchAny } from '../../git/hashes'
 import { getLfsAttributeStatus } from '../../git/lfsAttributes'
 import { getSubmoduleOverview } from '../../git/submoduleData'
+import { getBlame } from '../../git/blameData'
 import { getRemoteOverview } from '../../git/remoteData'
 import { createManualCommit, formatCommitComposeMessage } from '../../commands/log/commitCompose'
 import {
@@ -1128,6 +1129,12 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       (current) => ({
         ...current,
         worktree,
+        // Drop the blame cache (#0.71): staging / unstaging / reverting
+        // changes the working-tree contents, so any cached attribution
+        // (especially the "staged" not-yet-committed lines) is now
+        // potentially stale. Re-opening blame re-hydrates from the
+        // fresh tree.
+        blameByPath: undefined,
       }),
       issuedAtDepth,
     )
@@ -1299,6 +1306,11 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // crash the workstation because git couldn't resolve a sha.
   const [bisectCandidateDetail, setBisectCandidateDetail] = React.useState<GitCommitDetail | undefined>(undefined)
   const [bisectCandidateLoading, setBisectCandidateLoading] = React.useState(false)
+  // On-demand blame hydration flag (#0.71). True while the debounced
+  // `getBlame` for the active `state.blamePath` is in flight; the blame
+  // surface shows a loading placeholder until the parse lands in the
+  // `blameByPath` cache.
+  const [blameLoading, setBlameLoading] = React.useState(false)
   const bisectCandidateSha = state.activeView === 'bisect' && context.bisect?.active
     ? context.bisect.currentSha
     : ''
@@ -1690,6 +1702,58 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     state.selectedPullRequestTriageIndex,
     filteredPullRequestTriageList,
     context.pullRequestDetailByNumber,
+    setContext,
+  ])
+
+  // On-demand blame hydration (#0.71). Mirrors the per-item inspector
+  // hydration above, but keyed by PATH rather than item number and
+  // entered from the dedicated blame view rather than a triage list.
+  // When the blame view is active for a path with no cached entry,
+  // debounce-fetch `git blame --porcelain`, parse once, and cache the
+  // result in `context.blameByPath`. Re-opening a previously-blamed
+  // path renders instantly from the cache. The debounce keeps a rapid
+  // sequence of `b` presses (open, esc, open another) from firing a
+  // blame on every transient path.
+  const BLAME_HYDRATION_DELAY_MS = 150
+
+  React.useEffect(() => {
+    if (state.activeView !== 'blame') return
+    const path = state.blamePath
+    if (!path) return
+    if (context.blameByPath?.has(path)) {
+      // Cache hit — make sure the loading flag is cleared (it may be set
+      // from a previous cold path) so the surface renders the cached
+      // blame immediately.
+      setBlameLoading(false)
+      return
+    }
+
+    const issuedAtDepth = runtimes.length - 1
+    let active = true
+    setBlameLoading(true)
+    const timer = setTimeout(async () => {
+      const result = await getBlame(git, path)
+      if (!active) return
+      setContext(
+        (current) => ({
+          ...current,
+          blameByPath: new Map(current.blameByPath || []).set(result.path, result),
+        }),
+        issuedAtDepth,
+      )
+      setBlameLoading(false)
+    }, BLAME_HYDRATION_DELAY_MS)
+
+    return () => {
+      active = false
+      clearTimeout(timer)
+    }
+  }, [
+    runtimes.length,
+    git,
+    state.activeView,
+    state.blamePath,
+    context.blameByPath,
     setContext,
   ])
 
@@ -4924,6 +4988,13 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       submoduleSelectedPath,
       remoteCount: remoteVisibleCount,
       remoteSelectedName,
+      // Drive j/k on the blame view off the cached line count for the
+      // active path (#0.71); 0 while hydrating or on a failed blame, so
+      // the nav handlers no-op until lines exist.
+      blameLineCount: (() => {
+        const blame = state.blamePath ? context.blameByPath?.get(state.blamePath) : undefined
+        return blame && blame.ok ? blame.lines.length : 0
+      })(),
       issueCount: issueVisibleCount,
       issueSelectedUrl,
       pullRequestTriageCount: pullRequestTriageVisibleCount,
@@ -5207,6 +5278,8 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       compareDiffLoading,
       bisectCandidateDetail,
       bisectCandidateLoading,
+      blame: state.blamePath ? context.blameByPath?.get(state.blamePath) : undefined,
+      blameLoading,
       hasMoreCommits,
       loadingMoreCommits,
       spinnerFrame,

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -120,6 +120,13 @@ export type LogInkInputContext = {
   remoteCount?: number
   /** Name of the cursored remote (#0.71). Used as the yank target on the remotes view. */
   remoteSelectedName?: string
+  /**
+   * Number of blamed source lines for the active path (#0.71). Drives
+   * j/k navigation on the on-demand blame view. Undefined / 0 while the
+   * blame is still hydrating or the file is empty — the nav handlers
+   * no-op in that case.
+   */
+  blameLineCount?: number
   /** Number of issues in the triage list view (#882 phase 3). Drives j/k navigation. */
   issueCount?: number
   /** URL of the cursored issue (#882 phase 3). Used by `O` to open in the browser. */
@@ -2322,6 +2329,10 @@ export function getLogInkInputEvents(
       return [action({ type: 'moveRemote', delta: -1, count: context.remoteCount })]
     }
 
+    if (state.activeView === 'blame' && context.blameLineCount) {
+      return [action({ type: 'moveBlame', delta: -1, count: context.blameLineCount })]
+    }
+
     if (isSubmodulesActionTarget(state) && context.submoduleCount) {
       return [action({ type: 'moveSubmodule', delta: -1, count: context.submoduleCount })]
     }
@@ -2444,6 +2455,10 @@ export function getLogInkInputEvents(
 
     if (isRemotesActionTarget(state) && context.remoteCount) {
       return [action({ type: 'moveRemote', delta: 1, count: context.remoteCount })]
+    }
+
+    if (state.activeView === 'blame' && context.blameLineCount) {
+      return [action({ type: 'moveBlame', delta: 1, count: context.blameLineCount })]
     }
 
     if (isSubmodulesActionTarget(state) && context.submoduleCount) {
@@ -3144,6 +3159,27 @@ export function getLogInkInputEvents(
   // revert / stage events).
   if (inputValue === 'i' && state.activeView === 'status' && context.worktreeFileCount && context.worktreeSelectedPath) {
     return [{ type: 'openGitignorePicker' }]
+  }
+  // `b` opens the on-demand blame drill-down for the cursored worktree
+  // file (#0.71). Entered from the status file list; the runtime
+  // resolves blame lazily into its `blameByPath` cache keyed by this
+  // path. Also available from the worktree diff view, where the focused
+  // file path is known.
+  if (
+    inputValue === 'b' &&
+    state.activeView === 'status' &&
+    context.worktreeFileCount &&
+    context.worktreeSelectedPath
+  ) {
+    return [action({ type: 'navigateOpenBlameForPath', path: context.worktreeSelectedPath })]
+  }
+  if (
+    inputValue === 'b' &&
+    state.activeView === 'diff' &&
+    state.diffSource === 'worktree' &&
+    context.worktreeSelectedPath
+  ) {
+    return [action({ type: 'navigateOpenBlameForPath', path: context.worktreeSelectedPath })]
   }
   if (inputValue === 'o' && state.activeView === 'diff' && state.diffSource === 'worktree' && context.worktreeSelectedPath) {
     return [{ type: 'openFileInEditor', path: context.worktreeSelectedPath }]

--- a/src/workstation/runtime/inkKeymap.ts
+++ b/src/workstation/runtime/inkKeymap.ts
@@ -38,6 +38,7 @@ export type LogInkCommandId =
   | 'navigateIssues'
   | 'navigatePullRequest'
   | 'navigatePullRequestTriage'
+  | 'navigateBlame'
   | 'navigateReflog'
   | 'navigateRemotes'
   | 'navigateStash'
@@ -368,6 +369,13 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     label: 'remotes',
     description: 'Push the remotes view (#0.71). Lists every configured remote with its fetch / push URLs and offers add / remove / set-url / prune actions. `n` for network/remotes; gr is already reflog.',
     contexts: ['normal'],
+  },
+  {
+    id: 'navigateBlame',
+    keys: ['b'],
+    label: 'blame',
+    description: 'Open the on-demand `git blame` drill-down for the cursored file (#0.71). Available on a file row in the status view (and on the worktree diff). Blame is loaded lazily and cached per path; j/k scrolls, esc returns. `b` is free in these contexts — elsewhere it pages / marks bad.',
+    contexts: ['status', 'diff'],
   },
   {
     id: 'markForCompare',
@@ -1347,6 +1355,15 @@ function computeLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogInkF
       // (the prompt is the gate); remove / prune route through the
       // y-confirm path (`*` marks the destructive ones).
       contextual: ['↑/↓ remotes', 'a add', 'e set-url', 'x remove*', 'p prune*', 'y yank url', '/ filter', 'esc back'],
+      global: NORMAL_GLOBAL_HINTS,
+    }
+  }
+
+  if (options.activeView === 'blame') {
+    return {
+      // #0.71 — on-demand blame drill-down. Read-only: j/k scroll the
+      // windowed line list, esc pops back to the file list.
+      contextual: ['↑/↓ lines', 'gg/G top/bottom', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/workstation/runtime/inkViewModel.ts
+++ b/src/workstation/runtime/inkViewModel.ts
@@ -27,7 +27,7 @@ import {
 export type LogInkFocus = 'sidebar' | 'commits' | 'detail'
 
 export type LogInkSidebarTab = 'status' | 'branches' | 'tags' | 'stashes' | 'worktrees'
-export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash' | 'worktrees' | 'pull-request' | 'pull-request-triage' | 'issues' | 'conflicts' | 'reflog' | 'bisect' | 'changelog' | 'submodules' | 'remotes'
+export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash' | 'worktrees' | 'pull-request' | 'pull-request-triage' | 'issues' | 'conflicts' | 'reflog' | 'bisect' | 'changelog' | 'submodules' | 'remotes' | 'blame'
 export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk' | 'discard-draft'
 
 /**
@@ -313,6 +313,22 @@ export type LogInkState = {
    * back.
    */
   selectedRemoteIndex: number
+  /**
+   * Cursor for the on-demand blame view (#0.71). Indexes into the
+   * blamed file's `BlameLine[]`; windowed-rendered around this index so
+   * large files stay responsive. Reset to 0 each time a fresh path is
+   * opened (`navigateOpenBlameForPath`) so blame always opens at the
+   * top of the file.
+   */
+  selectedBlameIndex: number
+  /**
+   * Repo-relative path the blame view is currently showing (#0.71).
+   * Unlike the boot-loaded overview slices, blame is keyed by path and
+   * hydrated on demand: the runtime reads this path, looks it up in the
+   * `blameByPath` cache, and fetches it (debounced) on a cache miss.
+   * Undefined when the blame view has never been opened.
+   */
+  blamePath?: string
   /**
    * Cursor for the issues triage view (#882). Same lifecycle as the
    * other promoted-view indices — preserved across navigations so
@@ -888,6 +904,7 @@ export type LogInkAction =
   | { type: 'moveReflog'; delta: number; count: number }
   | { type: 'moveSubmodule'; delta: number; count: number }
   | { type: 'moveRemote'; delta: number; count: number }
+  | { type: 'moveBlame'; delta: number; count: number }
   | { type: 'moveIssue'; delta: number; count: number }
   | { type: 'movePullRequestTriage'; delta: number; count: number }
   | { type: 'cycleIssueFilter' }
@@ -912,6 +929,7 @@ export type LogInkAction =
   | { type: 'returnFromCommit'; stillDirty: boolean }
   | { type: 'navigateOpenDiffForCommit'; sha: string; commitIndex: number; fileIndex?: number }
   | { type: 'navigateOpenDiffForWorktreeFile'; fileIndex: number }
+  | { type: 'navigateOpenBlameForPath'; path: string }
   | { type: 'navigateOpenDiffForStash'; ref: string; stashIndex?: number }
   | { type: 'navigateOpenDiffForCompare'; base: LogInkCompareRef; head: LogInkCompareRef }
   | { type: 'setCompareBase'; value: LogInkCompareRef }
@@ -1500,6 +1518,7 @@ export function createLogInkState(
     selectedReflogIndex: 0,
     selectedSubmoduleIndex: 0,
     selectedRemoteIndex: 0,
+    selectedBlameIndex: 0,
     selectedIssueIndex: 0,
     selectedPullRequestTriageIndex: 0,
     selectedIssueFilter: 'open',
@@ -1847,6 +1866,12 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         selectedRemoteIndex: clampIndex(state.selectedRemoteIndex + action.delta, action.count),
         pendingKey: undefined,
       }
+    case 'moveBlame':
+      return {
+        ...state,
+        selectedBlameIndex: clampIndex(state.selectedBlameIndex + action.delta, action.count),
+        pendingKey: undefined,
+      }
     case 'moveIssue':
       return {
         ...state,
@@ -2124,6 +2149,19 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         selectedWorktreeFileIndex: Math.max(0, action.fileIndex),
         worktreeDiffOffset: 0,
         diffSource: 'worktree',
+      }
+    }
+    case 'navigateOpenBlameForPath': {
+      // Open the on-demand blame drill-down for a path. Reset the blame
+      // cursor to the top whenever the path changes so blame never opens
+      // mid-file; preserve it when re-opening the same path (the cached
+      // hydration is still valid and the user's place is worth keeping).
+      const next = withPushedView(state, 'blame')
+      const samePath = state.blamePath === action.path
+      return {
+        ...next,
+        blamePath: action.path,
+        selectedBlameIndex: samePath ? state.selectedBlameIndex : 0,
       }
     }
     case 'navigateOpenDiffForStash': {

--- a/src/workstation/runtime/mainPanel.ts
+++ b/src/workstation/runtime/mainPanel.ts
@@ -18,6 +18,7 @@ import type { WorktreeHunkOverview } from '../../git/statusHunks'
 import type { WorktreeFileDiff } from '../../git/worktreeDiffData'
 import type { SyntaxSpan } from '../../lib/syntax/highlightEngine'
 import { renderBisectSurface } from '../surfaces/bisect'
+import { renderBlameSurface, type BlameSurfaceData } from '../surfaces/blame'
 import { renderBranchesSurface } from '../surfaces/branches'
 import { renderChangelogSurface } from '../surfaces/changelog'
 import { renderComposeSurface } from '../surfaces/compose'
@@ -59,6 +60,10 @@ export type MainPanelExtras = {
   compareDiffLoading: boolean
   bisectCandidateDetail: GitCommitDetail | undefined
   bisectCandidateLoading: boolean
+  /** Cached blame for `state.blamePath` (#0.71). Undefined on a cache miss. */
+  blame: BlameSurfaceData['blame']
+  /** True while the on-demand blame hydration is in flight (#0.71). */
+  blameLoading: boolean
   hasMoreCommits: boolean
   loadingMoreCommits: boolean
   spinnerFrame: number
@@ -87,6 +92,8 @@ export function renderMainPanel(
     compareDiffLoading,
     bisectCandidateDetail,
     bisectCandidateLoading,
+    blame,
+    blameLoading,
     hasMoreCommits,
     loadingMoreCommits,
     spinnerFrame,
@@ -169,6 +176,10 @@ export function renderMainPanel(
 
   if (state.activeView === 'remotes') {
     return renderRemotesSurface(surface)
+  }
+
+  if (state.activeView === 'blame') {
+    return renderBlameSurface(surface, { blame, loading: blameLoading })
   }
 
   if (state.activeView === 'pull-request') {

--- a/src/workstation/runtime/types.ts
+++ b/src/workstation/runtime/types.ts
@@ -15,6 +15,7 @@
 import type * as ReactTypes from 'react'
 import type { SimpleGit } from 'simple-git'
 import type { BisectStatus } from '../../git/bisectData'
+import type { BlameResult } from '../../git/blameData'
 import type { BranchOverview } from '../../git/branchData'
 import type { LfsAttributeStatus } from '../../git/lfsAttributes'
 import type { RemoteOverview } from '../../git/remoteData'
@@ -41,6 +42,16 @@ import type { LogInkTheme, LogInkThemeConfig } from '../chrome/theme'
 
 export type LogInkContext = {
   bisect?: BisectStatus
+  /**
+   * Per-path blame cache keyed by repo-relative path (#0.71). Unlike the
+   * boot-loaded overview slices, blame is expensive and per-file, so
+   * it's hydrated on demand: the blame view's hydration effect parses
+   * `git blame --porcelain` once per path and caches the result here.
+   * Re-opening a previously blamed path renders instantly from the
+   * cache; the entry is invalidated (cleared) when the worktree
+   * refreshes so stale attributions don't linger after a commit.
+   */
+  blameByPath?: Map<string, BlameResult>
   branches?: BranchOverview
   /**
    * Repository-wide LFS attribute status (#884). When present, the

--- a/src/workstation/surfaces/blame/__snapshots__/blameRender.test.ts.snap
+++ b/src/workstation/surfaces/blame/__snapshots__/blameRender.test.ts.snap
@@ -1,0 +1,124 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`renderBlameSurface structural snapshot — empty / failure 1`] = `
+<Box
+  borderColor="cyan"
+  borderStyle="round"
+  flexDirection="column"
+  flexShrink={0}
+  paddingX={1}
+  width={120}
+>
+  <Box
+    justifyContent="space-between"
+  >
+    <Text
+      bold={true}
+    >
+      Blame *
+    </Text>
+    <Text
+      dimColor={true}
+    >
+      0 lines
+    </Text>
+  </Box>
+  <Text
+    dimColor={true}
+  >
+      logo.png
+  </Text>
+  <Text
+    dimColor={true}
+  >
+    Could not blame logo.png: binary file. Press esc to go back.
+  </Text>
+</Box>
+`;
+
+exports[`renderBlameSurface structural snapshot — loading 1`] = `
+<Box
+  borderColor="cyan"
+  borderStyle="round"
+  flexDirection="column"
+  flexShrink={0}
+  paddingX={1}
+  width={120}
+>
+  <Box
+    justifyContent="space-between"
+  >
+    <Text
+      bold={true}
+    >
+      Blame *
+    </Text>
+    <Text
+      dimColor={true}
+    >
+      loading blame
+    </Text>
+  </Box>
+  <Text
+    dimColor={true}
+  >
+      src/example.ts
+  </Text>
+  <Text
+    dimColor={true}
+  >
+    · Loading blame…
+  </Text>
+</Box>
+`;
+
+exports[`renderBlameSurface structural snapshot — populated 1`] = `
+<Box
+  borderColor="cyan"
+  borderStyle="round"
+  flexDirection="column"
+  flexShrink={0}
+  paddingX={1}
+  width={120}
+>
+  <Box
+    justifyContent="space-between"
+  >
+    <Text
+      bold={true}
+    >
+      Blame *
+    </Text>
+    <Text
+      dimColor={true}
+    >
+      1/2 lines
+    </Text>
+  </Box>
+  <Text
+    dimColor={true}
+  >
+      src/example.ts
+  </Text>
+  <Text
+    bold={true}
+  >
+    <Text
+      dimColor={true}
+    >
+      &gt; a1b2c3d4 Ada Lovelace         1 
+    </Text>
+    const answer = 42
+  </Text>
+  <Text
+    bold={false}
+  >
+    <Text
+      dimColor={true}
+    >
+        99887766 Grace Hopper         2 
+    </Text>
+    return answer
+  </Text>
+</Box>
+`;

--- a/src/workstation/surfaces/blame/blameRender.test.ts
+++ b/src/workstation/surfaces/blame/blameRender.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Structural tests for `renderBlameSurface`. Stubs `Text` / `Box` per
+ * the `surfaces/remotes/remotesRender.test.ts` pattern.
+ */
+import { createElement, type ReactElement } from 'react'
+import { createLogInkState, type LogInkState } from '../../../workstation/runtime/inkViewModel'
+import { createLogInkTheme } from '../../chrome/theme'
+import { createLogInkContextStatus } from '../../chrome/context'
+import type { BlameLine, BlameResult } from '../../../git/blameData'
+import type { LogInkComponents } from '../../runtime/types'
+import { renderBlameSurface, type BlameSurfaceData } from './index'
+
+type StubProps = Record<string, unknown>
+const Text = ((props: StubProps) =>
+  createElement('text', props, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+const Box = ((props: StubProps) =>
+  createElement('box', props, props.children as React.ReactNode)
+) as unknown as React.ComponentType<StubProps>
+
+const components: LogInkComponents = { Box, Text }
+
+function makeState(overrides: Partial<LogInkState> = {}): LogInkState {
+  return { ...createLogInkState([]), activeView: 'blame', blamePath: 'src/example.ts', ...overrides }
+}
+
+function makeLine(overrides: Partial<BlameLine> = {}): BlameLine {
+  return {
+    hash: 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678',
+    shortHash: 'a1b2c3d4',
+    author: 'Ada Lovelace',
+    authorTime: 1700000000,
+    lineNumber: 1,
+    content: 'const answer = 42',
+    ...overrides,
+  }
+}
+
+function render(state: LogInkState, data: BlameSurfaceData): ReactElement {
+  const theme = createLogInkTheme({})
+  return renderBlameSurface(
+    {
+      h: createElement,
+      components,
+      state,
+      context: {},
+      contextStatus: createLogInkContextStatus('ready'),
+      bodyRows: 30,
+      width: 120,
+      theme,
+    },
+    data,
+  )
+}
+
+describe('renderBlameSurface', () => {
+  it('renders a loading placeholder while blame hydrates', () => {
+    const tree = render(makeState(), { blame: undefined, loading: true })
+    expect(tree).toBeDefined()
+    expect(tree.type).toBe(Box)
+  })
+
+  it('treats a cold cache (no blame, has path) as loading', () => {
+    expect(render(makeState(), { blame: undefined, loading: false })).toBeDefined()
+  })
+
+  it('renders an empty / failure state when blame failed', () => {
+    const failed: BlameResult = { ok: false, path: 'logo.png', message: 'binary file' }
+    const tree = render(makeState({ blamePath: 'logo.png' }), { blame: failed, loading: false })
+    expect(tree).toBeDefined()
+  })
+
+  it('renders gutter + content rows for populated blame', () => {
+    const blame: BlameResult = {
+      ok: true,
+      path: 'src/example.ts',
+      lines: [makeLine(), makeLine({ lineNumber: 2, content: 'return answer' })],
+    }
+    expect(render(makeState(), { blame, loading: false })).toBeDefined()
+  })
+
+  it('reflects focus state via border color', () => {
+    const blame: BlameResult = { ok: true, path: 'src/example.ts', lines: [makeLine()] }
+    const focused = render(makeState({ focus: 'commits' }), { blame, loading: false })
+    const blurred = render(makeState({ focus: 'sidebar' }), { blame, loading: false })
+    expect((focused.props as StubProps).borderColor).not.toBe(
+      (blurred.props as StubProps).borderColor
+    )
+  })
+
+  it('structural snapshot — loading', () => {
+    expect(render(makeState(), { blame: undefined, loading: true })).toMatchSnapshot()
+  })
+
+  it('structural snapshot — empty / failure', () => {
+    const failed: BlameResult = { ok: false, path: 'logo.png', message: 'binary file' }
+    expect(render(makeState({ blamePath: 'logo.png' }), { blame: failed, loading: false }))
+      .toMatchSnapshot()
+  })
+
+  it('structural snapshot — populated', () => {
+    const blame: BlameResult = {
+      ok: true,
+      path: 'src/example.ts',
+      lines: [
+        makeLine(),
+        makeLine({ lineNumber: 2, content: 'return answer', author: 'Grace Hopper', shortHash: '99887766' }),
+      ],
+    }
+    expect(render(makeState(), { blame, loading: false })).toMatchSnapshot()
+  })
+})

--- a/src/workstation/surfaces/blame/index.ts
+++ b/src/workstation/surfaces/blame/index.ts
@@ -1,0 +1,136 @@
+/**
+ * Blame surface — on-demand `git blame` drill-down for a single file
+ * (#0.71 — expanded git ops).
+ *
+ * Architecturally distinct from the promoted list surfaces: blame is
+ * NOT boot-loaded. It's opened from the status view (`b` on a file
+ * row), keyed by path, and hydrated lazily into the runtime's
+ * `blameByPath` cache. While the cache is cold the surface shows a
+ * loading placeholder; once populated it renders each source line as a
+ * dimmed `<shorthash> <author>` gutter followed by the line content,
+ * windowed around `state.selectedBlameIndex` so even very large files
+ * stay responsive (we never render every line).
+ *
+ * The renderer is read-only: navigation (j/k) lives in `inkInput.ts`,
+ * the cursor model + path on `inkViewModel.ts`, and the hydration in
+ * `app.ts`.
+ */
+
+import type * as ReactTypes from 'react'
+import { formatLogInkBlameEmpty, formatLogInkLoading } from '../../chrome/surfaceStates'
+import { cellWidth, truncateCells } from '../../chrome/text'
+import type { BlameResult } from '../../../git/blameData'
+import type { SurfaceRenderContext } from '../../runtime/types'
+import { focusBorderColor, panelTitle } from '../../runtime/utils'
+
+/**
+ * Cap the rendered short-hash + author gutter so a long author name on
+ * one line doesn't shove every line's content off-screen. The gutter is
+ * `<8-char-hash> <author>` with the author column capped here.
+ */
+const AUTHOR_COL_CAP = 18
+
+/**
+ * Per-surface data the blame view needs beyond the universal
+ * `SurfaceRenderContext`. Mirrors the diff surface's extra-data bundle:
+ * the resolved (cache-hit) blame for the active path, plus a loading
+ * flag the runtime sets while the debounced hydration is in flight.
+ */
+export type BlameSurfaceData = {
+  /** Cached blame for `state.blamePath`, or undefined on a cache miss. */
+  blame: BlameResult | undefined
+  /** True while the on-demand hydration for this path is in flight. */
+  loading: boolean
+}
+
+export function renderBlameSurface(
+  ctx: SurfaceRenderContext,
+  data: BlameSurfaceData,
+): ReactTypes.ReactElement {
+  const { h, components, state, bodyRows, width, theme } = ctx
+  const { Box, Text } = components
+  const focused = state.focus === 'commits'
+  const path = state.blamePath
+  const blame = data.blame
+  // Loading covers both the explicit in-flight flag and the cold-cache
+  // window before the debounced fetch resolves into `blameByPath`.
+  const loading = data.loading || (!blame && Boolean(path))
+
+  const lines = blame && blame.ok ? blame.lines : []
+  const failureMessage = blame && !blame.ok ? blame.message : undefined
+
+  const listRows = Math.max(4, bodyRows - 4)
+  const selected = Math.max(0, Math.min(state.selectedBlameIndex, Math.max(0, lines.length - 1)))
+  // Window around the cursor — never render the whole file.
+  const windowStart = Math.max(
+    0,
+    Math.min(
+      Math.max(0, lines.length - listRows),
+      selected - Math.floor(listRows / 2),
+    ),
+  )
+  const visible = lines.slice(windowStart, windowStart + listRows)
+
+  const headerRight = loading
+    ? 'loading blame'
+    : lines.length
+      ? `${selected + 1}/${lines.length} lines`
+      : '0 lines'
+
+  // Line-number gutter width sized to the file's largest line number so
+  // the content column aligns; capped via the window so a 100k-line file
+  // doesn't reserve an absurd gutter.
+  const maxLineNumber = lines.length ? lines[lines.length - 1].lineNumber : 0
+  const lineNoWidth = Math.max(3, String(maxLineNumber).length)
+
+  const body: ReactTypes.ReactNode[] = loading
+    ? [h(Text, { key: 'blame-loading', dimColor: true }, formatLogInkLoading({ resource: 'blame' }))]
+    : lines.length === 0
+      ? [h(Text, { key: 'blame-empty', dimColor: true },
+          formatLogInkBlameEmpty({ path, failureMessage }))]
+      : visible.map((line, offset) => {
+        const index = windowStart + offset
+        const isSelected = index === selected
+        const cursor = isSelected ? '>' : ' '
+        const author = truncateCells(line.author, AUTHOR_COL_CAP).padEnd(AUTHOR_COL_CAP)
+        const lineNo = String(line.lineNumber).padStart(lineNoWidth)
+        // Dimmed blame gutter (`<shorthash> <author>`) + the line's
+        // number, then the content. The gutter is rendered as its own
+        // dimmed span so the source content reads at full contrast.
+        const gutter = `${cursor} ${line.shortHash} ${author} ${lineNo} `
+        const contentWidth = Math.max(8, width - 4 - cellWidth(gutter))
+        const content = truncateCells(line.content, contentWidth)
+        return h(Text, {
+          key: `blame-${index}`,
+          bold: isSelected,
+        },
+        h(Text, { dimColor: true }, gutter),
+        content)
+      })
+
+  // Scroll affordances — same idiom as the status surface so the user
+  // knows there's more file above / below the window.
+  const hasMoreAbove = !loading && windowStart > 0 && lines.length > 0
+  const hasMoreBelow = !loading && windowStart + listRows < lines.length
+
+  return h(Box, {
+    borderColor: focusBorderColor(theme, focused),
+    borderStyle: theme.borderStyle,
+    flexDirection: 'column',
+    flexShrink: 0,
+    paddingX: 1,
+    width,
+  },
+  h(Box, { justifyContent: 'space-between' },
+    h(Text, { bold: true }, panelTitle('Blame', focused)),
+    h(Text, { dimColor: true }, headerRight),
+  ),
+  h(Text, { dimColor: true }, truncateCells(path ? `  ${path}` : '  (no file)', Math.max(10, width - 4))),
+  ...(hasMoreAbove
+    ? [h(Text, { key: 'blame-more-above', dimColor: true }, `  ↑ ${windowStart} more above`)]
+    : []),
+  ...body,
+  ...(hasMoreBelow
+    ? [h(Text, { key: 'blame-more-below', dimColor: true }, `  ↓ ${lines.length - (windowStart + listRows)} more below`)]
+    : []))
+}


### PR DESCRIPTION
**PR 3 of the 0.71 "expanded git ops" release.** Press **`b`** on a file in the status view to open a blame drill-down for that file.

## How it works
- `src/git/blameData.ts` — `getBlame(git, path)` runs `git blame --porcelain` and parses it into one `BlameLine` per source line (`shortHash`, `author`, `authorTime`, 1-based `lineNumber`, `content`); uncommitted lines map to the all-zero sha. Best-effort.
- **On-demand + cached.** Unlike the boot-loaded list surfaces, blame is per-file and expensive, so it's fetched lazily into a `blameByPath` cache (keyed by path) when the view opens, behind a 750 ms debounce, with a loading placeholder — mirroring the PR/issue detail-hydration pattern.
- **Large-file safe.** Windowed render around `selectedBlameIndex`, so a 100k-line file stays responsive; gutter shows a dimmed `<shorthash> <author>` + the line.

## Keys
`b` enters blame from the status file list; `j`/`k` (or ↑/↓) move; `esc` returns. Collision-checked.

## Tests
`blameData` porcelain-parse, `blameRender` snapshots (empty/loading/populated), input/dispatch. Full suite green (lint + 3371 jest + build + cli + pack).

## Deferred
**File-history** (`git log -- <path>`) was scoped out to keep this PR focused on the must-have blame surface — easy follow-up (a key in the blame view to toggle to the file's commit list).

Follows PR 1 (submodule actions, #1212) and PR 2 (remotes, #1213). Next: PR 4 (rebase-onto-branch), the last.