### PR TITLE
fix: batch of 4 mislabeled bug fixes (#1615, #1618, #1620, #1633)

### DIFF
--- a/src/commands/log/config.ts
+++ b/src/commands/log/config.ts
@@ -12,6 +12,7 @@ export interface LogOptions extends BaseCommandOptions {
   commit?: string
   format?: LogFormat
   grep?: string
+  message?: string
   limit?: number
   merges?: boolean
   noMerges?: boolean
@@ -63,7 +64,20 @@ export const options = {
     // `LogOptions.grep`/`buildLogArgs` (data.ts) already supported this
     // — it just wasn't reachable from the CLI, only from the TUI's `/G:`
     // filter prefix (#1361). Documented for parity with --author/--path.
-    description: 'Filter commits by diff content matching a regex (git log -G)',
+    //
+    // NOTE (#1618): despite the name, this searches DIFF CONTENT (git log
+    // -G), not commit messages — twenty years of git convention expects
+    // --grep to search messages. Kept as-is for backward compatibility;
+    // use --message for message search.
+    description: 'Filter commits by diff content matching a regex (git log -G) — NOT commit messages, see --message',
+    type: 'string',
+  },
+  message: {
+    // #1618 — the message-search flag `--grep`'s name implied but never
+    // provided. Maps to git's own `--grep=`, so it composes with git's
+    // usual conventions (regex, case sensitivity, etc.) rather than
+    // reinventing message matching.
+    description: 'Filter commits by commit message matching a regex (git log --grep)',
     type: 'string',
   },
   limit: {

--- a/src/commands/log/data.test.ts
+++ b/src/commands/log/data.test.ts
@@ -244,6 +244,22 @@ describe('log data layer', () => {
     expect(args).toContain('-GTODO|FIXME')
   })
 
+  // Regression (#1618): --grep runs git's diff-content search (-G), not
+  // commit-message search — the behavior every git user's --grep muscle
+  // memory expects. --message is the actual message-search flag, mapping
+  // to git's own --grep=.
+  it('passes --grep=<regex> for --message (commit-message search)', () => {
+    const args = buildLogArgs(argv({ message: 'fix login' }))
+    expect(args).toContain('--grep=fix login')
+    expect(args).not.toContain('-Gfix login')
+  })
+
+  it('--message and --grep compose independently (message search vs. diff-content search)', () => {
+    const args = buildLogArgs(argv({ message: 'fix login', grep: 'TODO' }))
+    expect(args).toContain('--grep=fix login')
+    expect(args).toContain('-GTODO')
+  })
+
   it('parses commit detail metadata and changed files', () => {
     const detail = parseCommitDetail(
       [

--- a/src/commands/log/data.ts
+++ b/src/commands/log/data.ts
@@ -324,6 +324,11 @@ export function buildLogArgs(argv: LogArgv, options: LogRowLoadOptions = {}): st
     args.push(`-G${argv.grep}`)
   }
 
+  // #1618 — message search, distinct from --grep's diff-content search.
+  if (argv.message) {
+    args.push(`--grep=${argv.message}`)
+  }
+
   if (argv.since) {
     args.push(`--since=${argv.since}`)
   }

--- a/src/workstation/chrome/surfaceStates.test.ts
+++ b/src/workstation/chrome/surfaceStates.test.ts
@@ -9,6 +9,7 @@ import {
     formatLogInkStashEmpty,
     formatLogInkStatusEmpty,
     formatLogInkTagsEmpty,
+    formatLogInkWorktreesEmpty,
 } from './surfaceStates'
 
 describe('log Ink surface states', () => {
@@ -64,6 +65,26 @@ describe('log Ink surface states', () => {
       const message = formatLogInkStashEmpty({ filter: 'wip' })
       expect(message).toContain("'wip'")
       expect(message).toContain('ctrl+u')
+    })
+  })
+
+  // Regression (#1620): the worktrees surface hardcoded 'No linked
+  // worktrees.' regardless of an active filter, so filtering to zero
+  // matches contradicted the header's "0/N worktrees | filter: …" line.
+  describe('formatLogInkWorktreesEmpty', () => {
+    it('returns a tailored hint when no filter is active', () => {
+      const message = formatLogInkWorktreesEmpty({ filter: '' })
+      expect(message).toBe('No linked worktrees.')
+    })
+
+    it('flags the active filter and tells users how to clear it', () => {
+      const message = formatLogInkWorktreesEmpty({ filter: 'feature/foo' })
+      expect(message).toContain("'feature/foo'")
+      expect(message).toContain('ctrl+u')
+    })
+
+    it('treats whitespace-only filter as no filter', () => {
+      expect(formatLogInkWorktreesEmpty({ filter: '   ' })).toBe('No linked worktrees.')
     })
   })
 

--- a/src/workstation/chrome/surfaceStates.ts
+++ b/src/workstation/chrome/surfaceStates.ts
@@ -125,6 +125,17 @@ export function formatLogInkRemotesEmpty({ filter }: LogInkRemotesEmptyArgs): st
   return 'No remotes configured. Press a to add one.'
 }
 
+export type LogInkWorktreesEmptyArgs = {
+  filter: string
+}
+
+export function formatLogInkWorktreesEmpty({ filter }: LogInkWorktreesEmptyArgs): string {
+  if (filter.trim()) {
+    return `No worktrees match filter '${filter}'. Press ctrl+u to clear.`
+  }
+  return 'No linked worktrees.'
+}
+
 export type LogInkBlameEmptyArgs = {
   /** Repo-relative path being blamed, for a path-aware message. */
   path?: string

--- a/src/workstation/runtime/hooks/useTriageListHydration.test.ts
+++ b/src/workstation/runtime/hooks/useTriageListHydration.test.ts
@@ -1,0 +1,146 @@
+import {
+  useIssueTriageHydration,
+  usePullRequestTriageHydration,
+} from './useTriageListHydration'
+import { updateLogInkContextStatus } from '../../chrome/context'
+
+/**
+ * Regression tests for #1633 — an unexpected rejection (e.g. repository
+ * resolution failing above the forge's own gh-CLI error handling) used to be
+ * swallowed into bare `undefined` by the old `safe()` helper, which reads
+ * through the render layer as "still loading" forever. The fix routes any
+ * rejection through the same `{ available, authenticated, message }` shape
+ * the triage surfaces already render as an actionable error line.
+ *
+ * Minimal fake-React harness (same shape as useCommitDetailHydration.test.ts):
+ * records `useEffect` callbacks so the test can invoke the loader effect
+ * (the first one registered) directly.
+ */
+
+type EffectFn = () => void | (() => void)
+
+function makeReact(): {
+  React: typeof import('react')
+  runLoaderEffect: () => void | (() => void)
+} {
+  const effects: EffectFn[] = []
+  const React = {
+    useEffect: (fn: EffectFn) => {
+      effects.push(fn)
+    },
+  } as unknown as typeof import('react')
+  return {
+    React,
+    runLoaderEffect: () => {
+      if (effects.length !== 2) {
+        throw new Error(`expected exactly two effects, got ${effects.length}`)
+      }
+      // The loader effect is registered first, the filter-invalidation
+      // effect second (see useTriageListHydration.ts source order).
+      return effects[0]()
+    },
+  }
+}
+
+/** Flush pending microtasks so the effect's chained promise settles. */
+const flush = async (): Promise<void> => {
+  for (let i = 0; i < 10; i++) await Promise.resolve()
+}
+
+const git = {} as Parameters<typeof useIssueTriageHydration>[1]['git']
+const repoFrameDepthRef = { current: 0 }
+
+describe('useIssueTriageHydration', () => {
+  it('surfaces an unexpected getIssueList rejection as an actionable overview instead of undefined', async () => {
+    const forge = {
+      getIssueList: jest.fn().mockRejectedValue(new Error('no repository resolved')),
+    } as unknown as Parameters<typeof useIssueTriageHydration>[1]['forge']
+    const setContext = jest.fn()
+    const setContextStatus = jest.fn()
+    const { React, runLoaderEffect } = makeReact()
+
+    useIssueTriageHydration(React, {
+      git,
+      forge,
+      activeView: 'issues',
+      issueList: undefined,
+      selectedIssueFilter: 'open',
+      frameDepth: 0,
+      repoFrameDepthRef,
+      setContext,
+      setContextStatus,
+    })
+    runLoaderEffect()
+    await flush()
+
+    const contextUpdater = setContext.mock.calls[0][0] as (
+      prev: Record<string, unknown>,
+    ) => Record<string, unknown>
+    const next = contextUpdater({})
+    expect(next.issueList).toEqual({
+      available: true,
+      authenticated: true,
+      message: 'no repository resolved',
+    })
+
+    // The status must still resolve to 'ready' — not stuck on 'loading'.
+    const statusUpdater = setContextStatus.mock.calls[
+      setContextStatus.mock.calls.length - 1
+    ][0] as (prev: ReturnType<typeof updateLogInkContextStatus>) => unknown
+    const nextStatus = statusUpdater(
+      updateLogInkContextStatus(
+        { issueList: 'loading' } as never,
+        'issueList',
+        'loading',
+      ),
+    ) as { issueList: string }
+    expect(nextStatus.issueList).toBe('ready')
+  })
+})
+
+describe('usePullRequestTriageHydration', () => {
+  it('surfaces an unexpected getPullRequestList rejection as an actionable overview instead of undefined', async () => {
+    const forge = {
+      getPullRequestList: jest.fn().mockRejectedValue(new Error('gh not found')),
+    } as unknown as Parameters<typeof usePullRequestTriageHydration>[1]['forge']
+    const setContext = jest.fn()
+    const setContextStatus = jest.fn()
+    const { React, runLoaderEffect } = makeReact()
+
+    usePullRequestTriageHydration(React, {
+      git,
+      forge,
+      activeView: 'pull-request-triage',
+      pullRequestList: undefined,
+      selectedPullRequestFilter: 'open',
+      frameDepth: 0,
+      repoFrameDepthRef,
+      setContext,
+      setContextStatus,
+    })
+    runLoaderEffect()
+    await flush()
+
+    const contextUpdater = setContext.mock.calls[0][0] as (
+      prev: Record<string, unknown>,
+    ) => Record<string, unknown>
+    const next = contextUpdater({})
+    expect(next.pullRequestList).toEqual({
+      available: true,
+      authenticated: true,
+      message: 'gh not found',
+    })
+
+    const statusUpdater = setContextStatus.mock.calls[
+      setContextStatus.mock.calls.length - 1
+    ][0] as (prev: ReturnType<typeof updateLogInkContextStatus>) => unknown
+    const nextStatus = statusUpdater(
+      updateLogInkContextStatus(
+        { pullRequestList: 'loading' } as never,
+        'pullRequestList',
+        'loading',
+      ),
+    ) as { pullRequestList: string }
+    expect(nextStatus.pullRequestList).toBe('ready')
+  })
+})

--- a/src/workstation/runtime/hooks/useTriageListHydration.ts
+++ b/src/workstation/runtime/hooks/useTriageListHydration.ts
@@ -29,12 +29,30 @@ import { issueFilterForPreset, pullRequestFilterForPreset } from '../../../git/t
 import { updateLogInkContextStatus } from '../../chrome/context'
 import type { SetContextFn, SetContextStatusFn } from './useRepoStackRuntimes'
 
-/** Best-effort promise unwrap — same helper pattern as other hooks. */
-async function safe<T>(promise: Promise<T>): Promise<T | undefined> {
-  try {
-    return await promise
-  } catch {
-    return undefined
+/**
+ * #1633 — `getIssueList` / `getPullRequestList` already catch every
+ * gh-CLI-level failure internally and return an `{ available,
+ * authenticated, message }` overview the triage surfaces already know how
+ * to render as an actionable error line (see `issuesTriage/index.ts` /
+ * `pullRequestTriage/index.ts`'s `overview.message && !overview.issues`
+ * branch). But a failure ABOVE that layer — repository resolution
+ * throwing on an unexpected git error, for instance — still rejects the
+ * whole promise. The old blanket `safe()` swallowed that into bare
+ * `undefined`, which reads through the render layer as "still loading"
+ * forever — indistinguishable from a real empty queue. Falling back to
+ * the same `{ available: true, authenticated: true, message }` shape
+ * lets any unexpected rejection surface through the existing error UI
+ * instead.
+ */
+function triageListFailure(error: unknown, fallbackMessage: string): {
+  available: true
+  authenticated: true
+  message: string
+} {
+  return {
+    available: true,
+    authenticated: true,
+    message: error instanceof Error ? error.message : fallbackMessage,
   }
 }
 
@@ -83,20 +101,22 @@ export function useIssueTriageHydration(
       issuedAtDepth,
     )
     const filter = issueFilterForPreset(selectedIssueFilter)
-    void safe(forge.getIssueList(git, filter)).then((value) => {
-      if (!active) return
-      setContext(
-        (current) => ({
-          ...current,
-          issueList: value,
-        }),
-        issuedAtDepth,
-      )
-      setContextStatus(
-        (current) => updateLogInkContextStatus(current, 'issueList', 'ready'),
-        issuedAtDepth,
-      )
-    })
+    void forge.getIssueList(git, filter)
+      .catch((error) => triageListFailure(error, 'Failed to load issues.'))
+      .then((value) => {
+        if (!active) return
+        setContext(
+          (current) => ({
+            ...current,
+            issueList: value,
+          }),
+          issuedAtDepth,
+        )
+        setContextStatus(
+          (current) => updateLogInkContextStatus(current, 'issueList', 'ready'),
+          issuedAtDepth,
+        )
+      })
     return () => {
       active = false
     }
@@ -173,20 +193,22 @@ export function usePullRequestTriageHydration(
       issuedAtDepth,
     )
     const filter = pullRequestFilterForPreset(selectedPullRequestFilter)
-    void safe(forge.getPullRequestList(git, filter)).then((value) => {
-      if (!active) return
-      setContext(
-        (current) => ({
-          ...current,
-          pullRequestList: value,
-        }),
-        issuedAtDepth,
-      )
-      setContextStatus(
-        (current) => updateLogInkContextStatus(current, 'pullRequestList', 'ready'),
-        issuedAtDepth,
-      )
-    })
+    void forge.getPullRequestList(git, filter)
+      .catch((error) => triageListFailure(error, 'Failed to load pull requests.'))
+      .then((value) => {
+        if (!active) return
+        setContext(
+          (current) => ({
+            ...current,
+            pullRequestList: value,
+          }),
+          issuedAtDepth,
+        )
+        setContextStatus(
+          (current) => updateLogInkContextStatus(current, 'pullRequestList', 'ready'),
+          issuedAtDepth,
+        )
+      })
     return () => {
       active = false
     }

--- a/src/workstation/surfaces/reflog/index.ts
+++ b/src/workstation/surfaces/reflog/index.ts
@@ -34,7 +34,13 @@ export function renderReflogSurface(ctx: SurfaceRenderContext): ReactTypes.React
     ))
     : allEntries
   const selected = Math.max(0, Math.min(state.selectedReflogIndex, Math.max(0, entries.length - 1)))
-  const listRows = Math.max(4, bodyRows - 4)
+  // Row budget (#1392, #1615): the base reserve (borders + title + one
+  // spare) must also count the conditional rows, or the panel grows past
+  // its box mid-scroll — the filter affordance while filtering, and BOTH
+  // scroll indicators once the list overflows the window (the single
+  // spare absorbed only one of them). Mirrors the branches surface.
+  const baseRows = Math.max(4, bodyRows - 4 - (state.filterMode ? 1 : 0))
+  const listRows = entries.length > baseRows ? Math.max(4, baseRows - 1) : baseRows
   const startIndex = clampListWindowStart(selected, entries.length, listRows)
   const visible = entries.slice(startIndex, startIndex + listRows)
   const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
@@ -84,6 +90,11 @@ export function renderReflogSurface(ctx: SurfaceRenderContext): ReactTypes.React
         }, lineText)
       })
 
+  // Scroll indicators (#1615) — same "N more above/below" pattern as
+  // branches/tags so the user knows the list continues past the window.
+  const reflogHasMoreAbove = startIndex > 0 && entries.length > 0
+  const reflogHasMoreBelow = startIndex + listRows < entries.length
+
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
     borderStyle: theme.borderStyle,
@@ -97,5 +108,11 @@ export function renderReflogSurface(ctx: SurfaceRenderContext): ReactTypes.React
     h(Text, { dimColor: true }, headerRight)
   ),
   ...renderPromotedFilterAffordance(h, Text, state, theme),
-  ...lines)
+  ...(reflogHasMoreAbove
+    ? [h(Text, { key: 'reflog-more-above', dimColor: true }, `  ↑ ${startIndex} more above`)]
+    : []),
+  ...lines,
+  ...(reflogHasMoreBelow
+    ? [h(Text, { key: 'reflog-more-below', dimColor: true }, `  ↓ ${entries.length - (startIndex + listRows)} more below`)]
+    : []))
 }

