### PR TITLE
refactor(workstation): extract theme-picker state slice from inkViewModel

### DIFF
--- a/src/workstation/runtime/inkViewModel.test.ts
+++ b/src/workstation/runtime/inkViewModel.test.ts
@@ -3,9 +3,7 @@ import {
     DEFAULT_LOG_INK_STATUS_FILTER_MASK,
     applyLogInkAction,
     createLogInkState,
-    filterThemePresets,
     getActiveLogInkRepoFrame,
-    getThemePickerSelection,
     getLogInkRepoStackLabels,
     getLogInkSidebarTabs,
     getSelectedInkCommit,
@@ -2867,14 +2865,12 @@ describe('triage filter preset cycling (#882 phase 6)', () => {
     })
   })
 
+  // Pure theme-picker filter/cursor logic now lives in
+  // `themePicker.test.ts` alongside its extracted slice (#1630 first
+  // slice). This composition-root test stays here because it's the
+  // overlay-exclusivity behavior `applyLogInkAction` layers on top of
+  // the slice, not something the slice module itself owns.
   describe('theme picker', () => {
-    it('starts closed with a clean filter/cursor', () => {
-      const state = createLogInkState(rows)
-      expect(state.showThemePicker).toBe(false)
-      expect(state.themePickerFilter).toBe('')
-      expect(state.themePickerIndex).toBe(0)
-    })
-
     it('toggleThemePicker opens/closes and closes other overlays', () => {
       let state = createLogInkState(rows)
       state = applyLogInkAction(state, { type: 'toggleHelp' })
@@ -2885,66 +2881,6 @@ describe('triage filter preset cycling (#882 phase 6)', () => {
 
       state = applyLogInkAction(state, { type: 'toggleThemePicker' })
       expect(state.showThemePicker).toBe(false)
-    })
-
-    it('fuzzy-filters presets case-insensitively', () => {
-      expect(filterThemePresets('')).toContain('catppuccin')
-      // Exact substring still matches…
-      expect(filterThemePresets('TOKYO')).toContain('tokyo-night')
-      // …and a non-contiguous subsequence matches too.
-      const gl = filterThemePresets('gl')
-      expect(gl).toContain('gruvbox-light')
-      expect(gl).toContain('github-light')
-      // Nonsense query that can't appear as a subsequence → no matches.
-      expect(filterThemePresets('definitely-not-a-theme')).toHaveLength(0)
-    })
-
-    it('ranks the best fuzzy match first', () => {
-      // Exact preset id outranks the longer one that merely contains it.
-      const gruvbox = filterThemePresets('gruvbox')
-      expect(gruvbox[0]).toBe('gruvbox')
-      expect(gruvbox).toContain('gruvbox-light')
-      // Word-segment matches (after `-`) rank ahead of incidental ones.
-      const cm = filterThemePresets('cm')
-      expect(cm[0]).toBe('catppuccin-macchiato')
-    })
-
-    it('moveThemePicker clamps the cursor to the filtered list', () => {
-      let state = createLogInkState(rows)
-      state = applyLogInkAction(state, { type: 'toggleThemePicker' })
-      const count = filterThemePresets('').length
-
-      state = applyLogInkAction(state, { type: 'moveThemePicker', delta: -1, presetCount: count })
-      expect(state.themePickerIndex).toBe(0) // clamped at the top
-
-      state = applyLogInkAction(state, { type: 'moveThemePicker', delta: 999, presetCount: count })
-      expect(state.themePickerIndex).toBe(count - 1) // clamped at the bottom
-    })
-
-    it('typing into the filter resets the cursor and getThemePickerSelection follows it', () => {
-      let state = createLogInkState(rows)
-      state = applyLogInkAction(state, { type: 'toggleThemePicker' })
-      state = applyLogInkAction(state, { type: 'moveThemePicker', delta: 3, presetCount: 50 })
-      expect(state.themePickerIndex).toBe(3)
-
-      state = applyLogInkAction(state, { type: 'appendThemePickerFilter', value: 'gruvbox' })
-      expect(state.themePickerFilter).toBe('gruvbox')
-      expect(state.themePickerIndex).toBe(0)
-      expect(getThemePickerSelection(state)).toBe('gruvbox')
-
-      state = applyLogInkAction(state, { type: 'backspaceThemePickerFilter' })
-      expect(state.themePickerFilter).toBe('gruvbo')
-
-      state = applyLogInkAction(state, { type: 'clearThemePickerFilter' })
-      expect(state.themePickerFilter).toBe('')
-      expect(state.themePickerIndex).toBe(0)
-    })
-
-    it('getThemePickerSelection is undefined when nothing matches', () => {
-      let state = createLogInkState(rows)
-      state = applyLogInkAction(state, { type: 'toggleThemePicker' })
-      state = applyLogInkAction(state, { type: 'appendThemePickerFilter', value: 'zzzzz' })
-      expect(getThemePickerSelection(state)).toBeUndefined()
     })
   })
 })

