### PR TITLE
feat(workstation): rebase current branch onto a selected ref

### DIFF
--- a/src/git/rebaseActions.test.ts
+++ b/src/git/rebaseActions.test.ts
@@ -1,0 +1,55 @@
+import { rebaseOnto } from './rebaseActions'
+
+describe('rebaseOnto', () => {
+  it('runs a non-interactive `git rebase <ref>` (no -i, no editor)', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+    await rebaseOnto(git as never, 'main')
+    expect(git.raw).toHaveBeenCalledWith(['rebase', 'main'])
+    // Guard against an accidental interactive flag sneaking in — that
+    // would shell into $GIT_EDITOR and hang the TUI.
+    expect(git.raw.mock.calls[0][0]).not.toContain('-i')
+    expect(git.raw.mock.calls[0][0]).not.toContain('--interactive')
+  })
+
+  it('trims whitespace around the ref', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+    await rebaseOnto(git as never, '  origin/main  ')
+    expect(git.raw).toHaveBeenCalledWith(['rebase', 'origin/main'])
+  })
+
+  it('returns a friendly success message', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+    await expect(rebaseOnto(git as never, 'develop')).resolves.toEqual({
+      ok: true,
+      message: 'Rebased onto develop',
+    })
+  })
+
+  it('maps a conflict / failure to an error result carrying git\'s message', async () => {
+    const git = {
+      raw: jest.fn().mockRejectedValue(new Error('CONFLICT (content): Merge conflict in app.ts')),
+    }
+    await expect(rebaseOnto(git as never, 'main')).resolves.toEqual({
+      ok: false,
+      message: 'CONFLICT (content): Merge conflict in app.ts',
+    })
+  })
+
+  it('rejects an empty ref without calling git', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+    await expect(rebaseOnto(git as never, '   ')).resolves.toEqual({
+      ok: false,
+      message: 'Rebase target ref required.',
+    })
+    expect(git.raw).not.toHaveBeenCalled()
+  })
+
+  it('rejects a flag-like ref to avoid arg injection', async () => {
+    const git = { raw: jest.fn().mockResolvedValue('') }
+    await expect(rebaseOnto(git as never, '--onto=evil')).resolves.toEqual({
+      ok: false,
+      message: "Rebase target '--onto=evil' cannot start with '-'.",
+    })
+    expect(git.raw).not.toHaveBeenCalled()
+  })
+})

