### PR TITLE
design(workstation): dedupe sidebar branch/clean chrome; dim the clean chip

### DIFF
--- a/src/workstation/chrome/headerChips.ts
+++ b/src/workstation/chrome/headerChips.ts
@@ -194,7 +194,7 @@ export function buildHeaderChips(input: BuildHeaderChipsInput): HeaderChip[] {
       id: 'dirty',
       label: theme.ascii ? '+ clean' : '✓ clean',
       color: theme.colors.success,
-      dim: false,
+      dim: true,
       bold: false,
     }
   chips.push(dirtyChip)

--- a/src/workstation/runtime/sidebar.ts
+++ b/src/workstation/runtime/sidebar.ts
@@ -23,8 +23,8 @@ import { inlineSpinnerGlyph } from '../chrome/spinner'
 import { cellWidth, truncateCells, truncatePathCells } from '../chrome/text'
 import type { LogInkTheme } from '../chrome/theme'
 import type {
-  LogInkSidebarTab,
-  LogInkState,
+    LogInkSidebarTab,
+    LogInkState,
 } from '../../workstation/runtime/inkViewModel'
 import { getLogInkSidebarTabs, isPendingItemAction } from '../../workstation/runtime/inkViewModel'
 import { buildFilteredLists, type FilteredLists } from './hooks/buildFilteredLists'
@@ -206,15 +206,7 @@ function renderActiveSidebarContent(
     // unfiltered list here meant Enter/D/R could target a different
     // branch than the highlighted row while a filter was active.
     const sortedBranches = lists.filteredBranchList
-    const headerRows: ReactTypes.ReactElement[] = [
-      h(Text, { key: 'tab-branches-current', dimColor: true },
-        truncateCells(`  Current: ${branches.currentBranch || '<detached>'}`, width - 4)),
-      h(Text, { key: 'tab-branches-state', dimColor: true },
-        `  Worktree: ${branches.dirty ? 'dirty' : 'clean'}`),
-      h(Text, { key: 'tab-branches-spacer' }, ''),
-    ]
     return [
-      ...headerRows,
       ...renderSelectableSidebarRows(
         h, Text, sortedBranches, state.selectedBranchIndex, focused, width, theme,
         (branch) => {

--- a/src/workstation/runtime/sidebarFilteredLists.test.ts
+++ b/src/workstation/runtime/sidebarFilteredLists.test.ts
@@ -67,9 +67,9 @@ describe('sidebar list tabs honor the active filter (#1341)', () => {
     const text = renderBranchesTab('feat')
     expect(text).toContain('feat/login')
     expect(text).not.toContain('fix/crash')
-    // `main` appears in the "Current:" header line but must not appear
-    // as a selectable row — assert via the row marker spacing.
-    expect(text).toContain('Current: main')
+    // `main` is neither a filter match nor shown in a sidebar header
+    // row (the header chip owns that), so it should be absent entirely.
+    expect(text).not.toContain('main')
   })
 
   it('shows the narrowing as n/N in the tab header', () => {


### PR DESCRIPTION
Part of the "say everything once" design pass (#1367).

Two changes:

1. Remove the "Current: <branch>" and "Worktree: clean/dirty" sidebar rows from the branches tab. These duplicate information already present in the header chip bar. The freed 3 rows go to the branch list, giving users more visible entries.

2. Dim the "✓ clean" header chip. Its the default state and shouldnt compete visually with the warning-level "● dirty" chip or actionable status messages.

Testing:
- tsc --noEmit clean
- 127 workstation suites (2511 tests, 68 snapshots) pass
- Updated sidebarFilteredLists.test.ts to match new behavior

Relates to #1367