### PR TITLE
feat(workstation): PR triage — Enter opens the PR diff, C checks it out

### DIFF
--- a/src/git/forgeActions.ts
+++ b/src/git/forgeActions.ts
@@ -7,6 +7,7 @@ import type {
   PullRequestListOverview,
 } from './pullRequestListData'
 import type { PullRequestDetailResult } from './pullRequestDetailData'
+import type { PullRequestDiffResult } from './pullRequestDiffData'
 import type { IssueDetailResult } from './issueDetailData'
 import type {
   CreatePullRequestInput,
@@ -20,11 +21,13 @@ import { getPullRequestList } from './pullRequestListData'
 import { getIssueList } from './issuesListData'
 import { getPullRequestDetail } from './pullRequestDetailData'
 import { getIssueDetail } from './issueDetailData'
+import { getPullRequestDiff } from './pullRequestDiffData'
 import {
   addPullRequestAssignee,
   addPullRequestLabel,
   approvePullRequest,
   approvePullRequestByNumber,
+  checkoutPullRequestByNumber,
   closePullRequest,
   closePullRequestByNumber,
   commentPullRequest,
@@ -52,11 +55,13 @@ import {
   addMergeRequestLabel,
   approveMergeRequest,
   approveMergeRequestByNumber,
+  checkoutMergeRequestByNumber,
   closeMergeRequest,
   closeMergeRequestByNumber,
   commentMergeRequest,
   commentMergeRequestByNumber,
   createMergeRequest,
+  getMergeRequestDiff,
   mergeMergeRequest,
   mergeMergeRequestByNumber,
   openMergeRequest,
@@ -114,6 +119,12 @@ export type ForgeActions = {
   // Detail (number only; GitLab binds the project path internally)
   getPullRequestDetail: (n: number) => Promise<PullRequestDetailResult>
   getIssueDetail: (n: number) => Promise<IssueDetailResult>
+  /**
+   * Unified patch for a PR / MR by number (#1363). Backs the triage
+   * Enter → diff drill-in. Bitbucket has no CLI patch fetch, so its
+   * facade returns a graceful `{ ok: false }` explaining the gap.
+   */
+  getPullRequestDiffByNumber: (n: number) => Promise<PullRequestDiffResult>
   // Pull-request / merge-request mutations by number (triage)
   commentPullRequestByNumber: (n: number, body: string) => Promise<PullRequestActionResult>
   addPullRequestLabel: (n: number, label: string) => Promise<PullRequestActionResult>
@@ -122,6 +133,12 @@ export type ForgeActions = {
   closePullRequestByNumber: (n: number) => Promise<PullRequestActionResult>
   approvePullRequestByNumber: (n: number) => Promise<PullRequestActionResult>
   requestChangesPullRequestByNumber: (n: number, body: string) => Promise<PullRequestActionResult>
+  /**
+   * `gh pr checkout <n>` / `glab mr checkout <n>` (#1363) — fetch the
+   * PR's head branch and switch onto it. Bitbucket has no CLI
+   * counterpart, so its facade returns a graceful `{ ok: false }`.
+   */
+  checkoutPullRequestByNumber: (n: number) => Promise<PullRequestActionResult>
   // Current-branch PR / MR mutations
   mergePullRequest: (strategy: PullRequestMergeStrategy) => Promise<PullRequestActionResult>
   closePullRequest: () => Promise<PullRequestActionResult>
@@ -143,6 +160,7 @@ const githubActions: ForgeActions = {
   getIssueList: (git, filter) => getIssueList(git, filter),
   getPullRequestDetail: (n) => getPullRequestDetail(n),
   getIssueDetail: (n) => getIssueDetail(n),
+  getPullRequestDiffByNumber: (n) => getPullRequestDiff(n),
   commentPullRequestByNumber,
   addPullRequestLabel,
   addPullRequestAssignee,
@@ -150,6 +168,7 @@ const githubActions: ForgeActions = {
   closePullRequestByNumber,
   approvePullRequestByNumber,
   requestChangesPullRequestByNumber,
+  checkoutPullRequestByNumber,
   mergePullRequest,
   closePullRequest,
   approvePullRequest,
@@ -180,6 +199,7 @@ function gitlabActions(path: string | undefined, host?: string): ForgeActions {
       path ? getMergeRequestDetail(path, n) : Promise.resolve({ ok: false, message: 'No GitLab project resolved' }),
     getIssueDetail: (n) =>
       path ? getGitLabIssueDetail(path, n) : Promise.resolve({ ok: false, message: 'No GitLab project resolved' }),
+    getPullRequestDiffByNumber: (n) => getMergeRequestDiff(n, defaultGlabRunner, host),
     commentPullRequestByNumber: (n, body) => commentMergeRequestByNumber(n, body, defaultGlabRunner, host),
     addPullRequestLabel: (n, label) => addMergeRequestLabel(n, label, defaultGlabRunner, host),
     addPullRequestAssignee: (n, assignee) => addMergeRequestAssignee(n, assignee, defaultGlabRunner, host),
@@ -187,6 +207,7 @@ function gitlabActions(path: string | undefined, host?: string): ForgeActions {
     closePullRequestByNumber: (n) => closeMergeRequestByNumber(n, defaultGlabRunner, host),
     approvePullRequestByNumber: (n) => approveMergeRequestByNumber(n, defaultGlabRunner, host),
     requestChangesPullRequestByNumber: (n, body) => requestChangesMergeRequestByNumber(n, body, defaultGlabRunner, host),
+    checkoutPullRequestByNumber: (n) => checkoutMergeRequestByNumber(n, defaultGlabRunner, host),
     mergePullRequest: (strategy) => mergeMergeRequest(strategy, defaultGlabRunner, host),
     closePullRequest: () => closeMergeRequest(defaultGlabRunner, host),
     approvePullRequest: () => approveMergeRequest(defaultGlabRunner, host),
@@ -222,6 +243,11 @@ function bitbucketActions(
       path
         ? getBitbucketIssueDetail(path, n)
         : Promise.resolve({ ok: false, message: 'No Bitbucket project resolved' }),
+    // Bitbucket has no CLI patch fetch / checkout — surface the gap as a
+    // graceful failure so the diff surface / status line explain it
+    // instead of dead-ending (#1363).
+    getPullRequestDiffByNumber: () =>
+      Promise.resolve({ ok: false, message: 'Pull request diffs are not supported for Bitbucket yet.' }),
     commentPullRequestByNumber: (n, body) => commentBitbucketPullRequestByNumber(path ?? '', n, body),
     addPullRequestLabel: () => addBitbucketPullRequestLabel(),
     addPullRequestAssignee: (n, assignee) => addBitbucketPullRequestReviewer(path ?? '', n, assignee),
@@ -229,6 +255,8 @@ function bitbucketActions(
     closePullRequestByNumber: (n) => closeBitbucketPullRequestByNumber(path ?? '', n),
     approvePullRequestByNumber: (n) => approveBitbucketPullRequestByNumber(path ?? '', n),
     requestChangesPullRequestByNumber: (n, body) => requestChangesBitbucketPullRequestByNumber(path ?? '', n, body),
+    checkoutPullRequestByNumber: () =>
+      Promise.resolve({ ok: false, message: 'Pull request checkout is not supported for Bitbucket yet.' }),
     mergePullRequest: (strategy) => mergeBitbucketPullRequest(path, currentBranch, strategy),
     closePullRequest: () => closeBitbucketPullRequest(path, currentBranch),
     approvePullRequest: () => approveBitbucketPullRequest(path, currentBranch),

--- a/src/git/mergeRequestActions.test.ts
+++ b/src/git/mergeRequestActions.test.ts
@@ -1,5 +1,8 @@
 import {
   addMergeRequestAssignee,
+  buildMergeRequestDiffArgs,
+  checkoutMergeRequestByNumber,
+  getMergeRequestDiff,
   addMergeRequestLabel,
   approveMergeRequest,
   approveMergeRequestByNumber,
@@ -127,5 +130,43 @@ describe('MR mutating action arg contracts (#0.70)', () => {
     expect((await addMergeRequestAssignee(5, 'bob,carol', runner)).ok).toBe(false)
     expect((await createMergeRequest({ base: 'main', head: '--foo', title: 'T', body: 'B' }, runner)).ok).toBe(false)
     expect(calls).toEqual([])
+  })
+})
+
+describe('MR checkout + diff (#1363)', () => {
+  it('checkoutMergeRequestByNumber runs glab mr checkout <n>', async () => {
+    const { calls, runner } = capturingRunner()
+    const result = await checkoutMergeRequestByNumber(41, runner)
+    expect(calls[0]).toEqual(['mr', 'checkout', '41'])
+    expect(result.ok).toBe(true)
+    expect(result.message).toBe('Checked out merge request !41')
+  })
+
+  it('builds the glab mr diff argv with flag=value color suppression', () => {
+    expect(buildMergeRequestDiffArgs(7)).toEqual(['mr', 'diff', '7', '--color=never'])
+  })
+
+  it('getMergeRequestDiff parses the patch into lines', async () => {
+    const patch = 'diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b\n'
+    const runner = jest.fn().mockResolvedValue(patch)
+    const result = await getMergeRequestDiff(7, runner)
+    expect(runner).toHaveBeenCalledWith(['mr', 'diff', '7', '--color=never'])
+    expect(result).toEqual({
+      ok: true,
+      lines: ['diff --git a/x b/x', '--- a/x', '+++ b/x', '@@ -1 +1 @@', '-a', '+b'],
+    })
+  })
+
+  it('getMergeRequestDiff surfaces glab failures as { ok: false }', async () => {
+    // Unlike gh's resolver, the glab error path reads `error.message`.
+    const failure = new Error('404 Not Found')
+    // Diff call rejects; the error resolver's auth probe succeeds so
+    // the original stderr surfaces.
+    const runner = jest.fn().mockRejectedValueOnce(failure).mockResolvedValue('ok')
+    const result = await getMergeRequestDiff(7, runner)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.message).toContain('404 Not Found')
+    }
   })
 })

--- a/src/git/mergeRequestActions.ts
+++ b/src/git/mergeRequestActions.ts
@@ -1,6 +1,7 @@
 import { defaultGlabRunner, resolveGlabActionError, type GlabRunner } from './glabCli'
 import { rejectFlagLike, rejectUnsafeUsername } from './forgeArgGuards'
 import type { PullRequestActionResult } from './pullRequestActions'
+import { parsePullRequestDiffLines, type PullRequestDiffResult } from './pullRequestDiffData'
 
 /**
  * GitLab merge-request create/open, the glab counterparts to the gh
@@ -309,4 +310,49 @@ export function requestChangesMergeRequest(
     ok: true,
     message: output.trim() || 'Requested changes',
   }), hostname)
+}
+
+/**
+ * `glab mr checkout <n>` — the GitLab counterpart of
+ * `checkoutPullRequestByNumber` (#1363). Fetches the MR's source
+ * branch and switches the worktree onto it.
+ */
+export function checkoutMergeRequestByNumber(
+  mergeRequestNumber: number,
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
+): Promise<PullRequestActionResult> {
+  return runGlabAction(runner, ['mr', 'checkout', String(mergeRequestNumber)], (output) => ({
+    ok: true,
+    message: output.trim() || `Checked out merge request !${mergeRequestNumber}`,
+  }), hostname)
+}
+
+/**
+ * `glab mr diff <n>` argv (#1363). `--color=never` keeps the patch free
+ * of ANSI escapes regardless of glab's TTY detection — the workstation
+ * applies its own +/- theming per line.
+ */
+export function buildMergeRequestDiffArgs(mergeRequestNumber: number): string[] {
+  return ['mr', 'diff', String(mergeRequestNumber), '--color=never']
+}
+
+/**
+ * Unified-patch fetch for a merge request by number — the GitLab
+ * counterpart of `getPullRequestDiff` (#1363). Returns the shared
+ * `PullRequestDiffResult` so the workstation's PR-diff hydration
+ * treats both forges uniformly.
+ */
+export async function getMergeRequestDiff(
+  mergeRequestNumber: number,
+  runner: GlabRunner = defaultGlabRunner,
+  hostname?: string
+): Promise<PullRequestDiffResult> {
+  try {
+    const output = await runner(buildMergeRequestDiffArgs(mergeRequestNumber))
+    return { ok: true, lines: parsePullRequestDiffLines(output) }
+  } catch (error) {
+    const { message } = await resolveGlabActionError(error, runner, hostname)
+    return { ok: false, message }
+  }
 }

--- a/src/git/pullRequestActions.test.ts
+++ b/src/git/pullRequestActions.test.ts
@@ -1,5 +1,6 @@
 import {
   addPullRequestAssignee,
+  checkoutPullRequestByNumber,
   addPullRequestLabel,
   approvePullRequest,
   approvePullRequestByNumber,
@@ -361,5 +362,35 @@ describe('destructive PR by-number actions (#882 phase 5)', () => {
         'pr', 'review', '962', '--request-changes', '--body=please address X',
       ])
     })
+  })
+})
+
+describe('checkoutPullRequestByNumber (#1363)', () => {
+  it('runs gh pr checkout <n> and reports the switch', async () => {
+    const calls: string[][] = []
+    const runner = async (args: string[]): Promise<string> => {
+      calls.push(args)
+      return "Switched to branch 'feat/pr-branch'\n"
+    }
+    const result = await checkoutPullRequestByNumber(962, runner)
+    expect(calls[0]).toEqual(['pr', 'checkout', '962'])
+    expect(result.ok).toBe(true)
+    expect(result.message).toBe("Switched to branch 'feat/pr-branch'")
+  })
+
+  it('falls back to a synthesized message when gh is silent', async () => {
+    const runner = async (): Promise<string> => ''
+    const result = await checkoutPullRequestByNumber(3, runner)
+    expect(result).toEqual({ ok: true, message: 'Checked out pull request #3' })
+  })
+
+  it('surfaces a dirty-worktree refusal as { ok: false }', async () => {
+    const failure = Object.assign(new Error('Command failed: gh pr checkout 3'), {
+      stderr: 'error: Your local changes to the following files would be overwritten by checkout',
+    })
+    const runner = jest.fn().mockRejectedValueOnce(failure).mockResolvedValue('ok')
+    const result = await checkoutPullRequestByNumber(3, runner)
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('would be overwritten by checkout')
   })
 })

--- a/src/git/pullRequestActions.ts
+++ b/src/git/pullRequestActions.ts
@@ -323,3 +323,25 @@ export function requestChangesPullRequestByNumber(
     })
   )
 }
