### PR TITLE
test(e2e): PTY journeys for the destructive flows

### DIFF
--- a/e2e/batchBranchDelete.e2e.test.ts
+++ b/e2e/batchBranchDelete.e2e.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Golden journey: multi-select batch branch delete, plus the protected
+ * current-branch refusal (#1643). Against `branch-sync-showcase` (five
+ * local branches in five upstream-sync states), mark two non-current
+ * branches and batch-delete them — one deletes cleanly, the other isn't
+ * fully merged and needs its own force-confirm — then in a second pass,
+ * confirm the current branch refuses to delete even when marked.
+ */
+import { createScenarioRepo, type ScenarioRepo } from './fixtures'
+import { launchTui, type TuiSession } from './ptyHarness'
+
+describe('batch branch delete', () => {
+  let repo: ScenarioRepo
+  let tui: TuiSession
+
+  beforeAll(async () => {
+    repo = await createScenarioRepo('branch-sync-showcase')
+    tui = await launchTui({ cwd: repo.path })
+    await tui.waitForReady('Commits *')
+    tui.press('g', 'b')
+    await tui.waitForText('5/5 local')
+  })
+
+  afterAll(async () => {
+    await tui?.close()
+    await repo?.cleanup()
+  })
+
+  /** Press one key and let the screen settle before the next — batching
+   * keystrokes with no render yield in between has been flaky here. */
+  async function pressAndSettle(key: string): Promise<void> {
+    tui.press(key)
+    await tui.waitForIdle()
+  }
+
+  it('x marks feat/synced and local-only for batch delete', async () => {
+    // Cursor starts on `main` (current, top row); walk down past
+    // feat/ahead-only and feat/diverged to feat/synced.
+    await pressAndSettle('j')
+    await pressAndSettle('j')
+    await pressAndSettle('j')
+    tui.press('x')
+    let screen = await tui.waitForText('1 marked')
+    expect(screen).toContain('feat/synced')
+
+    await pressAndSettle('j')
+    tui.press('x')
+    screen = await tui.waitForText('2 marked')
+    expect(screen).toContain('local-only')
+  })
+
+  it('D confirms a multi-target delete listing both marked branches', async () => {
+    tui.press('D')
+    const screen = await tui.waitForText('Delete branch')
+    expect(screen).toContain('2 branches')
+    expect(screen).toContain('Press y to confirm')
+  })
+
+  it('y deletes the fully-merged branch and offers a force-confirm for the unmerged one', async () => {
+    tui.press('y')
+    const screen = await tui.waitForText('Force-delete branch')
+    expect(screen).toContain('local-only')
+    expect(screen).toContain('Not fully merged')
+  })
+
+  it('y force-confirms — both branches are gone', async () => {
+    tui.press('y')
+    const screen = await tui.waitForText('3/3 local')
+    expect(screen).not.toContain('feat/synced')
+    expect(screen).not.toContain('local-only')
+  })
+
+  it('marking and attempting to delete the current branch is refused, not silently dropped', async () => {
+    // The cursor doesn't reset to the top on this refresh — it stays
+    // wherever it last was, clamped against the just-shrunk list, and
+    // exactly where that clamps to isn't deterministic across runs. `k`
+    // at row 0 is a no-op, so pressing it more times than any possible
+    // list length reliably lands on `main` regardless of start position.
+    for (let i = 0; i < 5; i++) await pressAndSettle('k')
+    const screen = tui.snapshot()
+    expect(screen).toContain('> * main')
+
+    await pressAndSettle('x')
+    tui.press('D')
+    await tui.waitForText('Delete branch')
+    tui.press('y')
+    const result = await tui.waitForText('Cannot delete the current branch')
+    expect(result).toContain('3/3 local')
+  })
+})

