### PR TITLE
fix(workstation): PR panel vertical budget + commit file list end-of-list clamp

### DIFF
--- a/src/workstation/surfaces/detail/index.ts
+++ b/src/workstation/surfaces/detail/index.ts
@@ -29,6 +29,7 @@ import type * as ReactTypes from 'react'
 import type { LogInkContextStatus } from '../../chrome/context'
 import { isLogInkContextKeyLoading } from '../../chrome/context'
 import { formatHyperlink } from '../../chrome/hyperlinks'
+import { clampListWindowStart } from '../../chrome/layout'
 import { forgeNouns } from '../../chrome/forgeNouns'
 import type {
   InspectorAction,
@@ -218,7 +219,10 @@ function renderCommitFileList(
   }
 
   const clamped = Math.max(0, Math.min(selectedIndex, files.length - 1))
-  const startIndex = Math.max(0, clamped - Math.floor(maxRows / 2))
+  // Missed adoption site of the #1340 clamp (#1394): centering without
+  // the lower bound under-filled the window when the cursor sat near
+  // the last file.
+  const startIndex = clampListWindowStart(clamped, files.length, maxRows)
   const visible = files.slice(startIndex, startIndex + maxRows)
 
   return visible.map((file, offset) => {

--- a/src/workstation/surfaces/pullRequest/index.ts
+++ b/src/workstation/surfaces/pullRequest/index.ts
@@ -92,7 +92,12 @@ export function renderPullRequestSurface(ctx: SurfaceRenderContext): ReactTypes.
   const checkBudget = Math.max(3, Math.min(checkRows.length, Math.floor(bodyRows / 2)))
   const visibleChecks = checkRows.slice(0, checkBudget)
   const truncatedChecks = checkRows.length - visibleChecks.length
-  const bodyPreviewBudget = Math.max(2, bodyRows - 8 - visibleChecks.length)
+  // Count the surface's REAL fixed chrome (#1394): border (2) + header
+  // + title + state + blank + Checks label + checks summary + possible
+  // checks-trunc line + blank + Reviews label + reviews summary +
+  // blank + Description label + possible body-trunc line = 15. The old
+  // reserve of 8 let a long PR body overflow the panel by ~5 rows.
+  const bodyPreviewBudget = Math.max(2, bodyRows - 15 - visibleChecks.length)
   const bodyLines = (pr.body || '').split(/\r?\n/).filter((line) => line.trim().length > 0)
   const visibleBodyLines = bodyLines.slice(0, bodyPreviewBudget)
   const truncatedBodyLines = bodyLines.length - visibleBodyLines.length


### PR DESCRIPTION
Fixes #1394.

## 1. PR panel overflowed ~5 rows on well-described PRs

`bodyPreviewBudget = Math.max(2, bodyRows - 8 - visibleChecks)` — but the surface renders ~15 fixed rows: border (2), header, title, state line, blank, Checks label, checks summary, possible checks-truncation line, blank, Reviews label, reviews summary, blank, Description label, possible body-truncation line. Opening `gp` on a PR with a long body pushed the panel past `bodyRows` (footer pushed off / frame overdraw). The reserve now counts the real chrome.

## 2. Commit file list missed the #1340 clamp

`renderCommitFileList` still computed `startIndex = max(0, selected - floor(maxRows/2))` without the lower window clamp — with the cursor near the last file the window under-filled while earlier files that could fill it stayed hidden. Now uses the shared `clampListWindowStart`.

## Validation
- `tsc --noEmit` clean, `eslint` clean
- Full jest suite green: 309 suites / 3988 tests, snapshots unchanged