### PR TITLE
feat(workstation): multi-select cherry-pick range on history

### DIFF
--- a/src/git/historyActions.test.ts
+++ b/src/git/historyActions.test.ts
@@ -5,6 +5,7 @@ import {
   amendHeadCommit,
   checkoutOrDeleteFromRef,
   cherryPickCommit,
+  cherryPickRange,
   compareCommits,
   copyCommitHash,
   copyCommitMessage,
@@ -255,6 +256,57 @@ describe('log history actions', () => {
 
     expect(git.raw).toHaveBeenNthCalledWith(1, ['cherry-pick', commit.hash])
     expect(git.raw).toHaveBeenNthCalledWith(2, ['revert', '--no-edit', commit.hash])
+  })
+
+  // #1361 — history is v-range only for multi-select; cherry-pick's own
+  // range syntax replays the span in one command, unlike stash drop
+  // there's no per-item ordering to get wrong here.
+  describe('cherryPickRange', () => {
+    const oldest = { hash: 'oldest1234567890', shortHash: 'oldest12', message: 'feat: oldest' }
+    const newest = { hash: 'newest1234567890', shortHash: 'newest12', message: 'feat: newest' }
+
+    it('constructs the oldest^..newest range command', async () => {
+      const git = {
+        revparse: jest.fn().mockResolvedValue('/tmp/coco-missing-git-state'),
+        raw: jest.fn().mockResolvedValue(''),
+      }
+      await expect(cherryPickRange(git as never, oldest, newest)).resolves.toEqual({
+        ok: true,
+        message: 'Cherry-picked oldest12..newest12',
+      })
+      expect(git.raw).toHaveBeenCalledWith(['cherry-pick', 'oldest1234567890^..newest1234567890'])
+    })
+
+    it('delegates to the single-commit path when the range collapses to one commit', async () => {
+      const git = {
+        revparse: jest.fn().mockResolvedValue('/tmp/coco-missing-git-state'),
+        raw: jest.fn().mockResolvedValue(''),
+      }
+      await expect(cherryPickRange(git as never, commit, commit)).resolves.toEqual({
+        ok: true,
+        message: 'Cherry-picked abcdef1',
+      })
+      expect(git.raw).toHaveBeenCalledWith(['cherry-pick', commit.hash])
+    })
+
+    it('blocks while another git operation is in progress, same guard as the single commit', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'coco-history-range-'))
+      const mergeHead = join(tempDir, 'MERGE_HEAD')
+      writeFileSync(mergeHead, oldest.hash)
+      const git = {
+        revparse: jest.fn().mockResolvedValue(mergeHead),
+        raw: jest.fn(),
+      }
+      try {
+        await expect(cherryPickRange(git as never, oldest, newest)).resolves.toEqual({
+          ok: false,
+          message: 'Finish or abort the in-progress merge before editing history.',
+        })
+        expect(git.raw).not.toHaveBeenCalled()
+      } finally {
+        rmSync(tempDir, { force: true, recursive: true })
+      }
+    })
   })
 
   it('constructs reset and rebase commands with recovery guidance', async () => {

--- a/src/git/historyActions.ts
+++ b/src/git/historyActions.ts
@@ -353,6 +353,39 @@ export function cherryPickCommit(
 }
 
 /**
+ * Cherry-pick a contiguous range (#1361 multi-select — history is
+ * v-range only, no marks: a range is what "select a run of commits"
+ * naturally means, and `git cherry-pick`'s own range syntax already
+ * replays them in the right order in one command, so there's no
+ * per-item loop to get wrong the way stash drop order was.
+ *
+ * `oldest^..newest` — `oldest` is chronologically first (deepest in
+ * history) in the selected span, `newest` is chronologically last
+ * (closest to HEAD); the caller is responsible for that ordering
+ * (list display order is newest-first, so this is index-reversed from
+ * what's on screen). A conflict stops the sequence exactly like a
+ * single cherry-pick conflict — the existing conflict-recovery /
+ * continue-operation surfaces handle cherry-pick-in-progress state
+ * already, nothing range-specific needed there.
+ */
+export function cherryPickRange(
+  git: SimpleGit,
+  oldest: HistoryCommitRef,
+  newest: HistoryCommitRef
+): Promise<BranchActionResult> {
+  if (oldest.hash === newest.hash) {
+    return cherryPickCommit(git, newest)
+  }
+
+  return guardNoInProgressOperation(git).then((blocked) => (
+    blocked || runAction(
+      () => git.raw(['cherry-pick', `${oldest.hash}^..${newest.hash}`]),
+      `Cherry-picked ${oldest.shortHash}..${newest.shortHash}`
+    )
+  ))
+}
+
+/**
  * Materialize a single file's contents from a historical commit into the
  * working tree, leaving every other path untouched. Equivalent to
  * `git checkout <sha> -- <path>` for additions/modifications. When the

--- a/src/workstation/runtime/__snapshots__/footer.test.ts.snap
+++ b/src/workstation/runtime/__snapshots__/footer.test.ts.snap
@@ -14,7 +14,7 @@ exports[`renderFooter structural snapshot — default no-status footer 1`] = `
       color="gray"
       dimColor={true}
     >
-      ↑/↓ move   enter diff   c/R/Z/i mutate   f fixup   B/gT new   m compare   y/Y yank   / search
+      ↑/↓ move   enter diff   c/R/Z/i mutate   f fixup   B/gT new   m compare   v range   y/Y yank   / search
     </Text>
     <Text
       color="gray"
@@ -44,7 +44,7 @@ exports[`renderFooter structural snapshot — error keeps hints visible on row 1
       color="gray"
       dimColor={true}
     >
-      ↑/↓ move   enter diff   c/R/Z/i mutate   f fixup   B/gT new   m compare   y/Y yank   / search
+      ↑/↓ move   enter diff   c/R/Z/i mutate   f fixup   B/gT new   m compare   v range   y/Y yank   / search
     </Text>
     <Text
       color="gray"
@@ -77,7 +77,7 @@ exports[`renderFooter structural snapshot — loading status on row 2 1`] = `
       color="gray"
       dimColor={true}
     >
-      ↑/↓ move   enter diff   c/R/Z/i mutate   f fixup   B/gT new   m compare   y/Y yank   / search
+      ↑/↓ move   enter diff   c/R/Z/i mutate   f fixup   B/gT new   m compare   v range   y/Y yank   / search
     </Text>
     <Text
       color="gray"

--- a/src/workstation/runtime/hooks/useWorkflowAction.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.ts
@@ -50,7 +50,7 @@ import {
 import { forgeNouns } from '../../chrome/forgeNouns'
 import { openProviderUrl } from '../../../git/providerActions'
 import type { GitProviderType } from '../../../git/providerData'
-import { getSelectedBranchId, getSelectedBranch, getSelectedBranchBatch, getSelectedTagId, getSelectedTag, getSelectedStash, getSelectedStashBatch, getSelectedWorktreeId, getSelectedWorktree } from '../selection'
+import { getSelectedBranchId, getSelectedBranch, getSelectedBranchBatch, getSelectedTagId, getSelectedTag, getSelectedStash, getSelectedStashBatch, getSelectedCommitRange, getSelectedWorktreeId, getSelectedWorktree } from '../selection'
 import {
     LogInkPendingItemAction,
     LogInkAction,
@@ -88,6 +88,7 @@ import {
     ResetMode,
     checkoutFileFromCommit,
     cherryPickCommit,
+    cherryPickRange,
     createBranchFromCommit,
     createTagAtCommit,
     defaultOpenUrlRunner,
@@ -758,7 +759,22 @@ export function useWorkflowAction(
         if (!ref) return { ok: false, message: 'No stash ref active' }
         return checkoutFileFromStash(git, ref, path)
       },
+      // #1361 — history is v-range only (no x-marks): an active range
+      // cherry-picks as one `oldest^..newest` command instead of the
+      // single-commit path. `range` is in display order (newest
+      // first), so the git-layer args are index-reversed from what's
+      // on screen.
       'cherry-pick-commit': async () => {
+        const range = getSelectedCommitRange(state)
+        if (range && range.length > 1) {
+          const newest = range[0]
+          const oldest = range[range.length - 1]
+          return cherryPickRange(
+            git,
+            { hash: oldest.hash, shortHash: oldest.shortHash, message: oldest.message },
+            { hash: newest.hash, shortHash: newest.shortHash, message: newest.message },
+          )
+        }
         const commit = getSelectedInkCommit(state)
         if (!commit) return { ok: false, message: 'No commit selected' }
         return cherryPickCommit(git, {
@@ -1622,6 +1638,16 @@ export function useWorkflowAction(
       } else if (pendingItemAction && pendingItemAction.ids.length > 1) {
         dispatch({ type: 'setMarks', view: 'stash', ids: pendingItemAction.ids })
       }
+    }
+    // #1361 — a successful range cherry-pick consumed the selection;
+    // clear it so a stale range can't re-aim the next `c`. On failure
+    // (a conflict) the repo is now mid-cherry-pick and the existing
+    // conflict-recovery prompt takes over — leave the range alone so
+    // an abort-and-retry doesn't lose it. There's no plural
+    // pendingItemAction for commits to freeze a partial attempt into
+    // (cherry-pick's git command is one op, not a per-item loop).
+    if (id === 'cherry-pick-commit' && result?.ok) {
+      dispatch({ type: 'clearSelection' })
     }
     // A safe `delete-branch` (`git branch -d`) refuses branches that
     // aren't fully merged. Rather than dead-end on git's raw error, raise

--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -3662,6 +3662,64 @@ describe('log Ink input interactions', () => {
       })
     })
 
+    // #1361 — history is v-range only (no x-marks): cherry-pick's range
+    // syntax already replays a span correctly in one command.
+    describe('multi-select v / Esc on history (#1361)', () => {
+      function historyState() {
+        return { ...createLogInkState(rows), activeView: 'history' as const, focus: 'commits' as const }
+      }
+
+      it('v anchors a range at the cursored commit; v again clears it', () => {
+        const anchor = getLogInkInputEvents(historyState(), 'v', {})
+        expect(anchor[0]).toEqual(
+          { type: 'action', action: { type: 'setRangeAnchor', view: 'history', id: 'abc123456789' } },
+        )
+
+        const anchored = {
+          ...historyState(),
+          selection: { view: 'history' as const, anchorId: 'abc123456789', ids: new Set<string>() },
+        }
+        const clear = getLogInkInputEvents(anchored, 'v', {})
+        expect(clear[0]).toEqual(
+          { type: 'action', action: { type: 'setRangeAnchor', view: 'history', id: undefined } },
+        )
+      })
+
+      it('v on history anchors a range even on single-pane (peek loses the collision)', () => {
+        const events = getLogInkInputEvents(historyState(), 'v', {}, { singlePane: true })
+        expect(events[0]).toEqual(
+          { type: 'action', action: { type: 'setRangeAnchor', view: 'history', id: 'abc123456789' } },
+        )
+      })
+
+      it('v is a no-op while the cursor is on the synthetic new-commit row', () => {
+        const state = { ...historyState(), pendingCommitFocused: true }
+        const events = getLogInkInputEvents(state, 'v', {})
+        expect(events).toEqual([])
+      })
+
+      it('Esc is two-stage on a history range too', () => {
+        const both = {
+          ...historyState(),
+          selection: { view: 'history' as const, anchorId: 'abc123456789', ids: new Set<string>() },
+        }
+        const first = getLogInkInputEvents(both, '', { escape: true })
+        expect(first[0]).toEqual(
+          { type: 'action', action: { type: 'setRangeAnchor', view: 'history', id: undefined } },
+        )
+      })
+
+      it('Esc on an unrelated view leaves the history range alone', () => {
+        const state = {
+          ...createLogInkState(rows),
+          activeView: 'branches' as const,
+          selection: { view: 'history' as const, anchorId: 'abc123456789', ids: new Set<string>() },
+        }
+        const events = getLogInkInputEvents(state, '', { escape: true })
+        expect(events).not.toContainEqual({ type: 'action', action: { type: 'setRangeAnchor', view: 'history', id: undefined } })
+      })
+    })
+
     it('↑/↓ on the status view with the center pane focused still moves the worktree file list', () => {
       const state = {
         ...createLogInkState(rows),
@@ -5874,9 +5932,16 @@ describe('triage filter cycling (#882 phase 6)', () => {
   // any explicit focus change or drill-in cancels the ticket.
   describe('peek (single-pane sidebar glance)', () => {
     const singlePane = { singlePane: true }
+    // #1361 — history now carves itself out of the peek intercept (`v`
+    // anchors a cherry-pick range there instead), so these fixtures use
+    // 'status' — any main-pane view not claimed by a range/mark grammar
+    // exercises the same peek behavior the default history state used to.
+    function peekBaseState(): LogInkState {
+      return { ...createLogInkState(rows), activeView: 'status' }
+    }
 
     it('v opens a sidebar peek from the main pane and stores the return focus', () => {
-      let state = createLogInkState(rows)
+      let state = peekBaseState()
       expect(state.focus).toBe('commits')
 
       state = applyInput(state, 'v', {}, singlePane)
@@ -5922,7 +5987,7 @@ describe('triage filter cycling (#882 phase 6)', () => {
     })
 
     it('v again snaps back to the original pane and clears the ticket', () => {
-      let state = createLogInkState(rows)
+      let state = peekBaseState()
       state = applyInput(state, 'v', {}, singlePane)
       state = applyInput(state, 'v', {}, singlePane)
       expect(state.focus).toBe('commits')
@@ -5930,7 +5995,7 @@ describe('triage filter cycling (#882 phase 6)', () => {
     })
 
     it('Esc closes a peek back to the original pane', () => {
-      let state = createLogInkState(rows)
+      let state = peekBaseState()
       state = applyInput(state, 'v', {}, singlePane)
       state = applyInput(state, '', { escape: true }, singlePane)
       expect(state.focus).toBe('commits')
@@ -5938,7 +6003,7 @@ describe('triage filter cycling (#882 phase 6)', () => {
     })
 
     it('keeps the peek open while browsing the sidebar (←/→ tab switch)', () => {
-      let state = createLogInkState(rows)
+      let state = peekBaseState()
       state = applyInput(state, 'v', {}, singlePane)
       expect(state.sidebarTab).toBe('branches')
 
@@ -5950,14 +6015,14 @@ describe('triage filter cycling (#882 phase 6)', () => {
     })
 
     it('Tab cancels the peek ticket (explicit focus change)', () => {
-      let state = createLogInkState(rows)
+      let state = peekBaseState()
       state = applyInput(state, 'v', {}, singlePane)
       state = applyInput(state, '', { tab: true }, singlePane)
       expect(state.peekReturnFocus).toBeUndefined()
     })
 
     it('v is a no-op in the three-pane layout (not single-pane)', () => {
-      let state = createLogInkState(rows)
+      let state = peekBaseState()
       state = applyInput(state, 'v', {}, { singlePane: false })
       expect(state.focus).toBe('commits')
       expect(state.peekReturnFocus).toBeUndefined()

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -499,6 +499,20 @@ function isStashActionTarget(state: LogInkState): boolean {
 }
 
 /**
+ * True when `v` on the history view should anchor a cherry-pick range
+ * (#1361) rather than fall through to peek / any other `v` binding.
+ * History has no sidebar tab, so this is simpler than the promoted-view
+ * predicates above — just the one condition, shared with the actual
+ * range-anchor handler so the two can't drift.
+ */
+function isHistoryRangeTarget(state: LogInkState): boolean {
+  return state.activeView === 'history' &&
+    state.focus === 'commits' &&
+    state.filteredCommits.length > 0 &&
+    !state.pendingCommitFocused
+}
+
+/**
  * Reflog has no sidebar tab — only the dedicated promoted view (#781).
  * The condition stays as a single helper anyway so navigation handlers
  * can read it the same way they do for the other promoted views.
@@ -2776,16 +2790,17 @@ export function getLogInkInputEvents(
   // peek intercept made line-level staging unreachable on narrow
   // terminals (the narrow footer even replaced the "v select" hint
   // with "v peek", so the feature silently vanished with width).
-  // NOT on branch or stash action targets either (#1361): `v` is the
-  // range-select anchor there — the same collision #1389 fixed for the
-  // diff.
+  // NOT on branch, stash, or history range targets either (#1361): `v`
+  // is the range-select anchor there — the same collision #1389 fixed
+  // for the diff.
   if (
     inputValue === 'v' &&
     context.singlePane &&
     state.focus !== 'sidebar' &&
     !isWorktreeDiffTarget(state) &&
     !isBranchActionTarget(state) &&
-    !isStashActionTarget(state)
+    !isStashActionTarget(state) &&
+    !isHistoryRangeTarget(state)
   ) {
     return [action({ type: 'togglePeek' })]
   }
@@ -4141,9 +4156,34 @@ export function getLogInkInputEvents(
     }
   }
 
+  // #1361 — `v` anchors a range on the history view; j/k extends it
+  // (live span anchor..cursor) and `c` cherry-picks the range as one
+  // `oldest^..newest` command instead of a single commit. History is
+  // range-only (no x-marks) — a contiguous run is what "select several
+  // commits" naturally means, and the range syntax already replays
+  // them correctly without a per-item loop to get wrong.
+  if (inputValue === 'v' && isHistoryRangeTarget(state)) {
+    const anchored = state.selection?.view === 'history' && state.selection.anchorId !== undefined
+    if (anchored) {
+      return [
+        action({ type: 'setRangeAnchor', view: 'history', id: undefined }),
+        action({ type: 'setStatus', value: 'Range anchor cleared', ttl: 'echo' }),
+      ]
+    }
+    const id = state.filteredCommits[state.selectedIndex]?.hash
+    if (!id) {
+      return [action({ type: 'setStatus', value: 'No commit under cursor to anchor', kind: 'warning' })]
+    }
+    return [
+      action({ type: 'setRangeAnchor', view: 'history', id }),
+      action({ type: 'setStatus', value: 'Range anchor set — j/k extends, c cherry-picks the range' }),
+    ]
+  }
+
   // `c` on the history view cherry-picks the full selected commit on
-  // top of the current branch. Routed through the y-confirm flow since
-  // it can produce conflicts and is a real working-tree mutation.
+  // top of the current branch (or the active v-range as one command,
+  // #1361). Routed through the y-confirm flow since it can produce
+  // conflicts and is a real working-tree mutation.
   if (
     inputValue === 'c' &&
     state.activeView === 'history' &&

--- a/src/workstation/runtime/inkKeymap.footerHonesty.test.ts
+++ b/src/workstation/runtime/inkKeymap.footerHonesty.test.ts
@@ -785,12 +785,17 @@ function pendingKeyGFixture(): Fixture {
 }
 
 function peekingFixture(): Fixture {
-  const events = getLogInkInputEvents(createLogInkState(rows), 'v', {}, { singlePane: true })
-  const state = applyActionsFromEvents(createLogInkState(rows), events)
+  // #1361 — history now carves itself out of the peek intercept (`v`
+  // anchors a cherry-pick range there instead), so this fixture uses
+  // 'status' to trigger peek instead — any main-pane view NOT claimed
+  // by a range/mark grammar exercises the same peek behavior.
+  const base = { ...createLogInkState(rows), activeView: 'status' as const }
+  const events = getLogInkInputEvents(base, 'v', {}, { singlePane: true })
+  const state = applyActionsFromEvents(base, events)
   return {
     state,
     options: {
-      activeView: 'history', focus: 'sidebar', filterMode: false, showHelp: false,
+      activeView: 'status', focus: 'sidebar', filterMode: false, showHelp: false,
       peeking: true, singlePane: true, sidebarTab: 'branches', sidebarItemCount: 0,
     },
     context: { singlePane: true },

--- a/src/workstation/runtime/inkKeymap.test.ts
+++ b/src/workstation/runtime/inkKeymap.test.ts
@@ -24,7 +24,7 @@ describe('log Ink keymap', () => {
       // `c/R/Z/i mutate` is the compact chip for cherry-pick / revert /
       // reset / interactive-rebase — full descriptions in ? help and
       // the palette. `B/gT new` covers create-branch-here / create-tag-here.
-      contextual: ['↑/↓ move', 'enter diff', 'c/R/Z/i mutate', 'f fixup', 'B/gT new', 'm compare', 'y/Y yank', '/ search'],
+      contextual: ['↑/↓ move', 'enter diff', 'c/R/Z/i mutate', 'f fixup', 'B/gT new', 'm compare', 'v range', 'y/Y yank', '/ search'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/workstation/runtime/inkKeymap.ts
+++ b/src/workstation/runtime/inkKeymap.ts
@@ -1748,8 +1748,9 @@ function computeLogInkFooterHints(options: GetLogInkFooterHintsOptions): LogInkF
     // the affirmative gate (typing the name is the confirmation).
     // Grouped into compact `c/R/Z/i mutate` and `B/gT new` chips so
     // the footer stays scannable; full descriptions live in `?` help
-    // and the palette.
-    contextual: ['↑/↓ move', 'enter diff', 'c/R/Z/i mutate', 'f fixup', 'B/gT new', 'm compare', 'y/Y yank', '/ search'],
+    // and the palette. `v range` (#1361) anchors a span for `c` to
+    // cherry-pick as one command instead of the single cursored commit.
+    contextual: ['↑/↓ move', 'enter diff', 'c/R/Z/i mutate', 'f fixup', 'B/gT new', 'm compare', 'v range', 'y/Y yank', '/ search'],
     global: NORMAL_GLOBAL_HINTS,
   }
 }

--- a/src/workstation/runtime/overlays.test.ts
+++ b/src/workstation/runtime/overlays.test.ts
@@ -138,6 +138,25 @@ describe('confirmation target naming', () => {
     expect(text).toContain('commit abc1234: fix: the thing')
   })
 
+  // #1361 — an active v-range describes the span (oldest..newest) instead
+  // of the single cursored commit, so the confirm panel never shows one
+  // commit while the range command acts on several.
+  it('names the range for a cherry-pick confirm with an active v-range', () => {
+    const rows = [
+      { type: 'commit' as const, graph: '*', shortHash: 'c0', hash: 'c0', parents: [], date: '2026-05-03', author: 'Coco', refs: [], message: 'newest' },
+      { type: 'commit' as const, graph: '*', shortHash: 'c1', hash: 'c1', parents: [], date: '2026-05-02', author: 'Coco', refs: [], message: 'middle' },
+      { type: 'commit' as const, graph: '*', shortHash: 'c2', hash: 'c2', parents: [], date: '2026-05-01', author: 'Coco', refs: [], message: 'oldest' },
+    ]
+    const state = {
+      ...createLogInkState(rows),
+      pendingConfirmationId: 'cherry-pick-commit',
+      selectedIndex: 2,
+      selection: { view: 'history' as const, anchorId: 'c0', ids: new Set<string>() },
+    }
+    const text = flattenText(renderConfirmationPanel(createElement, components, state, {}, 80, theme, false))
+    expect(text).toContain('3 commits: c2..c0')
+  })
+
   // #1361 — a batch confirm must name every marked target (or an exact
   // count with the first few names), or the user confirms one item and
   // acts on N — the exact failure mode the #1452 audit warned about.

--- a/src/workstation/runtime/overlays.ts
+++ b/src/workstation/runtime/overlays.ts
@@ -34,7 +34,7 @@ import {
 import type { LogInkChoicePrompt, LogInkState } from '../../workstation/runtime/inkViewModel'
 import { filterThemePresets } from '../../workstation/runtime/inkViewModel'
 import { getLogInkWorkflowActionById } from '../../workstation/runtime/inkWorkflows'
-import { getSelectedCommitTarget } from '../../workstation/runtime/selection'
+import { getSelectedCommitTarget, getSelectedCommitRange } from '../../workstation/runtime/selection'
 import { resolvePendingItemAction } from './hooks/useWorkflowAction'
 import type { LogInkContext } from './types'
 import type { LogInkComponents } from './types'
@@ -131,6 +131,18 @@ export function describeConfirmationTarget(
     // branch/stash pluralize with -es; tag/worktree/pull-request with -s.
     const plural = /(ch|sh)$/.test(item.kind) ? `${item.kind}es` : `${item.kind}s`
     return `${item.ids.length} ${plural}: ${names}`
+  }
+  // #1361 — cherry-pick is the one commit-target workflow that's
+  // range-capable; describe the span (oldest..newest, chronological
+  // order — the reverse of display order) before falling back to
+  // the single cursored commit.
+  if (id === 'cherry-pick-commit') {
+    const range = getSelectedCommitRange(state)
+    if (range && range.length > 1) {
+      const newest = range[0]
+      const oldest = range[range.length - 1]
+      return `${range.length} commits: ${oldest.shortHash}..${newest.shortHash}`
+    }
   }
   const commit = getSelectedCommitTarget(id, state)
   if (commit) {

--- a/src/workstation/runtime/selection.test.ts
+++ b/src/workstation/runtime/selection.test.ts
@@ -7,7 +7,14 @@
  */
 import { applyLogInkAction, createLogInkState } from './inkViewModel'
 import type { LogInkContext } from './types'
-import { getSelectedBranchBatch, getSelectedBranchId, getSelectedTagId, getSelectedStashId, getSelectedStashBatch, getSelectedWorktree, getSelectedCommitTarget } from './selection'
+import { getSelectedBranchBatch, getSelectedBranchId, getSelectedTagId, getSelectedStashId, getSelectedStashBatch, getSelectedWorktree, getSelectedCommitTarget, getSelectedCommitRange } from './selection'
+
+function makeCommitRow(hash: string) {
+  return {
+    type: 'commit' as const, graph: '*', shortHash: hash, hash,
+    parents: [], date: '2026-05-01', author: 'Coco', refs: [], message: `commit ${hash}`,
+  }
+}
 
 function makeBranch(shortName: string, date = '2026-01-01') {
   return {
@@ -340,6 +347,57 @@ describe('selection selectors (#1452)', () => {
       state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'main' })
       const cursored = { ...state, selectedStashIndex: 0 }
       expect(getSelectedStashBatch(cursored, context).map((s) => s.ref)).toEqual(['stash@{0}'])
+    })
+  })
+
+  // #1361 — history is v-range only (no x-marks). Rows: c0 (newest) ..
+  // c4 (oldest), matching git log's own newest-first display order.
+  describe('getSelectedCommitRange', () => {
+    const rows = ['c0', 'c1', 'c2', 'c3', 'c4'].map(makeCommitRow)
+
+    it('returns undefined with no active range', () => {
+      const state = createLogInkState(rows)
+      expect(getSelectedCommitRange(state)).toBeUndefined()
+    })
+
+    it('resolves a forward range (anchor above cursor) in display order', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setRangeAnchor', view: 'history', id: 'c1' })
+      const ranged = { ...state, selectedIndex: 3 }
+      expect(getSelectedCommitRange(ranged)?.map((c) => c.hash)).toEqual(['c1', 'c2', 'c3'])
+    })
+
+    it('resolves a backward range (cursor above anchor) — same span, same display order', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setRangeAnchor', view: 'history', id: 'c3' })
+      const ranged = { ...state, selectedIndex: 1 }
+      expect(getSelectedCommitRange(ranged)?.map((c) => c.hash)).toEqual(['c1', 'c2', 'c3'])
+    })
+
+    it('a single-row range (anchor === cursor) resolves to one commit', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setRangeAnchor', view: 'history', id: 'c2' })
+      const ranged = { ...state, selectedIndex: 2 }
+      expect(getSelectedCommitRange(ranged)?.map((c) => c.hash)).toEqual(['c2'])
+    })
+
+    it('returns undefined when the anchor no longer resolves', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setRangeAnchor', view: 'history', id: 'gone' })
+      expect(getSelectedCommitRange(state)).toBeUndefined()
+    })
+
+    it('returns undefined while the cursor is on the synthetic new-commit row', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'setRangeAnchor', view: 'history', id: 'c1' })
+      const pending = { ...state, selectedIndex: 3, pendingCommitFocused: true }
+      expect(getSelectedCommitRange(pending)).toBeUndefined()
+    })
+
+    it('ignores a selection owned by a different view', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'toggleMark', view: 'branches', id: 'main' })
+      expect(getSelectedCommitRange({ ...state, selectedIndex: 2 })).toBeUndefined()
     })
   })
 })