--- a/src/workstation/surfaces/reflog/reflogRender.test.ts
+++ b/src/workstation/surfaces/reflog/reflogRender.test.ts
@@ -12,6 +12,7 @@ import {
 import type { ReflogOverview, ReflogViewEntry } from '../../../git/reflogData'
 import type { LogInkContext, LogInkComponents } from '../../runtime/types'
 import { renderReflogSurface } from './index'
+import { renderToLines } from '../../runtime/testSupport/renderToLines'
 
 type StubProps = Record<string, unknown>
 const Text = ((props: StubProps) =>
@@ -39,7 +40,7 @@ function makeEntry(overrides: Partial<ReflogViewEntry> = {}): ReflogViewEntry {
 
 function render(
   state: LogInkState,
-  options: { reflog?: ReflogOverview; loading?: boolean } = {}
+  options: { reflog?: ReflogOverview; loading?: boolean; bodyRows?: number } = {}
 ): ReactElement {
   const theme = createLogInkTheme({})
   const context: LogInkContext = options.reflog ? { reflog: options.reflog } : {}
@@ -52,7 +53,7 @@ function render(
     state,
     context,
     contextStatus,
-    bodyRows: 30,
+    bodyRows: options.bodyRows ?? 30,
     width: 120,
     theme,
   })
@@ -95,5 +96,55 @@ describe('renderReflogSurface', () => {
 
   it('structural snapshot — populated', () => {
     expect(render(makeState(), { reflog: { entries: [makeEntry()] } })).toMatchSnapshot()
+  })
+
+  // Regression (#1615): reflog windowed its rows with clampListWindowStart
+  // but rendered no scroll indicators, unlike every other windowed promoted
+  // surface (branches, tags, stash, ...) — and reflogs routinely have
+  // hundreds of entries, so this reads as "this is the whole reflog."
+  describe('scroll indicators (#1615)', () => {
+    const manyEntries: ReflogOverview = {
+      entries: Array.from({ length: 30 }, (_, i) =>
+        makeEntry({ selector: `HEAD@{${i}}`, subject: `commit: change ${i}` })),
+    }
+
+    it('shows only "more below" when cursored at the top', () => {
+      const tree = render(makeState({ selectedReflogIndex: 0 }), { reflog: manyEntries, bodyRows: 12 })
+      const text = renderToLines(tree, Text, Box).join('\n')
+      expect(text).not.toContain('more above')
+      expect(text).toContain('more below')
+    })
+
+    it('shows only "more above" when cursored at the bottom', () => {
+      const tree = render(makeState({ selectedReflogIndex: manyEntries.entries.length - 1 }), {
+        reflog: manyEntries,
+        bodyRows: 12,
+      })
+      const text = renderToLines(tree, Text, Box).join('\n')
+      expect(text).toContain('more above')
+      expect(text).not.toContain('more below')
+    })
+
+    it('shows both indicators mid-list and keeps the total rendered rows within bodyRows', () => {
+      const bodyRows = 12
+      const tree = render(makeState({ selectedReflogIndex: 15 }), { reflog: manyEntries, bodyRows })
+      const lines = renderToLines(tree, Text, Box)
+      const text = lines.join('\n')
+      expect(text).toContain('more above')
+      expect(text).toContain('more below')
+      const BORDER_ROWS = 2
+      expect(lines.length + BORDER_ROWS).toBeLessThanOrEqual(bodyRows)
+    })
+
+    it('keeps the total rendered row count within bodyRows with the filter affordance active too', () => {
+      const bodyRows = 12
+      const tree = render(
+        makeState({ selectedReflogIndex: 15, filterMode: true, filter: 'commit' }),
+        { reflog: manyEntries, bodyRows }
+      )
+      const lines = renderToLines(tree, Text, Box)
+      const BORDER_ROWS = 2
+      expect(lines.length + BORDER_ROWS).toBeLessThanOrEqual(bodyRows)
+    })
   })
 })

--- a/src/workstation/surfaces/remotes/index.ts
+++ b/src/workstation/surfaces/remotes/index.ts
@@ -34,7 +34,13 @@ export function renderRemotesSurface(ctx: SurfaceRenderContext): ReactTypes.Reac
     )
     : all
   const selected = Math.max(0, Math.min(state.selectedRemoteIndex, Math.max(0, filtered.length - 1)))
-  const listRows = Math.max(4, bodyRows - 4)
+  // Row budget (#1392, #1615): the base reserve (borders + title + one
+  // spare) must also count the conditional rows, or the panel grows past
+  // its box mid-scroll — the filter affordance while filtering, and BOTH
+  // scroll indicators once the list overflows the window (the single
+  // spare absorbed only one of them). Mirrors the branches surface.
+  const baseRows = Math.max(4, bodyRows - 4 - (state.filterMode ? 1 : 0))
+  const listRows = filtered.length > baseRows ? Math.max(4, baseRows - 1) : baseRows
   const startIndex = clampListWindowStart(selected, filtered.length, listRows)
   const visible = filtered.slice(startIndex, startIndex + listRows)
   const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
@@ -78,6 +84,11 @@ export function renderRemotesSurface(ctx: SurfaceRenderContext): ReactTypes.Reac
         }, lineText)
       })
 
