### PR TITLE
docs(readme): lead with AI commits, add Install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,14 @@
 [![Last Commit](https://img.shields.io/github/last-commit/gfargo/coco)](https://github.com/gfargo/coco/tree/main)
 [![Discord](https://img.shields.io/discord/1176716060825767948)](https://discord.gg/KGu9nE9Ejx)
 
-An AI-powered git assistant that generates meaningful commit messages, creates changelogs, explores repository history, and streamlines your development workflow.
+**Write your git commits with AI — then never leave the terminal.** `coco` turns your staged diff into a clear, Conventional-Commits-ready message in one command, and grows into a full keyboard-driven git workstation when you want it. Works across seven AI providers — including **fully local Ollama** (no API costs, nothing leaves your machine) — on GitHub and GitLab.
+
+```bash
+git add .
+coco commit          # AI writes the message from your staged changes
+```
+
+That's the core. Everything else — changelogs, code review, PRs, and the `coco ui` workstation — is the same engine pointed at more of your git workflow.
 
 **✨ Key Features:**
 
@@ -25,16 +32,26 @@ An AI-powered git assistant that generates meaningful commit messages, creates c
 - 📦 **Package Manager Friendly** - Works with npm, yarn, and pnpm
 - 👥 **Team Ready** - Shared configurations and enterprise deployment
 
+## Install
+
+```bash
+# Homebrew (macOS/Linux) — brings Node along, no prerequisites
+brew install gfargo/coco/coco
+
+# curl installer
+curl -fsSL https://coco.griffen.codes/install.sh | sh
+
+# npm / pnpm / yarn (needs Node 22+)
+npm install -g git-coco
+
+# or try it without installing
+npx git-coco@latest init
+```
+
 ## Quick Start
 
 ```bash
-# Try without installing
-npx git-coco@latest init
-
-# Install globally  
-npm install -g git-coco
-
-# Setup and configure
+# Setup and configure (pick a provider, set preferences)
 coco init
 
 # Generate your first commit


### PR DESCRIPTION
Repositions the README around the differentiated wedge — **local-first AI commit messages** — rather than the workstation TUI (a crowded fight vs lazygit/gitui/gh-dash). Part of the distribution push (see `specs/HANDOFF.md`).

## Changes
- **Hero** now opens with the core flow and the local-Ollama angle:
  ```bash
  git add .
  coco commit          # AI writes the message from your staged changes
  ```
  Seven providers including fully-local Ollama (no API cost, nothing leaves your machine). The `coco ui` workstation is reframed as the "grows into" payoff rather than the lede.
- New **Install** section covering Homebrew, curl, and npm/npx side by side.

## Note
The Homebrew/curl lines reference assets added in #1250 (install paths) and the not-yet-created tap / deployed site. Copy is accurate to the intended end state; the install methods become live as those follow-ups land.

## Validation
`yarn lint` / `yarn test` / `yarn build` green on the combined branch before splitting.