### PR TITLE
fix(workstation): frame-tag history row loaders so cross-repo fetches drop instead of splicing

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -212,6 +212,7 @@ import {useSpinnerFrame} from './hooks/useSpinnerFrame'
 import {useStatusSurfaceData} from './hooks/buildStatusSurfaceData'
 import {useStatusAutoDismiss} from './hooks/useStatusAutoDismiss'
 import {useHistoryCursorSync} from './hooks/useHistoryCursorSync'
+import {isStaleFrameResolve} from './loadMoreResolver'
 import {computeHasMoreCommits, useHistoryPaginationState, useLoadMoreHistory} from './hooks/useLoadMoreHistory'
 import {useOnboarding} from './hooks/useOnboarding'
 import {useRepoStackRuntimes} from './hooks/useRepoStackRuntimes'
@@ -488,6 +489,16 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   const loadingMoreCommitsRef = React.useRef(false)
   const loadMoreRequestRef = React.useRef(0)
   const mountedRef = React.useRef(true)
+  // #1384 — render-fresh mirror of the repo-frame depth
+  // (`state.repoStack.length - 1`). The history ROW loaders capture it
+  // at dispatch and re-read it at resolve to drop completions that
+  // straddle a repo-frame push / pop — rows live in the single reducer
+  // state and are swapped in place per frame, so unlike the #994
+  // context loaders there is no per-frame slot to route a late write
+  // to; dropping is the only safe completion. A ref (not a closure
+  // capture) so the STABLE loader callbacks always see the live depth.
+  const repoFrameDepthRef = React.useRef(state.repoStack.length - 1)
+  repoFrameDepthRef.current = state.repoStack.length - 1
 
   // P4.3 — idle tip rotation. Extracted into `useIdleTip` (0.72 app.ts
   // decomposition). The hook issues the `useState` tick counter then the
