### PR TITLE
refactor(workstation): extract compose + editor actions into hooks (0.72 app.ts decomposition)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -61,7 +61,6 @@ import { getBranchOverview } from '../../git/branchData'
 import { getLfsAttributeStatus } from '../../git/lfsAttributes'
 import { getSubmoduleOverview } from '../../git/submoduleData'
 import { getRemoteOverview } from '../../git/remoteData'
-import { createManualCommit, formatCommitComposeMessage } from '../../commands/log/commitCompose'
 import {
     runCommitDraftWorkflow,
     runCommitSplitApplyWorkflow,
@@ -344,6 +343,8 @@ import { useStatusAutoDismiss } from './hooks/useStatusAutoDismiss'
 import { useHistoryCursorSync } from './hooks/useHistoryCursorSync'
 import { useLoadMoreHistory } from './hooks/useLoadMoreHistory'
 import { useWorktreeStageActions } from './hooks/useWorktreeStageActions'
+import { useCommitComposeActions } from './hooks/useCommitComposeActions'
+import { useEditorActions } from './hooks/useEditorActions'
 
 // Chrome + overlay + dispatcher renderers extracted in phase 5a.7. The
 // per-surface and detail renderers are consumed internally by mainPanel /
@@ -355,7 +356,6 @@ import { renderMainPanel } from '../runtime/mainPanel'
 import { renderDetailPanel } from '../runtime/detailPanel'
 import { renderOnboardingOverlay } from '../runtime/overlays'
 import { getLogInkRuntimeContext, type LogInkRuntimeContextValue } from '../runtime/runtimeContext'
-import { ensureConfigFile, resolveConfigPath, type CocoConfigScope } from './configFiles'
 
 
 
@@ -1430,56 +1430,24 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     setWorktreeHunks,
   })
 
-  const createCommitFromCompose = React.useCallback(async () => {
-    const stagedCount = context.worktree?.stagedCount || 0
-
-    if (!stagedCount) {
-      dispatch({ type: 'setStatus', value: 'stage changes before committing', kind: 'warning' })
-      return
-    }
-
-    dispatch({ type: 'commitCompose', action: { type: 'setLoading', value: true } })
-    dispatch({ type: 'setStatus', value: 'creating commit' })
-    const result = await createManualCommit({
-      git,
-      summary: state.commitCompose.summary,
-      body: state.commitCompose.body,
-    })
-
-    dispatch({
-      type: 'commitCompose',
-      action: { type: 'setResult', message: result.message, details: result.details },
-    })
-    dispatch({ type: 'setStatus', value: result.message })
-
-    if (result.ok) {
-      dispatch({ type: 'commitCompose', action: { type: 'reset' } })
-      // Refresh BOTH worktree AND history rows — the new commit
-      // needs to show up in the history view, not just the staged
-      // counts. Without refreshHistoryRows the user would press `gh`
-      // and see the pre-commit log (same silent-failure shape as
-      // the split-apply case caught in this PR).
-      await refreshHistoryRows()
-      const worktree = await refreshWorktreeContext()
-      // Leave the compose view automatically: a still-dirty tree returns
-      // to Status (so the user can keep staging), an otherwise-complete
-      // commit returns to History (where the new commit now shows). The
-      // reducer inspects the live viewStack to pick the destination.
-      const stillDirty = Boolean(
-        worktree &&
-          worktree.stagedCount + worktree.unstagedCount + worktree.untrackedCount > 0,
-      )
-      dispatch({ type: 'returnFromCommit', stillDirty })
-    }
-  }, [
-    context.worktree?.stagedCount,
-    dispatch,
+  // Lifted verbatim into `useCommitComposeActions` (0.72 app.ts
+  // decomposition). `createCommitFromCompose` and `openComposeInEditor`
+  // are non-contiguous in the original file but read only early-declared
+  // values, so a single hook call here reproduces both `useCallback`
+  // identities exactly. Both are keystroke-dispatch-only — not in any
+  // effect/memo dep array — so co-locating them is identity-safe.
+  const {
+    createCommitFromCompose,
+    openComposeInEditor,
+  } = useCommitComposeActions(React, {
     git,
+    dispatch,
+    context,
+    commitCompose: state.commitCompose,
     refreshHistoryRows,
     refreshWorktreeContext,
-    state.commitCompose.body,
-    state.commitCompose.summary,
-  ])
+    resumeRef,
+  })
 
   // AbortController for the in-flight AI draft (#881 phase 3). Kept in
   // a ref rather than state because cancel is a side-effect: the input
