### PR TITLE
fix(commit): split apply — index isolation between groups; config-filtered staged files survive

### DIFF
--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -398,12 +398,50 @@ export async function applyCommitSplitPlan({
     previousHead = 'EMPTY'
   }
 
+  // The plan was built against the config-filtered staged list
+  // (ignoredFiles / ignoredExtensions — lockfiles and sourcemaps by
+  // default), but the up-front reset below unstages EVERYTHING. A
+  // staged file that no group claims (because the filter hid it from
+  // the planner) would silently end up unstaged and absent from every
+  // commit — a divergence from regular `coco commit`, which commits
+  // the whole index. Capture those paths now so they can be re-staged
+  // after the loop, preserving the user's staging intent.
+  const stagedBeforeReset = (await git.raw(['diff', '--cached', '--name-only', '-z']))
+    .split('\0')
+    .filter(Boolean)
+  const plannedFiles = new Set<string>()
+  for (const group of plan.groups) {
+    for (const file of group.files || []) {
+      plannedFiles.add(file)
+    }
+    for (const hunkId of group.hunks || []) {
+      const hunk = hunkInventory.byId.get(hunkId)
+      if (hunk) {
+        plannedFiles.add(hunk.filePath)
+      }
+    }
+  }
+  const unplannedStaged = stagedBeforeReset.filter((file) => !plannedFiles.has(file))
+
   await git.raw(['reset'])
 
   logger.startSpinner(`Applying ${applicableGroups.length} commits…`)
 
   const commitHashes: string[] = []
   const failures: { title: string; reason: string }[] = []
+
+  // A failed group can leave its files sitting in the index (add
+  // succeeded, commit rejected by a hook, patch half-applied, …). The
+  // next group's add would then compound on top and its commit would
+  // silently absorb the failed group's files under the wrong message.
+  const clearIndexAfterFailure = async () => {
+    try {
+      await git.raw(['reset'])
+    } catch {
+      // Best-effort — if even reset fails the per-group catch will
+      // surface whatever git is unhappy about on the next iteration.
+    }
+  }
 
   for (const group of applicableGroups) {
     const groupFiles = getGroupFiles(group)
@@ -450,6 +488,7 @@ export async function applyCommitSplitPlan({
           title: group.title,
           reason: 'git commit returned success but HEAD did not advance — commit may have been silently skipped',
         })
+        await clearIndexAfterFailure()
         continue
       }
       commitHashes.push(newHead)
@@ -460,8 +499,25 @@ export async function applyCommitSplitPlan({
         title: group.title,
         reason: error instanceof Error ? error.message : String(error),
       })
+      await clearIndexAfterFailure()
     }
   }
+
+  // Restore the staging intent for files the plan never saw (filtered
+  // out by ignoredFiles / ignoredExtensions before planning). They were
+  // staged when the user ran the split; leave them staged so the next
+  // status/compose surface shows them instead of silently dropping
+  // them into the unstaged pile.
+  if (unplannedStaged.length > 0) {
+    try {
+      await git.raw(['add', '--', ...unplannedStaged])
+    } catch {
+      // Best-effort — a path may have vanished from disk mid-apply.
+    }
+  }
+  const unplannedNote = unplannedStaged.length > 0
+    ? ` ${unplannedStaged.length} staged file(s) the plan excluded by config (e.g. lockfiles) were re-staged — commit them separately.`
+    : ''
 
   // If every group failed, throw — there's nothing to recover and
   // the caller needs a clear error path. Partial-success (some
@@ -485,7 +541,7 @@ export async function applyCommitSplitPlan({
     )
     return {
       commitHashes,
-      message: `Created ${commitHashes.length} of ${applicableGroups.length} planned commit(s). Failed: ${partial}`,
+      message: `Created ${commitHashes.length} of ${applicableGroups.length} planned commit(s). Failed: ${partial}${unplannedNote}`,
       fallback,
     }
   }
