### PR TITLE
feat(config): add coco config get/set/unset/list

### DIFF
--- a/src/commands/config/config.test.ts
+++ b/src/commands/config/config.test.ts
@@ -1,0 +1,190 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { Arguments } from 'yargs'
+import { handler } from './handler'
+import { ConfigArgv, ConfigOptions } from './config'
+import { Logger } from '../../lib/utils/logger'
+import { resolveGitRepoRoot } from '../../lib/utils/resolveGitRepoRoot'
+
+jest.mock('../../lib/utils/resolveGitRepoRoot')
+
+const mockResolveGitRepoRoot = resolveGitRepoRoot as jest.MockedFunction<typeof resolveGitRepoRoot>
+
+// `getXdgConfigPath` derives from process.env.XDG_CONFIG_HOME, and
+// `loadConfig`'s internal `loadXDGConfig` calls it directly (a same-file
+// reference `jest.mock` can't intercept) — so tests point it at a temp
+// dir via the real env var rather than mocking the function, keeping the
+// scoped-write path (via `resolveScopedConfigPath`) and the effective-read
+// path (via `loadConfig`) in agreement about which file is "global".
+const ORIGINAL_XDG_CONFIG_HOME = process.env.XDG_CONFIG_HOME
+
+function createLogger(): Logger {
+  return {
+    log: jest.fn(),
+    verbose: jest.fn(),
+    setConfig: jest.fn(),
+    error: jest.fn(),
+    startTimer: jest.fn().mockReturnThis(),
+    stopTimer: jest.fn(),
+    startSpinner: jest.fn().mockReturnThis(),
+    stopSpinner: jest.fn(),
+  } as unknown as Logger
+}
+
+function createArgv(overrides: Partial<ConfigOptions> = {}): ConfigArgv {
+  return {
+    $0: 'coco',
+    _: ['config'],
+    action: 'get',
+    verbose: false,
+    version: false,
+    help: false,
+    json: false,
+    ...overrides,
+  } as unknown as Arguments<ConfigOptions>
+}
+
+describe('config command (#1605)', () => {
+  let projectDir: string
+  let xdgDir: string
+  let logger: Logger
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-config-cmd-project-'))
+    xdgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-config-cmd-xdg-'))
+    mockResolveGitRepoRoot.mockReturnValue(projectDir)
+    process.env.XDG_CONFIG_HOME = xdgDir
+    logger = createLogger()
+  })
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true })
+    fs.rmSync(xdgDir, { recursive: true, force: true })
+    if (ORIGINAL_XDG_CONFIG_HOME === undefined) {
+      delete process.env.XDG_CONFIG_HOME
+    } else {
+      process.env.XDG_CONFIG_HOME = ORIGINAL_XDG_CONFIG_HOME
+    }
+    jest.clearAllMocks()
+  })
+
+  it('set writes a top-level key into the project scope file', async () => {
+    await handler(createArgv({ action: 'set', key: 'defaultBranch', value: 'develop', scope: 'project' }), logger)
+
+    const written = JSON.parse(fs.readFileSync(path.join(projectDir, '.coco.json'), 'utf8'))
+    expect(written.defaultBranch).toBe('develop')
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('Set defaultBranch'), expect.anything())
+  })
+
+  it('set coerces booleans and numbers before writing', async () => {
+    await handler(createArgv({ action: 'set', key: 'conventionalCommits', value: 'true', scope: 'project' }), logger)
+    await handler(createArgv({ action: 'set', key: 'service.tokenLimit', value: '2048', scope: 'project' }), logger)
+
+    const written = JSON.parse(fs.readFileSync(path.join(projectDir, '.coco.json'), 'utf8'))
+    expect(written.conventionalCommits).toBe(true)
+    expect(written.service.tokenLimit).toBe(2048)
+  })
+
+  it('set rejects an untrusted service key at project scope without writing the file', async () => {
+    await expect(
+      handler(
+        createArgv({ action: 'set', key: 'service.baseURL', value: 'https://evil.example', scope: 'project' }),
+        logger
+      )
+    ).rejects.toMatchObject({ name: 'CommandExitError', code: 1 })
+
+    expect(fs.existsSync(path.join(projectDir, '.coco.json'))).toBe(false)
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("can't be set"), expect.anything())
+  })
+
+  it('allows the same key at global scope', async () => {
+    await handler(
+      createArgv({ action: 'set', key: 'service.baseURL', value: 'https://openrouter.ai/api/v1', scope: 'global' }),
+      logger
+    )
+
+    const written = JSON.parse(fs.readFileSync(path.join(xdgDir, 'coco', 'config.json'), 'utf8'))
+    expect(written.service.baseURL).toBe('https://openrouter.ai/api/v1')
+  })
+
+  it('set replaces an existing value at the same key rather than duplicating it', async () => {
+    await handler(createArgv({ action: 'set', key: 'defaultBranch', value: 'develop', scope: 'project' }), logger)
+    await handler(createArgv({ action: 'set', key: 'defaultBranch', value: 'main', scope: 'project' }), logger)
+
+    const written = JSON.parse(fs.readFileSync(path.join(projectDir, '.coco.json'), 'utf8'))
+    expect(written.defaultBranch).toBe('main')
+  })
+
+  it('unset removes a key while preserving siblings', async () => {
+    await handler(createArgv({ action: 'set', key: 'defaultBranch', value: 'develop', scope: 'project' }), logger)
+    await handler(createArgv({ action: 'set', key: 'service.model', value: 'gpt-4o', scope: 'project' }), logger)
+    await handler(createArgv({ action: 'unset', key: 'defaultBranch', scope: 'project' }), logger)
+
+    const written = JSON.parse(fs.readFileSync(path.join(projectDir, '.coco.json'), 'utf8'))
+    expect(written.defaultBranch).toBeUndefined()
+    expect(written.service.model).toBe('gpt-4o')
+  })
+
+  it('get reports the effective value and its source after a project-scope set', async () => {
+    await handler(createArgv({ action: 'set', key: 'defaultBranch', value: 'develop', scope: 'project' }), logger)
+    await handler(createArgv({ action: 'get', key: 'defaultBranch' }), logger)
+
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('defaultBranch = "develop"'))
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('source: project'), expect.anything())
+  })
+
+  it('get reports "not set" for a key nothing defines', async () => {
+    await handler(createArgv({ action: 'get', key: 'nonexistent.key' }), logger)
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('is not set'), expect.anything())
+  })
+
+  it('get --json emits a structured payload', async () => {
+    const writes: string[] = []
+    const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(((chunk: string) => {
+      writes.push(String(chunk))
+      return true
+    }) as never)
+
+    try {
+      await handler(createArgv({ action: 'get', key: 'defaultBranch', json: true }), logger)
+    } finally {
+      writeSpy.mockRestore()
+    }
+
+    const parsed = JSON.parse(writes.join(''))
+    expect(parsed).toEqual({ key: 'defaultBranch', value: 'main', source: 'default' })
+  })
+
+  it('masks an API key value instead of printing it in plain text', async () => {
+    // The XDG loader's parseServiceConfig only reconstructs a `service`
+    // block when `provider` is present in the same file — set it first so
+    // the apiKey round-trips through the real load chain `get` reads from.
+    await handler(
+      createArgv({ action: 'set', key: 'service.provider', value: 'openai', scope: 'global' }),
+      logger
+    )
+    await handler(
+      createArgv({
+        action: 'set',
+        key: 'service.authentication.credentials.apiKey',
+        value: 'sk-real-secret-key',
+        scope: 'global',
+      }),
+      logger
+    )
+    await handler(createArgv({ action: 'get', key: 'service.authentication.credentials.apiKey' }), logger)
+
+    const loggedLines = (logger.log as jest.Mock).mock.calls.map((call) => call[0] as string)
+    expect(loggedLines.some((line) => line.includes('sk-real-secret-key'))).toBe(false)
+    expect(loggedLines.some((line) => line.includes('•••'))).toBe(true)
+  })
+
+  it('list --scope project prints only that scope\'s raw contents', async () => {
+    await handler(createArgv({ action: 'set', key: 'defaultBranch', value: 'develop', scope: 'project' }), logger)
+    await handler(createArgv({ action: 'list', scope: 'project' }), logger)
+
+    const loggedLines = (logger.log as jest.Mock).mock.calls.map((call) => call[0] as string)
+    expect(loggedLines.some((line) => line.includes('defaultBranch = "develop"'))).toBe(true)
+  })
+})

