### PR TITLE
refactor(commands): route prs/issues/pr-create through the ForgeActions adapter

### DIFF
--- a/src/commands/issues/handler.ts
+++ b/src/commands/issues/handler.ts
@@ -1,12 +1,9 @@
 import { formatIssueList } from '../../git/githubListFormatting'
-import {
-  getIssueList,
-  type IssueListFilter,
-  type IssueListItem,
-  type IssueListOverview,
+import type {
+  IssueListFilter,
+  IssueListItem,
+  IssueListOverview,
 } from '../../git/issuesListData'
-import { getGitLabIssueList } from '../../git/gitlabListData'
-import { getBitbucketIssueList } from '../../git/bitbucketListData'
 import type { CachedIssueList } from '../../git/githubListCache'
 import {
   createGitHubListHandler,
@@ -32,12 +29,7 @@ export const handler = createGitHubListHandler<
     search: argv.search,
     limit: argv.limit,
   }),
-  fetch: (git, filter, provider) =>
-    provider === 'gitlab'
-      ? getGitLabIssueList(git, filter)
-      : provider === 'bitbucket'
-        ? getBitbucketIssueList(git, filter)
-        : getIssueList(git, filter),
+  fetch: (git, filter, forge) => forge.getIssueList(git, filter),
   extractItems: (overview) => overview.issues,
   toCachePayload: (items) => ({ kind: 'issues', items }),
   formatList: formatIssueList,

--- a/src/commands/prCreate/handler.ts
+++ b/src/commands/prCreate/handler.ts
@@ -4,9 +4,7 @@ import { applyRepoFlag } from '../utils/applyRepoFlag'
 import { loadConfig } from '../../lib/config/utils/loadConfig'
 import { getProviderOverview } from '../../git/providerData'
 import { runPullRequestBodyWorkflow } from '../../git/aiActions'
-import { createPullRequest, openPullRequest } from '../../git/pullRequestActions'
-import { createMergeRequest, openMergeRequest } from '../../git/mergeRequestActions'
-import { createBitbucketPullRequest, openBitbucketPullRequest } from '../../git/bitbucketPullRequestActions'
+import { getForgeActions } from '../../git/forgeActions'
 import { forgeNouns } from '../../workstation/chrome/forgeNouns'
 import { commandExit } from '../../lib/utils/commandExit'
 import { emitJson } from '../../lib/ui/emitJson'
