### PR TITLE
fix(cli): forward global --json/--quiet through the default router

### DIFF
--- a/src/commands/defaultRouter.test.ts
+++ b/src/commands/defaultRouter.test.ts
@@ -139,6 +139,24 @@ describe('bare `coco` → workstation history view (#1169 regression)', () => {
   })
 })
 
+describe('buildSyntheticArgv forwards global json/quiet (#1877)', () => {
+  it('carries --json through to the routed handler', () => {
+    const synthetic = buildSyntheticArgv<UiArgv>(routeArgv({ json: true }))
+    expect(synthetic.json).toBe(true)
+  })
+
+  it('carries --quiet through to the routed handler', () => {
+    const synthetic = buildSyntheticArgv<UiArgv>(routeArgv({ quiet: true }))
+    expect(synthetic.quiet).toBe(true)
+  })
+
+  it('leaves json/quiet unset when the caller did not pass them', () => {
+    const synthetic = buildSyntheticArgv<UiArgv>(routeArgv())
+    expect(synthetic.json).toBeUndefined()
+    expect(synthetic.quiet).toBeUndefined()
+  })
+})
+
 describe('buildSyntheticArgv interactive override', () => {
   it('defaults `interactive` to true when no override is given (ui/workspace/init regression guard)', () => {
     const synthetic = buildSyntheticArgv<UiArgv>(routeArgv())
@@ -183,5 +201,29 @@ describe('legacy `--commit`/COCO_DEFAULT=commit route does not force interactive
     expect(commitHandler).toHaveBeenCalledTimes(1)
     const mockCommitHandler = commitHandler as jest.Mock
     expect(mockCommitHandler.mock.calls[0][0].interactive).toBe(false)
+  })
+
+  it('forwards --json to commitHandler instead of dropping it (#1877)', async () => {
+    // The exploit: `COCO_DEFAULT=commit coco --json` is documented as a
+    // preview-only escape hatch (commit/handler.ts treats argv.json as
+    // "generate a draft, don't commit"). Losing the flag here silently
+    // turned that preview into a real commit.
+    process.env.COCO_DEFAULT = 'commit'
+    const logger = new Logger({ silent: true })
+
+    await defaultRouteHandler(routeArgv({ json: true }), logger)
+
+    const mockCommitHandler = commitHandler as jest.Mock
+    expect(mockCommitHandler.mock.calls[0][0].json).toBe(true)
+  })
+
+  it('forwards --quiet to commitHandler instead of dropping it (#1877)', async () => {
+    process.env.COCO_DEFAULT = 'commit'
+    const logger = new Logger({ silent: true })
+
+    await defaultRouteHandler(routeArgv({ quiet: true }), logger)
+
+    const mockCommitHandler = commitHandler as jest.Mock
+    expect(mockCommitHandler.mock.calls[0][0].quiet).toBe(true)
   })
 })

--- a/src/commands/defaultRouter.ts
+++ b/src/commands/defaultRouter.ts
@@ -157,11 +157,15 @@ export function buildSyntheticArgv<T>(
   overrides: Partial<{ interactive: boolean }> = {}
 ): T {
   return ({
+    // Spread first so every global flag the user actually passed
+    // (json, quiet, and anything else yargs put on `$0`'s argv)
+    // reaches the routed-to handler by default. Previously this
+    // hand-picked fields and silently dropped `json`/`quiet`, which
+    // for the `commit` route flipped `coco --commit --json` (a
+    // documented preview-only escape hatch) into a real commit,
+    // since commit/handler.ts reads argv.json as that switch (#1877).
+    ...argv,
     _: ['$0'],
-    $0: argv.$0,
-    repo: argv.repo,
-    cwd: argv.cwd,
-    verbose: argv.verbose,
     interactive: true,
     version: false,
     help: false,


### PR DESCRIPTION
## Summary

`buildSyntheticArgv` (the shim the bare-`coco` default router uses to forward to `init`/`ui`/`workspace`/`commit`) hand-projected a fixed set of fields onto the argv it builds, silently dropping `json` and `quiet` — and anything else not explicitly enumerated.

For the `commit` route this wasn't cosmetic: `commit/handler.ts` reads `argv.json` as the "generate a draft, don't commit" switch. So `COCO_DEFAULT=commit coco --json` — the documented legacy escape hatch for scripts/CI/hook integrations expecting the same behavior as `coco commit --json` — silently opened the interactive review loop and created a real commit instead of printing `{"title","body"}`. `--quiet` was dropped the same way.

## Fix

Spread `argv` first in `buildSyntheticArgv` so every global flag the user actually passed reaches the routed-to handler by default, then apply the router's own overrides (`_`, `interactive`, `version`, `help`) on top — matching the fix suggested in #1877.

## Test plan
- [x] New tests in `defaultRouter.test.ts` reproduce the exact exploit (`COCO_DEFAULT=commit` + `--json`/`--quiet`) and assert `commitHandler` receives them
- [x] Existing `buildSyntheticArgv`/router tests still pass unchanged, including the regression guard documenting that command-specific yargs defaults (e.g. `ui`'s `all: true`) are still NOT carried by this shim — this fix only changes what's forwarded from the router's own argv, not what's synthesized
- [x] `npx jest src/commands/defaultRouter src/commands/commit src/commands/init src/commands/ui src/commands/workspace` — 307/307 pass
- [x] `npx tsc --noEmit -p .` — clean

Fixes #1877