### PR TITLE
refactor(workstation): extract submodule/remote handlers from useWorkflowAction

### DIFF
--- a/src/workstation/runtime/hooks/useSubmoduleRemoteWorkflowActions.test.ts
+++ b/src/workstation/runtime/hooks/useSubmoduleRemoteWorkflowActions.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Coverage for the submodule/remote workflow handlers extracted out of
+ * `useWorkflowAction.ts` (#1636 first domain slice). The git action layer
+ * is mocked so each handler resolves without touching a real repo; these
+ * tests pin down the guard messages and selection/parsing behavior that
+ * was previously only exercised indirectly through the god-hook.
+ */
+import { createSubmoduleRemoteWorkflowHandlers } from './useSubmoduleRemoteWorkflowActions'
+import {
+  initSubmodule,
+  syncSubmodule,
+  updateSubmodule,
+} from '../../../git/submoduleActions'
+import { addRemote, pruneRemote, removeRemote, setRemoteUrl } from '../../../git/remoteActions'
+import type { LogInkState } from '../inkViewModel'
+import type { LogInkContext } from '../types'
+import type { SubmoduleEntry } from '../../../git/submoduleData'
+import type { RemoteEntry } from '../../../git/remoteData'
+
+jest.mock('../../../git/submoduleActions', () => ({
+  initSubmodule: jest.fn().mockResolvedValue({ ok: true, message: 'submodule initialized' }),
+  updateSubmodule: jest.fn().mockResolvedValue({ ok: true, message: 'submodule updated' }),
+  syncSubmodule: jest.fn().mockResolvedValue({ ok: true, message: 'submodule synced' }),
+}))
+
+jest.mock('../../../git/remoteActions', () => ({
+  addRemote: jest.fn().mockResolvedValue({ ok: true, message: 'remote added' }),
+  setRemoteUrl: jest.fn().mockResolvedValue({ ok: true, message: 'remote url set' }),
+  removeRemote: jest.fn().mockResolvedValue({ ok: true, message: 'remote removed' }),
+  pruneRemote: jest.fn().mockResolvedValue({ ok: true, message: 'remote pruned' }),
+}))
+
+const initSubmoduleMock = initSubmodule as jest.MockedFunction<typeof initSubmodule>
+const updateSubmoduleMock = updateSubmodule as jest.MockedFunction<typeof updateSubmodule>
+const syncSubmoduleMock = syncSubmodule as jest.MockedFunction<typeof syncSubmodule>
+const addRemoteMock = addRemote as jest.MockedFunction<typeof addRemote>
+const setRemoteUrlMock = setRemoteUrl as jest.MockedFunction<typeof setRemoteUrl>
+const removeRemoteMock = removeRemote as jest.MockedFunction<typeof removeRemote>
+const pruneRemoteMock = pruneRemote as jest.MockedFunction<typeof pruneRemote>
+
+const git = {} as never
+
+const submodule: SubmoduleEntry = {
+  name: 'vendor/lib',
+  path: 'vendor/lib',
+  pinnedSha: 'abc1234',
+  flag: 'clean',
+} as SubmoduleEntry
+
+const remote: RemoteEntry = {
+  name: 'origin',
+  fetchUrl: 'git@example.com:acme/repo.git',
+  pushUrl: 'git@example.com:acme/repo.git',
+}
+
+const stateWithSelection = (): LogInkState =>
+  ({
+    filter: '',
+    selectedSubmoduleId: submodule.path,
+    selectedSubmoduleIndex: 0,
+    selectedRemoteId: remote.name,
+    selectedRemoteIndex: 0,
+  }) as unknown as LogInkState
+
+const emptyState = (): LogInkState =>
+  ({
+    filter: '',
+    selectedSubmoduleId: undefined,
+    selectedSubmoduleIndex: 0,
+    selectedRemoteId: undefined,
+    selectedRemoteIndex: 0,
+  }) as unknown as LogInkState
+
+const contextWithEntries = (): LogInkContext =>
+  ({
+    submodules: { entries: [submodule] },
+    remotes: { entries: [remote] },
+  }) as unknown as LogInkContext
+
+const emptyContext = (): LogInkContext =>
+  ({
+    submodules: { entries: [] },
+    remotes: { entries: [] },
+  }) as unknown as LogInkContext
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('submodule handlers', () => {
+  it('inits, updates, and syncs the selected submodule', async () => {
+    const handlers = createSubmoduleRemoteWorkflowHandlers({
+      git,
+      state: stateWithSelection(),
+      context: contextWithEntries(),
+    })
+
+    await handlers['submodule-init']()
+    expect(initSubmoduleMock).toHaveBeenCalledWith(git, submodule)
+
+    await handlers['submodule-update']()
+    expect(updateSubmoduleMock).toHaveBeenCalledWith(git, submodule, { init: true })
+
+    await handlers['submodule-sync']()
+    expect(syncSubmoduleMock).toHaveBeenCalledWith(git, submodule)
+  })
+
+  it('guards each submodule handler when nothing is selected', async () => {
+    const handlers = createSubmoduleRemoteWorkflowHandlers({
+      git,
+      state: emptyState(),
+      context: emptyContext(),
+    })
+
+    await expect(handlers['submodule-init']()).resolves.toEqual({
+      ok: false,
+      message: 'No submodule selected',
+    })
+    await expect(handlers['submodule-update']()).resolves.toEqual({
+      ok: false,
+      message: 'No submodule selected',
+    })
+    await expect(handlers['submodule-sync']()).resolves.toEqual({
+      ok: false,
+      message: 'No submodule selected',
+    })
+    expect(initSubmoduleMock).not.toHaveBeenCalled()
+    expect(updateSubmoduleMock).not.toHaveBeenCalled()
+    expect(syncSubmoduleMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('remote handlers', () => {
+  it('parses the "name url" payload for remote-add', async () => {
+    const handlers = createSubmoduleRemoteWorkflowHandlers({
+      git,
+      state: stateWithSelection(),
+      context: contextWithEntries(),
+      payload: '  upstream   git@example.com:acme/upstream.git  ',
+    })
+
+    await handlers['remote-add']()
+    expect(addRemoteMock).toHaveBeenCalledWith(
+      git,
+      'upstream',
+      'git@example.com:acme/upstream.git',
+    )
+  })
+
+  it('rejects an empty remote-add payload without calling addRemote', async () => {
+    const handlers = createSubmoduleRemoteWorkflowHandlers({
+      git,
+      state: stateWithSelection(),
+      context: contextWithEntries(),
+      payload: '   ',
+    })
+
+    await expect(handlers['remote-add']()).resolves.toEqual({
+      ok: false,
+      message: 'Remote name and URL required',
+    })
+    expect(addRemoteMock).not.toHaveBeenCalled()
+  })
+
+  it('sets, removes, and prunes the selected remote', async () => {
+    const handlers = createSubmoduleRemoteWorkflowHandlers({
+      git,
+      state: stateWithSelection(),
+      context: contextWithEntries(),
+      payload: 'git@example.com:acme/repo-new.git',
+    })
+
+    await handlers['remote-set-url']()
+    expect(setRemoteUrlMock).toHaveBeenCalledWith(
+      git,
+      remote.name,
+      'git@example.com:acme/repo-new.git',
+    )
+
+    await handlers['remote-remove']()
+    expect(removeRemoteMock).toHaveBeenCalledWith(git, remote.name)
+
+    await handlers['remote-prune']()
+    expect(pruneRemoteMock).toHaveBeenCalledWith(git, remote.name)
+  })
+
+  it('guards each remote handler when nothing is selected', async () => {
+    const handlers = createSubmoduleRemoteWorkflowHandlers({
+      git,
+      state: emptyState(),
+      context: emptyContext(),
+    })
+
+    await expect(handlers['remote-set-url']()).resolves.toEqual({
+      ok: false,
+      message: 'No remote selected',
+    })
+    await expect(handlers['remote-remove']()).resolves.toEqual({
+      ok: false,
+      message: 'No remote selected',
+    })
+    await expect(handlers['remote-prune']()).resolves.toEqual({
+      ok: false,
+      message: 'No remote selected',
+    })
+    expect(setRemoteUrlMock).not.toHaveBeenCalled()
+    expect(removeRemoteMock).not.toHaveBeenCalled()
+    expect(pruneRemoteMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/workstation/runtime/hooks/useSubmoduleRemoteWorkflowActions.ts
+++ b/src/workstation/runtime/hooks/useSubmoduleRemoteWorkflowActions.ts
@@ -1,0 +1,97 @@
+/**
+ * Submodule / remote workflow handlers — the first domain slice extracted
+ * out of `useWorkflowAction.ts`'s ~60-entry `handlers` object (#1636).
+ *
+ * Not a hook, despite the sibling filename convention: every entry in the
+ * source `handlers` object is a plain closure rebuilt fresh on each
+ * `runWorkflowAction` dispatch (the object literal itself lives inside that
+ * callback, never memoized entry-by-entry), and none of these seven are
+ * referenced by identity anywhere else. Naming this `useSubmoduleRemote...`
+ * would trip `react-hooks/rules-of-hooks` at its call site — it's invoked
+ * from inside `runWorkflowAction`'s body, itself nested in a
+ * `React.useCallback`, not at `useWorkflowAction`'s top level. A plain
+ * factory function reproduces the exact same per-dispatch-fresh-closure
+ * behavior with no dependency-array machinery to get wrong.
+ *
+ * Reproduced verbatim from the original inline entries — same guard
+ * messages, same selection resolution via the filtered list (so a
+ * filtered-out submodule/remote can never be the target), same `remote-add`
+ * payload parsing. The post-handler orchestration (status dispatch,
+ * pending-item spinner, context refresh) stays in `useWorkflowAction.ts`
+ * and treats these results identically to every other handler's.
+ */
+import { SimpleGit } from 'simple-git'
+import { getSelectedRemote, getSelectedSubmodule } from '../selection'
+import type { LogInkState } from '../inkViewModel'
+import type { LogInkContext } from '../types'
+import { initSubmodule, syncSubmodule, updateSubmodule } from '../../../git/submoduleActions'
+import { addRemote, pruneRemote, removeRemote, setRemoteUrl } from '../../../git/remoteActions'
+import type { BranchActionResult } from '../../../git/branchActions'
+
+export type SubmoduleRemoteWorkflowHandlersDeps = {
+  git: SimpleGit
+  state: LogInkState
+  context: LogInkContext
+  /** Raw prompt payload — only `remote-add` / `remote-set-url` read it. */
+  payload?: string
+}
+
+export function createSubmoduleRemoteWorkflowHandlers(
+  deps: SubmoduleRemoteWorkflowHandlersDeps
+): Record<string, () => Promise<BranchActionResult | undefined>> {
+  const { git, state, context, payload } = deps
+  return {
+    // #0.71 — submodule maintenance. Resolve the target from the filtered
+    // list so the cursor index lines up with what's on screen (a
+    // filtered-out submodule can never be the action target). The
+    // post-handler refreshContext reloads the submodule overview so the
+    // row's status flag updates after the action lands.
+    'submodule-init': async () => {
+      const entry = getSelectedSubmodule(state, context)
+      if (!entry) return { ok: false, message: 'No submodule selected' }
+      return initSubmodule(git, entry)
+    },
+    'submodule-update': async () => {
+      const entry = getSelectedSubmodule(state, context)
+      if (!entry) return { ok: false, message: 'No submodule selected' }
+      return updateSubmodule(git, entry, { init: true })
+    },
+    'submodule-sync': async () => {
+      const entry = getSelectedSubmodule(state, context)
+      if (!entry) return { ok: false, message: 'No submodule selected' }
+      return syncSubmodule(git, entry)
+    },
+    // #0.71 — remote management. add parses a single `name url` line from
+    // the prompt payload; set-url / remove / prune resolve the target from
+    // the filtered list so the cursor index lines up with what's on
+    // screen. The post-handler refreshContext reloads the remote overview
+    // so the list reflects the change.
+    'remote-add': async () => {
+      const raw = (payload || '').trim()
+      if (!raw) return { ok: false, message: 'Remote name and URL required' }
+      // Single-line `name url` prompt: first whitespace-run splits the
+      // name from the URL. A missing URL falls through to the action's
+      // own validation, which returns a friendly error.
+      const firstSpace = raw.search(/\s/)
+      const name = firstSpace === -1 ? raw : raw.slice(0, firstSpace)
+      const url = firstSpace === -1 ? '' : raw.slice(firstSpace).trim()
+      return addRemote(git, name, url)
+    },
+    'remote-set-url': async () => {
+      const entry = getSelectedRemote(state, context)
+      if (!entry) return { ok: false, message: 'No remote selected' }
+      const url = (payload || '').trim()
+      return setRemoteUrl(git, entry.name, url)
+    },
+    'remote-remove': async () => {
+      const entry = getSelectedRemote(state, context)
+      if (!entry) return { ok: false, message: 'No remote selected' }
+      return removeRemote(git, entry.name)
+    },
+    'remote-prune': async () => {
+      const entry = getSelectedRemote(state, context)
+      if (!entry) return { ok: false, message: 'No remote selected' }
+      return pruneRemote(git, entry.name)
+    },
+  }
+}

--- a/src/workstation/runtime/hooks/useWorkflowAction.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.ts
@@ -50,7 +50,7 @@ import {
 import { forgeNouns } from '../../chrome/forgeNouns'
 import { openProviderUrl } from '../../../git/providerActions'
 import type { GitProviderType } from '../../../git/providerData'
-import { getSelectedBranchId, getSelectedBranch, getSelectedBranchBatch, getSelectedTagId, getSelectedTag, getSelectedStash, getSelectedStashBatch, getSelectedCommitRange, getSelectedWorktreeId, getSelectedWorktree, getSelectedSubmodule, getSelectedRemote, getSelectedIssue, getSelectedPullRequestTriage, getSelectedPullRequestTriageId } from '../selection'
+import { getSelectedBranchId, getSelectedBranch, getSelectedBranchBatch, getSelectedTagId, getSelectedTag, getSelectedStash, getSelectedStashBatch, getSelectedCommitRange, getSelectedWorktreeId, getSelectedWorktree, getSelectedIssue, getSelectedPullRequestTriage, getSelectedPullRequestTriageId } from '../selection'
 import {
     LogInkPendingItemAction,
     LogInkAction,
@@ -119,8 +119,7 @@ import { applyStatusFilterMask } from '../../../git/statusData'
 import { bisectBad, bisectGood, bisectReset, bisectRun, bisectSkip, bisectStart, extractBisectRemainingHint } from '../../../git/bisectActions'
 import { checkoutReflogEntry, performReflogUndo, planReflogUndo } from '../../../git/reflogActions'
 import { executeRebasePlan } from '../../../git/rebasePlanActions'
-import { initSubmodule, syncSubmodule, updateSubmodule } from '../../../git/submoduleActions'
-import { addRemote, pruneRemote, removeRemote, setRemoteUrl } from '../../../git/remoteActions'
+import { createSubmoduleRemoteWorkflowHandlers } from './useSubmoduleRemoteWorkflowActions'
 import type { RepoStackRuntimes } from '../repoStackRuntime'
 import type { LogInkContext } from '../types'
 
@@ -968,58 +967,9 @@ export function useWorkflowAction(
           ? { ok: true, message: `Stashed changes and checked out PR #${prNumber} — the stash is waiting on the stash surface (gz)` }
           : { ok: false, message: `Stashed changes, but the checkout still failed: ${checkout.message}` }
       },
-      // #0.71 — submodule maintenance. Resolve the target from the
-      // filtered list so the cursor index lines up with what's on screen
-      // (a filtered-out submodule can never be the action target). The
-      // post-handler refreshContext reloads the submodule overview so the
-      // row's status flag updates after the action lands.
-      'submodule-init': async () => {
-        const entry = getSelectedSubmodule(state, context)
-        if (!entry) return { ok: false, message: 'No submodule selected' }
-        return initSubmodule(git, entry)
-      },
-      'submodule-update': async () => {
-        const entry = getSelectedSubmodule(state, context)
-        if (!entry) return { ok: false, message: 'No submodule selected' }
-        return updateSubmodule(git, entry, { init: true })
-      },
-      'submodule-sync': async () => {
-        const entry = getSelectedSubmodule(state, context)
-        if (!entry) return { ok: false, message: 'No submodule selected' }
-        return syncSubmodule(git, entry)
-      },
-      // #0.71 — remote management. add parses a single `name url` line
-      // from the prompt payload; set-url / remove / prune resolve the
-      // target from the filtered list so the cursor index lines up with
-      // what's on screen. The post-handler refreshContext reloads the
-      // remote overview so the list reflects the change.
-      'remote-add': async () => {
-        const raw = (payload || '').trim()
-        if (!raw) return { ok: false, message: 'Remote name and URL required' }
-        // Single-line `name url` prompt: first whitespace-run splits the
-        // name from the URL. A missing URL falls through to the action's
-        // own validation, which returns a friendly error.
-        const firstSpace = raw.search(/\s/)
-        const name = firstSpace === -1 ? raw : raw.slice(0, firstSpace)
-        const url = firstSpace === -1 ? '' : raw.slice(firstSpace).trim()
-        return addRemote(git, name, url)
-      },
-      'remote-set-url': async () => {
-        const entry = getSelectedRemote(state, context)
-        if (!entry) return { ok: false, message: 'No remote selected' }
-        const url = (payload || '').trim()
-        return setRemoteUrl(git, entry.name, url)
-      },
-      'remote-remove': async () => {
-        const entry = getSelectedRemote(state, context)
-        if (!entry) return { ok: false, message: 'No remote selected' }
-        return removeRemote(git, entry.name)
-      },
-      'remote-prune': async () => {
-        const entry = getSelectedRemote(state, context)
-        if (!entry) return { ok: false, message: 'No remote selected' }
-        return pruneRemote(git, entry.name)
-      },
+      // #0.71 — submodule maintenance + remote management, extracted to
+      // ./useSubmoduleRemoteWorkflowActions (#1636 first domain slice).
+      ...createSubmoduleRemoteWorkflowHandlers({ git, state, context, payload }),
       'create-tag-here': async () => {
         const commit = getSelectedInkCommit(state)
         const name = payload?.trim()


### PR DESCRIPTION
## What

`useWorkflowAction.ts`'s ~60-entry `handlers` object mixes every workflow domain (branch/tag/stash/submodule/remote/PR-triage/...) in one 1,961-line file. First domain-slice extraction toward the full decomposition the issue describes.

Closes #1636

## How

- New `useSubmoduleRemoteWorkflowActions.ts` exports `createSubmoduleRemoteWorkflowHandlers(deps)`, reproducing the 7 submodule/remote handlers (`submodule-init/update/sync`, `remote-add/set-url/remove/prune`) verbatim.
- Deliberately not a `use*` hook despite the sibling naming convention: the source `handlers` object is rebuilt fresh per dispatch inside a `React.useCallback` body, never memoized entry-by-entry, and this factory would be invoked from a nested callback — naming it `use...` would trip `react-hooks/rules-of-hooks`.
- `useWorkflowAction.ts` now spreads `createSubmoduleRemoteWorkflowHandlers(...)` in place of the 7 inline entries; removed now-unused imports.
- Added `useSubmoduleRemoteWorkflowActions.test.ts` — dedicated coverage for these 7 handlers didn't exist before (only indirectly, through the god-hook's own tests).

## Validation

- [x] `npx tsc --noEmit` passes
- [x] `npx jest` passes (useWorkflowAction suites + new test file + full `src/workstation` suite, 138/138)
- [x] New behavior has tests
- [x] `npx eslint` clean

## Notes

First-slice extraction, not the full decomposition — the remaining ~50 handlers stay in `useWorkflowAction.ts` for follow-up PRs, per the issue's own suggested per-domain sequencing.