### PR TITLE
Add branch operations workflows and screenshot support

### DIFF
--- a/.kiro/specs/workstation-branch-operations/.config.kiro
+++ b/.kiro/specs/workstation-branch-operations/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "0664ddf4-aea3-4bb3-b2cb-d9dc807ad01a", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/workstation-branch-operations/design.md
+++ b/.kiro/specs/workstation-branch-operations/design.md
@@ -1,0 +1,519 @@
+# Design Document: Workstation Branch Operations
+
+## Overview
+
+This feature adds five new branch-level workflows to the coco workstation branches view (`g b`): merge, reset-to-ref, force-push (via sub-choice from existing `P`), pull-with-strategy-choice (enhancement to existing `U`), and sync (pull+push compound). These extend the existing patterns — `useWorkflowAction` handlers, `pendingChoice` overlays, the `undoStack`, and `postApplyHints`-style momentum hints — without introducing new architectural concepts.
+
+The design mirrors what's already in place for the history view's `Z` reset, the PR triage view's `m` merge-strategy picker, and the push-rejected → force-push escalation flow. Each new operation follows the same keypress → choice/confirmation → git action → status + momentum hint pipeline that every existing write operation uses.
+
+---
+
+## Architecture
+
+The feature integrates across four layers (matching the existing `lib ← git ← workstation ← commands` direction):
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ inkInput.ts (branch-action predicate)                    │
+│   M → merge choice/confirm                              │
+│   Z → reset mode choice → confirm                       │
+│   P → push sub-choice (normal / force)                  │
+│   S → sync (no confirm — non-destructive)              │
+│   U → pull (enhanced with divergence recovery)          │
+├──────────────────────────────────────────────────────────┤
+│ inkWorkflows.ts (workflow registrations)                  │
+│   merge-into-current, reset-to-branch, sync-branch,    │
+│   (existing: force-push-current-branch,                 │
+│    pull-rebase-current, pull-merge-current)              │
+├──────────────────────────────────────────────────────────┤
+│ useWorkflowAction.ts (handlers)                          │
+│   merge handler → git merge + conflict routing          │
+│   reset-to-branch handler → git reset + undo entry      │
+│   sync handler → pull-then-push compound                 │
+├──────────────────────────────────────────────────────────┤
+│ src/git/branchActions.ts (new git functions)             │
+│   mergeBranch(), resetCurrentBranchToRef(),             │
+│   canFastForward(), syncBranch()                        │
+└──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Components and Interfaces
+
+### New Git Layer Functions (`src/git/branchActions.ts`)
+
+```typescript
+/** Merge the named branch into the current branch. */
+export function mergeBranch(
+  git: SimpleGit,
+  branchName: string,
+  fastForwardOnly?: boolean
+): Promise<BranchActionResult>
+
+/** Detect if the current branch can fast-forward to the given ref. */
+export function canFastForward(
+  git: SimpleGit,
+  targetRef: string
+): Promise<boolean>
+
+/** Reset the current branch to a given ref with the specified mode. */
+export function resetCurrentBranchToRef(
+  git: SimpleGit,
+  targetRef: string,
+  mode: ResetMode
+): Promise<BranchActionResult>
+
+/**
+ * Determine if a reset to targetRef would move the branch pointer
+ * backward (history rewrite) vs forward. Returns true when targetRef
+ * is an ancestor of HEAD — meaning HEAD has commits beyond targetRef
+ * that the reset would discard.
+ */
+export function isResetBackward(
+  git: SimpleGit,
+  targetRef: string
+): Promise<boolean>
+```
+
+### New Workflow IDs
+
+| Workflow ID | Key | Context | Confirmation | Description |
+|-------------|-----|---------|--------------|-------------|
+| `merge-into-current` | `M` | branches | y-confirm | Merge cursored branch into current |
+| `reset-to-branch` | `Z` | branches | y-confirm | Reset current branch to cursored ref |
+| `sync-branch` | `S` | branches | none | Pull + push compound |
+
+### Enhanced Existing Workflows
+
+| Workflow ID | Change |
+|-------------|--------|
+| `push-selected-branch` | `P` now raises a sub-choice: normal push / force push (instead of immediately pushing) |
+| `pull-selected-branch` / `pull-current-branch` | Already handles divergence via `isDivergedPullError` — no change needed beyond registering in the sync compound |
+
+### New Choice Prompts (`inkInput.ts` constants)
+
+```typescript
+// Note: The merge flow uses `setPendingConfirmation('merge-into-current')` directly.
+// The dynamic confirmation text (branch names + FF indicator) is computed in the
+// workflow registration's `warning` callback, not as a separate choice constant.
+// See the workflow registration in the Command Palette Integration section.
+
+const RESET_TO_BRANCH_MODE_CHOICE = {
+  id: 'reset-to-branch-mode-choice',
+  title: 'Reset current branch to the cursored branch',
+  warning: 'hard discards ALL uncommitted working-tree changes.',
+  options: [
+    { key: 's', label: 'Soft — keep changes staged', workflowId: 'reset-to-branch', payload: 'soft' },
+    { key: 'm', label: 'Mixed — keep changes unstaged', workflowId: 'reset-to-branch', payload: 'mixed' },
+    { key: 'h', label: 'Hard — discard working-tree changes', workflowId: 'reset-to-branch', payload: 'hard', destructive: true },
+  ],
+}
+
+const PUSH_SUB_CHOICE = {
+  id: 'push-sub-choice',
+  title: 'Push branch',
+  options: [
+    { key: 'p', label: 'Push (normal)', workflowId: 'push-selected-branch' },
+    { key: 'f', label: 'Force push (--force-with-lease)', workflowId: 'force-push-selected-branch', destructive: true },
+  ],
+}
+```
+
+### Keybinding Assignments (Branches View)
+
+Current branches view keys: `Enter`, `+`, `R`, `D`, `u`, `F`, `U`, `P`, `r`, `s`, `m`.
+
+New assignments:
+- **`M`** — merge (uppercase; distinct from existing `m` mark-compare-base)
+- **`Z`** — reset-to-ref (matches history view's `Z` convention)
+- **`S`** — sync (uppercase; distinct from existing `s` cycle-sort)
+- **`P`** — enhanced: raises push sub-choice (normal / force) instead of immediately pushing
+
+No new top-level binding needed for force-push — it lives as a sub-option of `P` and as a momentum-hint escalation after a rejected normal push (existing pattern). Pull-with-strategy remains on `U` with the existing diverged-pull recovery.
+
+**Collision check:** `M`, `Z`, `S` are all free in the branches view context. `P` already exists and is being enhanced (not added). The `inkKeymap.collisions.test.ts` guard will validate this.
+
+---
+
+## Data Models
+
+### New Undo Entry Variants
+
+The existing `UndoEntry` union in `undoStack.ts` needs two new variants:
+
+```typescript
+export type UndoEntry =
+  | { kind: 'delete-branch'; ... }
+  | { kind: 'drop-stash'; ... }
+  | { kind: 'reset-to-commit'; ... }
+  | { kind: 'delete-tag'; ... }
+  // NEW:
+  | { kind: 'merge-branch'; label: string; depth: number; workdir?: string; previousSha: string }
+  | { kind: 'reset-to-branch'; label: string; depth: number; workdir?: string; previousSha: string; mode: ResetMode }
+```
+
+The `merge-branch` undo performs `git reset --hard <previousSha>` (since a merge creates a new commit, undoing it means resetting to the pre-merge HEAD). The `reset-to-branch` undo performs `git reset --<originalMode> <previousSha>` (same pattern as the existing `reset-to-commit` entry).
+
+Note: The existing `reset-to-commit` entry type already handles the undo for history-view resets. The new `reset-to-branch` entry is structurally identical but uses a distinct `kind` so undo messages can reference the branch name context.
+
+### State Additions (`LogInkState`)
+
+No new state fields required. The feature uses existing state mechanisms:
+- `pendingChoice` — for mode/strategy pickers
+- `pendingConfirmationId` — for y-confirm overlays
+- `status` / `statusKind` — for success/error/loading messages
+- `undoStack` — for recording reversible operations
+- `activeView` — for conflict routing (set to `'conflicts'`)
+
+### Workflow Context (`LogInkWorkflowContext`)
+
+Already carries `branches?: BranchOverview` which includes `currentBranch`, the full branch list, and upstream info. No additions needed.
+
+---
+
+## Error Handling
+
+### Merge Errors
+
+| Condition | Handling |
+|-----------|----------|
+| Cursored branch = current branch | Prevent initiation. Status: "Cannot merge a branch into itself." |
+| Working tree dirty (git refuses) | Status error with git's message |
+| Conflicts detected | Route to conflicts view via existing `isOperationConflictError` + `setPendingChoice` pattern |
+| Merge already in progress | Status error: "A merge is already in progress. Use `g x` to resolve or abort." |
+
+### Reset Errors
+
+| Condition | Handling |
+|-----------|----------|
+| Cursored branch = current branch | Prevent initiation. Status: "Nothing to reset — branch is already at that ref." |
+| Working tree dirty + hard mode | Git refuses; surface the error. (The confirmation already warns.) |
+
+### Push/Force-Push Errors
+
+| Condition | Handling |
+|-----------|----------|
+| `--force-with-lease` rejected (remote has unseen commits) | Status error: "Remote has commits you haven't fetched. Run F to fetch first." |
+| No upstream configured | Status error: "No upstream — set one with `u` first." |
+| Danger warning fails to display | Block execution entirely. The confirmation panel rendering is a prerequisite — if `pendingConfirmationId` is set but the overlay isn't visible (a bug), the `y` keypress handler must not fire the workflow. (Enforcement: the overlay render returns a boolean indicating it rendered; the input handler checks this.) |
+
+### Sync Errors
+
+| Condition | Handling |
+|-----------|----------|
+| No upstream configured | Prevent initiation. Status: "No upstream — press `u` to set one first." |
+| Pull phase diverges | Present strategy-choice (rebase/merge) — same as standalone pull |
+| Pull phase conflicts | Route to conflicts view, status: "Sync interrupted — resolve conflicts then push manually with P." |
+| Push phase fails (non-fast-forward) | Status error with failure reason; pull result is preserved (already committed) |
+
+---
+
+## Fast-Forward Detection
+
+Before showing the merge confirmation overlay, the handler calls `canFastForward(git, cursoredBranchRef)`:
+
+```typescript
+async function canFastForward(git: SimpleGit, targetRef: string): Promise<boolean> {
+  // Current HEAD is an ancestor of targetRef AND targetRef is NOT
+  // an ancestor of current HEAD (i.e., target is strictly ahead).
+  try {
+    const mergeBase = (await git.raw(['merge-base', 'HEAD', targetRef])).trim()
+    const currentHead = (await git.raw(['rev-parse', 'HEAD'])).trim()
+    return mergeBase === currentHead
+  } catch {
+    return false
+  }
+}
+```
+
+When fast-forward is available:
+- The confirmation overlay text says "Fast-forward merge — no merge commit will be created"
+- The merge handler uses `git merge --ff-only` 
+- The success momentum hint says "Fast-forwarded `<current>` to `<target>`. Push with P"
+
+When branches have diverged:
+- The confirmation overlay says "Merge `<source>` into `<target>` — creates a merge commit"
+- Standard `git merge <branch>` is used
+
+---
+
+## Confirmation Flow
+
+All confirmations use the existing `y-confirm` overlay system (`pendingConfirmationId` + `LogInkWorkflowAction.requiresConfirmation: true`). The specific flows:
+
+### Merge (`M`)
+
+1. User presses `M` on cursored branch
+2. Guard: if cursored = current → status error, return (prevents initiation)
+3. Async: compute `canFastForward` result
+4. Show confirmation overlay with branch names + FF indicator
+5. On `y` → execute merge → on success: momentum hint + undo entry; on conflict: route to conflicts view
+
+### Reset (`Z`)
+
+1. User presses `Z` on cursored branch
+2. Guard: if cursored = current → status error, return (prevents initiation)
+3. Show mode-choice prompt (s/m/h) — same pattern as history view's `Z`
+4. User selects mode → confirmation overlay with history-rewrite warning (extra warning for hard mode)
+5. On `y` → execute reset → record undo entry → momentum hint (force-push suggestion only if `isResetBackward` returns true and branch has upstream)
+
+### Push (`P` enhanced)
+
+1. User presses `P` on cursored branch (or current branch)
+2. Show push sub-choice: `p` normal / `f` force-push
+3. If `p` → existing `push-selected-branch` workflow (no extra confirm)
+4. If `f` → `force-push-selected-branch` workflow (requires y-confirm with danger warning)
+5. Force-push confirmation MUST display the danger warning. If the warning fails to render, execution is blocked.
+
+### Sync (`S`)
+
+1. User presses `S` (no confirmation — compound of two non-destructive ops)
+2. Guard: no upstream → status error suggesting `u`
+3. Execute pull (ff-only) → if diverged, present strategy choice → on conflict, abort sync + route to conflicts
+4. If pull succeeded → execute push → on success: "Branch fully synchronized. View history with gh"
+
+---
+
+## Undo Entries
+
+### Merge Undo
+
+```typescript
+// Recorded on merge success:
+{ kind: 'merge-branch', label: `merge ${source} into ${target}`, depth, workdir, previousSha: premergeHead }
+
+// Reversed via:
+git.raw(['reset', '--hard', previousSha])
+```
+
+This matches the existing `reset-to-commit` inverse pattern. A merge undo always uses `--hard` because the merge commit itself is what's being unwound — there's no meaningful "keep staged" state for a merge reversal. Note: if the user had unrelated uncommitted changes that survived the merge (rare — git usually refuses merges with a dirty tree), the hard-reset undo would discard those changes too. The undo's `g u` feedback message should mention this: "Undid merge (hard reset) — uncommitted changes were not preserved."
+
+### Reset-to-Branch Undo
+
+```typescript
+// Recorded on reset success:
+{ kind: 'reset-to-branch', label: `reset to ${target} (${mode})`, depth, workdir, previousSha, mode }
+
+// Reversed via (same as reset-to-commit):
+restorePreviousHead(git, previousSha, mode)
+```
+
+Uses the same `restorePreviousHead` function the existing `reset-to-commit` undo calls.
+
+---
+
+## Conflict Routing
+
+When a merge or pull-with-strategy produces conflicts, the workstation routes to the conflicts view using the existing `isOperationConflictError` detection + `setPendingChoice` pattern already used by `rebase-onto-branch`, `cherry-pick-commit`, `pull-current-branch`, etc.
+
+The existing code in `useWorkflowAction.ts` already has a `conflictRecoveryTitles` map. The new workflow IDs are added to it:
+
+```typescript
+const conflictRecoveryTitles: Record<string, string> = {
+  ...existing,
+  'merge-into-current': 'Merge stopped on conflicts',
+}
+```
+
+The sync workflow handles conflicts specially: when the pull phase hits conflicts, the sync aborts (doesn't attempt push) and routes to the conflicts view with a message that the sync was interrupted.
+
+---
+
+## Key Registration
+
+### `inkKeymap.ts` — `LOG_INK_KEY_BINDINGS` additions
+
+```typescript
+{ keys: ['M'], contexts: ['branches'], label: 'merge', id: 'merge-into-current' },
+{ keys: ['Z'], contexts: ['branches'], label: 'reset', id: 'reset-to-branch' },
+{ keys: ['S'], contexts: ['branches'], label: 'sync', id: 'sync-branch' },
+```
+
+`P` already exists for branches (push); its behavior changes from direct-fire to sub-choice, but the binding entry stays the same.
+
+### `inkInput.ts` — branch action predicate handler
+
+The new keys are handled inside the existing `if (isBranchActionTarget(state) && context.branchCount)` block. Note: `isBranchActionTarget` returns true for BOTH the branches view proper (`activeView === 'branches' && focus === 'commits'`) AND the sidebar when `sidebarTab === 'branches'`. The new handlers inherit this dual-scope automatically — no extra handling needed, but be aware that the cursored branch may come from either context.
+
+```typescript
+if (inputValue === 'M') {
+  // Guard: can't merge into self
+  if (cursoredBranch === currentBranch) {
+    return [action({ type: 'setStatus', value: "Cannot merge a branch into itself.", kind: 'error' })]
+  }
+  return [action({ type: 'setPendingConfirmation', value: 'merge-into-current' })]
+}
+
+if (inputValue === 'Z') {
+  // Guard: can't reset to self
+  if (cursoredBranch === currentBranch) {
+    return [action({ type: 'setStatus', value: "Nothing to reset — already at that ref.", kind: 'error' })]
+  }
+  return [action({ type: 'setPendingChoice', value: RESET_TO_BRANCH_MODE_CHOICE })]
+}
+
+if (inputValue === 'S') {
+  return [{ type: 'runWorkflowAction', id: 'sync-branch' }]
+}
+
+// Enhanced P — sub-choice instead of direct push
+if (inputValue === 'P') {
+  return [action({ type: 'setPendingChoice', value: PUSH_SUB_CHOICE })]
+}
+```
+
+---
+
+## Command Palette Integration
+
+New workflow registrations in `inkWorkflows.ts` → `getLogInkWorkflowActions()`:
+
+```typescript
+{
+  id: 'merge-into-current',
+  key: 'M',
+  label: 'Merge branch into current',
+  description: 'Merge the selected branch into the current branch',
+  kind: 'destructive',
+  requiresConfirmation: true,
+  warning: (state) => `Merging into ${currentBranch}. Creates a merge commit (or fast-forwards if possible).`,
+},
+{
+  id: 'reset-to-branch',
+  key: '',  // Empty — routed via mode-choice, not direct key in palette
+  label: 'Reset current branch to ref',
+  description: 'Move the current branch pointer to match the selected ref',
+  kind: 'destructive',
+  requiresConfirmation: true,
+  warning: 'Rewrites local history. Use g u to undo if needed.',
+},
+{
+  id: 'sync-branch',
+  key: 'S',
+  label: 'Sync branch (pull + push)',
+  description: 'Pull from remote then push local commits',
+  kind: 'normal',
+  requiresConfirmation: false,
+},
+```
+
+The existing `force-push-current-branch` and `force-push-selected-branch` registrations already exist in the workflow table. They're accessed through the push sub-choice and through the non-fast-forward escalation path.
+
+---
+
+## Footer Hints
+
+New hints added to the branches view footer band (space-permitting, per narrow-terminal trimming rules):
+
+```
+M merge  Z reset  S sync  P push  ...existing...
+```
+
+Priority ordering (highest → lowest, leftmost survives trimming):
+1. `Enter` checkout (most common)
+2. `M` merge (new, high-value)
+3. `P` push (enhanced)
+4. `S` sync (new, compound convenience)
+5. `Z` reset (new, destructive)
+6. `+` create, `R` rename, `D` delete, `u` upstream (existing)
+
+---
+
+## Momentum Hints
+
+Following the `postApplyHints.ts` pattern, each successful operation returns a hint naming the next keystroke:
+
+| Operation | Momentum Hint |
+|-----------|---------------|
+| Merge (FF) | `"Fast-forwarded {current} to {source}. Push with P"` |
+| Merge (commit) | `"Merged {source} into {current}. Push with P"` |
+| Reset (backward + has upstream) | `"Reset {current} to {target} ({mode}). Force-push with P → f"` |
+| Reset (forward or no upstream) | `"Reset {current} to {target} ({mode}). View history with gh"` |
+| Sync | `"Branch fully synchronized. View history with gh"` |
+| Force-push | `"Force-pushed {branch} (with lease). View history with gh"` |
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- **Git layer** (`branchActions.test.ts`): `mergeBranch`, `canFastForward`, `resetCurrentBranchToRef`, `isResetBackward` against mock `SimpleGit` instances
+- **Undo stack** (`undoStack.test.ts`): new `merge-branch` and `reset-to-branch` entry push/pop/perform
+- **Choice constants**: verify `RESET_TO_BRANCH_MODE_CHOICE` and `PUSH_SUB_CHOICE` option shapes
+- **Workflow registrations**: confirm collision-test passes with new bindings
+
+### Integration Tests
+
+- Scenario-based tests using `@gfargo/git-scenarios`:
+  - `mid-merge-conflict` — verify conflict routing
+  - Feature branch ahead/behind scenarios — verify FF detection
+  - Diverged branch — verify pull strategy choice triggers
+
+### Property-Based Testing Assessment
+
+PBT is **not appropriate** for this feature. The operations are:
+- Git wrapper functions (external service calls)
+- UI workflow orchestration (input → state transitions)
+- Side-effect-heavy (write to git, read state, route views)
+
+The behavior doesn't vary meaningfully with random input — it's driven by discrete git states (ahead/behind/diverged/conflicted) and discrete user choices (key presses). Example-based unit tests against mocked `SimpleGit` and scenario-based integration tests provide the right coverage.
+
+---
+
+## Mermaid: Merge Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant I as inkInput
+    participant W as useWorkflowAction
+    participant G as git/branchActions
+
+    U->>I: Press M (branches view)
+    I->>I: Guard: cursored ≠ current
+    I->>I: setPendingConfirmation('merge-into-current')
+    Note over I: Confirmation overlay shows<br/>source→target + FF indicator
+    U->>I: Press y (confirm)
+    I->>W: runWorkflowAction('merge-into-current')
+    W->>G: canFastForward(git, cursoredRef)
+    G-->>W: true/false
+    alt Fast-forward available
+        W->>G: mergeBranch(git, ref, ffOnly=true)
+    else Diverged
+        W->>G: mergeBranch(git, ref)
+    end
+    alt Success
+        G-->>W: { ok: true }
+        W->>W: pushUndoEntry('merge-branch', preMergeHEAD)
+        W->>W: setStatus(momentum hint)
+    else Conflicts
+        G-->>W: { ok: false, conflict error }
+        W->>W: setPendingChoice(conflict-recovery)
+        Note over W: Routes to conflicts view
+    end
+```
+
+## Mermaid: Push Sub-Choice Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant I as inkInput
+    participant W as useWorkflowAction
+
+    U->>I: Press P (branches view)
+    I->>I: setPendingChoice(PUSH_SUB_CHOICE)
+    Note over I: Choice overlay: p=push, f=force
+    alt User selects p
+        U->>I: Press p
+        I->>W: runWorkflowAction('push-selected-branch')
+    else User selects f
+        U->>I: Press f
+        I->>I: setPendingConfirmation('force-push-selected-branch')
+        Note over I: Danger warning overlay
+        U->>I: Press y
+        I->>W: runWorkflowAction('force-push-selected-branch')
+    end
+```

--- a/.kiro/specs/workstation-branch-operations/requirements.md
+++ b/.kiro/specs/workstation-branch-operations/requirements.md
@@ -1,0 +1,181 @@
+# Requirements Document
+
+## Introduction
+
+This feature adds branch write operations to the coco workstation TUI (`coco ui`) that are currently missing from the branches view: merge, reset-branch-to-ref, push (including force-push), pull-with-strategy-choice, fast-forward merge, and a sync-branch compound operation. These operations complete the branch synchronization story, making `coco ui` a self-sufficient terminal git client for everyday branch workflows without dropping to a shell.
+
+## Glossary
+
+- **Workstation**: The full-screen Ink/React TUI accessed via `coco ui` or `coco log -i`
+- **Branches_View**: The workstation surface reached via `g b` that lists local and remote branches
+- **Cursored_Branch**: The branch currently highlighted by the selection cursor in the Branches_View
+- **Current_Branch**: The branch checked out in the working directory (HEAD)
+- **Merge_Operation**: A git merge that integrates changes from one branch into another
+- **Fast_Forward_Merge**: A merge where the target branch pointer advances without creating a merge commit because no divergence exists
+- **Reset_To_Ref**: Moves the current branch pointer to match another ref (branch, tag, or commit) using soft, mixed, or hard mode
+- **Force_Push**: A push that overwrites remote history using `--force-with-lease` (refuses to clobber unseen remote commits)
+- **Sync_Operation**: A compound pull-then-push workflow that brings local up to date and then publishes local commits
+- **Undo_Stack**: The session-scoped in-memory stack that records invertible destructive actions (branch delete, stash drop, reset, tag delete)
+- **Confirmation_Overlay**: The y-confirm or enter-confirm panel that gates destructive bare-keystroke actions
+- **Momentum_Hint**: A success message that names the next logical keystroke (e.g. "Merged main → feature. Push with P")
+- **Command_Palette**: The `:` overlay listing all registered workflows by name, searchable by typing
+- **Footer_Hints**: The bottom-row key labels showing available actions for the current view
+- **Conflicts_View**: The workstation surface (`g x`) that handles conflict resolution when a merge or rebase produces conflicts
+
+## Requirements
+
+### Requirement 1: Merge Branch
+
+**User Story:** As a developer, I want to merge the cursored branch into my current branch from the branches view, so that I can integrate changes without leaving the TUI.
+
+#### Acceptance Criteria
+
+1. WHEN the user presses the merge keybinding on a Cursored_Branch in the Branches_View, THE Workstation SHALL initiate a Merge_Operation that merges the Cursored_Branch into the Current_Branch
+2. WHEN the Cursored_Branch is the same as the Current_Branch, THE Workstation SHALL prevent the merge from initiating and display an error message stating that a branch cannot be merged into itself
+3. WHEN the Merge_Operation completes without conflicts, THE Workstation SHALL display a success Momentum_Hint naming the merged branch, the target branch, and suggesting push as the next action
+4. WHEN the Merge_Operation produces conflicts, THE Workstation SHALL transition to the Conflicts_View and display a status message indicating the number of conflicted files
+5. WHEN the Merge_Operation is initiated, THE Workstation SHALL display a Confirmation_Overlay showing the source branch, the target branch, and the merge direction
+
+### Requirement 2: Fast-Forward Merge
+
+**User Story:** As a developer, I want the workstation to detect when a fast-forward merge is possible and offer it as the default strategy, so that I avoid unnecessary merge commits.
+
+#### Acceptance Criteria
+
+1. WHEN the Current_Branch is strictly behind the Cursored_Branch with no divergent commits, THE Workstation SHALL indicate in the Confirmation_Overlay that a fast-forward merge is available
+2. WHEN a fast-forward merge is available and the user confirms, THE Workstation SHALL advance the Current_Branch pointer without creating a merge commit
+3. WHEN the branches have diverged, THE Workstation SHALL perform a standard merge that creates a merge commit
+4. WHEN a Fast_Forward_Merge completes, THE Workstation SHALL display a success message stating the branch was fast-forwarded and suggesting push as the next action
+
+### Requirement 3: Reset Current Branch to Another Ref
+
+**User Story:** As a developer, I want to reset my current branch to match the cursored branch from the branches view, so that I can realign branch pointers without using the command line.
+
+#### Acceptance Criteria
+
+1. WHEN the user presses the reset keybinding on a Cursored_Branch in the Branches_View, THE Workstation SHALL present a mode-choice prompt offering soft, mixed, and hard reset options
+2. WHEN the user selects a reset mode, THE Workstation SHALL display a Confirmation_Overlay with a warning that reset rewrites the Current_Branch history
+3. WHEN the reset completes, THE Workstation SHALL record the previous HEAD position in the Undo_Stack so that the operation can be reversed with `g u`
+4. WHEN a hard reset is selected, THE Workstation SHALL include an additional warning in the Confirmation_Overlay stating that uncommitted changes will be permanently lost
+5. WHEN the Cursored_Branch is the same as the Current_Branch, THE Workstation SHALL reject the reset and display a message stating there is nothing to reset
+
+### Requirement 4: Push After Merge or Reset
+
+**User Story:** As a developer, I want to push immediately after a merge or reset completes, so that I can publish changes in a single flow without extra keystrokes.
+
+#### Acceptance Criteria
+
+1. WHEN a Merge_Operation or Fast_Forward_Merge completes successfully, THE Workstation SHALL include a Momentum_Hint naming the push keybinding
+2. WHEN a Reset_To_Ref operation completes and the remote tracking branch exists and the reset moved the branch pointer backward (history rewrite), THE Workstation SHALL include a Momentum_Hint suggesting force-push as the next action
+3. WHEN the user presses the force-push keybinding in the Branches_View, THE Workstation SHALL display a Confirmation_Overlay with a warning that force-push rewrites remote history
+4. WHEN a force-push is confirmed, THE Workstation SHALL execute `git push --force-with-lease` for the Current_Branch
+5. IF a force-push fails because the remote has unseen commits, THEN THE Workstation SHALL display an error message recommending a fetch before retrying
+
+### Requirement 5: Pull Strategy Choice
+
+**User Story:** As a developer, I want to choose between pull-with-rebase and pull-with-merge when my local branch has diverged from the remote, so that I control how divergent histories are reconciled.
+
+#### Acceptance Criteria
+
+1. WHEN the user presses the pull keybinding and the pull fails due to divergence, THE Workstation SHALL present a strategy-choice prompt offering rebase and merge options
+2. WHEN the user selects rebase, THE Workstation SHALL execute `git pull --rebase` and display a success message on completion
+3. WHEN the user selects merge, THE Workstation SHALL execute `git pull --no-rebase` and display a success message on completion
+4. WHEN a pull-with-rebase encounters conflicts, THE Workstation SHALL transition to the Conflicts_View
+5. WHEN a pull-with-merge encounters conflicts, THE Workstation SHALL transition to the Conflicts_View
+6. WHEN the pull succeeds without divergence (fast-forward), THE Workstation SHALL complete silently with a success Momentum_Hint
+
+### Requirement 6: Sync Branch Operation
+
+**User Story:** As a developer, I want a single-keystroke sync operation that pulls and then pushes, so that I can bring my branch fully up to date with the remote in one action.
+
+#### Acceptance Criteria
+
+1. WHEN the user triggers the sync keybinding in the Branches_View, THE Workstation SHALL execute a pull followed by a push as a single compound workflow
+2. WHEN the pull phase of a Sync_Operation fails due to divergence, THE Workstation SHALL present the strategy-choice prompt before continuing
+3. WHEN the pull phase of a Sync_Operation encounters conflicts, THE Workstation SHALL abort the sync, transition to the Conflicts_View, and display a message that sync was interrupted
+4. WHEN the push phase of a Sync_Operation fails, THE Workstation SHALL display an error message with the failure reason and leave the successful pull result intact
+5. WHEN a Sync_Operation completes both phases successfully, THE Workstation SHALL display a single success message stating the branch is fully synchronized
+6. WHEN the Current_Branch has no upstream configured, THE Workstation SHALL reject the sync and display a message suggesting `u` to set an upstream first
+
+### Requirement 7: Conflict Handling
+
+**User Story:** As a developer, I want merge and pull operations that produce conflicts to route me directly to the conflicts view, so that I can resolve them without manual navigation.
+
+#### Acceptance Criteria
+
+1. WHEN a Merge_Operation produces conflicts, THE Workstation SHALL automatically navigate to the Conflicts_View
+2. WHEN a pull-with-rebase produces conflicts, THE Workstation SHALL automatically navigate to the Conflicts_View
+3. WHEN a pull-with-merge produces conflicts, THE Workstation SHALL automatically navigate to the Conflicts_View
+4. WHEN the Conflicts_View is reached via a branch operation, THE Workstation SHALL display a status message identifying the operation that caused the conflicts
+
+### Requirement 8: Undo Support
+
+**User Story:** As a developer, I want to undo merge and reset operations when possible, so that I can recover from mistakes without leaving the TUI.
+
+#### Acceptance Criteria
+
+1. WHEN a Merge_Operation completes, THE Workstation SHALL record the pre-merge HEAD in the Undo_Stack
+2. WHEN a Reset_To_Ref operation completes, THE Workstation SHALL record the pre-reset HEAD and the reset mode in the Undo_Stack
+3. WHEN the user triggers undo (`g u`) after a merge, THE Workstation SHALL reset the Current_Branch back to the pre-merge commit
+4. WHEN the user triggers undo (`g u`) after a reset, THE Workstation SHALL reset the Current_Branch back to the pre-reset commit using the same mode that was originally used
+5. IF a Merge_Operation has already been pushed to the remote, THEN THE Workstation SHALL still allow local undo but display a warning that the remote remains unchanged
+
+### Requirement 9: Feedback and Status Messages
+
+**User Story:** As a developer, I want clear loading, success, and error states for all branch operations, so that I always know what the TUI is doing.
+
+#### Acceptance Criteria
+
+1. WHILE a branch operation is in progress, THE Workstation SHALL display a loading indicator in the footer with the operation name
+2. WHEN a branch operation succeeds, THE Workstation SHALL display a success message in the footer using the success glyph and color
+3. WHEN a branch operation fails, THE Workstation SHALL display an error message in the footer using the error glyph and color, including the reason for failure
+4. WHEN a force-push warning is displayed, THE Workstation SHALL use the warning glyph and color to distinguish it from informational messages
+5. THE Workstation SHALL format all success messages as Momentum_Hints that name the next logical keystroke
+
+### Requirement 10: Confirmation Prompts
+
+**User Story:** As a developer, I want appropriate confirmation gates on destructive operations, so that I cannot accidentally rewrite history with a single errant keystroke.
+
+#### Acceptance Criteria
+
+1. WHEN the merge keybinding is pressed, THE Workstation SHALL require y-confirm before executing the merge
+2. WHEN the reset keybinding is pressed, THE Workstation SHALL require y-confirm before executing the reset
+3. WHEN the force-push keybinding is pressed, THE Workstation SHALL require y-confirm before executing the force-push
+4. WHEN the sync keybinding is pressed, THE Workstation SHALL execute without additional confirmation because the pull+push sequence is non-destructive under normal conditions
+5. WHEN a confirmation panel is displayed for force-push, THE Workstation SHALL include a danger-level warning that remote history will be rewritten, and SHALL block force-push execution entirely if the danger warning fails to display — requiring both user confirmation AND successful warning rendering before proceeding
+
+### Requirement 11: Keybinding Assignments
+
+**User Story:** As a developer, I want intuitive keybindings for the new operations that avoid collisions with existing keys in the branches view.
+
+#### Acceptance Criteria
+
+1. THE Workstation SHALL assign `M` to the merge operation in the Branches_View
+2. THE Workstation SHALL assign `Z` to the reset-to-ref operation in the Branches_View (matching the history view reset convention)
+3. THE Workstation SHALL assign `Shift+P` (capital `P`) with a force modifier or a sub-choice to expose force-push in the Branches_View
+4. THE Workstation SHALL assign `S` to the sync operation in the Branches_View
+5. THE Workstation SHALL retain the existing `U` keybinding for pull but enhance it with the divergence strategy-choice prompt
+6. WHEN a new keybinding is registered and a collision with an existing binding in the same context is detected by `inkKeymap.collisions.test.ts`, THE Workstation SHALL block registration entirely rather than auto-reassigning the conflicting binding
+
+### Requirement 12: Command Palette Entries
+
+**User Story:** As a developer, I want all new operations discoverable through the command palette, so that I can find them by name even if I forget the keybinding.
+
+#### Acceptance Criteria
+
+1. THE Workstation SHALL register a "Merge branch into current" entry in the Command_Palette accessible from the Branches_View
+2. THE Workstation SHALL register a "Reset current branch to ref" entry in the Command_Palette accessible from the Branches_View
+3. THE Workstation SHALL register a "Force push current branch" entry in the Command_Palette accessible from the Branches_View
+4. THE Workstation SHALL register a "Sync branch (pull + push)" entry in the Command_Palette accessible from the Branches_View
+5. THE Workstation SHALL register a "Pull with rebase" and "Pull with merge" entry in the Command_Palette accessible from the Branches_View
+
+### Requirement 13: Progressive Disclosure
+
+**User Story:** As a developer, I want new operations surfaced in footer hints and help views, so that I discover them naturally as I use the branches view.
+
+#### Acceptance Criteria
+
+1. WHEN the Branches_View is active, THE Workstation SHALL include merge, reset, and sync in the footer hint band (space permitting per the narrow-terminal trimming rules)
+2. WHEN the user presses `g?` in the Branches_View, THE Workstation SHALL list all new branch operations with their keybindings in the which-key strip
+3. WHEN the user presses `?` for full help, THE Workstation SHALL include a "Branch operations" section listing merge, reset, force-push, sync, and pull-strategy actions with descriptions
+4. THE Workstation SHALL respect the existing footer hint budget so that the 80x24 terminal floor remains functional without overflow

--- a/.kiro/specs/workstation-branch-operations/tasks.md
+++ b/.kiro/specs/workstation-branch-operations/tasks.md
@@ -1,0 +1,195 @@
+# Implementation Plan: Workstation Branch Operations
+
+## Overview
+
+This plan adds five branch-level workflows to the coco workstation branches view: merge, reset-to-ref, force-push (via sub-choice from `P`), pull-with-strategy-choice (enhanced `U`), and sync (pull+push compound). Implementation follows the existing layering: git functions first, then undo stack types, then workflow registrations and key handling, and finally wiring the workflow handlers together.
+
+## Tasks
+
+- [x] 1. Add merge and reset git layer functions
+  - [x] 1.1 Implement `mergeBranch` and `canFastForward` in `src/git/branchActions.ts`
+    - Add `mergeBranch(git, branchName, fastForwardOnly?)` that calls `git.merge([branchName])` (or `--ff-only` when `fastForwardOnly` is true) and returns a `BranchActionResult`
+    - Add `canFastForward(git, targetRef)` that uses `git.raw(['merge-base', 'HEAD', targetRef])` + `git.raw(['rev-parse', 'HEAD'])` to detect if current HEAD is an ancestor of targetRef
+    - Follow the existing `runAction()` helper pattern for error handling
+    - _Requirements: 1.1, 2.1, 2.2, 2.3_
+
+  - [x] 1.2 Implement `resetCurrentBranchToRef` and `isResetBackward` in `src/git/branchActions.ts`
+    - Add `resetCurrentBranchToRef(git, targetRef, mode: ResetMode)` that calls `git.reset([`--${mode}`, targetRef])` and returns a `BranchActionResult`
+    - Add `isResetBackward(git, targetRef)` that checks if targetRef is an ancestor of HEAD (meaning HEAD has commits beyond targetRef that the reset would discard) using `git.raw(['merge-base', '--is-ancestor', targetRef, 'HEAD'])` — exit 0 means targetRef IS an ancestor of HEAD → reset goes backward; non-zero exit means it's not → reset goes forward or diverges
+    - Import `ResetMode` from `src/git/historyActions.ts` (already exported there)
+    - _Requirements: 3.1, 3.2, 4.2_
+
+  - [x] 1.3 Write unit tests for new git layer functions in `src/git/branchActions.test.ts`
+    - Test `mergeBranch` with mock SimpleGit for success, conflict, and ff-only cases
+    - Test `canFastForward` for ahead, behind, and diverged scenarios
+    - Test `resetCurrentBranchToRef` for soft/mixed/hard modes
+    - Test `isResetBackward` for forward and backward reset cases
+    - _Requirements: 1.1, 2.1, 2.2, 3.1, 3.2_
+
+- [x] 2. Extend undo stack with merge and reset entry types
+  - [x] 2.1 Add `merge-branch` and `reset-to-branch` variants to `UndoEntry` in `src/workstation/runtime/undoStack.ts`
+    - Add `| { kind: 'merge-branch'; label: string; depth: number; workdir?: string; previousSha: string }` to the `UndoEntry` union
+    - Add `| { kind: 'reset-to-branch'; label: string; depth: number; workdir?: string; previousSha: string; mode: ResetMode }` to the `UndoEntry` union
+    - Extend `performUndo` switch to handle `merge-branch` (calls `restorePreviousHead(git, previousSha, 'hard')`) and `reset-to-branch` (calls `restorePreviousHead(git, previousSha, mode)`)
+    - _Requirements: 8.1, 8.2, 8.3, 8.4_
+
+  - [x] 2.2 Write unit tests for new undo entry types in `src/workstation/runtime/undoStack.test.ts`
+    - Test push/pop of `merge-branch` and `reset-to-branch` entries
+    - Test `performUndo` dispatches correctly for the new kinds
+    - _Requirements: 8.1, 8.2, 8.3, 8.4_
+
+- [x] 3. Register new keybindings in `src/workstation/runtime/inkKeymap.ts`
+  - [x] 3.1 Add `M`, `Z`, and `S` key bindings for branches context
+    - Add `{ keys: ['M'], contexts: ['branches'], label: 'merge', id: 'merge-into-current' }` to `LOG_INK_KEY_BINDINGS`
+    - Add `{ keys: ['Z'], contexts: ['branches'], label: 'reset', id: 'reset-to-branch' }` to `LOG_INK_KEY_BINDINGS`
+    - Add `{ keys: ['S'], contexts: ['branches'], label: 'sync', id: 'sync-branch' }` to `LOG_INK_KEY_BINDINGS`
+    - Verify the existing `inkKeymap.collisions.test.ts` passes (no collisions with existing bindings)
+    - _Requirements: 11.1, 11.2, 11.4, 11.6_
+
+- [x] 4. Register new workflow actions in `src/workstation/runtime/inkWorkflows.ts`
+  - [x] 4.1 Add `merge-into-current`, `reset-to-branch`, and `sync-branch` workflow registrations
+    - Add workflow action objects to `getLogInkWorkflowActions()` with appropriate `id`, `key`, `label`, `description`, `kind`, `requiresConfirmation`, and `warning` fields
+    - `merge-into-current`: kind `'destructive'`, requiresConfirmation `true`
+    - `reset-to-branch`: kind `'destructive'`, requiresConfirmation `true`
+    - `sync-branch`: kind `'normal'`, requiresConfirmation `false`
+    - _Requirements: 12.1, 12.2, 12.4_
+
+  - [x] 4.2 Write tests for new workflow registrations in `src/workstation/runtime/inkWorkflows.test.ts`
+    - Verify the new workflows are returned by `getLogInkWorkflowActions()`
+    - Verify their properties match the design (kind, confirmation requirements)
+    - _Requirements: 12.1, 12.2, 12.4_
+
+- [x] 5. Implement choice constants and input handling in `src/workstation/runtime/inkInput.ts`
+  - [x] 5.1 Add choice prompt constants (`MERGE_CONFIRM`, `RESET_TO_BRANCH_MODE_CHOICE`, `PUSH_SUB_CHOICE`)
+    - Define `RESET_TO_BRANCH_MODE_CHOICE` with soft/mixed/hard options following the existing `pendingChoice` pattern
+    - Define `PUSH_SUB_CHOICE` with normal push / force push options
+    - The merge flow uses `setPendingConfirmation` directly (no separate choice constant needed)
+    - _Requirements: 3.1, 3.4, 10.1, 10.2, 10.3_
+
+  - [x] 5.2 Add `M`, `Z`, `S` key handlers in the branches view action predicate block
+    - `M`: guard cursored = current → error status; else → `setPendingConfirmation('merge-into-current')`
+    - `Z`: guard cursored = current → error status; else → `setPendingChoice(RESET_TO_BRANCH_MODE_CHOICE)`
+    - `S`: guard no upstream → error status; else → `runWorkflowAction('sync-branch')`
+    - _Requirements: 1.2, 3.5, 6.6, 11.1, 11.2, 11.4_
+
+  - [x] 5.3 Enhance `P` handler to show push sub-choice instead of direct push
+    - Replace the existing direct-push behavior for `P` in branches view with `setPendingChoice(PUSH_SUB_CHOICE)`
+    - The sub-choice routes `p` → `push-selected-branch` and `f` → force-push confirmation
+    - Force-push option requires y-confirm with danger warning before execution
+    - _Requirements: 4.3, 4.4, 10.3, 10.5, 11.3_
+
+  - [x] 5.4 Write tests for new input handling in `src/workstation/runtime/inkInput.test.ts`
+    - Test `M` guard (cursored = current → error)
+    - Test `Z` guard (cursored = current → error)
+    - Test `S` guard (no upstream → error)
+    - Test `P` sub-choice dispatch
+    - _Requirements: 1.2, 3.5, 6.6, 11.3_
+
+- [x] 6. Checkpoint - Verify keybinding and registration layer
+  - Ensure all tests pass (`npm run test:jest`), ask the user if questions arise.
+  - Run `inkKeymap.collisions.test.ts` specifically to confirm no key conflicts.
+
+- [x] 7. Implement merge workflow handler
+  - [x] 7.1 Add `merge-into-current` handler in `src/workstation/runtime/hooks/useWorkflowAction.ts`
+    - Before execution: call `canFastForward(git, cursoredRef)` to determine merge strategy
+    - If FF available: call `mergeBranch(git, ref, true)` with ff-only
+    - If diverged: call `mergeBranch(git, ref)` for standard merge
+    - On success: push `merge-branch` undo entry with pre-merge HEAD, set momentum hint ("Fast-forwarded..." or "Merged...")
+    - On conflict: detect via `isOperationConflictError` and route to conflicts view using existing `conflictRecoveryTitles` pattern
+    - Add `'merge-into-current': 'Merge stopped on conflicts'` to `conflictRecoveryTitles`
+    - _Requirements: 1.1, 1.3, 1.4, 1.5, 2.1, 2.2, 2.3, 2.4, 4.1, 7.1, 7.4, 8.1, 8.3, 9.1, 9.2, 9.3_
+
+  - [x] 7.2 Write tests for merge workflow handler
+    - Test FF detection and merge-commit creation paths
+    - Test undo entry recording (pre-merge HEAD preserved)
+    - Test conflict routing to conflicts view
+    - Test self-merge guard prevents execution
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 7.1, 8.1_
+
+- [x] 8. Implement reset-to-branch workflow handler
+  - [x] 8.1 Add `reset-to-branch` handler in `src/workstation/runtime/hooks/useWorkflowAction.ts`
+    - Accept the mode from the choice prompt payload (soft/mixed/hard)
+    - Call `resetCurrentBranchToRef(git, cursoredRef, mode)`
+    - On success: push `reset-to-branch` undo entry with pre-reset HEAD and mode
+    - Call `isResetBackward(git, cursoredRef)` to determine momentum hint: if backward + has upstream → suggest force-push; otherwise → suggest view history
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 4.2, 8.2, 8.4, 9.1, 9.2, 9.3, 9.5_
+
+  - [x] 8.2 Write tests for reset-to-branch workflow handler
+    - Test soft/mixed/hard mode dispatch
+    - Test undo entry recording (previousSha + mode preserved)
+    - Test momentum hint selection based on `isResetBackward` result
+    - _Requirements: 3.1, 3.2, 3.3, 4.2, 8.2_
+
+- [x] 9. Implement sync workflow handler
+  - [x] 9.1 Add `sync-branch` handler in `src/workstation/runtime/hooks/useWorkflowAction.ts`
+    - Guard: check upstream exists, else set error status and return
+    - Execute pull (ff-only first); if diverged → present strategy-choice (rebase/merge) using existing `isDivergedPullError` detection
+    - If pull conflicts → abort sync, route to conflicts view with "Sync interrupted" message
+    - If pull succeeded → execute push; on success → "Branch fully synchronized" momentum hint
+    - If push fails → set error status with reason, leave pull result intact
+    - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 7.2, 7.3, 7.4, 9.1, 9.2, 9.3, 9.5_
+
+  - [x] 9.2 Write tests for sync workflow handler
+    - Test successful pull+push compound
+    - Test divergence triggers strategy choice
+    - Test conflict aborts sync and routes to conflicts view
+    - Test push failure preserves pull result
+    - Test no-upstream guard
+    - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.5, 6.6_
+
+- [x] 10. Checkpoint - Verify workflow handlers
+  - Ensure all tests pass (`npm run test:jest`), ask the user if questions arise.
+
+- [x] 11. Add footer hints and command palette entries
+  - [x] 11.1 Add footer hints for branches view in `src/workstation/runtime/footer.ts`
+    - Add `M merge`, `Z reset`, `S sync` to the branches view hint band
+    - Respect existing priority ordering and narrow-terminal trimming rules
+    - _Requirements: 13.1, 13.4_
+
+  - [x] 11.2 Ensure command palette discoverability
+    - Verify `merge-into-current`, `reset-to-branch`, and `sync-branch` appear in the command palette (`:`) when in branches view — they should already appear from the workflow registrations in task 4.1
+    - Add `force-push-selected-branch` to command palette if not already registered
+    - Add `pull-rebase-current` and `pull-merge-current` entries if not already registered
+    - _Requirements: 12.1, 12.2, 12.3, 12.4, 12.5_
+
+  - [x] 11.3 Write tests for footer hints
+    - Verify new hints appear in branches view footer output
+    - Verify trimming behavior respects 80x24 floor
+    - _Requirements: 13.1, 13.4_
+
+- [x] 12. Final checkpoint - Full validation
+  - Run `npm run lint` — zero new problems
+  - Run `npx tsc --noEmit` — no type errors
+  - Run `npm run test:jest` — all tests pass
+  - Verify `inkKeymap.collisions.test.ts` passes
+  - Verify `inkKeymap.footerHonesty.test.ts` passes (footer hints match registered bindings)
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- The design explicitly states PBT is not appropriate for this feature (git wrappers + UI workflow orchestration); testing uses example-based unit tests and scenario-based integration tests
+- The existing `branchActions.ts` already has `forcePushCurrentBranch`, `forcePushBranch`, `pullCurrentBranch`, `pullCurrentBranchRebase`, `pullCurrentBranchMerge`, `pushCurrentBranch`, and error detection helpers (`isNonFastForwardPushError`, `isDivergedPullError`, `isOperationConflictError`) — the new functions build on these patterns
+- The existing `undoStack.ts` already imports from `branchActions` and `historyActions` — extending it with two new entry kinds is straightforward
+- Checkpoints ensure incremental validation at the integration boundaries (registration layer, then workflow handlers, then full validation)
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1", "1.2"] },
+    { "id": 1, "tasks": ["1.3", "2.1"] },
+    { "id": 2, "tasks": ["2.2", "3.1"] },
+    { "id": 3, "tasks": ["4.1"] },
+    { "id": 4, "tasks": ["4.2", "5.1"] },
+    { "id": 5, "tasks": ["5.2", "5.3"] },
+    { "id": 6, "tasks": ["5.4"] },
+    { "id": 7, "tasks": ["7.1", "8.1", "9.1"] },
+    { "id": 8, "tasks": ["7.2", "8.2", "9.2"] },
+    { "id": 9, "tasks": ["11.1", "11.2"] },
+    { "id": 10, "tasks": ["11.3"] }
+  ]
+}
+```

--- a/.kiro/specs/workstation-branch-operations/tasks.meta.json
+++ b/.kiro/specs/workstation-branch-operations/tasks.meta.json
@@ -1,0 +1,476 @@
+{
+  "pbtResults": {},
+  "executionHistory": {
+    "1.1 Implement `mergeBranch` and `canFastForward` in `src/git/branchActions.ts`": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212258819
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212267261
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212410375
+      }
+    ],
+    "1.2 Implement `resetCurrentBranchToRef` and `isResetBackward` in `src/git/branchActions.ts`": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212258916
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212268162
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212411255
+      }
+    ],
+    "1.3 Write unit tests for new git layer functions in `src/git/branchActions.test.ts`": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212258972
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212415435
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212516235
+      }
+    ],
+    "2.1 Add `merge-branch` and `reset-to-branch` variants to `UndoEntry` in `src/workstation/runtime/undoStack.ts`": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259021
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212416369
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212517389
+      }
+    ],
+    "2.2 Write unit tests for new undo entry types in `src/workstation/runtime/undoStack.test.ts`": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259066
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212521324
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212639082
+      }
+    ],
+    "3.1 Add `M`, `Z`, and `S` key bindings for branches context": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259108
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212522214
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212638007
+      }
+    ],
+    "4.1 Add `merge-into-current`, `reset-to-branch`, and `sync-branch` workflow registrations": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259156
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212642862
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212733465
+      }
+    ],
+    "4.2 Write tests for new workflow registrations in `src/workstation/runtime/inkWorkflows.test.ts`": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259198
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212737547
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212841972
+      }
+    ],
+    "5.1 Add choice prompt constants (`MERGE_CONFIRM`, `RESET_TO_BRANCH_MODE_CHOICE`, `PUSH_SUB_CHOICE`)": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259245
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212738394
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212842961
+      }
+    ],
+    "5.2 Add `M`, `Z`, `S` key handlers in the branches view action predicate block": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259296
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212846868
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213092682
+      }
+    ],
+    "5.3 Enhance `P` handler to show push sub-choice instead of direct push": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259346
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212847671
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213093461
+      }
+    ],
+    "5.4 Write tests for new input handling in `src/workstation/runtime/inkInput.test.ts`": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259389
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213097352
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213271744
+      }
+    ],
+    "6. Checkpoint - Verify keybinding and registration layer": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259438
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213277622
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213338976
+      }
+    ],
+    "7.1 Add `merge-into-current` handler in `src/workstation/runtime/hooks/useWorkflowAction.ts`": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259481
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213343389
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213553737
+      }
+    ],
+    "7.2 Write tests for merge workflow handler": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259523
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213559409
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213779880
+      }
+    ],
+    "8.1 Add `reset-to-branch` handler in `src/workstation/runtime/hooks/useWorkflowAction.ts`": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259564
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213344239
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213554656
+      }
+    ],
+    "8.2 Write tests for reset-to-branch workflow handler": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259605
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213560162
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213780609
+      }
+    ],
+    "9.1 Add `sync-branch` handler in `src/workstation/runtime/hooks/useWorkflowAction.ts`": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259648
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213345060
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213555428
+      }
+    ],
+    "9.2 Write tests for sync workflow handler": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259690
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213560861
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213781316
+      }
+    ],
+    "10. Checkpoint - Verify workflow handlers": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259731
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213786752
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213932240
+      }
+    ],
+    "11.1 Add footer hints for branches view in `src/workstation/runtime/footer.ts`": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259774
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213787096
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213932993
+      }
+    ],
+    "11.2 Ensure command palette discoverability": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259832
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213787981
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213933682
+      }
+    ],
+    "11.3 Write tests for footer hints": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259900
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213938088
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786214076112
+      }
+    ],
+    "12. Final checkpoint - Full validation": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212259948
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786214079670
+      },
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786214250209
+      }
+    ],
+    "1. Add merge and reset git layer functions": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212516291
+      }
+    ],
+    "3. Register new keybindings in `src/workstation/runtime/inkKeymap.ts`": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212638055
+      }
+    ],
+    "2. Extend undo stack with merge and reset entry types": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212639144
+      }
+    ],
+    "4. Register new workflow actions in `src/workstation/runtime/inkWorkflows.ts`": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786212842018
+      }
+    ],
+    "5. Implement choice constants and input handling in `src/workstation/runtime/inkInput.ts`": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213271812
+      }
+    ],
+    "7. Implement merge workflow handler": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213779945
+      }
+    ],
+    "8. Implement reset-to-branch workflow handler": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213780656
+      }
+    ],
+    "9. Implement sync workflow handler": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786213781357
+      }
+    ],
+    "11. Add footer hints and command palette entries": [
+      {
+        "executionId": "a6a7d89f-0c10-495e-9e40-2f3f565af234",
+        "chatSessionId": "sess_d03402af-66c1-4c50-a90c-7083405226eb",
+        "timestamp": 1786214076167
+      }
+    ]
+  }
+}

--- a/bin/screenshot/recipes.ts
+++ b/bin/screenshot/recipes.ts
@@ -1263,6 +1263,42 @@ export const RECIPES: ScreenshotRecipe[] = [
     ],
   },
   {
+    name: 'demo-branch-operations',
+    description: 'UI: branches view — merge (M), reset mode choice (Z), push sub-choice (P), demonstrating the branch write workflow',
+    scenario: 'branch-sync-showcase',
+    command: 'ui',
+    emitGif: true,
+    actions: [
+      // Open branches view
+      { kind: 'sleep', ms: 800 },
+      { kind: 'type', text: 'gb' },
+      { kind: 'sleep', ms: 1500 },
+      // Move cursor down to a non-current branch
+      { kind: 'key', key: 'Down' },
+      { kind: 'sleep', ms: 500 },
+      { kind: 'key', key: 'Down' },
+      { kind: 'sleep', ms: 800 },
+      // Press M to merge — shows the confirmation overlay
+      { kind: 'type', text: 'M' },
+      { kind: 'sleep', ms: 2400 },
+      // Cancel the merge confirmation (Esc) so we can show the next op
+      { kind: 'key', key: 'Escape' },
+      { kind: 'sleep', ms: 800 },
+      // Press Z to reset — shows soft/mixed/hard mode choice
+      { kind: 'type', text: 'Z' },
+      { kind: 'sleep', ms: 2400 },
+      // Cancel the reset mode choice
+      { kind: 'key', key: 'Escape' },
+      { kind: 'sleep', ms: 800 },
+      // Press P to push — shows push sub-choice (normal / force-push)
+      { kind: 'type', text: 'P' },
+      { kind: 'sleep', ms: 2400 },
+      // Cancel the push sub-choice
+      { kind: 'key', key: 'Escape' },
+      { kind: 'sleep', ms: 1000 },
+    ],
+  },
+  {
     name: 'demo-search-filter',
     description: 'UI: open search, type query, see results filter live, clear',
     scenario: 'multi-commit-branch',

--- a/bin/syncScreenshots.ts
+++ b/bin/syncScreenshots.ts
@@ -99,6 +99,7 @@ const SITE_RECIPES = [
   'ui-which-key',
   'ui-view-keys',
   'demo-view-keys',
+  'demo-branch-operations',
   'ui-compare-refs',
   'ui-stage-pathspec',
   // GitHub-integration views (mock-gh) — real data, no longer stubbed
@@ -182,6 +183,7 @@ const FILENAME_MAP: Record<string, string[]> = {
   'ui-which-key': ['which-key.png'],
   'ui-view-keys': ['view-keys.png'],
   'demo-view-keys': ['demo-view-keys.gif'],
+  'demo-branch-operations': ['demo-branch-operations.gif'],
   'ui-compare-refs': ['view-compare.png'],
   'ui-stage-pathspec': ['stage-pathspec.png'],
   'ui-staging-hunks': ['staging-hunks.png'],

--- a/src/git/branchActions.test.ts
+++ b/src/git/branchActions.test.ts
@@ -1,29 +1,33 @@
 import {
-  checkoutBranch,
-  checkoutBranchByName,
-  createBranch,
-  deleteBranch,
-  deleteBranches,
-  isBranchCheckedOutElsewhereError,
-  isBranchNotFullyMergedError,
-  isDirtyWorktreeCheckoutError,
-  parseCheckedOutWorktreePath,
-  fetchBranch,
-  fetchRemotes,
-  getBranchActionRefs,
-  pullBranch,
-  pullCurrentBranch,
-  pushBranch,
-  pushCurrentBranch,
-  renameBranch,
-  setUpstream,
-  forcePushBranch,
-  forcePushCurrentBranch,
-  isDivergedPullError,
-  isNonFastForwardPushError,
-  pullCurrentBranchMerge,
-  pullCurrentBranchRebase,
-  restoreDeletedBranch,
+    checkoutBranch,
+    checkoutBranchByName,
+    createBranch,
+    deleteBranch,
+    deleteBranches,
+    isBranchCheckedOutElsewhereError,
+    isBranchNotFullyMergedError,
+    isDirtyWorktreeCheckoutError,
+    parseCheckedOutWorktreePath,
+    fetchBranch,
+    fetchRemotes,
+    getBranchActionRefs,
+    pullBranch,
+    pullCurrentBranch,
+    pushBranch,
+    pushCurrentBranch,
+    renameBranch,
+    setUpstream,
+    forcePushBranch,
+    forcePushCurrentBranch,
+    isDivergedPullError,
+    isNonFastForwardPushError,
+    pullCurrentBranchMerge,
+    pullCurrentBranchRebase,
+    restoreDeletedBranch,
+    mergeBranch,
+    canFastForward,
+    resetCurrentBranchToRef,
+    isResetBackward,
 } from './branchActions'
 import { BranchRef } from './branchData'
 
@@ -708,5 +712,146 @@ describe('log branch actions', () => {
       expect(result.message).toContain('Only local branches')
       expect(git.raw).not.toHaveBeenCalled()
     })
+  })
+})
+
+
+describe('mergeBranch', () => {
+  it('merges a branch into current with a standard merge', async () => {
+    const git = { merge: jest.fn().mockResolvedValue({}) }
+    const result = await mergeBranch(git as never, 'feature/widgets')
+    expect(result).toEqual({ ok: true, message: 'Merged feature/widgets into current branch' })
+    expect(git.merge).toHaveBeenCalledWith(['feature/widgets'])
+  })
+
+  it('merges with --ff-only when fastForwardOnly is true', async () => {
+    const git = { merge: jest.fn().mockResolvedValue({}) }
+    const result = await mergeBranch(git as never, 'feature/widgets', true)
+    expect(result).toEqual({ ok: true, message: 'Fast-forwarded to feature/widgets' })
+    expect(git.merge).toHaveBeenCalledWith(['--ff-only', 'feature/widgets'])
+  })
+
+  it('returns an error on merge conflict', async () => {
+    const git = {
+      merge: jest.fn().mockRejectedValue(new Error('CONFLICTS: Merge conflict in src/app.ts')),
+    }
+    const result = await mergeBranch(git as never, 'feature/widgets')
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('CONFLICTS')
+  })
+
+  it('returns an error when ff-only fails due to divergence', async () => {
+    const git = {
+      merge: jest.fn().mockRejectedValue(
+        new Error('fatal: Not possible to fast-forward, aborting.')
+      ),
+    }
+    const result = await mergeBranch(git as never, 'feature/widgets', true)
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('Not possible to fast-forward')
+  })
+})
+
+describe('canFastForward', () => {
+  it('returns true when HEAD equals the merge-base (current is ancestor of target)', async () => {
+    const git = {
+      raw: jest.fn()
+        .mockResolvedValueOnce('abc1234\n') // merge-base HEAD targetRef
+        .mockResolvedValueOnce('abc1234\n'), // rev-parse HEAD
+    }
+    const result = await canFastForward(git as never, 'feature/ahead')
+    expect(result).toBe(true)
+    expect(git.raw).toHaveBeenNthCalledWith(1, ['merge-base', 'HEAD', 'feature/ahead'])
+    expect(git.raw).toHaveBeenNthCalledWith(2, ['rev-parse', 'HEAD'])
+  })
+
+  it('returns false when HEAD is ahead of merge-base (branches diverged)', async () => {
+    const git = {
+      raw: jest.fn()
+        .mockResolvedValueOnce('aaa0000\n') // merge-base
+        .mockResolvedValueOnce('bbb1111\n'), // rev-parse HEAD (different)
+    }
+    const result = await canFastForward(git as never, 'feature/diverged')
+    expect(result).toBe(false)
+  })
+
+  it('returns false when target is behind HEAD (merge-base equals target, not HEAD)', async () => {
+    const git = {
+      raw: jest.fn()
+        .mockResolvedValueOnce('ccc2222\n') // merge-base (same as target, not HEAD)
+        .mockResolvedValueOnce('ddd3333\n'), // rev-parse HEAD
+    }
+    const result = await canFastForward(git as never, 'feature/behind')
+    expect(result).toBe(false)
+  })
+
+  it('returns false when git commands fail (e.g. invalid ref)', async () => {
+    const git = {
+      raw: jest.fn().mockRejectedValue(new Error('fatal: Not a valid object name')),
+    }
+    const result = await canFastForward(git as never, 'nonexistent-ref')
+    expect(result).toBe(false)
+  })
+})
+
+describe('resetCurrentBranchToRef', () => {
+  it('resets with --soft mode', async () => {
+    const git = { reset: jest.fn().mockResolvedValue('') }
+    const result = await resetCurrentBranchToRef(git as never, 'feature/target', 'soft')
+    expect(result).toEqual({ ok: true, message: 'Reset current branch to feature/target (soft)' })
+    expect(git.reset).toHaveBeenCalledWith(['--soft', 'feature/target'])
+  })
+
+  it('resets with --mixed mode', async () => {
+    const git = { reset: jest.fn().mockResolvedValue('') }
+    const result = await resetCurrentBranchToRef(git as never, 'feature/target', 'mixed')
+    expect(result).toEqual({ ok: true, message: 'Reset current branch to feature/target (mixed)' })
+    expect(git.reset).toHaveBeenCalledWith(['--mixed', 'feature/target'])
+  })
+
+  it('resets with --hard mode', async () => {
+    const git = { reset: jest.fn().mockResolvedValue('') }
+    const result = await resetCurrentBranchToRef(git as never, 'abc1234', 'hard')
+    expect(result).toEqual({ ok: true, message: 'Reset current branch to abc1234 (hard)' })
+    expect(git.reset).toHaveBeenCalledWith(['--hard', 'abc1234'])
+  })
+
+  it('returns an error when git reset fails', async () => {
+    const git = {
+      reset: jest.fn().mockRejectedValue(new Error('fatal: Could not parse object \'bad-ref\'.')),
+    }
+    const result = await resetCurrentBranchToRef(git as never, 'bad-ref', 'hard')
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('Could not parse object')
+  })
+})
+
+describe('isResetBackward', () => {
+  it('returns true when targetRef is an ancestor of HEAD (reset discards commits)', async () => {
+    const git = {
+      // Exit 0 → targetRef IS an ancestor of HEAD → backward reset
+      raw: jest.fn().mockResolvedValue(''),
+    }
+    const result = await isResetBackward(git as never, 'feature/old')
+    expect(result).toBe(true)
+    expect(git.raw).toHaveBeenCalledWith(['merge-base', '--is-ancestor', 'feature/old', 'HEAD'])
+  })
+
+  it('returns false when targetRef is NOT an ancestor of HEAD (reset goes forward or diverges)', async () => {
+    const git = {
+      // Non-zero exit → not an ancestor
+      raw: jest.fn().mockRejectedValue(new Error('exit code 1')),
+    }
+    const result = await isResetBackward(git as never, 'feature/ahead')
+    expect(result).toBe(false)
+    expect(git.raw).toHaveBeenCalledWith(['merge-base', '--is-ancestor', 'feature/ahead', 'HEAD'])
+  })
+
+  it('returns false when the ref does not exist', async () => {
+    const git = {
+      raw: jest.fn().mockRejectedValue(new Error('fatal: Not a valid commit name nonexistent')),
+    }
+    const result = await isResetBackward(git as never, 'nonexistent')
+    expect(result).toBe(false)
   })
 })

--- a/src/git/branchActions.ts
+++ b/src/git/branchActions.ts
@@ -1,6 +1,7 @@
 import { SimpleGit } from 'simple-git'
 import { BranchRef } from './branchData'
 import { rejectFlagLike } from './forgeArgGuards'
+import type { ResetMode } from './historyActions'
 import { listRemotes, resolveDefaultRemoteName } from './remoteResolution'
 
 export type BranchActionResult = {
@@ -338,6 +339,47 @@ export function pullCurrentBranchMerge(git: SimpleGit): Promise<BranchActionResu
   )
 }
 
+/**
+ * Merge the named branch into the current branch.
+ *
+ * When `fastForwardOnly` is true, the merge uses `--ff-only` and refuses
+ * to create a merge commit — use this after `canFastForward` confirms
+ * the fast-forward path is available.
+ */
+export function mergeBranch(
+  git: SimpleGit,
+  branchName: string,
+  fastForwardOnly?: boolean
+): Promise<BranchActionResult> {
+  const args = fastForwardOnly ? ['--ff-only', branchName] : [branchName]
+  return runAction(
+    () => git.merge(args),
+    fastForwardOnly
+      ? `Fast-forwarded to ${branchName}`
+      : `Merged ${branchName} into current branch`
+  )
+}
+
+/**
+ * Detect if the current branch can fast-forward to the given ref.
+ *
+ * Returns true when HEAD is an ancestor of `targetRef` — meaning the
+ * merge-base of HEAD and targetRef equals HEAD itself, so no divergent
+ * commits exist on the current branch.
+ */
+export async function canFastForward(
+  git: SimpleGit,
+  targetRef: string
+): Promise<boolean> {
+  try {
+    const mergeBase = (await git.raw(['merge-base', 'HEAD', targetRef])).trim()
+    const currentHead = (await git.raw(['rev-parse', 'HEAD'])).trim()
+    return mergeBase === currentHead
+  } catch {
+    return false
+  }
+}
+
 export function fetchRemotes(git: SimpleGit): Promise<BranchActionResult> {
   return runAction(
     () => git.raw(['fetch', '--all', '--prune']),
@@ -559,4 +601,37 @@ export function pullBranch(
       ]),
     `Fast-forwarded ${branch.shortName} to ${branch.upstream}`
   )
+}
+
+
+/** Reset the current branch to a given ref with the specified mode. */
+export function resetCurrentBranchToRef(
+  git: SimpleGit,
+  targetRef: string,
+  mode: ResetMode
+): Promise<BranchActionResult> {
+  return runAction(
+    () => git.reset([`--${mode}`, targetRef]),
+    `Reset current branch to ${targetRef} (${mode})`
+  )
+}
+
+/**
+ * Determine if a reset to targetRef would move the branch pointer
+ * backward (history rewrite) vs forward. Returns true when targetRef
+ * is an ancestor of HEAD — meaning HEAD has commits beyond targetRef
+ * that the reset would discard.
+ */
+export async function isResetBackward(
+  git: SimpleGit,
+  targetRef: string
+): Promise<boolean> {
+  try {
+    await git.raw(['merge-base', '--is-ancestor', targetRef, 'HEAD'])
+    // Exit 0 → targetRef IS an ancestor of HEAD → reset goes backward
+    return true
+  } catch {
+    // Non-zero exit → targetRef is not an ancestor of HEAD → reset goes forward or diverges
+    return false
+  }
 }

--- a/src/workstation/runtime/footer.test.ts
+++ b/src/workstation/runtime/footer.test.ts
@@ -425,6 +425,73 @@ describe('renderFooter', () => {
     })
   })
 
+  // Branches view footer hints (workstation-branch-operations)
+  describe('branches view footer hints', () => {
+    const renderBranches = (columns?: number) =>
+      asNode(
+        renderFooter(
+          createElement,
+          { Box, Text },
+          makeState({ activeView: 'branches' }),
+          baseContext,
+          createLogInkTheme({ noColor: false }),
+          undefined,
+          0,
+          false,
+          columns
+        )
+      )
+    const contextualText = (tree: Node): string => {
+      return String(childAt(childAt(tree, 0), 0).props.children)
+    }
+
+    it('includes M merge, Z reset, and S sync in the branches view contextual hints', () => {
+      const ctx = contextualText(renderBranches())
+      expect(ctx).toContain('M merge')
+      expect(ctx).toContain('Z reset')
+      expect(ctx).toContain('S sync')
+    })
+
+    it('includes P push alongside the new branch operation hints', () => {
+      const ctx = contextualText(renderBranches())
+      expect(ctx).toContain('P push')
+    })
+
+    it('preserves enter checkout as the leading action hint', () => {
+      const ctx = contextualText(renderBranches())
+      expect(ctx).toContain('enter checkout')
+      // enter checkout should appear before the new operation hints
+      const checkoutIdx = ctx.indexOf('enter checkout')
+      const mergeIdx = ctx.indexOf('M merge')
+      expect(checkoutIdx).toBeLessThan(mergeIdx)
+    })
+
+    it('fits the branches footer within the 80-column floor', () => {
+      const tree = renderBranches(80)
+      const ctx = contextualText(tree)
+      const glob = String(childAt(childAt(tree, 0), 1).props.children)
+      // paddingX (2) + minimum space-between gap (>=1)
+      expect(ctx.length + glob.length + 2 + 1).toBeLessThanOrEqual(80)
+    })
+
+    it('trims lower-priority hints at 80 columns while keeping the leading essentials', () => {
+      const ctx = contextualText(renderBranches(80))
+      // At 80 columns the leading movement + checkout hints survive;
+      // the tail (lower-priority ops) gets dropped to fit the row.
+      expect(ctx).toContain('↑/↓ branches')
+      expect(ctx).toContain('enter checkout')
+      // Tail hints like yank / sort are dropped before the essential ops.
+      expect(ctx).not.toContain('y yank')
+    })
+
+    it('fits the branches footer within 120 columns', () => {
+      const tree = renderBranches(120)
+      const ctx = contextualText(tree)
+      const glob = String(childAt(childAt(tree, 0), 1).props.children)
+      expect(ctx.length + glob.length + 2 + 1).toBeLessThanOrEqual(120)
+    })
+  })
+
   // Snapshot covers the no-status default — the layout most users see
   // most of the time — to catch incidental structural drift.
   it('structural snapshot — default no-status footer', () => {

--- a/src/workstation/runtime/hooks/useWorkflowAction.test.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.test.ts
@@ -2,7 +2,7 @@ import type ReactTypes from 'react'
 import type { GitLogRow } from '../../../git/logData'
 import { createLogInkState, applyLogInkAction } from '../inkViewModel'
 import { checkoutReflogEntry, performReflogUndo, planReflogUndo } from '../../../git/reflogActions'
-import { checkoutBranch, checkoutBranchByName, deleteBranches, pullCurrentBranch, pullCurrentBranchRebase, pushBranch } from '../../../git/branchActions'
+import { checkoutBranch, checkoutBranchByName, deleteBranches, pullCurrentBranch, pullCurrentBranchRebase, pushBranch, pushCurrentBranch, mergeBranch, canFastForward, resetCurrentBranchToRef, isResetBackward } from '../../../git/branchActions'
 import { cherryPickCommit, cherryPickRange, cherryPickCommits, autosquashRebase } from '../../../git/historyActions'
 import { createStash, dropStashes, restoreStash } from '../../../git/stashActions'
 import { addOrEditCommitNote } from '../../../git/notesActions'
@@ -30,11 +30,16 @@ jest.mock('../../../git/branchActions', () => {
   return {
     ...actual,
     pushBranch: jest.fn(),
+    pushCurrentBranch: jest.fn(),
     pullCurrentBranch: jest.fn(),
     pullCurrentBranchRebase: jest.fn(),
     checkoutBranch: jest.fn(),
     checkoutBranchByName: jest.fn(),
     deleteBranches: jest.fn(),
+    mergeBranch: jest.fn(),
+    canFastForward: jest.fn(),
+    resetCurrentBranchToRef: jest.fn(),
+    isResetBackward: jest.fn(),
   }
 })
 
@@ -1647,5 +1652,574 @@ describe('undo stack (OSS-1606)', () => {
     await runWorkflowAction('undo-last-action')
     expect(git.raw).toHaveBeenCalledWith(['tag', 'v1.0.0', 'abc1234'])
     expect(dispatch).toHaveBeenCalledWith({ type: 'popUndoEntry' })
+  })
+})
+
+
+const mergeBranchMock = mergeBranch as jest.MockedFunction<typeof mergeBranch>
+const canFastForwardMock = canFastForward as jest.MockedFunction<typeof canFastForward>
+
+const mergeBranch_otherBranch = {
+  type: 'local',
+  name: 'refs/heads/feature/merge-target',
+  shortName: 'feature/merge-target',
+  hash: 'merge123',
+  current: false,
+  upstream: undefined,
+  remote: undefined,
+  date: '2026-05-01',
+  subject: 'feat: merge target',
+  ahead: 0,
+  behind: 0,
+} as never
+
+describe('merge-into-current workflow handler', () => {
+  beforeEach(() => {
+    mergeBranchMock.mockReset()
+    canFastForwardMock.mockReset()
+  })
+
+  it('calls mergeBranch with ff-only when canFastForward returns true', async () => {
+    canFastForwardMock.mockResolvedValue(true)
+    mergeBranchMock.mockResolvedValue({ ok: true, message: 'Fast-forward merge complete' })
+    const git = {
+      revparse: jest.fn().mockResolvedValue('previoushead123\n'),
+    }
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      context: { branches: { localBranches: [mergeBranch_otherBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('merge-into-current')
+    expect(canFastForwardMock).toHaveBeenCalledWith(expect.anything(), 'feature/merge-target')
+    expect(mergeBranchMock).toHaveBeenCalledWith(expect.anything(), 'feature/merge-target', true)
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: expect.stringContaining('Fast-forwarded'),
+      kind: 'success',
+    }))
+  })
+
+  it('calls mergeBranch without ff-only when canFastForward returns false', async () => {
+    canFastForwardMock.mockResolvedValue(false)
+    mergeBranchMock.mockResolvedValue({ ok: true, message: 'Merge complete' })
+    const git = {
+      revparse: jest.fn().mockResolvedValue('previoushead123\n'),
+    }
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      context: { branches: { localBranches: [mergeBranch_otherBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('merge-into-current')
+    expect(canFastForwardMock).toHaveBeenCalledWith(expect.anything(), 'feature/merge-target')
+    expect(mergeBranchMock).toHaveBeenCalledWith(expect.anything(), 'feature/merge-target')
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: expect.stringContaining('Merged feature/merge-target into main'),
+      kind: 'success',
+    }))
+  })
+
+  it('captures undo entry with kind merge-branch and pre-merge HEAD on success', async () => {
+    canFastForwardMock.mockResolvedValue(false)
+    mergeBranchMock.mockResolvedValue({ ok: true, message: 'Merge complete' })
+    const git = {
+      revparse: jest.fn().mockResolvedValue('deadbeef9876\n'),
+    }
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      context: { branches: { localBranches: [mergeBranch_otherBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('merge-into-current')
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'pushUndoEntry',
+      value: {
+        kind: 'merge-branch',
+        label: 'merge feature/merge-target into main',
+        depth: 0,
+        previousSha: 'deadbeef9876',
+      },
+    })
+  })
+
+  it('routes to conflicts view when merge produces conflicts', async () => {
+    canFastForwardMock.mockResolvedValue(false)
+    mergeBranchMock.mockResolvedValue({
+      ok: false,
+      message: 'CONFLICT (content): Merge conflict in src/app.ts\nerror: Automatic merge failed',
+    })
+    const git = {
+      revparse: jest.fn().mockResolvedValue('previoushead123\n'),
+    }
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      context: { branches: { localBranches: [mergeBranch_otherBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('merge-into-current')
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setPendingChoice',
+      value: expect.objectContaining({
+        id: 'operation-conflict-recovery',
+        title: 'Merge stopped on conflicts',
+        keepStatusOnDismiss: true,
+        options: [
+          expect.objectContaining({ key: 'x', intent: 'open-conflicts' }),
+          expect.objectContaining({ key: 'a', workflowId: 'abort-operation', destructive: true }),
+        ],
+      }),
+    }))
+  })
+
+  it('returns error when cursored branch equals current branch (self-merge guard)', async () => {
+    const currentBranch = {
+      type: 'local',
+      name: 'refs/heads/main',
+      shortName: 'main',
+      hash: 'abc',
+      current: true,
+      upstream: 'origin/main',
+      remote: 'origin',
+      date: '2026-05-01',
+      subject: 'feat',
+      ahead: 0,
+      behind: 0,
+    } as never
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      context: { branches: { localBranches: [currentBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('merge-into-current')
+    // Self-merge guard fires BEFORE canFastForward or mergeBranch
+    expect(canFastForwardMock).not.toHaveBeenCalled()
+    expect(mergeBranchMock).not.toHaveBeenCalled()
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: 'Cannot merge a branch into itself.',
+      kind: 'error',
+    }))
+  })
+})
+
+
+const resetCurrentBranchToRefMock = resetCurrentBranchToRef as jest.MockedFunction<typeof resetCurrentBranchToRef>
+const isResetBackwardMock = isResetBackward as jest.MockedFunction<typeof isResetBackward>
+
+// A non-current branch with upstream for the reset-to-branch tests.
+const resetTargetBranch = {
+  type: 'local',
+  name: 'refs/heads/feature/target',
+  shortName: 'feature/target',
+  hash: 'targetabc',
+  current: false,
+  upstream: 'origin/feature/target',
+  remote: 'origin',
+  date: '2026-05-01',
+  subject: 'feat: target',
+  ahead: 0,
+  behind: 0,
+} as never
+
+// A non-current branch WITHOUT upstream.
+const resetTargetBranchNoUpstream = {
+  type: 'local',
+  name: 'refs/heads/feature/local-only',
+  shortName: 'feature/local-only',
+  hash: 'localonly',
+  current: false,
+  upstream: undefined,
+  remote: undefined,
+  date: '2026-05-01',
+  subject: 'feat: local only',
+  ahead: 0,
+  behind: 0,
+} as never
+
+// The current branch for reset-to-branch context.
+const currentBranchForReset = {
+  type: 'local',
+  name: 'refs/heads/main',
+  shortName: 'main',
+  hash: 'currentabc',
+  current: true,
+  upstream: 'origin/main',
+  remote: 'origin',
+  date: '2026-05-01',
+  subject: 'feat: current',
+  ahead: 0,
+  behind: 0,
+} as never
+
+describe('reset-to-branch workflow handler', () => {
+  beforeEach(() => {
+    resetCurrentBranchToRefMock.mockReset()
+    isResetBackwardMock.mockReset()
+  })
+
+  it('dispatches with soft mode when payload is "soft"', async () => {
+    resetCurrentBranchToRefMock.mockResolvedValue({ ok: true, message: 'Reset to feature/target' })
+    isResetBackwardMock.mockResolvedValue(false)
+    const git = {
+      revparse: jest.fn().mockResolvedValue('deadbeef1234\n'),
+    }
+    const dispatch = jest.fn()
+    const harness = createHookHarness()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      state: { ...createLogInkState([]), selectedBranchId: 'feature/target' } as never,
+      context: { branches: { localBranches: [currentBranchForReset, resetTargetBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('reset-to-branch', 'soft')
+    expect(resetCurrentBranchToRefMock).toHaveBeenCalledWith(expect.anything(), 'feature/target', 'soft')
+  })
+
+  it('dispatches with mixed mode when payload is "mixed"', async () => {
+    resetCurrentBranchToRefMock.mockResolvedValue({ ok: true, message: 'Reset to feature/target' })
+    isResetBackwardMock.mockResolvedValue(false)
+    const git = {
+      revparse: jest.fn().mockResolvedValue('deadbeef1234\n'),
+    }
+    const dispatch = jest.fn()
+    const harness = createHookHarness()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      state: { ...createLogInkState([]), selectedBranchId: 'feature/target' } as never,
+      context: { branches: { localBranches: [currentBranchForReset, resetTargetBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('reset-to-branch', 'mixed')
+    expect(resetCurrentBranchToRefMock).toHaveBeenCalledWith(expect.anything(), 'feature/target', 'mixed')
+  })
+
+  it('dispatches with hard mode when payload is "hard"', async () => {
+    resetCurrentBranchToRefMock.mockResolvedValue({ ok: true, message: 'Reset to feature/target' })
+    isResetBackwardMock.mockResolvedValue(false)
+    const git = {
+      revparse: jest.fn().mockResolvedValue('deadbeef1234\n'),
+    }
+    const dispatch = jest.fn()
+    const harness = createHookHarness()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      state: { ...createLogInkState([]), selectedBranchId: 'feature/target' } as never,
+      context: { branches: { localBranches: [currentBranchForReset, resetTargetBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('reset-to-branch', 'hard')
+    expect(resetCurrentBranchToRefMock).toHaveBeenCalledWith(expect.anything(), 'feature/target', 'hard')
+  })
+
+  it('captures an undo entry with previousSha and mode preserved on success', async () => {
+    resetCurrentBranchToRefMock.mockResolvedValue({ ok: true, message: 'Reset to feature/target' })
+    isResetBackwardMock.mockResolvedValue(false)
+    const git = {
+      revparse: jest.fn().mockResolvedValue('abc123previous\n'),
+    }
+    const dispatch = jest.fn()
+    const harness = createHookHarness()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      state: { ...createLogInkState([]), selectedBranchId: 'feature/target' } as never,
+      context: { branches: { localBranches: [currentBranchForReset, resetTargetBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('reset-to-branch', 'hard')
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'pushUndoEntry',
+      value: {
+        kind: 'reset-to-branch',
+        label: 'reset --hard to feature/target',
+        depth: 0,
+        previousSha: 'abc123previous',
+        mode: 'hard',
+      },
+    })
+  })
+
+  it('suggests force-push when isResetBackward is true and branch has upstream', async () => {
+    resetCurrentBranchToRefMock.mockResolvedValue({ ok: true, message: 'Reset to feature/target' })
+    isResetBackwardMock.mockResolvedValue(true)
+    const git = {
+      revparse: jest.fn().mockResolvedValue('deadbeef1234\n'),
+    }
+    const dispatch = jest.fn()
+    const harness = createHookHarness()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      state: { ...createLogInkState([]), selectedBranchId: 'feature/target' } as never,
+      context: { branches: { localBranches: [currentBranchForReset, resetTargetBranch], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('reset-to-branch', 'mixed')
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: expect.stringContaining('Force-push with P'),
+      kind: 'success',
+    }))
+  })
+
+  it('suggests view history when isResetBackward is false', async () => {
+    resetCurrentBranchToRefMock.mockResolvedValue({ ok: true, message: 'Reset to feature/local-only' })
+    isResetBackwardMock.mockResolvedValue(false)
+    const git = {
+      revparse: jest.fn().mockResolvedValue('deadbeef1234\n'),
+    }
+    const dispatch = jest.fn()
+    const harness = createHookHarness()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      state: { ...createLogInkState([]), selectedBranchId: 'feature/local-only' } as never,
+      context: { branches: { localBranches: [currentBranchForReset, resetTargetBranchNoUpstream], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('reset-to-branch', 'soft')
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: expect.stringContaining('View history with gh'),
+      kind: 'success',
+    }))
+  })
+
+  it('errors when cursored branch equals current branch (self-reset guard)', async () => {
+    const dispatch = jest.fn()
+    const git = {
+      revparse: jest.fn().mockResolvedValue('deadbeef\n'),
+    }
+    const harness = createHookHarness()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+      state: { ...createLogInkState([]), selectedBranchId: 'main' } as never,
+      context: { branches: { localBranches: [currentBranchForReset], currentBranch: 'main' } } as never,
+    }))
+
+    await runWorkflowAction('reset-to-branch', 'mixed')
+    expect(resetCurrentBranchToRefMock).not.toHaveBeenCalled()
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: 'Nothing to reset — already at that ref.',
+      kind: 'error',
+    }))
+  })
+})
+
+const pushCurrentBranchMock = pushCurrentBranch as jest.MockedFunction<typeof pushCurrentBranch>
+
+describe('sync-branch workflow handler (Requirement 6)', () => {
+  beforeEach(() => {
+    pullCurrentBranchMock.mockReset()
+    pushCurrentBranchMock.mockReset()
+  })
+
+  it('successful pull+push returns "Branch fully synchronized" momentum hint', async () => {
+    pullCurrentBranchMock.mockResolvedValue({ ok: true, message: 'Already up to date.' })
+    pushCurrentBranchMock.mockResolvedValue({ ok: true, message: 'Pushed to origin' })
+    const git = {
+      raw: jest.fn().mockResolvedValue('origin/main'),
+    }
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+    }))
+
+    await runWorkflowAction('sync-branch')
+    // Upstream check passed
+    expect(git.raw).toHaveBeenCalledWith(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'])
+    // Both phases called
+    expect(pullCurrentBranchMock).toHaveBeenCalled()
+    expect(pushCurrentBranchMock).toHaveBeenCalled()
+    // Final success message
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: expect.stringContaining('Branch fully synchronized'),
+      kind: 'success',
+    }))
+  })
+
+  it('returns error "No upstream — press u to set one first." when no upstream is configured', async () => {
+    const git = {
+      raw: jest.fn().mockRejectedValue(new Error("fatal: no upstream configured for branch 'feature'")),
+    }
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+    }))
+
+    await runWorkflowAction('sync-branch')
+    // Neither pull nor push should be attempted
+    expect(pullCurrentBranchMock).not.toHaveBeenCalled()
+    expect(pushCurrentBranchMock).not.toHaveBeenCalled()
+    // Error status dispatched
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: 'No upstream — press u to set one first.',
+      kind: 'error',
+    }))
+  })
+
+  it('dispatches diverged-pull-recovery setPendingChoice when pull diverges', async () => {
+    pullCurrentBranchMock.mockResolvedValue({
+      ok: false,
+      message: 'fatal: Not possible to fast-forward, aborting.',
+    })
+    const git = {
+      raw: jest.fn().mockResolvedValue('origin/main'),
+    }
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+    }))
+
+    await runWorkflowAction('sync-branch')
+    // Push should NOT be attempted after a diverged pull
+    expect(pushCurrentBranchMock).not.toHaveBeenCalled()
+    // Should present the rebase/merge strategy choice
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setPendingChoice',
+      value: expect.objectContaining({
+        id: 'diverged-pull-recovery',
+        title: 'Local and remote have diverged',
+        options: [
+          expect.objectContaining({ key: 'r', workflowId: 'pull-rebase-current' }),
+          expect.objectContaining({ key: 'm', workflowId: 'pull-merge-current' }),
+        ],
+      }),
+    }))
+  })
+
+  it('dispatches operation-conflict-recovery when pull encounters conflicts', async () => {
+    pullCurrentBranchMock.mockResolvedValue({
+      ok: false,
+      message: 'CONFLICT (content): Merge conflict in src/app.ts\nerror: could not apply abc1234... feat',
+    })
+    const git = {
+      raw: jest.fn().mockResolvedValue('origin/main'),
+    }
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+    }))
+
+    await runWorkflowAction('sync-branch')
+    // Push should NOT be attempted after a conflicted pull
+    expect(pushCurrentBranchMock).not.toHaveBeenCalled()
+    // Should present the conflict recovery choice
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setPendingChoice',
+      value: expect.objectContaining({
+        id: 'operation-conflict-recovery',
+        title: 'Sync interrupted — resolve conflicts then push manually with P',
+        options: [
+          expect.objectContaining({ key: 'x', intent: 'open-conflicts' }),
+          expect.objectContaining({ key: 'a', workflowId: 'abort-operation', destructive: true }),
+        ],
+      }),
+    }))
+  })
+
+  it('returns "Pull succeeded but push failed" when push fails after successful pull', async () => {
+    pullCurrentBranchMock.mockResolvedValue({ ok: true, message: 'Pulled from origin' })
+    pushCurrentBranchMock.mockResolvedValue({
+      ok: false,
+      message: "error: failed to push some refs to 'origin'",
+    })
+    const git = {
+      raw: jest.fn().mockResolvedValue('origin/main'),
+    }
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+    }))
+
+    await runWorkflowAction('sync-branch')
+    // Both pull and push were attempted
+    expect(pullCurrentBranchMock).toHaveBeenCalled()
+    expect(pushCurrentBranchMock).toHaveBeenCalled()
+    // Error status includes both context
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: expect.stringContaining('Pull succeeded but push failed'),
+      kind: 'error',
+    }))
+  })
+
+  it('returns the pull error directly when pull fails with a generic error', async () => {
+    pullCurrentBranchMock.mockResolvedValue({
+      ok: false,
+      message: 'fatal: could not read from remote repository',
+    })
+    const git = {
+      raw: jest.fn().mockResolvedValue('origin/main'),
+    }
+    const harness = createHookHarness()
+    const dispatch = jest.fn()
+    harness.beginRender()
+    const { runWorkflowAction } = useWorkflowAction(harness.React, createDeps({
+      dispatch,
+      git: git as never,
+    }))
+
+    await runWorkflowAction('sync-branch')
+    // Push should NOT be attempted after a failed pull
+    expect(pushCurrentBranchMock).not.toHaveBeenCalled()
+    // The pull error should surface directly
+    expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'setStatus',
+      value: 'fatal: could not read from remote repository',
+      kind: 'error',
+    }))
+    // No choice prompts should have been raised
+    expect(dispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'setPendingChoice' }))
   })
 })

--- a/src/workstation/runtime/hooks/useWorkflowAction.ts
+++ b/src/workstation/runtime/hooks/useWorkflowAction.ts
@@ -75,6 +75,10 @@ import {
     isNonFastForwardPushError,
     pullCurrentBranchMerge,
     pullCurrentBranchRebase,
+    resetCurrentBranchToRef,
+    isResetBackward,
+    mergeBranch,
+    canFastForward,
 } from '../../../git/branchActions'
 import { addToGitignore } from '../../../git/gitignore'
 import { createLightweightTag, deleteLocalTag, deleteRemoteTag, pushTag } from '../../../git/tagActions'
@@ -138,6 +142,7 @@ const REMOTE_OP_LOADERS: Record<string, RemoteOpState> = {
   'force-push-selected-branch': { kind: 'push', label: 'Force-pushing branch (with lease)…' },
   'pull-rebase-current': { kind: 'pull', label: 'Pulling with rebase…' },
   'pull-merge-current': { kind: 'pull', label: 'Pulling with merge…' },
+  'sync-branch': { kind: 'pull', label: 'Syncing branch (pull + push)…' },
 }
 
 /**
@@ -159,6 +164,7 @@ const REMOTE_OP_LOADERS: Record<string, RemoteOpState> = {
  */
 export const HISTORY_REWRITE_WORKFLOW_IDS = new Set([
   'reset-to-commit',
+  'reset-to-branch',
   'cherry-pick-commit',
   'revert-commit',
   'fixup-into-commit',
@@ -212,12 +218,16 @@ export const HISTORY_MUTATING_WORKFLOW_IDS = new Set([
   'cherry-pick-commit',
   'revert-commit',
   'reset-to-commit',
+  'reset-to-branch',
   'interactive-rebase',
   // Rebasing the current branch onto a ref rewrites its commits —
   // refresh the graph so the replayed history (or the mid-rebase
   // conflict state) shows instead of staying pinned to the pre-rebase
   // tip.
   'rebase-onto-branch',
+  // Merging a branch into the current branch creates (or fast-forwards
+  // to) new commits — refresh the graph so the merge result shows.
+  'merge-into-current',
   'bisect-good',
   'bisect-bad',
   'bisect-skip',
@@ -243,6 +253,8 @@ export const HISTORY_MUTATING_WORKFLOW_IDS = new Set([
   // undoing a branch/tag delete or stash drop changes the ref set. All
   // four warrant a graph refresh.
   'undo-last-action',
+  // Sync pulls remote commits then pushes local — both sides move refs.
+  'sync-branch',
 ])
 
 export function resolvePendingItemAction(
@@ -522,6 +534,48 @@ export function useWorkflowAction(
           return { ok: false, message: 'Cannot rebase a branch onto itself.' }
         }
         return rebaseOnto(git, branch.shortName)
+      },
+      // Merge the cursored branch into the current branch. Determines
+      // whether a fast-forward is available and uses --ff-only when it is;
+      // falls back to a standard merge commit when the branches have
+      // diverged. Conflict routing uses the shared `conflictRecoveryTitles`
+      // pattern (see below).
+      'merge-into-current': async () => {
+        const current = context.branches?.currentBranch
+        if (!current) {
+          return { ok: false, message: 'Detached HEAD — checkout a branch before merging.' }
+        }
+        const branch = getSelectedBranch(state, context)
+        if (!branch) return { ok: false, message: 'No branch selected' }
+        if (branch.shortName === current) {
+          return { ok: false, message: 'Cannot merge a branch into itself.' }
+        }
+        // Capture pre-merge HEAD for the undo entry.
+        const previousHead = await git.revparse(['HEAD']).then((sha) => sha.trim()).catch(() => undefined)
+        // Determine merge strategy.
+        const ff = await canFastForward(git, branch.shortName)
+        const result = ff
+          ? await mergeBranch(git, branch.shortName, true)
+          : await mergeBranch(git, branch.shortName)
+        if (result.ok) {
+          if (previousHead) {
+            capturedUndoEntries = [{
+              kind: 'merge-branch',
+              label: `merge ${branch.shortName} into ${current}`,
+              depth: issuedAtDepth,
+              workdir: issuedAtWorkdir,
+              previousSha: previousHead,
+            }]
+          }
+          // Momentum hint distinguishes FF from merge commit.
+          return {
+            ok: true,
+            message: ff
+              ? `Fast-forwarded ${current} to ${branch.shortName}. Push with P`
+              : `Merged ${branch.shortName} into ${current}. Push with P`,
+          }
+        }
+        return result
       },
       'delete-tag': async () => {
         const tag = getSelectedTag(state, context)
@@ -928,6 +982,53 @@ export function useWorkflowAction(
           message: commit.message,
         }, raw as ResetMode)
       },
+      'reset-to-branch': async () => {
+        // Mode arrives via the choice prompt payload — the reset-to-branch
+        // mode choice routes s/m/h here as soft/mixed/hard.
+        const raw = payload?.trim().toLowerCase() || 'mixed'
+        if (!isResetMode(raw)) {
+          return { ok: false, message: `Unknown reset mode: ${raw}. Use soft, mixed, or hard.` }
+        }
+        const branch = getSelectedBranch(state, context)
+        if (!branch) return { ok: false, message: 'No branch selected' }
+        const current = context.branches?.currentBranch
+        if (!current) {
+          return { ok: false, message: 'Detached HEAD — checkout a branch before resetting.' }
+        }
+        if (branch.shortName === current) {
+          return { ok: false, message: 'Nothing to reset — already at that ref.' }
+        }
+        const cursoredRef = branch.shortName
+        // Capture the pre-reset HEAD so a successful reset can be pushed
+        // onto the undo stack.
+        const previousHead = await git.revparse(['HEAD']).then((sha) => sha.trim()).catch(() => undefined)
+        // Determine before the reset whether it moves backward (discards
+        // commits) — after the reset HEAD will be at cursoredRef so the
+        // ancestor check would be meaningless.
+        const backward = await isResetBackward(git, cursoredRef).catch(() => false)
+        const result = await resetCurrentBranchToRef(git, cursoredRef, raw as ResetMode)
+        if (result.ok) {
+          // Push undo entry
+          if (previousHead) {
+            capturedUndoEntries = [{
+              kind: 'reset-to-branch',
+              label: `reset --${raw} to ${cursoredRef}`,
+              depth: issuedAtDepth,
+              workdir: issuedAtWorkdir,
+              previousSha: previousHead,
+              mode: raw as ResetMode,
+            }]
+          }
+          // Determine momentum hint based on whether reset was backward
+          // and whether the branch has an upstream.
+          const hasUpstream = Boolean(branch.upstream)
+          const hint = backward && hasUpstream
+            ? `Reset ${current} to ${cursoredRef} (${raw}). Force-push with P → f`
+            : `Reset ${current} to ${cursoredRef} (${raw}). View history with gh`
+          return { ok: true, message: hint }
+        }
+        return result
+      },
       'interactive-rebase': async () => {
         const commit = getSelectedInkCommit(state)
         if (!commit) return { ok: false, message: 'No commit selected' }
@@ -1247,6 +1348,67 @@ export function useWorkflowAction(
       },
       'pull-rebase-current': async () => pullCurrentBranchRebase(git),
       'pull-merge-current': async () => pullCurrentBranchMerge(git),
+      'sync-branch': async () => {
+        // Guard: the current branch must have an upstream configured.
+        const hasUpstream = await git
+          .raw(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'])
+          .then(() => true)
+          .catch(() => false)
+        if (!hasUpstream) {
+          return { ok: false, message: 'No upstream — press u to set one first.' }
+        }
+        // Phase 1: Pull (ff-only).
+        const pullResult = await pullCurrentBranch(git)
+        if (!pullResult.ok) {
+          // Diverged → present strategy choice (rebase/merge) — same as
+          // the standalone pull handler's recovery. The sync aborts here;
+          // the user picks a strategy and then pushes manually with P.
+          const pullFailureText = [pullResult.message, ...(pullResult.details || [])].join('\n')
+          if (isDivergedPullError(pullFailureText)) {
+            dispatch({
+              type: 'setPendingChoice',
+              value: {
+                id: 'diverged-pull-recovery',
+                title: 'Local and remote have diverged',
+                warning: 'A fast-forward pull is not possible. Choose how to reconcile.',
+                options: [
+                  { key: 'r', label: 'Pull with rebase (replay local commits on top)', workflowId: 'pull-rebase-current' },
+                  { key: 'm', label: 'Pull with merge (create a merge commit)', workflowId: 'pull-merge-current' },
+                ],
+              },
+            })
+            return { ok: false, message: pullResult.message }
+          }
+          // Conflicts → abort sync, route to conflicts view.
+          if (isOperationConflictError(pullFailureText)) {
+            dispatch({
+              type: 'setPendingChoice',
+              value: {
+                id: 'operation-conflict-recovery',
+                title: 'Sync interrupted — resolve conflicts then push manually with P',
+                warning: 'The repository is mid-operation. Resolve the conflicts and continue, or abort to unwind.',
+                keepStatusOnDismiss: true,
+                options: [
+                  { key: 'x', label: 'Open conflicts view', intent: 'open-conflicts' },
+                  { key: 'a', label: 'Abort the operation', workflowId: 'abort-operation', destructive: true },
+                ],
+              },
+            })
+            return { ok: false, message: 'Sync interrupted — resolve conflicts then push manually with P' }
+          }
+          // Any other pull failure → surface the error.
+          return pullResult
+        }
+        // Phase 2: Push.
+        const pushResult = await pushCurrentBranch(git)
+        if (!pushResult.ok) {
+          // Push failed — set error status with reason, but pull result
+          // is preserved (already committed).
+          return { ok: false, message: `Pull succeeded but push failed: ${pushResult.message}` }
+        }
+        // Both succeeded — momentum hint.
+        return { ok: true, message: 'Branch fully synchronized. View history with gh' }
+      },
       'add-to-gitignore': async () => addToGitignore(git, payload || ''),
       'rename-branch': async () => {
         const newName = payload?.trim()
@@ -1671,6 +1833,7 @@ export function useWorkflowAction(
       'pull-selected-branch': 'Pull stopped on conflicts',
       'pull-rebase-current': 'Pull stopped on conflicts',
       'pull-merge-current': 'Pull stopped on conflicts',
+      'merge-into-current': 'Merge stopped on conflicts',
     }
     // `continue-operation` covers merge/rebase/cherry-pick/revert, so its
     // title can't be a static string like the siblings above — it stops on

--- a/src/workstation/runtime/inkInput.test.ts
+++ b/src/workstation/runtime/inkInput.test.ts
@@ -4,6 +4,8 @@ import {
     getLogInkPaletteExecuteEvents,
     isCreatePrView,
     isCreateStashView,
+    PUSH_SUB_CHOICE,
+    RESET_TO_BRANCH_MODE_CHOICE,
 } from './inkInput'
 import { getLogInkPaletteCommands } from './inkKeymap'
 import { LogInkState, LogInkView, applyLogInkAction, createLogInkState } from './inkViewModel'
@@ -675,12 +677,15 @@ describe('log Ink input interactions', () => {
       ])
     })
 
-    it('routes P to push-selected-branch when branches sidebar focused with items', () => {
+    it('routes P to push sub-choice when branches sidebar focused with items', () => {
       const events = getLogInkInputEvents(
         branchSidebarState(), 'P', {}, { branchCount: 3 }
       )
       expect(events).toEqual([
-        { type: 'runWorkflowAction', id: 'push-selected-branch' },
+        {
+          type: 'action',
+          action: { type: 'setPendingChoice', value: PUSH_SUB_CHOICE },
+        },
       ])
     })
 
@@ -709,7 +714,10 @@ describe('log Ink input interactions', () => {
       const state = createLogInkState(rows, { activeView: 'branches' })
       const events = getLogInkInputEvents(state, 'P', {}, { branchCount: 3 })
       expect(events).toEqual([
-        { type: 'runWorkflowAction', id: 'push-selected-branch' },
+        {
+          type: 'action',
+          action: { type: 'setPendingChoice', value: PUSH_SUB_CHOICE },
+        },
       ])
     })
   })
@@ -784,6 +792,109 @@ describe('log Ink input interactions', () => {
         currentBranch: 'feature',
         branchSelectedShortName: 'main',
       })).toEqual([{ type: 'refreshContext' }])
+    })
+  })
+
+  describe('M merge-into-current on the branches view', () => {
+    it('dispatches setPendingConfirmation when cursored branch ≠ current', () => {
+      const state = createLogInkState(rows, { activeView: 'branches' })
+      const events = getLogInkInputEvents(state, 'M', {}, {
+        branchCount: 3,
+        currentBranch: 'feature',
+        branchSelectedShortName: 'main',
+      })
+      expect(events).toEqual([
+        {
+          type: 'action',
+          action: { type: 'setPendingConfirmation', value: 'merge-into-current' },
+        },
+      ])
+    })
+
+    it('shows error when cursored branch = current branch', () => {
+      const state = createLogInkState(rows, { activeView: 'branches' })
+      const events = getLogInkInputEvents(state, 'M', {}, {
+        branchCount: 3,
+        currentBranch: 'main',
+        branchSelectedShortName: 'main',
+      })
+      expect(events).toEqual([
+        {
+          type: 'action',
+          action: {
+            type: 'setStatus',
+            value: 'Cannot merge a branch into itself.',
+            kind: 'error',
+          },
+        },
+      ])
+    })
+  })
+
+  describe('Z reset-to-branch on the branches view', () => {
+    it('dispatches setPendingChoice with reset mode choice when cursored ≠ current', () => {
+      const state = createLogInkState(rows, { activeView: 'branches' })
+      const events = getLogInkInputEvents(state, 'Z', {}, {
+        branchCount: 3,
+        currentBranch: 'feature',
+        branchSelectedShortName: 'main',
+      })
+      expect(events).toEqual([
+        {
+          type: 'action',
+          action: { type: 'setPendingChoice', value: RESET_TO_BRANCH_MODE_CHOICE },
+        },
+      ])
+    })
+
+    it('shows error when cursored branch = current branch', () => {
+      const state = createLogInkState(rows, { activeView: 'branches' })
+      const events = getLogInkInputEvents(state, 'Z', {}, {
+        branchCount: 3,
+        currentBranch: 'main',
+        branchSelectedShortName: 'main',
+      })
+      expect(events).toEqual([
+        {
+          type: 'action',
+          action: {
+            type: 'setStatus',
+            value: 'Nothing to reset — already at that ref.',
+            kind: 'error',
+          },
+        },
+      ])
+    })
+  })
+
+  describe('S sync-branch on the branches view', () => {
+    it('dispatches runWorkflowAction sync-branch', () => {
+      const state = createLogInkState(rows, { activeView: 'branches' })
+      const events = getLogInkInputEvents(state, 'S', {}, {
+        branchCount: 3,
+        currentBranch: 'feature',
+        branchSelectedShortName: 'main',
+      })
+      expect(events).toEqual([
+        { type: 'runWorkflowAction', id: 'sync-branch' },
+      ])
+    })
+  })
+
+  describe('P push sub-choice on the branches view', () => {
+    it('dispatches setPendingChoice with PUSH_SUB_CHOICE', () => {
+      const state = createLogInkState(rows, { activeView: 'branches' })
+      const events = getLogInkInputEvents(state, 'P', {}, {
+        branchCount: 3,
+        currentBranch: 'feature',
+        branchSelectedShortName: 'main',
+      })
+      expect(events).toEqual([
+        {
+          type: 'action',
+          action: { type: 'setPendingChoice', value: PUSH_SUB_CHOICE },
+        },
+      ])
     })
   })
 
@@ -6588,10 +6699,10 @@ describe('global key allowlists (negation-guard conversion)', () => {
     }
   })
 
-  it('S creates a stash in every view except the commit triad (compose/status/diff)', () => {
-    const triad: LogInkView[] = ['compose', 'status', 'diff']
+  it('S creates a stash in every view except the commit triad (compose/status/diff) and branches (sync)', () => {
+    const excluded: LogInkView[] = ['compose', 'status', 'diff', 'branches']
     for (const view of ALL_VIEWS) {
-      expect(isCreateStashView(view)).toBe(!triad.includes(view))
+      expect(isCreateStashView(view)).toBe(!excluded.includes(view))
     }
   })
 })

--- a/src/workstation/runtime/inkInput.ts
+++ b/src/workstation/runtime/inkInput.ts
@@ -581,7 +581,7 @@ const CREATE_PR_VIEWS: readonly LogInkView[] = [
 // Bare `S` creates a stash everywhere EXCEPT the commit triad
 // (compose / status / diff), where `S` starts the commit-split flow.
 const CREATE_STASH_VIEWS: readonly LogInkView[] = [
-  'history', 'branches', 'tags', 'stash', 'worktrees', 'pull-request',
+  'history', 'tags', 'stash', 'worktrees', 'pull-request',
   'pull-request-triage', 'issues', 'conflicts', 'reflog', 'bisect',
   'changelog', 'submodules', 'remotes',
 ]
@@ -1017,6 +1017,35 @@ const RESET_MODE_CHOICE = {
     { key: 's', label: 'Soft — keep changes staged', workflowId: 'reset-to-commit', payload: 'soft' },
     { key: 'm', label: 'Mixed — keep changes unstaged', workflowId: 'reset-to-commit', payload: 'mixed' },
     { key: 'h', label: 'Hard — discard working-tree changes', workflowId: 'reset-to-commit', payload: 'hard', destructive: true },
+  ],
+}
+
+/**
+ * Reset the current branch to the cursored branch's ref. Presented when the
+ * user presses `Z` in the branches view — mirrors the history-view
+ * `RESET_MODE_CHOICE` but targets a branch ref instead of a commit.
+ */
+export const RESET_TO_BRANCH_MODE_CHOICE = {
+  id: 'reset-to-branch-mode-choice',
+  title: 'Reset current branch to the cursored branch',
+  warning: 'hard discards ALL uncommitted working-tree changes.',
+  options: [
+    { key: 's', label: 'Soft — keep changes staged', workflowId: 'reset-to-branch', payload: 'soft' },
+    { key: 'm', label: 'Mixed — keep changes unstaged', workflowId: 'reset-to-branch', payload: 'mixed' },
+    { key: 'h', label: 'Hard — discard working-tree changes', workflowId: 'reset-to-branch', payload: 'hard', destructive: true },
+  ],
+}
+
+/**
+ * Push sub-choice raised when the user presses `P` in the branches view.
+ * Lets the user pick between a normal push and a force-push (with lease).
+ */
+export const PUSH_SUB_CHOICE = {
+  id: 'push-sub-choice',
+  title: 'Push branch',
+  options: [
+    { key: 'p', label: 'Push (normal)', workflowId: 'push-selected-branch' },
+    { key: 'f', label: 'Force push (--force-with-lease)', workflowId: 'force-push-selected-branch', destructive: true },
   ],
 }
 
@@ -4343,17 +4372,51 @@ export function getLogInkInputEvents(
     return commitOrComposeEvents(state)
   }
 
-  // Context-sensitive per-branch variants of F / U / P. When the
-  // user has the branches sidebar / view focused with at least one
-  // branch, F / U / P should act on the cursored row, not on the
-  // current branch. This intercept fires BEFORE the generic
-  // workflow-by-key lookup below so the global *-current-branch
-  // variants don't shadow the contextual ones.
+  // Context-sensitive per-branch variants of F / U / P / M / Z / S.
+  // When the user has the branches sidebar / view focused with at least
+  // one branch, these keys act on the cursored row, not on the current
+  // branch. This intercept fires BEFORE the generic workflow-by-key
+  // lookup below so the global *-current-branch variants don't shadow
+  // the contextual ones.
   //
   // Outside the branches context, the generic lookup runs and the
   // F / U / P keys hit the global `fetch-remotes` / `pull-current-branch`
   // / `push-current-branch` workflows as before.
   if (isBranchActionTarget(state) && context.branchCount) {
+    // `M` merges the cursored branch into the current branch.
+    if (inputValue === 'M') {
+      const current = context.currentBranch
+      const target = context.branchSelectedShortName
+      if (!current || target === current) {
+        return [action({
+          type: 'setStatus',
+          value: 'Cannot merge a branch into itself.',
+          kind: 'error',
+        })]
+      }
+      return [action({ type: 'setPendingConfirmation', value: 'merge-into-current' })]
+    }
+
+    // `Z` resets the current branch to the cursored branch's ref.
+    if (inputValue === 'Z') {
+      const current = context.currentBranch
+      const target = context.branchSelectedShortName
+      if (!current || target === current) {
+        return [action({
+          type: 'setStatus',
+          value: 'Nothing to reset — already at that ref.',
+          kind: 'error',
+        })]
+      }
+      return [action({ type: 'setPendingChoice', value: RESET_TO_BRANCH_MODE_CHOICE })]
+    }
+
+    // `S` syncs the cursored branch (pull + push). The upstream guard
+    // is enforced by the workflow handler (it needs async git context).
+    if (inputValue === 'S') {
+      return [{ type: 'runWorkflowAction', id: 'sync-branch' }]
+    }
+
     if (inputValue === 'F') {
       return [{ type: 'runWorkflowAction', id: 'fetch-selected-branch' }]
     }
@@ -4361,7 +4424,7 @@ export function getLogInkInputEvents(
       return [{ type: 'runWorkflowAction', id: 'pull-selected-branch' }]
     }
     if (inputValue === 'P') {
-      return [{ type: 'runWorkflowAction', id: 'push-selected-branch' }]
+      return [action({ type: 'setPendingChoice', value: PUSH_SUB_CHOICE })]
     }
   }
 

--- a/src/workstation/runtime/inkKeymap.test.ts
+++ b/src/workstation/runtime/inkKeymap.test.ts
@@ -118,7 +118,7 @@ describe('log Ink keymap', () => {
       focus: 'commits',
       showHelp: false,
     })).toEqual({
-      contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'x/v mark', 'D delete', 'r rebase', 'm compare', 's sort', 'y yank'],
+      contextual: ['↑/↓ branches', 'enter checkout', 'M merge', 'P push', 'S sync', 'Z reset', '+ new', 'x/v mark', 'D delete', 'r rebase', 'm compare', 's sort', 'y yank'],
       global: ['g jump', '< back', '? help', ': cmds', 'q quit'],
     })
 

--- a/src/workstation/runtime/inkKeymap.ts
+++ b/src/workstation/runtime/inkKeymap.ts
@@ -113,6 +113,9 @@ export type LogInkCommandId =
   | 'workflowTriagePrOpen'
   | 'workflowTriageIssueOpen'
   | 'workflowRemoveWorktreeAndBranch'
+  | 'viewMergeIntoCurrent'
+  | 'viewResetToBranch'
+  | 'viewSyncBranch'
 
 export type LogInkBindingCategory =
   | 'essentials'
@@ -625,6 +628,27 @@ export const LOG_INK_KEY_BINDINGS: LogInkKeyBinding[] = [
     keys: ['r'],
     label: 'rebase onto',
     description: 'Rebase the current branch onto the cursored branch / ref (non-interactive) after confirmation.',
+    contexts: ['branches'],
+  },
+  {
+    id: 'viewMergeIntoCurrent',
+    keys: ['M'],
+    label: 'merge',
+    description: 'Merge the cursored branch into the current branch after confirmation.',
+    contexts: ['branches'],
+  },
+  {
+    id: 'viewResetToBranch',
+    keys: ['Z'],
+    label: 'reset',
+    description: 'Reset the current branch to the cursored ref (prompts for soft/mixed/hard).',
+    contexts: ['branches'],
+  },
+  {
+    id: 'viewSyncBranch',
+    keys: ['S'],
+    label: 'sync',
+    description: 'Pull from remote then push local commits (compound pull + push).',
     contexts: ['branches'],
   },
   {
@@ -1180,6 +1204,10 @@ const BINDING_CATEGORY_BY_ID: Partial<Record<LogInkCommandId, LogInkBindingCateg
   // Branches-view-only rebase-onto (#0.71) — a confirmation-gated
   // destructive op, grouped with the global mutate cluster.
   viewRebaseOnto: 'mutate',
+  // Branches-view-only merge/reset/sync (workstation-branch-operations)
+  viewMergeIntoCurrent: 'mutate',
+  viewResetToBranch: 'mutate',
+  viewSyncBranch: 'mutate',
   // ── History actions: per-view-only mutations scoped to the history
   //    surface. Distinct from the global mutate cluster so users see
   //    them grouped under their actual context.
@@ -1626,9 +1654,16 @@ function branchesHints(options: GetLogInkFooterHintsOptions): LogInkFooterHints 
     }
   }
   return {
-    // `x/v mark` covers both multi-select primitives (#1361): x
-    // toggles a mark, v anchors a range; D then deletes the batch.
-    contextual: ['↑/↓ branches', 'enter checkout', '+ new', 'x/v mark', 'D delete', 'r rebase', 'm compare', 's sort', 'y yank'],
+    // Priority ordering (highest → lowest, leftmost survives narrow-
+    // terminal trimming): Enter checkout > M merge > P push > S sync >
+    // Z reset > existing utility keys. `x/v mark` covers both multi-
+    // select primitives (#1361): x toggles a mark, v anchors a range;
+    // D then deletes the batch.
+    contextual: [
+      '↑/↓ branches', 'enter checkout',
+      'M merge', 'P push', 'S sync', 'Z reset',
+      '+ new', 'x/v mark', 'D delete', 'r rebase', 'm compare', 's sort', 'y yank',
+    ],
     global: NORMAL_GLOBAL_HINTS,
   }
 }

--- a/src/workstation/runtime/inkWorkflows.test.ts
+++ b/src/workstation/runtime/inkWorkflows.test.ts
@@ -235,6 +235,43 @@ describe('triage PR checkout workflow (#1363)', () => {
   })
 })
 
+describe('branch-level workflows (merge, reset, sync)', () => {
+  it('registers merge-into-current as destructive and confirmation-gated', () => {
+    const merge = getLogInkWorkflowActionById('merge-into-current')
+    expect(merge).toMatchObject({
+      id: 'merge-into-current',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    })
+  })
+
+  it('registers reset-to-branch as destructive and confirmation-gated', () => {
+    const reset = getLogInkWorkflowActionById('reset-to-branch')
+    expect(reset).toMatchObject({
+      id: 'reset-to-branch',
+      kind: 'destructive',
+      requiresConfirmation: true,
+    })
+  })
+
+  it('registers sync-branch as normal and confirmation-free', () => {
+    const sync = getLogInkWorkflowActionById('sync-branch')
+    expect(sync).toMatchObject({
+      id: 'sync-branch',
+      kind: 'normal',
+      requiresConfirmation: false,
+    })
+  })
+
+  it('returns all three branch workflows from getLogInkWorkflowActions()', () => {
+    const actions = getLogInkWorkflowActions()
+    const ids = actions.map((a) => a.id)
+    expect(ids).toContain('merge-into-current')
+    expect(ids).toContain('reset-to-branch')
+    expect(ids).toContain('sync-branch')
+  })
+})
+
 describe('PR ready-for-review / reopen workflows (#1933)', () => {
   it('registers ready-pr / reopen-pr and their triage counterparts as keyless, confirm-gated, non-destructive', () => {
     for (const id of ['ready-pr', 'reopen-pr', 'triage-pr-ready', 'triage-pr-reopen']) {

--- a/src/workstation/runtime/inkWorkflows.ts
+++ b/src/workstation/runtime/inkWorkflows.ts
@@ -359,6 +359,37 @@ export function getLogInkWorkflowActions(): LogInkWorkflowAction[] {
       requiresConfirmation: false,
     },
     {
+      // Branch-level workflows — merge, reset, sync. Bound to M / Z / S
+      // in the branches view (inkInput); the key field reflects the
+      // palette-visible binding (empty for reset-to-branch because it's
+      // routed via mode-choice, not a direct palette key).
+      id: 'merge-into-current',
+      key: 'M',
+      label: 'Merge branch into current',
+      description: 'Merge the selected branch into the current branch.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+      warning: (state) => state.pendingConfirmationPayload
+        || 'Merging into the current branch. Creates a merge commit (or fast-forwards if possible).',
+    },
+    {
+      id: 'reset-to-branch',
+      key: '',
+      label: 'Reset current branch to ref',
+      description: 'Move the current branch pointer to match the selected ref.',
+      kind: 'destructive',
+      requiresConfirmation: true,
+      warning: 'Rewrites local history. Use g u to undo if needed.',
+    },
+    {
+      id: 'sync-branch',
+      key: 'S',
+      label: 'Sync branch (pull + push)',
+      description: 'Pull from remote then push local commits.',
+      kind: 'normal',
+      requiresConfirmation: false,
+    },
+    {
       // Per-view-only — the inkInput handler scopes this to the tags
       // surface so we don't expose `R` as a remote-delete from elsewhere.
       // The empty `key` keeps the workflow palette-discoverable but does

--- a/src/workstation/runtime/undoStack.test.ts
+++ b/src/workstation/runtime/undoStack.test.ts
@@ -1,11 +1,11 @@
 import {
-  MAX_UNDO_STACK_SIZE,
-  findMostRecentUndoEntry,
-  performUndo,
-  popUndoEntry,
-  pushUndoEntry,
-  removeUndoEntry,
-  type UndoEntry,
+    MAX_UNDO_STACK_SIZE,
+    findMostRecentUndoEntry,
+    performUndo,
+    popUndoEntry,
+    pushUndoEntry,
+    removeUndoEntry,
+    type UndoEntry,
 } from './undoStack'
 
 function branchEntry(overrides: Partial<Extract<UndoEntry, { kind: 'delete-branch' }>> = {}): UndoEntry {
@@ -149,6 +149,133 @@ describe('undo stack (OSS-1606)', () => {
       const result = await performUndo(git as never, entry)
       expect(result).toEqual({ ok: true, message: 'Restored tag v1.0.0' })
       expect(git.raw).toHaveBeenCalledWith(['tag', 'v1.0.0', 'abc1234'])
+    })
+
+    it('resets --hard back to pre-merge HEAD for a merge-branch undo', async () => {
+      const git = {
+        revparse: jest.fn().mockResolvedValue('/tmp/coco-missing-git-state'),
+        raw: jest.fn().mockResolvedValue(''),
+      }
+      const entry: UndoEntry = {
+        kind: 'merge-branch',
+        label: 'merge feature/xyz into main',
+        depth: 0,
+        previousSha: 'aabbccdd1234',
+      }
+      const result = await performUndo(git as never, entry)
+      expect(result).toEqual({ ok: true, message: 'Restored HEAD to aabbccd' })
+      expect(git.raw).toHaveBeenCalledWith(['reset', '--hard', 'aabbccdd1234'])
+    })
+
+    it('resets using the recorded mode for a reset-to-branch undo (hard)', async () => {
+      const git = {
+        revparse: jest.fn().mockResolvedValue('/tmp/coco-missing-git-state'),
+        raw: jest.fn().mockResolvedValue(''),
+      }
+      const entry: UndoEntry = {
+        kind: 'reset-to-branch',
+        label: 'reset --hard to feature/other',
+        depth: 0,
+        previousSha: 'deadbeef5678',
+        mode: 'hard',
+      }
+      const result = await performUndo(git as never, entry)
+      expect(result).toEqual({ ok: true, message: 'Restored HEAD to deadbee' })
+      expect(git.raw).toHaveBeenCalledWith(['reset', '--hard', 'deadbeef5678'])
+    })
+
+    it('resets using the recorded mode for a reset-to-branch undo (soft)', async () => {
+      const git = {
+        revparse: jest.fn().mockResolvedValue('/tmp/coco-missing-git-state'),
+        raw: jest.fn().mockResolvedValue(''),
+      }
+      const entry: UndoEntry = {
+        kind: 'reset-to-branch',
+        label: 'reset --soft to feature/other',
+        depth: 0,
+        previousSha: 'deadbeef5678',
+        mode: 'soft',
+      }
+      const result = await performUndo(git as never, entry)
+      expect(result).toEqual({ ok: true, message: 'Restored HEAD to deadbee' })
+      expect(git.raw).toHaveBeenCalledWith(['reset', '--soft', 'deadbeef5678'])
+    })
+
+    it('resets using the recorded mode for a reset-to-branch undo (mixed)', async () => {
+      const git = {
+        revparse: jest.fn().mockResolvedValue('/tmp/coco-missing-git-state'),
+        raw: jest.fn().mockResolvedValue(''),
+      }
+      const entry: UndoEntry = {
+        kind: 'reset-to-branch',
+        label: 'reset --mixed to feature/other',
+        depth: 0,
+        previousSha: 'deadbeef5678',
+        mode: 'mixed',
+      }
+      const result = await performUndo(git as never, entry)
+      expect(result).toEqual({ ok: true, message: 'Restored HEAD to deadbee' })
+      expect(git.raw).toHaveBeenCalledWith(['reset', '--mixed', 'deadbeef5678'])
+    })
+  })
+
+  describe('pushUndoEntry / popUndoEntry with new entry types', () => {
+    it('push/pop works with merge-branch entries', () => {
+      const entry: UndoEntry = {
+        kind: 'merge-branch',
+        label: 'merge feature/xyz into main',
+        depth: 0,
+        previousSha: 'aabbccdd1234',
+      }
+      let stack: UndoEntry[] = []
+      stack = pushUndoEntry(stack, entry)
+      const { entry: popped, stack: remaining } = popUndoEntry(stack)
+      expect(popped).toEqual(entry)
+      expect(remaining).toEqual([])
+    })
+
+    it('push/pop works with reset-to-branch entries', () => {
+      const entry: UndoEntry = {
+        kind: 'reset-to-branch',
+        label: 'reset --hard to feature/other',
+        depth: 0,
+        previousSha: 'deadbeef5678',
+        mode: 'hard',
+      }
+      let stack: UndoEntry[] = []
+      stack = pushUndoEntry(stack, entry)
+      const { entry: popped, stack: remaining } = popUndoEntry(stack)
+      expect(popped).toEqual(entry)
+      expect(remaining).toEqual([])
+    })
+
+    it('interleaves new entry types with existing kinds in LIFO order', () => {
+      const deleteBranch = branchEntry({ name: 'old-branch' })
+      const mergeBranch: UndoEntry = {
+        kind: 'merge-branch',
+        label: 'merge feature/xyz',
+        depth: 0,
+        previousSha: 'aabb1234',
+      }
+      const resetToBranch: UndoEntry = {
+        kind: 'reset-to-branch',
+        label: 'reset --hard to develop',
+        depth: 0,
+        previousSha: 'ccdd5678',
+        mode: 'hard',
+      }
+
+      let stack: UndoEntry[] = []
+      stack = pushUndoEntry(stack, deleteBranch)
+      stack = pushUndoEntry(stack, mergeBranch)
+      stack = pushUndoEntry(stack, resetToBranch)
+
+      const pop1 = popUndoEntry(stack)
+      expect(pop1.entry).toEqual(resetToBranch)
+      const pop2 = popUndoEntry(pop1.stack)
+      expect(pop2.entry).toEqual(mergeBranch)
+      const pop3 = popUndoEntry(pop2.stack)
+      expect(pop3.entry).toEqual(deleteBranch)
     })
   })
 })

--- a/src/workstation/runtime/undoStack.ts
+++ b/src/workstation/runtime/undoStack.ts
@@ -49,6 +49,8 @@ export type UndoEntry =
   | { kind: 'drop-stash'; label: string; depth: number; workdir?: string; hash: string; message: string }
   | { kind: 'reset-to-commit'; label: string; depth: number; workdir?: string; previousSha: string; mode: ResetMode }
   | { kind: 'delete-tag'; label: string; depth: number; workdir?: string; name: string; sha: string }
+  | { kind: 'merge-branch'; label: string; depth: number; workdir?: string; previousSha: string }
+  | { kind: 'reset-to-branch'; label: string; depth: number; workdir?: string; previousSha: string; mode: ResetMode }
 
 export type UndoActionResult = { ok: boolean; message: string }
 
@@ -98,5 +100,9 @@ export function performUndo(git: SimpleGit, entry: UndoEntry): Promise<UndoActio
       return restorePreviousHead(git, entry.previousSha, entry.mode)
     case 'delete-tag':
       return restoreDeletedTag(git, entry.name, entry.sha)
+    case 'merge-branch':
+      return restorePreviousHead(git, entry.previousSha, 'hard')
+    case 'reset-to-branch':
+      return restorePreviousHead(git, entry.previousSha, entry.mode)
   }
 }


### PR DESCRIPTION

### 💥 BREAKING CHANGES
- None.

### Features
- Add branch-level merge, reset, sync, and push sub-choice workflows to the branches view, including fast-forward detection, merge conflict routing, reset mode selection, force-push confirmation, sync divergence recovery, and undo support for merge/reset actions. Register the new M, Z, S, and enhanced P bindings across the keymap, workflow engine, input handlers, and footer hints. (07957a8)
- Add a workstation branch-operations specification to document the requirements, design, and implementation task breakdown for the feature. (7aad90b)
- Add a branch-operations screenshot recipe that exercises merge, reset, and push flows so the UI can be captured consistently. (dcdb91b)
- Register the branch-operations screenshot in the sync pipeline and filename mapping so it is included with the existing site recipes. (c9e8019)

### Dependencies
- None.

### Tests
- Add broad coverage across the git layer, undo stack, key handling, workflow handlers, and UI hints for the new branch operations flows. (07957a8)