### PR TITLE
refactor(runtime): migrate single-extra surfaces to context components (#1237)

### DIFF
--- a/src/workstation/runtime/mainPanel.test.ts
+++ b/src/workstation/runtime/mainPanel.test.ts
@@ -47,6 +47,19 @@ function makeSurface(activeView: string): SurfaceRenderContext {
 // Minimal extras — the zero-extra branches don't read any of these.
 const EXTRAS = {} as unknown as MainPanelExtras
 
+// Extras with the slices the single-extra branches thread to their
+// components, so we can assert the dispatcher passes them through.
+const SPINNER = 7
+function makeExtras(): MainPanelExtras {
+  return {
+    spinnerFrame: SPINNER,
+    bisectCandidateDetail: { hash: 'abc' } as unknown,
+    bisectCandidateLoading: true,
+    blame: { lines: [] } as unknown,
+    blameLoading: true,
+  } as unknown as MainPanelExtras
+}
+
 const ZERO_EXTRA_VIEWS: Array<[view: string, displayName: string]> = [
   ['status', 'StatusSurface'],
   ['reflog', 'ReflogSurface'],
@@ -79,5 +92,44 @@ describe('renderMainPanel — zero-extra surface wiring', () => {
     // Same component object each render — remounting a fresh type every
     // render would be wasteful and defeat later memoization.
     expect(second.type).toBe(first.type)
+  })
+})
+
+describe('renderMainPanel — single-extra surface wiring', () => {
+  it.each([
+    ['compose', 'ComposeSurface'],
+    ['branches', 'BranchesSurface'],
+    ['tags', 'TagsSurface'],
+    ['stash', 'StashSurface'],
+    ['worktrees', 'WorktreesSurface'],
+  ])('mounts the %s view as %s and threads the spinner frame', (view, displayName) => {
+    const React = makeReact()
+    const el = renderMainPanel(React, makeSurface(view), makeExtras()) as unknown as CapturedElement
+    expect(el.type.displayName).toBe(displayName)
+    expect((el.props as { spinnerFrame: number }).spinnerFrame).toBe(SPINNER)
+  })
+
+  it('mounts diff as DiffSurface with the assembled diff slice as a prop', () => {
+    const React = makeReact()
+    const el = renderMainPanel(React, makeSurface('diff'), makeExtras()) as unknown as CapturedElement
+    expect(el.type.displayName).toBe('DiffSurface')
+    expect((el.props as { diff: unknown }).diff).toBeDefined()
+  })
+
+  it('mounts bisect as BisectSurface with candidate detail + loading props', () => {
+    const React = makeReact()
+    const el = renderMainPanel(React, makeSurface('bisect'), makeExtras()) as unknown as CapturedElement
+    expect(el.type.displayName).toBe('BisectSurface')
+    const props = el.props as { candidateDetail: unknown; candidateLoading: boolean }
+    expect(props.candidateDetail).toEqual({ hash: 'abc' })
+    expect(props.candidateLoading).toBe(true)
+  })
+
+  it('mounts blame as BlameSurface with the { blame, loading } data prop', () => {
+    const React = makeReact()
+    const el = renderMainPanel(React, makeSurface('blame'), makeExtras()) as unknown as CapturedElement
+    expect(el.type.displayName).toBe('BlameSurface')
+    const props = el.props as { data: { loading: boolean } }
+    expect(props.data.loading).toBe(true)
   })
 })

--- a/src/workstation/runtime/mainPanel.ts
+++ b/src/workstation/runtime/mainPanel.ts
@@ -36,7 +36,7 @@ import { renderStatusSurface } from '../surfaces/status'
 import { renderSubmodulesSurface } from '../surfaces/submodules'
 import { renderTagsSurface } from '../surfaces/tags'
 import { renderWorktreesSurface } from '../surfaces/worktrees'
-import { defineSurfaceComponent } from './runtimeContext'
+import { defineSurfaceComponent, useSurfaceRenderContext } from './runtimeContext'
 import type { SurfaceRenderContext } from './types'
 
 /**
@@ -75,6 +75,81 @@ function zeroExtraComponent(
     }
   }
   return cachedZeroExtraComponents[view]
+}
+
+/**
+ * Single-extra surfaces (#1237 surface migration) — their renderer needs
+ * the base {@link SurfaceRenderContext} plus exactly one per-render async
+ * slice (a spinner frame, diff data, blame data, a bisect candidate). The
+ * slice stays a component **prop** rather than moving into context, so it
+ * remains the per-surface boundary; the rest is read from
+ * `LogInkRuntimeContext` via {@link useSurfaceRenderContext}. All cached
+ * per process, like the zero-extra set.
+ */
+
+// Spinner-driven surfaces all share the `{ spinnerFrame }` prop shape, so
+// they group like the zero-extra set (keyed by `state.activeView`).
+let cachedSpinnerComponents: Partial<Record<string, ReactTypes.FC<{ spinnerFrame: number }>>> | null = null
+function spinnerSurfaceComponent(
+  React: typeof ReactTypes,
+  view: string
+): ReactTypes.FC<{ spinnerFrame: number }> | undefined {
+  if (!cachedSpinnerComponents) {
+    const make = (
+      renderSurface: (ctx: SurfaceRenderContext, spinnerFrame: number) => ReactTypes.ReactElement,
+      displayName: string
+    ): ReactTypes.FC<{ spinnerFrame: number }> => {
+      const Component: ReactTypes.FC<{ spinnerFrame: number }> = ({ spinnerFrame }) =>
+        renderSurface(useSurfaceRenderContext(React, 'main'), spinnerFrame)
+      Component.displayName = displayName
+      return Component
+    }
+    cachedSpinnerComponents = {
+      compose: make(renderComposeSurface, 'ComposeSurface'),
+      branches: make(renderBranchesSurface, 'BranchesSurface'),
+      tags: make(renderTagsSurface, 'TagsSurface'),
+      stash: make(renderStashSurface, 'StashSurface'),
+      worktrees: make(renderWorktreesSurface, 'WorktreesSurface'),
+    }
+  }
+  return cachedSpinnerComponents[view]
+}
+
+let cachedDiffComponent: ReactTypes.FC<{ diff: DiffSurfaceData }> | null = null
+function diffSurfaceComponent(React: typeof ReactTypes): ReactTypes.FC<{ diff: DiffSurfaceData }> {
+  if (!cachedDiffComponent) {
+    const Component: ReactTypes.FC<{ diff: DiffSurfaceData }> = ({ diff }) =>
+      renderDiffSurface(useSurfaceRenderContext(React, 'main'), diff)
+    Component.displayName = 'DiffSurface'
+    cachedDiffComponent = Component
+  }
+  return cachedDiffComponent
+}
+
+type BisectComponentProps = {
+  candidateDetail: GitCommitDetail | undefined
+  candidateLoading: boolean
+}
+let cachedBisectComponent: ReactTypes.FC<BisectComponentProps> | null = null
+function bisectSurfaceComponent(React: typeof ReactTypes): ReactTypes.FC<BisectComponentProps> {
+  if (!cachedBisectComponent) {
+    const Component: ReactTypes.FC<BisectComponentProps> = ({ candidateDetail, candidateLoading }) =>
+      renderBisectSurface(useSurfaceRenderContext(React, 'main'), candidateDetail, candidateLoading)
+    Component.displayName = 'BisectSurface'
+    cachedBisectComponent = Component
+  }
+  return cachedBisectComponent
+}
+
+let cachedBlameComponent: ReactTypes.FC<{ data: BlameSurfaceData }> | null = null
+function blameSurfaceComponent(React: typeof ReactTypes): ReactTypes.FC<{ data: BlameSurfaceData }> {
+  if (!cachedBlameComponent) {
+    const Component: ReactTypes.FC<{ data: BlameSurfaceData }> = ({ data }) =>
+      renderBlameSurface(useSurfaceRenderContext(React, 'main'), data)
+    Component.displayName = 'BlameSurface'
+    cachedBlameComponent = Component
+  }
+  return cachedBlameComponent
 }
 
 /**
@@ -179,19 +254,19 @@ export function renderMainPanel(
       compareDiffLoading,
       syntaxSpans,
     }
-    return renderDiffSurface(surface, diffData)
+    return h(diffSurfaceComponent(React), { diff: diffData })
   }
 
   if (state.activeView === 'compose') {
-    return renderComposeSurface(surface, spinnerFrame)
+    return h(spinnerSurfaceComponent(React, 'compose')!, { spinnerFrame })
   }
 
   if (state.activeView === 'branches') {
-    return renderBranchesSurface(surface, spinnerFrame)
+    return h(spinnerSurfaceComponent(React, 'branches')!, { spinnerFrame })
   }
 
   if (state.activeView === 'tags') {
-    return renderTagsSurface(surface, spinnerFrame)
+    return h(spinnerSurfaceComponent(React, 'tags')!, { spinnerFrame })
   }
 
   if (state.activeView === 'reflog') {
@@ -199,15 +274,18 @@ export function renderMainPanel(
   }
 
   if (state.activeView === 'bisect') {
-    return renderBisectSurface(surface, bisectCandidateDetail, bisectCandidateLoading)
+    return h(bisectSurfaceComponent(React), {
+      candidateDetail: bisectCandidateDetail,
+      candidateLoading: bisectCandidateLoading,
+    })
   }
 
   if (state.activeView === 'stash') {
-    return renderStashSurface(surface, spinnerFrame)
+    return h(spinnerSurfaceComponent(React, 'stash')!, { spinnerFrame })
   }
 
   if (state.activeView === 'worktrees') {
-    return renderWorktreesSurface(surface, spinnerFrame)
+    return h(spinnerSurfaceComponent(React, 'worktrees')!, { spinnerFrame })
   }
 
   if (state.activeView === 'submodules') {
@@ -219,7 +297,7 @@ export function renderMainPanel(
   }
 
   if (state.activeView === 'blame') {
-    return renderBlameSurface(surface, { blame, loading: blameLoading })
+    return h(blameSurfaceComponent(React), { data: { blame, loading: blameLoading } })
   }
 
   if (state.activeView === 'pull-request') {


### PR DESCRIPTION
## What

Second surface-migration batch (after [#1293](https://github.com/gfargo/coco/pull/1293)). The **eight** views whose renderer needs the base `SurfaceRenderContext` **plus exactly one** per-render async slice now mount as context-reading components. The slice stays a component **prop** (the per-surface boundary); everything else is read from `LogInkRuntimeContext`.

- **spinner-driven** (`{ spinnerFrame }`): `compose`, `branches`, `tags`, `stash`, `worktrees`
- **`diff`** (`DiffSurfaceData`) · **`bisect`** (candidate detail + loading) · **`blame`** (`BlameSurfaceData`)

## Changes

- **`mainPanel.ts`** — builds these components once (cached per process) and each branch returns `h(Component, { <slice> })`. Spinner-driven surfaces share one keyed cache; diff/bisect/blame get individual cached builders (distinct prop shapes).

## Behavior-preserving

Render fns are **unchanged** — colocated render-snapshot suites stay green (65). Output identical; only the source of `state`/`theme`/`context`/dims changes (context vs threaded `surface`).

## Tests

`mainPanel.test.ts` gains single-extra wiring coverage: each view → its named component, with the async slice threaded as a prop (spinner frame / assembled diff / bisect candidate / blame data).

## Validation

`tsc` clean · full jest green (3597 passed, 68 snapshots; 4 `tsTreeSitterParser` `.wasm-backed` failures are the known worktree gotcha, pass in CI) · eslint 0 errors · `rollup -c` builds.

## Next

PR 4: the `history` surface (8 params — pagination, density, rowMode, dateBucketing, syntaxSpans), then PR 5 the detail-panel cluster. Ladder in `specs/surface-context-migration-plan.md`.