--- a/src/commands/config/config.ts
+++ b/src/commands/config/config.ts
@@ -1,0 +1,53 @@
+import { Arguments, Argv } from 'yargs'
+import { getCommandUsageHeader } from '../../lib/ui/helpers'
+import { BaseCommandOptions } from '../types'
+
+export const CONFIG_ACTIONS = ['get', 'set', 'unset', 'list'] as const
+export type ConfigAction = typeof CONFIG_ACTIONS[number]
+
+export interface ConfigOptions extends BaseCommandOptions {
+  action: ConfigAction
+  key?: string
+  value?: string
+  scope?: 'global' | 'project'
+}
+
+export type ConfigArgv = Arguments<ConfigOptions>
+
+export const command = 'config <action> [key] [value]'
+
+export const builder = (yargs: Argv) => {
+  return yargs
+    .positional('action', {
+      describe: 'Config action to run',
+      type: 'string',
+      choices: CONFIG_ACTIONS,
+    })
+    .positional('key', {
+      describe: 'Dotted config key path (e.g. service.model, logTui.theme.preset)',
+      type: 'string',
+    })
+    .positional('value', {
+      describe: 'Value to write (for `set`) — booleans/numbers/JSON are coerced automatically',
+      type: 'string',
+    })
+    .option('scope', {
+      type: 'string',
+      choices: ['global', 'project'],
+      description: 'Which config file to write to (required for `set`/`unset`). `global` is ~/.config/coco/config.json; `project` is .coco.json.',
+    })
+    .check((argv) => {
+      const rawArgv = argv as { action?: string; key?: string; value?: string; scope?: string }
+      if ((rawArgv.action === 'get' || rawArgv.action === 'set' || rawArgv.action === 'unset') && !rawArgv.key) {
+        throw new Error(`coco config ${rawArgv.action} requires a <key>.`)
+      }
+      if (rawArgv.action === 'set' && rawArgv.value === undefined) {
+        throw new Error('coco config set requires a <value>.')
+      }
+      if ((rawArgv.action === 'set' || rawArgv.action === 'unset') && !rawArgv.scope) {
+        throw new Error(`coco config ${rawArgv.action} requires --scope global|project.`)
+      }
+      return true
+    })
+    .usage(getCommandUsageHeader(command))
+}

