### PR TITLE
fix(git): fully qualify tag push/delete refspecs

### DIFF
--- a/src/git/tagActions.test.ts
+++ b/src/git/tagActions.test.ts
@@ -28,7 +28,12 @@ describe('log tag actions', () => {
       'release v0.34.0',
     ])
     expect(git.raw).toHaveBeenNthCalledWith(3, ['tag', '-d', '0.34.0'])
-    expect(git.raw).toHaveBeenNthCalledWith(4, ['push', 'origin', '0.34.0'])
-    expect(git.raw).toHaveBeenNthCalledWith(5, ['push', 'origin', ':0.34.0'])
+    // Remote-side refspecs stay fully qualified. The bare forms are
+    // ambiguous against a same-named remote branch: push errors with
+    // "matches more than one", and delete resolves against ANY matching
+    // ref — `:0.34.0` deleted a remote BRANCH named 0.34.0 when the tag
+    // itself had never been pushed.
+    expect(git.raw).toHaveBeenNthCalledWith(4, ['push', 'origin', 'refs/tags/0.34.0'])
+    expect(git.raw).toHaveBeenNthCalledWith(5, ['push', 'origin', ':refs/tags/0.34.0'])
   })
 })

--- a/src/git/tagActions.ts
+++ b/src/git/tagActions.ts
@@ -52,15 +52,21 @@ export function deleteLocalTag(git: SimpleGit, tagName: string): Promise<TagActi
 }
 
 export function pushTag(git: SimpleGit, tagName: string): Promise<TagActionResult> {
+  // Fully qualified refspec: a bare name errors when the remote has a
+  // same-named branch ("matches more than one").
   return runAction(
-    () => git.raw(['push', 'origin', tagName]),
+    () => git.raw(['push', 'origin', `refs/tags/${tagName}`]),
     `Pushed tag ${tagName}`
   )
 }
 
 export function deleteRemoteTag(git: SimpleGit, tagName: string): Promise<TagActionResult> {
+  // MUST stay fully qualified: `git push origin :<name>` resolves the
+  // deletion target against ANY matching remote ref — with a local tag
+  // that was never pushed and a same-named remote branch, the bare form
+  // deletes the BRANCH while reporting "Deleted remote tag".
   return runAction(
-    () => git.raw(['push', 'origin', `:${tagName}`]),
+    () => git.raw(['push', 'origin', `:refs/tags/${tagName}`]),
     `Deleted remote tag ${tagName}`
   )
 }


### PR DESCRIPTION
## Problem

`deleteRemoteTag` ran `git push origin :<tagName>` with an unqualified refspec. Git resolves a bare deletion refspec against **any** matching remote ref — so with a local tag `foo` that was never pushed and a remote **branch** `foo`, the workstation's `delete-remote-tag` workflow deleted the remote branch and reported "Deleted remote tag foo". This was reproduced empirically in a scratch repo during review (`[deleted] foo` removed `refs/heads/foo`).

`pushTag` had the milder sibling: a bare name errors with "matches more than one" when the remote has a same-named branch.

## Fix

Qualify both directions: `refs/tags/<name>` on push, `:refs/tags/<name>` on delete. Test assertions updated with a comment explaining why the qualification must stay.

## Validation
- Full jest suite green (309 suites / 3988 tests)
- `eslint` clean