### PR TITLE
refactor(workstation): reserve y for danger, add warning to registry

### DIFF
--- a/src/workstation/runtime/hooks/useWorkflowAction.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.ts
@@ -44,61 +44,61 @@
 import type * as ReactTypes from 'react'
 import { SimpleGit } from 'simple-git'
 import {
-  LogInkContextStatus,
-  updateLogInkContextStatus,
+    LogInkContextStatus,
+    updateLogInkContextStatus,
 } from '../../chrome/context'
 import { forgeNouns } from '../../chrome/forgeNouns'
 import { sortBranches, sortTags } from '../../chrome/sorting'
 import { openProviderUrl } from '../../../git/providerActions'
 import type { GitProviderType } from '../../../git/providerData'
 import {
-  LogInkPendingItemAction,
-  LogInkAction,
-  LogInkState,
-  RemoteOpState,
-  getSelectedInkCommit,
+    LogInkPendingItemAction,
+    LogInkAction,
+    LogInkState,
+    RemoteOpState,
+    getSelectedInkCommit,
 } from '../inkViewModel'
 import {
-  checkoutBranch,
-  checkoutBranchByName,
-  createBranch,
-  deleteBranch,
-  isBranchCheckedOutElsewhereError,
-  isBranchNotFullyMergedError,
-  isDirtyWorktreeCheckoutError,
-  parseCheckedOutWorktreePath,
-  fetchBranch,
-  fetchRemotes,
-  pullBranch,
-  pullCurrentBranch,
-  pushBranch,
-  pushCurrentBranch,
-  renameBranch,
-  setUpstream,
-  forcePushBranch,
-  forcePushCurrentBranch,
-  isDivergedPullError,
-  isNonFastForwardPushError,
-  pullCurrentBranchMerge,
-  pullCurrentBranchRebase,
+    checkoutBranch,
+    checkoutBranchByName,
+    createBranch,
+    deleteBranch,
+    isBranchCheckedOutElsewhereError,
+    isBranchNotFullyMergedError,
+    isDirtyWorktreeCheckoutError,
+    parseCheckedOutWorktreePath,
+    fetchBranch,
+    fetchRemotes,
+    pullBranch,
+    pullCurrentBranch,
+    pushBranch,
+    pushCurrentBranch,
+    renameBranch,
+    setUpstream,
+    forcePushBranch,
+    forcePushCurrentBranch,
+    isDivergedPullError,
+    isNonFastForwardPushError,
+    pullCurrentBranchMerge,
+    pullCurrentBranchRebase,
 } from '../../../git/branchActions'
 import { addToGitignore } from '../../../git/gitignore'
 import { createLightweightTag, deleteLocalTag, deleteRemoteTag, pushTag } from '../../../git/tagActions'
 import {
-  ResetMode,
-  checkoutFileFromCommit,
-  cherryPickCommit,
-  createBranchFromCommit,
-  createTagAtCommit,
-  defaultOpenUrlRunner,
-  isResetMode,
-  resetToCommit,
-  revertCommit,
-  startInteractiveRebase,
-  createFixupCommit,
-  autosquashRebase,
-  amendHeadCommit,
-  rewordHeadCommit,
+    ResetMode,
+    checkoutFileFromCommit,
+    cherryPickCommit,
+    createBranchFromCommit,
+    createTagAtCommit,
+    defaultOpenUrlRunner,
+    isResetMode,
+    resetToCommit,
+    revertCommit,
+    startInteractiveRebase,
+    createFixupCommit,
+    autosquashRebase,
+    amendHeadCommit,
+    rewordHeadCommit,
 } from '../../../git/historyActions'
 import { applyStash, applyStashKeepIndex, checkoutFileFromStash, createStash, dropStash, popStash, renameStash, restoreStash, stashBranch } from '../../../git/stashActions'
 import { ApplyHunkTarget, applyHunkPatch } from '../../../git/hunkActions'
@@ -109,10 +109,10 @@ import { getForgeActions } from '../../../git/forgeActions'
 import { clearGitHubListCache } from '../../../git/githubListCache'
 import { isPullRequestMergeStrategy } from '../../../git/pullRequestActions'
 import {
-  stageAll,
-  stageAllFiles,
-  stagePathspec,
-  unstageAllFiles,
+    stageAll,
+    stageAllFiles,
+    stagePathspec,
+    unstageAllFiles,
 } from '../../../git/statusActions'
 import { applyStatusFilterMask } from '../../../git/statusData'
 import { bisectBad, bisectGood, bisectReset, bisectRun, bisectSkip, bisectStart, extractBisectRemainingHint } from '../../../git/bisectActions'
