### PR TITLE
refactor(runtime): extract resume-repaint tick into useResumeTick (#1237)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -215,6 +215,7 @@ import {useStatusAutoDismiss} from './hooks/useStatusAutoDismiss'
 import {useHistoryCursorSync} from './hooks/useHistoryCursorSync'
 import {useHistoryPaginationState, useLoadMoreHistory} from './hooks/useLoadMoreHistory'
 import {useOnboarding} from './hooks/useOnboarding'
+import {useResumeTick} from './hooks/useResumeTick'
 import {useWorktreeStageActions} from './hooks/useWorktreeStageActions'
 import {useCommitComposeActions} from './hooks/useCommitComposeActions'
 import {useCommitSplitActions} from './hooks/useCommitSplitActions'
@@ -358,18 +359,11 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   )
   const { exit } = useApp()
   const windowSize = useWindowSize()
-  // Bumping this on SIGCONT forces the existing tree to repaint so users
-  // land on a drawn screen after `fg` instead of an empty alt buffer.
-  const [, setResumeTick] = React.useState(0)
-  React.useEffect(() => {
-    if (!resumeRef) {
-      return
-    }
-    resumeRef.current = () => setResumeTick((tick) => tick + 1)
-    return () => {
-      resumeRef.current = null
-    }
-  }, [resumeRef])
+  // Resume-repaint tick (SIGCONT → `fg`), owned by `useResumeTick` (app.ts
+  // decomposition item 5 / #1237). The throwaway `useState` and its effect are
+  // adjacent, so they move together into the hook at this exact slot; the
+  // effect wires `resumeRef.current` to a tick-bump that forces a repaint.
+  useResumeTick(React, {resumeRef})
   // First-launch onboarding (P1.3). Persisted via a marker file in the
   // user's cache dir so the tip never reappears once dismissed. Lazy
   // initializer so the fs check only runs on mount, not every render.

--- a/src/workstation/runtime/hooks/useResumeTick.test.ts
+++ b/src/workstation/runtime/hooks/useResumeTick.test.ts
@@ -1,0 +1,74 @@
+import { useResumeTick } from './useResumeTick'
+
+/**
+ * Tests for `useResumeTick` (app.ts decomposition item 5 / #1237). Driven
+ * through a fake-React harness to prove the verbatim contract:
+ *   - with a `resumeRef`, the effect installs a callback that bumps the tick
+ *     and nulls the ref on cleanup;
+ *   - the installed callback bumps the throwaway counter via the updater form;
+ *   - with no `resumeRef`, the hook is a no-op.
+ */
+
+type EffectFn = () => void | (() => void)
+
+function makeReact(): {
+  React: typeof import('react')
+  setResumeTick: jest.Mock
+  runEffect: () => void | (() => void)
+} {
+  const setResumeTick = jest.fn()
+  const effects: EffectFn[] = []
+  const React = {
+    useState: (init: unknown) => [init, setResumeTick],
+    useEffect: (fn: EffectFn) => {
+      effects.push(fn)
+    },
+  } as unknown as typeof import('react')
+  return {
+    React,
+    setResumeTick,
+    runEffect: () => {
+      if (effects.length !== 1) {
+        throw new Error(`expected exactly one effect, got ${effects.length}`)
+      }
+      return effects[0]()
+    },
+  }
+}
+
+describe('useResumeTick', () => {
+  it('installs a tick-bump into resumeRef and nulls it on cleanup', () => {
+    const resumeRef: { current: (() => void) | null } = { current: null }
+    const { React, runEffect } = makeReact()
+
+    useResumeTick(React, { resumeRef })
+    const cleanup = runEffect() as () => void
+
+    expect(typeof resumeRef.current).toBe('function')
+    cleanup()
+    expect(resumeRef.current).toBeNull()
+  })
+
+  it('the installed callback bumps the throwaway counter via the updater form', () => {
+    const resumeRef: { current: (() => void) | null } = { current: null }
+    const { React, setResumeTick, runEffect } = makeReact()
+
+    useResumeTick(React, { resumeRef })
+    runEffect()
+    resumeRef.current?.()
+
+    expect(setResumeTick).toHaveBeenCalledTimes(1)
+    const updater = setResumeTick.mock.calls[0][0] as (tick: number) => number
+    expect(updater(41)).toBe(42)
+  })
+
+  it('is a no-op when there is no resumeRef', () => {
+    const { React, setResumeTick, runEffect } = makeReact()
+
+    useResumeTick(React, { resumeRef: undefined })
+    const cleanup = runEffect()
+
+    expect(cleanup).toBeUndefined()
+    expect(setResumeTick).not.toHaveBeenCalled()
+  })
+})

