### PR TITLE
docs: post-0.84.1 audit — 77 bug findings and 28 feature proposals

### DIFF
--- a/docs/audit-0.84.1/README.md
+++ b/docs/audit-0.84.1/README.md
@@ -1,0 +1,264 @@
+# Post-0.84.1 audit — bug findings and feature scoping
+
+A full-repository audit run against `main` at `c36ad0a` (`chore: release v0.84.1`), covering
+every layer: `lib/`, `git/` + the forge adapter, `workstation/`, and the CLI command
+surfaces, plus a forward-looking feature/extension scoping pass.
+
+**Totals: 77 bug findings and 28 feature proposals.**
+
+| Report | Scope | Findings |
+| --- | --- | --- |
+| [`bugs-workstation.md`](./bugs-workstation.md) | `src/workstation/**` — runtime, hooks, chrome, surfaces | 19 (1 critical, 6 high, 9 medium, 3 low) |
+| [`bugs-commands.md`](./bugs-commands.md) | `src/commands/**` + `src/index.ts` (excl. `agent/`, `mcp/`) | 25 (5 high, 13 medium, 7 low) |
+| [`bugs-git-forge.md`](./bugs-git-forge.md) | `src/git/**` — git actions + multi-forge adapter | 22 (5 high, 12 medium, 5 low) |
+| [`bugs-lib.md`](./bugs-lib.md) | `src/lib/**` — config, providers, tokenizer, parsers, cache | 11 (1 high, 7 medium, 3 low) |
+| [`feature-scoping.md`](./feature-scoping.md) | Forge/provider matrices + new capabilities | 28 proposals (9 P0, 12 P1, 7 P2) |
+
+## Why a static audit found 77 things when CI is green
+
+The validation gate was run first, in full, and it passes cleanly:
+
+| Check | Result |
+| --- | --- |
+| `npx tsc --noEmit -p tsconfig.json` | clean, exit 0 |
+| `npx eslint src bin e2e` | 42 problems — **0 errors**, 42 warnings, all `react-hooks/exhaustive-deps` |
+| `TZ=UTC NODE_OPTIONS=--experimental-vm-modules npx jest` | 391 passed / 3 skipped of 394 suites; 5596 tests; 68 snapshots; 81s; exit 0 |
+
+So every finding below is something the current gate cannot see. That is the useful signal
+in this audit, and it points at specific gate gaps: no assertion that layout panes tile to
+the terminal width, no unmount-cleanup lint for `AbortController`/timer refs, no
+`config.ts`-vs-`handler.ts` flag reconciliation test, no ban on `.padEnd` in width-sensitive
+surfaces, no unused-production-dependency check, and no stdout-purity test for `--json`.
+
+Where a co-located test *encodes* the buggy behavior, the reports call it out explicitly —
+there are five such cases (noted in `bugs-git-forge.md` for Bitbucket PR filtering and the
+hardcoded tag remote, `bugs-workstation.md` for the split-plan `r` retry, and
+`bugs-commands.md` for the split-apply index reset).
+
+All 42 eslint warnings were individually triaged in `bugs-workstation.md`: 34 are benign
+(omitted `useState` setters and ref objects, whose identity React guarantees), 6 are
+benign-by-design, and **2 are real** — a `forge` omission that only works today because of
+an undocumented coupling to the `git` dep, and `useYankActions` still enumerating
+`selected*Index` after the `#1452` selectors moved to `selected*Id`.
+
+## Already-filed work, excluded from this audit
+
+These 15 open issues were read first and deliberately not re-reported: #1830, #1829, #1828,
+#1827, #1826, #1825, #1824, #1823, #1822 (the agent/MCP set), #1820, #1819 (rail history
+rendering), #1722 (`inkInput.ts` router extraction), #1371 and #1370 (the extensibility and
+AI-native umbrellas), and #1241 (Bedrock live verification).
+
+The feature pass also explicitly excludes things that *already ship* and are easy to
+mis-propose: shell completions (bash/zsh/fish, `src/index.ts:247-293`), split/side-by-side
+diff (`chrome/splitDiff.ts`), Git LFS handling, multi-repo navigation
+(`repoStackRuntime.ts`), and `coco review --pr <n> --comment` posting to the forge.
+
+## File these first
+
+Ten items worth landing before anything else, in this order. The first five are correctness
+or safety; the last five are cheap and immediately visible.
+
+| # | Item | Why first |
+| --- | --- | --- |
+| 1 | `fix(config)`: `--ignoredFiles` wipes the default ignore list | **Secret exposure.** Verified empirically: the flag collapses 39 ignore entries to 1, re-admitting `.env`, `.env.local`, and `.env.production.local` to the model prompt. |
+| 2 | `fix(config)`: `config set …apiKey` writes 0644, non-atomically | **Secret at rest.** Any local user can read the provider key; `writeFileAtomic` (0600, tmp+rename) already exists and is not used. |
+| 3 | `fix(commit)`: `--split` apply resets the index and never restores it | **Data loss.** A hook rejecting one group leaves the user's curated index empty with no warning and no recovery path. |
+| 4 | `fix(workstation)`: pane widths can exceed terminal columns | **Only critical.** Reproduced numerically: at 100 cols, `Tab` to sidebar + `?` sums to 116 cols. Breaks the frame at a very common width. |
+| 5 | `fix(cli)`: default router drops `--json`/`--quiet` | **Silent mutation.** `coco --commit --json` performs a real interactive commit instead of printing a draft. |
+| 6 | `fix(changelog)`: `--write` swallows intervening `# ` release sections | Permanently deletes a major-version section of CHANGELOG.md. |
+| 7 | `fix(workstation)`: AbortControllers never aborted on unmount | Four hooks; pressing `q` mid-generation hangs the shell for 30–120s. |
+| 8 | `fix(cli)`: `getRepo` logs to **stdout** | One `console.log` breaks `JSON.parse(stdout)` for every `--json` consumer and the agent CLI. |
+| 9 | `feat(ci)`: gate the benchmark against `.bench/baseline.json` | Cheapest win in the audit — the baseline is already committed, nothing runs it. |
+| 10 | `feat(forge)`: draft→ready and PR reopen | `pr create -d` can create a draft but nothing can promote it; two of three lifecycle steps ship. |
+
+## Suggested issue clustering
+
+77 findings should not become 77 issues. Recommended grouping:
+
+- **File individually (the 17 high + 1 critical):** each has a distinct root cause, owner
+  surface, and acceptance criteria.
+- **Cluster into one issue each:**
+  - *Argument-injection guard parity* — `checkoutBranchByName`, `stashBranch`, `bisect start`,
+    and `git log` positional refs are one `rejectFlagLike`/`--end-of-options` sweep.
+  - *`--json` contract hardening* — the inconsistent failure payloads, `doctor --json`,
+    `getRepo`'s stdout write, and `--quiet` swallowing results are one contract fix.
+  - *Cell-width correctness* — `cellWidth`'s range table, the seven `padEnd` surfaces, and
+    `truncateCells`/`wrapCells` edge cases all resolve together, ideally by vendoring a real
+    East-Asian-Width lookup.
+  - *Unmount cleanup* — the four AbortController hooks plus the 5s commit timer are one
+    `useEffect` pattern applied five times, best paired with a lint rule.
+  - *Failure caching / retry* — issue-PR detail, blame, and file-history all cache failures
+    and permanently disable retry via the same cache-skip guard.
+  - *Mutually exclusive flags* — six unvalidated combinations, one `.check()` sweep per
+    command builder.
+  - *Dependency hygiene* — drop `@langchain/community` (22 MB, zero imports) and `p-queue`
+    (zero imports) together with the semaphore consolidation, plus a CI check so it can't
+    recur.
+- **Low-severity findings** are best appended as checklists to the cluster issue for their
+  area rather than filed standalone.
+
+## Headline feature finding
+
+`.kiro/specs/` holds two designed specs. One shipped; one did not:
+
+| Spec | Status |
+| --- | --- |
+| `review-autofix-agent/` | **Complete** — all 15 tasks, including optional 11/12. `src/lib/autofix/**` with adapters for codex/claude/gemini all exist with tests. |
+| `ai-conflict-resolution/` | **0 of 15 tasks.** `src/commands/resolve/` does not exist; `conflictResolve` never entered the `DynamicModelTask` union; `ProposalsSchema` has no `confidence` field; `conflictRegionActions.ts` has no conflict-marker guard on writes. |
+
+The conflict spec names exact files and line numbers and sits on a fully working data layer
+already shipped by #1369 — AI conflict resolution currently exists only inside `coco ui`,
+with nothing for a user mid-rebase in a plain terminal or in CI. It is the single
+highest-leverage item in the feature report, and it splits cleanly into about four PRs.
+The missing marker guard is also a live correctness hazard in the *shipped* TUI path.
+
+`feature-scoping.md` additionally derives two reference tables from the code that are worth
+keeping current: a **forge capability × provider matrix** (all 25 `ForgeActions` methods × 4
+facades, with file:line for every refusal) and a **provider registry coverage table**
+(showing that OpenAI-compatible endpoints reached via `baseURL` silently inherit OpenAI's
+token accounting, which *undercounts* and feeds straight into `enforcePromptBudget`).
+
+## Full checklist
+
+Titles are conventional-commit formatted and ready to use as issue titles. Suggested labels
+in brackets.
+
+### Critical
+
+- [ ] `fix(workstation)`: pane widths can exceed terminal columns when the help overlay opens on a focused sidebar `[bug]`
+
+### High
+
+- [ ] `fix(config)`: `--ignoredFiles` / `--ignoredExtensions` wipe the default ignore list, exposing `.env` to the prompt `[bug, security]`
+- [ ] `fix(config)`: `coco config set …apiKey --scope global` writes the key world-readable (0644) and non-atomically `[bug, security]`
+- [ ] `fix(commit)`: `--split` apply resets the index up front and never restores staging for failed groups `[bug]`
+- [ ] `fix(commit)`: `--split`'s "unclaimed" group silently unstages files and the CLI never says so `[bug]`
+- [ ] `fix(cli)`: the default router drops global `--json` / `--quiet`, so `coco --commit --json` performs a real commit `[bug]`
+- [ ] `fix(init)`: `--scope project` silently clobbers an existing `.coco.json`, dropping every unrelated key `[bug]`
+- [ ] `fix(workstation)`: filesystem watcher is torn down and rebuilt after every worktree refresh `[bug, performance]`
+- [ ] `fix(workstation)`: in-flight AI AbortControllers are never aborted on unmount, so `q` leaves the process hanging `[bug]`
+- [ ] `fix(workstation)`: Esc during a PR-body draft gives no feedback and leaves the spinner running `[bug]`
+- [ ] `fix(workstation)`: cellWidth mismeasures the exact status glyphs the UI renders `[bug]`
+- [ ] `fix(workstation)`: seven surfaces still pad columns with padEnd instead of padCells, breaking CJK alignment `[bug]`
+- [ ] `fix(workstation)`: command palette and theme picker hardcode 14 list rows and never clamp the window start `[bug]`
+- [ ] `fix(git)`: route self-hosted Bitbucket Server remotes somewhere real instead of api.bitbucket.org `[bug]`
+- [ ] `fix(git)`: stop routing forge URLs through `cmd /c start` on Windows `[bug, security]`
+- [ ] `fix(git)`: filter Bitbucket pull requests by author/assignee server-side `[bug]`
+- [ ] `fix(git)`: stop reporting API failures as "Empty response" in forge detail loaders `[bug]`
+- [ ] `fix(git)`: guard unresolved project path in Bitbucket/Gitea forge mutations `[bug]`
+
+### Medium
+
+- [ ] `fix(cli)`: global `--quiet` swallows command *results*, not just chrome `[bug]`
+- [ ] `fix(cli)`: `--json` failure payloads are inconsistent across commands `[bug]`
+- [ ] `fix(cli)`: `getRepo` writes its failure to stdout, corrupting every `--json` consumer `[bug]`
+- [ ] `fix(cli)`: mutually exclusive flags are silently resolved by precedence instead of validated `[bug]`
+- [ ] `fix(doctor)`: `--json` is ignored for the main diagnostics report, which prints ANSI art to stdout `[bug]`
+- [ ] `fix(review)`: `--pr <non-numeric>` becomes `NaN` and is passed straight to the forge `[bug]`
+- [ ] `fix(review)`: a generation failure and a severity-gate breach both exit 1 — CI can't tell them apart `[bug]`
+- [ ] `fix(review)`: `--comment` post failure is logged but the command still exits 0 `[bug]`
+- [ ] `fix(commit)`: `--split` never validates group titles against commitlint `[bug]`
+- [ ] `fix(commit)`: non-interactive hook failures print "fix the issues above" with the hook output muted `[bug]`
+- [ ] `fix(commit)`: `--print-message` failures are completely silent and skip the missing-API-key hint `[bug]`
+- [ ] `fix(git)`: every non-hook `GitError` is reported as "Commit blocked by pre-commit hook" `[bug]`
+- [ ] `fix(changelog)`: `--write` section replacement swallows intervening `# ` release sections `[bug]`
+- [ ] `fix(amend)`: `noVerify` from config is ignored (only the CLI flag is honored) `[bug]`
+- [ ] `fix(config)`: the argv spread can clobber real config with `undefined` and shallow-replaces nested objects `[bug, tech-debt]`
+- [ ] `perf(cache)`: the diff-summary cache rewrites the entire cache file on every write *and* every hit `[performance]`
+- [ ] `refactor(parsers)`: three hand-rolled semaphores, while the declared `p-queue` dependency is never imported `[refactor, tech-debt]`
+- [ ] `chore(deps)`: `@langchain/community` is a 22 MB production dependency that is never imported `[tech-debt]`
+- [ ] `fix(langchain)`: the prompt-budget accept threshold and trim target disagree by `responseTokenReserve` `[bug]`
+- [ ] `perf(langchain)`: the block-drop comparator re-tokenizes every block on each comparison `[performance]`
+- [ ] `fix(workstation)`: split-plan `r` retry is unreachable from the error state the overlay advertises `[bug]`
+- [ ] `fix(workstation)`: failed issue/PR detail fetches are dropped with no message and no retry `[bug]`
+- [ ] `fix(workstation)`: failed blame / file-history results are cached, permanently disabling retry `[bug]`
+- [ ] `fix(workstation)`: the 5s just-landed-commit timer is never cleared on unmount, so `q` lingers `[bug]`
+- [ ] `fix(workstation)`: loadCommitContext can leave a permanent loading status when the append is deduplicated `[bug]`
+- [ ] `fix(workstation)`: any open choice prompt bypasses the central confirmation gate for every workflow `[bug]`
+- [ ] `fix(workstation)`: `truncateCells` silently drops the ellipsis at narrow budgets `[bug]`
+- [ ] `fix(workstation)`: `wrapCells` returns unwrapped text when the budget is non-positive `[bug]`
+- [ ] `fix(workstation)`: `useHistoryRefetch` re-runs on every `logArgv` identity change `[bug, performance]`
+- [ ] `fix(git)`: stop swallowing gh failures as "No pull request found" `[bug]`
+- [ ] `fix(git)`: guard flag-like refs in `checkoutBranchByName`, `stashBranch`, and `bisect start` `[bug]`
+- [ ] `fix(git)`: pass `--end-of-options` before positional refs in `git log` `[bug]`
+- [ ] `fix(git)`: resolve the tag remote instead of hardcoding origin `[bug]`
+- [ ] `fix(git)`: don't drop a stash before the replacement store is known to succeed `[bug]`
+- [ ] `fix(git)`: actually open the browser for Bitbucket/Gitea `pr create --web` `[bug]`
+- [ ] `fix(git)`: paginate Gitea label lookup and distinguish "not found" from "lookup failed" `[bug]`
+- [ ] `fix(git)`: make workspace PR counts host-aware (GHE regression) `[bug]`
+- [ ] `fix(git)`: bound `git log --follow` in the file-history loader `[bug, performance]`
+- [ ] `fix(git)`: surface truncated comment threads instead of silently degrading `[bug]`
+
+### Low
+
+- [ ] `fix(commit)`: `openInEditor` is declared as a commit option but has no yargs flag `[bug]`
+- [ ] `fix(commit)`: `noResult` prints headings with no content unless `--verbose` `[bug]`
+- [ ] `fix(commit)`: the split apply confirmation defaults to "yes" `[bug]`
+- [ ] `fix(cli)`: numeric flags accept garbage and silently become `NaN` `[bug]`
+- [ ] `fix(cli)`: `handleResult` is not awaited in changelog and recap `[bug]`
+- [ ] `fix(recap)`: shortcut timeframe flags silently override an explicit `--timeframe` `[bug]`
+- [ ] `fix(workspace)`: handler always `process.exit(0)`, masking failures and pending writes `[bug]`
+- [ ] `fix(workstation)`: `openInEditor` does not pause Ink's stdin before spawning the editor `[bug]`
+- [ ] `fix(workstation)`: `reword-head` rewrites HEAD without the confirmation `amend-head` requires `[bug]`
+- [ ] `fix(workstation)`: workspace debug mode installs a SIGINT handler that suppresses Ctrl-C `[bug]`
+- [ ] `fix(git)`: don't hijack process.stdout in the commit workflow `[tech-debt]`
+- [ ] `fix(git)`: sanitize CI check names from forge payloads `[bug, security]`
+- [ ] `fix(git)`: bound conflict-marker file reads `[performance]`
+- [ ] `fix(git)`: use `--flag=value` (and guards) in gh list arg builders `[tech-debt]`
+- [ ] `fix(git)`: verify Bitbucket reviewer PUT doesn't clobber PR fields `[bug]`
+- [ ] `fix(langchain)`: `trimSummaryByBlocks` can return an over-budget prompt without throwing `[bug]`
+- [ ] `fix(langchain)`: the "N files omitted" count undercounts dropped directories `[bug]`
+- [ ] `fix(parsers)`: summarization failures are swallowed to `console.error`, bypassing the logger `[bug]`
+
+### Feature proposals — P0
+
+- [ ] `feat(resolve)`: ship the designed-but-unimplemented `coco resolve` CLI `[enhancement]` (L)
+- [ ] `feat(forge)`: add draft→ready and PR reopen to the forge adapter `[enhancement]` (S)
+- [ ] `feat(ci)`: gate the diff-condensing benchmark against the committed baseline `[enhancement, tech-debt]` (S)
+- [ ] `feat(observability)`: dollar-denominated cost, per-model pricing, and budget caps `[enhancement]` (M)
+- [ ] `feat(provider)`: use native structured output / JSON mode instead of parse-and-repair `[enhancement, performance]` (M)
+- [ ] `feat(provider)`: first-class OpenAI-compatible provider presets `[enhancement]` (M)
+- [ ] `feat(forge)`: fetch Bitbucket Cloud PR diffs instead of refusing `[enhancement]` (M)
+- [ ] `feat(lint)`: audit and reword existing commit history against commitlint `[enhancement]` (M)
+- [ ] `feat(distribution)`: official GitHub Action, pre-commit hook, and container image `[enhancement]` (M, file as 3)
+
+### Feature proposals — P1
+
+- [ ] `feat(forge)`: line-level review threads — read them, and post AI review as inline comments `[enhancement]` (L)
+- [ ] `feat(forge)`: Azure DevOps provider `[enhancement]` (L)
+- [ ] `feat(forge)`: Bitbucket Server / Data Center as a distinct provider `[enhancement]` (M)
+- [ ] `feat(forge)`: CI checks surface with re-run and auto-merge `[enhancement]` (M)
+- [ ] `feat(issues)`: create issues, and AI-draft them from a diff or a review finding `[enhancement]` (M)
+- [ ] `feat(mcp)`: expose resources and prompts primitives, not just tools `[enhancement]` (M)
+- [ ] `feat(mcp)`: progress notifications and streaming for long generations `[enhancement]` (M)
+- [ ] `feat(workstation)`: mouse support (click-to-focus, wheel scroll, click-to-select) `[enhancement]` (M)
+- [ ] `feat(workstation)`: undo stack for destructive git actions `[enhancement]` (M)
+- [ ] `feat(blame)`: `coco blame --explain` `[enhancement]` (M)
+- [ ] `feat(provider)`: promote prompt caching and reasoning effort to typed config `[enhancement]` (M)
+- [ ] `feat(distribution)`: Scoop / winget / AUR / Nix packaging plus a stale-version notice `[enhancement]` (M)
+
+### Feature proposals — P2
+
+- [ ] `feat(stack)`: stacked-branch / stacked-PR support `[enhancement]` (L)
+- [ ] `feat(watch)`: `coco watch` — continuous review and commit-draft daemon `[enhancement]` (M)
+- [ ] `feat(workstation)`: `git notes` and sparse-checkout awareness `[enhancement]` (M)
+- [ ] `feat(forge)`: CODEOWNERS awareness and required-reviewer surfacing `[enhancement]` (M)
+- [ ] `feat(i18n)`: take `language` beyond a one-sentence prompt hint `[enhancement]` (M, file as 2)
+- [ ] `feat(agent)`: read `AGENTS.md` / steering files as a first-class context source `[enhancement]` (S)
+- [ ] `feat(observability)`: report diff-summary cache hit rate in `doctor --cost` `[enhancement]` (S)
+
+## Confidence and verification
+
+Each finding carries an explicit confidence level. The distribution:
+
+- **high** — the large majority; verified against quoted code, and in several cases
+  reproduced by executing the real exported function (pane-width overflow, `cellWidth`
+  glyph measurement, `padEnd` vs `padCells` cell counts, the `loadConfig` ignore-list
+  collapse and argv clobber, yargs argv shapes for the flag-contract findings).
+- **medium** — one item: the Windows `cmd /c start` injection, which needs a Windows host to
+  confirm Node's quoting of a space-free `&` argument.
+- **needs-verification** — six items, each stating the exact check that would settle it.
+  These should be confirmed before filing, or filed with the open question stated.
+
+Nothing in this audit changed any source file. Every claim cites `path:line` so it can be
+re-checked independently.

