### PR TITLE
fix(test): increase timeout for hooks handler test suite

### DIFF
--- a/src/commands/hooks/handler.test.ts
+++ b/src/commands/hooks/handler.test.ts
@@ -6,6 +6,16 @@ import { Logger } from '../../lib/utils/logger'
 import { handler } from './handler'
 import { HooksArgv } from './config'
 
+// Each test spawns real git subprocesses (via simple-git) for hook-dir
+// resolution. Under heavy parallel load the default 5s jest timeout is
+// too tight — especially for tests that call handler() twice.
+jest.setTimeout(15000)
+
+describe('coco hooks <action> (#1591)', () => {simple-git) for hook-dir
+// resolution. Under heavy parallel load the default 5s jest timeout is
+// too tight — especially for tests that call handler() twice.
+jest.setTimeout(15000)
+
 describe('coco hooks <action> (#1591)', () => {
   let repoDir: string
   let originalCwd: string


### PR DESCRIPTION
The `uninstall: removes a previously installed hook` test in `src/commands/hooks/handler.test.ts` was timing out at the default 5s jest threshold under heavy parallel CI load (368 suites). The test spawns two sequential git subprocesses (install → uninstall), each resolving the hooks dir via `git rev-parse`. Under contention this exceeds 5s. **Fix:** Add `jest.setTimeout(15000)` before the describe block — consistent with other subprocess-heavy test suites in the repo (reflog integration, commit-log, etc.).