### PR TITLE
fix(workstation): clear stuck "loading context" chip for lazy keys

### DIFF
--- a/src/workstation/runtime/repoFrameFactory.test.ts
+++ b/src/workstation/runtime/repoFrameFactory.test.ts
@@ -33,9 +33,15 @@ describe('createInitialContextStatus', () => {
     expect(status.submodules).toBe('loading')
   })
 
-  it('seeds pullRequest as idle so the chrome does not stick on loading (#808)', () => {
+  it('seeds every lazy-loaded key as idle so the chrome does not stick on "loading context"', () => {
     const status = createInitialContextStatus()
+    // These three are hydrated on entry to their view, not at boot, so
+    // leaving them 'loading' kept the header's context indicator stuck
+    // forever (#808 fixed pullRequest; issueList / pullRequestList were
+    // the missed siblings).
     expect(status.pullRequest).toBe('idle')
+    expect(status.issueList).toBe('idle')
+    expect(status.pullRequestList).toBe('idle')
   })
 
   it('returns a fresh object on each call', () => {

--- a/src/workstation/runtime/repoFrameFactory.ts
+++ b/src/workstation/runtime/repoFrameFactory.ts
@@ -9,23 +9,30 @@ import type { RepoFrameRuntime } from './repoStackRuntime'
 
 /**
  * Build the initial `LogInkContextStatus` for a freshly-created frame
- * (#931). Every fetched key starts in `'loading'` so surfaces show the
- * loading hint immediately; `pullRequest` is the exception (#808) —
- * it's lazy-loaded on entry to the PR view, so we seed it `'idle'`
- * instead of leaving it stuck as a permanent "loading" flag in the
- * chrome.
+ * (#931). Every *boot-fetched* key starts in `'loading'` so surfaces show
+ * the loading hint immediately.
  *
- * Extracted so the root runtime (built at boot inside `LogInkApp`) and
- * the per-frame factory below share one canonical seed. The status
- * surfaces depend on the exact `'pullRequest' = 'idle'` initialization
- * to avoid spurious loading hints; locking it down in one helper means
- * the two code paths can't drift.
+ * The three **lazy-loaded** keys are the exception — they're hydrated on
+ * entry to their dedicated view, not at boot (see `loadLogInkContextEntries`,
+ * which deliberately omits them), so they're seeded `'idle'`. Leaving them
+ * `'loading'` made the chrome's context indicator ("loading context") stick
+ * forever, since nothing flips them to `'ready'` until the user actually
+ * navigates there:
+ *   - `pullRequest`      — full PR overview, lazy on the PR view (#808)
+ *   - `issueList`        — issue triage list, lazy on the issues view (#882)
+ *   - `pullRequestList`  — PR triage list, lazy on the PR-triage view (#882)
+ *
+ * Extracted so the root runtime (built at boot inside `LogInkApp`) and the
+ * per-frame factory below share one canonical seed; the status surfaces
+ * depend on the exact lazy-key `'idle'` seeding to avoid spurious loading
+ * hints, so locking it down in one helper means the two paths can't drift.
  */
+const LAZY_CONTEXT_KEYS = ['pullRequest', 'issueList', 'pullRequestList'] as const
+
 export function createInitialContextStatus(): LogInkContextStatus {
-  return updateLogInkContextStatus(
+  return LAZY_CONTEXT_KEYS.reduce(
+    (status, key) => updateLogInkContextStatus(status, key, 'idle'),
     createLogInkContextStatus('loading'),
-    'pullRequest',
-    'idle',
   )
 }
 


### PR DESCRIPTION
## Symptom

The header's context indicator showed **"loading context"** permanently — even on a fully-loaded, clean repo on the history view (spotted during manual TUI testing of the surface-context migration).

![still says loading context]

## Root cause

`createInitialContextStatus` (`repoFrameFactory.ts`) seeds **every** context key `'loading'`. Boot hydration (`loadLogInkContextEntries`) then covers only the **12 boot-eager** keys and flips them to `'ready'`. Three keys are **lazy-loaded on entry to their view**, not at boot:

- `pullRequest` — full PR overview, PR view (#808)
- `issueList` — issue triage list, issues view (#882)
- `pullRequestList` — PR triage list, PR-triage view (#882)

So those three stayed `'loading'` forever, and the header's `isLogInkContextLoading` (`Object.values(status).some(s => s === 'loading')`) never cleared.

#808 already fixed exactly this for `pullRequest` (seed it `'idle'`), but the **two sibling lazy keys were missed**.

## Fix

Seed all three lazy keys `'idle'` via a single `LAZY_CONTEXT_KEYS` list, so the seed can't drift from `loadLogInkContextEntries` again. Each key still transitions `'idle'` → `'loading'` → `'ready'` through its own view-entry hydration (verified at `app.ts:928` / `app.ts:983`), unchanged — so the chip correctly flashes while a lazy list loads, then clears.

## Not a regression

`repoFrameFactory.ts` is untouched by the #1237 surface-context migration — this is a pre-existing latent bug surfaced by testing.

## Validation

`tsc` clean · full jest green (3611 passed, 68 snapshots; the 4 `tsTreeSitterParser` `.wasm-backed` failures are the known worktree WASM gotcha, pass in CI) · eslint 0 errors · `rollup -c` builds. `repoFrameFactory.test.ts` extended to assert all three lazy keys seed `'idle'`.