### PR TITLE
fix(workstation): line-select survives single-pane; stale anchor can't eat Esc on commit diffs

### DIFF
--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -5322,6 +5322,43 @@ describe('triage filter cycling (#882 phase 6)', () => {
       expect(state.peekReturnFocus).toBe('commits')
     })
 
+    it('v stays line-select on the staging diff — peek must not shadow it (#1389)', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'navigateOpenDiffForWorktreeFile', fileIndex: 0 })
+      expect(state.activeView).toBe('diff')
+
+      const events = getLogInkInputEvents(state, 'v', {}, { ...singlePane, worktreeDiffLineCount: 20 })
+      expect(events.find((event) =>
+        event.type === 'action' && event.action.type === 'togglePeek'
+      )).toBeUndefined()
+    })
+
+    it('a stale line-select anchor does not swallow Esc on a commit diff (#1389)', () => {
+      let state = createLogInkState(rows)
+      // Set an anchor on the staging diff, hop out, then open a commit
+      // diff — the push clears the anchor, and even if one leaked, the
+      // Esc gate only fires on the worktree diff.
+      state = applyLogInkAction(state, { type: 'navigateOpenDiffForWorktreeFile', fileIndex: 0 })
+      state = applyLogInkAction(state, { type: 'setDiffLineSelectAnchor', value: 3 })
+      state = applyLogInkAction(state, { type: 'popView' })
+      const firstCommit = rows.find((row) => row.type === 'commit')
+      state = applyLogInkAction(state, {
+        type: 'navigateOpenDiffForCommit',
+        sha: firstCommit && 'hash' in firstCommit ? firstCommit.hash : '',
+        commitIndex: 0,
+      })
+      expect(state.activeView).toBe('diff')
+      expect(state.diffLineSelectAnchor).toBeUndefined()
+
+      // Belt-and-suspenders: force a stale anchor and confirm Esc pops
+      // instead of clearing invisible state.
+      const stale = { ...state, diffLineSelectAnchor: 3 }
+      const events = getLogInkInputEvents(stale, '', { escape: true }, {})
+      expect(events.find((event) =>
+        event.type === 'action' && event.action.type === 'setDiffLineSelectAnchor'
+      )).toBeUndefined()
+    })
+
     it('v again snaps back to the original pane and clears the ticket', () => {
       let state = createLogInkState(rows)
       state = applyInput(state, 'v', {}, singlePane)

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -1766,8 +1766,16 @@ export function getLogInkInputEvents(
   // mode would stick around, and the next Enter on history would
   // still try to capture a sha.
   // Line-select on the staging diff: Esc drops the selection without
-  // popping the view — the user is mid-staging, not leaving.
-  if (key.escape && state.diffLineSelectAnchor !== undefined && state.activeView === 'diff') {
+  // popping the view — the user is mid-staging, not leaving. Gated on
+  // the WORKTREE diff (#1389): the anchor is meaningless on
+  // commit/stash/compare diffs, and a stale one made the first Esc
+  // clear invisible state instead of popping.
+  if (
+    key.escape &&
+    state.diffLineSelectAnchor !== undefined &&
+    state.activeView === 'diff' &&
+    isWorktreeDiffTarget(state)
+  ) {
     return [action({ type: 'setDiffLineSelectAnchor', value: undefined })]
   }
 
@@ -2468,7 +2476,16 @@ export function getLogInkInputEvents(
   // narrow (single-pane) terminals: a momentary glance that snaps back
   // with `v` / Esc (handled above once peeking). No-op in the three-pane
   // layout (every pane is already on screen) and from the sidebar itself.
-  if (inputValue === 'v' && context.singlePane && state.focus !== 'sidebar') {
+  // NOT on the staging diff (#1389): `v` is line-select there, and the
+  // peek intercept made line-level staging unreachable on narrow
+  // terminals (the narrow footer even replaced the "v select" hint
+  // with "v peek", so the feature silently vanished with width).
+  if (
+    inputValue === 'v' &&
+    context.singlePane &&
+    state.focus !== 'sidebar' &&
+    !isWorktreeDiffTarget(state)
+  ) {
     return [action({ type: 'togglePeek' })]
   }
 

--- a/src/workstation/runtime/inkKeymap.ts
+++ b/src/workstation/runtime/inkKeymap.ts
@@ -1099,8 +1099,13 @@ export function getLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogI
   // global cluster don't fit alongside the switcher at the 80-col floor,
   // so both are trimmed (the dropped keys stay reachable via `?`).
   if (options.singlePane) {
+    // No `v peek` on the staging diff (#1389): `v` is line-select
+    // there (the input layer gates the peek off it), and advertising
+    // peek over select was how line-staging silently vanished on
+    // narrow terminals.
+    const onWorktreeDiff = options.activeView === 'diff' && options.diffSource === 'worktree'
     const lead =
-      options.focus === 'sidebar'
+      options.focus === 'sidebar' || onWorktreeDiff
         ? [singlePaneSwitcherHint(options.focus)]
         : [singlePaneSwitcherHint(options.focus), 'v peek']
     return {

--- a/src/workstation/runtime/inkViewModel.ts
+++ b/src/workstation/runtime/inkViewModel.ts
@@ -2493,6 +2493,10 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         selectedIndex: clampIndex(selectedIndex, filteredCommits.length),
         selectedFileIndex: Math.max(0, action.fileIndex ?? 0),
         diffPreviewOffset: 0,
+        // The anchor is a worktree-diff concept (#1389) — a stale one
+        // carried in from the staging diff made the commit diff's
+        // first Esc clear invisible state instead of popping.
+        diffLineSelectAnchor: undefined,
         diffSource: 'commit',
       }
     }


### PR DESCRIPTION
Fixes #1389.

## 1. `v` peek made line-level staging unreachable on narrow terminals

The single-pane peek intercept (`v` → sidebar glance) ran long before the worktree diff's line-select anchor handler, and it matched on every non-sidebar focus. On a narrow terminal the staging diff's `v` always opened the peek — line-level staging (#1358) was completely unreachable, and the narrow footer replaced the `v select` hint with `v peek`, so the feature silently vanished with terminal width. The peek intercept and the footer hint now both yield on the worktree diff (the pane switcher hint remains; Tab still reaches the sidebar).

## 2. Stale line-select anchor swallowed one Esc on commit diffs

`navigateOpenDiffForCommit` pushed the diff view preserving `diffLineSelectAnchor` (only the worktree-file path cleared it), and the Esc handler gated on `activeView === 'diff'` alone. Repro: staging diff → `v` (anchor set) → Tab to inspector → Enter (commit diff) → first Esc does nothing visible (clears the invisible anchor), second Esc pops. The push now clears the anchor, and the Esc gate additionally requires `isWorktreeDiffTarget` — the anchor is a staging-diff concept.

New tests: `v` on the single-pane staging diff emits no `togglePeek`; a commit-diff push clears the anchor; a forced stale anchor doesn't intercept Esc.

## Validation
- `tsc --noEmit` clean, `eslint` clean
- Full jest suite green: 309 suites / 3990 tests