### PR TITLE
ci: reduce GitHub Actions runner usage

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -21,11 +21,16 @@ on:
       - synchronize
       - labeled
 
+concurrency:
+  group: ai-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   review:
     # Label-gated: only runs when the PR carries the "claude review" label.
     if: ${{ contains(github.event.pull_request.labels.*.name, 'claude review') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,20 +12,22 @@ on:
 permissions:
   contents: read
 
-# Cancel in-progress runs for the same PR/branch when a new push lands.
-# Saves CI minutes and prevents stale results from racing fresh ones.
+# Keep only the newest run for a PR or branch. This is especially important on
+# main, where merge batches can otherwise start several copies of the gate.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # Cheap, fast-failing job — runs in ~5s and gives near-instant
-  # feedback on style violations before we wait on the full test
-  # suite. Doesn't block the test/build jobs (they run in parallel)
-  # but a lint failure surfaces on PRs immediately.
-  lint:
-    name: Lint
+  # Static analysis, packaging, and the packaged-CLI smoke test share one
+  # checkout/install/build. Keeping smoke beside build removes the transient
+  # dist artifact and a second dependency installation.
+  quality:
+    name: Quality & package
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      TZ: UTC
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,126 +43,18 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Lockfile hygiene
-        # Catches accidental npm usage in a yarn project. The
-        # `yarn install --frozen-lockfile` above already fails on
-        # drift, but this guard makes the failure mode obvious.
         run: test -f yarn.lock && test ! -f package-lock.json
 
       - name: Lint
         run: npm run lint
 
-  # Test matrix runs in parallel with lint and build. Coverage is
-  # collected on the primary OS+Node combo only (Ubuntu / 22.22.2)
-  # to keep upload bandwidth + Codecov processing time reasonable;
-  # the other matrix cells still run the full test suite, just
-  # without coverage instrumentation.
-  test:
-    name: Test (Node ${{ matrix.node-version }} on ${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    # Experimental matrix cells (currently Windows) surface failures
-    # without blocking the PR until they're reliably green.
-    continue-on-error: ${{ matrix.experimental || false }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-        node-version:
-          # Pinned to the floor declared in package.json engines
-          # (^22.22.2 || ^24.15.0 || >=26.0.0). The floor moved when
-          # ini@7 + commitlint@21 landed; CI exercises both LTS lines
-          # at the lower bound so a future transitive bump can't
-          # silently raise the floor without us noticing here first.
-          - 22.22.2
-          - 24.15.0
-        include:
-          # macOS smoke run on the primary Node version. Catches
-          # platform-specific issues (path separators, signal
-          # handling, TTY behaviour) that Linux-only CI would miss.
-          # Most coco users are on macOS, so a green Linux run isn't
-          # enough confidence on its own.
-          - os: macos-latest
-            node-version: 22.22.2
-          # Windows matrix cell (0.71). The workflow has long flagged
-          # path-separator concerns; this exercises them. Marked
-          # experimental (continue-on-error above) so newly-surfaced
-          # Windows-only failures don't block PRs while we stabilize.
-          # Promote to a required cell once it's reliably green.
-          - os: windows-latest
-            node-version: 22.22.2
-            experimental: true
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: yarn
-          cache-dependency-path: yarn.lock
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Run Jest tests with coverage
-        # `--coverage` enables istanbul instrumentation and writes
-        # lcov + json-summary output to coverage/. Thresholds in
-        # jest.config.ts are enforced automatically.
-        run: npm run test:coverage
-
-      - name: Upload coverage to Codecov
-        # Only upload from the canonical job (Linux + lowest Node).
-        # Multiple uploads from the matrix would land as separate
-        # reports and confuse Codecov's PR comments.
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '22.22.2'
-        uses: codecov/codecov-action@v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage/lcov.info
-          fail_ci_if_error: false
-          verbose: true
-
-      - name: Upload coverage artifact
-        # Persist coverage data from the canonical job so we can
-        # inspect it directly even if Codecov is down or
-        # unconfigured.
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '22.22.2'
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage
-          path: coverage/
-          retention-days: 14
-
-  # Build job runs in parallel with test and lint. Validates the
-  # rollup pipeline, schema generation, package contents, and the
-  # release-it dry run. Doesn't run jest — that's the test job's job.
-  build:
-    name: Build & package
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.22.2
-          cache: yarn
-          cache-dependency-path: yarn.lock
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+      - name: Typecheck
+        run: npx tsc --noEmit -p tsconfig.json
 
       - name: Build
         run: npm run build
 
       - name: Check generated schema drift
-        # The schema is generated from src/lib/schema.ts at build
-        # time. If a type changed but the committed schema.json
-        # didn't, the user's editor will hint against stale schema.
-        # Fail loudly here so the PR author regenerates.
         run: git diff --exit-code -- schema.json src/lib/schema.ts
 
       - name: Verify package dry run
@@ -169,46 +63,7 @@ jobs:
       - name: Validate release dry run
         run: npm run release:dry-run
 
-      - name: Upload built dist artifact
-        # Reused by the smoke job so we don't double-build.
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: |
-            dist/
-            schema.json
-          retention-days: 7
-
-  # Smoke test runs the packaged CLI against a temporary git repo.
-  # Depends on `build` so we test against the real bundled output,
-  # not the tsx-driven source. Catches issues that only show up
-  # post-bundling (missing externs, wrong CJS/ESM exports, etc.).
-  smoke:
-    name: Packaged CLI smoke
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.22.2
-          cache: yarn
-          cache-dependency-path: yarn.lock
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Download built dist
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-
       - name: Configure git identity
-        # smokeCli.ts spins up temp repos and commits to them; CI
-        # runners don't have a global git identity by default.
         run: |
           git config --global user.name "Coco CI"
           git config --global user.email "ci@example.com"
@@ -216,15 +71,15 @@ jobs:
       - name: Run packaged CLI smoke
         run: npm run test:cli
 
-  # PTY end-to-end journeys (#1424): boots the built workstation TUI in
-  # a real pseudo-terminal against scripted fixture repos, sends
-  # keystrokes, and asserts on the rendered screen text. Depends on
-  # `build` because the harness drives dist/index.js (fast startup
-  # inside the PTY), same as the smoke job.
-  e2e:
-    name: PTY e2e journeys
-    needs: build
+  # Coverage is collected once, on the canonical Linux/Node floor. Integration
+  # tests are excluded from that Jest invocation and then run once in their own
+  # step, reusing the same checkout and dependency installation.
+  tests:
+    name: Tests & coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 12
+    env:
+      TZ: UTC
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -239,136 +94,23 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Download built dist
-        uses: actions/download-artifact@v4
+      - name: Run unit tests with coverage
+        run: npm run test:coverage -- --testPathIgnorePatterns=integration
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v6
         with:
-          name: dist
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/lcov.info
+          fail_ci_if_error: false
+          verbose: true
 
       - name: Configure git identity
-        # Fixture repos are created by @gfargo/git-scenarios inside the
-        # jest process, which uses the runner's real HOME. (The TUI
-        # itself runs under a throwaway HOME the harness provisions.)
-        run: |
-          git config --global user.name "Coco CI"
-          git config --global user.email "ci@example.com"
-
-      - name: Run PTY e2e journeys
-        run: npm run test:e2e
-
-  # Visual-regression stills (#1424, second half): captures the VHS
-  # recipes that are the visual counterpart of the PTY e2e journeys
-  # (bin/screenshot/recipes.ts — ui-help-overlay-filter, ui-stash-diff,
-  # ui-search-filter, ui-history-pr-ready) and uploads them as a build
-  # artifact for PR review. Deliberately artifact-only for now, not a
-  # pass/fail pixel diff against committed baselines — that needs a
-  # tolerance-tuned diff tool and a baseline-image storage decision
-  # (repo bloat vs. LFS vs. external store) this slice doesn't make.
-  # Promote to a real diff gate once the recipe set stabilizes.
-  visual-regression:
-    name: Visual regression stills (VHS)
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.22.2
-          cache: yarn
-          cache-dependency-path: yarn.lock
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Download built dist
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-
-      - name: Install VHS + system deps (ttyd, ffmpeg)
-        # charmbracelet/vhs-action's bundled ffmpeg installer failed here
-        # ("Failed to install ffmpeg", no further detail — upstream
-        # installer issue, not a config problem on our end). Install each
-        # piece ourselves instead: ffmpeg via apt (reliable on
-        # ubuntu-latest), ttyd + vhs as static binaries straight from
-        # their GitHub releases, so the install is fully in our control.
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y ffmpeg
-
-          sudo curl -fsSL -o /usr/local/bin/ttyd \
-            https://github.com/tsl0922/ttyd/releases/latest/download/ttyd.x86_64
-          sudo chmod +x /usr/local/bin/ttyd
-
-          vhs_url=$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
-            https://api.github.com/repos/charmbracelet/vhs/releases/latest \
-            | jq -r '.assets[] | select(.name | endswith("_Linux_x86_64.tar.gz")) | .browser_download_url')
-          curl -fsSL -o /tmp/vhs.tar.gz "$vhs_url"
-          mkdir -p /tmp/vhs-install
-          tar -xzf /tmp/vhs.tar.gz -C /tmp/vhs-install --strip-components=1
-          sudo mv /tmp/vhs-install/vhs /usr/local/bin/vhs
-          sudo chmod +x /usr/local/bin/vhs
-
-          vhs --version
-          ttyd --version
-          ffmpeg -version | head -1
-
-      - name: Configure git identity
-        # @gfargo/git-scenarios spins up fixture repos and commits to them.
-        run: |
-          git config --global user.name "Coco CI"
-          git config --global user.email "ci@example.com"
-
-      - name: Capture e2e-journey stills
-        run: |
-          npm run screenshot -- --recipe ui-history-pr-ready
-          npm run screenshot -- --recipe ui-help-overlay-filter
-          npm run screenshot -- --recipe ui-search-filter
-          npm run screenshot -- --recipe ui-stash-diff
-
-      - name: Upload stills artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: visual-regression-stills
-          path: .screenshots/*.png
-          retention-days: 14
-
-  # Integration tests exercise the real CLI / data paths end-to-end via
-  # the dedicated `test:integration` script (previously unused in CI).
-  # The non-live suite always runs; the live GitLab suite is gated on
-  # COCO_GITLAB_IT + a test project and self-skips unless those repo
-  # secrets are configured, so the default flow needs no GitLab creds.
-  integration:
-    name: Integration tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.22.2
-          cache: yarn
-          cache-dependency-path: yarn.lock
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Configure git identity
-        # commands.integration spins up temp repos and commits to them.
         run: |
           git config --global user.name "Coco CI"
           git config --global user.email "ci@example.com"
 
       - name: Run integration tests
-        # Live GitLab tests activate only when these secrets are set;
-        # otherwise they self-skip (describe.skip).
         env:
           COCO_GITLAB_IT: ${{ secrets.COCO_GITLAB_IT }}
           COCO_GITLAB_TEST_PROJECT: ${{ secrets.COCO_GITLAB_TEST_PROJECT }}

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -6,17 +6,20 @@
 name: DevSkim
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
   schedule:
     - cron: '43 6 * * 6'
 
+concurrency:
+  group: devskim-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: DevSkim
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -1,0 +1,91 @@
+name: Full CI
+
+# Cross-platform and PTY coverage is deliberately off the per-commit hot path.
+# Run it weekly, on demand, or by adding the `full-ci` label to a pull request.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '23 7 * * 1'
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: full-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  platform:
+    name: Platform (Node ${{ matrix.node-version }} on ${{ matrix.os }})
+    if: github.event_name != 'pull_request' || github.event.label.name == 'full-ci'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: ${{ matrix.timeout }}
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            node-version: 24.15.0
+            timeout: 10
+            experimental: false
+          - os: macos-latest
+            node-version: 22.22.2
+            timeout: 25
+            experimental: false
+          - os: windows-latest
+            node-version: 22.22.2
+            timeout: 15
+            experimental: true
+    env:
+      TZ: UTC
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+          cache-dependency-path: yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run unit tests
+        run: npm run test:unit
+
+  e2e:
+    name: PTY e2e journeys
+    if: github.event_name != 'pull_request' || github.event.label.name == 'full-ci'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      TZ: UTC
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.22.2
+          cache: yarn
+          cache-dependency-path: yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build packaged CLI
+        run: npm run build
+
+      - name: Configure git identity
+        run: |
+          git config --global user.name "Coco CI"
+          git config --global user.email "ci@example.com"
+
+      - name: Run PTY e2e journeys
+        run: npm run test:e2e

--- a/.github/workflows/main-broken-alert.yml
+++ b/.github/workflows/main-broken-alert.yml
@@ -1,35 +1,61 @@
 name: Main broken alert
 
-# Post-merge safety net (OSS-459 / coco#1422): two independently-green PRs
-# can still combine into a red main. This watches completed `CI` runs and
-# files/updates a GitHub issue within minutes when a push to `main` goes
-# red, so the break is loud immediately instead of surfacing on the next
-# PR's CI. Uses `workflow_run` (rather than a job in ci.yml) so this
-# script always runs off the default-branch version of itself, regardless
-# of what triggered the CI run.
+# File/update the issue immediately when a main CI run fails. Successful runs
+# are reconciled once per day instead of starting a one-minute job after every
+# green merge.
 on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
+  schedule:
+    - cron: '43 7 * * *'
+  workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   issues: write
 
 jobs:
   alert:
-    if: github.event.workflow_run.head_branch == 'main'
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.conclusion == 'failure')
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/github-script@v7
         with:
           script: |
-            // Marker is an HTML comment unique to this workflow, so dedup
-            // can't collide with an unrelated `bug`-labeled issue.
             const marker = '<!-- main-broken-alert -->'
-            const conclusion = context.payload.workflow_run.conclusion
-            const runUrl = context.payload.workflow_run.html_url
-            const sha = context.payload.workflow_run.head_sha
+
+            let conclusion
+            let runUrl
+            let sha
+
+            if (context.eventName === 'workflow_run') {
+              conclusion = context.payload.workflow_run.conclusion
+              runUrl = context.payload.workflow_run.html_url
+              sha = context.payload.workflow_run.head_sha
+            } else {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'ci.yml',
+                branch: 'main',
+                status: 'completed',
+                per_page: 1,
+              })
+              const latest = data.workflow_runs[0]
+              if (!latest) {
+                core.info('No completed CI run found for main.')
+                return
+              }
+              conclusion = latest.conclusion
+              runUrl = latest.html_url
+              sha = latest.head_sha
+            }
 
             const { data: openIssues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
@@ -53,7 +79,7 @@ jobs:
                   repo: context.repo.repo,
                   title: '🔴 main is broken — CI failing on push',
                   labels: ['bug'],
-                  body: `${marker}\nCI failed on a push to \`main\` (${sha}).\n\nFailed run: ${runUrl}\n\nLikely cause: two independently-green PRs combined into a broken main (see OSS-459 / coco#1422). Investigate and fix or revert before building on top of this commit.`,
+                  body: `${marker}\nCI failed on a push to \`main\` (${sha}).\n\nFailed run: ${runUrl}\n\nLikely cause: two independently-green PRs combined into a broken main. Investigate and fix or revert before building on top of this commit.`,
                 })
               }
             } else if (conclusion === 'success' && existing) {

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -20,6 +20,7 @@ jobs:
   verify:
     name: Verify release package
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -44,6 +45,7 @@ jobs:
   publish:
     name: Publish package to npm
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: verify
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish }}
 

--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -23,9 +23,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: update-homebrew-tap
+  cancel-in-progress: true
+
 jobs:
   update-tap:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout coco
         uses: actions/checkout@v4

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,0 +1,90 @@
+name: Visual Regression
+
+# Captures are review artifacts, not a pass/fail pixel gate. Generate them only
+# on demand or when a reviewer adds the `visual-ci` label to a pull request.
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: visual-regression-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  capture:
+    name: VHS stills
+    if: github.event_name != 'pull_request' || github.event.label.name == 'visual-ci'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      TZ: UTC
+      VHS_VERSION: 0.11.0
+      TTYD_VERSION: 1.7.7
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.22.2
+          cache: yarn
+          cache-dependency-path: yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build packaged CLI
+        run: npm run build
+
+      - name: Install pinned VHS dependencies
+        run: |
+          set -euo pipefail
+
+          if ! command -v ffmpeg >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y ffmpeg
+          fi
+
+          curl -fsSL -o /tmp/ttyd \
+            "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.x86_64"
+          echo "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55  /tmp/ttyd" \
+            | sha256sum -c -
+          sudo install -m 0755 /tmp/ttyd /usr/local/bin/ttyd
+
+          curl -fsSL -o /tmp/vhs.tar.gz \
+            "https://github.com/charmbracelet/vhs/releases/download/v${VHS_VERSION}/vhs_${VHS_VERSION}_Linux_x86_64.tar.gz"
+          echo "99cb634587eaae0473c1ea377db80c3a048c27f99fe0a7febb1a1e8cb7ee5009  /tmp/vhs.tar.gz" \
+            | sha256sum -c -
+          mkdir -p /tmp/vhs-install
+          tar -xzf /tmp/vhs.tar.gz -C /tmp/vhs-install --strip-components=1
+          sudo install -m 0755 /tmp/vhs-install/vhs /usr/local/bin/vhs
+
+          vhs --version
+          ttyd --version
+          ffmpeg -version
+
+      - name: Configure git identity
+        run: |
+          git config --global user.name "Coco CI"
+          git config --global user.email "ci@example.com"
+
+      - name: Capture e2e-journey stills
+        run: |
+          npm run screenshot -- --recipe ui-history-pr-ready
+          npm run screenshot -- --recipe ui-help-overlay-filter
+          npm run screenshot -- --recipe ui-search-filter
+          npm run screenshot -- --recipe ui-stash-diff
+
+      - name: Upload stills artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-regression-stills
+          path: .screenshots/*.png
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 3

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -65,29 +65,32 @@ npm run screenshot:sync          # regenerate all marketing assets → .www
 
 ## CI (`.github/workflows/ci.yml`)
 
-Four core jobs run in parallel (the workstation lints/tests/builds/smoke-tests on
-every PR), plus an optional integration job. Concurrency cancels stale runs per ref.
+The per-commit gate is intentionally Linux-only and uses two parallel jobs. Stale
+runs are cancelled per ref, and every job has an explicit timeout.
 
-- **`lint`** — `eslint src bin`; also asserts `yarn.lock` exists and
-  `package-lock.json` does not (yarn-only guard).
-- **`test`** — matrix: Ubuntu Node 22.22.2 + 24.15.0 (required), macOS Node 22.22.2
-  (required), Windows Node 22.22.2 (experimental, `continue-on-error`). Runs
-  `npm run test:coverage`; uploads coverage to Codecov once (Ubuntu/22).
-- **`build`** — `npm run build`, asserts no `schema.json` drift, runs
-  `release:dry-run`, and uploads `dist/` as an artifact the smoke job reuses.
-- **`smoke`** (needs `build`) — downloads `dist/`, sets a git identity, runs
-  `npm run test:cli` (`bin/smokeCli.ts`) against the real bundled output to catch
-  packaging/export regressions tsc can't see.
-- **`integration`** (non-blocking) — `npm run test:integration`; gated on
-  `COCO_GITLAB_IT` / `COCO_GITLAB_TEST_PROJECT` secrets (self-skips without them).
+- **`quality`** — one checkout/install for lockfile hygiene, ESLint, standalone
+  TypeScript checking, build + schema drift, package/release dry runs, and the
+  packaged CLI smoke test. Build and smoke share the workspace, so no transient
+  `dist` artifact is needed.
+- **`tests`** — unit tests with coverage on Ubuntu / Node 22.22.2, Codecov upload,
+  then the integration suites without re-running them inside coverage. Live GitLab
+  cases remain gated on `COCO_GITLAB_IT` / `COCO_GITLAB_TEST_PROJECT`.
 
 Other workflows:
 
-- **`devskim.yml`** — Microsoft DevSkim security scan (push/PR to main + weekly),
+- **`full-ci.yml`** — the Node 24 / macOS / Windows matrix plus PTY e2e journeys;
+  runs weekly, manually, or when a PR receives the `full-ci` label. Platform cells
+  run unit tests without coverage instrumentation; Windows remains experimental.
+- **`visual-regression.yml`** — deterministic VHS still capture, manual or gated by
+  the `visual-ci` PR label. Pinned/checksummed VHS dependencies and short artifact
+  retention keep it reproducible without putting rendering on the hot path.
+- **`devskim.yml`** — Microsoft DevSkim security scan (PR to main + weekly),
   SARIF → GitHub Security tab, with test/fixture/generated paths excluded.
 - **`ai-review.yml`** — `anthropics/claude-code-action` review, gated on the
   `claude review` label; focuses on correctness, CLI-injection/secret-exposure
   security, and forge-abstraction parity. Needs `ANTHROPIC_API_KEY`.
+- **`main-broken-alert.yml`** — files/updates the main-broken issue immediately on
+  failure and reconciles recovery daily, avoiding a runner job after every green push.
 - **`publish-release.yml`** — verify (`npm test` + dry-run) then `npm publish`,
   triggered manually with a `publish` input.
 - **`update-homebrew-tap.yml`** — on release, polls npm for the new version,


### PR DESCRIPTION
## Summary

- consolidate required CI from nine runner jobs to two Ubuntu jobs
- move platform, PTY, and VHS checks to weekly, manual, or label-gated workflows
- remove duplicate scans and artifacts, cancel stale work, and cap job runtimes
- make visual artifacts deterministic and ensure hidden screenshots upload correctly

## Why

The July usage audit found 751 CI workflow runs consuming 17,714 raw runner-minutes, with coverage repeated across the entire platform matrix and visual captures running on every change. This keeps required feedback while moving expensive compatibility and visual checks off the per-commit path.

## Validation

- actionlint and YAML parsing
- npm run lint (0 errors; existing warnings only)
- npx tsc --noEmit -p tsconfig.json
- unit coverage: 389 suites / 5,567 tests passed
- integration: 59 passed; 9 credential-gated tests skipped
- build and generated-schema drift check
- package and release dry runs
- packaged CLI smoke test

## Follow-ups

- Local PTY validation currently has three pre-existing failures in cherryPickRange and resetUndo; 33/36 journeys pass. PTY runs are retained in Full CI, now off the per-commit path.
- Remove Ruby from the repository CodeQL language configuration in GitHub settings; that setting is managed outside these workflow files.