### PR TITLE
refactor(runtime): foundation for surface-context migration (#1237)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -1605,6 +1605,9 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     theme,
     layout,
     context,
+    contextStatus,
+    h,
+    components: { Box, Text },
   }
 
   if (layout.tooSmall) {

--- a/src/workstation/runtime/header.test.ts
+++ b/src/workstation/runtime/header.test.ts
@@ -24,6 +24,7 @@
  */
 import { createElement, type ReactElement } from 'react'
 import * as React from 'react'
+import { createLogInkContextStatus } from '../chrome/context'
 import { getLogInkLayout } from '../chrome/layout'
 import { createLogInkTheme } from '../chrome/theme'
 import { createLogInkState } from '../../workstation/runtime/inkViewModel'
@@ -70,6 +71,11 @@ function makeRuntimeValue(
     // fallback path — we want the per-chip labels in the output.
     layout: getLogInkLayout({ columns: 160, rows: 40 }),
     context,
+    // The header doesn't read these, but the runtime context value now
+    // also carries them (#1237 surface migration) so the type requires them.
+    contextStatus: createLogInkContextStatus('idle'),
+    h: createElement,
+    components: { Box, Text },
     ...overrides,
   }
 }

--- a/src/workstation/runtime/runtimeContext.test.ts
+++ b/src/workstation/runtime/runtimeContext.test.ts
@@ -12,7 +12,18 @@
  * provider-presence contract is exercised once a real consumer lands.
  */
 import * as React from 'react'
