### PR TITLE
refactor(workstation): extract commit-split actions into useCommitSplitActions (0.72 app.ts decomposition)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -63,8 +63,6 @@ import { getSubmoduleOverview } from '../../git/submoduleData'
 import { getRemoteOverview } from '../../git/remoteData'
 import {
     runCommitDraftWorkflow,
-    runCommitSplitApplyWorkflow,
-    runCommitSplitPlanWorkflow,
 } from '../../git/commitWorkflowActions'
 import { runChangelogTextWorkflow } from '../../git/aiActions'
 import {
@@ -91,7 +89,6 @@ import { forgeNouns } from '../chrome/forgeNouns'
 import { hasSeenOnboarding, markOnboardingSeen } from '../chrome/onboarding'
 import { createLogInkTheme, type LogInkThemePreset } from '../chrome/theme'
 import { saveThemePreset } from '../chrome/themePersistence'
-import { formatSplitApplySuccess } from '../chrome/postApplyHints'
 import { createInitialContextStatus, createRepoFrameRuntime } from './repoFrameFactory'
 import {
     resolveCommitDiffDrillInTarget,
@@ -344,6 +341,7 @@ import { useHistoryCursorSync } from './hooks/useHistoryCursorSync'
 import { useLoadMoreHistory } from './hooks/useLoadMoreHistory'
 import { useWorktreeStageActions } from './hooks/useWorktreeStageActions'
 import { useCommitComposeActions } from './hooks/useCommitComposeActions'
+import { useCommitSplitActions } from './hooks/useCommitSplitActions'
 import { useEditorActions } from './hooks/useEditorActions'
 
 // Chrome + overlay + dispatcher renderers extracted in phase 5a.7. The
@@ -1983,255 +1981,27 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     repoRootRef,
   })
 
