### PR TITLE
refactor(runtime): extract commit-detail hydration from app.ts (#1237)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -202,6 +202,7 @@ import type { LogArgv } from '../../commands/log/config'
 // LogInkState filter-mode shape.
 import {matchesPromotedFilter} from '../runtime/promotedFilter'
 import {useFilteredLists} from './hooks/buildFilteredLists'
+import {useCommitDetailHydration, useCommitDetailState} from './hooks/useCommitDetailHydration'
 import {useContextHydration} from './hooks/useContextHydration'
 import {useBlameLoadingState, useDetailHydration} from './hooks/useDetailHydration'
 import {useCommitFilePreviewHydration, useCompareDiffHydration, useStashDiffHydration, useWorktreeDiffHydration, useWorktreeHunksHydration} from './hooks/useDiffHydration'
@@ -501,8 +502,12 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // closure, so each effect run resolves against the right binding.
   // No additional depth tagging is needed.
   const activeRepoRoot = useActiveRepoRoot(React, git)
-  const [detail, setDetail] = React.useState<GitCommitDetail | undefined>(undefined)
-  const [detailLoading, setDetailLoading] = React.useState(false)
+  // Commit-detail hydration state, lifted into `useCommitDetailState`
+  // (app.ts decomposition item 1a / #1237). The `useState` pair stays in this
+  // exact slot; the loader effect that toggles it is issued ~600 lines below
+  // by `useCommitDetailHydration`, in its original position — a two-hook
+  // split to preserve React hook ordering. See that module's header.
+  const {detail, setDetail, detailLoading, setDetailLoading} = useCommitDetailState(React)
   const [filePreview, setFilePreview] = React.useState<GitCommitFilePreview | undefined>(undefined)
   const [filePreviewLoading, setFilePreviewLoading] = React.useState(false)
   const [worktreeDiff, setWorktreeDiff] = React.useState<WorktreeFileDiff | undefined>(undefined)
@@ -1101,30 +1106,17 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     setBlameLoading,
   })
 
-  React.useEffect(() => {
-    let active = true
-
-    async function loadDetail(): Promise<void> {
-      if (!selected) {
-        setDetail(undefined)
-        return
-      }
-
-      setDetailLoading(true)
-      const nextDetail = await safe(getCommitDetail(git, selected.hash))
-
-      if (active) {
-        setDetail(nextDetail)
-        setDetailLoading(false)
-      }
-    }
-
-    void loadDetail()
-
-    return () => {
-      active = false
-    }
-  }, [git, selected?.hash])
+  // Commit-detail loader, lifted verbatim into `useCommitDetailHydration`
+  // (app.ts decomposition item 1a / #1237) — guard, `active` cancellation
+  // flag, `safe()` wrapper, `detailLoading` toggles, and `[git, selected?.hash]`
+  // dependency array carry over byte-for-byte. Issued here, in its original
+  // slot; the `useState` it toggles is owned by `useCommitDetailState` above.
+  useCommitDetailHydration(React, {
+    git,
+    selected,
+    setDetail,
+    setDetailLoading,
+  })
 
   // #806 follow-up — auto-jump the history view to whichever branch /
   // tag / stash the user is cursoring (cluster N). Lifted verbatim into

