### PR TITLE
feat(workstation): discoverability polish — help filter, view-first help, momentum hints, idle tips default-on

### DIFF
--- a/src/workstation/KEYMAP.md
+++ b/src/workstation/KEYMAP.md
@@ -77,7 +77,7 @@ Available in every view (unless an overlay/mode has claimed the keyboard):
 |-----|--------|
 | `q` | Quit |
 | `Ctrl+C` | Quit (hard) |
-| `?` | Toggle help overlay (full categorized help) |
+| `?` | Toggle help overlay (full categorized help; "This view" section first, `/` type-to-filter inside, two-stage Esc clears the filter then closes) |
 | `:` | Command palette |
 | `/` | Enter filter mode |
 | `g` | Chord prefix (see below) |

--- a/src/workstation/chrome/postApplyHints.ts
+++ b/src/workstation/chrome/postApplyHints.ts
@@ -103,3 +103,11 @@ export function formatSplitApplySuccess(
   }
   return `${navCue}${tail}`
 }
+
+/**
+ * Momentum suffix for a successful manual commit (#1355). The moment a
+ * commit lands is exactly when "push it" and "see it in history" are
+ * the next moves — an unadorned "Created abc123" reads as a dead end.
+ * Concatenated onto the success message, not a standalone sentence.
+ */
+export const COMMIT_MOMENTUM_HINT = ' — P push · gh history'

--- a/src/workstation/runtime/hooks/useCommitComposeActions.ts
+++ b/src/workstation/runtime/hooks/useCommitComposeActions.ts
@@ -48,6 +48,7 @@ import { tmpdir } from 'node:os'
 import * as nodePath from 'node:path'
 import type { LogInkAction } from '../inkViewModel'
 import type { LogInkContext } from '../types'
+import { COMMIT_MOMENTUM_HINT } from '../../chrome/postApplyHints'
 import type { CommitComposeState } from '../../../commands/log/commitCompose'
 import { createManualCommit, formatCommitComposeMessage } from '../../../commands/log/commitCompose'
 import type { WorktreeOverview } from '../../../git/statusData'
@@ -114,7 +115,14 @@ export function useCommitComposeActions(
       type: 'commitCompose',
       action: { type: 'setResult', message: result.message, details: result.details },
     })
