### PR TITLE
design(workstation): reduce graph lane palette to 5 non-semantic hues; drop bold

### DIFF
--- a/src/workstation/chrome/graphLanes.test.ts
+++ b/src/workstation/chrome/graphLanes.test.ts
@@ -13,7 +13,7 @@ describe('lane palette helpers', () => {
     const theme = createLogInkTheme({ preset: 'default', env: {} })
     const palette = getLanePalette(theme)
 
-    expect(palette.length).toBeGreaterThanOrEqual(6)
+    expect(palette.length).toBeGreaterThanOrEqual(4)
     // Default uses ANSI named colors so 16-color terminals render them
     // faithfully without needing truecolor support.
     expect(palette[0]).toBe('cyan')

--- a/src/workstation/chrome/graphLanes.ts
+++ b/src/workstation/chrome/graphLanes.ts
@@ -14,25 +14,21 @@ export type LaneSegment = {
 }
 
 /**
- * Theme-aware lane palette. Default uses bright ANSI named colors that
- * render reliably on 16-color terminals; catppuccin / gruvbox lift
- * accent hues from their respective palettes so the graph stays
- * coherent with the surrounding chrome.
- *
- * Selecting 8 colors gives enough variety to distinguish lanes in
- * practice (most repos peak at 3-4 simultaneous lanes); the modulo
- * lookup wraps cleanly for the rare case of more.
+ * Theme-aware lane palette. Capped at 5 muted hues that exclude the
+ * semantic trio (red/green/yellow) so lanes don't compete with diff
+ * additions, commit status, or warning signals (#1368). Most repos
+ * peak at 3-4 simultaneous lanes; the modulo wraps cleanly for more.
  */
 const DEFAULT_LANE_PALETTE: readonly string[] = [
-  'cyan', 'magenta', 'yellow', 'green', 'blue', 'red', 'cyanBright', 'magentaBright',
+  'cyan', 'magenta', 'blue', 'cyanBright', 'magentaBright',
 ]
 
 const CATPPUCCIN_LANE_PALETTE: readonly string[] = [
-  '#89b4fa', '#f5c2e7', '#f9e2af', '#a6e3a1', '#cba6f7', '#fab387', '#94e2d5', '#f5e0dc',
+  '#89b4fa', '#f5c2e7', '#cba6f7', '#94e2d5', '#b4befe',
 ]
 
 const GRUVBOX_LANE_PALETTE: readonly string[] = [
-  '#83a598', '#d3869b', '#fabd2f', '#b8bb26', '#d65d0e', '#fb4934', '#8ec07c', '#fe8019',
+  '#83a598', '#d3869b', '#8ec07c', '#d65d0e', '#458588',
 ]
 
 export function getLanePalette(theme: LogInkTheme): readonly string[] {

--- a/src/workstation/surfaces/history/__snapshots__/historyRender.test.ts.snap
+++ b/src/workstation/surfaces/history/__snapshots__/historyRender.test.ts.snap
@@ -28,7 +28,6 @@ exports[`renderHistoryPanel structural snapshot — default 3-commit history 1`]
     color="#ffffff"
   >
     <Text
-      bold={true}
       dimColor={false}
     >
       ◉
@@ -62,7 +61,6 @@ exports[`renderHistoryPanel structural snapshot — default 3-commit history 1`]
   </Text>
   <Text>
     <Text
-      bold={true}
       color="cyan"
       dimColor={false}
     >
@@ -71,7 +69,6 @@ exports[`renderHistoryPanel structural snapshot — default 3-commit history 1`]
   </Text>
   <Text>
     <Text
-      bold={true}
       color="cyan"
       dimColor={false}
     >
@@ -103,7 +100,6 @@ exports[`renderHistoryPanel structural snapshot — default 3-commit history 1`]
   </Text>
   <Text>
     <Text
-      bold={true}
       color="cyan"
       dimColor={false}
     >
@@ -112,7 +108,6 @@ exports[`renderHistoryPanel structural snapshot — default 3-commit history 1`]
   </Text>
   <Text>
     <Text
-      bold={true}
       color="cyan"
       dimColor={false}
     >
@@ -209,7 +204,6 @@ exports[`renderHistoryPanel structural snapshot — narrow terminal (tight densi
     color="#ffffff"
   >
     <Text
-      bold={true}
       dimColor={false}
     >
       ◉
@@ -237,7 +231,6 @@ exports[`renderHistoryPanel structural snapshot — narrow terminal (tight densi
   </Text>
   <Text>
     <Text
-      bold={true}
       color="cyan"
       dimColor={false}
     >
@@ -246,7 +239,6 @@ exports[`renderHistoryPanel structural snapshot — narrow terminal (tight densi
   </Text>
   <Text>
     <Text
-      bold={true}
       color="cyan"
       dimColor={false}
     >
@@ -272,7 +264,6 @@ exports[`renderHistoryPanel structural snapshot — narrow terminal (tight densi
   </Text>
   <Text>
     <Text
-      bold={true}
       color="cyan"
       dimColor={false}
     >
@@ -281,7 +272,6 @@ exports[`renderHistoryPanel structural snapshot — narrow terminal (tight densi
   </Text>
   <Text>
     <Text
-      bold={true}
       color="cyan"
       dimColor={false}
     >

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -250,22 +250,15 @@ function renderLaneSegmentSpans(
   let totalLen = 0
 
   segments.forEach((seg, idx) => {
-    // Weight follows the lane, not the row. A tracked lane (`│`, the
-    // commit glyph, the fork/converge diagonals `╲ ╱` — anything that
-    // carries a `laneId`) renders bold so it reads at a consistent
-    // bright weight everywhere it appears: without the bold the base
-    // ANSI palette colors (`cyan`, `magenta`, …) sit a notch duller
-    // than the `*Bright` entries (#791), and earlier the whole fork/
-    // close row was dimmed (#831) — which made a single lane flicker
-    // bright→dim→bright as it passed through each junction. Genuine
-    // non-lane decoration (spaces, standalone `╲`/`╱`, no `laneId`)
-    // stays unbold in the muted color so it recedes on its own.
+    // Lane coloring WITHOUT bold — content (messages, semantic colors)
+    // should outweigh topology (#1368 item 2). Non-lane decoration
+    // (spaces, standalone diagonals) stays in the muted color so it
+    // recedes on its own.
     const hasLane = seg.laneId !== undefined
     const laneColor = options.suppressColor ? undefined : (getLaneColor(seg.laneId, theme) ?? muted)
     elements.push(h(Text, {
       key: `${keyPrefix}-${idx}`,
       color: laneColor,
-      bold: hasLane,
       dimColor: theme.noColor && !hasLane,
     }, seg.text))
     totalLen += seg.text.length


### PR DESCRIPTION
Part of the color discipline pass (#1368, item 2).

Caps lane colors at 5 hues (cyan, magenta, blue + 2 bright variants), excluding red/green/yellow so lanes dont compete with diff additions, success markers, or warning signals. Drops the blanket `bold: true` on lane segments so commit messages and semantic colors outweigh the topology.

Catppuccin and Gruvbox palettes also trimmed to 5 hues from their palette families.

Testing:
- tsc --noEmit clean
- 4 suites (37 tests, 10 snapshots) pass
- 2 snapshots updated

Relates to #1368