### PR TITLE
fix(review): distinguish severity-gate exit code, exit non-zero on failed --comment post

### DIFF
--- a/src/commands/review/config.ts
+++ b/src/commands/review/config.ts
@@ -3,6 +3,17 @@ import { z } from 'zod'
 import { getCommandUsageHeader } from '../../lib/ui/helpers'
 import { BaseCommandOptions } from '../types'
 
+/**
+ * Exit code for "the --severity CI gate found a finding at/above the
+ * threshold" — distinct from exit 1, which `commandExecutor`'s generic
+ * catch already uses for operational failures (missing API key, rate
+ * limit, unparseable model output, missing `gh`, ...). Before this, both
+ * outcomes exited 1, so a pipeline gating on `coco review --severity 7`
+ * couldn't tell "the reviewer found blocking issues" from "the reviewer
+ * never ran" (#1881).
+ */
+export const SEVERITY_GATE_EXIT_CODE = 2
+
 export interface ReviewOptions extends BaseCommandOptions {
   interactive: boolean
   branch: string
@@ -69,7 +80,7 @@ export const options = {
   severity: {
     type: 'number',
     alias: 's',
-    description: 'Exit non-zero if any finding has severity >= this threshold (1-10). For CI gating.',
+    description: `Exit ${SEVERITY_GATE_EXIT_CODE} if any finding has severity >= this threshold (1-10), distinct from exit 1 (operational failure — missing API key, rate limit, etc.) so CI can tell them apart. For CI gating.`,
   },
   language: {
     type: 'string',

--- a/src/commands/review/handler.ts
+++ b/src/commands/review/handler.ts
@@ -27,7 +27,7 @@ import { TaskList } from '../../lib/ui/TaskList'
 import { commandExit } from '../../lib/utils/commandExit'
 import { getTokenCounterForProvider } from '../../lib/utils/tokenizer'
 import { resolveGitRepoRoot } from '../../lib/utils/resolveGitRepoRoot'
-import { ReviewArgv, ReviewFeedbackItemArraySchema, ReviewOptions, ReviewFeedbackItem } from './config'
+import { ReviewArgv, ReviewFeedbackItemArraySchema, ReviewOptions, ReviewFeedbackItem, SEVERITY_GATE_EXIT_CODE } from './config'
 import { noResult } from './noResult'
 import { REVIEW_PROMPT } from './prompt'
 import { createSchemaParser } from '../../lib/langchain/utils/createSchemaParser'
@@ -386,14 +386,18 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
     if (postResult.ok) {
       logger.log(postResult.message, { color: 'green' })
     } else {
+      // A CI job whose whole purpose is "post the review to the PR" must
+      // not report success when nothing was posted (permissions, closed
+      // PR, gh not authenticated for that host, ...) (#1882).
       logger.error(postResult.message, { color: 'red' })
+      commandExit(1)
     }
   }
 
   if (argv.json) {
     emitJson(findings)
     if (exceedsThreshold) {
-      commandExit(1)
+      commandExit(SEVERITY_GATE_EXIT_CODE)
     }
     return
   }
@@ -429,6 +433,6 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
       `Review found ${findings.filter((f) => f.severity >= severityThreshold!).length} finding(s) at or above severity ${severityThreshold}.`,
       { color: 'red' }
     )
-    commandExit(1)
+    commandExit(SEVERITY_GATE_EXIT_CODE)
   }
 }

--- a/src/commands/review/review.test.ts
+++ b/src/commands/review/review.test.ts
@@ -1,7 +1,7 @@
 import { Arguments } from 'yargs'
 import { SimpleGit } from 'simple-git'
 import { handler } from './handler'
-import { ReviewOptions, ReviewFeedbackItemSchema, ReviewFeedbackItemArraySchema } from './config'
+import { ReviewOptions, ReviewFeedbackItemSchema, ReviewFeedbackItemArraySchema, SEVERITY_GATE_EXIT_CODE } from './config'
 import { Config } from '../../commands/types'
 import { getRepo } from '../../lib/simple-git/getRepo'
 import { getChanges } from '../../lib/simple-git/getChanges'
@@ -272,11 +272,15 @@ describe('review command', () => {
     })
   })
 
