### PR TITLE
test: isolate provider-key env vars and ~/.gitconfig from the real machine

### DIFF
--- a/src/commands/config/config.test.ts
+++ b/src/commands/config/config.test.ts
@@ -48,11 +48,22 @@ function createArgv(overrides: Partial<ConfigOptions> = {}): ConfigArgv {
 describe('config command (#1605)', () => {
   let projectDir: string
   let xdgDir: string
+  let fakeHomeDir: string
   let logger: Logger
+  let homedirSpy: jest.SpyInstance
 
   beforeEach(() => {
     projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-config-cmd-project-'))
     xdgDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-config-cmd-xdg-'))
+    // `loadGitConfig` reads `~/.gitconfig` straight off `os.homedir()` with
+    // no env-var override, unlike the XDG loader. Left unmocked, these
+    // tests read the REAL developer machine's `~/.gitconfig` — a `[coco]`
+    // section set by a prior `coco init` run (e.g. `defaultBranch`) makes
+    // "source: default" assertions fail only on that machine, not in a
+    // clean sandbox. Point homedir at an empty temp dir so the git layer
+    // never contributes here.
+    fakeHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coco-config-cmd-home-'))
+    homedirSpy = jest.spyOn(os, 'homedir').mockReturnValue(fakeHomeDir)
     mockResolveGitRepoRoot.mockReturnValue(projectDir)
     process.env.XDG_CONFIG_HOME = xdgDir
     logger = createLogger()
@@ -61,6 +72,8 @@ describe('config command (#1605)', () => {
   afterEach(() => {
     fs.rmSync(projectDir, { recursive: true, force: true })
     fs.rmSync(xdgDir, { recursive: true, force: true })
+    fs.rmSync(fakeHomeDir, { recursive: true, force: true })
+    homedirSpy.mockRestore()
     if (ORIGINAL_XDG_CONFIG_HOME === undefined) {
       delete process.env.XDG_CONFIG_HOME
     } else {

--- a/src/lib/config/services/env.test.ts
+++ b/src/lib/config/services/env.test.ts
@@ -125,6 +125,45 @@ describe('loadEnvConfig', () => {
   })
 
   describe('provider API keys from the environment', () => {
+    // Every provider-key env var this suite touches. A test that only sets
+    // (and restores) the one var it's exercising still reads through to
+    // whichever of these are ALREADY set in the ambient shell — e.g. a
+    // developer's real OPENAI_API_KEY, which outranks the deprecated
+    // OPEN_AI_KEY alias per #1584's own precedence. That leaked a real key
+    // into a test assertion (and into CI/release output) on any machine
+    // that had one exported. Stash and clear the full set before each test,
+    // restore it after, so these tests are hermetic regardless of the
+    // ambient environment.
+    const PROVIDER_KEY_ENV_VARS = [
+      'OPEN_AI_KEY',
+      'OPENAI_API_KEY',
+      'ANTHROPIC_API_KEY',
+      'GEMINI_API_KEY',
+      'GOOGLE_API_KEY',
+      'MISTRAL_API_KEY',
+      'AZURE_OPENAI_API_KEY',
+    ] as const
+
+    let savedEnv: Record<string, string | undefined>
+
+    beforeEach(() => {
+      savedEnv = {}
+      for (const key of PROVIDER_KEY_ENV_VARS) {
+        savedEnv[key] = process.env[key]
+        delete process.env[key]
+      }
+    })
+
+    afterEach(() => {
+      for (const key of PROVIDER_KEY_ENV_VARS) {
+        if (savedEnv[key] === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = savedEnv[key]
+        }
+      }
+    })
+
     // Regression for the toEnvVarName mangling bug: these env-var-form names
     // (OPEN_AI_KEY, GEMINI_API_KEY, ...) must be read verbatim, not rewritten
     // to COCO__O_P_E_N__A_I__K_E_Y. Each key only applies to its provider.
@@ -143,67 +182,50 @@ describe('loadEnvConfig', () => {
 
     it.each(cases)('reads $envVar into the $provider service auth', ({ provider, envVar }) => {
       process.env[envVar] = 'env-provided-key'
-      try {
-        const config = loadEnvConfig({
-          ...defaultConfig,
-          service: getDefaultServiceConfigFromAlias(provider),
-        })
-        expect(config.service.provider).toBe(provider)
-        expect(config.service.authentication.type).toBe('APIKey')
-        if (config.service.authentication.type === 'APIKey') {
-          expect(config.service.authentication.credentials?.apiKey).toBe('env-provided-key')
-        }
-      } finally {
-        delete process.env[envVar]
+      const config = loadEnvConfig({
+        ...defaultConfig,
+        service: getDefaultServiceConfigFromAlias(provider),
+      })
+      expect(config.service.provider).toBe(provider)
+      expect(config.service.authentication.type).toBe('APIKey')
+      if (config.service.authentication.type === 'APIKey') {
+        expect(config.service.authentication.credentials?.apiKey).toBe('env-provided-key')
       }
     })
 
     it('ignores a provider key when the configured provider differs', () => {
       process.env.GEMINI_API_KEY = 'gemini-key'
-      try {
-        const config = loadEnvConfig({
-          ...defaultConfig,
-          service: getDefaultServiceConfigFromAlias('openai'),
-        })
-        // openai service shouldn't pick up the gemini key
-        if (config.service.authentication.type === 'APIKey') {
-          expect(config.service.authentication.credentials?.apiKey).not.toBe('gemini-key')
-        }
-      } finally {
-        delete process.env.GEMINI_API_KEY
+      const config = loadEnvConfig({
+        ...defaultConfig,
+        service: getDefaultServiceConfigFromAlias('openai'),
+      })
+      // openai service shouldn't pick up the gemini key
+      if (config.service.authentication.type === 'APIKey') {
+        expect(config.service.authentication.credentials?.apiKey).not.toBe('gemini-key')
       }
     })
 
     it('ignores ANTHROPIC_API_KEY when the configured provider is not anthropic (#1584)', () => {
       process.env.ANTHROPIC_API_KEY = 'anthropic-key'
-      try {
-        const config = loadEnvConfig({
-          ...defaultConfig,
-          service: getDefaultServiceConfigFromAlias('openai'),
-        })
-        if (config.service.authentication.type === 'APIKey') {
-          expect(config.service.authentication.credentials?.apiKey).not.toBe('anthropic-key')
-        }
-      } finally {
-        delete process.env.ANTHROPIC_API_KEY
+      const config = loadEnvConfig({
+        ...defaultConfig,
+        service: getDefaultServiceConfigFromAlias('openai'),
+      })
+      if (config.service.authentication.type === 'APIKey') {
+        expect(config.service.authentication.credentials?.apiKey).not.toBe('anthropic-key')
       }
     })
 
     it('prefers OPENAI_API_KEY over the deprecated OPEN_AI_KEY alias when both are set (#1584)', () => {
       process.env.OPEN_AI_KEY = 'legacy-key'
       process.env.OPENAI_API_KEY = 'standard-key'
-      try {
-        const config = loadEnvConfig({
-          ...defaultConfig,
-          service: getDefaultServiceConfigFromAlias('openai'),
-        })
-        expect(config.service.authentication.type).toBe('APIKey')
-        if (config.service.authentication.type === 'APIKey') {
-          expect(config.service.authentication.credentials?.apiKey).toBe('standard-key')
-        }
-      } finally {
-        delete process.env.OPEN_AI_KEY
-        delete process.env.OPENAI_API_KEY
+      const config = loadEnvConfig({
+        ...defaultConfig,
+        service: getDefaultServiceConfigFromAlias('openai'),
+      })
+      expect(config.service.authentication.type).toBe('APIKey')
+      if (config.service.authentication.type === 'APIKey') {
+        expect(config.service.authentication.credentials?.apiKey).toBe('standard-key')
       }
     })
   })

--- a/src/lib/simple-git/getDiff.pathspec.test.ts
+++ b/src/lib/simple-git/getDiff.pathspec.test.ts
@@ -13,6 +13,13 @@ import { getDiff } from './getDiff'
 import { Logger } from '../utils/logger'
 import { FileChange } from '../types'
 
+// `createTempGitRepo()` spawns several real git subprocesses (init +
+// 3x addConfig + checkout) per test. The default 5s jest hook timeout can
+// be too tight under parallel test-runner load — sibling real-git-repo
+// suites (isEmptyRepo.test.ts, logData.test.ts, reflogActions.integration.test.ts)
+// already raise this for the same reason.
+jest.setTimeout(30_000)
+
 function createLogger(): Logger {
   return {
     log: jest.fn(),


### PR DESCRIPTION
## What

Fixes 3 test failures that only reproduce on a real dev machine (not in a clean sandbox/CI checkout), surfaced while running `npm run release` locally. Each test was reading real ambient machine state instead of a sandboxed one.

## How

- `env.test.ts`: the per-provider-key parametrized test only cleared the one env var it was testing, so a real `OPENAI_API_KEY` already exported in the shell won over the test's `OPEN_AI_KEY` value (per the documented "`OPENAI_API_KEY` wins if both set" precedence from #1584) and got asserted against directly — leaking the real key value into the test failure output. Now stashes and clears every provider-key env var before each test in that describe block and restores it after.
- `config.test.ts`: the `get --json` test assumed no config layer supplies `defaultBranch` unless the test wrote one, but `loadGitConfig` reads `~/.gitconfig` unconditionally (no env-var override like XDG has), so a real `[coco] defaultBranch` entry from a prior `coco init` run made the "source: default" assertion fail on that machine. Now points `os.homedir()` at an empty temp dir for the suite.
- `getDiff.pathspec.test.ts`: `createTempGitRepo()` (git init + 3x addConfig + checkout) hit the default 5s jest hook timeout under parallel test-runner load. Sibling real-git-repo suites (`isEmptyRepo.test.ts`, `logData.test.ts`, `reflogActions.integration.test.ts`) already raise this via `jest.setTimeout(30_000)` for the same reason — this file was just missing it.

None of these are product regressions; the underlying commit/config/review/getDiff behavior is unaffected.

## Validation

- [x] `npx tsc --noEmit` passes
- [x] All 3 fixed suites pass, including with a fake `OPENAI_API_KEY` deliberately set in the shell to simulate the leak scenario
- [x] Full `npm run test:jest` passes (361 suites) with the same contamination present
- [x] `npx eslint` clean on changed files
- [ ] `schema.json` regenerated — not needed, no config type changes
- [x] Commits follow Conventional Commits

## Notes

⚠️ The `npm run release` output that surfaced this bug included a real OpenAI API key in plain text (leaked via the failing `env.test.ts` assertion). That key should be rotated if it hasn't been already — unrelated to this fix, but worth flagging here for the record.
