### PR TITLE
fix(commit): validate --split group titles against commitlint (CMD-12)

### DIFF
--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -33,7 +33,6 @@ import {
 import {
     DuplicateRescueNote,
     formatPlanValidationIssuesError,
-    getPlanCommitlintFailures,
     getPlanValidationIssues,
     hasPlanValidationIssues,
 } from './splitPlanValidation'

--- a/src/commands/commit/split.ts
+++ b/src/commands/commit/split.ts
@@ -20,6 +20,7 @@ import {
     promptHookFailureRecovery,
 } from '../../lib/ui/hookFailurePrompt'
 import { CommitOptions } from './config'
+import { repairDraftAgainstValidationErrors } from './generateCommitDraft'
 import {
     DEFAULT_MAX_PLAN_ATTEMPTS,
     generateValidatedCommitSplitPlan,
@@ -32,9 +33,13 @@ import {
 import {
     DuplicateRescueNote,
     formatPlanValidationIssuesError,
+    getPlanCommitlintFailures,
     getPlanValidationIssues,
     hasPlanValidationIssues,
 } from './splitPlanValidation'
+
+/** Per-group commitlint validator (CMD-12) — mirrors `generateCommitDraft`'s choice between repo-configured and built-in conventional rules. */
+export type ValidateGroupMessage = (message: string) => Promise<{ valid: boolean; errors: string[] }>
 
 export { CommitSplitPlanSchema }
 export type { CommitSplitPlan, CommitSplitGroup }
@@ -176,6 +181,14 @@ export type HunkInventory = {
 export type CommitSplitPlanContext = {
   changes: Awaited<ReturnType<typeof getChanges>>
   hunkInventory: HunkInventory
+  /**
+   * Per-group commitlint validator (CMD-12), carried alongside the
+   * staged-state snapshot so a caller that holds the plan between
+   * preview and apply (the workstation's `S` → `y` flow) re-validates
+   * at apply time with the SAME validator the plan was generated
+   * against, without needing to re-derive it.
+   */
+  validateGroupMessage?: ValidateGroupMessage
 }
 
 function getGroupFiles(group: CommitSplitGroup): string[] {
@@ -436,6 +449,7 @@ export async function applyCommitSplitPlan({
   noVerify,
   fallback,
   onHookFailure,
+  validateGroupMessage,
 }: {
   plan: CommitSplitPlan
   changes: Awaited<ReturnType<typeof getChanges>>
@@ -461,6 +475,16 @@ export async function applyCommitSplitPlan({
    * pre-existing behavior.
    */
   onHookFailure?: (info: { title: string; hookOutput: string }) => Promise<HookFailureRecoveryChoice>
+  /**
+   * Optional per-group commitlint validator (CMD-12) — the same one the
+   * plan was generated against. Re-checked here, before any index
+   * mutation, so a group whose message still violates the project's
+   * rules is caught and mechanically repaired (or hard-rejected) rather
+   * than committed verbatim. Mainly catches the planner's single-group
+   * fallback, whose hardcoded title was never validated against a
+   * specific repo's rules.
+   */
+  validateGroupMessage?: ValidateGroupMessage
 }): Promise<CommitSplitApplyResult> {
   validatePlanForStagedFiles(plan, changes.staged, hunkInventory)
   assertNoUnstagedOverlap(plan, changes, hunkInventory)
@@ -488,6 +512,43 @@ export async function applyCommitSplitPlan({
   })
   if (applicableGroups.length === 0) {
     throw new Error('Split plan has no applicable groups (every group was empty).')
+  }
+
+  // CMD-12: last line of defense, before any index mutation. The plan
+  // generator already retries against `validateGroupMessage` when one is
+  // supplied, so a fresh multi-group plan should pass here too — this
+  // mainly catches the planner's single-group fallback, whose hardcoded
+  // title was never checked against a specific repo's commitlint rules,
+  // and any group whose message a caller mutated between generation and
+  // apply. A group that still fails after the same mechanical repair
+  // plain `coco commit` uses is a hard error: better to refuse than to
+  // commit a message the project's own rules reject.
+  const resolvedGroupMessages = new Map<CommitSplitGroup, string>()
+  if (validateGroupMessage) {
+    const hardFailures: { title: string; errors: string[] }[] = []
+    for (const group of applicableGroups) {
+      const body = group.body ? `\n\n${group.body}` : ''
+      const message = `${group.title}${body}`.trim()
+      const result = await validateGroupMessage(message)
+      if (result.valid) continue
+
+      const repaired = repairDraftAgainstValidationErrors(message, result.errors)
+      if (repaired !== message) {
+        const repairedResult = await validateGroupMessage(repaired)
+        if (repairedResult.valid) {
+          resolvedGroupMessages.set(group, repaired)
+          continue
+        }
+      }
+      hardFailures.push({ title: group.title, errors: result.errors })
+    }
+    if (hardFailures.length > 0) {
+      throw new Error(
+        `Cannot apply split plan: commit message(s) fail commitlint validation:\n${hardFailures
+          .map((f) => `- "${f.title}": ${f.errors.join('; ')}`)
+          .join('\n')}`
+      )
+    }
   }
 
   // Capture HEAD up-front so we can verify each commit actually
@@ -594,9 +655,12 @@ export async function applyCommitSplitPlan({
         }
 
         // Avoid the literal string "undefined" in the commit body when
-        // the LLM omitted the body field — fall back to title-only.
+        // the LLM omitted the body field — fall back to title-only. Use
+        // the commitlint-repaired message (CMD-12) when the pre-flight
+        // check above had to fix one up.
         const body = group.body ? `\n\n${group.body}` : ''
-        await createCommit(`${group.title}${body}`.trim(), git, undefined, { noVerify: groupNoVerify })
+        const commitMessage = resolvedGroupMessages.get(group) ?? `${group.title}${body}`.trim()
+        await createCommit(commitMessage, git, undefined, { noVerify: groupNoVerify })
 
         // Verify the commit actually advanced HEAD. Some hooks can
         // exit success without committing (e.g. `--no-verify`-mode
@@ -871,21 +935,36 @@ export async function prepareCommitSplitPlan({
     : ''
 
   let commitlintRulesContext = ''
+  // CMD-12: the split path used to only inject the rules into the prompt
+  // and never actually validate a group's title/body against them, unlike
+  // plain `coco commit` — so a produced plan could (and did) violate the
+  // project's own commitlint config. `validateGroupMessage` closes that
+  // gap: same repo-configured-vs-built-in choice as `generateCommitDraft`,
+  // reused for both the plan generator's self-correcting retry (below) and
+  // the apply-time hard gate in `applyCommitSplitPlan`.
+  let validateGroupMessage: ValidateGroupMessage | undefined
   const hasCommitLintConfig = await hasCommitlintConfig()
   if (useConventional || hasCommitLintConfig) {
     try {
-      const { getCommitlintRulesContext, checkCommitlintAvailability } = await import(
-        '../../lib/utils/commitlintValidator'
-      )
+      const {
+        getCommitlintRulesContext,
+        checkCommitlintAvailability,
+        validateCommitMessage,
+        validateConventionalCommitMessage,
+      } = await import('../../lib/utils/commitlintValidator')
       const availability = checkCommitlintAvailability()
       if (availability.available) {
         commitlintRulesContext = await getCommitlintRulesContext()
+        validateGroupMessage = hasCommitLintConfig
+          ? (message: string) => validateCommitMessage(message)
+          : (message: string) => validateConventionalCommitMessage(message)
       }
     } catch {
       // Commitlint integration is best-effort — a missing dep or a
       // bad config file shouldn't block the split. The model gets
       // the rules when we can pass them; otherwise it falls back to
-      // the conventional-commits ruleset (or generic style).
+      // the conventional-commits ruleset (or generic style), and group
+      // messages go unchecked rather than blocking the split entirely.
     }
   }
 
@@ -922,6 +1001,7 @@ export async function prepareCommitSplitPlan({
     // exhaustion instead of returning the single-group fallback.
     strict: Boolean(argv.strictSplit ?? config.strictSplit),
     signal,
+    validateGroupMessage,
   })
 
   const groupCount = plan.groups.filter((g) => !g.unclaimed).length
@@ -930,7 +1010,12 @@ export async function prepareCommitSplitPlan({
     { mode: 'succeed', color: 'green' }
   )
 
-  return { plan, context: { changes, hunkInventory }, fallback, dedupeWarnings }
+  return {
+    plan,
+    context: { changes, hunkInventory, validateGroupMessage },
+    fallback,
+    dedupeWarnings,
+  }
 }
 
 export async function handleCommitSplit({
@@ -1028,6 +1113,7 @@ export async function handleCommitSplit({
       noVerify: config.noVerify || false,
       fallback,
       onHookFailure,
+      validateGroupMessage: context.validateGroupMessage,
     })
     if (applied.fallback) {
       return [
@@ -1077,6 +1163,7 @@ export async function handleCommitSplit({
     noVerify: config.noVerify || false,
     fallback,
     onHookFailure,
+    validateGroupMessage: context.validateGroupMessage,
   })
   if (applied.fallback) {
     return [

--- a/src/commands/commit/splitApply.test.ts
+++ b/src/commands/commit/splitApply.test.ts
@@ -354,3 +354,162 @@ describe('applyCommitSplitPlan onHookFailure recovery (OSS-662)', () => {
     expect(result.message).not.toContain('aborted')
   })
 })
+
+/**
+ * CMD-12: the split path committed every group's `${title}\n\n${body}`
+ * verbatim with no commitlint check anywhere — in a commitlint-configured
+ * repo this could (and did) produce commits that violated the project's
+ * own rules. `applyCommitSplitPlan` now re-validates each group right
+ * before any index mutation, using the SAME validator the plan was
+ * generated against: pass through unchanged, mechanically repair and
+ * commit the repaired message, or refuse to touch the index at all.
+ */
+describe('applyCommitSplitPlan — commitlint hard gate (CMD-12)', () => {
+  const logger = new Logger({ silent: true })
+
+  afterEach(() => jest.clearAllMocks())
+
+  it('does nothing when no validator is supplied (bound-mode-off / repo has no commitlint config)', async () => {
+    const { git } = makeFakeGit.staged(['a.ts'])
+    mockedCreateCommit.mockImplementation(async () => {
+      git.advanceHead()
+      return {} as never
+    })
+    const plan = makePlan([{ title: 'not-conventional at all', files: ['a.ts'] }])
+
+    const result = await applyCommitSplitPlan({
+      plan,
+      changes: { staged: [fileChange('a.ts')], unstaged: [], untracked: [] },
+      hunkInventory: emptyHunkInventory,
+      git: git as never,
+      logger,
+      noVerify: false,
+    })
+
+    expect(mockedCreateCommit).toHaveBeenCalledWith(
+      'not-conventional at all',
+      expect.anything(),
+      undefined,
+      expect.anything()
+    )
+    expect(result.commitHashes).toEqual(['head-1'])
+  })
+
+  it('commits unchanged when every group already passes validation', async () => {
+    const { git } = makeFakeGit.staged(['a.ts'])
+    mockedCreateCommit.mockImplementation(async () => {
+      git.advanceHead()
+      return {} as never
+    })
+    const plan = makePlan([{ title: 'feat: add thing', files: ['a.ts'] }])
+    const validateGroupMessage = jest.fn(async () => ({ valid: true, errors: [] }))
+
+    const result = await applyCommitSplitPlan({
+      plan,
+      changes: { staged: [fileChange('a.ts')], unstaged: [], untracked: [] },
+      hunkInventory: emptyHunkInventory,
+      git: git as never,
+      logger,
+      noVerify: false,
+      validateGroupMessage,
+    })
+
+    expect(validateGroupMessage).toHaveBeenCalledWith('feat: add thing')
+    expect(mockedCreateCommit).toHaveBeenCalledWith(
+      'feat: add thing',
+      expect.anything(),
+      undefined,
+      expect.anything()
+    )
+    expect(result.commitHashes).toEqual(['head-1'])
+  })
+
+  it('commits the mechanically-repaired message when repair fixes the violation', async () => {
+    const { git } = makeFakeGit.staged(['a.ts'])
+    mockedCreateCommit.mockImplementation(async () => {
+      git.advanceHead()
+      return {} as never
+    })
+    // Uppercase-subject violation (lowercase `feat:` prefix, capitalized
+    // subject) — repairDraftAgainstValidationErrors lower-cases the
+    // subject's first letter, same repair plain `coco commit` applies.
+    const plan = makePlan([{ title: 'feat: Add Thing', files: ['a.ts'] }])
+    const validateGroupMessage = jest.fn(async (message: string) =>
+      message === 'feat: Add Thing'
+        ? { valid: false, errors: ['subject-case must be lower-case'] }
+        : { valid: true, errors: [] }
+    )
+
+    const result = await applyCommitSplitPlan({
+      plan,
+      changes: { staged: [fileChange('a.ts')], unstaged: [], untracked: [] },
+      hunkInventory: emptyHunkInventory,
+      git: git as never,
+      logger,
+      noVerify: false,
+      validateGroupMessage,
+    })
+
+    expect(mockedCreateCommit).toHaveBeenCalledWith(
+      'feat: add Thing',
+      expect.anything(),
+      undefined,
+      expect.anything()
+    )
+    expect(result.commitHashes).toEqual(['head-1'])
+  })
+
+  it('refuses to touch the index when a group still fails validation after repair', async () => {
+    const { git, ops } = makeFakeGit.staged(['a.ts'])
+    const plan = makePlan([{ title: 'Bad Title', files: ['a.ts'] }])
+    const validateGroupMessage = jest.fn(async () => ({
+      valid: false,
+      errors: ['type-empty may not be empty'],
+    }))
+
+    await expect(
+      applyCommitSplitPlan({
+        plan,
+        changes: { staged: [fileChange('a.ts')], unstaged: [], untracked: [] },
+        hunkInventory: emptyHunkInventory,
+        git: git as never,
+        logger,
+        noVerify: false,
+        validateGroupMessage,
+      })
+    ).rejects.toThrow(/commitlint validation/)
+
+    // Nothing was staged, reset, or committed — the check runs before any
+    // index mutation begins.
+    expect(ops).toEqual([])
+    expect(mockedCreateCommit).not.toHaveBeenCalled()
+  })
+
+  it('skips unclaimed groups (never committed) when validating', async () => {
+    const { git } = makeFakeGit.staged(['a.ts', 'c.ts'])
+    mockedCreateCommit.mockImplementation(async () => {
+      git.advanceHead()
+      return {} as never
+    })
+    const plan = {
+      groups: [
+        { title: 'feat: a', files: ['a.ts'], body: '' },
+        { title: '', files: ['c.ts'], body: '', unclaimed: true },
+      ],
+    } as CommitSplitPlan
+    const validateGroupMessage = jest.fn(async () => ({ valid: true, errors: [] }))
+
+    await applyCommitSplitPlan({
+      plan,
+      changes: { staged: [fileChange('a.ts'), fileChange('c.ts')], unstaged: [], untracked: [] },
+      hunkInventory: emptyHunkInventory,
+      git: git as never,
+      logger,
+      noVerify: false,
+      validateGroupMessage,
+    })
+
+    expect(validateGroupMessage).toHaveBeenCalledTimes(1)
+    expect(validateGroupMessage).toHaveBeenCalledWith('feat: a')
+  })
+})

--- a/src/commands/commit/splitPlanGenerator.test.ts
+++ b/src/commands/commit/splitPlanGenerator.test.ts
@@ -96,6 +96,95 @@ describe('generateValidatedCommitSplitPlan', () => {
     expect(String(secondCallVars.previous_attempt_feedback)).toContain('ghost.ts')
   })
 
+  // CMD-12: the split path never validated group titles against
+  // commitlint, unlike plain `coco commit`. `validateGroupMessage` closes
+  // that gap by reusing the same self-correcting retry loop the
+  // structural validator already drives.
+  describe('validateGroupMessage (CMD-12)', () => {
+    it('accepts a structurally-valid plan on the first attempt without calling the validator when none is supplied', async () => {
+      const validPlan: CommitSplitPlan = {
+        groups: [{ title: 'feat: add thing', files: ['a.ts', 'b.ts'], hunks: [] }],
+      }
+      mockExecuteChainWithSchema.mockResolvedValueOnce(validPlan)
+
+      const result = await generateValidatedCommitSplitPlan(baseArgs())
+
+      expect(result.attempts).toBe(1)
+    })
+
+    it('feeds a commitlint failure back into a retry attempt and succeeds once the title passes', async () => {
+      const badTitlePlan: CommitSplitPlan = {
+        groups: [{ title: 'Bad Title', files: ['a.ts', 'b.ts'], hunks: [] }],
+      }
+      const goodTitlePlan: CommitSplitPlan = {
+        groups: [{ title: 'feat: add thing', files: ['a.ts', 'b.ts'], hunks: [] }],
+      }
+      mockExecuteChainWithSchema
+        .mockResolvedValueOnce(badTitlePlan)
+        .mockResolvedValueOnce(goodTitlePlan)
+
+      const validateGroupMessage = jest.fn(async (message: string) =>
+        message.startsWith('feat:')
+          ? { valid: true, errors: [] }
+          : { valid: false, errors: ['type-empty'] }
+      )
+
+      const result = await generateValidatedCommitSplitPlan({
+        ...baseArgs(),
+        validateGroupMessage,
+      })
+
+      expect(result.attempts).toBe(2)
+      expect(result.plan).toStrictEqual(goodTitlePlan)
+      expect(validateGroupMessage).toHaveBeenCalledWith('Bad Title')
+      expect(validateGroupMessage).toHaveBeenCalledWith('feat: add thing')
+
+      const secondCallVars = mockExecuteChainWithSchema.mock.calls[1][3] as Record<string, unknown>
+      expect(String(secondCallVars.previous_attempt_feedback)).toContain(
+        'Group titles/bodies that fail commitlint validation'
+      )
+      expect(String(secondCallVars.previous_attempt_feedback)).toContain('Bad Title')
+      expect(String(secondCallVars.previous_attempt_feedback)).toContain('type-empty')
+    })
+
+    it('falls back to the single-group plan after exhausting attempts on a persistent commitlint failure', async () => {
+      const badTitlePlan: CommitSplitPlan = {
+        groups: [{ title: 'Bad Title', files: ['a.ts', 'b.ts'], hunks: [] }],
+      }
+      mockExecuteChainWithSchema.mockResolvedValue(badTitlePlan)
+
+      const validateGroupMessage = jest.fn(async () => ({ valid: false, errors: ['type-empty'] }))
+
+      const result = await generateValidatedCommitSplitPlan({
+        ...baseArgs(),
+        maxAttempts: 2,
+        validateGroupMessage,
+      })
+
+      expect(result.attempts).toBe(2)
+      expect(result.fallback).toBeDefined()
+      expect(result.fallback?.lastIssues.commitlintFailures).toEqual([
+        { index: 0, title: 'Bad Title', errors: ['type-empty'] },
+      ])
+    })
+
+    it('does not spend a commitlint check on a plan that still has structural issues', async () => {
+      const structurallyInvalidPlan: CommitSplitPlan = {
+        groups: [{ title: 'feat: thing', files: ['ghost.ts'], hunks: [] }],
+      }
+      mockExecuteChainWithSchema.mockResolvedValue(structurallyInvalidPlan)
+      const validateGroupMessage = jest.fn(async () => ({ valid: true, errors: [] }))
+
+      await generateValidatedCommitSplitPlan({
+        ...baseArgs(),
+        maxAttempts: 1,
+        validateGroupMessage,
+      })
+
+      expect(validateGroupMessage).not.toHaveBeenCalled()
+    })
+  })
+
   it('rescues phantom hunks before validation when the inventory is empty', async () => {
     // Regression for the #916 failure pattern: LLM emits hunk IDs
     // against an empty inventory (all staged files are new/added),

--- a/src/commands/commit/splitPlanGenerator.ts
+++ b/src/commands/commit/splitPlanGenerator.ts
@@ -13,6 +13,7 @@ import {
   dropEmptyGroups,
   formatPlanValidationFeedback,
   formatPlanValidationIssuesError,
+  getPlanCommitlintFailures,
   getPlanValidationIssues,
   hasPlanValidationIssues,
   HunkInventoryLike,
@@ -53,6 +54,15 @@ export interface GenerateSplitPlanArgs {
    * request down (surfaces as `LangChainCancelledError`).
    */
   signal?: AbortSignal
+  /**
+   * Optional per-group commitlint check (CMD-12). When provided, each
+   * group's `${title}\n\n${body}` is validated the same way plain
+   * `coco commit` validates its draft. Failures feed back through the
+   * same `previous_attempt_feedback` retry slot the structural
+   * validator uses, so the model gets a chance to fix its own titles
+   * before the attempt budget is exhausted.
+   */
+  validateGroupMessage?: (message: string) => Promise<{ valid: boolean; errors: string[] }>
 }
 
 /**
@@ -114,6 +124,7 @@ export async function generateValidatedCommitSplitPlan({
   maxAttempts = DEFAULT_MAX_PLAN_ATTEMPTS,
   strict = false,
   signal,
+  validateGroupMessage,
 }: GenerateSplitPlanArgs): Promise<GenerateSplitPlanResult> {
   let lastIssues: PlanValidationIssues | null = null
   let attempt = 0
@@ -189,6 +200,13 @@ export async function generateValidatedCommitSplitPlan({
     const plan = dropEmptyGroups(missingRescued)
 
     const issues = getPlanValidationIssues(plan, staged, hunkInventory)
+    // Commitlint validation can shell out / load a config file — only
+    // pay for it once the cheap structural checks above already pass,
+    // so a plan that's getting re-rolled for file/hunk reasons anyway
+    // doesn't also wait on it (CMD-12).
+    if (!hasPlanValidationIssues(issues) && validateGroupMessage) {
+      issues.commitlintFailures = await getPlanCommitlintFailures(plan, validateGroupMessage)
+    }
     if (!hasPlanValidationIssues(issues)) {
       if (attempt > 1 && logger) {
         logger.verbose(`Plan validated after ${attempt} attempts.`, { color: 'green' })
@@ -253,6 +271,7 @@ export async function generateValidatedCommitSplitPlan({
         mixedFiles: [],
         partiallyCoveredFiles: [],
         missingFiles: [],
+        commitlintFailures: [],
       },
     },
   }

--- a/src/commands/commit/splitPlanValidation.test.ts
+++ b/src/commands/commit/splitPlanValidation.test.ts
@@ -6,6 +6,7 @@ import {
   dropEmptyGroups,
   formatPlanValidationFeedback,
   formatPlanValidationIssuesError,
+  getPlanCommitlintFailures,
   getPlanValidationIssues,
   hasPlanValidationIssues,
   HunkInventoryLike,
@@ -139,6 +140,77 @@ describe('splitPlanValidation', () => {
     })
   })
 
+  // CMD-12: getPlanValidationIssues itself stays structural-only/sync;
+  // commitlint validation is async, so it's a separate function whose
+  // result callers merge into `issues.commitlintFailures`.
+  describe('getPlanCommitlintFailures', () => {
+    it('returns no failures when every group passes', async () => {
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'feat: a', files: ['a.ts'], hunks: [] },
+          { title: 'fix: b', files: ['b.ts'], hunks: [] },
+        ],
+      }
+      const validate = jest.fn(async () => ({ valid: true, errors: [] }))
+
+      const failures = await getPlanCommitlintFailures(plan, validate)
+
+      expect(failures).toEqual([])
+      expect(validate).toHaveBeenCalledWith('feat: a')
+      expect(validate).toHaveBeenCalledWith('fix: b')
+    })
+
+    it('reports the group index, title, and validator errors for a failing group', async () => {
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: 'feat: a', files: ['a.ts'], hunks: [] },
+          { title: 'Bad Title', files: ['b.ts'], hunks: [] },
+        ],
+      }
+      const validate = jest.fn(async (message: string) =>
+        message === 'Bad Title'
+          ? { valid: false, errors: ['subject-case must be lower-case', 'type-empty may not be empty'] }
+          : { valid: true, errors: [] }
+      )
+
+      const failures = await getPlanCommitlintFailures(plan, validate)
+
+      expect(failures).toEqual([
+        {
+          index: 1,
+          title: 'Bad Title',
+          errors: ['subject-case must be lower-case', 'type-empty may not be empty'],
+        },
+      ])
+    })
+
+    it('joins title and body into a single message before validating', async () => {
+      const plan: CommitSplitPlan = {
+        groups: [{ title: 'feat: a', body: 'Some detail.', files: ['a.ts'], hunks: [] }],
+      }
+      const validate = jest.fn(async () => ({ valid: true, errors: [] }))
+
+      await getPlanCommitlintFailures(plan, validate)
+
+      expect(validate).toHaveBeenCalledWith('feat: a\n\nSome detail.')
+    })
+
+    it('skips unclaimed groups (never committed) and groups with no title', async () => {
+      const plan: CommitSplitPlan = {
+        groups: [
+          { title: '', files: ['a.ts'], hunks: [], unclaimed: true },
+          { title: 'feat: b', files: ['b.ts'], hunks: [] },
+        ],
+      }
+      const validate = jest.fn(async () => ({ valid: true, errors: [] }))
+
+      await getPlanCommitlintFailures(plan, validate)
+
+      expect(validate).toHaveBeenCalledTimes(1)
+      expect(validate).toHaveBeenCalledWith('feat: b')
+    })
+  })
+
   describe('formatPlanValidationFeedback', () => {
     it('returns an empty string when there are no issues', () => {
       const feedback = formatPlanValidationFeedback({
@@ -149,6 +221,7 @@ describe('splitPlanValidation', () => {
         mixedFiles: [],
         partiallyCoveredFiles: [],
         missingFiles: [],
+        commitlintFailures: [],
       })
 
       expect(feedback).toBe('')
@@ -163,6 +236,7 @@ describe('splitPlanValidation', () => {
         mixedFiles: ['b.ts'],
         partiallyCoveredFiles: ['c.ts'],
         missingFiles: ['d.ts'],
+        commitlintFailures: [{ index: 0, title: 'bad title', errors: ['type-empty'] }],
       })
 
       expect(feedback).toContain('- Files referenced that are NOT in the staged file inventory')
@@ -177,6 +251,9 @@ describe('splitPlanValidation', () => {
       expect(feedback).toContain('c.ts')
       expect(feedback).toContain('Staged files missing from every group')
       expect(feedback).toContain('d.ts')
+      expect(feedback).toContain('Group titles/bodies that fail commitlint validation')
+      expect(feedback).toContain('bad title')
+      expect(feedback).toContain('type-empty')
     })
   })
 
@@ -190,6 +267,7 @@ describe('splitPlanValidation', () => {
         mixedFiles: [],
         partiallyCoveredFiles: [],
         missingFiles: [],
+        commitlintFailures: [],
       })
 
       expect(message).toBe('unknown files: ghost.ts; duplicate files: a.ts')

--- a/src/commands/commit/splitPlanValidation.ts
+++ b/src/commands/commit/splitPlanValidation.ts
@@ -11,6 +11,13 @@ export type HunkInventoryLike = {
   byFile: Map<string, StagedHunkLike[]>
 }
 
+/** One group's `${title}\n\n${body}` failing commitlint validation (CMD-12). */
+export interface CommitlintGroupFailure {
+  index: number
+  title: string
+  errors: string[]
+}
+
 export interface PlanValidationIssues {
   unknownFiles: string[]
   duplicateFiles: string[]
@@ -19,6 +26,14 @@ export interface PlanValidationIssues {
   mixedFiles: string[]
   partiallyCoveredFiles: string[]
   missingFiles: string[]
+  /**
+   * Populated by `getPlanCommitlintFailures` (CMD-12), not by
+   * `getPlanValidationIssues` itself — commitlint validation is async
+   * (it can shell out / load a config file), while the structural
+   * checks here stay synchronous. Always `[]` unless a caller merges
+   * commitlint results in.
+   */
+  commitlintFailures: CommitlintGroupFailure[]
 }
 
 const getGroupFiles = (group: CommitSplitGroup): string[] => group.files || []
@@ -90,7 +105,33 @@ export function getPlanValidationIssues(
     mixedFiles,
     partiallyCoveredFiles,
     missingFiles,
+    commitlintFailures: [],
   }
+}
+
+/**
+ * Check each group's `${title}\n\n${body}` against the given validator
+ * (CMD-12) — the same `validateCommitMessage`/`validateConventionalCommitMessage`
+ * plain `coco commit` uses. Skips `unclaimed` groups (never committed) and
+ * groups with no title. Async and separate from `getPlanValidationIssues`
+ * since commitlint validation can shell out / load a config file.
+ */
+export async function getPlanCommitlintFailures(
+  plan: CommitSplitPlan,
+  validate: (message: string) => Promise<{ valid: boolean; errors: string[] }>
+): Promise<CommitlintGroupFailure[]> {
+  const failures: CommitlintGroupFailure[] = []
+  for (let index = 0; index < plan.groups.length; index++) {
+    const group = plan.groups[index]
+    if (group.unclaimed || !group.title) continue
+    const body = group.body ? `\n\n${group.body}` : ''
+    const message = `${group.title}${body}`.trim()
+    const result = await validate(message)
+    if (!result.valid) {
+      failures.push({ index, title: group.title, errors: result.errors })
+    }
+  }
+  return failures
 }
 
 export function hasPlanValidationIssues(issues: PlanValidationIssues): boolean {
@@ -101,7 +142,8 @@ export function hasPlanValidationIssues(issues: PlanValidationIssues): boolean {
     issues.duplicateHunks.length > 0 ||
     issues.mixedFiles.length > 0 ||
     issues.partiallyCoveredFiles.length > 0 ||
-    issues.missingFiles.length > 0
+    issues.missingFiles.length > 0 ||
+    issues.commitlintFailures.length > 0
   )
 }
 
@@ -122,6 +164,11 @@ export function formatPlanValidationIssuesError(issues: PlanValidationIssues): s
       ? `files with only some hunks assigned: ${issues.partiallyCoveredFiles.join(', ')}`
       : undefined,
     issues.missingFiles.length ? `missing files: ${issues.missingFiles.join(', ')}` : undefined,
+    issues.commitlintFailures.length
+      ? `commitlint violations: ${issues.commitlintFailures
+          .map((f) => `"${f.title}" (${f.errors.join('; ')})`)
+          .join(', ')}`
+      : undefined,
   ]
     .filter(Boolean)
     .join('; ')
@@ -613,6 +660,14 @@ export function formatPlanValidationFeedback(issues: PlanValidationIssues): stri
   if (issues.missingFiles.length) {
     sections.push(
       `Staged files missing from every group (must appear exactly once): ${issues.missingFiles.join(', ')}`
+    )
+  }
+
+  if (issues.commitlintFailures.length) {
+    sections.push(
+      `Group titles/bodies that fail commitlint validation (fix the message, not the file/hunk assignment):\n${issues.commitlintFailures
+        .map((f) => `  - "${f.title}": ${f.errors.join('; ')}`)
+        .join('\n')}`
     )
   }
 

--- a/src/git/commitWorkflowActions.ts
+++ b/src/git/commitWorkflowActions.ts
@@ -382,6 +382,7 @@ export async function runCommitSplitApplyWorkflow(input: {
       logger,
       noVerify: input.noVerify || false,
       fallback: input.fallback,
+      validateGroupMessage: input.planContext.validateGroupMessage,
     })
     return {
       ok: true,


### PR DESCRIPTION
## Summary
- `coco commit --split` injected commitlint rules into the plan-generation prompt but never actually validated a group's `${title}\n\n${body}` against them — unlike plain `coco commit`, which retries, mechanically repairs, and ultimately refuses to commit an invalid message. In a commitlint-configured repo, `--split --apply` could produce commits that violated the project's own rules; if a `commit-msg` hook then rejected the group, the failure got misreported as a *pre-commit* hook problem (fixed separately in #2111), with no indication the root cause was the message itself.
- Adds a per-group validator — `validateCommitMessage` when the repo has commitlint configured, `validateConventionalCommitMessage` otherwise (the same choice `generateCommitDraft` already makes) — wired in at two points:
  - **Plan generation** (`generateValidatedCommitSplitPlan`): a failing group's errors feed back through the existing `previous_attempt_feedback` retry slot — the same self-correcting loop the structural (file/hunk) validator already drives, so the LLM gets a chance to fix its own titles.
  - **Apply time** (`applyCommitSplitPlan`), before any index mutation: a group still failing after the retry loop gets the same mechanical repair `generateCommitDraft` falls back to (case/line-length fixes); if that still doesn't pass, the apply is refused outright rather than committing a message the project's own rules reject. This is the real backstop — it's also the only thing that catches the planner's single-group fallback, whose hardcoded `chore: combined commit` title was never checked against a specific repo's rules.
- The validator is threaded through `CommitSplitPlanContext` (the object already carried between plan and apply) so both callers stay in sync: the CLI generates and applies in one call, while the workstation's `S` → `y` flow does it across two separate calls with the plan held in React state in between — both now re-check with the exact same validator the plan was generated against.

Closes #1885

## Test plan
- [x] New tests in `splitPlanValidation.test.ts` (`getPlanCommitlintFailures`), `splitPlanGenerator.test.ts` (retry-loop feedback + fallback), and `splitApply.test.ts` (apply-time pass-through / repair / hard-refusal / unclaimed-group skip)
- [x] `npx jest src/commands/commit src/git/commitWorkflowActions.test.ts src/workstation` — 3413/3413 passed
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx jest` (full suite) — pre-existing, unrelated tree-sitter WASM failures only (same 4 failures present on a clean `origin/main` checkout in this worktree)