### PR TITLE
fix(workstation): g-chords replace view instead of pushing

### DIFF
--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -1,9 +1,9 @@
 import { GitLogRow } from '../../commands/log/data'
 import {
-  getLogInkInputEvents,
-  getLogInkPaletteExecuteEvents,
-  isCreatePrView,
-  isCreateStashView,
+    getLogInkInputEvents,
+    getLogInkPaletteExecuteEvents,
+    isCreatePrView,
+    isCreateStashView,
 } from './inkInput'
 import { getLogInkPaletteCommands } from './inkKeymap'
 import { LogInkState, LogInkView, applyLogInkAction, createLogInkState } from './inkViewModel'
@@ -858,7 +858,7 @@ describe('log Ink input interactions', () => {
     state = applyInput(state, 'g')
     state = applyInput(state, 's')
 
-    expect(state.viewStack).toEqual(['history', 'status'])
+    expect(state.viewStack).toEqual(['status'])
     expect(state.activeView).toBe('status')
     expect(state.statusMessage).toBe('jumped to status')
   })
@@ -869,7 +869,7 @@ describe('log Ink input interactions', () => {
     state = applyInput(state, 'g')
     state = applyInput(state, 'd')
 
-    expect(state.viewStack).toEqual(['history', 'diff'])
+    expect(state.viewStack).toEqual(['diff'])
     expect(state.activeView).toBe('diff')
     expect(state.statusMessage).toBe('jumped to diff')
   })
@@ -880,7 +880,7 @@ describe('log Ink input interactions', () => {
     state = applyInput(state, 'g')
     state = applyInput(state, 'b')
 
-    expect(state.viewStack).toEqual(['history', 'branches'])
+    expect(state.viewStack).toEqual(['branches'])
     expect(state.activeView).toBe('branches')
     expect(state.statusMessage).toBe('jumped to branches')
   })
@@ -891,7 +891,7 @@ describe('log Ink input interactions', () => {
     state = applyInput(state, 'g')
     state = applyInput(state, 't')
 
-    expect(state.viewStack).toEqual(['history', 'tags'])
+    expect(state.viewStack).toEqual(['tags'])
     expect(state.activeView).toBe('tags')
     expect(state.statusMessage).toBe('jumped to tags')
   })
@@ -902,7 +902,7 @@ describe('log Ink input interactions', () => {
     state = applyInput(state, 'g')
     state = applyInput(state, 'z')
 
-    expect(state.viewStack).toEqual(['history', 'stash'])
+    expect(state.viewStack).toEqual(['stash'])
     expect(state.activeView).toBe('stash')
     expect(state.statusMessage).toBe('jumped to stash')
   })
@@ -1015,7 +1015,7 @@ describe('log Ink input interactions', () => {
     state = applyInput(state, 'g')
     state = applyInput(state, 'r')
 
-    expect(state.viewStack).toEqual(['history', 'reflog'])
+    expect(state.viewStack).toEqual(['reflog'])
     expect(state.activeView).toBe('reflog')
     expect(state.statusMessage).toBe('jumped to reflog')
   })
@@ -1238,7 +1238,7 @@ describe('log Ink input interactions', () => {
     state = applyInput(state, 'g')
     state = applyInput(state, 'B')
 
-    expect(state.viewStack).toEqual(['history', 'bisect'])
+    expect(state.viewStack).toEqual(['bisect'])
     expect(state.activeView).toBe('bisect')
     expect(state.statusMessage).toBe('jumped to bisect')
   })
@@ -1249,7 +1249,7 @@ describe('log Ink input interactions', () => {
     state = applyInput(state, 'g')
     state = applyInput(state, 'M')
 
-    expect(state.viewStack).toEqual(['history', 'submodules'])
+    expect(state.viewStack).toEqual(['submodules'])
     expect(state.activeView).toBe('submodules')
     expect(state.statusMessage).toBe('jumped to submodules')
   })
@@ -2132,7 +2132,7 @@ describe('log Ink input interactions', () => {
     expect(state.pendingKey).toBe('g')
 
     state = applyInput(state, 'c')
-    expect(state.viewStack).toEqual(['history', 'compose'])
+    expect(state.viewStack).toEqual(['compose'])
     expect(state.activeView).toBe('compose')
     expect(state.statusMessage).toBe('jumped to compose')
   })
@@ -3585,7 +3585,7 @@ describe('log Ink input interactions', () => {
       const events = getLogInkInputEvents(state, 't')
       expect(events).toContainEqual({
         type: 'action',
-        action: { type: 'pushView', value: 'tags' },
+        action: { type: 'replaceView', value: 'tags' },
       })
     })
 
@@ -3762,12 +3762,12 @@ describe('log Ink input interactions', () => {
         action: { type: 'setPendingKey', value: 'g' },
       })
 
