### PR TITLE
fix(workstation): boot-load background refresh can clobber an active history filter

### DIFF
--- a/src/workstation/runtime/app.ts
+++ b/src/workstation/runtime/app.ts
@@ -274,6 +274,12 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
   // capture) so the STABLE loader callbacks always see the live depth.
   const repoFrameDepthRef = React.useRef(state.repoStack.length - 1)
   repoFrameDepthRef.current = state.repoStack.length - 1
+  // #1361 follow-up — monotonic counter bumped by useHistoryRefetch
+  // every time it fires a filter/graph/frame refetch. useDeferredBootLoad
+  // captures it at dispatch and re-checks at resolve so its one-shot
+  // background fetch can't clobber a filter the user submitted while it
+  // was still in flight. See isStaleBootLoadResolve in loadMoreResolver.ts.
+  const historyRefetchGenerationRef = React.useRef(0)
 
   // P4.3 — idle tip rotation. Extracted into `useIdleTip` (0.72 app.ts
   // decomposition). The hook issues the `useState` tick counter then the
@@ -395,6 +401,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     mountedRef,
     repoFrameDepthRef,
     setHasMoreCommits,
+    historyRefetchGenerationRef,
   })
 
   // Auto-dismiss status messages after a short window so transient
@@ -431,6 +438,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     setHasMoreCommits,
     fullGraph: state.fullGraph,
     historyFetchArgs: state.historyFetchArgs,
+    historyRefetchGenerationRef,
   })
 
   // Context refresh callbacks (#1418 app.ts decomposition). Owns
