### PR TITLE
refactor(workstation): function-typed warning field on registry entries

### DIFF
--- a/src/workstation/runtime/inkWorkflows.ts
+++ b/src/workstation/runtime/inkWorkflows.ts
@@ -7,6 +7,7 @@ import { StashOverview } from '../../git/stashData'
 import { WorktreeOverview } from '../../git/statusData'
 import { TagOverview } from '../../git/tagData'
 import { WorktreeOverview as WorktreeListOverview } from '../../git/worktreeData'
+import type { LogInkState } from './inkViewModel'
 
 export type LogInkWorkflowContext = {
   branches?: BranchOverview
@@ -39,11 +40,12 @@ export type LogInkWorkflowAction = {
   /**
    * Warning copy shown in the confirmation panel when `requiresConfirmation`
    * is true (#1451). When set, the renderer uses this instead of the generic
-   * "Destructive Git action requires confirmation" fallback or the per-id
-   * if-chain in overlays.ts. Supports a payload interpolation function for
-   * context-dependent copy (e.g. naming the branch being deleted).
+   * "Destructive Git action requires confirmation" fallback. A function form
+   * is called with the pending state so payload-dependent copy (e.g. naming
+   * the branch being deleted or checked out) can be computed without a
+   * per-id if-chain in overlays.ts.
    */
-  warning?: string
+  warning?: string | ((state: LogInkState) => string)
 }
 
 function countLabel(count: number, singular: string, plural = `${singular}s`): string {
@@ -427,6 +429,12 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       description: 'Rebase the current branch onto the cursored branch / ref (non-interactive) after confirmation.',
       kind: 'destructive',
       requiresConfirmation: true,
+      // Per-invocation warning naming both branches, built in inkInput
+      // from the cursored + current branch and carried as the pending
+      // confirmation payload. Falls back to a static line if the payload
+      // is somehow absent.
+      warning: (state) => state.pendingConfirmationPayload
+        || 'Rebase rewrites the current branch\'s history. This cannot be undone by Coco.',
     },
     {
       id: 'delete-tag',
@@ -664,6 +672,12 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       description: 'Switch to the branch you just created.',
       kind: 'normal',
       requiresConfirmation: false,
+      // The payload IS the branch name (#1326) — render it so the user
+      // sees what they're about to switch to. Falls back to a generic
+      // line if the payload is somehow absent.
+      warning: (state) => state.pendingConfirmationPayload
+        ? `Branch '${state.pendingConfirmationPayload}' created — switch to it now?`
+        : 'Branch created — switch to it now?',
     },
     {
       // Per-view-only: scoped to the history view in inkInput via the

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -144,26 +144,17 @@ export function renderConfirmationPanel(
   const { Box, Text } = components
   const action = getLogInkWorkflowActionById(state.pendingConfirmationId)
   const label = action?.label || 'Workflow action'
+  // #1451 — prefer the registry's warning field over any fallback. Most
+  // entries carry a static string; a few (rebase-onto-branch,
+  // checkout-created-branch) need payload-dependent copy and supply a
+  // function instead (#1452 nice-to-have — replaces the old per-id
+  // if-chain here).
+  const registryWarning = typeof action?.warning === 'function'
+    ? action.warning(state)
+    : action?.warning
   const warning =
-    // #1451 — prefer the registry's warning field over any fallback.
-    // The mutation confirmations (revert-file, revert-hunk, discard-lines,
-    // discard-draft, discard-rebase-plan) all carry their own warning.
-    action?.warning
-    ? action.warning
-    // Rebase-onto carries a per-invocation warning naming both branches
-    // (built in inkInput from the cursored + current branch). Fall back
-    // to a static line if the payload is somehow absent.
-    : state.pendingConfirmationId === 'rebase-onto-branch'
-    ? state.pendingConfirmationPayload
-      || 'Rebase rewrites the current branch\'s history. This cannot be undone by Coco.'
-    // Post-create-branch / create-branch-here checkout prompt (#1326):
-    // the payload IS the branch name — render it so the user sees what
-    // they're about to switch to. Fall back to a generic line if the
-    // payload is somehow absent.
-    : state.pendingConfirmationId === 'checkout-created-branch'
-    ? state.pendingConfirmationPayload
-      ? `Branch '${state.pendingConfirmationPayload}' created — switch to it now?`
-      : 'Branch created — switch to it now?'
+    registryWarning
+    ? registryWarning
     : action?.kind === 'ai'
     ? `AI action requires confirmation. Estimated ${action.estimatedTokens || '<unknown>'} tokens.`
     : 'Destructive Git action requires confirmation.'


### PR DESCRIPTION
## Summary
- Replace the `rebase-onto-branch` / `checkout-created-branch` if-chain in `overlays.ts`'s confirmation warning resolution with a function form of the registry's `warning` field
- Payload-dependent confirmation copy is now declared alongside each workflow entry in `inkWorkflows.ts` instead of special-cased in the renderer

Nice-to-have from [specs/TODO_0.81.0.md](specs/TODO_0.81.0.md), part of the #1452 selection-model / confirmation cleanup work.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [x] `jest` full suite: 333 suites passed (2 skipped, pre-existing)
- [x] `rollup` build succeeds, no schema.json drift
- [x] Existing `overlays.test.ts` cases for both warning scenarios (payload present / absent) pass unchanged