-import { getLogInkRuntimeContext } from './runtimeContext'
+import type { LogInkContextStatus } from '../chrome/context'
+import type { LogInkLayout } from '../chrome/layout'
+import type { LogInkTheme } from '../chrome/theme'
+import type { LogInkState } from './inkViewModel'
+import type { LogInkComponents, LogInkContext, SurfaceRenderContext } from './types'
+import {
+  defineSurfaceComponent,
+  getLogInkRuntimeContext,
+  useLogInkRuntime,
+  useSurfaceRenderContext,
+  type LogInkRuntimeContextValue,
+} from './runtimeContext'
 
 describe('getLogInkRuntimeContext', () => {
   it('returns a stable, shared context identity across calls', () => {
@@ -28,5 +39,108 @@ describe('getLogInkRuntimeContext', () => {
     expect(context.displayName).toBe('LogInkRuntimeContext')
     expect(context.Provider).toBeDefined()
     expect(context.Consumer).toBeDefined()
+  })
+})
+
+/**
+ * Renderer-free fake-React harness (mirrors the surface/hook test pattern).
+ * `useContext` is stubbed to return a fixed value so we can exercise the
+ * consumer hooks without pulling in a React renderer the workstation suite
+ * doesn't bundle. `createContext` returns a throwaway — the real factory's
+ * cached identity is covered above; here we only care about the read path.
+ */
+function makeReact(value: LogInkRuntimeContextValue | null): typeof React {
+  return {
+    createContext: () => ({ displayName: '' }),
+    useContext: () => value,
+  } as unknown as typeof React
+}
+
+/** Sentinel values; the hooks pass these through, so identity is asserted. */
+function makeRuntimeValue(): LogInkRuntimeContextValue {
+  const h = (() => null) as unknown as typeof React.createElement
+  const components = { Box: () => null, Text: () => null } as unknown as LogInkComponents
+  return {
+    state: { sentinel: 'state' } as unknown as LogInkState,
+    dispatch: jest.fn(),
+    theme: { sentinel: 'theme' } as unknown as LogInkTheme,
+    layout: { bodyRows: 30, mainPanelWidth: 80, detailWidth: 40 } as unknown as LogInkLayout,
+    context: { sentinel: 'context' } as unknown as LogInkContext,
+    contextStatus: { sentinel: 'status' } as unknown as LogInkContextStatus,
+    h,
+    components,
+  }
+}
+
+describe('useLogInkRuntime', () => {
+  it('returns the context value when provided', () => {
+    const value = makeRuntimeValue()
+    expect(useLogInkRuntime(makeReact(value))).toBe(value)
+  })
+
+  it('throws outside a provider (null context value)', () => {
+    expect(() => useLogInkRuntime(makeReact(null))).toThrow(
+      /must be called inside a LogInkRuntimeContext provider/
+    )
+  })
+})
+
+describe('useSurfaceRenderContext', () => {
+  it('rebuilds the SurfaceRenderContext, passing core values through by identity', () => {
+    const value = makeRuntimeValue()
+    const ctx = useSurfaceRenderContext(makeReact(value), 'main')
+    expect(ctx.h).toBe(value.h)
+    expect(ctx.components).toBe(value.components)
+    expect(ctx.state).toBe(value.state)
+    expect(ctx.context).toBe(value.context)
+    expect(ctx.contextStatus).toBe(value.contextStatus)
+    expect(ctx.theme).toBe(value.theme)
+    expect(ctx.bodyRows).toBe(30)
+  })
+
+  it('selects the main-panel width for the main panel', () => {
+    const ctx = useSurfaceRenderContext(makeReact(makeRuntimeValue()), 'main')
+    expect(ctx.width).toBe(80)
+  })
+
+  it('selects the detail width for the detail panel', () => {
+    const ctx = useSurfaceRenderContext(makeReact(makeRuntimeValue()), 'detail')
+    expect(ctx.width).toBe(40)
+  })
+})
+
+describe('defineSurfaceComponent', () => {
+  it('wraps a render fn into a labelled component that feeds it the rebuilt ctx', () => {
+    const value = makeRuntimeValue()
+    const sentinel = { type: 'box' } as unknown as React.ReactElement
+    const renderSurface = jest.fn<React.ReactElement, [SurfaceRenderContext]>(() => sentinel)
+
+    const Component = defineSurfaceComponent(makeReact(value), renderSurface, {
+      displayName: 'TestSurface',
+    })
+    expect(Component.displayName).toBe('TestSurface')
+
+    // Invoke the function component directly (no renderer needed).
+    const out = (Component as () => React.ReactElement)()
+    expect(out).toBe(sentinel)
+    expect(renderSurface).toHaveBeenCalledTimes(1)
+    const ctx = renderSurface.mock.calls[0][0]
+    // Defaults to the main panel.
+    expect(ctx.width).toBe(80)
+    expect(ctx.state).toBe(value.state)
+  })
+
+  it('honors the detail panel option', () => {
+    const value = makeRuntimeValue()
+    const renderSurface = jest.fn<React.ReactElement, [SurfaceRenderContext]>(
+      () => ({ type: 'box' } as unknown as React.ReactElement)
+    )
+    const Component = defineSurfaceComponent(makeReact(value), renderSurface, {
+      displayName: 'TestDetail',
+      panel: 'detail',
+    })
+    ;(Component as () => React.ReactElement)()
+    const ctx = renderSurface.mock.calls[0][0]
+    expect(ctx.width).toBe(40)
   })
 })

--- a/src/workstation/runtime/runtimeContext.ts
+++ b/src/workstation/runtime/runtimeContext.ts
@@ -23,9 +23,10 @@
 
 import type * as ReactTypes from 'react'
 import type { LogInkAction, LogInkState } from '../../workstation/runtime/inkViewModel'
+import type { LogInkContextStatus } from '../chrome/context'
 import type { LogInkLayout } from '../chrome/layout'
 import type { LogInkTheme } from '../chrome/theme'
-import type { LogInkContext } from './types'
+import type { LogInkComponents, LogInkContext, SurfaceRenderContext } from './types'
 
 /**
  * The value carried by `LogInkRuntimeContext`. Intentionally the exact
@@ -40,6 +41,22 @@ export type LogInkRuntimeContextValue = {
   theme: LogInkTheme
   layout: LogInkLayout
   context: LogInkContext
+  /**
+   * Loading status per context key (#1237 surface migration). Surfaces
+   * read this to render per-slice "loading…" affordances; it was the
+   * `contextStatus` field threaded through every `SurfaceRenderContext`.
+   * App-wide and recomputed each render, like `state`.
+   */
+  contextStatus: LogInkContextStatus
+  /**
+   * Runtime render primitives — `React.createElement` (`h`) and the ink
+   * `{ Box, Text }` pair. The workstation never statically imports
+   * react/ink (both ESM, dynamic-import at boot), so a migrated surface
+   * component can't `import` them; they ride in the context, set once at
+   * the root. Stable for the life of the process.
+   */
+  h: typeof ReactTypes.createElement
+  components: LogInkComponents
 }
 
 type LogInkRuntimeContext = ReactTypes.Context<LogInkRuntimeContextValue | null>
@@ -74,4 +91,59 @@ export function useLogInkRuntime(React: typeof ReactTypes): LogInkRuntimeContext
     throw new Error('useLogInkRuntime must be called inside a LogInkRuntimeContext provider')
   }
   return value
