### PR TITLE
fix(workstation): width-responsive author/branch columns in PR triage

### DIFF
--- a/src/workstation/surfaces/pullRequestTriage/index.ts
+++ b/src/workstation/surfaces/pullRequestTriage/index.ts
@@ -170,12 +170,27 @@ export function renderPullRequestTriageSurface(ctx: SurfaceRenderContext): React
         6,
         Math.max(...windowed.map((p) => `#${p.number}`.length), 3)
       )
+      // Width-responsive column caps (#1391). The fixed caps (16
+      // author + 24 branch) plus the other columns totalled ~68 cells
+      // while the main panel interior is ~50-64 at common terminal
+      // widths — every row with a long author/branch wrapped, double-
+      // lining the whole list. Author and branch now shrink first:
+      // the interior minus the immovable columns (cursor, number,
+      // state, merge/review glyphs, inter-column gaps) splits between
+      // a title reserve and the author/branch pair.
+      const interior = Math.max(20, width - 4)
+      const immovable = 22 + numberColWidth
+      const remaining = Math.max(0, interior - immovable)
+      const titleReserve = Math.max(12, Math.floor(remaining * 0.45))
+      const authorBranchBudget = Math.max(10, remaining - titleReserve)
+      const authorCap = Math.max(4, Math.min(16, Math.floor(authorBranchBudget * 0.4)))
+      const branchCap = Math.max(6, Math.min(24, authorBranchBudget - authorCap))
       const authorColWidth = Math.min(
-        16,
+        authorCap,
         Math.max(...windowed.map((p) => (p.author || '').length), 4)
       )
       const branchColWidth = Math.min(
-        24,
+        branchCap,
         Math.max(...windowed.map((p) => p.headRefName.length), 6)
       )
 


### PR DESCRIPTION
Fixes #1391.

## Problem

The PR-triage row's fixed prefix — cursor (2) + number (≤6+2) + state (6+2) + merge glyph (1+2) + review glyph (1+2) + author (≤16+2) + branch (≤24+2) — totals ~68 cells, and `available = Math.max(8, …)` then guarantees ≥8 more cells of title. The main panel interior is ~50–64 cells at 100–130-col terminals, so with long authors/branch names **every row wrapped**, double-lining the list and breaking the windowed cursor math for everything below. (The issues surface's ~36-cell prefix is fine and is untouched.)

## Fix

Author/branch caps now derive from the panel width: immovable columns (cursor, number, state, glyphs, gaps) come off the interior, a title reserve (45% of the remainder, ≥12) is held back, and the author/branch pair splits the rest 40/60 — still bounded by the old 16/24 maxima on wide terminals, and still shrink-to-content via the existing per-window max. Title/label budgeting is unchanged (it already measures the real rendered prefix with `cellWidth`), so the title automatically absorbs whatever the narrower columns free up.

At 80 cols (interior 76): columns fit with ~21 cells of title. At a 120-col three-pane layout (interior ~64): author 8 + branch 12 + title ~16 — no wraps.

## Validation
- `tsc --noEmit` clean, `eslint` clean
- Full jest suite green: 309 suites / 3988 tests, snapshots unchanged