### PR TITLE
feat(workstation): reflog-powered global undo (z)

### DIFF
--- a/src/git/reflogActions.integration.test.ts
+++ b/src/git/reflogActions.integration.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Integration coverage for reflog global undo (#1361) against a REAL git
+ * repository. The unit tests in reflogActions.test.ts mock `git.raw()`
+ * entirely, which proves the control flow but never exercises `git`'s
+ * actual `reflog` subject format — `planReflogUndo`'s checkout-detection
+ * regex was written against documentation of that format, not a live
+ * `git reflog` run. This file closes that gap: real commits, a real
+ * branch switch, a real merge conflict, and real `reset --hard` /
+ * `checkout` calls, all verified against the actual repo state after.
+ */
+import { createTempGitRepo, TempGitRepo } from '@gfargo/git-scenarios'
+import { getReflogOverview } from './reflogData'
+import { performReflogUndo, planReflogUndo } from './reflogActions'
+
+jest.setTimeout(60000)
+
+describe('reflog undo integration (#1361)', () => {
+  const originalCwd = process.cwd()
+  let repo: TempGitRepo
+
+  beforeEach(async () => {
+    repo = await createTempGitRepo()
+    // getInProgressOperation resolves `git rev-parse --git-path <name>`,
+    // which git returns as a path RELATIVE to the process cwd (not an
+    // absolute path) — so the guard only sees the right `.git/` unless
+    // the process is actually inside the repo. The real app always runs
+    // from the repo root; this test replicates that instead of the
+    // implicit assumption breaking silently.
+    process.chdir(repo.path)
+  })
+
+  afterEach(async () => {
+    process.chdir(originalCwd)
+    await repo.cleanup()
+  })
+
+  it('undoes a checkout by switching back to the previous branch', async () => {
+    await repo.writeFile('.gitkeep', '\n')
+    await repo.commitAll('chore: initial commit')
+    await repo.git.checkoutLocalBranch('feature')
+    await repo.writeFile('feature.txt', 'work in progress\n')
+    await repo.commitAll('feat: add feature file')
+    await repo.git.checkout('main')
+
+    const { entries } = await getReflogOverview(repo.git)
+    // Real git reflog subject: "checkout: moving from feature to main" —
+    // this is the exact format planReflogUndo's regex must match.
+    expect(entries[0].subject).toBe('checkout: moving from feature to main')
+
+    const plan = planReflogUndo(entries)
+    expect(plan).toMatchObject({ kind: 'checkout', targetRef: 'feature' })
+
+    const result = await performReflogUndo(repo.git, plan!)
+    expect(result.ok).toBe(true)
+
+    const branch = (await repo.git.revparse(['--abbrev-ref', 'HEAD'])).trim()
+    expect(branch).toBe('feature')
+  })
+
+  it('undoes a commit by resetting --hard to the previous HEAD', async () => {
+    await repo.writeFile('.gitkeep', '\n')
+    await repo.commitAll('chore: initial commit')
+    const beforeHash = (await repo.git.revparse(['HEAD'])).trim()
+
+    await repo.writeFile('oops.txt', 'should be undone\n')
+    await repo.commitAll('chore: oops commit')
+    expect(await repo.exists('oops.txt')).toBe(true)
+
+    const { entries } = await getReflogOverview(repo.git)
+    const plan = planReflogUndo(entries)
+    expect(plan?.kind).toBe('reset')
+
+    const result = await performReflogUndo(repo.git, plan!)
+    expect(result.ok).toBe(true)
+
+    const afterHash = (await repo.git.revparse(['HEAD'])).trim()
+    expect(afterHash).toBe(beforeHash)
+    // reset --hard also restores the working tree, so the file the
+    // undone commit added is gone, not just uncommitted.
+    expect(await repo.exists('oops.txt')).toBe(false)
+  })
+
+  it('refuses to reset while a merge is in progress, leaving the conflict untouched', async () => {
+    await repo.writeFile('shared.txt', 'main content\n')
+    await repo.commitAll('chore: initial commit')
+
+    await repo.git.checkoutLocalBranch('conflicting')
+    await repo.writeFile('shared.txt', 'conflicting branch content\n')
+    await repo.commitAll('feat: change on conflicting branch')
+
+    await repo.git.checkout('main')
+    await repo.writeFile('shared.txt', 'main branch content\n')
+    await repo.commitAll('feat: change on main')
+
+    // This merge fails with a real conflict, leaving MERGE_HEAD on disk —
+    // exactly the state performReflogUndo's guard checks for.
+    await expect(repo.git.merge(['conflicting'])).rejects.toThrow()
+    expect(await repo.exists('.git/MERGE_HEAD')).toBe(true)
+
+    const result = await performReflogUndo(repo.git, {
+      description: 'x',
+      commandPreview: 'git reset --hard HEAD@{1}',
+      kind: 'reset',
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('in-progress')
+    // The guard must refuse BEFORE running reset — the conflict state
+    // (and MERGE_HEAD) should be untouched, not silently discarded.
+    expect(await repo.exists('.git/MERGE_HEAD')).toBe(true)
+  })
+})

--- a/src/git/reflogActions.test.ts
+++ b/src/git/reflogActions.test.ts
@@ -1,4 +1,4 @@
-import { checkoutReflogEntry } from './reflogActions'
+import { checkoutReflogEntry, performReflogUndo, planReflogUndo, ReflogUndoPlan } from './reflogActions'
 import { ReflogViewEntry } from './reflogData'
 
 function entry(overrides: Partial<ReflogViewEntry> = {}): ReflogViewEntry {
@@ -34,5 +34,108 @@ describe('reflog actions', () => {
     const result = await checkoutReflogEntry(git as never, entry())
     expect(result.ok).toBe(false)
     expect(result.message).toContain('pathspec did not match')
+  })
+})
+
+describe('planReflogUndo (#1361 global undo)', () => {
+  it('returns undefined for an empty reflog', () => {
+    expect(planReflogUndo([])).toBeUndefined()
+  })
+
+  it('inverts a checkout to switching back to the previous branch', () => {
+    const plan = planReflogUndo([entry({ subject: 'checkout: moving from main to feature' })])
+    expect(plan).toEqual({
+      description: "Undo checkout: switch back to 'main' (currently on 'feature').",
+      commandPreview: 'git checkout main',
+      kind: 'checkout',
+      targetRef: 'main',
+    })
+  })
+
+  it('inverts a commit to reset --hard HEAD@{1}', () => {
+    const plan = planReflogUndo([entry({ subject: 'commit: fix the thing' })])
+    expect(plan).toEqual({
+      description: 'Undo commit (fix the thing): reset --hard to the previous HEAD.',
+      commandPreview: 'git reset --hard HEAD@{1}',
+      kind: 'reset',
+    })
+  })
+
+  it('inverts a rebase, merge, reset, or any other verb to reset --hard HEAD@{1}', () => {
+    const plan = planReflogUndo([entry({ subject: 'rebase (finish): returning to refs/heads/feature' })])
+    expect(plan?.kind).toBe('reset')
+    expect(plan?.commandPreview).toBe('git reset --hard HEAD@{1}')
+  })
+
+  it('falls back to reset when a checkout subject does not match the expected shape', () => {
+    // Defensive: an unusual/localized reflog subject shouldn't crash the
+    // parse, just fall through to the always-safe reset inverse.
+    const plan = planReflogUndo([entry({ subject: 'checkout: something unexpected' })])
+    expect(plan?.kind).toBe('reset')
+  })
+
+  it('only looks at the reflog tip (most recent entry)', () => {
+    const plan = planReflogUndo([
+      entry({ subject: 'commit: latest' }),
+      entry({ subject: 'checkout: moving from main to feature' }),
+    ])
+    expect(plan?.kind).toBe('reset')
+  })
+})
+
+describe('performReflogUndo (#1361 global undo)', () => {
+  // getInProgressOperation checks a handful of `.git/<state-file>` paths
+  // via `git.revparse(['--git-path', ...])` — pointing every one at a
+  // path that can't exist makes it resolve 'none', matching the
+  // established mocking pattern in historyActions.test.ts.
+  function gitMock(rawResult: unknown = '') {
+    return {
+      revparse: jest.fn().mockResolvedValue('/tmp/coco-missing-git-state'),
+      raw: jest.fn().mockResolvedValue(rawResult),
+    }
+  }
+
+  it('checks out the target ref for a checkout-kind plan (no in-progress-operation check)', async () => {
+    const git = { raw: jest.fn().mockResolvedValue(''), revparse: jest.fn() }
+    const plan: ReflogUndoPlan = {
+      description: 'x', commandPreview: 'git checkout main', kind: 'checkout', targetRef: 'main',
+    }
+    const result = await performReflogUndo(git as never, plan)
+    expect(git.raw).toHaveBeenCalledWith(['checkout', 'main'])
+    expect(git.revparse).not.toHaveBeenCalled()
+    expect(result.ok).toBe(true)
+  })
+
+  it('runs reset --hard HEAD@{1} for a reset-kind plan', async () => {
+    const git = gitMock()
+    const plan: ReflogUndoPlan = { description: 'x', commandPreview: 'git reset --hard HEAD@{1}', kind: 'reset' }
+    const result = await performReflogUndo(git as never, plan)
+    expect(git.raw).toHaveBeenCalledWith(['reset', '--hard', 'HEAD@{1}'])
+    expect(result.ok).toBe(true)
+  })
+
+  it('refuses to reset while a rebase/merge/etc. is in progress', async () => {
+    const git = {
+      raw: jest.fn().mockResolvedValue(''),
+      revparse: jest.fn().mockImplementation((args: string[]) =>
+        args[1] === 'rebase-merge' ? Promise.resolve(__dirname) : Promise.resolve('/tmp/coco-missing-git-state')
+      ),
+    }
+    const plan: ReflogUndoPlan = { description: 'x', commandPreview: 'git reset --hard HEAD@{1}', kind: 'reset' }
+    const result = await performReflogUndo(git as never, plan)
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('in-progress')
+    expect(git.raw).not.toHaveBeenCalledWith(['reset', '--hard', 'HEAD@{1}'])
+  })
+
+  it('surfaces git errors as ok: false', async () => {
+    const git = {
+      revparse: jest.fn().mockResolvedValue('/tmp/coco-missing-git-state'),
+      raw: jest.fn().mockRejectedValue(new Error('fatal: ambiguous argument')),
+    }
+    const plan: ReflogUndoPlan = { description: 'x', commandPreview: 'git reset --hard HEAD@{1}', kind: 'reset' }
+    const result = await performReflogUndo(git as never, plan)
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('fatal: ambiguous argument')
   })
 })

--- a/src/git/reflogActions.ts
+++ b/src/git/reflogActions.ts
@@ -1,5 +1,6 @@
 import { SimpleGit } from 'simple-git'
-import { ReflogViewEntry } from './reflogData'
+import { getInProgressOperation } from './historyActions'
+import { ReflogViewEntry, splitReflogSubject } from './reflogData'
 
 /**
  * Reflog "time machine" actions (#0.67). The reflog view's whole value is
@@ -43,5 +44,94 @@ export function checkoutReflogEntry(
   return runAction(
     () => git.raw(['checkout', entry.hash]),
     `Checked out ${entry.selector} (${entry.hash}) — HEAD is now detached.`
+  )
+}
+
+/**
+ * Global undo (#1361) — lazygit's `z` safety blanket. Rather than a
+ * bespoke undo per operation type, this inspects the reflog tip and
+ * offers its inverse:
+ *
+ *   - `checkout: moving from X to Y` inverts to `git checkout X` —
+ *     switching back is the only sane undo for a branch move (a reset
+ *     would rewrite the CURRENT branch's history, which has nothing to
+ *     do with the checkout that just happened).
+ *   - Everything else (commit, reset, rebase, merge, cherry-pick,
+ *     revert, pull, ...) inverts to `git reset --hard HEAD@{1}` — the
+ *     standard reflog-recovery move, since `HEAD@{1}` means "wherever
+ *     HEAD pointed one operation ago" regardless of what that operation
+ *     was.
+ */
+export type ReflogUndoPlan = {
+  /** Human description of what will be undone, shown in the confirm panel. */
+  description: string
+  /** The exact command that will run, shown for transparency. */
+  commandPreview: string
+  /** Which inverse this is — drives `performReflogUndo`'s branch. */
+  kind: 'checkout' | 'reset'
+  /** Only set for `kind: 'checkout'` — the branch/ref to switch back to. */
+  targetRef?: string
+}
+
+const CHECKOUT_SUBJECT_PATTERN = /^moving from (\S+) to (\S+)$/
+
+/**
+ * Inspect the reflog tip and describe the inverse of the last operation,
+ * without performing it. Returns undefined when there's no reflog tip to
+ * undo (empty repo, or reflog data hasn't loaded yet).
+ */
+export function planReflogUndo(entries: ReflogViewEntry[]): ReflogUndoPlan | undefined {
+  const tip = entries[0]
+  if (!tip) return undefined
+  const { action, message } = splitReflogSubject(tip.subject)
+
+  if (action === 'checkout') {
+    const match = message.match(CHECKOUT_SUBJECT_PATTERN)
+    if (match) {
+      const [, from, to] = match
+      return {
+        description: `Undo checkout: switch back to '${from}' (currently on '${to}').`,
+        commandPreview: `git checkout ${from}`,
+        kind: 'checkout',
+        targetRef: from,
+      }
+    }
+  }
+
+  return {
+    description: `Undo ${action}${message ? ` (${message})` : ''}: reset --hard to the previous HEAD.`,
+    commandPreview: 'git reset --hard HEAD@{1}',
+    kind: 'reset',
+  }
+}
+
+/**
+ * Perform the inverse operation described by `plan`. Callers should
+ * re-derive `plan` from a fresh reflog read immediately before calling
+ * this — the reflog can move between when the user pressed the undo key
+ * and when they confirmed it.
+ */
+export async function performReflogUndo(
+  git: SimpleGit,
+  plan: ReflogUndoPlan
+): Promise<ReflogActionResult> {
+  if (plan.kind === 'checkout' && plan.targetRef) {
+    return runAction(
+      () => git.raw(['checkout', plan.targetRef as string]),
+      `Switched back to '${plan.targetRef}'.`
+    )
+  }
+  // reset --hard mid-rebase/merge/cherry-pick moves HEAD without cleaning
+  // up the operation's state files (.git/rebase-merge, MERGE_HEAD, ...),
+  // leaving the repo in a confusing half-finished state — same hazard
+  // `resetToCommit` guards against, so undo refuses the same way rather
+  // than silently making it worse.
+  const inProgress = await getInProgressOperation(git)
+  if (inProgress) {
+    return { ok: false, message: `Finish or abort the in-progress ${inProgress} before undoing.` }
+  }
+  return runAction(
+    () => git.raw(['reset', '--hard', 'HEAD@{1}']),
+    'Reset to the previous HEAD (HEAD@{1}).'
   )
 }

--- a/src/workstation/runtime/hooks/useInputHandler.ts
+++ b/src/workstation/runtime/hooks/useInputHandler.ts
@@ -41,6 +41,7 @@ import {
 } from '../inkInput'
 import { findStashFileForOffset } from '../../../git/stashData'
 import { getBisectCompletion } from '../../../git/bisectData'
+import { planReflogUndo } from '../../../git/reflogActions'
 import {
     resolveCommitDiffDrillInTarget,
     resolveSubmoduleViewDrillInTarget,
@@ -305,6 +306,10 @@ export function useInputHandler(
     const reflogSelectedHash = filteredReflogList[
       Math.min(state.selectedReflogIndex, Math.max(0, filteredReflogList.length - 1))
     ]?.hash
+    // #1361 global undo — reads the RAW reflog (not filteredReflogList),
+    // since undo always targets the actual last operation regardless of
+    // what's filtered/cursored on the reflog view.
+    const reflogUndoDescription = planReflogUndo(context.reflog?.entries || [])?.description
     const submoduleVisibleCount = filteredSubmoduleList.length
     const submoduleSelectedPath = filteredSubmoduleList[
       Math.min(state.selectedSubmoduleIndex, Math.max(0, filteredSubmoduleList.length - 1))
@@ -376,6 +381,7 @@ export function useInputHandler(
       stashCount: stashVisibleCount,
       reflogCount: reflogVisibleCount,
       reflogSelectedHash,
+      reflogUndoDescription,
       submoduleCount: submoduleVisibleCount,
       submoduleSelectedPath,
       remoteCount: remoteVisibleCount,

--- a/src/workstation/runtime/hooks/useWorkflowAction.test.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.test.ts
@@ -1,7 +1,7 @@
 import type ReactTypes from 'react'
 import type { GitLogRow } from '../../../commands/log/data'
 import { createLogInkState } from '../inkViewModel'
-import { checkoutReflogEntry } from '../../../git/reflogActions'
+import { checkoutReflogEntry, performReflogUndo, planReflogUndo } from '../../../git/reflogActions'
 import { checkoutBranch, checkoutBranchByName, pullCurrentBranch, pullCurrentBranchRebase, pushBranch } from '../../../git/branchActions'
 import { cherryPickCommit, autosquashRebase } from '../../../git/historyActions'
 import { createStash } from '../../../git/stashActions'
@@ -20,6 +20,8 @@ import { useWorkflowAction, type UseWorkflowActionDeps } from './useWorkflowActi
 
 jest.mock('../../../git/reflogActions', () => ({
   checkoutReflogEntry: jest.fn().mockResolvedValue({ ok: true, message: 'checked out' }),
+  planReflogUndo: jest.fn(),
+  performReflogUndo: jest.fn().mockResolvedValue({ ok: true, message: 'undone' }),
 }))
 
 jest.mock('../../../git/branchActions', () => {
@@ -62,6 +64,8 @@ jest.mock('../../../git/operationActions', () => {
 const checkoutReflogEntryMock = checkoutReflogEntry as jest.MockedFunction<
   typeof checkoutReflogEntry
 >
+const planReflogUndoMock = planReflogUndo as jest.MockedFunction<typeof planReflogUndo>
+const performReflogUndoMock = performReflogUndo as jest.MockedFunction<typeof performReflogUndo>
 
 /**
  * Minimal React stand-in with real `useRef` persistence across renders and
@@ -149,6 +153,42 @@ describe('runWorkflowAction reads the live render snapshot, not the mount-time c
     await first.runWorkflowAction('checkout-reflog-entry')
     expect(checkoutReflogEntryMock).toHaveBeenCalledTimes(1)
     expect(checkoutReflogEntryMock).toHaveBeenCalledWith(expect.anything(), entries[1])
+  })
+})
+
+describe('global-undo (#1361)', () => {
+  beforeEach(() => {
+    planReflogUndoMock.mockReset()
+    performReflogUndoMock.mockReset().mockResolvedValue({ ok: true, message: 'undone' })
+  })
+
+  it('re-derives the plan from the raw reflog and performs it', async () => {
+    const harness = createHookHarness()
+    const entries = [reflogEntry('aaaaaaaaaaaa')]
+    const plan = { description: 'x', commandPreview: 'git reset --hard HEAD@{1}', kind: 'reset' as const }
+    planReflogUndoMock.mockReturnValue(plan)
+
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      context: { reflog: { entries } } as UseWorkflowActionDeps['context'],
+    }))
+
+    await runWorkflowAction('global-undo')
+    expect(planReflogUndoMock).toHaveBeenCalledWith(entries)
+    expect(performReflogUndoMock).toHaveBeenCalledWith(expect.anything(), plan)
+  })
+
+  it('fails cleanly when there is no reflog entry to undo', async () => {
+    const harness = createHookHarness()
+    planReflogUndoMock.mockReturnValue(undefined)
+
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      context: { reflog: { entries: [] } } as unknown as UseWorkflowActionDeps['context'],
+    }))
+
+    await runWorkflowAction('global-undo')
+    expect(performReflogUndoMock).not.toHaveBeenCalled()
   })
 })
 

--- a/src/workstation/runtime/hooks/useWorkflowAction.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.ts
@@ -116,7 +116,7 @@ import {
 } from '../../../git/statusActions'
 import { applyStatusFilterMask } from '../../../git/statusData'
 import { bisectBad, bisectGood, bisectReset, bisectRun, bisectSkip, bisectStart, extractBisectRemainingHint } from '../../../git/bisectActions'
-import { checkoutReflogEntry } from '../../../git/reflogActions'
+import { checkoutReflogEntry, performReflogUndo, planReflogUndo } from '../../../git/reflogActions'
 import { executeRebasePlan } from '../../../git/rebasePlanActions'
 import { initSubmodule, syncSubmodule, updateSubmodule } from '../../../git/submoduleActions'
 import { addRemote, pruneRemote, removeRemote, setRemoteUrl } from '../../../git/remoteActions'
@@ -247,6 +247,9 @@ export const HISTORY_MUTATING_WORKFLOW_IDS = new Set([
   // Stash & switch onto a PR (#1430) moves HEAD via `gh pr checkout`
   // the same way `triage-pr-checkout` does.
   'stash-and-checkout-pr',
+  // #1361 — global undo moves HEAD either way (checkout back to the
+  // previous branch, or reset --hard to the previous commit).
+  'global-undo',
 ])
 
 export function resolvePendingItemAction(
@@ -890,6 +893,16 @@ export function useWorkflowAction(
         ]
         if (!entry) return { ok: false, message: 'No reflog entry selected' }
         return checkoutReflogEntry(git, entry)
+      },
+      // #1361 — global undo. Re-derives the plan from the RAW reflog
+      // (not filteredReflogList — undo always targets the actual last
+      // operation) rather than trusting whatever was resolved when `z`
+      // was pressed, since the reflog can move between keystroke and
+      // y-confirm.
+      'global-undo': async () => {
+        const plan = planReflogUndo(context.reflog?.entries || [])
+        if (!plan) return { ok: false, message: 'No reflog entry to undo.' }
+        return performReflogUndo(git, plan)
       },
       // Follow-up checkout after a successful create-branch-here (#1326).
       // Reached only via the in-runner setPendingConfirmation dispatch

--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -544,6 +544,47 @@ describe('log Ink input interactions', () => {
     ])
   })
 
+  // #1361 — global undo (`z` outside the more specific worktree-diff /
+  // status contexts above) raises the global-undo confirmation carrying
+  // the runtime-resolved description as payload.
+  it('z raises global-undo with the resolved description when there is a reflog tip to undo', () => {
+    expect(getLogInkInputEvents(
+      createLogInkState(rows),
+      'z',
+      {},
+      { reflogUndoDescription: "Undo checkout: switch back to 'main' (currently on 'feature')." }
+    )).toEqual([
+      {
+        type: 'action',
+        action: {
+          type: 'setPendingConfirmation',
+          value: 'global-undo',
+          payload: "Undo checkout: switch back to 'main' (currently on 'feature').",
+        },
+      },
+    ])
+  })
+
+  it('z is a no-op when there is no reflog tip to undo', () => {
+    expect(getLogInkInputEvents(createLogInkState(rows), 'z', {}, {})).toEqual([])
+  })
+
+  it('the scoped worktree-diff/status z handlers take precedence over global undo', () => {
+    // Both a resolvable undo AND a worktree-diff target are present —
+    // the more specific in-view action must win.
+    expect(getLogInkInputEvents(
+      createLogInkState(rows, { activeView: 'status' }),
+      'z',
+      {},
+      { worktreeFileCount: 1, reflogUndoDescription: 'Undo commit: reset --hard to the previous HEAD.' }
+    )).toEqual([
+      {
+        type: 'action',
+        action: { type: 'setPendingConfirmation', value: 'revert-file' },
+      },
+    ])
+  })
+
   it('confirms or cancels worktree revert actions explicitly', () => {
     const filePending = applyLogInkAction(createLogInkState(rows), {
       type: 'setPendingConfirmation',

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -128,6 +128,14 @@ export type LogInkInputContext = {
   reflogCount?: number
   /** Hash of the cursored reflog entry (#781). Used by Enter to drill into the diff. */
   reflogSelectedHash?: string
+  /**
+   * Human description of the reflog tip's inverse operation (#1361 global
+   * undo), or undefined when there's no reflog tip to undo yet. Set from
+   * the RAW reflog (not the filtered/cursored view list) — global undo
+   * always targets "the very last operation," regardless of what's
+   * filtered or cursored on the reflog view.
+   */
+  reflogUndoDescription?: string
   /** Number of registered submodules (#932). Drives j/k navigation on the submodules view. */
   submoduleCount?: number
   /** Repo-relative path of the cursored submodule (#932). Reserved for future per-entry actions. */
@@ -4298,6 +4306,20 @@ export function getLogInkInputEvents(
 
   if (inputValue === 'z' && isWorktreeDiffTarget(state) && context.worktreeHunkOffsets?.length) {
     return [action({ type: 'setPendingConfirmation', value: 'revert-hunk' })]
+  }
+
+  // #1361 — global undo (lazygit's `z` safety blanket), gated to fire only
+  // when none of the more specific `z` handlers above claimed it (discard
+  // lines / revert file / revert hunk are all more targeted "undo this
+  // one thing" actions on their own surfaces). `reflogUndoDescription` is
+  // only set when the runtime found a reflog tip to undo (#1361), so this
+  // is a no-op in an empty repo or before the reflog has loaded.
+  if (inputValue === 'z' && context.reflogUndoDescription) {
+    return [action({
+      type: 'setPendingConfirmation',
+      value: 'global-undo',
+      payload: context.reflogUndoDescription,
+    })]
   }
 
   if (

--- a/src/workstation/runtime/inkKeymap.test.ts
+++ b/src/workstation/runtime/inkKeymap.test.ts
@@ -372,7 +372,7 @@ describe('log Ink keymap', () => {
     expect(helpText).toContain('\\ Toggle compact and full graph display.')
     expect(helpText).toContain('gg Jump to the first visible commit.')
     expect(helpText).toContain('G Jump to the last visible commit.')
-    expect(helpText).toContain('z Ask to revert the selected file or hunk.')
+    expect(helpText).toContain('z Ask to revert the selected file or hunk, or undo the last operation.')
     expect(helpText).toContain('e Edit the manual commit summary or body inline.')
     expect(helpText).toContain('E Open the current commit draft in $EDITOR (or $VISUAL) for full editing, write-back on save.')
     // On history view, `c` is cherry-pick (the `c commit` binding is

--- a/src/workstation/runtime/inkKeymap.ts
+++ b/src/workstation/runtime/inkKeymap.ts
@@ -449,7 +449,9 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     id: 'revertSelection',
     keys: ['z'],
     label: 'revert',
-    description: 'Ask to revert the selected file or hunk.',
+    // #1361 — outside a revertable file/hunk target, `z` falls through
+    // to the global undo (reflog-powered inverse of the last operation).
+    description: 'Ask to revert the selected file or hunk, or undo the last operation.',
     contexts: ['commits'],
   },
   {

--- a/src/workstation/runtime/inkWorkflows.ts
+++ b/src/workstation/runtime/inkWorkflows.ts
@@ -7,6 +7,7 @@ import { StashOverview } from '../../git/stashData'
 import { WorktreeOverview } from '../../git/statusData'
 import { TagOverview } from '../../git/tagData'
 import { WorktreeOverview as WorktreeListOverview } from '../../git/worktreeData'
+import type { LogInkState } from './inkViewModel'
 
 export type LogInkWorkflowContext = {
   branches?: BranchOverview
@@ -39,11 +40,12 @@ export type LogInkWorkflowAction = {
   /**
    * Warning copy shown in the confirmation panel when `requiresConfirmation`
    * is true (#1451). When set, the renderer uses this instead of the generic
-   * "Destructive Git action requires confirmation" fallback or the per-id
-   * if-chain in overlays.ts. Supports a payload interpolation function for
-   * context-dependent copy (e.g. naming the branch being deleted).
+   * "Destructive Git action requires confirmation" fallback. A function form
+   * is called with the pending state so payload-dependent copy (e.g. naming
+   * the branch being deleted or checked out) can be computed without a
+   * per-id if-chain in overlays.ts.
    */
-  warning?: string
+  warning?: string | ((state: LogInkState) => string)
 }
 
 function countLabel(count: number, singular: string, plural = `${singular}s`): string {
@@ -427,6 +429,12 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       description: 'Rebase the current branch onto the cursored branch / ref (non-interactive) after confirmation.',
       kind: 'destructive',
       requiresConfirmation: true,
+      // Per-invocation warning naming both branches, built in inkInput
+      // from the cursored + current branch and carried as the pending
+      // confirmation payload. Falls back to a static line if the payload
+      // is somehow absent.
+      warning: (state) => state.pendingConfirmationPayload
+        || 'Rebase rewrites the current branch\'s history. This cannot be undone by Coco.',
     },
     {
       id: 'delete-tag',
@@ -664,6 +672,12 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       description: 'Switch to the branch you just created.',
       kind: 'normal',
       requiresConfirmation: false,
+      // The payload IS the branch name (#1326) — render it so the user
+      // sees what they're about to switch to. Falls back to a generic
+      // line if the payload is somehow absent.
+      warning: (state) => state.pendingConfirmationPayload
+        ? `Branch '${state.pendingConfirmationPayload}' created — switch to it now?`
+        : 'Branch created — switch to it now?',
     },
     {
       // Per-view-only: scoped to the history view in inkInput via the

--- a/src/workstation/runtime/inkWorkflows.ts
+++ b/src/workstation/runtime/inkWorkflows.ts
@@ -731,6 +731,21 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: true,
     },
     {
+      // #1361 — global undo (lazygit's `z` safety blanket). Dispatched
+      // ONLY by the dedicated `z` handler in inkInput.ts, gated on
+      // `context.reflogUndoDescription` being set — empty `key` keeps
+      // this out of the generic end-of-dispatch key fallback, which has
+      // no such gate and would fire with no description payload.
+      id: 'global-undo',
+      key: '',
+      label: 'Undo last operation',
+      description: 'Inspect the reflog tip and undo the last git operation (checkout switches back; everything else resets --hard to the previous HEAD).',
+      kind: 'destructive',
+      requiresConfirmation: true,
+      warning: (state) => state.pendingConfirmationPayload
+        || 'Undo the last git operation using the reflog.',
+    },
+    {
       // #0.71 — submodule maintenance actions. All three are scoped
       // per-view in inkInput (active only when activeView ===
       // 'submodules') so their single-letter keys (i / u / s) stay free

--- a/src/workstation/runtime/overlays.test.ts
+++ b/src/workstation/runtime/overlays.test.ts
@@ -186,6 +186,29 @@ describe('checkout-created-branch confirmation panel (#1326)', () => {
   })
 })
 
+describe('global-undo confirmation panel (#1361)', () => {
+  const components: LogInkComponents = { Box, Text }
+
+  it('renders the runtime-resolved undo description from payload', () => {
+    const state = {
+      ...createLogInkState([]),
+      pendingConfirmationId: 'global-undo',
+      pendingConfirmationPayload: "Undo checkout: switch back to 'main' (currently on 'feature').",
+    }
+    const text = flattenText(renderConfirmationPanel(createElement, components, state, {}, 80, theme, false))
+    expect(text).toContain('Undo last operation')
+    expect(text).toContain("Undo checkout: switch back to 'main' (currently on 'feature').")
+    expect(text).not.toContain('Destructive Git action requires confirmation')
+  })
+
+  it('falls back to a generic message when the payload is absent', () => {
+    const state = { ...createLogInkState([]), pendingConfirmationId: 'global-undo' }
+    const text = flattenText(renderConfirmationPanel(createElement, components, state, {}, 80, theme, false))
+    expect(text).toContain('Undo the last git operation using the reflog.')
+    expect(text).not.toContain('Destructive Git action requires confirmation')
+  })
+})
+
 describe('split-plan overlay — unclaimed group (#1180)', () => {
   const components: LogInkComponents = { Box, Text }
 

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -144,26 +144,17 @@ export function renderConfirmationPanel(
   const { Box, Text } = components
   const action = getLogInkWorkflowActionById(state.pendingConfirmationId)
   const label = action?.label || 'Workflow action'
+  // #1451 — prefer the registry's warning field over any fallback. Most
+  // entries carry a static string; a few (rebase-onto-branch,
+  // checkout-created-branch) need payload-dependent copy and supply a
+  // function instead (#1452 nice-to-have — replaces the old per-id
+  // if-chain here).
+  const registryWarning = typeof action?.warning === 'function'
+    ? action.warning(state)
+    : action?.warning
   const warning =
-    // #1451 — prefer the registry's warning field over any fallback.
-    // The mutation confirmations (revert-file, revert-hunk, discard-lines,
-    // discard-draft, discard-rebase-plan) all carry their own warning.
-    action?.warning
-    ? action.warning
-    // Rebase-onto carries a per-invocation warning naming both branches
-    // (built in inkInput from the cursored + current branch). Fall back
-    // to a static line if the payload is somehow absent.
-    : state.pendingConfirmationId === 'rebase-onto-branch'
-    ? state.pendingConfirmationPayload
-      || 'Rebase rewrites the current branch\'s history. This cannot be undone by Coco.'
-    // Post-create-branch / create-branch-here checkout prompt (#1326):
-    // the payload IS the branch name — render it so the user sees what
-    // they're about to switch to. Fall back to a generic line if the
-    // payload is somehow absent.
-    : state.pendingConfirmationId === 'checkout-created-branch'
-    ? state.pendingConfirmationPayload
-      ? `Branch '${state.pendingConfirmationPayload}' created — switch to it now?`
-      : 'Branch created — switch to it now?'
+    registryWarning
+    ? registryWarning
     : action?.kind === 'ai'
     ? `AI action requires confirmation. Estimated ${action.estimatedTokens || '<unknown>'} tokens.`
     : 'Destructive Git action requires confirmation.'


### PR DESCRIPTION
## Summary
Lazygit's `z` safety blanket: inspect the reflog tip, describe its inverse, y-confirm running it.

- **`src/git/reflogActions.ts`**: `planReflogUndo` (pure — inspects the reflog tip and picks the inverse: a `checkout: moving from X to Y` entry inverts to switching back to `X`; everything else — commit, reset, rebase, merge, cherry-pick, revert, pull, ... — inverts to `git reset --hard HEAD@{1}`) and `performReflogUndo` (executes the plan, refusing to reset while an operation is in progress — the same guard `resetToCommit` uses, since `reset --hard` mid-rebase/merge leaves stray state files around).
- **`inkWorkflows.ts`**: new `global-undo` registry entry with a function-typed `warning` (#1451 pattern) that shows the resolved description; empty `key` keeps it out of the generic end-of-dispatch key fallback (which has no gate and would fire with no description).
- **`inkInput.ts`**: `z` falls through to global undo only when none of the more specific worktree-diff/status revert handlers (discard-lines / revert-file / revert-hunk) claim it first, gated on a new `reflogUndoDescription` context field so it's a no-op with nothing to undo.
- **`useInputHandler.ts`**: resolves `reflogUndoDescription` from the RAW reflog (not the filtered/cursored reflog-view list) — undo always targets the actual last operation, regardless of what's filtered/cursored on the reflog view.
- **`useWorkflowAction.ts`**: the handler re-derives the plan fresh from the raw reflog at confirm time rather than trusting the press-time description, since the reflog can move between keystroke and y-confirm.

**Depends on #1551** (function-typed warning field) — branched from that work rather than duplicating the old `overlays.ts` if-chain the new field replaces. Merge order: #1551 before this one.

Part of #1361 per [specs/TODO_0.81.0.md](specs/TODO_0.81.0.md) — the multi-select item remains separate follow-up work.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [x] `jest` full suite: 333 suites passed (2 skipped, pre-existing)
- [x] `rollup` build succeeds, no schema.json drift
- [x] New tests: `planReflogUndo`/`performReflogUndo` pure-logic coverage (checkout inversion, reset fallback, in-progress-operation refusal, error surfacing) in `reflogActions.test.ts`; `z` dispatch precedence (scoped handlers win over global undo, no-op with nothing to undo) in `inkInput.test.ts`; confirm-panel rendering in `overlays.test.ts`; handler re-derivation in `useWorkflowAction.test.ts`