### PR TITLE
refactor(workstation): extract status-surface data into useStatusSurfaceData (0.72 app.ts decomposition)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -196,7 +196,6 @@ import {
     getStashCommitHashes,
     getStashDiff,
     getStashOverview,
-    parseStashDiffFiles,
 } from '../../git/stashData'
 import {
     revertFile,
@@ -209,9 +208,7 @@ import {
 } from '../../git/statusActions'
 import {
     applyStatusFilterMask,
-    flattenWorktreeGroups,
     getWorktreeOverview,
-    groupWorktreeFiles,
 } from '../../git/statusData'
 import {
     WorktreeHunkOverview,
@@ -351,6 +348,7 @@ import type { LogArgv } from '../../commands/log/config'
 // LogInkState filter-mode shape.
 import { matchesPromotedFilter } from '../runtime/promotedFilter'
 import { useFilteredLists } from './hooks/buildFilteredLists'
+import { useStatusSurfaceData } from './hooks/buildStatusSurfaceData'
 import {
     buildLoadedHashSet,
     resolveCursorSyncDecision,
@@ -844,43 +842,39 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
 
   const selected = getSelectedInkCommit(state)
   const selectedDetailFile = detail?.files[state.selectedFileIndex]
-  // Status surface visibility mask (#776). `visibleWorktreeFiles` is the
-  // single source of truth for staged/unstaged/untracked filtering: file
-  // count, selected-file resolution, and the rendered list all key off
-  // it so toggles never desync the cursor from the rendered rows.
-  const visibleWorktreeFiles = React.useMemo(
-    () => applyStatusFilterMask(context.worktree?.files || [], state.statusFilterMask),
-    [context.worktree?.files, state.statusFilterMask]
-  )
-  // Sectioned view of the visible files (#791 follow-up). Drives the
-  // status surface's three-tier cursor model: ←/→ jumps between
-  // groups, ↑ at index 0 promotes to the group header, Enter on the
-  // header fires the group's batch action. The renderer also consumes
-  // this so the visible file list stays in canonical group order
-  // regardless of whatever order `git status --porcelain` happens to
-  // emit.
-  const visibleWorktreeGroups = React.useMemo(
-    () => groupWorktreeFiles(visibleWorktreeFiles),
-    [visibleWorktreeFiles]
-  )
-  const visibleWorktreeFilesGrouped = React.useMemo(
-    () => flattenWorktreeGroups(visibleWorktreeGroups),
-    [visibleWorktreeGroups]
-  )
-  const selectedWorktreeFile = visibleWorktreeFilesGrouped[state.selectedWorktreeFileIndex]
-
-  // Stash patch per-file segmentation (#808). Hoisted out of the
-  // useInput callback (was running on every keystroke), the yank
-  // handler (was running per `y` press), and renderDiffSurface (was
-  // running per paint) into a single LogInkApp-scoped memo. When the
-  // active stash diff has hundreds of files, the prior fan-out was
-  // re-walking the entire patch text 2-3x per keystroke for no
-  // observable reason — the parsed list is purely a function of the
-  // line array, which only changes when the user opens a different
-  // stash.
-  const stashDiffParsedFiles = React.useMemo(
-    () => stashDiffLines ? parseStashDiffFiles(stashDiffLines) : [],
-    [stashDiffLines]
+  // Status-surface derived data (#776 / #791 / #808). Extracted into
+  // `useStatusSurfaceData` (0.72 app.ts decomposition). The hook issues
+  // one `React.useMemo` per value in the same order — and with the same
+  // per-value dependency arrays — these memos used to, delegating to the
+  // pure `buildStatusSurfaceData` core. Hook call-order and per-value
+  // reference identity are unchanged:
+  // `visibleWorktreeFiles` is the single source of truth for
+  // staged/unstaged/untracked filtering and feeds the grouping below; it
+  // stays internal to the hook (no direct consumer in app.ts), so only
+  // the values app.ts reads are destructured:
+  //  - `visibleWorktreeGroups` / `visibleWorktreeFilesGrouped` drive the
+  //    status surface's three-tier cursor model and keep the rendered
+  //    list in canonical group order regardless of the order
+  //    `git status --porcelain` emits.
+  //  - `selectedWorktreeFile` keeps a dedicated memo (deps
+  //    `[visibleWorktreeFilesGrouped, selectedWorktreeFileIndex]`) so an
+  //    unchanged selection yields a stable reference — it feeds the
+  //    worktree-diff and worktree-hunks effects below via its `.path` /
+  //    `.indexStatus` / `.worktreeStatus`.
+  //  - `stashDiffParsedFiles` is the per-file segmentation of the active
+  //    stash patch (hoisted out of useInput / the yank handler /
+  //    renderDiffSurface, all of which used to re-walk the patch text).
+  const {
+    visibleWorktreeGroups,
+    visibleWorktreeFilesGrouped,
+    selectedWorktreeFile,
+    stashDiffParsedFiles,
+  } = useStatusSurfaceData(
+    React,
+    context.worktree?.files,
+    state.statusFilterMask,
+    state.selectedWorktreeFileIndex,
+    stashDiffLines,
   )
 
   // Filtered promoted-view lists (#808). These were recomputed inline

--- a/src/workstation/runtime/hooks/buildStatusSurfaceData.test.ts
+++ b/src/workstation/runtime/hooks/buildStatusSurfaceData.test.ts
@@ -1,0 +1,142 @@
+import { buildStatusSurfaceData } from './buildStatusSurfaceData'
+import type { WorktreeFile, WorktreeFileVisibilityMask } from '../../../git/statusData'
+
+/**
+ * Unit tests for the pure `buildStatusSurfaceData` core (0.72 app.ts
+ * decomposition). No React harness — the hook (`useStatusSurfaceData`) is
+ * a thin per-value `useMemo` wrapper, so testing the pure derivation
+ * exercises all the status-surface behavior lifted verbatim out of
+ * app.ts. Mirrors `buildFilteredLists.test.ts`.
+ */
+
+const ALL_VISIBLE: WorktreeFileVisibilityMask = {
+  staged: true,
+  unstaged: true,
+  untracked: true,
+}
+
+function file(path: string, state: WorktreeFile['state']): WorktreeFile {
+  // indexStatus / worktreeStatus only need to be plausible — the
+  // derivations key off `state` (mask + grouping) and `path` (identity).
+  const indexStatus = state === 'staged' ? 'M' : state === 'untracked' ? '?' : ' '
+  const worktreeStatus = state === 'unstaged' ? 'M' : state === 'untracked' ? '?' : ' '
+  return { path, indexStatus, worktreeStatus, state }
+}
+
+// Deliberately out of canonical order (untracked before staged) so the
+// grouping/flattening reordering is observable.
+const files: WorktreeFile[] = [
+  file('c.txt', 'untracked'),
+  file('a.txt', 'staged'),
+  file('b.txt', 'unstaged'),
+  file('d.txt', 'staged'),
+]
+
+describe('buildStatusSurfaceData', () => {
+  describe('the visibility mask narrows the worktree files', () => {
+    it('returns every file when the mask is all-on', () => {
+      const result = buildStatusSurfaceData(files, ALL_VISIBLE, 0, undefined)
+      expect(result.visibleWorktreeFiles).toHaveLength(4)
+    })
+
+    it('drops files whose state is masked off', () => {
+      const result = buildStatusSurfaceData(
+        files,
+        { staged: true, unstaged: false, untracked: false },
+        0,
+        undefined,
+      )
+      expect(result.visibleWorktreeFiles.map((f) => f.path)).toEqual(['a.txt', 'd.txt'])
+    })
+  })
+
+  describe('grouping + flattening shapes', () => {
+    it('emits groups in canonical staged -> unstaged -> untracked order', () => {
+      const result = buildStatusSurfaceData(files, ALL_VISIBLE, 0, undefined)
+      expect(result.visibleWorktreeGroups.map((g) => g.state)).toEqual([
+        'staged',
+        'unstaged',
+        'untracked',
+      ])
+    })
+
+    it('records each group startIndex against the flattened list', () => {
+      const result = buildStatusSurfaceData(files, ALL_VISIBLE, 0, undefined)
+      expect(result.visibleWorktreeGroups.map((g) => g.startIndex)).toEqual([0, 2, 3])
+    })
+
+    it('flattens into canonical order regardless of input order', () => {
+      const result = buildStatusSurfaceData(files, ALL_VISIBLE, 0, undefined)
+      expect(result.visibleWorktreeFilesGrouped.map((f) => f.path)).toEqual([
+        'a.txt',
+        'd.txt',
+        'b.txt',
+        'c.txt',
+      ])
+    })
+  })
+
+  describe('selectedWorktreeFile resolves by index into the flattened list', () => {
+    it('resolves the file at the canonical index', () => {
+      // Flattened order is [a, d, b, c] — index 2 is the unstaged file.
+      const result = buildStatusSurfaceData(files, ALL_VISIBLE, 2, undefined)
+      expect(result.selectedWorktreeFile?.path).toBe('b.txt')
+    })
+
+    it('yields undefined for an out-of-range index', () => {
+      const result = buildStatusSurfaceData(files, ALL_VISIBLE, 99, undefined)
+      expect(result.selectedWorktreeFile).toBeUndefined()
+    })
+
+    it('resolves against the *visible* (masked) flattened list, not the raw files', () => {
+      // Only staged files visible => flattened [a, d]; index 1 is d.txt.
+      const result = buildStatusSurfaceData(
+        files,
+        { staged: true, unstaged: false, untracked: false },
+        1,
+        undefined,
+      )
+      expect(result.selectedWorktreeFile?.path).toBe('d.txt')
+    })
+  })
+
+  describe('stashDiffParsedFiles segments the active stash patch', () => {
+    it('parses per-file sections from the patch lines', () => {
+      const lines = [
+        'diff --git a/foo.ts b/foo.ts',
+        '@@ -1 +1 @@',
+        '-old',
+        '+new',
+        'diff --git a/bar.ts b/bar.ts',
+        '@@ -1 +1 @@',
+        '-x',
+        '+y',
+      ]
+      const result = buildStatusSurfaceData(files, ALL_VISIBLE, 0, lines)
+      expect(result.stashDiffParsedFiles.map((f) => f.path)).toEqual(['foo.ts', 'bar.ts'])
+      expect(result.stashDiffParsedFiles.map((f) => f.startLine)).toEqual([0, 4])
+    })
+
+    it('returns [] when no stash diff is loaded', () => {
+      const result = buildStatusSurfaceData(files, ALL_VISIBLE, 0, undefined)
+      expect(result.stashDiffParsedFiles).toEqual([])
+    })
+  })
+
+  describe('empty / undefined inputs yield safe empties', () => {
+    it('undefined worktree files => empty derivations', () => {
+      const result = buildStatusSurfaceData(undefined, ALL_VISIBLE, 0, undefined)
+      expect(result.visibleWorktreeFiles).toEqual([])
+      expect(result.visibleWorktreeGroups).toEqual([])
+      expect(result.visibleWorktreeFilesGrouped).toEqual([])
+      expect(result.selectedWorktreeFile).toBeUndefined()
+      expect(result.stashDiffParsedFiles).toEqual([])
+    })
+
+    it('empty file list => no groups and no selection', () => {
+      const result = buildStatusSurfaceData([], ALL_VISIBLE, 0, undefined)
+      expect(result.visibleWorktreeGroups).toEqual([])
+      expect(result.selectedWorktreeFile).toBeUndefined()
+    })
+  })
+})

--- a/src/workstation/runtime/hooks/buildStatusSurfaceData.ts
+++ b/src/workstation/runtime/hooks/buildStatusSurfaceData.ts
@@ -1,0 +1,130 @@
+/**
+ * Status-surface derived data (#776 / #791 / #808, extracted in the 0.72
+ * app.ts decomposition).
+ *
+ * The status surface renders the worktree file list narrowed by the live
+ * `statusFilterMask`, grouped/flattened into canonical staged → unstaged
+ * → untracked order, plus the per-file segmentation of the active stash
+ * diff. These derivations used to live as a cluster of inline `useMemo`s
+ * in `app.ts`; they have been lifted out of the component into this pure
+ * core plus a thin hook so `app.ts` stops carrying the status-surface
+ * derivation logic.
+ *
+ * Every derivation here is reproduced verbatim from the original memos —
+ * same helper calls (`applyStatusFilterMask`, `groupWorktreeFiles`,
+ * `flattenWorktreeGroups`, `parseStashDiffFiles`), same arguments. This
+ * is a behavior-preserving move, not a rewrite.
+ */
+
+import type * as ReactTypes from 'react'
+import {
+  applyStatusFilterMask,
+  flattenWorktreeGroups,
+  groupWorktreeFiles,
+  type WorktreeFile,
+  type WorktreeFileGroup,
+  type WorktreeFileVisibilityMask,
+} from '../../../git/statusData'
+import { parseStashDiffFiles, type StashDiffFile } from '../../../git/stashData'
+
+export type StatusSurfaceData = {
+  visibleWorktreeFiles: WorktreeFile[]
+  visibleWorktreeGroups: WorktreeFileGroup[]
+  visibleWorktreeFilesGrouped: WorktreeFile[]
+  selectedWorktreeFile: WorktreeFile | undefined
+  stashDiffParsedFiles: StashDiffFile[]
+}
+
+/**
+ * Pure derivation of the status surface's derived data from the loaded
+ * worktree files, the active visibility mask, the canonical selected
+ * file index, and the active stash diff lines.
+ *
+ * - `visibleWorktreeFiles` is the single source of truth for
+ *   staged/unstaged/untracked filtering — `applyStatusFilterMask` on the
+ *   raw `context.worktree?.files`.
+ * - `visibleWorktreeGroups` / `visibleWorktreeFilesGrouped` are the
+ *   sectioned and re-flattened (canonical-order) views the renderer and
+ *   the three-tier cursor model both key off.
+ * - `selectedWorktreeFile` resolves by `selectedWorktreeFileIndex` into
+ *   the flattened list (an out-of-range index yields `undefined`).
+ * - `stashDiffParsedFiles` is the per-file segmentation of the active
+ *   stash patch (empty when no stash diff is loaded).
+ *
+ * The helper calls and predicates are lifted verbatim from the original
+ * `app.ts` memos.
+ */
+export function buildStatusSurfaceData(
+  worktreeFiles: WorktreeFile[] | undefined,
+  statusFilterMask: WorktreeFileVisibilityMask,
+  selectedWorktreeFileIndex: number,
+  stashDiffLines: string[] | undefined,
+): StatusSurfaceData {
+  const visibleWorktreeFiles = applyStatusFilterMask(worktreeFiles || [], statusFilterMask)
+  const visibleWorktreeGroups = groupWorktreeFiles(visibleWorktreeFiles)
+  const visibleWorktreeFilesGrouped = flattenWorktreeGroups(visibleWorktreeGroups)
+  const selectedWorktreeFile = visibleWorktreeFilesGrouped[selectedWorktreeFileIndex]
+  const stashDiffParsedFiles = stashDiffLines ? parseStashDiffFiles(stashDiffLines) : []
+
+  return {
+    visibleWorktreeFiles,
+    visibleWorktreeGroups,
+    visibleWorktreeFilesGrouped,
+    selectedWorktreeFile,
+    stashDiffParsedFiles,
+  }
+}
+
+/**
+ * Thin hook wrapper. Issues one `React.useMemo` per derived value —
+ * preserving the exact hook call-order and per-value dependency arrays of
+ * the original `app.ts` memos, so React's hook ordering and
+ * reference-identity semantics are unchanged.
+ *
+ * `selectedWorktreeFile` keeps a dedicated memo with the same dep array
+ * the original code used (`visibleWorktreeFilesGrouped` +
+ * `selectedWorktreeFileIndex`): it feeds the worktree-diff and
+ * worktree-hunks effects elsewhere in `app.ts` via its `.path` /
+ * `.indexStatus` / `.worktreeStatus`, so an unchanged selection must
+ * yield a stable reference rather than fold into a larger memo that would
+ * churn on unrelated input changes.
+ *
+ * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
+ * convention) because the workstation never statically imports React.
+ */
+export function useStatusSurfaceData(
+  React: typeof ReactTypes,
+  worktreeFiles: WorktreeFile[] | undefined,
+  statusFilterMask: WorktreeFileVisibilityMask,
+  selectedWorktreeFileIndex: number,
+  stashDiffLines: string[] | undefined,
+): StatusSurfaceData {
+  const visibleWorktreeFiles = React.useMemo(
+    () => applyStatusFilterMask(worktreeFiles || [], statusFilterMask),
+    [worktreeFiles, statusFilterMask]
+  )
+  const visibleWorktreeGroups = React.useMemo(
+    () => groupWorktreeFiles(visibleWorktreeFiles),
+    [visibleWorktreeFiles]
+  )
+  const visibleWorktreeFilesGrouped = React.useMemo(
+    () => flattenWorktreeGroups(visibleWorktreeGroups),
+    [visibleWorktreeGroups]
+  )
+  const selectedWorktreeFile = React.useMemo(
+    () => visibleWorktreeFilesGrouped[selectedWorktreeFileIndex],
+    [visibleWorktreeFilesGrouped, selectedWorktreeFileIndex]
+  )
+  const stashDiffParsedFiles = React.useMemo(
+    () => stashDiffLines ? parseStashDiffFiles(stashDiffLines) : [],
+    [stashDiffLines]
+  )
+
+  return {
+    visibleWorktreeFiles,
+    visibleWorktreeGroups,
+    visibleWorktreeFilesGrouped,
+    selectedWorktreeFile,
+    stashDiffParsedFiles,
+  }
+}


### PR DESCRIPTION
## What

PR 2 of the 0.72 "finish app.ts decomposition" effort. Lifts the status-surface derived-data cluster out of `src/workstation/runtime/app.ts` into a new `useStatusSurfaceData` hook backed by a pure `buildStatusSurfaceData` core — the same pure-fn + thin-`React.useMemo`-wrapper pattern established by `useFilteredLists` (PR 1, #1216).

### What moved

The five status-surface derivations (previously inline in app.ts):
- `visibleWorktreeFiles` — `applyStatusFilterMask(worktree.files, statusFilterMask)`
- `visibleWorktreeGroups` — `groupWorktreeFiles(...)`
- `visibleWorktreeFilesGrouped` — `flattenWorktreeGroups(...)`
- `selectedWorktreeFile` — flattened list indexed by `selectedWorktreeFileIndex`
- `stashDiffParsedFiles` — `parseStashDiffFiles(stashDiffLines)`

All helper calls and arguments are reproduced verbatim — behavior-preserving move, not a rewrite.

### app.ts reduction

- `useMemo` count in app.ts: **8 → 5** (4 status-surface memos removed; the cluster collapses to one `useStatusSurfaceData(React, …)` call at the same position).
- net **−6 lines** in app.ts; three now-unused helper imports (`flattenWorktreeGroups`, `groupWorktreeFiles`, `parseStashDiffFiles`) dropped (`applyStatusFilterMask` stays — still used by the status-toggle handlers). `visibleWorktreeFiles` is now an internal-to-the-hook intermediate (no app.ts consumer) so it is intentionally not destructured.

### Hook inputs

`useStatusSurfaceData(React, context.worktree?.files, state.statusFilterMask, state.selectedWorktreeFileIndex, stashDiffLines)`.

### Identity preservation (critical)

`selectedWorktreeFile` keeps a **dedicated `useMemo`** with dep array `[visibleWorktreeFilesGrouped, selectedWorktreeFileIndex]`, so an unchanged selection yields a stable reference. It feeds the worktree-diff and worktree-hunks effects elsewhere in app.ts via its `.path` / `.indexStatus` / `.worktreeStatus` deps — folding it into a mega-memo would churn identity on unrelated input changes. Hook call-order and every per-value dep array match the original memos exactly.

### Tests

New `buildStatusSurfaceData.test.ts` unit-tests the pure core: mask narrowing, canonical grouping/flattening order + `startIndex`, `selectedWorktreeFile` resolution by index against the *visible* list + out-of-range → `undefined`, stash-patch segmentation, and empty/undefined-input safe empties.

Full suite green (lint + jest + build + cli + pack): 268 suites / 3412 tests passing.