+}
+
+/**
+ * Which panel a surface renders into. The main panel and the detail
+ * inspector have different widths, so a surface reconstructing its
+ * {@link SurfaceRenderContext} from the runtime context must say which.
+ */
+export type SurfacePanel = 'main' | 'detail'
+
+/**
+ * Rebuild the {@link SurfaceRenderContext} a `render*Surface` fn expects
+ * from the runtime context (#1237 surface migration). A migrated surface
+ * component calls this and hands the result to its existing (snapshot-
+ * tested) render fn unchanged — so the proven render logic doesn't move,
+ * only how it sources its inputs. `panel` selects the width.
+ */
+export function useSurfaceRenderContext(
+  React: typeof ReactTypes,
+  panel: SurfacePanel
+): SurfaceRenderContext {
+  const { h, components, state, context, contextStatus, theme, layout } =
+    useLogInkRuntime(React)
+  return {
+    h,
+    components,
+    state,
+    context,
+    contextStatus,
+    bodyRows: layout.bodyRows,
+    width: panel === 'detail' ? layout.detailWidth : layout.mainPanelWidth,
+    theme,
+  }
+}
+
+/**
+ * Wrap a zero-extra `render*Surface` fn — one that needs only the base
+ * {@link SurfaceRenderContext}, no per-render async slice — into a thin
+ * component that reads from the runtime context instead of receiving
+ * props. The caller caches the returned component (a per-surface getter)
+ * so its identity stays stable across renders; remounting it every render
+ * would be wasteful and defeat later memoization. Surfaces that also need
+ * async slices (diff data, spinner frames) write a bespoke component on
+ * top of {@link useSurfaceRenderContext} instead.
+ */
+export function defineSurfaceComponent(
+  React: typeof ReactTypes,
+  renderSurface: (ctx: SurfaceRenderContext) => ReactTypes.ReactElement,
+  options: { displayName: string; panel?: SurfacePanel }
+): ReactTypes.FC {
+  const SurfaceComponent: ReactTypes.FC = () => {
+    const ctx = useSurfaceRenderContext(React, options.panel ?? 'main')
+    return renderSurface(ctx)
+  }
+  SurfaceComponent.displayName = options.displayName
+  return SurfaceComponent
 }


### PR DESCRIPTION
## What

Groundwork for the remaining open half of #1237 / #1136 — migrating workstation **surfaces** off threaded props onto `LogInkRuntimeContext`. The 0.72.1 state-cluster split is done; this starts the surface migration. **No surface is migrated in this PR** — it lands only the machinery the per-surface PRs consume, so it's behavior-preserving.

## Changes

- **Grow `LogInkRuntimeContextValue`** with the set-once / app-wide values surfaces still receive as props: `contextStatus` + the injected render primitives `h` and `components`. (react/ink are dynamic-imported at boot, so a surface component can't `import` them — they ride in the context.) The provider value in `app.ts` populates the three new fields.
- **`useSurfaceRenderContext(React, panel)`** — rebuilds the `SurfaceRenderContext` a `render*Surface` fn already expects, from the context. The proven, snapshot-tested render logic moves unchanged; only how it sources inputs changes. `panel` selects main vs detail width.
- **`defineSurfaceComponent(React, renderFn, opts)`** — wraps a zero-extra render fn into a thin context-reading component (the common case for the first migration batch).

## Tests

Fake-React harness (mirrors the established hook-test pattern, no renderer needed): read path, `null`-context throw, identity pass-through, main/detail width selection, and the component wrapper. `header.test.ts` updated for the grown value shape (the header is already a context consumer).

## Validation

`tsc --noEmit` clean · full jest green (runtimeContext 9/9, header 6/6, 68 snapshots) · eslint 0 errors · `rollup -c` builds. (The 4 `tsTreeSitterParser` `.wasm-backed` failures are the known worktree WASM-grammar gotcha — unrelated, `src/lib/parsers`, fail identically on `main` here.)

## Next

PR 2 migrates the 8 zero-extra surfaces (status, conflicts, remotes, submodules, reflog, pullRequest, issuesTriage, pullRequestTriage) onto these helpers. Full ladder in `specs/surface-context-migration-plan.md`.