@@ -497,7 +553,7 @@ export async function applyCommitSplitPlan({
 
   return {
     commitHashes,
-    message: `Created ${commitHashes.length} split commit(s).`,
+    message: `Created ${commitHashes.length} split commit(s).${unplannedNote}`,
     fallback,
   }
 }

--- a/src/commands/commit/splitApply.test.ts
+++ b/src/commands/commit/splitApply.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for `applyCommitSplitPlan`'s apply-loop safety properties:
+ *
+ *   1. A failed group's staged files are RESET before the next group
+ *      runs — otherwise the next commit silently absorbs them under
+ *      the wrong message.
+ *   2. Staged files the plan never saw (filtered out of the planner's
+ *      view by ignoredFiles / ignoredExtensions — lockfiles by
+ *      default) are re-staged after the loop instead of being
+ *      silently dropped from every commit AND from the index.
+ *
+ * `createCommit` is mocked — these tests drive the loop's git-index
+ * choreography, not the commit plumbing (covered by createCommit.test.ts).
+ */
+
+import type { FileChange } from '../../lib/types'
+import { applyCommitSplitPlan, type CommitSplitPlan } from './split'
+import { createCommit } from '../../lib/simple-git/createCommit'
+import { Logger } from '../../lib/utils/logger'
+
+jest.mock('../../lib/simple-git/createCommit', () => ({
+  createCommit: jest.fn(),
+  PreCommitHookError: class PreCommitHookError extends Error {},
+}))
+
+const mockedCreateCommit = createCommit as jest.MockedFunction<typeof createCommit>
+
+/**
+ * Fake `git` recording an ordered op log of the index choreography.
+ * HEAD advances only when the `createCommit` mock chose to advance it.
+ */
+function makeFakeGit(options: { stagedBeforeReset: string[] }) {
+  const ops: string[] = []
+  let head = 0
+
+  const git = {
+    raw: jest.fn(async (args: string[]) => {
+      if (args[0] === 'diff' && args.includes('--cached')) {
+        ops.push('list-staged')
+        return options.stagedBeforeReset.join('\0') + (options.stagedBeforeReset.length ? '\0' : '')
+      }
+      ops.push(args.join(' '))
+      return ''
+    }),
+    add: jest.fn(async (files: string[]) => {
+      ops.push(`stage ${(Array.isArray(files) ? files : [files]).join(',')}`)
+      return ''
+    }),
+    status: jest.fn(async () => ({
+      staged: ['whatever.ts'],
+      created: [],
+      renamed: [],
+      modified: [],
+      deleted: [],
+      not_added: [],
+    })),
+    revparse: jest.fn(async () => `head-${head}`),
+    advanceHead: () => {
+      head += 1
+    },
+  }
+  return { git, ops }
+}
+
+function fileChange(filePath: string): FileChange {
+  return { filePath, status: 'modified', summary: `${filePath} changed` }
+}
+
+const emptyHunkInventory = {
+  hunks: [],
+  byId: new Map(),
+  byFile: new Map(),
+} as never
+
+function makePlan(groups: Array<{ title: string; files: string[] }>): CommitSplitPlan {
+  return { groups: groups.map((group) => ({ ...group, body: '' })) } as CommitSplitPlan
+}
+
+describe('applyCommitSplitPlan apply-loop safety', () => {
+  const logger = new Logger({ silent: true })
+
+  afterEach(() => jest.clearAllMocks())
+
+  it("resets a failed group's staging before the next group commits", async () => {
+    const { git, ops } = makeFakeGit({ stagedBeforeReset: ['a.ts', 'b.ts'] })
+    // Group A's commit is rejected (hook); group B succeeds.
+    mockedCreateCommit
+      .mockImplementationOnce(async () => {
+        throw new Error('Pre-commit hook failed')
+      })
+      .mockImplementationOnce(async () => {
+        git.advanceHead()
+        return {} as never
+      })
+
+    const plan = makePlan([
+      { title: 'feat: a', files: ['a.ts'] },
+      { title: 'feat: b', files: ['b.ts'] },
+    ])
+
+    const result = await applyCommitSplitPlan({
+      plan,
+      changes: { staged: [fileChange('a.ts'), fileChange('b.ts')], unstaged: [], untracked: [] },
+      hunkInventory: emptyHunkInventory,
+      git: git as never,
+      logger,
+      noVerify: false,
+    })
+
+    // The recovery reset must land between group A's staging and group
+    // B's staging — group A's files were left in the index by the
+    // failed commit and used to be absorbed into B's commit.
+    expect(ops).toEqual([
+      'list-staged',
+      'reset',
+      'stage a.ts',
+      'reset',
+      'stage b.ts',
+    ])
+    expect(result.commitHashes).toEqual(['head-1'])
+    expect(result.message).toContain('1 of 2')
+  })
+
+  it('re-stages staged files the plan never claimed (config-filtered lockfiles)', async () => {
+    const { git, ops } = makeFakeGit({
+      stagedBeforeReset: ['a.ts', 'yarn.lock'],
+    })
+    mockedCreateCommit.mockImplementation(async () => {
+      git.advanceHead()
+      return {} as never
+    })
+
+    const plan = makePlan([{ title: 'feat: a', files: ['a.ts'] }])
+
+    const result = await applyCommitSplitPlan({
+      plan,
+      changes: { staged: [fileChange('a.ts')], unstaged: [], untracked: [] },
+      hunkInventory: emptyHunkInventory,
+      git: git as never,
+      logger,
+      noVerify: false,
+    })
+
+    expect(ops).toContain('add -- yarn.lock')
+    expect(result.message).toContain('re-staged')
+  })
+
+  it('does not add a re-stage note when every staged file was planned', async () => {
+    const { git, ops } = makeFakeGit({ stagedBeforeReset: ['a.ts'] })
+    mockedCreateCommit.mockImplementation(async () => {
+      git.advanceHead()
+      return {} as never
+    })
+
+    const plan = makePlan([{ title: 'feat: a', files: ['a.ts'] }])
+
+    const result = await applyCommitSplitPlan({
+      plan,
+      changes: { staged: [fileChange('a.ts')], unstaged: [], untracked: [] },
+      hunkInventory: emptyHunkInventory,
+      git: git as never,
+      logger,
+      noVerify: false,
+    })
+
+    expect(ops.filter((op) => op.startsWith('add --'))).toEqual([])
+    expect(result.message).not.toContain('re-staged')
+  })
+})


### PR DESCRIPTION
Two verified integrity defects in the `--split` apply loop (`applyCommitSplitPlan`), from the git-layer review pass. Both compound with the hook-retry fix in #1380.

## 1. A failed group's staged files leak into the next group's commit

The per-group `catch` recorded the failure and `continue`d — but if group A's `git add` succeeded and its `createCommit` was rejected (hook, commitlint), A's files stayed in the index. Group B then staged its own files on top, and B's commit **silently included A's files under B's message**. The "Created N of M" partial-success summary masked the contamination.

The failure paths (catch + the HEAD-didn't-advance guard) now reset the index before the next group runs.

## 2. Staged-but-config-ignored files silently dropped from all commits

The plan is generated against the **filtered** staged list (`ignoredFiles`/`ignoredExtensions` — `package-lock.json`, `yarn.lock`, `*.lock`, `*.map` by default), but the up-front `git reset` unstages *everything* and no group ever re-adds the filtered files. Regular `coco commit` commits the whole index (the filter only hides files from the LLM); `--split` instead shipped lockfile-less commits and left the lockfile unstaged — a silent behavior divergence that breaks installs.

Apply now captures the true staged set before the reset, and after the loop re-stages any staged file no plan group claimed, with a note in the result message ("N staged file(s) the plan excluded by config (e.g. lockfiles) were re-staged — commit them separately"). Attribution to a specific group would be guesswork, so preserving the user's staging intent + surfacing it beats both silent dropping and silent inclusion.

New `splitApply.test.ts` drives the loop with a fake git and asserts the exact index choreography (reset lands between the failed group's staging and the next group's) plus the re-stage behavior and message.

## Validation
- `tsc --noEmit` clean, `eslint` clean
- Full jest suite green: 310 suites / 3991 tests