### PR TITLE
feat(models): refresh OpenAI + Gemini model lists (retire dead ids)

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -592,7 +592,11 @@
         "gpt-5-nano-2025-08-07",
         "gpt-5-mini",
         "gpt-5-mini-2025-08-07",
-        "gpt-5-chat-latest"
+        "gpt-5-chat-latest",
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.4-nano"
       ]
     },
     "OllamaModel": {
@@ -689,6 +693,8 @@
     "GeminiModel": {
       "type": "string",
       "enum": [
+        "gemini-3.5-flash",
+        "gemini-3.1-flash-lite",
         "gemini-2.5-pro",
         "gemini-2.5-flash",
         "gemini-2.5-flash-lite",

--- a/src/lib/langchain/constants.ts
+++ b/src/lib/langchain/constants.ts
@@ -1,21 +1,24 @@
 import { TiktokenModel } from '@langchain/openai'
 import { AnthropicModel, BedrockModel, GeminiModel, MistralModel } from './types'
 
+// gpt-4o and the gpt-4.1 family retired from the API in early 2026 (see
+// DEPRECATED_MODELS). The gpt-4 / o-series entries below are deprecated but
+// still served (shutting down late 2026); the gpt-5 family is current.
 export const OPEN_AI_MODELS = [
-  'gpt-4.5',
-  'gpt-4o',
+  // Current generation
+  'gpt-5.5',
+  'gpt-5.4',
+  'gpt-5.4-mini',
+  'gpt-5.4-nano',
+  // Still served (deprecated, retiring late 2026)
   'gpt-4o-mini',
-  'gpt-4.1',
-  'gpt-4.1-mini',
-  'gpt-4.1-nano',
-  'gpt-4-32k',
   'gpt-4-turbo',
   'gpt-4',
   'gpt-3.5-turbo',
+  'o3',
+  'o3-mini',
   'o1',
   'o1-mini',
-  'o3-mini',
-  'o3',
   'o4-mini',
 ] as TiktokenModel[]
 
@@ -37,15 +40,16 @@ export const ANTHROPIC_MODELS = [
   'claude-sonnet-4-5',
 ] as AnthropicModel[]
 
+// Gemini 1.5 and 2.0 shut down (404) in 2026 — see DEPRECATED_MODELS. Current
+// is the Gemini 3 (3.5 Flash / 3.1 Flash-Lite) + still-active 2.5 generation.
 export const GEMINI_MODELS = [
+  // Current generation
+  'gemini-3.5-flash',
+  'gemini-3.1-flash-lite',
+  // Still active
   'gemini-2.5-pro',
   'gemini-2.5-flash',
   'gemini-2.5-flash-lite',
-  'gemini-2.0-flash',
-  'gemini-2.0-flash-lite',
-  'gemini-1.5-pro',
-  'gemini-1.5-flash',
-  'gemini-1.5-flash-8b',
 ] as GeminiModel[]
 
 export const MISTRAL_MODELS = [

--- a/src/lib/langchain/modelValidity.test.ts
+++ b/src/lib/langchain/modelValidity.test.ts
@@ -6,7 +6,7 @@ import {
 
 describe('findModelOwner', () => {
   it('resolves a model to its closed-namespace provider', () => {
-    expect(findModelOwner('gpt-4o')).toBe('openai')
+    expect(findModelOwner('gpt-5.5')).toBe('openai')
     expect(findModelOwner('claude-sonnet-4-6')).toBe('anthropic')
     expect(findModelOwner('gemini-2.5-pro')).toBe('gemini')
     expect(findModelOwner('mistral-large-latest')).toBe('mistral')
@@ -33,22 +33,27 @@ describe('findModelOwner', () => {
 
 describe('getDeprecatedReplacement', () => {
   it('maps retired ids to a current replacement', () => {
-    expect(getDeprecatedReplacement('gpt-4-turbo-preview')).toBe('gpt-4o')
+    // gpt-4o / gpt-4.1 family retired → current gpt-5 generation.
+    expect(getDeprecatedReplacement('gpt-4-turbo-preview')).toBe('gpt-5.4-mini')
+    expect(getDeprecatedReplacement('gpt-4.1')).toBe('gpt-5.4-mini')
     // The whole pre-4.x Claude lineup retired → current first-party models.
     expect(getDeprecatedReplacement('claude-3-opus-20240229')).toBe('claude-opus-4-8')
     expect(getDeprecatedReplacement('claude-3-5-sonnet-latest')).toBe('claude-sonnet-4-6')
     expect(getDeprecatedReplacement('claude-sonnet-4-0')).toBe('claude-sonnet-4-6')
+    // Gemini 1.5 / 2.0 shut down → current 2.5 / 3.x generation.
+    expect(getDeprecatedReplacement('gemini-1.5-pro')).toBe('gemini-2.5-pro')
+    expect(getDeprecatedReplacement('gemini-2.0-flash')).toBe('gemini-2.5-flash')
   })
 
   it('returns undefined for current models', () => {
-    expect(getDeprecatedReplacement('gpt-4o')).toBeUndefined()
+    expect(getDeprecatedReplacement('gpt-5.5')).toBeUndefined()
   })
 })
 
 describe('detectProviderMismatch', () => {
   it('flags a model that belongs to a different provider', () => {
     expect(detectProviderMismatch('claude-sonnet-4-6', 'openai')).toBe('anthropic')
-    expect(detectProviderMismatch('gpt-4o', 'anthropic')).toBe('openai')
+    expect(detectProviderMismatch('gpt-5.5', 'anthropic')).toBe('openai')
     // a bedrock model under plain anthropic is a mismatch (owner: bedrock)
     expect(detectProviderMismatch('anthropic.claude-3-5-sonnet-20241022-v2:0', 'anthropic')).toBe(
       'bedrock',
@@ -56,12 +61,12 @@ describe('detectProviderMismatch', () => {
   })
 
   it('accepts a correctly-matched model', () => {
-    expect(detectProviderMismatch('gpt-4o', 'openai')).toBeNull()
+    expect(detectProviderMismatch('gpt-5.5', 'openai')).toBeNull()
     expect(detectProviderMismatch('claude-sonnet-4-6', 'anthropic')).toBeNull()
   })
 
   it('treats azure as sharing the OpenAI namespace', () => {
-    expect(detectProviderMismatch('gpt-4o', 'azure')).toBeNull()
+    expect(detectProviderMismatch('gpt-5.5', 'azure')).toBeNull()
   })
 
   it('never gates the dynamic sentinel, ollama, or unrecognized models', () => {
@@ -70,6 +75,6 @@ describe('detectProviderMismatch', () => {
     // a new/unlisted model for the right provider is NOT a definite mismatch
     expect(detectProviderMismatch('gpt-5-ultra-turbo', 'openai')).toBeNull()
     // even an openai model under ollama is left alone (open namespace)
-    expect(detectProviderMismatch('gpt-4o', 'ollama')).toBeNull()
+    expect(detectProviderMismatch('gpt-5.5', 'ollama')).toBeNull()
   })
 })

--- a/src/lib/langchain/modelValidity.ts
+++ b/src/lib/langchain/modelValidity.ts
@@ -20,12 +20,20 @@ import { LLMProvider } from './types'
  * command) so the runtime layer can reference the same list.
  */
 export const DEPRECATED_MODELS: Record<string, string> = {
-  'gpt-4-turbo-preview': 'gpt-4o',
-  'gpt-4-0125-preview': 'gpt-4o',
-  'gpt-4-1106-preview': 'gpt-4o',
-  'gpt-3.5-turbo-0125': 'gpt-4o-mini',
-  'gpt-3.5-turbo-1106': 'gpt-4o-mini',
-  'gpt-3.5-turbo-16k': 'gpt-4o-mini',
+  // OpenAI: gpt-4o and the gpt-4.1 family retired from the API in early 2026;
+  // the gpt-4-*-preview / gpt-3.5-turbo-* snapshots before them. Map to the
+  // current gpt-5 generation (the old gpt-4o target is itself retired now).
+  'gpt-4o': 'gpt-5.4-mini',
+  'gpt-4.5': 'gpt-5.5',
+  'gpt-4.1': 'gpt-5.4-mini',
+  'gpt-4.1-mini': 'gpt-5.4-mini',
+  'gpt-4.1-nano': 'gpt-5.4-nano',
+  'gpt-4-turbo-preview': 'gpt-5.4-mini',
+  'gpt-4-0125-preview': 'gpt-5.4-mini',
+  'gpt-4-1106-preview': 'gpt-5.4-mini',
+  'gpt-3.5-turbo-0125': 'gpt-5.4-nano',
+  'gpt-3.5-turbo-1106': 'gpt-5.4-nano',
+  'gpt-3.5-turbo-16k': 'gpt-5.4-nano',
   // The pre-4.x / 4.0 Claude lineup is retired (404 against the API). Map each
   // to its current first-party replacement so `coco doctor` and validation
   // steer users off a dead id instead of letting a request fail.
@@ -38,6 +46,12 @@ export const DEPRECATED_MODELS: Record<string, string> = {
   'claude-3-5-haiku-latest': 'claude-haiku-4-5',
   'claude-3-7-sonnet-latest': 'claude-sonnet-4-6',
   'claude-sonnet-4-0': 'claude-sonnet-4-6',
+  // Gemini 1.5 and 2.0 shut down (404) in 2026 → current 3.x / 2.5 generation.
+  'gemini-2.0-flash': 'gemini-2.5-flash',
+  'gemini-2.0-flash-lite': 'gemini-2.5-flash-lite',
+  'gemini-1.5-pro': 'gemini-2.5-pro',
+  'gemini-1.5-flash': 'gemini-2.5-flash',
+  'gemini-1.5-flash-8b': 'gemini-2.5-flash-lite',
 }
 
 /**

--- a/src/lib/langchain/types.ts
+++ b/src/lib/langchain/types.ts
@@ -14,10 +14,17 @@ export type DynamicModelPreference = 'cost' | 'balanced' | 'quality'
 
 export type OpenAIModel =
   | TiktokenModel
+  // Current generation
+  | 'gpt-5.5'
+  | 'gpt-5.4'
+  | 'gpt-5.4-mini'
+  | 'gpt-5.4-nano'
   | 'gpt-4o-mini'
+  // Retired — kept for back-compat config typing (dropped from OPEN_AI_MODELS,
+  // flagged via DEPRECATED_MODELS)
   | 'gpt-4o'
   | 'gpt-4.1'
-  | 'gpt-4.1-mini' 
+  | 'gpt-4.1-mini'
   | 'gpt-4.1-nano'
 
 export type AnthropicModel =
@@ -47,9 +54,14 @@ export type AnthropicModel =
   | 'claude-3-haiku-20240307'
 
 export type GeminiModel =
+  // Current generation
+  | 'gemini-3.5-flash'
+  | 'gemini-3.1-flash-lite'
   | 'gemini-2.5-pro'
   | 'gemini-2.5-flash'
   | 'gemini-2.5-flash-lite'
+  // Retired — kept for back-compat config typing (dropped from GEMINI_MODELS,
+  // flagged via DEPRECATED_MODELS)
   | 'gemini-2.0-flash'
   | 'gemini-2.0-flash-lite'
   | 'gemini-1.5-pro'

--- a/src/lib/langchain/utils.ts
+++ b/src/lib/langchain/utils.ts
@@ -122,7 +122,7 @@ export const DEFAULT_OPENAI_LLM_SERVICE: OpenAILLMService = {
   // tier is the right default for it; quality is on par for this
   // class of task. Users who want the older 4o-mini can still
   // override via service config.
-  model: 'gpt-4.1-nano',
+  model: 'gpt-5.4-nano',
   tokenLimit: 4096,
   temperature: 0.32,
   // Bumped 12 → 24 (#845, PR 3). The OpenAI fast tier comfortably

--- a/src/lib/langchain/utils/dynamicModels.test.ts
+++ b/src/lib/langchain/utils/dynamicModels.test.ts
@@ -42,12 +42,12 @@ const providerServices: Record<LLMProvider, LLMService> = {
 }
 const providerOverrides = {
   openai: {
-    summarize: 'gpt-4.1-nano',
-    largeDiff: 'gpt-4.1-mini',
+    summarize: 'gpt-5.4-nano',
+    largeDiff: 'gpt-5.4-mini',
   },
   azure: {
-    summarize: 'gpt-4.1-nano',
-    largeDiff: 'gpt-4.1-mini',
+    summarize: 'gpt-5.4-nano',
+    largeDiff: 'gpt-5.4-mini',
   },
   anthropic: {
     summarize: 'claude-haiku-4-5',
@@ -96,14 +96,14 @@ describe('dynamic model routing', () => {
   })
 
   it('uses provider defaults when model is dynamic', () => {
-    expect(resolveDynamicModel(baseConfig, 'summarize')).toBe('gpt-4.1-mini')
-    expect(resolveDynamicModel(baseConfig, 'review')).toBe('gpt-4.1')
+    expect(resolveDynamicModel(baseConfig, 'summarize')).toBe('gpt-5.4-mini')
+    expect(resolveDynamicModel(baseConfig, 'review')).toBe('gpt-5.4')
   })
 
   it.each([
-    ['openai', 'cost', 'gpt-4.1-nano', 'gpt-4.1-mini', 'gpt-4.1'] as const,
-    ['openai', 'balanced', 'gpt-4.1-mini', 'gpt-4.1-mini', 'gpt-4.1'] as const,
-    ['openai', 'quality', 'gpt-4.1-mini', 'gpt-4.1', 'gpt-4.1'] as const,
+    ['openai', 'cost', 'gpt-5.4-nano', 'gpt-5.4-mini', 'gpt-5.4'] as const,
+    ['openai', 'balanced', 'gpt-5.4-mini', 'gpt-5.4-mini', 'gpt-5.4'] as const,
+    ['openai', 'quality', 'gpt-5.4-mini', 'gpt-5.5', 'gpt-5.5'] as const,
     ['anthropic', 'cost', 'claude-haiku-4-5', 'claude-haiku-4-5', 'claude-sonnet-4-6'] as const,
     ['anthropic', 'balanced', 'claude-haiku-4-5', 'claude-sonnet-4-6', 'claude-opus-4-6'] as const,
     ['anthropic', 'quality', 'claude-sonnet-4-6', 'claude-opus-4-8', 'claude-opus-4-8'] as const,
@@ -130,15 +130,15 @@ describe('dynamic model routing', () => {
       service: {
         ...baseConfig.service,
         dynamicModels: {
-          summarize: 'gpt-4.1-nano',
-          commit: 'gpt-4o',
+          summarize: 'gpt-5.4-nano',
+          commit: 'gpt-5.5',
         },
       },
     } as Config
 
-    expect(resolveDynamicModel(config, 'summarize')).toBe('gpt-4.1-nano')
-    expect(resolveDynamicModel(config, 'commit')).toBe('gpt-4o')
-    expect(resolveDynamicModel(config, 'review')).toBe('gpt-4.1')
+    expect(resolveDynamicModel(config, 'summarize')).toBe('gpt-5.4-nano')
+    expect(resolveDynamicModel(config, 'commit')).toBe('gpt-5.5')
+    expect(resolveDynamicModel(config, 'review')).toBe('gpt-5.4')
   })
 
   it.each(['openai', 'anthropic', 'gemini', 'mistral', 'ollama'] as const)(
@@ -163,9 +163,9 @@ describe('dynamic model routing', () => {
   )
 
   it.each([
-    ['openai', 'cost', 'gpt-4.1-mini'] as const,
-    ['openai', 'balanced', 'gpt-4.1'] as const,
-    ['openai', 'quality', 'gpt-4.1'] as const,
+    ['openai', 'cost', 'gpt-5.4-mini'] as const,
+    ['openai', 'balanced', 'gpt-5.4'] as const,
+    ['openai', 'quality', 'gpt-5.5'] as const,
     ['anthropic', 'cost', 'claude-sonnet-4-6'] as const,
     ['anthropic', 'balanced', 'claude-opus-4-6'] as const,
     ['anthropic', 'quality', 'claude-opus-4-8'] as const,
@@ -195,14 +195,14 @@ describe('dynamic model routing', () => {
       },
     } as Config
 
-    expect(resolveDynamicModel(config, 'summarize')).toBe('gpt-4.1-nano')
+    expect(resolveDynamicModel(config, 'summarize')).toBe('gpt-5.4-nano')
   })
 
   it('returns a concrete service config for a task', () => {
     const service = resolveDynamicService(baseConfig, 'commit')
 
     expect(service.provider).toBe('openai')
-    expect(service.model).toBe('gpt-4.1-mini')
+    expect(service.model).toBe('gpt-5.4-mini')
   })
 
   it('rejects unknown dynamic task keys', () => {
@@ -211,7 +211,7 @@ describe('dynamic model routing', () => {
       service: {
         ...baseConfig.service,
         dynamicModels: {
-          unknownTask: 'gpt-4o',
+          unknownTask: 'gpt-5.5',
         },
       },
     } as unknown as Config

--- a/src/lib/langchain/utils/dynamicModels.ts
+++ b/src/lib/langchain/utils/dynamicModels.ts
@@ -11,40 +11,42 @@ import { LangChainConfigurationError } from '../errors'
 type ProviderDynamicDefaults = Record<DynamicModelPreference, Record<DynamicModelTask, LLMModel>>
 
 const OPENAI_DYNAMIC_DEFAULTS: ProviderDynamicDefaults = {
+  // The gpt-4.1 family retired from the API in early 2026 and now 404s.
+  // Re-pinned to the current gpt-5 generation (nano → mini → 5.4 → 5.5).
   cost: {
-    summarize: 'gpt-4.1-nano',
-    commit: 'gpt-4.1-mini',
+    summarize: 'gpt-5.4-nano',
+    commit: 'gpt-5.4-mini',
     // `commitSplit` floors at mini even in cost mode. The split
     // planner emits structured JSON with strict cross-group
     // constraints (files appear exactly once, hunks fully cover or
     // not at all). Nano-class models fail those constraints often
     // enough that the cost win is eaten by the 3-retry budget.
-    commitSplit: 'gpt-4.1-mini',
-    changelog: 'gpt-4.1-mini',
-    review: 'gpt-4.1-mini',
-    recap: 'gpt-4.1-nano',
-    repair: 'gpt-4.1-mini',
-    largeDiff: 'gpt-4.1',
+    commitSplit: 'gpt-5.4-mini',
+    changelog: 'gpt-5.4-mini',
+    review: 'gpt-5.4-mini',
+    recap: 'gpt-5.4-nano',
+    repair: 'gpt-5.4-mini',
+    largeDiff: 'gpt-5.4',
   },
   balanced: {
-    summarize: 'gpt-4.1-mini',
-    commit: 'gpt-4.1-mini',
-    commitSplit: 'gpt-4.1',
-    changelog: 'gpt-4.1',
-    review: 'gpt-4.1',
-    recap: 'gpt-4.1-mini',
-    repair: 'gpt-4.1',
-    largeDiff: 'gpt-4.1',
+    summarize: 'gpt-5.4-mini',
+    commit: 'gpt-5.4-mini',
+    commitSplit: 'gpt-5.4',
+    changelog: 'gpt-5.4',
+    review: 'gpt-5.4',
+    recap: 'gpt-5.4-mini',
+    repair: 'gpt-5.4',
+    largeDiff: 'gpt-5.4',
   },
   quality: {
-    summarize: 'gpt-4.1-mini',
-    commit: 'gpt-4.1',
-    commitSplit: 'gpt-4.1',
-    changelog: 'gpt-4.1',
-    review: 'gpt-4.1',
-    recap: 'gpt-4.1',
-    repair: 'gpt-4.1',
-    largeDiff: 'gpt-4.1',
+    summarize: 'gpt-5.4-mini',
+    commit: 'gpt-5.5',
+    commitSplit: 'gpt-5.5',
+    changelog: 'gpt-5.5',
+    review: 'gpt-5.5',
+    recap: 'gpt-5.5',
+    repair: 'gpt-5.5',
+    largeDiff: 'gpt-5.5',
   },
 }
 

--- a/src/lib/langchain/validation.test.ts
+++ b/src/lib/langchain/validation.test.ts
@@ -3,14 +3,14 @@ import { LangChainValidationError } from './errors'
 
 describe('validateModel (#1243 — per-provider validity)', () => {
   it('accepts a model that matches its provider', () => {
-    expect(() => validateModel('gpt-4o', 'openai')).not.toThrow()
+    expect(() => validateModel('gpt-5.5', 'openai')).not.toThrow()
     expect(() => validateModel('claude-sonnet-4-6', 'anthropic')).not.toThrow()
   })
 
   it('accepts the dynamic sentinel and open-namespace providers', () => {
     expect(() => validateModel('dynamic', 'openai')).not.toThrow()
     expect(() => validateModel('llama3.1:8b', 'ollama')).not.toThrow()
-    expect(() => validateModel('gpt-4o', 'azure')).not.toThrow() // azure shares openai ids
+    expect(() => validateModel('gpt-5.5', 'azure')).not.toThrow() // azure shares openai ids
   })
 
   it('accepts unrecognized / new models for the right provider', () => {
@@ -21,7 +21,7 @@ describe('validateModel (#1243 — per-provider validity)', () => {
     expect(() => validateModel('claude-sonnet-4-6', 'openai')).toThrow(
       LangChainValidationError,
     )
-    expect(() => validateModel('gpt-4o', 'anthropic')).toThrow(/is a openai model, not a anthropic/)
+    expect(() => validateModel('gpt-5.5', 'anthropic')).toThrow(/is a openai model, not a anthropic/)
   })
 
   it('still rejects empty / non-string models', () => {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -603,7 +603,11 @@ export const schema = {
         "gpt-5-nano-2025-08-07",
         "gpt-5-mini",
         "gpt-5-mini-2025-08-07",
-        "gpt-5-chat-latest"
+        "gpt-5-chat-latest",
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.4-nano"
       ]
     },
     "OllamaModel": {
@@ -700,6 +704,8 @@ export const schema = {
     "GeminiModel": {
       "type": "string",
       "enum": [
+        "gemini-3.5-flash",
+        "gemini-3.1-flash-lite",
         "gemini-2.5-pro",
         "gemini-2.5-flash",
         "gemini-2.5-flash-lite",


### PR DESCRIPTION
## Follow-up to #1288 — OpenAI + Gemini, web-verified

Same class of breakage as the Anthropic refresh, confirmed against each provider's **current model docs** (June 2026):

### OpenAI
- **`gpt-4o` and the entire `gpt-4.1` family retired** from the API in early 2026 (not on the [current models page](https://developers.openai.com/api/docs/models)). These were coco's **OpenAI dynamic-mode defaults** *and* the **default openai/azure service model** (`gpt-4.1-nano`) — so every default OpenAI path 404'd.
- `OPEN_AI_MODELS` now leads with the current **gpt-5 generation** (`gpt-5.5` / `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.4-nano`) and keeps the still-served-but-deprecated `gpt-4` / `o`-series (shutting down late 2026). Dropped the retired `gpt-4o` / `gpt-4.1*`.
- Dynamic defaults + default service model re-pinned to the gpt-5 generation.

### Gemini
- **Gemini 1.5 and 2.0 shut down (404)** in 2026 (1.5 retired; 2.0 Flash / Flash-Lite shut down June 1 2026 per the [models page](https://ai.google.dev/gemini-api/docs/models)). `GEMINI_MODELS` now leads with the current **Gemini 3** (`gemini-3.5-flash` / `gemini-3.1-flash-lite`) + still-active **2.5** family.
- Gemini dynamic defaults already used the 2.5 family → unaffected.

### Deprecated map + scope
- `DEPRECATED_MODELS` maps every retired OpenAI/Gemini id to a current replacement (the old `gpt-4o` targets were themselves retired now).
- Type unions keep retired ids for back-compat config typing.
- **Mistral** (auto-updating `-latest` aliases) and **Bedrock** (free-form `BedrockModel` ids, region-prefixed/uncertain format) left as-is — neither was broken in a way I could fix more accurately than leaving them.

### Validation
- Full `jest`: 289 suites / 3569 tests pass, 68 snapshots no diffs · `tsc --noEmit` clean · `eslint` 0 errors · `rollup -c` builds.

After this, coco's OpenAI / Anthropic / Gemini defaults all point at live, current models.