### PR TITLE
fix(workstation): two-stage Esc for prompts + rebase plan discard guard

### DIFF
--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -1,9 +1,9 @@
 import { GitLogRow } from '../../commands/log/data'
 import {
-  getLogInkInputEvents,
-  getLogInkPaletteExecuteEvents,
-  isCreatePrView,
-  isCreateStashView,
+    getLogInkInputEvents,
+    getLogInkPaletteExecuteEvents,
+    isCreatePrView,
+    isCreateStashView,
 } from './inkInput'
 import { getLogInkPaletteCommands } from './inkKeymap'
 import { LogInkState, LogInkView, applyLogInkAction, createLogInkState } from './inkViewModel'
@@ -3938,12 +3938,20 @@ describe('log Ink input interactions', () => {
       ])
     })
 
-    it('Esc on a multi-line prompt cancels the same way as single-line', () => {
+    it('Esc on a multi-line prompt with text clears first, then closes (two-stage #1446)', () => {
       let state = openMultilinePrompt()
       'wip'.split('').forEach((c) => { state = applyInput(state, c) })
-      const events = getLogInkInputEvents(state, '', { escape: true })
-      expect(events).toContainEqual({ type: 'action', action: { type: 'closeInputPrompt' } })
-      expect(events).toContainEqual({
+
+      // First Esc: clears the text but keeps the prompt open.
+      const firstEsc = getLogInkInputEvents(state, '', { escape: true })
+      expect(firstEsc).toContainEqual({ type: 'action', action: { type: 'clearInputPromptText' } })
+
+      // Apply the clear and press Esc again: now the prompt is empty,
+      // so the second Esc closes it.
+      state = applyLogInkAction(state, { type: 'clearInputPromptText' })
+      const secondEsc = getLogInkInputEvents(state, '', { escape: true })
+      expect(secondEsc).toContainEqual({ type: 'action', action: { type: 'closeInputPrompt' } })
+      expect(secondEsc).toContainEqual({
         type: 'action',
         action: { type: 'setStatus', value: 'cancelled' },
       })

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -1162,6 +1162,15 @@ export function getLogInkInputEvents(
     const isMultiline = Boolean(state.inputPrompt.multiline)
 
     if (key.escape) {
+      // #1446 — two-stage Esc for input prompts. First Esc clears
+      // non-empty text (the user can keep typing or press Esc again);
+      // second Esc on empty text closes the prompt. Matches the filter,
+      // palette, and theme-picker contracts so the most expensive text
+      // (multiline review bodies, PR descriptions) gets the same
+      // protection as the cheapest (a single-word filter).
+      if (state.inputPrompt.value.length > 0) {
+        return [action({ type: 'clearInputPromptText' })]
+      }
       return [
         action({ type: 'closeInputPrompt' }),
         action({ type: 'setStatus', value: 'cancelled' }),
@@ -1515,6 +1524,13 @@ export function getLogInkInputEvents(
           { type: 'exit' },
         ]
       }
+      if (state.pendingMutationConfirmation === 'discard-rebase-plan') {
+        return [
+          action({ type: 'setPendingMutationConfirmation', value: undefined }),
+          action({ type: 'clearRebasePlan' }),
+          action({ type: 'popView' }),
+        ]
+      }
       return [
         state.pendingMutationConfirmation === 'revert-hunk'
           ? { type: 'revertSelectedHunk' }
@@ -1528,6 +1544,8 @@ export function getLogInkInputEvents(
     if (inputValue === 'n' || key.escape) {
       const cancelMessage = state.pendingMutationConfirmation === 'discard-draft'
         ? 'kept draft — press q again to quit without saving'
+        : state.pendingMutationConfirmation === 'discard-rebase-plan'
+        ? 'kept rebase plan'
         : 'revert cancelled'
       return [
         action({ type: 'setPendingMutationConfirmation', value: undefined }),
@@ -1945,6 +1963,16 @@ export function getLogInkInputEvents(
       action({ type: 'clearCompareBase' }),
       action({ type: 'setStatus', value: `Cleared compare base ${state.compareBase.label}` }),
     ]
+  }
+
+  // #1446 — rebase-plan discard guard. A fully retagged/reordered
+  // rebase plan is expensive to recreate; Esc-ing away should confirm
+  // before silently dropping it, matching the compose-draft pattern.
+  // The confirm is only raised when Esc WOULD pop away from the rebase
+  // view (viewStack > 1) — otherwise there's nowhere to go and Esc
+  // is a no-op anyway.
+  if (key.escape && state.activeView === 'rebase' && state.rebasePlan && state.viewStack.length > 1) {
+    return [action({ type: 'setPendingMutationConfirmation', value: 'discard-rebase-plan' })]
   }
 
   if (key.escape && state.viewStack.length > 1) {

--- a/src/workstation/runtime/inkViewModel.ts
+++ b/src/workstation/runtime/inkViewModel.ts
@@ -11,10 +11,10 @@ import {
 } from '../../commands/log/commitCompose'
 import type { CommitSplitPlan, CommitSplitPlanContext } from '../../commands/commit/split'
 import {
-  cycleIssueFilterPreset,
-  cyclePullRequestFilterPreset,
-  type IssueFilterPreset,
-  type PullRequestFilterPreset,
+    cycleIssueFilterPreset,
+    cyclePullRequestFilterPreset,
+    type IssueFilterPreset,
+    type PullRequestFilterPreset,
 } from '../../git/triageFilterPresets'
 import { PromotedSelectionsSnapshot } from '../chrome/selectionRectify'
 import {
@@ -30,7 +30,7 @@ export type LogInkFocus = 'sidebar' | 'commits' | 'detail'
 
 export type LogInkSidebarTab = 'status' | 'branches' | 'tags' | 'stashes' | 'worktrees'
 export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash' | 'worktrees' | 'pull-request' | 'pull-request-triage' | 'issues' | 'conflicts' | 'reflog' | 'bisect' | 'changelog' | 'submodules' | 'remotes' | 'blame' | 'file-history' | 'rebase'
-export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk' | 'discard-lines' | 'discard-draft'
+export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk' | 'discard-lines' | 'discard-draft' | 'discard-rebase-plan'
 
 /**
  * Kinds of list item that can carry an inline pending-spinner while an


### PR DESCRIPTION
Resolves #1446 (problems 1 and 2 from the issue).

## Problem 1: Two-stage Esc for input prompts

Input prompts now get the same two-stage Esc contract as filter, palette, and theme picker:

- **First Esc** with non-empty text: clears the typed content (user can keep typing or bail)
- **Second Esc** on empty text: closes the prompt with "cancelled" status

Previously, a single Esc destroyed paragraphs of typed text (multiline PR review bodies, PR descriptions) with zero protection — the most expensive text to lose had the least protection.

## Problem 2: Rebase plan discard guard

Esc on the rebase view with an active (potentially edited) plan now routes through a y/n `pendingMutationConfirmation` instead of silently dropping the plan. Matches the compose-draft discard pattern.

- `y` → clears the plan + pops the view
- `n` / Esc → keeps the plan, status shows "kept rebase plan"

## Changes

- `inkInput.ts`: two-stage Esc logic in the input-prompt handler; rebase-plan discard guard before generic popView
- `inkViewModel.ts`: added `'discard-rebase-plan'` to `LogInkMutationConfirmation`
- `inkInput.test.ts`: updated the multiline prompt Esc test for two-stage behavior

## Validation

- `npx tsc --noEmit` clean
- `npm run lint` 0 errors
- 1370 runtime tests pass
