### PR TITLE
refactor(workstation): extract context hydration + refresh watcher into hooks (0.72 app.ts decomposition)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -112,10 +112,6 @@ import {
     rectifyPromotedSelectionIndex,
 } from '../chrome/selectionRectify'
 import {
-    LogInkRefreshWatcher,
-    createRefreshWatcher,
-} from '../chrome/refreshWatcher'
-import {
     LOG_INK_DEFAULT_COLUMNS,
     LOG_INK_DEFAULT_ROWS,
     LOG_INK_MIN_COLUMNS,
@@ -339,6 +335,7 @@ import type { LogArgv } from '../../commands/log/config'
 // LogInkState filter-mode shape.
 import { matchesPromotedFilter } from '../runtime/promotedFilter'
 import { useFilteredLists } from './hooks/buildFilteredLists'
+import { useContextHydration } from './hooks/useContextHydration'
 import { useBlameLoadingState, useDetailHydration } from './hooks/useDetailHydration'
 import {
   useCommitFilePreviewHydration,
@@ -348,6 +345,7 @@ import {
   useWorktreeHunksHydration,
 } from './hooks/useDiffHydration'
 import { useIdleTip } from './hooks/useIdleTip'
+import { useRefreshWatcher } from './hooks/useRefreshWatcher'
 import { useActiveRepoRoot, useViewModePersistence } from './hooks/useRepoPersistence'
 import { useSpinnerFrame } from './hooks/useSpinnerFrame'
 import { useStatusSurfaceData } from './hooks/buildStatusSurfaceData'
@@ -1009,55 +1007,17 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   }, [git, runtimes.length, setContext, setContextStatus])
 
   // Live refresh: watch .git metadata + the working tree root and reload
-  // context when something changes outside the TUI (editor save, external
-  // git commands, branch switch in another terminal). Best-effort — the
-  // watcher quietly skips paths that don't exist or platforms where
-  // fs.watch fails. Subdirectory unstaged edits don't fire; users can
-  // press `r` for those.
-  React.useEffect(() => {
-    let cancelled = false
-    let watcher: LogInkRefreshWatcher | null = null
-
-    void (async () => {
-      try {
-        const [repoRoot, gitDir] = await Promise.all([
-          git.revparse(['--show-toplevel']),
-          git.revparse(['--absolute-git-dir']),
-        ])
-        if (cancelled) {
-          return
-        }
-        watcher = createRefreshWatcher({
-          repoRoot: repoRoot.trim(),
-          gitDir: gitDir.trim(),
-          // Editor saves and git background processes can produce a steady
-          // drip of fs events on busy repos. The default 250ms debounce
-          // was tight enough that the watcher fired ~once per second; 750
-          // batches the steady-state better without delaying the user's
-          // perception of an actual change.
-          debounceMs: 750,
-          onChange: (kind) => {
-            if (!mountedRef.current) {
-              return
-            }
-            if (kind === 'full') {
-              void refreshContext({ silent: true })
-            } else {
-              void refreshWorktreeContext({ silent: true })
-            }
-          },
-        })
-      } catch {
-        // Not in a git worktree, or revparse failed. Skip — manual `r`
-        // refresh still works.
-      }
-    })()
-
-    return () => {
-      cancelled = true
-      watcher?.close()
-    }
-  }, [git, refreshContext, refreshWorktreeContext])
+  // context when something changes outside the TUI. Lifted verbatim into
+  // `useRefreshWatcher` (0.72 app.ts decomposition, PR 9) — the async
+  // `revparse` bootstrap, the `cancelled` guard, the 750ms debounce, the
+  // `mountedRef` mount check, and the `watcher?.close()` teardown all carry
+  // over byte-for-byte, as does the dep array.
+  useRefreshWatcher(React, {
+    git,
+    mountedRef,
+    refreshContext,
+    refreshWorktreeContext,
+  })
 
   // Per-repo sidebar tab persistence (#21). Resolve the repo root, look
   // up the cached tab, and dispatch `restoreSidebarTab` once on mount so
