### PR TITLE
fix(mcp): arm the usage ledger in deferred-binding mode (#1825)

### DIFF
--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -6,9 +6,10 @@ import {
   createMcpAgentInputJsonSchema,
   createMcpCondenseDiffInputJsonSchema,
 } from '../operations/agent/schemas'
-import { createCocoMcpServer } from './server'
+import { createCocoMcpServer, resetDeferredUsageTelemetryArmedForTests } from './server'
 
 const mockResolveAgentRepoRoot = jest.fn()
+const mockArmNonInteractiveUsageTelemetry = jest.fn()
 const mockCreateAgentOperationContext = jest.fn()
 const mockRunAgentOperation = jest.fn()
 const mockGetRepoStatus = jest.fn()
@@ -112,6 +113,10 @@ jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
 jest.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
   StdioServerTransport: class MockStdioServerTransport {},
 }))
+jest.mock('../commands/utils/usageTelemetry', () => ({
+  armNonInteractiveUsageTelemetry: (...args: unknown[]) =>
+    Promise.resolve(mockArmNonInteractiveUsageTelemetry(...args)),
+}))
 jest.mock('../operations/agent', () => {
   const schemas = jest.requireActual('../operations/agent/schemas') as typeof import('../operations/agent/schemas')
   const errors = jest.requireActual('../operations/agent/errors') as typeof import('../operations/agent/errors')
@@ -179,6 +184,7 @@ describe('createCocoMcpServer', () => {
     resourceRegistrations.clear()
     promptRegistrations.clear()
     serverOptions.length = 0
+    resetDeferredUsageTelemetryArmedForTests()
     mockResolveAgentRepoRoot.mockResolvedValue('/repo')
     mockCreateAgentOperationContext.mockResolvedValue({ signal: undefined } as never)
     mockRunAgentOperation.mockResolvedValue(reviewSuccess)
@@ -442,6 +448,49 @@ describe('createCocoMcpServer', () => {
     expect(mockCreateAgentOperationContext).toHaveBeenCalledWith(
       expect.objectContaining({ requireRepository: false }),
     )
+  })
+
+  describe('deferred-binding usage-telemetry arming (#1825)', () => {
+    it('arms the usage ledger against the first repository a deferred-mode call resolves', async () => {
+      createCocoMcpServer() // deferred mode: no bound root
+      mockResolveAgentRepoRoot.mockResolvedValueOnce('/deferred/repo')
+
+      await registrations.get('coco_review')!.handler({
+        source: { kind: 'summary', summary: 'changed' },
+        repo: '/deferred/repo',
+      }, makeExtra())
+
+      expect(mockArmNonInteractiveUsageTelemetry).toHaveBeenCalledWith({}, '/deferred/repo')
+    })
+
+    it('arms only once across multiple deferred-mode calls, even against a different resolved repo', async () => {
+      createCocoMcpServer()
+      mockResolveAgentRepoRoot.mockResolvedValueOnce('/deferred/repo-a')
+
+      await registrations.get('coco_review')!.handler({
+        source: { kind: 'summary', summary: 'changed' },
+        repo: '/deferred/repo-a',
+      }, makeExtra())
+
+      mockResolveAgentRepoRoot.mockResolvedValueOnce('/deferred/repo-b')
+      await registrations.get('coco_review')!.handler({
+        source: { kind: 'summary', summary: 'changed' },
+        repo: '/deferred/repo-b',
+      }, makeExtra())
+
+      expect(mockArmNonInteractiveUsageTelemetry).toHaveBeenCalledTimes(1)
+      expect(mockArmNonInteractiveUsageTelemetry).toHaveBeenCalledWith({}, '/deferred/repo-a')
+    })
+
+    it('does not arm telemetry from resolveEffectiveRepoRoot in bound mode (handler.ts already arms it at startup)', async () => {
+      createServer() // bound mode: repoRoot = '/repo'
+
+      await tool('coco_review').handler({
+        source: { kind: 'summary', summary: 'changed' },
+      }, makeExtra())
+
+      expect(mockArmNonInteractiveUsageTelemetry).not.toHaveBeenCalled()
+    })
   })
 
   it('emits a commit-draft-specific INVALID_REPOSITORY message when no repository resolves', async () => {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -11,6 +11,7 @@ import { CHANGELOG_PROMPT } from '../commands/changelog/prompt'
 import { COMMIT_PROMPT, CONVENTIONAL_COMMIT_PROMPT } from '../commands/commit/prompt'
 import { RECAP_PROMPT } from '../commands/recap/prompt'
 import { REVIEW_PROMPT } from '../commands/review/prompt'
+import { armNonInteractiveUsageTelemetry } from '../commands/utils/usageTelemetry'
 import { BUILD_VERSION } from '../lib/buildInfo'
 import { getPrompt } from '../lib/langchain/utils/getPrompt'
 import { getLanguageContext } from '../lib/langchain/utils/languageContext'
@@ -123,6 +124,33 @@ async function assertClientAllowsRoot(server: McpServer, repoRoot: string): Prom
 }
 
 /**
+ * Usage-ledger arming for deferred-binding mode (#1825). Bound mode arms the
+ * ledger at startup (`commands/mcp/handler.ts`), against the explicit
+ * `--repo`. Deferred mode has no repository at startup, so there's nothing
+ * to arm against — arming instead happens lazily, once, against the first
+ * repository a tool call actually resolves. Reading config against that
+ * real root (rather than the server's ambiguous startup cwd) also means a
+ * repo-local `telemetry.usage` override is honored, not just a global one.
+ *
+ * A process-global tag set once is the same tradeoff the ledger's arming
+ * functions already make for bound/CLI mode: a deferred server that later
+ * resolves a second, different repository keeps the first one's tag rather
+ * than re-tagging every call.
+ */
+let deferredUsageTelemetryArmed = false
+
+async function armDeferredUsageTelemetryOnce(repoRoot: string): Promise<void> {
+  if (deferredUsageTelemetryArmed) return
+  deferredUsageTelemetryArmed = true
+  await armNonInteractiveUsageTelemetry({}, repoRoot)
+}
+
+/** Test-only: reset the "armed once" latch between deferred-mode test cases. */
+export function resetDeferredUsageTelemetryArmedForTests(): void {
+  deferredUsageTelemetryArmed = false
+}
+
+/**
  * Resolve the effective repository root for a tool call. In bound mode
  * (explicit `--repo`), the server enforces single-repo confinement. In
  * deferred mode (no `--repo`), the repo is resolved per-call from:
@@ -149,11 +177,16 @@ async function resolveEffectiveRepoRoot(
 
   // Deferred mode: resolve from input.repo or client roots.
   if (inputRepo) {
-    return resolveAgentRepoRoot(inputRepo, undefined, signal)
+    const repoRoot = await resolveAgentRepoRoot(inputRepo, undefined, signal)
+    await armDeferredUsageTelemetryOnce(repoRoot)
+    return repoRoot
   }
 
   const fromRoots = await resolveRepoFromClientRoots(server)
-  if (fromRoots) return fromRoots
+  if (fromRoots) {
+    await armDeferredUsageTelemetryOnce(fromRoots)
+    return fromRoots
+  }
 
   throw new AgentOperationError(
     'INVALID_REPOSITORY',


### PR DESCRIPTION
## Summary
- `0.84.1`'s deferred repository binding (`coco mcp` with no `--repo`) made usage-ledger arming conditional on `--repo` being passed. The recommended global MCP client config omits `--repo`, so the recommended configuration was exactly the one that never recorded usage — even with `telemetry.usage: true` or `COCO_USAGE_LOG` set.
- Rather than arming unconditionally at startup with an ambiguous cwd (MCP clients often spawn the process at filesystem root, per the issue's own caveat), this arms the ledger lazily, once, against the first repository a deferred-mode tool call actually resolves — inside the shared `resolveEffectiveRepoRoot` choke point every tool handler already calls. That also means a repo-local `telemetry.usage` override is honored, not just a global one, since arming reads config against a real resolved root.
- Bound mode (`--repo`) is unchanged — it still arms at startup in `commands/mcp/handler.ts`.
- A deferred server that later resolves a *different* repository keeps the first one's tag rather than re-tagging every call — the same "set once" tradeoff the ledger's config-preference/repo-tag design already makes elsewhere, called out explicitly in the issue as an acceptable simplification for typical single-workspace-per-session usage.

Closes #1825

## Test plan
- [x] New tests in `src/mcp/server.test.ts`: deferred-mode arms the ledger against the first resolved repo, arms only once across multiple calls (even to a different repo), and bound mode does *not* arm from `resolveEffectiveRepoRoot` (handler.ts already covers it at startup)
- [x] `npx jest src/mcp/server.test.ts src/commands/mcp/handler.test.ts` — 53/53 passed
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx jest` (full suite) — pre-existing, unrelated tree-sitter WASM failures only (same 4 failures present on a clean `origin/main` checkout in this worktree)