--- a/src/git/rebaseActions.ts
+++ b/src/git/rebaseActions.ts
@@ -1,0 +1,58 @@
+import { SimpleGit } from 'simple-git'
+import { BranchActionResult } from './branchActions'
+import { rejectFlagLike } from './forgeArgGuards'
+
+/**
+ * Non-interactive rebase actions (#0.71 — expanded git ops).
+ *
+ * `rebaseOnto` rebases the current branch onto a selected branch/ref —
+ * the non-interactive counterpart to the `interactive-rebase` flow in
+ * `historyActions.ts` (which shells `git rebase -i` into $GIT_EDITOR).
+ * This one runs `git rebase <ref>` with NO `-i`, so it never opens an
+ * editor and can run unattended from the branches view.
+ *
+ * On a clean replay the command exits zero → `{ ok:true }`. On a
+ * conflict (or any other failure) git exits non-zero and we return
+ * `{ ok:false, message }` carrying git's own message. In the conflict
+ * case the repo is left mid-rebase; the existing in-progress-operation
+ * surfaces (`getGitOperationOverview`, the `gx` conflicts view, and the
+ * `A` abort-operation action) reflect and unwind that state — this
+ * action deliberately does NOT add `--continue` / `--abort` paths.
+ *
+ * The `ref` is validated with `rejectFlagLike` so a value beginning with
+ * `-` can't be misparsed by git as a flag. argv is passed via
+ * simple-git's execFile (no shell), so there's no command injection —
+ * this is defense-in-depth against a leading-`-` ref flipping a flag.
+ */
+
+async function runAction(
+  action: () => Promise<unknown>,
+  successMessage: string
+): Promise<BranchActionResult> {
+  try {
+    await action()
+    return { ok: true, message: successMessage }
+  } catch (error) {
+    return { ok: false, message: (error as Error).message }
+  }
+}
+
+/**
+ * `git rebase <ref>`: replay the current branch's commits on top of
+ * `<ref>`. Non-interactive — no `-i`, so $GIT_EDITOR is never opened.
+ * Validates the ref up front so a flag-like value never reaches argv.
+ */
+export function rebaseOnto(git: SimpleGit, ref: string): Promise<BranchActionResult> {
+  const trimmed = ref.trim()
+  if (!trimmed) {
+    return Promise.resolve({ ok: false, message: 'Rebase target ref required.' })
+  }
+  const flagError = rejectFlagLike(trimmed, `Rebase target '${trimmed}'`)
+  if (flagError) {
+    return Promise.resolve({ ok: false, message: flagError })
+  }
+  return runAction(
+    () => git.raw(['rebase', trimmed]),
+    `Rebased onto ${trimmed}`
+  )
+}

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -181,6 +181,7 @@ import {
 import { applyStash, applyStashKeepIndex, checkoutFileFromStash, createStash, dropStash, popStash, renameStash, restoreStash, stashBranch } from '../../git/stashActions'
 import { ApplyHunkTarget, applyHunkPatch } from '../../git/hunkActions'
 import { removeWorktree, removeWorktreeAndBranch } from '../../git/worktreeActions'
+import { rebaseOnto } from '../../git/rebaseActions'
 import { abortOperation, continueOperation, resolveConflictOurs, resolveConflictTheirs, stageConflictResolved } from '../../git/operationActions'
 import { getForgeActions, getForgePullRequestOverview } from '../../git/forgeActions'
 import { clearGitHubListCache } from '../../git/githubListCache'
@@ -3275,6 +3276,31 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         if (!branch) return { ok: false, message: 'No branch selected' }
         return deleteBranch(git, branch, true)
       },
+      // #0.71 — rebase the current branch onto the cursored branch / ref.
+      // Re-resolve BOTH branches off live context (the input-layer guards
+      // already gated the keystroke, but the confirm prompt sits between
+      // the keystroke and here, so the cursor / current branch could have
+      // moved — re-checking keeps the executed op honest). A conflict
+      // leaves the repo mid-rebase; the post-handler refreshContext below
+      // reloads the operation overview so the `gx` / `A` surfaces reflect
+      // it. No `--continue` / `--abort` here — those live on the existing
+      // in-progress-operation surfaces by design.
+      'rebase-onto-branch': async () => {
+        const current = context.branches?.currentBranch
+        if (!current) {
+          return { ok: false, message: 'Detached HEAD — checkout a branch before rebasing onto a ref.' }
+        }
+        const all = sortBranches(context.branches?.localBranches || [], state.branchSort)
+        const visible = state.filter
+          ? all.filter((b) => matchesPromotedFilter([b.shortName, b.upstream || ''], state.filter))
+          : all
+        const branch = visible[Math.min(state.selectedBranchIndex, visible.length - 1)]
+        if (!branch) return { ok: false, message: 'No branch selected' }
+        if (branch.shortName === current) {
+          return { ok: false, message: 'Cannot rebase a branch onto itself.' }
+        }
+        return rebaseOnto(git, branch.shortName)
+      },
       'delete-tag': async () => {
         const all = sortTags(context.tags?.tags || [], state.tagSort)
         const visible = state.filter
@@ -4238,6 +4264,11 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       'reset-soft-to-commit',
       'reset-mixed-to-commit',
       'interactive-rebase-to-commit',
+      // Rebasing the current branch onto a ref rewrites its commits —
+      // refresh the graph so the replayed history (or the mid-rebase
+      // conflict state) shows instead of staying pinned to the pre-rebase
+      // tip.
+      'rebase-onto-branch',
       'bisect-good',
       'bisect-bad',
       'bisect-skip',
@@ -4979,6 +5010,10 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       commitDiffHunkOffsets,
       branchCount: branchVisibleCount,
       branchSelectedShortName,
+      // Current branch for the `r` rebase-onto guard + warning (#0.71).
+      // Undefined on a detached HEAD, which the handler treats as "no
+      // branch to rebase".
+      currentBranch: context.branches?.currentBranch,
       tagCount: tagVisibleCount,
       tagSelectedName,
       stashCount: stashVisibleCount,

--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -673,6 +673,79 @@ describe('log Ink input interactions', () => {
     })
   })
 
