### PR TITLE
fix(git): stop misclassifying every non-hook GitError as a blocked hook

### DIFF
--- a/src/lib/simple-git/createCommit.test.ts
+++ b/src/lib/simple-git/createCommit.test.ts
@@ -98,10 +98,25 @@ describe('createCommit', () => {
   })
 
   it('wraps GitError as PreCommitHookError', async () => {
-    const gitErr = new GitError(undefined, '🔍 Running ruff...\nFound 2 errors.')
+    // Realistic `pre-commit` framework output: a "- hook id: …" line, per
+    // isPreCommitHookModifiedFilesError's own doc comment on that format.
+    const gitErr = new GitError(undefined, 'ruff.....................Failed\n- hook id: ruff\n\n🔍 Running ruff...\nFound 2 errors.')
     const commitMock = jest.fn().mockRejectedValue(gitErr)
     const git = makeGit(commitMock)
     await expect(createCommit('test commit', git)).rejects.toBeInstanceOf(PreCommitHookError)
+  })
+
+  it('does not wrap a GitError with no hook indication in its message (#1886)', async () => {
+    // GPG signing failures, index.lock contention, unborn-branch, and
+    // missing-identity errors all reach this same catch with hooks
+    // entirely out of the picture. Wrapping them misdirected users at
+    // hook config / --no-verify — which doesn't disable GPG signing, so
+    // the "fix" silently failed again the same way.
+    const gitErr = new GitError(undefined, 'error: gpg failed to sign the data\nfatal: failed to write commit object')
+    const commitMock = jest.fn().mockRejectedValue(gitErr)
+    const git = makeGit(commitMock)
+
+    await expect(createCommit('test commit', git)).rejects.toBe(gitErr)
   })
 
   it('does not blame hooks for "nothing to commit"', async () => {
@@ -121,7 +136,7 @@ describe('createCommit', () => {
   })
 
   it('preserves hook output in PreCommitHookError', async () => {
-    const hookOutput = '🔍 Running ruff...\nFound 2 errors.'
+    const hookOutput = 'ruff.....................Failed\n- hook id: ruff\n\n🔍 Running ruff...\nFound 2 errors.'
     const gitErr = new GitError(undefined, hookOutput)
     const commitMock = jest.fn().mockRejectedValue(gitErr)
     const git = makeGit(commitMock)

--- a/src/lib/simple-git/createCommit.ts
+++ b/src/lib/simple-git/createCommit.ts
@@ -51,6 +51,21 @@ function isKnownNonHookCommitFailure(message: string): boolean {
   )
 }
 
+/**
+ * Whether a GitError's message actually indicates a hook rejected the
+ * commit, as opposed to some other commit failure (GPG signing, an
+ * index.lock left by a crashed process, an unborn branch, a missing
+ * `user.name`/`user.email`) that git also reports via a non-zero exit
+ * with hooks entirely out of the picture. Deliberately narrow — err
+ * toward rethrowing the real GitError over misclassifying it, since the
+ * hook-failure UX (retry / skip hooks / abort) actively misdirects the
+ * user for these: `--no-verify` doesn't disable GPG signing, so "skip
+ * hooks" on a signing failure silently fails again the same way (#1886).
+ */
+function isLikelyHookFailure(message: string): boolean {
+  return /\bhook\b/i.test(message) || message.includes('pre-commit') || message.includes('commit-msg')
+}
+
 export interface CreateCommitOptions {
   /** When true, passes --no-verify to git commit, skipping pre-commit and commit-msg hooks. */
   noVerify?: boolean
@@ -114,10 +129,15 @@ export async function createCommit(
       if (isKnownNonHookCommitFailure(error.message)) {
         throw error
       }
-      // Wrap remaining GitErrors so callers can present them cleanly
-      // rather than showing a raw Node.js stack trace originating
-      // from simple-git internals.
-      throw new PreCommitHookError(error.message)
+      // Only wrap when the message actually indicates a hook — GPG
+      // signing failures, index.lock contention, unborn-branch and
+      // missing-identity errors all reach here too, and misclassifying
+      // them as a blocked hook pointed users at hook config / --no-verify
+      // for a problem neither one touches (#1886).
+      if (isLikelyHookFailure(error.message)) {
+        throw new PreCommitHookError(error.message)
+      }
+      throw error
     }
 
     throw error


### PR DESCRIPTION
## Summary

After the narrow "hook modified files" and "nothing to commit" checks, `createCommit` wrapped **all** remaining `GitError`s in `PreCommitHookError`. GPG signing failures, `index.lock` contention, unborn-branch, and identity errors (`Please tell me who you are`) all surfaced through the hook-failure recovery UX.

**Impact:** with `commit.gpgsign=true` and no usable key, `coco commit -i` prints `✖ Commit blocked by pre-commit hook` and offers `⚠️ Skip hooks — Retry with --no-verify`. `--no-verify` does not disable signing, so the offered "fix" silently fails again. In `--split`, the same misclassification drives the per-group retry/skip loop for a problem hooks had nothing to do with.

## Fix

Only wrap in `PreCommitHookError` when the message actually indicates a hook (`hook`, `pre-commit`, `commit-msg`); otherwise rethrow so `commandExecutor`'s generic formatter shows the real cause. Deliberately narrow — errs toward rethrowing the real `GitError` over misclassifying it, since the hook-recovery UX actively misdirects the user for these.

## Test plan
- [x] Updated the two existing test fixtures that used a bare lint-style message (no hook indication) with realistic `pre-commit`-framework output (`- hook id: …`), matching the format `isPreCommitHookModifiedFilesError`'s own doc comment describes
- [x] New test reproduces the exact bug: a GPG-signing-style `GitError` with no hook indication is rethrown as-is, not wrapped
- [x] `npx jest src/lib/simple-git/createCommit.test.ts` — 25/25 pass
- [x] Confirmed via grep that no other test file exercises the real classification logic — the 7 other files referencing `GitError`/`PreCommitHookError` all fully mock `createCommit`
- [x] `npx jest src/lib/simple-git src/commands/commit src/git` — 129 suites pass, no regressions
- [x] Full suite (`npx jest`) — only the 4 pre-existing/unrelated worktree-environment `tsTreeSitterParser` failures
- [x] `npx tsc --noEmit -p .` — clean

Fixes #1886