### PR TITLE
refactor(workstation): id-based selection model foundation

### DIFF
--- a/src/workstation/runtime/selection.test.ts
+++ b/src/workstation/runtime/selection.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for the id-based selection selectors (#1452).
+ *
+ * These verify that the selectors produce the correct id from the
+ * legacy index-based state — proving the bridge is correct before
+ * consumers start migrating to read through it.
+ */
+import { createLogInkState } from './inkViewModel'
+import type { LogInkContext } from './types'
+import { getSelectedBranchId, getSelectedTagId, getSelectedStashId } from './selection'
+
+function makeBranch(shortName: string, date = '2026-01-01') {
+  return {
+    shortName,
+    name: `refs/heads/${shortName}`,
+    hash: `abc${shortName}`,
+    date,
+    subject: `commit on ${shortName}`,
+    upstream: undefined,
+    gone: false,
+    ahead: 0,
+    behind: 0,
+  }
+}
+
+function makeTag(name: string) {
+  return { name, hash: `tag${name}`, subject: `tag ${name}`, date: '2026-01-01', tagger: '' }
+}
+
+function makeStash(index: number) {
+  return { ref: `stash@{${index}}`, message: `stash ${index}`, hash: `s${index}`, date: '2026-01-01' }
+}
+
+describe('selection selectors (#1452)', () => {
+  const context = {
+    branches: {
+      localBranches: [makeBranch('main'), makeBranch('feature'), makeBranch('hotfix')],
+      remoteBranches: [],
+      currentBranch: 'main',
+      dirty: false,
+    },
+    tags: { tags: [makeTag('v1.0'), makeTag('v2.0'), makeTag('v3.0')] },
+    stashes: { stashes: [makeStash(0), makeStash(1), makeStash(2)] },
+  } as unknown as LogInkContext
+
+  describe('getSelectedBranchId', () => {
+    it('returns the branch shortName at the selected index', () => {
+      // Default sort is 'name' (alphabetical): feature, hotfix, main
+      const state = { ...createLogInkState([]), selectedBranchIndex: 1 }
+      expect(getSelectedBranchId(state, context)).toBe('hotfix')
+    })
+
+    it('clamps out-of-range index to last item', () => {
+      const state = { ...createLogInkState([]), selectedBranchIndex: 99 }
+      // Sorted: feature, hotfix, main — last is 'main'
+      expect(getSelectedBranchId(state, context)).toBe('main')
+    })
+
+    it('returns undefined for empty branch list', () => {
+      const state = { ...createLogInkState([]), selectedBranchIndex: 0 }
+      const emptyCtx = { branches: { localBranches: [], remoteBranches: [], currentBranch: undefined, dirty: false } } as unknown as LogInkContext
+      expect(getSelectedBranchId(state, emptyCtx)).toBeUndefined()
+    })
+
+    it('respects the active filter', () => {
+      const state = { ...createLogInkState([]), selectedBranchIndex: 0, filter: 'hot' }
+      // Only 'hotfix' matches 'hot'
+      expect(getSelectedBranchId(state, context)).toBe('hotfix')
+    })
+  })
+
+  describe('getSelectedTagId', () => {
+    it('returns the tag name at the selected index', () => {
+      const state = { ...createLogInkState([]), selectedTagIndex: 2 }
+      expect(getSelectedTagId(state, context)).toBe('v3.0')
+    })
+
+    it('returns undefined for empty tags', () => {
+      const state = { ...createLogInkState([]), selectedTagIndex: 0 }
+      expect(getSelectedTagId(state, { tags: { tags: [] } })).toBeUndefined()
+    })
+  })
+
+  describe('getSelectedStashId', () => {
+    it('returns the stash ref at the selected index', () => {
+      const state = { ...createLogInkState([]), selectedStashIndex: 1 }
+      expect(getSelectedStashId(state, context)).toBe('stash@{1}')
+    })
+  })
+})

--- a/src/workstation/runtime/selection.ts
+++ b/src/workstation/runtime/selection.ts
@@ -1,0 +1,122 @@
+/**
+ * Id-based selection model (#1452).
+ *
+ * This module introduces the target selection architecture that will replace
+ * the 16 scalar `selected*Index` fields in `LogInkState`. The migration is
+ * incremental: each view converts one at a time, and during the transition
+ * the legacy index fields remain the source of truth while these selectors
+ * provide an id-based read interface over them.
+ *
+ * Design:
+ *   - A selection is a set of ids (not indexes) scoped to a view
+ *   - A cursor is a selection of size 1 (the current state for all views)
+ *   - Multi-select (#1361) extends to size N without changing the model
+ *   - Ids are stable across filter/sort/refresh changes (branch shortName,
+ *     tag name, stash ref, commit hash, etc.)
+ *   - The `anchorId` supports range-select (shift+j/k)
+ *
+ * Migration path (per view):
+ *   1. Use `getSelectedItemId()` to read the selection by id
+ *   2. Convert the move action to write through the new model
+ *   3. Remove the legacy `selected*Index` field once all consumers migrated
+ */
+
+import type { LogInkState } from './inkViewModel'
+import type { LogInkContext } from './types'
+import { sortBranches, sortTags } from '../chrome/sorting'
+import { matchesPromotedFilter } from './promotedFilter'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/**
+ * The target id-based selection model. Not yet stored in state — during
+ * the transition, these types define the interface selectors return and
+ * future state will carry.
+ */
+export type LogInkSelection = {
+  /** Which view this selection belongs to. */
+  view: string
+  /** The primary (cursor) item id. */
+  cursorId: string | undefined
+  /**
+   * Anchor for range-select. When set, the selection spans from
+   * `anchorId` to `cursorId` inclusive. Undefined = no range active.
+   */
+  anchorId?: string
+  /**
+   * All selected item ids. For a cursor (single selection), this is
+   * a set of size 0-1. For multi-select, size N.
+   */
+  ids: ReadonlySet<string>
+}
+
+// ─── Selectors (read interface over legacy index state) ───────────────────────
+
+/**
+ * Get the currently-selected branch's shortName, or undefined if the
+ * branch list is empty or the index is out of range.
+ *
+ * This is the id-based read interface for the branches view — it
+ * replaces inline `filteredBranchList[Math.min(state.selectedBranchIndex, ...)]`
+ * resolution scattered across inkInput, useWorkflowAction, and surfaces.
+ */
+export function getSelectedBranchId(
+  state: LogInkState,
+  context: LogInkContext,
+): string | undefined {
+  const all = sortBranches(context.branches?.localBranches || [], state.branchSort)
+  const visible = state.filter
+    ? all.filter((b) => matchesPromotedFilter([b.shortName, b.upstream || ''], state.filter))
+    : all
+  if (visible.length === 0) return undefined
+  const index = Math.min(state.selectedBranchIndex, visible.length - 1)
+  return visible[index]?.shortName
+}
+
+/**
+ * Get the currently-selected tag's name.
+ */
+export function getSelectedTagId(
+  state: LogInkState,
+  context: LogInkContext,
+): string | undefined {
+  const all = sortTags(context.tags?.tags || [], state.tagSort)
+  const visible = state.filter
+    ? all.filter((t) => matchesPromotedFilter([t.name, t.subject], state.filter))
+    : all
+  if (visible.length === 0) return undefined
+  const index = Math.min(state.selectedTagIndex, visible.length - 1)
+  return visible[index]?.name
+}
+
+/**
+ * Get the currently-selected stash's ref.
+ */
+export function getSelectedStashId(
+  state: LogInkState,
+  context: LogInkContext,
+): string | undefined {
+  const all = context.stashes?.stashes || []
+  const visible = state.filter
+    ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], state.filter))
+    : all
+  if (visible.length === 0) return undefined
+  const index = Math.min(state.selectedStashIndex, visible.length - 1)
+  return visible[index]?.ref
+}
+
+/**
+ * Get the currently-selected worktree's path.
+ */
+export function getSelectedWorktreeId(
+  state: LogInkState,
+  context: LogInkContext,
+): string | undefined {
+  const all = context.worktreeList?.worktrees || []
+  const visible = state.filter
+    ? all.filter((w) => matchesPromotedFilter([w.path, w.branch || ''], state.filter))
+    : all
+  if (visible.length === 0) return undefined
+  const index = Math.min(state.selectedWorktreeListIndex, visible.length - 1)
+  return visible[index]?.path
+}


### PR DESCRIPTION
Introduces the selection model types and bridge selectors for the index→id migration (#1452). Provides getSelectedBranchId/TagId/StashId/WorktreeId selectors over the legacy index state. Follow-up PRs will migrate consumers view-by-view.

Partial fix for #1452