### PR TITLE
feat(parsers): add Lua + Bash structural-diff fast-path parsers

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -421,14 +421,16 @@
                       "rb",
                       "php",
                       "kt",
-                      "swift"
+                      "swift",
+                      "lua",
+                      "bash"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`   - 'lua' : `.lua`   - 'bash' : `.sh` / `.bash`"
             }
           },
           "additionalProperties": false,
@@ -967,14 +969,16 @@
                       "rb",
                       "php",
                       "kt",
-                      "swift"
+                      "swift",
+                      "lua",
+                      "bash"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`   - 'lua' : `.lua`   - 'bash' : `.sh` / `.bash`"
             }
           },
           "additionalProperties": false,
@@ -1184,14 +1188,16 @@
                       "rb",
                       "php",
                       "kt",
-                      "swift"
+                      "swift",
+                      "lua",
+                      "bash"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`   - 'lua' : `.lua`   - 'bash' : `.sh` / `.bash`"
             }
           },
           "additionalProperties": false,
@@ -1388,14 +1394,16 @@
                       "rb",
                       "php",
                       "kt",
-                      "swift"
+                      "swift",
+                      "lua",
+                      "bash"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`   - 'lua' : `.lua`   - 'bash' : `.sh` / `.bash`"
             }
           },
           "additionalProperties": false,
@@ -1592,14 +1600,16 @@
                       "rb",
                       "php",
                       "kt",
-                      "swift"
+                      "swift",
+                      "lua",
+                      "bash"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`   - 'lua' : `.lua`   - 'bash' : `.sh` / `.bash`"
             }
           },
           "additionalProperties": false,
@@ -1805,14 +1815,16 @@
                       "rb",
                       "php",
                       "kt",
-                      "swift"
+                      "swift",
+                      "lua",
+                      "bash"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`   - 'lua' : `.lua`   - 'bash' : `.sh` / `.bash`"
             }
           },
           "additionalProperties": false,
@@ -2021,14 +2033,16 @@
                       "rb",
                       "php",
                       "kt",
