### PR TITLE
refactor(workstation): extract debounced detail hydration into useDetailHydration (0.72 app.ts decomposition)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -61,7 +61,6 @@ import { getBranchOverview } from '../../git/branchData'
 import { hashesMatchAny } from '../../git/hashes'
 import { getLfsAttributeStatus } from '../../git/lfsAttributes'
 import { getSubmoduleOverview } from '../../git/submoduleData'
-import { getBlame } from '../../git/blameData'
 import { getRemoteOverview } from '../../git/remoteData'
 import { createManualCommit, formatCommitComposeMessage } from '../../commands/log/commitCompose'
 import {
@@ -344,6 +343,7 @@ import type { LogArgv } from '../../commands/log/config'
 // LogInkState filter-mode shape.
 import { matchesPromotedFilter } from '../runtime/promotedFilter'
 import { useFilteredLists } from './hooks/buildFilteredLists'
+import { useBlameLoadingState, useDetailHydration } from './hooks/useDetailHydration'
 import { useIdleTip } from './hooks/useIdleTip'
 import { useActiveRepoRoot, useViewModePersistence } from './hooks/useRepoPersistence'
 import { useSpinnerFrame } from './hooks/useSpinnerFrame'
@@ -1107,8 +1107,11 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // On-demand blame hydration flag (#0.71). True while the debounced
   // `getBlame` for the active `state.blamePath` is in flight; the blame
   // surface shows a loading placeholder until the parse lands in the
-  // `blameByPath` cache.
-  const [blameLoading, setBlameLoading] = React.useState(false)
+  // `blameByPath` cache. The `useState` is issued here (in its original
+  // slot, next to the bisect-candidate `useState`s) by `useBlameLoadingState`
+  // to preserve hook ordering; the debounced effects that toggle it live in
+  // `useDetailHydration` further down (0.72 app.ts decomposition, PR 7).
+  const { blameLoading, setBlameLoading } = useBlameLoadingState(React)
   const bisectCandidateSha = state.activeView === 'bisect' && context.bisect?.active
     ? context.bisect.currentSha
     : ''
@@ -1408,152 +1411,30 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     setContextStatus((current) => updateLogInkContextStatus(current, 'pullRequestList', 'idle'))
   }, [state.selectedPullRequestFilter])
 
