### PR TITLE
fix(workstation): abort in-flight AI requests on unmount (WS-3)

### DIFF
--- a/src/workstation/runtime/hooks/useAiCommitDraftActions.test.ts
+++ b/src/workstation/runtime/hooks/useAiCommitDraftActions.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression coverage for WS-3 (#1857): `aiDraftAbortRef` had no unmount
+ * cleanup, so quitting (`q`) while an AI commit draft was in flight left
+ * the LLM HTTP request pending — the Node event loop wouldn't drain until
+ * the provider responded, delaying the shell prompt's return for as long
+ * as the request took.
+ */
+import { useAiCommitDraftActions, type UseAiCommitDraftActionsDeps } from './useAiCommitDraftActions'
+import { runCommitDraftWorkflow } from '../../../git/commitWorkflowActions'
+
+jest.mock('../../../git/commitWorkflowActions', () => ({
+  runCommitDraftWorkflow: jest.fn(),
+}))
+
+const runCommitDraftWorkflowMock = runCommitDraftWorkflow as jest.MockedFunction<
+  typeof runCommitDraftWorkflow
+>
+
+/** Fake React: `useCallback` returns the callback itself; `useRef` is a plain box; `useEffect` captures its cleanup. */
+function fakeReactWithUnmount(): { react: typeof import('react'); unmount: () => void } {
+  let cleanup: (() => void) | undefined
+  const react = {
+    useCallback: (fn: unknown) => fn,
+    useRef: (initial: unknown) => ({ current: initial }),
+    useEffect: (setup: () => void | (() => void)) => {
+      const result = setup()
+      if (typeof result === 'function') cleanup = result
+    },
+  } as unknown as typeof import('react')
+  return { react, unmount: () => cleanup?.() }
+}
+
+function baseDeps(overrides: Partial<UseAiCommitDraftActionsDeps> = {}): UseAiCommitDraftActionsDeps {
+  return {
+    git: {} as never,
+    dispatch: jest.fn(),
+    mountedRef: { current: true },
+    ...overrides,
+  }
+}
+
+describe('useAiCommitDraftActions — aborts an in-flight draft on unmount (WS-3)', () => {
+  beforeEach(() => {
+    runCommitDraftWorkflowMock.mockReset()
+  })
+
+  it('aborts the signal passed to runCommitDraftWorkflow when the component unmounts mid-request', async () => {
+    let capturedSignal: AbortSignal | undefined
+    runCommitDraftWorkflowMock.mockImplementation((input) => {
+      capturedSignal = input?.signal
+      return new Promise(() => {}) // never resolves — simulates an in-flight request
+    })
+
+    const { react, unmount } = fakeReactWithUnmount()
+    const { runAiCommitDraft } = useAiCommitDraftActions(react, baseDeps())
+
+    void runAiCommitDraft()
+    await Promise.resolve()
+
+    expect(capturedSignal?.aborted).toBe(false)
+    unmount()
+    expect(capturedSignal?.aborted).toBe(true)
+  })
+})

--- a/src/workstation/runtime/hooks/useAiCommitDraftActions.ts
+++ b/src/workstation/runtime/hooks/useAiCommitDraftActions.ts
@@ -88,6 +88,17 @@ export function useAiCommitDraftActions(
   // so a stale controller can't cancel a future draft.
   const aiDraftAbortRef = React.useRef<AbortController | null>(null)
 
+  // Abort an in-flight draft on unmount (WS-3) — otherwise `q` mid-
+  // generation leaves the LLM HTTP request pending and the Node event
+  // loop won't drain until the provider responds, so the shell prompt
+  // doesn't come back for the duration of the request.
+  React.useEffect(() => {
+    return () => {
+      aiDraftAbortRef.current?.abort()
+      aiDraftAbortRef.current = null
+    }
+  }, [])
+
   const runAiCommitDraft = React.useCallback(async () => {
     // Tear down any controller from a previous draft (defensive — a
     // settled call should have cleared it in the finally block, but

--- a/src/workstation/runtime/hooks/useChangelogActions.test.ts
+++ b/src/workstation/runtime/hooks/useChangelogActions.test.ts
@@ -16,12 +16,31 @@ const runChangelogTextWorkflowMock = runChangelogTextWorkflow as jest.MockedFunc
   typeof runChangelogTextWorkflow
 >
 
-/** Fake React: `useCallback` returns the callback itself; `useRef` is a plain box. */
+/**
+ * Fake React: `useCallback` returns the callback itself; `useRef` is a plain
+ * box; `useEffect` runs its setup synchronously once (mirroring mount) since
+ * most of these tests don't simulate a render/unmount cycle.
+ */
 function fakeReact(): typeof import('react') {
   return {
     useCallback: (fn: unknown) => fn,
     useRef: (initial: unknown) => ({ current: initial }),
+    useEffect: (setup: () => void | (() => void)) => setup(),
   } as unknown as typeof import('react')
+}
+
+/** Same as `fakeReact`, but captures the `useEffect` cleanup for manual invocation. */
+function fakeReactWithUnmount(): { react: typeof import('react'); unmount: () => void } {
+  let cleanup: (() => void) | undefined
+  const react = {
+    useCallback: (fn: unknown) => fn,
+    useRef: (initial: unknown) => ({ current: initial }),
+    useEffect: (setup: () => void | (() => void)) => {
+      const result = setup()
+      if (typeof result === 'function') cleanup = result
+    },
+  } as unknown as typeof import('react')
+  return { react, unmount: () => cleanup?.() }
 }
 
 function baseDeps(overrides: Partial<UseChangelogActionsDeps> = {}): UseChangelogActionsDeps {
@@ -52,5 +71,31 @@ describe('useChangelogActions — defensive catch for an unexpected workflow thr
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'setStatus', kind: 'error' })
     )
+  })
+})
+
+/**
+ * Regression coverage for WS-3 (#1857): `changelogAbortRef` had no unmount
+ * cleanup, so quitting (`q`) while a generation was in flight left the LLM
+ * HTTP request pending — the Node event loop wouldn't drain until the
+ * provider responded.
+ */
+describe('useChangelogActions — aborts an in-flight generation on unmount (WS-3)', () => {
+  it('aborts the signal passed to runChangelogTextWorkflow when the component unmounts mid-request', async () => {
+    let capturedSignal: AbortSignal | undefined
+    runChangelogTextWorkflowMock.mockImplementation((_argv, options) => {
+      capturedSignal = options?.signal
+      return new Promise(() => {}) // never resolves — simulates an in-flight request
+    })
+
+    const { react, unmount } = fakeReactWithUnmount()
+    const { startChangelogView } = useChangelogActions(react, baseDeps())
+
+    void startChangelogView()
+    await Promise.resolve()
+
+    expect(capturedSignal?.aborted).toBe(false)
+    unmount()
+    expect(capturedSignal?.aborted).toBe(true)
   })
 })

