### PR TITLE
feat(workstation): branch merge, reset, sync, and push sub-choice operations

### DIFF
--- a/src/git/branchActions.test.ts
+++ b/src/git/branchActions.test.ts
@@ -1,29 +1,33 @@
 import {
-  checkoutBranch,
-  checkoutBranchByName,
-  createBranch,
-  deleteBranch,
-  deleteBranches,
-  isBranchCheckedOutElsewhereError,
-  isBranchNotFullyMergedError,
-  isDirtyWorktreeCheckoutError,
-  parseCheckedOutWorktreePath,
-  fetchBranch,
-  fetchRemotes,
-  getBranchActionRefs,
-  pullBranch,
-  pullCurrentBranch,
-  pushBranch,
-  pushCurrentBranch,
-  renameBranch,
-  setUpstream,
-  forcePushBranch,
-  forcePushCurrentBranch,
-  isDivergedPullError,
-  isNonFastForwardPushError,
-  pullCurrentBranchMerge,
-  pullCurrentBranchRebase,
-  restoreDeletedBranch,
+    checkoutBranch,
+    checkoutBranchByName,
+    createBranch,
+    deleteBranch,
+    deleteBranches,
+    isBranchCheckedOutElsewhereError,
+    isBranchNotFullyMergedError,
+    isDirtyWorktreeCheckoutError,
+    parseCheckedOutWorktreePath,
+    fetchBranch,
+    fetchRemotes,
+    getBranchActionRefs,
+    pullBranch,
+    pullCurrentBranch,
+    pushBranch,
+    pushCurrentBranch,
+    renameBranch,
+    setUpstream,
+    forcePushBranch,
+    forcePushCurrentBranch,
+    isDivergedPullError,
+    isNonFastForwardPushError,
+    pullCurrentBranchMerge,
+    pullCurrentBranchRebase,
+    restoreDeletedBranch,
+    mergeBranch,
+    canFastForward,
+    resetCurrentBranchToRef,
+    isResetBackward,
 } from './branchActions'
 import { BranchRef } from './branchData'
 
@@ -708,5 +712,146 @@ describe('log branch actions', () => {
       expect(result.message).toContain('Only local branches')
       expect(git.raw).not.toHaveBeenCalled()
     })
+  })
+})
+
+
+describe('mergeBranch', () => {
+  it('merges a branch into current with a standard merge', async () => {
+    const git = { merge: jest.fn().mockResolvedValue({}) }
+    const result = await mergeBranch(git as never, 'feature/widgets')
+    expect(result).toEqual({ ok: true, message: 'Merged feature/widgets into current branch' })
+    expect(git.merge).toHaveBeenCalledWith(['feature/widgets'])
+  })
+
+  it('merges with --ff-only when fastForwardOnly is true', async () => {
+    const git = { merge: jest.fn().mockResolvedValue({}) }
+    const result = await mergeBranch(git as never, 'feature/widgets', true)
+    expect(result).toEqual({ ok: true, message: 'Fast-forwarded to feature/widgets' })
+    expect(git.merge).toHaveBeenCalledWith(['--ff-only', 'feature/widgets'])
+  })
+
+  it('returns an error on merge conflict', async () => {
+    const git = {
+      merge: jest.fn().mockRejectedValue(new Error('CONFLICTS: Merge conflict in src/app.ts')),
+    }
+    const result = await mergeBranch(git as never, 'feature/widgets')
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('CONFLICTS')
+  })
+
+  it('returns an error when ff-only fails due to divergence', async () => {
+    const git = {
+      merge: jest.fn().mockRejectedValue(
+        new Error('fatal: Not possible to fast-forward, aborting.')
+      ),
+    }
+    const result = await mergeBranch(git as never, 'feature/widgets', true)
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('Not possible to fast-forward')
+  })
+})
+
+describe('canFastForward', () => {
+  it('returns true when HEAD equals the merge-base (current is ancestor of target)', async () => {
+    const git = {
+      raw: jest.fn()
+        .mockResolvedValueOnce('abc1234\n') // merge-base HEAD targetRef
+        .mockResolvedValueOnce('abc1234\n'), // rev-parse HEAD
+    }
+    const result = await canFastForward(git as never, 'feature/ahead')
+    expect(result).toBe(true)
+    expect(git.raw).toHaveBeenNthCalledWith(1, ['merge-base', 'HEAD', 'feature/ahead'])
+    expect(git.raw).toHaveBeenNthCalledWith(2, ['rev-parse', 'HEAD'])
+  })
+
+  it('returns false when HEAD is ahead of merge-base (branches diverged)', async () => {
+    const git = {
+      raw: jest.fn()
+        .mockResolvedValueOnce('aaa0000\n') // merge-base
+        .mockResolvedValueOnce('bbb1111\n'), // rev-parse HEAD (different)
+    }
+    const result = await canFastForward(git as never, 'feature/diverged')
+    expect(result).toBe(false)
+  })
+
+  it('returns false when target is behind HEAD (merge-base equals target, not HEAD)', async () => {
+    const git = {
+      raw: jest.fn()
+        .mockResolvedValueOnce('ccc2222\n') // merge-base (same as target, not HEAD)
+        .mockResolvedValueOnce('ddd3333\n'), // rev-parse HEAD
+    }
+    const result = await canFastForward(git as never, 'feature/behind')
+    expect(result).toBe(false)
+  })
+
+  it('returns false when git commands fail (e.g. invalid ref)', async () => {
+    const git = {
+      raw: jest.fn().mockRejectedValue(new Error('fatal: Not a valid object name')),
+    }
+    const result = await canFastForward(git as never, 'nonexistent-ref')
+    expect(result).toBe(false)
+  })
+})
+
+describe('resetCurrentBranchToRef', () => {
+  it('resets with --soft mode', async () => {
+    const git = { reset: jest.fn().mockResolvedValue('') }
+    const result = await resetCurrentBranchToRef(git as never, 'feature/target', 'soft')
+    expect(result).toEqual({ ok: true, message: 'Reset current branch to feature/target (soft)' })
+    expect(git.reset).toHaveBeenCalledWith(['--soft', 'feature/target'])
+  })
+
+  it('resets with --mixed mode', async () => {
+    const git = { reset: jest.fn().mockResolvedValue('') }
+    const result = await resetCurrentBranchToRef(git as never, 'feature/target', 'mixed')
+    expect(result).toEqual({ ok: true, message: 'Reset current branch to feature/target (mixed)' })
+    expect(git.reset).toHaveBeenCalledWith(['--mixed', 'feature/target'])
+  })
+
+  it('resets with --hard mode', async () => {
+    const git = { reset: jest.fn().mockResolvedValue('') }
+    const result = await resetCurrentBranchToRef(git as never, 'abc1234', 'hard')
+    expect(result).toEqual({ ok: true, message: 'Reset current branch to abc1234 (hard)' })
+    expect(git.reset).toHaveBeenCalledWith(['--hard', 'abc1234'])
+  })
+
+  it('returns an error when git reset fails', async () => {
+    const git = {
+      reset: jest.fn().mockRejectedValue(new Error('fatal: Could not parse object \'bad-ref\'.')),
+    }
+    const result = await resetCurrentBranchToRef(git as never, 'bad-ref', 'hard')
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('Could not parse object')
+  })
+})
+
+describe('isResetBackward', () => {
+  it('returns true when targetRef is an ancestor of HEAD (reset discards commits)', async () => {
+    const git = {
+      // Exit 0 → targetRef IS an ancestor of HEAD → backward reset
+      raw: jest.fn().mockResolvedValue(''),
+    }
+    const result = await isResetBackward(git as never, 'feature/old')
+    expect(result).toBe(true)
+    expect(git.raw).toHaveBeenCalledWith(['merge-base', '--is-ancestor', 'feature/old', 'HEAD'])
+  })
+
+  it('returns false when targetRef is NOT an ancestor of HEAD (reset goes forward or diverges)', async () => {
+    const git = {
+      // Non-zero exit → not an ancestor
+      raw: jest.fn().mockRejectedValue(new Error('exit code 1')),
+    }
+    const result = await isResetBackward(git as never, 'feature/ahead')
+    expect(result).toBe(false)
+    expect(git.raw).toHaveBeenCalledWith(['merge-base', '--is-ancestor', 'feature/ahead', 'HEAD'])
+  })
+
+  it('returns false when the ref does not exist', async () => {
+    const git = {
+      raw: jest.fn().mockRejectedValue(new Error('fatal: Not a valid commit name nonexistent')),
+    }
+    const result = await isResetBackward(git as never, 'nonexistent')
+    expect(result).toBe(false)
   })
 })

--- a/src/git/branchActions.ts
+++ b/src/git/branchActions.ts
@@ -1,6 +1,7 @@
 import { SimpleGit } from 'simple-git'
 import { BranchRef } from './branchData'
 import { rejectFlagLike } from './forgeArgGuards'
+import type { ResetMode } from './historyActions'
 import { listRemotes, resolveDefaultRemoteName } from './remoteResolution'
 
 export type BranchActionResult = {
@@ -338,6 +339,47 @@ export function pullCurrentBranchMerge(git: SimpleGit): Promise<BranchActionResu
   )
 }
 
