### PR TITLE
refactor(runtime): migrate history surface to a context component (#1237)

### DIFF
--- a/src/workstation/runtime/mainPanel.test.ts
+++ b/src/workstation/runtime/mainPanel.test.ts
@@ -57,6 +57,11 @@ function makeExtras(): MainPanelExtras {
     bisectCandidateLoading: true,
     blame: { lines: [] } as unknown,
     blameLoading: true,
+    hasMoreCommits: true,
+    loadingMoreCommits: false,
+    density: 'comfortable',
+    rowMode: 'single',
+    dateBucketingEnabled: true,
   } as unknown as MainPanelExtras
 }
 
@@ -131,5 +136,17 @@ describe('renderMainPanel — single-extra surface wiring', () => {
     expect(el.type.displayName).toBe('BlameSurface')
     const props = el.props as { data: { loading: boolean } }
     expect(props.data.loading).toBe(true)
+  })
+
+  it('falls through to HistorySurface for the default view, threading its props', () => {
+    const React = makeReact()
+    // No explicit branch matches `history`, so the dispatcher's default
+    // returns the history component.
+    const el = renderMainPanel(React, makeSurface('history'), makeExtras()) as unknown as CapturedElement
+    expect(el.type.displayName).toBe('HistorySurface')
+    const props = el.props as { hasMoreCommits: boolean; rowMode: string; spinnerFrame: number }
+    expect(props.hasMoreCommits).toBe(true)
+    expect(props.rowMode).toBe('single')
+    expect(props.spinnerFrame).toBe(SPINNER)
   })
 })

--- a/src/workstation/runtime/mainPanel.ts
+++ b/src/workstation/runtime/mainPanel.ts
@@ -153,6 +153,41 @@ function blameSurfaceComponent(React: typeof ReactTypes): ReactTypes.FC<{ data: 
 }
 
 /**
+ * History surface (#1237) — the dispatcher's default view and its highest
+ * fan-in: pagination flags, layout density / row mode, date-bucketing, and
+ * the spinner frame. All ride as component props; the rest is read from
+ * context. `now` keeps its render-time default (the component doesn't
+ * thread it), matching the previous `undefined` positional arg.
+ */
+type HistoryComponentProps = {
+  hasMoreCommits: boolean
+  loadingMoreCommits: boolean
+  density: LogInkLayoutDensity
+  rowMode: 'single' | 'stacked'
+  dateBucketingEnabled: boolean
+  spinnerFrame: number
+}
+let cachedHistoryComponent: ReactTypes.FC<HistoryComponentProps> | null = null
+function historySurfaceComponent(React: typeof ReactTypes): ReactTypes.FC<HistoryComponentProps> {
+  if (!cachedHistoryComponent) {
+    const Component: ReactTypes.FC<HistoryComponentProps> = (props) =>
+      renderHistoryPanel(
+        useSurfaceRenderContext(React, 'main'),
+        props.hasMoreCommits,
+        props.loadingMoreCommits,
+        props.density,
+        props.rowMode,
+        props.dateBucketingEnabled,
+        undefined,
+        props.spinnerFrame
+      )
+    Component.displayName = 'HistorySurface'
+    cachedHistoryComponent = Component
+  }
+  return cachedHistoryComponent
+}
+
+/**
  * The per-surface render slices the main-panel dispatcher threads through to
  * the active surface. Bundled into one object (#0.68) so `renderMainPanel` is a
  * two-argument call (`surface` + `extras`) instead of 22 positional params — the
@@ -320,14 +355,12 @@ export function renderMainPanel(
     return h(zeroExtraComponent(React, 'changelog')!)
   }
 
-  return renderHistoryPanel(
-    surface,
+  return h(historySurfaceComponent(React), {
     hasMoreCommits,
     loadingMoreCommits,
     density,
     rowMode,
     dateBucketingEnabled,
-    undefined,
-    spinnerFrame
-  )
+    spinnerFrame,
+  })
 }


### PR DESCRIPTION
## What

Third surface-migration batch (after [#1294](https://github.com/gfargo/coco/pull/1294)) — the main panel's **default** view and its highest fan-in. The `history` surface now mounts as a context-reading component: pagination flags, layout density / row mode, date-bucketing, and the spinner frame ride as component props; the rest is read from `LogInkRuntimeContext`. `now` keeps its render-time default (matching the previous `undefined` positional arg).

**Milestone:** with this, *every main-panel branch* in the dispatcher mounts a component. `renderMainPanel` no longer passes the `surface` object to any render fn (it's still destructured for the split-plan overlay).

## Behavior-preserving

The render fn is **unchanged** — the history render-snapshot suite stays green, so output is identical; only the source of state/theme/context changes.

## Tests

`mainPanel.test.ts` covers the default-view fall-through → `HistorySurface` and its prop threading (pagination / rowMode / spinner).

## Validation

`tsc` clean · full jest green (3598 passed, 68 snapshots; 4 `tsTreeSitterParser` `.wasm-backed` failures = known worktree gotcha, pass in CI) · eslint 0 errors · `rollup -c` builds.

## Next

PR 5: the detail-panel cluster (`detailPanel.ts`, 10+ positional renderers) — convert positional → ctx-object, then componentize. Ladder in `specs/surface-context-migration-plan.md`.