### PR TITLE
refactor(workstation): worktree handlers use the selector's filter fallback

### DIFF
--- a/src/workstation/runtime/hooks/useWorkflowAction.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.ts
@@ -50,7 +50,7 @@ import {
 import { forgeNouns } from '../../chrome/forgeNouns'
 import { openProviderUrl } from '../../../git/providerActions'
 import type { GitProviderType } from '../../../git/providerData'
-import { getSelectedBranchId, getSelectedBranch, getSelectedTagId, getSelectedTag, getSelectedStashId, getSelectedStash, getSelectedWorktreeId } from '../selection'
+import { getSelectedBranchId, getSelectedBranch, getSelectedTagId, getSelectedTag, getSelectedStashId, getSelectedStash, getSelectedWorktreeId, getSelectedWorktree } from '../selection'
 import {
     LogInkPendingItemAction,
     LogInkAction,
@@ -1040,18 +1040,10 @@ export function useWorkflowAction(
       'apply-hunk-worktree': async () => runApplyHunk('worktree', payload),
       'apply-hunk-index': async () => runApplyHunk('index', payload),
       'remove-worktree': async () => {
-        const all = context.worktreeList?.worktrees || []
-        // Resolve the target from the visible (filtered) list so a
-        // hidden filtered-out worktree can never be the action target.
-        // Falls back to the cursor against the unfiltered list when the
-        // action is invoked from the palette without ever visiting the
-        // worktrees view.
-        const visible = state.filter
-          ? all.filter((w) => matchesPromotedFilter([w.path, w.branch || ''], state.filter))
-          : all
-        const cursorTarget = visible.length
-          ? visible[Math.min(state.selectedWorktreeListIndex, visible.length - 1)]
-          : all[Math.min(state.selectedWorktreeListIndex, Math.max(0, all.length - 1))]
+        // #1452 — resolves via the selector, which falls back to the
+        // cursor against the unfiltered list when the action is invoked
+        // from the palette with a filter active that hides every worktree.
+        const cursorTarget = getSelectedWorktree(state, context)
         if (!cursorTarget) return { ok: false, message: 'No worktree selected' }
         if (cursorTarget.current) {
           return {
@@ -1062,13 +1054,7 @@ export function useWorkflowAction(
         return removeWorktree(git, cursorTarget)
       },
       'remove-worktree-and-branch': async () => {
-        const all = context.worktreeList?.worktrees || []
-        const visible = state.filter
-          ? all.filter((w) => matchesPromotedFilter([w.path, w.branch || ''], state.filter))
-          : all
-        const cursorTarget = visible.length
-          ? visible[Math.min(state.selectedWorktreeListIndex, visible.length - 1)]
-          : all[Math.min(state.selectedWorktreeListIndex, Math.max(0, all.length - 1))]
+        const cursorTarget = getSelectedWorktree(state, context)
         if (!cursorTarget) return { ok: false, message: 'No worktree selected' }
         if (cursorTarget.current) {
           return {

--- a/src/workstation/runtime/selection.test.ts
+++ b/src/workstation/runtime/selection.test.ts
@@ -7,7 +7,7 @@
  */
 import { createLogInkState } from './inkViewModel'
 import type { LogInkContext } from './types'
-import { getSelectedBranchId, getSelectedTagId, getSelectedStashId } from './selection'
+import { getSelectedBranchId, getSelectedTagId, getSelectedStashId, getSelectedWorktree } from './selection'
 
 function makeBranch(shortName: string, date = '2026-01-01') {
   return {
@@ -29,6 +29,10 @@ function makeTag(name: string) {
 
 function makeStash(index: number) {
   return { ref: `stash@{${index}}`, message: `stash ${index}`, hash: `s${index}`, date: '2026-01-01' }
+}
+
+function makeWorktree(path: string, branch?: string) {
+  return { path, branch, head: `h-${path}`, detached: !branch, bare: false, current: false, dirty: false }
 }
 
 describe('selection selectors (#1452)', () => {
@@ -159,6 +163,41 @@ describe('selection selectors (#1452)', () => {
       // 'echo'. An index-only lookup would silently return the wrong
       // branch here; the id-first selector still returns 'echo'.
       expect(getSelectedBranchId(state, after)).toBe('echo')
+    })
+  })
+
+  describe('getSelectedWorktree', () => {
+    const worktreeContext = {
+      worktreeList: {
+        worktrees: [
+          makeWorktree('/repo', 'main'),
+          makeWorktree('/repo-feature', 'feature'),
+        ],
+      },
+    } as unknown as LogInkContext
+
+    it('returns the worktree at the selected index', () => {
+      const state = { ...createLogInkState([]), selectedWorktreeListIndex: 1 }
+      expect(getSelectedWorktree(state, worktreeContext)?.path).toBe('/repo-feature')
+    })
+
+    // A worktree action reachable from the palette (rather than the
+    // worktrees view) can fire with a stale filter still applied — the
+    // cursor should still resolve against the unfiltered list rather
+    // than going target-less.
+    it('falls back to the unfiltered list when the filter hides every worktree', () => {
+      const state = {
+        ...createLogInkState([]),
+        selectedWorktreeListIndex: 1,
+        filter: 'does-not-match-anything',
+      }
+      expect(getSelectedWorktree(state, worktreeContext)?.path).toBe('/repo-feature')
+    })
+
+    it('returns undefined when there are no worktrees at all', () => {
+      const state = { ...createLogInkState([]), selectedWorktreeListIndex: 0 }
+      const emptyCtx = { worktreeList: { worktrees: [] } } as unknown as LogInkContext
+      expect(getSelectedWorktree(state, emptyCtx)).toBeUndefined()
     })
   })
 })

--- a/src/workstation/runtime/selection.ts
+++ b/src/workstation/runtime/selection.ts
@@ -182,6 +182,12 @@ export function getSelectedWorktreeId(
 
 /**
  * Get the full WorktreeEntry for the currently-selected worktree.
+ *
+ * Falls back to indexing the unfiltered list when the active filter hides
+ * every worktree — a worktree action reachable from the palette (rather
+ * than from the worktrees view itself) can fire with a stale filter still
+ * applied, and the cursor should still resolve to something rather than
+ * silently going target-less.
  */
 export function getSelectedWorktree(
   state: LogInkState,
@@ -191,7 +197,9 @@ export function getSelectedWorktree(
   const visible = state.filter
     ? all.filter((w) => matchesPromotedFilter([w.path, w.branch || ''], state.filter))
     : all
-  if (visible.length === 0) return undefined
-  const index = Math.min(state.selectedWorktreeListIndex, visible.length - 1)
-  return visible[index]
+  if (visible.length > 0) {
+    return visible[Math.min(state.selectedWorktreeListIndex, visible.length - 1)]
+  }
+  if (all.length === 0) return undefined
+  return all[Math.min(state.selectedWorktreeListIndex, all.length - 1)]
 }


### PR DESCRIPTION
## Summary
- `getSelectedWorktree` now falls back to indexing the unfiltered worktree list when the active filter hides every entry, matching the inline fallback `remove-worktree` / `remove-worktree-and-branch` carried before this change (a worktree action reached from the palette can fire with a stale filter still applied)
- Both handlers in `useWorkflowAction.ts` now resolve their target through the selector instead of duplicating the sort+filter+fallback logic inline
- As a side effect, `resolvePendingItemAction`'s confirmation-target line (which already called `getSelectedWorktreeId`) now picks up the same fallback — previously it could show no target line while the handler still found one via its own inline fallback, a target-naming mismatch
- Adds `getSelectedWorktree` test coverage (none existed before) including the empty-filtered-list fallback case

Nice-to-have from [specs/TODO_0.81.0.md](specs/TODO_0.81.0.md): "Convert worktree handlers' special fallback logic to use the selector."

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [x] `jest` full suite: 333 suites passed (2 skipped, pre-existing), 3 new tests added
- [x] `rollup` build succeeds, no schema.json drift