### PR TITLE
fix(git): conflict parsers match exact markers, not prefixes

### DIFF
--- a/src/git/conflictRegionActions.test.ts
+++ b/src/git/conflictRegionActions.test.ts
@@ -73,6 +73,39 @@ describe('parseConflictRegions', () => {
   it('returns no regions for a clean file', () => {
     expect(parseConflictRegions('a\nb\nc\n').regions).toHaveLength(0)
   })
+
+  it('does not treat content lines starting with marker characters as markers (#1395)', () => {
+    // A setext underline (8+ '=') and a divider comment inside "ours"
+    // used to flip the parser into theirs early — the real separator
+    // then landed inside theirs, and accept-ours/theirs (and the AI
+    // resolver) operated on wrong side contents.
+    const { regions } = parseConflictRegions([
+      '<<<<<<< HEAD',
+      'Title',
+      '========',
+      '//======= divider comment',
+      'ours tail',
+      '=======',
+      'theirs line',
+      '>>>>>>> feature/x',
+      '',
+    ].join('\n'))
+    expect(regions).toHaveLength(1)
+    expect(regions[0].ours).toEqual(['Title', '========', '//======= divider comment', 'ours tail'])
+    expect(regions[0].theirs).toEqual(['theirs line'])
+  })
+
+  it('does not open a region on 8+ angle brackets, and tolerates CRLF markers', () => {
+    const clean = parseConflictRegions('<<<<<<<< not a marker\nplain\n')
+    expect(clean.regions).toHaveLength(0)
+
+    const crlf = parseConflictRegions(
+      '<<<<<<< HEAD\r\nours\r\n=======\r\ntheirs\r\n>>>>>>> other\r\n'
+    )
+    expect(crlf.regions).toHaveLength(1)
+    expect(crlf.regions[0].oursLabel).toBe('HEAD')
+    expect(crlf.regions[0].theirsLabel).toBe('other')
+  })
 })
 
 describe('apply/read against a real worktree file', () => {

--- a/src/git/conflictRegionActions.ts
+++ b/src/git/conflictRegionActions.ts
@@ -42,6 +42,20 @@ export type ConflictRegion = {
   theirs: string[]
 }
 
+// Git's markers are EXACTLY seven marker characters: `<<<<<<< <label>`,
+// `||||||| <base-label>`, a bare `=======`, `>>>>>>> <label>`. Matching
+// by prefix (#1395) let ordinary content flip the parser — an RST/
+// markdown setext underline (`========`) or a `//======== divider`
+// comment inside the "ours" side started the theirs section early, and
+// the real separator then landed INSIDE theirs. The AI resolver and
+// accept-ours/theirs would operate on the wrong side contents. The
+// `(?:\s|$)` tail (rather than requiring a label) tolerates CRLF and
+// label-less markers; an 8th marker character fails the match.
+export const CONFLICT_OURS_MARKER = /^<{7}(?:\s|$)/
+export const CONFLICT_BASE_MARKER = /^\|{7}(?:\s|$)/
+export const CONFLICT_SEPARATOR_MARKER = /^={7}\s*$/
+export const CONFLICT_THEIRS_MARKER = /^>{7}(?:\s|$)/
+
 export function parseConflictRegions(content: string): {
   lines: string[]
   regions: ConflictRegion[]
@@ -51,7 +65,7 @@ export function parseConflictRegions(content: string): {
 
   let i = 0
   while (i < lines.length) {
-    if (!lines[i].startsWith('<<<<<<<')) {
+    if (!CONFLICT_OURS_MARKER.test(lines[i])) {
       i += 1
       continue
     }
@@ -66,16 +80,16 @@ export function parseConflictRegions(content: string): {
     let j = i + 1
     for (; j < lines.length; j += 1) {
       const line = lines[j]
-      if (section !== 'theirs' && line.startsWith('|||||||')) {
+      if (section !== 'theirs' && CONFLICT_BASE_MARKER.test(line)) {
         section = 'base'
         base = []
         continue
       }
-      if (section !== 'theirs' && line.startsWith('=======')) {
+      if (section !== 'theirs' && CONFLICT_SEPARATOR_MARKER.test(line)) {
         section = 'theirs'
         continue
       }
-      if (section === 'theirs' && line.startsWith('>>>>>>>')) {
+      if (section === 'theirs' && CONFLICT_THEIRS_MARKER.test(line)) {
         theirsLabel = line.slice(7).trim()
         endLine = j + 1
         break

--- a/src/git/operationData.ts
+++ b/src/git/operationData.ts
@@ -1,6 +1,11 @@
 import { existsSync, readdirSync, readFileSync } from 'fs'
 import { isAbsolute, join } from 'path'
 import { SimpleGit } from 'simple-git'
+import {
+  CONFLICT_OURS_MARKER,
+  CONFLICT_SEPARATOR_MARKER,
+  CONFLICT_THEIRS_MARKER,
+} from './conflictRegionActions'
 
 export type GitOperationType = 'none' | 'merge' | 'rebase' | 'cherry-pick' | 'revert'
 
@@ -97,10 +102,12 @@ export function parseConflictMarkers(path: string, content: string): ConflictMar
       line: index + 1,
       marker: line.trim(),
     }))
+    // Exact markers only (#1395) — prefix matching also listed content
+    // lines like setext underlines (`========`) as conflict markers.
     .filter((entry) => (
-      entry.marker.startsWith('<<<<<<<') ||
-      entry.marker.startsWith('=======') ||
-      entry.marker.startsWith('>>>>>>>')
+      CONFLICT_OURS_MARKER.test(entry.marker) ||
+      CONFLICT_SEPARATOR_MARKER.test(entry.marker) ||
+      CONFLICT_THEIRS_MARKER.test(entry.marker)
     ))
 }
 


### PR DESCRIPTION
Fixes #1395.

## Problem

`parseConflictRegions` detected section transitions with `line.startsWith('=======')` / `startsWith('|||||||')` (and region open/close with the same prefix pattern). Git's real markers are **exactly seven** marker characters (`=======` bare; `<<<<<<<`/`|||||||`/`>>>>>>>` followed by a label). Ordinary file content — an RST/markdown setext underline (`========`), a `//======= divider` comment — inside the "ours" side flipped the parser into `theirs` early. The real separator then landed *inside* `theirs` content, and the AI resolver / accept-ours / accept-theirs paths operated on wrong side contents (region bounds stayed right, so the wrong text was written back as the "resolution" source material).

## Fix

Anchored exact-marker regexes: `/^<{7}(?:\s|$)/`, `/^\|{7}(?:\s|$)/`, `/^={7}\s*$/`, `/^>{7}(?:\s|$)/` — an 8th marker character fails the match, CRLF and label-less markers still pass. `parseConflictMarkers` in `operationData.ts` (the conflict-location lister) had the same prefix matching and now shares the exported regexes.

New tests: marker-like content lines stay in `ours`; 8+ angle brackets don't open a region; CRLF conflict files parse with clean labels.

## Validation
- `tsc --noEmit` clean, `eslint` clean
- Full jest suite green: 309 suites / 3990 tests