### PR TITLE
feat(parsers): add Kotlin + Swift structural-diff fast-path parsers

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -419,14 +419,16 @@
                       "cpp",
                       "cs",
                       "rb",
-                      "php"
+                      "php",
+                      "kt",
+                      "swift"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
             }
           },
           "additionalProperties": false,
@@ -963,14 +965,16 @@
                       "cpp",
                       "cs",
                       "rb",
-                      "php"
+                      "php",
+                      "kt",
+                      "swift"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
             }
           },
           "additionalProperties": false,
@@ -1178,14 +1182,16 @@
                       "cpp",
                       "cs",
                       "rb",
-                      "php"
+                      "php",
+                      "kt",
+                      "swift"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
             }
           },
           "additionalProperties": false,
@@ -1380,14 +1386,16 @@
                       "cpp",
                       "cs",
                       "rb",
-                      "php"
+                      "php",
+                      "kt",
+                      "swift"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
             }
           },
           "additionalProperties": false,
@@ -1582,14 +1590,16 @@
                       "cpp",
                       "cs",
                       "rb",
-                      "php"
+                      "php",
+                      "kt",
+                      "swift"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
             }
           },
           "additionalProperties": false,
@@ -1793,14 +1803,16 @@
                       "cpp",
                       "cs",
                       "rb",
-                      "php"
+                      "php",
+                      "kt",
+                      "swift"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
             }
           },
           "additionalProperties": false,
@@ -2007,14 +2019,16 @@
                       "cpp",
                       "cs",
                       "rb",
-                      "php"
+                      "php",
+                      "kt",
+                      "swift"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
             }
           },
           "additionalProperties": false,