-                      "swift"
+                      "swift",
+                      "lua",
+                      "bash"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`   - 'lua' : `.lua`   - 'bash' : `.sh` / `.bash`"
             }
           },
           "additionalProperties": false,

--- a/src/lib/langchain/types.ts
+++ b/src/lib/langchain/types.ts
@@ -311,6 +311,8 @@ export type BaseLLMService = {
      *   - 'php' : `.php`
      *   - 'kt' : `.kt` / `.kts`
      *   - 'swift' : `.swift`
+     *   - 'lua' : `.lua`
+     *   - 'bash' : `.sh` / `.bash`
      */
     languageAware?: {
       /**
@@ -337,6 +339,8 @@ export type BaseLLMService = {
         | 'php'
         | 'kt'
         | 'swift'
+        | 'lua'
+        | 'bash'
       )[]
     }
   }

--- a/src/lib/parsers/default/utils/bashStructuralDiff.test.ts
+++ b/src/lib/parsers/default/utils/bashStructuralDiff.test.ts
@@ -1,0 +1,84 @@
+import { FileDiff } from '../../../types'
+import {
+  isBashFile,
+  parseBashStructuralLine,
+  summarizeBashStructuralDiff,
+} from './bashStructuralDiff'
+
+function fileDiff(file: string, diff: string): FileDiff {
+  return { file, diff, tokenCount: diff.length, summary: '' } as FileDiff
+}
+
+describe('isBashFile', () => {
+  it('matches .sh and .bash files only', () => {
+    expect(isBashFile('scripts/deploy.sh')).toBe(true)
+    expect(isBashFile('lib/utils.bash')).toBe(true)
+    expect(isBashFile('src/widget.lua')).toBe(false)
+    expect(isBashFile('src/widget.ts')).toBe(false)
+  })
+})
+
+describe('parseBashStructuralLine', () => {
+  it('recognizes the POSIX `name()` form', () => {
+    expect(parseBashStructuralLine('deploy() {')).toEqual({
+      name: 'deploy', kind: 'function', exported: true,
+    })
+    expect(parseBashStructuralLine('build_all () {')).toEqual({
+      name: 'build_all', kind: 'function', exported: true,
+    })
+  })
+
+  it('recognizes the `function` keyword form', () => {
+    expect(parseBashStructuralLine('function setup {')).toEqual({
+      name: 'setup', kind: 'function', exported: true,
+    })
+    expect(parseBashStructuralLine('function teardown() {')).toEqual({
+      name: 'teardown', kind: 'function', exported: true,
+    })
+  })
+
+  it('accepts modest indentation, rejects deeply nested lines', () => {
+    expect(parseBashStructuralLine('    helper() {')).toEqual({
+      name: 'helper', kind: 'function', exported: true,
+    })
+    expect(parseBashStructuralLine('            deep() {')).toBeUndefined()
+  })
+
+  it('returns undefined for control-flow, assignments, subshells, and calls', () => {
+    expect(parseBashStructuralLine('if [ -n "$x" ]; then')).toBeUndefined()
+    expect(parseBashStructuralLine('for i in 1 2 3; do')).toBeUndefined()
+    expect(parseBashStructuralLine('arr=()')).toBeUndefined()
+    expect(parseBashStructuralLine('( cd /tmp && ls )')).toBeUndefined()
+    expect(parseBashStructuralLine('echo hello')).toBeUndefined()
+    expect(parseBashStructuralLine('')).toBeUndefined()
+  })
+})
+
+describe('summarizeBashStructuralDiff', () => {
+  it('returns undefined for non-shell files', () => {
+    expect(summarizeBashStructuralDiff(fileDiff('README.md', '+x'))).toBeUndefined()
+  })
+
+  it('names added functions', () => {
+    const diff = [
+      '@@ -0,0 +1,3 @@',
+      '+deploy() {',
+      '+  echo deploying',
+      '+}',
+    ].join('\n')
+    const out = summarizeBashStructuralDiff(fileDiff('scripts/ci.sh', diff)) || ''
+    expect(out).toContain('Updated Shell `scripts/ci.sh`')
+    expect(out).toMatch(/deploy\(\)/)
+  })
+
+  it('returns undefined for body-only edits', () => {
+    const diff = [
+      '@@ -1,3 +1,3 @@',
+      ' build() {',
+      '-  make',
+      '+  make -j4',
+      ' }',
+    ].join('\n')
+    expect(summarizeBashStructuralDiff(fileDiff('b.sh', diff))).toBeUndefined()
+  })
+})

--- a/src/lib/parsers/default/utils/bashStructuralDiff.ts
+++ b/src/lib/parsers/default/utils/bashStructuralDiff.ts
@@ -1,0 +1,52 @@
+import { FileDiff } from '../../../types'
+import {
+  StructuralSymbol,
+  summarizeStructuralDiff,
+} from './structuralDiff'
+
+/**
+ * Bash / shell structural fast path.
+ *
+ * Shell scripts have no classes — only functions, in two forms:
+ *   - POSIX:  `name() { … }`  (empty parens)
+ *   - ksh/bash keyword:  `function name { … }` / `function name() { … }`
+ *
+ * Shell has no visibility marker, so every function is `exported: true`.
+ * The POSIX form requires *empty* parens (`name()`), which a command or a
+ * call never has, so control flow (`if`, `for`, `case …`), assignments
+ * (`arr=()`), and subshells (`( … )`) don't false-match. Anything else
+ * returns undefined and falls through to the LLM. Up to ~8 spaces of
+ * leading whitespace is accepted; deeper lines bail.
+ */
+
+const BASH_EXTENSIONS = ['.sh', '.bash']
+
+export function isBashFile(path: string): boolean {
+  const lower = path.toLowerCase()
+  return BASH_EXTENSIONS.some((ext) => lower.endsWith(ext))
+}
+
+export function parseBashStructuralLine(line: string): StructuralSymbol | undefined {
+  const trimmed = line.replace(/^[ \t]{0,8}/, '')
+  const leftover = trimmed.replace(/^[ \t]+/, '')
+  if (leftover !== trimmed) return undefined
+
+  // `function name { … }` / `function name() { … }`.
+  const keywordMatch = trimmed.match(/^function\s+([A-Za-z_][\w:.-]*)\s*(?:\(\s*\))?\s*\{?/)
+  if (keywordMatch) return { name: keywordMatch[1], kind: 'function', exported: true }
+
+  // POSIX `name() { … }` — empty parens are required so a call / command
+  // (which never has them) can't trip the parser.
+  const posixMatch = trimmed.match(/^([A-Za-z_][\w:.-]*)\s*\(\s*\)\s*\{?/)
+  if (posixMatch) return { name: posixMatch[1], kind: 'function', exported: true }
+
+  return undefined
+}
+
+export function summarizeBashStructuralDiff(fileDiff: FileDiff): string | undefined {
+  if (!isBashFile(fileDiff.file)) return undefined
+  return summarizeStructuralDiff(fileDiff, {
+    label: 'Shell',
+    parseLine: parseBashStructuralLine,
+  })
+}

--- a/src/lib/parsers/default/utils/createFileChangeParserOptions.ts
+++ b/src/lib/parsers/default/utils/createFileChangeParserOptions.ts
@@ -27,6 +27,8 @@ export type FileChangeParserServiceBudget = {
         | 'php'
         | 'kt'
         | 'swift'
+        | 'lua'
+        | 'bash'
       )[]
     }
   }

--- a/src/lib/parsers/default/utils/luaStructuralDiff.test.ts
+++ b/src/lib/parsers/default/utils/luaStructuralDiff.test.ts
@@ -1,0 +1,91 @@
+import { FileDiff } from '../../../types'
+import {
+  isLuaFile,
+  parseLuaStructuralLine,
+  summarizeLuaStructuralDiff,
+} from './luaStructuralDiff'
+
+function fileDiff(file: string, diff: string): FileDiff {
+  return { file, diff, tokenCount: diff.length, summary: '' } as FileDiff
+}
+
+describe('isLuaFile', () => {
+  it('matches .lua files only', () => {
+    expect(isLuaFile('init.lua')).toBe(true)
+    expect(isLuaFile('src/widget.rb')).toBe(false)
+    expect(isLuaFile('src/widget.ts')).toBe(false)
+  })
+})
+
+describe('parseLuaStructuralLine', () => {
+  it('recognizes global and local function declarations', () => {
+    expect(parseLuaStructuralLine('function render(x)')).toEqual({
+      name: 'render', kind: 'function', exported: true,
+    })
+    expect(parseLuaStructuralLine('local function helper()')).toEqual({
+      name: 'helper', kind: 'function', exported: false,
+    })
+  })
+
+  it('keeps qualified table-function names (dot and colon)', () => {
+    expect(parseLuaStructuralLine('function M.setup(opts)')).toEqual({
+      name: 'M.setup', kind: 'function', exported: true,
+    })
+    expect(parseLuaStructuralLine('function Widget:render()')).toEqual({
+      name: 'Widget:render', kind: 'function', exported: true,
+    })
+  })
+
+  it('recognizes assigned function expressions', () => {
+    expect(parseLuaStructuralLine('callback = function(err)')).toEqual({
+      name: 'callback', kind: 'function', exported: true,
+    })
+    expect(parseLuaStructuralLine('local cb = function()')).toEqual({
+      name: 'cb', kind: 'function', exported: false,
+    })
+  })
+
+  it('accepts modest indentation, rejects deeply nested lines', () => {
+    expect(parseLuaStructuralLine('    function inner()')).toEqual({
+      name: 'inner', kind: 'function', exported: true,
+    })
+    expect(parseLuaStructuralLine('            function deep() end')).toBeUndefined()
+  })
+
+  it('returns undefined for control-flow, calls, assignments, and blanks', () => {
+    expect(parseLuaStructuralLine('if x then')).toBeUndefined()
+    expect(parseLuaStructuralLine('return render()')).toBeUndefined()
+    expect(parseLuaStructuralLine('local total = 1')).toBeUndefined()
+    expect(parseLuaStructuralLine('t = {}')).toBeUndefined()
+    expect(parseLuaStructuralLine('')).toBeUndefined()
+  })
+})
+
+describe('summarizeLuaStructuralDiff', () => {
+  it('returns undefined for non-Lua files', () => {
+    expect(summarizeLuaStructuralDiff(fileDiff('README.md', '+x'))).toBeUndefined()
+  })
+
+  it('names added functions', () => {
+    const diff = [
+      '@@ -0,0 +1,3 @@',
+      '+function M.setup(opts)',
+      '+  return opts',
+      '+end',
+    ].join('\n')
+    const out = summarizeLuaStructuralDiff(fileDiff('lua/plugin.lua', diff)) || ''
+    expect(out).toContain('Updated Lua `lua/plugin.lua`')
+    expect(out).toMatch(/M\.setup\(\)/)
+  })
+
+  it('returns undefined for body-only edits', () => {
+    const diff = [
+      '@@ -1,3 +1,3 @@',
+      ' function compute()',
+      '-  return 1',
+      '+  return 2',
+      ' end',
+    ].join('\n')
+    expect(summarizeLuaStructuralDiff(fileDiff('m.lua', diff))).toBeUndefined()
+  })
+})

--- a/src/lib/parsers/default/utils/luaStructuralDiff.ts
+++ b/src/lib/parsers/default/utils/luaStructuralDiff.ts
@@ -1,0 +1,61 @@
+import { FileDiff } from '../../../types'
+import {
+  StructuralSymbol,
+  summarizeStructuralDiff,
+} from './structuralDiff'
+
+/**
+ * Lua structural fast path.
+ *
+ * Lua has no classes — structure is just functions, declared a few ways:
+ *   - `function name(...)` / `local function name(...)`
+ *   - `function Table.name(...)` / `function Table:method(...)` (the
+ *     qualified name is kept, e.g. `M.foo` / `M:bar`, since that's how the
+ *     reader recognizes the member)
+ *   - `name = function(...)` / `local name = function(...)` (assigned)
+ *
+ * `local` declarations are file-scoped, so we mark them `exported: false`
+ * (cosmetic today). Anything not matching on a single line returns
+ * undefined and falls through to the LLM. Up to ~8 spaces of leading
+ * whitespace is accepted; deeper lines bail.
+ */
+
+const LUA_EXTENSIONS = ['.lua']
+
+export function isLuaFile(path: string): boolean {
+  const lower = path.toLowerCase()
+  return LUA_EXTENSIONS.some((ext) => lower.endsWith(ext))
+}
+
+export function parseLuaStructuralLine(line: string): StructuralSymbol | undefined {
+  const trimmed = line.replace(/^[ \t]{0,8}/, '')
+  const leftover = trimmed.replace(/^[ \t]+/, '')
+  if (leftover !== trimmed) return undefined
+
+  const isLocal = /^local\s+/.test(trimmed)
+  const exported = !isLocal
+
+  // `function name(...)`, `local function name(...)`,
+  // `function Table.name(...)`, `function Table:method(...)`.
+  const fnMatch = trimmed.match(
+    /^(?:local\s+)?function\s+([A-Za-z_][\w.:]*)\s*\(/
+  )
+  if (fnMatch) return { name: fnMatch[1], kind: 'function', exported }
+
+  // Assigned function expressions: `name = function(...)`,
+  // `local name = function(...)`, `Table.name = function(...)`.
+  const assignMatch = trimmed.match(
+    /^(?:local\s+)?([A-Za-z_][\w.:]*)\s*=\s*function\s*\(/
+  )
+  if (assignMatch) return { name: assignMatch[1], kind: 'function', exported }
+
+  return undefined
+}
+
+export function summarizeLuaStructuralDiff(fileDiff: FileDiff): string | undefined {
+  if (!isLuaFile(fileDiff.file)) return undefined
+  return summarizeStructuralDiff(fileDiff, {
+    label: 'Lua',
+    parseLine: parseLuaStructuralLine,
+  })
+}

--- a/src/lib/parsers/default/utils/structuralParserRegistry.ts
+++ b/src/lib/parsers/default/utils/structuralParserRegistry.ts
@@ -29,11 +29,13 @@ import { treeSitterGoParser } from '../__tree_sitter__/goTreeSitterParser'
 import { treeSitterPythonParser } from '../__tree_sitter__/pythonTreeSitterParser'
 import { treeSitterRustParser } from '../__tree_sitter__/rustTreeSitterParser'
 import { treeSitterTsParser } from '../__tree_sitter__/tsTreeSitterParser'
+import { summarizeBashStructuralDiff } from './bashStructuralDiff'
 import { summarizeCppStructuralDiff } from './cppStructuralDiff'
 import { summarizeCsStructuralDiff } from './csStructuralDiff'
 import { summarizeGoStructuralDiff } from './goStructuralDiff'
 import { summarizeJavaStructuralDiff } from './javaStructuralDiff'
 import { summarizeKotlinStructuralDiff } from './ktStructuralDiff'
+import { summarizeLuaStructuralDiff } from './luaStructuralDiff'
 import { summarizePhpStructuralDiff } from './phpStructuralDiff'
 import { summarizePythonStructuralDiff } from './pythonStructuralDiff'
 import { summarizeRubyStructuralDiff } from './rbStructuralDiff'
@@ -58,6 +60,8 @@ export type StructuralLanguageId =
   | 'php'
   | 'kt'
   | 'swift'
+  | 'lua'
+  | 'bash'
 
 /**
  * A structural parser is a strategy for producing a templated
@@ -113,6 +117,8 @@ const regexRb = regexParser(summarizeRubyStructuralDiff)
 const regexPhp = regexParser(summarizePhpStructuralDiff)
 const regexKt = regexParser(summarizeKotlinStructuralDiff)
 const regexSwift = regexParser(summarizeSwiftStructuralDiff)
+const regexLua = regexParser(summarizeLuaStructuralDiff)
+const regexBash = regexParser(summarizeBashStructuralDiff)
 
 /**
  * Per-language parser chains, in priority order. Tree-sitter is
@@ -135,6 +141,8 @@ const REGISTRY: Record<StructuralLanguageId, StructuralParser[]> = {
   php: [regexPhp],
   kt: [regexKt],
   swift: [regexSwift],
+  lua: [regexLua],
+  bash: [regexBash],
 }
 
 /**

--- a/src/lib/parsers/default/utils/summarizeDiffs.ts
+++ b/src/lib/parsers/default/utils/summarizeDiffs.ts
@@ -199,6 +199,8 @@ export type SummarizeDiffsOptions = {
         | 'php'
         | 'kt'
         | 'swift'
+        | 'lua'
+        | 'bash'
       )[]
     }
   }

--- a/src/lib/parsers/default/utils/summarizeLargeFiles.ts
+++ b/src/lib/parsers/default/utils/summarizeLargeFiles.ts
@@ -10,11 +10,13 @@ import {
   writeDiffSummary,
 } from './diffSummaryCache'
 import { summarizeMarkdownDiff } from './markdownDiff'
+import { isBashFile } from './bashStructuralDiff'
 import { isCppFile } from './cppStructuralDiff'
 import { isCsFile } from './csStructuralDiff'
 import { isGoFile } from './goStructuralDiff'
 import { isJavaFile } from './javaStructuralDiff'
 import { isKotlinFile } from './ktStructuralDiff'
+import { isLuaFile } from './luaStructuralDiff'
 import { isPhpFile } from './phpStructuralDiff'
 import { isPythonFile } from './pythonStructuralDiff'
 import { isRubyFile } from './rbStructuralDiff'
@@ -49,6 +51,8 @@ function detectStructuralLanguageId(path: string): StructuralLanguageId | undefi
   if (isPhpFile(path)) return 'php'
   if (isKotlinFile(path)) return 'kt'
   if (isSwiftFile(path)) return 'swift'
+  if (isLuaFile(path)) return 'lua'
+  if (isBashFile(path)) return 'bash'
   return undefined
 }
 
@@ -112,6 +116,8 @@ export type SummarizeLargeFilesOptions = {
         | 'php'
         | 'kt'
         | 'swift'
+        | 'lua'
+        | 'bash'
       )[]
     }
   }

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -432,14 +432,16 @@ export const schema = {
                       "rb",
                       "php",
                       "kt",
-                      "swift"
+                      "swift",
+                      "lua",
+                      "bash"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`   - 'lua' : `.lua`   - 'bash' : `.sh` / `.bash`"
             }
           },
           "additionalProperties": false,
