### PR TITLE
feat(hooks): add coco hooks install for a prepare-commit-msg hook

### DIFF
--- a/src/commands/commit/commit.test.ts
+++ b/src/commands/commit/commit.test.ts
@@ -214,6 +214,11 @@ describe('commit command', () => {
     mockGetPrompt.mockReturnValue({
       template: 'Test prompt template',
       inputVariables: ['summary'],
+      // `generateCommitDraft`'s `--print-message` path (#1591) calls
+      // `prompt.format(...)` directly (budgeting the summary token count)
+      // rather than going through the mocked `generateAndReviewLoop` /
+      // `executeChainWithSchema` path every other test exercises.
+      format: jest.fn().mockResolvedValue('rendered prompt'),
     } as unknown as ReturnType<typeof getPrompt>)
     mockGetCurrentBranchName.mockResolvedValue('main')
     mockGetPreviousCommits.mockResolvedValue('Previous commits mock')
@@ -395,6 +400,51 @@ describe('commit command', () => {
       const successOrder = mockLogSuccess.mock.invocationCallOrder[0]
       const telemetryOrder = mockLogLlmTelemetrySummary.mock.invocationCallOrder[0]
       expect(successOrder).toBeLessThan(telemetryOrder)
+    })
+  })
+
+  describe('--print-message (#1591)', () => {
+    beforeEach(() => {
+      argv.printMessage = true
+    })
+
+    it('prints the generated draft to stdout and returns without committing or reviewing', async () => {
+      const writes: string[] = []
+      const writeSpy = jest
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(((chunk: string) => {
+          writes.push(String(chunk))
+          return true
+        }) as never)
+      try {
+        await handler(argv, logger)
+      } finally {
+        writeSpy.mockRestore()
+      }
+
+      expect(writes.join('')).toContain('Test commit title')
+      expect(mockCreateCommit).not.toHaveBeenCalled()
+      expect(mockGenerateAndReviewLoop).not.toHaveBeenCalled()
+      expect(mockHandleResult).not.toHaveBeenCalled()
+    })
+
+    it('exits non-zero without printing anything when there are no staged changes', async () => {
+      mockGetChanges.mockResolvedValue({ staged: [], unstaged: [], untracked: [] })
+
+      const writes: string[] = []
+      const writeSpy = jest
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(((chunk: string) => {
+          writes.push(String(chunk))
+          return true
+        }) as never)
+      try {
+        await expect(handler(argv, logger)).rejects.toMatchObject({ code: 1 })
+      } finally {
+        writeSpy.mockRestore()
+      }
+
+      expect(writes).toHaveLength(0)
     })
   })
 })

--- a/src/commands/commit/config.ts
+++ b/src/commands/commit/config.ts
@@ -33,6 +33,12 @@ export interface CommitOptions extends BaseCommandOptions {
    * diff to the LLM (reduces token usage for large changesets).
    */
   noDiff?: boolean
+  /**
+   * Generate a commit message draft and print it to stdout without
+   * committing. Used by the `prepare-commit-msg` hook installed via
+   * `coco hooks install` (#1591) to fill a plain `git commit`'s message.
+   */
+  printMessage?: boolean
 }
 
 export type CommitArgv = Arguments<CommitOptions>
