### PR TITLE
fix(review): add missing side field to ReviewFeedbackItem test fixtures

### DIFF
--- a/src/lib/autofix/buildPrompt.realfs.test.ts
+++ b/src/lib/autofix/buildPrompt.realfs.test.ts
@@ -19,6 +19,7 @@ const baseItem: ReviewFeedbackItem = {
   severity: 7,
   category: 'Bug',
   filePath: 'src/utils/parse.ts',
+  side: 'RIGHT',
 }
 
 describe('buildPrompt — real filesystem', () => {

--- a/src/lib/autofix/buildPrompt.test.ts
+++ b/src/lib/autofix/buildPrompt.test.ts
@@ -22,6 +22,7 @@ const item: ReviewFeedbackItem = {
   severity: 7,
   category: 'Bug',
   filePath: 'src/utils/parse.ts',
+  side: 'RIGHT',
 }
 
 beforeEach(() => {

--- a/src/lib/autofix/index.test.ts
+++ b/src/lib/autofix/index.test.ts
@@ -40,6 +40,7 @@ const item: ReviewFeedbackItem = {
   severity: 7,
   category: 'bug',
   filePath: 'src/foo.ts',
+  side: 'RIGHT',
 }
 
 describe('runAutoFix', () => {

--- a/src/lib/ui/TaskList.test.ts
+++ b/src/lib/ui/TaskList.test.ts
@@ -75,6 +75,7 @@ const makeItem = (overrides?: Partial<ReviewFeedbackItem>): ReviewFeedbackItem =
   severity: 5,
   category: 'bug',
   filePath: 'src/foo.ts',
+  side: 'RIGHT',
   ...overrides,
 })
 


### PR DESCRIPTION
## Summary

Fixes main, broken by #2092 (#2093). That PR added a required `side` field to `ReviewFeedbackItem` backed by a Zod schema with `.default('RIGHT')`. Since the exported type uses `z.infer` (the post-parse output type), `side` is required in TypeScript even though it has a runtime default — four test files that hand-construct `ReviewFeedbackItem` fixtures predate the change and don't set it, so `tsc` fails them under ts-jest.

No production code constructs `ReviewFeedbackItem` object literals directly (only type-annotates parameters), so this was TS-only breakage confined to tests.

- `src/lib/ui/TaskList.test.ts`
- `src/lib/autofix/index.test.ts`
- `src/lib/autofix/buildPrompt.test.ts`
- `src/lib/autofix/buildPrompt.realfs.test.ts`

## Test plan
- [x] `npx jest` on the four affected suites — 76/76 pass
- [x] `npx tsc --noEmit -p .` — clean, project-wide
- [x] Full `npx jest` run — only pre-existing/unrelated local failure (`tsTreeSitterParser.test.ts`, environmental — passes on CI, needs root `node_modules`'s WASM binary not present in this worktree)

Closes #2093