### PR TITLE
fix(config): don't crash on a malformed .coco.json — warn and fall back

### DIFF
--- a/src/lib/config/services/project.test.ts
+++ b/src/lib/config/services/project.test.ts
@@ -43,6 +43,26 @@ describe('loadProjectConfig', () => {
     expect(config.service.provider).toBe('openai')
   })
 
+  it('does not crash on a malformed JSON config — warns and falls back', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+    mockFs.existsSync.mockReturnValue(true)
+    // A stray token — exactly the kind of hand-edit typo a user makes.
+    mockFs.readFileSync.mockReturnValue('{ "service": { bad json ]')
+
+    let config: Config | undefined
+    expect(() => {
+      config = loadProjectJsonConfig(openAIAliasConfig) as Config
+    }).not.toThrow()
+
+    // Falls back to the other config sources (here, the passed-in base).
+    expect(config?.service.provider).toBe('openai')
+    // Warns loudly with the file + the parse reason.
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0][0]).toContain('could not parse')
+    expect(warn.mock.calls[0][0]).toContain('.coco.json')
+    warn.mockRestore()
+  })
+
   it('should load project config with service alias', () => {
     mockFs.existsSync.mockReturnValue(true)
     mockFs.readFileSync.mockReturnValue(

--- a/src/lib/config/services/project.ts
+++ b/src/lib/config/services/project.ts
@@ -39,11 +39,32 @@ export function loadProjectJsonConfig<ConfigType = Config>(
   }
 
   if (resolvedPath) {
+    // Parse defensively. A malformed config file (a stray comma, an
+    // unquoted key) must NOT crash the whole tool — that's the same
+    // philosophy the validation path below spells out: a recoverable
+    // config problem should warn, not blow up at load time (which, since
+    // config loads early, took down every command with a raw stack trace).
+    // On a parse error we warn loudly with the file + the reason, then
+    // fall back to the other config sources so coco still runs.
+    let parsed: (Partial<Config> & { $schema?: string }) | undefined
+    try {
+      parsed = JSON.parse(fs.readFileSync(resolvedPath, 'utf-8')) as Partial<Config> & {
+        $schema?: string
+      }
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      console.warn(
+        `[coco] Warning: could not parse ${resolvedPath} as JSON — ignoring it.\n` +
+        `  Parse error: ${reason}\n` +
+        `  Fix the file's syntax (or run \`coco init\` to regenerate it). ` +
+        `Other config sources (defaults, XDG, git, env) still apply.`
+      )
+    }
+
+    if (parsed) {
     // Removing $schema from the project config to avoid validation errors.
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { $schema, ...projectConfig } = JSON.parse(
-      fs.readFileSync(resolvedPath, 'utf-8')
-    ) as Partial<Config> & { $schema: string }
+    const { $schema, ...projectConfig } = parsed
 
     const merged = { ...config, ...projectConfig } as Config
 
@@ -85,6 +106,7 @@ export function loadProjectJsonConfig<ConfigType = Config>(
       )
     }
     config = merged
+    }
   }
 
   if (opts?.returnSource) {


### PR DESCRIPTION
## Symptom (found during the pre-launch cold-start QA sweep)

A single JSON typo in `.coco.json` — a stray comma, an unquoted key — **crashed coco with a raw stack trace**:

```
SyntaxError: Expected property name or '}' in JSON at position 2
    at JSON.parse (<anonymous>)
    at loadProjectJsonConfig (...)
    ...
Node.js v24.16.0
```

Worse: config loads **early** (before yargs / `commandExecutor`), so this bypassed *every* graceful handler — including the new top-level one from #1299 — and dumped a Node stack as the user's first impression. Launch users hand-editing `.coco.json` will hit this.

## Fix

`loadProjectJsonConfig` parsed the file with an **unguarded `JSON.parse`** — even though the code immediately below already documents the intended philosophy for config problems: *"warn loudly, don't blow up at load time, fall back to defaults."* A *syntax* error skipped that path.

Wrap the parse in try/catch. On failure: warn with the file path + the parse reason + how to fix it (or run `coco init`), then fall back to the other config sources (defaults / XDG / git / env) so coco still runs.

```
[coco] Warning: could not parse .coco.json as JSON — ignoring it.
  Parse error: Expected property name or '}' in JSON at position 2 (line 1 column 3)
  Fix the file's syntax (or run `coco init` to regenerate it). Other config sources (defaults, XDG, git, env) still apply.
```

## Tests

A malformed file no longer throws, falls back to the base config, and warns once with the file + reason. Verified end-to-end: `coco doctor` against a corrupt `.coco.json` now warns and proceeds instead of crashing.

## Validation

`tsc` clean · full jest green (3623 passed, 68 snapshots; 4 `tsTreeSitterParser` `.wasm-backed` failures are the known worktree WASM gotcha, pass in CI) · eslint 0 errors · `rollup -c` builds.

## Known follow-up (not this PR)

The warning prints once per config load, and config loads a few times per invocation — so it repeats. Pre-existing (the schema-validation warning already does this); deduping is a separate change.