### PR TITLE
chore: add contributor onboarding + Homebrew tap automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,94 @@
+name: Bug report
+description: Report something that isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please search [existing issues](https://github.com/gfargo/coco/issues) first to avoid duplicates.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, and what you expected instead.
+      placeholder: Running `coco commit` did X, but I expected Y.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact commands and conditions that trigger it.
+      placeholder: |
+        1. `git add .`
+        2. `coco commit`
+        3. See error …
+    validations:
+      required: true
+  - type: dropdown
+    id: command
+    attributes:
+      label: Which command?
+      options:
+        - commit
+        - amend
+        - changelog
+        - recap
+        - review
+        - pr create
+        - log
+        - ui (workstation)
+        - workspace
+        - issues / prs
+        - doctor / init
+        - other / not sure
+    validations:
+      required: true
+  - type: dropdown
+    id: provider
+    attributes:
+      label: AI provider
+      options:
+        - OpenAI
+        - Anthropic
+        - Gemini
+        - Mistral
+        - Azure OpenAI
+        - AWS Bedrock
+        - Ollama (local)
+        - not relevant
+    validations:
+      required: false
+  - type: dropdown
+    id: forge
+    attributes:
+      label: Git forge (if relevant)
+      options:
+        - GitHub
+        - GitHub Enterprise
+        - GitLab
+        - GitLab self-managed
+        - not relevant
+    validations:
+      required: false
+  - type: textarea
+    id: doctor
+    attributes:
+      label: Environment
+      description: "Paste the output of `coco doctor` (redact anything sensitive), plus your OS and Node version."
+      render: shell
+      placeholder: |
+        coco --version:
+        node --version:
+        OS:
+        coco doctor: …
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / output
+      description: Relevant output, ideally with `--verbose`. Do NOT paste API keys, tokens, or proprietary diff content.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Discord
+    url: https://discord.gg/KGu9nE9Ejx
+    about: Questions, help, and general chat — fastest way to reach the community.
+  - name: 🗣️ GitHub Discussions
+    url: https://github.com/gfargo/coco/discussions
+    about: Ideas, Q&A, and show-and-tell that aren't bug reports or concrete feature requests.
+  - name: 📚 Documentation
+    url: https://coco.griffen.codes/docs
+    about: Getting started, configuration, providers, and the workstation guide.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,46 @@
+name: Feature request
+description: Suggest a new capability or an improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! Please check [existing issues](https://github.com/gfargo/coco/issues) and [discussions](https://github.com/gfargo/coco/discussions) first — there may already be a thread.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: The use case or pain point. What are you trying to do that coco makes hard today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What you'd like coco to do. A command, flag, view, or behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other tools or workarounds you've tried, and why they fall short.
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - commit / amend
+        - changelog / recap
+        - review
+        - pr / mr creation
+        - ui (workstation)
+        - workspace (multi-repo)
+        - providers / model routing
+        - forges (GitHub / GitLab / Bitbucket)
+        - config / init / doctor
+        - other
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+Thanks for contributing to git-coco! Keep PRs small and focused — one logical change.
+Title should follow Conventional Commits, e.g. `feat(commit): …` / `fix(ui): …`.
+-->
+
+## What
+
+<!-- What does this change do, and why? Link the issue it addresses. -->
+
+Closes #
+
+## How
+
+<!-- Brief notes on the approach, and anything reviewers should look at closely. -->
+
+## Validation
+
+- [ ] `npm test` passes locally (lint + jest + build + packaged-CLI smoke)
+- [ ] New behavior has tests; TUI changes carry render coverage (`src/workstation/README.md`)
+- [ ] `schema.json` regenerated if config types changed (`npm run build:schema`)
+- [ ] Docs updated where relevant (README / `.wiki/`)
+- [ ] Commits follow Conventional Commits
+
+## Notes
+
+<!-- Screenshots / GIFs for TUI changes, breaking-change callouts, follow-ups, etc. -->

--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -1,0 +1,92 @@
+name: Update Homebrew tap
+
+# Regenerates the Homebrew formula (url + sha256) from the freshly published
+# npm package and pushes it to gfargo/homebrew-tap, so `brew install gfargo/tap/coco`
+# always tracks the latest release.
+#
+# Setup (one time):
+#   1. Create the public tap repo gfargo/homebrew-tap with Formula/coco.rb.
+#   2. Add a repo secret HOMEBREW_TAP_TOKEN — a fine-grained PAT (or classic PAT
+#      with `repo` scope) that can push to gfargo/homebrew-tap.
+# After that this runs automatically on every published release.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 0.71.0). Blank = latest on npm."
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  update-tap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout coco
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.22.2
+
+      - name: Resolve version
+        id: ver
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            V="${{ github.event.inputs.version }}"
+          elif [ -n "${{ github.event.release.tag_name }}" ]; then
+            V="${{ github.event.release.tag_name }}"
+          else
+            V="latest"
+          fi
+          V="${V#v}"
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $V"
+
+      - name: Wait for npm to publish
+        if: steps.ver.outputs.version != 'latest'
+        run: |
+          for i in $(seq 1 30); do
+            if npm view "git-coco@${{ steps.ver.outputs.version }}" version >/dev/null 2>&1; then
+              echo "Found git-coco@${{ steps.ver.outputs.version }} on npm."
+              exit 0
+            fi
+            echo "Not on npm yet, waiting… ($i/30)"
+            sleep 10
+          done
+          echo "::error::git-coco@${{ steps.ver.outputs.version }} did not appear on npm in time."
+          exit 1
+
+      - name: Regenerate formula
+        run: node bin/genHomebrewFormula.mjs "${{ steps.ver.outputs.version }}"
+
+      - name: Checkout tap repo
+        uses: actions/checkout@v4
+        with:
+          repository: gfargo/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - name: Copy formula into tap
+        run: |
+          mkdir -p tap/Formula
+          cp packaging/homebrew/coco.rb tap/Formula/coco.rb
+
+      - name: Commit & push to tap
+        working-directory: tap
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet; then
+            echo "Formula already up to date — nothing to push."
+            exit 0
+          fi
+          git add Formula/coco.rb
+          git commit -m "coco ${{ steps.ver.outputs.version }}"
+          git push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,22 @@ Thank you for considering contributing to Commit Copilot! We appreciate your int
   - [Community](#community)
   - [Acknowledgements](#acknowledgements)
 
+## Quick start
+
+```bash
+git clone https://github.com/<your-fork>/coco && cd coco
+npm install
+npm run dev          # watch mode (use `npm run dev:tui` for coco ui / log -i / workspace)
+```
+
+Before opening a PR, run the full validation suite — the same gates CI runs:
+
+```bash
+npm test             # lint + jest + build + packaged-CLI smoke
+```
+
+Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (this project dogfoods `coco commit`). Keep each PR small and focused, and make sure it passes the suite above on its own.
+
 ## How Can I Contribute?
 
 There are several ways in which you can contribute to Commit Copilot (coco):
@@ -34,7 +50,7 @@ If you encounter a bug, have a feature request, or need assistance, please [subm
 
 ## Submitting Feature Requests
 
-If you have an idea for a new feature or an improvement to an existing feature, we would love to hear it! You can [submit a feature request](https://github.com/gfargo/coco/issues/new?assignees=&labels=feature+request&template=feature_request.md) on our GitHub repository. Please provide a clear and concise description of the feature you would like to see and any relevant use cases.
+If you have an idea for a new feature or an improvement to an existing feature, we would love to hear it! You can [submit a feature request](https://github.com/gfargo/coco/issues/new?template=feature_request.yml) on our GitHub repository. Please provide a clear and concise description of the feature you would like to see and any relevant use cases.
 
 ## Development Setup
 
@@ -121,7 +137,15 @@ We welcome and encourage pull requests from the community. To submit a pull requ
 6. Commit your changes and push them to your forked repository.
 7. Submit a pull request to the `main` branch of the Commit Copilot repository.
 
-Please provide a clear and detailed description of the changes you have made in your pull request. We will review your contribution as soon as possible.
+Please provide a clear and detailed description of the changes you have made in your pull request (the PR template will prompt you). We will review your contribution as soon as possible.
+
+**Before you open the PR, confirm:**
+
+- [ ] `npm test` passes locally (lint + jest + build + CLI smoke).
+- [ ] New behavior has tests; TUI changes carry render coverage (see `src/workstation/README.md`).
+- [ ] `schema.json` is regenerated if config types changed (`npm run build:schema`).
+- [ ] Commit messages follow Conventional Commits.
+- [ ] The PR is focused on one logical change.
 
 ## Community
 


### PR DESCRIPTION
Lands the remaining distribution/onboarding work so it ships in **0.72**.

## Changes
- **`CONTRIBUTING.md`** — quick-start, full-validation gate (`npm test`), and a pre-PR checklist; feature-request link points at the new issue form.
- **`.github/ISSUE_TEMPLATE/`** — `bug_report.yml`, `feature_request.yml`, `config.yml`.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — PR checklist.
- **`.github/workflows/update-homebrew-tap.yml`** — on each published release (or manual dispatch), waits for the version to appear on npm, regenerates `coco.rb` via `bin/genHomebrewFormula.mjs`, and pushes it to `gfargo/homebrew-tap`.

## ⚠️ Action required for the tap automation
Add a **`HOMEBREW_TAP_TOKEN`** repo secret (fine-grained PAT, or classic with `repo` scope) that can push to `gfargo/homebrew-tap`. Without it, the workflow's tap checkout/push step fails. Everything else is no-config.