### PR TITLE
refactor(workstation): extract cursor-sync + load-more pagination into hooks (0.72 app.ts decomposition)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -58,7 +58,6 @@ import * as nodePath from 'node:path'
 import type * as ReactTypes from 'react'
 import { SimpleGit } from 'simple-git'
 import { getBranchOverview } from '../../git/branchData'
-import { hashesMatchAny } from '../../git/hashes'
 import { getLfsAttributeStatus } from '../../git/lfsAttributes'
 import { getSubmoduleOverview } from '../../git/submoduleData'
 import { getRemoteOverview } from '../../git/remoteData'
@@ -77,7 +76,6 @@ import {
     getCommitDetail,
     getCommitRows,
     getLogRows,
-    getLogRowsAnchoredOn,
 } from '../../commands/log/data'
 import {
     LogInkContextKey,
@@ -350,10 +348,8 @@ import { useActiveRepoRoot, useViewModePersistence } from './hooks/useRepoPersis
 import { useSpinnerFrame } from './hooks/useSpinnerFrame'
 import { useStatusSurfaceData } from './hooks/buildStatusSurfaceData'
 import { useStatusAutoDismiss } from './hooks/useStatusAutoDismiss'
-import {
-    buildLoadedHashSet,
-    resolveCursorSyncDecision,
-} from './cursorSyncResolver'
+import { useHistoryCursorSync } from './hooks/useHistoryCursorSync'
+import { useLoadMoreHistory } from './hooks/useLoadMoreHistory'
 
 // Chrome + overlay + dispatcher renderers extracted in phase 5a.7. The
 // per-surface and detail renderers are consumed internally by mainPanel /
@@ -1343,202 +1339,21 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   }, [git, selected?.hash])
 
   // #806 follow-up — auto-jump the history view to whichever branch /
-  // tag the user is currently cursoring in the sidebar (or the
-  // dedicated branches / tags view).
-  //
-  // Originally this fired on a 150ms trailing-edge debounce. The user
-  // reported the sync feeling inconsistent (#839) — the trailing
-  // pattern means a fast scroll through a long branch list cancels
-  // the timer on every keystroke and only fires once on release; the
-  // user never sees the cursor follow their navigation. Switched to
-  // synchronous fire-on-effect so each cursor move snaps the history
-  // graph immediately. The dispatch is cheap (O(n) findIndex on the
-  // filtered commits + a state spread); React batches the re-renders
-  // so even rapid scroll only paints the final position. Tracks the
-  // last-dispatched hash via a ref so we don't fire setStatus
-  // repeatedly when several adjacent branches all point at the same
-  // commit (very common with squash-merged feature branches that all
-  // converge on `main`'s tip).
-  //
-  // No-op when the cursored ref's tip isn't in the loaded commit
-  // window (under compact mode the cursored branch's tip may not be
-  // fetched yet); a status hint surfaces in that case so the user
-  // knows to toggle full graph or load older commits.
-  const lastSyncedHashRef = React.useRef<string | undefined>(undefined)
-  // Tracks which target hashes we've already anchored a `git log`
-  // fetch on (#1034 follow-up). When the cursor-syncs-history effect
-  // sees a target whose hash isn't in the loaded window AND isn't in
-  // this set, it kicks off `getLogRowsAnchoredOn` and adds the hash
-  // here. After the fetch resolves and rows are appended, the effect
-  // re-fires; if the target STILL isn't loaded the resolver sees the
-  // hash in this set and returns `unreachable` instead of looping.
-  //
-  // Stored as a ref because (a) the resolver only ever reads it and
-  // (b) component re-renders on state.filteredCommits change are the
-  // re-fire trigger; storing here in state would add a redundant
-  // render per attempt.
-  const attemptedContextHashesRef = React.useRef<Set<string>>(new Set())
-  // Forward-reference for the targeted context loader. Defined later
-  // in the component body — see the load-more refactor for why this
-  // forward-ref pattern is needed and why the implementation is stable
-  // so the race that bit the previous auto-load chain doesn't recur.
-  type LoadCommitContextFn = (target: { hash: string; label: string }) => Promise<void>
-  const loadCommitContextRef = React.useRef<LoadCommitContextFn | null>(null)
-  React.useEffect(() => {
-    const onBranchTab = state.activeView === 'branches' ||
-      (state.focus === 'sidebar' && state.sidebarTab === 'branches')
-    const onTagTab = state.activeView === 'tags' ||
-      (state.focus === 'sidebar' && state.sidebarTab === 'tags')
-    // User-reported gap: cursoring a stash didn't sync the history
-    // cursor the way cursoring a branch / tag did. Same auto-jump
-    // affordance now extends to stashes; the stash's commit hash IS
-    // the row to land on (stashes are commits living off the
-    // `refs/stash` tree, visible under `--all` / fullGraph).
-    const onStashTab = state.activeView === 'stash' ||
-      (state.focus === 'sidebar' && state.sidebarTab === 'stashes')
-    if (!onBranchTab && !onTagTab && !onStashTab) return
-
-    let targetHash: string | undefined
-    let targetLabel: string | undefined
-
-    if (onBranchTab) {
-      const all = sortBranches(context.branches?.localBranches || [], state.branchSort)
-      const visible = state.filter
-        ? all.filter((b) => matchesPromotedFilter([b.shortName, b.upstream || ''], state.filter))
-        : all
-      const branch = visible[Math.min(state.selectedBranchIndex, Math.max(0, visible.length - 1))]
-      if (branch) {
-        targetHash = branch.hash
-        targetLabel = `branch ${branch.shortName}`
-      }
-    } else if (onTagTab) {
-      const all = sortTags(context.tags?.tags || [], state.tagSort)
-      const visible = state.filter
-        ? all.filter((t) => matchesPromotedFilter([t.name, t.subject], state.filter))
-        : all
-      const tag = visible[Math.min(state.selectedTagIndex, Math.max(0, visible.length - 1))]
-      if (tag) {
-        targetHash = tag.hash
-        targetLabel = `tag ${tag.name}`
-      }
-    } else if (onStashTab) {
-      const all = context.stashes?.stashes || []
-      const visible = state.filter
-        ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], state.filter))
-        : all
-      const stash = visible[Math.min(state.selectedStashIndex, Math.max(0, visible.length - 1))]
-      if (stash) {
-        // Two-step fallback chain for stash cursor sync:
-        //
-        //   1. Try `baseHash` (the branch tip the stash was created
-        //      from). This answers the user-visible question "where
-        //      in larger git history was this stash made?" — that's
-        //      the branch origin point, not the stash's own merge-
-        //      commit row off in `refs/stash`. Base commits live on
-        //      regular branches so they're almost always in the
-        //      loaded window.
-        //
-        //   2. If `baseHash` isn't in the loaded window (the stash's
-        //      base branch was deleted, or the base is older than
-        //      the 1000-commit cap), fall back to `stash.hash`
-        //      itself. The stash commit was added as an extraRef so
-        //      it's reachable from the graph if it fits the window.
-        //
-        // Only after BOTH miss does the effect report "tip not in
-        // loaded window." The label flips to mention "base" vs the
-        // stash commit so the user knows what they're looking at.
-        // hashesMatchAny handles the short-hash auto-extension
-        // mismatch between `git stash list --format=%h` (stash hash)
-        // and `git log --pretty=format:%h` (history row). Same
-        // hazard as the branch/tag cursor sync — see src/git/hashes.ts.
-        const baseLoaded = Boolean(stash.baseHash) && state.filteredCommits.some((c) =>
-          hashesMatchAny(stash.baseHash, [c.hash, c.shortHash])
-        )
-        const hashLoaded = state.filteredCommits.some((c) =>
-          hashesMatchAny(stash.hash, [c.hash, c.shortHash])
-        )
-        if (baseLoaded) {
-          targetHash = stash.baseHash
-          targetLabel = `${stash.ref}'s base`
-        } else if (hashLoaded) {
-          targetHash = stash.hash
-          targetLabel = stash.ref
-        } else {
-          // Neither in window — set to baseHash so the standard
-          // "not in loaded window" message fires with a meaningful
-          // label (the base is what the user actually wants to see).
-          targetHash = stash.baseHash || stash.hash
-          targetLabel = stash.ref
-        }
-      }
-    }
-
-    // Delegate the actual decision to the pure resolver so the
-    // logic is testable in isolation. The effect just performs the
-    // resolver's chosen action.
-    const decision = resolveCursorSyncDecision({
-      target: targetHash ? { hash: targetHash, label: targetLabel || targetHash } : undefined,
-      loadedHashes: buildLoadedHashSet(state.filteredCommits),
-      lastSyncedHash: lastSyncedHashRef.current,
-      attemptedContextHashes: attemptedContextHashesRef.current,
-    })
-
-    switch (decision.type) {
-      case 'noop':
-        return
-      case 'jump':
-        lastSyncedHashRef.current = decision.hash
-        dispatch({ type: 'selectCommitByHash', hash: decision.hash })
-        dispatch({
-          type: 'setStatus',
-          value: `Synced history to ${decision.label} tip`,
-        })
-        return
-      case 'load-context':
-        // Mark the hash as attempted BEFORE firing the load so a
-        // re-fire of this effect (state.filteredCommits change while
-        // the load is in flight) doesn't kick off a duplicate
-        // request. The resolver sees the hash in the set and
-        // returns `noop` until the load completes; on completion the
-        // appendRows triggers a final re-fire that either jumps or
-        // returns `unreachable`.
-        attemptedContextHashesRef.current.add(decision.target.hash)
-        void loadCommitContextRef.current?.(decision.target)
-        return
-      case 'unreachable':
-        dispatch({
-          type: 'setStatus',
-          value: `${decision.target.label} target commit is unreachable — not in any walked ref's history.`,
-          kind: 'warning',
-        })
-        return
-    }
-  }, [
-    dispatch, context.branches, context.tags, context.stashes,
-    state.activeView, state.focus, state.sidebarTab,
-    state.selectedBranchIndex, state.selectedTagIndex, state.selectedStashIndex,
-    state.branchSort, state.tagSort, state.filter,
-    state.filteredCommits,
-  ])
-
-  // Reset the dedup ref when the user moves focus away from the
-  // sidebar branches / tags / stashes tab so re-entering re-fires the
-  // sync even if the cursored row is the same as before.
-  React.useEffect(() => {
-    const onBranchTab = state.activeView === 'branches' ||
-      (state.focus === 'sidebar' && state.sidebarTab === 'branches')
-    const onTagTab = state.activeView === 'tags' ||
-      (state.focus === 'sidebar' && state.sidebarTab === 'tags')
-    const onStashTab = state.activeView === 'stash' ||
-      (state.focus === 'sidebar' && state.sidebarTab === 'stashes')
-    if (!onBranchTab && !onTagTab && !onStashTab) {
-      lastSyncedHashRef.current = undefined
-      // Drop any context-load attempt tracking too. If the user
-      // navigates back later we want to retry rather than show
-      // "unreachable" based on a stale attempted-set.
-      attemptedContextHashesRef.current = new Set()
-    }
-  }, [state.activeView, state.focus, state.sidebarTab])
+  // tag / stash the user is cursoring (cluster N). Lifted verbatim into
+  // `useHistoryCursorSync` (0.72 app.ts decomposition, PR 10): the two
+  // cluster-local refs (`lastSyncedHashRef`, `attemptedContextHashesRef`),
+  // the forward-reference bridge ref (`loadCommitContextRef`), and the
+  // sync + reset effects move over in the same declaration order with
+  // byte-identical dep arrays. The hook RETURNS `loadCommitContextRef` so
+  // the load-more cluster (`useLoadMoreHistory`, far below) can keep its
+  // `loadCommitContextRef.current = loadCommitContext` assignment in the
+  // exact same relative slot — see that hook for the full render-order
+  // race write-up.
+  const loadCommitContextRef = useHistoryCursorSync(React, {
+    dispatch,
+    context,
+    state,
+  })
 
   // Lifted verbatim into `useWorktreeDiffHydration` (0.72 app.ts
   // decomposition, PR 8) — guard, `active` flag, `safe()` wrapper, loading
