### PR TITLE
fix(commit): hook-retry no longer stages the entire worktree

### DIFF
--- a/src/lib/simple-git/createCommit.test.ts
+++ b/src/lib/simple-git/createCommit.test.ts
@@ -9,10 +9,12 @@ const mockCommitResult: CommitResult = {
   summary: { changes: 1, deletions: 0, insertions: 1 },
 }
 
-function makeGit(commitImpl: jest.Mock, addImpl?: jest.Mock): SimpleGit {
+function makeGit(commitImpl: jest.Mock, rawImpl?: jest.Mock): SimpleGit {
   return {
     commit: commitImpl,
-    add: addImpl ?? jest.fn().mockResolvedValue(undefined),
+    // `raw` serves both the staged-file listing (diff --cached) and the
+    // scoped re-add in the hook-retry path.
+    raw: rawImpl ?? jest.fn().mockResolvedValue(''),
   } as unknown as SimpleGit
 }
 
@@ -27,9 +29,13 @@ describe('isPreCommitHookModifiedFilesError', () => {
     expect(isPreCommitHookModifiedFilesError(err)).toBe(true)
   })
 
-  it('returns true when message contains "hook id:"', () => {
-    const err = new Error('- hook id: trailing-whitespace\n- exit code: 1')
-    expect(isPreCommitHookModifiedFilesError(err)).toBe(true)
+  it('returns false for a failing hook that did NOT modify files', () => {
+    // The pre-commit framework prints "- hook id:" for EVERY failing
+    // hook — plain lint failures included. Matching on it used to
+    // auto-stage the entire worktree and retry a commit the hook had
+    // genuinely rejected.
+    const err = new Error('- hook id: flake8\n- exit code: 1\n\nsrc/app.py:3:1: F401 unused import')
+    expect(isPreCommitHookModifiedFilesError(err)).toBe(false)
   })
 
   it('returns false for unrelated git errors', () => {
@@ -85,10 +91,10 @@ describe('createCommit', () => {
   })
 
   it('re-throws non-GitError errors', async () => {
-    const err = new Error('nothing to commit')
+    const err = new Error('spawn git ENOENT')
     const commitMock = jest.fn().mockRejectedValue(err)
     const git = makeGit(commitMock)
-    await expect(createCommit('test commit', git)).rejects.toThrow('nothing to commit')
+    await expect(createCommit('test commit', git)).rejects.toThrow('spawn git ENOENT')
   })
 
   it('wraps GitError as PreCommitHookError', async () => {
@@ -96,6 +102,22 @@ describe('createCommit', () => {
     const commitMock = jest.fn().mockRejectedValue(gitErr)
     const git = makeGit(commitMock)
     await expect(createCommit('test commit', git)).rejects.toBeInstanceOf(PreCommitHookError)
+  })
+
+  it('does not blame hooks for "nothing to commit"', async () => {
+    // Empty-index commits exit non-zero with hooks entirely out of the
+    // picture — wrapping them used to report "Commit blocked by hook:
+    // nothing to commit", pointing users at hook config that never ran.
+    const gitErr = new GitError(undefined, 'nothing to commit, working tree clean')
+    const commitMock = jest.fn().mockRejectedValue(gitErr)
+    const git = makeGit(commitMock)
+    try {
+      await createCommit('test commit', git)
+      fail('expected to throw')
+    } catch (err) {
+      expect(err).not.toBeInstanceOf(PreCommitHookError)
+      expect((err as Error).message).toContain('nothing to commit')
+    }
   })
 
   it('preserves hook output in PreCommitHookError', async () => {
@@ -140,29 +162,50 @@ describe('createCommit', () => {
       'black...Failed\n- hook id: black\n- files were modified by this hook'
     )
 
-    it('stages all files and retries the commit', async () => {
-      const addMock = jest.fn().mockResolvedValue(undefined)
+    it('re-stages only the already-staged files and retries the commit', async () => {
+      // The retry must be scoped to the index — `git add .` here used
+      // to sweep deliberately-unstaged edits and untracked files into
+      // the commit (catastrophic in the split flow, where every other
+      // group's changes sit unstaged).
+      const rawMock = jest.fn().mockImplementation((args: string[]) =>
+        Promise.resolve(args[0] === 'diff' ? 'src/a.ts\0src/b with space.ts\0' : '')
+      )
       const commitMock = jest
         .fn()
         .mockRejectedValueOnce(hookError)
         .mockResolvedValueOnce(mockCommitResult)
-      const git = makeGit(commitMock, addMock)
+      const git = makeGit(commitMock, rawMock)
 
       const result = await createCommit('test commit', git)
 
-      expect(addMock).toHaveBeenCalledWith('.')
+      expect(rawMock).toHaveBeenCalledWith(['diff', '--cached', '--name-only', '-z'])
+      expect(rawMock).toHaveBeenCalledWith(['add', '--', 'src/a.ts', 'src/b with space.ts'])
       expect(commitMock).toHaveBeenCalledTimes(2)
       expect(result).toEqual(mockCommitResult)
     })
 
-    it('calls onHookModifiedFiles callback before retry', async () => {
-      const onHookModifiedFiles = jest.fn()
-      const addMock = jest.fn().mockResolvedValue(undefined)
+    it('skips the re-add when the index is empty', async () => {
+      const rawMock = jest.fn().mockResolvedValue('')
       const commitMock = jest
         .fn()
         .mockRejectedValueOnce(hookError)
         .mockResolvedValueOnce(mockCommitResult)
-      const git = makeGit(commitMock, addMock)
+      const git = makeGit(commitMock, rawMock)
+
+      await createCommit('test commit', git)
+
+      expect(rawMock).toHaveBeenCalledTimes(1)
+      expect(rawMock).toHaveBeenCalledWith(['diff', '--cached', '--name-only', '-z'])
+    })
+
+    it('calls onHookModifiedFiles callback before retry', async () => {
+      const onHookModifiedFiles = jest.fn()
+      const rawMock = jest.fn().mockResolvedValue('')
+      const commitMock = jest
+        .fn()
+        .mockRejectedValueOnce(hookError)
+        .mockResolvedValueOnce(mockCommitResult)
+      const git = makeGit(commitMock, rawMock)
 
       await createCommit('test commit', git, onHookModifiedFiles)
 
@@ -170,35 +213,35 @@ describe('createCommit', () => {
     })
 
     it('works without an onHookModifiedFiles callback', async () => {
-      const addMock = jest.fn().mockResolvedValue(undefined)
+      const rawMock = jest.fn().mockResolvedValue('')
       const commitMock = jest
         .fn()
         .mockRejectedValueOnce(hookError)
         .mockResolvedValueOnce(mockCommitResult)
-      const git = makeGit(commitMock, addMock)
+      const git = makeGit(commitMock, rawMock)
 
       await expect(createCommit('test commit', git)).resolves.toEqual(mockCommitResult)
     })
 
     it('throws if the retry also fails', async () => {
       const retryError = new Error('commit failed after hook fix')
-      const addMock = jest.fn().mockResolvedValue(undefined)
+      const rawMock = jest.fn().mockResolvedValue('')
       const commitMock = jest
         .fn()
         .mockRejectedValueOnce(hookError)
         .mockRejectedValueOnce(retryError)
-      const git = makeGit(commitMock, addMock)
+      const git = makeGit(commitMock, rawMock)
 
       await expect(createCommit('test commit', git)).rejects.toThrow('commit failed after hook fix')
     })
 
     it('passes noVerify flag through to retry commit', async () => {
-      const addMock = jest.fn().mockResolvedValue(undefined)
+      const rawMock = jest.fn().mockResolvedValue('')
       const commitMock = jest
         .fn()
         .mockRejectedValueOnce(hookError)
         .mockResolvedValueOnce(mockCommitResult)
-      const git = makeGit(commitMock, addMock)
+      const git = makeGit(commitMock, rawMock)
 
       await createCommit('test commit', git, undefined, { noVerify: true })
 

--- a/src/lib/simple-git/createCommit.ts
+++ b/src/lib/simple-git/createCommit.ts
@@ -18,6 +18,13 @@ export class PreCommitHookError extends Error {
  * Detects whether a GitError was caused by a pre-commit hook that modified files.
  * These hooks (e.g. black, prettier) reformat files and exit non-zero on the first run,
  * but the commit can succeed once the modified files are re-staged.
+ *
+ * Deliberately NARROW: it must match only the "hook reformatted files"
+ * signature, not any failing hook. The pre-commit framework prints
+ * `- hook id: <name>` for EVERY failing hook — plain lint failures
+ * included — and matching on that used to auto-stage-and-retry a
+ * commit whose hook genuinely rejected it, silently sweeping the whole
+ * worktree into the commit (see the retry in `createCommit`).
  */
 export function isPreCommitHookModifiedFilesError(error: unknown): boolean {
   if (!(error instanceof Error)) return false
@@ -26,8 +33,21 @@ export function isPreCommitHookModifiedFilesError(error: unknown): boolean {
   // git itself outputs "modified files exist in working tree" in some hook setups
   return (
     msg.includes('files were modified by this hook') ||
-    msg.includes('modified by this hook') ||
-    msg.includes('hook id:')
+    msg.includes('modified by this hook')
+  )
+}
+
+/**
+ * Non-hook commit failures that must not be reported as "blocked by
+ * hook": git exits non-zero for these with hooks entirely out of the
+ * picture, and wrapping them in PreCommitHookError pointed users at
+ * their hook config for a problem that has nothing to do with it.
+ */
+function isKnownNonHookCommitFailure(message: string): boolean {
+  return (
+    message.includes('nothing to commit') ||
+    message.includes('no changes added to commit') ||
+    message.includes('nothing added to commit')
   )
 }
 
@@ -71,14 +91,32 @@ export async function createCommit(
         await onHookModifiedFiles()
       }
 
-      // Stage all hook-modified files and retry the commit once
-      await git.add('.')
+      // Re-stage ONLY the files that were already in the index — the
+      // hook reformatted those in the worktree, so `add` picks up the
+      // new content. `git add .` here used to sweep the ENTIRE
+      // worktree (deliberately-unstaged edits, untracked scratch
+      // files, and — in the split flow, where everything else sits
+      // unstaged after the up-front reset — every other group's
+      // changes) into this one commit.
+      const staged = (await git.raw(['diff', '--cached', '--name-only', '-z']))
+        .split('\0')
+        .filter(Boolean)
+      if (staged.length > 0) {
+        await git.raw(['add', '--', ...staged])
+      }
       return await git.commit(message, flags)
     }
 
-    // Wrap any other GitError so callers can present it cleanly rather than
-    // showing a raw Node.js stack trace originating from simple-git internals.
     if (error instanceof GitError) {
+      // Known non-hook failures pass through untouched: "nothing to
+      // commit" reported as "Commit blocked by hook: …" sent users
+      // debugging hooks that never ran.
+      if (isKnownNonHookCommitFailure(error.message)) {
+        throw error
+      }
+      // Wrap remaining GitErrors so callers can present them cleanly
+      // rather than showing a raw Node.js stack trace originating
+      // from simple-git internals.
       throw new PreCommitHookError(error.message)
     }
 


### PR DESCRIPTION
## Problem

Two compounding defects in `createCommit`'s pre-commit-hook retry (`src/lib/simple-git/createCommit.ts`):

1. **Over-broad detection.** `isPreCommitHookModifiedFilesError` matched `msg.includes('hook id:')` — but the pre-commit framework prints `- hook id: <name>` for **every** failing hook, plain lint failures included (`- hook id: flake8 / exit code: 1`). A hook that genuinely rejected the commit was treated as "hook reformatted files, retry".

2. **Over-broad retry.** On match, the retry ran `git add .` — staging the **entire worktree**: deliberately-unstaged edits, untracked scratch files, everything. In the split flow this is catastrophic: after the up-front `git reset`, all other groups' changes sit unstaged, so a reformatting/flaky hook on group 1 folded the whole plan (plus untracked files) into one commit under group 1's message.

Related: every other `GitError` was wrapped as `PreCommitHookError`, so "nothing to commit, working tree clean" surfaced as "Commit blocked by hook: …" — sending users to debug hooks that never ran.

## Fix

- Detection requires the `modified by this hook` signature (formatters like black/prettier print `- files were modified by this hook`); a failing hook without it propagates as the hook failure it is.
- The retry re-stages **only the files already in the index** (`git diff --cached --name-only -z` → `git add -- <files>`), picking up the hook's reformatting without widening the commit. Empty index → no re-add.
- `nothing to commit` / `no changes added to commit` GitErrors pass through unwrapped.

Tests updated/added for all three behaviors (including a filename-with-space case for the scoped re-add).

## Validation
- `tsc --noEmit` clean, `eslint` clean
- Full jest suite green: 309 suites / 3990 tests