### PR TITLE
fix(errors): distinguish insufficient_quota from rate limits on 429s

### DIFF
--- a/src/lib/langchain/errorHandler.test.ts
+++ b/src/lib/langchain/errorHandler.test.ts
@@ -3,6 +3,7 @@ import {
   LangChainNetworkError,
   LangChainExecutionError,
   LangChainAuthenticationError,
+  LangChainQuotaExceededError,
   LangChainRateLimitError,
 } from './errors'
 
@@ -231,6 +232,81 @@ describe('handleLangChainError', () => {
       } catch (e) {
         expect(e).toBeInstanceOf(LangChainRateLimitError)
         expect((e as LangChainRateLimitError).provider).toBe('anthropic')
+      }
+    })
+
+    it('does not classify a plain 429 as quota exhaustion', () => {
+      const error = { status: 429, message: 'Rate limit reached for gpt-4o' }
+
+      try {
+        handleLangChainError(error, 'test context', { provider: 'openai' })
+      } catch (e) {
+        expect(e).toBeInstanceOf(LangChainRateLimitError)
+        expect(e).not.toBeInstanceOf(LangChainQuotaExceededError)
+      }
+    })
+  })
+
+  // Providers reuse HTTP 429 for `insufficient_quota` (billing/budget
+  // exhausted). Classified separately from rate limits because the
+  // rate-limit remedy ("wait and retry") can never fix a dead balance.
+  describe('quota exhaustion on 429s (insufficient_quota)', () => {
+    it('throws LangChainQuotaExceededError for a 429 with an insufficient_quota code', () => {
+      const error = { status: 429, code: 'insufficient_quota', message: 'You exceeded your current quota' }
+
+      expect(() => {
+        handleLangChainError(error, 'test context', { provider: 'openai' })
+      }).toThrow(LangChainQuotaExceededError)
+    })
+
+    it('throws LangChainQuotaExceededError for a nested error.type of insufficient_quota', () => {
+      const error = {
+        status: 429,
+        message: 'You exceeded your current quota, please check your plan and billing details.',
+        error: { type: 'insufficient_quota', code: 'insufficient_quota' },
+      }
+
+      expect(() => {
+        handleLangChainError(error, 'test context', { provider: 'openai' })
+      }).toThrow(LangChainQuotaExceededError)
+    })
+
+    it('detects quota exhaustion from the message when no code is present', () => {
+      const error = { status: 429, message: 'You exceeded your current quota, please check your plan and billing details.' }
+
+      expect(() => {
+        handleLangChainError(error, 'test context')
+      }).toThrow(LangChainQuotaExceededError)
+    })
+
+    it("detects Anthropic's low-credit-balance message", () => {
+      const error = { status: 400, message: 'Your credit balance is too low to access the Anthropic API.' }
+
+      expect(() => {
+        handleLangChainError(error, 'test context', { provider: 'anthropic' })
+      }).toThrow(LangChainQuotaExceededError)
+    })
+
+    it('remains an instanceof LangChainRateLimitError for existing call sites', () => {
+      const error = { status: 429, code: 'insufficient_quota', message: 'You exceeded your current quota' }
+
+      try {
+        handleLangChainError(error, 'test context', { provider: 'openai' })
+      } catch (e) {
+        expect(e).toBeInstanceOf(LangChainRateLimitError)
+      }
+    })
+
+    it('carries the provider and original message through to the thrown error', () => {
+      const error = { status: 429, code: 'insufficient_quota', message: 'You exceeded your current quota' }
+
+      try {
+        handleLangChainError(error, 'test context', { provider: 'openai' })
+      } catch (e) {
+        expect(e).toBeInstanceOf(LangChainQuotaExceededError)
+        const quotaError = e as LangChainQuotaExceededError
+        expect(quotaError.provider).toBe('openai')
+        expect(quotaError.message).toBe('You exceeded your current quota')
       }
     })
   })

