### PR TITLE
refactor(workstation): migrate describeConfirmationTarget commit resolution to a selector

### DIFF
--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -32,8 +32,9 @@ import {
     getLogInkViewKeyBindings,
 } from '../../workstation/runtime/inkKeymap'
 import type { LogInkChoicePrompt, LogInkState } from '../../workstation/runtime/inkViewModel'
-import { filterThemePresets, getSelectedInkCommit } from '../../workstation/runtime/inkViewModel'
+import { filterThemePresets } from '../../workstation/runtime/inkViewModel'
 import { getLogInkWorkflowActionById } from '../../workstation/runtime/inkWorkflows'
+import { getSelectedCommitTarget } from '../../workstation/runtime/selection'
 import { resolvePendingItemAction } from './hooks/useWorkflowAction'
 import type { LogInkContext } from './types'
 import type { LogInkComponents } from './types'
@@ -91,27 +92,18 @@ export function renderInputPromptPanel(
 }
 
 /**
- * Confirmable workflow ids whose target is the cursored HISTORY commit.
- * Everything list-shaped (branch/tag/stash/worktree deletes and
- * checkouts) resolves through `resolvePendingItemAction` — the same
- * sorted+filtered resolver the runner and row spinners use, so the name
- * shown is exactly the item that will be acted on.
- */
-const COMMIT_TARGET_CONFIRMATION_IDS = new Set([
-  'cherry-pick-commit',
-  'revert-commit',
-  'interactive-rebase',
-  'reset-to-commit',
-  'fixup-into-commit',
-  'autosquash-rebase',
-])
-
-/**
  * Human line naming the item a pending confirmation will act on, or
  * undefined when the workflow has no resolvable single target. Shown in
  * the confirm overlay so the user never confirms blind — several
  * destructive keys (D / T / X / W) reach the confirm from views where
  * the target list isn't even on screen.
+ *
+ * Everything list-shaped (branch/tag/stash/worktree deletes and
+ * checkouts) resolves through `resolvePendingItemAction` — the same
+ * sorted+filtered resolver the runner and row spinners use. The
+ * commit-target workflows (cherry-pick, revert, rebase, etc.) resolve
+ * through `getSelectedCommitTarget` (#1452), the commit counterpart of
+ * the id-based selection selectors.
  */
 export function describeConfirmationTarget(
   state: LogInkState,
@@ -123,11 +115,9 @@ export function describeConfirmationTarget(
   if (item) {
     return `${item.kind}: ${item.id}`
   }
-  if (COMMIT_TARGET_CONFIRMATION_IDS.has(id)) {
-    const commit = getSelectedInkCommit(state)
-    if (commit) {
-      return `commit ${commit.shortHash}: ${commit.message}`
-    }
+  const commit = getSelectedCommitTarget(id, state)
+  if (commit) {
+    return `commit ${commit.shortHash}: ${commit.message}`
   }
   return undefined
 }

--- a/src/workstation/runtime/selection.test.ts
+++ b/src/workstation/runtime/selection.test.ts
@@ -7,7 +7,7 @@
  */
 import { createLogInkState } from './inkViewModel'
 import type { LogInkContext } from './types'
-import { getSelectedBranchId, getSelectedTagId, getSelectedStashId, getSelectedWorktree } from './selection'
+import { getSelectedBranchId, getSelectedTagId, getSelectedStashId, getSelectedWorktree, getSelectedCommitTarget } from './selection'
 
 function makeBranch(shortName: string, date = '2026-01-01') {
   return {
@@ -198,6 +198,28 @@ describe('selection selectors (#1452)', () => {
       const state = { ...createLogInkState([]), selectedWorktreeListIndex: 0 }
       const emptyCtx = { worktreeList: { worktrees: [] } } as unknown as LogInkContext
       expect(getSelectedWorktree(state, emptyCtx)).toBeUndefined()
+    })
+  })
+
+  describe('getSelectedCommitTarget', () => {
+    const rows = [{
+      type: 'commit' as const, graph: '*', shortHash: 'abc1234', hash: 'abc1234'.padEnd(12, '0'),
+      parents: [], date: '2026-05-01', author: 'Coco', refs: [], message: 'fix: the thing',
+    }]
+
+    it('returns the cursored commit for a commit-target confirmation id', () => {
+      const state = createLogInkState(rows)
+      expect(getSelectedCommitTarget('cherry-pick-commit', state)?.shortHash).toBe('abc1234')
+    })
+
+    it('returns undefined for a non-commit-target confirmation id', () => {
+      const state = createLogInkState(rows)
+      expect(getSelectedCommitTarget('delete-branch', state)).toBeUndefined()
+    })
+
+    it('returns undefined when id is undefined', () => {
+      const state = createLogInkState(rows)
+      expect(getSelectedCommitTarget(undefined, state)).toBeUndefined()
     })
   })
 })

