### PR TITLE
feat(commit): --split now plans and prompts to apply by default

### DIFF
--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -1912,6 +1912,130 @@ export const RECIPES: ScreenshotRecipe[] = [
       { kind: 'sleep', ms: 1800 },
     ],
   },
+
+  // ─────────────────────────────────────────────────────────────────
+  // HERO GIF SET — homepage hero carousel, all at 130×32 (≈16:9)
+  // ─────────────────────────────────────────────────────────────────
+  // These are short, punchy demos sized consistently for the homepage
+  // hero GIF showcase. Each one is ~5-10s and demonstrates a single
+  // coco capability. Run: npm run screenshot:sync hero-commit hero-split
+  // hero-ui hero-changelog hero-workspace
+  {
+    name: 'hero-commit',
+    description: 'Hero: coco commit — type command, AI drafts a commit message, done',
+    scenario: 'partial-stage',
+    command: 'commit --dry-run',
+    emitGif: true,
+    dimensions: { cols: 130, rows: 32 },
+    visibleCommand: 'coco commit',
+    env: {
+      COCO_SERVICE_PROVIDER: 'openai',
+      COCO_SERVICE_MODEL: 'gpt-4o-mini',
+    },
+    actions: [
+      // Wait for the LLM to return (fast model, ~2-4s).
+      { kind: 'sleep', ms: 5000 },
+    ],
+  },
+  {
+    name: 'hero-split',
+    description: 'Hero: coco commit --split — large staging area decomposed then applied',
+    scenario: 'dirty-many-files',
+    command: 'commit --split --conventional',
+    emitGif: true,
+    dimensions: { cols: 130, rows: 32 },
+    visibleCommand: 'coco commit --split',
+    env: {
+      COCO_SERVICE_PROVIDER: 'openai',
+      COCO_SERVICE_MODEL: 'gpt-4o-mini',
+    },
+    actions: [
+      // Let the LLM finish planning + show the apply prompt.
+      { kind: 'sleep', ms: 10000 },
+    ],
+  },
+  {
+    name: 'hero-ui',
+    description: 'Hero: coco ui — boot into history, browse commits, open diff, chord-switch views',
+    scenario: 'rich-history-graph',
+    command: 'ui --view history',
+    emitGif: true,
+    dimensions: { cols: 130, rows: 32 },
+    actions: [
+      // Let the workstation paint.
+      { kind: 'sleep', ms: 1200 },
+      // Browse history.
+      { kind: 'key', key: 'Down' },
+      { kind: 'sleep', ms: 350 },
+      { kind: 'key', key: 'Down' },
+      { kind: 'sleep', ms: 350 },
+      { kind: 'key', key: 'Down' },
+      { kind: 'sleep', ms: 600 },
+      // Open a commit's diff.
+      { kind: 'key', key: 'Enter' },
+      { kind: 'sleep', ms: 1400 },
+      // Scroll the diff.
+      { kind: 'key', key: 'Down' },
+      { kind: 'sleep', ms: 250 },
+      { kind: 'key', key: 'Down' },
+      { kind: 'sleep', ms: 250 },
+      { kind: 'key', key: 'Down' },
+      { kind: 'sleep', ms: 600 },
+      // Chord-switch to status.
+      { kind: 'type', text: 'gs' },
+      { kind: 'sleep', ms: 1200 },
+      // Chord-switch to branches.
+      { kind: 'type', text: 'gb' },
+      { kind: 'sleep', ms: 1200 },
+      // Back to history to close the loop.
+      { kind: 'type', text: 'gh' },
+      { kind: 'sleep', ms: 800 },
+    ],
+  },
+  {
+    name: 'hero-changelog',
+    description: 'Hero: coco changelog — generate release notes from branch diff',
+    scenario: 'feature-pr-ready',
+    command: 'changelog --branch main',
+    emitGif: true,
+    dimensions: { cols: 130, rows: 32 },
+    visibleCommand: 'coco changelog',
+    env: {
+      COCO_SERVICE_PROVIDER: 'openai',
+      COCO_SERVICE_MODEL: 'gpt-4o-mini',
+    },
+    actions: [
+      // LLM generates changelog from commits.
+      { kind: 'sleep', ms: 6000 },
+    ],
+  },
+  {
+    name: 'hero-workspace',
+    description: 'Hero: coco workspace — multi-repo browser, pick a repo, drop into its TUI',
+    scenario: '_workspace',
+    command: 'workspace --root . --maxDepth 1',
+    emitGif: true,
+    dimensions: { cols: 130, rows: 32 },
+    actions: [
+      // Let the workspace list paint.
+      { kind: 'sleep', ms: 1800 },
+      // Browse repos.
+      { kind: 'key', key: 'Down' },
+      { kind: 'sleep', ms: 500 },
+      { kind: 'key', key: 'Down' },
+      { kind: 'sleep', ms: 700 },
+      // Enter the selected repo — drops into its TUI.
+      { kind: 'key', key: 'Enter' },
+      { kind: 'sleep', ms: 2800 },
+      // Quick browse inside — end here, don't quit (avoids tail frame).
+      { kind: 'key', key: 'Down' },
+      { kind: 'sleep', ms: 400 },
+      { kind: 'key', key: 'Down' },
+      { kind: 'sleep', ms: 400 },
+      { kind: 'key', key: 'Down' },
+      { kind: 'sleep', ms: 1500 },
+    ],
+  },
 ]
 
 export function findRecipe(name: string): ScreenshotRecipe | undefined {

--- a/bin/syncScreenshots.ts
+++ b/bin/syncScreenshots.ts
@@ -36,7 +36,13 @@ const THEME_HISTORY_RECIPES = getLogInkThemePresets()
  * be synced to .www even if it exists in the recipe catalog.
  */
 const SITE_RECIPES = [
-  // Hero GIFs
+  // Hero GIFs — homepage carousel (all 130×32 consistent dimensions)
+  'hero-commit',
+  'hero-split',
+  'hero-ui',
+  'hero-changelog',
+  'hero-workspace',
+  // Legacy hero GIFs
   'demo-boot-workstation',
   'demo-commit-flow',
   'readme-commit',
@@ -113,6 +119,12 @@ const SITE_RECIPES = [
  * for semantic clarity on the site.
  */
 const FILENAME_MAP: Record<string, string[]> = {
+  // Hero GIF carousel — homepage (consistent 130×32 captures)
+  'hero-commit': ['hero-commit.gif'],
+  'hero-split': ['hero-split.gif'],
+  'hero-ui': ['hero-ui.gif'],
+  'hero-changelog': ['hero-changelog.gif'],
+  'hero-workspace': ['hero-workspace.gif'],
   'ui-history-rich-graph': ['hero-history-graph.png', 'view-history.png'],
   'ui-status-dirty-worktree': ['feature-status.png', 'view-status.png'],
   'ui-diff-feature-branch': ['view-diff.png'],

--- a/src/commands/commit/config.ts
+++ b/src/commands/commit/config.ts
@@ -117,17 +117,17 @@ export const options = {
     alias: 'n',
   },
   split: {
-    description: 'Group staged changes into multiple related commit proposals',
+    description: 'Group staged changes into multiple commits — shows the plan and prompts to apply',
     type: 'boolean',
     default: false,
   },
   plan: {
-    description: 'Only print a commit split plan without changing git state',
+    description: 'Print the split plan without prompting to apply (plan-only mode)',
     type: 'boolean',
     default: false,
   },
   apply: {
-    description: 'Apply a generated file-level or hunk-level commit split plan and create commits',
+    description: 'Apply a split plan immediately without confirmation',
     type: 'boolean',
     default: false,
   },

--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -14,20 +14,21 @@ import { FileChange } from '../../lib/types'
 import { hasCommitlintConfig } from '../../lib/utils/hasCommitlintConfig'
 import { Logger } from '../../lib/utils/logger'
 import { TokenCounter } from '../../lib/utils/tokenizer'
+import { confirmPrompt } from '../../lib/ui/inquirerPrompts'
 import { CommitOptions } from './config'
 import {
-  DEFAULT_MAX_PLAN_ATTEMPTS,
-  generateValidatedCommitSplitPlan,
+    DEFAULT_MAX_PLAN_ATTEMPTS,
+    generateValidatedCommitSplitPlan,
 } from './splitPlanGenerator'
 import {
-  CommitSplitGroup,
-  CommitSplitPlan,
-  CommitSplitPlanSchema,
+    CommitSplitGroup,
+    CommitSplitPlan,
+    CommitSplitPlanSchema,
 } from './splitPlanTypes'
 import {
-  formatPlanValidationIssuesError,
-  getPlanValidationIssues,
-  hasPlanValidationIssues,
+    formatPlanValidationIssuesError,
+    getPlanValidationIssues,
+    hasPlanValidationIssues,
 } from './splitPlanValidation'
 
 export { CommitSplitPlanSchema }
@@ -703,6 +704,20 @@ export async function handleCommitSplit({
 
   const { plan, context, fallback } = result
 
+  // --plan: print the plan and exit (opt-out from the default apply prompt).
+  if (argv.plan) {
+    if (fallback) {
+      return [
+        `Note: showing the single-commit fallback plan (${fallback.reason}).`,
+        'Re-run with a stronger model or use --strict-split to surface the planner error.',
+        '',
+        formatCommitSplitPlan(plan),
+      ].join('\n')
+    }
+    return formatCommitSplitPlan(plan)
+  }
+
+  // --apply: skip the confirmation prompt and apply directly.
   if (argv.apply) {
     const applied = await applyCommitSplitPlan({
       plan,
@@ -722,14 +737,39 @@ export async function handleCommitSplit({
     return applied.message
   }
 
+  // Default: show the plan, then prompt the user to apply.
   if (fallback) {
-    return [
-      `Note: showing the single-commit fallback plan (${fallback.reason}).`,
-      'Re-run with a stronger model or use --strict-split to surface the planner error.',
-      '',
-      formatCommitSplitPlan(plan),
-    ].join('\n')
+    logger.log(
+      `Note: showing the single-commit fallback plan (${fallback.reason}).\n` +
+      'Re-run with a stronger model or use --strict-split to surface the planner error.\n'
+    )
+  }
+  logger.log(formatCommitSplitPlan(plan))
+  logger.log('') // blank line before the prompt
+
+  const shouldApply = await confirmPrompt({
+    message: `Apply these ${plan.groups.filter((g) => !g.unclaimed).length} commits?`,
+    default: true,
+  })
+
+  if (!shouldApply) {
+    return 'Plan saved — re-run with --apply to commit later, or --plan to print again.'
   }
 
-  return formatCommitSplitPlan(plan)
+  const applied = await applyCommitSplitPlan({
+    plan,
+    changes: context.changes,
+    hunkInventory: context.hunkInventory,
+    git,
+    logger,
+    noVerify: argv.noVerify || config.noVerify || false,
+    fallback,
+  })
+  if (applied.fallback) {
+    return [
+      `Note: applied the single-commit fallback (${applied.fallback.reason}).`,
+      applied.message,
+    ].join('\n')
+  }
+  return applied.message
 }


### PR DESCRIPTION
Closes #1334

## Summary

`coco commit --split` now generates the plan, displays it, and prompts
"Apply these N commits? (Y/n)" — defaulting to yes. Previously it only
printed the plan (plan-only mode) and required a separate `--apply` run.

### New flag semantics

| Flag | Before | After |
|------|--------|-------|
| `--split` | Plan-only (print and exit) | Plan → display → prompt → apply on confirm |
| `--plan` | Same as `--split` | Explicit plan-only (no prompt, no apply) |
| `--apply` | Apply without confirmation | Unchanged |

### Also included

- 5 new `hero-*` GIF recipes at consistent 130×32 dimensions for the homepage carousel
- Registered in `SITE_RECIPES` + `FILENAME_MAP` for `screenshot:sync`
- Fixed workspace recipe (removed quit action causing tail frame)
## Summary

`coco commit --split\it` to show apply prompt in demo)

### Testing

All 69 existing split tests pass. The new prompt uses `confirmPrompt` from
`src/lib/ui/inquirerPrompts.ts` (same pattern as `coco init`).