--- a/src/workstation/runtime/hooks/useCommitDetailHydration.test.ts
+++ b/src/workstation/runtime/hooks/useCommitDetailHydration.test.ts
@@ -1,0 +1,153 @@
+import { getCommitDetail } from '../../../commands/log/data'
+import {
+  useCommitDetailHydration,
+  useCommitDetailState,
+} from './useCommitDetailHydration'
+
+/**
+ * Behavioral tests for the commit-detail hydration cluster (app.ts
+ * decomposition item 1a / #1237). The two hooks are a verbatim lift of the
+ * inline `useState` pair + loader effect; these tests drive them through a
+ * minimal fake-React harness (the runtime injects `React`) and a mocked data
+ * module to prove the contract carried over byte-for-byte:
+ *   - no commit cursored → reset detail to `undefined`, never fetch;
+ *   - commit cursored → toggle loading, fetch, then store the detail;
+ *   - cancellation via the `active` flag suppresses a stale write.
+ */
+
+jest.mock('../../../commands/log/data', () => ({
+  getCommitDetail: jest.fn(),
+}))
+
+const getCommitDetailMock = getCommitDetail as jest.MockedFunction<
+  typeof getCommitDetail
+>
+
+/** Flush pending microtasks so the effect's awaited `loadDetail` settles. */
+const flush = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0))
+
+type EffectFn = () => void | (() => void)
+
+/**
+ * Records `useEffect` callbacks so the test can invoke them explicitly,
+ * mirroring how React would fire them after commit. The hydration hook only
+ * reaches for `useEffect`; the state hook only reaches for `useState`.
+ */
+function makeReact(): {
+  React: typeof import('react')
+  runEffect: () => void | (() => void)
+} {
+  const effects: EffectFn[] = []
+  const React = {
+    useEffect: (fn: EffectFn) => {
+      effects.push(fn)
+    },
+  } as unknown as typeof import('react')
+  return {
+    React,
+    runEffect: () => {
+      if (effects.length !== 1) {
+        throw new Error(`expected exactly one effect, got ${effects.length}`)
+      }
+      return effects[0]()
+    },
+  }
+}
+
+const git = {} as Parameters<typeof useCommitDetailHydration>[1]['git']
+
+beforeEach(() => {
+  getCommitDetailMock.mockReset()
+})
+
+describe('useCommitDetailState', () => {
+  it('seeds detail undefined and detailLoading false, exposing both setters', () => {
+    const React = {
+      useState: (init: unknown) => {
+        const value = typeof init === 'function' ? (init as () => unknown)() : init
+        return [value, jest.fn()]
+      },
+    } as unknown as typeof import('react')
+
+    const result = useCommitDetailState(React)
+
+    expect(result.detail).toBeUndefined()
+    expect(result.detailLoading).toBe(false)
+    expect(typeof result.setDetail).toBe('function')
+    expect(typeof result.setDetailLoading).toBe('function')
+  })
+})
+
+describe('useCommitDetailHydration', () => {
+  it('resets detail to undefined and never fetches when no commit is cursored', async () => {
+    const setDetail = jest.fn()
+    const setDetailLoading = jest.fn()
+    const { React, runEffect } = makeReact()
+
+    useCommitDetailHydration(React, {
+      git,
+      selected: undefined,
+      setDetail,
+      setDetailLoading,
+    })
+    runEffect()
+    await flush()
+
+    expect(setDetail).toHaveBeenCalledWith(undefined)
+    expect(setDetailLoading).not.toHaveBeenCalled()
+    expect(getCommitDetailMock).not.toHaveBeenCalled()
+  })
+
+  it('toggles loading, fetches the cursored commit, then stores the detail', async () => {
+    const detail = { hash: 'abc123', files: [] }
+    getCommitDetailMock.mockResolvedValue(detail as never)
+    const setDetail = jest.fn()
+    const setDetailLoading = jest.fn()
+    const { React, runEffect } = makeReact()
+
+    useCommitDetailHydration(React, {
+      git,
+      selected: { hash: 'abc123' } as never,
+      setDetail,
+      setDetailLoading,
+    })
+    runEffect()
+
+    // Loading flips true synchronously, before the await.
+    expect(setDetailLoading).toHaveBeenCalledWith(true)
+    await flush()
+
+    expect(getCommitDetailMock).toHaveBeenCalledWith(git, 'abc123')
+    expect(setDetail).toHaveBeenCalledWith(detail)
+    expect(setDetailLoading).toHaveBeenLastCalledWith(false)
+  })
+
+  it('suppresses a stale write when the effect is cleaned up before the fetch resolves', async () => {
+    let resolveDetail: (value: unknown) => void = () => {}
+    getCommitDetailMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveDetail = resolve
+      }) as never,
+    )
+    const setDetail = jest.fn()
+    const setDetailLoading = jest.fn()
+    const { React, runEffect } = makeReact()
+
+    useCommitDetailHydration(React, {
+      git,
+      selected: { hash: 'def456' } as never,
+      setDetail,
+      setDetailLoading,
+    })
+    const cleanup = runEffect() as () => void
+    cleanup()
+    resolveDetail({ hash: 'def456', files: [] })
+    await flush()
+
+    // active === false, so neither the detail nor the loading-false write lands.
+    expect(setDetail).not.toHaveBeenCalled()
+    expect(setDetailLoading).toHaveBeenCalledTimes(1)
+    expect(setDetailLoading).toHaveBeenCalledWith(true)
+  })
+})

