### PR TITLE
refactor(runtime): extract first-run onboarding into useOnboarding (#1237)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -59,7 +59,6 @@ import {getSubmoduleOverview} from '../../git/submoduleData'
 import {getRemoteOverview} from '../../git/remoteData'
 import {LOG_INTERACTIVE_DEFAULT_LIMIT, buildToggleGraphArgs, getCommitRows, getLogRows} from '../../commands/log/data'
 import {LogInkContextKey, LogInkContextStatus, createLogInkContextStatus, updateLogInkContextStatus} from '../chrome/context'
-import {hasSeenOnboarding, markOnboardingSeen} from '../chrome/onboarding'
 import {createLogInkTheme, type LogInkThemePreset} from '../chrome/theme'
 import {saveThemePreset} from '../chrome/themePersistence'
 import {createInitialContextStatus, createRepoFrameRuntime} from './repoFrameFactory'
@@ -215,6 +214,7 @@ import {useStatusSurfaceData} from './hooks/buildStatusSurfaceData'
 import {useStatusAutoDismiss} from './hooks/useStatusAutoDismiss'
 import {useHistoryCursorSync} from './hooks/useHistoryCursorSync'
 import {useHistoryPaginationState, useLoadMoreHistory} from './hooks/useLoadMoreHistory'
+import {useOnboarding} from './hooks/useOnboarding'
 import {useWorktreeStageActions} from './hooks/useWorktreeStageActions'
 import {useCommitComposeActions} from './hooks/useCommitComposeActions'
 import {useCommitSplitActions} from './hooks/useCommitSplitActions'
@@ -373,7 +373,12 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // First-launch onboarding (P1.3). Persisted via a marker file in the
   // user's cache dir so the tip never reappears once dismissed. Lazy
   // initializer so the fs check only runs on mount, not every render.
-  const [showOnboarding, setShowOnboarding] = React.useState<boolean>(() => !hasSeenOnboarding())
+  // First-run onboarding overlay, owned by `useOnboarding` (app.ts
+  // decomposition item 4 / #1237). The hook seeds `showOnboarding` from
+  // `!hasSeenOnboarding()` and returns `dismissOnboarding`, which clears the
+  // overlay and writes the seen-marker; the input handler calls it on the
+  // first keystroke.
+  const {showOnboarding, dismissOnboarding} = useOnboarding(React)
   const [state, setState] = React.useState<LogInkState>(() =>
     createLogInkState(rows, {
       activeView: initialView,
@@ -1577,8 +1582,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     context,
     dispatch,
     showOnboarding,
-    setShowOnboarding,
-    markOnboardingSeen,
+    dismissOnboarding,
     filteredBranchList,
     filteredTagList,
     filteredStashList,

--- a/src/workstation/runtime/hooks/useInputHandler.ts
+++ b/src/workstation/runtime/hooks/useInputHandler.ts
@@ -73,10 +73,9 @@ export type UseInputHandlerDeps = {
   /** Reducer dispatch — drives the catch-all filter / navigation events. */
   dispatch: (action: LogInkAction) => void
 
-  /** First-launch onboarding overlay flag + setter. */
+  /** First-launch onboarding overlay flag + its dismiss (clears + persists). */
   showOnboarding: boolean
-  setShowOnboarding: (value: boolean) => void
-  markOnboardingSeen: () => void
+  dismissOnboarding: () => void
 
   /** Memoized filtered promoted-view lists (per-keystroke selection snapshots). */
   filteredBranchList: FilteredLists['filteredBranchList']
@@ -194,8 +193,7 @@ export function useInputHandler(
     context,
     dispatch,
     showOnboarding,
-    setShowOnboarding,
-    markOnboardingSeen,
+    dismissOnboarding,
     filteredBranchList,
     filteredTagList,
     filteredStashList,
@@ -254,8 +252,7 @@ export function useInputHandler(
     // and writes the seen-marker. Swallow the keystroke so the same key
     // doesn't also trigger normal input dispatch.
     if (showOnboarding) {
-      setShowOnboarding(false)
-      markOnboardingSeen()
+      dismissOnboarding()
       return
     }
 

--- a/src/workstation/runtime/hooks/useOnboarding.test.ts
+++ b/src/workstation/runtime/hooks/useOnboarding.test.ts
@@ -1,0 +1,68 @@
+import { hasSeenOnboarding, markOnboardingSeen } from '../../chrome/onboarding'
+import { useOnboarding } from './useOnboarding'
+
+/**
+ * Tests for `useOnboarding` (app.ts decomposition item 4 / #1237). Driven
+ * through a fake-React harness with the onboarding persistence module mocked,
+ * to prove the bundled contract:
+ *   - `showOnboarding` is seeded from `!hasSeenOnboarding()`;
+ *   - `dismissOnboarding` clears the overlay *and* writes the seen-marker,
+ *     in that order.
+ */
+
+jest.mock('../../chrome/onboarding', () => ({
+  hasSeenOnboarding: jest.fn(),
+  markOnboardingSeen: jest.fn(),
+}))
+
+const hasSeenOnboardingMock = hasSeenOnboarding as jest.MockedFunction<
+  typeof hasSeenOnboarding
+>
+const markOnboardingSeenMock = markOnboardingSeen as jest.MockedFunction<
+  typeof markOnboardingSeen
+>
+
+/** Fake React whose `useState` runs the lazy seed and `useCallback` is identity. */
+function makeReact(): {
+  React: typeof import('react')
+  setShowOnboarding: jest.Mock
+} {
+  const setShowOnboarding = jest.fn()
+  const React = {
+    useState: (init: unknown) => [
+      typeof init === 'function' ? (init as () => unknown)() : init,
+      setShowOnboarding,
+    ],
+    useCallback: (fn: unknown) => fn,
+  } as unknown as typeof import('react')
+  return { React, setShowOnboarding }
+}
+
+beforeEach(() => {
+  hasSeenOnboardingMock.mockReset()
+  markOnboardingSeenMock.mockReset()
+})
+
+describe('useOnboarding', () => {
+  it('shows the overlay on first launch (seen-marker absent)', () => {
+    hasSeenOnboardingMock.mockReturnValue(false)
+    const { React } = makeReact()
+    expect(useOnboarding(React).showOnboarding).toBe(true)
+  })
+
+  it('hides the overlay on later launches (seen-marker present)', () => {
+    hasSeenOnboardingMock.mockReturnValue(true)
+    const { React } = makeReact()
+    expect(useOnboarding(React).showOnboarding).toBe(false)
+  })
+
+  it('dismissOnboarding clears the overlay and persists the seen-marker', () => {
+    hasSeenOnboardingMock.mockReturnValue(false)
+    const { React, setShowOnboarding } = makeReact()
+
+    useOnboarding(React).dismissOnboarding()
+
+    expect(setShowOnboarding).toHaveBeenCalledWith(false)
+    expect(markOnboardingSeenMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/workstation/runtime/hooks/useOnboarding.ts
+++ b/src/workstation/runtime/hooks/useOnboarding.ts
@@ -1,0 +1,46 @@
+/**
+ * First-run onboarding overlay (extracted in the post-0.72 app.ts
+ * decomposition, item 4 / #1237; the feature itself is P1.3).
+ *
+ * This module bundles the first-launch overlay's show / dismiss / persistence
+ * into one unit, lifting it out of `app.ts`:
+ *   - `showOnboarding` — seeded once from `!hasSeenOnboarding()` (true on the
+ *     very first launch, before the seen-marker is written);
+ *   - `dismissOnboarding` — clears the overlay *and* writes the seen-marker via
+ *     `markOnboardingSeen()`, so the overlay never returns on later launches.
+ *
+ * The dismiss is wired into the input handler: the first keystroke after launch
+ * calls `dismissOnboarding()` (and swallows the key). Previously `app.ts` held
+ * the `useState` and passed `setShowOnboarding` + `markOnboardingSeen`
+ * separately into `useInputHandler`, which called both inline; folding them
+ * into `dismissOnboarding` keeps the two operations — `setShowOnboarding(false)`
+ * then `markOnboardingSeen()` — in the same order, so behavior is unchanged.
+ *
+ * `dismissOnboarding` is a stable `useCallback` (empty deps: the state setter
+ * and the module-level `markOnboardingSeen` are both stable), so the input
+ * handler sees a constant identity across renders.
+ *
+ * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
+ * convention) because the workstation never statically imports React.
+ */
+
+import type * as ReactTypes from 'react'
+import { hasSeenOnboarding, markOnboardingSeen } from '../../chrome/onboarding'
+
+/**
+ * Owns the first-run overlay state. Returns whether to render the overlay and
+ * a single `dismissOnboarding` that clears it and persists the seen-marker.
+ */
+export function useOnboarding(React: typeof ReactTypes): {
+  showOnboarding: boolean
+  dismissOnboarding: () => void
+} {
+  const [showOnboarding, setShowOnboarding] = React.useState<boolean>(
+    () => !hasSeenOnboarding(),
+  )
+  const dismissOnboarding = React.useCallback(() => {
+    setShowOnboarding(false)
+    markOnboardingSeen()
+  }, [])
+  return { showOnboarding, dismissOnboarding }
+}


### PR DESCRIPTION
## Item 4 — `app.ts` decomposition (#1237)

Bundles the first-launch onboarding overlay's show / dismiss / persistence into a new `useOnboarding` hook.

### What moved
- **`showOnboarding`** — the `useState`, seeded **verbatim** from `!hasSeenOnboarding()`.
- **`dismissOnboarding`** — a stable `useCallback` that clears the overlay and writes the seen-marker: `setShowOnboarding(false)` then `markOnboardingSeen()`, same order as the old inline code.

### Ripple into `useInputHandler`
The handler previously received `setShowOnboarding` + `markOnboardingSeen` and called both inline on the first keystroke. It now takes the single `dismissOnboarding` callback and calls it — same two operations, same order, behavior unchanged. This also removes the onboarding-persistence imports from `app.ts`.

### Changes
- New `hooks/useOnboarding.ts`.
- `app.ts`: `useState` → `useOnboarding(React)`; drop `hasSeenOnboarding`/`markOnboardingSeen` import; thread `dismissOnboarding` into the input handler.
- `useInputHandler.ts`: swap the two onboarding deps for `dismissOnboarding`; collapse the two inline calls.
- New `hooks/useOnboarding.test.ts` — seed (first launch vs returning) + dismiss (clears + persists).

### Validation
- `jest` (workstation): 111 suites / 1874 tests pass, 68 snapshots **no diffs**
- `tsc --noEmit`: clean · `eslint`: 0 errors · `rollup -c`: builds `dist/`