### PR TITLE
feat(workstation): error-recovery choice prompts + in-progress operation header chips

### DIFF
--- a/src/git/branchActions.test.ts
+++ b/src/git/branchActions.test.ts
@@ -5,6 +5,7 @@ import {
   deleteBranch,
   isBranchCheckedOutElsewhereError,
   isBranchNotFullyMergedError,
+  isDirtyWorktreeCheckoutError,
   parseCheckedOutWorktreePath,
   fetchBranch,
   fetchRemotes,
@@ -267,6 +268,42 @@ describe('log branch actions', () => {
       expect(isBranchNotFullyMergedError('Not Fully Merged')).toBe(true)
       expect(isBranchNotFullyMergedError('Cannot delete the current branch.')).toBe(false)
       expect(isBranchNotFullyMergedError(undefined)).toBe(false)
+    })
+  })
+
+  describe('isDirtyWorktreeCheckoutError (#1360)', () => {
+    it('matches the tracked-changes refusal from checkout and switch', () => {
+      expect(
+        isDirtyWorktreeCheckoutError(
+          'error: Your local changes to the following files would be overwritten by checkout:\n\tsrc/app.ts\nPlease commit your changes or stash them before you switch branches.\nAborting'
+        )
+      ).toBe(true)
+      expect(
+        isDirtyWorktreeCheckoutError('Your local changes would be overwritten by switch.')
+      ).toBe(true)
+    })
+
+    it('matches the untracked-files refusal', () => {
+      expect(
+        isDirtyWorktreeCheckoutError(
+          'error: The following untracked working tree files would be overwritten by checkout:\n\tnotes.md\nPlease move or remove them before you switch branches.'
+        )
+      ).toBe(true)
+    })
+
+    it('does NOT match the merge-flavored overwrite (pull recovery owns that) or other errors', () => {
+      // A dirty `git pull` refusal says "by merge" — that failure routes
+      // through the pull recovery flows, not stash-&-switch.
+      expect(
+        isDirtyWorktreeCheckoutError('error: Your local changes to the following files would be overwritten by merge:')
+      ).toBe(false)
+      expect(
+        isDirtyWorktreeCheckoutError("error: pathspec 'nope' did not match any file(s) known to git")
+      ).toBe(false)
+      expect(
+        isDirtyWorktreeCheckoutError("fatal: 'feat/x' is already used by worktree at '/repo/wt'")
+      ).toBe(false)
+      expect(isDirtyWorktreeCheckoutError(undefined)).toBe(false)
     })
   })
 

