### PR TITLE
fix(workspace): filter re-edit feedback, help scroll ceiling, clone modal height, clone focus chip

### DIFF
--- a/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
+++ b/src/workstation/surfaces/workspace/__snapshots__/view.test.ts.snap
@@ -5315,7 +5315,7 @@ exports[`renderWorkspaceApp snapshots the clone prompt on the URL field 1`] = `
       color="cyan"
       dimColor={false}
     >
-      [List]
+      [Clone]
     </Text>
   </Box>
   <Box
@@ -5882,19 +5882,19 @@ exports[`renderWorkspaceApp snapshots the clone prompt on the destination field 
       color="cyan"
       dimColor={false}
     >
-      [List]
+      [Clone]
     </Text>
   </Box>
   <Box
     flexDirection="row"
-    height={27}
+    height={26}
   >
     <Box
       borderColor="gray"
       borderStyle="classic"
       flexDirection="column"
       flexShrink={0}
-      height={27}
+      height={26}
       paddingX={1}
       width={22}
     >
@@ -5995,7 +5995,7 @@ exports[`renderWorkspaceApp snapshots the clone prompt on the destination field 
       borderStyle="classic"
       flexDirection="column"
       flexGrow={1}
-      height={27}
+      height={26}
       paddingX={1}
     >
       <Box

--- a/src/workstation/surfaces/workspace/runtime.ts
+++ b/src/workstation/surfaces/workspace/runtime.ts
@@ -66,7 +66,7 @@ import {
 } from '../../chrome/workspaceCache'
 import { installTerminalLifecycle } from '../../chrome/terminalLifecycle'
 
-import { renderWorkspaceApp } from './view'
+import { renderWorkspaceApp, workspaceHelpMaxOffset } from './view'
 import {
   applyWorkspaceAction,
   createWorkspaceState,
@@ -539,6 +539,8 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
   // surface visibly judders. Same pattern coco ui uses.
   const stateRef = React.useRef(state)
   stateRef.current = state
+  const rowsRef = React.useRef(rows)
+  rowsRef.current = rows
   const filterDraftRef = React.useRef(filterDraft)
   filterDraftRef.current = filterDraft
   const addRepoDraftRef = React.useRef(addRepoDraft)
@@ -1040,6 +1042,12 @@ function WorkspaceInkApp(props: WorkspaceInkAppProps): ReactTypes.ReactElement {
           setFilterDraft(state.filter ?? '')
         } else if (intent.action.type === 'clear-filter') {
           setFilterDraft('')
+        }
+        // Attach the scroll ceiling (terminal-height dependent, so the
+        // reducer can't compute it) — see the scroll-help reducer case.
+        if (intent.action.type === 'scroll-help') {
+          dispatch({ ...intent.action, maxOffset: workspaceHelpMaxOffset(rowsRef.current) })
+          break
         }
         dispatch(intent.action)
         break

--- a/src/workstation/surfaces/workspace/state.test.ts
+++ b/src/workstation/surfaces/workspace/state.test.ts
@@ -203,6 +203,22 @@ describe('workspace state reducer', () => {
     expect(up.helpScrollOffset).toBe(0)
   })
 
+  it('scroll-help ceiling-clamps against the provided maxOffset', () => {
+    const opened = applyWorkspaceAction(baseState, { type: 'toggle-help' })
+    // Holding j past the end used to keep incrementing the offset
+    // invisibly; k then unwound the excess before the view moved.
+    const down = applyWorkspaceAction(opened, { type: 'scroll-help', delta: 50, maxOffset: 12 })
+    expect(down.helpScrollOffset).toBe(12)
+    const up = applyWorkspaceAction(down, { type: 'scroll-help', delta: -1, maxOffset: 12 })
+    expect(up.helpScrollOffset).toBe(11)
+  })
+
+  it('scroll-help treats a negative maxOffset as zero', () => {
+    const opened = applyWorkspaceAction(baseState, { type: 'toggle-help' })
+    const down = applyWorkspaceAction(opened, { type: 'scroll-help', delta: 5, maxOffset: -3 })
+    expect(down.helpScrollOffset).toBe(0)
+  })
+
   it('reopening the help overlay resets the scroll offset to the top', () => {
     const opened = applyWorkspaceAction(baseState, { type: 'toggle-help' })
     const scrolled = applyWorkspaceAction(opened, { type: 'scroll-help', delta: 6 })

--- a/src/workstation/surfaces/workspace/state.ts
+++ b/src/workstation/surfaces/workspace/state.ts
@@ -135,7 +135,7 @@ export type WorkspaceAction =
   | { type: 'set-status'; status?: string }
   | { type: 'toggle-help' }
   | { type: 'close-help' }
-  | { type: 'scroll-help'; delta: number }
+  | { type: 'scroll-help'; delta: number; maxOffset?: number }
   | { type: 'toggle-theme-picker' }
   | { type: 'move-theme-picker'; delta: number; presetCount: number }
   | { type: 'append-theme-picker-filter'; value: string }
@@ -413,9 +413,16 @@ export function applyWorkspaceAction(
       return { ...state, showHelp: false, helpScrollOffset: 0 }
     }
     case 'scroll-help': {
-      // Floor-clamp at 0 only; the renderer ceiling-clamps against the
-      // real content height so `j` past the end sticks at the last row.
-      return { ...state, helpScrollOffset: Math.max(0, state.helpScrollOffset + action.delta) }
+      // Floor-clamp at 0; ceiling-clamp when the dispatcher provides
+      // the real content bound (runtime computes it from the terminal
+      // height). Without the ceiling the offset kept climbing past the
+      // end invisibly — the renderer's display clamp hid it, but `k`
+      // then spent N presses unwinding the excess before the view
+      // moved.
+      const next = Math.max(0, state.helpScrollOffset + action.delta)
+      const clamped =
+        action.maxOffset !== undefined ? Math.min(next, Math.max(0, action.maxOffset)) : next
+      return { ...state, helpScrollOffset: clamped }
     }
     case 'toggle-theme-picker': {
       return {

--- a/src/workstation/surfaces/workspace/view.test.ts
+++ b/src/workstation/surfaces/workspace/view.test.ts
@@ -189,6 +189,16 @@ describe('renderWorkspaceApp', () => {
     expect(tree).toMatchSnapshot()
   })
 
+  it('shows the live draft while re-editing an applied filter', () => {
+    // The committed-filter chip used to win over the draft, so `/`
+    // with a filter active gave zero feedback while typing.
+    const committed = applyWorkspaceAction(baseState(), { type: 'set-filter', filter: 'lib' })
+    const editing = applyWorkspaceAction(committed, { type: 'set-focus', focus: 'filter' })
+    const tree = render(editing, { filterDraft: 'libx' })
+    expect(JSON.stringify(tree)).toContain('filter: libx_')
+    expect(JSON.stringify(tree)).not.toContain('filter: lib ')
+  })
+
   it('snapshots the dirty tab', () => {
     const state = applyWorkspaceAction(baseState(), { type: 'set-tab', tab: 'dirty' })
     const tree = render(state)

--- a/src/workstation/surfaces/workspace/view.ts
+++ b/src/workstation/surfaces/workspace/view.ts
@@ -13,6 +13,7 @@ import type { TextProps } from 'ink'
 import type { LogInkTheme } from '../../chrome/theme'
 import { renderThemePickerOverlay } from '../../runtime/overlays'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
+import { truncateCells } from '../../chrome/text'
 
 import type { WorkspaceComponents } from './runtime'
 import { type PathCompletionResult } from './pathCompletion'
@@ -91,6 +92,8 @@ function focusLabel(focus: WorkspaceState['focus']): string {
       return 'Filter'
     case 'add-repo':
       return 'Add'
+    case 'clone-repo':
+      return 'Clone'
     case 'confirm-delete':
       return 'Confirm'
     default:
@@ -469,10 +472,14 @@ function renderListBody(
   })
   const visibleRepos = selectVisibleRepos(state)
 
-  const filterChip = state.filter
-    ? `  ·  filter: ${state.filter}`
-    : state.focus === 'filter'
-      ? `  ·  filter: ${deps.filterDraft}_`
+  // The live draft wins while the prompt is open — checking the
+  // committed filter first meant re-editing an applied filter (`/` with
+  // one active) showed the stale committed text with no cursor, and
+  // typing gave zero feedback until Enter.
+  const filterChip = state.focus === 'filter'
+    ? `  ·  filter: ${deps.filterDraft}_`
+    : state.filter
+      ? `  ·  filter: ${state.filter}`
       : ''
   // Half-circle ◐ reads as "in progress" without animation; pairs
   // nicely with the text so the column doesn't depend on color alone.
@@ -557,6 +564,38 @@ function renderHelpRow(
     ),
     React.createElement(Text, null, row.description)
   )
+}
+
+/**
+ * Total scrollable body rows in the help overlay — one title per
+ * section, optional subtitle, its rows, and an inter-section spacer.
+ * MUST mirror the body construction in `renderHelpOverlay` below.
+ */
+function workspaceHelpBodyRowCount(): number {
+  const sections = buildWorkspaceHelpSections()
+  return sections.reduce(
+    (count, section, index) =>
+      count +
+      1 +
+      (section.subtitle ? 1 : 0) +
+      section.rows.length +
+      (index < sections.length - 1 ? 1 : 0),
+    0
+  )
+}
+
+/**
+ * Ceiling for `helpScrollOffset` at the given terminal height. The
+ * reducer clamps against this (passed with the scroll action) so the
+ * offset can't grow past the end invisibly — holding `j` at the bottom
+ * used to keep incrementing state, and `k` then spent N presses
+ * unwinding the excess before the view moved.
+ */
+export function workspaceHelpMaxOffset(rows: number): number {
+  const HEADER_ROWS = 3
+  const overlayChromeRows = 4
+  const visibleRows = Math.max(4, rows - HEADER_ROWS - FOOTER_HEIGHT - overlayChromeRows)
+  return Math.max(0, workspaceHelpBodyRowCount() - visibleRows)
 }
 
 function renderHelpOverlay(deps: RenderWorkspaceAppDeps): ReactTypes.ReactElement | null {
@@ -784,7 +823,13 @@ function renderCloneRepoPrompt(deps: RenderWorkspaceAppDeps): ReactTypes.ReactEl
   const { Box, Text } = ink
   const urlActive = cloneField === 'url' && !cloning
   const targetActive = cloneField === 'target' && !cloning
-  const completionLine = cloneCompletion.completions.slice(0, 8).join('  ')
+  // Truncate to the panel interior — a directory with many matches
+  // would otherwise wrap the line and push the modal past its
+  // reserved height.
+  const completionLine = truncateCells(
+    cloneCompletion.completions.slice(0, 8).join('  '),
+    Math.max(20, deps.columns - 8)
+  )
   const hint = cloning
     ? 'Cloning… this can take a moment for large repos.'
     : cloneField === 'url'
@@ -872,8 +917,16 @@ function computeBodyHeight(deps: RenderWorkspaceAppDeps): number {
   const FOOTER_ROWS = FOOTER_HEIGHT
   const onboardingRows = buildWorkspaceOnboarding(deps.state).show ? 5 : 0
   const addRepoRows = deps.state.focus === 'add-repo' ? 5 : 0
-  // Clone modal is one row taller (URL + Into + hint + completion).
-  const cloneRows = deps.state.focus === 'clone-repo' ? 6 : 0
+  // Clone modal: border (2) + title + URL + Into + hint = 6, plus the
+  // completion line exactly when the renderer shows it (target field
+  // active with matches) — reserving 6 flat overflowed the screen by
+  // one row mid-tab-completion, clipping the footer where clone errors
+  // are surfaced.
+  const cloneCompletionRow =
+    deps.cloneField === 'target' && !deps.cloning && deps.cloneCompletion.completions.length > 0
+      ? 1
+      : 0
+  const cloneRows = deps.state.focus === 'clone-repo' ? 6 + cloneCompletionRow : 0
   const confirmRows = deps.state.focus === 'confirm-delete' ? 5 : 0
   const reserved = HEADER_ROWS + FOOTER_ROWS + onboardingRows + addRepoRows + cloneRows + confirmRows
   return Math.max(8, deps.rows - reserved)


### PR DESCRIPTION
Four small, verified UI defects in the workspace surface, from a fresh review pass:

1. **Re-editing an applied filter gave zero feedback.** The header chip's ternary checked the committed `state.filter` before the `focus === 'filter'` draft branch, so pressing `/` with a filter active showed the stale committed text (no cursor) while keystrokes silently edited the invisible draft. The draft now wins while the prompt is open. Covered by a new view test.

2. **Help overlay scroll offset grew unbounded.** The `scroll-help` reducer only floor-clamped at 0; the ceiling clamp was display-only. Holding `j` past the end kept incrementing state, so `k` appeared dead for N presses while it unwound the invisible excess. The runtime now passes the terminal-height-derived ceiling (`workspaceHelpMaxOffset`, kept in lockstep with the overlay's body construction) with the action, and the reducer clamps. Covered by new state tests.

3. **Clone modal overflowed the screen by one row during tab-completion.** `cloneRows` reserved 6 flat, but the renderer adds a completion line when the destination field is active with matches (7 rows total, incl. borders) — exactly when the user tab-completes, the layout exceeded the locked root height and Ink clipped the footer, where clone errors are surfaced. The budget now mirrors the renderer's condition, and the completion line is cell-truncated so many matches can't wrap it.

4. **Focus chip said `[List]` while the clone modal owned the keyboard.** `focusLabel` was missing the `clone-repo` case (every other modal has one). Snapshot updates are this chip only.

Also checked but *not* changed: the workspace text filter's field separator — it already joins with a `\x01` control byte (invisible in most editors), so cross-field query straddling was a false positive.

## Validation
- `eslint` clean (2 pre-existing warnings untouched), `tsc --noEmit` clean
- Full jest suite green: 309 suites / 3991 tests, 68 snapshots