### PR TITLE
fix(review): reject --pr/--mr coerced to NaN instead of forwarding it

### DIFF
--- a/src/commands/review/config.test.ts
+++ b/src/commands/review/config.test.ts
@@ -52,3 +52,32 @@ describe('review config validation (#1596)', () => {
     expect(check({})).toBe(true)
   })
 })
+
+describe('review --pr NaN validation (#1880)', () => {
+  const check = extractCheckFn()
+
+  it('rejects --pr coerced to NaN by yargs (e.g. `--pr abc`)', () => {
+    // yargs' `type: 'number'` coerces an unparseable value to NaN rather
+    // than failing the parse — same hole --severity had (#1599). NaN !==
+    // undefined, so without this check the value reached
+    // getPullRequestDiffByNumber(NaN) as a real forge request.
+    expect(() => check({ pr: NaN })).toThrow('--pr must be a positive integer')
+  })
+
+  it('rejects --mr coerced to NaN (the --pr alias)', () => {
+    expect(() => check({ pr: NaN, mr: NaN })).toThrow('--pr must be a positive integer')
+  })
+
+  it('rejects a zero or negative --pr', () => {
+    expect(() => check({ pr: 0 })).toThrow('--pr must be a positive integer')
+    expect(() => check({ pr: -1 })).toThrow('--pr must be a positive integer')
+  })
+
+  it('rejects a non-integer --pr', () => {
+    expect(() => check({ pr: 1.5 })).toThrow('--pr must be a positive integer')
+  })
+
+  it('still accepts a valid positive integer --pr', () => {
+    expect(check({ pr: 42 })).toBe(true)
+  })
+})

--- a/src/commands/review/config.ts
+++ b/src/commands/review/config.ts
@@ -102,6 +102,14 @@ export const builder = (yargs: Argv) => {
         throw new Error('--severity must be an integer between 1 and 10')
       }
       const rawArgv = argv as { pr?: number; comment?: boolean; branch?: string; staged?: boolean }
+      // Same NaN hole as --severity above (#1599): yargs coerces an
+      // unparseable --pr/--mr value to NaN rather than failing, and
+      // `rawArgv.pr !== undefined` is true for NaN too — so a typo'd
+      // --pr reached getPullRequestDiffByNumber(NaN) as a real request
+      // instead of a clear CLI error (#1880).
+      if (rawArgv.pr !== undefined && !(Number.isInteger(rawArgv.pr) && rawArgv.pr > 0)) {
+        throw new Error('--pr must be a positive integer')
+      }
       if (rawArgv.comment && rawArgv.pr === undefined) {
         throw new Error('--comment requires --pr <number>.')
       }


### PR DESCRIPTION
## Summary

The builder's `.check()` was hardened for `--severity` NaN in #1599, but the same yargs `type: 'number'` hole was left open on `--pr` (aliased as `--mr`). `NaN !== undefined`, so every `argv.pr !== undefined` guard in `handler.ts` passed for a NaN value too.

`coco review --pr abc` (or `--mr abc`, or a shell variable that expanded empty-ish) resolved the forge and called `getPullRequestDiffByNumber(NaN)` — the user got a forge-level error instead of a clear "`--pr` must be a positive integer" message. With `--comment` it would also have tried to post to PR `NaN`.

## Fix

Extends the existing `.check()` the same way #1599 did for `--severity`: reject `--pr`/`--mr` unless it's a positive integer.

## Test plan
- [x] New tests reproduce the exact NaN coercion (`--pr abc` → `{ pr: NaN }`), the `--mr` alias, zero/negative, and non-integer values
- [x] `npx jest src/commands/review/config.test.ts` — 11/11 pass
- [x] `npx jest src/commands/review` — 36/36 pass, no regressions
- [x] `npx tsc --noEmit -p .` — clean

Fixes #1880