@@ -1190,75 +1150,25 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // effect still gated on git swaps only.
   const contextStatusRef = React.useRef(contextStatus)
   contextStatusRef.current = contextStatus
-  React.useEffect(() => {
-    // #994 — capture the depth this boot load is being issued for.
-    // The git instance in the closure is bound to this frame; tagged
-    // writes ensure resolved values land on the correct runtime entry
-    // even if a subsequent push/pop changes the active frame mid-load.
-    const issuedAtDepth = runtimes.length - 1
-    let active = true
-
-    loadLogInkContextEntries(git).forEach(({ key, load }) => {
-      if (contextStatusRef.current[key] === 'ready') return
-      void load().then((value) => {
-        if (!active) {
-          return
-        }
-
-        setContext(
-          (current) => ({
-            ...current,
-            [key]: value,
-          }),
-          issuedAtDepth,
-        )
-        setContextStatus(
-          (current) => updateLogInkContextStatus(current, key, 'ready'),
-          issuedAtDepth,
-        )
-      })
-    })
-
-    return () => {
-      active = false
-    }
-  }, [git, runtimes.length, setContext, setContextStatus])
-
-  // Lazy-load the full pullRequest overview (#808). Only fires when
-  // the user actually navigates to the PR view, and only when we
-  // don't already have data (so a workflow-triggered refresh that
-  // hydrated `pullRequest` doesn't re-fetch on view entry). The
-  // dedicated PR view shows its own loading state while this is in
-  // flight; everywhere else (header glyph, yank, workflow runner)
-  // already falls through to the slim `provider.currentPullRequest`
-  // so the chrome stays populated immediately on boot.
-  React.useEffect(() => {
-    if (state.activeView !== 'pull-request') return
-    if (context.pullRequest) return
-    const issuedAtDepth = runtimes.length - 1
-    let active = true
-    setContextStatus(
-      (current) => updateLogInkContextStatus(current, 'pullRequest', 'loading'),
-      issuedAtDepth,
-    )
-    void safe(getForgePullRequestOverview(git)).then((value) => {
-      if (!active) return
-      setContext(
-        (current) => ({
-          ...current,
-          pullRequest: value,
-        }),
-        issuedAtDepth,
-      )
-      setContextStatus(
-        (current) => updateLogInkContextStatus(current, 'pullRequest', 'ready'),
-        issuedAtDepth,
-      )
-    })
-    return () => {
-      active = false
-    }
-  }, [git, runtimes.length, state.activeView, context.pullRequest, setContext, setContextStatus])
+  // Cache-aware boot load + lazy PR-overview hydration. Both effects were
+  // lifted verbatim into `useContextHydration` (0.72 app.ts decomposition,
+  // PR 9): the per-key `'ready'` gate (read through `contextStatusRef`),
+  // the `active` cancellation flag, the PR view / cache guards, and — the
+  // critical invariant — the `issuedAtDepth = runtimes.length - 1`
+  // frame-tag captured *before* the await all carry over byte-for-byte, as
+  // do the dep arrays. `loadLogInkContextEntries` (the boot loader table)
+  // and `contextStatusRef` stay here and are injected so the move stays
+  // faithful without relocating unrelated module-local helpers.
+  useContextHydration(React, {
+    git,
+    activeView: state.activeView,
+    context,
+    runtimes,
+    loadLogInkContextEntries,
+    contextStatusRef,
+    setContext,
+    setContextStatus,
+  })
 
   // Lazy-load the issue triage list (#882 phase 3, filter-aware
   // since phase 6). Fires on entry to the view AND on filter

