### PR TITLE
fix(workstation): truncateCells always shows a marker when truncating (WS-14)

### DIFF
--- a/src/workstation/chrome/text.test.ts
+++ b/src/workstation/chrome/text.test.ts
@@ -101,6 +101,36 @@ describe('log Ink text helpers', () => {
     expect(truncateCells('hello world', 8, { ascii: true })).toBe('hello...')
   })
 
+  // WS-14: a budget exactly equal to (or narrower than, in ascii mode) the
+  // ellipsis's own width used to drop the marker entirely — the old
+  // `width > cellWidth(ellipsis)` strict inequality returned a bare,
+  // silently-clipped value with no indication truncation happened at all.
+  describe('truncateCells always shows a marker when truncating, even at a narrow budget (WS-14)', () => {
+    it('shows the unicode ellipsis alone when the budget exactly equals its width', () => {
+      expect(truncateCells('feature/a', 1)).toBe('…')
+    })
+
+    it('shows the ascii ellipsis alone when the budget exactly equals its width', () => {
+      expect(truncateCells('feature/a', 3, { ascii: true })).toBe('...')
+    })
+
+    it('falls back to the compact unicode ellipsis in ascii mode when the 3-cell marker cannot fit', () => {
+      expect(truncateCells('feature/a', 1, { ascii: true })).toBe('…')
+      expect(truncateCells('feature/a', 2, { ascii: true })).toBe('f…')
+    })
+
+    it('never returns a value indistinguishable from an untruncated one at any narrow width', () => {
+      const value = 'feature/a-long-branch-name'
+      for (let width = 1; width <= 5; width++) {
+        for (const ascii of [false, true]) {
+          const truncated = truncateCells(value, width, { ascii })
+          expect(truncated).not.toBe(value.slice(0, width))
+          expect(cellWidth(truncated)).toBeLessThanOrEqual(width)
+        }
+      }
+    })
+  })
+
   describe('wrapCells', () => {
     it('never hangs when the budget is narrower than one wide character', () => {
       // Regression: an empty chunk never shrank `remaining`, spinning

--- a/src/workstation/chrome/text.ts
+++ b/src/workstation/chrome/text.ts
@@ -193,8 +193,17 @@ export function truncateCells(
   // Unicode `…` is 1 cell vs. ASCII `...` at 3 — matches `truncatePathCells`'s
   // dialect so a path elision and a plain truncation never mix markers
   // (#1366). `theme.ascii` opts back into the 3-cell ASCII form.
-  const ellipsis = options.ascii ? '...' : '…'
-  const suffix = width > cellWidth(ellipsis) ? ellipsis : ''
+  //
+  // WS-14: the old `width > cellWidth(ellipsis)` strict inequality meant a
+  // budget exactly equal to the ellipsis's width (1 for unicode, or any of
+  // 1-3 in ascii mode) got NO marker at all — just a silently clipped
+  // value indistinguishable from a complete one. `<=` admits the
+  // budget-equals-ellipsis case (marker alone, zero content), and falling
+  // back to the compact 1-cell `…` when even the 3-cell ascii form can't
+  // fit means a narrow ascii-mode budget still gets a visible marker
+  // instead of none.
+  const dialectEllipsis = options.ascii ? '...' : '…'
+  const suffix = cellWidth(dialectEllipsis) <= width ? dialectEllipsis : '…'
   const available = width - cellWidth(suffix)
   let used = 0
   let output = ''


### PR DESCRIPTION
## Summary
- `truncateCells`'s ellipsis suffix was only attached when `width > cellWidth(ellipsis)` — a strict inequality. A budget of exactly 1 cell (the default unicode `…`, 1 cell) or 1–3 cells (`{ ascii: true }`'s `...`, 3 cells) got **no marker at all**: the function returned a bare truncated value, visually indistinguishable from a complete one.
- At the 80-column ASCII floor, narrow columns (the reflog hash column, the triage number column, single-pane sidebar labels) could render silently-clipped values — e.g. a branch name `feature/a` shown as `fea` reads as a real, complete ref name.
- Fix: `<=` instead of `>` so a budget exactly equal to the ellipsis's width still gets the marker alone (zero content, just `…`), and falls back to the compact 1-cell unicode `…` whenever the dialect-preferred ellipsis (3 cells in ascii mode) can't fit in the budget — so even a 1–2 cell ascii-mode budget shows a visible marker instead of none.

Closes #1868

## Test plan
- [x] New tests: budget-equals-ellipsis-width for both unicode and ascii dialects, ascii-mode fallback to the compact marker at width 1–2, and a sweep across widths 1–5 in both dialects asserting the output is never a bare untruncated-looking slice
- [x] `npx jest src/workstation/chrome/text.test.ts` — 33/33 passed (all pre-existing cases still pass unchanged)
- [x] `npx jest src/workstation` — 160 suites / 3147 tests passed (no snapshot regressions across the ~30 call sites)
- [x] `npx eslint` and `npx tsc --noEmit -p .` — clean
- [x] `npx jest` (full suite) — pre-existing, unrelated tree-sitter WASM failures only (same 4 failures present on a clean `origin/main` checkout in this worktree)