@@ -1023,6 +1031,7 @@ export function LogInkApp(deps: LogInkComponentDeps): ReactTypes.ReactElement {
     historyFetchArgs: state.historyFetchArgs,
     mountedRef,
     setHasMoreCommits,
+    historyRefetchGenerationRef,
   })
 
   const commitDiffHunkOffsets = React.useMemo(() => (

--- a/src/workstation/runtime/hooks/useDeferredBootLoad.ts
+++ b/src/workstation/runtime/hooks/useDeferredBootLoad.ts
@@ -13,7 +13,19 @@
  * commits into the child frame. The `isStaleFrameResolve` check drops
  * the result in that case.
  *
- * Reproduced verbatim from the inline effect. Behavior-preserving.
+ * Refetch-generation-tagged (#1361 follow-up): the same hazard exists
+ * across a server-side history filter or graph-mode toggle, not just a
+ * frame switch — if the user submits `author:`/`path:`/`S:`/`G:` (or
+ * presses `g`) before this fetch resolves, `useHistoryRefetch` already
+ * painted the correctly filtered rows, and this loader's late
+ * `replaceRows` would silently clobber them back to the full unfiltered
+ * log. `isStaleBootLoadResolve` drops the result in that case too — see
+ * that function's doc comment in `loadMoreResolver.ts` for the full
+ * write-up (this was a real, previously-undetected bug in the shipped
+ * `author:`/`path:` filters, found while adding pickaxe/grep search).
+ *
+ * Reproduced verbatim from the inline effect, plus the refetch-
+ * generation guard above.
  *
  * `React` is injected per the runtime's convention.
  */
@@ -22,7 +34,7 @@ import type * as ReactTypes from 'react'
 import type { LogArgv } from '../../../commands/log/config'
 import type { GitLogRow } from '../../../commands/log/data'
 import type { LogInkAction } from '../inkViewModel'
-import { isStaleFrameResolve } from '../loadMoreResolver'
+import { isStaleBootLoadResolve } from '../loadMoreResolver'
 import { computeHasMoreCommits } from './useLoadMoreHistory'
 
 export type UseDeferredBootLoadDeps = {
@@ -38,6 +50,14 @@ export type UseDeferredBootLoadDeps = {
   repoFrameDepthRef: ReactTypes.MutableRefObject<number>
   /** Pagination seed setter. */
   setHasMoreCommits: (value: boolean) => void
+  /**
+   * Monotonic counter bumped by `useHistoryRefetch` every time it fires
+   * a filter/graph/frame refetch (#1361 follow-up). Captured at dispatch
+   * time and re-checked at resolve time so this loader can drop its
+   * result if a real refetch has started since — see
+   * `isStaleBootLoadResolve`.
+   */
+  historyRefetchGenerationRef: ReactTypes.MutableRefObject<number>
 }
 
 export function useDeferredBootLoad(
@@ -51,6 +71,7 @@ export function useDeferredBootLoad(
     mountedRef,
     repoFrameDepthRef,
     setHasMoreCommits,
+    historyRefetchGenerationRef,
   } = deps
 
   React.useEffect(() => {
@@ -60,13 +81,19 @@ export function useDeferredBootLoad(
     // the late `replaceRows` would swap root-repo commits into the
     // child frame. Same frame-tag-and-drop as `refreshHistoryRows`.
     const issuedAtDepth = repoFrameDepthRef.current
+    // #1361 follow-up — same hazard across a server-side filter / graph
+    // toggle submitted while this fetch is in flight; see
+    // isStaleBootLoadResolve.
+    const issuedRefetchGeneration = historyRefetchGenerationRef.current
     let cancelled = false
     void loadRows()
       .then((nextRows) => {
-        if (cancelled || isStaleFrameResolve({
+        if (cancelled || isStaleBootLoadResolve({
           mounted: mountedRef.current,
           issuedAtDepth,
           currentDepth: repoFrameDepthRef.current,
+          issuedRefetchGeneration,
+          currentRefetchGeneration: historyRefetchGenerationRef.current,
         })) return
         dispatch({ type: 'replaceRows', rows: nextRows })
         // Correct the pagination seed: on a cold cache the component

--- a/src/workstation/runtime/hooks/useHistoryRefetch.ts
+++ b/src/workstation/runtime/hooks/useHistoryRefetch.ts
@@ -72,6 +72,14 @@ export type UseHistoryRefetchDeps = {
    */
   mountedRef: ReactTypes.MutableRefObject<boolean>
   setHasMoreCommits: (value: boolean) => void
+  /**
+   * Monotonic counter bumped every time this effect actually fires a
+   * fetch (#1361 follow-up — see `isStaleBootLoadResolve`). Read by
+   * `useDeferredBootLoad` so its own one-shot background fetch can tell
+   * whether a real filter/graph refetch has started since it was
+   * dispatched, and drop its resolve instead of clobbering the result.
+   */
+  historyRefetchGenerationRef: ReactTypes.MutableRefObject<number>
 }
 
 export function useHistoryRefetch(
@@ -86,6 +94,7 @@ export function useHistoryRefetch(
     historyFetchArgs,
     mountedRef,
     setHasMoreCommits,
+    historyRefetchGenerationRef,
   } = deps
 
   const historyRefetchInitialized = React.useRef(false)
@@ -110,6 +119,11 @@ export function useHistoryRefetch(
 
     const requestId = historyRefetchRequestRef.current + 1
     historyRefetchRequestRef.current = requestId
+    // #1361 follow-up — bump BEFORE the async fetch starts so an
+    // in-flight refetch already outranks a slower-resolving boot load
+    // regardless of which promise settles first (see
+    // isStaleBootLoadResolve in loadMoreResolver.ts).
+    historyRefetchGenerationRef.current += 1
     const plan = resolveHistoryRefetch({
       logArgv,
       fullGraph,

--- a/src/workstation/runtime/hooks/useHistoryRefresh.ts
+++ b/src/workstation/runtime/hooks/useHistoryRefresh.ts
@@ -23,7 +23,7 @@ import type { LogInkAction, LogInkState } from '../inkViewModel'
 import { LOG_INTERACTIVE_DEFAULT_LIMIT, getLogRows } from '../../../commands/log/data'
 import { getStashCommitHashes } from '../../../git/stashData'
 import { buildHistoryRefetchArgv } from '../historyRefetchResolver'
-import { isStaleFrameResolve } from '../loadMoreResolver'
+import { isStaleBootLoadResolve } from '../loadMoreResolver'
 import { computeHasMoreCommits } from './useLoadMoreHistory'
 
 export type UseHistoryRefreshDeps = {
@@ -35,6 +35,14 @@ export type UseHistoryRefreshDeps = {
   setHasMoreCommits: ReactTypes.Dispatch<ReactTypes.SetStateAction<boolean>>
   fullGraph: boolean
   historyFetchArgs: LogInkState['historyFetchArgs']
+  /**
+   * Same #1361-follow-up staleness guard as `useDeferredBootLoad` — if
+   * the user changes the filter/graph mode WHILE this post-mutation
+   * refresh is in flight, `useHistoryRefetch` may already have painted
+   * the newer result by the time this one resolves. See
+   * `isStaleBootLoadResolve`.
+   */
+  historyRefetchGenerationRef: ReactTypes.MutableRefObject<number>
 }
 
 export type UseHistoryRefreshResult = {
@@ -45,7 +53,7 @@ export function useHistoryRefresh(
   React: typeof ReactTypes,
   deps: UseHistoryRefreshDeps,
 ): UseHistoryRefreshResult {
-  const { git, logArgv, dispatch, mountedRef, repoFrameDepthRef, setHasMoreCommits, fullGraph, historyFetchArgs } = deps
+  const { git, logArgv, dispatch, mountedRef, repoFrameDepthRef, setHasMoreCommits, fullGraph, historyFetchArgs, historyRefetchGenerationRef } = deps
 
   /**
    * Re-fetch the head of the commit log and replace `state.rows`.
@@ -60,6 +68,11 @@ export function useHistoryRefresh(
     try {
       // #1384 — capture the repo-frame depth BEFORE the awaits.
       const issuedAtDepth = repoFrameDepthRef.current
+      // #1361 follow-up — same for the refetch generation, and this
+      // refresh itself counts as a fresher generation so a still-
+      // in-flight boot load (or an even-earlier refresh) yields to it.
+      historyRefetchGenerationRef.current += 1
+      const issuedRefetchGeneration = historyRefetchGenerationRef.current
       // Same single-source argv derivation as the merged history refetch
       // effect (#1385) — graph mode AND server-side filter.
       const fetchArgs = historyFetchArgs
@@ -78,18 +91,20 @@ export function useHistoryRefresh(
         limit: LOG_INTERACTIVE_DEFAULT_LIMIT,
         extraRefs: stashHashes,
       })
-      const staleFrame = isStaleFrameResolve({
+      const stale = isStaleBootLoadResolve({
         mounted: mountedRef.current,
         issuedAtDepth,
         currentDepth: repoFrameDepthRef.current,
+        issuedRefetchGeneration,
+        currentRefetchGeneration: historyRefetchGenerationRef.current,
       })
-      if (!staleFrame && fresh) {
+      if (!stale && fresh) {
         dispatch({ type: 'replaceRows', rows: fresh })
         // Re-arm pagination from the fresh window (#1337).
         setHasMoreCommits(computeHasMoreCommits(logArgv, fresh))
       }
     } catch { /* ignore — stale rows beat blank rows */ }
-  }, [dispatch, git, logArgv, setHasMoreCommits, historyFetchArgs, fullGraph])
+  }, [dispatch, git, logArgv, setHasMoreCommits, historyFetchArgs, fullGraph, historyRefetchGenerationRef])
 
   return { refreshHistoryRows }
 }

--- a/src/workstation/runtime/loadMoreResolver.test.ts
+++ b/src/workstation/runtime/loadMoreResolver.test.ts
@@ -1,10 +1,12 @@
 import { LOG_INTERACTIVE_DEFAULT_LIMIT } from '../../commands/log/data'
 import {
   isCursorNearBottom,
+  isStaleBootLoadResolve,
   isStaleFrameResolve,
   isStaleLoadMoreCompletion,
   pageImpliesMore,
   shouldLoadMore,
+  type BootLoadResolveSnapshot,
   type LoadMoreCompletionSnapshot,
   type LoadMoreGuardSnapshot,
 } from './loadMoreResolver'
@@ -102,6 +104,43 @@ describe('isStaleFrameResolve', () => {
   it('drops after unmount regardless of depth', () => {
     expect(
       isStaleFrameResolve({ mounted: false, issuedAtDepth: 0, currentDepth: 0 }),
+    ).toBe(true)
+  })
+})
+
+// Regression for #1361's boot-load-vs-filter race: useDeferredBootLoad's
+// one-shot background fetch used to unconditionally clobber a server-side
+// history filter (author:/path:/S:/G:) submitted while it was still in
+// flight, since it had no way to know a fresher useHistoryRefetch had
+// already painted the correctly filtered rows.
+describe('isStaleBootLoadResolve', () => {
+  const baseBootSnap = (): BootLoadResolveSnapshot => ({
+    mounted: true,
+    issuedAtDepth: 0,
+    currentDepth: 0,
+    issuedRefetchGeneration: 0,
+    currentRefetchGeneration: 0,
+  })
+
+  it('accepts a resolve when nothing changed since dispatch', () => {
+    expect(isStaleBootLoadResolve(baseBootSnap())).toBe(false)
+  })
+
+  it('drops when a refetch generation has advanced since dispatch (a filter/graph refetch started)', () => {
+    expect(
+      isStaleBootLoadResolve({ ...baseBootSnap(), currentRefetchGeneration: 1 }),
+    ).toBe(true)
+  })
+
+  it('still drops on a repo-frame change even with no refetch (existing #1384 guard preserved)', () => {
+    expect(
+      isStaleBootLoadResolve({ ...baseBootSnap(), currentDepth: 1 }),
+    ).toBe(true)
+  })
+
+  it('drops after unmount regardless of everything else', () => {
+    expect(
+      isStaleBootLoadResolve({ ...baseBootSnap(), mounted: false }),
     ).toBe(true)
   })
 })

--- a/src/workstation/runtime/loadMoreResolver.ts
+++ b/src/workstation/runtime/loadMoreResolver.ts
@@ -114,6 +114,44 @@ export function isStaleFrameResolve(snap: FrameScopedResolveSnapshot): boolean {
 }
 
 /**
+ * The completion-time snapshot the deferred boot loader checks —
+ * the frame-scoped decision above plus a monotonic history-refetch
+ * generation.
+ */
+export type BootLoadResolveSnapshot = FrameScopedResolveSnapshot & {
+  /** History-refetch generation live when the boot load was dispatched. */
+  issuedRefetchGeneration: number
+  /** Live history-refetch generation at resolve time. */
+  currentRefetchGeneration: number
+}
+
+/**
+ * Stale-completion decision for `useDeferredBootLoad`'s one-shot
+ * background fetch.
+ *
+ * The boot loader fires once on mount and unconditionally
+ * `replaceRows`-es with the full unfiltered log when it resolves. If
+ * the user submits a server-side history filter (`author:`/`path:`/
+ * `S:`/`G:`) or toggles the graph mode WHILE that fetch is still in
+ * flight, `useHistoryRefetch`'s own effect fires and dispatches its
+ * OWN — correctly filtered — `replaceRows`. A boot load that resolves
+ * afterward would silently clobber it back to the unfiltered view:
+ * no error, no status line, nothing telling the user their filter was
+ * just discarded.
+ *
+ * `historyRefetchGenerationRef` is bumped the instant `useHistoryRefetch`
+ * fires (when the fetch STARTS, not when it resolves), so an in-flight
+ * refetch already wins over a slower-resolving boot load regardless of
+ * which one's promise settles first. The boot loader captures the
+ * generation at dispatch time and drops its resolve if a refetch has
+ * started since — same shape as the frame-depth guard above, just
+ * keyed on filter/graph freshness instead of repo-frame identity.
+ */
+export function isStaleBootLoadResolve(snap: BootLoadResolveSnapshot): boolean {
+  return isStaleFrameResolve(snap) || snap.currentRefetchGeneration !== snap.issuedRefetchGeneration
+}
+
+/**
  * The completion-time snapshot `loadMoreCommits` checks — the
  * frame-scoped decision above plus the pre-existing monotonic
  * request-id family (`loadMoreRequestRef`).


### PR DESCRIPTION
## Summary

Found a real, previously-undetected bug while manually verifying pickaxe/grep search (#1361): a race between the deferred boot loader's one-shot background refresh and the server-side history filter (`author:`/`path:` — the existing #776 feature — and the new `S:`/`G:`).

`useDeferredBootLoad` fires once on mount and unconditionally `replaceRows`-es with the full unfiltered log when its fetch resolves. If the user submits a filter (or toggles the graph mode) **while that fetch is still in flight**, `useHistoryRefetch`'s own effect already paints the correctly filtered rows — and the boot load resolving afterward silently clobbers them back to the unfiltered view. No error, no status line, nothing telling the user their filter was just discarded.

## Reproduction

Via the PTY e2e harness (#1424/#1565): boot, then immediately submit `author:<value guaranteed to match zero commits>`. The commit list stayed fully unfiltered (7 commits, header included). Waiting 5s for the background refresh to finish first — removing the race — made the identical filter work correctly, confirming the root cause. Reproduced on both `author:` (pre-existing feature) and `S:`/`G:` (new), ruling out anything pickaxe-specific.

## Fix

- A monotonic `historyRefetchGenerationRef`, bumped by `useHistoryRefetch` the instant it fires a fetch — not when it resolves, so an in-flight refetch already outranks a slower-resolving boot load regardless of which promise settles first.
- `useDeferredBootLoad` captures the generation at dispatch and drops its resolve if a refetch has started since — `isStaleBootLoadResolve` in `loadMoreResolver.ts`, same shape as the existing #1384 frame-depth guard it composes with (so drilling into a submodule mid-boot-load still works exactly as before).
- `useHistoryRefresh` (the post-mutation refresh, e.g. after a commit) gets the same guard for the analogous, narrower-window version of this race.

## Validation
- New unit tests for `isStaleBootLoadResolve` (4 cases: accepts a clean resolve, drops on generation advance, drops on frame change — existing #1384 behavior preserved, drops on unmount)
- Re-ran the race reproduction **5/5 clean** via the PTY harness after the fix
- Confirmed the normal (unfiltered) boot path is unaffected
- `npm run test:e2e` — 15/15
- `npm run lint && npm run test:jest` — 0 errors, 4780 passed (+4 new)

This unblocks #1361's pickaxe/grep PR, which shares the exact same refetch pathway and would otherwise inherit this race for its own `S:`/`G:` filters.