### PR TITLE
fix(commit): note re-staged files in the clean-success split-apply message too

### DIFF
--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -726,7 +726,7 @@ export async function applyCommitSplitPlan({
 
   return {
     commitHashes,
-    message: `Created ${commitHashes.length} split commit(s).${unplannedNote}`,
+    message: `Created ${commitHashes.length} split commit(s).${unplannedNote}${unresolvedNote}`,
     fallback,
   }
 }

--- a/src/commands/commit/splitApply.test.ts
+++ b/src/commands/commit/splitApply.test.ts
@@ -140,6 +140,40 @@ describe('applyCommitSplitPlan apply-loop safety', () => {
     expect(result.message).not.toContain('re-staged')
   })
 
+  it('re-stages a rescued "unclaimed" group file instead of dropping it silently (#1878)', async () => {
+    // rescueMissingFiles tags files the model failed to place with a
+    // synthetic `unclaimed: true` group so validation passes; applicableGroups
+    // then filters unclaimed groups out of the apply loop entirely (#1180).
+    // Those files are still in plannedFiles (built from every plan.group,
+    // unclaimed included) but never reach committedFiles, since they're
+    // never attempted — so they fall out of the same #1876 restage path as
+    // a failed group, without needing separate handling.
+    const { git, ops } = makeFakeGit.staged(['a.ts', 'c.ts'])
+    mockedCreateCommit.mockImplementation(async () => {
+      git.advanceHead()
+      return {} as never
+    })
+
+    const plan = {
+      groups: [
+        { title: 'feat: a', files: ['a.ts'], body: '' },
+        { title: 'unclaimed', files: ['c.ts'], body: '', unclaimed: true },
+      ],
+    } as CommitSplitPlan
+
+    const result = await applyCommitSplitPlan({
+      plan,
+      changes: { staged: [fileChange('a.ts'), fileChange('c.ts')], unstaged: [], untracked: [] },
+      hunkInventory: emptyHunkInventory,
+      git: git as never,
+      logger,
+      noVerify: false,
+    })
+
+    expect(ops).toContain('add -- c.ts')
+    expect(result.message).toContain('re-staged')
+  })
+
   it('re-stages every planned file before throwing when every group fails (#1876)', async () => {
     // The other half of the bug: "if every group fails, throw — but the
     // index is left empty" (no rollback of the up-front reset at all).


### PR DESCRIPTION
## Summary

Closes [#1878](https://github.com/gfargo/coco/issues/1878) — turned out to already be fixed as a side effect of [#1876](https://github.com/gfargo/coco/issues/1876)/#2100, with one real gap that a regression test for it surfaced.

**Background:** #1878 reported that `rescueMissingFiles` tags files the model failed to place with a synthetic `unclaimed: true` group so plan validation passes, but `applicableGroups` filters those groups out of the apply loop entirely (#1180) — so those files' staging was never restored, and the final message never mentioned them.

**Turns out:** #1876's fix (re-stage files from failed/unattempted groups) already covers this for free — `plannedFiles` is built from *every* `plan.group` including unclaimed ones, while `committedFiles` only gets populated for groups actually processed in `applicableGroups`. Since unclaimed groups are never attempted, their files already fall into the same restage path as a failed group.

**The one real gap:** I wrote a test to verify this and it caught that #1876 only threaded the "N file(s) re-staged" note into the *throw* message and the *partial-success* (`failures.length > 0`) return message — not the clean-success return (`Created N split commit(s).`), which is exactly the path an unclaimed-only scenario takes when every *attempted* group succeeds. The files were correctly re-staged; the message just stayed silent about it. One-line fix.

## Test plan
- [x] New test: a rescued `unclaimed: true` group's file is re-staged and the message says so
- [x] `npx jest src/commands/commit/splitApply.test.ts src/commands/commit/splitApplyDrift.test.ts` — 12/12 pass
- [x] `npx jest src/commands/commit` — 248/248 pass, no regressions
- [x] `npx tsc --noEmit -p .` — clean

Fixes #1878