### PR TITLE
refactor(workstation): extract repo-root + view-mode persistence hooks (0.72 app.ts decomposition)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -109,8 +109,6 @@ import {
     type RepoFrameRuntime,
     type RepoStackRuntimes,
 } from './repoStackRuntime'
-import { getSavedDiffViewMode, saveDiffViewMode } from '../chrome/diffViewModePersistence'
-import { getSavedSidebarTab, saveSidebarTab } from '../chrome/sidebarPersistence'
 import {
     PromotedSelectionsSnapshot,
     rectifyPromotedSelectionIndex,
@@ -347,6 +345,7 @@ import type { LogArgv } from '../../commands/log/config'
 import { matchesPromotedFilter } from '../runtime/promotedFilter'
 import { useFilteredLists } from './hooks/buildFilteredLists'
 import { useIdleTip } from './hooks/useIdleTip'
+import { useActiveRepoRoot, useViewModePersistence } from './hooks/useRepoPersistence'
 import { useSpinnerFrame } from './hooks/useSpinnerFrame'
 import { useStatusSurfaceData } from './hooks/buildStatusSurfaceData'
 import { useStatusAutoDismiss } from './hooks/useStatusAutoDismiss'
@@ -712,25 +711,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // and skips its write. The `git` reference itself is captured by
   // closure, so each effect run resolves against the right binding.
   // No additional depth tagging is needed.
-  const [activeRepoRoot, setActiveRepoRoot] = React.useState<string | undefined>(undefined)
-  React.useEffect(() => {
-    let cancelled = false
-    void (async () => {
-      try {
-        const root = (await git.revparse(['--show-toplevel'])).trim()
-        if (!cancelled && root) {
-          setActiveRepoRoot(root)
-        }
-      } catch {
-        if (!cancelled) {
-          setActiveRepoRoot(undefined)
-        }
-      }
-    })()
-    return () => {
-      cancelled = true
-    }
-  }, [git])
+  const activeRepoRoot = useActiveRepoRoot(React, git)
   const [detail, setDetail] = React.useState<GitCommitDetail | undefined>(undefined)
   const [detailLoading, setDetailLoading] = React.useState(false)
   const [filePreview, setFilePreview] = React.useState<GitCommitFilePreview | undefined>(undefined)
@@ -1087,72 +1068,13 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // Branches when entering compose / status doesn't overwrite the saved
   // preference.
   const repoRootRef = React.useRef<string | undefined>(undefined)
-  React.useEffect(() => {
-    let cancelled = false
-    void (async () => {
-      try {
-        const repoRoot = (await git.revparse(['--show-toplevel'])).trim()
-        if (cancelled || !repoRoot) return
-        repoRootRef.current = repoRoot
-        const saved = getSavedSidebarTab(repoRoot)
-        if (saved && saved !== state.userSidebarTab) {
-          dispatch({ type: 'restoreSidebarTab', value: saved })
-        }
-        // Diff view mode persistence (#785). Same per-repo cache pattern
-        // as the sidebar tab — restore the user's last preference if
-        // they had one. New repos / fresh installs default to unified.
-        const savedDiffMode = getSavedDiffViewMode(repoRoot)
-        if (savedDiffMode && savedDiffMode !== state.diffViewMode) {
-          dispatch({ type: 'setDiffViewMode', value: savedDiffMode })
-        }
-      } catch {
-        // Not in a worktree, or revparse failed; nothing to restore.
-      }
-    })()
-    return () => { cancelled = true }
-  }, [git, dispatch])
-
-  // Audit finding #2: re-resolve the repo root inline on every save
-  // and key the deps off `git` + the saved value. The original
-  // implementation read from `repoRootRef.current`, which is async-
-  // populated by the resolver effect above and can lag behind a git
-  // swap. After #995's synchronous pop-restore, the parent's freshly
-  // restored sidebar tab was being written into the submodule's
-  // cache because the ref still held the submodule root during the
-  // brief window before the resolver settled.
-  //
-  // The extra `revparse` cost per save is negligible (saves fire
-  // once per user-initiated tab change, not per render) and the
-  // cancellation flag prevents a stale resolution from racing a
-  // newer one in flight.
-  React.useEffect(() => {
-    let cancelled = false
-    void (async () => {
-      try {
-        const root = (await git.revparse(['--show-toplevel'])).trim()
-        if (cancelled || !root) return
-        saveSidebarTab(root, state.userSidebarTab)
-      } catch {
-        // Not in a worktree, or revparse failed — silently skip.
-        // The next save attempt will retry.
-      }
-    })()
-    return () => { cancelled = true }
-  }, [state.userSidebarTab, git])
-
-  React.useEffect(() => {
-    let cancelled = false
-    void (async () => {
-      try {
-        const root = (await git.revparse(['--show-toplevel'])).trim()
-        if (cancelled || !root) return
-        saveDiffViewMode(root, state.diffViewMode)
-      } catch {
-        // Same as above.
-      }
-    })()
-    return () => { cancelled = true }
-  }, [state.diffViewMode, git])
+  useViewModePersistence(React, {
+    git,
+    dispatch,
+    repoRootRef,
+    userSidebarTab: state.userSidebarTab,
+    diffViewMode: state.diffViewMode,
+  })
 
   // P-stash-explorer: load `git stash show -p <ref>` once the diff view
   // becomes active with diffSource='stash'. Best-effort — empty stashes

--- a/src/workstation/runtime/hooks/useRepoPersistence.ts
+++ b/src/workstation/runtime/hooks/useRepoPersistence.ts
@@ -1,0 +1,190 @@
+/**
+ * Repo-root resolution + per-repo view persistence (extracted in the 0.72
+ * app.ts decomposition).
+ *
+ * This module lifts two *non-adjacent* clusters out of `app.ts`:
+ *
+ *  - `useActiveRepoRoot` — the `activeRepoRoot` `useState` plus the effect
+ *    that resolves it via `git.revparse(['--show-toplevel'])` (#931 PR 3b).
+ *    The commit-diff drill-in helper needs an absolute workdir for the
+ *    active frame's `git`, so the root is re-resolved after every git swap.
+ *
+ *  - `useViewModePersistence` — the per-repo sidebar-tab + diff-view-mode
+ *    *restore* effect (revparse → `getSavedSidebarTab` / `getSavedDiffViewMode`
+ *    → dispatch) and the two *save* effects (`saveSidebarTab` /
+ *    `saveDiffViewMode`), each of which re-resolves the repo root inline
+ *    (Audit finding #2 — deliberately not reading the shared `repoRootRef`,
+ *    which can lag a git swap).
+ *
+ * CRITICAL — effect order. The two clusters sit ~375 lines apart in the
+ * original component, separated by many intervening effects. React fires
+ * effects in declaration order, so merging both clusters into a single
+ * hook at one call site would reorder them relative to those intervening
+ * effects. To preserve ordering exactly, this module exports *two* hooks,
+ * each called at the original cluster's position in `app.ts`:
+ *
+ *   const activeRepoRoot = useActiveRepoRoot(React, git)   // Region A (~715)
+ *   ...many other hooks/effects...
+ *   useViewModePersistence(React, { ... })                 // Region B (~1090)
+ *
+ * Within each hook the internal effects are reproduced verbatim and in the
+ * same order as the original (restore effect, then sidebar-save effect,
+ * then diff-save effect) — the `cancelled`-flag logic, the `revparse`
+ * calls, the dispatch payloads, and the dependency arrays are byte-for-byte
+ * the same. This is a behavior-preserving move, not a rewrite.
+ *
+ * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
+ * convention) because the workstation never statically imports React.
+ */
+
+import type * as ReactTypes from 'react'
+import type { SimpleGit } from 'simple-git'
+import { getSavedDiffViewMode, saveDiffViewMode } from '../../chrome/diffViewModePersistence'
+import { getSavedSidebarTab, saveSidebarTab } from '../../chrome/sidebarPersistence'
+import type { LogInkAction, LogInkDiffViewMode, LogInkSidebarTab } from '../inkViewModel'
+
+/**
+ * Region A — absolute repo root for the active frame's `git` (#931 PR 3b).
+ *
+ * Issues the `activeRepoRoot` `useState`, then the resolution `useEffect`,
+ * in the same order as the original `app.ts` cluster, preserving the
+ * effect's `[git]` dependency array and the per-effect `cancelled` flag
+ * (Audit finding #10 — rapid frame push/pop races are prevented because
+ * React fires the cleanup synchronously before the next effect body, so a
+ * pending revparse from the old `git` sees `cancelled === true` and skips
+ * its write). Returns the resolved root, `undefined` while in flight.
+ */
+export function useActiveRepoRoot(
+  React: typeof ReactTypes,
+  git: SimpleGit,
+): string | undefined {
+  const [activeRepoRoot, setActiveRepoRoot] = React.useState<string | undefined>(undefined)
+  React.useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const root = (await git.revparse(['--show-toplevel'])).trim()
+        if (!cancelled && root) {
+          setActiveRepoRoot(root)
+        }
+      } catch {
+        if (!cancelled) {
+          setActiveRepoRoot(undefined)
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [git])
+  return activeRepoRoot
+}
+
+export type UseViewModePersistenceDeps = {
+  /** The active frame's `git`. Drives both restore + save resolutions. */
+  git: SimpleGit
+  /** Reducer dispatch, used to restore the saved tab / diff mode. */
+  dispatch: (action: LogInkAction) => void
+  /**
+   * Shared repo-root ref, populated by the restore effect for the config
+   * editor's cwd fallback. Kept in `app.ts` because it is read outside this
+   * cluster; passed in so the write still lands.
+   */
+  repoRootRef: ReactTypes.MutableRefObject<string | undefined>
+  /**
+   * `state.userSidebarTab` — the user's explicit choice mirror (not the
+   * display `sidebarTab`), compared against the saved value on restore and
+   * persisted by the sidebar-save effect.
+   */
+  userSidebarTab: LogInkSidebarTab
+  /** `state.diffViewMode` — compared on restore and persisted on save. */
+  diffViewMode: LogInkDiffViewMode
+}
+
+/**
+ * Region B — per-repo sidebar-tab + diff-view-mode persistence (#785).
+ *
+ * Issues three effects in the exact order of the original `app.ts` cluster:
+ *
+ *   1. restore: revparse → write `repoRootRef` → `getSavedSidebarTab` /
+ *      `getSavedDiffViewMode` → dispatch, deps `[git, dispatch]`.
+ *   2. sidebar save: revparse → `saveSidebarTab`, deps `[userSidebarTab, git]`.
+ *   3. diff-mode save: revparse → `saveDiffViewMode`, deps `[diffViewMode, git]`.
+ *
+ * The save effects deliberately re-resolve the root inline rather than
+ * reading `repoRootRef.current` (Audit finding #2), because the ref is
+ * async-populated and can lag a git swap. That behavior is preserved
+ * verbatim — they do NOT read `repoRootRef` or a hoisted `activeRepoRoot`.
+ */
+export function useViewModePersistence(
+  React: typeof ReactTypes,
+  deps: UseViewModePersistenceDeps,
+): void {
+  const { git, dispatch, repoRootRef, userSidebarTab, diffViewMode } = deps
+  React.useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const repoRoot = (await git.revparse(['--show-toplevel'])).trim()
+        if (cancelled || !repoRoot) return
+        repoRootRef.current = repoRoot
+        const saved = getSavedSidebarTab(repoRoot)
+        if (saved && saved !== userSidebarTab) {
+          dispatch({ type: 'restoreSidebarTab', value: saved })
+        }
+        // Diff view mode persistence (#785). Same per-repo cache pattern
+        // as the sidebar tab — restore the user's last preference if
+        // they had one. New repos / fresh installs default to unified.
+        const savedDiffMode = getSavedDiffViewMode(repoRoot)
+        if (savedDiffMode && savedDiffMode !== diffViewMode) {
+          dispatch({ type: 'setDiffViewMode', value: savedDiffMode })
+        }
+      } catch {
+        // Not in a worktree, or revparse failed; nothing to restore.
+      }
+    })()
+    return () => { cancelled = true }
+  }, [git, dispatch])
+
+  // Audit finding #2: re-resolve the repo root inline on every save
+  // and key the deps off `git` + the saved value. The original
+  // implementation read from `repoRootRef.current`, which is async-
+  // populated by the resolver effect above and can lag behind a git
+  // swap. After #995's synchronous pop-restore, the parent's freshly
+  // restored sidebar tab was being written into the submodule's
+  // cache because the ref still held the submodule root during the
+  // brief window before the resolver settled.
+  //
+  // The extra `revparse` cost per save is negligible (saves fire
+  // once per user-initiated tab change, not per render) and the
+  // cancellation flag prevents a stale resolution from racing a
+  // newer one in flight.
+  React.useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const root = (await git.revparse(['--show-toplevel'])).trim()
+        if (cancelled || !root) return
+        saveSidebarTab(root, userSidebarTab)
+      } catch {
+        // Not in a worktree, or revparse failed — silently skip.
+        // The next save attempt will retry.
+      }
+    })()
+    return () => { cancelled = true }
+  }, [userSidebarTab, git])
+
+  React.useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const root = (await git.revparse(['--show-toplevel'])).trim()
+        if (cancelled || !root) return
+        saveDiffViewMode(root, diffViewMode)
+      } catch {
+        // Same as above.
+      }
+    })()
+    return () => { cancelled = true }
+  }, [diffViewMode, git])
+}


