### PR TITLE
refactor(runtime): extract bisect-candidate hydration from app.ts (#1237)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -57,7 +57,7 @@ import {getBranchOverview} from '../../git/branchData'
 import {getLfsAttributeStatus} from '../../git/lfsAttributes'
 import {getSubmoduleOverview} from '../../git/submoduleData'
 import {getRemoteOverview} from '../../git/remoteData'
-import {GitCommitDetail, LOG_INTERACTIVE_DEFAULT_LIMIT, buildToggleGraphArgs, getCommitDetail, getCommitRows, getLogRows} from '../../commands/log/data'
+import {LOG_INTERACTIVE_DEFAULT_LIMIT, buildToggleGraphArgs, getCommitRows, getLogRows} from '../../commands/log/data'
 import {LogInkContextKey, LogInkContextStatus, createLogInkContextStatus, updateLogInkContextStatus} from '../chrome/context'
 import {hasSeenOnboarding, markOnboardingSeen} from '../chrome/onboarding'
 import {createLogInkTheme, type LogInkThemePreset} from '../chrome/theme'
@@ -201,6 +201,7 @@ import type { LogArgv } from '../../commands/log/config'
 // LogInkState filter-mode shape.
 import {matchesPromotedFilter} from '../runtime/promotedFilter'
 import {useFilteredLists} from './hooks/buildFilteredLists'
+import {useBisectCandidateHydration, useBisectCandidateState} from './hooks/useBisectCandidateHydration'
 import {useCommitDetailHydration, useCommitDetailState} from './hooks/useCommitDetailHydration'
 import {useContextHydration} from './hooks/useContextHydration'
 import {useBlameLoadingState, useDetailHydration} from './hooks/useDetailHydration'
@@ -855,8 +856,17 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // when the bisect view is active. Best-effort: any failure leaves
   // the surface in its non-detail mode (decision log only) — never
   // crash the workstation because git couldn't resolve a sha.
-  const [bisectCandidateDetail, setBisectCandidateDetail] = React.useState<GitCommitDetail | undefined>(undefined)
-  const [bisectCandidateLoading, setBisectCandidateLoading] = React.useState(false)
+  // Owned by `useBisectCandidateState` (app.ts decomposition item 2 / #1237).
+  // The `useState` pair stays in this exact slot (just above the
+  // `useBlameLoadingState` call); the loader effect that toggles it is issued
+  // a few lines below by `useBisectCandidateHydration`, in its original
+  // position — a two-hook split to preserve React hook ordering.
+  const {
+    bisectCandidateDetail,
+    setBisectCandidateDetail,
+    bisectCandidateLoading,
+    setBisectCandidateLoading,
+  } = useBisectCandidateState(React)
   // On-demand blame hydration flag (#0.71). True while the debounced
   // `getBlame` for the active `state.blamePath` is in flight; the blame
   // surface shows a loading placeholder until the parse lands in the
@@ -868,23 +878,17 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   const bisectCandidateSha = state.activeView === 'bisect' && context.bisect?.active
     ? context.bisect.currentSha
     : ''
-  React.useEffect(() => {
-    if (!bisectCandidateSha) {
-      setBisectCandidateDetail(undefined)
-      setBisectCandidateLoading(false)
-      return
-    }
-    let active = true
-    setBisectCandidateLoading(true)
-    void (async () => {
-      const next = await safe(getCommitDetail(git, bisectCandidateSha))
-      if (active) {
-        setBisectCandidateDetail(next)
-        setBisectCandidateLoading(false)
-      }
-    })()
-    return () => { active = false }
-  }, [git, bisectCandidateSha])
+  // Lifted verbatim into `useBisectCandidateHydration` (app.ts decomposition
+  // item 2 / #1237) — the empty-sha guard, `active` cancellation flag, `safe()`
+  // wrapper, loading toggles, and `[git, bisectCandidateSha]` dependency array
+  // carry over byte-for-byte. Issued here, in its original slot; the `useState`
+  // pair it writes is owned by `useBisectCandidateState` above.
+  useBisectCandidateHydration(React, {
+    git,
+    bisectCandidateSha,
+    setBisectCandidateDetail,
+    setBisectCandidateLoading,
+  })
 
   // #779 — load `git diff <base>..<head>` once the diff view becomes
   // active with diffSource='compare'. Mirrors the stash loader's

--- a/src/workstation/runtime/hooks/useBisectCandidateHydration.test.ts
+++ b/src/workstation/runtime/hooks/useBisectCandidateHydration.test.ts
@@ -1,0 +1,148 @@
+import { getCommitDetail } from '../../../commands/log/data'
+import {
+  useBisectCandidateHydration,
+  useBisectCandidateState,
+} from './useBisectCandidateHydration'
+
+/**
+ * Behavioral tests for the bisect-candidate hydration cluster (app.ts
+ * decomposition item 2 / #1237). The two hooks are a verbatim lift of the
+ * inline `useState` pair + loader effect; these tests drive them through a
+ * minimal fake-React harness and a mocked data module to prove the contract
+ * carried over byte-for-byte:
+ *   - empty sha → clear detail + loading, never fetch;
+ *   - sha present → toggle loading, fetch, then store the detail;
+ *   - cancellation via the `active` flag suppresses a stale write.
+ */
+
+jest.mock('../../../commands/log/data', () => ({
+  getCommitDetail: jest.fn(),
+}))
+
+const getCommitDetailMock = getCommitDetail as jest.MockedFunction<
+  typeof getCommitDetail
+>
+
+/** Flush pending microtasks so the effect's awaited loader settles. */
+const flush = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0))
+
+type EffectFn = () => void | (() => void)
+
+function makeReact(): {
+  React: typeof import('react')
+  runEffect: () => void | (() => void)
+} {
+  const effects: EffectFn[] = []
+  const React = {
+    useEffect: (fn: EffectFn) => {
+      effects.push(fn)
+    },
+  } as unknown as typeof import('react')
+  return {
+    React,
+    runEffect: () => {
+      if (effects.length !== 1) {
+        throw new Error(`expected exactly one effect, got ${effects.length}`)
+      }
+      return effects[0]()
+    },
+  }
+}
+
+const git = {} as Parameters<typeof useBisectCandidateHydration>[1]['git']
+
+beforeEach(() => {
+  getCommitDetailMock.mockReset()
+})
+
+describe('useBisectCandidateState', () => {
+  it('seeds detail undefined and loading false, exposing both setters', () => {
+    const React = {
+      useState: (init: unknown) => {
+        const value = typeof init === 'function' ? (init as () => unknown)() : init
+        return [value, jest.fn()]
+      },
+    } as unknown as typeof import('react')
+
+    const result = useBisectCandidateState(React)
+
+    expect(result.bisectCandidateDetail).toBeUndefined()
+    expect(result.bisectCandidateLoading).toBe(false)
+    expect(typeof result.setBisectCandidateDetail).toBe('function')
+    expect(typeof result.setBisectCandidateLoading).toBe('function')
+  })
+})
+
+describe('useBisectCandidateHydration', () => {
+  it('clears detail + loading and never fetches when the sha is empty', async () => {
+    const setBisectCandidateDetail = jest.fn()
+    const setBisectCandidateLoading = jest.fn()
+    const { React, runEffect } = makeReact()
+
+    useBisectCandidateHydration(React, {
+      git,
+      bisectCandidateSha: '',
+      setBisectCandidateDetail,
+      setBisectCandidateLoading,
+    })
+    runEffect()
+    await flush()
+
+    expect(setBisectCandidateDetail).toHaveBeenCalledWith(undefined)
+    expect(setBisectCandidateLoading).toHaveBeenCalledWith(false)
+    expect(getCommitDetailMock).not.toHaveBeenCalled()
+  })
+
+  it('toggles loading, fetches the candidate sha, then stores the detail', async () => {
+    const detail = { hash: 'cand123', files: [] }
+    getCommitDetailMock.mockResolvedValue(detail as never)
+    const setBisectCandidateDetail = jest.fn()
+    const setBisectCandidateLoading = jest.fn()
+    const { React, runEffect } = makeReact()
+
+    useBisectCandidateHydration(React, {
+      git,
+      bisectCandidateSha: 'cand123',
+      setBisectCandidateDetail,
+      setBisectCandidateLoading,
+    })
+    runEffect()
+
+    // Loading flips true synchronously, before the await.
+    expect(setBisectCandidateLoading).toHaveBeenCalledWith(true)
+    await flush()
+
+    expect(getCommitDetailMock).toHaveBeenCalledWith(git, 'cand123')
+    expect(setBisectCandidateDetail).toHaveBeenCalledWith(detail)
+    expect(setBisectCandidateLoading).toHaveBeenLastCalledWith(false)
+  })
+
+  it('suppresses a stale write when cleaned up before the fetch resolves', async () => {
+    let resolveDetail: (value: unknown) => void = () => {}
+    getCommitDetailMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveDetail = resolve
+      }) as never,
+    )
+    const setBisectCandidateDetail = jest.fn()
+    const setBisectCandidateLoading = jest.fn()
+    const { React, runEffect } = makeReact()
+
+    useBisectCandidateHydration(React, {
+      git,
+      bisectCandidateSha: 'cand456',
+      setBisectCandidateDetail,
+      setBisectCandidateLoading,
+    })
+    const cleanup = runEffect() as () => void
+    cleanup()
+    resolveDetail({ hash: 'cand456', files: [] })
+    await flush()
+
+    // active === false → only the synchronous loading-true write landed.
+    expect(setBisectCandidateDetail).not.toHaveBeenCalled()
+    expect(setBisectCandidateLoading).toHaveBeenCalledTimes(1)
+    expect(setBisectCandidateLoading).toHaveBeenCalledWith(true)
+  })
+})

