### PR TITLE
fix(config): malformed JSON env var degrades instead of crashing; numeric coercion scoped to numeric-only keys

### DIFF
--- a/src/lib/config/services/env.test.ts
+++ b/src/lib/config/services/env.test.ts
@@ -140,4 +140,56 @@ describe('loadEnvConfig', () => {
       }
     })
   })
+
+  describe('parseEnvValue robustness (#1468)', () => {
+    it('does not coerce a numeric-looking model name to a number', () => {
+      process.env.COCO_SERVICE_MODEL = '123'
+      try {
+        const config = loadEnvConfig(defaultConfig)
+        expect(config.service.model).toBe('123')
+        expect(typeof config.service.model).toBe('string')
+      } finally {
+        delete process.env.COCO_SERVICE_MODEL
+      }
+    })
+
+    it('still coerces genuinely numeric keys (timeout, maxRetries)', () => {
+      process.env.COCO_SERVICE_REQUEST_OPTIONS_TIMEOUT = '5000'
+      process.env.COCO_SERVICE_REQUEST_OPTIONS_MAX_RETRIES = '3'
+      try {
+        const config = loadEnvConfig(defaultConfig)
+        expect(config.service.requestOptions?.timeout).toBe(5000)
+        expect(config.service.requestOptions?.maxRetries).toBe(3)
+      } finally {
+        delete process.env.COCO_SERVICE_REQUEST_OPTIONS_TIMEOUT
+        delete process.env.COCO_SERVICE_REQUEST_OPTIONS_MAX_RETRIES
+      }
+    })
+
+    it('degrades gracefully on malformed JSON instead of crashing', () => {
+      process.env.COCO_SERVICE_FIELDS = '{bad'
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+      try {
+        const config = loadEnvConfig(defaultConfig)
+        // Should not crash and the field should be left undefined / untouched
+        expect(config.service.fields).toBeUndefined()
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('malformed JSON')
+        )
+      } finally {
+        delete process.env.COCO_SERVICE_FIELDS
+        warnSpy.mockRestore()
+      }
+    })
+
+    it('parses valid JSON fields normally', () => {
+      process.env.COCO_SERVICE_FIELDS = '{"temperature": 0.7}'
+      try {
+        const config = loadEnvConfig(defaultConfig)
+        expect(config.service.fields).toEqual({ temperature: 0.7 })
+      } finally {
+        delete process.env.COCO_SERVICE_FIELDS
+      }
+    })
+  })
 })

--- a/src/lib/config/services/env.ts
+++ b/src/lib/config/services/env.ts
@@ -198,6 +198,17 @@ function handleServiceEnvVar(
   }
 }
 
+/**
+ * Keys whose env-var values should be coerced to numbers. All other
+ * numeric-looking strings (e.g. a model name that happens to be all digits)
+ * are left as strings so downstream schema validation (type: "string") and
+ * provider-mismatch checks see the correct type. (#1468)
+ */
+const NUMERIC_ENV_KEYS = new Set([
+  'COCO_SERVICE_REQUEST_OPTIONS_TIMEOUT',
+  'COCO_SERVICE_REQUEST_OPTIONS_MAX_RETRIES',
+])
+
 function parseEnvValue(key: string, value: ValuesTypes) {
   switch (true) {
     // Handle undefined values
@@ -214,13 +225,21 @@ function parseEnvValue(key: string, value: ValuesTypes) {
     case typeof value === 'string' && (value === 'false' || value === 'true'):
       return value === 'true'
 
-    // Handle number values
-    case typeof value === 'string' && !isNaN(Number(value)):
+    // Handle number values — only for explicitly numeric keys (#1468)
+    case typeof value === 'string' && NUMERIC_ENV_KEYS.has(key) && !isNaN(Number(value)):
       return Number(value)
 
-    // Handle JSON strings
+    // Handle JSON strings — wrap in try/catch so malformed JSON degrades
+    // gracefully instead of crashing every command (#1468)
     case typeof value === 'string' && value.startsWith('{'):
-      return JSON.parse(value)
+      try {
+        return JSON.parse(value)
+      } catch {
+        console.warn(
+          `[coco] Warning: env var ${toEnvVarName(key)} contains malformed JSON — ignoring.`
+        )
+        return undefined
+      }
 
     default:
       return value


### PR DESCRIPTION
Fixes two parseEnvValue defects in src/lib/config/services/env.ts.

Closes #1468 (severity: MEDIUM, from the config/security audit).

1. Malformed JSON env var crashes every command — COCO_SERVICE_FIELDS={bad threw a raw SyntaxError taking down every coco invocation. Now wrapped in try/catch with a console.warn and skip.

2. Numeric coercion corrupts string config values — !isNaN(Number(value)) coerced ANY numeric-looking string. COCO_SERVICE_MODEL=123 became number 123, not string "123". Now only timeout and maxRetries are coerced; all other values stay as strings.

Testing:
- tsc --noEmit clean
- jest src/lib/config/ — 8 suites, 59 tests pass (including 4 new regression tests)
- eslint clean