--- a/src/commands/config/handler.ts
+++ b/src/commands/config/handler.ts
@@ -1,0 +1,158 @@
+import { ajv } from '../../lib/ajv'
+import { DEFAULT_CONFIG } from '../../lib/config/constants'
+import {
+    coerceConfigValue,
+    flattenToDottedPaths,
+    getDottedPath,
+    setDottedPath,
+    toOnDiskConfigKey,
+    unsetDottedPath,
+} from '../../lib/config/utils/dottedPath'
+import { loadConfig } from '../../lib/config/utils/loadConfig'
+import { resolveConfigKeySource } from '../../lib/config/utils/resolveConfigKeySource'
+import {
+    checkProjectScopeKeyTrust,
+    readScopedConfigFile,
+    resolveScopedConfigPath,
+    writeScopedConfigFile,
+} from '../../lib/config/utils/scopedConfigFile'
+import { schema } from '../../lib/schema'
+import { CommandHandler } from '../../lib/types'
+import { emitJson } from '../../lib/ui/emitJson'
+import { commandExit } from '../../lib/utils/commandExit'
+import { applyRepoCwd } from '../utils/applyRepoFlag'
+import { ConfigArgv } from './config'
+
+const validate = ajv.compile(schema)
+
+/** Never print a real API key back to a terminal or --json output. */
+function maskSecrets(key: string, value: unknown): unknown {
+  const lastSegment = key.split('.').pop()?.toLowerCase()
+  if (lastSegment === 'apikey' && typeof value === 'string' && value.length > 0) {
+    return '•••••••••••••••'
+  }
+  return value
+}
+
+/**
+ * Best-effort schema sanity check for a scoped write (#1605). Validates the
+ * scope's OWN content layered on top of `DEFAULT_CONFIG` — not the full
+ * multi-source effective config — so a partial project/global file that's
+ * only ever meant to override a couple of keys doesn't fail validation for
+ * omitting fields another layer supplies. Warns rather than blocking the
+ * write, matching this codebase's existing config-validation philosophy
+ * (`services/project.ts`): a recoverable config problem shouldn't crash the
+ * command that's trying to fix it.
+ */
+function warnIfInvalid(scopeConfig: Record<string, unknown>, logger: Parameters<CommandHandler<ConfigArgv>>[1]): void {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { $schema, ...rest } = scopeConfig
+  const trial = {
+    ...DEFAULT_CONFIG,
+    ...rest,
+    service: { ...DEFAULT_CONFIG.service, ...(rest.service as Record<string, unknown> | undefined) },
+  }
+  if (!validate(trial)) {
+    logger.log(
+      `Warning: this value may not match coco's config schema: ${ajv.errorsText(validate.errors)}`,
+      { color: 'yellow' }
+    )
+  }
+}
+
+export const handler: CommandHandler<ConfigArgv> = async (argv, logger) => {
+  applyRepoCwd(argv)
+
+  const { action, key, value, scope } = argv
+
+  if (action === 'get') {
+    // loadConfig({}) rather than loadConfig(argv) — argv carries yargs'
+    // own bookkeeping fields (_, $0, action, scope, ...) that aren't real
+    // config keys and would otherwise leak into the effective-config view.
+    const effective = loadConfig({})
+    const resolved = getDottedPath(effective, key as string)
+    const { source, path } = resolveConfigKeySource(key as string)
+    const masked = maskSecrets(key as string, resolved)
+
+    if (argv.json) {
+      emitJson({ key, value: masked ?? null, source, path })
+      return
+    }
+
+    if (resolved === undefined) {
+      logger.log(`${key} is not set.`, { color: 'yellow' })
+      return
+    }
+
+    logger.log(`${key} = ${JSON.stringify(masked)}`)
+    logger.log(`  source: ${source}${path ? ` (${path})` : ''}`, { color: 'gray' })
+    return
+  }
+
+  if (action === 'list') {
+    if (scope) {
+      const filePath = resolveScopedConfigPath(scope)
+      const raw = readScopedConfigFile(filePath)
+      const flat = flattenToDottedPaths(raw)
+      const masked = Object.fromEntries(
+        Object.entries(flat).map(([k, v]) => [k, maskSecrets(k, v)])
+      )
+      if (argv.json) {
+        emitJson({ scope, path: filePath, values: masked })
+        return
+      }
+      logger.log(`${scope} scope (${filePath}):`)
+      for (const [k, v] of Object.entries(masked)) {
+        logger.log(`  ${k} = ${JSON.stringify(v)}`)
+      }
+      return
+    }
+
+    const effective = loadConfig({})
+    const flat = flattenToDottedPaths(effective)
+    const entries = Object.entries(flat).map(([k, v]) => {
+      const { source, path } = resolveConfigKeySource(k)
+      return { key: k, value: maskSecrets(k, v), source, path }
+    })
+
+    if (argv.json) {
+      emitJson(entries)
+      return
+    }
+
+    for (const entry of entries) {
+      logger.log(`${entry.key} = ${JSON.stringify(entry.value)}  ${entry.source}${entry.path ? ` (${entry.path})` : ''}`)
+    }
+    return
+  }
+
+  if (action === 'set') {
+    if (scope === 'project') {
+      const trustError = checkProjectScopeKeyTrust(key as string)
+      if (trustError) {
+        logger.error(trustError, { color: 'red' })
+        commandExit(1)
+      }
+    }
+
+    const filePath = resolveScopedConfigPath(scope as 'global' | 'project')
+    const raw = readScopedConfigFile(filePath)
+    const coerced = coerceConfigValue(value as string)
+    setDottedPath(raw, toOnDiskConfigKey(key as string), coerced)
+    warnIfInvalid(raw, logger)
+    writeScopedConfigFile(filePath, raw)
+
+    logger.log(`Set ${key} in ${scope} scope (${filePath}).`, { color: 'green' })
+    return
+  }
+
+  if (action === 'unset') {
+    const filePath = resolveScopedConfigPath(scope as 'global' | 'project')
+    const raw = readScopedConfigFile(filePath)
+    unsetDottedPath(raw, toOnDiskConfigKey(key as string))
+    writeScopedConfigFile(filePath, raw)
+
+    logger.log(`Unset ${key} in ${scope} scope (${filePath}).`, { color: 'green' })
+    return
+  }
+}

