### PR TITLE
refactor(workstation): unify confirmation systems

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -414,7 +414,6 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     inputPrompt: state.inputPrompt,
     pendingConfirmationId: state.pendingConfirmationId,
     pendingChoice: state.pendingChoice,
-    pendingMutationConfirmation: state.pendingMutationConfirmation,
     showCommandPalette: state.showCommandPalette,
     dispatch,
     mountedRef,
@@ -1168,7 +1167,6 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
         state.inputPrompt ||
         state.pendingConfirmationId ||
         state.pendingChoice ||
-        state.pendingMutationConfirmation ||
         state.pendingKey
       ? 'inspector'
       : undefined

--- a/src/workstation/runtime/detailPanel.ts
+++ b/src/workstation/runtime/detailPanel.ts
@@ -192,7 +192,7 @@ export function renderDetailPanel(
     return renderChoicePanel(h, components, state.pendingChoice, width, theme, focused)
   }
 
-  if (state.pendingConfirmationId || state.pendingMutationConfirmation) {
+  if (state.pendingConfirmationId) {
     return renderConfirmationPanel(h, components, state, surface.context, width, theme, focused)
   }
 

--- a/src/workstation/runtime/footer.ts
+++ b/src/workstation/runtime/footer.ts
@@ -106,7 +106,6 @@ export function renderFooter(
       state.inputPrompt ||
       state.pendingConfirmationId ||
       state.pendingChoice ||
-      state.pendingMutationConfirmation ||
       state.pendingKey ||
       state.filterMode
   )

--- a/src/workstation/runtime/hooks/useStatusAutoDismiss.test.ts
+++ b/src/workstation/runtime/hooks/useStatusAutoDismiss.test.ts
@@ -17,7 +17,6 @@ const noModals = {
   inputPrompt: undefined as unknown,
   pendingConfirmationId: undefined as unknown,
   pendingChoice: undefined as unknown,
-  pendingMutationConfirmation: undefined as unknown,
   showCommandPalette: undefined as unknown,
 }
 
@@ -50,7 +49,7 @@ describe('shouldAutoDismissStatus', () => {
 
   it('does not dismiss while a mutation confirmation is open', () => {
     expect(
-      shouldAutoDismissStatus({ ...noModals, pendingMutationConfirmation: 'revert-file' }),
+      shouldAutoDismissStatus({ ...noModals, pendingConfirmationId: 'revert-file' }),
     ).toBe(false)
   })
 

--- a/src/workstation/runtime/hooks/useStatusAutoDismiss.ts
+++ b/src/workstation/runtime/hooks/useStatusAutoDismiss.ts
@@ -44,8 +44,6 @@ export type UseStatusAutoDismissDeps = {
   pendingConfirmationId: unknown
   /** `state.pendingChoice` — a multi-choice prompt is open. */
   pendingChoice: unknown
-  /** `state.pendingMutationConfirmation` — a revert/discard confirm is open. */
-  pendingMutationConfirmation: unknown
   /** `state.showCommandPalette` — the command palette is open. */
   showCommandPalette: unknown
   /** Reducer dispatch, used to clear the message via `setStatus(undefined)`. */
@@ -70,7 +68,6 @@ export function shouldAutoDismissStatus(deps: {
   inputPrompt: unknown
   pendingConfirmationId: unknown
   pendingChoice: unknown
-  pendingMutationConfirmation: unknown
   showCommandPalette: unknown
 }): boolean {
   if (!deps.statusMessage) return false
@@ -84,7 +81,6 @@ export function shouldAutoDismissStatus(deps: {
     deps.inputPrompt ||
     deps.pendingConfirmationId ||
     deps.pendingChoice ||
-    deps.pendingMutationConfirmation ||
     deps.showCommandPalette
   ) {
     return false
@@ -95,7 +91,6 @@ export function shouldAutoDismissStatus(deps: {
 /**
  * Status-message auto-dismiss hook. Issues the single timer `useEffect`,
  * preserving the exact dependency array (`[dispatch, inputPrompt,
- * pendingConfirmationId, pendingChoice, pendingMutationConfirmation,
  * showCommandPalette, statusMessage]`) of the original `app.ts` cluster,
  * so React's hook ordering and the timer's reset/cancel semantics are
  * unchanged.
@@ -111,7 +106,6 @@ export function useStatusAutoDismiss(
     inputPrompt,
     pendingConfirmationId,
     pendingChoice,
-    pendingMutationConfirmation,
     showCommandPalette,
     dispatch,
     mountedRef,
@@ -119,7 +113,7 @@ export function useStatusAutoDismiss(
   React.useEffect(() => {
     if (!statusMessage) return
     if (statusKind === 'error' || statusLoading) return
-    if (inputPrompt || pendingConfirmationId || pendingChoice || pendingMutationConfirmation || showCommandPalette) {
+    if (inputPrompt || pendingConfirmationId || pendingChoice || showCommandPalette) {
       return
     }
     // The `setTimeout` callback is a literal arrow function (not a
@@ -137,7 +131,6 @@ export function useStatusAutoDismiss(
     inputPrompt,
     pendingConfirmationId,
     pendingChoice,
-    pendingMutationConfirmation,
     showCommandPalette,
     statusMessage,
     statusKind,

--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -108,11 +108,11 @@ describe('log Ink input interactions', () => {
     })
 
     const events = applyInput(state, 'q')
-    expect(events.pendingMutationConfirmation).toBe('discard-draft')
+    expect(events.pendingConfirmationId).toBe('discard-draft')
 
     // n cancels and keeps the draft
     state = applyInput(events, 'n')
-    expect(state.pendingMutationConfirmation).toBeUndefined()
+    expect(state.pendingConfirmationId).toBeUndefined()
     expect(state.commitCompose.summary).toBe('feat: in-flight summary')
   })
 
@@ -128,7 +128,7 @@ describe('log Ink input interactions', () => {
       action: { type: 'append', value: 'feat: ready to ship' },
     })
     state = applyInput(state, 'q')
-    expect(state.pendingMutationConfirmation).toBe('discard-draft')
+    expect(state.pendingConfirmationId).toBe('discard-draft')
 
     const events = getLogInkInputEvents(state, 'y')
     expect(events.find((event) => event.type === 'exit')).toBeDefined()
@@ -527,7 +527,7 @@ describe('log Ink input interactions', () => {
     )).toEqual([
       {
         type: 'action',
-        action: { type: 'setPendingMutationConfirmation', value: 'revert-file' },
+        action: { type: 'setPendingConfirmation', value: 'revert-file' },
       },
     ])
 
@@ -539,18 +539,18 @@ describe('log Ink input interactions', () => {
     )).toEqual([
       {
         type: 'action',
-        action: { type: 'setPendingMutationConfirmation', value: 'revert-hunk' },
+        action: { type: 'setPendingConfirmation', value: 'revert-hunk' },
       },
     ])
   })
 
   it('confirms or cancels worktree revert actions explicitly', () => {
     const filePending = applyLogInkAction(createLogInkState(rows), {
-      type: 'setPendingMutationConfirmation',
+      type: 'setPendingConfirmation',
       value: 'revert-file',
     })
     const hunkPending = applyLogInkAction(createLogInkState(rows), {
-      type: 'setPendingMutationConfirmation',
+      type: 'setPendingConfirmation',
       value: 'revert-hunk',
     })
 
@@ -558,20 +558,20 @@ describe('log Ink input interactions', () => {
       { type: 'revertSelectedFile' },
       {
         type: 'action',
-        action: { type: 'setPendingMutationConfirmation', value: undefined },
+        action: { type: 'setPendingConfirmation', value: undefined },
       },
     ])
     expect(getLogInkInputEvents(hunkPending, 'y')).toEqual([
       { type: 'revertSelectedHunk' },
       {
         type: 'action',
-        action: { type: 'setPendingMutationConfirmation', value: undefined },
+        action: { type: 'setPendingConfirmation', value: undefined },
       },
     ])
     expect(getLogInkInputEvents(filePending, 'n')).toEqual([
       {
         type: 'action',
-        action: { type: 'setPendingMutationConfirmation', value: undefined },
+        action: { type: 'setPendingConfirmation', value: undefined },
       },
       { type: 'action', action: { type: 'setStatus', value: 'revert cancelled' } },
     ])
@@ -2230,10 +2230,10 @@ describe('log Ink input interactions', () => {
 
     it('z opens the revert-hunk confirmation only on the staging diff', () => {
       const staging = applyInput(diffState('worktree'), 'z', {}, dirtyWorktreeContext)
-      expect(staging.pendingMutationConfirmation).toBe('revert-hunk')
+      expect(staging.pendingConfirmationId).toBe('revert-hunk')
 
       const commit = applyInput(diffState('commit'), 'z', {}, dirtyWorktreeContext)
-      expect(commit.pendingMutationConfirmation).toBeUndefined()
+      expect(commit.pendingConfirmationId).toBeUndefined()
     })
 
     it('j/k on a commit diff scroll the visible preview, not the hidden worktree diff', () => {
@@ -2284,7 +2284,7 @@ describe('log Ink input interactions', () => {
     it('z with a selection asks to discard the selected lines', () => {
       let state = worktreeDiffState({ diffLineSelectAnchor: 5 })
       state = applyInput(state, 'z', {}, dirtyDiffContext)
-      expect(state.pendingMutationConfirmation).toBe('discard-lines')
+      expect(state.pendingConfirmationId).toBe('discard-lines')
 
       const events = getLogInkInputEvents(state, 'y', {}, dirtyDiffContext)
       expect(events).toContainEqual({ type: 'revertSelectedLines' })
@@ -2294,7 +2294,7 @@ describe('log Ink input interactions', () => {
       expect(getLogInkInputEvents(worktreeDiffState(), ' ', {}, dirtyDiffContext))
         .toEqual([{ type: 'toggleSelectedHunkStage' }])
       const state = applyInput(worktreeDiffState(), 'z', {}, dirtyDiffContext)
-      expect(state.pendingMutationConfirmation).toBe('revert-hunk')
+      expect(state.pendingConfirmationId).toBe('revert-hunk')
     })
   })
 
@@ -4450,7 +4450,7 @@ describe('log Ink input interactions', () => {
         const actionTypes = events
           .filter((event): event is Extract<typeof event, { type: 'action' }> => event.type === 'action')
           .map((event) => event.action.type)
-        expect(actionTypes).not.toContain('setPendingMutationConfirmation')
+        expect(actionTypes).not.toContain('setPendingConfirmation')
         expect(actionTypes).not.toContain('navigateOpenBlameForPath')
         expect(actionTypes).not.toContain('navigateOpenFileHistoryForPath')
       }

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -784,7 +784,7 @@ export function getLogInkPaletteExecuteEvents(
     case 'refresh':
       return [{ type: 'refreshContext' }]
     case 'revertSelection':
-      return [action({ type: 'setPendingMutationConfirmation', value: 'revert-file' })]
+      return [action({ type: 'setPendingConfirmation', value: 'revert-file' })]
     case 'editCommit':
       return [
         ...(state.activeView !== 'compose'
@@ -872,7 +872,7 @@ export function getLogInkPaletteExecuteEvents(
       return []
     case 'quit':
       if (hasUnsavedComposeDraft(state)) {
-        return [action({ type: 'setPendingMutationConfirmation', value: 'discard-draft' })]
+        return [action({ type: 'setPendingConfirmation', value: 'discard-draft' })]
       }
       return [{ type: 'exit' }]
     case 'clearSearch':
@@ -1148,8 +1148,8 @@ export function getLogInkInputEvents(
   context: LogInkInputContext = {}
 ): LogInkInputEvent[] {
   if (key.ctrl && inputValue === 'c') {
-    if (hasUnsavedComposeDraft(state) && !state.pendingMutationConfirmation) {
-      return [action({ type: 'setPendingMutationConfirmation', value: 'discard-draft' })]
+    if (hasUnsavedComposeDraft(state) && !state.pendingConfirmationId) {
+      return [action({ type: 'setPendingConfirmation', value: 'discard-draft' })]
     }
     return [{ type: 'exit' }]
   }
@@ -1290,6 +1290,41 @@ export function getLogInkInputEvents(
         ]
       }
 
+      // #1451 — mutation confirmations (formerly `pendingMutationConfirmation`).
+      // These resolve via direct dispatch rather than `runWorkflowAction`
+      // because they call synchronous runtime hooks, not async git ops.
+      if (workflowAction?.id === 'revert-file') {
+        return [
+          { type: 'revertSelectedFile' },
+          action({ type: 'setPendingConfirmation', value: undefined }),
+        ]
+      }
+      if (workflowAction?.id === 'revert-hunk') {
+        return [
+          { type: 'revertSelectedHunk' },
+          action({ type: 'setPendingConfirmation', value: undefined }),
+        ]
+      }
+      if (workflowAction?.id === 'discard-lines') {
+        return [
+          { type: 'revertSelectedLines' },
+          action({ type: 'setPendingConfirmation', value: undefined }),
+        ]
+      }
+      if (workflowAction?.id === 'discard-draft') {
+        return [
+          action({ type: 'setPendingConfirmation', value: undefined }),
+          { type: 'exit' },
+        ]
+      }
+      if (workflowAction?.id === 'discard-rebase-plan') {
+        return [
+          action({ type: 'setPendingConfirmation', value: undefined }),
+          action({ type: 'clearRebasePlan' }),
+          action({ type: 'popView' }),
+        ]
+      }
+
       // Destructive + provider workflow actions (delete-branch, delete-tag,
       // drop-stash, remove-worktree, abort-operation, create-pr, …) defer
       // to the runtime — it has the live context needed to identify the
@@ -1308,9 +1343,20 @@ export function getLogInkInputEvents(
     }
 
     if (inputValue === 'n' || key.escape) {
+      // #1451 — per-id cancel messages for the unified confirmation system.
+      const cancelMessage =
+        state.pendingConfirmationId === 'discard-draft'
+          ? 'kept draft — press q again to quit without saving'
+          : state.pendingConfirmationId === 'discard-rebase-plan'
+          ? 'kept rebase plan'
+          : state.pendingConfirmationId === 'revert-file' ||
+            state.pendingConfirmationId === 'revert-hunk' ||
+            state.pendingConfirmationId === 'discard-lines'
+          ? 'revert cancelled'
+          : 'workflow action cancelled'
       return [
         action({ type: 'setPendingConfirmation', value: undefined }),
-        action({ type: 'setStatus', value: 'workflow action cancelled' }),
+        action({ type: 'setStatus', value: cancelMessage }),
       ]
     }
 
@@ -1511,46 +1557,6 @@ export function getLogInkInputEvents(
 
     if (inputValue && !key.ctrl && !key.meta) {
       return [action({ type: 'appendFilter', value: inputValue })]
-    }
-
-    return []
-  }
-
-  if (state.pendingMutationConfirmation) {
-    if (inputValue === 'y') {
-      if (state.pendingMutationConfirmation === 'discard-draft') {
-        return [
-          action({ type: 'setPendingMutationConfirmation', value: undefined }),
-          { type: 'exit' },
-        ]
-      }
-      if (state.pendingMutationConfirmation === 'discard-rebase-plan') {
-        return [
-          action({ type: 'setPendingMutationConfirmation', value: undefined }),
-          action({ type: 'clearRebasePlan' }),
-          action({ type: 'popView' }),
-        ]
-      }
-      return [
-        state.pendingMutationConfirmation === 'revert-hunk'
-          ? { type: 'revertSelectedHunk' }
-          : state.pendingMutationConfirmation === 'discard-lines'
-          ? { type: 'revertSelectedLines' }
-          : { type: 'revertSelectedFile' },
-        action({ type: 'setPendingMutationConfirmation', value: undefined }),
-      ]
-    }
-
-    if (inputValue === 'n' || key.escape) {
-      const cancelMessage = state.pendingMutationConfirmation === 'discard-draft'
-        ? 'kept draft — press q again to quit without saving'
-        : state.pendingMutationConfirmation === 'discard-rebase-plan'
-        ? 'kept rebase plan'
-        : 'revert cancelled'
-      return [
-        action({ type: 'setPendingMutationConfirmation', value: undefined }),
-        action({ type: 'setStatus', value: cancelMessage }),
-      ]
     }
 
     return []
@@ -1972,7 +1978,7 @@ export function getLogInkInputEvents(
   // view (viewStack > 1) — otherwise there's nowhere to go and Esc
   // is a no-op anyway.
   if (key.escape && state.activeView === 'rebase' && state.rebasePlan && state.viewStack.length > 1) {
-    return [action({ type: 'setPendingMutationConfirmation', value: 'discard-rebase-plan' })]
+    return [action({ type: 'setPendingConfirmation', value: 'discard-rebase-plan' })]
   }
 
   if (key.escape && state.viewStack.length > 1) {
@@ -1991,7 +1997,7 @@ export function getLogInkInputEvents(
 
   if (inputValue === 'q') {
     if (hasUnsavedComposeDraft(state)) {
-      return [action({ type: 'setPendingMutationConfirmation', value: 'discard-draft' })]
+      return [action({ type: 'setPendingConfirmation', value: 'discard-draft' })]
     }
     return [{ type: 'exit' }]
   }
@@ -4258,7 +4264,7 @@ export function getLogInkInputEvents(
     isWorktreeDiffTarget(state) &&
     state.diffLineSelectAnchor !== undefined
   ) {
-    return [action({ type: 'setPendingMutationConfirmation', value: 'discard-lines' })]
+    return [action({ type: 'setPendingConfirmation', value: 'discard-lines' })]
   }
 
   if (inputValue === ' ' && isWorktreeDiffTarget(state) && context.worktreeHunkOffsets?.length) {
@@ -4287,11 +4293,11 @@ export function getLogInkInputEvents(
     context.worktreeFileCount &&
     !state.statusGroupHeaderFocused
   ) {
-    return [action({ type: 'setPendingMutationConfirmation', value: 'revert-file' })]
+    return [action({ type: 'setPendingConfirmation', value: 'revert-file' })]
   }
 
   if (inputValue === 'z' && isWorktreeDiffTarget(state) && context.worktreeHunkOffsets?.length) {
-    return [action({ type: 'setPendingMutationConfirmation', value: 'revert-hunk' })]
+    return [action({ type: 'setPendingConfirmation', value: 'revert-hunk' })]
   }
 
   if (

--- a/src/workstation/runtime/inkViewModel.test.ts
+++ b/src/workstation/runtime/inkViewModel.test.ts
@@ -71,7 +71,7 @@ describe('log Ink view model', () => {
     expect(state.sidebarTab).toBe('branches')
     expect(state.showHelp).toBe(false)
     expect(state.showCommandPalette).toBe(false)
-    expect(state.pendingMutationConfirmation).toBeUndefined()
+    expect(state.pendingConfirmationId).toBeUndefined()
   })
 
   it('opens, moves, and closes the gitignore picker', () => {
@@ -656,14 +656,13 @@ describe('log Ink view model', () => {
     expect(state.pendingConfirmationId).toBeUndefined()
 
     state = applyLogInkAction(state, {
-      type: 'setPendingMutationConfirmation',
+      type: 'setPendingConfirmation',
       value: 'revert-file',
     })
-    expect(state.pendingMutationConfirmation).toBe('revert-file')
-    expect(state.pendingConfirmationId).toBeUndefined()
+    expect(state.pendingConfirmationId).toBe('revert-file')
 
-    state = applyLogInkAction(state, { type: 'setPendingMutationConfirmation', value: undefined })
-    expect(state.pendingMutationConfirmation).toBeUndefined()
+    state = applyLogInkAction(state, { type: 'setPendingConfirmation', value: undefined })
+    expect(state.pendingConfirmationId).toBeUndefined()
   })
 
   describe('AI conflict-resolution session (#1369)', () => {

--- a/src/workstation/runtime/inkViewModel.ts
+++ b/src/workstation/runtime/inkViewModel.ts
@@ -30,7 +30,6 @@ export type LogInkFocus = 'sidebar' | 'commits' | 'detail'
 
 export type LogInkSidebarTab = 'status' | 'branches' | 'tags' | 'stashes' | 'worktrees'
 export type LogInkView = 'history' | 'status' | 'diff' | 'compose' | 'branches' | 'tags' | 'stash' | 'worktrees' | 'pull-request' | 'pull-request-triage' | 'issues' | 'conflicts' | 'reflog' | 'bisect' | 'changelog' | 'submodules' | 'remotes' | 'blame' | 'file-history' | 'rebase'
-export type LogInkMutationConfirmation = 'revert-file' | 'revert-hunk' | 'discard-lines' | 'discard-draft' | 'discard-rebase-plan'
 
 /**
  * Kinds of list item that can carry an inline pending-spinner while an
@@ -542,7 +541,6 @@ export type LogInkState = {
    * walking state.
    */
   pendingConfirmationPayload?: string
-  pendingMutationConfirmation?: LogInkMutationConfirmation
   /**
    * Set when a `checkout-branch` was rejected because the branch is
    * already checked out in another worktree (#1175). Carries the branch
@@ -1143,7 +1141,6 @@ export type LogInkAction =
   | { type: 'setPendingConfirmation'; value?: string; payload?: string }
   | { type: 'setWorktreeCheckoutConflict'; value?: { branch: string; worktreePath: string; dirty: boolean } }
   | { type: 'setPendingChoice'; value?: LogInkChoicePrompt }
-  | { type: 'setPendingMutationConfirmation'; value?: LogInkMutationConfirmation }
   | { type: 'setPendingItemAction'; value?: LogInkPendingItemAction }
   | { type: 'appendPaletteFilter'; value: string }
   | { type: 'backspacePaletteFilter' }
@@ -1498,7 +1495,6 @@ function withPushedRepoFrame(
     pendingKey: undefined,
     pendingConfirmationId: undefined,
     pendingConfirmationPayload: undefined,
-    pendingMutationConfirmation: undefined,
     // #1429 — a choice prompt raised in the parent (or its worktree-
     // checkout-conflict sibling) references the PARENT repo's git call;
     // it can't be answered meaningfully after drilling into a submodule.
@@ -1600,7 +1596,6 @@ function withPoppedRepoFrame(state: LogInkState): LogInkState {
     pendingKey: undefined,
     pendingConfirmationId: undefined,
     pendingConfirmationPayload: undefined,
-    pendingMutationConfirmation: undefined,
     // #1429 — mirror of the push-time clear above; a choice prompt from
     // the popped (child) frame is equally meaningless once back in the
     // parent's context.
@@ -1948,7 +1943,6 @@ export function createLogInkState(
     workflowActionId: undefined,
     pendingConfirmationId: undefined,
     pendingConfirmationPayload: undefined,
-    pendingMutationConfirmation: undefined,
     pendingKey: undefined,
     focus: 'commits',
     // Default first-time tab is 'branches' — it's the most useful
@@ -2786,7 +2780,6 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         workflowActionId: action.value,
         pendingConfirmationId: undefined,
         pendingConfirmationPayload: undefined,
-        pendingMutationConfirmation: undefined,
         pendingKey: undefined,
       }
     case 'setPendingConfirmation':
@@ -2795,7 +2788,6 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         pendingConfirmationId: action.value,
         pendingConfirmationPayload: action.value ? action.payload : undefined,
         workflowActionId: action.value ? undefined : state.workflowActionId,
-        pendingMutationConfirmation: action.value ? undefined : state.pendingMutationConfirmation,
         // Only one modal prompt may own the keyboard (#1342): raising a
         // confirmation dismisses any open choice prompt so a `y` meant
         // for the confirm can't be matched against choice option keys.
@@ -2830,15 +2822,6 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         helpScrollOffset: action.value ? 0 : state.helpScrollOffset,
         helpFilter: action.value ? '' : state.helpFilter,
         helpFilterMode: action.value ? false : state.helpFilterMode,
-        pendingKey: undefined,
-      }
-    case 'setPendingMutationConfirmation':
-      return {
-        ...state,
-        pendingMutationConfirmation: action.value,
-        pendingConfirmationId: action.value ? undefined : state.pendingConfirmationId,
-        pendingConfirmationPayload: action.value ? undefined : state.pendingConfirmationPayload,
-        workflowActionId: action.value ? undefined : state.workflowActionId,
         pendingKey: undefined,
       }
     case 'setPendingItemAction':

--- a/src/workstation/runtime/inkWorkflows.ts
+++ b/src/workstation/runtime/inkWorkflows.ts
@@ -1174,6 +1174,56 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       kind: 'normal',
       requiresConfirmation: false,
     },
+    // #1451 — mutation confirmations unified into the registry. These
+    // were previously a separate `pendingMutationConfirmation` system;
+    // they now flow through the same `pendingConfirmationId` state and
+    // renderer. The input handler resolves them via direct dispatch
+    // (not `runWorkflowAction`) since they call sync runtime hooks.
+    {
+      id: 'revert-file',
+      key: '',
+      label: 'Revert selected file',
+      description: 'Discard all unstaged changes in the selected file.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+      warning: 'This discards local changes and cannot be undone by Coco.',
+    },
+    {
+      id: 'revert-hunk',
+      key: '',
+      label: 'Revert selected hunk',
+      description: 'Discard the selected hunk from the working tree.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+      warning: 'This discards local changes and cannot be undone by Coco.',
+    },
+    {
+      id: 'discard-lines',
+      key: '',
+      label: 'Discard the selected lines',
+      description: 'Discard the visually-selected lines from the working tree.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+      warning: 'This discards local changes and cannot be undone by Coco.',
+    },
+    {
+      id: 'discard-draft',
+      key: '',
+      label: 'Quit and discard the in-progress commit draft',
+      description: 'Exit the workstation, discarding unsaved compose content.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+      warning: 'You have an unsaved commit draft. Press y to discard it and quit.',
+    },
+    {
+      id: 'discard-rebase-plan',
+      key: '',
+      label: 'Discard rebase plan',
+      description: 'Leave the rebase view, discarding the edited rebase todo.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+      warning: 'You have an edited rebase plan. Press y to discard it and leave.',
+    },
   ]
 }
 

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -143,26 +143,12 @@ export function renderConfirmationPanel(
 ): ReactTypes.ReactElement {
   const { Box, Text } = components
   const action = getLogInkWorkflowActionById(state.pendingConfirmationId)
-  const mutationLabel = state.pendingMutationConfirmation === 'revert-hunk'
-    ? 'Revert selected hunk'
-    : state.pendingMutationConfirmation === 'discard-lines'
-      ? 'Discard the selected lines'
-    : state.pendingMutationConfirmation === 'revert-file'
-      ? 'Revert selected file'
-      : state.pendingMutationConfirmation === 'discard-draft'
-        ? 'Quit and discard the in-progress commit draft'
-        : undefined
-  const label = action?.label || mutationLabel || 'Workflow action'
-  const warning = state.pendingMutationConfirmation === 'discard-draft'
-    ? 'You have an unsaved commit draft. Press y to discard it and quit.'
-    : state.pendingMutationConfirmation === 'discard-rebase-plan'
-    ? 'You have an edited rebase plan. Press y to discard it and leave.'
-    : state.pendingMutationConfirmation
-    ? 'This discards local changes and cannot be undone by Coco.'
-    // #1451 — prefer the registry's warning field over the per-id
-    // if-chain. This is the migration path: as warnings move onto the
-    // registry entries, the if-chain shrinks until it's gone.
-    : action?.warning
+  const label = action?.label || 'Workflow action'
+  const warning =
+    // #1451 — prefer the registry's warning field over any fallback.
+    // The mutation confirmations (revert-file, revert-hunk, discard-lines,
+    // discard-draft, discard-rebase-plan) all carry their own warning.
+    action?.warning
     ? action.warning
     // Rebase-onto carries a per-invocation warning naming both branches
     // (built in inkInput from the cursored + current branch). Fall back


### PR DESCRIPTION
Folds the five pendingMutationConfirmation variants into the workflow registry so there's ONE confirmation state, ONE renderer, ONE keyboard contract (y/n/Esc). Follow-up to #1543.

Closes #1451