+/**
+ * Merge the named branch into the current branch.
+ *
+ * When `fastForwardOnly` is true, the merge uses `--ff-only` and refuses
+ * to create a merge commit — use this after `canFastForward` confirms
+ * the fast-forward path is available.
+ */
+export function mergeBranch(
+  git: SimpleGit,
+  branchName: string,
+  fastForwardOnly?: boolean
+): Promise<BranchActionResult> {
+  const args = fastForwardOnly ? ['--ff-only', branchName] : [branchName]
+  return runAction(
+    () => git.merge(args),
+    fastForwardOnly
+      ? `Fast-forwarded to ${branchName}`
+      : `Merged ${branchName} into current branch`
+  )
+}
+
+/**
+ * Detect if the current branch can fast-forward to the given ref.
+ *
+ * Returns true when HEAD is an ancestor of `targetRef` — meaning the
+ * merge-base of HEAD and targetRef equals HEAD itself, so no divergent
+ * commits exist on the current branch.
+ */
+export async function canFastForward(
+  git: SimpleGit,
+  targetRef: string
+): Promise<boolean> {
+  try {
+    const mergeBase = (await git.raw(['merge-base', 'HEAD', targetRef])).trim()
+    const currentHead = (await git.raw(['rev-parse', 'HEAD'])).trim()
+    return mergeBase === currentHead
+  } catch {
+    return false
+  }
+}
+
 export function fetchRemotes(git: SimpleGit): Promise<BranchActionResult> {
   return runAction(
     () => git.raw(['fetch', '--all', '--prune']),
@@ -559,4 +601,37 @@ export function pullBranch(
       ]),
     `Fast-forwarded ${branch.shortName} to ${branch.upstream}`
   )
+}
+
+
+/** Reset the current branch to a given ref with the specified mode. */
+export function resetCurrentBranchToRef(
+  git: SimpleGit,
+  targetRef: string,
+  mode: ResetMode
+): Promise<BranchActionResult> {
+  return runAction(
+    () => git.reset([`--${mode}`, targetRef]),
+    `Reset current branch to ${targetRef} (${mode})`
+  )
+}
+
+/**
+ * Determine if a reset to targetRef would move the branch pointer
+ * backward (history rewrite) vs forward. Returns true when targetRef
+ * is an ancestor of HEAD — meaning HEAD has commits beyond targetRef
+ * that the reset would discard.
+ */
+export async function isResetBackward(
+  git: SimpleGit,
+  targetRef: string
+): Promise<boolean> {
+  try {
+    await git.raw(['merge-base', '--is-ancestor', targetRef, 'HEAD'])
+    // Exit 0 → targetRef IS an ancestor of HEAD → reset goes backward
+    return true
+  } catch {
+    // Non-zero exit → targetRef is not an ancestor of HEAD → reset goes forward or diverges
+    return false
+  }
 }

--- a/src/workstation/runtime/footer.test.ts
+++ b/src/workstation/runtime/footer.test.ts
@@ -425,6 +425,73 @@ describe('renderFooter', () => {
     })
   })
 
