### PR TITLE
fix(commit): split apply refuses when the staged state drifted since the plan

### DIFF
--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -262,6 +262,74 @@ function assertNoUnstagedOverlap(
   }
 }
 
+/**
+ * Apply-time drift check (#1396). The plan and its validation ran
+ * against the snapshot taken at generation time, but `git add <file>`
+ * stages whatever is on disk NOW — the workstation holds the plan
+ * between preview and `y`-to-apply, and edits made in that window
+ * (editor autosave, formatter, another session) would be committed
+ * under the reviewed message with no guard firing (the snapshot's
+ * `unstaged` list predates them).
+ *
+ * Scope mirrors `assertNoUnstagedOverlap`: only FILE-mode claims are
+ * checked. Hunk-mode groups re-apply the recorded patches to the
+ * index (`applyPatchToIndex`), so disk state doesn't feed them.
+ *
+ * Reads per-file index/working-tree codes from `status().files` — the
+ * convenience arrays (`modified` etc.) conflate the two columns, and a
+ * cleanly staged file would false-positive as a worktree edit.
+ */
+async function assertNoStagedDriftSincePlan(
+  plan: CommitSplitPlan,
+  hunkInventory: HunkInventory,
+  git: ReturnType<typeof import('../../lib/simple-git/getRepo').getRepo>
+): Promise<void> {
+  const hunkFiles = new Set(
+    plan.groups.flatMap((group) =>
+      getGroupHunks(group)
+        .map((hunkId) => hunkInventory.byId.get(hunkId)?.filePath)
+        .filter((file): file is string => Boolean(file))
+    )
+  )
+  const fileModeFiles = plan.groups
+    .filter((group) => !group.unclaimed)
+    .flatMap((group) => getGroupFiles(group))
+    .filter((file) => !hunkFiles.has(file))
+  if (fileModeFiles.length === 0) {
+    return
+  }
+
+  const fresh = await git.status()
+  const freshStaged = new Set<string>([
+    ...fresh.staged,
+    ...fresh.created,
+    ...fresh.renamed.map((entry) =>
+      typeof entry === 'string' ? entry : entry.to
+    ),
+  ])
+  const worktreeEdited = new Set(
+    (fresh.files || [])
+      .filter((file) => {
+        const wd = file.working_dir
+        return wd && wd !== ' ' && wd !== '?'
+      })
+      .map((file) => file.path)
+  )
+
+  const unstagedSincePlan = fileModeFiles.filter((file) => !freshStaged.has(file))
+  if (unstagedSincePlan.length > 0) {
+    throw new Error(
+      `Staged changes drifted since the plan was generated — no longer staged: ${unstagedSincePlan.join(', ')}. Regenerate the plan (r) and re-apply.`
+    )
+  }
+  const editedSincePlan = fileModeFiles.filter((file) => worktreeEdited.has(file))
+  if (editedSincePlan.length > 0) {
+    throw new Error(
+      `Files changed on disk since the plan was generated: ${editedSincePlan.join(', ')}. Applying would commit the drifted content under the reviewed message — regenerate the plan (r) and re-apply.`
+    )
+  }
+}
+
 function buildPatchForHunks(hunks: StagedHunk[]): string {
   const byFile = new Map<string, StagedHunk[]>()
 
@@ -358,6 +426,7 @@ export async function applyCommitSplitPlan({
 }): Promise<CommitSplitApplyResult> {
   validatePlanForStagedFiles(plan, changes.staged, hunkInventory)
   assertNoUnstagedOverlap(plan, changes, hunkInventory)
+  await assertNoStagedDriftSincePlan(plan, hunkInventory, git)
 
   // Defensive: drop any group with empty files[] AND empty hunks[].
   // `dropEmptyGroups` runs in the generator's rescue chain but we

--- a/src/commands/commit/splitApplyDrift.test.ts
+++ b/src/commands/commit/splitApplyDrift.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for the apply-time drift check (#1396): `applyCommitSplitPlan`
+ * must refuse when the staged state changed between plan generation
+ * (the snapshot the workstation holds during preview) and `y`-to-apply
+ * — `git add` stages what is on disk NOW, so drifted content would be
+ * committed under the reviewed message with no guard firing.
+ *
+ * `createCommit` is mocked; the fake git drives `status()` to simulate
+ * the fresh probe.
+ */
+
+import type { FileChange } from '../../lib/types'
+import { applyCommitSplitPlan, type CommitSplitPlan } from './split'
+import { createCommit } from '../../lib/simple-git/createCommit'
+import { Logger } from '../../lib/utils/logger'
+
+jest.mock('../../lib/simple-git/createCommit', () => ({
+  createCommit: jest.fn(),
+  PreCommitHookError: class PreCommitHookError extends Error {},
+}))
+
+const mockedCreateCommit = createCommit as jest.MockedFunction<typeof createCommit>
+
+type FreshFile = { path: string; index: string; working_dir: string }
+
+function makeFakeGit(options: { staged: string[]; files?: FreshFile[] }) {
+  let head = 0
+  const git = {
+    raw: jest.fn(async () => ''),
+    add: jest.fn(async () => ''),
+    status: jest.fn(async () => ({
+      staged: options.staged,
+      created: [],
+      renamed: [],
+      modified: [],
+      deleted: [],
+      not_added: [],
+      files: options.files ?? [],
+    })),
+    revparse: jest.fn(async () => `head-${head}`),
+    advanceHead: () => {
+      head += 1
+    },
+  }
+  return git
+}
+
+function fileChange(filePath: string): FileChange {
+  return { filePath, status: 'modified', summary: `${filePath} changed` }
+}
+
+const emptyHunkInventory = {
+  hunks: [],
+  byId: new Map(),
+  byFile: new Map(),
+} as never
+
+function makePlan(files: string[]): CommitSplitPlan {
+  return { groups: [{ title: 'feat: x', body: '', files }] } as CommitSplitPlan
+}
+
+describe('applyCommitSplitPlan drift check (#1396)', () => {
+  const logger = new Logger({ silent: true })
+
+  afterEach(() => jest.clearAllMocks())
+
+  it('refuses when a planned file is no longer staged at apply time', async () => {
+    const git = makeFakeGit({ staged: [] })
+
+    await expect(
+      applyCommitSplitPlan({
+        plan: makePlan(['a.ts']),
+        changes: { staged: [fileChange('a.ts')], unstaged: [], untracked: [] },
+        hunkInventory: emptyHunkInventory,
+        git: git as never,
+        logger,
+        noVerify: false,
+      })
+    ).rejects.toThrow(/no longer staged: a\.ts/)
+
+    // The refusal must land BEFORE the up-front `git reset` wipes the
+    // index — nothing destructive may run on a drifted worktree.
+    expect(git.raw).not.toHaveBeenCalled()
+    expect(mockedCreateCommit).not.toHaveBeenCalled()
+  })
+
+  it('refuses when a planned file gained unstaged edits since the plan', async () => {
+    const git = makeFakeGit({
+      staged: ['a.ts'],
+      files: [{ path: 'a.ts', index: 'M', working_dir: 'M' }],
+    })
+
+    await expect(
+      applyCommitSplitPlan({
+        plan: makePlan(['a.ts']),
+        changes: { staged: [fileChange('a.ts')], unstaged: [], untracked: [] },
+        hunkInventory: emptyHunkInventory,
+        git: git as never,
+        logger,
+        noVerify: false,
+      })
+    ).rejects.toThrow(/changed on disk since the plan/)
+
+    expect(git.raw).not.toHaveBeenCalled()
+  })
+
+  it('applies cleanly when the fresh state matches the snapshot', async () => {
+    const git = makeFakeGit({
+      staged: ['a.ts'],
+      files: [{ path: 'a.ts', index: 'M', working_dir: ' ' }],
+    })
+    mockedCreateCommit.mockImplementation(async () => {
+      git.advanceHead()
+      return {} as never
+    })
+
+    const result = await applyCommitSplitPlan({
+      plan: makePlan(['a.ts']),
+      changes: { staged: [fileChange('a.ts')], unstaged: [], untracked: [] },
+      hunkInventory: emptyHunkInventory,
+      git: git as never,
+      logger,
+      noVerify: false,
+    })
+
+    expect(result.commitHashes).toEqual(['head-1'])
+  })
+})


### PR DESCRIPTION
Fixes #1396. Companion to #1381 (index isolation) — the two touch different regions of `applyCommitSplitPlan` and merge independently.

## Problem

The plan/apply split is what lets the workstation guarantee the executed split matches the previewed plan — but apply-time validation (`validatePlanForStagedFiles`, `assertNoUnstagedOverlap`) ran against the **snapshotted** `changes` from generation time. `git add <file>` stages whatever is on disk *now*: edits made between preview and `y` (editor autosave, a formatter, another session) were committed under the reviewed message, and the overlap guard couldn't fire because the snapshot's `unstaged` list predates them.

## Fix

`assertNoStagedDriftSincePlan` runs a fresh `git status` before the up-front reset and aborts with a regenerate-and-retry message when:
- a planned file is **no longer staged** (unstaged/reverted since the plan), or
- a planned file **gained unstaged worktree edits** (the autosave case).

Two deliberate scoping decisions:
- Only FILE-mode claims are checked, mirroring `assertNoUnstagedOverlap` — hunk-mode groups re-apply their recorded patches to the index (`applyPatchToIndex`), so disk state doesn't feed them.
- Per-file index/working-tree codes from `status().files` are used — simple-git's convenience arrays conflate the two columns, and a cleanly staged file would false-positive as a worktree edit.

Known limitation (documented): content re-staged after the plan (staged-blob drift with a clean worktree) isn't detectable without snapshot hashes; the guard covers the unstaged-drift cases, which are the dangerous-and-common ones.

New tests: refusal before any destructive git call for both drift kinds; clean apply when fresh state matches.

## Validation
- `tsc --noEmit` clean, `eslint` clean
- Full jest suite green: 310 suites / 3991 tests