### PR TITLE
refactor(runtime): own history-pagination state in useLoadMoreHistory (#1237)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -214,7 +214,7 @@ import {useSpinnerFrame} from './hooks/useSpinnerFrame'
 import {useStatusSurfaceData} from './hooks/buildStatusSurfaceData'
 import {useStatusAutoDismiss} from './hooks/useStatusAutoDismiss'
 import {useHistoryCursorSync} from './hooks/useHistoryCursorSync'
-import {useLoadMoreHistory} from './hooks/useLoadMoreHistory'
+import {useHistoryPaginationState, useLoadMoreHistory} from './hooks/useLoadMoreHistory'
 import {useWorktreeStageActions} from './hooks/useWorktreeStageActions'
 import {useCommitComposeActions} from './hooks/useCommitComposeActions'
 import {useCommitSplitActions} from './hooks/useCommitSplitActions'
@@ -539,11 +539,18 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // view becomes active with `diffSource === 'compare'`.
   const [compareDiffLines, setCompareDiffLines] = React.useState<string[] | undefined>(undefined)
   const [compareDiffLoading, setCompareDiffLoading] = React.useState(false)
-  const [hasMoreCommits, setHasMoreCommits] = React.useState(() => (
-    Boolean(logArgv?.interactive && !logArgv.limit) &&
-    getCommitRows(rows).length >= LOG_INTERACTIVE_DEFAULT_LIMIT
-  ))
-  const [loadingMoreCommits, setLoadingMoreCommits] = React.useState(false)
+  // Load-more pagination state, owned by `useHistoryPaginationState` (app.ts
+  // decomposition item 3 / #1237). The `useState` pair stays in this exact
+  // slot; the setters are shared (the loader `useLoadMoreHistory` below plus
+  // the history-filter / graph-toggle effects all write them), so the hook
+  // owns the slots and hands values + setters back here. The lazy seed for
+  // `hasMoreCommits` is preserved verbatim inside the hook.
+  const {
+    hasMoreCommits,
+    setHasMoreCommits,
+    loadingMoreCommits,
+    setLoadingMoreCommits,
+  } = useHistoryPaginationState(React, {logArgv, rows})
   const loadingMoreCommitsRef = React.useRef(false)
   const loadMoreRequestRef = React.useRef(0)
   const mountedRef = React.useRef(true)

--- a/src/workstation/runtime/hooks/useLoadMoreHistory.test.ts
+++ b/src/workstation/runtime/hooks/useLoadMoreHistory.test.ts
@@ -1,0 +1,90 @@
+import {
+  LOG_INTERACTIVE_DEFAULT_LIMIT,
+  getCommitRows,
+} from '../../../commands/log/data'
+import type { LogArgv } from '../../../commands/log/config'
+import { useHistoryPaginationState } from './useLoadMoreHistory'
+
+/**
+ * Tests for the `useHistoryPaginationState` seed (app.ts decomposition item 3
+ * / #1237). The loader (`useLoadMoreHistory`) is a verbatim lift validated by
+ * the green build + render snapshots; the only logic this hook adds is the
+ * lazy `hasMoreCommits` seed, exercised here through a fake-React harness with
+ * `getCommitRows` mocked to control the loaded-window size.
+ */
+
+jest.mock('../../../commands/log/data', () => {
+  const actual = jest.requireActual('../../../commands/log/data')
+  return { ...actual, getCommitRows: jest.fn() }
+})
+
+const getCommitRowsMock = getCommitRows as jest.MockedFunction<
+  typeof getCommitRows
+>
+
+/** Fake React whose `useState` runs the lazy initializer, as React would. */
+const React = {
+  useState: (init: unknown) => {
+    const value = typeof init === 'function' ? (init as () => unknown)() : init
+    return [value, jest.fn()]
+  },
+} as unknown as typeof import('react')
+
+/** A loaded window of `count` commit rows (only `.length` is read by the seed). */
+const rowsOfLength = (count: number) =>
+  getCommitRowsMock.mockReturnValue(
+    new Array(count).fill({}) as ReturnType<typeof getCommitRows>,
+  )
+
+const argv = (over: Partial<LogArgv>): LogArgv => over as LogArgv
+
+beforeEach(() => {
+  getCommitRowsMock.mockReset()
+})
+
+describe('useHistoryPaginationState seed', () => {
+  it('seeds hasMoreCommits true in interactive mode with a full default window and no --limit', () => {
+    rowsOfLength(LOG_INTERACTIVE_DEFAULT_LIMIT)
+    const { hasMoreCommits, loadingMoreCommits } = useHistoryPaginationState(React, {
+      logArgv: argv({ interactive: true }),
+      rows: [],
+    })
+    expect(hasMoreCommits).toBe(true)
+    expect(loadingMoreCommits).toBe(false)
+  })
+
+  it('seeds false when the loaded window is below the default page size', () => {
+    rowsOfLength(LOG_INTERACTIVE_DEFAULT_LIMIT - 1)
+    const { hasMoreCommits } = useHistoryPaginationState(React, {
+      logArgv: argv({ interactive: true }),
+      rows: [],
+    })
+    expect(hasMoreCommits).toBe(false)
+  })
+
+  it('seeds false (and never counts rows) when an explicit --limit is set', () => {
+    const { hasMoreCommits } = useHistoryPaginationState(React, {
+      logArgv: argv({ interactive: true, limit: 10 }),
+      rows: [],
+    })
+    expect(hasMoreCommits).toBe(false)
+    expect(getCommitRowsMock).not.toHaveBeenCalled()
+  })
+
+  it('seeds false when not in interactive mode', () => {
+    const { hasMoreCommits } = useHistoryPaginationState(React, {
+      logArgv: argv({ interactive: false }),
+      rows: [],
+    })
+    expect(hasMoreCommits).toBe(false)
+    expect(getCommitRowsMock).not.toHaveBeenCalled()
+  })
+
+  it('seeds false when there is no log argv at all', () => {
+    const { hasMoreCommits } = useHistoryPaginationState(React, {
+      logArgv: undefined,
+      rows: [],
+    })
+    expect(hasMoreCommits).toBe(false)
+  })
+})

--- a/src/workstation/runtime/hooks/useLoadMoreHistory.ts
+++ b/src/workstation/runtime/hooks/useLoadMoreHistory.ts
@@ -48,10 +48,17 @@
  *
  * `mountedRef`, `loadingMoreCommitsRef`, and `loadMoreRequestRef` stay
  * declared in `app.ts` (they are shared with — or, for `mountedRef`, read
- * by — many other clusters) and are passed in. `hasMoreCommits` /
- * `loadingMoreCommits` state and their setters also stay in `app.ts`
- * because the render and the history-filter / graph-toggle effects read
- * and write them; this hook receives the values and setters.
+ * by — many other clusters) and are passed in.
+ *
+ * The `hasMoreCommits` / `loadingMoreCommits` `useState` pair is owned by
+ * {@link useHistoryPaginationState} (app.ts decomposition item 3 / #1237),
+ * which issues the pair in its original `app.ts` slot near the top of the
+ * component. The setters are shared — the render and the history-filter /
+ * graph-toggle effects also read and write them — so the state hook only
+ * *owns* the slots and hands the values + setters back to `app.ts`, which
+ * threads them into this loader (and the filter / graph effects) exactly as
+ * before. A position-preserving split: the state hook is called where the
+ * `useState`s were, this loader stays at its original slot far below.
  *
  * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
  * convention) because the workstation never statically imports React.
