### PR TITLE
refactor(workstation): extract filtered-list memos into useFilteredLists (0.72 app.ts decomposition)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -350,6 +350,7 @@ import type { LogArgv } from '../../commands/log/config'
 // runtime/ rather than chrome/ because they're tightly coupled to the
 // LogInkState filter-mode shape.
 import { matchesPromotedFilter } from '../runtime/promotedFilter'
+import { useFilteredLists } from './hooks/buildFilteredLists'
 import {
     buildLoadedHashSet,
     resolveCursorSyncDecision,
@@ -887,98 +888,24 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // branches / tags and an active filter, that's hundreds of regex
   // matches per arrow-key press. Memoizing on (raw list, filter)
   // collapses the work to one pass per filter / data change.
-  const filteredBranchList = React.useMemo(() => {
-    const all = context.branches?.localBranches || []
-    if (!state.filter) return all
-    return all.filter((branch) =>
-      matchesPromotedFilter([branch.shortName, branch.upstream || ''], state.filter)
-    )
-  }, [context.branches?.localBranches, state.filter])
-  const filteredTagList = React.useMemo(() => {
-    const all = context.tags?.tags || []
-    if (!state.filter) return all
-    return all.filter((tag) =>
-      matchesPromotedFilter([tag.name, tag.subject], state.filter)
-    )
-  }, [context.tags?.tags, state.filter])
-  const filteredStashList = React.useMemo(() => {
-    const all = context.stashes?.stashes || []
-    if (!state.filter) return all
-    return all.filter((stash) =>
-      matchesPromotedFilter([stash.ref, stash.message], state.filter)
-    )
-  }, [context.stashes?.stashes, state.filter])
-  const filteredWorktreeList = React.useMemo(() => {
-    const all = context.worktreeList?.worktrees || []
-    if (!state.filter) return all
-    return all.filter((entry) =>
-      matchesPromotedFilter([entry.path, entry.branch || ''], state.filter)
-    )
-  }, [context.worktreeList?.worktrees, state.filter])
-  const filteredReflogList = React.useMemo(() => {
-    const all = context.reflog?.entries || []
-    if (!state.filter) return all
-    return all.filter((entry) =>
-      matchesPromotedFilter(
-        [entry.selector, entry.hash, entry.relativeDate, entry.subject],
-        state.filter
-      )
-    )
-  }, [context.reflog?.entries, state.filter])
-  const filteredSubmoduleList = React.useMemo(() => {
-    const all = context.submodules?.entries || []
-    if (!state.filter) return all
-    return all.filter((entry) =>
-      matchesPromotedFilter(
-        [entry.name, entry.path, entry.trackingBranch || '', entry.url || ''],
-        state.filter,
-      )
-    )
-  }, [context.submodules?.entries, state.filter])
-  const filteredRemoteList = React.useMemo(() => {
-    const all = context.remotes?.entries || []
-    if (!state.filter) return all
-    return all.filter((entry) =>
-      matchesPromotedFilter([entry.name, entry.fetchUrl, entry.pushUrl], state.filter)
-    )
-  }, [context.remotes?.entries, state.filter])
-  // Issues + PR triage filtered lists (#882 phase 3). Same memo
-  // pattern as the other promoted views — collapses per-keystroke
-  // filter work to one pass per (data, filter) change.
-  const filteredIssueList = React.useMemo(() => {
-    const all = context.issueList?.issues || []
-    if (!state.filter) return all
-    return all.filter((issue) =>
-      matchesPromotedFilter(
-        [
-          `#${issue.number}`,
-          issue.title,
-          issue.author || '',
-          ...(issue.labels || []),
-          ...(issue.assignees || []),
-        ],
-        state.filter,
-      )
-    )
-  }, [context.issueList?.issues, state.filter])
-  const filteredPullRequestTriageList = React.useMemo(() => {
-    const all = context.pullRequestList?.pullRequests || []
-    if (!state.filter) return all
-    return all.filter((pr) =>
-      matchesPromotedFilter(
-        [
-          `#${pr.number}`,
-          pr.title,
-          pr.author || '',
-          pr.headRefName,
-          pr.baseRefName,
-          ...(pr.labels || []),
-          ...(pr.assignees || []),
-        ],
-        state.filter,
-      )
-    )
-  }, [context.pullRequestList?.pullRequests, state.filter])
+  // Extracted into `useFilteredLists` (0.72 app.ts decomposition). The
+  // hook issues one `React.useMemo` per list in the same order — and
+  // with the same per-list dependency arrays — these memos used to,
+  // delegating to the pure `buildFilteredLists` core. Hook call-order
+  // and per-list reference identity are unchanged; every downstream
+  // consumer (the input handler, cursor-sync) destructures the same
+  // names below.
+  const {
+    filteredBranchList,
+    filteredTagList,
+    filteredStashList,
+    filteredWorktreeList,
+    filteredReflogList,
+    filteredSubmoduleList,
+    filteredRemoteList,
+    filteredIssueList,
+    filteredPullRequestTriageList,
+  } = useFilteredLists(React, context, state.filter)
 
   const dispatch = React.useCallback((action: Parameters<typeof applyLogInkAction>[1]) => {
     setState((current) => applyLogInkAction(current, action))

--- a/src/workstation/runtime/hooks/buildFilteredLists.test.ts
+++ b/src/workstation/runtime/hooks/buildFilteredLists.test.ts
@@ -1,0 +1,178 @@
+import { buildFilteredLists } from './buildFilteredLists'
+import type { LogInkContext } from '../types'
+
+/**
+ * Unit tests for the pure `buildFilteredLists` core (0.72 app.ts
+ * decomposition). No React harness — the hook (`useFilteredLists`) is a
+ * thin per-list `useMemo` wrapper, so testing the pure derivation
+ * exercises all the filter behavior that was lifted verbatim out of
+ * app.ts. Mirrors `cursorSyncResolver.test.ts`.
+ *
+ * Fixtures are hand-built partial overviews cast to `LogInkContext`; the
+ * filter predicate only ever reads the match fields each list keys off,
+ * so the casts keep the fixtures minimal without changing behavior.
+ */
+
+const context: LogInkContext = {
+  branches: {
+    currentBranch: 'main',
+    dirty: false,
+    localBranches: [
+      { shortName: 'main', upstream: 'origin/main' },
+      { shortName: 'feature/login', upstream: '' },
+    ],
+    remoteBranches: [],
+  },
+  tags: {
+    tags: [
+      { name: 'v1.0.0', subject: 'first release' },
+      { name: 'v2.0.0', subject: 'login overhaul' },
+    ],
+  },
+  stashes: {
+    stashes: [
+      { ref: 'stash@{0}', message: 'wip on main' },
+      { ref: 'stash@{1}', message: 'login experiment' },
+    ],
+  },
+  worktreeList: {
+    worktrees: [
+      { path: '/repo/main', branch: 'main' },
+      { path: '/repo/feature', branch: 'feature/login' },
+    ],
+  },
+  reflog: {
+    entries: [
+      { selector: 'HEAD@{0}', hash: 'aaa111', relativeDate: '2 hours ago', subject: 'commit: add main' },
+      { selector: 'HEAD@{1}', hash: 'bbb222', relativeDate: '3 hours ago', subject: 'checkout: login' },
+    ],
+  },
+  submodules: {
+    entries: [
+      { name: 'libfoo', path: 'vendor/foo', trackingBranch: 'main', url: 'https://x/foo.git' },
+      { name: 'libbar', path: 'vendor/bar', trackingBranch: 'login', url: 'https://x/bar.git' },
+    ],
+  },
+  remotes: {
+    entries: [
+      { name: 'origin', fetchUrl: 'https://x/main.git', pushUrl: 'https://x/main.git' },
+      { name: 'fork', fetchUrl: 'https://x/login.git', pushUrl: 'https://x/login.git' },
+    ],
+  },
+  issueList: {
+    issues: [
+      { number: 1, title: 'Fix main', author: 'alice', labels: ['bug'], assignees: ['alice'] },
+      { number: 2, title: 'Add login', author: 'bob', labels: ['feature'], assignees: ['bob'] },
+    ],
+  },
+  pullRequestList: {
+    pullRequests: [
+      {
+        number: 10,
+        title: 'Main cleanup',
+        author: 'alice',
+        headRefName: 'cleanup',
+        baseRefName: 'main',
+        labels: ['chore'],
+        assignees: ['alice'],
+      },
+      {
+        number: 11,
+        title: 'Login feature',
+        author: 'bob',
+        headRefName: 'feature/login',
+        baseRefName: 'main',
+        labels: ['feature'],
+        assignees: ['bob'],
+      },
+    ],
+  },
+} as unknown as LogInkContext
+
+describe('buildFilteredLists', () => {
+  describe('empty/undefined filter returns the full lists', () => {
+    it.each([undefined, ''])('filter=%p returns every row', (filter) => {
+      const result = buildFilteredLists(context, filter)
+      expect(result.filteredBranchList).toHaveLength(2)
+      expect(result.filteredTagList).toHaveLength(2)
+      expect(result.filteredStashList).toHaveLength(2)
+      expect(result.filteredWorktreeList).toHaveLength(2)
+      expect(result.filteredReflogList).toHaveLength(2)
+      expect(result.filteredSubmoduleList).toHaveLength(2)
+      expect(result.filteredRemoteList).toHaveLength(2)
+      expect(result.filteredIssueList).toHaveLength(2)
+      expect(result.filteredPullRequestTriageList).toHaveLength(2)
+    })
+
+    it('returns the original array reference for an undefined filter', () => {
+      const result = buildFilteredLists(context, undefined)
+      // No filter => the verbatim `return all` path, not a `.filter()` copy.
+      expect(result.filteredBranchList).toBe(context.branches?.localBranches)
+      expect(result.filteredIssueList).toBe(context.issueList?.issues)
+    })
+  })
+
+  describe('an active filter narrows each list', () => {
+    const result = buildFilteredLists(context, 'login')
+
+    it('matches branches on shortName/upstream', () => {
+      expect(result.filteredBranchList.map((b) => b.shortName)).toEqual(['feature/login'])
+    })
+    it('matches tags on name/subject', () => {
+      expect(result.filteredTagList.map((t) => t.name)).toEqual(['v2.0.0'])
+    })
+    it('matches stashes on ref/message', () => {
+      expect(result.filteredStashList.map((s) => s.ref)).toEqual(['stash@{1}'])
+    })
+    it('matches worktrees on path/branch', () => {
+      expect(result.filteredWorktreeList.map((w) => w.branch)).toEqual(['feature/login'])
+    })
+    it('matches reflog on selector/hash/relativeDate/subject', () => {
+      expect(result.filteredReflogList.map((e) => e.selector)).toEqual(['HEAD@{1}'])
+    })
+    it('matches submodules on name/path/trackingBranch/url', () => {
+      expect(result.filteredSubmoduleList.map((e) => e.name)).toEqual(['libbar'])
+    })
+    it('matches remotes on name/fetchUrl/pushUrl', () => {
+      expect(result.filteredRemoteList.map((e) => e.name)).toEqual(['fork'])
+    })
+    it('matches issues across the multi-field array (title/labels/assignees)', () => {
+      expect(result.filteredIssueList.map((i) => i.number)).toEqual([2])
+    })
+    it('matches PRs across the multi-field array (head/base/labels/assignees)', () => {
+      expect(result.filteredPullRequestTriageList.map((p) => p.number)).toEqual([11])
+    })
+
+    it('matches issues by label even when title/author miss', () => {
+      // "feature" only appears in issue #2's labels — proves the spread
+      // of `issue.labels` into the match array is preserved.
+      expect(buildFilteredLists(context, 'feature').filteredIssueList.map((i) => i.number)).toEqual([2])
+    })
+    it('matches PRs by issue-number token (`#11`)', () => {
+      expect(buildFilteredLists(context, '#11').filteredPullRequestTriageList.map((p) => p.number)).toEqual([11])
+    })
+  })
+
+  describe('missing context.* slices return []', () => {
+    it('returns empty arrays for every list when context is empty', () => {
+      const result = buildFilteredLists({}, undefined)
+      expect(result).toEqual({
+        filteredBranchList: [],
+        filteredTagList: [],
+        filteredStashList: [],
+        filteredWorktreeList: [],
+        filteredReflogList: [],
+        filteredSubmoduleList: [],
+        filteredRemoteList: [],
+        filteredIssueList: [],
+        filteredPullRequestTriageList: [],
+      })
+    })
+
+    it('returns [] for missing slices even with an active filter', () => {
+      const result = buildFilteredLists({}, 'anything')
+      expect(result.filteredBranchList).toEqual([])
+      expect(result.filteredPullRequestTriageList).toEqual([])
+    })
+  })
+})

--- a/src/workstation/runtime/hooks/buildFilteredLists.ts
+++ b/src/workstation/runtime/hooks/buildFilteredLists.ts
@@ -1,0 +1,227 @@
+/**
+ * Filtered promoted-view lists (#808, extracted in 0.72 app.ts
+ * decomposition).
+ *
+ * Each promoted surface (branches, tags, stashes, worktrees, reflog,
+ * submodules, remotes, issues, PR triage) renders `context.<list>`
+ * narrowed by the live `state.filter`. These derivations used to live as
+ * nine inline `useMemo`s in `app.ts`; they were recomputed inside
+ * `useInput` on every keystroke before #808 memoized them, and have now
+ * been lifted out of the component entirely into this pure core plus a
+ * thin hook so `app.ts` stops carrying the per-list filter logic.
+ *
+ * The filter predicate (`matchesPromotedFilter`) and the per-surface
+ * match-field arrays are reproduced verbatim from the original memos —
+ * this is a behavior-preserving move, not a rewrite.
+ */
+
+import type * as ReactTypes from 'react'
+import type { LogInkContext } from '../types'
+import { matchesPromotedFilter } from '../promotedFilter'
+
+// Element types are derived from `LogInkContext` via indexed access so
+// they track the real overview shapes (BranchRef, GitTagRef, StashEntry,
+// WorktreeEntry, ReflogViewEntry, SubmoduleEntry, RemoteEntry,
+// IssueListItem, PullRequestListItem) without re-importing each one and
+// risking drift.
+type BranchListItem = NonNullable<LogInkContext['branches']>['localBranches'][number]
+type TagListItem = NonNullable<LogInkContext['tags']>['tags'][number]
+type StashListItem = NonNullable<LogInkContext['stashes']>['stashes'][number]
+type WorktreeListItem = NonNullable<LogInkContext['worktreeList']>['worktrees'][number]
+type ReflogListItem = NonNullable<LogInkContext['reflog']>['entries'][number]
+type SubmoduleListItem = NonNullable<LogInkContext['submodules']>['entries'][number]
+type RemoteListItem = NonNullable<LogInkContext['remotes']>['entries'][number]
+type IssueListItemType = NonNullable<NonNullable<LogInkContext['issueList']>['issues']>[number]
+type PullRequestListItemType =
+  NonNullable<NonNullable<LogInkContext['pullRequestList']>['pullRequests']>[number]
+
+export type FilteredLists = {
+  filteredBranchList: BranchListItem[]
+  filteredTagList: TagListItem[]
+  filteredStashList: StashListItem[]
+  filteredWorktreeList: WorktreeListItem[]
+  filteredReflogList: ReflogListItem[]
+  filteredSubmoduleList: SubmoduleListItem[]
+  filteredRemoteList: RemoteListItem[]
+  filteredIssueList: IssueListItemType[]
+  filteredPullRequestTriageList: PullRequestListItemType[]
+}
+
+/**
+ * Pure derivation of every filtered promoted-view list from the loaded
+ * `context` and the active `filter`. A missing `context.*` slice yields
+ * `[]`; an empty/undefined filter returns the full list. The filter
+ * logic — including the multi-field match arrays for issues and PRs — is
+ * lifted verbatim from the original `app.ts` memos.
+ */
+export function buildFilteredLists(
+  context: LogInkContext,
+  filter: string | undefined,
+): FilteredLists {
+  const filteredBranchList = (() => {
+    const all = context.branches?.localBranches || []
+    if (!filter) return all
+    return all.filter((branch) =>
+      matchesPromotedFilter([branch.shortName, branch.upstream || ''], filter)
+    )
+  })()
+  const filteredTagList = (() => {
+    const all = context.tags?.tags || []
+    if (!filter) return all
+    return all.filter((tag) =>
+      matchesPromotedFilter([tag.name, tag.subject], filter)
+    )
+  })()
+  const filteredStashList = (() => {
+    const all = context.stashes?.stashes || []
+    if (!filter) return all
+    return all.filter((stash) =>
+      matchesPromotedFilter([stash.ref, stash.message], filter)
+    )
+  })()
+  const filteredWorktreeList = (() => {
+    const all = context.worktreeList?.worktrees || []
+    if (!filter) return all
+    return all.filter((entry) =>
+      matchesPromotedFilter([entry.path, entry.branch || ''], filter)
+    )
+  })()
+  const filteredReflogList = (() => {
+    const all = context.reflog?.entries || []
+    if (!filter) return all
+    return all.filter((entry) =>
+      matchesPromotedFilter(
+        [entry.selector, entry.hash, entry.relativeDate, entry.subject],
+        filter
+      )
+    )
+  })()
+  const filteredSubmoduleList = (() => {
+    const all = context.submodules?.entries || []
+    if (!filter) return all
+    return all.filter((entry) =>
+      matchesPromotedFilter(
+        [entry.name, entry.path, entry.trackingBranch || '', entry.url || ''],
+        filter,
+      )
+    )
+  })()
+  const filteredRemoteList = (() => {
+    const all = context.remotes?.entries || []
+    if (!filter) return all
+    return all.filter((entry) =>
+      matchesPromotedFilter([entry.name, entry.fetchUrl, entry.pushUrl], filter)
+    )
+  })()
+  const filteredIssueList = (() => {
+    const all = context.issueList?.issues || []
+    if (!filter) return all
+    return all.filter((issue) =>
+      matchesPromotedFilter(
+        [
+          `#${issue.number}`,
+          issue.title,
+          issue.author || '',
+          ...(issue.labels || []),
+          ...(issue.assignees || []),
+        ],
+        filter,
+      )
+    )
+  })()
+  const filteredPullRequestTriageList = (() => {
+    const all = context.pullRequestList?.pullRequests || []
+    if (!filter) return all
+    return all.filter((pr) =>
+      matchesPromotedFilter(
+        [
+          `#${pr.number}`,
+          pr.title,
+          pr.author || '',
+          pr.headRefName,
+          pr.baseRefName,
+          ...(pr.labels || []),
+          ...(pr.assignees || []),
+        ],
+        filter,
+      )
+    )
+  })()
+
+  return {
+    filteredBranchList,
+    filteredTagList,
+    filteredStashList,
+    filteredWorktreeList,
+    filteredReflogList,
+    filteredSubmoduleList,
+    filteredRemoteList,
+    filteredIssueList,
+    filteredPullRequestTriageList,
+  }
+}
+
+/**
+ * Thin hook wrapper. Issues one `React.useMemo` per list — preserving the
+ * exact hook call-order and per-list dependency arrays of the original
+ * `app.ts` memos so React's hook ordering and reference-identity
+ * semantics are unchanged. Each memo delegates to `buildFilteredLists`
+ * (recomputing only its own list) and returns the destructurable bundle.
+ *
+ * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
+ * convention) because the workstation never statically imports React.
+ */
+export function useFilteredLists(
+  React: typeof ReactTypes,
+  context: LogInkContext,
+  filter: string | undefined,
+): FilteredLists {
+  const filteredBranchList = React.useMemo(
+    () => buildFilteredLists(context, filter).filteredBranchList,
+    [context.branches?.localBranches, filter]
+  )
+  const filteredTagList = React.useMemo(
+    () => buildFilteredLists(context, filter).filteredTagList,
+    [context.tags?.tags, filter]
+  )
+  const filteredStashList = React.useMemo(
+    () => buildFilteredLists(context, filter).filteredStashList,
+    [context.stashes?.stashes, filter]
+  )
+  const filteredWorktreeList = React.useMemo(
+    () => buildFilteredLists(context, filter).filteredWorktreeList,
+    [context.worktreeList?.worktrees, filter]
+  )
+  const filteredReflogList = React.useMemo(
+    () => buildFilteredLists(context, filter).filteredReflogList,
+    [context.reflog?.entries, filter]
+  )
+  const filteredSubmoduleList = React.useMemo(
+    () => buildFilteredLists(context, filter).filteredSubmoduleList,
+    [context.submodules?.entries, filter]
+  )
+  const filteredRemoteList = React.useMemo(
+    () => buildFilteredLists(context, filter).filteredRemoteList,
+    [context.remotes?.entries, filter]
+  )
+  const filteredIssueList = React.useMemo(
+    () => buildFilteredLists(context, filter).filteredIssueList,
+    [context.issueList?.issues, filter]
+  )
+  const filteredPullRequestTriageList = React.useMemo(
+    () => buildFilteredLists(context, filter).filteredPullRequestTriageList,
+    [context.pullRequestList?.pullRequests, filter]
+  )
+
+  return {
+    filteredBranchList,
+    filteredTagList,
+    filteredStashList,
+    filteredWorktreeList,
+    filteredReflogList,
+    filteredSubmoduleList,
+    filteredRemoteList,
+    filteredIssueList,
+    filteredPullRequestTriageList,
+  }
+}


### PR DESCRIPTION
First PR of the 0.72 "finish app.ts decomposition" work. Behavior-preserving refactor of the TUI runtime.

## What moved
The nine inline `filtered*List` `useMemo`s in `src/workstation/runtime/app.ts` (#808 / #882 cluster — `filteredBranchList`, `filteredTagList`, `filteredStashList`, `filteredWorktreeList`, `filteredReflogList`, `filteredSubmoduleList`, `filteredRemoteList`, `filteredIssueList`, `filteredPullRequestTriageList`) are lifted out into a new `src/workstation/runtime/hooks/buildFilteredLists.ts`:

- **Pure core** — `buildFilteredLists(context, filter): FilteredLists` returns all nine filtered arrays. The filter predicate (`matchesPromotedFilter`) and the per-surface match-field arrays — including the multi-field arrays for issues and PR triage — are reproduced **verbatim**. Missing `context.*` slice → `[]`; empty/undefined filter returns the full list (same `return all` reference-identity as before).
- **Thin hook** — `useFilteredLists(React, context, filter)`. `React` is injected per the runtime's `getLogInkRuntimeContext(React)` convention (the workstation never statically imports React).

In `app.ts`, at the same position the memos occupied, they're replaced by a single destructuring `useFilteredLists(React, context, state.filter)` call. Every downstream consumer (input handler, cursor-sync) destructures the same names, untouched. The separate cursor-sync re-filtering logic is out of scope and untouched.

## Per-list memos (not a single memo)
The hook issues **one `React.useMemo` per list**, in the same order and with the same per-list dependency arrays the original memos used. This preserves React's hook call-order **and** per-list reference identity exactly — downstream consumers that re-run only when their specific list changes keep that granularity. (`FilteredLists` element types are derived from `LogInkContext` via indexed-access types so they track the real overview shapes — `BranchRef`, `GitTagRef`, `StashEntry`, `WorktreeEntry`, `ReflogViewEntry`, `SubmoduleEntry`, `RemoteEntry`, `IssueListItem`, `PullRequestListItem` — without drift.)

## app.ts reduction
- Net **−73 lines** (92 deletions, 19 insertions).
- `React.useMemo` count in app.ts drops from 17 → **8** (the 9 filtered-list memos removed).

## Tests
- New `buildFilteredLists.test.ts` unit-tests the pure core with hand-built `context` fixtures (mirroring `cursorSyncResolver.test.ts`, no React harness): empty/undefined filter returns full lists (and the original array reference), an active filter narrows each list, multi-field matching for issues/PRs (by label, by `#number` token), and missing `context.*` → `[]`.
- Full suite green: 267 suites / 3400 tests passing, lint + tsc-via-rollup build + cli smoke + pack all pass.

Behavior-preserving — no predicate or match-field array was changed.