### PR TITLE
fix(workstation): pre-release test fixes for 0.76.0

### DIFF
--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -1950,8 +1950,13 @@ export const RECIPES: ScreenshotRecipe[] = [
       COCO_SERVICE_MODEL: 'gpt-4o-mini',
     },
     actions: [
-      // Let the LLM finish planning + show the apply prompt.
-      { kind: 'sleep', ms: 10000 },
+      // LLM plans the split groups (~4-8s), then the plan displays and
+      // the apply prompt appears. Wait for the full flow to render.
+      { kind: 'sleep', ms: 14000 },
+      // Confirm the apply prompt (Y is default, just press Enter).
+      { kind: 'key', key: 'Enter' },
+      // Let the commits land and the success message render.
+      { kind: 'sleep', ms: 4000 },
     ],
   },
   {

--- a/src/workstation/chrome/historyRows.test.ts
+++ b/src/workstation/chrome/historyRows.test.ts
@@ -1,9 +1,9 @@
 import { GitLogRow } from '../../commands/log/data'
 import {
-  commitGlyphFor,
-  formatInkHistoryGraphRow,
-  formatInkRefLabels,
-  getVisibleLogInkHistory,
+    commitGlyphFor,
+    formatInkHistoryGraphRow,
+    formatInkRefLabels,
+    getVisibleLogInkHistory,
 } from './historyRows'
 import { applyLogInkAction, createLogInkState } from '../../workstation/runtime/inkViewModel'
 
@@ -419,7 +419,10 @@ describe('Ink history rows', () => {
   // visible label and the eye gets temporal orientation without per-
   // row repetition. Triggered by passing `dateBucketingNow`.
   describe('dateBucketingNow', () => {
-    const NOW = new Date(Date.UTC(2026, 4, 14)) // 2026-05-14
+    // Local-component constructor (not Date.UTC): bucketing compares the
+    // VIEWER's local day (#1336), so a UTC-instant `now` would make
+    // these assertions timezone-sensitive on contributor machines.
+    const NOW = new Date(2026, 4, 14) // 2026-05-14 local
 
     const fixtureRows: GitLogRow[] = [
       {


### PR DESCRIPTION
## What

Fixes the 3 failing tests in `historyRows.test.ts` that block the 0.76.0 release.

**Root cause:** The `dateBucket.ts` / `dateFormat.ts` modules were updated in #1373 to compare against the viewer's local day (`getFullYear`/`getMonth`/`getDate`), but the `historyRows.test.ts` fixture still constructed `NOW` as a UTC-midnight instant (`new Date(Date.UTC(2026, 4, 14))`). For contributors west of UTC the local-day extraction returned May 13 instead of May 14, collapsing the Today and Yesterday buckets into one header.

**Fix:** Switch to the local-component constructor (`new Date(2026, 4, 14)`) matching the fix already applied in `dateBucket.test.ts` and `dateFormat.test.ts`.

Also includes a screenshot recipe update (`bin/screenshot/recipes.ts`).

## Validation

- [x] `npx jest src/workstation/chrome/historyRows.test.ts` — all 29 tests pass
- [x] Commits follow Conventional Commits