### PR TITLE
fix(cli): graceful "Cancelled." on a user-cancelled prompt

### DIFF
--- a/src/lib/utils/commandExecutor.test.ts
+++ b/src/lib/utils/commandExecutor.test.ts
@@ -1,4 +1,4 @@
-import commandExecutor, { extractMissingOllamaModel } from './commandExecutor'
+import commandExecutor, { extractMissingOllamaModel, isPromptCancellation } from './commandExecutor'
 import { loadConfig } from '../config/utils/loadConfig'
 import { Logger } from './logger'
 import { CommandHandler } from '../types'
@@ -63,5 +63,23 @@ describe('extractMissingOllamaModel', () => {
     expect(extractMissingOllamaModel(new Error('ECONNREFUSED'))).toBeNull()
     expect(extractMissingOllamaModel('not an error')).toBeNull()
     expect(extractMissingOllamaModel(undefined)).toBeNull()
+  })
+})
+
+describe('isPromptCancellation', () => {
+  it('detects @inquirer/prompts ExitPromptError by name', () => {
+    const err = new Error('User force closed the prompt with 0 null')
+    err.name = 'ExitPromptError'
+    expect(isPromptCancellation(err)).toBe(true)
+  })
+
+  it('detects the cancel via the message even if the name drifts', () => {
+    expect(isPromptCancellation(new Error('User force closed the prompt with SIGINT'))).toBe(true)
+  })
+
+  it('is false for ordinary errors and non-Errors', () => {
+    expect(isPromptCancellation(new Error('Something else failed'))).toBe(false)
+    expect(isPromptCancellation('force closed the prompt')).toBe(false)
+    expect(isPromptCancellation(undefined)).toBe(false)
   })
 })

--- a/src/lib/utils/commandExecutor.ts
+++ b/src/lib/utils/commandExecutor.ts
@@ -119,6 +119,21 @@ function formatGenericError(error: Error, logger: Logger): void {
 }
 
 /**
+ * Detect a user-cancelled interactive prompt. `@inquirer/prompts` throws an
+ * `ExitPromptError` (message: "User force closed the prompt …") when the user
+ * hits Ctrl-C — or when there's no TTY and stdin is closed (e.g. a piped run).
+ * Without this it fell through to {@link formatGenericError} and surfaced as a
+ * scary "Failed to execute command / Error: User force closed the prompt with
+ * 0 null" — a rough first-run moment for anyone who Ctrl-C's out of `coco init`.
+ * Matched by name (not an `instanceof` import) to stay decoupled from the
+ * prompt lib's version, with a message fallback for older variants.
+ */
+export function isPromptCancellation(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  return error.name === 'ExitPromptError' || /force closed the prompt/i.test(error.message)
+}
+
+/**
  * Detect Ollama's "model not pulled" failure and pull out the model name.
  *
  * When the daemon is up but the requested model isn't pulled, Ollama returns
@@ -199,6 +214,15 @@ function commandExecutor<T extends Argv<BaseArgvOptions>['argv']>(handler: Comma
     } catch (error) {
       if (isCommandExitError(error)) {
         process.exitCode = error.code
+        return
+      }
+
+      // A user-cancelled prompt (Ctrl-C out of `coco init`, or a non-TTY
+      // run) is a normal action, not a crash — exit cleanly with a gentle
+      // note instead of the generic "Failed to execute command" path.
+      if (isPromptCancellation(error)) {
+        logger.log('\nCancelled.', { color: 'yellow' })
+        process.exitCode = 130 // 128 + SIGINT, the conventional "interrupted" code
         return
       }
 


### PR DESCRIPTION
## Symptom (pre-launch cold-start sweep, finding #2)

Ctrl-C out of `coco init` — or any interactive prompt, and non-TTY runs where stdin is closed — surfaced as:

```
Failed to execute command

Error: User force closed the prompt with 0 null
```

`@inquirer/prompts` throws an `ExitPromptError` on cancel, which fell through to `formatGenericError`. Cancelling a prompt is a *normal action*, not a crash — but it read like one. Launch users will Ctrl-C out of `init`.

## Fix

Detect it centrally in `commandExecutor` (so **every** prompting command benefits) and treat it gracefully:

```
Cancelled.
```

…with exit code **130** (128 + SIGINT, the conventional "interrupted" code). `isPromptCancellation` matches by error name (`ExitPromptError`) with a message fallback, so it stays decoupled from the prompt lib's version.

## Tests

`isPromptCancellation` unit tests (name match, message fallback, false for ordinary/non-Errors). Verified end-to-end: `coco init` with closed stdin now prints `Cancelled.` instead of the raw prompt error.

## Validation

`tsc` clean · full jest green (3626 passed, 68 snapshots; 4 `tsTreeSitterParser` `.wasm-backed` failures are the known worktree WASM gotcha, pass in CI) · eslint 0 errors · `rollup -c` builds.

---

This is the second of two fixes from the cold-start QA sweep (after #1301, the malformed-config crash). A third, lower-severity finding — config-load warnings printing ~3× per invocation — is noted as a separate follow-up.