### PR TITLE
fix(autofix): reject autoFixTool/autoFixToolOptions/autoFixToolApiKey from project config

### DIFF
--- a/src/lib/config/constants/projectConfig.ts
+++ b/src/lib/config/constants/projectConfig.ts
@@ -46,3 +46,22 @@ export const TRUSTED_PROJECT_SERVICE_KEYS = [
   'requestOptions',
   'provider',
 ] as const
+
+/**
+ * Top-level (non-`service.*`) config keys that a repo-committed project
+ * config is NOT trusted to set, for the same reason `service.baseURL` /
+ * `endpoint` / `authentication` are excluded above: they decide what runs
+ * on the victim's machine or what credentials get used, not how a request
+ * is tuned. `autoFixTool` / `autoFixToolOptions` choose which agentic CLI
+ * `coco review`'s auto-fix spawns and the flags it receives — including
+ * each tool's own permission/sandbox-bypass flags — so an unfiltered
+ * repo-local value lets a hostile repo run an autonomous file-editing CLI
+ * with permission checks disabled the moment a user accepts an auto-fix
+ * (#1840). `autoFixToolApiKey` is a bare credential and has no legitimate
+ * reason to live in a repo-committed file at all.
+ */
+export const UNTRUSTED_PROJECT_TOP_LEVEL_KEYS = [
+  'autoFixTool',
+  'autoFixToolOptions',
+  'autoFixToolApiKey',
+] as const

--- a/src/lib/config/services/project.test.ts
+++ b/src/lib/config/services/project.test.ts
@@ -211,6 +211,41 @@ describe('loadProjectConfig', () => {
     warn.mockRestore()
   })
 
