### PR TITLE
refactor(workstation): extract diff hydration into useDiffHydration (0.72 app.ts decomposition)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -75,7 +75,6 @@ import {
     LOG_INTERACTIVE_DEFAULT_LIMIT,
     buildToggleGraphArgs,
     getCommitDetail,
-    getCommitFilePreview,
     getCommitRows,
     getLogRows,
     getLogRowsAnchoredOn,
@@ -189,7 +188,6 @@ import { runPullRequestBodyWorkflow } from '../../git/aiActions'
 import {
     findStashFileForOffset,
     getStashCommitHashes,
-    getStashDiff,
     getStashOverview,
 } from '../../git/stashData'
 import {
@@ -207,21 +205,19 @@ import {
 } from '../../git/statusData'
 import {
     WorktreeHunkOverview,
-    getWorktreeHunks,
     revertHunk,
     stageHunk,
     unstageHunk,
 } from '../../git/statusHunks'
 import { getBisectCompletion, getBisectStatus } from '../../git/bisectData'
 import { bisectBad, bisectGood, bisectReset, bisectRun, bisectSkip, bisectStart, extractBisectRemainingHint } from '../../git/bisectActions'
-import { getCompareDiff } from '../../git/compareData'
 import { getReflogOverview } from '../../git/reflogData'
 import { checkoutReflogEntry } from '../../git/reflogActions'
 import { initSubmodule, syncSubmodule, updateSubmodule } from '../../git/submoduleActions'
 import { addRemote, pruneRemote, removeRemote, setRemoteUrl } from '../../git/remoteActions'
 import { getTagOverview } from '../../git/tagData'
 import { getWorktreeListOverview } from '../../git/worktreeData'
-import { WorktreeFileDiff, getWorktreeFileDiff } from '../../git/worktreeDiffData'
+import { WorktreeFileDiff } from '../../git/worktreeDiffData'
 
 
 async function safe<T>(promise: Promise<T>): Promise<T | undefined> {
@@ -344,6 +340,13 @@ import type { LogArgv } from '../../commands/log/config'
 import { matchesPromotedFilter } from '../runtime/promotedFilter'
 import { useFilteredLists } from './hooks/buildFilteredLists'
 import { useBlameLoadingState, useDetailHydration } from './hooks/useDetailHydration'
+import {
+  useCommitFilePreviewHydration,
+  useCompareDiffHydration,
+  useStashDiffHydration,
+  useWorktreeDiffHydration,
+  useWorktreeHunksHydration,
+} from './hooks/useDiffHydration'
 import { useIdleTip } from './hooks/useIdleTip'
 import { useActiveRepoRoot, useViewModePersistence } from './hooks/useRepoPersistence'
 import { useSpinnerFrame } from './hooks/useSpinnerFrame'
@@ -1079,21 +1082,18 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // P-stash-explorer: load `git stash show -p <ref>` once the diff view
   // becomes active with diffSource='stash'. Best-effort — empty stashes
   // or read errors fall through to a "no diff" hint at the render site.
-  React.useEffect(() => {
-    if (state.activeView !== 'diff' || state.diffSource !== 'stash' || !state.stashDiffRef) {
-      return
-    }
-    let active = true
-    setStashDiffLoading(true)
-    void (async () => {
-      const lines = await safe(getStashDiff(git, state.stashDiffRef!))
-      if (active) {
-        setStashDiffLines(lines || [])
-        setStashDiffLoading(false)
-      }
-    })()
-    return () => { active = false }
-  }, [git, state.activeView, state.diffSource, state.stashDiffRef])
+  // Lifted verbatim into `useStashDiffHydration` (0.72 app.ts
+  // decomposition, PR 8) — the guard, the `active` cancellation flag, the
+  // `safe()` wrapper, the loading toggle, and the dependency array all
+  // carry over byte-for-byte.
+  useStashDiffHydration(React, {
+    git,
+    activeView: state.activeView,
+    diffSource: state.diffSource,
+    stashDiffRef: state.stashDiffRef,
+    setStashDiffLines,
+    setStashDiffLoading,
+  })
 
   // #879 (item 2) — load commit detail for the active bisect's
   // current candidate so the bisect surface can show "what changed
@@ -1140,26 +1140,18 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // surface falls back to a "no diff" hint.
   const compareBaseRef = state.compareBase?.ref
   const compareHeadRef = state.compareHead?.ref
-  React.useEffect(() => {
-    if (
-      state.activeView !== 'diff' ||
-      state.diffSource !== 'compare' ||
-      !compareBaseRef ||
-      !compareHeadRef
-    ) {
-      return
-    }
-    let active = true
-    setCompareDiffLoading(true)
-    void (async () => {
-      const lines = await safe(getCompareDiff(git, compareBaseRef, compareHeadRef))
-      if (active) {
-        setCompareDiffLines(lines || [])
-        setCompareDiffLoading(false)
-      }
-    })()
-    return () => { active = false }
-  }, [git, state.activeView, state.diffSource, compareBaseRef, compareHeadRef])
+  // Lifted verbatim into `useCompareDiffHydration` (0.72 app.ts
+  // decomposition, PR 8) — guard, `active` flag, `safe()` wrapper, loading
+  // toggle, and dependency array carry over byte-for-byte.
+  useCompareDiffHydration(React, {
+    git,
+    activeView: state.activeView,
+    diffSource: state.diffSource,
+    compareBaseRef,
+    compareHeadRef,
+    setCompareDiffLines,
+    setCompareDiffLoading,
+  })
 
   // Reset compare-diff state whenever the diff view exits. Without
   // this, opening a new compare immediately after closing one would
@@ -1172,37 +1164,16 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
   }, [state.diffSource])
 
-  React.useEffect(() => {
-    let active = true
-
-    async function loadWorktreeHunks(): Promise<void> {
-      if (state.activeView !== 'diff' || !selectedWorktreeFile) {
-        setWorktreeHunks(undefined)
-        setWorktreeHunksLoading(false)
-        return
-      }
-
-      setWorktreeHunksLoading(true)
-      const nextHunks = await safe(getWorktreeHunks(git, selectedWorktreeFile))
-
-      if (active) {
-        setWorktreeHunks(nextHunks)
-        setWorktreeHunksLoading(false)
-      }
-    }
-
-    void loadWorktreeHunks()
-
-    return () => {
-      active = false
-    }
-  }, [
+  // Lifted verbatim into `useWorktreeHunksHydration` (0.72 app.ts
+  // decomposition, PR 8) — guard, `active` flag, `safe()` wrapper, loading
+  // toggle, and dependency array carry over byte-for-byte.
+  useWorktreeHunksHydration(React, {
     git,
-    selectedWorktreeFile?.indexStatus,
-    selectedWorktreeFile?.path,
-    selectedWorktreeFile?.worktreeStatus,
-    state.activeView,
-  ])
+    activeView: state.activeView,
+    selectedWorktreeFile,
+    setWorktreeHunks,
+    setWorktreeHunksLoading,
+  })
 
   // #931 PR 5 — Cache-aware boot load. The frame's `git` instance is
   // the dep that drives this effect; on push, the new frame's runtime
@@ -1659,37 +1630,16 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
   }, [state.activeView, state.focus, state.sidebarTab])
 
