### PR TITLE
refactor(workstation): migrate tag/stash handlers to selection selectors

### DIFF
--- a/src/workstation/runtime/hooks/useWorkflowAction.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.ts
@@ -48,10 +48,9 @@ import {
     updateLogInkContextStatus,
 } from '../../chrome/context'
 import { forgeNouns } from '../../chrome/forgeNouns'
-import { sortTags } from '../../chrome/sorting'
 import { openProviderUrl } from '../../../git/providerActions'
 import type { GitProviderType } from '../../../git/providerData'
-import { getSelectedBranchId, getSelectedBranch, getSelectedTagId, getSelectedStashId, getSelectedWorktreeId } from '../selection'
+import { getSelectedBranchId, getSelectedBranch, getSelectedTagId, getSelectedTag, getSelectedStashId, getSelectedStash, getSelectedWorktreeId } from '../selection'
 import {
     LogInkPendingItemAction,
     LogInkAction,
@@ -574,29 +573,17 @@ export function useWorkflowAction(
         return rebaseOnto(git, branch.shortName)
       },
       'delete-tag': async () => {
-        const all = sortTags(context.tags?.tags || [], state.tagSort)
-        const visible = state.filter
-          ? all.filter((t) => matchesPromotedFilter([t.name, t.subject], state.filter))
-          : all
-        const tag = visible[Math.min(state.selectedTagIndex, visible.length - 1)]
+        const tag = getSelectedTag(state, context)
         if (!tag) return { ok: false, message: 'No tag selected' }
         return deleteLocalTag(git, tag.name)
       },
       'push-tag': async () => {
-        const all = sortTags(context.tags?.tags || [], state.tagSort)
-        const visible = state.filter
-          ? all.filter((t) => matchesPromotedFilter([t.name, t.subject], state.filter))
-          : all
-        const tag = visible[Math.min(state.selectedTagIndex, visible.length - 1)]
+        const tag = getSelectedTag(state, context)
         if (!tag) return { ok: false, message: 'No tag selected' }
         return pushTag(git, tag.name)
       },
       'drop-stash': async () => {
-        const all = context.stashes?.stashes || []
-        const visible = state.filter
-          ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], state.filter))
-          : all
-        const stash = visible[Math.min(state.selectedStashIndex, visible.length - 1)]
+        const stash = getSelectedStash(state, context)
         if (!stash) return { ok: false, message: 'No stash selected' }
         // Remember the dropped commit so `u` can undo it.
         if (stash.hash) lastDroppedStashRef.current = { hash: stash.hash, message: stash.message }
@@ -610,47 +597,27 @@ export function useWorkflowAction(
         return result
       },
       'apply-stash': async () => {
-        const all = context.stashes?.stashes || []
-        const visible = state.filter
-          ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], state.filter))
-          : all
-        const stash = visible[Math.min(state.selectedStashIndex, visible.length - 1)]
+        const stash = getSelectedStash(state, context)
         if (!stash) return { ok: false, message: 'No stash selected' }
         return applyStash(git, stash)
       },
       'apply-stash-index': async () => {
-        const all = context.stashes?.stashes || []
-        const visible = state.filter
-          ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], state.filter))
-          : all
-        const stash = visible[Math.min(state.selectedStashIndex, visible.length - 1)]
+        const stash = getSelectedStash(state, context)
         if (!stash) return { ok: false, message: 'No stash selected' }
         return applyStashKeepIndex(git, stash)
       },
       'pop-stash': async () => {
-        const all = context.stashes?.stashes || []
-        const visible = state.filter
-          ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], state.filter))
-          : all
-        const stash = visible[Math.min(state.selectedStashIndex, visible.length - 1)]
+        const stash = getSelectedStash(state, context)
         if (!stash) return { ok: false, message: 'No stash selected' }
         return popStash(git, stash)
       },
       'rename-stash': async () => {
-        const all = context.stashes?.stashes || []
-        const visible = state.filter
-          ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], state.filter))
-          : all
-        const stash = visible[Math.min(state.selectedStashIndex, visible.length - 1)]
+        const stash = getSelectedStash(state, context)
         if (!stash) return { ok: false, message: 'No stash selected' }
         return renameStash(git, stash, payload ?? '')
       },
       'stash-branch': async () => {
-        const all = context.stashes?.stashes || []
-        const visible = state.filter
-          ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], state.filter))
-          : all
-        const stash = visible[Math.min(state.selectedStashIndex, visible.length - 1)]
+        const stash = getSelectedStash(state, context)
         if (!stash) return { ok: false, message: 'No stash selected' }
         return stashBranch(git, stash, payload ?? '')
       },
