### PR TITLE
feat(workstation): status message TTL classes (echo/result/advisory)

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -530,6 +530,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   const idleTip = useIdleTip(React, {
     idleTipsEnabled,
     statusMessage: state.statusMessage,
+    statusTtl: state.statusTtl,
     provider: context.provider?.repository.provider,
   })
 

--- a/src/workstation/runtime/hooks/useIdleTip.ts
+++ b/src/workstation/runtime/hooks/useIdleTip.ts
@@ -24,9 +24,9 @@
 import type * as ReactTypes from 'react'
 import type { GitProviderType } from '../../../git/providerData'
 import {
-  IDLE_TIPS_GRACE_MS,
-  IDLE_TIPS_INTERVAL_MS,
-  pickIdleTip,
+    IDLE_TIPS_GRACE_MS,
+    IDLE_TIPS_INTERVAL_MS,
+    pickIdleTip,
 } from '../../chrome/idleTips'
 import { isSnapshotMode } from '../../chrome/snapshotMode'
 
@@ -35,9 +35,15 @@ export type UseIdleTipDeps = {
   idleTipsEnabled: boolean | undefined
   /**
    * The live `state.statusMessage`. Any explicit message gates the tip off
-   * and resets the rotation cycle.
+   * and resets the rotation cycle — UNLESS `statusTtl` is 'echo' (#1449),
+   * in which case the message is transient and doesn't block tips.
    */
   statusMessage: string | undefined
+  /**
+   * The lifetime class of the current status message (#1449). When 'echo',
+   * the status doesn't suppress the idle-tip channel.
+   */
+  statusTtl: 'echo' | 'result' | 'advisory' | undefined
   /** The active forge provider, for forge-aware tip wording (PR vs MR). */
   provider: GitProviderType | undefined
 }
@@ -54,11 +60,16 @@ export function resolveIdleTip(
   idleTipsEnabled: boolean | undefined,
   statusMessage: string | undefined,
   provider: GitProviderType | undefined,
+  statusTtl?: 'echo' | 'result' | 'advisory',
 ): string | undefined {
   // Suppress tip rotation in snapshot mode to keep VHS captures
   // and screenshot stills deterministic (snapshotMode.ts invariant).
   if (isSnapshotMode()) return undefined
-  return idleTipsEnabled && !statusMessage
+  // #1449 — echo messages don't block tips. They're transient nav
+  // confirmations that expire on the next keystroke anyway; letting
+  // them starve the teaching channel was a design incoherence.
+  const blocking = statusMessage && statusTtl !== 'echo'
+  return idleTipsEnabled && !blocking
     ? pickIdleTip(tickIndex, provider)
     : undefined
 }
@@ -74,11 +85,13 @@ export function useIdleTip(
   React: typeof ReactTypes,
   deps: UseIdleTipDeps,
 ): string | undefined {
-  const { idleTipsEnabled, statusMessage, provider } = deps
+  const { idleTipsEnabled, statusMessage, statusTtl, provider } = deps
   const [idleTipIndex, setIdleTipIndex] = React.useState(0)
   React.useEffect(() => {
     if (!idleTipsEnabled) return
-    if (statusMessage) {
+    // #1449 — echo messages don't reset the cycle; they're transient
+    // and won't block the tip anyway (resolveIdleTip bypasses them).
+    if (statusMessage && statusTtl !== 'echo') {
       // Any explicit message resets the cycle; next idle stretch starts
       // from the grace window again.
       setIdleTipIndex(0)
@@ -99,6 +112,6 @@ export function useIdleTip(
       clearTimeout(grace)
       if (interval) clearInterval(interval)
     }
-  }, [idleTipsEnabled, statusMessage])
-  return resolveIdleTip(idleTipIndex, idleTipsEnabled, statusMessage, provider)
+  }, [idleTipsEnabled, statusMessage, statusTtl])
+  return resolveIdleTip(idleTipIndex, idleTipsEnabled, statusMessage, provider, statusTtl)
 }

--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -3700,7 +3700,7 @@ describe('log Ink input interactions', () => {
         { type: 'action', action: { type: 'toggleDiffViewMode' } },
         {
           type: 'action',
-          action: { type: 'setStatus', value: 'Switched to side-by-side diff', kind: 'success' },
+          action: { type: 'setStatus', value: 'Switched to side-by-side diff', ttl: 'echo' },
         },
       ])
     })
