### PR TITLE
fix(workstation): declare cherry-pick-commit as targets: multi (#1452)

### DIFF
--- a/src/workstation/runtime/hooks/useWorkflowAction.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.ts
@@ -759,11 +759,11 @@ export function useWorkflowAction(
         if (!ref) return { ok: false, message: 'No stash ref active' }
         return checkoutFileFromStash(git, ref, path)
       },
-      // #1361 — history is v-range only (no x-marks): an active range
-      // cherry-picks as one `oldest^..newest` command instead of the
-      // single-commit path. `range` is in display order (newest
-      // first), so the git-layer args are index-reversed from what's
-      // on screen.
+      // #1361 — batch-capable (`targets: 'multi'`): history is v-range
+      // only (no x-marks), so an active range cherry-picks as one
+      // `oldest^..newest` command instead of the single-commit path.
+      // `range` is in display order (newest first), so the git-layer
+      // args are index-reversed from what's on screen.
       'cherry-pick-commit': async () => {
         const range = getSelectedCommitRange(state)
         if (range && range.length > 1) {

--- a/src/workstation/runtime/inkWorkflows.test.ts
+++ b/src/workstation/runtime/inkWorkflows.test.ts
@@ -95,6 +95,15 @@ describe('log Ink workflows', () => {
     expect(getLogInkWorkflowActionById('checkout-file-from-commit')?.key).toBe('')
   })
 
+  // Regression for #1452: cherry-pick-commit resolves its target via
+  // getSelectedCommitRange (the range half of the #1452 batch selector)
+  // but the registry declaration originally omitted `targets: 'multi'`,
+  // making it the one batch-capable workflow that didn't self-document
+  // via the contract the other two (delete-branch, drop-stash) use.
+  it('declares cherry-pick-commit as targets: multi, matching its range-selector resolution', () => {
+    expect(getLogInkWorkflowActionById('cherry-pick-commit')?.targets).toBe('multi')
+  })
+
   it('registers force-delete-branch as a keyless, confirmation-gated escalation', () => {
     // Raised by the runtime as a second confirm when `git branch -d`
     // rejects an unmerged branch; keyless so no keystroke fires it.

--- a/src/workstation/runtime/inkWorkflows.ts
+++ b/src/workstation/runtime/inkWorkflows.ts
@@ -167,6 +167,12 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       description: 'Apply the selected commit on top of the current branch (after confirmation).',
       kind: 'destructive',
       requiresConfirmation: true,
+      // #1361 / #1452 — history is v-range only (no x-marks), so this
+      // resolves through the range half of the batch selector
+      // (getSelectedCommitRange) rather than marks; still a `'multi'`
+      // consumer of the shared #1452 selection model, not a single-item
+      // workflow with range bolted on the side.
+      targets: 'multi',
     },
     {
       // #1356 — force-push recovery. Never bound to a key: raised as a


### PR DESCRIPTION
## Summary

Small follow-up from auditing whether #1361's three merged multi-select PRs (#1558, #1560, #1561) actually adopted the unified id-keyed selection model #1452 proposed, or bypassed it. Findings posted to #1452 directly — short version: they adopted it (`src/workstation/runtime/selection.ts` implements #1452's proposed `{ view, anchorId?, ids: Set<string> }` shape and both `delete-branch`/`drop-stash` declare `targets: 'multi'` on their registry entries), but one gap slipped through.

`cherry-pick-commit`'s range handling in `useWorkflowAction.ts` resolves through `getSelectedCommitRange` — the exact same #1452 selector layer the other two batch workflows use — but its registry entry in `inkWorkflows.ts` never got the matching `targets: 'multi'` declaration. It was working correctly; it just wasn't self-documenting via the contract the codebase otherwise uses consistently.

## Changes
- `inkWorkflows.ts`: add `targets: 'multi'` to the `cherry-pick-commit` registry entry.
- `useWorkflowAction.ts`: tighten the resolution comment to point at the contract, matching the style already used for delete-branch/drop-stash.
- `inkWorkflows.test.ts`: regression test asserting the declaration.

No behavior change — `getSelectedCommitRange` was already being called correctly. This is metadata/documentation parity so the registry accurately reflects which workflows are batch-capable.

## Validation
- `npm run build && npm run lint && npm run test:jest` — all green, 4776 passed (was 4775; +1 new test)