+  // Branches view footer hints (workstation-branch-operations)
+  describe('branches view footer hints', () => {
+    const renderBranches = (columns?: number) =>
+      asNode(
+        renderFooter(
+          createElement,
+          { Box, Text },
+          makeState({ activeView: 'branches' }),
+          baseContext,
+          createLogInkTheme({ noColor: false }),
+          undefined,
+          0,
+          false,
+          columns
+        )
+      )
+    const contextualText = (tree: Node): string => {
+      return String(childAt(childAt(tree, 0), 0).props.children)
+    }
+
+    it('includes M merge, Z reset, and S sync in the branches view contextual hints', () => {
+      const ctx = contextualText(renderBranches())
+      expect(ctx).toContain('M merge')
+      expect(ctx).toContain('Z reset')
+      expect(ctx).toContain('S sync')
+    })
+
+    it('includes P push alongside the new branch operation hints', () => {
+      const ctx = contextualText(renderBranches())
+      expect(ctx).toContain('P push')
+    })
+
+    it('preserves enter checkout as the leading action hint', () => {
+      const ctx = contextualText(renderBranches())
+      expect(ctx).toContain('enter checkout')
+      // enter checkout should appear before the new operation hints
+      const checkoutIdx = ctx.indexOf('enter checkout')
+      const mergeIdx = ctx.indexOf('M merge')
+      expect(checkoutIdx).toBeLessThan(mergeIdx)
+    })
+
+    it('fits the branches footer within the 80-column floor', () => {
+      const tree = renderBranches(80)
+      const ctx = contextualText(tree)
+      const glob = String(childAt(childAt(tree, 0), 1).props.children)
+      // paddingX (2) + minimum space-between gap (>=1)
+      expect(ctx.length + glob.length + 2 + 1).toBeLessThanOrEqual(80)
+    })
+
+    it('trims lower-priority hints at 80 columns while keeping the leading essentials', () => {
+      const ctx = contextualText(renderBranches(80))
+      // At 80 columns the leading movement + checkout hints survive;
+      // the tail (lower-priority ops) gets dropped to fit the row.
+      expect(ctx).toContain('↑/↓ branches')
+      expect(ctx).toContain('enter checkout')
+      // Tail hints like yank / sort are dropped before the essential ops.
+      expect(ctx).not.toContain('y yank')
+    })
+
+    it('fits the branches footer within 120 columns', () => {
+      const tree = renderBranches(120)
+      const ctx = contextualText(tree)
+      const glob = String(childAt(childAt(tree, 0), 1).props.children)
+      expect(ctx.length + glob.length + 2 + 1).toBeLessThanOrEqual(120)
+    })
+  })
+
   // Snapshot covers the no-status default — the layout most users see
   // most of the time — to catch incidental structural drift.
   it('structural snapshot — default no-status footer', () => {

--- a/src/workstation/runtime/hooks/useWorkflowAction.test.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.test.ts
@@ -2,7 +2,7 @@ import type ReactTypes from 'react'
 import type { GitLogRow } from '../../../git/logData'
 import { createLogInkState, applyLogInkAction } from '../inkViewModel'
 import { checkoutReflogEntry, performReflogUndo, planReflogUndo } from '../../../git/reflogActions'
-import { checkoutBranch, checkoutBranchByName, deleteBranches, pullCurrentBranch, pullCurrentBranchRebase, pushBranch } from '../../../git/branchActions'
+import { checkoutBranch, checkoutBranchByName, deleteBranches, pullCurrentBranch, pullCurrentBranchRebase, pushBranch, pushCurrentBranch, mergeBranch, canFastForward, resetCurrentBranchToRef, isResetBackward } from '../../../git/branchActions'
 import { cherryPickCommit, cherryPickRange, cherryPickCommits, autosquashRebase } from '../../../git/historyActions'
 import { createStash, dropStashes, restoreStash } from '../../../git/stashActions'
 import { addOrEditCommitNote } from '../../../git/notesActions'
@@ -30,11 +30,16 @@ jest.mock('../../../git/branchActions', () => {
   return {
     ...actual,
     pushBranch: jest.fn(),
+    pushCurrentBranch: jest.fn(),
     pullCurrentBranch: jest.fn(),
     pullCurrentBranchRebase: jest.fn(),
     checkoutBranch: jest.fn(),
     checkoutBranchByName: jest.fn(),
     deleteBranches: jest.fn(),
+    mergeBranch: jest.fn(),
+    canFastForward: jest.fn(),
+    resetCurrentBranchToRef: jest.fn(),
+    isResetBackward: jest.fn(),
   }
 })
 
@@ -1647,5 +1652,574 @@ describe('undo stack (OSS-1606)', () => {
     await runWorkflowAction('undo-last-action')
     expect(git.raw).toHaveBeenCalledWith(['tag', 'v1.0.0', 'abc1234'])
     expect(dispatch).toHaveBeenCalledWith({ type: 'popUndoEntry' })
+  })
+})
+
+
+const mergeBranchMock = mergeBranch as jest.MockedFunction<typeof mergeBranch>
+const canFastForwardMock = canFastForward as jest.MockedFunction<typeof canFastForward>
+
+const mergeBranch_otherBranch = {
+  type: 'local',
+  name: 'refs/heads/feature/merge-target',
+  shortName: 'feature/merge-target',
+  hash: 'merge123',
+  current: false,
+  upstream: undefined,
+  remote: undefined,
+  date: '2026-05-01',
+  subject: 'feat: merge target',
+  ahead: 0,
+  behind: 0,
+} as never
+
+describe('merge-into-current workflow handler', () => {
+  beforeEach(() => {
+    mergeBranchMock.mockReset()
+    canFastForwardMock.mockReset()
+  })
+
+  it('calls mergeBranch with ff-only when canFastForward returns true', async () => {
+    canFastForwardMock.mockResolvedValue(true)
+    mergeBranchMock.mockResolvedValue({ ok: true, message: 'Fast-forward merge complete' })
+    const git = {
+      revparse: jest.fn().mockResolvedValue('previoushead123\n'),
+    }
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      context: { branches: { localBranches: [mergeBranch_otherBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('merge-into-current')
+    expect(canFastForwardMock).toHaveBeenCalledWith(expect.anything(), 'feature/merge-target')
+    expect(mergeBranchMock).toHaveBeenCalledWith(expect.anything(), 'feature/merge-target', true)
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: expect.stringContaining('Fast-forwarded'),
+      kind: 'success',
+    }))
+  })
+
+  it('calls mergeBranch without ff-only when canFastForward returns false', async () => {
+    canFastForwardMock.mockResolvedValue(false)
+    mergeBranchMock.mockResolvedValue({ ok: true, message: 'Merge complete' })
+    const git = {
+      revparse: jest.fn().mockResolvedValue('previoushead123\n'),
+    }
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      context: { branches: { localBranches: [mergeBranch_otherBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('merge-into-current')
+    expect(canFastForwardMock).toHaveBeenCalledWith(expect.anything(), 'feature/merge-target')
+    expect(mergeBranchMock).toHaveBeenCalledWith(expect.anything(), 'feature/merge-target')
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: expect.stringContaining('Merged feature/merge-target into main'),
+      kind: 'success',
+    }))
+  })
+
+  it('captures undo entry with kind merge-branch and pre-merge HEAD on success', async () => {
+    canFastForwardMock.mockResolvedValue(false)
+    mergeBranchMock.mockResolvedValue({ ok: true, message: 'Merge complete' })
+    const git = {
+      revparse: jest.fn().mockResolvedValue('deadbeef9876\n'),
+    }
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      context: { branches: { localBranches: [mergeBranch_otherBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('merge-into-current')
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'pushUndoEntry',
+      value: {
+        kind: 'merge-branch',
+        label: 'merge feature/merge-target into main',
+        depth: 0,
+        previousSha: 'deadbeef9876',
+      },
+    })
+  })
+
+  it('routes to conflicts view when merge produces conflicts', async () => {
+    canFastForwardMock.mockResolvedValue(false)
+    mergeBranchMock.mockResolvedValue({
+      ok: false,
+      message: 'CONFLICT (content): Merge conflict in src/app.ts\nerror: Automatic merge failed',
+    })
+    const git = {
+      revparse: jest.fn().mockResolvedValue('previoushead123\n'),
+    }
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      context: { branches: { localBranches: [mergeBranch_otherBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('merge-into-current')
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setPendingChoice',
+      value: expect.objectContaining({
+        id: 'operation-conflict-recovery',
+        title: 'Merge stopped on conflicts',
+        keepStatusOnDismiss: true,
+        options: [
+          expect.objectContaining({ key: 'x', intent: 'open-conflicts' }),
+          expect.objectContaining({ key: 'a', workflowId: 'abort-operation', destructive: true }),
+        ],
+      }),
+    }))
+  })
+
+  it('returns error when cursored branch equals current branch (self-merge guard)', async () => {
+    const currentBranch = {
+      type: 'local',
+      name: 'refs/heads/main',
+      shortName: 'main',
+      hash: 'abc',
+      current: true,
+      upstream: 'origin/main',
+      remote: 'origin',
+      date: '2026-05-01',
+      subject: 'feat',
+      ahead: 0,
+      behind: 0,
+    } as never
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      context: { branches: { localBranches: [currentBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('merge-into-current')
+    // Self-merge guard fires BEFORE canFastForward or mergeBranch
+    expect(canFastForwardMock).not.toHaveBeenCalled()
+    expect(mergeBranchMock).not.toHaveBeenCalled()
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: 'Cannot merge a branch into itself.',
+      kind: 'error',
+    }))
+  })
+})
+
+
+const resetCurrentBranchToRefMock = resetCurrentBranchToRef as jest.MockedFunction<typeof resetCurrentBranchToRef>
+const isResetBackwardMock = isResetBackward as jest.MockedFunction<typeof isResetBackward>
+
+// A non-current branch with upstream for the reset-to-branch tests.
+const resetTargetBranch = {
+  type: 'local',
+  name: 'refs/heads/feature/target',
+  shortName: 'feature/target',
+  hash: 'targetabc',
+  current: false,
+  upstream: 'origin/feature/target',
+  remote: 'origin',
+  date: '2026-05-01',
+  subject: 'feat: target',
+  ahead: 0,
+  behind: 0,
+} as never
+
+// A non-current branch WITHOUT upstream.
+const resetTargetBranchNoUpstream = {
+  type: 'local',
+  name: 'refs/heads/feature/local-only',
+  shortName: 'feature/local-only',
+  hash: 'localonly',
+  current: false,
+  upstream: undefined,
+  remote: undefined,
+  date: '2026-05-01',
+  subject: 'feat: local only',
+  ahead: 0,
+  behind: 0,
+} as never
+
+// The current branch for reset-to-branch context.
+const currentBranchForReset = {
+  type: 'local',
+  name: 'refs/heads/main',
+  shortName: 'main',
+  hash: 'currentabc',
+  current: true,
+  upstream: 'origin/main',
+  remote: 'origin',
+  date: '2026-05-01',
+  subject: 'feat: current',
+  ahead: 0,
+  behind: 0,
+} as never
+
+describe('reset-to-branch workflow handler', () => {
+  beforeEach(() => {
+    resetCurrentBranchToRefMock.mockReset()
+    isResetBackwardMock.mockReset()
+  })
+
+  it('dispatches with soft mode when payload is "soft"', async () => {
+    resetCurrentBranchToRefMock.mockResolvedValue({ ok: true, message: 'Reset to feature/target' })
+    isResetBackwardMock.mockResolvedValue(false)
+    const git = {
+      revparse: jest.fn().mockResolvedValue('deadbeef1234\n'),
+    }
+    const dispatch = jest.fn()
+    const harness = createHookHarness()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      state: { ...createLogInkState([]), selectedBranchId: 'feature/target' } as never,
+      context: { branches: { localBranches: [currentBranchForReset, resetTargetBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('reset-to-branch', 'soft')
+    expect(resetCurrentBranchToRefMock).toHaveBeenCalledWith(expect.anything(), 'feature/target', 'soft')
+  })
+
+  it('dispatches with mixed mode when payload is "mixed"', async () => {
+    resetCurrentBranchToRefMock.mockResolvedValue({ ok: true, message: 'Reset to feature/target' })
+    isResetBackwardMock.mockResolvedValue(false)
+    const git = {
+      revparse: jest.fn().mockResolvedValue('deadbeef1234\n'),
+    }
+    const dispatch = jest.fn()
+    const harness = createHookHarness()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      state: { ...createLogInkState([]), selectedBranchId: 'feature/target' } as never,
+      context: { branches: { localBranches: [currentBranchForReset, resetTargetBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('reset-to-branch', 'mixed')
+    expect(resetCurrentBranchToRefMock).toHaveBeenCalledWith(expect.anything(), 'feature/target', 'mixed')
+  })
+
+  it('dispatches with hard mode when payload is "hard"', async () => {
+    resetCurrentBranchToRefMock.mockResolvedValue({ ok: true, message: 'Reset to feature/target' })
+    isResetBackwardMock.mockResolvedValue(false)
+    const git = {
+      revparse: jest.fn().mockResolvedValue('deadbeef1234\n'),
+    }
+    const dispatch = jest.fn()
+    const harness = createHookHarness()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      state: { ...createLogInkState([]), selectedBranchId: 'feature/target' } as never,
+      context: { branches: { localBranches: [currentBranchForReset, resetTargetBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('reset-to-branch', 'hard')
+    expect(resetCurrentBranchToRefMock).toHaveBeenCalledWith(expect.anything(), 'feature/target', 'hard')
+  })
+
+  it('captures an undo entry with previousSha and mode preserved on success', async () => {
+    resetCurrentBranchToRefMock.mockResolvedValue({ ok: true, message: 'Reset to feature/target' })
+    isResetBackwardMock.mockResolvedValue(false)
+    const git = {
+      revparse: jest.fn().mockResolvedValue('abc123previous\n'),
+    }
+    const dispatch = jest.fn()
+    const harness = createHookHarness()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      state: { ...createLogInkState([]), selectedBranchId: 'feature/target' } as never,
+      context: { branches: { localBranches: [currentBranchForReset, resetTargetBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('reset-to-branch', 'hard')
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'pushUndoEntry',
+      value: {
+        kind: 'reset-to-branch',
+        label: 'reset --hard to feature/target',
+        depth: 0,
+        previousSha: 'abc123previous',
+        mode: 'hard',
+      },
+    })
+  })
+
+  it('suggests force-push when isResetBackward is true and branch has upstream', async () => {
+    resetCurrentBranchToRefMock.mockResolvedValue({ ok: true, message: 'Reset to feature/target' })
+    isResetBackwardMock.mockResolvedValue(true)
+    const git = {
+      revparse: jest.fn().mockResolvedValue('deadbeef1234\n'),
+    }
+    const dispatch = jest.fn()
+    const harness = createHookHarness()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      state: { ...createLogInkState([]), selectedBranchId: 'feature/target' } as never,
+      context: { branches: { localBranches: [currentBranchForReset, resetTargetBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('reset-to-branch', 'mixed')
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: expect.stringContaining('Force-push with P'),
+      kind: 'success',
+    }))
+  })
+
+  it('suggests view history when isResetBackward is false', async () => {
+    resetCurrentBranchToRefMock.mockResolvedValue({ ok: true, message: 'Reset to feature/local-only' })
+    isResetBackwardMock.mockResolvedValue(false)
+    const git = {
+      revparse: jest.fn().mockResolvedValue('deadbeef1234\n'),
+    }
+    const dispatch = jest.fn()
+    const harness = createHookHarness()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      state: { ...createLogInkState([]), selectedBranchId: 'feature/local-only' } as never,
+      context: { branches: { localBranches: [currentBranchForReset, resetTargetBranchNoUpstream], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('reset-to-branch', 'soft')
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: expect.stringContaining('View history with gh'),
+      kind: 'success',
+    }))
+  })
+
+  it('errors when cursored branch equals current branch (self-reset guard)', async () => {
+    const dispatch = jest.fn()
+    const git = {
+      revparse: jest.fn().mockResolvedValue('deadbeef\n'),
+    }
+    const harness = createHookHarness()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      state: { ...createLogInkState([]), selectedBranchId: 'main' } as never,
+      context: { branches: { localBranches: [currentBranchForReset], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('reset-to-branch', 'mixed')
+    expect(resetCurrentBranchToRefMock).not.toHaveBeenCalled()
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: 'Nothing to reset — already at that ref.',
+      kind: 'error',
+    }))
+  })
+})
+
+const pushCurrentBranchMock = pushCurrentBranch as jest.MockedFunction<typeof pushCurrentBranch>
+
+describe('sync-branch workflow handler (Requirement 6)', () => {
+  beforeEach(() => {
+    pullCurrentBranchMock.mockReset()
+    pushCurrentBranchMock.mockReset()
+  })
+
+  it('successful pull+push returns "Branch fully synchronized" momentum hint', async () => {
+    pullCurrentBranchMock.mockResolvedValue({ ok: true, message: 'Already up to date.' })
+    pushCurrentBranchMock.mockResolvedValue({ ok: true, message: 'Pushed to origin' })
+    const git = {
+      raw: jest.fn().mockResolvedValue('origin/main'),
+    }
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+    }))
+
+    await runWorkflowAction('sync-branch')
+    // Upstream check passed
+    expect(git.raw).toHaveBeenCalledWith(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'])
+    // Both phases called
+    expect(pullCurrentBranchMock).toHaveBeenCalled()
+    expect(pushCurrentBranchMock).toHaveBeenCalled()
+    // Final success message
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: expect.stringContaining('Branch fully synchronized'),
+      kind: 'success',
+    }))
+  })
+
+  it('returns error "No upstream — press u to set one first." when no upstream is configured', async () => {
+    const git = {
+      raw: jest.fn().mockRejectedValue(new Error("fatal: no upstream configured for branch 'feature'")),
+    }
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+    }))
+
+    await runWorkflowAction('sync-branch')
+    // Neither pull nor push should be attempted
+    expect(pullCurrentBranchMock).not.toHaveBeenCalled()
+    expect(pushCurrentBranchMock).not.toHaveBeenCalled()
+    // Error status dispatched
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: 'No upstream — press u to set one first.',
+      kind: 'error',
+    }))
+  })
+
+  it('dispatches diverged-pull-recovery setPendingChoice when pull diverges', async () => {
+    pullCurrentBranchMock.mockResolvedValue({
+      ok: false,
+      message: 'fatal: Not possible to fast-forward, aborting.',
+    })
+    const git = {
+      raw: jest.fn().mockResolvedValue('origin/main'),
+    }
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+    }))
+
+    await runWorkflowAction('sync-branch')
+    // Push should NOT be attempted after a diverged pull
+    expect(pushCurrentBranchMock).not.toHaveBeenCalled()
+    // Should present the rebase/merge strategy choice
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setPendingChoice',
+      value: expect.objectContaining({
+        id: 'diverged-pull-recovery',
+        title: 'Local and remote have diverged',
+        options: [
+          expect.objectContaining({ key: 'r', workflowId: 'pull-rebase-current' }),
+          expect.objectContaining({ key: 'm', workflowId: 'pull-merge-current' }),
+        ],
+      }),
+    }))
+  })
+
+  it('dispatches operation-conflict-recovery when pull encounters conflicts', async () => {
+    pullCurrentBranchMock.mockResolvedValue({
+      ok: false,
+      message: 'CONFLICT (content): Merge conflict in src/app.ts\nerror: could not apply abc1234... feat',
+    })
+    const git = {
+      raw: jest.fn().mockResolvedValue('origin/main'),
+    }
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+    }))
+
+    await runWorkflowAction('sync-branch')
+    // Push should NOT be attempted after a conflicted pull
+    expect(pushCurrentBranchMock).not.toHaveBeenCalled()
+    // Should present the conflict recovery choice
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setPendingChoice',
+      value: expect.objectContaining({
+        id: 'operation-conflict-recovery',
+        title: 'Sync interrupted — resolve conflicts then push manually with P',
+        options: [
+          expect.objectContaining({ key: 'x', intent: 'open-conflicts' }),
+          expect.objectContaining({ key: 'a', workflowId: 'abort-operation', destructive: true }),
+        ],
+      }),
+    }))
+  })
+
+  it('returns "Pull succeeded but push failed" when push fails after successful pull', async () => {
+    pullCurrentBranchMock.mockResolvedValue({ ok: true, message: 'Pulled from origin' })
+    pushCurrentBranchMock.mockResolvedValue({
+      ok: false,
+      message: "error: failed to push some refs to 'origin'",
+    })
+    const git = {
+      raw: jest.fn().mockResolvedValue('origin/main'),
+    }
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+    }))
+
+    await runWorkflowAction('sync-branch')
+    // Both pull and push were attempted
+    expect(pullCurrentBranchMock).toHaveBeenCalled()
+    expect(pushCurrentBranchMock).toHaveBeenCalled()
+    // Error status includes both context
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: expect.stringContaining('Pull succeeded but push failed'),
+      kind: 'error',
+    }))
+  })
+
+  it('returns the pull error directly when pull fails with a generic error', async () => {
+    pullCurrentBranchMock.mockResolvedValue({
+      ok: false,
+      message: 'fatal: could not read from remote repository',
+    })
+    const git = {
+      raw: jest.fn().mockResolvedValue('origin/main'),
+    }
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+    }))
+
+    await runWorkflowAction('sync-branch')
+    // Push should NOT be attempted after a failed pull
+    expect(pushCurrentBranchMock).not.toHaveBeenCalled()
+    // The pull error should surface directly
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: 'fatal: could not read from remote repository',
+      kind: 'error',
+    }))
+    // No choice prompts should have been raised
+    expect(dispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'setPendingChoice' }))
   })
 })

