### PR TITLE
feat(validation): per-provider model validity + shared deprecated map

### DIFF
--- a/src/commands/doctor/checks.ts
+++ b/src/commands/doctor/checks.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs'
 import { Config } from '../../lib/config/types'
 import { resolveDynamicModel } from '../../lib/langchain/utils/dynamicModels'
 import { DEFAULT_OLLAMA_ENDPOINT, getOllamaStatus } from '../../lib/langchain/utils/ollamaStatus'
+import { DEPRECATED_MODELS, detectProviderMismatch } from '../../lib/langchain/modelValidity'
+import { LLMProvider } from '../../lib/langchain/types'
 
 export type DiagnosticSeverity = 'error' | 'warn' | 'info'
 
@@ -10,21 +12,6 @@ export interface Diagnostic {
   message: string
   fix?: string
   autoFix?: (config: Record<string, unknown>) => void
-}
-
-/**
- * Deprecated or renamed model identifiers that should be updated.
- */
-const MODEL_UPGRADES: Record<string, string> = {
-  'gpt-4-turbo-preview': 'gpt-4o',
-  'gpt-4-0125-preview': 'gpt-4o',
-  'gpt-4-1106-preview': 'gpt-4o',
-  'gpt-3.5-turbo-0125': 'gpt-4o-mini',
-  'gpt-3.5-turbo-1106': 'gpt-4o-mini',
-  'gpt-3.5-turbo-16k': 'gpt-4o-mini',
-  'claude-3-opus-20240229': 'claude-sonnet-4-0',
-  'claude-3-sonnet-20240229': 'claude-3-5-sonnet-latest',
-  'claude-3-haiku-20240307': 'claude-3-5-haiku-latest',
 }
 
 export function runDiagnostics(config: Config): Diagnostic[] {
@@ -151,7 +138,20 @@ function checkModelCurrency(config: Config, diagnostics: Diagnostic[]) {
   if (!config.service?.model || config.service.model === 'dynamic') return
 
   const model = String(config.service.model)
-  const upgrade = MODEL_UPGRADES[model]
+  const provider = config.service.provider as LLMProvider
+
+  // Per-provider validity: flag a model that belongs to a different provider's
+  // namespace (e.g. a `claude-…` model configured under provider `openai`).
+  const mismatchOwner = detectProviderMismatch(model, provider)
+  if (mismatchOwner) {
+    diagnostics.push({
+      severity: 'error',
+      message: `Model "${model}" is a ${mismatchOwner} model, but service.provider is "${provider}".`,
+      fix: `Set service.model to a ${provider} model, or change service.provider to "${mismatchOwner}".`,
+    })
+  }
+
+  const upgrade = DEPRECATED_MODELS[model]
 
   if (upgrade) {
     diagnostics.push({

--- a/src/lib/langchain/modelValidity.test.ts
+++ b/src/lib/langchain/modelValidity.test.ts
@@ -1,0 +1,61 @@
+import {
+  detectProviderMismatch,
+  findModelOwner,
+  getDeprecatedReplacement,
+} from './modelValidity'
+
+describe('findModelOwner', () => {
+  it('resolves a model to its closed-namespace provider', () => {
+    expect(findModelOwner('gpt-4o')).toBe('openai')
+    expect(findModelOwner('claude-3-5-sonnet-latest')).toBe('anthropic')
+    expect(findModelOwner('gemini-2.5-pro')).toBe('gemini')
+    expect(findModelOwner('mistral-large-latest')).toBe('mistral')
+    expect(findModelOwner('anthropic.claude-3-5-sonnet-20241022-v2:0')).toBe('bedrock')
+  })
+
+  it('returns null for unrecognized / open-namespace models', () => {
+    expect(findModelOwner('llama3.1:8b')).toBeNull()
+    expect(findModelOwner('gpt-5-ultra-turbo')).toBeNull()
+    expect(findModelOwner('dynamic')).toBeNull()
+  })
+})
+
+describe('getDeprecatedReplacement', () => {
+  it('maps retired ids to a replacement', () => {
+    expect(getDeprecatedReplacement('gpt-4-turbo-preview')).toBe('gpt-4o')
+    expect(getDeprecatedReplacement('claude-3-opus-20240229')).toBe('claude-sonnet-4-0')
+  })
+
+  it('returns undefined for current models', () => {
+    expect(getDeprecatedReplacement('gpt-4o')).toBeUndefined()
+  })
+})
+
+describe('detectProviderMismatch', () => {
+  it('flags a model that belongs to a different provider', () => {
+    expect(detectProviderMismatch('claude-3-5-sonnet-latest', 'openai')).toBe('anthropic')
+    expect(detectProviderMismatch('gpt-4o', 'anthropic')).toBe('openai')
+    // a bedrock model under plain anthropic is a mismatch (owner: bedrock)
+    expect(detectProviderMismatch('anthropic.claude-3-5-sonnet-20241022-v2:0', 'anthropic')).toBe(
+      'bedrock',
+    )
+  })
+
+  it('accepts a correctly-matched model', () => {
+    expect(detectProviderMismatch('gpt-4o', 'openai')).toBeNull()
+    expect(detectProviderMismatch('claude-3-5-sonnet-latest', 'anthropic')).toBeNull()
+  })
+
+  it('treats azure as sharing the OpenAI namespace', () => {
+    expect(detectProviderMismatch('gpt-4o', 'azure')).toBeNull()
+  })
+
+  it('never gates the dynamic sentinel, ollama, or unrecognized models', () => {
+    expect(detectProviderMismatch('dynamic', 'openai')).toBeNull()
+    expect(detectProviderMismatch('llama3.1:8b', 'ollama')).toBeNull()
+    // a new/unlisted model for the right provider is NOT a definite mismatch
+    expect(detectProviderMismatch('gpt-5-ultra-turbo', 'openai')).toBeNull()
+    // even an openai model under ollama is left alone (open namespace)
+    expect(detectProviderMismatch('gpt-4o', 'ollama')).toBeNull()
+  })
+})

--- a/src/lib/langchain/modelValidity.ts
+++ b/src/lib/langchain/modelValidity.ts
@@ -1,0 +1,81 @@
+import {
+  ANTHROPIC_MODELS,
+  BEDROCK_MODELS,
+  GEMINI_MODELS,
+  MISTRAL_MODELS,
+  OPEN_AI_MODELS,
+} from './constants'
+import { LLMProvider } from './types'
+
+/**
+ * Shared model-validity knowledge: deprecated ids and per-provider namespaces.
+ *
+ * Single source of truth for both the runtime check (`validateModel`) and the
+ * `coco doctor` diagnostics, so the two never drift (#1243).
+ */
+
+/**
+ * Retired / superseded model ids → recommended replacement. `coco doctor`
+ * surfaces these as upgrade suggestions; kept here (rather than in the doctor
+ * command) so the runtime layer can reference the same list.
+ */
+export const DEPRECATED_MODELS: Record<string, string> = {
+  'gpt-4-turbo-preview': 'gpt-4o',
+  'gpt-4-0125-preview': 'gpt-4o',
+  'gpt-4-1106-preview': 'gpt-4o',
+  'gpt-3.5-turbo-0125': 'gpt-4o-mini',
+  'gpt-3.5-turbo-1106': 'gpt-4o-mini',
+  'gpt-3.5-turbo-16k': 'gpt-4o-mini',
+  'claude-3-opus-20240229': 'claude-sonnet-4-0',
+  'claude-3-sonnet-20240229': 'claude-3-5-sonnet-latest',
+  'claude-3-haiku-20240307': 'claude-3-5-haiku-latest',
+}
+
+/**
+ * Providers with a fixed, known model namespace we can validate against.
+ * Excludes `ollama` (arbitrary local model names) and `azure` (custom
+ * deployment names — folded into the OpenAI namespace via {@link namespaceFamily}).
+ */
+const CLOSED_PROVIDER_MODELS: Partial<Record<LLMProvider, readonly string[]>> = {
+  openai: OPEN_AI_MODELS as readonly string[],
+  anthropic: ANTHROPIC_MODELS as readonly string[],
+  gemini: GEMINI_MODELS as readonly string[],
+  mistral: MISTRAL_MODELS as readonly string[],
+  bedrock: BEDROCK_MODELS as readonly string[],
+}
+
+/** OpenAI and Azure share OpenAI's model ids in coco's config. */
+function namespaceFamily(provider: LLMProvider): LLMProvider {
+  return provider === 'azure' ? 'openai' : provider
+}
+
+/** Recommended replacement for a deprecated model id, or undefined. */
+export function getDeprecatedReplacement(model: string): string | undefined {
+  return DEPRECATED_MODELS[model]
+}
+
+/** The closed-namespace provider that owns this exact model id, or null. */
+export function findModelOwner(model: string): LLMProvider | null {
+  for (const [provider, models] of Object.entries(CLOSED_PROVIDER_MODELS)) {
+    if (models.includes(model)) return provider as LLMProvider
+  }
+  return null
+}
+
+/**
+ * Detect a *definite* cross-provider mismatch: `model` is exactly a known model
+ * of a different closed-namespace provider. Returns the owning provider, or
+ * null when there's no conflict — i.e. for the `dynamic` sentinel, open-namespace
+ * providers (ollama), unrecognized / new model ids, or a correct match
+ * (azure↔openai counts as a match). Exact-membership only, so new or custom
+ * models for the right provider never trip it.
+ */
+export function detectProviderMismatch(model: string, provider: LLMProvider): LLMProvider | null {
+  if (model === 'dynamic') return null
+  if (provider === 'ollama') return null
+
+  const owner = findModelOwner(model)
+  if (!owner) return null
+
+  return namespaceFamily(owner) === namespaceFamily(provider) ? null : owner
+}

--- a/src/lib/langchain/validation.test.ts
+++ b/src/lib/langchain/validation.test.ts
@@ -1,0 +1,31 @@
+import { validateModel } from './validation'
+import { LangChainValidationError } from './errors'
+
+describe('validateModel (#1243 — per-provider validity)', () => {
+  it('accepts a model that matches its provider', () => {
+    expect(() => validateModel('gpt-4o', 'openai')).not.toThrow()
+    expect(() => validateModel('claude-3-5-sonnet-latest', 'anthropic')).not.toThrow()
+  })
+
+  it('accepts the dynamic sentinel and open-namespace providers', () => {
+    expect(() => validateModel('dynamic', 'openai')).not.toThrow()
+    expect(() => validateModel('llama3.1:8b', 'ollama')).not.toThrow()
+    expect(() => validateModel('gpt-4o', 'azure')).not.toThrow() // azure shares openai ids
+  })
+
+  it('accepts unrecognized / new models for the right provider', () => {
+    expect(() => validateModel('gpt-5-ultra-turbo', 'openai')).not.toThrow()
+  })
+
+  it('throws on a definite cross-provider mismatch', () => {
+    expect(() => validateModel('claude-3-5-sonnet-latest', 'openai')).toThrow(
+      LangChainValidationError,
+    )
+    expect(() => validateModel('gpt-4o', 'anthropic')).toThrow(/is a openai model, not a anthropic/)
+  })
+
+  it('still rejects empty / non-string models', () => {
+    expect(() => validateModel('', 'openai')).toThrow(LangChainValidationError)
+    expect(() => validateModel('   ', 'openai')).toThrow(/non-empty string/)
+  })
+})

--- a/src/lib/langchain/validation.ts
+++ b/src/lib/langchain/validation.ts
@@ -1,6 +1,7 @@
 import { LangChainValidationError, LangChainConfigurationError } from './errors'
 import { LLMProvider, LLMModel, LLMService } from './types'
 import { LLM_PROVIDER_IDS } from './providers/registry'
+import { detectProviderMismatch } from './modelValidity'
 
 /**
  * Validates that a required parameter is not null or undefined
@@ -87,9 +88,20 @@ export function validateModel(
       { model, provider, functionName }
     )
   }
-  
-  // Additional provider-specific validation could be added here
-  // For now, we trust the TypeScript types
+
+  // Per-provider validity: fail fast on a *definite* cross-provider mismatch
+  // (the model is exactly a known model of a different provider, e.g.
+  // `claude-…` under provider `openai`). This would otherwise surface as a
+  // cryptic API error mid-run. Exact-membership only — unrecognized/new models
+  // and open-namespace providers (ollama) pass untouched.
+  const mismatchOwner = detectProviderMismatch(model, provider)
+  if (mismatchOwner) {
+    throw new LangChainValidationError(
+      `${functionName ? `${functionName}: ` : ''}Model '${model}' is a ${mismatchOwner} model, not a ${provider} model. ` +
+        `Set service.model to a ${provider} model, or change service.provider to '${mismatchOwner}'.`,
+      { model, provider, owner: mismatchOwner, functionName }
+    )
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes #1243.

`validateModel` was effectively a no-op (only a non-empty-string check). This makes it useful **without false positives** — important now that there are 6+ providers with distinct model namespaces.

## Changes
- **New `lib/langchain/modelValidity.ts`** — single source of truth for:
  - `DEPRECATED_MODELS` (moved out of `doctor/checks.ts`)
  - per-provider closed namespaces (openai/anthropic/gemini/mistral/bedrock)
  - `detectProviderMismatch(model, provider)` — exact-membership only; azure folds into the OpenAI namespace; ollama, the `dynamic` sentinel, and unrecognized/new models are never gated.
- **`validateModel`** now throws on a *definite* cross-provider mismatch (e.g. `claude-3-5-sonnet-latest` configured under provider `openai`) with an actionable message, instead of letting it fail later as a cryptic provider API error.
- **`coco doctor`** reuses the shared deprecated map (dedupes its private `MODEL_UPGRADES`) and gains the same cross-provider check as an `error` diagnostic.

### Why conservative (exact-membership)
A model only trips the check if it's *exactly* a known model of a different provider. New/unlisted models for the right provider, Ollama's arbitrary local names, Azure deployment names, and `dynamic` all pass untouched — so this can't break valid configs.

## Tests
`modelValidity.test.ts` (owner resolution, deprecated map, mismatch matrix incl. azure/ollama/dynamic/new-model edge cases) + `validation.test.ts` (validateModel accept/throw cases).

## Validation
`eslint` (0 errors), `tsc --noEmit` clean, wide `jest` sweep — **28 suites / 367 tests** across langchain + all getLlm-using commands — green, full `yarn build` green.