### PR TITLE
fix(cli): emit a JSON error payload on --json failure paths (CMD-11)

### DIFF
--- a/src/commands/amend/amend.test.ts
+++ b/src/commands/amend/amend.test.ts
@@ -211,6 +211,27 @@ describe('amend command', () => {
     expect(mockCreateCommit).not.toHaveBeenCalled()
   })
 
+  it('emits a JSON error payload (not empty stdout) when --json and there is no commit to amend (CMD-11)', async () => {
+    argv.json = true
+    git.revparse.mockRejectedValue(new Error('fatal: needed a single revision'))
+    const { writes, restore } = spyStdout()
+    try {
+      await expect(handler(argv, logger)).rejects.toMatchObject({ code: 1 })
+    } finally {
+      restore()
+    }
+    const json = writes.find((w) => {
+      try {
+        JSON.parse(w)
+        return true
+      } catch {
+        return false
+      }
+    })
+    expect(json).toBeDefined()
+    expect(JSON.parse(json as string)).toEqual({ error: expect.stringContaining('No commit to amend') })
+  })
+
   it('forwards argv.language to generateCommitDraft as a per-invocation override (OSS-2217)', async () => {
     ;(argv as unknown as { language?: string }).language = 'French'
     const { restore } = spyStdout()
@@ -233,5 +254,57 @@ describe('amend command', () => {
     })
     await expect(handler(argv, logger)).rejects.toMatchObject({ code: 1 })
     expect(mockCreateCommit).not.toHaveBeenCalled()
+  })
+
+  it('emits a JSON error payload when --json and draft generation fails (CMD-11)', async () => {
+    argv.json = true
+    mockGenerate.mockResolvedValue({
+      ok: false,
+      draft: '',
+      warnings: [],
+      validationErrors: ['Generated message failed commitlint validation.'],
+    })
+    const { writes, restore } = spyStdout()
+    try {
+      await expect(handler(argv, logger)).rejects.toMatchObject({ code: 1 })
+    } finally {
+      restore()
+    }
+    const json = writes.find((w) => {
+      try {
+        JSON.parse(w)
+        return true
+      } catch {
+        return false
+      }
+    })
+    expect(json).toBeDefined()
+    expect(JSON.parse(json as string)).toEqual({
+      error: 'Generated message failed commitlint validation.',
+    })
+  })
+
+  it('emits a JSON error payload when --json and there are no changes to summarize (CMD-11)', async () => {
+    argv.json = true
+    mockGetChangesByCommit.mockResolvedValue([])
+    mockGetChanges.mockResolvedValue({ staged: [], unstaged: [], untracked: [] })
+    const { writes, restore } = spyStdout()
+    try {
+      await expect(handler(argv, logger)).rejects.toMatchObject({ code: 1 })
+    } finally {
+      restore()
+    }
+    const json = writes.find((w) => {
+      try {
+        JSON.parse(w)
+        return true
+      } catch {
+        return false
+      }
+    })
+    expect(json).toBeDefined()
+    expect(JSON.parse(json as string)).toEqual({
+      error: 'Nothing to summarize for the last commit.',
+    })
   })
 })

--- a/src/commands/amend/handler.ts
+++ b/src/commands/amend/handler.ts
@@ -10,7 +10,7 @@ import { getChangesByCommit } from '../../lib/simple-git/getChangesByCommit'
 import { getChanges } from '../../lib/simple-git/getChanges'
 import { createCommit, PreCommitHookError } from '../../lib/simple-git/createCommit'
 import { commandExit } from '../../lib/utils/commandExit'
-import { emitJson } from '../../lib/ui/emitJson'
+import { emitJson, emitJsonError } from '../../lib/ui/emitJson'
 import { isInteractive, LOGO } from '../../lib/ui/helpers'
 import { logSuccess } from '../../lib/ui/logSuccess'
 import { selectPrompt, editorPrompt } from '../../lib/ui/inquirerPrompts'