@@ -3716,7 +3716,7 @@ describe('log Ink input interactions', () => {
 
       expect(events).toContainEqual({
         type: 'action',
-        action: { type: 'setStatus', value: 'Switched to unified diff', kind: 'success' },
+        action: { type: 'setStatus', value: 'Switched to unified diff', ttl: 'echo' },
       })
     })
 

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -668,12 +668,12 @@ export function getLogInkPaletteExecuteEvents(
     case 'moveToTop':
       return [
         action({ type: 'moveToTop' }),
-        action({ type: 'setStatus', value: 'jumped to first commit' }),
+        action({ type: 'setStatus', value: 'jumped to first commit', ttl: 'echo' }),
       ]
     case 'moveToBottom':
       return [
         action({ type: 'moveToBottom' }),
-        action({ type: 'setStatus', value: 'jumped to last commit' }),
+        action({ type: 'setStatus', value: 'jumped to last commit', ttl: 'echo' }),
       ]
     case 'nextMatch':
       return [action({ type: 'move', delta: 1 })]
@@ -2019,49 +2019,49 @@ export function getLogInkInputEvents(
   if (state.pendingKey === 'g' && inputValue === 'h') {
     return [
       action({ type: 'navigateHome' }),
-      action({ type: 'setStatus', value: 'jumped to history' }),
+      action({ type: 'setStatus', value: 'jumped to history', ttl: 'echo' }),
     ]
   }
 
   if (state.pendingKey === 'g' && inputValue === 's') {
     return [
       action({ type: 'replaceView', value: 'status' }),
-      action({ type: 'setStatus', value: 'jumped to status' }),
+      action({ type: 'setStatus', value: 'jumped to status', ttl: 'echo' }),
     ]
   }
 
   if (state.pendingKey === 'g' && inputValue === 'd') {
     return [
       action({ type: 'replaceView', value: 'diff' }),
-      action({ type: 'setStatus', value: 'jumped to diff' }),
+      action({ type: 'setStatus', value: 'jumped to diff', ttl: 'echo' }),
     ]
   }
 
   if (state.pendingKey === 'g' && inputValue === 'c') {
     return [
       action({ type: 'replaceView', value: 'compose' }),
-      action({ type: 'setStatus', value: 'jumped to compose' }),
+      action({ type: 'setStatus', value: 'jumped to compose', ttl: 'echo' }),
     ]
   }
 
   if (state.pendingKey === 'g' && inputValue === 'b') {
     return [
       action({ type: 'replaceView', value: 'branches' }),
-      action({ type: 'setStatus', value: 'jumped to branches' }),
+      action({ type: 'setStatus', value: 'jumped to branches', ttl: 'echo' }),
     ]
   }
 
   if (state.pendingKey === 'g' && inputValue === 't') {
     return [
       action({ type: 'replaceView', value: 'tags' }),
-      action({ type: 'setStatus', value: 'jumped to tags' }),
+      action({ type: 'setStatus', value: 'jumped to tags', ttl: 'echo' }),
     ]
   }
 
   if (state.pendingKey === 'g' && inputValue === 'z') {
     return [
       action({ type: 'replaceView', value: 'stash' }),
-      action({ type: 'setStatus', value: 'jumped to stash' }),
+      action({ type: 'setStatus', value: 'jumped to stash', ttl: 'echo' }),
     ]
   }
 
@@ -2080,7 +2080,7 @@ export function getLogInkInputEvents(
   if (state.pendingKey === 'g' && inputValue === 'w') {
     return [
       action({ type: 'replaceView', value: 'worktrees' }),
-      action({ type: 'setStatus', value: 'jumped to worktrees' }),
+      action({ type: 'setStatus', value: 'jumped to worktrees', ttl: 'echo' }),
     ]
   }
 
@@ -2092,7 +2092,7 @@ export function getLogInkInputEvents(
   if (state.pendingKey === 'g' && inputValue === 'p') {
     return [
       action({ type: 'replaceView', value: 'pull-request' }),
-      action({ type: 'setStatus', value: 'jumped to pull request' }),
+      action({ type: 'setStatus', value: 'jumped to pull request', ttl: 'echo' }),
     ]
   }
 
@@ -2103,7 +2103,7 @@ export function getLogInkInputEvents(
   if (state.pendingKey === 'g' && inputValue === 'P') {
     return [
       action({ type: 'replaceView', value: 'pull-request-triage' }),
-      action({ type: 'setStatus', value: 'jumped to PR triage' }),
+      action({ type: 'setStatus', value: 'jumped to PR triage', ttl: 'echo' }),
     ]
   }
 
@@ -2111,14 +2111,14 @@ export function getLogInkInputEvents(
   if (state.pendingKey === 'g' && inputValue === 'i') {
     return [
       action({ type: 'replaceView', value: 'issues' }),
-      action({ type: 'setStatus', value: 'jumped to issues' }),
+      action({ type: 'setStatus', value: 'jumped to issues', ttl: 'echo' }),
     ]
   }
 
   if (state.pendingKey === 'g' && inputValue === 'x') {
     return [
       action({ type: 'replaceView', value: 'conflicts' }),
-      action({ type: 'setStatus', value: 'jumped to conflicts' }),
+      action({ type: 'setStatus', value: 'jumped to conflicts', ttl: 'echo' }),
     ]
   }
 
@@ -2128,7 +2128,7 @@ export function getLogInkInputEvents(
   if (state.pendingKey === 'g' && inputValue === 'r') {
     return [
       action({ type: 'replaceView', value: 'reflog' }),
-      action({ type: 'setStatus', value: 'jumped to reflog' }),
+      action({ type: 'setStatus', value: 'jumped to reflog', ttl: 'echo' }),
     ]
   }
 
@@ -2139,7 +2139,7 @@ export function getLogInkInputEvents(
   if (state.pendingKey === 'g' && inputValue === 'B') {
     return [
       action({ type: 'replaceView', value: 'bisect' }),
-      action({ type: 'setStatus', value: 'jumped to bisect' }),
+      action({ type: 'setStatus', value: 'jumped to bisect', ttl: 'echo' }),
     ]
   }
 
@@ -2151,7 +2151,7 @@ export function getLogInkInputEvents(
   if (state.pendingKey === 'g' && inputValue === 'M') {
     return [
       action({ type: 'replaceView', value: 'submodules' }),
-      action({ type: 'setStatus', value: 'jumped to submodules' }),
+      action({ type: 'setStatus', value: 'jumped to submodules', ttl: 'echo' }),
     ]
   }
 
@@ -2162,7 +2162,7 @@ export function getLogInkInputEvents(
   if (state.pendingKey === 'g' && inputValue === 'n') {
     return [
       action({ type: 'replaceView', value: 'remotes' }),
-      action({ type: 'setStatus', value: 'jumped to remotes' }),
+      action({ type: 'setStatus', value: 'jumped to remotes', ttl: 'echo' }),
     ]
   }
 
@@ -2368,7 +2368,7 @@ export function getLogInkInputEvents(
         return context.blameLineCount
           ? [
             action({ type: 'moveBlame', delta: -context.blameLineCount, count: context.blameLineCount }),
-            action({ type: 'setStatus', value: 'jumped to first line' }),
+            action({ type: 'setStatus', value: 'jumped to first line', ttl: 'echo' }),
           ]
           : []
       }
@@ -2380,7 +2380,7 @@ export function getLogInkInputEvents(
               delta: -context.fileHistoryCommitCount,
               count: context.fileHistoryCommitCount,
             }),
-            action({ type: 'setStatus', value: 'jumped to first commit' }),
+            action({ type: 'setStatus', value: 'jumped to first commit', ttl: 'echo' }),
           ]
           : []
       }
@@ -2395,7 +2395,7 @@ export function getLogInkInputEvents(
       }
       return [
         action({ type: 'moveToTop' }),
-        action({ type: 'setStatus', value: 'jumped to first commit' }),
+        action({ type: 'setStatus', value: 'jumped to first commit', ttl: 'echo' }),
       ]
     }
 
@@ -2464,7 +2464,7 @@ export function getLogInkInputEvents(
         value: next === 'split'
           ? 'Switched to side-by-side diff'
           : 'Switched to unified diff',
-        kind: 'success',
+        ttl: 'echo',
       }),
     ]
   }
@@ -2494,7 +2494,7 @@ export function getLogInkInputEvents(
       return context.blameLineCount
         ? [
           action({ type: 'moveBlame', delta: context.blameLineCount, count: context.blameLineCount }),
-          action({ type: 'setStatus', value: 'jumped to last line' }),
+          action({ type: 'setStatus', value: 'jumped to last line', ttl: 'echo' }),
         ]
         : []
     }
@@ -2506,7 +2506,7 @@ export function getLogInkInputEvents(
             delta: context.fileHistoryCommitCount,
             count: context.fileHistoryCommitCount,
           }),
-          action({ type: 'setStatus', value: 'jumped to last commit' }),
+          action({ type: 'setStatus', value: 'jumped to last commit', ttl: 'echo' }),
         ]
         : []
     }
