### PR TITLE
design(workstation): filter remote-tracking twin from trailing refs when chip is shown

### DIFF
--- a/src/workstation/chrome/branchTip.test.ts
+++ b/src/workstation/chrome/branchTip.test.ts
@@ -91,16 +91,22 @@ describe('getBranchTipChip', () => {
 })
 
 describe('filterChippedRefs', () => {
-  it('removes HEAD -> X and bare X when X is the chip', () => {
+  it('removes HEAD -> X, bare X, and the remote-tracking twin when X is the chip', () => {
     const refs = ['HEAD -> main', 'main', 'origin/main', 'origin/HEAD']
     const chip = { name: 'main', isHead: true, kind: 'head' as const }
-    expect(filterChippedRefs(refs, chip)).toEqual(['origin/main', 'origin/HEAD'])
+    expect(filterChippedRefs(refs, chip, ['origin'])).toEqual(['origin/HEAD'])
   })
 
-  it('removes only the exact chip name for non-HEAD tips', () => {
+  it('removes the remote twin using fallback origin when no remoteNames provided', () => {
+    const refs = ['HEAD -> main', 'main', 'origin/main', 'origin/HEAD']
+    const chip = { name: 'main', isHead: true, kind: 'head' as const }
+    expect(filterChippedRefs(refs, chip)).toEqual(['origin/HEAD'])
+  })
+
+  it('removes only the exact chip name for non-HEAD tips (plus remote twin)', () => {
     const refs = ['claude/issues-prs-cli', 'origin/claude/issues-prs-cli']
     const chip = { name: 'claude/issues-prs-cli', isHead: false, kind: 'remote' as const }
-    expect(filterChippedRefs(refs, chip)).toEqual(['origin/claude/issues-prs-cli'])
+    expect(filterChippedRefs(refs, chip, ['origin'])).toEqual([])
   })
 
   it('removes the chip ref entirely when it is the only ref', () => {
@@ -114,10 +120,10 @@ describe('filterChippedRefs', () => {
     expect(filterChippedRefs(refs, undefined)).toEqual(refs)
   })
 
-  it('preserves tags even when they appear alongside the chipped branch', () => {
+  it('preserves tags even when the remote-tracking twin is removed', () => {
     const refs = ['HEAD -> main', 'main', 'tag: v1.0.0', 'origin/main']
     const chip = { name: 'main', isHead: true, kind: 'head' as const }
-    expect(filterChippedRefs(refs, chip)).toEqual(['tag: v1.0.0', 'origin/main'])
+    expect(filterChippedRefs(refs, chip, ['origin'])).toEqual(['tag: v1.0.0'])
   })
 
   it('strips bare HEAD only when the chip is the HEAD branch', () => {
@@ -126,5 +132,11 @@ describe('filterChippedRefs', () => {
     expect(filterChippedRefs(refs, headChip)).toEqual([])
     const nonHeadChip = { name: 'main', isHead: false, kind: 'local' as const }
     expect(filterChippedRefs(refs, nonHeadChip)).toEqual(['HEAD'])
+  })
+
+  it('removes twins from multiple remotes', () => {
+    const refs = ['HEAD -> feat', 'feat', 'origin/feat', 'upstream/feat', 'tag: v2']
+    const chip = { name: 'feat', isHead: true, kind: 'head' as const }
+    expect(filterChippedRefs(refs, chip, ['origin', 'upstream'])).toEqual(['tag: v2'])
   })
 })

--- a/src/workstation/chrome/branchTip.ts
+++ b/src/workstation/chrome/branchTip.ts
@@ -37,24 +37,38 @@ export type BranchTipChip = {
  * Strip refs that are already represented by a branch tip chip so the
  * trailing `[ref] [ref]` list doesn't repeat what the chip is already
  * showing. The chip carries the primary branch name; the trailing
- * list keeps everything else — including remote-tracking variants
- * (`origin/X`) and `origin/HEAD` — because those convey "remote is
- * also at this commit" info the chip alone doesn't.
+ * list keeps everything else (tags, `origin/HEAD`).
  *
  * Removes:
  *   - exact match of the chipped name (`main`, `feat/foo`)
  *   - `HEAD -> <name>` for the chipped name
- *   - bare `HEAD` when the chip is the HEAD branch (only paranoia;
- *     git typically emits `HEAD -> name` not both, but a detached
- *     fixup commit may have produced both)
+ *   - bare `HEAD` when the chip is the HEAD branch
+ *   - remote-tracking twin(s) of the chipped name (`origin/<name>`,
+ *     `upstream/<name>`) — these duplicate the chip's information
+ *     and consume subject-line budget (#1367 item 1)
  */
-export function filterChippedRefs(refs: string[], chip: BranchTipChip | undefined): string[] {
+export function filterChippedRefs(
+  refs: string[],
+  chip: BranchTipChip | undefined,
+  remoteNames?: string[],
+): string[] {
   if (!chip) return refs
   const headDecoration = `HEAD -> ${chip.name}`
+  // Build a set of remote-tracking variants to exclude.
+  const remoteTrackingTwins = new Set<string>()
+  if (remoteNames && remoteNames.length > 0) {
+    for (const remote of remoteNames) {
+      if (remote) remoteTrackingTwins.add(`${remote}/${chip.name}`)
+    }
+  } else {
+    // Fallback: assume "origin" when no remote list is available.
+    remoteTrackingTwins.add(`origin/${chip.name}`)
+  }
   return refs.filter((ref) => {
     if (ref === chip.name) return false
     if (ref === headDecoration) return false
     if (chip.isHead && ref === 'HEAD') return false
+    if (remoteTrackingTwins.has(ref)) return false
     return true
   })
 }

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -327,7 +327,7 @@ function renderCommitHistoryRow(
   const chip = fullGraph
     ? renderBranchTipChip(h, Text, commit, theme, `${commit.hash}-${index}-chip`, selected, remoteNames)
     : { node: null, width: 0, chip: undefined }
-  const refs = formatInkRefLabels(filterChippedRefs(commit.refs, chip.chip))
+  const refs = formatInkRefLabels(filterChippedRefs(commit.refs, chip.chip, remoteNames))
   // The "just landed" marker prepends 2 cells (`▎ ` / `* `) — the
   // stacked variant budgets it via recentMarkerWidth, and omitting it
   // here made marked rows wrap for ~5s after every commit (#1390).
@@ -477,7 +477,7 @@ function renderStackedCommitHistoryRow(
   // as a leading chip and a trailing label.
   const indent = ' '.repeat(graphWidth + 1)
   const dateText = formatCompactRelativeDate(commit.date, now)
-  const refs = formatInkRefLabels(filterChippedRefs(commit.refs, chip.chip))
+  const refs = formatInkRefLabels(filterChippedRefs(commit.refs, chip.chip, remoteNames))
   const metaRoom = Math.max(8, totalWidth - indent.length - (dateText ? dateText.length + 1 : 0))
   const refsTrunc = refs ? truncateCells(refs, metaRoom) : ''
   // If both pieces are empty (date unparseable + no refs), show a


### PR DESCRIPTION
Part of the "say everything once" design pass (#1367, item 1).

The HEAD row was painting the branch twice: once as the leading chip [main] and again as a trailing [origin/main] ref label, wasting ~12 cells of subject-line budget.

filterChippedRefs now accepts an optional remoteNames list and strips <remote>/<chip.name> variants. Falls back to assuming "origin" when no remote list is available. Tags and origin/HEAD are preserved (distinct information).

Testing:
- tsc --noEmit clean
- 3 suites (45 tests, 10 snapshots) pass
- Added test for multi-remote filtering

Relates to #1367