+  // Scroll indicators (#1615) — same "N more above/below" pattern as
+  // branches/tags so the user knows the list continues past the window.
+  const remotesHasMoreAbove = startIndex > 0 && filtered.length > 0
+  const remotesHasMoreBelow = startIndex + listRows < filtered.length
+
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
     borderStyle: theme.borderStyle,
@@ -91,7 +102,13 @@ export function renderRemotesSurface(ctx: SurfaceRenderContext): ReactTypes.Reac
     h(Text, { dimColor: true }, headerRight),
   ),
   ...renderPromotedFilterAffordance(h, Text, state, theme),
-  ...lines)
+  ...(remotesHasMoreAbove
+    ? [h(Text, { key: 'remotes-more-above', dimColor: true }, `  ↑ ${startIndex} more above`)]
+    : []),
+  ...lines,
+  ...(remotesHasMoreBelow
+    ? [h(Text, { key: 'remotes-more-below', dimColor: true }, `  ↓ ${filtered.length - (startIndex + listRows)} more below`)]
+    : []))
 }
 
 export type { RemoteEntry }

--- a/src/workstation/surfaces/remotes/remotesRender.test.ts
+++ b/src/workstation/surfaces/remotes/remotesRender.test.ts
@@ -12,6 +12,7 @@ import {
 import type { RemoteEntry, RemoteOverview } from '../../../git/remoteData'
 import type { LogInkContext, LogInkComponents } from '../../runtime/types'
 import { renderRemotesSurface } from './index'
+import { renderToLines } from '../../runtime/testSupport/renderToLines'
 
 type StubProps = Record<string, unknown>
 const Text = ((props: StubProps) =>
@@ -38,7 +39,7 @@ function makeEntry(overrides: Partial<RemoteEntry> = {}): RemoteEntry {
 
 function render(
   state: LogInkState,
-  options: { remotes?: RemoteOverview; loading?: boolean } = {}
+  options: { remotes?: RemoteOverview; loading?: boolean; bodyRows?: number } = {}
 ): ReactElement {
   const theme = createLogInkTheme({})
   const context: LogInkContext = options.remotes ? { remotes: options.remotes } : {}
@@ -51,7 +52,7 @@ function render(
     state,
     context,
     contextStatus,
-    bodyRows: 30,
+    bodyRows: options.bodyRows ?? 30,
     width: 120,
     theme,
   })
@@ -111,5 +112,55 @@ describe('renderRemotesSurface', () => {
         },
       })
     ).toMatchSnapshot()
+  })
+
+  // Regression (#1615): remotes windowed its rows with clampListWindowStart
+  // but rendered no scroll indicators, unlike every other windowed promoted
+  // surface (branches, tags, stash, ...).
+  describe('scroll indicators (#1615)', () => {
+    const manyRemotes: RemoteOverview = {
+      hasRemotes: true,
+      entries: Array.from({ length: 30 }, (_, i) =>
+        makeEntry({ name: `remote-${i}`, fetchUrl: `https://example.com/${i}.git`, pushUrl: `https://example.com/${i}.git` })),
+    }
+
+    it('shows only "more below" when cursored at the top', () => {
+      const tree = render(makeState({ selectedRemoteIndex: 0 }), { remotes: manyRemotes, bodyRows: 12 })
+      const text = renderToLines(tree, Text, Box).join('\n')
+      expect(text).not.toContain('more above')
+      expect(text).toContain('more below')
+    })
+
+    it('shows only "more above" when cursored at the bottom', () => {
+      const tree = render(makeState({ selectedRemoteIndex: manyRemotes.entries.length - 1 }), {
+        remotes: manyRemotes,
+        bodyRows: 12,
+      })
+      const text = renderToLines(tree, Text, Box).join('\n')
+      expect(text).toContain('more above')
+      expect(text).not.toContain('more below')
+    })
+
+    it('shows both indicators mid-list and keeps the total rendered rows within bodyRows', () => {
+      const bodyRows = 12
+      const tree = render(makeState({ selectedRemoteIndex: 15 }), { remotes: manyRemotes, bodyRows })
+      const lines = renderToLines(tree, Text, Box)
+      const text = lines.join('\n')
+      expect(text).toContain('more above')
+      expect(text).toContain('more below')
+      const BORDER_ROWS = 2
+      expect(lines.length + BORDER_ROWS).toBeLessThanOrEqual(bodyRows)
+    })
+
+    it('keeps the total rendered row count within bodyRows with the filter affordance active too', () => {
+      const bodyRows = 12
+      const tree = render(
+        makeState({ selectedRemoteIndex: 15, filterMode: true, filter: 'remote' }),
+        { remotes: manyRemotes, bodyRows }
+      )
+      const lines = renderToLines(tree, Text, Box)
+      const BORDER_ROWS = 2
+      expect(lines.length + BORDER_ROWS).toBeLessThanOrEqual(bodyRows)
+    })
   })
 })

