### PR TITLE
feat(i18n): add --language / locale config option

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -98,6 +98,11 @@
           "description": "Whether to include the current branch name in the commit prompt for context. When enabled, the current git branch name will be included in the prompt.",
           "default": true
         },
+        "language": {
+          "type": "string",
+          "description": "Language for AI-generated output (commit messages, changelogs, recaps, reviews) — free text, e.g. `'German'` or `'es'`. Conventional Commits type/scope tokens (`feat`, `fix(parser)`, ...) always stay in English; only the description/body localizes. Unset generates in English, the existing default.",
+          "default": "undefined"
+        },
         "autoFixTool": {
           "type": "string",
           "description": "The AI CLI tool to use for auto-fixing review issues. Must match a registered adapter key (e.g. \"codex\", \"claude\", \"gemini\"). When unset, the auto-fix action is disabled."

--- a/src/commands/changelog/changelog.test.ts
+++ b/src/commands/changelog/changelog.test.ts
@@ -202,6 +202,55 @@ describe('changelog command', () => {
     expect(writes.map((w) => w.trim())).toContain('null')
   })
 
+  describe('language_context (#1614)', () => {
+    it('is empty when no language is configured', async () => {
+      await handler(argv, logger)
+      const call = mockExecuteChain.mock.calls[0][0] as { variables: Record<string, string> }
+      expect(call.variables.language_context).toBe('')
+    })
+
+    it('builds an instruction from the configured language', async () => {
+      mockLoadConfig.mockReturnValue({
+        service: {
+          authentication: { type: 'APIKey', credentials: { apiKey: 'mock-api-key' } },
+          provider: 'openai',
+          model: 'gpt-4o',
+          tokenLimit: 4096,
+          temperature: 0.2,
+          maxConcurrent: 1,
+        },
+        defaultBranch: 'main',
+        mode: 'stdout',
+        language: 'German',
+      } as unknown as Config)
+
+      await handler(argv, logger)
+      const call = mockExecuteChain.mock.calls[0][0] as { variables: Record<string, string> }
+      expect(call.variables.language_context).toBe('Write the changelog in German.')
+    })
+
+    it('honors a per-invocation --language flag over the configured language', async () => {
+      ;(argv as unknown as { language?: string }).language = 'French'
+      mockLoadConfig.mockReturnValue({
+        service: {
+          authentication: { type: 'APIKey', credentials: { apiKey: 'mock-api-key' } },
+          provider: 'openai',
+          model: 'gpt-4o',
+          tokenLimit: 4096,
+          temperature: 0.2,
+          maxConcurrent: 1,
+        },
+        defaultBranch: 'main',
+        mode: 'stdout',
+        language: 'German',
+      } as unknown as Config)
+
+      await handler(argv, logger)
+      const call = mockExecuteChain.mock.calls[0][0] as { variables: Record<string, string> }
+      expect(call.variables.language_context).toBe('Write the changelog in French.')
+    })
+  })
+
   describe('--range (#1590)', () => {
     beforeEach(() => {
       mockGetCommitLogRangeDetails.mockResolvedValue([

--- a/src/commands/changelog/config.ts
+++ b/src/commands/changelog/config.ts
@@ -12,6 +12,8 @@ export interface ChangelogOptions extends BaseCommandOptions {
   additional?: string
   author?: boolean
   json?: boolean
+  /** Overrides the configured `language` for this invocation only. */
+  language?: string
 }
 
 export type ChangelogArgv = Arguments<ChangelogOptions>
@@ -73,6 +75,10 @@ export const options = {
     type: 'boolean',
     alias: 'interactive',
     description: 'Toggle interactive mode',
+  },
+  language: {
+    type: 'string',
+    description: 'Write the changelog in this language, overriding the configured `language`.',
   },
   // `--json` is a global flag (see src/index.ts).
 } as Record<string, Options>

--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -36,6 +36,7 @@ import {
     ChangelogResponseSchema,
 } from './config'
 import { CHANGELOG_PROMPT } from './prompt'
+import { getLanguageContext } from '../../lib/langchain/utils/languageContext'
 
 type CommitDetailsWithDiffText = CommitDetails & { diffText?: string };
 
@@ -304,6 +305,7 @@ export async function generateChangelogResult(
         format_instructions: formatInstructions,
         additional_context: additional_context,
         author_instructions: author_instructions,
+        language_context: getLanguageContext(argv.language || config.language, { taskDescription: 'changelog' }),
       }
 
       const budgetedPrompt = await enforcePromptBudget({

--- a/src/commands/changelog/prompt.ts
+++ b/src/commands/changelog/prompt.ts
@@ -22,6 +22,8 @@ You will be provided with a summary of changes. This summary can be one of the f
 ## Formatting Instructions
 {{format_instructions}}
 
+{{language_context}}
+
 {{additional_context}}
 
 """{{summary}}"""`
@@ -31,6 +33,7 @@ export const inputVariables = [
   'summary',
   'additional_context',
   'author_instructions',
+  'language_context',
 ]
 
 export const CHANGELOG_PROMPT = new PromptTemplate({

--- a/src/commands/commit/commit.test.ts
+++ b/src/commands/commit/commit.test.ts
@@ -32,6 +32,7 @@ jest.mock('../../lib/utils/commitlintValidator', () => ({
     warnings: [],
   }),
   getCommitlintRulesContext: jest.fn().mockResolvedValue(''),
+  checkCommitlintAvailability: jest.fn().mockReturnValue({ available: true, missingPackages: [] }),
 }))
 
 jest.mock('../../lib/simple-git/getRepo')
@@ -344,6 +345,73 @@ describe('commit command', () => {
 
     const variables = mockExecuteChainWithSchema.mock.calls[0][3] as Record<string, string>
     expect(variables.branch_name_context).toBe('')
+  })
+
+  describe('language_context (#1614)', () => {
+    it('is empty when no language is configured', async () => {
+      await handler(argv, logger)
+      const variables = mockExecuteChainWithSchema.mock.calls[0][3] as Record<string, string>
+      expect(variables.language_context).toBe('')
+    })
+
+    it('builds an instruction from the configured language', async () => {
+      mockLoadConfig.mockReturnValue({
+        service: { authentication: { type: 'apiKey' }, provider: 'openai', model: 'gpt-4o' },
+        hideCocoBanner: false,
+        noDiff: false,
+        ignoredFiles: [],
+        ignoredExtensions: [],
+        includeBranchName: true,
+        conventionalCommits: false,
+        openInEditor: false,
+        mode: 'stdout',
+        language: 'German',
+      } as unknown as Config)
+
+      await handler(argv, logger)
+      const variables = mockExecuteChainWithSchema.mock.calls[0][3] as Record<string, string>
+      expect(variables.language_context).toBe('Write the commit message in German.')
+    })
+
+    it('preserves Conventional Commits tokens when conventionalCommits is enabled', async () => {
+      argv.conventional = true
+      mockLoadConfig.mockReturnValue({
+        service: { authentication: { type: 'apiKey' }, provider: 'openai', model: 'gpt-4o' },
+        hideCocoBanner: false,
+        noDiff: false,
+        ignoredFiles: [],
+        ignoredExtensions: [],
+        includeBranchName: true,
+        conventionalCommits: true,
+        openInEditor: false,
+        mode: 'stdout',
+        language: 'German',
+      } as unknown as Config)
+
+      await handler(argv, logger)
+      const variables = mockExecuteChainWithSchema.mock.calls[0][3] as Record<string, string>
+      expect(variables.language_context).toContain('Keep the Conventional Commits type/scope tokens')
+    })
+
+    it('honors a per-invocation --language flag over the configured language', async () => {
+      ;(argv as unknown as { language?: string }).language = 'French'
+      mockLoadConfig.mockReturnValue({
+        service: { authentication: { type: 'apiKey' }, provider: 'openai', model: 'gpt-4o' },
+        hideCocoBanner: false,
+        noDiff: false,
+        ignoredFiles: [],
+        ignoredExtensions: [],
+        includeBranchName: true,
+        conventionalCommits: false,
+        openInEditor: false,
+        mode: 'stdout',
+        language: 'German',
+      } as unknown as Config)
+
+      await handler(argv, logger)
+      const variables = mockExecuteChainWithSchema.mock.calls[0][3] as Record<string, string>
+      expect(variables.language_context).toBe('Write the commit message in French.')
+    })
   })
 
   describe('interactive commit flow (awaited handleResult)', () => {

--- a/src/commands/commit/config.ts
+++ b/src/commands/commit/config.ts
@@ -33,6 +33,8 @@ export interface CommitOptions extends BaseCommandOptions {
    * diff to the LLM (reduces token usage for large changesets).
    */
   noDiff?: boolean
+  /** Overrides the configured `language` for this invocation only. */
+  language?: string
 }
 
 export type CommitArgv = Arguments<CommitOptions>
@@ -119,6 +121,10 @@ export const options = {
     type: 'boolean',
     default: false,
     alias: 'n',
+  },
+  language: {
+    description: 'Write the commit message in this language, overriding the configured `language`.',
+    type: 'string',
   },
   split: {
     description: 'Group staged changes into multiple commits — shows the plan and prompts to apply',

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -8,6 +8,7 @@ import { getLlm } from '../../lib/langchain/utils/getLlm'
 import { resolveDynamicService } from '../../lib/langchain/utils/dynamicModels'
 import { logLlmTelemetrySummary } from '../../lib/langchain/utils/observability'
 import { getPrompt } from '../../lib/langchain/utils/getPrompt'
+import { getLanguageContext } from '../../lib/langchain/utils/languageContext'
 import { fileChangeParser } from '../../lib/parsers/default'
 import { createFileChangeParserOptions } from '../../lib/parsers/default/utils/createFileChangeParserOptions'
 import { PreCommitHookError, createCommit } from '../../lib/simple-git/createCommit'
@@ -293,6 +294,10 @@ IMPORTANT RULES:
         commit_history: commit_history,
         branch_name_context: branchNameContext,
         commitlint_rules_context: commitlint_rules_context,
+        language_context: getLanguageContext(argv.language || config.language, {
+          taskDescription: 'commit message',
+          preserveConventionalTokens: USE_CONVENTIONAL_COMMITS,
+        }),
       }
 
       const maxAttempts =

--- a/src/commands/commit/prompt.ts
+++ b/src/commands/commit/prompt.ts
@@ -9,6 +9,7 @@ import { PromptTemplate } from '@langchain/core/prompts'
  * - additional_context: Optional user-provided context to guide the commit message generation
  * - commit_history: Optional history of previous commits for context
  * - branch_name_context: String containing formatted branch name (or empty if disabled)
+ * - language_context: Optional instruction to write the message in a configured language (empty if unset)
  */
 export const template = `Write informative git commit message, in the imperative, based on the diffs & file changes provided in the "Diff Summary" section.
 Commit Messages must have a short description that is less than 50 characters and a longer detailed summary around 300 characters, the shorter and more concise the better.
@@ -29,6 +30,8 @@ Please follow the guidelines below when writing your commit message:
 
 {{commitlint_rules_context}}
 
+{{language_context}}
+
 {{format_instructions}}
 
 {{commit_history}}
@@ -37,7 +40,7 @@ Please follow the guidelines below when writing your commit message:
 `
 
 // Define the variables that will be passed to the prompt template
-const inputVariables = ['summary', 'format_instructions', 'additional_context', 'commit_history', 'branch_name_context', 'commitlint_rules_context']
+const inputVariables = ['summary', 'format_instructions', 'additional_context', 'commit_history', 'branch_name_context', 'commitlint_rules_context', 'language_context']
 
 export const COMMIT_PROMPT = new PromptTemplate({
   template,
@@ -85,6 +88,8 @@ Based on the following diff summary, generate a conventional commit message that
 
 {{commitlint_rules_context}}
 
+{{language_context}}
+
 {{format_instructions}}
 
 {{commit_history}}
@@ -98,6 +103,7 @@ const conventionalInputVariables = [
   'format_instructions',
   'branch_name_context',
   'commitlint_rules_context',
+  'language_context',
 ]
 
 export const CONVENTIONAL_COMMIT_PROMPT = new PromptTemplate({

--- a/src/commands/recap/config.ts
+++ b/src/commands/recap/config.ts
@@ -11,6 +11,8 @@ export interface RecapOptions extends BaseCommandOptions {
   currentBranch?: boolean
   timeframe?: 'current' | 'yesterday' | 'last-week' | 'last-month' | 'last-tag' | 'currentBranch'
   json?: boolean
+  /** Overrides the configured `language` for this invocation only. */
+  language?: string
 }
 
 export type RecapArgv = Arguments<RecapOptions>
@@ -64,6 +66,10 @@ export const options = {
     type: 'boolean',
     alias: 'interactive',
     description: 'Toggle interactive mode',
+  },
+  language: {
+    type: 'string',
+    description: 'Write the recap in this language, overriding the configured `language`.',
   },
   // `--json` is a global flag (see src/index.ts).
 } as Record<string, Options>

--- a/src/commands/recap/handler.ts
+++ b/src/commands/recap/handler.ts
@@ -8,6 +8,7 @@ import { getLlm } from '../../lib/langchain/utils/getLlm'
 import { resolveDynamicService } from '../../lib/langchain/utils/dynamicModels'
 import { logLlmTelemetrySummary } from '../../lib/langchain/utils/observability'
 import { getPrompt } from '../../lib/langchain/utils/getPrompt'
+import { getLanguageContext } from '../../lib/langchain/utils/languageContext'
 import { getChanges } from '../../lib/simple-git/getChanges'
 import { getChangesByTimestamp } from '../../lib/simple-git/getChangesByTimestamp'
 import { getChangesSinceLastTag } from '../../lib/simple-git/getChangesSinceLastTag'
@@ -239,6 +240,7 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
           changes: context,
           format_instructions: formatInstructions,
           timeframe,
+          language_context: getLanguageContext(argv.language || config.language, { taskDescription: 'summary' }),
         }
         const budgetedPrompt = await enforcePromptBudget({
           prompt,

--- a/src/commands/recap/prompt.ts
+++ b/src/commands/recap/prompt.ts
@@ -9,9 +9,11 @@ Breaking down the changes into categories (e.g. bug fixes, new features, etc.) w
 
 {{format_instructions}}
 
+{{language_context}}
+
 """{{changes}}"""`
 
-export const inputVariables = ['timeframe', 'format_instructions', 'changes']
+export const inputVariables = ['timeframe', 'format_instructions', 'changes', 'language_context']
 
 export const RECAP_PROMPT = new PromptTemplate({
   template,

--- a/src/commands/recap/recap.test.ts
+++ b/src/commands/recap/recap.test.ts
@@ -144,6 +144,57 @@ describe('recap command', () => {
     expect(mockGetChanges).toHaveBeenCalled()
   })
 
+  describe('language_context (#1614)', () => {
+    it('is empty when no language is configured', async () => {
+      await handler(argv, logger)
+      const call = mockExecuteChain.mock.calls[0][0] as { variables: Record<string, string> }
+      expect(call.variables.language_context).toBe('')
+    })
+
+    it('builds an instruction from the configured language', async () => {
+      mockLoadConfig.mockReturnValue({
+        service: {
+          authentication: { type: 'APIKey', credentials: { apiKey: 'mock-api-key' } },
+          provider: 'openai',
+          model: 'gpt-4o',
+          tokenLimit: 4096,
+          temperature: 0.2,
+          maxConcurrent: 1,
+        },
+        defaultBranch: 'main',
+        mode: 'stdout',
+        currentBranch: false,
+        language: 'German',
+      } as unknown as Config)
+
+      await handler(argv, logger)
+      const call = mockExecuteChain.mock.calls[0][0] as { variables: Record<string, string> }
+      expect(call.variables.language_context).toBe('Write the summary in German.')
+    })
+
+    it('honors a per-invocation --language flag over the configured language', async () => {
+      ;(argv as unknown as { language?: string }).language = 'French'
+      mockLoadConfig.mockReturnValue({
+        service: {
+          authentication: { type: 'APIKey', credentials: { apiKey: 'mock-api-key' } },
+          provider: 'openai',
+          model: 'gpt-4o',
+          tokenLimit: 4096,
+          temperature: 0.2,
+          maxConcurrent: 1,
+        },
+        defaultBranch: 'main',
+        mode: 'stdout',
+        currentBranch: false,
+        language: 'German',
+      } as unknown as Config)
+
+      await handler(argv, logger)
+      const call = mockExecuteChain.mock.calls[0][0] as { variables: Record<string, string> }
+      expect(call.variables.language_context).toBe('Write the summary in French.')
+    })
+  })
+
   it('should call getChangesByTimestamp for yesterday', async () => {
     argv.yesterday = true
     await handler(argv, logger)

--- a/src/commands/review/config.ts
+++ b/src/commands/review/config.ts
@@ -9,6 +9,8 @@ export interface ReviewOptions extends BaseCommandOptions {
   json?: boolean
   staged?: boolean
   severity?: number
+  /** Overrides the configured `language` for this invocation only. */
+  language?: string
 }
 
 export type ReviewArgv = Arguments<ReviewOptions>
@@ -62,6 +64,10 @@ export const options = {
     type: 'number',
     alias: 's',
     description: 'Exit non-zero if any finding has severity >= this threshold (1-10). For CI gating.',
+  },
+  language: {
+    type: 'string',
+    description: 'Write review feedback in this language, overriding the configured `language`.',
   },
 } as Record<string, Options>
 

--- a/src/commands/review/handler.ts
+++ b/src/commands/review/handler.ts
@@ -9,6 +9,7 @@ import { enforcePromptBudget } from '../../lib/langchain/utils/enforcePromptBudg
 import { logLlmTelemetrySummary } from '../../lib/langchain/utils/observability'
 import { getLlm } from '../../lib/langchain/utils/getLlm'
 import { getPrompt } from '../../lib/langchain/utils/getPrompt'
+import { getLanguageContext } from '../../lib/langchain/utils/languageContext'
 import { fileChangeParser } from '../../lib/parsers/default/index'
 import { createFileChangeParserOptions } from '../../lib/parsers/default/utils/createFileChangeParserOptions'
 import { getChanges } from '../../lib/simple-git/getChanges'
@@ -254,6 +255,7 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
       const variables = {
         changes: context,
         format_instructions: formatInstructions,
+        language_context: getLanguageContext(argv.language || config.language, { taskDescription: 'code review feedback' }),
       }
       const budgetedPrompt = await enforcePromptBudget({
         prompt,

--- a/src/commands/review/prompt.ts
+++ b/src/commands/review/prompt.ts
@@ -14,11 +14,13 @@ export const template = `As an experienced software engineer, you are tasked wit
 
 {{format_instructions}}
 
+{{language_context}}
+
 Following the formatting instructions, perform a code review on the following changes
 
 """{{changes}}"""`
 
-export const inputVariables = ['format_instructions', 'changes']
+export const inputVariables = ['format_instructions', 'changes', 'language_context']
 
 export const REVIEW_PROMPT = new PromptTemplate({
   template,

--- a/src/commands/review/review.test.ts
+++ b/src/commands/review/review.test.ts
@@ -250,6 +250,60 @@ describe('review command', () => {
     )
   })
 
+  describe('language_context (#1614)', () => {
+    it('is empty when no language is configured', async () => {
+      argv.json = true
+      await handler(argv, logger)
+      const variables = mockExecuteChain.mock.calls[0][0].variables as Record<string, string>
+      expect(variables.language_context).toBe('')
+    })
+
+    it('builds an instruction from the configured language', async () => {
+      argv.json = true
+      mockLoadConfig.mockReturnValue({
+        service: {
+          authentication: { type: 'APIKey', credentials: { apiKey: 'mock-api-key' } },
+          provider: 'openai',
+          model: 'gpt-4o',
+          tokenLimit: 4096,
+          temperature: 0.2,
+          maxConcurrent: 1,
+        },
+        defaultBranch: 'main',
+        mode: 'stdout',
+        interactive: false,
+        language: 'German',
+      } as unknown as Config)
+
+      await handler(argv, logger)
+      const variables = mockExecuteChain.mock.calls[0][0].variables as Record<string, string>
+      expect(variables.language_context).toBe('Write the code review feedback in German.')
+    })
+
+    it('honors a per-invocation --language flag over the configured language', async () => {
+      argv.json = true
+      ;(argv as unknown as { language?: string }).language = 'French'
+      mockLoadConfig.mockReturnValue({
+        service: {
+          authentication: { type: 'APIKey', credentials: { apiKey: 'mock-api-key' } },
+          provider: 'openai',
+          model: 'gpt-4o',
+          tokenLimit: 4096,
+          temperature: 0.2,
+          maxConcurrent: 1,
+        },
+        defaultBranch: 'main',
+        mode: 'stdout',
+        interactive: false,
+        language: 'German',
+      } as unknown as Config)
+
+      await handler(argv, logger)
+      const variables = mockExecuteChain.mock.calls[0][0].variables as Record<string, string>
+      expect(variables.language_context).toBe('Write the code review feedback in French.')
+    })
+  })
+
   describe('non-interactive TTY handling (no --json)', () => {
     let originalStdinIsTTY: PropertyDescriptor | undefined
     let originalStdoutIsTTY: PropertyDescriptor | undefined

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -79,6 +79,17 @@ type BaseConfig = {
   includeBranchName?: boolean
 
   /**
+   * Language for AI-generated output (commit messages, changelogs, recaps,
+   * reviews) — free text, e.g. `'German'` or `'es'`. Conventional Commits
+   * type/scope tokens (`feat`, `fix(parser)`, ...) always stay in English;
+   * only the description/body localizes. Unset generates in English, the
+   * existing default.
+   *
+   * @default undefined
+   */
+  language?: string
+
+  /**
    * The AI CLI tool to use for auto-fixing review issues.
    * Must match a registered adapter key (e.g. "codex", "claude", "gemini").
    * When unset, the auto-fix action is disabled.

--- a/src/lib/langchain/utils/languageContext.test.ts
+++ b/src/lib/langchain/utils/languageContext.test.ts
@@ -1,0 +1,34 @@
+import { getLanguageContext } from './languageContext'
+
+describe('getLanguageContext', () => {
+  it('returns an empty string when language is unset', () => {
+    expect(getLanguageContext(undefined, { taskDescription: 'commit message' })).toBe('')
+  })
+
+  it('returns an empty string for an empty-string language', () => {
+    expect(getLanguageContext('', { taskDescription: 'commit message' })).toBe('')
+  })
+
+  it('builds a plain instruction sentence when set', () => {
+    expect(getLanguageContext('German', { taskDescription: 'changelog' })).toBe(
+      'Write the changelog in German.'
+    )
+  })
+
+  it('appends the Conventional Commits token caveat when requested', () => {
+    expect(
+      getLanguageContext('Spanish', { taskDescription: 'commit message', preserveConventionalTokens: true })
+    ).toBe(
+      'Write the commit message in Spanish. Keep the Conventional Commits type/scope tokens (e.g. feat, fix, chore) in English.'
+    )
+  })
+
+  it('omits the caveat when preserveConventionalTokens is false or unset', () => {
+    expect(
+      getLanguageContext('Spanish', { taskDescription: 'commit message', preserveConventionalTokens: false })
+    ).toBe('Write the commit message in Spanish.')
+    expect(getLanguageContext('Spanish', { taskDescription: 'commit message' })).toBe(
+      'Write the commit message in Spanish.'
+    )
+  })
+})

--- a/src/lib/langchain/utils/languageContext.ts
+++ b/src/lib/langchain/utils/languageContext.ts
@@ -1,0 +1,30 @@
+export type LanguageContextOptions = {
+  /** How the task is described in the sentence, e.g. 'commit message', 'changelog'. */
+  taskDescription: string
+  /**
+   * Append a caveat keeping Conventional Commits type/scope tokens
+   * (feat, fix, chore, ...) in English — only meaningful for tasks that
+   * actually emit those tokens.
+   */
+  preserveConventionalTokens?: boolean
+}
+
+/**
+ * Builds the `language_context` prompt variable from the `language` config
+ * key (#1614). Empty string when unset, mirroring how `branch_name_context`
+ * degrades — the template always declares the placeholder, so callers never
+ * need to special-case the unset case.
+ */
+export function getLanguageContext(
+  language: string | undefined,
+  { taskDescription, preserveConventionalTokens }: LanguageContextOptions
+): string {
+  if (!language) {
+    return ''
+  }
+
+  const base = `Write the ${taskDescription} in ${language}.`
+  return preserveConventionalTokens
+    ? `${base} Keep the Conventional Commits type/scope tokens (e.g. feat, fix, chore) in English.`
+    : base
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -109,6 +109,11 @@ export const schema = {
           "description": "Whether to include the current branch name in the commit prompt for context. When enabled, the current git branch name will be included in the prompt.",
           "default": true
         },
+        "language": {
+          "type": "string",
+          "description": "Language for AI-generated output (commit messages, changelogs, recaps, reviews) — free text, e.g. `'German'` or `'es'`. Conventional Commits type/scope tokens (`feat`, `fix(parser)`, ...) always stay in English; only the description/body localizes. Unset generates in English, the existing default.",
+          "default": "undefined"
+        },
         "autoFixTool": {
           "type": "string",
           "description": "The AI CLI tool to use for auto-fixing review issues. Must match a registered adapter key (e.g. \"codex\", \"claude\", \"gemini\"). When unset, the auto-fix action is disabled."


### PR DESCRIPTION
## What

Adds a `language` config option (and `--language` flag) so generated commit messages, changelogs, recaps, and reviews can be produced in a language other than English.

Closes #1614

## How

- New `BaseConfig.language` + regenerated `schema.json`.
- Shared `getLanguageContext(language, {taskDescription, preserveConventionalTokens})` helper builds the `language_context` prompt variable; empty when unset.
- Threaded through `commit`, `changelog`, `recap`, and `review`'s prompts/handlers. The commit path keeps Conventional Commits tokens in English even when a language is set.
- Deliberately excludes the summarize chain (keeps `SUMMARIZE_PROMPT_HASH` cache stable) and skips adding an `init` wizard question (`language` is file/flag-only, matching precedent set by `conventionalCommits`/`includeBranchName`).

## Validation

- [x] `npm test` passes locally (lint + jest + build + packaged-CLI smoke)
- [x] New behavior has tests across all four commands' test files + `languageContext.test.ts`
- [x] `schema.json` regenerated (`npm run build:schema`)
- [ ] Docs updated where relevant (README / `.wiki/`) — follow-up
- [x] Commits follow Conventional Commits

## Notes

Widest-surface change in this batch — touches `commit`/`changelog`/`recap`/`review` prompts and handlers. Will need to be rebased onto other PRs in this batch to resolve overlapping-file conflicts before merge.