-  React.useEffect(() => {
-    let active = true
-
-    async function loadWorktreeDiff(): Promise<void> {
-      if (state.activeView !== 'diff' || !selectedWorktreeFile) {
-        setWorktreeDiff(undefined)
-        setWorktreeDiffLoading(false)
-        return
-      }
-
-      setWorktreeDiffLoading(true)
-      const nextDiff = await safe(getWorktreeFileDiff(git, selectedWorktreeFile))
-
-      if (active) {
-        setWorktreeDiff(nextDiff)
-        setWorktreeDiffLoading(false)
-      }
-    }
-
-    void loadWorktreeDiff()
-
-    return () => {
-      active = false
-    }
-  }, [
+  // Lifted verbatim into `useWorktreeDiffHydration` (0.72 app.ts
+  // decomposition, PR 8) — guard, `active` flag, `safe()` wrapper, loading
+  // toggle, and dependency array carry over byte-for-byte.
+  useWorktreeDiffHydration(React, {
     git,
-    selectedWorktreeFile?.indexStatus,
-    selectedWorktreeFile?.path,
-    selectedWorktreeFile?.worktreeStatus,
-    state.activeView,
-  ])
+    activeView: state.activeView,
+    selectedWorktreeFile,
+    setWorktreeDiff,
+    setWorktreeDiffLoading,
+  })
 
   // Syntax-highlight the diff currently in view, off the render path
   // (#1117 follow-up). Mirrors the worktree-diff effect: detect the