--- a/src/workstation/surfaces/submodules/index.ts
+++ b/src/workstation/surfaces/submodules/index.ts
@@ -54,7 +54,13 @@ export function renderSubmodulesSurface(ctx: SurfaceRenderContext): ReactTypes.R
     )
     : all
   const selected = Math.max(0, Math.min(state.selectedSubmoduleIndex, Math.max(0, filtered.length - 1)))
-  const listRows = Math.max(4, bodyRows - 4)
+  // Row budget (#1392, #1615): the base reserve (borders + title + one
+  // spare) must also count the conditional rows, or the panel grows past
+  // its box mid-scroll — the filter affordance while filtering, and BOTH
+  // scroll indicators once the list overflows the window (the single
+  // spare absorbed only one of them). Mirrors the branches surface.
+  const baseRows = Math.max(4, bodyRows - 4 - (state.filterMode ? 1 : 0))
+  const listRows = filtered.length > baseRows ? Math.max(4, baseRows - 1) : baseRows
   const startIndex = clampListWindowStart(selected, filtered.length, listRows)
   const visible = filtered.slice(startIndex, startIndex + listRows)
   const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
@@ -100,6 +106,11 @@ export function renderSubmodulesSurface(ctx: SurfaceRenderContext): ReactTypes.R
         }, lineText)
       })
 
