### PR TITLE
fix(workstation): guard overlapping async operations against last-resolve-wins races

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -57,7 +57,8 @@ import {getBranchOverview} from '../../git/branchData'
 import {getLfsAttributeStatus} from '../../git/lfsAttributes'
 import {getSubmoduleOverview} from '../../git/submoduleData'
 import {getRemoteOverview} from '../../git/remoteData'
-import {LOG_INTERACTIVE_DEFAULT_LIMIT, buildToggleGraphArgs, getCommitRows, getLogRows} from '../../commands/log/data'
+import {LOG_INTERACTIVE_DEFAULT_LIMIT, getCommitRows, getLogRows} from '../../commands/log/data'
+import {buildHistoryRefetchArgv, resolveHistoryRefetch} from './historyRefetchResolver'
 import {LogInkContextKey, createLogInkContextStatus, updateLogInkContextStatus} from '../chrome/context'
 import {createLogInkTheme, type LogInkThemePreset} from '../chrome/theme'
 import {saveThemePreset} from '../chrome/themePersistence'
@@ -694,12 +695,19 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       // a late `replaceRows` would swap that repo's commits into
       // whichever frame is active now.
       const issuedAtDepth = repoFrameDepthRef.current
+      // Same single-source argv derivation as the merged history
+      // refetch effect (#1385) — graph mode AND server-side filter —
+      // so a post-operation refresh can never swap in rows fetched
+      // with a different topology than the one on screen. The bare
+      // fetch-args fallback preserves the old behavior for callers
+      // that mounted without a logArgv (non-interactive embeds).
       const fetchArgs = state.historyFetchArgs
-      const mergedArgv: LogArgv = {
-        ...logArgv,
-        ...(fetchArgs?.author ? { author: fetchArgs.author } : {}),
-        ...(fetchArgs?.path ? { path: fetchArgs.path } : {}),
-      } as LogArgv
+      const mergedArgv: LogArgv = logArgv
+        ? buildHistoryRefetchArgv(logArgv, state.fullGraph, fetchArgs)
+        : ({
+            ...(fetchArgs?.author ? { author: fetchArgs.author } : {}),
+            ...(fetchArgs?.path ? { path: fetchArgs.path } : {}),
+          } as LogArgv)
       // Stash commits as graph roots so post-operation refreshes
       // keep the same rich graph the boot loader assembled. Without
       // this, every commit / split-apply / etc. would drop stash
@@ -725,7 +733,19 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         setHasMoreCommits(computeHasMoreCommits(logArgv, fresh))
       }
     } catch { /* ignore — stale rows beat blank rows */ }