@@ -1265,11 +1232,7 @@ export function useWorkflowAction(
         return setUpstream(git, branch.shortName, upstream)
       },
       'delete-remote-tag': async () => {
-        const all = sortTags(context.tags?.tags || [], state.tagSort)
-        const visible = state.filter
-          ? all.filter((t) => matchesPromotedFilter([t.name, t.subject], state.filter))
-          : all
-        const tag = visible[Math.min(state.selectedTagIndex, visible.length - 1)]
+        const tag = getSelectedTag(state, context)
         if (!tag) return { ok: false, message: 'No tag selected' }
         return deleteRemoteTag(git, tag.name)
       },

--- a/src/workstation/runtime/selection.ts
+++ b/src/workstation/runtime/selection.ts
@@ -24,6 +24,9 @@
 import type { LogInkState } from './inkViewModel'
 import type { LogInkContext } from './types'
 import type { BranchRef } from '../../git/branchData'
+import type { GitTagRef } from '../../git/tagData'
+import type { StashEntry } from '../../git/stashData'
+import type { WorktreeEntry } from '../../git/worktreeData'
 import { sortBranches, sortTags } from '../chrome/sorting'
 import { matchesPromotedFilter } from './promotedFilter'
 
@@ -92,13 +95,23 @@ export function getSelectedTagId(
   state: LogInkState,
   context: LogInkContext,
 ): string | undefined {
+  return getSelectedTag(state, context)?.name
+}
+
+/**
+ * Get the full GitTagRef for the currently-selected tag.
+ */
+export function getSelectedTag(
+  state: LogInkState,
+  context: LogInkContext,
+): GitTagRef | undefined {
   const all = sortTags(context.tags?.tags || [], state.tagSort)
   const visible = state.filter
     ? all.filter((t) => matchesPromotedFilter([t.name, t.subject], state.filter))
     : all
   if (visible.length === 0) return undefined
   const index = Math.min(state.selectedTagIndex, visible.length - 1)
-  return visible[index]?.name
+  return visible[index]
 }
 
 /**
@@ -108,13 +121,23 @@ export function getSelectedStashId(
   state: LogInkState,
   context: LogInkContext,
 ): string | undefined {
+  return getSelectedStash(state, context)?.ref
+}
+
+/**
+ * Get the full StashEntry for the currently-selected stash.
+ */
+export function getSelectedStash(
+  state: LogInkState,
+  context: LogInkContext,
+): StashEntry | undefined {
   const all = context.stashes?.stashes || []
   const visible = state.filter
     ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], state.filter))
     : all
   if (visible.length === 0) return undefined
   const index = Math.min(state.selectedStashIndex, visible.length - 1)
-  return visible[index]?.ref
+  return visible[index]
 }
 
 /**
@@ -124,11 +147,21 @@ export function getSelectedWorktreeId(
   state: LogInkState,
   context: LogInkContext,
 ): string | undefined {
+  return getSelectedWorktree(state, context)?.path
+}
+
+/**
+ * Get the full WorktreeEntry for the currently-selected worktree.
+ */
+export function getSelectedWorktree(
+  state: LogInkState,
+  context: LogInkContext,
+): WorktreeEntry | undefined {
   const all = context.worktreeList?.worktrees || []
   const visible = state.filter
     ? all.filter((w) => matchesPromotedFilter([w.path, w.branch || ''], state.filter))
     : all
   if (visible.length === 0) return undefined
   const index = Math.min(state.selectedWorktreeListIndex, visible.length - 1)
-  return visible[index]?.path
+  return visible[index]
 }


### PR DESCRIPTION
Converts 9 more workflow handlers (tags: delete, push, delete-remote; stash: drop, apply, apply-index, pop, rename, branch) to the shared selectors. Adds full-object getSelectedTag/getSelectedStash/getSelectedWorktree selectors.

Partial fix for #1452