### PR TITLE
fix(workstation): ownership-guard post-await dispatches in AI draft/changelog/conflict hooks

### DIFF
--- a/src/workstation/runtime/hooks/useAiCommitDraftActions.ts
+++ b/src/workstation/runtime/hooks/useAiCommitDraftActions.ts
@@ -116,6 +116,8 @@ export function useAiCommitDraftActions(
           // workstation) mid-stream, React warns about updates on
           // an unmounted component. Drop the chunk silently.
           if (!mountedRef.current) return
+          // Superseded (#1386): a newer invocation owns the preview.
+          if (aiDraftAbortRef.current !== controller) return
           // Dispatch the full accumulated text — the preview chrome
           // helper does the last-N-lines slicing at render time, so
           // re-doing the slice here would be wasted work. Per-chunk
@@ -132,6 +134,14 @@ export function useAiCommitDraftActions(
       // post-await dispatch if the user quit while the LLM call was
       // in flight. Same pattern as `refreshHistoryRows` upstream.
       if (!mountedRef.current) return
+
+      // Ownership check (#1386): a rapid re-invocation (Esc then `I`
+      // again) aborted this call AFTER dispatching its own loading
+      // state — our cancelled/result dispatches would clobber it
+      // (spinner + streaming preview vanish while the new LLM call is
+      // running). The finally below only clears the ref when it still
+      // points at us, so `!==` here always means "superseded".
+      if (aiDraftAbortRef.current !== controller) return
 
       // Cancel path (#881 phase 3). User pressed Esc during the
       // stream; reducer drops loading + preview, status line shows
@@ -165,8 +175,9 @@ export function useAiCommitDraftActions(
       // that lets an error escape would otherwise strand the
       // spinner permanently with no user-facing recovery short of
       // quitting. Surface a generic failure and clear the loading
-      // state so the user can re-try.
-      if (mountedRef.current) {
+      // state so the user can re-try. Ownership-gated (#1386) like the
+      // happy path — a superseding invocation owns the loading state.
+      if (mountedRef.current && aiDraftAbortRef.current === controller) {
         dispatch({ type: 'commitCompose', action: { type: 'setLoading', value: false } })
         dispatch({
           type: 'setStatus',

--- a/src/workstation/runtime/hooks/useChangelogActions.ts
+++ b/src/workstation/runtime/hooks/useChangelogActions.ts
@@ -182,6 +182,14 @@ export function useChangelogActions(
     try {
       const result = await runChangelogTextWorkflow(argv, { signal: controller.signal })
 
+      // Ownership check (#1386): a rapid regenerate (`r`) aborted this
+      // call after installing its own controller + loading view — our
+      // cancelled/error dispatches would paint "Cancelled — press r to
+      // regenerate" over the NEW generation's loading state. The
+      // finally below only clears the ref when it still points at us,
+      // so `!==` here always means "superseded".
+      if (changelogAbortRef.current !== controller) return
+
       // Cancel path (#1338): the user pressed Esc mid-generation. Move
       // the view out of its loading state (r regenerates) and show a
       // neutral — not error — status line.

--- a/src/workstation/runtime/hooks/useConflictResolutionActions.ts
+++ b/src/workstation/runtime/hooks/useConflictResolutionActions.ts
@@ -102,6 +102,13 @@ export function useConflictResolutionActions(
       })
       if (!mountedRef.current) return
 
+      // Ownership check (#1386): a re-invocation aborted this call
+      // after installing its own controller + loading state — our
+      // cancelled/error dispatches would clear the new run's overlay.
+      // The finally below only clears the ref when it still points at
+      // us, so `!==` here always means "superseded".
+      if (abortRef.current !== controller) return
+
       if (!result.ok) {
         if (result.cancelled) {
           dispatch({ type: 'clearConflictResolution' })


### PR DESCRIPTION
Fixes #1386. Applies the ownership-guard pattern from #1378 (split-plan cancel) to the three remaining AI hooks.

## Problem

`useAiCommitDraftActions`, `useChangelogActions`, and `useConflictResolutionActions` all correctly check `abortRef.current === controller` in their `finally` blocks — but their **cancelled/result dispatch paths** checked only `mountedRef`. A new invocation aborts the predecessor *after* dispatching its own loading state, so the predecessor's cancelled path resolves later and dispatches over it:

- **AI draft:** Esc during `I`, immediately `I` again → call2 shows loading; call1's abort settles → `setLoading(false)` + "AI draft cancelled." → spinner and streaming preview vanish while call2's LLM stream is actually running; the draft later appears out of nowhere.
- **Changelog:** `r` regenerate mid-generation → the aborted call paints "Cancelled — press r to regenerate" over the new generation's loading view.
- **Conflict resolution:** same shape; the aborted call clears the new run's overlay.

## Fix

Every post-await dispatch — including the AI draft's streaming-chunk callback (stale chunks were overwriting the new call's preview) and its defensive catch — bails unless the abort ref still points at its own controller. Since the `finally` blocks only clear the ref on ownership, `!==` unambiguously means "superseded".

## Validation
- `tsc --noEmit` clean, `eslint` clean (1 pre-existing warning, verified present before the change)
- Full jest suite green: 309 suites / 3988 tests