### PR TITLE
fix: isolate EDITOR env in TaskList open-file test

### DIFF
--- a/src/lib/ui/TaskList.test.ts
+++ b/src/lib/ui/TaskList.test.ts
@@ -134,7 +134,8 @@ describe('TaskList — keyboard shortcut "a"', () => {
 
 describe('TaskList — keyboard shortcuts', () => {
   it('opens the current file when key "o" is pressed', async () => {
-    const expectedEditor = process.env.EDITOR || 'code'
+    const originalEditor = process.env.EDITOR
+    process.env.EDITOR = 'code'
 
     const tl = new TaskList([makeItem({ filePath: 'src/open-me.ts' })])
     const startPromise = tl.start()
@@ -144,10 +145,12 @@ describe('TaskList — keyboard shortcuts', () => {
     await startPromise.catch(() => undefined)
 
     expect(mockExecFile).toHaveBeenCalledWith(
-      expectedEditor,
+      'code',
       ['src/open-me.ts'],
       expect.any(Function)
     )
+
+    process.env.EDITOR = originalEditor
   })
 
   it('tokenizes an $EDITOR value with flags into separate args', async () => {


### PR DESCRIPTION
The test relied on the ambient $EDITOR value, which broke when the shell sets it to `code -w` (flags included). The implementation correctly tokenizes EDITOR on whitespace, but the test assertion expected the raw unsplit value.

Pin `EDITOR='code'` for the duration of the assertion so the test is environment-independent — matching the pattern already used by the adjacent tokenization test.