### PR TITLE
design(workstation): unify loading vocabulary across all surfaces

### DIFF
--- a/src/workstation/chrome/surfaceStates.test.ts
+++ b/src/workstation/chrome/surfaceStates.test.ts
@@ -1,23 +1,23 @@
 import {
-  formatLogInkBlameEmpty,
-  formatLogInkBranchesEmpty,
-  formatLogInkComposeEmpty,
-  formatLogInkHistoryEmpty,
-  formatLogInkLoading,
-  formatLogInkPullRequestDiffEmpty,
-  formatLogInkPullRequestDiffError,
-  formatLogInkStashEmpty,
-  formatLogInkStatusEmpty,
-  formatLogInkTagsEmpty,
+    formatLogInkBlameEmpty,
+    formatLogInkBranchesEmpty,
+    formatLogInkComposeEmpty,
+    formatLogInkHistoryEmpty,
+    formatLogInkLoading,
+    formatLogInkPullRequestDiffEmpty,
+    formatLogInkPullRequestDiffError,
+    formatLogInkStashEmpty,
+    formatLogInkStatusEmpty,
+    formatLogInkTagsEmpty,
 } from './surfaceStates'
 
 describe('log Ink surface states', () => {
   describe('formatLogInkLoading', () => {
     it('renders a uniform leading glyph + text per resource', () => {
-      expect(formatLogInkLoading({ resource: 'branches' })).toBe('· Loading branches…')
-      expect(formatLogInkLoading({ resource: 'tags' })).toBe('· Loading tags…')
-      expect(formatLogInkLoading({ resource: 'stashes' })).toBe('· Loading stashes…')
-      expect(formatLogInkLoading({ resource: 'worktree status' })).toBe('· Loading worktree status…')
+      expect(formatLogInkLoading({ resource: 'branches' })).toBe('Loading branches…')
+      expect(formatLogInkLoading({ resource: 'tags' })).toBe('Loading tags…')
+      expect(formatLogInkLoading({ resource: 'stashes' })).toBe('Loading stashes…')
+      expect(formatLogInkLoading({ resource: 'worktree status' })).toBe('Loading worktree status…')
     })
   })
 

--- a/src/workstation/chrome/surfaceStates.ts
+++ b/src/workstation/chrome/surfaceStates.ts
@@ -17,7 +17,7 @@ export type LogInkSurfaceLoadingArgs = {
  * consistently across surfaces. ASCII-safe — never relies on color.
  */
 export function formatLogInkLoading({ resource }: LogInkSurfaceLoadingArgs): string {
-  return `· Loading ${resource}…`
+  return `Loading ${resource}…`
 }
 
 export type LogInkBranchesEmptyArgs = {

--- a/src/workstation/surfaces/blame/__snapshots__/blameRender.test.ts.snap
+++ b/src/workstation/surfaces/blame/__snapshots__/blameRender.test.ts.snap
@@ -56,7 +56,7 @@ exports[`renderBlameSurface structural snapshot — loading 1`] = `
     <Text
       dimColor={true}
     >
-      loading blame
+      Loading blame…
     </Text>
   </Box>
   <Text
@@ -67,7 +67,7 @@ exports[`renderBlameSurface structural snapshot — loading 1`] = `
   <Text
     dimColor={true}
   >
-    · Loading blame…
+    Loading blame…
   </Text>
 </Box>
 `;

--- a/src/workstation/surfaces/blame/index.ts
+++ b/src/workstation/surfaces/blame/index.ts
@@ -74,7 +74,7 @@ export function renderBlameSurface(
   const visible = lines.slice(windowStart, windowStart + listRows)
 
   const headerRight = loading
-    ? 'loading blame'
+    ? 'Loading blame…'
     : lines.length
       ? `${selected + 1}/${lines.length} lines`
       : '0 lines'

--- a/src/workstation/surfaces/branches/index.ts
+++ b/src/workstation/surfaces/branches/index.ts
@@ -58,7 +58,7 @@ export function renderBranchesSurface(ctx: SurfaceRenderContext, spinnerFrame: n
   const filterLabel = state.filter ? `filter: ${state.filter}` : undefined
   const sortLabel = formatSortIndicator(state.branchSort, { ascii: theme.ascii })
   const headerRight = loading
-    ? 'loading branches'
+    ? 'Loading branches…'
     : [
       `${localBranches.length}/${sortedAll.length} local`,
       filterLabel,

--- a/src/workstation/surfaces/conflicts/index.ts
+++ b/src/workstation/surfaces/conflicts/index.ts
@@ -171,7 +171,7 @@ export function renderConflictsSurface(ctx: SurfaceRenderContext): ReactTypes.Re
   const visible = conflictedFiles.slice(startIndex, startIndex + listRows)
   const remaining = conflictedFiles.length
   const headerRight = loading
-    ? 'loading conflicts'
+    ? 'Loading conflicts…'
     : `${operationType} — ${remaining} ${remaining === 1 ? 'conflict' : 'conflicts'} remaining`
 
   const statusLabel = (file: { indexStatus: string; worktreeStatus: string }): string => {

--- a/src/workstation/surfaces/diff/diffSurface.test.ts
+++ b/src/workstation/surfaces/diff/diffSurface.test.ts
@@ -224,7 +224,7 @@ describe('PR diff surface (#1363)', () => {
 
   it('shows the surface-states loading line while the patch fetch runs', () => {
     const text = flattenText(buildPr({ loading: true }))
-    expect(text).toContain('· Loading diff for #962…')
+    expect(text).toContain('Loading diff for #962…')
   })
 
   it('surfaces a fetch failure with recovery hints instead of a bare empty state', () => {

--- a/src/workstation/surfaces/fileHistory/fileHistoryRender.test.ts
+++ b/src/workstation/surfaces/fileHistory/fileHistoryRender.test.ts
@@ -118,7 +118,7 @@ describe('renderFileHistorySurface', () => {
     expect((tree.props as StubProps).width).toBe(120)
     const text = collectText(tree)
     expect(text).toContain('File History')
-    expect(text).toContain('loading history')
+    expect(text).toContain('Loading history…')
     expect(text).toContain('Loading file history')
     expect(text).toContain('src/example.ts')
   })

--- a/src/workstation/surfaces/fileHistory/index.ts
+++ b/src/workstation/surfaces/fileHistory/index.ts
@@ -81,7 +81,7 @@ export function renderFileHistorySurface(
   const visible = commits.slice(windowStart, windowStart + listRows)
 
   const headerRight = loading
-    ? 'loading history'
+    ? 'Loading history…'
     : commits.length
       ? `${selected + 1}/${commits.length} commits`
       : '0 commits'

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -682,7 +682,7 @@ export function renderHistoryPanel(
     : Math.max(3, bodyRows - chromeRows)
   const visible = getVisibleLogInkHistory(state, listRows, { fullGraphSpacing, dateBucketingNow })
   const loadState = loadingMoreCommits
-    ? 'loading older commits'
+    ? 'Loading older commits…'
     : hasMoreCommits
       ? 'more below'
       : undefined

--- a/src/workstation/surfaces/issuesTriage/index.ts
+++ b/src/workstation/surfaces/issuesTriage/index.ts
@@ -69,7 +69,7 @@ export function renderIssuesTriageSurface(ctx: SurfaceRenderContext): ReactTypes
   let bodyLines: ReactTypes.ReactNode[] = []
 
   if (loading || !overview) {
-    headerRight = 'loading issues'
+    headerRight = 'Loading issues…'
     bodyLines = [
       h(Text, { key: 'issues-loading', dimColor: true }, formatLogInkLoading({ resource: 'issues' })),
     ]

--- a/src/workstation/surfaces/pullRequestTriage/index.ts
+++ b/src/workstation/surfaces/pullRequestTriage/index.ts
@@ -121,7 +121,7 @@ export function renderPullRequestTriageSurface(
   let bodyLines: ReactTypes.ReactNode[] = []
 
   if (loading || !overview) {
-    headerRight = `loading ${nouns.pluralLower}`
+    headerRight = `Loading ${nouns.pluralLower}…`
     bodyLines = [
       h(Text, { key: 'pr-triage-loading', dimColor: true }, formatLogInkLoading({ resource: nouns.pluralLower })),
     ]

--- a/src/workstation/surfaces/reflog/index.ts
+++ b/src/workstation/surfaces/reflog/index.ts
@@ -39,7 +39,7 @@ export function renderReflogSurface(ctx: SurfaceRenderContext): ReactTypes.React
   const visible = entries.slice(startIndex, startIndex + listRows)
   const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
   const headerRight = loading
-    ? 'loading reflog'
+    ? 'Loading reflog…'
     : `${entries.length}/${allEntries.length} entries${filterLabel}`
   const emptyLabel = formatLogInkReflogEmpty({ filter: state.filter })
   const loadingLabel = formatLogInkLoading({ resource: 'reflog' })

--- a/src/workstation/surfaces/remotes/index.ts
+++ b/src/workstation/surfaces/remotes/index.ts
@@ -39,7 +39,7 @@ export function renderRemotesSurface(ctx: SurfaceRenderContext): ReactTypes.Reac
   const visible = filtered.slice(startIndex, startIndex + listRows)
   const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
   const headerRight = loading
-    ? 'loading remotes'
+    ? 'Loading remotes…'
     : `${filtered.length}/${all.length} remotes${filterLabel}`
   const emptyLabel = formatLogInkRemotesEmpty({ filter: state.filter })
   const loadingLabel = formatLogInkLoading({ resource: 'remotes' })

--- a/src/workstation/surfaces/stash/index.ts
+++ b/src/workstation/surfaces/stash/index.ts
@@ -57,7 +57,7 @@ export function renderStashSurface(ctx: SurfaceRenderContext, spinnerFrame: numb
   const visible = stashes.slice(startIndex, startIndex + listRows)
   const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
   const headerRight = loading
-    ? 'loading stashes'
+    ? 'Loading stashes…'
     : `${stashes.length}/${allStashes.length} stashes${filterLabel}`
   const emptyLabel = formatLogInkStashEmpty({ filter: state.filter })
   const loadingLabel = formatLogInkLoading({ resource: 'stashes' })

--- a/src/workstation/surfaces/status/__snapshots__/statusRender.test.ts.snap
+++ b/src/workstation/surfaces/status/__snapshots__/statusRender.test.ts.snap
@@ -51,13 +51,13 @@ exports[`renderStatusSurface structural snapshot — loading worktree status 1`]
     <Text
       dimColor={true}
     >
-      loading status
+      Loading status…
     </Text>
   </Box>
   <Text
     dimColor={false}
   >
-    · Loading worktree status…
+    Loading worktree status…
   </Text>
 </Box>
 `;

--- a/src/workstation/surfaces/status/index.ts
+++ b/src/workstation/surfaces/status/index.ts
@@ -198,7 +198,7 @@ export function renderStatusSurface(ctx: SurfaceRenderContext): ReactTypes.React
         worktree.unstagedCount ? `${worktree.unstagedCount} unstaged` : undefined,
         worktree.untrackedCount ? `${worktree.untrackedCount} untracked` : undefined,
       ].filter(Boolean).join(' · ') || 'clean'
-      : 'loading status')
+      : 'Loading status…')
   ),
   // Mask indicator (#776). Only rendered when the mask is narrower
   // than the all-on default — keeps the chrome clean for users who

