### PR TITLE
fix(dist): shorten brew install to gfargo/tap/coco

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 [![Last Commit](https://img.shields.io/github/last-commit/gfargo/coco)](https://github.com/gfargo/coco/tree/main)
 [![Discord](https://img.shields.io/discord/1176716060825767948)](https://discord.gg/KGu9nE9Ejx)
 
-**Write your git commits with AI — then never leave the terminal.** `coco` turns your staged diff into a clear, Conventional-Commits-ready message in one command, and grows into a full keyboard-driven git workstation when you want it. Works across seven AI providers — including **fully local Ollama** (no API costs, nothing leaves your machine) — on GitHub and GitLab.
+**git-coco — write your git commits with AI, then never leave the terminal.** The `coco` command turns your staged diff into a clear, Conventional-Commits-ready message in one step, and grows into a full keyboard-driven git workstation when you want it. Works across seven AI providers — including **fully local Ollama** (no API costs, nothing leaves your machine) — on GitHub, GitHub Enterprise, and GitLab.
+
+> **Name note:** the package and project are **git-coco**; the command you run is `coco`.
 
 ```bash
 git add .
@@ -36,7 +38,7 @@ That's the core. Everything else — changelogs, code review, PRs, and the `coco
 
 ```bash
 # Homebrew (macOS/Linux) — brings Node along, no prerequisites
-brew install gfargo/coco/coco
+brew install gfargo/tap/coco
 
 # curl installer
 curl -fsSL https://coco.griffen.codes/install.sh | sh

--- a/install.sh
+++ b/install.sh
@@ -47,7 +47,7 @@ Install Node first, then re-run this script:
 Prefer not to manage Node yourself? On macOS/Linux you can install coco
 with Homebrew, which brings Node along as a dependency:
 
-  brew install gfargo/coco/coco
+  brew install gfargo/tap/coco
 
 EOF
   exit 1

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -26,12 +26,12 @@ toolchain.
 
 ### One-time tap setup
 
-1. Create a public repo named **`gfargo/homebrew-coco`**.
+1. Create a public repo named **`gfargo/homebrew-tap`**.
 2. Add the formula at `Formula/coco.rb` (copy from `packaging/homebrew/coco.rb`).
 3. Users install with:
 
    ```bash
-   brew install gfargo/coco/coco
+   brew install gfargo/tap/coco
    ```
 
 ### Keeping the formula current
@@ -50,6 +50,6 @@ This is wired into the release flow via the `release:formula` script.
 
 - [ ] `npm publish` succeeded and `npm view git-coco version` shows the new version
 - [ ] `node bin/genHomebrewFormula.mjs` run; `packaging/homebrew/coco.rb` updated
-- [ ] formula copied/pushed to `gfargo/homebrew-coco`
+- [ ] formula copied/pushed to `gfargo/homebrew-tap`
 - [ ] `install.sh` unchanged or re-copied to `.www/public/install.sh`
-- [ ] `brew install gfargo/coco/coco` smoke-tested on a clean machine (or CI)
+- [ ] `brew install gfargo/tap/coco` smoke-tested on a clean machine (or CI)

--- a/packaging/homebrew/coco.rb
+++ b/packaging/homebrew/coco.rb
@@ -1,9 +1,9 @@
 # Homebrew formula for coco (npm package `git-coco`).
 #
 # This lives here as the canonical source. To publish it, copy it into a tap
-# repo named `gfargo/homebrew-coco` (file: Formula/coco.rb). Users then run:
+# repo named `gfargo/homebrew-tap` (file: Formula/coco.rb). Users then run:
 #
-#     brew install gfargo/coco/coco
+#     brew install gfargo/tap/coco
 #
 # Regenerate the url + sha256 on each release with:
 #


### PR DESCRIPTION
Follow-up to #1250. Uses a generic `homebrew-tap` repo instead of `homebrew-coco`, dropping the repeated formula name from the install command:

```bash
brew install gfargo/tap/coco   # was: gfargo/coco/coco
```

A single `gfargo/homebrew-tap` repo can also hold any future formulae (the pattern charm/goreleaser/etc. use). The tap repo doesn't exist yet, so there's no migration cost — this just settles the name before it's created.

Updates the curl-installer hint (`install.sh`), README install block, formula header comment, and the packaging docs + release checklist. `bash -n install.sh` passes.