### PR TITLE
docs: contributor/agent environment guide — validation gotchas belong in the repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,31 @@ npm run scenario create <name>   # temp git scenario for hand-testing the TUI
 npm run screenshot:sync          # regenerate marketing assets → .www
 ```
 
+## Validating your changes
+
+The full gate a PR must pass — run all three, expect zero new problems:
+
+```bash
+npm run lint                       # eslint src bin
+npx tsc --noEmit -p tsconfig.json  # typecheck (not part of build)
+npm run test:jest                  # full jest suite
+```
+
+Gotchas that cost time if you skip them (most of these bit real contributors):
+
+- **Node ≥ 22 is mandatory** (`.nvmrc` = 22.22.2; engines pins `^22.22.2 || ^24.15.0 || >=26.0.0`). On older Node, jest fails immediately with `Preset ts-jest not found` — that error means "wrong Node," not "bad config." If your shell defaults to an old Node, put a ≥22 install first on `PATH`.
+- **Generate before you test.** `npm run test:jest` skips the `pretest:jest` step that `npm test` runs, so a bare `jest` invocation fails ~20 suites on a missing generated module. Either use `npm run test:jest` (runs the pre-step), or run the pre-step yourself once: `npm run build:info && node bin/copyTreeSitterWasm.mjs`. (In a git worktree the WASM copy exits non-zero — harmless; the module it needs resolves from the root checkout.)
+- **Match CI's environment or timezone/ESM tests diverge.** CI runs jest with `TZ=UTC NODE_OPTIONS=--experimental-vm-modules`. Date-bucketing and a few module-loading suites are environment-sensitive; a green run locally in a non-UTC zone can still fail in CI. Reproduce CI exactly with:
+  `TZ=UTC NODE_OPTIONS=--experimental-vm-modules npx jest`
+- **Working from a git worktree?** It has no `node_modules` of its own — resolve the jest/eslint/tsc binaries from the root checkout's `node_modules/.bin/` and run them with the worktree as CWD.
+- **One flaky test to know about:** `src/workstation/chrome/refreshWatcher.test.ts` (rename-survival) is timing-sensitive under heavy parallel load on macOS. If it's the *only* failure, re-run it in isolation to confirm before treating it as real.
+
+## Working with the team's conventions
+
+- **Branches** use conventional prefixes (`feat/`, `fix/`, `chore/`, `docs/`, `test/`, `perf/`, `refactor/`) — never the auto-generated `claude/…` prefix.
+- **No self-attribution in git.** Do not add `Co-Authored-By` or "Generated with …" trailers to commits or PR bodies.
+- **Parallel PRs get combination-tested before merge.** Two branches that are each green against the `main` they forked from can still break `main` together (a new production guard invalidating another PR's test fixture; two branches editing the same dispatch region). Before merging the second of an overlapping pair, merge current `main` into it locally and run the full suite — don't trust each branch's own green CI.
+
 ## House style
 
 - Match the surrounding code's idiom, naming, and comment density.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,25 @@ Test scenarios (deterministic temp git repo states) come from the [`@gfargo/git-
 
 If you're contributing TUI changes, read `src/workstation/README.md` first.
 
+### Validating your changes
+
+Every PR must pass three checks with zero new problems. Run them all before pushing:
+
+```bash
+npm run lint                       # eslint src bin
+npx tsc --noEmit -p tsconfig.json  # typecheck (the build does not typecheck for you)
+npm run test:jest                  # full jest suite
+```
+
+A few environment gotchas that trip people up:
+
+- **Node ≥ 22 is required** (`.nvmrc` = 22.22.2). On older Node, jest fails immediately with `Preset ts-jest not found` — that means "wrong Node version," not a config problem.
+- **`npm run test:jest` runs its own pre-step** (`build:info` + a tree-sitter WASM copy) via `pretest:jest`. If you invoke `jest` directly instead, run that pre-step first or ~20 suites fail on a missing generated module: `npm run build:info && node bin/copyTreeSitterWasm.mjs`.
+- **To reproduce CI exactly** (some date and module-loading tests are environment-sensitive), match CI's settings: `TZ=UTC NODE_OPTIONS=--experimental-vm-modules npx jest`.
+- **`refreshWatcher.test.ts` is timing-sensitive** under heavy parallel load; if it's the only failure, re-run it alone to confirm before assuming it's real.
+
+Contributors and agents share these conventions: conventional branch prefixes (`feat/`, `fix/`, `chore/`, …); no `Co-Authored-By` / "Generated with …" trailers in commits or PR bodies; and when two overlapping PRs are both green, combination-test them (merge current `main` in locally and re-run the suite) before merging the second — each branch's own green CI predates the other's changes. `AGENTS.md` carries the same guidance for AI agents.
+
 ### Testing the workstation (`coco ui`)
 
 Coco ships with a scenario library that spins up deterministic temp git repos for manual + automated testing. List the available scenarios, then create one and run `coco ui` against it:


### PR DESCRIPTION
Closes #1426.

## Problem
The environment knowledge needed to validate a change lived in session memory and individual heads, not the repo — so every new contributor (human or AI agent) re-derived the same gotchas, several of which cost real time this cycle: a wrong-Node run reads as a config error (`Preset ts-jest not found`); a bare `jest` invocation fails ~20 suites on a missing generated module; a non-UTC local run passes where CI fails.

## What this adds
- **AGENTS.md** — a `Validating your changes` section (the three-check gate + five gotchas: Node ≥22 and its `Preset ts-jest not found` tell, the `pretest:jest` generation step a bare jest skips, `TZ=UTC NODE_OPTIONS=--experimental-vm-modules` for CI parity, worktree binary resolution, the known `refreshWatcher` flake) and a `Working with the team's conventions` section (conventional branch prefixes, no attribution trailers, combination-testing overlapping PRs before merge).
- **CONTRIBUTING.md** — a matching `Validating your changes` subsection under Development Setup, cross-linked to AGENTS.md so humans and agents get one voice.

## Verification
Every command in the guide was run against the repo before documenting it: engines pin = `^22.22.2 || ^24.15.0 || >=26.0.0`; `pretest:jest` = `build:info && copyTreeSitterWasm` (so a bare jest skips it); `build:info` = `tsx bin/generateBuildInfo.ts`; `tsc --noEmit -p tsconfig.json` exits 0; `npm run lint` is 0 errors. Docs-only — no runtime or tests affected.