-  // Per-item inspector hydration (#882 follow-up to phase 6). When
-  // the user rests the cursor on an issue / PR row for ~250ms, fetch
-  // the body + comments (+ reviews + status checks for PRs) and
-  // cache the result keyed by number. Cursoring back to a previously-
-  // fetched item shows the cached entry instantly; rapid j/k
-  // navigation never fires a `gh` call because the debounce timer
-  // resets on every cursor move.
-  //
-  // The cache lives on `context.{issueDetailByNumber,
-  // pullRequestDetailByNumber}` so it survives the per-keystroke
-  // re-renders. It's intentionally Maps — `new Map(prev).set(k, v)`
-  // keeps the immutable update story simple, and entries persist
-  // until either the list is invalidated (post-mutation) or the
-  // process exits.
-  const DETAIL_HYDRATION_DELAY_MS = 250
-
-  React.useEffect(() => {
-    if (state.activeView !== 'issues') return
-    const cursored = filteredIssueList[
-      Math.min(state.selectedIssueIndex, Math.max(0, filteredIssueList.length - 1))
-    ]
-    if (!cursored) return
-    if (context.issueDetailByNumber?.has(cursored.number)) return
-
-    const issuedAtDepth = runtimes.length - 1
-    let active = true
-    const timer = setTimeout(async () => {
-      const result = await forge.getIssueDetail(cursored.number)
-      if (!active || !result.ok) return
-      setContext(
-        (current) => ({
-          ...current,
-          issueDetailByNumber: new Map(current.issueDetailByNumber || []).set(
-            result.detail.number,
-            result.detail
-          ),
-        }),
-        issuedAtDepth,
-      )
-    }, DETAIL_HYDRATION_DELAY_MS)
-
-    return () => {
-      active = false
-      clearTimeout(timer)
-    }
-  }, [
-    runtimes.length,
-    state.activeView,
-    state.selectedIssueIndex,
-    filteredIssueList,
-    context.issueDetailByNumber,
-    setContext,
-  ])
-
-  React.useEffect(() => {
-    if (state.activeView !== 'pull-request-triage') return
-    const cursored = filteredPullRequestTriageList[
-      Math.min(
-        state.selectedPullRequestTriageIndex,
-        Math.max(0, filteredPullRequestTriageList.length - 1)
-      )
-    ]
-    if (!cursored) return
-    if (context.pullRequestDetailByNumber?.has(cursored.number)) return
-
-    const issuedAtDepth = runtimes.length - 1
-    let active = true
-    const timer = setTimeout(async () => {
-      const result = await forge.getPullRequestDetail(cursored.number)
-      if (!active || !result.ok) return
-      setContext(
-        (current) => ({
-          ...current,
-          pullRequestDetailByNumber: new Map(current.pullRequestDetailByNumber || []).set(
-            result.detail.number,
-            result.detail
-          ),
-        }),
-        issuedAtDepth,
-      )
-    }, DETAIL_HYDRATION_DELAY_MS)
-
-    return () => {
-      active = false
-      clearTimeout(timer)
-    }
-  }, [
-    runtimes.length,
-    state.activeView,
-    state.selectedPullRequestTriageIndex,
-    filteredPullRequestTriageList,
-    context.pullRequestDetailByNumber,
-    setContext,
-  ])
-
-  // On-demand blame hydration (#0.71). Mirrors the per-item inspector
-  // hydration above, but keyed by PATH rather than item number and
-  // entered from the dedicated blame view rather than a triage list.
-  // When the blame view is active for a path with no cached entry,
-  // debounce-fetch `git blame --porcelain`, parse once, and cache the
-  // result in `context.blameByPath`. Re-opening a previously-blamed
-  // path renders instantly from the cache. The debounce keeps a rapid
-  // sequence of `b` presses (open, esc, open another) from firing a
-  // blame on every transient path.
-  const BLAME_HYDRATION_DELAY_MS = 150
-
-  React.useEffect(() => {
-    if (state.activeView !== 'blame') return
-    const path = state.blamePath
-    if (!path) return
-    if (context.blameByPath?.has(path)) {
-      // Cache hit — make sure the loading flag is cleared (it may be set
-      // from a previous cold path) so the surface renders the cached
-      // blame immediately.
-      setBlameLoading(false)
-      return
-    }
-
-    const issuedAtDepth = runtimes.length - 1
-    let active = true
-    setBlameLoading(true)
-    const timer = setTimeout(async () => {
-      const result = await getBlame(git, path)
-      if (!active) return
-      setContext(
-        (current) => ({
-          ...current,
-          blameByPath: new Map(current.blameByPath || []).set(result.path, result),
-        }),
-        issuedAtDepth,
-      )
-      setBlameLoading(false)
-    }, BLAME_HYDRATION_DELAY_MS)
-
-    return () => {
-      active = false
-      clearTimeout(timer)
-    }
-  }, [
-    runtimes.length,
+  // Per-item inspector hydration (#882) + on-demand blame hydration
+  // (#0.71). When the user rests the cursor on an issue / PR row for
+  // ~250ms — or opens the blame view for a path for ~150ms — fetch the
+  // detail and cache it keyed by number / path. Cursoring back to a
+  // previously-fetched item renders the cached entry instantly; rapid
+  // j/k navigation never fires a `gh` / `git blame` call because the
+  // debounce timer resets on every cursor move. The three debounced
+  // effects (issue detail, PR detail, blame) were lifted verbatim into
+  // `useDetailHydration` (0.72 app.ts decomposition, PR 7) — the debounce
+  // delays, the `active` cancellation flag, the cache-skip check, the
+  // `clearTimeout` cleanup, and the `issuedAtDepth` frame-tag captured
+  // before the await all carry over byte-for-byte. The `blameLoading`
+  // `useState` it toggles is issued above by `useBlameLoadingState`.
+  useDetailHydration(React, {
     git,
-    state.activeView,
-    state.blamePath,
-    context.blameByPath,
+    forge,
+    state,
+    context,
+    runtimes,
+    filteredIssueList,
+    filteredPullRequestTriageList,
     setContext,
-  ])
+    setBlameLoading,
+  })
 
   React.useEffect(() => {
     let active = true

--- a/src/workstation/runtime/hooks/useDetailHydration.test.ts
+++ b/src/workstation/runtime/hooks/useDetailHydration.test.ts
@@ -1,0 +1,50 @@
+import {
+  BLAME_HYDRATION_DELAY_MS,
+  DETAIL_HYDRATION_DELAY_MS,
+  shouldHydrate,
+} from './useDetailHydration'
+
+/**
+ * Unit tests for the pure `shouldHydrate` core (0.72 app.ts decomposition,
+ * PR 7). No React harness — the hook (`useDetailHydration`) is a verbatim
+ * lift of three debounced effects, validated by the green build; only the
+ * extracted "fetch only if not already cached" decision is exercised here.
+ */
+describe('shouldHydrate', () => {
+  it('hydrates (true) when the cache is undefined', () => {
+    expect(shouldHydrate(42, undefined)).toBe(true)
+    expect(shouldHydrate('src/app.ts', undefined)).toBe(true)
+  })
+
+  it('hydrates (true) when the key is absent from the cache', () => {
+    const cache = new Map<number, unknown>([[1, {}]])
+    expect(shouldHydrate(2, cache)).toBe(true)
+  })
+
+  it('skips (false) when the key is already cached', () => {
+    const cache = new Map<number, unknown>([[7, {}]])
+    expect(shouldHydrate(7, cache)).toBe(false)
+  })
+
+  it('skips (false) for a cached path key', () => {
+    const cache = new Map<string, unknown>([['src/app.ts', {}]])
+    expect(shouldHydrate('src/app.ts', cache)).toBe(false)
+  })
+
+  it('treats a key cached with a falsy value as present (skip)', () => {
+    // `.has` is what the guard keys off, not the stored value — a cached
+    // entry whose value is falsy must still suppress a refetch.
+    const cache = new Map<number, unknown>([[0, undefined]])
+    expect(shouldHydrate(0, cache)).toBe(false)
+  })
+})
+
+describe('debounce constants', () => {
+  it('preserves the issue / PR detail debounce window verbatim', () => {
+    expect(DETAIL_HYDRATION_DELAY_MS).toBe(250)
+  })
+
+  it('preserves the blame debounce window verbatim', () => {
+    expect(BLAME_HYDRATION_DELAY_MS).toBe(150)
+  })
+})

--- a/src/workstation/runtime/hooks/useDetailHydration.ts
+++ b/src/workstation/runtime/hooks/useDetailHydration.ts
@@ -1,0 +1,282 @@
+/**
+ * Debounced per-cursor detail hydration (extracted in the 0.72 app.ts
+ * decomposition, PR 7).
+ *
+ * This module lifts the *most timing-sensitive* cluster so far out of
+ * `app.ts`: the three debounced "hydrate detail on cursor-rest" effects,
+ * plus the `blameLoading` `useState` the blame effect toggles.
+ *
+ *   1. Issue detail   — debounced ~250ms; when the issues view is active,
+ *      fetch the cursored issue's detail (from the filtered issue list)
+ *      into the `issueDetailByNumber` cache via `setContext`.
+ *   2. PR detail      — debounced ~250ms; same shape for the cursored
+ *      PR-triage row → `pullRequestDetailByNumber`.
+ *   3. Blame          — debounced ~150ms; fetch `getBlame` for
+ *      `state.blamePath` into `blameByPath`, toggling `blameLoading`.
+ *
+ * Each effect:
+ *   - debounces with a `setTimeout(debounceMs)` that resets on every
+ *     cursor move (the cleanup `clearTimeout`s the pending timer);
+ *   - captures the `issuedAtDepth = runtimes.length - 1` frame-tag
+ *     **BEFORE the await** and passes it to `setContext` so an in-flight
+ *     load lands on the repo-stack frame that issued it, not whichever
+ *     frame is on top when the fetch resolves;
+ *   - guards stale results with an `active` flag flipped false in cleanup;
+ *   - skips the fetch when the number/path is already cached.
+ *
+ * These three effects are reproduced **verbatim and separate** — the
+ * debounce delays (250 / 250 / 150), the `active` cancellation flag, the
+ * `clearTimeout` cleanup, the cache-skip check, the `setBlameLoading`
+ * toggles, and the `issuedAtDepth` capture-before-await are byte-for-byte
+ * the same as the original `app.ts` cluster, and the dependency arrays are
+ * unchanged. This is a behavior-preserving move, not a rewrite. They are
+ * deliberately NOT unified despite their similar shape.
+ *
+ * CRITICAL — hook ordering. In the original component the `blameLoading`
+ * `useState` (issued at ~1111, next to the bisect-candidate `useState`s)
+ * sits ~300 lines *above* the three effects (~1427), separated by many
+ * intervening hooks (the bisect-candidate effects, `contextStatusRef`, the
+ * `forge` `useMemo`, the issue/PR list loaders, …). React fires hooks in
+ * declaration order, so collapsing the `useState` and the effects into a
+ * single hook at one call site would reorder the `useState` relative to
+ * those intervening hooks. To preserve ordering exactly, this module
+ * exports *two* hooks, each called at the original position:
+ *
+ *   const { blameLoading, setBlameLoading } = useBlameLoadingState(React) // ~1111
+ *   ...bisect effects, forge useMemo, list loaders...
+ *   useDetailHydration(React, { ..., setBlameLoading })                   // ~1427
+ *
+ * Order correctness wins. `useBlameLoadingState` issues only the
+ * `blameLoading` `useState` (in its original slot); `useDetailHydration`
+ * issues the three effects (in their original slot) and is handed
+ * `setBlameLoading` so the blame effect can toggle the flag exactly as
+ * before.
+ *
+ * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
+ * convention) because the workstation never statically imports React.
+ */
+
+import type * as ReactTypes from 'react'
+import type { SimpleGit } from 'simple-git'
+import { getBlame } from '../../../git/blameData'
+import type { ForgeActions } from '../../../git/forgeActions'
+import type { LogInkState } from '../inkViewModel'
+import type { LogInkContext } from '../types'
+
+/** Debounce window for issue / PR detail hydration. Lifted verbatim. */
+export const DETAIL_HYDRATION_DELAY_MS = 250
+/** Debounce window for blame hydration. Lifted verbatim. */
+export const BLAME_HYDRATION_DELAY_MS = 150
+
+/** The filtered issue-list element type, as derived from the live context. */
+type IssueListItemType = NonNullable<NonNullable<LogInkContext['issueList']>['issues']>[number]
+/** The filtered PR-triage-list element type, as derived from the live context. */
+type PullRequestListItemType =
+  NonNullable<NonNullable<LogInkContext['pullRequestList']>['pullRequests']>[number]
+
+/**
+ * Pure cache-skip predicate: should the cursored key be hydrated, i.e. is
+ * it *absent* from its detail cache? Mirrors the original inline guard
+ * `if (cache?.has(key)) return` — returns `false` when the key is already
+ * cached (skip the fetch), `true` otherwise (hydrate). Pulled out so the
+ * "fetch only if not already cached" decision is unit-testable without
+ * spinning React, debounce timers, or a forge adapter.
+ *
+ * The effects below keep their cache checks inline and byte-for-byte (the
+ * blame effect's check additionally clears the loading flag on a hit), so
+ * this helper documents and tests the decision rather than replacing it.
+ */
+export function shouldHydrate<K>(
+  cursoredKey: K,
+  cache: { has(key: K): boolean } | undefined,
+): boolean {
+  return !cache?.has(cursoredKey)
+}
+
+/**
+ * Issues only the `blameLoading` `useState`, in its original `app.ts`
+ * position (next to the bisect-candidate `useState`s, ~300 lines above the
+ * effects). Returns both the flag (for the blame surface / MainPanelExtras)
+ * and the setter (threaded into {@link useDetailHydration} so the blame
+ * effect can toggle it exactly as the inline code did).
+ */
+export function useBlameLoadingState(React: typeof ReactTypes): {
+  blameLoading: boolean
+  setBlameLoading: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
+} {
+  // On-demand blame hydration flag (#0.71). True while the debounced
+  // `getBlame` for the active `state.blamePath` is in flight; the blame
+  // surface shows a loading placeholder until the parse lands in the
+  // `blameByPath` cache.
+  const [blameLoading, setBlameLoading] = React.useState(false)
+  return { blameLoading, setBlameLoading }
+}
+
+export type UseDetailHydrationDeps = {
+  /** The active frame's `git`. Drives the blame `getBlame` fetch. */
+  git: SimpleGit
+  /** The forge adapter — issue / PR detail fetches. */
+  forge: ForgeActions
+  /** The full reducer state (cursor indices, `blamePath`, `activeView`). */
+  state: LogInkState
+  /** The active frame's loaded context (the detail caches live here). */
+  context: LogInkContext
+  /** Repo-stack runtimes — `runtimes.length - 1` is the frame-tag depth. */
+  runtimes: readonly unknown[]
+  /** The filtered issue list (from `useFilteredLists`). */
+  filteredIssueList: IssueListItemType[]
+  /** The filtered PR-triage list (from `useFilteredLists`). */
+  filteredPullRequestTriageList: PullRequestListItemType[]
+  /** Frame-tagging context writer (`setContext(next, issuedAtDepth)`). */
+  setContext: (
+    arg: LogInkContext | ((prev: LogInkContext) => LogInkContext),
+    targetDepth?: number,
+  ) => void
+  /** Blame loading-flag setter, from {@link useBlameLoadingState}. */
+  setBlameLoading: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
+}
+
+/**
+ * Issues the three debounced detail-hydration effects, in their original
+ * `app.ts` order and position (issue detail, then PR detail, then blame).
+ * Each effect is reproduced verbatim — same debounce delay, same `active`
+ * cancellation flag, same `issuedAtDepth = runtimes.length - 1`
+ * frame-tag captured *before* the `await`, same cache-skip check, same
+ * `clearTimeout` cleanup, same dependency array.
+ */
+export function useDetailHydration(
+  React: typeof ReactTypes,
+  deps: UseDetailHydrationDeps,
+): void {
+  const {
+    git,
+    forge,
+    state,
+    context,
+    runtimes,
+    filteredIssueList,
+    filteredPullRequestTriageList,
+    setContext,
+    setBlameLoading,
+  } = deps
+
+  React.useEffect(() => {
+    if (state.activeView !== 'issues') return
+    const cursored = filteredIssueList[
+      Math.min(state.selectedIssueIndex, Math.max(0, filteredIssueList.length - 1))
+    ]
+    if (!cursored) return
+    if (context.issueDetailByNumber?.has(cursored.number)) return
+
+    const issuedAtDepth = runtimes.length - 1
+    let active = true
+    const timer = setTimeout(async () => {
+      const result = await forge.getIssueDetail(cursored.number)
+      if (!active || !result.ok) return
+      setContext(
+        (current) => ({
+          ...current,
+          issueDetailByNumber: new Map(current.issueDetailByNumber || []).set(
+            result.detail.number,
+            result.detail
+          ),
+        }),
+        issuedAtDepth,
+      )
+    }, DETAIL_HYDRATION_DELAY_MS)
+
+    return () => {
+      active = false
+      clearTimeout(timer)
+    }
+  }, [
+    runtimes.length,
+    state.activeView,
+    state.selectedIssueIndex,
+    filteredIssueList,
+    context.issueDetailByNumber,
+    setContext,
+  ])
+
+  React.useEffect(() => {
+    if (state.activeView !== 'pull-request-triage') return
+    const cursored = filteredPullRequestTriageList[
+      Math.min(
+        state.selectedPullRequestTriageIndex,
+        Math.max(0, filteredPullRequestTriageList.length - 1)
+      )
+    ]
+    if (!cursored) return
+    if (context.pullRequestDetailByNumber?.has(cursored.number)) return
+
+    const issuedAtDepth = runtimes.length - 1
+    let active = true
+    const timer = setTimeout(async () => {
+      const result = await forge.getPullRequestDetail(cursored.number)
+      if (!active || !result.ok) return
+      setContext(
+        (current) => ({
+          ...current,
+          pullRequestDetailByNumber: new Map(current.pullRequestDetailByNumber || []).set(
+            result.detail.number,
+            result.detail
+          ),
+        }),
+        issuedAtDepth,
+      )
+    }, DETAIL_HYDRATION_DELAY_MS)
+
+    return () => {
+      active = false
+      clearTimeout(timer)
+    }
+  }, [
+    runtimes.length,
+    state.activeView,
+    state.selectedPullRequestTriageIndex,
+    filteredPullRequestTriageList,
+    context.pullRequestDetailByNumber,
+    setContext,
+  ])
+
+  React.useEffect(() => {
+    if (state.activeView !== 'blame') return
+    const path = state.blamePath
+    if (!path) return
+    if (context.blameByPath?.has(path)) {
+      // Cache hit — make sure the loading flag is cleared (it may be set
+      // from a previous cold path) so the surface renders the cached
+      // blame immediately.
+      setBlameLoading(false)
+      return
+    }
+
+    const issuedAtDepth = runtimes.length - 1
+    let active = true
+    setBlameLoading(true)
+    const timer = setTimeout(async () => {
+      const result = await getBlame(git, path)
+      if (!active) return
+      setContext(
+        (current) => ({
+          ...current,
+          blameByPath: new Map(current.blameByPath || []).set(result.path, result),
+        }),
+        issuedAtDepth,
+      )
+      setBlameLoading(false)
+    }, BLAME_HYDRATION_DELAY_MS)
+
+    return () => {
+      active = false
+      clearTimeout(timer)
+    }
+  }, [
+    runtimes.length,
+    git,
+    state.activeView,
+    state.blamePath,
+    context.blameByPath,
+    setContext,
+  ])
+}


### PR DESCRIPTION
## What

PR 7 of the 0.72 `app.ts` decomposition. Lifts the three debounced per-cursor **detail-hydration** effects — the most timing-sensitive cluster so far — plus the `blameLoading` `useState` out of `src/workstation/runtime/app.ts` into a new `runtime/hooks/useDetailHydration.ts`.

The three effects moved (verbatim, separate, in original order):

1. **Issue detail** — debounced 250ms; on the issues view, fetches the cursored issue's detail (from `filteredIssueList`) into `issueDetailByNumber`.
2. **PR detail** — debounced 250ms; same shape for the cursored PR-triage row → `pullRequestDetailByNumber`.
3. **Blame** — debounced 150ms; `getBlame` for `state.blamePath` into `blameByPath`, toggling the `blameLoading` flag.

## Behavior-preserving guarantees

- Debounce delays (250 / 250 / 150), the `active` cancellation flag, the `clearTimeout` cleanup, and the per-effect cache-skip check are carried over **byte-for-byte**.
- The `issuedAtDepth = runtimes.length - 1` **frame-tag is captured BEFORE the `await`** in every effect and passed to `setContext` exactly as before, so an in-flight load lands on the repo-stack frame that issued it.
- Dependency arrays are byte-identical (the blame effect keeps `git` and does *not* include `setBlameLoading`, as in the original).
- The three effects are deliberately **not unified** despite their similar shape.

## Hook structure (a split was required)

The cluster was **not fully contiguous**: the `blameLoading` `useState` sits ~300 lines *above* the three effects, interleaved with the bisect-candidate `useState`s, the `forge` `useMemo`, and several list-loader effects. Collapsing the `useState` into a single hook at the effects' position would reorder it relative to those intervening hooks. To preserve React hook ordering exactly, the module exports **two** position-preserving hooks (as PR 6 did):

- `useBlameLoadingState(React)` → `{ blameLoading, setBlameLoading }`, called in the `useState`'s original slot.
- `useDetailHydration(React, deps)` → the three effects, called in their original slot, handed `setBlameLoading`.

`blameLoading` consumers (the blame surface / MainPanelExtras) are unchanged — they now read it from the state hook.

## Pure core

Extracted `shouldHydrate(cursoredKey, cache)` (the "fetch only if not already cached" decision) and unit-tested it in `useDetailHydration.test.ts`. The effects keep their cache checks inline and byte-for-byte; the helper documents and tests the decision.

## app.ts reduction

- `React.useEffect`: 31 → 28 (−3)
- `React.useState`: 24 → 23 (−1)
- net −119 lines; removed the now-unused `getBlame` import.

## Validation

`npm test` fully green — 272 suites passed, 1 skipped (the gated GitLab integration test), 3443 tests passed, 3 skipped. `npx tsc --noEmit` clean.