### PR TITLE
refactor(runtime): own remaining diff-hydration state in useDiffHydration (#1237)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -73,12 +73,10 @@ import {getForgeActions, getForgePullRequestOverview} from '../../git/forgeActio
 import {issueFilterForPreset, pullRequestFilterForPreset} from '../../git/triageFilterPresets'
 import {getStashCommitHashes, getStashOverview} from '../../git/stashData'
 import {getWorktreeOverview} from '../../git/statusData'
-import {WorktreeHunkOverview} from '../../git/statusHunks'
 import {getBisectStatus} from '../../git/bisectData'
 import {getReflogOverview} from '../../git/reflogData'
 import {getTagOverview} from '../../git/tagData'
 import {getWorktreeListOverview} from '../../git/worktreeData'
-import {WorktreeFileDiff} from '../../git/worktreeDiffData'
 
 
 async function safe<T>(promise: Promise<T>): Promise<T | undefined> {
@@ -204,7 +202,7 @@ import {useBisectCandidateHydration, useBisectCandidateState} from './hooks/useB
 import {useCommitDetailHydration, useCommitDetailState} from './hooks/useCommitDetailHydration'
 import {useContextHydration} from './hooks/useContextHydration'
 import {useBlameLoadingState, useDetailHydration} from './hooks/useDetailHydration'
-import {useCommitFilePreviewHydration, useCommitFilePreviewState, useCompareDiffHydration, useStashDiffHydration, useWorktreeDiffHydration, useWorktreeHunksHydration} from './hooks/useDiffHydration'
+import {useCommitFilePreviewHydration, useCommitFilePreviewState, useCompareDiffHydration, useCompareDiffState, useStashDiffHydration, useStashDiffState, useWorktreeDiffHydration, useWorktreeDiffState, useWorktreeHunksHydration, useWorktreeHunksState} from './hooks/useDiffHydration'
 import {useDiffSyntaxHighlight, useDiffSyntaxState} from './hooks/useDiffSyntaxHighlight'
 import {useIdleTip} from './hooks/useIdleTip'
 import {useRefreshWatcher} from './hooks/useRefreshWatcher'
@@ -514,12 +512,14 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // `useCommitFilePreviewHydration`, in its original position — a two-hook split
   // to preserve React hook ordering. See `useDiffHydration`'s header.
   const {filePreview, setFilePreview, filePreviewLoading, setFilePreviewLoading} = useCommitFilePreviewState(React)
-  const [worktreeDiff, setWorktreeDiff] = React.useState<WorktreeFileDiff | undefined>(undefined)
-  const [worktreeDiffLoading, setWorktreeDiffLoading] = React.useState(false)
-  const [worktreeHunks, setWorktreeHunks] = React.useState<WorktreeHunkOverview | undefined>(
-    undefined
-  )
-  const [worktreeHunksLoading, setWorktreeHunksLoading] = React.useState(false)
+  // Worktree diff / hunks hydration state, owned by `useWorktreeDiffState` /
+  // `useWorktreeHunksState` (app.ts decomposition #1237). The `setWorktreeDiff`
+  // / `setWorktreeHunks` setters are shared with the staging callbacks
+  // (`useWorktreeStageActions`), so the hooks own the slots and hand the values
+  // + setters back here; the consumer call sites are unchanged. See
+  // `useDiffHydration`'s header.
+  const {worktreeDiff, setWorktreeDiff, worktreeDiffLoading, setWorktreeDiffLoading} = useWorktreeDiffState(React)
+  const {worktreeHunks, setWorktreeHunks, worktreeHunksLoading, setWorktreeHunksLoading} = useWorktreeHunksState(React)
   // Syntax-highlight spans for the diff currently in view (#1117
   // follow-up). Owned by `useDiffSyntaxState` (app.ts decomposition item 2 /
   // #1237); the `useState` stays in this exact slot while the effect that
@@ -532,12 +532,10 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // with diffSource='stash'. Lines are stored as a flat string[] —
   // renderDiffSurface paints each line through diffLineProps so +/-
   // colors match the commit-diff path.
-  const [stashDiffLines, setStashDiffLines] = React.useState<string[] | undefined>(undefined)
-  const [stashDiffLoading, setStashDiffLoading] = React.useState(false)
+  const {stashDiffLines, setStashDiffLines, stashDiffLoading, setStashDiffLoading} = useStashDiffState(React)
   // #779 — compare-two-refs diff state. Loaded lazily when the diff
   // view becomes active with `diffSource === 'compare'`.
-  const [compareDiffLines, setCompareDiffLines] = React.useState<string[] | undefined>(undefined)
-  const [compareDiffLoading, setCompareDiffLoading] = React.useState(false)
+  const {compareDiffLines, setCompareDiffLines, compareDiffLoading, setCompareDiffLoading} = useCompareDiffState(React)
   // Load-more pagination state, owned by `useHistoryPaginationState` (app.ts
   // decomposition item 3 / #1237). The `useState` pair stays in this exact
   // slot; the setters are shared (the loader `useLoadMoreHistory` below plus

--- a/src/workstation/runtime/hooks/useDiffHydration.test.ts
+++ b/src/workstation/runtime/hooks/useDiffHydration.test.ts
@@ -1,8 +1,24 @@
 import {
   shouldLoadWorktreeDiff,
   useCommitFilePreviewState,
+  useCompareDiffState,
+  useStashDiffState,
+  useWorktreeDiffState,
+  useWorktreeHunksState,
 } from './useDiffHydration'
 import type { WorktreeFile } from '../../../git/statusData'
+
+/**
+ * Fake React whose `useState` runs the lazy initializer (if any) and returns a
+ * jest setter, so the state hooks can be exercised without a renderer.
+ */
+const fakeReact = () =>
+  ({
+    useState: (init: unknown) => [
+      typeof init === 'function' ? (init as () => unknown)() : init,
+      jest.fn(),
+    ],
+  }) as unknown as typeof import('react')
 
 /**
  * Unit tests for the pure `shouldLoadWorktreeDiff` core (0.72 app.ts
@@ -42,18 +58,58 @@ describe('shouldLoadWorktreeDiff', () => {
  */
 describe('useCommitFilePreviewState', () => {
   it('seeds filePreview undefined and filePreviewLoading false, exposing both setters', () => {
-    const React = {
-      useState: (init: unknown) => {
-        const value = typeof init === 'function' ? (init as () => unknown)() : init
-        return [value, jest.fn()]
-      },
-    } as unknown as typeof import('react')
-
-    const result = useCommitFilePreviewState(React)
+    const result = useCommitFilePreviewState(fakeReact())
 
     expect(result.filePreview).toBeUndefined()
     expect(result.filePreviewLoading).toBe(false)
     expect(typeof result.setFilePreview).toBe('function')
     expect(typeof result.setFilePreviewLoading).toBe('function')
+  })
+})
+
+/**
+ * The remaining diff-hydration state hooks (app.ts decomposition #1237) each
+ * own one `useState` pair and surface its values + setters. The setters for
+ * worktree-diff / worktree-hunks (staging) and compare (compare-reset effect)
+ * are shared, so app.ts threads them to multiple consumers — verified here only
+ * that each hook seeds empty and exposes both setters.
+ */
+describe('useStashDiffState', () => {
+  it('seeds lines undefined + loading false and exposes both setters', () => {
+    const result = useStashDiffState(fakeReact())
+    expect(result.stashDiffLines).toBeUndefined()
+    expect(result.stashDiffLoading).toBe(false)
+    expect(typeof result.setStashDiffLines).toBe('function')
+    expect(typeof result.setStashDiffLoading).toBe('function')
+  })
+})
+
+describe('useCompareDiffState', () => {
+  it('seeds lines undefined + loading false and exposes both setters', () => {
+    const result = useCompareDiffState(fakeReact())
+    expect(result.compareDiffLines).toBeUndefined()
+    expect(result.compareDiffLoading).toBe(false)
+    expect(typeof result.setCompareDiffLines).toBe('function')
+    expect(typeof result.setCompareDiffLoading).toBe('function')
+  })
+})
+
+describe('useWorktreeHunksState', () => {
+  it('seeds hunks undefined + loading false and exposes both setters', () => {
+    const result = useWorktreeHunksState(fakeReact())
+    expect(result.worktreeHunks).toBeUndefined()
+    expect(result.worktreeHunksLoading).toBe(false)
+    expect(typeof result.setWorktreeHunks).toBe('function')
+    expect(typeof result.setWorktreeHunksLoading).toBe('function')
+  })
+})
+
+describe('useWorktreeDiffState', () => {
+  it('seeds diff undefined + loading false and exposes both setters', () => {
+    const result = useWorktreeDiffState(fakeReact())
+    expect(result.worktreeDiff).toBeUndefined()
+    expect(result.worktreeDiffLoading).toBe(false)
+    expect(typeof result.setWorktreeDiff).toBe('function')
+    expect(typeof result.setWorktreeDiffLoading).toBe('function')
   })
 })

--- a/src/workstation/runtime/hooks/useDiffHydration.ts
+++ b/src/workstation/runtime/hooks/useDiffHydration.ts
@@ -45,19 +45,22 @@
  * exactly, this module exports *five* hooks, each called at its original
  * slot in `app.ts`. Order correctness wins over tidiness.
  *
- * Most dedicated `useState` slots stay in `app.ts` because their diff setters
- * are also called from staging callbacks (`toggleSelectedFileStage`, the
- * hunk-stage callbacks) and the compare-reset effect — they are not owned by
- * these loaders. Each hook is handed the setter(s) it needs.
- *
- * The **commit file-preview** slot is the exception: `setFilePreview` /
- * `setFilePreviewLoading` are written *only* by its loader, so that pair's
- * `useState` is owned here via {@link useCommitFilePreviewState} (app.ts
- * decomposition item 2 / #1237). It is a position-preserving split — the state
- * hook is called at the original `useState` slot near the top of `app.ts`, and
- * `useCommitFilePreviewHydration` (the effect) stays at its original slot far
- * below, handed the setters — mirroring the `useCommitDetailState` +
- * `useCommitDetailHydration` split (item 1a).
+ * State ownership. Each diff slot's `useState` is owned here by a dedicated
+ * *state hook* (`useStashDiffState`, `useCompareDiffState`,
+ * `useWorktreeHunksState`, `useWorktreeDiffState`, `useCommitFilePreviewState`),
+ * each called at the slot's original position near the top of `app.ts` so React
+ * hook order is preserved (a position-preserving split — the loaders stay at
+ * their own original slots far below). The state hook returns the value(s) +
+ * setter(s); `app.ts` threads them into the matching loader **and** into any
+ * other consumer that writes the setter:
+ *   - `setWorktreeDiff` / `setWorktreeHunks` are also called by the staging
+ *     callbacks (`useWorktreeStageActions`);
+ *   - `setCompareDiffLines` / `setCompareDiffLoading` are also called by the
+ *     compare-reset effect.
+ * Because the returned setters keep the same names, those consumer call sites
+ * are unchanged — only the bare `useState` declarations became hook calls
+ * (app.ts decomposition items 1a / 2 / #1237). Mirrors the `useCommitDetailState`
+ * + `useCommitDetailHydration` split (item 1a).
  *
  * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
  * convention) because the workstation never statically imports React.
@@ -106,6 +109,27 @@ export function shouldLoadWorktreeDiff(
   selectedWorktreeFile: WorktreeFile | undefined,
 ): boolean {
   return activeView === 'diff' && Boolean(selectedWorktreeFile)
+}
+
+/**
+ * Owns the stash-diff `useState` pair, in its original `app.ts` slot. Both
+ * setters are written only by {@link useStashDiffHydration}. Returns the
+ * values (read by the render) + setters (threaded into the loader). A
+ * position-preserving split; see the module header.
+ */
+export function useStashDiffState(React: typeof ReactTypes): {
+  stashDiffLines: string[] | undefined
+  setStashDiffLines: ReactTypes.Dispatch<
+    ReactTypes.SetStateAction<string[] | undefined>
+  >
+  stashDiffLoading: boolean
+  setStashDiffLoading: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
+} {
+  const [stashDiffLines, setStashDiffLines] = React.useState<
+    string[] | undefined
+  >(undefined)
+  const [stashDiffLoading, setStashDiffLoading] = React.useState(false)
+  return { stashDiffLines, setStashDiffLines, stashDiffLoading, setStashDiffLoading }
 }
 
 export type UseStashDiffHydrationDeps = {
@@ -157,6 +181,33 @@ export function useStashDiffHydration(
     })()
     return () => { active = false }
   }, [git, activeView, diffSource, stashDiffRef])
+}
+
+/**
+ * Owns the compare-diff `useState` pair, in its original `app.ts` slot. Both
+ * setters are shared — {@link useCompareDiffHydration} *and* the compare-reset
+ * effect in `app.ts` write them — so this hook owns the slots and returns the
+ * values + setters, which `app.ts` threads into both. A position-preserving
+ * split; see the module header.
+ */
+export function useCompareDiffState(React: typeof ReactTypes): {
+  compareDiffLines: string[] | undefined
+  setCompareDiffLines: ReactTypes.Dispatch<
+    ReactTypes.SetStateAction<string[] | undefined>
+  >
+  compareDiffLoading: boolean
+  setCompareDiffLoading: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
+} {
+  const [compareDiffLines, setCompareDiffLines] = React.useState<
+    string[] | undefined
+  >(undefined)
+  const [compareDiffLoading, setCompareDiffLoading] = React.useState(false)
+  return {
+    compareDiffLines,
+    setCompareDiffLines,
+    compareDiffLoading,
+    setCompareDiffLoading,
+  }
 }
 
 export type UseCompareDiffHydrationDeps = {
@@ -216,6 +267,34 @@ export function useCompareDiffHydration(
     })()
     return () => { active = false }
   }, [git, activeView, diffSource, compareBaseRef, compareHeadRef])