--- a/src/workstation/runtime/hooks/useChangelogActions.ts
+++ b/src/workstation/runtime/hooks/useChangelogActions.ts
@@ -122,6 +122,16 @@ export function useChangelogActions(
   // in the finally block only when it still points at OUR controller.
   const changelogAbortRef = React.useRef<AbortController | null>(null)
 
+  // Abort an in-flight generation on unmount (WS-3) — otherwise `q`
+  // mid-generation leaves the LLM HTTP request pending and the Node
+  // event loop won't drain until the provider responds.
+  React.useEffect(() => {
+    return () => {
+      changelogAbortRef.current?.abort()
+      changelogAbortRef.current = null
+    }
+  }, [])
+
   const startChangelogView = React.useCallback(async (options: { force?: boolean } = {}) => {
     const head = context.branches?.currentBranch || context.provider?.currentBranch
     if (!head) {

--- a/src/workstation/runtime/hooks/useCommitSplitActions.test.ts
+++ b/src/workstation/runtime/hooks/useCommitSplitActions.test.ts
@@ -173,6 +173,49 @@ describe('useCommitSplitActions — recentCommits timer ownership (#1627)', () =
     })
     const dispatch = jest.fn()
     const deps = baseDeps({ dispatch, splitPlan: splitPlan as never })
+    // The hook now registers two unmount effects (the recentCommits timer
+    // and, since WS-3, the plan AbortController) — collect and run both,
+    // as a real unmount would.
+    const cleanups: Array<() => void> = []
+    const react = {
+      useCallback: (fn: unknown) => fn,
+      useRef: (initial: unknown) => ({ current: initial }),
+      useEffect: (setup: () => void | (() => void)) => {
+        const cleanup = setup()
+        if (typeof cleanup === 'function') {
+          cleanups.push(cleanup)
+        }
+      },
+    } as unknown as typeof import('react')
+    const { applyCommitSplit } = useCommitSplitActions(react, deps)
+
+    await applyCommitSplit()
+    cleanups.forEach((cleanup) => cleanup())
+
+    expect(jest.getTimerCount()).toBe(0)
+    jest.advanceTimersByTime(5000)
+    expect(dispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'clearRecentCommits' }))
+  })
+})
+
+/**
+ * Regression coverage for WS-3 (#1857): `planAbortRef` had no unmount
+ * cleanup, so quitting (`q`) while a split-plan generation was in flight
+ * left the LLM HTTP request pending — the Node event loop wouldn't drain
+ * until the provider responded.
+ */
+describe('useCommitSplitActions — aborts an in-flight plan generation on unmount (WS-3)', () => {
+  beforeEach(() => {
+    runCommitSplitPlanWorkflowMock.mockReset()
+  })
+
+  it('aborts the signal passed to runCommitSplitPlanWorkflow when the component unmounts mid-request', async () => {
+    let capturedSignal: AbortSignal | undefined
+    runCommitSplitPlanWorkflowMock.mockImplementation((input) => {
+      capturedSignal = input?.signal
+      return new Promise(() => {}) // never resolves — simulates an in-flight request
+    })
+
     let unmount: (() => void) | undefined
     const react = {
       useCallback: (fn: unknown) => fn,
@@ -184,13 +227,13 @@ describe('useCommitSplitActions — recentCommits timer ownership (#1627)', () =
         }
       },
     } as unknown as typeof import('react')
-    const { applyCommitSplit } = useCommitSplitActions(react, deps)
+    const { startCommitSplit } = useCommitSplitActions(react, baseDeps())
 
-    await applyCommitSplit()
+    void startCommitSplit()
+    await Promise.resolve()
+
+    expect(capturedSignal?.aborted).toBe(false)
     unmount?.()
-
-    expect(jest.getTimerCount()).toBe(0)
-    jest.advanceTimersByTime(5000)
-    expect(dispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'clearRecentCommits' }))
+    expect(capturedSignal?.aborted).toBe(true)
   })
 })

