### PR TITLE
feat(workstation): multi-select marks + range select, batch delete branches

### DIFF
--- a/src/git/branchActions.test.ts
+++ b/src/git/branchActions.test.ts
@@ -3,6 +3,7 @@ import {
   checkoutBranchByName,
   createBranch,
   deleteBranch,
+  deleteBranches,
   isBranchCheckedOutElsewhereError,
   isBranchNotFullyMergedError,
   isDirtyWorktreeCheckoutError,
@@ -219,6 +220,63 @@ describe('log branch actions', () => {
       const result = await deleteBranch(git as never, localBranch())
       expect(result.ok).toBe(false)
       expect(isBranchNotFullyMergedError(result.message)).toBe(true)
+    })
+  })
+
+  // #1361 — batch delete for multi-select.
+  describe('deleteBranches', () => {
+    it('deletes every branch and summarizes on full success', async () => {
+      const git = { raw: jest.fn().mockResolvedValue('') }
+      const result = await deleteBranches(git as never, [
+        localBranch({ shortName: 'feat/a' }),
+        localBranch({ shortName: 'feat/b' }),
+      ])
+      expect(result).toEqual({ ok: true, message: 'Deleted 2 branches: feat/a, feat/b' })
+      expect(git.raw).toHaveBeenNthCalledWith(1, ['branch', '-d', 'feat/a'])
+      expect(git.raw).toHaveBeenNthCalledWith(2, ['branch', '-d', 'feat/b'])
+    })
+
+    it('continues past a refusal and reports the raw per-branch failure in details', async () => {
+      const git = {
+        raw: jest.fn()
+          .mockRejectedValueOnce(new Error("error: the branch 'feat/a' is not fully merged."))
+          .mockResolvedValueOnce(''),
+      }
+      const result = await deleteBranches(git as never, [
+        localBranch({ shortName: 'feat/a' }),
+        localBranch({ shortName: 'feat/b' }),
+      ])
+      expect(result.ok).toBe(false)
+      expect(result.message).toBe('Deleted 1 of 2 branches — 1 refused')
+      // The raw git wording must survive into details so the caller's
+      // force-delete escalation detection keeps matching.
+      expect(isBranchNotFullyMergedError(result.details?.join('\n'))).toBe(true)
+      // Refusal did NOT stop the batch — the second delete still ran.
+      expect(git.raw).toHaveBeenCalledTimes(2)
+    })
+
+    it('a batch of one delegates to the single-branch behavior verbatim', async () => {
+      const git = { raw: jest.fn().mockResolvedValue('') }
+      const result = await deleteBranches(git as never, [localBranch()])
+      expect(result).toEqual({ ok: true, message: 'Deleted branch feature/test' })
+    })
+
+    it('refuses an empty batch without touching git', async () => {
+      const git = { raw: jest.fn() }
+      const result = await deleteBranches(git as never, [])
+      expect(result.ok).toBe(false)
+      expect(git.raw).not.toHaveBeenCalled()
+    })
+
+    it('per-branch guards (current branch) feed the summary instead of aborting the batch', async () => {
+      const git = { raw: jest.fn().mockResolvedValue('') }
+      const result = await deleteBranches(git as never, [
+        localBranch({ shortName: 'main', current: true }),
+        localBranch({ shortName: 'feat/b' }),
+      ])
+      expect(result.ok).toBe(false)
+      expect(result.message).toBe('Deleted 1 of 2 branches — 1 refused')
+      expect(result.details).toEqual(['main: Cannot delete the current branch.'])
     })
   })
 

