### PR TITLE
fix(cli): reconcile -t/-c short flags; complete CommitOptions interface

### DIFF
--- a/src/commands/commit/config.ts
+++ b/src/commands/commit/config.ts
@@ -12,6 +12,12 @@ export interface CommitOptions extends BaseCommandOptions {
   conventional: boolean
   includeBranchName: boolean
   noVerify: boolean
+  /** Free-text appended to the end of the generated commit message. */
+  append?: string
+  /** Append the ticket ID parsed from the branch name to the message. */
+  appendTicket?: boolean
+  /** Extra contextual information injected into the prompt. */
+  additional?: string
   split?: boolean
   plan?: boolean
   apply?: boolean
@@ -72,9 +78,10 @@ export const options = {
     type: 'string',
   },
   appendTicket: {
+    // No short alias: `-t` is reserved for `--tag` (changelog) to keep the
+    // letter consistent across commands (#1245).
     description: 'Append ticket ID from branch name to the commit message',
     type: 'boolean',
-    alias: 't',
   },
   additional: {
     description: 'Add extra contextual information to the prompt',

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -391,9 +391,9 @@ IMPORTANT RULES:
         const ticketId = extractTicketIdFromBranchName(branchName)
 
         const fullMessage = formatCommitMessage(commitMsg, {
-          append: argv.append as string | undefined,
+          append: argv.append,
           ticketId: ticketId || undefined,
-          appendTicket: argv.appendTicket as boolean | undefined,
+          appendTicket: argv.appendTicket,
         })
 
         // If commitlint validation is needed and not skipped, validate the message

--- a/src/commands/flagAliasConsistency.test.ts
+++ b/src/commands/flagAliasConsistency.test.ts
@@ -1,0 +1,22 @@
+import { options as commitOptions } from './commit/config'
+import { options as logOptions } from './log/config'
+import { options as changelogOptions } from './changelog/config'
+
+/**
+ * Guards the short-flag reconciliation from #1245: the two letters that
+ * previously meant different things across commands now resolve to one flag
+ * each. `-t` is `--tag` (changelog) and `-c` is `--conventional` (commit); the
+ * conflicting `commit --appendTicket -t` and `log --commit -c` aliases were
+ * dropped (long forms remain).
+ */
+describe('short-flag alias consistency (#1245)', () => {
+  it('reserves -t for changelog --tag only', () => {
+    expect(changelogOptions.tag.alias).toBe('t')
+    expect(commitOptions.appendTicket.alias).toBeUndefined()
+  })
+
+  it('reserves -c for commit --conventional only', () => {
+    expect(commitOptions.conventional.alias).toBe('c')
+    expect(logOptions.commit.alias).toBeUndefined()
+  })
+})

--- a/src/commands/log/config.ts
+++ b/src/commands/log/config.ts
@@ -47,9 +47,10 @@ export const options = {
     alias: 'b',
   },
   commit: {
+    // No short alias: `-c` is reserved for `--conventional` (commit) to keep
+    // the letter consistent across commands (#1245).
     description: 'Show details and changed files for a single commit',
     type: 'string',
-    alias: 'c',
   },
   format: {
     description: 'Output format',


### PR DESCRIPTION
Fixes #1245 and #1246.

## #1245 — conflicting short-flag aliases
A short letter now resolves to one flag across commands:
- **`-t`** → `--tag` (changelog) only; removed from commit's `--appendTicket`
- **`-c`** → `--conventional` (commit) only; removed from `log --commit`

Kept the letter on the stronger-mnemonic / more-used side (`--tag`, `--conventional`); the long forms `--appendTicket` and `--commit` are unchanged. A small `flagAliasConsistency.test.ts` guards the reconciliation.

⚠️ **Minor breaking change:** `coco commit -t` and `coco log -c` no longer resolve — use the long flags.

## #1246 — incomplete `CommitOptions` interface
`append` / `appendTicket` / `additional` were defined as yargs options but missing from the `CommitOptions` type, so the handler used loose `as` casts. Added them to the interface and dropped the casts (`argv.append` / `argv.appendTicket` are now properly typed).

## Validation
`eslint` (0 errors), `tsc --noEmit` clean, `jest` commit+log suites (13 suites / 196 tests) + new guard test green, full `yarn build` green.