### PR TITLE
fix(workstation): sidebar-focused yank copies the cursored sidebar entity

### DIFF
--- a/src/workstation/runtime/hooks/useYankActions.ts
+++ b/src/workstation/runtime/hooks/useYankActions.ts
@@ -139,7 +139,22 @@ export function useYankActions(
     let value: string | undefined
     let label: string | undefined
 
-    const view = state.activeView
+    // Sidebar-focused yank (#1388): the cursored SIDEBAR entity wins
+    // over the view behind it. The dispatcher's sidebar arms
+    // (isBranch/Tag/StashActionTarget) were effectively dead code —
+    // this resolver only consulted activeView, so `y` on a sidebar
+    // branch copied the history commit and labeled it as such.
+    const sidebarEntity =
+      state.focus === 'sidebar'
+        ? state.sidebarTab === 'branches'
+          ? ('branches' as const)
+          : state.sidebarTab === 'tags'
+            ? ('tags' as const)
+            : state.sidebarTab === 'stashes'
+              ? ('stash' as const)
+              : undefined
+        : undefined
+    const view = sidebarEntity ?? state.activeView
     if (view === 'history') {
       const commit = state.filteredCommits[state.selectedIndex]
       if (commit) {
@@ -326,6 +341,8 @@ export function useYankActions(
     state.diffSource,
     state.filter,
     state.filteredCommits,
+    state.focus,
+    state.sidebarTab,
     state.selectedBranchIndex,
     state.selectedIndex,
     state.selectedIssueIndex,

--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -2883,6 +2883,22 @@ describe('log Ink input interactions', () => {
       ])
     })
 
+    it('sidebar-focused y targets the sidebar entity, not the history commit (#1388)', () => {
+      // From the default history view, Tab to the sidebar on the
+      // branches tab: y must emit the ref-style yank (no short flag,
+      // matching the entity arm) — the history arm used to win, and
+      // the resolver copied the commit hash while the cursor sat on a
+      // branch row.
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setFocus', value: 'sidebar' })
+      state = applyLogInkAction(state, { type: 'setSidebarTab', value: 'branches' })
+      expect(state.activeView).toBe('history')
+
+      expect(getLogInkInputEvents(state, 'y', {}, { branchCount: 2 })).toEqual([
+        { type: 'yankFromActiveView' },
+      ])
+    })
+
     it('does not emit a short flag for views where it is meaningless', () => {
       // Branches/tags/stash/status only have one identifier per row — short
       // is reserved for hash-bearing views (history + commit-diff).

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -3825,9 +3825,11 @@ export function getLogInkInputEvents(
   // lists; the dispatcher only decides whether the keystroke applies.
   if (inputValue === 'y' || inputValue === 'Y') {
     const short = inputValue === 'Y'
-    if (state.activeView === 'history' && state.filteredCommits.length > 0) {
-      return [{ type: 'yankFromActiveView', short }]
-    }
+    // Entity arms run BEFORE the history fallback (#1388): from the
+    // workstation's default history view with the sidebar focused,
+    // the history branch used to always win, so `y` on a cursored
+    // sidebar branch copied the history commit instead. The resolver
+    // mirrors this precedence (sidebar entity wins over activeView).
     if (isBranchActionTarget(state) && context.branchCount) {
       return [{ type: 'yankFromActiveView' }]
     }
@@ -3836,6 +3838,9 @@ export function getLogInkInputEvents(
     }
     if (isStashActionTarget(state) && context.stashCount && context.stashSelectedRef) {
       return [{ type: 'yankFromActiveView' }]
+    }
+    if (state.activeView === 'history' && state.filteredCommits.length > 0) {
+      return [{ type: 'yankFromActiveView', short }]
     }
     if (state.activeView === 'status' && context.worktreeSelectedPath) {
       return [{ type: 'yankFromActiveView' }]


### PR DESCRIPTION
Fixes #1388.

## Problem

Two stacked defects: (a) the yank dispatch checked `activeView === 'history'` **before** the `isBranch/Tag/StashActionTarget` sidebar arms, so from the workstation's default history view with the sidebar focused, the history branch always won; (b) even when the sidebar arms fired (from the promoted views), the resolver (`useYankActions`) switched purely on `state.activeView` and never inspected focus — it could never return the sidebar-cursored ref. The sidebar arms (added for #791 in-sidebar selection) were effectively dead code.

Repro: history view → Tab to sidebar → `]` to Branches → ↓ to a branch → `y` → status reports "Copied commit <hash>" (the history commit), not the branch name.

## Fix

- Dispatch: the entity arms run before the history fallback (sidebar focus on the branches/tags/stashes tabs wins; other tabs keep the old behavior).
- Resolver: a sidebar-focus branch maps the active tab to its entity (branches/tags → their lists, stashes → stash) and resolves the cursored row against the same filtered+sorted lists the sidebar renders; everything else falls back to `activeView` as before. Missing hook deps (`state.focus`, `state.sidebarTab`) added.

New dispatch-level test: sidebar-focused `y` on the branches tab emits the ref-style yank from the history view.

## Validation
- `tsc --noEmit` clean, `eslint` clean (fixed the dep warning my change introduced)
- Full jest suite green: 309 suites / 3989 tests