### PR TITLE
feat(workstation): id-based selection for branches/tags/stashes (dual-write + flip)

### DIFF
--- a/src/workstation/runtime/hooks/useInputHandler.ts
+++ b/src/workstation/runtime/hooks/useInputHandler.ts
@@ -293,14 +293,19 @@ export function useInputHandler(
     const branchSelectedShortName = filteredBranchList[
       Math.min(state.selectedBranchIndex, Math.max(0, filteredBranchList.length - 1))
     ]?.shortName
+    // #1452 dual-write — id list in render order so moveBranch can
+    // resolve the post-move target's id without re-sorting/re-filtering.
+    const branchIds = filteredBranchList.map((b) => b.shortName)
     const tagVisibleCount = filteredTagList.length
     const tagSelectedName = filteredTagList[
       Math.min(state.selectedTagIndex, Math.max(0, filteredTagList.length - 1))
     ]?.name
+    const tagIds = filteredTagList.map((t) => t.name)
     const stashVisibleCount = filteredStashList.length
     const stashSelectedRef = filteredStashList[
       Math.min(state.selectedStashIndex, Math.max(0, filteredStashList.length - 1))
     ]?.ref
+    const stashIds = filteredStashList.map((s) => s.ref)
     const reflogVisibleCount = filteredReflogList.length
     const reflogSelectedHash = filteredReflogList[
       Math.min(state.selectedReflogIndex, Math.max(0, filteredReflogList.length - 1))
@@ -367,13 +372,16 @@ export function useInputHandler(
       commitDiffHunkOffsets,
       branchCount: branchVisibleCount,
       branchSelectedShortName,
+      branchIds,
       // Current branch for the `r` rebase-onto guard + warning (#0.71).
       // Undefined on a detached HEAD, which the handler treats as "no
       // branch to rebase".
       currentBranch: context.branches?.currentBranch,
       tagCount: tagVisibleCount,
       tagSelectedName,
+      tagIds,
       stashCount: stashVisibleCount,
+      stashIds,
       reflogCount: reflogVisibleCount,
       reflogSelectedHash,
       submoduleCount: submoduleVisibleCount,

--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -3408,6 +3408,54 @@ describe('log Ink input interactions', () => {
       expect(up).toEqual([{ type: 'action', action: { type: 'moveBranch', delta: -1, count: 5 } }])
     })
 
+    // #1452 dual-write — when the caller threads the sorted+filtered id
+    // list through context, moveBranch/moveTag/moveStash carry the
+    // post-move target's id so the reducer can mirror it into
+    // selectedBranchId/selectedTagId/selectedStashId.
+    it('moveBranch/moveTag/moveStash carry the post-move id when the context provides the id list', () => {
+      const branchIds = ['a', 'b', 'c', 'd', 'e']
+      const state = {
+        ...createLogInkState(rows),
+        activeView: 'branches' as const,
+        selectedBranchIndex: 1,
+        selectedTagIndex: 1,
+        selectedStashIndex: 1,
+      }
+
+      const branchDown = getLogInkInputEvents(state, '', { downArrow: true }, { branchCount: 5, branchIds })
+      expect(branchDown).toEqual([
+        { type: 'action', action: { type: 'moveBranch', delta: 1, count: 5, id: 'c' } },
+      ])
+
+      const branchUp = getLogInkInputEvents(state, '', { upArrow: true }, { branchCount: 5, branchIds })
+      expect(branchUp).toEqual([
+        { type: 'action', action: { type: 'moveBranch', delta: -1, count: 5, id: 'a' } },
+      ])
+
+      const tagIds = ['t1', 't2', 't3']
+      const tagState = { ...state, activeView: 'tags' as const }
+      const tagDown = getLogInkInputEvents(tagState, '', { downArrow: true }, { tagCount: 3, tagIds })
+      expect(tagDown).toEqual([
+        { type: 'action', action: { type: 'moveTag', delta: 1, count: 3, id: 't3' } },
+      ])
+
+      const stashIds = ['stash@{0}', 'stash@{1}', 'stash@{2}']
+      const stashState = { ...state, activeView: 'stash' as const }
+      const stashDown = getLogInkInputEvents(stashState, '', { downArrow: true }, { stashCount: 3, stashIds })
+      expect(stashDown).toEqual([
+        { type: 'action', action: { type: 'moveStash', delta: 1, count: 3, id: 'stash@{2}' } },
+      ])
+    })
+
+    it('clamps the resolved id to the last item at the end of the list', () => {
+      const branchIds = ['a', 'b', 'c']
+      const state = { ...createLogInkState(rows), activeView: 'branches' as const, selectedBranchIndex: 2 }
+      const down = getLogInkInputEvents(state, '', { downArrow: true }, { branchCount: 3, branchIds })
+      expect(down).toEqual([
+        { type: 'action', action: { type: 'moveBranch', delta: 1, count: 3, id: 'c' } },
+      ])
+    })
+
     it('↑/↓ on the status view with the center pane focused still moves the worktree file list', () => {
       const state = {
         ...createLogInkState(rows),

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -112,6 +112,13 @@ export type LogInkInputContext = {
    */
   branchSelectedShortName?: string
   /**
+   * Sorted + filtered branch shortNames, same order as the rendered
+   * list (#1452 dual-write). Lets moveBranch resolve the post-move
+   * target's id without duplicating sort/filter here — the caller
+   * (`useInputHandler`) already has the filtered list in scope.
+   */
+  branchIds?: string[]
+  /**
    * Name of the currently checked-out branch (#0.71). Used by the
    * branches-view `r` (rebase-onto) handler to build the confirmation
    * warning and to short-circuit a self-rebase / detached-HEAD before
@@ -124,7 +131,11 @@ export type LogInkInputContext = {
    * `branchSelectedShortName` but scoped to the tags view.
    */
   tagSelectedName?: string
+  /** Sorted + filtered tag names, same role as `branchIds` (#1452). */
+  tagIds?: string[]
   stashCount?: number
+  /** Filtered stash refs, same role as `branchIds` (#1452). Stashes have no sort mode to apply. */
+  stashIds?: string[]
   reflogCount?: number
   /** Hash of the cursored reflog entry (#781). Used by Enter to drill into the diff. */
   reflogSelectedHash?: string
@@ -311,6 +322,25 @@ function action(actionValue: LogInkAction): LogInkInputEvent {
     type: 'action',
     action: actionValue,
   }
+}
+
+/**
+ * Resolve the id at the post-move index for a `moveBranch`/`moveTag`/
+ * `moveStash` dispatch (#1452 dual-write). `ids` is the sorted +
+ * filtered id list in render order; undefined when the caller hasn't
+ * threaded it through `LogInkInputContext` yet (e.g. a test harness
+ * exercising only `count`), in which case the move still dispatches —
+ * it just carries no `id` payload.
+ */
+function resolveMoveTargetId(
+  ids: string[] | undefined,
+  currentIndex: number,
+  delta: number,
+  count: number,
+): string | undefined {
+  if (!ids || count === 0) return undefined
+  const newIndex = Math.max(0, Math.min(currentIndex + delta, count - 1))
+  return ids[newIndex]
 }
 
 /**
@@ -2868,15 +2898,30 @@ export function getLogInkInputEvents(
     }
 
     if (isBranchActionTarget(state) && context.branchCount) {
-      return [action({ type: 'moveBranch', delta: -1, count: context.branchCount })]
+      return [action({
+        type: 'moveBranch',
+        delta: -1,
+        count: context.branchCount,
+        id: resolveMoveTargetId(context.branchIds, state.selectedBranchIndex, -1, context.branchCount),
+      })]
     }
 
     if (isTagActionTarget(state) && context.tagCount) {
-      return [action({ type: 'moveTag', delta: -1, count: context.tagCount })]
+      return [action({
+        type: 'moveTag',
+        delta: -1,
+        count: context.tagCount,
+        id: resolveMoveTargetId(context.tagIds, state.selectedTagIndex, -1, context.tagCount),
+      })]
     }
 
     if (isStashActionTarget(state) && context.stashCount) {
-      return [action({ type: 'moveStash', delta: -1, count: context.stashCount })]
+      return [action({
+        type: 'moveStash',
+        delta: -1,
+        count: context.stashCount,
+        id: resolveMoveTargetId(context.stashIds, state.selectedStashIndex, -1, context.stashCount),
+      })]
     }
 
     if (isReflogActionTarget(state) && context.reflogCount) {
@@ -3004,15 +3049,30 @@ export function getLogInkInputEvents(
     }
 
     if (isBranchActionTarget(state) && context.branchCount) {
-      return [action({ type: 'moveBranch', delta: 1, count: context.branchCount })]
+      return [action({
+        type: 'moveBranch',
+        delta: 1,
+        count: context.branchCount,
+        id: resolveMoveTargetId(context.branchIds, state.selectedBranchIndex, 1, context.branchCount),
+      })]
     }
 
     if (isTagActionTarget(state) && context.tagCount) {
-      return [action({ type: 'moveTag', delta: 1, count: context.tagCount })]
+      return [action({
+        type: 'moveTag',
+        delta: 1,
+        count: context.tagCount,
+        id: resolveMoveTargetId(context.tagIds, state.selectedTagIndex, 1, context.tagCount),
+      })]
     }
 
     if (isStashActionTarget(state) && context.stashCount) {
-      return [action({ type: 'moveStash', delta: 1, count: context.stashCount })]
+      return [action({
+        type: 'moveStash',
+        delta: 1,
+        count: context.stashCount,
+        id: resolveMoveTargetId(context.stashIds, state.selectedStashIndex, 1, context.stashCount),
+      })]
     }
 
     if (isReflogActionTarget(state) && context.reflogCount) {

--- a/src/workstation/runtime/inkViewModel.test.ts
+++ b/src/workstation/runtime/inkViewModel.test.ts
@@ -1539,6 +1539,39 @@ describe('log Ink view model', () => {
     })
   })
 
+  // #1452 dual-write — moveBranch/moveTag/moveStash write the resolved
+  // id alongside the index. The reducer has no access to LogInkContext,
+  // so it trusts whatever id the dispatch site resolved; it does not
+  // (and cannot) verify the id matches the index itself.
+  describe('moveBranch / moveTag / moveStash id dual-write (#1452)', () => {
+    it('writes selectedBranchId alongside the index when the dispatch site resolved one', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'moveBranch', delta: 1, count: 5, id: 'feature' })
+      expect(state.selectedBranchIndex).toBe(1)
+      expect(state.selectedBranchId).toBe('feature')
+    })
+
+    it('leaves selectedBranchId undefined when the dispatch site could not resolve one', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'moveBranch', delta: 1, count: 5 })
+      expect(state.selectedBranchId).toBeUndefined()
+    })
+
+    it('writes selectedTagId alongside the index', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'moveTag', delta: 2, count: 5, id: 'v2.0' })
+      expect(state.selectedTagIndex).toBe(2)
+      expect(state.selectedTagId).toBe('v2.0')
+    })
+
+    it('writes selectedStashId alongside the index', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'moveStash', delta: 1, count: 5, id: 'stash@{1}' })
+      expect(state.selectedStashIndex).toBe(1)
+      expect(state.selectedStashId).toBe('stash@{1}')
+    })
+  })
+
   // Sidebar header focus (#806 follow-up) — escapes the items list
   // upward onto the active tab's header. Reducer-level coverage
   // here; input dispatch coverage lives in inkInput.test.ts.

--- a/src/workstation/runtime/inkViewModel.test.ts
+++ b/src/workstation/runtime/inkViewModel.test.ts
@@ -1572,6 +1572,57 @@ describe('log Ink view model', () => {
     })
   })
 
+  // #1452 flip — every OTHER action that resets or rectifies
+  // selectedBranchIndex/selectedTagIndex/selectedStashIndex must also
+  // clear (or precisely set) the id mirror, so the id-preferring
+  // selectors in selection.ts never resolve to a stale item that
+  // disagrees with a freshly reset/rectified index.
+  describe('id mirror stays consistent across non-move index resets (#1452)', () => {
+    it('resetBranchSelection clears selectedBranchId', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'moveBranch', delta: 3, count: 10, id: 'feature' })
+      expect(state.selectedBranchId).toBe('feature')
+      state = applyLogInkAction(state, { type: 'resetBranchSelection' })
+      expect(state.selectedBranchIndex).toBe(0)
+      expect(state.selectedBranchId).toBeUndefined()
+    })
+
+    it('cycleBranchSort clears selectedBranchId', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'moveBranch', delta: 3, count: 10, id: 'feature' })
+      state = applyLogInkAction(state, { type: 'cycleBranchSort' })
+      expect(state.selectedBranchIndex).toBe(0)
+      expect(state.selectedBranchId).toBeUndefined()
+    })
+
+    it('cycleTagSort clears selectedTagId', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'moveTag', delta: 3, count: 10, id: 'v2.0' })
+      state = applyLogInkAction(state, { type: 'cycleTagSort' })
+      expect(state.selectedTagIndex).toBe(0)
+      expect(state.selectedTagId).toBeUndefined()
+    })
+
+    it('navigateOpenDiffForStash sets selectedStashId precisely from action.ref', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'moveStash', delta: 3, count: 10, id: 'stash@{3}' })
+      state = applyLogInkAction(state, { type: 'navigateOpenDiffForStash', ref: 'stash@{7}', stashIndex: 2 })
+      expect(state.selectedStashIndex).toBe(2)
+      expect(state.selectedStashId).toBe('stash@{7}')
+    })
+
+    it('a filter change clears all three id mirrors', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'moveBranch', delta: 1, count: 10, id: 'feature' })
+      state = applyLogInkAction(state, { type: 'moveTag', delta: 1, count: 10, id: 'v2.0' })
+      state = applyLogInkAction(state, { type: 'moveStash', delta: 1, count: 10, id: 'stash@{1}' })
+      state = applyLogInkAction(state, { type: 'appendFilter', value: 'x' })
+      expect(state.selectedBranchId).toBeUndefined()
+      expect(state.selectedTagId).toBeUndefined()
+      expect(state.selectedStashId).toBeUndefined()
+    })
+  })
+
   // Sidebar header focus (#806 follow-up) — escapes the items list
   // upward onto the active tab's header. Reducer-level coverage
   // here; input dispatch coverage lives in inkInput.test.ts.
@@ -2225,6 +2276,28 @@ describe('log Ink view model', () => {
       expect(popped.branchSort).toBe(parentBranchSort)
       // Submodule's state is gone; only the root frame remains.
       expect(popped.repoStack).toHaveLength(1)
+    })
+
+    // #1452 — parentReturn only captures the index, not the id mirror
+    // (adding it is deferred; nothing reads these fields outside the
+    // selectors yet, so a cleared mirror right after push/pop is
+    // harmless — the selectors fall back to the restored index, which
+    // is exactly correct). Push and pop must each clear the mirror
+    // rather than leaking the other frame's id across the boundary.
+    it('pushRepoFrame and popRepoFrame clear the id mirrors', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'moveBranch', delta: 1, count: 10, id: 'feature' })
+      expect(state.selectedBranchId).toBe('feature')
+
+      const pushed = applyLogInkAction(state, { type: 'pushRepoFrame', label: 'vendor/lib' })
+      expect(pushed.selectedBranchId).toBeUndefined()
+
+      const insideSubmodule = applyLogInkAction(pushed, {
+        type: 'moveBranch', delta: 1, count: 10, id: 'submodule-branch',
+      })
+      const popped = applyLogInkAction(insideSubmodule, { type: 'popRepoFrame' })
+      expect(popped.selectedBranchId).toBeUndefined()
+      expect(popped.selectedBranchIndex).toBe(state.selectedBranchIndex)
     })
 
     // Regression: popping a frame entered FROM a commit diff used to

--- a/src/workstation/runtime/inkViewModel.ts
+++ b/src/workstation/runtime/inkViewModel.ts
@@ -1540,6 +1540,12 @@ function withPushedRepoFrame(
     selectedBranchIndex: 0,
     selectedTagIndex: 0,
     selectedStashIndex: 0,
+    // #1452 — a fresh repo frame has no meaningful id-cursor; the parent's
+    // was captured above (index-only, see the parentReturn TODO note) and
+    // this frame's own index resets to 0 alongside it.
+    selectedBranchId: undefined,
+    selectedTagId: undefined,
+    selectedStashId: undefined,
     selectedWorktreeListIndex: 0,
     selectedConflictFileIndex: 0,
     selectedReflogIndex: 0,
@@ -1612,6 +1618,12 @@ function withPoppedRepoFrame(state: LogInkState): LogInkState {
     selectedBranchIndex: ret.selectedBranchIndex ?? 0,
     selectedTagIndex: ret.selectedTagIndex ?? 0,
     selectedStashIndex: ret.selectedStashIndex ?? 0,
+    // #1452 — parentReturn only captures the index (not the id mirror);
+    // clearing here makes the selectors trust the just-restored index,
+    // which is exactly what was in effect before the push.
+    selectedBranchId: undefined,
+    selectedTagId: undefined,
+    selectedStashId: undefined,
     selectedWorktreeListIndex: ret.selectedWorktreeListIndex ?? 0,
     selectedConflictFileIndex: ret.selectedConflictFileIndex ?? 0,
     selectedReflogIndex: ret.selectedReflogIndex ?? 0,
@@ -1750,6 +1762,13 @@ function withFilter(
     selectedBranchIndex: branchIndex,
     selectedTagIndex: tagIndex,
     selectedStashIndex: stashIndex,
+    // #1452 — the rectified index above already follows the previously-
+    // selected item by key (or snaps to 0 when it dropped out); clearing
+    // the id mirror here just makes the selectors trust that freshly
+    // rectified index instead of a now-possibly-stale id.
+    selectedBranchId: undefined,
+    selectedTagId: undefined,
+    selectedStashId: undefined,
     selectedReflogIndex: reflogIndex,
     diffPreviewOffset: 0,
     pendingKey: undefined,
@@ -2189,6 +2208,10 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         selectedBranchIndex: 0,
+        // #1452 — clear the id mirror so the selector trusts the reset
+        // index (the just-checked-out branch is now pinned at top) rather
+        // than resolving back to whatever branch was selected before.
+        selectedBranchId: undefined,
         pendingKey: undefined,
       }
     case 'setSidebarHeaderFocused':
@@ -2359,8 +2382,11 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         ...state,
         branchSort: cycleBranchSort(state.branchSort),
         // Snap to the top of the (newly ordered) list so the user always
-        // sees what's now most relevant under the new mode.
+        // sees what's now most relevant under the new mode. #1452: clear
+        // the id mirror too, else the selector would keep resolving to
+        // the pre-resort branch instead of the new top-of-list item.
         selectedBranchIndex: 0,
+        selectedBranchId: undefined,
         pendingKey: undefined,
       }
     case 'cycleTagSort':
@@ -2368,6 +2394,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         ...state,
         tagSort: cycleTagSort(state.tagSort),
         selectedTagIndex: 0,
+        selectedTagId: undefined,
         pendingKey: undefined,
       }
     case 'openInputPrompt':
@@ -2657,6 +2684,9 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         diffSource: 'stash',
         stashDiffRef: action.ref,
         selectedStashIndex: Math.max(0, action.stashIndex ?? state.selectedStashIndex),
+        // #1452 — action.ref IS the target stash's id, so it can be set
+        // precisely here rather than just cleared.
+        selectedStashId: action.ref,
         // Reset the diff scroll offset so the stash patch always opens
         // at the top, mirroring `navigateOpenDiffForCommit`. Without
         // this, opening a stash inherits whatever offset the previous

--- a/src/workstation/runtime/inkViewModel.ts
+++ b/src/workstation/runtime/inkViewModel.ts
@@ -370,6 +370,16 @@ export type LogInkState = {
   selectedBranchIndex: number
   selectedTagIndex: number
   selectedStashIndex: number
+  /**
+   * Id-based cursor mirrors of the three indices above (#1452 dual-write
+   * phase). Written alongside the index by `moveBranch`/`moveTag`/
+   * `moveStash` when the dispatch site could resolve the target's id;
+   * not yet read by any consumer — `selected*Index` remains the source
+   * of truth until the migration flips it.
+   */
+  selectedBranchId?: string
+  selectedTagId?: string
+  selectedStashId?: string
   selectedWorktreeListIndex: number
   selectedConflictFileIndex: number
   /**
@@ -1088,7 +1098,12 @@ export type LogInkAction =
   | { type: 'selectCommitByHash'; hash: string }
   | { type: 'moveDetailFile'; delta: number; fileCount: number }
   | { type: 'moveWorktreeFile'; delta: number; fileCount: number }
-  | { type: 'moveBranch'; delta: number; count: number }
+  // `id` (#1452 dual-write) is the target's id at the post-move index,
+  // resolved by the dispatch site (which has the filtered list in
+  // scope) since the reducer has no access to `LogInkContext`. Written
+  // to `selected*Id` alongside the index; undefined when the dispatch
+  // site couldn't resolve it (e.g. a test harness omitting the id list).
+  | { type: 'moveBranch'; delta: number; count: number; id?: string }
   | { type: 'resetBranchSelection' }
   | { type: 'setSidebarHeaderFocused'; value: boolean }
   | { type: 'setStatusGroupHeaderFocused'; value: boolean }
@@ -1099,8 +1114,8 @@ export type LogInkAction =
   | { type: 'resetInspectorActionIndex' }
   | { type: 'setBootLoading'; value: boolean }
   | { type: 'setRemoteOp'; value: RemoteOpState | undefined }
-  | { type: 'moveTag'; delta: number; count: number }
-  | { type: 'moveStash'; delta: number; count: number }
+  | { type: 'moveTag'; delta: number; count: number; id?: string }
+  | { type: 'moveStash'; delta: number; count: number; id?: string }
   | { type: 'moveReflog'; delta: number; count: number }
   | { type: 'moveSubmodule'; delta: number; count: number }
   | { type: 'moveRemote'; delta: number; count: number }
@@ -1911,6 +1926,9 @@ export function createLogInkState(
     selectedBranchIndex: 0,
     selectedTagIndex: 0,
     selectedStashIndex: 0,
+    selectedBranchId: undefined,
+    selectedTagId: undefined,
+    selectedStashId: undefined,
     selectedWorktreeListIndex: 0,
     selectedConflictFileIndex: 0,
     selectedReflogIndex: 0,
@@ -2160,6 +2178,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         selectedBranchIndex: clampIndex(state.selectedBranchIndex + action.delta, action.count),
+        selectedBranchId: action.id,
         pendingKey: undefined,
       }
     case 'resetBranchSelection':
@@ -2250,12 +2269,14 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         selectedTagIndex: clampIndex(state.selectedTagIndex + action.delta, action.count),
+        selectedTagId: action.id,
         pendingKey: undefined,
       }
     case 'moveStash':
       return {
         ...state,
         selectedStashIndex: clampIndex(state.selectedStashIndex + action.delta, action.count),
+        selectedStashId: action.id,
         pendingKey: undefined,
       }
     case 'moveReflog':

--- a/src/workstation/runtime/selection.test.ts
+++ b/src/workstation/runtime/selection.test.ts
@@ -87,4 +87,38 @@ describe('selection selectors (#1452)', () => {
       expect(getSelectedStashId(state, context)).toBe('stash@{1}')
     })
   })
+
+  // #1452 flip — the id mirror wins over the index when both are set and
+  // the id still resolves, so the cursor follows the same logical item
+  // across a context refresh that reorders the sorted+filtered list
+  // (rendering, which still reads the raw index, is untouched by this —
+  // only action-target resolution through these selectors changes).
+  describe('id-first resolution (#1452 flip)', () => {
+    it('prefers selectedBranchId over selectedBranchIndex when both are set', () => {
+      // Sorted: feature, hotfix, main — index 0 is 'feature', but the id
+      // mirror points at 'main'.
+      const state = { ...createLogInkState([]), selectedBranchIndex: 0, selectedBranchId: 'main' }
+      expect(getSelectedBranchId(state, context)).toBe('main')
+    })
+
+    it('falls back to the index when selectedBranchId is undefined', () => {
+      const state = { ...createLogInkState([]), selectedBranchIndex: 0, selectedBranchId: undefined }
+      expect(getSelectedBranchId(state, context)).toBe('feature')
+    })
+
+    it('falls back to the index when selectedBranchId no longer resolves (deleted / filtered out)', () => {
+      const state = { ...createLogInkState([]), selectedBranchIndex: 1, selectedBranchId: 'gone' }
+      expect(getSelectedBranchId(state, context)).toBe('hotfix')
+    })
+
+    it('prefers selectedTagId over selectedTagIndex when both are set', () => {
+      const state = { ...createLogInkState([]), selectedTagIndex: 0, selectedTagId: 'v3.0' }
+      expect(getSelectedTagId(state, context)).toBe('v3.0')
+    })
+
+    it('prefers selectedStashId over selectedStashIndex when both are set', () => {
+      const state = { ...createLogInkState([]), selectedStashIndex: 0, selectedStashId: 'stash@{2}' }
+      expect(getSelectedStashId(state, context)).toBe('stash@{2}')
+    })
+  })
 })

--- a/src/workstation/runtime/selection.test.ts
+++ b/src/workstation/runtime/selection.test.ts
@@ -120,5 +120,45 @@ describe('selection selectors (#1452)', () => {
       const state = { ...createLogInkState([]), selectedStashIndex: 0, selectedStashId: 'stash@{2}' }
       expect(getSelectedStashId(state, context)).toBe('stash@{2}')
     })
+
+    // The actual scenario the flip exists to fix: a background context
+    // refresh (fetch completing, ahead/behind counts changing, a new
+    // branch appearing) can reorder the sorted+filtered list WITHOUT any
+    // reducer action touching the index. Before the flip, the selector
+    // blindly re-indexed into the new order and silently resolved to a
+    // different branch than the one the user had cursored — a stale
+    // index pointing at the wrong logical item. After the flip, the id
+    // mirror (written once when the user last moved the cursor) keeps
+    // resolving to the SAME branch even though its position moved.
+    it('keeps resolving to the same branch after a context refresh reorders the list', () => {
+      const before = {
+        branches: {
+          localBranches: [makeBranch('delta'), makeBranch('echo'), makeBranch('foxtrot')],
+          remoteBranches: [],
+          currentBranch: 'delta',
+          dirty: false,
+        },
+      } as unknown as LogInkContext
+      // User moved the cursor to 'echo' (index 1) — moveBranch's dual-write
+      // sets both fields together.
+      const state = { ...createLogInkState([]), selectedBranchIndex: 1, selectedBranchId: 'echo' }
+      expect(getSelectedBranchId(state, before)).toBe('echo')
+
+      // Background refresh: a new branch sorts alphabetically ahead of
+      // 'echo', shifting it from index 1 to index 2. No reducer action
+      // fired — `state` (index + id) is byte-identical to before.
+      const after = {
+        branches: {
+          localBranches: [makeBranch('alpha'), makeBranch('delta'), makeBranch('echo'), makeBranch('foxtrot')],
+          remoteBranches: [],
+          currentBranch: 'delta',
+          dirty: false,
+        },
+      } as unknown as LogInkContext
+      // Sorted: alpha, delta, echo, foxtrot — index 1 is now 'delta', NOT
+      // 'echo'. An index-only lookup would silently return the wrong
+      // branch here; the id-first selector still returns 'echo'.
+      expect(getSelectedBranchId(state, after)).toBe('echo')
+    })
   })
 })

--- a/src/workstation/runtime/selection.ts
+++ b/src/workstation/runtime/selection.ts
@@ -3,9 +3,8 @@
  *
  * This module introduces the target selection architecture that will replace
  * the 16 scalar `selected*Index` fields in `LogInkState`. The migration is
- * incremental: each view converts one at a time, and during the transition
- * the legacy index fields remain the source of truth while these selectors
- * provide an id-based read interface over them.
+ * incremental and per view; branches / tags / stashes have completed all
+ * three phases below, the rest are still index-only.
  *
  * Design:
  *   - A selection is a set of ids (not indexes) scoped to a view
@@ -16,9 +15,17 @@
  *   - The `anchorId` supports range-select (shift+j/k)
  *
  * Migration path (per view):
- *   1. Use `getSelectedItemId()` to read the selection by id
- *   2. Convert the move action to write through the new model
- *   3. Remove the legacy `selected*Index` field once all consumers migrated
+ *   1. Dual-write: the move action resolves + writes `selected*Id`
+ *      alongside the legacy index; every OTHER action that resets or
+ *      rectifies the index clears the id mirror in the same reducer case,
+ *      so the two are never allowed to silently disagree.
+ *   2. Flip: the selector (`getSelectedBranch` etc.) prefers the id when
+ *      it's set and still resolves in the current sorted + filtered list,
+ *      falling back to the index otherwise — done for branches / tags /
+ *      stashes.
+ *   3. Remove the legacy `selected*Index` field once every consumer reads
+ *      through the selector (not done yet — the field still backs
+ *      rendering / cursor-position reads across the codebase).
  */
 
 import type { LogInkState } from './inkViewModel'
@@ -73,7 +80,16 @@ export function getSelectedBranchId(
 
 /**
  * Get the full BranchRef for the currently-selected branch.
- * Returns the item from the sorted + filtered list at the selected index.
+ *
+ * #1452 flip — `selectedBranchId` is now the preferred source of truth:
+ * when set and still present in the sorted + filtered list, it wins
+ * (this is what keeps the cursor on the same logical branch across a
+ * background context refresh that reorders the list). Falls back to
+ * the index when the id is unset (actions that reset/rectify the index
+ * clear the id mirror in the same reducer case, precisely so this
+ * fallback is always consistent with what's on screen) or when the id
+ * no longer resolves to anything visible (branch deleted / filtered
+ * out elsewhere).
  */
 export function getSelectedBranch(
   state: LogInkState,
@@ -84,6 +100,10 @@ export function getSelectedBranch(
     ? all.filter((b) => matchesPromotedFilter([b.shortName, b.upstream || ''], state.filter))
     : all
   if (visible.length === 0) return undefined
+  if (state.selectedBranchId) {
+    const byId = visible.find((b) => b.shortName === state.selectedBranchId)
+    if (byId) return byId
+  }
   const index = Math.min(state.selectedBranchIndex, visible.length - 1)
   return visible[index]
 }
@@ -100,6 +120,7 @@ export function getSelectedTagId(
 
 /**
  * Get the full GitTagRef for the currently-selected tag.
+ * #1452 flip — same id-first, index-fallback resolution as `getSelectedBranch`.
  */
 export function getSelectedTag(
   state: LogInkState,
@@ -110,6 +131,10 @@ export function getSelectedTag(
     ? all.filter((t) => matchesPromotedFilter([t.name, t.subject], state.filter))
     : all
   if (visible.length === 0) return undefined
+  if (state.selectedTagId) {
+    const byId = visible.find((t) => t.name === state.selectedTagId)
+    if (byId) return byId
+  }
   const index = Math.min(state.selectedTagIndex, visible.length - 1)
   return visible[index]
 }
@@ -126,6 +151,7 @@ export function getSelectedStashId(
 
 /**
  * Get the full StashEntry for the currently-selected stash.
+ * #1452 flip — same id-first, index-fallback resolution as `getSelectedBranch`.
  */
 export function getSelectedStash(
   state: LogInkState,
@@ -136,6 +162,10 @@ export function getSelectedStash(
     ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], state.filter))
     : all
   if (visible.length === 0) return undefined
+  if (state.selectedStashId) {
+    const byId = visible.find((s) => s.ref === state.selectedStashId)
+    if (byId) return byId
+  }
   const index = Math.min(state.selectedStashIndex, visible.length - 1)
   return visible[index]
 }


### PR DESCRIPTION
## Summary

Two coupled steps of the #1452 selection-model migration, landed together since splitting them would leave an awkward intermediate state (a field that's written but neither trusted nor kept consistent):

**1. Dual-write.** Adds `selectedBranchId` / `selectedTagId` / `selectedStashId` to `LogInkState`, written alongside the legacy index by the `moveBranch` / `moveTag` / `moveStash` reducer cases. The reducer has no access to `LogInkContext`, so the id is resolved at the **dispatch site** in `inkInput.ts` (`getLogInkInputEvents`) via a new `resolveMoveTargetId` helper, fed by `branchIds` / `tagIds` / `stashIds` — the sorted+filtered id lists in render order, threaded through `LogInkInputContext` from `useInputHandler`'s already-memoized filtered lists.

**2. Flip.** `getSelectedBranch` / `getSelectedTag` / `getSelectedStash` (in `selection.ts`) now resolve by id first when it's set and still present in the current list, falling back to the index otherwise. This is what keeps an action's target following the same logical item across a background context refresh that reorders the list, instead of silently retargeting to whatever now sits at that numeric position.

To keep the id mirror from ever going stale relative to an intentional index reset, every *other* reducer case that writes these three index fields now also clears (or, where the target id is already known — `navigateOpenDiffForStash`'s `action.ref` — precisely sets) the mirror in the same case: `resetBranchSelection`, `cycleBranchSort` / `cycleTagSort`, the filter-rectification path (`withFilter`), repo-frame push/pop, and `navigateOpenDiffForStash`. This guarantees the id and index are never allowed to silently disagree.

**Not changed:** rendering (row highlighting, scroll position) still reads the raw index fields directly and is unaffected — this only changes what the selectors resolve to for the action-target consumers already migrated in prior PRs (`useYankActions` #1552, `useHistoryCursorSync` #1553, `resolvePendingItemAction`/`useWorkflowAction` #1548-#1550). Also deliberately does **not** thread the id fields through the repo-frame `parentReturn` capture/restore — since nothing outside the selectors reads them, a cleared mirror right after push/pop is harmless (falls back to the correctly-restored index). Full lifecycle wiring there, and migrating the remaining raw-index read sites (rendering/cursor position), is out of scope for #1452 — that's the "remove legacy fields" final phase, which requires those sites to move to a derived-index selector first.

Per [specs/TODO_0.81.0.md](specs/TODO_0.81.0.md).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files (one pre-existing-pattern `exhaustive-deps` warning in `inkInput.ts`'s dispatch sites, consistent with warnings already tolerated elsewhere)
- [x] `jest` full suite: 333 suites passed (2 skipped, pre-existing), 16 new tests added across `inkViewModel.test.ts`, `inkInput.test.ts`, and `selection.test.ts` — covering the dual-write itself, the id-first selector resolution (including the deleted/filtered-out fallback case), and every non-move write site clearing/setting the mirror correctly (including the repo-frame push/pop boundary)
- [x] `rollup` build succeeds, no schema.json drift
- [x] Existing `toEqual` assertions for `moveBranch`/`moveTag`/`moveStash` across the test suite still pass unchanged — Jest's `toEqual` treats an `id: undefined` payload as equivalent to an absent key