### PR TITLE
design(workstation): remote-tracking chips use muted color; drop status position-based dimming

### DIFF
--- a/src/workstation/surfaces/history/__snapshots__/branchTipChipRender.test.ts.snap
+++ b/src/workstation/surfaces/history/__snapshots__/branchTipChipRender.test.ts.snap
@@ -26,7 +26,7 @@ exports[`renderBranchTipChip — structural snapshots falls back to the legacy "
   "node": <Text>
     <Text
       bold={false}
-      color="yellow"
+      color="gray"
       inverse={true}
     >
        feat/widgets 
@@ -72,7 +72,7 @@ exports[`renderBranchTipChip — structural snapshots renders a remote-tracking 
   "node": <Text>
     <Text
       bold={false}
-      color="yellow"
+      color="gray"
       inverse={true}
     >
        origin/main 

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -156,19 +156,18 @@ export function renderBranchTipChip(
   //
   //   - HEAD  → success (the user's current branch — bright green)
   //   - local → info    (other local branches — calm blue)
-  //   - remote → warning (remote-tracking refs like origin/main —
-  //                      distinct so "where is upstream?" reads at a glance)
+  //   - remote → muted  (remote-tracking refs like origin/main —
+  //                      a pure fact, not a warning; dim so it doesn't
+  //                      compete with semantic warning uses of yellow)
   //
-  // Without the remote/local split, a chip on `origin/main` looked
-  // identical to a local-branch chip, so users couldn't tell from the
-  // commit list where their upstream actually pointed. The warning hue
-  // (typically a muted yellow / orange) is purposeful: not alarming,
-  // but visibly different from the local blue.
+  // Prior to #1368 remote chips used `warning`, which overloaded
+  // yellow with non-actionable information. Muted keeps the chip
+  // visibly distinct from local blue without the "pay attention" cue.
   const accent =
     chip.kind === 'head'
       ? theme.colors.success
       : chip.kind === 'remote'
-        ? theme.colors.warning
+        ? theme.colors.muted
         : theme.colors.info
   return {
     node: h(Text, {},

--- a/src/workstation/surfaces/status/__snapshots__/statusRender.test.ts.snap
+++ b/src/workstation/surfaces/status/__snapshots__/statusRender.test.ts.snap
@@ -87,7 +87,7 @@ exports[`renderStatusSurface structural snapshot — mixed staged + unstaged + u
   </Box>
   <Text
     bold={true}
-    dimColor={false}
+    dimColor={true}
   >
       ▾ Staged (1)
   </Text>

--- a/src/workstation/surfaces/status/index.ts
+++ b/src/workstation/surfaces/status/index.ts
@@ -132,7 +132,7 @@ export function renderStatusSurface(ctx: SurfaceRenderContext): ReactTypes.React
         return h(Text, {
           key: `status-group-${row.group.state}-${rowIndex}`,
           bold: true,
-          dimColor: !headerSelected && rowIndex > cursorRowIndex,
+          dimColor: !headerSelected,
           backgroundColor: headerSelected && !theme.noColor ? theme.colors.selection : undefined,
           color: headerSelected && !theme.noColor ? theme.colors.selectionForeground : undefined,
         }, truncateCells(text, rowBudget))
@@ -152,7 +152,7 @@ export function renderStatusSurface(ctx: SurfaceRenderContext): ReactTypes.React
       const tailTrunc = truncateCells(tail, Math.max(0, rowBudget - cellWidth(cursorPart) - dotCells - 2))
       return h(Text, {
         key: `status-file-${row.flatIndex}-${rowIndex}`,
-        dimColor: !isSelected && rowIndex > cursorRowIndex,
+        dimColor: !isSelected,
         backgroundColor: isSelected && focused && !theme.noColor ? theme.colors.selection : undefined,
         color: isSelected && focused && !theme.noColor ? theme.colors.selectionForeground : undefined,
       },


### PR DESCRIPTION
Two color discipline fixes (#1368, items 1 + 3):

1. **Remote-tracking branch chips** (origin/main) now use `theme.colors.muted` instead of `theme.colors.warning`. These communicate a pure fact (where is upstream?), not actionable information. Yellow was overloaded with too many unrelated meanings (behind-upstream, dirty, fix: prefix, staged dot, graph lane, BISECTING).

2. **Status surface** no longer dims every row below the cursor. The position-based `dimColor: rowIndex > cursorRowIndex` made whole sections appear disabled. Now only non-selected rows dim — same as every other surface.

Testing:
- tsc --noEmit clean
- 3 suites (32 tests, 13 snapshots) pass
- 3 snapshots updated to reflect color changes

Relates to #1368