--- a/src/workstation/runtime/selection.ts
+++ b/src/workstation/runtime/selection.ts
@@ -321,3 +321,32 @@ export function getSelectedCommitTarget(
   if (!id || !COMMIT_TARGET_CONFIRMATION_IDS.has(id)) return undefined
   return getSelectedInkCommit(state)
 }
+
+/**
+ * Resolve the active v-range on the history view (#1361) — commits are
+ * range-only in v1, no x-marks: a contiguous run is what "select
+ * several commits" naturally means, and `git cherry-pick`'s own range
+ * syntax replays them correctly in one command, so there's no
+ * per-item ordering trap to encode here the way stash drop had.
+ *
+ * Returns the span in DISPLAY order (index 0 = newest, matching
+ * `state.filteredCommits`), or undefined when there's no active range
+ * on history, the anchor no longer resolves (list reloaded out from
+ * under it), or the cursor is parked on the synthetic "new commit"
+ * row. Callers needing "oldest" / "newest" for the git command read
+ * `range[range.length - 1]` / `range[0]`.
+ */
+export function getSelectedCommitRange(
+  state: LogInkState,
+): GitLogCommitRow[] | undefined {
+  if (state.selection?.view !== 'history' || !state.selection.anchorId) return undefined
+  if (state.pendingCommitFocused) return undefined
+  const commits = state.filteredCommits
+  const anchorIndex = commits.findIndex((c) => c.hash === state.selection?.anchorId)
+  if (anchorIndex < 0 || commits.length === 0) return undefined
+  const cursorIndex = Math.min(state.selectedIndex, commits.length - 1)
+  const [from, to] = anchorIndex <= cursorIndex
+    ? [anchorIndex, cursorIndex]
+    : [cursorIndex, anchorIndex]
+  return commits.slice(from, to + 1)
+}

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -691,6 +691,15 @@ export function renderHistoryPanel(
     : `${state.commits.length} commits`
   // Show graph mode only when compact (the exception state worth noting)
   const graphMode = state.fullGraph ? undefined : 'compact'
+  // #1361 — surface an active cherry-pick range anchor in the header,
+  // same chip convention as the branches/stash surfaces. Deliberately
+  // NOT a per-row highlight in the graph (row rendering here is
+  // considerably more involved — graph lines, stacked mode, date
+  // bucketing — and the status-line feedback on `v` + the confirm
+  // panel's target line already tell the user what's spanned).
+  const rangeLabel = state.selection?.view === 'history' && state.selection.anchorId
+    ? 'range: v..cursor'
+    : undefined
 
   const pendingRowSelected = showPendingRow && Boolean(state.pendingCommitFocused) && focused
   // Real-commit selection is suppressed while the cursor is on the pending
@@ -711,7 +720,7 @@ export function renderHistoryPanel(
   },
   h(Box, { justifyContent: 'space-between' },
     h(Text, { bold: true }, panelTitle('Commits', focused)),
-    h(Text, { dimColor: true }, [title, graphMode, loadState].filter(Boolean).join(' · '))
+    h(Text, { dimColor: true }, [title, rangeLabel, graphMode, loadState].filter(Boolean).join(' · '))
   ),
   // Upstream-ahead banner. Surfaces "the remote has work you don't"
   // for the current branch — distinct from the chip work in 0.52.0


### PR DESCRIPTION
## Summary

PR C of #1361 multi-select (per `specs/DESIGN_multi_select.md`), stacked on #1559 (PR B) → #1558 (PR A), since it depends on the core selection state/actions.

Extends the grammar to the history view: `v` anchors a range (j/k extends, `v` again clears) and `c` cherry-picks the span as **one** `git cherry-pick oldest^..newest` command instead of a per-item loop. History is **v-range only, deliberately no x-marks** — a contiguous run is what "select several commits" naturally means, and cherry-pick's own range syntax already replays it correctly in one call, so there's no per-item ordering trap the way stash drop had.

**Git layer**: `cherryPickRange(git, oldest, newest)` collapses to `cherryPickCommit` when the range is a single commit. A conflict stops the sequence exactly like a single cherry-pick conflict — the existing conflict-recovery/continue-operation surfaces already key off the `'cherry-pick-commit'` workflow id, which stays the **same id** for both single and range (the handler branches internally on whether a range is active, instead of a second workflow id that would need its own confirm-title/keymap/registry entries).

**Selector**: `getSelectedCommitRange` resolves anchor..cursor against `state.filteredCommits` in display order (index 0 = newest, matching `git log`); handler and confirm-description read `range[0]`/`range[range.length-1]` for newest/oldest since the git command's argument order is the reverse of what's on screen.

**Confirm panel**: describes the range (`3 commits: oldest..newest`) instead of a single commit when active.

**Rendering**: deliberately **no per-row range highlight** in the history graph — that renderer is considerably more involved than branches/stash (graph lines, stacked mode, date bucketing) and touching it wasn't worth the risk for v1. The header chip + status-line feedback on `v` + the confirm panel's target line already tell the user what's spanned.

**Fixed collateral**: generalizing the peek-vs-range collision guard to also exclude history exposed that several existing peek tests used the history view as their implicit "any main-pane view" stand-in for triggering peek — they were silently passing for the wrong reason (peek never actually engaged, but the asserted-on fields happened to stay unchanged either way, since my new handler doesn't touch `focus`/`peekReturnFocus`). Repointed those fixtures at the status view (not claimed by any range/mark grammar) so they genuinely exercise peek again.

## Test plan
- [x] `tsc --noEmit` clean, `eslint` clean on all modified files
- [x] `jest` full suite: 333 suites passed (2 skipped, pre-existing), new tests: `cherryPickRange` (range command construction, single-commit collapse, in-progress-operation guard), `getSelectedCommitRange` (forward/backward range resolution in display order, single-row range, stale-anchor/pending-row/cross-view undefined cases), input dispatch (v anchor/clear incl. single-pane precedence over peek, no-op on the synthetic new-commit row, two-stage Esc), and confirm-panel range naming
- [x] `rollup` build succeeds, no schema.json drift
- [x] Caught and fixed a real test-fixture blind spot (peek tests silently not testing peek) as part of generalizing the collision guard — documented in the commit message

## This completes #1361 multi-select's planned scope
Batch stage/unstage remains deliberately deferred (already served by space auto-advance / `A` / pathspec staging).