### PR TITLE
fix(config): write scoped config files 0600 via writeFileAtomic

### DIFF
--- a/src/lib/config/services/xdg.persist.test.ts
+++ b/src/lib/config/services/xdg.persist.test.ts
@@ -42,4 +42,20 @@ describe('persistUsagePreference (#0.69)', () => {
     expect(onDisk.telemetry.usage).toBe(false)
     expect(onDisk.logTui.theme.preset).toBe('dracula')
   })
+
+  it('writes the file 0600 (owner-only), not world-readable (#1874)', () => {
+    expect(persistUsagePreference(true)).toBe(true)
+    const mode = fs.statSync(getXdgConfigPath()).mode & 0o777
+    expect(mode).toBe(0o600)
+  })
+
+  it('re-hardens an existing world-readable file back to 0600, not just merges content', () => {
+    fs.mkdirSync(path.dirname(getXdgConfigPath()), { recursive: true })
+    fs.writeFileSync(getXdgConfigPath(), '{}', { mode: 0o644 })
+
+    expect(persistUsagePreference(true)).toBe(true)
+
+    const mode = fs.statSync(getXdgConfigPath()).mode & 0o777
+    expect(mode).toBe(0o600)
+  })
 })

--- a/src/lib/config/services/xdg.ts
+++ b/src/lib/config/services/xdg.ts
@@ -3,6 +3,7 @@ import * as os from 'os'
 import * as path from 'path'
 import { LLMService } from '../../langchain/types'
 import { Config } from '../types'
+import { writeFileAtomic } from '../../utils/atomicFileWrite'
 
 /** Path to the global XDG config (`$XDG_CONFIG_HOME/coco/config.json`). */
 export function getXdgConfigPath(): string {
@@ -59,7 +60,7 @@ export function persistUsagePreference(usage: boolean): boolean {
     config.telemetry = { ...telemetry, usage }
 
     fs.mkdirSync(path.dirname(file), { recursive: true })
-    fs.writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`)
+    writeFileAtomic(file, `${JSON.stringify(config, null, 2)}\n`)
     return true
   } catch {
     return false

--- a/src/lib/config/utils/scopedConfigFile.test.ts
+++ b/src/lib/config/utils/scopedConfigFile.test.ts
@@ -95,6 +95,19 @@ describe('readScopedConfigFile / writeScopedConfigFile', () => {
     expect(written.$schema).not.toBe('https://stale.example/old.json')
     expect(Object.keys(written).filter((k) => k === '$schema')).toHaveLength(1)
   })
+
+  it('writes the file 0600 (owner-only), not world-readable (#1874)', () => {
+    writeScopedConfigFile(filePath, { defaultBranch: 'develop' })
+    const mode = fs.statSync(filePath).mode & 0o777
+    expect(mode).toBe(0o600)
+  })
+
+  it('re-hardens an existing world-readable file back to 0600 on overwrite', () => {
+    fs.writeFileSync(filePath, '{}', { mode: 0o644 })
+    writeScopedConfigFile(filePath, { defaultBranch: 'develop' })
+    const mode = fs.statSync(filePath).mode & 0o777
+    expect(mode).toBe(0o600)
+  })
 })
 
 describe('checkProjectScopeKeyTrust', () => {

--- a/src/lib/config/utils/scopedConfigFile.ts
+++ b/src/lib/config/utils/scopedConfigFile.ts
@@ -4,6 +4,7 @@ import { getXdgConfigPath } from '../services/xdg'
 import { PROJECT_CONFIG_CANDIDATES, TRUSTED_PROJECT_SERVICE_KEYS } from '../constants/projectConfig'
 import { resolveGitRepoRoot } from '../../utils/resolveGitRepoRoot'
 import { SCHEMA_PUBLIC_URL } from '../../schema'
+import { writeFileAtomic } from '../../utils/atomicFileWrite'
 
 export { PROJECT_CONFIG_CANDIDATES } from '../constants/projectConfig'
 
@@ -69,12 +70,19 @@ export function readScopedConfigFile(filePath: string): Record<string, unknown> 
   return parsed as Record<string, unknown>
 }
 
-/** Writes a scoped config object back to disk as pretty-printed JSON with a `$schema` pointer. */
+/**
+ * Writes a scoped config object back to disk as pretty-printed JSON with a
+ * `$schema` pointer. Config files may hold credentials (`coco config set
+ * service.authentication.credentials.apiKey`), so this always writes via
+ * `writeFileAtomic` — 0600 permissions, tmp+rename — rather than a bare
+ * `writeFileSync`, which would leave the file world-readable at the
+ * umask-derived default and vulnerable to a truncated partial write (#1874).
+ */
 export function writeScopedConfigFile(filePath: string, config: Record<string, unknown>): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true })
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { $schema, ...rest } = config
-  fs.writeFileSync(
+  writeFileAtomic(
     filePath,
     JSON.stringify({ $schema: SCHEMA_PUBLIC_URL, ...rest }, null, 2) + '\n'
   )


### PR DESCRIPTION
## Summary

`coco config set` is the documented way to write config, including credentials — `SENSITIVE_SEGMENTS` in `config/handler.ts` already masks `apiKey`/`token`/`password`/`clientSecret` on read/print, so credentials are clearly expected to live here. Both writers (`writeScopedConfigFile` for `coco config set`, `persistUsagePreference` for the telemetry preference) used a bare `fs.writeFileSync` with no `mode`, so the file landed at `0666 & ~umask` (0644 on a default umask) — readable by any local user — and non-atomically, so an interrupted write truncates the whole file.

`writeFileAtomic` already exists for exactly this (0600 default, tmp+rename via a random-suffixed tmp name with `O_EXCL`) and is already used for less-sensitive files. Routes both writers through it instead of duplicating the primitive.

- `src/lib/config/utils/scopedConfigFile.ts` — `writeScopedConfigFile` (used by `coco config set`, both `--scope global` and `--scope project`)
- `src/lib/config/services/xdg.ts` — `persistUsagePreference` (also fixes: this previously could *downgrade* a hand-hardened 0600 file back to 0644 on every telemetry-preference write, since it rewrites the whole file)

## Test plan
- [x] New tests assert `0600` mode on write, and re-hardening back to `0600` when overwriting a pre-existing `0644` file, in both `scopedConfigFile.test.ts` and `xdg.persist.test.ts`
- [x] `npx jest` on the two affected suites — 19/19 pass
- [x] `npx jest src/commands/config src/lib/config src/commands/init` — 192/192 pass, no regressions
- [x] `npx tsc --noEmit -p .` — clean

Fixes #1874