### PR TITLE
feat(changelog): add --write to update CHANGELOG.md in place

### DIFF
--- a/src/commands/changelog/changelog.test.ts
+++ b/src/commands/changelog/changelog.test.ts
@@ -1,3 +1,6 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
 import { Arguments } from 'yargs'
 import { SimpleGit } from 'simple-git'
 import { handler } from './handler'
@@ -179,6 +182,52 @@ describe('changelog command', () => {
     expect(mockHandleResult).toHaveBeenCalledWith(
       expect.objectContaining({ mode: 'stdout' })
     )
+  })
+
+  describe('--write (#1600)', () => {
+    let dir: string
+    let filePath: string
+
+    beforeEach(() => {
+      dir = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-changelog-handler-write-'))
+      filePath = path.join(dir, 'CHANGELOG.md')
+    })
+
+    afterEach(() => {
+      fs.rmSync(dir, { recursive: true, force: true })
+    })
+
+    it('writes the generated section into --file', async () => {
+      argv.write = true
+      argv.file = filePath
+
+      await handler(argv, logger)
+
+      const written = fs.readFileSync(filePath, 'utf8')
+      expect(written).toContain('## Mocked changelog title')
+      expect(written).toContain('Mocked changelog content')
+    })
+
+    it('still writes the file when --json is also passed', async () => {
+      argv.write = true
+      argv.file = filePath
+      argv.json = true
+
+      const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation((() => true) as never)
+      try {
+        await handler(argv, logger)
+      } finally {
+        writeSpy.mockRestore()
+      }
+
+      const written = fs.readFileSync(filePath, 'utf8')
+      expect(written).toContain('## Mocked changelog title')
+    })
+
+    it('does not touch the file when --write is not passed', async () => {
+      await handler(argv, logger)
+      expect(fs.existsSync(filePath)).toBe(false)
+    })
   })
 
   it('emits JSON null (not colored status text) when there are no commits and --json is passed', async () => {

--- a/src/commands/changelog/config.ts
+++ b/src/commands/changelog/config.ts
@@ -12,6 +12,8 @@ export interface ChangelogOptions extends BaseCommandOptions {
   additional?: string
   author?: boolean
   json?: boolean
+  write?: boolean
+  file?: string
 }
 
 export type ChangelogArgv = Arguments<ChangelogOptions>
@@ -73,6 +75,16 @@ export const options = {
     type: 'boolean',
     alias: 'interactive',
     description: 'Toggle interactive mode',
+  },
+  write: {
+    type: 'boolean',
+    description: 'Write the generated changelog into --file in place, instead of only printing it.',
+    default: false,
+  },
+  file: {
+    type: 'string',
+    description: 'CHANGELOG file to update with --write.',
+    default: 'CHANGELOG.md',
   },
   // `--json` is a global flag (see src/index.ts).
 } as Record<string, Options>

--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -36,6 +36,7 @@ import {
     ChangelogResponseSchema,
 } from './config'
 import { CHANGELOG_PROMPT } from './prompt'
+import { writeChangelogFile } from './writeChangelog'
 
 type CommitDetailsWithDiffText = CommitDetails & { diffText?: string };
 
@@ -387,6 +388,18 @@ export const handler: CommandHandler<ChangelogArgv> = async (argv, logger) => {
   }
 
   const { text: changelogMsg, structured } = await generateChangelogResult(argv, logger)
+
+  // #1600 — write before the --json early return, so `--json --write`
+  // still lands the file (release scripts want both: the file update
+  // and a machine-readable result to log/parse).
+  if (argv.write && structured) {
+    const filePath = argv.file || 'CHANGELOG.md'
+    writeChangelogFile({ filePath, title: structured.title, content: structured.content })
+    // Silenced along with the rest of the command's status chrome in
+    // non-interactive/--json mode (set up in generateChangelogResult) —
+    // no special-casing needed here.
+    logger.log(`Updated ${filePath}`, { color: 'green' })
+  }
 
   if (argv.json) {
     emitJson(structured ?? null)

--- a/src/commands/changelog/writeChangelog.test.ts
+++ b/src/commands/changelog/writeChangelog.test.ts
@@ -1,0 +1,85 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { buildChangelogSection, writeChangelogFile } from './writeChangelog'
+
+describe('buildChangelogSection', () => {
+  it('renders a `## title — date` heading followed by the trimmed content', () => {
+    const section = buildChangelogSection('v1.2.0', '\n- did a thing\n- did another\n\n', '2026-07-13')
+    expect(section).toBe('## v1.2.0 — 2026-07-13\n\n- did a thing\n- did another\n')
+  })
+})
+
+describe('writeChangelogFile', () => {
+  let dir: string
+  let filePath: string
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-changelog-write-'))
+    filePath = path.join(dir, 'CHANGELOG.md')
+  })
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('creates the file with a standard header when it does not exist', () => {
+    writeChangelogFile({ filePath, title: 'v1.0.0', content: '- initial release', date: '2026-07-13' })
+    const written = fs.readFileSync(filePath, 'utf8')
+    expect(written).toContain('# Changelog')
+    expect(written).toContain('## v1.0.0 — 2026-07-13')
+    expect(written).toContain('- initial release')
+  })
+
+  it('inserts a new section right after the top-level heading, above existing sections', () => {
+    fs.writeFileSync(filePath, '# Changelog\n\n## v1.0.0 — 2026-07-01\n\n- initial release\n')
+    writeChangelogFile({ filePath, title: 'v1.1.0', content: '- a new feature', date: '2026-07-13' })
+    const written = fs.readFileSync(filePath, 'utf8')
+    const v11Index = written.indexOf('## v1.1.0')
+    const v10Index = written.indexOf('## v1.0.0')
+    expect(v11Index).toBeGreaterThan(-1)
+    expect(v10Index).toBeGreaterThan(-1)
+    expect(v11Index).toBeLessThan(v10Index)
+    expect(written).toContain('- initial release')
+    expect(written).toContain('- a new feature')
+  })
+
+  it('replaces an existing section with the same title in place instead of duplicating it', () => {
+    fs.writeFileSync(
+      filePath,
+      [
+        '# Changelog',
+        '',
+        '## v1.1.0 — 2026-07-13',
+        '',
+        '- first draft of the feature',
+        '',
+        '## v1.0.0 — 2026-07-01',
+        '',
+        '- initial release',
+        '',
+      ].join('\n')
+    )
+    writeChangelogFile({ filePath, title: 'v1.1.0', content: '- final wording of the feature', date: '2026-07-13' })
+    const written = fs.readFileSync(filePath, 'utf8')
+
+    expect(written).not.toContain('first draft')
+    expect(written).toContain('final wording of the feature')
+    // Still exactly one v1.1.0 heading — not duplicated.
+    expect(written.split('## v1.1.0').length - 1).toBe(1)
+    // The older section is untouched.
+    expect(written).toContain('## v1.0.0 — 2026-07-01')
+    expect(written).toContain('- initial release')
+  })
+
+  it('does not match a title that is a prefix of another title', () => {
+    fs.writeFileSync(filePath, '# Changelog\n\n## v1.0 — 2026-07-01\n\n- old\n')
+    writeChangelogFile({ filePath, title: 'v1.0.0', content: '- new', date: '2026-07-13' })
+    const written = fs.readFileSync(filePath, 'utf8')
+    // Both headings survive — v1.0.0 was inserted as new, not merged into v1.0's section.
+    expect(written).toContain('## v1.0 — 2026-07-01')
+    expect(written).toContain('## v1.0.0 — 2026-07-13')
+    expect(written).toContain('- old')
+    expect(written).toContain('- new')
+  })
+})