--- a/src/lib/langchain/types.ts
+++ b/src/lib/langchain/types.ts
@@ -309,6 +309,8 @@ export type BaseLLMService = {
      *   - 'cs' : `.cs`
      *   - 'rb' : `.rb`
      *   - 'php' : `.php`
+     *   - 'kt' : `.kt` / `.kts`
+     *   - 'swift' : `.swift`
      */
     languageAware?: {
       /**
@@ -333,6 +335,8 @@ export type BaseLLMService = {
         | 'cs'
         | 'rb'
         | 'php'
+        | 'kt'
+        | 'swift'
       )[]
     }
   }

--- a/src/lib/parsers/default/utils/createFileChangeParserOptions.ts
+++ b/src/lib/parsers/default/utils/createFileChangeParserOptions.ts
@@ -25,6 +25,8 @@ export type FileChangeParserServiceBudget = {
         | 'cs'
         | 'rb'
         | 'php'
+        | 'kt'
+        | 'swift'
       )[]
     }
   }

--- a/src/lib/parsers/default/utils/ktStructuralDiff.test.ts
+++ b/src/lib/parsers/default/utils/ktStructuralDiff.test.ts
@@ -1,0 +1,113 @@
+import { FileDiff } from '../../../types'
+import {
+  isKotlinFile,
+  parseKotlinStructuralLine,
+  summarizeKotlinStructuralDiff,
+} from './ktStructuralDiff'
+
+function fileDiff(file: string, diff: string): FileDiff {
+  return { file, diff, tokenCount: diff.length, summary: '' } as FileDiff
+}
+
+describe('isKotlinFile', () => {
+  it('matches .kt and .kts files only', () => {
+    expect(isKotlinFile('src/Widget.kt')).toBe(true)
+    expect(isKotlinFile('build.gradle.kts')).toBe(true)
+    expect(isKotlinFile('src/widget.java')).toBe(false)
+    expect(isKotlinFile('src/widget.swift')).toBe(false)
+  })
+})
+
+describe('parseKotlinStructuralLine', () => {
+  it('recognizes functions, generics, and extension functions', () => {
+    expect(parseKotlinStructuralLine('fun render() {')).toEqual({
+      name: 'render', kind: 'function', exported: true,
+    })
+    expect(parseKotlinStructuralLine('fun <T> map(x: T): T {')).toEqual({
+      name: 'map', kind: 'function', exported: true,
+    })
+    expect(parseKotlinStructuralLine('fun String.shout(): String {')).toEqual({
+      name: 'shout', kind: 'function', exported: true,
+    })
+  })
+
+  it('recognizes class / data class / sealed class', () => {
+    expect(parseKotlinStructuralLine('class Widget {')).toEqual({
+      name: 'Widget', kind: 'class', exported: true,
+    })
+    expect(parseKotlinStructuralLine('data class Point(val x: Int)')).toEqual({
+      name: 'Point', kind: 'class', exported: true,
+    })
+    expect(parseKotlinStructuralLine('sealed class Result')).toEqual({
+      name: 'Result', kind: 'class', exported: true,
+    })
+  })
+
+  it('recognizes interface, fun interface, enum class, and object', () => {
+    expect(parseKotlinStructuralLine('interface Drawable {')).toEqual({
+      name: 'Drawable', kind: 'interface', exported: true,
+    })
+    expect(parseKotlinStructuralLine('fun interface Handler {')).toEqual({
+      name: 'Handler', kind: 'interface', exported: true,
+    })
+    expect(parseKotlinStructuralLine('enum class Color {')).toEqual({
+      name: 'Color', kind: 'enum', exported: true,
+    })
+    expect(parseKotlinStructuralLine('object Registry {')).toEqual({
+      name: 'Registry', kind: 'class', exported: true,
+    })
+  })
+
+  it('tracks private/internal visibility (exported: false)', () => {
+    expect(parseKotlinStructuralLine('private fun helper() {}')).toEqual({
+      name: 'helper', kind: 'function', exported: false,
+    })
+    expect(parseKotlinStructuralLine('internal class Impl {')).toEqual({
+      name: 'Impl', kind: 'class', exported: false,
+    })
+  })
+
+  it('accepts modest indentation, rejects deeply nested lines', () => {
+    expect(parseKotlinStructuralLine('    fun inner() {')).toEqual({
+      name: 'inner', kind: 'function', exported: true,
+    })
+    expect(parseKotlinStructuralLine('            fun deep() {}')).toBeUndefined()
+  })
+
+  it('returns undefined for control-flow, calls, properties, and blanks', () => {
+    expect(parseKotlinStructuralLine('if (x > 0) {')).toBeUndefined()
+    expect(parseKotlinStructuralLine('return render()')).toBeUndefined()
+    expect(parseKotlinStructuralLine('val total = 1')).toBeUndefined()
+    expect(parseKotlinStructuralLine('')).toBeUndefined()
+  })
+})
+
+describe('summarizeKotlinStructuralDiff', () => {
+  it('returns undefined for non-Kotlin files', () => {
+    expect(summarizeKotlinStructuralDiff(fileDiff('README.md', '+x'))).toBeUndefined()
+  })
+
+  it('names added classes and functions', () => {
+    const diff = [
+      '@@ -0,0 +1,3 @@',
+      '+class Widget {',
+      '+  fun render() {}',
+      '+}',
+    ].join('\n')
+    const out = summarizeKotlinStructuralDiff(fileDiff('src/Widget.kt', diff)) || ''
+    expect(out).toContain('Updated Kotlin `src/Widget.kt`')
+    expect(out).toMatch(/class Widget/)
+    expect(out).toMatch(/render\(\)/)
+  })
+
+  it('returns undefined for body-only edits', () => {
+    const diff = [
+      '@@ -1,3 +1,3 @@',
+      ' fun compute(): Int {',
+      '-    return 1',
+      '+    return 2',
+      ' }',
+    ].join('\n')
+    expect(summarizeKotlinStructuralDiff(fileDiff('src/w.kt', diff))).toBeUndefined()
+  })
+})

--- a/src/lib/parsers/default/utils/ktStructuralDiff.ts
+++ b/src/lib/parsers/default/utils/ktStructuralDiff.ts
@@ -1,0 +1,85 @@
+import { FileDiff } from '../../../types'
+import {
+  StructuralSymbol,
+  summarizeStructuralDiff,
+} from './structuralDiff'
+
+/**
+ * Kotlin structural fast path.
+ *
+ * Recognizes top-level declarations on a single line: `fun` (including
+ * generic `fun <T> name(` and extension `fun Receiver.name(`), `class` /
+ * `data class` / `sealed class` / `abstract class` / `open class`,
+ * `enum class`, `interface` / `fun interface`, and named `object`s.
+ *
+ * Kotlin is public-by-default; we strip leading declaration modifiers and
+ * mark `private` / `protected` / `internal` declarations `exported: false`
+ * (cosmetic — the shared renderer doesn't surface it today, but it keeps
+ * the symbol shape honest). Nuance beyond a single line (multi-line
+ * signatures, nested locals) is left to the LLM fallback.
+ *
+ * Like the other regex parsers we accept up to ~8 spaces (2 indent levels)
+ * of leading whitespace so nested members still register, and bail on
+ * anything deeper.
+ */
+
+const KT_EXTENSIONS = ['.kt', '.kts']
+
+// Leading declaration modifiers, stripped before matching the keyword.
+// `enum` is intentionally absent — `enum class` is matched as a unit.
+const KT_MODIFIER =
+  /^(?:public|protected|private|internal|open|final|abstract|sealed|data|inner|annotation|value|companion|inline|infix|operator|suspend|external|override|lateinit|tailrec|expect|actual)\s+/
+
+export function isKotlinFile(path: string): boolean {
+  const lower = path.toLowerCase()
+  return KT_EXTENSIONS.some((ext) => lower.endsWith(ext))
+}
+
+export function parseKotlinStructuralLine(line: string): StructuralSymbol | undefined {
+  const trimmed = line.replace(/^[ \t]{0,8}/, '')
+  const leftover = trimmed.replace(/^[ \t]+/, '')
+  if (leftover !== trimmed) return undefined
+
+  // Strip leading modifiers, recording visibility.
+  let body = trimmed
+  let exported = true
+  for (;;) {
+    const m = body.match(KT_MODIFIER)
+    if (!m) break
+    if (/^(?:private|protected|internal)\b/.test(m[0])) exported = false
+    body = body.slice(m[0].length)
+  }
+
+  // `enum class Name` — before the plain `class` matcher.
+  const enumMatch = body.match(/^enum\s+class\s+([A-Za-z_]\w*)/)
+  if (enumMatch) return { name: enumMatch[1], kind: 'enum', exported }
+
+  // `interface Name` / `fun interface Name` (SAM) — before `fun`/`class`.
+  const interfaceMatch = body.match(/^(?:fun\s+)?interface\s+([A-Za-z_]\w*)/)
+  if (interfaceMatch) return { name: interfaceMatch[1], kind: 'interface', exported }
+
+  // `class Name` (modifiers already stripped).
+  const classMatch = body.match(/^class\s+([A-Za-z_]\w*)/)
+  if (classMatch) return { name: classMatch[1], kind: 'class', exported }
+
+  // Named `object Name` (singleton). Anonymous `companion object` has no
+  // name and isn't worth reporting.
+  const objectMatch = body.match(/^object\s+([A-Za-z_]\w*)/)
+  if (objectMatch) return { name: objectMatch[1], kind: 'class', exported }
+
+  // `fun name(` / `fun <T> name(` / `fun Receiver.name(`.
+  const funMatch = body.match(
+    /^fun\s+(?:<[^>]*>\s*)?(?:[A-Za-z_][\w.]*\.)?([A-Za-z_]\w*)\s*\(/
+  )
+  if (funMatch) return { name: funMatch[1], kind: 'function', exported }
+
+  return undefined
+}
+
+export function summarizeKotlinStructuralDiff(fileDiff: FileDiff): string | undefined {
+  if (!isKotlinFile(fileDiff.file)) return undefined
+  return summarizeStructuralDiff(fileDiff, {
+    label: 'Kotlin',
+    parseLine: parseKotlinStructuralLine,
+  })
+}

--- a/src/lib/parsers/default/utils/structuralParserRegistry.ts
+++ b/src/lib/parsers/default/utils/structuralParserRegistry.ts
@@ -33,10 +33,12 @@ import { summarizeCppStructuralDiff } from './cppStructuralDiff'
 import { summarizeCsStructuralDiff } from './csStructuralDiff'
 import { summarizeGoStructuralDiff } from './goStructuralDiff'
 import { summarizeJavaStructuralDiff } from './javaStructuralDiff'
+import { summarizeKotlinStructuralDiff } from './ktStructuralDiff'
 import { summarizePhpStructuralDiff } from './phpStructuralDiff'
 import { summarizePythonStructuralDiff } from './pythonStructuralDiff'
 import { summarizeRubyStructuralDiff } from './rbStructuralDiff'
 import { summarizeRustStructuralDiff } from './rustStructuralDiff'
+import { summarizeSwiftStructuralDiff } from './swiftStructuralDiff'
 import { summarizeTsStructuralDiff } from './tsStructuralDiff'
 
 /** Identifier reported by each parser for telemetry / debugging. */
@@ -54,6 +56,8 @@ export type StructuralLanguageId =
   | 'cs'
   | 'rb'
   | 'php'
+  | 'kt'
+  | 'swift'
 
 /**
  * A structural parser is a strategy for producing a templated
@@ -107,6 +111,8 @@ const regexCpp = regexParser(summarizeCppStructuralDiff)
 const regexCs = regexParser(summarizeCsStructuralDiff)
 const regexRb = regexParser(summarizeRubyStructuralDiff)
 const regexPhp = regexParser(summarizePhpStructuralDiff)
+const regexKt = regexParser(summarizeKotlinStructuralDiff)
+const regexSwift = regexParser(summarizeSwiftStructuralDiff)
 
 /**
  * Per-language parser chains, in priority order. Tree-sitter is
@@ -127,6 +133,8 @@ const REGISTRY: Record<StructuralLanguageId, StructuralParser[]> = {
   cs: [regexCs],
   rb: [regexRb],
   php: [regexPhp],
+  kt: [regexKt],
+  swift: [regexSwift],
 }
 
 /**

--- a/src/lib/parsers/default/utils/summarizeDiffs.ts
+++ b/src/lib/parsers/default/utils/summarizeDiffs.ts
@@ -197,6 +197,8 @@ export type SummarizeDiffsOptions = {
         | 'cs'
         | 'rb'
         | 'php'
+        | 'kt'
+        | 'swift'
       )[]
     }
   }

--- a/src/lib/parsers/default/utils/summarizeLargeFiles.ts
+++ b/src/lib/parsers/default/utils/summarizeLargeFiles.ts
@@ -14,10 +14,12 @@ import { isCppFile } from './cppStructuralDiff'
 import { isCsFile } from './csStructuralDiff'
 import { isGoFile } from './goStructuralDiff'
 import { isJavaFile } from './javaStructuralDiff'
+import { isKotlinFile } from './ktStructuralDiff'
 import { isPhpFile } from './phpStructuralDiff'
 import { isPythonFile } from './pythonStructuralDiff'
 import { isRubyFile } from './rbStructuralDiff'
 import { isRustFile } from './rustStructuralDiff'
+import { isSwiftFile } from './swiftStructuralDiff'
 import {
   dispatchStructuralParser,
   hasTreeSitterParser,
@@ -45,6 +47,8 @@ function detectStructuralLanguageId(path: string): StructuralLanguageId | undefi
   if (isCsFile(path)) return 'cs'
   if (isRubyFile(path)) return 'rb'
   if (isPhpFile(path)) return 'php'
+  if (isKotlinFile(path)) return 'kt'
+  if (isSwiftFile(path)) return 'swift'
   return undefined
 }
 
@@ -106,6 +110,8 @@ export type SummarizeLargeFilesOptions = {
         | 'cs'
         | 'rb'
         | 'php'
+        | 'kt'
+        | 'swift'
       )[]
     }
   }

--- a/src/lib/parsers/default/utils/swiftStructuralDiff.test.ts
+++ b/src/lib/parsers/default/utils/swiftStructuralDiff.test.ts
@@ -1,0 +1,115 @@
+import { FileDiff } from '../../../types'
+import {
+  isSwiftFile,
+  parseSwiftStructuralLine,
+  summarizeSwiftStructuralDiff,
+} from './swiftStructuralDiff'
+
+function fileDiff(file: string, diff: string): FileDiff {
+  return { file, diff, tokenCount: diff.length, summary: '' } as FileDiff
+}
+
+describe('isSwiftFile', () => {
+  it('matches .swift files only', () => {
+    expect(isSwiftFile('Sources/Widget.swift')).toBe(true)
+    expect(isSwiftFile('src/widget.kt')).toBe(false)
+    expect(isSwiftFile('src/widget.ts')).toBe(false)
+  })
+})
+
+describe('parseSwiftStructuralLine', () => {
+  it('recognizes functions, generics, and static/class methods', () => {
+    expect(parseSwiftStructuralLine('func render() {')).toEqual({
+      name: 'render', kind: 'function', exported: true,
+    })
+    expect(parseSwiftStructuralLine('func map<T>(_ x: T) -> T {')).toEqual({
+      name: 'map', kind: 'function', exported: true,
+    })
+    expect(parseSwiftStructuralLine('static func make() {')).toEqual({
+      name: 'make', kind: 'function', exported: true,
+    })
+    // `class func` is a type method — the `class` modifier must not be read
+    // as a `class` declaration named "func".
+    expect(parseSwiftStructuralLine('class func factory() {')).toEqual({
+      name: 'factory', kind: 'function', exported: true,
+    })
+  })
+
+  it('maps the type-like declarations to the nearest kind', () => {
+    expect(parseSwiftStructuralLine('class Widget {')).toEqual({
+      name: 'Widget', kind: 'class', exported: true,
+    })
+    expect(parseSwiftStructuralLine('struct Point {')).toEqual({
+      name: 'Point', kind: 'type', exported: true,
+    })
+    expect(parseSwiftStructuralLine('enum Color {')).toEqual({
+      name: 'Color', kind: 'enum', exported: true,
+    })
+    expect(parseSwiftStructuralLine('protocol Drawable {')).toEqual({
+      name: 'Drawable', kind: 'interface', exported: true,
+    })
+    expect(parseSwiftStructuralLine('extension String {')).toEqual({
+      name: 'String', kind: 'impl', exported: true,
+    })
+    expect(parseSwiftStructuralLine('actor Worker {')).toEqual({
+      name: 'Worker', kind: 'class', exported: true,
+    })
+  })
+
+  it('strips attributes + modifiers and tracks private visibility', () => {
+    expect(parseSwiftStructuralLine('public final class Foo {')).toEqual({
+      name: 'Foo', kind: 'class', exported: true,
+    })
+    expect(parseSwiftStructuralLine('@objc private func secret() {')).toEqual({
+      name: 'secret', kind: 'function', exported: false,
+    })
+    expect(parseSwiftStructuralLine('fileprivate struct Hidden {')).toEqual({
+      name: 'Hidden', kind: 'type', exported: false,
+    })
+  })
+
+  it('accepts modest indentation, rejects deeply nested lines', () => {
+    expect(parseSwiftStructuralLine('    func inner() {')).toEqual({
+      name: 'inner', kind: 'function', exported: true,
+    })
+    expect(parseSwiftStructuralLine('            func deep() {}')).toBeUndefined()
+  })
+
+  it('returns undefined for control-flow, calls, properties, and blanks', () => {
+    expect(parseSwiftStructuralLine('if x > 0 {')).toBeUndefined()
+    expect(parseSwiftStructuralLine('return render()')).toBeUndefined()
+    expect(parseSwiftStructuralLine('let total = 1')).toBeUndefined()
+    expect(parseSwiftStructuralLine('@objc')).toBeUndefined()
+    expect(parseSwiftStructuralLine('')).toBeUndefined()
+  })
+})
+
+describe('summarizeSwiftStructuralDiff', () => {
+  it('returns undefined for non-Swift files', () => {
+    expect(summarizeSwiftStructuralDiff(fileDiff('README.md', '+x'))).toBeUndefined()
+  })
+
+  it('names added structs and functions', () => {
+    const diff = [
+      '@@ -0,0 +1,3 @@',
+      '+struct Point {',
+      '+  func distance() -> Double {}',
+      '+}',
+    ].join('\n')
+    const out = summarizeSwiftStructuralDiff(fileDiff('Sources/Point.swift', diff)) || ''
+    expect(out).toContain('Updated Swift `Sources/Point.swift`')
+    expect(out).toMatch(/type Point/)
+    expect(out).toMatch(/distance\(\)/)
+  })
+
+  it('returns undefined for body-only edits', () => {
+    const diff = [
+      '@@ -1,3 +1,3 @@',
+      ' func compute() -> Int {',
+      '-    return 1',
+      '+    return 2',
+      ' }',
+    ].join('\n')
+    expect(summarizeSwiftStructuralDiff(fileDiff('w.swift', diff))).toBeUndefined()
+  })
+})

--- a/src/lib/parsers/default/utils/swiftStructuralDiff.ts
+++ b/src/lib/parsers/default/utils/swiftStructuralDiff.ts
@@ -1,0 +1,97 @@
+import { FileDiff } from '../../../types'
+import {
+  StructuralSymbol,
+  summarizeStructuralDiff,
+} from './structuralDiff'
+
+/**
+ * Swift structural fast path.
+ *
+ * Recognizes top-level declarations on a single line: `func` (including
+ * `static`/`class` methods and generic `func name<T>(`), `class`, `struct`,
+ * `enum`, `protocol`, `extension`, and `actor`. Maps each onto the nearest
+ * shared symbol kind:
+ *   - `struct`    → `type`      (no dedicated struct kind)
+ *   - `protocol`  → `interface`
+ *   - `extension` → `impl`
+ *   - `actor`     → `class`
+ *
+ * Swift puts attributes (`@objc`, `@MainActor(…)`) and access/behavior
+ * modifiers (`public`, `final`, `static`, `class`, …) before the keyword,
+ * so we strip those first. `class`/`static` are only stripped when they
+ * front a member declaration (`class func`, `static let`) — never a real
+ * `class Name`. We mark `private` / `fileprivate` declarations
+ * `exported: false` (cosmetic today).
+ *
+ * Up to ~8 spaces (2 indent levels) of leading whitespace is accepted so
+ * nested members register; deeper lines bail to the LLM fallback.
+ */
+
+const SWIFT_EXTENSIONS = ['.swift']
+
+// Leading attributes / modifiers stripped before the keyword. `class` and
+// `static` are stripped only when they precede a member keyword, so a real
+// `class Name` is never mistaken for the `class func`/`class var` modifier.
+const SWIFT_MODIFIER =
+  /^(?:@[A-Za-z_]\w*(?:\([^)]*\))?|public|private|fileprivate|internal|open|final|override|mutating|nonmutating|required|convenience|lazy|weak|unowned|dynamic|indirect|nonisolated|static|class(?=\s+(?:func|var|let|subscript|init)))\s+/
+
+// Declaration keywords that must never be read as a type name (guards
+// against e.g. `class func foo` slipping into the `class Name` matcher).
+const SWIFT_DECL_KEYWORDS = new Set([
+  'func', 'var', 'let', 'init', 'deinit', 'subscript', 'case', 'associatedtype', 'typealias',
+])
+
+export function isSwiftFile(path: string): boolean {
+  const lower = path.toLowerCase()
+  return SWIFT_EXTENSIONS.some((ext) => lower.endsWith(ext))
+}
+
+export function parseSwiftStructuralLine(line: string): StructuralSymbol | undefined {
+  const trimmed = line.replace(/^[ \t]{0,8}/, '')
+  const leftover = trimmed.replace(/^[ \t]+/, '')
+  if (leftover !== trimmed) return undefined
+
+  // Strip leading attributes + modifiers, recording visibility.
+  let body = trimmed
+  let exported = true
+  for (;;) {
+    const m = body.match(SWIFT_MODIFIER)
+    if (!m) break
+    if (/^(?:private|fileprivate)\b/.test(m[0])) exported = false
+    body = body.slice(m[0].length)
+  }
+
+  // `func name(` / `func name<T>(`.
+  const funcMatch = body.match(/^func\s+([A-Za-z_]\w*)\s*[(<]/)
+  if (funcMatch) return { name: funcMatch[1], kind: 'function', exported }
+
+  const protocolMatch = body.match(/^protocol\s+([A-Za-z_]\w*)/)
+  if (protocolMatch) return { name: protocolMatch[1], kind: 'interface', exported }
+
+  const extensionMatch = body.match(/^extension\s+([A-Za-z_][\w.]*)/)
+  if (extensionMatch) return { name: extensionMatch[1], kind: 'impl', exported }
+
+  const enumMatch = body.match(/^(?:indirect\s+)?enum\s+([A-Za-z_]\w*)/)
+  if (enumMatch) return { name: enumMatch[1], kind: 'enum', exported }
+
+  const structMatch = body.match(/^struct\s+([A-Za-z_]\w*)/)
+  if (structMatch) return { name: structMatch[1], kind: 'type', exported }
+
+  const actorMatch = body.match(/^actor\s+([A-Za-z_]\w*)/)
+  if (actorMatch) return { name: actorMatch[1], kind: 'class', exported }
+
+  const classMatch = body.match(/^class\s+([A-Za-z_]\w*)/)
+  if (classMatch && !SWIFT_DECL_KEYWORDS.has(classMatch[1])) {
+    return { name: classMatch[1], kind: 'class', exported }
+  }
+
+  return undefined
+}
+
+export function summarizeSwiftStructuralDiff(fileDiff: FileDiff): string | undefined {
+  if (!isSwiftFile(fileDiff.file)) return undefined
+  return summarizeStructuralDiff(fileDiff, {
+    label: 'Swift',
+    parseLine: parseSwiftStructuralLine,
+  })
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -430,14 +430,16 @@ export const schema = {
                       "cpp",
                       "cs",
                       "rb",
-                      "php"
+                      "php",
+                      "kt",
+                      "swift"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
             }
           },
           "additionalProperties": false,
@@ -974,14 +976,16 @@ export const schema = {
                       "cpp",
                       "cs",
                       "rb",
-                      "php"
+                      "php",
+                      "kt",
+                      "swift"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
             }
           },
           "additionalProperties": false,
@@ -1189,14 +1193,16 @@ export const schema = {
                       "cpp",
                       "cs",
                       "rb",
-                      "php"
+                      "php",
+                      "kt",
+                      "swift"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
             }
           },
           "additionalProperties": false,
@@ -1391,14 +1397,16 @@ export const schema = {
                       "cpp",
                       "cs",
                       "rb",
-                      "php"
+                      "php",
+                      "kt",
+                      "swift"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
             }
           },
           "additionalProperties": false,
