### PR TITLE
design(workstation): unify panel meta separators; drop default-state noise

### DIFF
--- a/src/workstation/surfaces/branches/__snapshots__/branchesRender.test.ts.snap
+++ b/src/workstation/surfaces/branches/__snapshots__/branchesRender.test.ts.snap
@@ -20,7 +20,7 @@ exports[`renderBranchesSurface structural snapshot — empty 1`] = `
     <Text
       dimColor={true}
     >
-      0/0 local | current: main | ▼ name
+      0/0 local · ▼ name
     </Text>
   </Box>
   <Text
@@ -51,7 +51,7 @@ exports[`renderBranchesSurface structural snapshot — populated 1`] = `
     <Text
       dimColor={true}
     >
-      1/1 local | current: main | ▼ name
+      1/1 local · ▼ name
     </Text>
   </Box>
   <Text

--- a/src/workstation/surfaces/branches/index.ts
+++ b/src/workstation/surfaces/branches/index.ts
@@ -55,11 +55,15 @@ export function renderBranchesSurface(ctx: SurfaceRenderContext, spinnerFrame: n
   const listRows = localBranches.length > baseRows ? Math.max(4, baseRows - 1) : baseRows
   const startIndex = clampListWindowStart(selected, localBranches.length, listRows)
   const visible = localBranches.slice(startIndex, startIndex + listRows)
-  const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
-  const sortLabel = ` | ${formatSortIndicator(state.branchSort, { ascii: theme.ascii })}`
+  const filterLabel = state.filter ? `filter: ${state.filter}` : undefined
+  const sortLabel = formatSortIndicator(state.branchSort, { ascii: theme.ascii })
   const headerRight = loading
     ? 'loading branches'
-    : `${localBranches.length}/${sortedAll.length} local | current: ${branches?.currentBranch || '<detached>'}${filterLabel}${sortLabel}`
+    : [
+      `${localBranches.length}/${sortedAll.length} local`,
+      filterLabel,
+      sortLabel,
+    ].filter(Boolean).join(' · ')
   const emptyLabel = formatLogInkBranchesEmpty({ filter: state.filter })
   const loadingLabel = formatLogInkLoading({ resource: 'branches' })
   // Per-column width derived from the visible window (#833) so columns

--- a/src/workstation/surfaces/history/__snapshots__/historyRender.test.ts.snap
+++ b/src/workstation/surfaces/history/__snapshots__/historyRender.test.ts.snap
@@ -20,7 +20,7 @@ exports[`renderHistoryPanel structural snapshot — default 3-commit history 1`]
     <Text
       dimColor={true}
     >
-      3/3 commits | full graph | loaded
+      3 commits
     </Text>
   </Box>
   <Text
@@ -170,7 +170,7 @@ exports[`renderHistoryPanel structural snapshot — empty repo 1`] = `
     <Text
       dimColor={true}
     >
-      0/0 commits | full graph | loaded
+      0 commits
     </Text>
   </Box>
   <Text
@@ -201,7 +201,7 @@ exports[`renderHistoryPanel structural snapshot — narrow terminal (tight densi
     <Text
       dimColor={true}
     >
-      3/3 commits | full graph | loaded
+      3 commits
     </Text>
   </Box>
   <Text

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -685,9 +685,13 @@ export function renderHistoryPanel(
     ? 'loading older commits'
     : hasMoreCommits
       ? 'more below'
-      : 'loaded'
-  const title = `${state.filteredCommits.length}/${state.commits.length} commits`
-  const graphMode = state.fullGraph ? 'full graph' : 'compact graph'
+      : undefined
+  // Only show the fraction when a filter is active or rows were trimmed
+  const title = state.filteredCommits.length < state.commits.length
+    ? `${state.filteredCommits.length}/${state.commits.length}`
+    : `${state.commits.length} commits`
+  // Show graph mode only when compact (the exception state worth noting)
+  const graphMode = state.fullGraph ? undefined : 'compact'
 
   const pendingRowSelected = showPendingRow && Boolean(state.pendingCommitFocused) && focused
   // Real-commit selection is suppressed while the cursor is on the pending
@@ -708,7 +712,7 @@ export function renderHistoryPanel(
   },
   h(Box, { justifyContent: 'space-between' },
     h(Text, { bold: true }, panelTitle('Commits', focused)),
-    h(Text, { dimColor: true }, `${title} | ${graphMode} | ${loadState}`)
+    h(Text, { dimColor: true }, [title, graphMode, loadState].filter(Boolean).join(' · '))
   ),
   // Upstream-ahead banner. Surfaces "the remote has work you don't"
   // for the current branch — distinct from the chip work in 0.52.0

--- a/src/workstation/surfaces/status/__snapshots__/statusRender.test.ts.snap
+++ b/src/workstation/surfaces/status/__snapshots__/statusRender.test.ts.snap
@@ -20,7 +20,7 @@ exports[`renderStatusSurface structural snapshot — clean worktree 1`] = `
     <Text
       dimColor={true}
     >
-      0 staged | 0 unstaged | 0 untracked
+      clean
     </Text>
   </Box>
   <Text
@@ -51,7 +51,7 @@ exports[`renderStatusSurface structural snapshot — loading worktree status 1`]
     <Text
       dimColor={true}
     >
-      status loading
+      loading status
     </Text>
   </Box>
   <Text
@@ -82,7 +82,7 @@ exports[`renderStatusSurface structural snapshot — mixed staged + unstaged + u
     <Text
       dimColor={true}
     >
-      1 staged | 1 unstaged | 1 untracked
+      1 staged · 1 unstaged · 1 untracked
     </Text>
   </Box>
   <Text

--- a/src/workstation/surfaces/status/index.ts
+++ b/src/workstation/surfaces/status/index.ts
@@ -193,8 +193,12 @@ export function renderStatusSurface(ctx: SurfaceRenderContext): ReactTypes.React
   h(Box, { justifyContent: 'space-between' },
     h(Text, { bold: true }, panelTitle('Worktree', focused)),
     h(Text, { dimColor: true }, worktree
-      ? `${worktree.stagedCount} staged | ${worktree.unstagedCount} unstaged | ${worktree.untrackedCount} untracked`
-      : 'status loading')
+      ? [
+        worktree.stagedCount ? `${worktree.stagedCount} staged` : undefined,
+        worktree.unstagedCount ? `${worktree.unstagedCount} unstaged` : undefined,
+        worktree.untrackedCount ? `${worktree.untrackedCount} untracked` : undefined,
+      ].filter(Boolean).join(' · ') || 'clean'
+      : 'loading status')
   ),
   // Mask indicator (#776). Only rendered when the mask is narrower
   // than the all-on default — keeps the chrome clean for users who


### PR DESCRIPTION
Part of the "say everything once" design pass (#1367, items 4+5).

Unifies panel meta separators from `|` to `·` across history, status, and branches surfaces — matching the header/footer convention. Also eliminates always-on default-state reporting:

- History: drops "loaded" (the permanent default), shows graph mode only when compact (the exception worth noting), shows commit fraction only when a filter is active
- Status: shows only non-zero counts instead of "0 staged | 0 unstaged | 0 untracked"; falls back to "clean" when all are zero
- Branches: drops "current: <branch>" (duplicates the header chip); uses · separators for count/filter/sort

Testing:
- tsc --noEmit clean
- 5 affected surface suites (62 tests) pass
- 8 snapshots updated to reflect the new format

Relates to #1367