### PR TITLE
fix(deps): bump brace-expansion to 5.0.7, patching a DoS advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
   },
   "resolutions": {
     "cross-spawn": "7.0.6",
-    "brace-expansion": "^5.0.6",
+    "brace-expansion": "^5.0.7",
     "@anthropic-ai/sdk": "^0.91.1",
     "ip-address": "^10.1.1",
     "shell-quote": "^1.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2713,10 +2713,10 @@ bowser@^2.11.0:
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.14.1.tgz#4ea39bf31e305184522d7ad7bfd91389e4f0cb79"
   integrity sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==
 
-brace-expansion@^1.1.7, brace-expansion@^5.0.2, brace-expansion@^5.0.5, brace-expansion@^5.0.6:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
-  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
+brace-expansion@^1.1.7, brace-expansion@^5.0.2, brace-expansion@^5.0.5, brace-expansion@^5.0.7:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.7.tgz#1b0e46965b479dad65af737b4a02790a05498337"
+  integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
## Problem

[GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) / CVE-2026-13149 ([Dependabot alert #167](https://github.com/gfargo/coco/security/dependabot/167), high severity): `brace-expansion`'s `expand()` is exponential-time (O(2^n)) in the number of consecutive non-expanding `{}` groups — a ~90-byte, 30-group input hangs the calling thread for minutes.

The existing `resolutions` pin in `package.json` (added for an earlier brace-expansion CVE) forces every consumer, including the `^1.1.7` range some transitive deps declare, to `^5.0.6` — which falls inside this advisory's vulnerable range (`>= 3.0.0, < 5.0.7`).

## Fix

Bump the resolutions pin to `^5.0.7` (the first patched release) and regenerate `yarn.lock`. Scope is exactly `package.json` + `yarn.lock`, one line each.

## Validation

tsc clean, eslint 0 errors, full jest suite green (only the pre-existing worktree-local tree-sitter WASM failures, unrelated), rollup build succeeds.