### PR TITLE
refactor(workstation): migrate worktree cursor to id-based selection (#1452)

### DIFF
--- a/src/workstation/runtime/hooks/useInputHandler.ts
+++ b/src/workstation/runtime/hooks/useInputHandler.ts
@@ -334,6 +334,9 @@ export function useInputHandler(
     const pullRequestTriageSelectedUrl = pullRequestTriageSelected?.url
     const pullRequestTriageSelectedNumber = pullRequestTriageSelected?.number
     const worktreeVisibleCount = filteredWorktreeList.length
+    // #1452 dual-write — same role as branchIds: id list in render order
+    // so moveWorktreeListEntry can resolve the post-move target's id.
+    const worktreeListIds = filteredWorktreeList.map((w) => w.path)
 
     // When the diff view is showing a stash or PR patch, swap the
     // previewLineCount to that patch's length so the existing
@@ -428,6 +431,7 @@ export function useInputHandler(
       stashDiffSelectedPath,
       prDiffFileOffsets: prDiffFileOffsets.length ? prDiffFileOffsets : undefined,
       worktreeListCount: worktreeVisibleCount,
+      worktreeListIds,
       worktreeSelectedPath: visibleWorktreeFilesGrouped[state.selectedWorktreeFileIndex]?.path,
       statusGroups: visibleWorktreeGroups.map((group) => ({
         state: group.state as 'staged' | 'unstaged' | 'untracked',

--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -3517,6 +3517,30 @@ describe('log Ink input interactions', () => {
       ])
     })
 
+    // #1452 worktree flip — same dual-write as branch/tag/stash above.
+    it('moveWorktreeListEntry carries the post-move id when the context provides worktreeListIds', () => {
+      const worktreeListIds = ['/repo', '/repo-a', '/repo-b']
+      const state = {
+        ...createLogInkState(rows),
+        activeView: 'worktrees' as const,
+        selectedWorktreeListIndex: 1,
+      }
+
+      const down = getLogInkInputEvents(state, '', { downArrow: true }, {
+        worktreeListCount: 3, worktreeListIds,
+      })
+      expect(down).toEqual([
+        { type: 'action', action: { type: 'moveWorktreeListEntry', delta: 1, count: 3, id: '/repo-b' } },
+      ])
+
+      const up = getLogInkInputEvents(state, '', { upArrow: true }, {
+        worktreeListCount: 3, worktreeListIds,
+      })
+      expect(up).toEqual([
+        { type: 'action', action: { type: 'moveWorktreeListEntry', delta: -1, count: 3, id: '/repo' } },
+      ])
+    })
+
     // #1361 — multi-select grammar on the branches view.
     describe('multi-select x / v / Esc (#1361)', () => {
       function branchesState() {

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -190,6 +190,8 @@ export type LogInkInputContext = {
    */
   pullRequestTriageSelectedNumber?: number
   worktreeListCount?: number
+  /** Sorted + filtered worktree paths, same role as `branchIds` (#1452). */
+  worktreeListIds?: string[]
   /** Ref of the stash currently under the cursor (e.g. `stash@{0}`). */
   stashSelectedRef?: string
   /**
@@ -3012,7 +3014,12 @@ export function getLogInkInputEvents(
     }
 
     if (isWorktreeActionTarget(state) && context.worktreeListCount) {
-      return [action({ type: 'moveWorktreeListEntry', delta: -1, count: context.worktreeListCount })]
+      return [action({
+        type: 'moveWorktreeListEntry',
+        delta: -1,
+        count: context.worktreeListCount,
+        id: resolveMoveTargetId(context.worktreeListIds, state.selectedWorktreeListIndex, -1, context.worktreeListCount),
+      })]
     }
 
     if (state.activeView === 'conflicts' && context.conflictFileCount) {
@@ -3163,7 +3170,12 @@ export function getLogInkInputEvents(
     }
 
     if (isWorktreeActionTarget(state) && context.worktreeListCount) {
-      return [action({ type: 'moveWorktreeListEntry', delta: 1, count: context.worktreeListCount })]
+      return [action({
+        type: 'moveWorktreeListEntry',
+        delta: 1,
+        count: context.worktreeListCount,
+        id: resolveMoveTargetId(context.worktreeListIds, state.selectedWorktreeListIndex, 1, context.worktreeListCount),
+      })]
     }
 
     if (state.activeView === 'conflicts' && context.conflictFileCount) {

--- a/src/workstation/runtime/inkViewModel.test.ts
+++ b/src/workstation/runtime/inkViewModel.test.ts
@@ -1570,6 +1570,19 @@ describe('log Ink view model', () => {
       expect(state.selectedStashIndex).toBe(1)
       expect(state.selectedStashId).toBe('stash@{1}')
     })
+
+    it('writes selectedWorktreeListId alongside the index', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'moveWorktreeListEntry', delta: 1, count: 5, id: '/repo-feature' })
+      expect(state.selectedWorktreeListIndex).toBe(1)
+      expect(state.selectedWorktreeListId).toBe('/repo-feature')
+    })
+
+    it('leaves selectedWorktreeListId undefined when the dispatch site could not resolve one', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'moveWorktreeListEntry', delta: 1, count: 5 })
+      expect(state.selectedWorktreeListId).toBeUndefined()
+    })
   })
 
   // #1452 flip — every OTHER action that resets or rectifies
@@ -2386,6 +2399,23 @@ describe('log Ink view model', () => {
       const popped = applyLogInkAction(insideSubmodule, { type: 'popRepoFrame' })
       expect(popped.selectedBranchId).toBeUndefined()
       expect(popped.selectedBranchIndex).toBe(state.selectedBranchIndex)
+    })
+
+    // Same discipline for the worktree id mirror (#1452 worktree flip).
+    it('pushRepoFrame and popRepoFrame clear selectedWorktreeListId too', () => {
+      let state = createLogInkState(rows)
+      state = applyLogInkAction(state, { type: 'moveWorktreeListEntry', delta: 1, count: 10, id: '/repo-feature' })
+      expect(state.selectedWorktreeListId).toBe('/repo-feature')
+
+      const pushed = applyLogInkAction(state, { type: 'pushRepoFrame', label: 'vendor/lib' })
+      expect(pushed.selectedWorktreeListId).toBeUndefined()
+
+      const insideSubmodule = applyLogInkAction(pushed, {
+        type: 'moveWorktreeListEntry', delta: 1, count: 10, id: '/submodule-worktree',
+      })
+      const popped = applyLogInkAction(insideSubmodule, { type: 'popRepoFrame' })
+      expect(popped.selectedWorktreeListId).toBeUndefined()
+      expect(popped.selectedWorktreeListIndex).toBe(state.selectedWorktreeListIndex)
     })
 
     // Regression: popping a frame entered FROM a commit diff used to

--- a/src/workstation/runtime/inkViewModel.ts
+++ b/src/workstation/runtime/inkViewModel.ts
@@ -402,21 +402,36 @@ export type LogInkState = {
   selectedTagIndex: number
   selectedStashIndex: number
   /**
-   * Id-based cursor mirrors of the three indices above (#1452 dual-write
-   * phase). Written alongside the index by `moveBranch`/`moveTag`/
-   * `moveStash` when the dispatch site could resolve the target's id;
-   * not yet read by any consumer — `selected*Index` remains the source
-   * of truth until the migration flips it.
+   * Id-based cursor mirrors of the three indices above (#1452). Written
+   * alongside the index by `moveBranch`/`moveTag`/`moveStash` when the
+   * dispatch site could resolve the target's id; the selectors in
+   * `selection.ts` (`getSelectedBranch`/`getSelectedTag`/`getSelectedStash`)
+   * prefer the id when it's set and still resolves in the current
+   * sorted + filtered list, falling back to the index otherwise.
    */
   selectedBranchId?: string
   selectedTagId?: string
   selectedStashId?: string
   selectedWorktreeListIndex: number
+  /**
+   * Id mirror of the index above (#1452), same dual-write discipline —
+   * written by `moveWorktreeListEntry`, preferred by `getSelectedWorktree`
+   * (`selection.ts`) when it still resolves in the current filtered list.
+   */
+  selectedWorktreeListId?: string
   selectedConflictFileIndex: number
   /**
    * Cursor for the promoted reflog view (#781). Lives on the root state
    * for the same reason as the other selected* indices: navigating away
    * and back should keep the user's place in the list.
+   *
+   * #1452 — intentionally NOT getting an id mirror. A reflog selector
+   * (`HEAD@{N}`) IS the position, not a separate stable identity: every
+   * new operation prepends and shifts every later selector, so there's
+   * no content-stable key to resolve "the same entry" against after a
+   * refresh the way a branch shortName or commit hash lets us. `withFilter`
+   * already treats this view as snap-to-0-on-filter-change rather than
+   * rectify, for the same reason.
    */
   selectedReflogIndex: number
   /**
@@ -439,6 +454,10 @@ export type LogInkState = {
    * large files stay responsive. Reset to 0 each time a fresh path is
    * opened (`navigateOpenBlameForPath`) so blame always opens at the
    * top of the file.
+   *
+   * #1452 — intentionally NOT getting an id mirror, same reasoning as
+   * `selectedReflogIndex`: a blame line's identity IS its line number
+   * in the file, there's no separate stable key to resolve against.
    */
   selectedBlameIndex: number
   /**
@@ -1163,7 +1182,7 @@ export type LogInkAction =
   | { type: 'movePullRequestTriage'; delta: number; count: number }
   | { type: 'cycleIssueFilter' }
   | { type: 'cyclePullRequestTriageFilter' }
-  | { type: 'moveWorktreeListEntry'; delta: number; count: number }
+  | { type: 'moveWorktreeListEntry'; delta: number; count: number; id?: string }
   | { type: 'moveConflictFile'; delta: number; count: number }
   | { type: 'moveToBottom' }
   | { type: 'moveToTop' }
@@ -1608,6 +1627,7 @@ function withPushedRepoFrame(
     selectedTagId: undefined,
     selectedStashId: undefined,
     selectedWorktreeListIndex: 0,
+    selectedWorktreeListId: undefined,
     selectedConflictFileIndex: 0,
     selectedReflogIndex: 0,
     selectedRemoteIndex: 0,
@@ -1686,6 +1706,8 @@ function withPoppedRepoFrame(state: LogInkState): LogInkState {
     selectedTagId: undefined,
     selectedStashId: undefined,
     selectedWorktreeListIndex: ret.selectedWorktreeListIndex ?? 0,
+    // parentReturn doesn't capture the id mirror either — same reasoning.
+    selectedWorktreeListId: undefined,
     selectedConflictFileIndex: ret.selectedConflictFileIndex ?? 0,
     selectedReflogIndex: ret.selectedReflogIndex ?? 0,
     selectedRemoteIndex: ret.selectedRemoteIndex ?? 0,
@@ -2433,6 +2455,7 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
       return {
         ...state,
         selectedWorktreeListIndex: clampIndex(state.selectedWorktreeListIndex + action.delta, action.count),
+        selectedWorktreeListId: action.id,
         pendingKey: undefined,
       }
     case 'moveConflictFile':

--- a/src/workstation/runtime/selection.test.ts
+++ b/src/workstation/runtime/selection.test.ts
@@ -206,6 +206,69 @@ describe('selection selectors (#1452)', () => {
       const emptyCtx = { worktreeList: { worktrees: [] } } as unknown as LogInkContext
       expect(getSelectedWorktree(state, emptyCtx)).toBeUndefined()
     })
+
+    // #1452 flip — same id-first, index-fallback resolution as branch/tag/
+    // stash, so a context refresh that reorders the worktree list can't
+    // silently resolve to the wrong logical worktree.
+    it('prefers selectedWorktreeListId over selectedWorktreeListIndex when both are set', () => {
+      const state = {
+        ...createLogInkState([]),
+        selectedWorktreeListIndex: 0,
+        selectedWorktreeListId: '/repo-feature',
+      }
+      expect(getSelectedWorktree(state, worktreeContext)?.path).toBe('/repo-feature')
+    })
+
+    it('falls back to the index when selectedWorktreeListId is undefined', () => {
+      const state = {
+        ...createLogInkState([]),
+        selectedWorktreeListIndex: 0,
+        selectedWorktreeListId: undefined,
+      }
+      expect(getSelectedWorktree(state, worktreeContext)?.path).toBe('/repo')
+    })
+
+    it('falls back to the index when selectedWorktreeListId no longer resolves', () => {
+      const state = {
+        ...createLogInkState([]),
+        selectedWorktreeListIndex: 1,
+        selectedWorktreeListId: '/gone',
+      }
+      expect(getSelectedWorktree(state, worktreeContext)?.path).toBe('/repo-feature')
+    })
+
+    it('keeps resolving to the same worktree after a context refresh reorders the list', () => {
+      const before = {
+        worktreeList: { worktrees: [makeWorktree('/repo', 'main'), makeWorktree('/repo-b', 'b')] },
+      } as unknown as LogInkContext
+      const state = {
+        ...createLogInkState([]),
+        selectedWorktreeListIndex: 1,
+        selectedWorktreeListId: '/repo-b',
+      }
+      expect(getSelectedWorktree(state, before)?.path).toBe('/repo-b')
+
+      // A new worktree sorts ahead of '/repo-b', shifting it from index 1
+      // to index 2. No reducer action fired — state is unchanged.
+      const after = {
+        worktreeList: {
+          worktrees: [makeWorktree('/repo-a', 'a'), makeWorktree('/repo', 'main'), makeWorktree('/repo-b', 'b')],
+        },
+      } as unknown as LogInkContext
+      // Index 1 is now '/repo' — an index-only lookup would resolve
+      // there; the id-first selector still returns '/repo-b'.
+      expect(getSelectedWorktree(state, after)?.path).toBe('/repo-b')
+    })
+
+    it('id-first resolution also applies to the unfiltered fallback path', () => {
+      const state = {
+        ...createLogInkState([]),
+        selectedWorktreeListIndex: 0,
+        selectedWorktreeListId: '/repo-feature',
+        filter: 'does-not-match-anything',
+      }
+      expect(getSelectedWorktree(state, worktreeContext)?.path).toBe('/repo-feature')
+    })
   })
 
   describe('getSelectedCommitTarget', () => {

--- a/src/workstation/runtime/selection.ts
+++ b/src/workstation/runtime/selection.ts
@@ -2,9 +2,14 @@
  * Id-based selection model (#1452).
  *
  * This module introduces the target selection architecture that will replace
- * the 16 scalar `selected*Index` fields in `LogInkState`. The migration is
- * incremental and per view; branches / tags / stashes have completed all
- * three phases below, the rest are still index-only.
+ * the scalar `selected*Index` fields in `LogInkState`. The migration is
+ * incremental and per view; branches / tags / stashes / worktrees have
+ * completed phases 1-2 below. `reflog` and `blame` are intentionally
+ * staying index-only (see the doc comments on `selectedReflogIndex` /
+ * `selectedBlameIndex` in `inkViewModel.ts` — their cursor position IS
+ * the identity, there's no separate stable id to key on). The remaining
+ * views (submodules, remotes, issues, PR triage, file-history, and the
+ * history/diff/status-file cursors) are tracked for a future pass.
  *
  * Design:
  *   - A selection is a set of ids (not indexes) scoped to a view
@@ -271,6 +276,13 @@ export function getSelectedWorktreeId(
 /**
  * Get the full WorktreeEntry for the currently-selected worktree.
  *
+ * #1452 flip — `selectedWorktreeListId` is preferred when set and still
+ * resolves in the current visible list, same id-first/index-fallback
+ * resolution as `getSelectedBranch`/`getSelectedTag`/`getSelectedStash`.
+ * This is what keeps the cursor on the same logical worktree across a
+ * background context refresh that reorders the list, instead of
+ * silently landing on whatever now sits at the old numeric index.
+ *
  * Falls back to indexing the unfiltered list when the active filter hides
  * every worktree — a worktree action reachable from the palette (rather
  * than from the worktrees view itself) can fire with a stale filter still
@@ -286,9 +298,17 @@ export function getSelectedWorktree(
     ? all.filter((w) => matchesPromotedFilter([w.path, w.branch || ''], state.filter))
     : all
   if (visible.length > 0) {
+    if (state.selectedWorktreeListId) {
+      const byId = visible.find((w) => w.path === state.selectedWorktreeListId)
+      if (byId) return byId
+    }
     return visible[Math.min(state.selectedWorktreeListIndex, visible.length - 1)]
   }
   if (all.length === 0) return undefined
+  if (state.selectedWorktreeListId) {
+    const byId = all.find((w) => w.path === state.selectedWorktreeListId)
+    if (byId) return byId
+  }
   return all[Math.min(state.selectedWorktreeListIndex, all.length - 1)]
 }
 


### PR DESCRIPTION
## Summary

Wraps up the last open item for the 0.81.0 milestone (#1452 — the id-based selection paradigm groundwork issue).

Completes the migration (dual-write + selector flip) for the **worktrees** view, following the exact pattern branches/tags/stashes already went through in an earlier pass:

- `selectedWorktreeListId` mirrors `selectedWorktreeListIndex`, written by `moveWorktreeListEntry`'s dispatch site (`context.worktreeListIds`, threaded through `useInputHandler.ts` the same way as `branchIds`), cleared alongside the index on repo-frame push/pop.
- `getSelectedWorktree` (`selection.ts`) now prefers the id when set and still resolves in the current list, falling back to the index — so a background context refresh that reorders the worktree list can no longer silently resolve the cursor to the wrong logical worktree.

Worktrees was the cleanest remaining field to migrate: it already had a single consolidated selector (`getSelectedWorktree`/`getSelectedWorktreeId`, consumed in exactly 3 places in `useWorkflowAction.ts`) unlike submodules/remotes, whose resolution is scattered across ~6 inline `filteredList[index]` sites — a bigger consolidation job, tracked separately.

Also documents `selectedReflogIndex` and `selectedBlameIndex` as **intentionally not** getting an id mirror — both fields' cursor position IS the identity (a reflog `HEAD@{N}` selector is pure position; a blame line's identity is its line number), so there's no separate stable key to migrate to. Previously this was left unstated, reading like an oversight rather than a deliberate call.

## Follow-up

Filed #1569 to track the remaining views (submodules, remotes, issues, PR-triage, file-history, and the heavier history/diff/status-file trio) as its own scoped issue. The paradigm decision #1452 forced is made and now proven across four views — what's left is incremental, view-by-view application, not more design work, so I'm closing #1452 with this PR rather than leaving it open indefinitely for unbounded cleanup.

## Validation
- New tests mirroring the branch/tag/stash pattern exactly: `selection.test.ts` (id-first resolution, context-refresh-reorder regression, unfiltered-fallback), `inkViewModel.test.ts` (dual-write, repo-frame push/pop clears the mirror), `inkInput.test.ts` (dispatch-site id resolution)
- Manually verified live via the PTY harness: `gw` → worktrees view → `j` moves the cursor and the inspector panel updates to the new worktree correctly
- `npm run build && npm run lint` — 0 errors (41 pre-existing warnings, unrelated)
- `npm run test:jest` — 4799 passed (+9 new)
- `npm run test:e2e` — 15/15 (one flake on the first run, unrelated file — boot/navigate journey, doesn't touch worktrees — clean on rerun and in isolation)

Closes #1452.