### PR TITLE
fix(workstation): rows that exceeded the panel width and wrapped

### DIFF
--- a/src/workstation/surfaces/compose/index.ts
+++ b/src/workstation/surfaces/compose/index.ts
@@ -240,15 +240,17 @@ export function renderComposeSurface(ctx: SurfaceRenderContext, spinnerFrame: nu
       ...renderStreamingPreviewLines(h, components, compose.streamingPreview, bodyTextWidth, theme),
     ]
     : []),
-  ...(compose.message ? [h(Text, undefined, ''), h(Text, { key: 'compose-msg' }, truncateCells(compose.message, 140))] : []),
+  // Panel-width budget, not a hardcoded 140 (#1390) — long result /
+  // detail / hint lines wrapped and pushed the panel past bodyRows.
+  ...(compose.message ? [h(Text, undefined, ''), h(Text, { key: 'compose-msg' }, truncateCells(compose.message, Math.max(20, width - 4)))] : []),
   ...(compose.details || []).map((line, index) => h(Text, {
     key: `compose-detail-${index}`,
     dimColor: true,
-  }, truncateCells(`  ${line}`, 140))),
+  }, truncateCells(`  ${line}`, Math.max(20, width - 4)))),
   ...(!hasStagedFiles && noStagedHint
     ? [
       h(Text, { key: 'compose-no-staged-spacer' }, ''),
-      h(Text, { key: 'compose-no-staged', dimColor: true }, truncateCells(noStagedHint, 140)),
+      h(Text, { key: 'compose-no-staged', dimColor: true }, truncateCells(noStagedHint, Math.max(20, width - 4))),
     ]
     : []),
   h(Box, { flexGrow: 1 }),

--- a/src/workstation/surfaces/detail/index.ts
+++ b/src/workstation/surfaces/detail/index.ts
@@ -163,15 +163,42 @@ function renderInspectorRefs(
   h: typeof ReactTypes.createElement,
   Text: LogInkComponents['Text'],
   refs: string[],
-  repository: ProviderRepository | undefined
+  repository: ProviderRepository | undefined,
+  budget: number
 ): ReactTypes.ReactElement[] {
+  // Cell-budgeted (#1390): the refs line was the ONE inspector header
+  // line without truncation, and a branch-tip commit
+  // (`HEAD -> main, origin/main, origin/HEAD`) wrapped the narrow
+  // inspector 2-3 lines — pushing the file list past the panel — every
+  // time the cursor rested on it. Refs are OSC-8 hyperlink spans, so
+  // we budget whole refs (with a "+N more" overflow marker) rather
+  // than slicing through escape sequences.
+  const MORE_RESERVE = 8
   const out: ReactTypes.ReactElement[] = []
-  refs.forEach((ref, index) => {
+  let used = 0
+  for (let index = 0; index < refs.length; index += 1) {
+    const ref = refs[index]
+    const isLast = index === refs.length - 1
+    const reserve = isLast ? 0 : MORE_RESERVE
+    if (index > 0 && used + 2 + cellWidth(ref) + reserve > budget) {
+      out.push(h(Text, { key: 'ref-more' }, ` +${refs.length - index} more`))
+      break
+    }
     if (index > 0) {
       out.push(h(Text, { key: `ref-sep-${index}` }, ', '))
+      used += 2
+    }
+    const room = budget - used - reserve
+    if (cellWidth(ref) > room) {
+      out.push(h(Text, { key: `ref-${index}` }, truncateCells(ref, Math.max(4, room))))
+      if (!isLast) {
+        out.push(h(Text, { key: 'ref-more' }, ` +${refs.length - index - 1} more`))
+      }
+      break
     }
     out.push(h(Text, { key: `ref-${index}` }, formatHyperlink(ref, buildRefUrl(repository, ref))))
-  })
+    used += cellWidth(ref)
+  }
   return out
 }
 
@@ -388,7 +415,8 @@ export function renderHistoryInspector(
     buildCommitUrl(repository, detail.hash)
   )
   const refNodes = detail.refs.length
-    ? renderInspectorRefs(h, Text, detail.refs, repository)
+    // 'Refs:   ' prefix = 8 cells; the rest of the interior is the budget.
+    ? renderInspectorRefs(h, Text, detail.refs, repository, Math.max(8, width - 4 - 8))
     : null
 
   // Inspector reorder (PR — drop duplicative Workflows trailer):