+  // Scroll indicators (#1615) — same "N more above/below" pattern as
+  // branches/tags so the user knows the list continues past the window.
+  const submodulesHasMoreAbove = startIndex > 0 && filtered.length > 0
+  const submodulesHasMoreBelow = startIndex + listRows < filtered.length
+
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
     borderStyle: theme.borderStyle,
@@ -113,5 +124,11 @@ export function renderSubmodulesSurface(ctx: SurfaceRenderContext): ReactTypes.R
     h(Text, { dimColor: true }, headerRight),
   ),
   ...renderPromotedFilterAffordance(h, Text, state, theme),
-  ...lines)
+  ...(submodulesHasMoreAbove
+    ? [h(Text, { key: 'submodules-more-above', dimColor: true }, `  ↑ ${startIndex} more above`)]
+    : []),
+  ...lines,
+  ...(submodulesHasMoreBelow
+    ? [h(Text, { key: 'submodules-more-below', dimColor: true }, `  ↓ ${filtered.length - (startIndex + listRows)} more below`)]
+    : []))
 }

--- a/src/workstation/surfaces/submodules/submodulesRender.test.ts
+++ b/src/workstation/surfaces/submodules/submodulesRender.test.ts
@@ -12,6 +12,7 @@ import {
 import type { SubmoduleEntry, SubmoduleOverview } from '../../../git/submoduleData'
 import type { LogInkContext, LogInkComponents } from '../../runtime/types'
 import { renderSubmodulesSurface } from './index'
+import { renderToLines } from '../../runtime/testSupport/renderToLines'
 
 type StubProps = Record<string, unknown>
 const Text = ((props: StubProps) =>
@@ -39,7 +40,7 @@ function makeEntry(overrides: Partial<SubmoduleEntry> = {}): SubmoduleEntry {
 
 function render(
   state: LogInkState,
-  options: { submodules?: SubmoduleOverview; loading?: boolean } = {}
+  options: { submodules?: SubmoduleOverview; loading?: boolean; bodyRows?: number } = {}
 ): ReactElement {
   const theme = createLogInkTheme({})
   const context: LogInkContext = options.submodules ? { submodules: options.submodules } : {}
@@ -52,7 +53,7 @@ function render(
     state,
     context,
     contextStatus,
-    bodyRows: 30,
+    bodyRows: options.bodyRows ?? 30,
     width: 120,
     theme,
   })
@@ -98,5 +99,61 @@ describe('renderSubmodulesSurface', () => {
     expect(
       render(makeState(), { submodules: { hasSubmodules: true, entries: [makeEntry()] } })
     ).toMatchSnapshot()
+  })
+
+  // Regression (#1615): submodules windowed its rows with
+  // clampListWindowStart but rendered no scroll indicators, unlike every
+  // other windowed promoted surface (branches, tags, stash, ...).
+  describe('scroll indicators (#1615)', () => {
+    const manySubmodules: SubmoduleOverview = {
+      hasSubmodules: true,
+      entries: Array.from({ length: 30 }, (_, i) =>
+        makeEntry({ name: `vendor/lib-${i}`, path: `vendor/lib-${i}` })),
+    }
+
+    it('shows only "more below" when cursored at the top', () => {
+      const tree = render(makeState({ selectedSubmoduleIndex: 0 }), {
+        submodules: manySubmodules,
+        bodyRows: 12,
+      })
+      const text = renderToLines(tree, Text, Box).join('\n')
+      expect(text).not.toContain('more above')
+      expect(text).toContain('more below')
+    })
+
+    it('shows only "more above" when cursored at the bottom', () => {
+      const tree = render(makeState({ selectedSubmoduleIndex: manySubmodules.entries.length - 1 }), {
+        submodules: manySubmodules,
+        bodyRows: 12,
+      })
+      const text = renderToLines(tree, Text, Box).join('\n')
+      expect(text).toContain('more above')
+      expect(text).not.toContain('more below')
+    })
+
+    it('shows both indicators mid-list and keeps the total rendered rows within bodyRows', () => {
+      const bodyRows = 12
+      const tree = render(makeState({ selectedSubmoduleIndex: 15 }), {
+        submodules: manySubmodules,
+        bodyRows,
+      })
+      const lines = renderToLines(tree, Text, Box)
+      const text = lines.join('\n')
+      expect(text).toContain('more above')
+      expect(text).toContain('more below')
+      const BORDER_ROWS = 2
+      expect(lines.length + BORDER_ROWS).toBeLessThanOrEqual(bodyRows)
+    })
+
+    it('keeps the total rendered row count within bodyRows with the filter affordance active too', () => {
+      const bodyRows = 12
+      const tree = render(
+        makeState({ selectedSubmoduleIndex: 15, filterMode: true, filter: 'vendor' }),
+        { submodules: manySubmodules, bodyRows }
+      )
+      const lines = renderToLines(tree, Text, Box)
+      const BORDER_ROWS = 2
+      expect(lines.length + BORDER_ROWS).toBeLessThanOrEqual(bodyRows)
+    })
   })
 })

--- a/src/workstation/surfaces/worktrees/index.ts
+++ b/src/workstation/surfaces/worktrees/index.ts
@@ -34,7 +34,13 @@ export function renderWorktreesSurface(ctx: SurfaceRenderContext, spinnerFrame: 
     )
     : allWorktrees
   const selected = Math.max(0, Math.min(state.selectedWorktreeListIndex, Math.max(0, worktrees.length - 1)))
-  const listRows = Math.max(4, bodyRows - 4)
+  // Row budget (#1392, #1615): the base reserve (borders + title + one
+  // spare) must also count the conditional rows, or the panel grows past
+  // its box mid-scroll — the filter affordance while filtering, and BOTH
+  // scroll indicators once the list overflows the window (the single
+  // spare absorbed only one of them). Mirrors the branches surface.
+  const baseRows = Math.max(4, bodyRows - 4 - (state.filterMode ? 1 : 0))
+  const listRows = worktrees.length > baseRows ? Math.max(4, baseRows - 1) : baseRows
   const startIndex = clampListWindowStart(selected, worktrees.length, listRows)
   const visible = worktrees.slice(startIndex, startIndex + listRows)
   const filterLabel = state.filter ? ` | filter: ${state.filter}` : ''
@@ -76,6 +82,11 @@ export function renderWorktreesSurface(ctx: SurfaceRenderContext, spinnerFrame: 
         ))
       })
 
