### PR TITLE
feat(doctor): live Ollama daemon + model checks in coco doctor

### DIFF
--- a/src/commands/doctor/checks.test.ts
+++ b/src/commands/doctor/checks.test.ts
@@ -1,0 +1,108 @@
+import { Config } from '../../lib/config/types'
+import { getOllamaStatus } from '../../lib/langchain/utils/ollamaStatus'
+import { checkOllamaLiveness } from './checks'
+
+jest.mock('../../lib/langchain/utils/ollamaStatus', () => ({
+  DEFAULT_OLLAMA_ENDPOINT: 'http://localhost:11434',
+  getOllamaStatus: jest.fn(),
+}))
+
+const mockGetOllamaStatus = getOllamaStatus as jest.MockedFunction<typeof getOllamaStatus>
+
+function ollamaConfig(overrides: Record<string, unknown> = {}): Config {
+  return {
+    service: {
+      provider: 'ollama',
+      model: 'llama3.1:8b',
+      authentication: { type: 'None' },
+      ...overrides,
+    },
+  } as unknown as Config
+}
+
+describe('checkOllamaLiveness', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  it('is a no-op for non-Ollama providers (no network call)', async () => {
+    const config = { service: { provider: 'openai', model: 'gpt-4o' } } as unknown as Config
+
+    const diagnostics = await checkOllamaLiveness(config)
+
+    expect(diagnostics).toEqual([])
+    expect(mockGetOllamaStatus).not.toHaveBeenCalled()
+  })
+
+  it('errors with a serve hint when installed but the daemon is unreachable', async () => {
+    mockGetOllamaStatus.mockResolvedValue({ reachable: false, installed: true, models: [] })
+
+    const [diagnostic] = await checkOllamaLiveness(ollamaConfig())
+
+    expect(diagnostic.severity).toBe('error')
+    expect(diagnostic.message).toContain('not reachable')
+    expect(diagnostic.fix).toContain('ollama serve')
+  })
+
+  it('errors with an install hint when Ollama is not installed', async () => {
+    mockGetOllamaStatus.mockResolvedValue({ reachable: false, installed: false, models: [] })
+
+    const [diagnostic] = await checkOllamaLiveness(ollamaConfig())
+
+    expect(diagnostic.severity).toBe('error')
+    expect(diagnostic.fix).toContain('ollama.com/download')
+  })
+
+  it('passes silently when the configured model is pulled', async () => {
+    mockGetOllamaStatus.mockResolvedValue({
+      reachable: true,
+      installed: true,
+      models: ['llama3.1:8b', 'qwen2.5-coder:7b'],
+    })
+
+    const diagnostics = await checkOllamaLiveness(ollamaConfig())
+
+    expect(diagnostics).toEqual([])
+  })
+
+  it('tolerates the implicit :latest tag', async () => {
+    mockGetOllamaStatus.mockResolvedValue({
+      reachable: true,
+      installed: true,
+      models: ['llama3.1:latest'],
+    })
+
+    const diagnostics = await checkOllamaLiveness(ollamaConfig({ model: 'llama3.1' }))
+
+    expect(diagnostics).toEqual([])
+  })
+
+  it('warns with a pull hint when the configured model is missing', async () => {
+    mockGetOllamaStatus.mockResolvedValue({
+      reachable: true,
+      installed: true,
+      models: ['llama3.2:3b'],
+    })
+
+    const [diagnostic] = await checkOllamaLiveness(ollamaConfig({ model: 'llama3.1:8b' }))
+
+    expect(diagnostic.severity).toBe('warn')
+    expect(diagnostic.message).toContain("'llama3.1:8b'")
+    expect(diagnostic.fix).toBe('Pull it with `ollama pull llama3.1:8b`.')
+  })
+
+  it('resolves the commit-tier model for dynamic configs', async () => {
+    mockGetOllamaStatus.mockResolvedValue({
+      reachable: true,
+      installed: true,
+      models: ['llama3.2:3b'],
+    })
+
+    const [diagnostic] = await checkOllamaLiveness(
+      ollamaConfig({ model: 'dynamic', dynamicModelPreference: 'balanced' }),
+    )
+
+    expect(diagnostic.severity).toBe('warn')
+    // balanced commit tier for ollama is qwen2.5-coder:14b
+    expect(diagnostic.message).toContain('qwen2.5-coder:14b')
+    expect(diagnostic.message).toContain('dynamic → commit')
+  })
+})

--- a/src/commands/doctor/checks.ts
+++ b/src/commands/doctor/checks.ts
@@ -1,5 +1,7 @@
 import * as fs from 'fs'
 import { Config } from '../../lib/config/types'
+import { resolveDynamicModel } from '../../lib/langchain/utils/dynamicModels'
+import { DEFAULT_OLLAMA_ENDPOINT, getOllamaStatus } from '../../lib/langchain/utils/ollamaStatus'
 
 export type DiagnosticSeverity = 'error' | 'warn' | 'info'
 
@@ -299,4 +301,61 @@ function checkProjectConfigFile(diagnostics: Diagnostic[]) {
       fix: `Fix the JSON syntax in ${configPath} or regenerate it with \`coco init --scope project\`.`,
     })
   }