--- a/src/workstation/runtime/selection.ts
+++ b/src/workstation/runtime/selection.ts
@@ -28,7 +28,8 @@
  *      rendering / cursor-position reads across the codebase).
  */
 
-import type { LogInkState } from './inkViewModel'
+import type { GitLogCommitRow } from '../../commands/log/data'
+import { getSelectedInkCommit, type LogInkState } from './inkViewModel'
 import type { LogInkContext } from './types'
 import type { BranchRef } from '../../git/branchData'
 import type { GitTagRef } from '../../git/tagData'
@@ -202,4 +203,34 @@ export function getSelectedWorktree(
   }
   if (all.length === 0) return undefined
   return all[Math.min(state.selectedWorktreeListIndex, all.length - 1)]
+}
+
+/**
+ * Confirmable workflow ids whose target is the cursored HISTORY commit,
+ * not a promoted-view list item. Everything list-shaped (branch/tag/
+ * stash/worktree deletes and checkouts) resolves through the selectors
+ * above; this is the commit-target counterpart, used by
+ * `describeConfirmationTarget` (overlays.ts) to name the confirm
+ * target so the user never confirms blind.
+ */
+const COMMIT_TARGET_CONFIRMATION_IDS = new Set([
+  'cherry-pick-commit',
+  'revert-commit',
+  'interactive-rebase',
+  'reset-to-commit',
+  'fixup-into-commit',
+  'autosquash-rebase',
+])
+
+/**
+ * Get the cursored commit when `id` is one of the commit-target
+ * confirmation workflows, or undefined otherwise (either `id` isn't a
+ * commit-target workflow, or no commit is under the cursor).
+ */
+export function getSelectedCommitTarget(
+  id: string | undefined,
+  state: LogInkState,
+): GitLogCommitRow | undefined {
+  if (!id || !COMMIT_TARGET_CONFIRMATION_IDS.has(id)) return undefined
+  return getSelectedInkCommit(state)
 }


### PR DESCRIPTION
## Summary
- Adds `getSelectedCommitTarget(id, state)` to `selection.ts` — the commit-target counterpart to the branch/tag/stash/worktree selectors, wrapping `COMMIT_TARGET_CONFIRMATION_IDS` + the existing `getSelectedInkCommit` (already index-based, just not colocated with the other selectors)
- `overlays.ts`'s `describeConfirmationTarget` now delegates to it instead of inlining the id-set check, matching the pattern already used for the list-shaped targets via `resolvePendingItemAction`

Last nice-to-have from [specs/TODO_0.81.0.md](specs/TODO_0.81.0.md)'s #1452 cleanup list.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [x] `jest` full suite: 333 suites passed (2 skipped, pre-existing), 3 new tests for `getSelectedCommitTarget`
- [x] `rollup` build succeeds, no schema.json drift
- [x] Existing `overlays.test.ts` "confirmation target naming" cases (including the commit case) pass unchanged