### PR TITLE
refactor(runtime): migrate zero-extra surfaces to context components (#1237)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -1645,7 +1645,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     theme,
   }
   const mainPanel = () =>
-    renderMainPanel(mainSurface, {
+    renderMainPanel(React, mainSurface, {
       worktreeDiff,
       worktreeDiffLoading,
       worktreeHunks,

--- a/src/workstation/runtime/mainPanel.test.ts
+++ b/src/workstation/runtime/mainPanel.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for the main-panel dispatcher's zero-extra surface wiring
+ * (#1237 surface migration).
+ *
+ * The nine zero-extra views (those whose renderer needs only the base
+ * SurfaceRenderContext) are now mounted as context-reading components:
+ * `renderMainPanel` returns `h(<Surface>Component)` instead of calling the
+ * render fn inline. These tests pin that wiring without a React renderer —
+ * we only assert the dispatcher returns an element whose type is the
+ * correctly-named, cached surface component for the active view. The
+ * surfaces' own render output stays covered by their colocated
+ * render-snapshot suites (unchanged by the migration).
+ */
+import type * as ReactTypes from 'react'
+import { renderMainPanel, type MainPanelExtras } from './mainPanel'
+import type { LogInkState } from './inkViewModel'
+import type { SurfaceRenderContext } from './types'
+
+// `h` stub: records (type, props) so we can read back the element the
+// dispatcher created. The cached surface components carry the displayName
+// defineSurfaceComponent set, which is what we assert against.
+type CapturedElement = { type: ReactTypes.FC; props: unknown }
+function makeReact(): typeof ReactTypes {
+  return {
+    createElement: (type: ReactTypes.FC, props: unknown) => ({ type, props }),
+    // The dispatcher's zero-extra components are built via
+    // defineSurfaceComponent, which only needs createContext lazily; it's
+    // never invoked here because we don't render the returned component.
+    createContext: () => ({ displayName: '' }),
+  } as unknown as typeof ReactTypes
+}
+
+function makeSurface(activeView: string): SurfaceRenderContext {
+  const React = makeReact()
+  return {
+    h: React.createElement,
+    components: { Box: () => null, Text: () => null } as unknown as SurfaceRenderContext['components'],
+    state: { activeView, splitPlan: undefined } as unknown as LogInkState,
+    context: {},
+    contextStatus: {} as unknown as SurfaceRenderContext['contextStatus'],
+    bodyRows: 30,
+    width: 80,
+    theme: {} as unknown as SurfaceRenderContext['theme'],
+  }
+}
+
+// Minimal extras — the zero-extra branches don't read any of these.
+const EXTRAS = {} as unknown as MainPanelExtras
+
+const ZERO_EXTRA_VIEWS: Array<[view: string, displayName: string]> = [
+  ['status', 'StatusSurface'],
+  ['reflog', 'ReflogSurface'],
+  ['submodules', 'SubmodulesSurface'],
+  ['remotes', 'RemotesSurface'],
+  ['pull-request', 'PullRequestSurface'],
+  ['pull-request-triage', 'PullRequestTriageSurface'],
+  ['issues', 'IssuesTriageSurface'],
+  ['conflicts', 'ConflictsSurface'],
+  ['changelog', 'ChangelogSurface'],
+]
+
+describe('renderMainPanel — zero-extra surface wiring', () => {
+  it.each(ZERO_EXTRA_VIEWS)(
+    'mounts the %s view as the %s component (not an inline render)',
+    (view, displayName) => {
+      const React = makeReact()
+      const el = renderMainPanel(React, makeSurface(view), EXTRAS) as unknown as CapturedElement
+      expect(typeof el.type).toBe('function')
+      expect(el.type.displayName).toBe(displayName)
+      // Zero-extra components take no props — they self-serve from context.
+      expect(el.props == null || Object.keys(el.props).length === 0).toBe(true)
+    }
+  )
+
+  it('caches components across calls (stable identity per view)', () => {
+    const React = makeReact()
+    const first = renderMainPanel(React, makeSurface('status'), EXTRAS) as unknown as CapturedElement
+    const second = renderMainPanel(React, makeSurface('status'), EXTRAS) as unknown as CapturedElement
+    // Same component object each render — remounting a fresh type every
+    // render would be wasteful and defeat later memoization.
+    expect(second.type).toBe(first.type)
+  })
+})

--- a/src/workstation/runtime/mainPanel.ts
+++ b/src/workstation/runtime/mainPanel.ts
@@ -36,7 +36,46 @@ import { renderStatusSurface } from '../surfaces/status'
 import { renderSubmodulesSurface } from '../surfaces/submodules'
 import { renderTagsSurface } from '../surfaces/tags'
 import { renderWorktreesSurface } from '../surfaces/worktrees'
+import { defineSurfaceComponent } from './runtimeContext'
 import type { SurfaceRenderContext } from './types'
+
+/**
+ * Zero-extra surfaces (#1237 surface migration) — those whose renderer
+ * needs only the base {@link SurfaceRenderContext}, no per-render async
+ * slice. Each is wrapped once into a thin component that self-serves
+ * state / theme / context from `LogInkRuntimeContext`, so the dispatcher
+ * mounts `h(Component)` instead of calling the render fn inline and
+ * threading `surface` down. Cached per process (one React instance), so
+ * the component identity stays stable across renders.
+ *
+ * Keyed by `state.activeView`. Surfaces that also need an async slice
+ * (diff data, spinner frames, pagination) are not here — they migrate to
+ * bespoke components in later PRs and stay regular calls for now.
+ */
+let cachedZeroExtraComponents: Partial<Record<string, ReactTypes.FC>> | null = null
+function zeroExtraComponent(
+  React: typeof ReactTypes,
+  view: string
+): ReactTypes.FC | undefined {
+  if (!cachedZeroExtraComponents) {
+    const define = (
+      renderSurface: (ctx: SurfaceRenderContext) => ReactTypes.ReactElement,
+      displayName: string
+    ): ReactTypes.FC => defineSurfaceComponent(React, renderSurface, { displayName })
+    cachedZeroExtraComponents = {
+      status: define(renderStatusSurface, 'StatusSurface'),
+      reflog: define(renderReflogSurface, 'ReflogSurface'),
+      submodules: define(renderSubmodulesSurface, 'SubmodulesSurface'),
+      remotes: define(renderRemotesSurface, 'RemotesSurface'),
+      'pull-request': define(renderPullRequestSurface, 'PullRequestSurface'),
+      'pull-request-triage': define(renderPullRequestTriageSurface, 'PullRequestTriageSurface'),
+      issues: define(renderIssuesTriageSurface, 'IssuesTriageSurface'),
+      conflicts: define(renderConflictsSurface, 'ConflictsSurface'),
+      changelog: define(renderChangelogSurface, 'ChangelogSurface'),
+    }
+  }
+  return cachedZeroExtraComponents[view]
+}
 
 /**
  * The per-surface render slices the main-panel dispatcher threads through to
@@ -74,6 +113,7 @@ export type MainPanelExtras = {
 }
 
 export function renderMainPanel(
+  React: typeof ReactTypes,
   surface: SurfaceRenderContext,
   extras: MainPanelExtras
 ): ReactTypes.ReactElement {
@@ -120,7 +160,7 @@ export function renderMainPanel(
   }
 
   if (state.activeView === 'status') {
-    return renderStatusSurface(surface)
+    return h(zeroExtraComponent(React, 'status')!)
   }
 
   if (state.activeView === 'diff') {
@@ -155,7 +195,7 @@ export function renderMainPanel(
   }
 
   if (state.activeView === 'reflog') {
-    return renderReflogSurface(surface)
+    return h(zeroExtraComponent(React, 'reflog')!)
   }
 
   if (state.activeView === 'bisect') {
@@ -171,11 +211,11 @@ export function renderMainPanel(
   }
 
   if (state.activeView === 'submodules') {
-    return renderSubmodulesSurface(surface)
+    return h(zeroExtraComponent(React, 'submodules')!)
   }
 
   if (state.activeView === 'remotes') {
-    return renderRemotesSurface(surface)
+    return h(zeroExtraComponent(React, 'remotes')!)
   }
 
   if (state.activeView === 'blame') {
@@ -183,23 +223,23 @@ export function renderMainPanel(
   }
 
   if (state.activeView === 'pull-request') {
-    return renderPullRequestSurface(surface)
+    return h(zeroExtraComponent(React, 'pull-request')!)
   }
 
   if (state.activeView === 'pull-request-triage') {
-    return renderPullRequestTriageSurface(surface)
+    return h(zeroExtraComponent(React, 'pull-request-triage')!)
   }
 
   if (state.activeView === 'issues') {
-    return renderIssuesTriageSurface(surface)
+    return h(zeroExtraComponent(React, 'issues')!)
   }
 
   if (state.activeView === 'conflicts') {
-    return renderConflictsSurface(surface)
+    return h(zeroExtraComponent(React, 'conflicts')!)
   }
 
   if (state.activeView === 'changelog') {
-    return renderChangelogSurface(surface)
+    return h(zeroExtraComponent(React, 'changelog')!)
   }
 
   return renderHistoryPanel(


### PR DESCRIPTION
## What

First surface-migration batch on the [#1292](https://github.com/gfargo/coco/pull/1292) foundation. The **nine** views whose renderer needs only the base `SurfaceRenderContext` now mount as thin, context-reading components instead of being called inline with a threaded `surface` object:

`status` · `reflog` · `submodules` · `remotes` · `pull-request` · `pull-request-triage` · `issues` · `conflicts` · `changelog`

(One more than the planned 8 — `changelog` turned out to be zero-extra in the dispatch too.)

## Changes

- **`mainPanel.ts`** — each zero-extra branch returns `h(<Surface>Component)`. The components are built once via `defineSurfaceComponent` and cached per process (stable identity across renders, so React doesn't remount them). `renderMainPanel` gains a leading `React` param so the dispatcher can build them.
- **`app.ts`** — pass `React` through to `renderMainPanel` (its only caller).

## Behavior-preserving

The render fns themselves are **unchanged** — their colocated render-snapshot suites stay green (65 snapshots), so output is byte-identical. Only how each surface *sources* `state`/`theme`/`context`/`contextStatus` changes: from `LogInkRuntimeContext` rather than the threaded `surface` prop. (The widths/dims resolve to the same `layout` values either way.)

## Tests

New `mainPanel.test.ts` pins the wiring without a renderer: each view → its correctly-named cached component, no props (they self-serve from context), and stable identity across renders.

## Validation

`tsc --noEmit` clean · full jest green (3589 passed, 68 snapshots; the 4 `tsTreeSitterParser` `.wasm-backed` failures are the known worktree WASM-grammar gotcha — pass in CI) · eslint 0 errors · `rollup -c` builds.

## Next

PR 3: the single-extra surfaces (branches, tags, stash, worktrees, compose, blame, diff) — bespoke components reading core from context with their async slice still a prop. Ladder in `specs/surface-context-migration-plan.md`.