--- a/src/workstation/runtime/hooks/useContextHydration.test.ts
+++ b/src/workstation/runtime/hooks/useContextHydration.test.ts
@@ -1,0 +1,64 @@
+import { shouldHydrateContextKey } from './useContextHydration'
+import {
+  createLogInkContextStatus,
+  updateLogInkContextStatus,
+} from '../../chrome/context'
+
+/**
+ * Unit tests for the pure `shouldHydrateContextKey` core (0.72 app.ts
+ * decomposition, PR 9). No React harness — the two context-hydration effects
+ * (boot load + PR overview) are verbatim lifts of inline-async effects
+ * validated by the green build; only the extracted per-key boot gate
+ * ("hydrate a key unless its status is already 'ready'") is exercised here.
+ * This mirrors the inline guard
+ * `if (contextStatusRef.current[key] === 'ready') return`.
+ */
+describe('shouldHydrateContextKey', () => {
+  it('hydrates (true) a key that is still idle', () => {
+    const status = createLogInkContextStatus('idle')
+    expect(shouldHydrateContextKey(status, 'branches')).toBe(true)
+  })
+
+  it('hydrates (true) a key that is mid-load', () => {
+    const status = updateLogInkContextStatus(
+      createLogInkContextStatus('idle'),
+      'tags',
+      'loading',
+    )
+    expect(shouldHydrateContextKey(status, 'tags')).toBe(true)
+  })
+
+  it('skips (false) a key that is already ready', () => {
+    const status = updateLogInkContextStatus(
+      createLogInkContextStatus('idle'),
+      'branches',
+      'ready',
+    )
+    expect(shouldHydrateContextKey(status, 'branches')).toBe(false)
+  })
+
+  it('decides per key — a ready sibling does not gate another key', () => {
+    const status = updateLogInkContextStatus(
+      createLogInkContextStatus('idle'),
+      'branches',
+      'ready',
+    )
+    // `branches` is ready (skip) but `tags` is still idle (hydrate).
+    expect(shouldHydrateContextKey(status, 'branches')).toBe(false)
+    expect(shouldHydrateContextKey(status, 'tags')).toBe(true)
+  })
+
+  it('hydrates (true) every key when the whole status is fresh', () => {
+    const status = createLogInkContextStatus('idle')
+    for (const key of Object.keys(status) as Array<keyof typeof status>) {
+      expect(shouldHydrateContextKey(status, key)).toBe(true)
+    }
+  })
+
+  it('skips (false) every key when the whole status is ready', () => {
+    const status = createLogInkContextStatus('ready')
+    for (const key of Object.keys(status) as Array<keyof typeof status>) {
+      expect(shouldHydrateContextKey(status, key)).toBe(false)
+    }
+  })
+})

