### PR TITLE
fix(workstation): Esc actually cancels an in-flight split-plan generation

### DIFF
--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -531,6 +531,7 @@ export async function prepareCommitSplitPlan({
   llm,
   planLlm,
   planService,
+  signal,
 }: {
   argv: Arguments<CommitOptions>
   config: Config & CommitOptions
@@ -551,6 +552,13 @@ export async function prepareCommitSplitPlan({
   planLlm?: ReturnType<typeof getLlm>
   /** Service descriptor matching `planLlm` (for telemetry metadata). */
   planService?: LLMService
+  /**
+   * Optional user-cancellation signal — forwarded into the plan
+   * generation LLM calls (workstation Esc). The diff-summary pre-pass
+   * is not signal-aware yet; a cancel during it takes effect the
+   * moment the plan step starts (pre-aborted signal check).
+   */
+  signal?: AbortSignal
 }): Promise<
   | {
       plan: CommitSplitPlan
@@ -677,6 +685,7 @@ export async function prepareCommitSplitPlan({
     // the planner reverts to the pre-#1005 behaviour of throwing on
     // exhaustion instead of returning the single-group fallback.
     strict: Boolean(argv.strictSplit ?? config.strictSplit),
+    signal,
   })
 
   const groupCount = plan.groups.filter((g) => !g.unclaimed).length

--- a/src/commands/commit/splitPlanGenerator.ts
+++ b/src/commands/commit/splitPlanGenerator.ts
@@ -44,6 +44,12 @@ export interface GenerateSplitPlanArgs {
    * degraded plan.
    */
   strict?: boolean
+  /**
+   * Optional user-cancellation signal — forwarded into each plan
+   * attempt's LLM call so Esc in the workstation actually tears the
+   * request down (surfaces as `LangChainCancelledError`).
+   */
+  signal?: AbortSignal
 }
 
 /**
@@ -93,6 +99,7 @@ export async function generateValidatedCommitSplitPlan({
   metadata = {},
   maxAttempts = DEFAULT_MAX_PLAN_ATTEMPTS,
   strict = false,
+  signal,
 }: GenerateSplitPlanArgs): Promise<GenerateSplitPlanResult> {
   let lastIssues: PlanValidationIssues | null = null
   let attempt = 0
@@ -115,6 +122,7 @@ export async function generateValidatedCommitSplitPlan({
       {
         logger,
         tokenizer,
+        signal,
         metadata: {
           task: 'commit-split-plan',
           ...metadata,

--- a/src/git/commitWorkflowActions.ts
+++ b/src/git/commitWorkflowActions.ts
@@ -10,6 +10,7 @@ import {
   applyCommitSplitPlan,
   prepareCommitSplitPlan,
 } from '../commands/commit/split'
+import { LangChainCancelledError } from '../lib/langchain/errors'
 import { LLMModel } from '../lib/langchain/types'
 import {
   getApiKeyForModel,
@@ -287,7 +288,17 @@ export type CommitSplitPlanResult =
        */
       fallback?: import('../commands/commit/splitPlanGenerator').SplitPlanFallbackInfo
     }
-  | { ok: false; message: string; details?: string[] }
+  | {
+      ok: false
+      message: string
+      details?: string[]
+      /**
+       * True when the failure is a user abort (Esc during generation),
+       * not an error — callers should stay quiet instead of surfacing
+       * an error status.
+       */
+      cancelled?: boolean
+    }
 
 /**
  * Run plan generation in isolation — no formatting, no apply, no
@@ -298,7 +309,7 @@ export type CommitSplitPlanResult =
  * split matches what the user previewed.
  */
 export async function runCommitSplitPlanWorkflow(
-  input: { git?: SimpleGit } = {}
+  input: { git?: SimpleGit; signal?: AbortSignal } = {}
 ): Promise<CommitSplitPlanResult> {
   const git = input.git || getRepo()
   const argv = createCommitWorkflowArgv('split-plan')
@@ -341,6 +352,7 @@ export async function runCommitSplitPlanWorkflow(
       llm,
       planLlm,
       planService: splitService,
+      signal: input.signal,
     })
 
     if ('empty' in result) {
@@ -357,6 +369,11 @@ export async function runCommitSplitPlanWorkflow(
       fallback: result.fallback,
     }
   } catch (error) {
+    // User abort (Esc during generation) is intent, not failure — let
+    // the caller drop the result silently instead of painting an error.
+    if (error instanceof LangChainCancelledError) {
+      return { ok: false, cancelled: true, message: 'Split plan cancelled.' }
+    }
     if (isCommandExitError(error)) {
       const lines = compactOutputLines(error.message)
       return {

--- a/src/lib/langchain/utils/executeChainWithSchema.ts
+++ b/src/lib/langchain/utils/executeChainWithSchema.ts
@@ -1,6 +1,7 @@
 import { StringOutputParser } from '@langchain/core/output_parsers'
 import { PromptTemplate } from '@langchain/core/prompts'
 import { z } from 'zod'
+import { LangChainCancelledError } from '../errors'
 import { withRetry, type RetryOptions } from '../../utils/retry'
 import { Logger } from '../../utils/logger'
 import { TokenCounter } from '../../utils/tokenizer'
@@ -19,6 +20,13 @@ export interface ExecuteChainWithSchemaOptions<T> extends SchemaParserOptions {
   logger?: Logger
   tokenizer?: TokenCounter
   metadata?: Partial<LlmCallMetadata>
+  /**
+   * Optional user-cancellation signal (#1338 pattern). Forwarded into
+   * `executeChain` so the underlying HTTP request tears down when the
+   * signal fires. Aborts surface as `LangChainCancelledError`, are
+   * never retried, and skip the fallback parser.
+   */
+  signal?: AbortSignal
 }
 
 /**
@@ -45,6 +53,7 @@ export async function executeChainWithSchema<T>(
     logger,
     tokenizer,
     metadata,
+    signal,
     ...parserOptions
   } = options
   
@@ -61,19 +70,26 @@ export async function executeChainWithSchema<T>(
       parser,
       logger,
       tokenizer,
+      signal,
       metadata: {
         task: 'schema-chain',
         ...metadata,
         retryAttempt: attempt,
       },
     })
-    
+
     return result as T
   }
-  
+
   try {
     return await withRetry(operation, retryOptions)
   } catch (error) {
+    // A user abort is intent, not a parse failure — never degrade it
+    // into the fallback path (which would fire ANOTHER llm call on an
+    // already-cancelled interaction).
+    if (error instanceof LangChainCancelledError) {
+      throw error
+    }
     if (fallbackParser) {
       if (onFallback) {
         onFallback()
@@ -86,6 +102,7 @@ export async function executeChainWithSchema<T>(
         parser: new StringOutputParser(),
         logger,
         tokenizer,
+        signal,
         metadata: {
           task: 'schema-chain-fallback',
           ...metadata,

--- a/src/lib/utils/retry.test.ts
+++ b/src/lib/utils/retry.test.ts
@@ -49,10 +49,23 @@ describe('retry utilities', () => {
     it('should respect shouldRetry predicate', async () => {
       const operation = jest.fn().mockRejectedValue(new Error('ValidationError'))
       const shouldRetry = jest.fn().mockReturnValue(false)
-      
+
       await expect(withRetry(operation, { shouldRetry })).rejects.toThrow('ValidationError')
       expect(operation).toHaveBeenCalledTimes(1)
       expect(shouldRetry).toHaveBeenCalledWith(expect.any(Error))
+    })
+
+    it('never retries a user cancellation by default', async () => {
+      // A cancelled LLM call (LangChainCancelledError) is intent, not a
+      // transient failure — the default predicate must not re-issue it.
+      const cancelled = new Error('user cancelled')
+      cancelled.name = 'LangChainCancelledError'
+      const operation = jest.fn().mockRejectedValue(cancelled)
+
+      await expect(withRetry(operation, { maxAttempts: 3, backoffMs: 1 })).rejects.toThrow(
+        'user cancelled'
+      )
+      expect(operation).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/lib/utils/retry.ts
+++ b/src/lib/utils/retry.ts
@@ -30,12 +30,18 @@ function defaultShouldRetry(error: Error): boolean {
   if (error.name.includes('Validation') || error.name.includes('Configuration')) {
     return false
   }
-  
+
   // Don't retry authentication errors
   if (error.name.includes('Authentication')) {
     return false
   }
-  
+
+  // Never retry a user cancellation (LangChainCancelledError et al) —
+  // the abort was intent, and a retry would re-issue the aborted call.
+  if (error.name.includes('Cancelled')) {
+    return false
+  }
+
   // Retry execution errors and timeouts
   return true
 }

--- a/src/workstation/runtime/hooks/useCommitSplitActions.ts
+++ b/src/workstation/runtime/hooks/useCommitSplitActions.ts
@@ -102,6 +102,14 @@ export function useCommitSplitActions(
     refreshWorktreeContext,
   } = deps
 
+  // AbortController for the in-flight plan generation (#1338 pattern —
+  // same shape as the changelog / commit-draft cancels). Esc used to be
+  // a "soft cancel": the overlay closed but the LLM call ran to
+  // completion and its unconditional `setSplitPlanReady` dispatch
+  // REOPENED the overlay tens of seconds later, stealing the keyboard
+  // from whatever the user had moved on to.
+  const planAbortRef = React.useRef<AbortController | null>(null)
+
   // `S` keystroke — start the `coco commit --split` flow (#907).
   // Pre-flight refuses cleanly when:
   //   - Nothing is staged (suggests `g s` to pick files)
@@ -132,7 +140,30 @@ export function useCommitSplitActions(
     dispatch({ type: 'startSplitPlanLoad' })
     dispatch({ type: 'setStatus', value: 'Generating split plan (this can take a minute)…', loading: true })
 
-    const result = await runCommitSplitPlanWorkflow({ git })
+    // Abort any predecessor (r re-roll while one is already running)
+    // and take ownership of the slot for this invocation.
+    planAbortRef.current?.abort()
+    const controller = new AbortController()
+    planAbortRef.current = controller
+
+    let result: Awaited<ReturnType<typeof runCommitSplitPlanWorkflow>>
+    try {
+      result = await runCommitSplitPlanWorkflow({ git, signal: controller.signal })
+    } finally {
+      if (planAbortRef.current === controller) {
+        planAbortRef.current = null
+      }
+    }
+
+    // Ownership check: if the user cancelled (Esc → abort) or a newer
+    // invocation superseded this one, drop the result on the floor —
+    // the cancel path already closed the overlay and set its status.
+    if (controller.signal.aborted) {
+      return
+    }
+    if (!result.ok && result.cancelled) {
+      return
+    }
 
     if (!result.ok) {
       dispatch({ type: 'setSplitPlanError', error: result.message })
@@ -359,9 +390,13 @@ export function useCommitSplitActions(
     })
   }, [dispatch, git, refreshContext, refreshHistoryRows, refreshWorktreeContext, stateSplitPlan])
 
-  // Esc inside the overlay — close without applying. Status line gets
-  // a confirmation so the user knows the operation was abandoned.
+  // Esc inside the overlay — close without applying, and tear down an
+  // in-flight generation (the abort propagates into the LLM HTTP
+  // request; the start path's ownership check drops the settled
+  // result). Status line gets a confirmation so the user knows the
+  // operation was abandoned.
   const cancelCommitSplit = React.useCallback(() => {
+    planAbortRef.current?.abort()
     dispatch({ type: 'clearSplitPlan' })
     dispatch({ type: 'setStatus', value: 'Split plan cancelled.' })
   }, [dispatch])

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -1490,11 +1490,11 @@ export function getLogInkInputEvents(
     const lineCount = context.splitPlanLineCount || 0
 
     if (key.escape) {
-      // Esc during loading is a soft cancel — we can't actually abort
-      // the in-flight LLM call (runs in a sibling promise), but we
-      // close the overlay and the runtime ignores the resolved plan
-      // when it eventually lands (it checks `state.splitPlan?.status`
-      // before dispatching setSplitPlanReady).
+      // Esc closes the overlay AND aborts an in-flight generation —
+      // `cancelCommitSplit` fires the plan AbortController (#1338
+      // pattern), and the start path drops a superseded/aborted
+      // result instead of dispatching setSplitPlanReady over the
+      // user's next activity.
       return [{ type: 'cancelCommitSplit' }]
     }
 


### PR DESCRIPTION
## Problem

Esc during split-plan generation claimed to be a soft cancel — the comment in `inkInput.ts` said "the runtime ignores the resolved plan when it eventually lands (it checks `state.splitPlan?.status` before dispatching setSplitPlanReady)". **No such check existed.** `useCommitSplitActions.startCommitSplit` dispatched `setSplitPlanReady` unconditionally when the LLM resolved, and the reducer unconditionally re-creates the overlay.

Repro: `S` → "this can take a minute" → Esc (overlay closes, "Split plan cancelled.") → user resumes staging/composing → 30–60s later the LLM resolves → **the split overlay pops back open and steals every keystroke** (the overlay intercept claims all input). The call also billed tokens with no way to stop it — a violation of the workstation's Esc-cancels-any-AI-call invariant (README §Async LLM calls), which changelog/commit-draft/PR-body all honor.

## Fix (mirrors the #1338 changelog pattern)

- `executeChainWithSchema` gains a `signal` option: forwarded into both the schema chain and the fallback chain via `executeChain` (which already supported it), and a cancellation is rethrown rather than degraded into the fallback parser (which would have fired *another* LLM call post-abort).
- `withRetry`'s default predicate no longer retries errors named `*Cancelled*` — re-issuing an aborted call is wrong everywhere. (New unit test.)
- `generateValidatedCommitSplitPlan` → `prepareCommitSplitPlan` → `runCommitSplitPlanWorkflow` thread the signal; the workflow translates `LangChainCancelledError` into `{ ok: false, cancelled: true }` (same shape the draft workflow uses).
- The hook holds an `AbortController` per invocation: `cancelCommitSplit` (Esc/q) aborts it, a re-roll aborts its predecessor, and the start path drops aborted/superseded/cancelled results instead of dispatching over the user's next activity.

The diff-summary pre-pass is not signal-aware yet; a cancel during it takes effect the instant the plan step starts (pre-aborted check in `executeChain`) — and the overlay can never zombie-reopen regardless, thanks to the ownership check.

## Validation
- `tsc --noEmit` clean, `eslint` clean
- Full jest suite green: 309 suites / 3989 tests