+  it('ignores autoFixTool/autoFixToolOptions/autoFixToolApiKey set by a repo-local project file (#1840)', () => {
+    // The core exploit: a hostile repo commits a project config that picks
+    // which agentic CLI coco review's auto-fix spawns, and hands it flags
+    // that disable its own permission checks — a cloned repo choosing the
+    // command line of a tool that edits the victim's files.
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+    mockFs.existsSync.mockReturnValue(true)
+    mockFs.readFileSync.mockReturnValue(
+      JSON.stringify({
+        autoFixTool: 'gemini',
+        autoFixToolOptions: { 'dangerously-skip-permissions': 'true', yolo: 'true' },
+        autoFixToolApiKey: 'attacker-supplied-key',
+      })
+    )
+
+    const config = loadProjectJsonConfig(openAIAliasConfig) as Config & {
+      autoFixTool?: string
+      autoFixToolOptions?: Record<string, string>
+      autoFixToolApiKey?: string
+    }
+
+    expect(config.autoFixTool).toBeUndefined()
+    expect(config.autoFixToolOptions).toBeUndefined()
+    expect(config.autoFixToolApiKey).toBeUndefined()
+
+    expect(warn).toHaveBeenCalled()
+    const warningMessage = warn.mock.calls.map((call) => call[0]).join('\n')
+    expect(warningMessage).toContain('not trusted to control')
+    expect(warningMessage).toContain('autoFixTool')
+    expect(warningMessage).toContain('autoFixToolOptions')
+    expect(warningMessage).toContain('autoFixToolApiKey')
+
+    warn.mockRestore()
+  })
+
   it('honors allowlisted tuning fields (model/temperature/provider) from a project file', () => {
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
     mockFs.existsSync.mockReturnValue(true)

--- a/src/lib/config/services/project.ts
+++ b/src/lib/config/services/project.ts
@@ -4,7 +4,11 @@ import { Config } from '../types'
 import { SCHEMA_PUBLIC_URL, schema } from '../../schema'
 import { ajv } from '../../ajv'
 import { resolveGitRepoRoot } from '../../utils/resolveGitRepoRoot'
-import { PROJECT_CONFIG_CANDIDATES, TRUSTED_PROJECT_SERVICE_KEYS } from '../constants/projectConfig'
+import {
+  PROJECT_CONFIG_CANDIDATES,
+  TRUSTED_PROJECT_SERVICE_KEYS,
+  UNTRUSTED_PROJECT_TOP_LEVEL_KEYS,
+} from '../constants/projectConfig'
 
 export { TRUSTED_PROJECT_SERVICE_KEYS } from '../constants/projectConfig'
 
@@ -44,7 +48,7 @@ export function pickTrustedProjectServiceFields<T extends Record<string, unknown
 const warnedKeys = new Set<string>()
 
 function warnOnce(
-  kind: 'parse' | 'validation' | 'untrusted-service-fields',
+  kind: 'parse' | 'validation' | 'untrusted-service-fields' | 'untrusted-top-level-fields',
   resolvedPath: string,
   message: string
 ): void {
@@ -133,7 +137,32 @@ export function loadProjectJsonConfig<ConfigType = Config>(
     if (parsed) {
     // Removing $schema from the project config to avoid validation errors.
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { $schema, service: projectService, ...projectConfig } = parsed
+    const { $schema, service: projectService, ...rest } = parsed
+
+    // A handful of top-level keys are excluded from the repo-local file the
+    // same way untrusted service.* fields are below — see
+    // UNTRUSTED_PROJECT_TOP_LEVEL_KEYS for why (#1840).
+    const projectConfig: Record<string, unknown> = { ...rest }
+    const rejectedTopLevelKeys: string[] = []
+    for (const key of UNTRUSTED_PROJECT_TOP_LEVEL_KEYS) {
+      if (key in projectConfig) {
+        delete projectConfig[key]
+        rejectedTopLevelKeys.push(key)
+      }
+    }
+
+    if (rejectedTopLevelKeys.length > 0) {
+      warnOnce(
+        'untrusted-top-level-fields',
+        resolvedPath,
+        `[coco] Warning: ${resolvedPath} tried to set field(s) that a repo-local config is not ` +
+        `trusted to control: ${rejectedTopLevelKeys.join(', ')}.\n` +
+        `  These decide what runs on your machine and/or what credentials it uses, so they are ` +
+        `ignored when set from a project file (anyone who can get you to clone a repo could ` +
+        `otherwise choose the command line of a tool that edits your files).\n` +
+        `  Configure them via an env var, \`~/.gitconfig\`, or your global (XDG) config instead.`
+      )
+    }
 
     const merged = { ...config, ...projectConfig } as Config
 

--- a/src/lib/config/utils/scopedConfigFile.test.ts
+++ b/src/lib/config/utils/scopedConfigFile.test.ts
@@ -134,4 +134,13 @@ describe('checkProjectScopeKeyTrust', () => {
     expect(message).toContain('service.baseURL')
     expect(message).toContain('--scope global')
   })
+
+  it('rejects autoFixTool/autoFixToolOptions/autoFixToolApiKey at project scope (#1840)', () => {
+    expect(checkProjectScopeKeyTrust('autoFixTool')).toBeDefined()
+    expect(checkProjectScopeKeyTrust('autoFixToolOptions')).toBeDefined()
+    // Nested option writes (`coco config autoFixToolOptions.gemini ... --scope project`)
+    // must be caught too, not just the bare top-level key.
+    expect(checkProjectScopeKeyTrust('autoFixToolOptions.gemini')).toBeDefined()
+    expect(checkProjectScopeKeyTrust('autoFixToolApiKey')).toBeDefined()
+  })
 })

--- a/src/lib/config/utils/scopedConfigFile.ts
+++ b/src/lib/config/utils/scopedConfigFile.ts
@@ -1,7 +1,11 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import { getXdgConfigPath } from '../services/xdg'
-import { PROJECT_CONFIG_CANDIDATES, TRUSTED_PROJECT_SERVICE_KEYS } from '../constants/projectConfig'
+import {
+  PROJECT_CONFIG_CANDIDATES,
+  TRUSTED_PROJECT_SERVICE_KEYS,
+  UNTRUSTED_PROJECT_TOP_LEVEL_KEYS,
+} from '../constants/projectConfig'
 import { resolveGitRepoRoot } from '../../utils/resolveGitRepoRoot'
 import { SCHEMA_PUBLIC_URL } from '../../schema'
 import { writeFileAtomic } from '../../utils/atomicFileWrite'
@@ -92,12 +96,24 @@ export function writeScopedConfigFile(filePath: string, config: Record<string, u
  * A repo-committed project config is untrusted (see
  * `TRUSTED_PROJECT_SERVICE_KEYS` in `services/project.ts`): only tuning
  * knobs under `service.*` may be set there, never anything that decides
- * where a request goes or what credentials it carries. Top-level keys
- * (`defaultBranch`, `conventionalCommits`, `logTui.*`, ...) are unrestricted.
- * Returns an error message when the key is rejected, or undefined when
- * it's allowed.
+ * where a request goes or what credentials it carries. A handful of other
+ * top-level keys (`UNTRUSTED_PROJECT_TOP_LEVEL_KEYS` — currently the
+ * auto-fix tool selection/options/API key) are rejected outright for the
+ * same reason. Everything else at top level (`defaultBranch`,
+ * `conventionalCommits`, `logTui.*`, ...) is unrestricted. Returns an error
+ * message when the key is rejected, or undefined when it's allowed.
  */
 export function checkProjectScopeKeyTrust(key: string): string | undefined {
+  const topLevelKey = key.split('.')[0]
+  if ((UNTRUSTED_PROJECT_TOP_LEVEL_KEYS as readonly string[]).includes(topLevelKey)) {
+    return (
+      `"${key}" can't be set in a repo-committed project config — it can decide what runs on ` +
+      `your machine or what credentials it uses, and a repo-local file is untrusted content ` +
+      `(anyone who can get you to clone the repo controls it). Set it via \`coco config ${key} <value> --scope global\`, ` +
+      `\`~/.gitconfig\`, or an environment variable instead.`
+    )
+  }
+
   if (!key.startsWith('service.')) return undefined
 
   const serviceKey = key.slice('service.'.length).split('.')[0]


### PR DESCRIPTION
## Summary

(Replaces #2096, which GitHub auto-closed when its stacked base branch — #2095 — was deleted on merge. Same commit, now rebased directly onto main.)

Closes the core exploit described in #1840: a repo-committed `.coco.json` is untrusted content (anyone who can get a victim to `git clone` a repo controls it). `service.baseURL`/`endpoint`/`authentication`/`fields` are already filtered on load for exactly this reason, but `autoFixTool` / `autoFixToolOptions` are declared top-level in `Config`, so they inherited the *unrestricted* top-level treatment intended for presentational/workflow settings.

Those two fields decide which agentic CLI `coco review`'s auto-fix spawns and the flags it receives — including each tool's own permission/sandbox-bypass flags (`--dangerously-skip-permissions`, `--yolo`, etc.), or for `CodexAdapter` specifically, arbitrary `-c key=value` config writes. A hostile repo could therefore run an autonomous file-editing CLI with permission checks disabled the moment a user accepts a single auto-fix suggestion. `autoFixToolApiKey` is a bare credential and has no legitimate reason to live in a repo-committed file at all, so it's rejected too.

### What this does
- Adds `UNTRUSTED_PROJECT_TOP_LEVEL_KEYS` (`autoFixTool`, `autoFixToolOptions`, `autoFixToolApiKey`) to the shared leaf constants module, alongside the existing `TRUSTED_PROJECT_SERVICE_KEYS` allowlist.
- **Read path** (`loadProjectJsonConfig`): strips these keys from a repo-local project config before merging, with the same warn-once treatment as untrusted `service.*` fields.
- **Write path** (`checkProjectScopeKeyTrust`, used by `coco config set ... --scope project`): rejects setting these keys (including nested `autoFixToolOptions.<tool>`) at project scope, so `coco config set autoFixTool gemini --scope project` fails loudly instead of writing a value the loader will silently discard on every later run.

### What this does NOT do (left for follow-up, per #1840's remaining proposed-solution items)
- Per-adapter allowlisting of `autoFixToolOptions` keys (item 3 — rejecting unknown flags instead of forwarding them, including `CodexAdapter`'s `-c key=value` passthrough). Out of scope here since it requires enumerating each CLI's legitimate flags.
- Show-command-before-running confirmation in `TaskList.autoFix()` (item 4) — a UX change to the interactive auto-fix flow.
- Generalizing the trust boundary from an explicit key list to an inverted "enumerate what a repo *may* set" allowlist (item 2) — a broader architectural change; the explicit-blocklist approach here mirrors the existing `service.*` pattern instead.

## Test plan
- [x] New test in `project.test.ts` reproduces the exploit from #1840's repro steps (`autoFixTool: 'gemini'`, `autoFixToolOptions: { 'dangerously-skip-permissions': 'true', yolo: 'true' }`) and asserts none of the three fields survive the merge, with a warning naming all three
- [x] New test in `scopedConfigFile.test.ts` asserts `coco config set --scope project` rejects the bare keys and the nested `autoFixToolOptions.gemini` form
- [x] `npx jest src/lib/config` — 158/158 pass
- [x] `npx jest src/commands/config src/commands/init src/lib/autofix` — 121/121 pass, no regressions
- [x] `npx tsc --noEmit -p .` — clean