### PR TITLE
feat(tree-sitter): mirror fallback for grammar downloads

### DIFF
--- a/src/lib/parsers/default/__tree_sitter__/download.test.ts
+++ b/src/lib/parsers/default/__tree_sitter__/download.test.ts
@@ -7,7 +7,7 @@ import { join } from 'node:path'
 // BEFORE the cache module is imported so its first read picks it up.
 process.env.COCO_CACHE_DIR = mkdtempSync(join(tmpdir(), 'coco-cache-download-test-'))
 
-import { downloadTreeSitterParser, formatDownloadOutcome } from './download'
+import { downloadTreeSitterParser, formatDownloadOutcome, treeSitterMirrorUrls } from './download'
 import { getCachedWasmPath, getTreeSitterCacheDir } from './cache'
 import { TREE_SITTER_MANIFEST } from './manifest'
 
@@ -105,6 +105,63 @@ describe('downloadTreeSitterParser', () => {
     if (outcome.ok) throw new Error('expected failure')
     if (outcome.reason !== 'network') throw new Error('expected network reason')
     expect(outcome.message).toBe('ECONNREFUSED')
+  })
+
+  it('falls back to a mirror when the primary CDN fails (#1247)', async () => {
+    const tried: string[] = []
+    const fakeFetch: typeof globalThis.fetch = async (input) => {
+      const url = String(input)
+      tried.push(url)
+      // jsdelivr (primary) is down; a mirror serves the bytes.
+      if (url.startsWith('https://cdn.jsdelivr.net/')) {
+        throw new Error('ENOTFOUND cdn.jsdelivr.net')
+      }
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        arrayBuffer: async () => PY_BYTES.buffer,
+      } as unknown as Response
+    }
+
+    const outcome = await downloadTreeSitterParser('python', { fetchImpl: fakeFetch })
+    expect(outcome.ok).toBe(true)
+    // primary attempted first, then a mirror
+    expect(tried[0]).toContain('cdn.jsdelivr.net')
+    expect(tried.length).toBeGreaterThanOrEqual(2)
+    expect(tried[1]).toMatch(/fastly\.jsdelivr\.net|unpkg\.com/)
+  })
+
+  it('tries every mirror before giving up, surfacing the last failure', async () => {
+    const tried: string[] = []
+    const fakeFetch: typeof globalThis.fetch = async (input) => {
+      tried.push(String(input))
+      throw new Error('ECONNREFUSED')
+    }
+
+    const outcome = await downloadTreeSitterParser('python', { fetchImpl: fakeFetch })
+    expect(outcome.ok).toBe(false)
+    if (outcome.ok || outcome.reason !== 'network') throw new Error('expected network failure')
+    // all three sources attempted
+    expect(tried).toHaveLength(3)
+  })
+})
+
+describe('treeSitterMirrorUrls', () => {
+  it('derives Fastly + unpkg mirrors from a jsdelivr npm URL', () => {
+    const urls = treeSitterMirrorUrls(
+      'https://cdn.jsdelivr.net/npm/tree-sitter-python@0.23.6/tree-sitter-python.wasm',
+    )
+    expect(urls).toEqual([
+      'https://cdn.jsdelivr.net/npm/tree-sitter-python@0.23.6/tree-sitter-python.wasm',
+      'https://fastly.jsdelivr.net/npm/tree-sitter-python@0.23.6/tree-sitter-python.wasm',
+      'https://unpkg.com/tree-sitter-python@0.23.6/tree-sitter-python.wasm',
+    ])
+  })
+
+  it('returns just the original for a non-jsdelivr URL', () => {
+    const urls = treeSitterMirrorUrls('https://example.com/custom.wasm')
+    expect(urls).toEqual(['https://example.com/custom.wasm'])
   })
 })
 

--- a/src/lib/parsers/default/__tree_sitter__/download.ts
+++ b/src/lib/parsers/default/__tree_sitter__/download.ts
@@ -3,7 +3,9 @@
  *
  * Owns the contract:
  *