+}
+
+/**
+ * Owns the worktree-hunks `useState` pair, in its original `app.ts` slot.
+ * `setWorktreeHunks` is shared — {@link useWorktreeHunksHydration} *and* the
+ * staging callbacks (`useWorktreeStageActions`) write it — so this hook owns
+ * the slots and returns the values + setters, which `app.ts` threads into both.
+ * `setWorktreeHunksLoading` is loader-only. A position-preserving split; see
+ * the module header.
+ */
+export function useWorktreeHunksState(React: typeof ReactTypes): {
+  worktreeHunks: WorktreeHunkOverview | undefined
+  setWorktreeHunks: ReactTypes.Dispatch<
+    ReactTypes.SetStateAction<WorktreeHunkOverview | undefined>
+  >
+  worktreeHunksLoading: boolean
+  setWorktreeHunksLoading: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
+} {
+  const [worktreeHunks, setWorktreeHunks] = React.useState<
+    WorktreeHunkOverview | undefined
+  >(undefined)
+  const [worktreeHunksLoading, setWorktreeHunksLoading] = React.useState(false)
+  return {
+    worktreeHunks,
+    setWorktreeHunks,
+    worktreeHunksLoading,
+    setWorktreeHunksLoading,
+  }
 }
 
 export type UseWorktreeHunksHydrationDeps = {
@@ -280,6 +359,34 @@ export function useWorktreeHunksHydration(
     selectedWorktreeFile?.worktreeStatus,
     activeView,
   ])