--- a/src/git/branchActions.ts
+++ b/src/git/branchActions.ts
@@ -163,6 +163,48 @@ export function deleteBranch(
 }
 
 /**
+ * Delete several branches sequentially (#1361 batch delete). Continues
+ * past per-branch refusals — `-d`'s not-fully-merged guard, the
+ * current-branch guard, worktree-checkout refusals — and reports a
+ * summary. Per-branch failure messages ride in `details` verbatim, so
+ * the caller's not-fully-merged detection (for the force-delete
+ * escalation) keeps matching git's raw wording.
+ */
+export async function deleteBranches(
+  git: SimpleGit,
+  branches: BranchRef[],
+  force = false
+): Promise<BranchActionResult> {
+  if (branches.length === 0) {
+    return { ok: false, message: 'No branches selected.' }
+  }
+  if (branches.length === 1) {
+    return deleteBranch(git, branches[0], force)
+  }
+
+  const deleted: string[] = []
+  const failures: string[] = []
+  for (const branch of branches) {
+    const result = await deleteBranch(git, branch, force)
+    if (result.ok) {
+      deleted.push(branch.shortName)
+    } else {
+      failures.push(`${branch.shortName}: ${result.message}`)
+    }
+  }
+
+  if (failures.length === 0) {
+    const verb = force ? 'Force-deleted' : 'Deleted'
+    return { ok: true, message: `${verb} ${deleted.length} branches: ${deleted.join(', ')}` }
+  }
+  return {
+    ok: false,
+    message: `Deleted ${deleted.length} of ${branches.length} branches — ${failures.length} refused`,
+    details: failures,
+  }
+}
+
+/**
  * True when a failed `git branch -d` was rejected specifically because the
  * branch isn't fully merged (the one case worth offering a force-delete
  * for). Matches git's wording across versions ("not fully merged").

--- a/src/workstation/runtime/hooks/useWorkflowAction.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.ts
@@ -50,7 +50,7 @@ import {
 import { forgeNouns } from '../../chrome/forgeNouns'
 import { openProviderUrl } from '../../../git/providerActions'
 import type { GitProviderType } from '../../../git/providerData'
-import { getSelectedBranchId, getSelectedBranch, getSelectedTagId, getSelectedTag, getSelectedStashId, getSelectedStash, getSelectedWorktreeId, getSelectedWorktree } from '../selection'
+import { getSelectedBranchId, getSelectedBranch, getSelectedBranchBatch, getSelectedTagId, getSelectedTag, getSelectedStashId, getSelectedStash, getSelectedWorktreeId, getSelectedWorktree } from '../selection'
 import {
     LogInkPendingItemAction,
     LogInkAction,
@@ -62,7 +62,7 @@ import {
     checkoutBranch,
     checkoutBranchByName,
     createBranch,
-    deleteBranch,
+    deleteBranches,
     isBranchCheckedOutElsewhereError,
     isBranchNotFullyMergedError,
     isDirtyWorktreeCheckoutError,
@@ -264,23 +264,29 @@ export function resolvePendingItemAction(
   // logic that was previously inlined here for each branch workflow.
   if (id === 'checkout-branch') {
     const branchId = getSelectedBranchId(state, context)
-    return branchId ? { kind: 'branch', id: branchId, action: 'checkout' } : undefined
+    return branchId ? { kind: 'branch', ids: [branchId], action: 'checkout' } : undefined
   }
   if (id === 'delete-branch' || id === 'force-delete-branch') {
-    const branchId = getSelectedBranchId(state, context)
-    return branchId ? { kind: 'branch', id: branchId, action: 'delete' } : undefined
+    // #1361 — the delete workflows are batch-capable (`targets: 'multi'`
+    // in the registry): resolve through the range → marks → cursor
+    // ladder so the confirm target line and the row spinners cover
+    // every branch the handler will act on.
+    const branches = getSelectedBranchBatch(state, context)
+    return branches.length > 0
+      ? { kind: 'branch', ids: branches.map((b) => b.shortName), action: 'delete' }
+      : undefined
   }
   if (id === 'delete-tag') {
     const tagId = getSelectedTagId(state, context)
-    return tagId ? { kind: 'tag', id: tagId, action: 'delete' } : undefined
+    return tagId ? { kind: 'tag', ids: [tagId], action: 'delete' } : undefined
   }
   if (id === 'drop-stash') {
     const stashId = getSelectedStashId(state, context)
-    return stashId ? { kind: 'stash', id: stashId, action: 'delete' } : undefined
+    return stashId ? { kind: 'stash', ids: [stashId], action: 'delete' } : undefined
   }
   if (id === 'remove-worktree') {
     const worktreeId = getSelectedWorktreeId(state, context)
-    return worktreeId ? { kind: 'worktree', id: worktreeId, action: 'delete' } : undefined
+    return worktreeId ? { kind: 'worktree', ids: [worktreeId], action: 'delete' } : undefined
   }
   // #1363 — `gh pr checkout <n>` gets the same inline row spinner as a
   // branch checkout. Resolution mirrors `buildFilteredLists`'s triage
@@ -305,7 +311,7 @@ export function resolvePendingItemAction(
         )
       : all
     const pr = visible[Math.min(state.selectedPullRequestTriageIndex, Math.max(0, visible.length - 1))]
-    return pr ? { kind: 'pull-request', id: String(pr.number), action: 'checkout' } : undefined
+    return pr ? { kind: 'pull-request', ids: [String(pr.number)], action: 'checkout' } : undefined
   }
   return undefined
 }
@@ -544,15 +550,20 @@ export function useWorkflowAction(
         if (branch.current) return { ok: true, message: `Already on ${branch.shortName}` }
         return checkoutBranch(git, branch)
       },
+      // #1361 — batch-capable (`targets: 'multi'`): resolves the range →
+      // marks → cursor ladder and deletes every target, continuing past
+      // per-branch refusals with a summary. The single-cursor case
+      // degrades to exactly the old behavior (batch of one delegates to
+      // deleteBranch).
       'delete-branch': async () => {
-        const branch = getSelectedBranch(state, context)
-        if (!branch) return { ok: false, message: 'No branch selected' }
-        return deleteBranch(git, branch)
+        const branches = getSelectedBranchBatch(state, context)
+        if (branches.length === 0) return { ok: false, message: 'No branch selected' }
+        return deleteBranches(git, branches)
       },
       'force-delete-branch': async () => {
-        const branch = getSelectedBranch(state, context)
-        if (!branch) return { ok: false, message: 'No branch selected' }
-        return deleteBranch(git, branch, true)
+        const branches = getSelectedBranchBatch(state, context)
+        if (branches.length === 0) return { ok: false, message: 'No branch selected' }
+        return deleteBranches(git, branches, true)
       },
       // #0.71 — rebase the current branch onto the cursored branch / ref.
       // Re-resolve BOTH branches off live context (the input-layer guards
@@ -1572,12 +1583,30 @@ export function useWorkflowAction(
       value: `${result?.message || 'Workflow action complete'}${historyRewriteHint}`,
       kind: result ? (result.ok ? 'success' : 'error') : undefined,
     })
+    // #1361 — batch delete selection lifecycle. A successful delete
+    // consumed the selection; clear it so leftover marks can't re-aim a
+    // later D. On failure, FREEZE the attempted target set into explicit
+    // marks (replacing any positional v-range): the deleted branches
+    // won't resolve after the refresh below, so the surviving marks are
+    // exactly the refused ones — which makes the force-delete escalation
+    // re-target precisely them instead of re-resolving a range against
+    // the shrunken list.
+    if (id === 'delete-branch' || id === 'force-delete-branch') {
+      if (result?.ok) {
+        dispatch({ type: 'clearSelection' })
+      } else if (pendingItemAction && pendingItemAction.ids.length > 1) {
+        dispatch({ type: 'setMarks', view: 'branches', ids: pendingItemAction.ids })
+      }
+    }
     // A safe `delete-branch` (`git branch -d`) refuses branches that
     // aren't fully merged. Rather than dead-end on git's raw error, raise
     // a second y-confirm offering the force-delete (`git branch -D`). The
     // cursor hasn't moved (the delete failed), so the force handler
-    // re-resolves the same branch.
-    if (id === 'delete-branch' && !result?.ok && isBranchNotFullyMergedError(result?.message)) {
+    // re-resolves the same branch. Batch refusals carry each branch's
+    // raw git message in `details`, so the not-fully-merged detection
+    // scans those too.
+    const deleteFailureText = [result?.message, ...((result as { details?: string[] } | undefined)?.details || [])].join('\n')
+    if (id === 'delete-branch' && !result?.ok && isBranchNotFullyMergedError(deleteFailureText)) {
       dispatch({ type: 'setPendingConfirmation', value: 'force-delete-branch' })
     }
     // After a successful create-branch-here, offer to switch onto the
@@ -1657,7 +1686,7 @@ export function useWorkflowAction(
       isBranchCheckedOutElsewhereError(result?.message)
     ) {
       const worktreePath = parseCheckedOutWorktreePath(result?.message)
-      const branchName = pendingItemAction?.id
+      const branchName = pendingItemAction?.ids[0]
       dispatch({
         type: 'setStatus',
         value: worktreePath
@@ -1690,7 +1719,7 @@ export function useWorkflowAction(
     }
     if (id === 'checkout-branch' && !result?.ok && isBranchCheckedOutElsewhereError(result?.message)) {
       const worktreePath = parseCheckedOutWorktreePath(result?.message)
-      const branchName = pendingItemAction?.id
+      const branchName = pendingItemAction?.ids[0]
       if (worktreePath && branchName && frameChanged) {
         // #1429 — the frame changed mid-await; dropping silently here (no
         // fallback dispatch) matches the other recovery-prompt guards below.
@@ -1743,7 +1772,7 @@ export function useWorkflowAction(
       !frameChanged
     ) {
       if (id === 'triage-pr-checkout') {
-        const prNumber = payload?.trim() || pendingItemAction?.id
+        const prNumber = payload?.trim() || pendingItemAction?.ids[0]
         if (prNumber) {
           dispatch({
             type: 'setPendingChoice',
@@ -1758,7 +1787,7 @@ export function useWorkflowAction(
           })
         }
       } else {
-        const branchName = id === 'checkout-created-branch' ? payload?.trim() : pendingItemAction?.id
+        const branchName = id === 'checkout-created-branch' ? payload?.trim() : pendingItemAction?.ids[0]
         if (branchName) {
           dispatch({
             type: 'setPendingChoice',

--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -3497,6 +3497,89 @@ describe('log Ink input interactions', () => {
       ])
     })
 
+    // #1361 — multi-select grammar on the branches view.
+    describe('multi-select x / v / Esc (#1361)', () => {
+      function branchesState() {
+        return { ...createLogInkState(rows), activeView: 'branches' as const }
+      }
+
+      it('x toggles a mark on the cursored branch and auto-advances', () => {
+        const events = getLogInkInputEvents(branchesState(), 'x', {}, {
+          branchCount: 3, branchSelectedShortName: 'feat/a',
+        })
+        expect(events).toEqual([
+          { type: 'action', action: { type: 'toggleMark', view: 'branches', id: 'feat/a' } },
+          { type: 'action', action: { type: 'moveBranch', delta: 1, count: 3 } },
+        ])
+      })
+
+      it('x works from the sidebar branches tab too', () => {
+        const events = getLogInkInputEvents(sidebarBranchesState(), 'x', {}, {
+          branchCount: 3, branchSelectedShortName: 'feat/a',
+        })
+        expect(events[0]).toEqual(
+          { type: 'action', action: { type: 'toggleMark', view: 'branches', id: 'feat/a' } },
+        )
+      })
+
+      it('v anchors a range at the cursored branch; v again clears it', () => {
+        const anchor = getLogInkInputEvents(branchesState(), 'v', {}, {
+          branchCount: 3, branchSelectedShortName: 'feat/a',
+        })
+        expect(anchor[0]).toEqual(
+          { type: 'action', action: { type: 'setRangeAnchor', view: 'branches', id: 'feat/a' } },
+        )
+
+        const anchored = {
+          ...branchesState(),
+          selection: { view: 'branches' as const, anchorId: 'feat/a', ids: new Set<string>() },
+        }
+        const clear = getLogInkInputEvents(anchored, 'v', {}, {
+          branchCount: 3, branchSelectedShortName: 'feat/b',
+        })
+        expect(clear[0]).toEqual(
+          { type: 'action', action: { type: 'setRangeAnchor', view: 'branches', id: undefined } },
+        )
+      })
+
+      it('v on the branches view anchors a range even on single-pane (peek loses the collision)', () => {
+        const events = getLogInkInputEvents(branchesState(), 'v', {}, {
+          singlePane: true, branchCount: 3, branchSelectedShortName: 'feat/a',
+        })
+        expect(events[0]).toEqual(
+          { type: 'action', action: { type: 'setRangeAnchor', view: 'branches', id: 'feat/a' } },
+        )
+      })
+
+      it('Esc is two-stage: anchor first, marks second, then falls through to normal handling', () => {
+        const both = {
+          ...branchesState(),
+          selection: { view: 'branches' as const, anchorId: 'feat/a', ids: new Set(['feat/b']) },
+        }
+        const first = getLogInkInputEvents(both, '', { escape: true })
+        expect(first[0]).toEqual(
+          { type: 'action', action: { type: 'setRangeAnchor', view: 'branches', id: undefined } },
+        )
+
+        const marksOnly = {
+          ...branchesState(),
+          selection: { view: 'branches' as const, anchorId: undefined, ids: new Set(['feat/b']) },
+        }
+        const second = getLogInkInputEvents(marksOnly, '', { escape: true })
+        expect(second[0]).toEqual({ type: 'action', action: { type: 'clearSelection' } })
+      })
+
+      it('Esc on an unrelated view leaves another view\'s marks alone', () => {
+        const state = {
+          ...createLogInkState(rows),
+          activeView: 'history' as const,
+          selection: { view: 'branches' as const, anchorId: undefined, ids: new Set(['feat/b']) },
+        }
+        const events = getLogInkInputEvents(state, '', { escape: true })
+        expect(events).not.toContainEqual({ type: 'action', action: { type: 'clearSelection' } })
+      })
+    })
+
     it('↑/↓ on the status view with the center pane focused still moves the worktree file list', () => {
       const state = {
         ...createLogInkState(rows),

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -1995,6 +1995,30 @@ export function getLogInkInputEvents(
     return [action({ type: 'togglePeek' })]
   }
 
+  // #1361 — multi-select Esc rungs, two-stage like the filter's Esc:
+  // first Esc drops the range anchor (the user is mid-range and wants
+  // out of range mode, not out of their marks), the next clears the
+  // marked set. Scoped to the surface that owns the selection (the
+  // promoted view OR its sidebar tab — marks can be toggled from both)
+  // so Esc on an unrelated view still pops normally; placed above the
+  // generic popView rung so clearing a selection never also navigates.
+  const selectionOwnsFocus = state.selection && (
+    state.selection.view === state.activeView ||
+    (state.selection.view === 'branches' && isBranchActionTarget(state))
+  )
+  if (key.escape && state.selection && selectionOwnsFocus) {
+    if (state.selection.anchorId !== undefined) {
+      return [
+        action({ type: 'setRangeAnchor', view: state.selection.view, id: undefined }),
+        action({ type: 'setStatus', value: 'Range anchor cleared', ttl: 'echo' }),
+      ]
+    }
+    return [
+      action({ type: 'clearSelection' }),
+      action({ type: 'setStatus', value: `Cleared ${state.selection.ids.size} marked`, ttl: 'echo' }),
+    ]
+  }
+
   // Compare-flow cancel via Esc (#779) when there's no view to pop.
   // History is always the nav-stack root (navigateHome resets the
   // stack instead of pushing "history" onto it), so a compareBase-armed
@@ -2749,11 +2773,14 @@ export function getLogInkInputEvents(
   // peek intercept made line-level staging unreachable on narrow
   // terminals (the narrow footer even replaced the "v select" hint
   // with "v peek", so the feature silently vanished with width).
+  // NOT on branch action targets either (#1361): `v` is the range-select
+  // anchor there — the same collision #1389 fixed for the diff.
   if (
     inputValue === 'v' &&
     context.singlePane &&
     state.focus !== 'sidebar' &&
-    !isWorktreeDiffTarget(state)
+    !isWorktreeDiffTarget(state) &&
+    !isBranchActionTarget(state)
   ) {
     return [action({ type: 'togglePeek' })]
   }
@@ -3642,6 +3669,46 @@ export function getLogInkInputEvents(
     return [
       action({ type: 'setCompareBase', value: ref }),
       action({ type: 'setStatus', value: `Compare base: ${ref.label} — press enter on another ref to diff` }),
+    ]
+  }
+
+  // #1361 multi-select — `x` toggles a mark on the cursored branch and
+  // auto-advances one row (space-space-space staging ergonomic, #1353),
+  // so marking a run of branches is `x x x`. Batch-capable workflows
+  // (D delete) then act on the marked set, each target named in the
+  // confirm panel. Esc clears (two-stage: range anchor first, marks
+  // second).
+  if (inputValue === 'x' && isBranchActionTarget(state) && context.branchCount) {
+    const id = context.branchSelectedShortName
+    if (!id) {
+      return [action({ type: 'setStatus', value: 'No branch under cursor to mark', kind: 'warning' })]
+    }
+    return [
+      action({ type: 'toggleMark', view: 'branches', id }),
+      action({ type: 'moveBranch', delta: 1, count: context.branchCount }),
+    ]
+  }
+
+  // #1361 — `v` anchors a range selection at the cursored branch; j/k
+  // then extends it (the live range is anchor..cursor) and a
+  // batch-capable workflow acts on the span. Same visual-select grammar
+  // as the staging diff's line-select (#1389). `v` again clears the
+  // anchor.
+  if (inputValue === 'v' && isBranchActionTarget(state) && context.branchCount) {
+    const anchored = state.selection?.view === 'branches' && state.selection.anchorId !== undefined
+    if (anchored) {
+      return [
+        action({ type: 'setRangeAnchor', view: 'branches', id: undefined }),
+        action({ type: 'setStatus', value: 'Range anchor cleared', ttl: 'echo' }),
+      ]
+    }
+    const id = context.branchSelectedShortName
+    if (!id) {
+      return [action({ type: 'setStatus', value: 'No branch under cursor to anchor', kind: 'warning' })]
+    }
+    return [
+      action({ type: 'setRangeAnchor', view: 'branches', id }),
+      action({ type: 'setStatus', value: `Range anchor: ${id} — j/k extends, D acts on the range` }),
     ]
   }
 

--- a/src/workstation/runtime/inkKeymap.test.ts
+++ b/src/workstation/runtime/inkKeymap.test.ts
@@ -118,7 +118,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'D delete', 'r rebase', 'm compare', 's sort', 'y yank'],
+      contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'x/v mark', 'D delete', 'r rebase', 'm compare', 's sort', 'y yank'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/workstation/runtime/inkKeymap.ts
+++ b/src/workstation/runtime/inkKeymap.ts
@@ -1585,7 +1585,9 @@ function computeLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogInkF
       }
     }
     return {
-      contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'D delete', 'r rebase', 'm compare', 's sort', 'y yank'],
+      // `x/v mark` covers both multi-select primitives (#1361): x
+      // toggles a mark, v anchors a range; D then deletes the batch.
+      contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'x/v mark', 'D delete', 'r rebase', 'm compare', 's sort', 'y yank'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/workstation/runtime/inkViewModel.test.ts
+++ b/src/workstation/runtime/inkViewModel.test.ts
@@ -1643,15 +1643,31 @@ describe('log Ink view model', () => {
       expect(state.selection).toEqual({ view: 'stash', anchorId: undefined, ids: new Set(['stash@{0}']) })
     })
 
-    it('setRangeAnchor sets, then clears without touching marks in the same view', () => {
+    // #1361 — marks and a range anchor are mutually exclusive within a
+    // view: the batch selector already prioritizes an active range over
+    // marks, so letting both coexist would paint mark glyphs on rows a
+    // batch action wouldn't actually touch (found in review — the
+    // selector-priority behavior was tested, the state invariant wasn't).
+    it('setRangeAnchor drops any existing marks in the same view', () => {
       let state = createLogInkState(rows)
       state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'feat/a' })
       state = applyLogInkAction(state, { type: 'setRangeAnchor', view: 'branches', id: 'feat/b' })
-      expect(state.selection?.anchorId).toBe('feat/b')
-      expect(state.selection?.ids).toEqual(new Set(['feat/a']))
+      expect(state.selection).toEqual({ view: 'branches', anchorId: 'feat/b', ids: new Set() })
+    })
+
+    it('toggleMark drops any existing range anchor in the same view', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setRangeAnchor', view: 'branches', id: 'feat/a' })
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'feat/b' })
+      expect(state.selection).toEqual({ view: 'branches', anchorId: undefined, ids: new Set(['feat/b']) })
+    })
+
+    it('clearing the anchor after it superseded marks leaves the selection empty', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'feat/a' })
+      state = applyLogInkAction(state, { type: 'setRangeAnchor', view: 'branches', id: 'feat/b' })
       state = applyLogInkAction(state, { type: 'setRangeAnchor', view: 'branches', id: undefined })
-      expect(state.selection?.anchorId).toBeUndefined()
-      expect(state.selection?.ids).toEqual(new Set(['feat/a']))
+      expect(state.selection).toBeUndefined()
     })
 
     it('clearing the anchor with no marks collapses the selection to undefined', () => {

--- a/src/workstation/runtime/inkViewModel.test.ts
+++ b/src/workstation/runtime/inkViewModel.test.ts
@@ -1623,6 +1623,78 @@ describe('log Ink view model', () => {
     })
   })
 
+  // #1361 — multi-select marks + range anchor.
+  describe('multi-select selection (#1361)', () => {
+    it('toggleMark adds then removes an id, collapsing to undefined when empty', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'feat/a' })
+      expect(state.selection).toEqual({ view: 'branches', anchorId: undefined, ids: new Set(['feat/a']) })
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'feat/b' })
+      expect(state.selection?.ids).toEqual(new Set(['feat/a', 'feat/b']))
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'feat/a' })
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'feat/b' })
+      expect(state.selection).toBeUndefined()
+    })
+
+    it('marking in a different view resets the previous view\'s selection', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'feat/a' })
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'stash', id: 'stash@{0}' })
+      expect(state.selection).toEqual({ view: 'stash', anchorId: undefined, ids: new Set(['stash@{0}']) })
+    })
+
+    it('setRangeAnchor sets, then clears without touching marks in the same view', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'feat/a' })
+      state = applyLogInkAction(state, { type: 'setRangeAnchor', view: 'branches', id: 'feat/b' })
+      expect(state.selection?.anchorId).toBe('feat/b')
+      expect(state.selection?.ids).toEqual(new Set(['feat/a']))
+      state = applyLogInkAction(state, { type: 'setRangeAnchor', view: 'branches', id: undefined })
+      expect(state.selection?.anchorId).toBeUndefined()
+      expect(state.selection?.ids).toEqual(new Set(['feat/a']))
+    })
+
+    it('clearing the anchor with no marks collapses the selection to undefined', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setRangeAnchor', view: 'branches', id: 'feat/a' })
+      state = applyLogInkAction(state, { type: 'setRangeAnchor', view: 'branches', id: undefined })
+      expect(state.selection).toBeUndefined()
+    })
+
+    it('setMarks replaces the selection wholesale and drops any anchor', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setRangeAnchor', view: 'branches', id: 'feat/a' })
+      state = applyLogInkAction(state, { type: 'setMarks', view: 'branches', ids: ['feat/b', 'feat/c'] })
+      expect(state.selection).toEqual({ view: 'branches', anchorId: undefined, ids: new Set(['feat/b', 'feat/c']) })
+      state = applyLogInkAction(state, { type: 'setMarks', view: 'branches', ids: [] })
+      expect(state.selection).toBeUndefined()
+    })
+
+    it('clearSelection drops everything', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'feat/a' })
+      state = applyLogInkAction(state, { type: 'clearSelection' })
+      expect(state.selection).toBeUndefined()
+    })
+
+    it('marks survive filter changes (ids are stable across re-filtering)', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'feat/a' })
+      state = applyLogInkAction(state, { type: 'appendFilter', value: 'x' })
+      expect(state.selection?.ids).toEqual(new Set(['feat/a']))
+    })
+
+    it('marks are cleared at the repo-frame boundary, both push and pop', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'feat/a' })
+      const pushed = applyLogInkAction(state, { type: 'pushRepoFrame', label: 'vendor/lib' })
+      expect(pushed.selection).toBeUndefined()
+      const markedInside = applyLogInkAction(pushed, { type: 'toggleMark', view: 'branches', id: 'sub-branch' })
+      const popped = applyLogInkAction(markedInside, { type: 'popRepoFrame' })
+      expect(popped.selection).toBeUndefined()
+    })
+  })
+
   // Sidebar header focus (#806 follow-up) — escapes the items list
   // upward onto the active tab's header. Reducer-level coverage
   // here; input dispatch coverage lives in inkInput.test.ts.

--- a/src/workstation/runtime/inkViewModel.ts
+++ b/src/workstation/runtime/inkViewModel.ts
@@ -47,14 +47,32 @@ export type LogInkListItemKind = 'branch' | 'tag' | 'stash' | 'worktree' | 'pull
 export type LogInkPendingActionKind = 'delete' | 'checkout'
 
 /**
- * One in-flight action against a specific list-item row. Keyed by
- * `kind` + a stable id so it can't accidentally match a same-named row
- * in a different list rendering at the same time.
+ * One in-flight action against one or more list-item rows. Keyed by
+ * `kind` + stable ids so it can't accidentally match a same-named row
+ * in a different list rendering at the same time. Single-target
+ * workflows carry exactly one id; batch workflows (#1361 multi-select)
+ * carry the full target set so every affected row spins at once.
  */
 export type LogInkPendingItemAction = {
   kind: LogInkListItemKind
-  id: string
+  ids: string[]
   action: LogInkPendingActionKind
+}
+
+/**
+ * The canonical multi-select state (#1361, built on the #1452 id-based
+ * model). A selection belongs to ONE view at a time — marking in a
+ * different view resets it. `ids` is the x-toggled marked set;
+ * `anchorId` is the v-range anchor (the live range is anchor..cursor,
+ * resolved positionally against the visible list at action time).
+ * Ids (branch shortName / tag name / stash ref / commit hash) are
+ * stable across refresh, re-sort, and filter changes, so a mark can
+ * never silently re-aim the way an index would.
+ */
+export type LogInkMarkedSelection = {
+  view: LogInkView
+  anchorId?: string
+  ids: ReadonlySet<string>
 }
 
 /**
@@ -118,7 +136,20 @@ export function isPendingItemAction(
   kind: LogInkListItemKind,
   id: string
 ): boolean {
-  return pending?.kind === kind && pending.id === id
+  return pending?.kind === kind && pending.ids.includes(id)
+}
+
+/**
+ * True when `selection` (a `state.selection`) marks this exact row.
+ * Same field-not-state convention as `isPendingItemAction` above so
+ * renderers can call it without a forward reference.
+ */
+export function isMarkedItem(
+  selection: LogInkMarkedSelection | undefined,
+  view: LogInkView,
+  id: string
+): boolean {
+  return selection?.view === view && selection.ids.has(id)
 }
 
 /**
@@ -583,6 +614,14 @@ export type LogInkState = {
    * a different list rendering at the same time.
    */
   pendingItemAction?: LogInkPendingItemAction
