### PR TITLE
perf(startup): lazy-load provider SDKs at first LLM use

### DIFF
--- a/src/commands/changelog/changelog.test.ts
+++ b/src/commands/changelog/changelog.test.ts
@@ -123,7 +123,7 @@ describe('changelog command', () => {
       provider: 'openai',
       model: 'gpt-4o',
     })
-    mockGetLlm.mockReturnValue({} as unknown as ReturnType<typeof getLlm>)
+    mockGetLlm.mockResolvedValue({} as unknown as Awaited<ReturnType<typeof getLlm>>)
     mockGetTokenCounterForProvider.mockResolvedValue((text: string) => text.length)
     mockGetCommitLogCurrentBranch.mockResolvedValue([
       {

--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -123,8 +123,8 @@ export async function generateChangelogResult(
     logger.setConfig({ silent: true })
   }
 
-  const llm = getLlm(provider, model as LLMModel, { ...config, service: changelogService })
-  const summaryLlm = getLlm(provider, summaryService.model as LLMModel, { ...config, service: summaryService })
+  const llm = await getLlm(provider, model as LLMModel, { ...config, service: changelogService })
+  const summaryLlm = await getLlm(provider, summaryService.model as LLMModel, { ...config, service: summaryService })
   const tokenizer = await getTokenCounterForProvider(provider, String(model))
 
   let structured: ChangelogResponse | undefined

--- a/src/commands/commands.integration.test.ts
+++ b/src/commands/commands.integration.test.ts
@@ -148,7 +148,7 @@ describe('command integration with temp git repos', () => {
       return true
     })
 
-    mockGetLlm.mockReturnValue({} as unknown as ReturnType<typeof getLlm>)
+    mockGetLlm.mockResolvedValue({} as unknown as Awaited<ReturnType<typeof getLlm>>)
     mockGetTokenCounterForProvider.mockResolvedValue((text: string) => Math.ceil(text.length / 4))
     mockExecuteChain.mockResolvedValue({
       title: 'Generated changelog',

--- a/src/commands/commit/commit.test.ts
+++ b/src/commands/commit/commit.test.ts
@@ -187,7 +187,7 @@ describe('commit command', () => {
       model: 'gpt-4o',
     })
     mockGetTokenCounterForProvider.mockResolvedValue(jest.fn())
-    mockGetLlm.mockReturnValue({} as unknown as ReturnType<typeof getLlm>)
+    mockGetLlm.mockResolvedValue({} as unknown as Awaited<ReturnType<typeof getLlm>>)
 
     // Mock prompts
     mockCommitPrompt.template = 'Test commit prompt template'

--- a/src/commands/commit/generateCommitDraft.test.ts
+++ b/src/commands/commit/generateCommitDraft.test.ts
@@ -112,7 +112,7 @@ describe('generateCommitDraft — diff summary budgeting (OSS-504 / #1459)', () 
       ...(config.service as Record<string, unknown>),
       model: task === 'commit' ? 'commit-model' : 'summarize-model',
     }) as ReturnType<typeof resolveDynamicService>)
-    mockGetLlm.mockReturnValue({} as ReturnType<typeof getLlm>)
+    mockGetLlm.mockResolvedValue({} as Awaited<ReturnType<typeof getLlm>>)
     mockGetTokenCounterForProvider.mockResolvedValue(charTokenizer)
     mockGetChanges.mockResolvedValue({
       staged: [{ filePath: 'src/index.ts', status: 'modified', summary: 'changed' }],
@@ -216,7 +216,7 @@ describe('generateCommitDraft — language_context propagation (OSS-989 / #1683)
       ...(config.service as Record<string, unknown>),
       model: task === 'commit' ? 'commit-model' : 'summarize-model',
     }) as ReturnType<typeof resolveDynamicService>)
-    mockGetLlm.mockReturnValue({} as ReturnType<typeof getLlm>)
+    mockGetLlm.mockResolvedValue({} as Awaited<ReturnType<typeof getLlm>>)
     mockGetTokenCounterForProvider.mockResolvedValue(charTokenizer)
     mockGetChanges.mockResolvedValue({
       staged: [{ filePath: 'src/index.ts', status: 'modified', summary: 'changed' }],

--- a/src/commands/commit/generateCommitDraft.ts
+++ b/src/commands/commit/generateCommitDraft.ts
@@ -153,8 +153,8 @@ export async function generateCommitDraft({
   }
 
   const tokenizer = await getTokenCounterForProvider(provider, String(model))
-  const llm = getLlm(provider, model as LLMModel, { ...config, service: commitService })
-  const summaryLlm = getLlm(provider, summaryService.model as LLMModel, {
+  const llm = await getLlm(provider, model as LLMModel, { ...config, service: commitService })
+  const summaryLlm = await getLlm(provider, summaryService.model as LLMModel, {
     ...config,
     service: summaryService,
   })

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -77,14 +77,14 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
 
   const tokenizer = await getTokenCounterForProvider(provider, String(model))
 
-  const llm = getLlm(provider, model as LLMModel, { ...config, service: commitService })
-  const summaryLlm = getLlm(provider, summaryService.model as LLMModel, { ...config, service: summaryService })
+  const llm = await getLlm(provider, model as LLMModel, { ...config, service: commitService })
+  const summaryLlm = await getLlm(provider, summaryService.model as LLMModel, { ...config, service: summaryService })
   // The split planner uses a dedicated LLM because its output schema
   // is far stricter than the regular commit-message path (every staged
   // file claimed exactly once, no cross-group duplication, hunk-vs-
   // file mode exclusivity). Weak models fail those constraints often
   // enough that the `cost` preference floors `commitSplit` at mini.
-  const splitLlm = getLlm(provider, splitService.model as LLMModel, { ...config, service: splitService })
+  const splitLlm = await getLlm(provider, splitService.model as LLMModel, { ...config, service: splitService })
 
   const INTERACTIVE = argv.interactive || isInteractive(config)
   if (INTERACTIVE) {

--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -743,14 +743,14 @@ export async function prepareCommitSplitPlan({
    * LLM for the diff-summary pre-pass. Typically the regular commit
    * or summarize model.
    */
-  llm: ReturnType<typeof getLlm>
+  llm: Awaited<ReturnType<typeof getLlm>>
   /**
    * Optional dedicated LLM for the structured plan-generation step.
    * Defaults to `llm` when omitted. Wired by `handleCommitSplit` so
    * the `commitSplit` dynamic-model task can floor the planner at a
    * stronger model than the diff summarizer.
    */
-  planLlm?: ReturnType<typeof getLlm>
+  planLlm?: Awaited<ReturnType<typeof getLlm>>
   /** Service descriptor matching `planLlm` (for telemetry metadata). */
   planService?: LLMService
   /**
@@ -921,8 +921,8 @@ export async function handleCommitSplit({
   git: ReturnType<typeof import('../../lib/simple-git/getRepo').getRepo>
   logger: Logger
   tokenizer: TokenCounter
-  llm: ReturnType<typeof getLlm>
-  planLlm?: ReturnType<typeof getLlm>
+  llm: Awaited<ReturnType<typeof getLlm>>
+  planLlm?: Awaited<ReturnType<typeof getLlm>>
   planService?: LLMService
   /**
    * Whether the CLI is running with an interactive prompt UI (matches

--- a/src/commands/commit/splitPlanGenerator.ts
+++ b/src/commands/commit/splitPlanGenerator.ts
@@ -29,7 +29,7 @@ export const NO_PREVIOUS_FEEDBACK_PLACEHOLDER = 'None — this is the first atte
 export const DEFAULT_MAX_PLAN_ATTEMPTS = 3
 
 export interface GenerateSplitPlanArgs {
-  llm: ReturnType<typeof getLlm>
+  llm: Awaited<ReturnType<typeof getLlm>>
   prompt: PromptTemplate
   variables: Record<string, unknown>
   staged: FileChange[]

--- a/src/commands/recap/handler.ts
+++ b/src/commands/recap/handler.ts
@@ -45,8 +45,8 @@ export const handler: CommandHandler<RecapArgv> = async (argv, logger) => {
 
   const tokenizer = await getTokenCounterForProvider(provider, String(model))
 
-  const llm = getLlm(provider, model as LLMModel, { ...config, service: recapService })
-  const summaryLlm = getLlm(provider, summaryService.model as LLMModel, { ...config, service: summaryService })
+  const llm = await getLlm(provider, model as LLMModel, { ...config, service: recapService })
+  const summaryLlm = await getLlm(provider, summaryService.model as LLMModel, { ...config, service: summaryService })
 
   const INTERACTIVE = argv.json ? false : (argv.interactive || isInteractive(config))
   if (INTERACTIVE) {

--- a/src/commands/recap/recap.test.ts
+++ b/src/commands/recap/recap.test.ts
@@ -112,7 +112,7 @@ describe('recap command', () => {
       provider: 'openai',
       model: 'gpt-4o',
     })
-    mockGetLlm.mockReturnValue({} as unknown as ReturnType<typeof getLlm>)
+    mockGetLlm.mockResolvedValue({} as unknown as Awaited<ReturnType<typeof getLlm>>)
     mockGetTokenCounterForProvider.mockResolvedValue((text: string) => text.length)
     // Non-empty by default so the 'current' timeframe reaches the LLM path
     // (matching every other test's expectation below) instead of hitting

--- a/src/commands/review/handler.ts
+++ b/src/commands/review/handler.ts
@@ -77,8 +77,8 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
 
   const tokenizer = await getTokenCounterForProvider(provider, String(model))
 
-  const llm = getLlm(provider, model as LLMModel, { ...config, service: reviewService })
-  const summaryLlm = getLlm(provider, summaryService.model as LLMModel, { ...config, service: summaryService })
+  const llm = await getLlm(provider, model as LLMModel, { ...config, service: reviewService })
+  const summaryLlm = await getLlm(provider, summaryService.model as LLMModel, { ...config, service: summaryService })
 
   const INTERACTIVE = argv.json ? false : (argv.interactive || isInteractive(config))
   if (INTERACTIVE) {

--- a/src/commands/review/review.test.ts
+++ b/src/commands/review/review.test.ts
@@ -119,7 +119,7 @@ describe('review command', () => {
       provider: 'openai',
       model: 'gpt-4o',
     })
-    mockGetLlm.mockReturnValue({} as unknown as ReturnType<typeof getLlm>)
+    mockGetLlm.mockResolvedValue({} as unknown as Awaited<ReturnType<typeof getLlm>>)
     mockGetTokenCounterForProvider.mockResolvedValue((text: string) => text.length)
     mockGetChanges.mockResolvedValue({
       staged: [{ filePath: 'src/file.ts', status: 'modified', summary: 'changed file' }],

--- a/src/git/commitWorkflowActions.ts
+++ b/src/git/commitWorkflowActions.ts
@@ -342,8 +342,8 @@ export async function runCommitSplitPlanWorkflow(
 
   try {
     const tokenizer = await getTokenCounterForProvider(provider, String(model))
-    const llm = getLlm(provider, model as LLMModel, { ...config, service: commitService })
-    const planLlm = getLlm(provider, splitService.model as LLMModel, {
+    const llm = await getLlm(provider, model as LLMModel, { ...config, service: commitService })
+    const planLlm = await getLlm(provider, splitService.model as LLMModel, {
       ...config,
       service: splitService,
     })

--- a/src/git/conflictAiActions.ts
+++ b/src/git/conflictAiActions.ts
@@ -133,7 +133,7 @@ export async function runConflictResolutionWorkflow(input: {
   }
 
   try {
-    const llm = getLlm(provider, service.model as LLMModel, { ...config, service })
+    const llm = await getLlm(provider, service.model as LLMModel, { ...config, service })
     // `any`: @langchain/core bundles its own zod copy, so the parser's
     // inferred output type is `unknown` against the project's zod and
     // fails executeChain's `Runnable<any, T>` constraint. Same

--- a/src/lib/langchain/constants.ts
+++ b/src/lib/langchain/constants.ts
@@ -1,4 +1,4 @@
-import { TiktokenModel } from '@langchain/openai'
+import type { TiktokenModel } from '@langchain/openai'
 import { AnthropicModel, BedrockModel, GeminiModel, MistralModel } from './types'
 
 // gpt-4o and the gpt-4.1 family retired from the API in early 2026 (see

--- a/src/lib/langchain/providers/anthropic.ts
+++ b/src/lib/langchain/providers/anthropic.ts
@@ -1,9 +1,9 @@
-import { ChatAnthropic } from '@langchain/anthropic'
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models'
 import { DEFAULT_MAX_OUTPUT_TOKENS } from './constants'
 import type { CreateLlmArgs, ProviderDefinition } from './types'
 
-function createAnthropicLlm({ model, config, apiKey }: CreateLlmArgs): BaseChatModel {
+async function createAnthropicLlm({ model, config, apiKey }: CreateLlmArgs): Promise<BaseChatModel> {
+  const { ChatAnthropic } = await import('@langchain/anthropic')
   const anthropicConfig: ConstructorParameters<typeof ChatAnthropic>[0] = {
     anthropicApiKey: apiKey,
     maxConcurrency: config.service.maxConcurrent,

--- a/src/lib/langchain/providers/azure.ts
+++ b/src/lib/langchain/providers/azure.ts
@@ -1,10 +1,10 @@
-import { AzureChatOpenAI } from '@langchain/openai'
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models'
 import type { AzureLLMService } from '../types'
 import { DEFAULT_MAX_OUTPUT_TOKENS } from './constants'
 import type { CreateLlmArgs, ProviderDefinition } from './types'
 
-function createAzureLlm({ model, config, apiKey }: CreateLlmArgs): BaseChatModel {
+async function createAzureLlm({ model, config, apiKey }: CreateLlmArgs): Promise<BaseChatModel> {
+  const { AzureChatOpenAI } = await import('@langchain/openai')
   const svc = config.service as AzureLLMService
 
   const azureConfig: ConstructorParameters<typeof AzureChatOpenAI>[0] = {

--- a/src/lib/langchain/providers/bedrock.ts
+++ b/src/lib/langchain/providers/bedrock.ts
@@ -1,10 +1,10 @@
-import { ChatBedrockConverse } from '@langchain/aws'
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models'
 import type { BedrockLLMService } from '../types'
 import { DEFAULT_MAX_OUTPUT_TOKENS } from './constants'
 import type { CreateLlmArgs, ProviderDefinition } from './types'
 
-function createBedrockLlm({ model, config }: CreateLlmArgs): BaseChatModel {
+async function createBedrockLlm({ model, config }: CreateLlmArgs): Promise<BaseChatModel> {
+  const { ChatBedrockConverse } = await import('@langchain/aws')
   const svc = config.service as BedrockLLMService
 
   const bedrockConfig: ConstructorParameters<typeof ChatBedrockConverse>[0] = {

--- a/src/lib/langchain/providers/gemini.ts
+++ b/src/lib/langchain/providers/gemini.ts
@@ -1,9 +1,9 @@
-import { ChatGoogleGenerativeAI } from '@langchain/google-genai'
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models'
 import { DEFAULT_MAX_OUTPUT_TOKENS } from './constants'
 import type { CreateLlmArgs, ProviderDefinition } from './types'
 
-function createGeminiLlm({ model, config, apiKey }: CreateLlmArgs): BaseChatModel {
+async function createGeminiLlm({ model, config, apiKey }: CreateLlmArgs): Promise<BaseChatModel> {
+  const { ChatGoogleGenerativeAI } = await import('@langchain/google-genai')
   const geminiConfig: ConstructorParameters<typeof ChatGoogleGenerativeAI>[0] = {
     apiKey,
     model,

--- a/src/lib/langchain/providers/mistral.ts
+++ b/src/lib/langchain/providers/mistral.ts
@@ -1,9 +1,9 @@
-import { ChatMistralAI } from '@langchain/mistralai'
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models'
 import { DEFAULT_MAX_OUTPUT_TOKENS } from './constants'
 import type { CreateLlmArgs, ProviderDefinition } from './types'
 
-function createMistralLlm({ model, config, apiKey }: CreateLlmArgs): BaseChatModel {
+async function createMistralLlm({ model, config, apiKey }: CreateLlmArgs): Promise<BaseChatModel> {
+  const { ChatMistralAI } = await import('@langchain/mistralai')
   const mistralConfig: ConstructorParameters<typeof ChatMistralAI>[0] = {
     apiKey,
     model,

--- a/src/lib/langchain/providers/ollama.ts
+++ b/src/lib/langchain/providers/ollama.ts
@@ -1,4 +1,3 @@
-import { ChatOllama } from '@langchain/ollama'
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models'
 import type { Config } from '../../../commands/types'
 import { DEFAULT_MAX_OUTPUT_TOKENS } from './constants'
@@ -14,7 +13,8 @@ function resolveOllamaEndpoint(config: Config): string {
     : DEFAULT_OLLAMA_ENDPOINT
 }
 
-function createOllamaLlm({ model, config }: CreateLlmArgs): BaseChatModel {
+async function createOllamaLlm({ model, config }: CreateLlmArgs): Promise<BaseChatModel> {
+  const { ChatOllama } = await import('@langchain/ollama')
   const ollamaConfig: ConstructorParameters<typeof ChatOllama>[0] = {
     baseUrl: resolveOllamaEndpoint(config),
     maxConcurrency: config.service.maxConcurrent,

--- a/src/lib/langchain/providers/openai.ts
+++ b/src/lib/langchain/providers/openai.ts
@@ -1,9 +1,9 @@
-import { ChatOpenAI } from '@langchain/openai'
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models'
 import { DEFAULT_MAX_OUTPUT_TOKENS } from './constants'
 import type { CreateLlmArgs, ProviderDefinition } from './types'
 
-function createOpenAiLlm({ model, config, apiKey }: CreateLlmArgs): BaseChatModel {
+async function createOpenAiLlm({ model, config, apiKey }: CreateLlmArgs): Promise<BaseChatModel> {
+  const { ChatOpenAI } = await import('@langchain/openai')
   const openaiConfig: Partial<ConstructorParameters<typeof ChatOpenAI>[0]> = {
     apiKey,
     maxConcurrency: config.service.maxConcurrent,

--- a/src/lib/langchain/providers/providerConfig.test.ts
+++ b/src/lib/langchain/providers/providerConfig.test.ts
@@ -55,21 +55,21 @@ function temperatureOf(llm: unknown): number | undefined {
 }
 
 describe.each(CASES)('provider config forwarding — $provider', (c) => {
-  it('defaults temperature to 0.2 when unset', () => {
-    const llm = getLlm(c.provider, c.model as LLMModel, makeConfig(c))
+  it('defaults temperature to 0.2 when unset', async () => {
+    const llm = await getLlm(c.provider, c.model as LLMModel, makeConfig(c))
     expect(temperatureOf(llm)).toBe(0.2)
   })
 
-  it('respects an explicit temperature, including 0', () => {
-    const hot = getLlm(c.provider, c.model as LLMModel, makeConfig(c, { temperature: 0.9 }))
+  it('respects an explicit temperature, including 0', async () => {
+    const hot = await getLlm(c.provider, c.model as LLMModel, makeConfig(c, { temperature: 0.9 }))
     expect(temperatureOf(hot)).toBe(0.9)
 
-    const deterministic = getLlm(c.provider, c.model as LLMModel, makeConfig(c, { temperature: 0 }))
+    const deterministic = await getLlm(c.provider, c.model as LLMModel, makeConfig(c, { temperature: 0 }))
     expect(temperatureOf(deterministic)).toBe(0)
   })
 
-  it('merges service.fields last so it overrides the base config', () => {
-    const llm = getLlm(
+  it('merges service.fields last so it overrides the base config', async () => {
+    const llm = await getLlm(
       c.provider,
       c.model as LLMModel,
       makeConfig(c, { temperature: 0.3, fields: { temperature: 0.71 } })
@@ -77,13 +77,13 @@ describe.each(CASES)('provider config forwarding — $provider', (c) => {
     expect(temperatureOf(llm)).toBe(0.71)
   })
 
-  it('defaults the output-token cap to DEFAULT_MAX_OUTPUT_TOKENS', () => {
-    const llm = getLlm(c.provider, c.model as LLMModel, makeConfig(c)) as unknown as Record<string, unknown>
+  it('defaults the output-token cap to DEFAULT_MAX_OUTPUT_TOKENS', async () => {
+    const llm = await getLlm(c.provider, c.model as LLMModel, makeConfig(c)) as unknown as Record<string, unknown>
     expect(llm[c.maxTokensField]).toBe(DEFAULT_MAX_OUTPUT_TOKENS)
   })
 
-  it('lets service.fields override the default output-token cap', () => {
-    const llm = getLlm(
+  it('lets service.fields override the default output-token cap', async () => {
+    const llm = await getLlm(
       c.provider,
       c.model as LLMModel,
       makeConfig(c, { fields: { [c.maxTokensField]: 8192 } })
@@ -106,8 +106,8 @@ describe('bedrock config forwarding', () => {
     } as unknown as Config
   }
 
-  it('forwards region and defaults temperature to 0.2', () => {
-    const llm = getLlm(
+  it('forwards region and defaults temperature to 0.2', async () => {
+    const llm = await getLlm(
       'bedrock',
       'anthropic.claude-sonnet-4-6' as LLMModel,
       bedrockConfig()
@@ -116,11 +116,11 @@ describe('bedrock config forwarding', () => {
     expect(temperatureOf(llm)).toBe(0.2)
   })
 
-  it('defaults the output-token cap and lets service.fields override it', () => {
-    const llm = getLlm('bedrock', 'anthropic.claude-sonnet-4-6' as LLMModel, bedrockConfig())
+  it('defaults the output-token cap and lets service.fields override it', async () => {
+    const llm = await getLlm('bedrock', 'anthropic.claude-sonnet-4-6' as LLMModel, bedrockConfig())
     expect((llm as { maxTokens?: number }).maxTokens).toBe(DEFAULT_MAX_OUTPUT_TOKENS)
 
-    const overridden = getLlm(
+    const overridden = await getLlm(
       'bedrock',
       'anthropic.claude-sonnet-4-6' as LLMModel,
       bedrockConfig({ fields: { maxTokens: 8192 } })
@@ -128,8 +128,8 @@ describe('bedrock config forwarding', () => {
     expect((overridden as { maxTokens?: number }).maxTokens).toBe(8192)
   })
 
-  it('omits credentials when none are configured (defers to the AWS chain)', () => {
-    const llm = getLlm(
+  it('omits credentials when none are configured (defers to the AWS chain)', async () => {
+    const llm = await getLlm(
       'bedrock',
       'anthropic.claude-sonnet-4-6' as LLMModel,
       bedrockConfig()
@@ -137,8 +137,8 @@ describe('bedrock config forwarding', () => {
     expect((llm as { credentials?: unknown }).credentials).toBeUndefined()
   })
 
-  it('passes explicit credentials only when both id and secret are present', () => {
-    const llm = getLlm(
+  it('passes explicit credentials only when both id and secret are present', async () => {
+    const llm = await getLlm(
       'bedrock',
       'anthropic.claude-sonnet-4-6' as LLMModel,
       bedrockConfig({ accessKeyId: 'AKIA', secretAccessKey: 'secret', sessionToken: 'tok' })
@@ -150,8 +150,8 @@ describe('bedrock config forwarding', () => {
     })
   })
 
-  it('ignores a lone accessKeyId without a secret', () => {
-    const llm = getLlm(
+  it('ignores a lone accessKeyId without a secret', async () => {
+    const llm = await getLlm(
       'bedrock',
       'anthropic.claude-sonnet-4-6' as LLMModel,
       bedrockConfig({ accessKeyId: 'AKIA' })

--- a/src/lib/langchain/providers/registry.test.ts
+++ b/src/lib/langchain/providers/registry.test.ts
@@ -26,11 +26,11 @@ function makeConfig(service: Record<string, unknown>): Config {
 }
 
 describe('provider registry', () => {
-  it('registers the built-in providers', () => {
+  it('registers the built-in providers', async () => {
     expect(LLM_PROVIDER_IDS.sort()).toEqual(['anthropic', 'azure', 'bedrock', 'gemini', 'mistral', 'ollama', 'openai'])
   })
 
-  it('exposes per-provider auth requirements', () => {
+  it('exposes per-provider auth requirements', async () => {
     expect(providerRequiresAuth('openai')).toBe(true)
     expect(providerRequiresAuth('anthropic')).toBe(true)
     expect(providerRequiresAuth('gemini')).toBe(true)
@@ -41,21 +41,21 @@ describe('provider registry', () => {
     expect(providerRequiresAuth('nope')).toBe(false)
   })
 
-  it('finds definitions by id and returns undefined for unknown', () => {
+  it('finds definitions by id and returns undefined for unknown', async () => {
     expect(findProviderDefinition('openai')?.id).toBe('openai')
     expect(findProviderDefinition('mystery')).toBeUndefined()
   })
 })
 
 describe('getLlm via registry', () => {
-  it('builds an OpenAI model and records provider metadata', () => {
-    const llm = getLlm('openai', 'gpt-5.4-mini' as LLMModel, makeConfig({ provider: 'openai', model: 'gpt-5.4-mini' }))
+  it('builds an OpenAI model and records provider metadata', async () => {
+    const llm = await getLlm('openai', 'gpt-5.4-mini' as LLMModel, makeConfig({ provider: 'openai', model: 'gpt-5.4-mini' }))
     expect(llm).toBeInstanceOf(ChatOpenAI)
     expect(getLlmMetadata(llm).provider).toBe('openai')
   })
 
-  it('threads service.maxConcurrent into the OpenAI client (#1629)', () => {
-    const llm = getLlm(
+  it('threads service.maxConcurrent into the OpenAI client (#1629)', async () => {
+    const llm = await getLlm(
       'openai',
       'gpt-5.4-mini' as LLMModel,
       makeConfig({ provider: 'openai', model: 'gpt-5.4-mini', maxConcurrent: 3 })
@@ -63,8 +63,8 @@ describe('getLlm via registry', () => {
     expect((llm as unknown as { caller: { maxConcurrency: number } }).caller.maxConcurrency).toBe(3)
   })
 
-  it('builds an Anthropic model and records provider metadata', () => {
-    const llm = getLlm(
+  it('builds an Anthropic model and records provider metadata', async () => {
+    const llm = await getLlm(
       'anthropic',
       'claude-sonnet-4-6' as LLMModel,
       makeConfig({ provider: 'anthropic', model: 'claude-sonnet-4-6' })
@@ -73,8 +73,8 @@ describe('getLlm via registry', () => {
     expect(getLlmMetadata(llm).provider).toBe('anthropic')
   })
 
-  it('builds a Gemini model and records provider metadata', () => {
-    const llm = getLlm(
+  it('builds a Gemini model and records provider metadata', async () => {
+    const llm = await getLlm(
       'gemini',
       'gemini-2.5-flash' as LLMModel,
       makeConfig({ provider: 'gemini', model: 'gemini-2.5-flash' })
@@ -83,8 +83,8 @@ describe('getLlm via registry', () => {
     expect(getLlmMetadata(llm).provider).toBe('gemini')
   })
 
-  it('builds a Mistral model and records provider metadata', () => {
-    const llm = getLlm(
+  it('builds a Mistral model and records provider metadata', async () => {
+    const llm = await getLlm(
       'mistral',
       'mistral-small-latest' as LLMModel,
       makeConfig({ provider: 'mistral', model: 'mistral-small-latest' })
@@ -93,8 +93,8 @@ describe('getLlm via registry', () => {
     expect(getLlmMetadata(llm).provider).toBe('mistral')
   })
 
-  it('builds an Azure OpenAI model and records provider metadata', () => {
-    const llm = getLlm(
+  it('builds an Azure OpenAI model and records provider metadata', async () => {
+    const llm = await getLlm(
       'azure',
       'gpt-5.4-mini' as LLMModel,
       makeConfig({
@@ -109,14 +109,14 @@ describe('getLlm via registry', () => {
     expect(getLlmMetadata(llm).provider).toBe('azure')
   })
 
-  it('builds a Bedrock model (no auth) and records provider metadata', () => {
+  it('builds a Bedrock model (no auth) and records provider metadata', async () => {
     // Bedrock authenticates via the AWS credential chain, not a coco-managed
     // API key — `requiresAuth` is false. The ChatBedrockConverse constructor
     // resolves AWS credentials lazily (on first invoke), so it instantiates
     // fine in the test env without any AWS creds present.
     expect(findProviderDefinition('bedrock')?.requiresAuth).toBe(false)
 
-    const llm = getLlm(
+    const llm = await getLlm(
       'bedrock',
       'anthropic.claude-sonnet-4-6' as LLMModel,
       makeConfig({
@@ -130,8 +130,8 @@ describe('getLlm via registry', () => {
     expect(getLlmMetadata(llm).provider).toBe('bedrock')
   })
 
-  it('builds an Ollama model (no auth) and records the endpoint', () => {
-    const llm = getLlm(
+  it('builds an Ollama model (no auth) and records the endpoint', async () => {
+    const llm = await getLlm(
       'ollama',
       'llama3' as LLMModel,
       makeConfig({
@@ -147,8 +147,8 @@ describe('getLlm via registry', () => {
     expect(meta.endpoint).toBe('http://localhost:11434')
   })
 
-  it('defaults numPredict and lets service.fields override it for Ollama', () => {
-    const llm = getLlm(
+  it('defaults numPredict and lets service.fields override it for Ollama', async () => {
+    const llm = await getLlm(
       'ollama',
       'llama3' as LLMModel,
       makeConfig({
@@ -160,7 +160,7 @@ describe('getLlm via registry', () => {
     )
     expect((llm as { numPredict?: number }).numPredict).toBe(DEFAULT_MAX_OUTPUT_TOKENS)
 
-    const overridden = getLlm(
+    const overridden = await getLlm(
       'ollama',
       'llama3' as LLMModel,
       makeConfig({
@@ -177,8 +177,8 @@ describe('getLlm via registry', () => {
   // Regression (#1631): `createOllamaLlm` never forwarded `temperature`, so
   // both the 0.4 service default and any user-configured value were ignored
   // — generation ran at the Ollama daemon's own default instead.
-  it('defaults temperature to 0.4 and respects an explicit value, including 0', () => {
-    const llm = getLlm(
+  it('defaults temperature to 0.4 and respects an explicit value, including 0', async () => {
+    const llm = await getLlm(
       'ollama',
       'llama3' as LLMModel,
       makeConfig({
@@ -190,7 +190,7 @@ describe('getLlm via registry', () => {
     )
     expect((llm as { temperature?: number }).temperature).toBe(0.4)
 
-    const deterministic = getLlm(
+    const deterministic = await getLlm(
       'ollama',
       'llama3' as LLMModel,
       makeConfig({
@@ -203,7 +203,7 @@ describe('getLlm via registry', () => {
     )
     expect((deterministic as { temperature?: number }).temperature).toBe(0)
 
-    const hot = getLlm(
+    const hot = await getLlm(
       'ollama',
       'llama3' as LLMModel,
       makeConfig({
@@ -217,8 +217,8 @@ describe('getLlm via registry', () => {
     expect((hot as { temperature?: number }).temperature).toBe(0.9)
   })
 
-  it('lets service.fields override the Ollama temperature', () => {
-    const llm = getLlm(
+  it('lets service.fields override the Ollama temperature', async () => {
+    const llm = await getLlm(
       'ollama',
       'llama3' as LLMModel,
       makeConfig({

--- a/src/lib/langchain/providers/types.ts
+++ b/src/lib/langchain/providers/types.ts
@@ -28,8 +28,13 @@ export type ProviderDefinition = {
    * Bedrock) set this false.
    */
   requiresAuth: boolean
-  /** Instantiate the chat model for this provider. */
-  createLlm: (args: CreateLlmArgs) => BaseChatModel
+  /**
+   * Instantiate the chat model for this provider. Async so implementations
+   * can `await import()` their SDK on first use — the provider SDKs dominate
+   * CLI startup time (~2.5s of require cost across all of them, 1.2s for
+   * Mistral alone), so none of them may be imported at module scope.
+   */
+  createLlm: (args: CreateLlmArgs) => Promise<BaseChatModel>
   /**
    * Resolve the effective endpoint for observability / network-error
    * messages, when the provider has a meaningful one (e.g. Ollama's base

--- a/src/lib/langchain/utils/executeChain.test.ts
+++ b/src/lib/langchain/utils/executeChain.test.ts
@@ -44,10 +44,10 @@ function silentLogger(): Logger {
 /**
  * See executeChainStreaming.test.ts for why this cast exists: FakeListChatModel
  * implements the same Runnable surface the helper exercises but isn't a
- * member of the narrow `ReturnType<typeof getLlm>` union.
+ * member of the narrow `Awaited<ReturnType<typeof getLlm>>` union.
  */
-function asLlm(model: FakeListChatModel): ReturnType<typeof getLlm> {
-  return model as unknown as ReturnType<typeof getLlm>
+function asLlm(model: FakeListChatModel): Awaited<ReturnType<typeof getLlm>> {
+  return model as unknown as Awaited<ReturnType<typeof getLlm>>
 }
 
 describe('executeChain', () => {

--- a/src/lib/langchain/utils/executeChain.ts
+++ b/src/lib/langchain/utils/executeChain.ts
@@ -20,7 +20,7 @@ import { estimatePromptTokens, LlmCallMetadata, logLlmCall } from './observabili
 type ExecuteChainInput<T> = {
   variables: Record<string, unknown>
   prompt: PromptTemplate
-  llm: ReturnType<typeof getLlm>
+  llm: Awaited<ReturnType<typeof getLlm>>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   parser: Runnable<any, T>
   /** Optional provider name for better error messages */

--- a/src/lib/langchain/utils/executeChainStreaming.test.ts
+++ b/src/lib/langchain/utils/executeChainStreaming.test.ts
@@ -114,8 +114,8 @@ function chunkRecorder(): {
  * type-system convenience for tests; the runtime behaviour is the same
  * polymorphic Runnable dispatch.
  */
-function asLlm(model: FakeListChatModel): ReturnType<typeof getLlm> {
-  return model as unknown as ReturnType<typeof getLlm>
+function asLlm(model: FakeListChatModel): Awaited<ReturnType<typeof getLlm>> {
+  return model as unknown as Awaited<ReturnType<typeof getLlm>>
 }
 
 describe('executeChainStreaming', () => {

--- a/src/lib/langchain/utils/executeChainStreaming.ts
+++ b/src/lib/langchain/utils/executeChainStreaming.ts
@@ -46,7 +46,7 @@ export type StreamChunkHandler = (chunk: StreamingChunk) => void
 export interface ExecuteChainStreamingInput<T> {
   variables: Record<string, unknown>
   prompt: PromptTemplate
-  llm: ReturnType<typeof getLlm>
+  llm: Awaited<ReturnType<typeof getLlm>>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   parser: Runnable<any, T>
   /**

--- a/src/lib/langchain/utils/executeChainWithSchema.ts
+++ b/src/lib/langchain/utils/executeChainWithSchema.ts
@@ -41,7 +41,7 @@ export interface ExecuteChainWithSchemaOptions<T> extends SchemaParserOptions {
  */
 export async function executeChainWithSchema<T>(
   schema: z.ZodSchema<T>,
-  llm: ReturnType<typeof getLlm>,
+  llm: Awaited<ReturnType<typeof getLlm>>,
   prompt: PromptTemplate,
   variables: Record<string, unknown>,
   options: ExecuteChainWithSchemaOptions<T> = {}

--- a/src/lib/langchain/utils/getLlm.test.ts
+++ b/src/lib/langchain/utils/getLlm.test.ts
@@ -16,8 +16,8 @@ function makeAnthropicConfig(service: Record<string, unknown> = {}): Config {
 }
 
 describe('getLlm — Anthropic field forwarding', () => {
-  it('forwards temperature and maxTokens from service.fields', () => {
-    const llm = getLlm(
+  it('forwards temperature and maxTokens from service.fields', async () => {
+    const llm = await getLlm(
       'anthropic',
       'claude-sonnet-4-6' as LLMModel,
       makeAnthropicConfig({ fields: { temperature: 0.7, maxTokens: 1234 } })
@@ -29,8 +29,8 @@ describe('getLlm — Anthropic field forwarding', () => {
     expect(anthropic.maxTokens).toBe(1234)
   })
 
-  it('forwards a custom baseURL as the Anthropic API URL', () => {
-    const llm = getLlm(
+  it('forwards a custom baseURL as the Anthropic API URL', async () => {
+    const llm = await getLlm(
       'anthropic',
       'claude-sonnet-4-6' as LLMModel,
       makeAnthropicConfig({ baseURL: 'https://proxy.example.com' })
@@ -40,8 +40,8 @@ describe('getLlm — Anthropic field forwarding', () => {
     expect(anthropic.apiUrl).toBe('https://proxy.example.com')
   })
 
-  it('applies the base service temperature when no field override is present', () => {
-    const llm = getLlm(
+  it('applies the base service temperature when no field override is present', async () => {
+    const llm = await getLlm(
       'anthropic',
       'claude-sonnet-4-6' as LLMModel,
       makeAnthropicConfig({ temperature: 0.4 })

--- a/src/lib/langchain/utils/getLlm.ts
+++ b/src/lib/langchain/utils/getLlm.ts
@@ -22,7 +22,11 @@ import { recordLlmMetadata } from './llmMetadata'
  * @throws LangChainConfigurationError if the provider/model combination is invalid
  * @throws LangChainExecutionError if LLM instantiation fails
  */
-export function getLlm(provider: LLMProvider, model: LLMModel, config: Config): BaseChatModel {
+export async function getLlm(
+  provider: LLMProvider,
+  model: LLMModel,
+  config: Config
+): Promise<BaseChatModel> {
   // Validate input parameters
   validateProvider(provider, 'getLlm')
   validateModel(model, provider, 'getLlm')
@@ -46,7 +50,7 @@ export function getLlm(provider: LLMProvider, model: LLMModel, config: Config): 
   }
 
   try {
-    const llm = definition.createLlm({ model, config, apiKey })
+    const llm = await definition.createLlm({ model, config, apiKey })
     recordLlmMetadata(llm, {
       provider,
       endpoint: definition.resolveEndpoint?.(config),

--- a/src/lib/parsers/default/utils/createFileChangeParserOptions.ts
+++ b/src/lib/parsers/default/utils/createFileChangeParserOptions.ts
@@ -37,7 +37,7 @@ export type FileChangeParserServiceBudget = {
 export type CreateFileChangeParserOptionsInput = {
   command: string
   git: SimpleGit
-  llm: ReturnType<typeof getLlm>
+  llm: Awaited<ReturnType<typeof getLlm>>
   logger: Logger
   model: string
   provider: LLMProvider | string

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -49,7 +49,7 @@ export interface DirectoryDiff {
 
 export interface BaseParserOptions {
   tokenizer: TokenCounter
-  llm: ReturnType<typeof getLlm>
+  llm: Awaited<ReturnType<typeof getLlm>>
   git: SimpleGit
   logger: Logger
   maxTokens?: number


### PR DESCRIPTION
## Problem

`coco --version` (and every command's time-to-banner) took **~3s**, nearly all of it module loading. A require-time profile of the published bundle:

```
  1192 @mistralai/mistralai
   429 (app)
   244 @langchain/core
   147 openai
    67 langsmith
    62 @smithy/core
    60 @anthropic-ai/sdk
    ...
  total require time: 2687 ms
```

Every provider module imports its LangChain SDK at module scope, and `providers/registry.ts` imports every provider — so all seven SDKs load on every invocation regardless of which provider is configured.

## Change

- `ProviderDefinition.createLlm` is now async; each provider `await import()`s its SDK inside the factory, so the cost is paid only when (and for the provider) an LLM is actually created. Dynamic import stays lazy in both the CJS and ESM rollup outputs.
- Registry metadata (`label`, `requiresAuth`, `tokenCorrectionFactor`) remains eagerly available for sync consumers (tokenizer, validation, init wizard).
- `getLlm` is async; all call sites were already in async functions and now await it. Shared types moved to `Awaited<ReturnType<typeof getLlm>>`.
- `constants.ts`'s `TiktokenModel` import made explicitly type-only.

## Results

| | before | after |
|---|---|---|
| `--version` wall time | ~3.0s | **~0.28s** |
| require time | 2687ms | **258ms** |

Verified end-to-end with a live `commit --printMessage` run against OpenAI (lazy `ChatOpenAI` import path), plus the ESM bundle boots. Full jest suite green apart from the pre-existing worktree-only tree-sitter WASM failures (also fail on a clean checkout of main in a worktree).