-  // `S` keystroke — start the `coco commit --split` flow (#907).
-  // Pre-flight refuses cleanly when:
-  //   - Nothing is staged (suggests `g s` to pick files)
-  //   - A bisect / merge / rebase is in progress (split would be confusing)
-  // Then opens the overlay in 'loading' state, kicks off the plan
-  // workflow, and dispatches setSplitPlanReady (or setSplitPlanError)
-  // when it resolves. The overlay handles the rest from there.
-  const startCommitSplit = React.useCallback(async () => {
-    const stagedCount = context.worktree?.stagedCount || 0
-    if (stagedCount === 0) {
-      dispatch({
-        type: 'setStatus',
-        value: 'Nothing staged to split. Stage some files first (`g s` to pick).',
-        kind: 'error',
-      })
-      return
-    }
-    const operation = context.operation
-    if (operation?.operation && operation.operation !== 'none') {
-      dispatch({
-        type: 'setStatus',
-        value: `A ${operation.operation} is in progress — finish or abort it before splitting.`,
-        kind: 'error',
-      })
-      return
-    }
-
-    dispatch({ type: 'startSplitPlanLoad' })
-    dispatch({ type: 'setStatus', value: 'Generating split plan (this can take a minute)…', loading: true })
-
-    const result = await runCommitSplitPlanWorkflow({ git })
-
-    if (!result.ok) {
-      dispatch({ type: 'setSplitPlanError', error: result.message })
-      dispatch({
-        type: 'setStatus',
-        value: `Split plan failed: ${result.message}`,
-        kind: 'error',
-      })
-      return
-    }
-
-    dispatch({
-      type: 'setSplitPlanReady',
-      plan: result.plan,
-      planContext: result.planContext,
-      fallback: result.fallback,
-    })
-    const readyMessage = result.fallback
-      ? `Split planner exhausted retries — showing single-commit fallback. y/Enter to apply as one commit, r to re-roll, Esc to cancel.`
-      : `Split plan ready: ${result.plan.groups.length} commit(s). y/Enter to apply, Esc to cancel.`
-    // Use 'info' kind for the fallback path (still actionable, just
-    // not a clean win). The reducer's "warning" is the absence of
-    // `success` framing — the message text itself carries the cue.
-    dispatch({
-      type: 'setStatus',
-      value: readyMessage,
-      kind: result.fallback ? 'info' : 'success',
-    })
-  }, [context.operation, context.worktree?.stagedCount, dispatch, git])
-
-  // `y`/Enter inside the overlay — apply the previewed plan. Uses the
-  // plan + planContext from state (set by setSplitPlanReady) so the
-  // executed split matches what the user reviewed exactly. No LLM
-  // re-roll, no plan drift.
-  const applyCommitSplit = React.useCallback(async () => {
-    const splitPlan = state.splitPlan
-    if (!splitPlan?.plan || !splitPlan.planContext) {
-      dispatch({ type: 'setStatus', value: 'No split plan loaded yet — wait for generation.', kind: 'warning' })
-      return
-    }
-
-    // Diagnostic dump for the silent-failure bug surfaced in #944
-    // manual testing. Writes a per-step record to a file in /tmp so
-    // we have ground truth when the workstation's view of the world
-    // disagrees with the underlying git state. Path is printed in
-    // the post-apply status so the user can paste it back in an
-    // issue / PR comment.
-    const dumpPath = nodePath.join(
-      tmpdir(),
-      `coco-split-apply-${Date.now()}.log`
-    )
-    const dump: string[] = [
-      `[${new Date().toISOString()}] split apply diagnostic dump`,
-      `plan: ${splitPlan.plan.groups.length} group(s)`,
-      ...splitPlan.plan.groups.map((g, i) =>
-        `  group ${i + 1}: ${g.title} — files=[${(g.files || []).join(', ')}] hunks=[${(g.hunks || []).join(', ')}]`
-      ),
-    ]
-    try {
-      const headBefore = (await git.revparse(['HEAD'])).trim()
-      dump.push(`HEAD before apply: ${headBefore}`)
-      const statusBefore = await git.status()
-      dump.push(`staged before apply: ${[...statusBefore.staged, ...statusBefore.created, ...statusBefore.renamed].length}`)
-      dump.push(`unstaged before apply: ${statusBefore.modified.length + statusBefore.deleted.length}`)
-      dump.push(`untracked before apply: ${statusBefore.not_added.length}`)
-    } catch (error) {
-      dump.push(`pre-apply git probe failed: ${(error as Error).message}`)
-    }
-
-    dispatch({ type: 'setSplitPlanApplying' })
-    dispatch({ type: 'setStatus', value: 'Applying split plan…', loading: true })
-
-    const result = await runCommitSplitApplyWorkflow({
-      plan: splitPlan.plan,
-      planContext: splitPlan.planContext,
-      git,
-      fallback: splitPlan.fallback,
-    })
-
-    dump.push(`workflow returned: ok=${result.ok} message="${result.message}" commitHashes=[${(result.commitHashes || []).join(', ')}]`)
-
-    try {
-      const headAfter = (await git.revparse(['HEAD'])).trim()
-      dump.push(`HEAD after apply: ${headAfter}`)
-      const statusAfter = await git.status()
-      dump.push(`staged after apply: ${[...statusAfter.staged, ...statusAfter.created, ...statusAfter.renamed].length}`)
-      dump.push(`unstaged after apply: ${statusAfter.modified.length + statusAfter.deleted.length}`)
-      dump.push(`untracked after apply: ${statusAfter.not_added.length}`)
-      const recentLog = await git.raw(['log', '--oneline', '-n', '10'])
-      dump.push(`git log -n 10:`)
-      dump.push(...recentLog.split('\n').map((line) => `  ${line}`))
-    } catch (error) {
-      dump.push(`post-apply git probe failed: ${(error as Error).message}`)
-    }
-
-    try {
-      writeFileSync(dumpPath, dump.join('\n'), 'utf8')
-    } catch { /* ignore — diagnostic is best-effort */ }
-
-    if (!result.ok) {
-      // Keep the overlay open so the user can see what happened and
-      // try again. setSplitPlanError preserves the existing plan in
-      // 'ready' state with the error annotation.
-      dispatch({ type: 'setSplitPlanError', error: result.message })
-      dispatch({
-        type: 'setStatus',
-        value: `Split apply failed: ${result.message} · diagnostic log: ${dumpPath}`,
-        kind: 'error',
-      })
-      return
-    }
-
-    // Success — close the overlay, reset compose (the staged set is
-    // now empty since the plan committed everything), and route the
-    // user to the history view so they see the just-landed commits
-    // with the recent-commit marker firing on each row that was
-    // created. Previous behavior popped compose to whatever was
-    // beneath (often status — which now reads "clean worktree" and
-    // gives the user no signal that anything just happened);
-    // history is the natural follow-on surface.
-    //
-    // navigateHome nukes the rest of the stack so `<` after apply
-    // doesn't walk back into the now-empty compose / status state
-    // the user just left behind.
-    // Did the plan leave files for the user (the `unclaimed` group the
-    // split couldn't confidently place)? They're now sitting unstaged in
-    // the worktree, so land on status — not history — so the user sees
-    // and handles them, rather than dropping them on a clean-looking
-    // history view (#1180).
-    const unclaimedGroup = splitPlan.plan.groups.find((group) => group.unclaimed)
-    const unclaimedFileCount = unclaimedGroup?.files?.length ?? 0
-
-    dispatch({ type: 'clearSplitPlan' })
-    dispatch({ type: 'commitCompose', action: { type: 'reset' } })
-    dispatch({ type: 'navigateHome' })
-    if (unclaimedFileCount > 0) {
-      dispatch({ type: 'pushView', value: 'status' })
-    }
-
-    // Refresh BEFORE setting the final status so we can peek at the
-    // post-apply worktree state and craft a directive next-step hint
-    // ("X unstaged + Y untracked remaining — press gs to stage / I
-    // to draft / …"). An empty success message reads as a dead end;
-    // a next-step hint keeps momentum.
-    //
-    // Critical: refreshHistoryRows is the one that re-fetches the
-    // commit log. Without this, `gh` would show the pre-apply log —
-    // exactly the "spinner runs, no commits visible" silent-failure
-    // report from #942 manual testing. The actual commits DO land;
-    // `state.rows` just never gets re-fetched after boot.
-    await refreshHistoryRows()
-    await refreshWorktreeContext()
-    await refreshContext()
-
-    // Best-effort peek at the fresh worktree counts. If the second
-    // load fails we just fall back to the bare success message — no
-    // reason to noisily surface a status-line lookup error after a
-    // genuine success.
-    const fresh = await getWorktreeOverview(git).catch(() => undefined)
-    const unstaged = fresh?.unstagedCount || 0
-    const untracked = fresh?.untrackedCount || 0
-
-    // The workflow now returns the actually-created commit hashes
-    // directly (verified against HEAD inside applyCommitSplitPlan —
-    // each commit confirmed to have advanced the tip). Drive the
-    // just-landed marker AND the success-message commit count from
-    // that exact data instead of doing a second rev-list round-trip
-    // that could disagree with reality on partial-apply.
-    const commitHashes = result.commitHashes || []
-    if (commitHashes.length > 0) {
-      // Audit finding #9: timestamp captured at dispatch time.
-      dispatch({ type: 'markRecentCommits', hashes: commitHashes, markedAt: Date.now() })
-      // DevSkim: ignore DS172411 — function literal, fixed delay,
-      // no caller-supplied data flowing through.
-      setTimeout(() => dispatch({ type: 'clearRecentCommits' }), 5000)
-    }
-
-    // If the workflow reported success but zero commits actually
-    // landed, surface that as an error — the spinner-then-silence
-    // failure mode from #940 manual testing where the apply appeared
-    // to succeed but the worktree got wiped with no commits made.
-    if (commitHashes.length === 0) {
-      const detail = result.message || 'No commits were created.'
-      dispatch({
-        type: 'setStatus',
-        value: `Split apply produced zero commits: ${detail} · diagnostic log: ${dumpPath}`,
-        kind: 'error',
-      })
-      return
-    }
-
-    const successMessage = formatSplitApplySuccess(
-      commitHashes.length,
-      unstaged,
-      untracked,
-      result.fallback ? { reason: result.fallback.reason } : undefined
-    )
-    // Name the files the split deliberately left behind so the jump to
-    // status reads as intentional, not a surprise (#1180).
-    const unclaimedNote = unclaimedFileCount > 0
-      ? ` · ${unclaimedFileCount} file${unclaimedFileCount === 1 ? '' : 's'} left for you on status`
-      : ''
-    // Fallback path uses 'info' kind — apply technically succeeded
-    // but the user should know it landed as a single combined commit
-    // rather than a real LLM-driven multi-group split.
-    dispatch({
-      type: 'setStatus',
-      value: `${successMessage}${unclaimedNote}`,
-      kind: result.fallback ? 'info' : 'success',
-    })
-  }, [dispatch, git, refreshContext, refreshHistoryRows, refreshWorktreeContext, state.splitPlan])
-
-  // Esc inside the overlay — close without applying. Status line gets
-  // a confirmation so the user knows the operation was abandoned.
-  const cancelCommitSplit = React.useCallback(() => {
-    dispatch({ type: 'clearSplitPlan' })
-    dispatch({ type: 'setStatus', value: 'Split plan cancelled.' })
-  }, [dispatch])
+  // Lifted verbatim into `useCommitSplitActions` (0.72 app.ts
+  // decomposition). `startCommitSplit`, `applyCommitSplit`, and
+  // `cancelCommitSplit` are three contiguous callbacks sharing the
+  // `state.splitPlan` orchestration; all read only early-declared values
+  // (`context`, `state.splitPlan`, `git`, `dispatch`, the three refresh
+  // callbacks), so a single hook call at their original slot reproduces all
+  // three `useCallback` identities exactly. They are keystroke-dispatch-only
+  // — not in any effect/memo dep array — so co-locating them is identity-safe.
+  const {
+    startCommitSplit,
+    applyCommitSplit,
+    cancelCommitSplit,
+  } = useCommitSplitActions(React, {
+    git,
+    dispatch,
+    context,
+    splitPlan: state.splitPlan,
+    refreshContext,
+    refreshHistoryRows,
+    refreshWorktreeContext,
+  })
 
   // Resolve the destructive-action target from the live filtered+sorted
   // list the user is looking at, run the action against it, surface the