+  /**
+   * Multi-select marks + range anchor (#1361). Undefined when nothing
+   * is marked. View-scoped: marking in a different view resets it.
+   * Survives navigation, filter, sort, and refresh (ids are stable);
+   * cleared by Esc (two-stage: anchor first, then marks), by a
+   * successful batch action, and at the repo-frame boundary.
+   */
+  selection?: LogInkMarkedSelection
   focus: LogInkFocus
   /**
    * Set while the user is "peeking" the sidebar (#1135 v2) — a momentary
@@ -1169,6 +1208,22 @@ export type LogInkAction =
   | { type: 'setWorktreeCheckoutConflict'; value?: { branch: string; worktreePath: string; dirty: boolean } }
   | { type: 'setPendingChoice'; value?: LogInkChoicePrompt }
   | { type: 'setPendingItemAction'; value?: LogInkPendingItemAction }
+  // #1361 multi-select. `toggleMark` flips the id's membership in the
+  // marked set (resetting the set first if it belonged to another view);
+  // `setRangeAnchor` sets/clears the v-range anchor the same way;
+  // `clearSelection` drops everything. The id is resolved at the
+  // dispatch site (the input layer has the cursored item's id in
+  // context) — the reducer has no access to LogInkContext.
+  | { type: 'toggleMark'; view: LogInkView; id: string }
+  | { type: 'setRangeAnchor'; view: LogInkView; id?: string }
+  // Replace the selection wholesale with explicit ids (anchor cleared).
+  // Used by the workflow runner to FREEZE a positional v-range into
+  // explicit marks the moment a batch action executes — after a partial
+  // failure the surviving marks are exactly the refused items, so a
+  // force-delete escalation re-targets precisely them instead of
+  // re-resolving a now-meaningless range against the shrunken list.
+  | { type: 'setMarks'; view: LogInkView; ids: string[] }
+  | { type: 'clearSelection' }
   | { type: 'appendPaletteFilter'; value: string }
   | { type: 'backspacePaletteFilter' }
   | { type: 'clearPaletteFilter' }
@@ -1533,6 +1588,12 @@ function withPushedRepoFrame(
     // cursors would be arbitrary positions in the submodule's lists.
     // All captured in parentReturn above and restored on pop.
     compareBase: undefined,
+    // #1361 — marks reference the PARENT repo's items; a submodule's
+    // branch that happens to share a name must not inherit them. Not
+    // captured in parentReturn (deliberately conservative — re-marking
+    // after a drill-in round-trip is cheap; a stale cross-repo mark on
+    // a destructive batch is not).
+    selection: undefined,
     blamePath: undefined,
     fileHistoryPath: undefined,
     changelogCache: {},
@@ -1640,6 +1701,9 @@ function withPoppedRepoFrame(state: LogInkState): LogInkState {
     // parent's context.
     pendingChoice: undefined,
     worktreeCheckoutConflict: undefined,
+    // #1361 — mirror of the push-time clear: the child frame's marks
+    // reference the child repo's items, not the parent's.
+    selection: undefined,
   }
 }
 
@@ -2892,6 +2956,48 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       // touches nothing else so the list keeps rendering normally
       // underneath the one spinner'd row.
       return { ...state, pendingItemAction: action.value }
+    case 'toggleMark': {
+      // #1361 — flip the id's membership in the marked set. A selection
+      // belongs to one view: marking in a different view starts fresh
+      // (stale cross-view marks were the audit's core hazard). An empty
+      // result with no anchor collapses back to undefined so "is
+      // anything selected" stays a simple existence check.
+      const sameView = state.selection?.view === action.view
+      const ids = new Set(sameView ? state.selection?.ids : [])
+      if (ids.has(action.id)) {
+        ids.delete(action.id)
+      } else {
+        ids.add(action.id)
+      }
+      const anchorId = sameView ? state.selection?.anchorId : undefined
+      return {
+        ...state,
+        selection: ids.size === 0 && !anchorId
+          ? undefined
+          : { view: action.view, anchorId, ids },
+        pendingKey: undefined,
+      }
+    }
+    case 'setRangeAnchor': {
+      const sameView = state.selection?.view === action.view
+      const ids: ReadonlySet<string> = sameView ? (state.selection?.ids ?? new Set()) : new Set()
+      return {
+        ...state,
+        selection: action.id === undefined && ids.size === 0
+          ? undefined
+          : { view: action.view, anchorId: action.id, ids },
+        pendingKey: undefined,
+      }
+    }
+    case 'setMarks':
+      return {
+        ...state,
+        selection: action.ids.length === 0
+          ? undefined
+          : { view: action.view, anchorId: undefined, ids: new Set(action.ids) },
+      }
+    case 'clearSelection':
+      return { ...state, selection: undefined }
     case 'toggleFilterMode':
       return {
         ...state,

--- a/src/workstation/runtime/inkViewModel.ts
+++ b/src/workstation/runtime/inkViewModel.ts
@@ -2959,9 +2959,15 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
     case 'toggleMark': {
       // #1361 — flip the id's membership in the marked set. A selection
       // belongs to one view: marking in a different view starts fresh
-      // (stale cross-view marks were the audit's core hazard). An empty
-      // result with no anchor collapses back to undefined so "is
-      // anything selected" stays a simple existence check.
+      // (stale cross-view marks were the audit's core hazard). Marks
+      // and a range anchor are mutually exclusive within a view too —
+      // the batch selector already prioritizes an active range over
+      // marks (see getSelectedBranchBatch/getSelectedStashBatch), so
+      // leaving a stale anchor around while marks accumulate would
+      // paint mark glyphs on rows a batch action wouldn't actually
+      // touch. Toggling a mark always drops any anchor. An empty
+      // result collapses back to undefined so "is anything selected"
+      // stays a simple existence check.
       const sameView = state.selection?.view === action.view
       const ids = new Set(sameView ? state.selection?.ids : [])
       if (ids.has(action.id)) {
@@ -2969,26 +2975,29 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       } else {
         ids.add(action.id)
       }
-      const anchorId = sameView ? state.selection?.anchorId : undefined
       return {
         ...state,
-        selection: ids.size === 0 && !anchorId
+        selection: ids.size === 0
           ? undefined
-          : { view: action.view, anchorId, ids },
+          : { view: action.view, anchorId: undefined, ids },
         pendingKey: undefined,
       }
     }
-    case 'setRangeAnchor': {
-      const sameView = state.selection?.view === action.view
-      const ids: ReadonlySet<string> = sameView ? (state.selection?.ids ?? new Set()) : new Set()
+    case 'setRangeAnchor':
+      // #1361 — mirror of toggleMark's mutual-exclusivity rule:
+      // starting a new range anchor drops any marks in the same (or a
+      // different) view, for the same reason — a stale mark can't
+      // coexist with an active range without misleading the row
+      // rendering. Clearing the anchor (id undefined) always leaves
+      // nothing behind: marks are already gone by the time an anchor
+      // could exist, so there's nothing left to collapse around.
       return {
         ...state,
-        selection: action.id === undefined && ids.size === 0
+        selection: action.id === undefined
           ? undefined
-          : { view: action.view, anchorId: action.id, ids },
+          : { view: action.view, anchorId: action.id, ids: new Set() },
         pendingKey: undefined,
       }
-    }
     case 'setMarks':
       return {
         ...state,

--- a/src/workstation/runtime/inkWorkflows.ts
+++ b/src/workstation/runtime/inkWorkflows.ts
@@ -46,6 +46,16 @@ export type LogInkWorkflowAction = {
    * per-id if-chain in overlays.ts.
    */
   warning?: string | ((state: LogInkState) => string)