--- a/src/commands/config/index.ts
+++ b/src/commands/config/index.ts
@@ -1,0 +1,10 @@
+import commandExecutor from '../../lib/utils/commandExecutor'
+import { builder, command } from './config'
+import { handler } from './handler'
+
+export default {
+  command,
+  desc: 'Get, set, or unset a coco config key (get/set/unset/list)',
+  builder,
+  handler: commandExecutor(handler),
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import amend from './commands/amend'
 import cache from './commands/cache'
 import changelog from './commands/changelog'
 import commit from './commands/commit'
+import configCmd from './commands/config'
 import doctor from './commands/doctor'
 import init from './commands/init'
 import issues from './commands/issues'
@@ -19,6 +20,7 @@ import { AmendOptions } from './commands/amend/config'
 import { CacheOptions } from './commands/cache/config'
 import { ChangelogOptions } from './commands/changelog/config'
 import { CommitOptions } from './commands/commit/config'
+import { ConfigOptions as ConfigCmdOptions } from './commands/config/config'
 import { defaultRouteHandler, type DefaultRouteArgv } from './commands/defaultRouter'
 import { DoctorOptions } from './commands/doctor/config'
 import { InitOptions } from './commands/init/config'
@@ -186,6 +188,13 @@ y.command<CacheOptions>(
   cache.handler
 )
 
+y.command<ConfigCmdOptions>(
+  configCmd.command,
+  configCmd.desc,
+  configCmd.builder,
+  configCmd.handler
+)
+
 y.command<IssuesOptions>(
   issues.command,
   issues.desc,
@@ -237,6 +246,7 @@ export {
   changelog,
   commit,
   Config,
+  configCmd,
   doctor,
   init,
   issues,

--- a/src/index.ts
+++ b/src/index.ts
@@ -240,6 +240,7 @@ const FISH_COMPLETION_SUBCOMMANDS: Array<{ name: string; desc: string }> = [
   { name: firstCommandToken(ui.command), desc: ui.desc },
   { name: firstCommandToken(workspace.command), desc: workspace.desc },
   { name: firstCommandToken(cache.command), desc: cache.desc },
+  { name: firstCommandToken(configCmd.command), desc: configCmd.desc },
   { name: firstCommandToken(issues.command), desc: issues.desc },
   { name: firstCommandToken(prCreate.command), desc: prCreate.desc },
   { name: firstCommandToken(prs.command), desc: prs.desc },

--- a/src/lib/config/utils/dottedPath.test.ts
+++ b/src/lib/config/utils/dottedPath.test.ts
@@ -1,0 +1,131 @@
+import {
+    coerceConfigValue,
+    flattenToDottedPaths,
+    getDottedPath,
+    setDottedPath,
+    splitDottedPath,
+    unsetDottedPath,
+} from './dottedPath'
+
+describe('splitDottedPath', () => {
+  it('splits on dots and drops empty segments', () => {
+    expect(splitDottedPath('service.model')).toEqual(['service', 'model'])
+    expect(splitDottedPath('a..b')).toEqual(['a', 'b'])
+    expect(splitDottedPath('')).toEqual([])
+  })
+})
+
+describe('getDottedPath', () => {
+  it('reads a nested value', () => {
+    expect(getDottedPath({ service: { model: 'gpt-4o' } }, 'service.model')).toBe('gpt-4o')
+  })
+
+  it('returns undefined when a segment is missing', () => {
+    expect(getDottedPath({ service: {} }, 'service.model')).toBeUndefined()
+    expect(getDottedPath({}, 'service.model')).toBeUndefined()
+  })
+
+  it('returns undefined when a segment is not an object', () => {
+    expect(getDottedPath({ service: 'not-an-object' }, 'service.model')).toBeUndefined()
+  })
+
+  it('reads a top-level value', () => {
+    expect(getDottedPath({ defaultBranch: 'main' }, 'defaultBranch')).toBe('main')
+  })
+})
+
+describe('setDottedPath', () => {
+  it('sets a top-level value', () => {
+    const obj: Record<string, unknown> = {}
+    setDottedPath(obj, 'defaultBranch', 'develop')
+    expect(obj).toEqual({ defaultBranch: 'develop' })
+  })
+
+  it('creates intermediate objects as needed', () => {
+    const obj: Record<string, unknown> = {}
+    setDottedPath(obj, 'service.model', 'gpt-4o')
+    expect(obj).toEqual({ service: { model: 'gpt-4o' } })
+  })
+
+  it('preserves sibling keys when setting a nested value', () => {
+    const obj: Record<string, unknown> = { service: { provider: 'openai' } }
+    setDottedPath(obj, 'service.model', 'gpt-4o')
+    expect(obj).toEqual({ service: { provider: 'openai', model: 'gpt-4o' } })
+  })
+
+  it('overwrites a non-object intermediate value with an object', () => {
+    const obj: Record<string, unknown> = { service: 'oops' }
+    setDottedPath(obj, 'service.model', 'gpt-4o')
+    expect(obj).toEqual({ service: { model: 'gpt-4o' } })
+  })
+})
+
+describe('unsetDottedPath', () => {
+  it('removes a top-level key', () => {
+    const obj: Record<string, unknown> = { defaultBranch: 'main', mode: 'stdout' }
+    unsetDottedPath(obj, 'defaultBranch')
+    expect(obj).toEqual({ mode: 'stdout' })
+  })
+
+  it('removes a nested key, preserving siblings', () => {
+    const obj: Record<string, unknown> = { service: { provider: 'openai', model: 'gpt-4o' } }
+    unsetDottedPath(obj, 'service.model')
+    expect(obj).toEqual({ service: { provider: 'openai' } })
+  })
+
+  it('is a no-op when the path does not exist', () => {
+    const obj: Record<string, unknown> = { service: { provider: 'openai' } }
+    unsetDottedPath(obj, 'service.nonexistent.deep')
+    expect(obj).toEqual({ service: { provider: 'openai' } })
+  })
+})
+
+describe('flattenToDottedPaths', () => {
+  it('flattens nested objects into dotted keys', () => {
+    expect(
+      flattenToDottedPaths({ service: { provider: 'openai', model: 'gpt-4o' }, defaultBranch: 'main' })
+    ).toEqual({
+      'service.provider': 'openai',
+      'service.model': 'gpt-4o',
+      defaultBranch: 'main',
+    })
+  })
+
+  it('skips undefined leaves rather than emitting the literal string "undefined"', () => {
+    expect(flattenToDottedPaths({ service: { model: 'gpt-4o', baseURL: undefined } })).toEqual({
+      'service.model': 'gpt-4o',
+    })
+  })
+
+  it('keeps arrays as leaf values (does not recurse into them)', () => {
+    expect(flattenToDottedPaths({ ignoredFiles: ['a', 'b'] })).toEqual({
+      ignoredFiles: ['a', 'b'],
+    })
+  })
+})
+
+describe('coerceConfigValue', () => {
+  it('coerces booleans', () => {
+    expect(coerceConfigValue('true')).toBe(true)
+    expect(coerceConfigValue('false')).toBe(false)
+  })
+
+  it('coerces null', () => {
+    expect(coerceConfigValue('null')).toBeNull()
+  })
+
+  it('coerces numeric strings to numbers', () => {
+    expect(coerceConfigValue('42')).toBe(42)
+    expect(coerceConfigValue('0.7')).toBe(0.7)
+  })
+
+  it('parses JSON arrays and objects', () => {
+    expect(coerceConfigValue('["a","b"]')).toEqual(['a', 'b'])
+    expect(coerceConfigValue('{"a":1}')).toEqual({ a: 1 })
+  })
+
+  it('falls back to the raw string when not JSON/boolean/number', () => {
+    expect(coerceConfigValue('gpt-4o')).toBe('gpt-4o')
+    expect(coerceConfigValue('http://localhost:1234/v1')).toBe('http://localhost:1234/v1')
+  })
+})

--- a/src/lib/config/utils/dottedPath.ts
+++ b/src/lib/config/utils/dottedPath.ts
@@ -1,0 +1,128 @@
+/**
+ * Minimal dotted-key-path helpers for `coco config` (#1605) — `get`/`set`/
+ * `unset`/`flatten` over plain JSON-shaped objects (`service.model`,
+ * `logTui.theme.preset`, ...). No array-index syntax; coco's config schema
+ * doesn't nest arrays deep enough to need it.
+ */
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function splitDottedPath(key: string): string[] {
+  return key.split('.').filter(Boolean)
+}
+
+/**
+ * The persisted-config on-disk shape (both the XDG JSON file and
+ * `~/.gitconfig`'s `[coco]` section) stores the API key flat, as
+ * `service.apiKey` — see `parseServiceConfig`'s `openai`/`anthropic`/etc.
+ * cases in `services/xdg.ts` and `serviceApiKey` in `services/git.ts`.
+ * The runtime `Config`/`LLMService` TYPE nests it instead, at
+ * `service.authentication.credentials.apiKey` — that's the shape schema
+ * validation and `coco doctor` present. `coco config` accepts the
+ * type-shaped dotted path (the one a user would actually reach for) and
+ * transparently aliases it to the on-disk flat key wherever it reads or
+ * writes a scoped file directly, so a written key is one the loaders
+ * actually pick back up.
+ */
+export function toOnDiskConfigKey(key: string): string {
+  return key === 'service.authentication.credentials.apiKey' ? 'service.apiKey' : key
+}
+
+/** Reads a dotted-path value out of `obj`. Returns undefined if any segment is missing. */
+export function getDottedPath(obj: unknown, key: string): unknown {
+  const segments = splitDottedPath(key)
+  let current: unknown = obj
+
+  for (const segment of segments) {
+    if (!isPlainObject(current)) return undefined
+    current = current[segment]
+  }
+
+  return current
+}
+
+/**
+ * Sets a dotted-path value into `obj`, creating intermediate objects as
+ * needed. Mutates and returns `obj`.
+ */
+export function setDottedPath<T extends Record<string, unknown>>(obj: T, key: string, value: unknown): T {
+  const segments = splitDottedPath(key)
+  if (segments.length === 0) return obj
+
+  let current: Record<string, unknown> = obj
+  for (let i = 0; i < segments.length - 1; i++) {
+    const segment = segments[i]
+    if (!isPlainObject(current[segment])) {
+      current[segment] = {}
+    }
+    current = current[segment] as Record<string, unknown>
+  }
+
+  current[segments[segments.length - 1]] = value
+  return obj
+}
+
+/**
+ * Removes a dotted-path key from `obj`, if present. Mutates and returns
+ * `obj`. Leaves now-empty intermediate objects in place rather than
+ * pruning them — harmless, and pruning risks deleting a sibling-holding
+ * object a caller didn't expect touched.
+ */
+export function unsetDottedPath<T extends Record<string, unknown>>(obj: T, key: string): T {
+  const segments = splitDottedPath(key)
+  if (segments.length === 0) return obj
+
+  let current: unknown = obj
+  for (let i = 0; i < segments.length - 1; i++) {
+    if (!isPlainObject(current)) return obj
+    current = current[segments[i]]
+  }
+
+  if (isPlainObject(current)) {
+    delete current[segments[segments.length - 1]]
+  }
+
+  return obj
+}
+
+/** Flattens a nested object into `{ "a.b.c": value }` entries, for `config list`. */
+export function flattenToDottedPaths(obj: unknown, prefix = ''): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+
+  if (!isPlainObject(obj)) {
+    if (prefix) result[prefix] = obj
+    return result
+  }
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined) continue
+    const path = prefix ? `${prefix}.${key}` : key
+    if (isPlainObject(value)) {
+      Object.assign(result, flattenToDottedPaths(value, path))
+    } else {
+      result[path] = value
+    }
+  }
+
+  return result
+}
+
+/**
+ * Best-effort coercion of a CLI string value into a JSON-typed value:
+ * `"true"`/`"false"` → boolean, a numeric string → number, valid JSON
+ * (arrays/objects) → parsed, anything else → the original string.
+ */
+export function coerceConfigValue(raw: string): unknown {
+  if (raw === 'true') return true
+  if (raw === 'false') return false
+  if (raw === 'null') return null
+  if (raw.trim() !== '' && !Number.isNaN(Number(raw))) return Number(raw)
+
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return raw
+  }
+}

