### PR TITLE
fix(workstation): four input-dispatch gates

### DIFF
--- a/src/workstation/runtime/footer.ts
+++ b/src/workstation/runtime/footer.ts
@@ -121,6 +121,7 @@ export function renderFooter(
     showHelp: state.showHelp,
     sidebarTab: state.sidebarTab,
     sidebarItemCount,
+    bisectActive: Boolean(context.bisect?.active),
     compareBaseSet: Boolean(state.compareBase),
     splitPlanStatus: state.splitPlan?.status,
     singlePane: singlePane && !overlayForcesPane,

--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -1313,8 +1313,27 @@ describe('log Ink input interactions', () => {
     let state = createLogInkState(rows)
     state = applyLogInkAction(state, { type: 'pushView', value: 'bisect' })
 
-    const events = getLogInkInputEvents(state, 'y', {}, {})
+    const events = getLogInkInputEvents(state, 'y', {}, { bisectActive: true })
     expect(events).toContainEqual({ type: 'runWorkflowAction', id: 'bisect-good' })
+  })
+
+  it('y/b/x on the empty bisect view (no active session) do not fire raw git bisect', () => {
+    // Like `s`/`R`, the mark/reset keys are meaningless before a
+    // session exists — they used to surface a raw `git bisect` error
+    // ("You need to start by \"git bisect start\"") on the status line.
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'bisect' })
+
+    expect(getLogInkInputEvents(state, 'y', {}, { bisectActive: false }))
+      .not.toContainEqual({ type: 'runWorkflowAction', id: 'bisect-good' })
+    expect(getLogInkInputEvents(state, 'b', {}, { bisectActive: false }))
+      .not.toContainEqual({ type: 'runWorkflowAction', id: 'bisect-bad' })
+    const resetEvents = getLogInkInputEvents(state, 'x', {}, { bisectActive: false })
+    expect(resetEvents.find((event) =>
+      event.type === 'action' &&
+      event.action.type === 'setPendingConfirmation' &&
+      event.action.value === 'bisect-reset'
+    )).toBeUndefined()
   })
 
   it('g on the bisect view arms the chord so gh/gs navigation works mid-bisect (#1352)', () => {
@@ -1342,7 +1361,7 @@ describe('log Ink input interactions', () => {
     let state = createLogInkState(rows)
     state = applyLogInkAction(state, { type: 'pushView', value: 'bisect' })
 
-    const events = getLogInkInputEvents(state, 'b', {}, {})
+    const events = getLogInkInputEvents(state, 'b', {}, { bisectActive: true })
 
     expect(events).toContainEqual({ type: 'runWorkflowAction', id: 'bisect-bad' })
   })
@@ -1455,7 +1474,7 @@ describe('log Ink input interactions', () => {
     let state = createLogInkState(rows)
     state = applyLogInkAction(state, { type: 'pushView', value: 'bisect' })
 
-    const events = getLogInkInputEvents(state, 'x', {}, {})
+    const events = getLogInkInputEvents(state, 'x', {}, { bisectActive: true })
 
     const confirm = events.find((event) =>
       event.type === 'action' && event.action.type === 'setPendingConfirmation'
@@ -1464,6 +1483,57 @@ describe('log Ink input interactions', () => {
     if (confirm && confirm.type === 'action' && confirm.action.type === 'setPendingConfirmation') {
       expect(confirm.action.value).toBe('bisect-reset')
     }
+  })
+
+  it('1/2/3 with the sidebar focused jump tabs instead of toggling the status mask', () => {
+    // The sidebar footer advertises "1-5 jump"; the status-view mask
+    // intercept used to eat 1/2/3 (toggling center-pane state
+    // invisibly) while the sidebar stayed put.
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'status' })
+    state = applyLogInkAction(state, { type: 'setFocus', value: 'sidebar' })
+
+    const events = getLogInkInputEvents(state, '2', {}, {})
+    expect(events.find((event) =>
+      event.type === 'action' && event.action.type === 'toggleStatusFilterMask'
+    )).toBeUndefined()
+    expect(events.find((event) =>
+      event.type === 'action' && event.action.type === 'setSidebarTab'
+    )).toBeDefined()
+
+    // Commits focus keeps the mask toggle.
+    state = applyLogInkAction(state, { type: 'setFocus', value: 'commits' })
+    const maskEvents = getLogInkInputEvents(state, '2', {}, {})
+    expect(maskEvents.find((event) =>
+      event.type === 'action' && event.action.type === 'toggleStatusFilterMask'
+    )).toBeDefined()
+  })
+
+  it('C respects the CREATE_PR_VIEWS allowlist on non-opted-in views', () => {
+    // rebase / blame / file-history deliberately did not opt into the
+    // bare-C create-PR binding; the registry fall-through at the end
+    // of the dispatcher used to fire the workflow anyway.
+    for (const view of ['blame', 'file-history'] as const) {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: view })
+      const events = getLogInkInputEvents(state, 'C', {}, {})
+      expect(events).not.toContainEqual({ type: 'runWorkflowAction', id: 'create-pr' })
+      expect(events).not.toContainEqual({ type: 'startCreatePullRequest' })
+    }
+  })
+
+  it('arrow keys scroll the ready changelog view like j/k', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'changelog' })
+
+    const down = getLogInkInputEvents(state, '', { downArrow: true }, { changelogLineCount: 40 })
+    expect(down.find((event) =>
+      event.type === 'action' && event.action.type === 'pageChangelog' && event.action.delta === 1
+    )).toBeDefined()
+    const up = getLogInkInputEvents(state, '', { upArrow: true }, { changelogLineCount: 40 })
+    expect(up.find((event) =>
+      event.type === 'action' && event.action.type === 'pageChangelog' && event.action.delta === -1
+    )).toBeDefined()
   })
 
   it('does not hijack g/b/s/x outside the bisect view (#784)', () => {
@@ -2952,7 +3022,7 @@ describe('log Ink input interactions', () => {
         getLogInkInputEvents(state, 'Y', {}, { bisectCompletionSha: 'abc12345' })
       ).toEqual([{ type: 'yankFromActiveView', short: true }])
       // No terminator → `y` is the mark-good key mid-bisect (#1352).
-      expect(getLogInkInputEvents(state, 'y', {}, {}))
+      expect(getLogInkInputEvents(state, 'y', {}, { bisectActive: true }))
         .toEqual([{ type: 'runWorkflowAction', id: 'bisect-good' }])
     })
 

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -2119,11 +2119,20 @@ export function getLogInkInputEvents(
   if (state.activeView === 'bisect' && state.focus === 'commits') {
     // Gated off once the bisect has terminated: the completion panel
     // rebinds y/Y to yank the first-bad sha (#879 item 3), and there
-    // is no candidate left to mark.
-    if (inputValue === 'y' && !key.ctrl && !key.meta && !context.bisectCompletionSha) {
+    // is no candidate left to mark. Also gated on an ACTIVE session —
+    // like `s`/`R`, marking is meaningless from the empty-state view
+    // and used to surface a raw `git bisect` error ("You need to
+    // start by \"git bisect start\"") on the status line.
+    if (
+      inputValue === 'y' &&
+      !key.ctrl &&
+      !key.meta &&
+      context.bisectActive &&
+      !context.bisectCompletionSha
+    ) {
       return [{ type: 'runWorkflowAction', id: 'bisect-good' }]
     }
-    if (inputValue === 'b' && state.pendingKey !== 'g') {
+    if (inputValue === 'b' && state.pendingKey !== 'g' && context.bisectActive) {
       return [{ type: 'runWorkflowAction', id: 'bisect-bad' }]
     }
     if (inputValue === 's') {
@@ -2145,7 +2154,7 @@ export function getLogInkInputEvents(
         }),
       ]
     }
-    if (inputValue === 'x') {
+    if (inputValue === 'x' && context.bisectActive) {
       return [action({ type: 'setPendingConfirmation', value: 'bisect-reset' })]
     }
     // #879 item 5 — `R` (capital) on an active bisect view opens an
@@ -2176,10 +2185,13 @@ export function getLogInkInputEvents(
   // is 'ready' — scroll keystrokes early-return when changelogLineCount
   // is missing so they no-op gracefully during loading / error states.
   if (state.activeView === 'changelog') {
-    if (inputValue === 'j' && context.changelogLineCount) {
+    // Arrows are synonyms for j/k here like on every other surface —
+    // they used to be swallowed by the loading-state guard below even
+    // when the view was ready, leaving ↓/↑ silently dead.
+    if ((inputValue === 'j' || key.downArrow) && context.changelogLineCount) {
       return [action({ type: 'pageChangelog', delta: 1, lineCount: context.changelogLineCount })]
     }
-    if (inputValue === 'k' && context.changelogLineCount) {
+    if ((inputValue === 'k' || key.upArrow) && context.changelogLineCount) {
       return [action({ type: 'pageChangelog', delta: -1, lineCount: context.changelogLineCount })]
     }
     if (key.pageDown && context.changelogLineCount) {
@@ -2449,8 +2461,15 @@ export function getLogInkInputEvents(
   // Status surface intercepts 1/2/3 before the sidebar-tab numeric
   // jump (#776): each key toggles a staging-category bit on the
   // visibility mask. The reducer snaps back to all-on if all three
-  // bits go off so the user always has rendered files.
-  if (state.activeView === 'status' && (inputValue === '1' || inputValue === '2' || inputValue === '3')) {
+  // bits go off so the user always has rendered files. NOT while the
+  // sidebar is focused — its footer advertises "1-5 jump", and the
+  // mask intercept silently ate 1/2/3 (toggling center-pane state)
+  // while the sidebar stayed put.
+  if (
+    state.activeView === 'status' &&
+    state.focus !== 'sidebar' &&
+    (inputValue === '1' || inputValue === '2' || inputValue === '3')
+  ) {
     const kind: 'staged' | 'unstaged' | 'untracked' =
       inputValue === '1' ? 'staged' : inputValue === '2' ? 'unstaged' : 'untracked'
     return [action({ type: 'toggleStatusFilterMask', kind })]
@@ -4073,6 +4092,16 @@ export function getLogInkInputEvents(
   }
 
   const workflowAction = getLogInkWorkflowActionByKey(inputValue)
+
+  // The registry fall-through must respect the per-view allowlist:
+  // `C` on every opted-in view already matched `isCreatePrView` above,
+  // so reaching here means the active view (rebase, blame,
+  // file-history) deliberately did NOT opt in — firing the workflow
+  // anyway reintroduced exactly the hazard the allowlist exists to
+  // remove (a PR-creation flow launching mid-rebase-plan).
+  if (workflowAction?.id === 'create-pr' && !isCreatePrView(state.activeView)) {
+    return []
+  }
 
   if (workflowAction?.requiresConfirmation) {
     return [action({ type: 'setPendingConfirmation', value: workflowAction.id })]

--- a/src/workstation/runtime/inkKeymap.ts
+++ b/src/workstation/runtime/inkKeymap.ts
@@ -689,6 +689,10 @@ export type GetLogInkFooterHintsOptions = {
    *  back to the generic "enter open" hint instead of showing per-item
    *  ops the user cannot reach. */
   sidebarItemCount?: number
+  /** True while a bisect session is in progress. The bisect view's
+   *  mark/skip/run/reset keys are gated on an active session, so the
+   *  footer must not advertise them from the empty-state view. */
+  bisectActive?: boolean
   /**
    * Current diff view rendering mode (#785). When set on the diff view
    * the footer surfaces `d split` / `d unified` so users see what `d`
@@ -1420,7 +1424,12 @@ function computeLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogInkF
 
   if (options.activeView === 'bisect') {
     return {
-      contextual: ['y good', 'b bad', 's skip', 'R run', 'x reset', 'esc back'],
+      // No session yet → the only live keys are the start wizard and
+      // back-out; the mark/skip/run/reset set is gated on an active
+      // session in the input layer.
+      contextual: options.bisectActive
+        ? ['y good', 'b bad', 's skip', 'R run', 'x reset', 'esc back']
+        : ['s start', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }


### PR DESCRIPTION
Four verified keyboard-dispatch defects from a fresh review of `inkInput.ts` precedence order:

1. **Sidebar "1-5 jump" was broken on the status view.** The status-view 1/2/3 staging-mask intercept had no focus gate, so with the sidebar focused (whose footer advertises "1-5 jump"), pressing 1/2/3 silently toggled the center pane's visibility mask while the sidebar stayed put — only 4/5 worked as advertised. The intercept now yields while `focus === 'sidebar'`.

2. **`C` defeated its own allowlist on rebase / blame / file-history.** `CREATE_PR_VIEWS` exists so views must opt in to the bare-`C` create-PR binding — but on non-opted-in views the keystroke fell through to the end-of-dispatcher workflow-by-key registry, which matched `create-pr` (no confirmation) and launched the PR-creation flow mid-rebase-plan. The fall-through now respects the allowlist.

3. **Bisect `y`/`b`/`x` fired with no active session.** `s`/`R` already gate on `bisectActive`; the mark/reset keys didn't, so pressing `y` on the empty-state view ran raw `git bisect good` and surfaced `You need to start by \"git bisect start\"` on the status line. Now gated, and the footer shows `s start · esc back` from the empty state instead of advertising five dead keys.

4. **↓/↑ were dead on the ready changelog view.** The loading-state key swallow (from the #1348 fix) caught arrow keys even when the view was ready; they're now synonyms for j/k like every other surface.

New tests for all four; three existing bisect tests updated to pass `bisectActive: true` (which is the point of the change).

## Validation
- `tsc --noEmit` clean, `eslint` clean
- Full jest suite green: 309 suites / 3992 tests