@@ -1808,7 +1808,7 @@ export function useWorkflowAction(
             title: `'${branchName}' is checked out in another worktree`,
             warning: `Checked out at ${worktreePath}.${dirty ? ' That worktree has uncommitted changes — removal will be refused until it is clean or stashed.' : ''}`,
             options: [
-              { key: 'y', label: 'Switch to that worktree', intent: 'switch-worktree' },
+              { key: 's', label: 'Switch to that worktree', intent: 'switch-worktree' },
               { key: 'r', label: 'Remove worktree & check out here', workflowId: 'conflict-remove-worktree-checkout', destructive: true },
               { key: 'x', label: 'Remove worktree & delete branch', workflowId: 'conflict-remove-worktree-branch', destructive: true },
             ],

--- a/src/workstation/runtime/inkWorkflows.ts
+++ b/src/workstation/runtime/inkWorkflows.ts
@@ -36,6 +36,14 @@ export type LogInkWorkflowAction = {
   kind: LogInkWorkflowActionKind
   requiresConfirmation: boolean
   estimatedTokens?: number
+  /**
+   * Warning copy shown in the confirmation panel when `requiresConfirmation`
+   * is true (#1451). When set, the renderer uses this instead of the generic
+   * "Destructive Git action requires confirmation" fallback or the per-id
+   * if-chain in overlays.ts. Supports a payload interpolation function for
+   * context-dependent copy (e.g. naming the branch being deleted).
+   */
+  warning?: string
 }
 
 function countLabel(count: number, singular: string, plural = `${singular}s`): string {
@@ -160,6 +168,7 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       description: 'git push --force-with-lease — overwrite the remote branch after a history rewrite.',
       kind: 'destructive',
       requiresConfirmation: true,
+      warning: 'Push was rejected (remote moved). --force-with-lease overwrites the remote branch, but still refuses if it moved since your last fetch.',
     },
     {
       id: 'force-push-selected-branch',
@@ -168,6 +177,7 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       description: 'git push --force-with-lease for the cursored branch after a history rewrite.',
       kind: 'destructive',
       requiresConfirmation: true,
+      warning: 'Push was rejected (remote moved). --force-with-lease overwrites the remote branch, but still refuses if it moved since your last fetch.',
     },
     {
       // Divergence recovery pair — offered via choice prompt when
@@ -398,6 +408,7 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       description: 'Force-delete the selected branch even if it is not fully merged (git branch -D).',
       kind: 'destructive',
       requiresConfirmation: true,
+      warning: 'Not fully merged. Force-delete (git branch -D) is irreversible.',
     },
     {
       // #0.71 — rebase the current branch onto the cursored branch/ref

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -155,17 +155,15 @@ export function renderConfirmationPanel(
   const label = action?.label || mutationLabel || 'Workflow action'
   const warning = state.pendingMutationConfirmation === 'discard-draft'
     ? 'You have an unsaved commit draft. Press y to discard it and quit.'
+    : state.pendingMutationConfirmation === 'discard-rebase-plan'
+    ? 'You have an edited rebase plan. Press y to discard it and leave.'
     : state.pendingMutationConfirmation
     ? 'This discards local changes and cannot be undone by Coco.'
-    // Second-stage confirm raised when a safe delete hit an unmerged
-    // branch — name the reason so the force isn't a blind "y again".
-    : state.pendingConfirmationId === 'force-delete-branch'
-    ? 'Not fully merged. Force-delete (git branch -D) is irreversible.'
-    // Push was rejected non-fast-forward — name what the force actually
-    // does and its remaining safety net so the y isn't blind.
-    : state.pendingConfirmationId === 'force-push-current-branch' ||
-      state.pendingConfirmationId === 'force-push-selected-branch'
-    ? 'Push was rejected (remote moved). --force-with-lease overwrites the remote branch, but still refuses if it moved since your last fetch.'
+    // #1451 — prefer the registry's warning field over the per-id
+    // if-chain. This is the migration path: as warnings move onto the
+    // registry entries, the if-chain shrinks until it's gone.
+    : action?.warning
+    ? action.warning
     // Rebase-onto carries a per-invocation warning naming both branches
     // (built in inkInput from the cursored + current branch). Fall back
     // to a static line if the payload is somehow absent.


### PR DESCRIPTION
Partial fix for #1451.

## What

Begins the confirmation system unification with the two highest-impact changes:

### 1. Reserve `y` for danger confirmations only

The worktree-conflict choice prompt previously bound `y` to "Switch to that worktree" (a non-destructive navigation action). This broke muscle memory: `y` should always mean "execute the dangerous thing." Rebound to `s` (switch).

### 2. Move warning copy onto registry entries

Added an optional `warning` field to `LogInkWorkflowAction`. The confirmation panel renderer now prefers `action.warning` over the growing per-id if-chain in `overlays.ts`. As more entries get their `warning` populated, the if-chain shrinks toward elimination.

Populated for: `force-push-current-branch`, `force-push-selected-branch`, `force-delete-branch`.

### 3. Rebase plan discard copy

Added the `discard-rebase-plan` mutation confirmation copy (from #1446) to the renderer.

## What remains (follow-up)

- Fold `pendingMutationConfirmation` variants (revert-file, revert-hunk, discard-lines, discard-draft, discard-rebase-plan) into the workflow registry as proper entries
- Move `rebase-onto-branch` and `checkout-created-branch` payload-dependent warnings onto the registry (needs a function-typed `warning` field)
- Unified precedence for both systems

## Validation

- `npx tsc --noEmit` clean
- `npm run lint` 0 errors
- 1370 runtime tests pass