-    dispatch({ type: 'setStatus', value: result.message })
+    // Momentum hint (#1355): a landed commit's natural next moves are
+    // push and history — say so at the moment it matters. Outcome-
+    // colored per the #1349 convention.
+    dispatch({
+      type: 'setStatus',
+      value: result.ok ? `${result.message}${COMMIT_MOMENTUM_HINT}` : result.message,
+      kind: result.ok ? 'success' : 'error',
+    })
 
     if (result.ok) {
       dispatch({ type: 'commitCompose', action: { type: 'reset' } })

--- a/src/workstation/runtime/hooks/useWorkflowAction.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.ts
@@ -159,6 +159,33 @@ const REMOTE_OP_LOADERS: Record<string, RemoteOpState> = {
  * Returns `undefined` for non-delete workflows (and when nothing is
  * selected), which the runner treats as "no pending marker".
  */
+/**
+ * Workflow ids whose SUCCESS rewrote local history — the moments where
+ * advertising the reflog time machine actually matters (#1355). The
+ * shared result dispatch appends `gr reflog to recover` for these.
+ * Deliberately excludes ref-only moves (checkout, fetch/pull/push) and
+ * additive commits: recovery hints on operations nobody regrets are
+ * noise.
+ */
+const HISTORY_REWRITE_WORKFLOW_IDS = new Set([
+  'reset-hard-to-commit',
+  'reset-soft-to-commit',
+  'reset-mixed-to-commit',
+  'cherry-pick-commit',
+  'revert-commit',
+  'fixup-into-commit',
+  'autosquash-rebase',
+  'interactive-rebase-to-commit',
+  'execute-rebase-plan',
+  'rebase-onto-branch',
+  'amend-head',
+  'reword-head',
+])
+
+export function isHistoryRewriteWorkflow(id: string): boolean {
+  return HISTORY_REWRITE_WORKFLOW_IDS.has(id)
+}
+
 export function resolvePendingItemAction(
   id: string,
   state: LogInkState,
@@ -1478,9 +1505,14 @@ export function useWorkflowAction(
     // Handlers that return no result (pure-navigation ones) keep the
     // neutral info treatment. Recovery escalations below may follow up
     // with their own prompt/warning on top of the error status.
+    // Momentum hint (#1355): after a history rewrite lands, advertise
+    // the reflog time machine AT the moment it matters — recovery
+    // exists but was never surfaced when the user might want it.
+    const historyRewriteHint =
+      result?.ok && isHistoryRewriteWorkflow(id) ? ' · gr reflog to recover' : ''
     dispatch({
       type: 'setStatus',
-      value: result?.message || 'Workflow action complete',
+      value: `${result?.message || 'Workflow action complete'}${historyRewriteHint}`,
       kind: result ? (result.ok ? 'success' : 'error') : undefined,
     })
     // A safe `delete-branch` (`git branch -d`) refuses branches that

--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -1806,6 +1806,50 @@ describe('log Ink input interactions', () => {
       expect(state.repoStack).toHaveLength(2)
     })
 
+    it('help type-to-filter: / opens, typing narrows, Enter keeps, Esc is two-stage (#1355)', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'toggleHelp' })
+
+      // `/` enters filter mode; printable keys append.
+      state = applyInput(state, '/', {})
+      expect(state.helpFilterMode).toBe(true)
+      state = applyInput(state, 's', {})
+      state = applyInput(state, 't', {})
+      expect(state.helpFilter).toBe('st')
+
+      // j must append while filtering, not scroll.
+      state = applyInput(state, 'j', {})
+      expect(state.helpFilter).toBe('stj')
+      expect(state.helpScrollOffset).toBe(0)
+      state = applyInput(state, '', { backspace: true })
+      expect(state.helpFilter).toBe('st')
+
+      // Enter keeps the filter, returns j/k to scrolling.
+      state = applyInput(state, '', { return: true })
+      expect(state.helpFilterMode).toBe(false)
+      expect(state.helpFilter).toBe('st')
+      state = applyInput(state, 'j', {})
+      expect(state.helpScrollOffset).toBe(1)
+
+      // Two-stage Esc: first clears the committed filter, second closes.
+      state = applyInput(state, '', { escape: true })
+      expect(state.helpFilter).toBe('')
+      expect(state.showHelp).toBe(true)
+      state = applyInput(state, '', { escape: true })
+      expect(state.showHelp).toBe(false)
+    })
+
+    it('reopening help starts with a clean filter (#1355)', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'toggleHelp' })
+      state = applyInput(state, '/', {})
+      state = applyInput(state, 'x', {})
+      state = applyLogInkAction(state, { type: 'toggleHelp' })
+      state = applyLogInkAction(state, { type: 'toggleHelp' })
+      expect(state.helpFilter).toBe('')
+      expect(state.helpFilterMode).toBe(false)
+    })
+
     describe('submodules-view drill-in (PR 4 / #932)', () => {
       function submodulesViewState() {
         return createLogInkState(rows, {

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -1717,7 +1717,34 @@ export function getLogInkInputEvents(
   // `return []` so a stray keypress can't drop the user into the
   // wrong surface.
   if (state.showHelp) {
+    // Type-to-filter (#1355) — `/` opens a text input that narrows the
+    // 30+ binding rows. While it owns the keyboard, printable keys
+    // append; Enter keeps the filter and returns j/k to scrolling;
+    // Esc clears (mirrors the palette's two-stage Esc).
+    if (state.helpFilterMode) {
+      if (key.escape) {
+        return [action({ type: 'clearHelpFilter' })]
+      }
+      if (key.return) {
+        return [action({ type: 'commitHelpFilter' })]
+      }
+      if (key.backspace || key.delete) {
+        return [action({ type: 'backspaceHelpFilter' })]
+      }
+      if (inputValue && !key.ctrl && !key.meta) {
+        return [action({ type: 'appendHelpFilter', value: inputValue })]
+      }
+      return []
+    }
+    if (inputValue === '/') {
+      return [action({ type: 'openHelpFilter' })]
+    }
     if (key.escape || inputValue === '?') {
+      // Two-stage Esc: a committed filter clears first, then the
+      // overlay closes — same contract as the command palette.
+      if (key.escape && state.helpFilter) {
+        return [action({ type: 'clearHelpFilter' })]
+      }
       return [action({ type: 'toggleHelp' })]
     }
     if (inputValue === 'q') {

--- a/src/workstation/runtime/inkKeymap.test.ts
+++ b/src/workstation/runtime/inkKeymap.test.ts
@@ -301,7 +301,9 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: true,
     })).toEqual({
-      contextual: ['? close', 'tab focus', '/ search'],
+      // Honest help footer (#1355): every advertised key is live in
+      // the help handler; / opens the overlay's type-to-filter.
+      contextual: ['? close', '/ filter', 'j/k scroll'],
       global: ['q quit'],
     })
 
@@ -316,22 +318,23 @@ describe('log Ink keymap', () => {
     })
   })
 
-  it('groups help into Global and the active view', () => {
+  it('groups help into the active view (leading, #1355) and Global', () => {
     const sections = getLogInkHelpSections({ activeView: 'history', focus: 'commits' })
 
+    // "This view" leads: ? answers "what can I do HERE" first.
     expect(sections.map((section) => section.title)).toEqual([
-      'Global',
       'This view (history)',
+      'Global',
     ])
 
-    const globals = sections[0].bindings.map((binding) => binding.id)
+    const globals = sections[1].bindings.map((binding) => binding.id)
     expect(globals).toContain('help')
     expect(globals).toContain('commandPalette')
     expect(globals).toContain('quit')
     expect(globals).toContain('focusNext')
     expect(globals).not.toContain('moveUp')
 
-    const viewBindings = sections[1].bindings.map((binding) => binding.id)
+    const viewBindings = sections[0].bindings.map((binding) => binding.id)
     expect(viewBindings).toContain('moveUp')
     expect(viewBindings).toContain('search')
     expect(viewBindings).toContain('toggleGraph')
@@ -341,10 +344,10 @@ describe('log Ink keymap', () => {
 
   it('renders the help label with the active view', () => {
     const status = getLogInkHelpSections({ activeView: 'status', focus: 'commits' })
-    expect(status[1].title).toBe('This view (status)')
+    expect(status[0].title).toBe('This view (status)')
 
     const diff = getLogInkHelpSections({ activeView: 'diff', focus: 'detail' })
-    expect(diff[1].title).toBe('This view (diff)')
+    expect(diff[0].title).toBe('This view (diff)')
   })
 
   it('still derives bindings from the shared keymap', () => {
@@ -447,17 +450,17 @@ describe('log Ink keymap', () => {
 
   it('exposes the gc compose chord as a global navigation binding', () => {
     const sections = getLogInkHelpSections({ activeView: 'history', focus: 'commits' })
-    const globalIds = sections[0].bindings.map((binding) => binding.id)
+    const globalIds = sections[1].bindings.map((binding) => binding.id)
 
     expect(globalIds).toContain('navigateCompose')
 
-    const composeBinding = sections[0].bindings.find((binding) => binding.id === 'navigateCompose')
+    const composeBinding = sections[1].bindings.find((binding) => binding.id === 'navigateCompose')
     expect(composeBinding?.keys).toEqual(['gc'])
   })
 
   it('exposes the gb/gt/gz chords as global navigation bindings', () => {
     const sections = getLogInkHelpSections({ activeView: 'history', focus: 'commits' })
-    const globals = sections[0].bindings
+    const globals = sections[1].bindings
 
     const branches = globals.find((binding) => binding.id === 'navigateBranches')
     const tags = globals.find((binding) => binding.id === 'navigateTags')

--- a/src/workstation/runtime/inkKeymap.ts
+++ b/src/workstation/runtime/inkKeymap.ts
@@ -1142,8 +1142,12 @@ function computeLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogInkF
   }
 
   if (options.showHelp) {
+    // Every key here is live inside the help handler — the old set
+    // advertised `tab focus` and `/ search` while the handler
+    // swallowed both ("a footer that lies about a key is a bug",
+    // #1355). `/` is now true: it opens the overlay's type-to-filter.
     return {
-      contextual: ['? close', 'tab focus', '/ search'],
+      contextual: ['? close', '/ filter', 'j/k scroll'],
       global: ['q quit'],
     }
   }
@@ -1516,16 +1520,18 @@ export function getLogInkHelpSections(
     !GLOBAL_BINDING_IDS.includes(binding.id) && bindingMatchesViewContext(binding, options)
   )
 
+  // "This view" leads (#1355): users press `?` to answer "what can I
+  // do HERE" — the global set is reference material, not the answer.
   return [
-    {
-      title: 'Global',
-      bindings: globals,
-      subgroups: buildSubgroups(globals, true),
-    },
     {
       title: `This view (${options.activeView})`,
       bindings: viewBindings,
       subgroups: buildSubgroups(viewBindings, false),
+    },
+    {
+      title: 'Global',
+      bindings: globals,
+      subgroups: buildSubgroups(globals, true),
     },
   ]
 }

--- a/src/workstation/runtime/inkRuntime.ts
+++ b/src/workstation/runtime/inkRuntime.ts
@@ -36,10 +36,12 @@ type LogInkStreams = {
 type LogInkOptions = {
   appLabel?: string
   /**
-   * P4.3 — opt-in idle tip rotation. Forwarded from `logTui.idleTips` in the
-   * user's config. The runtime starts a tip cycle when `state.statusMessage`
-   * is empty for >10s; the tip lives in the footer's status slot until the
-   * next user action sets a real message.
+   * Idle tip rotation, ON by default (#1355 — it was opt-in, so the
+   * audience who needed it never saw it). Forwarded from
+   * `logTui.idleTips` in the user's config; set `false` to opt out.
+   * The runtime starts a tip cycle when `state.statusMessage` is empty
+   * for >10s; the tip lives in the footer's status slot until the next
+   * user action sets a real message.
    */
   idleTips?: boolean
   /**
@@ -121,7 +123,10 @@ export async function startInkInteractiveLog(
   const app = React.createElement(LogInkApp, {
     appLabel: options.appLabel || 'coco log',
     git,
-    idleTipsEnabled: Boolean(options.idleTips),
+    // Default-ON (#1355): the tip rotation is activity-suppressed with
+    // a grace period, and the audience who needs it never finds an
+    // opt-in. `logTui.idleTips: false` remains the opt-out.
+    idleTipsEnabled: options.idleTips !== false,
     // Resolve undefined → true so the default flips on automatically.
     // An explicit `false` from config opts out.
     dateBucketingEnabled: options.dateBucketing !== false,

--- a/src/workstation/runtime/inkViewModel.ts
+++ b/src/workstation/runtime/inkViewModel.ts
@@ -472,6 +472,19 @@ export type LogInkState = {
    */
   helpScrollOffset: number
   /**
+   * Type-to-filter query for the help overlay (#1355). Narrows the
+   * 30+ binding rows by key / label / description. Cleared whenever
+   * the overlay opens or closes.
+   */
+  helpFilter: string
+  /**
+   * True while the help overlay's filter input owns the keyboard
+   * (opened with `/`). While set, printable keys append to
+   * `helpFilter` instead of scrolling; Enter keeps the filter and
+   * returns to scroll keys; Esc clears it.
+   */
+  helpFilterMode: boolean
+  /**
    * Which-key view-keys strip (#1137). When true, the detail panel shows a
    * compact list of the single-key actions available in the current view,
    * sourced from `LOG_INK_KEY_BINDINGS`. Opened by the `g?` chord; the
@@ -1099,6 +1112,11 @@ export type LogInkAction =
   | { type: 'toggleGraph' }
   | { type: 'toggleHelp' }
   | { type: 'scrollHelp'; delta: number }
+  | { type: 'openHelpFilter' }
+  | { type: 'appendHelpFilter'; value: string }
+  | { type: 'backspaceHelpFilter' }
+  | { type: 'commitHelpFilter' }
+  | { type: 'clearHelpFilter' }
   | { type: 'toggleViewKeys' }
   | { type: 'toggleCommandPalette' }
   | { type: 'toggleThemePicker' }
@@ -1865,6 +1883,8 @@ export function createLogInkState(
     fullGraph: options.fullGraph ?? true,
     showHelp: false,
     helpScrollOffset: 0,
+    helpFilter: '',
+    helpFilterMode: false,
     showViewKeys: false,
     showCommandPalette: false,
     workflowActionId: undefined,
@@ -2729,6 +2749,8 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         showCommandPalette: false,
         showHelp: false,
         helpScrollOffset: 0,
+        helpFilter: '',
+        helpFilterMode: false,
         showViewKeys: false,
         pendingKey: undefined,
       }
@@ -2747,6 +2769,8 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         // next open always starts at the top — feels more predictable
         // than picking up where the user last scrolled.
         helpScrollOffset: 0,
+        helpFilter: '',
+        helpFilterMode: false,
         showCommandPalette: false,
         // Opening full help supersedes the compact view-keys strip — this
         // is the progressive-disclosure step (`?` from the strip expands
@@ -2763,6 +2787,8 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         // overlays; opening it closes anything else that was showing.
         showHelp: false,
         helpScrollOffset: 0,
+        helpFilter: '',
+        helpFilterMode: false,
         showCommandPalette: false,
         pendingKey: undefined,
       }
@@ -2775,6 +2801,19 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         ...state,
         helpScrollOffset: Math.max(0, state.helpScrollOffset + action.delta),
       }
+    case 'openHelpFilter':
+      return { ...state, helpFilterMode: true }
+    case 'appendHelpFilter':
+      // Typing narrows from the top — reset the scroll so the first
+      // match is visible instead of whatever row the user had reached.
+      return { ...state, helpFilter: state.helpFilter + action.value, helpScrollOffset: 0 }
+    case 'backspaceHelpFilter':
+      return { ...state, helpFilter: state.helpFilter.slice(0, -1), helpScrollOffset: 0 }
+    case 'commitHelpFilter':
+      // Enter keeps the narrowed list but returns j/k to scrolling.
+      return { ...state, helpFilterMode: false }
+    case 'clearHelpFilter':
+      return { ...state, helpFilter: '', helpFilterMode: false, helpScrollOffset: 0 }
     case 'toggleCommandPalette': {
       const opening = !state.showCommandPalette
       return {
@@ -2782,6 +2821,8 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         showCommandPalette: opening,
         showHelp: false,
         helpScrollOffset: 0,
+        helpFilter: '',
+        helpFilterMode: false,
         showViewKeys: false,
         // Reset palette interaction state on every open/close so the next
         // session starts from a clean slate.

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -422,10 +422,31 @@ export function renderHelpPanel(
     focus: state.focus,
   })
 
+  // Type-to-filter (#1355): narrow rows by key / label / description,
+  // case-insensitive substring. Subgroups and sections that filter to
+  // empty drop out entirely so matches aren't buried under headings.
+  const helpQuery = state.helpFilter.trim().toLowerCase()
+  const bindingMatches = (binding: (typeof sections)[number]['bindings'][number]): boolean => {
+    if (!helpQuery) return true
+    return (
+      formatBindingKeys(binding).toLowerCase().includes(helpQuery) ||
+      binding.label.toLowerCase().includes(helpQuery) ||
+      binding.description.toLowerCase().includes(helpQuery)
+    )
+  }
+
+  let matchedAny = false
   for (const section of sections) {
+    const subgroups = section.subgroups
+      .map((subgroup) => ({ ...subgroup, bindings: subgroup.bindings.filter(bindingMatches) }))
+      .filter((subgroup) => subgroup.bindings.length > 0)
+    if (subgroups.length === 0) {
+      continue
+    }
+    matchedAny = true
     body.push(h(Text, { key: `${section.title}-spacer` }, ''))
     body.push(h(Text, { bold: true, key: section.title }, section.title))
-    section.subgroups.forEach((subgroup, subgroupIndex) => {
+    subgroups.forEach((subgroup, subgroupIndex) => {
       // Dim subgroup heading; first subgroup follows the section
       // title directly so we skip the leading spacer to keep the
       // visual hierarchy tight (section title → subgroup → bindings).
@@ -443,13 +464,18 @@ export function renderHelpPanel(
       })
     })
   }
+  if (!matchedAny && helpQuery) {
+    body.push(h(Text, { key: 'help-no-match', dimColor: true },
+      `No bindings match "${state.helpFilter}" — esc clears the filter.`))
+  }
 
   // Reserve rows for: title (1), border (2), padding (0). The "more
   // above" / "more below" hints take 1 row each when present and are
   // accounted for inside the window calculation below. When no
   // bodyRows is provided, fall back to rendering everything (legacy
   // path; tests pass undefined).
-  const titleAndChromeRows = 3
+  const filterRow = state.helpFilterMode || state.helpFilter ? 1 : 0
+  const titleAndChromeRows = 3 + filterRow
   const visibleRows = bodyRows > 0
     ? Math.max(4, bodyRows - titleAndChromeRows)
     : body.length
@@ -463,6 +489,13 @@ export function renderHelpPanel(
   const children: ReactTypes.ReactNode[] = [
     h(Text, { bold: true, key: 'title' }, panelTitle('Help', focused)),
   ]
+  // Filter input line (#1355). Rendered while typing (cursor shown)
+  // and while a committed filter narrows the list, so the narrowing is
+  // never invisible.
+  if (state.helpFilterMode || state.helpFilter) {
+    children.push(h(Text, { key: 'help-filter' },
+      `filter: ${state.helpFilter}${state.helpFilterMode ? '_' : ''}`))
+  }
 
   // Visual hint that there's content scrolled above. The dim style
   // matches the rest of the chrome's "metadata" voice and avoids


### PR DESCRIPTION
Closes #1355. Four small discoverability items from the interaction-design audit, first feature PR of the 0.78 cycle.

## 1. The help footer stops lying — and `/` becomes real

With help open the footer advertised `tab focus` and `/ search`; the handler swallowed both. Per the issue's suggestion, `/` now opens a **type-to-filter** over the 30+ binding rows: printable keys narrow by key/label/description (empty subgroups and sections drop out), Enter keeps the filter and returns `j/k` to scrolling, Esc is two-stage (clear filter → close) matching the palette contract. The footer reads `? close · / filter · j/k scroll` — every key live.

## 2. "This view" leads the help overlay

`?` answers "what can I do *here*" — the view section now renders before Global.

## 3. Momentum hints beyond split-apply

- A landed commit appends `— P push · gh history` (and commit results are outcome-colored per the #1349 convention — they previously rendered as neutral info).
- Every successful history-rewrite workflow (soft/mixed/hard reset, cherry-pick, revert, fixup, autosquash, rebase-onto, interactive rebase, execute-rebase-plan, amend, reword) appends `· gr reflog to recover` — the reflog time machine finally advertised at the moment it matters. Ref-only moves and additive ops are deliberately excluded (recovery hints on operations nobody regrets are noise).

## 4. Idle tips default-on

The rotation was opt-in via `logTui.idleTips`, so the audience who needed it never saw it. It's already activity-suppressed with a >10s grace period; the default flips to on, `logTui.idleTips: false` opts out.

Tests: new input-layer coverage for the filter mode (open/type/j-appends/backspace/Enter/two-stage Esc, clean state on reopen); the five keymap tests pinning the old order/hints updated to the new contract. KEYMAP.md updated.

## Validation
- `tsc --noEmit` clean, `eslint` clean
- Full jest suite green: 4,046 tests