@@ -61,6 +68,7 @@ import type * as ReactTypes from 'react'
 import type { SimpleGit } from 'simple-git'
 import type { LogArgv } from '../../../commands/log/config'
 import {
+  GitLogRow,
   LOG_INTERACTIVE_DEFAULT_LIMIT,
   getCommitRows,
   getLogRows,
@@ -80,6 +88,46 @@ async function safe<T>(promise: Promise<T>): Promise<T | undefined> {
     return await promise
   } catch {
     return undefined
+  }
+}
+
+export type UseHistoryPaginationStateDeps = {
+  /** The interactive log argv, or undefined when not in interactive log mode. */
+  logArgv: LogArgv | undefined
+  /** The initial commit-log rows the component mounted with. */
+  rows: GitLogRow[]
+}
+
+/**
+ * Issues the `hasMoreCommits` / `loadingMoreCommits` `useState` pair, in its
+ * original `app.ts` position. `hasMoreCommits` keeps its verbatim lazy seed —
+ * true only in interactive log mode without an explicit `--limit` when the
+ * initial window already filled the default page — so the first render's
+ * pagination affordance is unchanged. Returns the values (read by the render)
+ * and the setters (shared: threaded into {@link useLoadMoreHistory} and the
+ * history-filter / graph-toggle effects, which also write them). A
+ * position-preserving split; see the module header.
+ */
+export function useHistoryPaginationState(
+  React: typeof ReactTypes,
+  deps: UseHistoryPaginationStateDeps,
+): {
+  hasMoreCommits: boolean
+  setHasMoreCommits: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
+  loadingMoreCommits: boolean
+  setLoadingMoreCommits: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
+} {
+  const { logArgv, rows } = deps
+  const [hasMoreCommits, setHasMoreCommits] = React.useState(() => (
+    Boolean(logArgv?.interactive && !logArgv.limit) &&
+    getCommitRows(rows).length >= LOG_INTERACTIVE_DEFAULT_LIMIT
+  ))
+  const [loadingMoreCommits, setLoadingMoreCommits] = React.useState(false)
+  return {
+    hasMoreCommits,
+    setHasMoreCommits,
+    loadingMoreCommits,
+    setLoadingMoreCommits,
   }
 }
 


### PR DESCRIPTION
## Item 3 — `app.ts` decomposition (#1237)

Moves the `hasMoreCommits` / `loadingMoreCommits` `useState` pair out of `app.ts` into a new `useHistoryPaginationState` hook in the `useLoadMoreHistory` module, so pagination state lives in the same unit as its loader.

### Why a state hook (not folded into `useLoadMoreHistory`)
The setters are **shared** — the render plus the history-filter and graph-toggle effects read/write them, on top of the loader. And `useLoadMoreHistory` is called ~850 lines below the `useState`s, so moving the declarations there would reorder every state slot in between (catastrophic). So this follows the same position-preserving split as items 1a/2: the state hook owns the pair in its **original slot** and hands values + setters back to `app.ts`, which threads them into the loader and the filter/graph effects exactly as before.

### Preserved behavior
- `hasMoreCommits` keeps its **verbatim lazy seed** (interactive log mode, no explicit `--limit`, initial window already at the default page size).
- The two pagination refs (`loadingMoreCommitsRef`, `loadMoreRequestRef`) and `mountedRef` stay in `app.ts`, unchanged.

### Changes
- `useLoadMoreHistory.ts`: add `useHistoryPaginationState`; update module header note.
- `app.ts`: bare `useState` pair → `useHistoryPaginationState(React, {logArgv, rows})`.
- New `useLoadMoreHistory.test.ts` — seed tests across the interactive / `--limit` / window-size branches.

### Validation
- `jest` (workstation): 110 suites / 1871 tests pass, 68 snapshots **no diffs**
- `tsc --noEmit`: clean · `eslint`: 0 errors · `rollup -c`: builds `dist/`