### PR TITLE
refactor(runtime): extract diff syntax-highlight from app.ts (#1237)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -70,7 +70,6 @@ import type { LogInkVisiblePane } from '../chrome/layout'
 import {LogInkState, applyLogInkAction, createLogInkState, getSelectedInkCommit, getThemePickerSelection} from '../../workstation/runtime/inkViewModel'
 import {getGitOperationOverview} from '../../git/operationData'
 import {getProviderOverview} from '../../git/providerData'
-import {highlightDiffCode, type SyntaxSpan} from '../../lib/syntax/highlightEngine'
 import {getForgeActions, getForgePullRequestOverview} from '../../git/forgeActions'
 import {issueFilterForPreset, pullRequestFilterForPreset} from '../../git/triageFilterPresets'
 import {getStashCommitHashes, getStashOverview} from '../../git/stashData'
@@ -206,6 +205,7 @@ import {useCommitDetailHydration, useCommitDetailState} from './hooks/useCommitD
 import {useContextHydration} from './hooks/useContextHydration'
 import {useBlameLoadingState, useDetailHydration} from './hooks/useDetailHydration'
 import {useCommitFilePreviewHydration, useCommitFilePreviewState, useCompareDiffHydration, useStashDiffHydration, useWorktreeDiffHydration, useWorktreeHunksHydration} from './hooks/useDiffHydration'
+import {useDiffSyntaxHighlight, useDiffSyntaxState} from './hooks/useDiffSyntaxHighlight'
 import {useIdleTip} from './hooks/useIdleTip'
 import {useRefreshWatcher} from './hooks/useRefreshWatcher'
 import {useActiveRepoRoot, useViewModePersistence} from './hooks/useRepoPersistence'
@@ -521,12 +521,12 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   )
   const [worktreeHunksLoading, setWorktreeHunksLoading] = React.useState(false)
   // Syntax-highlight spans for the diff currently in view (#1117
-  // follow-up). Computed off the render path by the effect below;
-  // keyed by marker-stripped code line so the diff renderer looks
-  // spans up directly. `undefined` = no highlighting (renders plain).
-  const [diffSyntaxSpans, setDiffSyntaxSpans] = React.useState<
-    Map<string, SyntaxSpan[]> | undefined
-  >(undefined)
+  // follow-up). Owned by `useDiffSyntaxState` (app.ts decomposition item 2 /
+  // #1237); the `useState` stays in this exact slot while the effect that
+  // computes the spans is issued ~600 lines below by `useDiffSyntaxHighlight`,
+  // in its original position — a two-hook split to preserve hook ordering.
+  // `undefined` = no highlighting (renders plain).
+  const {diffSyntaxSpans, setDiffSyntaxSpans} = useDiffSyntaxState(React)
   // Stash diff explorer (Enter on a stash row): the runtime fetches
   // `git stash show -p <ref>` lazily once the diff view becomes active
   // with diffSource='stash'. Lines are stored as a flat string[] —
@@ -1151,49 +1151,22 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   })
 
   // Syntax-highlight the diff currently in view, off the render path
-  // (#1117 follow-up). Mirrors the worktree-diff effect: detect the
-  // active file + its diff lines (worktree or commit source), tokenize
-  // via tree-sitter, and store the per-line spans for the renderer.
-  // Stash / compare sources aren't highlighted yet (multi-file patch /
-  // no single path). Gated on the config flag + a color terminal.
-  React.useEffect(() => {
-    if (!syntaxHighlightEnabled || theme.noColor || state.activeView !== 'diff') {
-      setDiffSyntaxSpans(undefined)
-      return
-    }
-    let filePath: string | undefined
-    let lines: string[] | undefined
-    if (state.diffSource === 'commit') {
-      filePath = selectedDetailFile?.path
-      lines = filePreview?.hunks
-    } else if (worktreeDiff && !worktreeDiff.untracked) {
-      filePath = worktreeDiff.filePath
-      lines = worktreeDiff.lines
-    }
-    if (!filePath || !lines || lines.length === 0) {
-      setDiffSyntaxSpans(undefined)
-      return
-    }
-    let active = true
-    void highlightDiffCode(filePath, lines)
-      .then((map) => {
-        if (active) setDiffSyntaxSpans(map.size > 0 ? map : undefined)
-      })
-      .catch(() => {
-        if (active) setDiffSyntaxSpans(undefined)
-      })
-    return () => {
-      active = false
-    }
-  }, [
+  // (#1117 follow-up). Lifted verbatim into `useDiffSyntaxHighlight` (app.ts
+  // decomposition item 2 / #1237) — the gate, the commit-vs-worktree source
+  // detection, the `active` cancellation flag, the `highlightDiffCode` call,
+  // and the dependency array carry over byte-for-byte. Issued here, in its
+  // original slot; the `useState` it writes is owned by `useDiffSyntaxState`
+  // above.
+  useDiffSyntaxHighlight(React, {
     syntaxHighlightEnabled,
-    theme.noColor,
-    state.activeView,
-    state.diffSource,
-    selectedDetailFile?.path,
+    noColor: theme.noColor,
+    activeView: state.activeView,
+    diffSource: state.diffSource,
+    selectedDetailFile,
     filePreview,
     worktreeDiff,
-  ])
+    setDiffSyntaxSpans,
+  })
 
   // Lifted verbatim into `useWorktreeStageActions` (0.72 app.ts
   // decomposition — the first extraction of action callbacks). The four