@@ -2521,7 +2521,7 @@ export function getLogInkInputEvents(
     }
     return [
       action({ type: 'moveToBottom' }),
-      action({ type: 'setStatus', value: 'jumped to last commit' }),
+      action({ type: 'setStatus', value: 'jumped to last commit', ttl: 'echo' }),
     ]
   }
 

--- a/src/workstation/runtime/inkViewModel.ts
+++ b/src/workstation/runtime/inkViewModel.ts
@@ -655,6 +655,19 @@ export type LogInkState = {
    */
   statusKind?: 'info' | 'error' | 'success' | 'warning'
   /**
+   * Lifetime class for the current status message (#1449).
+   *   - 'echo'     : navigation confirmations / mode toggles. Cleared
+   *                   automatically on the next dispatched action.
+   *   - 'result'   : workflow success/error. Persists until the next
+   *                   action on that surface replaces it.
+   *   - 'advisory' : warnings. Sticky until the condition clears.
+   *
+   * When undefined, the message behaves like 'result' (legacy default).
+   * The idle-tip gate treats 'echo' as non-blocking: a stale "jumped to
+   * status" doesn't suppress the teaching channel.
+   */
+  statusTtl?: 'echo' | 'result' | 'advisory'
+  /**
    * Transient loading flag for the status line. When true, the footer
    * prefixes the message with the shared spinner frame so users see
    * motion during sub-second LLM calls (create-PR body generation,
@@ -1124,7 +1137,7 @@ export type LogInkAction =
   | { type: 'setPendingKey'; value?: string }
   | { type: 'setSidebarTab'; value: LogInkSidebarTab }
   | { type: 'restoreSidebarTab'; value: LogInkSidebarTab }
-  | { type: 'setStatus'; value?: string; kind?: 'info' | 'error' | 'success' | 'warning'; loading?: boolean }
+  | { type: 'setStatus'; value?: string; kind?: 'info' | 'error' | 'success' | 'warning'; loading?: boolean; ttl?: 'echo' | 'result' | 'advisory' }
   | { type: 'setPendingPullRequestBodyDraft'; value: boolean }
   | { type: 'setWorkflowAction'; value?: string }
   | { type: 'setPendingConfirmation'; value?: string; payload?: string }
@@ -1998,6 +2011,16 @@ export function getLogInkRepoStackLabels(state: LogInkState): string[] {
 }
 
 export function applyLogInkAction(state: LogInkState, action: LogInkAction): LogInkState {
+  // #1449 — echo messages expire on the next keystroke. If the current
+  // status has ttl:'echo' and the incoming action is NOT itself a
+  // setStatus (which would just replace it anyway), clear it so the
+  // footer returns to idle and tips can render. This keeps the reducer
+  // pure — no timers, no side effects — while giving navigation echoes
+  // the "next-keystroke" lifetime the issue prescribes.
+  if (state.statusTtl === 'echo' && action.type !== 'setStatus') {
+    state = { ...state, statusMessage: undefined, statusKind: undefined, statusTtl: undefined, statusLoading: undefined }
+  }
+
   switch (action.type) {
     case 'appendRows':
       return appendRows(state, action.rows, action.mainOrderingCount)
@@ -2738,6 +2761,8 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         // 'error' doesn't bleed into the next info update. Explicit
         // 'info' also clears kind for the same reason.
         statusKind: !action.value || action.kind === 'info' ? undefined : action.kind,
+        // #1449 — lifetime class. Defaults to 'result' when omitted.
+        statusTtl: !action.value ? undefined : (action.ttl || 'result'),
         // Same clearing semantics for loading — every setStatus that
         // doesn't explicitly opt in (loading: true) clears the flag so
         // a stale spinner doesn't linger after the LLM call finishes.


### PR DESCRIPTION
Resolves #1449.

## What

Adds a lifetime contract (`ttl`) to `setStatus` so navigation echoes don't immortally occupy the status row and starve idle tips.

## TTL classes

| Class | Lifetime | Use case |
|-------|----------|----------|
| `echo` | Expires on next dispatched action | Nav confirmations ("jumped to status"), mode toggles ("Switched to side-by-side") |
| `result` | Persists until replaced (default) | Workflow success/error ("Deleted branch feature"), warnings |
| `advisory` | Sticky until condition clears | Reserved for condition-based warnings |

## How it works

- The reducer stores `statusTtl` alongside `statusMessage`/`statusKind`
- At the TOP of `applyLogInkAction`, if the current status is `echo` and the incoming action isn't itself a `setStatus`, the echo is cleared — **pure reducer, no timers**
- Idle tips treat `echo` as non-blocking: a stale "jumped to status" no longer suppresses the teaching channel for the rest of the session

## Changes

- `inkViewModel.ts`: `statusTtl` state field, `ttl` on `setStatus` action, echo-expiry in `applyLogInkAction`
- `inkInput.ts`: 24 nav-echo calls tagged `ttl: 'echo'`; diff-toggle changed from `kind: 'success'` to `ttl: 'echo'`
- `useIdleTip.ts`: `statusTtl` passed through deps; `resolveIdleTip` bypasses echo messages
- `app.ts`: passes `statusTtl` to the idle-tip hook

## Validation

- `npx tsc --noEmit` clean
- `npm run lint` 0 errors
- 1370 runtime tests pass
