### PR TITLE
fix(commit): mock the tokenizer function generateCommitDraft actually calls

### DIFF
--- a/src/commands/commit/generateCommitDraft.test.ts
+++ b/src/commands/commit/generateCommitDraft.test.ts
@@ -8,7 +8,7 @@ import { loadConfig } from '../../lib/config/utils/loadConfig'
 import { getApiKeyForModel, getModelAndProviderFromConfig } from '../../lib/langchain/utils'
 import { resolveDynamicService } from '../../lib/langchain/utils/dynamicModels'
 import { getLlm } from '../../lib/langchain/utils/getLlm'
-import { getTokenCounter } from '../../lib/utils/tokenizer'
+import { getTokenCounterForProvider } from '../../lib/utils/tokenizer'
 import { fileChangeParser } from '../../lib/parsers/default'
 import { getChanges } from '../../lib/simple-git/getChanges'
 import { getCurrentBranchName } from '../../lib/simple-git/getCurrentBranchName'
@@ -37,7 +37,9 @@ const mockResolveDynamicService = resolveDynamicService as jest.MockedFunction<
   typeof resolveDynamicService
 >
 const mockGetLlm = getLlm as jest.MockedFunction<typeof getLlm>
-const mockGetTokenCounter = getTokenCounter as jest.MockedFunction<typeof getTokenCounter>
+const mockGetTokenCounterForProvider = getTokenCounterForProvider as jest.MockedFunction<
+  typeof getTokenCounterForProvider
+>
 const mockFileChangeParser = fileChangeParser as jest.MockedFunction<typeof fileChangeParser>
 const mockGetChanges = getChanges as jest.MockedFunction<typeof getChanges>
 const mockGetCurrentBranchName = getCurrentBranchName as jest.MockedFunction<
@@ -111,7 +113,7 @@ describe('generateCommitDraft — diff summary budgeting (OSS-504 / #1459)', () 
       model: task === 'commit' ? 'commit-model' : 'summarize-model',
     }) as ReturnType<typeof resolveDynamicService>)
     mockGetLlm.mockReturnValue({} as ReturnType<typeof getLlm>)
-    mockGetTokenCounter.mockResolvedValue(charTokenizer)
+    mockGetTokenCounterForProvider.mockResolvedValue(charTokenizer)
     mockGetChanges.mockResolvedValue({
       staged: [{ filePath: 'src/index.ts', status: 'modified', summary: 'changed' }],
       unstaged: [],


### PR DESCRIPTION
## Summary
- #1486 added a new test that mocked `getTokenCounter`, but `generateCommitDraft.ts` calls `getTokenCounterForProvider` (renamed by #1485, which had already landed on main before #1486's stale branch was squash-merged).
- Because git's 3-way merge saw no textual conflict, the mismatch went in silently and broke `main`'s test suite / CI immediately after #1486 merged.

## Fix
Mock `getTokenCounterForProvider` instead, matching what the source actually calls.

## Test plan
- [x] `jest generateCommitDraft` — 4/4 passing (was 3 failing)
- [x] Full suite: 330/332 suites passing, 4594/4607 tests passing (2 pre-existing skips)