@@ -4256,30 +4206,16 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     visibleWorktreeFilesGrouped,
   ])
 
-  React.useEffect(() => {
-    let active = true
-
-    async function loadPreview(): Promise<void> {
-      if (!selected || !selectedDetailFile) {
-        setFilePreview(undefined)
-        return
-      }
-
-      setFilePreviewLoading(true)
-      const nextPreview = await safe(getCommitFilePreview(git, selected.hash, selectedDetailFile))
-
-      if (active) {
-        setFilePreview(nextPreview)
-        setFilePreviewLoading(false)
-      }
-    }
-
-    void loadPreview()
-
-    return () => {
-      active = false
-    }
-  }, [git, selected?.hash, selectedDetailFile?.path, selectedDetailFile?.oldPath])
+  // Lifted verbatim into `useCommitFilePreviewHydration` (0.72 app.ts
+  // decomposition, PR 8) — guard, `active` flag, `safe()` wrapper, loading
+  // toggle, and dependency array carry over byte-for-byte.
+  useCommitFilePreviewHydration(React, {
+    git,
+    selected,
+    selectedDetailFile,
+    setFilePreview,
+    setFilePreviewLoading,
+  })
 
   React.useEffect(() => {
     return () => {

--- a/src/workstation/runtime/hooks/useDiffHydration.test.ts
+++ b/src/workstation/runtime/hooks/useDiffHydration.test.ts
@@ -1,0 +1,32 @@
+import { shouldLoadWorktreeDiff } from './useDiffHydration'
+import type { WorktreeFile } from '../../../git/statusData'
+
+/**
+ * Unit tests for the pure `shouldLoadWorktreeDiff` core (0.72 app.ts
+ * decomposition, PR 8). No React harness — the five diff-hydration hooks are
+ * verbatim lifts of inline-async effects validated by the green build; only
+ * the extracted "load the worktree diff data only when the diff view is
+ * active and a file is cursored" guard (shared identically by the
+ * worktree-hunks and worktree-file-diff loaders) is exercised here.
+ */
+const file = (path: string): WorktreeFile =>
+  ({ path } as unknown as WorktreeFile)
+
+describe('shouldLoadWorktreeDiff', () => {
+  it('loads (true) when the diff view is active and a file is cursored', () => {
+    expect(shouldLoadWorktreeDiff('diff', file('src/app.ts'))).toBe(true)
+  })
+
+  it('skips (false) when no worktree file is cursored', () => {
+    expect(shouldLoadWorktreeDiff('diff', undefined)).toBe(false)
+  })
+
+  it('skips (false) when the active view is not the diff view', () => {
+    expect(shouldLoadWorktreeDiff('history', file('src/app.ts'))).toBe(false)
+    expect(shouldLoadWorktreeDiff('status', file('src/app.ts'))).toBe(false)
+  })
+
+  it('skips (false) when neither condition holds', () => {
+    expect(shouldLoadWorktreeDiff('history', undefined)).toBe(false)
+  })
+})

--- a/src/workstation/runtime/hooks/useDiffHydration.ts
+++ b/src/workstation/runtime/hooks/useDiffHydration.ts
@@ -1,0 +1,398 @@
+/**
+ * Lazy diff/hunks hydration (extracted in the 0.72 app.ts decomposition,
+ * PR 8).
+ *
+ * This module lifts the cluster of "fetch the diff text / parsed hunks for
+ * the active selection once the diff view becomes active" effects out of
+ * `app.ts`. Five effects, one per diff *source*, each fetching lazily into
+ * its own dedicated `useState` slot:
+ *
+ *   1. Stash diff    — `getStashDiff(git, stashDiffRef)` once the diff view
+ *      is active with `diffSource === 'stash'`, into `stashDiffLines`.
+ *   2. Compare diff  — `getCompareDiff(git, base, head)` once active with
+ *      `diffSource === 'compare'`, into `compareDiffLines`.
+ *   3. Worktree hunks — `getWorktreeHunks(git, selectedWorktreeFile)` for
+ *      the cursored worktree file, into `worktreeHunks`.
+ *   4. Worktree file diff — `getWorktreeFileDiff(git, selectedWorktreeFile)`
+ *      for the cursored worktree file, into `worktreeDiff`.
+ *   5. Commit file preview — `getCommitFilePreview(git, sha, file)` for the
+ *      cursored commit's selected file, into `filePreview`.
+ *
+ * Each effect is a best-effort lazy loader: the fetch is wrapped in `safe()`
+ * (errors fall through to a "no diff" hint at the render site), guarded with
+ * an `active` flag flipped false in cleanup so a stale in-flight load can't
+ * clobber a newer selection, and toggles a `*Loading` flag around the await.
+ *
+ * Unlike the detail-hydration cluster (PR 7), these loaders write to *local*
+ * `useState` slots — `setStashDiffLines`, `setCompareDiffLines`,
+ * `setWorktreeHunks`, `setWorktreeDiff`, `setFilePreview` — rather than into
+ * the frame-tagged `context`. There is therefore no `issuedAtDepth`
+ * frame-tag here: cancellation is the `active` flag alone, exactly as in the
+ * original inline code. The five effects are reproduced **verbatim and
+ * separate** — the guard conditions, the `active` flag, the `safe()`
+ * wrapper, the `set*Loading` toggles, and the dependency arrays are
+ * byte-for-byte the same as the original `app.ts` effects. This is a
+ * behavior-preserving move, not a rewrite; they are deliberately NOT unified
+ * despite their similar shape.
+ *
+ * CRITICAL — hook ordering. The five effects are NOT contiguous in `app.ts`:
+ * they are scattered across ~3200 lines (the stash, compare, and worktree
+ * loaders sit ~1082–1692; the commit file-preview loader sits ~4259),
+ * interleaved with unrelated effects (the boot-load, PR-overview, bisect,
+ * compare-reset, branch-tab-sync and syntax-highlight effects). React fires
+ * hooks in declaration order, so collapsing them into one call site would
+ * reorder them relative to those intervening hooks. To preserve ordering
+ * exactly, this module exports *five* hooks, each called at its original
+ * slot in `app.ts`. Order correctness wins over tidiness.
+ *
+ * The dedicated `useState` slots stay in `app.ts` because the diff setters
+ * are also called from staging callbacks (`toggleSelectedFileStage`, the
+ * hunk-stage callbacks) and the compare-reset effect — they are not owned by
+ * these loaders. Each hook is handed the setter(s) it needs.
+ *
+ * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
+ * convention) because the workstation never statically imports React.
+ */
+
+import type * as ReactTypes from 'react'
+import type { SimpleGit } from 'simple-git'
+import {
+  GitCommitDetail,
+  GitCommitFilePreview,
+  GitLogCommitRow,
+  getCommitFilePreview,
+} from '../../../commands/log/data'
+import { getCompareDiff } from '../../../git/compareData'
+import { getStashDiff } from '../../../git/stashData'
+import { WorktreeHunkOverview, getWorktreeHunks } from '../../../git/statusHunks'
+import type { WorktreeFile } from '../../../git/statusData'
+import { WorktreeFileDiff, getWorktreeFileDiff } from '../../../git/worktreeDiffData'
+import type { LogInkDiffSource, LogInkView } from '../inkViewModel'
+
+/**
+ * Best-effort promise unwrap, lifted verbatim from `app.ts`. Swallows the
+ * rejection so a git error leaves the diff surface on its "no diff" hint
+ * instead of crashing the workstation.
+ */
+async function safe<T>(promise: Promise<T>): Promise<T | undefined> {
+  try {
+    return await promise
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Pure guard shared (identically) by the worktree-hunks and
+ * worktree-file-diff loaders: hydrate the worktree diff data only when the
+ * diff view is active *and* a worktree file is cursored. Returns `false`
+ * when either is missing (the effects reset their state and bail), `true`
+ * when both hold (the fetch should run).
+ *
+ * The effects keep their guard inline and byte-for-byte; this helper
+ * documents and tests the decision rather than replacing it.
+ */
+export function shouldLoadWorktreeDiff(
+  activeView: LogInkView,
+  selectedWorktreeFile: WorktreeFile | undefined,
+): boolean {
+  return activeView === 'diff' && Boolean(selectedWorktreeFile)
+}
+
+export type UseStashDiffHydrationDeps = {
+  /** The active frame's `git`. */
+  git: SimpleGit
+  /** `state.activeView` — only `'diff'` triggers a load. */
+  activeView: LogInkView
+  /** `state.diffSource` — only `'stash'` triggers a load. */
+  diffSource: LogInkDiffSource | undefined
+  /** `state.stashDiffRef` — the stash ref to `git stash show -p`. */
+  stashDiffRef: string | undefined
+  /** Writer for the loaded stash diff lines. */
+  setStashDiffLines: ReactTypes.Dispatch<
+    ReactTypes.SetStateAction<string[] | undefined>
+  >
+  /** Loading-flag setter for the stash diff fetch. */
+  setStashDiffLoading: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
+}
+
+/**
+ * P-stash-explorer: load `git stash show -p <ref>` once the diff view
+ * becomes active with diffSource='stash'. Lifted verbatim from `app.ts`.
+ */
+export function useStashDiffHydration(
+  React: typeof ReactTypes,
+  deps: UseStashDiffHydrationDeps,
+): void {
+  const {
+    git,
+    activeView,
+    diffSource,
+    stashDiffRef,
+    setStashDiffLines,
+    setStashDiffLoading,
+  } = deps
+
+  React.useEffect(() => {
+    if (activeView !== 'diff' || diffSource !== 'stash' || !stashDiffRef) {
+      return
+    }
+    let active = true
+    setStashDiffLoading(true)
+    void (async () => {
+      const lines = await safe(getStashDiff(git, stashDiffRef!))
+      if (active) {
+        setStashDiffLines(lines || [])
+        setStashDiffLoading(false)
+      }
+    })()
+    return () => { active = false }
+  }, [git, activeView, diffSource, stashDiffRef])
+}
+
+export type UseCompareDiffHydrationDeps = {
+  /** The active frame's `git`. */
+  git: SimpleGit
+  /** `state.activeView` — only `'diff'` triggers a load. */
+  activeView: LogInkView
+  /** `state.diffSource` — only `'compare'` triggers a load. */
+  diffSource: LogInkDiffSource | undefined
+  /** `state.compareBase?.ref` — the base ref of the comparison. */
+  compareBaseRef: string | undefined
+  /** `state.compareHead?.ref` — the head ref of the comparison. */
+  compareHeadRef: string | undefined
+  /** Writer for the loaded compare diff lines. */
+  setCompareDiffLines: ReactTypes.Dispatch<
+    ReactTypes.SetStateAction<string[] | undefined>
+  >
+  /** Loading-flag setter for the compare diff fetch. */
+  setCompareDiffLoading: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
+}
+
+/**
+ * #779 — load `git diff <base>..<head>` once the diff view becomes active
+ * with diffSource='compare'. Lifted verbatim from `app.ts`.
+ */
+export function useCompareDiffHydration(
+  React: typeof ReactTypes,
+  deps: UseCompareDiffHydrationDeps,
+): void {
+  const {
+    git,
+    activeView,
+    diffSource,
+    compareBaseRef,
+    compareHeadRef,
+    setCompareDiffLines,
+    setCompareDiffLoading,
+  } = deps
+
+  React.useEffect(() => {
+    if (
+      activeView !== 'diff' ||
+      diffSource !== 'compare' ||
+      !compareBaseRef ||
+      !compareHeadRef
+    ) {
+      return
+    }
+    let active = true
+    setCompareDiffLoading(true)
+    void (async () => {
+      const lines = await safe(getCompareDiff(git, compareBaseRef, compareHeadRef))
+      if (active) {
+        setCompareDiffLines(lines || [])
+        setCompareDiffLoading(false)
+      }
+    })()
+    return () => { active = false }
+  }, [git, activeView, diffSource, compareBaseRef, compareHeadRef])
+}
+
+export type UseWorktreeHunksHydrationDeps = {
+  /** The active frame's `git`. */
+  git: SimpleGit
+  /** `state.activeView` — only `'diff'` triggers a load. */
+  activeView: LogInkView
+  /** The cursored worktree file (from `useStatusSurfaceData`). */
+  selectedWorktreeFile: WorktreeFile | undefined
+  /** Writer for the parsed worktree hunks. */
+  setWorktreeHunks: ReactTypes.Dispatch<
+    ReactTypes.SetStateAction<WorktreeHunkOverview | undefined>
+  >
+  /** Loading-flag setter for the worktree hunks fetch. */
+  setWorktreeHunksLoading: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
+}
+
+/**
+ * Parse the cursored worktree file's hunks once the diff view is active.
+ * Lifted verbatim from `app.ts`.
+ */
+export function useWorktreeHunksHydration(
+  React: typeof ReactTypes,
+  deps: UseWorktreeHunksHydrationDeps,
+): void {
+  const {
+    git,
+    activeView,
+    selectedWorktreeFile,
+    setWorktreeHunks,
+    setWorktreeHunksLoading,
+  } = deps
+
+  React.useEffect(() => {
+    let active = true
+
+    async function loadWorktreeHunks(): Promise<void> {
+      if (activeView !== 'diff' || !selectedWorktreeFile) {
+        setWorktreeHunks(undefined)
+        setWorktreeHunksLoading(false)
+        return
+      }
+
+      setWorktreeHunksLoading(true)
+      const nextHunks = await safe(getWorktreeHunks(git, selectedWorktreeFile))
+
+      if (active) {
+        setWorktreeHunks(nextHunks)
+        setWorktreeHunksLoading(false)
+      }
+    }
+
+    void loadWorktreeHunks()
+
+    return () => {
+      active = false
+    }
+  }, [
+    git,
+    selectedWorktreeFile?.indexStatus,
+    selectedWorktreeFile?.path,
+    selectedWorktreeFile?.worktreeStatus,
+    activeView,
+  ])
+}
+
+export type UseWorktreeDiffHydrationDeps = {
+  /** The active frame's `git`. */
+  git: SimpleGit
+  /** `state.activeView` — only `'diff'` triggers a load. */
+  activeView: LogInkView
+  /** The cursored worktree file (from `useStatusSurfaceData`). */
+  selectedWorktreeFile: WorktreeFile | undefined
+  /** Writer for the loaded worktree file diff. */
+  setWorktreeDiff: ReactTypes.Dispatch<
+    ReactTypes.SetStateAction<WorktreeFileDiff | undefined>
+  >
+  /** Loading-flag setter for the worktree file diff fetch. */
+  setWorktreeDiffLoading: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
+}
+
+/**
+ * Load the cursored worktree file's diff once the diff view is active.
+ * Lifted verbatim from `app.ts`.
+ */
+export function useWorktreeDiffHydration(
+  React: typeof ReactTypes,
+  deps: UseWorktreeDiffHydrationDeps,
+): void {
+  const {
+    git,
+    activeView,
+    selectedWorktreeFile,
+    setWorktreeDiff,
+    setWorktreeDiffLoading,
+  } = deps
+
+  React.useEffect(() => {
+    let active = true
+
+    async function loadWorktreeDiff(): Promise<void> {
+      if (activeView !== 'diff' || !selectedWorktreeFile) {
+        setWorktreeDiff(undefined)
+        setWorktreeDiffLoading(false)
+        return
+      }
+
+      setWorktreeDiffLoading(true)
+      const nextDiff = await safe(getWorktreeFileDiff(git, selectedWorktreeFile))
+
+      if (active) {
+        setWorktreeDiff(nextDiff)
+        setWorktreeDiffLoading(false)
+      }
+    }
+
+    void loadWorktreeDiff()
+
+    return () => {
+      active = false
+    }
+  }, [
+    git,
+    selectedWorktreeFile?.indexStatus,
+    selectedWorktreeFile?.path,
+    selectedWorktreeFile?.worktreeStatus,
+    activeView,
+  ])
+}
+
+/** The cursored commit's selected detail file, as fed to the preview load. */
+type SelectedDetailFile = GitCommitDetail['files'][number] | undefined
+
+export type UseCommitFilePreviewHydrationDeps = {
+  /** The active frame's `git`. */
+  git: SimpleGit
+  /** The cursored commit row (drives the `sha`), or `undefined`. */
+  selected: GitLogCommitRow | undefined
+  /** The cursored commit's selected detail file. */
+  selectedDetailFile: SelectedDetailFile
+  /** Writer for the loaded per-file commit preview. */
+  setFilePreview: ReactTypes.Dispatch<
+    ReactTypes.SetStateAction<GitCommitFilePreview | undefined>
+  >
+  /** Loading-flag setter for the commit file preview fetch. */
+  setFilePreviewLoading: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
+}
+
+/**
+ * Load the per-file diff preview for the cursored commit's selected file.
+ * Lifted verbatim from `app.ts`.
+ */
+export function useCommitFilePreviewHydration(
+  React: typeof ReactTypes,
+  deps: UseCommitFilePreviewHydrationDeps,
+): void {
+  const {
+    git,
+    selected,
+    selectedDetailFile,
+    setFilePreview,
+    setFilePreviewLoading,
+  } = deps
+
+  React.useEffect(() => {
+    let active = true
+
+    async function loadPreview(): Promise<void> {
+      if (!selected || !selectedDetailFile) {
+        setFilePreview(undefined)
+        return
+      }
+
+      setFilePreviewLoading(true)
+      const nextPreview = await safe(getCommitFilePreview(git, selected.hash, selectedDetailFile))
+
+      if (active) {
+        setFilePreview(nextPreview)
+        setFilePreviewLoading(false)
+      }
+    }
+
+    void loadPreview()
+
+    return () => {
+      active = false
+    }
+  }, [git, selected?.hash, selectedDetailFile?.path, selectedDetailFile?.oldPath])
+}


### PR DESCRIPTION
## PR 8 of the 0.72 \`app.ts\` decomposition

Lifts the lazy **diff / hunks hydration** effects out of \`src/workstation/runtime/app.ts\` into \`src/workstation/runtime/hooks/useDiffHydration.ts\`. Behavior-preserving refactor of the TUI runtime.

### Effects moved (verbatim, separate, original order)

Five lazy "fetch the diff for the active selection once the diff view is active" loaders, each into its own hook:

| # | Loader | Fetch | Writes | Original \`app.ts\` lines |
|---|--------|-------|--------|----------------|
| 1 | \`useStashDiffHydration\` | \`getStashDiff\` | \`stashDiffLines\` | ~1082–1096 |
| 2 | \`useCompareDiffHydration\` | \`getCompareDiff\` | \`compareDiffLines\` | ~1143–1162 |
| 3 | \`useWorktreeHunksHydration\` | \`getWorktreeHunks\` | \`worktreeHunks\` | ~1175–1205 |
| 4 | \`useWorktreeDiffHydration\` | \`getWorktreeFileDiff\` | \`worktreeDiff\` | ~1662–1692 |
| 5 | \`useCommitFilePreviewHydration\` | \`getCommitFilePreview\` | \`filePreview\` | ~4259–4282 |

### Contiguous vs split — **split (position-preserving)**

The five effects are **not contiguous** — they're scattered across ~3200 lines and interleaved with unrelated effects the prompt forbids touching (boot-load, PR-overview, bisect, compare-reset, branch-tab-sync, syntax-highlight). React fires hooks in declaration order, so collapsing them into one call site would reorder them relative to those intervening hooks. Following the PR 6 / PR 7 precedent, the module exports **five hooks**, each called at its **original slot** in \`app.ts\`. Order correctness wins over tidiness.

### Frame-tagging / cancellation / cache-skip

These loaders are **not** part of the frame-tagged \`context\` cluster: unlike detail hydration (PR 7), they write to **local \`useState\` slots**, not \`setContext\`/\`setContextStatus\`, and therefore carry **no \`issuedAtDepth\` frame-tag** — cancellation is the \`active\` flag alone, exactly as in the original inline code. The \`active\` cancellation flag, the \`safe()\` wrapper, the \`set*Loading\` toggles, the guard conditions, and the dependency arrays are all reproduced **byte-for-byte**. The dedicated \`useState\` slots stay in \`app.ts\` (their setters are also called from staging callbacks and the compare-reset effect), so each hook receives the setter(s) it needs.

### Pure core

Extracted \`shouldLoadWorktreeDiff(activeView, selectedWorktreeFile)\` — the guard shared identically by loaders 3 and 4 — and unit-tested it in \`useDiffHydration.test.ts\` (4 tests). The effects keep their guard inline and byte-for-byte; the helper documents/tests the decision rather than replacing it. The other four loaders are inline-async with no clean seam; they rely on the green build.

### \`app.ts\` reduction

- \`React.useEffect\`: **28 → 23** (−5)
- \`React.useState\`: **23 → 23** (unchanged — state slots stay in \`app.ts\` by design)

### Validation

- \`npm test\` fully green: **273 passed, 1 skipped** (the gated GitLab integration test), 3447 tests passing.
- \`npx tsc --noEmit\` clean.