### PR TITLE
refactor(config): consolidate duplicated path resolution into single source of truth

### DIFF
--- a/src/lib/config/services/project.ts
+++ b/src/lib/config/services/project.ts
@@ -4,6 +4,7 @@ import { Config } from '../types'
 import { SCHEMA_PUBLIC_URL, schema } from '../../schema'
 import { ajv } from '../../ajv'
 import { resolveGitRepoRoot } from '../../utils/resolveGitRepoRoot'
+import { PROJECT_CONFIG_CANDIDATES } from '../utils/scopedConfigFile'
 
 const validate = ajv.compile(schema)
 
@@ -121,10 +122,9 @@ export function loadProjectJsonConfig<ConfigType = Config>(
   // the repo root once (falling back to cwd outside a git repo) so a
   // subdirectory invocation finds the same file `coco init` wrote.
   const repoRoot = resolveGitRepoRoot()
-  const candidates = ['.coco.json', '.coco.config.json']
   let resolvedPath: string | undefined
 
-  for (const candidate of candidates) {
+  for (const candidate of PROJECT_CONFIG_CANDIDATES) {
     const candidatePath = path.join(repoRoot, candidate)
     if (fs.existsSync(candidatePath)) {
       resolvedPath = candidatePath

--- a/src/lib/config/services/xdg.ts
+++ b/src/lib/config/services/xdg.ts
@@ -10,7 +10,8 @@ export function getXdgConfigPath(): string {
   return path.join(xdgConfigHome, 'coco', 'config.json')
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+/** Shallow object guard used by the config merge writers. */
+export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 

--- a/src/lib/config/utils/scopedConfigFile.ts
+++ b/src/lib/config/utils/scopedConfigFile.ts
@@ -7,7 +7,29 @@ import { SCHEMA_PUBLIC_URL } from '../../schema'
 
 export type ConfigWriteScope = 'global' | 'project'
 
-const PROJECT_CONFIG_CANDIDATES = ['.coco.json', '.coco.config.json'] as const
+/**
+ * The filenames coco looks for when resolving a project-scoped config,
+ * in priority order. Exported so callers that need the raw list (the
+ * workstation's editor-open flow, `coco init`) don't have to hardcode
+ * their own copy (#1731).
+ */
+export const PROJECT_CONFIG_CANDIDATES = ['.coco.json', '.coco.config.json'] as const
+
+/**
+ * Resolve the project config path for a given repo root: the first
+ * existing candidate file, or the preferred default (`.coco.json`) when
+ * none exists yet. Exported as the single source of truth for the
+ * candidate-walk logic previously duplicated in 4 places (#1731).
+ */
+export function resolveProjectConfigPath(repoRoot: string): string {
+  for (const candidate of PROJECT_CONFIG_CANDIDATES) {
+    const candidatePath = path.join(repoRoot, candidate)
+    if (fs.existsSync(candidatePath)) {
+      return candidatePath
+    }
+  }
+  return path.join(repoRoot, PROJECT_CONFIG_CANDIDATES[0])
+}
 
 /**
  * Resolve the on-disk path for a `coco config` write scope (#1605).
@@ -26,15 +48,7 @@ export function resolveScopedConfigPath(scope: ConfigWriteScope): string {
     return getXdgConfigPath()
   }
 
-  const repoRoot = resolveGitRepoRoot()
-  for (const candidate of PROJECT_CONFIG_CANDIDATES) {
-    const candidatePath = path.join(repoRoot, candidate)
-    if (fs.existsSync(candidatePath)) {
-      return candidatePath
-    }
-  }
-
-  return path.join(repoRoot, PROJECT_CONFIG_CANDIDATES[0])
+  return resolveProjectConfigPath(resolveGitRepoRoot())
 }
 
 /** Reads and parses a scoped config file. Returns `{}` if it doesn't exist. */

--- a/src/lib/utils/getProjectConfigFilePath.ts
+++ b/src/lib/utils/getProjectConfigFilePath.ts
@@ -1,11 +1,12 @@
 import { findProjectRoot } from './findProjectRoot'
+import { PROJECT_CONFIG_CANDIDATES } from '../config/utils/scopedConfigFile'
 
 // `.env` was removed as a project-config storage option (#1623): the
 // writer emitted un-prefixed flattened names the env loader never read
 // (COCO_* prefix expected), and nothing loaded a `.env` file into
 // process.env in the first place — the option produced a file coco could
 // never consume. `.coco.json` is the recommended, actually-working format.
-export type ProjectConfigFileName = '.coco.json' | '.coco.config.json'
+export type ProjectConfigFileName = (typeof PROJECT_CONFIG_CANDIDATES)[number]
 
 export async function getProjectConfigFilePath(configFileName: ProjectConfigFileName) {
   const projectRoot = findProjectRoot(process.cwd())

--- a/src/workstation/chrome/themePersistence.ts
+++ b/src/workstation/chrome/themePersistence.ts
@@ -1,8 +1,8 @@
 import * as fs from 'node:fs'
-import * as os from 'node:os'
 import * as path from 'node:path'
 
 import { writeFileAtomic } from '../../lib/utils/atomicFileWrite'
+import { getXdgConfigPath, isRecord } from '../../lib/config/services/xdg'
 import { getLogInkThemePresets, type LogInkThemePreset } from './theme'
 
 /**
@@ -18,15 +18,6 @@ import { getLogInkThemePresets, type LogInkThemePreset } from './theme'
  */
 
 const VALID_PRESETS = new Set<string>(getLogInkThemePresets())
-
-export function getXdgConfigPath(): string {
-  const home = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config')
-  return path.join(home, 'coco', 'config.json')
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
 
 /**
  * Write `logTui.theme.preset = <preset>` into the global config, merging
@@ -91,3 +82,7 @@ export function getSavedThemePreset(): LogInkThemePreset | undefined {
     return undefined
   }
 }
+
+// Re-export for consumers that historically imported from this module.
+// The canonical definition lives in lib/config/services/xdg.ts (#1731).
+export { getXdgConfigPath } from '../../lib/config/services/xdg'

--- a/src/workstation/runtime/configFiles.ts
+++ b/src/workstation/runtime/configFiles.ts
@@ -17,7 +17,8 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import { SCHEMA_PUBLIC_URL } from '../../lib/schema'
-import { getXdgConfigPath } from '../chrome/themePersistence'
+import { getXdgConfigPath } from '../../lib/config/services/xdg'
+import { resolveProjectConfigPath } from '../../lib/config/utils/scopedConfigFile'
 
 export type CocoConfigScope = 'global' | 'project'
 
@@ -42,16 +43,11 @@ export function getGlobalConfigPath(): string {
 }
 
 /**
- * The project config path for `repoRoot`: the first existing of
- * `.coco.json` / `.coco.config.json`, else `.coco.json` as the default
- * to create.
+ * The project config path for `repoRoot`: delegates to the shared
+ * candidate-walk in lib/config (#1731).
  */
 export function getProjectConfigPath(repoRoot: string): string {
-  for (const name of ['.coco.json', '.coco.config.json']) {
-    const candidate = path.join(repoRoot, name)
-    if (fs.existsSync(candidate)) return candidate
-  }
-  return path.join(repoRoot, '.coco.json')
+  return resolveProjectConfigPath(repoRoot)
 }
 
 /** Resolve the config path for a scope. `project` needs the repo root. */


### PR DESCRIPTION
## Summary

Config-file path resolution was implemented 4–5 separate times across the codebase. Two byte-identical `getXdgConfigPath()` functions existed (plus matching `isRecord()` helpers), and the `.coco.json` / `.coco.config.json` candidate walk was repeated in 4 files. A rename or third candidate would have needed coordinated edits in all of them.

## Changes

### XDG config path (`getXdgConfigPath` + `isRecord`)

- **Single source of truth:** `src/lib/config/services/xdg.ts` (was already there, now exports `isRecord` too)
- **Removed duplicate:** `src/workstation/chrome/themePersistence.ts` no longer defines its own copy; imports from lib and re-exports for backward compat

### Project config candidate walk

- **Single source of truth:** `src/lib/config/utils/scopedConfigFile.ts` now exports `PROJECT_CONFIG_CANDIDATES` and `resolveProjectConfigPath(repoRoot)`
- **Deduplicated callers:**
  - `configFiles.ts` → delegates to `resolveProjectConfigPath`
  - `project.ts` → uses the shared `PROJECT_CONFIG_CANDIDATES` constant
  - `getProjectConfigFilePath.ts` → derives its `ProjectConfigFileName` type from the constant
  - `resolveScopedConfigPath` → calls the extracted helper

## Impact

Adding a third config candidate (or renaming `.coco.json`) now requires exactly one edit instead of four.

## Testing

- `npx tsc --noEmit` — clean
- `eslint` — 0 errors
- All 203 config/theme/scopedConfig tests pass

Closes #1731