--- a/src/workstation/runtime/hooks/useCommitDetailHydration.ts
+++ b/src/workstation/runtime/hooks/useCommitDetailHydration.ts
@@ -1,0 +1,132 @@
+/**
+ * Commit-detail hydration (extracted in the post-0.72 app.ts decomposition,
+ * item 1a / #1237).
+ *
+ * This module lifts the "load the cursored commit's full detail" cluster out
+ * of `app.ts`: the `detail` / `detailLoading` `useState` pair and the single
+ * effect that fetches `getCommitDetail(git, selected.hash)` into them once the
+ * cursor rests on a commit row. The loaded `detail` drives the inspector's
+ * file list (`selectedDetailFile`), the diff/file-preview surfaces, and the
+ * footer's loading chrome.
+ *
+ * The effect is a best-effort loader: the fetch is wrapped in `safe()` (a git
+ * error leaves `detail` undefined → the surface shows its "no detail" hint
+ * instead of crashing), guarded with an `active` flag flipped false in cleanup
+ * so a stale in-flight load can't clobber a newer selection, and toggles
+ * `detailLoading` around the await. It is reproduced **verbatim** — the guard,
+ * the `active` flag, the `safe()` wrapper, the `setDetailLoading` toggles, and
+ * the `[git, selected?.hash]` dependency array are byte-for-byte the same as
+ * the original `app.ts` effect. This is a behavior-preserving move, not a
+ * rewrite.
+ *
+ * CRITICAL — hook ordering. In `app.ts` the `detail` / `detailLoading`
+ * `useState` pair sits near the top of the hydration-state block (~L504),
+ * while the loader effect sits ~600 lines below (~L1104), separated by many
+ * intervening hooks (the bisect effects, the issue/PR list loaders,
+ * `useContextHydration`, `useDetailHydration`, …). React fires hooks in
+ * declaration order, so collapsing the `useState` and the effect into a single
+ * hook at one call site would reorder one of them relative to those
+ * intervening hooks — moving the `useState` down corrupts every state slot
+ * after it (catastrophic), and moving the effect up changes effect-execution
+ * order (which the render-snapshot suite does not catch). To preserve ordering
+ * exactly, this module exports *two* hooks, each called at the original
+ * position:
+ *
+ *   const { detail, setDetail, detailLoading, setDetailLoading } =
+ *     useCommitDetailState(React)                                   // ~L504
+ *   ...intervening hooks...
+ *   useCommitDetailHydration(React, { git, selected, setDetail, setDetailLoading }) // ~L1104
+ *
+ * Order correctness wins. `useCommitDetailState` issues only the two
+ * `useState`s (in their original slot); `useCommitDetailHydration` issues the
+ * effect (in its original slot) and is handed the setters so the loader
+ * toggles `detail` / `detailLoading` exactly as before. This mirrors the
+ * `useBlameLoadingState` + `useDetailHydration` split (PR 7).
+ *
+ * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
+ * convention) because the workstation never statically imports React.
+ */
+
+import type * as ReactTypes from 'react'
+import type { SimpleGit } from 'simple-git'
+import { GitCommitDetail, GitLogCommitRow, getCommitDetail } from '../../../commands/log/data'
+
+/**
+ * Best-effort promise unwrap, lifted verbatim from `app.ts`. Swallows the
+ * rejection so a git error leaves the detail surface on its "no detail" hint
+ * instead of crashing the workstation.
+ */
+async function safe<T>(promise: Promise<T>): Promise<T | undefined> {
+  try {
+    return await promise
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Issues only the `detail` / `detailLoading` `useState` pair, in its original
+ * `app.ts` position (top of the hydration-state block, ~600 lines above the
+ * loader effect). Returns the values (consumed by the inspector / footer) and
+ * the setters (threaded into {@link useCommitDetailHydration} so the loader
+ * effect can toggle them exactly as the inline code did).
+ */
+export function useCommitDetailState(React: typeof ReactTypes): {
+  detail: GitCommitDetail | undefined
+  setDetail: ReactTypes.Dispatch<ReactTypes.SetStateAction<GitCommitDetail | undefined>>
+  detailLoading: boolean
+  setDetailLoading: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
+} {
+  const [detail, setDetail] = React.useState<GitCommitDetail | undefined>(undefined)
+  const [detailLoading, setDetailLoading] = React.useState(false)
+  return { detail, setDetail, detailLoading, setDetailLoading }
+}
+
+export type UseCommitDetailHydrationDeps = {
+  /** The active frame's `git`. Drives the `getCommitDetail` fetch. */
+  git: SimpleGit
+  /** The cursored commit row (drives the `sha`), or `undefined`. */
+  selected: GitLogCommitRow | undefined
+  /** Writer for the loaded commit detail, from {@link useCommitDetailState}. */
+  setDetail: ReactTypes.Dispatch<ReactTypes.SetStateAction<GitCommitDetail | undefined>>
+  /** Loading-flag setter, from {@link useCommitDetailState}. */
+  setDetailLoading: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
+}
+
+/**
+ * Issues the commit-detail loader effect, in its original `app.ts` position.
+ * Reproduced verbatim — same `!selected` guard, same `active` cancellation
+ * flag, same `safe()` wrapper, same `setDetailLoading` toggles, same
+ * `[git, selected?.hash]` dependency array.
+ */
+export function useCommitDetailHydration(
+  React: typeof ReactTypes,
+  deps: UseCommitDetailHydrationDeps,
+): void {
+  const { git, selected, setDetail, setDetailLoading } = deps
+
+  React.useEffect(() => {
+    let active = true
+
+    async function loadDetail(): Promise<void> {
+      if (!selected) {
+        setDetail(undefined)
+        return
+      }
+
+      setDetailLoading(true)
+      const nextDetail = await safe(getCommitDetail(git, selected.hash))
+
+      if (active) {
+        setDetail(nextDetail)
+        setDetailLoading(false)
+      }
+    }
+
+    void loadDetail()
+
+    return () => {
+      active = false
+    }
+  }, [git, selected?.hash])
+}


### PR DESCRIPTION
## Item 1a — `app.ts` decomposition (#1237)

Lifts the `detail` / `detailLoading` hydration cluster out of `app.ts` into a new `useCommitDetailHydration` module. This is the one remaining hydration cluster whose loader effect was still inline (the other diff/detail loaders were extracted in the 0.72 series).

### Approach — position-preserving two-hook split
The `useState` pair (top of the hydration-state block) and its loader effect are ~600 lines apart, with `selected` declared in between. Collapsing them into one call site would reorder hooks. So, mirroring the established `useBlameLoadingState` + `useDetailHydration` precedent, the module exports **two** hooks, each called at the original position:

- **`useCommitDetailState(React)`** — issues the `detail` / `detailLoading` `useState` pair in its original slot; returns values + setters.
- **`useCommitDetailHydration(React, { git, selected, setDetail, setDetailLoading })`** — issues the loader effect in its original slot.

The effect is reproduced **verbatim** — same `!selected` guard, `active` cancellation flag, `safe()` wrapper, `detailLoading` toggles, and `[git, selected?.hash]` dependency array. **Nothing moves**, so there is no effect-reordering risk and the render-snapshot suite is fully sufficient to prove behavior preservation.

### Changes
- `app.ts`: bare `useState` pair → `useCommitDetailState(React)`; inline `loadDetail` effect → `useCommitDetailHydration(...)`. Net −8 LOC.
- New `hooks/useCommitDetailHydration.ts`.
- New `hooks/useCommitDetailHydration.test.ts` — behavioral tests for the guard (no fetch), load (toggle + fetch + store), and cancellation (stale-write suppression) paths.

### Validation
- `jest` (full): 282 suites / 3512 tests pass, 68 snapshots **no diffs**
- new hook test: 4/4
- `tsc --noEmit`: clean
- `eslint`: 0 errors
- `rollup -c`: builds `dist/`