### PR TITLE
refactor(workstation): extract bisect input handling from inkInput.ts

### DIFF
--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -26,6 +26,7 @@ import {
     getLogInkWorkflowActionByKey,
 } from './inkWorkflows'
 import { sidebarTabHasSelectableItems } from '../chrome/sidebarSelection'
+import { handleBisectInput } from '../surfaces/bisect/input'
 
 export type LogInkInputKey = {
   backspace?: boolean
@@ -2338,68 +2339,11 @@ export function getLogInkInputEvents(
     return [action({ type: 'setPendingKey', value: undefined })]
   }
 
-  // #784 / #1352 — bisect view action keys. Scoped to `state.activeView
-  // === 'bisect' && state.focus === 'commits'` so the single-letter
-  // keys stay free everywhere else. Mark-good is `y` (yes/good), NOT
-  // bare `g`: the old `g` binding shadowed the global chord prefix, so
-  // a user reflexively typing `gh`/`gs` to navigate away silently ran
-  // `git bisect good` on the current candidate. `g` now arms the chord
-  // on bisect like everywhere else (`gh`/`gs`/`gx` work mid-bisect);
-  // `b` keeps the `pendingKey !== 'g'` guard so `gb` still reaches
-  // branches. The trade: `y` yank is unavailable on this one transient
-  // view (the candidate sha is visible in the panel).
-  if (state.activeView === 'bisect' && state.focus === 'commits') {
-    // Gated off once the bisect has terminated: the completion panel
-    // rebinds y/Y to yank the first-bad sha (#879 item 3), and there
-    // is no candidate left to mark. Also gated on an ACTIVE session —
-    // like `s`/`R`, marking is meaningless from the empty-state view
-    // and used to surface a raw `git bisect` error ("You need to
-    // start by \"git bisect start\"") on the status line.
-    if (
-      inputValue === 'y' &&
-      !key.ctrl &&
-      !key.meta &&
-      context.bisectActive &&
-      !context.bisectCompletionSha
-    ) {
-      return [{ type: 'runWorkflowAction', id: 'bisect-good' }]
-    }
-    if (inputValue === 'b' && state.pendingKey !== 'g' && context.bisectActive) {
-      return [{ type: 'runWorkflowAction', id: 'bisect-bad' }]
-    }
-    if (inputValue === 's') {
-      // #879 item 4 — `s` is context-overloaded. When a bisect is
-      // active, the original #784 behavior applies: skip the current
-      // candidate. When no bisect is active, the empty-state view is
-      // showing and `s` enters the in-TUI start wizard: push history,
-      // mark the user as picking the BAD commit, surface a sticky
-      // banner explaining the next step.
-      if (context.bisectActive) {
-        return [{ type: 'runWorkflowAction', id: 'bisect-skip' }]
-      }
-      return [
-        action({ type: 'setBisectPickMode', mode: 'bad' }),
-        action({ type: 'pushView', value: 'history' }),
-        action({
-          type: 'setStatus',
-          value: 'Pick the BAD commit (where the bug is present). Enter to confirm · esc to cancel',
-        }),
-      ]
-    }
-    if (inputValue === 'x' && context.bisectActive) {
-      return [action({ type: 'setPendingConfirmation', value: 'bisect-reset' })]
-    }
-    // #879 item 5 — `R` (capital) on an active bisect view opens an
-    // input prompt for a test command. Only fires when a session is
-    // active because `git bisect run` is meaningless otherwise. Lower-
-    // case `r` stays free for future view-local bindings.
-    if (inputValue === 'R' && context.bisectActive) {
-      return [action({
-        type: 'openInputPrompt',
-        kind: 'bisect-run-command',
-        label: 'Bisect run command (e.g. npm test, pytest -k regression)',
-      })]
-    }
+  // #784 / #1352 — bisect view action keys, extracted to
+  // `surfaces/bisect/input.ts` (#1625 first surface).
+  const bisectEvents = handleBisectInput(state, inputValue, key, context)
+  if (bisectEvents) {
+    return bisectEvents
   }
 
   // Changelog view local keymap. Scoped to `activeView === 'changelog'`

--- a/src/workstation/surfaces/bisect/input.test.ts
+++ b/src/workstation/surfaces/bisect/input.test.ts
@@ -1,0 +1,117 @@
+import { handleBisectInput } from './input'
+import { createLogInkState } from '../../runtime/inkViewModel'
+import type { GitLogRow } from '../../../commands/log/data'
+
+/**
+ * Direct coverage for the bisect-view input handler extracted out of
+ * `inkInput.ts`'s router (#1625 first surface). `inkInput.test.ts` keeps
+ * its existing bisect cases too — those exercise the full
+ * `getLogInkInputEvents` router and guard that it actually delegates
+ * here; these tests pin down the handler's own logic in isolation.
+ */
+
+const rows: GitLogRow[] = [
+  {
+    type: 'commit',
+    graph: '*',
+    shortHash: 'abc1234',
+    hash: 'abc123456789',
+    parents: [],
+    date: '2026-04-29',
+    author: 'Coco Test',
+    refs: [],
+    message: 'Initial commit',
+  },
+]
+
+const bisectState = () => {
+  const state = createLogInkState(rows)
+  return { ...state, activeView: 'bisect' as const, focus: 'commits' as const }
+}
+
+describe('handleBisectInput', () => {
+  it('returns null outside the bisect view', () => {
+    const state = { ...bisectState(), activeView: 'history' as const }
+    expect(handleBisectInput(state, 'y', {}, { bisectActive: true })).toBeNull()
+  })
+
+  it('returns null when the bisect view is not commit-focused', () => {
+    const state = { ...bisectState(), focus: 'sidebar' as const }
+    expect(handleBisectInput(state, 'y', {}, { bisectActive: true })).toBeNull()
+  })
+
+  it('marks good on y when a session is active and not completed', () => {
+    const events = handleBisectInput(bisectState(), 'y', {}, { bisectActive: true })
+    expect(events).toEqual([{ type: 'runWorkflowAction', id: 'bisect-good' }])
+  })
+
+  it('does not mark good once the bisect has completed', () => {
+    const events = handleBisectInput(
+      bisectState(),
+      'y',
+      {},
+      { bisectActive: true, bisectCompletionSha: 'deadbeef' }
+    )
+    expect(events).toBeNull()
+  })
+
+  it('does not mark good with ctrl or meta held (yields to global shortcuts)', () => {
+    expect(handleBisectInput(bisectState(), 'y', { ctrl: true }, { bisectActive: true })).toBeNull()
+    expect(handleBisectInput(bisectState(), 'y', { meta: true }, { bisectActive: true })).toBeNull()
+  })
+
+  it('marks bad on b when active, but not while the g chord is armed', () => {
+    const events = handleBisectInput(bisectState(), 'b', {}, { bisectActive: true })
+    expect(events).toEqual([{ type: 'runWorkflowAction', id: 'bisect-bad' }])
+
+    const armed = { ...bisectState(), pendingKey: 'g' }
+    expect(handleBisectInput(armed, 'b', {}, { bisectActive: true })).toBeNull()
+  })
+
+  it('skips the candidate on s when active', () => {
+    const events = handleBisectInput(bisectState(), 's', {}, { bisectActive: true })
+    expect(events).toEqual([{ type: 'runWorkflowAction', id: 'bisect-skip' }])
+  })
+
+  it('enters the start wizard on s when no session is active', () => {
+    const events = handleBisectInput(bisectState(), 's', {}, { bisectActive: false })
+    expect(events).toEqual([
+      { type: 'action', action: { type: 'setBisectPickMode', mode: 'bad' } },
+      { type: 'action', action: { type: 'pushView', value: 'history' } },
+      {
+        type: 'action',
+        action: {
+          type: 'setStatus',
+          value: 'Pick the BAD commit (where the bug is present). Enter to confirm · esc to cancel',
+        },
+      },
+    ])
+  })
+
+  it('opens the reset confirmation on x when active, no-ops when inactive', () => {
+    const events = handleBisectInput(bisectState(), 'x', {}, { bisectActive: true })
+    expect(events).toEqual([
+      { type: 'action', action: { type: 'setPendingConfirmation', value: 'bisect-reset' } },
+    ])
+    expect(handleBisectInput(bisectState(), 'x', {}, { bisectActive: false })).toBeNull()
+  })
+
+  it('opens the run-command prompt on R when active, no-ops when inactive', () => {
+    const events = handleBisectInput(bisectState(), 'R', {}, { bisectActive: true })
+    expect(events).toEqual([
+      {
+        type: 'action',
+        action: {
+          type: 'openInputPrompt',
+          kind: 'bisect-run-command',
+          label: 'Bisect run command (e.g. npm test, pytest -k regression)',
+        },
+      },
+    ])
+    expect(handleBisectInput(bisectState(), 'R', {}, { bisectActive: false })).toBeNull()
+  })
+
+  it('returns null for an unmatched key', () => {
+    expect(handleBisectInput(bisectState(), 'q', {}, { bisectActive: true })).toBeNull()
+  })
+})

--- a/src/workstation/surfaces/bisect/input.ts
+++ b/src/workstation/surfaces/bisect/input.ts
@@ -1,0 +1,96 @@
+import type { LogInkAction, LogInkState } from '../../runtime/inkViewModel'
+import type {
+  LogInkInputContext,
+  LogInkInputEvent,
+  LogInkInputKey,
+} from '../../runtime/inkInput'
+
+/**
+ * Bisect view action keys (#784 / #1352) — the first per-surface input
+ * module extracted out of `inkInput.ts`'s monolithic router (#1625 first
+ * surface). Scoped entirely to `state.activeView === 'bisect' &&
+ * state.focus === 'commits'`, with no dependency on any other view's
+ * state, which is what makes it safe to lift verbatim.
+ *
+ * Mark-good is `y` (yes/good), NOT bare `g`: the old `g` binding shadowed
+ * the global chord prefix, so a user reflexively typing `gh`/`gs` to
+ * navigate away silently ran `git bisect good` on the current candidate.
+ * `g` now arms the chord on bisect like everywhere else (`gh`/`gs`/`gx`
+ * work mid-bisect); `b` keeps the `pendingKey !== 'g'` guard so `gb`
+ * still reaches branches. The trade: `y` yank is unavailable on this one
+ * transient view (the candidate sha is visible in the panel).
+ *
+ * Returns `null` when no bisect-local binding matches, so the caller
+ * (`getLogInkInputEvents`) falls through to the rest of the router.
+ */
+export function handleBisectInput(
+  state: LogInkState,
+  inputValue: string,
+  key: LogInkInputKey,
+  context: LogInkInputContext
+): LogInkInputEvent[] | null {
+  if (state.activeView !== 'bisect' || state.focus !== 'commits') {
+    return null
+  }
+
+  // Gated off once the bisect has terminated: the completion panel
+  // rebinds y/Y to yank the first-bad sha (#879 item 3), and there is no
+  // candidate left to mark. Also gated on an ACTIVE session — like
+  // `s`/`R`, marking is meaningless from the empty-state view and used
+  // to surface a raw `git bisect` error ("You need to start by \"git
+  // bisect start\"") on the status line.
+  if (
+    inputValue === 'y' &&
+    !key.ctrl &&
+    !key.meta &&
+    context.bisectActive &&
+    !context.bisectCompletionSha
+  ) {
+    return [{ type: 'runWorkflowAction', id: 'bisect-good' }]
+  }
+  if (inputValue === 'b' && state.pendingKey !== 'g' && context.bisectActive) {
+    return [{ type: 'runWorkflowAction', id: 'bisect-bad' }]
+  }
+  if (inputValue === 's') {
+    // #879 item 4 — `s` is context-overloaded. When a bisect is active,
+    // the original #784 behavior applies: skip the current candidate.
+    // When no bisect is active, the empty-state view is showing and `s`
+    // enters the in-TUI start wizard: push history, mark the user as
+    // picking the BAD commit, surface a sticky banner explaining the
+    // next step.
+    if (context.bisectActive) {
+      return [{ type: 'runWorkflowAction', id: 'bisect-skip' }]
+    }
+    return [
+      action({ type: 'setBisectPickMode', mode: 'bad' }),
+      action({ type: 'pushView', value: 'history' }),
+      action({
+        type: 'setStatus',
+        value: 'Pick the BAD commit (where the bug is present). Enter to confirm · esc to cancel',
+      }),
+    ]
+  }
+  if (inputValue === 'x' && context.bisectActive) {
+    return [action({ type: 'setPendingConfirmation', value: 'bisect-reset' })]
+  }
+  // #879 item 5 — `R` (capital) on an active bisect view opens an input
+  // prompt for a test command. Only fires when a session is active
+  // because `git bisect run` is meaningless otherwise. Lower-case `r`
+  // stays free for future view-local bindings.
+  if (inputValue === 'R' && context.bisectActive) {
+    return [action({
+      type: 'openInputPrompt',
+      kind: 'bisect-run-command',
+      label: 'Bisect run command (e.g. npm test, pytest -k regression)',
+    })]
+  }
+
+  return null
+}
+
+function action(actionValue: LogInkAction): LogInkInputEvent {
+  return {
+    type: 'action',
+    action: actionValue,
+  }
+}


### PR DESCRIPTION
## What

`inkInput.ts`'s `getLogInkInputEvents` is a single 4.6k-line key router covering every view. First per-surface input extraction, mirroring the per-surface render modules that already exist under `surfaces/<view>/`.

Closes #1625

## How

- New `surfaces/bisect/input.ts` exports `handleBisectInput(state, inputValue, key, context)`, holding the bisect view's action-key handling (`y`/`b`/`s`/`x`/`R`, gated on `activeView === 'bisect' && focus === 'commits'`).
- Bisect was picked as the starting point per the issue's own sequencing suggestion — it's the one view-scoped block with no dependency on any other view's state, which is what makes it safe to lift verbatim.
- `inkInput.ts` now delegates to `handleBisectInput()` and falls through to the rest of the router when it returns `null`.
- Existing integration tests in `inkInput.test.ts` are unchanged and confirm the router still delegates correctly; new `input.test.ts` exercises the handler directly.

## Validation

- [x] `npx tsc --noEmit` passes
- [x] `npx jest` passes (inkInput + bisect suites + full `src/workstation` suite, 138/138)
- [x] New behavior has tests
- [x] `npx eslint` clean

## Notes

First-surface extraction, not the full decomposition — the remaining ~15 views' input handling stays in `inkInput.ts` for follow-up PRs, sequenced the same way as the completed app.ts decomposition (#1418/#1544).