### PR TITLE
fix(workstation): view-local gg/G/PageUp/PageDown on blame, file-history, and changelog

### DIFF
--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -1536,6 +1536,62 @@ describe('log Ink input interactions', () => {
     )).toBeDefined()
   })
 
+  describe('view-local jump keys on blame / file-history / changelog (#1387)', () => {
+    it('G and gg move the blame cursor, not the hidden history cursor', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'blame' })
+
+      const bottom = getLogInkInputEvents(state, 'G', {}, { blameLineCount: 120 })
+      expect(bottom.find((event) =>
+        event.type === 'action' && event.action.type === 'moveBlame' && event.action.delta === 120
+      )).toBeDefined()
+      expect(bottom.find((event) =>
+        event.type === 'action' && event.action.type === 'moveToBottom'
+      )).toBeUndefined()
+
+      const armed = applyLogInkAction(state, { type: 'setPendingKey', value: 'g' })
+      const top = getLogInkInputEvents(armed, 'g', {}, { blameLineCount: 120 })
+      expect(top.find((event) =>
+        event.type === 'action' && event.action.type === 'moveBlame' && event.action.delta === -120
+      )).toBeDefined()
+      expect(top.find((event) =>
+        event.type === 'action' && event.action.type === 'moveToTop'
+      )).toBeUndefined()
+    })
+
+    it('PageDown moves the file-history cursor, not the history list', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'file-history' })
+
+      const events = getLogInkInputEvents(state, '', { pageDown: true }, { fileHistoryCommitCount: 40 })
+      expect(events.find((event) =>
+        event.type === 'action' && event.action.type === 'moveFileHistory' && event.action.delta === 10
+      )).toBeDefined()
+      expect(events.find((event) =>
+        event.type === 'action' && event.action.type === 'page'
+      )).toBeUndefined()
+    })
+
+    it('swallows the jump keys while the view is still loading (no count)', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'blame' })
+
+      expect(getLogInkInputEvents(state, 'G', {}, {})).toEqual([])
+      expect(getLogInkInputEvents(state, '', { pageUp: true }, {})).toEqual([])
+    })
+
+    it('G scrolls the ready changelog to the end instead of moving history', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'pushView', value: 'changelog' })
+
+      const events = getLogInkInputEvents(state, 'G', {}, { changelogLineCount: 80 })
+      expect(events.find((event) =>
+        event.type === 'action' && event.action.type === 'pageChangelog' && event.action.delta === 80
+      )).toBeDefined()
+      expect(getLogInkInputEvents(state, 'G', {}, {})).toEqual([])
+    })
+  })
+
   it('does not hijack g/b/s/x outside the bisect view (#784)', () => {
     // Defensive check: pressing `g` on the history view must still set
     // pendingKey for the chord prefix, not fire bisect-good.

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -2223,6 +2223,39 @@ export function getLogInkInputEvents(
 
   if (inputValue === 'g') {
     if (state.pendingKey === 'g') {
+      // View-local top jumps (#1387): blame / file-history / changelog
+      // advertise gg in the footer, but the generic moveToTop below
+      // only touches the HISTORY cursor — the visible list stayed put
+      // while the hidden selection silently relocated.
+      if (state.activeView === 'blame') {
+        return context.blameLineCount
+          ? [
+            action({ type: 'moveBlame', delta: -context.blameLineCount, count: context.blameLineCount }),
+            action({ type: 'setStatus', value: 'jumped to first line' }),
+          ]
+          : []
+      }
+      if (state.activeView === 'file-history') {
+        return context.fileHistoryCommitCount
+          ? [
+            action({
+              type: 'moveFileHistory',
+              delta: -context.fileHistoryCommitCount,
+              count: context.fileHistoryCommitCount,
+            }),
+            action({ type: 'setStatus', value: 'jumped to first commit' }),
+          ]
+          : []
+      }
+      if (state.activeView === 'changelog') {
+        return context.changelogLineCount
+          ? [action({
+            type: 'pageChangelog',
+            delta: -context.changelogLineCount,
+            lineCount: context.changelogLineCount,
+          })]
+          : []
+      }
       return [
         action({ type: 'moveToTop' }),
         action({ type: 'setStatus', value: 'jumped to first commit' }),
@@ -2319,6 +2352,36 @@ export function getLogInkInputEvents(
   }
 
   if (inputValue === 'G') {
+    // View-local bottom jumps (#1387) — see the gg mirror above.
+    if (state.activeView === 'blame') {
+      return context.blameLineCount
+        ? [
+          action({ type: 'moveBlame', delta: context.blameLineCount, count: context.blameLineCount }),
+          action({ type: 'setStatus', value: 'jumped to last line' }),
+        ]
+        : []
+    }
+    if (state.activeView === 'file-history') {
+      return context.fileHistoryCommitCount
+        ? [
+          action({
+            type: 'moveFileHistory',
+            delta: context.fileHistoryCommitCount,
+            count: context.fileHistoryCommitCount,
+          }),
+          action({ type: 'setStatus', value: 'jumped to last commit' }),
+        ]
+        : []
+    }
+    if (state.activeView === 'changelog') {
+      return context.changelogLineCount
+        ? [action({
+          type: 'pageChangelog',
+          delta: context.changelogLineCount,
+          lineCount: context.changelogLineCount,
+        })]
+        : []
+    }
     return [
       action({ type: 'moveToBottom' }),
       action({ type: 'setStatus', value: 'jumped to last commit' }),
@@ -2859,6 +2922,19 @@ export function getLogInkInputEvents(
       })]
     }
 
+    // View-local paging (#1387) — the generic `page` fallback below
+    // moves the HIDDEN history cursor beneath these surfaces.
+    if (state.activeView === 'blame') {
+      return context.blameLineCount
+        ? [action({ type: 'moveBlame', delta: -10, count: context.blameLineCount })]
+        : []
+    }
+    if (state.activeView === 'file-history') {
+      return context.fileHistoryCommitCount
+        ? [action({ type: 'moveFileHistory', delta: -10, count: context.fileHistoryCommitCount })]
+        : []
+    }
+
     return [action({ type: 'page', delta: -10 })]
   }
 
@@ -2886,6 +2962,18 @@ export function getLogInkInputEvents(
         delta: 8,
         previewLineCount: context.previewLineCount,
       })]
+    }
+
+    // View-local paging (#1387) — mirror of the pageUp branch above.
+    if (state.activeView === 'blame') {
+      return context.blameLineCount
+        ? [action({ type: 'moveBlame', delta: 10, count: context.blameLineCount })]
+        : []
+    }
+    if (state.activeView === 'file-history') {
+      return context.fileHistoryCommitCount
+        ? [action({ type: 'moveFileHistory', delta: 10, count: context.fileHistoryCommitCount })]
+        : []
     }
 
     return [action({ type: 'page', delta: 10 })]


### PR DESCRIPTION
Fixes #1387.

## Problem

Blame and file-history advertise `gg/G top/bottom` in their footers, but the input layer had no view-local branch for either key — they dispatched `moveToTop`/`moveToBottom`, which only touch `selectedIndex` (the **history** cursor). Repro: open blame (`b` on a status file) → `G` → status says "jumped to last commit", the blame list doesn't move, and the history selection has silently relocated (visible after Esc). PageUp/PageDown leaked to the hidden history list the same way. The changelog view had the sibling gap: the #1348 loading-swallow covers j/k/arrows, but `G`/`gg` still moved history beneath the ready view.

## Fix

View-local handling reusing the existing clamped actions:
- blame: `gg`/`G` → `moveBlame ∓lineCount`; PageUp/Down → `moveBlame ∓10`
- file-history: same via `moveFileHistory`
- changelog: `gg`/`G` → `pageChangelog ∓lineCount` (scroll to start/end)

While a view is still loading (no count yet) the keys are swallowed rather than falling through — same contract as the #1348 fix.

New tests cover blame `G`/`gg`, file-history PageDown, the loading swallow, and changelog `G`.

## Validation
- `tsc --noEmit` clean, `eslint` clean
- Full jest suite green (one unrelated flaky: `refreshWatcher` rename-survival under parallel load — passes 4/4 in isolation and on suite re-run; flagged separately)