### PR TITLE
fix(workstation): clear loader loading flag on early-return bail

### DIFF
--- a/src/workstation/runtime/hooks/useCommitDetailHydration.test.ts
+++ b/src/workstation/runtime/hooks/useCommitDetailHydration.test.ts
@@ -80,7 +80,7 @@ describe('useCommitDetailState', () => {
 })
 
 describe('useCommitDetailHydration', () => {
-  it('resets detail to undefined and never fetches when no commit is cursored', async () => {
+  it('resets detail + loading to a clean state and never fetches when no commit is cursored', async () => {
     const setDetail = jest.fn()
     const setDetailLoading = jest.fn()
     const { React, runEffect } = makeReact()
@@ -95,7 +95,9 @@ describe('useCommitDetailHydration', () => {
     await flush()
 
     expect(setDetail).toHaveBeenCalledWith(undefined)
-    expect(setDetailLoading).not.toHaveBeenCalled()
+    // The bail must also clear the loading flag — otherwise a selection that
+    // clears mid-fetch leaves the inspector stuck on "Loading commit details…".
+    expect(setDetailLoading).toHaveBeenCalledWith(false)
     expect(getCommitDetailMock).not.toHaveBeenCalled()
   })
 

--- a/src/workstation/runtime/hooks/useCommitDetailHydration.ts
+++ b/src/workstation/runtime/hooks/useCommitDetailHydration.ts
@@ -111,6 +111,11 @@ export function useCommitDetailHydration(
     async function loadDetail(): Promise<void> {
       if (!selected) {
         setDetail(undefined)
+        // Reset the loading flag too: if the selection clears while a fetch is
+        // in flight, the cleanup flips `active` false so the in-flight branch
+        // below never runs `setDetailLoading(false)` — without this the
+        // inspector is left showing "Loading commit details…" indefinitely.
+        setDetailLoading(false)
         return
       }
 

--- a/src/workstation/runtime/hooks/useDiffHydration.test.ts
+++ b/src/workstation/runtime/hooks/useDiffHydration.test.ts
@@ -1,12 +1,31 @@
 import {
   shouldLoadWorktreeDiff,
+  useCommitFilePreviewHydration,
   useCommitFilePreviewState,
+  useCompareDiffHydration,
   useCompareDiffState,
+  useStashDiffHydration,
   useStashDiffState,
   useWorktreeDiffState,
   useWorktreeHunksState,
 } from './useDiffHydration'
 import type { WorktreeFile } from '../../../git/statusData'
+
+type EffectFn = () => void | (() => void)
+
+/** Fake React that records the single `useEffect` so the test can run it. */
+function effectReact(): {
+  React: typeof import('react')
+  runEffect: () => void | (() => void)
+} {
+  const effects: EffectFn[] = []
+  const React = {
+    useEffect: (fn: EffectFn) => {
+      effects.push(fn)
+    },
+  } as unknown as typeof import('react')
+  return { React, runEffect: () => effects[0]() }
+}
 
 /**
  * Fake React whose `useState` runs the lazy initializer (if any) and returns a
@@ -111,5 +130,63 @@ describe('useWorktreeDiffState', () => {
     expect(result.worktreeDiffLoading).toBe(false)
     expect(typeof result.setWorktreeDiff).toBe('function')
     expect(typeof result.setWorktreeDiffLoading).toBe('function')
+  })
+})
+
+/**
+ * Loader bail must clear the `*Loading` flag, not just return. If the view /
+ * selection changes away while a fetch is in flight, the effect cleanup flips
+ * `active` false so the in-flight branch never resets the flag — without the
+ * reset on the bail, the surface is left stuck on "Loading…". (No data fetch
+ * happens on the bail, so no data-layer mock is needed.)
+ */
+describe('loader bail clears its loading flag', () => {
+  const git = {} as never
+
+  it('stash: guard-fail bail resets setStashDiffLoading(false)', () => {
+    const setStashDiffLoading = jest.fn()
+    const { React, runEffect } = effectReact()
+    useStashDiffHydration(React, {
+      git,
+      activeView: 'history', // not 'diff' → guard fails
+      diffSource: 'stash',
+      stashDiffRef: 'stash@{0}',
+      setStashDiffLines: jest.fn(),
+      setStashDiffLoading,
+    })
+    runEffect()
+    expect(setStashDiffLoading).toHaveBeenCalledWith(false)
+  })
+
+  it('compare: guard-fail bail resets setCompareDiffLoading(false)', () => {
+    const setCompareDiffLoading = jest.fn()
+    const { React, runEffect } = effectReact()
+    useCompareDiffHydration(React, {
+      git,
+      activeView: 'diff',
+      diffSource: 'compare',
+      compareBaseRef: undefined, // missing ref → guard fails
+      compareHeadRef: 'HEAD',
+      setCompareDiffLines: jest.fn(),
+      setCompareDiffLoading,
+    })
+    runEffect()
+    expect(setCompareDiffLoading).toHaveBeenCalledWith(false)
+  })
+
+  it('commit file preview: no-selection bail resets setFilePreviewLoading(false)', () => {
+    const setFilePreview = jest.fn()
+    const setFilePreviewLoading = jest.fn()
+    const { React, runEffect } = effectReact()
+    useCommitFilePreviewHydration(React, {
+      git,
+      selected: undefined, // no commit → bail
+      selectedDetailFile: undefined,
+      setFilePreview,
+      setFilePreviewLoading,
+    })
+    runEffect()
+    expect(setFilePreview).toHaveBeenCalledWith(undefined)
+    expect(setFilePreviewLoading).toHaveBeenCalledWith(false)
   })
 })

--- a/src/workstation/runtime/hooks/useDiffHydration.ts
+++ b/src/workstation/runtime/hooks/useDiffHydration.ts
@@ -168,6 +168,11 @@ export function useStashDiffHydration(
 
   React.useEffect(() => {
     if (activeView !== 'diff' || diffSource !== 'stash' || !stashDiffRef) {
+      // Clear the loading flag on the guard-fail bail: if the view changes
+      // away from the stash diff while a fetch is in flight, the cleanup flips
+      // `active` false so the in-flight branch never resets it — without this
+      // the flag stays stuck `true`.
+      setStashDiffLoading(false)
       return
     }
     let active = true
@@ -254,6 +259,10 @@ export function useCompareDiffHydration(
       !compareBaseRef ||
       !compareHeadRef
     ) {
+      // Clear the loading flag on the guard-fail bail (see the stash loader):
+      // a view change while a compare fetch is in flight would otherwise leave
+      // it stuck `true`.
+      setCompareDiffLoading(false)
       return
     }
     let active = true
@@ -519,6 +528,10 @@ export function useCommitFilePreviewHydration(
     async function loadPreview(): Promise<void> {
       if (!selected || !selectedDetailFile) {
         setFilePreview(undefined)
+        // Reset the loading flag too (see the commit-detail loader): if the
+        // selection / file clears mid-fetch, the `active` guard suppresses the
+        // in-flight reset, leaving the preview stuck on "Loading…".
+        setFilePreviewLoading(false)
         return
       }
 


### PR DESCRIPTION
## A stuck "Loading…" state, found while auditing the #1237 decomposition

While reviewing the recently-extracted hydration hooks for regressions, an independent audit surfaced a **latent (pre-existing) bug**, not a refactor regression: four lazy loaders return from their bail without clearing their `*Loading` flag.

### The bug
The commit-detail, file-preview, stash-diff, and compare-diff loaders set `*Loading(true)` only after their guard passes, and reset it to `false` inside an `if (active) { … }` branch after the `await`. But their **bail** (no selection / guard fail) just `return`s. So:

1. A fetch is in flight → `*Loading` is `true`.
2. The selection (or active diff view) clears → effect cleanup flips `active` false; the new effect run hits the bail and returns.
3. The in-flight fetch resolves → its `if (active)` branch is skipped → `set*Loading(false)` never runs.
4. **`*Loading` is stuck `true`.**

For the commit-detail loader this is user-visible: `detail/index.ts` renders `'Loading commit details…'` whenever `loading` is true and `detail` is empty, so the inspector shows a permanent "Loading…" until the next selection. Low-frequency (needs the clear to land inside the fetch window) and self-healing, but a real glitch.

### The fix
Add `set*Loading(false)` to each bail — exactly what the **worktree-diff / worktree-hunks loaders already do** (this just brings the other four in line). No data fetch happens on the bail, and setting React state to its current value is a no-op, so already-bailing renders are unaffected.

### Changes
- `useCommitDetailHydration.ts`, `useDiffHydration.ts` (file-preview, stash, compare loaders): one-line loading reset on the bail.
- Tests: the commit-detail "no commit cursored" test now asserts the reset; new effect-harness tests cover the stash / compare / file-preview bails.

### Validation
- `jest` (workstation): 114 suites / 1895 tests pass, **68 snapshots no diffs** (the race isn't snapshot-exercised).
- `tsc --noEmit`: clean · `eslint`: 0 errors · `rollup -c`: builds `dist/`.