### PR TITLE
fix(init): read-merge-write .coco.json instead of overwriting it

### DIFF
--- a/src/commands/init/handler.ts
+++ b/src/commands/init/handler.ts
@@ -352,7 +352,7 @@ export const handler: CommandHandler<InitArgv> = async (argv, logger) => {
       const configToWrite: ConfigWithServiceObject = isProjectScope
         ? { ...config, service: pickTrustedProjectServiceFields(config.service) as ConfigWithServiceObject['service'] }
         : config
-      appendToProjectJsonConfig(configFilePath, configToWrite)
+      await appendToProjectJsonConfig(configFilePath, configToWrite)
     } else {
       // Fail loud rather than silently no-op: any config-file type without a
       // writer branch is a bug, and a silent skip here looks like success.

--- a/src/lib/config/services/project.test.ts
+++ b/src/lib/config/services/project.test.ts
@@ -1,12 +1,16 @@
 import * as fs from 'fs'
 import * as path from 'path'
-import { loadProjectJsonConfig, pickTrustedProjectServiceFields, resetConfigLoadWarnings } from './project'
+import { appendToProjectJsonConfig, loadProjectJsonConfig, pickTrustedProjectServiceFields, resetConfigLoadWarnings } from './project'
 import { Config } from '../types'
 import { getDefaultServiceConfigFromAlias } from '../../langchain/utils'
 import { resolveGitRepoRoot } from '../../utils/resolveGitRepoRoot'
+import { writeFileAtomic } from '../../utils/atomicFileWrite'
+import { confirmPrompt } from '../../ui/inquirerPrompts'
 
 jest.mock('fs')
 jest.mock('os')
+jest.mock('../../utils/atomicFileWrite')
+jest.mock('../../ui/inquirerPrompts')
 // Real implementation: project.ts joins the resolved repo root with the
 // candidate filename via path.join (#1616) — nothing in this file asserts
 // on a mocked path.join, so keeping the real behavior lets that join
@@ -23,6 +27,8 @@ jest.mock('../../utils/resolveGitRepoRoot')
 
 const mockFs = fs as jest.Mocked<typeof fs>
 const mockResolveGitRepoRoot = resolveGitRepoRoot as jest.MockedFunction<typeof resolveGitRepoRoot>
+const mockWriteFileAtomic = writeFileAtomic as jest.MockedFunction<typeof writeFileAtomic>
+const mockConfirmPrompt = confirmPrompt as jest.MockedFunction<typeof confirmPrompt>
 
 // project.ts joins this with path.join, which is platform-native (`\` on
 // Windows) — comparisons below must go through the same real `path.join`
@@ -344,5 +350,88 @@ describe('pickTrustedProjectServiceFields', () => {
       tokenLimit: 4096,
       requestOptions: { timeout: 30000, maxRetries: 2 },
     })
+  })
+})
+
+describe('appendToProjectJsonConfig (#1875)', () => {
+  const FILE_PATH = '/fake/repo/root/.coco.json'
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('writes directly with no confirm prompt when the file does not exist yet', async () => {
+    mockFs.existsSync.mockReturnValue(false)
+
+    await appendToProjectJsonConfig(FILE_PATH, { defaultBranch: 'main' })
+
+    expect(mockConfirmPrompt).not.toHaveBeenCalled()
+    expect(mockWriteFileAtomic).toHaveBeenCalledTimes(1)
+    const [writtenPath, writtenContent, opts] = mockWriteFileAtomic.mock.calls[0]
+    expect(writtenPath).toBe(FILE_PATH)
+    expect(opts).toEqual({ preserveExistingMode: true })
+    expect(JSON.parse(writtenContent)).toMatchObject({ defaultBranch: 'main' })
+  })
+
+  it('prompts before touching an existing file, and writes nothing when declined', async () => {
+    mockFs.existsSync.mockReturnValue(true)
+    mockFs.readFileSync.mockReturnValue(JSON.stringify({ defaultBranch: 'main' }))
+    mockConfirmPrompt.mockResolvedValue(false)
+
+    await appendToProjectJsonConfig(FILE_PATH, { defaultBranch: 'develop' })
+
+    expect(mockConfirmPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining(FILE_PATH) })
+    )
+    expect(mockWriteFileAtomic).not.toHaveBeenCalled()
+  })
+
+  it('merges into existing unrelated keys instead of destroying them, once confirmed (core exploit)', async () => {
+    // The bug: re-running `coco init --scope project` (e.g. to change the
+    // model) used to wipe a committed .coco.json down to just what this
+    // call sets, silently dropping keys like logTui.theme.
+    mockFs.existsSync.mockReturnValue(true)
+    mockFs.readFileSync.mockReturnValue(
+      JSON.stringify({
+        defaultBranch: 'main',
+        logTui: { theme: { preset: 'dracula' } },
+        ignoredFiles: ['package-lock.json'],
+      })
+    )
+    mockConfirmPrompt.mockResolvedValue(true)
+
+    await appendToProjectJsonConfig(FILE_PATH, { defaultBranch: 'develop' })
+
+    const written = JSON.parse(mockWriteFileAtomic.mock.calls[0][1])
+    expect(written.defaultBranch).toBe('develop')
+    expect(written.logTui).toEqual({ theme: { preset: 'dracula' } })
+    expect(written.ignoredFiles).toEqual(['package-lock.json'])
+  })
+
+  it('shallow-merges service, with the new call winning over existing values', async () => {
+    mockFs.existsSync.mockReturnValue(true)
+    mockFs.readFileSync.mockReturnValue(
+      JSON.stringify({ service: { provider: 'openai', model: 'gpt-4o-mini', temperature: 0.2 } })
+    )
+    mockConfirmPrompt.mockResolvedValue(true)
+
+    await appendToProjectJsonConfig(FILE_PATH, {
+      service: { provider: 'openai', model: 'gpt-4o' } as unknown as Config['service'],
+    })
+
+    const written = JSON.parse(mockWriteFileAtomic.mock.calls[0][1])
+    expect(written.service).toEqual({ provider: 'openai', model: 'gpt-4o', temperature: 0.2 })
+  })
+
+  it('confirms then writes a fresh config when the existing file is malformed JSON', async () => {
+    mockFs.existsSync.mockReturnValue(true)
+    mockFs.readFileSync.mockReturnValue('{ not valid json')
+    mockConfirmPrompt.mockResolvedValue(true)
+
+    await appendToProjectJsonConfig(FILE_PATH, { defaultBranch: 'develop' })
+
+    expect(mockConfirmPrompt).toHaveBeenCalled()
+    const written = JSON.parse(mockWriteFileAtomic.mock.calls[0][1])
+    expect(written).toMatchObject({ defaultBranch: 'develop' })
   })
 })

