### PR TITLE
fix(init): write project config for the recommended .coco.json format

### DIFF
--- a/src/commands/init/handler.ts
+++ b/src/commands/init/handler.ts
@@ -238,8 +238,22 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
       await appendToGitConfig(configFilePath, config)
     } else if (configFilePath.endsWith('.env')) {
       await appendToEnvFile(configFilePath, config)
-    } else if (configFilePath.endsWith('.coco.config.json')) {
+    } else if (
+      // Both JSON project-config formats route to the same writer. The
+      // recommended `.coco.json` was previously missing here, so selecting it
+      // silently wrote nothing while still reporting "init successful". Check
+      // the more-specific legacy name first (`.coco.json` is a suffix of
+      // neither, so order is not strictly required, but keep it explicit).
+      configFilePath.endsWith('.coco.config.json') ||
+      configFilePath.endsWith('.coco.json')
+    ) {
       appendToProjectJsonConfig(configFilePath, config)
+    } else {
+      // Fail loud rather than silently no-op: any config-file type without a
+      // writer branch is a bug, and a silent skip here looks like success.
+      throw new Error(
+        `init: no config writer for "${configFilePath}" — this is a bug`,
+      )
     }
 
     // Persist the usage-stats choice to the global (per-machine) config.

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -171,6 +171,23 @@ describe('init command', () => {
     })
   })
 
+  it('writes project json config for the recommended .coco.json format', async () => {
+    // Regression: `.coco.json` (the recommended option) previously matched no
+    // write branch, so init reported success but persisted nothing.
+    jest.spyOn(questions, 'selectProjectConfigFileType').mockResolvedValue('.coco.json')
+    mockGetProjectConfigFilePath.mockResolvedValue('/repo/.coco.json')
+
+    await handler(createArgv({ scope: 'project' }), logger)
+
+    expect(mockAppendToProjectJsonConfig).toHaveBeenCalledWith(
+      '/repo/.coco.json',
+      expect.any(Object),
+    )
+    expect(logger.log).toHaveBeenCalledWith('\ninit successful! 🦾🤖🎉', {
+      color: 'green',
+    })
+  })
+
   it('writes env config when selected for a project config', async () => {
     jest.spyOn(questions, 'selectProjectConfigFileType').mockResolvedValue('.env')
     mockGetProjectConfigFilePath.mockResolvedValue('/repo/.env')


### PR DESCRIPTION
## Found while extending the 0.72.1 validation sweep

`coco init` (project scope) offers two JSON config formats:
- **`.coco.json` (recommended)**
- `.coco.config.json` (legacy)

…and the config *reader* (`lib/config/services/project.ts`) **prefers `.coco.json`**. But the init **write-dispatch** only handled `.gitconfig`, `.env`, and `.coco.config.json`:

```ts
if      (configFilePath.endsWith('.gitconfig'))        { … }
else if (configFilePath.endsWith('.env'))              { … }
else if (configFilePath.endsWith('.coco.config.json')) { appendToProjectJsonConfig(…) }
// no .coco.json branch, no else
```

So choosing the **recommended** `.coco.json` matched no branch → **nothing was written**, while init still printed `init successful! 🦾🤖🎉`. The user is left with no persisted config and no error.

### Fix
- Route **both** JSON formats (`.coco.json` and `.coco.config.json`) to `appendToProjectJsonConfig` (they're the same writer).
- Add a defensive `else` that **throws** on any unhandled config-file type, so a future format can't silently no-op behind a success message again.
- Regression test: selecting `.coco.json` now asserts `appendToProjectJsonConfig('/repo/.coco.json', …)` and the success log.

Pre-existing (the dispatch predates the 0.72.1 Ollama work), but reachable from the init flow and the *recommended* option was the broken one.

### Validation
- `jest` init suite 8/8 (incl. new regression) · `tsc --noEmit` clean · `eslint` 0 errors · `rollup -c` builds.