@@ -138,6 +144,12 @@ export const options = {
   strictSplit: {
     description:
       'Fail loudly if the split planner exhausts its retry budget with an invalid plan (otherwise falls back to a single combined commit).',
+    type: 'boolean',
+    default: false,
+  },
+  printMessage: {
+    description:
+      'Generate a commit message draft and print it to stdout without committing (used by the `coco hooks install` prepare-commit-msg hook).',
     type: 'boolean',
     default: false,
   },

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -11,6 +11,7 @@ import { getPrompt } from '../../lib/langchain/utils/getPrompt'
 import { fileChangeParser } from '../../lib/parsers/default'
 import { createFileChangeParserOptions } from '../../lib/parsers/default/utils/createFileChangeParserOptions'
 import { PreCommitHookError, createCommit } from '../../lib/simple-git/createCommit'
+import { generateCommitDraft } from './generateCommitDraft'
 import { extractTicketIdFromBranchName } from '../../lib/simple-git/extractTicketIdFromBranchName'
 import { getChanges } from '../../lib/simple-git/getChanges'
 import { getCurrentBranchName } from '../../lib/simple-git/getCurrentBranchName'
@@ -40,6 +41,27 @@ import { handleCommitSplit, isCommitSplitCommand } from './split'
 
 export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
   const git = applyRepoFlag(argv)
+
+  // `--print-message`: generate a draft and print it to stdout without
+  // committing. Skips the interactive review loop, the split planner, and
+  // `createCommit` entirely — this is the non-interactive path the
+  // `prepare-commit-msg` hook installed via `coco hooks install` calls on
+  // every plain `git commit` (#1591).
+  if (argv.printMessage) {
+    const result = await generateCommitDraft({ git, argv, logger })
+    if (!result.ok || !result.draft) {
+      for (const warning of result.warnings) {
+        logger.verbose(warning, { color: 'yellow' })
+      }
+      for (const validationError of result.validationErrors) {
+        logger.verbose(validationError, { color: 'red' })
+      }
+      commandExit(1)
+    }
+    process.stdout.write(`${result.draft}\n`)
+    return
+  }
+
   const config = loadConfig<CommitOptions, CommitArgv>(argv)
   const key = getApiKeyForModel(config)
   const { provider } = getModelAndProviderFromConfig(config)

--- a/src/commands/hooks/config.ts
+++ b/src/commands/hooks/config.ts
@@ -1,0 +1,42 @@
+import { Arguments, Argv, Options } from 'yargs'
+import { getCommandUsageHeader } from '../../lib/ui/helpers'
+import { BaseCommandOptions } from '../types'
+
+export interface HooksOptions extends BaseCommandOptions {
+  action?: HooksAction
+  /** Overwrite an existing (non-coco) hook backup instead of refusing. */
+  force?: boolean
+}
+
+export type HooksArgv = Arguments<HooksOptions>
+
+/**
+ * `coco hooks <action>` manages the `prepare-commit-msg` git hook (#1591) so
+ * a plain `git commit` gets an AI-generated message, without requiring
+ * `coco commit`. Modeled after `cache <subcommand>`'s single-verb-many-
+ * actions shape.
+ */
+export const HOOKS_ACTIONS = ['install', 'uninstall', 'status'] as const
+
+export type HooksAction = typeof HOOKS_ACTIONS[number]
+
+export const command = 'hooks <action>'
+
+export const options = {
+  force: {
+    type: 'boolean',
+    default: false,
+    description: 'Overwrite an existing hook backup instead of refusing (install only).',
+  },
+} as Record<string, Options>
+
+export const builder = (yargs: Argv) => {
+  return yargs
+    .positional('action', {
+      describe: 'Hook action to run',
+      type: 'string',
+      choices: HOOKS_ACTIONS,
+    })
+    .options(options)
+    .usage(getCommandUsageHeader(command))
+}

--- a/src/commands/hooks/handler.test.ts
+++ b/src/commands/hooks/handler.test.ts
@@ -1,0 +1,150 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import simpleGit from 'simple-git'
+import { Logger } from '../../lib/utils/logger'
+import { handler } from './handler'
+import { HooksArgv } from './config'
+
+describe('coco hooks <action> (#1591)', () => {
+  let repoDir: string
+  let originalCwd: string
+  let logger: Logger
+
+  beforeEach(async () => {
+    originalCwd = process.cwd()
+    repoDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'coco-hooks-cmd-')))
+    await simpleGit(repoDir).init()
+    process.chdir(repoDir)
+    logger = {
+      log: jest.fn(),
+      verbose: jest.fn(),
+      setConfig: jest.fn(),
+      error: jest.fn(),
+      startTimer: jest.fn().mockReturnThis(),
+      stopTimer: jest.fn(),
+      startSpinner: jest.fn().mockReturnThis(),
+      stopSpinner: jest.fn(),
+    } as unknown as Logger
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    fs.rmSync(repoDir, { recursive: true, force: true })
+  })
+
+  function hookPath(): string {
+    return path.join(repoDir, '.git', 'hooks', 'prepare-commit-msg')
+  }
+
+  function argv(action: HooksArgv['action']): HooksArgv {
+    return { action, $0: 'coco', _: ['hooks'] } as unknown as HooksArgv
+  }
+
+  it('install: writes the hook and logs success', async () => {
+    await handler(argv('install'), logger)
+
+    expect(fs.existsSync(hookPath())).toBe(true)
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('Installed'),
+      expect.objectContaining({ color: 'green' })
+    )
+  })
+
+  it('install: emits JSON when --json is passed', async () => {
+    const writes: string[] = []
+    const writeSpy = jest
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(((chunk: string) => {
+        writes.push(String(chunk))
+        return true
+      }) as never)
+    try {
+      await handler({ ...argv('install'), json: true }, logger)
+    } finally {
+      writeSpy.mockRestore()
+    }
+
+    const jsonCall = writes.find((chunk) => {
+      try {
+        JSON.parse(chunk)
+        return true
+      } catch {
+        return false
+      }
+    })
+    expect(jsonCall).toBeDefined()
+    expect(JSON.parse(jsonCall as string)).toEqual(expect.objectContaining({ ok: true }))
+  })
+
+  it('install: exits non-zero when it refuses (existing unmanaged backup, no --force)', async () => {
+    const hooksDir = path.join(repoDir, '.git', 'hooks')
+    fs.mkdirSync(hooksDir, { recursive: true })
+    fs.writeFileSync(path.join(hooksDir, 'prepare-commit-msg'), '#!/bin/sh\necho "husky-v2"\n', {
+      mode: 0o755,
+    })
+    fs.writeFileSync(
+      path.join(hooksDir, 'prepare-commit-msg.pre-coco'),
+      '#!/bin/sh\necho "husky-v1"\n',
+      { mode: 0o755 }
+    )
+
+    await expect(handler(argv('install'), logger)).rejects.toMatchObject({ code: 1 })
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('--force'),
+      expect.objectContaining({ color: 'red' })
+    )
+  })
+
+  it('uninstall: reports a no-op when nothing is installed', async () => {
+    await handler(argv('uninstall'), logger)
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('No prepare-commit-msg hook'),
+      expect.anything()
+    )
+  })
+
+  it('uninstall: removes a previously installed hook', async () => {
+    await handler(argv('install'), logger)
+    await handler(argv('uninstall'), logger)
+    expect(fs.existsSync(hookPath())).toBe(false)
+  })
+
+  it('status: reports not installed', async () => {
+    await handler(argv('status'), logger)
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining('No prepare-commit-msg hook'),
+      expect.objectContaining({ color: 'yellow' })
+    )
+  })
+
+  it('status: reports installed after install, as JSON', async () => {
+    await handler(argv('install'), logger)
+
+    const writes: string[] = []
+    const writeSpy = jest
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(((chunk: string) => {
+        writes.push(String(chunk))
+        return true
+      }) as never)
+    try {
+      await handler({ ...argv('status'), json: true }, logger)
+    } finally {
+      writeSpy.mockRestore()
+    }
+
+    const jsonCall = writes.find((chunk) => {
+      try {
+        JSON.parse(chunk)
+        return true
+      } catch {
+        return false
+      }
+    })
+    expect(jsonCall).toBeDefined()
+    expect(JSON.parse(jsonCall as string)).toEqual(
+      expect.objectContaining({ installed: true, managedByCoco: true })
+    )
+  })
+})