--- a/src/workstation/runtime/hooks/useDiffSyntaxHighlight.test.ts
+++ b/src/workstation/runtime/hooks/useDiffSyntaxHighlight.test.ts
@@ -1,0 +1,169 @@
+import { highlightDiffCode } from '../../../lib/syntax/highlightEngine'
+import {
+  useDiffSyntaxHighlight,
+  useDiffSyntaxState,
+} from './useDiffSyntaxHighlight'
+
+/**
+ * Behavioral tests for the diff syntax-highlight cluster (app.ts decomposition
+ * item 2 / #1237). The two hooks are a verbatim lift of the inline
+ * `diffSyntaxSpans` `useState` + highlight effect; these tests drive them
+ * through a minimal fake-React harness and a mocked highlight engine to prove
+ * the contract carried over byte-for-byte:
+ *   - gate off (flag/noColor/not-diff) → clear spans, never tokenize;
+ *   - commit source → highlight the file preview's hunks and store the spans;
+ *   - cancellation via the `active` flag suppresses a stale write.
+ */
+
+jest.mock('../../../lib/syntax/highlightEngine', () => ({
+  highlightDiffCode: jest.fn(),
+}))
+
+const highlightDiffCodeMock = highlightDiffCode as jest.MockedFunction<
+  typeof highlightDiffCode
+>
+
+/** Flush pending microtasks so the effect's `.then` settles. */
+const flush = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0))
+
+type EffectFn = () => void | (() => void)
+
+function makeReact(): {
+  React: typeof import('react')
+  runEffect: () => void | (() => void)
+} {
+  const effects: EffectFn[] = []
+  const React = {
+    useEffect: (fn: EffectFn) => {
+      effects.push(fn)
+    },
+  } as unknown as typeof import('react')
+  return {
+    React,
+    runEffect: () => {
+      if (effects.length !== 1) {
+        throw new Error(`expected exactly one effect, got ${effects.length}`)
+      }
+      return effects[0]()
+    },
+  }
+}
+
+type Deps = Parameters<typeof useDiffSyntaxHighlight>[1]
+
+/** Baseline deps for the "commit source, everything on" happy path. */
+const baseDeps = (over: Partial<Deps> = {}): Deps => ({
+  syntaxHighlightEnabled: true,
+  noColor: false,
+  activeView: 'diff' as Deps['activeView'],
+  diffSource: 'commit' as Deps['diffSource'],
+  selectedDetailFile: { path: 'src/app.ts' } as unknown as Deps['selectedDetailFile'],
+  filePreview: { hunks: ['@@ -1 +1 @@', '-a', '+b'] } as unknown as Deps['filePreview'],
+  worktreeDiff: undefined,
+  setDiffSyntaxSpans: jest.fn(),
+  ...over,
+})
+
+beforeEach(() => {
+  highlightDiffCodeMock.mockReset()
+})
+
+describe('useDiffSyntaxState', () => {
+  it('seeds diffSyntaxSpans undefined and exposes the setter', () => {
+    const React = {
+      useState: (init: unknown) => {
+        const value = typeof init === 'function' ? (init as () => unknown)() : init
+        return [value, jest.fn()]
+      },
+    } as unknown as typeof import('react')
+
+    const result = useDiffSyntaxState(React)
+
+    expect(result.diffSyntaxSpans).toBeUndefined()
+    expect(typeof result.setDiffSyntaxSpans).toBe('function')
+  })
+})
+
+describe('useDiffSyntaxHighlight', () => {
+  it.each([
+    ['the flag is off', { syntaxHighlightEnabled: false }],
+    ['the terminal is no-color', { noColor: true }],
+    ['the active view is not diff', { activeView: 'history' as Deps['activeView'] }],
+  ])('clears spans and never tokenizes when %s', async (_label, over) => {
+    const setDiffSyntaxSpans = jest.fn()
+    const { React, runEffect } = makeReact()
+
+    useDiffSyntaxHighlight(React, baseDeps({ ...over, setDiffSyntaxSpans }))
+    runEffect()
+    await flush()
+
+    expect(setDiffSyntaxSpans).toHaveBeenCalledWith(undefined)
+    expect(highlightDiffCodeMock).not.toHaveBeenCalled()
+  })
+
+  it('clears spans when the commit source has no file / lines', async () => {
+    const setDiffSyntaxSpans = jest.fn()
+    const { React, runEffect } = makeReact()
+
+    useDiffSyntaxHighlight(
+      React,
+      baseDeps({ filePreview: { hunks: [] } as unknown as Deps['filePreview'], setDiffSyntaxSpans }),
+    )
+    runEffect()
+    await flush()
+
+    expect(setDiffSyntaxSpans).toHaveBeenCalledWith(undefined)
+    expect(highlightDiffCodeMock).not.toHaveBeenCalled()
+  })
+
+  it('highlights the commit file preview and stores the spans', async () => {
+    const spans = new Map([['+b', [{ start: 0 }]]])
+    highlightDiffCodeMock.mockResolvedValue(spans as never)
+    const setDiffSyntaxSpans = jest.fn()
+    const { React, runEffect } = makeReact()
+
+    useDiffSyntaxHighlight(React, baseDeps({ setDiffSyntaxSpans }))
+    runEffect()
+    await flush()
+
+    expect(highlightDiffCodeMock).toHaveBeenCalledWith('src/app.ts', [
+      '@@ -1 +1 @@',
+      '-a',
+      '+b',
+    ])
+    expect(setDiffSyntaxSpans).toHaveBeenLastCalledWith(spans)
+  })
+
+  it('stores undefined when highlighting yields an empty map', async () => {
+    highlightDiffCodeMock.mockResolvedValue(new Map() as never)
+    const setDiffSyntaxSpans = jest.fn()
+    const { React, runEffect } = makeReact()
+
+    useDiffSyntaxHighlight(React, baseDeps({ setDiffSyntaxSpans }))
+    runEffect()
+    await flush()
+
+    expect(setDiffSyntaxSpans).toHaveBeenLastCalledWith(undefined)
+  })
+
+  it('suppresses a stale write when cleaned up before highlighting resolves', async () => {
+    let resolveSpans: (value: unknown) => void = () => {}
+    highlightDiffCodeMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSpans = resolve
+      }) as never,
+    )
+    const setDiffSyntaxSpans = jest.fn()
+    const { React, runEffect } = makeReact()
+
+    useDiffSyntaxHighlight(React, baseDeps({ setDiffSyntaxSpans }))
+    const cleanup = runEffect() as () => void
+    cleanup()
+    resolveSpans(new Map([['+b', []]]))
+    await flush()
+
+    // active === false → the resolved spans are dropped.
+    expect(setDiffSyntaxSpans).not.toHaveBeenCalled()
+  })
+})

