### PR TITLE
refactor(langchain): drop dead llm param + tighten createSchemaParser return

### DIFF
--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -252,7 +252,7 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
     parser,
     agent: async (context, options) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const parser: any = createSchemaParser(ChangelogResponseSchema, llm)
+      const parser: any = createSchemaParser(ChangelogResponseSchema)
 
       const prompt = getPrompt({
         template: options.prompt,

--- a/src/commands/commit/generateCommitDraft.ts
+++ b/src/commands/commit/generateCommitDraft.ts
@@ -366,7 +366,7 @@ export async function generateCommitDraft({
       // fall through to executeChainWithSchema below for a real
       // schema-validated retry — paying for a second LLM call only
       // on the edge case where the streamed output is unsalvageable.
-      const streamingParser = createSchemaParser(schema, llm)
+      const streamingParser = createSchemaParser(schema)
       // Capture the final accumulated text out-of-band so we can
       // attempt salvage if the parser throws on completion (audit
       // finding #1). Updated on every chunk; the last value is

--- a/src/commands/recap/handler.ts
+++ b/src/commands/recap/handler.ts
@@ -227,7 +227,7 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
 
       try {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const parser: any = createSchemaParser(RecapLlmResponseSchema, llm)
+        const parser: any = createSchemaParser(RecapLlmResponseSchema)
         
         const variables = {
           changes: context,

--- a/src/commands/review/handler.ts
+++ b/src/commands/review/handler.ts
@@ -223,7 +223,7 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
     parser,
     agent: async (context, options) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const parser: any = createSchemaParser(ReviewFeedbackResponseSchema, llm)
+      const parser: any = createSchemaParser(ReviewFeedbackResponseSchema)
 
       const formatInstructions =
         "Respond with a valid JSON object, containing four fields:'title' a string, 'summary' a short summary of the problem (include line number if big file), 'severity' a numeric enum up to ten, 'category' an enum string, and 'filePath' a relative filepath to file as string."

--- a/src/lib/langchain/utils/createSchemaParser.ts
+++ b/src/lib/langchain/utils/createSchemaParser.ts
@@ -3,7 +3,6 @@ import { z } from 'zod'
 import { handleLangChainError } from '../errorHandler'
 import { LangChainExecutionError } from '../errors'
 import { validateRequired } from '../validation'
-import { getLlm } from './getLlm'
 
 export interface SchemaParserOptions {
   maxRetries?: number
@@ -11,22 +10,18 @@ export interface SchemaParserOptions {
 }
 
 /**
- * Creates a StructuredOutputParser for schema-based generation
+ * Creates a StructuredOutputParser for schema-based generation.
+ *
  * @param schema - Zod schema for the expected output structure
- * @param llm - LLM instance (kept for API compatibility)
  * @param options - Configuration options
  * @returns StructuredOutputParser configured with the provided schema
  * @throws LangChainExecutionError if parser creation fails
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function createSchemaParser(
   schema: z.ZodType,
-  llm: ReturnType<typeof getLlm>,
   options: SchemaParserOptions = {}
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): any {
+): StructuredOutputParser<z.ZodType> {
   validateRequired(schema, 'schema', 'createSchemaParser')
-  validateRequired(llm, 'llm', 'createSchemaParser')
   validateRequired(options, 'options', 'createSchemaParser')
 
   if (typeof schema.parse !== 'function') {
@@ -54,12 +49,12 @@ export function createSchemaParser(
   }
 
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return StructuredOutputParser.fromZodSchema(schema as any)
+    // `as never`: @langchain/core bundles its own zod copy, so the project's
+    // `z.ZodType` isn't structurally identical to the one fromZodSchema expects.
+    return StructuredOutputParser.fromZodSchema(schema as never)
   } catch (error) {
     handleLangChainError(error, 'createSchemaParser: Failed to create schema parser', {
       schemaName: schema.constructor.name,
-      llmType: llm.constructor.name,
       hasRetryTemplate: !!retryTemplate,
     })
   }

--- a/src/lib/langchain/utils/executeChainWithSchema.ts
+++ b/src/lib/langchain/utils/executeChainWithSchema.ts
@@ -49,7 +49,7 @@ export async function executeChainWithSchema<T>(
   } = options
   
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const parser: any = createSchemaParser(schema, llm, parserOptions)
+  const parser: any = createSchemaParser(schema, parserOptions)
   let attempt = 0
 
   const operation = async (): Promise<T> => {


### PR DESCRIPTION
Fixes #1244.

`createSchemaParser`'s `llm` parameter was dead — `StructuredOutputParser.fromZodSchema` builds the parser from the zod schema alone; `llm` was only passed to a `validateRequired` guard and an error-context string. The return type was also `any`.

## Changes
- Remove the `llm` parameter (and the now-unused `getLlm` import / `validateRequired(llm)` guard).
- Tighten the return type `any` → `StructuredOutputParser<z.ZodType>` (the input keeps a localized `as never` cast for the @langchain/core-bundled-zod mismatch, documented inline).
- Update all 5 call sites (`executeChainWithSchema`, `generateCommitDraft`, `recap`/`changelog`/`review` handlers) to drop the argument.

## Validation
`eslint` (0 errors), `tsc --noEmit` clean, `jest` 13 suites / 161 tests across the affected areas, full `yarn build` green.