### PR TITLE
test(commands,ui): cover prs/issues argv mapping and the review-decision loop

### DIFF
--- a/src/commands/issues/issues.test.ts
+++ b/src/commands/issues/issues.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Coverage for the `coco issues` command (#1642) — argv→filter mapping,
+ * forge-dispatch selection, and the `--json` contract. Mirrors
+ * `../prs/prs.test.ts`; the two commands share `createGitHubListHandler`.
+ */
+jest.mock('../utils/applyRepoFlag')
+jest.mock('../../git/providerData')
+jest.mock('../../git/issuesListData')
+jest.mock('../../git/gitlabListData')
+jest.mock('../../git/bitbucketListData')
+jest.mock('../../lib/ui/emitJson')
+
+import { Arguments } from 'yargs'
+import { SimpleGit } from 'simple-git'
+import { handler } from './handler'
+import { IssuesOptions } from './config'
+import { applyRepoFlag } from '../utils/applyRepoFlag'
+import { getProviderRepositoryForGit } from '../../git/providerData'
+import { getIssueList } from '../../git/issuesListData'
+import { getGitLabIssueList } from '../../git/gitlabListData'
+import { getBitbucketIssueList } from '../../git/bitbucketListData'
+import { emitJson } from '../../lib/ui/emitJson'
+import { Logger } from '../../lib/utils/logger'
+
+const applyRepoFlagMock = applyRepoFlag as jest.MockedFunction<typeof applyRepoFlag>
+const getProviderRepositoryForGitMock =
+  getProviderRepositoryForGit as jest.MockedFunction<typeof getProviderRepositoryForGit>
+const getIssueListMock = getIssueList as jest.MockedFunction<typeof getIssueList>
+const getGitLabIssueListMock = getGitLabIssueList as jest.MockedFunction<typeof getGitLabIssueList>
+const getBitbucketIssueListMock =
+  getBitbucketIssueList as jest.MockedFunction<typeof getBitbucketIssueList>
+const emitJsonMock = emitJson as jest.MockedFunction<typeof emitJson>
+
+const fakeGit = {} as SimpleGit
+
+function createLogger(): Logger {
+  return {
+    log: jest.fn(),
+    verbose: jest.fn(),
+    setConfig: jest.fn(),
+    error: jest.fn(),
+    startTimer: jest.fn().mockReturnThis(),
+    stopTimer: jest.fn().mockReturnThis(),
+    startSpinner: jest.fn().mockReturnThis(),
+    stopSpinner: jest.fn().mockReturnThis(),
+  } as unknown as Logger
+}
+
+function baseArgv(overrides: Partial<IssuesOptions> = {}): Arguments<IssuesOptions> {
+  return {
+    $0: 'coco',
+    _: ['issues'],
+    state: 'open',
+    mine: false,
+    json: false,
+    refresh: false,
+    cache: false,
+    ...overrides,
+  } as Arguments<IssuesOptions>
+}
+
+const overview = {
+  available: true,
+  authenticated: true,
+  issues: [
+    { number: 1, title: 'Bug report', url: 'https://x/1', state: 'OPEN', createdAt: '', updatedAt: '' },
+  ],
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  applyRepoFlagMock.mockReturnValue(fakeGit)
+  getProviderRepositoryForGitMock.mockResolvedValue({
+    provider: 'github',
+    remote: 'origin',
+    owner: 'acme',
+    name: 'widgets',
+  })
+  getIssueListMock.mockResolvedValue(overview as never)
+  getGitLabIssueListMock.mockResolvedValue(overview as never)
+  getBitbucketIssueListMock.mockResolvedValue(overview as never)
+})
+
+describe('coco issues — argv to filter mapping', () => {
+  it('maps --mine to assignee @me, overriding a bare --assignee', async () => {
+    await handler(baseArgv({ mine: true, assignee: 'someone-else' }), createLogger())
+
+    expect(getIssueListMock).toHaveBeenCalledWith(
+      fakeGit,
+      expect.objectContaining({ assignee: '@me' })
+    )
+  })
+
+  it('passes state, author, label, search, limit straight through', async () => {
+    await handler(
+      baseArgv({
+        state: 'closed',
+        author: 'octocat',
+        label: 'bug',
+        search: 'is:open',
+        limit: 5,
+      }),
+      createLogger()
+    )
+
+    expect(getIssueListMock).toHaveBeenCalledWith(fakeGit, {
+      state: 'closed',
+      assignee: undefined,
+      author: 'octocat',
+      label: 'bug',
+      search: 'is:open',
+      limit: 5,
+    })
+  })
+})
+
+describe('coco issues — forge dispatch selection', () => {
+  it('routes to getIssueList for github', async () => {
+    await handler(baseArgv(), createLogger())
+    expect(getIssueListMock).toHaveBeenCalled()
+    expect(getGitLabIssueListMock).not.toHaveBeenCalled()
+    expect(getBitbucketIssueListMock).not.toHaveBeenCalled()
+  })
+
+  it('routes to getGitLabIssueList for gitlab', async () => {
+    getProviderRepositoryForGitMock.mockResolvedValue({
+      provider: 'gitlab', remote: 'origin', owner: 'acme', name: 'widgets',
+    })
+    await handler(baseArgv(), createLogger())
+    expect(getGitLabIssueListMock).toHaveBeenCalled()
+    expect(getIssueListMock).not.toHaveBeenCalled()
+    expect(getBitbucketIssueListMock).not.toHaveBeenCalled()
+  })
+
+  it('routes to getBitbucketIssueList for bitbucket', async () => {
+    getProviderRepositoryForGitMock.mockResolvedValue({
+      provider: 'bitbucket', remote: 'origin', owner: 'acme', name: 'widgets',
+    })
+    await handler(baseArgv(), createLogger())
+    expect(getBitbucketIssueListMock).toHaveBeenCalled()
+    expect(getIssueListMock).not.toHaveBeenCalled()
+    expect(getGitLabIssueListMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('coco issues — --json contract', () => {
+  it('emits the raw item list as JSON instead of the formatted table', async () => {
+    const logger = createLogger()
+    await handler(baseArgv({ json: true }), logger)
+
+    expect(emitJsonMock).toHaveBeenCalledWith(overview.issues)
+    expect(logger.log).not.toHaveBeenCalled()
+  })
+})

--- a/src/commands/prs/prs.test.ts
+++ b/src/commands/prs/prs.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Coverage for the `coco prs` command (#1642) — argv→filter mapping,
+ * forge-dispatch selection, and the `--json` contract. The shared engine
+ * (`createGitHubListHandler`) is exercised through the composed handler
+ * rather than in isolation, since the spec object it's built from isn't
+ * exported separately.
+ */
+jest.mock('../utils/applyRepoFlag')
+jest.mock('../../git/providerData')
+jest.mock('../../git/pullRequestListData')
+jest.mock('../../git/gitlabListData')
+jest.mock('../../git/bitbucketListData')
+jest.mock('../../lib/ui/emitJson')
+
+import { Arguments } from 'yargs'
+import { SimpleGit } from 'simple-git'
+import { handler } from './handler'
+import { PrsOptions } from './config'
+import { applyRepoFlag } from '../utils/applyRepoFlag'
+import { getProviderRepositoryForGit } from '../../git/providerData'
+import { getPullRequestList } from '../../git/pullRequestListData'
+import { getMergeRequestList } from '../../git/gitlabListData'
+import { getBitbucketPullRequestList } from '../../git/bitbucketListData'
+import { emitJson } from '../../lib/ui/emitJson'
+import { Logger } from '../../lib/utils/logger'
+
+const applyRepoFlagMock = applyRepoFlag as jest.MockedFunction<typeof applyRepoFlag>
+const getProviderRepositoryForGitMock =
+  getProviderRepositoryForGit as jest.MockedFunction<typeof getProviderRepositoryForGit>
+const getPullRequestListMock = getPullRequestList as jest.MockedFunction<typeof getPullRequestList>
+const getMergeRequestListMock = getMergeRequestList as jest.MockedFunction<typeof getMergeRequestList>
+const getBitbucketPullRequestListMock =
+  getBitbucketPullRequestList as jest.MockedFunction<typeof getBitbucketPullRequestList>
+const emitJsonMock = emitJson as jest.MockedFunction<typeof emitJson>
+
+const fakeGit = {} as SimpleGit
+
+function createLogger(): Logger {
+  return {
+    log: jest.fn(),
+    verbose: jest.fn(),
+    setConfig: jest.fn(),
+    error: jest.fn(),
+    startTimer: jest.fn().mockReturnThis(),
+    stopTimer: jest.fn().mockReturnThis(),
+    startSpinner: jest.fn().mockReturnThis(),
+    stopSpinner: jest.fn().mockReturnThis(),
+  } as unknown as Logger
+}
+
+function baseArgv(overrides: Partial<PrsOptions> = {}): Arguments<PrsOptions> {
+  return {
+    $0: 'coco',
+    _: ['prs'],
+    state: 'open',
+    draft: false,
+    mine: false,
+    json: false,
+    refresh: false,
+    cache: false,
+    ...overrides,
+  } as Arguments<PrsOptions>
+}
+
+const overview = {
+  available: true,
+  authenticated: true,
+  pullRequests: [
+    { number: 1, title: 'Add feature', url: 'https://x/1', state: 'OPEN', isDraft: false, headRefName: 'f', baseRefName: 'main', createdAt: '', updatedAt: '' },
+  ],
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  applyRepoFlagMock.mockReturnValue(fakeGit)
+  getProviderRepositoryForGitMock.mockResolvedValue({
+    provider: 'github',
+    remote: 'origin',
+    owner: 'acme',
+    name: 'widgets',
+  })
+  getPullRequestListMock.mockResolvedValue(overview as never)
+  getMergeRequestListMock.mockResolvedValue(overview as never)
+  getBitbucketPullRequestListMock.mockResolvedValue(overview as never)
+})
+
+describe('coco prs — argv to filter mapping', () => {
+  it('maps --mine to assignee @me, overriding a bare --assignee', async () => {
+    await handler(baseArgv({ mine: true, assignee: 'someone-else' }), createLogger())
+
+    expect(getPullRequestListMock).toHaveBeenCalledWith(
+      fakeGit,
+      expect.objectContaining({ assignee: '@me' })
+    )
+  })
+
+  it('passes state, author, label, search, base, head, draft, limit straight through', async () => {
+    await handler(
+      baseArgv({
+        state: 'closed',
+        author: 'octocat',
+        label: 'bug',
+        search: 'is:open',
+        base: 'main',
+        head: 'feature/x',
+        draft: true,
+        limit: 5,
+      }),
+      createLogger()
+    )
+
+    expect(getPullRequestListMock).toHaveBeenCalledWith(fakeGit, {
+      state: 'closed',
+      assignee: undefined,
+      author: 'octocat',
+      label: 'bug',
+      search: 'is:open',
+      base: 'main',
+      head: 'feature/x',
+      draft: true,
+      limit: 5,
+    })
+  })
+})
+
+describe('coco prs — forge dispatch selection', () => {
+  it('routes to getPullRequestList for github', async () => {
+    getProviderRepositoryForGitMock.mockResolvedValue({
+      provider: 'github', remote: 'origin', owner: 'acme', name: 'widgets',
+    })
+    await handler(baseArgv(), createLogger())
+    expect(getPullRequestListMock).toHaveBeenCalled()
+    expect(getMergeRequestListMock).not.toHaveBeenCalled()
+    expect(getBitbucketPullRequestListMock).not.toHaveBeenCalled()
+  })
+
+  it('routes to getMergeRequestList for gitlab', async () => {
+    getProviderRepositoryForGitMock.mockResolvedValue({
+      provider: 'gitlab', remote: 'origin', owner: 'acme', name: 'widgets',
+    })
+    await handler(baseArgv(), createLogger())
+    expect(getMergeRequestListMock).toHaveBeenCalled()
+    expect(getPullRequestListMock).not.toHaveBeenCalled()
+    expect(getBitbucketPullRequestListMock).not.toHaveBeenCalled()
+  })
+
+  it('routes to getBitbucketPullRequestList for bitbucket', async () => {
+    getProviderRepositoryForGitMock.mockResolvedValue({
+      provider: 'bitbucket', remote: 'origin', owner: 'acme', name: 'widgets',
+    })
+    await handler(baseArgv(), createLogger())
+    expect(getBitbucketPullRequestListMock).toHaveBeenCalled()
+    expect(getPullRequestListMock).not.toHaveBeenCalled()
+    expect(getMergeRequestListMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('coco prs — --json contract', () => {
+  it('emits the raw item list as JSON instead of the formatted table', async () => {
+    const logger = createLogger()
+    await handler(baseArgv({ json: true }), logger)
+
+    expect(emitJsonMock).toHaveBeenCalledWith(overview.pullRequests)
+    expect(logger.log).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/ui/generateAndReviewLoop.test.ts
+++ b/src/lib/ui/generateAndReviewLoop.test.ts
@@ -3,10 +3,25 @@
  * Every command test suite (commit, review, recap, changelog) mocks this
  * module entirely, so the loop's own control flow — in particular the
  * agent-returned-no-content exit path — had no test coverage until now.
+ *
+ * Extended (#1642) with table-driven coverage of the review-decision
+ * branches (approve / edit / cancel / retryMessageOnly / retryFull /
+ * modifyPrompt) and the REGENERATE_COMMIT_MESSAGE special-case, mocking
+ * the review-decision prompt + editor prompt so each branch is reachable
+ * without a real TTY. This locks in the exact surface the interactive-mode
+ * fixes (#1470, #1508, #1510) kept touching.
  */
-import { generateAndReviewLoop } from './generateAndReviewLoop'
+jest.mock('./getUserReviewDecision')
+jest.mock('./inquirerPrompts')
+
+import { generateAndReviewLoop, GenerateReviewLoopOptions } from './generateAndReviewLoop'
+import { getUserReviewDecision, ReviewDecision } from './getUserReviewDecision'
+import { editorPrompt } from './inquirerPrompts'
 import { CommandExitError, isCommandExitError } from '../utils/commandExit'
 import { Logger } from '../utils/logger'
+
+const getUserReviewDecisionMock = getUserReviewDecision as jest.MockedFunction<typeof getUserReviewDecision>
+const editorPromptMock = editorPrompt as jest.MockedFunction<typeof editorPrompt>
 
 function createLogger(): Logger {
   return {
@@ -20,6 +35,23 @@ function createLogger(): Logger {
     stopSpinner: jest.fn().mockReturnThis(),
   } as unknown as Logger
 }
+
+function baseOptions(overrides: Partial<GenerateReviewLoopOptions> = {}): GenerateReviewLoopOptions {
+  return {
+    interactive: true,
+    logger: createLogger(),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest.spyOn(console, 'log').mockImplementation(() => undefined)
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
 
 describe('generateAndReviewLoop', () => {
   it('exits with a non-zero code (not 0) when the agent returns empty content', async () => {
@@ -84,5 +116,205 @@ describe('generateAndReviewLoop', () => {
     })
 
     expect(result).toBe('generated content')
+  })
+})
+
+describe('generateAndReviewLoop — non-interactive extras', () => {
+  it('applies reviewParser to shape the returned (non-interactive) result', async () => {
+    const result = await generateAndReviewLoop({
+      label: 'commit message',
+      factory: async () => ({ file: 'x' }),
+      parser: async () => 'diff context',
+      noResult: jest.fn(),
+      agent: async () => 'raw result',
+      reviewParser: (r) => `parsed:${r}`,
+      options: baseOptions({ interactive: false }),
+    })
+
+    expect(result).toBe('parsed:raw result')
+    expect(getUserReviewDecisionMock).not.toHaveBeenCalled()
+  })
+
+  it('calls noResult when the factory yields no changes, but still proceeds through the loop', async () => {
+    const noResult = jest.fn()
+    const agent = jest.fn().mockResolvedValue('result')
+    await generateAndReviewLoop({
+      label: 'commit message',
+      factory: async () => ({}),
+      parser: async () => 'context',
+      noResult,
+      agent,
+      options: baseOptions({ interactive: false }),
+    })
+
+    expect(noResult).toHaveBeenCalledWith(expect.objectContaining({ interactive: false }))
+    expect(agent).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('generateAndReviewLoop — interactive decisions', () => {
+  it('approve: returns the (unedited) result in a single pass', async () => {
+    getUserReviewDecisionMock.mockResolvedValue('approve')
+    const agent = jest.fn().mockResolvedValue('generated message')
+    const parser = jest.fn().mockResolvedValue('context')
+
+    const result = await generateAndReviewLoop({
+      label: 'commit message',
+      factory: async () => ({ file: 'x' }),
+      parser,
+      noResult: jest.fn(),
+      agent,
+      options: baseOptions(),
+    })
+
+    expect(result).toBe('generated message')
+    expect(agent).toHaveBeenCalledTimes(1)
+    expect(parser).toHaveBeenCalledTimes(1)
+    expect(editorPromptMock).not.toHaveBeenCalled()
+  })
+
+  it('edit: flips openInEditor and routes the result through editorPrompt', async () => {
+    getUserReviewDecisionMock.mockResolvedValue('edit')
+    editorPromptMock.mockResolvedValue('hand-edited message')
+    const agent = jest.fn().mockResolvedValue('generated message')
+
+    const options = baseOptions()
+    const result = await generateAndReviewLoop({
+      label: 'commit message',
+      factory: async () => ({ file: 'x' }),
+      parser: async () => 'context',
+      noResult: jest.fn(),
+      agent,
+      options,
+    })
+
+    expect(options.openInEditor).toBe(true)
+    expect(editorPromptMock).toHaveBeenCalledWith(
+      expect.objectContaining({ default: 'generated message' })
+    )
+    expect(result).toBe('hand-edited message')
+  })
+
+  it('cancel: exits via CommandExitError(0) without returning a result', async () => {
+    getUserReviewDecisionMock.mockResolvedValue('cancel')
+    const agent = jest.fn().mockResolvedValue('generated message')
+
+    const promise = generateAndReviewLoop({
+      label: 'commit message',
+      factory: async () => ({ file: 'x' }),
+      parser: async () => 'context',
+      noResult: jest.fn(),
+      agent,
+      options: baseOptions(),
+    })
+
+    await expect(promise).rejects.toBeInstanceOf(CommandExitError)
+    await expect(promise).rejects.toMatchObject({ code: 0 })
+  })
+
+  it('retryFull: clears context + prompt and regenerates from parser again', async () => {
+    const decisions: ReviewDecision[] = ['retryFull', 'approve']
+    getUserReviewDecisionMock.mockImplementation(async () => decisions.shift()!)
+    const parser = jest.fn().mockResolvedValueOnce('context v1').mockResolvedValueOnce('context v2')
+    const agent = jest.fn().mockResolvedValueOnce('draft 1').mockResolvedValueOnce('draft 2')
+
+    const options = baseOptions({ prompt: 'original prompt' })
+    const result = await generateAndReviewLoop({
+      label: 'commit message',
+      factory: async () => ({ file: 'x' }),
+      parser,
+      noResult: jest.fn(),
+      agent,
+      options,
+    })
+
+    expect(parser).toHaveBeenCalledTimes(2)
+    expect(agent).toHaveBeenCalledTimes(2)
+    expect(agent).toHaveBeenNthCalledWith(2, 'context v2', expect.anything())
+    expect(result).toBe('draft 2')
+  })
+
+  it('retryMessageOnly: keeps the existing context, regenerates only via agent', async () => {
+    const decisions: ReviewDecision[] = ['retryMessageOnly', 'approve']
+    getUserReviewDecisionMock.mockImplementation(async () => decisions.shift()!)
+    const parser = jest.fn().mockResolvedValue('stable context')
+    const agent = jest.fn().mockResolvedValueOnce('draft 1').mockResolvedValueOnce('draft 2')
+
+    const result = await generateAndReviewLoop({
+      label: 'commit message',
+      factory: async () => ({ file: 'x' }),
+      parser,
+      noResult: jest.fn(),
+      agent,
+      options: baseOptions(),
+    })
+
+    // context is never cleared on retryMessageOnly, so the parser (which
+    // only re-runs when context is empty) fires once, not twice.
+    expect(parser).toHaveBeenCalledTimes(1)
+    expect(agent).toHaveBeenCalledTimes(2)
+    expect(agent).toHaveBeenNthCalledWith(1, 'stable context', expect.anything())
+    expect(agent).toHaveBeenNthCalledWith(2, 'stable context', expect.anything())
+    expect(result).toBe('draft 2')
+  })
+
+  it('modifyPrompt: re-prompts for a new prompt template before the next agent call', async () => {
+    const decisions: ReviewDecision[] = ['modifyPrompt', 'approve']
+    getUserReviewDecisionMock.mockImplementation(async () => decisions.shift()!)
+    editorPromptMock.mockResolvedValue('new prompt template')
+    const agent = jest.fn().mockResolvedValueOnce('draft 1').mockResolvedValueOnce('draft 2')
+
+    const options = baseOptions({ prompt: 'original prompt' })
+    const result = await generateAndReviewLoop({
+      label: 'commit message',
+      factory: async () => ({ file: 'x' }),
+      parser: async () => 'context',
+      noResult: jest.fn(),
+      agent,
+      options,
+    })
+
+    expect(editorPromptMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Edit the prompt' })
+    )
+    expect(options.prompt).toBe('new prompt template')
+    expect(agent).toHaveBeenCalledTimes(2)
+    expect(result).toBe('draft 2')
+  })
+})
+
+describe('generateAndReviewLoop — agent error paths', () => {
+  it('REGENERATE_COMMIT_MESSAGE: swallows the error and regenerates without consulting the reviewer', async () => {
+    const agent = jest.fn()
+      .mockRejectedValueOnce(new Error('REGENERATE_COMMIT_MESSAGE'))
+      .mockResolvedValueOnce('final result')
+
+    const result = await generateAndReviewLoop({
+      label: 'commit message',
+      factory: async () => ({ file: 'x' }),
+      parser: async () => 'context',
+      noResult: jest.fn(),
+      agent,
+      options: baseOptions({ interactive: false }),
+    })
+
+    expect(agent).toHaveBeenCalledTimes(2)
+    expect(result).toBe('final result')
+    expect(getUserReviewDecisionMock).not.toHaveBeenCalled()
+  })
+
+  it('propagates any other agent error', async () => {
+    const agent = jest.fn().mockRejectedValue(new Error('boom'))
+
+    await expect(
+      generateAndReviewLoop({
+        label: 'commit message',
+        factory: async () => ({ file: 'x' }),
+        parser: async () => 'context',
+        noResult: jest.fn(),
+        agent,
+        options: baseOptions({ interactive: false }),
+      })
+    ).rejects.toThrow('boom')
   })
 })

--- a/src/lib/ui/getUserReviewDecision.test.ts
+++ b/src/lib/ui/getUserReviewDecision.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Coverage for the review-decision choice list (#1642) — asserts which
+ * options `getUserReviewDecision` composes under each `enable*` flag, since
+ * `generateAndReviewLoop.ts` branches on exactly these value strings.
+ */
+jest.mock('./inquirerPrompts')
+
+import { selectPrompt } from './inquirerPrompts'
+import { getUserReviewDecision } from './getUserReviewDecision'
+
+const selectPromptMock = selectPrompt as jest.MockedFunction<typeof selectPrompt>
+
+type SelectPromptConfig = {
+  message: string
+  choices: Array<{ name: string; value: string; description: string }>
+}
+
+function lastConfig(callIndex = 0): SelectPromptConfig {
+  return selectPromptMock.mock.calls[callIndex][0] as SelectPromptConfig
+}
+
+function choiceValues(): string[] {
+  return lastConfig().choices.map((c) => c.value)
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  selectPromptMock.mockResolvedValue('approve')
+})
+
+describe('getUserReviewDecision', () => {
+  it('always includes approve and cancel', async () => {
+    await getUserReviewDecision({ label: 'commit message', enableEdit: false, enableRetry: false, enableFullRetry: false, enableModifyPrompt: false })
+    expect(choiceValues()).toEqual(['approve', 'cancel'])
+  })
+
+  it('defaults every enable* flag to true when omitted', async () => {
+    await getUserReviewDecision({ label: 'commit message' })
+    expect(choiceValues()).toEqual(['approve', 'edit', 'modifyPrompt', 'retryMessageOnly', 'retryFull', 'cancel'])
+  })
+
+  it('adds edit only when enableEdit is true', async () => {
+    await getUserReviewDecision({ label: 'x', enableEdit: true, enableRetry: false, enableFullRetry: false, enableModifyPrompt: false })
+    expect(choiceValues()).toEqual(['approve', 'edit', 'cancel'])
+  })
+
+  it('adds modifyPrompt only when enableModifyPrompt is true', async () => {
+    await getUserReviewDecision({ label: 'x', enableEdit: false, enableRetry: false, enableFullRetry: false, enableModifyPrompt: true })
+    expect(choiceValues()).toEqual(['approve', 'modifyPrompt', 'cancel'])
+  })
+
+  it('adds retryMessageOnly only when enableRetry is true', async () => {
+    await getUserReviewDecision({ label: 'x', enableEdit: false, enableRetry: true, enableFullRetry: false, enableModifyPrompt: false })
+    expect(choiceValues()).toEqual(['approve', 'retryMessageOnly', 'cancel'])
+  })
+
+  it('adds retryFull only when enableFullRetry is true', async () => {
+    await getUserReviewDecision({ label: 'x', enableEdit: false, enableRetry: false, enableFullRetry: true, enableModifyPrompt: false })
+    expect(choiceValues()).toEqual(['approve', 'retryFull', 'cancel'])
+  })
+
+  it('falls back to default names/descriptions but honors overrides', async () => {
+    await getUserReviewDecision({
+      label: 'changelog',
+      enableEdit: false,
+      enableRetry: true,
+      enableFullRetry: false,
+      enableModifyPrompt: false,
+      labels: { retryMessageOnly: '🔁 Redo' },
+      descriptions: { approve: 'Ship it' },
+    })
+    const choices = lastConfig().choices
+    expect(choices.find((c) => c.value === 'approve')?.description).toBe('Ship it')
+    expect(choices.find((c) => c.value === 'retryMessageOnly')?.name).toBe('🔁 Redo')
+  })
+
+  it('uses selectLabel as the prompt message when provided, else a default mentioning the label', async () => {
+    await getUserReviewDecision({ label: 'PR description', selectLabel: 'Custom prompt?' })
+    expect(lastConfig(0).message).toBe('Custom prompt?')
+
+    await getUserReviewDecision({ label: 'PR description' })
+    expect(lastConfig(1).message).toContain('PR description')
+  })
+
+  it('returns whatever selectPrompt resolves to', async () => {
+    selectPromptMock.mockResolvedValue('retryFull')
+    await expect(getUserReviewDecision({ label: 'x' })).resolves.toBe('retryFull')
+  })
+})


### PR DESCRIPTION
## What

Adds missing test coverage for a few previously-untested paths: `prs`/`issues` command argv→filter mapping and forge dispatch, `getUserReviewDecision`'s choice-list composition, and `generateAndReviewLoop`'s decision branches.

Closes #1642

## How

- `src/commands/prs/prs.test.ts` (new): `--mine` → `assignee: '@me'` override behavior, forge dispatch selection (github/gitlab/bitbucket), and the `--json` contract (raw items, not the formatted table).
- `src/commands/issues/issues.test.ts` (new): mirrors the prs coverage for issues.
- `src/lib/ui/getUserReviewDecision.test.ts` (new): 9 cases covering choice-list composition under each `enable*` flag combination.
- `src/lib/ui/generateAndReviewLoop.test.ts` (extended): approve/edit/cancel/retryFull/retryMessageOnly/modifyPrompt decisions and the `REGENERATE_COMMIT_MESSAGE` error path, including the context-clearing distinction between retryFull and retryMessageOnly.
- All new tests were verified via mutation testing (temporarily breaking the logic under test) to confirm they actually catch regressions, not just execute the code.

## Validation

- [x] `npx tsc --noEmit` passes
- [x] `npx jest` passes on new + existing suites
- [x] New behavior has tests (this PR is test-only)
- [x] `npx eslint` clean

## Notes

Test-only change, no production code touched.