--- a/src/workstation/runtime/hooks/useWorkflowAction.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.ts
@@ -75,6 +75,10 @@ import {
     isNonFastForwardPushError,
     pullCurrentBranchMerge,
     pullCurrentBranchRebase,
+    resetCurrentBranchToRef,
+    isResetBackward,
+    mergeBranch,
+    canFastForward,
 } from '../../../git/branchActions'
 import { addToGitignore } from '../../../git/gitignore'
 import { createLightweightTag, deleteLocalTag, deleteRemoteTag, pushTag } from '../../../git/tagActions'
@@ -138,6 +142,7 @@ const REMOTE_OP_LOADERS: Record<string, RemoteOpState> = {
   'force-push-selected-branch': { kind: 'push', label: 'Force-pushing branch (with lease)…' },
   'pull-rebase-current': { kind: 'pull', label: 'Pulling with rebase…' },
   'pull-merge-current': { kind: 'pull', label: 'Pulling with merge…' },
+  'sync-branch': { kind: 'pull', label: 'Syncing branch (pull + push)…' },
 }
 
 /**
@@ -159,6 +164,7 @@ const REMOTE_OP_LOADERS: Record<string, RemoteOpState> = {
  */
 export const HISTORY_REWRITE_WORKFLOW_IDS = new Set([
   'reset-to-commit',
+  'reset-to-branch',
   'cherry-pick-commit',
   'revert-commit',
   'fixup-into-commit',
@@ -212,12 +218,16 @@ export const HISTORY_MUTATING_WORKFLOW_IDS = new Set([
   'cherry-pick-commit',
   'revert-commit',
   'reset-to-commit',
+  'reset-to-branch',
   'interactive-rebase',
   // Rebasing the current branch onto a ref rewrites its commits —
   // refresh the graph so the replayed history (or the mid-rebase
   // conflict state) shows instead of staying pinned to the pre-rebase
   // tip.
   'rebase-onto-branch',
+  // Merging a branch into the current branch creates (or fast-forwards
+  // to) new commits — refresh the graph so the merge result shows.
+  'merge-into-current',
   'bisect-good',
   'bisect-bad',
   'bisect-skip',
@@ -243,6 +253,8 @@ export const HISTORY_MUTATING_WORKFLOW_IDS = new Set([
   // undoing a branch/tag delete or stash drop changes the ref set. All
   // four warrant a graph refresh.
   'undo-last-action',
+  // Sync pulls remote commits then pushes local — both sides move refs.
+  'sync-branch',
 ])
 
 export function resolvePendingItemAction(
@@ -522,6 +534,48 @@ export function useWorkflowAction(
           return { ok: false, message: 'Cannot rebase a branch onto itself.' }
         }
         return rebaseOnto(git, branch.shortName)
+      },
+      // Merge the cursored branch into the current branch. Determines
+      // whether a fast-forward is available and uses --ff-only when it is;
+      // falls back to a standard merge commit when the branches have
+      // diverged. Conflict routing uses the shared `conflictRecoveryTitles`
+      // pattern (see below).
+      'merge-into-current': async () => {
+        const current = context.branches?.currentBranch
+        if (!current) {
+          return { ok: false, message: 'Detached HEAD — checkout a branch before merging.' }
+        }
+        const branch = getSelectedBranch(state, context)
+        if (!branch) return { ok: false, message: 'No branch selected' }
+        if (branch.shortName === current) {
+          return { ok: false, message: 'Cannot merge a branch into itself.' }
+        }
+        // Capture pre-merge HEAD for the undo entry.
+        const previousHead = await git.revparse(['HEAD']).then((sha) => sha.trim()).catch(() => undefined)
+        // Determine merge strategy.
+        const ff = await canFastForward(git, branch.shortName)
+        const result = ff
+          ? await mergeBranch(git, branch.shortName, true)
+          : await mergeBranch(git, branch.shortName)
+        if (result.ok) {
+          if (previousHead) {
+            capturedUndoEntries = [{
+              kind: 'merge-branch',
+              label: `merge ${branch.shortName} into ${current}`,
+              depth: issuedAtDepth,
+              workdir: issuedAtWorkdir,
+              previousSha: previousHead,
+            }]
+          }
+          // Momentum hint distinguishes FF from merge commit.
+          return {
+            ok: true,
+            message: ff
+              ? `Fast-forwarded ${current} to ${branch.shortName}. Push with P`
+              : `Merged ${branch.shortName} into ${current}. Push with P`,
+          }
+        }
+        return result
       },
       'delete-tag': async () => {
         const tag = getSelectedTag(state, context)
@@ -928,6 +982,53 @@ export function useWorkflowAction(
           message: commit.message,
         }, raw as ResetMode)
       },
+      'reset-to-branch': async () => {
+        // Mode arrives via the choice prompt payload — the reset-to-branch
+        // mode choice routes s/m/h here as soft/mixed/hard.
+        const raw = payload?.trim().toLowerCase() || 'mixed'
+        if (!isResetMode(raw)) {
+          return { ok: false, message: `Unknown reset mode: ${raw}. Use soft, mixed, or hard.` }
+        }
+        const branch = getSelectedBranch(state, context)
+        if (!branch) return { ok: false, message: 'No branch selected' }
+        const current = context.branches?.currentBranch
+        if (!current) {
+          return { ok: false, message: 'Detached HEAD — checkout a branch before resetting.' }
+        }
+        if (branch.shortName === current) {
+          return { ok: false, message: 'Nothing to reset — already at that ref.' }
+        }
+        const cursoredRef = branch.shortName
+        // Capture the pre-reset HEAD so a successful reset can be pushed
+        // onto the undo stack.
+        const previousHead = await git.revparse(['HEAD']).then((sha) => sha.trim()).catch(() => undefined)
+        // Determine before the reset whether it moves backward (discards
+        // commits) — after the reset HEAD will be at cursoredRef so the
+        // ancestor check would be meaningless.
+        const backward = await isResetBackward(git, cursoredRef).catch(() => false)
+        const result = await resetCurrentBranchToRef(git, cursoredRef, raw as ResetMode)
+        if (result.ok) {
+          // Push undo entry
+          if (previousHead) {
+            capturedUndoEntries = [{
+              kind: 'reset-to-branch',
+              label: `reset --${raw} to ${cursoredRef}`,
+              depth: issuedAtDepth,
+              workdir: issuedAtWorkdir,
+              previousSha: previousHead,
+              mode: raw as ResetMode,
+            }]
+          }
+          // Determine momentum hint based on whether reset was backward
+          // and whether the branch has an upstream.
+          const hasUpstream = Boolean(branch.upstream)
+          const hint = backward && hasUpstream
+            ? `Reset ${current} to ${cursoredRef} (${raw}). Force-push with P → f`
+            : `Reset ${current} to ${cursoredRef} (${raw}). View history with gh`
+          return { ok: true, message: hint }
+        }
+        return result
+      },
       'interactive-rebase': async () => {
         const commit = getSelectedInkCommit(state)
         if (!commit) return { ok: false, message: 'No commit selected' }
@@ -1247,6 +1348,67 @@ export function useWorkflowAction(
       },
       'pull-rebase-current': async () => pullCurrentBranchRebase(git),
       'pull-merge-current': async () => pullCurrentBranchMerge(git),
+      'sync-branch': async () => {
+        // Guard: the current branch must have an upstream configured.
+        const hasUpstream = await git
+          .raw(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'])
+          .then(() => true)
+          .catch(() => false)
+        if (!hasUpstream) {
+          return { ok: false, message: 'No upstream — press u to set one first.' }
+        }
+        // Phase 1: Pull (ff-only).
+        const pullResult = await pullCurrentBranch(git)
+        if (!pullResult.ok) {
+          // Diverged → present strategy choice (rebase/merge) — same as
+          // the standalone pull handler's recovery. The sync aborts here;
+          // the user picks a strategy and then pushes manually with P.
+          const pullFailureText = [pullResult.message, ...(pullResult.details || [])].join('\n')
+          if (isDivergedPullError(pullFailureText)) {
+            dispatch({
+              type: 'setPendingChoice',
+              value: {
+                id: 'diverged-pull-recovery',
+                title: 'Local and remote have diverged',
+                warning: 'A fast-forward pull is not possible. Choose how to reconcile.',
+                options: [
+                  { key: 'r', label: 'Pull with rebase (replay local commits on top)', workflowId: 'pull-rebase-current' },
+                  { key: 'm', label: 'Pull with merge (create a merge commit)', workflowId: 'pull-merge-current' },
+                ],
+              },
+            })
+            return { ok: false, message: pullResult.message }
+          }
+          // Conflicts → abort sync, route to conflicts view.
+          if (isOperationConflictError(pullFailureText)) {
+            dispatch({
+              type: 'setPendingChoice',
+              value: {
+                id: 'operation-conflict-recovery',
+                title: 'Sync interrupted — resolve conflicts then push manually with P',
+                warning: 'The repository is mid-operation. Resolve the conflicts and continue, or abort to unwind.',
+                keepStatusOnDismiss: true,
+                options: [
+                  { key: 'x', label: 'Open conflicts view', intent: 'open-conflicts' },
+                  { key: 'a', label: 'Abort the operation', workflowId: 'abort-operation', destructive: true },
+                ],
+              },
+            })
+            return { ok: false, message: 'Sync interrupted — resolve conflicts then push manually with P' }
+          }
+          // Any other pull failure → surface the error.
+          return pullResult
+        }
+        // Phase 2: Push.
+        const pushResult = await pushCurrentBranch(git)
+        if (!pushResult.ok) {
+          // Push failed — set error status with reason, but pull result
+          // is preserved (already committed).
+          return { ok: false, message: `Pull succeeded but push failed: ${pushResult.message}` }
+        }
+        // Both succeeded — momentum hint.
+        return { ok: true, message: 'Branch fully synchronized. View history with gh' }
+      },
       'add-to-gitignore': async () => addToGitignore(git, payload || ''),
       'rename-branch': async () => {
         const newName = payload?.trim()
@@ -1671,6 +1833,7 @@ export function useWorkflowAction(
       'pull-selected-branch': 'Pull stopped on conflicts',
       'pull-rebase-current': 'Pull stopped on conflicts',
       'pull-merge-current': 'Pull stopped on conflicts',
+      'merge-into-current': 'Merge stopped on conflicts',
     }
     // `continue-operation` covers merge/rebase/cherry-pick/revert, so its
     // title can't be a static string like the siblings above — it stops on

--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -4,6 +4,8 @@ import {
     getLogInkPaletteExecuteEvents,
     isCreatePrView,
     isCreateStashView,
+    PUSH_SUB_CHOICE,
+    RESET_TO_BRANCH_MODE_CHOICE,
 } from './inkInput'
 import { getLogInkPaletteCommands } from './inkKeymap'
 import { LogInkState, LogInkView, applyLogInkAction, createLogInkState } from './inkViewModel'
@@ -675,12 +677,15 @@ describe('log Ink input interactions', () => {
       ])
     })
 
-    it('routes P to push-selected-branch when branches sidebar focused with items', () => {
+    it('routes P to push sub-choice when branches sidebar focused with items', () => {
       const events = getLogInkInputEvents(
         branchSidebarState(), 'P', {}, { branchCount: 3 }
       )
       expect(events).toEqual([
-        { type: 'runWorkflowAction', id: 'push-selected-branch' },
+        {
+          type: 'action',
+          action: { type: 'setPendingChoice', value: PUSH_SUB_CHOICE },
+        },
       ])
     })
 
@@ -709,7 +714,10 @@ describe('log Ink input interactions', () => {
       const state = createLogInkState(rows, { activeView: 'branches' })
       const events = getLogInkInputEvents(state, 'P', {}, { branchCount: 3 })
       expect(events).toEqual([
-        { type: 'runWorkflowAction', id: 'push-selected-branch' },
+        {
+          type: 'action',
+          action: { type: 'setPendingChoice', value: PUSH_SUB_CHOICE },
+        },
       ])
     })
   })
@@ -784,6 +792,109 @@ describe('log Ink input interactions', () => {
         currentBranch: 'feature',
         branchSelectedShortName: 'main',
       })).toEqual([{ type: 'refreshContext' }])
+    })
+  })
+
+  describe('M merge-into-current on the branches view', () => {
+    it('dispatches setPendingConfirmation when cursored branch ≠ current', () => {
+      const state = createLogInkState(rows, { activeView: 'branches' })
+      const events = getLogInkInputEvents(state, 'M', {}, {
+        branchCount: 3,
+        currentBranch: 'feature',
+        branchSelectedShortName: 'main',
+      })
+      expect(events).toEqual([
+        {
+          type: 'action',
+          action: { type: 'setPendingConfirmation', value: 'merge-into-current' },
+        },
+      ])
+    })
+
+    it('shows error when cursored branch = current branch', () => {
+      const state = createLogInkState(rows, { activeView: 'branches' })
+      const events = getLogInkInputEvents(state, 'M', {}, {
+        branchCount: 3,
+        currentBranch: 'main',
+        branchSelectedShortName: 'main',
+      })
+      expect(events).toEqual([
+        {
+          type: 'action',
+          action: {
+            type: 'setStatus',
+            value: 'Cannot merge a branch into itself.',
+            kind: 'error',
+          },
+        },
+      ])
+    })
+  })
+
+  describe('Z reset-to-branch on the branches view', () => {
+    it('dispatches setPendingChoice with reset mode choice when cursored ≠ current', () => {
+      const state = createLogInkState(rows, { activeView: 'branches' })
+      const events = getLogInkInputEvents(state, 'Z', {}, {
+        branchCount: 3,
+        currentBranch: 'feature',
+        branchSelectedShortName: 'main',
+      })
+      expect(events).toEqual([
+        {
+          type: 'action',
+          action: { type: 'setPendingChoice', value: RESET_TO_BRANCH_MODE_CHOICE },
+        },
+      ])
+    })
+
+    it('shows error when cursored branch = current branch', () => {
+      const state = createLogInkState(rows, { activeView: 'branches' })
+      const events = getLogInkInputEvents(state, 'Z', {}, {
+        branchCount: 3,
+        currentBranch: 'main',
+        branchSelectedShortName: 'main',
+      })
+      expect(events).toEqual([
+        {
+          type: 'action',
+          action: {
+            type: 'setStatus',
+            value: 'Nothing to reset — already at that ref.',
+            kind: 'error',
+          },
+        },
+      ])
+    })
+  })
+
+  describe('S sync-branch on the branches view', () => {
+    it('dispatches runWorkflowAction sync-branch', () => {
+      const state = createLogInkState(rows, { activeView: 'branches' })
+      const events = getLogInkInputEvents(state, 'S', {}, {
+        branchCount: 3,
+        currentBranch: 'feature',
+        branchSelectedShortName: 'main',
+      })
+      expect(events).toEqual([
+        { type: 'runWorkflowAction', id: 'sync-branch' },
+      ])
+    })
+  })
+
+  describe('P push sub-choice on the branches view', () => {
+    it('dispatches setPendingChoice with PUSH_SUB_CHOICE', () => {
+      const state = createLogInkState(rows, { activeView: 'branches' })
+      const events = getLogInkInputEvents(state, 'P', {}, {
+        branchCount: 3,
+        currentBranch: 'feature',
+        branchSelectedShortName: 'main',
+      })
+      expect(events).toEqual([
+        {
+          type: 'action',
+          action: { type: 'setPendingChoice', value: PUSH_SUB_CHOICE },
+        },
+      ])
     })
   })
 