--- a/src/workstation/runtime/inkViewModel.ts
+++ b/src/workstation/runtime/inkViewModel.ts
@@ -2,7 +2,12 @@ import { GitLogCommitRow, GitLogRow, getCommitRows } from '../../commands/log/da
 import { hashesMatchAny } from '../../git/hashes'
 import type { RebasePlanRow, RebaseTodoAction } from '../../git/rebasePlanActions'
 import type { ConflictRegion } from '../../git/conflictRegionActions'
-import { getLogInkThemePresets, type LogInkThemePreset } from '../chrome/theme'
+import {
+    applyThemePickerAction,
+    createThemePickerState,
+    type ThemePickerAction,
+} from './themePicker'
+export { filterThemePresets, getThemePickerSelection, getThemePickerSelectionFor } from './themePicker'
 import {
     CommitComposeAction,
     CommitComposeState,
@@ -606,10 +611,10 @@ export type LogInkState = {
   paletteSelectedIndex: number
   paletteRecent: string[]
   /**
-   * Theme picker (`gC`) interaction state. `themePickerFilter` is the
-   * typed substring query; `themePickerIndex` is a cursor into the
-   * filtered preset list. While open, the workstation live-previews the
-   * cursored theme (wired in `app.ts`).
+   * Theme picker (`gC`) interaction state — owned by `./themePicker.ts`
+   * (#1630 first slice). Fields stay flat here rather than nested so the
+   * many read call sites don't churn; the action/reducer logic and the
+   * fuzzy-filter helpers live in that module.
    */
   showThemePicker: boolean
   themePickerFilter: string
@@ -1289,11 +1294,7 @@ export type LogInkAction =
   | { type: 'clearHelpFilter' }
   | { type: 'toggleViewKeys' }
   | { type: 'toggleCommandPalette' }
-  | { type: 'toggleThemePicker' }
-  | { type: 'moveThemePicker'; delta: number; presetCount: number }
-  | { type: 'appendThemePickerFilter'; value: string }
-  | { type: 'backspaceThemePickerFilter' }
-  | { type: 'clearThemePickerFilter' }
+  | ThemePickerAction
   | { type: 'openGitignorePicker'; file: string }
   | { type: 'closeGitignorePicker' }
   | { type: 'moveGitignorePicker'; delta: number; count: number }
@@ -2094,9 +2095,7 @@ export function createLogInkState(
     paletteFilter: '',
     paletteSelectedIndex: 0,
     paletteRecent: [],
-    showThemePicker: false,
-    themePickerFilter: '',
-    themePickerIndex: 0,
+    ...createThemePickerState(),
     commitCompose: createCommitComposeState(),
     diffPreviewOffset: 0,
     worktreeDiffOffset: 0,
@@ -3209,48 +3208,23 @@ export function applyLogInkAction(state: LogInkState, action: LogInkAction): Log
         pendingKey: undefined,
       }
     }
-    case 'toggleThemePicker': {
-      const opening = !state.showThemePicker
+    case 'toggleThemePicker':
       return {
         ...state,
-        showThemePicker: opening,
+        ...applyThemePickerAction(state, action),
         // Only one overlay at a time — close help / palette / view-keys on open.
         showHelp: false,
         showViewKeys: false,
         showCommandPalette: false,
-        themePickerFilter: '',
-        themePickerIndex: 0,
         pendingKey: undefined,
       }
-    }
     case 'moveThemePicker':
-      return {
-        ...state,
-        themePickerIndex: clampIndex(
-          state.themePickerIndex + action.delta,
-          action.presetCount
-        ),
-        pendingKey: undefined,
-      }
     case 'appendThemePickerFilter':
-      return {
-        ...state,
-        themePickerFilter: `${state.themePickerFilter}${action.value}`,
-        themePickerIndex: 0,
-        pendingKey: undefined,
-      }
     case 'backspaceThemePickerFilter':
-      return {
-        ...state,
-        themePickerFilter: state.themePickerFilter.slice(0, -1),
-        themePickerIndex: 0,
-        pendingKey: undefined,
-      }
     case 'clearThemePickerFilter':
       return {
         ...state,
-        themePickerFilter: '',
-        themePickerIndex: 0,
+        ...applyThemePickerAction(state, action),
         pendingKey: undefined,
       }
     case 'openGitignorePicker':
@@ -3697,71 +3671,6 @@ export function intentOpenComposeForFile(
   return { type: 'navigateOpenComposeForFile', fileIndex: idx }
 }
 
-/**
- * Fuzzy (subsequence) score for a preset id against a lowercase query.
- * Returns `null` when the query chars don't appear in order; otherwise a
- * score where contiguous runs, a start-of-string match, and matches right
- * after a `-` separator are rewarded — so `gl` ranks `gruvbox-light` /
- * `github-light` above incidental matches, and `tn` finds `tokyo-night`.
- */
-function fuzzyScoreThemePreset(preset: string, query: string): number | null {
-  const target = preset.toLowerCase()
-  let qi = 0
-  let score = 0
-  let lastMatch = -2
-  for (let i = 0; i < target.length && qi < query.length; i += 1) {
-    if (target[i] === query[qi]) {
-      score += 1
-      if (i === lastMatch + 1) score += 4 // contiguous run
-      if (i === 0) score += 8 // matches the very start
-      else if (target[i - 1] === '-') score += 4 // start of a word segment
-      lastMatch = i
-      qi += 1
-    }
-  }
-  return qi === query.length ? score : null
-}
-
-/**
- * Filter the full preset list by a fuzzy (subsequence) query, ranked best
- * match first (ties broken by catalog order). An empty query returns every
- * preset in catalog order. Shared by the theme picker overlay renderer, the
- * input handler (for cursor bounds), and the live-preview selector so all
- * three agree on the same filtered list.
- */
-export function filterThemePresets(filter: string): LogInkThemePreset[] {
-  const query = filter.trim().toLowerCase()
-  const all = getLogInkThemePresets()
-  if (!query) {
-    return all
-  }
-  return all
-    .map((preset, index) => ({ preset, index, score: fuzzyScoreThemePreset(preset, query) }))
-    .filter((entry): entry is { preset: LogInkThemePreset; index: number; score: number } => entry.score !== null)
-    .sort((a, b) => b.score - a.score || a.index - b.index)
-    .map((entry) => entry.preset)
-}
-
-/**
- * The preset currently under the theme-picker cursor (clamped to the
- * filtered list). `undefined` when the filter matches nothing.
- */
-export function getThemePickerSelection(state: LogInkState): LogInkThemePreset | undefined {
-  return getThemePickerSelectionFor(state.themePickerFilter, state.themePickerIndex)
-}
-
-/**
- * State-model-agnostic variant: the preset under the picker cursor for a
- * raw `filter` + `index`. Used by the workspace top-level surface, which
- * keeps its own state shape but shares the picker filtering.
- */
-export function getThemePickerSelectionFor(
-  filter: string,
-  index: number
-): LogInkThemePreset | undefined {
-  const filtered = filterThemePresets(filter)
-  if (filtered.length === 0) {
-    return undefined
-  }
-  return filtered[clampIndex(index, filtered.length)]
-}
+// Theme picker fuzzy-filter + selection helpers live in ./themePicker.ts
+// (#1630 first slice) and are re-exported above so existing importers
+// don't churn.

--- a/src/workstation/runtime/themePicker.test.ts
+++ b/src/workstation/runtime/themePicker.test.ts
@@ -1,0 +1,88 @@
+import {
+  applyThemePickerAction,
+  createThemePickerState,
+  filterThemePresets,
+  getThemePickerSelection,
+} from './themePicker'
+
+/**
+ * Coverage for the theme-picker slice extracted out of `inkViewModel.ts`
+ * (#1630 first slice). `inkViewModel.test.ts` keeps only the
+ * composition-root-specific case (toggling closes sibling overlays,
+ * which this module doesn't own) — everything else that's pure to the
+ * picker's own three fields and the fuzzy-filter helpers lives here.
+ */
+describe('theme picker slice', () => {
+  it('starts closed with a clean filter/cursor', () => {
+    const state = createThemePickerState()
+    expect(state.showThemePicker).toBe(false)
+    expect(state.themePickerFilter).toBe('')
+    expect(state.themePickerIndex).toBe(0)
+  })
+
+  it('toggleThemePicker flips open state and resets filter/cursor', () => {
+    let state = createThemePickerState()
+    state = applyThemePickerAction(state, { type: 'toggleThemePicker' })
+    expect(state.showThemePicker).toBe(true)
+
+    state = applyThemePickerAction(state, { type: 'toggleThemePicker' })
+    expect(state.showThemePicker).toBe(false)
+  })
+
+  it('fuzzy-filters presets case-insensitively', () => {
+    expect(filterThemePresets('')).toContain('catppuccin')
+    // Exact substring still matches…
+    expect(filterThemePresets('TOKYO')).toContain('tokyo-night')
+    // …and a non-contiguous subsequence matches too.
+    const gl = filterThemePresets('gl')
+    expect(gl).toContain('gruvbox-light')
+    expect(gl).toContain('github-light')
+    // Nonsense query that can't appear as a subsequence → no matches.
+    expect(filterThemePresets('definitely-not-a-theme')).toHaveLength(0)
+  })
+
+  it('ranks the best fuzzy match first', () => {
+    // Exact preset id outranks the longer one that merely contains it.
+    const gruvbox = filterThemePresets('gruvbox')
+    expect(gruvbox[0]).toBe('gruvbox')
+    expect(gruvbox).toContain('gruvbox-light')
+    // Word-segment matches (after `-`) rank ahead of incidental ones.
+    const cm = filterThemePresets('cm')
+    expect(cm[0]).toBe('catppuccin-macchiato')
+  })
+
+  it('moveThemePicker clamps the cursor to the filtered list', () => {
+    let state = createThemePickerState()
+    const count = filterThemePresets('').length
+
+    state = applyThemePickerAction(state, { type: 'moveThemePicker', delta: -1, presetCount: count })
+    expect(state.themePickerIndex).toBe(0) // clamped at the top
+
+    state = applyThemePickerAction(state, { type: 'moveThemePicker', delta: 999, presetCount: count })
+    expect(state.themePickerIndex).toBe(count - 1) // clamped at the bottom
+  })
+
+  it('typing into the filter resets the cursor and getThemePickerSelection follows it', () => {
+    let state = createThemePickerState()
+    state = applyThemePickerAction(state, { type: 'moveThemePicker', delta: 3, presetCount: 50 })
+    expect(state.themePickerIndex).toBe(3)
+
+    state = applyThemePickerAction(state, { type: 'appendThemePickerFilter', value: 'gruvbox' })
+    expect(state.themePickerFilter).toBe('gruvbox')
+    expect(state.themePickerIndex).toBe(0)
+    expect(getThemePickerSelection(state)).toBe('gruvbox')
+
+    state = applyThemePickerAction(state, { type: 'backspaceThemePickerFilter' })
+    expect(state.themePickerFilter).toBe('gruvbo')
+
+    state = applyThemePickerAction(state, { type: 'clearThemePickerFilter' })
+    expect(state.themePickerFilter).toBe('')
+    expect(state.themePickerIndex).toBe(0)
+  })
+
+  it('getThemePickerSelection is undefined when nothing matches', () => {
+    let state = createThemePickerState()
+    state = applyThemePickerAction(state, { type: 'appendThemePickerFilter', value: 'zzzzz' })
+    expect(getThemePickerSelection(state)).toBeUndefined()
+  })
+})

--- a/src/workstation/runtime/themePicker.ts
+++ b/src/workstation/runtime/themePicker.ts
@@ -1,0 +1,164 @@
+import { getLogInkThemePresets, type LogInkThemePreset } from '../chrome/theme'
+
+/**
+ * Theme picker (`gC`) interaction state — the first per-surface slice
+ * pulled out of `inkViewModel.ts`'s monolith (#1630), following the
+ * `commitCompose.ts` pattern: state fragment + action union + a pure
+ * `reduce(state, action)`.
+ *
+ * Unlike `commitCompose.ts`, these fields stay flat on `LogInkState`
+ * rather than nested under a `themePicker` sub-object — 13 call sites
+ * read `state.showThemePicker` / `themePickerFilter` / `themePickerIndex`
+ * directly (renderers, the input router, the workspace surface's own
+ * mirrored state), and nesting would churn all of them for no behavior
+ * change. `applyLogInkAction`'s `'toggleThemePicker'` case also closes
+ * OTHER overlays (help / view-keys / command palette) — that
+ * exclusivity is genuinely global state, so it stays in the composition
+ * root; this module only owns the picker's own three fields.
+ */
+export type ThemePickerFields = {
+  showThemePicker: boolean
+  themePickerFilter: string
+  themePickerIndex: number
+}
+
+export type ThemePickerAction =
+  | { type: 'toggleThemePicker' }
+  | { type: 'moveThemePicker'; delta: number; presetCount: number }
+  | { type: 'appendThemePickerFilter'; value: string }
+  | { type: 'backspaceThemePickerFilter' }
+  | { type: 'clearThemePickerFilter' }
+
+export function createThemePickerState(): ThemePickerFields {
+  return {
+    showThemePicker: false,
+    themePickerFilter: '',
+    themePickerIndex: 0,
+  }
+}
+
+function clampIndex(index: number, length: number): number {
+  if (length === 0) {
+    return 0
+  }
+
+  return Math.max(0, Math.min(index, length - 1))
+}
+
+/**
+ * Reduces the picker's own three fields. `'toggleThemePicker'` here only
+ * flips `showThemePicker` and resets the filter/cursor — the composition
+ * root additionally closes sibling overlays on the same action before
+ * merging this result back in.
+ */
+export function applyThemePickerAction(
+  state: ThemePickerFields,
+  action: ThemePickerAction
+): ThemePickerFields {
+  switch (action.type) {
+    case 'toggleThemePicker':
+      return {
+        ...state,
+        showThemePicker: !state.showThemePicker,
+        themePickerFilter: '',
+        themePickerIndex: 0,
+      }
+    case 'moveThemePicker':
+      return {
+        ...state,
+        themePickerIndex: clampIndex(
+          state.themePickerIndex + action.delta,
+          action.presetCount
+        ),
+      }
+    case 'appendThemePickerFilter':
+      return {
+        ...state,
+        themePickerFilter: `${state.themePickerFilter}${action.value}`,
+        themePickerIndex: 0,
+      }
+    case 'backspaceThemePickerFilter':
+      return {
+        ...state,
+        themePickerFilter: state.themePickerFilter.slice(0, -1),
+        themePickerIndex: 0,
+      }
+    case 'clearThemePickerFilter':
+      return {
+        ...state,
+        themePickerFilter: '',
+        themePickerIndex: 0,
+      }
+    default:
+      return state
+  }
+}
+
+/**
+ * Fuzzy (subsequence) score for a preset id against a lowercase query.
+ * Returns `null` when the query chars don't appear in order; otherwise a
+ * score where contiguous runs, a start-of-string match, and matches right
+ * after a `-` separator are rewarded — so `gl` ranks `gruvbox-light` /
+ * `github-light` above incidental matches, and `tn` finds `tokyo-night`.
+ */
+function fuzzyScoreThemePreset(preset: string, query: string): number | null {
+  const target = preset.toLowerCase()
+  let qi = 0
+  let score = 0
+  let lastMatch = -2
+  for (let i = 0; i < target.length && qi < query.length; i += 1) {
+    if (target[i] === query[qi]) {
+      score += 1
+      if (i === lastMatch + 1) score += 4 // contiguous run
+      if (i === 0) score += 8 // matches the very start
+      else if (target[i - 1] === '-') score += 4 // start of a word segment
+      lastMatch = i
+      qi += 1
+    }
+  }
+  return qi === query.length ? score : null
+}
+
+/**
+ * Filter the full preset list by a fuzzy (subsequence) query, ranked best
+ * match first (ties broken by catalog order). An empty query returns every
+ * preset in catalog order. Shared by the theme picker overlay renderer, the
+ * input handler (for cursor bounds), and the live-preview selector so all
+ * three agree on the same filtered list.
+ */
+export function filterThemePresets(filter: string): LogInkThemePreset[] {
+  const query = filter.trim().toLowerCase()
+  const all = getLogInkThemePresets()
+  if (!query) {
+    return all
+  }
+  return all
+    .map((preset, index) => ({ preset, index, score: fuzzyScoreThemePreset(preset, query) }))
+    .filter((entry): entry is { preset: LogInkThemePreset; index: number; score: number } => entry.score !== null)
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map((entry) => entry.preset)
+}
+
+/**
+ * The preset currently under the theme-picker cursor (clamped to the
+ * filtered list). `undefined` when the filter matches nothing.
+ */
+export function getThemePickerSelection(state: ThemePickerFields): LogInkThemePreset | undefined {
+  return getThemePickerSelectionFor(state.themePickerFilter, state.themePickerIndex)
+}
+
+/**
+ * State-model-agnostic variant: the preset under the picker cursor for a
+ * raw `filter` + `index`. Used by the workspace top-level surface, which
+ * keeps its own state shape but shares the picker filtering.
+ */
+export function getThemePickerSelectionFor(
+  filter: string,
+  index: number
+): LogInkThemePreset | undefined {
+  const filtered = filterThemePresets(filter)
+  if (filtered.length === 0) {
+    return undefined
+  }
+  return filtered[clampIndex(index, filtered.length)]
+}


### PR DESCRIPTION
## What

`inkViewModel.ts`'s `LogInkState`/`LogInkAction`/`applyLogInkAction` mix every view's state in one 3.7k-line module. First per-surface slice extraction, following the `commitCompose.ts` pattern already in the codebase.

Closes #1630

## How

- New `themePicker.ts` holds the theme picker's fields (`showThemePicker`/`themePickerFilter`/`themePickerIndex`), its action union, `createThemePickerState()`, `applyThemePickerAction()`, and the fuzzy-filter/selection helpers (`filterThemePresets`, `getThemePickerSelection`, `getThemePickerSelectionFor`).
- State fields stay flat on `LogInkState` rather than nested under a `themePicker` sub-object — 13 call sites read them directly, and nesting would churn all of them for no behavior change.
- The overlay-exclusivity logic (closing help/palette when the picker opens) stays in `applyLogInkAction` since it's a cross-slice concern the slice module doesn't own.
- `inkViewModel.ts` re-exports the slice's public helpers so no importer needed to change.
- Test coverage for the pure slice logic moved to `themePicker.test.ts`; `inkViewModel.test.ts` keeps only the composition-root-specific overlay-exclusivity case.

## Validation

- [x] `npx tsc --noEmit` passes
- [x] `npx jest` passes (inkViewModel/workspace/inkInput/overlays/useThemeState suites + full `src/workstation` suite, 138/138)
- [x] New behavior has tests
- [x] `npx eslint` clean

## Notes

First-slice extraction, not the full decomposition — the remaining 15 views' state stays in `inkViewModel.ts` for follow-up PRs, per the issue's own per-view sequencing.