### PR TITLE
chore: gitignore local .homebrew-tap checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ coverage/
 # WWW NextJS marketing frontend site
 .www/
 
+# Local Homebrew tap checkout (gfargo/homebrew-tap)
+.homebrew-tap/
+
 /src/lib/buildInfo.ts
 
 .kiro


### PR DESCRIPTION
Adds `.homebrew-tap/` to `.gitignore`, matching the existing `.www/` and `.wiki/` entries. This is a gitignored local clone of the [`gfargo/homebrew-tap`](https://github.com/gfargo/homebrew-tap) repo so the Homebrew formula can be worked on in-tree without polluting `git status`.