### PR TITLE
fix(commit): re-stage files from failed/unattempted split-apply groups

### DIFF
--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -530,6 +530,12 @@ export async function applyCommitSplitPlan({
   }
   const unplannedStaged = stagedBeforeReset.filter((file) => !plannedFiles.has(file))
 
+  // Files that actually landed in a commit. Anything in `plannedFiles`
+  // still missing from this set after the loop belongs to a group that
+  // failed or was never attempted (aborted) — restored to staged below
+  // instead of silently left out of the index (#1876).
+  const committedFiles = new Set<string>()
+
   await git.raw(['reset'])
 
   logger.startSpinner(`Applying ${applicableGroups.length} commits…`)
@@ -608,6 +614,10 @@ export async function applyCommitSplitPlan({
         }
         commitHashes.push(newHead)
         previousHead = newHead
+        for (const file of groupFiles) committedFiles.add(file)
+        for (const hunk of groupHunks) {
+          if (hunk) committedFiles.add(hunk.filePath)
+        }
         logger.verbose(`Created split commit ${newHead.slice(0, 8)}: ${group.title}`, { color: 'green' })
         break
       } catch (error) {
@@ -657,8 +667,26 @@ export async function applyCommitSplitPlan({
       // Best-effort — a path may have vanished from disk mid-apply.
     }
   }
+
+  // Restore the staging intent for planned files whose group failed or
+  // was never attempted (aborted). Without this, a hook rejecting one
+  // group — or a mid-run SIGINT — left the user with those files
+  // unstaged and no warning, discarding a hand-curated index (#1876).
+  const unresolvedPlannedFiles = [...plannedFiles].filter(
+    (file) => !committedFiles.has(file) && stagedBeforeReset.includes(file)
+  )
+  if (unresolvedPlannedFiles.length > 0) {
+    try {
+      await git.raw(['add', '--', ...unresolvedPlannedFiles])
+    } catch {
+      // Best-effort — a path may have vanished from disk mid-apply.
+    }
+  }
   const unplannedNote = unplannedStaged.length > 0
     ? ` ${unplannedStaged.length} staged file(s) the plan excluded by config (e.g. lockfiles) were re-staged — commit them separately.`
+    : ''
+  const unresolvedNote = unresolvedPlannedFiles.length > 0
+    ? ` ${unresolvedPlannedFiles.length} file(s) from failed/unattempted group(s) were re-staged — resolve and commit them separately.`
     : ''
   const abortedNote = aborted
     ? ' Stopped after the hook failure was aborted — remaining groups were not attempted.'
@@ -672,7 +700,7 @@ export async function applyCommitSplitPlan({
     logger.stopSpinner('Split apply failed', { mode: 'fail', color: 'red' })
     const detail = failures.map((f) => `  - ${f.title}: ${f.reason}`).join('\n')
     throw new Error(
-      `Split apply created zero commits across ${applicableGroups.length} group(s).${abortedNote}\n${detail}`
+      `Split apply created zero commits across ${applicableGroups.length} group(s).${abortedNote}${unresolvedNote}\n${detail}`
     )
   }
 
@@ -686,7 +714,7 @@ export async function applyCommitSplitPlan({
     )
     return {
       commitHashes,
-      message: `Created ${commitHashes.length} of ${applicableGroups.length} planned commit(s). Failed: ${partial}${unplannedNote}${abortedNote}`,
+      message: `Created ${commitHashes.length} of ${applicableGroups.length} planned commit(s). Failed: ${partial}${unplannedNote}${unresolvedNote}${abortedNote}`,
       fallback,
     }
   }

--- a/src/commands/commit/splitApply.test.ts
+++ b/src/commands/commit/splitApply.test.ts
@@ -79,16 +79,21 @@ describe('applyCommitSplitPlan apply-loop safety', () => {
 
     // The recovery reset must land between group A's staging and group
     // B's staging — group A's files were left in the index by the
-    // failed commit and used to be absorbed into B's commit.
+    // failed commit and used to be absorbed into B's commit. Group A's
+    // file (a.ts) belonged to the failed group and was originally
+    // staged, so it must be re-staged after the loop rather than left
+    // unstaged with no warning (#1876).
     expect(ops).toEqual([
       'list-staged',
       'reset',
       'stage a.ts',
       'reset',
       'stage b.ts',
+      'add -- a.ts',
     ])
     expect(result.commitHashes).toEqual(['head-1'])
     expect(result.message).toContain('1 of 2')
+    expect(result.message).toContain('re-staged')
   })
 
   it('re-stages staged files the plan never claimed (config-filtered lockfiles)', async () => {
@@ -133,6 +138,33 @@ describe('applyCommitSplitPlan apply-loop safety', () => {
 
     expect(ops.filter((op) => op.startsWith('add --'))).toEqual([])
     expect(result.message).not.toContain('re-staged')
+  })
+
+  it('re-stages every planned file before throwing when every group fails (#1876)', async () => {
+    // The other half of the bug: "if every group fails, throw — but the
+    // index is left empty" (no rollback of the up-front reset at all).
+    const { git, ops } = makeFakeGit.staged(['a.ts', 'b.ts'])
+    mockedCreateCommit.mockImplementation(async () => {
+      throw new Error('Pre-commit hook failed')
+    })
+
+    const plan = makePlan([
+      { title: 'feat: a', files: ['a.ts'] },
+      { title: 'feat: b', files: ['b.ts'] },
+    ])
+
+    await expect(
+      applyCommitSplitPlan({
+        plan,
+        changes: { staged: [fileChange('a.ts'), fileChange('b.ts')], unstaged: [], untracked: [] },
+        hunkInventory: emptyHunkInventory,
+        git: git as never,
+        logger,
+        noVerify: false,
+      })
+    ).rejects.toThrow('Split apply created zero commits')
+
+    expect(ops).toContain('add -- a.ts b.ts')
   })
 })
 
@@ -212,7 +244,7 @@ describe('applyCommitSplitPlan onHookFailure recovery (OSS-662)', () => {
   })
 
   it('stops processing remaining groups and reports partial success when onHookFailure resolves "abort"', async () => {
-    const { git } = makeFakeGit.staged(['a.ts', 'b.ts', 'c.ts'])
+    const { git, ops } = makeFakeGit.staged(['a.ts', 'b.ts', 'c.ts'])
     mockedCreateCommit
       .mockImplementationOnce(async () => {
         git.advanceHead()
@@ -249,6 +281,12 @@ describe('applyCommitSplitPlan onHookFailure recovery (OSS-662)', () => {
     expect(result.commitHashes).toEqual(['head-1'])
     expect(result.message).toContain('1 of 3')
     expect(result.message).toContain('aborted')
+
+    // b.ts (failed group) and c.ts (never attempted after the abort)
+    // must both come back staged rather than left in the unstaged pile
+    // with no warning (#1876).
+    expect(ops).toContain('add -- b.ts c.ts')
+    expect(result.message).toContain('re-staged')
   })
 
   it('records the failure and continues to the next group when no onHookFailure callback is supplied', async () => {


### PR DESCRIPTION
## Summary

`applyCommitSplitPlan` (`coco commit --split --apply`) resets the whole index up front (`git reset`), then re-stages per group as each commit lands. Only files the plan never saw at all (filtered out by `ignoredFiles`/`ignoredExtensions`) were re-staged after the loop — a group that failed (hook rejection, patch conflict) or was never attempted (remaining groups after an aborted hook choice, or a mid-run interrupt) left its files sitting unstaged, with **no rollback and no mention in the result message**. A user who ran `--split --apply` on a hand-curated index could lose that curation with no warning. If every group failed, the function threw with the index left completely empty.

The existing test `splitApply.test.ts:83-90` encoded this as expected behavior (`ops` ending right after group B's staging, no re-add of group A's file).

## Fix

Track which planned files actually landed in a commit (`committedFiles`). After the loop — including on the zero-commit throw path — re-stage whatever's left from the pre-apply staged set (`stagedBeforeReset`) that didn't make it into a commit, alongside the existing re-stage for plan-excluded files. Both the throw message and the partial-success return message now say explicitly how many files were re-staged.

## Test plan
- [x] Updated the test that encoded the old behavior — now asserts the failed group's file gets re-staged, and the message says so
- [x] New test: on `abort`, both the failed group's and the never-attempted group's files get re-staged
- [x] New test: on total failure (every group fails), the function still re-stages before throwing
- [x] `npx jest src/commands/commit/splitApply.test.ts src/commands/commit/splitApplyDrift.test.ts` — 11/11 pass
- [x] `npx jest src/commands/commit` — 247/247 pass, no regressions
- [x] `npx tsc --noEmit -p .` — clean

Fixes #1876