--- a/src/workstation/runtime/hooks/useDiffSyntaxHighlight.ts
+++ b/src/workstation/runtime/hooks/useDiffSyntaxHighlight.ts
@@ -1,0 +1,155 @@
+/**
+ * Diff syntax-highlight hydration (extracted in the post-0.72 app.ts
+ * decomposition, item 2 / #1237).
+ *
+ * This module lifts the "tokenize the diff currently in view, off the render
+ * path" cluster out of `app.ts` (#1117 follow-up): the `diffSyntaxSpans`
+ * `useState` slot and the effect that, when the diff view is active, detects
+ * the active file + its diff lines (commit or worktree source), runs them
+ * through `highlightDiffCode` (tree-sitter), and stores the per-line spans for
+ * the renderer. Stash / compare sources aren't highlighted (multi-file patch /
+ * no single path), and highlighting is gated on the config flag + a color
+ * terminal.
+ *
+ * The effect is reproduced **verbatim** — the same gate, the same
+ * commit-vs-worktree source detection, the `active` cancellation flag, the
+ * `highlightDiffCode(...).then/.catch` shape, and the dependency array are
+ * byte-for-byte the same as the original `app.ts` effect. This is a
+ * behavior-preserving move, not a rewrite.
+ *
+ * `setDiffSyntaxSpans` is written *only* by this effect (no staging callback
+ * or reset effect touches it), so — unlike the worktree / stash / compare diff
+ * slots — the `useState` is owned here.
+ *
+ * CRITICAL — hook ordering. In `app.ts` the `diffSyntaxSpans` `useState` sits
+ * near the top of the hydration-state block (~L527), while the effect sits
+ * ~600 lines below (~L1159), separated by many intervening hooks. React fires
+ * hooks in declaration order, so collapsing the `useState` and the effect into
+ * a single call site would reorder one of them relative to those intervening
+ * hooks — moving the `useState` down corrupts every state slot after it
+ * (catastrophic), and moving the effect up changes effect-execution order
+ * (which the render-snapshot suite does not catch). To preserve ordering
+ * exactly, this module exports *two* hooks, each called at the original
+ * position:
+ *
+ *   const { diffSyntaxSpans, setDiffSyntaxSpans } = useDiffSyntaxState(React) // ~L527
+ *   ...intervening hooks...
+ *   useDiffSyntaxHighlight(React, { ..., setDiffSyntaxSpans })                // ~L1159
+ *
+ * Order correctness wins. Mirrors the `useCommitDetailState` +
+ * `useCommitDetailHydration` split (item 1a).
+ *
+ * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
+ * convention) because the workstation never statically imports React.
+ */
+
+import type * as ReactTypes from 'react'
+import { GitCommitDetail, GitCommitFilePreview } from '../../../commands/log/data'
+import type { WorktreeFileDiff } from '../../../git/worktreeDiffData'
+import { highlightDiffCode, type SyntaxSpan } from '../../../lib/syntax/highlightEngine'
+import type { LogInkDiffSource, LogInkView } from '../inkViewModel'
+
+/** The cursored commit's selected detail file (drives the commit-source path). */
+type SelectedDetailFile = GitCommitDetail['files'][number] | undefined
+
+/**
+ * Issues only the `diffSyntaxSpans` `useState`, in its original `app.ts`
+ * position (top of the hydration-state block, ~600 lines above the effect).
+ * Returns the value (read by the diff render surface) and the setter (threaded
+ * into {@link useDiffSyntaxHighlight} so the effect can store / clear spans
+ * exactly as the inline code did). A position-preserving split; see the module
+ * header.
+ */
+export function useDiffSyntaxState(React: typeof ReactTypes): {
+  diffSyntaxSpans: Map<string, SyntaxSpan[]> | undefined
+  setDiffSyntaxSpans: ReactTypes.Dispatch<
+    ReactTypes.SetStateAction<Map<string, SyntaxSpan[]> | undefined>
+  >
+} {
+  const [diffSyntaxSpans, setDiffSyntaxSpans] = React.useState<
+    Map<string, SyntaxSpan[]> | undefined
+  >(undefined)
+  return { diffSyntaxSpans, setDiffSyntaxSpans }
+}
+
+export type UseDiffSyntaxHighlightDeps = {
+  /** Config flag (`syntaxHighlightEnabled`) — off ⇒ never highlight. */
+  syntaxHighlightEnabled: boolean | undefined
+  /** `theme.noColor` — a no-color terminal skips highlighting. */
+  noColor: boolean | undefined
+  /** `state.activeView` — only the `'diff'` view highlights. */
+  activeView: LogInkView
+  /** `state.diffSource` — `'commit'` uses the file preview, else worktree. */
+  diffSource: LogInkDiffSource | undefined
+  /** The cursored commit's selected detail file (commit-source path). */
+  selectedDetailFile: SelectedDetailFile
+  /** The loaded commit file preview (commit-source lines via `.hunks`). */
+  filePreview: GitCommitFilePreview | undefined
+  /** The loaded worktree file diff (worktree-source path + lines). */
+  worktreeDiff: WorktreeFileDiff | undefined
+  /** Writer for the per-line spans, from {@link useDiffSyntaxState}. */
+  setDiffSyntaxSpans: ReactTypes.Dispatch<
+    ReactTypes.SetStateAction<Map<string, SyntaxSpan[]> | undefined>
+  >
+}
+
+/**
+ * Issues the diff syntax-highlight effect, in its original `app.ts` position.
+ * Reproduced verbatim — same gate, same commit-vs-worktree source detection,
+ * same `active` cancellation flag, same `highlightDiffCode(...).then/.catch`,
+ * same dependency array.
+ */
+export function useDiffSyntaxHighlight(
+  React: typeof ReactTypes,
+  deps: UseDiffSyntaxHighlightDeps,
+): void {
+  const {
+    syntaxHighlightEnabled,
+    noColor,
+    activeView,
+    diffSource,
+    selectedDetailFile,
+    filePreview,
+    worktreeDiff,
+    setDiffSyntaxSpans,
+  } = deps
+
+  React.useEffect(() => {
+    if (!syntaxHighlightEnabled || noColor || activeView !== 'diff') {
+      setDiffSyntaxSpans(undefined)
+      return
+    }
+    let filePath: string | undefined
+    let lines: string[] | undefined
+    if (diffSource === 'commit') {
+      filePath = selectedDetailFile?.path
+      lines = filePreview?.hunks
+    } else if (worktreeDiff && !worktreeDiff.untracked) {
+      filePath = worktreeDiff.filePath
+      lines = worktreeDiff.lines
+    }
+    if (!filePath || !lines || lines.length === 0) {
+      setDiffSyntaxSpans(undefined)
+      return
+    }
+    let active = true
+    void highlightDiffCode(filePath, lines)
+      .then((map) => {
+        if (active) setDiffSyntaxSpans(map.size > 0 ? map : undefined)
+      })
+      .catch(() => {
+        if (active) setDiffSyntaxSpans(undefined)
+      })
+    return () => {
+      active = false
+    }
+  }, [
+    syntaxHighlightEnabled,
+    noColor,
+    activeView,
+    diffSource,
+    selectedDetailFile?.path,
+    filePreview,
+    worktreeDiff,
+  ])
+}


