### PR TITLE
refactor(runtime): extract repo-stack runtimes into useRepoStackRuntimes (#1237)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -58,11 +58,9 @@ import {getLfsAttributeStatus} from '../../git/lfsAttributes'
 import {getSubmoduleOverview} from '../../git/submoduleData'
 import {getRemoteOverview} from '../../git/remoteData'
 import {LOG_INTERACTIVE_DEFAULT_LIMIT, buildToggleGraphArgs, getCommitRows, getLogRows} from '../../commands/log/data'
-import {LogInkContextKey, LogInkContextStatus, createLogInkContextStatus, updateLogInkContextStatus} from '../chrome/context'
+import {LogInkContextKey, createLogInkContextStatus, updateLogInkContextStatus} from '../chrome/context'
 import {createLogInkTheme, type LogInkThemePreset} from '../chrome/theme'
 import {saveThemePreset} from '../chrome/themePersistence'
-import {createInitialContextStatus, createRepoFrameRuntime} from './repoFrameFactory'
-import {getActiveRepoFrameRuntime, syncRepoStackRuntimes, updateRepoFrameRuntime, type RepoFrameRuntime, type RepoStackRuntimes} from './repoStackRuntime'
 import {PromotedSelectionsSnapshot, rectifyPromotedSelectionIndex} from '../chrome/selectionRectify'
 import {LOG_INK_DEFAULT_COLUMNS, LOG_INK_DEFAULT_ROWS, LOG_INK_MIN_COLUMNS, LOG_INK_MIN_ROWS, getLogInkLayout} from '../chrome/layout'
 import type { LogInkVisiblePane } from '../chrome/layout'
@@ -213,6 +211,7 @@ import {useStatusAutoDismiss} from './hooks/useStatusAutoDismiss'
 import {useHistoryCursorSync} from './hooks/useHistoryCursorSync'
 import {useHistoryPaginationState, useLoadMoreHistory} from './hooks/useLoadMoreHistory'
 import {useOnboarding} from './hooks/useOnboarding'
+import {useRepoStackRuntimes} from './hooks/useRepoStackRuntimes'
 import {useResumeTick} from './hooks/useResumeTick'
 import {useWorktreeStageActions} from './hooks/useWorktreeStageActions'
 import {useCommitComposeActions} from './hooks/useCommitComposeActions'
@@ -403,88 +402,21 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // cached entry so a drill-in / drill-out round trip doesn't re-pay
   // the context load cost. Seeded with a single root runtime against
   // the cwd `coco ui` was launched in.
-  const [runtimes, setRuntimes] = React.useState<RepoStackRuntimes>(() => [{
-    git: rootGit,
-    context: {},
-    contextStatus: createInitialContextStatus(),
-  }])
-  // Sync `runtimes` against the view-model stack on every push / pop.
-  // The sync is monotone — push appends a new runtime via the factory,
-  // pop slices off the top runtime; the parent's cached state survives.
-  // The factory is wrapped to capture `rootGit` so a defensively-pushed
-  // frame without a workdir still has a working `SimpleGit` bound.
-  React.useEffect(() => {
-    setRuntimes((prev) => {
-      const { runtimes: next } = syncRepoStackRuntimes(
-        prev,
-        state.repoStack,
-        (frame) => createRepoFrameRuntime(frame, rootGit),
-      )
-      return next
-    })
-  }, [state.repoStack, rootGit])
-  // Active-frame projection (#931). `git`, `context`, `contextStatus`
-  // — every existing closure / effect / surface reads these names; the
-  // only thing this PR changes is where they come from. When the user
-  // drills into a submodule, the top-of-stack runtime swaps, every
-  // dep array that lists `git` re-fires, and the loaders refetch
-  // against the submodule's working tree.
-  const activeRuntime: RepoFrameRuntime = getActiveRepoFrameRuntime(runtimes) ?? {
-    git: rootGit,
-    context: {},
-    contextStatus: createInitialContextStatus(),
-  }
-  const git = activeRuntime.git
-  const context = activeRuntime.context
-  const contextStatus = activeRuntime.contextStatus
-  // Wrappers that delegate to the active frame's runtime entry so the
-  // existing call sites stay byte-identical. Support both function-
-  // updater and value-updater forms (the codebase uses both).
-  //
-  // `targetDepth` (#994) routes the write to a specific frame instead
-  // of the currently-active one. Loaders that capture the depth at
-  // issue-time and pass it here are robust against frame-stack
-  // mutations (push / pop) that happen while the load is in flight —
-  // the write lands on the frame that issued it, or silently drops
-  // if that frame has been popped (`updateRepoFrameRuntime` no-ops on
-  // out-of-range indices). Without the tag, an in-flight refresh on
-  // the parent would clobber a freshly-pushed submodule frame.
-  const setContext = React.useCallback(
-    (
-      arg: LogInkContext | ((prev: LogInkContext) => LogInkContext),
-      targetDepth?: number,
-    ) => {
-      setRuntimes((prev) => {
-        const depth = targetDepth ?? prev.length - 1
-        if (depth < 0) return prev
-        return updateRepoFrameRuntime(prev, depth, (frame) => ({
-          ...frame,
-          context: typeof arg === 'function'
-            ? (arg as (p: LogInkContext) => LogInkContext)(frame.context)
-            : arg,
-        }))
-      })
-    },
-    [],
-  )
-  const setContextStatus = React.useCallback(
-    (
-      arg: LogInkContextStatus | ((prev: LogInkContextStatus) => LogInkContextStatus),
-      targetDepth?: number,
-    ) => {
-      setRuntimes((prev) => {
-        const depth = targetDepth ?? prev.length - 1
-        if (depth < 0) return prev
-        return updateRepoFrameRuntime(prev, depth, (frame) => ({
-          ...frame,
-          contextStatus: typeof arg === 'function'
-            ? (arg as (p: LogInkContextStatus) => LogInkContextStatus)(frame.contextStatus)
-            : arg,
-        }))
-      })
-    },
-    [],
-  )
+  // Repo-stack runtimes (#931 / #994), owned by `useRepoStackRuntimes` (app.ts
+  // decomposition item 6 / #1237). The contiguous cluster — the `runtimes`
+  // `useState`, the push/pop sync effect, the active-frame `git` / `context` /
+  // `contextStatus` projection, and the frame-tagged `setContext` /
+  // `setContextStatus` writers — moves wholesale into the hook at this exact
+  // slot, preserving React hook order. Every downstream consumer reads the same
+  // returned names, so nothing else changes. See the hook's header.
+  const {
+    runtimes,
+    git,
+    context,
+    contextStatus,
+    setContext,
+    setContextStatus,
+  } = useRepoStackRuntimes(React, {rootGit, repoStack: state.repoStack})
   // #931 PR 3b — Absolute repo root for the active frame's `git`.
   // Resolved asynchronously after every `git` swap (push / pop /
   // boot) so the commit-diff drill-in helper can construct absolute

--- a/src/workstation/runtime/hooks/useRepoStackRuntimes.test.ts
+++ b/src/workstation/runtime/hooks/useRepoStackRuntimes.test.ts
@@ -1,0 +1,131 @@
+import type { SimpleGit } from 'simple-git'
+import { createInitialContextStatus } from '../repoFrameFactory'
+import type { RepoFrameRuntime, RepoStackRuntimes } from '../repoStackRuntime'
+import type { LogInkContext } from '../types'
+import { useRepoStackRuntimes } from './useRepoStackRuntimes'
+
+/**
+ * Tests for `useRepoStackRuntimes` (app.ts decomposition item 6 / #1237).
+ * Driven through a fake-React harness (the sync effect is ignored — it is a
+ * verbatim lift of the separately-tested `syncRepoStackRuntimes`). Covers the
+ * seed projection and the frame-tagged `setContext` / `setContextStatus`
+ * writers, including `targetDepth` routing and the out-of-range guard.
+ */
+
+const rootGit = { __tag: 'rootGit' } as unknown as SimpleGit
+
+/** A fake frame runtime with a labelled git + given context. */
+const frame = (label: string, context: LogInkContext = {}): RepoFrameRuntime =>
+  ({
+    git: { __tag: label } as unknown as SimpleGit,
+    context,
+    contextStatus: createInitialContextStatus(),
+  })
+
+function makeReact(): {
+  React: typeof import('react')
+  setRuntimes: jest.Mock
+} {
+  const setRuntimes = jest.fn()
+  const React = {
+    useState: (init: unknown) => [
+      typeof init === 'function' ? (init as () => unknown)() : init,
+      setRuntimes,
+    ],
+    useEffect: () => {},
+    useCallback: (fn: unknown) => fn,
+  } as unknown as typeof import('react')
+  return { React, setRuntimes }
+}
+
+/** Apply the (function) updater the writer handed to setRuntimes. */
+const applyUpdater = (setRuntimes: jest.Mock, prev: RepoStackRuntimes) =>
+  (setRuntimes.mock.calls[0][0] as (p: RepoStackRuntimes) => RepoStackRuntimes)(prev)
+
+describe('useRepoStackRuntimes seed projection', () => {
+  it('seeds a single root frame and projects git/context/contextStatus off it', () => {
+    const { React } = makeReact()
+    const result = useRepoStackRuntimes(React, { rootGit, repoStack: [] })
+
+    expect(result.runtimes).toHaveLength(1)
+    expect(result.git).toBe(rootGit)
+    expect(result.context).toEqual({})
+    expect(result.contextStatus).toEqual(createInitialContextStatus())
+  })
+})
+
+describe('setContext', () => {
+  it('writes the active (top-of-stack) frame, leaving the others untouched', () => {
+    const { React, setRuntimes } = makeReact()
+    const { setContext } = useRepoStackRuntimes(React, { rootGit, repoStack: [] })
+
+    setContext({ pendingKey: 'branchList' } as unknown as LogInkContext)
+    const prev: RepoStackRuntimes = [frame('parent'), frame('child')]
+    const next = applyUpdater(setRuntimes, prev)
+
+    expect(next[1].context).toEqual({ pendingKey: 'branchList' })
+    expect(next[0]).toBe(prev[0])
+  })
+
+  it('supports the function-updater form against the active frame', () => {
+    const { React, setRuntimes } = makeReact()
+    const { setContext } = useRepoStackRuntimes(React, { rootGit, repoStack: [] })
+
+    setContext((prevContext) => ({ ...prevContext, pendingKey: 'tagList' }))
+    const prev: RepoStackRuntimes = [
+      frame('only', { pendingKey: 'stashList' } as unknown as LogInkContext),
+    ]
+    const next = applyUpdater(setRuntimes, prev)
+
+    expect(next[0].context).toEqual({ pendingKey: 'tagList' })
+  })
+
+  it('routes to a specific frame when targetDepth is given', () => {
+    const { React, setRuntimes } = makeReact()
+    const { setContext } = useRepoStackRuntimes(React, { rootGit, repoStack: [] })
+
+    setContext({ pendingKey: 'branchList' } as unknown as LogInkContext, 0)
+    const prev: RepoStackRuntimes = [frame('parent'), frame('child')]
+    const next = applyUpdater(setRuntimes, prev)
+
+    expect(next[0].context).toEqual({ pendingKey: 'branchList' })
+    expect(next[1]).toBe(prev[1])
+  })
+
+  it('no-ops on a negative depth (drops the write)', () => {
+    const { React, setRuntimes } = makeReact()
+    const { setContext } = useRepoStackRuntimes(React, { rootGit, repoStack: [] })
+
+    setContext({ pendingKey: 'branchList' } as unknown as LogInkContext, -1)
+    const prev: RepoStackRuntimes = [frame('parent')]
+    const next = applyUpdater(setRuntimes, prev)
+
+    expect(next).toBe(prev)
+  })
+
+  it('drops the write when targetDepth points at a popped (out-of-range) frame', () => {
+    const { React, setRuntimes } = makeReact()
+    const { setContext } = useRepoStackRuntimes(React, { rootGit, repoStack: [] })
+
+    setContext({ pendingKey: 'branchList' } as unknown as LogInkContext, 5)
+    const prev: RepoStackRuntimes = [frame('parent')]
+    const next = applyUpdater(setRuntimes, prev)
+
+    expect(next).toEqual(prev)
+    expect(next[0].context).toEqual(prev[0].context)
+  })
+})
+
+describe('setContextStatus', () => {
+  it('writes the active frame contextStatus via the function-updater form', () => {
+    const { React, setRuntimes } = makeReact()
+    const { setContextStatus } = useRepoStackRuntimes(React, { rootGit, repoStack: [] })
+
+    setContextStatus((prevStatus) => ({ ...prevStatus, branchList: 'loading' } as never))
+    const prev: RepoStackRuntimes = [frame('parent'), frame('child')]
+    const next = applyUpdater(setRuntimes, prev)
+
+    expect(next[1].contextStatus).toMatchObject({ branchList: 'loading' })
+    expect(next[0]).toBe(prev[0])
+  })
+})

--- a/src/workstation/runtime/hooks/useRepoStackRuntimes.ts
+++ b/src/workstation/runtime/hooks/useRepoStackRuntimes.ts
@@ -1,0 +1,178 @@
+/**
+ * Repo-stack runtimes — the multi-repo workspace foundation (extracted in the
+ * post-0.72 app.ts decomposition, item 6 / #1237; the feature itself is #931 /
+ * #994).
+ *
+ * This module lifts the entire repo-stack state cluster out of `app.ts`. It is
+ * the *root* state of the component: `git`, `context`, and `contextStatus` —
+ * read by virtually every loader, effect, and surface — are projections of the
+ * active (top-of-stack) frame, and `setContext` / `setContextStatus` are the
+ * frame-tagged writers every loader uses. The cluster is **contiguous** in
+ * `app.ts` (one `useState`, one sync effect, the active-frame projection, two
+ * `useCallback`s), so it moves wholesale into a single hook called at the
+ * original slot — React issues `useState → useEffect → useCallback →
+ * useCallback` in the exact same order, preserving hook order. Everything is
+ * reproduced **verbatim**; this is a behavior-preserving move, not a rewrite.
+ *
+ * What it owns:
+ *   - `runtimes` — the frame stack (`RepoStackRuntimes`), seeded with a single
+ *     root frame bound to `rootGit`;
+ *   - the sync effect — `syncRepoStackRuntimes(prev, repoStack, factory)` runs
+ *     on every push / pop (`[repoStack, rootGit]`): push appends a runtime via
+ *     the factory, pop slices the top off, the parent's cached state survives;
+ *   - the active-frame projection — `git` / `context` / `contextStatus` read
+ *     off `getActiveRepoFrameRuntime(runtimes)` (falling back to a root-bound
+ *     default), so a submodule drill-in swaps the top frame and every dep array
+ *     that lists `git` re-fires;
+ *   - `setContext` / `setContextStatus` — stable (`[]`) `useCallback`s that
+ *     delegate to the active frame's runtime via `updateRepoFrameRuntime`. The
+ *     optional `targetDepth` (#994) routes a write to a specific frame instead
+ *     of the active one, so a load that captured its depth at issue-time lands
+ *     on the frame that issued it — or silently drops if that frame was popped
+ *     (`updateRepoFrameRuntime` no-ops on out-of-range indices). Without the
+ *     tag, an in-flight refresh on the parent would clobber a freshly-pushed
+ *     submodule frame.
+ *
+ * `activeRuntime` stays internal — it is referenced only by the projection.
+ * The hook returns the names `app.ts` already used (`runtimes`, `git`,
+ * `context`, `contextStatus`, `setContext`, `setContextStatus`), so every
+ * downstream consumer (the ~30 `setContext` call sites, the `runtimes.length`
+ * frame-tag depth reads, the `git` / `context` readers) is unchanged.
+ *
+ * `React` is injected (per the runtime's `getLogInkRuntimeContext(React)`
+ * convention) because the workstation never statically imports React.
+ */
+
+import type * as ReactTypes from 'react'
+import type { SimpleGit } from 'simple-git'
+import type { LogInkContextStatus } from '../../chrome/context'
+import { createInitialContextStatus, createRepoFrameRuntime } from '../repoFrameFactory'
+import type { LogInkRepoFrame } from '../inkViewModel'
+import {
+  getActiveRepoFrameRuntime,
+  syncRepoStackRuntimes,
+  updateRepoFrameRuntime,
+  type RepoFrameRuntime,
+  type RepoStackRuntimes,
+} from '../repoStackRuntime'
+import type { LogInkContext } from '../types'
+
+/** Frame-tagged context writer — `setContext(next, targetDepth?)`. */
+export type SetContextFn = (
+  arg: LogInkContext | ((prev: LogInkContext) => LogInkContext),
+  targetDepth?: number,
+) => void
+
+/** Frame-tagged context-status writer — `setContextStatus(next, targetDepth?)`. */
+export type SetContextStatusFn = (
+  arg: LogInkContextStatus | ((prev: LogInkContextStatus) => LogInkContextStatus),
+  targetDepth?: number,
+) => void
+
+export type UseRepoStackRuntimesDeps = {
+  /** The root frame's `git` (the cwd `coco ui` launched in). */
+  rootGit: SimpleGit
+  /** `state.repoStack` — the view-model frame stack the runtimes sync against. */
+  repoStack: readonly LogInkRepoFrame[]
+}
+
+export type UseRepoStackRuntimesResult = {
+  /** The full frame stack — `runtimes.length` is the frame-tag depth. */
+  runtimes: RepoStackRuntimes
+  /** The active (top-of-stack) frame's `git`. */
+  git: SimpleGit
+  /** The active frame's loaded context. */
+  context: LogInkContext
+  /** The active frame's per-key load status. */
+  contextStatus: LogInkContextStatus
+  /** Frame-tagged context writer. */
+  setContext: SetContextFn
+  /** Frame-tagged context-status writer. */
+  setContextStatus: SetContextStatusFn
+}
+
+/**
+ * Owns the repo-stack runtimes cluster (see the module header). Verbatim lift
+ * of the contiguous `app.ts` block, called at its original slot.
+ */
+export function useRepoStackRuntimes(
+  React: typeof ReactTypes,
+  deps: UseRepoStackRuntimesDeps,
+): UseRepoStackRuntimesResult {
+  const { rootGit, repoStack } = deps
+
+  const [runtimes, setRuntimes] = React.useState<RepoStackRuntimes>(() => [{
+    git: rootGit,
+    context: {},
+    contextStatus: createInitialContextStatus(),
+  }])
+  // Sync `runtimes` against the view-model stack on every push / pop.
+  // The sync is monotone — push appends a new runtime via the factory,
+  // pop slices off the top runtime; the parent's cached state survives.
+  // The factory is wrapped to capture `rootGit` so a defensively-pushed
+  // frame without a workdir still has a working `SimpleGit` bound.
+  React.useEffect(() => {
+    setRuntimes((prev) => {
+      const { runtimes: next } = syncRepoStackRuntimes(
+        prev,
+        repoStack,
+        (frame) => createRepoFrameRuntime(frame, rootGit),
+      )
+      return next
+    })
+  }, [repoStack, rootGit])
+  // Active-frame projection (#931). `git`, `context`, `contextStatus`
+  // — every existing closure / effect / surface reads these names.
+  const activeRuntime: RepoFrameRuntime = getActiveRepoFrameRuntime(runtimes) ?? {
+    git: rootGit,
+    context: {},
+    contextStatus: createInitialContextStatus(),
+  }
+  const git = activeRuntime.git
+  const context = activeRuntime.context
+  const contextStatus = activeRuntime.contextStatus
+  // Wrappers that delegate to the active frame's runtime entry so the
+  // existing call sites stay byte-identical. Support both function-
+  // updater and value-updater forms (the codebase uses both).
+  //
+  // `targetDepth` (#994) routes the write to a specific frame instead
+  // of the currently-active one. Loaders that capture the depth at
+  // issue-time and pass it here are robust against frame-stack
+  // mutations (push / pop) that happen while the load is in flight —
+  // the write lands on the frame that issued it, or silently drops
+  // if that frame has been popped (`updateRepoFrameRuntime` no-ops on
+  // out-of-range indices). Without the tag, an in-flight refresh on
+  // the parent would clobber a freshly-pushed submodule frame.
+  const setContext = React.useCallback<SetContextFn>(
+    (arg, targetDepth) => {
+      setRuntimes((prev) => {
+        const depth = targetDepth ?? prev.length - 1
+        if (depth < 0) return prev
+        return updateRepoFrameRuntime(prev, depth, (frame) => ({
+          ...frame,
+          context: typeof arg === 'function'
+            ? (arg as (p: LogInkContext) => LogInkContext)(frame.context)
+            : arg,
+        }))
+      })
+    },
+    [],
+  )
+  const setContextStatus = React.useCallback<SetContextStatusFn>(
+    (arg, targetDepth) => {
+      setRuntimes((prev) => {
+        const depth = targetDepth ?? prev.length - 1
+        if (depth < 0) return prev
+        return updateRepoFrameRuntime(prev, depth, (frame) => ({
+          ...frame,
+          contextStatus: typeof arg === 'function'
+            ? (arg as (p: LogInkContextStatus) => LogInkContextStatus)(frame.contextStatus)
+            : arg,
+        }))
+      })
+    },
+    [],
+  )
+
+  return { runtimes, git, context, contextStatus, setContext, setContextStatus }
+}


### PR DESCRIPTION
## Item 6 — `app.ts` decomposition (#1237): the foundational repo-stack state

Lifts the entire repo-stack runtimes cluster — the *root* state of the component — into a new `useRepoStackRuntimes` hook. `git`, `context`, and `contextStatus` (read by virtually every loader, effect, and surface) are projections of the active frame, and `setContext` / `setContextStatus` are the frame-tagged writers every loader uses.

### Why this is low-risk despite the blast radius
The cluster is **contiguous** in `app.ts` (L406–487): one `useState`, one push/pop sync effect, the active-frame projection, two `useCallback` writers. So it moves wholesale into a single hook **called at the original slot** — React issues `useState → useEffect → useCallback → useCallback` in the exact same order, preserving hook order. Everything is reproduced **verbatim**.

The hook returns the names `app.ts` already used, so:
- the ~30 `setContext` / `setContextStatus` call sites,
- the ~15 `runtimes.length` frame-tag-depth reads,
- every `git` / `context` / `contextStatus` reader

are all **unchanged** — only L406–487 collapsed to one call. `activeRuntime` stays internal (referenced only by the projection).

### What moved
- `runtimes` `useState` (seeded with the root frame from `rootGit`).
- The sync effect: `syncRepoStackRuntimes(prev, repoStack, factory)` on `[repoStack, rootGit]`.
- `git` / `context` / `contextStatus` projection off `getActiveRepoFrameRuntime`.
- `setContext` / `setContextStatus` — stable `useCallback([])` writers with `targetDepth` (#994) routing via `updateRepoFrameRuntime`.

`app.ts` drops the now-unused `repoFrameFactory` / `repoStackRuntime` imports and the `LogInkContextStatus` type import.

### Validation
- **Full** `jest` suite: 288 suites / 3547 tests pass, **68 snapshots no diffs** — the state everything derives from moved without a single render diff.
- `tsc --noEmit`: clean (every `setContext` consumer is type-checked) · `eslint`: 0 errors · `rollup -c`: builds `dist/`.
- New `useRepoStackRuntimes.test.ts`: seed projection + frame-tagged writers (active-frame, function-updater, `targetDepth` routing, negative / out-of-range guards).

> ⚠️ CI can't exercise the live submodule **drill-in / drill-out** (push/pop) path. Recommend a manual `coco ui` smoke on a repo with a submodule before/after merge — see the manual validation checklist.

After this, `app.ts`'s remaining `useState` is essentially the core reducer state.