@@ -6588,10 +6699,10 @@ describe('global key allowlists (negation-guard conversion)', () => {
     }
   })
 
-  it('S creates a stash in every view except the commit triad (compose/status/diff)', () => {
-    const triad: LogInkView[] = ['compose', 'status', 'diff']
+  it('S creates a stash in every view except the commit triad (compose/status/diff) and branches (sync)', () => {
+    const excluded: LogInkView[] = ['compose', 'status', 'diff', 'branches']
     for (const view of ALL_VIEWS) {
-      expect(isCreateStashView(view)).toBe(!triad.includes(view))
+      expect(isCreateStashView(view)).toBe(!excluded.includes(view))
     }
   })
 })

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -581,7 +581,7 @@ const CREATE_PR_VIEWS: readonly LogInkView[] = [
 // Bare `S` creates a stash everywhere EXCEPT the commit triad
 // (compose / status / diff), where `S` starts the commit-split flow.
 const CREATE_STASH_VIEWS: readonly LogInkView[] = [
-  'history', 'branches', 'tags', 'stash', 'worktrees', 'pull-request',
+  'history', 'tags', 'stash', 'worktrees', 'pull-request',
   'pull-request-triage', 'issues', 'conflicts', 'reflog', 'bisect',
   'changelog', 'submodules', 'remotes',
 ]
@@ -1017,6 +1017,35 @@ const RESET_MODE_CHOICE = {
     { key: 's', label: 'Soft — keep changes staged', workflowId: 'reset-to-commit', payload: 'soft' },
     { key: 'm', label: 'Mixed — keep changes unstaged', workflowId: 'reset-to-commit', payload: 'mixed' },
     { key: 'h', label: 'Hard — discard working-tree changes', workflowId: 'reset-to-commit', payload: 'hard', destructive: true },
+  ],
+}
+
+/**
+ * Reset the current branch to the cursored branch's ref. Presented when the
+ * user presses `Z` in the branches view — mirrors the history-view
+ * `RESET_MODE_CHOICE` but targets a branch ref instead of a commit.
+ */
+export const RESET_TO_BRANCH_MODE_CHOICE = {
+  id: 'reset-to-branch-mode-choice',
+  title: 'Reset current branch to the cursored branch',
+  warning: 'hard discards ALL uncommitted working-tree changes.',
+  options: [
+    { key: 's', label: 'Soft — keep changes staged', workflowId: 'reset-to-branch', payload: 'soft' },
+    { key: 'm', label: 'Mixed — keep changes unstaged', workflowId: 'reset-to-branch', payload: 'mixed' },
+    { key: 'h', label: 'Hard — discard working-tree changes', workflowId: 'reset-to-branch', payload: 'hard', destructive: true },
+  ],
+}
+
+/**
+ * Push sub-choice raised when the user presses `P` in the branches view.
+ * Lets the user pick between a normal push and a force-push (with lease).
+ */
+export const PUSH_SUB_CHOICE = {
+  id: 'push-sub-choice',
+  title: 'Push branch',
+  options: [
+    { key: 'p', label: 'Push (normal)', workflowId: 'push-selected-branch' },
+    { key: 'f', label: 'Force push (--force-with-lease)', workflowId: 'force-push-selected-branch', destructive: true },
   ],
 }
 