--- a/src/workstation/runtime/hooks/useCommitSplitActions.ts
+++ b/src/workstation/runtime/hooks/useCommitSplitActions.ts
@@ -137,6 +137,16 @@ export function useCommitSplitActions(
   // from whatever the user had moved on to.
   const planAbortRef = React.useRef<AbortController | null>(null)
 
+  // Abort an in-flight plan generation on unmount (WS-3) — otherwise
+  // `q` mid-generation leaves the LLM HTTP request pending and the
+  // Node event loop won't drain until the provider responds.
+  React.useEffect(() => {
+    return () => {
+      planAbortRef.current?.abort()
+      planAbortRef.current = null
+    }
+  }, [])
+
   // `S` keystroke — start the `coco commit --split` flow (#907).
   // Pre-flight refuses cleanly when:
   //   - Nothing is staged (suggests `g s` to pick files)

--- a/src/workstation/runtime/hooks/useConflictResolutionActions.test.ts
+++ b/src/workstation/runtime/hooks/useConflictResolutionActions.test.ts
@@ -28,12 +28,31 @@ const getConflictFileRegionsMock = getConflictFileRegions as jest.MockedFunction
   typeof getConflictFileRegions
 >
 
-/** Fake React: `useCallback` returns the callback itself; `useRef` is a plain box. */
+/**
+ * Fake React: `useCallback` returns the callback itself; `useRef` is a plain
+ * box; `useEffect` runs its setup synchronously once (mirroring mount) since
+ * most of these tests don't simulate a render/unmount cycle.
+ */
 function fakeReact(): typeof import('react') {
   return {
     useCallback: (fn: unknown) => fn,
     useRef: (initial: unknown) => ({ current: initial }),
+    useEffect: (setup: () => void | (() => void)) => setup(),
   } as unknown as typeof import('react')
+}
+
+/** Same as `fakeReact`, but captures the `useEffect` cleanup for manual invocation. */
+function fakeReactWithUnmount(): { react: typeof import('react'); unmount: () => void } {
+  let cleanup: (() => void) | undefined
+  const react = {
+    useCallback: (fn: unknown) => fn,
+    useRef: (initial: unknown) => ({ current: initial }),
+    useEffect: (setup: () => void | (() => void)) => {
+      const result = setup()
+      if (typeof result === 'function') cleanup = result
+    },
+  } as unknown as typeof import('react')
+  return { react, unmount: () => cleanup?.() }
 }
 
 function baseDeps(
@@ -82,5 +101,43 @@ describe('useConflictResolutionActions — defensive catch for an unexpected wor
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'setStatus', kind: 'error' })
     )
