### PR TITLE
fix(workstation): correct stale import path in bisect input test

### DIFF
--- a/src/workstation/surfaces/bisect/input.test.ts
+++ b/src/workstation/surfaces/bisect/input.test.ts
@@ -1,6 +1,6 @@
 import { handleBisectInput } from './input'
 import { createLogInkState } from '../../runtime/inkViewModel'
-import type { GitLogRow } from '../../../commands/log/data'
+import type { GitLogRow } from '../../../git/logData'
 
 /**
  * Direct coverage for the bisect-view input handler extracted out of


### PR DESCRIPTION
## What

Fixes a build break on `main` introduced by merging two independently-green tech-debt PRs together: #1625 (bisect input extraction) branched off `main` before #1638 (log promotion) moved `commands/log/data.ts` to `git/logData.ts`, so #1625's new `src/workstation/surfaces/bisect/input.test.ts` wasn't in scope for #1638's importer rewrite.

`npx tsc --noEmit` didn't catch it (tsconfig excludes `*.test.ts`), so it only surfaced when running the full `npx jest` suite post-merge — exactly the "green-alone/broken-together" failure mode `.github/BRANCH_PROTECTION.md` calls out.

## How

- `src/workstation/surfaces/bisect/input.test.ts`: `import type { GitLogRow } from '../../../commands/log/data'` → `'../../../git/logData'`.
- Audited the rest of the tree for the same stale-path pattern; the only other hits (`chrome/text.ts` / `text.test.ts`) are illustrative example strings for a path-truncation helper, not real imports — left unchanged.

## Validation

- [x] `npx jest src/workstation/surfaces/bisect` passes (2 suites, 21 tests)
- [x] `npx jest` full suite passes except the 4 pre-existing, unrelated tree-sitter WASM failures (present on `main` before this change too)

## Notes

One-line import fix, no behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBgeU9gYuYUHPFnLa8rJXF)_