@@ -4343,17 +4372,51 @@ export function getLogInkInputEvents(
     return commitOrComposeEvents(state)
   }
 
-  // Context-sensitive per-branch variants of F / U / P. When the
-  // user has the branches sidebar / view focused with at least one
-  // branch, F / U / P should act on the cursored row, not on the
-  // current branch. This intercept fires BEFORE the generic
-  // workflow-by-key lookup below so the global *-current-branch
-  // variants don't shadow the contextual ones.
+  // Context-sensitive per-branch variants of F / U / P / M / Z / S.
+  // When the user has the branches sidebar / view focused with at least
+  // one branch, these keys act on the cursored row, not on the current
+  // branch. This intercept fires BEFORE the generic workflow-by-key
+  // lookup below so the global *-current-branch variants don't shadow
+  // the contextual ones.
   //
   // Outside the branches context, the generic lookup runs and the
   // F / U / P keys hit the global `fetch-remotes` / `pull-current-branch`
   // / `push-current-branch` workflows as before.
   if (isBranchActionTarget(state) && context.branchCount) {
+    // `M` merges the cursored branch into the current branch.
+    if (inputValue === 'M') {
+      const current = context.currentBranch
+      const target = context.branchSelectedShortName
+      if (!current || target === current) {
+        return [action({
+          type: 'setStatus',
+          value: 'Cannot merge a branch into itself.',
+          kind: 'error',
+        })]
+      }
+      return [action({ type: 'setPendingConfirmation', value: 'merge-into-current' })]
+    }
+
+    // `Z` resets the current branch to the cursored branch's ref.
+    if (inputValue === 'Z') {
+      const current = context.currentBranch
+      const target = context.branchSelectedShortName
+      if (!current || target === current) {
+        return [action({
+          type: 'setStatus',
+          value: 'Nothing to reset — already at that ref.',
+          kind: 'error',
+        })]
+      }
+      return [action({ type: 'setPendingChoice', value: RESET_TO_BRANCH_MODE_CHOICE })]
+    }
+
+    // `S` syncs the cursored branch (pull + push). The upstream guard
+    // is enforced by the workflow handler (it needs async git context).
+    if (inputValue === 'S') {
+      return [{ type: 'runWorkflowAction', id: 'sync-branch' }]
+    }
+
     if (inputValue === 'F') {
       return [{ type: 'runWorkflowAction', id: 'fetch-selected-branch' }]
     }
@@ -4361,7 +4424,7 @@ export function getLogInkInputEvents(
       return [{ type: 'runWorkflowAction', id: 'pull-selected-branch' }]
     }
     if (inputValue === 'P') {
-      return [{ type: 'runWorkflowAction', id: 'push-selected-branch' }]
+      return [action({ type: 'setPendingChoice', value: PUSH_SUB_CHOICE })]
     }
   }
 