+
+/**
+ * `gh pr checkout <n>` — fetch the PR's head branch and switch the
+ * worktree onto it (#1363). The one triage verb that mutates LOCAL
+ * state rather than forge state: no y-confirm (a checkout is cheap to
+ * undo and gh refuses rather than clobbering a dirty worktree), but
+ * the workstation runs it as a workflow so it gets the row spinner +
+ * post-op context refresh like `checkout-branch`.
+ */
+export function checkoutPullRequestByNumber(
+  pullRequestNumber: number,
+  runner: GhRunner = defaultGhRunner
+): Promise<PullRequestActionResult> {
+  return runGhAction(
+    runner,
+    ['pr', 'checkout', String(pullRequestNumber)],
+    (output) => ({
+      ok: true,
+      message: output.trim() || `Checked out pull request #${pullRequestNumber}`,
+    })
+  )
+}

--- a/src/git/pullRequestDiffData.test.ts
+++ b/src/git/pullRequestDiffData.test.ts
@@ -1,0 +1,70 @@
+import {
+  buildPullRequestDiffArgs,
+  getPullRequestDiff,
+  parsePullRequestDiffLines,
+} from './pullRequestDiffData'
+
+const SAMPLE_PATCH = [
+  'diff --git a/src/a.ts b/src/a.ts',
+  'index 1111111..2222222 100644',
+  '--- a/src/a.ts',
+  '+++ b/src/a.ts',
+  '@@ -1,2 +1,2 @@',
+  '-old line',
+  '+new line',
+].join('\n')
+
+describe('pull request diff data (#1363)', () => {
+  it('builds the gh pr diff argv with flag=value color suppression', () => {
+    expect(buildPullRequestDiffArgs(962)).toEqual([
+      'pr',
+      'diff',
+      '962',
+      '--color=never',
+    ])
+  })
+
+  describe('parsePullRequestDiffLines', () => {
+    it('splits the patch into lines and drops the trailing newline', () => {
+      expect(parsePullRequestDiffLines(`${SAMPLE_PATCH}\n`)).toEqual(
+        SAMPLE_PATCH.split('\n')
+      )
+    })
+
+    it('strips CR from CRLF patches', () => {
+      expect(parsePullRequestDiffLines('line one\r\nline two\r\n')).toEqual([
+        'line one',
+        'line two',
+      ])
+    })
+
+    it('maps an empty / whitespace-only patch to [] (renders the empty hint, not a blank row)', () => {
+      expect(parsePullRequestDiffLines('')).toEqual([])
+      expect(parsePullRequestDiffLines('\n')).toEqual([])
+    })
+  })
+
+  it('fetches and parses the patch through the injected runner', async () => {
+    const runner = jest.fn().mockResolvedValue(`${SAMPLE_PATCH}\n`)
+    const result = await getPullRequestDiff(41, runner)
+    expect(runner).toHaveBeenCalledWith(['pr', 'diff', '41', '--color=never'])
+    expect(result).toEqual({ ok: true, lines: SAMPLE_PATCH.split('\n') })
+  })
+
+  it('captures a gh failure as { ok: false } with the stderr message (no throw)', async () => {
+    const failure = Object.assign(new Error('Command failed: gh pr diff 41'), {
+      stderr: 'GraphQL: Could not resolve to a PullRequest with the number of 41.',
+    })
+    // First call (the diff) rejects; the error resolver's auth probe
+    // (`gh auth status`) succeeds so the original stderr surfaces.
+    const runner = jest
+      .fn()
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValue('Logged in to github.com')
+    const result = await getPullRequestDiff(41, runner)
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.message).toContain('Could not resolve to a PullRequest')
+    }
+  })
+})

--- a/src/git/pullRequestDiffData.ts
+++ b/src/git/pullRequestDiffData.ts
@@ -1,0 +1,49 @@
+import { defaultGhRunner, resolveGhActionError, type GhRunner } from './githubCli'
+
+/**
+ * Unified-patch fetch for a pull request by number (#1363). Backs the
+ * workstation's PR-triage Enter → diff drill-in: the triage list only
+ * carries metadata, so the patch is fetched lazily (and cached by the
+ * runtime, bounded per repo-frame) once the user actually opens a PR.
+ *
+ * Same result-shape philosophy as `pullRequestActions.ts` — errors are
+ * captured into `{ ok: false, message }` (via the shared gh error
+ * compaction) instead of thrown, so the hydration layer can surface
+ * them on the diff surface without a try/catch at every call site.
+ */
+export type PullRequestDiffResult =
+  | { ok: true; lines: string[] }
+  | { ok: false; message: string }
+
+/**
+ * `gh pr diff <n>` argv. `--color=never` keeps the patch free of ANSI
+ * escapes regardless of gh's TTY detection — the workstation applies
+ * its own +/- theming per line.
+ */
+export function buildPullRequestDiffArgs(pullRequestNumber: number): string[] {
+  return ['pr', 'diff', String(pullRequestNumber), '--color=never']
+}
+
+/**
+ * Split a raw patch into lines for the diff surface. A single trailing
+ * newline is dropped (it would render as a phantom empty last row);
+ * an empty / whitespace-only patch maps to `[]` so the surface can
+ * show its "no diff" hint instead of one blank line.
+ */
+export function parsePullRequestDiffLines(output: string): string[] {
+  if (!output.trim()) return []
+  return output.replace(/\n$/, '').split('\n').map((line) => line.replace(/\r$/, ''))
+}
+
+export async function getPullRequestDiff(
+  pullRequestNumber: number,
+  runner: GhRunner = defaultGhRunner
+): Promise<PullRequestDiffResult> {
+  try {
+    const output = await runner(buildPullRequestDiffArgs(pullRequestNumber))
+    return { ok: true, lines: parsePullRequestDiffLines(output) }
+  } catch (error) {
+    const { message } = await resolveGhActionError(error, runner)
+    return { ok: false, message }
+  }
+}

--- a/src/workstation/KEYMAP.md
+++ b/src/workstation/KEYMAP.md
@@ -208,6 +208,17 @@ The hunk is the unit of action here.
 | `j`/`k` | Line-scroll |
 | `d` | Toggle unified / split |
 
+### Diff — pull request (triage `Enter`, read-only)
+
+| Key | Action |
+|-----|--------|
+| `j`/`k` | Line-scroll the patch |
+| `[` / `]` | Previous / next **file** (PR patches index by file, like stash diffs) |
+| `C` | Check the viewed PR's branch out locally (`gh pr checkout <n>`) |
+| `d` | Toggle unified / split |
+
+No cherry-pick / hunk-apply / `$EDITOR` here — the patch's files live on the PR's head branch, not necessarily in the local worktree. `C` is the "act on it" verb.
+
 ### Compose (commit message)
 
 | Key | Action |
@@ -289,6 +300,8 @@ While AI proposals are open (after `M`):
 
 | Key | Action |
 |-----|--------|
+| `Enter` | Open the PR's diff (triage; `gh pr diff <n>`, cached per number) |
+| `C` | Check the PR's branch out locally (triage; `gh pr checkout <n>`) — the global create-PR `C` is repurposed on this view |
 | `m` | Merge (1-key strategy choice: `m` merge · `s` squash · `r` rebase) |
 | `a` | Approve (confirm) |
 | `R` | Request changes (review prompt) |
@@ -347,7 +360,7 @@ arriving from another view.** Disambiguation is by the dispatch model above.
 | Key | Meanings by context |
 |-----|---------------------|
 | `c` | history → cherry-pick commit · commit/stash diff → cherry-pick/restore file · status/diff/compose → commit · PR/PR-triage → comment · issues → comment |
-| `C` | conflicts → continue operation · compose → *blocked* (guard against fat-finger PR-create) · elsewhere → create PR |
+| `C` | conflicts → continue operation · PR triage / PR diff → **checkout PR** (#1363) · compose → *blocked* (guard against fat-finger PR-create) · elsewhere → create PR |
 | `R` | history → revert · branches → rename · tags → delete-remote · PR/PR-triage → request changes · bisect → run command |
 | `a` | status/worktree-diff → stage whole file · stashes → apply · PR/PR-triage → approve · compose → **amend HEAD** (confirm; #1350) |
 | `m` | branches/tags/history (compare flow) → mark compare base · PR/PR-triage → merge |
@@ -360,7 +373,7 @@ arriving from another view.** Disambiguation is by the dispatch model above.
 | `f` | history → fixup staged into cursored commit · PR-triage → cycle PR filter · issues → cycle issue filter |
 | `o` | status/diff/conflicts → open file in `$EDITOR` (consistent — different file resolution only) |
 | `y` | bisect → mark good · conflicts (AI proposals open) → accept proposal · elsewhere → yank (`g` stays the chord prefix everywhere — bisect used to shadow it and `gh` silently marked the candidate good) |
-| `[` / `]` | worktree diff → hunk · commit diff → hunk · stash diff → **file** · sidebar/inspector focus → cycle tab |
+| `[` / `]` | worktree diff → hunk · commit diff → hunk · stash/PR diff → **file** · sidebar/inspector focus → cycle tab |
 
 The three highest-risk overloads, because they're guard-heavy or
 context-subtle, are `c`, `C`, and `[`/`]`. Touch their handlers carefully.

--- a/src/workstation/chrome/surfaceStates.test.ts
+++ b/src/workstation/chrome/surfaceStates.test.ts
@@ -4,6 +4,8 @@ import {
   formatLogInkComposeEmpty,
   formatLogInkHistoryEmpty,
   formatLogInkLoading,
+  formatLogInkPullRequestDiffEmpty,
+  formatLogInkPullRequestDiffError,
   formatLogInkStashEmpty,
   formatLogInkStatusEmpty,
   formatLogInkTagsEmpty,
@@ -123,5 +125,18 @@ describe('log Ink surface states', () => {
       expect(message).toContain('gs') // status view
       expect(message).toContain('gc') // round-trip back to compose
     })
+  })
+})
+
+describe('PR diff loading / error states (#1363)', () => {
+  it('leads the error state with the CLI message and points at recovery keys', () => {
+    const text = formatLogInkPullRequestDiffError({ message: 'gh: Not Found (HTTP 404)' })
+    expect(text).toContain('gh: Not Found (HTTP 404)')
+    expect(text).toContain('esc')
+    expect(text).toContain('r to refresh')
+  })
+
+  it('distinguishes an empty patch from a failed fetch', () => {
+    expect(formatLogInkPullRequestDiffEmpty()).toBe('No diff to display for this pull request.')
   })
 })

--- a/src/workstation/chrome/surfaceStates.ts
+++ b/src/workstation/chrome/surfaceStates.ts
@@ -210,3 +210,28 @@ export function formatLogInkForgeNoRemote({
 }: LogInkForgeUnavailableArgs): string {
   return `${resource} require a ${forge} remote (origin or fallback). None detected for this repo.`
 }
+
+export type LogInkPullRequestDiffErrorArgs = {
+  /** Failure message from the forge CLI patch fetch. */
+  message: string
+}
+
+/**
+ * Error copy for the PR diff drill-in (#1363). The fetch failures here
+ * are actionable (auth expired, PR branch deleted, unsupported forge)
+ * so the surface leads with the CLI's message instead of a generic
+ * "no diff" hint that would read as an empty pull request.
+ */
+export function formatLogInkPullRequestDiffError({
+  message,
+}: LogInkPullRequestDiffErrorArgs): string {
+  return `Could not load the diff: ${message} Press esc to go back, r to refresh.`
+}
+
+/**
+ * Empty copy for the PR diff drill-in (#1363): the fetch succeeded but
+ * the patch is empty (e.g. an empty commit or a fully-reverted PR).
+ */
+export function formatLogInkPullRequestDiffEmpty(): string {
+  return 'No diff to display for this pull request.'
+}

--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -71,7 +71,7 @@ import {getGitOperationOverview} from '../../git/operationData'
 import {getProviderOverview} from '../../git/providerData'
 import {getForgeActions, getForgePullRequestOverview} from '../../git/forgeActions'
 import {issueFilterForPreset, pullRequestFilterForPreset} from '../../git/triageFilterPresets'
-import {getStashCommitHashes, getStashOverview} from '../../git/stashData'
+import {getStashCommitHashes, getStashOverview, parseStashDiffFiles} from '../../git/stashData'
 import {getWorktreeOverview} from '../../git/statusData'
 import {getBisectStatus} from '../../git/bisectData'
 import {getReflogOverview} from '../../git/reflogData'
@@ -205,6 +205,7 @@ import {useCommitDetailHydration, useCommitDetailState} from './hooks/useCommitD
 import {useContextHydration} from './hooks/useContextHydration'
 import {useBlameLoadingState, useDetailHydration, useFileHistoryLoadingState} from './hooks/useDetailHydration'
 import {useCommitFilePreviewHydration, useCommitFilePreviewState, useCompareDiffHydration, useCompareDiffState, useStashDiffHydration, useStashDiffState, useWorktreeDiffHydration, useWorktreeDiffState, useWorktreeHunksHydration, useWorktreeHunksState} from './hooks/useDiffHydration'
+import {usePullRequestDiffHydration, usePullRequestDiffState} from './hooks/usePullRequestDiffHydration'
 import {useDiffSyntaxHighlight, useDiffSyntaxState} from './hooks/useDiffSyntaxHighlight'
 import {useIdleTip} from './hooks/useIdleTip'
 import {useRefreshWatcher} from './hooks/useRefreshWatcher'
@@ -475,6 +476,15 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // #779 — compare-two-refs diff state. Loaded lazily when the diff
   // view becomes active with `diffSource === 'compare'`.
   const {compareDiffLines, setCompareDiffLines, compareDiffLoading, setCompareDiffLoading} = useCompareDiffState(React)