@@ -978,14 +980,16 @@ export const schema = {
                       "rb",
                       "php",
                       "kt",
-                      "swift"
+                      "swift",
+                      "lua",
+                      "bash"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`   - 'lua' : `.lua`   - 'bash' : `.sh` / `.bash`"
             }
           },
           "additionalProperties": false,
@@ -1195,14 +1199,16 @@ export const schema = {
                       "rb",
                       "php",
                       "kt",
-                      "swift"
+                      "swift",
+                      "lua",
+                      "bash"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`   - 'lua' : `.lua`   - 'bash' : `.sh` / `.bash`"
             }
           },
           "additionalProperties": false,
@@ -1399,14 +1405,16 @@ export const schema = {
                       "rb",
                       "php",
                       "kt",
-                      "swift"
+                      "swift",
+                      "lua",
+                      "bash"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`   - 'lua' : `.lua`   - 'bash' : `.sh` / `.bash`"
             }
           },
           "additionalProperties": false,
@@ -1603,14 +1611,16 @@ export const schema = {
                       "rb",
                       "php",
                       "kt",
-                      "swift"
+                      "swift",
+                      "lua",
+                      "bash"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`   - 'lua' : `.lua`   - 'bash' : `.sh` / `.bash`"
             }
           },
           "additionalProperties": false,
