### PR TITLE
fix(models): correct o3/o3-mini typos and dedupe gpt-4.1 in OPEN_AI_MODELS

### DIFF
--- a/src/lib/langchain/constants.ts
+++ b/src/lib/langchain/constants.ts
@@ -6,7 +6,6 @@ export const OPEN_AI_MODELS = [
   'gpt-4o',
   'gpt-4o-mini',
   'gpt-4.1',
-  'gpt-4.1',
   'gpt-4.1-mini',
   'gpt-4.1-nano',
   'gpt-4-32k',
@@ -15,8 +14,8 @@ export const OPEN_AI_MODELS = [
   'gpt-3.5-turbo',
   'o1',
   'o1-mini',
-  '03-mini',
-  '03',
+  'o3-mini',
+  'o3',
   'o4-mini',
 ] as TiktokenModel[]
 

--- a/src/lib/langchain/modelValidity.test.ts
+++ b/src/lib/langchain/modelValidity.test.ts
@@ -18,6 +18,17 @@ describe('findModelOwner', () => {
     expect(findModelOwner('gpt-5-ultra-turbo')).toBeNull()
     expect(findModelOwner('dynamic')).toBeNull()
   })
+
+  it('recognizes the o-series reasoning models (regression: o3 typo)', () => {
+    // `OPEN_AI_MODELS` previously listed these as `'03'` / `'03-mini'` (zero,
+    // not the letter o), so the real models went unrecognized and the typo'd
+    // ids were offered in the init picker.
+    expect(findModelOwner('o3')).toBe('openai')
+    expect(findModelOwner('o3-mini')).toBe('openai')
+    expect(findModelOwner('o4-mini')).toBe('openai')
+    expect(findModelOwner('03')).toBeNull()
+    expect(findModelOwner('03-mini')).toBeNull()
+  })
 })
 
 describe('getDeprecatedReplacement', () => {


### PR DESCRIPTION
## Found while extending the 0.72.1 validation sweep

`OPEN_AI_MODELS` listed the o-series reasoning models as **`'03-mini'` / `'03'`** — digit **zero**, not the letter **o** — and duplicated `'gpt-4.1'`.

This array became load-bearing in #1272, feeding two paths:
- **`coco init` model picker** (`questions.ts:153,189`) → it **offered `03` / `03-mini`** as selectable models. Picking one writes a non-existent model id that the OpenAI API rejects at commit time.
- **Per-provider model validity** (`modelValidity.ts`) → the *real* `o3` / `o3-mini` were unrecognized (treated as unknown), so they got no provider-mismatch / deprecation coverage.

### Fix
- `'03-mini'` → `'o3-mini'`, `'03'` → `'o3'` (now consistent with the existing `o1` / `o1-mini` / `o4-mini`).
- Removed the duplicate `'gpt-4.1'`.
- Regression test: `findModelOwner('o3' | 'o3-mini')` → `'openai'`, and the typo'd `'03'` ids → `null`.

### Validation
- `jest` modelValidity 9/9 (incl. regression) + validation suite green · `tsc --noEmit` clean · `eslint` 0 errors · `rollup -c` builds.