### PR TITLE
feat(models): refresh Claude-on-Bedrock ids to the current generation

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -725,12 +725,16 @@
         {
           "type": "string",
           "enum": [
+            "anthropic.claude-opus-4-8",
+            "anthropic.claude-opus-4-7",
+            "anthropic.claude-sonnet-4-6",
+            "anthropic.claude-haiku-4-5",
+            "meta.llama3-1-70b-instruct-v1:0",
+            "mistral.mistral-large-2407-v1:0",
             "anthropic.claude-3-5-sonnet-20241022-v2:0",
             "anthropic.claude-3-5-haiku-20241022-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "meta.llama3-1-70b-instruct-v1:0",
-            "mistral.mistral-large-2407-v1:0"
+            "anthropic.claude-3-haiku-20240307-v1:0"
           ]
         }
       ],

--- a/src/lib/langchain/constants.ts
+++ b/src/lib/langchain/constants.ts
@@ -62,11 +62,17 @@ export const MISTRAL_MODELS = [
   'open-mistral-nemo',
 ] as MistralModel[]
 
+// Picker suggestions only — `BedrockModel` accepts any string, since Bedrock
+// ids vary by region / inference-profile. The legacy `anthropic.claude-3-*` ids
+// mirrored first-party models that have since retired; bumped to the current
+// Claude generation on Bedrock (`anthropic.` prefix, no date/version suffix).
 export const BEDROCK_MODELS = [
-  'anthropic.claude-3-5-sonnet-20241022-v2:0',
-  'anthropic.claude-3-5-haiku-20241022-v1:0',
-  'anthropic.claude-sonnet-4-20250514-v1:0',
-  'anthropic.claude-3-haiku-20240307-v1:0',
+  // Current Claude generation
+  'anthropic.claude-opus-4-8',
+  'anthropic.claude-opus-4-7',
+  'anthropic.claude-sonnet-4-6',
+  'anthropic.claude-haiku-4-5',
+  // Other Bedrock foundation models
   'meta.llama3-1-70b-instruct-v1:0',
   'mistral.mistral-large-2407-v1:0',
 ] as BedrockModel[]

