### PR TITLE
chore(docs): fix doc rot and stale TODOs

### DIFF
--- a/bin/generateBuildInfo.ts
+++ b/bin/generateBuildInfo.ts
@@ -24,6 +24,11 @@ async function generateBuildInfo(): Promise<void> {
  * Current build version from package.json
  */
 export const BUILD_VERSION = ${JSON.stringify(process.env.npm_package_version)}
+
+/**
+ * Package name from package.json
+ */
+export const BUILD_PACKAGE_NAME = ${JSON.stringify(process.env.npm_package_name)}
 `
 
     fs.writeFileSync(tsPath, tsContent)

--- a/schema.json
+++ b/schema.json
@@ -133,7 +133,7 @@
             },
             "syntaxHighlight": {
               "type": "boolean",
-              "description": "Syntax-highlight code in the diff view using tree-sitter (TypeScript / TSX / JavaScript today). On by default. Highlighting degrades gracefully — unsupported languages, non-ASCII lines, and parse failures fall back to the plain add/remove coloring — so the only reason to disable it is preference or a very low-color terminal. Set to `false` to opt out.",
+              "description": "Syntax-highlight code in the diff view using tree-sitter. Built-in languages (TypeScript / TSX / JavaScript) highlight immediately; others lazy-download their grammar on first use — see `TREE_SITTER_MANIFEST` (src/lib/parsers/default/__tree_sitter__/manifest.ts) for the current supported-language list. On by default. Highlighting degrades gracefully — unsupported languages, non-ASCII lines, and parse failures fall back to the plain add/remove coloring — so the only reason to disable it is preference or a very low-color terminal. Set to `false` to opt out.",
               "default": true
             }
           },

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -123,8 +123,11 @@ type BaseConfig = {
     dateBucketing?: boolean
 
     /**
-     * Syntax-highlight code in the diff view using tree-sitter
-     * (TypeScript / TSX / JavaScript today). On by default. Highlighting
+     * Syntax-highlight code in the diff view using tree-sitter. Built-in
+     * languages (TypeScript / TSX / JavaScript) highlight immediately;
+     * others lazy-download their grammar on first use — see
+     * `TREE_SITTER_MANIFEST` (src/lib/parsers/default/__tree_sitter__/manifest.ts)
+     * for the current supported-language list. On by default. Highlighting
      * degrades gracefully — unsupported languages, non-ASCII lines, and
      * parse failures fall back to the plain add/remove coloring — so the
      * only reason to disable it is preference or a very low-color

--- a/src/lib/langchain/chains/summarize/prompt.ts
+++ b/src/lib/langchain/chains/summarize/prompt.ts
@@ -11,7 +11,6 @@ import { PromptTemplate } from '@langchain/core/prompts'
  * - Add guidance for preserving semantic meaning of changes
  * - Consider change type (added/modified/deleted) in prompt for better context
  * - Include hints about the programming language for more idiomatic summaries
- * - Add support for custom user-provided summarization prompts via config
  */
 const template = `GOAL: Use functional abstractions to summarize the following text
 

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -144,7 +144,7 @@ export const schema = {
             },
             "syntaxHighlight": {
               "type": "boolean",
-              "description": "Syntax-highlight code in the diff view using tree-sitter (TypeScript / TSX / JavaScript today). On by default. Highlighting degrades gracefully — unsupported languages, non-ASCII lines, and parse failures fall back to the plain add/remove coloring — so the only reason to disable it is preference or a very low-color terminal. Set to `false` to opt out.",
+              "description": "Syntax-highlight code in the diff view using tree-sitter. Built-in languages (TypeScript / TSX / JavaScript) highlight immediately; others lazy-download their grammar on first use — see `TREE_SITTER_MANIFEST` (src/lib/parsers/default/__tree_sitter__/manifest.ts) for the current supported-language list. On by default. Highlighting degrades gracefully — unsupported languages, non-ASCII lines, and parse failures fall back to the plain add/remove coloring — so the only reason to disable it is preference or a very low-color terminal. Set to `false` to opt out.",
               "default": true
             }
           },

--- a/src/lib/ui/checkAndHandlePackageInstall.ts
+++ b/src/lib/ui/checkAndHandlePackageInstall.ts
@@ -1,11 +1,11 @@
+import { BUILD_PACKAGE_NAME } from '../buildInfo'
 import { findProjectRoot } from '../utils/findProjectRoot'
 import { installNpmPackage } from '../utils/installPackage'
 import { isPackageInstalled } from '../utils/isPackageInstalled'
 import { Logger } from '../utils/logger'
 import { confirmPrompt } from './inquirerPrompts'
 
-// TODO: QoL improvement to import this from `package.json`
-const packageName = 'git-coco'
+const packageName = BUILD_PACKAGE_NAME
 
 type CheckAndHandlePackageInstallationInput = {
   global?: boolean


### PR DESCRIPTION
## What

Fixes several small doc-rot spots found during a tech-debt sweep: a hardcoded package name with a stale TODO, a shipped-feature bullet left in a prompt TODO comment, and a stale enumerated language list in a config doc comment.

Closes #1644

## How

- `bin/generateBuildInfo.ts` now emits `BUILD_PACKAGE_NAME` from `process.env.npm_package_name`.
- `src/lib/ui/checkAndHandlePackageInstall.ts` reads that constant instead of a hardcoded `'git-coco'` string.
- `src/lib/langchain/chains/summarize/prompt.ts` — removed a TODO bullet for a feature that's already shipped (`summarizePrompt` config).
- `src/lib/config/types.ts` — `syntaxHighlight` doc comment now points at `TREE_SITTER_MANIFEST` as the source of truth instead of a stale enumerated list.
- `schema.json` regenerated via `npm run build:schema` (2-line diff from the doc comment change).

## Validation

- [x] `npx tsc --noEmit` passes
- [x] `npm run build:schema` regenerated cleanly
- [ ] N/A — doc-only change, no new tests needed

## Notes

No behavior change.