--- a/src/workstation/runtime/inkKeymap.test.ts
+++ b/src/workstation/runtime/inkKeymap.test.ts
@@ -118,7 +118,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'x/v mark', 'D delete', 'r rebase', 'm compare', 's sort', 'y yank'],
+      contextual: ['↑/↓ branches', 'enter checkout', 'M merge', 'P push', 'S sync', 'Z reset', '+ new', 'x/v mark', 'D delete', 'r rebase', 'm compare', 's sort', 'y yank'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/workstation/runtime/inkKeymap.ts
+++ b/src/workstation/runtime/inkKeymap.ts
@@ -113,6 +113,9 @@ export type LogInkCommandId =
   | 'workflowTriagePrOpen'
   | 'workflowTriageIssueOpen'
   | 'workflowRemoveWorktreeAndBranch'
+  | 'viewMergeIntoCurrent'
+  | 'viewResetToBranch'
+  | 'viewSyncBranch'
 
 export type LogInkBindingCategory =
   | 'essentials'
@@ -625,6 +628,27 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     keys: ['r'],
     label: 'rebase onto',
     description: 'Rebase the current branch onto the cursored branch / ref (non-interactive) after confirmation.',
+    contexts: ['branches'],
+  },
+  {
+    id: 'viewMergeIntoCurrent',
+    keys: ['M'],
+    label: 'merge',
+    description: 'Merge the cursored branch into the current branch after confirmation.',
+    contexts: ['branches'],
+  },
+  {
+    id: 'viewResetToBranch',
+    keys: ['Z'],
+    label: 'reset',
+    description: 'Reset the current branch to the cursored ref (prompts for soft/mixed/hard).',
+    contexts: ['branches'],
+  },
+  {
+    id: 'viewSyncBranch',
+    keys: ['S'],
+    label: 'sync',
+    description: 'Pull from remote then push local commits (compound pull + push).',
     contexts: ['branches'],
   },
   {
@@ -1180,6 +1204,10 @@ const BINDING_CATEGORY_BY_ID: Partial<Record<LogInkCommandId, LogInkBindingCateg
   // Branches-view-only rebase-onto (#0.71) — a confirmation-gated
   // destructive op, grouped with the global mutate cluster.
   viewRebaseOnto: 'mutate',
+  // Branches-view-only merge/reset/sync (workstation-branch-operations)
+  viewMergeIntoCurrent: 'mutate',
+  viewResetToBranch: 'mutate',
+  viewSyncBranch: 'mutate',
   // ── History actions: per-view-only mutations scoped to the history
   //    surface. Distinct from the global mutate cluster so users see
   //    them grouped under their actual context.
@@ -1626,9 +1654,16 @@ function branchesHints(options: GetLogInkFooterHintsOptions): LogInkFooterHints 
     }
   }
   return {
-    // `x/v mark` covers both multi-select primitives (#1361): x
-    // toggles a mark, v anchors a range; D then deletes the batch.
-    contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'x/v mark', 'D delete', 'r rebase', 'm compare', 's sort', 'y yank'],
+    // Priority ordering (highest → lowest, leftmost survives narrow-
+    // terminal trimming): Enter checkout > M merge > P push > S sync >
+    // Z reset > existing utility keys. `x/v mark` covers both multi-
+    // select primitives (#1361): x toggles a mark, v anchors a range;
+    // D then deletes the batch.
+    contextual: [
+      '↑/↓ branches', 'enter checkout',
+      'M merge', 'P push', 'S sync', 'Z reset',
+      '+ new', 'x/v mark', 'D delete', 'r rebase', 'm compare', 's sort', 'y yank',
+    ],
     global: NORMAL_GLOBAL_HINTS,
   }
 }

--- a/src/workstation/runtime/inkWorkflows.test.ts
+++ b/src/workstation/runtime/inkWorkflows.test.ts
@@ -235,6 +235,43 @@ describe('triage PR checkout workflow (#1363)', () => {
   })
 })
 