@@ -157,15 +155,13 @@ export const handler: CommandHandler<PrCreateArgv> = async (argv, logger) => {
     overview.repository.owner && overview.repository.name
       ? `${overview.repository.owner}/${overview.repository.name}`
       : undefined
+  const forge = getForgeActions(provider, {
+    gitlabPath: repoPath,
+    gitlabHost: overview.repository.host,
+    bitbucketPath: repoPath,
+  })
 
-  let result
-  if (provider === 'gitlab') {
-    result = await createMergeRequest(input)
-  } else if (provider === 'bitbucket' && repoPath) {
-    result = await createBitbucketPullRequest(repoPath, input)
-  } else {
-    result = await createPullRequest(input)
-  }
+  const result = await forge.createPullRequest(input)
 
   if (!result.ok) {
     logger.error(result.message, { color: 'red' })
@@ -177,12 +173,6 @@ export const handler: CommandHandler<PrCreateArgv> = async (argv, logger) => {
   logger.log(result.message, { color: 'green' })
 
   if (argv.web && result.url) {
-    if (provider === 'gitlab') {
-      await openMergeRequest(result.url)
-    } else if (provider === 'bitbucket') {
-      openBitbucketPullRequest(result.url)
-    } else {
-      await openPullRequest(result.url)
-    }
+    await forge.openPullRequest(result.url)
   }
 }

--- a/src/commands/prCreate/prCreate.test.ts
+++ b/src/commands/prCreate/prCreate.test.ts
@@ -8,6 +8,9 @@ import { loadConfig } from '../../lib/config/utils/loadConfig'
 import { getProviderOverview } from '../../git/providerData'
 import { runPullRequestBodyWorkflow } from '../../git/aiActions'
 import { createPullRequest, openPullRequest } from '../../git/pullRequestActions'
+import { createMergeRequest, openMergeRequest } from '../../git/mergeRequestActions'
+import { createBitbucketPullRequest, openBitbucketPullRequest } from '../../git/bitbucketPullRequestActions'
+import { defaultGlabRunner } from '../../git/glabCli'
 import { Logger } from '../../lib/utils/logger'
 
 jest.mock('../utils/applyRepoFlag')
@@ -15,6 +18,8 @@ jest.mock('../../lib/config/utils/loadConfig')
 jest.mock('../../git/providerData')
 jest.mock('../../git/aiActions')
 jest.mock('../../git/pullRequestActions')
+jest.mock('../../git/mergeRequestActions')
+jest.mock('../../git/bitbucketPullRequestActions')
 
 const mockApplyRepoFlag = applyRepoFlag as jest.MockedFunction<typeof applyRepoFlag>
 const mockLoadConfig = loadConfig as jest.MockedFunction<typeof loadConfig>
@@ -22,6 +27,10 @@ const mockOverview = getProviderOverview as jest.MockedFunction<typeof getProvid
 const mockBodyWorkflow = runPullRequestBodyWorkflow as jest.MockedFunction<typeof runPullRequestBodyWorkflow>
 const mockCreatePr = createPullRequest as jest.MockedFunction<typeof createPullRequest>
 const mockOpenPr = openPullRequest as jest.MockedFunction<typeof openPullRequest>
+const mockCreateMr = createMergeRequest as jest.MockedFunction<typeof createMergeRequest>
+const mockOpenMr = openMergeRequest as jest.MockedFunction<typeof openMergeRequest>
+const mockCreateBitbucketPr = createBitbucketPullRequest as jest.MockedFunction<typeof createBitbucketPullRequest>
+const mockOpenBitbucketPr = openBitbucketPullRequest as jest.MockedFunction<typeof openBitbucketPullRequest>
 
 function okOverview(over: Record<string, unknown> = {}) {
   return {
@@ -58,6 +67,10 @@ describe('pr create command', () => {
     })
     mockCreatePr.mockResolvedValue({ ok: true, message: 'Created pull request: https://gh/pr/1', url: 'https://gh/pr/1' })
     mockOpenPr.mockResolvedValue({ ok: true, message: 'opened' })
+    mockCreateMr.mockResolvedValue({ ok: true, message: 'Created merge request: https://gl/mr/1', url: 'https://gl/mr/1' })
+    mockOpenMr.mockResolvedValue({ ok: true, message: 'opened' })
+    mockCreateBitbucketPr.mockResolvedValue({ ok: true, message: 'Created pull request: https://bb/pr/1', url: 'https://bb/pr/1' })
+    mockOpenBitbucketPr.mockReturnValue({ ok: true, message: 'opened' })
   })
 
   afterEach(() => jest.clearAllMocks())
@@ -122,6 +135,38 @@ describe('pr create command', () => {
     argv.web = true
     await handler(argv, logger)
     expect(mockOpenPr).toHaveBeenCalledWith('https://gh/pr/1')
+  })
+
+  // Adapter-dispatch coverage (#1634): the handler routes create/open
+  // through getForgeActions instead of hand-branching on provider, so
+  // these prove gitlab/bitbucket still reach their own implementations.
+  it('routes creation and --web open to the gitlab implementation', async () => {
+    mockOverview.mockResolvedValue(
+      okOverview({ repository: { provider: 'gitlab', remote: 'origin', defaultBranch: 'main', host: 'gitlab.acme.com', owner: 'g', name: 'p' } })
+    )
+    argv.web = true
+    await handler(argv, logger)
+    expect(mockCreateMr).toHaveBeenCalledWith(
+      expect.objectContaining({ base: 'main', head: 'feature/x', title: 'feat: add x' }),
+      defaultGlabRunner,
+      'gitlab.acme.com'
+    )
+    expect(mockOpenMr).toHaveBeenCalledWith('https://gl/mr/1', defaultGlabRunner, 'gitlab.acme.com')
+    expect(mockCreatePr).not.toHaveBeenCalled()
+  })
+
+  it('routes creation and --web open to the bitbucket implementation', async () => {
+    mockOverview.mockResolvedValue(
+      okOverview({ repository: { provider: 'bitbucket', remote: 'origin', defaultBranch: 'main', owner: 'b', name: 'p' } })
+    )
+    argv.web = true
+    await handler(argv, logger)
+    expect(mockCreateBitbucketPr).toHaveBeenCalledWith(
+      'b/p',
+      expect.objectContaining({ base: 'main', head: 'feature/x', title: 'feat: add x' })
+    )
+    expect(mockOpenBitbucketPr).toHaveBeenCalledWith('https://bb/pr/1')
+    expect(mockCreatePr).not.toHaveBeenCalled()
   })
 
   it('exits non-zero when gh is not authenticated', async () => {

--- a/src/commands/prs/handler.ts
+++ b/src/commands/prs/handler.ts
@@ -1,12 +1,9 @@
 import { formatPullRequestList } from '../../git/githubListFormatting'
-import {
-  getPullRequestList,
-  type PullRequestListFilter,
-  type PullRequestListItem,
-  type PullRequestListOverview,
+import type {
+  PullRequestListFilter,
+  PullRequestListItem,
+  PullRequestListOverview,
 } from '../../git/pullRequestListData'
-import { getMergeRequestList } from '../../git/gitlabListData'
-import { getBitbucketPullRequestList } from '../../git/bitbucketListData'
 import type { CachedPullRequestList } from '../../git/githubListCache'
 import {
   createGitHubListHandler,
@@ -36,12 +33,7 @@ export const handler = createGitHubListHandler<
     draft: argv.draft,
     limit: argv.limit,
   }),
-  fetch: (git, filter, provider) =>
-    provider === 'gitlab'
-      ? getMergeRequestList(git, filter)
-      : provider === 'bitbucket'
-        ? getBitbucketPullRequestList(git, filter)
-        : getPullRequestList(git, filter),
+  fetch: (git, filter, forge) => forge.getPullRequestList(git, filter),
   extractItems: (overview) => overview.pullRequests,
   toCachePayload: (items) => ({ kind: 'prs', items }),
   formatList: formatPullRequestList,

--- a/src/commands/utils/githubListCommand.ts
+++ b/src/commands/utils/githubListCommand.ts
@@ -2,10 +2,8 @@ import chalk from 'chalk'
 import { SimpleGit } from 'simple-git'
 import { CommandHandler } from '../../lib/types'
 import { commandExit } from '../../lib/utils/commandExit'
-import {
-  getProviderRepositoryForGit,
-  type GitProviderType,
-} from '../../git/providerData'
+import { getProviderRepositoryForGit } from '../../git/providerData'
+import { getForgeActions, type ForgeActions } from '../../git/forgeActions'
 import {
   CachedList,
   readCachedList,
@@ -65,8 +63,12 @@ export type GitHubListCommandSpec<
   /** Short label for the auth hint, e.g. 'issue triage' | 'PR triage'. */
   triageLabel: string
   buildFilter: (argv: Argv) => Filter
-  /** Fetch the list, dispatching on the detected forge (github | gitlab). */
-  fetch: (git: SimpleGit, filter: Filter, provider: GitProviderType | undefined) => Promise<Overview>
+  /**
+   * Fetch the list via the forge adapter — the per-command spec only maps
+   * argv -> filter and calls the matching adapter method; provider dispatch
+   * (github | gitlab | bitbucket) lives entirely in `getForgeActions` (#1634).
+   */
+  fetch: (git: SimpleGit, filter: Filter, forge: ForgeActions) => Promise<Overview>
   extractItems: (overview: Overview) => Item[] | undefined
   toCachePayload: (items: Item[]) => Cached
   /** Render the list body. `nounLower` is the forge-aware singular noun. */
@@ -111,9 +113,16 @@ export function createGitHubListHandler<
     // Repository metadata is needed for the header in both paths (cache hit
     // and fresh fetch). The cache hit path skips the fetch entirely, so probe
     // it directly here — cheap, just a single `git remote` parse. The detected
-    // provider also routes the fetch to the right forge CLI.
+    // provider also builds the forge adapter that routes the fetch.
     const repository = await getProviderRepositoryForGit(git)
     const provider = repository?.provider
+    const forgePath =
+      repository?.owner && repository?.name ? `${repository.owner}/${repository.name}` : undefined
+    const forge = getForgeActions(provider, {
+      gitlabPath: forgePath,
+      gitlabHost: repository?.host,
+      bitbucketPath: forgePath,
+    })
 
     if (cacheEnabled && !argv.refresh) {
       const cached = readCachedList<Cached>(spec.kind, repoPath, filter)
@@ -125,7 +134,7 @@ export function createGitHubListHandler<
     }
 
     if (!items) {
-      const overview = await spec.fetch(git, filter, provider)
+      const overview = await spec.fetch(git, filter, forge)
 
       if (!overview.available) {
         logger.error(overview.message || 'No supported remote (GitHub or GitLab) detected.', { color: 'red' })


### PR DESCRIPTION
## What

`prs`, `issues`, and `prCreate` each branched on `provider` directly and imported forge-specific functions, violating the "forge work goes through the adapter, never branch on provider inside a surface" rule in AGENTS.md.

Closes #1634

## How

- `src/commands/utils/githubListCommand.ts`: `GitHubListCommandSpec.fetch` now receives a constructed `ForgeActions` instead of a raw `provider` — the handler builds it once via `getForgeActions(...)`.
- `src/commands/prs/handler.ts` / `src/commands/issues/handler.ts`: `fetch` is now a one-line call into `forge.getPullRequestList` / `forge.getIssueList`; removed direct imports of `getPullRequestList`/`getMergeRequestList`/`getBitbucketPullRequestList`.
- `src/commands/prCreate/handler.ts`: replaced the `if (provider === 'gitlab') ... else if (bitbucket) ... else` create/open branches with `forge.createPullRequest(...)` / `forge.openPullRequest(...)`.
- `src/commands/prCreate/prCreate.test.ts`: extended with gitlab/bitbucket create-dispatch coverage (previously only the github path was tested).

## Validation

- [x] `npx tsc --noEmit` passes
- [x] `npx jest` passes on prs/issues/prCreate suites and the broader commands suite
- [x] New behavior has tests
- [x] `npx eslint` clean

## Notes

No behavior change — pure dispatch-path refactor. Same runtime behavior for all three providers, verified via existing + extended test coverage.