@@ -1593,14 +1601,16 @@ export const schema = {
                       "cpp",
                       "cs",
                       "rb",
-                      "php"
+                      "php",
+                      "kt",
+                      "swift"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
             }
           },
           "additionalProperties": false,
@@ -1804,14 +1814,16 @@ export const schema = {
                       "cpp",
                       "cs",
                       "rb",
-                      "php"
+                      "php",
+                      "kt",
+                      "swift"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
             }
           },
           "additionalProperties": false,
@@ -2018,14 +2030,16 @@ export const schema = {
                       "cpp",
                       "cs",
                       "rb",
-                      "php"
+                      "php",
+                      "kt",
+                      "swift"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
             }
           },
           "additionalProperties": false,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -105,6 +105,8 @@ export interface BaseParserOptions {
         | 'cs'
         | 'rb'
         | 'php'
+        | 'kt'
+        | 'swift'
       )[]
     }
   }


### PR DESCRIPTION
## What

Extends the **language-aware structural fast path** (the LLM-free diff summarizer, #883) to **Kotlin** and **Swift**, following the established 0.66 regex pattern (Java/C/C++/C#/Ruby/PHP). A diff in these languages now resolves to a deterministic, zero-cost symbol summary instead of spending an LLM call — saving latency and tokens.

```
Updated Kotlin `A.kt`. added: class Foo, bar(). +2/-0 lines.
Updated Swift `B.swift`. added: type P, d(). +2/-0 lines.
```

## Coverage

- **Kotlin** (`.kt` / `.kts`): `fun` (incl. generics + extension functions), `class` / `data class` / `sealed class`, `interface` / `fun interface`, `enum class`, and named `object`s. Strips leading modifiers; tracks `private`/`internal`.
- **Swift** (`.swift`): `func` (incl. `static`/`class` methods + generics), `class`, `struct`→`type`, `enum`, `protocol`→`interface`, `extension`→`impl`, `actor`. Strips attributes + modifiers; the `class func` modifier is handled so a type method is never misread as a `class` declaration.

Both are stateless line parsers — anything not recognizable on a single line returns `undefined` and falls through to the LLM (false negatives are safe; the regexes are anchored to avoid false **positives**, which would produce wrong summaries).

## Wiring

Registered in the parser registry + the language detector, and added to **all four** inline config-schema union copies (`types.ts`, `langchain/types.ts`, `summarizeLargeFiles.ts`, `summarizeDiffs.ts`, `createFileChangeParserOptions.ts`); `schema.json` / `schema.ts` regenerated.

> Note: that union is duplicated across 5 files — a maintenance hazard I hit three times here. Filed a follow-up to dedupe it into one shared type.

## Tests

Per-language suites: file detection, every symbol kind, visibility tracking, indentation limits, control-flow/call rejection, the `class func` guard, and end-to-end summaries. Verified through the full dispatch path (detector → registry → summary).

## Validation

`tsc` clean · full jest green (3646 passed, 68 snapshots; 4 `tsTreeSitterParser` `.wasm-backed` failures are the known worktree WASM gotcha, pass in CI) · eslint 0 errors · `rollup -c` builds.

## Next

PR 2 of this batch adds Lua + Bash (function-only languages).