### PR TITLE
feat(workstation): pickaxe (S:) and grep-diff (G:) history filter search (#1361)

### DIFF
--- a/src/commands/log/config.ts
+++ b/src/commands/log/config.ts
@@ -59,6 +59,13 @@ export const options = {
     choices: ['table', 'json'],
     default: 'table',
   },
+  grep: {
+    // `LogOptions.grep`/`buildLogArgs` (data.ts) already supported this
+    // — it just wasn't reachable from the CLI, only from the TUI's `/G:`
+    // filter prefix (#1361). Documented for parity with --author/--path.
+    description: 'Filter commits by diff content matching a regex (git log -G)',
+    type: 'string',
+  },
   limit: {
     description: 'Maximum number of commits to show (defaults to 30, or 300 in interactive mode)',
     type: 'number',
@@ -77,6 +84,12 @@ export const options = {
   path: {
     description: 'Filter commits by changed path',
     type: 'array',
+  },
+  pickaxe: {
+    // Same story as --grep above — supported at the data layer, only
+    // reachable via the TUI's `/S:` filter prefix until now (#1361).
+    description: 'Filter commits that changed the occurrence count of a string (git log -S, pickaxe)',
+    type: 'string',
   },
   since: {
     description: 'Show commits more recent than a date',

--- a/src/workstation/runtime/historyRefetchResolver.test.ts
+++ b/src/workstation/runtime/historyRefetchResolver.test.ts
@@ -1,5 +1,6 @@
 import type { LogArgv } from '../../commands/log/config'
 import {
+  applyHistoryFetchArgsOverlay,
   buildHistoryRefetchArgv,
   resolveHistoryRefetch,
 } from './historyRefetchResolver'
@@ -40,6 +41,46 @@ describe('buildHistoryRefetchArgv', () => {
 
     expect(merged.path).toBe('docs/')
     expect(merged.author).toBe('bob')
+  })
+
+  it('applies the pickaxe (#1361 S:) filter', () => {
+    const merged = buildHistoryRefetchArgv(argv(), false, { pickaxe: 'useState' })
+
+    expect(merged.pickaxe).toBe('useState')
+  })
+
+  it('applies the grep-diff (#1361 G:) filter', () => {
+    const merged = buildHistoryRefetchArgv(argv(), false, { grep: '^export' })
+
+    expect(merged.grep).toBe('^export')
+  })
+})
+
+describe('applyHistoryFetchArgsOverlay', () => {
+  // Regression for #1361: useLoadMoreHistory.ts used to hand-roll its
+  // own copy of just the author/path overlay and silently dropped
+  // pickaxe/grep. This is the shared helper both call sites now use —
+  // covering it here covers every consumer.
+  it('overlays every filter kind (author/path/pickaxe/grep) onto the base argv', () => {
+    const merged = applyHistoryFetchArgsOverlay(argv({ view: 'compact' }), {
+      author: 'alice',
+      path: 'src/',
+      pickaxe: 'useState',
+      grep: '^export',
+    })
+
+    expect(merged).toMatchObject({
+      view: 'compact',
+      author: 'alice',
+      path: 'src/',
+      pickaxe: 'useState',
+      grep: '^export',
+    })
+  })
+
+  it('returns the base argv unchanged when no fetch args are active', () => {
+    const base = argv({ path: 'docs/' })
+    expect(applyHistoryFetchArgsOverlay(base, undefined)).toEqual(base)
   })
 })
 

--- a/src/workstation/runtime/historyRefetchResolver.ts
+++ b/src/workstation/runtime/historyRefetchResolver.ts
@@ -61,6 +61,29 @@ export type HistoryRefetchPlan = {
 }
 
 /**
+ * Overlay a server-side history filter (`author:`/`path:`/`S:`/`G:`,
+ * #776 + #1361) onto a base argv. Factored out so every call site that
+ * needs "the current filter, applied on top of some base argv" shares
+ * one place to add a new prefix — `useLoadMoreHistory.ts`'s pagination
+ * path used to hand-roll its own copy of just the author/path lines and
+ * silently missed pickaxe/grep when #1361 added them here (#1361
+ * follow-up), which meant an active `S:`/`G:` filter got dropped the
+ * moment the user scrolled to load older commits.
+ */
+export function applyHistoryFetchArgsOverlay(
+  base: LogArgv,
+  fetchArgs: LogInkHistoryFetchArgs | undefined,
+): LogArgv {
+  return {
+    ...base,
+    ...(fetchArgs?.author ? { author: fetchArgs.author } : {}),
+    ...(fetchArgs?.path ? { path: fetchArgs.path } : {}),
+    ...(fetchArgs?.pickaxe ? { pickaxe: fetchArgs.pickaxe } : {}),
+    ...(fetchArgs?.grep ? { grep: fetchArgs.grep } : {}),
+  }
+}
+
+/**
  * Derive the single merged argv for a history refetch: graph mode
  * first (`buildToggleGraphArgs` maps `fullGraph` onto `view`), then
  * the server-side filter overlay. Both the filter submit and the
@@ -72,13 +95,7 @@ export function buildHistoryRefetchArgv(
   fullGraph: boolean,
   fetchArgs: LogInkHistoryFetchArgs | undefined,
 ): LogArgv {
-  return {
-    ...buildToggleGraphArgs(logArgv, fullGraph),
-    ...(fetchArgs?.author ? { author: fetchArgs.author } : {}),
-    ...(fetchArgs?.path ? { path: fetchArgs.path } : {}),
-    ...(fetchArgs?.pickaxe ? { pickaxe: fetchArgs.pickaxe } : {}),
-    ...(fetchArgs?.grep ? { grep: fetchArgs.grep } : {}),
-  }
+  return applyHistoryFetchArgsOverlay(buildToggleGraphArgs(logArgv, fullGraph), fetchArgs)
 }
 
 /**

--- a/src/workstation/runtime/hooks/useLoadMoreHistory.ts
+++ b/src/workstation/runtime/hooks/useLoadMoreHistory.ts
@@ -83,6 +83,7 @@ import {
   getLogRowsAnchoredOn,
 } from '../../../commands/log/data'
 import { getStashCommitHashes } from '../../../git/stashData'
+import { applyHistoryFetchArgsOverlay } from '../historyRefetchResolver'
 import type { LogInkAction, LogInkState } from '../inkViewModel'
 import { isStaleFrameResolve, isStaleLoadMoreCompletion } from '../loadMoreResolver'
 import type { LoadCommitContextFn } from './useHistoryCursorSync'
@@ -298,12 +299,13 @@ export function useLoadMoreHistory(
       value: options.statusMessage || 'loading older commits',
       loading: true,
     })
-    const fetchArgs = snap.historyFetchArgs
-    const mergedArgv: LogArgv = {
-      ...snap.logArgv,
-      ...(fetchArgs?.author ? { author: fetchArgs.author } : {}),
-      ...(fetchArgs?.path ? { path: fetchArgs.path } : {}),
-    }
+    // #1361 — this used to hand-roll its own author/path merge here and
+    // silently missed pickaxe/grep when they were added to the sibling
+    // refetch path (historyRefetchResolver.ts). Sharing the overlay
+    // helper means a future filter prefix can't drift out of sync
+    // between "submit a new filter" and "load more under the active
+    // filter" again.
+    const mergedArgv: LogArgv = applyHistoryFetchArgsOverlay(snap.logArgv, snap.historyFetchArgs)
     // Load-more paths a fresh page from git AFTER what's already
     // loaded; pass the stash hashes again so the additional rows
     // stay graph-consistent with the boot fetch (a window that

--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -3269,6 +3269,26 @@ describe('log Ink input interactions', () => {
       expect(state.historyFetchArgs).toEqual({ author: 'alice' })
     })
 
+    it('Enter on S:<value> sets the pickaxe arg (#1361)', () => {
+      let state = createLogInkState(rows, { activeView: 'history' })
+      state = applyInput(state, '/')
+      'S:useState'.split('').forEach((c) => {
+        state = applyInput(state, c)
+      })
+      state = applyInput(state, '', { return: true })
+      expect(state.historyFetchArgs).toEqual({ pickaxe: 'useState' })
+    })
+
+    it('Enter on G:<value> sets the grep-diff arg (#1361)', () => {
+      let state = createLogInkState(rows, { activeView: 'history' })
+      state = applyInput(state, '/')
+      'G:^export'.split('').forEach((c) => {
+        state = applyInput(state, c)
+      })
+      state = applyInput(state, '', { return: true })
+      expect(state.historyFetchArgs).toEqual({ grep: '^export' })
+    })
+
     it('Enter on a non-prefix filter still just exits filter mode (no fetch args)', () => {
       let state = createLogInkState(rows)
       state = applyInput(state, '/')

--- a/src/workstation/surfaces/history/historyRender.test.ts
+++ b/src/workstation/surfaces/history/historyRender.test.ts
@@ -22,7 +22,7 @@ import { createLogInkContextStatus } from '../../chrome/context'
 import { createLogInkTheme } from '../../chrome/theme'
 import type { GitLogRow } from '../../../commands/log/data'
 import type { LogInkContext, LogInkComponents } from '../../runtime/types'
-import { renderHistoryPanel } from './index'
+import { formatHistoryFetchArgs, renderHistoryPanel } from './index'
 
 // Synthetic stubs for Ink's <Text> / <Box> — collect every prop the
 // renderer passes (color, dimColor, bold, children, …) and render
@@ -224,5 +224,28 @@ describe('renderHistoryPanel', () => {
     expect(
       render(makeState(), { density: 'tight', width: 60 })
     ).toMatchSnapshot()
+  })
+})
+
+describe('formatHistoryFetchArgs', () => {
+  // Regression for #1361: pickaxe (S:) and grep-diff (G:) filters used
+  // to fall through to the 'none' fallback here, so the filter banner
+  // told users no server-side filter was active while one actually was.
+  it('renders the pickaxe filter as -S<token>', () => {
+    expect(formatHistoryFetchArgs({ pickaxe: 'useState' })).toBe('-SuseState')
+  })
+
+  it('renders the grep-diff filter as -G<regex>', () => {
+    expect(formatHistoryFetchArgs({ grep: '^export' })).toBe('-G^export')
+  })
+
+  it('renders every active filter kind together', () => {
+    expect(
+      formatHistoryFetchArgs({ author: 'alice', path: 'src/', pickaxe: 'useState', grep: '^export' })
+    ).toBe('--author=alice -- src/ -SuseState -G^export')
+  })
+
+  it('falls back to "none" when no filter is active', () => {
+    expect(formatHistoryFetchArgs({})).toBe('none')
   })
 })

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -179,10 +179,16 @@ export function renderBranchTipChip(
   }
 }
 
-function formatHistoryFetchArgs(args: LogInkHistoryFetchArgs): string {
+export function formatHistoryFetchArgs(args: LogInkHistoryFetchArgs): string {
   const parts: string[] = []
   if (args.author) parts.push(`--author=${args.author}`)
   if (args.path) parts.push(`-- ${args.path}`)
+  // #1361 — pickaxe (S:) and grep-diff (G:) were missing here, so an
+  // active server-side filter of either kind fell through to the
+  // 'none' fallback below, misleading the user into thinking no
+  // filter was applied.
+  if (args.pickaxe) parts.push(`-S${args.pickaxe}`)
+  if (args.grep) parts.push(`-G${args.grep}`)
   return parts.join(' ') || 'none'
 }
 


### PR DESCRIPTION
## Summary

Extends the #776 server-side filter prefixes (`author:`/`path:`) with `git log -S` (pickaxe) / `git log -G` (grep-diff), following the same pattern end-to-end — `/S:token` and `/G:regex` in the history view's filter.

Turns out the parser, argv plumbing, and refetch resolver already had pickaxe/grep support landed alongside `author:`/`path:` in an earlier pass. This PR closes the two real gaps that were left over, plus rounds out test coverage and CLI parity:

- **`useLoadMoreHistory.ts`**: pagination (load-more, scrolling to load older commits) silently dropped an active `S:`/`G:` filter, paging in unfiltered rows. Fixed by factoring the author/path/pickaxe/grep overlay into a shared `applyHistoryFetchArgsOverlay` helper (`historyRefetchResolver.ts`) so the refetch path and the pagination path can't drift out of sync again — which is exactly how this gap happened the first time (pagination had its own hand-rolled copy of just the author/path lines).
- **`history/index.ts`**: the footer's active-filter indicator (`formatHistoryFetchArgs`) fell through to `'none'` for an active `S:`/`G:` filter, misleading the user into thinking nothing was filtered.
- **`commands/log/config.ts`**: expose `--pickaxe`/`--grep` as documented CLI flags (`LogOptions` already had the fields; the yargs `options` object didn't), for parity with `--author`/`--path`.
- **Test coverage**: `applyHistoryFetchArgsOverlay` + `buildHistoryRefetchArgv` pickaxe/grep cases, `formatHistoryFetchArgs` pickaxe/grep/combined/none cases, and Enter-on-`S:`/Enter-on-`G:` dispatch symmetry with the existing `author:`/`path:` cases.

## Note on sequencing

This branch is rebased on top of #1567 (merged) — while manually verifying this feature I found a real, previously-undetected race between the boot-load background refresh and any server-side filter, which made `author:`/`path:`/`S:`/`G:` all unreliable if submitted right after boot. That's fixed separately; this PR is pickaxe/grep only.

## Validation
- Manually verified end-to-end via the PTY e2e harness: `S:Pipeline1` against a fixture with a known single matching commit returns exactly that commit, reliably — 3/3 runs, including immediately after boot (only reliable now that #1567 is merged)
- `npm run test:e2e` — 15/15
- `npm run lint && npm run test:jest` — 0 errors, 4790 passed (+10 new)