### PR TITLE
fix(commit): declare the openInEditor yargs flag

### DIFF
--- a/src/commands/commit/config.test.ts
+++ b/src/commands/commit/config.test.ts
@@ -16,4 +16,23 @@ describe('commit config options', () => {
     expect(parse(['--includeBranchName']).includeBranchName).toBe(true)
     expect(parse(['--no-includeBranchName']).includeBranchName).toBe(false)
   })
+
+  // #1892: openInEditor was part of CommitOptions (read at handler.ts:480)
+  // and settable via config, but had no yargs entry — under the CLI's real
+  // .strictOptions() (src/index.ts), --open-in-editor was rejected as an
+  // unknown argument even though the type it's meant to control is public.
+  it('accepts --open-in-editor under strictOptions instead of "Unknown arguments" (#1892)', () => {
+    let failMessage: string | null = null
+    const argv = yargs(['--open-in-editor'])
+      .options(options)
+      .strictOptions()
+      .fail((msg) => {
+        failMessage = msg
+      })
+      .exitProcess(false)
+      .parseSync()
+
+    expect(failMessage).toBeNull()
+    expect(argv.openInEditor).toBe(true)
+  })
 })

--- a/src/commands/commit/config.ts
+++ b/src/commands/commit/config.ts
@@ -158,6 +158,10 @@ export const options = {
     type: 'boolean',
     default: false,
   },
+  openInEditor: {
+    description: 'When editing a commit message (e.g. after a validation failure), open it in $EDITOR instead of the inline prompt',
+    type: 'boolean',
+  },
   // `--json` is a global flag (see src/index.ts). On `commit` it behaves like
   // `--print-message` — generate a draft, don't commit — but emits the result
   // as structured `{ "title", "body" }` for machine consumers.


### PR DESCRIPTION
## Summary

`CommitOptions.openInEditor: boolean` is part of the command's public option type and is read from config at `handler.ts:480` (gates whether editing a commit message during the validation-failure recovery flow opens `\$EDITOR`), but no `openInEditor` entry existed in the yargs `options` map. Under the CLI's real `.strictOptions()` (`src/index.ts:432`), `coco commit --open-in-editor` was rejected as an unknown argument — the flag was only reachable via a config file, despite being a documented-looking option someone reading the type would reasonably expect to pass on the CLI.

## Fix

Declared the flag in `options`.

## Test plan
- [x] New test reproduces the exact repro from the issue (`--open-in-editor` under real `.strictOptions()`) and confirms it's now accepted and sets `openInEditor: true`
- [x] `npx jest src/commands/commit/config.test.ts` — 3/3 pass
- [x] `npx jest src/commands/commit` — 249/249 pass, no regressions
- [x] `npx tsc --noEmit -p .` — clean

Fixes #1892