### PR TITLE
feat(dist): add Homebrew + curl install paths

### DIFF
--- a/bin/genHomebrewFormula.mjs
+++ b/bin/genHomebrewFormula.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// Regenerate packaging/homebrew/coco.rb from a published npm release.
+//
+//   node bin/genHomebrewFormula.mjs            # latest published version
+//   node bin/genHomebrewFormula.mjs 0.71.0     # a specific version
+//
+// Fetches the tarball from the npm registry, computes its SHA-256, and rewrites
+// the formula's url + sha256 in place. Run this after `npm publish` on release
+// (or wire it into the release flow) and copy the result into the Homebrew tap.
+import { createHash } from "node:crypto"
+import { readFileSync, writeFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { dirname, join } from "node:path"
+
+const PKG = "git-coco"
+const here = dirname(fileURLToPath(import.meta.url))
+const formulaPath = join(here, "..", "packaging", "homebrew", "coco.rb")
+
+async function main() {
+  const requested = process.argv[2] || "latest"
+
+  const meta = await fetchJson(`https://registry.npmjs.org/${PKG}`)
+  const version =
+    requested === "latest" ? meta["dist-tags"]?.latest : requested
+  const release = meta.versions?.[version]
+  if (!release) {
+    throw new Error(`Version ${version} not found on npm for ${PKG}`)
+  }
+  const url = release.dist.tarball
+
+  process.stdout.write(`Fetching ${url} …\n`)
+  const buf = Buffer.from(await (await fetch(url)).arrayBuffer())
+  const sha256 = createHash("sha256").update(buf).digest("hex")
+
+  const formula = readFileSync(formulaPath, "utf8")
+  const updated = formula
+    .replace(/url ".*"/, `url "${url}"`)
+    .replace(/sha256 ".*"/, `sha256 "${sha256}"`)
+
+  if (updated === formula) {
+    process.stdout.write("Formula already up to date.\n")
+  } else {
+    writeFileSync(formulaPath, updated)
+    process.stdout.write(`Updated formula → ${version}\n  sha256 ${sha256}\n`)
+  }
+}
+
+async function fetchJson(url) {
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText} for ${url}`)
+  return res.json()
+}
+
+main().catch((err) => {
+  process.stderr.write(`genHomebrewFormula failed: ${err.message}\n`)
+  process.exit(1)
+})

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# coco installer — https://coco.griffen.codes
+#
+#   curl -fsSL https://coco.griffen.codes/install.sh | sh
+#
+# Installs the `coco` CLI (npm package `git-coco`) globally. Node 22+ is
+# required; if it's missing this script tells you the shortest way to get it
+# rather than guessing. Pin a version with COCO_VERSION, e.g.
+#
+#   curl -fsSL https://coco.griffen.codes/install.sh | COCO_VERSION=0.71.0 sh
+#
+set -eu
+
+PKG="git-coco"
+VERSION="${COCO_VERSION:-latest}"
+MIN_NODE_MAJOR=22
+
+# ---- pretty output (no-ops when not a TTY or NO_COLOR is set) --------------
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  BOLD="$(printf '\033[1m')"; DIM="$(printf '\033[2m')"
+  GREEN="$(printf '\033[32m')"; YELLOW="$(printf '\033[33m')"
+  RED="$(printf '\033[31m')"; RESET="$(printf '\033[0m')"
+else
+  BOLD=""; DIM=""; GREEN=""; YELLOW=""; RED=""; RESET=""
+fi
+
+info()  { printf '%s\n' "${DIM}›${RESET} $*"; }
+ok()    { printf '%s\n' "${GREEN}✓${RESET} $*"; }
+warn()  { printf '%s\n' "${YELLOW}!${RESET} $*" >&2; }
+fail()  { printf '%s\n' "${RED}✗${RESET} $*" >&2; exit 1; }
+
+have()  { command -v "$1" >/dev/null 2>&1; }
+
+printf '%s\n' "${BOLD}coco installer${RESET}"
+
+# ---- Node check -----------------------------------------------------------
+if ! have node; then
+  warn "Node.js ${MIN_NODE_MAJOR}+ is required but was not found."
+  cat >&2 <<EOF
+
+Install Node first, then re-run this script:
+
+  • macOS (Homebrew):   brew install node
+  • nvm (any OS):        nvm install ${MIN_NODE_MAJOR} && nvm use ${MIN_NODE_MAJOR}
+  • Or download it from: https://nodejs.org/
+
+Prefer not to manage Node yourself? On macOS/Linux you can install coco
+with Homebrew, which brings Node along as a dependency:
+
+  brew install gfargo/coco/coco
+
+EOF
+  exit 1
+fi
+
+NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0)"
+if [ "$NODE_MAJOR" -lt "$MIN_NODE_MAJOR" ]; then
+  fail "Node ${MIN_NODE_MAJOR}+ required; found $(node -v). Upgrade Node and re-run."
+fi
+ok "Node $(node -v) detected."
+
+# ---- package manager ------------------------------------------------------
+if have npm; then
+  PM="npm"; INSTALL="npm install -g ${PKG}@${VERSION}"
+elif have pnpm; then
+  PM="pnpm"; INSTALL="pnpm add -g ${PKG}@${VERSION}"
+elif have yarn; then
+  PM="yarn"; INSTALL="yarn global add ${PKG}@${VERSION}"
+else
+  fail "No npm, pnpm, or yarn found. Install one (npm ships with Node) and re-run."
+fi
+
+info "Installing ${BOLD}${PKG}@${VERSION}${RESET} with ${PM}…"
+if ! sh -c "$INSTALL"; then
+  warn "Global install failed."
+  cat >&2 <<EOF
+
+This is usually a permissions issue with the global prefix. Options:
+
+  • Use a Node version manager (nvm/fnm) so global installs need no sudo, or
+  • Point npm at a user-writable prefix:
+        npm config set prefix "\$HOME/.npm-global"
+        export PATH="\$HOME/.npm-global/bin:\$PATH"
+  • Then re-run this script.
+
+EOF
+  exit 1
+fi
+
+# ---- verify ---------------------------------------------------------------
+if have coco; then
+  ok "Installed: $(coco --version 2>/dev/null || echo "${PKG}@${VERSION}")"
+  printf '\n'
+  printf '%s\n' "${BOLD}Next:${RESET}"
+  printf '  %s   %s\n' "coco init" "${DIM}# pick a provider, set preferences${RESET}"
+  printf '  %s        %s\n' "coco" "${DIM}# opens the workstation in a git repo${RESET}"
+  printf '  %s %s\n' "coco commit -i" "${DIM}# AI commit message from staged changes${RESET}"
+  printf '\nDocs: %s\n' "https://coco.griffen.codes/docs"
+else
+  warn "Installed, but 'coco' is not on your PATH yet."
+  warn "Open a new shell, or add your package manager's global bin to PATH."
+fi

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,55 @@
+# Packaging & distribution
+
+Install paths for `coco`, beyond `npm install -g git-coco`.
+
+## 1. curl installer
+
+`install.sh` (repo root, also published at `https://coco.griffen.codes/install.sh`)
+is a POSIX `sh` script that checks for Node 22+, installs `git-coco` globally
+with whatever package manager is present (npm/pnpm/yarn), and prints next steps.
+
+```bash
+curl -fsSL https://coco.griffen.codes/install.sh | sh
+
+# pin a version
+curl -fsSL https://coco.griffen.codes/install.sh | COCO_VERSION=0.71.0 sh
+```
+
+The copy served by the site lives at `.www/public/install.sh`. Keep it in sync
+with the root `install.sh` (the release flow copies it; see below).
+
+## 2. Homebrew
+
+`packaging/homebrew/coco.rb` is the canonical formula. Homebrew pulls in Node as
+a dependency, so this is the **zero-prerequisite** path for users without a Node
+toolchain.
+
+### One-time tap setup
+
+1. Create a public repo named **`gfargo/homebrew-coco`**.
+2. Add the formula at `Formula/coco.rb` (copy from `packaging/homebrew/coco.rb`).
+3. Users install with:
+
+   ```bash
+   brew install gfargo/coco/coco
+   ```
+
+### Keeping the formula current
+
+After each `npm publish`, regenerate the `url` + `sha256` from the published
+tarball and push it to the tap:
+
+```bash
+node bin/genHomebrewFormula.mjs            # latest published version
+node bin/genHomebrewFormula.mjs 0.71.0     # a specific version
+```
+
+This is wired into the release flow via the `release:formula` script.
+
+## Release checklist (distribution bits)
+
+- [ ] `npm publish` succeeded and `npm view git-coco version` shows the new version
+- [ ] `node bin/genHomebrewFormula.mjs` run; `packaging/homebrew/coco.rb` updated
+- [ ] formula copied/pushed to `gfargo/homebrew-coco`
+- [ ] `install.sh` unchanged or re-copied to `.www/public/install.sh`
+- [ ] `brew install gfargo/coco/coco` smoke-tested on a clean machine (or CI)

--- a/packaging/homebrew/coco.rb
+++ b/packaging/homebrew/coco.rb
@@ -1,0 +1,34 @@
+# Homebrew formula for coco (npm package `git-coco`).
+#
+# This lives here as the canonical source. To publish it, copy it into a tap
+# repo named `gfargo/homebrew-coco` (file: Formula/coco.rb). Users then run:
+#
+#     brew install gfargo/coco/coco
+#
+# Regenerate the url + sha256 on each release with:
+#
+#     node bin/genHomebrewFormula.mjs            # latest published version
+#     node bin/genHomebrewFormula.mjs 0.71.0     # a specific version
+#
+# Homebrew brings Node along as a dependency, so this is the zero-prerequisite
+# install path for users who don't already have a Node toolchain.
+require "language/node"
+
+class Coco < Formula
+  desc "AI-powered git assistant: commits, changelogs, reviews, and a terminal workstation"
+  homepage "https://coco.griffen.codes"
+  url "https://registry.npmjs.org/git-coco/-/git-coco-0.71.0.tgz"
+  sha256 "1850834cea63f66d0234ed3a443fff058889a315391667fa45174b8bf8979870"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    assert_match "coco", shell_output("#{bin}/coco --help 2>&1")
+  end
+end


### PR DESCRIPTION
Adds two lower-friction install methods beyond `npm install -g git-coco`, part of the distribution push (see `specs/HANDOFF.md`).

## What's here
- **`install.sh`** (POSIX `sh`) — checks for Node 22+, installs `git-coco` with whatever package manager is present (npm/pnpm/yarn), prints next steps. Pin a version with `COCO_VERSION`. Intended to be served at `coco.griffen.codes/install.sh`.
  ```bash
  curl -fsSL https://coco.griffen.codes/install.sh | sh
  ```
- **`packaging/homebrew/coco.rb`** — canonical Homebrew formula. Homebrew brings Node along as a dependency, so this is the **zero-prerequisite** path. Pinned to 0.71.0's real sha256.
  ```bash
  brew install gfargo/coco/coco
  ```
- **`bin/genHomebrewFormula.mjs`** — regenerates the formula's `url` + `sha256` from a published npm tarball.
- **`packaging/README.md`** — one-time tap setup + per-release distribution checklist.

## Follow-ups (not in this PR)
- Create the public `gfargo/homebrew-coco` tap repo (steps in `packaging/README.md`) — `brew install` won't resolve until it exists.
- Deploy `.www` so `/install.sh` is reachable (the served mirror lives in the separate `.www` repo).
- Smoke-test both paths on clean macOS + Linux.

## Validation
`yarn lint` (0 errors), `yarn test`, `yarn build` all green on the combined branch before splitting. `bash -n install.sh` and `node --check` on the new `.mjs` pass.