### PR TITLE
fix(workstation): expand tabs before truncation in diff and blame rows

### DIFF
--- a/src/workstation/chrome/text.test.ts
+++ b/src/workstation/chrome/text.test.ts
@@ -1,6 +1,37 @@
-import { cellWidth, truncateCells, truncatePathCells, wrapCells } from './text'
+import { cellWidth, expandTabs, truncateCells, truncatePathCells, wrapCells } from './text'
 
 describe('log Ink text helpers', () => {
+  describe('expandTabs (#1393)', () => {
+    it('expands tabs to the next fixed 8-column stop', () => {
+      expect(expandTabs('\ta')).toBe('        a')
+      expect(expandTabs('ab\tc')).toBe('ab      c')
+      expect(expandTabs('12345678\tx')).toBe('12345678        x')
+    })
+
+    it('tracks columns across multiple tabs and wide characters', () => {
+      // Two-cell CJK char advances the column by 2 before the tab.
+      expect(expandTabs('変\tx')).toBe('変      x')
+      expect(expandTabs('\t\tx')).toBe('                x')
+    })
+
+    it('honours startColumn for segment-wise expansion', () => {
+      // Continuing at column 6 → next stop is 8 → 2 spaces.
+      expect(expandTabs('\tx', 8, 6)).toBe('  x')
+    })
+
+    it('returns tab-free strings unchanged', () => {
+      const plain = 'no tabs here'
+      expect(expandTabs(plain)).toBe(plain)
+    })
+
+    it('makes tab-indented content measurable by cellWidth', () => {
+      // The overflow class: cellWidth saw 0 for the tab while the
+      // terminal advanced 8 cells.
+      expect(cellWidth('\tfoo')).toBe(3)
+      expect(cellWidth(expandTabs('\tfoo'))).toBe(11)
+    })
+  })
+
   it('measures wide and emoji characters by terminal cell width', () => {
     expect(cellWidth('abc')).toBe(3)
     expect(cellWidth('変更')).toBe(4)

--- a/src/workstation/chrome/text.ts
+++ b/src/workstation/chrome/text.ts
@@ -218,3 +218,34 @@ export function truncatePathCells(value: string, width: number): string {
   // elided, then ellipsis-truncates the filename.
   return truncateCells(`…/${filename}`, width)
 }
+
+/**
+ * Expand tab characters to spaces using fixed column stops (#1393).
+ *
+ * `cellWidth` counts control characters as 0 cells, but a terminal
+ * advances to the next tab stop per `\t` — so tab-indented content
+ * (Go, Makefiles) rendered rows that visually overran every truncation
+ * budget while "measuring" as fitting. Expanding at fixed stops from
+ * the string's own start is deliberately simpler than real terminal
+ * tab stops (which are column-relative to whatever gutters render
+ * before the content): the output is consistent and measurable, which
+ * is what the width math needs. `startColumn` lets segment-wise
+ * callers (syntax-highlighted diff spans) keep the column running
+ * across segments.
+ */
+export function expandTabs(value: string, tabWidth = 8, startColumn = 0): string {
+  if (!value.includes('\t')) return value
+  let out = ''
+  let column = startColumn
+  for (const character of value) {
+    if (character === '\t') {
+      const pad = tabWidth - (column % tabWidth)
+      out += ' '.repeat(pad)
+      column += pad
+      continue
+    }
+    out += character
+    column += characterWidth(character)
+  }
+  return out
+}

--- a/src/workstation/runtime/diffLineRender.ts
+++ b/src/workstation/runtime/diffLineRender.ts
@@ -10,7 +10,7 @@
  * (marker cell + truncated code) so columns never drift.
  */
 import type * as ReactTypes from 'react'
-import { cellWidth, truncateCells } from '../chrome/text'
+import { cellWidth, expandTabs, truncateCells } from '../chrome/text'
 import { resolveSyntaxColor } from '../chrome/syntaxColors'
 import type { LogInkTheme } from '../chrome/theme'
 import type { SyntaxSpan } from '../../lib/syntax/highlightEngine'
@@ -33,7 +33,10 @@ export function renderDiffLine(
 ): ReactTypes.ReactElement {
   const spans = line ? syntaxSpans?.get(line.slice(1)) : undefined
   if (!spans || spans.length === 0) {
-    return h(Text, { key, ...diffLineProps(line, theme) }, truncateCells(line, maxCells))
+    // Tabs expand BEFORE truncation (#1393) — cellWidth counts them as
+    // 0 cells while the terminal advances a full stop, so tab-indented
+    // rows overran the budget while "measuring" as fitting.
+    return h(Text, { key, ...diffLineProps(line, theme) }, truncateCells(expandTabs(line), maxCells))
   }
 
   const marker = line[0]
@@ -50,7 +53,10 @@ export function renderDiffLine(
   let used = 0
   for (const span of spans) {
     if (used >= budget) break
-    const segment = truncateCells(code.slice(span.start, span.end), budget - used)
+    // Expand tabs with the running column (#1393) so indentation-only
+    // spans consume their real terminal width before truncation.
+    const expanded = expandTabs(code.slice(span.start, span.end), 8, used)
+    const segment = truncateCells(expanded, budget - used)
     if (!segment) continue
     used += cellWidth(segment)
     children.push(

--- a/src/workstation/runtime/worktreeDiffBody.ts
+++ b/src/workstation/runtime/worktreeDiffBody.ts
@@ -18,7 +18,7 @@
  * unstaged — the same order `getWorktreeHunks` builds).
  */
 import type * as ReactTypes from 'react'
-import { truncateCells } from '../chrome/text'
+import { expandTabs, truncateCells } from '../chrome/text'
 import type { LogInkTheme } from '../chrome/theme'
 import type { WorktreeHunk } from '../../git/statusHunks'
 import type { SyntaxSpan } from '../../lib/syntax/highlightEngine'
@@ -85,7 +85,7 @@ export function renderWorktreeDiffBody(
         h(Text, { color: accent }, bar),
         h(Text, { color: badgeColor, bold: isSelected }, badge),
         h(Text, { bold: isSelected, color: isSelected ? accent : (theme.noColor ? undefined : theme.colors.muted) },
-          truncateCells(line, codeWidth))
+          truncateCells(expandTabs(line), codeWidth))
       )
     }
 
@@ -94,7 +94,7 @@ export function renderWorktreeDiffBody(
     // focus); the selected hunk and unstaged hunks keep full diff +
     // syntax coloring via renderDiffLine so the focus stays vivid.
     const content = isStaged && !isSelected && hunkIndex >= 0
-      ? h(Text, { key: `${key}-c`, dimColor: true }, truncateCells(line, codeWidth))
+      ? h(Text, { key: `${key}-c`, dimColor: true }, truncateCells(expandTabs(line), codeWidth))
       : renderDiffLine(h, Text, line, theme, syntaxSpans, codeWidth, `${key}-c`)
 
     return h(Box, { key, flexDirection: 'row' },

--- a/src/workstation/surfaces/blame/index.ts
+++ b/src/workstation/surfaces/blame/index.ts
@@ -18,7 +18,7 @@
 
 import type * as ReactTypes from 'react'
 import { formatLogInkBlameEmpty, formatLogInkLoading } from '../../chrome/surfaceStates'
-import { cellWidth, truncateCells } from '../../chrome/text'
+import { expandTabs, cellWidth, truncateCells } from '../../chrome/text'
 import type { BlameResult } from '../../../git/blameData'
 import type { SurfaceRenderContext } from '../../runtime/types'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
@@ -99,7 +99,9 @@ export function renderBlameSurface(
         // dimmed span so the source content reads at full contrast.
         const gutter = `${cursor} ${line.shortHash} ${author} ${lineNo} `
         const contentWidth = Math.max(8, width - 4 - cellWidth(gutter))
-        const content = truncateCells(line.content, contentWidth)
+        // Tabs expand before truncation (#1393) — Go/Makefile blame
+        // rows overran the panel while "measuring" as fitting.
+        const content = truncateCells(expandTabs(line.content), contentWidth)
         return h(Text, {
           key: `blame-${index}`,
           bold: isSelected,


### PR DESCRIPTION
Fixes #1393.

## Problem

`cellWidth` (chrome/text.ts) counts codepoints < 32 as zero cells — but the terminal advances to the next 8-column tab stop per `\t`, and nothing expanded tabs upstream: blame content keeps the source line's own tabs (`blameData` strips only the porcelain tab), and diff lines pass through untouched. A Go/Makefile blame or diff rendered rows that visually overran their budget (misaligned rows bleeding past the panel border), and truncation couldn't see the width the tabs consume — "fitting" lines didn't fit.

## Fix

New `expandTabs(value, tabWidth = 8, startColumn = 0)` in `chrome/text.ts`: fixed column stops tracked with real cell widths (wide chars advance 2). Fixed stops from the string's own start are deliberately simpler than true terminal tab stops (which are column-relative to whatever gutters render first) — the output is consistent and measurable, which is what the width math needs.

Applied at the three render paths:
- `renderDiffLine` — the plain path expands the whole line; the syntax-highlighted path expands each span segment with the running column (`startColumn`), so indentation-only spans consume their real width before truncation.
- `worktreeDiffBody` — the two direct truncations (hunk header row, dimmed staged rows).
- blame surface — the content column after the gutter.

Unit tests for the helper (stops, wide chars, startColumn, the cellWidth-vs-terminal divergence) ride along.

## Validation
- `tsc --noEmit` clean, `eslint` clean
- Full jest suite green: 309 suites / 3993 tests, snapshots unchanged