--- a/src/lib/config/utils/resolveConfigKeySource.test.ts
+++ b/src/lib/config/utils/resolveConfigKeySource.test.ts
@@ -1,0 +1,102 @@
+import { resolveConfigKeySource } from './resolveConfigKeySource'
+import { loadEnvConfig } from '../services/env'
+import { loadGitConfig } from '../services/git'
+import { loadProjectJsonConfig } from '../services/project'
+import { loadXDGConfig } from '../services/xdg'
+
+jest.mock('../services/env')
+jest.mock('../services/git')
+jest.mock('../services/project')
+jest.mock('../services/xdg')
+
+const mockLoadEnvConfig = loadEnvConfig as jest.MockedFunction<typeof loadEnvConfig>
+const mockLoadGitConfig = loadGitConfig as jest.MockedFunction<typeof loadGitConfig>
+const mockLoadProjectJsonConfig = loadProjectJsonConfig as jest.MockedFunction<typeof loadProjectJsonConfig>
+const mockLoadXDGConfig = loadXDGConfig as jest.MockedFunction<typeof loadXDGConfig>
+
+function noneActive() {
+  mockLoadEnvConfig.mockReturnValue({ config: {}, active: false } as never)
+  mockLoadProjectJsonConfig.mockReturnValue({ config: {}, path: undefined } as never)
+  mockLoadGitConfig.mockReturnValue({ config: {}, path: undefined } as never)
+  mockLoadXDGConfig.mockReturnValue({ config: {}, path: undefined } as never)
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  noneActive()
+})
+
+describe('resolveConfigKeySource', () => {
+  it('falls back to default when no layer defines the key', () => {
+    expect(resolveConfigKeySource('defaultBranch')).toEqual({ source: 'default' })
+  })
+
+  it('reports env when the env layer is active and defines the key', () => {
+    mockLoadEnvConfig.mockReturnValue({
+      config: { defaultBranch: 'from-env' },
+      active: true,
+    } as never)
+    expect(resolveConfigKeySource('defaultBranch')).toEqual({ source: 'env' })
+  })
+
+  it('reports project (with path) when the project layer defines the key', () => {
+    mockLoadProjectJsonConfig.mockReturnValue({
+      config: { defaultBranch: 'from-project' },
+      path: '/repo/.coco.json',
+    } as never)
+    expect(resolveConfigKeySource('defaultBranch')).toEqual({
+      source: 'project',
+      path: '/repo/.coco.json',
+    })
+  })
+
+  it('reports git (with path) when the git layer defines the key', () => {
+    mockLoadGitConfig.mockReturnValue({
+      config: { defaultBranch: 'from-git' },
+      path: '/home/user/.gitconfig',
+    } as never)
+    expect(resolveConfigKeySource('defaultBranch')).toEqual({
+      source: 'git',
+      path: '/home/user/.gitconfig',
+    })
+  })
+
+  it('reports xdg (with path) when the xdg layer defines the key', () => {
+    mockLoadXDGConfig.mockReturnValue({
+      config: { defaultBranch: 'from-xdg' },
+      path: '/home/user/.config/coco/config.json',
+    } as never)
+    expect(resolveConfigKeySource('defaultBranch')).toEqual({
+      source: 'xdg',
+      path: '/home/user/.config/coco/config.json',
+    })
+  })
+
+  it('honors precedence — env wins over project, git, and xdg when all define the key', () => {
+    mockLoadEnvConfig.mockReturnValue({ config: { defaultBranch: 'env' }, active: true } as never)
+    mockLoadProjectJsonConfig.mockReturnValue({ config: { defaultBranch: 'project' }, path: '/p' } as never)
+    mockLoadGitConfig.mockReturnValue({ config: { defaultBranch: 'git' }, path: '/g' } as never)
+    mockLoadXDGConfig.mockReturnValue({ config: { defaultBranch: 'xdg' }, path: '/x' } as never)
+
+    expect(resolveConfigKeySource('defaultBranch')).toEqual({ source: 'env' })
+  })
+
+  it('honors precedence — project wins over git and xdg when env does not define the key', () => {
+    mockLoadProjectJsonConfig.mockReturnValue({ config: { defaultBranch: 'project' }, path: '/p' } as never)
+    mockLoadGitConfig.mockReturnValue({ config: { defaultBranch: 'git' }, path: '/g' } as never)
+    mockLoadXDGConfig.mockReturnValue({ config: { defaultBranch: 'xdg' }, path: '/x' } as never)
+
+    expect(resolveConfigKeySource('defaultBranch')).toEqual({ source: 'project', path: '/p' })
+  })
+
+  it('resolves a nested dotted key', () => {
+    mockLoadXDGConfig.mockReturnValue({
+      config: { service: { model: 'gpt-4o' } },
+      path: '/home/user/.config/coco/config.json',
+    } as never)
+    expect(resolveConfigKeySource('service.model')).toEqual({
+      source: 'xdg',
+      path: '/home/user/.config/coco/config.json',
+    })
+  })
+})

