### PR TITLE
fix(cli): stop --quiet from swallowing actual command results

### DIFF
--- a/src/commands/commands.integration.test.ts
+++ b/src/commands/commands.integration.test.ts
@@ -123,6 +123,7 @@ function createConfig(overrides: Partial<Config> = {}): Config {
 function createLogger(): Logger {
   return {
     log: jest.fn(),
+    result: jest.fn(),
     verbose: jest.fn(),
     setConfig: jest.fn(),
     error: jest.fn(),

--- a/src/commands/config/config.test.ts
+++ b/src/commands/config/config.test.ts
@@ -22,6 +22,7 @@ const ORIGINAL_XDG_CONFIG_HOME = process.env.XDG_CONFIG_HOME
 function createLogger(): Logger {
   return {
     log: jest.fn(),
+    result: jest.fn(),
     verbose: jest.fn(),
     setConfig: jest.fn(),
     error: jest.fn(),
@@ -87,7 +88,7 @@ describe('config command (#1605)', () => {
 
     const written = JSON.parse(fs.readFileSync(path.join(projectDir, '.coco.json'), 'utf8'))
     expect(written.defaultBranch).toBe('develop')
-    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('Set defaultBranch'), expect.anything())
+    expect(logger.result).toHaveBeenCalledWith(expect.stringContaining('Set defaultBranch'), expect.anything())
   })
 
   it('set coerces booleans and numbers before writing', async () => {
@@ -143,13 +144,13 @@ describe('config command (#1605)', () => {
     await handler(createArgv({ action: 'set', key: 'defaultBranch', value: 'develop', scope: 'project' }), logger)
     await handler(createArgv({ action: 'get', key: 'defaultBranch' }), logger)
 
-    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('defaultBranch = "develop"'))
-    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('source: project'), expect.anything())
+    expect(logger.result).toHaveBeenCalledWith(expect.stringContaining('defaultBranch = "develop"'))
+    expect(logger.result).toHaveBeenCalledWith(expect.stringContaining('source: project'), expect.anything())
   })
 
   it('get reports "not set" for a key nothing defines', async () => {
     await handler(createArgv({ action: 'get', key: 'nonexistent.key' }), logger)
-    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('is not set'), expect.anything())
+    expect(logger.result).toHaveBeenCalledWith(expect.stringContaining('is not set'), expect.anything())
   })
 
   it('get --json emits a structured payload', async () => {
@@ -185,7 +186,7 @@ describe('config command (#1605)', () => {
     )
     await handler(createArgv({ action: 'get', key: 'service.authentication.credentials.apiKey' }), logger)
 
-    const loggedLines = (logger.log as jest.Mock).mock.calls.map((call) => call[0] as string)
+    const loggedLines = (logger.result as jest.Mock).mock.calls.map((call) => call[0] as string)
     expect(loggedLines.some((line) => line.includes('sk-real-secret-key'))).toBe(false)
     expect(loggedLines.some((line) => line.includes('•••'))).toBe(true)
   })
@@ -210,7 +211,7 @@ describe('config command (#1605)', () => {
     await handler(createArgv({ action: 'get', key: 'service.secretAccessKey' }), logger)
     await handler(createArgv({ action: 'get', key: 'service.sessionToken' }), logger)
 
-    const loggedLines = (logger.log as jest.Mock).mock.calls.map((call) => call[0] as string)
+    const loggedLines = (logger.result as jest.Mock).mock.calls.map((call) => call[0] as string)
     expect(loggedLines.some((line) => line.includes('wJalrXUtnFEMI-secret'))).toBe(false)
     expect(loggedLines.some((line) => line.includes('session-token-secret'))).toBe(false)
     expect(loggedLines.filter((line) => line.includes('•••')).length).toBeGreaterThanOrEqual(2)
@@ -227,7 +228,7 @@ describe('config command (#1605)', () => {
     )
     await handler(createArgv({ action: 'list' }), logger)
 
-    const loggedLines = (logger.log as jest.Mock).mock.calls.map((call) => call[0] as string)
+    const loggedLines = (logger.result as jest.Mock).mock.calls.map((call) => call[0] as string)
     expect(loggedLines.some((line) => line.includes('wJalrXUtnFEMI-secret'))).toBe(false)
     expect(loggedLines.some((line) => line.includes('service.secretAccessKey') && line.includes('•••'))).toBe(true)
   })
@@ -240,7 +241,7 @@ describe('config command (#1605)', () => {
     await handler(createArgv({ action: 'get', key: 'service.model' }), logger)
     await handler(createArgv({ action: 'get', key: 'service.provider' }), logger)
 
-    const loggedLines = (logger.log as jest.Mock).mock.calls.map((call) => call[0] as string)
+    const loggedLines = (logger.result as jest.Mock).mock.calls.map((call) => call[0] as string)
     expect(loggedLines.some((line) => line.includes('service.model = "gpt-4o"'))).toBe(true)
     expect(loggedLines.some((line) => line.includes('service.provider = "openai"'))).toBe(true)
     expect(loggedLines.some((line) => line.includes('is not set'))).toBe(false)
@@ -253,14 +254,14 @@ describe('config command (#1605)', () => {
     )
     await handler(createArgv({ action: 'get', key: 'service.temperature' }), logger)
 
-    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('service.temperature = 0.2'))
+    expect(logger.result).toHaveBeenCalledWith(expect.stringContaining('service.temperature = 0.2'))
   })
 
   it('list --scope project prints only that scope\'s raw contents', async () => {
     await handler(createArgv({ action: 'set', key: 'defaultBranch', value: 'develop', scope: 'project' }), logger)
     await handler(createArgv({ action: 'list', scope: 'project' }), logger)
 
-    const loggedLines = (logger.log as jest.Mock).mock.calls.map((call) => call[0] as string)
+    const loggedLines = (logger.result as jest.Mock).mock.calls.map((call) => call[0] as string)
     expect(loggedLines.some((line) => line.includes('defaultBranch = "develop"'))).toBe(true)
   })
 })

--- a/src/commands/config/handler.ts
+++ b/src/commands/config/handler.ts
@@ -64,7 +64,11 @@ function warnIfInvalid(scopeConfig: Record<string, unknown>, logger: Parameters<
     service: { ...DEFAULT_CONFIG.service, ...(rest.service as Record<string, unknown> | undefined) },
   }
   if (!validate(trial)) {
-    logger.log(
+    // A warning the user needs to see even under --quiet, same as any
+    // other logger.error() call — it was previously routed through
+    // log(), so `coco config set --quiet` hid a real schema problem
+    // while still writing the file (#1879).
+    logger.error(
       `Warning: this value may not match coco's config schema: ${ajv.errorsText(validate.errors)}`,
       { color: 'yellow' }
     )
@@ -91,12 +95,12 @@ export const handler: CommandHandler<ConfigArgv> = async (argv, logger) => {
     }
 
     if (resolved === undefined) {
-      logger.log(`${key} is not set.`, { color: 'yellow' })
+      logger.result(`${key} is not set.`, { color: 'yellow' })
       return
     }
 
-    logger.log(`${key} = ${JSON.stringify(masked)}`)
-    logger.log(`  source: ${source}${path ? ` (${path})` : ''}`, { color: 'gray' })
+    logger.result(`${key} = ${JSON.stringify(masked)}`)
+    logger.result(`  source: ${source}${path ? ` (${path})` : ''}`, { color: 'gray' })
     return
   }
 
@@ -114,7 +118,7 @@ export const handler: CommandHandler<ConfigArgv> = async (argv, logger) => {
       }
       logger.log(`${scope} scope (${filePath}):`)
       for (const [k, v] of Object.entries(masked)) {
-        logger.log(`  ${k} = ${JSON.stringify(v)}`)
+        logger.result(`  ${k} = ${JSON.stringify(v)}`)
       }
       return
     }
@@ -132,7 +136,7 @@ export const handler: CommandHandler<ConfigArgv> = async (argv, logger) => {
     }
 
     for (const entry of entries) {
-      logger.log(`${entry.key} = ${JSON.stringify(entry.value)}  ${entry.source}${entry.path ? ` (${entry.path})` : ''}`)
+      logger.result(`${entry.key} = ${JSON.stringify(entry.value)}  ${entry.source}${entry.path ? ` (${entry.path})` : ''}`)
     }
     return
   }
@@ -153,7 +157,10 @@ export const handler: CommandHandler<ConfigArgv> = async (argv, logger) => {
     warnIfInvalid(raw, logger)
     writeScopedConfigFile(filePath, raw)
 
-    logger.log(`Set ${key} in ${scope} scope (${filePath}).`, { color: 'green' })
+    // `set` has no --json branch, so this confirmation is the only signal
+    // the command did anything — suppressing it under --quiet made a
+    // successful write indistinguishable from a silent no-op (#1879).
+    logger.result(`Set ${key} in ${scope} scope (${filePath}).`, { color: 'green' })
     return
   }
 

--- a/src/commands/issues/issues.test.ts
+++ b/src/commands/issues/issues.test.ts
@@ -36,6 +36,7 @@ const fakeGit = {} as SimpleGit
 function createLogger(): Logger {
   return {
     log: jest.fn(),
+    result: jest.fn(),
     verbose: jest.fn(),
     setConfig: jest.fn(),
     error: jest.fn(),

--- a/src/commands/prCreate/handler.ts
+++ b/src/commands/prCreate/handler.ts
@@ -114,7 +114,9 @@ export const handler: CommandHandler<PrCreateArgv> = async (argv, logger) => {
   }
 
   if (argv.dryRun) {
-    logger.log(`${title}\n\n${body}`)
+    // The generated title/body is --dry-run's entire result — must
+    // survive --quiet (#1879).
+    logger.result(`${title}\n\n${body}`)
     return
   }
 

--- a/src/commands/prCreate/prCreate.test.ts
+++ b/src/commands/prCreate/prCreate.test.ts
@@ -55,7 +55,7 @@ describe('pr create command', () => {
       version: false,
       help: false,
     } as Arguments<PrCreateOptions>
-    logger = { log: jest.fn(), verbose: jest.fn(), setConfig: jest.fn(), error: jest.fn() } as unknown as Logger
+    logger = { log: jest.fn(), result: jest.fn(), verbose: jest.fn(), setConfig: jest.fn(), error: jest.fn() } as unknown as Logger
 
     mockApplyRepoFlag.mockReturnValue({} as SimpleGit)
     mockLoadConfig.mockReturnValue({ service: { provider: 'openai' } } as unknown as Config)

--- a/src/commands/prs/prs.test.ts
+++ b/src/commands/prs/prs.test.ts
@@ -38,6 +38,7 @@ const fakeGit = {} as SimpleGit
 function createLogger(): Logger {
   return {
     log: jest.fn(),
+    result: jest.fn(),
     verbose: jest.fn(),
     setConfig: jest.fn(),
     error: jest.fn(),

--- a/src/commands/review/handler.ts
+++ b/src/commands/review/handler.ts
@@ -401,7 +401,9 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
   const canShowTaskList = process.stdin.isTTY && process.stdout.isTTY
   if (!canShowTaskList) {
     logger.log(chalk.bold('Review findings:\n'))
-    logger.log(formatFindings(findings))
+    // The findings are the result, not status chrome — must survive
+    // --quiet (piped/CI usage of this exact non-TTY branch) (#1879).
+    logger.result(formatFindings(findings))
     logger.log(chalk.dim('\nNon-interactive session detected — re-run with --json for machine-readable output.'))
   } else {
     const repoRoot = resolveGitRepoRoot(process.cwd())

--- a/src/commands/review/review.test.ts
+++ b/src/commands/review/review.test.ts
@@ -122,6 +122,7 @@ describe('review command', () => {
     }
     logger = {
       log: jest.fn(),
+      result: jest.fn(),
       verbose: jest.fn(),
       setConfig: jest.fn(),
       error: jest.fn(),

--- a/src/commands/utils/githubListCommand.ts
+++ b/src/commands/utils/githubListCommand.ts
@@ -195,6 +195,8 @@ export function createGitHubListHandler<
       logger.log('')
     }
 
-    logger.log(spec.formatList(items, listNoun))
+    // The list itself is the command's result, not status chrome — must
+    // still print under --quiet (#1879), unlike the header above it.
+    logger.result(spec.formatList(items, listNoun))
   }
 }

--- a/src/lib/utils/logger.test.ts
+++ b/src/lib/utils/logger.test.ts
@@ -1,0 +1,49 @@
+import { Logger } from './logger'
+
+describe('Logger.result (#1879)', () => {
+  it('writes to stdout even when quiet is set', () => {
+    const spy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    try {
+      const logger = new Logger({ quiet: true })
+      logger.result('the actual output')
+      expect(spy).toHaveBeenCalledWith('the actual output\n')
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('writes to stdout even when silent is set', () => {
+    const spy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    try {
+      const logger = new Logger({ silent: true })
+      logger.result('the actual output')
+      expect(spy).toHaveBeenCalledWith('the actual output\n')
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('does not color the message by default', () => {
+    const spy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    try {
+      const logger = new Logger({})
+      logger.result('plain')
+      expect(spy).toHaveBeenCalledWith('plain\n')
+    } finally {
+      spy.mockRestore()
+    }
+  })
+})
+
+describe('Logger.log still honors quiet/silent (regression guard)', () => {
+  it('suppresses log() output under quiet', () => {
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => undefined)
+    try {
+      const logger = new Logger({ quiet: true })
+      logger.log('chrome')
+      expect(spy).not.toHaveBeenCalled()
+    } finally {
+      spy.mockRestore()
+    }
+  })
+})

--- a/src/lib/utils/logger.ts
+++ b/src/lib/utils/logger.ts
@@ -68,6 +68,29 @@ export class Logger {
   }
 
   /**
+   * Always writes to stdout, regardless of `silent` or `quiet`.
+   *
+   * `--quiet` is documented as suppressing status chrome only — "Results
+   * (and --json) still print to stdout." `log()` doesn't honor that for
+   * anything routed through it: a command whose *output* (not just its
+   * spinners/banners) goes through `logger.log()` prints nothing at all
+   * under `--quiet`, exits 0, and the caller has no way to tell "quiet
+   * success" from "silently produced nothing" (#1879). Use this for a
+   * command's actual result/payload; keep `log()` for chrome.
+   */
+  public result(message: string, options: LoggerOptions = {}): Logger {
+    let outputMessage = message
+
+    if (options.color) {
+      outputMessage = chalk[options.color](outputMessage)
+    }
+
+    process.stdout.write(outputMessage + '\n')
+
+    return this
+  }
+
+  /**
    * Always writes to stderr, regardless of `silent` or `quiet`.
    * Use this for error messages that must reach the user even when status
    * output is suppressed.


### PR DESCRIPTION
## Summary

`--quiet` is documented as suppressing status chrome only — "Results (and --json) still print to stdout." That held only for commands writing through `process.stdout.write`/`emitJson`. Anything routed through `Logger.log` lost it entirely, since `log()` early-returns when muted.

**Impact:** `coco prs --quiet`, `coco issues --quiet`, `coco config get/list/set --quiet`, `coco pr create --dry-run --quiet`, and `coco review --quiet` (non-TTY/piped) all printed **nothing at all** and exited 0 — indistinguishable from a silent failure. `config set --quiet` additionally hid the schema-mismatch warning from `warnIfInvalid` while still writing the file.

## Fix

Added `Logger.result()`, mirroring the existing `error()`'s bypass-mute pattern but for stdout — use it for a command's actual result/payload, keep `log()` for banners/spinners/status. Routed the five affected call sites through it:
- `githubListCommand.ts` — the list/table itself (header stays as chrome)
- `config/handler.ts` — `get`'s value+source, both `list` variants' entries, and `set`'s confirmation (its only success signal — no `--json` alternative)
- `review/handler.ts` — the non-TTY findings text
- `prCreate/handler.ts` — `--dry-run`'s title+body

Also moved `warnIfInvalid`'s schema-mismatch warning to `logger.error()` — a warning the user needs to see even under `--quiet`, same category as any other `error()` call, and conventionally belongs on stderr regardless.

**Deferred:** `coco doctor`'s report is also affected but its output was never split into chrome vs. payload the way these commands' were — that's the same structural gap [#1883](https://github.com/gfargo/coco/issues/1883) already needs to fix for `--json`, so it's left for that follow-up rather than doing it twice.

## Test plan
- [x] New `logger.test.ts`: `result()` writes to stdout under both `quiet` and `silent`, `log()` still suppressed (regression guard)
- [x] Updated assertions in `config.test.ts`/`prs.test.ts`/`issues.test.ts`/`prCreate.test.ts`/`review.test.ts`/`commands.integration.test.ts` — mocks needed `result: jest.fn()`, and content assertions that moved off `logger.log` now check `logger.result`
- [x] `npx jest` — full suite: 6953 tests, only the 4 pre-existing/unrelated worktree-environment `tsTreeSitterParser` failures (verified passing on real CI, missing `web-tree-sitter.wasm` in this worktree's local `node_modules`)
- [x] `npx tsc --noEmit -p .` — clean

Fixes #1879