+  /**
+   * Target contract (#1361 multi-select). `'multi'` workflows resolve
+   * their targets through the batch selector (range → marked set →
+   * cursored single) and execute against every resolved item; the
+   * confirm panel pluralizes accordingly. Absent/`'single'` workflows
+   * always act on the one cursored item and ignore marks entirely —
+   * the plural contract is opt-in per workflow so a checkout can never
+   * accidentally become plural.
+   */
+  targets?: 'single' | 'multi'
 }
 
 function countLabel(count: number, singular: string, plural = `${singular}s`): string {
@@ -395,9 +405,13 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       id: 'delete-branch',
       key: 'D',
       label: 'Delete branch',
-      description: 'Delete the selected branch after confirmation.',
+      description: 'Delete the selected or marked branches after confirmation.',
       kind: 'destructive',
       requiresConfirmation: true,
+      // #1361 — first batch-capable workflow: with x-marks or a v-range
+      // active on the branches view, one D deletes them all (each named
+      // in the confirm panel).
+      targets: 'multi',
     },
     {
       // No key binding — this is raised by the runtime as a second
@@ -407,10 +421,14 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       id: 'force-delete-branch',
       key: '',
       label: 'Force-delete branch',
-      description: 'Force-delete the selected branch even if it is not fully merged (git branch -D).',
+      description: 'Force-delete the selected or marked branches even if not fully merged (git branch -D).',
       kind: 'destructive',
       requiresConfirmation: true,
       warning: 'Not fully merged. Force-delete (git branch -D) is irreversible.',
+      // #1361 — after a batch -d refusal the marks that remain
+      // resolvable are exactly the refused branches, so the escalated
+      // force-delete re-targets precisely them.
+      targets: 'multi',
     },
     {
       // #0.71 — rebase the current branch onto the cursored branch/ref

--- a/src/workstation/runtime/overlays.test.ts
+++ b/src/workstation/runtime/overlays.test.ts
@@ -137,6 +137,42 @@ describe('confirmation target naming', () => {
     const text = flattenText(renderConfirmationPanel(createElement, components, state, {}, 80, theme, false))
     expect(text).toContain('commit abc1234: fix: the thing')
   })
+
+  // #1361 — a batch confirm must name every marked target (or an exact
+  // count with the first few names), or the user confirms one item and
+  // acts on N — the exact failure mode the #1452 audit warned about.
+  function branchContext(names: string[]) {
+    return {
+      branches: {
+        localBranches: names.map((shortName) => ({ shortName, current: false, ahead: 0, behind: 0 })),
+      },
+    } as never
+  }
+
+  it('pluralizes the target line for a marked batch, naming each branch', () => {
+    const state = {
+      ...createLogInkState([]),
+      pendingConfirmationId: 'delete-branch',
+      selection: { view: 'branches' as const, anchorId: undefined, ids: new Set(['feat/a', 'feat/b', 'feat/c']) },
+    }
+    const text = flattenText(renderConfirmationPanel(
+      createElement, components, state, branchContext(['feat/a', 'feat/b', 'feat/c', 'main']), 100, theme, false,
+    ))
+    expect(text).toContain('3 branches: feat/a, feat/b, feat/c')
+  })
+
+  it('caps the inline names and reports the exact overflow count', () => {
+    const names = ['b1', 'b2', 'b3', 'b4', 'b5', 'b6']
+    const state = {
+      ...createLogInkState([]),
+      pendingConfirmationId: 'delete-branch',
+      selection: { view: 'branches' as const, anchorId: undefined, ids: new Set(names) },
+    }
+    const text = flattenText(renderConfirmationPanel(
+      createElement, components, state, branchContext([...names, 'main']), 120, theme, false,
+    ))
+    expect(text).toContain('6 branches: b1, b2, b3, b4 +2 more')
+  })
 })
 
 describe('rebase-onto-branch confirmation panel (#0.71)', () => {

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -92,11 +92,20 @@ export function renderInputPromptPanel(
 }
 
 /**
- * Human line naming the item a pending confirmation will act on, or
- * undefined when the workflow has no resolvable single target. Shown in
- * the confirm overlay so the user never confirms blind — several
+ * Cap on how many batch target names the confirm panel spells out
+ * inline (#1361). Beyond it the line abbreviates to "+N more" so a
+ * 20-item batch can't overflow a 24-row terminal — the count is always
+ * exact even when the names are truncated.
+ */
+const CONFIRMATION_TARGET_NAME_CAP = 4
+
+/**
+ * Human line naming the item(s) a pending confirmation will act on, or
+ * undefined when the workflow has no resolvable target. Shown in the
+ * confirm overlay so the user never confirms blind — several
  * destructive keys (D / T / X / W) reach the confirm from views where
- * the target list isn't even on screen.
+ * the target list isn't even on screen, and a batch confirm (#1361)
+ * must name every marked item or the user confirms one and acts on N.
  *
  * Everything list-shaped (branch/tag/stash/worktree deletes and
  * checkouts) resolves through `resolvePendingItemAction` — the same
@@ -112,8 +121,16 @@ export function describeConfirmationTarget(
   const id = state.pendingConfirmationId
   if (!id) return undefined
   const item = resolvePendingItemAction(id, state, context)
-  if (item) {
-    return `${item.kind}: ${item.id}`
+  if (item && item.ids.length === 1) {
+    return `${item.kind}: ${item.ids[0]}`
+  }
+  if (item && item.ids.length > 1) {
+    const shown = item.ids.slice(0, CONFIRMATION_TARGET_NAME_CAP)
+    const overflow = item.ids.length - shown.length
+    const names = overflow > 0 ? `${shown.join(', ')} +${overflow} more` : shown.join(', ')
+    // branch/stash pluralize with -es; tag/worktree/pull-request with -s.
+    const plural = /(ch|sh)$/.test(item.kind) ? `${item.kind}es` : `${item.kind}s`
+    return `${item.ids.length} ${plural}: ${names}`
   }
   const commit = getSelectedCommitTarget(id, state)
   if (commit) {

--- a/src/workstation/runtime/pendingItemAction.test.ts
+++ b/src/workstation/runtime/pendingItemAction.test.ts
@@ -99,7 +99,7 @@ function ctxFor(
 
 describe('isPendingItemAction', () => {
   it('matches only on the same kind AND id', () => {
-    const pending: LogInkPendingItemAction = { kind: 'branch', id: 'feat/x', action: 'delete' }
+    const pending: LogInkPendingItemAction = { kind: 'branch', ids: ['feat/x'], action: 'delete' }
     expect(isPendingItemAction(pending, 'branch', 'feat/x')).toBe(true)
     expect(isPendingItemAction(pending, 'branch', 'main')).toBe(false) // id differs
     expect(isPendingItemAction(pending, 'tag', 'feat/x')).toBe(false) // kind differs
@@ -107,7 +107,7 @@ describe('isPendingItemAction', () => {
   })
 
   it('is action-agnostic — a checkout in flight spins the same as a delete', () => {
-    const checkout: LogInkPendingItemAction = { kind: 'branch', id: 'feat/x', action: 'checkout' }
+    const checkout: LogInkPendingItemAction = { kind: 'branch', ids: ['feat/x'], action: 'checkout' }
     expect(isPendingItemAction(checkout, 'branch', 'feat/x')).toBe(true)
   })
 })
@@ -116,8 +116,8 @@ describe('setPendingItemAction reducer', () => {
   it('sets and clears the pending target without touching anything else', () => {
     let state = createLogInkState([])
     expect(state.pendingItemAction).toBeUndefined()
-    state = applyLogInkAction(state, { type: 'setPendingItemAction', value: { kind: 'stash', id: 'stash@{0}', action: 'delete' } })
-    expect(state.pendingItemAction).toEqual({ kind: 'stash', id: 'stash@{0}', action: 'delete' })
+    state = applyLogInkAction(state, { type: 'setPendingItemAction', value: { kind: 'stash', ids: ['stash@{0}'], action: 'delete' } })
+    expect(state.pendingItemAction).toEqual({ kind: 'stash', ids: ['stash@{0}'], action: 'delete' })
     state = applyLogInkAction(state, { type: 'setPendingItemAction', value: undefined })
     expect(state.pendingItemAction).toBeUndefined()
   })
@@ -128,32 +128,32 @@ describe('inline pending spinner per surface', () => {
     const plain = flattenText(renderBranchesSurface(ctxFor('branches'), 0))
     expect(plain).not.toContain(SPIN)
 
-    const pending = flattenText(renderBranchesSurface(ctxFor('branches', { kind: 'branch', id: 'feat/x', action: 'delete' }), 0))
+    const pending = flattenText(renderBranchesSurface(ctxFor('branches', { kind: 'branch', ids: ['feat/x'], action: 'delete' }), 0))
     expect(pending).toContain(SPIN)
     expect(pending).toContain('feat/x') // row still shows its name
   })
 
   it('branches: a pending checkout spins the targeted row too', () => {
-    const pending = flattenText(renderBranchesSurface(ctxFor('branches', { kind: 'branch', id: 'feat/x', action: 'checkout' }), 0))
+    const pending = flattenText(renderBranchesSurface(ctxFor('branches', { kind: 'branch', ids: ['feat/x'], action: 'checkout' }), 0))
     expect(pending).toContain(SPIN)
     expect(pending).toContain('feat/x')
   })
 
   it('worktrees: swaps the targeted row marker for a spinner', () => {
-    const pending = flattenText(renderWorktreesSurface(ctxFor('worktrees', { kind: 'worktree', id: '/repo/wt', action: 'delete' }), 0))
+    const pending = flattenText(renderWorktreesSurface(ctxFor('worktrees', { kind: 'worktree', ids: ['/repo/wt'], action: 'delete' }), 0))
     expect(pending).toContain(SPIN)
     expect(flattenText(renderWorktreesSurface(ctxFor('worktrees'), 0))).not.toContain(SPIN)
   })
 
   it('tags: appends a spinner (no leading icon to swap)', () => {
-    const pending = flattenText(renderTagsSurface(ctxFor('tags', { kind: 'tag', id: 'v1.1.0', action: 'delete' }), 0))
+    const pending = flattenText(renderTagsSurface(ctxFor('tags', { kind: 'tag', ids: ['v1.1.0'], action: 'delete' }), 0))
     expect(pending).toContain(SPIN)
     expect(pending).toContain('v1.1.0')
     expect(flattenText(renderTagsSurface(ctxFor('tags'), 0))).not.toContain(SPIN)
   })
 
   it('stashes: appends a spinner', () => {
-    const pending = flattenText(renderStashSurface(ctxFor('stash', { kind: 'stash', id: 'stash@{1}', action: 'delete' }), 0))
+    const pending = flattenText(renderStashSurface(ctxFor('stash', { kind: 'stash', ids: ['stash@{1}'], action: 'delete' }), 0))
     expect(pending).toContain(SPIN)
     expect(flattenText(renderStashSurface(ctxFor('stash'), 0))).not.toContain(SPIN)
   })
@@ -162,14 +162,14 @@ describe('inline pending spinner per surface', () => {
 describe('inline pending spinner in the sidebar', () => {
   it('shows the spinner on the targeted branch row of the active tab', () => {
     const base = createLogInkState([])
-    const state = { ...base, sidebarTab: 'branches' as const, focus: 'sidebar' as const, pendingItemAction: { kind: 'branch' as const, id: 'feat/x', action: 'delete' as const } }
+    const state = { ...base, sidebarTab: 'branches' as const, focus: 'sidebar' as const, pendingItemAction: { kind: 'branch' as const, ids: ['feat/x'], action: 'delete' as const } }
     const tree = renderSidebar(createElement, components, state, context, createLogInkContextStatus('ready'), 40, 30, theme, 0)
     expect(flattenText(tree)).toContain(SPIN)
   })
 
   it('shows the spinner on a branch being checked out', () => {
     const base = createLogInkState([])
-    const state = { ...base, sidebarTab: 'branches' as const, focus: 'sidebar' as const, pendingItemAction: { kind: 'branch' as const, id: 'feat/x', action: 'checkout' as const } }
+    const state = { ...base, sidebarTab: 'branches' as const, focus: 'sidebar' as const, pendingItemAction: { kind: 'branch' as const, ids: ['feat/x'], action: 'checkout' as const } }
     const tree = renderSidebar(createElement, components, state, context, createLogInkContextStatus('ready'), 40, 30, theme, 0)
     expect(flattenText(tree)).toContain(SPIN)
   })
@@ -217,7 +217,7 @@ describe('inline pending spinner on the PR triage list (#1363)', () => {
   }
 
   it('swaps the cursor glyph for the spinner on the PR being checked out', () => {
-    const text = renderTriage({ kind: 'pull-request', id: '42', action: 'checkout' })
+    const text = renderTriage({ kind: 'pull-request', ids: ['42'], action: 'checkout' })
     expect(text).toMatch(new RegExp(`${SPIN}\\s+#42`))
     expect(text).not.toMatch(new RegExp(`${SPIN}\\s+#41`))
   })

--- a/src/workstation/runtime/selection.test.ts
+++ b/src/workstation/runtime/selection.test.ts
@@ -5,9 +5,9 @@
  * legacy index-based state — proving the bridge is correct before
  * consumers start migrating to read through it.
  */
-import { createLogInkState } from './inkViewModel'
+import { applyLogInkAction, createLogInkState } from './inkViewModel'
 import type { LogInkContext } from './types'
-import { getSelectedBranchId, getSelectedTagId, getSelectedStashId, getSelectedWorktree, getSelectedCommitTarget } from './selection'
+import { getSelectedBranchBatch, getSelectedBranchId, getSelectedTagId, getSelectedStashId, getSelectedWorktree, getSelectedCommitTarget } from './selection'
 
 function makeBranch(shortName: string, date = '2026-01-01') {
   return {
@@ -220,6 +220,72 @@ describe('selection selectors (#1452)', () => {
     it('returns undefined when id is undefined', () => {
       const state = createLogInkState(rows)
       expect(getSelectedCommitTarget(undefined, state)).toBeUndefined()
+    })
+  })
+
+  // #1361 — batch target resolution: range → marks → cursored single.
+  // Sorted branch order in this fixture: feature, hotfix, main.
+  describe('getSelectedBranchBatch', () => {
+    it('falls back to the single cursored branch with no selection', () => {
+      const state = { ...createLogInkState([]), selectedBranchIndex: 1 }
+      expect(getSelectedBranchBatch(state, context).map((b) => b.shortName)).toEqual(['hotfix'])
+    })
+
+    it('resolves the marked set in list order regardless of marking order', () => {
+      let state = createLogInkState([])
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'main' })
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'feature' })
+      expect(getSelectedBranchBatch(state, context).map((b) => b.shortName)).toEqual(['feature', 'main'])
+    })
+
+    it('marked ids that no longer resolve drop out silently', () => {
+      let state = createLogInkState([])
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'feature' })
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'deleted-elsewhere' })
+      expect(getSelectedBranchBatch(state, context).map((b) => b.shortName)).toEqual(['feature'])
+    })
+
+    it('marks survive an active filter — every marked branch resolves, not just visible ones', () => {
+      let state = createLogInkState([])
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'feature' })
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'main' })
+      const filtered = { ...state, filter: 'feat' }
+      expect(getSelectedBranchBatch(filtered, context).map((b) => b.shortName)).toEqual(['feature', 'main'])
+    })
+
+    it('an active range anchor wins over marks and resolves anchor..cursor positionally', () => {
+      let state = createLogInkState([])
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'main' })
+      state = applyLogInkAction(state, { type: 'setRangeAnchor', view: 'branches', id: 'feature' })
+      // Anchor on 'feature' (index 0), cursor on index 1 ('hotfix').
+      const ranged = { ...state, selectedBranchIndex: 1 }
+      expect(getSelectedBranchBatch(ranged, context).map((b) => b.shortName)).toEqual(['feature', 'hotfix'])
+    })
+
+    it('a backwards range (cursor above the anchor) resolves the same span', () => {
+      let state = createLogInkState([])
+      state = applyLogInkAction(state, { type: 'setRangeAnchor', view: 'branches', id: 'main' })
+      // Anchor on 'main' (index 2), cursor up at index 0 ('feature').
+      const ranged = { ...state, selectedBranchIndex: 0 }
+      expect(getSelectedBranchBatch(ranged, context).map((b) => b.shortName))
+        .toEqual(['feature', 'hotfix', 'main'])
+    })
+
+    it('skips the range rung when the anchor no longer resolves in the visible list', () => {
+      let state = createLogInkState([])
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'hotfix' })
+      state = applyLogInkAction(state, { type: 'setRangeAnchor', view: 'branches', id: 'main' })
+      // Filter hides 'main' — the positional range is meaningless, so
+      // resolution falls through to the marked set.
+      const filtered = { ...state, filter: 'hot', selectedBranchIndex: 0 }
+      expect(getSelectedBranchBatch(filtered, context).map((b) => b.shortName)).toEqual(['hotfix'])
+    })
+
+    it('ignores a selection owned by a different view', () => {
+      let state = createLogInkState([])
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'stash', id: 'stash@{0}' })
+      const cursored = { ...state, selectedBranchIndex: 0 }
+      expect(getSelectedBranchBatch(cursored, context).map((b) => b.shortName)).toEqual(['feature'])
     })
   })
 })

