### PR TITLE
fix(git): checkoutOrDeleteFromRef verifies the ref before the destructive fallback

### DIFF
--- a/src/git/historyActions.test.ts
+++ b/src/git/historyActions.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import {
   amendHeadCommit,
+  checkoutOrDeleteFromRef,
   cherryPickCommit,
   compareCommits,
   copyCommitHash,
@@ -37,6 +38,57 @@ describe('log history actions', () => {
     await expect(historyActionTestInternals.isHeadCommit(git as never, 'abcdef1234567890')).resolves.toBe(true)
     await expect(historyActionTestInternals.isHeadCommit(git as never, 'abcdef1')).resolves.toBe(true)
     await expect(historyActionTestInternals.isHeadCommit(git as never, '1234567')).resolves.toBe(false)
+  })
+
+  describe('checkoutOrDeleteFromRef (#1383)', () => {
+    // The ref-verify guard is the safety line: a stale selector
+    // (`stash@{2}` after the stash list changed) used to be
+    // indistinguishable from "path deleted at ref" and fell through
+    // to `git rm --force`, deleting the user's file.
+    it('refuses to touch the worktree when the ref does not resolve', async () => {
+      const raw = jest.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'rev-parse') {
+          throw new Error("fatal: Needed a single revision")
+        }
+        return ''
+      })
+      const git = { raw }
+
+      const result = await checkoutOrDeleteFromRef(git as never, 'stash@{2}', 'src/a.ts', 'stash@{2}')
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toContain('no longer resolves')
+      const destructive = raw.mock.calls.filter(([args]) => args[0] === 'rm' || args[0] === 'checkout')
+      expect(destructive).toEqual([])
+    })
+
+    it('checks the file out when it exists at the ref', async () => {
+      const raw = jest.fn().mockResolvedValue('')
+      const git = { raw }
+
+      const result = await checkoutOrDeleteFromRef(git as never, 'abc1234', 'src/a.ts', 'abc1234')
+
+      expect(result).toEqual({ ok: true, message: 'Checked out src/a.ts from abc1234' })
+      expect(raw).toHaveBeenCalledWith(['checkout', 'abc1234', '--', 'src/a.ts'])
+    })
+
+    it('mirrors a deletion only when the ref resolves but the path is absent', async () => {
+      const raw = jest.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'cat-file') {
+          throw new Error('fatal: Not a valid object name')
+        }
+        return ''
+      })
+      const git = { raw }
+
+      const result = await checkoutOrDeleteFromRef(git as never, 'abc1234', 'src/gone.ts', 'abc1234')
+
+      expect(result).toEqual({
+        ok: true,
+        message: 'Removed src/gone.ts (mirrors deletion from abc1234)',
+      })
+      expect(raw).toHaveBeenCalledWith(['rm', '--force', '--quiet', '--', 'src/gone.ts'])
+    })
   })
 
   it('amends HEAD with staged changes', async () => {

--- a/src/git/historyActions.ts
+++ b/src/git/historyActions.ts
@@ -376,6 +376,20 @@ export async function checkoutOrDeleteFromRef(
   path: string,
   label: string
 ): Promise<BranchActionResult> {
+  // Verify the REF resolves before interpreting a cat-file failure as
+  // "path deleted at ref" (#1383). The two failures were conflated: a
+  // stale selector (e.g. `stash@{2}` held in workstation state after
+  // the stash list changed) fell through to the destructive branch and
+  // `git rm --force`d the user's file instead of surfacing the bad
+  // revision.
+  try {
+    await git.raw(['rev-parse', '--verify', '--quiet', `${ref}^{commit}`])
+  } catch {
+    return {
+      ok: false,
+      message: `${label} no longer resolves — the ref may have changed. Refresh and retry.`,
+    }
+  }
   const exists = await pathExistsAtRef(git, ref, path)
   if (exists) {
     return runAction(


### PR DESCRIPTION
Fixes #1383.

## Problem

`checkoutOrDeleteFromRef` decides between "check the file out from the ref" and "mirror a deletion (`git rm --force`)" using `pathExistsAtRef`, whose bare `catch { return false }` conflates two very different failures:

- the path genuinely doesn't exist at the ref (→ deletion mirror is correct), and
- **the ref itself doesn't resolve** — most concretely a stale stash selector (`stash@{2}` held in workstation state after another stash was dropped/created).

In the second case the fallback ran `git rm --force --quiet -- <path>`, deleting the user's file from worktree + index instead of reporting the bad revision.

## Fix

Verify the ref up front (`git rev-parse --verify --quiet <ref>^{commit}`). If it doesn't resolve, return a clean `ok: false` ("no longer resolves — the ref may have changed. Refresh and retry.") without touching the worktree. Only a resolving ref with an absent path reaches the deletion mirror.

Three new tests cover: unresolvable ref → no destructive git call; happy-path checkout; deletion mirror only when the ref resolves.

## Validation
- `tsc --noEmit` clean, `eslint` clean
- Full jest suite green: 309 suites / 3991 tests