### PR DESCRIPTION
## Item 2 (cont.) — `app.ts` decomposition (#1237)

Follows #1273 and #1275 (both merged). Lifts the `diffSyntaxSpans` cluster (#1117 follow-up) — the `useState` slot and the inline effect that tokenizes the in-view diff via tree-sitter off the render path — into a new `useDiffSyntaxHighlight` module.

### Why this pair can move
`setDiffSyntaxSpans` is written **only** by this effect — no staging callback or reset effect touches it — so the `useState` is safe to own in the hook module.

### Position-preserving split (same template as item 1a)
- **`useDiffSyntaxState(React)`** — issues the `useState` at its original slot near the top of `app.ts`; returns value + setter.
- **`useDiffSyntaxHighlight(React, {...})`** — the highlight effect, reproduced **verbatim** (same gate, commit-vs-worktree source detection, `active` cancellation flag, `highlightDiffCode` call, and dependency array), at its original slot ~600 lines below, handed the setter.

Nothing moves → hook order preserved → render-snapshot suite is sufficient.

### Changes
- New `hooks/useDiffSyntaxHighlight.ts` (state hook + effect hook).
- `app.ts`: bare `useState` → `useDiffSyntaxState(React)`; inline effect → `useDiffSyntaxHighlight(...)`; drop now-unused `highlightDiffCode` / `SyntaxSpan` import.
- New `hooks/useDiffSyntaxHighlight.test.ts` — behavioral tests for the gate (3 cases), no-lines short-circuit, highlight + store, empty-map → undefined, and cancellation paths.

### Validation
- `jest` (workstation): 108 suites / 1862 tests pass, 68 snapshots **no diffs**
- `tsc --noEmit`: clean · `eslint`: 0 errors · `rollup -c`: builds `dist/`