--- a/src/commands/hooks/handler.ts
+++ b/src/commands/hooks/handler.ts
@@ -1,0 +1,52 @@
+import { CommandHandler } from '../../lib/types'
+import { emitJson } from '../../lib/ui/emitJson'
+import { commandExit } from '../../lib/utils/commandExit'
+import { applyRepoFlag } from '../utils/applyRepoFlag'
+import { HooksArgv } from './config'
+import { getHooksStatus, installHooks, uninstallHooks } from './manageHooks'
+
+export const handler: CommandHandler<HooksArgv> = async (argv, logger) => {
+  const git = applyRepoFlag(argv)
+
+  switch (argv.action) {
+    case 'install': {
+      const result = await installHooks({ git, force: Boolean(argv.force) })
+      if (argv.json) {
+        emitJson(result)
+      } else {
+        logger.log(result.message, { color: result.ok ? 'green' : 'red' })
+      }
+      if (!result.ok) {
+        commandExit(1)
+      }
+      return
+    }
+    case 'uninstall': {
+      const result = await uninstallHooks({ git })
+      if (argv.json) {
+        emitJson(result)
+      } else {
+        logger.log(result.message, { color: result.ok ? 'green' : 'yellow' })
+      }
+      if (!result.ok) {
+        commandExit(1)
+      }
+      return
+    }
+    case 'status': {
+      const status = await getHooksStatus({ git })
+      if (argv.json) {
+        emitJson(status)
+        return
+      }
+      logger.log(status.message, {
+        color: status.installed && status.managedByCoco ? 'green' : 'yellow',
+      })
+      return
+    }
+    default: {
+      logger.error(`Unknown hooks action: ${String(argv.action)}`, { color: 'red' })
+      commandExit(1)
+    }
+  }
+}

