### PR TITLE
feat(review): add --pr &lt;n&gt; to review a forge PR/MR by number

### DIFF
--- a/src/commands/review/config.test.ts
+++ b/src/commands/review/config.test.ts
@@ -1,0 +1,54 @@
+import { Argv } from 'yargs'
+import { builder } from './config'
+
+// The builder's `.check()` callback is what enforces the `--pr`/`--comment`/
+// `--branch`/`--staged` combination rules (#1596). Exercise it directly
+// against a minimal yargs-chain stub instead of a full `.parseSync()`, since
+// yargs' default failure handler calls `process.exit` on a thrown check
+// error rather than propagating it to the test.
+function extractCheckFn(): (argv: Record<string, unknown>) => boolean {
+  let captured: ((argv: Record<string, unknown>) => boolean) | undefined
+  const fakeYargs = {
+    options: () => fakeYargs,
+    check: (fn: (argv: Record<string, unknown>) => boolean) => {
+      captured = fn
+      return fakeYargs
+    },
+    usage: () => fakeYargs,
+  }
+  builder(fakeYargs as unknown as Argv)
+  if (!captured) throw new Error('builder did not register a .check() callback')
+  return captured
+}
+
+describe('review config validation (#1596)', () => {
+  const check = extractCheckFn()
+
+  it('rejects --comment without --pr', () => {
+    expect(() => check({ comment: true })).toThrow('--comment requires --pr <number>.')
+  })
+
+  it('rejects --pr combined with --branch', () => {
+    expect(() => check({ pr: 3, branch: 'main' })).toThrow(
+      '--pr cannot be combined with --branch or --staged.'
+    )
+  })
+
+  it('rejects --pr combined with --staged', () => {
+    expect(() => check({ pr: 3, staged: true })).toThrow(
+      '--pr cannot be combined with --branch or --staged.'
+    )
+  })
+
+  it('accepts --pr alone', () => {
+    expect(check({ pr: 3 })).toBe(true)
+  })
+
+  it('accepts --pr with --comment', () => {
+    expect(check({ pr: 3, comment: true })).toBe(true)
+  })
+
+  it('accepts neither --pr nor --comment', () => {
+    expect(check({})).toBe(true)
+  })
+})

--- a/src/commands/review/config.ts
+++ b/src/commands/review/config.ts
@@ -9,6 +9,10 @@ export interface ReviewOptions extends BaseCommandOptions {
   json?: boolean
   staged?: boolean
   severity?: number
+  /** Review an existing forge PR/MR by number instead of local changes. */
+  pr?: number
+  /** Post the findings summary (or request-changes above --severity) to the PR/MR. */
+  comment?: boolean
 }
 
 export type ReviewArgv = Arguments<ReviewOptions>
@@ -63,6 +67,16 @@ export const options = {
     alias: 's',
     description: 'Exit non-zero if any finding has severity >= this threshold (1-10). For CI gating.',
   },
+  pr: {
+    type: 'number',
+    alias: 'mr',
+    description: 'Review a forge pull/merge request by number instead of local changes.',
+  },
+  comment: {
+    type: 'boolean',
+    default: false,
+    description: 'Post the findings to the PR/MR (requires --pr). Findings meeting --severity request changes instead of a plain comment.',
+  },
 } as Record<string, Options>
 
 export const builder = (yargs: Argv) => {
@@ -78,6 +92,13 @@ export const builder = (yargs: Argv) => {
         !(Number.isInteger(severity) && severity >= 1 && severity <= 10)
       ) {
         throw new Error('--severity must be an integer between 1 and 10')
+      }
+      const rawArgv = argv as { pr?: number; comment?: boolean; branch?: string; staged?: boolean }
+      if (rawArgv.comment && rawArgv.pr === undefined) {
+        throw new Error('--comment requires --pr <number>.')
+      }
+      if (rawArgv.pr !== undefined && (rawArgv.branch || rawArgv.staged)) {
+        throw new Error('--pr cannot be combined with --branch or --staged.')
       }
       return true
     })

--- a/src/commands/review/handler.ts
+++ b/src/commands/review/handler.ts
@@ -2,6 +2,8 @@ import { LLMModel } from '../../lib/langchain/types'
 import chalk from 'chalk'
 import { z } from 'zod'
 import { loadConfig } from '../../lib/config/utils/loadConfig'
+import { getProviderOverview } from '../../git/providerData'
+import { getForgeActions } from '../../git/forgeActions'
 import { getApiKeyForModel, getModelAndProviderFromConfig } from '../../lib/langchain/utils'
 import { executeChain } from '../../lib/langchain/utils/executeChain'
 import { resolveDynamicService } from '../../lib/langchain/utils/dynamicModels'
@@ -48,6 +50,17 @@ function formatFindings(findings: ReviewFeedbackItem[]): string {
     .join('\n\n')
 }
 