+}
+
+/** Does the Ollama daemon report `model` as pulled? Tolerant of the implicit
+ * `:latest` tag Ollama applies when a model is referenced without one. */
+function isModelPulled(model: string, pulled: string[]): boolean {
+  if (pulled.includes(model)) return true
+  if (!model.includes(':')) return pulled.includes(`${model}:latest`)
+  if (model.endsWith(':latest')) return pulled.includes(model.slice(0, -':latest'.length))
+  return false
+}
+
+/**
+ * Live Ollama checks that need a network round-trip — kept out of the
+ * synchronous {@link runDiagnostics} (which `coco init` runs inline) so only
+ * `coco doctor` pays the cost. No-op for non-Ollama providers.
+ *
+ * Surfaces the two first-run cliffs the config checks can't see:
+ *   - the daemon isn't reachable at the configured endpoint, and
+ *   - the model coco will actually call isn't pulled (for `dynamic`, the
+ *     resolved commit-tier model is checked).
+ */
+export async function checkOllamaLiveness(config: Config): Promise<Diagnostic[]> {
+  const diagnostics: Diagnostic[] = []
+  if (config.service?.provider !== 'ollama') return diagnostics
+
+  const endpoint =
+    ('endpoint' in config.service && config.service.endpoint) || DEFAULT_OLLAMA_ENDPOINT
+  const status = await getOllamaStatus(endpoint)
+
+  if (!status.reachable) {
+    diagnostics.push({
+      severity: 'error',
+      message: `Ollama daemon is not reachable at ${endpoint}.`,
+      fix: status.installed
+        ? 'Start it with `ollama serve` (or open the Ollama app).'
+        : 'Install Ollama (https://ollama.com/download), then run `ollama serve`.',
+    })
+    return diagnostics
+  }
+
+  const configuredModel = config.service.model
+  const modelToCheck =
+    configuredModel === 'dynamic' ? resolveDynamicModel(config, 'commit') : configuredModel
+
+  if (modelToCheck && !isModelPulled(modelToCheck, status.models)) {
+    const dynamicNote = configuredModel === 'dynamic' ? ' (dynamic → commit)' : ''
+    const have = status.models.length
+      ? ` Pulled: ${status.models.slice(0, 4).join(', ')}${status.models.length > 4 ? '…' : ''}.`
+      : ''
+    diagnostics.push({
+      severity: 'warn',
+      message: `Ollama model '${modelToCheck}'${dynamicNote} isn't pulled.${have}`,
+      fix: `Pull it with \`ollama pull ${modelToCheck}\`.`,
+    })
+  }
+
+  return diagnostics
 }

--- a/src/commands/doctor/handler.ts
+++ b/src/commands/doctor/handler.ts
@@ -21,7 +21,7 @@ import {
   type UsageAggregate,
 } from '../../lib/langchain/utils/usageLedger'
 import { DoctorArgv, DoctorOptions } from './config'
-import { DiagnosticSeverity, runDiagnostics } from './checks'
+import { checkOllamaLiveness, DiagnosticSeverity, runDiagnostics } from './checks'
 import { Config } from '../../lib/config/types'
 
 function renderUsageRows(rows: UsageAggregate[], unit: string): string[] {
@@ -179,8 +179,10 @@ export const handler: CommandHandler<DoctorArgv> = async (argv, logger) => {
 
   logger.log('')
 
-  // Run diagnostics
+  // Run diagnostics — sync config checks plus live Ollama probes (daemon
+  // reachability + configured-model-pulled), which need a network round-trip.
   const diagnostics = runDiagnostics(config)
+  diagnostics.push(...(await checkOllamaLiveness(config)))
 
   if (diagnostics.length === 0) {
     logger.log(chalk.green(`${PASS()} No issues found. Your configuration looks good!`))


### PR DESCRIPTION
Second slice of the 0.73 **Ollama onboarding** polish (follow-up to #1264). `coco doctor` validated Ollama *config shape* only — it never checked whether the daemon was reachable or whether the configured model was pulled, so the first failure surfaced as a raw error on `coco commit`.

## Change
New async `checkOllamaLiveness(config)` in `doctor/checks.ts`, called from the (async) doctor handler. Kept **out of** the synchronous `runDiagnostics` so only `coco doctor` pays the network cost — `coco init`'s inline verify is unchanged (no network added to init).

It surfaces the two first-run cliffs the config checks can't see:
- **daemon unreachable** → `error` with `ollama serve` (or install) guidance
- **model not pulled** → `warn` with `ollama pull <model>`; for `model: "dynamic"` the resolved **commit-tier** model is checked (catches the heavyweight-default trap, e.g. `qwen2.5-coder:14b`)
- tolerant of Ollama's implicit `:latest` tag
- no-op for non-Ollama providers

## Tests
`doctor/checks.test.ts` (new) — 7 cases: non-Ollama no-op, unreachable+installed, unreachable+not-installed, model pulled, `:latest` tolerance, model missing, dynamic→commit resolution.

## Validation
`eslint` (0 errors), `tsc --noEmit` clean, `jest` 7/7, **full `yarn build` green** (run in the root worktree).

## Remaining 0.73 Ollama follow-up
- Actionable runtime error on `coco commit` when daemon down / model missing (PR 3)
- Fix `handleMissingApiKey` Ollama copy (`OLLAMA_API_KEY` misleading for local)