### PR TITLE
chore(eslint): add eslint-plugin-react-hooks for rules-of-hooks safety net

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,10 @@
   "root": true,
   "parser": "@typescript-eslint/parser",
   "extends": ["plugin:@typescript-eslint/recommended"],
+  "plugins": ["react-hooks"],
   "parserOptions": { "ecmaVersion": 2018, "sourceType": "module" },
-  "rules": {}
+  "rules": {
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@typescript-eslint/parser": "^7.13.1",
     "cross-env": "^10.1.0",
     "eslint": "^8.54.0",
+    "eslint-plugin-react-hooks": "4.6.2",
     "ink-testing-library": "4.0.0",
     "jest": "^30.0.5",
     "release-it": "^20.0.1",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -50,7 +50,9 @@ const config = [
       }),
       eslint({
         throwOnError: true,
-        throwOnWarning: true,
+        // Warnings are advisory (e.g. react-hooks/exhaustive-deps) and must not
+        // fail the build; errors (e.g. react-hooks/rules-of-hooks) still do.
+        throwOnWarning: false,
         include: ['src/**/*.ts'],
         exclude: ['node_modules/**', 'dist/**'],
       }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3150,6 +3150,11 @@ escodegen@^2.1.0:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-plugin-react-hooks@4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz#c829eb06c0e6f484b3fbb85a97e57784f328c596"
+  integrity sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==
+
 eslint-scope@^7.2.2:
   version "7.2.2"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz"
@@ -4672,7 +4677,7 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^3.1.2, minimatch@^3.1.3:
+minimatch@^3.1.2:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
   integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==


### PR DESCRIPTION
## Why

`eslint-plugin-react-hooks` was not installed, so the ESLint config (eslint 8.x, legacy `.eslintrc`) never enforced rules-of-hooks or exhaustive-deps. The workstation TUI runtime (`src/workstation/runtime/`) was just decomposed into 26 custom hooks under `hooks/use*.ts` plus `app.ts` (an Ink/React component). That component is **never mounted in tests**, so a hook-order or stale-dep regression would not be caught by the suite. This plugin is the missing safety net.

## What

- **Add `eslint-plugin-react-hooks@4.6.2`** as a devDependency (Yarn; exact pin, no `package-lock.json`). 4.6.2 is the well-tested release for eslint 8.x + legacy `.eslintrc`.
- **Enable the rules** in `.eslintrc`:
  - `react-hooks/rules-of-hooks: error`
  - `react-hooks/exhaustive-deps: warn` — starts as `warn` to avoid a large failing baseline.
- **Flip `@rollup/plugin-eslint` `throwOnWarning` → `false`** in `rollup.config.mjs`. The build runs ESLint with `throwOnWarning: true`, which would turn the new advisory `exhaustive-deps` warnings into hard build failures (defeating the point of "start as warn"). `throwOnError` stays `true`, so `rules-of-hooks` errors — and any other ESLint error — still fail the build. The build had zero warnings before, so this only affects the new react-hooks warnings.

## Lint results

`yarn lint`: **0 errors, 41 warnings** — all `exhaustive-deps`, zero `rules-of-hooks` violations (no hook-order bugs found). The warnings are spread across `app.ts` and the extracted hooks.

**Do not "fix" these by editing dep arrays.** Many extracted hooks carry hand-curated dependency arrays that were preserved byte-for-byte during the decomposition; the goal here is to surface the lint signal, not to alter behavior-preserving code.

### Expect limited value on the hooks themselves

The custom hooks receive `React` (`typeof ReactTypes`) as their first parameter because the runtime can't statically import React. `exhaustive-deps` doesn't trace `React.useCallback`/`React.useMemo`/`React.useEffect` through that indirection, so it's noisy and limited on the hook files. Its real value is guarding **`app.ts` and future code** that calls hooks directly.

## Validation

- `yarn lint` → exit 0 (warnings only)
- `npm test` → **green** end-to-end (jest: 3471 passed / 3 skipped; lint; rollup build; smoke CLI; `npm pack --dry-run`)