-      // Second press completes gd → pushView 'diff', not toggleDiffViewMode
+      // Second press completes gd → replaceView 'diff', not toggleDiffViewMode
       const chordState = applyLogInkAction(state, { type: 'setPendingKey', value: 'g' })
       const completeChord = getLogInkInputEvents(chordState, 'd')
       expect(completeChord).toContainEqual({
         type: 'action',
-        action: { type: 'pushView', value: 'diff' },
+        action: { type: 'replaceView', value: 'diff' },
       })
       expect(completeChord).not.toContainEqual({
         type: 'action',
@@ -4815,7 +4815,7 @@ describe('log Ink input interactions', () => {
       // Second key: x pushes conflicts view
       state = applyInput(state, 'x')
       expect(state.activeView).toBe('conflicts')
-      expect(state.viewStack).toEqual(['history', 'conflicts'])
+      expect(state.viewStack).toEqual(['conflicts'])
     })
 
     it('moves cursor up and down in the conflicts view', () => {

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -710,35 +710,35 @@ export function getLogInkPaletteExecuteEvents(
         label: 'Stash message (empty = WIP)',
       })]
     case 'navigateStatus':
-      return [action({ type: 'pushView', value: 'status' })]
+      return [action({ type: 'replaceView', value: 'status' })]
     case 'navigateDiff':
-      return [action({ type: 'pushView', value: 'diff' })]
+      return [action({ type: 'replaceView', value: 'diff' })]
     case 'navigateCompose':
-      return [action({ type: 'pushView', value: 'compose' })]
+      return [action({ type: 'replaceView', value: 'compose' })]
     case 'navigateBranches':
-      return [action({ type: 'pushView', value: 'branches' })]
+      return [action({ type: 'replaceView', value: 'branches' })]
     case 'navigateTags':
-      return [action({ type: 'pushView', value: 'tags' })]
+      return [action({ type: 'replaceView', value: 'tags' })]
     case 'navigateStash':
-      return [action({ type: 'pushView', value: 'stash' })]
+      return [action({ type: 'replaceView', value: 'stash' })]
     case 'navigateWorktrees':
-      return [action({ type: 'pushView', value: 'worktrees' })]
+      return [action({ type: 'replaceView', value: 'worktrees' })]
     case 'navigatePullRequest':
-      return [action({ type: 'pushView', value: 'pull-request' })]
+      return [action({ type: 'replaceView', value: 'pull-request' })]
     case 'navigatePullRequestTriage':
-      return [action({ type: 'pushView', value: 'pull-request-triage' })]
+      return [action({ type: 'replaceView', value: 'pull-request-triage' })]
     case 'navigateIssues':
-      return [action({ type: 'pushView', value: 'issues' })]
+      return [action({ type: 'replaceView', value: 'issues' })]
     case 'navigateConflicts':
-      return [action({ type: 'pushView', value: 'conflicts' })]
+      return [action({ type: 'replaceView', value: 'conflicts' })]
     case 'navigateReflog':
-      return [action({ type: 'pushView', value: 'reflog' })]
+      return [action({ type: 'replaceView', value: 'reflog' })]
     case 'navigateBisect':
-      return [action({ type: 'pushView', value: 'bisect' })]
+      return [action({ type: 'replaceView', value: 'bisect' })]
     case 'navigateSubmodules':
-      return [action({ type: 'pushView', value: 'submodules' })]
+      return [action({ type: 'replaceView', value: 'submodules' })]
     case 'navigateRemotes':
-      return [action({ type: 'pushView', value: 'remotes' })]
+      return [action({ type: 'replaceView', value: 'remotes' })]
     case 'markForCompare':
       // Palette context can't reach the cursored ref (filtered branch /
       // tag lists live in runtime state, not the reducer). Surface a
@@ -1997,42 +1997,42 @@ export function getLogInkInputEvents(
 
   if (state.pendingKey === 'g' && inputValue === 's') {
     return [
-      action({ type: 'pushView', value: 'status' }),
+      action({ type: 'replaceView', value: 'status' }),
       action({ type: 'setStatus', value: 'jumped to status' }),
     ]
   }
 
   if (state.pendingKey === 'g' && inputValue === 'd') {
     return [
-      action({ type: 'pushView', value: 'diff' }),
+      action({ type: 'replaceView', value: 'diff' }),
       action({ type: 'setStatus', value: 'jumped to diff' }),
     ]
   }
 
   if (state.pendingKey === 'g' && inputValue === 'c') {
     return [
-      action({ type: 'pushView', value: 'compose' }),
+      action({ type: 'replaceView', value: 'compose' }),
       action({ type: 'setStatus', value: 'jumped to compose' }),
     ]
   }
 
   if (state.pendingKey === 'g' && inputValue === 'b') {
     return [
-      action({ type: 'pushView', value: 'branches' }),
+      action({ type: 'replaceView', value: 'branches' }),
       action({ type: 'setStatus', value: 'jumped to branches' }),
     ]
   }
 
   if (state.pendingKey === 'g' && inputValue === 't') {
     return [
-      action({ type: 'pushView', value: 'tags' }),
+      action({ type: 'replaceView', value: 'tags' }),
       action({ type: 'setStatus', value: 'jumped to tags' }),
     ]
   }
 
   if (state.pendingKey === 'g' && inputValue === 'z') {
     return [
-      action({ type: 'pushView', value: 'stash' }),
+      action({ type: 'replaceView', value: 'stash' }),
       action({ type: 'setStatus', value: 'jumped to stash' }),
     ]
   }
@@ -2051,7 +2051,7 @@ export function getLogInkInputEvents(
 
   if (state.pendingKey === 'g' && inputValue === 'w') {
     return [
-      action({ type: 'pushView', value: 'worktrees' }),
+      action({ type: 'replaceView', value: 'worktrees' }),
       action({ type: 'setStatus', value: 'jumped to worktrees' }),
     ]
   }
@@ -2063,7 +2063,7 @@ export function getLogInkInputEvents(
   // exposes m / x / a / R / c action keys scoped to the view.
   if (state.pendingKey === 'g' && inputValue === 'p') {
     return [
-      action({ type: 'pushView', value: 'pull-request' }),
+      action({ type: 'replaceView', value: 'pull-request' }),
       action({ type: 'setStatus', value: 'jumped to pull request' }),
     ]
   }
@@ -2074,7 +2074,7 @@ export function getLogInkInputEvents(
   // read-only list views shipped in #882.
   if (state.pendingKey === 'g' && inputValue === 'P') {
     return [
-      action({ type: 'pushView', value: 'pull-request-triage' }),
+      action({ type: 'replaceView', value: 'pull-request-triage' }),
       action({ type: 'setStatus', value: 'jumped to PR triage' }),
     ]
   }
@@ -2082,14 +2082,14 @@ export function getLogInkInputEvents(
   // `gi` chord (#882 phase 3): jump to the issue triage list.
   if (state.pendingKey === 'g' && inputValue === 'i') {
     return [
-      action({ type: 'pushView', value: 'issues' }),
+      action({ type: 'replaceView', value: 'issues' }),
       action({ type: 'setStatus', value: 'jumped to issues' }),
     ]
   }
 
   if (state.pendingKey === 'g' && inputValue === 'x') {
     return [
-      action({ type: 'pushView', value: 'conflicts' }),
+      action({ type: 'replaceView', value: 'conflicts' }),
       action({ type: 'setStatus', value: 'jumped to conflicts' }),
     ]
   }
@@ -2099,7 +2099,7 @@ export function getLogInkInputEvents(
   // commit-diff for the entry's hash. Loaded lazily by the runtime.
   if (state.pendingKey === 'g' && inputValue === 'r') {
     return [
-      action({ type: 'pushView', value: 'reflog' }),
+      action({ type: 'replaceView', value: 'reflog' }),
       action({ type: 'setStatus', value: 'jumped to reflog' }),
     ]
   }
@@ -2110,7 +2110,7 @@ export function getLogInkInputEvents(
   // know how to start one. The view's surface tells them the next step.
   if (state.pendingKey === 'g' && inputValue === 'B') {
     return [
-      action({ type: 'pushView', value: 'bisect' }),
+      action({ type: 'replaceView', value: 'bisect' }),
       action({ type: 'setStatus', value: 'jumped to bisect' }),
     ]
   }
@@ -2122,7 +2122,7 @@ export function getLogInkInputEvents(
   // empty-state copy can tell the user how to add one.
   if (state.pendingKey === 'g' && inputValue === 'M') {
     return [
-      action({ type: 'pushView', value: 'submodules' }),
+      action({ type: 'replaceView', value: 'submodules' }),
       action({ type: 'setStatus', value: 'jumped to submodules' }),
     ]
   }
@@ -2133,7 +2133,7 @@ export function getLogInkInputEvents(
   // the user at `a add`.
   if (state.pendingKey === 'g' && inputValue === 'n') {
     return [
-      action({ type: 'pushView', value: 'remotes' }),
+      action({ type: 'replaceView', value: 'remotes' }),
       action({ type: 'setStatus', value: 'jumped to remotes' }),
     ]
   }


### PR DESCRIPTION
Resolves #1450.

## What

Lateral navigation (g-chords and palette "jump to" commands) now uses `replaceView` instead of `pushView`, so the view stack stays flat.

## Before

`gs` → `gb` → `gz` → `gd` produced stack `['history', 'status', 'branches', 'stash', 'diff']` — 4 Esc presses to get home, retracing a wander path nobody remembers.

## After

Each chord replaces the top of the stack. The stack is at most `[peer]` or `[peer, drill-in]`. Esc always returns one level — matching Enter (hierarchical drill-in) semantics.

## Changes

- `inkInput.ts`: all 15 g-chord handlers + the 15 palette-execute navigate cases switched from `pushView` to `replaceView`
- `inkInput.test.ts`: 12 assertions updated to expect the flat stack shape

## What stays as pushView

- Enter → diff/blame/file-history (hierarchical drill-ins)
- Compose from commit flow (`c` on status/diff)
- Conflicts from choice prompt
- Bisect-start pushing history for sha selection

## Validation

- `npx tsc --noEmit` clean
- `npm run lint` 0 errors
- 1370 runtime tests pass, 643 input/keymap tests pass