--- a/src/lib/config/utils/resolveConfigKeySource.ts
+++ b/src/lib/config/utils/resolveConfigKeySource.ts
@@ -1,0 +1,47 @@
+import { loadEnvConfig } from '../services/env'
+import { loadGitConfig } from '../services/git'
+import { loadProjectJsonConfig } from '../services/project'
+import { loadXDGConfig } from '../services/xdg'
+import { getDottedPath } from './dottedPath'
+import type { ConfigSource } from './loadConfig'
+
+export type ConfigKeySourceInfo = {
+  source: ConfigSource
+  path?: string
+}
+
+/**
+ * Determine which config layer actually supplies a given dotted key's
+ * effective value (#1605 `coco config get`'s "which source won" display).
+ *
+ * `loadConfig` tracks which sources were *active* overall
+ * (`getConfigSources`), but not which one wins for any one key — this
+ * re-runs each `returnSource`-capable loader against an empty base so its
+ * return value reflects only what that layer itself defines, then checks
+ * highest-precedence-first (mirrors `loadConfig`'s merge order: env >
+ * project > git > xdg > default; argv isn't considered here since `coco
+ * config get` reads persisted config, not a live invocation's flags).
+ */
+export function resolveConfigKeySource(key: string): ConfigKeySourceInfo {
+  const { config: envConfig, active: envActive } = loadEnvConfig({}, { returnSource: true })
+  if (envActive && getDottedPath(envConfig, key) !== undefined) {
+    return { source: 'env' }
+  }
+
+  const { config: projectConfig, path: projectPath } = loadProjectJsonConfig({}, { returnSource: true })
+  if (projectPath && getDottedPath(projectConfig, key) !== undefined) {
+    return { source: 'project', path: projectPath }
+  }
+
+  const { config: gitConfig, path: gitPath } = loadGitConfig({}, { returnSource: true })
+  if (gitPath && getDottedPath(gitConfig, key) !== undefined) {
+    return { source: 'git', path: gitPath }
+  }
+
+  const { config: xdgConfig, path: xdgPath } = loadXDGConfig({}, { returnSource: true })
+  if (xdgPath && getDottedPath(xdgConfig, key) !== undefined) {
+    return { source: 'xdg', path: xdgPath }
+  }
+
+  return { source: 'default' }
+}