@@ -1816,14 +1826,16 @@ export const schema = {
                       "rb",
                       "php",
                       "kt",
-                      "swift"
+                      "swift",
+                      "lua",
+                      "bash"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`   - 'lua' : `.lua`   - 'bash' : `.sh` / `.bash`"
             }
           },
           "additionalProperties": false,
@@ -2032,14 +2044,16 @@ export const schema = {
                       "rb",
                       "php",
                       "kt",
-                      "swift"
+                      "swift",
+                      "lua",
+                      "bash"
                     ]
                   },
                   "description": "Languages to opt in. Omit / empty to enable all supported languages."
                 }
               },
               "additionalProperties": false,
-              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`"
+              "description": "Language-aware structural fast path (#883). Replace the LLM summary with a symbol-level extract (\"added parseRequest(); removed legacyParse()\") for source files in the listed languages. Off by default; quality is harder to validate than the markdown fast path so we don't enable it without opt-in.\n\nDiffs without top-level structural signals (paragraph-only body edits, formatting changes) still go to the LLM regardless of this flag.\n\nCurrently supports:   - 'ts' : `.ts` / `.tsx` / `.mts` / `.cts`   - 'js' : `.js` / `.jsx` / `.mjs` / `.cjs`   - 'py' : `.py` / `.pyi`   - 'rs' : `.rs`   - 'go' : `.go`   - 'java' : `.java`   - 'cpp' : `.c` / `.h` / `.cpp` / `.cc` / `.cxx` / `.hpp` / `.hh` / `.hxx`   - 'cs' : `.cs`   - 'rb' : `.rb`   - 'php' : `.php`   - 'kt' : `.kt` / `.kts`   - 'swift' : `.swift`   - 'lua' : `.lua`   - 'bash' : `.sh` / `.bash`"
             }
           },
           "additionalProperties": false,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -107,6 +107,8 @@ export interface BaseParserOptions {
         | 'php'
         | 'kt'
         | 'swift'
+        | 'lua'
+        | 'bash'
       )[]
     }
   }