--- a/src/workstation/surfaces/diff/index.ts
+++ b/src/workstation/surfaces/diff/index.ts
@@ -220,7 +220,9 @@ export function renderDiffSurface(
     },
     h(Box, { justifyContent: 'space-between' },
       h(Text, { bold: true }, panelTitle(splitActive ? 'Stash diff (split)' : 'Stash diff', focused)),
-      h(Text, { dimColor: true }, stashIdentity.subtitle)
+      // Cell-budgeted (#1390): default WIP stash subjects run 60+ chars
+      // and wrapped the space-between header row, stealing a body row.
+      h(Text, { dimColor: true }, truncateCells(stashIdentity.subtitle, Math.max(10, width - 4 - 20)))
     ),
     ...headerLines.map((line, index) => h(Text, {
       key: `stash-diff-header-${index}`,
@@ -351,7 +353,9 @@ export function renderDiffSurface(
     },
     h(Box, { justifyContent: 'space-between' },
       h(Text, { bold: true }, panelTitle(splitActive ? 'Diff (split)' : 'Diff', focused)),
-      h(Text, { dimColor: true }, selectedDetailFile?.path || 'no file')
+      // Path middle-elides into the budget (#1390) so a deep monorepo
+      // path can't wrap the header row.
+      h(Text, { dimColor: true }, truncatePathCells(selectedDetailFile?.path || 'no file', Math.max(10, width - 4 - 14)))
     ),
     ...headerLines.map((line, index) => h(Text, {
       key: `diff-surface-header-${index}`,
@@ -426,7 +430,8 @@ export function renderDiffSurface(
     // Use the path of the file actually being diffed (the grouped/visible
     // selection feeds the loaded diff) — `worktreeFile` indexes the raw,
     // ungrouped file list and can name a different file than the diff body.
-    h(Text, { dimColor: true }, worktreeDiff?.filePath || worktreeFile?.path || 'no file')
+    // Middle-elided into the budget (#1390) so it can't wrap the header.
+    h(Text, { dimColor: true }, truncatePathCells(worktreeDiff?.filePath || worktreeFile?.path || 'no file', Math.max(10, width - 4 - 6)))
   ),
   ...headerLines.map((line, index) => h(Text, {
     key: `diff-surface-header-${index}`,

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -328,8 +328,12 @@ function renderCommitHistoryRow(
     ? renderBranchTipChip(h, Text, commit, theme, `${commit.hash}-${index}-chip`, selected, remoteNames)
     : { node: null, width: 0, chip: undefined }
   const refs = formatInkRefLabels(filterChippedRefs(commit.refs, chip.chip))
+  // The "just landed" marker prepends 2 cells (`▎ ` / `* `) — the
+  // stacked variant budgets it via recentMarkerWidth, and omitting it
+  // here made marked rows wrap for ~5s after every commit (#1390).
+  const recentMarkerWidth = isRecent ? 2 : 0
   const fixedWidth =
-    graphWidth + 1 + commit.shortHash.length + 1 + dateSegmentWidth + chip.width
+    graphWidth + 1 + commit.shortHash.length + 1 + dateSegmentWidth + chip.width + recentMarkerWidth
   // Refs trail the message and shrink first when the row is narrow:
   // the user can always see the full ref list in the inspector, so
   // the headline subject keeps priority over decoration.
@@ -509,7 +513,8 @@ function renderPendingCommitRow(
   Text: LogInkComponents['Text'],
   worktree: NonNullable<LogInkContext['worktree']>,
   selected: boolean,
-  theme: LogInkTheme
+  theme: LogInkTheme,
+  panelWidth: number
 ): ReactTypes.ReactElement {
   const parts: string[] = []
   if (worktree.stagedCount) {
@@ -533,7 +538,7 @@ function renderPendingCommitRow(
       ? theme.colors.selectionForeground
       : (theme.noColor ? undefined : theme.colors.accent),
     backgroundColor: selected && !theme.noColor ? theme.colors.selection : undefined,
-  }, truncateCells(label, 140))
+  }, truncateCells(label, Math.max(20, panelWidth - 4)))
 }
 
 /**
@@ -681,7 +686,7 @@ export function renderHistoryPanel(
   const realSelectionSuppressed = state.pendingCommitFocused
 
   const pendingNode = showPendingRow
-    ? renderPendingCommitRow(h, Text, worktree!, pendingRowSelected, theme)
+    ? renderPendingCommitRow(h, Text, worktree!, pendingRowSelected, theme, width)
     : null
 
   return h(Box, {

--- a/src/workstation/surfaces/status/index.ts
+++ b/src/workstation/surfaces/status/index.ts
@@ -79,6 +79,11 @@ export function renderStatusSurface(ctx: SurfaceRenderContext): ReactTypes.React
   const visibleGroups = groupWorktreeFiles(visibleFiles)
   const surfaceRows = buildStatusSurfaceRows(visibleGroups)
   const listRows = Math.max(4, bodyRows - 5)
+  // Row budget = the panel interior (border 2 + paddingX 2), NOT a
+  // hardcoded 140 (#1390): a monorepo path longer than the panel used
+  // to wrap, shifting the windowed list and pushing the panel past
+  // bodyRows (the body Box has no overflow clipping).
+  const rowBudget = Math.max(20, width - 4)
   const selectedIndex = state.selectedWorktreeFileIndex
   const headerFocused = state.statusGroupHeaderFocused
   // Resolve the cursor's row index in the flat (header-and-file) row
@@ -123,7 +128,7 @@ export function renderStatusSurface(ctx: SurfaceRenderContext): ReactTypes.React
           dimColor: !headerSelected && rowIndex > cursorRowIndex,
           backgroundColor: headerSelected && !theme.noColor ? theme.colors.selection : undefined,
           color: headerSelected && !theme.noColor ? theme.colors.selectionForeground : undefined,
-        }, truncateCells(text, 140))
+        }, truncateCells(text, rowBudget))
       }
       const isSelected = !headerFocused && row.flatIndex === selectedIndex
       const cursorPart = `${isSelected ? '>' : ' '} `
@@ -137,7 +142,7 @@ export function renderStatusSurface(ctx: SurfaceRenderContext): ReactTypes.React
       // slice we lazily-loaded on boot; missing context → no badge.
       const lfsBadge = context.lfs && isPathLfsTracked(context.lfs, row.file.path) ? ' LFS' : ''
       const tail = `${row.file.indexStatus}${row.file.worktreeStatus} ${row.file.path}${lfsBadge}`
-      const tailTrunc = truncateCells(tail, Math.max(0, 140 - cellWidth(cursorPart) - dotCells - 2))
+      const tailTrunc = truncateCells(tail, Math.max(0, rowBudget - cellWidth(cursorPart) - dotCells - 2))
       return h(Text, {
         key: `status-file-${row.flatIndex}-${rowIndex}`,
         dimColor: !isSelected && rowIndex > cursorRowIndex,
@@ -201,5 +206,5 @@ export function renderStatusSurface(ctx: SurfaceRenderContext): ReactTypes.React
   ...fallbackLines.map((line, index) => h(Text, {
     key: `status-surface-fallback-${index}`,
     dimColor: index > 0,
-  }, truncateCells(line, 140))))
+  }, truncateCells(line, rowBudget))))
 }


### PR DESCRIPTION
Fixes #1390.

Wrapped rows are the workstation's most visible rendering defect class: the app body Box has no overflow clipping, so a single wrapped row shifts the windowed list, misaligns the cursor math, and pushes the panel bottom past `bodyRows`. This PR fixes the four confirmed sources:

1. **Status surface hardcoded 140-cell truncation** (group headers, file rows, fallback lines). The panel interior is ~50–64 cells at 100–130-col terminals — any longer path (routine in monorepos) wrapped. Now budgeted to the real interior (`width - 4`), with the row's cursor/dot prefix subtracted like before.

2. **History: the just-landed marker wasn't budgeted in single-line rows.** `fixedWidth` omitted the 2-cell `▎ ` marker (the stacked variant budgets it via `recentMarkerWidth`), so marked rows wrapped for ~5s after every commit/split-apply, then "healed". The pending-commit row's 140 sentinel is gone too.

3. **Inspector `Refs:` line was the one untruncated header line.** Resting the cursor on a branch tip (`HEAD -> main, origin/main, origin/HEAD`) wrapped the 20–32-cell inspector 2–3 rows — i.e. constantly. Refs are OSC-8 hyperlink spans, so rather than slicing through escape sequences, the line now budgets whole refs and appends `+N more` when they don't fit (first ref cell-truncates if it alone exceeds the budget).

4. **Diff surface header right-labels** (stash subtitle — default WIP subjects run 60+ chars; commit-diff file path; worktree-diff file path) now truncate / middle-elide into the panel budget so the `space-between` header row can't wrap and steal a body row.

Compose's result/details/hint 140 sentinels are also replaced with the panel budget.

## Validation
- `tsc --noEmit` clean, `eslint` clean
- Full jest suite green: 309 suites / 3988 tests, all 68 snapshots unchanged (fixtures render inside the budgets)