+  // Scroll indicators (#1615) — same "N more above/below" pattern as
+  // branches/tags so the user knows the list continues past the window.
+  const worktreesHasMoreAbove = startIndex > 0 && worktrees.length > 0
+  const worktreesHasMoreBelow = startIndex + listRows < worktrees.length
+
   return h(Box, {
     borderColor: focusBorderColor(theme, focused),
     borderStyle: theme.borderStyle,
@@ -89,5 +100,11 @@ export function renderWorktreesSurface(ctx: SurfaceRenderContext, spinnerFrame: 
     h(Text, { dimColor: true }, headerRight)
   ),
   ...renderPromotedFilterAffordance(h, Text, state, theme),
-  ...lines)
+  ...(worktreesHasMoreAbove
+    ? [h(Text, { key: 'worktrees-more-above', dimColor: true }, `  ↑ ${startIndex} more above`)]
+    : []),
+  ...lines,
+  ...(worktreesHasMoreBelow
+    ? [h(Text, { key: 'worktrees-more-below', dimColor: true }, `  ↓ ${worktrees.length - (startIndex + listRows)} more below`)]
+    : []))
 }

--- a/src/workstation/surfaces/worktrees/index.ts
+++ b/src/workstation/surfaces/worktrees/index.ts
@@ -12,7 +12,7 @@ import type * as ReactTypes from 'react'
 import { isLogInkContextKeyLoading } from '../../chrome/context'
 import { clampListWindowStart } from '../../chrome/layout'
 import { inlineSpinnerGlyph } from '../../chrome/spinner'
