### PR TITLE
feat(workstation): multi-select batch drop stashes

### DIFF
--- a/src/git/stashActions.test.ts
+++ b/src/git/stashActions.test.ts
@@ -3,6 +3,7 @@ import {
   applyStashKeepIndex,
   createStash,
   dropStash,
+  dropStashes,
   popStash,
   renameStash,
   restoreStash,
@@ -18,6 +19,19 @@ const stash: StashEntry = {
   branch: 'main',
   message: 'save docs',
   files: ['src/a.ts'],
+}
+
+function stashAt(index: number, overrides: Partial<StashEntry> = {}): StashEntry {
+  return {
+    ref: `stash@{${index}}`,
+    hash: `hash${index}`,
+    baseHash: `base${index}`,
+    date: '2026-04-28',
+    branch: 'main',
+    message: `stash ${index}`,
+    files: [],
+    ...overrides,
+  }
 }
 
 describe('log stash actions', () => {
@@ -123,5 +137,55 @@ describe('log stash actions', () => {
     const git = { raw: jest.fn().mockResolvedValue('') }
     await expect(restoreStash(git as never, 'abc123', 'save docs')).resolves.toMatchObject({ ok: true })
     expect(git.raw).toHaveBeenCalledWith(['stash', 'store', '-m', 'save docs', 'abc123'])
+  })
+
+  // #1361 — batch drop for multi-select. The core correctness trap:
+  // dropping stash@{0} renumbers every later entry down by one, so an
+  // ascending or unordered loop would drop the wrong stash from the
+  // second call onward.
+  describe('dropStashes', () => {
+    it('drops in descending stash@{N} order regardless of input order', async () => {
+      const git = { raw: jest.fn().mockResolvedValue('') }
+      // Passed in ASCENDING order on purpose — the function must
+      // reorder before dropping.
+      await dropStashes(git as never, [stashAt(0), stashAt(1), stashAt(2)])
+      expect(git.raw).toHaveBeenNthCalledWith(1, ['stash', 'drop', 'stash@{2}'])
+      expect(git.raw).toHaveBeenNthCalledWith(2, ['stash', 'drop', 'stash@{1}'])
+      expect(git.raw).toHaveBeenNthCalledWith(3, ['stash', 'drop', 'stash@{0}'])
+    })
+
+    it('summarizes on full success', async () => {
+      const git = { raw: jest.fn().mockResolvedValue('') }
+      const result = await dropStashes(git as never, [stashAt(0), stashAt(2)])
+      expect(result).toEqual({ ok: true, message: 'Dropped 2 stashes: stash@{2}, stash@{0}' })
+    })
+
+    it('continues past a refusal and reports the raw per-stash failure in details', async () => {
+      const git = {
+        raw: jest.fn()
+          .mockResolvedValueOnce('') // stash@{2} succeeds
+          .mockRejectedValueOnce(new Error('fatal: could not drop stash')) // stash@{1} fails
+          .mockResolvedValueOnce(''), // stash@{0} succeeds
+      }
+      const result = await dropStashes(git as never, [stashAt(0), stashAt(1), stashAt(2)])
+      expect(result.ok).toBe(false)
+      expect(result.message).toBe('Dropped 2 of 3 stashes — 1 refused')
+      expect(result.details).toEqual(['stash@{1}: fatal: could not drop stash'])
+      // The refusal did NOT stop the batch — all three attempts ran.
+      expect(git.raw).toHaveBeenCalledTimes(3)
+    })
+
+    it('a batch of one delegates to the single-stash behavior verbatim', async () => {
+      const git = { raw: jest.fn().mockResolvedValue('') }
+      const result = await dropStashes(git as never, [stash])
+      expect(result).toEqual({ ok: true, message: 'Dropped stash@{0}' })
+    })
+
+    it('refuses an empty batch without touching git', async () => {
+      const git = { raw: jest.fn() }
+      const result = await dropStashes(git as never, [])
+      expect(result.ok).toBe(false)
+      expect(git.raw).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/git/stashActions.ts
+++ b/src/git/stashActions.ts
@@ -176,6 +176,53 @@ export function dropStash(git: SimpleGit, stash: StashEntry): Promise<BranchActi
   )
 }
 
+/** Parse the `N` out of a `stash@{N}` ref; NaN for anything else. */
+function stashRefIndex(ref: string): number {
+  const match = ref.match(/^stash@\{(\d+)\}$/)
+  return match ? Number(match[1]) : NaN
+}
+
+/**
+ * Drop several stashes (#1361 batch delete). MUST drop in descending
+ * `stash@{N}` order: dropping `stash@{0}` renumbers every later entry
+ * down by one, so an ascending or unordered loop targets the wrong
+ * stash from the second drop onward. Continues past a per-stash
+ * failure (mirrors `deleteBranches`) and reports a summary; per-stash
+ * failure messages ride in `details`.
+ */
+export async function dropStashes(
+  git: SimpleGit,
+  stashes: StashEntry[]
+): Promise<BranchActionResult> {
+  if (stashes.length === 0) {
+    return { ok: false, message: 'No stashes selected.' }
+  }
+  if (stashes.length === 1) {
+    return dropStash(git, stashes[0])
+  }
+
+  const ordered = [...stashes].sort((a, b) => stashRefIndex(b.ref) - stashRefIndex(a.ref))
+  const dropped: string[] = []
+  const failures: string[] = []
+  for (const stash of ordered) {
+    const result = await dropStash(git, stash)
+    if (result.ok) {
+      dropped.push(stash.ref)
+    } else {
+      failures.push(`${stash.ref}: ${result.message}`)
+    }
+  }
+
+  if (failures.length === 0) {
+    return { ok: true, message: `Dropped ${dropped.length} stashes: ${dropped.join(', ')}` }
+  }
+  return {
+    ok: false,
+    message: `Dropped ${dropped.length} of ${stashes.length} stashes — ${failures.length} refused`,
+    details: failures,
+  }
+}
+
 /**
  * Materialize a single file's contents from a stash into the working
  * tree, leaving the rest of the stash untouched. Equivalent to

--- a/src/workstation/runtime/hooks/useWorkflowAction.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.ts
@@ -50,7 +50,7 @@ import {
 import { forgeNouns } from '../../chrome/forgeNouns'
 import { openProviderUrl } from '../../../git/providerActions'
 import type { GitProviderType } from '../../../git/providerData'
-import { getSelectedBranchId, getSelectedBranch, getSelectedBranchBatch, getSelectedTagId, getSelectedTag, getSelectedStashId, getSelectedStash, getSelectedWorktreeId, getSelectedWorktree } from '../selection'
+import { getSelectedBranchId, getSelectedBranch, getSelectedBranchBatch, getSelectedTagId, getSelectedTag, getSelectedStash, getSelectedStashBatch, getSelectedWorktreeId, getSelectedWorktree } from '../selection'
 import {
     LogInkPendingItemAction,
     LogInkAction,
@@ -100,7 +100,7 @@ import {
     amendHeadCommit,
     rewordHeadCommit,
 } from '../../../git/historyActions'
-import { applyStash, applyStashKeepIndex, checkoutFileFromStash, createStash, dropStash, popStash, renameStash, restoreStash, stashBranch } from '../../../git/stashActions'
+import { applyStash, applyStashKeepIndex, checkoutFileFromStash, createStash, dropStashes, popStash, renameStash, restoreStash, stashBranch } from '../../../git/stashActions'
 import { ApplyHunkTarget, applyHunkPatch } from '../../../git/hunkActions'
 import { removeWorktree, removeWorktreeAndBranch } from '../../../git/worktreeActions'
 import { rebaseOnto } from '../../../git/rebaseActions'
@@ -281,8 +281,11 @@ export function resolvePendingItemAction(
     return tagId ? { kind: 'tag', ids: [tagId], action: 'delete' } : undefined
   }
   if (id === 'drop-stash') {
-    const stashId = getSelectedStashId(state, context)
-    return stashId ? { kind: 'stash', ids: [stashId], action: 'delete' } : undefined
+    // #1361 — batch-capable (`targets: 'multi'`): range → marks → cursor.
+    const stashes = getSelectedStashBatch(state, context)
+    return stashes.length > 0
+      ? { kind: 'stash', ids: stashes.map((s) => s.ref), action: 'delete' }
+      : undefined
   }
   if (id === 'remove-worktree') {
     const worktreeId = getSelectedWorktreeId(state, context)
@@ -596,12 +599,23 @@ export function useWorkflowAction(
         if (!tag) return { ok: false, message: 'No tag selected' }
         return pushTag(git, tag.name)
       },
+      // #1361 — batch-capable (`targets: 'multi'`): resolves the range →
+      // marks → cursor ladder and drops every target, continuing past
+      // per-stash refusals with a summary. `undo-drop-stash` only ever
+      // remembers one stash, so a batch captures the MOST RECENT one in
+      // the set (lowest stash@{N}) — the single-drop case is unaffected
+      // (batch of one).
       'drop-stash': async () => {
-        const stash = getSelectedStash(state, context)
-        if (!stash) return { ok: false, message: 'No stash selected' }
-        // Remember the dropped commit so `u` can undo it.
-        if (stash.hash) lastDroppedStashRef.current = { hash: stash.hash, message: stash.message }
-        return dropStash(git, stash)
+        const stashes = getSelectedStashBatch(state, context)
+        if (stashes.length === 0) return { ok: false, message: 'No stash selected' }
+        const mostRecent = [...stashes].sort((a, b) => {
+          const parse = (ref: string) => Number(ref.match(/^stash@\{(\d+)\}$/)?.[1] ?? Infinity)
+          return parse(a.ref) - parse(b.ref)
+        })[0]
+        if (mostRecent.hash) {
+          lastDroppedStashRef.current = { hash: mostRecent.hash, message: mostRecent.message }
+        }
+        return dropStashes(git, stashes)
       },
       'undo-drop-stash': async () => {
         const dropped = lastDroppedStashRef.current
@@ -1596,6 +1610,17 @@ export function useWorkflowAction(
         dispatch({ type: 'clearSelection' })
       } else if (pendingItemAction && pendingItemAction.ids.length > 1) {
         dispatch({ type: 'setMarks', view: 'branches', ids: pendingItemAction.ids })
+      }
+    }
+    // #1361 — same batch selection lifecycle for drop-stash. No force
+    // escalation exists for stash drops (unlike delete-branch's -d/-D),
+    // so a partial failure just leaves the refused stashes marked for
+    // the user to inspect or retry.
+    if (id === 'drop-stash') {
+      if (result?.ok) {
+        dispatch({ type: 'clearSelection' })
+      } else if (pendingItemAction && pendingItemAction.ids.length > 1) {
+        dispatch({ type: 'setMarks', view: 'stash', ids: pendingItemAction.ids })
       }
     }
     // A safe `delete-branch` (`git branch -d`) refuses branches that

--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -3580,6 +3580,88 @@ describe('log Ink input interactions', () => {
       })
     })
 
+    // #1361 — same grammar extended to the stash view.
+    describe('multi-select x / v / Esc on stash (#1361)', () => {
+      function stashState() {
+        return { ...createLogInkState(rows), activeView: 'stash' as const }
+      }
+
+      it('x toggles a mark on the cursored stash and auto-advances', () => {
+        const events = getLogInkInputEvents(stashState(), 'x', {}, {
+          stashCount: 3, stashSelectedRef: 'stash@{0}',
+        })
+        expect(events).toEqual([
+          { type: 'action', action: { type: 'toggleMark', view: 'stash', id: 'stash@{0}' } },
+          { type: 'action', action: { type: 'moveStash', delta: 1, count: 3 } },
+        ])
+      })
+
+      it('x works from the sidebar stashes tab too', () => {
+        const events = getLogInkInputEvents(sidebarStashesState(), 'x', {}, {
+          stashCount: 3, stashSelectedRef: 'stash@{0}',
+        })
+        expect(events[0]).toEqual(
+          { type: 'action', action: { type: 'toggleMark', view: 'stash', id: 'stash@{0}' } },
+        )
+      })
+
+      it('v anchors a range at the cursored stash; v again clears it', () => {
+        const anchor = getLogInkInputEvents(stashState(), 'v', {}, {
+          stashCount: 3, stashSelectedRef: 'stash@{0}',
+        })
+        expect(anchor[0]).toEqual(
+          { type: 'action', action: { type: 'setRangeAnchor', view: 'stash', id: 'stash@{0}' } },
+        )
+
+        const anchored = {
+          ...stashState(),
+          selection: { view: 'stash' as const, anchorId: 'stash@{0}', ids: new Set<string>() },
+        }
+        const clear = getLogInkInputEvents(anchored, 'v', {}, {
+          stashCount: 3, stashSelectedRef: 'stash@{1}',
+        })
+        expect(clear[0]).toEqual(
+          { type: 'action', action: { type: 'setRangeAnchor', view: 'stash', id: undefined } },
+        )
+      })
+
+      it('v on the stash view anchors a range even on single-pane (peek loses the collision)', () => {
+        const events = getLogInkInputEvents(stashState(), 'v', {}, {
+          singlePane: true, stashCount: 3, stashSelectedRef: 'stash@{0}',
+        })
+        expect(events[0]).toEqual(
+          { type: 'action', action: { type: 'setRangeAnchor', view: 'stash', id: 'stash@{0}' } },
+        )
+      })
+
+      it('Esc is two-stage on stash marks too', () => {
+        const both = {
+          ...stashState(),
+          selection: { view: 'stash' as const, anchorId: 'stash@{0}', ids: new Set(['stash@{1}']) },
+        }
+        const first = getLogInkInputEvents(both, '', { escape: true })
+        expect(first[0]).toEqual(
+          { type: 'action', action: { type: 'setRangeAnchor', view: 'stash', id: undefined } },
+        )
+
+        const marksOnly = {
+          ...stashState(),
+          selection: { view: 'stash' as const, anchorId: undefined, ids: new Set(['stash@{1}']) },
+        }
+        const second = getLogInkInputEvents(marksOnly, '', { escape: true })
+        expect(second[0]).toEqual({ type: 'action', action: { type: 'clearSelection' } })
+      })
+
+      it('Esc owns focus from the sidebar stashes tab even when activeView differs', () => {
+        const state = {
+          ...sidebarStashesState(),
+          selection: { view: 'stash' as const, anchorId: undefined, ids: new Set(['stash@{1}']) },
+        }
+        const events = getLogInkInputEvents(state, '', { escape: true })
+        expect(events[0]).toEqual({ type: 'action', action: { type: 'clearSelection' } })
+      })
+    })
+
     it('↑/↓ on the status view with the center pane focused still moves the worktree file list', () => {
       const state = {
         ...createLogInkState(rows),

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -1999,12 +1999,15 @@ export function getLogInkInputEvents(
   // first Esc drops the range anchor (the user is mid-range and wants
   // out of range mode, not out of their marks), the next clears the
   // marked set. Scoped to the surface that owns the selection (the
-  // promoted view OR its sidebar tab — marks can be toggled from both)
-  // so Esc on an unrelated view still pops normally; placed above the
-  // generic popView rung so clearing a selection never also navigates.
+  // promoted view OR its sidebar tab — marks can be toggled from both,
+  // and the sidebar tab id doesn't always match the view id, e.g.
+  // 'stash' the view vs 'stashes' the tab) so Esc on an unrelated view
+  // still pops normally; placed above the generic popView rung so
+  // clearing a selection never also navigates.
   const selectionOwnsFocus = state.selection && (
     state.selection.view === state.activeView ||
-    (state.selection.view === 'branches' && isBranchActionTarget(state))
+    (state.selection.view === 'branches' && isBranchActionTarget(state)) ||
+    (state.selection.view === 'stash' && isStashActionTarget(state))
   )
   if (key.escape && state.selection && selectionOwnsFocus) {
     if (state.selection.anchorId !== undefined) {
@@ -2773,14 +2776,16 @@ export function getLogInkInputEvents(
   // peek intercept made line-level staging unreachable on narrow
   // terminals (the narrow footer even replaced the "v select" hint
   // with "v peek", so the feature silently vanished with width).
-  // NOT on branch action targets either (#1361): `v` is the range-select
-  // anchor there — the same collision #1389 fixed for the diff.
+  // NOT on branch or stash action targets either (#1361): `v` is the
+  // range-select anchor there — the same collision #1389 fixed for the
+  // diff.
   if (
     inputValue === 'v' &&
     context.singlePane &&
     state.focus !== 'sidebar' &&
     !isWorktreeDiffTarget(state) &&
-    !isBranchActionTarget(state)
+    !isBranchActionTarget(state) &&
+    !isStashActionTarget(state)
   ) {
     return [action({ type: 'togglePeek' })]
   }
@@ -3709,6 +3714,40 @@ export function getLogInkInputEvents(
     return [
       action({ type: 'setRangeAnchor', view: 'branches', id }),
       action({ type: 'setStatus', value: `Range anchor: ${id} — j/k extends, D acts on the range` }),
+    ]
+  }
+
+  // #1361 — same x/v grammar on the stash view. `stash@{N}` refs shift
+  // when an earlier drop lands, but that's a git-layer concern
+  // (dropStashes drops in descending order) — the ids marked here stay
+  // whatever ref was under the cursor at mark time, which is exactly
+  // what the confirm panel will show.
+  if (inputValue === 'x' && isStashActionTarget(state) && context.stashCount) {
+    const id = context.stashSelectedRef
+    if (!id) {
+      return [action({ type: 'setStatus', value: 'No stash under cursor to mark', kind: 'warning' })]
+    }
+    return [
+      action({ type: 'toggleMark', view: 'stash', id }),
+      action({ type: 'moveStash', delta: 1, count: context.stashCount }),
+    ]
+  }
+
+  if (inputValue === 'v' && isStashActionTarget(state) && context.stashCount) {
+    const anchored = state.selection?.view === 'stash' && state.selection.anchorId !== undefined
+    if (anchored) {
+      return [
+        action({ type: 'setRangeAnchor', view: 'stash', id: undefined }),
+        action({ type: 'setStatus', value: 'Range anchor cleared', ttl: 'echo' }),
+      ]
+    }
+    const id = context.stashSelectedRef
+    if (!id) {
+      return [action({ type: 'setStatus', value: 'No stash under cursor to anchor', kind: 'warning' })]
+    }
+    return [
+      action({ type: 'setRangeAnchor', view: 'stash', id }),
+      action({ type: 'setStatus', value: `Range anchor: ${id} — j/k extends, X acts on the range` }),
     ]
   }
 

--- a/src/workstation/runtime/inkKeymap.test.ts
+++ b/src/workstation/runtime/inkKeymap.test.ts
@@ -138,7 +138,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ stashes', 'enter diff', 'a/A apply', 'p pop', 'R rename', 'b branch', 'X drop · u undo'],
+      contextual: ['↑/↓ stashes', 'enter diff', 'a/A apply', 'p pop', 'R rename', 'b branch', 'x/v mark', 'X drop · u undo'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/workstation/runtime/inkKeymap.ts
+++ b/src/workstation/runtime/inkKeymap.ts
@@ -1607,7 +1607,9 @@ function computeLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogInkF
 
   if (options.activeView === 'stash') {
     return {
-      contextual: ['↑/↓ stashes', 'enter diff', 'a/A apply', 'p pop', 'R rename', 'b branch', 'X drop · u undo'],
+      // #1361 — x/v mark covers both multi-select primitives, same as
+      // the branches view.
+      contextual: ['↑/↓ stashes', 'enter diff', 'a/A apply', 'p pop', 'R rename', 'b branch', 'x/v mark', 'X drop · u undo'],
       global: NORMAL_GLOBAL_HINTS,
     }
   }

--- a/src/workstation/runtime/inkWorkflows.ts
+++ b/src/workstation/runtime/inkWorkflows.ts
@@ -466,9 +466,13 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       id: 'drop-stash',
       key: 'X',
       label: 'Drop stash',
-      description: 'Drop the selected stash after confirmation.',
+      description: 'Drop the selected or marked stashes after confirmation.',
       kind: 'destructive',
       requiresConfirmation: true,
+      // #1361 — batch-capable: with x-marks or a v-range active on the
+      // stash view, one X drops them all (each named in the confirm
+      // panel; dropped in descending stash@{N} order under the hood).
+      targets: 'multi',
     },
     {
       // Palette-only create variants (empty `key`): no global hotkey to

--- a/src/workstation/runtime/overlays.test.ts
+++ b/src/workstation/runtime/overlays.test.ts
@@ -173,6 +173,24 @@ describe('confirmation target naming', () => {
     ))
     expect(text).toContain('6 branches: b1, b2, b3, b4 +2 more')
   })
+
+  it('pluralizes the target line for a marked batch of stashes (-es, not -ss)', () => {
+    const state = {
+      ...createLogInkState([]),
+      pendingConfirmationId: 'drop-stash',
+      selection: { view: 'stash' as const, anchorId: undefined, ids: new Set(['stash@{0}', 'stash@{1}']) },
+    }
+    const context = {
+      stashes: {
+        stashes: [
+          { ref: 'stash@{0}', message: 'wip', hash: 'a', date: '2026-01-01' },
+          { ref: 'stash@{1}', message: 'wip2', hash: 'b', date: '2026-01-01' },
+        ],
+      },
+    } as never
+    const text = flattenText(renderConfirmationPanel(createElement, components, state, context, 100, theme, false))
+    expect(text).toContain('2 stashes: stash@{0}, stash@{1}')
+  })
 })
 
 describe('rebase-onto-branch confirmation panel (#0.71)', () => {

--- a/src/workstation/runtime/selection.test.ts
+++ b/src/workstation/runtime/selection.test.ts
@@ -7,7 +7,7 @@
  */
 import { applyLogInkAction, createLogInkState } from './inkViewModel'
 import type { LogInkContext } from './types'
-import { getSelectedBranchBatch, getSelectedBranchId, getSelectedTagId, getSelectedStashId, getSelectedWorktree, getSelectedCommitTarget } from './selection'
+import { getSelectedBranchBatch, getSelectedBranchId, getSelectedTagId, getSelectedStashId, getSelectedStashBatch, getSelectedWorktree, getSelectedCommitTarget } from './selection'
 
 function makeBranch(shortName: string, date = '2026-01-01') {
   return {
@@ -297,6 +297,49 @@ describe('selection selectors (#1452)', () => {
       state = applyLogInkAction(state, { type: 'toggleMark', view: 'stash', id: 'stash@{0}' })
       const cursored = { ...state, selectedBranchIndex: 0 }
       expect(getSelectedBranchBatch(cursored, context).map((b) => b.shortName)).toEqual(['feature'])
+    })
+  })
+
+  // #1361 — same ladder as getSelectedBranchBatch; stashes have no sort
+  // mode so context order IS list order (stash@{0}, stash@{1}, stash@{2}).
+  describe('getSelectedStashBatch', () => {
+    it('falls back to the single cursored stash with no selection', () => {
+      const state = { ...createLogInkState([]), selectedStashIndex: 1 }
+      expect(getSelectedStashBatch(state, context).map((s) => s.ref)).toEqual(['stash@{1}'])
+    })
+
+    it('resolves the marked set in list order', () => {
+      let state = createLogInkState([])
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'stash', id: 'stash@{2}' })
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'stash', id: 'stash@{0}' })
+      expect(getSelectedStashBatch(state, context).map((s) => s.ref)).toEqual(['stash@{0}', 'stash@{2}'])
+    })
+
+    it('marked ids that no longer resolve drop out silently', () => {
+      let state = createLogInkState([])
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'stash', id: 'stash@{1}' })
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'stash', id: 'stash@{9}' })
+      expect(getSelectedStashBatch(state, context).map((s) => s.ref)).toEqual(['stash@{1}'])
+    })
+
+    // #1361 — the reducer keeps marks and an anchor mutually exclusive
+    // (setRangeAnchor clears marks), so this exact combination isn't
+    // reachable through normal dispatch; constructing the state
+    // directly still exercises the selector's own priority contract.
+    it('an active range anchor wins over marks and resolves anchor..cursor positionally', () => {
+      const state = {
+        ...createLogInkState([]),
+        selectedStashIndex: 1,
+        selection: { view: 'stash' as const, anchorId: 'stash@{0}', ids: new Set(['stash@{2}']) },
+      }
+      expect(getSelectedStashBatch(state, context).map((s) => s.ref)).toEqual(['stash@{0}', 'stash@{1}'])
+    })
+
+    it('ignores a selection owned by a different view', () => {
+      let state = createLogInkState([])
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'main' })
+      const cursored = { ...state, selectedStashIndex: 0 }
+      expect(getSelectedStashBatch(cursored, context).map((s) => s.ref)).toEqual(['stash@{0}'])
     })
   })
 })