--- a/src/workstation/runtime/hooks/useBisectCandidateHydration.ts
+++ b/src/workstation/runtime/hooks/useBisectCandidateHydration.ts
@@ -1,0 +1,138 @@
+/**
+ * Bisect-candidate detail hydration (extracted in the post-0.72 app.ts
+ * decomposition, item 2 / #1237; the feature itself is #879).
+ *
+ * This module lifts the "load commit detail for the active bisect's current
+ * candidate" cluster out of `app.ts`: the `bisectCandidateDetail` /
+ * `bisectCandidateLoading` `useState` pair and the effect that fetches
+ * `getCommitDetail(git, bisect.currentSha)` into them once the bisect view is
+ * active. The loaded detail lets the bisect surface show "what changed here"
+ * alongside the decision keys; any failure leaves the surface in its
+ * decision-log-only mode (best-effort, never crash).
+ *
+ * The effect is reproduced **verbatim** — the same empty-sha guard, the
+ * `active` cancellation flag, the `safe()` wrapper, the `setBisectCandidateLoading`
+ * toggles, and the `[git, bisectCandidateSha]` dependency array are
+ * byte-for-byte the same as the original `app.ts` effect. This is a
+ * behavior-preserving move, not a rewrite.
+ *
+ * `setBisectCandidateDetail` / `setBisectCandidateLoading` are written *only*
+ * by this effect, so the pair is owned here.
+ *
+ * CRITICAL — hook ordering. In `app.ts` the `useState` pair (~L858) and the
+ * effect (~L871) are *not* adjacent: a `useBlameLoadingState` call sits between
+ * them. Collapsing the `useState` and the effect into a single hook at one call
+ * site would reorder one of them relative to that intervening hook — moving the
+ * `useState` past it corrupts the state slots (catastrophic), and moving the
+ * effect changes effect-execution order (which the render-snapshot suite does
+ * not catch). To preserve ordering exactly, this module exports *two* hooks,
+ * each called at the original position:
+ *
+ *   const { bisectCandidateDetail, setBisectCandidateDetail, ... } =
+ *     useBisectCandidateState(React)                                    // ~L858
+ *   const { blameLoading, setBlameLoading } = useBlameLoadingState(React) // ~L867
+ *   useBisectCandidateHydration(React, { git, bisectCandidateSha, ... })  // ~L871
+ *
+ * Order correctness wins. Mirrors the `useCommitDetailState` +
+ * `useCommitDetailHydration` split (item 1a).
+ *
+ * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
+ * convention) because the workstation never statically imports React.
+ */
+
+import type * as ReactTypes from 'react'
+import type { SimpleGit } from 'simple-git'
+import { GitCommitDetail, getCommitDetail } from '../../../commands/log/data'
+
+/**
+ * Best-effort promise unwrap, lifted verbatim from `app.ts`. Swallows the
+ * rejection so a git error leaves the bisect surface in its decision-log-only
+ * mode instead of crashing the workstation.
+ */
+async function safe<T>(promise: Promise<T>): Promise<T | undefined> {
+  try {
+    return await promise
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Issues only the bisect-candidate `useState` pair, in its original `app.ts`
+ * position (next to the bisect comment block, just above the
+ * `useBlameLoadingState` call). Returns the values (read by the bisect surface)
+ * and the setters (threaded into {@link useBisectCandidateHydration} so the
+ * loader can toggle them exactly as the inline code did). A position-preserving
+ * split; see the module header.
+ */
+export function useBisectCandidateState(React: typeof ReactTypes): {
+  bisectCandidateDetail: GitCommitDetail | undefined
+  setBisectCandidateDetail: ReactTypes.Dispatch<
+    ReactTypes.SetStateAction<GitCommitDetail | undefined>
+  >
+  bisectCandidateLoading: boolean
+  setBisectCandidateLoading: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
+} {
+  const [bisectCandidateDetail, setBisectCandidateDetail] = React.useState<
+    GitCommitDetail | undefined
+  >(undefined)
+  const [bisectCandidateLoading, setBisectCandidateLoading] = React.useState(false)
+  return {
+    bisectCandidateDetail,
+    setBisectCandidateDetail,
+    bisectCandidateLoading,
+    setBisectCandidateLoading,
+  }
+}
+
+export type UseBisectCandidateHydrationDeps = {
+  /** The active frame's `git`. Drives the `getCommitDetail` fetch. */
+  git: SimpleGit
+  /**
+   * The bisect's current candidate sha (`''` when the bisect view isn't active
+   * or no bisect is running). Empty ⇒ clear the detail and skip the fetch.
+   */
+  bisectCandidateSha: string
+  /** Writer for the loaded detail, from {@link useBisectCandidateState}. */
+  setBisectCandidateDetail: ReactTypes.Dispatch<
+    ReactTypes.SetStateAction<GitCommitDetail | undefined>
+  >
+  /** Loading-flag setter, from {@link useBisectCandidateState}. */
+  setBisectCandidateLoading: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
+}
+
+/**
+ * Issues the bisect-candidate loader effect, in its original `app.ts` position.
+ * Reproduced verbatim — same empty-sha guard, `active` cancellation flag,
+ * `safe()` wrapper, `setBisectCandidateLoading` toggles, and
+ * `[git, bisectCandidateSha]` dependency array.
+ */
+export function useBisectCandidateHydration(
+  React: typeof ReactTypes,
+  deps: UseBisectCandidateHydrationDeps,
+): void {
+  const {
+    git,
+    bisectCandidateSha,
+    setBisectCandidateDetail,
+    setBisectCandidateLoading,
+  } = deps
+
+  React.useEffect(() => {
+    if (!bisectCandidateSha) {
+      setBisectCandidateDetail(undefined)
+      setBisectCandidateLoading(false)
+      return
+    }
+    let active = true
+    setBisectCandidateLoading(true)
+    void (async () => {
+      const next = await safe(getCommitDetail(git, bisectCandidateSha))
+      if (active) {
+        setBisectCandidateDetail(next)
+        setBisectCandidateLoading(false)
+      }
+    })()
+    return () => { active = false }
+  }, [git, bisectCandidateSha])
+}


### PR DESCRIPTION
## Item 2 (cont.) — `app.ts` decomposition (#1237)

Follows #1273, #1275, #1276 (all merged). The **last clean item-2 move**: lifts the `bisectCandidateDetail` / `bisectCandidateLoading` cluster (#879) — the `useState` pair and the effect that loads `getCommitDetail` for the active bisect's current candidate — into a new `useBisectCandidateHydration` module.

### Why this pair can move
`setBisectCandidateDetail` / `setBisectCandidateLoading` are written **only** by this effect — no staging callback or reset effect touches them.

### Position-preserving split (same template as item 1a)
The `useState` pair and the effect straddle a `useBlameLoadingState` call, so neither may move to a single site:
- **`useBisectCandidateState(React)`** — issues the `useState` pair at its original slot.
- **`useBisectCandidateHydration(React, {...})`** — the loader effect, reproduced **verbatim** (empty-sha guard, `active` flag, `safe()` wrapper, loading toggles, `[git, bisectCandidateSha]` deps), at its original slot just below.

Nothing moves → hook order preserved → render-snapshot suite is sufficient.

### Changes
- New `hooks/useBisectCandidateHydration.ts` (state hook + effect hook).
- `app.ts`: bare `useState` pair → `useBisectCandidateState(React)`; inline effect → `useBisectCandidateHydration(...)`; drop now-unused `getCommitDetail` / `GitCommitDetail` import (this was app.ts's last `getCommitDetail` caller).
- New `hooks/useBisectCandidateHydration.test.ts` — behavioral tests for the empty-sha, load, and cancellation paths.

### Validation
- `jest` (workstation): 109 suites / 1866 tests pass, 68 snapshots **no diffs**
- `tsc --noEmit`: clean · `eslint`: 0 errors · `rollup -c`: builds `dist/`

---
This completes the **clean** hydration-state-ownership moves. The remaining item-2 pairs (`worktreeDiff`, `worktreeHunks`, `stashDiff`, `compareDiff`) have setters shared with the staging callbacks / compare-reset effect, so they're blocked on a larger change (or stay in `app.ts`). See the plan doc.