--- a/src/workstation/runtime/hooks/useCommitSplitActions.ts
+++ b/src/workstation/runtime/hooks/useCommitSplitActions.ts
@@ -1,0 +1,360 @@
+/**
+ * Commit-split action handlers (extracted in the 0.72 app.ts decomposition —
+ * the third action-callback extraction, after `useWorktreeStageActions` and
+ * `useCommitComposeActions`).
+ *
+ * This module lifts the three contiguous commit-split `React.useCallback`
+ * handlers out of `app.ts`, in original declaration order, preserving their
+ * behavior verbatim:
+ *
+ *   1. `startCommitSplit` — `S` keystroke. Pre-flight refuses cleanly when
+ *      nothing is staged or a bisect / merge / rebase is in progress, opens
+ *      the overlay in 'loading' state via `runCommitSplitPlanWorkflow({ git })`,
+ *      then dispatches `setSplitPlanReady` (or `setSplitPlanError`).
+ *   2. `applyCommitSplit` — `y`/Enter inside the overlay. Reads
+ *      `state.splitPlan.{plan, planContext, fallback}`, runs
+ *      `runCommitSplitApplyWorkflow()`, writes a best-effort diagnostic dump to
+ *      `/tmp`, refreshes via `refreshHistoryRows` / `refreshWorktreeContext` /
+ *      `refreshContext`, and routes the user home (or to status) with the
+ *      `markRecentCommits` marker firing on the just-landed commits.
+ *   3. `cancelCommitSplit` — Esc inside the overlay. Clears the plan and
+ *      confirms on the status line.
+ *
+ * Each handler body and its `useCallback` dependency array is reproduced
+ * byte-for-byte: the diagnostic-dump path/format, the refresh/dispatch
+ * sequencing in the apply path (the exact order of `refreshHistoryRows` /
+ * `refreshWorktreeContext` / `refreshContext` and the
+ * `clearSplitPlan` / `commitCompose` / `navigateHome` / `pushView` /
+ * `markRecentCommits` dispatches — reordering any of these would change the
+ * post-apply UI state), and the guard conditions are all unchanged. This is a
+ * behavior-preserving move, not a rewrite; the three are deliberately NOT
+ * consolidated despite sharing the `state.splitPlan` orchestration.
+ *
+ * Hook ordering / identity. The three callbacks are contiguous in `app.ts`
+ * (~lines 1993–2234) and are invoked ONLY from the input handler's keystroke
+ * dispatch (`startCommitSplit` / `applyCommitSplit` / `cancelCommitSplit`
+ * events) — they are NOT referenced in any `useEffect` / `useMemo` dependency
+ * array, so there is no identity-stability hazard from co-locating them. A
+ * single hook called at their original slot reproduces both the hook-call
+ * order and the three `useCallback` identities exactly.
+ *
+ * The module-level helpers the handlers call
+ * (`runCommitSplitPlanWorkflow`, `runCommitSplitApplyWorkflow`,
+ * `getWorktreeOverview`, `formatSplitApplySuccess`, the `node:fs` /
+ * `node:os` / `node:path` primitives for the diagnostic dump) are imported
+ * directly here rather than threaded.
+ *
+ * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
+ * convention) because the workstation never statically imports React.
+ */
+
+import type * as ReactTypes from 'react'
+import type { SimpleGit } from 'simple-git'
+import { writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import * as nodePath from 'node:path'
+import type { LogInkAction, SplitPlanState } from '../inkViewModel'
+import type { LogInkContext } from '../types'
+import {
+  runCommitSplitApplyWorkflow,
+  runCommitSplitPlanWorkflow,
+} from '../../../git/commitWorkflowActions'
+import { getWorktreeOverview } from '../../../git/statusData'
+import { formatSplitApplySuccess } from '../../chrome/postApplyHints'
+
+export type UseCommitSplitActionsDeps = {
+  /** The active frame's `git`. */
+  git: SimpleGit
+  /** Reducer dispatch — drives the split overlay + status messages. */
+  dispatch: (action: LogInkAction) => void
+  /**
+   * The active frame's context — `context.worktree?.stagedCount` and
+   * `context.operation` gate the start of the split.
+   */
+  context: LogInkContext
+  /** `state.splitPlan` — the previewed plan + planContext + fallback. */
+  splitPlan: SplitPlanState | undefined
+  /** Loud refresh of the full repository context after a split applies. */
+  refreshContext: (options?: { silent?: boolean }) => Promise<unknown>
+  /** Re-fetch the history rows so the new commits show up in the log view. */
+  refreshHistoryRows: () => Promise<unknown>
+  /** Re-fetch the worktree context after the split applies. */
+  refreshWorktreeContext: (options?: { silent?: boolean }) => Promise<unknown>
+}
+
+export type UseCommitSplitActionsResult = {
+  startCommitSplit: () => Promise<void>
+  applyCommitSplit: () => Promise<void>
+  cancelCommitSplit: () => void
+}
+
+export function useCommitSplitActions(
+  React: typeof ReactTypes,
+  deps: UseCommitSplitActionsDeps,
+): UseCommitSplitActionsResult {
+  const {
+    git,
+    dispatch,
+    context,
+    splitPlan: stateSplitPlan,
+    refreshContext,
+    refreshHistoryRows,
+    refreshWorktreeContext,
+  } = deps
+
+  // `S` keystroke — start the `coco commit --split` flow (#907).
+  // Pre-flight refuses cleanly when:
+  //   - Nothing is staged (suggests `g s` to pick files)
+  //   - A bisect / merge / rebase is in progress (split would be confusing)
+  // Then opens the overlay in 'loading' state, kicks off the plan
+  // workflow, and dispatches setSplitPlanReady (or setSplitPlanError)
+  // when it resolves. The overlay handles the rest from there.
+  const startCommitSplit = React.useCallback(async () => {
+    const stagedCount = context.worktree?.stagedCount || 0
+    if (stagedCount === 0) {
+      dispatch({
+        type: 'setStatus',
+        value: 'Nothing staged to split. Stage some files first (`g s` to pick).',
+        kind: 'error',
+      })
+      return
+    }
+    const operation = context.operation
+    if (operation?.operation && operation.operation !== 'none') {
+      dispatch({
+        type: 'setStatus',
+        value: `A ${operation.operation} is in progress — finish or abort it before splitting.`,
+        kind: 'error',
+      })
+      return
+    }
+
+    dispatch({ type: 'startSplitPlanLoad' })
+    dispatch({ type: 'setStatus', value: 'Generating split plan (this can take a minute)…', loading: true })
+
+    const result = await runCommitSplitPlanWorkflow({ git })
+
+    if (!result.ok) {
+      dispatch({ type: 'setSplitPlanError', error: result.message })
+      dispatch({
+        type: 'setStatus',
+        value: `Split plan failed: ${result.message}`,
+        kind: 'error',
+      })
+      return
+    }
+
+    dispatch({
+      type: 'setSplitPlanReady',
+      plan: result.plan,
+      planContext: result.planContext,
+      fallback: result.fallback,
+    })
+    const readyMessage = result.fallback
+      ? `Split planner exhausted retries — showing single-commit fallback. y/Enter to apply as one commit, r to re-roll, Esc to cancel.`
+      : `Split plan ready: ${result.plan.groups.length} commit(s). y/Enter to apply, Esc to cancel.`
+    // Use 'info' kind for the fallback path (still actionable, just
+    // not a clean win). The reducer's "warning" is the absence of
+    // `success` framing — the message text itself carries the cue.
+    dispatch({
+      type: 'setStatus',
+      value: readyMessage,
+      kind: result.fallback ? 'info' : 'success',
+    })
+  }, [context.operation, context.worktree?.stagedCount, dispatch, git])
+
+  // `y`/Enter inside the overlay — apply the previewed plan. Uses the
+  // plan + planContext from state (set by setSplitPlanReady) so the
+  // executed split matches what the user reviewed exactly. No LLM
+  // re-roll, no plan drift.
+  const applyCommitSplit = React.useCallback(async () => {
+    const splitPlan = stateSplitPlan
+    if (!splitPlan?.plan || !splitPlan.planContext) {
+      dispatch({ type: 'setStatus', value: 'No split plan loaded yet — wait for generation.', kind: 'warning' })
+      return
+    }
+
+    // Diagnostic dump for the silent-failure bug surfaced in #944
+    // manual testing. Writes a per-step record to a file in /tmp so
+    // we have ground truth when the workstation's view of the world
+    // disagrees with the underlying git state. Path is printed in
+    // the post-apply status so the user can paste it back in an
+    // issue / PR comment.
+    const dumpPath = nodePath.join(
+      tmpdir(),
+      `coco-split-apply-${Date.now()}.log`
+    )
+    const dump: string[] = [
+      `[${new Date().toISOString()}] split apply diagnostic dump`,
+      `plan: ${splitPlan.plan.groups.length} group(s)`,
+      ...splitPlan.plan.groups.map((g, i) =>
+        `  group ${i + 1}: ${g.title} — files=[${(g.files || []).join(', ')}] hunks=[${(g.hunks || []).join(', ')}]`
+      ),
+    ]
+    try {
+      const headBefore = (await git.revparse(['HEAD'])).trim()
+      dump.push(`HEAD before apply: ${headBefore}`)
+      const statusBefore = await git.status()
+      dump.push(`staged before apply: ${[...statusBefore.staged, ...statusBefore.created, ...statusBefore.renamed].length}`)
+      dump.push(`unstaged before apply: ${statusBefore.modified.length + statusBefore.deleted.length}`)
+      dump.push(`untracked before apply: ${statusBefore.not_added.length}`)
+    } catch (error) {
+      dump.push(`pre-apply git probe failed: ${(error as Error).message}`)
+    }
+
+    dispatch({ type: 'setSplitPlanApplying' })
+    dispatch({ type: 'setStatus', value: 'Applying split plan…', loading: true })
+
+    const result = await runCommitSplitApplyWorkflow({
+      plan: splitPlan.plan,
+      planContext: splitPlan.planContext,
+      git,
+      fallback: splitPlan.fallback,
+    })
+
+    dump.push(`workflow returned: ok=${result.ok} message="${result.message}" commitHashes=[${(result.commitHashes || []).join(', ')}]`)
+
+    try {
+      const headAfter = (await git.revparse(['HEAD'])).trim()
+      dump.push(`HEAD after apply: ${headAfter}`)
+      const statusAfter = await git.status()
+      dump.push(`staged after apply: ${[...statusAfter.staged, ...statusAfter.created, ...statusAfter.renamed].length}`)
+      dump.push(`unstaged after apply: ${statusAfter.modified.length + statusAfter.deleted.length}`)
+      dump.push(`untracked after apply: ${statusAfter.not_added.length}`)
+      const recentLog = await git.raw(['log', '--oneline', '-n', '10'])
+      dump.push(`git log -n 10:`)
+      dump.push(...recentLog.split('\n').map((line) => `  ${line}`))
+    } catch (error) {
+      dump.push(`post-apply git probe failed: ${(error as Error).message}`)
+    }
+
+    try {
+      writeFileSync(dumpPath, dump.join('\n'), 'utf8')
+    } catch { /* ignore — diagnostic is best-effort */ }
+
+    if (!result.ok) {
+      // Keep the overlay open so the user can see what happened and
+      // try again. setSplitPlanError preserves the existing plan in
+      // 'ready' state with the error annotation.
+      dispatch({ type: 'setSplitPlanError', error: result.message })
+      dispatch({
+        type: 'setStatus',
+        value: `Split apply failed: ${result.message} · diagnostic log: ${dumpPath}`,
+        kind: 'error',
+      })
+      return
+    }
+
+    // Success — close the overlay, reset compose (the staged set is
+    // now empty since the plan committed everything), and route the
+    // user to the history view so they see the just-landed commits
+    // with the recent-commit marker firing on each row that was
+    // created. Previous behavior popped compose to whatever was
+    // beneath (often status — which now reads "clean worktree" and
+    // gives the user no signal that anything just happened);
+    // history is the natural follow-on surface.
+    //
+    // navigateHome nukes the rest of the stack so `<` after apply
+    // doesn't walk back into the now-empty compose / status state
+    // the user just left behind.
+    // Did the plan leave files for the user (the `unclaimed` group the
+    // split couldn't confidently place)? They're now sitting unstaged in
+    // the worktree, so land on status — not history — so the user sees
+    // and handles them, rather than dropping them on a clean-looking
+    // history view (#1180).
+    const unclaimedGroup = splitPlan.plan.groups.find((group) => group.unclaimed)
+    const unclaimedFileCount = unclaimedGroup?.files?.length ?? 0
+
+    dispatch({ type: 'clearSplitPlan' })
+    dispatch({ type: 'commitCompose', action: { type: 'reset' } })
+    dispatch({ type: 'navigateHome' })
+    if (unclaimedFileCount > 0) {
+      dispatch({ type: 'pushView', value: 'status' })
+    }
+
+    // Refresh BEFORE setting the final status so we can peek at the
+    // post-apply worktree state and craft a directive next-step hint
+    // ("X unstaged + Y untracked remaining — press gs to stage / I
+    // to draft / …"). An empty success message reads as a dead end;
+    // a next-step hint keeps momentum.
+    //
+    // Critical: refreshHistoryRows is the one that re-fetches the
+    // commit log. Without this, `gh` would show the pre-apply log —
+    // exactly the "spinner runs, no commits visible" silent-failure
+    // report from #942 manual testing. The actual commits DO land;
+    // `state.rows` just never gets re-fetched after boot.
+    await refreshHistoryRows()
+    await refreshWorktreeContext()
+    await refreshContext()
+
+    // Best-effort peek at the fresh worktree counts. If the second
+    // load fails we just fall back to the bare success message — no
+    // reason to noisily surface a status-line lookup error after a
+    // genuine success.
+    const fresh = await getWorktreeOverview(git).catch(() => undefined)
+    const unstaged = fresh?.unstagedCount || 0
+    const untracked = fresh?.untrackedCount || 0
+
+    // The workflow now returns the actually-created commit hashes
+    // directly (verified against HEAD inside applyCommitSplitPlan —
+    // each commit confirmed to have advanced the tip). Drive the
+    // just-landed marker AND the success-message commit count from
+    // that exact data instead of doing a second rev-list round-trip
+    // that could disagree with reality on partial-apply.
+    const commitHashes = result.commitHashes || []
+    if (commitHashes.length > 0) {
+      // Audit finding #9: timestamp captured at dispatch time.
+      dispatch({ type: 'markRecentCommits', hashes: commitHashes, markedAt: Date.now() })
+      // DevSkim: ignore DS172411 — function literal, fixed delay,
+      // no caller-supplied data flowing through.
+      setTimeout(() => dispatch({ type: 'clearRecentCommits' }), 5000)
+    }
+
+    // If the workflow reported success but zero commits actually
+    // landed, surface that as an error — the spinner-then-silence
+    // failure mode from #940 manual testing where the apply appeared
+    // to succeed but the worktree got wiped with no commits made.
+    if (commitHashes.length === 0) {
+      const detail = result.message || 'No commits were created.'
+      dispatch({
+        type: 'setStatus',
+        value: `Split apply produced zero commits: ${detail} · diagnostic log: ${dumpPath}`,
+        kind: 'error',
+      })
+      return
+    }
+
+    const successMessage = formatSplitApplySuccess(
+      commitHashes.length,
+      unstaged,
+      untracked,
+      result.fallback ? { reason: result.fallback.reason } : undefined
+    )
+    // Name the files the split deliberately left behind so the jump to
+    // status reads as intentional, not a surprise (#1180).
+    const unclaimedNote = unclaimedFileCount > 0
+      ? ` · ${unclaimedFileCount} file${unclaimedFileCount === 1 ? '' : 's'} left for you on status`
+      : ''
+    // Fallback path uses 'info' kind — apply technically succeeded
+    // but the user should know it landed as a single combined commit
+    // rather than a real LLM-driven multi-group split.
+    dispatch({
+      type: 'setStatus',
+      value: `${successMessage}${unclaimedNote}`,
+      kind: result.fallback ? 'info' : 'success',
+    })
+  }, [dispatch, git, refreshContext, refreshHistoryRows, refreshWorktreeContext, stateSplitPlan])
+
+  // Esc inside the overlay — close without applying. Status line gets
+  // a confirmation so the user knows the operation was abandoned.
+  const cancelCommitSplit = React.useCallback(() => {
+    dispatch({ type: 'clearSplitPlan' })
+    dispatch({ type: 'setStatus', value: 'Split plan cancelled.' })
+  }, [dispatch])
+
+  return {
+    startCommitSplit,
+    applyCommitSplit,
+    cancelCommitSplit,
+  }
+}


### PR DESCRIPTION
Continues the 0.72 `app.ts` decomposition (PR 13, after `useWorktreeStageActions` / `useCommitComposeActions`). Lifts the three contiguous commit-split action handlers out of `src/workstation/runtime/app.ts` into a new `useCommitSplitActions` hook.

## What moved (verbatim)
- `startCommitSplit` — `S` keystroke pre-flight (staged-count + operation-in-progress guards) → `runCommitSplitPlanWorkflow({ git })` → `startSplitPlanLoad` / `setSplitPlanReady` / `setSplitPlanError`.
- `applyCommitSplit` — `y`/Enter apply: reads `state.splitPlan.{plan, planContext, fallback}`, runs `runCommitSplitApplyWorkflow()`, writes the diagnostic dump to `/tmp`, then the refresh/dispatch sequence.
- `cancelCommitSplit` — Esc: `clearSplitPlan` / `setStatus`.

All three handler **bodies and `useCallback` dependency arrays are byte-identical** to the originals. The three stay distinct (not consolidated).

## Discipline
- Dep arrays preserved exactly:
  - `startCommitSplit`: `[context.operation, context.worktree?.stagedCount, dispatch, git]`
  - `applyCommitSplit`: `[dispatch, git, refreshContext, refreshHistoryRows, refreshWorktreeContext, state.splitPlan]`
  - `cancelCommitSplit`: `[dispatch]`
- The `applyCommitSplit` refresh/dispatch sequencing (`refreshHistoryRows` → `refreshWorktreeContext` → `refreshContext`; `clearSplitPlan` / `commitCompose reset` / `navigateHome` / conditional `pushView status` / `markRecentCommits`) is preserved exactly — reordering would change post-apply UI state.
- The diagnostic-dump path/format is preserved verbatim.
- **No identity hazard**: all three are invoked ONLY from the input handler's keystroke dispatch (`startCommitSplit` / `applyCommitSplit` / `cancelCommitSplit` events) — none appear in any `useEffect` / `useMemo` dependency array.
- Single hook call placed at the handlers' original slot; all inputs (`context`, `state.splitPlan`, `git`, `dispatch`, `refreshContext`, `refreshHistoryRows`, `refreshWorktreeContext`) are declared above it.

## Imports
- Removed from `app.ts` (now unused): `runCommitSplitPlanWorkflow`, `runCommitSplitApplyWorkflow` (kept `runCommitDraftWorkflow`), and `formatSplitApplySuccess`. Moved into the hook along with `getWorktreeOverview` + the `node:fs`/`node:os`/`node:path` builtins for the dump.
- Node builtins remain imported in `app.ts` (still used by the changelog editor / other paths) — verified by grep + lint.
- No pure core extracted: the `startCommitSplit` pre-flight dispatches two distinct error messages with interleaved early returns; a single `canStartCommitSplit(...)` boolean would not preserve the verbatim body, so it was left inline (covered by the green build).

## app.ts reduction
- `React.useCallback` count: 20 → 17.
- Line count: 4271 → 4041.

## Validation
- `npm test` fully green: 275 suites passed (1 skipped — gated GitLab integration), 3465 tests passed (3 skipped). jest + lint + build + CLI smoke + pack all pass.
- `npx tsc --noEmit` clean.