### PR TITLE
refactor(runtime): own commit file-preview state in useDiffHydration (#1237)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -57,7 +57,7 @@ import {getBranchOverview} from '../../git/branchData'
 import {getLfsAttributeStatus} from '../../git/lfsAttributes'
 import {getSubmoduleOverview} from '../../git/submoduleData'
 import {getRemoteOverview} from '../../git/remoteData'
-import {GitCommitDetail, GitCommitFilePreview, LOG_INTERACTIVE_DEFAULT_LIMIT, buildToggleGraphArgs, getCommitDetail, getCommitRows, getLogRows} from '../../commands/log/data'
+import {GitCommitDetail, LOG_INTERACTIVE_DEFAULT_LIMIT, buildToggleGraphArgs, getCommitDetail, getCommitRows, getLogRows} from '../../commands/log/data'
 import {LogInkContextKey, LogInkContextStatus, createLogInkContextStatus, updateLogInkContextStatus} from '../chrome/context'
 import {hasSeenOnboarding, markOnboardingSeen} from '../chrome/onboarding'
 import {createLogInkTheme, type LogInkThemePreset} from '../chrome/theme'
@@ -205,7 +205,7 @@ import {useFilteredLists} from './hooks/buildFilteredLists'
 import {useCommitDetailHydration, useCommitDetailState} from './hooks/useCommitDetailHydration'
 import {useContextHydration} from './hooks/useContextHydration'
 import {useBlameLoadingState, useDetailHydration} from './hooks/useDetailHydration'
-import {useCommitFilePreviewHydration, useCompareDiffHydration, useStashDiffHydration, useWorktreeDiffHydration, useWorktreeHunksHydration} from './hooks/useDiffHydration'
+import {useCommitFilePreviewHydration, useCommitFilePreviewState, useCompareDiffHydration, useStashDiffHydration, useWorktreeDiffHydration, useWorktreeHunksHydration} from './hooks/useDiffHydration'
 import {useIdleTip} from './hooks/useIdleTip'
 import {useRefreshWatcher} from './hooks/useRefreshWatcher'
 import {useActiveRepoRoot, useViewModePersistence} from './hooks/useRepoPersistence'
@@ -508,8 +508,12 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // by `useCommitDetailHydration`, in its original position — a two-hook
   // split to preserve React hook ordering. See that module's header.
   const {detail, setDetail, detailLoading, setDetailLoading} = useCommitDetailState(React)
-  const [filePreview, setFilePreview] = React.useState<GitCommitFilePreview | undefined>(undefined)
-  const [filePreviewLoading, setFilePreviewLoading] = React.useState(false)
+  // Commit file-preview hydration state, lifted into `useCommitFilePreviewState`
+  // (app.ts decomposition item 2 / #1237). The `useState` pair stays in this
+  // exact slot; the loader effect that toggles it is issued ~900 lines below by
+  // `useCommitFilePreviewHydration`, in its original position — a two-hook split
+  // to preserve React hook ordering. See `useDiffHydration`'s header.
+  const {filePreview, setFilePreview, filePreviewLoading, setFilePreviewLoading} = useCommitFilePreviewState(React)
   const [worktreeDiff, setWorktreeDiff] = React.useState<WorktreeFileDiff | undefined>(undefined)
   const [worktreeDiffLoading, setWorktreeDiffLoading] = React.useState(false)
   const [worktreeHunks, setWorktreeHunks] = React.useState<WorktreeHunkOverview | undefined>(

--- a/src/workstation/runtime/hooks/useDiffHydration.test.ts
+++ b/src/workstation/runtime/hooks/useDiffHydration.test.ts
@@ -1,4 +1,7 @@
-import { shouldLoadWorktreeDiff } from './useDiffHydration'
+import {
+  shouldLoadWorktreeDiff,
+  useCommitFilePreviewState,
+} from './useDiffHydration'
 import type { WorktreeFile } from '../../../git/statusData'
 
 /**
@@ -28,5 +31,29 @@ describe('shouldLoadWorktreeDiff', () => {
 
   it('skips (false) when neither condition holds', () => {
     expect(shouldLoadWorktreeDiff('history', undefined)).toBe(false)
+  })
+})
+
+/**
+ * `useCommitFilePreviewState` (app.ts decomposition item 2 / #1237) owns the
+ * commit file-preview `useState` pair. Driven through a minimal fake-React
+ * harness — it must seed both slots empty and surface both setters so the
+ * loader effect can toggle them.
+ */
+describe('useCommitFilePreviewState', () => {
+  it('seeds filePreview undefined and filePreviewLoading false, exposing both setters', () => {
+    const React = {
+      useState: (init: unknown) => {
+        const value = typeof init === 'function' ? (init as () => unknown)() : init
+        return [value, jest.fn()]
+      },
+    } as unknown as typeof import('react')
+
+    const result = useCommitFilePreviewState(React)
+
+    expect(result.filePreview).toBeUndefined()
+    expect(result.filePreviewLoading).toBe(false)
+    expect(typeof result.setFilePreview).toBe('function')
+    expect(typeof result.setFilePreviewLoading).toBe('function')
   })
 })

--- a/src/workstation/runtime/hooks/useDiffHydration.ts
+++ b/src/workstation/runtime/hooks/useDiffHydration.ts
@@ -45,10 +45,19 @@
  * exactly, this module exports *five* hooks, each called at its original
  * slot in `app.ts`. Order correctness wins over tidiness.
  *
- * The dedicated `useState` slots stay in `app.ts` because the diff setters
+ * Most dedicated `useState` slots stay in `app.ts` because their diff setters
  * are also called from staging callbacks (`toggleSelectedFileStage`, the
  * hunk-stage callbacks) and the compare-reset effect — they are not owned by
  * these loaders. Each hook is handed the setter(s) it needs.
+ *
+ * The **commit file-preview** slot is the exception: `setFilePreview` /
+ * `setFilePreviewLoading` are written *only* by its loader, so that pair's
+ * `useState` is owned here via {@link useCommitFilePreviewState} (app.ts
+ * decomposition item 2 / #1237). It is a position-preserving split — the state
+ * hook is called at the original `useState` slot near the top of `app.ts`, and
+ * `useCommitFilePreviewHydration` (the effect) stays at its original slot far
+ * below, handed the setters — mirroring the `useCommitDetailState` +
+ * `useCommitDetailHydration` split (item 1a).
  *
  * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
  * convention) because the workstation never statically imports React.
@@ -339,6 +348,32 @@ export function useWorktreeDiffHydration(
 
 /** The cursored commit's selected detail file, as fed to the preview load. */
 type SelectedDetailFile = GitCommitDetail['files'][number] | undefined
+
+/**
+ * Issues the commit file-preview `useState` pair, in its original `app.ts`
+ * position (top of the hydration-state block, ~900 lines above the loader
+ * effect). `setFilePreview` / `setFilePreviewLoading` are written *only* by
+ * {@link useCommitFilePreviewHydration}, so — unlike the worktree / stash /
+ * compare slots whose setters are shared with staging callbacks and the
+ * compare-reset effect — this pair can be owned here. Returns the values (the
+ * preview drives the syntax-highlight effect and the diff render surfaces) and
+ * the setters (threaded into the loader). A position-preserving split that
+ * keeps every hook in its original slot; see the module header.
+ */
+export function useCommitFilePreviewState(React: typeof ReactTypes): {
+  filePreview: GitCommitFilePreview | undefined
+  setFilePreview: ReactTypes.Dispatch<
+    ReactTypes.SetStateAction<GitCommitFilePreview | undefined>
+  >
+  filePreviewLoading: boolean
+  setFilePreviewLoading: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
+} {
+  const [filePreview, setFilePreview] = React.useState<
+    GitCommitFilePreview | undefined
+  >(undefined)
+  const [filePreviewLoading, setFilePreviewLoading] = React.useState(false)
+  return { filePreview, setFilePreview, filePreviewLoading, setFilePreviewLoading }
+}
 
 export type UseCommitFilePreviewHydrationDeps = {
   /** The active frame's `git`. */


### PR DESCRIPTION
## Item 2 — `app.ts` decomposition (#1237)

> **Stacked on #1273** (item 1a). Base will retarget to `main` once #1273 merges. The diff here is item 2 only.

Moves the `filePreview` / `filePreviewLoading` `useState` pair out of `app.ts` into a new `useCommitFilePreviewState` hook in the `useDiffHydration` module.

### Why this pair (and not the others) can move
The module previously kept *all* diff `useState` slots in `app.ts` because their setters are shared — `setWorktreeDiff` / `setWorktreeHunks` are called by the staging callbacks, and the stash/compare setters by the compare-reset effect. **`setFilePreview` / `setFilePreviewLoading` are the exception: only the file-preview loader writes them**, so the pair can be owned in the hook module.

### Position-preserving split
Same template as item 1a (`useCommitDetailState`):
- **`useCommitFilePreviewState(React)`** — issues the `useState` pair at its original slot near the top of `app.ts`; returns values + setters.
- **`useCommitFilePreviewHydration(...)`** — the existing loader effect, unchanged, still at its original slot ~900 lines below, still handed the setters.

Nothing moves → hook order preserved → render-snapshot suite is sufficient.

### Changes
- `useDiffHydration.ts`: add `useCommitFilePreviewState`; update module header note.
- `app.ts`: bare `useState` pair → `useCommitFilePreviewState(React)`; drop now-unused `GitCommitFilePreview` import.
- `useDiffHydration.test.ts`: unit test for the new state hook.

### Validation
- `jest` (workstation): 107 suites / 1854 tests pass, 68 snapshots **no diffs**
- `tsc --noEmit`: clean
- `eslint`: 0 errors
- `rollup -c`: builds `dist/`