### PR TITLE
feat(init): OpenAI-compatible endpoint presets

### DIFF
--- a/src/commands/doctor/checks.test.ts
+++ b/src/commands/doctor/checks.test.ts
@@ -1,6 +1,12 @@
 import { Config } from '../../lib/config/types'
 import { getOllamaStatus } from '../../lib/langchain/utils/ollamaStatus'
-import { checkEndpointSupport, checkOllamaLiveness, checkProviderValidity, Diagnostic } from './checks'
+import {
+    checkAuthentication,
+    checkEndpointSupport,
+    checkOllamaLiveness,
+    checkProviderValidity,
+    Diagnostic,
+} from './checks'
 
 jest.mock('../../lib/langchain/utils/ollamaStatus', () => ({
   DEFAULT_OLLAMA_ENDPOINT: 'http://localhost:11434',
@@ -92,6 +98,54 @@ describe('checkProviderValidity', () => {
     const diagnostics: Diagnostic[] = []
     checkProviderValidity(configWithProvider('aws'), diagnostics)
     expect(diagnostics[0].message).toContain('"bedrock"')
+  })
+})
+
+describe('checkAuthentication', () => {
+  it('errors when a real provider (openai, no baseURL) has no authentication configured', () => {
+    const config = {
+      service: { provider: 'openai', model: 'gpt-4o', authentication: { type: 'None' } },
+    } as unknown as Config
+    const diagnostics: Diagnostic[] = []
+    checkAuthentication(config, diagnostics)
+
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0].severity).toBe('error')
+    expect(diagnostics[0].message).toContain('requires authentication')
+  })
+
+  // #1610 — an OpenAI-compatible endpoint (baseURL set) is commonly
+  // self-hosted/local and may have no auth at all (LM Studio, vLLM); that
+  // shouldn't read as a broken config the way a keyless real OpenAI does.
+  it('only warns when an OpenAI-compatible endpoint (baseURL set) has no authentication configured', () => {
+    const config = {
+      service: {
+        provider: 'openai',
+        model: 'local-model',
+        baseURL: 'http://localhost:1234/v1',
+        authentication: { type: 'None' },
+      },
+    } as unknown as Config
+    const diagnostics: Diagnostic[] = []
+    checkAuthentication(config, diagnostics)
+
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0].severity).toBe('warn')
+    expect(diagnostics[0].message).toContain('http://localhost:1234/v1')
+  })
+
+  it('produces no diagnostic when a real provider has an API key', () => {
+    const config = {
+      service: {
+        provider: 'openai',
+        model: 'gpt-4o',
+        authentication: { type: 'APIKey', credentials: { apiKey: 'sk-real-key' } },
+      },
+    } as unknown as Config
+    const diagnostics: Diagnostic[] = []
+    checkAuthentication(config, diagnostics)
+
+    expect(diagnostics).toEqual([])
   })
 })
 

--- a/src/commands/doctor/checks.ts
+++ b/src/commands/doctor/checks.ts
@@ -103,7 +103,7 @@ export function checkProviderValidity(config: Config, diagnostics: Diagnostic[])
   }
 }
 