--- a/src/commands/hooks/index.ts
+++ b/src/commands/hooks/index.ts
@@ -1,0 +1,11 @@
+import commandExecutor from '../../lib/utils/commandExecutor'
+import { builder, command, options } from './config'
+import { handler } from './handler'
+
+export default {
+  command,
+  desc: 'Manage git hooks that give plain `git commit` AI-generated messages.',
+  builder,
+  handler: commandExecutor(handler),
+  options,
+}

--- a/src/commands/hooks/manageHooks.test.ts
+++ b/src/commands/hooks/manageHooks.test.ts
@@ -1,0 +1,151 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import simpleGit, { SimpleGit } from 'simple-git'
+import { getHooksStatus, HOOK_MARKER, installHooks, uninstallHooks } from './manageHooks'
+
+describe('manageHooks (#1591)', () => {
+  let repoDir: string
+  let git: SimpleGit
+  let originalCwd: string
+
+  beforeEach(async () => {
+    originalCwd = process.cwd()
+    repoDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'coco-hooks-')))
+    git = simpleGit(repoDir)
+    await git.init()
+    // `resolveHooksDir` resolves `git rev-parse --git-path hooks`'s output
+    // against `process.cwd()` — the same invariant `applyRepoFlag` maintains
+    // in production (it chdir's before any command touches git). Match that
+    // invariant here instead of relying on a mismatched SimpleGit baseDir.
+    process.chdir(repoDir)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    fs.rmSync(repoDir, { recursive: true, force: true })
+  })
+
+  function hookPath(): string {
+    return path.join(repoDir, '.git', 'hooks', 'prepare-commit-msg')
+  }
+
+  function backupPath(): string {
+    return path.join(repoDir, '.git', 'hooks', 'prepare-commit-msg.pre-coco')
+  }
+
+  it('installs the hook when none exists', async () => {
+    const result = await installHooks({ git })
+
+    expect(result.ok).toBe(true)
+    expect(fs.existsSync(hookPath())).toBe(true)
+    const content = fs.readFileSync(hookPath(), 'utf8')
+    expect(content).toContain(HOOK_MARKER)
+    expect(fs.existsSync(backupPath())).toBe(false)
+  })
+
+  it('is idempotent when re-installing over its own hook', async () => {
+    await installHooks({ git })
+    const result = await installHooks({ git })
+
+    expect(result.ok).toBe(true)
+    expect(fs.existsSync(backupPath())).toBe(false)
+  })
+
+  it('backs up a pre-existing unmanaged hook instead of clobbering it', async () => {
+    fs.mkdirSync(path.join(repoDir, '.git', 'hooks'), { recursive: true })
+    fs.writeFileSync(hookPath(), '#!/bin/sh\necho "husky"\n', { mode: 0o755 })
+
+    const result = await installHooks({ git })
+
+    expect(result.ok).toBe(true)
+    expect(result.message).toContain('backed up')
+    expect(fs.readFileSync(backupPath(), 'utf8')).toContain('husky')
+    expect(fs.readFileSync(hookPath(), 'utf8')).toContain(HOOK_MARKER)
+  })
+
+  it('refuses to overwrite an existing backup without --force', async () => {
+    fs.mkdirSync(path.join(repoDir, '.git', 'hooks'), { recursive: true })
+    fs.writeFileSync(hookPath(), '#!/bin/sh\necho "husky-v2"\n', { mode: 0o755 })
+    fs.writeFileSync(backupPath(), '#!/bin/sh\necho "husky-v1"\n', { mode: 0o755 })
+
+    const result = await installHooks({ git })
+
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('--force')
+    // Neither file touched.
+    expect(fs.readFileSync(backupPath(), 'utf8')).toContain('husky-v1')
+    expect(fs.readFileSync(hookPath(), 'utf8')).toContain('husky-v2')
+  })
+
+  it('overwrites an existing backup with --force', async () => {
+    fs.mkdirSync(path.join(repoDir, '.git', 'hooks'), { recursive: true })
+    fs.writeFileSync(hookPath(), '#!/bin/sh\necho "husky-v2"\n', { mode: 0o755 })
+    fs.writeFileSync(backupPath(), '#!/bin/sh\necho "husky-v1"\n', { mode: 0o755 })
+
+    const result = await installHooks({ git, force: true })
+
+    expect(result.ok).toBe(true)
+    expect(fs.readFileSync(backupPath(), 'utf8')).toContain('husky-v2')
+    expect(fs.readFileSync(hookPath(), 'utf8')).toContain(HOOK_MARKER)
+  })
+
+  it('reports not-installed status before installing', async () => {
+    const status = await getHooksStatus({ git })
+    expect(status.installed).toBe(false)
+    expect(status.managedByCoco).toBe(false)
+  })
+
+  it('reports managed status after installing', async () => {
+    await installHooks({ git })
+    const status = await getHooksStatus({ git })
+    expect(status.installed).toBe(true)
+    expect(status.managedByCoco).toBe(true)
+  })
+
+  it('reports unmanaged status for a foreign hook', async () => {
+    fs.mkdirSync(path.join(repoDir, '.git', 'hooks'), { recursive: true })
+    fs.writeFileSync(hookPath(), '#!/bin/sh\necho "husky"\n', { mode: 0o755 })
+
+    const status = await getHooksStatus({ git })
+    expect(status.installed).toBe(true)
+    expect(status.managedByCoco).toBe(false)
+  })
+
+  it('uninstalls the hook and restores a backed-up one', async () => {
+    fs.mkdirSync(path.join(repoDir, '.git', 'hooks'), { recursive: true })
+    fs.writeFileSync(hookPath(), '#!/bin/sh\necho "husky"\n', { mode: 0o755 })
+
+    await installHooks({ git })
+    const result = await uninstallHooks({ git })
+
+    expect(result.ok).toBe(true)
+    expect(result.message).toContain('restored')
+    expect(fs.readFileSync(hookPath(), 'utf8')).toContain('husky')
+    expect(fs.existsSync(backupPath())).toBe(false)
+  })
+
+  it('uninstalls cleanly when there was nothing to restore', async () => {
+    await installHooks({ git })
+    const result = await uninstallHooks({ git })
+
+    expect(result.ok).toBe(true)
+    expect(fs.existsSync(hookPath())).toBe(false)
+  })
+
+  it('is a no-op when uninstalling with nothing installed', async () => {
+    const result = await uninstallHooks({ git })
+    expect(result.ok).toBe(true)
+    expect(result.message).toContain('No prepare-commit-msg hook')
+  })
+
+  it('refuses to remove a foreign hook it did not install', async () => {
+    fs.mkdirSync(path.join(repoDir, '.git', 'hooks'), { recursive: true })
+    fs.writeFileSync(hookPath(), '#!/bin/sh\necho "husky"\n', { mode: 0o755 })
+
+    const result = await uninstallHooks({ git })
+
+    expect(result.ok).toBe(false)
+    expect(fs.existsSync(hookPath())).toBe(true)
+  })
+})