- *   1. Fetch the manifest-pinned `.wasm` from the CDN URL
+ *   1. Fetch the manifest-pinned `.wasm` from the CDN URL, falling back
+ *      through mirror CDNs (jsdelivr → jsdelivr-Fastly → unpkg) if a
+ *      source is unreachable (#1247)
  *   2. Compute SHA-256 over the bytes
  *   3. Compare against the manifest-pinned hash; refuse to write
  *      on mismatch
@@ -49,6 +51,23 @@ export type DownloadOutcome =
  * The orchestrator handles `ok: false` cases by surrendering to
  * the regex fallback and (optionally) logging.
  */
+/**
+ * Mirror chain for a manifest `.wasm` URL. The manifest pins jsdelivr's
+ * canonical npm path; the same file is served byte-for-byte by jsdelivr's
+ * Fastly edge and by unpkg, so if one CDN is down or blocked we fall through
+ * to the next. SHA-256 verification in {@link downloadTreeSitterParser} guards
+ * integrity regardless of which mirror answered, so adding sources is safe.
+ */
+export function treeSitterMirrorUrls(wasmUrl: string): string[] {
+  const urls = [wasmUrl]
+  const npmPath = wasmUrl.match(/^https:\/\/cdn\.jsdelivr\.net\/npm\/(.+)$/)?.[1]
+  if (npmPath) {
+    urls.push(`https://fastly.jsdelivr.net/npm/${npmPath}`)
+    urls.push(`https://unpkg.com/${npmPath}`)
+  }
+  return urls
+}
+
 export async function downloadTreeSitterParser(
   language: LazyTreeSitterLanguageId,
   options?: { fetchImpl?: typeof globalThis.fetch },
@@ -56,39 +75,51 @@ export async function downloadTreeSitterParser(
   const entry: TreeSitterManifestEntry = TREE_SITTER_MANIFEST[language]
   const fetchImpl = options?.fetchImpl || globalThis.fetch
 
-  let body: ArrayBuffer
-  try {
-    const response = await fetchImpl(entry.wasmUrl)
-    if (!response.ok) {
-      return { ok: false, reason: 'network', message: `HTTP ${response.status} ${response.statusText}` }
+  let lastFailure: DownloadOutcome = {
+    ok: false,
+    reason: 'network',
+    message: 'no download URLs available',
+  }
+
+  // Try each mirror in order; advance to the next on a network failure, a
+  // non-2xx response, or a SHA mismatch (a mirror serving unexpected bytes).
+  for (const url of treeSitterMirrorUrls(entry.wasmUrl)) {
+    let body: ArrayBuffer
+    try {
+      const response = await fetchImpl(url)
+      if (!response.ok) {
+        lastFailure = { ok: false, reason: 'network', message: `HTTP ${response.status} ${response.statusText}` }
+        continue
+      }
+      body = await response.arrayBuffer()
+    } catch (error) {
+      lastFailure = { ok: false, reason: 'network', message: (error as Error).message }
+      continue
     }
-    body = await response.arrayBuffer()
-  } catch (error) {
-    return { ok: false, reason: 'network', message: (error as Error).message }
-  }
 
-  const bytes = new Uint8Array(body)
-  const actualHash = createHash('sha256').update(bytes).digest('hex')
-  if (actualHash !== entry.sha256) {
-    return {
-      ok: false,
-      reason: 'sha-mismatch',
-      expected: entry.sha256,
-      actual: actualHash,
+    const bytes = new Uint8Array(body)
+    const actualHash = createHash('sha256').update(bytes).digest('hex')
+    if (actualHash !== entry.sha256) {
+      lastFailure = { ok: false, reason: 'sha-mismatch', expected: entry.sha256, actual: actualHash }
+      continue
     }
+
+    const cacheDir = ensureTreeSitterCacheDir()
+    const finalPath = getCachedWasmPath(language)
+    const tempPath = join(cacheDir, `tree-sitter-${language}.wasm.tmp-${process.pid}-${Date.now()}`)
+    try {
+      writeFileSync(tempPath, bytes)
+      renameSync(tempPath, finalPath)
+    } catch (error) {
+      // A write failure is local, not mirror-specific — retrying other
+      // sources won't help, so surface it immediately.
+      return { ok: false, reason: 'write-failed', message: (error as Error).message }
+    }
+
+    return { ok: true, path: finalPath, bytes: bytes.byteLength }
   }
 
-  const cacheDir = ensureTreeSitterCacheDir()
-  const finalPath = getCachedWasmPath(language)
-  const tempPath = join(cacheDir, `tree-sitter-${language}.wasm.tmp-${process.pid}-${Date.now()}`)
-  try {
-    writeFileSync(tempPath, bytes)
-    renameSync(tempPath, finalPath)
-  } catch (error) {
-    return { ok: false, reason: 'write-failed', message: (error as Error).message }
-  }
-
-  return { ok: true, path: finalPath, bytes: bytes.byteLength }
+  return lastFailure
 }
 
 /**

--- a/src/lib/parsers/default/__tree_sitter__/manifest.ts
+++ b/src/lib/parsers/default/__tree_sitter__/manifest.ts
@@ -13,8 +13,9 @@
  * (~450 KB for Python) from a globally-distributed CDN, without
  * pulling the full npm tarball (which would be 10× larger for the
  * same content). The URL pattern is stable across versions; only
- * the version segment changes. Mirrors (unpkg, fastly) are options
- * if jsdelivr proves unreliable in practice.
+ * the version segment changes. If jsdelivr is unreachable, the
+ * download module falls back to its Fastly edge and then unpkg —
+ * the same byte-for-byte file (see `treeSitterMirrorUrls`).
  *
  * SHA-256s are computed at manifest-edit time by downloading the
  * file once and running `shasum -a 256`. The download module


### PR DESCRIPTION
Fixes #1247.

Lazy tree-sitter grammar `.wasm` downloads hit **only** jsdelivr — if that CDN was down or network-blocked, the download failed and coco silently fell back to the regex parser (degraded syntax features).

## Change
- Add **`treeSitterMirrorUrls(wasmUrl)`** deriving a mirror chain from the manifest's jsdelivr URL: **jsdelivr → `fastly.jsdelivr.net` → `unpkg.com`** (the same npm file, byte-for-byte).
- `downloadTreeSitterParser` now loops the chain, advancing on a network failure, non-2xx, or SHA mismatch (a mirror serving unexpected bytes). It returns the last failure if every source is exhausted.
- **SHA-256 verification is unchanged** and guards integrity for *every* mirror, so adding sources is safe. A local write failure short-circuits (mirrors won't help).

## Tests
+5 cases: primary-fails-mirror-succeeds, all-mirrors-tried-then-fail, and `treeSitterMirrorUrls` derivation (jsdelivr + non-jsdelivr). Existing download tests unchanged (failure-message formats preserved).

## Validation
`eslint` (0 errors), `tsc --noEmit` clean, `jest` download suite (11 tests), full `yarn build` green.