### PR TITLE
fix(commit): restore type compat after @langchain/core 1.1.48 bump

### DIFF
--- a/src/commands/commit/generateCommitDraft.ts
+++ b/src/commands/commit/generateCommitDraft.ts
@@ -366,7 +366,17 @@ export async function generateCommitDraft({
       // fall through to executeChainWithSchema below for a real
       // schema-validated retry — paying for a second LLM call only
       // on the edge case where the streamed output is unsalvageable.
-      const streamingParser = createSchemaParser(schema)
+      //
+      // `: any` matches every other `createSchemaParser` call site
+      // (recap / changelog / review / executeChainWithSchema): since
+      // @langchain/core 1.1.48, `StructuredOutputParser.fromZodSchema`
+      // returns a parser whose output type is erased to `unknown` (the
+      // bundled Zod 4 types no longer flow through), so a strictly-typed
+      // assignment no longer satisfies `executeChainStreaming`'s
+      // `Runnable<…, { title, body }>` parser param. The runtime parser
+      // is unchanged; only its inferred TS type regressed.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const streamingParser: any = createSchemaParser(schema)
       // Capture the final accumulated text out-of-band so we can
       // attempt salvage if the parser throws on completion (audit
       // finding #1). Updated on every chunk; the last value is


### PR DESCRIPTION
## Why

`main` is **red** — the Dependabot `@langchain/core` bump (1.1.34 → 1.1.48, merged in #1262's batch) broke the build:

```
src/commands/commit/generateCommitDraft.ts(387,11): error TS2322:
  Type 'StructuredOutputParser<ZodType<unknown, …>>' is not assignable to
  type 'Runnable<any, { title: string; body: string; }, …>'.
    Type 'Promise<unknown>' is not assignable to type 'Promise<{ title; body }>'.
```

Since 1.1.48, `StructuredOutputParser.fromZodSchema` returns a parser whose output type is erased to `unknown` (the bundled **Zod 4** types — note `$ZodTypeInternals` — no longer flow through). So the one strictly-typed `createSchemaParser` call site no longer satisfies `executeChainStreaming`'s `Runnable<…, { title, body }>` parser param.

## Fix

Annotate that call site `: any` with the matching `eslint-disable-next-line @typescript-eslint/no-explicit-any` — **exactly what every other `createSchemaParser` caller already does** (`recap`, `changelog`, `review`, `executeChainWithSchema`) for this same dual-zod typing friction (the function already casts its input `as never` for the same reason). The runtime parser is unchanged; only its *inferred TS type* regressed with the dependency bump.

Minimal and convention-consistent on purpose — a generic over the project's Zod risks fighting langchain's bundled Zod-4 types, and the priority is getting `main` green again.

## Validation

`tsc` clean · the previously-failing suites pass (commit / integration / prCreate / amend — 165 tests) · full jest green (3611 passed, 68 snapshots; 4 `tsTreeSitterParser` `.wasm-backed` failures are the known worktree WASM gotcha, pass in CI) · eslint 0 errors · `rollup -c` builds.

## Note

This is a pre-existing breakage on `main` (a merged Dependabot bump), not from any feature branch — it currently blocks every open PR. Merging this unblocks the queue.