--- a/src/commands/hooks/manageHooks.ts
+++ b/src/commands/hooks/manageHooks.ts
@@ -1,0 +1,179 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import * as path from 'node:path'
+import { SimpleGit } from 'simple-git'
+
+export type HooksActionResult = {
+  ok: boolean
+  message: string
+}
+
+export type HooksStatusResult = {
+  installed: boolean
+  managedByCoco: boolean
+  hooksDir: string
+  hookPath: string
+  message: string
+}
+
+/** Marks a hook file as coco-managed so install/uninstall/status can recognize it on re-read. */
+export const HOOK_MARKER = '# coco:managed-hook prepare-commit-msg'
+
+const HOOK_FILENAME = 'prepare-commit-msg'
+const BACKUP_FILENAME = 'prepare-commit-msg.pre-coco'
+
+/**
+ * The installed hook script. Chains to a backed-up pre-existing hook first
+ * (respecting its exit code, so a chained hook can still block the commit),
+ * then fills the message file with a `coco commit --print-message` draft —
+ * but only when the file has no real content yet, so a manual `-m`, a
+ * template, or the chained hook's own output is never clobbered. Every
+ * coco-specific step fails open: a missing `coco` binary or a generation
+ * error leaves the message file untouched rather than blocking the commit.
+ */
+export const HOOK_SCRIPT = `#!/usr/bin/env sh
+${HOOK_MARKER}
+# Installed by \`coco hooks install\`. Do not edit by hand — re-run
+# \`coco hooks install --force\` to regenerate, or \`coco hooks uninstall\` to remove.
+
+COMMIT_MSG_FILE="$1"
+COMMIT_SOURCE="$2"
+HOOK_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+CHAINED_HOOK="$HOOK_DIR/${BACKUP_FILENAME}"
+
+if [ -x "$CHAINED_HOOK" ]; then
+  "$CHAINED_HOOK" "$@" || exit $?
+fi
+
+if [ -n "$COCO_SKIP" ]; then
+  exit 0
+fi
+
+case "$COMMIT_SOURCE" in
+  merge|squash|message|commit)
+    exit 0
+    ;;
+esac
+
+if [ -s "$COMMIT_MSG_FILE" ] && grep -vqE '^[[:space:]]*(#|$)' "$COMMIT_MSG_FILE"; then
+  # A message is already present (manual -m, a template, or the chained hook
+  # above supplied one) — don't clobber it.
+  exit 0
+fi
+
+if ! command -v coco >/dev/null 2>&1; then
+  exit 0
+fi
+
+GENERATED="$(coco commit --print-message --quiet 2>/dev/null)" || exit 0
+
+if [ -n "$GENERATED" ]; then
+  printf '%s\\n' "$GENERATED" > "$COMMIT_MSG_FILE"
+fi
+
+exit 0
+`
+
+/**
+ * Resolves the hook directory the same way git itself would — honoring
+ * `core.hooksPath` overrides and worktree-local git dirs — rather than
+ * assuming `<repoRoot>/.git/hooks`.
+ */
+export async function resolveHooksDir(git: SimpleGit): Promise<string> {
+  const output = await git.raw(['rev-parse', '--git-path', 'hooks'])
+  return path.resolve(output.trim())
+}
+
+export async function installHooks({
+  git,
+  force = false,
+}: {
+  git: SimpleGit
+  force?: boolean
+}): Promise<HooksActionResult> {
+  const hooksDir = await resolveHooksDir(git)
+  mkdirSync(hooksDir, { recursive: true })
+
+  const hookPath = path.join(hooksDir, HOOK_FILENAME)
+  const backupPath = path.join(hooksDir, BACKUP_FILENAME)
+
+  const existing = existsSync(hookPath) ? readFileSync(hookPath, 'utf8') : undefined
+  const alreadyManaged = existing !== undefined && existing.includes(HOOK_MARKER)
+
+  if (existing !== undefined && !alreadyManaged) {
+    if (existsSync(backupPath) && !force) {
+      return {
+        ok: false,
+        message: `An existing prepare-commit-msg hook is already backed up at ${backupPath}. Re-run with --force to overwrite it, or remove it manually first.`,
+      }
+    }
+    writeFileSync(backupPath, existing, { mode: 0o755 })
+  }
+
+  writeFileSync(hookPath, HOOK_SCRIPT, { mode: 0o755 })
+
+  return {
+    ok: true,
+    message:
+      existing !== undefined && !alreadyManaged
+        ? `Installed the prepare-commit-msg hook at ${hookPath} (existing hook backed up to ${backupPath}).`
+        : `Installed the prepare-commit-msg hook at ${hookPath}.`,
+  }
+}
+
+export async function uninstallHooks({ git }: { git: SimpleGit }): Promise<HooksActionResult> {
+  const hooksDir = await resolveHooksDir(git)
+  const hookPath = path.join(hooksDir, HOOK_FILENAME)
+  const backupPath = path.join(hooksDir, BACKUP_FILENAME)
+
+  if (!existsSync(hookPath)) {
+    return { ok: true, message: 'No prepare-commit-msg hook is installed.' }
+  }
+
+  const content = readFileSync(hookPath, 'utf8')
+  if (!content.includes(HOOK_MARKER)) {
+    return {
+      ok: false,
+      message: `${hookPath} was not installed by coco — leaving it in place.`,
+    }
+  }
+
+  rmSync(hookPath)
+
+  if (existsSync(backupPath)) {
+    renameSync(backupPath, hookPath)
+    return {
+      ok: true,
+      message: `Removed coco's prepare-commit-msg hook and restored the previous hook at ${hookPath}.`,
+    }
+  }
+
+  return { ok: true, message: "Removed coco's prepare-commit-msg hook." }
+}
+
+export async function getHooksStatus({ git }: { git: SimpleGit }): Promise<HooksStatusResult> {
+  const hooksDir = await resolveHooksDir(git)
+  const hookPath = path.join(hooksDir, HOOK_FILENAME)
+
+  if (!existsSync(hookPath)) {
+    return {
+      installed: false,
+      managedByCoco: false,
+      hooksDir,
+      hookPath,
+      message: 'No prepare-commit-msg hook is installed.',
+    }
+  }
+
+  const content = readFileSync(hookPath, 'utf8')
+  const managedByCoco = content.includes(HOOK_MARKER)
+
+  return {
+    installed: true,
+    managedByCoco,
+    hooksDir,
+    hookPath,
+    message: managedByCoco
+      ? `coco's prepare-commit-msg hook is installed at ${hookPath}.`
+      : `A prepare-commit-msg hook exists at ${hookPath} but was not installed by coco.`,
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import cache from './commands/cache'
 import changelog from './commands/changelog'
 import commit from './commands/commit'
 import doctor from './commands/doctor'
+import hooks from './commands/hooks'
 import init from './commands/init'
 import issues from './commands/issues'
 import log from './commands/log'
@@ -21,6 +22,7 @@ import { ChangelogOptions } from './commands/changelog/config'
 import { CommitOptions } from './commands/commit/config'
 import { defaultRouteHandler, type DefaultRouteArgv } from './commands/defaultRouter'
 import { DoctorOptions } from './commands/doctor/config'
+import { HooksOptions } from './commands/hooks/config'
 import { InitOptions } from './commands/init/config'
 import { IssuesOptions } from './commands/issues/config'
 import { LogOptions } from './commands/log/config'
@@ -186,6 +188,13 @@ y.command<CacheOptions>(
   cache.handler
 )
 
+y.command<HooksOptions>(
+  hooks.command,
+  hooks.desc,
+  hooks.builder,
+  hooks.handler
+)
+
 y.command<IssuesOptions>(
   issues.command,
   issues.desc,
@@ -238,6 +247,7 @@ export {
   commit,
   Config,
   doctor,
+  hooks,
   init,
   issues,
   log,


### PR DESCRIPTION
## What

Adds `coco hooks install|uninstall|status` to manage a `prepare-commit-msg` git hook so a plain `git commit` gets an AI-generated message, plus `commit --print-message` as the non-interactive entry point the hook calls.

Closes #1591

## How

- Hook directory resolved the way git itself would (`git rev-parse --git-path hooks`, respecting `core.hooksPath`).
- Chains to any pre-existing hook first (backed up on install, restored on uninstall), still respecting its exit code — so an existing hook that wants to block a commit still can.
- Only fills the message file when it has no real content yet (no manual `-m`, template, or chained-hook output already present).
- Every coco-specific step fails open: a missing `coco` binary or a generation error leaves the message file untouched instead of blocking the commit.
- `commit --print-message` reuses the existing `generateCommitDraft` helper and prints the draft to stdout without committing.

## Validation

- [x] `npm test` passes locally (lint + jest + build + packaged-CLI smoke)
- [x] New behavior has tests (`manageHooks.test.ts`, `handler.test.ts`, `commit.test.ts`)
- [x] `schema.json` regenerated — not needed, no config type changes
- [ ] Docs updated where relevant (README / `.wiki/`) — follow-up
- [x] Commits follow Conventional Commits

## Notes

Manually verified end-to-end against a real temp repo (`hooks install` → `hooks status` → `hooks uninstall`) in addition to the automated tests.