--- a/src/lib/config/utils/scopedConfigFile.test.ts
+++ b/src/lib/config/utils/scopedConfigFile.test.ts
@@ -1,0 +1,124 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import {
+    checkProjectScopeKeyTrust,
+    readScopedConfigFile,
+    resolveScopedConfigPath,
+    writeScopedConfigFile,
+} from './scopedConfigFile'
+import { getXdgConfigPath } from '../services/xdg'
+import { resolveGitRepoRoot } from '../../utils/resolveGitRepoRoot'
+
+jest.mock('../services/xdg', () => ({
+  getXdgConfigPath: jest.fn(),
+}))
+jest.mock('../../utils/resolveGitRepoRoot', () => ({
+  resolveGitRepoRoot: jest.fn(),
+}))
+
+const mockGetXdgConfigPath = getXdgConfigPath as jest.MockedFunction<typeof getXdgConfigPath>
+const mockResolveGitRepoRoot = resolveGitRepoRoot as jest.MockedFunction<typeof resolveGitRepoRoot>
+
+describe('resolveScopedConfigPath', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-scoped-config-'))
+    mockResolveGitRepoRoot.mockReturnValue(dir)
+  })
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('returns the XDG config path for global scope', () => {
+    mockGetXdgConfigPath.mockReturnValue('/home/user/.config/coco/config.json')
+    expect(resolveScopedConfigPath('global')).toBe('/home/user/.config/coco/config.json')
+  })
+
+  it('defaults to .coco.json for project scope when neither file exists', () => {
+    expect(resolveScopedConfigPath('project')).toBe(path.join(dir, '.coco.json'))
+  })
+
+  it('prefers an existing .coco.json', () => {
+    fs.writeFileSync(path.join(dir, '.coco.json'), '{}')
+    expect(resolveScopedConfigPath('project')).toBe(path.join(dir, '.coco.json'))
+  })
+
+  it('falls back to an existing .coco.config.json when .coco.json is absent', () => {
+    fs.writeFileSync(path.join(dir, '.coco.config.json'), '{}')
+    expect(resolveScopedConfigPath('project')).toBe(path.join(dir, '.coco.config.json'))
+  })
+})
+
+describe('readScopedConfigFile / writeScopedConfigFile', () => {
+  let dir: string
+  let filePath: string
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-scoped-config-rw-'))
+    filePath = path.join(dir, '.coco.json')
+  })
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('reads {} for a missing file', () => {
+    expect(readScopedConfigFile(filePath)).toEqual({})
+  })
+
+  it('reads {} for an empty file', () => {
+    fs.writeFileSync(filePath, '')
+    expect(readScopedConfigFile(filePath)).toEqual({})
+  })
+
+  it('throws when the file root is not a JSON object', () => {
+    fs.writeFileSync(filePath, '[1,2,3]')
+    expect(() => readScopedConfigFile(filePath)).toThrow(/does not contain a JSON object/)
+  })
+
+  it('round-trips a config object with a $schema pointer added', () => {
+    writeScopedConfigFile(filePath, { defaultBranch: 'develop' })
+    const written = fs.readFileSync(filePath, 'utf8')
+    expect(written).toContain('"$schema"')
+    expect(readScopedConfigFile(filePath)).toEqual({
+      $schema: expect.stringContaining('schema.json'),
+      defaultBranch: 'develop',
+    })
+  })
+
+  it('replaces a pre-existing $schema value rather than duplicating it', () => {
+    writeScopedConfigFile(filePath, { $schema: 'https://stale.example/old.json', defaultBranch: 'main' })
+    const written = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+    expect(written.$schema).not.toBe('https://stale.example/old.json')
+    expect(Object.keys(written).filter((k) => k === '$schema')).toHaveLength(1)
+  })
+})
+
+describe('checkProjectScopeKeyTrust', () => {
+  it('allows non-service keys', () => {
+    expect(checkProjectScopeKeyTrust('defaultBranch')).toBeUndefined()
+    expect(checkProjectScopeKeyTrust('logTui.theme.preset')).toBeUndefined()
+  })
+
+  it('allows trusted service keys', () => {
+    expect(checkProjectScopeKeyTrust('service.model')).toBeUndefined()
+    expect(checkProjectScopeKeyTrust('service.tokenLimit')).toBeUndefined()
+    expect(checkProjectScopeKeyTrust('service.provider')).toBeUndefined()
+  })
+
+  it('rejects untrusted service keys that control where requests go or what credentials they carry', () => {
+    expect(checkProjectScopeKeyTrust('service.baseURL')).toBeDefined()
+    expect(checkProjectScopeKeyTrust('service.endpoint')).toBeDefined()
+    expect(checkProjectScopeKeyTrust('service.authentication')).toBeDefined()
+    expect(checkProjectScopeKeyTrust('service.authentication.credentials.apiKey')).toBeDefined()
+  })
+
+  it('includes the rejected key and a --scope global suggestion in the error message', () => {
+    const message = checkProjectScopeKeyTrust('service.baseURL')
+    expect(message).toContain('service.baseURL')
+    expect(message).toContain('--scope global')
+  })
+})

