### PR TITLE
feat(init): graceful Ollama first-run in coco init

### DIFF
--- a/src/commands/init/handler.ts
+++ b/src/commands/init/handler.ts
@@ -12,8 +12,9 @@ import { installNpmPackage } from '../../lib/utils/installPackage'
 
 import { ConfigWithServiceObject } from '../../lib/config/types'
 import { loadConfig } from '../../lib/config/utils/loadConfig'
-import { OllamaLLMService } from '../../lib/langchain/types'
+import { LLMModel, LLMProvider, OllamaLLMService } from '../../lib/langchain/types'
 import { getDefaultServiceConfigFromAlias } from '../../lib/langchain/utils'
+import { OllamaNotReadyError } from '../../lib/langchain/utils/ollamaStatus'
 import { CommandHandler } from '../../lib/types'
 import { Logger } from '../../lib/utils/logger'
 import { getPathToUsersGitConfig } from '../../lib/utils/getPathToUsersGitConfig'
@@ -49,8 +50,24 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
   // Ask about commitlint setup after scope selection
   shouldSetupCommitlint = await questions.setupCommitlint()
 
-  const llmProvider = await questions.selectLLMProvider()
-  const llmModel = await questions.selectLLMModel(llmProvider)
+  // Pick provider + model in a loop so an unusable Ollama (not installed /
+  // not running / no models pulled) re-offers the provider picker instead of
+  // hard-exiting and discarding the answers above.
+  let llmProvider: LLMProvider
+  let llmModel: LLMModel
+  for (;;) {
+    llmProvider = await questions.selectLLMProvider()
+    try {
+      llmModel = await questions.selectLLMModel(llmProvider)
+      break
+    } catch (err) {
+      if (err instanceof OllamaNotReadyError) {
+        logger.log(chalk.dim("\nLet's choose a provider again."))
+        continue
+      }
+      throw err
+    }
+  }
 
   const service = getDefaultServiceConfigFromAlias(llmProvider, llmModel)
 

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -14,6 +14,7 @@ import { getProjectConfigFilePath } from '../../lib/utils/getProjectConfigFilePa
 import { installNpmPackage } from '../../lib/utils/installPackage'
 import { Logger } from '../../lib/utils/logger'
 import { confirmPrompt } from '../../lib/ui/inquirerPrompts'
+import { OllamaNotReadyError } from '../../lib/langchain/utils/ollamaStatus'
 
 jest.mock('../../lib/ui/inquirerPrompts', () => ({
   confirmPrompt: jest.fn(),
@@ -239,5 +240,30 @@ describe('init command', () => {
     })
     expect(mockLogResult).toHaveBeenCalled()
     expect(mockAppendToProjectJsonConfig).toHaveBeenCalled()
+  })
+
+  it('re-offers the provider picker when Ollama is not ready, preserving the session', async () => {
+    // First pass: user picks Ollama, but it isn't ready, so selectLLMModel
+    // throws OllamaNotReadyError. The handler should catch it and re-prompt
+    // the provider rather than aborting the whole init session.
+    jest
+      .spyOn(questions, 'selectLLMProvider')
+      .mockResolvedValueOnce('ollama')
+      .mockResolvedValueOnce('openai')
+    jest
+      .spyOn(questions, 'selectLLMModel')
+      .mockRejectedValueOnce(new OllamaNotReadyError())
+      .mockResolvedValueOnce('gpt-4o')
+    mockApiKeyService('openai')
+
+    await handler(createArgv({ scope: 'project' }), logger)
+
+    expect(questions.selectLLMProvider).toHaveBeenCalledTimes(2)
+    expect(mockAppendToProjectJsonConfig).toHaveBeenCalledWith(
+      '/repo/.coco.config.json',
+      expect.objectContaining({
+        service: expect.objectContaining({ provider: 'openai' }),
+      })
+    )
   })
 })

--- a/src/commands/init/questions.ts
+++ b/src/commands/init/questions.ts
@@ -1,5 +1,13 @@
+import chalk from 'chalk'
+
 import { ANTHROPIC_MODELS, BEDROCK_MODELS, GEMINI_MODELS, MISTRAL_MODELS, OPEN_AI_MODELS } from '../../lib/langchain/constants'
 import { LLMModel, LLMProvider } from '../../lib/langchain/types'
