### PR TITLE
docs(readme): add coco commit hero GIF; point demo at a code change

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ git add .
 coco commit          # AI writes the message from your staged changes
 ```
 
+![coco commit drafting a Conventional Commit message from a staged diff](https://coco.griffen.codes/screenshots/demo-commit-flow.gif)
+
 That's the core. Everything else — changelogs, code review, PRs, and the `coco ui` workstation — is the same engine pointed at more of your git workflow.
 
 **✨ Key Features:**

--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -1270,8 +1270,8 @@ export const RECIPES: ScreenshotRecipe[] = [
   },
   {
     name: 'demo-commit-flow',
-    description: 'coco commit: AI drafts a Conventional Commit message from staged changes',
-    scenario: 'single-staged-file',
+    description: 'coco commit: AI drafts a Conventional Commit message from staged code changes',
+    scenario: 'partial-stage',
     command: 'commit --dry-run --conventional',
     emitGif: true,
     dimensions: { cols: 100, rows: 28 },


### PR DESCRIPTION
Adds the **launch hero GIF** for the `coco commit` wedge and makes the demo a code change.

## Changes
- **README hero** — embeds the `coco commit` demo GIF directly under the `git add . && coco commit` block (served from `coco.griffen.codes/screenshots/demo-commit-flow.gif`). Visual proof of the headline claim.
- **`demo-commit-flow` recipe** — repointed from `single-staged-file` (a README → `docs:`) to `partial-stage` (staged code changes), so the AI drafts a code-oriented Conventional Commit. Captured with local Ollama (`qwen2.5-coder`), it renders e.g. `refactor(api/auth): …` from the staged diff.

## Asset
The GIF is rendered through the existing screenshot pipeline (real `coco commit --dry-run --conventional`, ~5s, 0.10 MB after the lossless/optimized pass). AI-dependent demos aren't in the auto-sync `SITE_RECIPES` (they can't regenerate without a provider), so the refreshed GIF is committed to the `.www` repo separately — paired PR.

## Note
The exact commit type/wording varies run-to-run (real local model), which is expected for a live-AI demo; the recipe is reproducible by anyone with Ollama + `COCO_SERVICE_PROVIDER=ollama`.