--- a/src/lib/config/utils/scopedConfigFile.ts
+++ b/src/lib/config/utils/scopedConfigFile.ts
@@ -1,0 +1,91 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { getXdgConfigPath } from '../services/xdg'
+import { TRUSTED_PROJECT_SERVICE_KEYS } from '../services/project'
+import { resolveGitRepoRoot } from '../../utils/resolveGitRepoRoot'
+import { SCHEMA_PUBLIC_URL } from '../../schema'
+
+export type ConfigWriteScope = 'global' | 'project'
+
+const PROJECT_CONFIG_CANDIDATES = ['.coco.json', '.coco.config.json'] as const
+
+/**
+ * Resolve the on-disk path for a `coco config` write scope (#1605).
+ *
+ * - `global` is always the XDG config (`~/.config/coco/config.json`) — the
+ *   same JSON file `telemetry.usage` already persists to. `coco init`'s
+ *   global scope instead writes `~/.gitconfig` in INI form; `coco config`
+ *   deliberately targets the JSON file instead so get/set/unset don't have
+ *   to round-trip INI syntax. Both are read by `loadConfig`, so either is a
+ *   valid place to keep global settings.
+ * - `project` prefers an existing `.coco.json` / `.coco.config.json` (in
+ *   that order); if neither exists yet, defaults to creating `.coco.json`.
+ */
+export function resolveScopedConfigPath(scope: ConfigWriteScope): string {
+  if (scope === 'global') {
+    return getXdgConfigPath()
+  }
+
+  const repoRoot = resolveGitRepoRoot()
+  for (const candidate of PROJECT_CONFIG_CANDIDATES) {
+    const candidatePath = path.join(repoRoot, candidate)
+    if (fs.existsSync(candidatePath)) {
+      return candidatePath
+    }
+  }
+
+  return path.join(repoRoot, PROJECT_CONFIG_CANDIDATES[0])
+}
+
+/** Reads and parses a scoped config file. Returns `{}` if it doesn't exist. */
+export function readScopedConfigFile(filePath: string): Record<string, unknown> {
+  if (!fs.existsSync(filePath)) {
+    return {}
+  }
+
+  const raw = fs.readFileSync(filePath, 'utf-8')
+  if (!raw.trim()) return {}
+
+  const parsed: unknown = JSON.parse(raw)
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`${filePath} does not contain a JSON object at its root.`)
+  }
+
+  return parsed as Record<string, unknown>
+}
+
+/** Writes a scoped config object back to disk as pretty-printed JSON with a `$schema` pointer. */
+export function writeScopedConfigFile(filePath: string, config: Record<string, unknown>): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { $schema, ...rest } = config
+  fs.writeFileSync(
+    filePath,
+    JSON.stringify({ $schema: SCHEMA_PUBLIC_URL, ...rest }, null, 2) + '\n'
+  )
+}
+
+/**
+ * A repo-committed project config is untrusted (see
+ * `TRUSTED_PROJECT_SERVICE_KEYS` in `services/project.ts`): only tuning
+ * knobs under `service.*` may be set there, never anything that decides
+ * where a request goes or what credentials it carries. Top-level keys
+ * (`defaultBranch`, `conventionalCommits`, `logTui.*`, ...) are unrestricted.
+ * Returns an error message when the key is rejected, or undefined when
+ * it's allowed.
+ */
+export function checkProjectScopeKeyTrust(key: string): string | undefined {
+  if (!key.startsWith('service.')) return undefined
+
+  const serviceKey = key.slice('service.'.length).split('.')[0]
+  if ((TRUSTED_PROJECT_SERVICE_KEYS as readonly string[]).includes(serviceKey)) {
+    return undefined
+  }
+
+  return (
+    `"${key}" can't be set in a repo-committed project config — it can decide where your ` +
+    `requests go or what credentials they carry, and a repo-local file is untrusted content ` +
+    `(anyone who can get you to clone the repo controls it). Set it via \`coco config ${key} <value> --scope global\`, ` +
+    `\`~/.gitconfig\`, or an environment variable instead.`
+  )
+}


### PR DESCRIPTION
## What

Adds `coco config get|set|unset|list [key] [value] [--scope]` for reading and editing coco's config without hand-editing JSON/INI files.

Closes #1605

## How

- Dotted-path helpers (`getDottedPath`/`setDottedPath`/`unsetDottedPath`/`flattenToDottedPaths`/`coerceConfigValue`) plus `toOnDiskConfigKey` to alias the on-disk flat `service.apiKey` shape to the runtime's nested `service.authentication.credentials.apiKey`.
- `get`/`list` read the effective merged config (via `loadConfig`) and report which source layer (env/project/git/xdg/default) supplies a key; secrets are masked.
- `set`/`unset` write only the two JSON-based scopes (`global` → XDG config, `project` → `.coco.json`/`.coco.config.json`); `~/.gitconfig` (INI) is intentionally out of scope for writes.
- `set --scope project` reuses the existing `TRUSTED_PROJECT_SERVICE_KEYS` allowlist so untrusted repo-committed config can't set arbitrary service keys.

## Validation

- [x] `npm test` passes locally (lint + jest + build + packaged-CLI smoke)
- [x] New behavior has tests (`dottedPath.test.ts`, `scopedConfigFile.test.ts`, `resolveConfigKeySource.test.ts`, `config.test.ts`)
- [x] `schema.json` regenerated — not needed, no config type changes
- [ ] Docs updated where relevant (README / `.wiki/`) — follow-up
- [x] Commits follow Conventional Commits

## Notes

Discovered two pre-existing, unrelated bugs in `xdg.ts`'s `parseServiceConfig` while building this (not fixed here, out of scope): (1) it silently drops the whole `service` block on reload if `provider` is missing from the raw JSON, and (2) even when `provider` is present, only a hardcoded subset of fields round-trips (e.g. `temperature`/`tokenLimit`/`maxConcurrent` are written but never read back). Worth a follow-up issue.
