### PR TITLE
fix(parsers): tighten trivialDiff header detection for SQL/Lua comment lines

### DIFF
--- a/src/lib/parsers/default/utils/trivialDiff.ts
+++ b/src/lib/parsers/default/utils/trivialDiff.ts
@@ -109,8 +109,11 @@ function isHeaderLine(line: string): boolean {
   return (
     line.startsWith('diff --git') ||
     line.startsWith('index ') ||
-    line.startsWith('--- ') ||
-    line.startsWith('+++ ') ||
+    // Match only actual unified-diff file headers, not content lines
+    // that happen to start with '--- ' or '+++ ' (e.g. SQL/Lua/Haskell
+    // `-- ` comments rendered as deleted lines: `--- comment`) (#1699).
+    /^--- (?:a\/|b\/|\/dev\/null)/.test(line) ||
+    /^\+\+\+ (?:a\/|b\/|\/dev\/null)/.test(line) ||
     line.startsWith('@@') ||
     line.startsWith('new file mode') ||
     line.startsWith('deleted file mode') ||


### PR DESCRIPTION
## Summary

`isHeaderLine()` in `trivialDiff.ts` matched any line starting with `'--- '` or `'+++ '`. In a unified diff, a deleted SQL/Lua/Haskell comment line like `-- old note` renders as `-— old note` which satisfies `startsWith('--- ')`, causing `detectTrivialDiffShape` to skip it as metadata rather than counting it as a deletion.

This made modifications (where the only deletions were `-- ` comments) get classified as pure additions — `summarizeLargeFiles` would then emit "Added `file.sql` (N lines)." for a file that was actually modified.

## Fix

Tighten the `--- ` / `+++ ` checks to only match actual unified-diff file headers using regexes:

```typescript
/^--- (?:a\/|b\/|\/dev\/null)/.test(line)
/^\+\+\+ (?:a\/|b\/|\/dev\/null)/.test(line)
```

These are the only valid forms for unified-diff file headers (`--- a/path`, `--- /dev/null`). Content lines that happen to start with `--- ` (deleted `-- ` comments) no longer match.

## Testing

- `npx tsc --noEmit` — clean
- All 15 trivialDiff tests pass (including the existing "ignores +++ / --- header markers" test)

Closes #1699