+  // #1363 — PR-triage diff state (Enter on a triage row). Loaded lazily
+  // when the diff view becomes active with `diffSource === 'pr'`; the
+  // loader hook below serves repeat opens from a bounded per-number
+  // cache invalidated when the triage list refetches.
+  const {
+    prDiffLines, setPrDiffLines,
+    prDiffLoading, setPrDiffLoading,
+    prDiffError, setPrDiffError,
+  } = usePullRequestDiffState(React)
   // Load-more pagination state, owned by `useHistoryPaginationState` (app.ts
   // decomposition item 3 / #1237). The `useState` pair stays in this exact
   // slot; the setters are shared (the loader `useLoadMoreHistory` below plus
@@ -568,6 +578,14 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     state.statusFilterMask,
     state.selectedWorktreeFileIndex,
     stashDiffLines,
+  )
+
+  // #1363 — per-file segmentation of the active PR patch (same
+  // `diff --git` walk as `stashDiffParsedFiles`), memoized so the `[`/`]`
+  // file-jump offsets in the input handler don't re-parse per keystroke.
+  const prDiffParsedFiles = React.useMemo(
+    () => (prDiffLines ? parseStashDiffFiles(prDiffLines) : []),
+    [prDiffLines],
   )
 
   // Filtered promoted-view lists (#808). These were recomputed inline
@@ -1033,6 +1051,23 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     }),
     [forgeProvider, forgePath, forgeGitlabHost, forgeCurrentBranch]
   )