--- a/docs/audit-0.84.1/bugs-commands.md
+++ b/docs/audit-0.84.1/bugs-commands.md
@@ -1,0 +1,403 @@
+# coco CLI command-surface bug audit
+
+**Target:** `/projects/sandbox/coco` (`git-coco` v0.84.1)
+**Scope:** `src/commands/**` (excluding `agent/`, `mcp/`) + `src/index.ts`, plus the shared helpers those command handlers call (`lib/ui/*`, `lib/config/**` writers, `lib/simple-git/createCommit`).
+**Method:** full read of every in-scope `config.ts`/`handler.ts` pair, flag-by-flag cross-check of declared vs. consumed options, plus empirical `npx tsx` yargs probes (probe file deleted; no files added or changed inside the repo).
+
+None of the findings below are caught by the existing gate (`tsc --noEmit` clean, eslint only react-hooks warnings, 391 suites / 5596 tests passing). Where a co-located test *encodes* the buggy behavior, that is called out explicitly.
+
+---
+
+## HIGH
+
+### [SEVERITY: high] fix(config): `coco config set …apiKey --scope global` writes the key world-readable (0644) and non-atomically
+**File:** `src/lib/config/utils/scopedConfigFile.ts:72-80` (also `src/lib/config/services/xdg.ts:62`)
+**What's wrong:** `coco config set` is the documented way to write config, including credentials (`config/handler.ts` even has a `SENSITIVE_SEGMENTS` masker for `apikey`, `token`, `password`, `clientsecret`, so credentials are clearly expected to live here). The writer uses a bare `fs.writeFileSync` with no `mode`, so the file lands at `0666 & ~umask` — 0644 on a default umask — and any local user can read the API key. The repo already ships the correct primitive: `writeFileAtomic` defaults to `mode: 0o600` and does tmp+rename (`src/lib/utils/atomicFileWrite.ts:29-40`), and is used for less sensitive files (CHANGELOG). The plain `writeFileSync` is also non-atomic: an interrupted write truncates the user's whole global config.
+**Evidence:**
+```ts
+export function writeScopedConfigFile(filePath: string, config: Record<string, unknown>): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  const { $schema, ...rest } = config
+  fs.writeFileSync(
+    filePath,
+    JSON.stringify({ $schema: SCHEMA_PUBLIC_URL, ...rest }, null, 2) + '\n'
+  )
+}
+```
+**Impact:** `coco config set service.authentication.credentials.apiKey sk-… --scope global` → `~/.config/coco/config.json` is `-rw-r--r--` containing a plaintext provider key. Reproduce: run the command, then `stat -c %a ~/.config/coco/config.json` → `644`. `persistUsagePreference` (xdg.ts:62) writes the same file the same way, so it can also *downgrade* a hand-hardened 0600 file back to 0644 (it rewrites the whole file).
+**Suggested fix:** route both writers through `writeFileAtomic(filePath, data)` (0600 default, tmp+rename); optionally `chmodSync(file, 0o600)` on pre-existing files before write.
+**Confidence:** high
+
+### [SEVERITY: high] fix(init): `--scope project` silently clobbers an existing `.coco.json`, dropping every unrelated key
+**File:** `src/lib/config/services/project.ts:251-266` (called from `src/commands/init/handler.ts:349`)
+**What's wrong:** the function is named `appendToProjectJsonConfig`, but it does a full overwrite: it never reads the existing file, so any keys the user (or a prior `coco doctor --fix`) put there — `logTui.theme`, `workspace.roots`, `ignoredFiles`, `prompt`, `forgeHosts`, `telemetry` — are destroyed. There is no "existing config found, override?" confirmation, even though the codebase *has* one (`CONFIG_ALREADY_EXISTS` in `lib/ui/helpers.ts:45`) and the sibling global path uses it (`git.ts:230-235` passes `confirmUpdate: true, confirmMessage: CONFIG_ALREADY_EXISTS` to `updateFileSection`). So the global scope asks before touching `~/.gitconfig`, and the project scope silently truncates `.coco.json`.
+**Evidence:**
+```ts
+export const appendToProjectJsonConfig = (filePath: string, config: Partial<Config>) => {
+  if (!fs.existsSync(filePath)) {
+    fs.writeFileSync(filePath, '{}')
+  }
+  fs.writeFileSync(filePath, JSON.stringify({ $schema: SCHEMA_PUBLIC_URL, ...config }, null, 2))
+}
+```
+**Impact:** re-running `coco init --scope project` (e.g. to change the model) wipes a committed `.coco.json` down to `{defaultBranch, mode, service}` and reports `init successful! 🦾🤖🎉`. Reproduce: add `"logTui": {"theme":{"preset":"dracula"}}` to `.coco.json`, run `coco init --scope project`, accept — the key is gone.
+**Suggested fix:** read-merge-write (deep merge `service`), and prompt with `CONFIG_ALREADY_EXISTS(filePath)` when the file already exists; write via `writeFileAtomic(..., { preserveExistingMode: true })`.
+**Confidence:** high
+
+### [SEVERITY: high] fix(commit): `--split` apply resets the index up front and never restores staging for failed groups
+**File:** `src/commands/commit/split.ts:533` / `:653-676`
+**What's wrong:** `applyCommitSplitPlan` unstages *everything* (`git reset`) before the loop, then re-stages per group. Only files the plan never saw (config-filtered lockfiles) are re-added afterwards (`:653`). Files belonging to a group whose commit failed stay unstaged forever — and if *every* group fails, the function throws with the index still empty. There is no rollback of the reset and no mention of it in either the partial-success message or the thrown error, so a user who ran `coco commit --split --apply` on a hand-curated index loses that curation with no warning.
+**Evidence:**
+```ts
+await git.raw(['reset'])
+…
+if (commitHashes.length === 0) {
+  logger.stopSpinner('Split apply failed', { mode: 'fail', color: 'red' })
+  const detail = failures.map((f) => `  - ${f.title}: ${f.reason}`).join('\n')
+  throw new Error(`Split apply created zero commits across ${applicableGroups.length} group(s).${abortedNote}\n${detail}`)
+}
+```
+**Impact:** a pre-commit hook that rejects the first group (or a `git apply --cached` conflict, or a mid-run SIGINT) leaves the user with an empty index and a message that says only "Created 1 of 2 planned commit(s). Failed: …". Reproduce: stage two files, make a hook reject one, run `coco commit --split --apply`, then `git diff --cached --name-only` → empty for the failed group's files. The co-located test **encodes** this: `splitApply.test.ts:84-90` asserts `ops` ends at `['…','reset','stage a.ts','reset','stage b.ts']` with no re-add of `a.ts`.
+**Suggested fix:** capture `stagedBeforeReset` (already computed at `:528`) and, on any failure path (including the zero-commit throw), re-`git add --` the files of failed/unattempted groups; state explicitly in the message which paths were left unstaged.
+**Confidence:** high
+
+### [SEVERITY: high] fix(cli): the default router drops global `--json` / `--quiet`, so `coco --commit --json` performs a real commit
+**File:** `src/commands/defaultRouter.ts:155-170`
+**What's wrong:** `buildSyntheticArgv` hand-projects the fields it forwards and omits `json` and `quiet`. Every route (`init`, `ui`, `workspace`, `commit`) therefore runs as if those globals were never passed. For the `commit` route this is not cosmetic: `commit/handler.ts:65` uses `argv.json` as the "generate a draft, don't commit" switch, so losing the flag flips a preview into a mutation.
+**Evidence:**
+```ts
+  return ({
+    _: ['$0'], $0: argv.$0, repo: argv.repo, cwd: argv.cwd,
+    verbose: argv.verbose, interactive: true, version: false, help: false,
+    ...overrides,
+  } as unknown) as T
+```
+**Impact:** `coco --commit --json` (the documented legacy escape hatch, also reachable via `COCO_DEFAULT=commit`) is expected to print `{"title","body"}`; instead, with the `mode: "interactive"` config `coco init` writes by default, it opens the interactive review loop and creates a commit. `coco --commit --quiet` likewise ignores `--quiet`. Reproduce: `COCO_DEFAULT=commit coco --json` in a repo with staged changes.
+**Suggested fix:** forward `json` and `quiet` (and `$0`-level unknowns generally) in `buildSyntheticArgv`; ideally spread `argv` and override only the command-specific fields.
+**Confidence:** high
+
+### [SEVERITY: high] fix(commit): `--split`'s "unclaimed" group silently unstages files and the CLI never says so
+**File:** `src/commands/commit/split.ts:478-489` + `:660-686`
+**What's wrong:** `rescueMissingFiles` (`splitPlanValidation.ts:437-482`) appends a synthetic `unclaimed: true` group for files the model failed to place, and validation then treats those files as "claimed" so the plan passes. Apply-time, `applicableGroups` filters unclaimed groups out — but the up-front `git reset` already unstaged them, and they are excluded from the `unplannedStaged` restore because `plannedFiles` counts *every* group including unclaimed. The final message (`Created N split commit(s).`) mentions only the config-filtered restore, never the unclaimed files.
+**Evidence:**
+```ts
+    if (group.unclaimed) {
+      return false
+    }
+```
+```ts
+  const unplannedNote = unplannedStaged.length > 0
+    ? ` ${unplannedStaged.length} staged file(s) the plan excluded by config (e.g. lockfiles) were re-staged — commit them separately.`
+    : ''
+```
+**Impact:** `coco commit --split --apply` in CI/non-TTY reports success while N staged files were dropped from the index and from every commit. The comment at `:479-481` claims the user "lands on the status screen to handle them" — true only for the Workstation surface, not for the CLI path this code also serves.
+**Suggested fix:** re-stage unclaimed-group files after the loop and append an explicit note (`M file(s) were left uncommitted and remain staged: …`) to `CommitSplitApplyResult.message`.
+**Confidence:** high
+
+---
+
+## MEDIUM
+
+### [SEVERITY: medium] fix(cli): global `--quiet` swallows command *results*, not just chrome
+**File:** `src/commands/utils/githubListCommand.ts:195`, `src/commands/doctor/handler.ts:164+`, `src/commands/config/handler.ts:108/126/151`, `src/commands/review/handler.ts:396-400`, `src/commands/prCreate/handler.ts:110`
+**What's wrong:** `--quiet` is documented as "Suppress non-error status output. Results (and --json) still print to stdout" (`src/index.ts:76-80`, README:79). That holds only for commands that write results via `process.stdout.write`/`emitJson`. Commands that emit their payload through `logger.log` lose it entirely, because `Logger.log` early-returns when muted (`lib/utils/logger.ts:56-58`).
+**Evidence:**
+```ts
+    logger.log(spec.formatList(items, listNoun))        // prs / issues: the entire table
+```
+```ts
+    logger.log(chalk.bold('Review findings:\n'))
+    logger.log(formatFindings(findings))                // review, non-TTY path
+```
+**Impact:** `coco prs --quiet`, `coco issues --quiet`, `coco doctor --quiet`, `coco config get service.model --quiet`, `coco config list --quiet`, `coco pr create --dry-run --quiet`, and `coco review --quiet` (piped/CI) all print **nothing at all** and exit 0. `config set --quiet` additionally hides the schema-mismatch warning from `warnIfInvalid` while still writing the file.
+**Suggested fix:** write final results through `process.stdout.write` (as `handleResult`/`emitJson` do), or add a `logger.result()` channel that ignores quiet; keep only banners/spinners/status behind quiet.
+**Confidence:** high
+
+### [SEVERITY: medium] fix(review): `--pr <non-numeric>` becomes `NaN` and is passed straight to the forge
+**File:** `src/commands/review/config.ts:76-80` + `:88-112`, used at `src/commands/review/handler.ts:97/116`
+**What's wrong:** the builder's `.check()` was hardened for `--severity` NaN (#1599) but the same yargs `type: 'number'` hole was left open on `--pr`. `NaN !== undefined`, so every `argv.pr !== undefined` guard passes.
+**Evidence:**
+```ts
+  const forge = argv.pr !== undefined
+```
+Probe (`yargs` with the real builder): `review --pr notanumber` → `fail: null`, `{ pr: NaN, mr: NaN }`.
+**Impact:** `coco review --pr abc` (or `--mr abc`, or a shell variable that expanded empty-ish) resolves the forge, then calls `getPullRequestDiffByNumber(NaN)` → `gh pr diff NaN`; the user gets a forge-level error instead of "`--pr` must be a positive integer". With `--comment` it would also try to post to PR `NaN`.
+**Suggested fix:** extend the existing `.check()`: `if (pr !== undefined && !(Number.isInteger(pr) && pr > 0)) throw new Error('--pr must be a positive integer')`.
+**Confidence:** high
+
+### [SEVERITY: medium] fix(review): a generation failure and a severity-gate breach both exit 1 — CI can't tell them apart
+**File:** `src/commands/review/handler.ts:367-372`, `:406-412`
+**What's wrong:** the CI gate exits 1 via `commandExit(1)`, and *any* other failure (no API key → `handleMissingApiKey`'s `commandExit(1)`, rate limit, unparseable model output, missing `gh`) also lands on exit code 1 through `commandExecutor`'s catch (`lib/utils/commandExecutor.ts:303`). A pipeline gating on `coco review --severity 7` cannot distinguish "the reviewer found blocking issues" from "the reviewer never ran".
+**Evidence:**
+```ts
+  if (exceedsThreshold) {
+    logger.log(`Review found ${…} finding(s) at or above severity ${severityThreshold}.`, { color: 'red' })
+    commandExit(1)
+  }
+```
+**Impact:** infrastructure flakes are indistinguishable from real review failures; teams either ignore the gate or block on transient errors. Reproduce: `unset OPENAI_API_KEY; coco review --severity 7 --json; echo $?` → `1` with no JSON, same code as a genuine breach.
+**Suggested fix:** reserve a dedicated code for the gate (e.g. `commandExit(2)` for "findings at/above threshold"), document it, and keep 1 for operational failure.
+**Confidence:** high
+
+### [SEVERITY: medium] fix(review): `--comment` post failure is logged but the command still exits 0
+**File:** `src/commands/review/handler.ts:374-385`
+**What's wrong:** when the forge rejects the comment / request-changes call (permissions, closed PR, `gh` not authenticated for that host), the failure is printed and execution falls through; nothing sets a non-zero exit.
+**Evidence:**
+```ts
+    if (postResult.ok) {
+      logger.log(postResult.message, { color: 'green' })
+    } else {
+      logger.error(postResult.message, { color: 'red' })
+    }
+```
+**Impact:** a CI job whose whole purpose is "post the review to the PR" reports success while nothing was posted (unless the severity gate happens to fire independently). Reproduce: `coco review --pr <n> --comment` with a read-only token → stderr message, `echo $?` → `0`.
+**Suggested fix:** `commandExit(1)` on `!postResult.ok` (or accumulate and exit non-zero at the end, distinct from the severity code).
+**Confidence:** high
+
+### [SEVERITY: medium] fix(doctor): `--json` is ignored for the main diagnostics report, which prints ANSI art to stdout
+**File:** `src/commands/doctor/handler.ts:141-166`
+**What's wrong:** `argv.json` is only honored inside the `--clear` and `--cost` branches. The default diagnostics path unconditionally logs the logo, the config-source list, and the diagnostics table via `logger.log` (i.e. `console.log` → stdout), with no JSON payload anywhere. `doctor/config.ts:32` nevertheless advertises `// --json is a global flag`.
+**Evidence:**
+```ts
+  if (argv.cost) { … renderCostReport(config, logger, Boolean(argv.json)); return }
+
+  logger.log(LOGO)
+  logger.log('')
+  logger.log(chalk.bold('coco doctor') + ' — checking your configuration\n')
+```
+**Impact:** `coco doctor --json | jq .` fails on the first byte (a box-drawing logo). Since `doctor` is the recommended pre-flight check, this breaks exactly the machine consumer the flag exists for.
+**Suggested fix:** emit `{ sources, diagnostics: [{severity, message, fix}], errors, warnings }` via `emitJson` and suppress all `logger.log` chrome when `argv.json` is set (the pattern recap/review/changelog already use).
+**Confidence:** high
+
+### [SEVERITY: medium] fix(cli): `--json` failure payloads are inconsistent — most commands emit plain text on stderr and nothing on stdout
+**File:** `src/commands/amend/handler.ts:80-87`, `src/commands/review/handler.ts:120-122`, `src/commands/prCreate/handler.ts:89-101`, `src/commands/changelog/handler.ts:109-111`, `src/commands/utils/githubListCommand.ts:141-172`
+**What's wrong:** `commit` (`handler.ts:73-81`) and `recap` (`handler.ts:316-320`) deliberately emit `{"error": …}` in JSON mode so machine consumers get a parseable failure. Every other `--json`-capable command exits 1 with an empty stdout: `amend` logs the draft errors through `logger`/`logger.error` *before* its `if (argv.json)` branch and never emits JSON; `review`, `pr create`, `changelog`, `prs`, `issues` do the same for their forge/validation failures.
+**Evidence (amend — `argv.json` is checked only after the failure return):**
+```ts
+  if (!result.ok || !result.draft) {
+    for (const warning of result.warnings) logger.log(warning, { color: 'yellow' })
+    for (const error of result.validationErrors) logger.error(error, { color: 'red' })
+    commandExit(1)
+    return
+  }
+  …
+  if (argv.json) { emitJson({ previous: previousMessage, message }); return }
+```
+**Impact:** a wrapper doing `out = $(coco amend --json) || parse_error(out)` gets an empty string and must fall back to scraping stderr. Reproduce: `coco amend --json` in a repo with no changes → exit 1, stdout empty.
+**Suggested fix:** pick one contract (`{"error": "..."}` on stdout + non-zero exit) and apply it to every `--json` path; simplest is a shared `emitJsonError(reason)` helper called from each failure branch.
+**Confidence:** high
+
+### [SEVERITY: medium] fix(commit): `--split` never validates group titles against commitlint, unlike plain `coco commit`
+**File:** `src/commands/commit/split.ts:845-865` (prompt context only) vs `src/commands/commit/handler.ts:373-500`
+**What's wrong:** the regular commit path runs `validateCommitMessage` and retries/prompts until the message passes commitlint. The split path only *injects the rules into the prompt* (`commitlintRulesContext`) and then commits each group's `${title}\n\n${body}` verbatim — there is no `validateCommitMessage` call anywhere in `split.ts` (grep confirms: the only importers of `commitlintValidator` in the commit folder are `handler.ts` and `generateCommitDraft.ts`).
+**Evidence:**
+```ts
+      const body = group.body ? `\n\n${group.body}` : ''
+      await createCommit(`${group.title}${body}`.trim(), git, undefined, { noVerify: groupNoVerify })
+```
+**Impact:** in a commitlint repo, `coco commit --split --apply` produces commits that violate the project's own rules; if a `commit-msg` hook exists, git rejects the group and the failure is misreported as a *pre-commit* hook problem (see next finding), with a "Skip hooks" remedy that bypasses the very rule the project wants. The single-group fallback title (`'chore: combined commit'`, `splitPlanValidation.ts:564`) is conventional-safe but would still fail a `scope-enum`/`subject-case` ruleset.
+**Suggested fix:** validate each group title (+body) with `validateCommitMessage` at plan time, feed failures back through the existing `previous_attempt_feedback` retry slot, and surface a hard error before touching the index.
+**Confidence:** high
+
+### [SEVERITY: medium] fix(git): every non-hook `GitError` is reported as "Commit blocked by pre-commit hook"
+**File:** `src/lib/simple-git/createCommit.ts:110-119`
+**What's wrong:** after the narrow "hook modified files" and "nothing to commit" checks, *all* remaining `GitError`s are wrapped in `PreCommitHookError`. GPG signing failures, `index.lock` contention, unborn-branch and identity errors (`Please tell me who you are`) all surface through the hook-failure UX.
+**Evidence:**
+```ts
+    if (error instanceof GitError) {
+      if (isKnownNonHookCommitFailure(error.message)) { throw error }
+      throw new PreCommitHookError(error.message)
+    }
+```
+**Impact:** with `commit.gpgsign=true` and no usable key, `coco commit -i` prints `✖ Commit blocked by pre-commit hook` and offers `⚠️  Skip hooks — Retry with --no-verify` (`lib/ui/hookFailurePrompt.ts:44-52`); `--no-verify` does not disable signing, so the "fix" silently fails again. In `--split` the same misclassification drives the per-group retry/skip loop.
+**Suggested fix:** only wrap when the error text actually indicates a hook (`hook`, `pre-commit`, `commit-msg`); otherwise rethrow so `commandExecutor`'s generic formatter shows the real cause.
+**Confidence:** high
+
+### [SEVERITY: medium] fix(commit): non-interactive hook failures print "fix the issues above" with the hook output muted
+**File:** `src/lib/ui/hookFailurePrompt.ts:27-40` + `src/commands/commit/handler.ts:124`
+**What's wrong:** the recovery helper prints the header via `logger.error` (always reaches stderr) but the actual hook output via `logger.log` — and the commit handler mutes the logger for every non-interactive run (`logger.setConfig({ quiet: true })`). The non-interactive branch then tells the user to fix "the issues above", which were suppressed.
+**Evidence:**
+```ts
+  logger.log('\nHook output:', { color: 'yellow' })
+  logger.log(SEPERATOR)
+  logger.log(hookOutput)
+  …
+  if (!interactive) {
+    logger.error('\nFix the issues above and try again, or use --no-verify to skip hooks.', { color: 'yellow' })
+    return 'abort'
+  }
+```
+**Impact:** `coco commit --split --apply` in CI (or `coco commit` with `commit: true` in config) reports a blocked commit with zero diagnostic detail. Reproduce: add a `pre-commit` hook that prints lint errors and exits 1, then run `coco commit --split --apply` — stderr shows only the header and the "fix the issues above" line.
+**Suggested fix:** print `hookOutput` with `logger.error` (or `process.stderr.write`) so it survives quiet/non-interactive mode.
+**Confidence:** high
+
+### [SEVERITY: medium] fix(commit): `--print-message` failures are completely silent (cause is `verbose`-gated), and skip the missing-API-key hint
+**File:** `src/commands/commit/handler.ts:65-82`
+**What's wrong:** on the draft-only path, warnings and validation errors are emitted with `logger.verbose`, which no-ops unless `--verbose` is set. The non-JSON branch then exits 1 having printed nothing. This path also bypasses `handleMissingApiKey` (called only later, at `:104`), so the specific "set `OPENAI_API_KEY` / run `coco init`" recovery copy that exists in `lib/ui/handleMissingApiKey.ts` is replaced by silence — `generateCommitDraft` returns `validationErrors: ['No API key configured for the commit service.']` and it is thrown away.
+**Evidence:**
+```ts
+      for (const warning of result.warnings) {
+        logger.verbose(warning, { color: 'yellow' })
+      }
+      for (const validationError of result.validationErrors) {
+        logger.verbose(validationError, { color: 'red' })
+      }
+```
+**Impact:** `coco commit --print-message` (the exact command the installed `prepare-commit-msg` hook runs, `hooks/manageHooks.ts:76`) fails with no output and exit 1 — so `git commit` opens an empty editor and the user has no idea coco tried and why it failed. Reproduce: `unset OPENAI_API_KEY; coco commit --print-message; echo $?` → no output, `1`.
+**Suggested fix:** print warnings/validation errors with `logger.error` on this path, and call `handleMissingApiKey` before `generateCommitDraft` (or surface its `validationErrors` verbatim).
+**Confidence:** high
+
+### [SEVERITY: medium] fix(cli): mutually exclusive flags are silently resolved by precedence instead of validated
+**File:** `src/commands/commit/split.ts:988-1010`, `src/commands/commit/handler.ts:65`, `src/commands/amend/handler.ts:25/92-98`, `src/commands/changelog/handler.ts:102-135`
+**What's wrong:** several commands accept contradictory flag pairs and pick a winner with no warning. Verified by probe (all parse cleanly under `.strictOptions()`):
+- `commit --split --plan --apply` → `{split:true, plan:true, apply:true}`; `if (argv.plan) return formatPlanPreview()` runs first, so `--apply` is dropped.
+- `commit --print-message --split` → the print-message early return wins; the split planner never runs.
+- `commit --apply` / `--strict-split` alone → `isCommitSplitCommand()` is false (`split.ts:112-116`), so both are silently no-ops.
+- `amend --dry-run --apply` → `previewOnly` wins; `--apply` ignored.
+- `changelog --only-diff` silently ignores `--range` / `--tag` / `--since-last-tag` (the `exclusiveOptions` guard at `:102-111` never considers `onlyDiff`).
+- `doctor --clear --cost` → `--clear` wins, no cost report.
+**Evidence:**
+```ts
+  // --plan: print the plan and exit (opt-out from the default apply prompt).
+  if (argv.plan) {
+    return formatPlanPreview()
+  }
+  // --apply: skip the confirmation prompt and apply directly.
+  if (argv.apply) {
+```
+**Impact:** scripts that pass a redundant/incorrect combination get a different behavior than requested with no diagnostic — most consequentially `--split --plan --apply` (user expects commits, gets a preview) and `--apply` alone (user expects a split apply, gets a plain single commit draft). Note `review`'s builder already demonstrates the right pattern with `.check()` for `--comment`/`--pr`/`--branch`/`--staged`.
+**Suggested fix:** add `.check()` validation (or `.conflicts()`) per command: reject `--plan` with `--apply`, `--dry-run` with `--apply`, `--print-message` with split flags, `--only-diff` with range selectors, and error on `--apply`/`--strict-split` without `--split`.
+**Confidence:** high
+
+### [SEVERITY: medium] fix(changelog): `--write` section replacement scans only to the next `## `, swallowing intervening `# ` release sections
+**File:** `src/commands/changelog/writeChangelog.ts:64-78`
+**What's wrong:** when an existing `## {title}` section is found, the end of the section is located by scanning forward for the next line starting with `## `. A top-level `# ` heading does not match, so everything from the replaced section down to the next `##` — including any `# [2.0.0]`-style major-release section and all of its body — is deleted. conventional-changelog / standard-version emit exactly that shape (`# [2.0.0]` for majors, `## [1.1.0]` for minors), so this is a realistic layout. Related: `trimmedEnd` is computed (`:71-74`) and then never used — `after` slices from the untrimmed `endIndex`, so the documented "trim the trailing blank lines" behavior is not implemented.
+**Evidence:**
+```ts
+    let endIndex = startIndex + 1
+    while (endIndex < lines.length && !lines[endIndex].startsWith('## ')) {
+      endIndex += 1
+    }
+```
+**Impact:** re-running `coco changelog --write` for a title that already exists can permanently delete an entire major-version section of CHANGELOG.md (the write itself is atomic, so there's no partial-file symptom to notice — the content is just gone). Reproduce: CHANGELOG with `## v1.2 — …`, then `# [2.0.0]` + body, then `## v1.1`; write section `v1.2` → the `# [2.0.0]` block disappears.
+**Suggested fix:** stop the scan at any heading of the same or higher level (`/^#{1,2} /`), and either use `trimmedEnd` or delete it.
+**Confidence:** high
+
+### [SEVERITY: medium] fix(amend): `noVerify` from config is ignored (only the CLI flag is honored)
+**File:** `src/commands/amend/handler.ts:141`
+**What's wrong:** `commit` resolves the setting from both sources (`handler.ts:553`: `const noVerify = argv.noVerify || config.noVerify || false`, and `split.ts:1000`/`:1049` do the same). `amend` reads only `argv.noVerify`, so a user with `noVerify: true` in `.coco.json`/`~/.gitconfig` gets hooks run on amend but skipped on commit.
+**Evidence:**
+```ts
+      { amend: true, noVerify: argv.noVerify }
+```
+**Impact:** inconsistent, surprising hook behavior between two sibling commands; in a repo with a slow/blocking pre-commit hook, `coco amend` fails where `coco commit` succeeds. Reproduce: set `coco.noVerify=true` in `~/.gitconfig`, add a failing pre-commit hook, run `coco commit` (skips) vs `coco amend` (blocked).
+**Suggested fix:** `noVerify: argv.noVerify || config.noVerify || false`.
+**Confidence:** high
+
+---
+
+## LOW
+
+### [SEVERITY: low] fix(commit): `openInEditor` is declared as a commit option but has no yargs flag
+**File:** `src/commands/commit/config.ts:8` (interface) vs `:80-158` (options map)
+**What's wrong:** `CommitOptions.openInEditor: boolean` is part of the command's public option type and is read from config (`handler.ts:480`, `editResult`), but no `openInEditor` entry exists in the yargs `options` map. Under `.strictOptions()` the flag is rejected.
+**Evidence:** probe — `commit --open-in-editor` → `fail: Unknown arguments: open-in-editor, openInEditor`.
+**Impact:** users reading the type (or the config key) reasonably try `--open-in-editor` and get "Unknown argument"; the behavior is only reachable via config.
+**Suggested fix:** declare the flag (`openInEditor: { type: 'boolean', description: … }`) or drop it from the argv-facing interface.
+**Confidence:** high
+
+### [SEVERITY: low] fix(cli): numeric flags accept garbage and silently become `NaN`
+**File:** `src/commands/commit/config.ts:108-113`, `src/commands/prs/config.ts:73-76`, `src/commands/issues/config.ts:63-66`
+**What's wrong:** unlike `review --severity` (guarded) and `log --limit` (normalized in `git/logData.ts:119-127`), these numeric options have no validation. Probe: `commit -p abc` → `withPreviousCommits: NaN` (then `NaN > 0` is false, so the requested commit history is silently omitted); `prs --limit abc` → `limit: NaN`, and `typeof NaN === 'number'` passes the guard at `git/pullRequestListData.ts:150`, so `gh pr list --limit NaN` is executed.
+**Evidence:**
+```ts
+  if (typeof filter.limit === 'number') args.push('--limit', String(filter.limit))
+```
+**Impact:** a typo/empty shell variable either silently drops context (`-p`) or produces a confusing `gh`-level error instead of a CLI-level one.
+**Suggested fix:** add `.check()` integer/range validation (or `coerce` with an explicit throw) for `withPreviousCommits` and `limit`.
+**Confidence:** high
+
+### [SEVERITY: low] fix(commit): `noResult` prints "Changes not staged for commit:" headings with no content unless `--verbose`
+**File:** `src/commands/commit/noResult.ts:28-40`
+**What's wrong:** the section headings use `logger.log` but the file lists use `logger.verbose`, which no-ops without `--verbose`.
+**Evidence:**
+```ts
+      logger.log('\nChanges not staged for commit:', { color: 'yellow' })
+      logger.verbose(`\t${unstaged.map(({ summary }) => summary).join('\n\t')}`, { color: 'red' })
+```
+**Impact:** `coco commit` with only unstaged work prints two dangling headings and no file names — the actionable part (which files to `git add`) is hidden behind a flag.
+**Suggested fix:** use `logger.log` for the lists (they are short), or drop the headings when the body is suppressed.
+**Confidence:** high
+
+### [SEVERITY: low] fix(cli): `handleResult` is not awaited in changelog and recap
+**File:** `src/commands/changelog/handler.ts:422`, `src/commands/recap/handler.ts:325`
+**What's wrong:** both call the async `handleResult({...})` without `await` (commit and log do await it). In interactive mode the `interactiveModeCallback` (`logSuccess`) therefore races the following `logLlmTelemetrySummary` call, and any rejection becomes an unhandled promise rejection outside `commandExecutor`'s try/catch.
+**Evidence:**
+```ts
+  handleResult({
+    result: changelogMsg,
+    interactiveModeCallback: async () => { logSuccess() },
+    mode: MODE as 'interactive' | 'stdout',
+  })
+  logLlmTelemetrySummary(logger, 'changelog')
+```
+**Impact:** out-of-order output in interactive mode; a future throw inside the callback would escape error handling entirely.
+**Suggested fix:** `await handleResult(...)`.
+**Confidence:** high
+
+### [SEVERITY: low] fix(workspace): handler always `process.exit(0)`, masking failures and bypassing pending writes
+**File:** `src/commands/workspace/handler.ts:168-172`
+**What's wrong:** the force-exit (added to avoid lingering `gh` child processes) hardcodes code 0 and runs immediately after `flushWorkspaceTrace()`, discarding any `process.exitCode` an inner surface set and cutting off asynchronous flushes (cache writes, ledger appends).
+**Evidence:**
+```ts
+  await startCocoWorkspace(argv)
+  flushWorkspaceTrace()
+  process.exit(0)
+```
+**Impact:** `coco workspace` can never report a non-zero exit, and a just-issued overview/commit cache write can be truncated. (Related, minor: `commandExit`-based exits everywhere else use `process.exitCode`, which flushes correctly — this is the one hard `process.exit` in the command layer.)
+**Suggested fix:** `process.exitCode = process.exitCode ?? 0` plus `process.exit()` after an explicit flush, or unref the offending child process instead of force-exiting.
+**Confidence:** medium
+
+### [SEVERITY: low] fix(commit): the split apply confirmation defaults to "yes"
+**File:** `src/commands/commit/split.ts:1034-1037`
+**What's wrong:** the only confirmation gate before rewriting the index and creating N commits defaults to accept, so a stray Enter applies the plan.
+**Evidence:**
+```ts
+  const shouldApply = await confirmPrompt({
+    message: `Apply these ${plan.groups.filter((g) => !g.unclaimed).length} commits?`,
+    default: true,
+  })
+```
+**Impact:** an accidental Enter (common when the plan preview scrolls past) performs a destructive, multi-commit, index-resetting operation. Contrast `init`'s advanced prompts, which default to `false`.
+**Suggested fix:** `default: false` for this prompt (it is the destructive one), or require typing the group count.
+**Confidence:** high
+
+### [SEVERITY: low] fix(recap): shortcut timeframe flags silently override an explicit `--timeframe`
+**File:** `src/commands/recap/handler.ts:66-78`
+**What's wrong:** the ternary chain resolves `--last-month`/`--last-tag`/`--yesterday`/`--last-week`/`--current-branch` before ever looking at `argv.timeframe`, which `config.ts:63-67` documents as "canonical form of the shortcut flags above".
+**Evidence:**
+```ts
+  const timeframe = lastMonth ? 'last-month' : lastTag ? 'last-tag' : yesterday ? 'yesterday' : lastWeek ? 'last-week'
+    : argv.currentBranch || config.currentBranch ? 'currentBranch'
+    : argv.timeframe ?? config.timeframe ?? 'current'
+```
+**Impact:** `coco recap --yesterday --timeframe last-week` recaps yesterday with no warning about the conflict.
+**Suggested fix:** `.check()` that at most one timeframe selector is present.
+**Confidence:** high
+
+---
+
+## Areas I checked and found clean
+
+- **`review --severity` NaN handling** — `config.ts:88-99` `.check()` rejects non-integer/out-of-range values, and the handler re-guards with `Number.isFinite` (`handler.ts:367`). Probe confirms `--severity high` fails loudly.
+- **`recap --tag <value>`** — the builder's `.check()` (`recap/config.ts:76-93`) correctly rejects the stray positional and points at `coco changelog --tag`.
+- **`pr <action>`** — `choices: ['create']` on the positional means `coco pr close` fails natively instead of creating a PR; `cache <subcommand>` and `config <action>`/`hooks <action>` use the same pattern.
+- **`--no-cache` reachability** — `prs`/`issues` declare `cache: {default: true}` specifically so yargs' boolean negation works under `.strictOptions()`; probe confirms `--no-cache` → `cache: false`. Same for `ui --no-all`.
+- **stdout purity of `emitJson`** — `emitJson`/`handleResult` write directly to `process.stdout`; `ora` spinners go to stderr; `Logger.error` goes to stderr; the project/XDG config `console.warn`s go to stderr. recap/review/changelog additionally mute the logger in `--json` mode. (The one gap: `commit --json --verbose` never mutes the logger, so `logger.verbose`/`stopTimer` lines would land on stdout — worth a one-line `setConfig({quiet:true})` but not user-visible without `--verbose`.)
+- **Exit codes / flushing** — all exits route through `commandExit` → `CommandExitError` → `process.exitCode` in `commandExecutor`, so stdout is never truncated; prompt cancellation is mapped to 130 (`commandExecutor.ts:275-278`).
+- **Non-TTY prompt guards** — `cache prefetch` with no args checks `process.stdin.isTTY` and prints an explicit non-interactive hint; `commit --split` deliberately behaves like `--plan` instead of prompting when not interactive (`split.ts:1013-1023`); `promptHookFailureRecovery` degrades to `abort`; `review` falls back to a static render when `!process.stdin.isTTY && !process.stdout.isTTY`.
+- **`hooks install/uninstall/status`** — marker-based idempotency, `mode: 0o755` on both the hook and the backup, `lstat`-based symlink refusal with `--force` opt-in, backup-collision refusal, `git rev-parse --git-path hooks` (honors `core.hooksPath`/worktrees), restore-on-uninstall, and a hook script that fails open (`|| exit 0`) and never clobbers an existing message.
+- **`--repo`/`--cwd` global** — every in-scope handler calls `applyRepoFlag`/`applyRepoCwd` before `loadConfig` (including the changelog handler's extra pre-`loadConfig` `applyRepoCwd` at `:390`); no command silently ignores it.
+- **Split plan validation core** — `getPlanValidationIssues` covers unknown/duplicate/mixed/partial/missing files and hunks; `dropEmptyGroups` runs last and is re-asserted defensively at apply time; apply-time drift detection exists for file-mode claims (`assertNoStagedDriftSincePlan`) and unstaged-overlap is rejected up front; `git apply --cached` failures are captured with stderr.
+- **`log`** — `normalizeLimit` (`git/logData.ts:115-127`) handles `NaN`/`<1`; empty-repo short-circuit emits `[]` in JSON mode and exits 0; `--format json`/global `--json` agree.
+- **Short-flag aliases** — `flagAliasConsistency.test.ts` enforces no intra-command letter collisions and the `-t`/`-c` reservations; I found no new collisions (the global `-v`/`-q` do not clash with any command's aliases).

--- a/docs/audit-0.84.1/bugs-git-forge.md
+++ b/docs/audit-0.84.1/bugs-git-forge.md
@@ -1,0 +1,568 @@
+# Bug audit — `src/git/**` (coco v0.84.1)
+
+Read-only audit. No code changed. Every claim below is quoted from the file at the cited line.
+
+Scope covered: git read/write actions (`logData`, `historyActions`, `branchActions`, `statusActions`,
+`statusHunks`, `stash*`, `tag*`, `worktree*`, `reflog*`, `bisect*`, `blame*`, `submodule*`,
+`operation*`, `conflictRegionActions`, `rebase*`, `hunkActions`, `compareData`, `fileHistoryData`,
+`workspace*`, `cloneRepo`, `gitignore`, `repoIdentifier`) and the multi-forge adapter
+(`forgeActions`, `forgeLoad`, `forgeErrors`, `forgeText`, `forgeArgGuards`, `githubCli`, `glabCli`,
+`bitbucketCli`, `giteaCli`, and all `*ListData` / `*DetailData` / `*Actions` per-forge modules).
+
+---
+
+## HIGH
+
+### [SEVERITY: high] fix(git): route self-hosted Bitbucket Server remotes somewhere real instead of api.bitbucket.org
+**File:** src/git/bitbucketCli.ts:40,76 (with src/git/providerData.ts:115)
+**What's wrong:** `detectProvider` classifies **any** host containing `bitbucket` as the `bitbucket`
+provider, and `forgeHostOverrides` lets a user map an arbitrary vanity host to `bitbucket`. But the
+Bitbucket runner has a single hardcoded cloud API base and never consults the parsed host —
+`BitbucketProject.host` is populated by `resolveForgeProject` and then discarded. Bitbucket
+Server/Data Center serves a completely different API (`/rest/api/1.0/...`), so every call for a
+self-hosted remote is sent to Atlassian's cloud with a workspace slug that doesn't exist there.
+`getForgeActions` has `gitlabHost` and `giteaHost` options but no `bitbucketHost`.
+**Evidence:**
+```ts
+// providerData.ts:115
+if (h === 'bitbucket.org' || h.includes('bitbucket')) return 'bitbucket'
+// bitbucketCli.ts:40,76
+export const BITBUCKET_API_BASE = 'https://api.bitbucket.org/2.0'
+const url = endpoint.startsWith('http') ? endpoint : `${BITBUCKET_API_BASE}/${endpoint}`
+```
+**Impact:** On `bitbucket.acme.com`, `coco prs` / `coco issues` / every PR mutation hits
+`https://api.bitbucket.org/2.0/repositories/<ws>/<repo>/...`. Users see "Bitbucket credentials are
+invalid" or a 404 body, or — worse — if a same-named workspace exists on Bitbucket Cloud, they act on
+the **wrong repository**. Reproduce: point `origin` at any `*bitbucket*` host that is not
+`bitbucket.org` and run `coco prs`. No test exercises the non-`bitbucket.org` branch
+(`bitbucketCli.test.ts` and `providerData.test.ts` only assert `bitbucket.org`).
+**Suggested fix:** Thread `project.host` into the runner (`makeBitbucketRunner(host)` mirroring
+`makeGiteaRunner`), and gate non-`bitbucket.org` hosts behind an explicit "Bitbucket Server is not
+supported" message rather than silently addressing the cloud API.
+**Confidence:** high
+
+### [SEVERITY: high] fix(git): stop routing forge URLs through `cmd /c start` on Windows
+**File:** src/git/historyActions.ts:112 (reached from src/git/providerActions.ts:19)
+**What's wrong:** `defaultOpenUrlRunner` opens URLs on Windows via `execFile('cmd', ['/c','start','',url])`.
+`execFile` does not use a shell, but `cmd.exe` *is* the shell here and parses its own command line, so
+shell metacharacters in `url` (`&`, `|`, `^`, `>`) are interpreted by cmd. Node only adds quoting for
+args containing spaces/tabs/quotes, so a URL with `&` and no space is passed unquoted. The URL is
+built from remote-derived data: `buildProviderUrl` percent-encodes only the *ref* portion, while the
+base is `https://${parsed.host}/${parsed.owner}/${parsed.name}` straight out of `.git/config` with no
+character validation in `parseRemoteUrl`.
+**Evidence:**
+```ts
+// historyActions.ts:110-113
+if (process.platform === 'win32') {
+  await runCommand('cmd', ['/c', 'start', '', url])
+  return
+}
+```
+```ts
+// providerData.ts:158 — webUrl is unvalidated remote text
+webUrl: `https://${parsed.host}/${parsed.owner}/${parsed.name}`,
+```
+**Impact:** On Windows, a repo whose remote URL contains `&calc` (or any command) executes it when the
+user presses the open-in-browser key. Reproduce: `git remote set-url origin https://example.com/a&calc/b`,
+open the branches/history view on Windows, trigger `open-provider-url`.
+**Suggested fix:** Use `spawn('rundll32', ['url.dll,FileProtocolHandler', url])` or
+`powershell -NoProfile -Command Start-Process -- <url>` with argv separation, and validate that the
+resolved URL parses as `http(s)` with a hostname before handing it to any launcher.
+**Confidence:** medium — the injection path is standard-known for `cmd /c start`; a Windows box is
+needed to confirm Node's exact quoting for a `&`-containing, space-free argument.
+
+### [SEVERITY: high] fix(git): filter Bitbucket pull requests by author/assignee server-side
+**File:** src/git/bitbucketListData.ts:231-250
+**What's wrong:** The Bitbucket **issue** loader was explicitly fixed to resolve `@me` and push the
+filter into the BBQL query *before* fetching (see its own comment at line 338-343). The **pull
+request** loader still fetches `want` (default 30) PRs unfiltered and then filters in memory, even
+though BBQL supports `author.nickname` and `reviewers.nickname`.
+**Evidence:**
+```ts
+// bitbucketListData.ts:239-248
+if (filter.author) {
+  const authorFilter = filter.author === '@me' ? me : filter.author
+  pullRequests = pullRequests.filter((pr) => pr.author === authorFilter)
+}
+if (filter.assignee) { ... pr.assignees?.includes(assigneeFilter) ... }
+```
+vs. the sibling issue path, whose comment states the exact bug: *"Filtering after the fetch (the old
+approach) ran against only the first `want` issues of the unfiltered list, so a user whose issues sat
+past that window saw them silently dropped."*
+**Impact:** `coco prs --author @me` on a busy Bitbucket repo silently returns an empty or partial list
+whenever the user's PRs are older than the newest 30. Same for `--assignee`. Reproduce: repo with 40+
+open PRs where yours are #1-#5.
+**Test note:** `bitbucketListData.test.ts:354-400` encodes the buggy behavior — the fixtures contain
+only two PRs, so post-fetch filtering passes; the issue-list tests at 448-470 assert the correct
+server-side form (`reporter.nickname = "erin"` in the endpoint).
+**Suggested fix:** Extend `buildPullRequestEndpoint` with `author.nickname = "…"` /
+`reviewers.nickname = "…"` clauses (already have `bbqlQuote`), matching `buildIssueEndpoint`.
+**Confidence:** high
+
+### [SEVERITY: high] fix(git): stop reporting API failures as "Empty response" in forge detail loaders
+**File:** src/git/bitbucketDetailData.ts:55-62,146; src/git/gitlabDetailData.ts:79-84,150; src/git/giteaDetailData.ts:55-62
+**What's wrong:** All three non-GitHub detail loaders fetch the primary object through a `safeJson`
+helper that catches **every** error and returns `undefined`; the caller then reports "Empty response".
+A 401, 403, 404, DNS failure, or timeout is therefore indistinguishable from an empty body, and the
+underlying stderr/status is thrown away.
+**Evidence:**
+```ts
+// bitbucketDetailData.ts:55-62 (gitlab/gitea identical)
+async function safeJson<T>(runner: BitbucketRunner, endpoint: string): Promise<T | undefined> {
+  try { const out = (await runner(endpoint)).trim(); return out ? (JSON.parse(out) as T) : undefined }
+  catch { return undefined }
+}
+```
+```ts
+// bitbucketDetailData.ts:146
+return { ok: false, message: `Empty response from Bitbucket for pull request #${pullRequestNumber}` }
+```
+**Impact:** A user whose token expired mid-session sees "Empty response from Bitbucket for pull
+request #12" in the inspector instead of the auth hint the forge layer already knows how to produce
+(`describeBitbucketStatus`). Every diagnosis path (wrong workspace, private repo, offline) collapses
+into one wrong message. Reproduce: unset `BITBUCKET_ACCESS_TOKEN` mid-run, or point at a PR number
+that doesn't exist.
+**Suggested fix:** Let the primary-object fetch throw and route it through
+`resolveBitbucketActionError` / `resolveGlabActionError` / `resolveGiteaActionError` (which already
+re-probe auth); keep `safeJson` only for the genuinely optional sub-resources (approvals, statuses).
+**Confidence:** high
+
+### [SEVERITY: high] fix(git): guard unresolved project path in Bitbucket/Gitea forge mutations
+**File:** src/git/forgeActions.ts:281-302, 330-352
+**What's wrong:** In the Bitbucket and Gitea facades the *detail* methods guard a missing project path
+and return `{ ok: false, message: 'No … project resolved' }`, but every by-number mutation and every
+issue mutation coerces with `path ?? ''`, producing endpoints with an empty path segment. The Gitea
+facade additionally builds its runner with `makeGiteaRunner(host ?? '')`, i.e. base `https:///api/v1`
+when the host is unknown.
+**Evidence:**
+```ts
+// forgeActions.ts:284-285,298-302
+mergePullRequestByNumber: (n, strategy) => mergeBitbucketPullRequestByNumber(path ?? '', n, strategy),
+requestChangesPullRequestByNumber: (n, body) => requestChangesBitbucketPullRequestByNumber(path ?? '', n, body),
+commentIssue: (n, body) => commentBitbucketIssue(path ?? '', n, body),
+closeIssue: (n) => closeBitbucketIssue(path ?? '', n),
+// forgeActions.ts:319
+const runner = makeGiteaRunner(host ?? '')
+```
+**Impact:** With an unresolvable remote the user gets an HTTP 404 body or a `Failed to parse URL`
+network error (further masked by the auth re-probe into "Set GITEA_TOKEN"), instead of the clear "No
+project resolved" message the detail path returns for the identical precondition. Reproduce:
+`getForgeActions('bitbucket', {})` then `mergePullRequestByNumber(1, 'merge')` → request to
+`repositories//pullrequests/1/merge`.
+**Suggested fix:** Hoist one `if (!path) return { ok:false, message:'No … project resolved' }` guard
+(and a host guard for Gitea) shared by every method in the facade.
+**Confidence:** high
+
+---
+
+## MEDIUM
+
+### [SEVERITY: medium] fix(git): stop swallowing gh failures as "No pull request found"
+**File:** src/git/pullRequestData.ts:167-176
+**What's wrong:** The GitHub current-branch overview wraps `gh pr view` in a bare `catch` that
+discards the error and always reports "No pull request found for \<branch\>". Rate limits, network
+failures, a gh crash, a repo the token can't see, and a genuinely PR-less branch are reported
+identically. Every other forge lets the error reach `loadForgeOverview`, which surfaces
+`error.message`.
+**Evidence:**
+```ts
+// pullRequestData.ts:168-175
+try {
+  const output = await runner(['pr', 'view', '--json', PULL_REQUEST_VIEW_JSON_FIELDS])
+  return { currentPullRequest: parsePullRequestInfo(output) }
+} catch {
+  return { message: currentBranch ? `No pull request found for ${currentBranch}.` : 'No current branch.' }
+}
+```
+**Impact:** Offline or rate-limited users are told their PR doesn't exist. Reproduce: set an invalid
+`GH_TOKEN` after the auth probe passes, or run with the network down.
+**Suggested fix:** Inspect the error — only map gh's "no pull requests found" to the friendly message
+and let anything else fall through to `compactGhError` (already available).
+**Confidence:** high
+
+### [SEVERITY: medium] fix(git): guard flag-like branch name in checkoutBranchByName
+**File:** src/git/branchActions.ts:117-121
+**What's wrong:** Its siblings in the same file (`createBranch:104`, `renameBranch:129`,
+`setUpstream:373`) all call `rejectFlagLike` before handing a user-typed name to git.
+`checkoutBranchByName` — which receives free-typed input from the create-branch-here confirm prompt —
+does not, and there is no `--end-of-options` / `--` separator.
+**Evidence:**
+```ts
+export function checkoutBranchByName(git: SimpleGit, name: string): Promise<BranchActionResult> {
+  const trimmed = name.trim()
+  if (!trimmed) return Promise.resolve({ ok: false, message: 'Branch name required' })
+  return runAction(() => git.raw(['switch', trimmed]), `Checked out ${trimmed}`)
+}
+```
+**Impact:** A typed value beginning with `-` is parsed by `git switch` as an option — e.g. `--detach`
+detaches HEAD, `-c foo` creates a branch — while the result message claims "Checked out \<value\>".
+Not remote-code-execution (no shell), but it silently performs a different git operation than the one
+named.
+**Suggested fix:** `rejectFlagLike(trimmed, …)` like its siblings, and/or `['switch', '--', trimmed]`.
+**Confidence:** high
+
+### [SEVERITY: medium] fix(git): guard flag-like branch name in stashBranch
+**File:** src/git/stashActions.ts:96-105
+**What's wrong:** Same asymmetry as above: `historyActions.createBranchFromCommit` and
+`branchActions.createBranch` guard user-typed branch names; `stash branch <name>` does not.
+**Evidence:**
+```ts
+const trimmed = branchName.trim()
+if (!trimmed) return Promise.resolve({ ok: false, message: 'Cancelled: empty branch name.' })
+return runAction(() => git.raw(['stash', 'branch', trimmed, stash.ref]), …)
+```
+**Impact:** A leading-`-` name is consumed as a `git stash branch` option; the action reports success
+for an operation that didn't happen as described.
+**Suggested fix:** Add `rejectFlagLike`.
+**Confidence:** high
+
+### [SEVERITY: medium] fix(git): guard bisect start refs
+**File:** src/git/bisectActions.ts:17-40
+**What's wrong:** `bisectStart` (and the optional `ref` on good/bad/skip) passes refs positionally with
+no leading-dash guard and no `--`. `git bisect start` accepts options such as `--term-new` /
+`--term-old` / `--no-checkout` in exactly that position.
+**Evidence:**
+```ts
+export async function bisectStart(git: SimpleGit, badRef: string, goodRef: string): Promise<string> {
+  return git.raw(['bisect', 'start', badRef, goodRef])
+}
+```
+**Impact:** A mistyped/pasted ref starting with `-` starts a bisect with altered semantics (or errors
+opaquely) rather than being rejected up front. Also note `bisectRun` intentionally shells through
+`sh -c` (documented); that is by design for user-supplied test commands, but it means the bisect
+surface is the one place in `src/git` where a shell is involved — worth an explicit confirm gate.
+**Suggested fix:** `rejectFlagLike` both refs (the helper already exists and is used by
+`rebaseActions.rebaseOnto` for the same shape of input).
+**Confidence:** high
+
+### [SEVERITY: medium] fix(git): resolve the tag remote instead of hardcoding origin
+**File:** src/git/tagActions.ts:49-66
+**What's wrong:** `pushTag` and `deleteRemoteTag` hardcode `origin`, while the rest of the layer
+resolves "origin, else the first remote" through `resolveDefaultRemote` (githubCli.ts:126) or
+`branchActions.resolveDefaultRemote` (branchActions.ts:60).
+**Evidence:**
+```ts
+() => git.raw(['push', 'origin', `refs/tags/${tagName}`]),
+…
+() => git.raw(['push', 'origin', `:refs/tags/${tagName}`]),
+```
+**Impact:** In a repo whose only remote is `upstream` (fork workflows, `git remote rename`), tag
+push/delete fails with git's raw "'origin' does not appear to be a git repository" instead of using
+the single configured remote. `tagActions.test.ts:26-27` locks the hardcoded `origin` in.
+**Suggested fix:** Reuse the shared default-remote resolver and surface "no remote configured" when
+there is none.
+**Confidence:** high
+
+### [SEVERITY: medium] fix(git): don't drop a stash before the replacement store is known to succeed
+**File:** src/git/stashActions.ts:136-140
+**What's wrong:** `renameStash` drops the reflog entry first and then re-stores the commit under the
+new message (the ordering is deliberate and documented). But if the `store` fails, the entry is gone
+and the returned message contains only git's `store` error — not the commit hash needed to recover.
+**Evidence:**
+```ts
+return runAction(async () => {
+  await git.raw(['stash', 'drop', stash.ref])
+  await git.raw(['stash', 'store', '-m', storedMessage, stash.hash])
+}, `Renamed ${stash.ref} → ${trimmed}`)
+```
+**Impact:** A failed rename removes the stash from the list; the work is only recoverable via
+`git fsck`/reflog spelunking because the UI never shows `stash.hash`. Reproduce: make `stash store`
+fail (e.g. concurrent stash mutation, read-only `.git`).
+**Suggested fix:** Wrap the pair so a failed `store` retries or, at minimum, include
+`stash.hash` in the failure `details` (`git stash store -m … <hash>` is then a copy-paste recovery).
+**Confidence:** high
+
+### [SEVERITY: medium] fix(git): actually open the browser for Bitbucket/Gitea `pr create --web`
+**File:** src/git/bitbucketPullRequestActions.ts:55-57; src/git/giteaPullRequestActions.ts:56-58
+**What's wrong:** GitHub and GitLab implement `openPullRequest` by invoking the CLI's `--web`
+(`['pr','view','--web']` / `['mr','view','--web']`). Bitbucket and Gitea return `ok: true` without
+opening anything, even though the repo already has a cross-platform opener
+(`historyActions.defaultOpenUrlRunner`, used by `providerActions.openProviderUrl`).
+**Evidence:**
+```ts
+export function openBitbucketPullRequest(url: string): PullRequestActionResult {
+  return { ok: true, message: `Open this URL in your browser: ${url}`, url }
+}
+```
+**Impact:** `coco pr create --web` on Bitbucket/Gitea reports success and no browser opens
+(handler: `src/commands/prCreate/handler.ts:178`). Parity gap the facade's own capability table doesn't
+record as unsupported (unlike checkout/diff, which return `ok: false`).
+**Suggested fix:** Call `defaultOpenUrlRunner(url)` (with the Windows fix above) and return its
+result, or return `ok: false` so the CLI reports the gap honestly.
+**Confidence:** high
+
+### [SEVERITY: medium] fix(git): paginate Gitea label lookup and distinguish "not found" from "lookup failed"
+**File:** src/git/giteaPullRequestActions.ts:143-176
+**What's wrong:** `resolveGiteaLabelId` requests only the first 50 repo labels and swallows any error
+into `undefined`; the caller then reports a definitive "not found — create it in Gitea first".
+Org-level labels are not in the repo label list at all.
+**Evidence:**
+```ts
+const out = (await runner(`repos/${projectPath}/labels?limit=50`)).trim()
+const labels = out ? (JSON.parse(out) as Array<{ id?: number; name?: string }>) : []
+return labels.find((l) => l.name === label)?.id
+} catch { return undefined }
+```
+```ts
+if (id === undefined) {
+  return { ok: false, message: `Label '${label}' not found on this repository. Create it in Gitea first.` }
+}
+```
+**Impact:** On repos with >50 labels (or any transient API error), adding an existing label fails with
+advice to create a label that already exists — and following that advice creates a duplicate.
+**Suggested fix:** Page through `/labels` with the shared `paginate` helper (already imported
+elsewhere in the Gitea modules), include `/orgs/{org}/labels`, and separate the throw path from the
+not-found path.
+**Confidence:** high
+
+### [SEVERITY: medium] fix(git): make workspace PR counts host-aware (GHE regression)
+**File:** src/git/workspacePullRequestData.ts:185,208
+**What's wrong:** The workspace surface probes auth with the github.com default
+(`isGhAuthenticated(runner)` → `getGhStatus(runner, 'github.com')`) and resolves repos with the
+github.com-only `parseGitHubRemoteUrl`. The rest of the layer was migrated to host-aware resolution
+for exactly this reason (`getGitHubRepositoryForGit`, "#1609" in `issuesListData.ts:135`).
+**Evidence:**
+```ts
+const authenticated = await isGhAuthenticated(runner)   // github.com only
+…
+const repo = parseGitHubRemoteUrl(url)                   // returns undefined for GHE hosts
+```
+**Impact:** A workspace of GitHub Enterprise repos shows no PR badges at all, and a user authenticated
+only to a GHE host gets `authenticated: false` (whole column dropped). Reproduce: workspace root with
+GHE remotes only.
+**Suggested fix:** Parse with the host-agnostic `parseRemoteUrl` + `detectProvider`, probe
+`getGhStatus(runner, host)`, and pass `-R <webUrl>` (the same trick `providerData.getDefaultBranch`
+uses at line 267-270) instead of a bare `owner/name` slug.
+**Confidence:** high
+
+### [SEVERITY: medium] fix(git): bound `git log --follow` in the file-history loader
+**File:** src/git/fileHistoryData.ts:86-99
+**What's wrong:** Unlike `logData.buildLogArgs` (which always sets `--max-count`), the file-history
+loader runs an unbounded `git log --follow` and buffers the whole result. `--follow` on an old file in
+a large repo can walk the entire history.
+**Evidence:**
+```ts
+output = await git.raw([
+  'log', '--follow', `--format=%H${SEP}%h${SEP}%an${SEP}%at${SEP}%s${REC}`, '--', path,
+])
+```
+**Impact:** Opening file history for a long-lived file blocks the TUI for seconds and buffers the full
+log into memory; there is no `--max-count`, no timeout, and no AbortSignal, so the keystroke cannot be
+cancelled. Same shape applies to `blameData.getBlame` (`git blame --porcelain` on a huge file).
+**Suggested fix:** Add `--max-count=<limit>` (mirroring `LOG_DEFAULT_LIMIT`) with a "load more" path,
+and thread an AbortSignal.
+**Confidence:** high
+
+### [SEVERITY: medium] fix(git): surface truncated comment threads instead of silently degrading
+**File:** src/git/gitlabDetailData.ts:60-84; src/git/bitbucketDetailData.ts:64-82; src/git/giteaDetailData.ts:65-83
+**What's wrong:** All three comment loaders call `paginate({ want: Infinity, maxPages: 20, onError: 'stop' })`.
+`onError: 'stop'` discards a mid-pagination error and returns the partial list; the 20-page cap
+silently truncates long threads. Nothing in the returned `PullRequestDetail` records that the list is
+incomplete.
+**Evidence:**
+```ts
+// gitlabDetailData.ts:70-83
+parsePage: (output) => { if (!output) return undefined … },
+want: Infinity, maxPages: 20, onError: 'stop',
+```
+**Impact:** The inspector shows a truncated discussion (up to 2000 GitLab notes / 1000 Bitbucket
+comments, then nothing) and a failed page 3 renders as "the thread ended at page 2" — a reviewer can
+miss a change request. Reproduce: a PR with >1000 comments, or make the second page 500.
+**Suggested fix:** Return `{ items, truncated: boolean }` from the pagination and render a
+"… N more comments (fetch failed / limit reached)" row.
+**Confidence:** high
+
+### [SEVERITY: medium] fix(git): pass `--end-of-options` before positional refs in `git log`
+**File:** src/git/logData.ts:400-418
+**What's wrong:** `buildLogArgs` appends `argv.branch` and `options.extraRefs` as bare positionals,
+with `--` only added when `argv.path` is non-empty. The repo already knows the right pattern — it uses
+`--end-of-options` exactly once, in `src/operations/agent/context.ts:179`.
+**Evidence:**
+```ts
+} else if (argv.branch) {
+  args.push(argv.branch)
+}
+…
+if (options.extraRefs && options.extraRefs.length > 0) {
+  args.push(...options.extraRefs)
+}
+```
+**Impact:** `coco log --branch <value-starting-with-dash>` (or a stash hash list that ever contains a
+non-hash) makes git reinterpret the value as an option; and a branch name that collides with a file
+name produces git's ambiguity error instead of the intended log. Lower severity than the mutating
+paths because `git log` is read-only.
+**Suggested fix:** Insert `--end-of-options` before the first positional ref (git ≥ 2.24) and keep the
+existing `--` for pathspecs.
+**Confidence:** high
+
+---
+
+## LOW
+
+### [SEVERITY: low] fix(git): don't hijack process.stdout in the commit workflow
+**File:** src/git/commitWorkflowActions.ts:141-152
+**What's wrong:** `runCommitWorkflow` replaces the global `process.stdout.write` for the duration of
+the commit handler and treats everything captured as the commit message. Anything else that writes to
+stdout during that window (Ink frame renders, a logger that isn't silenced, another concurrent
+workflow) is swallowed into `output` and can end up in the commit message.
+**Evidence:**
+```ts
+process.stdout.write = ((chunk: string | Uint8Array, ...args: unknown[]) => {
+  output += typeof chunk === 'string' ? chunk : chunk.toString()
+  …
+}) as typeof process.stdout.write
+…
+if (action === 'commit' && message) { await createCommit(message, git, …) }
+```
+**Impact:** Latent rather than live: `runCommitWorkflow` is referenced only by
+`commitWorkflowActions.test.ts` — the TUI uses `runCommitDraftWorkflow`, which has no stdout capture.
+Wiring this function into any Ink surface would commit captured render output.
+**Suggested fix:** Have the commit handler return its text (as `generateCommitDraft` already does)
+instead of capturing global stdout; or delete the unused function.
+**Confidence:** high (the hazard and the fact that it is currently unreferenced in production are
+both verified)
+
+### [SEVERITY: low] fix(git): sanitize CI check names from forge payloads
+**File:** src/git/forgeText.ts:100-113
+**What's wrong:** `sanitizePullRequestDetail` strips control bytes from body, comments, and review
+author/body, but not from `statusCheckRollup[].name` / `.status` / `.conclusion`. Check names are
+attacker-influenced (they come from a workflow file in the PR's own branch on GitHub, or a build
+status POST on Bitbucket/Gitea).
+**Evidence:**
+```ts
+export function sanitizePullRequestDetail(detail: PullRequestDetail): PullRequestDetail {
+  return { ...detail, body: stripControlMultiline(detail.body),
+    comments: detail.comments.map(sanitizeComment),
+    reviews: detail.reviews.map((review) => ({ …clean(review.author), body: stripControlMultiline(review.body) })),
+  }
+}
+```
+(`statusCheckRollup` is spread through untouched; the same is true of
+`sanitizePullRequestInfo`, which also omits `statusCheckRollup` and `reviews`.)
+**Impact:** A check named with ANSI/OSC sequences can wipe scrollback, spoof a "✓ approved" row, or
+drive OSC 52 in the inspector — precisely the threat model the module's own docblock describes.
+**Suggested fix:** Map `statusCheckRollup` (and `PullRequestInfo.reviews`) through `stripControl`.
+**Confidence:** high
+
+### [SEVERITY: low] fix(git): bound conflict-marker file reads
+**File:** src/git/operationData.ts:131-150
+**What's wrong:** `getConflictMarkers` reads each conflicted file fully into memory with
+`readFileSync(filePath, 'utf8')` and splits it, only checking the 12-marker limit *between* files.
+**Evidence:**
+```ts
+markers.push(...parseConflictMarkers(file.path, readFileSync(filePath, 'utf8')))
+```
+**Impact:** A conflicted large binary-ish or generated file (lockfiles, minified bundles) is fully
+read and line-split on every operation-overview refresh.
+**Suggested fix:** Skip files above a size threshold (`statSync`), or stream line-by-line and stop at
+the marker limit.
+**Confidence:** high
+
+### [SEVERITY: low] fix(git): use `--flag=value` (and guards) in gh list arg builders
+**File:** src/git/pullRequestListData.ts:140-152; src/git/issuesListData.ts:117-127
+**What's wrong:** `forgeArgGuards.ts:2-9` documents the layer-wide invariant that *"Action builders
+pass values as `--flag=value` (so flag injection is already neutralized)"*. The two gh **list**
+builders use the space-separated form and apply none of the guards, and `parsePullRequestListItems` /
+`parseIssueListItems` call `JSON.parse` on gh's stdout with no try/catch — the throw is caught by
+`loadForgeList`, which surfaces the raw `Unexpected token …` string to the user.
+**Evidence:**
+```ts
+if (filter.state) args.push('--state', filter.state)
+if (filter.assignee) args.push('--assignee', filter.assignee)
+…
+const raw = JSON.parse(trimmed) as Array<Record<string, unknown>>
+```
+**Impact:** Mostly a consistency/robustness gap — Go's flag parser consumes the following token as the
+value even when it starts with `-`, so the injection risk is small; the user-visible defect is that any
+non-JSON stdout (a gh deprecation notice, a truncated stream) produces a JSON parser error instead of
+"GitHub CLI returned unexpected output".
+**Suggested fix:** Switch to `--flag=value` to match every other builder, and wrap the parse with a
+"unexpected gh output" message that includes the first line of stdout.
+**Confidence:** high
+
+### [SEVERITY: low] fix(git): verify Bitbucket reviewer PUT doesn't clobber PR fields
+**File:** src/git/bitbucketPullRequestActions.ts:181-190
+**What's wrong:** Adding a reviewer issues `PUT /repositories/{path}/pullrequests/{id}` with a body
+containing **only** `reviewers`. Bitbucket's PR update endpoint documents `title` as required and
+behaves as a merge-update; if any field is treated as absent-means-clear, the PR's title/description
+could be affected.
+**Evidence:**
+```ts
+return runBitbucketAction(runner, `repositories/${projectPath}/pullrequests/${pullRequestNumber}`,
+  'PUT', { reviewers: [...currentReviewers, { account_id: accountId }] }, …)
+```
+**Impact:** Potential silent mutation of PR title/description when assigning a reviewer.
+**Suggested fix:** Fetch the PR first (the function already does, for `reviewers`) and echo `title`
+(and `description`) back in the PUT body.
+**Confidence:** needs-verification — confirm against a live Bitbucket Cloud PR whether a
+`reviewers`-only PUT returns 400 or blanks `title`/`description`. The existing test
+(`bitbucketPullRequestActions.test.ts`) only asserts the request shape, so it would not catch either
+outcome.
+
+---
+
+## Areas I checked and found clean
+
+- **No shell anywhere in the git layer except by design.** `grep` for `shell: true`, `execSync`, and
+  string-concatenated commands across `src/git/**` returns nothing. All process launches are
+  `execFile`/`spawn` with array argv (`githubCli.ts:113`, `glabCli.ts:47`, `rebasePlanActions.ts:156`,
+  `statusHunks.ts:71`, `historyActions.ts:52,70`). The one deliberate shell is
+  `bisectActions.bisectRun` (`git bisect run sh -c <cmd>`), documented as the user's own test command.
+- **`rebasePlanActions` editor plumbing.** `GIT_SEQUENCE_EDITOR: cp '<todoFile>'` and the reword
+  `-F '<file>'` paths are single-quoted, the temp dir comes from `mkdtempSync`, and the env override is
+  scoped to the spawned process rather than mutating the shared SimpleGit instance. Mid-run stops are
+  detected from repo state, not localized stderr text (`#1688`) — correct.
+- **Porcelain/NUL parsing.** `statusData.parsePorcelainStatus`, `operationData.parseConflictedFiles`,
+  and `logData.parseNumstat`/`parseNameStatus` all use `-z` and correctly consume the extra origin-path
+  token for `R`/`C` records, so `core.quotePath` and paths with spaces/quotes/newlines round-trip.
+  `expandCollapsedRename` covers the brace form (`#1707`).
+- **Diff-header path extraction** (`stashData.resolveDiffGitHeaderPath` + `unescapeGitQuoted`): the
+  quoted/unquoted-per-side handling, the octal-escape single-pass decoder, and the length-halving
+  fallback are all correct, including the `a\\tb` case the comment calls out.
+- **Conflict-marker parsing** (`conflictRegionActions`): exactly-seven-character marker regexes
+  (`#1395`) prevent setext underlines from flipping sections; diff3 base handling, unterminated-region
+  bail-out, content-identity matching before write, path containment check against the worktree root,
+  and atomic tmp+rename write are all sound.
+- **Ours/theirs inversion during rebase** (`operationActions.resolveConflictKeepCurrentBranch`) is
+  handled correctly — this is the single most commonly-wrong thing in a git TUI.
+- **Empty-repo / unborn-HEAD handling**: `logData.getLogRows` retries through `isEmptyRepo` rather
+  than matching localized git strings (`#1708`); `workspaceData.getRepoSummary` and
+  `providerData.detectLocalDefaultBranch` both degrade cleanly with no commits.
+- **Detached HEAD**: `workspaceData` falls back to `rev-parse --short HEAD`;
+  `forgeLoad.loadForgeOverview` short-circuits with "No current branch." for GitLab/Bitbucket/Gitea;
+  Bitbucket/Gitea current-branch mutations return "No current branch (detached HEAD?)".
+- **Divergence math**: both `parseDivergence` implementations (`branchData.ts:78`,
+  `workspaceData.ts:284`) map `rev-list --left-right --count <upstream>...<branch>` to
+  behind/ahead in the right order.
+- **Timeouts / buffers / cancellation on the gh and glab runners**: `GH_DEFAULT_TIMEOUT_MS`,
+  `GH_MAX_BUFFER_BYTES` (16 MB, deliberately above execFile's 1 MB default), and optional
+  `AbortSignal` are wired in both (`githubCli.ts:113`, `glabCli.ts:47`); the REST runners use
+  `AbortSignal.timeout`. `workspacePullRequestData.runGhWithTimeout` correctly aborts and clears its
+  timer.
+- **Secret handling**: no token is ever interpolated into a URL or an error message. Bitbucket/Gitea
+  credentials go into an `Authorization` header only (`bitbucketCli.ts:47-58`, `giteaCli.ts:44-47`);
+  `compactCliError` strips the echoed `Command failed:` argv line, which is what would otherwise leak
+  a `--body` payload into a notification.
+- **`cloneRepo.validateCloneUrl`** correctly rejects leading-dash remotes, `ext::`/`file::` transport
+  helpers, and non-allowlisted schemes — the strongest guard in the layer.
+- **`glab` verb/flag contract**: `glabCompat.test.ts` live-checks `mr create/merge/note create/update`
+  and `issue note/update` flags against the installed binary. I verified against the
+  [glab `issue note` docs](https://docs.gitlab.com/cli/issue/note/) and the
+  [MR that introduced `mr note create`](https://gitlab.com/gitlab-org/cli/-/merge_requests/3099/reports)
+  that coco's asymmetric use of `mr note create` vs `issue note` is currently correct, not a bug.
+  (Content was rephrased for compliance with licensing restrictions.)
+- **GitLab `iid` vs `id`**: every GitLab mapping uses `iid` (`gitlabListData.ts:174,247,313`), and the
+  Gitea mappings use `number` while Bitbucket uses `id` — all correct for their APIs.
+- **GHE host awareness on the main GitHub paths**: `getGitHubRepositoryForGit`,
+  `getGhStatus(runner, repository.host)`, and the `gh repo view <webUrl>` full-URL form
+  (`providerData.ts:263-275`) are all correct; the only remaining github.com-only path is the
+  workspace PR-count fetcher reported above.
+- **`simple-git` `revparse` trimming**: verified in `node_modules/simple-git/dist/cjs/index.js:4644`
+  that `revparse` uses `straightThroughStringTask(commands, true)` (trimmed), so the untrimmed-looking
+  `statusHunks.applyPatch` `cwd` is not a bug.
+- **`statusHunks` line-staging math** (`sliceHunkLines`) — the stage vs discard neutralization rules
+  and the recount of `oldLines`/`newLines` match `git add -p`'s edit semantics; the EPIPE listener on
+  `child.stdin` (`#1639`) is correctly placed.
+- **Batch-order hazards**: `dropStashes` sorts descending by `stash@{N}` (renumbering-safe) and
+  `deleteBranches` continues past per-item refusals while preserving git's raw wording for the
+  force-delete escalation match.

--- a/docs/audit-0.84.1/bugs-lib.md
+++ b/docs/audit-0.84.1/bugs-lib.md
@@ -1,0 +1,428 @@
+# Bug audit — `src/lib/**` (coco v0.84.1)
+
+Read-only audit. No code changed. Every claim below is quoted from the file at the cited
+line, and the four findings marked **(verified empirically)** were confirmed by executing
+the real exported functions via `npx tsx` (probe files deleted; `git status` left clean).
+
+None of these are caught by the existing gate: `npx tsc --noEmit` is clean, `npx eslint src
+bin e2e` reports 42 problems that are *all* `react-hooks/exhaustive-deps`, and the full
+suite passes (391 suites / 5596 tests / 68 snapshots, `TZ=UTC`).
+
+---
+
+## HIGH
+
+### [SEVERITY: high] fix(config): `--ignoredFiles` / `--ignoredExtensions` wipe the default ignore list, exposing `.env` to the prompt
+
+**File:** `src/lib/config/utils/loadConfig.ts` (the trailing `return { ...config, ...argv }`)
+
+**What's wrong:** `loadConfig` builds the ignore list by unioning defaults + `.gitignore`
+through `mergeIgnoreLists(config)`, and *then* spreads `argv` over the result. Because the
+spread is a plain shallow overwrite, an `ignoredFiles` value arriving from the CLI
+**replaces** the merged list instead of extending it — bypassing the very helper that
+exists to prevent this. `mergeIgnoreLists` is called one statement too early.
+
+**Evidence:** the merge runs before the spread, so the spread wins:
+
+```ts
+config = mergeIgnoreLists(config)
+_lastConfigSources = sources
+return { ...config, ...argv } as Config & ConfigType & ArgvType
+```
+
+**(verified empirically)** — same `loadConfig`, with and without the flag:
+
+```
+no flag  -> ignoredFiles: 39 entries, including
+            "package-lock.json","yarn.lock","node_modules","dist/**/*",
+            ".env",".env.local",".env.production.local","coverage/", …
+with flag-> ignoredFiles: ["secret.ts"]                    <-- everything else gone
+if merged-> ["package-lock.json","yarn.lock","pnpm-lock.yaml","bun.lockb",
+             "bun.lock","node_modules","secret.ts"]        <-- what it should be
+```
+
+**Impact:** this is a secret-exposure vector, not just a token-waste bug. `.env`,
+`.env.local`, and `.env.production.local` are in the default/gitignore-derived list, so
+`coco commit --ignoredFiles secret.ts` (a user narrowing the ignore list, reasonably
+expecting to *add* an entry) silently re-admits every dotenv file, lockfile, and
+`node_modules` path to the diff that gets sent to the model. Reproduce: stage a `.env`
+alongside a source file and run `coco commit --ignoredFiles secret.ts --print-message`.
+
+Note this is the exact class of bug `mergeIgnoreLists` was introduced to fix at the
+config-file layer; the argv layer never got the same treatment.
+
+**Suggested fix:** move the argv spread *above* `mergeIgnoreLists`, so CLI-supplied lists
+go through the same union as every other source. Also route argv through the existing
+`removeUndefined` helper (see next finding) and strip yargs' `_` / `$0`.
+
+**Confidence:** high
+
+---
+
+## MEDIUM
+
+### [SEVERITY: medium] fix(config): the argv spread can clobber real config with `undefined` and shallow-replaces nested objects
+
+**File:** `src/lib/config/utils/loadConfig.ts` (same trailing spread)
+
+**What's wrong:** three separate robustness gaps in one expression. (a) The env and
+git-config loaders both sanitize themselves (`removeUndefined(envConfig)` at
+`services/env.ts:122`, `removeUndefined(config)` at `services/git.ts:147`) — argv does not,
+so any `undefined`-valued argv key overwrites a resolved value with `undefined`. (b) The
+spread is shallow, so an argv-supplied `service` replaces the whole merged service object;
+`services/env.ts` has an explicit deep-merge for `service` precisely because of this. (c)
+yargs' `_` and `$0` land in the returned `Config`, so `resolveConfigKeySource` and
+`coco config list` see keys that aren't config.
+
+**Evidence (verified empirically)** — calling the real `loadConfig`:
+
+```
+loadConfig({ verbose: undefined, defaultBranch: undefined, _: ['commit'], $0: 'coco' })
+  verbose:       undefined   (DEFAULT_CONFIG.verbose is false)
+  defaultBranch: undefined   (DEFAULT_CONFIG.defaultBranch is "main")
+  has '_': true   has '$0': true
+
+loadConfig({ service: { provider: 'anthropic' } })
+  service -> {"provider":"anthropic"}   (model, authentication, endpoint all dropped)
+```
+
+**Impact:** currently **latent rather than live** — I confirmed yargs does not emit keys
+for declared-but-unset options (parsing the real `commit` builder yields 19 keys, none
+`undefined`). So this is a landmine, not an active defect: the first command that adds a
+`coerce`, a conditional default, or hand-builds an argv object gets a silent
+`defaultBranch: undefined`. `src/commands/defaultRouter.ts` already hand-builds synthetic
+argv objects, which is exactly the shape that trips this.
+
+**Suggested fix:** `return { ...config, ...removeUndefined(argv as Record<string, unknown>) }`
+with `_`/`$0` omitted, and deep-merge `service` the way `env.ts` does.
+
+**Confidence:** high (behavior verified; live impact explicitly scoped to latent)
+
+### [SEVERITY: medium] perf(cache): the diff-summary cache rewrites the entire cache file on every write *and* every hit
+
+**File:** `src/lib/parsers/default/utils/diffSummaryCache.ts:119` (`writeDiffSummary`), `:153` (`touchDiffSummary`)
+
+**What's wrong:** both functions do a full synchronous read-modify-write of one shared JSON
+file: `readEnvelope()` → mutate → `fs.writeFileSync()`. `touchDiffSummary` exists *only* to
+update an LRU timestamp, and its own docblock says it runs "when a read returned a hit" —
+so a fully-cached run pays a complete parse-and-rewrite of the cache per cache hit.
+
+**Impact:** three compounding costs on the hot path of every AI command.
+
+1. **Write amplification.** With the cache at its 500-entry cap, each of N summarized files
+   triggers a parse + stringify + write of the whole file — O(N × cache_size) synchronous
+   I/O where O(N) was intended.
+2. **Event-loop blocking.** These are `*Sync` calls issued from callbacks that resolve while
+   other LLM requests are in flight (`summarizeDiffs.ts:288` dispatches through a
+   concurrency-6 semaphore), so each one stalls every concurrent request.
+3. **Cross-process races.** Within one process the function is fully synchronous, so there
+   is no lost-update window — but two coco processes (a `coco ui` AI draft plus a CLI run,
+   or parallel CI jobs) genuinely interleave, and the write is not atomic. `readEnvelope`'s
+   try/catch means a torn file self-heals by discarding the *entire* cache.
+
+**Suggested fix:** hold the envelope in memory for the process lifetime, mutate it there,
+and flush once on exit (or debounced). Make `touchDiffSummary` memory-only. Use the
+existing `writeFileAtomic` (`src/lib/utils/atomicFileWrite.ts`) for the flush so a crash or
+a competing process cannot truncate the file.
+
+**Confidence:** high
+
+### [SEVERITY: medium] refactor(parsers): three hand-rolled copies of a concurrency semaphore, while the declared `p-queue` dependency is never imported
+
+**File:** `src/lib/parsers/default/utils/summarizeDiffs.ts:327`, `summarizeLargeFiles.ts:326`, `collectDiffs.ts:8`
+
+**What's wrong:** `createLimit` is duplicated three times (two of them byte-similar), and
+the shared implementation has an over-admission race: the `active >= limit` check is
+performed once and is **not** re-checked after the waiter is woken.
+
+**Evidence:**
+
+```ts
+const runNext = () => {
+  active--                                   // slot freed here …
+  const next = queue.shift()
+  if (next) next()                           // … waiter's `active++` runs a microtask later
+}
+
+return async <T>(operation: () => Promise<T>): Promise<T> => {
+  if (active >= limit) {
+    await new Promise<void>((resolve) => queue.push(resolve))
+  }
+  active++                                   // no re-check after waking
+  try { return await operation() } finally { runNext() }
+}
+```
+
+Between `active--` and the woken waiter's `active++`, `active` sits at `limit - 1`. A caller
+arriving in that window passes the check without queueing, so `active` reaches `limit + 1`.
+
+**Impact:** latent at all three current call sites, because each dispatches its whole batch
+up-front via `.map()` and no late arrivals exist. It becomes live the moment anything
+submits work incrementally (a watch mode, an interactive re-summarize) — and it would
+present as "concurrency limit is ignored", i.e. more parallel LLM calls than the user
+configured, which costs money.
+
+Separately: **`p-queue@5.0.0` is a production dependency with zero references** anywhere in
+`src`, `bin`, or `e2e` — a battle-tested semaphore is already being shipped to users and
+paid for, while three hand-rolled ones are used instead. `.github/dependabot.yml:9` even
+carries an explicit ignore entry for it, so the pin has been maintained while the code
+rotted.
+
+**Suggested fix:** delete all three `createLimit`s, use `p-queue`, and keep one shared
+wrapper in `src/lib/utils/` (next to the existing `mapWithConcurrency`). If the hand-rolled
+version is kept instead, re-check `active` in a `while` loop rather than an `if`, and drop
+`p-queue` from `dependencies`.
+
+**Confidence:** high
+
+### [SEVERITY: medium] chore(deps): `@langchain/community` is a 22 MB production dependency that is never imported
+
+**File:** `package.json:146`
+
+**What's wrong:** `"@langchain/community": "^1.1.29"` sits in `dependencies`, but a repo-wide
+search for `@langchain/community` across `src`, `bin`, `e2e`, `rollup.config.mjs`, and
+`jest.config.ts` returns **only the `package.json` line itself** — no static import, no
+`await import()`, no rollup reference. Nothing else in `node_modules` depends on it either.
+
+I checked the other four candidates my scan flagged and they are all legitimate, so this is
+the only real one:
+
+| Package | Verdict |
+| --- | --- |
+| `@commitlint/core` | **used** — `await import('@commitlint/core')` at `commitlintValidator.ts:106,287,311` |
+| `web-tree-sitter` | **used** — lazy loader in `parsers/default/__tree_sitter__/runtime.ts` |
+| `react-devtools-core` | **legitimate** — declared peer dep of `ink@7` (`>=6.1.2`) |
+| `p-queue` | unused (see previous finding) |
+| `@langchain/community` | **unused** |
+
+**Impact:** 22 MB of install weight on every `npm i -g git-coco`, plus its transitive
+surface in every `npm audit` and Dependabot run, for zero functionality. It also implies a
+capability coco doesn't have — a reader scanning `dependencies` reasonably concludes the
+community provider set is available.
+
+**Suggested fix:** remove both `@langchain/community` and `p-queue` from `dependencies`
+(the latter only after the semaphore consolidation above), and add a CI check — a
+`depcheck`/`knip` step, or extend `bin/smokeCli.ts` — so an unreferenced production
+dependency fails the build.
+
+**Confidence:** high
+
+### [SEVERITY: medium] fix(langchain): the prompt-budget accept threshold and trim target disagree by `responseTokenReserve`
+
+**File:** `src/lib/langchain/utils/enforcePromptBudget.ts` (fast-path return vs. `tokenBudget`)
+
+**What's wrong:** the early-return accepts any prompt at or under `maxTokens`, ignoring the
+response reserve entirely. But once trimming engages, the target becomes
+`maxTokens - responseTokenReserve`. The reserve therefore either matters or it doesn't,
+depending on which side of the threshold you land on.
+
+**Evidence:**
+
+```ts
+if (promptTokenCount <= maxTokens) {
+  return { variables, promptTokenCount, truncated: false }   // reserve ignored
+}
+…
+const tokenBudget = maxTokens - responseTokenReserve          // reserve enforced
+```
+
+**Impact:** a discontinuous cliff at the boundary. A prompt at exactly `maxTokens` ships
+untouched with no room reserved for the completion; a prompt one token larger is trimmed
+all the way down to `maxTokens - 512`. So the case most likely to be truncated by the
+*provider* (a prompt that exactly fills the window) is the one case coco waves through,
+while a marginally larger prompt loses 512 tokens of real diff content it didn't need to.
+
+**Suggested fix:** pick one semantic. Either `maxTokens` is the prompt budget (drop the
+reserve from `tokenBudget`) or it is the request budget (compare the fast path against
+`maxTokens - responseTokenReserve` too). Document which in the docblock, since
+`DEFAULT_RESPONSE_TOKEN_RESERVE` is exported for callers to pre-budget with.
+
+**Confidence:** high
+
+### [SEVERITY: medium] perf(langchain): the block-drop comparator re-tokenizes every block on each comparison
+
+**File:** `src/lib/langchain/utils/enforcePromptBudget.ts` (`trimSummaryByBlocks`)
+
+**What's wrong:** the sort comparator calls the tokenizer twice per invocation instead of
+precomputing each block's size once.
+
+**Evidence:**
+
+```ts
+const dropQueue = [...blocks].sort((a, b) => tokenizer(b.text) - tokenizer(a.text))
+```
+
+**Impact:** `Array.prototype.sort` invokes the comparator O(n log n) times, so for 50
+directory blocks that's roughly 600 full tiktoken encodes of substantial text — all
+redundant, all on the main thread, and all inside the path that only runs when the prompt is
+*already* oversized (i.e. when the blocks are at their largest). This is on top of the
+~17 full-prompt renders-and-encodes the subsequent binary search performs.
+
+**Suggested fix:** `const sized = blocks.map((b) => ({ ...b, tokens: tokenizer(b.text) }))`
+once, then sort on `tokens`. Pure win, no behavior change.
+
+**Confidence:** high
+
+### [SEVERITY: medium] fix(cli): `getRepo` writes its failure to stdout, corrupting every `--json` consumer
+
+**File:** `src/lib/simple-git/getRepo.ts:20`
+
+**What's wrong:** the failure path uses `console.log` (stdout) rather than the logger or
+stderr, and discards `baseDir` — the one piece of actionable context the caller supplied.
+
+**Evidence:**
+
+```ts
+try {
+  git = baseDir ? simpleGit(baseDir) : simpleGit()
+} catch (e) {
+  console.log('Error initializing git repo', e)
+  commandExit(1)
+}
+```
+
+**Impact:** `getRepo` is upstream of essentially every command, so on failure a non-JSON
+line is emitted **on stdout** before the process exits — breaking `coco commit --json`,
+`coco review --json`, `coco prs --json`, and the agent CLI for any machine consumer doing
+`JSON.parse(stdout)`. It also defeats `--quiet`, which the logger would honor. Reproduce:
+`coco commit --json --repo /path/that/is/not/a/repo`.
+
+**Suggested fix:** `logger.error(\`Error initializing git repo${baseDir ? \` at ${baseDir}\` : ''}: ${message}\`)`,
+or at minimum `process.stderr.write`. The same audit turned up `console.log` in
+`src/lib/ui/TaskList.ts` (many sites) — acceptable there since it is an interactive-only
+surface, but worth a lint rule banning bare `console.log` under `src/lib/**` outside `ui/`.
+
+**Confidence:** high
+
+---
+
+## LOW
+
+### [SEVERITY: low] fix(langchain): `trimSummaryByBlocks` can return an over-budget prompt without throwing
+
+**File:** `src/lib/langchain/utils/enforcePromptBudget.ts` (`trimSummaryByBlocks`, the final binary search)
+
+**What's wrong:** the search seeds `bestSummary` with separator + omitted-marker and
+accepts its token count unconditionally — it is never compared against `tokenBudget`. Every
+other exhaustion path in this module throws a clear error; this one returns silently.
+
+**Evidence:**
+
+```ts
+let bestSummary = `${DIRECTORY_BLOCK_SEPARATOR}${marker}`
+let bestTokenCount = await render(bestSummary)   // never checked against tokenBudget
+```
+
+Compare the sibling path, which does the right thing:
+
+```ts
+if (emptySummaryTokenCount > maxTokens) {
+  throw new Error(`Rendered prompt exceeds token budget before adding ${summaryKey}: …`)
+}
+```
+
+**Impact:** narrow but real. Reaching `trimSummaryByBlocks` requires
+`overhead < maxTokens - reserve`, so the overflow needs the omitted-files marker to push it
+back over — an edge case, but when it happens coco reports `truncated: true` and sends an
+over-budget request, so the user sees the provider's `context_length_exceeded` instead of
+coco's own actionable message.
+
+**Suggested fix:** after the search, throw the same style of error when
+`bestTokenCount > tokenBudget`.
+
+**Confidence:** high
+
+### [SEVERITY: low] fix(langchain): the "N files omitted" count undercounts dropped directories
+
+**File:** `src/lib/langchain/utils/enforcePromptBudget.ts` (`countFileBullets`)
+
+**What's wrong:** `omittedFileCount` only counts lines starting with `FILE_BULLET_PREFIX`,
+so a dropped block's directory header — and any non-bullet content in it — is invisible.
+
+**Evidence:**
+
+```ts
+function countFileBullets(blockText: string): number {
+  return blockText.split('\n').filter((line) => line.startsWith(FILE_BULLET_PREFIX)).length
+}
+```
+
+**Impact:** the marker the model sees (`[N files omitted for length]`) understates what was
+dropped, so the model's own hedging about incompleteness is calibrated to the wrong number.
+Cosmetic-adjacent, but it is the only signal the model gets that the diff is partial.
+
+**Suggested fix:** count directory blocks as well, or reword the marker to
+`[N files across M directories omitted for length]`.
+
+**Confidence:** high
+
+### [SEVERITY: low] fix(parsers): summarization failures are swallowed to `console.error`, bypassing the logger and `--quiet`
+
+**File:** `src/lib/parsers/default/utils/summarizeLargeFiles.ts:302`, `summarizeDiffs.ts:133`
+
+**What's wrong:** both catch blocks return the original (unsummarized) diff and report via
+bare `console.error`, so the failure never reaches the logger, never respects `--quiet`, and
+never surfaces as a warning the caller can attach to the result.
+
+**Evidence:**
+
+```ts
+} catch (error) {
+  // On error, return original diff unchanged
+  console.error(`Failed to summarize file ${fileDiff.file}:`, error)
+  return fileDiff
+}
+```
+
+**Impact:** silent degradation with a real consequence — returning the *unsummarized* diff
+is precisely what blows the token budget the summarizer exists to protect, so a run that
+silently loses every summarization ends up trimming real content in
+`enforcePromptBudget` instead. The `logger` is already threaded into both functions'
+options, so the correct channel is in hand.
+
+**Suggested fix:** use the injected `logger.verbose`/`logger.warn`, and count failures so
+the caller can report "summarization degraded for N files".
+
+**Confidence:** high
+
+---
+
+## Areas I checked and found clean
+
+- **tiktoken encoder lifecycle** (`src/lib/utils/tokenizer.ts`) — `tikTokenCache` correctly
+  prevents the WASM-heap leak the docblock describes (`#1641`); handles are intentionally
+  never `free()`d because the cache is bounded by the handful of distinct model names a
+  process uses. The `encoding_for_model` → `fallbackEncodingForModel` fallback correctly
+  avoids crashing on Azure custom deployment names and post-pin OpenAI ids, and the
+  `o200k_base`-by-default / `cl100k_base`-for-legacy split is the right approximation.
+- **`tokenCorrectionFactor` application** — applied in exactly one place
+  (`getTokenCounterForProvider`) and correctly skipped for the two tiktoken-native providers,
+  so the two budget paths cannot diverge. Both the scalar and the per-model-function forms
+  are handled, with a `?? 1` fallback.
+- **Surrogate-pair safety in truncation** — `stripTrailingHighSurrogate` is applied at both
+  char-slice sites, so a budget slice can never emit a lone high surrogate (the failure mode
+  strict providers reject).
+- **`summaryBudget === 0` exhaustion path** — correctly re-renders with an empty summary and
+  throws a precise, actionable error rather than shipping an over-budget request.
+- **Config precedence order** — the load sequence (defaults → XDG → git → project → env)
+  produces the documented precedence, since each later source overwrites earlier ones. The
+  env loader's `SERVICE_SCALAR_ENV_KEYS` ordering puts `COCO_SERVICE_PROVIDER` ahead of the
+  keys whose interpretation depends on it, and `PROVIDER_API_KEY_ENV_VARS` resolution
+  correctly keys off the *effective* provider, so a config-file provider plus an env-var key
+  for a different provider does not cross-wire.
+- **`COCO_SERVICE_BASE_URL` provider gating** — gating it on the `openai` provider is
+  correct, not a bug: `LLMProvider` has no separate `openai-compatible` member, and
+  OpenAI-compatible endpoints are reached via `openai` + `baseURL` by design.
+- **Secret redaction in `coco config`** — `SENSITIVE_SEGMENTS` + `maskSecrets` are applied on
+  every read path (`get`, `list`, and both `emitJson` branches), so keys are masked in JSON
+  output too. `doctor/checks.ts` reads `authentication.credentials?.apiKey` only to test for
+  presence and never prints the value.
+- **Exit-code flushing** — `commandExit` throws a `CommandExitError` that
+  `commandExecutor` converts to `process.exitCode` rather than calling `process.exit()`, so
+  stdout is always flushed before exit; prompt cancellation maps to the conventional 130.
+- **`writeFileAtomic`** (`src/lib/utils/atomicFileWrite.ts`) — correct tmp+rename with a
+  `0o600` default. (The finding that config writers don't *use* it belongs to the commands
+  audit, not here.)
+- **Corrupted-cache self-healing** — `readEnvelope`'s try/catch means a torn or truncated
+  cache file is discarded rather than crashing the CLI; the LRU `enforceHardCap` runs after
+  insertion, so the cap is respected.

--- a/docs/audit-0.84.1/bugs-workstation.md
+++ b/docs/audit-0.84.1/bugs-workstation.md
@@ -1,0 +1,767 @@
+# `coco ui` workstation runtime — bug audit (v0.84.1)
+
+Scope: `src/workstation/**` (runtime, hooks, chrome, surfaces). No code was changed.
+Every claim below was verified against the code at the cited line; three of them were
+additionally reproduced numerically by executing the real exported functions.
+
+Already-filed items (rail history divisor / line-aware budgeting, rail ref-metadata
+wrapping, `getLogInkInputEvents` router extraction, custom commands / edit-hunk /
+patch building, AI pre-commit review, AI rebase plan, explain-commit, triage copilot)
+are excluded.
+
+---
+
+## CRITICAL
+
+### [SEVERITY: critical] fix(workstation): pane widths can exceed terminal columns when the help overlay opens on a focused sidebar
+**File:** `src/workstation/chrome/layout.ts:236-268` (call site `src/workstation/runtime/app.ts:1201-1206`)
+
+**What's wrong:** `detailWidth`, `sidebarWidth` and `mainPanelWidth` are each computed with an
+independent floor, and only `mainPanelWidth` is derived by subtraction — but it is then clamped
+up with `Math.max(20, …)`. When the help overlay forces `detailWidth >= 60` and the sidebar is
+focused (`>= 32`), the subtraction goes negative, the `Math.max(20, …)` floor kicks in, and the
+three widths sum to more than `columns`. The module's own docstring promises "the three panels
+always tile flush".
+
+**Evidence:**
+```ts
+const detailWidth = input.helpOverlayActive
+  ? Math.max(60, Math.min(100, Math.floor(columns * 0.50)))
+  : /* … */
+const sidebarWidth = input.sidebarFocused
+  ? Math.max(32, Math.min(50, Math.floor(columns * 0.36)))
+  : calcSidebarAtRestWidth(columns, density)
+mainPanelWidth: Math.max(20, columns - sidebarWidth - detailWidth),
+```
+Reproduced by calling `getLogInkLayout` directly:
+```
+cols=100 help+sidebar: side=36 main=20 detail=60 SUM=116 OVERFLOW=16
+cols=110 help+sidebar: side=39 main=20 detail=60 SUM=119 OVERFLOW=9
+cols=119 help+sidebar: side=42 main=20 detail=60 SUM=122 OVERFLOW=3
+cols=130 help+sidebar: side=46 main=20 detail=65 SUM=131 OVERFLOW=1
+cols=100 help only   : side=24 main=20 detail=60 SUM=104 OVERFLOW=4
+```
+`app.ts` feeds both flags from live state, so the combination is reachable:
+```ts
+sidebarFocused: state.focus === 'sidebar',
+inspectorFocused: state.focus === 'detail',
+helpOverlayActive: state.showHelp,
+```
+
+**Impact:** In a terminal 100–130 columns wide (a very common laptop/tmux-split size), pressing
+`Tab` to focus the sidebar and then `?` makes the horizontal flex row wider than the terminal.
+Ink wraps or clips the row: the inspector/help panel drops onto a second visual row, the borders
+break, and the footer is pushed off-screen. Repro: `stty cols 100`, `coco ui`, `Tab` until focus
+is on the sidebar, `?`.
+
+**Suggested fix:** Compute the three widths as one allocation pass: budget `detailWidth` and
+`sidebarWidth` against `columns` (shrink the *lower-priority* pane instead of floor-clamping the
+main panel), then set `mainPanelWidth = columns - sidebarWidth - detailWidth` with no `Math.max`,
+and assert `sum === columns` in `layout.test.ts` across the 80..240 column sweep and every
+focus/overlay combination.
+
+**Confidence:** high
+
+---
+
+## HIGH
+
+### [SEVERITY: high] fix(workstation): filesystem watcher is torn down and rebuilt after every worktree refresh
+**File:** `src/workstation/runtime/hooks/useContextRefresh.ts:267`, consumed at `src/workstation/runtime/hooks/useRefreshWatcher.ts:153`
+
+**What's wrong:** `refreshWorktreeContext` is a `useCallback` whose dep list contains
+`currentWorktree` — which `app.ts` passes as `context.worktree` (`app.ts:468`). Every worktree
+refresh writes a brand-new `getWorktreeOverview()` object into context, so `refreshWorktreeContext`
+gets a new identity, so `useRefreshWatcher`'s effect (which lists it as a dep) re-runs: it closes
+all five `fs.watch` handles, re-runs two `git rev-parse` subprocesses, and re-registers the
+watches — including the *recursive* watch on `.git/refs/heads`. Because the watcher's own
+`onChange` is what calls `refreshWorktreeContext`, the loop is self-reinforcing.
+
+**Evidence:**
+```ts
+// useContextRefresh.ts
+    setWorktreeDiffRefreshToken((token) => token + 1)
+    return worktree
+  }, [git, runtimesLength, currentWorktree, setContext, setContextStatus, setWorktreeDiffRefreshToken])
+```
+```ts
+// useRefreshWatcher.ts — the effect re-subscribes on any dep identity change
+  }, [git, refreshContext, refreshWorktreeContext, refreshHistoryRows])
+```
+The hook's own docstring even flags the hazard it then reintroduces: *"A leaked watcher is a real
+regression, so the teardown return is preserved exactly."*
+
+**Impact:** Any editor save inside the repo causes: 750 ms debounce → worktree refresh → watcher
+teardown/rebuild (2 child processes + 5 `fs.watch` registrations). On a large repo the recursive
+re-watch is measurably expensive, and any filesystem event that lands in the gap between
+`watcher.close()` and the new `createRefreshWatcher()` is silently lost — which is the reported
+"the TUI stopped auto-refreshing" symptom. Repro: `coco ui`, then in another terminal
+`while true; do touch README.md; sleep 1; done` and watch the process's open-FD count and
+`git rev-parse` invocations churn.
+
+**Suggested fix:** Drop `currentWorktree` from the `refreshWorktreeContext` dep array and read the
+previous overview through a ref (`currentWorktreeRef.current`) inside the callback — the value is
+only used for the `#1617` stale-beats-blank return. That makes the callback stable and the watcher
+mount-once-per-`git`.
+
+**Confidence:** high
+
+---
+
+### [SEVERITY: high] fix(workstation): in-flight AI AbortControllers are never aborted on unmount, so `q` leaves the process hanging
+**File:** `src/workstation/runtime/hooks/useAiCommitDraftActions.ts:89`, `useChangelogActions.ts:123`, `useCommitSplitActions.ts:126`, `useConflictResolutionActions.ts:65`
+
+**What's wrong:** All four hooks own an `AbortController` in a ref and abort it only from an
+explicit `Esc` handler or from a superseding invocation. None of them registers an unmount
+cleanup. `grep -n "useEffect" ` across the four files returns no effect at all — the controllers
+have no lifecycle tie to the component.
+
+**Evidence:**
+```ts
+const aiDraftAbortRef  = React.useRef<AbortController | null>(null)   // useAiCommitDraftActions.ts:89
+const changelogAbortRef = React.useRef<AbortController | null>(null)  // useChangelogActions.ts:123
+const planAbortRef     = React.useRef<AbortController | null>(null)   // useCommitSplitActions.ts:126
+const abortRef         = React.useRef<AbortController | null>(null)   // useConflictResolutionActions.ts:65
+```
+
+**Impact:** Press `I` (AI commit draft), `L` (changelog), `S` (split plan) or the AI
+conflict-resolution key, then immediately `q`. Ink unmounts and `installTerminalLifecycle`
+restores the terminal, but the HTTP request to the LLM provider is still pending, so the Node
+event loop does not drain — the user's shell prompt does not come back until the provider
+responds (30–120 s on a slow model), with no UI and no way to interrupt other than a second
+`Ctrl-C`.
+
+**Suggested fix:** In each hook add
+`React.useEffect(() => () => { ref.current?.abort(); ref.current = null }, [])`. Keep the same
+ownership discipline the `finally` blocks already use.
+
+**Confidence:** high
+
+---
+
+### [SEVERITY: high] fix(workstation): Esc during a PR-body draft gives no feedback and leaves the spinner running
+**File:** `src/workstation/runtime/hooks/usePullRequestActions.ts:255-259`
+
+**What's wrong:** `cancelPullRequestBodyDraft` only mutates a boolean on a handle. It dispatches
+nothing — no status change, no clearing of `pendingPullRequestBodyDraft`, no abort. The status
+line set before the call carries `loading: true`, and `useStatusAutoDismiss` explicitly refuses
+to clear a loading line (`if (deps.statusKind === 'error' || deps.statusLoading) return false`).
+So the advertised affordance produces zero observable effect until the LLM resolves. Every sibling
+cancel (`cancelAiCommitDraft`, `cancelChangelog`, `cancelCommitSplit`) either aborts the controller
+or dispatches immediately.
+
+**Evidence:**
+```ts
+const cancelPullRequestBodyDraft = React.useCallback(() => {
+  const handle = pullRequestBodyCancelRef.current
+  if (!handle) return
+  handle.cancelled = true
+}, [])
+```
+The status it fails to clear:
+```ts
+value: `generating ${nouns.abbrev} body from changelog (vs ${defaultBranch}) — Esc to skip prompt`,
+loading: true,
+```
+
+**Impact:** Press `C` to create a PR, then `Esc`. The spinner keeps spinning and the status keeps
+saying "Esc to skip prompt" for the whole generation window; users press `Esc` repeatedly, then
+conclude the TUI is wedged. Repro: `C` on a feature branch with a slow model, `Esc`, observe the
+footer.
+
+**Suggested fix:** In `cancelPullRequestBodyDraft`, after setting `handle.cancelled = true`, also
+`dispatch({ type: 'setPendingPullRequestBodyDraft', value: false })` and
+`dispatch({ type: 'setStatus', value: \`${nouns.abbrev} draft cancelled.\` })`. Longer term thread
+an `AbortSignal` through `runPullRequestBodyWorkflow` so the cancel is hard like its siblings.
+
+**Confidence:** high
+
+---
+
+### [SEVERITY: high] fix(workstation): cellWidth mismeasures the exact status glyphs the UI renders
+**File:** `src/workstation/chrome/text.ts:10-26`
+
+**What's wrong:** `WIDE_CHARACTER_RANGES` treats the whole Miscellaneous-Symbols + Dingbats
+span `[0x2600, 0x27bf]` as double-width. That is wrong for every text-presentation glyph in
+that block, and coco renders several of them. Symmetrically, `U+23F3 ⏳` / `U+231B ⌛` are
+genuinely East-Asian-Wide but fall outside every range and measure as 1.
+
+**Evidence:**
+```ts
+  [0x2600, 0x27bf],
+  [0x2b1b, 0x2b1c],
+```
+Measured by calling the real `cellWidth`:
+```
+"✓" U+2713 => 2   (terminals render 1)   footer.ts:161, headerChips.ts:206, bisect/index.ts:119
+"✗" U+2717 => 2   (renders 1)            footer.ts:159, conflicts/index.ts:62
+"⚠" U+26A0 => 2   (renders 1)            footer.ts:160, headerChips.ts:226, overlays.ts:829
+"✚" U+271A => 2   (renders 1)            diff/index.ts:524
+"❯" U+276F => 2   (renders 1)            conflicts/index.ts:64, rebase/index.ts:83
+"⏳" U+23F3 => 1   (renders 2)            detail/index.ts:736, detail/index.ts:1001
+```
+`chrome/text.test.ts:35-50` covers `✨`, `🫡`, `⭐`, `⬛`, `⭕` — all genuinely wide — and never
+exercises the text-presentation dingbats, so the suite passes.
+
+**Impact:** Every truncation budget computed over a line that starts with a status glyph is off
+by one. Concretely: the `❯` selection cursor in the conflicts and rebase surfaces makes the
+*selected* row's content budget 1 cell shorter than the unselected rows, so the highlighted row
+truncates earlier than its neighbours (visible ragged edge that moves with the cursor). The
+`⏳ AI draft in progress` line in the inspector is 1 cell *wider* than measured and overflows its
+panel. Repro: `gx` on a conflicted repo and move the cursor down the region list at any width;
+the selected row's tail shifts.
+
+**Suggested fix:** Replace the hand-rolled range table with a lookup driven by Unicode
+`East_Asian_Width=W/F` plus `Emoji_Presentation=Yes` (or vendor `get-east-asian-width`). At
+minimum, narrow `[0x2600, 0x27bf]` to the emoji-presentation subranges and add
+`[0x231a, 0x231b]`, `[0x23e9, 0x23f3]`. Add the six glyphs above to `text.test.ts`.
+
+**Confidence:** high
+
+---
+
+### [SEVERITY: high] fix(workstation): seven surfaces still pad columns with padEnd instead of padCells, breaking CJK alignment
+**File:** `src/workstation/surfaces/blame/index.ts:97`, `fileHistory/index.ts:115`, `reflog/index.ts:78-80`, `submodules/index.ts:92-93`, `remotes/index.ts:68`, `issuesTriage/index.ts:136`, `pullRequestTriage/index.ts:224-225`
+
+**What's wrong:** `padCells` was added specifically because "`String.padEnd` counts UTF-16 code
+units, so padding a wide-glyph name … overshoots by one fill character per wide character"
+(`chrome/text.ts:139-146`). It was adopted in `branches`, `tags`, `worktrees`, `interactive` and
+`splitDiff`, but seven surfaces still compose `truncateCells(value, W).padEnd(W)` — measuring the
+value in cells and then padding in code units.
+
+**Evidence:**
+```ts
+// surfaces/blame/index.ts:97
+const author = truncateCells(line.author, AUTHOR_COL_CAP).padEnd(AUTHOR_COL_CAP)
+// surfaces/pullRequestTriage/index.ts:224-225
+const authorStr = truncateCells(pr.author || '', authorColWidth).padEnd(authorColWidth)
+const branchStr = truncateCells(pr.headRefName, branchColWidth).padEnd(branchColWidth)
+```
+Reproduced with `AUTHOR_COL_CAP = 18`:
+```
+"Alice Smith"  padEnd cells=18   padCells cells=18
+"山田太郎"      padEnd cells=22   padCells cells=18   ← 4 cells of overflow
+"张伟"          padEnd cells=20   padCells cells=18
+```
+
+**Impact:** On any repo with CJK author names, the blame gutter, file-history list, reflog table,
+and issue/PR triage tables lose column alignment — every row with a wide-glyph author shifts the
+following columns right by 1 cell per wide character, and rows overrun the panel width so the
+right border shows ragged. Repro: `coco ui` on a repo with a CJK-named committer, `gb` (blame) or
+`gP` (PR triage).
+
+**Suggested fix:** Replace each `truncateCells(x, W).padEnd(W)` with
+`padCells(truncateCells(x, W), W)` and add a lint rule (or a `text.test.ts`-adjacent grep test)
+banning `.padEnd(` in `src/workstation/surfaces/**`.
+
+**Confidence:** high
+
+---
+
+### [SEVERITY: high] fix(workstation): command palette and theme picker hardcode 14 list rows and never clamp the window start
+**File:** `src/workstation/runtime/overlays.ts:543-545` and `:628-630`
+
+**What's wrong:** Two problems in the same three lines. (a) `listRows` is a literal `14`, not
+derived from the panel's `bodyRows`, so the overlay can be taller than the pane it renders into.
+(b) `startIndex` has a lower clamp but no upper clamp, so once the cursor passes the middle of a
+list the window runs off the end and renders fewer than 14 rows. The shared helper that fixes
+exactly this — `clampListWindowStart` in `chrome/layout.ts:291`, added for #1340 — is used by the
+list surfaces but was never applied here.
+
+**Evidence:**
+```ts
+  const listRows = 14
+  const startIndex = Math.max(0, selectedIndex - Math.floor(listRows / 2))
+  const visible = filtered.slice(startIndex, startIndex + listRows)
+```
+versus the shared helper it should call:
+```ts
+export function clampListWindowStart(selected: number, count: number, listRows: number): number {
+  return Math.max(0, Math.min(Math.max(0, count - listRows), selected - Math.floor(listRows / 2)))
+}
+```
+
+**Impact:** (a) At the documented 80×24 floor the inspector body is
+`bodyRows = Math.max(8, 24 - 5) = 19` rows, while the palette renders up to
+title + input + hint + blank + recent-hint + more-above + 14 items + more-below = 21 rows inside a
+2-row border — 23 rows in a 19-row hole. The bottom of the palette and the app footer are pushed
+off-screen. (b) With a filter that matches ~20 commands, arrowing to the last entry gives
+`startIndex = 19 - 7 = 12`, `slice(12, 26)` → only 8 rows render even though 14 fit: the palette
+visibly shrinks as you scroll down and the "↓ N more below" hint disappears. Repro: `stty rows 24`,
+`coco ui`, `:` and hold `↓`.
+
+**Suggested fix:** Pass the panel's `bodyRows` into `renderCommandPaletteOverlay` /
+`renderThemePickerOverlay` and compute `listRows = Math.max(4, bodyRows - chromeRows)`; replace the
+`startIndex` expression with `clampListWindowStart(selectedIndex, filtered.length, listRows)`.
+
+**Confidence:** high
+
+---
+
+## MEDIUM
+
+### [SEVERITY: medium] fix(workstation): split-plan `r` retry is unreachable from the error state the overlay advertises it for
+**File:** `src/workstation/runtime/inkInput.ts:1671-1674` (advertised at `src/workstation/runtime/overlays.ts:907`)
+
+**What's wrong:** The overlay intercept only accepts `r` when `status === 'ready'`. In the error
+state the keystroke falls through to the block's catch-all `return []`, which consumes it silently.
+The overlay renders the opposite instruction.
+
+**Evidence:**
+```ts
+// inkInput.ts — "`r` retries from the error state (or regenerates from ready…)"
+if (inputValue === 'r' && state.splitPlan.status === 'ready') {
+  return [{ type: 'startCommitSplit' }]
+}
+```
+```ts
+// overlays.ts:907 — only rendered when overlay.error is set
+? [h(Text, { key: 'split-plan-error-hint', dimColor: true }, '   Press `r` to retry, `Esc` to cancel.')]
+```
+**The co-located test encodes the intent but not the behaviour** — `inkInput.test.ts:5570-5584`
+is titled *"r retries (re-runs the plan workflow) from the ready state"* and its comment says
+*"After an error, the overlay surfaces 'Press `r` to retry' — this keystroke should re-fire
+startCommitSplit"*, yet it only builds a `setSplitPlanReady` state. No test covers
+`setSplitPlanError` + `r`.
+
+**Impact:** When the split-plan LLM call fails, the overlay tells the user to press `r`; pressing
+it does nothing (the key is swallowed, so there is not even a "not wired" status). The only exit is
+`Esc` and re-running `S` from scratch. Repro: `S` with the provider unreachable, then `r`.
+
+**Suggested fix:** Change the guard to
+`state.splitPlan.status === 'ready' || state.splitPlan.status === 'error'` and add the missing
+`setSplitPlanError` case to `inkInput.test.ts`.
+
+**Confidence:** high
+
+---
+
+### [SEVERITY: medium] fix(workstation): failed issue/PR detail fetches are dropped with no message and no retry
+**File:** `src/workstation/runtime/hooks/useDetailHydration.ts:196` and `:243`
+
+**What's wrong:** Both debounced forge-detail loaders discard a failed result without writing
+anything to context and without surfacing the `message` the forge layer went to the trouble of
+producing. Because nothing is written, the effect's `context.*DetailByNumber` dep never changes, so
+there is no re-attempt either.
+
+**Evidence:**
+```ts
+const result = await forge.getIssueDetail(cursored.number)
+if (!active || !result.ok) return
+```
+Contrast the sibling list loaders, which were explicitly fixed for this in `#1633`
+(`useTriageListHydration.ts:31-52`): *"The old blanket `safe()` swallowed that into bare
+`undefined`, which reads through the render layer as 'still loading' forever — indistinguishable
+from a real empty queue."* The detail loaders never got the same treatment.
+
+**Impact:** With `gh` unauthenticated, rate-limited, or the issue deleted, the triage preview pane
+stays permanently blank with no explanation, and re-cursoring the row does not retry. Repro:
+`GH_TOKEN=bogus coco ui`, `gi`, cursor a row.
+
+**Suggested fix:** Store the failure in the cache as a renderable error shape (mirroring
+`triageListFailure`) so the preview pane can print the message, and/or dispatch a `setStatus` with
+`kind: 'warning'`.
+
+**Confidence:** high
+
+---
+
+### [SEVERITY: medium] fix(workstation): failed blame / file-history results are cached, permanently disabling retry
+**File:** `src/workstation/runtime/hooks/useDetailHydration.ts:285-300` and `:325-340`
+
+**What's wrong:** `getBlame` / `getFileHistory` return `{ ok: false, path, message }` on any git
+failure. The effects write the result into `blameByPath` / `fileHistoryByPath` unconditionally, and
+the cache-skip guard at the top of the effect (`if (context.blameByPath?.has(path)) return`) then
+treats the failure as a satisfied entry forever.
+
+**Evidence:**
+```ts
+const result = await getBlame(git, path)
+if (!active) return
+setContext(
+  (current) => ({
+    ...current,
+    blameByPath: new Map(current.blameByPath || []).set(result.path, result),
+  }),
+  issuedAtDepth,
+)
+```
+`git/blameData.ts:136-141` shows the failure shape being cached:
+```ts
+} catch (error) {
+  const message = error instanceof Error ? error.message : 'git blame failed'
+  return { ok: false, path, message }
+}
+```
+
+**Impact:** A transient `index.lock` contention (very likely, since the watcher fires blame
+re-hydration right after external git commands) poisons the cache for that path for the rest of the
+session. `useInputHandler` also reads `blameLineCount` as `blame.ok ? blame.lines.length : 0`, so
+`j`/`k` become permanently dead on that file. Only a worktree refresh (which clears
+`blameByPath`) recovers it. Repro: `gb` on a file while `git gc` holds the lock, then retry `gb`.
+
+**Suggested fix:** Only cache `result.ok === true`; on failure dispatch a warning status and leave
+the cache empty so a re-entry retries.
+
+**Confidence:** high
+
+---
+
+### [SEVERITY: medium] fix(workstation): the 5s just-landed-commit timer is never cleared on unmount, so `q` lingers
+**File:** `src/workstation/runtime/hooks/useCommitSplitActions.ts:413-418`
+
+**What's wrong:** `recentCommitsTimerRef` is correctly cancelled by the *next* apply (#1627), and
+the callback is `mountedRef`-guarded so it will not dispatch into a dead tree — but nothing clears
+it on unmount, so the pending `setTimeout` keeps the event loop alive.
+
+**Evidence:**
+```ts
+recentCommitsTimerRef.current = setTimeout(() => {
+  recentCommitsTimerRef.current = null
+  if (mountedRef.current) {
+    dispatch({ type: 'clearRecentCommits' })
+  }
+}, 5000)
+```
+There is no `React.useEffect` anywhere in the file (verified by grep), so no cleanup exists.
+
+**Impact:** Apply a split, then press `q` within 5 s: the terminal is restored but the process does
+not exit for the remainder of the 5 s window, so the shell prompt is delayed and the user sees a
+hung terminal. Repro: `S`, `y`, `q` immediately.
+
+**Suggested fix:** Add
+`React.useEffect(() => () => { if (recentCommitsTimerRef.current) clearTimeout(recentCommitsTimerRef.current) }, [])`.
+
+**Confidence:** high
+
+---
+
+### [SEVERITY: medium] fix(workstation): loadCommitContext can leave a permanent loading status when the append is fully deduplicated
+**File:** `src/workstation/runtime/hooks/useLoadMoreHistory.ts:399-418`
+
+**What's wrong:** `loadCommitContext` dispatches a `loading: true` status and then, on the success
+path, deliberately dispatches nothing — relying on the cursor-sync effect to re-fire and replace the
+status. But that re-fire is triggered by a `state.filteredCommits` identity change; `appendRows`
+deduplicates by hash, so an anchored fetch that returns only rows already in the window can leave
+`filteredCommits` unchanged, in which case nothing re-fires and nothing clears the status.
+
+**Evidence:**
+```ts
+dispatch({ type: 'setStatus', value: `Loading commits around ${target.label}…`, loading: true })
+…
+if (rows.length > 0) {
+  dispatch({ type: 'appendRows', rows })
+  // Don't dispatch a setStatus here — the cursor-sync effect
+  // will re-fire on the appendRows-driven filteredCommits change …
+}
+```
+`useStatusAutoDismiss` cannot rescue it (`if (deps.statusKind === 'error' || deps.statusLoading) return false`).
+
+**Impact:** Cursor a branch/tag/stash whose target is present in the loaded rows only under a
+short-hash form the resolver's `Set` lookup misses: the "Loading commits around X…" spinner sticks
+until the next status-producing keystroke.
+
+**Suggested fix:** Dispatch a terminal status on the append path as well (or clear
+`loading` explicitly) rather than relying on a downstream effect to fire. Repro requires an anchored
+fetch whose rows are all duplicates — **needs verification** that `appendRows` can return a
+reference-identical `filteredCommits`; check the `appendRows` reducer case in `inkViewModel.ts` for
+an early `return state` when no new hashes are added.
+
+**Confidence:** needs-verification
+
+---
+
+### [SEVERITY: medium] fix(workstation): any open choice prompt bypasses the central confirmation gate for every workflow
+**File:** `src/workstation/runtime/hooks/useInputHandler.ts:600-612`
+
+**What's wrong:** The `#1445` centralized confirmation gate treats "a choice prompt is open" as
+blanket consent for *any* workflow id, not just the one the choice offered.
+
+**Evidence:**
+```ts
+const alreadyConfirmed =
+  event.confirmed ||
+  state.pendingConfirmationId === event.id ||
+  Boolean(state.pendingChoice)
+if (workflow?.requiresConfirmation && !alreadyConfirmed) {
+  dispatch({ type: 'setPendingConfirmation', value: event.id, payload: event.payload })
+} else {
+  void runWorkflowAction(event.id, event.payload)
+}
+```
+
+**Impact:** If any keystroke path can emit a `runWorkflowAction` event while `state.pendingChoice`
+is set, a destructive workflow (`delete-branch`, `reset-to-commit`, `drop-stash`) runs with no
+y/n gate. The recovery prompts raised by `useWorkflowAction` (`worktree-checkout-conflict`,
+`diverged-pull-recovery`, `operation-conflict-recovery`, `fixup-autosquash-offer`) all leave
+`pendingChoice` set while the user reads them.
+
+**Suggested fix:** Narrow the third clause to
+`state.pendingChoice?.options.some((o) => o.workflowId === event.id)`.
+**Needs verification:** confirm whether the choice overlay in `overlayInput.ts` /
+`getLogInkInputEvents` claims *every* keystroke while `pendingChoice` is set. If it does, this is
+latent rather than live — but the gate should still be narrowed, because the comment claims
+per-choice consent that the code does not implement.
+
+**Confidence:** needs-verification
+
+---
+
+### [SEVERITY: medium] fix(workstation): `truncateCells` silently drops the ellipsis at narrow budgets
+**File:** `src/workstation/chrome/text.ts:159-160`
+
+**What's wrong:** The suffix is only attached when `width > cellWidth(ellipsis)` — a strict `>`.
+With the default unicode `…` (1 cell) a budget of exactly 1 yields no marker; with
+`theme.ascii` (`...`, 3 cells) any budget of 1–3 yields no marker. The function then returns a
+truncated string that is visually indistinguishable from a complete one.
+
+**Evidence:**
+```ts
+const ellipsis = options.ascii ? '...' : '…'
+const suffix = width > cellWidth(ellipsis) ? ellipsis : ''
+const available = width - cellWidth(suffix)
+```
+
+**Impact:** In ASCII/no-color mode at the 80-column floor, narrow columns (the reflog `hashColWidth`,
+the triage `numberColWidth`, single-pane sidebar labels) render silently-clipped values — a branch
+name `feature/a` shown as `fea` reads as a real ref. Repro: `COCO_ASCII=1 coco ui` at 80 columns on
+a repo with long ref names.
+
+**Suggested fix:** Use `>=` and, when the budget cannot hold the ellipsis plus at least one content
+cell, fall back to the 1-cell `…` even in ascii mode (or return the marker alone).
+
+**Confidence:** high
+
+---
+
+### [SEVERITY: medium] fix(workstation): `wrapCells` returns unwrapped text when the budget is non-positive
+**File:** `src/workstation/chrome/text.ts:60-62`
+
+**What's wrong:** The `width < 1` guard returns `[value]` — the caller asked for a wrapped result
+and gets an arbitrarily long single line instead.
+
+**Evidence:**
+```ts
+export function wrapCells(value: string, width: number): string[] {
+  if (width < 1) {
+    return [value]
+  }
+```
+The compose surface's budget is floored (`Math.max(8, width - 6)`), but the layout can hand
+`width: 0` to a hidden pane — `getLogInkLayout`'s single-pane branch sets the two non-visible
+panes to `sidebarWidth: 0` / `mainPanelWidth: 0` / `detailWidth: 0` (`layout.ts:249-253`).
+
+**Impact:** Any surface that wraps against a pane width without its own floor will emit a single
+unbounded line into a zero-width Box, which Ink renders as an overflowing row that corrupts the
+frame. **Needs verification:** confirm whether any `wrapCells` call site can receive a
+layout-derived width of `0` without an intervening `Math.max` — grep the `wrapCells(` call sites in
+`surfaces/**` and check each width expression.
+
+**Suggested fix:** Return `[]` (or `['']`) for `width < 1`, and floor every pane-derived width at
+the call sites.
+
+**Confidence:** needs-verification
+
+---
+
+### [SEVERITY: medium] fix(workstation): `useHistoryRefetch` re-runs on every `logArgv` identity change
+**File:** `src/workstation/runtime/hooks/useHistoryRefetch.ts:172`
+
+**What's wrong:** The dep array lists `logArgv`, an object. If any caller of `LogInkApp` recreates
+the argv object per render (rather than passing a stable prop), every render fires a fresh
+`git log` — bumping `historyRefetchGenerationRef`, which is also the counter
+`useDeferredBootLoad` and `useHistoryRefresh` use for their stale-resolve guards. That would make
+those guards fire spuriously and drop legitimate results.
+
+**Evidence:**
+```ts
+  }, [dispatch, git, logArgv, historyFetchArgs, fullGraph])
+```
+```ts
+historyRefetchGenerationRef.current += 1
+const issuedRefetchGeneration = historyRefetchGenerationRef.current
+```
+
+**Impact:** Repeated `git log` subprocesses and dropped boot/refresh results. **Needs
+verification:** confirm `deps.logArgv` reaching `LogInkApp` is referentially stable (check the
+`coco ui` / `coco log --interactive` entry points in `src/commands/log/`). If it is stable, this
+is a latent fragility rather than a live bug and should be documented with a `useMemo`/ref guard.
+
+**Confidence:** needs-verification
+
+---
+
+## LOW
+
+### [SEVERITY: low] fix(workstation): `openInEditor` does not pause Ink's stdin before spawning the editor
+**File:** `src/workstation/runtime/hooks/useEditorActions.ts:97-100`
+
+**What's wrong:** The handler drops raw mode and writes the alt-screen exit, but leaves Ink's
+`stdin` `data` listener attached and the stream flowing while `spawnSync` runs with
+`stdio: 'inherit'`. Ink's own `useStdin().setRawMode` refcount is bypassed entirely, so Ink still
+believes raw mode is on.
+
+**Evidence:**
+```ts
+stdin.setRawMode?.(false)
+out.write(`${SHOW_CURSOR}${EXIT_ALT}`)
+const result = spawnSync(editor, [...editorPrefixArgs, path], { stdio: 'inherit' })
+```
+
+**Impact:** Parent and child share the TTY fd with the parent's read stream still in flowing mode.
+`spawnSync` blocks the loop so the practical exposure is limited to bytes buffered at the moment of
+the call, but any such bytes are delivered to Ink's handler after the editor exits — a stray
+keystroke firing a workstation action. `useChangelogActions.openChangelogInEditor` has the
+identical shape. **Needs verification:** reproduce by typing ahead into `$EDITOR` and checking
+whether a workstation action fires on return.
+
+**Suggested fix:** `stdin.pause()` / `stdin.resume()` around the spawn (or route through Ink's
+`useStdin().setRawMode` so the refcount and listener state stay coherent).
+
+**Confidence:** needs-verification
+
+---
+
+### [SEVERITY: low] fix(workstation): `reword-head` rewrites HEAD without the confirmation its sibling `amend-head` requires
+**File:** `src/workstation/runtime/inkWorkflows.ts` (registry entry for `reword-head`)
+
+**What's wrong:** Enumerating the registry against `HISTORY_REWRITE_WORKFLOW_IDS`
+(`useWorkflowAction.ts:157-168`) shows exactly one history-rewriting workflow with no
+`requiresConfirmation`:
+```
+--- history-rewriting workflows WITHOUT requiresConfirmation ---
+  reword-head {"kind":"normal","label":"Reword HEAD commit message"}
+```
+All 9 siblings (`amend-head`, `reset-to-commit`, `cherry-pick-commit`, `revert-commit`,
+`fixup-into-commit`, `autosquash-rebase`, `interactive-rebase`, `execute-rebase-plan`,
+`rebase-onto-branch`) gate on a y-confirm.
+
+**Impact:** `reword-head` rewrites the HEAD commit (invalidating any push) with no confirmation
+step. Consent is arguably implicit because the flow opens an input prompt for the new message, but
+the asymmetry with `amend-head` — which also prompts *and* confirms — means the same class of
+rewrite has two different safety levels.
+
+**Suggested fix:** Either add `requiresConfirmation: true` for parity, or document the
+"prompt implies consent" rule and drop it from `amend-head` too. Add a registry-invariant test
+asserting every id in `HISTORY_REWRITE_WORKFLOW_IDS` follows the chosen rule.
+
+**Confidence:** high (the asymmetry is verified; whether it is *wrong* is a product call)
+
+---
+
+### [SEVERITY: low] fix(workstation): workspace debug mode installs a SIGINT handler that suppresses default Ctrl-C termination
+**File:** `src/workstation/surfaces/workspace/runtime.ts:382-383`
+
+**What's wrong:** Installing a `SIGINT` listener replaces Node's default hard-exit. The handler only
+logs and flushes; it never exits. Unlike `terminalLifecycle.ts`, which pairs every `process.on` with
+a `process.off` in `dispose()`, these are never removed.
+
+**Evidence:**
+```ts
+process.on('SIGINT', () => { workspaceDebug('SIGINT'); flushWorkspaceTrace() })
+process.on('SIGTERM', () => { workspaceDebug('SIGTERM'); flushWorkspaceTrace() })
+```
+
+**Impact:** With the workspace debug env var set, `Ctrl-C` no longer terminates the process in any
+window where the TTY is in cooked mode (notably during a `$EDITOR` spawn, which explicitly calls
+`setRawMode(false)`) — the app becomes un-interruptible and needs `kill`. Guarded behind
+`workspaceDebugEnabled()`, so end users are not normally exposed. **Needs verification:** confirm
+the env-var name and that raw mode is genuinely off during the editor window.
+
+**Suggested fix:** Re-raise after flushing (`process.exit(130)`) or install the handler with
+`{ once: true }` and a manual default-behaviour replay; expose a `dispose()` like
+`terminalLifecycle` does.
+
+**Confidence:** needs-verification
+
+---
+
+## Notes on the 42 `react-hooks/exhaustive-deps` warnings
+
+I enumerated all 42 (`npx eslint 'src/workstation/**/*.ts' --rule '{"react-hooks/exhaustive-deps":"warn"}'`).
+Classification:
+
+**Benign (34).** Omitted `useState` setters (`setStashDiffLines`, `setWorktreeDiff`,
+`setBlameLoading`, `setFilePreview`, `setPrDiffLines`, `setHasMoreCommits`, …) and omitted refs
+(`mountedRef`, `loadMoreRequestRef`, `loadingMoreCommitsRef`, `repoFrameDepthRef`,
+`historyRefetchGenerationRef`, `contextStatusRef`, `loadCommitContextRef`, `repoRootRef`). React
+guarantees setter identity and ref-object identity across renders, so these cannot go stale.
+
+**Benign-by-design (5).** The four warnings that name `selected` / `selectedWorktreeFile` /
+`selectedDetailFile` while the array lists their scalar sub-fields (`useCommitDetailHydration.ts:155`,
+`useDiffHydration.ts:402/507/634`) — the effects only read the enumerated scalars from those objects,
+so keying on the scalars is *narrower* and correct (it is what prevents a refetch on every context
+refresh). `useDeferredBootLoad.ts:117` is an intentional `[]` one-shot with a documented rationale.
+
+**Real, but latent rather than live (2).**
+- `useDetailHydration.ts:212` / `:258` and `useTriageListHydration.ts:123` / `:215` omit `forge`.
+  `forge` is a `useMemo` keyed on the provider; in practice `git` (which *is* a dep) changes on the
+  same repo-frame transition that changes `forge`, so the effects do re-fire. This is a correctness
+  coupling that is not stated anywhere — if `git` ever becomes stable across a provider change
+  (e.g. a host/provider override applied in place), the loaders will silently keep the old adapter.
+  Worth documenting or fixing.
+- `useYankActions.ts:300` enumerates `state.selected*Index` for every view but omits the
+  `state.selected*Id` fields that the `#1452` selectors now read
+  (`selection.ts:107-113`, `:190-196`, `:216-222`, and the `selectedWorktreeListId` /
+  `selectedSubmoduleId` / `selectedRemoteId` / `selectedIssueId` /
+  `selectedPullRequestTriageId` arms). Today the move actions dual-write id **and** index, so the
+  index dep changes whenever the id does and the callback regenerates. This is exactly the drift
+  `useWorkflowAction.ts:319-327` was rewritten (to a `depsRef` snapshot) to eliminate after it
+  *"shipped wrong-target destructive actions"*. `useYankActions` is the last enumerated-array
+  holdout and should adopt the same `depsRef` pattern before phase 3 of the #1452 migration removes
+  the `selected*Index` fields — at which point the array silently stops tracking the cursor.
+  **Needs verification** that no reducer case writes `selected*Id` without also writing
+  `selected*Index`.
+
+**One real memo mismatch, benign.** `buildFilteredLists.ts:210` names `context` and `sorts`; the
+array lists every consumed `context.*` slice plus `sorts.branchSort` / `sorts.tagSort`, which is the
+complete read set. `app.ts:1068` (`Box`/`Text`/`h`/`React`) is injected-module identity — stable.
+
+---
+
+## Areas I checked and found clean
+
+- **`useDiffHydration`** — all five loaders correctly flip `active` in cleanup, wrap the fetch in
+  `safe()`, and clear the `*Loading` flag on the guard-fail bail (the exact class of stuck-spinner
+  bug the audit was looking for, and it is handled in every arm). The `#OSS-595` debounce+cache in
+  `useCommitFilePreviewHydration` clears its timer in cleanup.
+- **`useLoadMoreHistory` / `useHistoryRefetch` / `useDeferredBootLoad`** — the generation/request-id
+  and `issuedAtDepth` frame-tag guards are checked *after* every await, and the `#1612` fix correctly
+  captures *and* re-checks the shared `historyRefetchGenerationRef` (not just the hook-local
+  request id). The `state.repoStack.length` rescope effect correctly resets the in-flight flags that
+  a dropped completion would otherwise strand.
+- **`useAiCommitDraftActions` / `useChangelogActions` / `useCommitSplitActions` /
+  `useConflictResolutionActions`** — the controller-ownership discipline (`ref.current !== controller`
+  checked after the await, `finally` clearing only its own controller) is correct in all four, and
+  `onStreamChunk` is both `mountedRef`- and ownership-guarded. The only gap is unmount (reported
+  above).
+- **`useWorkflowAction`** — the `depsRef` snapshot removes the whole stale-closure class; the
+  `remoteOpClaimRef` / `pendingItemActionClaimRef` tokens correctly prevent an earlier overlapping
+  remote op from clearing a later one's loader; the `frameChanged` re-read of `depsRef.current`
+  after the await correctly drops recovery prompts across a repo-frame transition.
+- **`chrome/refreshWatcher.ts`** — `close()` disposes the debouncer and every `FSWatcher`; the
+  `safeWatchFileViaParent` indirection correctly survives git's write-lock-then-rename (a direct
+  file watch would sit on the orphaned inode). `useRefreshWatcher`'s `cancelled` check sits between
+  the awaits and the assignment with no gap, so no watcher can leak on a fast unmount.
+- **`chrome/terminalLifecycle.ts`** — every `process.on` has a matching `process.off` in `dispose()`;
+  the SIGTSTP/SIGCONT/SIGTERM/SIGHUP restore sequences are complete and idempotent.
+- **`useSpinnerFrame` / `useIdleTip` / `useStatusAutoDismiss`** — all three clear every timer in
+  cleanup, including `useIdleTip`'s nested `setInterval` created inside the grace `setTimeout`.
+- **`useRepoPersistence`** — the `#1598` `restoredGitRef` gate does close the
+  restore-vs-save ordering race for both plain mount and the git-swap case; the save effects'
+  deliberate inline `revparse` (rather than reading the lagging `repoRootRef`) is correct.
+- **Destructive-workflow confirmation coverage** — 45 of 110 registry entries declare
+  `requiresConfirmation`, and every delete/drop/reset/revert/discard/remove/force/abort/prune id has
+  it (only `reword-head` is the reported gap). `inkKeymap.collisions.test.ts` correctly guards the
+  declarative binding table against same-context duplicates with an empty allow-list.
+- **`wrapCells` hard-split loop** — the `chunk === ''` fallback genuinely prevents the documented
+  infinite loop when the budget is narrower than one wide glyph, and `remaining.slice(chunk.length)`
+  is code-unit-correct because `chunk` is built as a code-unit prefix.
+- **List-window clamping in the surfaces** — `blame`, `fileHistory`, `rebase`, `reflog`, `remotes`,
+  `submodules`, `stash`, `tags`, `worktrees`, `branches`, `status`, `issuesTriage`,
+  `pullRequestTriage` all clamp both ends (`Math.max(0, Math.min(count - listRows, …))`) or route
+  through `clampListWindowStart`; no negative or inverted `slice` ranges. Only the two overlay lists
+  in `overlays.ts` are unclamped (reported above).
+- **`getLogInkLayout` at the 80×24 floor** — `tooSmall` is correctly `false` at exactly 80×24,
+  `singlePane` engages below 100 columns, and the single-pane width assignment does tile exactly
+  (`columns` to the visible pane, `0` to the other two).

--- a/docs/audit-0.84.1/feature-scoping.md
+++ b/docs/audit-0.84.1/feature-scoping.md
@@ -1,0 +1,341 @@
+# coco — feature / extension scoping
+
+**Target:** `/projects/sandbox/coco` (`git-coco` v0.84.1)
+**Method:** full read of `src/git/forgeActions.ts` + every per-forge implementation, `src/lib/langchain/providers/**`, `src/commands/**` mount table in `src/index.ts`, `src/workstation/surfaces/**` + `runtime/inkKeymap.ts` + `KEYMAP.md`, `src/mcp/server.ts`, `src/operations/agent/**`, `.github/workflows/**`, `packaging/`, `install.sh`, `bin/**`, and both in-repo implementation specs. No files were created or modified inside the repo.
+**Excluded as duplicates:** #1370, #1371, #1722, #1819, #1820, #1241, #1822–#1830.
+
+---
+
+## Headline finding: one designed spec is 100% unimplemented
+
+| Spec | Status | Evidence |
+|---|---|---|
+| `.kiro/specs/review-autofix-agent/` | **Shipped.** All 15 tasks (incl. optional 11/12) checked. | `src/lib/autofix/{index,buildPrompt,types}.ts` + `adapters/{codex,claude,gemini}.ts` all exist with co-located tests; `autoFixTool` / `autoFixToolOptions` present at `src/lib/config/types.ts:97,104`. |
+| `.kiro/specs/ai-conflict-resolution/` | **0 of 15 tasks done.** Every checkbox in `tasks.md` is `- [ ]`. | `src/commands/resolve/` does not exist. `grep -rn conflictResolve src/` returns **nothing** — the `DynamicModelTask` union never got the task. `grep -n confidence src/git/conflictAiActions.ts` returns **nothing** — the `ProposalsSchema` confidence field was never added. No conflict-marker validation in `conflictRegionActions.ts`. |
+
+The conflict spec has requirements → design → a 15-task plan naming exact files and line numbers, and the underlying TUI machinery it builds on (`src/git/conflictAiActions.ts`, `src/git/conflictRegionActions.ts`, `src/workstation/runtime/conflictResolutionState.ts`, `useConflictResolutionActions.ts`) is all shipped from #1369. **This is the single highest-leverage item in this report: a fully designed, fully specified feature sitting at zero implementation on top of a working data layer.** See P0-1.
+
+---
+
+## Forge capability × provider matrix
+
+Derived from the `ForgeActions` type and the four facades in `src/git/forgeActions.ts`. GitHub Enterprise is not a separate row — `detectProvider` (`src/git/providerData.ts:110`) folds `*github*` hosts into `github` and the `gh` CLI handles the host.
+
+Legend: ✅ real implementation · ⚠️ implemented with a semantic compromise · ❌ hard-coded `{ ok: false }` refusal.
+
+| `ForgeActions` capability | GitHub / GHE (`gh`) | GitLab (`glab api`) | Bitbucket Cloud (`fetch`) | Gitea / Forgejo / Codeberg (`fetch`) |
+|---|---|---|---|---|
+| `getPullRequestList` | ✅ | ✅ | ✅ | ✅ |
+| `getIssueList` | ✅ | ✅ | ✅ | ✅ |
+| `getPullRequestDetail` | ✅ | ✅ | ✅ | ✅ |
+| `getIssueDetail` | ✅ | ✅ | ✅ | ✅ |
+| `getPullRequestDiffByNumber` | ✅ | ✅ | ❌ `forgeActions.ts:277` | ✅ `getGiteaPullRequestDiff` |
+| `checkoutPullRequestByNumber` | ✅ | ✅ | ❌ `forgeActions.ts:286` | ❌ `forgeActions.ts:347` |
+| `commentPullRequestByNumber` | ✅ | ✅ | ✅ | ✅ |
+| `addPullRequestLabel` | ✅ | ✅ | ❌ `bitbucketPullRequestActions.ts:144` | ✅ |
+| `addPullRequestAssignee` | ✅ assignee | ✅ assignee | ⚠️ maps to **reviewer** | ⚠️ maps to **reviewer** |
+| `mergePullRequestByNumber` | ✅ | ✅ | ✅ | ✅ |
+| `closePullRequestByNumber` | ✅ | ✅ | ✅ | ✅ |
+| `approvePullRequestByNumber` | ✅ | ✅ | ✅ | ✅ |
+| `requestChangesPullRequestByNumber` | ✅ | ✅ | ✅ | ✅ |
+| `mergePullRequest` (current branch) | ✅ | ✅ | ⚠️ needs `currentBranch` threaded | ⚠️ needs `currentBranch` threaded |
+| `closePullRequest` / `approvePullRequest` / `commentPullRequest` / `requestChangesPullRequest` | ✅ | ✅ | ⚠️ same | ⚠️ same |
+| `createPullRequest` | ✅ | ✅ | ✅ | ✅ |
+| `openPullRequest` | ✅ | ✅ | ✅ | ✅ |
+| `commentIssue` | ✅ | ✅ | ✅ | ✅ |
+| `addIssueLabel` | ✅ | ✅ | ❌ `bitbucketIssueActions.ts:35` | ✅ |
+| `addIssueAssignee` | ✅ | ✅ | ✅ | ✅ |
+| `closeIssue` / `reopenIssue` | ✅ | ✅ | ✅ | ✅ |
+
+### Data-model parity (rendered but outside the facade)
+
+| Field | GitHub | GitLab | Bitbucket | Gitea |
+|---|---|---|---|---|
+| `isDraft` | ✅ | ✅ `draft ?? work_in_progress` | ✅ | ✅ `isDraftPR()` title heuristic |
+| `reviewDecision` | ✅ `pullRequestListData.ts:128` | ❌ hard `undefined` (`gitlabListData.ts:177,314`) | ❌ hard `undefined` (`bitbucketListData.ts:144`) | ❌ hard `undefined` (`giteaListData.ts:127`) |
+| `statusCheckRollup` (detail) | ✅ native | ⚠️ one synthetic `pipeline` check (`gitlabDetailData.ts:129`) | ⚠️ commit statuses | ⚠️ commit statuses |
+| `reviews` (detail) | ✅ native | ⚠️ approvals mapped to reviews | ⚠️ participants mapped to reviews | ✅ native |
+
+### Capabilities the adapter does not model **for any forge**
+
+Not "missing on forge X" — absent from the `ForgeActions` type entirely: **draft → ready transition** (`isDraft` is read-only; `grep -rni markReady|readyForReview src/` is empty), **reopen a PR** (issues can reopen, PRs cannot), **auto-merge / merge-when-pipeline-succeeds**, **check re-run** (`grep -rni rerun src/git` finds only prose), **line-level review threads** (read or write), **request reviewers as a distinct verb**, **remove label / remove assignee** (add-only), **edit PR title/body/base**, **update-branch / sync-with-base**, **create an issue** (`grep -rn createIssue src/` is empty — `coco issues` can comment/label/assign/close/reopen but not open one), **milestones**, **projects**, **releases**, **GitHub Discussions**, **wikis**, **CODEOWNERS / required-reviewer awareness**, **cross-repo search**.
+
+### Forges missing entirely
+
+`GitProviderType` (`providerData.ts:29`) is `github | gitlab | bitbucket | gitea | unsupported`. Not modelled: **Azure DevOps / TFS**, **Bitbucket Server / Data Center** (any `*bitbucket*` host collapses into the Cloud facade, whose API base is a fixed cloud constant), **sourcehut**, **Gogs**, **Radicle**. Forgejo and Codeberg are covered by the Gitea facade (`detectProvider` maps `codeberg.org`, `*forgejo*`, `*gitea*`).
+
+---
+
+## Provider registry coverage
+
+Derived from `PROVIDERS` in `src/lib/langchain/providers/registry.ts` (7 entries) and the per-provider `ProviderDynamicDefaults` tables in `src/lib/langchain/utils/dynamicModels.ts`.
+
+| Provider | Registered? | `requiresAuth` | Token correction | Dynamic-model defaults | Init-wizard entry |
+|---|---|---|---|---|---|
+| OpenAI | ✅ `openai.ts` | true | none (tiktoken native) | ✅ gpt-5.4 family | ✅ |
+| Anthropic | ✅ `anthropic.ts` | true | ✅ 1.2 | ✅ claude-4.x family | ✅ |
+| Azure OpenAI | ✅ `azure.ts` | true | none | ✅ | ✅ |
+| Google Gemini (API) | ✅ `gemini.ts` | true | ✅ | ✅ gemini-2.5 family | ✅ |
+| Mistral | ✅ `mistral.ts` | true | ✅ | ✅ | ✅ |
+| AWS Bedrock | ✅ `bedrock.ts` | false (cred chain) | ✅ per-model fn | ✅ | ✅ |
+| Ollama (local) | ✅ `ollama.ts` | false | ✅ 1.2 | ✅ | ✅ |
+| OpenRouter / any OpenAI-compatible | ⚠️ **reachable only** via `service.baseURL` on the `openai` provider (`openai.ts:26-28`) | — | ❌ inherits OpenAI's *none* → undercounts non-tiktoken models | ❌ none | ❌ |
+| DeepSeek, xAI/Grok, Groq, Together, Fireworks, GitHub Models, Cloudflare Workers AI | ❌ same `baseURL` workaround, same three gaps | — | ❌ | ❌ | ❌ |
+| LM Studio / vLLM / llama.cpp server | ❌ same workaround (OpenAI-compatible), *not* reachable through the Ollama provider — `ollama.ts` hardcodes `ChatOllama` + `numPredict` | — | ❌ | ❌ | ❌ |
+| Google Vertex AI | ❌ not registerable — needs ADC / service-account auth, which `CreateLlmArgs` (`apiKey: string`) cannot express | — | — | — | — |
+| Cohere, AI21, Watsonx, Databricks | ❌ | — | — | — | — |
+
+### Provider-level features unmodelled
+
+- **Prompt caching.** Nothing in `openai.ts` / `anthropic.ts` sets `cache_control` or reads `cache_read_input_tokens`. `UsageRecord` (`usageLedger.ts:21`) has `promptTokens` / `completionTokens` only — cached reads are invisible.
+- **Batch API.** No batch submission path anywhere; every call is synchronous `chain.invoke`.
+- **Reasoning-effort / thinking budget.** Only through the untyped `service.fields` escape hatch (`Object.assign(openaiConfig, config.service.fields)`), so it is undiscoverable, unvalidated, and absent from `schema.json`.
+- **Native structured output / JSON mode.** `grep -rn "withStructuredOutput|responseFormat|json_object" src/lib` returns **zero hits**. Every structured task goes through `PromptTemplate` → text → parser → zod validate, with a dedicated `repair` dynamic-model task to retry malformed JSON (`executeChainWithSchema.ts`). That repair round-trip is pure cost that native JSON-schema mode removes.
+- **Vision input, tool calling.** Neither modelled (tool calling is arguably out of scope for read-only generation; vision is not — screenshots in PR descriptions are common).
+- **Provider-native token counting.** `tokenCorrectionFactor` (1.2 fudge over the gpt-4o tiktoken baseline) stands in for Anthropic's `count_tokens` and Gemini's `countTokens`.
+
+---
+
+# P0 — table stakes gaps users will hit
+
+### [PRIORITY: P0] [EFFORT: L] feat(resolve): ship the designed-but-unimplemented `coco resolve` CLI
+**Category:** command
+**Gap:** `.kiro/specs/ai-conflict-resolution/tasks.md` has 15 tasks, all unchecked. `src/commands/resolve/` does not exist; `conflictResolve` is absent from the `DynamicModelTask` union in `src/lib/langchain/types.ts`; `ProposalsSchema` in `src/git/conflictAiActions.ts` has no `confidence` field; `applyConflictResolution` in `src/git/conflictRegionActions.ts` does not reject replacements that still contain `<<<<<<<`. AI conflict resolution today is reachable **only** from inside `coco ui`'s conflicts surface.
+**Why it matters:** Conflict resolution is the highest-pain git moment and the one place scripted/CI use matters most (`coco resolve status` for exit-code gating, `--apply --confidence high` for unattended rebases). Today a user mid-rebase in a terminal without the TUI has nothing. The absent marker validation is also a correctness hazard in the shipped TUI path.
+**Sketch:** Execute the spec as written — it names the files and line numbers. Data layer first: `src/lib/langchain/types.ts` + `utils/dynamicModels.ts` (`conflictResolve` task, falling back to `review`'s model), `conflictAiActions.ts` (confidence enum, per-region chunking, `runConflictExplanationWorkflow`), `conflictRegionActions.ts` (marker guard). Then `src/commands/resolve/{config,index,handler,statusHandler,explainHandler,resolveHandler,prompt}.ts` mounted in `src/index.ts`. Regenerate `schema.json`.
+**Already-there leverage:** `getConflictedFiles`, `getInProgressOperationType`, region parsing, `applyConflictResolution`, `stageConflictResolved`, `runConflictResolutionWorkflow`, and the `$EDITOR` spawn pattern in `useConflictResolutionActions.ts` are all shipped. The spec estimates the command layer as incremental (status → explain → resolve).
+**Effort notes / risks:** L overall, but splits cleanly into ~4 PRs (tasks 1–4 data layer, 6–7 status, 8 explain, 9–11 resolve). Touches the shipped TUI path (confidence field is additive; marker guard changes behavior — it *rejects* previously-accepted writes, which is the point). Schema drift gate in CI will fail unless `schema.json` is committed.
+
+### [PRIORITY: P0] [EFFORT: S] feat(forge): add draft→ready and PR reopen to the forge adapter
+**Category:** forge parity
+**Gap:** `ProviderPullRequestStatus.isDraft` is read and rendered (header chips, triage rows, all four forges), and `pr create -d/--draft` can *create* a draft — but there is no way to promote one. `grep -rni "markReady|readyForReview" src/` is empty. Symmetrically, `ForgeActions` has `reopenIssue` but no `reopenPullRequest`.
+**Why it matters:** "Open as draft, finish, mark ready" is the single most common PR lifecycle, and coco supports two of the three steps. Every user who uses `-d` hits this. Accidentally closing a PR from the triage view (`ForgeActions.closePullRequestByNumber` is one keystroke) is currently unrecoverable inside coco.
+**Sketch:** Add `markPullRequestReady(n)` and `reopenPullRequest(n)` to the `ForgeActions` type in `src/git/forgeActions.ts`; implement in `pullRequestActions.ts` (`gh pr ready`), `mergeRequestActions.ts` (`glab api ... PUT` clearing the `Draft:` title prefix), `bitbucketPullRequestActions.ts` (`PUT /pullrequests/{id}` with `draft: false`), `giteaPullRequestActions.ts` (`PATCH /pulls/{n}`). Bind keys in the pull-request and pullRequestTriage surfaces via `inkKeymap.ts` + `KEYMAP.md`.
+**Already-there leverage:** Four working runners, a uniform `PullRequestActionResult`, and an established by-number mutation pattern to copy line-for-line. Gitea's draft model is a title prefix, and `isDraftPR()` in `giteaListData.ts:108` already encodes that heuristic.
+**Effort notes / risks:** Honors the "add to `ForgeActions`, implement for every provider" invariant. GitLab/Gitea draft-as-title-prefix means the implementation is a title rewrite, not a flag — needs care not to clobber a user-authored title.
+
+### [PRIORITY: P0] [EFFORT: M] feat(observability): dollar-denominated cost, per-model pricing, and budget caps
+**Category:** observability
+**Gap:** `coco doctor --cost` renders `"${promptTokens} in / ${completionTokens} out tok"` (`src/commands/doctor/handler.ts:30-33`). There is no price table anywhere — `grep -rni "pricePer|costUsd|pricing" src/lib src/commands` returns one unrelated hit. `UsageAggregate` has no cost field, and there is no cap, alert, or pre-flight estimate.
+**Why it matters:** "Cost" that reports tokens is not a cost report. Users on `service.model: "dynamic"` with a `quality` preference are routed to `gpt-5.5` / `claude-opus-4-8` for every commit and have no way to see the bill or bound it. Teams cannot adopt `dynamic` routing without a budget guardrail. This is the difference between a telemetry feature and a cost feature.
+**Sketch:** Add `src/lib/langchain/pricing.ts` — a `Record<LLMModel, { inputPer1M, outputPer1M, cachedInputPer1M? }>` table with an `unknown → undefined` fallback so unpriced models degrade to tokens instead of lying. Extend `UsageAggregate` in `usageLedger.ts` with `estimatedCostUsd`; extend `summarizeUsageBy*` to sum it; extend the doctor renderer. Add `telemetry.budget: { monthlyUsd, warnAtPercent }` to `src/lib/config/types.ts` and a check in `src/commands/doctor/checks.ts`; enforce a soft warning at call time from `observability.ts`.
+**Already-there leverage:** The ledger already records `provider`, `model`, `promptTokens`, `completionTokens` per call with bounded size and a working consent gate — the entire data-collection half is done. `doctor/checks.ts` already has a fix-suggestion mechanism to hang budget warnings on.
+**Effort notes / risks:** The price table is a maintenance treadmill; ship it as data with an explicit `pricesAsOf` date and label output "estimated". Must not weaken the `telemetry.usage` / `COCO_USAGE_LOG` gate or start recording anything beyond metadata.
+
+### [PRIORITY: P0] [EFFORT: M] feat(provider): use native structured output / JSON mode instead of parse-and-repair
+**Category:** provider
+**Gap:** Zero uses of `withStructuredOutput` / `responseFormat` / `json_object` in `src/lib`. Structured tasks (commit split plan, review findings, conflict proposals) prompt for JSON as free text, parse it, validate with zod, and on failure spend a whole extra LLM call on the dedicated `repair` dynamic-model task.
+**Why it matters:** Every malformed-JSON retry is a paid round-trip and a latency spike on exactly the heaviest tasks (`commitSplit`, `review`, `largeDiff`). Providers that support native JSON-schema constrained decoding make that failure mode structurally impossible. This is a direct cost *and* reliability win on the features coco markets hardest.
+**Sketch:** Add an optional `supportsStructuredOutput?: 'json-schema' | 'json-mode'` to `ProviderDefinition` in `providers/types.ts`; set it on `openai`, `azure`, `gemini`, `mistral`, `ollama` (format=json). In `executeChainWithSchema.ts`, when the resolved provider advertises support and the caller supplied a zod schema, bind it via `llm.withStructuredOutput(schema)` and skip the text parser; otherwise keep today's path verbatim. Keep `repair` as the fallback for non-supporting providers.
+**Already-there leverage:** Callers already pass zod schemas (`ProposalsSchema` and friends), so the schema is in hand at the call site — no new plumbing. `ProviderDefinition` is explicitly designed as the place for per-provider capability facts (`tokenCorrectionFactor` is the precedent).
+**Effort notes / risks:** Must stay opt-in-by-capability so Bedrock/Anthropic/local paths are untouched. Structured-output mode changes token accounting slightly (schema is billed as input) — coordinate with the cost work above. Behavior change is observable in snapshot tests of prompts.
+
+### [PRIORITY: P0] [EFFORT: M] feat(provider): first-class OpenAI-compatible provider presets (DeepSeek, Groq, xAI, Together, Fireworks, LM Studio, vLLM)
+**Category:** provider
+**Gap:** All of these are *technically* reachable by setting `service.baseURL` on the `openai` provider (`openai.ts:26-28`), but they get none of the registry's benefits: no entry in `PROVIDERS`, no `tokenCorrectionFactor` (so a Llama- or DeepSeek-tokenized prompt is counted with the gpt-4o tiktoken baseline and *undercounts*, which feeds directly into `enforcePromptBudget`), no `ProviderDynamicDefaults` row (so `service.model: "dynamic"` cannot work), no init-wizard entry, no endpoint in `doctor`. Note the local-server case specifically: LM Studio / vLLM / llama.cpp are **not** reachable through `ollama.ts`, which hardcodes `ChatOllama` and `numPredict`.
+**Why it matters:** Cost-sensitive and privacy-sensitive users are the two loudest segments for a tool like this, and both are currently steered into an undocumented escape hatch with a silently wrong token budget. Undercounting tokens means prompt-budget enforcement fails open and calls get rejected by the provider instead of pre-trimmed.
+**Sketch:** Add `src/lib/langchain/providers/openaiCompatible.ts` — a factory that stamps out `ProviderDefinition`s sharing `createOpenAiLlm` but carrying their own `id`, `label`, default `baseURL`, env-var name, and `tokenCorrectionFactor`. Register `deepseek`, `groq`, `xai`, `together`, `fireworks`, `openrouter`, `lmstudio`, `vllm` in `registry.ts`. Add a `ProviderDynamicDefaults` row per provider in `dynamicModels.ts`. Extend `LLMProvider` and the init wizard choices. Regenerate `schema.json`.
+**Already-there leverage:** The registry was built for exactly this — its docblock says "adding a provider is a matter of writing a `ProviderDefinition` module and registering it here." `createOpenAiLlm` already handles `baseURL` and `fields` merge, and lazy `await import()` keeps startup cost flat regardless of how many presets are added.
+**Effort notes / risks:** M mostly because of the per-provider model catalogs in `dynamicModels.ts` (3 preferences × 8 tasks each) and the auth-resolver env-var mapping. Model ids churn fast; consider allowing a preset to opt out of `dynamic` rather than shipping a stale catalog.
+
+### [PRIORITY: P0] [EFFORT: S] feat(ci): gate the diff-condensing benchmark against the committed baseline
+**Category:** observability
+**Gap:** `bin/benchmark.ts` and `.bench/baseline.json` exist and the bench already prints a baseline diff, but `grep -rn bench .github/workflows/` finds only a DevSkim *exclude* path. Nothing runs `npm run bench` in CI. The workstation bench (`bin/benchmarkWorkstation.ts`) is likewise unwired.
+**Why it matters:** The diff-condensing pipeline is the hot path for every AI command and the thing whose regressions cost users real money (more `llmCalls` = higher bill). The baseline is already checked in, so the repo is one workflow step away from catching a regression at PR time instead of in a release. Cheapest high-value item in this report.
+**Sketch:** Add a `bench` job to `.github/workflows/ci.yml` (mirroring the existing `integration` job shape) running `npm run bench`; teach `bin/benchmark.ts` a `--check` flag that exits non-zero when `llmCalls` or `durationMs` regress past a tolerance versus `.bench/baseline.json`, and post the diff as a PR summary. The mock chain is deterministic, so no API keys or secrets are needed.
+**Already-there leverage:** Deterministic latency model, fixture set, baseline file, and the diff printer all exist. CI already has a `visual-regression` job that demonstrates the artifact-upload pattern.
+**Effort notes / risks:** S. Needs a sane tolerance so runner variance doesn't produce flakes — gate on `llmCalls` (fully deterministic) strictly and `durationMs` loosely, following the same "artifact first, gate later" caution the `visual-regression` job documents.
+
+### [PRIORITY: P0] [EFFORT: M] feat(forge): fetch Bitbucket Cloud PR diffs instead of refusing
+**Category:** forge parity
+**Gap:** `forgeActions.ts:277-278` hard-codes `{ ok: false, message: 'Pull request diffs are not supported for Bitbucket yet.' }`. Bitbucket Cloud's REST API *does* expose `GET /2.0/repositories/{ws}/{slug}/pullrequests/{id}/diff`; the comment's stated reason is "no CLI patch fetch", but the Bitbucket facade doesn't use a CLI at all — it uses `fetch`.
+**Why it matters:** This one refusal disables the triage `Enter → diff` drill-in **and** `coco review --pr <n>` for every Bitbucket user, i.e. it silently removes the AI review feature for a whole supported forge. `review/handler.ts:119` calls `forge.getPullRequestDiffByNumber` and dead-ends.
+**Sketch:** Implement `getBitbucketPullRequestDiff(path, n, runner)` in `src/git/bitbucketDetailData.ts` against `/diff` (raw text, follows a redirect), returning the shared `PullRequestDiffResult`; wire it into `bitbucketActions` in `forgeActions.ts`. Gitea's `getGiteaPullRequestDiff` is the exact template.
+**Already-there leverage:** `defaultBitbucketRunner` + pagination helpers + `PullRequestDiffResult` shape + a working Gitea implementation of the identical capability. Bitbucket integration tests already exist (`bitbucket.integration.test.ts`).
+**Effort notes / risks:** M not S because the `/diff` endpoint returns a redirect to raw content and the runner currently assumes JSON — that's a small runner extension, and the raw-text path needs its own test. Same gap exists for `checkoutPullRequestByNumber` on Bitbucket and Gitea, which is genuinely harder (needs `git fetch` of the source ref) — worth a follow-up issue.
+
+### [PRIORITY: P0] [EFFORT: M] feat(lint): audit and reword existing commit history against commitlint
+**Category:** command
+**Gap:** coco's commitlint integration only ever runs *forward* — validating a message it is about to write (`commit`, `amend`, `commitSplit`). There is no way to ask "is my branch's history conventional?" `src/index.ts` mounts 20 commands; none of them read history for message quality.
+**Why it matters:** Repos adopting Conventional Commits mid-stream, and anyone about to squash-merge a messy branch, need exactly this. It is also the natural CI gate: `coco lint --since origin/main --severity`. coco already owns the commitlint config discovery and the AI rewriting capability — no other tool combines both.
+**Sketch:** New `src/commands/lint/{config,index,handler}.ts` mounted in `src/index.ts`. Read the range via `src/git/logData.ts`, validate each subject through the existing commitlint loader used by `src/commands/commit/`, and for failures call a new `reword` prompt to propose a conforming subject. Flags: `--since`, `--range`, `--json`, `--fix` (writes an interactive-rebase `reword` todo through `src/git/rebasePlanActions.ts`), `--severity` for exit-code gating.
+**Already-there leverage:** commitlint discovery + validation is shipped; `buildRebaseTodo` / `executeRebasePlan` in `rebasePlanActions.ts` already build and run `reword` todos; `--severity`-style CI gating is already proven in `src/commands/review/config.ts`; `--json` is a global flag.
+**Effort notes / risks:** The read-only lint path is S; `--fix` is what makes it M, because rewriting published history is dangerous — default to dry-run, require explicit `--fix`, refuse when the range contains merges or is already pushed unless forced.
+
+### [PRIORITY: P0] [EFFORT: M] feat(distribution): official GitHub Action, pre-commit hook, and container image
+**Category:** distribution
+**Gap:** No `action.yml`, no `Dockerfile`, no `.pre-commit-hooks.yaml` at the repo root. `packaging/` contains a single Homebrew formula. Shell completions *do* exist (`src/index.ts:247-293`, bash/zsh/fish) and `install.sh` covers curl-install — so the gap is specifically **CI and hook-framework** distribution.
+**Why it matters:** `coco review --severity 7` and `coco lint` are CI-shaped features with no CI-shaped delivery: every adopter hand-writes a workflow that installs Node 22, npm-installs `git-coco`, and plumbs `OPENAI_API_KEY`. The repo's own `.github/workflows/ai-review.yml` is evidence the demand exists in-house. A pre-commit hook only exists as coco's own bespoke `prepare-commit-msg` installer (`src/commands/hooks/manageHooks.ts`), which the millions of repos on the `pre-commit` framework cannot use.
+**Sketch:** (1) `action.yml` — composite action wrapping `setup-node` + `npm i -g git-coco@<ref>` + a `command` input, with `severity`/`json` passthrough and outputs for the findings JSON. (2) `.pre-commit-hooks.yaml` declaring a `coco-commit-msg` hook. (3) `Dockerfile` on `node:22-alpine` with `gh` and `glab` preinstalled, published from `publish-release.yml` alongside npm. (4) A README/wiki "Use coco in CI" section.
+**Already-there leverage:** `--json`, `--quiet`, `--repo`, and `--severity` exit-code gating already make every command CI-friendly; `bin/smokeCli.ts` gives a ready smoke target for the container; `publish-release.yml` + `update-homebrew-tap.yml` show the release-fanout pattern to copy.
+**Effort notes / risks:** M spread across three independent deliverables — file as three issues under one umbrella. The container needs a decision on whether forge CLIs are baked in (size) or expected from the host.
+
+---
+
+# P1 — significant gaps and differentiating bets
+
+### [PRIORITY: P1] [EFFORT: L] feat(forge): line-level review threads — read them, and post AI review as inline comments
+**Category:** forge parity
+**Gap:** `PullRequestDetail` (`pullRequestDetailData.ts:31-37`) carries `body`, `comments`, `reviews`, `statusCheckRollup` — all thread-level. There is no notion of a review *thread* anchored to a file and line, in either direction. `coco review --pr <n> --comment` posts one markdown blob as a PR-level comment (`review/handler.ts:374-378`) even though the review findings already carry file + line.
+**Why it matters:** Two large user-visible losses. (a) Reviewers using `coco ui` for triage can't see or answer the actual review conversation, so they leave for the web UI at the exact moment coco should be sticky. (b) coco's flagship AI review produces per-file, per-line findings and then flattens them into a wall of text — inline comments are how humans consume review.
+**Sketch:** Add `getPullRequestReviewThreads(n)` and `createPullRequestReviewComments(n, comments[])` to `ForgeActions`. GitHub: `gh api` GraphQL `reviewThreads` + REST `POST /pulls/{n}/reviews` with a `comments[]` array. GitLab: discussions API with `position`. Gitea: `POST /pulls/{n}/reviews` with `comments`. Bitbucket: `POST /pullrequests/{id}/comments` with `inline`. Render threads in the `detail` surface (new tab) and thread the findings' existing `file`/`line` into the `--comment` path in `review/handler.ts`.
+**Already-there leverage:** Review findings already carry file/line (that's what `src/lib/autofix/buildPrompt.ts` consumes). The `detail` surface already has a tab model. All four runners exist. `forgeText.ts` sanitization already handles untrusted forge markdown.
+**Effort notes / risks:** L — four genuinely different position/anchor models, and diff-position anchoring (side, start_line, commit sha) is the classic source of API 422s. Needs the `ForgeActions` "implement for every provider or return explicit unsupported" discipline; Bitbucket's `inline` model is the weakest and may legitimately return unsupported for multi-line ranges.
+
+### [PRIORITY: P1] [EFFORT: L] feat(forge): Azure DevOps provider
+**Category:** forge parity
+**Gap:** `GitProviderType` has no `azure` member; an `dev.azure.com` or `*.visualstudio.com` remote resolves to `unsupported` (`providerData.ts:110-121`), which disables `prs`, `issues`, `pr create`, and the entire workstation triage stack.
+**Why it matters:** Azure DevOps Repos is the largest forge coco doesn't support, and it dominates exactly the enterprise segment that also buys Azure OpenAI — which coco *does* support as a first-class provider. That mismatch is odd: an org can use coco's Azure LLM but not its Azure repos.
+**Sketch:** Add `'azure-devops'` to `GitProviderType`, host detection for `dev.azure.com` / `*.visualstudio.com` / on-prem via `forgeHosts`, and a `src/git/azureDevOpsCli.ts` runner (PAT auth via `fetch`; no CLI binary, exactly like Bitbucket/Gitea) plus `azureDevOpsListData.ts`, `azureDevOpsDetailData.ts`, `azureDevOpsPullRequestActions.ts`, `azureDevOpsIssueActions.ts`, and an `azureDevOpsActions()` facade in `forgeActions.ts`.
+**Already-there leverage:** The Gitea facade is a complete, recent, CLI-free worked example of adding a forge — same file set, same `makeXRunner(host)` pattern, same graceful-unsupported convention. `parseRemoteUrl` is already host-agnostic and `forgeHostOverrides` already supports vanity hosts.
+**Effort notes / risks:** L. Azure DevOps has a genuinely different resource hierarchy (organization / project / repo, three segments where every other forge has two), which the `owner`/`name` shape of `ProviderRepository` cannot express — that's the real cost, and it may require a third optional segment threaded through `buildProviderUrl`. Work items are not issues; the `issues` mapping will be lossy and should say so.
+
+### [PRIORITY: P1] [EFFORT: M] feat(forge): Bitbucket Server / Data Center as a distinct provider
+**Category:** forge parity
+**Gap:** `detectProvider` classifies *any* host containing `bitbucket` as `bitbucket`, and the Bitbucket facade is hardwired to the Cloud API base. Self-hosted Bitbucket Server/DC — a different API (`/rest/api/1.0`), different auth, different pagination — is silently routed to a cloud endpoint.
+**Why it matters:** Enterprise Bitbucket is overwhelmingly Server/DC, not Cloud. Users get confusing auth failures rather than "unsupported", which is worse than no support.
+**Sketch:** Add `'bitbucket-server'` to `GitProviderType`, make it selectable via the existing `forgeHosts` config override (auto-detection is not reliably possible), and add `src/git/bitbucketServerCli.ts` with a host-bound runner following `makeGiteaRunner`, plus the four data/action modules and a facade branch in `getForgeActions`.
+**Already-there leverage:** `forgeHostOverrides` / `setForgeHostOverrides` already exists precisely for vanity self-hosted hosts; the Gitea host-bound-runner pattern is the template; Bitbucket Cloud's DTO mapping is a starting point even though the endpoints differ.
+**Effort notes / risks:** M. Overlaps with a known bug (cloud-API misrouting for `*bitbucket*` hosts) — coordinate so the fix and the new provider don't conflict. `/rest/api/1.0` has no issues concept, so `getIssueList` should return explicit unsupported.
+
+### [PRIORITY: P1] [EFFORT: M] feat(forge): CI checks surface with re-run and auto-merge
+**Category:** forge parity
+**Gap:** Checks are read-only and shallow: `statusCheckRollup` is a flat `{name, status, conclusion}[]` (GitLab collapses an entire pipeline into one synthetic row, `gitlabDetailData.ts:129-133`). No job logs, no re-run, no auto-merge/merge-when-pipeline-succeeds. `grep -rni rerun src/git` finds nothing.
+**Why it matters:** "One flaky check failed, re-run it, then merge" is a daily loop that currently forces a browser trip, breaking the terminal-native promise. Auto-merge is the mechanism that makes coco's PR flow actually terminate without babysitting.
+**Sketch:** Add `getPullRequestChecks(n)`, `rerunFailedChecks(n)`, and `enableAutoMerge(n, strategy)` to `ForgeActions`. GitHub: `gh run rerun --failed`, `gh pr merge --auto`. GitLab: `POST /pipelines/{id}/retry`, `merge_when_pipeline_succeeds`. Gitea: `POST /actions/runs/{id}/rerun`, `merge_when_checks_succeed`. Bitbucket: explicit unsupported for re-run. Render as a checks tab in the `detail` surface with keys in `inkKeymap.ts`.
+**Already-there leverage:** `PullRequestStatusCheck` and the per-forge check mapping already exist in all four detail fetchers; the merge-strategy vocabulary (`PullRequestMergeStrategy`) is already normalized across forges; `headerChips.ts` already renders check state.
+**Effort notes / risks:** M. Re-run needs a check-run→workflow-run id mapping that the current flat shape discards, so `PullRequestStatusCheck` gains an optional `runId`. Auto-merge semantics differ enough per forge (GitHub requires branch protection; GitLab requires a pipeline) that the failure messages matter more than the happy path.
+
+### [PRIORITY: P1] [EFFORT: M] feat(issues): create issues, and AI-draft them from a diff or a review finding
+**Category:** command
+**Gap:** `grep -rn createIssue src/` is empty. `ForgeActions` can comment/label/assign/close/reopen an issue but not open one. `coco issues` is read + triage only.
+**Why it matters:** coco already *generates* the exact content an issue needs — `coco review` produces titled, severity-scored, file-anchored findings, and the shipped autofix flow proves those findings are actionable artifacts. Not being able to file one is a dead end in a workflow coco otherwise owns end to end. It also unblocks "triage this repo" style automation without granting write access to anything but the issue tracker.
+**Sketch:** Add `createIssue(input)` to `ForgeActions` (all four forges support it: `gh issue create`, `glab api POST /issues`, Bitbucket `POST /issues`, Gitea `POST /issues`). Add `src/commands/issues/createHandler.ts` behind `coco issues create` with `--title`/`--body`/`--from-review`/`-i`/`--dry-run`/`--json`, mirroring `src/commands/prCreate/` flag shape. In the TUI, add a "file issue from finding" action.
+**Already-there leverage:** `src/commands/prCreate/` is a complete worked example of AI-drafted forge creation (interactive confirm, `--dry-run`, `--json`, web fallback); review findings are already structured; `runPullRequestBodyWorkstation` in `aiActions.ts` shows the body-generation pattern.
+**Effort notes / risks:** M. Forge mutation, so it must go through the adapter. Explicitly **must not** be exposed as an MCP tool — that would violate the "MCP generation tools remain repository-read-only, no forge mutations" invariant.
+
+### [PRIORITY: P1] [EFFORT: M] feat(mcp): expose resources and prompts primitives, not just tools
+**Category:** agent-mcp
+**Gap:** `src/mcp/server.ts` registers four tools (`server.registerTool` in a loop over the agent operations) and nothing else — no `registerResource`, no `registerPrompt`. Clients can only *call* coco; they cannot *browse* repository context or reuse coco's prompt library.
+**Why it matters:** Tools are the imperative surface; resources and prompts are the discoverable ones. An MCP client that could read `coco://repo/status`, `coco://repo/diff/staged`, or `coco://repo/branch-context` as resources would stop burning tool calls on context gathering, and exposing coco's commit/review prompt templates as MCP prompts turns coco into a prompt provider for any agent — a genuinely differentiating position that no other git MCP server holds.
+**Sketch:** In `src/mcp/server.ts`, add `server.registerResource` entries backed by the existing read-only loaders in `src/operations/agent/context.ts` (status, staged diff, branch context, recent log), and `server.registerPrompt` entries wrapping the `prompt.ts` templates from `src/commands/{commit,review,changelog,recap}/`. Both are read-only by construction, so the invariant holds trivially.
+**Already-there leverage:** Root confinement, repo normalization, and the client-roots resolution (`getClientCapabilities()?.roots` / `listRoots()`) are already implemented and tested in `server.ts`. `src/operations/agent/context.ts` already produces exactly the read-only context payloads a resource would serve, with SHA-256 provenance.
+**Effort notes / risks:** M. Resource URI design is the only real decision. Must keep `telemetry.usage` metadata-only semantics for resource reads, and must not let a resource URI become a per-call repo switch (explicitly forbidden). Outside the #1822–#1830 set, which is all tools/docs.
+
+### [PRIORITY: P1] [EFFORT: M] feat(mcp): progress notifications and streaming for long generations
+**Category:** agent-mcp
+**Gap:** MCP tool calls are single-shot request/response. A `coco_review` over a large diff fans out into many summarization calls (see `summarizeDiffs.ts` wave scheduling) and the client sees nothing until it completes. No `notifications/progress`, no partial results.
+**Why it matters:** Agent clients time out or double-fire on long calls. coco's own TUI already solved this problem for humans — `service.streaming.enabled` streams the commit draft token-by-token with `AbortController` cancel — so the machine surface is behind the human one on the same underlying capability.
+**Sketch:** Thread a `progressToken` from the MCP request into `src/operations/agent/generate.ts` and emit `notifications/progress` at the existing stage boundaries in the diff-condensing pipeline. Reuse `executeChainStreaming` where a single call dominates. Keep the terminal envelope shape byte-identical so non-progress-aware clients are unaffected.
+**Already-there leverage:** `executeChainStreaming` + `AbortController` cancellation already exist and are already wired through the agent operation layer; the parser pipeline already has discrete wave/stage boundaries that are natural progress points; the MCP SDK supports progress natively.
+**Effort notes / risks:** M. The `src/operations/agent/` layer must stay transport-agnostic — progress emission has to be injected as a callback from `src/mcp/`, not imported into operations, or the shared-operations invariant breaks. Also outside #1822–#1830.
+
+### [PRIORITY: P1] [EFFORT: M] feat(workstation): mouse support (click-to-focus, wheel scroll, click-to-select)
+**Category:** tui
+**Gap:** Documented as a deliberate non-feature: "The TUI is keyboard-only by design ... No mouse input is consumed" (`src/workstation/runtime/app.ts:23-25`). No SGR mouse-mode enable anywhere.
+**Why it matters:** lazygit, gitui, and tig all consume mouse events. The keyboard-first design is right; keyboard-*only* costs new users their first five minutes — wheel-scrolling a long diff and clicking a pane to focus it are muscle memory. This is the most common first-impression complaint class for dense TUIs, and it is additive: no existing binding changes.
+**Sketch:** Enable SGR mouse reporting (`?1006h`/`?1000h`) in `src/workstation/chrome/terminalLifecycle.ts` behind `ui.mouse: true` (default off for one release), parse the escape sequences in `src/workstation/runtime/inkInput.ts` alongside key events, and map to three actions only: pane focus, list-row select, and scroll. Extend `LOG_INK_KEY_BINDINGS`-adjacent docs in `KEYMAP.md`.
+**Already-there leverage:** `terminalLifecycle.ts` already owns alt-screen enter/exit, so mouse-mode enable/disable has a correct home with guaranteed teardown. `layout.ts` already computes pane rectangles, which is exactly the hit-testing input. `selectionRectify.ts` already normalizes selection changes from arbitrary sources.
+**Effort notes / risks:** M. Mouse mode breaks terminal text selection unless shift-override is documented; teardown must be bulletproof or a crash leaves the user's terminal in mouse mode (mitigated by `terminalLifecycle`'s existing cleanup path). Touches `inkInput.ts`, which #1722 is extracting — sequence after that lands.
+
+### [PRIORITY: P1] [EFFORT: M] feat(workstation): undo stack for destructive git actions
+**Category:** tui
+**Gap:** `grep -rni "undoStack|redoStack" src/` is empty. The workstation exposes one-keystroke destructive operations across `branches` (delete), `stash` (drop), `history` (reset), `tags` (delete), and `pullRequestTriage` (close) with no unified undo. There *is* a `reflog` surface, but it is a browser, not an undo affordance.
+**Why it matters:** Key-dense TUIs make mistakes cheap to commit and expensive to reverse; `KEYMAP.md` itself flags overload risk as a live hazard. The safety net is what lets users trust the density. magit's and lazygit's undo affordances are a big part of why users forgive their key density.
+**Sketch:** Add `src/workstation/runtime/undoStack.ts` — a bounded in-session stack where each destructive action pushes `{ label, inverse }` (branch delete → recreate at recorded sha; stash drop → `git stash store` the recorded sha; reset → reset back to the recorded HEAD; tag delete → recreate). Capture the pre-state in the existing action hooks under `runtime/hooks/`, bind `gu` (the `g`-chord namespace is already the "global/meta" space), and surface the stack in the footer.
+**Already-there leverage:** `reflogActions.ts` + `reflogData.ts` already resolve prior positions, which is most of the inverse-operation data. The `g`-chord dispatch layer and the collision-guard test (`inkKeymap.collisions.test.ts`) make adding a safe binding mechanical. `postApplyHints.ts` is already the place that tells users what just happened.
+**Effort notes / risks:** M. Not every action is invertible — the stack must record only actions with a real inverse and say so, rather than promising universal undo. Must not present itself as undo for pushed history. Session-scoped only; persisting it is a separate question.
+
+### [PRIORITY: P1] [EFFORT: M] feat(blame): `coco blame --explain` — attribute a line and explain why it changed
+**Category:** command
+**Gap:** `src/git/blameData.ts` and a `blame` workstation surface exist, but blame is TUI-only (no `blame` entry among the 20 commands mounted in `src/index.ts`) and purely mechanical — it reports who and when, never why.
+**Why it matters:** "Who wrote this and what were they thinking" is the single most common code-archaeology question, and it is precisely where an LLM adds something git cannot: reading the introducing commit, its neighbours, and the linked PR, then explaining intent. This is a differentiating bet rather than a parity fix — no other git CLI ships it, and coco already has every input.
+**Sketch:** New `src/commands/blame/{config,index,handler,prompt}.ts` — `coco blame <file> [--lines a:b] [--explain] [--json]`. Non-explain mode renders `blameData.ts` output. `--explain` resolves each blame sha's full commit via `logData.ts`, optionally the PR that merged it via `ForgeActions`, and asks for a per-range intent summary. Add an `E` binding to the blame surface for the same in-TUI.
+**Already-there leverage:** `blameData.ts`, `fileHistoryData.ts`, `logData.ts`, the blame surface, and the forge adapter for PR lookup are all shipped. A new `blameExplain` dynamic-model task slots into the existing `DynamicModelTask` table.
+**Effort notes / risks:** M. Cost control matters — a naive implementation makes one LLM call per blame sha; batch by introducing-commit and cap the range. Fits the layering cleanly (`git` data → `commands` handler).
+
+### [PRIORITY: P1] [EFFORT: M] feat(provider): promote prompt caching and reasoning effort to typed config
+**Category:** provider
+**Gap:** Both are reachable only through `service.fields` (`Object.assign(anthropicConfig, config.service.fields)`), so they are undiscoverable, unvalidated, absent from `schema.json`, and invisible to `doctor`. Nothing reads cache-hit usage metadata back — `UsageRecord` has no cached-token field.
+**Why it matters:** Prompt caching is the largest single cost lever available to coco's workload: the same system prompt and often the same diff summaries are resent across `commit`, `review`, and `changelog` in one session. Reasoning effort is the quality/cost dial users most want on `review` and `commitSplit`. Both are currently invisible.
+**Sketch:** Add `service.promptCache?: boolean` and `service.reasoningEffort?: 'minimal'|'low'|'medium'|'high'` to `src/lib/config/types.ts`; translate per provider in `providers/{anthropic,openai,azure,gemini,bedrock}.ts` (Anthropic `cache_control` breakpoints on the system block; OpenAI/Azure `reasoning_effort`; Gemini `thinkingConfig`), gated by a new `supportsPromptCache` / `supportsReasoningEffort` flag on `ProviderDefinition`. Record `cachedInputTokens` in `usageLedger.ts` and report hit-rate in `doctor --cost`. Regenerate `schema.json`.
+**Already-there leverage:** `ProviderDefinition` is the established home for per-provider capability facts; `DEFAULT_MAX_OUTPUT_TOKENS` shows the shared-default pattern; the observability layer already reads provider usage metadata for token counts, so cached-token extraction is the same code path.
+**Effort notes / risks:** M. Cache breakpoints must go on the stable prefix or they cost more than they save — needs prompt-template awareness, which is why this is M not S. Pairs naturally with the P0 cost work; ship pricing first so the win is measurable.
+
+### [PRIORITY: P1] [EFFORT: M] feat(distribution): Scoop / winget / AUR / Nix packaging plus a stale-version notice
+**Category:** distribution
+**Gap:** `packaging/` holds only `packaging/homebrew/coco.rb`, and `update-homebrew-tap.yml` is the only packaging fanout. `install.sh` requires Node 22+ and npm. No self-update or new-version notice exists (`grep -rni "self-update|update-notifier|latestVersion" src bin` is empty), and `--version` prints a bare string with no `--json`.
+**Why it matters:** CI already runs a Windows matrix cell, so Windows users are an acknowledged constituency with no native install path. Linux users get no distro package. And because there is no update notice, users sit on old versions indefinitely — which matters unusually much here, since `dynamicModels.ts` pins model ids that *retire* (the file's own comments record gpt-4.1 and claude-3.5 defaults starting to 404). A stale coco silently breaks.
+**Sketch:** Extend `bin/genHomebrewFormula.mjs` into a manifest generator covering a Scoop bucket, a winget manifest, a PKGBUILD, and a Nix flake; fan out from `publish-release.yml` the way the Homebrew tap update already does. Add `--version --json` (version, node, platform, resolved provider — `src/lib/buildInfo.ts` already carries `BUILD_VERSION`) and a cached once-daily registry check that prints a one-line notice, off under `--quiet`/non-TTY and disableable via config.
+**Already-there leverage:** `genHomebrewFormula.mjs` + `verifyRelease.mjs` + `update-homebrew-tap.yml` are a complete release-fanout precedent; `src/lib/buildInfo.ts` is generated at build time; `src/workstation/chrome/jsonStore.ts` gives a cache primitive for the last-checked timestamp.
+**Effort notes / risks:** M, mostly per-ecosystem tedium and review latency (winget/AUR need external submissions). The version check must never block a command, never run under `--json`/`--quiet`/CI, and must be opt-out — a chatty CLI is worse than a stale one.
+
+---
+
+# P2 — worthwhile, lower urgency
+
+### [PRIORITY: P2] [EFFORT: L] feat(stack): stacked-branch / stacked-PR support
+**Category:** command
+**Gap:** No notion of a branch stack. `grep -rni "stacked|prStack"` finds only history *row rendering* modes and `repoStackRuntime.ts` (multi-repo navigation, unrelated). `ForgeActions.createPullRequest` takes a single `base`, and nothing tracks parent/child relationships or restacks children after a parent rebase.
+**Why it matters:** Stacked development is where Graphite, `git-town`, and `spr` have carved out real adoption, and it is a workflow AI helps with disproportionately — decomposing a large change into a stack is exactly what `commit --split` already does one level down. This is the most differentiating bet in this report.
+**Sketch:** Add `src/git/stackData.ts` + `stackActions.ts` storing parent pointers in git config (`branch.<name>.coco-parent`, no new files, survives clone-independently), a `stack` workstation surface, and `coco stack {create,restack,submit,status}` where `submit` walks the stack calling `ForgeActions.createPullRequest` with each branch's parent as base. Reuse `commitSplit` planning to propose a stack from a large working set.
+**Already-there leverage:** `branchData.ts`/`branchActions.ts`, `rebaseActions.ts`/`rebasePlanActions.ts`, `worktreeActions.ts`, the split planner, and the multi-row surface pattern are all shipped. `configFiles.ts` already reads/writes git config sections.
+**Effort notes / risks:** L and genuinely risky — restack-after-rebase is where every stacking tool accumulates its bug reports, and conflict handling mid-restack must integrate with the (currently unimplemented) `coco resolve` work. Sequence after P0-1. Large new surface area for the keymap.
+
+### [PRIORITY: P2] [EFFORT: M] feat(workstation): `git notes` and sparse-checkout awareness
+**Category:** tui
+**Gap:** `grep -rni "git notes|sparse-checkout" src/` returns nothing. There is no notes read/write and no indication when the working tree is a partial checkout. (LFS *is* handled — `lfsAttributes.ts`, `lfsPointer.ts` — and submodules have a surface plus `submoduleDiff.ts`, so this is the remaining pair.)
+**Why it matters:** Notes are how teams attach review metadata and CI provenance to commits without rewriting them; a git client that hides them hides data. Sparse-checkout matters more: in a sparse cone, `status` and `diff` legitimately omit paths, and a UI that doesn't say so looks like it lost the user's files.
+**Sketch:** `src/git/notesData.ts` + `notesActions.ts` (`git notes list/show/add`), rendered as a `detail` surface tab with an add/edit action. For sparse: read `core.sparseCheckout` / `.git/info/sparse-checkout` in `src/git/statusData.ts` and surface a header chip via `headerChips.ts` plus an empty-state hint in `surfaceStates.ts`.
+**Already-there leverage:** The `detail` surface tab model, `headerChips.ts`, and `surfaceStates.ts` empty-state copy pipeline all exist. `lfsAttributes.ts` is the precedent for "read a git config/attributes fact and reflect it in chrome."
+**Effort notes / risks:** M. Notes refs are easy to get wrong across `refs/notes/*` namespaces; scope v1 to `refs/notes/commits`. The sparse-checkout half is closer to S and could ship first.
+
+### [PRIORITY: P2] [EFFORT: M] feat(watch): `coco watch` — continuous review and commit-draft daemon
+**Category:** command
+**Gap:** No watch mode anywhere. `src/workstation/chrome/refreshWatcher.ts` watches the repo, but only to refresh the TUI.
+**Why it matters:** The pre-commit-review idea in #1370 is one-shot and TUI-bound. A standing `coco watch --review` that reviews each save-quiesced change set, or `--draft` that keeps a commit message current as you stage, turns coco from a command you remember to run into ambient feedback. Natural companion to the editor-extension direction.
+**Sketch:** New `src/commands/watch/{config,index,handler}.ts` reusing `refreshWatcher`'s debounce/quiesce logic (extracted down into `src/lib/` to respect layering — `commands` may not import from `workstation`). Re-run `review`/`commit-draft` through `src/operations/agent/` on each settled change, with a diff-hash guard so an unchanged tree never triggers a call. `--json` line-delimited output for editor consumption.
+**Already-there leverage:** `refreshWatcher.ts` already solves rename-survival and debounce (with a documented flaky test to inherit carefully); `src/operations/agent/generate.ts` is already the reusable non-interactive generation entry point; `diffSummaryCache.ts` gives cheap change detection.
+**Effort notes / risks:** M. Cost containment is the whole design problem — a watch loop that fires an LLM call per keystroke is a bill. Requires the hash guard, a min-interval, and ideally the P0 budget cap landing first. The `refreshWatcher` extraction must move *down* into `lib/`, never sideways.
+
+### [PRIORITY: P2] [EFFORT: S] feat(agent): read `AGENTS.md` / steering files as a first-class context source
+**Category:** agent-mcp
+**Gap:** `src/operations/agent/context.ts` assembles diff/status/branch context. Nothing reads `AGENTS.md`, `CLAUDE.md`, `.kiro/steering/**`, or `CONTRIBUTING.md` — so coco's own generation has no access to the house style that this very repo documents for other agents.
+**Why it matters:** The most common complaint about AI commit messages and reviews is that they ignore project conventions. Every convention coco needs is already written down in a conventional location. It is also pleasingly self-referential: coco would follow its own `AGENTS.md` "House style" section.
+**Sketch:** Add `resolveProjectConventions(root)` to `src/operations/agent/context.ts` — read a bounded allowlist of paths, truncate to a token budget, hash for provenance — and thread the text into the `commit`/`review`/`changelog` prompt templates as a new `conventions_context` variable (exactly how `language_context` and `branch_name_context` already degrade to `''` when absent).
+**Already-there leverage:** `languageContext.ts` is the precise template for an optional prompt-variable helper. The agent layer already computes SHA-256 provenance for supplied context, which is what makes trusting a repo file auditable. `enforcePromptBudget` already handles truncation.
+**Effort notes / risks:** S, but it brushes a real invariant: MCP tools deliberately do **not** execute repository-defined prompts (`server.ts:141,175`). Reading a markdown file as *context* is not executing a prompt, but it is repository-controlled text entering the prompt — so it must be gated behind the existing `trustRepositoryConfig` flag (already threaded for `config.language` at `generateCommitDraft.ts:297`) and default off for MCP.
+
+### [PRIORITY: P2] [EFFORT: M] feat(i18n): take `language` beyond a one-sentence prompt hint
+**Category:** distribution
+**Gap:** `language` is implemented entirely by `getLanguageContext` (`src/lib/langchain/utils/languageContext.ts`), which returns the single sentence "Write the {task} in {language}." Only four handlers consume it (`commit`, `changelog`, `recap`, `review`) — `amend` does not, despite writing a commit message. All CLI chrome, `--help` text, error messages, TUI labels, footer hints, help overlay, idle tips, and `surfaceStates.ts` empty-state copy are hardcoded English.
+**Why it matters:** The config key advertises localization the product doesn't have. A non-English team gets Spanish commit messages inside an entirely English UI, and gets English again the moment they run `amend`. Either deepen it or scope the key honestly.
+**Sketch:** Two separable issues. (1) **Consistency (S):** thread `getLanguageContext` through `src/commands/amend/handler.ts` and any other generating handler, and add a test asserting every generation handler consumes it. (2) **UI locale (M):** introduce `src/lib/i18n/` with a flat message catalog, migrate the highest-value strings first (`surfaceStates.ts`, `inkKeymap.ts` footer hints, help overlay sections, `aiErrors.ts`), keep English as the fallback, and add a lint rule against new inline user-facing literals in those files.
+**Already-there leverage:** Empty-state and error copy is already centralized (`surfaceStates.ts`, `aiErrors.ts`, `idleTips.ts`, `forgeNouns.ts`) — the hard consolidation work is done, which is what makes catalog extraction tractable at all.
+**Effort notes / risks:** Part 1 is S and should ship immediately as a standalone parity fix. Part 2 is M and will collide with every render snapshot test; it also affects fixed-width TUI layout, since translated strings are longer — `layout.ts` width budgeting assumes English lengths.
+
+### [PRIORITY: P2] [EFFORT: S] feat(observability): report diff-summary cache hit rate in `doctor --cost`
+**Category:** observability
+**Gap:** `src/lib/parsers/default/utils/diffSummaryCache.ts` has `readDiffSummary`, `writeDiffSummary`, and a `touchDiffSummary` whose docblock literally says it runs "when a read returned a hit" — the hit signal exists and is discarded. `doctor --cost` reports calls, tokens, and latency, never cache effectiveness. `coco cache` manages the cache without measuring it.
+**Why it matters:** The cache is the second-biggest cost lever after prompt caching, and nobody can tell whether it's working. A user whose cache is thrashing (because they run from varying subdirectories, or their model id keeps changing, both of which change the cache key via `diffSummaryKey(diff, model, promptHash)`) has no signal at all — and the file's own comments record that a subdirectory-related cache-miss bug already happened once.
+**Sketch:** Add an optional `cacheHit?: boolean` to `UsageRecord` in `usageLedger.ts`, set it where the parser consults `readDiffSummary`, aggregate as a hit-rate column in `summarizeUsageByTask`, and render it in `doctor/handler.ts`. Add "cache hit rate below X%" as a `doctor/checks.ts` warning with a fix hint.
+**Already-there leverage:** Hit/miss is already known at the call site; `UsageRecord` is already an append-only metadata-only line format that tolerates new optional fields (`surface` was added the same way, with a documented back-compat default); the aggregation and rendering pipeline needs one more column.
+**Effort notes / risks:** S. A boolean is metadata, so the read-only/no-content telemetry invariant holds. Ship alongside the P0 cost work so `doctor --cost` grows once, not twice.
+
+### [PRIORITY: P2] [EFFORT: M] feat(forge): CODEOWNERS awareness and required-reviewer surfacing
+**Category:** forge parity
+**Gap:** `grep -rni CODEOWNERS src/` returns nothing. `reviewDecision` — the field that would carry required-review state — is hard-coded `undefined` on GitLab, Bitbucket, and Gitea (`gitlabListData.ts:177,314`, `bitbucketListData.ts:144`, `giteaListData.ts:127`), so even the read-only signal only works on GitHub.
+**Why it matters:** "Who must approve this, and are they blocking?" decides whether a PR row in triage is actionable. Without it, `coco ui`'s triage view ranks a PR that needs one specific reviewer identically to one that needs nothing. On three of four forges coco can't even say whether review is satisfied.
+**Sketch:** Two halves. (a) `src/git/codeowners.ts` — parse `.github/CODEOWNERS` / `CODEOWNERS` / `docs/CODEOWNERS` with `minimatch` (already a dependency) and map changed paths to owners; surface owners in the `pullRequest` and `diff` surfaces and as a `pr create` reviewer suggestion. (b) Populate `reviewDecision` for the other three forges: GitLab approval rules (`/approval_state`), Gitea `/reviews`, Bitbucket participant approvals — the raw data is already fetched by the detail fetchers, just not normalized into the list row.
+**Already-there leverage:** `minimatch` is a dependency; `pullRequestDetailData.ts` and its three siblings already fetch approval/review payloads for the inspector, so half of (b) is a normalization pass over data already in memory. `headerChips.ts` already renders review state for GitHub.
+**Effort notes / risks:** M. CODEOWNERS is a deceptively fiddly format (ordering, negation, team handles that can't be resolved without an API call) — v1 should resolve patterns and show raw handles without expanding teams. Populating `reviewDecision` per forge must keep the GitHub vocabulary as the normalized target so surfaces stay provider-blind.
+
+---
+
+## Suggested sequencing
+
+1. **Immediately:** P0-6 (bench CI gate, S) and P0-2 (draft→ready, S) — days, not weeks, and both are visible.
+2. **Then the money cluster:** P0-3 (dollar cost + budgets) → P0-4 (structured output) → P1 prompt caching → P2 cache hit rate. Land pricing first so every subsequent win is measurable in the same units.
+3. **Then the flagship:** P0-1 (`coco resolve`) as ~4 sequenced PRs against the existing spec.
+4. **Then forge parity:** P0-7 (Bitbucket diffs) → P1 checks/auto-merge → P1 review threads → P1 Azure DevOps / Bitbucket Server.
+5. **Defer:** P2-1 (stacks) until `coco resolve` exists, since restack conflict handling depends on it.


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @gfargo :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
Full-repository audit against `main` at `c36ad0a` (`chore: release v0.84.1`). Documentation only — **no source changes**.

Lands `docs/audit-0.84.1/` with an index plus five reports: **77 bug findings** (1 critical, 17 high, 41 medium, 18 low) and **28 feature proposals**, written as ready-to-file issue drafts.

## Why this exists

The validation gate was run first, in full, and it passes clean:

| Check | Result |
| --- | --- |
| `npx tsc --noEmit -p tsconfig.json` | clean, exit 0 |
| `npx eslint src bin e2e` | 42 problems — **0 errors**, all `react-hooks/exhaustive-deps` |
| `TZ=UTC NODE_OPTIONS=--experimental-vm-modules npx jest` | 391 passed / 3 skipped of 394 suites; 5596 tests; 68 snapshots; exit 0 |

So every finding is something the current gate cannot see, and each one also points at a specific gate gap — no assertion that layout panes tile to the terminal width, no unmount-cleanup lint for `AbortController`/timer refs, no `config.ts`-vs-`handler.ts` flag reconciliation test, no ban on `.padEnd` in width-sensitive surfaces, no unused-production-dependency check, no stdout-purity test for `--json`.

All 42 eslint warnings were individually triaged: 34 benign, 6 benign-by-design, **2 real**.

## Contents

| Report | Scope | Findings |
| --- | --- | --- |
| `bugs-workstation.md` | `src/workstation/**` | 19 (1 critical, 6 high, 9 medium, 3 low) |
| `bugs-commands.md` | `src/commands/**` + `src/index.ts` | 25 (5 high, 13 medium, 7 low) |
| `bugs-git-forge.md` | `src/git/**` + forge adapter | 22 (5 high, 12 medium, 5 low) |
| `bugs-lib.md` | `src/lib/**` | 11 (1 high, 7 medium, 3 low) |
| `feature-scoping.md` | forge/provider matrices + 28 proposals | 9 P0, 12 P1, 7 P2 |

## Highest-priority findings

1. **`--ignoredFiles` wipes the default ignore list** — verified empirically: the flag collapses 39 ignore entries to 1, re-admitting `.env`, `.env.local`, and `.env.production.local` to the model prompt. `mergeIgnoreLists` runs one statement before the argv spread that overwrites it.
2. **`config set …apiKey` writes 0644, non-atomically** — provider key readable by any local user; `writeFileAtomic` (0600, tmp+rename) already exists and is unused.
3. **`commit --split` apply resets the index and never restores it** — a hook rejecting one group leaves a curated index empty, with no warning and no recovery path. The co-located test encodes this.
4. **Pane widths can exceed terminal columns** (only critical) — reproduced numerically: at 100 cols, `Tab` to sidebar + `?` sums to 116.
5. **Default router drops `--json`/`--quiet`** — `coco --commit --json` performs a real interactive commit instead of printing a draft.

## Headline feature finding

`.kiro/specs/ai-conflict-resolution/` is **fully designed with 0 of 15 tasks implemented** — `src/commands/resolve/` doesn't exist, `conflictResolve` never entered the `DynamicModelTask` union, `ProposalsSchema` has no `confidence` field, and `conflictRegionActions.ts` has no conflict-marker guard on writes (a live correctness hazard in the shipped TUI path). By contrast `review-autofix-agent/` shipped complete, all 15 tasks.

The feature report also derives two reference tables from the code: a forge capability × provider matrix (25 `ForgeActions` methods × 4 facades, file:line for every refusal) and a provider registry coverage table — which surfaced that OpenAI-compatible endpoints reached via `baseURL` inherit OpenAI's token accounting, *undercounting* and feeding straight into `enforcePromptBudget`.

## Scope discipline

- The 15 open issues were read first; #1830, #1829, #1828, #1827, #1826, #1825, #1824, #1823, #1822, #1820, #1819, #1722, #1371, #1370, and #1241 are deliberately not re-reported.
- Features that already ship were explicitly excluded to avoid mis-proposals: shell completions, split diff, LFS handling, multi-repo navigation, and `review --pr --comment`.
- Every finding cites `path:line` and carries an explicit confidence level. One is `medium` (Windows `cmd /c start` quoting, needs a Windows host); six are `needs-verification` and state the exact check that would settle them.

## Suggested next step

`README.md` includes a "file these first" top-10 and a clustering recommendation — 77 findings should become roughly 25 issues, since several (argument-injection guard parity, `--json` contract hardening, cell-width correctness, unmount cleanup, failure-caching/retry, mutually exclusive flags, dependency hygiene) share a single root cause and fix.

## Testing

Documentation only. Full gate re-run on this branch to confirm no drift: `tsc --noEmit` clean, eslint 0 errors, 391/391 jest suites passing.