### PR DESCRIPTION
PR 6 of the 0.72 "finish app.ts decomposition" series. Behavior-preserving extraction of the repo-root resolution and per-repo view-mode persistence effects out of `src/workstation/runtime/app.ts` into a new `runtime/hooks/useRepoPersistence.ts`.

## The two-region split, and why two hooks

This cluster spans **two non-adjacent regions** of `app.ts`:

- **Region A (~715):** the `activeRepoRoot` `useState` + the effect that resolves it via `git.revparse(['--show-toplevel'])` (#931 PR 3b).
- **Region B (~1090):** the sidebar-tab + diff-view-mode **restore** effect, plus the two **save** effects (`saveSidebarTab` / `saveDiffViewMode`).

The regions are ~375 lines apart, with many unrelated effects between them. React fires effects in **declaration order**, so collapsing both clusters into a single hook called at one position would reorder them relative to those intervening effects. To keep ordering byte-identical, the module exports **two** hooks, each called at its cluster's original position:

- `useActiveRepoRoot(React, git): string | undefined` — Region A's `useState` + resolution effect, called at ~715, returns `activeRepoRoot`.
- `useViewModePersistence(React, deps)` — Region B's restore + two save effects, called at ~1090 as a void hook.

Within each hook the internal effects are preserved as **separate** `useEffect`s in the original order (restore → sidebar-save → diff-save); the `cancelled` flags, `revparse` calls, dispatch payloads, and dependency arrays (`[git]`, `[git, dispatch]`, `[userSidebarTab, git]`, `[diffViewMode, git]`) are unchanged.

## Verbatim inline re-resolve preserved

The two save effects intentionally **re-resolve the repo root inline** on each save (Audit finding #2) rather than reading the shared `repoRootRef.current` (which is async-populated and can lag a git swap). That behavior is preserved exactly — the save effects do **not** read `repoRootRef` or a hoisted `activeRepoRoot`.

## repoRootRef stays in app.ts

`repoRootRef` is consumed at the `openConfigInEditor` callback (cwd fallback) **outside** both regions, so it remains declared in `app.ts` and is passed into `useViewModePersistence`; the restore effect still writes `repoRootRef.current` through the passed-in ref.

## app.ts effect reduction

- Region A: `useState` + 1 `useEffect` → 1 hook call.
- Region B: 3 `useEffect`s → 1 hook call.
- Net: `app.ts` -78 lines (87 removed, 9 added); 4 effects + 1 `useState` lifted out, `setActiveRepoRoot` confirmed referenced only in Region A.

No pure helper worth testing was extracted — the restore guard is a trivial inline comparison and the persistence helpers (`getSavedSidebarTab` etc.) are already tested — so effect wiring is covered by the green build (no new test file, per plan).

## Validation

`npm test` fully green: 271 suites passed (1 skipped), 3436 tests passed (3 skipped), 68 snapshots. `tsc --noEmit` clean. Existing suite untouched.