@@ -30,6 +30,7 @@ export const handler: CommandHandler<AmendArgv> = async (argv, logger) => {
     await git.revparse(['--verify', 'HEAD'])
   } catch {
     logger.error('No commit to amend — the repository has no commits yet.', { color: 'red' })
+    if (argv.json) emitJsonError('No commit to amend — the repository has no commits yet.')
     commandExit(1)
     return
   }
@@ -59,6 +60,7 @@ export const handler: CommandHandler<AmendArgv> = async (argv, logger) => {
 
   if (changes.length === 0) {
     logger.log('Nothing to summarize for the last commit.', { color: 'yellow' })
+    if (argv.json) emitJsonError('Nothing to summarize for the last commit.')
     commandExit(1)
     return
   }
@@ -80,6 +82,9 @@ export const handler: CommandHandler<AmendArgv> = async (argv, logger) => {
   if (!result.ok || !result.draft) {
     for (const warning of result.warnings) logger.log(warning, { color: 'yellow' })
     for (const error of result.validationErrors) logger.error(error, { color: 'red' })
+    if (argv.json) {
+      emitJsonError(result.validationErrors[0] || 'Failed to generate a commit message draft.')
+    }
     commandExit(1)
     return
   }

--- a/src/commands/changelog/changelog.test.ts
+++ b/src/commands/changelog/changelog.test.ts
@@ -428,6 +428,50 @@ describe('changelog command', () => {
       expect(mockGetCommitLogRangeDetails).not.toHaveBeenCalled()
     })
 
+    // CMD-11: a --json caller used to get empty stdout on this failure.
+    it('emits a JSON error payload when --json and the range has no recognizable separator', async () => {
+      argv.json = true
+      mockLoadConfig.mockReturnValue({
+        service: {
+          authentication: { type: 'APIKey', credentials: { apiKey: 'mock-api-key' } },
+          provider: 'openai',
+          model: 'gpt-4o',
+          tokenLimit: 4096,
+          temperature: 0.2,
+          maxConcurrent: 1,
+        },
+        defaultBranch: 'main',
+        mode: 'stdout',
+        range: 'not-a-valid-range',
+      } as unknown as Config)
+
+      const writes: string[] = []
+      const writeSpy = jest
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(((chunk: string) => {
+          writes.push(String(chunk))
+          return true
+        }) as never)
+      try {
+        await expect(handler(argv, logger)).rejects.toMatchObject({ name: 'CommandExitError', code: 1 })
+      } finally {
+        writeSpy.mockRestore()
+      }
+
+      const jsonCall = writes.find((message) => {
+        try {
+          JSON.parse(message)
+          return true
+        } catch {
+          return false
+        }
+      })
+      expect(jsonCall).toBeDefined()
+      expect(JSON.parse(jsonCall as string)).toEqual({
+        error: expect.stringContaining('Invalid range provided'),
+      })
+    })
+
     it('rejects --range combined with --branch instead of silently ignoring --branch', async () => {
       argv.branch = 'develop'
       mockLoadConfig.mockReturnValue({

--- a/src/commands/changelog/handler.ts
+++ b/src/commands/changelog/handler.ts
@@ -21,7 +21,7 @@ import { applyRepoCwd, applyRepoFlag } from '../utils/applyRepoFlag'
 import { generateAndReviewLoop } from '../../lib/ui/generateAndReviewLoop'
 import { handleMissingApiKey } from '../../lib/ui/handleMissingApiKey'
 import { handleResult } from '../../lib/ui/handleResult'
-import { emitJson } from '../../lib/ui/emitJson'
+import { emitJson, emitJsonError } from '../../lib/ui/emitJson'
 import { LOGO, isInteractive } from '../../lib/ui/helpers'
 import { logSuccess } from '../../lib/ui/logSuccess'
 import { getDiffForBranch } from '../../lib/simple-git/getDiffForBranch'
@@ -107,7 +107,9 @@ export async function generateChangelogResult(
   ].filter(Boolean)
 
   if (exclusiveOptions.length > 1) {
-    logger.error(`Options ${exclusiveOptions.join(', ')} cannot be used together.`, { color: 'red' })
+    const message = `Options ${exclusiveOptions.join(', ')} cannot be used together.`
+    logger.error(message, { color: 'red' })
+    if (argv.json) emitJsonError(message)
     commandExit(1)
   }
 
@@ -119,7 +121,9 @@ export async function generateChangelogResult(
     ].filter(Boolean)
 
     if (ignoredByOnlyDiff.length > 0) {
-      logger.error(`--only-diff cannot be combined with ${ignoredByOnlyDiff.join(', ')}.`, { color: 'red' })
+      const message = `--only-diff cannot be combined with ${ignoredByOnlyDiff.join(', ')}.`
+      logger.error(message, { color: 'red' })
+      if (argv.json) emitJsonError(message)
       commandExit(1)
     }
   }
@@ -171,7 +175,9 @@ export async function generateChangelogResult(
       // mode with no warning (#1590).
       const [from, to] = config.range.split(/:|\.{2,3}/)
       if (!from || !to) {
-        logger.error(`Invalid range provided. Expected format is <from>:<to> (or <from>..<to>)`, { color: 'red' })
+        const message = `Invalid range provided. Expected format is <from>:<to> (or <from>..<to>)`
+        logger.error(message, { color: 'red' })
+        if (argv.json) emitJsonError(message)
         commandExit(1)
       }
       commits = await getCommitLogRangeDetails(from, to, { git, noMerges: true })

--- a/src/commands/prCreate/handler.ts
+++ b/src/commands/prCreate/handler.ts
@@ -7,7 +7,7 @@ import { runPullRequestBodyWorkflow } from '../../git/aiActions'
 import { getForgeActions } from '../../git/forgeActions'
 import { forgeNouns } from '../../workstation/chrome/forgeNouns'
 import { commandExit } from '../../lib/utils/commandExit'
-import { emitJson } from '../../lib/ui/emitJson'
+import { emitJson, emitJsonError } from '../../lib/ui/emitJson'
 import { isInteractive, LOGO } from '../../lib/ui/helpers'
 import { selectPrompt, editorPrompt } from '../../lib/ui/inquirerPrompts'
 import { PrCreateArgv, PrCreateOptions } from './config'
@@ -39,11 +39,11 @@ export const handler: CommandHandler<PrCreateArgv> = async (argv, logger) => {
     provider !== 'bitbucket-server' &&
     provider !== 'gitea'
   ) {
-    logger.error(
+    const message =
       overview.repository.message ||
-        'No supported remote (GitHub, GitLab, Bitbucket, Bitbucket Server, or Gitea) detected.',
-      { color: 'red' }
-    )
+      'No supported remote (GitHub, GitLab, Bitbucket, Bitbucket Server, or Gitea) detected.'
+    logger.error(message, { color: 'red' })
+    if (argv.json) emitJsonError(message)
     commandExit(1)
     return
   }
@@ -51,24 +51,27 @@ export const handler: CommandHandler<PrCreateArgv> = async (argv, logger) => {
   if (!overview.authenticated) {
     // `getProviderOverview` already routes through the forge's auth probe, so
     // this is the curated "install / authenticate the CLI" recovery hint.
-    logger.log(overview.message || 'The forge CLI is unavailable.', { color: 'yellow' })
+    const message = overview.message || 'The forge CLI is unavailable.'
+    logger.log(message, { color: 'yellow' })
+    if (argv.json) emitJsonError(message)
     commandExit(1)
     return
   }
 
   const head = overview.currentBranch
   if (!head) {
-    logger.error('Could not determine the current branch (detached HEAD?).', { color: 'red' })
+    const message = 'Could not determine the current branch (detached HEAD?).'
+    logger.error(message, { color: 'red' })
+    if (argv.json) emitJsonError(message)
     commandExit(1)
     return
   }
 
   const base = argv.base || overview.repository.defaultBranch || 'main'
   if (head === base) {
-    logger.log(
-      `You're on the base branch ('${base}'). Check out a feature branch before creating a ${nouns.abbrev}.`,
-      { color: 'yellow' }
-    )
+    const message = `You're on the base branch ('${base}'). Check out a feature branch before creating a ${nouns.abbrev}.`
+    logger.log(message, { color: 'yellow' })
+    if (argv.json) emitJsonError(message)
     commandExit(1)
     return
   }
@@ -94,7 +97,9 @@ export const handler: CommandHandler<PrCreateArgv> = async (argv, logger) => {
   if (!title || !body) {
     const generated = await runPullRequestBodyWorkflow({ baseBranch: base })
     if (!generated.ok) {
-      logger.error(generated.message || `Failed to generate a ${nouns.singularLower} body.`, { color: 'red' })
+      const message = generated.message || `Failed to generate a ${nouns.singularLower} body.`
+      logger.error(message, { color: 'red' })
+      if (argv.json) emitJsonError(message)
       commandExit(1)
       return
     }
@@ -103,7 +108,9 @@ export const handler: CommandHandler<PrCreateArgv> = async (argv, logger) => {
   }
 
   if (!title) {
-    logger.error(`Could not produce a ${nouns.singularLower} title.`, { color: 'red' })
+    const message = `Could not produce a ${nouns.singularLower} title.`
+    logger.error(message, { color: 'red' })
+    if (argv.json) emitJsonError(message)
     commandExit(1)
     return
   }

--- a/src/commands/prCreate/prCreate.test.ts
+++ b/src/commands/prCreate/prCreate.test.ts
@@ -33,6 +33,27 @@ const mockOpenMr = openMergeRequest as jest.MockedFunction<typeof openMergeReque
 const mockCreateBitbucketPr = createBitbucketPullRequest as jest.MockedFunction<typeof createBitbucketPullRequest>
 const mockOpenBitbucketPr = openBitbucketPullRequest as jest.MockedFunction<typeof openBitbucketPullRequest>
 
+const spyStdout = () => {
+  const writes: string[] = []
+  const spy = jest.spyOn(process.stdout, 'write').mockImplementation(((chunk: string) => {
+    writes.push(String(chunk))
+    return true
+  }) as never)
+  return { writes, restore: () => spy.mockRestore() }
+}
+
+function findJson(writes: string[]): unknown {
+  const raw = writes.find((w) => {
+    try {
+      JSON.parse(w)
+      return true
+    } catch {
+      return false
+    }
+  })
+  return raw === undefined ? undefined : JSON.parse(raw)
+}
+
 function okOverview(over: Record<string, unknown> = {}) {
   return {
     repository: { provider: 'github', remote: 'origin', defaultBranch: 'main' },
@@ -195,6 +216,49 @@ describe('pr create command', () => {
     mockBodyWorkflow.mockResolvedValue({ ok: false, message: 'no commits ahead of base' })
     await expect(handler(argv, logger)).rejects.toMatchObject({ code: 1 })
     expect(mockCreatePr).not.toHaveBeenCalled()
+  })
+
+  // CMD-11: every commandExit(1) failure branch reachable before the
+  // --json preview-return must emit a { error } payload, not empty
+  // stdout — a machine caller shouldn't have to scrape stderr.
+  describe('--json failure payloads (CMD-11)', () => {
+    it('emits a JSON error when not authenticated', async () => {
+      argv.json = true
+      mockOverview.mockResolvedValue(okOverview({ authenticated: false, message: 'run gh auth login' }))
+      const { writes, restore } = spyStdout()
+      try {
+        await expect(handler(argv, logger)).rejects.toMatchObject({ code: 1 })
+      } finally {
+        restore()
+      }
+      expect(findJson(writes)).toEqual({ error: 'run gh auth login' })
+    })
+
+    it('emits a JSON error when on the base branch', async () => {
+      argv.json = true
+      mockOverview.mockResolvedValue(okOverview({ currentBranch: 'main' }))
+      const { writes, restore } = spyStdout()
+      try {
+        await expect(handler(argv, logger)).rejects.toMatchObject({ code: 1 })
+      } finally {
+        restore()
+      }
+      expect(findJson(writes)).toEqual({
+        error: expect.stringContaining("You're on the base branch"),
+      })
+    })
+
+    it('emits a JSON error when body generation fails', async () => {
+      argv.json = true
+      mockBodyWorkflow.mockResolvedValue({ ok: false, message: 'no commits ahead of base' })
+      const { writes, restore } = spyStdout()
+      try {
+        await expect(handler(argv, logger)).rejects.toMatchObject({ code: 1 })
+      } finally {
+        restore()
+      }
+      expect(findJson(writes)).toEqual({ error: 'no commits ahead of base' })
+    })
   })
 
   it('renders the curated no-commits message, never the generic exit sentinel text (#1604)', async () => {

--- a/src/commands/prs/prs.test.ts
+++ b/src/commands/prs/prs.test.ts
@@ -21,7 +21,7 @@ import { getProviderRepositoryForGit } from '../../git/providerData'
 import { getPullRequestList } from '../../git/pullRequestListData'
 import { getMergeRequestList } from '../../git/gitlabListData'
 import { getBitbucketPullRequestList } from '../../git/bitbucketListData'
-import { emitJson } from '../../lib/ui/emitJson'
+import { emitJson, emitJsonError } from '../../lib/ui/emitJson'
 import { Logger } from '../../lib/utils/logger'
 
 const applyRepoFlagMock = applyRepoFlag as jest.MockedFunction<typeof applyRepoFlag>
@@ -32,6 +32,7 @@ const getMergeRequestListMock = getMergeRequestList as jest.MockedFunction<typeo
 const getBitbucketPullRequestListMock =
   getBitbucketPullRequestList as jest.MockedFunction<typeof getBitbucketPullRequestList>
 const emitJsonMock = emitJson as jest.MockedFunction<typeof emitJson>
+const emitJsonErrorMock = emitJsonError as jest.MockedFunction<typeof emitJsonError>
 
 const fakeGit = {} as SimpleGit
 
@@ -163,5 +164,31 @@ describe('coco prs — --json contract', () => {
 
     expect(emitJsonMock).toHaveBeenCalledWith(overview.pullRequests)
     expect(logger.log).not.toHaveBeenCalled()
+  })
+
+  // CMD-11: forge/availability failures used to exit 1 with empty
+  // stdout under --json — a machine caller had to scrape stderr.
+  it('emits a JSON error instead of empty stdout when the forge is unavailable', async () => {
+    getPullRequestListMock.mockResolvedValue({
+      available: false,
+      authenticated: false,
+      message: 'No supported remote detected.',
+    } as never)
+
+    await expect(handler(baseArgv({ json: true }), createLogger())).rejects.toMatchObject({ code: 1 })
+
+    expect(emitJsonErrorMock).toHaveBeenCalledWith('No supported remote detected.')
+  })
+
+  it('emits a JSON error instead of empty stdout when not authenticated', async () => {
+    getPullRequestListMock.mockResolvedValue({
+      available: true,
+      authenticated: false,
+      message: 'gh not authenticated',
+    } as never)
+
+    await expect(handler(baseArgv({ json: true }), createLogger())).rejects.toMatchObject({ code: 1 })
+
+    expect(emitJsonErrorMock).toHaveBeenCalledWith('gh not authenticated')
   })
 })

--- a/src/commands/review/handler.ts
+++ b/src/commands/review/handler.ts
@@ -20,7 +20,7 @@ import { getCurrentBranchName } from '../../lib/simple-git/getCurrentBranchName'
 import { CommandHandler } from '../../lib/types'
 import { applyRepoFlag } from '../utils/applyRepoFlag'
 import { generateAndReviewLoop } from '../../lib/ui/generateAndReviewLoop'
-import { emitJson } from '../../lib/ui/emitJson'
+import { emitJson, emitJsonError } from '../../lib/ui/emitJson'
 import { handleMissingApiKey } from '../../lib/ui/handleMissingApiKey'
 import { isInteractive, LOGO, severityColor } from '../../lib/ui/helpers'
 import { TaskList } from '../../lib/ui/TaskList'
@@ -123,6 +123,7 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
       const diffResult = await forge!.getPullRequestDiffByNumber(argv.pr)
       if (!diffResult.ok) {
         logger.error(diffResult.message, { color: 'red' })
+        if (argv.json) emitJsonError(diffResult.message)
         commandExit(1)
       }
       if (diffResult.lines.length === 0) {
@@ -390,6 +391,10 @@ export const handler: CommandHandler<ReviewArgv> = async (argv, logger) => {
       // not report success when nothing was posted (permissions, closed
       // PR, gh not authenticated for that host, ...) (#1882).
       logger.error(postResult.message, { color: 'red' })
+      // The findings themselves were generated successfully — only the
+      // post failed — so a --json caller still gets them, alongside the
+      // error, instead of empty stdout (CMD-11).
+      if (argv.json) emitJson({ findings, error: postResult.message })
       commandExit(1)
     }
   }

--- a/src/commands/review/review.test.ts
+++ b/src/commands/review/review.test.ts
@@ -571,6 +571,37 @@ describe('review command', () => {
       expect(logger.error).toHaveBeenCalledWith('PR #42 not found.', { color: 'red' })
     })
 
+    // CMD-11: a --json caller used to get empty stdout on this failure,
+    // exit code 1 and nothing parseable to explain why.
+    it('emits a JSON error payload (not empty stdout) when the PR diff cannot be retrieved', async () => {
+      argv.pr = 42
+      mockGetPullRequestDiffByNumber.mockResolvedValue({ ok: false, message: 'PR #42 not found.' })
+
+      const writes: string[] = []
+      const writeSpy = jest
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(((chunk: string) => {
+          writes.push(String(chunk))
+          return true
+        }) as never)
+      try {
+        await expect(handler(argv, logger)).rejects.toMatchObject({ code: 1 })
+      } finally {
+        writeSpy.mockRestore()
+      }
+
+      const jsonCall = writes.find((message) => {
+        try {
+          JSON.parse(message)
+          return true
+        } catch {
+          return false
+        }
+      })
+      expect(jsonCall).toBeDefined()
+      expect(JSON.parse(jsonCall as string)).toEqual({ error: 'PR #42 not found.' })
+    })
+
     it('posts a plain comment when findings stay below --severity', async () => {
       argv.pr = 42
       argv.comment = true
@@ -602,6 +633,42 @@ describe('review command', () => {
 
       await expect(handler(argv, logger)).rejects.toMatchObject({ code: 1 })
       expect(logger.error).toHaveBeenCalledWith('Permission denied.', { color: 'red' })
+    })
+
+    // CMD-11: findings were already generated successfully by this point —
+    // only the forge post failed — so a --json caller should still get
+    // them, alongside the error, instead of empty stdout.
+    it('still emits the generated findings as JSON, alongside the error, when the post fails', async () => {
+      argv.pr = 42
+      argv.comment = true
+      mockCommentPullRequestByNumber.mockResolvedValue({ ok: false, message: 'Permission denied.' })
+
+      const writes: string[] = []
+      const writeSpy = jest
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(((chunk: string) => {
+          writes.push(String(chunk))
+          return true
+        }) as never)
+      try {
+        await expect(handler(argv, logger)).rejects.toMatchObject({ code: 1 })
+      } finally {
+        writeSpy.mockRestore()
+      }
+
+      const jsonCall = writes.find((message) => {
+        try {
+          JSON.parse(message)
+          return true
+        } catch {
+          return false
+        }
+      })
+      expect(jsonCall).toBeDefined()
+      const parsed = JSON.parse(jsonCall as string)
+      expect(parsed.error).toBe('Permission denied.')
+      expect(Array.isArray(parsed.findings)).toBe(true)
+      expect(parsed.findings[0]).toMatchObject({ title: 'Review finding' })
     })
 
     it('keeps the posted markdown unchanged when a finding carries line/side data (OSS-2405)', async () => {

--- a/src/commands/utils/githubListCommand.ts
+++ b/src/commands/utils/githubListCommand.ts
@@ -12,7 +12,7 @@ import {
 import type { IssueListFilter } from '../../git/issuesListData'
 import type { PullRequestListFilter } from '../../git/pullRequestListData'
 import { applyRepoFlag } from './applyRepoFlag'
-import { emitJson } from '../../lib/ui/emitJson'
+import { emitJson, emitJsonError } from '../../lib/ui/emitJson'
 
 /**
  * Shared shape behind `coco issues` and `coco prs`. The two commands were
@@ -142,24 +142,29 @@ export function createGitHubListHandler<
       const overview = await spec.fetch(git, filter, forge)
 
       if (!overview.available) {
-        logger.error(overview.message || 'No supported remote (GitHub or GitLab) detected.', { color: 'red' })
+        const message = overview.message || 'No supported remote (GitHub or GitLab) detected.'
+        logger.error(message, { color: 'red' })
+        if (argv.json) emitJsonError(message)
         commandExit(1)
         return
       }
 
       if (!overview.authenticated) {
-        logger.log(overview.message || 'No authenticated forge CLI detected.', { color: 'yellow' })
+        const message = overview.message || 'No authenticated forge CLI detected.'
+        logger.log(message, { color: 'yellow' })
         logger.log(
           chalk.dim(
             `Authenticate the matching CLI (GitHub \`gh\` or GitLab \`glab\`) to enable ${spec.triageLabel}.`
           )
         )
+        if (argv.json) emitJsonError(message)
         commandExit(1)
         return
       }
 
       if (overview.message) {
         logger.error(overview.message, { color: 'red' })
+        if (argv.json) emitJsonError(overview.message)
         commandExit(1)
         return
       }

--- a/src/lib/ui/emitJson.ts
+++ b/src/lib/ui/emitJson.ts
@@ -9,3 +9,15 @@
 export function emitJson(value: unknown): void {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`)
 }
+
+/**
+ * Write a machine-readable `{ "error": "..." }` payload to stdout for a
+ * `--json` caller that's about to exit non-zero. `commit` and `recap`
+ * already followed this contract for their own failure paths (CMD-11) —
+ * this is the same shape, extracted so every other `--json`-capable
+ * command's failure branches can emit it too, instead of exiting 1 with
+ * empty stdout and forcing the caller to scrape stderr.
+ */
+export function emitJsonError(error: string): void {
+  emitJson({ error })
+}


### PR DESCRIPTION
## Summary
- `commit` and `recap` already emit `{ "error": "..." }` on stdout before exiting non-zero under `--json`. `amend`, `review`, `pr create`, `changelog`, and the shared `coco prs`/`coco issues` list handler didn't — they logged through `logger.error`/`logger.log` (invisible if the caller only reads stdout) and exited 1 with empty stdout, forcing a wrapper script to fall back to scraping stderr.
- Adds a shared `emitJsonError(message)` helper (`src/lib/ui/emitJson.ts`) and applies it to every `--json`-reachable `commandExit(1)` branch in the five affected files:
  - `amend`: no commit to amend, nothing to summarize, draft generation failed
  - `review`: PR diff fetch failure; and the `--comment` post-failure path — special-cased to emit `{ findings, error }` since the findings were already generated by that point, not just `{ error }`
  - `pr create`: unsupported provider, not authenticated, no current branch, on base branch, PR body generation failed, no title produced
  - `changelog`: mutually-exclusive range/branch/tag options, `--only-diff` combined with another range option, malformed `--range` value
  - `coco prs` / `coco issues` (shared `githubListCommand.ts`): forge unavailable, not authenticated, forge error message

Closes #1884

## Test plan
- [x] New regression tests in `amend.test.ts`, `prCreate.test.ts`, `prs.test.ts`, `review.test.ts`, `changelog.test.ts` — each asserts a parseable `{ error }` (or `{ findings, error }`) payload reaches stdout on the previously-silent failure paths
- [x] `npx jest src/commands/{amend,prCreate,prs,review,changelog,issues}` — 143/143 passed
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx jest` (full suite) — pre-existing, unrelated tree-sitter WASM failures only (same 4 failures present on a clean `origin/main` checkout in this worktree)