### PR TITLE
feat(workstation): pickaxe and grep-diff search (S:/G: prefixes)

### DIFF
--- a/src/commands/log/config.ts
+++ b/src/commands/log/config.ts
@@ -11,10 +11,12 @@ export interface LogOptions extends BaseCommandOptions {
   branch?: string
   commit?: string
   format?: LogFormat
+  grep?: string
   limit?: number
   merges?: boolean
   noMerges?: boolean
   path?: string | string[]
+  pickaxe?: string
   since?: string
   until?: string
   view?: LogView

--- a/src/commands/log/data.test.ts
+++ b/src/commands/log/data.test.ts
@@ -4,19 +4,19 @@ import { join } from 'path'
 import { simpleGit } from 'simple-git'
 import { Arguments } from 'yargs'
 import {
-  COMMIT_CONTEXT_DEFAULT_LIMIT,
-  FIELD_SEPARATOR,
-  LOG_DEFAULT_LIMIT,
-  LOG_INTERACTIVE_DEFAULT_LIMIT,
-  buildLogArgs,
-  buildToggleGraphArgs,
-  getCommitFilePreview,
-  getCommitRows,
-  getLogRows,
-  getLogRowsAnchoredOn,
-  getLogView,
-  parseCommitDetail,
-  parseLogOutput,
+    COMMIT_CONTEXT_DEFAULT_LIMIT,
+    FIELD_SEPARATOR,
+    LOG_DEFAULT_LIMIT,
+    LOG_INTERACTIVE_DEFAULT_LIMIT,
+    buildLogArgs,
+    buildToggleGraphArgs,
+    getCommitFilePreview,
+    getCommitRows,
+    getLogRows,
+    getLogRowsAnchoredOn,
+    getLogView,
+    parseCommitDetail,
+    parseLogOutput,
 } from './data'
 import { LogOptions } from './config'
 
@@ -232,6 +232,16 @@ describe('log data layer', () => {
     expect(buildLogArgs(argv())).toEqual(
       expect.arrayContaining([expect.stringContaining('%P')])
     )
+  })
+
+  it('passes -S<token> for pickaxe search', () => {
+    const args = buildLogArgs(argv({ pickaxe: 'useState' }))
+    expect(args).toContain('-SuseState')
+  })
+
+  it('passes -G<regex> for grep-diff search', () => {
+    const args = buildLogArgs(argv({ grep: 'TODO|FIXME' }))
+    expect(args).toContain('-GTODO|FIXME')
   })
 
   it('parses commit detail metadata and changed files', () => {

--- a/src/commands/log/data.ts
+++ b/src/commands/log/data.ts
@@ -316,6 +316,14 @@ export function buildLogArgs(argv: LogArgv, options: LogRowLoadOptions = {}): st
     args.push(`--author=${argv.author}`)
   }
 
+  if (argv.pickaxe) {
+    args.push(`-S${argv.pickaxe}`)
+  }
+
+  if (argv.grep) {
+    args.push(`-G${argv.grep}`)
+  }
+
   if (argv.since) {
     args.push(`--since=${argv.since}`)
   }

--- a/src/workstation/runtime/historyRefetchResolver.ts
+++ b/src/workstation/runtime/historyRefetchResolver.ts
@@ -76,6 +76,8 @@ export function buildHistoryRefetchArgv(
     ...buildToggleGraphArgs(logArgv, fullGraph),
     ...(fetchArgs?.author ? { author: fetchArgs.author } : {}),
     ...(fetchArgs?.path ? { path: fetchArgs.path } : {}),
+    ...(fetchArgs?.pickaxe ? { pickaxe: fetchArgs.pickaxe } : {}),
+    ...(fetchArgs?.grep ? { grep: fetchArgs.grep } : {}),
   }
 }
 
@@ -87,6 +89,8 @@ export function buildHistoryRefetchArgv(
 function describeFetchArgs(fetchArgs: LogInkHistoryFetchArgs | undefined): string | undefined {
   if (fetchArgs?.author) return `author:${fetchArgs.author}`
   if (fetchArgs?.path) return `path:${fetchArgs.path}`
+  if (fetchArgs?.pickaxe) return `S:${fetchArgs.pickaxe}`
+  if (fetchArgs?.grep) return `G:${fetchArgs.grep}`
   return undefined
 }
 

--- a/src/workstation/runtime/hooks/useHistoryRefresh.ts
+++ b/src/workstation/runtime/hooks/useHistoryRefresh.ts
@@ -68,6 +68,8 @@ export function useHistoryRefresh(
         : ({
             ...(fetchArgs?.author ? { author: fetchArgs.author } : {}),
             ...(fetchArgs?.path ? { path: fetchArgs.path } : {}),
+            ...(fetchArgs?.pickaxe ? { pickaxe: fetchArgs.pickaxe } : {}),
+            ...(fetchArgs?.grep ? { grep: fetchArgs.grep } : {}),
           } as LogArgv)
       // Stash commits as graph roots so post-operation refreshes keep the
       // same rich graph the boot loader assembled.

--- a/src/workstation/runtime/inkViewModel.test.ts
+++ b/src/workstation/runtime/inkViewModel.test.ts
@@ -1409,6 +1409,21 @@ describe('log Ink view model', () => {
         expect(parseLogInkHistoryFetchPrefix('feat')).toBeUndefined()
         expect(parseLogInkHistoryFetchPrefix('fixpathfoo')).toBeUndefined()
       })
+
+      it('parses S:<token> into a pickaxe fetch arg', () => {
+        expect(parseLogInkHistoryFetchPrefix('S:useState')).toEqual({ pickaxe: 'useState' })
+        expect(parseLogInkHistoryFetchPrefix('S:my function name')).toEqual({ pickaxe: 'my function name' })
+      })
+
+      it('parses G:<regex> into a grep fetch arg', () => {
+        expect(parseLogInkHistoryFetchPrefix('G:TODO|FIXME')).toEqual({ grep: 'TODO|FIXME' })
+        expect(parseLogInkHistoryFetchPrefix('G:\\bclass\\b')).toEqual({ grep: '\\bclass\\b' })
+      })
+
+      it('returns undefined for S: and G: with no value', () => {
+        expect(parseLogInkHistoryFetchPrefix('S:')).toBeUndefined()
+        expect(parseLogInkHistoryFetchPrefix('G:   ')).toBeUndefined()
+      })
     })
 
     it('setHistoryFetchArgs / replaceRows / clear flow keeps state internally consistent', () => {

--- a/src/workstation/runtime/inkViewModel.ts
+++ b/src/workstation/runtime/inkViewModel.ts
@@ -963,6 +963,10 @@ export type LogInkStatusFilterMask = {
 export type LogInkHistoryFetchArgs = {
   author?: string
   path?: string
+  /** `git log -S <token>` — find commits that add/remove the token. */
+  pickaxe?: string
+  /** `git log -G <regex>` — find commits whose patch matches the regex. */
+  grep?: string
 }
 
 export const DEFAULT_LOG_INK_STATUS_FILTER_MASK: LogInkStatusFilterMask = {
@@ -972,12 +976,12 @@ export const DEFAULT_LOG_INK_STATUS_FILTER_MASK: LogInkStatusFilterMask = {
 }
 
 /**
- * Detect a history server-side filter prefix (#776). Returns the parsed
- * `LogInkHistoryFetchArgs` for `path:<value>` and `author:<value>`
- * prefixes, or `undefined` for a plain (client-side) filter. The whole
- * remainder of the string (post-prefix) becomes the value — paths and
- * author names commonly contain spaces, and we don't try to parse
- * shell-like syntax.
+ * Detect a history server-side filter prefix (#776, #1361). Returns the
+ * parsed `LogInkHistoryFetchArgs` for `path:<value>`, `author:<value>`,
+ * `S:<token>` (pickaxe), and `G:<regex>` (grep-diff) prefixes, or
+ * `undefined` for a plain (client-side) filter. The whole remainder of
+ * the string (post-prefix) becomes the value — paths, author names,
+ * and search tokens commonly contain spaces.
  */
 export function parseLogInkHistoryFetchPrefix(filter: string): LogInkHistoryFetchArgs | undefined {
   const trimmed = filter.trim()
@@ -988,6 +992,14 @@ export function parseLogInkHistoryFetchPrefix(filter: string): LogInkHistoryFetc
   if (trimmed.startsWith('author:')) {
     const value = trimmed.slice('author:'.length).trim()
     return value ? { author: value } : undefined
+  }
+  if (trimmed.startsWith('S:')) {
+    const value = trimmed.slice('S:'.length).trim()
+    return value ? { pickaxe: value } : undefined
+  }
+  if (trimmed.startsWith('G:')) {
+    const value = trimmed.slice('G:'.length).trim()
+    return value ? { grep: value } : undefined
   }
   return undefined
 }


### PR DESCRIPTION
Adds commit-content search to the history filter. Type `/S:useState` + Enter to find commits that add/remove 'useState', or `/G:TODO|FIXME` for regex matching. Same UX as path:/author: prefixes.

Partial fix for #1361