### PR TITLE
refactor(langchain): unify the transient is-retryable-error notion

### DIFF
--- a/src/lib/langchain/chains/summarize/index.ts
+++ b/src/lib/langchain/chains/summarize/index.ts
@@ -8,6 +8,7 @@ import { RecursiveCharacterTextSplitter } from '@langchain/textsplitters'
 import { Logger } from '../../../utils/logger'
 import { TokenCounter } from '../../../utils/tokenizer'
 import { LlmCallMetadata, logLlmCall } from '../../utils/observability'
+import { isRetryableError } from '../../errorHandler'
 
 export type SummarizeContext = {
   textSplitter: RecursiveCharacterTextSplitter
@@ -37,20 +38,8 @@ const BACKOFF_RETRIES = 3
 const BACKOFF_BASE_MS = 1000
 const BACKOFF_CAP_MS = 5000
 
-function isRetryableError(error: unknown): boolean {
-  if (!error || typeof error !== 'object') return false
-  const err = error as { status?: number; code?: string | number; message?: string }
-  if (err.status === 429 || err.status === 503 || err.status === 502 || err.status === 504) {
-    return true
-  }
-  if (err.code === 429 || err.code === 'rate_limit_exceeded' || err.code === 'ECONNRESET' || err.code === 'ETIMEDOUT') {
-    return true
-  }
-  if (typeof err.message === 'string' && /(rate.?limit|429|too many requests|timeout|temporarily unavailable)/i.test(err.message)) {
-    return true
-  }
-  return false
-}
+// Retryability uses the shared transient-error predicate (errorHandler), so the
+// summarize backoff and the rest of the codebase agree on what's retryable.
 
 async function invokeWithBackoff(
   chain: SummarizeContext['chain'],

--- a/src/lib/langchain/errorHandler.test.ts
+++ b/src/lib/langchain/errorHandler.test.ts
@@ -1,4 +1,4 @@
-import { isNetworkError, handleLangChainError } from './errorHandler'
+import { isNetworkError, isRetryableError, handleLangChainError } from './errorHandler'
 import { LangChainNetworkError, LangChainExecutionError } from './errors'
 
 describe('isNetworkError', () => {
@@ -52,6 +52,44 @@ describe('isNetworkError', () => {
   it('should be case-insensitive', () => {
     const error = new Error('FETCH FAILED')
     expect(isNetworkError(error)).toBe(true)
+  })
+})
+
+describe('isRetryableError (#1242 — shared transient predicate)', () => {
+  it('treats connection failures (network errors) as retryable', () => {
+    expect(isRetryableError(new Error('fetch failed'))).toBe(true)
+    expect(isRetryableError(new Error('connect ECONNREFUSED 127.0.0.1:11434'))).toBe(true)
+  })
+
+  it('retries transient HTTP statuses', () => {
+    for (const status of [429, 502, 503, 504]) {
+      expect(isRetryableError({ status })).toBe(true)
+    }
+    expect(isRetryableError({ status: 400 })).toBe(false)
+    expect(isRetryableError({ status: 404 })).toBe(false)
+  })
+
+  it('retries rate-limit / timeout error codes', () => {
+    expect(isRetryableError({ code: 429 })).toBe(true)
+    expect(isRetryableError({ code: 'rate_limit_exceeded' })).toBe(true)
+    expect(isRetryableError({ code: 'ECONNRESET' })).toBe(true)
+    expect(isRetryableError({ code: 'ETIMEDOUT' })).toBe(true)
+    expect(isRetryableError({ code: 'EPERM' })).toBe(false)
+  })
+
+  it('retries on transient message signals (case-insensitive)', () => {
+    expect(isRetryableError({ message: 'Rate limit exceeded' })).toBe(true)
+    expect(isRetryableError({ message: '429 Too Many Requests' })).toBe(true)
+    expect(isRetryableError({ message: 'Service temporarily unavailable' })).toBe(true)
+    expect(isRetryableError({ message: 'request timeout' })).toBe(true)
+    expect(isRetryableError({ message: 'Invalid JSON' })).toBe(false)
+  })
+
+  it('returns false for non-transient / non-object inputs', () => {
+    expect(isRetryableError(new Error('Validation failed'))).toBe(false)
+    expect(isRetryableError(null)).toBe(false)
+    expect(isRetryableError(undefined)).toBe(false)
+    expect(isRetryableError('boom')).toBe(false)
   })
 })
 

--- a/src/lib/langchain/errorHandler.ts
+++ b/src/lib/langchain/errorHandler.ts
@@ -41,6 +41,52 @@ export function isNetworkError(error: unknown): boolean {
   )
 }
 
+/** HTTP statuses worth retrying with backoff (rate limit + transient 5xx). */
+const RETRYABLE_HTTP_STATUS = new Set([429, 502, 503, 504])
+
+/** Substrings that signal a transient, retryable provider error. */
+const TRANSIENT_ERROR_PATTERNS = [
+  'rate limit',
+  'rate-limit',
+  'ratelimit',
+  '429',
+  'too many requests',
+  'timeout',
+  'temporarily unavailable',
+]
+
+/**
+ * The single shared notion of a *retryable* (transient) error: a connection
+ * failure (see {@link isNetworkError}) OR a transient HTTP status / rate-limit /
+ * timeout signal from a provider. Callers that back off and retry (e.g. the
+ * summarize chain) should use this rather than re-deriving their own predicate.
+ *
+ * Deliberately distinct from `utils/retry`'s `defaultShouldRetry`, which is
+ * broader: that one retries *any* non-permanent error (anything that isn't a
+ * validation / configuration / authentication failure) so schema-output retries
+ * can re-roll on e.g. unparseable model output. Transient ⊂ defaultShouldRetry.
+ */
+export function isRetryableError(error: unknown): boolean {
+  if (isNetworkError(error)) return true
+  if (!error || typeof error !== 'object') return false
+
+  const err = error as { status?: number; code?: string | number; message?: string }
+  if (typeof err.status === 'number' && RETRYABLE_HTTP_STATUS.has(err.status)) return true
+  if (
+    err.code === 429 ||
+    err.code === 'rate_limit_exceeded' ||
+    err.code === 'ECONNRESET' ||
+    err.code === 'ETIMEDOUT'
+  ) {
+    return true
+  }
+  if (typeof err.message === 'string') {
+    const message = err.message.toLowerCase()
+    if (TRANSIENT_ERROR_PATTERNS.some((pattern) => message.includes(pattern))) return true
+  }
+  return false
+}
+
 /**
  * Wraps errors with additional context and converts them to LangChain errors
  */

--- a/src/lib/utils/retry.ts
+++ b/src/lib/utils/retry.ts
@@ -17,7 +17,13 @@ export interface RetryOptions {
 }
 
 /**
- * Default retry predicate - retries on non-validation errors
+ * Default retry predicate — retries any *non-permanent* error: everything
+ * except validation / configuration / authentication failures. This is
+ * intentionally broader than `errorHandler.isRetryableError` (the shared
+ * *transient* predicate): generic retries here re-roll on e.g. unparseable
+ * schema output, not just network/rate-limit blips. Transient ⊂ this set.
+ * Callers that only want to retry transient errors should pass
+ * `shouldRetry: isRetryableError` explicitly.
  */
 function defaultShouldRetry(error: Error): boolean {
   // Don't retry validation errors or configuration errors


### PR DESCRIPTION
Fixes #1242.

Three divergent retryable-error checks existed:
- `errorHandler.isNetworkError` — connection-failure string patterns
- `summarize`'s local `isRetryableError` — 429/502/503/504 + rate-limit/timeout code/message
- `utils/retry.defaultShouldRetry` — broad deny-list (retry unless validation/config/auth)

## Change
- Add one shared **`isRetryableError`** in `errorHandler` = network failure (`isNetworkError`) ∪ transient HTTP status (429/502/503/504) ∪ rate-limit/timeout code/message. It's the single canonical *transient* predicate.
- `summarize` now imports it (drops its private copy). Behavior is the same set **plus** connection blips (`ECONNREFUSED`/`fetch failed`), which are exactly what backoff should retry — a small improvement, not a regression.
- `retry.defaultShouldRetry` is **kept** (it must stay broader so schema-output retries re-roll on unparseable model output) and now documents the relationship: transient ⊂ defaultShouldRetry. Callers wanting transient-only retries can pass `shouldRetry: isRetryableError`.

## Validation
`eslint` (0 errors), `tsc --noEmit` clean, `jest` errorHandler + summarize suites (30 tests, incl. new `isRetryableError` cases), full `yarn build` green.