-  }, [dispatch, git, logArgv, setHasMoreCommits, state.historyFetchArgs])
+  }, [dispatch, git, logArgv, setHasMoreCommits, state.historyFetchArgs, state.fullGraph])
+
+  // #1385 — per-frame monotonic request ids for the two context
+  // refreshers below. Frame-tagging (#994) pins each refresh's WRITE to
+  // the frame it was issued from, but nothing sequenced two overlapping
+  // refreshes on the SAME frame: a watcher-triggered silent refresh and
+  // a manual `r` could resolve out of order, and the earlier-started
+  // 13-way Promise.all batch — resolving last — replaced the fresher
+  // context wholesale (e.g. a deleted branch reappearing until the next
+  // event). Each call claims the next id for its frame before awaiting
+  // and drops its resolve if a newer claim exists by the time it lands.
+  const refreshContextRequestRef = React.useRef<Record<number, number>>({})
+  const refreshWorktreeRequestRef = React.useRef<Record<number, number>>({})
 
   const refreshContext = React.useCallback(async (options: { silent?: boolean } = {}) => {
     // Loud refresh (manual `r`): flip everything to 'loading' so the user
@@ -742,11 +762,19 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     // parent frame (the one whose `git` was used for the fetch),
     // not on the freshly-pushed submodule frame.
     const issuedAtDepth = runtimes.length - 1
+    const requestId = (refreshContextRequestRef.current[issuedAtDepth] ?? 0) + 1
+    refreshContextRequestRef.current[issuedAtDepth] = requestId
     if (!options.silent) {
       dispatch({ type: 'setStatus', value: 'refreshing repository context' })
       setContextStatus(createLogInkContextStatus('loading'), issuedAtDepth)
     }
     const next = await loadLogInkContext(git)
+    // #1385 — a newer refresh was issued for this frame while ours was
+    // in flight; its snapshot is fresher than ours, so drop this one
+    // (the newer request owns the 'ready' flip and the status line).
+    if (refreshContextRequestRef.current[issuedAtDepth] !== requestId) {
+      return
+    }
     setContext(next, issuedAtDepth)
     setContextStatus(createLogInkContextStatus('ready'), issuedAtDepth)
     if (!options.silent) {
@@ -758,6 +786,9 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     // #994 — same frame-tagging as refreshContext above. Worktree
     // loads are usually fast but still race-prone on slow disks.
     const issuedAtDepth = runtimes.length - 1
+    // #1385 — same per-frame sequencing as refreshContext above.
+    const requestId = (refreshWorktreeRequestRef.current[issuedAtDepth] ?? 0) + 1
+    refreshWorktreeRequestRef.current[issuedAtDepth] = requestId
     if (!options.silent) {
       setContextStatus(
         (current) => updateLogInkContextStatus(current, 'worktree', 'loading'),
@@ -765,6 +796,16 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       )
     }
     const worktree = await safe(getWorktreeOverview(git))
+
+    // #1385 — a newer worktree refresh was issued for this frame while
+    // ours was in flight. Skip the context write (the newer request's
+    // snapshot is fresher) but still return OUR overview: callers await
+    // this function for the result of the refresh they themselves
+    // issued, and that contract holds regardless of who writes the
+    // shared context.
+    if (refreshWorktreeRequestRef.current[issuedAtDepth] !== requestId) {
+      return worktree
+    }
 
     setContext(
       (current) => ({
@@ -1450,124 +1491,78 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     loadCommitContextRef,
   })
 
-  // Server-side history filter (#776). When the user submits `path:foo`
-  // or `author:foo`, the filter parser dispatches setHistoryFetchArgs;
-  // this effect picks up the change, re-runs `getLogRows` with merged
-  // args, and replaces the rows. Clearing the fetch args (Ctrl+U inside
-  // filter mode) re-fetches with the original logArgv so the user gets
-  // the live full log back, not a stale snapshot of the initial rows.
-  const historyFetchEffectInitialized = React.useRef(false)
-  const historyFetchRequestRef = React.useRef(0)
+  // Merged history refetch (#1385): server-side filter (#776), graph
+  // mode toggle (`g`, #791 follow-up), and repo-frame switches all
+  // funnel through ONE effect.
+  //
+  // These used to be two sibling effects — one keyed on
+  // `state.historyFetchArgs`, one on `state.fullGraph` — both listing
+  // the active frame's `git` with mount-consumed first-run-skip refs.
+  // Every drill-in/out therefore ran BOTH bodies: two concurrent
+  // `getLogRows` calls whose argv genuinely diverged (the filter fetch
+  // ignored `fullGraph`; the graph fetch ignored the filter), and
+  // whichever resolved last decided — nondeterministically — whether
+  // the frame showed full/compact and filtered/unfiltered rows, plus
+  // contradictory status lines. One effect means one merged argv
+  // (`buildHistoryRefetchArgv` consults BOTH dimensions) and one
+  // request id, so a superseded fetch always drops. The prev-value ref
+  // exists only to pick the right status copy (`resolveHistoryRefetch`)
+  // — filter submit, graph toggle, or frame switch.
+  const historyRefetchInitialized = React.useRef(false)
+  const historyRefetchRequestRef = React.useRef(0)
+  const historyRefetchPrevRef = React.useRef<{
+    fullGraph: boolean
+    fetchArgs: LogInkState['historyFetchArgs']
+  } | undefined>(undefined)
   React.useEffect(() => {
     if (!logArgv) return
+    const prev = historyRefetchPrevRef.current
+    historyRefetchPrevRef.current = {
+      fullGraph: state.fullGraph,
+      fetchArgs: state.historyFetchArgs,
+    }
     // Skip the first run — initial rows came in via deps.rows; we only
-    // want to fetch in response to *changes* to historyFetchArgs.
-    if (!historyFetchEffectInitialized.current) {
-      historyFetchEffectInitialized.current = true
+    // want to fetch in response to *changes*.
+    if (!historyRefetchInitialized.current) {
+      historyRefetchInitialized.current = true
       return
     }
 
-    const requestId = historyFetchRequestRef.current + 1
-    historyFetchRequestRef.current = requestId
-    const fetchArgs = state.historyFetchArgs
-    const merged: LogArgv = {
-      ...logArgv,
-      ...(fetchArgs?.author ? { author: fetchArgs.author } : {}),
-      ...(fetchArgs?.path ? { path: fetchArgs.path } : {}),
-    }
-    const description = fetchArgs?.author
-      ? `author:${fetchArgs.author}`
-      : fetchArgs?.path
-        ? `path:${fetchArgs.path}`
-        : undefined
-
-    dispatch({
-      type: 'setStatus',
-      value: description ? `Refetching with ${description}` : 'Restoring full log',
+    const requestId = historyRefetchRequestRef.current + 1
+    historyRefetchRequestRef.current = requestId
+    const plan = resolveHistoryRefetch({
+      logArgv,
+      fullGraph: state.fullGraph,
+      fetchArgs: state.historyFetchArgs,
+      fetchArgsChanged: prev !== undefined && prev.fetchArgs !== state.historyFetchArgs,
+      fullGraphChanged: prev !== undefined && prev.fullGraph !== state.fullGraph,
     })
 
+    dispatch({ type: 'setStatus', value: plan.pendingStatus })
+
     void (async () => {
+      // Include stash commits as graph roots so the re-fetch sees the
+      // same rich graph the boot loader assembles. Without this, any
+      // refetch would lose the stash anchors that loadRowsWithStashes
+      // seeded on boot.
       const stashHashes = await getStashCommitHashes(git).catch(() => [])
-      const nextRows = await safe(getLogRows(git, merged, {
+      const nextRows = await safe(getLogRows(git, plan.argv, {
         limit: LOG_INTERACTIVE_DEFAULT_LIMIT,
         extraRefs: stashHashes,
       }))
-      if (!mountedRef.current || historyFetchRequestRef.current !== requestId) {
+      if (!mountedRef.current || historyRefetchRequestRef.current !== requestId) {
         return
       }
       if (!nextRows) {
-        dispatch({ type: 'setStatus', value: 'Failed to refetch with active filter', kind: 'error' })
+        dispatch({ type: 'setStatus', value: plan.errorStatus, kind: 'error' })
         return
       }
       dispatch({ type: 'replaceRows', rows: nextRows })
       const matched = getCommitRows(nextRows).length
       setHasMoreCommits(matched >= LOG_INTERACTIVE_DEFAULT_LIMIT)
-      dispatch({
-        type: 'setStatus',
-        value: description
-          ? `Showing ${matched} commits matching ${description}`
-          : 'Showing full log',
-        kind: 'success',
-      })
+      dispatch({ type: 'setStatus', value: plan.successStatus(matched), kind: 'success' })
     })()
-  }, [dispatch, git, logArgv, state.historyFetchArgs])
-
-  // Graph mode toggle (`g` key, #791 follow-up). The header label flips
-  // between "compact graph" and "full graph", but unless we re-fetch with
-  // the right `view`, the underlying rows still come from the user's
-  // initial argv (default `--first-parent --no-merges`) and the renderer
-  // has no topology to draw — defeating the per-lane / junction work.
-  // Mirrors the historyFetchArgs effect: skip first run, request-id ref
-  // for stale-completion guard, swap rows in place via replaceRows.
-  const toggleGraphEffectInitialized = React.useRef(false)
-  const toggleGraphRequestRef = React.useRef(0)
-  React.useEffect(() => {
-    if (!logArgv) return
-    if (!toggleGraphEffectInitialized.current) {
-      toggleGraphEffectInitialized.current = true
-      return
-    }
-
-    const requestId = toggleGraphRequestRef.current + 1
-    toggleGraphRequestRef.current = requestId
-    const merged = buildToggleGraphArgs(logArgv, state.fullGraph)
-
-    dispatch({
-      type: 'setStatus',
-      value: state.fullGraph
-        ? 'Loading full topology…'
-        : 'Loading compact history…',
-    })
-
-    void (async () => {
-      // Include stash commits as graph roots so the toggle's re-fetch
-      // sees the same rich graph the boot loader assembles. Without
-      // this, flipping `\` into full mode and back loses the stash
-      // anchors that loadRowsWithStashes seeded on boot.
-      const stashHashes = await getStashCommitHashes(git).catch(() => [])
-      const nextRows = await safe(getLogRows(git, merged, {
-        limit: LOG_INTERACTIVE_DEFAULT_LIMIT,
-        extraRefs: stashHashes,
-      }))
-      if (!mountedRef.current || toggleGraphRequestRef.current !== requestId) {
-        return
-      }
-      if (!nextRows) {
-        dispatch({ type: 'setStatus', value: 'Failed to refetch graph rows', kind: 'error' })
-        return
-      }
-      dispatch({ type: 'replaceRows', rows: nextRows })
-      const matched = getCommitRows(nextRows).length
-      setHasMoreCommits(matched >= LOG_INTERACTIVE_DEFAULT_LIMIT)
-      dispatch({
-        type: 'setStatus',
-        value: state.fullGraph
-          ? `Showing ${matched} commits across all branches`
-          : `Showing ${matched} commits (compact)`,
-        kind: 'success',
-      })
-    })()
-  }, [dispatch, git, logArgv, state.fullGraph])
+  }, [dispatch, git, logArgv, state.historyFetchArgs, state.fullGraph])
 
   const commitDiffHunkOffsets = React.useMemo(() => (
     filePreview?.hunks

--- a/src/workstation/runtime/historyRefetchResolver.test.ts
+++ b/src/workstation/runtime/historyRefetchResolver.test.ts
@@ -1,0 +1,144 @@
+import type { LogArgv } from '../../commands/log/config'
+import {
+  buildHistoryRefetchArgv,
+  resolveHistoryRefetch,
+} from './historyRefetchResolver'
+
+const argv = (over: Partial<LogArgv> = {}): LogArgv =>
+  ({
+    $0: 'coco',
+    _: ['log'],
+    interactive: true,
+    ...over,
+  }) as LogArgv
+
+describe('buildHistoryRefetchArgv', () => {
+  it('applies the full-graph view AND the server-side filter in one argv', () => {
+    const merged = buildHistoryRefetchArgv(argv(), true, { author: 'alice' })
+
+    expect(merged.view).toBe('full')
+    expect(merged.author).toBe('alice')
+  })
+
+  it('keeps the active filter when deriving the compact view (old graph effect dropped it)', () => {
+    const merged = buildHistoryRefetchArgv(argv(), false, { path: 'src/' })
+
+    expect(merged.view).toBe('compact')
+    expect(merged.path).toBe('src/')
+  })
+
+  it('keeps the graph mode when the filter clears (old filter effect dropped it)', () => {
+    const merged = buildHistoryRefetchArgv(argv({ view: 'compact' }), false, undefined)
+
+    expect(merged.view).toBe('compact')
+    expect(merged.author).toBeUndefined()
+    expect(merged.path).toBeUndefined()
+  })
+
+  it('preserves the base argv path when no path filter is active', () => {
+    const merged = buildHistoryRefetchArgv(argv({ path: 'docs/' }), true, { author: 'bob' })
+
+    expect(merged.path).toBe('docs/')
+    expect(merged.author).toBe('bob')
+  })
+})
+
+describe('resolveHistoryRefetch', () => {
+  it('uses the filter copy when the fetch args changed (author)', () => {
+    const plan = resolveHistoryRefetch({
+      logArgv: argv(),
+      fullGraph: true,
+      fetchArgs: { author: 'alice' },
+      fetchArgsChanged: true,
+      fullGraphChanged: false,
+    })
+
+    expect(plan.trigger).toBe('filter')
+    expect(plan.pendingStatus).toBe('Refetching with author:alice')
+    expect(plan.errorStatus).toBe('Failed to refetch with active filter')
+    expect(plan.successStatus(12)).toBe('Showing 12 commits matching author:alice')
+  })
+
+  it('uses the restore copy when the fetch args cleared', () => {
+    const plan = resolveHistoryRefetch({
+      logArgv: argv(),
+      fullGraph: true,
+      fetchArgs: undefined,
+      fetchArgsChanged: true,
+      fullGraphChanged: false,
+    })
+
+    expect(plan.trigger).toBe('filter')
+    expect(plan.pendingStatus).toBe('Restoring full log')
+    expect(plan.successStatus(40)).toBe('Showing full log')
+  })
+
+  it('uses the graph copy when only fullGraph changed', () => {
+    const full = resolveHistoryRefetch({
+      logArgv: argv(),
+      fullGraph: true,
+      fetchArgs: undefined,
+      fetchArgsChanged: false,
+      fullGraphChanged: true,
+    })
+    expect(full.trigger).toBe('graph')
+    expect(full.pendingStatus).toBe('Loading full topology…')
+    expect(full.errorStatus).toBe('Failed to refetch graph rows')
+    expect(full.successStatus(7)).toBe('Showing 7 commits across all branches')
+
+    const compact = resolveHistoryRefetch({
+      logArgv: argv(),
+      fullGraph: false,
+      fetchArgs: undefined,
+      fetchArgsChanged: false,
+      fullGraphChanged: true,
+    })
+    expect(compact.pendingStatus).toBe('Loading compact history…')
+    expect(compact.successStatus(7)).toBe('Showing 7 commits (compact)')
+  })
+
+  it('treats a run where neither input changed as a repo-frame switch', () => {
+    const plan = resolveHistoryRefetch({
+      logArgv: argv(),
+      fullGraph: true,
+      fetchArgs: undefined,
+      fetchArgsChanged: false,
+      fullGraphChanged: false,
+    })
+
+    expect(plan.trigger).toBe('frame')
+    expect(plan.pendingStatus).toBe('Loading history…')
+    expect(plan.errorStatus).toBe('Failed to load history')
+    expect(plan.successStatus(30)).toBe('Showing 30 commits')
+  })
+
+  it('a filter change wins the copy when both inputs changed', () => {
+    const plan = resolveHistoryRefetch({
+      logArgv: argv(),
+      fullGraph: false,
+      fetchArgs: { path: 'src/' },
+      fetchArgsChanged: true,
+      fullGraphChanged: true,
+    })
+
+    expect(plan.trigger).toBe('filter')
+    // The argv still honors BOTH dimensions regardless of the copy.
+    expect(plan.argv.view).toBe('compact')
+    expect(plan.argv.path).toBe('src/')
+  })
+
+  it('always derives the argv from the merged picture, whatever the trigger', () => {
+    const plan = resolveHistoryRefetch({
+      logArgv: argv(),
+      fullGraph: true,
+      fetchArgs: { author: 'alice' },
+      fetchArgsChanged: false,
+      fullGraphChanged: false,
+    })
+
+    // Frame-switch refetch keeps the live filter AND the graph mode.
+    expect(plan.trigger).toBe('frame')
+    expect(plan.argv.view).toBe('full')
+    expect(plan.argv.author).toBe('alice')
+  })
+})

--- a/src/workstation/runtime/historyRefetchResolver.ts
+++ b/src/workstation/runtime/historyRefetchResolver.ts
@@ -1,0 +1,142 @@
+import type { LogArgv } from '../../commands/log/config'
+import { buildToggleGraphArgs } from '../../commands/log/data'
+import type { LogInkHistoryFetchArgs } from './inkViewModel'
+
+/**
+ * Pure decision logic for the merged history-refetch effect (#1385).
+ *
+ * The workstation used to run TWO sibling effects against the history
+ * rows: one keyed on `state.historyFetchArgs` (server-side `author:` /
+ * `path:` filters, #776) and one keyed on `state.fullGraph` (the `g`
+ * graph toggle, #791 follow-up). Both listed the active frame's `git`
+ * in their dependency arrays with mount-consumed first-run-skip refs,
+ * so every repo-frame drill-in/out re-ran BOTH bodies — two concurrent
+ * `getLogRows` calls whose argv genuinely diverged (the filter fetch
+ * ignored `fullGraph`; the graph fetch ignored the filter), with
+ * whichever resolved last deciding what the frame showed.
+ *
+ * This module owns the two decisions the merged effect needs, so they
+ * can be unit tested without driving the full runtime (same pattern as
+ * `loadMoreResolver` / `cursorSyncResolver`):
+ *
+ *   - `buildHistoryRefetchArgv` — derive ONE argv from the full
+ *     (logArgv, fullGraph, fetchArgs) picture, so a graph toggle keeps
+ *     the active filter and a filter submit keeps the graph mode.
+ *
+ *   - `resolveHistoryRefetch` — pick the status copy for the fetch
+ *     based on WHICH input changed (filter submit, graph toggle, or a
+ *     repo-frame switch), preserving the per-trigger wording the two
+ *     original effects used.
+ *
+ * The async plumbing (stash-hash collection, the fetch itself, the
+ * request-id stale guard, dispatches) stays in `app.ts`.
+ */
+
+/** What caused the refetch — decides the status-line copy. */
+export type HistoryRefetchTrigger = 'filter' | 'graph' | 'frame'
+
+export type HistoryRefetchInput = {
+  /** The boot log argv (the merge base every refetch starts from). */
+  logArgv: LogArgv
+  /** Current graph mode (`state.fullGraph`). */
+  fullGraph: boolean
+  /** Current server-side filter (`state.historyFetchArgs`), if any. */
+  fetchArgs: LogInkHistoryFetchArgs | undefined
+  /** Whether `state.historyFetchArgs` changed since the last effect run. */
+  fetchArgsChanged: boolean
+  /** Whether `state.fullGraph` changed since the last effect run. */
+  fullGraphChanged: boolean
+}
+
+export type HistoryRefetchPlan = {
+  /** The single merged argv the fetch must use. */
+  argv: LogArgv
+  trigger: HistoryRefetchTrigger
+  /** Status line shown while the fetch is in flight. */
+  pendingStatus: string
+  /** Status line shown when the fetch fails. */
+  errorStatus: string
+  /** Status line shown on success, given the fetched commit count. */
+  successStatus: (matched: number) => string
+}
+
+/**
+ * Derive the single merged argv for a history refetch: graph mode
+ * first (`buildToggleGraphArgs` maps `fullGraph` onto `view`), then
+ * the server-side filter overlay. Both the filter submit and the
+ * graph toggle now consult the OTHER dimension's current state, so
+ * concurrent triggers can never produce divergent fetches.
+ */
+export function buildHistoryRefetchArgv(
+  logArgv: LogArgv,
+  fullGraph: boolean,
+  fetchArgs: LogInkHistoryFetchArgs | undefined,
+): LogArgv {
+  return {
+    ...buildToggleGraphArgs(logArgv, fullGraph),
+    ...(fetchArgs?.author ? { author: fetchArgs.author } : {}),
+    ...(fetchArgs?.path ? { path: fetchArgs.path } : {}),
+  }
+}
+
+/**
+ * Human description of the active server-side filter — `author:foo` /
+ * `path:bar` — or undefined when no filter is active. Mirrors the copy
+ * the original filter effect produced.
+ */
+function describeFetchArgs(fetchArgs: LogInkHistoryFetchArgs | undefined): string | undefined {
+  if (fetchArgs?.author) return `author:${fetchArgs.author}`
+  if (fetchArgs?.path) return `path:${fetchArgs.path}`
+  return undefined
+}
+
+/**
+ * Build the full refetch plan: merged argv + trigger-appropriate
+ * status copy.
+ *
+ * Trigger precedence: a filter change wins over a graph change (both
+ * changing in one pass is not reachable from single keystrokes, but a
+ * deterministic answer beats an arbitrary one), and a run where
+ * neither changed can only mean the effect re-fired because the
+ * active frame's `git` / `logArgv` changed — a repo-frame switch,
+ * which gets neutral "loading history" copy instead of the two
+ * contradictory status lines the old twin effects raced onto the
+ * status bar.
+ */
+export function resolveHistoryRefetch(input: HistoryRefetchInput): HistoryRefetchPlan {
+  const { logArgv, fullGraph, fetchArgs, fetchArgsChanged, fullGraphChanged } = input
+  const argv = buildHistoryRefetchArgv(logArgv, fullGraph, fetchArgs)
+
+  if (fetchArgsChanged) {
+    const description = describeFetchArgs(fetchArgs)
+    return {
+      argv,
+      trigger: 'filter',
+      pendingStatus: description ? `Refetching with ${description}` : 'Restoring full log',
+      errorStatus: 'Failed to refetch with active filter',
+      successStatus: (matched) =>
+        description ? `Showing ${matched} commits matching ${description}` : 'Showing full log',
+    }
+  }
+
+  if (fullGraphChanged) {
+    return {
+      argv,
+      trigger: 'graph',
+      pendingStatus: fullGraph ? 'Loading full topology…' : 'Loading compact history…',
+      errorStatus: 'Failed to refetch graph rows',
+      successStatus: (matched) =>
+        fullGraph
+          ? `Showing ${matched} commits across all branches`
+          : `Showing ${matched} commits (compact)`,
+    }
+  }
+
+  return {
+    argv,
+    trigger: 'frame',
+    pendingStatus: 'Loading history…',
+    errorStatus: 'Failed to load history',
+    successStatus: (matched) => `Showing ${matched} commits`,
+  }
+}

--- a/src/workstation/runtime/hooks/useWorkflowAction.test.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.test.ts
@@ -207,6 +207,70 @@ describe('push/pull failure recovery (#1356)', () => {
   })
 })
 
+describe('overlapping invocations do not clear each other\'s loaders (#1385)', () => {
+  it('an earlier-finishing remote op leaves a later op\'s loader in place', async () => {
+    // A = pull (starts first, finishes first), B = push (starts while A
+    // is in flight, finishes last). Before the ownership guard, A's
+    // finally unconditionally dispatched `setRemoteOp undefined` and
+    // killed B's loader while B's git call was still running.
+    let resolvePull: (value: { ok: boolean; message: string }) => void = () => undefined
+    pullCurrentBranchMock.mockReset()
+    pullCurrentBranchMock.mockImplementation(
+      () => new Promise((resolve) => { resolvePull = resolve })
+    )
+    let resolvePush: (value: { ok: boolean; message: string }) => void = () => undefined
+    pushBranchMock.mockReset()
+    pushBranchMock.mockImplementation(
+      () => new Promise((resolve) => { resolvePush = resolve })
+    )
+
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      context: { branches: { localBranches: [localBranch], currentBranch: 'main' } } as never,
+    }))
+
+    const remoteOpClears = () =>
+      dispatch.mock.calls.filter(
+        ([action]) => action.type === 'setRemoteOp' && action.value === undefined
+      )
+
+    // A starts: pull loader installed, handler pending.
+    const pullRun = runWorkflowAction('pull-current-branch')
+    // B starts mid-A: push loader replaces the pull loader.
+    const pushRun = runWorkflowAction('push-selected-branch')
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'setRemoteOp',
+      value: expect.objectContaining({ kind: 'push' }),
+    })
+
+    // A finishes while B is still in flight — its finally must NOT
+    // clear the loader B installed.
+    resolvePull({ ok: true, message: 'Pulled main from origin' })
+    await pullRun
+    expect(remoteOpClears()).toHaveLength(0)
+
+    // B finishes — as the latest claim it clears the loader exactly once.
+    resolvePush({ ok: true, message: 'Pushed main to origin' })
+    await pushRun
+    expect(remoteOpClears()).toHaveLength(1)
+  })
+
+  it('a solo invocation still clears its own loader (no overlap)', async () => {
+    pullCurrentBranchMock.mockReset()
+    pullCurrentBranchMock.mockResolvedValue({ ok: true, message: 'Pulled main from origin' })
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({ dispatch }))
+
+    await runWorkflowAction('pull-current-branch')
+    expect(dispatch).toHaveBeenCalledWith({ type: 'setRemoteOp', value: undefined })
+  })
+})
+
 describe('result status carries the outcome kind (#1349)', () => {
   it('a failing handler dispatches statusKind error', async () => {
     pullCurrentBranchMock.mockResolvedValue({

--- a/src/workstation/runtime/hooks/useWorkflowAction.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.ts
@@ -301,6 +301,20 @@ export function useWorkflowAction(
   // commit's parent to rebase from.
   const lastFixupTargetRef = React.useRef<{ hash: string; shortHash: string; message: string } | null>(null)
 
+  // Ownership tokens for the shared loader state (#1385). Workflow
+  // keystrokes stay live while a remote op runs, so two invocations can
+  // overlap — e.g. `F` (fetch) then `p` (push) mid-fetch. Without a
+  // guard, the fetch's `finally` unconditionally dispatched
+  // `setRemoteOp undefined` and killed the push's loader while the push
+  // was still running (and likewise for the per-row pending spinner).
+  // Each invocation that installs a loader claims the next token; the
+  // `finally` clears the loader only when its claim is still the latest
+  // — i.e. no later invocation has installed its own loader since. Same
+  // identity-check-before-cleanup shape as the AbortController guard in
+  // `useChangelogActions`' finally.
+  const remoteOpClaimRef = React.useRef(0)
+  const pendingItemActionClaimRef = React.useRef(0)
+
   const runWorkflowAction = React.useCallback(async (id: string, payload?: string) => {
     // Resolve the live snapshot first — every name below shadows what the
     // old closure captured, keeping the ~1,200-line body byte-identical.
@@ -1438,7 +1452,9 @@ export function useWorkflowAction(
     // hands straight off to the freshly-fetched rows instead of
     // flashing the stale list for a frame in between.
     const remoteOp = REMOTE_OP_LOADERS[id]
+    let remoteOpClaim = 0
     if (remoteOp) {
+      remoteOpClaim = ++remoteOpClaimRef.current
       dispatch({ type: 'setRemoteOp', value: remoteOp })
     }
     // Mark the cursored row as busy so it shows an inline pending
@@ -1448,7 +1464,9 @@ export function useWorkflowAction(
     // with the new current branch, and a failure (e.g. an unmerged
     // branch) restores the row's normal icon alongside the error status.
     const pendingItemAction = resolvePendingItemAction(id, state, context)
+    let pendingItemActionClaim = 0
     if (pendingItemAction) {
+      pendingItemActionClaim = ++pendingItemActionClaimRef.current
       dispatch({ type: 'setPendingItemAction', value: pendingItemAction })
     }
     try {
@@ -1742,14 +1760,18 @@ export function useWorkflowAction(
     } finally {
       // Always clear the loader — even if a refresh threw — so a
       // failed fetch/pull can't leave the history surface stuck behind
-      // the spinner.
-      if (remoteOp) {
+      // the spinner. Ownership check (#1385): only clear when OUR claim
+      // is still the latest — a later overlapping invocation that
+      // installed its own loader now owns the clear, and yanking it
+      // out from under that still-running op killed its loader early.
+      if (remoteOp && remoteOpClaimRef.current === remoteOpClaim) {
         dispatch({ type: 'setRemoteOp', value: undefined })
       }
       // Same guarantee for the per-row pending spinner (delete or
       // checkout): clear it whether the action succeeded, failed, or the
-      // refresh threw, so no row is left spinning forever.
-      if (pendingItemAction) {
+      // refresh threw, so no row is left spinning forever — with the
+      // same #1385 ownership check.
+      if (pendingItemAction && pendingItemActionClaimRef.current === pendingItemActionClaim) {
         dispatch({ type: 'setPendingItemAction', value: undefined })
       }
     }


### PR DESCRIPTION
## Problem

Three related last-resolve-wins races from the async code-review sweep, all mechanisms detailed in #1385:

1. **Double, divergent history fetch on every repo-frame switch.** The server-side filter effect (`state.historyFetchArgs`) and the graph-toggle effect (`state.fullGraph`) in `app.ts` both listed the active frame's `git` in deps with mount-consumed first-run-skip refs. Every drill-in/out ran BOTH bodies: two concurrent `getLogRows` calls whose argv genuinely diverged — the filter fetch ignored `fullGraph`, the graph fetch ignored the filter. Whichever resolved last decided whether the frame showed full/compact and filtered/unfiltered rows, nondeterministically, plus contradictory status lines.
2. **No request sequencing on `refreshContext` / `refreshWorktreeContext`.** Frame-tagged (#994) but not versioned: a watcher-triggered silent refresh overlapping a manual `r` could resolve out of order, and the earlier-started 13-way `Promise.all` batch — resolving last — replaced the fresher context wholesale (deleted branch reappearing until the next event).
3. **Overlapping `runWorkflowAction` invocations cleared each other's loaders.** The `finally` block unconditionally dispatched `setRemoteOp` / `setPendingItemAction` `undefined`, so `F` (fetch) then `p` (push) mid-fetch killed the push's loader when the fetch settled.

## Fix

1. **One merged history-refetch effect** replaces the twins. A new pure helper module `historyRefetchResolver.ts` (same pattern as `loadMoreResolver` / `cursorSyncResolver`) owns the decisions:
   - `buildHistoryRefetchArgv` derives ONE argv from the full `(logArgv, fullGraph, fetchArgs)` picture — a graph toggle keeps the active filter, a filter submit keeps the graph mode, and a frame switch fetches with both.
   - `resolveHistoryRefetch` picks the per-trigger status copy (filter submit / graph toggle / repo-frame switch), preserving the original wording for the first two and giving frame switches neutral "Loading history…" copy instead of two racing status lines.
   - The single effect keeps the first-run-skip and now shares ONE request id, so a superseded fetch always drops.
   - `refreshHistoryRows` adopts the same argv derivation so post-operation refreshes can't swap in rows fetched with a different topology than the one on screen.
2. **Per-frame monotonic request ids** for `refreshContext` / `refreshWorktreeContext`: each call claims the next id for its frame before awaiting and drops its resolve when a newer claim exists. `refreshWorktreeContext` still returns its own fetched overview when stale (callers await the result of the refresh *they* issued); it just skips the shared context write.
3. **Ownership tokens for the workflow loaders**: each `runWorkflowAction` invocation that installs `remoteOp` / `pendingItemAction` claims a monotonic token; the `finally` clears the loader only while its claim is still the latest — the same identity-check-before-cleanup shape as `useChangelogActions`' AbortController guard.

## Validation

- `tsc --noEmit -p tsconfig.json` clean.
- ESLint on all changed files: 0 errors, 8 pre-existing `react-hooks/exhaustive-deps` warnings (baseline on main is 9 — merging the two effects removed one).
- Full jest suite (`TZ=UTC NODE_OPTIONS=--experimental-vm-modules`): 3999 passed, 1 failed — the known-flaky `refreshWatcher.test.ts` rename-survival test under parallel load, which passes in isolation (confirmed).
- New unit tests: `historyRefetchResolver.test.ts` (merged-argv derivation + per-trigger copy) and two `useWorkflowAction.test.ts` cases (an earlier-finishing remote op leaves a later op's loader in place; a solo invocation still clears its own).

Fixes #1385