@@ -4133,194 +3948,34 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }
   }, [])
 
-  React.useEffect(() => {
-    loadingMoreCommitsRef.current = loadingMoreCommits
-  }, [loadingMoreCommits])
-
-  // STABLE useCallback (empty deps) for loadMoreCommits. The function
-  // reads the volatile state (commit counts, fetch args, hasMore) via
-  // refs that update on every render so the identity stays constant.
-  //
-  // Why stable matters: the cursor-syncs-history auto-load chain
-  // calls this through a forward-reference ref (loadMoreCommitsRef).
-  // If loadMoreCommits regenerated on every render — as the previous
-  // implementation did via state deps — there was a render-order
-  // race: the cursor sync effect would call the PREVIOUS render's
-  // callback (still in the ref because the ref-setter useEffect runs
-  // after the cursor-sync effect in declaration order), which had
-  // captured a stale `state.commits.length` and re-fetched the same
-  // window. The auto-load chain appeared to fire but never advanced
-  // through history.
-  //
-  // Stable identity + refs sidesteps the race entirely: the function
-  // never changes, and every call reads the latest state.
-  const loadMoreStateRef = React.useRef({
-    commitsLength: state.commits.length,
-    filteredCommitsLength: state.filteredCommits.length,
-    historyFetchArgs: state.historyFetchArgs,
-    hasMoreCommits,
-    logArgv,
-  })
-  loadMoreStateRef.current = {
-    commitsLength: state.commits.length,
-    filteredCommitsLength: state.filteredCommits.length,
-    historyFetchArgs: state.historyFetchArgs,
-    hasMoreCommits,
-    logArgv,
-  }
-
-  const loadMoreCommits = React.useCallback(async (
-    options: { statusMessage?: string } = {}
-  ): Promise<{ fired: boolean; addedCommits: number }> => {
-    const snap = loadMoreStateRef.current
-    if (!snap.logArgv || snap.logArgv.limit || loadingMoreCommitsRef.current || !snap.hasMoreCommits) {
-      return { fired: false, addedCommits: 0 }
-    }
-    if (snap.filteredCommitsLength === 0) {
-      return { fired: false, addedCommits: 0 }
-    }
-
-    loadingMoreCommitsRef.current = true
-    const requestId = loadMoreRequestRef.current + 1
-    loadMoreRequestRef.current = requestId
-    setLoadingMoreCommits(true)
-    dispatch({
-      type: 'setStatus',
-      value: options.statusMessage || 'loading older commits',
-      loading: true,
-    })
-    const fetchArgs = snap.historyFetchArgs
-    const mergedArgv: LogArgv = {
-      ...snap.logArgv,
-      ...(fetchArgs?.author ? { author: fetchArgs.author } : {}),
-      ...(fetchArgs?.path ? { path: fetchArgs.path } : {}),
-    }
-    // Load-more paths a fresh page from git AFTER what's already
-    // loaded; pass the stash hashes again so the additional rows
-    // stay graph-consistent with the boot fetch (a window that
-    // dropped stashes mid-stream would render with broken junctions).
-    const stashHashes = await getStashCommitHashes(git).catch(() => [])
-    const nextRows = await safe(
-      getLogRows(git, mergedArgv, {
-        limit: LOG_INTERACTIVE_DEFAULT_LIMIT,
-        skip: snap.commitsLength,
-        extraRefs: stashHashes,
-      })
-    )
-
-    if (!mountedRef.current || loadMoreRequestRef.current !== requestId) {
-      return { fired: false, addedCommits: 0 }
-    }
-
-    loadingMoreCommitsRef.current = false
-    setLoadingMoreCommits(false)
-
-    const nextCommitCount = nextRows ? getCommitRows(nextRows).length : 0
-
-    if (!nextRows) {
-      dispatch({ type: 'setStatus', value: 'failed to load older commits', kind: 'error' })
-      return { fired: false, addedCommits: 0 }
-    }
-
-    if (nextRows?.length) {
-      dispatch({ type: 'appendRows', rows: nextRows })
-    }
-
-    setHasMoreCommits(nextCommitCount >= LOG_INTERACTIVE_DEFAULT_LIMIT)
-    return { fired: true, addedCommits: nextCommitCount }
-    // Empty deps — the function is intentionally stable. State is
-    // read via `loadMoreStateRef.current` at call time, and `dispatch`
-    // / `git` / `setLoadingMoreCommits` / `setHasMoreCommits` are
-    // already stable across renders by React's contract.
-  }, [dispatch, git])
-
-  // Scroll-near-bottom auto-trigger. Fires when the user's cursor is
-  // within 20 rows of the last loaded commit so older history is
-  // already on its way by the time they reach the bottom.
-  React.useEffect(() => {
-    const remaining = state.filteredCommits.length - state.selectedIndex - 1
-    if (remaining > 20) return
-    void loadMoreCommits().then((result) => {
-      if (result.fired) {
-        dispatch({
-          type: 'setStatus',
-          value: result.addedCommits
-            ? `loaded ${result.addedCommits} older commits`
-            : 'end of history',
-        })
-      }
-    })
-  }, [
+  // Load-more pagination + targeted-context loader (cluster O). Lifted
+  // verbatim into `useLoadMoreHistory` (0.72 app.ts decomposition, PR 10):
+  // the `loadingMoreCommitsRef` mirror effect, the STABLE `loadMoreCommits`
+  // `useCallback` (deps `[dispatch, git]`, identity preserved so the
+  // cursor-sync chain never sees a stale callback), the scroll-near-bottom
+  // auto-trigger effect, the STABLE `loadCommitContext` `useCallback`, and
+  // the `loadCommitContextRef.current = loadCommitContext` bridge-assignment
+  // effect all move over in the same declaration order with byte-identical
+  // dep arrays. `mountedRef`, `loadingMoreCommitsRef`, `loadMoreRequestRef`,
+  // the `hasMoreCommits` / `loadingMoreCommits` state and their setters stay
+  // in app.ts (read/written by the render and the history-filter / graph-
+  // toggle effects) and are passed in. The hook keeps the bridge assignment
+  // in its EXACT relative slot so the render-order race documented in
+  // `useHistoryCursorSync` cannot recur.
+  useLoadMoreHistory(React, {
+    git,
     dispatch,
-    loadMoreCommits,
-    state.filteredCommits.length,
-    state.selectedIndex,
-  ])
-
-  /**
-   * Targeted-context loader for the cursor-syncs-history effect. Called
-   * when the resolver returns `load-context` — the user cursored a
-   * branch / tag / stash whose target commit isn't in the loaded
-   * window, so we run a `git log` anchored on that commit (guaranteed
-   * to include it) and merge the result via `appendRows` (which
-   * already deduplicates by hash).
-   *
-   * Stable identity (empty deps) for the same reason as
-   * `loadMoreCommits` — the cursor-sync effect calls this through a
-   * forward-reference ref, and a regenerating callback would
-   * reintroduce the render-order race that bit the previous chain.
-   * All volatile state (logArgv, mostly) is read via refs.
-   */
-  const loadCommitContextStateRef = React.useRef({ logArgv })
-  loadCommitContextStateRef.current = { logArgv }
-
-  const loadCommitContext = React.useCallback(async (
-    target: { hash: string; label: string }
-  ): Promise<void> => {
-    const snap = loadCommitContextStateRef.current
-    if (!snap.logArgv) return
-    dispatch({
-      type: 'setStatus',
-      value: `Loading commits around ${target.label}…`,
-      loading: true,
-    })
-    try {
-      // No stashHashes here — `getLogRowsAnchoredOn` walks only from
-      // the target so it can guarantee the target's inclusion.
-      // Stashes are already in the loaded graph from boot's
-      // `loadRowsWithStashes`; `appendRows` deduplicates by hash so
-      // the merged result keeps both views without double-counting.
-      const rows = await getLogRowsAnchoredOn(git, snap.logArgv, target.hash, {})
-      if (!mountedRef.current) return
-      if (rows.length > 0) {
-        dispatch({ type: 'appendRows', rows })
-        // Don't dispatch a setStatus here — the cursor-sync effect
-        // will re-fire on the appendRows-driven filteredCommits
-        // change and either jump (success) or report unreachable
-        // (failure), surfacing the right message.
-      } else {
-        dispatch({
-          type: 'setStatus',
-          value: `${target.label} target commit returned no rows — orphan ref?`,
-          kind: 'warning',
-        })
-      }
-    } catch (error) {
-      if (mountedRef.current) {
-        dispatch({
-          type: 'setStatus',
-          value: `Failed to load context for ${target.label}: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-          kind: 'error',
-        })
-      }
-    }
-  }, [dispatch, git])
-
-  React.useEffect(() => {
-    loadCommitContextRef.current = loadCommitContext
-  }, [loadCommitContext])
+    state,
+    logArgv,
+    hasMoreCommits,
+    setHasMoreCommits,
+    loadingMoreCommits,
+    setLoadingMoreCommits,
+    mountedRef,
+    loadingMoreCommitsRef,
+    loadMoreRequestRef,
+    loadCommitContextRef,
+  })
 
   // Server-side history filter (#776). When the user submits `path:foo`
   // or `author:foo`, the filter parser dispatches setHistoryFetchArgs;

--- a/src/workstation/runtime/hooks/useHistoryCursorSync.ts
+++ b/src/workstation/runtime/hooks/useHistoryCursorSync.ts
@@ -1,0 +1,272 @@
+/**
+ * History-cursor sync cluster (extracted in the 0.72 app.ts decomposition,
+ * PR 10 — cluster N).
+ *
+ * This module lifts the "cursoring a branch / tag / stash auto-jumps the
+ * history cursor to that ref's commit" machinery out of `app.ts`:
+ *
+ *   1. the main sync effect — resolves the cursored ref's target hash
+ *      (branch tip / tag commit / stash base-or-commit), delegates the
+ *      decision to the pure `resolveCursorSyncDecision`, then performs
+ *      it: `jump` (move the cursor + status), `load-context` (fire the
+ *      bridged targeted loader), or `unreachable` (warn);
+ *   2. the reset effect — clears the dedup ref + the attempted-context
+ *      set when focus leaves the branches / tags / stashes surface so
+ *      re-entering re-fires the sync.
+ *
+ * THE RACE (why this is the highest-risk extraction in the series).
+ * ----------------------------------------------------------------
+ * The sync effect (cluster N) and the load-more / targeted-context
+ * machinery (cluster O, `useLoadMoreHistory`) are ~2750 lines apart in
+ * the original component with dozens of intervening effects. They are
+ * coupled through ONE forward-reference ref, `loadCommitContextRef`:
+ *
+ *   - cluster N **reads** it: when the resolver returns `load-context`,
+ *     the effect calls `loadCommitContextRef.current?.(target)` to walk
+ *     a `git log` anchored on the cursored commit and merge the result;
+ *   - cluster O **writes** it: an effect assigns
+ *     `loadCommitContextRef.current = loadCommitContext` after the
+ *     `loadCommitContext` `useCallback` is created.
+ *
+ * The ref MUST hold a *stable* callback. Cluster O's `loadCommitContext`
+ * (and its sibling `loadMoreCommits`) are `useCallback`s with stable
+ * identity — they read all volatile state through their own snapshot
+ * refs. If either regenerated every render, the cursor-sync effect (which
+ * runs BEFORE cluster O's ref-assignment effect in declaration order)
+ * would invoke the PREVIOUS render's callback still sitting in the ref —
+ * the exact render-order race that previously made the auto-load chain
+ * fire but never advance through history.
+ *
+ * To preserve that ordering EXACTLY, `loadCommitContextRef` is declared
+ * here (issued in the same slot the original cluster declared it — after
+ * the two cluster-N refs, before the sync effect) and **returned** so
+ * `app.ts` can thread it into `useLoadMoreHistory`, whose assignment
+ * effect keeps its exact relative position far below. Splitting the
+ * clusters into two position-preserving hooks (à la PR 6 `repoRootRef`)
+ * rather than one merged hook is what keeps every effect in declaration
+ * order — merging would reorder them past the ~dozens of intervening
+ * effects between the two clusters.
+ *
+ * The sync effect and reset effect are reproduced **verbatim and
+ * separate**, in original order; the target-resolution branches, the
+ * resolver call, the dispatch payloads, the `lastSyncedHashRef` dedup,
+ * the `attemptedContextHashesRef` bookkeeping, and both dependency arrays
+ * are byte-for-byte the same as the original `app.ts` cluster. This is a
+ * behavior-preserving move, not a rewrite.
+ *
+ * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
+ * convention) because the workstation never statically imports React.
+ */
+
+import type * as ReactTypes from 'react'
+import { hashesMatchAny } from '../../../git/hashes'
+import { sortBranches, sortTags } from '../../chrome/sorting'
+import { matchesPromotedFilter } from '../promotedFilter'
+import {
+  buildLoadedHashSet,
+  resolveCursorSyncDecision,
+} from '../cursorSyncResolver'
+import type { LogInkAction, LogInkState } from '../inkViewModel'
+import type { LogInkContext } from '../types'
+
+/** Forward-reference signature for the bridged targeted-context loader. */
+export type LoadCommitContextFn = (target: { hash: string; label: string }) => Promise<void>
+
+export type UseHistoryCursorSyncDeps = {
+  /** Reducer dispatch — drives the cursor jump + status updates. */
+  dispatch: (action: LogInkAction) => void
+  /** The active frame's loaded context (branches / tags / stashes). */
+  context: LogInkContext
+  /** The reducer state — read for the cursored row + loaded window. */
+  state: LogInkState
+}
+
+/**
+ * Cluster N — history-cursor sync. Issues the two cluster-local refs and
+ * the bridge ref in their original order, then the two effects verbatim.
+ * Returns `loadCommitContextRef` so `app.ts` can thread it into
+ * `useLoadMoreHistory`, which assigns `.current` at its original slot.
+ */
+export function useHistoryCursorSync(
+  React: typeof ReactTypes,
+  deps: UseHistoryCursorSyncDeps,
+): ReactTypes.MutableRefObject<LoadCommitContextFn | null> {
+  const { dispatch, context, state } = deps
+
+  const lastSyncedHashRef = React.useRef<string | undefined>(undefined)
+  // Tracks which target hashes we've already anchored a `git log`
+  // fetch on (#1034 follow-up). When the cursor-syncs-history effect
+  // sees a target whose hash isn't in the loaded window AND isn't in
+  // this set, it kicks off `getLogRowsAnchoredOn` and adds the hash
+  // here. After the fetch resolves and rows are appended, the effect
+  // re-fires; if the target STILL isn't loaded the resolver sees the
+  // hash in this set and returns `unreachable` instead of looping.
+  //
+  // Stored as a ref because (a) the resolver only ever reads it and
+  // (b) component re-renders on state.filteredCommits change are the
+  // re-fire trigger; storing here in state would add a redundant
+  // render per attempt.
+  const attemptedContextHashesRef = React.useRef<Set<string>>(new Set())
+  // Forward-reference for the targeted context loader. Defined later
+  // in the component body — see the load-more refactor for why this
+  // forward-ref pattern is needed and why the implementation is stable
+  // so the race that bit the previous auto-load chain doesn't recur.
+  const loadCommitContextRef = React.useRef<LoadCommitContextFn | null>(null)
+  React.useEffect(() => {
+    const onBranchTab = state.activeView === 'branches' ||
+      (state.focus === 'sidebar' && state.sidebarTab === 'branches')
+    const onTagTab = state.activeView === 'tags' ||
+      (state.focus === 'sidebar' && state.sidebarTab === 'tags')
+    // User-reported gap: cursoring a stash didn't sync the history
+    // cursor the way cursoring a branch / tag did. Same auto-jump
+    // affordance now extends to stashes; the stash's commit hash IS
+    // the row to land on (stashes are commits living off the
+    // `refs/stash` tree, visible under `--all` / fullGraph).
+    const onStashTab = state.activeView === 'stash' ||
+      (state.focus === 'sidebar' && state.sidebarTab === 'stashes')
+    if (!onBranchTab && !onTagTab && !onStashTab) return
+
+    let targetHash: string | undefined
+    let targetLabel: string | undefined
+
+    if (onBranchTab) {
+      const all = sortBranches(context.branches?.localBranches || [], state.branchSort)
+      const visible = state.filter
+        ? all.filter((b) => matchesPromotedFilter([b.shortName, b.upstream || ''], state.filter))
+        : all
+      const branch = visible[Math.min(state.selectedBranchIndex, Math.max(0, visible.length - 1))]
+      if (branch) {
+        targetHash = branch.hash
+        targetLabel = `branch ${branch.shortName}`
+      }
+    } else if (onTagTab) {
+      const all = sortTags(context.tags?.tags || [], state.tagSort)
+      const visible = state.filter
+        ? all.filter((t) => matchesPromotedFilter([t.name, t.subject], state.filter))
+        : all
+      const tag = visible[Math.min(state.selectedTagIndex, Math.max(0, visible.length - 1))]
+      if (tag) {
+        targetHash = tag.hash
+        targetLabel = `tag ${tag.name}`
+      }
+    } else if (onStashTab) {
+      const all = context.stashes?.stashes || []
+      const visible = state.filter
+        ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], state.filter))
+        : all
+      const stash = visible[Math.min(state.selectedStashIndex, Math.max(0, visible.length - 1))]
+      if (stash) {
+        // Two-step fallback chain for stash cursor sync:
+        //
+        //   1. Try `baseHash` (the branch tip the stash was created
+        //      from). This answers the user-visible question "where
+        //      in larger git history was this stash made?" — that's
+        //      the branch origin point, not the stash's own merge-
+        //      commit row off in `refs/stash`. Base commits live on
+        //      regular branches so they're almost always in the
+        //      loaded window.
+        //
+        //   2. If `baseHash` isn't in the loaded window (the stash's
+        //      base branch was deleted, or the base is older than
+        //      the 1000-commit cap), fall back to `stash.hash`
+        //      itself. The stash commit was added as an extraRef so
+        //      it's reachable from the graph if it fits the window.
+        //
+        // Only after BOTH miss does the effect report "tip not in
+        // loaded window." The label flips to mention "base" vs the
+        // stash commit so the user knows what they're looking at.
+        // hashesMatchAny handles the short-hash auto-extension
+        // mismatch between `git stash list --format=%h` (stash hash)
+        // and `git log --pretty=format:%h` (history row). Same
+        // hazard as the branch/tag cursor sync — see src/git/hashes.ts.
+        const baseLoaded = Boolean(stash.baseHash) && state.filteredCommits.some((c) =>
+          hashesMatchAny(stash.baseHash, [c.hash, c.shortHash])
+        )
+        const hashLoaded = state.filteredCommits.some((c) =>
+          hashesMatchAny(stash.hash, [c.hash, c.shortHash])
+        )
+        if (baseLoaded) {
+          targetHash = stash.baseHash
+          targetLabel = `${stash.ref}'s base`
+        } else if (hashLoaded) {
+          targetHash = stash.hash
+          targetLabel = stash.ref
+        } else {
+          // Neither in window — set to baseHash so the standard
+          // "not in loaded window" message fires with a meaningful
+          // label (the base is what the user actually wants to see).
+          targetHash = stash.baseHash || stash.hash
+          targetLabel = stash.ref
+        }
+      }
+    }
+
+    // Delegate the actual decision to the pure resolver so the
+    // logic is testable in isolation. The effect just performs the
+    // resolver's chosen action.
+    const decision = resolveCursorSyncDecision({
+      target: targetHash ? { hash: targetHash, label: targetLabel || targetHash } : undefined,
+      loadedHashes: buildLoadedHashSet(state.filteredCommits),
+      lastSyncedHash: lastSyncedHashRef.current,
+      attemptedContextHashes: attemptedContextHashesRef.current,
+    })
+
+    switch (decision.type) {
+      case 'noop':
+        return
+      case 'jump':
+        lastSyncedHashRef.current = decision.hash
+        dispatch({ type: 'selectCommitByHash', hash: decision.hash })
+        dispatch({
+          type: 'setStatus',
+          value: `Synced history to ${decision.label} tip`,
+        })
+        return
+      case 'load-context':
+        // Mark the hash as attempted BEFORE firing the load so a
+        // re-fire of this effect (state.filteredCommits change while
+        // the load is in flight) doesn't kick off a duplicate
+        // request. The resolver sees the hash in the set and
+        // returns `noop` until the load completes; on completion the
+        // appendRows triggers a final re-fire that either jumps or
+        // returns `unreachable`.
+        attemptedContextHashesRef.current.add(decision.target.hash)
+        void loadCommitContextRef.current?.(decision.target)
+        return
+      case 'unreachable':
+        dispatch({
+          type: 'setStatus',
+          value: `${decision.target.label} target commit is unreachable — not in any walked ref's history.`,
+          kind: 'warning',
+        })
+        return
+    }
+  }, [
+    dispatch, context.branches, context.tags, context.stashes,
+    state.activeView, state.focus, state.sidebarTab,
+    state.selectedBranchIndex, state.selectedTagIndex, state.selectedStashIndex,
+    state.branchSort, state.tagSort, state.filter,
+    state.filteredCommits,
+  ])
+
+  // Reset the dedup ref when the user moves focus away from the
+  // sidebar branches / tags / stashes tab so re-entering re-fires the
+  // sync even if the cursored row is the same as before.
+  React.useEffect(() => {
+    const onBranchTab = state.activeView === 'branches' ||
+      (state.focus === 'sidebar' && state.sidebarTab === 'branches')
+    const onTagTab = state.activeView === 'tags' ||
+      (state.focus === 'sidebar' && state.sidebarTab === 'tags')
+    const onStashTab = state.activeView === 'stash' ||
+      (state.focus === 'sidebar' && state.sidebarTab === 'stashes')
+    if (!onBranchTab && !onTagTab && !onStashTab) {
+      lastSyncedHashRef.current = undefined
+      // Drop any context-load attempt tracking too. If the user
+      // navigates back later we want to retry rather than show
+      // "unreachable" based on a stale attempted-set.
+      attemptedContextHashesRef.current = new Set()
+    }
+  }, [state.activeView, state.focus, state.sidebarTab])
+
+  return loadCommitContextRef
+}

--- a/src/workstation/runtime/hooks/useLoadMoreHistory.ts
+++ b/src/workstation/runtime/hooks/useLoadMoreHistory.ts
@@ -1,0 +1,327 @@
+/**
+ * Load-more pagination cluster (extracted in the 0.72 app.ts
+ * decomposition, PR 10 — cluster O).
+ *
+ * This module lifts the older-commit pagination machinery out of
+ * `app.ts`, in original declaration order:
+ *
+ *   1. `loadingMoreCommitsRef` mirror effect — keeps the synchronous
+ *      ref in step with the `loadingMoreCommits` state so the callbacks
+ *      can read in-flight status without a stale closure;
+ *   2. `loadMoreStateRef` + `loadMoreCommits` — the STABLE (empty-ish
+ *      dep) `useCallback` that pages a fresh `git log` window AFTER the
+ *      loaded commits, reading all volatile state via the snapshot ref;
+ *   3. the scroll-near-bottom auto-trigger effect — fires `loadMoreCommits`
+ *      once the cursor is within 20 rows of the last loaded commit;
+ *   4. `loadCommitContextStateRef` + `loadCommitContext` — the STABLE
+ *      `useCallback` that walks a `git log` anchored on a cursored ref's
+ *      commit (the targeted-context loader the cursor-sync effect bridges
+ *      to);
+ *   5. the bridge-assignment effect — `loadCommitContextRef.current =
+ *      loadCommitContext`, in its EXACT original slot at the end of the
+ *      cluster.
+ *
+ * THE RACE (read `useHistoryCursorSync` for the full write-up). Cluster N
+ * (cursor sync) **reads** `loadCommitContextRef.current`; this cluster
+ * **writes** it. The cursor-sync effect runs BEFORE this cluster's
+ * assignment effect in declaration order, so the ref must always hold a
+ * STABLE callback — otherwise the sync effect would invoke a stale
+ * previous-render callback that captured an old `state.commits.length`
+ * and re-fetched the same window, making the auto-load chain fire but
+ * never advance. `loadMoreCommits` and `loadCommitContext` are therefore
+ * kept as stable `useCallback`s (deps `[dispatch, git]`) that read all
+ * volatile state through their own snapshot refs. Both `useCallback` dep
+ * arrays and the `loadCommitContextRef.current = ` assignment timing are
+ * preserved BYTE-FOR-BYTE.
+ *
+ * Why two position-preserving hooks instead of one merged hook: the two
+ * clusters sit ~2750 lines apart with dozens of intervening effects.
+ * React fires effects in declaration order; merging would reorder them.
+ * So `loadCommitContextRef` is declared in `useHistoryCursorSync` (at the
+ * cluster-N slot) and threaded in here so the assignment effect keeps its
+ * exact relative position (à la PR 6 `repoRootRef`).
+ *
+ * Everything is reproduced **verbatim and separate**, in original order;
+ * the request-id stale guards, the `mountedRef` mount checks, the
+ * cancellation logic, the dispatch payloads, and every dependency array
+ * are byte-for-byte the same as the original `app.ts` cluster.
+ *
+ * `mountedRef`, `loadingMoreCommitsRef`, and `loadMoreRequestRef` stay
+ * declared in `app.ts` (they are shared with — or, for `mountedRef`, read
+ * by — many other clusters) and are passed in. `hasMoreCommits` /
+ * `loadingMoreCommits` state and their setters also stay in `app.ts`
+ * because the render and the history-filter / graph-toggle effects read
+ * and write them; this hook receives the values and setters.
+ *
+ * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
+ * convention) because the workstation never statically imports React.
+ */
+
+import type * as ReactTypes from 'react'
+import type { SimpleGit } from 'simple-git'
+import type { LogArgv } from '../../../commands/log/config'
+import {
+  LOG_INTERACTIVE_DEFAULT_LIMIT,
+  getCommitRows,
+  getLogRows,
+  getLogRowsAnchoredOn,
+} from '../../../commands/log/data'
+import { getStashCommitHashes } from '../../../git/stashData'
+import type { LogInkAction, LogInkState } from '../inkViewModel'
+import type { LoadCommitContextFn } from './useHistoryCursorSync'
+
+/**
+ * Best-effort promise unwrap, lifted verbatim from `app.ts`. Swallows the
+ * rejection so a failed page leaves the existing rows on screen instead
+ * of crashing the workstation.
+ */
+async function safe<T>(promise: Promise<T>): Promise<T | undefined> {
+  try {
+    return await promise
+  } catch {
+    return undefined
+  }
+}
+
+export type UseLoadMoreHistoryDeps = {
+  /** The active frame's `git`. */
+  git: SimpleGit
+  /** Reducer dispatch — drives status + row appends. */
+  dispatch: (action: LogInkAction) => void
+  /** The reducer state — read for commit counts, fetch args, cursor. */
+  state: LogInkState
+  /** The interactive log argv, or undefined when not in interactive log mode. */
+  logArgv: LogArgv | undefined
+  /** Whether the runtime believes more pages exist beyond the loaded window. */
+  hasMoreCommits: boolean
+  setHasMoreCommits: (value: boolean) => void
+  /** Whether a page fetch is currently in flight. */
+  loadingMoreCommits: boolean
+  setLoadingMoreCommits: (value: boolean) => void
+  /**
+   * Mount sentinel ref shared across the component (read by many other
+   * clusters), kept in `app.ts` and passed in so the stale-completion
+   * guards still see the live value.
+   */
+  mountedRef: ReactTypes.MutableRefObject<boolean>
+  /** Synchronous in-flight mirror of `loadingMoreCommits`, kept in `app.ts`. */
+  loadingMoreCommitsRef: ReactTypes.MutableRefObject<boolean>
+  /** Monotonic request id for the page fetch stale-completion guard. */
+  loadMoreRequestRef: ReactTypes.MutableRefObject<number>
+  /**
+   * The forward-reference bridge ref declared in `useHistoryCursorSync`.
+   * This hook's assignment effect writes `loadCommitContext` into it at
+   * the cluster's original slot so the cursor-sync effect can invoke the
+   * stable targeted-context loader.
+   */
+  loadCommitContextRef: ReactTypes.MutableRefObject<LoadCommitContextFn | null>
+}
+
+export function useLoadMoreHistory(
+  React: typeof ReactTypes,
+  deps: UseLoadMoreHistoryDeps,
+): void {
+  const {
+    git,
+    dispatch,
+    state,
+    logArgv,
+    hasMoreCommits,
+    setHasMoreCommits,
+    loadingMoreCommits,
+    setLoadingMoreCommits,
+    mountedRef,
+    loadingMoreCommitsRef,
+    loadMoreRequestRef,
+    loadCommitContextRef,
+  } = deps
+
+  React.useEffect(() => {
+    loadingMoreCommitsRef.current = loadingMoreCommits
+  }, [loadingMoreCommits])
+
+  // STABLE useCallback (empty deps) for loadMoreCommits. The function
+  // reads the volatile state (commit counts, fetch args, hasMore) via
+  // refs that update on every render so the identity stays constant.
+  //
+  // Why stable matters: the cursor-syncs-history auto-load chain
+  // calls this through a forward-reference ref (loadMoreCommitsRef).
+  // If loadMoreCommits regenerated on every render — as the previous
+  // implementation did via state deps — there was a render-order
+  // race: the cursor sync effect would call the PREVIOUS render's
+  // callback (still in the ref because the ref-setter useEffect runs
+  // after the cursor-sync effect in declaration order), which had
+  // captured a stale `state.commits.length` and re-fetched the same
+  // window. The auto-load chain appeared to fire but never advanced
+  // through history.
+  //
+  // Stable identity + refs sidesteps the race entirely: the function
+  // never changes, and every call reads the latest state.
+  const loadMoreStateRef = React.useRef({
+    commitsLength: state.commits.length,
+    filteredCommitsLength: state.filteredCommits.length,
+    historyFetchArgs: state.historyFetchArgs,
+    hasMoreCommits,
+    logArgv,
+  })
+  loadMoreStateRef.current = {
+    commitsLength: state.commits.length,
+    filteredCommitsLength: state.filteredCommits.length,
+    historyFetchArgs: state.historyFetchArgs,
+    hasMoreCommits,
+    logArgv,
+  }
+
+  const loadMoreCommits = React.useCallback(async (
+    options: { statusMessage?: string } = {}
+  ): Promise<{ fired: boolean; addedCommits: number }> => {
+    const snap = loadMoreStateRef.current
+    if (!snap.logArgv || snap.logArgv.limit || loadingMoreCommitsRef.current || !snap.hasMoreCommits) {
+      return { fired: false, addedCommits: 0 }
+    }
+    if (snap.filteredCommitsLength === 0) {
+      return { fired: false, addedCommits: 0 }
+    }
+
+    loadingMoreCommitsRef.current = true
+    const requestId = loadMoreRequestRef.current + 1
+    loadMoreRequestRef.current = requestId
+    setLoadingMoreCommits(true)
+    dispatch({
+      type: 'setStatus',
+      value: options.statusMessage || 'loading older commits',
+      loading: true,
+    })
+    const fetchArgs = snap.historyFetchArgs
+    const mergedArgv: LogArgv = {
+      ...snap.logArgv,
+      ...(fetchArgs?.author ? { author: fetchArgs.author } : {}),
+      ...(fetchArgs?.path ? { path: fetchArgs.path } : {}),
+    }
+    // Load-more paths a fresh page from git AFTER what's already
+    // loaded; pass the stash hashes again so the additional rows
+    // stay graph-consistent with the boot fetch (a window that
+    // dropped stashes mid-stream would render with broken junctions).
+    const stashHashes = await getStashCommitHashes(git).catch(() => [])
+    const nextRows = await safe(
+      getLogRows(git, mergedArgv, {
+        limit: LOG_INTERACTIVE_DEFAULT_LIMIT,
+        skip: snap.commitsLength,
+        extraRefs: stashHashes,
+      })
+    )
+
+    if (!mountedRef.current || loadMoreRequestRef.current !== requestId) {
+      return { fired: false, addedCommits: 0 }
+    }
+
+    loadingMoreCommitsRef.current = false
+    setLoadingMoreCommits(false)
+
+    const nextCommitCount = nextRows ? getCommitRows(nextRows).length : 0
+
+    if (!nextRows) {
+      dispatch({ type: 'setStatus', value: 'failed to load older commits', kind: 'error' })
+      return { fired: false, addedCommits: 0 }
+    }
+
+    if (nextRows?.length) {
+      dispatch({ type: 'appendRows', rows: nextRows })
+    }
+
+    setHasMoreCommits(nextCommitCount >= LOG_INTERACTIVE_DEFAULT_LIMIT)
+    return { fired: true, addedCommits: nextCommitCount }
+    // Empty deps — the function is intentionally stable. State is
+    // read via `loadMoreStateRef.current` at call time, and `dispatch`
+    // / `git` / `setLoadingMoreCommits` / `setHasMoreCommits` are
+    // already stable across renders by React's contract.
+  }, [dispatch, git])
+
+  // Scroll-near-bottom auto-trigger. Fires when the user's cursor is
+  // within 20 rows of the last loaded commit so older history is
+  // already on its way by the time they reach the bottom.
+  React.useEffect(() => {
+    const remaining = state.filteredCommits.length - state.selectedIndex - 1
+    if (remaining > 20) return
+    void loadMoreCommits().then((result) => {
+      if (result.fired) {
+        dispatch({
+          type: 'setStatus',
+          value: result.addedCommits
+            ? `loaded ${result.addedCommits} older commits`
+            : 'end of history',
+        })
+      }
+    })
+  }, [
+    dispatch,
+    loadMoreCommits,
+    state.filteredCommits.length,
+    state.selectedIndex,
+  ])
+
+  /**
+   * Targeted-context loader for the cursor-syncs-history effect. Called
+   * when the resolver returns `load-context` — the user cursored a
+   * branch / tag / stash whose target commit isn't in the loaded
+   * window, so we run a `git log` anchored on that commit (guaranteed
+   * to include it) and merge the result via `appendRows` (which
+   * already deduplicates by hash).
+   *
+   * Stable identity (empty deps) for the same reason as
+   * `loadMoreCommits` — the cursor-sync effect calls this through a
+   * forward-reference ref, and a regenerating callback would
+   * reintroduce the render-order race that bit the previous chain.
+   * All volatile state (logArgv, mostly) is read via refs.
+   */
+  const loadCommitContextStateRef = React.useRef({ logArgv })
+  loadCommitContextStateRef.current = { logArgv }
+
+  const loadCommitContext = React.useCallback(async (
+    target: { hash: string; label: string }
+  ): Promise<void> => {
+    const snap = loadCommitContextStateRef.current
+    if (!snap.logArgv) return
+    dispatch({
+      type: 'setStatus',
+      value: `Loading commits around ${target.label}…`,
+      loading: true,
+    })
+    try {
+      // No stashHashes here — `getLogRowsAnchoredOn` walks only from
+      // the target so it can guarantee the target's inclusion.
+      // Stashes are already in the loaded graph from boot's
+      // `loadRowsWithStashes`; `appendRows` deduplicates by hash so
+      // the merged result keeps both views without double-counting.
+      const rows = await getLogRowsAnchoredOn(git, snap.logArgv, target.hash, {})
+      if (!mountedRef.current) return
+      if (rows.length > 0) {
+        dispatch({ type: 'appendRows', rows })
+        // Don't dispatch a setStatus here — the cursor-sync effect
+        // will re-fire on the appendRows-driven filteredCommits
+        // change and either jump (success) or report unreachable
+        // (failure), surfacing the right message.
+      } else {
+        dispatch({
+          type: 'setStatus',
+          value: `${target.label} target commit returned no rows — orphan ref?`,
+          kind: 'warning',
+        })
+      }
+    } catch (error) {
+      if (mountedRef.current) {
+        dispatch({
+          type: 'setStatus',
+          value: `Failed to load context for ${target.label}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          kind: 'error',
+        })
+      }
+    }
+  }, [dispatch, git])
+
+  React.useEffect(() => {
+    loadCommitContextRef.current = loadCommitContext
+  }, [loadCommitContext])
+}

--- a/src/workstation/runtime/loadMoreResolver.test.ts
+++ b/src/workstation/runtime/loadMoreResolver.test.ts
@@ -1,0 +1,74 @@
+import { LOG_INTERACTIVE_DEFAULT_LIMIT } from '../../commands/log/data'
+import {
+  isCursorNearBottom,
+  pageImpliesMore,
+  shouldLoadMore,
+  type LoadMoreGuardSnapshot,
+} from './loadMoreResolver'
+
+const baseSnap = (): LoadMoreGuardSnapshot => ({
+  logArgv: { interactive: true } as { limit?: number },
+  loadingMore: false,
+  hasMoreCommits: true,
+  filteredCommitsLength: 1000,
+})
+
+describe('shouldLoadMore', () => {
+  it('fires when interactive, more pages exist, not loading, rows present', () => {
+    expect(shouldLoadMore(baseSnap())).toBe(true)
+  })
+
+  it('bails when there is no logArgv', () => {
+    expect(shouldLoadMore({ ...baseSnap(), logArgv: null })).toBe(false)
+    expect(shouldLoadMore({ ...baseSnap(), logArgv: undefined })).toBe(false)
+  })
+
+  it('bails when an explicit --limit is set', () => {
+    expect(shouldLoadMore({ ...baseSnap(), logArgv: { limit: 50 } })).toBe(false)
+  })
+
+  it('bails when a fetch is already in flight', () => {
+    expect(shouldLoadMore({ ...baseSnap(), loadingMore: true })).toBe(false)
+  })
+
+  it('bails when no more pages are believed to exist', () => {
+    expect(shouldLoadMore({ ...baseSnap(), hasMoreCommits: false })).toBe(false)
+  })
+
+  it('bails when zero commits are loaded (nothing to skip past)', () => {
+    expect(shouldLoadMore({ ...baseSnap(), filteredCommitsLength: 0 })).toBe(false)
+  })
+})
+
+describe('isCursorNearBottom', () => {
+  it('is false when the cursor is far from the last loaded row', () => {
+    // 100 rows, cursor at 0 → remaining 99 > 20
+    expect(isCursorNearBottom(100, 0)).toBe(false)
+  })
+
+  it('is false at exactly 21 rows remaining', () => {
+    // length 100, index 78 → remaining = 100 - 78 - 1 = 21
+    expect(isCursorNearBottom(100, 78)).toBe(false)
+  })
+
+  it('is true at exactly 20 rows remaining (boundary)', () => {
+    // length 100, index 79 → remaining = 100 - 79 - 1 = 20
+    expect(isCursorNearBottom(100, 79)).toBe(true)
+  })
+
+  it('is true on the last row', () => {
+    expect(isCursorNearBottom(100, 99)).toBe(true)
+  })
+})
+
+describe('pageImpliesMore', () => {
+  it('is true for a full page', () => {
+    expect(pageImpliesMore(LOG_INTERACTIVE_DEFAULT_LIMIT)).toBe(true)
+    expect(pageImpliesMore(LOG_INTERACTIVE_DEFAULT_LIMIT + 5)).toBe(true)
+  })
+
+  it('is false for a short page (end of history)', () => {
+    expect(pageImpliesMore(LOG_INTERACTIVE_DEFAULT_LIMIT - 1)).toBe(false)
+    expect(pageImpliesMore(0)).toBe(false)
+  })
+})

--- a/src/workstation/runtime/loadMoreResolver.ts
+++ b/src/workstation/runtime/loadMoreResolver.ts
@@ -1,0 +1,82 @@
+import { LOG_INTERACTIVE_DEFAULT_LIMIT } from '../../commands/log/data'
+
+/**
+ * Pure decision helpers for the load-more pagination cluster.
+ *
+ * The async plumbing (git fetch, dispatch, ref bookkeeping) stays in the
+ * `useLoadMoreHistory` hook; these are the two cleanly separable
+ * decisions lifted out of that machinery so they can be unit tested
+ * without driving the full runtime.
+ *
+ *   - `shouldLoadMore` — the entry guard at the top of `loadMoreCommits`.
+ *     Returns whether a fetch is even worth firing given the current
+ *     paging snapshot (interactive log only, no explicit `--limit`, not
+ *     already loading, more pages believed to exist, at least one row
+ *     loaded to skip past).
+ *
+ *   - `isCursorNearBottom` — the scroll-near-bottom auto-trigger
+ *     threshold. The auto-load fires once the cursor is within 20 rows
+ *     of the last loaded commit so older history is already on its way
+ *     by the time the user reaches the bottom.
+ *
+ * Both mirror the original inline logic byte-for-byte; the hook calls
+ * them in the exact spots the inline expressions sat.
+ */
+
+/**
+ * The slice of paging state `shouldLoadMore` reads. Matches the shape
+ * of `loadMoreStateRef.current` that the hook snapshots per render —
+ * only the fields the guard actually consults are required here.
+ */
+export type LoadMoreGuardSnapshot = {
+  /** The interactive log argv, or undefined when not in interactive log mode. */
+  logArgv: { limit?: number } | null | undefined
+  /** Whether a fetch is already in flight (mirrors `loadingMoreCommitsRef`). */
+  loadingMore: boolean
+  /** Whether the runtime believes more pages exist beyond the loaded window. */
+  hasMoreCommits: boolean
+  /** Number of filtered commits currently loaded. Zero → nothing to page past. */
+  filteredCommitsLength: number
+}
+
+/**
+ * Entry guard for `loadMoreCommits`. Returns `true` when a fetch should
+ * fire. Faithful to the original two early-return checks:
+ *
+ *   1. bail when there's no argv, an explicit `--limit` is set, a fetch
+ *      is already loading, or we've reached the end (`!hasMoreCommits`);
+ *   2. bail when no commits are loaded yet (nothing to skip past).
+ */
+export function shouldLoadMore(snap: LoadMoreGuardSnapshot): boolean {
+  if (!snap.logArgv || snap.logArgv.limit || snap.loadingMore || !snap.hasMoreCommits) {
+    return false
+  }
+  if (snap.filteredCommitsLength === 0) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Scroll-near-bottom predicate for the auto-trigger effect. `true` once
+ * the cursor sits within 20 rows of the last loaded commit. Mirrors the
+ * inline `const remaining = length - selectedIndex - 1; if (remaining > 20) return`.
+ */
+export function isCursorNearBottom(
+  filteredCommitsLength: number,
+  selectedIndex: number,
+): boolean {
+  const remaining = filteredCommitsLength - selectedIndex - 1
+  return remaining <= 20
+}
+
+/**
+ * Whether a freshly fetched page implies more pages still exist. A page
+ * that came back full (>= the interactive default limit) means git had
+ * more to give; a short page means we hit the end. Mirrors the inline
+ * `nextCommitCount >= LOG_INTERACTIVE_DEFAULT_LIMIT` used to drive
+ * `setHasMoreCommits` after every append.
+ */
+export function pageImpliesMore(pageCommitCount: number): boolean {
+  return pageCommitCount >= LOG_INTERACTIVE_DEFAULT_LIMIT
+}


### PR DESCRIPTION
PR 10 of the 0.72 \`app.ts\` decomposition. Behavior-preserving extraction of the **cursor-sync/history (cluster N)** and **load-more pagination (cluster O)** clusters out of \`src/workstation/runtime/app.ts\`. This is the highest-risk extraction in the series because of a documented render-order race between the two clusters.

## The race (what reads/writes the bridge ref, why order matters)
The two clusters are coupled through ONE forward-reference ref, \`loadCommitContextRef\`:

- **Cluster N reads it.** When the cursor-sync resolver returns \`load-context\` (user cursored a branch/tag/stash whose commit isn't in the loaded window), the effect calls \`loadCommitContextRef.current?.(target)\` to walk a \`git log\` anchored on that commit and merge the result.
- **Cluster O writes it.** An effect assigns \`loadCommitContextRef.current = loadCommitContext\` after the \`loadCommitContext\` \`useCallback\` is created.

The cursor-sync effect runs **before** cluster O's assignment effect in declaration order. The ref must therefore always hold a **stable** callback. Both \`loadMoreCommits\` and \`loadCommitContext\` are \`useCallback\`s with deps \`[dispatch, git]\` that read all volatile state (commit counts, fetch args, \`hasMore\`, \`logArgv\`) through their own per-render snapshot refs. If either regenerated every render, the cursor-sync effect would invoke the **previous** render's callback still sitting in the ref — one that captured a stale \`state.commits.length\` and re-fetched the same window, making the auto-load chain fire but never advance through history. That is the exact bug this structure prevents.

## Coupled or independent → coupled, two position-preserving hooks
The clusters are **coupled** (they share \`loadCommitContextRef\`), but they sit ~2750 lines apart with dozens of intervening effects. Merging them into one hook call site would reorder effects relative to those intervening effects, which React fires in declaration order. So — following the PR 6 \`repoRootRef\` precedent — they become **two** position-preserving hooks:

- \`useHistoryCursorSync(React, { dispatch, context, state })\` at the cluster-N slot (~line 1345). It declares the two cluster-local refs (\`lastSyncedHashRef\`, \`attemptedContextHashesRef\`) and the bridge ref \`loadCommitContextRef\` in their original order, runs the sync effect + reset effect verbatim, and **returns** \`loadCommitContextRef\`.
- \`useLoadMoreHistory(React, { ... })\` at the cluster-O slot (~line 3955). It receives \`loadCommitContextRef\` and keeps the \`loadCommitContextRef.current = loadCommitContext\` assignment effect in its **exact** relative position (last in the cluster), so the race cannot recur.

## What stayed in app.ts and why
- \`loadCommitContextRef\` is **declared inside \`useHistoryCursorSync\`** (its original slot) and threaded into \`useLoadMoreHistory\` — keeping every effect in declaration order.
- \`mountedRef\`, \`loadingMoreCommitsRef\`, \`loadMoreRequestRef\` stay declared in app.ts (\`mountedRef\` is read by ~a dozen other clusters; the other two are top-level paging refs) and are passed in.
- \`hasMoreCommits\` / \`loadingMoreCommits\` state and their setters stay in app.ts — \`setHasMoreCommits\` is also written by the history-filter (#776) and graph-toggle (#791) effects, and both values are consumed by the render. The hook receives the values + setters.

## Preserved byte-for-byte (verified by diff against HEAD)
- \`loadMoreCommits\` \`useCallback\` body + dep array \`[dispatch, git]\` — identity stability preserved.
- \`loadCommitContext\` \`useCallback\` body + dep array \`[dispatch, git]\`.
- The cursor-sync main effect (incl. its 13-line dep array) and reset effect.
- The \`loadCommitContextRef.current = loadCommitContext\` assignment effect and its timing/slot.
- Request-id stale guards, \`mountedRef\` mount checks, cancellation/\`hasMore\` guards.

## Pure cores extracted + unit-tested
\`src/workstation/runtime/loadMoreResolver.ts\` (+ test, 12 cases):
- \`shouldLoadMore(snap)\` — the entry guard.
- \`isCursorNearBottom(length, index)\` — the scroll-trigger threshold (boundary-tested at remaining === 20/21).
- \`pageImpliesMore(count)\` — the \`>= LOG_INTERACTIVE_DEFAULT_LIMIT\` \`hasMore\` recompute.

Cluster N already delegates its decision to the pre-existing, separately-tested \`resolveCursorSyncDecision\`; its target-resolution branches are tightly coupled to context/state/sort/filter with no clean seam, so they moved verbatim rather than being re-extracted.

## app.ts reduction
- \`React.useEffect\`: 20 → 15
- \`React.useCallback\`: 30 → 28
- \`React.useState\`: 23 → 23 (state intentionally stayed in app.ts)

## Validation
- \`npm run test:jest\`: 275 passed, 1 skipped (gated GitLab integration), 0 failed; 3465 tests pass.
- \`npx tsc --noEmit\`: clean.
- \`npm run build\` (rollup, the only type-check signal for the wired runtime since LogInkApp isn't mounted in tests): clean.