### PR TITLE
fix(git): createStash takes explicit pathspecs instead of tokenizing on whitespace

### DIFF
--- a/src/git/stashActions.test.ts
+++ b/src/git/stashActions.test.ts
@@ -61,8 +61,14 @@ describe('log stash actions', () => {
     // --staged is index-only: no -u, no --keep-index.
     expect(git.raw).toHaveBeenLastCalledWith(['stash', 'push', '--staged', '-m', 'idx'])
 
-    await createStash(git as never, '', { pathspec: 'src/a.ts  src/b.ts' })
+    await createStash(git as never, '', { paths: ['src/a.ts', 'src/b.ts'] })
     expect(git.raw).toHaveBeenLastCalledWith(['stash', 'push', '-u', '--', 'src/a.ts', 'src/b.ts'])
+
+    // A single path containing spaces stays ONE pathspec (#1397) —
+    // whitespace tokenization used to split it, and a fragment could
+    // match a real directory and stash far more than asked.
+    await createStash(git as never, '', { paths: ['my file.ts'] })
+    expect(git.raw).toHaveBeenLastCalledWith(['stash', 'push', '-u', '--', 'my file.ts'])
   })
 
   it('applies with --index to restore the staged split', async () => {

--- a/src/git/stashActions.ts
+++ b/src/git/stashActions.ts
@@ -24,8 +24,15 @@ export type CreateStashOptions = {
   keepIndex?: boolean
   /** `--staged`: stash only the staged (index) changes. */
   stagedOnly?: boolean
-  /** `-- <paths>`: stash only the matching paths (partial stash). */
-  pathspec?: string
+  /**
+   * `-- <paths>`: stash only the matching pathspecs (partial stash).
+   * Explicit list — NOT a whitespace-tokenized string (#1397): a
+   * single path containing a space (`my file.ts`) must reach git as
+   * one pathspec, or a fragment can match a real directory and stash
+   * far more than asked. Callers that accept typed input own the
+   * tokenization decision at their boundary.
+   */
+  paths?: string[]
 }
 
 export function createStash(
@@ -48,13 +55,13 @@ export function createStash(
 
   if (trimmedMessage) args.push('-m', trimmedMessage)
 
-  const paths = options.pathspec?.trim()
-  if (paths) args.push('--', ...paths.split(/\s+/))
+  const paths = (options.paths ?? []).map((path) => path.trim()).filter(Boolean)
+  if (paths.length > 0) args.push('--', ...paths)
 
   const what = options.stagedOnly
     ? 'staged changes'
-    : paths
-      ? `“${paths}”`
+    : paths.length > 0
+      ? `“${paths.join(' ')}”`
       : options.keepIndex
         ? 'changes (index kept)'
         : ''


### PR DESCRIPTION
Fixes #1397.

## Problem

`createStash`'s `pathspec?: string` option split on `/\s+/` — `my file.ts` became two pathspecs. Best case git errors on the unmatched spec; worse case a fragment matches a real directory (`src notes.txt` → all of `src/`) and the stash removes far more from the worktree than asked (recoverable, but very surprising).

## Fix

The option is now `paths?: string[]` — explicit pathspecs, no tokenization inside the git layer. No live UI caller passed `pathspec` yet (only the unit test), so this is an API correction with no behavior migration: whichever future prompt wires up partial stash owns the tokenization decision at its input boundary, where it can offer quoting or per-file selection. A path containing spaces now reaches git as a single spec (new test).

## Validation
- `tsc --noEmit` clean, `eslint` clean
- Full jest suite green: 309 suites / 3988 tests