### PR TITLE
fix(workstation): collapse stacked rows to single-line when bucketed and ref-less

### DIFF
--- a/src/workstation/surfaces/history/historyRender.test.ts
+++ b/src/workstation/surfaces/history/historyRender.test.ts
@@ -209,17 +209,17 @@ describe('renderHistoryPanel', () => {
       return out
     }
 
-    it('falls back to the relative date on line 2 for ref-less rows under bucketing', () => {
+    it('collapses ref-less rows to single-line under bucketing (no redundant date line)', () => {
       const tree = render(makeState(), {
         rowMode: 'stacked',
         width: 40,
         dateBucketingEnabled: true,
       })
       const strings = collectStrings(tree, [])
-      // bbb2222 / ccc3333 have no refs; with the date suppressed they used
-      // to render a bare `·` placeholder. Now the relative date fills the
-      // line ('2026-05-18' vs now 2026-05-26 → '8d').
-      expect(strings).toContain('8d')
+      // bbb2222 / ccc3333 have no refs; with bucketing active the bucket
+      // header already conveys the timeframe, so line 2 is suppressed
+      // entirely — no relative date, no `·` placeholder (#1421).
+      expect(strings).not.toContain('8d')
       expect(strings).not.toContain('·')
     })
 

--- a/src/workstation/surfaces/history/index.ts
+++ b/src/workstation/surfaces/history/index.ts
@@ -476,11 +476,19 @@ function renderStackedCommitHistoryRow(
   // as a leading chip and a trailing label.
   const indent = ' '.repeat(graphWidth + 1)
   const refs = formatInkRefLabels(filterChippedRefs(commit.refs, chip.chip, remoteNames))
-  // Bucket headers make the per-row date redundant — but only when the row
-  // has refs to show instead. A ref-less row under bucketing used to render
-  // a bare `·` placeholder on line 2, which at rail widths made the whole
-  // list read as double-spaced noise; fall back to the relative date so the
-  // line earns its space.
+  // When bucketing is active, the bucket header already conveys the
+  // timeframe — a per-row date is redundant. If the commit also has
+  // no refs, line 2 would only show "1d" / "3d" (or a bare `·`),
+  // which at rail widths makes the whole list read as double-spaced
+  // noise. Collapse to a single-line row in that case so the graph
+  // is dense and readable on tiny terminals (#1421).
+  if (bucketed && !refs) {
+    return h(Box, {
+      key: `${commit.hash}-${index}-stack`,
+      flexDirection: 'column',
+    }, lineOne)
+  }
+
   const dateText = bucketed && refs ? '' : formatCompactRelativeDate(commit.date, now)
   const metaRoom = Math.max(8, totalWidth - indent.length - (dateText ? dateText.length + 1 : 0))
   const refsTrunc = refs ? truncateCells(refs, metaRoom) : ''
@@ -686,14 +694,19 @@ export function renderHistoryPanel(
   const chromeRows = (showPendingRow ? 5 : 4)
     + (upstreamBanner ? 1 : 0)
     + (state.historyFetchArgs ? 1 : 0)
-  // Stacked rows take two terminal lines each and (with transition rows
-  // suppressed above) every stacked item is a commit, so the item budget
-  // is the line budget halved. Bucket headers cost one line each, which
-  // under-fills by a line per header — safe direction, never overflows.
-  // (The old 2/3 ratio from #1368 assumed the commit/transition
-  // alternation averaging ~1.5 lines per item.)
+  // Stacked rows normally take two terminal lines each, so the item
+  // budget is the line budget halved. But when bucketing is active,
+  // commits without refs collapse to a single line (#1421) — only
+  // branch-tip / tagged commits keep the metadata row. In practice
+  // ~80-90% of visible commits carry no refs, so the effective lines
+  // per item is much closer to 1 than 2. A divisor of 1.4 fills the
+  // panel densely while leaving headroom for the occasional 2-line
+  // row and the bucket headers (1 line each). Without bucketing the
+  // old /2 ratio applies (every row is two lines). Safe direction:
+  // under-fill never overflows.
+  const stackedDivisor = dateBucketingNow ? 1.4 : 2
   const listRows = rowMode === 'stacked'
-    ? Math.max(2, Math.floor((bodyRows - chromeRows) / 2))
+    ? Math.max(2, Math.floor((bodyRows - chromeRows) / stackedDivisor))
     : Math.max(3, bodyRows - chromeRows)
   const visible = getVisibleLogInkHistory(state, listRows, { fullGraphSpacing, dateBucketingNow })
   const loadState = loadingMoreCommits


### PR DESCRIPTION
## Summary

On rail-density terminals (< 100 cols), the stacked row mode rendered every commit as two lines — graph/hash/subject on line 1, relative date on line 2. With date bucketing active (bucket headers like "This week", "Yesterday"), the per-row date was redundant, making the whole list read as double-spaced.

## Changes

- **Skip line 2 entirely** for commits without refs when bucketing is active. The bucket header already conveys the timeframe, so a standalone "1d" or "3d" metadata line adds no information and wastes vertical space.
- **Adjust the listRows budget** from a fixed `/2` divisor to `/1.4` when stacked + bucketed, reflecting that most rows are now single-line. Without bucketing the original `/2` still applies.
- Commits with branch/tag refs still render two lines (the refs metadata line earns its space).
- Updated the test that asserted the old "fall back to relative date" behavior to match the new single-line collapse.

## Testing

- `npx tsc --noEmit` — clean
- `eslint` — clean
- All 174 history-related tests pass
