### PR TITLE
feat(errors): actionable hint when an Ollama model isn't pulled

### DIFF
--- a/src/lib/utils/commandExecutor.test.ts
+++ b/src/lib/utils/commandExecutor.test.ts
@@ -1,4 +1,4 @@
-import commandExecutor from './commandExecutor'
+import commandExecutor, { extractMissingOllamaModel } from './commandExecutor'
 import { loadConfig } from '../config/utils/loadConfig'
 import { Logger } from './logger'
 import { CommandHandler } from '../types'
@@ -34,5 +34,34 @@ describe('commandExecutor — global --quiet wiring', () => {
     }
     await commandExecutor(handler)({ quiet: false } as never)
     expect(logSpy).toHaveBeenCalled()
+  })
+})
+
+describe('extractMissingOllamaModel', () => {
+  it('extracts the model from Ollama\'s not-found message (quoted)', () => {
+    const err = new Error('model "qwen2.5-coder:14b" not found, try pulling it first')
+    expect(extractMissingOllamaModel(err)).toBe('qwen2.5-coder:14b')
+  })
+
+  it('extracts the model when unquoted', () => {
+    const err = new Error('model llama3.1:8b not found, try pulling it first')
+    expect(extractMissingOllamaModel(err)).toBe('llama3.1:8b')
+  })
+
+  it('sees through a wrapped/prefixed message', () => {
+    const err = new Error('commit: model "phi3:mini" not found, try pulling it first')
+    expect(extractMissingOllamaModel(err)).toBe('phi3:mini')
+  })
+
+  it('ignores non-Ollama "model not found" errors (no pull hint)', () => {
+    // OpenAI-style — must not get mis-advised toward `ollama pull`
+    const err = new Error('The model `gpt-5` does not exist or you do not have access.')
+    expect(extractMissingOllamaModel(err)).toBeNull()
+  })
+
+  it('returns null for unrelated errors and non-Errors', () => {
+    expect(extractMissingOllamaModel(new Error('ECONNREFUSED'))).toBeNull()
+    expect(extractMissingOllamaModel('not an error')).toBeNull()
+    expect(extractMissingOllamaModel(undefined)).toBeNull()
   })
 })

--- a/src/lib/utils/commandExecutor.ts
+++ b/src/lib/utils/commandExecutor.ts
@@ -119,6 +119,35 @@ function formatGenericError(error: Error, logger: Logger): void {
 }
 
 /**
+ * Detect Ollama's "model not pulled" failure and pull out the model name.
+ *
+ * When the daemon is up but the requested model isn't pulled, Ollama returns
+ * `model "<name>" not found, try pulling it first`. We gate on both `not found`
+ * **and** `pull` so an OpenAI/Anthropic "model does not exist" error doesn't get
+ * mis-advised toward `ollama pull`. Returns the model name, or null when the
+ * error isn't this case.
+ */
+export function extractMissingOllamaModel(error: unknown): string | null {
+  const message = error instanceof Error ? error.message : ''
+  if (!message) return null
+  if (!/not found/i.test(message) || !/pull/i.test(message)) return null
+  const match = message.match(/model\s+["']?([^"'\s]+)["']?\s+not found/i)
+  return match ? match[1] : null
+}
+
+/**
+ * Render an actionable hint for a not-yet-pulled Ollama model, instead of
+ * letting the raw "model not found" bubble through the generic formatter.
+ */
+function formatModelNotFoundError(model: string, logger: Logger): void {
+  logger.log(`\nError: Ollama model "${model}" isn't available locally`, { color: 'red' })
+  logger.log('\nLikely fixes:', { color: 'yellow' })
+  logger.log(`  • Pull it: ollama pull ${model}`, { color: 'white' })
+  logger.log('  • See what you have: ollama list', { color: 'white' })
+  logger.log('  • Run `coco doctor` to check your provider + model', { color: 'white' })
+}
+
+/**
  * Resolve the local usage-stats recording preference for this run (#0.69) and
  * arm the ledger. Recording is opt-out: a first interactive run with no
  * preference set anywhere defaults on, persists the choice to the global
@@ -174,10 +203,13 @@ function commandExecutor<T extends Argv<BaseArgvOptions>['argv']>(handler: Comma
       }
 
       // Handle specific error types with helpful messages
+      const missingOllamaModel = extractMissingOllamaModel(error)
       if (error instanceof LangChainNetworkError) {
         formatNetworkError(error, logger)
       } else if (error instanceof LangChainAuthenticationError) {
         formatAuthenticationError(error, logger)
+      } else if (missingOllamaModel) {
+        formatModelNotFoundError(missingOllamaModel, logger)
       } else {
         formatGenericError(error as Error, logger)
       }


### PR DESCRIPTION
Third slice of the 0.73 **Ollama onboarding** polish (after #1264 init, #1265 doctor). Closes the last runtime gap.

## Problem
The error formatter already gives provider-aware hints for **daemon down** (`ollama serve`) and **auth** failures. But when the daemon is up and the model simply isn't pulled, Ollama returns `model "X" not found, try pulling it first` — which fell through to the **generic** formatter (`Failed to execute command / Error: <raw>`), with no `ollama pull` guidance.

## Change
- `extractMissingOllamaModel(error)` — detects Ollama's signature (gated on **both** `not found` and `pull`, so an OpenAI/Anthropic "model does not exist" error isn't mis-advised toward `ollama pull`) and extracts the model name.
- `formatModelNotFoundError` — shows `ollama pull <model>`, `ollama list`, and `coco doctor`.
- Wired into the `commandExecutor` catch ahead of the generic fallback.

## Tests
5 new cases on the detector: quoted / unquoted / wrapped messages, OpenAI-style false-positive rejection, and non-Ollama / non-Error inputs.

## Validation
`eslint` (0 errors), `tsc --noEmit` clean, `jest` 7/7, full `yarn build` green.

## Ollama onboarding — complete
- ✅ #1264 graceful `coco init` first-run
- ✅ #1265 `coco doctor` daemon + model liveness
- ✅ this — actionable runtime model-not-found hint

(The `handleMissingApiKey` `OLLAMA_API_KEY` copy is unreachable for normal Ollama configs — auth is `None`, enforced by doctor — so it was intentionally left out.)