### PR TITLE
chore(commit): broaden flag-alias guard; drop redundant CommitOptions casts

### DIFF
--- a/src/commands/commit/generateCommitDraft.ts
+++ b/src/commands/commit/generateCommitDraft.ts
@@ -486,9 +486,9 @@ export async function generateCommitDraft({
 
     const ticketId = extractTicketIdFromBranchName(branchName)
     const fullMessage = formatCommitMessage(commitMsg, {
-      append: argv.append as string | undefined,
+      append: argv.append,
       ticketId: ticketId || undefined,
-      appendTicket: argv.appendTicket as boolean | undefined,
+      appendTicket: argv.appendTicket,
     })
     lastDraft = fullMessage
 

--- a/src/commands/flagAliasConsistency.test.ts
+++ b/src/commands/flagAliasConsistency.test.ts
@@ -1,14 +1,54 @@
-import { options as commitOptions } from './commit/config'
-import { options as logOptions } from './log/config'
+import { options as amendOptions } from './amend/config'
 import { options as changelogOptions } from './changelog/config'
+import { options as commitOptions } from './commit/config'
+import { options as doctorOptions } from './doctor/config'
+import { options as initOptions } from './init/config'
+import { options as issuesOptions } from './issues/config'
+import { options as logOptions } from './log/config'
+import { options as prCreateOptions } from './prCreate/config'
+import { options as prsOptions } from './prs/config'
+import { options as recapOptions } from './recap/config'
+import { options as reviewOptions } from './review/config'
+import { options as uiOptions } from './ui/config'
+import { options as workspaceOptions } from './workspace/config'
 
 /**
- * Guards the short-flag reconciliation from #1245: the two letters that
- * previously meant different things across commands now resolve to one flag
- * each. `-t` is `--tag` (changelog) and `-c` is `--conventional` (commit); the
- * conflicting `commit --appendTicket -t` and `log --commit -c` aliases were
- * dropped (long forms remain).
+ * Guards short-flag consistency.
+ *
+ * 1. The #1245 reconciliation: the two letters that previously meant different
+ *    things across commands now resolve to one flag each — `-t` is `--tag`
+ *    (changelog) and `-c` is `--conventional` (commit); the conflicting
+ *    `commit --appendTicket -t` and `log --commit -c` aliases were dropped.
+ * 2. The structural invariant that prevents a yargs conflict: within any single
+ *    command, no single-letter alias may map to two different options. (Reusing
+ *    a letter across *different* commands is intentional — e.g. `-b` is `branch`
+ *    in some commands — and is deliberately NOT asserted here.)
  */
+
+/** Each command's option map, keyed by command name for clear failures. */
+const COMMAND_OPTIONS: Record<
+  string,
+  Record<string, { alias?: string | readonly string[] }>
+> = {
+  amend: amendOptions,
+  changelog: changelogOptions,
+  commit: commitOptions,
+  doctor: doctorOptions,
+  init: initOptions,
+  issues: issuesOptions,
+  log: logOptions,
+  prCreate: prCreateOptions,
+  prs: prsOptions,
+  recap: recapOptions,
+  review: reviewOptions,
+  ui: uiOptions,
+  workspace: workspaceOptions,
+}
+
+/** Normalize a yargs `alias` (string | string[] | undefined) to an array. */
+const toAliases = (alias: string | readonly string[] | undefined): string[] =>
+  alias == null ? [] : Array.isArray(alias) ? [...alias] : [alias as string]
+
 describe('short-flag alias consistency (#1245)', () => {
   it('reserves -t for changelog --tag only', () => {
     expect(changelogOptions.tag.alias).toBe('t')
@@ -19,4 +59,25 @@ describe('short-flag alias consistency (#1245)', () => {
     expect(commitOptions.conventional.alias).toBe('c')
     expect(logOptions.commit.alias).toBeUndefined()
   })
+})
+
+describe('no duplicate single-letter alias within a command', () => {
+  it.each(Object.entries(COMMAND_OPTIONS))(
+    '%s: each short flag maps to exactly one option',
+    (_command, options) => {
+      const optionsByLetter: Record<string, string[]> = {}
+      for (const [optionKey, def] of Object.entries(options)) {
+        for (const alias of toAliases(def.alias)) {
+          if (alias.length === 1) {
+            ;(optionsByLetter[alias] ??= []).push(optionKey)
+          }
+        }
+      }
+      // A letter claimed by >1 option in the same command is a yargs conflict.
+      const conflicts = Object.entries(optionsByLetter).filter(
+        ([, keys]) => keys.length > 1,
+      )
+      expect(conflicts).toEqual([])
+    },
+  )
 })


### PR DESCRIPTION
## Two low-priority cleanups from the 0.72.1 review

Both flagged during the review sweep as non-bugs worth tidying.

### 1. Broaden the flag-alias regression guard
`flagAliasConsistency.test.ts` only pinned the two reconciled flags from #1245. It now also asserts the **structural invariant** across **all 13 command option maps**: within any single command, no single-letter alias maps to two different options — the condition that makes yargs throw.

Cross-command letter reuse (e.g. `-b` meaning `branch` in some commands) is **intentional** and is deliberately *not* asserted. The new test passes today, confirming no command currently has a within-command short-flag collision.

### 2. Drop redundant `CommitOptions` casts
`generateCommitDraft.ts` cast `argv.append as string | undefined` / `argv.appendTicket as boolean | undefined`. Since #1268 added those fields to the `CommitOptions` interface, `argv` (typed `Arguments<CommitOptions>`) already carries the exact types — the whole point of that typing was to drop such casts (the handler already reads them un-cast). Removed.

### Validation
- `jest` flag-alias + full commit suite: 9 suites / 145 tests pass · `tsc --noEmit` clean · `eslint` 0 errors · `rollup -c` builds.