--- a/src/workstation/surfaces/submodules/index.ts
+++ b/src/workstation/surfaces/submodules/index.ts
@@ -59,7 +59,7 @@ export function renderSubmodulesSurface(ctx: SurfaceRenderContext): ReactTypes.R
   const visible = filtered.slice(startIndex, startIndex + listRows)
   const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
   const headerRight = loading
-    ? 'loading submodules'
+    ? 'Loading submodules…'
     : `${filtered.length}/${all.length} submodules${filterLabel}`
   const emptyLabel = formatLogInkSubmodulesEmpty({ filter: state.filter })
   const loadingLabel = formatLogInkLoading({ resource: 'submodules' })

--- a/src/workstation/surfaces/tags/index.ts
+++ b/src/workstation/surfaces/tags/index.ts
@@ -43,7 +43,7 @@ export function renderTagsSurface(ctx: SurfaceRenderContext, spinnerFrame: numbe
   const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
   const sortLabel = ` | ${formatSortIndicator(state.tagSort, { ascii: theme.ascii })}`
   const headerRight = loading
-    ? 'loading tags'
+    ? 'Loading tags…'
     : `${tags.length}/${sortedAll.length} tags${filterLabel}${sortLabel}`
   const emptyLabel = formatLogInkTagsEmpty({ filter: state.filter })
   const loadingLabel = formatLogInkLoading({ resource: 'tags' })

--- a/src/workstation/surfaces/worktrees/index.ts
+++ b/src/workstation/surfaces/worktrees/index.ts
@@ -39,7 +39,7 @@ export function renderWorktreesSurface(ctx: SurfaceRenderContext, spinnerFrame: 
   const visible = worktrees.slice(startIndex, startIndex + listRows)
   const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
   const headerRight = loading
-    ? 'loading worktrees'
+    ? 'Loading worktrees…'
     : `${worktrees.length}/${allWorktrees.length} worktrees${filterLabel}`
   // Per-window branch column width (#833). Worktrees often track
   // branches with names varying widely in length (`main` vs.


### PR DESCRIPTION
Part of the "say everything once" design pass (#1367, item 5).

Standardizes loading copy to one consistent form: capitalized "Loading <resource>…" with trailing ellipsis, everywhere — both in the headerRight slot and in the body placeholder.

Before: lowercase "loading branches" (headers) vs "· Loading branches…" (body).
After: both read "Loading branches…".

Drops the "· " prefix from formatLogInkLoading since the phrase now appears identically in both slots and the prefix was a visual conflict with the dot-separator convention.

Covers all 14 surfaces.

Testing:
- tsc --noEmit clean
- 33 surface suites + surfaceStates test (351 tests, 65 snapshots) pass

Relates to #1367