--- a/src/workstation/runtime/hooks/useResumeTick.ts
+++ b/src/workstation/runtime/hooks/useResumeTick.ts
@@ -1,0 +1,61 @@
+/**
+ * Resume-repaint tick (extracted in the post-0.72 app.ts decomposition,
+ * item 5 / #1237).
+ *
+ * When the workstation is suspended (Ctrl-Z) and later resumed (`fg` →
+ * SIGCONT), the terminal comes back on the alternate screen buffer with
+ * nothing drawn — Ink doesn't repaint on its own, so the user lands on an
+ * empty screen. The runtime installs a resume callback into `resumeRef`; the
+ * SIGCONT handler invokes it, and this hook's callback bumps a throwaway
+ * counter to force the existing React tree to re-render (repaint).
+ *
+ * This module lifts the cluster — the throwaway `setResumeTick` `useState` and
+ * the effect that wires `resumeRef.current` to the tick-bump (and nulls it on
+ * cleanup) — out of `app.ts`. The `useState` and effect are **adjacent** in
+ * the original, with no intervening hooks, so they move together into one hook
+ * called at the original slot; hook order is preserved. The effect is
+ * reproduced verbatim — same `!resumeRef` guard, same
+ * `resumeRef.current = () => setResumeTick((tick) => tick + 1)` assignment,
+ * same cleanup, same `[resumeRef]` dependency array.
+ *
+ * `resumeRef` stays owned by the runtime (it is also read by the editor /
+ * compose / changelog action hooks to re-arm the screen after shelling out)
+ * and is passed in.
+ *
+ * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
+ * convention) because the workstation never statically imports React.
+ */
+
+import type * as ReactTypes from 'react'
+
+export type UseResumeTickDeps = {
+  /**
+   * The runtime's resume-callback slot. The SIGCONT handler calls
+   * `resumeRef.current?.()`; this hook points it at a tick-bump so the tree
+   * repaints. Optional — absent in non-interactive / test seams, in which
+   * case the hook is a no-op.
+   */
+  resumeRef?: ReactTypes.MutableRefObject<(() => void) | null>
+}
+
+/**
+ * Installs the resume-repaint callback into `resumeRef` and bumps a throwaway
+ * counter when invoked, forcing the React tree to repaint after `fg`.
+ */
+export function useResumeTick(
+  React: typeof ReactTypes,
+  deps: UseResumeTickDeps,
+): void {
+  const { resumeRef } = deps
+
+  const [, setResumeTick] = React.useState(0)
+  React.useEffect(() => {
+    if (!resumeRef) {
+      return
+    }
+    resumeRef.current = () => setResumeTick((tick) => tick + 1)
+    return () => {
+      resumeRef.current = null
+    }
+  }, [resumeRef])
+}


### PR DESCRIPTION
## Item 5 — `app.ts` decomposition (#1237)

Follows #1279. Lifts the SIGCONT resume-repaint cluster into a new `useResumeTick` hook.

### What & why
When the workstation is suspended (Ctrl-Z) and resumed (`fg` → SIGCONT), Ink comes back on the alternate screen buffer without repainting — the user lands on an empty screen. The runtime installs a resume callback into `resumeRef`; the SIGCONT handler invokes it, and this cluster's callback bumps a throwaway counter to force a re-render (repaint).

### Single combined hook (order-safe)
The throwaway `setResumeTick` `useState` and its effect are **adjacent** in `app.ts` with no intervening hooks, so they move together into one hook called at the original slot — hook order is preserved. The effect is reproduced **verbatim**: same `!resumeRef` guard, `resumeRef.current = () => setResumeTick((tick) => tick + 1)` assignment, cleanup, and `[resumeRef]` deps.

`resumeRef` stays runtime-owned (it's also read by the editor / compose / changelog action hooks to re-arm the screen after shelling out) and is passed in.

### Changes
- New `hooks/useResumeTick.ts`.
- `app.ts`: the `useState` + effect → `useResumeTick(React, {resumeRef})`.
- New `hooks/useResumeTick.test.ts` — install/cleanup, the tick-bump updater, and the no-`resumeRef` no-op.

### Validation
- `jest` (workstation): 112 suites / 1877 tests pass, 68 snapshots **no diffs**
- `tsc --noEmit`: clean · `eslint`: 0 errors · `rollup -c`: builds `dist/`