+}
+
+/**
+ * Owns the worktree-file-diff `useState` pair, in its original `app.ts` slot.
+ * `setWorktreeDiff` is shared — {@link useWorktreeDiffHydration} *and* the
+ * staging callbacks (`useWorktreeStageActions`) write it — so this hook owns
+ * the slots and returns the values + setters, which `app.ts` threads into both.
+ * `setWorktreeDiffLoading` is loader-only. A position-preserving split; see the
+ * module header.
+ */
+export function useWorktreeDiffState(React: typeof ReactTypes): {
+  worktreeDiff: WorktreeFileDiff | undefined
+  setWorktreeDiff: ReactTypes.Dispatch<
+    ReactTypes.SetStateAction<WorktreeFileDiff | undefined>
+  >
+  worktreeDiffLoading: boolean
+  setWorktreeDiffLoading: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
+} {
+  const [worktreeDiff, setWorktreeDiff] = React.useState<
+    WorktreeFileDiff | undefined
+  >(undefined)
+  const [worktreeDiffLoading, setWorktreeDiffLoading] = React.useState(false)
+  return {
+    worktreeDiff,
+    setWorktreeDiff,
+    worktreeDiffLoading,
+    setWorktreeDiffLoading,
+  }
 }
 
 export type UseWorktreeDiffHydrationDeps = {


### PR DESCRIPTION
## `app.ts` decomposition (#1237) — the previously-"blocked" diff pairs

Completes the diff-hydration state-ownership moves. These four pairs were left in `app.ts` earlier because their setters are **shared**:

- `setWorktreeDiff` and `setWorktreeHunks` — also written by the staging callbacks (`useWorktreeStageActions`);
- `setCompareDiffLines` / `setCompareDiffLoading` — also written by the compare-reset effect.

### Shared setters aren't actually a blocker
The state-hook split (proven by `useHistoryPaginationState` in #1278) handles them: each pair gets a dedicated state hook — **`useWorktreeDiffState`**, **`useWorktreeHunksState`**, **`useStashDiffState`**, **`useCompareDiffState`** — called at its **original `useState` slot**, owning the slot and returning the value(s) + setter(s). Because the returned setters keep the same names, **every consumer call site is unchanged** (loaders, staging callbacks, compare-reset effect) — only the bare `useState` declarations became hook calls. No hook reordering.

`stashDiff` turned out clean (loader-only setters, like file-preview); worktree/compare are the genuinely-shared ones.

### Changes
- `useDiffHydration.ts`: four new state hooks; module header rewritten to describe per-slot ownership + which setters are shared.
- `app.ts`: four bare `useState` pairs → state-hook calls; drop now-unused `WorktreeFileDiff` / `WorktreeHunkOverview` imports.
- `useDiffHydration.test.ts`: seed tests for the four new hooks.

### Validation
- `jest` (workstation): 112 suites / 1881 tests pass, 68 snapshots **no diffs**
- `tsc --noEmit`: clean · `eslint`: 0 errors · `rollup -c`: builds `dist/`

After this, every diff/detail/pagination/onboarding/resume `useState` is owned by a hook; the remaining `app.ts` state is the core reducer state + theme/repo-stack. Item 6 (repo-stack `runtimes`) is next.