@@ -2001,187 +1969,19 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     try { rmSync(dir, { recursive: true, force: true }) } catch { /* ignore */ }
   }, [dispatch, resumeRef, state.changelogView.text])
 
-  // Open a file in $EDITOR (or $VISUAL) by suspending Ink's hold on the
-  // terminal, spawning the editor synchronously inheriting stdio, then
-  // restoring the alt screen + raw mode and forcing a re-render. The
-  // dance mirrors the SIGTSTP / SIGCONT path in inkTerminalLifecycle.
-  // Falls back to vi when neither env var is set; surfaces a status
-  // message on missing-binary / non-zero exit so the user isn't left
-  // wondering.
-  const openInEditor = React.useCallback((path: string) => {
-    if (!path) return
-    const editorEnv = process.env.VISUAL || process.env.EDITOR || 'vi'
-    // $VISUAL / $EDITOR commonly include flags (`code -w`, `vim -f`,
-    // `emacs -nw`). Tokenize on whitespace so the leading word is the
-    // executable and the rest are passed as arguments — passing the
-    // full string to spawnSync as the executable would fail with
-    // ENOENT for any of those configurations.
-    const editorArgs = editorEnv.trim().split(/\s+/).filter(Boolean)
-    const editor = editorArgs[0] || 'vi'
-    const editorPrefixArgs = editorArgs.slice(1)
-    const out = process.stdout
-    const stdin = process.stdin
-    const ENTER_ALT = '\x1b[?1049h'
-    const EXIT_ALT = '\x1b[?1049l'
-    const SHOW_CURSOR = '\x1b[?25h'
-    const HIDE_CURSOR = '\x1b[?25l'
-    try {
-      // Drop into the primary buffer + cooked mode so the editor
-      // doesn't inherit our raw-mode keystrokes.
-      stdin.setRawMode?.(false)
-      out.write(`${SHOW_CURSOR}${EXIT_ALT}`)
-      const result = spawnSync(editor, [...editorPrefixArgs, path], { stdio: 'inherit' })
-      if (result.error) {
-        dispatch({ type: 'setStatus', value: `Failed to launch ${editor}: ${result.error.message}`, kind: 'error' })
-      } else if (result.signal) {
-        // Editor was killed by a signal (e.g. ^C, SIGTERM). status is
-        // null in this case, so the old `status !== 0` check would
-        // mistakenly fall through to the success branch.
-        dispatch({ type: 'setStatus', value: `${editor} interrupted by ${result.signal}`, kind: 'warning' })
-      } else if (typeof result.status === 'number' && result.status !== 0) {
-        dispatch({ type: 'setStatus', value: `${editor} exited with status ${result.status}`, kind: 'warning' })
-      } else {
-        dispatch({ type: 'setStatus', value: `Edited ${path}`, kind: 'success' })
-      }
-    } finally {
-      // Re-enter the alt screen + raw mode + hidden cursor; nudge React
-      // so the freshly-restored screen actually paints.
-      out.write(`${ENTER_ALT}${HIDE_CURSOR}`)
-      stdin.setRawMode?.(true)
-      resumeRef?.current?.()
-    }
-    // Worktree status may have changed (e.g. user saved an edit) — silent
-    // refresh so the file row reflects the new staged/unstaged state.
-    void refreshWorktreeContext({ silent: true })
-  }, [dispatch, refreshWorktreeContext, resumeRef])
-
-  // Open the global or project coco config in $EDITOR (gk / gK + their
-  // command-palette entries). Scaffolds a templated starter when the file
-  // doesn't exist yet so the user never lands in an empty buffer or hits
-  // a "no such file" error.
-  const openConfigInEditor = React.useCallback((scope: CocoConfigScope) => {
-    // `repoRootRef` is populated async from `git rev-parse --show-toplevel`;
-    // fall back to cwd so a freshly-launched session can still scaffold +
-    // open the project config before that resolves.
-    const repoRoot = repoRootRef.current || process.cwd()
-    const filePath = resolveConfigPath(scope, repoRoot)
-    try {
-      const { created } = ensureConfigFile(filePath)
-      if (created) {
-        dispatch({ type: 'setStatus', value: `Created ${scope} config at ${filePath}`, kind: 'success' })
-      }
-    } catch (error) {
-      dispatch({ type: 'setStatus', value: `Could not create config: ${(error as Error).message}`, kind: 'error' })
-      return
-    }
-    openInEditor(filePath)
-  }, [dispatch, openInEditor])
-
-  // `E` keystroke handler — open the current commit draft in $EDITOR
-  // (or $VISUAL), then read the file back and update the compose state
-  // with the saved content. Mirrors the suspend → spawn → resume
-  // terminal dance of `openInEditor` but operates on an in-memory
-  // draft (round-tripped through a temp file) rather than a worktree
-  // file. Useful when the inline compose editor isn't enough — long
-  // bodies, markdown highlighting, paste from elsewhere, etc.
-  //
-  // Empty drafts are still written to the temp file so the user gets
-  // a blank canvas; the read-back uses `setDraft` which splits content
-  // into summary + body via `splitCommitDraft`, so the new content
-  // re-populates both fields correctly regardless of which one was
-  // active before.
-  const openComposeInEditor = React.useCallback(() => {
-    // Build the current draft text the same way `createManualCommit`
-    // would — single string, blank line between summary and body.
-    // Round-tripping through this format keeps the parse symmetric:
-    // the editor sees what a real commit message would look like, and
-    // `splitCommitDraft` on the way back reverses it cleanly.
-    const composeState = state.commitCompose
-    const draft = formatCommitComposeMessage(composeState.summary, composeState.body)
-
-    // Temp dir + file. mkdtemp is cleaned up at the end regardless of
-    // editor success/failure (`finally` block below). `.md` extension
-    // helps editors pick up markdown highlighting — most commit-
-    // message workflows treat the body as markdown-ish.
-    let dir: string | undefined
-    try {
-      dir = mkdtempSync(nodePath.join(tmpdir(), 'coco-compose-'))
-    } catch (error) {
-      dispatch({
-        type: 'setStatus',
-        value: `Failed to create temp file for editor: ${(error as Error).message}`,
-        kind: 'error',
-      })
-      return
-    }
-    const file = nodePath.join(dir, 'COMMIT_EDITMSG.md')
-    try {
-      writeFileSync(file, draft, 'utf8')
-    } catch (error) {
-      dispatch({
-        type: 'setStatus',
-        value: `Failed to seed temp file: ${(error as Error).message}`,
-        kind: 'error',
-      })
-      try { rmSync(dir, { recursive: true, force: true }) } catch { /* ignore */ }
-      return
-    }
-
-    const editorEnv = process.env.VISUAL || process.env.EDITOR || 'vi'
-    const editorArgs = editorEnv.trim().split(/\s+/).filter(Boolean)
-    const editor = editorArgs[0] || 'vi'
-    const editorPrefixArgs = editorArgs.slice(1)
-    const out = process.stdout
-    const stdin = process.stdin
-    const ENTER_ALT = '\x1b[?1049h'
-    const EXIT_ALT = '\x1b[?1049l'
-    const SHOW_CURSOR = '\x1b[?25h'
-    const HIDE_CURSOR = '\x1b[?25l'
-
-    let editorOk = false
-    try {
-      stdin.setRawMode?.(false)
-      out.write(`${SHOW_CURSOR}${EXIT_ALT}`)
-      const result = spawnSync(editor, [...editorPrefixArgs, file], { stdio: 'inherit' })
-      if (result.error) {
-        dispatch({ type: 'setStatus', value: `Failed to launch ${editor}: ${result.error.message}`, kind: 'error' })
-      } else if (result.signal) {
-        dispatch({ type: 'setStatus', value: `${editor} interrupted by ${result.signal}`, kind: 'warning' })
-      } else if (typeof result.status === 'number' && result.status !== 0) {
-        dispatch({ type: 'setStatus', value: `${editor} exited with status ${result.status}`, kind: 'warning' })
-      } else {
-        editorOk = true
-      }
-    } finally {
-      out.write(`${ENTER_ALT}${HIDE_CURSOR}`)
-      stdin.setRawMode?.(true)
-      resumeRef?.current?.()
-    }
-
-    // Read the (possibly edited) file back and update compose state.
-    // We only do this when the editor exited cleanly — a crash / kill
-    // shouldn't blow away the user's draft. The setDraft action
-    // re-splits into summary + body via splitCommitDraft.
-    if (editorOk) {
-      try {
-        const content = readFileSync(file, 'utf8')
-        dispatch({ type: 'commitCompose', action: { type: 'setDraft', value: content } })
-        dispatch({ type: 'setStatus', value: 'Commit draft updated from editor.', kind: 'success' })
-      } catch (error) {
-        dispatch({
-          type: 'setStatus',
-          value: `Failed to read back edited draft: ${(error as Error).message}`,
-          kind: 'error',
-        })
-      }
-    }
-
-    // Always clean up the temp dir — even on failure paths above. We
-    // don't want abandoned coco-compose-* directories accumulating in
-    // /tmp across sessions. Best-effort; ignore errors (e.g. file
-    // already removed by the user from inside their editor).
-    try { rmSync(dir, { recursive: true, force: true }) } catch { /* ignore */ }
-  }, [dispatch, resumeRef, state.commitCompose])
+  // Lifted verbatim into `useEditorActions` (0.72 app.ts decomposition).
+  // `openConfigInEditor` depends on the in-hook `openInEditor` identity
+  // (`[dispatch, openInEditor]`), so the pair must share a hook. Both are
+  // keystroke-dispatch-only — not in any effect/memo dep array.
+  const {
+    openInEditor,
+    openConfigInEditor,
+  } = useEditorActions(React, {
+    dispatch,
+    refreshWorktreeContext,
+    resumeRef,
+    repoRootRef,
+  })
 
   // `S` keystroke — start the `coco commit --split` flow (#907).
   // Pre-flight refuses cleanly when:

--- a/src/workstation/runtime/hooks/useCommitComposeActions.ts
+++ b/src/workstation/runtime/hooks/useCommitComposeActions.ts
@@ -1,0 +1,258 @@
+/**
+ * Commit-compose action handlers (extracted in the 0.72 app.ts decomposition,
+ * the second action-callback extraction after `useWorktreeStageActions`).
+ *
+ * This module lifts the two commit-compose `React.useCallback` handlers out of
+ * `app.ts`, preserving their original behavior verbatim:
+ *
+ *   1. `createCommitFromCompose` — guards on `context.worktree?.stagedCount`,
+ *      runs `createManualCommit(git, …)` with the in-progress
+ *      summary / body, then on success resets the compose state, refreshes
+ *      BOTH the history rows and the worktree context, and dispatches
+ *      `returnFromCommit` with the still-dirty verdict.
+ *   2. `openComposeInEditor` — round-trips the current draft through a temp
+ *      `.md` file in `$VISUAL` / `$EDITOR` using the alt-screen / raw-mode
+ *      terminal dance, then reads the saved content back into compose state.
+ *
+ * In `app.ts` these two callbacks are NON-contiguous — separated by ~600 lines
+ * of other handlers — but both read only early-declared values (`context`,
+ * `state.commitCompose`, `git`, `dispatch`, `refreshHistoryRows`,
+ * `refreshWorktreeContext`, `resumeRef`). Co-locating them in a single hook
+ * called near the earlier (`createCommitFromCompose`) slot reproduces both
+ * `useCallback` identities exactly. They are invoked ONLY from the input
+ * handler's keystroke dispatch (`createManualCommit` / `openComposeInEditor`
+ * events) — NOT referenced in any `useEffect` / `useMemo` dependency array — so
+ * there is no identity-stability hazard from the move.
+ *
+ * Each handler body and its `useCallback` dependency array is reproduced
+ * verbatim: the only change is that `state.commitCompose` is threaded in as the
+ * local `commitCompose` (so the dep array references `commitCompose.summary` /
+ * `commitCompose.body` instead of `state.commitCompose.*`), exactly mirroring
+ * how `useWorktreeStageActions` renamed `state.worktreeDiffOffset`. The
+ * dependency SET — and thus the re-render semantics — is byte-for-byte the
+ * same.
+ *
+ * The module-level helpers the handlers call (`createManualCommit`,
+ * `formatCommitComposeMessage`, `spawnSync`, the `node:fs` / `node:os` /
+ * `node:path` primitives) are imported directly here rather than threaded.
+ *
+ * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
+ * convention) because the workstation never statically imports React.
+ */
+
+import type * as ReactTypes from 'react'
+import type { SimpleGit } from 'simple-git'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import * as nodePath from 'node:path'
+import type { LogInkAction } from '../inkViewModel'
+import type { LogInkContext } from '../types'
+import type { CommitComposeState } from '../../../commands/log/commitCompose'
+import { createManualCommit, formatCommitComposeMessage } from '../../../commands/log/commitCompose'
+import type { WorktreeOverview } from '../../../git/statusData'
+
+export type UseCommitComposeActionsDeps = {
+  /** The active frame's `git`. */
+  git: SimpleGit
+  /** Reducer dispatch — drives compose + status messages. */
+  dispatch: (action: LogInkAction) => void
+  /** The active frame's context — `context.worktree?.stagedCount` gates the commit. */
+  context: LogInkContext
+  /** `state.commitCompose` — the in-progress summary / body draft. */
+  commitCompose: CommitComposeState
+  /** Re-fetch the history rows so a new commit shows up in the log view. */
+  refreshHistoryRows: () => Promise<unknown>
+  /**
+   * Re-fetch the worktree context after committing. Returns the fresh
+   * overview (or `undefined`) so the post-commit navigation can read the
+   * still-dirty counts directly instead of racing the async `setContext`.
+   */
+  refreshWorktreeContext: (options?: {
+    silent?: boolean
+  }) => Promise<WorktreeOverview | undefined>
+  /** Forces a re-render after the editor restores the alt screen. */
+  resumeRef?: ReactTypes.MutableRefObject<(() => void) | null>
+}
+
+export type UseCommitComposeActionsResult = {
+  createCommitFromCompose: () => Promise<void>
+  openComposeInEditor: () => void
+}
+
+export function useCommitComposeActions(
+  React: typeof ReactTypes,
+  deps: UseCommitComposeActionsDeps,
+): UseCommitComposeActionsResult {
+  const {
+    git,
+    dispatch,
+    context,
+    commitCompose,
+    refreshHistoryRows,
+    refreshWorktreeContext,
+    resumeRef,
+  } = deps
+
+  const createCommitFromCompose = React.useCallback(async () => {
+    const stagedCount = context.worktree?.stagedCount || 0
+
+    if (!stagedCount) {
+      dispatch({ type: 'setStatus', value: 'stage changes before committing', kind: 'warning' })
+      return
+    }
+
+    dispatch({ type: 'commitCompose', action: { type: 'setLoading', value: true } })
+    dispatch({ type: 'setStatus', value: 'creating commit' })
+    const result = await createManualCommit({
+      git,
+      summary: commitCompose.summary,
+      body: commitCompose.body,
+    })
+
+    dispatch({
+      type: 'commitCompose',
+      action: { type: 'setResult', message: result.message, details: result.details },
+    })
+    dispatch({ type: 'setStatus', value: result.message })
+
+    if (result.ok) {
+      dispatch({ type: 'commitCompose', action: { type: 'reset' } })
+      // Refresh BOTH worktree AND history rows — the new commit
+      // needs to show up in the history view, not just the staged
+      // counts. Without refreshHistoryRows the user would press `gh`
+      // and see the pre-commit log (same silent-failure shape as
+      // the split-apply case caught in this PR).
+      await refreshHistoryRows()
+      const worktree = await refreshWorktreeContext()
+      // Leave the compose view automatically: a still-dirty tree returns
+      // to Status (so the user can keep staging), an otherwise-complete
+      // commit returns to History (where the new commit now shows). The
+      // reducer inspects the live viewStack to pick the destination.
+      const stillDirty = Boolean(
+        worktree &&
+          worktree.stagedCount + worktree.unstagedCount + worktree.untrackedCount > 0,
+      )
+      dispatch({ type: 'returnFromCommit', stillDirty })
+    }
+  }, [
+    context.worktree?.stagedCount,
+    dispatch,
+    git,
+    refreshHistoryRows,
+    refreshWorktreeContext,
+    commitCompose.body,
+    commitCompose.summary,
+  ])
+
+  // `E` keystroke handler — open the current commit draft in $EDITOR
+  // (or $VISUAL), then read the file back and update the compose state
+  // with the saved content. Mirrors the suspend → spawn → resume
+  // terminal dance of `openInEditor` but operates on an in-memory
+  // draft (round-tripped through a temp file) rather than a worktree
+  // file. Useful when the inline compose editor isn't enough — long
+  // bodies, markdown highlighting, paste from elsewhere, etc.
+  //
+  // Empty drafts are still written to the temp file so the user gets
+  // a blank canvas; the read-back uses `setDraft` which splits content
+  // into summary + body via `splitCommitDraft`, so the new content
+  // re-populates both fields correctly regardless of which one was
+  // active before.
+  const openComposeInEditor = React.useCallback(() => {
+    // Build the current draft text the same way `createManualCommit`
+    // would — single string, blank line between summary and body.
+    // Round-tripping through this format keeps the parse symmetric:
+    // the editor sees what a real commit message would look like, and
+    // `splitCommitDraft` on the way back reverses it cleanly.
+    const composeState = commitCompose
+    const draft = formatCommitComposeMessage(composeState.summary, composeState.body)
+
+    // Temp dir + file. mkdtemp is cleaned up at the end regardless of
+    // editor success/failure (`finally` block below). `.md` extension
+    // helps editors pick up markdown highlighting — most commit-
+    // message workflows treat the body as markdown-ish.
+    let dir: string | undefined
+    try {
+      dir = mkdtempSync(nodePath.join(tmpdir(), 'coco-compose-'))
+    } catch (error) {
+      dispatch({
+        type: 'setStatus',
+        value: `Failed to create temp file for editor: ${(error as Error).message}`,
+        kind: 'error',
+      })
+      return
+    }
+    const file = nodePath.join(dir, 'COMMIT_EDITMSG.md')
+    try {
+      writeFileSync(file, draft, 'utf8')
+    } catch (error) {
+      dispatch({
+        type: 'setStatus',
+        value: `Failed to seed temp file: ${(error as Error).message}`,
+        kind: 'error',
+      })
+      try { rmSync(dir, { recursive: true, force: true }) } catch { /* ignore */ }
+      return
+    }
+
+    const editorEnv = process.env.VISUAL || process.env.EDITOR || 'vi'
+    const editorArgs = editorEnv.trim().split(/\s+/).filter(Boolean)
+    const editor = editorArgs[0] || 'vi'
+    const editorPrefixArgs = editorArgs.slice(1)
+    const out = process.stdout
+    const stdin = process.stdin
+    const ENTER_ALT = '\x1b[?1049h'
+    const EXIT_ALT = '\x1b[?1049l'
+    const SHOW_CURSOR = '\x1b[?25h'
+    const HIDE_CURSOR = '\x1b[?25l'
+
+    let editorOk = false
+    try {
+      stdin.setRawMode?.(false)
+      out.write(`${SHOW_CURSOR}${EXIT_ALT}`)
+      const result = spawnSync(editor, [...editorPrefixArgs, file], { stdio: 'inherit' })
+      if (result.error) {
+        dispatch({ type: 'setStatus', value: `Failed to launch ${editor}: ${result.error.message}`, kind: 'error' })
+      } else if (result.signal) {
+        dispatch({ type: 'setStatus', value: `${editor} interrupted by ${result.signal}`, kind: 'warning' })
+      } else if (typeof result.status === 'number' && result.status !== 0) {
+        dispatch({ type: 'setStatus', value: `${editor} exited with status ${result.status}`, kind: 'warning' })
+      } else {
+        editorOk = true
+      }
+    } finally {
+      out.write(`${ENTER_ALT}${HIDE_CURSOR}`)
+      stdin.setRawMode?.(true)
+      resumeRef?.current?.()
+    }
+
+    // Read the (possibly edited) file back and update compose state.
+    // We only do this when the editor exited cleanly — a crash / kill
+    // shouldn't blow away the user's draft. The setDraft action
+    // re-splits into summary + body via splitCommitDraft.
+    if (editorOk) {
+      try {
+        const content = readFileSync(file, 'utf8')
+        dispatch({ type: 'commitCompose', action: { type: 'setDraft', value: content } })
+        dispatch({ type: 'setStatus', value: 'Commit draft updated from editor.', kind: 'success' })
+      } catch (error) {
+        dispatch({
+          type: 'setStatus',
+          value: `Failed to read back edited draft: ${(error as Error).message}`,
+          kind: 'error',
+        })
+      }
+    }
+
+    // Always clean up the temp dir — even on failure paths above. We
+    // don't want abandoned coco-compose-* directories accumulating in
+    // /tmp across sessions. Best-effort; ignore errors (e.g. file
+    // already removed by the user from inside their editor).
+    try { rmSync(dir, { recursive: true, force: true }) } catch { /* ignore */ }
+  }, [dispatch, resumeRef, commitCompose])
+
+  return {
+    createCommitFromCompose,
+    openComposeInEditor,
+  }
+}

