### PR TITLE
feat(autofix): add Claude and Gemini adapters

### DIFF
--- a/src/lib/autofix/adapters/claude.test.ts
+++ b/src/lib/autofix/adapters/claude.test.ts
@@ -1,0 +1,145 @@
+import { EventEmitter } from 'events'
+import { ClaudeAdapter } from './claude'
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn(),
+}))
+
+import { spawn } from 'child_process'
+
+const mockSpawn = spawn as jest.Mock
+
+function makeChild(exitCode: number | null = 0, errorCode?: string) {
+  const child = new EventEmitter() as EventEmitter & { stdin: null }
+  child.stdin = null
+
+  process.nextTick(() => {
+    if (errorCode) {
+      const err = Object.assign(new Error(errorCode), { code: errorCode })
+      child.emit('error', err)
+    } else {
+      child.emit('close', exitCode)
+    }
+  })
+
+  return child
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('ClaudeAdapter', () => {
+  const adapter = new ClaudeAdapter()
+
+  it('spawns claude with --print and the prompt as the last argument', async () => {
+    mockSpawn.mockReturnValue(makeChild(0))
+
+    await adapter.run('fix the bug')
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'claude',
+      ['--print', 'fix the bug'],
+      expect.objectContaining({ stdio: 'inherit' })
+    )
+  })
+
+  it('inherits current process env', async () => {
+    mockSpawn.mockReturnValue(makeChild(0))
+
+    await adapter.run('fix the bug')
+
+    const envArg = mockSpawn.mock.calls[0][2].env
+    // The env should contain all of process.env
+    for (const key of Object.keys(process.env)) {
+      expect(envArg[key]).toBe(process.env[key])
+    }
+  })
+
+  it('appends autoFixToolOptions as --key value flags after --print', async () => {
+    mockSpawn.mockReturnValue(makeChild(0))
+
+    await adapter.run('fix the bug', { model: 'claude-sonnet-4-20250514', 'max-turns': '10' })
+
+    const args = mockSpawn.mock.calls[0][1] as string[]
+    expect(args).toContain('--model')
+    expect(args).toContain('claude-sonnet-4-20250514')
+    expect(args).toContain('--max-turns')
+    expect(args).toContain('10')
+    expect(args[args.length - 1]).toBe('fix the bug')
+  })
+
+  it('overrides ANTHROPIC_API_KEY when an explicit apiKey is provided', async () => {
+    mockSpawn.mockReturnValue(makeChild(0))
+
+    await adapter.run('fix the bug', undefined, 'override-key')
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'claude',
+      expect.any(Array),
+      expect.objectContaining({
+        env: expect.objectContaining({ ANTHROPIC_API_KEY: 'override-key' }),
+      })
+    )
+  })
+
+  it('preserves inherited ANTHROPIC_API_KEY when apiKey is undefined', async () => {
+    const previousApiKey = process.env.ANTHROPIC_API_KEY
+    process.env.ANTHROPIC_API_KEY = 'inherited-key'
+    mockSpawn.mockReturnValue(makeChild(0))
+
+    try {
+      await adapter.run('fix the bug', undefined, undefined)
+    } finally {
+      process.env.ANTHROPIC_API_KEY = previousApiKey
+    }
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'claude',
+      expect.any(Array),
+      expect.objectContaining({
+        env: expect.objectContaining({ ANTHROPIC_API_KEY: 'inherited-key' }),
+      })
+    )
+  })
+
+  it('does not replace inherited ANTHROPIC_API_KEY with an empty apiKey', async () => {
+    const previousApiKey = process.env.ANTHROPIC_API_KEY
+    process.env.ANTHROPIC_API_KEY = 'inherited-key'
+    mockSpawn.mockReturnValue(makeChild(0))
+
+    try {
+      await adapter.run('fix the bug', undefined, '')
+    } finally {
+      process.env.ANTHROPIC_API_KEY = previousApiKey
+    }
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'claude',
+      expect.any(Array),
+      expect.objectContaining({
+        env: expect.objectContaining({ ANTHROPIC_API_KEY: 'inherited-key' }),
+      })
+    )
+  })
+
+  it('resolves when child process exits with code 0', async () => {
+    mockSpawn.mockReturnValue(makeChild(0))
+
+    await expect(adapter.run('fix the bug')).resolves.toBeUndefined()
+  })
+
+  it('rejects with exit code when child process exits non-zero', async () => {
+    mockSpawn.mockReturnValue(makeChild(1))
+
+    await expect(adapter.run('fix the bug')).rejects.toThrow('claude exited with code 1')
+  })
+
+  it('throws descriptive error when claude binary is not found (ENOENT)', async () => {
+    mockSpawn.mockReturnValue(makeChild(null, 'ENOENT'))
+
+    await expect(adapter.run('fix the bug')).rejects.toThrow(
+      'claude binary not found. Please install Claude Code: https://docs.anthropic.com/en/docs/claude-code'
+    )
+  })
+})