+  })
+})
+
+/**
+ * Regression coverage for WS-3 (#1857): `abortRef` had no unmount cleanup,
+ * so quitting (`q`) while a resolution request was in flight left the LLM
+ * HTTP request pending — the Node event loop wouldn't drain until the
+ * provider responded.
+ */
+describe('useConflictResolutionActions — aborts an in-flight request on unmount (WS-3)', () => {
+  beforeEach(() => {
+    runConflictResolutionWorkflowMock.mockReset()
+    getConflictFileRegionsMock.mockReset()
+    getConflictFileRegionsMock.mockResolvedValue({
+      ok: true,
+      regions: [{ index: 0 } as never],
+    } as never)
+  })
+
+  it('aborts the signal passed to runConflictResolutionWorkflow when the component unmounts mid-request', async () => {
+    let capturedSignal: AbortSignal | undefined
+    runConflictResolutionWorkflowMock.mockImplementation(({ signal }) => {
+      capturedSignal = signal
+      return new Promise(() => {}) // never resolves — simulates an in-flight request
+    })
+
+    const { react, unmount } = fakeReactWithUnmount()
+    const { startConflictResolution } = useConflictResolutionActions(react, baseDeps())
+
+    void startConflictResolution()
+    // Two ticks: one for the `getConflictFileRegions` await to settle,
+    // one for the controller assignment that follows it.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(capturedSignal?.aborted).toBe(false)
+    unmount()
+    expect(capturedSignal?.aborted).toBe(true)
   })
 })

--- a/src/workstation/runtime/hooks/useConflictResolutionActions.ts
+++ b/src/workstation/runtime/hooks/useConflictResolutionActions.ts
@@ -64,6 +64,16 @@ export function useConflictResolutionActions(
   // `aiDraftAbortRef` in useAiCommitDraftActions.
   const abortRef = React.useRef<AbortController | null>(null)
 
+  // Abort an in-flight resolution request on unmount (WS-3) —
+  // otherwise `q` mid-generation leaves the LLM HTTP request pending
+  // and the Node event loop won't drain until the provider responds.
+  React.useEffect(() => {
+    return () => {
+      abortRef.current?.abort()
+      abortRef.current = null
+    }
+  }, [])
+
   const startConflictResolution = React.useCallback(async () => {
     const { git, state, context, dispatch, mountedRef } = depsRef.current
     const files = context.operation?.conflictedFiles || []


### PR DESCRIPTION
## Summary
- `useAiCommitDraftActions`, `useChangelogActions`, `useCommitSplitActions`, and `useConflictResolutionActions` each own an `AbortController` for their in-flight LLM call, but none tied it to the component's lifecycle — no `useEffect` cleanup existed in any of the four hooks.
- Pressing `I` (AI commit draft), `L` (changelog), `S` (split plan), or `M` (conflict resolution) and then quitting with `q` before the request settled left Ink's terminal restored but the HTTP request to the provider still pending. The Node event loop doesn't drain until that promise settles, so the shell prompt didn't return until the provider responded (up to 30–120s on a slow model).
- Fix: each hook now registers `React.useEffect(() => () => controllerRef.current?.abort(), [])`, aborting any in-flight request on unmount.

Closes #1857

## Test plan
- [x] New/updated regression tests in all four hooks' test files, each verifying the request's `AbortSignal` fires when the fake-React `useEffect` cleanup (simulating unmount) runs
- [x] Fixed a latent bug in `useCommitSplitActions.test.ts`'s existing unmount-simulation harness that only captured the *last* registered `useEffect` cleanup — now collects and runs all of them, matching real unmount semantics
- [x] `npx jest src/workstation` — 160 suites / 3143 tests passed
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx jest` (full suite) — pre-existing, unrelated tree-sitter WASM failures only (verified identical on a clean `origin/main` checkout in this worktree)