### PR TITLE
fix(security): resolve open Dependabot alerts, harden screenshot.ts subprocess call

### DIFF
--- a/bin/screenshot.ts
+++ b/bin/screenshot.ts
@@ -308,8 +308,7 @@ async function spinUpAsync(scenarioName: string | null): Promise<{ path: string;
       const repo = await fromScenario(scenarios[i])
       const targetDir = join(realParent, ['widget-app', 'dashboard', 'api-server'][i])
       mkdirSyncFs(targetDir, { recursive: true })
-      const { execSync } = await import('child_process')
-      execSync(`cp -a ${repo.path}/. ${targetDir}/`)
+      spawnSync('cp', ['-a', `${repo.path}/.`, `${targetDir}/`])
       repos.push(repo)
     }
 

--- a/package.json
+++ b/package.json
@@ -173,6 +173,11 @@
     "ip-address": "^10.1.1",
     "shell-quote": "^1.8.4",
     "flatted": "^3.4.2",
-    "picomatch": "^4.0.4"
+    "picomatch": "^4.0.4",
+    "js-yaml": "^4.2.0",
+    "react-devtools-core/**/ws": "^7.5.11",
+    "**/@humanwhocodes/config-array/minimatch": "^3.1.3",
+    "**/test-exclude/minimatch": "^3.1.3",
+    "**/rimraf/**/minimatch": "^3.1.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2565,13 +2565,6 @@ arg@^4.1.0:
   resolved "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
-argparse@^1.0.7:
-  version "1.0.10"
-  resolved "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz"
-  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
-  dependencies:
-    sprintf-js "~1.0.2"
-
 argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
@@ -3453,7 +3446,7 @@ espree@^9.6.0, espree@^9.6.1:
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.4.1"
 
-esprima@^4.0.0, esprima@^4.0.1:
+esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -4755,18 +4748,10 @@ js-tokens@^4.0.0:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1:
-  version "3.14.2"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
-js-yaml@^4.1.0, js-yaml@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+js-yaml@^3.13.1, js-yaml@^4.1.0, js-yaml@^4.1.1, js-yaml@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 
@@ -5073,14 +5058,7 @@ minimatch@^10.2.2, minimatch@^10.2.5:
   dependencies:
     brace-expansion "^5.0.5"
 
-minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
-  dependencies:
-    brace-expansion "^1.1.7"
-
-minimatch@^3.1.2:
+minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2, minimatch@^3.1.3:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
   integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
@@ -6145,11 +6123,6 @@ sourcemap-codec@^1.4.8:
   resolved "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
-sprintf-js@~1.0.2:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-  integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
-
 stack-utils@^2.0.6:
   version "2.0.6"
   resolved "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz"
@@ -6730,10 +6703,10 @@ write-file-atomic@^5.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^4.0.1"
 
-ws@^7:
-  version "7.5.10"
-  resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz"
-  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
+ws@^7, ws@^7.5.11:
+  version "7.5.13"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.13.tgz#12aa507eaca76c295c278b1aebf4698ab2c1845f"
+  integrity sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==
 
 ws@^8.18.0, ws@^8.20.0:
   version "8.21.0"


### PR DESCRIPTION
## Summary
- Pins `js-yaml`, `ws`, and `minimatch` past their vulnerable ranges via `resolutions`, closing all 4 open Dependabot alerts:
  - #165 / #166 — js-yaml quadratic-complexity DoS (GHSA-h67p-54hq-rp68 / CVE-2026-53550) — both the runtime copy (via `@langchain/community`) and the dev copy (via `@istanbuljs/load-nyc-config`) now resolve to `4.3.0`. Verified the latter's only call site uses `.load()`, which is API-compatible across the v3→v4 boundary.
  - #155 — `ws` memory-exhaustion DoS (CVE-2026-48779) — the copy nested under `react-devtools-core` now resolves to `7.5.13`.
  - #74 — `minimatch` ReDoS (CVE-2026-27903) — the eslint/jest-tooling edges pinned to `3.1.2` now resolve to `3.1.5`.
- Hardens `bin/screenshot.ts`'s `_workspace` scenario: replaces an `execSync` template-string shell call with `spawnSync` + an argv array, closing CodeQL finding #142 (shell-command-injection-from-environment). The interpolated path was always coco's own temp dir, not external input, but the array form removes the shell entirely.

## Test plan
- [x] `yarn install` — confirmed via `yarn why <pkg>` that no vulnerable version remains for `js-yaml`, `ws`, or `minimatch`
- [x] `npm run lint` — 0 errors (42 pre-existing, unrelated `react-hooks/exhaustive-deps` warnings)
- [x] `npm run test:jest` — 362/364 suites, 5177/5183 tests passing (6 skipped, pre-existing)
- [x] `npm run build` — production build + type declarations + tree-sitter wasm copy all succeed