### PR TITLE
feat(commit): support the global --json flag for structured draft output

### DIFF
--- a/src/commands/commit/commit.test.ts
+++ b/src/commands/commit/commit.test.ts
@@ -515,4 +515,72 @@ describe('commit command', () => {
       expect(writes).toHaveLength(0)
     })
   })
+
+  describe('--json', () => {
+    beforeEach(() => {
+      argv.json = true
+    })
+
+    const captureStdout = async (run: () => Promise<void>): Promise<string> => {
+      const writes: string[] = []
+      const writeSpy = jest
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(((chunk: string) => {
+          writes.push(String(chunk))
+          return true
+        }) as never)
+      try {
+        await run()
+      } finally {
+        writeSpy.mockRestore()
+      }
+      return writes.join('')
+    }
+
+    it('emits the draft as structured { title, body } JSON without committing or reviewing', async () => {
+      const output = await captureStdout(() => handler(argv, logger))
+
+      expect(JSON.parse(output)).toEqual({
+        title: 'Test commit title',
+        body: 'Test commit body',
+      })
+      expect(mockCreateCommit).not.toHaveBeenCalled()
+      expect(mockGenerateAndReviewLoop).not.toHaveBeenCalled()
+      expect(mockHandleResult).not.toHaveBeenCalled()
+    })
+
+    it('keeps --append content in the body, so the JSON matches what --print-message would print', async () => {
+      argv.append = 'Reviewed-by: QA'
+
+      const output = await captureStdout(() => handler(argv, logger))
+
+      expect(JSON.parse(output)).toEqual({
+        title: 'Test commit title',
+        body: 'Test commit body\n\nReviewed-by: QA',
+      })
+    })
+
+    it('wins over --print-message: one machine-readable payload, no duplicate raw draft', async () => {
+      argv.printMessage = true
+
+      const output = await captureStdout(() => handler(argv, logger))
+
+      expect(JSON.parse(output)).toEqual({
+        title: 'Test commit title',
+        body: 'Test commit body',
+      })
+    })
+
+    it('emits a parseable { error } payload and exits non-zero when there are no staged changes', async () => {
+      mockGetChanges.mockResolvedValue({ staged: [], unstaged: [], untracked: [] })
+
+      const output = await captureStdout(async () => {
+        await expect(handler(argv, logger)).rejects.toMatchObject({ code: 1 })
+      })
+
+      const parsed = JSON.parse(output)
+      expect(typeof parsed.error).toBe('string')
+      expect(parsed.error.length).toBeGreaterThan(0)
+    })
+  })
 })

--- a/src/commands/commit/config.ts
+++ b/src/commands/commit/config.ts
@@ -159,6 +159,9 @@ export const options = {
     type: 'boolean',
     default: false,
   },
+  // `--json` is a global flag (see src/index.ts). On `commit` it behaves like
+  // `--print-message` — generate a draft, don't commit — but emits the result
+  // as structured `{ "title", "body" }` for machine consumers.
 } as Record<string, Options>
 
 export const builder = (yargs: Argv) => {

--- a/src/commands/commit/handler.ts
+++ b/src/commands/commit/handler.ts
@@ -19,6 +19,7 @@ import { getCurrentBranchName } from '../../lib/simple-git/getCurrentBranchName'
 import { getPreviousCommits } from '../../lib/simple-git/getPreviousCommits'
 import { CommandHandler, FileChange } from '../../lib/types'
 import { applyRepoFlag } from '../utils/applyRepoFlag'
+import { emitJson } from '../../lib/ui/emitJson'
 import { generateAndReviewLoop } from '../../lib/ui/generateAndReviewLoop'
 import { handleMissingApiKey } from '../../lib/ui/handleMissingApiKey'
 import { handleResult } from '../../lib/ui/handleResult'
@@ -48,7 +49,13 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
   // `createCommit` entirely — this is the non-interactive path the
   // `prepare-commit-msg` hook installed via `coco hooks install` calls on
   // every plain `git commit` (#1591).
-  if (argv.printMessage) {
+  //
+  // The global `--json` flag rides the same draft-only path, but emits the
+  // result as structured `{ "title", "body" }` via `emitJson` instead of the
+  // flattened message text — for agents and pipelines that consume the draft
+  // programmatically. When both flags are passed, `--json` wins: one payload,
+  // machine-readable.
+  if (argv.printMessage || argv.json) {
     const result = await generateCommitDraft({ git, argv, logger })
     if (!result.ok || !result.draft) {
       for (const warning of result.warnings) {
@@ -57,9 +64,27 @@ export const handler: CommandHandler<CommitArgv> = async (argv, logger) => {
       for (const validationError of result.validationErrors) {
         logger.verbose(validationError, { color: 'red' })
       }
+      if (argv.json) {
+        // Machine consumers get a parseable error payload on stdout
+        // (mirrors recap's `--json` error shape); the non-zero exit code
+        // stays the primary failure signal.
+        const reason = [...result.warnings, ...result.validationErrors].join('; ')
+        emitJson({ error: reason || 'Failed to generate a commit message draft.' })
+      }
       commandExit(1)
     }
-    process.stdout.write(`${result.draft}\n`)
+    if (argv.json) {
+      // Split the finished draft rather than reusing the raw LLM response:
+      // the draft is the single source of truth after `--append` /
+      // `--append-ticket` and commitlint retries have been applied, and
+      // `formatCommitMessage` always joins the parts as `title\n\nbody`.
+      const separatorIndex = result.draft.indexOf('\n\n')
+      const title = separatorIndex === -1 ? result.draft : result.draft.slice(0, separatorIndex)
+      const body = separatorIndex === -1 ? '' : result.draft.slice(separatorIndex + 2)
+      emitJson({ title, body })
+    } else {
+      process.stdout.write(`${result.draft}\n`)
+    }
     return
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,8 @@ y.option('quiet', {
 
 // Global `--json` — declared globally so it's a recognized, documented flag
 // on every command. Commands that produce structured output (issues, prs,
-// log, changelog, recap, review) read `argv.json` and emit via `emitJson`.
+// log, changelog, recap, review, commit) read `argv.json` and emit via
+// `emitJson`.
 y.option('json', {
   type: 'boolean',
   description: 'Emit machine-readable JSON to stdout (supported commands only).',


### PR DESCRIPTION
Hey Griffin! This wires `coco commit` into the global `--json` flag: it generates a draft on the same non-interactive path as `--print-message` (#1591) — no TUI, no commit — but emits it as structured `{"title", "body"}` instead of the flattened text.

We drive coco from a few agent pipelines, and the consumers want the parts rather than re-splitting a text blob. Since review/recap/changelog already read the global `--json`, commit felt like the missing one. Failures emit a parseable `{"error"}` payload with the usual non-zero exit (recap's shape), and `--json` wins if both flags are passed.

Tests follow the existing `--print-message` block in `commit.test.ts`. Lint, typecheck, and the full jest suite are green locally.

Thanks!