### PR TITLE
fix(workspace): canonicalize roots before deriving cache/preference keys

### DIFF
--- a/src/workstation/chrome/workspaceCache.test.ts
+++ b/src/workstation/chrome/workspaceCache.test.ts
@@ -35,6 +35,22 @@ describe('workspaceCacheKey', () => {
   it('differs when the set of roots differs', () => {
     expect(workspaceCacheKey(['~/code'])).not.toBe(workspaceCacheKey(['~/code', '~/work']))
   })
+
+  it('is stable across spellings of the same directory', () => {
+    // `~/x` and its absolute expansion must share a key — hashing the
+    // raw string split one directory's cache across spellings.
+    expect(workspaceCacheKey(['~/code'])).toBe(workspaceCacheKey([`${os.homedir()}/code`]))
+  })
+
+  it('differs for the same relative root launched from different directories', () => {
+    // A relative `--root ./code` resolves against the process cwd —
+    // hashing the raw "./code" string collided every launch directory
+    // into one cache, so boot painted the OTHER workspace's repo list.
+    expect(workspaceCacheKey(['./code'])).toBe(
+      workspaceCacheKey([`${process.cwd()}/code`])
+    )
+    expect(workspaceCacheKey(['./code'])).not.toBe(workspaceCacheKey(['/somewhere-else/code']))
+  })
 })
 
 describe('workspace cache read/write', () => {

--- a/src/workstation/chrome/workspaceCache.ts
+++ b/src/workstation/chrome/workspaceCache.ts
@@ -1,6 +1,6 @@
 import * as crypto from 'node:crypto'
 
-import { WorkspaceOverview } from '../../git/workspaceData'
+import { canonicalize, WorkspaceOverview } from '../../git/workspaceData'
 
 import { createJsonStore } from './jsonStore'
 
@@ -22,7 +22,17 @@ import { createJsonStore } from './jsonStore'
 const CACHE_SCHEMA_VERSION = 1
 
 export function workspaceCacheKey(roots: ReadonlyArray<string>): string {
-  const normalized = [...roots].map((entry) => entry.trim()).filter(Boolean).sort()
+  // Canonicalize before hashing: roots arrive as typed (`--root ./code`,
+  // `~/code`, config strings). Hashing the raw spelling split one
+  // directory's cache across spellings AND collided different
+  // directories launched with the same relative `--root` — boot then
+  // painted the OTHER workspace's cached repo list until discovery
+  // corrected it.
+  const normalized = [...roots]
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => canonicalize(entry))
+    .sort()
   // sha1 here is a non-security cache-key derivation. DevSkim DS126858
   // does not apply.
   return crypto.createHash('sha1').update(normalized.join('\n')).digest('hex').slice(0, 16) // DevSkim: ignore DS126858

--- a/src/workstation/chrome/workspacePreferences.ts
+++ b/src/workstation/chrome/workspacePreferences.ts
@@ -1,5 +1,6 @@
 import * as crypto from 'node:crypto'
 
+import { canonicalize } from '../../git/workspaceData'
 import {
   WORKSPACE_SORT_MODES,
   type WorkspaceSortMode,
@@ -56,7 +57,15 @@ const store = createJsonStore<WorkspacePreferences>({
 })
 
 export function workspacePreferencesKey(roots: ReadonlyArray<string>): string {
-  const normalized = [...roots].map((entry) => entry.trim()).filter(Boolean).sort()
+  // Canonicalize before hashing (mirrors `workspaceCacheKey`): two
+  // spellings of one directory must share preferences, and two
+  // different directories launched with the same relative `--root`
+  // must NOT cross-pollinate sort/tab/filter.
+  const normalized = [...roots]
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => canonicalize(entry))
+    .sort()
   return crypto.createHash('sha1').update(normalized.join('\n')).digest('hex').slice(0, 16) // DevSkim: ignore DS126858
 }
 


### PR DESCRIPTION
## Problem

`workspaceCacheKey` and `workspacePreferencesKey` hashed the root list **as typed** (`--root ./code`, `~/code`, config strings — `resolveWorkspaceRoots` deliberately passes them through so the footer shows what the user wrote).

Two consequences:

- **Collisions:** launching with the same relative `--root ./code` from two different directories produced the same key, so boot painted the *other* workspace's cached repo list (wrong-repo stale data until background discovery corrects it), and sort/tab/filter preferences cross-pollinated between unrelated workspaces.
- **Splits:** `~/code` and `/Users/me/code` (or a symlinked spelling — `/tmp` vs `/private/tmp`) got separate caches and preferences for the same directory.

## Fix

Canonicalize each root (existing `canonicalize` = expand-home → resolve → realpath best-effort, the same helper discovery already uses for scanning) inside both key derivations before hashing. `resolveWorkspaceRoots` stays a pure pass-through, so user-facing root display is unchanged.

New tests: same-directory spellings share a key; the same relative root from different cwds does not collide.

## Validation
- `tsc --noEmit` clean, `eslint` clean
- Full jest suite green (309 suites / 3990 tests)