--- a/src/workstation/runtime/hooks/useContextHydration.ts
+++ b/src/workstation/runtime/hooks/useContextHydration.ts
@@ -1,0 +1,215 @@
+/**
+ * Context hydration effects (extracted in the 0.72 app.ts decomposition,
+ * PR 9).
+ *
+ * This module lifts the two effects that load the MAIN context for the
+ * active view into the active repo-stack frame's `context` /
+ * `contextStatus`:
+ *
+ *   1. Boot load     — fires on every `git` swap (mount, drill-in,
+ *      drill-out). Iterates the per-key boot loaders from
+ *      `loadLogInkContextEntries(git)`, skips any key already `'ready'`
+ *      (read through `contextStatusRef`, NOT the `contextStatus` dep, so
+ *      the effect's own per-key `'ready'` writes don't re-fire it), and
+ *      writes each resolved value + `'ready'` status as it lands.
+ *   2. PR overview   — lazily loads the full `pullRequest` overview (#808)
+ *      the first time the user navigates to the PR view and only when it
+ *      isn't already cached.
+ *
+ * Both effects:
+ *   - capture the `issuedAtDepth = runtimes.length - 1` frame-tag
+ *     **BEFORE the await** and pass it to `setContext` / `setContextStatus`
+ *     so an in-flight load lands on the repo-stack frame that issued it,
+ *     not whichever frame is on top when the fetch resolves (#994);
+ *   - guard stale results with an `active` flag flipped false in cleanup.
+ *
+ * The two effects are reproduced **verbatim and separate** — the per-key
+ * gate, the `contextStatusRef` read, the `active` cancellation flag, the
+ * view / cache guards, the `issuedAtDepth` capture-before-await, and the
+ * dependency arrays are byte-for-byte the same as the original `app.ts`
+ * cluster. This is a behavior-preserving move, not a rewrite. They are
+ * adjacent in `app.ts` and stay adjacent here (one hook, two effects in
+ * order).
+ *
+ * `loadLogInkContextEntries` (the boot per-key loader table) and
+ * `contextStatusRef` (the latest-status ref) live in `app.ts` and are
+ * injected so the move stays faithful without relocating unrelated
+ * module-local helpers.
+ *
+ * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
+ * convention) because the workstation never statically imports React.
+ */
+
+import type * as ReactTypes from 'react'
+import type { SimpleGit } from 'simple-git'
+import { getForgePullRequestOverview } from '../../../git/forgeActions'
+import type {
+  LogInkContextKey,
+  LogInkContextStatus,
+} from '../../chrome/context'
+import { updateLogInkContextStatus } from '../../chrome/context'
+import type { LogInkView } from '../inkViewModel'
+import type { LogInkContext } from '../types'
+
+/**
+ * Best-effort promise unwrap, lifted verbatim from `app.ts`. Swallows the
+ * rejection so a failed fetch leaves the existing context on screen instead
+ * of crashing the workstation.
+ */
+async function safe<T>(promise: Promise<T>): Promise<T | undefined> {
+  try {
+    return await promise
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Pure gate for the per-key boot load: hydrate a key only when it isn't
+ * already `'ready'`. Mirrors the inline guard
+ * `if (contextStatusRef.current[key] === 'ready') return` — returns `false`
+ * when the key is already loaded (skip the fetch), `true` otherwise
+ * (hydrate). Pulled out so the "skip already-ready keys" decision is
+ * unit-testable without spinning React, a repo stack, or the loader table.
+ *
+ * The boot-load effect keeps its check inline and byte-for-byte; this helper
+ * documents and tests the decision rather than replacing it.
+ */
+export function shouldHydrateContextKey(
+  status: LogInkContextStatus,
+  key: LogInkContextKey,
+): boolean {
+  return status[key] !== 'ready'
+}
+
+export type UseContextHydrationDeps = {
+  /** The active frame's `git`. Drives both boot and PR-overview fetches. */
+  git: SimpleGit
+  /** `state.activeView` — only `'pull-request'` triggers the PR overview. */
+  activeView: LogInkView
+  /**
+   * The active frame's loaded context. `context.pullRequest` is the cache
+   * guard for the PR-overview effect.
+   */
+  context: LogInkContext
+  /** Repo-stack runtimes — `runtimes.length - 1` is the frame-tag depth. */
+  runtimes: readonly unknown[]
+  /**
+   * The boot per-key loader table (`loadLogInkContextEntries`), kept in
+   * `app.ts`. Each entry resolves one context key.
+   */
+  loadLogInkContextEntries: (git: SimpleGit) => Array<{
+    key: LogInkContextKey
+    load: () => Promise<LogInkContext[LogInkContextKey] | undefined>
+  }>
+  /**
+   * Latest-status ref (`contextStatusRef`), kept in `app.ts`. Read inside
+   * the boot effect so its own per-key `'ready'` writes don't re-trigger it.
+   */
+  contextStatusRef: ReactTypes.MutableRefObject<LogInkContextStatus>
+  /** Frame-tagging context writer (`setContext(next, issuedAtDepth)`). */
+  setContext: (
+    arg: LogInkContext | ((prev: LogInkContext) => LogInkContext),
+    targetDepth?: number,
+  ) => void
+  /** Frame-tagging status writer (`setContextStatus(next, issuedAtDepth)`). */
+  setContextStatus: (
+    arg:
+      | LogInkContextStatus
+      | ((prev: LogInkContextStatus) => LogInkContextStatus),
+    targetDepth?: number,
+  ) => void
+}
+
+/**
+ * Issues the boot-load and PR-overview context-hydration effects, in their
+ * original `app.ts` order and position (boot load, then PR overview). Each
+ * effect is reproduced verbatim — same per-key / view / cache guards, same
+ * `active` cancellation flag, same `issuedAtDepth = runtimes.length - 1`
+ * frame-tag captured *before* the `await`, same dependency array.
+ */
+export function useContextHydration(
+  React: typeof ReactTypes,
+  deps: UseContextHydrationDeps,
+): void {
+  const {
+    git,
+    activeView,
+    context,
+    runtimes,
+    loadLogInkContextEntries,
+    contextStatusRef,
+    setContext,
+    setContextStatus,
+  } = deps
+
+  React.useEffect(() => {
+    // #994 — capture the depth this boot load is being issued for.
+    // The git instance in the closure is bound to this frame; tagged
+    // writes ensure resolved values land on the correct runtime entry
+    // even if a subsequent push/pop changes the active frame mid-load.
+    const issuedAtDepth = runtimes.length - 1
+    let active = true
+
+    loadLogInkContextEntries(git).forEach(({ key, load }) => {
+      if (contextStatusRef.current[key] === 'ready') return
+      void load().then((value) => {
+        if (!active) {
+          return
+        }
+
+        setContext(
+          (current) => ({
+            ...current,
+            [key]: value,
+          }),
+          issuedAtDepth,
+        )
+        setContextStatus(
+          (current) => updateLogInkContextStatus(current, key, 'ready'),
+          issuedAtDepth,
+        )
+      })
+    })
+
+    return () => {
+      active = false
+    }
+  }, [git, runtimes.length, setContext, setContextStatus])
+
+  // Lazy-load the full pullRequest overview (#808). Only fires when
+  // the user actually navigates to the PR view, and only when we
+  // don't already have data (so a workflow-triggered refresh that
+  // hydrated `pullRequest` doesn't re-fetch on view entry). The
+  // dedicated PR view shows its own loading state while this is in
+  // flight; everywhere else (header glyph, yank, workflow runner)
+  // already falls through to the slim `provider.currentPullRequest`
+  // so the chrome stays populated immediately on boot.
+  React.useEffect(() => {
+    if (activeView !== 'pull-request') return
+    if (context.pullRequest) return
+    const issuedAtDepth = runtimes.length - 1
+    let active = true
+    setContextStatus(
+      (current) => updateLogInkContextStatus(current, 'pullRequest', 'loading'),
+      issuedAtDepth,
+    )
+    void safe(getForgePullRequestOverview(git)).then((value) => {
+      if (!active) return
+      setContext(
+        (current) => ({
+          ...current,
+          pullRequest: value,
+        }),
+        issuedAtDepth,
+      )
+      setContextStatus(
+        (current) => updateLogInkContextStatus(current, 'pullRequest', 'ready'),
+        issuedAtDepth,
+      )
+    })
+    return () => {
+      active = false
+    }
+  }, [git, runtimes.length, activeView, context.pullRequest, setContext, setContextStatus])
+}

--- a/src/workstation/runtime/hooks/useRefreshWatcher.ts
+++ b/src/workstation/runtime/hooks/useRefreshWatcher.ts
@@ -1,0 +1,107 @@
+/**
+ * Live-refresh filesystem watcher (extracted in the 0.72 app.ts
+ * decomposition, PR 9).
+ *
+ * This module lifts the single effect that watches the repo's `.git`
+ * metadata + working-tree root and re-triggers a context reload when
+ * something changes outside the TUI (editor save, external git commands,
+ * a branch switch in another terminal). On a `'full'` change it calls
+ * `refreshContext({ silent: true })`; on a worktree-only change it calls
+ * `refreshWorktreeContext({ silent: true })`. Both refreshers are the
+ * frame-tagged `useCallback`s from `app.ts`, passed in unchanged.
+ *
+ * The effect is reproduced **verbatim** — the async `revparse` bootstrap,
+ * the `cancelled` guard, the 750ms debounce, the `mountedRef` mount check
+ * inside `onChange`, the best-effort `try/catch`, and — critically — the
+ * cleanup that flips `cancelled` and calls `watcher?.close()` all carry
+ * over byte-for-byte. A leaked watcher is a real regression, so the
+ * teardown return is preserved exactly. The dependency array
+ * `[git, refreshContext, refreshWorktreeContext]` is unchanged. This is a
+ * behavior-preserving move, not a rewrite.
+ *
+ * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
+ * convention) because the workstation never statically imports React.
+ */
+
+import type * as ReactTypes from 'react'
+import type { SimpleGit } from 'simple-git'
+import type { LogInkRefreshWatcher } from '../../chrome/refreshWatcher'
+import { createRefreshWatcher } from '../../chrome/refreshWatcher'
+
+export type UseRefreshWatcherDeps = {
+  /** The active frame's `git`. Drives `revparse` + scopes the watcher. */
+  git: SimpleGit
+  /** Mount flag — `onChange` no-ops once the component unmounts. */
+  mountedRef: ReactTypes.MutableRefObject<boolean>
+  /** Frame-tagged full-context refresher (`refreshContext`) from `app.ts`. */
+  refreshContext: (options?: { silent?: boolean }) => Promise<void>
+  /**
+   * Frame-tagged worktree-only refresher (`refreshWorktreeContext`) from
+   * `app.ts`.
+   */
+  refreshWorktreeContext: (options?: { silent?: boolean }) => Promise<unknown>
+}
+
+/**
+ * Issues the live-refresh watcher effect, in its original `app.ts`
+ * position. Reproduced verbatim — same async bootstrap, same `cancelled`
+ * guard, same 750ms debounce, same `mountedRef` check, same best-effort
+ * `try/catch`, same `watcher?.close()` teardown, same dependency array.
+ */
+export function useRefreshWatcher(
+  React: typeof ReactTypes,
+  deps: UseRefreshWatcherDeps,
+): void {
+  const { git, mountedRef, refreshContext, refreshWorktreeContext } = deps
+
+  // Live refresh: watch .git metadata + the working tree root and reload
+  // context when something changes outside the TUI (editor save, external
+  // git commands, branch switch in another terminal). Best-effort — the
+  // watcher quietly skips paths that don't exist or platforms where
+  // fs.watch fails. Subdirectory unstaged edits don't fire; users can
+  // press `r` for those.
+  React.useEffect(() => {
+    let cancelled = false
+    let watcher: LogInkRefreshWatcher | null = null
+
+    void (async () => {
+      try {
+        const [repoRoot, gitDir] = await Promise.all([
+          git.revparse(['--show-toplevel']),
+          git.revparse(['--absolute-git-dir']),
+        ])
+        if (cancelled) {
+          return
+        }
+        watcher = createRefreshWatcher({
+          repoRoot: repoRoot.trim(),
+          gitDir: gitDir.trim(),
+          // Editor saves and git background processes can produce a steady
+          // drip of fs events on busy repos. The default 250ms debounce
+          // was tight enough that the watcher fired ~once per second; 750
+          // batches the steady-state better without delaying the user's
+          // perception of an actual change.
+          debounceMs: 750,
+          onChange: (kind) => {
+            if (!mountedRef.current) {
+              return
+            }
+            if (kind === 'full') {
+              void refreshContext({ silent: true })
+            } else {
+              void refreshWorktreeContext({ silent: true })
+            }
+          },
+        })
+      } catch {
+        // Not in a git worktree, or revparse failed. Skip — manual `r`
+        // refresh still works.
+      }
+    })()
+
+    return () => {
+      cancelled = true
+      watcher?.close()
+    }
+  }, [git, refreshContext, refreshWorktreeContext])
+}


### PR DESCRIPTION
PR 9 of the 0.72 \`app.ts\` decomposition. Behavior-preserving refactor of the TUI runtime: lifts the context-hydration effects (cluster J) and the live-refresh filesystem watcher (cluster K) out of \`src/workstation/runtime/app.ts\` into hooks, matching the PR 1-8 convention.

## Effects moved

### Cluster J — context hydration → \`useContextHydration.ts\`
Two adjacent effects, moved **verbatim and separate**, in original order:
- **Boot load** (orig. ~1155-1187) — cache-aware per-key boot loader. Iterates \`loadLogInkContextEntries(git)\`, skips keys already \`'ready'\` (read through \`contextStatusRef\`, not the \`contextStatus\` dep), writes each resolved value + status as it lands. Dep array \`[git, runtimes.length, setContext, setContextStatus]\`.
- **PR overview** (orig. ~1197-1223, #808) — lazily loads the full \`pullRequest\` overview on entry to the PR view, gated on \`context.pullRequest\` being absent. Dep array \`[git, runtimes.length, state.activeView, context.pullRequest, setContext, setContextStatus]\`.

The two effects are contiguous in \`app.ts\`, so they stay contiguous in one hook (two effects, in order). \`loadLogInkContextEntries\` (the boot loader table) and \`contextStatusRef\` (a \`useRef\`, must keep its hook slot) stay in \`app.ts\` and are injected, so the move is faithful without relocating unrelated module-local helpers.

### Cluster K — live-refresh watcher → \`useRefreshWatcher.ts\`
- **Refresh watcher** (orig. ~1017-1060) — \`fs.watch\`-based watcher over \`.git\` metadata + working-tree root. On a \`'full'\` change calls \`refreshContext({ silent: true })\`; on a worktree change calls \`refreshWorktreeContext({ silent: true })\`. Both refreshers are the frame-tagged \`useCallback\`s from \`app.ts\`, passed in unchanged. Dep array \`[git, refreshContext, refreshWorktreeContext]\`.

Cluster K is **not contiguous** with J (separated by the \`refreshContext\`/\`refreshWorktreeContext\` callbacks and many intervening hooks), so it is issued at its own original slot — split, position-preserving, as PR 6/7/8 did. React hook order is unchanged.

## Invariants preserved verbatim
- **\`issuedAtDepth = runtimes.length - 1\` captured BEFORE the await** in both J effects, passed to \`setContext\`/\`setContextStatus\` exactly as before — the #994 frame-tag that lands in-flight loads on the repo-stack frame that issued them after drill-in/out.
- **Watcher teardown** — the cleanup return (\`cancelled = true\` + \`watcher?.close()\`) is byte-for-byte identical; no leaked watcher.
- All dep arrays byte-identical; \`active\`/\`cancelled\` cancellation flags, view/cache guards, and the 750ms debounce carry over unchanged.

## Pure core
Extracted \`shouldHydrateContextKey(status, key)\` — the per-key boot gate (\`status[key] !== 'ready'\`), unit-tested in \`useContextHydration.test.ts\` (6 cases). The watcher is all inline-async with no clean seam, so it relies on the green build.

## app.ts reduction
- \`React.useEffect\`: 23 → 20 (3 effects moved)
- \`React.useState\`: 23 → 23 (no state moved; \`contextStatusRef\` is a \`useRef\` and stays)
- 32 insertions, 122 deletions

## Validation
- \`npm test\` fully green: 274 suites passed, 1 skipped (gated GitLab integration), 3453 tests passed.
- \`npx tsc --noEmit\` clean.