--- a/src/lib/autofix/adapters/claude.ts
+++ b/src/lib/autofix/adapters/claude.ts
@@ -1,0 +1,45 @@
+import { spawn } from 'child_process'
+import { BaseAdapter } from '../types'
+
+export class ClaudeAdapter implements BaseAdapter {
+  async run(prompt: string, options?: Record<string, string>, apiKey?: string): Promise<void> {
+    const args: string[] = ['--print']
+
+    if (options) {
+      for (const [key, value] of Object.entries(options)) {
+        args.push(`--${key}`, value)
+      }
+    }
+
+    args.push(prompt)
+
+    // Preserve the caller's environment by default and only override the API key
+    // when an explicit non-empty key is provided through auto-fix config.
+    const env = { ...process.env }
+    if (apiKey) env['ANTHROPIC_API_KEY'] = apiKey
+
+    return new Promise((resolve, reject) => {
+      const child = spawn('claude', args, { stdio: 'inherit', env })
+
+      child.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'ENOENT') {
+          reject(
+            new Error(
+              'claude binary not found. Please install Claude Code: https://docs.anthropic.com/en/docs/claude-code'
+            )
+          )
+        } else {
+          reject(err)
+        }
+      })
+
+      child.on('close', (code: number | null) => {
+        if (code === 0) {
+          resolve()
+        } else {
+          reject(new Error(`claude exited with code ${code}`))
+        }
+      })
+    })
+  }
+}

--- a/src/lib/autofix/adapters/gemini.test.ts
+++ b/src/lib/autofix/adapters/gemini.test.ts
@@ -1,0 +1,145 @@
+import { EventEmitter } from 'events'
+import { GeminiAdapter } from './gemini'
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn(),
+}))
+
+import { spawn } from 'child_process'
+
+const mockSpawn = spawn as jest.Mock
+
+function makeChild(exitCode: number | null = 0, errorCode?: string) {
+  const child = new EventEmitter() as EventEmitter & { stdin: null }
+  child.stdin = null
+
+  process.nextTick(() => {
+    if (errorCode) {
+      const err = Object.assign(new Error(errorCode), { code: errorCode })
+      child.emit('error', err)
+    } else {
+      child.emit('close', exitCode)
+    }
+  })
+
+  return child
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('GeminiAdapter', () => {
+  const adapter = new GeminiAdapter()
+
+  it('spawns gemini with the prompt as the last argument', async () => {
+    mockSpawn.mockReturnValue(makeChild(0))
+
+    await adapter.run('fix the bug')
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'gemini',
+      ['fix the bug'],
+      expect.objectContaining({ stdio: 'inherit' })
+    )
+  })
+
+  it('inherits current process env', async () => {
+    mockSpawn.mockReturnValue(makeChild(0))
+
+    await adapter.run('fix the bug')
+
+    const envArg = mockSpawn.mock.calls[0][2].env
+    // The env should contain all process.env keys (spread, not reference-equal)
+    for (const key of Object.keys(process.env)) {
+      expect(envArg).toHaveProperty(key, process.env[key])
+    }
+  })
+
+  it('appends autoFixToolOptions as --key value flags before the prompt', async () => {
+    mockSpawn.mockReturnValue(makeChild(0))
+
+    await adapter.run('fix the bug', { model: 'gemini-2.5-pro', sandbox: 'none' })
+
+    const args = mockSpawn.mock.calls[0][1] as string[]
+    expect(args).toContain('--model')
+    expect(args).toContain('gemini-2.5-pro')
+    expect(args).toContain('--sandbox')
+    expect(args).toContain('none')
+    expect(args[args.length - 1]).toBe('fix the bug')
+  })
+
+  it('overrides GEMINI_API_KEY when an explicit apiKey is provided', async () => {
+    mockSpawn.mockReturnValue(makeChild(0))
+
+    await adapter.run('fix the bug', undefined, 'override-key')
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'gemini',
+      expect.any(Array),
+      expect.objectContaining({
+        env: expect.objectContaining({ GEMINI_API_KEY: 'override-key' }),
+      })
+    )
+  })
+
+  it('preserves inherited GEMINI_API_KEY when apiKey is undefined', async () => {
+    const previousApiKey = process.env.GEMINI_API_KEY
+    process.env.GEMINI_API_KEY = 'inherited-key'
+    mockSpawn.mockReturnValue(makeChild(0))
+
+    try {
+      await adapter.run('fix the bug', undefined, undefined)
+    } finally {
+      process.env.GEMINI_API_KEY = previousApiKey
+    }
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'gemini',
+      expect.any(Array),
+      expect.objectContaining({
+        env: expect.objectContaining({ GEMINI_API_KEY: 'inherited-key' }),
+      })
+    )
+  })
+
+  it('does not replace inherited GEMINI_API_KEY with an empty apiKey', async () => {
+    const previousApiKey = process.env.GEMINI_API_KEY
+    process.env.GEMINI_API_KEY = 'inherited-key'
+    mockSpawn.mockReturnValue(makeChild(0))
+
+    try {
+      await adapter.run('fix the bug', undefined, '')
+    } finally {
+      process.env.GEMINI_API_KEY = previousApiKey
+    }
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'gemini',
+      expect.any(Array),
+      expect.objectContaining({
+        env: expect.objectContaining({ GEMINI_API_KEY: 'inherited-key' }),
+      })
+    )
+  })
+
+  it('resolves when child process exits with code 0', async () => {
+    mockSpawn.mockReturnValue(makeChild(0))
+
+    await expect(adapter.run('fix the bug')).resolves.toBeUndefined()
+  })
+
+  it('rejects with exit code when child process exits non-zero', async () => {
+    mockSpawn.mockReturnValue(makeChild(1))
+
+    await expect(adapter.run('fix the bug')).rejects.toThrow('gemini exited with code 1')
+  })
+
+  it('throws descriptive error when gemini binary is not found (ENOENT)', async () => {
+    mockSpawn.mockReturnValue(makeChild(null, 'ENOENT'))
+
+    await expect(adapter.run('fix the bug')).rejects.toThrow(
+      'gemini binary not found. Please install Gemini CLI: https://ai.google.dev/gemini-api/docs/quickstart'
+    )
+  })
+})