+describe('branch-level workflows (merge, reset, sync)', () => {
+  it('registers merge-into-current as destructive and confirmation-gated', () => {
+    const merge = getLogInkWorkflowActionById('merge-into-current')
+    expect(merge).toMatchObject({
+      id: 'merge-into-current',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    })
+  })
+
+  it('registers reset-to-branch as destructive and confirmation-gated', () => {
+    const reset = getLogInkWorkflowActionById('reset-to-branch')
+    expect(reset).toMatchObject({
+      id: 'reset-to-branch',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    })
+  })
+
+  it('registers sync-branch as normal and confirmation-free', () => {
+    const sync = getLogInkWorkflowActionById('sync-branch')
+    expect(sync).toMatchObject({
+      id: 'sync-branch',
+      kind: 'normal',
+      requiresConfirmation: false,
+    })
+  })
+
+  it('returns all three branch workflows from getLogInkWorkflowActions()', () => {
+    const actions = getLogInkWorkflowActions()
+    const ids = actions.map((a) => a.id)
+    expect(ids).toContain('merge-into-current')
+    expect(ids).toContain('reset-to-branch')
+    expect(ids).toContain('sync-branch')
+  })
+})
+
 describe('PR ready-for-review / reopen workflows (#1933)', () => {
   it('registers ready-pr / reopen-pr and their triage counterparts as keyless, confirm-gated, non-destructive', () => {
     for (const id of ['ready-pr', 'reopen-pr', 'triage-pr-ready', 'triage-pr-reopen']) {

--- a/src/workstation/runtime/inkWorkflows.ts
+++ b/src/workstation/runtime/inkWorkflows.ts
@@ -359,6 +359,37 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: false,
     },
     {
+      // Branch-level workflows — merge, reset, sync. Bound to M / Z / S
+      // in the branches view (inkInput); the key field reflects the
+      // palette-visible binding (empty for reset-to-branch because it's
+      // routed via mode-choice, not a direct palette key).
+      id: 'merge-into-current',
+      key: 'M',
+      label: 'Merge branch into current',
+      description: 'Merge the selected branch into the current branch.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+      warning: (state) => state.pendingConfirmationPayload
+        || 'Merging into the current branch. Creates a merge commit (or fast-forwards if possible).',
+    },
+    {
+      id: 'reset-to-branch',
+      key: '',
+      label: 'Reset current branch to ref',
+      description: 'Move the current branch pointer to match the selected ref.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+      warning: 'Rewrites local history. Use g u to undo if needed.',
+    },
+    {
+      id: 'sync-branch',
+      key: 'S',
+      label: 'Sync branch (pull + push)',
+      description: 'Pull from remote then push local commits.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
       // Per-view-only — the inkInput handler scopes this to the tags
       // surface so we don't expose `R` as a remote-delete from elsewhere.
       // The empty `key` keeps the workflow palette-discoverable but does

--- a/src/workstation/runtime/undoStack.test.ts
+++ b/src/workstation/runtime/undoStack.test.ts
@@ -1,11 +1,11 @@
 import {
-  MAX_UNDO_STACK_SIZE,
-  findMostRecentUndoEntry,
-  performUndo,
-  popUndoEntry,
-  pushUndoEntry,
-  removeUndoEntry,
-  type UndoEntry,
+    MAX_UNDO_STACK_SIZE,
+    findMostRecentUndoEntry,
+    performUndo,
+    popUndoEntry,
+    pushUndoEntry,
+    removeUndoEntry,
+    type UndoEntry,
 } from './undoStack'
 
 function branchEntry(overrides: Partial<Extract<UndoEntry, { kind: 'delete-branch' }>> = {}): UndoEntry {
@@ -149,6 +149,133 @@ describe('undo stack (OSS-1606)', () => {
       const result = await performUndo(git as never, entry)
       expect(result).toEqual({ ok: true, message: 'Restored tag v1.0.0' })
       expect(git.raw).toHaveBeenCalledWith(['tag', 'v1.0.0', 'abc1234'])
+    })
+
+    it('resets --hard back to pre-merge HEAD for a merge-branch undo', async () => {
+      const git = {
+        revparse: jest.fn().mockResolvedValue('/tmp/coco-missing-git-state'),
+        raw: jest.fn().mockResolvedValue(''),
+      }
+      const entry: UndoEntry = {
+        kind: 'merge-branch',
+        label: 'merge feature/xyz into main',
+        depth: 0,
+        previousSha: 'aabbccdd1234',
+      }
+      const result = await performUndo(git as never, entry)
+      expect(result).toEqual({ ok: true, message: 'Restored HEAD to aabbccd' })
+      expect(git.raw).toHaveBeenCalledWith(['reset', '--hard', 'aabbccdd1234'])
+    })
+
+    it('resets using the recorded mode for a reset-to-branch undo (hard)', async () => {
+      const git = {
+        revparse: jest.fn().mockResolvedValue('/tmp/coco-missing-git-state'),
+        raw: jest.fn().mockResolvedValue(''),
+      }
+      const entry: UndoEntry = {
+        kind: 'reset-to-branch',
+        label: 'reset --hard to feature/other',
+        depth: 0,
+        previousSha: 'deadbeef5678',
+        mode: 'hard',
+      }
+      const result = await performUndo(git as never, entry)
+      expect(result).toEqual({ ok: true, message: 'Restored HEAD to deadbee' })
+      expect(git.raw).toHaveBeenCalledWith(['reset', '--hard', 'deadbeef5678'])
+    })
+
+    it('resets using the recorded mode for a reset-to-branch undo (soft)', async () => {
+      const git = {
+        revparse: jest.fn().mockResolvedValue('/tmp/coco-missing-git-state'),
+        raw: jest.fn().mockResolvedValue(''),
+      }
+      const entry: UndoEntry = {
+        kind: 'reset-to-branch',
+        label: 'reset --soft to feature/other',
+        depth: 0,
+        previousSha: 'deadbeef5678',
+        mode: 'soft',
+      }
+      const result = await performUndo(git as never, entry)
+      expect(result).toEqual({ ok: true, message: 'Restored HEAD to deadbee' })
+      expect(git.raw).toHaveBeenCalledWith(['reset', '--soft', 'deadbeef5678'])
+    })
+
+    it('resets using the recorded mode for a reset-to-branch undo (mixed)', async () => {
+      const git = {
+        revparse: jest.fn().mockResolvedValue('/tmp/coco-missing-git-state'),
+        raw: jest.fn().mockResolvedValue(''),
+      }
+      const entry: UndoEntry = {
+        kind: 'reset-to-branch',
+        label: 'reset --mixed to feature/other',
+        depth: 0,
+        previousSha: 'deadbeef5678',
+        mode: 'mixed',
+      }
+      const result = await performUndo(git as never, entry)
+      expect(result).toEqual({ ok: true, message: 'Restored HEAD to deadbee' })
+      expect(git.raw).toHaveBeenCalledWith(['reset', '--mixed', 'deadbeef5678'])
+    })
+  })
+
+  describe('pushUndoEntry / popUndoEntry with new entry types', () => {
+    it('push/pop works with merge-branch entries', () => {
+      const entry: UndoEntry = {
+        kind: 'merge-branch',
+        label: 'merge feature/xyz into main',
+        depth: 0,
+        previousSha: 'aabbccdd1234',
+      }
+      let stack: UndoEntry[] = []
+      stack = pushUndoEntry(stack, entry)
+      const { entry: popped, stack: remaining } = popUndoEntry(stack)
+      expect(popped).toEqual(entry)
+      expect(remaining).toEqual([])
+    })
+
+    it('push/pop works with reset-to-branch entries', () => {
+      const entry: UndoEntry = {
+        kind: 'reset-to-branch',
+        label: 'reset --hard to feature/other',
+        depth: 0,
+        previousSha: 'deadbeef5678',
+        mode: 'hard',
+      }
+      let stack: UndoEntry[] = []
+      stack = pushUndoEntry(stack, entry)
+      const { entry: popped, stack: remaining } = popUndoEntry(stack)
+      expect(popped).toEqual(entry)
+      expect(remaining).toEqual([])
+    })
+
+    it('interleaves new entry types with existing kinds in LIFO order', () => {
+      const deleteBranch = branchEntry({ name: 'old-branch' })
+      const mergeBranch: UndoEntry = {
+        kind: 'merge-branch',
+        label: 'merge feature/xyz',
+        depth: 0,
+        previousSha: 'aabb1234',
+      }
+      const resetToBranch: UndoEntry = {
+        kind: 'reset-to-branch',
+        label: 'reset --hard to develop',
+        depth: 0,
+        previousSha: 'ccdd5678',
+        mode: 'hard',
+      }
+
+      let stack: UndoEntry[] = []
+      stack = pushUndoEntry(stack, deleteBranch)
+      stack = pushUndoEntry(stack, mergeBranch)
+      stack = pushUndoEntry(stack, resetToBranch)
+
+      const pop1 = popUndoEntry(stack)
+      expect(pop1.entry).toEqual(resetToBranch)
+      const pop2 = popUndoEntry(pop1.stack)
+      expect(pop2.entry).toEqual(mergeBranch)
+      const pop3 = popUndoEntry(pop2.stack)
+      expect(pop3.entry).toEqual(deleteBranch)
     })
   })
 })

--- a/src/workstation/runtime/undoStack.ts
+++ b/src/workstation/runtime/undoStack.ts
@@ -49,6 +49,8 @@ export type UndoEntry =
   | { kind: 'drop-stash'; label: string; depth: number; workdir?: string; hash: string; message: string }
   | { kind: 'reset-to-commit'; label: string; depth: number; workdir?: string; previousSha: string; mode: ResetMode }
   | { kind: 'delete-tag'; label: string; depth: number; workdir?: string; name: string; sha: string }
+  | { kind: 'merge-branch'; label: string; depth: number; workdir?: string; previousSha: string }
+  | { kind: 'reset-to-branch'; label: string; depth: number; workdir?: string; previousSha: string; mode: ResetMode }
 
 export type UndoActionResult = { ok: boolean; message: string }
 
@@ -98,5 +100,9 @@ export function performUndo(git: SimpleGit, entry: UndoEntry): Promise<UndoActio
       return restorePreviousHead(git, entry.previousSha, entry.mode)
     case 'delete-tag':
       return restoreDeletedTag(git, entry.name, entry.sha)
+    case 'merge-branch':
+      return restorePreviousHead(git, entry.previousSha, 'hard')
+    case 'reset-to-branch':
+      return restorePreviousHead(git, entry.previousSha, entry.mode)
   }
 }


### PR DESCRIPTION
## Summary

Adds five new branch-level workflows to the workstation branches view (`g b`), completing the branch synchronization story so `coco ui` is self-sufficient for everyday branch workflows without dropping to a shell.

## New Operations

| Key | Action | Description |
|-----|--------|-------------|
| `M` | Merge | Merges cursored branch into current (auto-detects FF vs merge commit) |
| `Z` | Reset | Resets current branch to cursored ref (soft/mixed/hard mode choice) |
| `S` | Sync | Compound pull+push with divergence recovery and conflict handling |
| `P` | Push (enhanced) | Sub-choice: normal push or force-push (`--force-with-lease`) |

## Implementation

Spans the full stack following established patterns:

- **Git layer** (`src/git/branchActions.ts`): `mergeBranch`, `canFastForward`, `resetCurrentBranchToRef`, `isResetBackward`
- **Undo stack** (`undoStack.ts`): `merge-branch` and `reset-to-branch` entry types with `performUndo` handlers
- **Keymap** (`inkKeymap.ts`): `M`/`Z`/`S` bindings for `branches` context, collision-free
- **Workflows** (`inkWorkflows.ts`): Three new registrations — `merge-into-current` (destructive), `reset-to-branch` (destructive), `sync-branch` (normal)
- **Input** (`inkInput.ts`): `RESET_TO_BRANCH_MODE_CHOICE` and `PUSH_SUB_CHOICE` constants, key handlers with self-operation guards
- **Workflow handlers** (`useWorkflowAction.ts`): Full merge/reset/sync logic with undo entries, momentum hints, conflict routing, and divergence recovery
- **Footer** (`inkKeymap.ts`): Updated hints with priority ordering (Enter > M > P > S > Z > utility keys)

## Key Design Decisions

- **FF detection before merge**: `canFastForward` checks if HEAD is an ancestor of the target before choosing `--ff-only` vs standard merge — avoids unnecessary merge commits
- **Reset backward detection**: `isResetBackward` runs *before* the reset (after reset, HEAD moves to target making the check meaningless) — enables context-aware momentum hints ("force-push with P → f" vs "view history")
- **Sync abort on divergence**: Rather than silently rebasing, sync surfaces a strategy choice (rebase/merge) so the user picks intentionally — the push continues only after a clean pull
- **Push sub-choice**: `P` no longer fires a direct push; it raises `PUSH_SUB_CHOICE` so force-push is discoverable but gated behind a destructive confirmation

## Tests

40+ new tests across all layers:
- Git layer: 15 tests (merge, FF detection, reset modes, backward detection)
- Undo stack: 7 tests (push/pop, performUndo dispatch for both new types)
- Input handling: 6 tests (M/Z/S/P guards and dispatch)
- Workflow handlers: 18 tests (merge FF/non-FF/conflict/self-guard, reset modes/undo/hints, sync pull+push/divergence/conflicts/no-upstream)
- Workflows: 4 tests (registration shape verification)
- Footer: 6 tests (hint presence, priority ordering, 80-col trimming)

Full suite passes: **6671 tests, 0 failures**. Lint clean, typecheck clean.

## How to Test

1. `coco ui` → `g b` (branches view)
2. Cursor to a non-current branch
3. Press `M` to merge, `Z` for reset mode choice, `S` to sync, `P` for push sub-choice
4. Verify `g u` undoes merge/reset operations
5. Force a conflict scenario to verify conflict routing (`g x`)