-import { formatLogInkLoading } from '../../chrome/surfaceStates'
+import { formatLogInkLoading, formatLogInkWorktreesEmpty } from '../../chrome/surfaceStates'
 import { truncateCells } from '../../chrome/text'
 import {
   matchesPromotedFilter,
@@ -55,7 +55,7 @@ export function renderWorktreesSurface(ctx: SurfaceRenderContext, spinnerFrame: 
   const lines: ReactTypes.ReactNode[] = loading
     ? [h(Text, { key: 'worktrees-loading', dimColor: true }, formatLogInkLoading({ resource: 'worktrees' }))]
     : worktrees.length === 0
-      ? [h(Text, { key: 'worktrees-empty', dimColor: true }, 'No linked worktrees.')]
+      ? [h(Text, { key: 'worktrees-empty', dimColor: true }, formatLogInkWorktreesEmpty({ filter: state.filter }))]
       : visible.map((entry, offset) => {
         const index = startIndex + offset
         const isSelected = index === selected

--- a/src/workstation/surfaces/worktrees/worktreesRender.test.ts
+++ b/src/workstation/surfaces/worktrees/worktreesRender.test.ts
@@ -106,4 +106,33 @@ describe('renderWorktreesSurface', () => {
       render(makeState(), { worktreeList: makeOverview([makeEntry()]) })
     ).toMatchSnapshot()
   })
+
+  // Regression (#1620): an active filter matching zero worktrees used to
+  // render the same "No linked worktrees." copy as a genuinely empty repo,
+  // contradicting the header's "0/N worktrees | filter: …" line.
+  describe('filtered-to-zero empty state (#1620)', () => {
+    function flatten(node: unknown, out: string[] = []): string[] {
+      if (node == null) return out
+      if (typeof node === 'string') { out.push(node); return out }
+      if (Array.isArray(node)) { node.forEach((n) => flatten(n, out)); return out }
+      const props = (node as { props?: { children?: unknown } }).props
+      if (props) flatten(props.children, out)
+      return out
+    }
+
+    it('shows filter-aware copy, not the genuinely-empty message, when the filter matches nothing', () => {
+      const tree = render(makeState({ filter: 'no-such-worktree' }), {
+        worktreeList: makeOverview([makeEntry()]),
+      })
+      const text = flatten(tree).join('\n')
+      expect(text).toContain("No worktrees match filter 'no-such-worktree'")
+      expect(text).not.toContain('No linked worktrees.')
+    })
+
+    it('still shows the genuinely-empty message with no filter active', () => {
+      const tree = render(makeState(), { worktreeList: makeOverview([]) })
+      const text = flatten(tree).join('\n')
+      expect(text).toContain('No linked worktrees.')
+    })
+  })
 })

--- a/src/workstation/surfaces/worktrees/worktreesRender.test.ts
+++ b/src/workstation/surfaces/worktrees/worktreesRender.test.ts
@@ -12,6 +12,7 @@ import {
 import type { WorktreeEntry, WorktreeOverview } from '../../../git/worktreeData'
 import type { LogInkContext, LogInkComponents } from '../../runtime/types'
 import { renderWorktreesSurface } from './index'
+import { renderToLines } from '../../runtime/testSupport/renderToLines'
 
 type StubProps = Record<string, unknown>
 const Text = ((props: StubProps) =>
@@ -46,7 +47,7 @@ function makeOverview(worktrees: WorktreeEntry[]): WorktreeOverview {
 
 function render(
   state: LogInkState,
-  options: { worktreeList?: WorktreeOverview; loading?: boolean } = {}
+  options: { worktreeList?: WorktreeOverview; loading?: boolean; bodyRows?: number } = {}
 ): ReactElement {
   const theme = createLogInkTheme({})
   const context: LogInkContext = options.worktreeList
@@ -61,7 +62,7 @@ function render(
     state,
     context,
     contextStatus,
-    bodyRows: 30,
+    bodyRows: options.bodyRows ?? 30,
     width: 120,
     theme,
   })
@@ -133,6 +134,64 @@ describe('renderWorktreesSurface', () => {
       const tree = render(makeState(), { worktreeList: makeOverview([]) })
       const text = flatten(tree).join('\n')
       expect(text).toContain('No linked worktrees.')
+    })
+  })
+
+  // Regression (#1615): worktrees windowed its rows with clampListWindowStart
+  // but rendered no scroll indicators, unlike every other windowed promoted
+  // surface (branches, tags, stash, ...) — a long worktree list read as "this
+  // is everything" with no signal that entries scrolled off either edge.
+  describe('scroll indicators (#1615)', () => {
+    const manyWorktrees = Array.from({ length: 30 }, (_, i) =>
+      makeEntry({ path: `/repo-wt-${i}`, branch: `feature/${i}`, current: i === 0 }))
+
+    it('shows only "more below" when cursored at the top', () => {
+      const tree = render(makeState({ selectedWorktreeListIndex: 0 }), {
+        worktreeList: makeOverview(manyWorktrees),
+        bodyRows: 12,
+      })
+      const lines = renderToLines(tree, Text, Box)
+      const text = lines.join('\n')
+      expect(text).not.toContain('more above')
+      expect(text).toContain('more below')
+    })
+
+    it('shows only "more above" when cursored at the bottom', () => {
+      const tree = render(makeState({ selectedWorktreeListIndex: manyWorktrees.length - 1 }), {
+        worktreeList: makeOverview(manyWorktrees),
+        bodyRows: 12,
+      })
+      const lines = renderToLines(tree, Text, Box)
+      const text = lines.join('\n')
+      expect(text).toContain('more above')
+      expect(text).not.toContain('more below')
+    })
+
+    it('shows both indicators mid-list and keeps the total rendered rows within bodyRows', () => {
+      const bodyRows = 12
+      const tree = render(makeState({ selectedWorktreeListIndex: 15 }), {
+        worktreeList: makeOverview(manyWorktrees),
+        bodyRows,
+      })
+      const lines = renderToLines(tree, Text, Box)
+      const text = lines.join('\n')
+      expect(text).toContain('more above')
+      expect(text).toContain('more below')
+      // The panel's own border isn't part of the flattened content lines
+      // renderToLines counts, but it still costs 2 rows against bodyRows.
+      const BORDER_ROWS = 2
+      expect(lines.length + BORDER_ROWS).toBeLessThanOrEqual(bodyRows)
+    })
+
+    it('keeps the total rendered row count within bodyRows with the filter affordance active too', () => {
+      const bodyRows = 12
+      const tree = render(
+        makeState({ selectedWorktreeListIndex: 15, filterMode: true, filter: 'feature' }),
+        { worktreeList: makeOverview(manyWorktrees), bodyRows }
+      )
+      const lines = renderToLines(tree, Text, Box)
+      const BORDER_ROWS = 2
+      expect(lines.length + BORDER_ROWS).toBeLessThanOrEqual(bodyRows)
     })
   })
 })


### PR DESCRIPTION
## What

Four issues filed as `enhancement`/`design` that read exactly like bugs. Closes #1615, #1618, #1620, #1633.

- **#1620** — worktrees empty state ignored the active filter, always showing "No linked worktrees" even when the filter matched zero results.
- **#1615** — worktrees/remotes/submodules/reflog surfaces had no scroll indicators, so a list overflowing the visible window gave no sign it continued.
- **#1618** — added `--message` to `coco log` for commit-message search (`git log --grep`), since `--grep` was already taken by diff-content search (`git log -G`) and renaming it would break existing users.
- **#1633** — an unexpected triage-list fetch rejection (e.g. repository resolution failing) was swallowed into bare `undefined`, which reads through the render layer as "still loading" forever instead of surfacing the existing error UI.

## How

Each issue was fixed independently with a targeted regression test, verified to fail without its corresponding fix (via `git stash`) and pass with it.

## Validation

- [x] `npx tsc --noEmit` passes
- [x] New/updated tests per fix, verified to fail without the fix
- [x] Full `src/workstation` test suite (2746 tests) passes
- [ ] `npm test` (full CI matrix) — will run in this PR

## Notes

None.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBgeU9gYuYUHPFnLa8rJXF)_