--- a/src/lib/langchain/modelValidity.test.ts
+++ b/src/lib/langchain/modelValidity.test.ts
@@ -10,7 +10,7 @@ describe('findModelOwner', () => {
     expect(findModelOwner('claude-sonnet-4-6')).toBe('anthropic')
     expect(findModelOwner('gemini-2.5-pro')).toBe('gemini')
     expect(findModelOwner('mistral-large-latest')).toBe('mistral')
-    expect(findModelOwner('anthropic.claude-3-5-sonnet-20241022-v2:0')).toBe('bedrock')
+    expect(findModelOwner('anthropic.claude-sonnet-4-6')).toBe('bedrock')
   })
 
   it('returns null for unrecognized / open-namespace models', () => {
@@ -55,7 +55,7 @@ describe('detectProviderMismatch', () => {
     expect(detectProviderMismatch('claude-sonnet-4-6', 'openai')).toBe('anthropic')
     expect(detectProviderMismatch('gpt-5.5', 'anthropic')).toBe('openai')
     // a bedrock model under plain anthropic is a mismatch (owner: bedrock)
-    expect(detectProviderMismatch('anthropic.claude-3-5-sonnet-20241022-v2:0', 'anthropic')).toBe(
+    expect(detectProviderMismatch('anthropic.claude-sonnet-4-6', 'anthropic')).toBe(
       'bedrock',
     )
   })

--- a/src/lib/langchain/modelValidity.ts
+++ b/src/lib/langchain/modelValidity.ts
@@ -52,6 +52,12 @@ export const DEPRECATED_MODELS: Record<string, string> = {
   'gemini-1.5-pro': 'gemini-2.5-pro',
   'gemini-1.5-flash': 'gemini-2.5-flash',
   'gemini-1.5-flash-8b': 'gemini-2.5-flash-lite',
+  // Claude-on-Bedrock: the claude-3-5 / sonnet-4-0 ids mirror retired
+  // first-party models → current Claude generation on Bedrock.
+  'anthropic.claude-3-5-sonnet-20241022-v2:0': 'anthropic.claude-sonnet-4-6',
+  'anthropic.claude-3-5-haiku-20241022-v1:0': 'anthropic.claude-haiku-4-5',
+  'anthropic.claude-3-haiku-20240307-v1:0': 'anthropic.claude-haiku-4-5',
+  'anthropic.claude-sonnet-4-20250514-v1:0': 'anthropic.claude-sonnet-4-6',
 }
 
 /**

--- a/src/lib/langchain/types.ts
+++ b/src/lib/langchain/types.ts
@@ -149,12 +149,20 @@ export type OllamaModel =
  * `(string & {})` preserves the literal union members of the other providers.
  */
 export type BedrockModel =
+  // Current Claude generation on Bedrock
+  | 'anthropic.claude-opus-4-8'
+  | 'anthropic.claude-opus-4-7'
+  | 'anthropic.claude-sonnet-4-6'
+  | 'anthropic.claude-haiku-4-5'
+  // Other foundation models
+  | 'meta.llama3-1-70b-instruct-v1:0'
+  | 'mistral.mistral-large-2407-v1:0'
+  // Retired Claude-on-Bedrock — kept for back-compat suggestions, flagged via
+  // DEPRECATED_MODELS
   | 'anthropic.claude-3-5-sonnet-20241022-v2:0'
   | 'anthropic.claude-3-5-haiku-20241022-v1:0'
   | 'anthropic.claude-sonnet-4-20250514-v1:0'
   | 'anthropic.claude-3-haiku-20240307-v1:0'
-  | 'meta.llama3-1-70b-instruct-v1:0'
-  | 'mistral.mistral-large-2407-v1:0'
   // eslint-disable-next-line @typescript-eslint/ban-types
   | (string & {})
 

--- a/src/lib/langchain/utils.ts
+++ b/src/lib/langchain/utils.ts
@@ -219,7 +219,9 @@ export const DEFAULT_AZURE_LLM_SERVICE: AzureLLMService = {
 
 export const DEFAULT_BEDROCK_LLM_SERVICE: BedrockLLMService = {
   provider: 'bedrock',
-  model: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+  // claude-3-5-sonnet on Bedrock mirrored a now-retired first-party model;
+  // default to the current fast tier (Haiku 4.5) for diff summarization.
+  model: 'anthropic.claude-haiku-4-5',
   region: 'us-east-1',
   maxConcurrent: 8,
   tokenLimit: 4096,

--- a/src/lib/langchain/utils/dynamicModels.ts
+++ b/src/lib/langchain/utils/dynamicModels.ts
@@ -156,36 +156,39 @@ const MISTRAL_DYNAMIC_DEFAULTS: ProviderDynamicDefaults = {
 }
 
 const BEDROCK_DYNAMIC_DEFAULTS: ProviderDynamicDefaults = {
+  // The claude-3-5 / sonnet-4-0 Bedrock ids mirrored first-party models that
+  // retired in 2025–2026. Re-pinned to the current Claude generation on Bedrock
+  // (Haiku 4.5 → Sonnet 4.6 → Opus 4.7 balanced / 4.8 quality).
   cost: {
-    summarize: 'anthropic.claude-3-5-haiku-20241022-v1:0',
-    commit: 'anthropic.claude-3-5-haiku-20241022-v1:0',
+    summarize: 'anthropic.claude-haiku-4-5',
+    commit: 'anthropic.claude-haiku-4-5',
     // Floor at sonnet — see note on OpenAI commitSplit above.
-    commitSplit: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
-    changelog: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
-    review: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
-    recap: 'anthropic.claude-3-5-haiku-20241022-v1:0',
-    repair: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
-    largeDiff: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+    commitSplit: 'anthropic.claude-sonnet-4-6',
+    changelog: 'anthropic.claude-sonnet-4-6',
+    review: 'anthropic.claude-sonnet-4-6',
+    recap: 'anthropic.claude-haiku-4-5',
+    repair: 'anthropic.claude-sonnet-4-6',
+    largeDiff: 'anthropic.claude-sonnet-4-6',
   },
   balanced: {
-    summarize: 'anthropic.claude-3-5-haiku-20241022-v1:0',
-    commit: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
-    commitSplit: 'anthropic.claude-sonnet-4-20250514-v1:0',
-    changelog: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
-    review: 'anthropic.claude-sonnet-4-20250514-v1:0',
-    recap: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
-    repair: 'anthropic.claude-sonnet-4-20250514-v1:0',
-    largeDiff: 'anthropic.claude-sonnet-4-20250514-v1:0',
+    summarize: 'anthropic.claude-haiku-4-5',
+    commit: 'anthropic.claude-sonnet-4-6',
+    commitSplit: 'anthropic.claude-opus-4-7',
+    changelog: 'anthropic.claude-sonnet-4-6',
+    review: 'anthropic.claude-opus-4-7',
+    recap: 'anthropic.claude-sonnet-4-6',
+    repair: 'anthropic.claude-opus-4-7',
+    largeDiff: 'anthropic.claude-opus-4-7',
   },
   quality: {
-    summarize: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
-    commit: 'anthropic.claude-sonnet-4-20250514-v1:0',
-    commitSplit: 'anthropic.claude-sonnet-4-20250514-v1:0',
-    changelog: 'anthropic.claude-sonnet-4-20250514-v1:0',
-    review: 'anthropic.claude-sonnet-4-20250514-v1:0',
-    recap: 'anthropic.claude-sonnet-4-20250514-v1:0',
-    repair: 'anthropic.claude-sonnet-4-20250514-v1:0',
-    largeDiff: 'anthropic.claude-sonnet-4-20250514-v1:0',
+    summarize: 'anthropic.claude-sonnet-4-6',
+    commit: 'anthropic.claude-opus-4-8',
+    commitSplit: 'anthropic.claude-opus-4-8',
+    changelog: 'anthropic.claude-opus-4-8',
+    review: 'anthropic.claude-opus-4-8',
+    recap: 'anthropic.claude-opus-4-8',
+    repair: 'anthropic.claude-opus-4-8',
+    largeDiff: 'anthropic.claude-opus-4-8',
   },
 }
 

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -736,12 +736,16 @@ export const schema = {
         {
           "type": "string",
           "enum": [
+            "anthropic.claude-opus-4-8",
+            "anthropic.claude-opus-4-7",
+            "anthropic.claude-sonnet-4-6",
+            "anthropic.claude-haiku-4-5",
+            "meta.llama3-1-70b-instruct-v1:0",
+            "mistral.mistral-large-2407-v1:0",
             "anthropic.claude-3-5-sonnet-20241022-v2:0",
             "anthropic.claude-3-5-haiku-20241022-v1:0",
             "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "meta.llama3-1-70b-instruct-v1:0",
-            "mistral.mistral-large-2407-v1:0"
+            "anthropic.claude-3-haiku-20240307-v1:0"
           ]
         }
       ],


### PR DESCRIPTION
## Final provider in the model refresh

Completes the sweep (after #1288 Anthropic, #1289 OpenAI + Gemini). coco's Bedrock suggestions, **dynamic defaults**, and **default service model** all used the legacy `anthropic.claude-3-5-*` / `claude-sonnet-4-20250514` ids — which mirror first-party Claude models that have since retired.

Re-pinned to the current Claude generation on Bedrock using the documented `anthropic.claude-<model>` id form (Opus 4.8 / 4.7, Sonnet 4.6, Haiku 4.5):
- `BEDROCK_MODELS` picker suggestions + `BedrockModel` union (retired ids kept in the union for back-compat — it accepts any string anyway).
- `BEDROCK_DYNAMIC_DEFAULTS` (Haiku 4.5 → Sonnet 4.6 → Opus 4.7/4.8) and the **default Bedrock service model** (→ Haiku 4.5).
- `DEPRECATED_MODELS` maps the retired Bedrock ids to their current replacement.

### Caveat (as discussed)
Bedrock ids are **free-form** and vary by region / inference-profile (some setups use a `global.`/`us.` prefix or an inference-profile ARN). `BedrockModel` accepts any string, so these are *reasonable defaults/suggestions* — users override with whatever their region/profile requires. This is the "reasonable default" pass, not an exhaustive per-region matrix.

### Validation
- Full `jest`: 289 suites / 3569 tests pass, 68 snapshots no diffs · `tsc --noEmit` clean · `eslint` 0 errors · `rollup -c` builds.

After this, **all five closed-namespace providers** (OpenAI, Anthropic, Gemini, Bedrock) point their defaults at current models; Mistral uses auto-updating `-latest` aliases.