### PR TITLE
fix(agent): surface diff truncation as a warning instead of silence

### DIFF
--- a/src/lib/langchain/utils/enforcePromptBudget.test.ts
+++ b/src/lib/langchain/utils/enforcePromptBudget.test.ts
@@ -34,6 +34,45 @@ describe('enforcePromptBudget', () => {
     expect(result.variables).toEqual(variables)
   })
 
+  it('never truncates mid-line — snaps back to the last complete line (#1843)', async () => {
+    // Reproduces the issue's real failure mode: a naive character-prefix
+    // binary search cut mid-identifier (`handler184` truncated to
+    // `handler18`), handing the model a syntactically broken diff tail.
+    const line1 = 'line one of the diff'
+    const line2 = 'const handler184 = (input: Request) => {'
+    const line3 = 'more content that must not survive'
+    const summary = `${line1}\n${line2}\n${line3}`
+    const additionalContext = 'context'
+    const responseTokenReserve = 10
+
+    const overheadTokenCount = tokenizer(
+      await prompt.format({ summary: '', additional_context: additionalContext })
+    )
+    // Force the binary search to land mid-identifier: "const handler18",
+    // one character short of the real "handler184" identifier.
+    const cutPoint = line1.length + 1 + 'const handler18'.length
+    const tokenBudget = overheadTokenCount + cutPoint
+    const maxTokens = tokenBudget + responseTokenReserve
+
+    const result = await enforcePromptBudget({
+      prompt,
+      variables: { summary, additional_context: additionalContext },
+      tokenizer,
+      maxTokens,
+      responseTokenReserve,
+    })
+
+    expect(result.truncated).toBe(true)
+    // The naive cut (verified by the pre-fix binary search landing exactly
+    // here) would have handed the model "...\nconst handler18" — a broken
+    // identifier. The snap must remove it entirely, not just leave it.
+    expect(result.variables.summary).not.toContain('handler1')
+    expect(result.variables.summary).not.toContain('const')
+    expect(result.variables.summary).not.toContain(line3)
+    // What survives is exactly the last complete line, nothing partial.
+    expect(result.variables.summary).toBe(line1)
+  })
+
   it('trims summary when prompt overhead pushes the rendered prompt over budget', async () => {
     const result = await enforcePromptBudget({
       prompt,
@@ -272,7 +311,9 @@ describe('enforcePromptBudget', () => {
   it('never leaves an unpaired surrogate when char-slicing lands mid-emoji', async () => {
     const additionalContext = 'context'
     const responseTokenReserve = 10
-    const prefix = 'a'.repeat(40)
+    // Ends in a newline so the line-boundary snap (#1843) is a no-op here —
+    // this test is about surrogate-pair safety specifically, not the snap.
+    const prefix = `${'a'.repeat(39)}\n`
     const summary = `${prefix}😀${'b'.repeat(40)}`
 
     const overheadTokenCount = tokenizer(
@@ -292,7 +333,9 @@ describe('enforcePromptBudget', () => {
     })
 
     expect(result.truncated).toBe(true)
-    expect(result.variables.summary).toBe(prefix)
+    // .trimEnd() (pre-existing, unrelated to the line-boundary snap) strips
+    // the trailing newline `prefix` was given to make the snap a no-op.
+    expect(result.variables.summary).toBe(prefix.trimEnd())
     expect(/[\uD800-\uDBFF]$/.test(result.variables.summary)).toBe(false)
     expect(() => JSON.stringify(result.variables.summary)).not.toThrow()
   })
@@ -335,7 +378,9 @@ describe('enforcePromptBudget', () => {
 
   it('never leaves an unpaired surrogate when the last-block char-slice fallback lands mid-emoji', async () => {
     const bigBlockBody = `* changes in "/generated"\n\n${FILE_BULLET_PREFIX}${'x'.repeat(300)}\n\n`
-    const prefix = `* changes in "/src/auth"\n\n${FILE_BULLET_PREFIX}${'a'.repeat(20)}`
+    // Ends in a newline so the line-boundary snap (#1843) is a no-op here —
+    // this test is about surrogate-pair safety specifically, not the snap.
+    const prefix = `* changes in "/src/auth"\n\n${FILE_BULLET_PREFIX}${'a'.repeat(19)}\n`
     const smallBlockBody = `${prefix}😀${'a'.repeat(20)}\n\n`
     const summary =
       `${DIRECTORY_BLOCK_SEPARATOR}${bigBlockBody}` +

--- a/src/lib/langchain/utils/enforcePromptBudget.ts
+++ b/src/lib/langchain/utils/enforcePromptBudget.ts
@@ -76,6 +76,21 @@ function stripTrailingHighSurrogate(value: string): string {
 }
 
 /**
+ * A character-prefix binary search finds the largest slice that fits the
+ * token budget with no regard for where that lands — typically mid-line,
+ * mid-identifier. Snap back to the end of the last complete line so a
+ * truncated summary is always well-formed instead of handing the model
+ * (and any caller reading the result) a syntactically broken tail (#1843).
+ * Safe to call on an already-fitting slice: removing more characters only
+ * reduces the token count, never increases it. No newline at all means no
+ * complete line survives — degrade to empty rather than a garbled partial.
+ */
+function snapToLineBoundary(text: string): string {
+  const lastNewline = text.lastIndexOf('\n')
+  return lastNewline === -1 ? '' : text.slice(0, lastNewline + 1)
+}
+
+/**
  * Trim a summary composed of whole directory blocks (see
  * `DIRECTORY_BLOCK_SEPARATOR`) by dropping entire blocks rather than
  * slicing through arbitrary characters. Blocks are dropped largest-first,
@@ -135,19 +150,31 @@ async function trimSummaryByBlocks(
   let high = lastBlock.text.length
   let bestSummary = `${DIRECTORY_BLOCK_SEPARATOR}${marker}`
   let bestTokenCount = await render(bestSummary)
+  let bestSlice = ''
 
   while (low <= high) {
     const mid = Math.floor((low + high) / 2)
-    const candidateSummary = `${DIRECTORY_BLOCK_SEPARATOR}${stripTrailingHighSurrogate(lastBlock.text.slice(0, mid))}${marker}`
+    const candidateSlice = stripTrailingHighSurrogate(lastBlock.text.slice(0, mid))
+    const candidateSummary = `${DIRECTORY_BLOCK_SEPARATOR}${candidateSlice}${marker}`
     const candidateTokenCount = await render(candidateSummary)
 
     if (candidateTokenCount <= tokenBudget) {
       bestSummary = candidateSummary
       bestTokenCount = candidateTokenCount
+      bestSlice = candidateSlice
       low = mid + 1
     } else {
       high = mid - 1
     }
+  }
+
+  // Snap the winning slice to the last complete line (#1843); only the
+  // trimmed slice itself, not the separator/marker wrapped around it.
+  // Re-render once more only if snapping actually removed anything.
+  const snappedSlice = snapToLineBoundary(bestSlice)
+  if (snappedSlice !== bestSlice) {
+    bestSummary = `${DIRECTORY_BLOCK_SEPARATOR}${snappedSlice}${marker}`
+    bestTokenCount = await render(bestSummary)
   }
 
   if (bestTokenCount > tokenBudget) {
@@ -193,7 +220,14 @@ async function trimSummaryByCharSlice(
     }
   }
 
-  return { summary: bestSummary.trimEnd(), tokenCount: bestTokenCount }
+  // Snap to the last complete line (#1843); re-render only if it changed.
+  const snappedSummary = snapToLineBoundary(bestSummary)
+  if (snappedSummary !== bestSummary) {
+    const snappedVariables = { ...variables, [summaryKey]: snappedSummary }
+    bestTokenCount = tokenizer(await renderPrompt(prompt, snappedVariables))
+  }
+
+  return { summary: snappedSummary.trimEnd(), tokenCount: bestTokenCount }
 }
 
 /**

--- a/src/operations/agent/generate.test.ts
+++ b/src/operations/agent/generate.test.ts
@@ -298,6 +298,90 @@ describe('agent generate progress reporting', () => {
     })
   })
 
+  describe('truncation warnings surface in the envelope (#1843)', () => {
+    // The core bug: executeStructured computed budgeted.truncated and threw
+    // it away, so a review/changelog/recap that silently analyzed only a
+    // fraction of the diff reported ok: true with no warning at all — an
+    // agent or CI --severity gate had no signal to distinguish "clean" from
+    // "only saw half the diff".
+    //
+    // 2500 is comfortably above every prompt template's fixed overhead
+    // (~1100-1600 chars observed) so budgeting never throws before even
+    // adding the change text, and a 5000-char mocked diff is comfortably
+    // larger than that budget so truncation reliably engages for all three
+    // operations regardless of their differing template overhead.
+    const TRUNCATING_TOKEN_LIMIT = 2500
+
+    function mockTruncatingBudget() {
+      mockLoadConfig.mockReturnValue({
+        service: {
+          tokenLimit: TRUNCATING_TOKEN_LIMIT,
+          authentication: { type: 'None' },
+          streaming: { enabled: false },
+          provider: 'test-provider',
+        },
+        prompt: undefined,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+      mockResolveChangeSource.mockResolvedValue({
+        text: 'x'.repeat(5000),
+        warnings: [],
+        meta: { kind: 'summary', digest: 'sha256:test', verification: 'provided-unverified' },
+      })
+    }
+
+    it('adds a truncation warning to the review envelope when the budget is exceeded', async () => {
+      mockTruncatingBudget()
+      const result = await generateAgentReview(baseInput, makeContext(undefined))
+
+      if (result.status !== 'completed') throw new Error('expected a completed envelope')
+      expect(result.warnings.some((w) => w.includes('truncated'))).toBe(true)
+    })
+
+    it('adds a truncation warning to the changelog envelope when the budget is exceeded', async () => {
+      mockTruncatingBudget()
+      mockExecuteChain.mockResolvedValueOnce({ title: 't', content: 'c' } as never)
+      const result = await generateAgentChangelog(baseInput, makeContext(undefined))
+
+      if (result.status !== 'completed') throw new Error('expected a completed envelope')
+      expect(result.warnings.some((w) => w.includes('truncated'))).toBe(true)
+    })
+
+    it('adds a truncation warning to the recap envelope when the budget is exceeded', async () => {
+      mockTruncatingBudget()
+      mockExecuteChain.mockResolvedValueOnce({ title: 't', summary: 's' } as never)
+      const result = await generateAgentRecap(baseInput, makeContext(undefined))
+
+      if (result.status !== 'completed') throw new Error('expected a completed envelope')
+      expect(result.warnings.some((w) => w.includes('truncated'))).toBe(true)
+    })
+
+    it('does not add a truncation warning when the budget is not exceeded', async () => {
+      const result = await generateAgentReview(baseInput, makeContext(undefined))
+
+      if (result.status !== 'completed') throw new Error('expected a completed envelope')
+      expect(result.warnings.some((w) => w.includes('truncated'))).toBe(false)
+    })
+
+    it('preserves resolveChangeSource warnings alongside the truncation warning', async () => {
+      // mockTruncatingBudget() sets up the long diff text needed to force
+      // truncation — set the extra warning after it, not before, or this
+      // override wipes that text back to the short default.
+      mockTruncatingBudget()
+      mockResolveChangeSource.mockResolvedValue({
+        text: 'x'.repeat(5000),
+        warnings: ['some other warning'],
+        meta: { kind: 'summary', digest: 'sha256:test', verification: 'provided-unverified' },
+      })
+
+      const result = await generateAgentReview(baseInput, makeContext(undefined))
+
+      if (result.status !== 'completed') throw new Error('expected a completed envelope')
+      expect(result.warnings).toContain('some other warning')
+      expect(result.warnings.some((w) => w.includes('truncated'))).toBe(true)
+    })
+  })
+
   describe('generateAgentCommitDraft', () => {
     beforeEach(() => {
       mockGenerateCommitDraft.mockResolvedValue({

--- a/src/operations/agent/generate.ts
+++ b/src/operations/agent/generate.ts
@@ -325,6 +325,15 @@ function plannedEnvelope(
   }
 }
 
+/**
+ * Result plus whether the prompt-budget guard had to truncate the change
+ * context to fit. Previously `executeStructured` returned only the parsed
+ * result, discarding `budgeted.truncated` — so a review/changelog/recap
+ * that silently analyzed a fraction of the diff had no way to tell its
+ * caller, and reported `ok: true` with no warning (#1843).
+ */
+type StructuredCallResult<T> = { result: T; truncated: boolean }
+
 async function executeStructured<T>(input: {
   operation: AgentOperation
   task: SupportedTask
@@ -334,7 +343,7 @@ async function executeStructured<T>(input: {
   promptTemplate: typeof REVIEW_PROMPT
   variables: Record<string, string>
   summaryKey: string
-}): Promise<T> {
+}): Promise<StructuredCallResult<T>> {
   const runtime = await createRuntime(input.task, input.options, input.context)
   const { prompt, budgeted } = await prepareStructuredCall({
     runtime,
@@ -357,7 +366,7 @@ async function executeStructured<T>(input: {
   const streamingEnabled = Boolean(input.context.onProgress && runtime.config.service.streaming?.enabled)
   if (streamingEnabled) {
     try {
-      return await executeChainStreaming<T>({
+      const result = await executeChainStreaming<T>({
         llm: runtime.llm,
         prompt,
         variables: budgeted.variables,
@@ -371,6 +380,7 @@ async function executeStructured<T>(input: {
         signal: input.context.signal,
         metadata,
       })
+      return { result, truncated: budgeted.truncated }
     } catch (error) {
       if (error instanceof LangChainCancelledError) throw error
       // Streaming failed for a non-cancellation reason (unsupported
@@ -385,7 +395,7 @@ async function executeStructured<T>(input: {
     }
   }
 
-  return executeChain<T>({
+  const result = await executeChain<T>({
     llm: runtime.llm,
     prompt,
     variables: budgeted.variables,
@@ -395,6 +405,20 @@ async function executeStructured<T>(input: {
     signal: input.context.signal,
     metadata,
   })
+  return { result, truncated: budgeted.truncated }
+}
+
+/**
+ * Build the "context was truncated" warning appended to an operation's
+ * envelope when `executeStructured` had to trim the change context to fit
+ * the model's token budget (#1843). Kept as one shared message so all
+ * three affected operations (review/changelog/recap) read identically.
+ */
+function truncationWarning(): string {
+  return (
+    'Change context exceeded the model\'s token budget and was truncated to fit — ' +
+    'this result may be based on an incomplete view of the changes.'
+  )
 }
 
 function envelope<T>(
@@ -539,7 +563,7 @@ export async function generateAgentReview(
     return plannedEnvelope('review', plan, resolved.warnings, resolved.meta)
   }
   report(context, 'Generating review…', 0.4)
-  const findings = await executeStructured<ReviewFeedbackItem[]>({
+  const { result: findings, truncated } = await executeStructured<ReviewFeedbackItem[]>({
     operation: 'review',
     task: 'review',
     context,
@@ -551,7 +575,8 @@ export async function generateAgentReview(
   })
   findings.sort((a, b) => b.severity - a.severity)
   report(context, 'Completed', 1)
-  return envelope('review', { findings }, resolved.warnings, resolved.meta, conventions.provenance)
+  const warnings = truncated ? [...resolved.warnings, truncationWarning()] : resolved.warnings
+  return envelope('review', { findings }, warnings, resolved.meta, conventions.provenance)
 }
 
 export async function generateAgentChangelog(
@@ -587,7 +612,7 @@ export async function generateAgentChangelog(
     return plannedEnvelope('changelog', plan, resolved.warnings, resolved.meta)
   }
   report(context, 'Generating changelog…', 0.4)
-  const result = await executeStructured<ChangelogResponse>({
+  const { result, truncated } = await executeStructured<ChangelogResponse>({
     operation: 'changelog',
     task: 'changelog',
     context,
@@ -598,7 +623,8 @@ export async function generateAgentChangelog(
     variables,
   })
   report(context, 'Completed', 1)
-  return envelope('changelog', result, resolved.warnings, resolved.meta, conventions.provenance)
+  const warnings = truncated ? [...resolved.warnings, truncationWarning()] : resolved.warnings
+  return envelope('changelog', result, warnings, resolved.meta, conventions.provenance)
 }
 
 export async function generateAgentRecap(
@@ -632,7 +658,7 @@ export async function generateAgentRecap(
     return plannedEnvelope('recap', plan, resolved.warnings, resolved.meta)
   }
   report(context, 'Generating recap…', 0.4)
-  const result = await executeStructured<RecapData>({
+  const { result, truncated } = await executeStructured<RecapData>({
     operation: 'recap',
     task: 'recap',
     context,
@@ -643,7 +669,8 @@ export async function generateAgentRecap(
     variables,
   })
   report(context, 'Completed', 1)
-  return envelope('recap', result, resolved.warnings, resolved.meta, conventions.provenance)
+  const warnings = truncated ? [...resolved.warnings, truncationWarning()] : resolved.warnings
+  return envelope('recap', result, warnings, resolved.meta, conventions.provenance)
 }
 
 export async function runAgentOperation(


### PR DESCRIPTION
## Summary

Scoped subset of [#1843](https://github.com/gfargo/coco/issues/1843) — the core "make truncation honest and correct" fix. Deliberately leaves out the issue's two more speculative/judgment-call items (see below).

On the agent/MCP surface, a diff that exceeds the token budget is silently truncated — `executeStructured` computed `budgeted.truncated` and threw it away, so `generateAgentReview`/`Changelog`/`Recap` returned `ok: true` with no warning even when the model only saw a fraction of the diff. Per the issue's real-world repro: a 400-line single-file diff at the shipped default `tokenLimit: 4096` had **54% of it discarded**, with the cut landing mid-identifier — and the envelope reported success with an empty `warnings: []`. An agent or a CI `--severity` gate reading that has no way to tell "clean" from "only analyzed half the diff."

## Fix

1. **Surface it.** `executeStructured` now returns `{ result, truncated }` instead of just the parsed result. All three affected operations (`review`/`changelog`/`recap` — `commit-draft` already routes through a separate, already-warning-aware path) append a shared truncation warning to the envelope's `warnings` array when it fires.
2. **Never cut mid-line.** The character-prefix binary search that trims an oversized summary (both the whole-block-dropping path and the plain char-slice fallback) now snaps its result back to the last complete line, so a truncated summary is always well-formed instead of handing the model — and any caller reading the result — a syntactically broken diff tail.

## Deliberately out of scope (separate follow-up)
- Bumping the stale `tokenLimit: 4096` default toward each provider's real context window — this is the "highest-leverage" item per the issue, but it's a cost/product tradeoff (larger budget = more tokens billed per call), not a pure correctness bug, and needs accurate per-provider context-window research I don't want to guess at.
- Making truncation opt-in-`error` for machine callers instead of always warn-and-continue — an API/design decision.

## Test plan
- [x] New test in `enforcePromptBudget.test.ts` reproduces the issue's exact failure mode (`handler184` truncated to `handler18`) and asserts the snap removes the broken fragment entirely rather than just trimming it
- [x] New tests in `generate.test.ts`: each of the three operations gets a truncation warning under a tight budget, no warning when the budget isn't exceeded, and `resolveChangeSource`'s own warnings survive alongside the new one
- [x] `npx jest src/lib/langchain/utils/enforcePromptBudget.test.ts` — 14/14 pass
- [x] `npx jest src/operations/agent/generate.test.ts` — 29/29 pass
- [x] `npx jest src/operations/agent src/lib/langchain` — 639/639 pass, no regressions
- [x] Full suite (`npx jest`) — only the 4 pre-existing/unrelated worktree-environment `tsTreeSitterParser` failures
- [x] `npx tsc --noEmit -p .` — clean

Part of #1843 (leaves the tokenLimit-defaults and opt-in-error items open)