### PR TITLE
refactor(runtime): migrate detail-panel surfaces to context components (#1237)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -1672,6 +1672,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     })
   const detailPanel = () =>
     renderDetailPanel(
+      React,
       {
         h,
         components: { Box, Text },

--- a/src/workstation/runtime/detailPanel.test.ts
+++ b/src/workstation/runtime/detailPanel.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for the detail-panel dispatcher's surface wiring (#1237 surface
+ * migration).
+ *
+ * The per-view detail surfaces (commit panel, diff detail, the preview
+ * panels, the history inspector) now mount as context-reading components:
+ * `renderDetailPanel` returns `h(<Surface>Component, props)` instead of
+ * calling the positional renderer inline. These tests pin that routing
+ * without a React renderer — we assert the dispatcher returns an element
+ * whose type is the correctly-named component for the active view, and
+ * that the per-render slices (detail / loading / file preview / tabbed)
+ * ride as props. The surfaces' own output stays covered by the colocated
+ * `surfaces/detail` suites (unchanged by the migration); the overlays stay
+ * positional and are covered by `overlays.test.ts`.
+ */
+import type * as ReactTypes from 'react'
+import { renderDetailPanel, type DetailPanelExtras } from './detailPanel'
+import type { LogInkState } from './inkViewModel'
+import type { SurfaceRenderContext } from './types'
+
+type CapturedElement = { type: ReactTypes.FC; props: Record<string, unknown> | null }
+function makeReact(): typeof ReactTypes {
+  return {
+    createElement: (type: ReactTypes.FC, props: unknown) => ({ type, props }),
+    createContext: () => ({ displayName: '' }),
+  } as unknown as typeof ReactTypes
+}
+
+function makeSurface(state: Partial<LogInkState>): SurfaceRenderContext {
+  const React = makeReact()
+  return {
+    h: React.createElement,
+    components: { Box: () => null, Text: () => null } as unknown as SurfaceRenderContext['components'],
+    // All overlay flags absent (falsy) so dispatch reaches the view branches.
+    state: { focus: 'detail', ...state } as unknown as LogInkState,
+    context: {},
+    contextStatus: {} as unknown as SurfaceRenderContext['contextStatus'],
+    bodyRows: 30,
+    width: 60,
+    theme: {} as unknown as SurfaceRenderContext['theme'],
+  }
+}
+
+const EXTRAS: DetailPanelExtras = {
+  detail: { hash: 'abc' } as unknown as DetailPanelExtras['detail'],
+  loading: true,
+  filePreview: undefined,
+  filePreviewLoading: false,
+  tabbed: true,
+}
+
+function dispatch(state: Partial<LogInkState>): CapturedElement {
+  const React = makeReact()
+  return renderDetailPanel(React, makeSurface(state), EXTRAS) as unknown as CapturedElement
+}
+
+describe('renderDetailPanel — detail surface wiring', () => {
+  it.each([
+    [{ activeView: 'status' }, 'CommitPanel'],
+    [{ activeView: 'diff', diffSource: 'worktree' }, 'CommitPanel'],
+    [{ activeView: 'compose' }, 'ComposeContextPanel'],
+    [{ activeView: 'history', pendingCommitFocused: true }, 'ComposeContextPanel'],
+    [{ activeView: 'branches' }, 'BranchPreviewPanel'],
+    [{ activeView: 'tags' }, 'TagPreviewPanel'],
+    [{ activeView: 'stash' }, 'StashPreviewPanel'],
+    [{ activeView: 'submodules' }, 'SubmodulePreviewPanel'],
+    [{ activeView: 'issues' }, 'IssueTriagePreviewPanel'],
+    [{ activeView: 'pull-request-triage' }, 'PullRequestTriagePreviewPanel'],
+  ] as Array<[Partial<LogInkState>, string]>)(
+    'routes %o to the %s component',
+    (state, displayName) => {
+      const el = dispatch(state)
+      expect(typeof el.type).toBe('function')
+      expect(el.type.displayName).toBe(displayName)
+    }
+  )
+
+  it('routes commit-sourced diff to CommitDiffDetail with detail + loading props', () => {
+    const el = dispatch({ activeView: 'diff', diffSource: 'commit' })
+    expect(el.type.displayName).toBe('CommitDiffDetail')
+    const props = el.props as { detail: { hash: string }; loading: boolean }
+    expect(props.detail).toEqual({ hash: 'abc' })
+    expect(props.loading).toBe(true)
+  })
+
+  it('falls through to HistoryInspector with the inspector slices as props', () => {
+    const el = dispatch({ activeView: 'history' })
+    expect(el.type.displayName).toBe('HistoryInspector')
+    const props = el.props as { detail: unknown; tabbed: boolean }
+    expect(props.detail).toEqual({ hash: 'abc' })
+    expect(props.tabbed).toBe(true)
+  })
+
+  it('caches detail components across calls (stable identity)', () => {
+    const first = dispatch({ activeView: 'status' })
+    const second = dispatch({ activeView: 'status' })
+    expect(second.type).toBe(first.type)
+  })
+})

--- a/src/workstation/runtime/detailPanel.ts
+++ b/src/workstation/runtime/detailPanel.ts
@@ -41,6 +41,7 @@ import {
     renderThemePickerOverlay,
     renderViewKeysOverlay,
 } from './overlays'
+import { useSurfaceRenderContext } from './runtimeContext'
 import type { SurfaceRenderContext } from './types'
 
 /**
@@ -57,11 +58,103 @@ export type DetailPanelExtras = {
   tabbed: boolean
 }
 
+/**
+ * Detail-panel surface components (#1237 surface migration). The detail
+ * renderers keep their positional signatures (and their colocated
+ * render-snapshot suites) unchanged; these thin wrappers read the base
+ * context via {@link useSurfaceRenderContext} (panel `'detail'`, so the
+ * detail width resolves correctly) and call the renderer, deriving
+ * `focused` from `state.focus === 'detail'` exactly as the dispatcher did.
+ * The overlays (help / palette / pickers / confirmation / chord) stay
+ * positional — a separate, transient concern. All cached per process.
+ */
+
+// The eight preview/context panels share one positional signature, so they
+// group like the main panel's zero-extra set.
+type CoreDetailRenderer = (
+  h: typeof ReactTypes.createElement,
+  components: SurfaceRenderContext['components'],
+  state: SurfaceRenderContext['state'],
+  context: SurfaceRenderContext['context'],
+  contextStatus: SurfaceRenderContext['contextStatus'],
+  width: number,
+  theme: SurfaceRenderContext['theme'],
+  focused: boolean
+) => ReactTypes.ReactElement
+
+let cachedCoreDetailComponents: Partial<Record<string, ReactTypes.FC>> | null = null
+function coreDetailComponent(React: typeof ReactTypes, key: string): ReactTypes.FC | undefined {
+  if (!cachedCoreDetailComponents) {
+    const make = (render: CoreDetailRenderer, displayName: string): ReactTypes.FC => {
+      const Component: ReactTypes.FC = () => {
+        const { h, components, state, context, contextStatus, width, theme } =
+          useSurfaceRenderContext(React, 'detail')
+        return render(h, components, state, context, contextStatus, width, theme, state.focus === 'detail')
+      }
+      Component.displayName = displayName
+      return Component
+    }
+    cachedCoreDetailComponents = {
+      commit: make(renderCommitPanel, 'CommitPanel'),
+      composeContext: make(renderComposeContextPanel, 'ComposeContextPanel'),
+      branchPreview: make(renderBranchPreviewPanel, 'BranchPreviewPanel'),
+      tagPreview: make(renderTagPreviewPanel, 'TagPreviewPanel'),
+      stashPreview: make(renderStashPreviewPanel, 'StashPreviewPanel'),
+      submodulePreview: make(renderSubmodulePreviewPanel, 'SubmodulePreviewPanel'),
+      issuePreview: make(renderIssueTriagePreviewPanel, 'IssueTriagePreviewPanel'),
+      prPreview: make(renderPullRequestTriagePreviewPanel, 'PullRequestTriagePreviewPanel'),
+    }
+  }
+  return cachedCoreDetailComponents[key]
+}
+
+type CommitDiffProps = { detail: GitCommitDetail | undefined; loading: boolean }
+let cachedCommitDiffComponent: ReactTypes.FC<CommitDiffProps> | null = null
+function commitDiffDetailComponent(React: typeof ReactTypes): ReactTypes.FC<CommitDiffProps> {
+  if (!cachedCommitDiffComponent) {
+    const Component: ReactTypes.FC<CommitDiffProps> = ({ detail, loading }) => {
+      const { h, components, state, width, theme } = useSurfaceRenderContext(React, 'detail')
+      return renderCommitDiffDetail(h, components, state, detail, loading, width, theme, state.focus === 'detail')
+    }
+    Component.displayName = 'CommitDiffDetail'
+    cachedCommitDiffComponent = Component
+  }
+  return cachedCommitDiffComponent
+}
+
+type HistoryInspectorProps = {
+  detail: GitCommitDetail | undefined
+  loading: boolean
+  filePreview: GitCommitFilePreview | undefined
+  filePreviewLoading: boolean
+  tabbed: boolean
+}
+let cachedHistoryInspectorComponent: ReactTypes.FC<HistoryInspectorProps> | null = null
+function historyInspectorComponent(React: typeof ReactTypes): ReactTypes.FC<HistoryInspectorProps> {
+  if (!cachedHistoryInspectorComponent) {
+    const Component: ReactTypes.FC<HistoryInspectorProps> = (props) => {
+      const { h, components, state, context, contextStatus, width, theme } =
+        useSurfaceRenderContext(React, 'detail')
+      return renderHistoryInspector(
+        h, components, state, context, contextStatus, props.detail, props.loading,
+        props.filePreview, props.filePreviewLoading, width, props.tabbed, theme, state.focus === 'detail'
+      )
+    }
+    Component.displayName = 'HistoryInspector'
+    cachedHistoryInspectorComponent = Component
+  }
+  return cachedHistoryInspectorComponent
+}
+
 export function renderDetailPanel(
+  React: typeof ReactTypes,
   surface: SurfaceRenderContext,
   extras: DetailPanelExtras
 ): ReactTypes.ReactElement {
-  const { h, components, state, context, contextStatus, bodyRows, width, theme } = surface
+  // Only the values the overlay branches still need positionally are
+  // destructured here; the per-view detail surfaces self-serve the rest
+  // from LogInkRuntimeContext via their components (#1237).
+  const { h, components, state, bodyRows, width, theme } = surface
   const { detail, loading, filePreview, filePreviewLoading, tabbed } = extras
   const focused = state.focus === 'detail'
 
@@ -121,7 +214,7 @@ export function renderDetailPanel(
   // worktree summary so the user sees what's staged / unstaged at a glance
   // — same surface as the compose view's right panel.
   if (state.activeView === 'history' && state.pendingCommitFocused) {
-    return renderComposeContextPanel(h, components, state, context, contextStatus, width, theme, focused)
+    return h(coreDetailComponent(React, 'composeContext')!)
   }
 
   // Status + worktree-sourced diff keep the staging compose panel — it's
@@ -129,50 +222,53 @@ export function renderDetailPanel(
   // history → Enter) gets a dedicated explore panel: subject, body, and a
   // navigable file list whose selection swaps the center diff.
   if (state.activeView === 'status') {
-    return renderCommitPanel(h, components, state, context, contextStatus, width, theme, focused)
+    return h(coreDetailComponent(React, 'commit')!)
   }
 
   if (state.activeView === 'diff') {
     if (state.diffSource === 'commit') {
-      return renderCommitDiffDetail(h, components, state, detail, loading, width, theme, focused)
+      return h(commitDiffDetailComponent(React), { detail, loading })
     }
-    return renderCommitPanel(h, components, state, context, contextStatus, width, theme, focused)
+    return h(coreDetailComponent(React, 'commit')!)
   }
 
   // Compose view: the right panel had been falling through to the inspector
   // and showing the last selected commit's data, which is wrong context for
   // an in-progress commit. Show the worktree summary instead.
   if (state.activeView === 'compose') {
-    return renderComposeContextPanel(h, components, state, context, contextStatus, width, theme, focused)
+    return h(coreDetailComponent(React, 'composeContext')!)
   }
 
   // Preview pane (P4.1) — fzf / yazi / lazygit style: branches, tags, and
   // stash views each get a tailored summary of the selected entry instead
   // of falling through to the (stale) history inspector.
   if (state.activeView === 'branches') {
-    return renderBranchPreviewPanel(h, components, state, context, contextStatus, width, theme, focused)
+    return h(coreDetailComponent(React, 'branchPreview')!)
   }
   if (state.activeView === 'tags') {
-    return renderTagPreviewPanel(h, components, state, context, contextStatus, width, theme, focused)
+    return h(coreDetailComponent(React, 'tagPreview')!)
   }
   if (state.activeView === 'stash') {
-    return renderStashPreviewPanel(h, components, state, context, contextStatus, width, theme, focused)
+    return h(coreDetailComponent(React, 'stashPreview')!)
   }
 
   if (state.activeView === 'submodules') {
-    return renderSubmodulePreviewPanel(h, components, state, context, contextStatus, width, theme, focused)
+    return h(coreDetailComponent(React, 'submodulePreview')!)
   }
 
   if (state.activeView === 'issues') {
-    return renderIssueTriagePreviewPanel(h, components, state, context, contextStatus, width, theme, focused)
+    return h(coreDetailComponent(React, 'issuePreview')!)
   }
 
   if (state.activeView === 'pull-request-triage') {
-    return renderPullRequestTriagePreviewPanel(h, components, state, context, contextStatus, width, theme, focused)
+    return h(coreDetailComponent(React, 'prPreview')!)
   }
 
-  return renderHistoryInspector(
-    h, components, state, context, contextStatus, detail, loading,
-    filePreview, filePreviewLoading, width, tabbed, theme, focused
-  )
+  return h(historyInspectorComponent(React), {
+    detail,
+    loading,
+    filePreview,
+    filePreviewLoading,
+    tabbed,
+  })
 }

--- a/src/workstation/runtime/overlays.test.ts
+++ b/src/workstation/runtime/overlays.test.ts
@@ -6,6 +6,7 @@
  * pulling Ink (ESM) into ts-jest. Same trick as `singlePane.test.ts`.
  */
 import { createElement } from 'react'
+import * as React from 'react'
 import { createLogInkContextStatus } from '../chrome/context'
 import { createLogInkTheme } from '../chrome/theme'
 import { createLogInkState } from '../../workstation/runtime/inkViewModel'
@@ -44,7 +45,10 @@ function renderViewKeys(activeView: string) {
     showViewKeys: true,
     activeView: activeView as never,
   }
+  // The view-keys overlay returns before any per-view detail surface, so
+  // the `React` arg is unused here — pass the real instance for shape.
   return renderDetailPanel(
+    React,
     {
       h: createElement,
       components: { Box, Text },

--- a/src/workstation/runtime/singlePane.test.ts
+++ b/src/workstation/runtime/singlePane.test.ts
@@ -12,11 +12,13 @@
  * Ink (ESM) into ts-jest. Same trick as `footer.test.ts`.
  */
 import { createElement } from 'react'
+import * as React from 'react'
 import { createLogInkState } from '../../workstation/runtime/inkViewModel'
 import { createLogInkContextStatus } from '../chrome/context'
 import { getLogInkLayout } from '../chrome/layout'
 import { createLogInkTheme } from '../chrome/theme'
 import { renderDetailPanel } from './detailPanel'
+import type { LogInkRuntimeContextValue } from './runtimeContext'
 import { renderSidebar } from './sidebar'
 import type { LogInkContext } from './types'
 
@@ -30,6 +32,19 @@ const Box = ((props: StubProps) =>
 
 type Node = { props: StubProps }
 const asNode = (value: unknown): Node => value as Node
+
+// The detail surfaces now mount as components that read width/etc. from
+// LogInkRuntimeContext (#1237). A thin React shim whose `useContext`
+// returns a fixed runtime value lets us render the inspector component
+// without a renderer (same trick as header.test.ts).
+function reactWithRuntime(value: LogInkRuntimeContextValue): typeof React {
+  return new Proxy(React, {
+    get(target, prop, receiver) {
+      if (prop === 'useContext') return () => value
+      return Reflect.get(target, prop, receiver)
+    },
+  }) as typeof React
+}
 
 const theme = createLogInkTheme({ noColor: false })
 const context: LogInkContext = {}
@@ -67,27 +82,42 @@ describe('single-pane render smoke (80×24 floor)', () => {
     expect(layout.singlePane).toBe(true)
     expect(layout.visiblePane).toBe('inspector')
 
-    const tree = asNode(
-      renderDetailPanel(
-        {
-          h: createElement,
-          components: { Box, Text },
-          state,
-          context,
-          contextStatus,
-          bodyRows: layout.bodyRows,
-          width: layout.detailWidth,
-          theme,
-        },
-        {
-          detail: undefined,
-          loading: false,
-          filePreview: undefined,
-          filePreviewLoading: false,
-          tabbed: false,
-        }
-      )
-    )
+    // The inspector mounts as the HistoryInspector component; it reads its
+    // width from the runtime context's `layout.detailWidth` (80 here).
+    const runtimeValue: LogInkRuntimeContextValue = {
+      state,
+      dispatch: () => {},
+      theme,
+      layout,
+      context,
+      contextStatus,
+      h: createElement,
+      components: { Box, Text },
+    }
+    const shim = reactWithRuntime(runtimeValue)
+    const element = renderDetailPanel(
+      shim,
+      {
+        h: createElement,
+        components: { Box, Text },
+        state,
+        context,
+        contextStatus,
+        bodyRows: layout.bodyRows,
+        width: layout.detailWidth,
+        theme,
+      },
+      {
+        detail: undefined,
+        loading: false,
+        filePreview: undefined,
+        filePreviewLoading: false,
+        tabbed: false,
+      }
+    ) as unknown as { type: (props: unknown) => unknown; props: unknown }
+
+    // Render the returned component through the shim to reach the surface.
+    const tree = asNode(element.type(element.props))
     expect(tree.props.width).toBe(80)
   })
 })


### PR DESCRIPTION
## What

Fourth surface-migration batch (after [#1295](https://github.com/gfargo/coco/pull/1295)) — the **detail/inspector cluster**. The ten per-view detail surfaces now mount as context-reading components: `renderDetailPanel` returns `h(<Surface>Component, props)` instead of calling the positional renderer inline.

- **Eight preview/context panels** (commit, compose-context, branch/tag/stash/submodule previews, issue + PR triage previews) share one positional signature → grouped under a keyed cache.
- **Commit-sourced diff detail** and the **history inspector** take their async slices as component props (`detail`/`loading`; +`filePreview`/`filePreviewLoading`/`tabbed` for the inspector).

## Behavior-preserving

The detail renderers keep their **positional signatures and colocated render-snapshot suites unchanged** — `focused` is derived inside each wrapper from `state.focus === 'detail'`, exactly as the dispatcher did, so output is identical. `renderDetailPanel` gains a leading `React` param and no longer destructures `context`/`contextStatus` (the components self-serve those). The transient **overlays** (help/palette/pickers/confirmation/chord) stay positional — a separate concern.

## Tests

- New `detailPanel.test.ts` pins view→component routing + prop threading (without a renderer).
- `singlePane.test.ts` updated to render the inspector *through* the context shim (the `header.test.ts` Proxy pattern), still asserting full-width (80) in single-pane.
- `overlays.test.ts` gets the new `React` arg — its overlay branch returns before any component, so it's otherwise unaffected.

## Validation

`tsc` clean · full jest green (3611 passed, 68 snapshots; 4 `tsTreeSitterParser` `.wasm-backed` failures = known worktree gotcha, pass in CI) · eslint 0 errors · `rollup -c` builds.

## Next

PR 6 (final): per-surface memoization + prune the now-dead threading in `app.ts` (`SurfaceRenderContext` / `MainPanelExtras` shrink to true per-surface slices), then close #1237. Ladder in `specs/surface-context-migration-plan.md`.