@@ -597,10 +608,19 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // dispatching after the user `q` quits before rows arrive.
   React.useEffect(() => {
     if (!loadRows) return
+    // #1384 — the boot fetch runs against the ROOT frame's git; if the
+    // user drills into a submodule before a slow boot load resolves,
+    // the late `replaceRows` would swap root-repo commits into the
+    // child frame. Same frame-tag-and-drop as `refreshHistoryRows`.
+    const issuedAtDepth = repoFrameDepthRef.current
     let cancelled = false
     void loadRows()
       .then((nextRows) => {
-        if (cancelled || !mountedRef.current) return
+        if (cancelled || isStaleFrameResolve({
+          mounted: mountedRef.current,
+          issuedAtDepth,
+          currentDepth: repoFrameDepthRef.current,
+        })) return
         dispatch({ type: 'replaceRows', rows: nextRows })
         // Correct the pagination seed: on a cold cache the component
         // mounted with zero rows, so the lazy `hasMoreCommits` seed
@@ -667,6 +687,13 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
    */
   const refreshHistoryRows = React.useCallback(async () => {
     try {
+      // #1384 — capture the repo-frame depth BEFORE the awaits (the
+      // same discipline as refreshContext's #994 tag below). The
+      // resolve drops when the frame stack changed mid-flight: this
+      // callback's `git` belongs to the frame it was created for, so
+      // a late `replaceRows` would swap that repo's commits into
+      // whichever frame is active now.
+      const issuedAtDepth = repoFrameDepthRef.current
       const fetchArgs = state.historyFetchArgs
       const mergedArgv: LogArgv = {
         ...logArgv,
@@ -683,7 +710,12 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         limit: LOG_INTERACTIVE_DEFAULT_LIMIT,
         extraRefs: stashHashes,
       })
-      if (mountedRef.current && fresh) {
+      const staleFrame = isStaleFrameResolve({
+        mounted: mountedRef.current,
+        issuedAtDepth,
+        currentDepth: repoFrameDepthRef.current,
+      })
+      if (!staleFrame && fresh) {
         dispatch({ type: 'replaceRows', rows: fresh })
         // Re-arm pagination from the fresh window (#1337): the refresh
         // truncates the loaded rows back to one page, so a user who had
@@ -1005,8 +1037,20 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // in `useEffect`.
   React.useEffect(() => {
     if (state.activeView !== 'issues') return
-    setContext((current) => (current.issueList ? { ...current, issueList: undefined } : current))
-    setContextStatus((current) => updateLogInkContextStatus(current, 'issueList', 'idle'))
+    // #1384 — frame-tag the clear (via the render-fresh depth ref, so
+    // the deliberately-narrow dep array below stays untouched): the
+    // preset belongs to the frame whose view is showing, so the write
+    // must land there, not on whichever frame is active if a push /
+    // pop lands in the same commit window.
+    const issuedAtDepth = repoFrameDepthRef.current
+    setContext(
+      (current) => (current.issueList ? { ...current, issueList: undefined } : current),
+      issuedAtDepth,
+    )
+    setContextStatus(
+      (current) => updateLogInkContextStatus(current, 'issueList', 'idle'),
+      issuedAtDepth,
+    )
     // We deliberately depend ONLY on the preset — not on
     // activeView — so re-entering the view doesn't re-fire and
     // discard the just-loaded data. The activeView guard above
@@ -1055,10 +1099,17 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
 
   React.useEffect(() => {
     if (state.activeView !== 'pull-request-triage') return
-    setContext((current) =>
-      current.pullRequestList ? { ...current, pullRequestList: undefined } : current
+    // #1384 — frame-tagged like the issue preset-clear above.
+    const issuedAtDepth = repoFrameDepthRef.current
+    setContext(
+      (current) =>
+        current.pullRequestList ? { ...current, pullRequestList: undefined } : current,
+      issuedAtDepth,
     )
-    setContextStatus((current) => updateLogInkContextStatus(current, 'pullRequestList', 'idle'))
+    setContextStatus(
+      (current) => updateLogInkContextStatus(current, 'pullRequestList', 'idle'),
+      issuedAtDepth,
+    )
   }, [state.selectedPullRequestFilter])
 
   // Per-item inspector hydration (#882) + on-demand blame hydration
@@ -1341,6 +1392,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     refreshContext,
     refreshHistoryRows,
     refreshWorktreeContext,
+    runtimes,
     setContext,
     setContextStatus,
     forge,

--- a/src/workstation/runtime/hooks/useLoadMoreHistory.ts
+++ b/src/workstation/runtime/hooks/useLoadMoreHistory.ts
@@ -46,6 +46,14 @@
  * cancellation logic, the dispatch payloads, and every dependency array
  * are byte-for-byte the same as the original `app.ts` cluster.
  *
+ * #1384 layered the repo-frame discipline on top: both loaders capture
+ * the repo-stack depth at dispatch and drop their resolve when the
+ * frame stack changed mid-flight (the pure decisions live in
+ * `loadMoreResolver.ts`), and a rescope effect bumps
+ * `loadMoreRequestRef` / resets the in-flight flags on every frame
+ * push / pop so a parent-frame page can never splice into a child
+ * frame's history.
+ *
  * `mountedRef`, `loadingMoreCommitsRef`, and `loadMoreRequestRef` stay
  * declared in `app.ts` (they are shared with — or, for `mountedRef`, read
  * by — many other clusters) and are passed in.
@@ -76,6 +84,7 @@ import {
 } from '../../../commands/log/data'
 import { getStashCommitHashes } from '../../../git/stashData'
 import type { LogInkAction, LogInkState } from '../inkViewModel'
+import { isStaleFrameResolve, isStaleLoadMoreCompletion } from '../loadMoreResolver'
 import type { LoadCommitContextFn } from './useHistoryCursorSync'
 
 /**
@@ -204,6 +213,30 @@ export function useLoadMoreHistory(
     loadingMoreCommitsRef.current = loadingMoreCommits
   }, [loadingMoreCommits])
 
+  // #1384 — rescope the pagination request family on every repo-frame
+  // push / pop. The history rows are swapped in place per frame (the
+  // git-keyed refetch effects in app.ts replace them), but nothing used
+  // to invalidate an in-flight page fetch: a parent-frame page resolving
+  // after a submodule drill-in passed the request-id guard and spliced
+  // parent-repo commits into the child frame's graph. Bumping the id on
+  // every frame transition means a pre-transition fetch can never
+  // satisfy the guard — even after a push → pop round trip back to the
+  // same depth. The in-flight flags are reset too: the stale completion
+  // returns early WITHOUT clearing them (by design — it must not
+  // clobber a newer fetch's state), so without this reset a dropped
+  // completion would leave `loadingMoreCommitsRef` true forever and
+  // permanently disable pagination in the new frame.
+  React.useEffect(() => {
+    loadMoreRequestRef.current += 1
+    loadingMoreCommitsRef.current = false
+    setLoadingMoreCommits(false)
+  }, [
+    state.repoStack.length,
+    loadMoreRequestRef,
+    loadingMoreCommitsRef,
+    setLoadingMoreCommits,
+  ])
+
   // STABLE useCallback (empty deps) for loadMoreCommits. The function
   // reads the volatile state (commit counts, fetch args, hasMore) via
   // refs that update on every render so the identity stays constant.
@@ -227,6 +260,10 @@ export function useLoadMoreHistory(
     historyFetchArgs: state.historyFetchArgs,
     hasMoreCommits,
     logArgv,
+    // #1384 — repo-frame depth, captured at dispatch and re-read at
+    // resolve so a fetch issued in one frame drops instead of splicing
+    // its rows into whichever frame is active when it lands.
+    repoFrameDepth: state.repoStack.length - 1,
   })
   loadMoreStateRef.current = {
     mainHistoryCommitCount: state.mainHistoryCommitCount,
@@ -234,6 +271,7 @@ export function useLoadMoreHistory(
     historyFetchArgs: state.historyFetchArgs,
     hasMoreCommits,
     logArgv,
+    repoFrameDepth: state.repoStack.length - 1,
   }
 
   const loadMoreCommits = React.useCallback(async (
@@ -250,6 +288,10 @@ export function useLoadMoreHistory(
     loadingMoreCommitsRef.current = true
     const requestId = loadMoreRequestRef.current + 1
     loadMoreRequestRef.current = requestId
+    // #1384 — frame-tag the fetch (same discipline as the #994 context
+    // loaders): capture the depth it was issued from so the resolve can
+    // drop when the repo-frame stack changed mid-flight.
+    const issuedAtDepth = snap.repoFrameDepth
     setLoadingMoreCommits(true)
     dispatch({
       type: 'setStatus',
@@ -279,7 +321,18 @@ export function useLoadMoreHistory(
       })
     )
 
-    if (!mountedRef.current || loadMoreRequestRef.current !== requestId) {
+    // Stale-completion guard (#1384): unmounted, superseded request id
+    // (a newer fetch OR the frame push/pop rescope bump), or a repo-
+    // frame depth change. A stale completion must NOT touch the
+    // loading flags or `hasMoreCommits` — they now belong to the new
+    // frame (the rescope effect above resets them on frame moves).
+    if (isStaleLoadMoreCompletion({
+      mounted: mountedRef.current,
+      requestId,
+      currentRequestId: loadMoreRequestRef.current,
+      issuedAtDepth,
+      currentDepth: loadMoreStateRef.current.repoFrameDepth,
+    })) {
       return { fired: false, addedCommits: 0 }
     }
 
@@ -344,14 +397,22 @@ export function useLoadMoreHistory(
    * reintroduce the render-order race that bit the previous chain.
    * All volatile state (logArgv, mostly) is read via refs.
    */
-  const loadCommitContextStateRef = React.useRef({ logArgv })
-  loadCommitContextStateRef.current = { logArgv }
+  const loadCommitContextStateRef = React.useRef({
+    logArgv,
+    repoFrameDepth: state.repoStack.length - 1,
+  })
+  loadCommitContextStateRef.current = {
+    logArgv,
+    repoFrameDepth: state.repoStack.length - 1,
+  }
 
   const loadCommitContext = React.useCallback(async (
     target: { hash: string; label: string }
   ): Promise<void> => {
     const snap = loadCommitContextStateRef.current
     if (!snap.logArgv) return
+    // #1384 — frame-tag the anchored fetch; see `loadMoreCommits`.
+    const issuedAtDepth = snap.repoFrameDepth
     dispatch({
       type: 'setStatus',
       value: `Loading commits around ${target.label}…`,
@@ -364,7 +425,15 @@ export function useLoadMoreHistory(
       // `loadRowsWithStashes`; `appendRows` deduplicates by hash so
       // the merged result keeps both views without double-counting.
       const rows = await getLogRowsAnchoredOn(git, snap.logArgv, target.hash, {})
-      if (!mountedRef.current) return
+      // #1384 — drop the resolve when the repo-frame stack changed
+      // mid-flight: the anchored rows belong to the frame that issued
+      // the fetch, and `appendRows` would splice them into whichever
+      // frame is active now.
+      if (isStaleFrameResolve({
+        mounted: mountedRef.current,
+        issuedAtDepth,
+        currentDepth: loadCommitContextStateRef.current.repoFrameDepth,
+      })) return
       if (rows.length > 0) {
         dispatch({ type: 'appendRows', rows })
         // Don't dispatch a setStatus here — the cursor-sync effect
@@ -379,7 +448,13 @@ export function useLoadMoreHistory(
         })
       }
     } catch (error) {
-      if (mountedRef.current) {
+      // Same frame-scoped drop for the failure path (#1384): a stale
+      // frame's error message would mislabel the ACTIVE frame's state.
+      if (!isStaleFrameResolve({
+        mounted: mountedRef.current,
+        issuedAtDepth,
+        currentDepth: loadCommitContextStateRef.current.repoFrameDepth,
+      })) {
         dispatch({
           type: 'setStatus',
           value: `Failed to load context for ${target.label}: ${

--- a/src/workstation/runtime/hooks/useWorkflowAction.test.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.test.ts
@@ -66,6 +66,7 @@ function createDeps(over: Partial<UseWorkflowActionDeps>): UseWorkflowActionDeps
     refreshContext: jest.fn().mockResolvedValue(undefined),
     refreshHistoryRows: jest.fn().mockResolvedValue(undefined),
     refreshWorktreeContext: jest.fn().mockResolvedValue(undefined),
+    runtimes: [{}] as unknown as UseWorkflowActionDeps['runtimes'],
     setContext: jest.fn(),
     setContextStatus: jest.fn(),
     forge: {} as UseWorkflowActionDeps['forge'],

--- a/src/workstation/runtime/hooks/useWorkflowAction.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.ts
@@ -120,6 +120,7 @@ import { executeRebasePlan } from '../../../git/rebasePlanActions'
 import { initSubmodule, syncSubmodule, updateSubmodule } from '../../../git/submoduleActions'
 import { addRemote, pruneRemote, removeRemote, setRemoteUrl } from '../../../git/remoteActions'
 import { matchesPromotedFilter } from '../promotedFilter'
+import type { RepoStackRuntimes } from '../repoStackRuntime'
 import type { LogInkContext } from '../types'
 
 // Element types are derived from `LogInkContext` indexed access so they track
@@ -233,6 +234,14 @@ export type UseWorkflowActionDeps = {
    * awaits-and-ignores it, so `Promise<unknown>` is the precise contract.
    */
   refreshWorktreeContext: (options?: { silent?: boolean }) => Promise<unknown>
+  /**
+   * The repo-stack runtimes (#1384) — `runtimes.length - 1` at keystroke
+   * time is the frame-tag depth the cache-invalidation helpers pass to
+   * `setContext` / `setContextStatus`, so a triage mutation that finishes
+   * after a repo-frame push / pop still writes to (or is dropped with)
+   * the frame that issued it.
+   */
+  runtimes: RepoStackRuntimes
   /** Frame-aware context setter (used by the issue / PR cache-invalidation helpers). */
   setContext: (
     arg: LogInkContext | ((prev: LogInkContext) => LogInkContext),
@@ -303,6 +312,7 @@ export function useWorkflowAction(
       refreshContext,
       refreshHistoryRows,
       refreshWorktreeContext,
+      runtimes,
       setContext,
       setContextStatus,
       forge,
@@ -313,6 +323,13 @@ export function useWorkflowAction(
       filteredIssueList,
       filteredPullRequestTriageList,
     } = depsRef.current
+    // #1384 — capture the repo-frame depth at keystroke time, BEFORE any
+    // handler awaits. The invalidation helpers below run after the git /
+    // forge mutation resolves; frame-tagging their writes means a
+    // drill-in (or pop) that happens mid-mutation can't get its list
+    // cleared by the parent frame's completion — the write lands on the
+    // issuing frame, or silently drops if that frame was popped.
+    const issuedAtDepth = runtimes.length - 1
 
     // `worktreeDirty` is a pure derivation of the (already-threaded) whole
     // `context.worktree` — derived from the same live snapshot.
@@ -372,8 +389,11 @@ export function useWorkflowAction(
           }
         }
         return next
-      })
-      setContextStatus((current) => updateLogInkContextStatus(current, 'issueList', 'idle'))
+      }, issuedAtDepth)
+      setContextStatus(
+        (current) => updateLogInkContextStatus(current, 'issueList', 'idle'),
+        issuedAtDepth,
+      )
       clearGitHubListCache()
     }
     const invalidatePullRequestListCaches = (pullRequestNumber?: number): void => {
@@ -389,8 +409,11 @@ export function useWorkflowAction(
           }
         }
         return next
-      })
-      setContextStatus((current) => updateLogInkContextStatus(current, 'pullRequestList', 'idle'))
+      }, issuedAtDepth)
+      setContextStatus(
+        (current) => updateLogInkContextStatus(current, 'pullRequestList', 'idle'),
+        issuedAtDepth,
+      )
       clearGitHubListCache()
     }
 

--- a/src/workstation/runtime/loadMoreResolver.test.ts
+++ b/src/workstation/runtime/loadMoreResolver.test.ts
@@ -1,8 +1,11 @@
 import { LOG_INTERACTIVE_DEFAULT_LIMIT } from '../../commands/log/data'
 import {
   isCursorNearBottom,
+  isStaleFrameResolve,
+  isStaleLoadMoreCompletion,
   pageImpliesMore,
   shouldLoadMore,
+  type LoadMoreCompletionSnapshot,
   type LoadMoreGuardSnapshot,
 } from './loadMoreResolver'
 
@@ -70,5 +73,75 @@ describe('pageImpliesMore', () => {
   it('is false for a short page (end of history)', () => {
     expect(pageImpliesMore(LOG_INTERACTIVE_DEFAULT_LIMIT - 1)).toBe(false)
     expect(pageImpliesMore(0)).toBe(false)
+  })
+})
+
+// #1384 — frame-scoped stale-completion decisions. The history rows are
+// swapped in place on every repo-frame push / pop, so a resolve issued
+// in one frame must DROP when the stack changed mid-flight rather than
+// splice its rows into whichever frame is active now.
+describe('isStaleFrameResolve', () => {
+  it('accepts a resolve that lands in the frame that issued it', () => {
+    expect(
+      isStaleFrameResolve({ mounted: true, issuedAtDepth: 0, currentDepth: 0 }),
+    ).toBe(false)
+  })
+
+  it('drops after a drill-in (parent fetch resolving in the child frame)', () => {
+    expect(
+      isStaleFrameResolve({ mounted: true, issuedAtDepth: 0, currentDepth: 1 }),
+    ).toBe(true)
+  })
+
+  it('drops after a pop (child fetch resolving back in the parent frame)', () => {
+    expect(
+      isStaleFrameResolve({ mounted: true, issuedAtDepth: 1, currentDepth: 0 }),
+    ).toBe(true)
+  })
+
+  it('drops after unmount regardless of depth', () => {
+    expect(
+      isStaleFrameResolve({ mounted: false, issuedAtDepth: 0, currentDepth: 0 }),
+    ).toBe(true)
+  })
+})
+
+describe('isStaleLoadMoreCompletion', () => {
+  const fresh = (): LoadMoreCompletionSnapshot => ({
+    mounted: true,
+    requestId: 3,
+    currentRequestId: 3,
+    issuedAtDepth: 0,
+    currentDepth: 0,
+  })
+
+  it('accepts the completion of the current request in the issuing frame', () => {
+    expect(isStaleLoadMoreCompletion(fresh())).toBe(false)
+  })
+
+  it('drops after unmount', () => {
+    expect(isStaleLoadMoreCompletion({ ...fresh(), mounted: false })).toBe(true)
+  })
+
+  it('drops when a newer request superseded this one', () => {
+    expect(isStaleLoadMoreCompletion({ ...fresh(), currentRequestId: 4 })).toBe(true)
+  })
+
+  it('drops when the repo-frame depth changed mid-flight (drill-in)', () => {
+    expect(isStaleLoadMoreCompletion({ ...fresh(), currentDepth: 1 })).toBe(true)
+  })
+
+  it('drops a push → pop round trip back to the SAME depth via the rescoped request family', () => {
+    // The frame push and pop each bump the request family, so even
+    // though the depth matches again, the id no longer does.
+    expect(
+      isStaleLoadMoreCompletion({
+        ...fresh(),
+        issuedAtDepth: 0,
+        currentDepth: 0,
+        requestId: 3,
+        currentRequestId: 5,
+      }),
+    ).toBe(true)
   })
 })

--- a/src/workstation/runtime/loadMoreResolver.ts
+++ b/src/workstation/runtime/loadMoreResolver.ts
@@ -80,3 +80,66 @@ export function isCursorNearBottom(
 export function pageImpliesMore(pageCommitCount: number): boolean {
   return pageCommitCount >= LOG_INTERACTIVE_DEFAULT_LIMIT
 }
+
+/**
+ * The completion-time snapshot a frame-scoped history-row resolve checks
+ * before writing (#1384). `issuedAtDepth` is the repo-frame depth
+ * (`repoStack.length - 1`) captured when the fetch was dispatched;
+ * `currentDepth` is the live depth when it resolves.
+ */
+export type FrameScopedResolveSnapshot = {
+  /** Whether the component is still mounted (mirrors `mountedRef`). */
+  mounted: boolean
+  /** Repo-frame depth captured when the fetch was dispatched. */
+  issuedAtDepth: number
+  /** Live repo-frame depth at resolve time. */
+  currentDepth: number
+}
+
+/**
+ * Stale-completion decision for the frame-scoped row loaders
+ * (`loadCommitContext`, `refreshHistoryRows`) — #1384.
+ *
+ * The history ROWS live in the single reducer state and are swapped
+ * in place on every repo-frame push / pop (unlike the context, which
+ * is stored per frame and can be *routed* to the issuing frame via
+ * `setContext(next, targetDepth)`, the #994 pattern). A row write has
+ * no frame to route to — if the frame stack changed while the fetch
+ * was in flight, the only safe move is to DROP the resolve: an
+ * append / replace from the parent frame would splice parent-repo
+ * commits into the child frame's history (or vice versa after a pop).
+ */
+export function isStaleFrameResolve(snap: FrameScopedResolveSnapshot): boolean {
+  return !snap.mounted || snap.currentDepth !== snap.issuedAtDepth
+}
+
+/**
+ * The completion-time snapshot `loadMoreCommits` checks — the
+ * frame-scoped decision above plus the pre-existing monotonic
+ * request-id family (`loadMoreRequestRef`).
+ */
+export type LoadMoreCompletionSnapshot = FrameScopedResolveSnapshot & {
+  /** The request id this fetch was issued with. */
+  requestId: number
+  /** The live request id at resolve time (mirrors `loadMoreRequestRef`). */
+  currentRequestId: number
+}
+
+/**
+ * Stale-completion decision for the `loadMoreCommits` resolve (#1384).
+ *
+ * Three ways a completion goes stale:
+ *   1. the component unmounted;
+ *   2. the request-id family moved on — a newer page fetch was issued,
+ *      or a repo-frame push / pop rescoped the family (the runtime
+ *      bumps `loadMoreRequestRef` on every frame transition so a
+ *      pre-push fetch can never satisfy the guard post-push, even
+ *      after a push → pop round trip back to the SAME depth);
+ *   3. the repo-frame depth changed — belt-and-braces with (2) for
+ *      the render tick before the rescope bump lands.
+ */
+export function isStaleLoadMoreCompletion(snap: LoadMoreCompletionSnapshot): boolean {
+  if (!snap.mounted) return true
+  if (snap.currentRequestId !== snap.requestId) return true
+  return snap.currentDepth !== snap.issuedAtDepth
+}


### PR DESCRIPTION
## Problem

The history ROW loaders resolved into whichever repo frame was active. `loadMoreCommits` / `loadCommitContext` (`useLoadMoreHistory.ts`) and `refreshHistoryRows` / the boot loader (`app.ts`) guarded only on `mountedRef` plus their own request-id family, and nothing bumped or rescoped those guards on a repo-frame push/pop.

Concrete failure: scroll deep in parent history (auto page fetch in flight) → drill into a submodule (Enter on a submodule row) → child history loads → the parent's page resolves → `appendRows` splices ~100 parent-repo commits into the submodule frame's graph, and `setHasMoreCommits` is computed from the parent's count. The `#994` depth-capture fix protected the *context* loaders; the row loaders never got it.

Related residual (same shape, lower likelihood): the issue/PR triage preset-clear effects and the workflow-action `invalidateIssueListCaches` / `invalidatePullRequestListCaches` called `setContext` / `setContextStatus` with no `targetDepth`, so a triage mutation finishing after a drill-in cleared the *child* frame's list.

## Fix

Applies the existing `#994` discipline (depth captured at dispatch, stale writes dropped/routed) to the row loaders:

- **Frame-tag + drop for row writes** — rows live in the single reducer state and are swapped in place per frame, so unlike the per-frame context there is no slot to *route* a late write to; dropping is the only safe completion. `loadMoreCommits`, `loadCommitContext`, `refreshHistoryRows`, and the boot loader now capture the repo-stack depth at dispatch (via render-fresh snapshot refs / a new `repoFrameDepthRef`) and drop their resolve when the depth changed mid-flight.
- **Rescope the pagination request family on frame push/pop** — a new effect in `useLoadMoreHistory` bumps `loadMoreRequestRef` and resets `loadingMoreCommitsRef` / `loadingMoreCommits` on every repo-frame transition. This closes the push → pop round trip back to the *same* depth (depth alone can't distinguish it), and fixes the latent bug where a stale completion left `loadingMoreCommitsRef` stuck true, permanently disabling pagination in the new frame.
- **Frame-tag the triage invalidations** — the preset-clear effects in `app.ts` and the two invalidation helpers in `useWorkflowAction.ts` now pass the depth captured at issue time (keystroke time for the workflow helpers, before any handler awaits) as `targetDepth`, using the plumbing `setContext` / `setContextStatus` already have from `#994`. `runtimes` is threaded into `useWorkflowAction`'s deps bag for this.
- **Pure, tested drop decisions** — `isStaleFrameResolve` and `isStaleLoadMoreCompletion` live in `loadMoreResolver.ts` (the module that already holds this cluster's pure decisions) and are imported by the real code paths. Tests cover drill-in, pop, unmount, superseded request, and the same-depth push→pop round trip.

The two request-id-guarded refetch effects (history-filter and graph-toggle) were audited and are already safe: they re-key on `git` and bump their request refs on every frame transition.

## Validation

- `tsc --noEmit -p tsconfig.json` — clean
- eslint on all changed files — identical warning set to baseline (13 pre-existing `react-hooks/exhaustive-deps` warnings, 0 new)
- Full jest suite (`TZ=UTC NODE_OPTIONS=--experimental-vm-modules`) — 309 suites / 3997 tests passed, 0 failures

Fixes #1384