--- a/src/lib/autofix/adapters/gemini.ts
+++ b/src/lib/autofix/adapters/gemini.ts
@@ -1,0 +1,45 @@
+import { spawn } from 'child_process'
+import { BaseAdapter } from '../types'
+
+export class GeminiAdapter implements BaseAdapter {
+  async run(prompt: string, options?: Record<string, string>, apiKey?: string): Promise<void> {
+    const args: string[] = []
+
+    if (options) {
+      for (const [key, value] of Object.entries(options)) {
+        args.push(`--${key}`, value)
+      }
+    }
+
+    args.push(prompt)
+
+    // Preserve the caller's environment by default and only override the API key
+    // when an explicit non-empty key is provided through auto-fix config.
+    const env = { ...process.env }
+    if (apiKey) env['GEMINI_API_KEY'] = apiKey
+
+    return new Promise((resolve, reject) => {
+      const child = spawn('gemini', args, { stdio: 'inherit', env })
+
+      child.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'ENOENT') {
+          reject(
+            new Error(
+              'gemini binary not found. Please install Gemini CLI: https://ai.google.dev/gemini-api/docs/quickstart'
+            )
+          )
+        } else {
+          reject(err)
+        }
+      })
+
+      child.on('close', (code: number | null) => {
+        if (code === 0) {
+          resolve()
+        } else {
+          reject(new Error(`gemini exited with code ${code}`))
+        }
+      })
+    })
+  }
+}

--- a/src/lib/autofix/index.ts
+++ b/src/lib/autofix/index.ts
@@ -1,10 +1,14 @@
 import { ReviewFeedbackItem } from '../../commands/review/config'
 import { buildPrompt } from './buildPrompt'
 import { CodexAdapter } from './adapters/codex'
+import { ClaudeAdapter } from './adapters/claude'
+import { GeminiAdapter } from './adapters/gemini'
 import { BaseAdapter, AutoFixConfig } from './types'
 
 const registry: Record<string, BaseAdapter> = {
   codex: new CodexAdapter(),
+  claude: new ClaudeAdapter(),
+  gemini: new GeminiAdapter(),
 }
 
 export async function runAutoFix(item: ReviewFeedbackItem, config: AutoFixConfig): Promise<void> {


### PR DESCRIPTION
## Summary

 Adds two new auto-fix agent adapters to the review-autofix system: 
 
 - **ClaudeAdapter** — spawns `claude --print` with `ANTHROPIC_API_KEY` env injection 
 - **GeminiAdapter** — spawns `gemini` with `GEMINI_API_KEY` env injection 
 
 Both follow the `BaseAdapter` contract established by `CodexAdapter` and are registered in the adapter registry so users can set `autoFixTool: "claude"` or `autoFixTool: "gemini"` in their config. 
 
 ## What was tested 
 
 - 36 unit tests across all 3 adapters pass (`npx jest src/lib/autofix/`) 
 - Full lint, typecheck, and test suite pass (5534 tests, 0 failures) 
 - Adapter registry correctly dispatches to claude/gemini/codex by config key 
 
 ## Files changed 
 
 - `src/lib/autofix/adapters/claude.ts` — new adapter 
 - `src/lib/autofix/adapters/claude.test.ts` — 9 unit tests 
 - `src/lib/autofix/adapters/gemini.ts` — new adapter 
 - `src/lib/autofix/adapters/gemini.test.ts` — 9 unit tests 
 - `src/lib/autofix/index.ts` — register both adapters