### PR TITLE
fix(workstation): widen PTY e2e wait timeout to survive CI contention (#1564)

### DIFF
--- a/e2e/ptyHarness.ts
+++ b/e2e/ptyHarness.ts
@@ -94,7 +94,13 @@ export interface WaitOptions {
   intervalMs?: number
 }
 
-const DEFAULT_WAIT: Required<WaitOptions> = { timeoutMs: 30_000, intervalMs: 50 }
+// 30s was too tight under real CI contention: main-broken-alert (#1564)
+// caught a run where searchFilter.e2e.test.ts timed out twice waiting on
+// keystroke round-trips on a noisy shared runner (83s total vs. 22s on
+// the PR's own quieter run) — the TUI was still alive and responsive,
+// just slow to paint. 45s gives real headroom while jest's per-file
+// testTimeout (120s in jest.e2e.config.ts) still bounds the worst case.
+const DEFAULT_WAIT: Required<WaitOptions> = { timeoutMs: 45_000, intervalMs: 50 }
 
 /**
  * One live TUI process in a PTY plus the emulated screen it draws on.

--- a/e2e/ptyHarness.ts
+++ b/e2e/ptyHarness.ts
@@ -102,6 +102,9 @@ export interface WaitOptions {
 // testTimeout (120s in jest.e2e.config.ts) still bounds the worst case.
 const DEFAULT_WAIT: Required<WaitOptions> = { timeoutMs: 45_000, intervalMs: 50 }
 
+/** See the comment on {@link TuiSession.waitForReady}. */
+const STDIN_LISTENER_GRACE_MS = 750
+
 /**
  * One live TUI process in a PTY plus the emulated screen it draws on.
  * Construct via {@link launchTui}; always `close()` in `finally`/afterEach.
@@ -282,7 +285,18 @@ export class TuiSession {
       `TUI ready (anchor ${anchor}, no loading chip)`,
       options
     )
-    return this.waitForIdle(400, options)
+    const screen = await this.waitForIdle(400, options)
+    // Ink's `useInput` raw-mode stdin listener attaches during a
+    // post-commit effect a tick or two after the first paint — the
+    // paint alone (gated on above) doesn't guarantee the process is
+    // actually listening yet. Root-caused from #1564's second CI
+    // failure: under a loaded runner the screen was byte-for-byte
+    // unchanged 45s after a keypress, meaning it never reached the
+    // dispatcher at all, not just rendered slowly. Idle-settling on
+    // repaint activity doesn't catch this gap since there's nothing
+    // left to repaint. Pad with a fixed delay instead.
+    await delay(STDIN_LISTENER_GRACE_MS)
+    return screen
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes the main-broken-alert filed in #1564. Two rounds:

**Round 1 (30s→45s timeout)**: the push-to-main run after #1563 hit `searchFilter.e2e.test.ts` timing out on 30s keystroke-response waits under a noisy shared runner. Looked like plain CI-noise at first.

**Round 2 (the real fix)**: round 1's own CI run still failed — this time `stashFlow.e2e.test.ts`, with the failure screen **byte-for-byte unchanged from boot** 45s after a keypress. That's not slow rendering, that's a dropped keystroke, so a longer timeout was never going to fix it.

Root cause: Ink's `useInput` hook calls `setRawMode(true)` and attaches its input listener inside a `useEffect` (`node_modules/ink/build/hooks/use-input.js`), which fires strictly *after* React commits the first paint. `waitForReady()`'s anchor-text + idle-settle check only proves the paint landed on screen — not that the effect (and therefore the stdin listener) has actually run yet. On a loaded CI runner that gap can outlive the idle-settle window, so a keystroke sent the instant `waitForReady()` resolves can land before anyone is listening for it.

## Fix

- `e2e/ptyHarness.ts`: widen the default wait timeout 30s→45s (real headroom, doesn't hurt).
- `e2e/ptyHarness.ts`: pad `waitForReady()` with a fixed stdin-listener grace delay after the idle-settle check — this is the actual fix for the dropped-keystroke race.

## Validation
- `npm run build && npm run test:e2e` — 15/15, 3 clean runs
- `npm run test:e2e` once more under artificial CPU contention (six `yes > /dev/null` background processes saturating cores) to approximate the load that exposed this on CI — still 15/15

Closes #1564.