### PR DESCRIPTION
## What

Second batch extending the **language-aware structural fast path** (the LLM-free diff summarizer), after [#1303](https://github.com/gfargo/coco/pull/1303). Both are function-only languages (no classes).

```
Updated Lua `p.lua`. added: M.setup(). +2/-0 lines.
Updated Shell `ci.sh`. added: deploy(). +2/-0 lines.
```

## Coverage

- **Lua** (`.lua`): `function name`, `local function name`, qualified `function M.foo` / `function W:bar` (keeps the dotted/colon name), and assigned function expressions `name = function(...)`. `local` → `exported: false`.
- **Shell** (`.sh` / `.bash`): POSIX `name() { }` and ksh/bash `function name { }`. The POSIX form requires **empty** parens, so control flow (`if`/`for`), `arr=()` assignments, subshells `( … )`, and command calls don't false-match.

## Wiring

Registry + language detector + **all five** config-schema union copies; `schema.json` / `schema.ts` regenerated. (The 5-copy duplication has a dedupe follow-up filed.)

## Tests

Per-language suites: file detection, every declaration form, qualified names, indentation limits, false-positive rejection (control flow / assignments / subshells / calls), and end-to-end summaries. Verified through the full dispatch path (detector → registry → summary).

## Validation

`tsc` clean · full jest green (3663 passed, 68 snapshots; 4 `tsTreeSitterParser` `.wasm-backed` failures are the known worktree WASM gotcha, pass in CI) · eslint 0 errors · `rollup -c` builds.

## Together with #1303

This brings the regex fast path to **6 new languages** (Kotlin, Swift, Lua, Bash) — diffs in them now resolve to a deterministic, zero-cost symbol summary instead of an LLM call, saving latency and tokens.