+// Plain-markdown rendering for posting to a forge PR/MR comment — no ANSI
+// color codes, since those render as literal escape sequences on GitHub/GitLab.
+function formatFindingsMarkdown(findings: ReviewFeedbackItem[]): string {
+  if (findings.length === 0) {
+    return 'coco review found no issues.'
+  }
+  return findings
+    .map((task) => `- **[${task.severity}] ${task.title}** (${task.category}) — \`${task.filePath}\`\n  ${task.summary}`)
+    .join('\n')
+}
+
 export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
   const git = applyRepoFlag(argv)
   const config = loadConfig<ReviewOptions, ReviewArgv>(argv)
@@ -73,7 +86,42 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
     }
   }
 
+  // `--pr <n>`: review an existing forge PR/MR instead of local changes.
+  // Resolved once up front so both the diff-fetch (factory) and the
+  // optional `--comment` post-review step share the same forge instance.
+  const forge = argv.pr !== undefined
+    ? await (async () => {
+        const overview = await getProviderOverview(git)
+        const forgeProvider = overview.repository.provider
+        const repoPath =
+          overview.repository.owner && overview.repository.name
+            ? `${overview.repository.owner}/${overview.repository.name}`
+            : undefined
+        return getForgeActions(forgeProvider, {
+          gitlabPath: repoPath,
+          gitlabHost: overview.repository.host,
+          bitbucketPath: repoPath,
+        })
+      })()
+    : undefined
+
   async function factory() {
+    if (argv.pr !== undefined) {
+      logger.verbose(`Fetching diff for PR/MR #${argv.pr}`, { color: 'yellow' })
+
+      const diffResult = await forge!.getPullRequestDiffByNumber(argv.pr)
+      if (!diffResult.ok) {
+        logger.error(diffResult.message, { color: 'red' })
+        commandExit(1)
+      }
+      if (diffResult.lines.length === 0) {
+        logger.log(`No diff found for PR/MR #${argv.pr}. Exiting...`)
+        commandExit(0)
+      }
+
+      return [diffResult.lines.join('\n')]
+    }
+
     if (argv.branch) {
       logger.verbose(`Generating diff for branch: ${argv.branch}`, { color: 'yellow' })
 
@@ -278,7 +326,7 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
         logger,
         tokenizer,
         metadata: {
-          task: argv.branch ? 'review-branch' : 'review',
+          task: argv.pr !== undefined ? 'review-pr' : argv.branch ? 'review-branch' : 'review',
           command: 'review',
           provider,
           model: String(model),
@@ -308,6 +356,22 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
   const severityThreshold = Number.isFinite(argv.severity) ? argv.severity : undefined
   const exceedsThreshold =
     severityThreshold !== undefined && findings.some((f) => f.severity >= severityThreshold)
+
+  // `--comment`: post the findings to the PR/MR (requires `--pr`, enforced by
+  // the builder's `.check()`). Findings meeting `--severity` request changes
+  // instead of a plain comment, mirroring the CI-gating semantics above.
+  if (argv.comment && argv.pr !== undefined && forge) {
+    const body = formatFindingsMarkdown(findings)
+    const postResult = exceedsThreshold
+      ? await forge.requestChangesPullRequestByNumber(argv.pr, body)
+      : await forge.commentPullRequestByNumber(argv.pr, body)
+
+    if (postResult.ok) {
+      logger.log(postResult.message, { color: 'green' })
+    } else {
+      logger.error(postResult.message, { color: 'red' })
+    }
+  }
 
   if (argv.json) {
     emitJson(findings)

--- a/src/commands/review/review.test.ts
+++ b/src/commands/review/review.test.ts
@@ -15,6 +15,8 @@ import { getLlm } from '../../lib/langchain/utils/getLlm'
 import { getTokenCounterForProvider } from '../../lib/utils/tokenizer'
 import { Logger } from '../../lib/utils/logger'
 import { TaskList } from '../../lib/ui/TaskList'
+import { getProviderOverview } from '../../git/providerData'
+import { getForgeActions } from '../../git/forgeActions'
 
 jest.mock('../../lib/simple-git/getRepo')
 jest.mock('../../lib/simple-git/getChanges')
@@ -29,6 +31,8 @@ jest.mock('../../lib/config/utils/loadConfig')
 jest.mock('../../lib/langchain/utils')
 jest.mock('../../lib/langchain/utils/getLlm')
 jest.mock('../../lib/utils/tokenizer')
+jest.mock('../../git/providerData')
+jest.mock('../../git/forgeActions')
 jest.mock('../../lib/ui/generateAndReviewLoop', () => ({
   generateAndReviewLoop: jest.fn().mockImplementation(async ({ factory, parser, agent, noResult, options }) => {
     const changes = await factory()
@@ -62,6 +66,8 @@ const mockGetLlm = getLlm as jest.MockedFunction<typeof getLlm>
 const mockGetTokenCounterForProvider = getTokenCounterForProvider as jest.MockedFunction<
   typeof getTokenCounterForProvider
 >
+const mockGetProviderOverview = getProviderOverview as jest.MockedFunction<typeof getProviderOverview>
+const mockGetForgeActions = getForgeActions as jest.MockedFunction<typeof getForgeActions>
 const MockTaskList = TaskList as unknown as jest.Mock
 
 describe('review command', () => {
@@ -299,6 +305,78 @@ describe('review command', () => {
         expect.anything()
       )
       expect(mockTaskListStart).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('--pr / --comment (#1596)', () => {
+    const mockGetPullRequestDiffByNumber = jest.fn()
+    const mockCommentPullRequestByNumber = jest.fn()
+    const mockRequestChangesPullRequestByNumber = jest.fn()
+
+    beforeEach(() => {
+      argv.json = true
+
+      mockGetProviderOverview.mockResolvedValue({
+        repository: { provider: 'github', remote: 'origin', owner: 'acme', name: 'widgets' },
+        authenticated: true,
+      } as unknown as Awaited<ReturnType<typeof getProviderOverview>>)
+
+      mockGetForgeActions.mockReturnValue({
+        getPullRequestDiffByNumber: mockGetPullRequestDiffByNumber,
+        commentPullRequestByNumber: mockCommentPullRequestByNumber,
+        requestChangesPullRequestByNumber: mockRequestChangesPullRequestByNumber,
+      } as unknown as ReturnType<typeof getForgeActions>)
+
+      mockGetPullRequestDiffByNumber.mockResolvedValue({
+        ok: true,
+        lines: ['diff --git a/file.ts b/file.ts', '+added line'],
+      })
+      mockCommentPullRequestByNumber.mockResolvedValue({ ok: true, message: 'Comment posted.' })
+      mockRequestChangesPullRequestByNumber.mockResolvedValue({ ok: true, message: 'Changes requested.' })
+    })
+
+    it('sources the review context from the PR diff instead of local changes', async () => {
+      argv.pr = 42
+
+      await handler(argv, logger)
+
+      expect(mockGetForgeActions).toHaveBeenCalledWith('github', expect.objectContaining({ gitlabPath: 'acme/widgets' }))
+      expect(mockGetPullRequestDiffByNumber).toHaveBeenCalledWith(42)
+      expect(mockGetChanges).not.toHaveBeenCalled()
+      expect(mockGetDiffForBranch).not.toHaveBeenCalled()
+
+      const variables = mockExecuteChain.mock.calls[0][0].variables as Record<string, string>
+      expect(variables.changes).toContain('+added line')
+    })
+
+    it('exits with the diff-fetch error when the PR diff cannot be retrieved', async () => {
+      argv.pr = 42
+      mockGetPullRequestDiffByNumber.mockResolvedValue({ ok: false, message: 'PR #42 not found.' })
+
+      await expect(handler(argv, logger)).rejects.toMatchObject({ code: 1 })
+      expect(logger.error).toHaveBeenCalledWith('PR #42 not found.', { color: 'red' })
+    })
+
+    it('posts a plain comment when findings stay below --severity', async () => {
+      argv.pr = 42
+      argv.comment = true
+      argv.severity = 8 // finding severity is 5 → below threshold
+
+      await handler(argv, logger)
+
+      expect(mockCommentPullRequestByNumber).toHaveBeenCalledWith(42, expect.stringContaining('Review finding'))
+      expect(mockRequestChangesPullRequestByNumber).not.toHaveBeenCalled()
+    })
+
+    it('requests changes instead of commenting when findings meet --severity', async () => {
+      argv.pr = 42
+      argv.comment = true
+      argv.severity = 4 // finding severity is 5 → meets threshold
+
+      await expect(handler(argv, logger)).rejects.toMatchObject({ code: 1 })
+
+      expect(mockRequestChangesPullRequestByNumber).toHaveBeenCalledWith(42, expect.stringContaining('Review finding'))
+      expect(mockCommentPullRequestByNumber).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
## What

Adds `coco review --pr <n>` to review an existing forge pull/merge request's diff instead of local changes, plus `--comment` to post the findings back to the PR/MR.

Closes #1596

## How

- Sources the review context from `ForgeActions.getPullRequestDiffByNumber(n)`'s unified diff instead of the working-tree diff pipeline.
- `--comment` (requires `--pr`) posts a plain comment normally, or `requestChangesPullRequestByNumber` when a finding meets `--severity` — reusing the existing CI-gating threshold.
- `--pr` cannot be combined with `--branch`/`--staged`, enforced in the builder's `.check()`.

## Validation

- [x] `npm test` passes locally (lint + jest + build + packaged-CLI smoke)
- [x] New behavior has tests (`review.test.ts`, `config.test.ts`)
- [x] `schema.json` regenerated — not needed, no config type changes
- [ ] Docs updated where relevant (README / `.wiki/`) — follow-up
- [x] Commits follow Conventional Commits

## Notes

`PullRequestDetail` has no `title`/`body` field today, so injecting PR title/body context into the review prompt is deliberately out of scope for this pass (matches the issue's own open question).
