### PR TITLE
fix(workstation): count conditional rows in the branches/stash/status/history budgets

### DIFF
--- a/src/workstation/surfaces/branches/index.ts
+++ b/src/workstation/surfaces/branches/index.ts
@@ -46,7 +46,13 @@ export function renderBranchesSurface(ctx: SurfaceRenderContext, spinnerFrame: n
     )
     : sortedAll
   const selected = Math.max(0, Math.min(state.selectedBranchIndex, Math.max(0, localBranches.length - 1)))
-  const listRows = Math.max(4, bodyRows - 4)
+  // Row budget (#1392): the base reserve (borders + title + one spare)
+  // must also count the conditional rows, or the panel grows past its
+  // box mid-scroll — the filter affordance while filtering, and BOTH
+  // scroll indicators once the list overflows the window (the single
+  // spare absorbed only one of them).
+  const baseRows = Math.max(4, bodyRows - 4 - (state.filterMode ? 1 : 0))
+  const listRows = localBranches.length > baseRows ? Math.max(4, baseRows - 1) : baseRows
   const startIndex = clampListWindowStart(selected, localBranches.length, listRows)
   const visible = localBranches.slice(startIndex, startIndex + listRows)
   const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -667,7 +667,16 @@ export function renderHistoryPanel(
   // breaks down and the dividers would read as noise.
   const fullGraphSpacing = state.fullGraph && !state.filter
   const dateBucketingNow = !dateBucketingEnabled || state.filter ? undefined : now
-  const chromeRows = showPendingRow ? 5 : 4
+  // Hoisted so the row budget can count the banner (#1392) — it used
+  // to be computed inline in the return, invisible to chromeRows.
+  const currentBranchRef = context.branches?.localBranches.find((branch) => branch.current)
+  const upstreamBanner = formatUpstreamAheadBanner(currentBranchRef, { ascii: theme.ascii })
+  // Conditional single-line chrome must be budgeted (#1392): with the
+  // upstream-ahead banner and the path:/author: fetch indicator both
+  // showing, the panel grew past its box and pushed the footer down.
+  const chromeRows = (showPendingRow ? 5 : 4)
+    + (upstreamBanner ? 1 : 0)
+    + (state.historyFetchArgs ? 1 : 0)
   const listRows = rowMode === 'stacked'
     ? Math.max(2, Math.floor((bodyRows - chromeRows) / 2))
     : Math.max(3, bodyRows - chromeRows)
@@ -710,15 +719,12 @@ export function renderHistoryPanel(
   // Two wording variants (behind-only vs diverged) live in the
   // helper; render is identical aside from the formatted string.
   // Warning yellow = same semantic as the remote-tracking chip kind.
-  ...((() => {
-    const currentBranchRef = context.branches?.localBranches.find((branch) => branch.current)
-    const banner = formatUpstreamAheadBanner(currentBranchRef, { ascii: theme.ascii })
-    if (!banner) return []
-    return [h(Text, {
+  ...(upstreamBanner
+    ? [h(Text, {
       key: 'upstream-ahead-banner',
       color: theme.noColor ? undefined : theme.colors.warning,
-    }, banner)]
-  })()),
+    }, upstreamBanner)]
+    : []),
   // Server-side filter indicator (#776). Only rendered when the user
   // has an active path:/author: prefix; clears when they Ctrl+U.
   ...(state.historyFetchArgs

--- a/src/workstation/surfaces/stash/index.ts
+++ b/src/workstation/surfaces/stash/index.ts
@@ -47,8 +47,12 @@ export function renderStashSurface(ctx: SurfaceRenderContext, spinnerFrame: numb
     : allStashes
   const selected = Math.max(0, Math.min(state.selectedStashIndex, Math.max(0, stashes.length - 1)))
   // One extra row reserved (vs the other surfaces' `- 4`) for the column
-  // header row below.
-  const listRows = Math.max(4, bodyRows - 5)
+  // header row below. Conditional rows are counted too (#1392): the
+  // filter affordance while filtering, and one more for the second
+  // scroll indicator once the list overflows the window (the base
+  // spare absorbed only one of the two).
+  const baseRows = Math.max(4, bodyRows - 5 - (state.filterMode ? 1 : 0))
+  const listRows = stashes.length > baseRows ? Math.max(4, baseRows - 1) : baseRows
   const startIndex = clampListWindowStart(selected, stashes.length, listRows)
   const visible = stashes.slice(startIndex, startIndex + listRows)
   const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''

--- a/src/workstation/surfaces/status/index.ts
+++ b/src/workstation/surfaces/status/index.ts
@@ -78,7 +78,14 @@ export function renderStatusSurface(ctx: SurfaceRenderContext): ReactTypes.React
   // same file across all three (renderer / input / workflow handlers).
   const visibleGroups = groupWorktreeFiles(visibleFiles)
   const surfaceRows = buildStatusSurfaceRows(visibleGroups)
-  const listRows = Math.max(4, bodyRows - 5)
+  // Row budget (#1392): the base reserve covers borders + title + the
+  // two scroll indicators, but the 1/2/3 mask indicator row (rendered
+  // only when the mask is narrowed) must be counted too — with all
+  // three showing the panel grew one row past its box.
+  const listRows = Math.max(
+    4,
+    bodyRows - 5 - (isStatusFilterMaskActive(state.statusFilterMask) ? 1 : 0)
+  )
   // Row budget = the panel interior (border 2 + paddingX 2), NOT a
   // hardcoded 140 (#1390): a monorepo path longer than the panel used
   // to wrap, shifting the windowed list and pushing the panel past


### PR DESCRIPTION
Fixes #1392. The same defect class #1347 fixed for the workspace panel, residual in four workstation surfaces.

## Problem

Each surface reserved fixed chrome plus at most one spare row, but the conditional single-line rows weren't budgeted. Mid-scroll, **both** `↑ N more above` / `↓ N more below` indicators render (2 rows into a 0-1 row spare); the promoted-filter affordance adds one while filtering; status adds the 1/2/3 mask-indicator row when narrowed; history adds the upstream-ahead banner and the `path:/author:` fetch indicator. Whenever the cursor sat mid-list (or the banners coexisted), the panel rendered 1-2 rows past its box — the app body has no overflow clipping, so the bottom border and footer were pushed down.

## Fix

- **branches / stash**: subtract the filter-affordance row while filtering, and one more row once the list overflows the window (only then can both indicators show). At the very top/bottom of an overflowing list one row under-fills — preferred over overflowing.
- **status**: count the mask-indicator row when the mask is narrowed (the base reserve already carried two spares for the indicators).
- **history**: hoist the upstream-ahead banner computation out of the render inline (it was invisible to `chromeRows`) and count it plus the fetch-indicator row.

## Validation
- `tsc --noEmit` clean, `eslint` clean
- Full jest suite green: 309 suites / 3988 tests, snapshots unchanged