-  it('exits non-zero when a finding meets the --severity threshold (--json)', async () => {
+  it('exits with the dedicated severity-gate code when a finding meets the --severity threshold (--json)', async () => {
+    // Exit 1 is reserved for operational failure (commandExecutor's generic
+    // catch already uses it for missing API key, rate limit, etc.) — a
+    // pipeline gating on --severity must be able to tell "the reviewer
+    // found blocking issues" from "the reviewer never ran" (#1881).
     argv.json = true
     argv.severity = 4 // finding severity is 5 → should gate
 
-    await expect(handler(argv, logger)).rejects.toMatchObject({ code: 1 })
+    await expect(handler(argv, logger)).rejects.toMatchObject({ code: SEVERITY_GATE_EXIT_CODE })
   })
 
   it('does not gate when findings are below the --severity threshold', async () => {
@@ -583,10 +587,21 @@ describe('review command', () => {
       argv.comment = true
       argv.severity = 4 // finding severity is 5 → meets threshold
 
-      await expect(handler(argv, logger)).rejects.toMatchObject({ code: 1 })
+      await expect(handler(argv, logger)).rejects.toMatchObject({ code: SEVERITY_GATE_EXIT_CODE })
 
       expect(mockRequestChangesPullRequestByNumber).toHaveBeenCalledWith(42, expect.stringContaining('Review finding'))
       expect(mockCommentPullRequestByNumber).not.toHaveBeenCalled()
+    })
+
+    it('exits 1 (not the severity-gate code) when the post itself fails (#1882)', async () => {
+      // A CI job whose whole purpose is "post the review to the PR" must
+      // not report success when nothing was posted.
+      argv.pr = 42
+      argv.comment = true
+      mockCommentPullRequestByNumber.mockResolvedValue({ ok: false, message: 'Permission denied.' })
+
+      await expect(handler(argv, logger)).rejects.toMatchObject({ code: 1 })
+      expect(logger.error).toHaveBeenCalledWith('Permission denied.', { color: 'red' })
     })
 
     it('keeps the posted markdown unchanged when a finding carries line/side data (OSS-2405)', async () => {


### PR DESCRIPTION
## Summary

Two exit-code correctness bugs in `review/handler.ts`, both from the same 2026-07 audit, fixed together since they're in the same function.

### #1881 — severity-gate breach indistinguishable from operational failure
The `--severity` CI gate exited via `commandExit(1)` — the same code `commandExecutor`'s generic catch already uses for operational failures (missing API key, rate limit, unparseable model output, missing `gh`). A pipeline gating on `coco review --severity 7` couldn't tell "the reviewer found blocking issues" from "the reviewer never ran." Repro: `unset OPENAI_API_KEY; coco review --severity 7 --json; echo $?` → `1`, same code as a genuine severity breach.

**Fix:** reserved a dedicated `SEVERITY_GATE_EXIT_CODE` (2) for the gate, documented on the `--severity` flag itself, keeping 1 for operational failure.

**Compatibility note:** any pipeline branching on "exit code is exactly 1" for the severity gate specifically (as opposed to just "non-zero = fail the step," the common case) needs updating to check for 2 instead. Since 1 was ambiguous before this fix, such a pipeline was already unreliable.

### #1882 — failed `--comment` post still exits 0
When `--comment`'s forge post failed (permissions, closed PR, `gh` not authenticated for that host), the failure was logged but execution fell through with nothing setting a non-zero exit. A CI job whose whole purpose is "post the review to the PR" reported success while nothing was posted. Repro: `coco review --pr <n> --comment` with a read-only token → stderr message, `echo $?` → `0`.

**Fix:** exits 1 immediately when the post fails, before falling through to the `--json`/severity-gate logic.

## Test plan
- [x] Updated the 2 existing tests that encoded the old ambiguous exit-1 severity-gate behavior to expect `SEVERITY_GATE_EXIT_CODE`
- [x] New test: a failed `--comment` post exits 1 (not the severity-gate code), with the forge's error message logged
- [x] `npx jest src/commands/review` — 37/37 pass
- [x] `npx jest src/commands/review src/commands/mcp src/operations/agent` — 299/299 pass, no regressions
- [x] `npx tsc --noEmit -p .` — clean

Fixes #1881
Fixes #1882