### PR TITLE
fix(cli): graceful top-level error handler instead of a raw stack dump

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import { UiOptions } from './commands/ui/config'
 import { WorkspaceOptions } from './commands/workspace/config'
 import { Config } from './lib/config/types'
 import * as types from './lib/types'
+import { handleFatalError } from './lib/ui/handleFatalError'
 import commandExecutor from './lib/utils/commandExecutor'
 
 const y = yargs()
@@ -223,8 +224,7 @@ async function main(): Promise<void> {
 }
 
 main().catch((error) => {
-  console.error(error)
-  process.exit(1)
+  process.exit(handleFatalError(error))
 })
 
 export {

--- a/src/lib/ui/handleFatalError.test.ts
+++ b/src/lib/ui/handleFatalError.test.ts
@@ -1,0 +1,76 @@
+import { CommandExitError } from '../utils/commandExit'
+import { handleFatalError, isFatalDebug } from './handleFatalError'
+
+describe('isFatalDebug', () => {
+  it('is true with --verbose', () => {
+    expect(isFatalDebug(['node', 'coco', 'commit', '--verbose'], {})).toBe(true)
+  })
+
+  it('is true with the -v alias', () => {
+    expect(isFatalDebug(['node', 'coco', '-v'], {})).toBe(true)
+  })
+
+  it('is true with COCO_DEBUG set', () => {
+    expect(isFatalDebug(['node', 'coco', 'commit'], { COCO_DEBUG: '1' })).toBe(true)
+  })
+
+  it('is false without either', () => {
+    expect(isFatalDebug(['node', 'coco', 'commit'], {})).toBe(false)
+  })
+})
+
+describe('handleFatalError', () => {
+  function capture(error: unknown, opts: { debug?: boolean } = {}) {
+    const out: string[] = []
+    const code = handleFatalError(error, { ...opts, write: (line) => out.push(line) })
+    return { code, text: out.join('\n') }
+  }
+
+  it('returns the exit code for an intentional CommandExitError without printing', () => {
+    const out: string[] = []
+    const code = handleFatalError(new CommandExitError(2), { write: (l) => out.push(l) })
+    expect(code).toBe(2)
+    // The handler that threw already printed friendly copy — we must not double up.
+    expect(out).toHaveLength(0)
+  })
+
+  it('preserves a zero exit code from CommandExitError', () => {
+    const out: string[] = []
+    expect(handleFatalError(new CommandExitError(0), { write: (l) => out.push(l) })).toBe(0)
+    expect(out).toHaveLength(0)
+  })
+
+  it('prints a friendly message + issue link and exits 1 for an unexpected error', () => {
+    const { code, text } = capture(new Error('kaboom'), { debug: false })
+    expect(code).toBe(1)
+    expect(text).toContain('unexpected error')
+    expect(text).toContain('kaboom')
+    expect(text).toContain('https://github.com/gfargo/coco/issues/new/choose')
+  })
+
+  it('hides the stack by default and points at --verbose', () => {
+    const err = new Error('kaboom')
+    err.stack = 'Error: kaboom\n    at secret-internal (/private/path.ts:1:1)'
+    const { text } = capture(err, { debug: false })
+    expect(text).not.toContain('secret-internal')
+    expect(text).toContain('--verbose')
+  })
+
+  it('includes the full stack when debug is on', () => {
+    const err = new Error('kaboom')
+    err.stack = 'Error: kaboom\n    at secret-internal (/private/path.ts:1:1)'
+    const { text } = capture(err, { debug: true })
+    expect(text).toContain('secret-internal')
+  })
+
+  it('handles a non-Error throw (string)', () => {
+    const { code, text } = capture('just a string', { debug: false })
+    expect(code).toBe(1)
+    expect(text).toContain('just a string')
+  })
+
+  it('falls back to "Unknown error" for an empty message', () => {
+    const { text } = capture(new Error(''), { debug: false })
+    expect(text).toContain('Unknown error')
+  })
+})

--- a/src/lib/ui/handleFatalError.ts
+++ b/src/lib/ui/handleFatalError.ts
@@ -1,0 +1,77 @@
+import chalk from 'chalk'
+
+import { isCommandExitError } from '../utils/commandExit'
+import { FAIL } from './glyphs'
+
+/** Where unexpected-crash copy points users to file a report. */
+const ISSUE_URL = 'https://github.com/gfargo/coco/issues/new/choose'
+
+/**
+ * Whether the fatal handler should print the full stack trace. Read from the
+ * raw process args + env rather than parsed yargs argv, because the top-level
+ * `main().catch` runs outside (and sometimes before) yargs parsing. Mirrors
+ * the global `--verbose` / `-v` flag, plus a `COCO_DEBUG` escape hatch.
+ */
+export function isFatalDebug(
+  argv: readonly string[] = process.argv,
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return argv.includes('--verbose') || argv.includes('-v') || Boolean(env.COCO_DEBUG)
+}
+
+/**
+ * Last-resort handler for errors that escape `commandExecutor` and reach
+ * `main().catch` — yargs setup, the env-driven prefetch, the default router,
+ * or anything thrown before a command's own graceful handling kicks in.
+ * Returns the exit code so the caller drives `process.exit`.
+ *
+ * Two cases:
+ *   - {@link CommandExitError} — an intentional, already-messaged exit (the
+ *     handler that threw it printed the friendly copy). Return its code
+ *     silently; printing anything here would double up.
+ *   - Anything else — an unexpected crash. Print a short, actionable message
+ *     (the cause + how to report it) instead of dumping a raw stack trace as
+ *     the user's first impression. The full stack is gated behind
+ *     `--verbose` / `COCO_DEBUG` so a plain run stays readable while a bug
+ *     report can still include the trace. Doubles as a crash→issue funnel.
+ *
+ * `write` is injectable for testing; defaults to stderr.
+ */
+export function handleFatalError(
+  error: unknown,
+  opts: { debug?: boolean; write?: (line: string) => void } = {}
+): number {
+  if (isCommandExitError(error)) {
+    return error.code
+  }
+
+  const debug = opts.debug ?? isFatalDebug()
+  const write = opts.write ?? ((line: string) => console.error(line))
+  const message = error instanceof Error ? error.message : String(error)
+
+  const lines = [
+    '',
+    `${FAIL()} ${chalk.bold('coco hit an unexpected error.')}`,
+    '',
+    chalk.red(message || 'Unknown error'),
+    '',
+  ]
+
+  if (debug && error instanceof Error && error.stack) {
+    lines.push(chalk.dim(error.stack), '')
+  } else {
+    lines.push(
+      chalk.dim('Re-run with --verbose (or COCO_DEBUG=1) to see the full stack trace.'),
+      ''
+    )
+  }
+
+  lines.push(
+    `${chalk.bold('Looks like a bug?')} Please report it: ${chalk.cyan(ISSUE_URL)}`,
+    chalk.dim('Include the command you ran and the output above.'),
+    ''
+  )
+
+  write(lines.join('\n'))
+  return 1
+}


### PR DESCRIPTION
## Symptom

`main().catch` printed the **raw Error object** (full stack trace) for any error that escaped `commandExecutor` — yargs setup, the env-driven prefetch, the default router, or anything thrown before a command's own graceful handling. On a fresh install (launch traffic!) that's a wall of stack trace as the user's first impression.

```js
// before
main().catch((error) => { console.error(error); process.exit(1) })
```

## Fix

Route it through a new, tested `handleFatalError` (`src/lib/ui/handleFatalError.ts`):

- **`CommandExitError`** → return its code **silently** — the handler that threw it (e.g. `handleMissingApiKey`) already printed friendly copy; printing again would double up.
- **Anything else** → a short, actionable message: the cause + a **"report a bug"** link to the issue chooser, instead of a stack. The full stack is gated behind `--verbose` / `COCO_DEBUG`, so plain runs stay readable while a bug report can still include the trace.

It doubles as a **crash → issue funnel** — exactly the kind of feedback the freeze's distribution push is trying to open.

`commandExecutor`'s own `formatGenericError` already handles unexpected *command* errors this way (message unconditionally, stack under `--verbose`); this brings the last-resort catch in line, and reuses the existing `--verbose`/`-v` convention.

## Tests

`handleFatalError.test.ts` (11 cases): `CommandExitError` passes its code through with **no output** (incl. code 0); unknown errors print message + issue link + exit 1; stack hidden by default / shown under debug; `isFatalDebug` detects `--verbose` / `-v` / `COCO_DEBUG`; non-Error throws and empty messages handled. The `write` fn is injectable so no `process.exit` / console capture needed.

## Validation

`tsc` clean · full jest green (3622 passed, 68 snapshots; 4 `tsTreeSitterParser` `.wasm-backed` failures are the known worktree WASM gotcha, pass in CI) · eslint 0 errors · `rollup -c` builds · built-CLI `--version` smoke OK.