--- a/src/lib/langchain/errorHandler.ts
+++ b/src/lib/langchain/errorHandler.ts
@@ -3,6 +3,7 @@ import {
   LangChainError,
   LangChainExecutionError,
   LangChainNetworkError,
+  LangChainQuotaExceededError,
   LangChainRateLimitError,
 } from './errors'
 
@@ -139,6 +140,37 @@ function isAuthError(error: unknown): boolean {
 const RATE_LIMIT_MESSAGE_PATTERNS = ['rate limit', 'rate-limit', 'ratelimit', 'too many requests']
 
 /**
+ * Substrings that signal quota/billing exhaustion rather than a rate limit.
+ * "exceeded your current quota" is OpenAI's `insufficient_quota` message;
+ * "credit balance is too low" is Anthropic's out-of-credits message.
+ */
+const QUOTA_MESSAGE_PATTERNS = [
+  'insufficient_quota',
+  'exceeded your current quota',
+  'credit balance is too low',
+]
+
+/**
+ * Quota/billing exhaustion. OpenAI (and others) reuse HTTP 429 for
+ * `insufficient_quota`, so without this check a dead billing account rendered
+ * the rate-limit remedy ("wait a bit and retry") — advice that can never
+ * work. Checked before {@link isRateLimitError} since a quota 429 satisfies
+ * that predicate too.
+ */
+function isQuotaExceededError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+  const err = error as { code?: string | number; error?: { code?: string; type?: string }; message?: string }
+  const code = err.code ?? err.error?.code
+  const type = err.error?.type
+  if (code === 'insufficient_quota' || type === 'insufficient_quota') return true
+  if (typeof err.message === 'string') {
+    const message = err.message.toLowerCase()
+    return QUOTA_MESSAGE_PATTERNS.some((pattern) => message.includes(pattern))
+  }
+  return false
+}
+
+/**
  * #1637 — a 429 that survived the summarize chain's retry/backoff (or any
  * other provider call that doesn't retry) used to surface as a raw
  * provider message via the generic execution-error wrap, with no
@@ -192,6 +224,20 @@ export function handleLangChainError(
     const message = extractErrorMessage(error)
 
     throw new LangChainAuthenticationError(message, provider, endpoint, {
+      originalError: error instanceof Error ? error.name : typeof error,
+      originalMessage: message,
+      context,
+      ...additionalContext
+    })
+  }
+
+  // Quota/billing exhaustion masquerading as a 429 — must precede the
+  // rate-limit check so the billing remedy renders instead of "retry".
+  if (isQuotaExceededError(error)) {
+    const provider = additionalContext?.provider as string | undefined
+    const message = extractErrorMessage(error)
+
+    throw new LangChainQuotaExceededError(message, provider, {
       originalError: error instanceof Error ? error.name : typeof error,
       originalMessage: message,
       context,

--- a/src/lib/langchain/errors.ts
+++ b/src/lib/langchain/errors.ts
@@ -91,6 +91,20 @@ export class LangChainRateLimitError extends LangChainError {
 }
 
 /**
+ * Quota/billing exhaustion (`insufficient_quota`). Providers reuse HTTP 429
+ * for this, but it is *not* a rate limit: no amount of waiting or lowering
+ * concurrency helps — the fix is adding credits or raising a budget cap. A
+ * subclass of `LangChainRateLimitError` so any `instanceof` rate-limit call
+ * site still matches, while the formatter can single it out to render
+ * billing-oriented guidance instead of "wait and retry".
+ */
+export class LangChainQuotaExceededError extends LangChainRateLimitError {
+  constructor(message: string, provider?: string, context?: Record<string, unknown>) {
+    super(message, provider, context)
+  }
+}
+
+/**
  * Timeout and retry-related errors
  */
 export class LangChainTimeoutError extends LangChainError {

--- a/src/lib/utils/commandExecutor.test.ts
+++ b/src/lib/utils/commandExecutor.test.ts
@@ -79,6 +79,53 @@ describe('commandExecutor — global --quiet wiring', () => {
     expect(process.exitCode).toBe(1)
   })
 
+  // Providers reuse HTTP 429 for `insufficient_quota` (billing exhausted).
+  // This exercises the full pipeline: a raw provider-shaped quota error
+  // classified by handleLangChainError, then rendered with billing-oriented
+  // guidance instead of the rate-limit "wait and retry" remedy.
+  it('renders billing guidance (not the rate-limit remedy) for an insufficient_quota 429', async () => {
+    const handler: CommandHandler<never> = async () => {
+      handleLangChainError(
+        {
+          status: 429,
+          code: 'insufficient_quota',
+          message: 'You exceeded your current quota, please check your plan and billing details.',
+        },
+        'executeChain: Chain execution failed',
+        { provider: 'openai' }
+      )
+    }
+    await commandExecutor(handler)({ quiet: true } as never)
+
+    const written = stderrSpy.mock.calls.map((call) => String(call[0])).join('')
+    expect(written).toContain('quota exhausted (billing)')
+    expect(written).toContain('credit balance')
+    expect(written).toContain('budget caps')
+    // The provider's own message renders without --verbose
+    expect(written).toContain('You exceeded your current quota')
+    // The rate-limit remedy must not render — retrying can't fix billing
+    expect(written).not.toContain('Wait a bit and retry')
+    expect(written).not.toContain('service.maxConcurrent')
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('includes the provider message in rate-limit output without --verbose', async () => {
+    const handler: CommandHandler<never> = async () => {
+      handleLangChainError(
+        { status: 429, message: 'Rate limit reached for gpt-4o: try again in 20s' },
+        'executeChain: Chain execution failed',
+        { provider: 'openai' }
+      )
+    }
+    await commandExecutor(handler)({ quiet: true } as never)
+
+    const written = stderrSpy.mock.calls.map((call) => String(call[0])).join('')
+    expect(written).toContain('Rate limited by openai')
+    expect(written).toContain('Rate limit reached for gpt-4o: try again in 20s')
+    expect(written).toContain('Wait a bit and retry')
+    expect(process.exitCode).toBe(1)
+  })
+
   it('emits network error to stderr even when --quiet is set', async () => {
     const handler: CommandHandler<never> = async () => {
       throw new LangChainNetworkError('connection refused', 'https://api.openai.com', 'openai')

--- a/src/lib/utils/commandExecutor.ts
+++ b/src/lib/utils/commandExecutor.ts
@@ -5,7 +5,7 @@ import { Logger } from './logger'
 import { CommandHandler } from '../types'
 import { BaseArgvOptions } from '../../commands/types'
 import { Config } from '../config/types'
-import { LangChainNetworkError, LangChainAuthenticationError, LangChainRateLimitError } from '../langchain/errors'
+import { LangChainNetworkError, LangChainAuthenticationError, LangChainQuotaExceededError, LangChainRateLimitError } from '../langchain/errors'
 import { isCommandExitError } from './commandExit'
 import { decideUsageConsent, isConsentInteractive, USAGE_ENABLED_NOTICE } from './usageConsent'
 import { persistUsagePreference } from '../config/services/xdg'
@@ -111,12 +111,43 @@ function formatRateLimitError(error: LangChainRateLimitError, logger: Logger): v
   logger.error('\nFailed to execute command', { color: 'yellow' })
   logger.error(`\nError: Rate limited by ${provider}`, { color: 'red' })
 
+  // The provider's own message prints unconditionally (was `--verbose`-only):
+  // it carries the specifics — which limit, reset window, request id — that
+  // users need to tell a transient 429 from something deeper.
+  if (error.message) {
+    logger.error(`       ${error.message}`, { color: 'gray' })
+  }
+
   logger.error('\nTroubleshooting:', { color: 'cyan' })
   logger.error('  • Lower `service.maxConcurrent` in your config to send fewer requests at once', { color: 'white' })
   logger.error('  • Wait a bit and retry — many providers reset rate-limit windows quickly', { color: 'white' })
   logger.error('  • Check your provider dashboard for your current rate/usage limits', { color: 'white' })
+}
 
-  logger.verbose(`\nOriginal error: ${error.message}`, { color: 'gray' })
+/**
+ * Formats a quota/billing exhaustion error (`insufficient_quota`). Providers
+ * reuse HTTP 429 for this, but the rate-limit remedy ("wait and retry") can
+ * never fix an exhausted balance — the guidance here is billing-oriented.
+ */
+function formatQuotaExceededError(error: LangChainQuotaExceededError, logger: Logger): void {
+  const provider = error.provider || 'LLM service'
+
+  logger.error('\nFailed to execute command', { color: 'yellow' })
+  logger.error(`\nError: ${provider} quota exhausted (billing) — not a rate limit`, { color: 'red' })
+
+  if (error.message) {
+    logger.error(`       ${error.message}`, { color: 'gray' })
+  }
+
+  logger.error('\nTroubleshooting:', { color: 'cyan' })
+  logger.error('  • Check your credit balance / prepaid credits on the provider dashboard', { color: 'white' })
+  logger.error('  • Check project or organization budget caps and monthly spend limits', { color: 'white' })
+  if (provider === 'openai' || provider === 'OpenAI') {
+    logger.error('  • See https://platform.openai.com/settings/organization/billing and the Limits page', { color: 'white' })
+  } else if (provider === 'anthropic' || provider === 'Anthropic') {
+    logger.error('  • See https://console.anthropic.com/settings/billing', { color: 'white' })
+  }
+  logger.error('  • Waiting and retrying will not help until billing is resolved', { color: 'white' })
 }
 
 /**
@@ -257,6 +288,9 @@ function commandExecutor<T extends Argv<BaseArgvOptions>['argv']>(handler: Comma
         formatNetworkError(error, logger)
       } else if (error instanceof LangChainAuthenticationError) {
         formatAuthenticationError(error, logger)
+      } else if (error instanceof LangChainQuotaExceededError) {
+        // Before the rate-limit branch: quota subclasses LangChainRateLimitError.
+        formatQuotaExceededError(error, logger)
       } else if (error instanceof LangChainRateLimitError) {
         formatRateLimitError(error, logger)
       } else if (missingOllamaModel) {


### PR DESCRIPTION
## Problem

The error classifier (`isRateLimitError` in `src/lib/langchain/errorHandler.ts`) buckets every HTTP 429 into `LangChainRateLimitError`, rendered as **"Rate limited by openai"** with retry / `maxConcurrent` troubleshooting tips. But OpenAI (and other providers) also use HTTP 429 for `insufficient_quota` — billing/budget exhausted — where "wait a bit and retry" can never work. On top of that, the provider's actual error message was only visible with `--verbose`, so users had nothing concrete to diagnose from.

## Changes

- **New `LangChainQuotaExceededError`** (subclass of `LangChainRateLimitError`, so existing `instanceof` call sites still match). Classified before the rate-limit check via `insufficient_quota` code / nested `error.code` / `error.type`, plus the OpenAI ("exceeded your current quota") and Anthropic ("credit balance is too low") message shapes.
- **Billing-oriented formatter** for quota errors: check credit balance / prepaid credits, project & org budget caps, provider billing pages (OpenAI/Anthropic links), and an explicit note that retrying won't help.
- **Provider message now prints without `--verbose`** in both rate-limit and quota output — it carries the specifics (which limit, reset window, request id) users need.

## Testing

- New `errorHandler` classification tests (quota code/type/message shapes, plain-429 non-misclassification, subclass relationship) mirroring the existing #1637 suites.
- New end-to-end `commandExecutor` tests asserting the billing guidance renders for an `insufficient_quota` 429 (and the retry remedy does not), and that the provider message appears in non-verbose rate-limit output.
- Full jest suite green locally except the four known tree-sitter WASM worktree failures (pre-existing environment issue, unrelated). Lint clean.