+  describe('r rebase-onto on the branches view (#0.71)', () => {
+    // `r` is the global refresh everywhere — on the branches view it is
+    // intercepted FIRST to mean "rebase current onto cursored ref",
+    // routed through the y-confirm gate with a warning naming both
+    // branches. Guards short-circuit a self-rebase / detached HEAD.
+
+    it('routes r to the rebase-onto confirmation with a branch-naming warning', () => {
+      const state = createLogInkState(rows, { activeView: 'branches' })
+      const events = getLogInkInputEvents(state, 'r', {}, {
+        branchCount: 3,
+        currentBranch: 'feature',
+        branchSelectedShortName: 'main',
+      })
+      expect(events).toEqual([
+        {
+          type: 'action',
+          action: {
+            type: 'setPendingConfirmation',
+            value: 'rebase-onto-branch',
+            payload: "Rebase feature onto main? This rewrites feature's history.",
+          },
+        },
+      ])
+    })
+
+    it('blocks a self-rebase with a clear warning instead of confirming', () => {
+      const state = createLogInkState(rows, { activeView: 'branches' })
+      const events = getLogInkInputEvents(state, 'r', {}, {
+        branchCount: 3,
+        currentBranch: 'main',
+        branchSelectedShortName: 'main',
+      })
+      expect(events).toEqual([
+        {
+          type: 'action',
+          action: {
+            type: 'setStatus',
+            value: 'Cannot rebase a branch onto itself.',
+            kind: 'warning',
+          },
+        },
+      ])
+    })
+
+    it('blocks a rebase on detached HEAD (no current branch)', () => {
+      const state = createLogInkState(rows, { activeView: 'branches' })
+      const events = getLogInkInputEvents(state, 'r', {}, {
+        branchCount: 3,
+        currentBranch: undefined,
+        branchSelectedShortName: 'main',
+      })
+      expect(events).toEqual([
+        {
+          type: 'action',
+          action: {
+            type: 'setStatus',
+            value: 'Detached HEAD — checkout a branch before rebasing onto a ref.',
+            kind: 'warning',
+          },
+        },
+      ])
+    })
+
+    it('still falls through to the global refresh outside the branches view', () => {
+      const state = createLogInkState(rows, { activeView: 'history' })
+      expect(getLogInkInputEvents(state, 'r', {}, {
+        branchCount: 3,
+        currentBranch: 'feature',
+        branchSelectedShortName: 'main',
+      })).toEqual([{ type: 'refreshContext' }])
+    })
+  })
+
   describe('help overlay key handling', () => {
     it('j/k scroll the help overlay without changing focus', () => {
       let state = createLogInkState(rows)

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -102,6 +102,13 @@ export type LogInkInputContext = {
    * resolve the head ref from the branches view.
    */
   branchSelectedShortName?: string
+  /**
+   * Name of the currently checked-out branch (#0.71). Used by the
+   * branches-view `r` (rebase-onto) handler to build the confirmation
+   * warning and to short-circuit a self-rebase / detached-HEAD before
+   * routing through the y-confirm path. Undefined on a detached HEAD.
+   */
+  currentBranch?: string
   tagCount?: number
   /**
    * Name of the cursored tag (#779). Same role as
@@ -2059,6 +2066,52 @@ export function getLogInkInputEvents(
 
   if (inputValue === 'N') {
     return [action({ type: 'move', delta: -1 })]
+  }
+
+  // Per-view branches action: `r` rebases the current branch onto the
+  // cursored branch / ref (#0.71 — non-interactive `git rebase <ref>`).
+  // The most dangerous op in this release — it rewrites the current
+  // branch's history — so it NEVER runs directly: it routes through the
+  // y-confirm path. Two guards run up front so the confirm prompt is
+  // only raised for an operation that can actually proceed:
+  //   - detached HEAD (no current branch): nothing to rebase onto a ref
+  //   - self-rebase (cursored ref === current branch): a no-op git would
+  //     reject anyway, surfaced here as a clear status instead.
+  // Scoped to the branches target so the letter stays free elsewhere
+  // (the global `r` refresh below still fires on every other view). The
+  // confirmation warning names both branches; it's carried as the
+  // pending-confirmation payload and rendered by `renderConfirmationPanel`
+  // — the runtime handler re-resolves both branches off live context, so
+  // it ignores this payload.
+  if (inputValue === 'r' && isBranchActionTarget(state) && context.branchCount) {
+    const current = context.currentBranch
+    const target = context.branchSelectedShortName
+    if (!current) {
+      return [action({
+        type: 'setStatus',
+        value: 'Detached HEAD — checkout a branch before rebasing onto a ref.',
+        kind: 'warning',
+      })]
+    }
+    if (!target) {
+      return [action({
+        type: 'setStatus',
+        value: 'No branch under cursor to rebase onto.',
+        kind: 'warning',
+      })]
+    }
+    if (target === current) {
+      return [action({
+        type: 'setStatus',
+        value: 'Cannot rebase a branch onto itself.',
+        kind: 'warning',
+      })]
+    }
+    return [action({
+      type: 'setPendingConfirmation',
+      value: 'rebase-onto-branch',
+      payload: `Rebase ${current} onto ${target}? This rewrites ${current}'s history.`,
+    })]
   }
 
   if (inputValue === 'r') {

--- a/src/workstation/runtime/inkKeymap.test.ts
+++ b/src/workstation/runtime/inkKeymap.test.ts
@@ -118,7 +118,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'D delete', 'm compare', 's sort', 'y yank'],
+      contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'D delete', 'r rebase', 'm compare', 's sort', 'y yank'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/workstation/runtime/inkKeymap.ts
+++ b/src/workstation/runtime/inkKeymap.ts
@@ -74,6 +74,7 @@ export type LogInkCommandId =
   | 'viewRevert'
   | 'viewReset'
   | 'viewInteractiveRebase'
+  | 'viewRebaseOnto'
   | 'viewCreateBranchHere'
   | 'viewCreateTagHere'
   | 'viewChangelog'
@@ -552,6 +553,19 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     contexts: ['history'],
   },
   {
+    // #0.71 — branches-view-only. `r` rebases the current branch onto the
+    // cursored branch / ref (non-interactive). Scoped to `branches` so it
+    // doesn't collide with the global `r` refresh (context `normal`); the
+    // resolver in inkInput intercepts it before the refresh path. The
+    // most dangerous op in the release, so it routes through the
+    // y-confirm gate with a warning naming both branches.
+    id: 'viewRebaseOnto',
+    keys: ['r'],
+    label: 'rebase onto',
+    description: 'Rebase the current branch onto the cursored branch / ref (non-interactive) after confirmation.',
+    contexts: ['branches'],
+  },
+  {
     id: 'viewCreateBranchHere',
     keys: ['B'],
     label: 'create branch here',
@@ -864,6 +878,9 @@ const BINDING_CATEGORY_BY_ID: Partial<Record<LogInkCommandId, LogInkBindingCateg
   workflowAbortOperation: 'mutate',
   workflowAiCommitSummary: 'mutate',
   workflowAiConflictHelp: 'mutate',
+  // Branches-view-only rebase-onto (#0.71) — a confirmation-gated
+  // destructive op, grouped with the global mutate cluster.
+  viewRebaseOnto: 'mutate',
   // ── History actions: per-view-only mutations scoped to the history
   //    surface. Distinct from the global mutate cluster so users see
   //    them grouped under their actual context.
@@ -1265,7 +1282,7 @@ function computeLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogInkF
       }
     }
     return {
-      contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'D delete', 'm compare', 's sort', 'y yank'],
+      contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'D delete', 'r rebase', 'm compare', 's sort', 'y yank'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/workstation/runtime/inkWorkflows.test.ts
+++ b/src/workstation/runtime/inkWorkflows.test.ts
@@ -99,6 +99,19 @@ describe('log Ink workflows', () => {
     expect(getLogInkWorkflowActionByKey('')).toBeUndefined()
   })
 
+  it('registers rebase-onto-branch as a keyless, confirmation-gated destructive op (#0.71)', () => {
+    // Per-view-only: the `r` keystroke is scoped to the branches surface
+    // in inkInput, so the registry entry is keyless (palette-discoverable
+    // without a global hotkey). Destructive — it rewrites history — so it
+    // must require confirmation.
+    const rebase = getLogInkWorkflowActionById('rebase-onto-branch')
+    expect(rebase).toMatchObject({
+      key: '',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    })
+  })
+
   // Issue #777 — revert / reset / interactive-rebase wired through the
   // workflow registry as palette-only entries (key: ''). Real keystroke
   // dispatch is per-view scoped in inkInput.ts so they only fire on

--- a/src/workstation/runtime/inkWorkflows.ts
+++ b/src/workstation/runtime/inkWorkflows.ts
@@ -333,6 +333,24 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: true,
     },
     {
+      // #0.71 — rebase the current branch onto the cursored branch/ref
+      // (non-interactive `git rebase <ref>`). Per-view-only: the inkInput
+      // handler scopes the `r` keystroke to the branches surface and the
+      // runtime resolves the cursored + current branch, so the empty
+      // `key` keeps it palette-discoverable without registering a global
+      // hotkey. The most dangerous op in this release — it rewrites the
+      // current branch's history — so it gates on the y-confirm path with
+      // a warning naming both branches. A conflict leaves the repo
+      // mid-rebase; the existing `gx` / `A` surfaces reflect and unwind
+      // it (no `--continue` / `--abort` workflow added here, by design).
+      id: 'rebase-onto-branch',
+      key: '',
+      label: 'Rebase current onto selected ref',
+      description: 'Rebase the current branch onto the cursored branch / ref (non-interactive) after confirmation.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    },
+    {
       id: 'delete-tag',
       key: 'T',
       label: 'Delete tag',

--- a/src/workstation/runtime/overlays.test.ts
+++ b/src/workstation/runtime/overlays.test.ts
@@ -103,6 +103,28 @@ describe('force-delete-branch confirmation panel', () => {
   })
 })
 
+describe('rebase-onto-branch confirmation panel (#0.71)', () => {
+  const components: LogInkComponents = { Box, Text }
+
+  it('renders the per-invocation warning naming both branches', () => {
+    const state = {
+      ...createLogInkState([]),
+      pendingConfirmationId: 'rebase-onto-branch',
+      pendingConfirmationPayload: "Rebase feature onto main? This rewrites feature's history.",
+    }
+    const text = flattenText(renderConfirmationPanel(createElement, components, state, 80, theme, false))
+    expect(text).toContain('Rebase current onto selected ref')
+    expect(text).toContain("Rebase feature onto main? This rewrites feature's history.")
+    expect(text).not.toContain('Destructive Git action requires confirmation')
+  })
+
+  it('falls back to a static warning when the payload is absent', () => {
+    const state = { ...createLogInkState([]), pendingConfirmationId: 'rebase-onto-branch' }
+    const text = flattenText(renderConfirmationPanel(createElement, components, state, 80, theme, false))
+    expect(text).toContain('Rebase rewrites the current branch')
+  })
+})
+
 describe('split-plan overlay — unclaimed group (#1180)', () => {
   const components: LogInkComponents = { Box, Text }
 

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -114,6 +114,12 @@ export function renderConfirmationPanel(
     // branch — name the reason so the force isn't a blind "y again".
     : state.pendingConfirmationId === 'force-delete-branch'
     ? 'Not fully merged. Force-delete (git branch -D) is irreversible.'
+    // Rebase-onto carries a per-invocation warning naming both branches
+    // (built in inkInput from the cursored + current branch). Fall back
+    // to a static line if the payload is somehow absent.
+    : state.pendingConfirmationId === 'rebase-onto-branch'
+    ? state.pendingConfirmationPayload
+      || 'Rebase rewrites the current branch\'s history. This cannot be undone by Coco.'
     : action?.kind === 'ai'
     ? `AI action requires confirmation. Estimated ${action.estimatedTokens || '<unknown>'} tokens.`
     : 'Destructive Git action requires confirmation.'


### PR DESCRIPTION
## Summary

PR 4 (last) of the 0.71 "expanded git ops" release: **rebase-onto-branch** — rebase the current branch onto a branch/ref selected in the workstation **branches** view. This is the non-interactive counterpart to the existing `interactive-rebase` flow (which shells `git rebase -i` into `$GIT_EDITOR` from the history view).

This is the most dangerous op in the release — it rewrites the current branch's history — so the destructive-confirmation gate and guards are non-negotiable.

## What it does

- **Action** (`src/git/rebaseActions.ts`): `rebaseOnto(git, ref)` runs `git rebase <ref>` — **non-interactive** (no `-i`, never opens an editor). Returns `{ ok, message }` via a `runAction`-style helper; on a conflict the command exits non-zero and we return `{ ok:false }` carrying git's own message, leaving the repo mid-rebase. The `ref` is validated with `rejectFlagLike` so a leading-`-` ref can't be misparsed as a flag.
- **Entry key:** `r` on the **branches** view (rebase mnemonic). `R` was already taken (rename-branch) and `u` (set-upstream), so `r` it is. Globally `r` means "refresh"; the branches-view handler intercepts it **before** the global refresh path (same overload pattern the history-view mutating keys use). Verified collision-free — the declarative binding lives in the `branches` context (`branches::r`), distinct from `refresh`'s `normal::r`.
- **Destructive confirm + warning:** `r` never runs directly — it routes through `setPendingConfirmation` (`y`/`n`). The workflow entry `rebase-onto-branch` is `kind:'destructive'`, `requiresConfirmation:true`. The confirmation warning reads:

  > Rebase &lt;current&gt; onto &lt;ref&gt;? This rewrites &lt;current&gt;'s history.

  (built from the cursored + current branch and rendered by `renderConfirmationPanel`; falls back to a static line if absent).
- **Guards** (in both the input layer and the runtime handler, so the confirm prompt is only raised for an op that can proceed):
  - **Self-rebase:** cursored ref === current branch → `Cannot rebase a branch onto itself.`
  - **Detached HEAD:** no current branch → `Detached HEAD — checkout a branch before rebasing onto a ref.`
- **Wiring:** runtime handler in `app.ts` re-resolves both branches off live context, runs the guards, then calls `rebaseOnto`. Added to `historyMutatingIds` so the graph refreshes after a successful rebase; the post-action `refreshContext` reloads the operation overview so a stalled rebase is reflected.

## Mid-rebase conflict state

A conflict leaves the repo mid-rebase. This is **handled by the existing in-progress-operation surfaces** — `getGitOperationOverview`, the `gx` conflicts view, and the `A` abort-operation action. Per scope, this PR deliberately does **not** add `--continue` / `--abort` workflow actions; those already exist on those surfaces.

## Tests

- `rebaseActions.test.ts`: argv (`['rebase', '<ref>']`), asserts no `-i`/`--interactive`, ok/error mapping (incl. a conflict message), empty-ref + flag-like-ref guards.
- `inkInput.test.ts`: `r` → rebase-onto confirmation with the branch-naming payload; self-rebase + detached-HEAD guards; `r` still refreshes outside the branches view.
- `overlays.test.ts`: dynamic warning renders both branch names; static fallback.
- `inkWorkflows.test.ts`: registry entry is keyless, destructive, confirmation-gated.
- Footer-hint + collision tests updated.

Full suite green: `npm test` (lint + jest + build + cli + pack). 266 suites, 3384 tests passing.