--- a/e2e/cherryPickRange.e2e.test.ts
+++ b/e2e/cherryPickRange.e2e.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Golden journey: multi-select cherry-pick range onto another branch
+ * (#1643). Against the `multi-commit-branch` scenario, checkout `main`
+ * (history stays `--all` so `feat/dashboard`'s commits remain visible),
+ * anchor a 2-commit range with `v`, extend with `j`, and cherry-pick the
+ * whole range with `c` — exercises the multi-select range primitive
+ * (#1361) driving a real `git cherry-pick` end-to-end.
+ */
+import { createScenarioRepo, type ScenarioRepo } from './fixtures'
+import { launchTui, type TuiSession } from './ptyHarness'
+
+describe('cherry-pick range', () => {
+  let repo: ScenarioRepo
+  let tui: TuiSession
+
+  beforeAll(async () => {
+    repo = await createScenarioRepo('multi-commit-branch')
+    tui = await launchTui({ cwd: repo.path })
+    await tui.waitForReady('Commits *')
+  })
+
+  afterAll(async () => {
+    await tui?.close()
+    await repo?.cleanup()
+  })
+
+  it('checks out main, keeping feat/dashboard commits visible in --all history', async () => {
+    tui.press('g', 'b')
+    await tui.waitForText('2/2 local')
+    tui.press('j', 'enter')
+    const screen = await tui.waitForText('ℹ Synced history to branch main tip')
+    expect(screen).toContain('⎇ main')
+  })
+
+  it('gh jumps to history, cursor starting on the checked-out HEAD commit', async () => {
+    tui.press('g', 'h')
+    const screen = await tui.waitForText('ℹ jumped to history')
+    expect(screen).toContain('10 commits')
+    expect(screen).toContain('[main] chore: baseline app shell')
+    // feat/dashboard's commits are still listed (history defaults to --all).
+    expect(screen).toContain('[feat/dashboard] feat: add dashboard export-to-csv')
+  })
+
+  it('v anchors a range at the cursor', async () => {
+    // Cursor lands on the HEAD commit (main tip) after gh; walk up two rows
+    // to `60ff18b` before anchoring. Settle before anchoring — otherwise
+    // `v` can fire before both cursor moves land, anchoring one row off.
+    tui.press('k', 'k')
+    await tui.waitForIdle()
+    tui.press('v')
+    const screen = await tui.waitForText('Range anchor set')
+    expect(screen).toContain('range: v..cursor')
+  })
+
+  it('j extends the range one row down to a6e44d1', async () => {
+    tui.press('j')
+    // The anchor message text doesn't change on extend, so settle instead
+    // of waiting on new text — otherwise `c` below can fire on a
+    // single-commit range if it races the reducer's cursor-move handling.
+    await tui.waitForIdle()
+  })
+
+  it('c cherry-picks the whole range as one confirmable action', async () => {
+    tui.press('c')
+    const screen = await tui.waitForText('Cherry-pick commit')
+    expect(screen).toContain('2 commits')
+    expect(screen).toContain('Press y to confirm')
+  })
+
+  it('y confirms — both commits land on main in their original order', async () => {
+    tui.press('y')
+    // Gate on the history refetch (12 commits), not the status message —
+    // the success toast can paint a beat before the header count refreshes.
+    const screen = await tui.waitForText('12 commits')
+    expect(screen).toContain('✓ Cherry-picked')
+    expect(screen).toContain('[main] feat: wire dashboard to data source')
+    expect(screen).toContain('feat: add dashboard layout')
+    // feat/dashboard's own copies of these commits are still present too —
+    // cherry-pick creates new commits, it doesn't move the originals.
+    expect(screen).toContain('a6e44d1')
+  })
+})

--- a/e2e/rebaseConflictAbort.e2e.test.ts
+++ b/e2e/rebaseConflictAbort.e2e.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Golden journey: in-progress conflicted rebase → abort path (#1643).
+ * Uses the pre-baked `mid-rebase-conflict` scenario rather than starting
+ * a rebase from inside the TUI — a real conflicting rebase is
+ * inherently timing/content-sensitive to construct live, where the
+ * fixture gives a deterministic starting point for CI. Asserts the
+ * in-progress operation chip (#1416/#1474) is visible on boot, then
+ * drives the abort path via the conflicts view.
+ */
+import { createScenarioRepo, type ScenarioRepo } from './fixtures'
+import { launchTui, type TuiSession } from './ptyHarness'
+
+describe('rebase conflict → abort', () => {
+  let repo: ScenarioRepo
+  let tui: TuiSession
+
+  beforeAll(async () => {
+    repo = await createScenarioRepo('mid-rebase-conflict')
+    tui = await launchTui({ cwd: repo.path })
+    await tui.waitForReady('Commits *')
+  })
+
+  afterAll(async () => {
+    await tui?.close()
+    await repo?.cleanup()
+  })
+
+  it('boots with the REBASING operation chip visible in the header', async () => {
+    const screen = tui.snapshot()
+    expect(screen).toContain('REBASING (1 conflict)')
+  })
+
+  it('gx jumps to the conflicts view, listing the unresolved file', async () => {
+    tui.press('g', 'x')
+    const screen = await tui.waitForText('rebase — 1 conflict remaining')
+    expect(screen).toContain('UU src/config.ts')
+  })
+
+  it('A opens the abort-operation confirmation', async () => {
+    tui.press('A')
+    const screen = await tui.waitForText('Abort operation')
+    expect(screen).toContain('Press y to confirm')
+  })
+
+  it('y aborts — the rebase ends and the tree is clean again', async () => {
+    tui.press('y')
+    // Gate on the header settling to clean, not the status toast — the
+    // toast paints a beat before the header's operation-chip clears.
+    const screen = await tui.waitForText('✓ clean')
+    expect(screen).toContain('Aborted rebase')
+    expect(screen).not.toContain('REBASING')
+  })
+
+  it('the conflicts view reports no operation in progress', async () => {
+    const screen = await tui.waitForText('no operation in progress')
+    expect(screen).toContain('No merge, rebase, cherry-pick, or revert in progress.')
+  })
+})

--- a/e2e/resetUndo.e2e.test.ts
+++ b/e2e/resetUndo.e2e.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Golden journey: hard-reset a branch back, then reflog-powered undo
+ * restores it (#1643). Proves the 0.81 undo story (#1361 global `z`)
+ * end-to-end through a real `git reset --hard` + `git reset` recovery,
+ * not just the unit-level reflog parsing.
+ */
+import { createScenarioRepo, type ScenarioRepo } from './fixtures'
+import { launchTui, type TuiSession } from './ptyHarness'
+
+describe('reset + undo', () => {
+  let repo: ScenarioRepo
+  let tui: TuiSession
+
+  beforeAll(async () => {
+    repo = await createScenarioRepo('multi-commit-branch')
+    tui = await launchTui({ cwd: repo.path })
+    await tui.waitForReady('Commits *')
+  })
+
+  afterAll(async () => {
+    await tui?.close()
+    await repo?.cleanup()
+  })
+
+  /** Press one key and let the screen settle before the next — batching
+   * keystrokes with no render yield in between has been flaky here. */
+  async function pressAndSettle(key: string): Promise<void> {
+    tui.press(key)
+    await tui.waitForIdle()
+  }
+
+  const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+  it('boots on feat/dashboard with its full 10-commit history', async () => {
+    const screen = await tui.waitForText('10 commits')
+    expect(screen).toContain('⎇ feat/dashboard')
+  })
+
+  it('Z opens the reset mode picker for the cursored commit', async () => {
+    await pressAndSettle('j')
+    await pressAndSettle('j')
+    tui.press('Z')
+    const screen = await tui.waitForText('Reset branch tip')
+    expect(screen).toContain('Hard')
+    expect(screen).toContain('Soft')
+    expect(screen).toContain('Mixed')
+  })
+
+  it('h resets --hard to the cursored commit, dropping the two above it', async () => {
+    tui.press('h')
+    // Gate on the header count, not the status toast — the toast paints a
+    // beat before the header/reflog-undo-description refresh lands, and
+    // the next test's `z` needs that refresh to have already happened.
+    const screen = await tui.waitForText('8 commits')
+    expect(screen).toContain('Reset current branch to')
+    expect(screen).toContain('--hard')
+    expect(screen).not.toContain('feat: add dashboard export-to-csv')
+  })
+
+  it('z surfaces the global reflog undo for the reset it just did', async () => {
+    // The reflog context refetches off a debounced fs.watch (250ms) on
+    // .git/logs/HEAD, independent of the header count's own refresh —
+    // give it room to land before z reads context.reflogUndoDescription,
+    // or it can still describe the entry from before this reset.
+    await delay(800)
+    tui.press('z')
+    const screen = await tui.waitForText('Undo last operation')
+    expect(screen).toContain('Undo reset')
+    expect(screen).toContain('Press y to confirm')
+  })
+
+  it('y confirms — the branch tip is restored to its pre-reset state', async () => {
+    tui.press('y')
+    const screen = await tui.waitForText('10 commits')
+    expect(screen).toContain('Reset to the previous HEAD')
+    expect(screen).toContain('feat: add dashboard export-to-csv')
+  })
+})


### PR DESCRIPTION
## What

Adds PTY-driven e2e coverage for four destructive/recovery TUI journeys that had no end-to-end test: cherry-pick range, reset + global undo, batch branch delete, and rebase-conflict abort.

Closes #1643

## How

- `e2e/cherryPickRange.e2e.test.ts`: range-select two commits via `v`/`j` and cherry-pick them; gates the final assertion on the header's refreshed commit count rather than the status toast, since the toast paints before the header refresh completes.
- `e2e/resetUndo.e2e.test.ts`: hard-reset via the reset-mode picker, then exercises the global reflog undo (`z`) — needed an explicit wait since `reflogUndoDescription` refreshes on an independently-debounced watcher cycle from the header.
- `e2e/batchBranchDelete.e2e.test.ts`: marks and batch-deletes two branches (one merged, one requiring a force-confirm), then verifies current-branch deletion is refused.
- `e2e/rebaseConflictAbort.e2e.test.ts`: uses the pre-baked `mid-rebase-conflict` fixture scenario (for CI determinism) to test the conflict-abort flow via `gx` → `A` → confirm.

## Validation

- [x] `npx cross-env NODE_OPTIONS=--experimental-vm-modules npx jest --config jest.e2e.config.ts` passes for all 4 new suites, each re-run multiple times to confirm no flake
- [x] New behavior has tests (this PR is test-only)

## Notes

Flagged but did NOT fix (out of scope for this test-only issue): the branches surface's "N marked" count doesn't purge names of branches deleted in a batch operation, so it can overcount on a subsequent mark. Worth a follow-up bug ticket.

Also confirmed `e2e/helpOverlay.e2e.test.ts` has a pre-existing flake under CI-style resource contention (passes in isolation) — unrelated to this change.