### PR TITLE
fix(commit): surface pre-commit hook output under quiet/non-interactive mode

### DIFF
--- a/src/commands/commit/splitHookFailure.test.ts
+++ b/src/commands/commit/splitHookFailure.test.ts
@@ -133,7 +133,9 @@ describe('handleCommitSplit — pre-commit hook failure recovery (OSS-662)', () 
     mockedSelectPrompt.mockResolvedValue('retry')
 
     const logger = new Logger({})
-    const logSpy = jest.spyOn(logger, 'log')
+    // Hook output goes through error(), not log() (#1887) — it must survive
+    // the quiet mode the non-interactive commit path mutes the logger with.
+    const errorSpy = jest.spyOn(logger, 'error')
 
     const output = await handleCommitSplit({
       argv: baseArgv,
@@ -146,7 +148,7 @@ describe('handleCommitSplit — pre-commit hook failure recovery (OSS-662)', () 
     })
 
     expect(mockedSelectPrompt).toHaveBeenCalledTimes(1)
-    const loggedLines = logSpy.mock.calls.map((call) => String(call[0]))
+    const loggedLines = errorSpy.mock.calls.map((call) => String(call[0]))
     expect(loggedLines.some((line) => line.includes('Hook output:'))).toBe(true)
     expect(loggedLines.some((line) => line.includes('biome check failed on widget.ts'))).toBe(true)
     expect(mockedCreateCommit).toHaveBeenCalledTimes(2)

--- a/src/lib/ui/hookFailurePrompt.test.ts
+++ b/src/lib/ui/hookFailurePrompt.test.ts
@@ -11,7 +11,6 @@ describe('promptHookFailureRecovery', () => {
 
   it('logs the header and hook output, then returns the prompted choice when interactive', async () => {
     const logger = new Logger({ silent: true })
-    const logSpy = jest.spyOn(logger, 'log')
     const errorSpy = jest.spyOn(logger, 'error')
     mockedSelectPrompt.mockResolvedValue('retry')
 
@@ -27,7 +26,9 @@ describe('promptHookFailureRecovery', () => {
       expect.stringContaining('✖ Commit blocked by pre-commit hook'),
       expect.anything()
     )
-    expect(logSpy.mock.calls.some((call) => String(call[0]).includes('lint failed on file.ts'))).toBe(
+    // error(), not log() (#1887) — see the dedicated quiet-mode test below
+    // for why this distinction is the actual bug, not just an API choice.
+    expect(errorSpy.mock.calls.some((call) => String(call[0]).includes('lint failed on file.ts'))).toBe(
       true
     )
     expect(mockedSelectPrompt).toHaveBeenCalledWith(
@@ -59,5 +60,30 @@ describe('promptHookFailureRecovery', () => {
       expect.stringContaining('Fix the issues above'),
       expect.anything()
     )
+  })
+
+  it('surfaces the actual hook output under quiet mode instead of only "fix the issues above" (#1887)', async () => {
+    // The real bug: commit/handler.ts mutes the logger for every
+    // non-interactive run (logger.setConfig({ quiet: true })). Spying on
+    // the Logger method alone doesn't prove the content survived muting —
+    // assert against the real process.stderr.write the way commit/handler
+    // actually configures the logger, to lock in that this reaches the
+    // user rather than just "the method was called".
+    const logger = new Logger({ quiet: true })
+    const writeSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    try {
+      await promptHookFailureRecovery({
+        logger,
+        header: '✖ Commit blocked by pre-commit hook',
+        hookOutput: 'lint failed on file.ts: unexpected console.log',
+        interactive: false,
+      })
+
+      const written = writeSpy.mock.calls.map((call) => String(call[0])).join('')
+      expect(written).toContain('lint failed on file.ts: unexpected console.log')
+    } finally {
+      writeSpy.mockRestore()
+    }
   })
 })

--- a/src/lib/ui/hookFailurePrompt.ts
+++ b/src/lib/ui/hookFailurePrompt.ts
@@ -24,10 +24,15 @@ export async function promptHookFailureRecovery({
   interactive: boolean
 }): Promise<HookFailureRecoveryChoice> {
   logger.error(`\n${header}`, { color: 'red' })
-  logger.log('\nHook output:', { color: 'yellow' })
-  logger.log(SEPERATOR)
-  logger.log(hookOutput)
-  logger.log(SEPERATOR)
+  // logger.error(), not log(): the commit handler mutes the logger for
+  // every non-interactive run (logger.setConfig({ quiet: true })), and the
+  // non-interactive branch below tells the user to "fix the issues above"
+  // — which, printed via log(), were the issues actually suppressed
+  // (#1887). Matches the header line above, which was already error().
+  logger.error('\nHook output:', { color: 'yellow' })
+  logger.error(SEPERATOR)
+  logger.error(hookOutput)
+  logger.error(SEPERATOR)
 
   if (!interactive) {
     logger.error(


### PR DESCRIPTION
## Summary

`promptHookFailureRecovery` (the shared pre-commit-hook-failure UX for `coco commit` and `coco commit --split`) printed its header via `logger.error()` (always reaches stderr) but the actual hook output — the useful diagnostic content — via `logger.log()`. The commit handler mutes the logger for every non-interactive run (`logger.setConfig({ quiet: true })`), and the non-interactive branch then tells the user to "fix the issues above" — which had just been suppressed.

**Impact:** `coco commit --split --apply` in CI (or `coco commit` with `commit: true` in config) reports a blocked commit with zero diagnostic detail. Repro: add a `pre-commit` hook that prints lint errors and exits 1, run `coco commit --split --apply` — stderr shows only the header and the "fix the issues above" line, never the actual hook output.

## Fix

Route the hook-output lines (`Hook output:`, the separators, and the output itself) through `error()` instead of `log()`, matching the header line right above them — same rationale as `error()`'s existing doc comment: "Use this for error messages that must reach the user even when status output is suppressed."

## Test plan
- [x] Two existing tests only spied on the `Logger` method itself (`jest.spyOn(logger, 'log')`), which proves "was `.log()` called with this content" — not "did it survive muting." Updated both to check `error()` instead, since that's what actually matters.
- [x] New test asserts the real `process.stderr.write` output under `{ quiet: true }` (the actual bug scenario, not just a method-call spy)
- [x] `npx jest src/lib/ui/hookFailurePrompt src/commands/commit src/commands/hooks` — 284/284 pass (also caught and fixed the same shallow-spy pattern in `splitHookFailure.test.ts`)
- [x] Full suite (`npx jest`) — only the 4 pre-existing/unrelated worktree-environment `tsTreeSitterParser` failures
- [x] `npx tsc --noEmit -p .` — clean

Fixes #1887