### PR TITLE
fix(workstation): tighten stacked-mode history rows at rail widths

### DIFF
--- a/src/workstation/surfaces/history/historyRender.test.ts
+++ b/src/workstation/surfaces/history/historyRender.test.ts
@@ -183,6 +183,58 @@ describe('renderHistoryPanel', () => {
     expect(tree).toBeDefined()
   })
 
+  // Rail-density regressions (screenshot report, 2026-07): stacked mode
+  // rendered nearly every commit as subject line + `·`-only meta line +
+  // graph transition line — three terminal lines of mostly air per commit.
+  describe('stacked-mode density', () => {
+    const collectStrings = (node: unknown, out: string[]): string[] => {
+      if (typeof node === 'string') {
+        out.push(node)
+      } else if (Array.isArray(node)) {
+        node.forEach((child) => collectStrings(child, out))
+      } else if (node && typeof node === 'object' && 'props' in node) {
+        collectStrings((node as { props: { children?: unknown } }).props.children, out)
+      }
+      return out
+    }
+
+    const collectKeys = (node: unknown, out: string[]): string[] => {
+      if (Array.isArray(node)) {
+        node.forEach((child) => collectKeys(child, out))
+      } else if (node && typeof node === 'object' && 'props' in node) {
+        const key = (node as { key?: unknown }).key
+        if (typeof key === 'string') out.push(key)
+        collectKeys((node as { props: { children?: unknown } }).props.children, out)
+      }
+      return out
+    }
+
+    it('falls back to the relative date on line 2 for ref-less rows under bucketing', () => {
+      const tree = render(makeState(), {
+        rowMode: 'stacked',
+        width: 40,
+        dateBucketingEnabled: true,
+      })
+      const strings = collectStrings(tree, [])
+      // bbb2222 / ccc3333 have no refs; with the date suppressed they used
+      // to render a bare `·` placeholder. Now the relative date fills the
+      // line ('2026-05-18' vs now 2026-05-26 → '8d').
+      expect(strings).toContain('8d')
+      expect(strings).not.toContain('·')
+    })
+
+    it('skips per-commit graph transition rows in stacked mode', () => {
+      const single = render(makeState(), { rowMode: 'single', width: 120 })
+      const stacked = render(makeState(), { rowMode: 'stacked', width: 40 })
+      const graphRows = (tree: ReactElement) =>
+        collectKeys(tree, []).filter((key) => key.startsWith('graph-'))
+      // Full-graph single mode keeps its spacer rhythm; stacked mode
+      // drops the dedicated topology line (commits already cost 2 lines).
+      expect(graphRows(single).length).toBeGreaterThan(0)
+      expect(graphRows(stacked).length).toBe(0)
+    })
+  })
+
   it('swaps the commit list for a loader while a remote op is in flight', () => {
     // Collect every string rendered anywhere in the tree.
     const collectText = (node: unknown, out: string[]): string[] => {

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -475,8 +475,13 @@ function renderStackedCommitHistoryRow(
   // filtered against the chip so we don't repeat the branch tip both
   // as a leading chip and a trailing label.
   const indent = ' '.repeat(graphWidth + 1)
-  const dateText = bucketed ? '' : formatCompactRelativeDate(commit.date, now)
   const refs = formatInkRefLabels(filterChippedRefs(commit.refs, chip.chip, remoteNames))
+  // Bucket headers make the per-row date redundant — but only when the row
+  // has refs to show instead. A ref-less row under bucketing used to render
+  // a bare `·` placeholder on line 2, which at rail widths made the whole
+  // list read as double-spaced noise; fall back to the relative date so the
+  // line earns its space.
+  const dateText = bucketed && refs ? '' : formatCompactRelativeDate(commit.date, now)
   const metaRoom = Math.max(8, totalWidth - indent.length - (dateText ? dateText.length + 1 : 0))
   const refsTrunc = refs ? truncateCells(refs, metaRoom) : ''
   // If both pieces are empty (date unparseable + no refs), show a
@@ -664,7 +669,12 @@ export function renderHistoryPanel(
   // guardrail: even with bucketing enabled, an active search filter
   // shuffles commits by relevance so the adjacent-bucket invariant
   // breaks down and the dividers would read as noise.
-  const fullGraphSpacing = state.fullGraph && !state.filter
+  // Stacked rows already cost two terminal lines, so the per-commit
+  // transition row (comfortable rhythm on wide layouts) pushed each commit
+  // to ~3 lines at rail widths — the list read as mostly air. Rail mode
+  // keeps the lane rails on commit rows but skips the dedicated topology
+  // line between them.
+  const fullGraphSpacing = state.fullGraph && !state.filter && rowMode !== 'stacked'
   const dateBucketingNow = !dateBucketingEnabled || state.filter ? undefined : now
   // Hoisted so the row budget can count the banner (#1392) — it used
   // to be computed inline in the return, invisible to chromeRows.
@@ -676,14 +686,14 @@ export function renderHistoryPanel(
   const chromeRows = (showPendingRow ? 5 : 4)
     + (upstreamBanner ? 1 : 0)
     + (state.historyFetchArgs ? 1 : 0)
-  // Stacked rows take two terminal lines each; graph spacers and
-  // bucket headers take one. In practice the expanded list alternates
-  // commit (2 lines) and transition (1 line), so the average item
-  // costs ~1.5 lines. Dividing by 2 left ~25% of the body blank on
-  // 80×24 terminals (#1368). Using 2/3 of the line budget as the item
-  // count fills the panel without overflow.
+  // Stacked rows take two terminal lines each and (with transition rows
+  // suppressed above) every stacked item is a commit, so the item budget
+  // is the line budget halved. Bucket headers cost one line each, which
+  // under-fills by a line per header — safe direction, never overflows.
+  // (The old 2/3 ratio from #1368 assumed the commit/transition
+  // alternation averaging ~1.5 lines per item.)
   const listRows = rowMode === 'stacked'
-    ? Math.max(2, Math.floor((bodyRows - chromeRows) * 2 / 3))
+    ? Math.max(2, Math.floor((bodyRows - chromeRows) / 2))
     : Math.max(3, bodyRows - chromeRows)
   const visible = getVisibleLogInkHistory(state, listRows, { fullGraphSpacing, dateBucketingNow })
   const loadState = loadingMoreCommits


### PR DESCRIPTION
## Problem

At rail widths (<100 cols) the commit graph read as double-spaced noise (screenshot report). Each commit cost up to **three terminal lines**:

1. the subject line,
2. a metadata line that collapsed to a bare `·` placeholder for ref-less rows — date bucketing (#1527) suppresses the per-row date, and most commits have no branch/tag chip, so nearly every row got a dot-only line,
3. a full-graph transition row (#1190) injected after every commit.

## Change (stacked mode only)

- **Line 2 falls back to the compact relative date** (`8d`, `3w`, …) when the row has no refs to show — the line earns its space instead of rendering `·`. Wide layouts and rows with refs are unchanged.
- **Per-commit transition rows are skipped.** Commit rows keep their lane rails; only the dedicated topology line between commits goes. The stacked item budget moves from the 2/3 ratio (tuned in #1368 for the commit/transition alternation averaging ~1.5 lines/item) to a straight halving, which also fits more commits on screen.

Merge-crossing glyph runs (`├┼┼┼┤`) and lane width are untouched — that rendering is correct topology, just dense; can revisit separately if it still bothers at rail widths.

## Validation

- New structural regression tests: ref-less bucketed rows show the relative date and never a `·`; stacked render contains zero `graph-*` transition rows while single-mode full-graph keeps them.
- Full jest suite green (only the known worktree-local tree-sitter WASM failures, which also fail on a clean main checkout in a worktree); eslint 0 errors; rollup build green.