+import {
+  getOllamaStatus,
+  OllamaNotReadyError,
+  pullOllamaModel,
+  RECOMMENDED_STARTER_MODEL,
+} from '../../lib/langchain/utils/ollamaStatus'
 import {
     confirmPrompt,
     editorPrompt,
@@ -7,11 +15,72 @@ import {
     passwordPrompt,
     selectPrompt,
 } from '../../lib/ui/inquirerPrompts'
-import { commandExit } from '../../lib/utils/commandExit'
-import { execPromise } from '../../lib/utils/execPromise'
 import { ProjectConfigFileName } from '../../lib/utils/getProjectConfigFilePath'
 import { COMMIT_PROMPT } from '../commit/prompt'
 import { InstallationScope } from './config'
+
+/**
+ * Resolve the list of locally-available Ollama models for the init picker,
+ * guiding the user through the common first-run states instead of crashing:
+ *
+ *   - not installed       → install link, then re-run or pick another provider
+ *   - installed, not up   → `ollama serve` hint, then re-run or pick another
+ *   - up, no models       → recommend + optionally pull a starter model
+ *
+ * Throws {@link OllamaNotReadyError} when Ollama can't be used and the user
+ * didn't fix it inline — the handler catches this to re-offer the provider
+ * picker, preserving the rest of the init session.
+ */
+async function ensureOllamaModels(): Promise<string[]> {
+  let status = await getOllamaStatus()
+
+  if (!status.reachable) {
+    if (!status.installed) {
+      console.log(
+        `\n${chalk.yellow('Ollama isn’t installed')} — coco’s local-AI path needs it.\n` +
+          `  Install: ${chalk.cyan('https://ollama.com/download')} ${chalk.dim('(macOS/Linux:')} ${chalk.cyan('brew install ollama')}${chalk.dim(')')}\n` +
+          `  Then run ${chalk.cyan('ollama serve')} and re-run ${chalk.cyan('coco init')}, or pick another provider below.`,
+      )
+    } else {
+      console.log(
+        `\n${chalk.yellow('Ollama is installed but not running.')}\n` +
+          `  Start it with ${chalk.cyan('ollama serve')} (or open the Ollama app), then re-run — or pick another provider below.`,
+      )
+    }
+    throw new OllamaNotReadyError()
+  }
+
+  if (status.models.length === 0) {
+    console.log(
+      `\n${chalk.yellow('No Ollama models are pulled yet.')} ` +
+        `coco recommends ${chalk.cyan(RECOMMENDED_STARTER_MODEL)} to start ${chalk.dim('(~4.7 GB).')}`,
+    )
+    const shouldPull = await confirmPrompt({
+      message: `pull ${RECOMMENDED_STARTER_MODEL} now?`,
+      default: true,
+    })
+    if (!shouldPull) {
+      console.log(
+        `  ${chalk.dim('No problem — pull one yourself with')} ${chalk.cyan(`ollama pull ${RECOMMENDED_STARTER_MODEL}`)}${chalk.dim(', or pick another provider below.')}`,
+      )
+      throw new OllamaNotReadyError()
+    }
+    try {
+      await pullOllamaModel(RECOMMENDED_STARTER_MODEL)
+    } catch {
+      console.log(
+        `  ${chalk.red('Pull failed.')} Run ${chalk.cyan(`ollama pull ${RECOMMENDED_STARTER_MODEL}`)} manually, or pick another provider below.`,
+      )
+      throw new OllamaNotReadyError()
+    }
+    status = await getOllamaStatus()
+    if (status.models.length === 0) {
+      throw new OllamaNotReadyError()
+    }
+  }
+
+  return status.models
+}
 
 export const questions = {
   /**
@@ -134,17 +203,7 @@ export const questions = {
     }
 
     if (provider === 'ollama') {
-      // Check if ollama is installed
-      const { stdout } = await execPromise(
-        `ollama list |  awk '{print $1}' | awk '{if(NR>1)print}'`
-      )
-
-      const availableOllamaModels = stdout.split('\n').filter(Boolean)
-
-      if (availableOllamaModels.length === 0) {
-        console.log('No Ollama models found. Please install one via Ollama CLI.')
-        commandExit(1)
-      }
+      const availableOllamaModels = await ensureOllamaModels()
 
       availableModels = [
         ...availableOllamaModels.map((model) => ({

--- a/src/lib/langchain/utils/ollamaStatus.test.ts
+++ b/src/lib/langchain/utils/ollamaStatus.test.ts
@@ -1,0 +1,99 @@
+import { execPromise } from '../../utils/execPromise'
+import {
+  DEFAULT_OLLAMA_ENDPOINT,
+  getOllamaStatus,
+  OllamaNotReadyError,
+  RECOMMENDED_STARTER_MODEL,
+} from './ollamaStatus'
+
+jest.mock('../../utils/execPromise')
+
+const mockExecPromise = execPromise as jest.MockedFunction<typeof execPromise>
+
+function mockFetchOnce(impl: () => Promise<unknown> | never) {
+  ;(global as unknown as { fetch: jest.Mock }).fetch = jest.fn(impl as never)
+}
+
+describe('getOllamaStatus', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.clearAllMocks()
+  })
+
+  it('reports reachable + pulled models when the daemon responds', async () => {
+    mockFetchOnce(async () => ({
+      ok: true,
+      json: async () => ({
+        models: [{ name: 'llama3.1:8b' }, { name: 'qwen2.5-coder:7b' }, { name: '' }],
+      }),
+    }))
+
+    const status = await getOllamaStatus()
+
+    expect(status.reachable).toBe(true)
+    expect(status.installed).toBe(true)
+    // empty / missing names are filtered out
+    expect(status.models).toEqual(['llama3.1:8b', 'qwen2.5-coder:7b'])
+    // a reachable daemon never needs the PATH probe
+    expect(mockExecPromise).not.toHaveBeenCalled()
+  })
+
+  it('distinguishes installed-but-not-running from not-installed when unreachable', async () => {
+    mockFetchOnce(async () => {
+      throw new Error('ECONNREFUSED')
+    })
+    mockExecPromise.mockResolvedValue({ stdout: '/usr/local/bin/ollama', stderr: '' })
+
+    const status = await getOllamaStatus()
+
+    expect(status.reachable).toBe(false)
+    expect(status.installed).toBe(true) // binary on PATH
+    expect(status.models).toEqual([])
+  })
+
+  it('reports not installed when unreachable and the binary is absent', async () => {
+    mockFetchOnce(async () => {
+      throw new Error('ECONNREFUSED')
+    })
+    mockExecPromise.mockRejectedValue('not found')
+
+    const status = await getOllamaStatus()
+
+    expect(status.reachable).toBe(false)
+    expect(status.installed).toBe(false)
+  })
+
+  it('treats a non-OK response as unreachable', async () => {
+    mockFetchOnce(async () => ({ ok: false, json: async () => ({}) }))
+    mockExecPromise.mockRejectedValue('not found')
+
+    const status = await getOllamaStatus()
+
+    expect(status.reachable).toBe(false)
+  })
+
+  it('strips trailing slashes from the endpoint when building the tags URL', async () => {
+    const fetchMock = jest.fn(async () => ({ ok: true, json: async () => ({ models: [] }) }))
+    ;(global as unknown as { fetch: jest.Mock }).fetch = fetchMock as never
+
+    await getOllamaStatus('http://localhost:11434/')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:11434/api/tags',
+      expect.any(Object),
+    )
+  })
+})
+
+describe('constants + error', () => {
+  it('exposes a localhost default endpoint and a small starter model', () => {
+    expect(DEFAULT_OLLAMA_ENDPOINT).toBe('http://localhost:11434')
+    expect(RECOMMENDED_STARTER_MODEL).toBe('llama3.1:8b')
+  })
+
+  it('OllamaNotReadyError is a named Error', () => {
+    const err = new OllamaNotReadyError()
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe('OllamaNotReadyError')
+  })
+})

--- a/src/lib/langchain/utils/ollamaStatus.ts
+++ b/src/lib/langchain/utils/ollamaStatus.ts
@@ -1,0 +1,95 @@
+import { spawn } from 'child_process'
+
+import { execPromise } from '../../utils/execPromise'
+
+/** Fallback endpoint when none is configured — matches the Ollama default and
+ * the provider's own `DEFAULT_OLLAMA_ENDPOINT`. */
+export const DEFAULT_OLLAMA_ENDPOINT = 'http://localhost:11434'
+
+/**
+ * The starter model first-run users are pointed at. It's coco's cost-tier
+ * `commit` default and ~4.7 GB — large enough for solid commit messages, small
+ * enough to pull and run on a typical laptop. (The `balanced`/`quality` dynamic
+ * defaults reach for bigger coder models; we deliberately recommend the small
+ * one for the very first pull.)
+ */
+export const RECOMMENDED_STARTER_MODEL = 'llama3.1:8b'
+
+export interface OllamaStatus {
+  /** The daemon answered at the endpoint. */
+  reachable: boolean
+  /** The `ollama` binary resolved on PATH (best-effort). A reachable endpoint
+   * counts as installed, since a remote daemon needs no local binary. */
+  installed: boolean
+  /** Names of locally-pulled models (empty when unreachable). */
+  models: string[]
+}
+
+/**
+ * Raised when Ollama can't be used as configured and the user opted not to fix
+ * it inline. `coco init` catches this to re-offer the provider picker instead
+ * of aborting the whole session (the old behavior hard-exited via
+ * `commandExit(1)`, discarding every prior answer).
+ */
+export class OllamaNotReadyError extends Error {
+  constructor(message = 'Ollama is not ready') {
+    super(message)
+    this.name = 'OllamaNotReadyError'
+  }
+}
+
+/**
+ * Probe a local (or remote) Ollama instance over its HTTP API. Cross-platform
+ * (no `awk`/shell pipes), and a single call tells us reachability *and* the
+ * pulled-model list. Falls back to a PATH probe only to distinguish
+ * "not installed" from "installed but not running" for the guidance copy.
+ */
+export async function getOllamaStatus(
+  endpoint: string = DEFAULT_OLLAMA_ENDPOINT,
+): Promise<OllamaStatus> {
+  let reachable = false
+  let models: string[] = []
+
+  try {
+    const res = await fetch(`${endpoint.replace(/\/+$/, '')}/api/tags`, {
+      signal: AbortSignal.timeout(2500),
+    })
+    if (res.ok) {
+      reachable = true
+      const data = (await res.json()) as { models?: Array<{ name?: string }> }
+      models = (data.models ?? [])
+        .map((m) => m.name)
+        .filter((name): name is string => typeof name === 'string' && name.length > 0)
+    }
+  } catch {
+    reachable = false
+  }
+
+  const installed = reachable || (await isOllamaBinaryPresent())
+  return { reachable, installed, models }
+}
+
+async function isOllamaBinaryPresent(): Promise<boolean> {
+  const probe = process.platform === 'win32' ? 'where ollama' : 'command -v ollama'
+  try {
+    await execPromise(probe)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Run `ollama pull <model>` with live progress (inherited stdio) so the user
+ * sees the download bar. Resolves on success; rejects on spawn error or
+ * non-zero exit.
+ */
+export function pullOllamaModel(model: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('ollama', ['pull', model], { stdio: 'inherit' })
+    child.on('error', reject)
+    child.on('close', (code) =>
+      code === 0 ? resolve() : reject(new Error(`ollama pull exited with code ${code}`)),
+    )
+  })
+}


### PR DESCRIPTION
First slice of the 0.73 **Ollama onboarding** polish (freeze-allowed). Since Ollama is the *default* provider in the picker, this is most new users' first impression of the "local AI commits" path the launch leads with.

## Problem
The Ollama branch of `coco init` shelled out:
```
ollama list | awk '{print $1}' | awk '{if(NR>1)print}'
```
- **Non-portable** — no `awk` on Windows.
- **Crashes** if Ollama isn't installed (`execPromise` rejects with a raw "command not found").
- On no models, prints a vague message and **hard-exits**, discarding every prior init answer (scope, commitlint).
- No "daemon not running" guidance.

## Change
New `lib/langchain/utils/ollamaStatus.ts`:
- `getOllamaStatus(endpoint?)` — probes the HTTP API (`/api/tags`) for reachability **and** pulled models in one cross-platform call; a PATH probe only distinguishes "not installed" from "not running" for the copy.
- `pullOllamaModel(model)` — `ollama pull` with live progress.
- `OllamaNotReadyError` — typed signal.

`coco init` now guides each first-run state instead of crashing:
- **not installed** → install link (`ollama.com/download` / `brew install ollama`)
- **installed but not running** → `ollama serve`
- **up but no models** → recommends + optionally pulls `llama3.1:8b` (~4.7 GB, the cost-tier `commit` default), prompted — never automatic

When Ollama can't be used and the user doesn't fix it inline, the handler catches `OllamaNotReadyError` and **re-offers the provider picker** — prior answers are preserved (no more session loss).

## Tests
- `ollamaStatus.test.ts` — reachable / not-running / not-installed / non-OK / endpoint normalization (7 cases).
- `init.test.ts` — new test: not-ready → re-prompt → completes with another provider.

## Validation
`eslint` (0 errors), `tsc --noEmit` clean, `jest` init + ollamaStatus suites green (7/7 each). Full rollup build deferred to CI (nested-worktree PATH quirk locally).

## Follow-ups (rest of the 0.73 Ollama polish)
- `coco doctor`: Ollama daemon liveness + configured-model-pulled check
- Actionable runtime error on commit when daemon down / model missing
- Fix `handleMissingApiKey` Ollama copy (`OLLAMA_API_KEY` is misleading for local)