--- a/src/workstation/runtime/selection.test.ts
+++ b/src/workstation/runtime/selection.test.ts
@@ -253,13 +253,20 @@ describe('selection selectors (#1452)', () => {
       expect(getSelectedBranchBatch(filtered, context).map((b) => b.shortName)).toEqual(['feature', 'main'])
     })
 
+    // #1361 — the reducer keeps marks and an anchor mutually exclusive
+    // (setRangeAnchor clears marks, toggleMark clears the anchor), so
+    // this exact combination isn't reachable through normal dispatch.
+    // Constructing the state directly still exercises the selector's
+    // own priority contract defensively — anything that ever hands it
+    // a selection with both set must not silently act on the marks.
     it('an active range anchor wins over marks and resolves anchor..cursor positionally', () => {
-      let state = createLogInkState([])
-      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'main' })
-      state = applyLogInkAction(state, { type: 'setRangeAnchor', view: 'branches', id: 'feature' })
+      const state = {
+        ...createLogInkState([]),
+        selectedBranchIndex: 1,
+        selection: { view: 'branches' as const, anchorId: 'feature', ids: new Set(['main']) },
+      }
       // Anchor on 'feature' (index 0), cursor on index 1 ('hotfix').
-      const ranged = { ...state, selectedBranchIndex: 1 }
-      expect(getSelectedBranchBatch(ranged, context).map((b) => b.shortName)).toEqual(['feature', 'hotfix'])
+      expect(getSelectedBranchBatch(state, context).map((b) => b.shortName)).toEqual(['feature', 'hotfix'])
     })
 
     it('a backwards range (cursor above the anchor) resolves the same span', () => {
@@ -272,13 +279,17 @@ describe('selection selectors (#1452)', () => {
     })
 
     it('skips the range rung when the anchor no longer resolves in the visible list', () => {
-      let state = createLogInkState([])
-      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'hotfix' })
-      state = applyLogInkAction(state, { type: 'setRangeAnchor', view: 'branches', id: 'main' })
+      // Same defensive-construction note as above — directly building
+      // the state exercises the selector's fallback-to-marks rung.
+      const state = {
+        ...createLogInkState([]),
+        filter: 'hot',
+        selectedBranchIndex: 0,
+        selection: { view: 'branches' as const, anchorId: 'main', ids: new Set(['hotfix']) },
+      }
       // Filter hides 'main' — the positional range is meaningless, so
       // resolution falls through to the marked set.
-      const filtered = { ...state, filter: 'hot', selectedBranchIndex: 0 }
-      expect(getSelectedBranchBatch(filtered, context).map((b) => b.shortName)).toEqual(['hotfix'])
+      expect(getSelectedBranchBatch(state, context).map((b) => b.shortName)).toEqual(['hotfix'])
     })
 
     it('ignores a selection owned by a different view', () => {

--- a/src/workstation/runtime/selection.ts
+++ b/src/workstation/runtime/selection.ts
@@ -110,6 +110,55 @@ export function getSelectedBranch(
 }
 
 /**
+ * Resolve the branch targets for a batch-capable (`targets: 'multi'`)
+ * workflow (#1361). Deterministic priority ladder:
+ *
+ *   1. Range active (v-anchor set on the branches view) → the contiguous
+ *      anchor..cursor span, resolved POSITIONALLY against the visible
+ *      (sorted + filtered) list — a range is what the user sees between
+ *      two rows on screen.
+ *   2. Marked set non-empty → the x-toggled ids, resolved against the
+ *      FULL sorted list in list order. Marks are explicit per-item
+ *      choices, so an active filter must not silently drop targets —
+ *      the confirm panel names every resolved target either way.
+ *   3. Neither → the single cursored branch (existing behavior).
+ *
+ * Marked ids that no longer resolve (branch deleted by another process,
+ * or by an earlier item of the same batch) drop out silently. If the
+ * range anchor itself no longer resolves in the visible list, the range
+ * rung is skipped rather than guessing at a span.
+ */
+export function getSelectedBranchBatch(
+  state: LogInkState,
+  context: LogInkContext,
+): BranchRef[] {
+  const all = sortBranches(context.branches?.localBranches || [], state.branchSort)
+  const selection = state.selection?.view === 'branches' ? state.selection : undefined
+
+  if (selection?.anchorId) {
+    const visible = state.filter
+      ? all.filter((b) => matchesPromotedFilter([b.shortName, b.upstream || ''], state.filter))
+      : all
+    const anchorIndex = visible.findIndex((b) => b.shortName === selection.anchorId)
+    if (anchorIndex >= 0 && visible.length > 0) {
+      const cursorIndex = Math.min(state.selectedBranchIndex, visible.length - 1)
+      const [from, to] = anchorIndex <= cursorIndex
+        ? [anchorIndex, cursorIndex]
+        : [cursorIndex, anchorIndex]
+      return visible.slice(from, to + 1)
+    }
+  }
+
+  if (selection && selection.ids.size > 0) {
+    const marked = all.filter((b) => selection.ids.has(b.shortName))
+    if (marked.length > 0) return marked
+  }
+
+  const single = getSelectedBranch(state, context)
+  return single ? [single] : []
+}
+
+/**
  * Get the currently-selected tag's name.
  */
 export function getSelectedTagId(

--- a/src/workstation/runtime/sidebar.ts
+++ b/src/workstation/runtime/sidebar.ts
@@ -26,7 +26,7 @@ import type {
     LogInkSidebarTab,
     LogInkState,
 } from '../../workstation/runtime/inkViewModel'
-import { getLogInkSidebarTabs, isPendingItemAction } from '../../workstation/runtime/inkViewModel'
+import { getLogInkSidebarTabs, isMarkedItem, isPendingItemAction } from '../../workstation/runtime/inkViewModel'
 import { buildFilteredLists, type FilteredLists } from './hooks/buildFilteredLists'
 import type { LogInkComponents, LogInkContext } from './types'
 import { focusBorderColor, panelTitle, sidebarTabLabel } from './utils'
@@ -213,7 +213,13 @@ function renderActiveSidebarContent(
           const glyph = isPendingItemAction(pending, 'branch', branch.shortName)
             ? spin
             : branchRowMarker(branch, { ascii: theme.ascii }).glyph
-          return `${glyph} ${branch.shortName}`
+          // #1361 — x-marked rows carry the mark glyph in the sidebar
+          // too, so a batch built from the sidebar tab reads the same
+          // as on the promoted view.
+          const mark = isMarkedItem(state.selection, 'branches', branch.shortName)
+            ? (theme.ascii ? '*' : '●')
+            : ' '
+          return `${mark}${glyph} ${branch.shortName}`
         },
         'tab-branches', visibleListCount,
         // Paint the checked-out branch green so "where am I?" reads at a

--- a/src/workstation/surfaces/branches/index.ts
+++ b/src/workstation/surfaces/branches/index.ts
@@ -31,7 +31,7 @@ import {
 } from '../../runtime/promotedFilter'
 import type { SurfaceRenderContext } from '../../runtime/types'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
-import { isPendingItemAction } from '../../../workstation/runtime/inkViewModel'
+import { isMarkedItem, isPendingItemAction } from '../../../workstation/runtime/inkViewModel'
 
 export function renderBranchesSurface(ctx: SurfaceRenderContext, spinnerFrame: number = 0): ReactTypes.ReactElement {
   const { h, components, state, context, contextStatus, bodyRows, width, theme } = ctx
@@ -57,10 +57,20 @@ export function renderBranchesSurface(ctx: SurfaceRenderContext, spinnerFrame: n
   const visible = localBranches.slice(startIndex, startIndex + listRows)
   const filterLabel = state.filter ? `filter: ${state.filter}` : undefined
   const sortLabel = formatSortIndicator(state.branchSort, { ascii: theme.ascii })
+  // #1361 — surface the marked count (or an active range anchor) in the
+  // header so the batch scope is visible even when marked rows have
+  // scrolled out of the window.
+  const branchSelection = state.selection?.view === 'branches' ? state.selection : undefined
+  const markedLabel = branchSelection?.anchorId
+    ? 'range: v..cursor'
+    : branchSelection && branchSelection.ids.size > 0
+      ? `${branchSelection.ids.size} marked`
+      : undefined
   const headerRight = loading
     ? 'Loading branches…'
     : [
       `${localBranches.length}/${sortedAll.length} local`,
+      markedLabel,
       filterLabel,
       sortLabel,
     ].filter(Boolean).join(' · ')
@@ -83,6 +93,15 @@ export function renderBranchesSurface(ctx: SurfaceRenderContext, spinnerFrame: n
         const index = startIndex + offset
         const isSelected = index === selected
         const cursor = isSelected ? '>' : ' '
+        // #1361 — x-marked rows carry a mark glyph in the pad slot
+        // between the cursor and the sync-state marker, so the marked
+        // set reads at a glance before a batch D. The v-range renders
+        // no per-row glyph (it's the live span between anchor and
+        // cursor); the anchor row alone is glyphed as a waypoint.
+        const isMarked = isMarkedItem(state.selection, 'branches', branch.shortName)
+        const isRangeAnchor = state.selection?.view === 'branches' &&
+          state.selection.anchorId === branch.shortName
+        const markGlyph = isMarked || isRangeAnchor ? (theme.ascii ? '*' : '●') : ' '
         const marker = branchRowMarker(branch, { ascii: theme.ascii })
         // While this branch's delete is in flight, its sync-state marker
         // is replaced by an inline spinner (accent-coloured) so the row
@@ -100,7 +119,7 @@ export function renderBranchesSurface(ctx: SurfaceRenderContext, spinnerFrame: n
         const namePadded = truncateCells(branch.shortName, nameColWidth).padEnd(nameColWidth)
         const timestampPadded = lastTouched.padEnd(8)
         const lineDim = !isSelected && !branch.current
-        const cursorAndPad = `${cursor} `
+        const cursorAndPad = `${cursor}${markGlyph}`
         const trailingName = ` ${namePadded} `
         const trailingDivergence = divergence ? ` ${divergence}` : ''
         // Truncate the assembled line to the actual panel width so a


### PR DESCRIPTION
## Summary

First slice of #1361 multi-select / range operations, built on the #1452 id-based selection model and canonizing it as THE selection idiom (the compare `m` mark and diff line-range coexist unmigrated — future tech-debt, not this PR). Design doc: `specs/DESIGN_multi_select.md` (local).

**State**: `selection?: { view, anchorId?, ids: Set<id> }` — view-scoped (marking in another view resets it), id-keyed so marks survive refresh/filter/re-sort (the exact property #1452's flip gave the cursor), cleared at the repo-frame boundary. Actions: `toggleMark`, `setRangeAnchor`, `setMarks`, `clearSelection`.

**Grammar** (branches view + sidebar branches tab):
- `x` toggles a mark on the cursored branch and auto-advances (the #1353 space-space-space staging ergonomic) — key audit confirmed `x` is free on all list views
- `v` anchors a range; j/k extends; the live span is anchor..cursor — the same visual-select grammar the staging diff shipped in #1358/#1389, and the single-pane peek handler excludes branch targets exactly the way it already excludes the diff
- `Esc` is two-stage: anchor first, marks second — slotted above the generic popView rung so clearing never also navigates

**Plural workflow contract**:
- `targets: 'single' | 'multi'` on the registry (mirrors how `warning` was added); `delete-branch`/`force-delete-branch` opt in — single-target workflows ignore marks entirely, so a checkout can never become plural
- `LogInkPendingItemAction.id` → `ids: string[]`; `isPendingItemAction` keeps its signature (membership check) so every row renderer is untouched
- Confirm target line pluralizes with an exact count + first 4 names: `→ 3 branches: a, b, c` / `+N more` — the user never confirms one item while N get acted on (the #1452 audit's core hazard)

**Resolution ladder** (`getSelectedBranchBatch`): active v-range (positional, visible list) → marked set (full sorted list — a filter must not silently drop explicit marks; they're all named in the confirm) → cursored single (unchanged existing behavior).

**Batch execution**: `deleteBranches` loops with continue-on-error and a summary ("Deleted 2 of 4 branches — 2 refused"); per-branch raw git messages ride in `details` so the not-fully-merged force-delete escalation keeps matching. On batch failure the attempted set is **frozen into marks** (`setMarks`): deleted branches stop resolving after the refresh, so the escalated force-delete re-targets exactly the refused ones — never a stale positional range against the shrunken list.

**Rendering**: marked rows carry a `●`/`*` glyph beside the cursor (surface + sidebar); the branches header shows a live `N marked` / `range: v..cursor` chip; footer gains `x/v mark`.

## Follow-ups (separate PRs per the design doc)
- PR B: batch drop stashes (with the descending-index renumbering handling)
- PR C: cherry-pick range on history (`git cherry-pick oldest^..newest`, existing conflict surfaces handle mid-range stops)
- Batch stage/unstage deferred — already well-served by space auto-advance / `A` / pathspec staging

## Test plan
- [x] `tsc --noEmit` clean, `eslint` clean on all modified files
- [x] `jest` full suite: 333 suites passed (2 skipped, pre-existing), 29 new tests: reducer semantics (toggle/anchor/setMarks/clear, view-scoping, filter survival, repo-frame clearing), batch resolution ladder (marks in list order, dropped stale ids, filter-hidden marks still resolve, backwards range, anchor-gone fallback, cross-view isolation), input dispatch (x auto-advance, sidebar x, v toggle, single-pane precedence over peek, two-stage Esc, unrelated-view Esc), confirm-panel pluralization (+cap/overflow), and `deleteBranches` (success summary, continue-on-error with raw git wording preserved in details, batch-of-one delegation, empty batch, per-branch guards)
- [x] `rollup` build succeeds, no schema.json drift