-function checkAuthentication(config: Config, diagnostics: Diagnostic[]) {
+export function checkAuthentication(config: Config, diagnostics: Diagnostic[]) {
   if (!config.service) return
 
   const { provider, authentication } = config.service
@@ -161,9 +161,16 @@ function checkAuthentication(config: Config, diagnostics: Diagnostic[]) {
   }
 
   if (!authentication || authentication.type === 'None') {
+    // A custom baseURL on the openai provider means an OpenAI-compatible
+    // endpoint (OpenRouter, Groq, LM Studio, vLLM, custom — #1610), not the
+    // real OpenAI API. Self-hosted/local ones commonly run without auth, so
+    // this is a warning rather than a hard error for that case.
+    const isCompatEndpoint = provider === 'openai' && Boolean((config.service as { baseURL?: string }).baseURL)
     diagnostics.push({
-      severity: 'error',
-      message: `Provider "${provider}" requires authentication but none is configured.`,
+      severity: isCompatEndpoint ? 'warn' : 'error',
+      message: isCompatEndpoint
+        ? `No authentication configured for the OpenAI-compatible endpoint at "${(config.service as { baseURL?: string }).baseURL}". This is fine for a self-hosted/no-auth endpoint (LM Studio, vLLM, ...) — otherwise set an API key.`
+        : `Provider "${provider}" requires authentication but none is configured.`,
       fix: `Set service.authentication to { "type": "APIKey", "credentials": { "apiKey": "..." } } or use the OPENAI_API_KEY / ANTHROPIC_API_KEY / AZURE_OPENAI_API_KEY / GEMINI_API_KEY / MISTRAL_API_KEY environment variable.`,
     })
     return

--- a/src/commands/init/handler.ts
+++ b/src/commands/init/handler.ts
@@ -11,7 +11,7 @@ import { installNpmPackage } from '../../lib/utils/installPackage'
 
 import { ConfigWithServiceObject } from '../../lib/config/types'
 import { loadConfig } from '../../lib/config/utils/loadConfig'
-import { LLMModel, LLMProvider, OllamaLLMService } from '../../lib/langchain/types'
+import { LLMModel, LLMProvider, OllamaLLMService, OpenAILLMService } from '../../lib/langchain/types'
 import { getDefaultServiceConfigFromAlias } from '../../lib/langchain/utils'
 import { OllamaNotReadyError } from '../../lib/langchain/utils/ollamaStatus'
 import { CommandHandler } from '../../lib/types'
@@ -21,7 +21,8 @@ import { getProjectConfigFilePath } from '../../lib/utils/getProjectConfigFilePa
 import { runDiagnostics } from '../doctor/checks'
 import { applyRepoCwd } from '../utils/applyRepoFlag'
 import { InitArgv, InitOptions } from './config'
-import { questions } from './questions'
+import { questions, OPENAI_COMPATIBLE_SENTINEL } from './questions'
+import { OpenAiCompatiblePreset } from './openAiCompatiblePresets'
 
 export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
   // Honor the global --repo flag so `coco init --repo <X> --scope project`
@@ -54,10 +55,22 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
   // hard-exiting and discarding the answers above.
   let llmProvider: LLMProvider
   let llmModel: LLMModel
+  // Set when the user picks "OpenAI-compatible endpoint" (#1610) — the
+  // underlying provider is still 'openai', but the model is free text and
+  // the service gets a custom baseURL + a preset-specific API key hint.
+  let compatiblePreset: OpenAiCompatiblePreset | undefined
   for (;;) {
-    llmProvider = await questions.selectLLMProvider()
+    const picked = await questions.selectLLMProvider()
     try {
-      llmModel = await questions.selectLLMModel(llmProvider)
+      if (picked === OPENAI_COMPATIBLE_SENTINEL) {
+        compatiblePreset = await questions.selectOpenAiCompatiblePreset()
+        llmProvider = 'openai'
+        llmModel = await questions.inputOpenAiCompatibleModel()
+      } else {
+        compatiblePreset = undefined
+        llmProvider = picked
+        llmModel = await questions.selectLLMModel(llmProvider)
+      }
       break
     } catch (err) {
       if (err instanceof OllamaNotReadyError) {
@@ -69,6 +82,13 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
   }
 
   const service = getDefaultServiceConfigFromAlias(llmProvider, llmModel)
+
+  // compatiblePreset is only ever set alongside llmProvider === 'openai'
+  // (see the selection loop above), so `service` is always an
+  // OpenAILLMService here.
+  if (compatiblePreset?.baseURL) {
+    (service as OpenAILLMService).baseURL = compatiblePreset.baseURL
+  }
 
   const config: ConfigWithServiceObject = {
     defaultBranch: 'main',
@@ -94,7 +114,9 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
   }
 
   let apiKey = '' as string
-  const inputPrompt = inputPromptByProvider[llmProvider]
+  const inputPrompt = compatiblePreset
+    ? { label: compatiblePreset.label, envVar: compatiblePreset.apiKeyEnvVar }
+    : inputPromptByProvider[llmProvider]
   if (inputPrompt) {
     if (isProjectScope) {
       const envVarName: string = inputPrompt.envVar
@@ -105,7 +127,12 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
         )
       )
     } else {
-      apiKey = await questions.inputApiKey(inputPrompt.label, inputPrompt.envVar)
+      // Local/self-hosted compat endpoints (LM Studio, vLLM, custom)
+      // typically don't enforce a real key — let it through blank instead
+      // of forcing a placeholder value.
+      apiKey = compatiblePreset && !compatiblePreset.requiresApiKey
+        ? await questions.inputOptionalApiKey(inputPrompt.label, inputPrompt.envVar)
+        : await questions.inputApiKey(inputPrompt.label, inputPrompt.envVar)
 
       if (config.service.authentication.type === 'APIKey') {
         config.service.authentication.credentials.apiKey = '•••••••••••••••'
@@ -214,9 +241,18 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
   let approvalMessage = 'does this look good?'
 
   if (config.service.authentication.type === 'APIKey') {
-    // add to config after logging, so that the API key is not logged
-    config.service.authentication.credentials.apiKey = apiKey
-    approvalMessage = 'looking good? (API key hidden for security)'
+    if (!apiKey && compatiblePreset && !compatiblePreset.requiresApiKey) {
+      // Compat endpoint with no key entered (LM Studio / vLLM / custom,
+      // typically no auth) — 'APIKey' with an empty string would make
+      // every command think a key is missing and fail with a "set your
+      // API key" prompt. Drop to 'None' so unauthenticated local
+      // endpoints work out of the box.
+      config.service.authentication = { type: 'None', credentials: undefined }
+    } else {
+      // add to config after logging, so that the API key is not logged
+      config.service.authentication.credentials.apiKey = apiKey
+      approvalMessage = apiKey ? 'looking good? (API key hidden for security)' : approvalMessage
+    }
   }
 
   const isApproved = await confirmPrompt({

--- a/src/commands/init/init.test.ts
+++ b/src/commands/init/init.test.ts
@@ -1,5 +1,5 @@
 import { handler } from './handler'
-import { questions } from './questions'
+import { questions, OPENAI_COMPATIBLE_SENTINEL } from './questions'
 import { InitOptions } from './config'
 import { Config } from '../types'
 import { appendToGitConfig } from '../../lib/config/services/git'
@@ -194,6 +194,75 @@ describe('init command', () => {
         }),
       })
     )
+  })
+
+  describe('OpenAI-compatible endpoint presets (#1610)', () => {
+    beforeEach(() => {
+      mockLoadConfig.mockReturnValue({
+        scope: 'global',
+        dryRun: false,
+      } as unknown as Config)
+      mockApiKeyService('openai')
+    })
+
+    it('resolves the sentinel to provider=openai with the preset baseURL, and requires an API key for a hosted preset (OpenRouter)', async () => {
+      jest.spyOn(questions, 'selectLLMProvider').mockResolvedValue(OPENAI_COMPATIBLE_SENTINEL)
+      jest.spyOn(questions, 'selectOpenAiCompatiblePreset').mockResolvedValue({
+        id: 'openrouter',
+        label: 'OpenRouter',
+        baseURL: 'https://openrouter.ai/api/v1',
+        apiKeyEnvVar: 'OPENROUTER_API_KEY',
+        requiresApiKey: true,
+      })
+      jest.spyOn(questions, 'inputOpenAiCompatibleModel').mockResolvedValue('meta-llama/llama-3.3-70b-instruct')
+      jest.spyOn(questions, 'inputApiKey').mockResolvedValue('or-secret-key')
+
+      await handler(createArgv({ scope: 'global' }), logger)
+
+      expect(questions.selectLLMModel).not.toHaveBeenCalled()
+      expect(questions.inputApiKey).toHaveBeenCalledWith('OpenRouter', 'OPENROUTER_API_KEY')
+      expect(mockAppendToGitConfig).toHaveBeenCalledWith(
+        '/home/coco/.gitconfig',
+        expect.objectContaining({
+          service: expect.objectContaining({
+            provider: 'openai',
+            baseURL: 'https://openrouter.ai/api/v1',
+            authentication: expect.objectContaining({
+              type: 'APIKey',
+              credentials: expect.objectContaining({ apiKey: 'or-secret-key' }),
+            }),
+          }),
+        })
+      )
+    })
+
+    it('drops to no-auth when a self-hosted preset (LM Studio) gets no API key', async () => {
+      jest.spyOn(questions, 'selectLLMProvider').mockResolvedValue(OPENAI_COMPATIBLE_SENTINEL)
+      jest.spyOn(questions, 'selectOpenAiCompatiblePreset').mockResolvedValue({
+        id: 'lmstudio',
+        label: 'LM Studio',
+        baseURL: 'http://localhost:1234/v1',
+        apiKeyEnvVar: 'LMSTUDIO_API_KEY',
+        requiresApiKey: false,
+      })
+      jest.spyOn(questions, 'inputOpenAiCompatibleModel').mockResolvedValue('local-model')
+      jest.spyOn(questions, 'inputOptionalApiKey').mockResolvedValue('')
+
+      await handler(createArgv({ scope: 'global' }), logger)
+
+      expect(questions.inputOptionalApiKey).toHaveBeenCalledWith('LM Studio', 'LMSTUDIO_API_KEY')
+      expect(questions.inputApiKey).not.toHaveBeenCalled()
+      expect(mockAppendToGitConfig).toHaveBeenCalledWith(
+        '/home/coco/.gitconfig',
+        expect.objectContaining({
+          service: expect.objectContaining({
+            provider: 'openai',
+            baseURL: 'http://localhost:1234/v1',
+            authentication: { type: 'None', credentials: undefined },
+          }),
+        })
+      )
+    })
   })
 
   it('skips the custom Ollama endpoint prompt for project scope', async () => {

--- a/src/commands/init/openAiCompatiblePresets.test.ts
+++ b/src/commands/init/openAiCompatiblePresets.test.ts
@@ -1,0 +1,36 @@
+import { findOpenAiCompatiblePreset, OPENAI_COMPATIBLE_PRESETS } from './openAiCompatiblePresets'
+
+describe('OPENAI_COMPATIBLE_PRESETS', () => {
+  it('includes OpenRouter, Groq, LM Studio, vLLM, and a custom fallback', () => {
+    const ids = OPENAI_COMPATIBLE_PRESETS.map((preset) => preset.id)
+    expect(ids).toEqual(['openrouter', 'groq', 'lmstudio', 'vllm', 'custom'])
+  })
+
+  it('gives fixed-endpoint presets a baseURL and self-hosted ones none', () => {
+    const byId = Object.fromEntries(OPENAI_COMPATIBLE_PRESETS.map((p) => [p.id, p]))
+    expect(byId.openrouter.baseURL).toBe('https://openrouter.ai/api/v1')
+    expect(byId.groq.baseURL).toBeTruthy()
+    expect(byId.lmstudio.baseURL).toBe('http://localhost:1234/v1')
+    expect(byId.vllm.baseURL).toBeUndefined()
+    expect(byId.custom.baseURL).toBeUndefined()
+  })
+
+  it('only requires an API key for the hosted presets', () => {
+    const byId = Object.fromEntries(OPENAI_COMPATIBLE_PRESETS.map((p) => [p.id, p]))
+    expect(byId.openrouter.requiresApiKey).toBe(true)
+    expect(byId.groq.requiresApiKey).toBe(true)
+    expect(byId.lmstudio.requiresApiKey).toBe(false)
+    expect(byId.vllm.requiresApiKey).toBe(false)
+    expect(byId.custom.requiresApiKey).toBe(false)
+  })
+})
+
+describe('findOpenAiCompatiblePreset', () => {
+  it('finds a preset by id', () => {
+    expect(findOpenAiCompatiblePreset('groq')?.label).toBe('Groq')
+  })
+
+  it('returns undefined for an unknown id', () => {
+    expect(findOpenAiCompatiblePreset('nope')).toBeUndefined()
+  })
+})

--- a/src/commands/init/openAiCompatiblePresets.ts
+++ b/src/commands/init/openAiCompatiblePresets.ts
@@ -1,0 +1,58 @@
+/**
+ * Named presets for OpenAI-compatible endpoints (#1610). `service.baseURL`
+ * on the OpenAI provider already supports pointing at any OpenAI-compatible
+ * API — these presets just make that capability discoverable from the
+ * `coco init` wizard instead of requiring a hand-edited config file.
+ */
+export type OpenAiCompatiblePresetId = 'openrouter' | 'groq' | 'lmstudio' | 'vllm' | 'custom'
+
+export type OpenAiCompatiblePreset = {
+  id: OpenAiCompatiblePresetId
+  label: string
+  /** Fixed endpoint, or undefined when the user must supply one (vLLM / custom). */
+  baseURL?: string
+  /** Env var name hint shown in the API-key prompt. */
+  apiKeyEnvVar: string
+  /** Local/self-hosted endpoints typically don't enforce a real key. */
+  requiresApiKey: boolean
+}
+
+export const OPENAI_COMPATIBLE_PRESETS: OpenAiCompatiblePreset[] = [
+  {
+    id: 'openrouter',
+    label: 'OpenRouter',
+    baseURL: 'https://openrouter.ai/api/v1',
+    apiKeyEnvVar: 'OPENROUTER_API_KEY',
+    requiresApiKey: true,
+  },
+  {
+    id: 'groq',
+    label: 'Groq',
+    baseURL: 'https://api.groq.com/openai/v1',
+    apiKeyEnvVar: 'GROQ_API_KEY',
+    requiresApiKey: true,
+  },
+  {
+    id: 'lmstudio',
+    label: 'LM Studio',
+    baseURL: 'http://localhost:1234/v1',
+    apiKeyEnvVar: 'LMSTUDIO_API_KEY',
+    requiresApiKey: false,
+  },
+  {
+    id: 'vllm',
+    label: 'vLLM',
+    apiKeyEnvVar: 'VLLM_API_KEY',
+    requiresApiKey: false,
+  },
+  {
+    id: 'custom',
+    label: 'Custom OpenAI-compatible URL',
+    apiKeyEnvVar: 'OPENAI_COMPATIBLE_API_KEY',
+    requiresApiKey: false,
+  },
+]
+
+export function findOpenAiCompatiblePreset(id: string): OpenAiCompatiblePreset | undefined {
+  return OPENAI_COMPATIBLE_PRESETS.find((preset) => preset.id === id)
+}

--- a/src/commands/init/questions.ts
+++ b/src/commands/init/questions.ts
@@ -18,6 +18,10 @@ import {
 import { ProjectConfigFileName } from '../../lib/utils/getProjectConfigFilePath'
 import { COMMIT_PROMPT } from '../commit/prompt'
 import { InstallationScope } from './config'
+import { OPENAI_COMPATIBLE_PRESETS, OpenAiCompatiblePreset } from './openAiCompatiblePresets'
+
+/** Sentinel returned by `selectLLMProvider` for the compat-endpoint branch. */
+export const OPENAI_COMPATIBLE_SENTINEL = 'openai-compatible' as const
 
 /**
  * Resolve the list of locally-available Ollama models for the init picker,
@@ -102,8 +106,8 @@ export const questions = {
         },
       ],
     }),
-  selectLLMProvider: async (): Promise<LLMProvider> =>
-    await selectPrompt<LLMProvider>({
+  selectLLMProvider: async (): Promise<LLMProvider | typeof OPENAI_COMPATIBLE_SENTINEL> =>
+    await selectPrompt<LLMProvider | typeof OPENAI_COMPATIBLE_SENTINEL>({
       message: 'select language model provider:',
       choices: [
         {
@@ -140,10 +144,52 @@ export const questions = {
           name: 'AWS Bedrock',
           value: 'bedrock',
           description: 'AWS Bedrock (uses the AWS credential chain)',
-        }
+        },
+        {
+          name: 'OpenAI-compatible endpoint',
+          value: OPENAI_COMPATIBLE_SENTINEL,
+          description: 'OpenRouter, Groq, LM Studio, vLLM, or any other OpenAI-compatible API',
+        },
       ],
       default: 'ollama',
     }),
+
+  selectOpenAiCompatiblePreset: async (): Promise<OpenAiCompatiblePreset> => {
+    const presetId = await selectPrompt<OpenAiCompatiblePreset['id']>({
+      message: 'select OpenAI-compatible endpoint:',
+      choices: OPENAI_COMPATIBLE_PRESETS.map((preset) => ({
+        name: preset.label,
+        value: preset.id,
+        description: preset.baseURL ? preset.baseURL : 'you provide the base URL',
+      })),
+    })
+    const preset = OPENAI_COMPATIBLE_PRESETS.find((p) => p.id === presetId)
+    if (!preset) {
+      throw new Error(`selectOpenAiCompatiblePreset: unknown preset id '${presetId}'`)
+    }
+
+    if (preset.baseURL) {
+      return preset
+    }
+
+    // vLLM / custom: no fixed endpoint, ask for one.
+    const baseURL = await inputPrompt({
+      message: `${preset.label} base URL (e.g. http://localhost:8000/v1):`,
+      validate(input) {
+        return input.trim().length > 0 ? true : 'Base URL cannot be empty'
+      },
+    })
+
+    return { ...preset, baseURL: baseURL.trim() }
+  },
+
+  inputOpenAiCompatibleModel: async (): Promise<LLMModel> =>
+    (await inputPrompt({
+      message: 'model id (e.g. meta-llama/llama-3.3-70b-instruct):',
+      validate(input) {
+        return input.trim().length > 0 ? true : 'Model id cannot be empty'
+      },
+    })) as LLMModel,
 
   selectLLMModel: async (provider: LLMProvider): Promise<LLMModel> => {
     let availableModels = [] as { name: string; value: LLMModel }[]
@@ -264,6 +310,33 @@ export const questions = {
         return input.length > 0 ? true : 'API key cannot be empty';
       },
     });
+  },
+
+  /**
+   * Same as `inputApiKey`, but empty is a valid answer — for
+   * self-hosted/local OpenAI-compatible endpoints (LM Studio, vLLM, custom)
+   * that typically don't enforce a real key.
+   */
+  inputOptionalApiKey: async (
+    keyName: string,
+    envVarName: string
+  ): Promise<string> => {
+    const envVarValue = process.env[envVarName]
+
+    if (envVarValue) {
+      const useExisting = await confirmPrompt({
+        message: `Use existing ${envVarName} env var?`,
+        default: true,
+      })
+
+      if (useExisting) {
+        return envVarValue
+      }
+    }
+
+    return await passwordPrompt({
+      message: `Enter your ${keyName} API key (optional — leave blank if this endpoint doesn't require one):`,
+    })
   },
 
   inputTokenLimit: async (): Promise<number> => {


### PR DESCRIPTION
## What

Adds an "OpenAI-compatible endpoint" choice to `coco init`'s provider picker, with named presets (OpenRouter, Groq, LM Studio, vLLM, custom) so self-hosted / compatible endpoints don't require hand-editing config after the wizard.

Closes #1610

## How

- `selectLLMProvider()`'s return type widens locally to include an exported `OPENAI_COMPATIBLE_SENTINEL`; resolves to `provider: 'openai'` + a separately-tracked preset, not a change to the `LLMProvider` union itself.
- New `selectOpenAiCompatiblePreset()` / `inputOpenAiCompatibleModel()` / `inputOptionalApiKey()` wizard steps.
- `init/handler.ts` sets `service.baseURL` from the preset and only requires an API key when the preset says so (LM Studio / vLLM can go keyless → `authentication.type: 'None'`).
- `doctor`'s `checkAuthentication` downgrades "no auth configured" from error to warn specifically for an `openai` provider with a custom `baseURL` set (compat endpoints commonly have no auth).

## Validation

- [x] `npm test` passes locally (lint + jest + build + packaged-CLI smoke)
- [x] New behavior has tests (`openAiCompatiblePresets.test.ts`, `init.test.ts`, `doctor/checks.test.ts`)
- [x] `schema.json` regenerated — not needed, no config type changes
- [ ] Docs updated where relevant (README / `.wiki/`) — follow-up
- [x] Commits follow Conventional Commits

## Notes

None.