--- a/src/lib/config/services/project.ts
+++ b/src/lib/config/services/project.ts
@@ -4,6 +4,10 @@ import { Config } from '../types'
 import { SCHEMA_PUBLIC_URL, schema } from '../../schema'
 import { ajv } from '../../ajv'
 import { resolveGitRepoRoot } from '../../utils/resolveGitRepoRoot'
+import { writeFileAtomic } from '../../utils/atomicFileWrite'
+import { CONFIG_ALREADY_EXISTS } from '../../ui/helpers'
+import { confirmPrompt } from '../../ui/inquirerPrompts'
+import { isRecord } from './xdg'
 import {
   PROJECT_CONFIG_CANDIDATES,
   TRUSTED_PROJECT_SERVICE_KEYS,
@@ -250,20 +254,66 @@ export function loadProjectJsonConfig<ConfigType = Config>(
   return config as ConfigType
 }
 
-export const appendToProjectJsonConfig = (filePath: string, config: Partial<Config>) => {
-  if (!fs.existsSync(filePath)) {
-    fs.writeFileSync(filePath, '{}')
+/**
+ * Writes `config` into a repo-local project config file, read-merging
+ * with any existing content instead of overwriting it wholesale. Despite
+ * the name, this used to be a blind overwrite — any keys the user (or a
+ * prior `coco doctor --fix`) had set that this call doesn't know about
+ * (`logTui.theme`, `workspace.roots`, `ignoredFiles`, `prompt`,
+ * `forgeHosts`, `telemetry`, ...) were silently destroyed, with no
+ * "existing config found, override?" prompt even though the sibling
+ * global-scope writer (`appendToGitConfig`) already has one (#1875).
+ *
+ * Confirms via `CONFIG_ALREADY_EXISTS` before touching a file that
+ * already exists — declining leaves the file untouched. `service` is
+ * merged one level deep (existing knobs survive unless this call's
+ * config explicitly sets them); everything else is a shallow merge,
+ * matching how the read path (`loadProjectJsonConfig`) already merges
+ * `service` from a project file.
+ */
+export const appendToProjectJsonConfig = async (filePath: string, config: Partial<Config>): Promise<void> => {
+  let existing: Partial<Config> & { $schema?: string } = {}
+
+  if (fs.existsSync(filePath)) {
+    try {
+      const raw = fs.readFileSync(filePath, 'utf-8')
+      if (raw.trim()) {
+        const parsed: unknown = JSON.parse(raw)
+        if (isRecord(parsed)) {
+          existing = parsed as Partial<Config> & { $schema?: string }
+        }
+      }
+    } catch {
+      // Malformed existing file — fall through to the confirm prompt;
+      // confirming replaces it with a fresh, valid config instead of
+      // crashing `coco init`.
+    }
+
+    const confirmOverwrite = await confirmPrompt({
+      message: CONFIG_ALREADY_EXISTS(filePath),
+      default: false,
+    })
+    if (!confirmOverwrite) {
+      return
+    }
   }
 
-  fs.writeFileSync(
-    filePath,
-    JSON.stringify(
-      {
-        $schema: SCHEMA_PUBLIC_URL,
-        ...config,
-      },
-      null,
-      2
-    )
-  )
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { $schema: _existingSchema, service: existingService, ...existingRest } = existing
+  const { service: newService, ...newRest } = config
+
+  const merged: Partial<Config> & { $schema?: string } = {
+    ...existingRest,
+    ...newRest,
+    $schema: SCHEMA_PUBLIC_URL,
+  }
+
+  if (isRecord(existingService) || isRecord(newService)) {
+    merged.service = {
+      ...(isRecord(existingService) ? existingService : {}),
+      ...(isRecord(newService) ? newService : {}),
+    } as Config['service']
+  }
+
+  writeFileAtomic(filePath, JSON.stringify(merged, null, 2) + '\n', { preserveExistingMode: true })
 }


### PR DESCRIPTION
## Summary

`appendToProjectJsonConfig` is named as if it merges, but wrote the file wholesale with no read step first — so any key it doesn't know about (`logTui.theme`, `workspace.roots`, `ignoredFiles`, `prompt`, `forgeHosts`, `telemetry`, ...) was silently destroyed on every write. Unlike the sibling global-scope writer (`appendToGitConfig`, used for `~/.gitconfig`), there was no "existing config found, override?" confirmation — even though the codebase already has that exact primitive (`CONFIG_ALREADY_EXISTS`), just not wired up here.

Repro: add `"logTui": {"theme":{"preset":"dracula"}}` to `.coco.json`, run `coco init --scope project` (e.g. just to change the model), accept the wizard — the key is gone, and `init` reports success.

## Fix

- Read the existing file first (tolerant of a missing/empty/malformed file — malformed falls through to the confirm prompt rather than crashing `coco init`).
- Confirm via `CONFIG_ALREADY_EXISTS(filePath)` before touching a file that already exists (matches the global-scope UX). Declining leaves the file completely untouched.
- Merge: `service` one level deep (existing knobs survive unless the new call explicitly sets them — matching how the *read* path, `loadProjectJsonConfig`, already merges `service` from a project file), everything else shallow.
- Write via the existing `writeFileAtomic` primitive with `preserveExistingMode: true`, so this fix doesn't also change the file's permissions as a side effect.

`appendToProjectJsonConfig` is now async (it prompts), so its one call site in `init/handler.ts` is now awaited.

## Test plan
- [x] New tests in `project.test.ts`: no file → writes directly, no prompt; existing file + declined confirm → no write; **the core exploit** — unrelated keys (`logTui`, `ignoredFiles`) survive a confirmed write; `service` shallow-merges with the new call winning; malformed existing JSON → confirms, then writes fresh
- [x] `npx jest src/lib/config src/commands/init src/commands/config` — 199/199 pass, no regressions (existing `init.test.ts` mocks this function at the module level, so its assertions on what gets *passed in* are unaffected)
- [x] `npx tsc --noEmit -p .` — clean

Fixes #1875