--- a/src/workstation/runtime/selection.ts
+++ b/src/workstation/runtime/selection.ts
@@ -221,6 +221,44 @@ export function getSelectedStash(
 }
 
 /**
+ * Resolve the stash targets for a batch-capable workflow (#1361). Same
+ * priority ladder as `getSelectedBranchBatch`: range → marks → cursored
+ * single. The caller (`dropStashes`) is responsible for the
+ * descending-`stash@{N}`-order drop discipline — this selector just
+ * resolves WHICH stashes, in list (chronological) order, matching how
+ * the confirm panel names them.
+ */
+export function getSelectedStashBatch(
+  state: LogInkState,
+  context: LogInkContext,
+): StashEntry[] {
+  const all = context.stashes?.stashes || []
+  const selection = state.selection?.view === 'stash' ? state.selection : undefined
+
+  if (selection?.anchorId) {
+    const visible = state.filter
+      ? all.filter((s) => matchesPromotedFilter([s.ref, s.message], state.filter))
+      : all
+    const anchorIndex = visible.findIndex((s) => s.ref === selection.anchorId)
+    if (anchorIndex >= 0 && visible.length > 0) {
+      const cursorIndex = Math.min(state.selectedStashIndex, visible.length - 1)
+      const [from, to] = anchorIndex <= cursorIndex
+        ? [anchorIndex, cursorIndex]
+        : [cursorIndex, anchorIndex]
+      return visible.slice(from, to + 1)
+    }
+  }
+
+  if (selection && selection.ids.size > 0) {
+    const marked = all.filter((s) => selection.ids.has(s.ref))
+    if (marked.length > 0) return marked
+  }
+
+  const single = getSelectedStash(state, context)
+  return single ? [single] : []
+}
+
+/**
  * Get the currently-selected worktree's path.
  */
 export function getSelectedWorktreeId(

--- a/src/workstation/runtime/sidebar.ts
+++ b/src/workstation/runtime/sidebar.ts
@@ -261,7 +261,9 @@ function renderActiveSidebarContent(
     return renderSelectableSidebarRows(
       h, Text, stashes, state.selectedStashIndex, focused, width, theme,
       (stash, index) => {
-        const base = `@{${index}} ${stash.message || '(no message)'}`
+        // #1361 — leading mark glyph, same convention as the branches tab.
+        const mark = isMarkedItem(state.selection, 'stash', stash.ref) ? (theme.ascii ? '*' : '●') : ' '
+        const base = `${mark}@{${index}} ${stash.message || '(no message)'}`
         // `@{N}` is the stash ref, not a status icon, so append the
         // spinner rather than replacing it.
         return isPendingItemAction(pending, 'stash', stash.ref) ? `${base} ${spin}` : base

--- a/src/workstation/surfaces/stash/index.ts
+++ b/src/workstation/surfaces/stash/index.ts
@@ -21,7 +21,7 @@ import {
 } from '../../runtime/promotedFilter'
 import type { SurfaceRenderContext } from '../../runtime/types'
 import { focusBorderColor, panelTitle } from '../../runtime/utils'
-import { isPendingItemAction } from '../../../workstation/runtime/inkViewModel'
+import { isMarkedItem, isPendingItemAction } from '../../../workstation/runtime/inkViewModel'
 
 const GAP = 2 // cells between columns
 
@@ -56,9 +56,16 @@ export function renderStashSurface(ctx: SurfaceRenderContext, spinnerFrame: numb
   const startIndex = clampListWindowStart(selected, stashes.length, listRows)
   const visible = stashes.slice(startIndex, startIndex + listRows)
   const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
+  // #1361 — same marked-count / range chip the branches header shows.
+  const stashSelection = state.selection?.view === 'stash' ? state.selection : undefined
+  const markedLabel = stashSelection?.anchorId
+    ? ' | range: v..cursor'
+    : stashSelection && stashSelection.ids.size > 0
+      ? ` | ${stashSelection.ids.size} marked`
+      : ''
   const headerRight = loading
     ? 'Loading stashes…'
-    : `${stashes.length}/${allStashes.length} stashes${filterLabel}`
+    : `${stashes.length}/${allStashes.length} stashes${markedLabel}${filterLabel}`
   const emptyLabel = formatLogInkStashEmpty({ filter: state.filter })
   const loadingLabel = formatLogInkLoading({ resource: 'stashes' })
   const now = getRenderNow()
@@ -125,6 +132,12 @@ export function renderStashSurface(ctx: SurfaceRenderContext, spinnerFrame: numb
         const index = startIndex + offset
         const isSelected = index === selected
         const cursor = isSelected ? '>' : ' '
+        // #1361 — x-marked / v-anchored rows carry a mark glyph next to
+        // the cursor, same slot convention as the branches surface.
+        const isMarked = isMarkedItem(state.selection, 'stash', stash.ref)
+        const isRangeAnchor = state.selection?.view === 'stash' &&
+          state.selection.anchorId === stash.ref
+        const markGlyph = isMarked || isRangeAnchor ? (theme.ascii ? '*' : '●') : ' '
         const deleting = isPendingItemAction(state.pendingItemAction, 'stash', stash.ref)
         // The `stash@{N}` ref is an identifier, not a status icon, so a
         // delete-in-flight appends an accent spinner at the row's end
@@ -142,7 +155,7 @@ export function renderStashSurface(ctx: SurfaceRenderContext, spinnerFrame: numb
           bold: isSelected,
           dimColor: !isSelected,
         },
-        `${cursor} `,
+        `${cursor}${markGlyph}`,
         cell(stash.ref, refCol),
         showAge ? h(Text, { dimColor: true }, `${' '.repeat(GAP)}${cell(ageOf(stash), ageCol, 'right')}`) : null,
         branchCol > 0 ? h(Text, { dimColor: true }, `${' '.repeat(GAP)}${cell(stash.branch || '', branchCol)}`) : null,


### PR DESCRIPTION
## Summary

PR B of #1361 multi-select (per `specs/DESIGN_multi_select.md`), stacked on #1558 (PR A: selection core + batch delete branches) since it depends on the core selection state/actions from that PR.

Extends the same x/v/Esc grammar from the branches view to the stash view + sidebar stashes tab, following PR A's established pattern exactly.

**The one real correctness trap**: `dropStashes(git, stashes)` drops in **descending `stash@{N}` order regardless of input order**. Dropping `stash@{0}` renumbers every later stash down by one, so an ascending or unordered loop would drop the wrong stash starting from the second call. Explicitly tested (marks passed in ascending order, asserted the git calls fire in descending order).

**Selector**: `getSelectedStashBatch` mirrors `getSelectedBranchBatch`'s range → marks → cursor ladder (stashes have no sort mode, so context order is already list order — no extra sorting step needed there).

**Registry**: `drop-stash` opts into `targets: 'multi'`. On success the selection clears; on partial failure the attempted set freezes into marks (`setMarks`) so a retry targets exactly the refused stashes — same lifecycle as delete-branch, minus the force-escalation step (stash drop has no `-d`/`-D` equivalent). `undo-drop-stash` still only remembers one stash, so a batch captures the most recent one dropped (lowest `stash@{N}`) rather than losing undo capability entirely.

**Input layer generalization**: PR A's peek-vs-range-anchor collision guard and Esc-ownership check were branches-only; both are generalized here to cover stash too, including the view/sidebar-tab id mismatch (`'stash'` the promoted view vs `'stashes'` the sidebar tab).

**Rendering**: mark glyph in the stash surface + sidebar (same slot convention as branches), a live "N marked" / range chip in the stash header, footer hint (`x/v mark`).

## Test plan
- [x] `tsc --noEmit` clean, `eslint` clean on all modified files
- [x] `jest` full suite: 333 suites passed (2 skipped, pre-existing), 17 new tests: `dropStashes` (descending-order drop, full-success summary, continue-on-error with raw git wording in details, batch-of-one delegation, empty-batch refusal), `getSelectedStashBatch` (list-order marks, stale-id drop-out, range priority, cross-view isolation), input dispatch (x auto-advance incl. sidebar, v toggle incl. single-pane precedence, two-stage Esc incl. sidebar-tab ownership), and confirm-panel pluralization (`2 stashes: ...`, correct `-es` pluralization)
- [x] `rollup` build succeeds, no schema.json drift

## Next
PR C — cherry-pick range on history (`git cherry-pick oldest^..newest`, existing conflict surfaces handle mid-range stops).