### PR TITLE
test(workstation): guard the history-rewrite confirmation invariant (WS-18)

### DIFF
--- a/src/workstation/runtime/inkWorkflows.test.ts
+++ b/src/workstation/runtime/inkWorkflows.test.ts
@@ -4,6 +4,7 @@ import {
     getLogInkWorkflowActions,
     getLogInkWorkflowSections,
 } from './inkWorkflows'
+import { HISTORY_REWRITE_WORKFLOW_IDS } from './hooks/useWorkflowAction'
 
 describe('log Ink workflows', () => {
   it('builds workflow sections from available repository context', () => {
@@ -55,6 +56,40 @@ describe('log Ink workflows', () => {
     expect(ai.every((action) => action.requiresConfirmation && action.estimatedTokens)).toBe(true)
     expect(getLogInkWorkflowActionByKey('D')?.id).toBe('delete-branch')
     expect(getLogInkWorkflowActionById('ai-commit-summary')?.key).toBe('I')
+  })
+
+  // WS-18: reword-head is the sole entry in HISTORY_REWRITE_WORKFLOW_IDS
+  // without requiresConfirmation. That's intentional, not an oversight —
+  // its handler (useWorkflowAction.ts) opens an input prompt pre-seeded
+  // with the current subject, and submitting that prompt is treated as
+  // the confirmation step (see the comment on this entry in
+  // inkWorkflows.ts). Every other history-rewriting workflow goes
+  // straight from keystroke/selection to execution with no interstitial
+  // step, so it needs requiresConfirmation as its only safety gate.
+  //
+  // This test doesn't take a position on whether the asymmetry is
+  // correct UX (that's a product call — see #1872) — it only pins down
+  // the CURRENT documented rule so a future history-rewriting workflow
+  // added with neither an explicit confirm nor a documented prompt gate
+  // fails loudly instead of silently shipping unprotected.
+  describe('history-rewrite workflows require an explicit safety gate (WS-18)', () => {
+    const PROMPT_GATED_EXCEPTIONS = new Set(['reword-head'])
+
+    it('requires confirmation for every history-rewrite workflow, unless documented as prompt-gated', () => {
+      const ungated = [...HISTORY_REWRITE_WORKFLOW_IDS].filter((id) => {
+        if (PROMPT_GATED_EXCEPTIONS.has(id)) return false
+        return !getLogInkWorkflowActionById(id)?.requiresConfirmation
+      })
+
+      expect(ungated).toEqual([])
+    })
+
+    it('keeps the prompt-gated exception list accurate: only real, registered workflow ids', () => {
+      for (const id of PROMPT_GATED_EXCEPTIONS) {
+        expect(HISTORY_REWRITE_WORKFLOW_IDS.has(id)).toBe(true)
+        expect(getLogInkWorkflowActionById(id)).toBeDefined()
+      }
+    })
   })
 
   // Regression: arrow keys (left/right) and other unbound keystrokes


### PR DESCRIPTION
## Summary
Investigated #1872: is `reword-head` (the sole entry in `HISTORY_REWRITE_WORKFLOW_IDS` without `requiresConfirmation: true`) a bug, as the audit's asymmetry-detection flagged?

**Finding: this is deliberate, documented design, not an oversight.** `reword-head`'s handler (`useWorkflowAction.ts`) opens an input prompt pre-seeded with the current commit subject, and submitting that prompt is what triggers the rewrite — the existing code comment in `inkWorkflows.ts` says exactly this ("the prompt itself is the confirmation step"), dating to #1350. Every other history-rewriting workflow (including its closest sibling, `amend-head`) goes straight from a keystroke/selection to execution with no interstitial step, which is why *those* need the explicit `y`-confirm as their only safety gate.

The issue's own confidence note agrees: *"the asymmetry is verified; whether it is wrong is a product call."* Whether a pre-filled prompt-and-submit is sufficient consent for a HEAD-rewriting action (vs. requiring the same explicit confirm its siblings get, i.e. prompt *and* confirm like `amend-head` does with staged changes) is a UX decision for @gfargo, not something to resolve unilaterally by flipping a flag.

## What this PR does
Adds the registry-invariant test the issue itself suggested: every id in `HISTORY_REWRITE_WORKFLOW_IDS` must have `requiresConfirmation: true` unless it's in an explicit, documented `PROMPT_GATED_EXCEPTIONS` allowlist (currently just `reword-head`). This doesn't change any runtime behavior — it pins down the *current* rule so a future history-rewriting workflow added with neither an explicit confirm nor a documented prompt gate fails a test instead of silently shipping unprotected.

**Leaving #1872 open** — the actual policy question (should `reword-head` also require an explicit confirm, or is prompt-implies-consent the right long-term rule for message-editing flows generally) needs your call, not mine. Left a comment on the issue with these findings.

## Test plan
- [x] New test in `inkWorkflows.test.ts`: every `HISTORY_REWRITE_WORKFLOW_IDS` entry requires confirmation unless explicitly allowlisted as prompt-gated; the allowlist itself is validated against the real registry
- [x] `npx jest src/workstation/runtime/inkWorkflows.test.ts` — 24/24 passed
- [x] `npx jest src/workstation` — 160 suites / 3149 tests passed
- [x] `npx eslint` and `npx tsc --noEmit -p .` — clean
- [x] `npx jest` (full suite) — pre-existing, unrelated tree-sitter WASM failures only (same 4 failures present on a clean `origin/main` checkout in this worktree)