--- a/src/commands/changelog/writeChangelog.ts
+++ b/src/commands/changelog/writeChangelog.ts
@@ -1,0 +1,79 @@
+import fs from 'fs'
+import { writeFileAtomic } from '../../lib/utils/atomicFileWrite'
+
+const DEFAULT_CHANGELOG_HEADER = '# Changelog\n'
+
+export type ChangelogSectionInput = {
+  filePath: string
+  title: string
+  content: string
+  /** Injectable for tests; defaults to today (YYYY-MM-DD, local time). */
+  date?: string
+}
+
+function todayIsoDate(): string {
+  const now = new Date()
+  const y = now.getFullYear()
+  const m = String(now.getMonth() + 1).padStart(2, '0')
+  const d = String(now.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+export function buildChangelogSection(title: string, content: string, date: string): string {
+  return `## ${title} — ${date}\n\n${content.trim()}\n`
+}
+
+/**
+ * Idempotently insert or replace a `## {title}` section in a CHANGELOG-style
+ * file (#1600). Plain markdown headings, not marker comments — a
+ * human-read CHANGELOG shouldn't carry `<!-- coco:start -->`-style noise.
+ *
+ * - Missing file: created with a standard `# Changelog` header.
+ * - No existing `## {title}` section: the new section is inserted right
+ *   after the file's top-level `# ` heading (or at the very top if there
+ *   isn't one), so the newest entry reads first.
+ * - An existing `## {title}` section (matched on the title text, ignoring
+ *   the trailing date): replaced in place — re-running for the same
+ *   title updates it rather than duplicating it.
+ */
+export function writeChangelogFile({ filePath, title, content, date = todayIsoDate() }: ChangelogSectionInput): void {
+  const section = buildChangelogSection(title, content, date)
+  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : DEFAULT_CHANGELOG_HEADER
+  const lines = existing.split(/\r?\n/)
+  const headingPrefix = `## ${title}`
+
+  const startIndex = lines.findIndex((line) => line.trim() === headingPrefix.trim() || line.trim().startsWith(`${headingPrefix} `))
+
+  if (startIndex !== -1) {
+    let endIndex = startIndex + 1
+    while (endIndex < lines.length && !lines[endIndex].startsWith('## ')) {
+      endIndex += 1
+    }
+    // Trim the trailing blank lines the old section left behind so the
+    // replacement doesn't accumulate extra blank runs on repeated writes.
+    let trimmedEnd = endIndex
+    while (trimmedEnd > startIndex + 1 && lines[trimmedEnd - 1].trim() === '') {
+      trimmedEnd -= 1
+    }
+    const before = lines.slice(0, startIndex)
+    const after = lines.slice(endIndex)
+    const next = [...before, ...section.split(/\r?\n/), ...after]
+    writeFileAtomic(filePath, next.join('\n'))
+    return
+  }
+
+  const topHeadingIndex = lines.findIndex((line) => line.startsWith('# ') && !line.startsWith('## '))
+  if (topHeadingIndex === -1) {
+    writeFileAtomic(filePath, `${DEFAULT_CHANGELOG_HEADER}\n${section}\n${existing.trim()}\n`.trimEnd() + '\n')
+    return
+  }
+
+  let insertAt = topHeadingIndex + 1
+  while (insertAt < lines.length && lines[insertAt].trim() === '') {
+    insertAt += 1
+  }
+  const before = lines.slice(0, insertAt)
+  const after = lines.slice(insertAt)
+  const next = [...before, '', ...section.split(/\r?\n/), ...after]
+  writeFileAtomic(filePath, next.join('\n'))
+}


### PR DESCRIPTION
## What

Adds `coco changelog --write [--file <path>]` to insert or replace a generated section directly in `CHANGELOG.md` instead of only printing to stdout.

Closes #1600

## How

- `writeChangelogFile({filePath, title, content, date})` matches on the `## {title}` heading (ignoring trailing date) to decide insert-vs-replace, and writes atomically via the existing `writeFileAtomic` helper.
- Wired into the handler before the `--json` early return, so `--write` and `--json` can be combined.

## Validation

- [x] `npm test` passes locally (lint + jest + build + packaged-CLI smoke)
- [x] New behavior has tests (`writeChangelog.test.ts`, `changelog.test.ts`)
- [x] `schema.json` regenerated — not needed, no config type changes
- [ ] Docs updated where relevant (README / `.wiki/`) — follow-up
- [x] Commits follow Conventional Commits

## Notes

None.