--- a/src/workstation/runtime/hooks/useEditorActions.ts
+++ b/src/workstation/runtime/hooks/useEditorActions.ts
@@ -1,0 +1,137 @@
+/**
+ * Editor-launch action handlers (extracted in the 0.72 app.ts decomposition,
+ * alongside `useCommitComposeActions`).
+ *
+ * This module lifts the two generic editor `React.useCallback` handlers out of
+ * `app.ts`, preserving their original behavior verbatim:
+ *
+ *   1. `openInEditor` — the generic `$VISUAL` / `$EDITOR` launcher. Drops out
+ *      of the alt screen + raw mode, spawns the editor on the given path with
+ *      inherited stdio, restores the alt screen + raw mode + hidden cursor,
+ *      forces a re-render via `resumeRef`, then silently refreshes the worktree
+ *      context (an edit may have changed the staged / unstaged state).
+ *   2. `openConfigInEditor` — resolves the global / project coco config path
+ *      (falling back to cwd until `repoRootRef` resolves), scaffolds a
+ *      templated starter via `ensureConfigFile` when missing, then delegates to
+ *      `openInEditor`. It **depends on `openInEditor`** (its dep array is
+ *      `[dispatch, openInEditor]`), so the two MUST live in the same hook for
+ *      that in-hook identity reference to hold.
+ *
+ * Each handler body and its `useCallback` dependency array is reproduced
+ * byte-for-byte from `app.ts`. The alt-screen / raw-mode terminal dance and the
+ * `resumeRef?.current?.()` resume sequencing in `openInEditor` are preserved
+ * exactly — a botched resume leaves the user's terminal wedged.
+ *
+ * Both callbacks are invoked ONLY from the input handler's keystroke dispatch
+ * (`openInEditor` / `openConfigInEditor` events) — NOT referenced in any
+ * `useEffect` / `useMemo` dependency array — so there is no identity-stability
+ * hazard from the move.
+ *
+ * The module-level helpers (`spawnSync`, `ensureConfigFile`,
+ * `resolveConfigPath`) are imported directly here rather than threaded.
+ *
+ * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
+ * convention) because the workstation never statically imports React.
+ */
+
+import type * as ReactTypes from 'react'
+import { spawnSync } from 'node:child_process'
+import type { LogInkAction } from '../inkViewModel'
+import { ensureConfigFile, resolveConfigPath, type CocoConfigScope } from '../configFiles'
+
+export type UseEditorActionsDeps = {
+  /** Reducer dispatch — drives status messages. */
+  dispatch: (action: LogInkAction) => void
+  /** Silently re-fetch the worktree context after an edit may have changed it. */
+  refreshWorktreeContext: (options?: { silent?: boolean }) => Promise<unknown>
+  /** Forces a re-render after the editor restores the alt screen. */
+  resumeRef?: ReactTypes.MutableRefObject<(() => void) | null>
+  /** Repo root (async-populated); cwd fallback for config scaffolding. */
+  repoRootRef: ReactTypes.MutableRefObject<string | undefined>
+}
+
+export type UseEditorActionsResult = {
+  openInEditor: (path: string) => void
+  openConfigInEditor: (scope: CocoConfigScope) => void
+}
+
+export function useEditorActions(
+  React: typeof ReactTypes,
+  deps: UseEditorActionsDeps,
+): UseEditorActionsResult {
+  const { dispatch, refreshWorktreeContext, resumeRef, repoRootRef } = deps
+
+  const openInEditor = React.useCallback((path: string) => {
+    if (!path) return
+    const editorEnv = process.env.VISUAL || process.env.EDITOR || 'vi'
+    // $VISUAL / $EDITOR commonly include flags (`code -w`, `vim -f`,
+    // `emacs -nw`). Tokenize on whitespace so the leading word is the
+    // executable and the rest are passed as arguments — passing the
+    // full string to spawnSync as the executable would fail with
+    // ENOENT for any of those configurations.
+    const editorArgs = editorEnv.trim().split(/\s+/).filter(Boolean)
+    const editor = editorArgs[0] || 'vi'
+    const editorPrefixArgs = editorArgs.slice(1)
+    const out = process.stdout
+    const stdin = process.stdin
+    const ENTER_ALT = '\x1b[?1049h'
+    const EXIT_ALT = '\x1b[?1049l'
+    const SHOW_CURSOR = '\x1b[?25h'
+    const HIDE_CURSOR = '\x1b[?25l'
+    try {
+      // Drop into the primary buffer + cooked mode so the editor
+      // doesn't inherit our raw-mode keystrokes.
+      stdin.setRawMode?.(false)
+      out.write(`${SHOW_CURSOR}${EXIT_ALT}`)
+      const result = spawnSync(editor, [...editorPrefixArgs, path], { stdio: 'inherit' })
+      if (result.error) {
+        dispatch({ type: 'setStatus', value: `Failed to launch ${editor}: ${result.error.message}`, kind: 'error' })
+      } else if (result.signal) {
+        // Editor was killed by a signal (e.g. ^C, SIGTERM). status is
+        // null in this case, so the old `status !== 0` check would
+        // mistakenly fall through to the success branch.
+        dispatch({ type: 'setStatus', value: `${editor} interrupted by ${result.signal}`, kind: 'warning' })
+      } else if (typeof result.status === 'number' && result.status !== 0) {
+        dispatch({ type: 'setStatus', value: `${editor} exited with status ${result.status}`, kind: 'warning' })
+      } else {
+        dispatch({ type: 'setStatus', value: `Edited ${path}`, kind: 'success' })
+      }
+    } finally {
+      // Re-enter the alt screen + raw mode + hidden cursor; nudge React
+      // so the freshly-restored screen actually paints.
+      out.write(`${ENTER_ALT}${HIDE_CURSOR}`)
+      stdin.setRawMode?.(true)
+      resumeRef?.current?.()
+    }
+    // Worktree status may have changed (e.g. user saved an edit) — silent
+    // refresh so the file row reflects the new staged/unstaged state.
+    void refreshWorktreeContext({ silent: true })
+  }, [dispatch, refreshWorktreeContext, resumeRef])
+
+  // Open the global or project coco config in $EDITOR (gk / gK + their
+  // command-palette entries). Scaffolds a templated starter when the file
+  // doesn't exist yet so the user never lands in an empty buffer or hits
+  // a "no such file" error.
+  const openConfigInEditor = React.useCallback((scope: CocoConfigScope) => {
+    // `repoRootRef` is populated async from `git rev-parse --show-toplevel`;
+    // fall back to cwd so a freshly-launched session can still scaffold +
+    // open the project config before that resolves.
+    const repoRoot = repoRootRef.current || process.cwd()
+    const filePath = resolveConfigPath(scope, repoRoot)
+    try {
+      const { created } = ensureConfigFile(filePath)
+      if (created) {
+        dispatch({ type: 'setStatus', value: `Created ${scope} config at ${filePath}`, kind: 'success' })
+      }
+    } catch (error) {
+      dispatch({ type: 'setStatus', value: `Could not create config: ${(error as Error).message}`, kind: 'error' })
+      return
+    }
+    openInEditor(filePath)
+  }, [dispatch, openInEditor])
+
+  return {
+    openInEditor,
+    openConfigInEditor,
+  }
+}


