### PR TITLE
perf(workstation): remove isEmptyRepo probe; cap diff lines at 8k

### DIFF
--- a/src/commands/log/data.ts
+++ b/src/commands/log/data.ts
@@ -1,7 +1,6 @@
 import { SimpleGit } from 'simple-git'
 import { extractLfsPatchChange, renderLfsSummary } from '../../git/lfsPointer'
 import { extractSubmoduleChange, renderSubmoduleSummary, type SubmoduleChange } from '../../git/submoduleDiff'
-import { isEmptyRepo } from '../../lib/simple-git/isEmptyRepo'
 import { LogArgv, LogView } from './config'
 
 export const FIELD_SEPARATOR = '\x1f'
@@ -437,19 +436,20 @@ export async function getLogRows(
   options: LogRowLoadOptions = {}
 ): Promise<GitLogRow[]> {
   // Unborn HEAD short-circuit. Without this, `git log` on a freshly
-  // `git init`'d repo throws "fatal: your current branch 'main' does
-  // not have any commits yet" — fine when the caller can catch and
-  // translate, painful otherwise (the workstation runtime surfaces it
-  // as "Failed to load commits: fatal: ..." in the status line).
-  //
-  // Returning [] is the natural contract: callers that already render
-  // an empty-history surface (`formatLogInkHistoryEmpty`) get the
-  // right experience automatically; `coco log` retains its own
-  // friendlier message via the handler's isEmptyRepo check.
-  if (await isEmptyRepo(git)) {
-    return []
+  // Catch git's "does not have any commits yet" error instead of
+  // probing isEmptyRepo before every fetch (#1364 item 5). The probe
+  // added a subprocess to every getLogRows call (boot, refresh, each
+  // load-more page, graph toggle, filter refetch). Catching the error
+  // is O(0) on non-empty repos.
+  try {
+    return parseLogOutput(await git.raw(buildLogArgs(argv, options)))
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err)
+    if (message.includes('does not have any commits yet') || message.includes('bad default revision')) {
+      return []
+    }
+    throw err
   }
-  return parseLogOutput(await git.raw(buildLogArgs(argv, options)))
 }
 
 export async function getCommitDetail(git: SimpleGit, commit: string): Promise<GitCommitDetail> {

--- a/src/git/worktreeDiffData.ts
+++ b/src/git/worktreeDiffData.ts
@@ -32,6 +32,13 @@ function sectionLines(title: string, diff: string): string[] {
   return [title, ...body]
 }
 
+/**
+ * Maximum diff lines fetched per file (#1365 item 5). Prevents OOM on
+ * huge generated files (bundle diffs, lockfiles) — the TUI only renders
+ * ~40 lines at a time anyway.
+ */
+const MAX_DIFF_LINES = 8000
+
 export async function getWorktreeFileDiff(
   git: SimpleGit,
   file: WorktreeFile | undefined
@@ -61,11 +68,20 @@ export async function getWorktreeFileDiff(
   const unstagedDiff = file.worktreeStatus.trim()
     ? await git.diff(['--', file.path])
     : ''
-  const lines = [
+  let lines = [
     ...(stagedDiff ? sectionLines('Staged changes', stagedDiff) : []),
     ...(stagedDiff && unstagedDiff ? [''] : []),
     ...(unstagedDiff ? sectionLines('Unstaged changes', unstagedDiff) : []),
   ]
+
+  // Cap at MAX_DIFF_LINES to prevent OOM on huge files.
+  if (lines.length > MAX_DIFF_LINES) {
+    lines = [
+      ...lines.slice(0, MAX_DIFF_LINES),
+      '',
+      `… truncated (${lines.length - MAX_DIFF_LINES} more lines — open in $EDITOR for the full diff)`,
+    ]
+  }
 
   return {
     filePath: file.path,


### PR DESCRIPTION
Two more quick perf wins (#1364 item 5, #1365 item 5):

1. **getLogRows no longer calls isEmptyRepo before every fetch.** Catches the git error instead. Saves one subprocess on every history fetch (boot, refresh, load-more, graph toggle, filter refetch).

2. **getWorktreeFileDiff caps output at 8,000 lines.** Prevents OOM and syntax-highlight stalls on huge generated files. Shows a truncation message pointing to $EDITOR.

Testing:
- tsc --noEmit clean
- data.test.ts + worktreeDiffData.test.ts (28 tests) pass

Relates to #1364, #1365