+
+  // #1363 — load the PR patch (via the forge facade) once the diff view
+  // becomes active with diffSource='pr'. Same lazy-loader shape as the
+  // stash hydration above, plus a bounded per-number cache keyed on the
+  // triage list's identity (a refetch invalidates every cached patch)
+  // and a surfaced error message (a failed `gh pr diff` is actionable,
+  // unlike a missing stash diff).
+  usePullRequestDiffHydration(React, {
+    getPullRequestDiffByNumber: forge.getPullRequestDiffByNumber,
+    activeView: state.activeView,
+    diffSource: state.diffSource,
+    prDiffNumber: state.prDiffNumber,
+    pullRequestList: context.pullRequestList,
+    setPrDiffLines,
+    setPrDiffLoading,
+    setPrDiffError,
+  })
 
   React.useEffect(() => {
     if (state.activeView !== 'issues') return
@@ -1640,6 +1675,8 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     selectedWorktreeFile,
     stashDiffParsedFiles,
     stashDiffLines,
+    prDiffLines,
+    prDiffParsedFiles,
     filePreview,
     commitDiffHunkOffsets,
     detail,
@@ -1786,6 +1823,9 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
       stashDiffLoading,
       compareDiffLines,
       compareDiffLoading,
+      prDiffLines,
+      prDiffLoading,
+      prDiffError,
       bisectCandidateDetail,
       bisectCandidateLoading,
       blame: state.blamePath ? context.blameByPath?.get(state.blamePath) : undefined,

--- a/src/workstation/runtime/detailPanel.ts
+++ b/src/workstation/runtime/detailPanel.ts
@@ -229,6 +229,14 @@ export function renderDetailPanel(
     if (state.diffSource === 'commit') {
       return h(commitDiffDetailComponent(React), { detail, loading })
     }
+    // PR-sourced diff (#1363): keep the triage preview pane alongside
+    // the patch — the cursored triage row is the PR being viewed
+    // (`navigateOpenDiffForPullRequest` syncs the index), so the panel
+    // shows the PR's metadata / checks instead of a stale commit
+    // inspector.
+    if (state.diffSource === 'pr') {
+      return h(coreDetailComponent(React, 'prPreview')!)
+    }
     return h(coreDetailComponent(React, 'commit')!)
   }
 

--- a/src/workstation/runtime/hooks/useDetailHydration.ts
+++ b/src/workstation/runtime/hooks/useDetailHydration.ts
@@ -219,7 +219,12 @@ export function useDetailHydration(
   ])
 
   React.useEffect(() => {
-    if (state.activeView !== 'pull-request-triage') return
+    // #1363 — the PR-sourced diff keeps the triage preview panel on the
+    // right, so detail hydration stays live there too: a user who
+    // Enter-drills before the 250ms debounce fires still gets checks /
+    // reviewers next to the patch.
+    const onPrDiff = state.activeView === 'diff' && state.diffSource === 'pr'
+    if (state.activeView !== 'pull-request-triage' && !onPrDiff) return
     const cursored = filteredPullRequestTriageList[
       Math.min(
         state.selectedPullRequestTriageIndex,
@@ -253,6 +258,9 @@ export function useDetailHydration(
   }, [
     runtimes.length,
     state.activeView,
+    // #1363 — the guard reads the diff source (PR-sourced diff keeps
+    // hydrating); refire if it changes under a stable activeView.
+    state.diffSource,
     state.selectedPullRequestTriageIndex,
     filteredPullRequestTriageList,
     context.pullRequestDetailByNumber,

--- a/src/workstation/runtime/hooks/useInputHandler.ts
+++ b/src/workstation/runtime/hooks/useInputHandler.ts
@@ -96,6 +96,10 @@ export type UseInputHandlerDeps = {
 
   /** Active stash patch lines (drives the stash-diff preview path). */
   stashDiffLines: string[] | undefined
+  /** Active PR patch lines (#1363 — drives the PR-diff preview path). */
+  prDiffLines: string[] | undefined
+  /** Per-file segmentation of the PR patch (#1363 — `[`/`]` file jump). */
+  prDiffParsedFiles: StatusSurfaceData['stashDiffParsedFiles']
   /** Active commit-file diff preview (drives the commit-diff preview path). */
   filePreview: GitCommitFilePreview | undefined
   /** `@@`-header offsets within the commit-diff preview (hunk navigation). */
@@ -219,6 +223,8 @@ export function useInputHandler(
     selectedWorktreeFile,
     stashDiffParsedFiles,
     stashDiffLines,
+    prDiffLines,
+    prDiffParsedFiles,
     filePreview,
     commitDiffHunkOffsets,
     detail,
@@ -311,17 +317,22 @@ export function useInputHandler(
       Math.min(state.selectedIssueIndex, Math.max(0, filteredIssueList.length - 1))
     ]?.url
     const pullRequestTriageVisibleCount = filteredPullRequestTriageList.length
-    const pullRequestTriageSelectedUrl = filteredPullRequestTriageList[
+    const pullRequestTriageSelected = filteredPullRequestTriageList[
       Math.min(state.selectedPullRequestTriageIndex, Math.max(0, filteredPullRequestTriageList.length - 1))
-    ]?.url
+    ]
+    const pullRequestTriageSelectedUrl = pullRequestTriageSelected?.url
+    const pullRequestTriageSelectedNumber = pullRequestTriageSelected?.number
     const worktreeVisibleCount = filteredWorktreeList.length
 
-    // When the diff view is showing a stash patch, swap the previewLineCount
-    // to the stash diff length so the existing pageDetailPreview path
-    // (j/k, PgUp/PgDn) scrolls through it without a parallel pipeline.
+    // When the diff view is showing a stash or PR patch, swap the
+    // previewLineCount to that patch's length so the existing
+    // pageDetailPreview path (j/k, PgUp/PgDn) scrolls through it
+    // without a parallel pipeline.
     const diffPreviewLineCount = state.diffSource === 'stash'
       ? stashDiffLines?.length
-      : filePreview?.hunks.length
+      : state.diffSource === 'pr'
+        ? prDiffLines?.length
+        : filePreview?.hunks.length
 
     // Per-file segmentation for stash diffs reads the LogInkApp-scoped
     // memo so navigation keys + the input-context derivation share a
@@ -332,6 +343,13 @@ export function useInputHandler(
     const stashDiffSelectedPath = state.diffSource === 'stash'
       ? findStashFileForOffset(stashDiffFiles, state.diffPreviewOffset)?.path
       : undefined
+    // #1363 — same segmentation for the PR patch, feeding the `[`/`]`
+    // per-file jump on the PR diff. Distinct field (not overloading the
+    // stash one) so the stash-only verbs (`c` cherry-pick, `o` open)
+    // can't acquire a PR-diff target by accident.
+    const prDiffFileOffsets = state.diffSource === 'pr'
+      ? prDiffParsedFiles.map((file) => file.startLine)
+      : []
 
     getLogInkInputEvents(state, inputValue, key, {
       // Narrow terminals show one pane at a time (#1135) — gates the `v`
@@ -389,9 +407,11 @@ export function useInputHandler(
       issueSelectedUrl,
       pullRequestTriageCount: pullRequestTriageVisibleCount,
       pullRequestTriageSelectedUrl,
+      pullRequestTriageSelectedNumber,
       stashSelectedRef,
       stashDiffFileOffsets: stashDiffFileOffsets.length ? stashDiffFileOffsets : undefined,
       stashDiffSelectedPath,
+      prDiffFileOffsets: prDiffFileOffsets.length ? prDiffFileOffsets : undefined,
       worktreeListCount: worktreeVisibleCount,
       worktreeSelectedPath: visibleWorktreeFilesGrouped[state.selectedWorktreeFileIndex]?.path,
       statusGroups: visibleWorktreeGroups.map((group) => ({

--- a/src/workstation/runtime/hooks/usePullRequestDiffHydration.test.ts
+++ b/src/workstation/runtime/hooks/usePullRequestDiffHydration.test.ts
@@ -1,0 +1,242 @@
+import type * as ReactTypes from 'react'
+import type { PullRequestListOverview } from '../../../git/pullRequestListData'
+import {
+  PR_DIFF_CACHE_LIMIT,
+  createPullRequestDiffCache,
+  readPullRequestDiffCache,
+  usePullRequestDiffHydration,
+  usePullRequestDiffState,
+  writePullRequestDiffCache,
+  type UsePullRequestDiffHydrationDeps,
+} from './usePullRequestDiffHydration'
+
+/**
+ * Minimal fake React for the loader hook: `useRef` persists across
+ * "renders" (calls) like the real thing, and `useEffect` bodies are
+ * captured so the test can flush them (running the previous cleanup
+ * first, as React does when deps change).
+ */
+function hookHarness(): {
+  React: typeof ReactTypes
+  flushEffect: () => Promise<void>
+} {
+  const refs: Array<{ current: unknown }> = []
+  let refIndex = 0
+  let pendingEffect: (() => void | (() => void)) | undefined
+  let lastCleanup: (() => void) | undefined
+  const React = {
+    useRef: (initial: unknown) => {
+      if (refIndex >= refs.length) refs.push({ current: initial })
+      return refs[refIndex++]
+    },
+    useEffect: (fn: () => void | (() => void)) => {
+      pendingEffect = fn
+    },
+  } as unknown as typeof ReactTypes
+  return {
+    React,
+    flushEffect: async () => {
+      refIndex = 0
+      lastCleanup?.()
+      const cleanup = pendingEffect?.()
+      lastCleanup = typeof cleanup === 'function' ? cleanup : undefined
+      // Let the async loader body settle.
+      await new Promise((resolve) => setImmediate(resolve))
+    },
+  }
+}
+
+const overview = (tag: string): PullRequestListOverview =>
+  ({ available: true, authenticated: true, pullRequests: [], message: tag } as PullRequestListOverview)
+
+describe('PR diff cache (#1363)', () => {
+  it('round-trips entries within one generation', () => {
+    const cache = createPullRequestDiffCache()
+    const gen = overview('a')
+    writePullRequestDiffCache(cache, gen, 7, ['diff --git a/x b/x'])
+    expect(readPullRequestDiffCache(cache, gen, 7)).toEqual(['diff --git a/x b/x'])
+    expect(readPullRequestDiffCache(cache, gen, 8)).toBeUndefined()
+  })
+
+  it('invalidates every entry when the generation (triage list identity) changes', () => {
+    const cache = createPullRequestDiffCache()
+    const before = overview('before')
+    writePullRequestDiffCache(cache, before, 7, ['old patch'])
+    // Refresh / filter change replaces the overview object.
+    const after = overview('after')
+    expect(readPullRequestDiffCache(cache, after, 7)).toBeUndefined()
+    // And the old generation's entries are gone for good — a flip back
+    // to the same number under the new generation refetches.
+    writePullRequestDiffCache(cache, after, 7, ['new patch'])
+    expect(readPullRequestDiffCache(cache, after, 7)).toEqual(['new patch'])
+  })
+
+  it(`is bounded to the last ${PR_DIFF_CACHE_LIMIT} patches, LRU-evicted`, () => {
+    const cache = createPullRequestDiffCache()
+    const gen = overview('gen')
+    for (let n = 1; n <= PR_DIFF_CACHE_LIMIT; n += 1) {
+      writePullRequestDiffCache(cache, gen, n, [`patch ${n}`])
+    }
+    // Touch #1 so #2 becomes the least-recently-used entry.
+    expect(readPullRequestDiffCache(cache, gen, 1)).toEqual(['patch 1'])
+    writePullRequestDiffCache(cache, gen, PR_DIFF_CACHE_LIMIT + 1, ['patch new'])
+    expect(cache.entries.size).toBe(PR_DIFF_CACHE_LIMIT)
+    expect(readPullRequestDiffCache(cache, gen, 2)).toBeUndefined()
+    expect(readPullRequestDiffCache(cache, gen, 1)).toEqual(['patch 1'])
+    expect(readPullRequestDiffCache(cache, gen, PR_DIFF_CACHE_LIMIT + 1)).toEqual(['patch new'])
+  })
+})
+
+describe('usePullRequestDiffState', () => {
+  it('owns three slots: lines (undefined), loading (false), error (undefined)', () => {
+    const states: unknown[] = []
+    const React = {
+      useState: (init: unknown) => {
+        states.push(init)
+        return [init, jest.fn()]
+      },
+    } as unknown as typeof ReactTypes
+    const slots = usePullRequestDiffState(React)
+    expect(states).toEqual([undefined, false, undefined])
+    expect(slots.prDiffLines).toBeUndefined()
+    expect(slots.prDiffLoading).toBe(false)
+    expect(slots.prDiffError).toBeUndefined()
+  })
+})
+
+describe('usePullRequestDiffHydration', () => {
+  function makeDeps(
+    overrides: Partial<UsePullRequestDiffHydrationDeps> = {}
+  ): UsePullRequestDiffHydrationDeps & {
+    setPrDiffLines: jest.Mock
+    setPrDiffLoading: jest.Mock
+    setPrDiffError: jest.Mock
+  } {
+    return {
+      getPullRequestDiffByNumber: jest.fn().mockResolvedValue({ ok: true, lines: ['+x'] }),
+      activeView: 'diff',
+      diffSource: 'pr',
+      prDiffNumber: 41,
+      pullRequestList: overview('gen-1'),
+      setPrDiffLines: jest.fn(),
+      setPrDiffLoading: jest.fn(),
+      setPrDiffError: jest.fn(),
+      ...overrides,
+    } as UsePullRequestDiffHydrationDeps & {
+      setPrDiffLines: jest.Mock
+      setPrDiffLoading: jest.Mock
+      setPrDiffError: jest.Mock
+    }
+  }
+
+  it('loads the patch once the diff view is active with diffSource=pr', async () => {
+    const { React, flushEffect } = hookHarness()
+    const deps = makeDeps()
+    usePullRequestDiffHydration(React, deps)
+    await flushEffect()
+    expect(deps.getPullRequestDiffByNumber).toHaveBeenCalledWith(41)
+    expect(deps.setPrDiffLoading).toHaveBeenNthCalledWith(1, true)
+    expect(deps.setPrDiffLines).toHaveBeenCalledWith(['+x'])
+    expect(deps.setPrDiffLoading).toHaveBeenLastCalledWith(false)
+  })
+
+  // Unrolled (not a loop) so react-hooks/rules-of-hooks doesn't flag the
+  // harnessed hook call — each case gets its own fresh harness anyway.
+  it('bails (and clears the loading flag) when the diff view is not active', async () => {
+    const { React, flushEffect } = hookHarness()
+    const deps = makeDeps({ activeView: 'pull-request-triage' })
+    usePullRequestDiffHydration(React, deps)
+    await flushEffect()
+    expect(deps.getPullRequestDiffByNumber).not.toHaveBeenCalled()
+    expect(deps.setPrDiffLoading).toHaveBeenCalledWith(false)
+  })
+
+  it('bails when the diff is not PR-sourced (stash/commit/compare/worktree)', async () => {
+    const { React, flushEffect } = hookHarness()
+    const deps = makeDeps({ diffSource: 'stash' })
+    usePullRequestDiffHydration(React, deps)
+    await flushEffect()
+    expect(deps.getPullRequestDiffByNumber).not.toHaveBeenCalled()
+    expect(deps.setPrDiffLoading).toHaveBeenCalledWith(false)
+  })
+
+  it('bails when no PR number is recorded', async () => {
+    const { React, flushEffect } = hookHarness()
+    const deps = makeDeps({ prDiffNumber: undefined })
+    usePullRequestDiffHydration(React, deps)
+    await flushEffect()
+    expect(deps.getPullRequestDiffByNumber).not.toHaveBeenCalled()
+    expect(deps.setPrDiffLoading).toHaveBeenCalledWith(false)
+  })
+
+  it('serves a repeat open from the cache without refetching', async () => {
+    const { React, flushEffect } = hookHarness()
+    const deps = makeDeps()
+    usePullRequestDiffHydration(React, deps)
+    await flushEffect()
+    expect(deps.getPullRequestDiffByNumber).toHaveBeenCalledTimes(1)
+
+    // Pop back to the list…
+    usePullRequestDiffHydration(React, { ...deps, activeView: 'pull-request-triage' })
+    await flushEffect()
+    // …and re-open the same PR: cache hit, no second fetch, no loading flash.
+    deps.setPrDiffLoading.mockClear()
+    usePullRequestDiffHydration(React, deps)
+    await flushEffect()
+    expect(deps.getPullRequestDiffByNumber).toHaveBeenCalledTimes(1)
+    expect(deps.setPrDiffLines).toHaveBeenLastCalledWith(['+x'])
+    expect(deps.setPrDiffLoading).not.toHaveBeenCalledWith(true)
+  })
+
+  it('refetches after the triage list refreshes (new overview identity)', async () => {
+    const { React, flushEffect } = hookHarness()
+    const deps = makeDeps()
+    usePullRequestDiffHydration(React, deps)
+    await flushEffect()
+    usePullRequestDiffHydration(React, { ...deps, pullRequestList: overview('gen-2') })
+    await flushEffect()
+    expect(deps.getPullRequestDiffByNumber).toHaveBeenCalledTimes(2)
+  })
+
+  it('surfaces a fetch failure via setPrDiffError (and does not cache it)', async () => {
+    const { React, flushEffect } = hookHarness()
+    const deps = makeDeps({
+      getPullRequestDiffByNumber: jest
+        .fn()
+        .mockResolvedValueOnce({ ok: false, message: 'auth expired' })
+        .mockResolvedValue({ ok: true, lines: ['+fixed'] }),
+    })
+    usePullRequestDiffHydration(React, deps)
+    await flushEffect()
+    expect(deps.setPrDiffError).toHaveBeenCalledWith('auth expired')
+    expect(deps.setPrDiffLines).toHaveBeenCalledWith([])
+
+    // A retry (same deps re-fired) must hit the network again — errors
+    // are never cached.
+    usePullRequestDiffHydration(React, { ...deps, prDiffNumber: 41 })
+    await flushEffect()
+    expect(deps.getPullRequestDiffByNumber).toHaveBeenCalledTimes(2)
+    expect(deps.setPrDiffLines).toHaveBeenLastCalledWith(['+fixed'])
+    expect(deps.setPrDiffError).toHaveBeenLastCalledWith(undefined)
+  })
+
+  it('drops a stale in-flight resolve after cleanup (active flag)', async () => {
+    const { React, flushEffect } = hookHarness()
+    let resolveFetch: (value: { ok: true; lines: string[] }) => void = () => undefined
+    const deps = makeDeps({
+      getPullRequestDiffByNumber: jest.fn().mockReturnValue(
+        new Promise((resolve) => { resolveFetch = resolve })
+      ),
+    })
+    usePullRequestDiffHydration(React, deps)
+    await flushEffect()
+    // Navigate away — the next flush runs the cleanup for the in-flight
+    // effect before the guard-bail effect.
+    usePullRequestDiffHydration(React, { ...deps, diffSource: undefined })
+    await flushEffect()
+    deps.setPrDiffLines.mockClear()
+    resolveFetch({ ok: true, lines: ['+stale'] })
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(deps.setPrDiffLines).not.toHaveBeenCalled()
+  })
+})

--- a/src/workstation/runtime/hooks/usePullRequestDiffHydration.ts
+++ b/src/workstation/runtime/hooks/usePullRequestDiffHydration.ts
@@ -1,0 +1,220 @@
+/**
+ * PR-diff hydration for the triage Enter → diff drill-in (#1363).
+ *
+ * Mirrors `useDiffHydration`'s per-source discipline: a state hook owning
+ * the `useState` slots and a loader hook issuing one lazy effect, guarded
+ * on `activeView === 'diff' && diffSource === 'pr'` with an `active` flag
+ * flipped false in cleanup so a stale in-flight fetch can't clobber a
+ * newer selection. Like those loaders it writes to *local* `useState`
+ * slots — not the frame-tagged context — so the `active` flag alone is
+ * the cancellation story (#994's frame-tag applies to context writers).
+ *
+ * Two deliberate departures from the stash/compare loaders:
+ *
+ *   1. **Errors surface.** `gh pr diff` failures are actionable (auth
+ *      expired, PR closed + branch deleted, network) so the fetcher
+ *      returns `{ ok: false, message }` instead of throwing, and the
+ *      hook stores the message for the diff surface to render — a
+ *      silent "no diff" hint would read as an empty PR.
+ *   2. **Bounded per-number cache.** Patches are the most expensive
+ *      triage fetch (a full network round-trip per PR), and review
+ *      flows bounce between the list and a handful of diffs. The last
+ *      {@link PR_DIFF_CACHE_LIMIT} patches are kept, keyed by PR
+ *      number, LRU-evicted, and invalidated wholesale whenever the
+ *      triage list refetches (`pullRequestList` reference identity is
+ *      the cache generation — a refresh / filter change replaces the
+ *      overview object, so stale patches can't outlive the list that
+ *      produced them).
+ */
+
+import type * as ReactTypes from 'react'
+import type { PullRequestDiffResult } from '../../../git/pullRequestDiffData'
+import type { PullRequestListOverview } from '../../../git/pullRequestListData'
+import type { LogInkDiffSource, LogInkView } from '../inkViewModel'
+
+/** Max cached PR patches per generation. Small — a review session hops
+ * between a handful of PRs; anything larger just holds dead patches. */
+export const PR_DIFF_CACHE_LIMIT = 8
+
+/**
+ * Bounded LRU cache for PR patches. `generation` carries the
+ * `pullRequestList` overview identity the entries were fetched under;
+ * a mismatch on read/write resets the map (list refetched ⇒ every
+ * cached patch may be stale).
+ */
+export type PullRequestDiffCache = {
+  generation: unknown
+  entries: Map<number, string[]>
+}
+
+export function createPullRequestDiffCache(): PullRequestDiffCache {
+  return { generation: undefined, entries: new Map() }
+}
+
+/** Reset the cache when the triage list identity (generation) moved. */
+function syncCacheGeneration(cache: PullRequestDiffCache, generation: unknown): void {
+  if (cache.generation !== generation) {
+    cache.generation = generation
+    cache.entries.clear()
+  }
+}
+
+/**
+ * Cache read: returns the patch for `number` fetched under `generation`,
+ * refreshing its LRU position on hit. A generation mismatch clears the
+ * cache and misses.
+ */
+export function readPullRequestDiffCache(
+  cache: PullRequestDiffCache,
+  generation: unknown,
+  number: number
+): string[] | undefined {
+  syncCacheGeneration(cache, generation)
+  const hit = cache.entries.get(number)
+  if (hit === undefined) return undefined
+  // Map preserves insertion order — delete + set moves the entry to the
+  // back so eviction always drops the least-recently-used patch.
+  cache.entries.delete(number)
+  cache.entries.set(number, hit)
+  return hit
+}
+
+/**
+ * Cache write under `generation`, evicting the least-recently-used
+ * entry past {@link PR_DIFF_CACHE_LIMIT}.
+ */
+export function writePullRequestDiffCache(
+  cache: PullRequestDiffCache,
+  generation: unknown,
+  number: number,
+  lines: string[]
+): void {
+  syncCacheGeneration(cache, generation)
+  cache.entries.delete(number)
+  cache.entries.set(number, lines)
+  while (cache.entries.size > PR_DIFF_CACHE_LIMIT) {
+    const oldest = cache.entries.keys().next()
+    if (oldest.done) break
+    cache.entries.delete(oldest.value)
+  }
+}
+
+/**
+ * Owns the PR-diff `useState` slots. All three setters are written only
+ * by {@link usePullRequestDiffHydration}. Returns the values (read by
+ * the diff surface render) + setters (threaded into the loader). Same
+ * state-hook/loader-hook split as `useStashDiffState` — call each at a
+ * stable slot in `app.ts` to preserve React hook ordering.
+ */
+export function usePullRequestDiffState(React: typeof ReactTypes): {
+  prDiffLines: string[] | undefined
+  setPrDiffLines: ReactTypes.Dispatch<ReactTypes.SetStateAction<string[] | undefined>>
+  prDiffLoading: boolean
+  setPrDiffLoading: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
+  prDiffError: string | undefined
+  setPrDiffError: ReactTypes.Dispatch<ReactTypes.SetStateAction<string | undefined>>
+} {
+  const [prDiffLines, setPrDiffLines] = React.useState<string[] | undefined>(undefined)
+  const [prDiffLoading, setPrDiffLoading] = React.useState(false)
+  const [prDiffError, setPrDiffError] = React.useState<string | undefined>(undefined)
+  return {
+    prDiffLines,
+    setPrDiffLines,
+    prDiffLoading,
+    setPrDiffLoading,
+    prDiffError,
+    setPrDiffError,
+  }
+}
+
+export type UsePullRequestDiffHydrationDeps = {
+  /**
+   * Patch fetcher — `forge.getPullRequestDiffByNumber` (identity-stable:
+   * `forge` is memoized on the detected provider in `app.ts`). Injected
+   * as a function so tests exercise the effect without a forge facade.
+   */
+  getPullRequestDiffByNumber: (n: number) => Promise<PullRequestDiffResult>
+  /** `state.activeView` — only `'diff'` triggers a load. */
+  activeView: LogInkView
+  /** `state.diffSource` — only `'pr'` triggers a load. */
+  diffSource: LogInkDiffSource | undefined
+  /** `state.prDiffNumber` — the PR number to fetch. */
+  prDiffNumber: number | undefined
+  /**
+   * The triage list overview — its reference identity is the cache
+   * generation. A refetch (refresh, filter change, frame swap) replaces
+   * the object and invalidates every cached patch.
+   */
+  pullRequestList: PullRequestListOverview | undefined
+  /** Writer for the loaded patch lines. */
+  setPrDiffLines: ReactTypes.Dispatch<ReactTypes.SetStateAction<string[] | undefined>>
+  /** Loading-flag setter for the patch fetch. */
+  setPrDiffLoading: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
+  /** Writer for the surfaced fetch-error message. */
+  setPrDiffError: ReactTypes.Dispatch<ReactTypes.SetStateAction<string | undefined>>
+}
+
+/**
+ * #1363 — load `gh pr diff <n>` (via the forge facade) once the diff
+ * view becomes active with `diffSource === 'pr'`, serving repeat opens
+ * from the bounded per-number cache.
+ */
+export function usePullRequestDiffHydration(
+  React: typeof ReactTypes,
+  deps: UsePullRequestDiffHydrationDeps,
+): void {
+  const {
+    getPullRequestDiffByNumber,
+    activeView,
+    diffSource,
+    prDiffNumber,
+    pullRequestList,
+    setPrDiffLines,
+    setPrDiffLoading,
+    setPrDiffError,
+  } = deps
+
+  const cacheRef = React.useRef<PullRequestDiffCache>(createPullRequestDiffCache())
+
+  React.useEffect(() => {
+    if (activeView !== 'diff' || diffSource !== 'pr' || !prDiffNumber) {
+      // Clear the loading flag on the guard-fail bail (see the stash
+      // loader): a view change while a fetch is in flight would
+      // otherwise leave it stuck `true`.
+      setPrDiffLoading(false)
+      return
+    }
+    const cached = readPullRequestDiffCache(cacheRef.current, pullRequestList, prDiffNumber)
+    if (cached !== undefined) {
+      setPrDiffLines(cached)
+      setPrDiffError(undefined)
+      setPrDiffLoading(false)
+      return
+    }
+    let active = true
+    setPrDiffLoading(true)
+    setPrDiffError(undefined)
+    void (async () => {
+      // The fetcher never throws — failures ride `{ ok: false }` — but
+      // guard anyway so an unexpected rejection degrades to the error
+      // line instead of an unhandled rejection.
+      const result = await getPullRequestDiffByNumber(prDiffNumber).catch(
+        (error: unknown): PullRequestDiffResult => ({
+          ok: false,
+          message: error instanceof Error ? error.message : String(error),
+        })
+      )
+      if (!active) return
+      if (result.ok) {
+        writePullRequestDiffCache(cacheRef.current, pullRequestList, prDiffNumber, result.lines)
+        setPrDiffLines(result.lines)
+        setPrDiffError(undefined)
+      } else {
+        setPrDiffLines([])
+        setPrDiffError(result.message)
+      }
+      setPrDiffLoading(false)
+    })()
+    return () => { active = false }
+  }, [getPullRequestDiffByNumber, activeView, diffSource, prDiffNumber, pullRequestList])
+}

--- a/src/workstation/runtime/hooks/useWorkflowAction.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.ts
@@ -212,6 +212,31 @@ export function resolvePendingItemAction(
       : all[Math.min(state.selectedWorktreeListIndex, Math.max(0, all.length - 1))]
     return wt ? { kind: 'worktree', id: wt.path, action: 'delete' } : undefined
   }
+  // #1363 — `gh pr checkout <n>` gets the same inline row spinner as a
+  // branch checkout. Resolution mirrors `buildFilteredLists`'s triage
+  // filter fields so the spinner lands on exactly the row the handler
+  // will act on.
+  if (id === 'triage-pr-checkout') {
+    const all = context.pullRequestList?.pullRequests || []
+    const visible = filter
+      ? all.filter((pr) =>
+          matchesPromotedFilter(
+            [
+              `#${pr.number}`,
+              pr.title,
+              pr.author || '',
+              pr.headRefName,
+              pr.baseRefName,
+              ...(pr.labels || []),
+              ...(pr.assignees || []),
+            ],
+            filter
+          )
+        )
+      : all
+    const pr = visible[Math.min(state.selectedPullRequestTriageIndex, Math.max(0, visible.length - 1))]
+    return pr ? { kind: 'pull-request', id: String(pr.number), action: 'checkout' } : undefined
+  }
   return undefined
 }
 
@@ -1408,6 +1433,27 @@ export function useWorkflowAction(
         if (result.ok) invalidatePullRequestListCaches(pr.number)
         return result
       },
+      // #1363 — `gh pr checkout <n>` for the cursored triage row. The
+      // only triage verb that mutates LOCAL state (HEAD moves), so it
+      // skips the list-cache invalidation (the PR itself is untouched)
+      // and instead rides the checkout follow-ups below: history
+      // refresh + cursor snap + silent context refresh, exactly like
+      // `checkout-branch`.
+      'triage-pr-checkout': async () => {
+        // The PR-diff `C` path carries the viewed PR's number as the
+        // payload (the triage cursor could drift if the list refetched
+        // under the open diff); the triage-list `C` path omits it and
+        // targets the cursored row.
+        const payloadNumber = Number(payload)
+        if (payload && Number.isInteger(payloadNumber) && payloadNumber > 0) {
+          return forge.checkoutPullRequestByNumber(payloadNumber)
+        }
+        const pr = filteredPullRequestTriageList[
+          Math.min(state.selectedPullRequestTriageIndex, Math.max(0, filteredPullRequestTriageList.length - 1))
+        ]
+        if (!pr) return { ok: false, message: 'No pull request under cursor' }
+        return forge.checkoutPullRequestByNumber(pr.number)
+      },
       // Status surface group-level batch ops (#791 follow-up). The
       // input handler dispatches these when the user presses Enter on a
       // group header. We re-derive the file list from the live
@@ -1683,6 +1729,10 @@ export function useWorkflowAction(
       // changes HEAD — refresh the graph so the current-branch marker
       // and history view reflect the switch (#1326).
       'checkout-created-branch',
+      // `gh pr checkout <n>` fetches the PR branch and moves HEAD onto
+      // it — refresh so the PR's commits and the current-branch marker
+      // appear (#1363).
+      'triage-pr-checkout',
     ])
     if (result?.ok && historyMutatingIds.has(id)) {
       await refreshHistoryRows()
@@ -1697,7 +1747,7 @@ export function useWorkflowAction(
     // (resolvePendingItemAction → action 'checkout'), so a silent
     // stale-while-revalidate swap keeps the list readable and just
     // repaints the current-branch marker once the new context lands.
-    if ((id === 'checkout-branch' || id === 'conflict-remove-worktree-checkout' || id === 'checkout-created-branch') && result?.ok) {
+    if ((id === 'checkout-branch' || id === 'conflict-remove-worktree-checkout' || id === 'checkout-created-branch' || id === 'triage-pr-checkout') && result?.ok) {
       dispatch({ type: 'resetBranchSelection' })
       await refreshContext({ silent: true })
     } else {

--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -5298,6 +5298,107 @@ describe('triage-view per-row actions (#882 phase 4)', () => {
       const result = applyInput(state, 'c')
       expect(result.inputPrompt?.kind).toBe('pr-comment')
     })
+
+    // #1363 — Enter on a triage row opens the PR diff.
+    it('Enter opens the PR diff for the cursored row', () => {
+      const state = applyInput(baseState(), '', { return: true }, {
+        pullRequestTriageCount: 2,
+        pullRequestTriageSelectedNumber: 962,
+      })
+      expect(state.activeView).toBe('diff')
+      expect(state.diffSource).toBe('pr')
+      expect(state.prDiffNumber).toBe(962)
+      expect(state.statusMessage).toBe('viewing diff for #962')
+    })
+
+    it('Enter stays inert while the triage list is loading / empty (zero count)', () => {
+      const events = getLogInkInputEvents(baseState(), '', { return: true }, {
+        pullRequestTriageCount: 0,
+      })
+      expect(events.find((event) =>
+        event.type === 'action' && event.action.type === 'navigateOpenDiffForPullRequest'
+      )).toBeUndefined()
+      // And without a resolved number (defensive — count>0 implies one).
+      const noNumber = getLogInkInputEvents(baseState(), '', { return: true }, {
+        pullRequestTriageCount: 2,
+      })
+      expect(noNumber.find((event) =>
+        event.type === 'action' && event.action.type === 'navigateOpenDiffForPullRequest'
+      )).toBeUndefined()
+    })
+
+    // #1363 — C on a triage row checks the PR out locally instead of
+    // opening the create-PR flow (the view opted out of CREATE_PR_VIEWS).
+    it('C dispatches the triage-pr-checkout workflow for the cursored row', () => {
+      const events = getLogInkInputEvents(baseState(), 'C', {}, {
+        pullRequestTriageCount: 2,
+        pullRequestTriageSelectedNumber: 962,
+      })
+      expect(events).toEqual([{ type: 'runWorkflowAction', id: 'triage-pr-checkout' }])
+    })
+
+    it('C never fires create-PR from the triage view, even with an empty list', () => {
+      // With rows in scope C means checkout; with none it must be inert
+      // rather than falling through to the create-PR workflow.
+      for (const context of [
+        { pullRequestTriageCount: 2, pullRequestTriageSelectedNumber: 962 },
+        {},
+      ]) {
+        const events = getLogInkInputEvents(baseState(), 'C', {}, context)
+        expect(events).not.toContainEqual({ type: 'startCreatePullRequest' })
+        expect(events).not.toContainEqual({ type: 'runWorkflowAction', id: 'create-pr' })
+      }
+    })
+  })
+})
+
+describe('PR diff view keys (#1363)', () => {
+  const prDiffState = (): LogInkState => {
+    let state = applyLogInkAction(createLogInkState(rows), {
+      type: 'pushView',
+      value: 'pull-request-triage',
+    })
+    state = applyLogInkAction(state, { type: 'navigateOpenDiffForPullRequest', number: 962 })
+    return state
+  }
+
+  it('j/k line-scroll the PR patch via previewLineCount', () => {
+    let state = prDiffState()
+    state = applyInput(state, 'j', {}, { previewLineCount: 40 })
+    expect(state.diffPreviewOffset).toBe(1)
+    state = applyInput(state, 'k', {}, { previewLineCount: 40 })
+    expect(state.diffPreviewOffset).toBe(0)
+  })
+
+  it('[ and ] jump between files via prDiffFileOffsets', () => {
+    let state = prDiffState()
+    const offsets = [0, 12, 30]
+    state = applyInput(state, ']', {}, { prDiffFileOffsets: offsets })
+    expect(state.diffPreviewOffset).toBe(12)
+    state = applyInput(state, ']', {}, { prDiffFileOffsets: offsets })
+    expect(state.diffPreviewOffset).toBe(30)
+    state = applyInput(state, '[', {}, { prDiffFileOffsets: offsets })
+    expect(state.diffPreviewOffset).toBe(12)
+  })
+
+  it('C checks out the viewed PR, carrying the number as the payload', () => {
+    const events = getLogInkInputEvents(prDiffState(), 'C', {}, {})
+    expect(events).toEqual([
+      { type: 'runWorkflowAction', id: 'triage-pr-checkout', payload: '962' },
+    ])
+  })
+
+  it('stash-only verbs stay dead on the PR diff (no cherry-pick / editor target)', () => {
+    // `c` on a stash diff cherry-picks the cursored file; on a PR diff
+    // the file may not exist locally, so the key must not resolve a
+    // target even when file offsets are present.
+    const events = getLogInkInputEvents(prDiffState(), 'c', {}, {
+      prDiffFileOffsets: [0, 10],
+    })
+    expect(events.find((event) =>
+      event.type === 'action' && event.action.type === 'setPendingConfirmation'
+    )).toBeUndefined()
+    expect(events).not.toContainEqual(expect.objectContaining({ type: 'openFileInEditor' }))
   })
 })
 
@@ -5703,9 +5804,12 @@ const ALL_VIEWS: LogInkView[] = [
 ]
 
 describe('global key allowlists (negation-guard conversion)', () => {
-  it('C creates a PR in every view except conflicts', () => {
+  it('C creates a PR in every view except conflicts and the PR triage list', () => {
+    // conflicts → C marks the conflict resolved; pull-request-triage →
+    // C checks the cursored PR out locally (#1363).
+    const excluded: LogInkView[] = ['conflicts', 'pull-request-triage']
     for (const view of ALL_VIEWS) {
-      expect(isCreatePrView(view)).toBe(view !== 'conflicts')
+      expect(isCreatePrView(view)).toBe(!excluded.includes(view))
     }
   })
 

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -165,6 +165,11 @@ export type LogInkInputContext = {
   pullRequestTriageCount?: number
   /** URL of the cursored PR in the triage list view (#882 phase 3). */
   pullRequestTriageSelectedUrl?: string
+  /**
+   * Number of the cursored PR in the triage list view (#1363). Drives
+   * the Enter → PR diff drill-in and the `C` checkout workflow.
+   */
+  pullRequestTriageSelectedNumber?: number
   worktreeListCount?: number
   /** Ref of the stash currently under the cursor (e.g. `stash@{0}`). */
   stashSelectedRef?: string
@@ -179,6 +184,13 @@ export type LogInkInputContext = {
    * patch. Used by `c` (cherry-pick) to know which path to materialize.
    */
   stashDiffSelectedPath?: string
+  /**
+   * Per-file `diff --git` line offsets inside the active PR diff
+   * (#1363). Used by `]` / `[` to jump to next / previous file within
+   * the PR patch — a distinct field from `stashDiffFileOffsets` so the
+   * stash-only verbs never acquire a PR-diff target.
+   */
+  prDiffFileOffsets?: number[]
   /**
    * Path of the cursored file in the worktree (status / worktree diff
    * views). Used by `o` (open in $EDITOR).
@@ -483,10 +495,13 @@ function isWorktreeDiffTarget(state: LogInkState): boolean {
  * views are absent so the lists can't silently drift.
  */
 // Bare `C` creates a pull request everywhere EXCEPT the conflicts view, where
-// `C` means "mark conflict resolved".
+// `C` means "mark conflict resolved", and the PR-triage view, where `C`
+// means `gh pr checkout <n>` for the cursored row (#1363) — on a list of
+// existing PRs, "get this PR's branch locally" is the far likelier intent
+// than opening a brand-new PR.
 const CREATE_PR_VIEWS: readonly LogInkView[] = [
   'history', 'status', 'diff', 'compose', 'branches', 'tags', 'stash',
-  'worktrees', 'pull-request', 'pull-request-triage', 'issues', 'reflog',
+  'worktrees', 'pull-request', 'issues', 'reflog',
   'bisect', 'changelog', 'submodules', 'remotes',
 ]
 // Bare `S` creates a stash everywhere EXCEPT the commit triad
@@ -2484,6 +2499,13 @@ export function getLogInkInputEvents(
         hunkOffsets: context.stashDiffFileOffsets,
       })]
     }
+    if (state.activeView === 'diff' && state.diffSource === 'pr' && context.prDiffFileOffsets?.length) {
+      return [action({
+        type: 'jumpCommitDiffHunk',
+        delta: -1,
+        hunkOffsets: context.prDiffFileOffsets,
+      })]
+    }
     if (state.activeView === 'diff' && context.commitDiffHunkOffsets?.length) {
       return [action({
         type: 'jumpCommitDiffHunk',
@@ -2514,6 +2536,13 @@ export function getLogInkInputEvents(
         type: 'jumpCommitDiffHunk',
         delta: 1,
         hunkOffsets: context.stashDiffFileOffsets,
+      })]
+    }
+    if (state.activeView === 'diff' && state.diffSource === 'pr' && context.prDiffFileOffsets?.length) {
+      return [action({
+        type: 'jumpCommitDiffHunk',
+        delta: 1,
+        hunkOffsets: context.prDiffFileOffsets,
       })]
     }
     if (state.activeView === 'diff' && context.commitDiffHunkOffsets?.length) {
@@ -3530,6 +3559,29 @@ export function getLogInkInputEvents(
   // issue handlers above; distinct view id so the keys don't
   // collide with the single-PR action panel (`pull-request`).
   if (state.activeView === 'pull-request-triage' && state.focus === 'commits') {
+    // #1363 — Enter opens the PR diff (`gh pr diff <n>` hydrated by the
+    // runtime once the view lands). Both guards matter: a zero count
+    // (list still loading / empty / fully filtered out) or a missing
+    // number mean there is no row to drill into, so Enter stays inert
+    // instead of pushing a source-less diff view.
+    if (key.return && context.pullRequestTriageCount && context.pullRequestTriageSelectedNumber) {
+      return [
+        action({
+          type: 'navigateOpenDiffForPullRequest',
+          number: context.pullRequestTriageSelectedNumber,
+          pullRequestIndex: state.selectedPullRequestTriageIndex,
+        }),
+        action({ type: 'setStatus', value: `viewing diff for #${context.pullRequestTriageSelectedNumber}` }),
+      ]
+    }
+    // #1363 — `C` checks the cursored PR out locally (`gh pr checkout
+    // <n>`), the "review this properly" one-key. The triage view opted
+    // OUT of the global create-PR `C` allowlist (see CREATE_PR_VIEWS)
+    // so this binding owns the key here; create-PR stays reachable from
+    // every other opted-in view.
+    if (inputValue === 'C' && context.pullRequestTriageCount && context.pullRequestTriageSelectedNumber) {
+      return [{ type: 'runWorkflowAction', id: 'triage-pr-checkout' }]
+    }
     if (inputValue === 'O' && context.pullRequestTriageSelectedUrl) {
       return [{ type: 'runWorkflowAction', id: 'triage-pr-open' }]
     }
@@ -3714,6 +3766,15 @@ export function getLogInkInputEvents(
       value: 'Finish or cancel the commit draft before creating a PR.',
       kind: 'warning',
     })]
+  }
+  // #1363 — `C` on the PR diff checks the viewed PR out locally, the
+  // natural "read the patch → review it properly" follow-up. Must sit
+  // before the create-PR fallthrough below ('diff' is an opted-in
+  // create-PR view; only the PR-sourced diff repurposes the key). The
+  // PR number travels as the payload so the runner targets the viewed
+  // PR even if the triage list refetched underneath the diff.
+  if (inputValue === 'C' && state.activeView === 'diff' && state.diffSource === 'pr' && state.prDiffNumber) {
+    return [{ type: 'runWorkflowAction', id: 'triage-pr-checkout', payload: String(state.prDiffNumber) }]
   }
   if (inputValue === 'C' && isCreatePrView(state.activeView)) {
     return [{ type: 'startCreatePullRequest' }]

--- a/src/workstation/runtime/inkKeymap.test.ts
+++ b/src/workstation/runtime/inkKeymap.test.ts
@@ -732,3 +732,32 @@ describe('log Ink keymap', () => {
     })
   })
 })
+
+describe('PR triage review flow hints (#1363)', () => {
+  it('surfaces the enter-diff + C-checkout pair on the triage list footer', () => {
+    const hints = getLogInkFooterHints({
+      activeView: 'pull-request-triage',
+      filterMode: false,
+      focus: 'commits',
+      showHelp: false,
+    })
+    expect(hints.contextual).toContain('enter diff')
+    expect(hints.contextual).toContain('C checkout')
+  })
+
+  it('gives the PR-sourced diff its own read-only hint set (file jump + checkout, no mutate verbs)', () => {
+    const hints = getLogInkFooterHints({
+      activeView: 'diff',
+      diffSource: 'pr',
+      filterMode: false,
+      focus: 'commits',
+      showHelp: false,
+    })
+    expect(hints.contextual).toEqual(['j/k lines', '[/] file', 'C checkout', 'd split', 'esc back'])
+    // The stash/commit-diff mutate verbs must not leak in — the PR's
+    // files aren't in the local worktree.
+    expect(hints.contextual).not.toContain('c cherry-pick')
+    expect(hints.contextual).not.toContain('H apply hunk')
+    expect(hints.contextual).not.toContain('o edit')
+  })
+})

--- a/src/workstation/runtime/inkKeymap.ts
+++ b/src/workstation/runtime/inkKeymap.ts
@@ -664,7 +664,7 @@ export type GetLogInkFooterHintsOptions = {
   activeView?: LogInkView
   /** Used to differentiate the diff-view hints between commit / worktree
    *  / stash sources without reaching into runtime state. */
-  diffSource?: 'commit' | 'worktree' | 'stash' | 'compare'
+  diffSource?: 'commit' | 'worktree' | 'stash' | 'compare' | 'pr'
   filterMode: boolean
   focus: LogInkFocus
   showHelp: boolean
@@ -1282,6 +1282,17 @@ function computeLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogInkF
         global: NORMAL_GLOBAL_HINTS,
       }
     }
+    if (options.diffSource === 'pr') {
+      // PR-triage drill-in (#1363): read-only like compare (the files
+      // live on the PR's head branch, so no cherry-pick / hunk apply /
+      // open-in-editor), but with the stash diff's per-file `[/]` jump.
+      // `C` checks the PR's branch out locally — the "review this
+      // properly" follow-up to reading the patch.
+      return {
+        contextual: ['j/k lines', '[/] file', 'C checkout', splitToggleHint, 'esc back'],
+        global: NORMAL_GLOBAL_HINTS,
+      }
+    }
     // Worktree (staging) diff. Consistent with the commit/stash diffs
     // (#1185): j/k scroll lines, [/] jump between hunks. space stages /
     // unstages the hunk under the viewport, a stages the whole file, z
@@ -1384,9 +1395,10 @@ function computeLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogInkF
   if (options.activeView === 'pull-request-triage') {
     return {
       // #882 phase 4-6 — full PR action panel scoped to the triage
-      // list + filter cycling. AI summarize (`I`) deferred to a
-      // follow-up.
-      contextual: ['↑/↓ PRs', 'f filter', 'O open', 'y yank URL', 'c comment', 'L label', 'A assign', 'm merge*', 'x close*', 'a approve', 'R changes*', 'esc back'],
+      // list + filter cycling; #1363 adds the review pair (enter →
+      // read the diff, C → check the branch out locally). AI
+      // summarize (`I`) deferred to a follow-up.
+      contextual: ['↑/↓ PRs', 'enter diff', 'C checkout', 'f filter', 'O open', 'y yank URL', 'c comment', 'L label', 'A assign', 'm merge*', 'x close*', 'a approve', 'R changes*', 'esc back'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/workstation/runtime/inkViewModel.test.ts
+++ b/src/workstation/runtime/inkViewModel.test.ts
@@ -2592,3 +2592,65 @@ describe('worktree hunk navigation — viewport-derived current hunk (#1179)', (
     expect(hunkIndexAtOffset(state.worktreeDiffOffset, offsets)).toBe(2)
   })
 })
+
+describe('PR-triage diff drill-in (#1363)', () => {
+  it('navigateOpenDiffForPullRequest pushes the diff view tagged diffSource=pr', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'pull-request-triage' })
+    state = applyLogInkAction(state, {
+      type: 'navigateOpenDiffForPullRequest',
+      number: 962,
+      pullRequestIndex: 3,
+    })
+    expect(state.activeView).toBe('diff')
+    expect(state.viewStack).toEqual(['history', 'pull-request-triage', 'diff'])
+    expect(state.diffSource).toBe('pr')
+    expect(state.prDiffNumber).toBe(962)
+    expect(state.selectedPullRequestTriageIndex).toBe(3)
+  })
+
+  it('resets the scroll offsets and line-select anchor so the patch opens at the top', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pageDetailPreview', delta: 5, previewLineCount: 100 })
+    expect(state.diffPreviewOffset).toBeGreaterThan(0)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'pull-request-triage' })
+    state = applyLogInkAction(state, { type: 'navigateOpenDiffForPullRequest', number: 7 })
+    expect(state.diffPreviewOffset).toBe(0)
+    expect(state.worktreeDiffOffset).toBe(0)
+    expect(state.diffLineSelectAnchor).toBeUndefined()
+  })
+
+  it('popping the diff view clears diffSource and prDiffNumber (mirrors stashDiffRef)', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'pull-request-triage' })
+    state = applyLogInkAction(state, { type: 'navigateOpenDiffForPullRequest', number: 962 })
+    state = applyLogInkAction(state, { type: 'popView' })
+    expect(state.activeView).toBe('pull-request-triage')
+    expect(state.diffSource).toBeUndefined()
+    expect(state.prDiffNumber).toBeUndefined()
+  })
+
+  it('pushing a non-diff view over the PR diff clears the PR diff identity', () => {
+    let state = createLogInkState(rows)
+    state = applyLogInkAction(state, { type: 'pushView', value: 'pull-request-triage' })
+    state = applyLogInkAction(state, { type: 'navigateOpenDiffForPullRequest', number: 962 })
+    state = applyLogInkAction(state, { type: 'pushView', value: 'history' })
+    expect(state.prDiffNumber).toBeUndefined()
+    expect(state.diffSource).toBeUndefined()
+  })
+
+  it('repo-frame push/pop round-trips the PR diff identity (#931 capture discipline)', () => {
+    let state = createLogInkState(rows, { repoLabel: 'coco' })
+    state = applyLogInkAction(state, { type: 'pushView', value: 'pull-request-triage' })
+    state = applyLogInkAction(state, { type: 'navigateOpenDiffForPullRequest', number: 962 })
+    state = applyLogInkAction(state, { type: 'pushRepoFrame', label: 'vendor/lib' })
+    // The child frame opens on its own history view; any view push
+    // inside it clears the carried diff identity (same shared-state
+    // semantics as stashDiffRef — see LogInkRepoFrameReturn's doc).
+    expect(state.activeView).toBe('history')
+    state = applyLogInkAction(state, { type: 'popRepoFrame' })
+    expect(state.activeView).toBe('diff')
+    expect(state.diffSource).toBe('pr')
+    expect(state.prDiffNumber).toBe(962)
+  })
+})

--- a/src/workstation/runtime/inkViewModel.ts
+++ b/src/workstation/runtime/inkViewModel.ts
@@ -37,7 +37,7 @@ export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk' | 'discar
  * async action runs against them. Each maps to a surface + a stable
  * per-row id used by `pendingItemAction`.
  */
-export type LogInkListItemKind = 'branch' | 'tag' | 'stash' | 'worktree'
+export type LogInkListItemKind = 'branch' | 'tag' | 'stash' | 'worktree' | 'pull-request'
 
 /**
  * Which async action is in flight on the pending row. The inline
@@ -184,6 +184,7 @@ export type LogInkRepoFrameReturn = {
    */
   diffSource?: LogInkDiffSource
   stashDiffRef?: string
+  prDiffNumber?: number
   compareHead?: LogInkCompareRef
   selectedIndex: number
   selectedFileIndex: number
@@ -241,7 +242,7 @@ export type LogInkRepoFrameReturn = {
  * input handlers off this field so a dirty worktree can't bleed staging
  * UI into a commit-diff view.
  */
-export type LogInkDiffSource = 'commit' | 'worktree' | 'stash' | 'compare'
+export type LogInkDiffSource = 'commit' | 'worktree' | 'stash' | 'compare' | 'pr'
 
 /**
  * A ref in the compare-two-refs flow (#779). `kind` is captured from
@@ -660,6 +661,13 @@ export type LogInkState = {
    */
   stashDiffRef?: string
   /**
+   * Pull-request number currently being inspected in the diff view
+   * (#1363 — triage Enter → PR diff). Set by
+   * `navigateOpenDiffForPullRequest`; cleared when the diff view is
+   * popped or replaced, mirroring `stashDiffRef`.
+   */
+  prDiffNumber?: number
+  /**
    * Compare-two-refs flow (#779). `compareBase` is set by `m` on a
    * branch / tag / history row; while it's defined, the footer shows
    * a "compare base: <label>" hint and `Enter` on a second ref opens
@@ -1069,6 +1077,7 @@ export type LogInkAction =
   | { type: 'navigateOpenFileHistoryForPath'; path: string }
   | { type: 'moveFileHistory'; delta: number; count: number }
   | { type: 'navigateOpenDiffForStash'; ref: string; stashIndex?: number }
+  | { type: 'navigateOpenDiffForPullRequest'; number: number; pullRequestIndex?: number }
   | { type: 'navigateOpenDiffForCompare'; base: LogInkCompareRef; head: LogInkCompareRef }
   | { type: 'setCompareBase'; value: LogInkCompareRef }
   | { type: 'clearCompareBase' }
@@ -1307,6 +1316,7 @@ function withPushedView(state: LogInkState, value: LogInkView): LogInkState {
     diffLineSelectAnchor: value === 'diff' ? state.diffLineSelectAnchor : undefined,
     diffSource: value === 'diff' ? state.diffSource : undefined,
     stashDiffRef: value === 'diff' ? state.stashDiffRef : undefined,
+    prDiffNumber: value === 'diff' ? state.prDiffNumber : undefined,
     compareHead: value === 'diff' ? state.compareHead : undefined,
     pendingCommitFocused: value === 'history' ? state.pendingCommitFocused : false,
     statusGroupHeaderFocused: value === 'status' ? state.statusGroupHeaderFocused : false,
@@ -1345,6 +1355,7 @@ function withPoppedView(state: LogInkState): LogInkState {
     worktreeDiffOffset: next === 'diff' ? state.worktreeDiffOffset : 0,
     diffSource: next === 'diff' ? state.diffSource : undefined,
     stashDiffRef: next === 'diff' ? state.stashDiffRef : undefined,
+    prDiffNumber: next === 'diff' ? state.prDiffNumber : undefined,
     compareBase: wasOnDiff ? undefined : state.compareBase,
     compareHead: next === 'diff' ? state.compareHead : undefined,
     pendingCommitFocused: next === 'history' ? state.pendingCommitFocused : false,
@@ -1393,6 +1404,7 @@ function withPushedRepoFrame(
       viewStack: [...state.viewStack],
       diffSource: state.diffSource,
       stashDiffRef: state.stashDiffRef,
+      prDiffNumber: state.prDiffNumber,
       compareHead: state.compareHead,
       selectedIndex: state.selectedIndex,
       selectedFileIndex: state.selectedFileIndex,
@@ -1491,6 +1503,7 @@ function withPoppedRepoFrame(state: LogInkState): LogInkState {
     viewStack: ret.viewStack?.length ? [...ret.viewStack] : [ret.activeView],
     diffSource: ret.diffSource,
     stashDiffRef: ret.stashDiffRef,
+    prDiffNumber: ret.prDiffNumber,
     compareHead: ret.compareHead,
     selectedIndex: ret.selectedIndex,
     selectedFileIndex: ret.selectedFileIndex,
@@ -1548,6 +1561,7 @@ function withReplacedView(state: LogInkState, value: LogInkView): LogInkState {
     diffLineSelectAnchor: value === 'diff' ? state.diffLineSelectAnchor : undefined,
     diffSource: value === 'diff' ? state.diffSource : undefined,
     stashDiffRef: value === 'diff' ? state.stashDiffRef : undefined,
+    prDiffNumber: value === 'diff' ? state.prDiffNumber : undefined,
     compareHead: value === 'diff' ? state.compareHead : undefined,
     pendingCommitFocused: value === 'history' ? state.pendingCommitFocused : false,
     statusGroupHeaderFocused: value === 'status' ? state.statusGroupHeaderFocused : false,
@@ -2548,6 +2562,23 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         // diff had, landing the user mid-patch.
         diffPreviewOffset: 0,
         worktreeDiffOffset: 0,
+      }
+    }
+    case 'navigateOpenDiffForPullRequest': {
+      const next = withPushedView(state, 'diff')
+      return {
+        ...next,
+        diffSource: 'pr',
+        prDiffNumber: action.number,
+        selectedPullRequestTriageIndex: Math.max(
+          0,
+          action.pullRequestIndex ?? state.selectedPullRequestTriageIndex
+        ),
+        // Reset the diff scroll offset so the PR patch always opens at
+        // the top — same reasoning as the stash branch above.
+        diffPreviewOffset: 0,
+        worktreeDiffOffset: 0,
+        diffLineSelectAnchor: undefined,
       }
     }
     case 'navigateOpenDiffForCompare': {

--- a/src/workstation/runtime/inkWorkflows.test.ts
+++ b/src/workstation/runtime/inkWorkflows.test.ts
@@ -208,3 +208,20 @@ describe('log Ink workflows', () => {
     expect(text).toContain('Operation data loading')
   })
 })
+
+describe('triage PR checkout workflow (#1363)', () => {
+  it('registers triage-pr-checkout as keyless (view-scoped C dispatches by id) and confirmation-free', () => {
+    // Non-destructive: gh refuses on a dirty worktree rather than
+    // clobbering it, and switching back is one checkout — same
+    // consent model as checkout-branch.
+    expect(getLogInkWorkflowActionById('triage-pr-checkout')).toMatchObject({
+      key: '',
+      kind: 'normal',
+      requiresConfirmation: false,
+    })
+  })
+
+  it('never resolves triage-pr-checkout from a raw C keystroke (create-pr owns the registry key)', () => {
+    expect(getLogInkWorkflowActionByKey('C')?.id).toBe('create-pr')
+  })
+})

--- a/src/workstation/runtime/inkWorkflows.ts
+++ b/src/workstation/runtime/inkWorkflows.ts
@@ -583,6 +583,21 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: true,
     },
     {
+      // #1363 — review-locally in one key. Scoped to the triage view in
+      // inkInput (key `C` there; the view opted out of the global
+      // create-PR allowlist so the key is free). Non-destructive: gh
+      // refuses rather than clobbering a dirty worktree, and switching
+      // back is one checkout — so no y-confirm, mirroring
+      // `checkout-branch`. Empty key keeps it palette-discoverable
+      // without registering a global hotkey.
+      id: 'triage-pr-checkout',
+      key: '',
+      label: 'Check out pull request',
+      description: 'gh pr checkout <n> — fetch the cursored pull request\'s branch and switch onto it.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
       // Per-view-only: scoped to the history view in inkInput so `R`
       // doesn't fire elsewhere (it's also `R` for rename in branches
       // and delete-remote-tag in tags). Empty key keeps it

--- a/src/workstation/runtime/mainPanel.test.ts
+++ b/src/workstation/runtime/mainPanel.test.ts
@@ -71,7 +71,6 @@ const ZERO_EXTRA_VIEWS: Array<[view: string, displayName: string]> = [
   ['submodules', 'SubmodulesSurface'],
   ['remotes', 'RemotesSurface'],
   ['pull-request', 'PullRequestSurface'],
-  ['pull-request-triage', 'PullRequestTriageSurface'],
   ['issues', 'IssuesTriageSurface'],
   ['conflicts', 'ConflictsSurface'],
   ['changelog', 'ChangelogSurface'],
@@ -107,6 +106,9 @@ describe('renderMainPanel — single-extra surface wiring', () => {
     ['tags', 'TagsSurface'],
     ['stash', 'StashSurface'],
     ['worktrees', 'WorktreesSurface'],
+    // #1363 — the triage list moved to the spinner group for the
+    // checkout row spinner.
+    ['pull-request-triage', 'PullRequestTriageSurface'],
   ])('mounts the %s view as %s and threads the spinner frame', (view, displayName) => {
     const React = makeReact()
     const el = renderMainPanel(React, makeSurface(view), makeExtras()) as unknown as CapturedElement

--- a/src/workstation/runtime/mainPanel.ts
+++ b/src/workstation/runtime/mainPanel.ts
@@ -71,7 +71,6 @@ function zeroExtraComponent(
       submodules: define(renderSubmodulesSurface, 'SubmodulesSurface'),
       remotes: define(renderRemotesSurface, 'RemotesSurface'),
       'pull-request': define(renderPullRequestSurface, 'PullRequestSurface'),
-      'pull-request-triage': define(renderPullRequestTriageSurface, 'PullRequestTriageSurface'),
       issues: define(renderIssuesTriageSurface, 'IssuesTriageSurface'),
       conflicts: define(renderConflictsSurface, 'ConflictsSurface'),
       changelog: define(renderChangelogSurface, 'ChangelogSurface'),
@@ -113,6 +112,9 @@ function spinnerSurfaceComponent(
       tags: make(renderTagsSurface, 'TagsSurface'),
       stash: make(renderStashSurface, 'StashSurface'),
       worktrees: make(renderWorktreesSurface, 'WorktreesSurface'),
+      // #1363 — the triage list needs the spinner frame for the inline
+      // pending-row spinner while `gh pr checkout <n>` runs.
+      'pull-request-triage': make(renderPullRequestTriageSurface, 'PullRequestTriageSurface'),
     }
   }
   return cachedSpinnerComponents[view]
@@ -223,6 +225,9 @@ export type MainPanelExtras = {
   stashDiffLoading: boolean
   compareDiffLines: string[] | undefined
   compareDiffLoading: boolean
+  prDiffLines: string[] | undefined
+  prDiffLoading: boolean
+  prDiffError: string | undefined
   bisectCandidateDetail: GitCommitDetail | undefined
   bisectCandidateLoading: boolean
   /** Cached blame for `state.blamePath` (#0.71). Undefined on a cache miss. */
@@ -260,6 +265,9 @@ export function renderMainPanel(
     stashDiffLoading,
     compareDiffLines,
     compareDiffLoading,
+    prDiffLines,
+    prDiffLoading,
+    prDiffError,
     bisectCandidateDetail,
     bisectCandidateLoading,
     blame,
@@ -309,6 +317,9 @@ export function renderMainPanel(
       stashDiffLoading,
       compareDiffLines,
       compareDiffLoading,
+      prDiffLines,
+      prDiffLoading,
+      prDiffError,
       syntaxSpans,
     }
     return h(diffSurfaceComponent(React), { diff: diffData })
@@ -372,7 +383,7 @@ export function renderMainPanel(
   }
 
   if (state.activeView === 'pull-request-triage') {
-    return h(zeroExtraComponent(React, 'pull-request-triage')!)
+    return h(spinnerSurfaceComponent(React, 'pull-request-triage')!, { spinnerFrame })
   }
 
   if (state.activeView === 'issues') {

--- a/src/workstation/runtime/pendingItemAction.test.ts
+++ b/src/workstation/runtime/pendingItemAction.test.ts
@@ -174,3 +174,55 @@ describe('inline pending spinner in the sidebar', () => {
     expect(flattenText(tree)).toContain(SPIN)
   })
 })
+
+describe('inline pending spinner on the PR triage list (#1363)', () => {
+  const { renderPullRequestTriageSurface } =
+    // Imported lazily to keep the top-of-file import block focused on
+    // the original four surfaces.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    require('../surfaces/pullRequestTriage') as typeof import('../surfaces/pullRequestTriage')
+
+  const triageContext = {
+    ...context,
+    pullRequestList: {
+      available: true,
+      authenticated: true,
+      repository: { owner: 'gfargo', name: 'coco' },
+      pullRequests: [
+        {
+          number: 41, title: 'feat: one', url: 'https://x/41', state: 'OPEN', isDraft: false,
+          headRefName: 'feat/one', baseRefName: 'main', createdAt: '', updatedAt: '',
+        },
+        {
+          number: 42, title: 'feat: two', url: 'https://x/42', state: 'OPEN', isDraft: false,
+          headRefName: 'feat/two', baseRefName: 'main', createdAt: '', updatedAt: '',
+        },
+      ],
+    },
+  } as unknown as LogInkContext
+
+  function renderTriage(pending?: LogInkPendingItemAction): string {
+    const base = createLogInkState([])
+    const ctx: SurfaceRenderContext = {
+      h: createElement,
+      components,
+      state: { ...base, activeView: 'pull-request-triage', focus: 'commits', pendingItemAction: pending },
+      context: triageContext,
+      contextStatus: createLogInkContextStatus('ready'),
+      bodyRows: 30,
+      width: 90,
+      theme,
+    }
+    return flattenText(renderPullRequestTriageSurface(ctx, 0))
+  }
+
+  it('swaps the cursor glyph for the spinner on the PR being checked out', () => {
+    const text = renderTriage({ kind: 'pull-request', id: '42', action: 'checkout' })
+    expect(text).toMatch(new RegExp(`${SPIN}\\s+#42`))
+    expect(text).not.toMatch(new RegExp(`${SPIN}\\s+#41`))
+  })
+
+  it('renders no spinner when nothing is pending', () => {
+    expect(renderTriage()).not.toContain(SPIN)
+  })
+})

--- a/src/workstation/surfaces/diff/diffSurface.test.ts
+++ b/src/workstation/surfaces/diff/diffSurface.test.ts
@@ -144,3 +144,110 @@ describe('worktree diff — hunk staging rail (#1184, #1185)', () => {
     }
   })
 })
+
+describe('PR diff surface (#1363)', () => {
+  const prPatch = [
+    'diff --git a/src/a.ts b/src/a.ts',
+    '--- a/src/a.ts',
+    '+++ b/src/a.ts',
+    '@@ -1 +1 @@',
+    '-old',
+    '+new',
+    'diff --git a/src/b.ts b/src/b.ts',
+    '--- a/src/b.ts',
+    '+++ b/src/b.ts',
+    '@@ -2 +2 @@',
+    '-two',
+    '+three',
+  ]
+
+  function buildPr(overrides: {
+    lines?: string[]
+    loading?: boolean
+    error?: string
+    offset?: number
+  } = {}): unknown {
+    const base = createLogInkState([])
+    const ctx = {
+      h: createElement,
+      components,
+      state: {
+        ...base,
+        activeView: 'diff',
+        diffSource: 'pr',
+        prDiffNumber: 962,
+        focus: 'commits',
+        diffPreviewOffset: overrides.offset ?? 0,
+      },
+      context: {
+        pullRequestList: {
+          available: true,
+          authenticated: true,
+          pullRequests: [
+            { number: 962, title: 'feat: triage detail' },
+          ],
+        },
+      } as unknown as LogInkContext,
+      contextStatus: createLogInkContextStatus('ready'),
+      bodyRows: 30,
+      width: 100,
+      theme,
+    } as unknown as SurfaceRenderContext
+
+    const diff = {
+      worktreeDiff: undefined,
+      worktreeDiffLoading: false,
+      worktreeHunks: undefined,
+      worktreeHunksLoading: false,
+      filePreview: undefined,
+      filePreviewLoading: false,
+      commitDiffHunkOffsets: undefined,
+      selectedDetailFile: undefined,
+      stashDiffLines: undefined,
+      stashDiffLoading: false,
+      compareDiffLines: undefined,
+      compareDiffLoading: false,
+      prDiffLines: overrides.lines,
+      prDiffLoading: overrides.loading ?? false,
+      prDiffError: overrides.error,
+      syntaxSpans: undefined,
+    } as unknown as DiffSurfaceData
+
+    return renderDiffSurface(ctx, diff)
+  }
+
+  it('renders the PR title bar with the number + triage-list title', () => {
+    const text = flattenText(buildPr({ lines: prPatch }))
+    expect(text).toContain('PR diff')
+    expect(text).toContain('#962 feat: triage detail')
+  })
+
+  it('shows the surface-states loading line while the patch fetch runs', () => {
+    const text = flattenText(buildPr({ loading: true }))
+    expect(text).toContain('· Loading diff for #962…')
+  })
+
+  it('surfaces a fetch failure with recovery hints instead of a bare empty state', () => {
+    const text = flattenText(buildPr({ error: 'gh auth token expired.', lines: [] }))
+    expect(text).toContain('Could not load the diff: gh auth token expired.')
+    expect(text).toContain('Press esc to go back')
+  })
+
+  it('renders the empty-patch hint for a diff-less PR', () => {
+    const text = flattenText(buildPr({ lines: [] }))
+    expect(text).toContain('No diff to display for this pull request.')
+  })
+
+  it('segments the patch per file and tracks the file containing the scroll offset', () => {
+    // Offset 0 sits inside the first file.
+    expect(flattenText(buildPr({ lines: prPatch }))).toContain('File 1/2: src/a.ts')
+    // Offset 7 sits inside the second file (its header is line 6).
+    expect(flattenText(buildPr({ lines: prPatch, offset: 7 }))).toContain('File 2/2: src/b.ts')
+  })
+
+  it('replaces diff --git headers with compact ▾ path markers', () => {
+    const text = flattenText(buildPr({ lines: prPatch }))
+    expect(text).toContain('▾ src/a.ts')
+    expect(text).not.toContain('diff --git a/src/a.ts')
+  })
+})

--- a/src/workstation/surfaces/diff/index.ts
+++ b/src/workstation/surfaces/diff/index.ts
@@ -1,5 +1,5 @@
 /**
- * Diff surface — the unified or side-by-side diff view. Four sources
+ * Diff surface — the unified or side-by-side diff view. Five sources
  * route through here, disambiguated by `state.diffSource`:
  *
  *   - `'stash'`    → render the patch text from a `git stash show -p`,
@@ -12,6 +12,11 @@
  *                    flow.
  *   - `'commit'`   → file preview hunks for a commit (history → Enter
  *                    on a commit). Read-only commit-diff exploration.
+ *   - `'pr'`       → `gh pr diff <n>` patch from the PR-triage drill-in
+ *                    (#1363). Read-only like compare, but keeps the
+ *                    stash diff's per-file `]` / `[` cursor — a PR
+ *                    patch is multi-file and "which file am I in" is
+ *                    the core review question.
  *   - default      → worktree-file diff for the active status entry,
  *                    with hunk navigation + per-hunk staging / revert.
  *
@@ -24,6 +29,11 @@
 import type * as ReactTypes from 'react'
 import { isLogInkContextKeyLoading } from '../../chrome/context'
 import { formatStashHeaderIdentity } from '../../chrome/stashHeader'
+import {
+  formatLogInkLoading,
+  formatLogInkPullRequestDiffEmpty,
+  formatLogInkPullRequestDiffError,
+} from '../../chrome/surfaceStates'
 import { cellWidth, truncateCells, truncatePathCells } from '../../chrome/text'
 import type {
   GitCommitDetail,
@@ -74,6 +84,9 @@ export type DiffSurfaceData = {
   stashDiffLoading: boolean
   compareDiffLines: string[] | undefined
   compareDiffLoading: boolean
+  prDiffLines: string[] | undefined
+  prDiffLoading: boolean
+  prDiffError: string | undefined
   syntaxSpans?: Map<string, SyntaxSpan[]>
 }
 
@@ -95,6 +108,9 @@ export function renderDiffSurface(
     stashDiffLoading,
     compareDiffLines,
     compareDiffLoading,
+    prDiffLines,
+    prDiffLoading,
+    prDiffError,
     syntaxSpans,
   } = diff
   const { Box, Text } = components
@@ -229,6 +245,111 @@ export function renderDiffSurface(
       dimColor: index > 0,
     }, truncateCells(line, width - 4))),
     ...stashBodyNodes)
+  }
+
+  // PR-triage drill-in branch (#1363). Mirrors the stash diff above —
+  // same per-file `diff --git` segmentation so `]` / `[` jump between
+  // files and the active file's header carries the selection bar — but
+  // read-only: the patch's files live on the PR's head branch, not
+  // necessarily in the local worktree, so cherry-pick / open-in-editor
+  // have no sensible target here (checkout the PR with `C` instead).
+  if (state.diffSource === 'pr') {
+    const lines = prDiffLines || []
+    const splitActive = isSplitDiffViable(state, width)
+    const splitRequestedButTooNarrow = state.diffViewMode === 'split' && !splitActive
+    const visibleLines = lines.slice(
+      state.diffPreviewOffset,
+      state.diffPreviewOffset + visibleRows
+    )
+    const prFiles = parseStashDiffFiles(lines)
+    const fileCount = prFiles.length
+    const currentFile = findStashFileForOffset(prFiles, state.diffPreviewOffset)
+    const currentFileIndex = currentFile
+      ? Math.max(0, prFiles.findIndex((file) => file.startLine === currentFile.startLine))
+      : -1
+    // Panel subtitle: the triage row the user drilled in from. The
+    // number is authoritative (`state.prDiffNumber`); the title is a
+    // best-effort lookup against the triage list so a refetch that
+    // dropped the PR still renders a usable `#<n>` header.
+    const prItem = context.pullRequestList?.pullRequests?.find(
+      (pr) => pr.number === state.prDiffNumber
+    )
+    const prLabel = `#${state.prDiffNumber ?? '?'}${prItem ? ` ${prItem.title}` : ''}`
+    const baseHeaderLines: string[] = prDiffLoading
+      ? [formatLogInkLoading({ resource: `diff for #${state.prDiffNumber ?? '?'}` })]
+      : prDiffError
+        ? [formatLogInkPullRequestDiffError({ message: prDiffError })]
+        : lines.length
+          ? [
+            fileCount > 0 && currentFile
+              ? `File ${currentFileIndex + 1}/${fileCount}: ${currentFile.path}`
+              : 'No files in this diff.',
+            `Lines ${Math.min(state.diffPreviewOffset + 1, lines.length)}-${Math.min(state.diffPreviewOffset + visibleLines.length, lines.length)}/${lines.length}`,
+            '',
+          ]
+          : [formatLogInkPullRequestDiffEmpty()]
+    const headerLines = splitRequestedButTooNarrow
+      ? [...baseHeaderLines.slice(0, -1), 'Terminal too narrow for side-by-side; showing unified.', '']
+      : baseHeaderLines
+
+    // File header anchor map — see the stash branch above: O(1) restyle
+    // of each `diff --git` row, with the file containing the scroll
+    // offset marked active on the selection bar.
+    const prFileByStartLine = new Map(prFiles.map((file) => [file.startLine, file]))
+    const activeStartLine = currentFile?.startLine
+    const prBodyNodes: ReactTypes.ReactNode[] = prDiffLoading || prDiffError || !lines.length
+      ? []
+      : splitActive
+        ? renderSplitDiffBody(
+          h, components, lines, state.diffPreviewOffset, visibleRows, width, theme,
+          'pr-diff-split', syntaxSpans
+        )
+        : visibleLines.map((line, index) => {
+          const absoluteIndex = state.diffPreviewOffset + index
+          const headerFile = prFileByStartLine.get(absoluteIndex)
+          if (headerFile) {
+            const isActive = absoluteIndex === activeStartLine
+            const arrow = theme.ascii ? '> ' : '▾ '
+            const activeHeader = isActive && focused && !theme.noColor
+            return h(Text, {
+              key: `pr-diff-line-${absoluteIndex}`,
+              bold: true,
+              color: activeHeader
+                ? theme.colors.selectionForeground
+                : (theme.noColor ? undefined : theme.colors.accent),
+              backgroundColor: activeHeader ? theme.colors.selection : undefined,
+            }, (() => {
+              const pathBudget = (width - 4) - cellWidth(arrow)
+              return pathBudget >= 8
+                ? `${arrow}${truncatePathCells(headerFile.path, pathBudget)}`
+                : truncateCells(`${arrow}${headerFile.path}`, width - 4)
+            })())
+          }
+          return renderDiffLine(
+            h, Text, line, theme, syntaxSpans, width - 4,
+            `pr-diff-line-${absoluteIndex}`
+          )
+        })
+
+    return h(Box, {
+      borderColor: focusBorderColor(theme, focused),
+      borderStyle: theme.borderStyle,
+      flexDirection: 'column',
+      flexShrink: 0,
+      paddingX: 1,
+      width,
+    },
+    h(Box, { justifyContent: 'space-between' },
+      h(Text, { bold: true }, panelTitle(splitActive ? 'PR diff (split)' : 'PR diff', focused)),
+      // Cell-budgeted like the stash subtitle (#1390) so a long PR
+      // title can't wrap the space-between header row.
+      h(Text, { dimColor: true }, truncateCells(prLabel, Math.max(10, width - 4 - 20)))
+    ),
+    ...headerLines.map((line, index) => h(Text, {
+      key: `pr-diff-header-${index}`,
+      dimColor: index > 0,
+    }, truncateCells(line, width - 4))),
+    ...prBodyNodes)
   }
 
   // Compare-two-refs branch (#779). Mirrors the stash diff above but

--- a/src/workstation/surfaces/pullRequestTriage/index.ts
+++ b/src/workstation/surfaces/pullRequestTriage/index.ts
@@ -13,6 +13,7 @@
 import type * as ReactTypes from 'react'
 import type { PullRequestListItem } from '../../../git/pullRequestListData'
 import { isLogInkContextKeyLoading } from '../../chrome/context'
+import { inlineSpinnerGlyph } from '../../chrome/spinner'
 import { clampListWindowStart } from '../../chrome/layout'
 import { forgeNouns } from '../../chrome/forgeNouns'
 import {
@@ -25,6 +26,7 @@ import { cellWidth, truncateCells } from '../../chrome/text'
 import type { LogInkTheme } from '../../chrome/theme'
 import { PULL_REQUEST_FILTER_LABELS } from '../../../git/triageFilterPresets'
 import { matchesPromotedFilter } from '../../runtime/promotedFilter'
+import { isPendingItemAction } from '../../runtime/inkViewModel'
 import type { SurfaceRenderContext } from '../../runtime/types'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
 
@@ -104,7 +106,10 @@ function matchesPullRequestFilter(pr: PullRequestListItem, filter: string): bool
   )
 }
 
-export function renderPullRequestTriageSurface(ctx: SurfaceRenderContext): ReactTypes.ReactElement {
+export function renderPullRequestTriageSurface(
+  ctx: SurfaceRenderContext,
+  spinnerFrame: number = 0
+): ReactTypes.ReactElement {
   const { h, components, state, context, contextStatus, bodyRows, width, theme } = ctx
   const { Box, Text } = components
   const focused = state.focus === 'commits'
@@ -197,7 +202,11 @@ export function renderPullRequestTriageSurface(ctx: SurfaceRenderContext): React
       bodyLines = windowed.map((pr, offset) => {
         const index = startIndex + offset
         const isSelected = index === selected
-        const cursor = isSelected ? '>' : ' '
+        // #1363 — while `gh pr checkout <n>` runs against this row, the
+        // cursor glyph swaps for the shared inline spinner (same idiom
+        // as the branches surface's delete/checkout rows).
+        const busy = isPendingItemAction(state.pendingItemAction, 'pull-request', String(pr.number))
+        const cursor = busy ? inlineSpinnerGlyph(spinnerFrame, theme.ascii) : isSelected ? '>' : ' '
         const numStr = `#${pr.number}`.padEnd(numberColWidth)
         const stateLabel = pr.isDraft ? 'draft' : pr.state.toLowerCase()
         const stateStr = stateLabel.padEnd(6)


### PR DESCRIPTION
The PR triage surface could approve, merge, or request changes on a PR without ever showing a line of code. This wires the missing review flow.

## The flow

1. `gP` → the PR triage list.
2. `Enter` on a row → the PR's unified diff (`gh pr diff <n>`), rendered by the diff surface with the stash diff's **per-file cursor**: compact `▾ path` headers (active file on the selection bar), `File n/N` tracking in the header, `[`/`]` per-file jump, `j/k` + PgUp/PgDn scroll, `d` split view. The inspector keeps the PR preview panel (checks / reviewers / detail) next to the patch.
3. Read the diff, then either back out (`Esc`) to `a` approve / `R` request changes from the list — or press **`C` to check the PR's branch out locally** (`gh pr checkout <n>`), right from the diff or from the list row.

## What shipped

**Enter → PR diff** (issue item 1)
- New `diffSource: 'pr'` + `prDiffNumber` state; `navigateOpenDiffForPullRequest` mirrors the stash drill-in exactly (push/pop/replace clearing, scroll reset, repo-frame `parentReturn` capture/restore).
- Per-file cursor shipped (the "ideal" option in the issue), reusing the stash patch segmentation — not the scroll-only fallback.
- New fetchers behind the forge facade: `getPullRequestDiff` (`gh pr diff <n> --color=never`, execFile wrapper conventions, compacted error surfaces) and a `glab mr diff <n>` counterpart. **Bitbucket descoped**: no CLI patch fetch exists, so its facade returns a graceful `{ ok: false }` the diff surface renders as an actionable error.

**`C` = checkout** (issue item 2)
- Decision: **removed `pull-request-triage` from `CREATE_PR_VIEWS`** (allowlist comment + binding pin test updated) — on a list of existing PRs, "get this branch locally" beats "create a new PR" for `C`. Create-PR stays reachable everywhere else.
- `triage-pr-checkout` workflow: standard row spinner (new `'pull-request'` pending-item kind; the triage surface joined the spinner-prop group), history-rows refresh + cursor snap + silent context refresh — same follow-ups as `checkout-branch`. No y-confirm (gh refuses on a dirty worktree rather than clobbering it).
- `C` inside the PR diff carries the viewed number as the workflow payload, so a list refetch under the open diff can't retarget the checkout.

**Diff cache** (issue item 4)
- Bounded LRU of the **last 8 patches** keyed by PR number, invalidated wholesale whenever the triage list refetches (`pullRequestList` overview identity is the cache generation — refresh, filter cycle, and frame swaps all replace it). Loading via `formatLogInkLoading`; fetch failures surface a dedicated error line (new `surfaceStates` helpers) instead of a silent "no diff". Errors are never cached.

**Descoped (loudly)**
- Issue item 3 (review actions inside the detail view): skipped — the triage list already has `a`/`R`/`m`/`x` one `Esc` away, and nothing fell out naturally.
- Bitbucket diff/checkout: graceful not-supported messages (no CLI equivalent).
- `y` yank on the PR diff: no target wired (candidate follow-up: yank the PR URL).

**Keymaps**: footer hints for the triage list (`enter diff · C checkout · …`) and a dedicated read-only hint set for the PR-sourced diff; KEYMAP.md updated (new "Diff — pull request" section, `C` and `[`/`]` overload rows).

## Tests

Fetcher argv + parser + error surfaces (gh and glab, mocked runners), reducer transitions (push/pop/replace clearing, repo-frame round-trip), input dispatch (Enter incl. the loading/empty-list inert case, `C` on list + diff, `[`/`]` file jump, stash-verb leakage guard), hydration cache (hit / generation invalidation / LRU bound / error-not-cached / stale-resolve drop), diff-surface render states (loading / error / empty / file segmentation), triage row spinner, keymap hints + allowlist pins. Full suite: 314 suites / 4096 tests green; tsc clean; eslint 0 new problems.

Closes #1363