### PR DESCRIPTION
Continues the 0.72 `app.ts` decomposition (PRs 1–11). Behavior-preserving move of four action callbacks out of `src/workstation/runtime/app.ts` into two new hooks under `src/workstation/runtime/hooks/`.

## What moved

**`useCommitComposeActions(React, deps)`** → `{ createCommitFromCompose, openComposeInEditor }`
- The two compose handlers are *non-contiguous* in `app.ts` (~570 lines apart) but read only early-declared values, so a single hook call at the earlier slot reproduces both `useCallback` identities.

**`useEditorActions(React, deps)`** → `{ openInEditor, openConfigInEditor }`
- `openConfigInEditor` depends on the in-hook `openInEditor` identity (`[dispatch, openInEditor]`), so the pair shares a hook.

## Discipline

- `useCallback` bodies + dependency arrays are byte-identical. The only rename is `state.commitCompose` → threaded-in `commitCompose` (so dep entries read `commitCompose.summary` / `commitCompose.body` / `commitCompose`), exactly mirroring how `useWorktreeStageActions` renamed `state.worktreeDiffOffset`. The dependency *set* — and re-render semantics — is unchanged.
- The alt-screen / raw-mode terminal dance and the `resumeRef?.current?.()` resume sequencing are preserved verbatim.
- No identity hazard: all four are invoked only from the input handler's keystroke dispatch — none appear in any `useEffect` / `useMemo` dependency array.
- `refreshWorktreeContext` is typed `=> Promise<WorktreeOverview | undefined>` for the compose hook (it reads the fresh overview's counts) and `=> Promise<unknown>` for the editor hook (await-and-ignore), per the PR 11 convention.

## Removed from app.ts

- `import { createManualCommit, formatCommitComposeMessage } from '../../commands/log/commitCompose'`
- `import { ensureConfigFile, resolveConfigPath, type CocoConfigScope } from './configFiles'`

Both import lines became fully unused in `app.ts` after the move (verified by grep + lint); the helpers are imported directly inside the hooks.

## Metrics

- `app.ts`: 4471 → 4271 lines (−200); `React.useCallback` 24 → 20 (−4).

## Validation

- `npm test` fully green (jest 3446 passed / 274 suites, lint, build, CLI smoke, pack). Gated GitLab integration test stays skipped.
- `npx tsc --noEmit` clean.