--- a/src/git/branchActions.ts
+++ b/src/git/branchActions.ts
@@ -178,6 +178,21 @@ export function isBranchCheckedOutElsewhereError(message: string | undefined): b
 }
 
 /**
+ * True when a checkout / switch was refused because uncommitted local
+ * changes (tracked or untracked) would be overwritten. Matches git's
+ * wording across versions and both entry commands: "Your local changes
+ * to the following files would be overwritten by checkout" / "The
+ * following untracked working tree files would be overwritten by
+ * checkout" (and the `git switch` phrasing). Deliberately narrower than
+ * a generic dirty-tree check — the merge-flavored "overwritten by
+ * merge" rejection routes through the pull recovery flows instead
+ * (#1360).
+ */
+export function isDirtyWorktreeCheckoutError(message: string | undefined): boolean {
+  return /would be overwritten by (checkout|switch)/i.test(message || '')
+}
+
+/**
  * Pull the worktree path out of git's "checked out at '<path>'" /
  * "used by worktree at '<path>'" rejection so the UI can name where the
  * branch is still in use. Returns undefined when the message doesn't

--- a/src/git/operationActions.test.ts
+++ b/src/git/operationActions.test.ts
@@ -1,6 +1,7 @@
 import {
     abortOperation,
     continueOperation,
+    isOperationConflictError,
     operationActionTestInternals,
     resolveConflictKeepCurrentBranch,
     resolveConflictKeepIncoming,
@@ -150,6 +151,33 @@ describe('log operation actions', () => {
 
       expect(result.ok).toBe(false)
       expect(result.message).toContain('error: path not found')
+    })
+  })
+
+  describe('isOperationConflictError (#1360)', () => {
+    it('matches conflict output across the merge-machinery operations', () => {
+      // Merge / pull --no-rebase.
+      expect(isOperationConflictError(
+        'Auto-merging src/app.ts\nCONFLICT (content): Merge conflict in src/app.ts\nAutomatic merge failed; fix conflicts and then commit the result.'
+      )).toBe(true)
+      // Cherry-pick / rebase replay.
+      expect(isOperationConflictError('error: could not apply abc1234... feat: add thing')).toBe(true)
+      // Revert.
+      expect(isOperationConflictError('error: could not revert abc1234... feat: add thing')).toBe(true)
+      // Rebase's hint block (sometimes the only line callers hold).
+      expect(isOperationConflictError(
+        'Resolve all conflicts manually, mark them as resolved with "git add/rm <conflicted_files>"'
+      )).toBe(true)
+      // Non-content conflict flavors carry the CONFLICT ( prefix.
+      expect(isOperationConflictError('CONFLICT (modify/delete): src/app.ts deleted in HEAD')).toBe(true)
+    })
+
+    it('does NOT match unrelated failures', () => {
+      expect(isOperationConflictError("fatal: bad revision 'nope'")).toBe(false)
+      expect(isOperationConflictError('error: Your local changes to the following files would be overwritten by merge:')).toBe(false)
+      expect(isOperationConflictError('fatal: Not possible to fast-forward, aborting.')).toBe(false)
+      expect(isOperationConflictError('! [rejected] main -> main (non-fast-forward)')).toBe(false)
+      expect(isOperationConflictError(undefined)).toBe(false)
     })
   })
 })

--- a/src/git/operationActions.ts
+++ b/src/git/operationActions.ts
@@ -69,6 +69,29 @@ function getOperationCommand(
   }
 }
 
+/**
+ * True when a failed merge-machinery action (cherry-pick / revert /
+ * rebase / pull) stopped on CONFLICTS — i.e. the repo is now sitting
+ * mid-operation waiting for the user — as opposed to failing outright
+ * for an unrelated reason (bad ref, network, hook rejection). Matches
+ * git's conflict phrasings across versions and operations:
+ *
+ *   - "CONFLICT (content): Merge conflict in <file>"   (all operations)
+ *   - "Automatic merge failed; fix conflicts and then commit the result."
+ *     (merge / pull --no-rebase)
+ *   - "error: could not apply <sha>..."                (cherry-pick / rebase)
+ *   - "error: could not revert <sha>..."               (revert)
+ *   - "Resolve all conflicts manually, mark them as resolved..."
+ *     (rebase's hint block)
+ *
+ * Callers should join `message` + `details` before testing — several
+ * action modules split git's multi-line stderr across both fields
+ * (same contract as `isNonFastForwardPushError`).
+ */
+export function isOperationConflictError(message: string | undefined): boolean {
+  return /CONFLICT \(|Merge conflict in |Automatic merge failed|could not apply|could not revert|Resolve all conflicts manually/i.test(message || '')
+}
+
 export function continueOperation(
   git: SimpleGit,
   operation: GitOperationType

--- a/src/workstation/chrome/headerChips.test.ts
+++ b/src/workstation/chrome/headerChips.test.ts
@@ -75,6 +75,58 @@ describe('buildHeaderChips', () => {
     expect(chips.find((c) => c.id === 'bisecting')).toBeUndefined()
   })
 
+  describe('in-progress operation chip (#1360)', () => {
+    it('renders a warning chip for each merge-machinery operation', () => {
+      const cases = [
+        ['merge', '⚠ MERGING'],
+        ['rebase', '⚠ REBASING'],
+        ['cherry-pick', '⚠ CHERRY-PICKING'],
+        ['revert', '⚠ REVERTING'],
+      ] as const
+      for (const [operation, label] of cases) {
+        const chips = buildHeaderChips(makeInput({ operation }))
+        const chip = chips.find((c) => c.id === 'operation')!
+        expect(chip).toBeDefined()
+        expect(chip.label).toBe(label)
+        expect(chip.color).toBe('yellow') // theme.colors.warning
+        expect(chip.bold).toBe(true)
+      }
+    })
+
+    it('appends the conflict count with singular/plural copy', () => {
+      const three = buildHeaderChips(makeInput({ operation: 'rebase', operationConflicts: 3 }))
+      expect(three.find((c) => c.id === 'operation')!.label).toBe('⚠ REBASING (3 conflicts)')
+      const one = buildHeaderChips(makeInput({ operation: 'merge', operationConflicts: 1 }))
+      expect(one.find((c) => c.id === 'operation')!.label).toBe('⚠ MERGING (1 conflict)')
+      // Zero conflicts (all resolved, operation not yet continued) drops
+      // the parenthetical rather than rendering "(0 conflicts)".
+      const zero = buildHeaderChips(makeInput({ operation: 'cherry-pick', operationConflicts: 0 }))
+      expect(zero.find((c) => c.id === 'operation')!.label).toBe('⚠ CHERRY-PICKING')
+    })
+
+    it('omits the chip when no operation is in progress (undefined or none)', () => {
+      expect(
+        buildHeaderChips(makeInput()).find((c) => c.id === 'operation')
+      ).toBeUndefined()
+      expect(
+        buildHeaderChips(makeInput({ operation: 'none' })).find((c) => c.id === 'operation')
+      ).toBeUndefined()
+    })
+
+    it('sits in the state cluster — after dirty, before bisecting', () => {
+      const chips = buildHeaderChips(makeInput({ operation: 'rebase', bisecting: true }))
+      const ids = chips.map((c) => c.id)
+      expect(ids.indexOf('operation')).toBe(ids.indexOf('dirty') + 1)
+      expect(ids.indexOf('bisecting')).toBe(ids.indexOf('operation') + 1)
+    })
+
+    it('falls back to the ASCII glyph per theme.ascii', () => {
+      const theme = createLogInkTheme({ noColor: false, ascii: true })
+      const chips = buildHeaderChips(makeInput({ theme, operation: 'rebase', operationConflicts: 2 }))
+      expect(chips.find((c) => c.id === 'operation')!.label).toBe('! REBASING (2 conflicts)')
+    })
+  })
+
   it('omits the PR chip entirely when no pull request is loaded', () => {
     const chips = buildHeaderChips(makeInput({ pullRequest: undefined }))
     expect(chips.find((c) => c.id === 'pr')).toBeUndefined()

--- a/src/workstation/chrome/headerChips.ts
+++ b/src/workstation/chrome/headerChips.ts
@@ -32,6 +32,7 @@ import { forgeNouns } from './forgeNouns'
 import type { LogInkTheme } from './theme'
 import { getPullRequestStateGlyph } from './iconography'
 import type { GitProviderType } from '../../git/providerData'
+import type { GitOperationType } from '../../git/operationData'
 
 export type HeaderChip = {
   /**
@@ -60,12 +61,24 @@ export type HeaderChipId =
   | 'repo'
   | 'branch'
   | 'dirty'
+  | 'operation'
   | 'bisecting'
   | 'pr'
   | 'view'
   | 'loading'
   | 'mode'
   | 'search'
+
+/**
+ * Chip copy for the in-progress merge-machinery operations (#1360).
+ * `none` never renders a chip, so the map covers only the real four.
+ */
+const OPERATION_CHIP_LABELS: Record<Exclude<GitOperationType, 'none'>, string> = {
+  merge: 'MERGING',
+  rebase: 'REBASING',
+  'cherry-pick': 'CHERRY-PICKING',
+  revert: 'REVERTING',
+}
 
 export type BuildHeaderChipsInput = {
   appLabel: string
@@ -79,6 +92,19 @@ export type BuildHeaderChipsInput = {
   dirty: boolean
   /** True when `context.bisect.active` — renders its own warning chip. */
   bisecting: boolean
+  /**
+   * In-progress merge-machinery operation from `context.operation`
+   * (#1360). `undefined` / `'none'` omits the chip; anything else
+   * renders `⚠ REBASING` / `⚠ MERGING` / … so a half-finished
+   * operation is never invisible. Bisect keeps its own chip above.
+   */
+  operation?: GitOperationType
+  /**
+   * Conflicted-file count for the operation chip — appends
+   * `(3 conflicts)` when > 0. Ignored when no operation is in
+   * progress.
+   */
+  operationConflicts?: number
   /**
    * Pull request state for the current branch, if any. `undefined`
    * omits the PR chip entirely (no "no PR" placeholder).
@@ -172,6 +198,25 @@ export function buildHeaderChips(input: BuildHeaderChipsInput): HeaderChip[] {
       bold: false,
     }
   chips.push(dirtyChip)
+
+  // In-progress operation — only when the merge machinery left the repo
+  // mid-flight (#1360). Same warning treatment as the bisect chip: an
+  // operation waiting on the user must be visible from every view, not
+  // just the conflicts surface. The conflict count rides along so the
+  // chip doubles as a progress meter while conflicts are resolved.
+  if (input.operation && input.operation !== 'none') {
+    const conflicts = input.operationConflicts ?? 0
+    const suffix = conflicts > 0
+      ? ` (${conflicts} conflict${conflicts === 1 ? '' : 's'})`
+      : ''
+    chips.push({
+      id: 'operation',
+      label: `${theme.ascii ? '!' : '⚠'} ${OPERATION_CHIP_LABELS[input.operation]}${suffix}`,
+      color: theme.colors.warning,
+      dim: false,
+      bold: true,
+    })
+  }
 
   // Bisect — only when active. Distinct chip so users entering the TUI
   // mid-bisect see it immediately (#784). Warning color because bisect

--- a/src/workstation/runtime/header.test.ts
+++ b/src/workstation/runtime/header.test.ts
@@ -132,6 +132,45 @@ describe('createLogInkHeader', () => {
     expect(collectText(tree)).toContain('main')
   })
 
+  it('renders the in-progress operation chip with the conflict count from context.operation (#1360)', () => {
+    const base = makeRuntimeValue()
+    const tree = renderHeader(makeRuntimeValue({
+      context: {
+        ...base.context,
+        operation: {
+          operation: 'rebase',
+          conflictedFiles: [
+            { path: 'src/a.ts', indexStatus: 'U', worktreeStatus: 'U' },
+            { path: 'src/b.ts', indexStatus: 'U', worktreeStatus: 'U' },
+            { path: 'src/c.ts', indexStatus: 'U', worktreeStatus: 'U' },
+          ],
+          conflictMarkers: [],
+          hooks: { hooksPath: '', configuredHooks: [] },
+          aiConflictHelpAvailable: true,
+        },
+      } as unknown as LogInkContext,
+    }))
+    expect(collectText(tree)).toContain('REBASING (3 conflicts)')
+  })
+
+  it('omits the operation chip when context.operation reports none in progress', () => {
+    const base = makeRuntimeValue()
+    const tree = renderHeader(makeRuntimeValue({
+      context: {
+        ...base.context,
+        operation: {
+          operation: 'none',
+          conflictedFiles: [],
+          conflictMarkers: [],
+          hooks: { hooksPath: '', configuredHooks: [] },
+          aiConflictHelpAvailable: false,
+        },
+      } as unknown as LogInkContext,
+    }))
+    expect(collectText(tree)).not.toContain('MERGING')
+    expect(collectText(tree)).not.toContain('REBASING')
+  })
+
   it('wraps the chips in a 3-high bordered Box (layout unchanged)', () => {
     const tree = renderHeader(makeRuntimeValue())
     const props = (tree as unknown as { props: StubProps }).props

--- a/src/workstation/runtime/header.ts
+++ b/src/workstation/runtime/header.ts
@@ -92,6 +92,12 @@ export function createLogInkHeader(
     const branch = context.branches?.currentBranch || context.provider?.currentBranch || '<detached>'
     const dirty = Boolean(context.branches?.dirty)
     const bisecting = Boolean(context.bisect?.active)
+    // In-progress merge-machinery operation (#1360) — 'none' collapses
+    // to undefined so the chip builder's omit-when-absent rule applies.
+    const operation = context.operation?.operation && context.operation.operation !== 'none'
+      ? context.operation.operation
+      : undefined
+    const operationConflicts = context.operation?.conflictedFiles?.length ?? 0
     const repo = context.provider?.repository.owner && context.provider.repository.name
       ? `${context.provider.repository.owner}/${context.provider.repository.name}`
       : 'local repository'
@@ -122,6 +128,8 @@ export function createLogInkHeader(
       branch,
       dirty,
       bisecting,
+      operation,
+      operationConflicts,
       pullRequest: prInfo ? {
         number: prInfo.number,
         state: prInfo.state,

--- a/src/workstation/runtime/hooks/useWorkflowAction.test.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.test.ts
@@ -1,7 +1,10 @@
 import type ReactTypes from 'react'
+import type { GitLogRow } from '../../../commands/log/data'
 import { createLogInkState } from '../inkViewModel'
 import { checkoutReflogEntry } from '../../../git/reflogActions'
-import { pullCurrentBranch, pushBranch } from '../../../git/branchActions'
+import { checkoutBranch, checkoutBranchByName, pullCurrentBranch, pullCurrentBranchRebase, pushBranch } from '../../../git/branchActions'
+import { cherryPickCommit } from '../../../git/historyActions'
+import { createStash } from '../../../git/stashActions'
 import { useWorkflowAction, type UseWorkflowActionDeps } from './useWorkflowAction'
 
 /**
@@ -24,6 +27,25 @@ jest.mock('../../../git/branchActions', () => {
     ...actual,
     pushBranch: jest.fn(),
     pullCurrentBranch: jest.fn(),
+    pullCurrentBranchRebase: jest.fn(),
+    checkoutBranch: jest.fn(),
+    checkoutBranchByName: jest.fn(),
+  }
+})
+
+jest.mock('../../../git/historyActions', () => {
+  const actual = jest.requireActual('../../../git/historyActions')
+  return {
+    ...actual,
+    cherryPickCommit: jest.fn(),
+  }
+})
+
+jest.mock('../../../git/stashActions', () => {
+  const actual = jest.requireActual('../../../git/stashActions')
+  return {
+    ...actual,
+    createStash: jest.fn(),
   }
 })
 
@@ -302,6 +324,230 @@ describe('result status carries the outcome kind (#1349)', () => {
       type: 'setStatus',
       value: 'Pulled main from origin',
       kind: 'success',
+    }))
+  })
+})
+
+const checkoutBranchMock = checkoutBranch as jest.MockedFunction<typeof checkoutBranch>
+const checkoutBranchByNameMock = checkoutBranchByName as jest.MockedFunction<typeof checkoutBranchByName>
+const cherryPickCommitMock = cherryPickCommit as jest.MockedFunction<typeof cherryPickCommit>
+const createStashMock = createStash as jest.MockedFunction<typeof createStash>
+const pullCurrentBranchRebaseMock = pullCurrentBranchRebase as jest.MockedFunction<typeof pullCurrentBranchRebase>
+
+// A NON-current local branch so the checkout-branch handler actually
+// calls git instead of short-circuiting on "Already on <branch>".
+const otherBranch = {
+  type: 'local',
+  name: 'refs/heads/feature/other',
+  shortName: 'feature/other',
+  hash: 'def',
+  current: false,
+  upstream: undefined,
+  remote: undefined,
+  date: '2026-05-01',
+  subject: 'feat',
+  ahead: 0,
+  behind: 0,
+} as never
+
+describe('dirty-checkout recovery (#1360)', () => {
+  beforeEach(() => {
+    checkoutBranchMock.mockReset()
+    checkoutBranchByNameMock.mockReset()
+    createStashMock.mockReset()
+  })
+
+  it('offers stash & switch when the checkout is refused for uncommitted changes', async () => {
+    checkoutBranchMock.mockResolvedValue({
+      ok: false,
+      message: 'error: Your local changes to the following files would be overwritten by checkout:\n\tsrc/app.ts\nPlease commit your changes or stash them before you switch branches.\nAborting',
+    })
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      context: { branches: { localBranches: [otherBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('checkout-branch')
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setPendingChoice',
+      value: expect.objectContaining({
+        id: 'dirty-checkout-recovery',
+        options: [
+          expect.objectContaining({
+            key: 's',
+            workflowId: 'stash-and-checkout-branch',
+            payload: 'feature/other',
+          }),
+        ],
+      }),
+    }))
+  })
+
+  it('does NOT offer it for unrelated checkout failures', async () => {
+    checkoutBranchMock.mockResolvedValue({
+      ok: false,
+      message: "error: pathspec 'feature/other' did not match any file(s) known to git",
+    })
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      context: { branches: { localBranches: [otherBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('checkout-branch')
+    expect(dispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'setPendingChoice' }))
+  })
+
+  it('stash-and-checkout-branch stashes first, then switches, and hints at gz', async () => {
+    createStashMock.mockResolvedValue({ ok: true, message: 'Created stash: WIP before switching to feature/other' })
+    checkoutBranchByNameMock.mockResolvedValue({ ok: true, message: 'Checked out feature/other' })
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({ dispatch }))
+
+    await runWorkflowAction('stash-and-checkout-branch', 'feature/other')
+    expect(createStashMock).toHaveBeenCalledWith(expect.anything(), 'WIP before switching to feature/other')
+    expect(checkoutBranchByNameMock).toHaveBeenCalledWith(expect.anything(), 'feature/other')
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: expect.stringContaining('(gz)'),
+      kind: 'success',
+    }))
+    // HEAD moved — the branch cursor snaps home like every checkout path.
+    expect(dispatch).toHaveBeenCalledWith({ type: 'resetBranchSelection' })
+  })
+
+  it('a failed stash aborts before the switch is attempted', async () => {
+    createStashMock.mockResolvedValue({ ok: false, message: 'fatal: unable to write new index file' })
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({ dispatch }))
+
+    await runWorkflowAction('stash-and-checkout-branch', 'feature/other')
+    expect(checkoutBranchByNameMock).not.toHaveBeenCalled()
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      kind: 'error',
+    }))
+  })
+})
+
+const commitRow: GitLogRow = {
+  type: 'commit',
+  graph: '*',
+  shortHash: 'abc1234',
+  hash: 'abc123456789',
+  parents: ['def567890123'],
+  date: '2026-04-29',
+  author: 'Coco Test',
+  refs: [],
+  message: 'feat: add thing',
+}
+
+describe('operation conflict recovery (#1360)', () => {
+  beforeEach(() => {
+    cherryPickCommitMock.mockReset()
+    pullCurrentBranchMock.mockReset()
+  })
+
+  it('a conflicted cherry-pick raises the conflicts/abort choice and keeps the error on dismissal', async () => {
+    cherryPickCommitMock.mockResolvedValue({
+      ok: false,
+      message: 'error: could not apply abc1234... feat: add thing',
+      details: ['CONFLICT (content): Merge conflict in src/app.ts'],
+    })
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      state: createLogInkState([commitRow]),
+    }))
+
+    await runWorkflowAction('cherry-pick-commit')
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setPendingChoice',
+      value: expect.objectContaining({
+        id: 'operation-conflict-recovery',
+        title: 'Cherry-pick stopped on conflicts',
+        // Declining the recovery must leave git's raw error visible.
+        keepStatusOnDismiss: true,
+        options: [
+          expect.objectContaining({ key: 'x', intent: 'open-conflicts' }),
+          expect.objectContaining({ key: 'a', workflowId: 'abort-operation', destructive: true }),
+        ],
+      }),
+    }))
+    // The raw error still landed on the status line first.
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: 'error: could not apply abc1234... feat: add thing',
+      kind: 'error',
+    }))
+  })
+
+  it('detects conflicts when only the details lines carry the CONFLICT marker', async () => {
+    cherryPickCommitMock.mockResolvedValue({
+      ok: false,
+      message: 'Auto-merging src/app.ts',
+      details: ['CONFLICT (content): Merge conflict in src/app.ts'],
+    })
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      state: createLogInkState([commitRow]),
+    }))
+
+    await runWorkflowAction('cherry-pick-commit')
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setPendingChoice',
+      value: expect.objectContaining({ id: 'operation-conflict-recovery' }),
+    }))
+  })
+
+  it('does NOT raise the choice for non-conflict cherry-pick failures', async () => {
+    cherryPickCommitMock.mockResolvedValue({
+      ok: false,
+      message: "fatal: bad revision 'abc123456789'",
+    })
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      state: createLogInkState([commitRow]),
+    }))
+
+    await runWorkflowAction('cherry-pick-commit')
+    expect(dispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'setPendingChoice' }))
+  })
+
+  it('a conflicted pull --rebase raises the same recovery choice', async () => {
+    pullCurrentBranchRebaseMock.mockResolvedValue({
+      ok: false,
+      message: 'CONFLICT (content): Merge conflict in src/app.ts\nerror: could not apply abc1234... feat',
+    })
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({ dispatch }))
+
+    await runWorkflowAction('pull-rebase-current')
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setPendingChoice',
+      value: expect.objectContaining({
+        id: 'operation-conflict-recovery',
+        title: 'Pull stopped on conflicts',
+      }),
     }))
   })
 })

--- a/src/workstation/runtime/hooks/useWorkflowAction.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.ts
@@ -65,6 +65,7 @@ import {
   deleteBranch,
   isBranchCheckedOutElsewhereError,
   isBranchNotFullyMergedError,
+  isDirtyWorktreeCheckoutError,
   parseCheckedOutWorktreePath,
   fetchBranch,
   fetchRemotes,
@@ -103,7 +104,7 @@ import { applyStash, applyStashKeepIndex, checkoutFileFromStash, createStash, dr
 import { ApplyHunkTarget, applyHunkPatch } from '../../../git/hunkActions'
 import { removeWorktree, removeWorktreeAndBranch } from '../../../git/worktreeActions'
 import { rebaseOnto } from '../../../git/rebaseActions'
-import { abortOperation, continueOperation, resolveConflictKeepCurrentBranch, resolveConflictKeepIncoming, stageConflictResolved } from '../../../git/operationActions'
+import { abortOperation, continueOperation, isOperationConflictError, resolveConflictKeepCurrentBranch, resolveConflictKeepIncoming, stageConflictResolved } from '../../../git/operationActions'
 import { getForgeActions } from '../../../git/forgeActions'
 import { clearGitHubListCache } from '../../../git/githubListCache'
 import { isPullRequestMergeStrategy } from '../../../git/pullRequestActions'
@@ -855,6 +856,26 @@ export function useWorkflowAction(
       // know it's a plain local name.
       'checkout-created-branch': async () => {
         return checkoutBranchByName(git, payload ?? '')
+      },
+      // Recovery follow-up for a dirty-worktree checkout refusal (#1360).
+      // Reached only via the dirty-checkout-recovery choice prompt below;
+      // the target branch name rides in `payload`. Stashes EVERYTHING
+      // (createStash passes `-u`, so untracked files ride along — they
+      // can block a switch too) and retries the switch by name. The
+      // stash is deliberately NOT auto-popped after the switch — the
+      // success message points at the stash surface (gz) so the user
+      // decides when (and on which branch) to bring the changes back.
+      'stash-and-checkout-branch': async () => {
+        const name = payload?.trim()
+        if (!name) return { ok: false, message: 'Branch name required' }
+        const stashed = await createStash(git, `WIP before switching to ${name}`)
+        if (!stashed.ok) {
+          return { ok: false, message: `Stash failed — staying put: ${stashed.message}` }
+        }
+        const checkout = await checkoutBranchByName(git, name)
+        return checkout.ok
+          ? { ok: true, message: `Stashed changes and switched to ${name} — the stash is waiting on the stash surface (gz)` }
+          : { ok: false, message: `Stashed changes, but the switch still failed: ${checkout.message}` }
       },
       // #0.71 — submodule maintenance. Resolve the target from the
       // filtered list so the cursor index lines up with what's on screen
@@ -1629,6 +1650,69 @@ export function useWorkflowAction(
         })
       }
     }
+    // #1360 — `git switch` on a dirty tree dead-ends with git's raw
+    // "would be overwritten" refusal. Offer stash & switch instead:
+    // `s` stashes everything (untracked included) and retries the
+    // checkout; Esc keeps the changes (and the current branch) in
+    // place. The cursor hasn't moved (the checkout failed), so the
+    // branch name captured for the row spinner is the retry target.
+    if (
+      id === 'checkout-branch' &&
+      !result?.ok &&
+      isDirtyWorktreeCheckoutError([result?.message, ...((result as { details?: string[] } | undefined)?.details || [])].join('\n'))
+    ) {
+      const branchName = pendingItemAction?.id
+      if (branchName) {
+        dispatch({
+          type: 'setPendingChoice',
+          value: {
+            id: 'dirty-checkout-recovery',
+            title: `Uncommitted changes block switching to '${branchName}'`,
+            warning: 'Stash & switch stashes everything (including untracked files), then retries the checkout. The stash stays put for you to pop later.',
+            options: [
+              { key: 's', label: 'Stash changes & switch', workflowId: 'stash-and-checkout-branch', payload: branchName },
+            ],
+          },
+        })
+      }
+    }
+    // #1360 — a cherry-pick / revert / rebase / pull that stopped on
+    // CONFLICTS used to dump git's stderr on the status line and leave
+    // the user to find `gx` on their own. Detect the conflict outcome
+    // and offer the two moves that matter at that moment: open the
+    // conflicts view, or abort the operation to unwind. Esc dismisses
+    // the prompt but keeps the raw error status visible underneath
+    // (`keepStatusOnDismiss`) — the repo really is mid-operation.
+    const conflictRecoveryTitles: Record<string, string> = {
+      'cherry-pick-commit': 'Cherry-pick stopped on conflicts',
+      'revert-commit': 'Revert stopped on conflicts',
+      'rebase-onto-branch': 'Rebase stopped on conflicts',
+      'interactive-rebase': 'Rebase stopped on conflicts',
+      'execute-rebase-plan': 'Rebase stopped on conflicts',
+      'pull-current-branch': 'Pull stopped on conflicts',
+      'pull-selected-branch': 'Pull stopped on conflicts',
+      'pull-rebase-current': 'Pull stopped on conflicts',
+      'pull-merge-current': 'Pull stopped on conflicts',
+    }
+    if (
+      conflictRecoveryTitles[id] &&
+      !result?.ok &&
+      isOperationConflictError([result?.message, ...((result as { details?: string[] } | undefined)?.details || [])].join('\n'))
+    ) {
+      dispatch({
+        type: 'setPendingChoice',
+        value: {
+          id: 'operation-conflict-recovery',
+          title: conflictRecoveryTitles[id],
+          warning: 'The repository is mid-operation. Resolve the conflicts and continue, or abort to unwind.',
+          keepStatusOnDismiss: true,
+          options: [
+            { key: 'x', label: 'Open conflicts view', intent: 'open-conflicts' },
+            { key: 'a', label: 'Abort the operation', workflowId: 'abort-operation', destructive: true },
+          ],
+        },
+      })
+    }
     // Refresh history rows AS WELL when the workflow could have
     // changed the commits the user sees (#945 follow-up). The
     // workflow IDs below all either create/rewrite local commits or
@@ -1683,6 +1767,9 @@ export function useWorkflowAction(
       // changes HEAD — refresh the graph so the current-branch marker
       // and history view reflect the switch (#1326).
       'checkout-created-branch',
+      // Stash & switch (#1360) changes HEAD the same way a plain
+      // checkout does.
+      'stash-and-checkout-branch',
     ])
     if (result?.ok && historyMutatingIds.has(id)) {
       await refreshHistoryRows()
@@ -1697,7 +1784,7 @@ export function useWorkflowAction(
     // (resolvePendingItemAction → action 'checkout'), so a silent
     // stale-while-revalidate swap keeps the list readable and just
     // repaints the current-branch marker once the new context lands.
-    if ((id === 'checkout-branch' || id === 'conflict-remove-worktree-checkout' || id === 'checkout-created-branch') && result?.ok) {
+    if ((id === 'checkout-branch' || id === 'conflict-remove-worktree-checkout' || id === 'checkout-created-branch' || id === 'stash-and-checkout-branch') && result?.ok) {
       dispatch({ type: 'resetBranchSelection' })
       await refreshContext({ silent: true })
     } else {
@@ -1734,6 +1821,11 @@ export function useWorkflowAction(
     // Stage-all / stage-pathspec change staged/unstaged counts — refresh
     // the worktree so the status list + compose summary reflect it.
     if (result?.ok && (id === 'stage-all' || id === 'stage-pathspec')) {
+      await refreshWorktreeContext()
+    }
+    // Stash & switch (#1360) empties the worktree into a stash — refresh
+    // so the staged/unstaged/untracked counts drop to zero immediately.
+    if (result?.ok && id === 'stash-and-checkout-branch') {
       await refreshWorktreeContext()
     }
     if (result?.ok && id === 'drop-stash') {

--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -5624,6 +5624,74 @@ describe('triage filter cycling (#882 phase 6)', () => {
     })
   })
 
+  describe('operation-conflict-recovery choice prompt (#1360)', () => {
+    function conflictRecoveryState() {
+      // The workflow runner lands the raw git error on the status line
+      // FIRST, then raises the recovery prompt on top of it.
+      let state = applyLogInkAction(createLogInkState(rows), {
+        type: 'setStatus',
+        value: 'error: could not apply abc1234... feat: add thing',
+        kind: 'error',
+      })
+      state = applyLogInkAction(state, {
+        type: 'setPendingChoice',
+        value: {
+          id: 'operation-conflict-recovery',
+          title: 'Cherry-pick stopped on conflicts',
+          keepStatusOnDismiss: true,
+          options: [
+            { key: 'x', label: 'Open conflicts view', intent: 'open-conflicts' },
+            { key: 'a', label: 'Abort the operation', workflowId: 'abort-operation', destructive: true },
+          ],
+        },
+      })
+      return state
+    }
+
+    it('x (open-conflicts intent) pushes the conflicts view and closes the prompt', () => {
+      const state = conflictRecoveryState()
+      const after = applyInput(state, 'x')
+      expect(after.activeView).toBe('conflicts')
+      expect(after.pendingChoice).toBeUndefined()
+      // The sticky error stays put — the view push carries no setStatus.
+      expect(after.statusMessage).toBe('error: could not apply abc1234... feat: add thing')
+    })
+
+    it('a runs the abort-operation workflow and closes the prompt', () => {
+      const state = conflictRecoveryState()
+      const events = getLogInkInputEvents(state, 'a')
+      expect(events).toContainEqual({ type: 'runWorkflowAction', id: 'abort-operation', payload: undefined })
+      const after = applyInput(state, 'a')
+      expect(after.pendingChoice).toBeUndefined()
+    })
+
+    it('Esc dismisses but keeps the raw error status visible (keepStatusOnDismiss)', () => {
+      const state = conflictRecoveryState()
+      const after = applyInput(state, '', { escape: true })
+      expect(after.pendingChoice).toBeUndefined()
+      expect(after.statusMessage).toBe('error: could not apply abc1234... feat: add thing')
+      expect(after.statusKind).toBe('error')
+    })
+
+    it('a prompt WITHOUT keepStatusOnDismiss still overwrites the status with cancelled', () => {
+      let state = applyLogInkAction(createLogInkState(rows), {
+        type: 'setStatus',
+        value: 'some earlier status',
+      })
+      state = applyLogInkAction(state, {
+        type: 'setPendingChoice',
+        value: {
+          id: 'diverged-pull-recovery',
+          title: 'Local and remote have diverged',
+          options: [{ key: 'r', label: 'Pull with rebase', workflowId: 'pull-rebase-current' }],
+        },
+      })
+      const after = applyInput(state, '', { escape: true })
+      expect(after.pendingChoice).toBeUndefined()
+      expect(after.statusMessage).toBe('cancelled')
+    })
+  })
+
   describe('modal prompt keyboard precedence (#1342)', () => {
     const choice = {
       id: 'diverged-pull-recovery',

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -1173,6 +1173,16 @@ export function getLogInkInputEvents(
           action({ type: 'setWorktreeCheckoutConflict', value: undefined }),
         ]
       }
+      // `open-conflicts` routes straight to the conflicts view (#1360)
+      // — pure navigation, same reasoning as `switch-worktree` above.
+      // The sticky error status underneath stays put so the user still
+      // sees what stopped the operation once they land on the view.
+      if (option.intent === 'open-conflicts') {
+        return [
+          action({ type: 'pushView', value: 'conflicts' }),
+          action({ type: 'setPendingChoice', value: undefined }),
+        ]
+      }
       if (option.workflowId) {
         // The workflow runner owns the live context + clears any
         // conflict state once it resolves. Options may carry a payload
@@ -1190,7 +1200,12 @@ export function getLogInkInputEvents(
         ...(state.worktreeCheckoutConflict
           ? [action({ type: 'setWorktreeCheckoutConflict', value: undefined })]
           : []),
-        action({ type: 'setStatus', value: 'cancelled' }),
+        // Recovery prompts raised on top of a sticky error status keep
+        // that status visible after dismissal (#1360) — declining the
+        // recovery doesn't make git's error less true.
+        ...(state.pendingChoice.keepStatusOnDismiss
+          ? []
+          : [action({ type: 'setStatus', value: 'cancelled' })]),
       ]
     }
     return []

--- a/src/workstation/runtime/inkViewModel.ts
+++ b/src/workstation/runtime/inkViewModel.ts
@@ -77,7 +77,12 @@ export type LogInkChoiceOption = {
    * (reset soft/mixed/hard, merge strategy merge/squash/rebase).
    */
   payload?: string
-  intent?: 'switch-worktree'
+  /**
+   * `switch-worktree` opens the conflicting worktree as a nested repo
+   * frame (#1175); `open-conflicts` pushes the conflicts view (#1360).
+   * Both are pure navigation and bypass the workflow runner.
+   */
+  intent?: 'switch-worktree' | 'open-conflicts'
 }
 
 /**
@@ -91,6 +96,14 @@ export type LogInkChoicePrompt = {
   title: string
   warning?: string
   options: LogInkChoiceOption[]
+  /**
+   * When true, dismissing the prompt (n / Esc) leaves the current
+   * status line untouched instead of overwriting it with "cancelled".
+   * Used by recovery prompts raised ON TOP of a sticky error status
+   * (#1360) — declining the recovery must keep git's raw error visible,
+   * because the error is still the truth about what happened.
+   */
+  keepStatusOnDismiss?: boolean
 }
 
 /**


### PR DESCRIPTION
Three error-recovery upgrades from the TUI excellence audit — the missing applications of the #1181 choice-prompt pattern, plus header visibility for half-finished operations.

## 1. Dirty checkout → "stash & switch?"

**Before:** pressing `Enter` on a branch with uncommitted changes in the way dead-ended on git's raw refusal — `error: Your local changes to the following files would be overwritten by checkout: …` — and the user had to leave, stash by hand (`gZ`), and retry.

**After:** the failure is detected (`isDirtyWorktreeCheckoutError`, matching both the tracked-changes and untracked-files phrasings for `checkout`/`switch`) and a choice prompt is raised:

- `s` — **Stash changes & switch**: creates a stash including untracked files (`stash push -u`), then retries the checkout by name. On success the status line points at the stash surface: *"…the stash is waiting on the stash surface (gz)"*. The stash is deliberately not auto-popped.
- `Esc` — cancel, changes stay in place.

The predicate deliberately does **not** match "overwritten by merge" — that failure belongs to the pull-recovery flows.

## 2. Conflicted cherry-pick / rebase / pull → route to conflicts

**Before:** a conflicting cherry-pick (or revert / `rebase-onto` / rebase plan / pull) dumped stderr as a sticky one-line error and left the user to find `gx` on their own — even though the conflicts view and `abortOperation` already existed.

**After:** conflict output is detected (`isOperationConflictError` — `CONFLICT (…)`, `Merge conflict in`, `Automatic merge failed`, `could not apply/revert`, the rebase hint block; message + details joined before testing) and a choice is raised:

- `x` — **Open conflicts view** (new `open-conflicts` choice intent — pure navigation, same pattern as `switch-worktree`)
- `a` — **Abort the operation** (routes to the existing `abort-operation` workflow, rendered destructive)
- `Esc` — dismiss, **keeping git's raw error visible** on the status line (new `keepStatusOnDismiss` flag on `LogInkChoicePrompt`; without it the dismiss path overwrote the error with "cancelled")

Covered ids: `cherry-pick-commit`, `revert-commit`, `rebase-onto-branch`, `interactive-rebase`, `execute-rebase-plan`, and the four pull variants.

## 3. In-progress operation header chips

**Before:** `getInProgressOperationType` already detected merge/rebase/cherry-pick/revert and the header had a `⚠ BISECTING` chip — but a half-finished cherry-pick was invisible from every view except `gx`.

**After:** `context.operation` renders a warning chip in the header's state cluster (after `dirty`, before `bisecting`):

```
coco · gfargo/coco · ⎇ main · ● dirty · ⚠ REBASING (3 conflicts) · [NORMAL]
```

`⚠ MERGING` / `⚠ REBASING` / `⚠ CHERRY-PICKING` / `⚠ REVERTING`, with the live conflict count from `context.operation.conflictedFiles` (singular/plural copy, parenthetical dropped at zero), and `!` as the `theme.ascii` fallback — matching the BISECTING chip conventions exactly.

## Tests

- `branchActions.test.ts` — `isDirtyWorktreeCheckoutError` phrasings + negatives (merge-flavored overwrite, pathspec, worktree-checkout)
- `operationActions.test.ts` — `isOperationConflictError` across all operations + negatives (bad revision, diverged pull, non-ff push)
- `useWorkflowAction.test.ts` — dirty-checkout prompt raise/skip, stash-then-switch ordering (stash failure aborts before the switch), conflict prompt for cherry-pick (incl. detection via `details` only) and pull --rebase, non-conflict failures don't prompt
- `inkInput.test.ts` — `x` pushes the conflicts view, `a` runs abort-operation, Esc preserves the sticky error under `keepStatusOnDismiss`, and prompts without the flag still show "cancelled"
- `headerChips.test.ts` / `header.test.ts` — all four chip labels, conflict-count copy, placement, ASCII fallback, omission on `none`, and the runtime derivation from `context.operation`

Validation: eslint clean on changed files, `tsc --noEmit` clean, full jest suite green (312 suites / 4068 tests / 68 snapshots).

KEYMAP.md untouched — the prompt keys are transient overlay keys, matching the worktree-checkout-conflict precedent (its keys aren't listed either).

Closes #1360
