### PR TITLE
fix(workstation): enforce danger policy for destructive workflows

### DIFF
--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -4037,7 +4037,7 @@ export function getLogInkInputEvents(
     })]
   }
   if (inputValue === 'c' && isReflogActionTarget(state) && context.reflogCount) {
-    return [{ type: 'runWorkflowAction', id: 'checkout-reflog-entry' }]
+    return [action({ type: 'setPendingConfirmation', value: 'checkout-reflog-entry' })]
   }
 
   // #0.71 — submodule maintenance on the cursored row. Scoped to the

--- a/src/workstation/runtime/inkKeymap.collisions.test.ts
+++ b/src/workstation/runtime/inkKeymap.collisions.test.ts
@@ -219,4 +219,28 @@ describe('LOG_INK_KEY_BINDINGS collision guard', () => {
     const missing = viewsRequiringBindings.filter((v) => !viewsWithBindings.has(v))
     expect(missing).toEqual([])
   })
+
+  it('kind "destructive" implies requiresConfirmation (danger policy #1448)', () => {
+    // #1448 — the danger doctrine: every workflow marked destructive
+    // must either require confirmation OR carry a documented waiver
+    // explaining why confirmation is unnecessary (e.g. undo is cheap,
+    // or the action is input-mediated so the prompt IS the confirm).
+    //
+    // Waivers live here, not in the registry, so adding one is a
+    // reviewed, visible decision. Each entry must carry a justification.
+    const DANGER_WAIVERS = new Set<string>([
+      // apply-hunk-worktree / apply-hunk-index: `git apply -R` cleanly
+      // undoes the patch. Undo is cheap; confirming every hunk-apply
+      // would kill the drill-in-and-apply flow's speed.
+      // (Currently kind: 'normal' so they don't hit this assertion,
+      // but documented here for the doctrine record.)
+    ])
+
+    const actions = getLogInkWorkflowActions()
+    const violations = actions
+      .filter((a) => a.kind === 'destructive' && !a.requiresConfirmation && !DANGER_WAIVERS.has(a.id))
+      .map((a) => a.id)
+
+    expect(violations).toEqual([])
+  })
 })

--- a/src/workstation/runtime/inkWorkflows.test.ts
+++ b/src/workstation/runtime/inkWorkflows.test.ts
@@ -1,8 +1,8 @@
 import {
-  getLogInkWorkflowActionById,
-  getLogInkWorkflowActionByKey,
-  getLogInkWorkflowActions,
-  getLogInkWorkflowSections,
+    getLogInkWorkflowActionById,
+    getLogInkWorkflowActionByKey,
+    getLogInkWorkflowActions,
+    getLogInkWorkflowSections,
 } from './inkWorkflows'
 
 describe('log Ink workflows', () => {
@@ -71,8 +71,8 @@ describe('log Ink workflows', () => {
   it('registers the reflog checkout action as palette-only (view-scoped dispatch is by id)', () => {
     expect(getLogInkWorkflowActionById('checkout-reflog-entry')).toMatchObject({
       key: '',
-      kind: 'normal',
-      requiresConfirmation: false,
+      kind: 'destructive',
+      requiresConfirmation: true,
     })
   })
 

--- a/src/workstation/runtime/inkWorkflows.ts
+++ b/src/workstation/runtime/inkWorkflows.ts
@@ -375,9 +375,9 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       id: 'stage-all-untracked',
       key: '',
       label: 'Stage all untracked files',
-      description: 'Add every untracked file to the index after confirmation.',
-      kind: 'destructive',
-      requiresConfirmation: true,
+      description: 'Add every untracked file to the index.',
+      kind: 'normal',
+      requiresConfirmation: false,
     },
     {
       id: 'delete-branch',
@@ -696,12 +696,14 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       // Reset-to-entry and branch-from-entry reuse the existing
       // `reset-to-commit` / `create-branch-here` workflows (a reflog
       // entry is just a commit by hash); only checkout is reflog-specific.
+      // #1448 — bare keystroke that moves HEAD (detaches). Per the danger
+      // doctrine, HEAD-moving bare-key ops confirm.
       id: 'checkout-reflog-entry',
       key: '',
       label: 'Checkout reflog entry',
-      description: 'Check out the commit at the cursored reflog entry (detaches HEAD).',
-      kind: 'normal',
-      requiresConfirmation: false,
+      description: 'Check out the commit at the cursored reflog entry (detaches HEAD, after confirmation).',
+      kind: 'destructive',
+      requiresConfirmation: true,
     },
     {
       // #0.71 — submodule maintenance actions. All three are scoped


### PR DESCRIPTION
Resolves #1448.

## What

Codifies the danger doctrine as a build-time assertion and fixes the two entries that violated it.

## Fixes

- **`stage-all-untracked`**: downgraded to `kind:'normal'` — staging is trivially reversible via `git reset`; the mislabel taught users y-confirms don't reliably mean danger.
- **`checkout-reflog-entry`**: upgraded to `kind:'destructive'` + `requiresConfirmation: true` — bare keystroke `c` that detaches HEAD instantly; per doctrine, HEAD-moving bare-key ops must gate on y-confirm.

## New assertion

`inkKeymap.collisions.test.ts` now enforces:

> `kind === 'destructive'` implies `requiresConfirmation === true` (or explicit waiver in `DANGER_WAIVERS`)

This fails the build if someone adds a destructive workflow without confirmation and no reviewed waiver.

## Validation

- `npx tsc --noEmit` clean
- `npm run lint` 0 errors
- All 246 keymap tests pass (including new assertion)
