### PR TITLE
fix(langchain): clamp AsyncCaller retries to 0 across all providers

### DIFF
--- a/src/lib/langchain/chains/summarize/index.ts
+++ b/src/lib/langchain/chains/summarize/index.ts
@@ -33,6 +33,10 @@ export type SummarizeContext = {
  * pipeline ultimately handles via fewer concurrent passes anyway.
  * 3 retries with 1s/2s/4s waits trade ~7s of worst-case extra
  * latency for resilience to brief rate-limit blips.
+ *
+ * NOTE: LangChain's internal AsyncCaller retries are disabled at the
+ * provider level (maxRetries: 0, #1677) so this is the ONLY retry
+ * layer for summarize calls — no multiplication.
  */
 const BACKOFF_RETRIES = 3
 const BACKOFF_BASE_MS = 1000

--- a/src/lib/langchain/providers/anthropic.ts
+++ b/src/lib/langchain/providers/anthropic.ts
@@ -7,11 +7,16 @@ async function createAnthropicLlm({ model, config, apiKey }: CreateLlmArgs): Pro
   const anthropicConfig: ConstructorParameters<typeof ChatAnthropic>[0] = {
     anthropicApiKey: apiKey,
     maxConcurrency: config.service.maxConcurrent,
+    // Disable LangChain's built-in AsyncCaller retries (#1677).
+    maxRetries: config.service.requestOptions?.maxRetries ?? 0,
     model,
     // `??` not `||` so an explicit `temperature: 0` (fully deterministic) is
     // respected instead of being coerced to the 0.2 default.
     temperature: config.service.temperature ?? 0.2,
     maxTokens: DEFAULT_MAX_OUTPUT_TOKENS,
+    ...(config.service.requestOptions?.timeout
+      ? { clientOptions: { timeout: config.service.requestOptions.timeout } }
+      : {}),
   }
 
   // Custom endpoint for proxies / gateways.

--- a/src/lib/langchain/providers/azure.ts
+++ b/src/lib/langchain/providers/azure.ts
@@ -14,7 +14,12 @@ async function createAzureLlm({ model, config, apiKey }: CreateLlmArgs): Promise
     azureOpenAIApiVersion: svc.apiVersion,
     temperature: config.service.temperature ?? 0.2,
     maxConcurrency: config.service.maxConcurrent,
+    // Disable LangChain's built-in AsyncCaller retries (#1677).
+    maxRetries: config.service.requestOptions?.maxRetries ?? 0,
     maxTokens: DEFAULT_MAX_OUTPUT_TOKENS,
+    ...(config.service.requestOptions?.timeout
+      ? { timeout: config.service.requestOptions.timeout }
+      : {}),
   }
 
   // Merge Azure-specific fields forwarded from service config.

--- a/src/lib/langchain/providers/bedrock.ts
+++ b/src/lib/langchain/providers/bedrock.ts
@@ -26,6 +26,8 @@ async function createBedrockLlm({ model, config }: CreateLlmArgs): Promise<BaseC
       : {}),
     temperature: config.service.temperature ?? 0.2,
     maxConcurrency: config.service.maxConcurrent,
+    // Disable LangChain's built-in AsyncCaller retries (#1677).
+    maxRetries: config.service.requestOptions?.maxRetries ?? 0,
   }
 
   // Merge Bedrock-specific fields forwarded from service config.

--- a/src/lib/langchain/providers/gemini.ts
+++ b/src/lib/langchain/providers/gemini.ts
@@ -9,6 +9,8 @@ async function createGeminiLlm({ model, config, apiKey }: CreateLlmArgs): Promis
     model,
     temperature: config.service.temperature ?? 0.2,
     maxConcurrency: config.service.maxConcurrent,
+    // Disable LangChain's built-in AsyncCaller retries (#1677).
+    maxRetries: config.service.requestOptions?.maxRetries ?? 0,
     maxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
   }
 

--- a/src/lib/langchain/providers/mistral.ts
+++ b/src/lib/langchain/providers/mistral.ts
@@ -9,6 +9,8 @@ async function createMistralLlm({ model, config, apiKey }: CreateLlmArgs): Promi
     model,
     temperature: config.service.temperature ?? 0.2,
     maxConcurrency: config.service.maxConcurrent,
+    // Disable LangChain's built-in AsyncCaller retries (#1677).
+    maxRetries: config.service.requestOptions?.maxRetries ?? 0,
     maxTokens: DEFAULT_MAX_OUTPUT_TOKENS,
   }
 

--- a/src/lib/langchain/providers/ollama.ts
+++ b/src/lib/langchain/providers/ollama.ts
@@ -18,6 +18,8 @@ async function createOllamaLlm({ model, config }: CreateLlmArgs): Promise<BaseCh
   const ollamaConfig: ConstructorParameters<typeof ChatOllama>[0] = {
     baseUrl: resolveOllamaEndpoint(config),
     maxConcurrency: config.service.maxConcurrent,
+    // Disable LangChain's built-in AsyncCaller retries (#1677).
+    maxRetries: config.service.requestOptions?.maxRetries ?? 0,
     model,
     // `??` not `||` so an explicit `temperature: 0` (fully deterministic) is
     // respected instead of being coerced to the default (#1631). Matches the

--- a/src/lib/langchain/providers/openai.ts
+++ b/src/lib/langchain/providers/openai.ts
@@ -7,11 +7,18 @@ async function createOpenAiLlm({ model, config, apiKey }: CreateLlmArgs): Promis
   const openaiConfig: Partial<ConstructorParameters<typeof ChatOpenAI>[0]> = {
     apiKey,
     maxConcurrency: config.service.maxConcurrent,
+    // Disable LangChain's built-in AsyncCaller retries — coco's own
+    // retry layers (invokeWithBackoff, withRetry in executeChainWithSchema)
+    // are the single retry authority (#1677).
+    maxRetries: config.service.requestOptions?.maxRetries ?? 0,
     model,
     // `??` not `||` so an explicit `temperature: 0` (fully deterministic) is
     // respected instead of being coerced to the 0.2 default.
     temperature: config.service.temperature ?? 0.2,
     maxTokens: DEFAULT_MAX_OUTPUT_TOKENS,
+    ...(config.service.requestOptions?.timeout
+      ? { timeout: config.service.requestOptions.timeout }
+      : {}),
   }
 
   // Custom base URL for OpenAI-compatible APIs (OpenRouter, etc.).


### PR DESCRIPTION
## Summary

LangChain's built-in `AsyncCaller` defaults to 6 internal retries with exponential backoff (~63s worst case for 429/5xx). Coco layers its own retry logic on top (`invokeWithBackoff`: 4 attempts for summarize, `executeChainWithSchema`: 3 attempts via `withRetry`), so a single failing call could multiply into ~28 HTTP requests and minutes of hang — hammering a rate-limited key instead of the documented ~7s backoff.

## Fix

Pass `maxRetries: 0` to every LangChain `ChatModel` constructor across all 7 providers (OpenAI, Anthropic, Azure, Gemini, Mistral, Bedrock, Ollama). This makes coco's own retry layers the single retry authority.

The value reads from `config.service.requestOptions?.maxRetries ?? 0`, so users who explicitly set `requestOptions.maxRetries` in their config will have that honored — but the default is now 0 (no internal LangChain retries).

Also forwards `requestOptions.timeout` to providers that support it (OpenAI/Azure via `timeout`, Anthropic via `clientOptions.timeout`).

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Transient 503 during commit | Up to 7 × 3 = 21 HTTP attempts | 3 attempts (withRetry only) |
| Rate limit during summarize fan-out | Up to 7 × 4 = 28 attempts per chunk | 4 attempts (invokeWithBackoff only) |
| Worst-case hang per failing call | ~4+ minutes | ~7s |

## Testing

- `npx tsc --noEmit` — clean
- `eslint` — clean
- All 340 langchain/provider/summarize tests pass

Closes #1677
